### PR TITLE
fix: terminate type-checker hang on typeof inside composite types

### DIFF
--- a/SharpTS.Tests/SharedTests/KeyOfTypeOfTests.cs
+++ b/SharpTS.Tests/SharedTests/KeyOfTypeOfTests.cs
@@ -474,4 +474,61 @@ public class KeyOfTypeOfTests
     }
 
     #endregion
+
+    #region typeof in Composite Types (regression: parse hang)
+
+    // Regression for an infinite loop in the type checker: `typeof` was resolved BEFORE union/
+    // intersection were split in ToTypeInfoCore, so a typeof operand inside a composite (e.g.
+    // `typeof a & typeof b`) handed the whole "a & typeof b" string to the custom typeof-path
+    // parser, which spun forever on the first '&'/'|'. These exercise both composites end to end.
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void TypeOf_IntersectionOfTwoTypeOf(ExecutionMode mode)
+    {
+        var source = """
+            let a = { x: 1 };
+            let b = { y: 2 };
+            type AB = typeof a & typeof b;
+            let ab: AB = { x: 1, y: 2 };
+            console.log(ab.x);
+            console.log(ab.y);
+            """;
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("1\n2\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void TypeOf_UnionWithNull(ExecutionMode mode)
+    {
+        // Resolving `typeof a | null` to a real union (rather than hanging) means null is a genuine
+        // arm — so the object arm must be narrowed before member access.
+        var source = """
+            let a = { x: 1 };
+            type MaybeA = typeof a | null;
+            let v: MaybeA = a;
+            if (v !== null) {
+                console.log(v.x);
+            }
+            """;
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("1\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void TypeOf_IntersectionEnforcesBothMembers(ExecutionMode mode)
+    {
+        // The intersection must require members from BOTH operands — a value missing `y` is invalid.
+        var source = """
+            let a = { x: 1 };
+            let b = { y: 2 };
+            type AB = typeof a & typeof b;
+            let ab: AB = { x: 1 };
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.Run(source, mode));
+    }
+
+    #endregion
 }

--- a/TypeSystem/TypeChecker.TypeParsing.cs
+++ b/TypeSystem/TypeChecker.TypeParsing.cs
@@ -154,13 +154,6 @@ public partial class TypeChecker
             return new TypeInfo.KeyOf(innerType);
         }
 
-        // Handle typeof type operator: "typeof variableName"
-        if (typeName.StartsWith("typeof "))
-        {
-            string path = typeName[7..].Trim();
-            return EvaluateTypeOf(path);
-        }
-
         // Handle infer keyword for conditional types: "infer U"
         if (typeName.StartsWith("infer "))
         {
@@ -209,6 +202,18 @@ public partial class TypeChecker
                 var types = parts.Select(ToTypeInfo).ToList();
                 return SimplifyIntersection(types);
             }
+        }
+
+        // Handle typeof type operator: "typeof variableName".
+        // MUST come AFTER the union/intersection/conditional splits above: `typeof` binds tighter
+        // than `&`/`|`, so `typeof A & typeof B` is `(typeof A) & (typeof B)` and the composite must
+        // be split first. Unlike `keyof` (which recurses through ToTypeInfo and so splits naturally),
+        // `typeof` resolves via the custom ParseTypeOfPath — handed an un-split composite it would
+        // spin forever on the first `&`/`|`. Splitting first hands EvaluateTypeOf a clean entity path.
+        if (typeName.StartsWith("typeof "))
+        {
+            string path = typeName[7..].Trim();
+            return EvaluateTypeOf(path);
         }
 
         // Handle inline object types: "{ x: number; y?: string }"
@@ -1589,6 +1594,13 @@ public partial class TypeChecker
 
         while (i < path.Length)
         {
+            // Defense-in-depth: a typeof path should only ever contain identifiers, '.', and '[...]'.
+            // If a character matches none of the branches below (e.g. a stray '&'/'|' from an un-split
+            // composite type), `i` would not advance and the loop would spin forever — a hard checker
+            // hang. Record the start and break if an iteration consumes nothing, so malformed input
+            // degrades to a partial parse instead of locking up.
+            int iterStart = i;
+
             // Skip leading whitespace
             while (i < path.Length && char.IsWhiteSpace(path[i])) i++;
             if (i >= path.Length) break;
@@ -1645,6 +1657,9 @@ public partial class TypeChecker
                 while (i < path.Length && char.IsWhiteSpace(path[i])) i++;
                 if (i < path.Length && path[i] == ']') i++; // skip ]
             }
+
+            // No branch advanced past this iteration's start — stop rather than spin.
+            if (i == iterStart) break;
         }
 
         return result;


### PR DESCRIPTION
Fixes a type-checker hang when `typeof` appears inside composite (intersection/union) type annotations.

Standalone fix; the RuntimeValue-migration PR stack is based on this branch.