### PR TITLE
perf: native CallV2 for core function types + span dispatch in Execution/ (migration PR 2/4)

### DIFF
--- a/Execution/Interpreter.Async.cs
+++ b/Execution/Interpreter.Async.cs
@@ -153,7 +153,7 @@ public partial class Interpreter
 
                 // Call the async iterator function
                 if (asyncIteratorFn is ISharpTSCallable callable)
-                    return callable.Call(this, []);
+                    return callable.CallV2(this, []).ToObject();
             }
         }
         else if (iterable is SharpTSInstance inst)
@@ -162,7 +162,7 @@ public partial class Interpreter
             if (asyncIteratorFn != null)
             {
                 if (asyncIteratorFn is ISharpTSCallable callable)
-                    return callable.Call(this, []);
+                    return callable.CallV2(this, []).ToObject();
             }
         }
         return null;
@@ -235,7 +235,7 @@ public partial class Interpreter
                 if (method is SharpTSArrowFunction arrowFunc)
                     method = arrowFunc.Bind(obj);
                 if (method is ISharpTSCallable callable)
-                    return callable.Call(this, args);
+                    return callable.CallV2(this, CallableInterop.ToRuntimeValues(args)).ToObject();
             }
         }
         else if (target is SharpTSInstance inst)
@@ -245,7 +245,7 @@ public partial class Interpreter
             if (method != null)
             {
                 var bound = SharpTSClass.BindMethod(method, inst);
-                return bound.Call(this, args);
+                return bound.CallV2(this, CallableInterop.ToRuntimeValues(args)).ToObject();
             }
         }
         else if (target is SharpTSGenerator gen)
@@ -570,7 +570,7 @@ public partial class Interpreter
                 if (member is BuiltInMethod bm && bm.MinArity == 0 && bm.MaxArity == 0)
                 {
                     // It's a constant property, invoke it to get the value
-                    return RuntimeValue.FromBoxed(bm.Call(this, []));
+                    return bm.CallV2(this, []);
                 }
                 return RuntimeValue.FromObject(member);
             }
@@ -757,7 +757,7 @@ public partial class Interpreter
         foreach (var expr in tagged.Expressions)
             args.Add((await EvaluateAsync(expr)).ToObject());
 
-        return RuntimeValue.FromBoxed(callable.Call(this, args));
+        return callable.CallV2(this, CallableInterop.ToRuntimeValues(args));
     }
 
     // Helper methods for index operations

--- a/Execution/Interpreter.Calls.cs
+++ b/Execution/Interpreter.Calls.cs
@@ -51,7 +51,7 @@ public partial class Interpreter
             {
                 pooledList.Add((await ctx.EvaluateExprAsync(arg)).ToObject());
             }
-            return method.Call(this, pooledList);
+            return method.CallV2(this, CallableInterop.ToRuntimeValues(pooledList)).ToObject();
         }
         finally
         {
@@ -183,7 +183,7 @@ public partial class Interpreter
             // Per ECMA-262 §10.2.1: missing arguments become undefined; do not
             // reject calls for user-defined functions. Built-in methods enforce
             // their own min-arity in BuiltInMethod.Call.
-            return function.Call(this, argumentsList);
+            return function.CallV2(this, CallableInterop.ToRuntimeValues(argumentsList)).ToObject();
         }
         finally
         {
@@ -253,7 +253,7 @@ public partial class Interpreter
             {
                 pooledList.Add(Evaluate(arg));
             }
-            return RuntimeValue.FromBoxed(method.Call(this, pooledList));
+            return method.CallV2(this, CallableInterop.ToRuntimeValues(pooledList));
         }
         finally
         {
@@ -411,7 +411,7 @@ public partial class Interpreter
 
             // Per ECMA-262 §10.2.1: missing arguments become undefined; do not
             // reject calls for user-defined functions.
-            return RuntimeValue.FromBoxed(function.Call(this, argumentsList));
+            return function.CallV2(this, CallableInterop.ToRuntimeValues(argumentsList));
         }
         finally
         {

--- a/Execution/Interpreter.Decorators.cs
+++ b/Execution/Interpreter.Decorators.cs
@@ -1,4 +1,5 @@
 using SharpTS.Parsing;
+using SharpTS.Runtime;
 using SharpTS.Runtime.Types;
 
 namespace SharpTS.Execution;
@@ -98,13 +99,13 @@ public partial class Interpreter
             if (_decoratorMode == DecoratorMode.Legacy)
             {
                 // Legacy: decorator(constructor)
-                result = decoratorFn.Call(this, [klass]);
+                result = decoratorFn.CallV2(this, [RuntimeValue.FromBoxed(klass)]).ToObject();
             }
             else
             {
                 // Stage 3: decorator(value, context)
                 var context = SharpTSDecoratorContext.ForClass(klass.Name);
-                result = decoratorFn.Call(this, [klass, context.ToRuntimeObject()]);
+                result = decoratorFn.CallV2(this, [RuntimeValue.FromBoxed(klass), RuntimeValue.FromBoxed(context.ToRuntimeObject())]).ToObject();
             }
 
             // If decorator returns a class, use it as replacement
@@ -139,7 +140,7 @@ public partial class Interpreter
                 // Legacy: decorator(target, propertyKey, descriptor)
                 var target = method.IsStatic ? (object)klass : klass; // prototype would be instance, but we use class
                 var descriptor = SharpTSPropertyDescriptor.ForMethod(func);
-                result = decoratorFn.Call(this, [target, method.Name.Lexeme, descriptor.ToObject()]);
+                result = decoratorFn.CallV2(this, [RuntimeValue.FromBoxed(target), RuntimeValue.FromString(method.Name.Lexeme), RuntimeValue.FromBoxed(descriptor.ToObject())]).ToObject();
 
                 if (result is SharpTSObject resultObj)
                 {
@@ -154,7 +155,7 @@ public partial class Interpreter
             {
                 // Stage 3: decorator(value, context)
                 var context = SharpTSDecoratorContext.ForMethod(method.Name.Lexeme, method.IsStatic);
-                result = decoratorFn.Call(this, [func, context.ToRuntimeObject()]);
+                result = decoratorFn.CallV2(this, [RuntimeValue.FromBoxed(func), RuntimeValue.FromBoxed(context.ToRuntimeObject())]).ToObject();
 
                 if (result is ISharpTSCallable replacement)
                 {
@@ -191,7 +192,7 @@ public partial class Interpreter
                     ? SharpTSPropertyDescriptor.ForGetter(func)
                     : SharpTSPropertyDescriptor.ForSetter(func);
 
-                result = decoratorFn.Call(this, [klass, accessor.Name.Lexeme, descriptor.ToObject()]);
+                result = decoratorFn.CallV2(this, [RuntimeValue.FromBoxed(klass), RuntimeValue.FromString(accessor.Name.Lexeme), RuntimeValue.FromBoxed(descriptor.ToObject())]).ToObject();
 
                 if (result is SharpTSObject resultObj)
                 {
@@ -210,7 +211,7 @@ public partial class Interpreter
                     ? SharpTSDecoratorContext.ForGetter(accessor.Name.Lexeme, isStatic)
                     : SharpTSDecoratorContext.ForSetter(accessor.Name.Lexeme, isStatic);
 
-                result = decoratorFn.Call(this, [func, context.ToRuntimeObject()]);
+                result = decoratorFn.CallV2(this, [RuntimeValue.FromBoxed(func), RuntimeValue.FromBoxed(context.ToRuntimeObject())]).ToObject();
 
                 if (result is SharpTSFunction replacement)
                 {
@@ -241,13 +242,13 @@ public partial class Interpreter
             {
                 // Legacy: decorator(target, propertyKey)
                 var target = field.IsStatic ? (object)klass : klass;
-                decoratorFn.Call(this, [target, field.Name.Lexeme]);
+                decoratorFn.CallV2(this, [RuntimeValue.FromBoxed(target), RuntimeValue.FromString(field.Name.Lexeme)]);
             }
             else
             {
                 // Stage 3: decorator(undefined, context)
                 var context = SharpTSDecoratorContext.ForField(field.Name.Lexeme, field.IsStatic);
-                decoratorFn.Call(this, [null, context.ToRuntimeObject()]);
+                decoratorFn.CallV2(this, [RuntimeValue.Null, RuntimeValue.FromBoxed(context.ToRuntimeObject())]);
             }
         }
     }
@@ -274,7 +275,7 @@ public partial class Interpreter
                     // Legacy: decorator(target, methodName, parameterIndex)
                     var target = method.IsStatic ? (object)klass : klass;
                     string? propertyKey = method.Name.Lexeme == "constructor" ? null : method.Name.Lexeme;
-                    decoratorFn.Call(this, [target, propertyKey, (double)paramIndex]);
+                    decoratorFn.CallV2(this, [RuntimeValue.FromBoxed(target), RuntimeValue.FromBoxed(propertyKey), RuntimeValue.FromNumber(paramIndex)]);
                 }
             }
         }

--- a/Execution/Interpreter.Expressions.cs
+++ b/Execution/Interpreter.Expressions.cs
@@ -288,7 +288,7 @@ public partial class Interpreter
         foreach (var expr in tagged.Expressions)
             args.Add(Evaluate(expr));
 
-        return RuntimeValue.FromBoxed(callable.Call(this, args));
+        return callable.CallV2(this, CallableInterop.ToRuntimeValues(args));
     }
 
     /// <summary>
@@ -334,6 +334,7 @@ public partial class Interpreter
     {
         public int Arity() => 0;
         public object? Call(Interpreter interpreter, List<object?> arguments) => null;
+        public RuntimeValue CallV2(Interpreter interpreter, ReadOnlySpan<RuntimeValue> arguments) => RuntimeValue.Null;
     }
 
     /// <summary>
@@ -774,7 +775,7 @@ public partial class Interpreter
             if (index is SharpTSSymbol fnSym)
             {
                 if (fn.TryGetSymbolAccessor(fnSym, out var symGetter, out _) && symGetter != null)
-                    return RuntimeValue.FromBoxed(symGetter.Call(this, []));
+                    return symGetter.CallV2(this, []);
                 if (fn.TryGetSymbolProperty(fnSym, out var symVal))
                     return RuntimeValue.FromBoxed(symVal ?? SharpTSUndefined.Instance);
             }
@@ -789,7 +790,7 @@ public partial class Interpreter
             if (index is SharpTSSymbol arrSym)
             {
                 if (afn.TryGetSymbolAccessor(arrSym, out var arrGetter, out _) && arrGetter != null)
-                    return RuntimeValue.FromBoxed(arrGetter.Call(this, []));
+                    return arrGetter.CallV2(this, []);
                 if (afn.TryGetSymbolProperty(arrSym, out var arrSymVal))
                     return RuntimeValue.FromBoxed(arrSymVal ?? SharpTSUndefined.Instance);
             }

--- a/Execution/Interpreter.Helpers.cs
+++ b/Execution/Interpreter.Helpers.cs
@@ -413,7 +413,7 @@ public partial class Interpreter
         // Call the executor synchronously with resolve and reject callbacks
         try
         {
-            callable.Call(this, [resolveCallback, rejectCallback]);
+            callable.CallV2(this, [RuntimeValue.FromBoxed(resolveCallback), RuntimeValue.FromBoxed(rejectCallback)]);
         }
         catch (Exception ex)
         {

--- a/Execution/Interpreter.Properties.cs
+++ b/Execution/Interpreter.Properties.cs
@@ -90,7 +90,7 @@ public partial class Interpreter
                 ["constructor"] = userFn,
             });
             var bound = userFn.BindThis(newThis);
-            var result = bound.Call(this, fnArgs);
+            var result = bound.CallV2(this, CallableInterop.ToRuntimeValues(fnArgs)).ToObject();
             // JS spec: if constructor returns an object, use it; otherwise use the new `this`.
             return result is SharpTSObject or SharpTSInstance or SharpTSArray
                 ? result
@@ -123,7 +123,7 @@ public partial class Interpreter
                 ["constructor"] = userArrowFn,
             });
             var bound = userArrowFn.Bind(newThis);
-            var result = bound.Call(this, arrowArgs);
+            var result = bound.CallV2(this, CallableInterop.ToRuntimeValues(arrowArgs)).ToObject();
             return result is SharpTSObject or SharpTSInstance or SharpTSArray
                 ? result
                 : newThis;
@@ -146,7 +146,7 @@ public partial class Interpreter
         if (klass is ISharpTSCallable callable && klass is not SharpTSClass && klass is not BoundFunction)
         {
             List<object?> ctorArgs = await ctx.EvaluateAllAsync(newExpr.Arguments);
-            return callable.Call(this, ctorArgs);
+            return callable.CallV2(this, CallableInterop.ToRuntimeValues(ctorArgs)).ToObject();
         }
 
         // Bound functions cannot be used as constructors (JS spec compliance)
@@ -170,7 +170,7 @@ public partial class Interpreter
         }
 
         List<object?> arguments = await ctx.EvaluateAllAsync(newExpr.Arguments);
-        return sharpClass.Call(this, arguments);
+        return sharpClass.CallV2(this, CallableInterop.ToRuntimeValues(arguments)).ToObject();
     }
 
     /// <summary>
@@ -209,7 +209,7 @@ public partial class Interpreter
                 ["constructor"] = userFn,
             });
             var bound = userFn.BindThis(newThis);
-            var result = bound.Call(this, [.. args]);
+            var result = bound.CallV2(this, CallableInterop.ToRuntimeValues([.. args])).ToObject();
             return result is SharpTSObject or SharpTSInstance or SharpTSArray
                 or SharpTSRegExp or SharpTSDate or SharpTSMap or SharpTSSet
                 ? result : newThis;
@@ -227,7 +227,7 @@ public partial class Interpreter
                 ["constructor"] = arrowFn,
             });
             var bound = arrowFn.Bind(newThis);
-            var result = bound.Call(this, [.. args]);
+            var result = bound.CallV2(this, CallableInterop.ToRuntimeValues([.. args])).ToObject();
             return result is SharpTSObject or SharpTSInstance or SharpTSArray
                 or SharpTSRegExp or SharpTSDate or SharpTSMap or SharpTSSet
                 ? result : newThis;
@@ -241,7 +241,7 @@ public partial class Interpreter
         // Fallback: treat as a callable; Reflect.construct shape.
         if (callable is ISharpTSCallable c)
         {
-            return c.Call(this, [.. args]);
+            return c.CallV2(this, CallableInterop.ToRuntimeValues([.. args])).ToObject();
         }
         throw new InterpreterException("TypeError: Construct called on non-callable.");
     }
@@ -314,7 +314,7 @@ public partial class Interpreter
                 ["constructor"] = userFn,
             });
             var bound = userFn.BindThis(newThis);
-            var result = bound.Call(this, fnArgs);
+            var result = bound.CallV2(this, CallableInterop.ToRuntimeValues(fnArgs)).ToObject();
             return RuntimeValue.FromBoxed(result is SharpTSObject or SharpTSInstance or SharpTSArray
                 or SharpTSRegExp or SharpTSDate or SharpTSMap or SharpTSSet
                 ? result
@@ -343,7 +343,7 @@ public partial class Interpreter
                 ["constructor"] = userArrowFn,
             });
             var bound = userArrowFn.Bind(newThis);
-            var result = bound.Call(this, arrowArgs);
+            var result = bound.CallV2(this, CallableInterop.ToRuntimeValues(arrowArgs)).ToObject();
             return RuntimeValue.FromBoxed(result is SharpTSObject or SharpTSInstance or SharpTSArray
                 or SharpTSRegExp or SharpTSDate or SharpTSMap or SharpTSSet
                 ? result
@@ -366,7 +366,7 @@ public partial class Interpreter
             {
                 ctorArgs.Add(Evaluate(arg));
             }
-            return RuntimeValue.FromBoxed(callable.Call(this, ctorArgs));
+            return callable.CallV2(this, CallableInterop.ToRuntimeValues(ctorArgs));
         }
 
         // Bound functions cannot be used as constructors (JS spec compliance)
@@ -440,7 +440,7 @@ public partial class Interpreter
                 // by BuiltInMethod.CreateConstant / BuiltInStaticBuilder.CallableConstant.
                 if (member is BuiltInMethod bm && bm.IsConstant)
                 {
-                    return RuntimeValue.FromBoxed(bm.Call(this, []));
+                    return bm.CallV2(this, []);
                 }
                 return RuntimeValue.FromObject(member);
             }
@@ -545,7 +545,7 @@ public partial class Interpreter
             // Accessor defined via Object.defineProperty(fn, name, {get, set}).
             if (fn.TryGetAccessor(memberName, out var getter, out _) && getter != null)
             {
-                return RuntimeValue.FromBoxed(getter.Call(this, []));
+                return getter.CallV2(this, []);
             }
             if (fn.TryGetProperty(memberName, out var userProp))
                 return RuntimeValue.FromBoxed(userProp);
@@ -560,7 +560,7 @@ public partial class Interpreter
         if (obj is SharpTSArrowFunction arrowFn)
         {
             if (arrowFn.TryGetAccessor(memberName, out var getter, out _) && getter != null)
-                return RuntimeValue.FromBoxed(getter.Call(this, []));
+                return getter.CallV2(this, []);
             if (arrowFn.TryGetProperty(memberName, out var arrowProp))
                 return RuntimeValue.FromBoxed(arrowProp);
             // Lazy-init `fn.prototype` for function expressions (HasOwnThis).
@@ -594,7 +594,7 @@ public partial class Interpreter
         if (obj is SharpTSRegExp regex)
         {
             if (regex.TryGetAccessor(memberName, out var rxGetter, out _) && rxGetter != null)
-                return RuntimeValue.FromBoxed(rxGetter.Call(this, []));
+                return rxGetter.CallV2(this, []);
             if (memberName == "flags")
                 return RuntimeValue.FromBoxed(Runtime.BuiltIns.RegExpBuiltIns.GetMember(regex, memberName, this));
             // ECMA-262 §22.2.6.1: `constructor` is inherited from
@@ -709,7 +709,7 @@ public partial class Interpreter
         var staticGetter = klass.FindStaticGetter(memberName);
         if (staticGetter != null)
         {
-            return staticGetter.BindStatic(klass).Call(this, []);
+            return staticGetter.BindStatic(klass).CallV2(this, []).ToObject();
         }
 
         // Try static method
@@ -781,7 +781,7 @@ public partial class Interpreter
         {
             // Invoke the getter with 'this' bound to the object
             var boundGetter = BindAccessorToObject(getter, simpleObj);
-            return boundGetter.Call(this, []);
+            return boundGetter.CallV2(this, []).ToObject();
         }
 
         // Own property
@@ -807,7 +807,7 @@ public partial class Interpreter
             if (protoGetter != null)
             {
                 var boundProtoGetter = BindAccessorToObject(protoGetter, simpleObj);
-                return boundProtoGetter.Call(this, []);
+                return boundProtoGetter.CallV2(this, []).ToObject();
             }
             if (proto.HasProperty(memberName))
             {
@@ -945,7 +945,7 @@ public partial class Interpreter
         if (obj is SharpTSFunction fn)
         {
             if (fn.TryGetAccessor(memberName, out var getter, out _) && getter != null)
-                return getter.Call(this, []);
+                return getter.CallV2(this, []).ToObject();
             if (fn.TryGetProperty(memberName, out var v)) return v;
             if (memberName == "name") return fn.TryGetProperty("name", out var n) ? n : "";
             if (memberName == "length") return (double)fn.Arity();
@@ -963,7 +963,7 @@ public partial class Interpreter
         if (obj is SharpTSArrowFunction arrowFn2)
         {
             if (arrowFn2.TryGetAccessor(memberName, out var arrowGetter, out _) && arrowGetter != null)
-                return arrowGetter.Call(this, []);
+                return arrowGetter.CallV2(this, []).ToObject();
             if (arrowFn2.TryGetProperty(memberName, out var arrowProp2)) return arrowProp2;
             if (memberName == "length") return (double)arrowFn2.Arity();
             return SharpTSUndefined.Instance;
@@ -1167,7 +1167,7 @@ public partial class Interpreter
             // Accessor set path (Object.defineProperty setter).
             if (userFn.TryGetAccessor(set.Name.Lexeme, out _, out var setter) && setter != null)
             {
-                setter.Call(this, [value]);
+                setter.CallV2(this, [RuntimeValue.FromBoxed(value)]);
                 return value;
             }
             userFn.SetProperty(set.Name.Lexeme, value);
@@ -1177,7 +1177,7 @@ public partial class Interpreter
         {
             if (arrowFn.TryGetAccessor(set.Name.Lexeme, out _, out var arrowSetter) && arrowSetter != null)
             {
-                arrowSetter.Call(this, [value]);
+                arrowSetter.CallV2(this, [RuntimeValue.FromBoxed(value)]);
                 return value;
             }
             arrowFn.SetProperty(set.Name.Lexeme, value);
@@ -1228,7 +1228,7 @@ public partial class Interpreter
                 var staticSetterClass = klass.FindStaticSetter(memberName);
                 if (staticSetterClass != null)
                 {
-                    staticSetterClass.BindStatic(klass).Call(this, [value]);
+                    staticSetterClass.BindStatic(klass).CallV2(this, [RuntimeValue.FromBoxed(value)]);
                     return value;
                 }
                 klass.SetStaticProperty(memberName, value);
@@ -1252,7 +1252,7 @@ public partial class Interpreter
                 if (regex.TryGetAccessor(memberName, out _, out var userSetter)
                     && userSetter != null)
                 {
-                    userSetter.Call(this, [value]);
+                    userSetter.CallV2(this, [RuntimeValue.FromBoxed(value)]);
                     return value;
                 }
                 if (memberName == "lastIndex")
@@ -1308,7 +1308,7 @@ public partial class Interpreter
             if (setter != null)
             {
                 var boundSetter = BindAccessorToObject(setter, simpleObj);
-                boundSetter.Call(this, [value]);
+                boundSetter.CallV2(this, [RuntimeValue.FromBoxed(value)]);
                 return value;
             }
 
@@ -1508,7 +1508,7 @@ public partial class Interpreter
                 throw new InterpreterException($"Static private method '{methodName}' does not exist on class '{klass.Name}'.");
             }
 
-            return RuntimeValue.FromBoxed(method.Call(this, arguments));
+            return method.CallV2(this, CallableInterop.ToRuntimeValues(arguments));
         }
 
         // Instance private method call
@@ -1524,7 +1524,7 @@ public partial class Interpreter
             }
 
             // Bind method to instance
-            return RuntimeValue.FromBoxed(SharpTSClass.BindMethod(method, instance).Call(this, arguments));
+            return SharpTSClass.BindMethod(method, instance).CallV2(this, CallableInterop.ToRuntimeValues(arguments));
         }
 
         throw new InterpreterException($"Cannot call private method '{methodName}' on non-class value.");

--- a/Execution/Interpreter.Statements.cs
+++ b/Execution/Interpreter.Statements.cs
@@ -779,11 +779,11 @@ public partial class Interpreter
         object? iterator;
         if (iteratorFn is ISharpTSCallable callable)
         {
-            iterator = callable.Call(this, []);
+            iterator = callable.CallV2(this, []).ToObject();
         }
         else if (iteratorFn is SharpTSFunction fn)
         {
-            iterator = fn.Call(this, []);
+            iterator = fn.CallV2(this, []).ToObject();
         }
         else
         {
@@ -829,11 +829,11 @@ public partial class Interpreter
             object? result;
             if (nextMethod is ISharpTSCallable nextCallable)
             {
-                result = nextCallable.Call(this, []);
+                result = nextCallable.CallV2(this, []).ToObject();
             }
             else if (nextMethod is SharpTSFunction nextFn)
             {
-                result = nextFn.Call(this, []);
+                result = nextFn.CallV2(this, []).ToObject();
             }
             else
             {
@@ -1096,7 +1096,7 @@ public partial class Interpreter
             if (resource is SharpTSInstance instance)
             {
                 var boundFunc = func.Bind(instance);
-                result = boundFunc.Call(this, []);
+                result = boundFunc.CallV2(this, []).ToObject();
             }
             else
             {
@@ -1106,7 +1106,7 @@ public partial class Interpreter
                 _environment.Define("this", resource);
                 try
                 {
-                    result = func.Call(this, []);
+                    result = func.CallV2(this, []).ToObject();
                 }
                 finally
                 {
@@ -1120,17 +1120,17 @@ public partial class Interpreter
             if (arrowFunc.HasOwnThis)
             {
                 var boundFunc = arrowFunc.Bind(resource!);
-                result = boundFunc.Call(this, []);
+                result = boundFunc.CallV2(this, []).ToObject();
             }
             else
             {
                 // Arrow functions without own 'this' use lexical scope
-                result = arrowFunc.Call(this, []);
+                result = arrowFunc.CallV2(this, []).ToObject();
             }
         }
         else if (disposeMethod is ISharpTSCallable callable)
         {
-            result = callable.Call(this, []);
+            result = callable.CallV2(this, []).ToObject();
         }
 
         // Wait for async disposal to complete

--- a/Execution/Interpreter.cs
+++ b/Execution/Interpreter.cs
@@ -470,7 +470,7 @@ public partial class Interpreter : IDisposable
                 {
                     try
                     {
-                        callback.Call(this, []);
+                        callback.CallV2(this, []);
                     }
                     catch (Exception ex)
                     {
@@ -1249,8 +1249,8 @@ public partial class Interpreter : IDisposable
         var argv = ProcessBuiltIns.GetArgv();
         // Pass argv only if main expects it
         object? result = mainFunc.Parameters.Count == 0
-            ? mainFn.Call(this, [])
-            : mainFn.Call(this, [argv]);
+            ? mainFn.CallV2(this, []).ToObject()
+            : mainFn.CallV2(this, [RuntimeValue.FromBoxed(argv)]).ToObject();
 
         // If result is a Promise, await it
         if (result is SharpTSPromise promise)

--- a/Runtime/Types/SharpTSAsyncFunction.cs
+++ b/Runtime/Types/SharpTSAsyncFunction.cs
@@ -71,6 +71,16 @@ public class SharpTSAsyncFunction : ISharpTSAsyncCallable
     }
 
     /// <summary>
+    /// RuntimeValue entry point. Copy-first: the span is materialized into a boxed
+    /// list before the async state machine starts — arguments must outlive suspension.
+    /// </summary>
+    public RuntimeValue CallV2(Interpreter interpreter, ReadOnlySpan<RuntimeValue> arguments)
+    {
+        var task = CallAsync(interpreter, CallableInterop.ToBoxedList(arguments));
+        return RuntimeValue.FromObject(new SharpTSPromise(task));
+    }
+
+    /// <summary>
     /// Asynchronously executes the function body.
     /// </summary>
     public async Task<object?> CallAsync(Interpreter interpreter, List<object?> arguments)
@@ -185,6 +195,16 @@ public class SharpTSAsyncArrowFunction : ISharpTSAsyncCallable
     {
         var task = CallAsync(interpreter, arguments);
         return new SharpTSPromise(task);
+    }
+
+    /// <summary>
+    /// RuntimeValue entry point. Copy-first: the span is materialized into a boxed
+    /// list before the async state machine starts — arguments must outlive suspension.
+    /// </summary>
+    public RuntimeValue CallV2(Interpreter interpreter, ReadOnlySpan<RuntimeValue> arguments)
+    {
+        var task = CallAsync(interpreter, CallableInterop.ToBoxedList(arguments));
+        return RuntimeValue.FromObject(new SharpTSPromise(task));
     }
 
     /// <summary>

--- a/Runtime/Types/SharpTSAsyncGeneratorFunction.cs
+++ b/Runtime/Types/SharpTSAsyncGeneratorFunction.cs
@@ -41,6 +41,17 @@ public class SharpTSAsyncGeneratorFunction : ISharpTSCallable
     }
 
     /// <summary>
+    /// RuntimeValue entry point. Binding is synchronous — the generator body runs
+    /// later from the bound environment, so the span never escapes this frame.
+    /// </summary>
+    public RuntimeValue CallV2(Interpreter interpreter, ReadOnlySpan<RuntimeValue> arguments)
+    {
+        RuntimeEnvironment environment = new(_closure);
+        ParameterBinder.BindRV(_declaration.Parameters ?? [], arguments, environment, interpreter);
+        return RuntimeValue.FromObject(new SharpTSAsyncGenerator(_declaration, environment, interpreter));
+    }
+
+    /// <summary>
     /// Creates a bound version with 'this' set for method calls.
     /// </summary>
     public SharpTSAsyncGeneratorFunction Bind(SharpTSInstance instance)

--- a/Runtime/Types/SharpTSClass.cs
+++ b/Runtime/Types/SharpTSClass.cs
@@ -82,6 +82,9 @@ public class SharpTSClass(
     }
 
     public virtual object? Call(Interpreter interpreter, List<object?> arguments)
+        => CallV2(interpreter, CallableInterop.ToRuntimeValues(arguments)).ToObject();
+
+    public virtual RuntimeValue CallV2(Interpreter interpreter, ReadOnlySpan<RuntimeValue> arguments)
     {
         SharpTSInstance instance = new(this);
 
@@ -98,15 +101,15 @@ public class SharpTSClass(
         ISharpTSCallable? constructor = FindMethod("constructor");
         if (constructor != null)
         {
-            BindMethod(constructor, instance).Call(interpreter, arguments);
+            BindMethod(constructor, instance).CallV2(interpreter, arguments);
         }
         else if (Superclass != null)
         {
             // If no constructor, call super constructor
-            Superclass.Call(interpreter, arguments);
+            Superclass.CallV2(interpreter, arguments);
         }
 
-        return instance;
+        return RuntimeValue.FromObject(instance);
     }
 
     /// <summary>

--- a/Runtime/Types/SharpTSErrorClass.cs
+++ b/Runtime/Types/SharpTSErrorClass.cs
@@ -158,9 +158,10 @@ public class SharpTSErrorClass : SharpTSClass
     }
 
     /// <summary>
-    /// Overrides <see cref="SharpTSClass.Call"/> to initialise error fields after instance creation.
+    /// Overrides <see cref="SharpTSClass.CallV2"/> to initialise error fields after instance
+    /// creation. The base <c>Call</c> delegates here, so this is the single construct body.
     /// </summary>
-    public override object? Call(Interpreter interpreter, List<object?> arguments)
+    public override RuntimeValue CallV2(Interpreter interpreter, ReadOnlySpan<RuntimeValue> arguments)
     {
         SharpTSInstance instance = new(this);
 
@@ -174,15 +175,15 @@ public class SharpTSErrorClass : SharpTSClass
         if (hasUserConstructor && constructor != null)
         {
             // User-defined constructor — super() in body will call ErrorConstructorCallable
-            BindMethod(constructor, instance).Call(interpreter, arguments);
+            BindMethod(constructor, instance).CallV2(interpreter, arguments);
         }
         else
         {
             // No user constructor (or built-in Error class) — initialise error fields directly
-            InitializeErrorFields(instance, _errorTypeName, arguments);
+            InitializeErrorFields(instance, _errorTypeName, CallableInterop.ToBoxedList(arguments));
         }
 
-        return instance;
+        return RuntimeValue.FromObject(instance);
     }
 
     /// <summary>
@@ -208,6 +209,15 @@ public class SharpTSErrorClass : SharpTSClass
             if (instance != null)
                 InitializeErrorFields(instance, errorTypeName, arguments);
             return null;
+        }
+
+        public RuntimeValue CallV2(Interpreter interpreter, ReadOnlySpan<RuntimeValue> arguments)
+        {
+            var instance = _boundInstance
+                ?? interpreter.GetCurrentThis() as SharpTSInstance;
+            if (instance != null)
+                InitializeErrorFields(instance, errorTypeName, CallableInterop.ToBoxedList(arguments));
+            return RuntimeValue.Null;
         }
     }
 }

--- a/Runtime/Types/SharpTSFunctionGlobal.cs
+++ b/Runtime/Types/SharpTSFunctionGlobal.cs
@@ -71,6 +71,12 @@ public sealed class SharpTSFunctionProtoToString : ISharpTSCallable
         return target?.ToString() ?? "function () { [native code] }";
     }
 
+    public RuntimeValue CallV2(Execution.Interpreter interpreter, ReadOnlySpan<RuntimeValue> arguments)
+    {
+        var target = _boundThis ?? (arguments.Length > 0 ? arguments[0].ToObject() : null);
+        return RuntimeValue.FromString(target?.ToString() ?? "function () { [native code] }");
+    }
+
     public SharpTSFunctionProtoToString BindTo(object? thisArg) => new(thisArg);
 
     public override string ToString() => "function toString() { [native code] }";

--- a/Runtime/Types/SharpTSGeneratorFunction.cs
+++ b/Runtime/Types/SharpTSGeneratorFunction.cs
@@ -43,6 +43,17 @@ public class SharpTSGeneratorFunction : ISharpTSCallable
     }
 
     /// <summary>
+    /// RuntimeValue entry point. Parameter binding happens synchronously before this
+    /// returns; only the bound environment outlives the call, so the span never escapes.
+    /// </summary>
+    public RuntimeValue CallV2(Interpreter interpreter, ReadOnlySpan<RuntimeValue> arguments)
+    {
+        RuntimeEnvironment environment = new(_closure);
+        ParameterBinder.BindRV(_declaration.Parameters, arguments, environment, interpreter);
+        return RuntimeValue.FromObject(new SharpTSGenerator(_declaration, environment, interpreter));
+    }
+
+    /// <summary>
     /// Creates a bound version with 'this' set for method calls.
     /// </summary>
     public SharpTSGeneratorFunction Bind(SharpTSInstance instance)
@@ -107,6 +118,20 @@ public class SharpTSArrowGeneratorFunction : ISharpTSCallable
         ParameterBinder.Bind(_declaration.Parameters, arguments, environment, interpreter);
 
         return new SharpTSArrowGenerator(_declaration, environment, interpreter);
+    }
+
+    /// <summary>
+    /// RuntimeValue entry point — see <see cref="SharpTSGeneratorFunction.CallV2"/>.
+    /// </summary>
+    public RuntimeValue CallV2(Interpreter interpreter, ReadOnlySpan<RuntimeValue> arguments)
+    {
+        RuntimeEnvironment environment = new(_closure);
+        if (_declaration.Name != null)
+        {
+            environment.Define(_declaration.Name.Lexeme, this);
+        }
+        ParameterBinder.BindRV(_declaration.Parameters, arguments, environment, interpreter);
+        return RuntimeValue.FromObject(new SharpTSArrowGenerator(_declaration, environment, interpreter));
     }
 
     /// <summary>

--- a/Runtime/Types/SharpTSGlobalFunction.cs
+++ b/Runtime/Types/SharpTSGlobalFunction.cs
@@ -26,13 +26,17 @@ public sealed class SharpTSGlobalFunction : ISharpTSCallable, ITypeCategorized
     public int Arity() => 0;
 
     public object? Call(Interp interpreter, List<object?> arguments)
+        => CallV2(interpreter, CallableInterop.ToRuntimeValues(arguments)).ToObject();
+
+    public RuntimeValue CallV2(Interp interpreter, ReadOnlySpan<RuntimeValue> arguments)
     {
         // Build ephemeral literal Expr args wrapping the already-evaluated
-        // argument values, then invoke the registered handler.
-        var argExprs = new List<Expr>(arguments.Count);
+        // argument values, then invoke the registered handler. The handler
+        // protocol takes Exprs, so values are boxed into literals either way.
+        var argExprs = new List<Expr>(arguments.Length);
         foreach (var a in arguments)
         {
-            argExprs.Add(new Expr.Literal(a));
+            argExprs.Add(new Expr.Literal(a.ToObject()));
         }
 
         if (GlobalFunctionRegistry.Instance.TryGetHandlerV2(Name, out var handlerV2) && handlerV2 != null)
@@ -41,7 +45,7 @@ public sealed class SharpTSGlobalFunction : ISharpTSCallable, ITypeCategorized
                 expr => ValueTask.FromResult(interpreter.EvaluateRV(expr)),
                 argExprs,
                 interpreter);
-            return task.GetAwaiter().GetResult().ToObject();
+            return task.GetAwaiter().GetResult();
         }
 
         if (GlobalFunctionRegistry.Instance.TryGetHandler(Name, out var handler) && handler != null)
@@ -50,7 +54,7 @@ public sealed class SharpTSGlobalFunction : ISharpTSCallable, ITypeCategorized
                 expr => ValueTask.FromResult(interpreter.Evaluate(expr)),
                 argExprs,
                 interpreter);
-            return task.GetAwaiter().GetResult();
+            return RuntimeValue.FromBoxed(task.GetAwaiter().GetResult());
         }
 
         throw new Exception($"Runtime Error: Global function '{Name}' is not registered.");


### PR DESCRIPTION
## PR 2 of 4: finish the RuntimeValue/V2 callable migration

Stacked on #173. Core function types get native `CallV2` bodies, and all 60 legacy `.Call(` sites in `Execution/` move to span dispatch.

### Changes
- **`SharpTSClass`**: native virtual `CallV2` is now the single construct body (field/private/auto-accessor init, constructor dispatch via `CallV2`); legacy `Call` is a delegating one-liner. **`SharpTSErrorClass`** overrides `CallV2` (its legacy `Call` override is deleted — base delegation routes through the virtual).
- **Async functions** (`SharpTSAsyncFunction`/`SharpTSAsyncArrowFunction`): copy-first — span materialized to a boxed list before the async state machine starts (arguments must outlive suspension).
- **Generators** (sync/arrow/async-generator functions): bind natively via `ParameterBinder.BindRV`; binding is synchronous so the span never escapes the frame.
- **Small wrappers**: `SharpTSGlobalFunction` (result no longer round-trips through object?), `SharpTSFunctionProtoToString`, `ErrorConstructorCallable`, `NoOpCallable`.
- **Execution/ call sites** (60 across Properties/Statements/Decorators/Async/Calls/Expressions/Helpers/Interpreter): zero-to-three-arg calls use collection-expression spans (stack-backed, allocation-free); list-arg sites use `CallableInterop.ToRuntimeValues`; `RuntimeValue.FromBoxed(x.Call(...))` wrappers collapse to bare `CallV2`. Pooling (`ArgumentListPool`, `ArrayPool<RuntimeValue>`) untouched. No span crosses an `await`.

### Verification
- xUnit: **10,454 passed** (the 2 `PackagingTests` failures reproduce on clean base — environmental).
- TS conformance: **31/31, zero baseline diff**.
- Test262 (Debug, subprocess worker, facts run separately): **0 regressions both modes**; drift is exactly the known stale-baseline set (17 compiled / 14 interpreted new passes, byte-identical to the base-commit runs verified in #173). Interpreted totals match base exactly (Pass=3912, Fail=3735, RuntimeError=2716).
- Note: a combined single-testhost run of both Test262 facts crashes the testhost after the compiled fact (pre-existing harness fragility, reproduces on base; facts pass when run separately). Worker-stall flakes can shuffle a `RuntimeError:worker-stalled` bucket between neighboring `Array/of` tests — re-run settles it.

### Recommended follow-up (separate from this stack)
Refresh the Test262 baselines on main (`SHARPTS_TEST262_UPDATE_BASELINE=1`): they predate the #102-era improvements (`28887d1b`, `2e695807`, `6810f28e`) and every suite run now reports those 17+14 stale new passes as failures.