### PR TITLE
feat: type-check instance field initializers and field assignments (#157)

### DIFF
--- a/SharpTS.Tests/TypeCheckerTests/FieldAssignmentTypeCheckTests.cs
+++ b/SharpTS.Tests/TypeCheckerTests/FieldAssignmentTypeCheckTests.cs
@@ -1,0 +1,74 @@
+using SharpTS.Tests.Infrastructure;
+using SharpTS.TypeSystem.Exceptions;
+using Xunit;
+
+namespace SharpTS.Tests.TypeCheckerTests;
+
+/// <summary>
+/// Type-checking of instance field initializers and instance field assignments. Both were
+/// previously unchecked: a non-setter field assignment (<c>this.x = v</c>) and an instance field
+/// initializer (<c>x = v</c> / <c>r = () =&gt; {…}</c>) now validate against the field's declared type
+/// and type-check their bodies.
+/// </summary>
+public class FieldAssignmentTypeCheckTests
+{
+    [Fact]
+    public void InstanceFieldInitializer_TypeMismatch_Errors()
+    {
+        Assert.ThrowsAny<TypeCheckException>(() =>
+            TestHarness.RunInterpreted("class C { x: number = \"bad\"; }"));
+    }
+
+    [Fact]
+    public void InstanceFieldInitializer_Compatible_Ok()
+    {
+        TestHarness.RunInterpreted("class C { x: number = 5; } let c: C = new C(); console.log(c.x);");
+    }
+
+    [Fact]
+    public void InstanceFieldAssignment_TypeMismatch_Errors()
+    {
+        // `this.x = v` is now checked against x's declared type.
+        Assert.ThrowsAny<TypeCheckException>(() =>
+            TestHarness.RunInterpreted("class C { x: number = 0; m() { this.x = \"bad\"; } }"));
+    }
+
+    [Fact]
+    public void InstanceFieldAssignment_Compatible_Ok()
+    {
+        TestHarness.RunInterpreted("""
+            class C { x: number = 0; m(): void { this.x = 7; } }
+            let c: C = new C();
+            c.m();
+            console.log(c.x);
+            """);
+    }
+
+    [Fact]
+    public void FieldArrowInitializer_BodyIsTypeChecked()
+    {
+        // The arrow body assigned to a field is type-checked: `this.t = this.u` with unrelated
+        // constrained type parameters is an error (it previously went unchecked).
+        Assert.ThrowsAny<TypeCheckException>(() =>
+            TestHarness.RunInterpreted("""
+                class Foo { foo: string; }
+                class C<T extends Foo, U extends Foo> {
+                    t: T;
+                    u: U;
+                    r = () => { this.t = this.u; };
+                }
+                """));
+    }
+
+    [Fact]
+    public void UntypedField_AssignmentNotConstrained()
+    {
+        // A field with no annotation is `any`; assignments to it are unconstrained.
+        TestHarness.RunInterpreted("""
+            class C { x = 0; m(): void { this.x = 1; } }
+            let c: C = new C();
+            c.m();
+            console.log("ok");
+            """);
+    }
+}

--- a/SharpTS.TypeScriptConformance/baselines/interpreted.txt
+++ b/SharpTS.TypeScriptConformance/baselines/interpreted.txt
@@ -75,6 +75,6 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/numberAs
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/optionalPropertyAssignableToStringIndexSignature.ts Fail
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/typeParameterAssignability.ts Pass
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/typeParameterAssignability2.ts Fail
-tests/cases/conformance/types/typeRelationships/assignmentCompatibility/typeParameterAssignability3.ts Fail
+tests/cases/conformance/types/typeRelationships/assignmentCompatibility/typeParameterAssignability3.ts Pass
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/undefinedAssignableToEveryType.ts Pass
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/unionTypesAssignability.ts Fail

--- a/TypeSystem/TypeChecker.Properties.cs
+++ b/TypeSystem/TypeChecker.Properties.cs
@@ -532,7 +532,26 @@ public partial class TypeChecker
                  current = GetSuperclass(current);
              }
 
-             return CheckExpr(set.Value);
+             // Check the assigned value against the field's declared type (walking the chain). Plain
+             // (non-setter) instance fields were previously assigned without a compatibility check.
+             TypeInfo fieldValueType = CheckExpr(set.Value);
+             current = startClass;
+             while (current != null)
+             {
+                 var fieldTypes = GetFieldTypes(current);
+                 if (fieldTypes != null && fieldTypes.TryGetValue(memberName, out var fieldDeclType))
+                 {
+                     if (fieldDeclType is not (TypeInfo.Inferred or TypeInfo.Any)
+                         && !IsCompatible(fieldDeclType, fieldValueType))
+                     {
+                         throw new TypeCheckException($" Cannot assign type '{fieldValueType}' to field '{memberName}' of type '{fieldDeclType}'.", tsCode: "TS2322");
+                     }
+                     if (assignedPath != null) InstallPostAssignmentNarrowing(assignedPath, fieldDeclType, fieldValueType);
+                     break;
+                 }
+                 current = GetSuperclass(current);
+             }
+             return fieldValueType;
         }
         else if (objType is TypeInfo.Record record)
         {

--- a/TypeSystem/TypeChecker.Statements.Classes.cs
+++ b/TypeSystem/TypeChecker.Statements.Classes.cs
@@ -588,6 +588,23 @@ public partial class TypeChecker
 
         try
         {
+            // Check instance field initializers (e.g. `x = 5`, `r = () => { ... }`) within the
+            // instance context so `this` and the class's type parameters resolve inside them. Static
+            // fields are checked separately at class scope. Inferred/Any field types skip the
+            // assignability check but the initializer is still type-checked.
+            foreach (var field in classStmt.Fields)
+            {
+                if (field.IsStatic || field.Initializer == null) continue;
+                TypeInfo initType = CheckExpr(field.Initializer);
+                var declaredTypes = field.IsPrivate ? classTypeForBody.PrivateFieldTypes : classTypeForBody.FieldTypes;
+                if (declaredTypes.TryGetValue(field.Name.Lexeme, out var fieldDeclaredType)
+                    && fieldDeclaredType is not (TypeInfo.Inferred or TypeInfo.Any)
+                    && !IsCompatible(fieldDeclaredType, initType))
+                {
+                    throw new TypeCheckException($" Cannot assign type '{initType}' to field '{field.Name.Lexeme}' of type '{fieldDeclaredType}'.", tsCode: "TS2322");
+                }
+            }
+
             // Only check methods that have bodies (skip overload signatures)
             foreach (var method in classStmt.Methods.Where(m => m.Body != null))
             {


### PR DESCRIPTION
Part of #80. Fixes #157 (a follow-up from #155).

## Problem
Two instance-field paths were not type-checked:
1. **Instance field initializers** (`x = 5`, `r = () => {…}`) — only *static* initializers were checked, so instance initializer bodies (e.g. an arrow) were never type-checked.
2. **Instance field assignments** (`this.x = v`) — `CheckSet` validated setters but a plain field assignment just evaluated the RHS and returned, never checking it against the field's declared type.

```ts
class C { x: number = 0; m() { this.x = "bad"; } }   // both now error
```

## Fix
- Check instance (non-static) field initializers inside the instance context (so `this` and the class's type parameters resolve), validating against the declared type. Inferred/`any` fields skip the assignability check but the body is still type-checked.
- In `CheckSet`, validate a plain instance field assignment against the field's declared type (walking the inheritance chain).

## Verification
- **Conformance:** `typeParameterAssignability3` flips **Fail → Pass** (subset Pass 24 → 25, 0 regressions); baseline regenerated.
- **Unit suite:** full suite green except the 2 pre-existing `PackagingTests` failures — **0 regressions** despite adding a check to the hot `this.x = …` assignment path. Adds `FieldAssignmentTypeCheckTests` (6 tests).

This is a general correctness improvement beyond conformance — instance field assignments and initializers are now type-checked like the rest of the language.
