### PR TITLE
eval() support + co-locate SharpTS.dll only when needed (#107)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,6 +136,8 @@ The same applies to `PropertyDescriptorStore`, `ObjectBuiltIns`, and any other S
 
 **Why:** When emitting IL with `typeof(X).GetMethod(...)`, the method token references the SharpTS assembly directly. This creates a hard dependency. The reflection pattern emits IL that does `Type.GetType("..., SharpTS")` at runtime, allowing graceful degradation if SharpTS isn't present.
 
+**Soft-dependency signal + auto-copy:** Some features (eval, Proxy, Intl, vm, dns, `@DotNetType` dynamic events) emit a `Type.GetType("…, SharpTS")` path whose *normal* execution needs SharpTS.dll present. When such a path is emitted, the emit site records a reason via `EmittedRuntime.RequireSharpTSRuntime(reason)`, surfaced through `ILCompiler.RequiredSharpTSRuntimeReasons`. After `Save`, the CLI (`Program.cs` `CopySharpTSRuntimeIfNeeded`) co-locates SharpTS.dll with the output **only when** that set is non-empty — programs using none of these stay fully standalone. `--compile … --standalone` suppresses the copy (those features then throw a clear "not supported" error at runtime). Do NOT record reasons for pure-BCL features (zlib, child_process, JSON) or unconditional graceful-fallback plumbing (`process`) — only paths a normal program actually reaches.
+
 ### Error Handling Conventions
 
 - Type errors: "Type Error:" prefix

--- a/Cli/CommandLineParser.cs
+++ b/Cli/CommandLineParser.cs
@@ -52,7 +52,8 @@ public record CompileOptions(
     bool MsBuildErrors = false,
     bool QuietMode = false,
     IReadOnlyList<string>? References = null,
-    BundlerMode Bundler = BundlerMode.Auto
+    BundlerMode Bundler = BundlerMode.Auto,
+    bool Standalone = false
 )
 {
     public IReadOnlyList<string> References { get; init; } = References ?? [];
@@ -277,6 +278,7 @@ public class CommandLineParser
         bool verifyIL = false;
         bool msbuildErrors = false;
         bool quietMode = false;
+        bool standalone = false;
         string? sdkPath = null;
         BundlerMode bundlerMode = BundlerMode.Auto;
 
@@ -376,6 +378,10 @@ public class CommandLineParser
             {
                 quietMode = true;
             }
+            else if (args[i] == "--standalone")
+            {
+                standalone = true;
+            }
             else if (args[i] == "--pack")
             {
                 pack = true;
@@ -415,7 +421,8 @@ public class CommandLineParser
             MsBuildErrors: msbuildErrors,
             QuietMode: quietMode,
             References: references,
-            Bundler: bundlerMode
+            Bundler: bundlerMode,
+            Standalone: standalone
         );
 
         var packOptions = new PackOptions(

--- a/Compilation/CallHandlers/GlobalFunctionHandler.cs
+++ b/Compilation/CallHandlers/GlobalFunctionHandler.cs
@@ -43,6 +43,10 @@ public class GlobalFunctionHandler : ICallHandler
     /// </summary>
     private static bool EmitEval(IEmitterContext emitter, System.Reflection.Emit.ILGenerator il, CompilationContext ctx, Expr.Call call)
     {
+        // eval always routes through EvalBridge in the SharpTS runtime — record the soft
+        // dependency so the build co-locates SharpTS.dll with the output.
+        ctx.Runtime?.RequireSharpTSRuntime("eval()");
+
         // object arg = <arg0 boxed> (or null when called with no arguments)
         var argLocal = il.DeclareLocal(ctx.Types.Object);
         if (call.Arguments.Count > 0) { emitter.EmitExpression(call.Arguments[0]); emitter.EmitBoxIfNeeded(call.Arguments[0]); }

--- a/Compilation/CallHandlers/GlobalFunctionHandler.cs
+++ b/Compilation/CallHandlers/GlobalFunctionHandler.cs
@@ -21,6 +21,7 @@ public class GlobalFunctionHandler : ICallHandler
 
         return v.Name.Lexeme switch
         {
+            "eval" => EmitEval(emitter, il, ctx, call),
             "parseInt" => EmitParseInt(emitter, il, ctx, call),
             "parseFloat" => EmitParseFloat(emitter, il, ctx, call),
             "isNaN" => EmitIsNaN(emitter, il, ctx, call),
@@ -32,6 +33,55 @@ public class GlobalFunctionHandler : ICallHandler
             "decodeURIComponent" => EmitDecodeURIComponent(emitter, il, ctx, call),
             _ => false
         };
+    }
+
+    /// <summary>
+    /// Emits a compiled <c>eval(arg)</c>. Compiled output has no live interpreter/scope, so this
+    /// reflectively invokes <c>SharpTS.Execution.EvalBridge.Eval(object)</c> (indirect, global-scope
+    /// eval) only when the SharpTS runtime is present, degrading to a deterministic throw otherwise.
+    /// The reflection pattern keeps the output DLL free of a hard SharpTS.dll reference.
+    /// </summary>
+    private static bool EmitEval(IEmitterContext emitter, System.Reflection.Emit.ILGenerator il, CompilationContext ctx, Expr.Call call)
+    {
+        // object arg = <arg0 boxed> (or null when called with no arguments)
+        var argLocal = il.DeclareLocal(ctx.Types.Object);
+        if (call.Arguments.Count > 0) { emitter.EmitExpression(call.Arguments[0]); emitter.EmitBoxIfNeeded(call.Arguments[0]); }
+        else { il.Emit(System.Reflection.Emit.OpCodes.Ldnull); }
+        il.Emit(System.Reflection.Emit.OpCodes.Stloc, argLocal);
+
+        // Type t = Type.GetType("SharpTS.Execution.EvalBridge, SharpTS");
+        il.Emit(System.Reflection.Emit.OpCodes.Ldstr, "SharpTS.Execution.EvalBridge, SharpTS");
+        il.Emit(System.Reflection.Emit.OpCodes.Call, ctx.Types.GetMethod(ctx.Types.Type, "GetType", ctx.Types.String));
+
+        // Graceful degradation: if the SharpTS runtime isn't present, t is null — throw a clear error
+        // instead of letting the subsequent virtual calls NRE.
+        var present = il.DefineLabel();
+        il.Emit(System.Reflection.Emit.OpCodes.Dup);
+        il.Emit(System.Reflection.Emit.OpCodes.Brtrue, present);
+        il.Emit(System.Reflection.Emit.OpCodes.Pop);
+        il.Emit(System.Reflection.Emit.OpCodes.Ldstr, "eval is not supported in standalone compiled output (SharpTS runtime not present).");
+        il.Emit(System.Reflection.Emit.OpCodes.Newobj, ctx.Types.ExceptionCtorString);
+        il.Emit(System.Reflection.Emit.OpCodes.Throw);
+        il.MarkLabel(present);
+
+        // MethodInfo m = t.GetMethod("Eval");
+        il.Emit(System.Reflection.Emit.OpCodes.Ldstr, "Eval");
+        il.Emit(System.Reflection.Emit.OpCodes.Callvirt, ctx.Types.GetMethod(ctx.Types.Type, "GetMethod", ctx.Types.String));
+
+        // return (object) m.Invoke(null, new object[] { arg });
+        il.Emit(System.Reflection.Emit.OpCodes.Ldnull);
+        il.Emit(System.Reflection.Emit.OpCodes.Ldc_I4_1);
+        il.Emit(System.Reflection.Emit.OpCodes.Newarr, ctx.Types.Object);
+        il.Emit(System.Reflection.Emit.OpCodes.Dup);
+        il.Emit(System.Reflection.Emit.OpCodes.Ldc_I4_0);
+        il.Emit(System.Reflection.Emit.OpCodes.Ldloc, argLocal);
+        il.Emit(System.Reflection.Emit.OpCodes.Stelem_Ref);
+        il.Emit(System.Reflection.Emit.OpCodes.Callvirt, ctx.Types.GetMethod(
+            ctx.Types.MethodInfo, "Invoke", ctx.Types.Object, ctx.Types.ObjectArray));
+
+        // Result is an arbitrary JS value (boxed object) of statically unknown type.
+        emitter.SetStackUnknown();
+        return true;
     }
 
     private static bool EmitParseInt(IEmitterContext emitter, System.Reflection.Emit.ILGenerator il, CompilationContext ctx, Expr.Call call)

--- a/Compilation/EmittedRuntime.cs
+++ b/Compilation/EmittedRuntime.cs
@@ -17,6 +17,28 @@ namespace SharpTS.Compilation;
 /// <seealso cref="ILEmitter"/>
 public class EmittedRuntime
 {
+    /// <summary>
+    /// Human-readable reasons this compilation emitted late binding into the SharpTS runtime
+    /// assembly (e.g. "eval()", "Proxy", "Intl"). Populated during emission by
+    /// <see cref="RequireSharpTSRuntime"/> at the feature gates / call sites that emit a
+    /// <c>Type.GetType("…, SharpTS")</c> reflection path whose <em>normal</em> execution needs
+    /// SharpTS.dll present. When non-empty, the build copies SharpTS.dll next to the output so
+    /// the soft dependency resolves; when empty, the output is fully standalone.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately excludes graceful-fallback-only late binding that a normal program never
+    /// reaches (e.g. the unconditional <c>process</c> helper), and pure-BCL features that emit
+    /// no late binding at all (zlib, child_process, JSON). See <c>RuntimeEmitter.RuntimeClass</c>
+    /// and <c>GlobalFunctionHandler.EmitEval</c> for the recording sites.
+    /// </remarks>
+    public SortedSet<string> RequiredSharpTSRuntimeReasons { get; } = new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Records that <paramref name="reason"/> emitted a SharpTS-runtime late-binding path that a
+    /// normal execution will hit. Idempotent.
+    /// </summary>
+    public void RequireSharpTSRuntime(string reason) => RequiredSharpTSRuntimeReasons.Add(reason);
+
     // The emitted $Undefined singleton class
     public Type UndefinedType { get; set; } = null!;
     public FieldInfo UndefinedInstance { get; set; } = null!;

--- a/Compilation/ILCompiler.cs
+++ b/Compilation/ILCompiler.cs
@@ -86,6 +86,15 @@ public partial class ILCompiler
     // Emitted runtime (for standalone DLLs)
     private EmittedRuntime _runtime = null!;
 
+    /// <summary>
+    /// Reasons this compilation emitted SharpTS-runtime late binding whose normal execution
+    /// needs SharpTS.dll present (e.g. "eval()", "Proxy", "Intl"). Empty ⇒ fully standalone.
+    /// Valid after <see cref="Compile"/> / <see cref="CompileModules"/> have run. The CLI uses
+    /// this to decide whether to co-locate SharpTS.dll with the output.
+    /// </summary>
+    public IReadOnlyCollection<string> RequiredSharpTSRuntimeReasons =>
+        _runtime?.RequiredSharpTSRuntimeReasons ?? (IReadOnlyCollection<string>)Array.Empty<string>();
+
     // Type information from static analysis
     private TypeMap _typeMap = null!;
 

--- a/Compilation/ILEmitter.Calls.ExternalInterop.cs
+++ b/Compilation/ILEmitter.Calls.ExternalInterop.cs
@@ -635,6 +635,11 @@ public partial class ILEmitter
             ? "CompiledAddEventListener"
             : "CompiledRemoveEventListener";
 
+        // This slow path reflects into DotNetEventBinder in the SharpTS runtime — record the
+        // soft dependency so the build co-locates SharpTS.dll. (The literal-event-name fast
+        // path is pure IL and does not reach here.)
+        _ctx.Runtime?.RequireSharpTSRuntime("@DotNetType dynamic event binding");
+
         // Locals: object receiver, object[] args
         var receiverLocal = IL.DeclareLocal(_ctx.Types.Object);
         if (isStatic || receiver == null)

--- a/Compilation/RuntimeEmitter.RuntimeClass.cs
+++ b/Compilation/RuntimeEmitter.RuntimeClass.cs
@@ -976,8 +976,13 @@ public partial class RuntimeEmitter
         // FinalizationRegistry methods
         EmitFinalizationRegistryMethods(typeBuilder, runtime);
         // Proxy methods — gated on UsesProxy (`new Proxy()` / bare `Proxy`).
+        // Proxy trap dispatch late-binds to SharpTSProxy on its normal path, so the
+        // compiled output needs SharpTS.dll present at runtime when Proxy is used.
         if (_features.UsesProxy)
+        {
+            runtime.RequireSharpTSRuntime("Proxy");
             EmitProxyMethods(typeBuilder, runtime);
+        }
         // AbortController/AbortSignal methods (FireAbortEvent must be emitted
         // before AbortController methods). Gated on UsesAbortController, also
         // implied by UsesWebStreams (ReadableStream pipeTo checks abort state).
@@ -1005,6 +1010,8 @@ public partial class RuntimeEmitter
             EmitOsModuleMethods(typeBuilder, runtime);
         if (_features.UsesDns)
         {
+            // dns.Resolver late-binds to RuntimeTypes.DnsCreateResolver — needs SharpTS at runtime.
+            runtime.RequireSharpTSRuntime("dns module");
             EmitDnsModuleMethods(typeBuilder, runtime);
             EmitDnsPromisesMethods(typeBuilder, runtime);
         }
@@ -1084,8 +1091,12 @@ public partial class RuntimeEmitter
         // string_decoder module migrated to stdlib/node/string_decoder.ts.
 
         // Intl support (Intl.NumberFormat / DateTimeFormat / Collator) — gated.
+        // Every Intl operation late-binds to RuntimeTypes — needs SharpTS at runtime.
         if (_features.UsesIntl)
+        {
+            runtime.RequireSharpTSRuntime("Intl");
             EmitIntlMethods(typeBuilder, runtime);
+        }
 
         // TLS handshake helpers — only meaningful with TLS types emitted.
         if (_features.UsesTls)
@@ -1099,8 +1110,12 @@ public partial class RuntimeEmitter
             EmitClusterHelpers(typeBuilder, runtime);
 
         // Vm module support — gated on UsesVm (set by `import 'vm'`).
+        // vm delegates to VmModuleInterpreter via late binding — needs SharpTS at runtime.
         if (_features.UsesVm)
+        {
+            runtime.RequireSharpTSRuntime("vm module");
             EmitVmMethods(typeBuilder, runtime);
+        }
 
         // Web Streams API (stream/web) is now fully pure-IL emitted via
         // RuntimeEmitter.QueuingStrategy.cs / WritableStream.cs /

--- a/Execution/EvalBridge.cs
+++ b/Execution/EvalBridge.cs
@@ -1,0 +1,37 @@
+namespace SharpTS.Execution;
+
+/// <summary>
+/// Reflection entry point for the global <c>eval()</c> function in <b>compiled</b> output.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Compiled programs run as native .NET IL with no live <see cref="Interpreter"/> behind
+/// them, so there is no caller scope for eval'd code to capture. This bridge therefore
+/// implements <b>indirect eval</b> semantics: it spins up a fresh interpreter and evaluates
+/// the source in a clean global scope (built-in globals like <c>Number</c>, <c>Math</c>,
+/// <c>JSON</c> resolve normally; compiled local variables are intentionally not visible).
+/// </para>
+/// <para>
+/// The compiled DLL never references this type directly — it is invoked via
+/// <c>Type.GetType("SharpTS.Execution.EvalBridge, SharpTS")</c> at runtime (see
+/// <c>GlobalFunctionHandler.EmitEval</c>), preserving the standalone-DLL constraint. When
+/// SharpTS is not present the compiled call site degrades gracefully with a deterministic
+/// throw rather than resolving this method.
+/// </para>
+/// </remarks>
+public static class EvalBridge
+{
+    /// <summary>
+    /// Evaluates <paramref name="argument"/> as JavaScript/TypeScript source in a fresh global
+    /// scope and returns the completion value. Per ECMA-262 §19.2.1, a non-string argument is
+    /// returned unchanged.
+    /// </summary>
+    public static object? Eval(object? argument)
+    {
+        if (argument is not string source)
+            return argument;
+
+        var interpreter = new Interpreter();
+        return interpreter.Eval(source);
+    }
+}

--- a/Execution/Interpreter.cs
+++ b/Execution/Interpreter.cs
@@ -1051,6 +1051,39 @@ public partial class Interpreter : IDisposable
     }
 
     /// <summary>
+    /// Implements the global <c>eval(source)</c> function. Lexes, parses, and interprets
+    /// <paramref name="source"/> in the interpreter's current environment, returning the
+    /// completion value (the value of the last expression statement, or <c>undefined</c>).
+    /// </summary>
+    /// <remarks>
+    /// This is "direct eval" semantics: the evaluated code runs against the current scope
+    /// chain. It is intentionally NOT type-checked — <c>eval</c> is typed as
+    /// <c>(s: string) =&gt; any</c>, matching tsc, so the string body is dynamic. The
+    /// variable resolver is also skipped so identifier lookups fall back to runtime
+    /// scope-chain traversal (<see cref="LookupVariableRV"/>), which resolves names against
+    /// the live caller environment rather than a from-scratch resolution that would compute
+    /// wrong scope depths. A parse failure throws a <c>SyntaxError</c>.
+    /// </remarks>
+    public object? Eval(string source)
+    {
+        var lexer = new Lexer(source);
+        List<Token> tokens = lexer.ScanTokens();
+        var parser = new Parser(tokens);
+        var parseResult = parser.Parse();
+        if (!parseResult.IsSuccess)
+        {
+            var detail = parseResult.Diagnostics.Count > 0
+                ? parseResult.Diagnostics[0].ToString()
+                : "invalid syntax";
+            throw new ThrowException(new SharpTSError($"SyntaxError: {detail}"));
+        }
+
+        // Preserve the outer type map: InterpretRepl assigns _typeMap, and passing null
+        // would clobber type-aware dispatch for the remainder of the outer program.
+        return InterpretRepl(parseResult.Statements, _typeMap);
+    }
+
+    /// <summary>
     /// Interprets multiple modules in dependency order.
     /// </summary>
     /// <param name="modules">Modules in dependency order (dependencies first)</param>

--- a/Program.cs
+++ b/Program.cs
@@ -82,7 +82,7 @@ switch (command)
         break;
 
     case ParsedCommand.Compile compile:
-        var outputOptions = new OutputOptions(compile.CompileOptions.MsBuildErrors, compile.CompileOptions.QuietMode);
+        var outputOptions = new OutputOptions(compile.CompileOptions.MsBuildErrors, compile.CompileOptions.QuietMode, compile.CompileOptions.Standalone);
         CompileFile(
             compile.InputFile,
             compile.OutputFile,
@@ -504,6 +504,7 @@ static void CompileModuleFile(string absolutePath, string outputPath, bool prese
         compiler.Save(outputPath);
 
         GenerateRuntimeConfig(outputPath);
+        CopySharpTSRuntimeIfNeeded(compiler, outputPath, outputOptions);
         if (!outputOptions.QuietMode)
         {
             Console.WriteLine($"Compiled to {outputPath}");
@@ -604,6 +605,7 @@ static void CompileSingleFile(List<Stmt> statements, string outputPath, bool pre
         compiler.Save(outputPath);
 
         GenerateRuntimeConfig(outputPath);
+        CopySharpTSRuntimeIfNeeded(compiler, outputPath, outputOptions);
         if (!outputOptions.QuietMode)
         {
             Console.WriteLine($"Compiled to {outputPath}");
@@ -614,6 +616,54 @@ static void CompileSingleFile(List<Stmt> statements, string outputPath, bool pre
         {
             VerifyCompiledAssembly(outputPath, sdkPath);
         }
+    }
+}
+
+/// <summary>
+/// Co-locates SharpTS.dll with the compiled output when, and only when, the compilation emitted
+/// late binding into the SharpTS runtime whose normal execution needs it (eval, Proxy, Intl, vm,
+/// dns, @DotNetType dynamic events). Programs that use none of these stay fully standalone — no
+/// copy. <c>--standalone</c> suppresses the copy (the soft-dependent features then throw a clear
+/// "not supported" error at runtime instead).
+/// </summary>
+static void CopySharpTSRuntimeIfNeeded(ILCompiler compiler, string outputPath, OutputOptions outputOptions)
+{
+    var reasons = compiler.RequiredSharpTSRuntimeReasons;
+    if (reasons.Count == 0)
+        return; // fully standalone — nothing to co-locate
+
+    string reasonList = string.Join(", ", reasons);
+
+    if (outputOptions.Standalone)
+    {
+        if (!outputOptions.QuietMode)
+            Console.WriteLine(
+                $"Note: output uses features needing the SharpTS runtime ({reasonList}); " +
+                "--standalone set, so SharpTS.dll was not copied. These features will throw at runtime unless SharpTS.dll is present.");
+        return;
+    }
+
+    var sharpTsPath = typeof(SharpTS.Execution.Interpreter).Assembly.Location;
+    var outDir = Path.GetDirectoryName(Path.GetFullPath(outputPath));
+    if (string.IsNullOrEmpty(sharpTsPath) || !File.Exists(sharpTsPath) || outDir == null)
+    {
+        if (!outputOptions.QuietMode)
+            Console.WriteLine($"Warning: could not locate SharpTS.dll to co-locate with output; features ({reasonList}) may fail at runtime.");
+        return;
+    }
+
+    var destPath = Path.Combine(outDir, Path.GetFileName(sharpTsPath));
+    try
+    {
+        if (!string.Equals(Path.GetFullPath(sharpTsPath), Path.GetFullPath(destPath), StringComparison.OrdinalIgnoreCase))
+            File.Copy(sharpTsPath, destPath, overwrite: true);
+        if (!outputOptions.QuietMode)
+            Console.WriteLine($"Copied SharpTS.dll next to output — required at runtime by: {reasonList}");
+    }
+    catch (Exception ex)
+    {
+        if (!outputOptions.QuietMode)
+            Console.WriteLine($"Warning: failed to co-locate SharpTS.dll with output ({reasonList}): {ex.Message}");
     }
 }
 
@@ -874,4 +924,4 @@ static void PrintCompileUsage()
     Console.WriteLine("  --version <ver>        Override package version");
 }
 
-record OutputOptions(bool MsBuildErrors, bool QuietMode);
+record OutputOptions(bool MsBuildErrors, bool QuietMode, bool Standalone = false);

--- a/Runtime/BuiltIns/BuiltInNames.cs
+++ b/Runtime/BuiltIns/BuiltInNames.cs
@@ -157,6 +157,7 @@ public static class BuiltInNames
     ];
 
     // Individual function constants
+    public const string Eval = "eval";
     public const string ParseInt = "parseInt";
     public const string ParseFloat = "parseFloat";
     public const string IsNaN = "isNaN";

--- a/Runtime/BuiltIns/GlobalFunctionHandlers.cs
+++ b/Runtime/BuiltIns/GlobalFunctionHandlers.cs
@@ -20,6 +20,9 @@ internal static class GlobalFunctionHandlers
         registry.RegisterV2(BuiltInNames.BigInt, HandleBigInt);
         registry.RegisterV2(BuiltInNames.Date, HandleDate);
 
+        // Dynamic code evaluation
+        registry.RegisterV2(BuiltInNames.Eval, HandleEval);
+
         // Parsing functions
         registry.RegisterV2(BuiltInNames.ParseInt, HandleParseInt);
         registry.RegisterV2(BuiltInNames.ParseFloat, HandleParseFloat);
@@ -101,6 +104,23 @@ internal static class GlobalFunctionHandlers
         Interpreter interpreter)
     {
         return ValueTask.FromResult(RuntimeValue.FromString(new SharpTSDate().ToString()));
+    }
+
+    private static async ValueTask<RuntimeValue> HandleEval(
+        Func<Expr, ValueTask<RuntimeValue>> evaluateArg,
+        IReadOnlyList<Expr> arguments,
+        Interpreter interpreter)
+    {
+        if (arguments.Count < 1)
+            return RuntimeValue.Undefined;
+
+        var argRV = await evaluateArg(arguments[0]);
+
+        // Per ECMA-262 §19.2.1: if the argument is not a string, eval returns it unchanged.
+        if (!argRV.IsString)
+            return argRV;
+
+        return RuntimeValue.FromBoxed(interpreter.Eval(argRV.AsString()));
     }
 
     private static async ValueTask<RuntimeValue> HandleParseInt(

--- a/STATUS.md
+++ b/STATUS.md
@@ -353,7 +353,7 @@ This section documents JavaScript/TypeScript features that are **not currently i
 
 | Feature | Status | Notes |
 |---------|--------|-------|
-| `eval()` | ❌ | No dynamic code evaluation |
+| `eval()` | ⚠️ | Typed as `(s: string) => any`. **Interpreted:** direct eval — source runs against the caller's scope chain. **Compiled:** indirect eval via the SharpTS runtime (`EvalBridge`) — global builtins resolve but compiled locals are not visible. The build auto-copies SharpTS.dll next to the output when eval is used (see "Standalone DLL Constraint" in CLAUDE.md); with `--standalone` it is not copied and eval throws "eval not supported" at runtime. Eval'd source is not type-checked. Non-string args returned unchanged (ECMA-262 §19.2.1). |
 | `Function` constructor | ❌ | Cannot create functions from strings |
 | `queueMicrotask()` | ✅ | Schedules microtask for execution |
 

--- a/SharpTS.Tests/CompilerTests/RuntimeDependencySignalTests.cs
+++ b/SharpTS.Tests/CompilerTests/RuntimeDependencySignalTests.cs
@@ -1,0 +1,73 @@
+using SharpTS.Compilation;
+using SharpTS.Parsing;
+using SharpTS.TypeSystem;
+using Xunit;
+
+namespace SharpTS.Tests.CompilerTests;
+
+/// <summary>
+/// Verifies the compile-time signal that drives co-locating SharpTS.dll with compiled output:
+/// <see cref="ILCompiler.RequiredSharpTSRuntimeReasons"/>. A program that uses none of the
+/// SharpTS-runtime-backed features must stay fully standalone (empty reasons); programs that use
+/// eval/Proxy/Intl/etc. must report the corresponding reason so the build copies the runtime.
+/// </summary>
+public class RuntimeDependencySignalTests
+{
+    private static IReadOnlyCollection<string> ReasonsFor(string source)
+    {
+        var tokens = new Lexer(source).ScanTokens();
+        var statements = new Parser(tokens).ParseOrThrow();
+        var typeMap = new TypeChecker().Check(statements);
+        var deadCodeInfo = new DeadCodeAnalyzer(typeMap).Analyze(statements);
+
+        var compiler = new ILCompiler("runtime_signal_test");
+        compiler.Compile(statements, typeMap, deadCodeInfo);
+        return compiler.RequiredSharpTSRuntimeReasons;
+    }
+
+    [Fact]
+    public void TrivialProgram_RequiresNoRuntime()
+    {
+        var reasons = ReasonsFor("""
+            const xs = [1, 2, 3].map(x => x * 2);
+            console.log(xs.join(","));
+            """);
+        Assert.Empty(reasons);
+    }
+
+    [Fact]
+    public void Eval_RequiresRuntime()
+    {
+        var reasons = ReasonsFor("""console.log(eval("1 + 2"));""");
+        Assert.Contains("eval()", reasons);
+    }
+
+    [Fact]
+    public void Proxy_RequiresRuntime()
+    {
+        var reasons = ReasonsFor("""
+            const p: any = new Proxy({ a: 1 }, { get: (t, k) => 42 });
+            console.log(p.a);
+            """);
+        Assert.Contains("Proxy", reasons);
+    }
+
+    [Fact]
+    public void Intl_RequiresRuntime()
+    {
+        var reasons = ReasonsFor("""
+            const nf = new Intl.NumberFormat("en-US");
+            console.log(nf.format(1234.5));
+            """);
+        Assert.Contains("Intl", reasons);
+    }
+
+    [Fact]
+    public void Eval_DoesNotFalselyReportOtherFeatures()
+    {
+        var reasons = ReasonsFor("""console.log(eval("1 + 2"));""");
+        Assert.DoesNotContain("Proxy", reasons);
+        Assert.DoesNotContain("Intl", reasons);
+        Assert.DoesNotContain("vm module", reasons);
+    }
+}

--- a/SharpTS.Tests/CompilerTests/StandaloneDllTests.cs
+++ b/SharpTS.Tests/CompilerTests/StandaloneDllTests.cs
@@ -41,6 +41,7 @@ public class StandaloneDllTests
         "Compilation/RuntimeEmitter.DnsPromises.cs",           // dns/promises delegation to RuntimeTypes via reflection
         "Compilation/RuntimeEmitter.DnsResolver.cs",           // dns.Resolver factory via RuntimeTypes
         "Compilation/ILEmitter.Calls.ExternalInterop.cs",      // @DotNetType delegate shim + event subscription via DotNetDelegateShim/DotNetEventBinder
+        "Compilation/CallHandlers/GlobalFunctionHandler.cs",   // eval() indirect dispatch via EvalBridge (graceful throw when SharpTS absent)
     };
 
     /// <summary>

--- a/SharpTS.Tests/SharedTests/EvalTests.cs
+++ b/SharpTS.Tests/SharedTests/EvalTests.cs
@@ -1,0 +1,97 @@
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests;
+
+/// <summary>
+/// Tests for the global <c>eval()</c> function (issue #107).
+/// <para>
+/// Interpreter mode performs <b>direct eval</b> (the evaluated source runs against the caller's
+/// scope chain). Compiled mode performs <b>indirect eval</b> via the SharpTS runtime
+/// (<c>EvalBridge</c>): global builtins resolve, but compiled local variables are not visible —
+/// hence the local-capture test is interpreter-only.
+/// </para>
+/// </summary>
+public class EvalTests
+{
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Eval_WhitespaceTolerance_ResolvesGlobals(ExecutionMode mode)
+    {
+        // Test262 S11.2.1_A1.1-style: eval tolerates interior whitespace and resolves globals.
+        var source = """
+            console.log(eval("Number\t.\tPOSITIVE_INFINITY") === Number.POSITIVE_INFINITY);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("true\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Eval_ReturnsCompletionValueOfExpression(ExecutionMode mode)
+    {
+        var source = """
+            console.log(eval("1 + 2 * 3"));
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("7\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Eval_NonStringArgument_ReturnedUnchanged(ExecutionMode mode)
+    {
+        // ECMA-262 §19.2.1: eval(non-string) returns the argument unchanged.
+        var source = """
+            console.log(eval(42));
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("42\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Eval_StatementsThenCompletionValue(ExecutionMode mode)
+    {
+        var source = """
+            console.log(eval("var x = 10; x * x"));
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("100\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Eval_BuiltinMethodCalls(ExecutionMode mode)
+    {
+        var source = """
+            console.log(eval("'abc'.toUpperCase()"));
+            console.log(eval("Math.max(3, 7, 2)"));
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("ABC\n7\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void Eval_DirectEval_SeesCallerLocals(ExecutionMode mode)
+    {
+        // Direct-eval semantics: the evaluated source resolves against the caller's scope.
+        // Interpreter-only — compiled output has no live interpreter/scope for direct eval.
+        var source = """
+            function outer(): number {
+                const secret: number = 7;
+                return eval("secret + 1") as number;
+            }
+            console.log(outer());
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("8\n", output);
+    }
+}

--- a/TypeSystem/TypeChecker.Calls.cs
+++ b/TypeSystem/TypeChecker.Calls.cs
@@ -288,6 +288,14 @@ public partial class TypeChecker
             return new TypeInfo.Primitive(Parsing.TokenType.TYPE_BOOLEAN);
         }
 
+        // Handle global eval() — typed as (s: string) => any. The argument string is
+        // not statically analyzed (matching tsc's `eval` lib typing), so the result is Any.
+        if (call.Callee is Expr.Variable evalVar && evalVar.Name.Lexeme == "eval")
+        {
+            foreach (var arg in call.Arguments) CheckExpr(arg);
+            return new TypeInfo.Any();
+        }
+
         // Timer functions (setTimeout / clearTimeout / setInterval / clearInterval)
         // have two resolutions: the JS globals (untyped, `_environment.Get` returns
         // null — handled here) and imports from stdlib/node/timers{,/promises}.ts

--- a/TypeSystem/TypeChecker.Expressions.cs
+++ b/TypeSystem/TypeChecker.Expressions.cs
@@ -1224,6 +1224,7 @@ public partial class TypeChecker
         if (name.Lexeme == "parseFloat") return new TypeInfo.Any(); // Global parseFloat function
         if (name.Lexeme == "isNaN") return new TypeInfo.Any(); // Global isNaN function
         if (name.Lexeme == "isFinite") return new TypeInfo.Any(); // Global isFinite function
+        if (name.Lexeme == "eval") return new TypeInfo.Any(); // Global eval(): (s: string) => any
         if (name.Lexeme == "globalThis") return new TypeInfo.Any(); // globalThis ES2020
         if (name.Lexeme == "fetch") return new TypeInfo.Any(); // fetch() global function
         if (name.Lexeme == "setTimeout") return new TypeInfo.Any(); // setTimeout() global function


### PR DESCRIPTION
## Summary

Two related changes:

1. **`eval()` support (closes #107)** — real eval in both execution modes.
2. **Runtime-dependency signal + auto-copy** — co-locate `SharpTS.dll` with compiled output only when a feature actually needs it at runtime.

## 1. eval() (#107)

`eval` is now registered as a global typed `(s: string) => any` (identifier + call paths), removing the categorical `TypeCheckError` floor that blocked any program referencing eval.

- **Interpreted:** direct eval — `Interpreter.Eval()` lexes/parses/interprets the source against the caller's scope chain and returns the completion value. Not type-checked (matches tsc); non-string args returned unchanged (ECMA-262 §19.2.1); parse failures throw `SyntaxError`.
- **Compiled:** indirect eval via `EvalBridge` in the SharpTS runtime, invoked through the `Type.GetType("…,SharpTS")` reflection pattern so the output DLL keeps **no hard SharpTS reference**. Global builtins resolve; compiled locals are not visible (no live interpreter behind native IL). Degrades to a deterministic "eval not supported" throw when SharpTS.dll is absent.

### Acceptance verified
The issue's criterion — the property-accessor eval tests move off `TypeCheckError` — is confirmed: `test/language/expressions/property-accessors/S11.2.1_A1.1.js` now **passes all 9 Unicode-whitespace checks** (TAB, VT, FF, SP, NBSP, LF, CR, LS, PS) in **both** interpreted and compiled modes (`TypeCheckError → Pass`).

## 2. Co-locate SharpTS.dll only when needed

Some features (eval, Proxy, Intl, vm, dns, `@DotNetType` dynamic events) emit a `Type.GetType("…,SharpTS")` path whose *normal* execution needs SharpTS.dll present. A byte-scan for `,SharpTS` is too coarse — the unconditional `process` helper bakes that string into every DLL, yet a trivial program runs fine standalone. So this adds a **semantic** signal:

- `EmittedRuntime.RequiredSharpTSRuntimeReasons` + `RequireSharpTSRuntime(reason)`, surfaced via `ILCompiler.RequiredSharpTSRuntimeReasons` (one set per compilation).
- Recorded at the gates/call sites that emit a *reachable* late-binding path; **not** recorded for pure-BCL features (zlib, child_process, JSON) or unconditional graceful-fallback plumbing (`process`).
- `Program.cs` copies `SharpTS.dll` next to the output after `Save` **only when** the reason set is non-empty — programs using none of these stay fully standalone.
- New `--compile … --standalone` flag suppresses the copy (those features then throw their clear "not supported" error at runtime).

### Verified end-to-end
- Trivial program → **no copy**.
- `eval` program → `Copied SharpTS.dll … required at runtime by: eval()`; co-located DLL runs.
- `Proxy` program → copy with reason `Proxy`; runs.
- `--standalone` → note printed, **no copy**.

## Tests
- `EvalTests` — both modes (whitespace tolerance, completion values, non-string passthrough, var decls, builtin calls) + an interpreter-only direct-eval local-capture case.
- `RuntimeDependencySignalTests` — trivial = empty reasons; eval/Proxy/Intl flagged; eval does not false-positive other features.
- Full suite: **10335 passed**; only the 2 pre-existing `PackagingTests.Pack_WithoutPackageJson_*` failures remain (confirmed failing at baseline `main`, unrelated). Standalone-DLL guard green.

## Known limitations / follow-ups (not in scope here)
- Compiled eval is indirect-only (can't see compiled locals) — by design.
- `AbortSignal.any` late-binds but is gated only at the coarse `UsesAbortController` level, so it's left unflagged to avoid penalizing common AbortController + fetch use.
- The `-t exe` and NuGet packaging paths don't yet consume the runtime-dependency signal.

Closes #107.
