### PR TITLE
Remove explicit 'any' type usage in ObjectLiterals.ts

### DIFF
--- a/SharpTS.Benchmarks/TypeScriptSources/ObjectLiterals.ts
+++ b/SharpTS.Benchmarks/TypeScriptSources/ObjectLiterals.ts
@@ -28,8 +28,8 @@ function nestedLiteralLoop(n: number): number {
             point: { x: i, y: i + 1 },
             label: "pt"
         };
-        const inner = o.point as any;
-        total = total + (inner.x as number);
+        const inner = o.point;
+        total = total + inner.x;
     }
     return total;
 }


### PR DESCRIPTION
## Problem Background
In the `ObjectLiterals.ts` benchmark file, explicit `any` type assertions were used unnecessarily, which can reduce TypeScript's type safety and code readability. TypeScript's type inference is capable of automatically determining types, making such assertions redundant.

## Changes Made
- Removed the `as any` type assertion for the `inner` variable in the `nestedLiteralLoop` function.
- Removed the `as number` type assertion for accessing `inner.x`, relying on TypeScript's type inference instead.
- Simplified the code by eliminating unnecessary type casts without altering functionality.

## Verification
The changes ensure the code remains functionally identical while improving type annotations. To verify:
1. Confirm the TypeScript code compiles without errors (type inference should handle the types correctly).
2. Run the benchmarks to ensure performance and behavior are unchanged.