### PR TITLE
feat: parse function types with untyped (implicit-any) parameters (#149)

### DIFF
--- a/Parsing/Parser.Types.cs
+++ b/Parsing/Parser.Types.cs
@@ -80,7 +80,9 @@ public partial class Parser
                 // Handle optional parameter marker: x?: number
                 bool isOptional = false;
 
-                // Parameter can be: name: type, name?: type, or just type
+                // Parameter can be: name: type, name?: type, name (bare, implicit any),
+                // name? (bare optional, implicit any), or just a type expression.
+                string paramType;
                 if (Check(TokenType.IDENTIFIER) &&
                     (PeekNext().Type == TokenType.COLON || PeekNext().Type == TokenType.QUESTION))
                 {
@@ -89,10 +91,21 @@ public partial class Parser
                     {
                         isOptional = true;
                     }
-                    Consume(TokenType.COLON, "Expect ':' after parameter name in function type.");
+                    // The type annotation is optional: `(x?) => R` / `(x) => R` give the parameter
+                    // an implicit `any` type (the name is a label only).
+                    paramType = Match(TokenType.COLON) ? ParseTypeAnnotation() : "any";
                 }
-
-                string paramType = ParseTypeAnnotation();
+                else if (!isRest && Check(TokenType.IDENTIFIER) &&
+                         (PeekNext().Type == TokenType.RIGHT_PAREN || PeekNext().Type == TokenType.COMMA))
+                {
+                    // Bare parameter name with no annotation: implicit `any`.
+                    Advance(); // consume name
+                    paramType = "any";
+                }
+                else
+                {
+                    paramType = ParseTypeAnnotation();
+                }
 
                 // Preserve optional/rest info in the type string representation
                 if (isRest)
@@ -115,6 +128,27 @@ public partial class Parser
             return $"(this: {thisType}, {string.Join(", ", paramTypes)}) => {returnType}";
         }
         return $"({string.Join(", ", paramTypes)}) => {returnType}";
+    }
+
+    /// <summary>
+    /// Speculative lookahead used in type position: with the opening '(' already consumed, scans to
+    /// the matching ')' and reports whether a '=>' immediately follows. This distinguishes a function
+    /// type whose first parameter is a bare untyped name — <c>(x) =&gt; R</c>, <c>(x, y) =&gt; R</c> —
+    /// from a grouped type such as <c>(Foo)</c> or <c>(A | B)</c>. Restores the position before returning.
+    /// </summary>
+    private bool ParenGroupFollowedByArrow()
+    {
+        int saved = _current;
+        int depth = 1; // the opening '(' has already been consumed
+        while (!IsAtEnd() && depth > 0)
+        {
+            var type = Advance().Type;
+            if (type == TokenType.LEFT_PAREN) depth++;
+            else if (type == TokenType.RIGHT_PAREN) depth--;
+        }
+        bool followedByArrow = depth == 0 && Check(TokenType.ARROW);
+        _current = saved;
+        return followedByArrow;
     }
 
     /// <summary>
@@ -363,6 +397,13 @@ public partial class Parser
             else if (Check(TokenType.DOT_DOT_DOT))
             {
                 // (...rest: T) => R - rest parameter as the first parameter
+                isFunctionType = true;
+            }
+            else if (Check(TokenType.IDENTIFIER) && ParenGroupFollowedByArrow())
+            {
+                // (x) => R, (x, y) => R - function type with bare (implicitly-`any`) parameter
+                // names. Disambiguated from a grouped type (e.g. `(Foo)` or `(A | B)`) by the `=>`
+                // that follows the matching ')'.
                 isFunctionType = true;
             }
 

--- a/SharpTS.Tests/ParserTests/FunctionTypeAnnotationTests.cs
+++ b/SharpTS.Tests/ParserTests/FunctionTypeAnnotationTests.cs
@@ -220,4 +220,49 @@ public class FunctionTypeAnnotationTests
     }
 
     #endregion
+
+    #region Untyped (implicit-any) parameters in function types
+
+    [Fact]
+    public void FunctionType_BareParameterName_Parses()
+    {
+        // `(x) => number`: x is a parameter name with implicit `any`, not a grouped type.
+        Assert.NotEmpty(Parse("let f: (x) => number;"));
+    }
+
+    [Fact]
+    public void FunctionType_MultipleBareParameters_Parses()
+    {
+        Assert.NotEmpty(Parse("let f: (x, y) => number;"));
+    }
+
+    [Fact]
+    public void FunctionType_MixedTypedAndBareParameters_Parses()
+    {
+        Assert.NotEmpty(Parse("let f: (x: number, y) => number;"));
+    }
+
+    [Fact]
+    public void FunctionType_BareOptionalParameter_Parses()
+    {
+        // `(x?) => number`: optional parameter with implicit `any`.
+        Assert.NotEmpty(Parse("let f: (x?) => number;"));
+    }
+
+    [Fact]
+    public void FunctionType_BareParameterInIndexSignature_Parses()
+    {
+        // The function type appears as an index-signature value: `[k: string]: (x) => number`.
+        Assert.NotEmpty(Parse("interface I { [k: string]: (x) => number; }"));
+    }
+
+    [Fact]
+    public void GroupedType_StillParses_NotMistakenForFunctionType()
+    {
+        // Regression guard: a grouped/parenthesized type with no trailing `=>` stays a grouped type.
+        Assert.NotEmpty(Parse("let a: (number | string)[];"));
+        Assert.NotEmpty(Parse("let b: (Foo);"));
+    }
+
+    #endregion
 }

--- a/SharpTS.TypeScriptConformance/baselines/interpreted.txt
+++ b/SharpTS.TypeScriptConformance/baselines/interpreted.txt
@@ -8,9 +8,9 @@ tests/cases/conformance/types/conditional/inferTypesInvalidExtendsDeclaration.ts
 tests/cases/conformance/types/conditional/inferTypesWithExtends1.ts ParseError
 tests/cases/conformance/types/conditional/inferTypesWithExtends2.ts Fail
 tests/cases/conformance/types/conditional/variance.ts Fail
-tests/cases/conformance/types/typeRelationships/assignmentCompatibility/anyAssignabilityInInheritance.ts ParseError
+tests/cases/conformance/types/typeRelationships/assignmentCompatibility/anyAssignabilityInInheritance.ts Fail
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/anyAssignableToEveryType.ts Pass
-tests/cases/conformance/types/typeRelationships/assignmentCompatibility/anyAssignableToEveryType2.ts ParseError
+tests/cases/conformance/types/typeRelationships/assignmentCompatibility/anyAssignableToEveryType2.ts Pass
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatBetweenTupleAndArray.ts Pass
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignatures.ts Fail
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignatures2.ts Fail
@@ -65,7 +65,7 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/construc
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/constructSignatureAssignabilityInInheritance6.ts Fail
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/covariantCallbacks.ts Fail
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/enumAssignability.ts Fail
-tests/cases/conformance/types/typeRelationships/assignmentCompatibility/enumAssignabilityInInheritance.ts ParseError
+tests/cases/conformance/types/typeRelationships/assignmentCompatibility/enumAssignabilityInInheritance.ts Fail
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/everyTypeAssignableToAny.ts Pass
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/genericCallWithObjectTypeArgsAndInitializers.ts Fail
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/intersectionIncludingPropFromGlobalAugmentation.ts Pass


### PR DESCRIPTION
Part of #80. Fixes #149.

In type position, a function type whose parameter has **no annotation** failed to parse:

```ts
declare function f(x: (x) => number): number;   // Parse Error: Expect ')' after parameters
interface I { [k: string]: (x) => number }       // same
```

## Fix
Two gaps in `Parser.Types.cs`:
1. **Lookahead** — added a bounded paren-matching scan (`ParenGroupFollowedByArrow`) so `(x) => R` / `(x, y) => R` are recognized as function types, disambiguated from grouped types (`(Foo)`, `(A | B)`) by the `=>` after the matching `)`.
2. **Body parser** (`ParseFunctionTypeBody`) — a bare parameter name (and `(x?)`) is now treated as an implicit-`any` parameter; the name is a label only.

## Verification
- **Conformance:** ParseError 7 → 4. `anyAssignableToEveryType2` flips **ParseError → Pass**; `anyAssignabilityInInheritance` and `enumAssignabilityInInheritance` move **ParseError → Fail** (they now parse and fail later on an unrelated overloaded-`declare`-function resolution gap — forward progress into the type-checker). 0 regressions; baseline regenerated.
- **Unit suite:** full suite green except the 2 pre-existing `PackagingTests` failures (fail identically on clean `main`); a `Fork_WorkersShareHttpPort` flake passed on isolated re-run. Added 6 parser tests in `FunctionTypeAnnotationTests`, including a grouped-type regression guard.
