### PR TITLE
feat: model call/construct signatures on object type literals (#122)

### DIFF
--- a/SharpTS.Tests/TypeCheckerTests/ObjectLiteralSignatureTests.cs
+++ b/SharpTS.Tests/TypeCheckerTests/ObjectLiteralSignatureTests.cs
@@ -1,0 +1,83 @@
+using SharpTS.TypeSystem.Exceptions;
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.TypeCheckerTests;
+
+/// <summary>
+/// Type-checking coverage for call/construct signatures on inline object type literals
+/// (issue #122). These mirror the behaviour callable/constructable interfaces already have:
+/// an object type like <c>{ (x: number): T }</c> is callable, and <c>{ new (x): T }</c> is
+/// constructable, and they participate in assignability in both directions.
+/// </summary>
+public class ObjectLiteralSignatureTests
+{
+    // ---- Call signatures ------------------------------------------------
+
+    [Fact]
+    public void CallableObjectType_AcceptsMatchingFunction()
+    {
+        // A function whose signature matches is assignable to a callable object type.
+        TestHarness.RunInterpreted("let f: { (x: number): string }; f = (x: number) => \"\" + x;");
+    }
+
+    [Fact]
+    public void CallableObjectType_VoidReturn_AcceptsValueReturningFunction()
+    {
+        // void-returning call signature accepts a function that returns a value.
+        TestHarness.RunInterpreted("let f: { (x: number): void }; f = (x: number) => \"ignored\";");
+    }
+
+    [Fact]
+    public void CallableObjectType_FewerParameters_IsAccepted()
+    {
+        // A function taking fewer parameters than the signature is assignable.
+        TestHarness.RunInterpreted("let f: { (x: number): void }; f = () => {};");
+    }
+
+    [Fact]
+    public void CallableObjectType_RejectsIncompatibleParameter()
+    {
+        Assert.ThrowsAny<TypeCheckException>(() =>
+            TestHarness.RunInterpreted("let f: { (x: number): void }; f = (x: string) => {};"));
+    }
+
+    [Fact]
+    public void CallableObjectType_IsInvocable_ReturningSignatureReturnType()
+    {
+        // Calling a value typed as a callable object type yields the signature's return type.
+        TestHarness.RunInterpreted("let f: { (x: number): string }; f = (x: number) => \"\" + x; let r: string = f(5);");
+    }
+
+    [Fact]
+    public void CallableObjectType_CallResultRespectsReturnType()
+    {
+        Assert.ThrowsAny<TypeCheckException>(() =>
+            TestHarness.RunInterpreted("let f: { (x: number): string }; f = (x: number) => \"\" + x; let n: number = f(5);"));
+    }
+
+    [Fact]
+    public void CallableInterface_AssignableToFunctionVariable()
+    {
+        // Reverse direction: a callable interface is assignable to a function-typed target.
+        TestHarness.RunInterpreted("interface T { (x: number): void } let t: T; let a: (x: number) => void; a = t;");
+    }
+
+    // ---- Construct signatures ------------------------------------------
+
+    [Fact]
+    public void ConstructableObjectType_RejectsPlainFunction()
+    {
+        // A plain (arrow) function is not a constructor.
+        Assert.ThrowsAny<TypeCheckException>(() =>
+            TestHarness.RunInterpreted("let C: { new (x: number): object }; C = (x: number) => ({});"));
+    }
+
+    [Fact]
+    public void ConstructableObjectType_RejectsCallableOnlySource()
+    {
+        // A callable-only object type is not constructable.
+        Assert.ThrowsAny<TypeCheckException>(() =>
+            TestHarness.RunInterpreted("let C: { new (x: number): object }; let f: { (x: number): object }; C = f;"));
+    }
+}

--- a/TypeSystem/TypeChecker.Calls.cs
+++ b/TypeSystem/TypeChecker.Calls.cs
@@ -615,6 +615,11 @@ public partial class TypeChecker
         {
             return CheckGenericCallableInterfaceCall(gi, call.TypeArgs, call.Arguments);
         }
+        // Handle callable inline object types: `{ (x): T }`
+        if (calleeType is TypeInfo.Record callableRec && callableRec.IsCallable)
+        {
+            return CheckCallSignaturesCall(callableRec.CallSignatures!, "object type", call.TypeArgs, call.Arguments);
+        }
 
         // Handle union types containing functions (e.g., from property access on union type)
         if (calleeType is TypeInfo.Union unionCallee)
@@ -683,10 +688,23 @@ public partial class TypeChecker
             throw new TypeCheckException($"Interface '{itf.Name}' is not callable.", tsCode: "TS2349");
         }
 
+        return CheckCallSignaturesCall(itf.CallSignatures, $"interface '{itf.Name}'", typeArgs, arguments);
+    }
+
+    /// <summary>
+    /// Resolves a call against a set of call signatures (shared by callable interfaces and callable
+    /// inline object types). Returns the matching signature's return type.
+    /// </summary>
+    private TypeInfo CheckCallSignaturesCall(
+        List<TypeInfo.CallSignature> callSignatures,
+        string calleeDescription,
+        List<string>? typeArgs,
+        List<Expr> arguments)
+    {
         List<TypeInfo> argTypes = arguments.Select(CheckExpr).ToList();
 
         // Try each call signature
-        foreach (var callSig in itf.CallSignatures)
+        foreach (var callSig in callSignatures)
         {
             if (callSig.IsGeneric)
             {
@@ -705,7 +723,7 @@ public partial class TypeChecker
             }
         }
 
-        throw new TypeCheckException($"No call signature matches the call for interface '{itf.Name}'.", tsCode: "TS2769");
+        throw new TypeCheckException($"No call signature matches the call for {calleeDescription}.", tsCode: "TS2769");
     }
 
     /// <summary>

--- a/TypeSystem/TypeChecker.Compatibility.Callable.cs
+++ b/TypeSystem/TypeChecker.Compatibility.Callable.cs
@@ -15,36 +15,83 @@ public partial class TypeChecker
     }
 
     /// <summary>
-    /// Checks if a function type matches a single call signature.
+    /// Checks if a function type matches a single call signature. A call signature <c>(p): r</c>
+    /// is itself a function type, so assignability is just function-to-function assignability —
+    /// route through the shared logic so void-return covariance and parameter-arity rules stay
+    /// consistent in one place.
     /// </summary>
     private bool FunctionMatchesCallSignature(TypeInfo.Function func, TypeInfo.CallSignature sig)
     {
-        // Generic signatures need special handling
+        // Generic call signatures are complex to match structurally - defer to the actual call.
         if (sig.IsGeneric)
+            return false;
+
+        return IsCompatible(CallSignatureToFunction(sig), func);
+    }
+
+    /// <summary>Views a call signature as the function type it denotes.</summary>
+    private static TypeInfo.Function CallSignatureToFunction(TypeInfo.CallSignature sig) =>
+        new(sig.ParamTypes, sig.ReturnType, sig.RequiredParams, sig.HasRestParam, ThisType: null, sig.ParamNames);
+
+    /// <summary>
+    /// Call signatures carried by a callable type (interface or inline object type), or null if the
+    /// type is not callable. Used to make callable interfaces and object types interchangeable in
+    /// assignability checks.
+    /// </summary>
+    private static List<TypeInfo.CallSignature>? GetCallSignatures(TypeInfo type) => type switch
+    {
+        TypeInfo.Interface { IsCallable: true } itf => itf.CallSignatures,
+        TypeInfo.Record { IsCallable: true } rec => rec.CallSignatures,
+        _ => null,
+    };
+
+    /// <summary>
+    /// Checks that every call signature of a callable source type is assignable to the target
+    /// function type — i.e. the callable can stand in for the function.
+    /// </summary>
+    private bool CallableAssignableToFunction(List<TypeInfo.CallSignature> sourceSignatures, TypeInfo.Function target)
+    {
+        foreach (var sig in sourceSignatures)
         {
-            // For generic call signatures, check if function can satisfy the signature
-            // For now, require exact structural match (this could be relaxed later)
-            return false; // Generic call signatures are complex to match - defer to actual call
+            if (sig.IsGeneric) continue; // best-effort: skip generic signatures
+            if (IsCompatible(target, CallSignatureToFunction(sig)))
+                return true;
         }
+        return false;
+    }
 
-        // Check parameter count compatibility
-        if (func.MinArity > sig.ParamTypes.Count)
-            return false;
+    /// <summary>
+    /// Construct signatures carried by a constructable type (interface or inline object type), or
+    /// null if the type is not constructable.
+    /// </summary>
+    private static List<TypeInfo.ConstructorSignature>? GetConstructorSignatures(TypeInfo type) => type switch
+    {
+        TypeInfo.Interface { IsConstructable: true } itf => itf.ConstructorSignatures,
+        TypeInfo.Record { IsConstructable: true } rec => rec.ConstructorSignatures,
+        _ => null,
+    };
 
-        if (func.ParamTypes.Count < sig.MinArity)
-            return false;
+    /// <summary>Views a construct signature as the (constructor) function type it denotes.</summary>
+    private static TypeInfo.Function ConstructorSignatureToFunction(TypeInfo.ConstructorSignature sig) =>
+        new(sig.ParamTypes, sig.ReturnType, sig.RequiredParams, sig.HasRestParam, ThisType: null, sig.ParamNames);
 
-        // Check parameter type compatibility (contravariant - signature params must be assignable FROM function params)
-        int paramCount = Math.Min(func.ParamTypes.Count, sig.ParamTypes.Count);
-        for (int i = 0; i < paramCount; i++)
+    /// <summary>
+    /// Checks that every construct signature required by the target is satisfied by one of the
+    /// source's construct signatures (parameter contravariance, return covariance via the shared
+    /// function-compatibility logic).
+    /// </summary>
+    private bool ConstructorSignaturesSatisfiedBy(
+        List<TypeInfo.ConstructorSignature> targetSignatures,
+        List<TypeInfo.ConstructorSignature> sourceSignatures)
+    {
+        foreach (var ts in targetSignatures)
         {
-            // Function parameter type should accept what the signature requires
-            if (!IsCompatible(func.ParamTypes[i], sig.ParamTypes[i]))
+            if (ts.IsGeneric) continue; // best-effort: skip generic signatures
+            var targetFunc = ConstructorSignatureToFunction(ts);
+            if (!sourceSignatures.Any(ss => !ss.IsGeneric && IsCompatible(targetFunc, ConstructorSignatureToFunction(ss))))
                 return false;
         }
-
-        // Check return type compatibility (covariant - function return must be assignable TO signature return)
-        return IsCompatible(sig.ReturnType, func.ReturnType);
+        return true;
     }
 
     /// <summary>

--- a/TypeSystem/TypeChecker.Compatibility.cs
+++ b/TypeSystem/TypeChecker.Compatibility.cs
@@ -700,16 +700,39 @@ public partial class TypeChecker
 
         if (expected is TypeInfo.Interface itf)
         {
-            // Function assignable to callable interface
-            if (itf.IsCallable && actual is TypeInfo.Function func)
+            // Callable interface: the source must satisfy the call signatures.
+            if (itf.IsCallable)
             {
-                return FunctionMatchesCallSignatures(func, itf.CallSignatures!);
+                if (actual is TypeInfo.Function func)
+                    return FunctionMatchesCallSignatures(func, itf.CallSignatures!);
+
+                if (GetCallSignatures(actual) is { } actualCallSigs)
+                {
+                    foreach (var es in itf.CallSignatures!)
+                        if (!actualCallSigs.Any(@as => IsCompatible(CallSignatureToFunction(es), CallSignatureToFunction(@as))))
+                            return false;
+                    // Non-signature members (if any) still checked by the structural path below.
+                    if (itf.Members.Count == 0) return true;
+                }
+                // Other actuals (e.g. generic functions) may still be callable via downstream
+                // paths — fall through rather than rejecting here.
             }
 
-            // Class assignable to constructable interface
-            if (itf.IsConstructable && actual is TypeInfo.Class cls)
+            // Constructable interface: the source must satisfy the construct signatures.
+            if (itf.IsConstructable)
             {
-                return ClassMatchesConstructorSignatures(cls, itf.ConstructorSignatures!);
+                if (actual is TypeInfo.Class cls)
+                    return ClassMatchesConstructorSignatures(cls, itf.ConstructorSignatures!);
+
+                if (GetConstructorSignatures(actual) is { } actualCtorSigs)
+                {
+                    if (!ConstructorSignaturesSatisfiedBy(itf.ConstructorSignatures!, actualCtorSigs)) return false;
+                    if (itf.Members.Count == 0) return true;
+                }
+                else if (actual is not TypeInfo.Any)
+                {
+                    return false; // a constructable interface is not satisfied by a non-constructable source
+                }
             }
 
             // If actual is also an interface, compare member-to-member structurally
@@ -774,6 +797,48 @@ public partial class TypeChecker
         if (expected is TypeInfo.Array a1 && actual is TypeInfo.Array a2)
         {
             return IsCompatible(a1.ElementType, a2.ElementType);
+        }
+
+        // Callable / constructable inline object types: `{ (x): T }`, `{ new (x): T }`, and mixed
+        // forms with named fields. Mirrors the callable-interface handling above.
+        if (expected is TypeInfo.Record exSigRec && (exSigRec.IsCallable || exSigRec.IsConstructable))
+        {
+            if (exSigRec.IsCallable)
+            {
+                if (actual is TypeInfo.Function callableFunc)
+                {
+                    if (!FunctionMatchesCallSignatures(callableFunc, exSigRec.CallSignatures!)) return false;
+                }
+                else if (GetCallSignatures(actual) is { } actualSigs)
+                {
+                    // Callable interface/object source: each expected signature must be matched.
+                    foreach (var es in exSigRec.CallSignatures!)
+                        if (!actualSigs.Any(@as => IsCompatible(CallSignatureToFunction(es), CallSignatureToFunction(@as))))
+                            return false;
+                }
+                // Other actuals (e.g. generic functions) may still be callable via downstream paths.
+            }
+
+            if (exSigRec.IsConstructable)
+            {
+                if (actual is TypeInfo.Class constructableCls)
+                {
+                    if (!ClassMatchesConstructorSignatures(constructableCls, exSigRec.ConstructorSignatures!)) return false;
+                }
+                else if (GetConstructorSignatures(actual) is { } actualCtorSigs)
+                {
+                    if (!ConstructorSignaturesSatisfiedBy(exSigRec.ConstructorSignatures!, actualCtorSigs)) return false;
+                }
+                else if (actual is not TypeInfo.Any)
+                {
+                    return false; // a constructable object type is not satisfied by a non-constructable source
+                }
+            }
+
+            // Mixed object types still must match their named fields structurally.
+            if (exSigRec.Fields.Count > 0)
+                return CheckStructuralCompatibility(exSigRec.Fields, actual, exSigRec.OptionalFields);
+            return true;
         }
 
         // Record-to-Record compatibility (inline object types)
@@ -841,6 +906,13 @@ public partial class TypeChecker
         }
 
         // Function type compatibility
+        // A callable interface or object type (`{ (x): T }`) is assignable to a function-typed
+        // target when one of its call signatures satisfies that function type.
+        if (expected is TypeInfo.Function expectedFunc && GetCallSignatures(actual) is { } sourceCallSigs)
+        {
+            return CallableAssignableToFunction(sourceCallSigs, expectedFunc);
+        }
+
         if (expected is TypeInfo.Function f1 && actual is TypeInfo.Function f2)
         {
             // Actual can have fewer params (unused callback params) or more optional params

--- a/TypeSystem/TypeChecker.TypeParsing.cs
+++ b/TypeSystem/TypeChecker.TypeParsing.cs
@@ -797,7 +797,7 @@ public partial class TypeChecker
         TypeInfo? numberIndexType = null;
         TypeInfo? symbolIndexType = null;
         List<string> callSignatures = [];
-        bool hasConstructSignature = false;
+        List<string> constructSignatures = [];
 
         // Split by semicolon (the separator used in ParseInlineObjectType)
         var members = SplitObjectMembers(inner.AsSpan());
@@ -808,10 +808,9 @@ public partial class TypeChecker
             if (string.IsNullOrEmpty(m)) continue;
 
             // Construct signature: "new (params) => ret" (emitted by ParseInlineObjectType).
-            // Not yet modeled on object types; recognized here so it doesn't mis-parse as a field.
             if (m.StartsWith("new ") && m.Contains("=>"))
             {
-                hasConstructSignature = true;
+                constructSignatures.Add(m["new ".Length..].Trim());
                 continue;
             }
 
@@ -872,21 +871,74 @@ public partial class TypeChecker
         }
 
         // A pure single call-signature object type (e.g. `{ (x: number): void }`) is structurally
-        // a function type — resolve it as such so it type-checks against function types correctly.
-        // Mixed/overloaded/construct cases aren't modeled yet; their named fields still form a
-        // Record that reaches the checker (signatures are dropped, not turned into bogus fields).
-        if (callSignatures.Count == 1 && fields.Count == 0 && !hasConstructSignature
+        // a plain function type — resolve it as such so it type-checks against function types
+        // (and other callables) through the well-trodden Function paths.
+        if (callSignatures.Count == 1 && constructSignatures.Count == 0 && fields.Count == 0
             && stringIndexType == null && numberIndexType == null && symbolIndexType == null)
         {
             return ToTypeInfo(callSignatures[0]);
         }
+
+        // Richer object types — mixed call-sig + fields, overloads, or construct signatures —
+        // carry their signatures on the Record so it is callable/constructable and structurally
+        // comparable against callable interfaces and other object types.
+        List<TypeInfo.CallSignature>? recCallSigs = ConvertCallSignatures(callSignatures);
+        List<TypeInfo.ConstructorSignature>? recCtorSigs = ConvertConstructSignatures(constructSignatures);
 
         return new TypeInfo.Record(
             fields.ToFrozenDictionary(),
             stringIndexType,
             numberIndexType,
             symbolIndexType,
-            optionalFields.Count > 0 ? optionalFields.ToFrozenSet() : null);
+            optionalFields.Count > 0 ? optionalFields.ToFrozenSet() : null,
+            CallSignatures: recCallSigs,
+            ConstructorSignatures: recCtorSigs);
+    }
+
+    /// <summary>
+    /// Converts call-signature member strings ("(params) =&gt; ret") into <see cref="TypeInfo.CallSignature"/>s
+    /// by routing through the function-type resolver. Signatures that don't resolve to a function
+    /// (e.g. exotic generics) are skipped rather than aborting the whole object type.
+    /// </summary>
+    private List<TypeInfo.CallSignature>? ConvertCallSignatures(List<string> sigStrings)
+    {
+        if (sigStrings.Count == 0) return null;
+        List<TypeInfo.CallSignature> result = [];
+        foreach (var s in sigStrings)
+        {
+            if (TryResolveFunction(s) is { } f)
+                result.Add(new TypeInfo.CallSignature(null, f.ParamTypes, f.ReturnType, f.RequiredParams, f.HasRestParam, f.ParamNames));
+        }
+        return result.Count > 0 ? result : null;
+    }
+
+    /// <summary>
+    /// Converts construct-signature member strings (the "(params) =&gt; ret" remainder after "new ")
+    /// into <see cref="TypeInfo.ConstructorSignature"/>s.
+    /// </summary>
+    private List<TypeInfo.ConstructorSignature>? ConvertConstructSignatures(List<string> sigStrings)
+    {
+        if (sigStrings.Count == 0) return null;
+        List<TypeInfo.ConstructorSignature> result = [];
+        foreach (var s in sigStrings)
+        {
+            if (TryResolveFunction(s) is { } f)
+                result.Add(new TypeInfo.ConstructorSignature(null, f.ParamTypes, f.ReturnType, f.RequiredParams, f.HasRestParam, f.ParamNames));
+        }
+        return result.Count > 0 ? result : null;
+    }
+
+    /// <summary>Resolves a function-type string to a <see cref="TypeInfo.Function"/>, or null on failure.</summary>
+    private TypeInfo.Function? TryResolveFunction(string sigString)
+    {
+        try
+        {
+            return ToTypeInfo(sigString) as TypeInfo.Function;
+        }
+        catch
+        {
+            return null;
+        }
     }
 
     private List<string> SplitObjectMembers(ReadOnlySpan<char> inner)

--- a/TypeSystem/TypeInfo.cs
+++ b/TypeSystem/TypeInfo.cs
@@ -673,10 +673,24 @@ public abstract record TypeInfo
         TypeInfo? SymbolIndexType = null,
         FrozenSet<string>? OptionalFields = null,
         bool IsReadonly = false,
-        FrozenSet<string>? GetterOnlyFields = null
+        FrozenSet<string>? GetterOnlyFields = null,
+        List<CallSignature>? CallSignatures = null,
+        List<ConstructorSignature>? ConstructorSignatures = null
     ) : TypeInfo
     {
         public bool HasIndexSignature => StringIndexType != null || NumberIndexType != null || SymbolIndexType != null;
+
+        /// <summary>True when this object type has at least one call signature (`{ (x): T }`).</summary>
+        public bool HasCallSignature => CallSignatures is { Count: > 0 };
+
+        /// <summary>True when this object type has at least one construct signature (`{ new (x): T }`).</summary>
+        public bool HasConstructorSignature => ConstructorSignatures is { Count: > 0 };
+
+        /// <summary>An object type with a call signature is callable, like a callable interface.</summary>
+        public bool IsCallable => HasCallSignature;
+
+        /// <summary>An object type with a construct signature is constructable.</summary>
+        public bool IsConstructable => HasConstructorSignature;
 
         /// <summary>
         /// Checks if a field is optional.
@@ -691,7 +705,10 @@ public abstract record TypeInfo
         public override string ToString()
         {
             var prefix = IsReadonly ? "readonly " : "";
-            return $"{prefix}{{ {string.Join(", ", Fields.Select(f => $"{f.Key}{(IsFieldOptional(f.Key) ? "?" : "")}: {f.Value}"))} }}";
+            var parts = Fields.Select(f => $"{f.Key}{(IsFieldOptional(f.Key) ? "?" : "")}: {f.Value}").ToList();
+            if (CallSignatures != null) parts.InsertRange(0, CallSignatures.Select(s => s.ToString()));
+            if (ConstructorSignatures != null) parts.InsertRange(0, ConstructorSignatures.Select(s => s.ToString()));
+            return $"{prefix}{{ {string.Join(", ", parts)} }}";
         }
     }
     


### PR DESCRIPTION
Part of #80. Implements #122.

Inline object types with call/construct signatures now participate in assignability and calls with the same fidelity as callable/constructable **interfaces** — previously (after #121) they parsed but their signatures were dropped.

## Changes
- **`TypeInfo.Record`** gains `CallSignatures` / `ConstructorSignatures` (+ `IsCallable` / `IsConstructable`), mirroring `Interface`. Optional defaulted fields → the ~70 `new TypeInfo.Record(...)` sites are untouched.
- **`ParseInlineObjectTypeInfo`** converts the bare-signature member strings into `TypeInfo.CallSignature` / `ConstructorSignature` and attaches them (pure single-call-sig → `Function` shortcut retained).
- **Compatibility**: callable/constructable `Record`s wired into the same paths interfaces use. Call-signature matching now routes through the shared `Function`↔`Function` logic — fixing **void-return covariance** and **parameter arity** for callables in one place. Added the **reverse direction** (callable interface/object → function-typed target) and interface↔interface / object↔object signature matching; constructable targets correctly reject non-constructable sources.
- **Call sites**: a callable `Record` is invocable; `CheckCallableInterfaceCall` refactored into a shared `CheckCallSignaturesCall`.

## Verification
- New `ObjectLiteralSignatureTests` (9 tests) lock in the behaviour.
- Verified against the conformance corpus: false positives on `assignmentCompatWithCallSignatures` drop **6 → 1** (the one remaining is an out-of-scope generic-function→function gap), and `assignmentCompatWithConstructSignatures` becomes a **perfect diagnostic match**.
- Full xUnit suite green except the 2 known pre-existing packaging failures (fail identically on `main`).
- TS conformance baseline **unchanged — zero regressions**.

## Why the conformance baseline doesn't move yet
The errors-baseline runner matches on `(line, TSnnnn)`, but the recovery path (`CheckWithRecovery`) currently **drops the `TsCode`**, so only zero-error tests can match today. Propagating it is correct but unmasks pre-existing false positives unrelated to this feature (nominal-vs-structural class typing, non-strict `null`/`undefined` assignability). That work is tracked separately in **#125** and must land with those fixes to keep the baseline green. Once #125 lands, this PR's modeling becomes visible (e.g. the construct-signature test flips to Pass).

## Follow-ups
- #125 — propagate `TSnnnn` through the recovery path (+ fix the unmasked false positives). Gates measurable conformance for all negative tests.
- Generic-function → function assignability (the remaining `assignmentCompatWithCallSignatures` false positive) — pre-existing, not filed yet.
