### PR TITLE
fix(parser): allow method chaining on new expressions

### DIFF
--- a/Parsing/Parser.Expressions.cs
+++ b/Parsing/Parser.Expressions.cs
@@ -374,7 +374,11 @@ public partial class Parser
                 } while (Match(TokenType.COMMA));
             }
             Consume(TokenType.RIGHT_PAREN, "Expect ')' after arguments.");
-            return new Expr.New(callee, typeArgs, arguments);
+
+            // Allow operations on new expressions
+            // Examples: new Date().toISOString()
+            Expr newExpr = new Expr.New(callee, typeArgs, arguments);
+            return ParseCallChain(newExpr);
         }
 
         return Call();
@@ -383,7 +387,16 @@ public partial class Parser
     private Expr Call()
     {
         Expr expr = Primary();
+        return ParseCallChain(expr);
+    }
 
+    /// <summary>
+    /// Parses postfix operations on an expression: method calls, property access,
+    /// index access, type assertions, non-null assertions, and tagged templates.
+    /// This is extracted to allow reuse after parsing new expressions.
+    /// </summary>
+    private Expr ParseCallChain(Expr expr)
+    {
         while (true)
         {
             // Check for type arguments before call: func<T>(args)


### PR DESCRIPTION
**Problem**

The parser didn't support operations (method calls, property access, indexing) on new expressions. This caused common patterns like new Date().toISOString() to fail parsing.

**Root Cause**

In UnaryPrefix(), after parsing new ClassName(), the parser immediately returned the Expr.New without checking for postfix operations:
```
// Before: returned immediately, no postfix handlingreturn 
new Expr.New(callee, typeArgs, arguments);
```

**Fix**
Extracted the postfix handling loop from Call() into a reusable ParseCallChain(Expr expr) method, then applied it after parsing new expressions:
```
// After: allows .method(), [index], etc.
Expr newExpr = new Expr.New(callee, typeArgs, arguments);
return ParseCallChain(newExpr);
```

Example to test:
```
console.log(`${new Date().toISOString()}`);
```