### PR TITLE
feat: check index-signature compatibility in assignability (#153)

### DIFF
--- a/SharpTS.Tests/TypeCheckerTests/ClassIndexSignatureTests.cs
+++ b/SharpTS.Tests/TypeCheckerTests/ClassIndexSignatureTests.cs
@@ -59,4 +59,51 @@ public class ClassIndexSignatureTests
         // [expr] (no `ident:` shape) must remain a computed property name, not an index signature.
         TestHarness.RunInterpreted("const k = \"key\"; class A { [k]: number = 1; } let a: A = new A();");
     }
+
+    #region Index-signature assignability (issue: index signatures must be compatible)
+
+    [Fact]
+    public void IndexSignature_SubtypeValue_AssignableToClassIndex()
+    {
+        // `{ [x: string]: Derived }` is assignable to a class with `{ [x: string]: Base }` (Derived <: Base).
+        TestHarness.RunInterpreted("""
+            interface Base { foo: string; }
+            interface Derived extends Base { bar: string; }
+            class A { [x: string]: Base; }
+            function g(b: { [x: string]: Derived }): A { return b; }
+            """);
+    }
+
+    [Fact]
+    public void IndexSignature_SupertypeValue_NotAssignableToNarrowerIndex()
+    {
+        // The reverse direction is unsafe: a Base-valued index is not assignable to a Derived-valued one.
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted("""
+            interface Base { foo: string; }
+            interface Derived extends Base { bar: string; }
+            function h(a: { [x: string]: Base }): { [x: string]: Derived } { return a; }
+            """));
+    }
+
+    [Fact]
+    public void IndexSignature_NamedMemberAssignableToIndexType_Ok()
+    {
+        // A source's named member compatible with the target's string index type is fine.
+        TestHarness.RunInterpreted("""
+            interface Base { foo: string; }
+            interface Derived extends Base { bar: string; }
+            function good(src: { p: Derived }): { [k: string]: Base } { return src; }
+            """);
+    }
+
+    [Fact]
+    public void IndexSignature_NamedMemberNotAssignableToIndexType_Error()
+    {
+        // A named member incompatible with the target's string index type is rejected.
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted("""
+            function bad(src: { p: number }): { [k: string]: string } { return src; }
+            """));
+    }
+
+    #endregion
 }

--- a/TypeSystem/TypeChecker.Compatibility.Helpers.cs
+++ b/TypeSystem/TypeChecker.Compatibility.Helpers.cs
@@ -83,6 +83,62 @@ public partial class TypeChecker
     private static bool IsPublicMember(FrozenDictionary<string, AccessModifier> access, string name)
         => !access.TryGetValue(name, out var mod) || mod == AccessModifier.Public;
 
+    /// <summary>The string index signature value type of any object-like type, or null.</summary>
+    private static TypeInfo? StringIndexOf(TypeInfo t) => t switch
+    {
+        TypeInfo.Record r => r.StringIndexType,
+        TypeInfo.Interface i => i.StringIndexType,
+        TypeInfo.Class c => c.StringIndexType,
+        TypeInfo.Instance inst => inst.ResolvedClassType is TypeInfo.Class c ? c.StringIndexType : null,
+        _ => null
+    };
+
+    /// <summary>The number index signature value type of any object-like type, or null.</summary>
+    private static TypeInfo? NumberIndexOf(TypeInfo t) => t switch
+    {
+        TypeInfo.Record r => r.NumberIndexType,
+        TypeInfo.Interface i => i.NumberIndexType,
+        TypeInfo.Class c => c.NumberIndexType,
+        TypeInfo.Instance inst => inst.ResolvedClassType is TypeInfo.Class c ? c.NumberIndexType : null,
+        _ => null
+    };
+
+    /// <summary>The named (non-index) member value types of any object-like type.</summary>
+    private static IEnumerable<TypeInfo> NamedMemberTypesOf(TypeInfo t) => t switch
+    {
+        TypeInfo.Record r => r.Fields.Values,
+        TypeInfo.Interface i => i.GetAllMembers().Select(m => m.Value),
+        TypeInfo.Class c => CollectPublicInstanceMembers(c).Values,
+        TypeInfo.Instance inst => inst.ResolvedClassType is TypeInfo.Class c ? CollectPublicInstanceMembers(c).Values : [],
+        _ => []
+    };
+
+    /// <summary>
+    /// True when <paramref name="actual"/> satisfies the index signatures of <paramref name="expected"/>
+    /// (TypeScript "index signatures must be compatible"). For a string index <c>[s: string]: V</c> on
+    /// the target, the source's string/number index types and every named member must be assignable to
+    /// <c>V</c>; likewise for a number index. Returns true when the target declares no index signature.
+    /// </summary>
+    private bool IndexSignaturesSatisfied(TypeInfo expected, TypeInfo actual)
+    {
+        var expStr = StringIndexOf(expected);
+        var expNum = NumberIndexOf(expected);
+        if (expStr is null && expNum is null) return true;
+
+        if (expStr is not null)
+        {
+            if (StringIndexOf(actual) is { } actStr && !IsCompatible(expStr, actStr)) return false;
+            if (NumberIndexOf(actual) is { } actNum && !IsCompatible(expStr, actNum)) return false;
+            foreach (var memberType in NamedMemberTypesOf(actual))
+                if (!IsCompatible(expStr, memberType)) return false;
+        }
+        if (expNum is not null)
+        {
+            if (NumberIndexOf(actual) is { } actNum && !IsCompatible(expNum, actNum)) return false;
+        }
+        return true;
+    }
+
     /// <summary>
     /// Returns the parameter type of <paramref name="f"/> at <paramref name="index"/>, expanding a
     /// trailing rest parameter to its element type so it covers any position at or beyond the rest

--- a/TypeSystem/TypeChecker.Compatibility.cs
+++ b/TypeSystem/TypeChecker.Compatibility.cs
@@ -702,7 +702,11 @@ public partial class TypeChecker
                 if (!HasNominalClassBrand(expectedClass))
                 {
                     var targetMembers = CollectPublicInstanceMembers(expectedClass);
-                    if (targetMembers.Count > 0 && CheckStructuralCompatibility(targetMembers, i2))
+                    // A target with named members or an index signature can match structurally; both
+                    // the named members and the index signatures must be satisfied.
+                    if ((targetMembers.Count > 0 || expectedClass.Core.HasIndexSignature)
+                        && CheckStructuralCompatibility(targetMembers, i2)
+                        && IndexSignaturesSatisfied(expectedClass, i2))
                     {
                         return true;
                     }
@@ -728,7 +732,9 @@ public partial class TypeChecker
             !HasNominalClassBrand(targetClass))
         {
             var targetMembers = CollectPublicInstanceMembers(targetClass);
-            if (targetMembers.Count > 0 && CheckStructuralCompatibility(targetMembers, actual))
+            if ((targetMembers.Count > 0 || targetClass.Core.HasIndexSignature)
+                && CheckStructuralCompatibility(targetMembers, actual)
+                && IndexSignaturesSatisfied(targetClass, actual))
             {
                 return true;
             }
@@ -792,12 +798,13 @@ public partial class TypeChecker
                         return false;
                     }
                 }
-                return true;
+                return IndexSignaturesSatisfied(itf, actualItf);
             }
             // Use GetAllMembers to include inherited members when checking structural compatibility
             var allMembers = itf.GetAllMembers().ToDictionary(m => m.Key, m => m.Value);
             var allOptional = itf.GetAllOptionalMembers().ToHashSet();
-            return CheckStructuralCompatibility(allMembers, actual, allOptional);
+            return CheckStructuralCompatibility(allMembers, actual, allOptional)
+                && IndexSignaturesSatisfied(itf, actual);
         }
 
         // Handle InstantiatedGeneric interface (e.g., Container<number>)
@@ -895,9 +902,9 @@ public partial class TypeChecker
                     return false;
                 }
             }
-            // If expected has only index signatures (no explicit fields), empty object is compatible
-            // Index signatures allow any number of keys (including zero)
-            return true;
+            // Named fields match; the target's index signatures (if any) must also be satisfied by
+            // the source's members and own index signatures.
+            return IndexSignaturesSatisfied(expRecord, actRecord);
         }
 
         // Record constraint compatibility with types that have members (String, Array, etc.)
@@ -905,7 +912,8 @@ public partial class TypeChecker
         if (expected is TypeInfo.Record expRec)
         {
             // Use CheckStructuralCompatibility to check if actual type has all required fields
-            return CheckStructuralCompatibility(expRec.Fields, actual, expRec.OptionalFields);
+            return CheckStructuralCompatibility(expRec.Fields, actual, expRec.OptionalFields)
+                && IndexSignaturesSatisfied(expRec, actual);
         }
 
         // Tuple-to-tuple compatibility


### PR DESCRIPTION
Part of #80. Fixes #153.

## Problem
Index-signature assignability was unchecked — Record-to-Record returned `true` ignoring index types, and assignment to a class/object with an index signature never compared index value types:

```ts
interface Base { foo: string; }
interface Derived extends Base { bar: string; }
class A { [x: string]: Base; }
var a: A; var b: { [x: string]: Derived; };
a = b;   // should be OK (Derived <: Base) — was wrongly rejected
b = a;   // should ERROR (Base not <: Derived) — was wrongly accepted
```

## Fix
`IndexSignaturesSatisfied(expected, actual)` + unified `StringIndexOf`/`NumberIndexOf`/`NamedMemberTypesOf` accessors (Record/Interface/Class/Instance), wired into the Record-, Interface-, and class-instance-target branches. For a target index `[k]: V`, the source's index types and every named member must be assignable to `V`. Index-only class targets are now matchable.

## Verification
- Correct verdicts confirmed (`a = b` OK, `b = a` errors; member-vs-index both directions). 4 unit tests in `ClassIndexSignatureTests`.
- Full suite green except the 2 pre-existing `PackagingTests` failures. **0 regressions** despite touching hot-path compat branches.

## ⚠️ Does not flip conformance yet (honest scoping)
The `assignmentCompatWith{String,Numeric}Indexer*` tests each **bundle a generic-class index case** (`class A<T> { [x: string]: T }` used as `A<Base>`) whose index type needs type-argument substitution on an `InstantiatedGeneric`. That's the **same generic-instantiation frontier** that blocks the generic call/construct-signature group (#151). This PR is correct, regression-free groundwork those flips will build on once generic instantiation lands.
