### PR TITLE
feat: parenthesized conditional types, constrained infer, abstract new (#141)

### DIFF
--- a/Parsing/Parser.Types.cs
+++ b/Parsing/Parser.Types.cs
@@ -199,11 +199,24 @@ public partial class Parser
     {
         string typeName;
 
-        // Handle infer keyword for conditional types: infer U
+        // Handle infer keyword for conditional types: infer U, or constrained infer: infer U extends C
         if (Match(TokenType.INFER))
         {
             Token paramName = Consume(TokenType.IDENTIFIER, "Expect type parameter name after 'infer'.");
+            if (Match(TokenType.EXTENDS))
+            {
+                // Constraint binds tighter than the enclosing conditional's `?`, so stop at union level.
+                string constraint = ParseUnionType();
+                return $"infer {paramName.Lexeme} extends {constraint}";
+            }
             return $"infer {paramName.Lexeme}";
+        }
+
+        // `abstract` constructor type: abstract new (params) => ReturnType. The abstract modifier
+        // doesn't change the structural shape, so parse it like a regular constructor type.
+        if (Check(TokenType.ABSTRACT) && PeekNext().Type == TokenType.NEW)
+        {
+            Advance(); // consume 'abstract'
         }
 
         // Handle constructor type: new (params) => ReturnType  or  new <T>(params) => ReturnType.
@@ -359,8 +372,10 @@ public partial class Parser
             }
             else
             {
-                // Parse as grouped type: (type1 | type2)
-                typeName = "(" + ParseUnionType() + ")";
+                // Parse as grouped type: (type1 | type2), or a parenthesized conditional type
+                // (T extends U ? X : Y). Use ParseConditionalType so the grouped body can contain
+                // `extends ? :` rather than stopping at `extends`.
+                typeName = "(" + ParseConditionalType() + ")";
                 Consume(TokenType.RIGHT_PAREN, "Expect ')' after grouped type.");
             }
         }

--- a/SharpTS.Tests/TypeCheckerTests/TypeParserEdgeCaseTests.cs
+++ b/SharpTS.Tests/TypeCheckerTests/TypeParserEdgeCaseTests.cs
@@ -1,0 +1,39 @@
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.TypeCheckerTests;
+
+/// <summary>
+/// Type-parser edge cases: parenthesized conditional types, constrained <c>infer</c>, and
+/// <c>abstract new</c> constructor types.
+/// </summary>
+public class TypeParserEdgeCaseTests
+{
+    [Fact]
+    public void ParenthesizedConditionalType_Parses()
+    {
+        TestHarness.RunInterpreted("type S<T> = { a: string } & (T extends object ? { b: T } : { c: number }); let s: S<object>;");
+    }
+
+    [Fact]
+    public void ConstrainedInfer_Parses()
+    {
+        TestHarness.RunInterpreted("type First<T> = T extends [infer A extends number, ...unknown[]] ? A : never; let x: First<[1, 2]>;");
+    }
+
+    [Fact]
+    public void AbstractNewConstructorType_Parses()
+    {
+        TestHarness.RunInterpreted("type C<T> = abstract new (x: string) => T; let c: C<object>;");
+    }
+
+    [Fact]
+    public void RegularGroupedAndInferAndNew_StillParse()
+    {
+        // Regression guards for the unmodified common forms.
+        TestHarness.RunInterpreted(
+            "let g: (string | number)[] = []; " +
+            "type U<T> = T extends (infer E)[] ? E : never; " +
+            "let f: new (x: number) => object;");
+    }
+}

--- a/SharpTS.TypeScriptConformance/baselines/interpreted.txt
+++ b/SharpTS.TypeScriptConformance/baselines/interpreted.txt
@@ -1,13 +1,13 @@
 # TS conformance baseline — do not hand-edit. Regenerate with SHARPTS_TSCONFORMANCE_UPDATE_BASELINE=1.
 tests/cases/conformance/types/conditional/conditionalTypes1.ts Fail
 tests/cases/conformance/types/conditional/conditionalTypes2.ts Fail
-tests/cases/conformance/types/conditional/conditionalTypesExcessProperties.ts ParseError
+tests/cases/conformance/types/conditional/conditionalTypesExcessProperties.ts Fail
 tests/cases/conformance/types/conditional/inferTypes1.ts ParseError
 tests/cases/conformance/types/conditional/inferTypes2.ts ParseError
-tests/cases/conformance/types/conditional/inferTypesInvalidExtendsDeclaration.ts ParseError
+tests/cases/conformance/types/conditional/inferTypesInvalidExtendsDeclaration.ts Skipped:lib-drift
 tests/cases/conformance/types/conditional/inferTypesWithExtends1.ts ParseError
-tests/cases/conformance/types/conditional/inferTypesWithExtends2.ts ParseError
-tests/cases/conformance/types/conditional/variance.ts ParseError
+tests/cases/conformance/types/conditional/inferTypesWithExtends2.ts Fail
+tests/cases/conformance/types/conditional/variance.ts Fail
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/anyAssignabilityInInheritance.ts ParseError
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/anyAssignableToEveryType.ts Pass
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/anyAssignableToEveryType2.ts ParseError


### PR DESCRIPTION
Part of #80. Closes #141. Branched off `main` (post-#139), single PR, no stacking.

Three small type-parser gaps (`Parser.Types.cs` `ParsePrimaryType`):

1. **Parenthesized conditional types** `(T extends U ? X : Y)` — the grouped-type body used `ParseUnionType` (which stops at `extends`) → "Expect ')' after grouped type". Now uses `ParseConditionalType` (a safe superset).
2. **Constrained infer** `infer A extends C` (e.g. `T extends infer A extends object ? ... : ...`) — `infer` now optionally consumes an `extends <union>` constraint (binds tighter than the enclosing conditional `?`).
3. **`abstract new` constructor types** `abstract new (params) => T` — the `abstract` modifier before `new` is consumed and the constructor type parsed as usual.

## Impact
- Conformance subset: **11 → 7 ParseError** (3 → Fail, 1 → Skipped[lib-drift]), **0 regressions**.

## Verification
- New `TypeParserEdgeCaseTests` (4) incl. regression guards for plain grouped types, `infer E`, and `new (...) => T`.
- Full xUnit suite green except the 2 known pre-existing packaging failures.
- Conformance suite green (31/31) against the regenerated baseline.
