### PR TITLE
feat: co-locate/pack SharpTS.dll for -t exe and --pack outputs (#117)

### DIFF
--- a/Packaging/NuGetPackager.cs
+++ b/Packaging/NuGetPackager.cs
@@ -119,6 +119,22 @@ public class NuGetPackager(PackageJson packageJson, string? packageIdOverride = 
             });
         }
 
+        // Add the SharpTS runtime when it was co-located next to the output assembly. The compile
+        // step places SharpTS.dll there (consuming ILCompiler.RequiredSharpTSRuntimeReasons) only
+        // when the program uses a feature that late-binds into the runtime — eval, Proxy, Intl, vm,
+        // dns, @DotNetType dynamic events — and not under --standalone. Pure libraries stay
+        // dependency-free, so a package consumer can run those features without the gap.
+        var sharpTsRuntimePath = Path.Combine(
+            Path.GetDirectoryName(Path.GetFullPath(assemblyPath)) ?? ".", "SharpTS.dll");
+        if (File.Exists(sharpTsRuntimePath))
+        {
+            builder.Files.Add(new PhysicalPackageFile
+            {
+                SourcePath = sharpTsRuntimePath,
+                TargetPath = $"lib/{targetFramework.GetShortFolderName()}/SharpTS.dll"
+            });
+        }
+
         // Build and save the package
         var packagePath = Path.Combine(outputDirectory, $"{packageId}.{version}.nupkg");
         using var stream = File.Create(packagePath);

--- a/Program.cs
+++ b/Program.cs
@@ -480,6 +480,11 @@ static void CompileModuleFile(string absolutePath, string outputPath, bool prese
                 {
                     Console.WriteLine($"Compiled to {outputPath} (using {bundleResult.TechniqueDescription})");
                 }
+
+                // Co-locate SharpTS.dll next to the EXE when the program uses a feature that
+                // late-binds into the SharpTS runtime (eval, Proxy, Intl, vm, dns, @DotNetType
+                // dynamic events). Honors --standalone. Pure programs stay a single file.
+                CopySharpTSRuntimeIfNeeded(compiler, outputPath, outputOptions);
             }
             catch (Exception ex) when (bundlerMode != BundlerMode.Auto)
             {
@@ -581,6 +586,11 @@ static void CompileSingleFile(List<Stmt> statements, string outputPath, bool pre
                 {
                     Console.WriteLine($"Compiled to {outputPath} (using {bundleResult.TechniqueDescription})");
                 }
+
+                // Co-locate SharpTS.dll next to the EXE when the program uses a feature that
+                // late-binds into the SharpTS runtime (eval, Proxy, Intl, vm, dns, @DotNetType
+                // dynamic events). Honors --standalone. Pure programs stay a single file.
+                CopySharpTSRuntimeIfNeeded(compiler, outputPath, outputOptions);
             }
             catch (Exception ex) when (bundlerMode != BundlerMode.Auto)
             {

--- a/SharpTS.Tests/IntegrationTests/CliBundlerTests.cs
+++ b/SharpTS.Tests/IntegrationTests/CliBundlerTests.cs
@@ -319,4 +319,39 @@ public class CliBundlerTests
         Assert.NotEqual(0, result.ExitCode);
         Assert.Contains("--bundler requires a value", result.StandardOutput);
     }
+
+    [Fact]
+    public void Compile_TargetExe_WithRuntimeFeature_CoLocatesSharpTSDll()
+    {
+        // A program using a feature that late-binds into the SharpTS runtime (Intl) must get
+        // SharpTS.dll alongside the EXE so the feature works at runtime (#117).
+        if (!SdkBundlerDetector.IsSdkAvailable) return;
+
+        using var tempDir = CliTestHelper.CreateTempDirectory();
+        var scriptPath = tempDir.CreateFile("app.ts",
+            "const f = new Intl.NumberFormat(\"en-US\"); console.log(f.format(1234));");
+
+        var result = CliTestHelper.RunCli($"-c \"{scriptPath}\" -t exe", tempDir.Path);
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.True(File.Exists(tempDir.GetPath("app.exe")));
+        Assert.True(File.Exists(tempDir.GetPath("SharpTS.dll")),
+            "SharpTS.dll should be co-located next to the EXE for an Intl-using program");
+    }
+
+    [Fact]
+    public void Compile_TargetExe_PureProgram_StaysSingleFile()
+    {
+        if (!SdkBundlerDetector.IsSdkAvailable) return;
+
+        using var tempDir = CliTestHelper.CreateTempDirectory();
+        var scriptPath = tempDir.CreateFile("app.ts", CliFixtures.SimpleHelloWorld);
+
+        var result = CliTestHelper.RunCli($"-c \"{scriptPath}\" -t exe", tempDir.Path);
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.True(File.Exists(tempDir.GetPath("app.exe")));
+        Assert.False(File.Exists(tempDir.GetPath("SharpTS.dll")),
+            "a pure program should stay a single file (no co-located SharpTS.dll)");
+    }
 }

--- a/SharpTS.Tests/PackagingTests/NuGetPackagerTests.cs
+++ b/SharpTS.Tests/PackagingTests/NuGetPackagerTests.cs
@@ -208,6 +208,35 @@ public class NuGetPackagerTests : IDisposable
         Assert.Equal("3.0.0", packager.Version);
     }
 
+    [Fact]
+    public void CreatePackage_IncludesSharpTSRuntime_WhenCoLocated()
+    {
+        // The compile step co-locates SharpTS.dll next to the output when the program uses a
+        // runtime-dependent feature (#117). The package must carry it so consumers don't hit the gap.
+        var package = new PackageJson { Name = "TestLib", Version = "1.0.0" };
+        var assemblyPath = CreateDummyAssembly("TestLib.dll");
+        File.WriteAllBytes(Path.Combine(_tempDir, "SharpTS.dll"), [0x4D, 0x5A]);
+
+        var nupkgPath = new NuGetPackager(package).CreatePackage(assemblyPath, _tempDir);
+
+        using var archive = ZipFile.OpenRead(nupkgPath);
+        Assert.NotNull(archive.GetEntry("lib/net10.0/SharpTS.dll"));
+    }
+
+    [Fact]
+    public void CreatePackage_OmitsSharpTSRuntime_WhenNotCoLocated()
+    {
+        // A pure library (no runtime-dependent feature) has no co-located SharpTS.dll, so the
+        // package stays dependency-free.
+        var package = new PackageJson { Name = "TestLib", Version = "1.0.0" };
+        var assemblyPath = CreateDummyAssembly("TestLib.dll");
+
+        var nupkgPath = new NuGetPackager(package).CreatePackage(assemblyPath, _tempDir);
+
+        using var archive = ZipFile.OpenRead(nupkgPath);
+        Assert.Null(archive.GetEntry("lib/net10.0/SharpTS.dll"));
+    }
+
     private string CreateDummyAssembly(string fileName)
     {
         var path = Path.Combine(_tempDir, fileName);


### PR DESCRIPTION
Closes #117.

#115 made `--compile` (DLL output) co-locate `SharpTS.dll` next to the output **only** when the program uses a feature that late-binds into the SharpTS runtime — eval, Proxy, Intl, vm, dns, `@DotNetType` dynamic events — via `ILCompiler.RequiredSharpTSRuntimeReasons`. Two other output paths didn't consume that signal:

1. **`--compile -t exe`** — the single-file EXE bundler emitted neither a bundled nor co-located `SharpTS.dll`, so the feature threw at runtime.
2. **`--pack`** — the NuGet package shipped the output DLL + runtimeconfig but not `SharpTS.dll`, so a package consumer hit the same gap.

## Fix
- **exe** (`Program.cs`): both EXE branches now call `CopySharpTSRuntimeIfNeeded` after a successful bundle — `SharpTS.dll` lands next to the EXE when needed, honoring `--standalone`; pure programs stay a single file.
- **pack** (`NuGetPackager.CreatePackage`): includes `SharpTS.dll` under `lib/<tfm>/` when it was co-located next to the output assembly (the materialized `RequiredSharpTSRuntimeReasons` signal — DRY, and respects `--standalone`/pure-program for free). Pure libraries stay dependency-free.

## Verification
End-to-end via the CLI:
- `-t exe` of an `Intl` program → `Copied SharpTS.dll next to output — required at runtime by: Intl`, `SharpTS.dll` + `app.exe` present.
- `--pack` of an `Intl` library → nupkg contains `lib/net10.0/SharpTS.dll` **and** `lib/net10.0/lib.dll`.
- Pure programs do neither.

Tests: `NuGetPackagerTests` (include / omit SharpTS.dll), `CliBundlerTests` (co-locate / single-file). Targeted suite green except the 2 known pre-existing `Pack_WithoutPackageJson_*` failures.