### PR TITLE
fix(typecheck): type-check statements inside namespace/module bodies (#143)

### DIFF
--- a/SharpTS.Tests/TypeCheckerTests/NamespaceBodyTypeCheckTests.cs
+++ b/SharpTS.Tests/TypeCheckerTests/NamespaceBodyTypeCheckTests.cs
@@ -1,0 +1,44 @@
+using SharpTS.TypeSystem.Exceptions;
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.TypeCheckerTests;
+
+/// <summary>
+/// Statements inside a namespace/module body are type-checked like top-level statements.
+/// Previously only declarations were checked, so type errors in expression statements (e.g. a
+/// bad assignment) inside a namespace were silently ignored — a soundness hole.
+/// </summary>
+public class NamespaceBodyTypeCheckTests
+{
+    [Fact]
+    public void BadAssignment_InNamespace_IsReported()
+    {
+        Assert.ThrowsAny<TypeCheckException>(() =>
+            TestHarness.RunInterpreted(
+                "class S { a: string = \"\"; } class T { b: number = 0; } " +
+                "namespace N { let s: S; let t: T; s = t; }"));
+    }
+
+    [Fact]
+    public void BadAssignment_InModule_IsReported()
+    {
+        Assert.ThrowsAny<TypeCheckException>(() =>
+            TestHarness.RunInterpreted(
+                "module M { let n: number = 1; let s: string = \"\"; n = s; }"));
+    }
+
+    [Fact]
+    public void ValidStatements_InNamespace_AreClean()
+    {
+        TestHarness.RunInterpreted("module M { let a: number = 1; a = 2; let b = a + 1; }");
+    }
+
+    [Fact]
+    public void BadCallResultAssignment_InNamespace_IsReported()
+    {
+        Assert.ThrowsAny<TypeCheckException>(() =>
+            TestHarness.RunInterpreted(
+                "namespace N { function f(): string { return \"\"; } let n: number = f(); }"));
+    }
+}

--- a/TypeSystem/TypeChecker.Namespaces.cs
+++ b/TypeSystem/TypeChecker.Namespaces.cs
@@ -165,6 +165,10 @@ public partial class TypeChecker
             member = export.Declaration;
         }
 
+        // Track the member's line so diagnostics raised while checking it (which often don't carry
+        // their own line) are reported against the member, not the enclosing namespace.
+        _currentStatementLine = TryGetStmtLine(member);
+
         switch (member)
         {
             case Stmt.Function funcStmt:
@@ -201,6 +205,13 @@ public partial class TypeChecker
             case Stmt.TypeAlias:
             case Stmt.ImportAlias:
                 // Already handled in first pass
+                break;
+
+            default:
+                // Any other statement — `const`, expression statements (e.g. `s = t;`),
+                // control flow — is type-checked normally so errors inside a namespace body
+                // are reported just like at the top level.
+                CheckStmt(member);
                 break;
         }
     }


### PR DESCRIPTION
Closes #143. A soundness fix surfaced while working the TS-conformance Fail bucket (#80).

`CheckNamespaceMember` only checked a fixed set of declarations; its `switch` had no `default`, so expression statements (a bad assignment `s = t;`), `const`, and control flow inside a namespace/module body were silently skipped and **never type-checked** — yet the same code errors correctly at top level.

```ts
class S { a: string = ""; } class T { b: number = 0; }
namespace N { let s: S; let t: T; s = t; }   // was: no error (should be TS2322)
```

## Fix (`TypeChecker.Namespaces.cs`)
- `default` case → `CheckStmt(member)`.
- Set `_currentStatementLine` to the member's line so diagnostics land on the member, not the enclosing namespace (previously line 1).

## Verification
- New `NamespaceBodyTypeCheckTests` (4): bad assignment in namespace/module reported; valid statements clean; bad call-result assignment reported.
- Full xUnit suite green except the 2 known pre-existing packaging failures.
- **Conformance baseline unchanged** — this is foundational for the `module`-wrapped `assignmentCompatibility` tests, but doesn't flip them on its own (they also need deeper callable/constructable/structural assignability work to match their full expected diagnostic sets).