### PR TITLE
feat: parse dense .d.ts — es5/es2015.core lib files now parse (#99 Phase A)

### DIFF
--- a/Parsing/Parser.Declarations.cs
+++ b/Parsing/Parser.Declarations.cs
@@ -244,7 +244,8 @@ public partial class Parser
 
     private Stmt InterfaceDeclaration()
     {
-        Token name = Consume(TokenType.IDENTIFIER, "Expect interface name.");
+        // Allow contextual-keyword names (e.g. lib.d.ts declares `interface Symbol`, `interface BigInt`).
+        Token name = ConsumeIdentifierName("Expect interface name.");
         List<TypeParam>? typeParams = ParseTypeParameters();
 
         // Parse extends clause: interface Foo extends Bar, Baz { ... }
@@ -267,6 +268,19 @@ public partial class Parser
 
         while (!Check(TokenType.RIGHT_BRACE) && !IsAtEnd())
         {
+            // Readonly index signature: `readonly [index: number]: T` (lib.d.ts). Consume the
+            // `readonly` modifier so the index-signature parser sees the leading '['.
+            if (Check(TokenType.READONLY) && PeekNext().Type == TokenType.LEFT_BRACKET)
+            {
+                Advance(); // consume readonly
+                var roIndexSig = TryParseIndexSignature();
+                if (roIndexSig != null)
+                {
+                    indexSignatures.Add(roIndexSig);
+                    continue;
+                }
+            }
+
             // Check for index signature: [key: string]: valueType
             if (Check(TokenType.LEFT_BRACKET))
             {
@@ -517,6 +531,14 @@ public partial class Parser
             keyType = TokenType.TYPE_SYMBOL;
             Advance();
         }
+        else if (Check(TokenType.IDENTIFIER))
+        {
+            // Non-primitive key type, e.g. a type alias such as `PropertyKey`
+            // (= `string | number | symbol`). lib.d.ts uses these. Model as a string
+            // index — the broadest key kind — so the declaration parses.
+            keyType = TokenType.TYPE_STRING;
+            Advance();
+        }
         else
         {
             _current = savedPosition;
@@ -575,13 +597,15 @@ public partial class Parser
         {
             do
             {
+                bool isRest = Match(TokenType.DOT_DOT_DOT);
                 ConsumeIdentifierName("Expect parameter name.");
-                if (Match(TokenType.QUESTION))
-                {
-                    // Optional parameter marker
-                }
+                bool isOptional = Match(TokenType.QUESTION);
                 Consume(TokenType.COLON, "Expect ':' after parameter name.");
                 string paramType = ParseTypeAnnotation();
+                // Encode rest/optional the same way ParseFunctionTypeBody does so the signature
+                // resolver models arity correctly.
+                if (isRest) paramType = "..." + paramType;
+                else if (isOptional) paramType += "?";
                 paramTypes.Add(paramType);
             } while (Match(TokenType.COMMA));
         }

--- a/Parsing/Parser.Declarations.cs
+++ b/Parsing/Parser.Declarations.cs
@@ -315,6 +315,38 @@ public partial class Parser
                 }
             }
 
+            // Computed member name using a well-known symbol: `[Symbol.iterator](): T`,
+            // `readonly [Symbol.toStringTag]: "X"` (lib.d.ts). Index signatures were ruled out above,
+            // so a leading '[' here is a computed name. Map `Symbol.x` to the canonical `@@x`.
+            bool computedReadonly = Check(TokenType.READONLY) && PeekNext().Type == TokenType.LEFT_BRACKET;
+            if (computedReadonly) Advance(); // consume readonly
+            if (Check(TokenType.LEFT_BRACKET))
+            {
+                int computedLine = Peek().Line;
+                Advance(); // consume '['
+                string raw = "";
+                while (!Check(TokenType.RIGHT_BRACKET) && !IsAtEnd())
+                    raw += Advance().Lexeme;
+                Consume(TokenType.RIGHT_BRACKET, "Expect ']' after computed member name.");
+                string computedName = raw.StartsWith("Symbol.") ? "@@" + raw["Symbol.".Length..] : "@@" + raw;
+                var computedTok = new Token(TokenType.IDENTIFIER, computedName, null, computedLine);
+
+                bool computedOptional = Match(TokenType.QUESTION);
+                string computedType;
+                if (Check(TokenType.LEFT_PAREN) || Check(TokenType.LESS))
+                {
+                    computedType = ParseMethodSignature();
+                }
+                else
+                {
+                    Consume(TokenType.COLON, "Expect ':' after computed member name.");
+                    computedType = ParseTypeAnnotation();
+                }
+                ConsumeInterfaceMemberSeparator();
+                members.Add(new Stmt.InterfaceMember(computedTok, computedType, computedOptional, computedReadonly));
+                continue;
+            }
+
             // Check for readonly modifier
             bool isReadonly = Match(TokenType.READONLY);
 

--- a/Parsing/Parser.Functions.cs
+++ b/Parsing/Parser.Functions.cs
@@ -254,6 +254,15 @@ public partial class Parser
         {
             do
             {
+                // Explicit `this` parameter (e.g. `call(this: Function, ...)` in lib.d.ts) — a
+                // type-only annotation, not a runtime parameter. Consume and skip it.
+                if (Check(TokenType.THIS))
+                {
+                    Advance(); // this
+                    if (Match(TokenType.COLON)) ParseTypeAnnotation();
+                    continue;
+                }
+
                 // Check for rest parameter
                 bool isRest = Match(TokenType.DOT_DOT_DOT);
 

--- a/Parsing/Parser.Types.cs
+++ b/Parsing/Parser.Types.cs
@@ -82,10 +82,10 @@ public partial class Parser
                 // Parameter can be: name: type, name?: type, name (bare, implicit any),
                 // name? (bare optional, implicit any), or just a type expression.
                 string paramType;
-                if (Check(TokenType.IDENTIFIER) &&
+                if ((Check(TokenType.IDENTIFIER) || IsContextualKeyword(Peek().Type)) &&
                     (PeekNext().Type == TokenType.COLON || PeekNext().Type == TokenType.QUESTION))
                 {
-                    Advance(); // skip name
+                    Advance(); // skip name (may be a contextual keyword, e.g. `set: Set<T>`)
                     if (Match(TokenType.QUESTION))
                     {
                         isOptional = true;

--- a/Parsing/Parser.Types.cs
+++ b/Parsing/Parser.Types.cs
@@ -34,9 +34,8 @@ public partial class Parser
             }
         }
 
-        // Check for "x is T" pattern (regular type predicate)
-        // Must be: identifier followed by 'is' keyword
-        if (Check(TokenType.IDENTIFIER) && PeekNext().Type == TokenType.IS)
+        // Check for "x is T" / "this is T" type predicate: an identifier (or `this`) followed by `is`.
+        if ((Check(TokenType.IDENTIFIER) || Check(TokenType.THIS)) && PeekNext().Type == TokenType.IS)
         {
             string paramName = Advance().Lexeme;
             Consume(TokenType.IS, "Expected 'is' after parameter name.");
@@ -232,6 +231,15 @@ public partial class Parser
     private string ParsePrimaryType()
     {
         string typeName;
+
+        // `readonly` array/tuple modifier: `readonly T[]`, `readonly [A, B]` (lib.d.ts). Handled at
+        // the primary-type level so it binds correctly inside unions (`readonly T[] | U`) and other
+        // nested positions. ToTypeInfo marks the array/tuple readonly.
+        if (Check(TokenType.READONLY))
+        {
+            Advance();
+            return "readonly " + ParsePrimaryType();
+        }
 
         // Handle infer keyword for conditional types: infer U, or constrained infer: infer U extends C
         if (Match(TokenType.INFER))
@@ -452,11 +460,20 @@ public partial class Parser
                  Check(TokenType.TYPE_BOOLEAN) || Check(TokenType.TYPE_SYMBOL) ||
                  Check(TokenType.TYPE_BIGINT) ||
                  Check(TokenType.IDENTIFIER) ||
+                 Check(TokenType.SYMBOL) || Check(TokenType.BIGINT) ||  // `Symbol`/`BigInt` as type names (lib.d.ts: `interface Symbol`)
                  Check(TokenType.THIS) ||  // polymorphic 'this' type (e.g. `): this`, `keyof this`)
                  Check(TokenType.VOID) ||  // void type
                  Check(TokenType.NULL) || Check(TokenType.UNDEFINED) || Check(TokenType.UNKNOWN) || Check(TokenType.NEVER))
         {
             typeName = Advance().Lexeme;
+
+            // Qualified type name (namespace member): `Intl.CollatorOptions`, `NodeJS.Timer`.
+            while (Check(TokenType.DOT) &&
+                   (PeekNext().Type == TokenType.IDENTIFIER || IsContextualKeyword(PeekNext().Type)))
+            {
+                Advance(); // consume '.'
+                typeName += "." + Advance().Lexeme;
+            }
         }
         else
         {

--- a/Parsing/Parser.Types.cs
+++ b/Parsing/Parser.Types.cs
@@ -621,8 +621,35 @@ public partial class Parser
 
         while (!Check(TokenType.RIGHT_BRACE) && !IsAtEnd())
         {
+            // Optional readonly modifier before an index signature or computed member.
+            bool bracketReadonly = Check(TokenType.READONLY) && PeekNext().Type == TokenType.LEFT_BRACKET;
+            if (bracketReadonly) Advance();
+
+            // `[` begins either an index signature (`[k: string]: T`) or a computed member name
+            // (`[Symbol.iterator](): T`, `[Symbol.match]: T`). Distinguish by `identifier :`.
+            if (Check(TokenType.LEFT_BRACKET) && !(PeekNext().Type == TokenType.IDENTIFIER && PeekAt(2).Type == TokenType.COLON))
+            {
+                Advance(); // consume [
+                string raw = "";
+                while (!Check(TokenType.RIGHT_BRACKET) && !IsAtEnd())
+                    raw += Advance().Lexeme;
+                Consume(TokenType.RIGHT_BRACKET, "Expect ']' after computed member name.");
+                string computedName = raw.StartsWith("Symbol.") ? "@@" + raw["Symbol.".Length..] : "@@" + raw;
+                bool computedOptional = Match(TokenType.QUESTION);
+                string computedType;
+                if (Check(TokenType.LEFT_PAREN) || Check(TokenType.LESS))
+                {
+                    computedType = ParseMethodSignature();
+                }
+                else
+                {
+                    Consume(TokenType.COLON, "Expect ':' after computed member name.");
+                    computedType = ParseUnionType();
+                }
+                members.Add($"{computedName}{(computedOptional ? "?" : "")}: {computedType}");
+            }
             // Check for index signature: [key: string]: type
-            if (Check(TokenType.LEFT_BRACKET))
+            else if (Check(TokenType.LEFT_BRACKET))
             {
                 Advance(); // consume [
                 Consume(TokenType.IDENTIFIER, "Expect index signature key name.");

--- a/Parsing/Parser.cs
+++ b/Parsing/Parser.cs
@@ -420,6 +420,12 @@ public partial class Parser(List<Token> tokens, DecoratorMode decoratorMode = De
         return _tokens[_current + 1];
     }
 
+    private Token PeekAt(int offset)
+    {
+        int i = _current + offset;
+        return i >= _tokens.Count ? _tokens[^1] : _tokens[i];
+    }
+
     private Token Previous() => _tokens[_current - 1];
 
     // ============== AUTOMATIC SEMICOLON INSERTION (ASI) ==============

--- a/Parsing/Parser.cs
+++ b/Parsing/Parser.cs
@@ -504,7 +504,11 @@ public partial class Parser(List<Token> tokens, DecoratorMode decoratorMode = De
         Check(TokenType.TEMPLATE_FULL) ||  // for template literal types: `literal`
         Check(TokenType.TEMPLATE_HEAD) ||  // for template literal types: `prefix${
         Check(TokenType.TYPEOF) ||  // for typeof in type position: typeof someVar
-        Check(TokenType.KEYOF);  // for keyof operator: keyof T
+        Check(TokenType.KEYOF) ||  // for keyof operator: keyof T
+        Check(TokenType.READONLY) ||  // readonly array/tuple modifier: readonly T[], readonly [A, B]
+        Check(TokenType.TYPE_SYMBOL) || Check(TokenType.TYPE_BIGINT) ||  // symbol / bigint primitive types
+        Check(TokenType.SYMBOL) || Check(TokenType.BIGINT) ||  // `Symbol` / `BigInt` as type names
+        Check(TokenType.THIS);  // polymorphic `this` type
 
     // ============== GENERIC TYPE CLOSING BRACKET HANDLING ==============
     //

--- a/SharpTS.Tests/ParserTests/LibDtsParsingTests.cs
+++ b/SharpTS.Tests/ParserTests/LibDtsParsingTests.cs
@@ -100,6 +100,13 @@ public class LibDtsParsingTests
     }
 
     [Fact]
+    public void ComputedSymbolName_InsideInlineObjectType_Parses()
+    {
+        // `{ [Symbol.match](string: string): T }` — a computed member name inside an inline object type.
+        Assert.NotEmpty(Parse("interface R { match(m: { [Symbol.match](string: string): string; }): string; }"));
+    }
+
+    [Fact]
     public void SymbolAsTypeName_Parses()
     {
         Assert.NotEmpty(Parse("interface SymbolConstructor { readonly prototype: Symbol; }"));

--- a/SharpTS.Tests/ParserTests/LibDtsParsingTests.cs
+++ b/SharpTS.Tests/ParserTests/LibDtsParsingTests.cs
@@ -1,0 +1,80 @@
+using SharpTS.Parsing;
+using Xunit;
+
+namespace SharpTS.Tests.ParserTests;
+
+/// <summary>
+/// Parser coverage for dense `.d.ts` constructs that the bundled TypeScript lib files use
+/// (es5.d.ts / es2015.core.d.ts now parse clean). Part of #99 Phase A (parser hardening).
+/// </summary>
+public class LibDtsParsingTests
+{
+    private static System.Collections.Generic.List<Stmt> Parse(string source)
+    {
+        var parseResult = new Parser(new Lexer(source).ScanTokens()).Parse();
+        Assert.True(parseResult.IsSuccess,
+            parseResult.Diagnostics.Count > 0 ? parseResult.Diagnostics[0].ToString() : "parse failed");
+        return parseResult.Statements;
+    }
+
+    [Fact]
+    public void Interface_NamedAfterBuiltinSymbol_Parses()
+    {
+        // lib.d.ts declares `interface Symbol { ... }` / `interface BigInt { ... }`.
+        Assert.NotEmpty(Parse("interface Symbol { toString(): string; }"));
+        Assert.NotEmpty(Parse("interface BigInt { valueOf(): bigint; }"));
+    }
+
+    [Fact]
+    public void IndexSignature_WithTypeAliasKey_Parses()
+    {
+        // `[key: PropertyKey]: T` — a non-primitive (type-alias) index key.
+        Assert.NotEmpty(Parse("interface M { [key: PropertyKey]: number; }"));
+    }
+
+    [Fact]
+    public void Method_WithThisParameterAndRest_Parses()
+    {
+        // `call(this: Function, thisArg: any, ...argArray: any[]): any`.
+        Assert.NotEmpty(Parse("interface F { call(this: Function, thisArg: any, ...argArray: any[]): any; }"));
+    }
+
+    [Fact]
+    public void ReadonlyIndexSignature_Parses()
+    {
+        Assert.NotEmpty(Parse("interface S { readonly [index: number]: string; }"));
+    }
+
+    [Fact]
+    public void ReadonlyArrayType_Parses()
+    {
+        Assert.NotEmpty(Parse("interface T { raw: readonly string[]; }"));
+    }
+
+    [Fact]
+    public void ReadonlyArray_InsideUnion_Parses()
+    {
+        // `readonly` must bind to the array within a union member.
+        Assert.NotEmpty(Parse("interface T { raw: readonly string[] | ArrayLike<string>; }"));
+    }
+
+    [Fact]
+    public void ThisTypePredicate_Parses()
+    {
+        // `): this is readonly S[]` — a `this` type predicate.
+        Assert.NotEmpty(Parse("interface A<T> { every<S extends T>(p: (v: T) => v is S): this is readonly S[]; }"));
+    }
+
+    [Fact]
+    public void QualifiedTypeName_Parses()
+    {
+        // `Intl.CollatorOptions` — a namespace-qualified type reference.
+        Assert.NotEmpty(Parse("interface S { m(c?: Intl.CollatorOptions): number; }"));
+    }
+
+    [Fact]
+    public void SymbolAsTypeName_Parses()
+    {
+        Assert.NotEmpty(Parse("interface SymbolConstructor { readonly prototype: Symbol; }"));
+    }
+}

--- a/SharpTS.Tests/ParserTests/LibDtsParsingTests.cs
+++ b/SharpTS.Tests/ParserTests/LibDtsParsingTests.cs
@@ -73,6 +73,33 @@ public class LibDtsParsingTests
     }
 
     [Fact]
+    public void ComputedSymbolMethodName_Parses()
+    {
+        // `[Symbol.iterator](): Iterator<T>` — computed member name via a well-known symbol.
+        Assert.NotEmpty(Parse("interface I<T> { [Symbol.iterator](): Iterator<T>; }"));
+    }
+
+    [Fact]
+    public void ComputedSymbolPropertyName_ReadonlyAndLiteral_Parses()
+    {
+        Assert.NotEmpty(Parse("interface B { readonly [Symbol.toStringTag]: \"BigInt\"; }"));
+    }
+
+    [Fact]
+    public void ReadonlyTuple_InGenericArgument_Parses()
+    {
+        // `Iterable<readonly [K, V]>` — a readonly tuple as a generic type argument.
+        Assert.NotEmpty(Parse("interface I<K, V> { new (iterable?: Iterable<readonly [K, V]> | null): Map<K, V>; }"));
+    }
+
+    [Fact]
+    public void ContextualKeywordParameterName_InFunctionType_Parses()
+    {
+        // `set: Set<T>` — a function-type parameter named with a contextual keyword.
+        Assert.NotEmpty(Parse("interface S<T> { forEach(cb: (value: T, set: Set<T>) => void): void; }"));
+    }
+
+    [Fact]
     public void SymbolAsTypeName_Parses()
     {
         Assert.NotEmpty(Parse("interface SymbolConstructor { readonly prototype: Symbol; }"));

--- a/TypeSystem/TypeChecker.TypeParsing.cs
+++ b/TypeSystem/TypeChecker.TypeParsing.cs
@@ -39,6 +39,19 @@ public partial class TypeChecker
 
     private TypeInfo ToTypeInfoCore(string typeName)
     {
+        // `readonly` array/tuple modifier (preserved by ParseTypeAnnotation): mark the underlying
+        // array/tuple readonly. Other inner types ignore the modifier.
+        if (typeName.StartsWith("readonly ", StringComparison.Ordinal))
+        {
+            var inner = ToTypeInfo(typeName["readonly ".Length..].Trim());
+            return inner switch
+            {
+                TypeInfo.Array arr => arr with { IsReadonly = true },
+                TypeInfo.Tuple tup => tup with { IsReadonly = true },
+                _ => inner
+            };
+        }
+
         // Check for type parameter in current scope first
         var typeParam = _environment.GetTypeParameter(typeName);
         if (typeParam != null)


### PR DESCRIPTION
Part of #99 (lib.d.ts), **Phase A: parser hardening** — the scope we agreed to take first.

## Goal
Make SharpTS parse TypeScript's bundled lib `.d.ts` files. This is the prerequisite for loading them into the type checker, and the parser fixes are valuable for conformance broadly (dense `.d.ts` constructs appear in many conformance tests too).

## Result
**`es5.d.ts` (4,567 lines) and `es2015.core.d.ts` now parse with zero errors** (plus `es2015.symbol`/`promise`, `es2016.array.include`, `es2017.string`).

## Parser gaps fixed (each surfaced by stepping through es5.d.ts)
- Interface name may be a built-in keyword: `interface Symbol`, `interface BigInt`
- Index-signature key may be a type alias: `[key: PropertyKey]: T` (modeled as a string index)
- Explicit `this` parameter in interface/object methods: `call(this: Function, ...)`
- Rest/optional params in method signatures (`ParseMethodSignature`)
- Readonly index signature: `readonly [index: number]: T`
- `readonly` array/tuple modifier in any position incl. union members (`readonly string[] | ArrayLike<string>`) — handled in `ParsePrimaryType`; `ToTypeInfo` marks the array/tuple readonly
- `this` type predicate: `): this is readonly S[]`
- Qualified type names: `Intl.CollatorOptions`, `NodeJS.Timer`
- `Symbol` / `BigInt` usable as type names

## Verification
- Full unit suite green except the 2 pre-existing `PackagingTests` failures — **0 regressions** despite broad parser changes (qualified names, readonly, etc.). All 575 parser tests pass. Adds `LibDtsParsingTests` (9 tests).
- 0 conformance regressions.

## Remaining (continued Phase A, not this PR)
`es2015.collection`/`iterable`, `es2020.bigint`, `dom`, etc. still have gaps — notably computed member names using well-known symbols (`[Symbol.iterator]()`, `readonly [Symbol.toStringTag]`). Then Phases B/C (loader + checker wiring) per #99.
