### PR TITLE
docs: refresh TS-conformance status to reflect the parser sweep (#89)

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -497,9 +497,13 @@ Two external corpora pin SharpTS against canonical references. Both run as stand
 
 | Subset | Tests | Pass | Fail | ParseError | Skipped |
 |---|---:|---:|---:|---:|---:|
-| `types/typeRelationships/assignmentCompatibility/` | 70 | 4 (5.7%) | 9 (12.9%) | 57 (81.4%) | 0 |
+| `types/typeRelationships/assignmentCompatibility/` | 70 | 16 (22.9%) | 50 | 4 | 0 |
+| `types/conditional/` | 9 | 0 | 5 | 3 | 1 |
+| **Total** | **79** | **16 (20.3%)** | **55** | **7** | **1** |
 
-The high `ParseError` rate is dominated by `declare function` (and related ambient declarations) — the parser doesn't fully support that surface yet. Supporting it is the largest single lever to lift conformance pass rate; tracked as follow-up work, not yet scheduled.
+The parser is no longer the bottleneck. An extended parser sweep took the subset's `ParseError` count from 57 → 7 (≈86%): ambient `declare` of non-class declarations, `declare function`, generic/this/conditional/mapped/indexed-access/constructor/leading-operator types, `module Foo {}` namespaces, call/construct/index signatures, keyword & string/numeric property names, function-type and arrow optional/rest parameters, and more. Negative-test matching itself was unlocked by propagating canonical `TSnnnn` codes through the type-checker's error-recovery path ([#125](https://github.com/nickna/SharpTS/issues/125)), which also added a `strictNullChecks` option (default on; the runner follows each test's `@strict`/`@strictNullChecks` directive).
+
+The dominant bucket is now `Fail` — tests that parse and reach the type checker but whose diagnostic set doesn't yet match `tsc`'s. These are mostly the `assignmentCompatibility` cases, which require deeper callable / constructable / structural assignability. The largest remaining levers are structural class-to-class assignability ([#129](https://github.com/nickna/SharpTS/issues/129) — SharpTS is nominal by design) and loading `tsc`'s `lib.*.d.ts` ([#99](https://github.com/nickna/SharpTS/issues/99)).
 
 `Skipped` includes:
 - **Multi-file tests** (`Skipped:multi-file-deferred`) — cross-file resolution into the runner is follow-up work.

--- a/SharpTS.TypeScriptConformance/README.md
+++ b/SharpTS.TypeScriptConformance/README.md
@@ -28,7 +28,7 @@ This project is **not** included in `SharpTS.sln`. Solution-level `dotnet build`
 dotnet test SharpTS.TypeScriptConformance/SharpTS.TypeScriptConformance.csproj
 ```
 
-The suite runs in well under a second on the current subset (~70 tests). It type-checks each test, diffs the resulting diagnostics against `tsc`'s `*.errors.txt` baseline, classifies into a bucket, and compares the bucket distribution against the committed baseline at `baselines/interpreted.txt`.
+The suite runs in well under a second on the current subset (~79 tests, across `assignmentCompatibility/` and `conditional/`). It type-checks each test, diffs the resulting diagnostics against `tsc`'s `*.errors.txt` baseline, classifies into a bucket, and compares the bucket distribution against the committed baseline at `baselines/interpreted.txt`.
 
 ## Updating the baseline
 


### PR DESCRIPTION
Part of #89. The conformance work merged over the last stretch (#121–#144) left `STATUS.md`'s status section stale.

## Before (stale)
- One 70-test folder: **4 Pass (5.7%) / 9 Fail / 57 ParseError (81%)**
- Claimed `declare function` was "the largest single lever" to lift the pass rate.

## After (current, committed baseline)
- Two folders (`assignmentCompatibility` + `conditional`), **79 tests: 16 Pass (20.3%) / 55 Fail / 7 ParseError / 1 Skipped**.
- Documents that the parser sweep took ParseError **57 → 7 (~86%)**, that negative-test matching was unlocked by propagating `TSnnnn` codes through the recovery path (#125) plus a `strictNullChecks` option, and that the dominant bucket is now **Fail** (type-checker assignability) — with structural classes (#129) and `lib.d.ts` loading (#99) the largest remaining levers.

Also updates the conformance project README's "~70 tests" → "~79 (two folders)".

Docs-only; no code changes.