### PR TITLE
feat: model class-body index signatures (#123)

### DIFF
--- a/Parsing/AST.cs
+++ b/Parsing/AST.cs
@@ -378,7 +378,7 @@ public abstract record Stmt
     /// Class declaration. IsDeclare indicates an ambient declaration (declare class) which has no implementation.
     /// StaticInitializers contains static fields and static blocks in declaration order for proper initialization sequencing.
     /// </summary>
-    public record Class(Token Name, List<TypeParam>? TypeParams, Expr? SuperclassExpr, List<string>? SuperclassTypeArgs, List<Stmt.Function> Methods, List<Stmt.Field> Fields, List<Stmt.Accessor>? Accessors = null, List<Stmt.AutoAccessor>? AutoAccessors = null, List<Token>? Interfaces = null, List<List<string>>? InterfaceTypeArgs = null, bool IsAbstract = false, List<Decorator>? Decorators = null, bool IsDeclare = false, List<Stmt>? StaticInitializers = null) : Stmt;
+    public record Class(Token Name, List<TypeParam>? TypeParams, Expr? SuperclassExpr, List<string>? SuperclassTypeArgs, List<Stmt.Function> Methods, List<Stmt.Field> Fields, List<Stmt.Accessor>? Accessors = null, List<Stmt.AutoAccessor>? AutoAccessors = null, List<Token>? Interfaces = null, List<List<string>>? InterfaceTypeArgs = null, bool IsAbstract = false, List<Decorator>? Decorators = null, bool IsDeclare = false, List<Stmt>? StaticInitializers = null, List<Stmt.IndexSignature>? IndexSignatures = null) : Stmt;
     /// <summary>
     /// Static block: static { statements }
     /// Executes once when the class is initialized, in declaration order with static fields.

--- a/Parsing/Parser.Classes.cs
+++ b/Parsing/Parser.Classes.cs
@@ -38,6 +38,7 @@ public partial class Parser
         List<Stmt.Accessor> accessors = [];
         List<Stmt.AutoAccessor> autoAccessors = [];
         List<Stmt> staticInitializers = [];
+        List<Stmt.IndexSignature> indexSignatures = [];
         while (!Check(TokenType.RIGHT_BRACKET) && !Check(TokenType.RIGHT_BRACE) && !IsAtEnd())
         {
             try
@@ -308,10 +309,9 @@ public partial class Parser
             {
                 // Index signature: [key: string|number|symbol]: ValueType. Distinguished from a
                 // computed property name ([expr]: T) by an identifier immediately followed by ':'.
-                // Parsed here so the class body no longer hits a ParseError; full modeling of the
-                // index type on the class is deferred (see issue #121).
-                if (TryConsumeClassIndexSignature())
+                if (TryParseClassIndexSignature() is { } indexSig)
                 {
+                    indexSignatures.Add(indexSig);
                     continue;
                 }
 
@@ -503,35 +503,36 @@ public partial class Parser
         }
 
         Consume(TokenType.RIGHT_BRACE, "Expect '}' after class body.");
-        return new Stmt.Class(name, typeParams, superclassExpr, superclassTypeArgs, methods, fields, accessors.Count > 0 ? accessors : null, autoAccessors.Count > 0 ? autoAccessors : null, interfaces, interfaceTypeArgs, isAbstract, classDecorators, isDeclare, staticInitializers.Count > 0 ? staticInitializers : null);
+        return new Stmt.Class(name, typeParams, superclassExpr, superclassTypeArgs, methods, fields, accessors.Count > 0 ? accessors : null, autoAccessors.Count > 0 ? autoAccessors : null, interfaces, interfaceTypeArgs, isAbstract, classDecorators, isDeclare, staticInitializers.Count > 0 ? staticInitializers : null, indexSignatures.Count > 0 ? indexSignatures : null);
     }
 
     /// <summary>
     /// Probes for a class index signature: <c>[key: string|number|symbol]: ValueType</c>.
     /// Must be called positioned at the opening <c>[</c>. On a match, consumes the whole signature
-    /// (and its terminator) and returns true; on no match, restores position and returns false so
-    /// the caller can fall through to computed-property-name parsing. The parsed value type is
-    /// currently discarded — modeling the index type on the class type is deferred (issue #121).
+    /// (and its terminator) and returns the parsed <see cref="Stmt.IndexSignature"/>; on no match,
+    /// restores position and returns null so the caller can fall through to computed-property-name
+    /// parsing.
     /// </summary>
-    private bool TryConsumeClassIndexSignature()
+    private Stmt.IndexSignature? TryParseClassIndexSignature()
     {
         int saved = _current;
 
-        if (!Match(TokenType.LEFT_BRACKET)) { _current = saved; return false; }
-        if (!Check(TokenType.IDENTIFIER)) { _current = saved; return false; }
-        Advance(); // key name
-        if (!Match(TokenType.COLON)) { _current = saved; return false; }
+        if (!Match(TokenType.LEFT_BRACKET)) { _current = saved; return null; }
+        if (!Check(TokenType.IDENTIFIER)) { _current = saved; return null; }
+        Token keyName = Advance(); // key name
+        if (!Match(TokenType.COLON)) { _current = saved; return null; }
         if (!Match(TokenType.TYPE_STRING, TokenType.TYPE_NUMBER, TokenType.TYPE_SYMBOL))
         {
             _current = saved;
-            return false;
+            return null;
         }
-        if (!Match(TokenType.RIGHT_BRACKET)) { _current = saved; return false; }
-        if (!Match(TokenType.COLON)) { _current = saved; return false; }
+        TokenType keyType = Previous().Type;
+        if (!Match(TokenType.RIGHT_BRACKET)) { _current = saved; return null; }
+        if (!Match(TokenType.COLON)) { _current = saved; return null; }
 
-        ParseTypeAnnotation(); // value type (validated, then discarded)
+        string valueType = ParseTypeAnnotation();
         ConsumeSemicolon("Expect ';' after index signature.");
-        return true;
+        return new Stmt.IndexSignature(keyName, keyType, valueType);
     }
 
     /// <summary>

--- a/SharpTS.Tests/TypeCheckerTests/ClassIndexSignatureTests.cs
+++ b/SharpTS.Tests/TypeCheckerTests/ClassIndexSignatureTests.cs
@@ -1,0 +1,62 @@
+using SharpTS.TypeSystem.Exceptions;
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.TypeCheckerTests;
+
+/// <summary>
+/// Type-checking coverage for class-body index signatures (issue #123):
+/// <c>class A { [k: string]: T }</c>. The index type is modelled on the class and consulted
+/// when indexing a class instance, mirroring index signatures on interfaces/object types.
+/// </summary>
+public class ClassIndexSignatureTests
+{
+    [Fact]
+    public void ClassWithStringIndex_Parses()
+    {
+        // Distinguished from a computed property name; no parse error.
+        TestHarness.RunInterpreted("class A { [k: string]: number } let a: A = new A();");
+    }
+
+    [Fact]
+    public void StringIndexAccess_ReturnsValueType()
+    {
+        TestHarness.RunInterpreted("class A { [k: string]: number } let a: A = new A(); let n: number = a[\"x\"];");
+    }
+
+    [Fact]
+    public void StringIndexAccess_TypeMismatchErrors()
+    {
+        Assert.ThrowsAny<TypeCheckException>(() =>
+            TestHarness.RunInterpreted("class A { [k: string]: number } let a: A = new A(); let s: string = a[\"x\"];"));
+    }
+
+    [Fact]
+    public void NumberIndexAccess_ReturnsValueType()
+    {
+        TestHarness.RunInterpreted("class A { [k: number]: string } let a: A = new A(); let s: string = a[0];");
+    }
+
+    [Fact]
+    public void NumericKey_FallsBackToStringIndex()
+    {
+        // A class with only a string index signature still accepts numeric keys.
+        TestHarness.RunInterpreted("class A { [k: string]: number } let a: A = new A(); let n: number = a[0];");
+    }
+
+    [Fact]
+    public void DeclareClassWithIndexSignature_IsModeled()
+    {
+        // `declare class` has no runtime body, so assert via a type mismatch that short-circuits
+        // before interpretation — confirming the ambient class's index type is modeled too.
+        Assert.ThrowsAny<TypeCheckException>(() =>
+            TestHarness.RunInterpreted("declare class A { [k: string]: number } let a: A; let s: string = a[\"x\"];"));
+    }
+
+    [Fact]
+    public void ComputedPropertyName_StillParses_NotMistakenForIndexSignature()
+    {
+        // [expr] (no `ident:` shape) must remain a computed property name, not an index signature.
+        TestHarness.RunInterpreted("const k = \"key\"; class A { [k]: number = 1; } let a: A = new A();");
+    }
+}

--- a/TypeSystem/ClassMetadataCore.cs
+++ b/TypeSystem/ClassMetadataCore.cs
@@ -26,9 +26,15 @@ public sealed record ClassMetadataCore(
     FrozenDictionary<string, TypeInfo>? PrivateFields = null,
     FrozenDictionary<string, TypeInfo>? PrivateMethods = null,
     FrozenDictionary<string, TypeInfo>? StaticPrivateFields = null,
-    FrozenDictionary<string, TypeInfo>? StaticPrivateMethods = null
+    FrozenDictionary<string, TypeInfo>? StaticPrivateMethods = null,
+    TypeInfo? StringIndexType = null,
+    TypeInfo? NumberIndexType = null,
+    TypeInfo? SymbolIndexType = null
 )
 {
+    /// <summary>True when the class declares any index signature.</summary>
+    public bool HasIndexSignature => StringIndexType != null || NumberIndexType != null || SymbolIndexType != null;
+
     /// <summary>Abstract method names with empty fallback.</summary>
     public FrozenSet<string> AbstractMethodSet => AbstractMethods ?? FrozenSet<string>.Empty;
 

--- a/TypeSystem/TypeChecker.Compatibility.Structural.cs
+++ b/TypeSystem/TypeChecker.Compatibility.Structural.cs
@@ -82,6 +82,9 @@ public partial class TypeChecker
             {
                 expectedKeys.Add(setter.Key);
             }
+            // A class index signature accepts arbitrary keys, like Record/Interface index signatures.
+            hasStringIndex = cls.StringIndexType != null;
+            hasNumberIndex = cls.NumberIndexType != null;
         }
         else
         {

--- a/TypeSystem/TypeChecker.Properties.Index.cs
+++ b/TypeSystem/TypeChecker.Properties.Index.cs
@@ -154,6 +154,8 @@ public partial class TypeChecker
                 return rec2.StringIndexType;
             if (objType is TypeInfo.Interface itf2 && itf2.StringIndexType != null)
                 return itf2.StringIndexType;
+            if (GetClassIndexType(objType, TokenType.TYPE_STRING) is { } clsStr)
+                return clsStr;
 
             // Allow bracket access on any object/interface (returns any for unknown keys)
             if (objType is TypeInfo.Record or TypeInfo.Interface or TypeInfo.Instance)
@@ -230,6 +232,12 @@ public partial class TypeChecker
                 return itf3.NumberIndexType;
             if (objType is TypeInfo.Record rec3 && rec3.NumberIndexType != null)
                 return rec3.NumberIndexType;
+            // A class with only a string index signature still accepts numeric keys (number keys
+            // are a subset of string keys), matching TypeScript.
+            if (GetClassIndexType(objType, TokenType.TYPE_NUMBER) is { } clsNum)
+                return clsNum;
+            if (GetClassIndexType(objType, TokenType.TYPE_STRING) is { } clsNumStr)
+                return clsNumStr;
         }
 
         // Handle symbol index (Symbol and UniqueSymbol both qualify)
@@ -239,6 +247,8 @@ public partial class TypeChecker
                 return itf4.SymbolIndexType;
             if (objType is TypeInfo.Record rec4 && rec4.SymbolIndexType != null)
                 return rec4.SymbolIndexType;
+            if (GetClassIndexType(objType, TokenType.TYPE_SYMBOL) is { } clsSym)
+                return clsSym;
 
             // Allow symbol bracket access on any object (returns any)
             if (objType is TypeInfo.Record or TypeInfo.Interface or TypeInfo.Instance)
@@ -251,6 +261,29 @@ public partial class TypeChecker
         }
 
         throw new TypeCheckException($" Index type '{indexType}' is not valid for indexing '{objType}'.", tsCode: "TS7053");
+    }
+
+    /// <summary>
+    /// Returns the value type of a class's index signature for the given key type, or null if the
+    /// type is not a class instance (or has no such index signature). Accepts both a bare
+    /// <see cref="TypeInfo.Class"/> and a <see cref="TypeInfo.Instance"/> wrapping one.
+    /// </summary>
+    private static TypeInfo? GetClassIndexType(TypeInfo objType, TokenType keyType)
+    {
+        TypeInfo.Class? cls = objType switch
+        {
+            TypeInfo.Class c => c,
+            TypeInfo.Instance { ClassType: TypeInfo.Class ic } => ic,
+            _ => null
+        };
+        if (cls == null) return null;
+        return keyType switch
+        {
+            TokenType.TYPE_STRING => cls.StringIndexType,
+            TokenType.TYPE_NUMBER => cls.NumberIndexType,
+            TokenType.TYPE_SYMBOL => cls.SymbolIndexType,
+            _ => null
+        };
     }
 
     private TypeInfo CheckSetIndex(Expr.SetIndex setIndex)

--- a/TypeSystem/TypeChecker.Statements.Classes.cs
+++ b/TypeSystem/TypeChecker.Statements.Classes.cs
@@ -94,6 +94,22 @@ public partial class TypeChecker
         using (new EnvironmentScope(this, classTypeEnv))
         {
 
+        // Index signatures: [key: string|number|symbol]: ValueType. Resolved inside the class
+        // type-environment scope so value types can reference the class's own type parameters.
+        if (classStmt.IndexSignatures != null)
+        {
+            foreach (var indexSig in classStmt.IndexSignatures)
+            {
+                TypeInfo valueType = ToTypeInfo(indexSig.ValueType);
+                switch (indexSig.KeyType)
+                {
+                    case TokenType.TYPE_STRING: mutableClass.StringIndexType = valueType; break;
+                    case TokenType.TYPE_NUMBER: mutableClass.NumberIndexType = valueType; break;
+                    case TokenType.TYPE_SYMBOL: mutableClass.SymbolIndexType = valueType; break;
+                }
+            }
+        }
+
         // Helper to build a TypeInfo.Function from a method declaration
         TypeInfo.Function BuildMethodFuncType(Stmt.Function method)
         {
@@ -837,6 +853,22 @@ public partial class TypeChecker
 
         using (new EnvironmentScope(this, classTypeEnv))
         {
+
+        // Index signatures: [key: string|number|symbol]: ValueType. Resolved inside the class
+        // type-environment scope so value types can reference the class's own type parameters.
+        if (classStmt.IndexSignatures != null)
+        {
+            foreach (var indexSig in classStmt.IndexSignatures)
+            {
+                TypeInfo valueType = ToTypeInfo(indexSig.ValueType);
+                switch (indexSig.KeyType)
+                {
+                    case TokenType.TYPE_STRING: mutableClass.StringIndexType = valueType; break;
+                    case TokenType.TYPE_NUMBER: mutableClass.NumberIndexType = valueType; break;
+                    case TokenType.TYPE_SYMBOL: mutableClass.SymbolIndexType = valueType; break;
+                }
+            }
+        }
 
         // Helper to build a TypeInfo.Function from a method declaration
         TypeInfo.Function BuildMethodFuncType(Stmt.Function method)

--- a/TypeSystem/TypeInfo.cs
+++ b/TypeSystem/TypeInfo.cs
@@ -212,6 +212,10 @@ public abstract record TypeInfo
         public FrozenDictionary<string, TypeInfo>? PrivateMethods => Core.PrivateMethods;
         public FrozenDictionary<string, TypeInfo>? StaticPrivateFields => Core.StaticPrivateFields;
         public FrozenDictionary<string, TypeInfo>? StaticPrivateMethods => Core.StaticPrivateMethods;
+        public TypeInfo? StringIndexType => Core.StringIndexType;
+        public TypeInfo? NumberIndexType => Core.NumberIndexType;
+        public TypeInfo? SymbolIndexType => Core.SymbolIndexType;
+        public bool HasIndexSignature => Core.HasIndexSignature;
 
         // Computed properties delegate to Core
         public FrozenSet<string> AbstractMethodSet => Core.AbstractMethodSet;
@@ -258,6 +262,10 @@ public abstract record TypeInfo
         public Dictionary<string, TypeInfo> PrivateMethods { get; } = [];
         public Dictionary<string, TypeInfo> StaticPrivateFields { get; } = [];
         public Dictionary<string, TypeInfo> StaticPrivateMethods { get; } = [];
+        // Index signatures: [key: string|number|symbol]: ValueType
+        public TypeInfo? StringIndexType { get; set; }
+        public TypeInfo? NumberIndexType { get; set; }
+        public TypeInfo? SymbolIndexType { get; set; }
 
         private ClassMetadataCore? _frozenCore;
         private TypeInfo.Class? _frozen;
@@ -286,7 +294,10 @@ public abstract record TypeInfo
                 PrivateFields.Count > 0 ? PrivateFields.ToFrozenDictionary() : null,
                 PrivateMethods.Count > 0 ? PrivateMethods.ToFrozenDictionary() : null,
                 StaticPrivateFields.Count > 0 ? StaticPrivateFields.ToFrozenDictionary() : null,
-                StaticPrivateMethods.Count > 0 ? StaticPrivateMethods.ToFrozenDictionary() : null);
+                StaticPrivateMethods.Count > 0 ? StaticPrivateMethods.ToFrozenDictionary() : null,
+                StringIndexType,
+                NumberIndexType,
+                SymbolIndexType);
             return _frozenCore;
         }
 
@@ -1180,6 +1191,10 @@ public abstract record TypeInfo
         public FrozenDictionary<string, TypeInfo>? PrivateMethods => Core.PrivateMethods;
         public FrozenDictionary<string, TypeInfo>? StaticPrivateFields => Core.StaticPrivateFields;
         public FrozenDictionary<string, TypeInfo>? StaticPrivateMethods => Core.StaticPrivateMethods;
+        public TypeInfo? StringIndexType => Core.StringIndexType;
+        public TypeInfo? NumberIndexType => Core.NumberIndexType;
+        public TypeInfo? SymbolIndexType => Core.SymbolIndexType;
+        public bool HasIndexSignature => Core.HasIndexSignature;
 
         // Computed properties delegate to Core
         public FrozenSet<string> AbstractMethodSet => Core.AbstractMethodSet;


### PR DESCRIPTION
Part of #80. Implements #123.

`class A { [k: string]: T }` parsed since #121, but its value type was **discarded**. This models the index type on the class and consults it when indexing a class instance — mirroring index signatures on interfaces/object types.

## Changes
- **Parser**: `TryParseClassIndexSignature` returns the parsed `Stmt.IndexSignature` (key name, key-type token, value type) instead of discarding; `ClassDeclaration` collects them into a new `Stmt.Class.IndexSignatures` slot.
- **Types**: `ClassMetadataCore`, `MutableClass`, and `TypeInfo.Class` gain `String`/`Number`/`SymbolIndexType` (optional defaulted — existing construction sites unaffected). `CheckClassDeclaration` / `CheckDeclareClass` resolve the signatures inside the class type-environment scope (so value types can reference the class's own type parameters).
- **Index access**: indexing a class instance (`TypeInfo.Class` or `Instance<Class>`) by string/number/symbol returns the matching index value type, including the TS number-key-uses-string-index fallback. Excess-property checking treats a class index signature like an interface/record one.

## Verification
- New `ClassIndexSignatureTests` (7): parsing, string/number index access, type-mismatch errors, numeric-key fallback, ambient `declare class`, and computed-property-name disambiguation.
- Full xUnit suite green except the 2 known pre-existing packaging failures.
- TS conformance baseline **unchanged — zero regressions**.

## Scope notes
- Index-signature **value-type assignability** (e.g. a number-index not assignable to a string-index target) is intentionally **not** implemented here — it's a pre-existing general gap (not enforced for `Record`↔`Record` either) and orthogonal to this feature.
- As with #122, the conformance baseline can't reflect these negative `assignmentCompatWith{String,Numeric}Indexer` tests until **#125** (recovery-path `TsCode`) lands.
- Class **expression** index signatures (`const C = class { [k]: T }`) are deferred (rare); only class declarations are covered.
