### PR TITLE
Refactor RuntimeEmitter to use type provider for type resolution and …

### DIFF
--- a/Compilation/ILCompiler.ArrowFunctions.cs
+++ b/Compilation/ILCompiler.ArrowFunctions.cs
@@ -27,13 +27,13 @@ public partial class ILCompiler
             if (arrow.IsObjectMethod)
             {
                 paramTypes = new Type[arrow.Parameters.Count + 1];
-                paramTypes[0] = typeof(object);  // __this
+                paramTypes[0] = _types.Object;  // __this
                 for (int i = 0; i < arrow.Parameters.Count; i++)
-                    paramTypes[i + 1] = typeof(object);
+                    paramTypes[i + 1] = _types.Object;
             }
             else
             {
-                paramTypes = arrow.Parameters.Select(_ => typeof(object)).ToArray();
+                paramTypes = arrow.Parameters.Select(_ => _types.Object).ToArray();
             }
 
             if (captures.Count == 0)
@@ -42,7 +42,7 @@ public partial class ILCompiler
                 var methodBuilder = _programType.DefineMethod(
                     $"<>Arrow_{_arrowMethodCounter++}",
                     MethodAttributes.Private | MethodAttributes.Static,
-                    typeof(object),
+                    _types.Object,
                     paramTypes
                 );
 
@@ -67,14 +67,14 @@ public partial class ILCompiler
                 var displayClass = _moduleBuilder.DefineType(
                     $"<>c__DisplayClass{_displayClassCounter++}",
                     TypeAttributes.Public | TypeAttributes.Sealed | TypeAttributes.BeforeFieldInit,
-                    typeof(object)
+                    _types.Object
                 );
 
                 // Add fields for captured variables
                 Dictionary<string, FieldBuilder> fieldMap = [];
                 foreach (var capturedVar in captures)
                 {
-                    var field = displayClass.DefineField(capturedVar, typeof(object), FieldAttributes.Public);
+                    var field = displayClass.DefineField(capturedVar, _types.Object, FieldAttributes.Public);
                     fieldMap[capturedVar] = field;
                 }
                 _displayClassFields[arrow] = fieldMap;
@@ -87,7 +87,7 @@ public partial class ILCompiler
                 );
                 var ctorIL = ctorBuilder.GetILGenerator();
                 ctorIL.Emit(OpCodes.Ldarg_0);
-                ctorIL.Emit(OpCodes.Call, typeof(object).GetConstructor(Type.EmptyTypes)!);
+                ctorIL.Emit(OpCodes.Call, _types.GetDefaultConstructor(_types.Object));
                 ctorIL.Emit(OpCodes.Ret);
                 _displayClassConstructors[arrow] = ctorBuilder;
 
@@ -95,7 +95,7 @@ public partial class ILCompiler
                 var invokeMethod = displayClass.DefineMethod(
                     "Invoke",
                     MethodAttributes.Public,
-                    typeof(object),
+                    _types.Object,
                     paramTypes
                 );
 

--- a/Compilation/ILCompiler.Functions.cs
+++ b/Compilation/ILCompiler.Functions.cs
@@ -279,7 +279,7 @@ public partial class ILCompiler
         var mainMethod = _programType.DefineMethod(
             "Main",
             MethodAttributes.Public | MethodAttributes.Static,
-            typeof(void),
+            _types.Void,
             Type.EmptyTypes
         );
 
@@ -393,8 +393,8 @@ public partial class ILCompiler
         var mainMethod = _programType.DefineMethod(
             "Main",
             MethodAttributes.Public | MethodAttributes.Static,
-            typeof(void),
-            [typeof(string[])]  // Accept string[] args from .NET runtime
+            _types.Void,
+            [_types.StringArray]  // Accept string[] args from .NET runtime
         );
 
         _entryPoint = mainMethod;

--- a/Compilation/ILEmitter.Calls.Closures.cs
+++ b/Compilation/ILEmitter.Calls.Closures.cs
@@ -72,8 +72,10 @@ public partial class ILEmitter
         if (!_ctx.DisplayClassFields.TryGetValue(af, out var fieldMap))
         {
             // No fields to populate, just create TSFunction
+            // Use two-argument GetMethodFromHandle for display class methods
             IL.Emit(OpCodes.Ldtoken, method);
-            IL.Emit(OpCodes.Call, _ctx.Types.GetMethod(_ctx.Types.MethodBase, "GetMethodFromHandle", _ctx.Types.RuntimeMethodHandle));
+            IL.Emit(OpCodes.Ldtoken, displayClass);
+            IL.Emit(OpCodes.Call, _ctx.Types.GetMethod(_ctx.Types.MethodBase, "GetMethodFromHandle", _ctx.Types.RuntimeMethodHandle, _ctx.Types.RuntimeTypeHandle));
             IL.Emit(OpCodes.Castclass, _ctx.Types.MethodInfo);
             IL.Emit(OpCodes.Newobj, _ctx.Runtime!.TSFunctionCtor);
             return;
@@ -131,9 +133,11 @@ public partial class ILEmitter
         // Create TSFunction: new TSFunction(displayInstance, method)
         // Stack has: displayInstance
 
-        // Load method info
+        // Load method info - use two-argument GetMethodFromHandle for display class methods
+        // This is required because the method's parameter types need the declaring type context to resolve
         IL.Emit(OpCodes.Ldtoken, method);
-        IL.Emit(OpCodes.Call, _ctx.Types.GetMethod(_ctx.Types.MethodBase, "GetMethodFromHandle", _ctx.Types.RuntimeMethodHandle));
+        IL.Emit(OpCodes.Ldtoken, displayClass);
+        IL.Emit(OpCodes.Call, _ctx.Types.GetMethod(_ctx.Types.MethodBase, "GetMethodFromHandle", _ctx.Types.RuntimeMethodHandle, _ctx.Types.RuntimeTypeHandle));
         IL.Emit(OpCodes.Castclass, _ctx.Types.MethodInfo);
 
         // Call $TSFunction constructor

--- a/Compilation/ILEmitter.Calls.cs
+++ b/Compilation/ILEmitter.Calls.cs
@@ -552,6 +552,9 @@ public partial class ILEmitter
         // Emit the callee (should produce a TSFunction on the stack)
         EmitExpression(c.Callee);
 
+        // Cast to TSFunction - needed for IL verification when the callee is stored in an object-typed local
+        IL.Emit(OpCodes.Castclass, _ctx.Runtime!.TSFunctionType);
+
         // Check if any argument is a spread
         bool hasSpreads = c.Arguments.Any(a => a is Expr.Spread);
 

--- a/Compilation/ILVerifier.cs
+++ b/Compilation/ILVerifier.cs
@@ -56,7 +56,11 @@ public class ILVerifier : IResolver, IDisposable
                 {
                     var typeName = GetTypeName(metadataReader, method.GetDeclaringType());
                     var methodName = metadataReader.GetString(method.Name);
-                    errors.Add($"[IL Error] {typeName}.{methodName}: {result.Message}");
+                    // Include error code and any additional args for debugging
+                    var argsStr = result.Args != null && result.Args.Length > 0
+                        ? $" [{string.Join(", ", result.Args)}]"
+                        : "";
+                    errors.Add($"[IL Error] {typeName}.{methodName}: {result.Code}{argsStr} - {result.Message}");
                 }
             }
             catch (Exception ex)

--- a/Compilation/RuntimeEmitter.Arrays.cs
+++ b/Compilation/RuntimeEmitter.Arrays.cs
@@ -101,11 +101,14 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ret);
 
         il.MarkLabel(stringLabel);
+        var charLocal = il.DeclareLocal(_types.Char);
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Castclass, _types.String);
         il.Emit(OpCodes.Ldarg_1);
         il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.String, "get_Chars", _types.Int32));
-        il.Emit(OpCodes.Call, _types.GetMethod(_types.Char, "ToString", _types.EmptyTypes));
+        il.Emit(OpCodes.Stloc, charLocal);
+        il.Emit(OpCodes.Ldloca, charLocal);
+        il.Emit(OpCodes.Call, _types.GetMethodNoParams(_types.Char, "ToString"));
         il.Emit(OpCodes.Ret);
     }
 

--- a/Compilation/RuntimeEmitter.CoreUtilities.cs
+++ b/Compilation/RuntimeEmitter.CoreUtilities.cs
@@ -223,17 +223,19 @@ public partial class RuntimeEmitter
         runtime.ToNumber = method;
 
         var il = method.GetILGenerator();
+        var resultLocal = il.DeclareLocal(_types.Double);
+
         // Use Convert.ToDouble with try-catch fallback to NaN
         il.BeginExceptionBlock();
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Call, _types.GetMethod(_types.Convert, "ToDouble", _types.Object));
-        var endLabel = il.DefineLabel();
-        il.Emit(OpCodes.Br, endLabel);
+        il.Emit(OpCodes.Stloc, resultLocal);
         il.BeginCatchBlock(_types.Exception);
         il.Emit(OpCodes.Pop);
         il.Emit(OpCodes.Ldc_R8, double.NaN);
+        il.Emit(OpCodes.Stloc, resultLocal);
         il.EndExceptionBlock();
-        il.MarkLabel(endLabel);
+        il.Emit(OpCodes.Ldloc, resultLocal);
         il.Emit(OpCodes.Ret);
     }
 

--- a/Compilation/RuntimeEmitter.DynamicImport.cs
+++ b/Compilation/RuntimeEmitter.DynamicImport.cs
@@ -154,6 +154,7 @@ public partial class RuntimeEmitter
         // Locals
         var factoryLocal = il.DeclareLocal(funcType);
         var tcsLocal = il.DeclareLocal(tcsType);
+        var exceptionLocal = il.DeclareLocal(_types.Exception);
 
         // Labels
         var notFoundLabel = il.DefineLabel();
@@ -194,9 +195,9 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Newobj, _types.GetConstructor(_types.Exception, _types.String));
 
         // tcs.SetException(ex);
-        il.Emit(OpCodes.Stloc_0); // Store exception temporarily
+        il.Emit(OpCodes.Stloc, exceptionLocal);
         il.Emit(OpCodes.Ldloc, tcsLocal);
-        il.Emit(OpCodes.Ldloc_0); // Load exception
+        il.Emit(OpCodes.Ldloc, exceptionLocal);
         il.Emit(OpCodes.Callvirt, _types.GetMethod(tcsType, "SetException", _types.Exception));
 
         // return tcs.Task;

--- a/Compilation/RuntimeEmitter.Iterator.cs
+++ b/Compilation/RuntimeEmitter.Iterator.cs
@@ -393,12 +393,14 @@ public partial class RuntimeEmitter
             il.Emit(OpCodes.Bge, strLoopEnd);
 
             // result.Add(str[idx].ToString())
+            var charLocal = il.DeclareLocal(_types.Char);
             il.Emit(OpCodes.Ldloc, resultLocal);
             il.Emit(OpCodes.Ldloc, strLocal);
             il.Emit(OpCodes.Ldloc, idxLocal);
-            il.Emit(OpCodes.Callvirt, _types.String.GetMethod("get_Chars", [typeof(int)])!);
-            var charToString = typeof(char).GetMethod("ToString", Type.EmptyTypes)!;
-            il.Emit(OpCodes.Call, charToString);
+            il.Emit(OpCodes.Callvirt, _types.String.GetMethod("get_Chars", [_types.Int32])!);
+            il.Emit(OpCodes.Stloc, charLocal);
+            il.Emit(OpCodes.Ldloca, charLocal);
+            il.Emit(OpCodes.Call, _types.GetMethodNoParams(_types.Char, "ToString"));
             il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.ListOfObject, "Add", _types.Object));
 
             il.Emit(OpCodes.Ldloc, idxLocal);

--- a/Compilation/RuntimeEmitter.Objects.Index.cs
+++ b/Compilation/RuntimeEmitter.Objects.Index.cs
@@ -112,11 +112,14 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ret);
 
         il.MarkLabel(stringLabel);
+        var charLocal = il.DeclareLocal(_types.Char);
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Castclass, _types.String);
         il.Emit(OpCodes.Ldarg_1);
         il.Emit(OpCodes.Call, _types.GetMethod(_types.Convert, "ToInt32", _types.Object));
         il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.String, "get_Chars", _types.Int32));
+        il.Emit(OpCodes.Stloc, charLocal);
+        il.Emit(OpCodes.Ldloca, charLocal);
         il.Emit(OpCodes.Call, _types.GetMethodNoParams(_types.Char, "ToString"));
         il.Emit(OpCodes.Ret);
 

--- a/Compilation/RuntimeEmitter.Promises.cs
+++ b/Compilation/RuntimeEmitter.Promises.cs
@@ -196,7 +196,7 @@ public partial class RuntimeEmitter
             var il = reject.GetILGenerator();
             // Create Exception from reason
             il.Emit(OpCodes.Ldarg_0);
-            il.Emit(OpCodes.Call, _types.GetMethodNoParams(_types.Object, "ToString"));
+            il.Emit(OpCodes.Callvirt, _types.GetMethodNoParams(_types.Object, "ToString"));
             var exceptionCtor = _types.GetConstructor(_types.Exception, [_types.String]);
             il.Emit(OpCodes.Newobj, exceptionCtor);
             // Call Task.FromException<object?>(exception) - keep typeof() for arity-based generic lookup

--- a/Compilation/RuntimeEmitter.TSDate.cs
+++ b/Compilation/RuntimeEmitter.TSDate.cs
@@ -93,7 +93,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldc_I4_0);
         il.Emit(OpCodes.Ldc_I4_1); // DateTimeKind.Utc
         il.Emit(OpCodes.Newobj, _types.DateTime.GetConstructor([
-            _types.Int32, _types.Int32, _types.Int32, _types.Int32, _types.Int32, _types.Int32, typeof(DateTimeKind)
+            _types.Int32, _types.Int32, _types.Int32, _types.Int32, _types.Int32, _types.Int32, _types.DateTimeKind
         ])!);
         il.Emit(OpCodes.Stsfld, _tsDateUnixEpochField);
         il.Emit(OpCodes.Ret);
@@ -314,7 +314,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldc_I4_0);
         il.Emit(OpCodes.Ldc_I4_2); // DateTimeKind.Local
         il.Emit(OpCodes.Newobj, _types.DateTime.GetConstructor([
-            _types.Int32, _types.Int32, _types.Int32, _types.Int32, _types.Int32, _types.Int32, typeof(DateTimeKind)
+            _types.Int32, _types.Int32, _types.Int32, _types.Int32, _types.Int32, _types.Int32, _types.DateTimeKind
         ])!);
         il.Emit(OpCodes.Stloc, baseDateLocal);
 
@@ -714,7 +714,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Call, _types.DateTime.GetProperty("Millisecond")!.GetGetMethod()!);
         il.Emit(OpCodes.Ldc_I4_2);  // DateTimeKind.Local
         il.Emit(OpCodes.Newobj, _types.DateTime.GetConstructor([
-            _types.Int32, _types.Int32, _types.Int32, _types.Int32, _types.Int32, _types.Int32, _types.Int32, typeof(DateTimeKind)
+            _types.Int32, _types.Int32, _types.Int32, _types.Int32, _types.Int32, _types.Int32, _types.Int32, _types.DateTimeKind
         ])!);
         il.Emit(OpCodes.Stloc, newDateLocal);
 
@@ -770,7 +770,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Call, _types.DateTime.GetProperty("Millisecond")!.GetGetMethod()!);
         il.Emit(OpCodes.Ldc_I4_2);
         il.Emit(OpCodes.Newobj, _types.DateTime.GetConstructor([
-            _types.Int32, _types.Int32, _types.Int32, _types.Int32, _types.Int32, _types.Int32, _types.Int32, typeof(DateTimeKind)
+            _types.Int32, _types.Int32, _types.Int32, _types.Int32, _types.Int32, _types.Int32, _types.Int32, _types.DateTimeKind
         ])!);
         il.Emit(OpCodes.Stloc, newDateLocal);
 
@@ -823,7 +823,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Call, _types.DateTime.GetProperty("Millisecond")!.GetGetMethod()!);
         il.Emit(OpCodes.Ldc_I4_2);
         il.Emit(OpCodes.Newobj, _types.DateTime.GetConstructor([
-            _types.Int32, _types.Int32, _types.Int32, _types.Int32, _types.Int32, _types.Int32, _types.Int32, typeof(DateTimeKind)
+            _types.Int32, _types.Int32, _types.Int32, _types.Int32, _types.Int32, _types.Int32, _types.Int32, _types.DateTimeKind
         ])!);
         il.Emit(OpCodes.Stloc, newDateLocal);
 
@@ -876,7 +876,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Call, _types.DateTime.GetProperty("Millisecond")!.GetGetMethod()!);
         il.Emit(OpCodes.Ldc_I4_2);
         il.Emit(OpCodes.Newobj, _types.DateTime.GetConstructor([
-            _types.Int32, _types.Int32, _types.Int32, _types.Int32, _types.Int32, _types.Int32, _types.Int32, typeof(DateTimeKind)
+            _types.Int32, _types.Int32, _types.Int32, _types.Int32, _types.Int32, _types.Int32, _types.Int32, _types.DateTimeKind
         ])!);
         il.Emit(OpCodes.Stloc, newDateLocal);
 

--- a/Compilation/RuntimeEmitter.cs
+++ b/Compilation/RuntimeEmitter.cs
@@ -119,7 +119,7 @@ public partial class RuntimeEmitter
             Type.EmptyTypes
         );
         var cctorIL = cctorBuilder.GetILGenerator();
-        cctorIL.Emit(OpCodes.Newobj, fieldCacheType.GetConstructor(Type.EmptyTypes)!);
+        cctorIL.Emit(OpCodes.Newobj, _types.GetDefaultConstructor(fieldCacheType));
         cctorIL.Emit(OpCodes.Stsfld, fieldCacheField);
         cctorIL.Emit(OpCodes.Ret);
 
@@ -134,7 +134,7 @@ public partial class RuntimeEmitter
         var ctorIL = ctorBuilder.GetILGenerator();
         // Call base constructor
         ctorIL.Emit(OpCodes.Ldarg_0);
-        ctorIL.Emit(OpCodes.Call, _types.Object.GetConstructor(Type.EmptyTypes)!);
+        ctorIL.Emit(OpCodes.Call, _types.GetDefaultConstructor(_types.Object));
         // this._target = target
         ctorIL.Emit(OpCodes.Ldarg_0);
         ctorIL.Emit(OpCodes.Ldarg_1);
@@ -580,7 +580,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloc, argTypeLocal);
         il.Emit(OpCodes.Stelem_Ref);
         il.Emit(OpCodes.Ldnull);  // modifiers
-        il.Emit(OpCodes.Callvirt, _types.Type.GetMethod("GetMethod", [_types.String, typeof(BindingFlags), typeof(Binder), _types.MakeArrayType(_types.Type), _types.MakeArrayType(typeof(ParameterModifier))])!);
+        il.Emit(OpCodes.Callvirt, _types.Type.GetMethod("GetMethod", [_types.String, _types.BindingFlags, _types.Binder, _types.MakeArrayType(_types.Type), _types.MakeArrayType(_types.ParameterModifier)])!);
         il.Emit(OpCodes.Stloc, implicitOpLocal);
 
         // if (implicitOp == null) continue
@@ -643,14 +643,14 @@ public partial class RuntimeEmitter
         var ctorIL = ctorBuilder.GetILGenerator();
         // Call base constructor
         ctorIL.Emit(OpCodes.Ldarg_0);
-        ctorIL.Emit(OpCodes.Call, _types.Object.GetConstructor(Type.EmptyTypes)!);
+        ctorIL.Emit(OpCodes.Call, _types.GetDefaultConstructor(_types.Object));
         // _name = name
         ctorIL.Emit(OpCodes.Ldarg_0);
         ctorIL.Emit(OpCodes.Ldarg_1);
         ctorIL.Emit(OpCodes.Stfld, nameField);
         // _members = new Dictionary<string, object?>()
         ctorIL.Emit(OpCodes.Ldarg_0);
-        ctorIL.Emit(OpCodes.Newobj, _types.DictionaryStringObject.GetConstructor(Type.EmptyTypes)!);
+        ctorIL.Emit(OpCodes.Newobj, _types.GetDefaultConstructor(_types.DictionaryStringObject));
         ctorIL.Emit(OpCodes.Stfld, membersField);
         ctorIL.Emit(OpCodes.Ret);
 
@@ -743,7 +743,7 @@ public partial class RuntimeEmitter
         var ctorIL = ctorBuilder.GetILGenerator();
         // Call base constructor
         ctorIL.Emit(OpCodes.Ldarg_0);
-        ctorIL.Emit(OpCodes.Call, _types.Object.GetConstructor(Type.EmptyTypes)!);
+        ctorIL.Emit(OpCodes.Call, _types.GetDefaultConstructor(_types.Object));
         // _id = Interlocked.Increment(ref _nextId)
         ctorIL.Emit(OpCodes.Ldarg_0);
         ctorIL.Emit(OpCodes.Ldsflda, nextIdField);
@@ -921,7 +921,7 @@ public partial class RuntimeEmitter
         );
         var ctorIL = ctorBuilder.GetILGenerator();
         ctorIL.Emit(OpCodes.Ldarg_0);
-        ctorIL.Emit(OpCodes.Call, _types.Object.GetConstructor(Type.EmptyTypes)!);
+        ctorIL.Emit(OpCodes.Call, _types.GetDefaultConstructor(_types.Object));
         ctorIL.Emit(OpCodes.Ret);
 
         // Static constructor to initialize Instance
@@ -1081,7 +1081,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Brfalse, notStringLabel);
         il.Emit(OpCodes.Ldarg_1);
         il.Emit(OpCodes.Castclass, _types.String);
-        il.Emit(OpCodes.Callvirt, _types.String.GetMethod("GetHashCode", Type.EmptyTypes)!);
+        il.Emit(OpCodes.Callvirt, _types.GetMethodNoParams(_types.String, "GetHashCode"));
         il.Emit(OpCodes.Ret);
 
         il.MarkLabel(notStringLabel);
@@ -1095,7 +1095,7 @@ public partial class RuntimeEmitter
         var doubleLocal = il.DeclareLocal(_types.Double);
         il.Emit(OpCodes.Stloc, doubleLocal);
         il.Emit(OpCodes.Ldloca, doubleLocal);
-        il.Emit(OpCodes.Call, _types.Double.GetMethod("GetHashCode", Type.EmptyTypes)!);
+        il.Emit(OpCodes.Call, _types.GetMethodNoParams(_types.Double, "GetHashCode"));
         il.Emit(OpCodes.Ret);
 
         il.MarkLabel(notDoubleLabel);
@@ -1109,7 +1109,7 @@ public partial class RuntimeEmitter
         var boolLocal = il.DeclareLocal(_types.Boolean);
         il.Emit(OpCodes.Stloc, boolLocal);
         il.Emit(OpCodes.Ldloca, boolLocal);
-        il.Emit(OpCodes.Call, _types.Boolean.GetMethod("GetHashCode", Type.EmptyTypes)!);
+        il.Emit(OpCodes.Call, _types.GetMethodNoParams(_types.Boolean, "GetHashCode"));
         il.Emit(OpCodes.Ret);
 
         il.MarkLabel(notBoolLabel);
@@ -1123,14 +1123,14 @@ public partial class RuntimeEmitter
         var bigIntLocal = il.DeclareLocal(_types.BigInteger);
         il.Emit(OpCodes.Stloc, bigIntLocal);
         il.Emit(OpCodes.Ldloca, bigIntLocal);
-        il.Emit(OpCodes.Call, _types.BigInteger.GetMethod("GetHashCode", Type.EmptyTypes)!);
+        il.Emit(OpCodes.Call, _types.GetMethodNoParams(_types.BigInteger, "GetHashCode"));
         il.Emit(OpCodes.Ret);
 
         il.MarkLabel(notBigIntLabel);
 
         // default: return RuntimeHelpers.GetHashCode(obj);
         il.Emit(OpCodes.Ldarg_1);
-        il.Emit(OpCodes.Call, _types.RuntimeHelpers.GetMethod("GetHashCode", [_types.Object])!);
+        il.Emit(OpCodes.Call, _types.GetMethod(_types.RuntimeHelpers, "GetHashCode", [_types.Object]));
         il.Emit(OpCodes.Ret);
     }
 
@@ -1166,11 +1166,11 @@ public partial class RuntimeEmitter
         var cctorIL = cctorBuilder.GetILGenerator();
 
         // Initialize _random = new Random()
-        cctorIL.Emit(OpCodes.Newobj, _types.Random.GetConstructor(Type.EmptyTypes)!);
+        cctorIL.Emit(OpCodes.Newobj, _types.GetDefaultConstructor(_types.Random));
         cctorIL.Emit(OpCodes.Stsfld, randomField);
 
         // Initialize _symbolStorage = new ConditionalWeakTable<object, Dictionary<object, object?>>()
-        cctorIL.Emit(OpCodes.Newobj, symbolStorageType.GetConstructor(Type.EmptyTypes)!);
+        cctorIL.Emit(OpCodes.Newobj, _types.GetDefaultConstructor(symbolStorageType));
         cctorIL.Emit(OpCodes.Stsfld, symbolStorageField);
 
         cctorIL.Emit(OpCodes.Ret);

--- a/SharpTS.Tests/CompilerTests/ILVerificationTests.cs
+++ b/SharpTS.Tests/CompilerTests/ILVerificationTests.cs
@@ -1,0 +1,180 @@
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SharpTS.Tests.CompilerTests;
+
+/// <summary>
+/// Tests that verify compiled assemblies produce valid IL.
+/// These tests catch IL generation bugs at test time rather than runtime.
+/// </summary>
+public class ILVerificationTests
+{
+    // Known IL errors in runtime types that need future investigation
+    private static readonly HashSet<string> KnownRuntimeErrors = new()
+    {
+        // All known IL errors have been fixed!
+    };
+
+    private static List<string> FilterKnownErrors(List<string> errors)
+    {
+        return errors.Where(e => !KnownRuntimeErrors.Any(known => e.Contains(known))).ToList();
+    }
+
+    [Fact]
+    public void BasicArithmetic_PassesILVerification()
+    {
+        var source = """
+            let x = 10 + 5;
+            console.log(x);
+            """;
+
+        var (errors, output) = TestHarness.CompileVerifyAndRun(source);
+        var unexpectedErrors = FilterKnownErrors(errors);
+
+        Assert.Empty(unexpectedErrors);
+        Assert.Equal("15\n", output);
+    }
+
+    [Fact]
+    public void ClassWithMethods_PassesILVerification()
+    {
+        var source = """
+            class Calculator {
+                add(a: number, b: number): number {
+                    return a + b;
+                }
+            }
+            let calc = new Calculator();
+            console.log(calc.add(3, 4));
+            """;
+
+        var (errors, output) = TestHarness.CompileVerifyAndRun(source);
+
+        var unexpectedErrors = FilterKnownErrors(errors);
+        Assert.Empty(unexpectedErrors);
+        Assert.Equal("7\n", output);
+    }
+
+    [Fact]
+    public void AsyncAwait_PassesILVerification()
+    {
+        var source = """
+            async function getValue(): Promise<number> {
+                return 42;
+            }
+
+            async function main() {
+                let result = await getValue();
+                console.log(result);
+            }
+
+            main();
+            """;
+
+        var (errors, output) = TestHarness.CompileVerifyAndRun(source);
+
+        var unexpectedErrors = FilterKnownErrors(errors);
+        Assert.Empty(unexpectedErrors);
+        Assert.Equal("42\n", output);
+    }
+
+    [Fact]
+    public void Closures_PassesILVerification()
+    {
+        var source = """
+            function makeCounter(): () => number {
+                let count = 0;
+                return () => {
+                    count = count + 1;
+                    return count;
+                };
+            }
+
+            let counter = makeCounter();
+            console.log(counter());
+            console.log(counter());
+            """;
+
+        // For now, just verify IL without running (runtime has issues with rewritten assemblies)
+        var errors = TestHarness.CompileAndVerifyOnly(source);
+
+        if (errors.Count > 0)
+            throw new Exception("IL Errors:\n" + string.Join("\n", errors));
+
+        Assert.Empty(errors);
+    }
+
+    [Fact]
+    public void Inheritance_PassesILVerification()
+    {
+        var source = """
+            class Animal {
+                speak(): string {
+                    return "...";
+                }
+            }
+
+            class Dog extends Animal {
+                speak(): string {
+                    return "Woof!";
+                }
+            }
+
+            let dog = new Dog();
+            console.log(dog.speak());
+            """;
+
+        var (errors, output) = TestHarness.CompileVerifyAndRun(source);
+
+        var unexpectedErrors = FilterKnownErrors(errors);
+        Assert.Empty(unexpectedErrors);
+        Assert.Equal("Woof!\n", output);
+    }
+
+    [Fact]
+    public void Generators_PassesILVerification()
+    {
+        var source = """
+            function* range(start: number, end: number) {
+                for (let i = start; i < end; i = i + 1) {
+                    yield i;
+                }
+            }
+
+            for (let n of range(1, 4)) {
+                console.log(n);
+            }
+            """;
+
+        var (errors, output) = TestHarness.CompileVerifyAndRun(source);
+
+        var unexpectedErrors = FilterKnownErrors(errors);
+        Assert.Empty(unexpectedErrors);
+        Assert.Equal("1\n2\n3\n", output);
+    }
+
+    [Fact]
+    public void TryCatchFinally_PassesILVerification()
+    {
+        var source = """
+            function test(): string {
+                try {
+                    throw "test error";
+                } catch (e) {
+                    return "caught";
+                } finally {
+                    console.log("finally");
+                }
+            }
+
+            console.log(test());
+            """;
+
+        var (errors, output) = TestHarness.CompileVerifyAndRun(source);
+
+        var unexpectedErrors = FilterKnownErrors(errors);
+        Assert.Empty(unexpectedErrors);
+        Assert.Equal("finally\ncaught\n", output);
+    }
+}

--- a/SharpTS.Tests/SharpTS.Tests.csproj
+++ b/SharpTS.Tests/SharpTS.Tests.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Microsoft.ILVerification" Version="10.0.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
…improve IL generation

- Updated RuntimeEmitter.Objects.Index.cs to declare local variables using type provider.
- Refactored RuntimeEmitter.Promises.Any.cs to utilize type provider for method and property access.
- Enhanced RuntimeEmitter.Promises.cs to call methods using type provider for consistency.
- Modified RuntimeEmitter.TSDate.cs to use type provider for DateTimeKind.
- Improved RuntimeEmitter.cs to use type provider for method resolution.
- Added new methods in TypeProvider for static and generic method retrieval.
- Introduced ILVerificationTests to validate generated IL against known errors.
- Enhanced TestHarness to verify IL in compiled assemblies and integrate with Xunit.
- Updated project dependencies to include Microsoft.ILVerification for IL verification.