### PR TITLE
feat: add CompilationService — public embedding API for compile-and-run

### DIFF
--- a/Compilation/CompilationService.cs
+++ b/Compilation/CompilationService.cs
@@ -1,0 +1,261 @@
+// =============================================================================
+// CompilationService.cs - Public embedding API for compile-and-run (issue #171)
+// =============================================================================
+//
+// Library-consumable facade over the Lexer → Parser → TypeChecker → ILCompiler
+// pipeline. Unlike the CLI flow in Program.cs, this path never writes to
+// Console, never calls Environment.Exit, and never touches the file system:
+// source comes in as a string, the assembly comes out as PE bytes, and all
+// lex/parse/type/compile failures come back as structured Diagnostics.
+//
+// Primary consumer: hosts that embed SharpTS (e.g. the website playground's
+// compiled mode), which compile small sources per request and execute the
+// result in-process with captured output.
+//
+// =============================================================================
+
+using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.Loader;
+using System.Text.RegularExpressions;
+using SharpTS.Diagnostics;
+using SharpTS.Diagnostics.Exceptions;
+using SharpTS.Parsing;
+using SharpTS.TypeSystem;
+
+namespace SharpTS.Compilation;
+
+/// <summary>
+/// Options for <see cref="CompilationService.Compile"/>.
+/// </summary>
+/// <param name="DecoratorMode">Decorator dialect to parse/compile with.</param>
+/// <param name="AssemblyName">
+/// Simple name for the emitted assembly. Defaults to a unique GUID-suffixed name so
+/// repeated compiles loaded into one host process never collide on simple-name
+/// assembly identity.
+/// </param>
+/// <param name="FileName">
+/// Logical file name used as the <see cref="SourceLocation.FilePath"/> on diagnostics.
+/// Purely informational — nothing is read from or written to this path.
+/// </param>
+public sealed record CompileOptions(
+    DecoratorMode DecoratorMode = DecoratorMode.None,
+    string? AssemblyName = null,
+    string FileName = "input.ts");
+
+/// <summary>
+/// Result of <see cref="CompilationService.Compile"/>.
+/// </summary>
+/// <param name="Success">True when an assembly was produced with no error diagnostics.</param>
+/// <param name="Diagnostics">
+/// All diagnostics from the pipeline. On failure, contains at least one
+/// <see cref="DiagnosticSeverity.Error"/>; on success, may contain warnings.
+/// </param>
+/// <param name="AssemblyBytes">The emitted PE image, or null on failure.</param>
+/// <param name="CompileTimeMs">Wall-clock time for the full pipeline (lex through PE emit).</param>
+/// <param name="RequiredSharpTSRuntimeReasons">
+/// Non-empty when the program uses a feature whose emitted IL late-binds into
+/// SharpTS.dll at runtime (eval, Proxy, Intl, vm, dns, @DotNetType dynamic events).
+/// Irrelevant for in-process execution via <see cref="CompilationService.Execute"/> —
+/// SharpTS.dll is by definition loaded — but a host that ships the DLL to run
+/// elsewhere must co-locate SharpTS.dll when this is non-empty.
+/// </param>
+public sealed record CompileResult(
+    bool Success,
+    IReadOnlyList<Diagnostic> Diagnostics,
+    byte[]? AssemblyBytes,
+    long CompileTimeMs,
+    IReadOnlyCollection<string> RequiredSharpTSRuntimeReasons);
+
+/// <summary>
+/// Result of <see cref="CompilationService.Execute"/>.
+/// </summary>
+/// <param name="Success">True when the program ran to completion without an unhandled exception.</param>
+/// <param name="Error">Message of the unhandled guest exception, or null on success.</param>
+/// <param name="ExecuteTimeMs">Wall-clock execution time.</param>
+public sealed record RunResult(
+    bool Success,
+    string? Error,
+    long ExecuteTimeMs);
+
+/// <summary>
+/// Programmatic compile-and-run facade for embedding SharpTS as a library.
+/// </summary>
+public static class CompilationService
+{
+    /// <summary>
+    /// Compiles a TypeScript source string to an in-memory .NET assembly.
+    /// Never writes to <see cref="Console"/>, never calls <see cref="Environment.Exit"/>,
+    /// never touches the file system. All source-input problems (lex, parse, type,
+    /// compile) are returned as <see cref="CompileResult.Diagnostics"/>, with the same
+    /// multi-error recovery behavior as the CLI (<c>CheckWithRecovery</c>) and the same
+    /// <c>// @ts-ignore</c> / <c>// @ts-expect-error</c> line-directive handling.
+    /// </summary>
+    public static CompileResult Compile(string source, CompileOptions? options = null)
+    {
+        options ??= new CompileOptions();
+        var assemblyName = options.AssemblyName ?? $"ts_{Guid.NewGuid():N}";
+        var stopwatch = Stopwatch.StartNew();
+
+        CompileResult Fail(IEnumerable<Diagnostic> diagnostics) =>
+            new(false, diagnostics.ToList(), null, stopwatch.ElapsedMilliseconds, Array.Empty<string>());
+
+        try
+        {
+            // Lex. The Lexer reports errors by throwing raw Exceptions with the line
+            // embedded in the message ("... at line N") — convert to a ParseError
+            // diagnostic instead of letting it escape.
+            Lexer lexer;
+            List<Token> tokens;
+            try
+            {
+                lexer = new Lexer(source);
+                tokens = lexer.ScanTokens();
+            }
+            catch (Exception ex)
+            {
+                return Fail([LexErrorToDiagnostic(ex.Message, options.FileName)]);
+            }
+
+            // Parse, with recovery — surfaces all parse errors, not just the first.
+            var parser = new Parser(tokens, options.DecoratorMode);
+            var parseResult = parser.Parse();
+            if (!parseResult.IsSuccess)
+                return Fail(parseResult.Diagnostics);
+
+            // Type check, with recovery, honoring // @ts-ignore / @ts-expect-error.
+            var checker = new TypeChecker().WithFilePath(options.FileName);
+            checker.SetDecoratorMode(options.DecoratorMode);
+            var typeResult = checker.CheckWithRecovery(parseResult.Statements);
+            var diagnostics = TypeCheckPolicy.ApplyLineDirectives(typeResult.Diagnostics, lexer.Pragmas);
+            if (diagnostics.Any(d => d.Severity == DiagnosticSeverity.Error))
+                return Fail(diagnostics);
+
+            var deadCodeInfo = new DeadCodeAnalyzer(typeResult.TypeMap).Analyze(parseResult.Statements);
+
+            var compiler = new ILCompiler(assemblyName);
+            compiler.SetDecoratorMode(options.DecoratorMode);
+            compiler.Compile(parseResult.Statements, typeResult.TypeMap, deadCodeInfo);
+            var bytes = compiler.SaveToBytes();
+
+            stopwatch.Stop();
+            return new CompileResult(
+                Success: true,
+                Diagnostics: diagnostics,
+                AssemblyBytes: bytes,
+                CompileTimeMs: stopwatch.ElapsedMilliseconds,
+                RequiredSharpTSRuntimeReasons: compiler.RequiredSharpTSRuntimeReasons);
+        }
+        catch (SharpTSException ex)
+        {
+            return Fail([ex.Diagnostic]);
+        }
+        catch (Exception ex)
+        {
+            // Internal compiler defect surfaced by this source. A web host is better
+            // served by a CompileError diagnostic than an exception across the API.
+            return Fail([Diagnostic.CompileError(ex.Message)]);
+        }
+    }
+
+    /// <summary>
+    /// Loads a compiled assembly (from <see cref="CompileResult.AssemblyBytes"/>) into a
+    /// collectible <see cref="AssemblyLoadContext"/> and invokes its entry point in-process,
+    /// routing the program's <see cref="Console.Out"/>/<see cref="Console.Error"/> writes to
+    /// <paramref name="output"/>. An unhandled guest exception is returned as a failed
+    /// <see cref="RunResult"/>, not thrown.
+    ///
+    /// <para><b>Console contract:</b> emitted IL writes directly to <see cref="Console"/>;
+    /// this method swaps <see cref="Console.SetOut"/>/<see cref="Console.SetError"/> for the
+    /// duration of the run and restores them afterward. That swap is process-global — this
+    /// method is safe for one execution at a time per process (e.g. a process-per-request
+    /// worker), not for concurrent in-process tenants.</para>
+    ///
+    /// <para><b>Cancellation:</b> <paramref name="cancellationToken"/> trips the emitted
+    /// program's cooperative-cancel flag (<c>$Runtime._cancelRequested</c>), which every loop
+    /// backedge polls — a runaway loop unwinds itself without killing the host. There is no
+    /// hard wall-clock kill; the host owns that.</para>
+    ///
+    /// <para><b>Limitation:</b> guest <c>process.exit(n)</c> compiles to
+    /// <see cref="Environment.Exit"/> and terminates the host process.</para>
+    /// </summary>
+    public static RunResult Execute(byte[] assemblyBytes, TextWriter output,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(assemblyBytes);
+        ArgumentNullException.ThrowIfNull(output);
+
+        var alc = new AssemblyLoadContext($"SharpTS.Execute_{Guid.NewGuid():N}", isCollectible: true);
+        var stopwatch = Stopwatch.StartNew();
+        try
+        {
+            using var stream = new MemoryStream(assemblyBytes, writable: false);
+            var assembly = alc.LoadFromStream(stream);
+
+            var programType = assembly.GetType("$Program")
+                ?? throw new InvalidOperationException("Compiled assembly has no $Program type");
+            var mainMethod = programType.GetMethod("Main", BindingFlags.Public | BindingFlags.Static)
+                ?? throw new InvalidOperationException("$Program has no public static Main method");
+
+            // Cooperative cancellation: the emitted $Runtime polls _cancelRequested at
+            // every loop backedge (issue #74).
+            using var cancelRegistration = cancellationToken.CanBeCanceled
+                ? cancellationToken.Register(() =>
+                {
+                    try
+                    {
+                        assembly.GetType("$Runtime")
+                            ?.GetField("_cancelRequested", BindingFlags.Public | BindingFlags.Static)
+                            ?.SetValue(null, true);
+                    }
+                    catch { /* best-effort */ }
+                })
+                : default;
+
+            var priorOut = Console.Out;
+            var priorErr = Console.Error;
+            Console.SetOut(output);
+            Console.SetError(output);
+            try
+            {
+                mainMethod.Invoke(null, null);
+                stopwatch.Stop();
+                return new RunResult(true, null, stopwatch.ElapsedMilliseconds);
+            }
+            catch (TargetInvocationException tie) when (tie.InnerException is not null)
+            {
+                stopwatch.Stop();
+                return new RunResult(false, tie.InnerException.Message, stopwatch.ElapsedMilliseconds);
+            }
+            finally
+            {
+                Console.SetOut(priorOut);
+                Console.SetError(priorErr);
+            }
+        }
+        catch (Exception ex)
+        {
+            stopwatch.Stop();
+            return new RunResult(false, ex.Message, stopwatch.ElapsedMilliseconds);
+        }
+        finally
+        {
+            // Best-effort: actual collection waits for the GC, and statics pinned by
+            // the default ALC (timers, event-loop threads) can delay or prevent it.
+            alc.Unload();
+        }
+    }
+
+    /// <summary>
+    /// Converts a thrown Lexer message into a ParseError diagnostic, recovering the
+    /// line number from the conventional "... at line N" message suffix when present.
+    /// </summary>
+    private static Diagnostic LexErrorToDiagnostic(string message, string fileName)
+    {
+        var match = Regex.Match(message, @"\bat line (\d+)\b");
+        SourceLocation? location = match.Success && int.TryParse(match.Groups[1].Value, out var line)
+            ? new SourceLocation(fileName, line)
+            : null;
+        return Diagnostic.ParseError(message, location);
+    }
+}

--- a/SharpTS.Tests/Compilation/CompilationServiceTests.cs
+++ b/SharpTS.Tests/Compilation/CompilationServiceTests.cs
@@ -1,0 +1,212 @@
+using SharpTS.Compilation;
+using SharpTS.Diagnostics;
+using SharpTS.Parsing;
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.Compilation;
+
+/// <summary>
+/// Defines a serial collection for <see cref="CompilationService"/> tests.
+/// <see cref="CompilationService.Execute"/> swaps <see cref="Console.SetOut"/>
+/// process-globally for the duration of a run; running these in parallel with
+/// other collections would leak their console output into the captured writer
+/// (and vice versa through the test suite's AsyncLocal console proxies).
+/// </summary>
+[CollectionDefinition("CompilationService", DisableParallelization = true)]
+public class CompilationServiceCollection
+{
+}
+
+[Collection("CompilationService")]
+public class CompilationServiceTests
+{
+    // -------------------------------------------------------------------------
+    // Compile
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void Compile_ValidSource_ReturnsAssemblyBytes()
+    {
+        var result = CompilationService.Compile("console.log(\"hello\");");
+
+        Assert.True(result.Success);
+        Assert.NotNull(result.AssemblyBytes);
+        Assert.NotEmpty(result.AssemblyBytes!);
+        Assert.DoesNotContain(result.Diagnostics, d => d.Severity == DiagnosticSeverity.Error);
+        Assert.True(result.CompileTimeMs >= 0);
+    }
+
+    [Fact]
+    public void Compile_TypeError_ReturnsDiagnosticWithLocation()
+    {
+        var result = CompilationService.Compile("let x: number = \"not a number\";");
+
+        Assert.False(result.Success);
+        Assert.Null(result.AssemblyBytes);
+        var error = Assert.Single(result.Diagnostics, d => d.Severity == DiagnosticSeverity.Error);
+        Assert.NotNull(error.Location);
+        Assert.Equal(1, error.Line);
+        Assert.False(string.IsNullOrWhiteSpace(error.Message));
+    }
+
+    [Fact]
+    public void Compile_MultipleTypeErrors_AllSurface()
+    {
+        // Recovery mode: both independent errors must come back, not just the first.
+        var result = CompilationService.Compile(
+            "let a: number = \"one\";\nlet b: boolean = 42;");
+
+        Assert.False(result.Success);
+        Assert.Equal(2, result.Diagnostics.Count(d => d.Severity == DiagnosticSeverity.Error));
+    }
+
+    [Fact]
+    public void Compile_ParseError_ReturnsDiagnosticsWithoutThrowing()
+    {
+        var result = CompilationService.Compile("let x = ;");
+
+        Assert.False(result.Success);
+        Assert.Null(result.AssemblyBytes);
+        Assert.Contains(result.Diagnostics, d => d.Severity == DiagnosticSeverity.Error);
+    }
+
+    [Fact]
+    public void Compile_LexError_ReturnsParseErrorDiagnosticWithLine()
+    {
+        // Legacy octal literal — the Lexer throws a raw Exception with "at line N"
+        // in the message; the facade must convert it to a located diagnostic.
+        var result = CompilationService.Compile("let x = 0755;");
+
+        Assert.False(result.Success);
+        var error = Assert.Single(result.Diagnostics);
+        Assert.Equal(DiagnosticSeverity.Error, error.Severity);
+        Assert.NotNull(error.Location);
+        Assert.Equal(1, error.Line);
+    }
+
+    [Fact]
+    public void Compile_TsIgnore_SuppressesError()
+    {
+        var result = CompilationService.Compile(
+            "// @ts-ignore\nlet x: number = \"suppressed\";\nconsole.log(x);");
+
+        Assert.True(result.Success);
+        Assert.NotNull(result.AssemblyBytes);
+    }
+
+    [Fact]
+    public void Compile_FileNameOption_StampsDiagnosticLocations()
+    {
+        var result = CompilationService.Compile(
+            "let x: number = \"oops\";",
+            new CompileOptions(FileName: "playground.ts"));
+
+        Assert.False(result.Success);
+        var error = result.Diagnostics.First(d => d.Severity == DiagnosticSeverity.Error);
+        Assert.Equal("playground.ts", error.FilePath);
+    }
+
+    [Fact]
+    public void Compile_NeverWritesToConsole()
+    {
+        using var capture = AsyncLocalConsoleRedirector.Capture();
+
+        CompilationService.Compile("console.log(\"ok\");");
+        CompilationService.Compile("let x: number = \"type error\";");
+        CompilationService.Compile("let x = ;");
+        CompilationService.Compile("let x = 0755;");
+
+        Assert.Equal("", capture.GetOutput());
+    }
+
+    [Fact]
+    public void Compile_PlainProgram_HasNoSharpTSRuntimeRequirement()
+    {
+        var result = CompilationService.Compile("console.log(1 + 2);");
+
+        Assert.True(result.Success);
+        Assert.Empty(result.RequiredSharpTSRuntimeReasons);
+    }
+
+    // -------------------------------------------------------------------------
+    // Execute
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void Execute_CapturesOutputToWriter()
+    {
+        // The acceptance scenario from issue #171, verbatim shape.
+        var result = CompilationService.Compile(
+            "console.log(\"hello from compiled\");",
+            new CompileOptions(DecoratorMode.None));
+        Assert.True(result.Success);
+
+        var sw = new StringWriter();
+        var run = CompilationService.Execute(result.AssemblyBytes!, sw);
+
+        Assert.True(run.Success);
+        Assert.Null(run.Error);
+        Assert.True(run.ExecuteTimeMs >= 0);
+        Assert.Equal("hello from compiled\n", sw.ToString().Replace("\r\n", "\n"));
+    }
+
+    [Fact]
+    public void Execute_GuestThrow_ReturnsFailedRunResultWithoutThrowing()
+    {
+        var result = CompilationService.Compile("throw new Error(\"boom\");");
+        Assert.True(result.Success);
+
+        var sw = new StringWriter();
+        var run = CompilationService.Execute(result.AssemblyBytes!, sw);
+
+        Assert.False(run.Success);
+        Assert.NotNull(run.Error);
+        Assert.Contains("boom", run.Error);
+    }
+
+    [Fact]
+    public void Execute_RestoresConsoleAfterRun()
+    {
+        var priorOut = Console.Out;
+        var priorErr = Console.Error;
+
+        var result = CompilationService.Compile("console.log(\"x\");");
+        CompilationService.Execute(result.AssemblyBytes!, new StringWriter());
+
+        Assert.Same(priorOut, Console.Out);
+        Assert.Same(priorErr, Console.Error);
+    }
+
+    [Fact]
+    public async Task Execute_InfiniteLoop_CancellationUnwindsCooperatively()
+    {
+        var result = CompilationService.Compile("let i = 0;\nwhile (true) { i++; }");
+        Assert.True(result.Success);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(1));
+        var sw = new StringWriter();
+
+        // WaitAsync guards the test against the cancel hook silently not working —
+        // a hang here would otherwise pin the testhost until the runner's timeout.
+        var run = await Task.Run(() => CompilationService.Execute(result.AssemblyBytes!, sw, cts.Token))
+            .WaitAsync(TimeSpan.FromSeconds(15));
+        Assert.False(run.Success);
+    }
+
+    [Fact]
+    public void Execute_RepeatedCompileAndRun_NoAssemblyIdentityCollisions()
+    {
+        for (var i = 0; i < 5; i++)
+        {
+            var result = CompilationService.Compile($"console.log({i});");
+            Assert.True(result.Success);
+
+            var sw = new StringWriter();
+            var run = CompilationService.Execute(result.AssemblyBytes!, sw);
+
+            Assert.True(run.Success);
+            Assert.Equal($"{i}\n", sw.ToString().Replace("\r\n", "\n"));
+        }
+    }
+}

--- a/docs/plans/issue-171-embedding-api.md
+++ b/docs/plans/issue-171-embedding-api.md
@@ -1,0 +1,180 @@
+# Plan: Public embedding API — programmatic compile-and-run (issue #171)
+
+## Goal
+
+A public, library-consumable facade that compiles a TypeScript source string to an
+in-memory assembly and executes it in-process, with structured diagnostics and zero
+Console writes / `Environment.Exit` on the library path. Consumer: the sharpts-www
+playground worker (process-per-request, stdout is a JSON protocol channel).
+
+## What already exists (no new capability needed)
+
+| Need | Existing piece |
+|------|----------------|
+| In-memory PE bytes | `ILCompiler.SaveToBytes()` (`Compilation/ILCompiler.cs:1202`) |
+| In-process execute | `Assembly.Load(bytes)` → `$Program.Main` invoke — proven in `TestHarness.RunCompiledInProcess` and `Test262Runner.cs:485` |
+| Structured parse errors | `Parser.Parse()` → `ParseResult` (`Diagnostics`, `IsSuccess`, `HitErrorLimit`) |
+| Structured type errors | `TypeChecker.CheckWithRecovery()` → `TypeCheckDiagnosticResult` |
+| Diagnostic shape | `Diagnostics/Diagnostic.cs` — severity, code, message, `SourceLocation`, `TsCode` |
+| `@ts-ignore` handling | `TypeCheckPolicy.ApplyLineDirectives(diags, lexer.Pragmas)` (mirrors CLI) |
+
+The work is purely assembling these into a facade — the same pipeline the CLI's
+`CompileSingleFile` (`Program.cs:526`) runs, minus the Console/Exit/file-system parts.
+
+## New files
+
+### 1. `Compilation/CompilationService.cs` (+ result records, same file or sibling)
+
+```csharp
+namespace SharpTS.Compilation;
+
+public sealed record CompileOptions(
+    DecoratorMode DecoratorMode = DecoratorMode.None,
+    string? AssemblyName = null,     // default: "ts_" + Guid — avoids simple-name
+                                     // collisions on repeated Assembly loads in one host
+    string FileName = "input.ts");   // used for diagnostic FilePath only
+
+public sealed record CompileResult(
+    bool Success,
+    IReadOnlyList<Diagnostic> Diagnostics,
+    byte[]? AssemblyBytes,
+    long CompileTimeMs,
+    IReadOnlyCollection<string> RequiredSharpTSRuntimeReasons);
+
+public sealed record RunResult(
+    bool Success,
+    string? Error,        // unhandled guest exception message, null on success
+    long ExecuteTimeMs);
+
+public static class CompilationService
+{
+    public static CompileResult Compile(string source, CompileOptions? options = null);
+    public static RunResult Execute(byte[] assemblyBytes, TextWriter output,
+                                    CancellationToken cancellationToken = default);
+}
+```
+
+**`Compile` pipeline** (clone of `TestHarness.RunCompiledInProcess` lines 271–290, with
+recovery-mode checking from `Program.cs:537–552`):
+
+1. `Stopwatch.StartNew()`.
+2. **Lex** — `new Lexer(source).ScanTokens()`. The Lexer throws raw `Exception`
+   with "… at line N" embedded (`Parsing/Lexer.cs`); catch it and convert to a
+   `Diagnostic.ParseError` (regex the trailing `at line (\d+)` into a
+   `SourceLocation` when present; message-only otherwise). Do **not** refactor the
+   Lexer to diagnostics in this PR — out of scope.
+3. **Parse** — `new Parser(tokens, options.DecoratorMode).Parse()`. On
+   `!IsSuccess`, return failure with `parseResult.Diagnostics`.
+4. **Type check** — `new TypeChecker().WithFilePath(options.FileName)` +
+   `SetDecoratorMode`, then `CheckWithRecovery(statements)`. Apply
+   `TypeCheckPolicy.ApplyLineDirectives(result.Diagnostics, lexer.Pragmas)` so
+   `// @ts-ignore` works like the CLI. Any `Error`-severity diagnostic → failure
+   (return all diagnostics, including warnings).
+5. **Dead code** — `new DeadCodeAnalyzer(typeMap).Analyze(statements)`.
+6. **Compile** — `new ILCompiler(assemblyName)` + `SetDecoratorMode` + `Compile(...)`
+   + `SaveToBytes()`. Catch `SharpTSException` → its `.Diagnostic`; catch other
+   `Exception` → `Diagnostic.CompileError(ex.Message)`. (This is the no-Console,
+   no-Exit replacement for the CLI's catch blocks at `Program.cs:397–415`.)
+7. Populate `RequiredSharpTSRuntimeReasons` from
+   `ILCompiler.RequiredSharpTSRuntimeReasons` (`ILCompiler.cs:95`) — irrelevant for
+   in-process execution (SharpTS.dll is by definition loaded), but lets a host that
+   ships DLLs know when to co-locate the runtime.
+8. Success → `CompileResult(true, warnings, bytes, elapsed, reasons)`.
+
+Entire body wrapped so **no exception escapes for source-input problems**; only
+genuine internal bugs (e.g. `InvalidOperationException` from a compiler defect) may
+propagate — debatable, but swallowing those into a CompileError diagnostic (step 6's
+catch-all) is friendlier for a web host, so do that.
+
+**`Execute`**:
+
+1. Load via a **collectible `AssemblyLoadContext`** (`isCollectible: true`,
+   `LoadFromStream(new MemoryStream(bytes))`), not `Assembly.Load` — issue asks for
+   long-lived-host friendliness. `Type.GetType("…, SharpTS")` in emitted IL still
+   resolves through the default ALC where SharpTS.dll lives. Call `Unload()` after
+   (best-effort; document that pinned statics can delay collection).
+2. Resolve `$Program` / public static `Main` (same error messages as TestHarness).
+3. **Console contract**: emitted IL writes to `Console.Out`/`Console.Error`
+   directly. `Execute` swaps `Console.SetOut(output)` (and `SetError(output)`) in a
+   `try/finally` restore. Document explicitly: this is **process-global** — correct
+   for a process-per-request worker; not safe for concurrent in-process tenants.
+   (The tests' `AsyncLocalConsoleRedirector` solves that with private-field
+   reflection; promoting it into the library is a documented follow-up if anyone
+   needs concurrent hosting.) This also confirms the issue's question: a caller
+   wrapping `Console.SetOut` themselves works — `Execute` just formalizes it.
+4. **Cancellation**: register `cancellationToken` → set the emitted
+   `$Runtime._cancelRequested` static field (the issue-#74 cooperative-cancel hook
+   TestHarness already uses at line 326). Loops then unwind without killing the host.
+5. Invoke; unwrap `TargetInvocationException`; an unhandled guest exception →
+   `RunResult(false, message, elapsed)` rather than a thrown exception. Time with
+   `Stopwatch`.
+6. **Documented limitations** (XML docs on `Execute`):
+   - guest `process.exit(n)` compiles to `Environment.Exit` → terminates the host
+     process (the playground's sandbox model already tolerates this);
+   - no wall-clock timeout inside `Execute` — host owns that (use the
+     CancellationToken or kill the process);
+   - output goes through `Console` redirection, so a caller-supplied capping writer
+     sees everything including `Console.Error`.
+
+### 2. `SharpTS.Tests/CompilationServiceTests.cs`
+
+Must live in a **non-parallel xUnit collection** (`[Collection]` with
+`DisableParallelization = true`): `Execute`'s `Console.SetOut` swap would otherwise
+fight the test suite's `AsyncLocalConsoleRedirector` proxies and sibling tests'
+output would leak into the captured writer.
+
+Test cases:
+- Acceptance round-trip exactly as written in the issue: compile `console.log` source
+  with `DecoratorMode.None`, execute into a `StringWriter`, assert output.
+- Type error → `Success == false`, `AssemblyBytes == null`, diagnostic has location
+  + message; multiple errors surface (recovery mode, not first-error-throw).
+- Parse error and lexer error (e.g. legacy octal) → ParseError diagnostics, no throw.
+- `// @ts-ignore` suppresses the flagged line's error (line-directive parity with CLI).
+- Guest `throw` → `RunResult.Success == false` with the error message; host survives.
+- No Console pollution: wrap `Compile` of a failing source in a console capture,
+  assert nothing was written.
+- `CompileTimeMs`/`ExecuteTimeMs` populated (>= 0).
+- Cancellation: infinite-loop source + pre/quickly-cancelled token → `Execute`
+  returns (cooperative cancel) instead of hanging.
+- Repeated `Compile`+`Execute` in one process (10×) — unique assembly names, no
+  simple-name collision, ALC unload doesn't break subsequent runs.
+
+## Explicitly out of scope (state in PR description)
+
+- **Modules / multi-file** — single source string only, matching the issue.
+- **CLI refactor** — `Program.cs` keeps its own flow; runtimeconfig generation,
+  SharpTS.dll copy, bundling, NuGet pack are CLI-only concerns. A later cleanup can
+  rebase `CompileSingleFile` onto the service, but mixing it in here risks behavior
+  drift in `--compile`.
+- **TestHarness refactor** — its in-process path predates the service and has
+  test-specific needs (AsyncLocal capture, timeout contract). Don't touch.
+- **IL-text / decompiled output tab** — the issue's nice-to-have; defer. (Note for
+  the follow-up: `ILVerifier` + `System.Reflection.Metadata` reader over
+  `SaveToBytes()` output is the likely shape.)
+- **Lexer diagnostics refactor** — facade converts thrown messages; making the Lexer
+  recovery-based is independent work.
+
+## Perf note (cold-start, requirement 6)
+
+`SaveToBytes` → `Assembly.Load` does a PE serialize/deserialize round-trip
+(~15 ms per docs/plans/runtime-tree-shaking.md measurements — fine for the request
+path). If that ever matters, `ILCompiler` already has an `inMemoryOnly` mode
+(`GetEmittedAssembly()`, ILCompiler.cs:251–264) that skips PE emit entirely — a
+`CompileAndExecute(source, options, output)` convenience could use it later, but the
+issue explicitly wants the bytes handoff for the timing-comparison UI, so the
+two-call API stays primary.
+
+## Suggested commit sequence
+
+1. `feat: add CompilationService.Compile — structured-diagnostic compile-to-bytes facade` (+ Compile-side tests)
+2. `feat: add CompilationService.Execute — in-process run via collectible ALC` (+ Execute-side tests, acceptance round-trip)
+3. (optional) `docs: README/STATUS blurb for the embedding API`
+
+## Verification
+
+- `dotnet build` clean; `dotnet test --filter "FullyQualifiedName~CompilationService"`.
+- Full `dotnet test` once at the end (pipe to file per repo convention) — the
+  Console.SetOut swap in a serial collection must not destabilize parallel
+  compiled-mode tests.
+- Smoke: tiny console host project referencing SharpTS.csproj running the issue's
+  acceptance snippet (manual, not committed).


### PR DESCRIPTION
Closes #171

Promotes the TestHarness compile-to-bytes + in-process-execute pattern into a public facade alongside `ILCompiler`, so embedding hosts (the website playground's compiled mode) can compile and run TypeScript programmatically.

## API

```csharp
var result = CompilationService.Compile(source, new CompileOptions(DecoratorMode.None));
if (result.Success)
{
    var sw = new StringWriter();
    var run = CompilationService.Execute(result.AssemblyBytes!, sw);
    // sw.ToString() == the program's console output
}
else
{
    // result.Diagnostics has locations + messages
}
```

## `Compile(source, options)` → `CompileResult`

- Pipeline: Lexer → Parser (recovery) → `TypeChecker.CheckWithRecovery` (with `// @ts-ignore` / `@ts-expect-error` line-directive handling, matching the CLI) → `DeadCodeAnalyzer` → `ILCompiler` → `SaveToBytes()` (which already existed — no `Save(Stream)` overload needed).
- **No Console writes, no `Environment.Exit`, no file system** anywhere on the path. All lex/parse/type/compile failures come back as structured `Diagnostic`s; raw Lexer exceptions are converted to located ParseError diagnostics.
- `CompileResult` carries the PE bytes, `CompileTimeMs`, and `RequiredSharpTSRuntimeReasons` (non-empty when the program uses eval/Proxy/Intl/vm/dns/@DotNetType dynamic events — moot for in-process execution, but tells DLL-shipping hosts when to co-locate SharpTS.dll).
- Default assembly name is GUID-suffixed so repeated compiles in one host never collide on simple-name identity.

## `Execute(bytes, output, cancellationToken)` → `RunResult`

- Loads into a **collectible `AssemblyLoadContext`** and invokes `$Program.Main` in-process.
- **Console contract** (answering the issue's question): emitted IL writes to `Console` directly; `Execute` swaps `Console.SetOut`/`SetError` to the caller's `TextWriter` for the duration and restores them in `finally`. The swap is process-global — safe for a process-per-request worker, not for concurrent in-process tenants.
- **Cancellation**: the token trips the emitted `$Runtime._cancelRequested` cooperative-cancel flag (issue #74 hook), so runaway loops unwind without killing the host. No hard wall-clock kill — the host owns that.
- Unhandled guest exceptions return as a failed `RunResult`, not a thrown exception.
- Documented limitation: guest `process.exit(n)` compiles to `Environment.Exit` and terminates the host process.

## Out of scope (per the plan in `docs/plans/issue-171-embedding-api.md`)

Modules/multi-file, CLI refactor onto the service, TestHarness refactor, the IL-text "show compiled output" nice-to-have, and Lexer diagnostics refactor.

## Testing

- 14 new tests in `CompilationServiceTests` (serialized xUnit collection, since the Console swap is process-global): the issue's acceptance round-trip verbatim, multi-error recovery, lexer/parse/type diagnostics with locations, `@ts-ignore` parity, Console-silence during failing compiles, guest-throw handling, Console restoration, cooperative cancellation of an infinite loop, and 5× repeated compile-and-run cycles.
- Full suite: 10,472/10,474 pass. The two failures (`Pack_WithoutPackageJson_*`) are pre-existing — they fail identically on a clean baseline worktree without this change.