### PR TITLE
refactor: bulk Runtime/ callable migration — CallV2 on all implementors (migration PR 3/4)

### DIFF
--- a/Runtime/BuiltIns/ArrayBuiltIns.cs
+++ b/Runtime/BuiltIns/ArrayBuiltIns.cs
@@ -219,7 +219,7 @@ public static class ArrayBuiltIns
         {
             _compareArgs[0] = x.Element;
             _compareArgs[1] = y.Element;
-            var result = _fn.Call(_interp, _compareArgs);
+            var result = _fn.CallBoxed(_interp, _compareArgs);
             if (result is double d && !double.IsNaN(d) && d != 0)
                 return d < 0 ? -1 : 1;
             // Stability tie-breaker: preserve original order
@@ -810,7 +810,7 @@ public static class ArrayBuiltIns
                 callbackArgs[0] = accumulator;
                 callbackArgs[1] = arr[i];
                 callbackArgs[2] = (double)i;
-                accumulator = callback.Call(interp, callbackArgs);
+                accumulator = callback.CallBoxed(interp, callbackArgs);
             }
             return RuntimeValue.FromBoxed(accumulator);
         }
@@ -861,7 +861,7 @@ public static class ArrayBuiltIns
                 callbackArgs[0] = accumulator;
                 callbackArgs[1] = arr[i];
                 callbackArgs[2] = (double)i;
-                accumulator = callback.Call(interp, callbackArgs);
+                accumulator = callback.CallBoxed(interp, callbackArgs);
             }
             return RuntimeValue.FromBoxed(accumulator);
         }

--- a/Runtime/BuiltIns/ArrayStaticBuiltIns.cs
+++ b/Runtime/BuiltIns/ArrayStaticBuiltIns.cs
@@ -47,7 +47,7 @@ public static class ArrayStaticBuiltIns
                     {
                         callbackArgs[0] = elements[i];
                         callbackArgs[1] = (double)i;
-                        result.Add(mapFn.Call(interpreter, callbackArgs));
+                        result.Add(mapFn.CallBoxed(interpreter, callbackArgs));
                     }
                     return new SharpTSArray(result);
                 }

--- a/Runtime/BuiltIns/BuiltInAsyncMethod.cs
+++ b/Runtime/BuiltIns/BuiltInAsyncMethod.cs
@@ -125,6 +125,14 @@ public class BuiltInAsyncMethod : ISharpTSCallable, ISharpTSAsyncCallable
     }
 
     /// <summary>
+    /// RuntimeValue call - materializes the arguments into a boxed list (they must
+    /// outlive any suspension) and routes through <see cref="Call"/>, which wraps
+    /// synchronous throws into a rejected Promise.
+    /// </summary>
+    public RuntimeValue CallV2(Interpreter interpreter, ReadOnlySpan<RuntimeValue> arguments)
+        => RuntimeValue.FromBoxed(Call(interpreter, CallableInterop.ToBoxedList(arguments)));
+
+    /// <summary>
     /// Async call - awaits the implementation directly.
     /// </summary>
     public async Task<object?> CallAsync(Interpreter interpreter, List<object?> arguments)

--- a/Runtime/BuiltIns/BuiltInConstructorFactory.cs
+++ b/Runtime/BuiltIns/BuiltInConstructorFactory.cs
@@ -117,7 +117,7 @@ public static class BuiltInConstructorFactory
         // Check TypedArray constructors
         if (BuiltInNames.IsTypedArrayName(name))
         {
-            return WorkerBuiltIns.GetTypedArrayConstructor(name).Call(interpreter!, args.ToList());
+            return WorkerBuiltIns.GetTypedArrayConstructor(name).CallBoxed(interpreter!, args.ToList());
         }
 
         // Note: Error constructors are handled by SharpTSErrorClass (registered as globals)
@@ -125,17 +125,17 @@ public static class BuiltInConstructorFactory
         // Check MessageChannel and SharedArrayBuffer (need interpreter)
         if (name == BuiltInNames.MessageChannel)
         {
-            return WorkerBuiltIns.MessageChannelConstructor.Call(interpreter!, args.ToList());
+            return WorkerBuiltIns.MessageChannelConstructor.CallBoxed(interpreter!, args.ToList());
         }
 
         if (name == BuiltInNames.SharedArrayBuffer)
         {
-            return WorkerBuiltIns.SharedArrayBufferConstructor.Call(interpreter!, args.ToList());
+            return WorkerBuiltIns.SharedArrayBufferConstructor.CallBoxed(interpreter!, args.ToList());
         }
 
         if (name == BuiltInNames.ArrayBuffer)
         {
-            return WorkerBuiltIns.ArrayBufferConstructor.Call(interpreter!, args.ToList());
+            return WorkerBuiltIns.ArrayBufferConstructor.CallBoxed(interpreter!, args.ToList());
         }
 
         if (name == BuiltInNames.BroadcastChannel)

--- a/Runtime/BuiltIns/FetchHelpers.cs
+++ b/Runtime/BuiltIns/FetchHelpers.cs
@@ -178,9 +178,9 @@ public static class FetchHelpers
                 var bound = pushMethod.Bind(stream);
                 if (bodyBytes != null && bodyBytes.Length > 0)
                 {
-                    bound.Call(null!, new List<object?> { new SharpTSBuffer(bodyBytes) });
+                    bound.CallBoxed(null!, new List<object?> { new SharpTSBuffer(bodyBytes) });
                 }
-                bound.Call(null!, new List<object?> { null }); // EOF
+                bound.CallBoxed(null!, new List<object?> { null }); // EOF
             }
         }
     }

--- a/Runtime/BuiltIns/FunctionBuiltIns.cs
+++ b/Runtime/BuiltIns/FunctionBuiltIns.cs
@@ -160,7 +160,7 @@ public static class FunctionBuiltIns
         // Arrow functions ignore thisArg
         if (callable is SharpTSArrowFunction arrow && !arrow.HasOwnThis)
         {
-            return callable.Call(interp, args);
+            return callable.CallBoxed(interp, args);
         }
 
         // For regular functions, we need to bind 'this'
@@ -168,31 +168,31 @@ public static class FunctionBuiltIns
         {
             // Create a temporary bound function
             var bound = new BoundFunction(fn, thisArg, new List<object?>());
-            return bound.Call(interp, args);
+            return bound.CallBoxed(interp, args);
         }
 
         if (callable is SharpTSArrowFunction arrowWithThis)
         {
             // Function expression with its own 'this'
             var bound = arrowWithThis.Bind(thisArg!);
-            return bound.Call(interp, args);
+            return bound.CallBoxed(interp, args);
         }
 
         // Array.prototype methods rebind their receiver via BindTo so that
         // Array.prototype.push.apply(target, items) pushes onto `target`.
         if (callable is SharpTSArrayUnboundMethod unbound)
         {
-            return unbound.BindTo(thisArg).Call(interp, args);
+            return unbound.BindTo(thisArg).CallBoxed(interp, args);
         }
         // Function.prototype.toString rebinds so that funcToString.call(fn) works.
         if (callable is SharpTSFunctionProtoToString fnToStr)
         {
-            return fnToStr.BindTo(thisArg).Call(interp, args);
+            return fnToStr.BindTo(thisArg).CallBoxed(interp, args);
         }
         // Object.prototype methods rebind to support hasOwnProperty.call(obj, key).
         if (callable is SharpTSObjectUnboundMethod objUnbound)
         {
-            return objUnbound.BindTo(thisArg).Call(interp, args);
+            return objUnbound.BindTo(thisArg).CallBoxed(interp, args);
         }
 
         // BuiltInMethod (e.g. Array.prototype.every exposed via
@@ -202,7 +202,7 @@ public static class FunctionBuiltIns
         // (typically null), and the implementation sees a null receiver.
         if (callable is BuiltInMethod builtIn)
         {
-            return builtIn.Bind(thisArg).Call(interp, args);
+            return builtIn.Bind(thisArg).CallBoxed(interp, args);
         }
 
         // Array.prototype adapter — same rebind story. Without this,
@@ -210,7 +210,7 @@ public static class FunctionBuiltIns
         // no receiver, silently skipping the spec-mandated ToObject / TypeError.
         if (callable is Types.ArrayPrototypeMethodWrapper arrayProto)
         {
-            return arrayProto.Bind(thisArg).Call(interp, args);
+            return arrayProto.Bind(thisArg).CallBoxed(interp, args);
         }
 
         // String.prototype adapter — same pattern. Rebind so
@@ -218,23 +218,23 @@ public static class FunctionBuiltIns
         // coercion + dispatch.
         if (callable is Types.StringPrototypeMethodWrapper stringProto)
         {
-            return stringProto.Bind(thisArg).Call(interp, args);
+            return stringProto.Bind(thisArg).CallBoxed(interp, args);
         }
 
         // Number.prototype adapter — same pattern.
         if (callable is Types.NumberPrototypeMethodWrapper numberProto)
         {
-            return numberProto.Bind(thisArg).Call(interp, args);
+            return numberProto.Bind(thisArg).CallBoxed(interp, args);
         }
 
         // Boolean.prototype adapter — same pattern.
         if (callable is Types.BooleanPrototypeMethodWrapper boolProto)
         {
-            return boolProto.Bind(thisArg).Call(interp, args);
+            return boolProto.Bind(thisArg).CallBoxed(interp, args);
         }
 
         // For other callables, just call directly
-        return callable.Call(interp, args);
+        return callable.CallBoxed(interp, args);
     }
 }
 
@@ -338,13 +338,13 @@ public class BoundFunction : ISharpTSCallable
                 // Since SharpTSFunction.Bind requires SharpTSInstance, we need a workaround
                 // We'll create a special environment handling in the BoundFunction call
                 var boundFn = CreateBoundSharpTSFunction(fn, _thisArg);
-                return boundFn.Call(interpreter, combinedArgs);
+                return boundFn.CallBoxed(interpreter, combinedArgs);
             }
 
             if (_target is SharpTSArrowFunction arrow && arrow.HasOwnThis)
             {
                 var boundArrow = arrow.Bind(_thisArg);
-                return boundArrow.Call(interpreter, combinedArgs);
+                return boundArrow.CallBoxed(interpreter, combinedArgs);
             }
 
             // Built-in methods read their receiver from the bound `_receiver`
@@ -355,12 +355,12 @@ public class BoundFunction : ISharpTSCallable
             // throws.
             if (_target is BuiltInMethod bim)
             {
-                return bim.Bind(_thisArg).Call(interpreter, combinedArgs);
+                return bim.Bind(_thisArg).CallBoxed(interpreter, combinedArgs);
             }
         }
 
         // For arrow functions or when no 'this' binding needed
-        return _target.Call(interpreter, combinedArgs);
+        return _target.CallBoxed(interpreter, combinedArgs);
     }
 
     /// <summary>
@@ -397,14 +397,14 @@ internal class BoundSharpTSFunctionWrapper : ISharpTSCallable
         if (_thisArg is SharpTSInstance instance)
         {
             var boundFn = _fn.Bind(instance);
-            return boundFn.Call(interpreter, arguments);
+            return boundFn.CallBoxed(interpreter, arguments);
         }
 
         // For non-instance 'this' values, we need to set up the environment manually
         // Create a synthetic instance that wraps the actual object
         var syntheticInstance = new SyntheticThisInstance(_thisArg);
         var boundFn2 = _fn.Bind(syntheticInstance);
-        var result = boundFn2.Call(interpreter, arguments);
+        var result = boundFn2.CallBoxed(interpreter, arguments);
         FlushSyntheticBack(syntheticInstance, _thisArg);
         return result;
     }

--- a/Runtime/BuiltIns/GeneratorBuiltIns.cs
+++ b/Runtime/BuiltIns/GeneratorBuiltIns.cs
@@ -83,7 +83,7 @@ public static class GeneratorBuiltIns
             var iter = WrapAsIterator((SharpTSGenerator)receiver!);
             var method = IteratorBuiltIns.GetMember(iter, name);
             if (method is BuiltInMethod bm)
-                return bm.Call(interp, args);
+                return bm.CallBoxed(interp, args);
             throw new Exception($"Runtime Error: Iterator method '{name}' not found.");
         });
     }

--- a/Runtime/BuiltIns/IteratorBuiltIns.cs
+++ b/Runtime/BuiltIns/IteratorBuiltIns.cs
@@ -52,7 +52,7 @@ public static class IteratorBuiltIns
         {
             callArgs[0] = item;
             callArgs[1] = index++;
-            yield return callback.Call(interp, callArgs);
+            yield return callback.CallBoxed(interp, callArgs);
         }
     }
 
@@ -71,7 +71,7 @@ public static class IteratorBuiltIns
         {
             callArgs[0] = item;
             callArgs[1] = index++;
-            if (IsTruthy(predicate.Call(interp, callArgs)))
+            if (IsTruthy(predicate.CallBoxed(interp, callArgs)))
                 yield return item;
         }
     }
@@ -128,7 +128,7 @@ public static class IteratorBuiltIns
         {
             callArgs[0] = item;
             callArgs[1] = index++;
-            var result = callback.Call(interp, callArgs);
+            var result = callback.CallBoxed(interp, callArgs);
             foreach (var inner in ToIterable(result))
                 yield return inner;
         }
@@ -154,7 +154,7 @@ public static class IteratorBuiltIns
             }
             callArgs[0] = accumulator;
             callArgs[1] = item;
-            accumulator = callback.Call(interp, callArgs);
+            accumulator = callback.CallBoxed(interp, callArgs);
         }
 
         if (first)
@@ -182,7 +182,7 @@ public static class IteratorBuiltIns
         {
             callArgs[0] = item;
             callArgs[1] = index++;
-            callback.Call(interp, callArgs);
+            callback.CallBoxed(interp, callArgs);
         }
         return null;
     }
@@ -198,7 +198,7 @@ public static class IteratorBuiltIns
         {
             callArgs[0] = item;
             callArgs[1] = index++;
-            if (IsTruthy(predicate.Call(interp, callArgs)))
+            if (IsTruthy(predicate.CallBoxed(interp, callArgs)))
                 return true;
         }
         return false;
@@ -215,7 +215,7 @@ public static class IteratorBuiltIns
         {
             callArgs[0] = item;
             callArgs[1] = index++;
-            if (!IsTruthy(predicate.Call(interp, callArgs)))
+            if (!IsTruthy(predicate.CallBoxed(interp, callArgs)))
                 return false;
         }
         return true;
@@ -232,7 +232,7 @@ public static class IteratorBuiltIns
         {
             callArgs[0] = item;
             callArgs[1] = index++;
-            if (IsTruthy(predicate.Call(interp, callArgs)))
+            if (IsTruthy(predicate.CallBoxed(interp, callArgs)))
                 return item;
         }
         return null;

--- a/Runtime/BuiltIns/JSONBuiltIns.cs
+++ b/Runtime/BuiltIns/JSONBuiltIns.cs
@@ -194,10 +194,10 @@ public static class JSONBuiltIns
         // bind attempt; we forward to their plain Call. Both other shapes
         // honor an explicit binding via their respective Bind helpers.
         if (reviver is SharpTSFunction fn)
-            return fn.BindThis(holder).Call(interp, [key, val]);
+            return fn.BindThis(holder).CallBoxed(interp, [key, val]);
         if (reviver is SharpTSArrowFunction arrow && arrow.HasOwnThis && holder != null)
-            return arrow.Bind(holder).Call(interp, [key, val]);
-        return reviver.Call(interp, [key, val]);
+            return arrow.Bind(holder).CallBoxed(interp, [key, val]);
+        return reviver.CallBoxed(interp, [key, val]);
     }
 
     private static object? StringifyJson(Interpreter interp, object? _, List<object?> args)
@@ -248,7 +248,7 @@ public static class JSONBuiltIns
     {
         if (replacer != null)
         {
-            value = replacer.Call(interp, [key, value]);
+            value = replacer.CallBoxed(interp, [key, value]);
         }
 
         // Check for toJSON() method before serializing
@@ -305,12 +305,12 @@ public static class JSONBuiltIns
         {
             var toJson = inst.GetClass().FindMethod("toJSON");
             if (toJson != null)
-                return SharpTSClass.BindMethod(toJson, inst).Call(interp, []);
+                return SharpTSClass.BindMethod(toJson, inst).CallBoxed(interp, []);
         }
         else if (value is SharpTSObject obj && obj.Fields.TryGetValue("toJSON", out var fn))
         {
             if (fn is ISharpTSCallable callable)
-                return callable.Call(interp, []);
+                return callable.CallBoxed(interp, []);
         }
         return value;
     }

--- a/Runtime/BuiltIns/MapBuiltIns.cs
+++ b/Runtime/BuiltIns/MapBuiltIns.cs
@@ -67,7 +67,7 @@ public static class MapBuiltIns
         {
             callbackArgs[0] = kvp.Value;
             callbackArgs[1] = kvp.Key;
-            callback.Call(interp, callbackArgs);
+            callback.CallBoxed(interp, callbackArgs);
         }
         return null;
     }
@@ -87,7 +87,7 @@ public static class MapBuiltIns
             var element = iterable[i];
             callbackArgs[0] = element;
             callbackArgs[1] = (double)i;
-            var key = callback.Call(interp, callbackArgs);
+            var key = callback.CallBoxed(interp, callbackArgs);
 
             var existing = result.Get(key);
             if (existing == null)

--- a/Runtime/BuiltIns/Modules/Interpreter/ChildProcessModuleInterpreter.cs
+++ b/Runtime/BuiltIns/Modules/Interpreter/ChildProcessModuleInterpreter.cs
@@ -245,7 +245,7 @@ public static class ChildProcessModuleInterpreter
                         {
                             ["message"] = "Command timed out"
                         }));
-                        callback?.Call(null!, [new SharpTSObject(new Dictionary<string, object?>
+                        callback?.CallBoxed(null!, [new SharpTSObject(new Dictionary<string, object?>
                         {
                             ["message"] = "Command timed out"
                         }), stdout, stderr]);
@@ -266,11 +266,11 @@ public static class ChildProcessModuleInterpreter
                         ["message"] = $"Command failed with exit code {process.ExitCode}",
                         ["code"] = (double)process.ExitCode
                     });
-                    callback?.Call(null!, [errorObj, stdout, stderr]);
+                    callback?.CallBoxed(null!, [errorObj, stdout, stderr]);
                 }
                 else
                 {
-                    callback?.Call(null!, [null, stdout, stderr]);
+                    callback?.CallBoxed(null!, [null, stdout, stderr]);
                 }
 
                 childProcess.EmitDirect("close", (double)process.ExitCode);
@@ -283,7 +283,7 @@ public static class ChildProcessModuleInterpreter
                     ["message"] = ex.Message
                 });
                 childProcess.EmitDirect("error", errorObj);
-                callback?.Call(null!, [errorObj, "", ""]);
+                callback?.CallBoxed(null!, [errorObj, "", ""]);
             }
         });
 
@@ -373,9 +373,9 @@ public static class ChildProcessModuleInterpreter
                     }
                     // Call the callback if provided (3rd arg in Node.js write(chunk, enc, cb))
                     if (wargs.Count > 2 && wargs[2] is ISharpTSCallable cb)
-                        cb.Call(null!, [null]);
+                        cb.CallBoxed(null!, [null]);
                     else if (wargs.Count > 1 && wargs[1] is ISharpTSCallable cb2)
-                        cb2.Call(null!, [null]);
+                        cb2.CallBoxed(null!, [null]);
                     return true;
                 }));
 
@@ -573,7 +573,7 @@ public static class ChildProcessModuleInterpreter
                         var timeoutErr = new SharpTSObject(new Dictionary<string, object?>
                             { ["message"] = "Command timed out" });
                         childProcess.EmitDirect("error", timeoutErr);
-                        callback?.Call(null!, [timeoutErr, stdout, stderr]);
+                        callback?.CallBoxed(null!, [timeoutErr, stdout, stderr]);
                         return;
                     }
                 }
@@ -591,11 +591,11 @@ public static class ChildProcessModuleInterpreter
                         ["message"] = $"Command failed with exit code {process.ExitCode}",
                         ["code"] = (double)process.ExitCode
                     });
-                    callback?.Call(null!, [errorObj, stdout, stderr]);
+                    callback?.CallBoxed(null!, [errorObj, stdout, stderr]);
                 }
                 else
                 {
-                    callback?.Call(null!, [null, stdout, stderr]);
+                    callback?.CallBoxed(null!, [null, stdout, stderr]);
                 }
 
                 childProcess.EmitDirect("close", (double)process.ExitCode);
@@ -606,7 +606,7 @@ public static class ChildProcessModuleInterpreter
                 var errorObj = new SharpTSObject(new Dictionary<string, object?>
                     { ["message"] = ex.Message });
                 childProcess.EmitDirect("error", errorObj);
-                callback?.Call(null!, [errorObj, "", ""]);
+                callback?.CallBoxed(null!, [errorObj, "", ""]);
             }
         });
 

--- a/Runtime/BuiltIns/Modules/Interpreter/CryptoModuleInterpreter.cs
+++ b/Runtime/BuiltIns/Modules/Interpreter/CryptoModuleInterpreter.cs
@@ -683,7 +683,7 @@ public static class CryptoModuleInterpreter
     {
         interpreter.ScheduleTimer(0, 0, () =>
         {
-            callback.Call(interpreter, [error, result]);
+            callback.CallBoxed(interpreter, [error, result]);
             interpreter.Unref();
         }, isInterval: false);
     }
@@ -819,7 +819,7 @@ public static class CryptoModuleInterpreter
                 // Node.js generateKeyPair callback is (err, publicKey, privateKey)
                 interpreter.ScheduleTimer(0, 0, () =>
                 {
-                    callback.Call(interpreter, [null, result.GetProperty("publicKey"), result.GetProperty("privateKey")]);
+                    callback.CallBoxed(interpreter, [null, result.GetProperty("publicKey"), result.GetProperty("privateKey")]);
                     interpreter.Unref();
                 }, isInterval: false);
             }

--- a/Runtime/BuiltIns/Modules/Interpreter/DgramModuleInterpreter.cs
+++ b/Runtime/BuiltIns/Modules/Interpreter/DgramModuleInterpreter.cs
@@ -36,7 +36,7 @@ public static class DgramModuleInterpreter
         if (args.Count > 1 && args[1] is ISharpTSCallable callback)
         {
             var onMethod = socket.GetMember("on") as BuiltInMethod;
-            onMethod?.Bind(socket).Call(interpreter, new List<object?> { "message", callback });
+            onMethod?.Bind(socket).CallBoxed(interpreter, new List<object?> { "message", callback });
         }
 
         return socket;
@@ -53,5 +53,8 @@ public static class DgramModuleInterpreter
         {
             return CreateSocket(interpreter, null, args);
         }
+
+        public RuntimeValue CallV2(Interp interpreter, ReadOnlySpan<RuntimeValue> arguments)
+            => RuntimeValue.FromBoxed(Call(interpreter, CallableInterop.ToBoxedList(arguments)));
     }
 }

--- a/Runtime/BuiltIns/Modules/Interpreter/DnsModuleInterpreter.cs
+++ b/Runtime/BuiltIns/Modules/Interpreter/DnsModuleInterpreter.cs
@@ -300,7 +300,7 @@ public static class DnsModuleInterpreter
                 var result = WrapDnsResult(raw);
                 interpreter.ScheduleTimer(0, 0, () =>
                 {
-                    callback.Call(interpreter, [null, result]);
+                    callback.CallBoxed(interpreter, [null, result]);
                     interpreter.Unref();
                 }, isInterval: false);
             }
@@ -308,7 +308,7 @@ public static class DnsModuleInterpreter
             {
                 interpreter.ScheduleTimer(0, 0, () =>
                 {
-                    callback.Call(interpreter, [CreateDnsError(ExtractErrorCode(ex), hostname), null]);
+                    callback.CallBoxed(interpreter, [CreateDnsError(ExtractErrorCode(ex), hostname), null]);
                     interpreter.Unref();
                 }, isInterval: false);
             }
@@ -332,7 +332,7 @@ public static class DnsModuleInterpreter
                 var wrapped = new SharpTSArray(result);
                 interpreter.ScheduleTimer(0, 0, () =>
                 {
-                    callback.Call(interpreter, [null, wrapped]);
+                    callback.CallBoxed(interpreter, [null, wrapped]);
                     interpreter.Unref();
                 }, isInterval: false);
             }
@@ -340,7 +340,7 @@ public static class DnsModuleInterpreter
             {
                 interpreter.ScheduleTimer(0, 0, () =>
                 {
-                    callback.Call(interpreter, [CreateDnsError(ExtractErrorCode(ex), hostname), null]);
+                    callback.CallBoxed(interpreter, [CreateDnsError(ExtractErrorCode(ex), hostname), null]);
                     interpreter.Unref();
                 }, isInterval: false);
             }
@@ -363,7 +363,7 @@ public static class DnsModuleInterpreter
                 var wrapped = new SharpTSArray(result);
                 interpreter.ScheduleTimer(0, 0, () =>
                 {
-                    callback.Call(interpreter, [null, wrapped]);
+                    callback.CallBoxed(interpreter, [null, wrapped]);
                     interpreter.Unref();
                 }, isInterval: false);
             }
@@ -371,7 +371,7 @@ public static class DnsModuleInterpreter
             {
                 interpreter.ScheduleTimer(0, 0, () =>
                 {
-                    callback.Call(interpreter, [CreateDnsError(ExtractErrorCode(ex), ip), null]);
+                    callback.CallBoxed(interpreter, [CreateDnsError(ExtractErrorCode(ex), ip), null]);
                     interpreter.Unref();
                 }, isInterval: false);
             }
@@ -396,7 +396,7 @@ public static class DnsModuleInterpreter
                 var result = WrapDnsResult(raw);
                 interpreter.ScheduleTimer(0, 0, () =>
                 {
-                    callback.Call(interpreter, [null, result]);
+                    callback.CallBoxed(interpreter, [null, result]);
                     interpreter.Unref();
                 }, isInterval: false);
             }
@@ -404,7 +404,7 @@ public static class DnsModuleInterpreter
             {
                 interpreter.ScheduleTimer(0, 0, () =>
                 {
-                    callback.Call(interpreter, [CreateDnsError(ExtractErrorCode(ex), hostname), null]);
+                    callback.CallBoxed(interpreter, [CreateDnsError(ExtractErrorCode(ex), hostname), null]);
                     interpreter.Unref();
                 }, isInterval: false);
             }
@@ -496,7 +496,7 @@ public static class DnsModuleInterpreter
                 var result = WrapDnsResult(raw);
                 interpreter.ScheduleTimer(0, 0, () =>
                 {
-                    callback.Call(interpreter, [null, result]);
+                    callback.CallBoxed(interpreter, [null, result]);
                     interpreter.Unref();
                 }, isInterval: false);
             }
@@ -504,7 +504,7 @@ public static class DnsModuleInterpreter
             {
                 interpreter.ScheduleTimer(0, 0, () =>
                 {
-                    callback.Call(interpreter, [CreateDnsError(ExtractErrorCode(ex), hostname), null]);
+                    callback.CallBoxed(interpreter, [CreateDnsError(ExtractErrorCode(ex), hostname), null]);
                     interpreter.Unref();
                 }, isInterval: false);
             }
@@ -554,7 +554,7 @@ public static class DnsModuleInterpreter
                 var result = WrapDnsResult(raw);
                 interpreter.ScheduleTimer(0, 0, () =>
                 {
-                    callback.Call(interpreter, [null, result]);
+                    callback.CallBoxed(interpreter, [null, result]);
                     interpreter.Unref();
                 }, isInterval: false);
             }
@@ -562,7 +562,7 @@ public static class DnsModuleInterpreter
             {
                 interpreter.ScheduleTimer(0, 0, () =>
                 {
-                    callback.Call(interpreter, [CreateDnsError(ExtractErrorCode(ex), hostname), null]);
+                    callback.CallBoxed(interpreter, [CreateDnsError(ExtractErrorCode(ex), hostname), null]);
                     interpreter.Unref();
                 }, isInterval: false);
             }
@@ -588,7 +588,7 @@ public static class DnsModuleInterpreter
                 var result = ResolveAddresses(hostname, AddressFamily.InterNetwork);
                 interpreter.ScheduleTimer(0, 0, () =>
                 {
-                    callback.Call(interpreter, [null, result]);
+                    callback.CallBoxed(interpreter, [null, result]);
                     interpreter.Unref();
                 }, isInterval: false);
             }
@@ -596,7 +596,7 @@ public static class DnsModuleInterpreter
             {
                 interpreter.ScheduleTimer(0, 0, () =>
                 {
-                    callback.Call(interpreter, [CreateDnsError(GetErrorCode(ex), hostname), null]);
+                    callback.CallBoxed(interpreter, [CreateDnsError(GetErrorCode(ex), hostname), null]);
                     interpreter.Unref();
                 }, isInterval: false);
             }
@@ -622,7 +622,7 @@ public static class DnsModuleInterpreter
                 var result = ResolveAddresses(hostname, AddressFamily.InterNetworkV6);
                 interpreter.ScheduleTimer(0, 0, () =>
                 {
-                    callback.Call(interpreter, [null, result]);
+                    callback.CallBoxed(interpreter, [null, result]);
                     interpreter.Unref();
                 }, isInterval: false);
             }
@@ -630,7 +630,7 @@ public static class DnsModuleInterpreter
             {
                 interpreter.ScheduleTimer(0, 0, () =>
                 {
-                    callback.Call(interpreter, [CreateDnsError(GetErrorCode(ex), hostname), null]);
+                    callback.CallBoxed(interpreter, [CreateDnsError(GetErrorCode(ex), hostname), null]);
                     interpreter.Unref();
                 }, isInterval: false);
             }
@@ -660,7 +660,7 @@ public static class DnsModuleInterpreter
                 var hostnames = new SharpTSArray(new List<object?> { hostEntry.HostName });
                 interpreter.ScheduleTimer(0, 0, () =>
                 {
-                    callback.Call(interpreter, [null, hostnames]);
+                    callback.CallBoxed(interpreter, [null, hostnames]);
                     interpreter.Unref();
                 }, isInterval: false);
             }
@@ -668,7 +668,7 @@ public static class DnsModuleInterpreter
             {
                 interpreter.ScheduleTimer(0, 0, () =>
                 {
-                    callback.Call(interpreter, [CreateDnsError(GetErrorCode(ex), ip), null]);
+                    callback.CallBoxed(interpreter, [CreateDnsError(GetErrorCode(ex), ip), null]);
                     interpreter.Unref();
                 }, isInterval: false);
             }
@@ -676,7 +676,7 @@ public static class DnsModuleInterpreter
             {
                 interpreter.ScheduleTimer(0, 0, () =>
                 {
-                    callback.Call(interpreter, [CreateDnsError("EAI_FAIL", ip), null]);
+                    callback.CallBoxed(interpreter, [CreateDnsError("EAI_FAIL", ip), null]);
                     interpreter.Unref();
                 }, isInterval: false);
             }

--- a/Runtime/BuiltIns/Modules/Interpreter/FsAsyncHelpers.cs
+++ b/Runtime/BuiltIns/Modules/Interpreter/FsAsyncHelpers.cs
@@ -543,7 +543,7 @@ public static class FsAsyncHelpers
         var getTime = dateObj.GetProperty("getTime");
         if (getTime is BuiltInMethod method)
         {
-            var result = method.Bind(dateObj).Call(null!, []);
+            var result = method.Bind(dateObj).CallBoxed(null!, []);
             if (result is double ms)
             {
                 return DateTimeOffset.FromUnixTimeMilliseconds((long)ms).LocalDateTime;

--- a/Runtime/BuiltIns/Modules/Interpreter/FsModuleInterpreter.cs
+++ b/Runtime/BuiltIns/Modules/Interpreter/FsModuleInterpreter.cs
@@ -678,7 +678,7 @@ public static class FsModuleInterpreter
         if (getTime is BuiltInMethod method)
         {
             // BuiltInMethod.Call needs an Interpreter but we pass null since getTime doesn't use it
-            var result = method.Bind(dateObj).Call(null!, []);
+            var result = method.Bind(dateObj).CallBoxed(null!, []);
             if (result is double ms)
             {
                 return DateTimeOffset.FromUnixTimeMilliseconds((long)ms).LocalDateTime;
@@ -951,7 +951,7 @@ public static class FsModuleInterpreter
     {
         interpreter.ScheduleTimer(0, 0, () =>
         {
-            callback.Call(interpreter, [error, result]);
+            callback.CallBoxed(interpreter, [error, result]);
         }, isInterval: false);
     }
 
@@ -1562,7 +1562,7 @@ public static class FsModuleInterpreter
             if (args.Count > 1 && args[1] is ISharpTSCallable listener)
             {
                 var offMethod = watcher.GetMember("off") as BuiltInMethod;
-                offMethod?.Call(interpreter, ["change", listener]);
+                offMethod?.CallBoxed(interpreter, ["change", listener]);
             }
             else
             {

--- a/Runtime/BuiltIns/Modules/Interpreter/HttpModuleInterpreter.cs
+++ b/Runtime/BuiltIns/Modules/Interpreter/HttpModuleInterpreter.cs
@@ -106,7 +106,7 @@ public static class HttpModuleInterpreter
         }
 
         // Delegate to fetch - use Call which returns a Promise
-        var promise = FetchBuiltIns.FetchMethod.Call(interpreter, new List<object?> { url, options });
+        var promise = FetchBuiltIns.FetchMethod.CallBoxed(interpreter, new List<object?> { url, options });
         if (promise is SharpTSPromise fetchPromise)
         {
             return await fetchPromise.GetValueAsync();
@@ -242,5 +242,8 @@ public static class HttpModuleInterpreter
             // Do nothing - user must add 'request' event listener
             return null;
         }
+
+        public RuntimeValue CallV2(Interp interpreter, ReadOnlySpan<RuntimeValue> arguments)
+            => RuntimeValue.FromBoxed(Call(interpreter, CallableInterop.ToBoxedList(arguments)));
     }
 }

--- a/Runtime/BuiltIns/Modules/Interpreter/NetModuleInterpreter.cs
+++ b/Runtime/BuiltIns/Modules/Interpreter/NetModuleInterpreter.cs
@@ -65,7 +65,7 @@ public static class NetModuleInterpreter
 
         // Delegate to socket.connect()
         var connectMethod = socket.GetMember("connect") as BuiltInMethod;
-        connectMethod?.Bind(socket).Call(interpreter, args);
+        connectMethod?.Bind(socket).CallBoxed(interpreter, args);
 
         return socket;
     }

--- a/Runtime/BuiltIns/Modules/Interpreter/ProcessModuleInterpreter.cs
+++ b/Runtime/BuiltIns/Modules/Interpreter/ProcessModuleInterpreter.cs
@@ -82,19 +82,19 @@ public static class ProcessModuleInterpreter
     {
         // Delegate to ProcessBuiltIns via GetMember to use cached implementation
         var method = ProcessBuiltIns.GetMember("hrtime") as BuiltInMethod;
-        return method?.Call(interpreter, args);
+        return method?.CallBoxed(interpreter, args);
     }
 
     private static object? Uptime(Interp interpreter, object? receiver, List<object?> args)
     {
         var method = ProcessBuiltIns.GetMember("uptime") as BuiltInMethod;
-        return method?.Call(interpreter, args);
+        return method?.CallBoxed(interpreter, args);
     }
 
     private static object? MemoryUsage(Interp interpreter, object? receiver, List<object?> args)
     {
         var method = ProcessBuiltIns.GetMember("memoryUsage") as BuiltInMethod;
-        return method?.Call(interpreter, args);
+        return method?.CallBoxed(interpreter, args);
     }
 
     /// <summary>

--- a/Runtime/BuiltIns/Modules/Interpreter/StreamModuleInterpreter.cs
+++ b/Runtime/BuiltIns/Modules/Interpreter/StreamModuleInterpreter.cs
@@ -90,7 +90,7 @@ public static class StreamModuleInterpreter
         {
             if (called) return;
             called = true;
-            cbRef.Call(interp, [error]);
+            cbRef.CallBoxed(interp, [error]);
         }
 
         // Create listener callables
@@ -160,7 +160,7 @@ public static class StreamModuleInterpreter
 
             // Call pipe on source
             var pipeMethod = GetStreamMethod(source, "pipe");
-            pipeMethod?.Call(interpreter, [dest]);
+            pipeMethod?.CallBoxed(interpreter, [dest]);
         }
 
         // Attach error listeners on all streams for auto-destroy
@@ -181,10 +181,10 @@ public static class StreamModuleInterpreter
                     foreach (var stream in streams)
                     {
                         var destroyMethod = GetStreamMethod(stream, "destroy");
-                        destroyMethod?.Call(interp, []);
+                        destroyMethod?.CallBoxed(interp, []);
                     }
 
-                    finalCallback?.Call(interp, [error]);
+                    finalCallback?.CallBoxed(interp, [error]);
                 }), once: true);
             }
         }
@@ -198,7 +198,7 @@ public static class StreamModuleInterpreter
             lastEmitter.AddListenerDirect(eventName, new FinishedListener((interp, _) =>
             {
                 if (!errorCalled)
-                    finalCallback?.Call(interp, [null]);
+                    finalCallback?.CallBoxed(interp, [null]);
             }), once: true);
         }
 
@@ -244,5 +244,8 @@ public static class StreamModuleInterpreter
             _action(interpreter, arguments);
             return null;
         }
+
+        public RuntimeValue CallV2(Interp interpreter, ReadOnlySpan<RuntimeValue> arguments)
+            => RuntimeValue.FromBoxed(Call(interpreter, CallableInterop.ToBoxedList(arguments)));
     }
 }

--- a/Runtime/BuiltIns/Modules/Interpreter/VmModuleInterpreter.cs
+++ b/Runtime/BuiltIns/Modules/Interpreter/VmModuleInterpreter.cs
@@ -486,4 +486,7 @@ public sealed class VmScriptConstructor : ISharpTSCallable
             ["runInContext"] = runInCtx,
         };
     }
+
+    public RuntimeValue CallV2(Interp interpreter, ReadOnlySpan<RuntimeValue> arguments)
+        => RuntimeValue.FromBoxed(Call(interpreter, CallableInterop.ToBoxedList(arguments)));
 }

--- a/Runtime/BuiltIns/Modules/Interpreter/ZlibModuleInterpreter.cs
+++ b/Runtime/BuiltIns/Modules/Interpreter/ZlibModuleInterpreter.cs
@@ -354,11 +354,11 @@ public static class ZlibModuleInterpreter
                 else
                     result = ZlibHelpers.DeflateRawDecompress(input, options);
 
-                callback?.Call(interpreter, [null, new SharpTSBuffer(result)]);
+                callback?.CallBoxed(interpreter, [null, new SharpTSBuffer(result)]);
             }
             catch (Exception ex)
             {
-                callback?.Call(interpreter, [ex.Message]);
+                callback?.CallBoxed(interpreter, [ex.Message]);
             }
         }, isInterval: false);
 
@@ -377,11 +377,11 @@ public static class ZlibModuleInterpreter
             try
             {
                 var result = operation(input, options);
-                callback?.Call(interpreter, [null, new SharpTSBuffer(result)]);
+                callback?.CallBoxed(interpreter, [null, new SharpTSBuffer(result)]);
             }
             catch (Exception ex)
             {
-                callback?.Call(interpreter, [ex.Message]);
+                callback?.CallBoxed(interpreter, [ex.Message]);
             }
         }, isInterval: false);
 

--- a/Runtime/BuiltIns/ObjectBuiltIns.cs
+++ b/Runtime/BuiltIns/ObjectBuiltIns.cs
@@ -1903,7 +1903,7 @@ public static class ObjectBuiltIns
             var element = iterable[i];
             callbackArgs[0] = element;
             callbackArgs[1] = (double)i;
-            var key = callback.Call(interp, callbackArgs);
+            var key = callback.CallBoxed(interp, callbackArgs);
             var keyStr = key?.ToString() ?? "undefined";
 
             if (!groups.TryGetValue(keyStr, out var existing))

--- a/Runtime/BuiltIns/ProcessBuiltIns.cs
+++ b/Runtime/BuiltIns/ProcessBuiltIns.cs
@@ -287,7 +287,7 @@ public static class ProcessBuiltIns
             {
                 // Use interpreter-based emit for interpreted mode
                 var emit = process.GetMember("emit") as BuiltInMethod;
-                emit?.Bind(process).Call(interpreter, ["exit", (double)exitCode]);
+                emit?.Bind(process).CallBoxed(interpreter, ["exit", (double)exitCode]);
             }
             else
             {
@@ -346,7 +346,7 @@ public static class ProcessBuiltIns
                 var offMethod = process.GetMember(methodName) as BuiltInMethod;
                 if (offMethod != null)
                 {
-                    return offMethod.Bind(process).Call(null!, args.ToList<object?>());
+                    return offMethod.Bind(process).CallBoxed(null!, args.ToList<object?>());
                 }
                 return process;
 
@@ -354,7 +354,7 @@ public static class ProcessBuiltIns
                 var removeMethod = process.GetMember(methodName) as BuiltInMethod;
                 if (removeMethod != null)
                 {
-                    return removeMethod.Bind(process).Call(null!, args.ToList<object?>());
+                    return removeMethod.Bind(process).CallBoxed(null!, args.ToList<object?>());
                 }
                 return process;
 
@@ -362,7 +362,7 @@ public static class ProcessBuiltIns
                 var lcMethod = process.GetMember(methodName) as BuiltInMethod;
                 if (lcMethod != null)
                 {
-                    return lcMethod.Bind(process).Call(null!, args.ToList<object?>());
+                    return lcMethod.Bind(process).CallBoxed(null!, args.ToList<object?>());
                 }
                 return 0.0;
 
@@ -375,7 +375,7 @@ public static class ProcessBuiltIns
                 var method = process.GetMember(methodName) as BuiltInMethod;
                 if (method != null)
                 {
-                    return method.Bind(process).Call(null!, args.ToList<object?>());
+                    return method.Bind(process).CallBoxed(null!, args.ToList<object?>());
                 }
                 return process;
 
@@ -404,7 +404,7 @@ public static class ProcessBuiltIns
             if (interpreter != null)
             {
                 var emit = process.GetMember("emit") as BuiltInMethod;
-                var result = emit?.Bind(process).Call(interpreter, ["uncaughtException", errorObj]);
+                var result = emit?.Bind(process).CallBoxed(interpreter, ["uncaughtException", errorObj]);
                 return result is true;
             }
             else

--- a/Runtime/BuiltIns/PromiseBuiltIns.cs
+++ b/Runtime/BuiltIns/PromiseBuiltIns.cs
@@ -535,7 +535,7 @@ public static class PromiseBuiltIns
     /// </summary>
     private static object? CallCallback(ISharpTSCallable callback, List<object?> args, Interpreter interpreter)
     {
-        return callback.Call(interpreter, args);
+        return callback.CallBoxed(interpreter, args);
     }
 
     /// <summary>

--- a/Runtime/BuiltIns/ReflectBuiltIns.cs
+++ b/Runtime/BuiltIns/ReflectBuiltIns.cs
@@ -355,14 +355,14 @@ public static class ReflectBuiltIns
                 if (target is SharpTSFunction fn)
                 {
                     var bound = new BoundFunction(fn, thisArg, []);
-                    return bound.Call(interpreter, callArgs);
+                    return bound.CallBoxed(interpreter, callArgs);
                 }
                 if (target is SharpTSArrowFunction arrow && arrow.HasOwnThis)
                 {
                     var bound = arrow.Bind(thisArg!);
-                    return bound.Call(interpreter, callArgs);
+                    return bound.CallBoxed(interpreter, callArgs);
                 }
-                return target.Call(interpreter, callArgs);
+                return target.CallBoxed(interpreter, callArgs);
             }),
 
             "construct" => new BuiltInMethod("construct", 2, 3, (interpreter, _, args) =>
@@ -409,11 +409,11 @@ public static class ReflectBuiltIns
 
                 if (target is SharpTSClass cls)
                 {
-                    return cls.Call(interpreter, callArgs);
+                    return cls.CallBoxed(interpreter, callArgs);
                 }
                 if (target is ISharpTSCallable callable)
                 {
-                    return callable.Call(interpreter, callArgs);
+                    return callable.CallBoxed(interpreter, callArgs);
                 }
                 throw new ThrowException(new SharpTSTypeError(
                     "Reflect.construct target is not a constructor"));
@@ -484,5 +484,8 @@ public static class ReflectBuiltIns
             // Return undefined (decorators that don't modify return void/undefined)
             return null;
         }
+
+        public RuntimeValue CallV2(Interpreter interpreter, ReadOnlySpan<RuntimeValue> arguments)
+            => RuntimeValue.FromBoxed(Call(interpreter, CallableInterop.ToBoxedList(arguments)));
     }
 }

--- a/Runtime/BuiltIns/RegExpBuiltIns.cs
+++ b/Runtime/BuiltIns/RegExpBuiltIns.cs
@@ -180,7 +180,7 @@ public static class RegExpBuiltIns
             && receiver.TryGetAccessor(name, out var userGetter, out _)
             && userGetter != null)
         {
-            return userGetter.Call(interpreter, []);
+            return userGetter.CallBoxed(interpreter, []);
         }
 
         // User-set DATA properties (set via `r.foo = x` after
@@ -1013,13 +1013,13 @@ public static class RegExpBuiltIns
         if (obj is SharpTSFunction fn)
         {
             if (fn.TryGetSymbolAccessor(symbol, out var getter, out _) && getter != null)
-                return getter.Call(interp, []);
+                return getter.CallBoxed(interp, []);
             if (fn.TryGetSymbolProperty(symbol, out var v)) return v;
         }
         if (obj is SharpTSArrowFunction arr)
         {
             if (arr.TryGetSymbolAccessor(symbol, out var arrGetter, out _) && arrGetter != null)
-                return arrGetter.Call(interp, []);
+                return arrGetter.CallBoxed(interp, []);
             if (arr.TryGetSymbolProperty(symbol, out var v2)) return v2;
         }
         return null;

--- a/Runtime/BuiltIns/SetBuiltIns.cs
+++ b/Runtime/BuiltIns/SetBuiltIns.cs
@@ -76,7 +76,7 @@ public static class SetBuiltIns
         {
             callbackArgs[0] = value;
             callbackArgs[1] = value;
-            callback.Call(interp, callbackArgs);
+            callback.CallBoxed(interp, callbackArgs);
         }
         return null;
     }

--- a/Runtime/BuiltIns/TimerBuiltIns.cs
+++ b/Runtime/BuiltIns/TimerBuiltIns.cs
@@ -36,7 +36,7 @@ public static class TimerBuiltIns
             {
                 try
                 {
-                    callback.Call(interpreter, args);
+                    callback.CallBoxed(interpreter, args);
                 }
                 finally
                 {
@@ -94,7 +94,7 @@ public static class TimerBuiltIns
         {
             if (!cts.IsCancellationRequested && !interpreter.IsDisposed)
             {
-                callback.Call(interpreter, args);
+                callback.CallBoxed(interpreter, args);
             }
         }, isInterval: true);
 

--- a/Runtime/BuiltIns/WorkerBuiltIns.cs
+++ b/Runtime/BuiltIns/WorkerBuiltIns.cs
@@ -125,6 +125,9 @@ internal class SharedArrayBufferConstructorImpl : ISharpTSCallable
         return new SharpTSSharedArrayBuffer((int)length);
     }
 
+    public RuntimeValue CallV2(Interpreter interpreter, ReadOnlySpan<RuntimeValue> arguments)
+        => RuntimeValue.FromBoxed(Call(interpreter, CallableInterop.ToBoxedList(arguments)));
+
     public object? GetProperty(string name)
     {
         return name switch
@@ -149,6 +152,9 @@ internal class ArrayBufferConstructorImpl : ISharpTSCallable
 
         return new SharpTSArrayBuffer((int)length);
     }
+
+    public RuntimeValue CallV2(Interpreter interpreter, ReadOnlySpan<RuntimeValue> arguments)
+        => RuntimeValue.FromBoxed(Call(interpreter, CallableInterop.ToBoxedList(arguments)));
 
     public object? GetProperty(string name)
     {
@@ -237,6 +243,9 @@ internal class TypedArrayConstructorImpl<T> : ISharpTSCallable where T : SharpTS
         throw new Exception("Invalid arguments for TypedArray constructor");
     }
 
+    public RuntimeValue CallV2(Interpreter interpreter, ReadOnlySpan<RuntimeValue> arguments)
+        => RuntimeValue.FromBoxed(Call(interpreter, CallableInterop.ToBoxedList(arguments)));
+
     public object? GetProperty(string name)
     {
         return name switch
@@ -294,6 +303,9 @@ internal class DataViewConstructorImpl : ISharpTSCallable
 
         throw new Exception("TypeError: First argument to DataView constructor must be an ArrayBuffer or SharedArrayBuffer");
     }
+
+    public RuntimeValue CallV2(Interpreter interpreter, ReadOnlySpan<RuntimeValue> arguments)
+        => RuntimeValue.FromBoxed(Call(interpreter, CallableInterop.ToBoxedList(arguments)));
 
     public object? GetProperty(string name)
     {

--- a/Runtime/DotNet/DotNetClass.cs
+++ b/Runtime/DotNet/DotNetClass.cs
@@ -73,6 +73,9 @@ public sealed class DotNetClass : ISharpTSCallable, ITypeCategorized
         });
     }
 
+    public RuntimeValue CallV2(Interpreter interpreter, ReadOnlySpan<RuntimeValue> arguments)
+        => RuntimeValue.FromBoxed(Call(interpreter, CallableInterop.ToBoxedList(arguments)));
+
     /// <summary>
     /// Evaluates <c>ClassName.member</c> for static access.
     /// </summary>

--- a/Runtime/DotNet/DotNetDelegateShim.cs
+++ b/Runtime/DotNet/DotNetDelegateShim.cs
@@ -104,7 +104,7 @@ internal static class DotNetDelegateShim
             argsList.Add(WrapIncoming(rawArgs[i]));
         }
 
-        var result = callable.Call(interpreter, argsList);
+        var result = callable.CallBoxed(interpreter, argsList);
 
         if (returnType == typeof(void)) return null;
         return DotNetMarshaller.Convert(result, returnType, interpreter);

--- a/Runtime/DotNet/DotNetEventBinder.cs
+++ b/Runtime/DotNet/DotNetEventBinder.cs
@@ -97,6 +97,9 @@ internal sealed class DotNetEventBinder : ISharpTSCallable
         return SharpTSUndefined.Instance;
     }
 
+    public RuntimeValue CallV2(Interpreter interpreter, ReadOnlySpan<RuntimeValue> arguments)
+        => RuntimeValue.FromBoxed(Call(interpreter, CallableInterop.ToBoxedList(arguments)));
+
     // ----------------------------------------------------------------------
     // Compile-mode entry points
     // ----------------------------------------------------------------------

--- a/Runtime/DotNet/DotNetMethod.cs
+++ b/Runtime/DotNet/DotNetMethod.cs
@@ -53,6 +53,9 @@ internal sealed class DotNetMethod : ISharpTSCallable
         });
     }
 
+    public RuntimeValue CallV2(Interpreter interpreter, ReadOnlySpan<RuntimeValue> arguments)
+        => RuntimeValue.FromBoxed(Call(interpreter, CallableInterop.ToBoxedList(arguments)));
+
     /// <summary>
     /// Marshals TS arguments into a .NET argument array matching the resolved parameter list,
     /// honoring params-array semantics and default values. The interpreter reference is

--- a/Runtime/RuntimeCallableDispatcher.cs
+++ b/Runtime/RuntimeCallableDispatcher.cs
@@ -62,7 +62,7 @@ public static class RuntimeCallableDispatcher
         switch (callable)
         {
             case ISharpTSCallable tsCallable:
-                return tsCallable.Call(interpreter!, args.ToList());
+                return tsCallable.CallBoxed(interpreter!, args.ToList());
 
             case SharpTS.Compilation.TSFunction tsFunc:
                 return tsFunc.Invoke(args);

--- a/Runtime/Types/ClusterSingleton.cs
+++ b/Runtime/Types/ClusterSingleton.cs
@@ -80,7 +80,7 @@ public class ClusterSingleton : SharpTSEventEmitter
         // If callback provided, invoke it after disconnect
         if (callback is ISharpTSCallable callable)
         {
-            callable.Call(null!, []);
+            callable.CallBoxed(null!, []);
         }
     }
 
@@ -139,7 +139,7 @@ public class ClusterSingleton : SharpTSEventEmitter
         {
             try
             {
-                emitMethod.Call(null!, args);
+                emitMethod.CallBoxed(null!, args);
             }
             catch
             {

--- a/Runtime/Types/PromiseCallbacks.cs
+++ b/Runtime/Types/PromiseCallbacks.cs
@@ -18,10 +18,13 @@ public class PromiseResolveCallback : ISharpTSCallable
     public int Arity() => 0; // 0 minimum - resolve can be called with 0 or 1 argument
 
     public object? Call(Interpreter interpreter, List<object?> arguments)
+        => CallV2(interpreter, CallableInterop.ToRuntimeValues(arguments)).ToObject();
+
+    public RuntimeValue CallV2(Interpreter interpreter, ReadOnlySpan<RuntimeValue> arguments)
     {
-        var value = arguments.Count > 0 ? arguments[0] : null;
+        var value = arguments.Length > 0 ? arguments[0].ToObject() : null;
         _resolve(value);
-        return SharpTSUndefined.Instance;
+        return RuntimeValue.Undefined;
     }
 }
 
@@ -41,9 +44,12 @@ public class PromiseRejectCallback : ISharpTSCallable
     public int Arity() => 0; // 0 minimum - reject can be called with 0 or 1 argument
 
     public object? Call(Interpreter interpreter, List<object?> arguments)
+        => CallV2(interpreter, CallableInterop.ToRuntimeValues(arguments)).ToObject();
+
+    public RuntimeValue CallV2(Interpreter interpreter, ReadOnlySpan<RuntimeValue> arguments)
     {
-        var reason = arguments.Count > 0 ? arguments[0] : null;
+        var reason = arguments.Length > 0 ? arguments[0].ToObject() : null;
         _reject(reason);
-        return SharpTSUndefined.Instance;
+        return RuntimeValue.Undefined;
     }
 }

--- a/Runtime/Types/SharpTSAbortSignal.cs
+++ b/Runtime/Types/SharpTSAbortSignal.cs
@@ -158,14 +158,14 @@ public class SharpTSAbortSignal : ITypeCategorized
         // ISharpTSCallable from interpreter — needs interpreter
         if (listener is ISharpTSCallable callable)
         {
-            callable.Call(interpreter!, []);
+            callable.CallV2(interpreter!, []);
             return;
         }
 
         // BuiltInMethod
         if (listener is BuiltInMethod builtIn)
         {
-            builtIn.Call(interpreter!, []);
+            builtIn.CallV2(interpreter!, []);
             return;
         }
 

--- a/Runtime/Types/SharpTSArrayGlobal.cs
+++ b/Runtime/Types/SharpTSArrayGlobal.cs
@@ -48,6 +48,9 @@ public sealed class SharpTSArrayGlobal : ISharpTSCallable
         return new SharpTSArray(new List<object?>(arguments));
     }
 
+    public RuntimeValue CallV2(Interp interpreter, ReadOnlySpan<RuntimeValue> arguments)
+        => RuntimeValue.FromBoxed(Call(interpreter, CallableInterop.ToBoxedList(arguments)));
+
     public object? GetMember(string name)
     {
         if (name == "prototype") return _prototype;
@@ -144,7 +147,7 @@ internal sealed class ArrayPrototypeMethodWrapper : ISharpTSCallable
 
         // Fast path: receiver is a real array.
         if (_receiver is SharpTSArray arr)
-            return _inner.Bind(arr).Call(interpreter, arguments);
+            return _inner.Bind(arr).CallBoxed(interpreter, arguments);
 
         // Slow path: receiver is array-like (object with `length` + indexed
         // props, or a string). ECMA-262 spec: ToObject(this), then iterate via
@@ -156,13 +159,16 @@ internal sealed class ArrayPrototypeMethodWrapper : ISharpTSCallable
         if (TryMaterializeArrayLike(_receiver, interpreter, out var tempArr))
         {
             var wrappedArgs = WrapCallbackArguments(arguments, tempArr, _receiver);
-            return _inner.Bind(tempArr).Call(interpreter, wrappedArgs);
+            return _inner.Bind(tempArr).CallBoxed(interpreter, wrappedArgs);
         }
 
         // Fallback: receiver type we can't coerce — let the inner method try.
         // It will likely throw a meaningful error.
-        return _inner.Bind(_receiver).Call(interpreter, arguments);
+        return _inner.Bind(_receiver).CallBoxed(interpreter, arguments);
     }
+
+    public RuntimeValue CallV2(Interp interpreter, ReadOnlySpan<RuntimeValue> arguments)
+        => RuntimeValue.FromBoxed(Call(interpreter, CallableInterop.ToBoxedList(arguments)));
 
     /// <summary>
     /// Attempts to build a temp <see cref="SharpTSArray"/> matching the
@@ -237,7 +243,7 @@ internal sealed class ArrayPrototypeMethodWrapper : ISharpTSCallable
     {
         var getter = obj.GetGetter(name);
         if (getter != null)
-            return getter.Call(interpreter, new List<object?>());
+            return getter.CallV2(interpreter, []).ToObject();
         return obj.GetProperty(name);
     }
 
@@ -316,8 +322,11 @@ internal sealed class ArrayPrototypeMethodWrapper : ISharpTSCallable
                 if (ReferenceEquals(arguments[i], _tempArr))
                     arguments[i] = _originalReceiver;
             }
-            return _inner.Call(interpreter, arguments);
+            return _inner.CallBoxed(interpreter, arguments);
         }
+
+        public RuntimeValue CallV2(Interp interpreter, ReadOnlySpan<RuntimeValue> arguments)
+            => RuntimeValue.FromBoxed(Call(interpreter, CallableInterop.ToBoxedList(arguments)));
     }
 }
 
@@ -376,6 +385,9 @@ public sealed class SharpTSArrayUnboundMethod : ISharpTSCallable
         }
         return _impl(target, rest);
     }
+
+    public RuntimeValue CallV2(Interp interpreter, ReadOnlySpan<RuntimeValue> arguments)
+        => RuntimeValue.FromBoxed(Call(interpreter, CallableInterop.ToBoxedList(arguments)));
 
     /// <summary>
     /// Produces a bound variant — used by <c>Function.prototype.apply/call</c>

--- a/Runtime/Types/SharpTSAsyncLocalStorage.cs
+++ b/Runtime/Types/SharpTSAsyncLocalStorage.cs
@@ -132,7 +132,7 @@ public class SharpTSAsyncLocalStorage
     private static object? InvokeCallback(Interp? interpreter, object? callback, List<object?> args)
     {
         if (callback is ISharpTSCallable callable)
-            return callable.Call(interpreter!, args);
+            return callable.CallBoxed(interpreter!, args);
 
         // Compiled mode: use reflection to find Invoke(object[]) on emitted types
         var invokeMethod = callback?.GetType().GetMethod("Invoke", [typeof(object?[])]);

--- a/Runtime/Types/SharpTSAsyncLocalStorageConstructor.cs
+++ b/Runtime/Types/SharpTSAsyncLocalStorageConstructor.cs
@@ -18,8 +18,11 @@ public sealed class SharpTSAsyncLocalStorageConstructor : ISharpTSCallable
     public int Arity() => 0;
 
     public object? Call(Interp interpreter, List<object?> arguments)
+        => CallV2(interpreter, CallableInterop.ToRuntimeValues(arguments)).ToObject();
+
+    public RuntimeValue CallV2(Interp interpreter, ReadOnlySpan<RuntimeValue> arguments)
     {
-        return new SharpTSAsyncLocalStorage();
+        return RuntimeValue.FromObject(new SharpTSAsyncLocalStorage());
     }
 
     public override string ToString() => "[Function: AsyncLocalStorage]";

--- a/Runtime/Types/SharpTSBroadcastChannel.cs
+++ b/Runtime/Types/SharpTSBroadcastChannel.cs
@@ -253,7 +253,7 @@ public class SharpTSBroadcastChannel : SharpTSEventEmitter, IDisposable
             // Also invoke the property-style onmessage handler if set (WHATWG spec).
             if (_onMessageHandler is ISharpTSCallable callable)
             {
-                try { callable.Call(_ownerInterpreter, [eventData]); }
+                try { callable.CallBoxed(_ownerInterpreter, [eventData]); }
                 catch { /* listeners may not throw out of delivery */ }
             }
         }
@@ -370,4 +370,7 @@ internal class BroadcastChannelConstructor : ISharpTSCallable
         };
         return channel;
     }
+
+    public RuntimeValue CallV2(Interp interpreter, ReadOnlySpan<RuntimeValue> arguments)
+        => RuntimeValue.FromBoxed(Call(interpreter, CallableInterop.ToBoxedList(arguments)));
 }

--- a/Runtime/Types/SharpTSBuiltInConstructor.cs
+++ b/Runtime/Types/SharpTSBuiltInConstructor.cs
@@ -33,6 +33,9 @@ public sealed class SharpTSBuiltInConstructor : ISharpTSCallable
         return _factory(arguments);
     }
 
+    public RuntimeValue CallV2(Interp interpreter, ReadOnlySpan<RuntimeValue> arguments)
+        => RuntimeValue.FromBoxed(Call(interpreter, CallableInterop.ToBoxedList(arguments)));
+
     /// <summary>
     /// Resolves static methods like <c>Map.groupBy()</c> via the built-in registry.
     /// Called by the interpreter's GetFieldsProperty dispatch chain via reflection.

--- a/Runtime/Types/SharpTSCallbackifiedFunction.cs
+++ b/Runtime/Types/SharpTSCallbackifiedFunction.cs
@@ -46,20 +46,23 @@ public class SharpTSCallbackifiedFunction : ISharpTSCallable
         try
         {
             // Call the original function
-            var result = _wrapped.Call(interpreter, originalArgs);
+            var result = _wrapped.CallBoxed(interpreter, originalArgs);
 
             // Call callback with (null, result)
-            callback.Call(interpreter, [null, result]);
+            callback.CallV2(interpreter, [RuntimeValue.Null, RuntimeValue.FromBoxed(result)]);
         }
         catch (Exception ex)
         {
             // Call callback with (error, null)
             var error = new SharpTSError(ex.Message);
-            callback.Call(interpreter, [error, null]);
+            callback.CallV2(interpreter, [RuntimeValue.FromObject(error), RuntimeValue.Null]);
         }
 
         return null;
     }
+
+    public RuntimeValue CallV2(Interpreter interpreter, ReadOnlySpan<RuntimeValue> arguments)
+        => RuntimeValue.FromBoxed(Call(interpreter, CallableInterop.ToBoxedList(arguments)));
 
     public override string ToString() => $"<callbackified fn>";
 }

--- a/Runtime/Types/SharpTSClusterWorker.cs
+++ b/Runtime/Types/SharpTSClusterWorker.cs
@@ -191,7 +191,7 @@ public class SharpTSClusterWorker : SharpTSEventEmitter, IDisposable
                 interpreter?.ScheduleTimer(0, 0, () =>
                 {
                     var emitMethod = SharpTSProcess.Instance.GetMember("emit") as BuiltInMethod;
-                    emitMethod?.Call(workerInterp!, ["message", cloned]);
+                    emitMethod?.CallBoxed(workerInterp!, ["message", cloned]);
                 }, false);
             }
             catch (Exception ex)
@@ -335,7 +335,7 @@ public class SharpTSClusterWorker : SharpTSEventEmitter, IDisposable
             var emitMethod = GetMember("emit") as BuiltInMethod;
             var emitArgs = new List<object?> { eventName };
             emitArgs.AddRange(args);
-            emitMethod?.Call(_parentInterpreter, emitArgs);
+            emitMethod?.CallBoxed(_parentInterpreter, emitArgs);
         }
         else
         {

--- a/Runtime/Types/SharpTSDatagramSocket.cs
+++ b/Runtime/Types/SharpTSDatagramSocket.cs
@@ -211,7 +211,7 @@ public class SharpTSDatagramSocket : SharpTSEventEmitter
                 {
                     interpreter.ScheduleTimer(0, 0, () =>
                     {
-                        sendCallback.Call(interpreter, [null]);
+                        sendCallback.CallBoxed(interpreter, [null]);
                     }, isInterval: false);
                 }
             }
@@ -221,7 +221,7 @@ public class SharpTSDatagramSocket : SharpTSEventEmitter
                 {
                     interpreter.ScheduleTimer(0, 0, () =>
                     {
-                        sendCallback.Call(interpreter, [new SharpTSError(ex.Message)]);
+                        sendCallback.CallBoxed(interpreter, [new SharpTSError(ex.Message)]);
                     }, isInterval: false);
                 }
                 else
@@ -265,7 +265,7 @@ public class SharpTSDatagramSocket : SharpTSEventEmitter
             {
                 closeInterpreter.ScheduleTimer(0, 0, () =>
                 {
-                    callback.Call(closeInterpreter, []);
+                    callback.CallBoxed(closeInterpreter, []);
                 }, isInterval: false);
             }
 
@@ -539,6 +539,6 @@ public class SharpTSDatagramSocket : SharpTSEventEmitter
     private void Once(string eventName, ISharpTSCallable callback)
     {
         var onceMethod = base.GetMember("once") as BuiltInMethod;
-        onceMethod?.Bind(this).Call(null!, new List<object?> { eventName, callback });
+        onceMethod?.Bind(this).CallBoxed(null!, new List<object?> { eventName, callback });
     }
 }

--- a/Runtime/Types/SharpTSDecoratorContext.cs
+++ b/Runtime/Types/SharpTSDecoratorContext.cs
@@ -64,7 +64,7 @@ public class SharpTSDecoratorContext
         {
             // Create a bound version of the initializer with 'this' set to instance
             var bound = init is SharpTSFunction fn ? fn.Bind(instance) : init;
-            bound.Call(interpreter, []);
+            bound.CallV2(interpreter, []);
         }
     }
 
@@ -196,8 +196,11 @@ public class SharpTSDecoratorContext
         public int Arity() => 1;
 
         public object? Call(Interpreter interpreter, List<object?> arguments)
+            => CallV2(interpreter, CallableInterop.ToRuntimeValues(arguments)).ToObject();
+
+        public RuntimeValue CallV2(Interpreter interpreter, ReadOnlySpan<RuntimeValue> arguments)
         {
-            if (arguments.Count > 0 && arguments[0] is ISharpTSCallable fn)
+            if (arguments.Length > 0 && arguments[0].ToObject() is ISharpTSCallable fn)
             {
                 context.AddInitializer(fn);
             }
@@ -205,7 +208,7 @@ public class SharpTSDecoratorContext
             {
                 throw new Exception("Runtime Error: addInitializer expects a function argument.");
             }
-            return null;
+            return RuntimeValue.Null;
         }
     }
 }

--- a/Runtime/Types/SharpTSDeprecatedFunction.cs
+++ b/Runtime/Types/SharpTSDeprecatedFunction.cs
@@ -36,13 +36,16 @@ public class SharpTSDeprecatedFunction : ISharpTSCallable
     public int Arity() => _wrapped.Arity();
 
     public object? Call(Interpreter interpreter, List<object?> arguments)
+        => CallV2(interpreter, CallableInterop.ToRuntimeValues(arguments)).ToObject();
+
+    public RuntimeValue CallV2(Interpreter interpreter, ReadOnlySpan<RuntimeValue> arguments)
     {
         if (!_warned)
         {
             _warned = true;
             interpreter.Error.WriteLine($"DeprecationWarning: {_message}");
         }
-        return _wrapped.Call(interpreter, arguments);
+        return _wrapped.CallV2(interpreter, arguments);
     }
 
     public override string ToString() => $"<deprecated fn>";

--- a/Runtime/Types/SharpTSDuplex.cs
+++ b/Runtime/Types/SharpTSDuplex.cs
@@ -135,7 +135,7 @@ public class SharpTSDuplex : SharpTSReadable
             var writeArgs = new List<object?> { chunk, encoding ?? "utf8", cbWrapper };
             try
             {
-                _writeCallback.Call(interpreter, writeArgs);
+                _writeCallback.CallBoxed(interpreter, writeArgs);
             }
             catch (Exception ex)
             {
@@ -148,7 +148,7 @@ public class SharpTSDuplex : SharpTSReadable
             // Sync completion
             _pendingWrites--;
             _writableLength -= chunkSize;
-            callback?.Call(interpreter, []);
+            callback?.CallBoxed(interpreter, []);
             CheckDrain(interpreter);
         }
 
@@ -227,7 +227,7 @@ public class SharpTSDuplex : SharpTSReadable
             var finalCbWrapper = new WriteCallbackWrapper(null, interpreter, this, 0);
             try
             {
-                _finalCallback.Call(interpreter, [finalCbWrapper]);
+                _finalCallback.CallBoxed(interpreter, [finalCbWrapper]);
             }
             catch (Exception ex)
             {
@@ -236,7 +236,7 @@ public class SharpTSDuplex : SharpTSReadable
         }
 
         _writableFinished = true;
-        callback?.Call(interpreter, []);
+        callback?.CallBoxed(interpreter, []);
         EmitEvent(interpreter, "finish", []);
 
         return this;
@@ -274,7 +274,7 @@ public class SharpTSDuplex : SharpTSReadable
 
         // Destroy the readable side too via the base Destroy method
         var baseDestroy = base.GetMember("destroy") as BuiltInMethod;
-        baseDestroy?.Bind(this).Call(interpreter, args);
+        baseDestroy?.Bind(this).CallBoxed(interpreter, args);
 
         return this;
     }
@@ -302,9 +302,12 @@ public class SharpTSDuplex : SharpTSReadable
         {
             _stream._pendingWrites--;
             _stream._writableLength -= _chunkSize;
-            _callback?.Call(_interpreter, []);
+            _callback?.CallBoxed(_interpreter, []);
             _stream.CheckDrain(_interpreter);
             return null;
         }
+
+        public RuntimeValue CallV2(Interp interpreter, ReadOnlySpan<RuntimeValue> arguments)
+            => RuntimeValue.FromBoxed(Call(interpreter, CallableInterop.ToBoxedList(arguments)));
     }
 }

--- a/Runtime/Types/SharpTSDuplexConstructor.cs
+++ b/Runtime/Types/SharpTSDuplexConstructor.cs
@@ -53,7 +53,7 @@ public sealed class SharpTSDuplexConstructor : ISharpTSCallable
             if (options.GetProperty("encoding") is string encoding)
             {
                 var setEncoding = stream.GetMember("setEncoding") as Runtime.BuiltIns.BuiltInMethod;
-                setEncoding?.Bind(stream).Call(interpreter, [encoding]);
+                setEncoding?.Bind(stream).CallBoxed(interpreter, [encoding]);
             }
 
             // objectMode option - sets both readable and writable sides
@@ -73,6 +73,9 @@ public sealed class SharpTSDuplexConstructor : ISharpTSCallable
 
         return stream;
     }
+
+    public RuntimeValue CallV2(Interp interpreter, ReadOnlySpan<RuntimeValue> arguments)
+        => RuntimeValue.FromBoxed(Call(interpreter, CallableInterop.ToBoxedList(arguments)));
 
     /// <summary>
     /// Gets a property from the Duplex constructor (static properties/methods).

--- a/Runtime/Types/SharpTSErrorClass.cs
+++ b/Runtime/Types/SharpTSErrorClass.cs
@@ -237,11 +237,14 @@ internal sealed class ErrorToStringCallable : ISharpTSCallable, IInstanceBindabl
     }
 
     public object? Call(Interpreter interpreter, List<object?> arguments)
+        => CallV2(interpreter, CallableInterop.ToRuntimeValues(arguments)).ToObject();
+
+    public RuntimeValue CallV2(Interpreter interpreter, ReadOnlySpan<RuntimeValue> arguments)
     {
         var instance = _boundInstance
             ?? interpreter.GetCurrentThis() as SharpTSInstance;
-        if (instance == null) return "Error";
-        return SharpTSErrorClass.ErrorToString(instance);
+        if (instance == null) return RuntimeValue.FromString("Error");
+        return RuntimeValue.FromString(SharpTSErrorClass.ErrorToString(instance));
     }
 }
 

--- a/Runtime/Types/SharpTSEventEmitter.cs
+++ b/Runtime/Types/SharpTSEventEmitter.cs
@@ -186,7 +186,7 @@ public class SharpTSEventEmitter : ITypeCategorized
         {
             var fullArgs = new List<object?> { eventName };
             fullArgs.AddRange(args);
-            emit.Bind(this).Call(interpreter, fullArgs);
+            emit.Bind(this).CallBoxed(interpreter, fullArgs);
         }
     }
 
@@ -197,7 +197,7 @@ public class SharpTSEventEmitter : ITypeCategorized
     {
         if (listener is ISharpTSCallable callable)
         {
-            callable.Call(interpreter!, eventArgs);
+            callable.CallBoxed(interpreter!, eventArgs);
         }
         else
         {

--- a/Runtime/Types/SharpTSEventEmitterConstructor.cs
+++ b/Runtime/Types/SharpTSEventEmitterConstructor.cs
@@ -37,6 +37,9 @@ public sealed class SharpTSEventEmitterConstructor : ISharpTSCallable
         return new SharpTSEventEmitter();
     }
 
+    public RuntimeValue CallV2(Interp interpreter, ReadOnlySpan<RuntimeValue> arguments)
+        => RuntimeValue.FromBoxed(Call(interpreter, CallableInterop.ToBoxedList(arguments)));
+
     /// <summary>
     /// Gets a property from the EventEmitter constructor (static properties/methods).
     /// </summary>

--- a/Runtime/Types/SharpTSFSWatcher.cs
+++ b/Runtime/Types/SharpTSFSWatcher.cs
@@ -126,7 +126,7 @@ public class SharpTSFSWatcher : SharpTSEventEmitter, IDisposable
         var emitMethod = base.GetMember("emit") as BuiltInMethod;
         if (emitMethod != null)
         {
-            emitMethod.Call(_interpreter, [eventType, eventType, filename]);
+            emitMethod.CallBoxed(_interpreter, [eventType, eventType, filename]);
         }
     }
 
@@ -185,7 +185,7 @@ public class SharpTSFSWatcher : SharpTSEventEmitter, IDisposable
         if (_interpreter != null)
         {
             var emitMethod = base.GetMember("emit") as BuiltInMethod;
-            emitMethod?.Call(_interpreter, ["close"]);
+            emitMethod?.CallBoxed(_interpreter, ["close"]);
         }
 
         _interpreter = null;

--- a/Runtime/Types/SharpTSFetchGlobal.cs
+++ b/Runtime/Types/SharpTSFetchGlobal.cs
@@ -29,6 +29,9 @@ public sealed class SharpTSFetchGlobal : ISharpTSCallable, ISharpTSAsyncCallable
     public object? Call(Interpreter interpreter, List<object?> arguments)
         => _inner.Call(interpreter, arguments);
 
+    public RuntimeValue CallV2(Interpreter interpreter, ReadOnlySpan<RuntimeValue> arguments)
+        => RuntimeValue.FromBoxed(Call(interpreter, CallableInterop.ToBoxedList(arguments)));
+
     public Task<object?> CallAsync(Interpreter interpreter, List<object?> arguments)
         => _inner.CallAsync(interpreter, arguments);
 

--- a/Runtime/Types/SharpTSFetchResponse.cs
+++ b/Runtime/Types/SharpTSFetchResponse.cs
@@ -215,14 +215,14 @@ public class SharpTSFetchResponse : ITypeCategorized
                 // Push data and EOF into the readable's internal buffer
                 // The readable will drain when a 'data' listener is added
                 var pushMethod = _bodyStream.GetMember("push") as BuiltInMethod;
-                pushMethod?.Bind(_bodyStream).Call(null!, new List<object?> { buf });
-                pushMethod?.Bind(_bodyStream).Call(null!, new List<object?> { null }); // EOF
+                pushMethod?.Bind(_bodyStream).CallBoxed(null!, new List<object?> { buf });
+                pushMethod?.Bind(_bodyStream).CallBoxed(null!, new List<object?> { null }); // EOF
             }
             catch (Exception)
             {
                 // Body already consumed or error - push EOF
                 var pushMethod = _bodyStream.GetMember("push") as BuiltInMethod;
-                pushMethod?.Bind(_bodyStream).Call(null!, new List<object?> { null });
+                pushMethod?.Bind(_bodyStream).CallBoxed(null!, new List<object?> { null });
             }
         }).GetAwaiter().GetResult();
 

--- a/Runtime/Types/SharpTSFinalizationRegistry.cs
+++ b/Runtime/Types/SharpTSFinalizationRegistry.cs
@@ -72,7 +72,7 @@ public class SharpTSFinalizationRegistry : ITypeCategorized
         {
             try
             {
-                _cleanupCallback.Call(interpreter!, [heldValue]);
+                _cleanupCallback.CallV2(interpreter!, [RuntimeValue.FromBoxed(heldValue)]);
             }
             catch
             {

--- a/Runtime/Types/SharpTSFunctionGlobal.cs
+++ b/Runtime/Types/SharpTSFunctionGlobal.cs
@@ -19,6 +19,9 @@ public sealed class SharpTSFunctionGlobal : ISharpTSCallable
     public object? Call(Execution.Interpreter interpreter, List<object?> arguments)
         => throw new Exception("Runtime Error: Dynamic Function() construction is not supported.");
 
+    public RuntimeValue CallV2(Execution.Interpreter interpreter, ReadOnlySpan<RuntimeValue> arguments)
+        => RuntimeValue.FromBoxed(Call(interpreter, CallableInterop.ToBoxedList(arguments)));
+
     public object? GetMember(string name)
     {
         if (name == "prototype") return _prototype;
@@ -66,10 +69,7 @@ public sealed class SharpTSFunctionProtoToString : ISharpTSCallable
     public int Arity() => 0;
 
     public object? Call(Execution.Interpreter interpreter, List<object?> arguments)
-    {
-        var target = _boundThis ?? (arguments.Count > 0 ? arguments[0] : null);
-        return target?.ToString() ?? "function () { [native code] }";
-    }
+        => CallV2(interpreter, CallableInterop.ToRuntimeValues(arguments)).ToObject();
 
     public RuntimeValue CallV2(Execution.Interpreter interpreter, ReadOnlySpan<RuntimeValue> arguments)
     {

--- a/Runtime/Types/SharpTSHeaders.cs
+++ b/Runtime/Types/SharpTSHeaders.cs
@@ -277,7 +277,7 @@ public class SharpTSHeaders : ITypeCategorized
     {
         if (callback is ISharpTSCallable callable)
         {
-            callable.Call(interp!, [value, key]);
+            callable.CallBoxed(interp!, [value, key]);
         }
     }
 

--- a/Runtime/Types/SharpTSHttpRequest.cs
+++ b/Runtime/Types/SharpTSHttpRequest.cs
@@ -92,12 +92,12 @@ public class SharpTSHttpRequest : SharpTSReadable
             if (body.Length > 0)
             {
                 var pushMethod = base.GetMember("push") as BuiltInMethod;
-                pushMethod?.Bind(this).Call(interpreter, [new SharpTSBuffer(body)]);
+                pushMethod?.Bind(this).CallBoxed(interpreter, [new SharpTSBuffer(body)]);
             }
 
             // Signal EOF
             var pushNull = base.GetMember("push") as BuiltInMethod;
-            pushNull?.Bind(this).Call(interpreter, new List<object?> { null });
+            pushNull?.Bind(this).CallBoxed(interpreter, new List<object?> { null });
             _endEmitted = true;
         }
         catch (Exception ex)

--- a/Runtime/Types/SharpTSHttpResponse.cs
+++ b/Runtime/Types/SharpTSHttpResponse.cs
@@ -218,7 +218,7 @@ public class SharpTSHttpResponse : SharpTSWritable
         ISharpTSCallable? callback = null;
         if (args.Count > 1 && args[1] is ISharpTSCallable cb1) callback = cb1;
         if (args.Count > 2 && args[2] is ISharpTSCallable cb2) callback = cb2;
-        callback?.Call(interpreter, []);
+        callback?.CallBoxed(interpreter, []);
 
         return true;
     }
@@ -263,7 +263,7 @@ public class SharpTSHttpResponse : SharpTSWritable
         {
             if (arg is ISharpTSCallable cb) { callback = cb; break; }
         }
-        callback?.Call(interpreter, []);
+        callback?.CallBoxed(interpreter, []);
 
         // Emit 'finish' event (Writable stream semantics)
         EmitEvent(interpreter, "finish", []);

--- a/Runtime/Types/SharpTSHttpServer.cs
+++ b/Runtime/Types/SharpTSHttpServer.cs
@@ -147,7 +147,7 @@ public class SharpTSHttpServer : SharpTSEventEmitter, IDisposable
         // Call the listening callback
         if (callback != null)
         {
-            callback.Call(interpreter, new List<object?>());
+            callback.CallBoxed(interpreter, new List<object?>());
         }
 
         // Emit 'listening' event
@@ -185,7 +185,7 @@ public class SharpTSHttpServer : SharpTSEventEmitter, IDisposable
         _isListening = true;
         interpreter.Ref();
 
-        callback?.Call(interpreter, new List<object?>());
+        callback?.CallBoxed(interpreter, new List<object?>());
         EmitEvent("listening", new List<object?>());
 
         return this;
@@ -277,7 +277,7 @@ public class SharpTSHttpServer : SharpTSEventEmitter, IDisposable
         {
             interp.ScheduleTimer(0, 0, () =>
             {
-                callback?.Call(interp, new List<object?>());
+                callback?.CallBoxed(interp, new List<object?>());
                 EmitEvent("close", new List<object?>());
             }, isInterval: false);
         }
@@ -411,7 +411,7 @@ public class SharpTSHttpServer : SharpTSEventEmitter, IDisposable
                     EmitEvent("request", new List<object?> { req, res });
 
                     // Call the request handler
-                    _requestHandler.Call(_interpreter!, new List<object?> { req, res });
+                    _requestHandler.CallBoxed(_interpreter!, new List<object?> { req, res });
 
                     // Read and emit body events
                     await req.EmitDataEventsAsync(_interpreter!);

--- a/Runtime/Types/SharpTSInstance.cs
+++ b/Runtime/Types/SharpTSInstance.cs
@@ -183,7 +183,7 @@ public class SharpTSInstance(SharpTSClass klass) : ISharpTSPropertyAccessor, ITy
         return resolution.Type switch
         {
             ResolutionType.AutoAccessor => _klass.GetAutoAccessorValue(this, propName),
-            ResolutionType.Getter => ((SharpTSFunction)resolution.Function!).Bind(this).Call(_interpreter!, []),
+            ResolutionType.Getter => ((SharpTSFunction)resolution.Function!).Bind(this).CallV2(_interpreter!, []).ToObject(),
             ResolutionType.Field => _fields[propName],
             ResolutionType.Method => GetOrCreateBoundMethod(propName, resolution.Function!),
             ResolutionType.ClassSelf => _klass,
@@ -250,7 +250,7 @@ public class SharpTSInstance(SharpTSClass klass) : ISharpTSPropertyAccessor, ITy
 
         if (cachedSetter != null && _interpreter != null)
         {
-            cachedSetter.Bind(this).Call(_interpreter, [value]);
+            cachedSetter.Bind(this).CallV2(_interpreter, [RuntimeValue.FromBoxed(value)]);
             return;
         }
 
@@ -310,7 +310,7 @@ public class SharpTSInstance(SharpTSClass klass) : ISharpTSPropertyAccessor, ITy
 
         if (cachedSetter != null && _interpreter != null)
         {
-            cachedSetter.Bind(this).Call(_interpreter, [value]);
+            cachedSetter.Bind(this).CallV2(_interpreter, [RuntimeValue.FromBoxed(value)]);
             return;
         }
 

--- a/Runtime/Types/SharpTSNetServer.cs
+++ b/Runtime/Types/SharpTSNetServer.cs
@@ -176,7 +176,7 @@ public class SharpTSNetServer : SharpTSEventEmitter, IDisposable
 
         // Emit 'listening' event and call callback
         if (callback != null)
-            callback.Call(interpreter, []);
+            callback.CallBoxed(interpreter, []);
         EmitEvent(interpreter, "listening", []);
 
         // Start accepting connections
@@ -207,7 +207,7 @@ public class SharpTSNetServer : SharpTSEventEmitter, IDisposable
                 StartAcceptingIpcWindows(interpreter, pipeReady);
                 pipeReady.Wait(5000); // Wait up to 5s for pipe to be ready
 
-                callback?.Call(interpreter, []);
+                callback?.CallBoxed(interpreter, []);
                 EmitEvent(interpreter, "listening", []);
             }
             else
@@ -224,7 +224,7 @@ public class SharpTSNetServer : SharpTSEventEmitter, IDisposable
                 _isListening = true;
                 interpreter.Ref();
 
-                callback?.Call(interpreter, []);
+                callback?.CallBoxed(interpreter, []);
                 EmitEvent(interpreter, "listening", []);
 
                 StartAcceptingIpcUnix(interpreter);
@@ -292,7 +292,7 @@ public class SharpTSNetServer : SharpTSEventEmitter, IDisposable
                         var readReady = new ManualResetEventSlim(false);
                         socket.StartReading(interpreter, readReady);
                         readReady.Wait(5000);
-                        _connectionListener?.Call(interpreter, [socket]);
+                        _connectionListener?.CallBoxed(interpreter, [socket]);
                         EmitEvent(interpreter, "connection", [socket]);
                     }, isInterval: false);
                 }
@@ -340,7 +340,7 @@ public class SharpTSNetServer : SharpTSEventEmitter, IDisposable
                         var socket = new SharpTSSocket(stream, _pipePath!);
                         _connections.Add(socket);
                         socket.StartReading(interpreter);
-                        _connectionListener?.Call(interpreter, [socket]);
+                        _connectionListener?.CallBoxed(interpreter, [socket]);
                         EmitEvent(interpreter, "connection", [socket]);
                     }, isInterval: false);
                 }
@@ -370,7 +370,7 @@ public class SharpTSNetServer : SharpTSEventEmitter, IDisposable
             {
                 var socket = new SharpTSSocket(tcpClient);
                 _connections.Add(socket);
-                _connectionListener?.Call(interpreter, [socket]);
+                _connectionListener?.CallBoxed(interpreter, [socket]);
                 EmitEvent(interpreter, "connection", [socket]);
                 socket.StartReading(interpreter);
             }, isInterval: false);
@@ -379,7 +379,7 @@ public class SharpTSNetServer : SharpTSEventEmitter, IDisposable
         _isListening = true;
         interpreter.Ref();
 
-        callback?.Call(interpreter, []);
+        callback?.CallBoxed(interpreter, []);
         EmitEvent(interpreter, "listening", []);
 
         return this;
@@ -412,7 +412,7 @@ public class SharpTSNetServer : SharpTSEventEmitter, IDisposable
                         _connections.Add(socket);
 
                         // Call connection listener if set
-                        _connectionListener?.Call(interpreter, [socket]);
+                        _connectionListener?.CallBoxed(interpreter, [socket]);
 
                         // Emit 'connection' event
                         EmitEvent(interpreter, "connection", [socket]);
@@ -470,7 +470,7 @@ public class SharpTSNetServer : SharpTSEventEmitter, IDisposable
         _interpreter?.Unref();
 
         ISharpTSCallable? callback = args.Count > 0 ? WrapCallbackArg(args[0]) : null;
-        callback?.Call(interpreter, []);
+        callback?.CallBoxed(interpreter, []);
 
         EmitEvent(interpreter, "close", []);
 
@@ -518,7 +518,7 @@ public class SharpTSNetServer : SharpTSEventEmitter, IDisposable
     {
         if (args.Count > 0 && args[0] is ISharpTSCallable callback)
         {
-            callback.Call(interpreter, [null, (double)_connections.Count]);
+            callback.CallBoxed(interpreter, [null, (double)_connections.Count]);
         }
         return this;
     }

--- a/Runtime/Types/SharpTSObjectNamespace.cs
+++ b/Runtime/Types/SharpTSObjectNamespace.cs
@@ -34,5 +34,8 @@ public class SharpTSObjectNamespace : ISharpTSCallable
         return value;
     }
 
+    public RuntimeValue CallV2(Interpreter interpreter, ReadOnlySpan<RuntimeValue> arguments)
+        => RuntimeValue.FromBoxed(Call(interpreter, CallableInterop.ToBoxedList(arguments)));
+
     public override string ToString() => "function Object() { [native code] }";
 }

--- a/Runtime/Types/SharpTSObjectPrototype.cs
+++ b/Runtime/Types/SharpTSObjectPrototype.cs
@@ -83,6 +83,9 @@ public sealed class SharpTSObjectUnboundMethod : ISharpTSCallable
         return _impl(target, rest);
     }
 
+    public RuntimeValue CallV2(Interp interpreter, ReadOnlySpan<RuntimeValue> arguments)
+        => RuntimeValue.FromBoxed(Call(interpreter, CallableInterop.ToBoxedList(arguments)));
+
     public SharpTSObjectUnboundMethod BindTo(object? thisArg) => new(_name, _impl, thisArg);
 
     public override string ToString() => $"function {_name}() {{ [native code] }}";

--- a/Runtime/Types/SharpTSPassThroughConstructor.cs
+++ b/Runtime/Types/SharpTSPassThroughConstructor.cs
@@ -35,12 +35,15 @@ public sealed class SharpTSPassThroughConstructor : ISharpTSCallable
             if (options.GetProperty("encoding") is string encoding)
             {
                 var setEncoding = stream.GetMember("setEncoding") as Runtime.BuiltIns.BuiltInMethod;
-                setEncoding?.Bind(stream).Call(interpreter, [encoding]);
+                setEncoding?.Bind(stream).CallV2(interpreter, [RuntimeValue.FromString(encoding)]);
             }
         }
 
         return stream;
     }
+
+    public RuntimeValue CallV2(Interp interpreter, ReadOnlySpan<RuntimeValue> arguments)
+        => RuntimeValue.FromBoxed(Call(interpreter, CallableInterop.ToBoxedList(arguments)));
 
     /// <summary>
     /// Gets a property from the PassThrough constructor (static properties/methods).

--- a/Runtime/Types/SharpTSPrimitiveNamespaces.cs
+++ b/Runtime/Types/SharpTSPrimitiveNamespaces.cs
@@ -26,6 +26,9 @@ public class SharpTSStringNamespace : ISharpTSCallable
         return arg.ToString() ?? "";
     }
 
+    public RuntimeValue CallV2(Interpreter interpreter, ReadOnlySpan<RuntimeValue> arguments)
+        => RuntimeValue.FromBoxed(Call(interpreter, CallableInterop.ToBoxedList(arguments)));
+
     /// <summary>
     /// Returns <c>String.prototype</c> so real-world patterns like
     /// <c>String.prototype.trim.call(x)</c> resolve correctly; built-in static
@@ -104,8 +107,11 @@ internal sealed class StringPrototypeMethodWrapper : ISharpTSCallable
         }
 
         var coerced = CoerceToString(_receiver);
-        return _inner.Bind(coerced).Call(interpreter, arguments);
+        return _inner.Bind(coerced).CallBoxed(interpreter, arguments);
     }
+
+    public RuntimeValue CallV2(Interpreter interpreter, ReadOnlySpan<RuntimeValue> arguments)
+        => RuntimeValue.FromBoxed(Call(interpreter, CallableInterop.ToBoxedList(arguments)));
 
     /// <summary>
     /// ECMA-262 ToString abstract operation — mapped to the receiver types
@@ -170,6 +176,9 @@ public class SharpTSNumberNamespace : ISharpTSCallable
         }
         return double.NaN;
     }
+
+    public RuntimeValue CallV2(Interpreter interpreter, ReadOnlySpan<RuntimeValue> arguments)
+        => RuntimeValue.FromBoxed(Call(interpreter, CallableInterop.ToBoxedList(arguments)));
 
     /// <summary>
     /// Returns <c>Number.prototype</c> (so <c>Number.prototype.toString.call(x)</c>
@@ -246,8 +255,11 @@ internal sealed class NumberPrototypeMethodWrapper : ISharpTSCallable
                 $"Number.prototype.{_name} requires that 'this' be a Number"));
         }
 
-        return _inner.Bind(d).Call(interpreter, arguments);
+        return _inner.Bind(d).CallBoxed(interpreter, arguments);
     }
+
+    public RuntimeValue CallV2(Interpreter interpreter, ReadOnlySpan<RuntimeValue> arguments)
+        => RuntimeValue.FromBoxed(Call(interpreter, CallableInterop.ToBoxedList(arguments)));
 
     public override string ToString() => $"function {_name}() {{ [native code] }}";
 }
@@ -269,6 +281,9 @@ public class SharpTSBooleanNamespace : ISharpTSCallable
         var arg = arguments[0];
         return SharpTS.Compilation.RuntimeTypes.IsTruthy(arg);
     }
+
+    public RuntimeValue CallV2(Interpreter interpreter, ReadOnlySpan<RuntimeValue> arguments)
+        => RuntimeValue.FromBoxed(Call(interpreter, CallableInterop.ToBoxedList(arguments)));
 
     /// <summary>
     /// Returns <c>Boolean.prototype</c>. Boolean has no static members worth
@@ -338,13 +353,16 @@ internal sealed class BooleanPrototypeMethodWrapper : ISharpTSCallable
         => new(_name, _isToString, receiver);
 
     public object? Call(Interpreter interpreter, List<object?> arguments)
+        => CallV2(interpreter, CallableInterop.ToRuntimeValues(arguments)).ToObject();
+
+    public RuntimeValue CallV2(Interpreter interpreter, ReadOnlySpan<RuntimeValue> arguments)
     {
         if (!_hasReceiver || _receiver is not bool b)
         {
             throw new ThrowException(new SharpTSTypeError(
                 $"Boolean.prototype.{_name} requires that 'this' be a Boolean"));
         }
-        return _isToString ? (b ? "true" : "false") : (object)b;
+        return _isToString ? RuntimeValue.FromString(b ? "true" : "false") : RuntimeValue.FromBoolean(b);
     }
 
     public override string ToString() => $"function {_name}() {{ [native code] }}";

--- a/Runtime/Types/SharpTSPromisifiedFunction.cs
+++ b/Runtime/Types/SharpTSPromisifiedFunction.cs
@@ -45,7 +45,7 @@ public class SharpTSPromisifiedFunction : ISharpTSCallable
         try
         {
             // Call the original function with the callback
-            _wrapped.Call(interpreter, argsWithCallback);
+            _wrapped.CallBoxed(interpreter, argsWithCallback);
         }
         catch (Exception ex)
         {
@@ -55,6 +55,9 @@ public class SharpTSPromisifiedFunction : ISharpTSCallable
 
         return new SharpTSPromise(tcs.Task);
     }
+
+    public RuntimeValue CallV2(Interpreter interpreter, ReadOnlySpan<RuntimeValue> arguments)
+        => RuntimeValue.FromBoxed(Call(interpreter, CallableInterop.ToBoxedList(arguments)));
 
     public override string ToString() => "<promisified fn>";
 }
@@ -106,6 +109,9 @@ internal class SharpTSPromisifyCallback : ISharpTSCallable
 
         return null;
     }
+
+    public RuntimeValue CallV2(Interpreter interpreter, ReadOnlySpan<RuntimeValue> arguments)
+        => RuntimeValue.FromBoxed(Call(interpreter, CallableInterop.ToBoxedList(arguments)));
 
     public override string ToString() => "<promisify callback>";
 }

--- a/Runtime/Types/SharpTSProxy.cs
+++ b/Runtime/Types/SharpTSProxy.cs
@@ -90,7 +90,7 @@ public class SharpTSProxy : ISharpTSCallable
     private object? InvokeTrap(object trap, Interpreter? interp, List<object?> args)
     {
         if (trap is ISharpTSCallable callable)
-            return callable.Call(interp!, args);
+            return callable.CallBoxed(interp!, args);
 
         // Func<object?[], object?> delegate
         if (trap is Func<object?[], object?> func)
@@ -241,7 +241,7 @@ public class SharpTSProxy : ISharpTSCallable
         if (trap == null)
         {
             if (_target is ISharpTSCallable callable)
-                return callable.Call(interp!, args);
+                return callable.CallBoxed(interp!, args);
 
             // Compiled mode: target is a TSFunction, not ISharpTSCallable
             if (interp == null)
@@ -265,9 +265,9 @@ public class SharpTSProxy : ISharpTSCallable
         if (trap == null)
         {
             if (_target is SharpTSClass klass)
-                return klass.Call(interp!, args);
+                return klass.CallBoxed(interp!, args);
             if (_target is ISharpTSCallable callable)
-                return callable.Call(interp!, args);
+                return callable.CallBoxed(interp!, args);
             throw new Exception("Runtime Error: Proxy target is not constructable.");
         }
 
@@ -377,6 +377,9 @@ public class SharpTSProxy : ISharpTSCallable
     {
         return TrapApply(null, arguments, interpreter);
     }
+
+    public RuntimeValue CallV2(Interpreter interpreter, ReadOnlySpan<RuntimeValue> arguments)
+        => RuntimeValue.FromBoxed(Call(interpreter, CallableInterop.ToBoxedList(arguments)));
 
     #endregion
 

--- a/Runtime/Types/SharpTSReadStream.cs
+++ b/Runtime/Types/SharpTSReadStream.cs
@@ -85,12 +85,12 @@ public class SharpTSReadStream : SharpTSReadable
 
                 // Use base Push via the BuiltInMethod mechanism
                 var pushMethod = GetMember("push") as BuiltInMethod;
-                pushMethod?.Bind(this).Call(interpreter, [chunk]);
+                pushMethod?.Bind(this).CallBoxed(interpreter, [chunk]);
             }
 
             // Signal EOF
             var pushEof = GetMember("push") as BuiltInMethod;
-            pushEof?.Bind(this).Call(interpreter, new List<object?> { null });
+            pushEof?.Bind(this).CallBoxed(interpreter, new List<object?> { null });
 
             CloseFileStream(interpreter);
         }

--- a/Runtime/Types/SharpTSReadable.cs
+++ b/Runtime/Types/SharpTSReadable.cs
@@ -89,7 +89,7 @@ public class SharpTSReadable : SharpTSEventEmitter
     {
         // Call base on
         var baseOn = base.GetMember("on") as BuiltInMethod;
-        baseOn?.Bind(this).Call(interpreter, args);
+        baseOn?.Bind(this).CallBoxed(interpreter, args);
 
         var eventName = args.Count > 0 ? args[0]?.ToString() : null;
 
@@ -112,7 +112,7 @@ public class SharpTSReadable : SharpTSEventEmitter
     {
         // Call base once
         var baseOnce = base.GetMember("once") as BuiltInMethod;
-        baseOnce?.Bind(this).Call(interpreter, args);
+        baseOnce?.Bind(this).CallBoxed(interpreter, args);
 
         var eventName = args.Count > 0 ? args[0]?.ToString() : null;
 
@@ -446,19 +446,19 @@ public class SharpTSReadable : SharpTSEventEmitter
         else if (destObj is SharpTSPassThrough passThrough)
         {
             var writeMethod = passThrough.GetMember("write") as BuiltInMethod;
-            var result = writeMethod?.Bind(passThrough).Call(interpreter, [chunk, encoding]);
+            var result = writeMethod?.Bind(passThrough).CallBoxed(interpreter, [chunk, encoding]);
             return result is not false;
         }
         else if (destObj is SharpTSTransform transform)
         {
             var writeMethod = transform.GetMember("write") as BuiltInMethod;
-            var result = writeMethod?.Bind(transform).Call(interpreter, [chunk, encoding]);
+            var result = writeMethod?.Bind(transform).CallBoxed(interpreter, [chunk, encoding]);
             return result is not false;
         }
         else if (destObj is SharpTSDuplex duplex)
         {
             var writeMethod = duplex.GetMember("write") as BuiltInMethod;
-            var result = writeMethod?.Bind(duplex).Call(interpreter, [chunk, encoding]);
+            var result = writeMethod?.Bind(duplex).CallBoxed(interpreter, [chunk, encoding]);
             return result is not false;
         }
         return true;
@@ -476,17 +476,17 @@ public class SharpTSReadable : SharpTSEventEmitter
         else if (destObj is SharpTSPassThrough passThrough)
         {
             var endMethod = passThrough.GetMember("end") as BuiltInMethod;
-            endMethod?.Bind(passThrough).Call(interpreter, []);
+            endMethod?.Bind(passThrough).CallBoxed(interpreter, []);
         }
         else if (destObj is SharpTSTransform transform)
         {
             var endMethod = transform.GetMember("end") as BuiltInMethod;
-            endMethod?.Bind(transform).Call(interpreter, []);
+            endMethod?.Bind(transform).CallBoxed(interpreter, []);
         }
         else if (destObj is SharpTSDuplex duplex)
         {
             var endMethod = duplex.GetMember("end") as BuiltInMethod;
-            endMethod?.Bind(duplex).Call(interpreter, []);
+            endMethod?.Bind(duplex).CallBoxed(interpreter, []);
         }
     }
 
@@ -603,12 +603,12 @@ public class SharpTSReadable : SharpTSEventEmitter
         if (dest is SharpTSWritable writable)
         {
             var onceMethod = ((SharpTSEventEmitter)writable).GetMember("once") as BuiltInMethod;
-            onceMethod?.Bind(writable).Call(interpreter, ["drain", listener]);
+            onceMethod?.Bind(writable).CallBoxed(interpreter, ["drain", listener]);
         }
         else if (dest is SharpTSDuplex duplex)
         {
             var onceMethod = ((SharpTSEventEmitter)duplex).GetMember("once") as BuiltInMethod;
-            onceMethod?.Bind(duplex).Call(interpreter, ["drain", listener]);
+            onceMethod?.Bind(duplex).CallBoxed(interpreter, ["drain", listener]);
         }
     }
 
@@ -639,6 +639,9 @@ public class SharpTSReadable : SharpTSEventEmitter
             }
             return null;
         }
+
+        public RuntimeValue CallV2(Interp interpreter, ReadOnlySpan<RuntimeValue> arguments)
+            => RuntimeValue.FromBoxed(Call(interpreter, CallableInterop.ToBoxedList(arguments)));
     }
 
     private void FlushPipes(Interp interpreter)
@@ -715,7 +718,7 @@ public class SharpTSReadable : SharpTSEventEmitter
         while (_readBuffer.Count > 0)
         {
             var chunk = _readBuffer.Dequeue();
-            fn.Call(interpreter, [chunk]);
+            fn.CallBoxed(interpreter, [chunk]);
         }
         return null;
     }
@@ -735,7 +738,7 @@ public class SharpTSReadable : SharpTSEventEmitter
 
         // Pipe self to the transform
         var pipeMethod = GetMember("pipe") as BuiltInMethod;
-        pipeMethod?.Bind(this).Call(interpreter, [transform]);
+        pipeMethod?.Bind(this).CallBoxed(interpreter, [transform]);
 
         return transform;
     }
@@ -754,7 +757,7 @@ public class SharpTSReadable : SharpTSEventEmitter
         transform.SetTransformCallback(new FilterTransformCallable(fn));
 
         var pipeMethod = GetMember("pipe") as BuiltInMethod;
-        pipeMethod?.Bind(this).Call(interpreter, [transform]);
+        pipeMethod?.Bind(this).CallBoxed(interpreter, [transform]);
 
         return transform;
     }
@@ -771,10 +774,13 @@ public class SharpTSReadable : SharpTSEventEmitter
         {
             var chunk = arguments.Count > 0 ? arguments[0] : null;
             var callback = arguments.Count > 2 ? arguments[2] as ISharpTSCallable : null;
-            var result = _fn.Call(interpreter, [chunk]);
-            callback?.Call(interpreter, [null, result]);
+            var result = _fn.CallBoxed(interpreter, [chunk]);
+            callback?.CallBoxed(interpreter, [null, result]);
             return null;
         }
+
+        public RuntimeValue CallV2(Interp interpreter, ReadOnlySpan<RuntimeValue> arguments)
+            => RuntimeValue.FromBoxed(Call(interpreter, CallableInterop.ToBoxedList(arguments)));
     }
 
     /// <summary>
@@ -789,13 +795,16 @@ public class SharpTSReadable : SharpTSEventEmitter
         {
             var chunk = arguments.Count > 0 ? arguments[0] : null;
             var callback = arguments.Count > 2 ? arguments[2] as ISharpTSCallable : null;
-            var result = _fn.Call(interpreter, [chunk]);
+            var result = _fn.CallBoxed(interpreter, [chunk]);
             if (result is true || (result is double d && d != 0))
-                callback?.Call(interpreter, [null, chunk]);
+                callback?.CallBoxed(interpreter, [null, chunk]);
             else
-                callback?.Call(interpreter, [null]);
+                callback?.CallBoxed(interpreter, [null]);
             return null;
         }
+
+        public RuntimeValue CallV2(Interp interpreter, ReadOnlySpan<RuntimeValue> arguments)
+            => RuntimeValue.FromBoxed(Call(interpreter, CallableInterop.ToBoxedList(arguments)));
     }
 
     /// <summary>

--- a/Runtime/Types/SharpTSReadableConstructor.cs
+++ b/Runtime/Types/SharpTSReadableConstructor.cs
@@ -43,7 +43,7 @@ public sealed class SharpTSReadableConstructor : ISharpTSCallable
             if (options.GetProperty("encoding") is string encoding)
             {
                 var setEncoding = stream.GetMember("setEncoding") as Runtime.BuiltIns.BuiltInMethod;
-                setEncoding?.Bind(stream).Call(interpreter, [encoding]);
+                setEncoding?.Bind(stream).CallBoxed(interpreter, [encoding]);
             }
 
             // objectMode option
@@ -61,6 +61,9 @@ public sealed class SharpTSReadableConstructor : ISharpTSCallable
 
         return stream;
     }
+
+    public RuntimeValue CallV2(Interp interpreter, ReadOnlySpan<RuntimeValue> arguments)
+        => RuntimeValue.FromBoxed(Call(interpreter, CallableInterop.ToBoxedList(arguments)));
 
     /// <summary>
     /// Gets a property from the Readable constructor (static properties/methods).
@@ -97,7 +100,7 @@ public sealed class SharpTSReadableConstructor : ISharpTSCallable
             foreach (var item in arr)
             {
                 var pushMethod = stream.GetMember("push") as BuiltInMethod;
-                pushMethod?.Bind(stream).Call(interpreter, [item]);
+                pushMethod?.Bind(stream).CallBoxed(interpreter, [item]);
             }
         }
         else if (iterable is List<object?> list)
@@ -105,13 +108,13 @@ public sealed class SharpTSReadableConstructor : ISharpTSCallable
             foreach (var item in list)
             {
                 var pushMethod = stream.GetMember("push") as BuiltInMethod;
-                pushMethod?.Bind(stream).Call(interpreter, [item]);
+                pushMethod?.Bind(stream).CallBoxed(interpreter, [item]);
             }
         }
 
         // Push null to signal EOF
         var pushEnd = stream.GetMember("push") as BuiltInMethod;
-        pushEnd?.Bind(stream).Call(interpreter, [null]);
+        pushEnd?.Bind(stream).CallBoxed(interpreter, [null]);
 
         return stream;
     }

--- a/Runtime/Types/SharpTSReadlineInterface.cs
+++ b/Runtime/Types/SharpTSReadlineInterface.cs
@@ -65,7 +65,7 @@ public class SharpTSReadlineInterface : SharpTSEventEmitter
 
         if (callback is ISharpTSCallable callable)
         {
-            callable.Call(interpreter, [answer]);
+            callable.CallBoxed(interpreter, [answer]);
         }
 
         return null;

--- a/Runtime/Types/SharpTSSocket.cs
+++ b/Runtime/Types/SharpTSSocket.cs
@@ -324,7 +324,7 @@ public class SharpTSSocket : SharpTSEventEmitter
                     _bytesWritten += data.Length;
                     if (callback != null)
                     {
-                        interpreter.ScheduleTimer(0, 0, () => callback.Call(interpreter, []), false);
+                        interpreter.ScheduleTimer(0, 0, () => callback.CallBoxed(interpreter, []), false);
                     }
                 }
                 catch (Exception ex)
@@ -342,7 +342,7 @@ public class SharpTSSocket : SharpTSEventEmitter
         {
             _stream.Write(data, 0, data.Length);
             _bytesWritten += data.Length;
-            callback?.Call(interpreter, []);
+            callback?.CallBoxed(interpreter, []);
             return true;
         }
         catch (Exception ex)
@@ -397,7 +397,7 @@ public class SharpTSSocket : SharpTSEventEmitter
         {
             if (arg is ISharpTSCallable cb) { callback = cb; break; }
         }
-        callback?.Call(interpreter, []);
+        callback?.CallBoxed(interpreter, []);
 
         return this;
     }
@@ -668,5 +668,8 @@ public class SharpTSSocket : SharpTSEventEmitter
             }
             return null;
         }
+
+        public RuntimeValue CallV2(Interp interpreter, ReadOnlySpan<RuntimeValue> arguments)
+            => RuntimeValue.FromBoxed(Call(interpreter, CallableInterop.ToBoxedList(arguments)));
     }
 }

--- a/Runtime/Types/SharpTSStatWatcher.cs
+++ b/Runtime/Types/SharpTSStatWatcher.cs
@@ -116,7 +116,7 @@ public class SharpTSStatWatcher : SharpTSEventEmitter, IDisposable
         if (_interpreter == null || _closed) return;
 
         var emitMethod = base.GetMember("emit") as BuiltInMethod;
-        emitMethod?.Call(_interpreter, ["change", current, previous]);
+        emitMethod?.CallBoxed(_interpreter, ["change", current, previous]);
     }
 
     /// <summary>

--- a/Runtime/Types/SharpTSStderr.cs
+++ b/Runtime/Types/SharpTSStderr.cs
@@ -63,8 +63,11 @@ public class SharpTSStderr : SharpTSWritable
             else
                 Console.Error.Write(data);
 
-            callback?.Call(interpreter!, []);
+            callback?.CallBoxed(interpreter!, []);
             return null;
         }
+
+        public RuntimeValue CallV2(Interp interpreter, ReadOnlySpan<RuntimeValue> arguments)
+            => RuntimeValue.FromBoxed(Call(interpreter, CallableInterop.ToBoxedList(arguments)));
     }
 }

--- a/Runtime/Types/SharpTSStdin.cs
+++ b/Runtime/Types/SharpTSStdin.cs
@@ -48,7 +48,7 @@ public class SharpTSStdin : SharpTSReadable
 
         // Delegate to base Readable's on (which handles flowing mode)
         var baseOn = base.GetMember("on") as BuiltInMethod;
-        baseOn?.Bind(this).Call(interpreter, args);
+        baseOn?.Bind(this).CallBoxed(interpreter, args);
 
         if (eventName == "data" || eventName == "readable")
         {
@@ -63,7 +63,7 @@ public class SharpTSStdin : SharpTSReadable
         var eventName = args.Count > 0 ? args[0]?.ToString() : null;
 
         var baseOnce = base.GetMember("once") as BuiltInMethod;
-        baseOnce?.Bind(this).Call(interpreter, args);
+        baseOnce?.Bind(this).CallBoxed(interpreter, args);
 
         if (eventName == "data" || eventName == "readable")
         {
@@ -76,7 +76,7 @@ public class SharpTSStdin : SharpTSReadable
     private object? ResumeWithReader(Interp interpreter, object? receiver, List<object?> args)
     {
         var baseResume = base.GetMember("resume") as BuiltInMethod;
-        baseResume?.Bind(this).Call(interpreter, args);
+        baseResume?.Bind(this).CallBoxed(interpreter, args);
         StartReaderThread(interpreter);
         return this;
     }
@@ -126,7 +126,7 @@ public class SharpTSStdin : SharpTSReadable
     internal void PushFromExternal(Interp interpreter, object? chunk)
     {
         var pushMethod = base.GetMember("push") as BuiltInMethod;
-        pushMethod?.Bind(this).Call(interpreter, [chunk]);
+        pushMethod?.Bind(this).CallBoxed(interpreter, [chunk]);
     }
 
     /// <summary>

--- a/Runtime/Types/SharpTSStdout.cs
+++ b/Runtime/Types/SharpTSStdout.cs
@@ -68,8 +68,11 @@ public class SharpTSStdout : SharpTSWritable
             else
                 Console.Write(data);
 
-            callback?.Call(interpreter!, []);
+            callback?.CallBoxed(interpreter!, []);
             return null;
         }
+
+        public RuntimeValue CallV2(Interp interpreter, ReadOnlySpan<RuntimeValue> arguments)
+            => RuntimeValue.FromBoxed(Call(interpreter, CallableInterop.ToBoxedList(arguments)));
     }
 }

--- a/Runtime/Types/SharpTSTextDecoder.cs
+++ b/Runtime/Types/SharpTSTextDecoder.cs
@@ -150,6 +150,9 @@ public class SharpTSTextDecoder : ISharpTSPropertyAccessor
             return DecodeFromArgs(arguments.ToArray());
         }
 
+        public RuntimeValue CallV2(Interpreter interpreter, ReadOnlySpan<RuntimeValue> arguments)
+            => RuntimeValue.FromBoxed(Call(interpreter, CallableInterop.ToBoxedList(arguments)));
+
         /// <summary>
         /// Called by compiled mode via reflection (InvokeValue finds this method).
         /// </summary>

--- a/Runtime/Types/SharpTSTlsServer.cs
+++ b/Runtime/Types/SharpTSTlsServer.cs
@@ -176,7 +176,7 @@ public class SharpTSTlsServer : SharpTSEventEmitter, IDisposable
         interpreter.Ref();
 
         if (callback != null)
-            callback.Call(interpreter, []);
+            callback.CallBoxed(interpreter, []);
         EmitEvent(interpreter, "listening", []);
 
         StartAccepting(interpreter);
@@ -228,7 +228,7 @@ public class SharpTSTlsServer : SharpTSEventEmitter, IDisposable
                                 {
                                     try
                                     {
-                                        var result = sniCb.Call(interp, [hostName]);
+                                        var result = sniCb.CallBoxed(interp, [hostName]);
                                         if (result is SharpTSObject ctx)
                                         {
                                             var ctxCert = ctx.GetProperty("cert") as string;
@@ -252,7 +252,7 @@ public class SharpTSTlsServer : SharpTSEventEmitter, IDisposable
                                 var tlsSocket = new SharpTSTlsSocket(tcpClient, sslStream);
                                 _connections.Add(tlsSocket);
 
-                                _connectionListener?.Call(interpreter, [tlsSocket]);
+                                _connectionListener?.CallBoxed(interpreter, [tlsSocket]);
                                 EmitEvent(interpreter, "secureConnection", [tlsSocket]);
 
                                 tlsSocket.StartReading(interpreter);
@@ -289,7 +289,7 @@ public class SharpTSTlsServer : SharpTSEventEmitter, IDisposable
         _interpreter?.Unref();
 
         ISharpTSCallable? callback = args.Count > 0 ? args[0] as ISharpTSCallable : null;
-        callback?.Call(interpreter, []);
+        callback?.CallBoxed(interpreter, []);
 
         EmitEvent(interpreter, "close", []);
 
@@ -313,7 +313,7 @@ public class SharpTSTlsServer : SharpTSEventEmitter, IDisposable
     {
         if (args.Count > 0 && args[0] is ISharpTSCallable callback)
         {
-            callback.Call(interpreter, [null, (double)_connections.Count]);
+            callback.CallBoxed(interpreter, [null, (double)_connections.Count]);
         }
         return this;
     }

--- a/Runtime/Types/SharpTSTransform.cs
+++ b/Runtime/Types/SharpTSTransform.cs
@@ -80,7 +80,7 @@ public class SharpTSTransform : SharpTSDuplex
         {
             try
             {
-                _transformCallback.Call(interpreter, [chunk, encoding, doneCallback]);
+                _transformCallback.CallBoxed(interpreter, [chunk, encoding, doneCallback]);
             }
             catch (Exception ex)
             {
@@ -92,7 +92,7 @@ public class SharpTSTransform : SharpTSDuplex
         {
             // Default transform: pass through
             PushToReadableSide(interpreter, chunk);
-            doneCallback.Call(interpreter, []);
+            doneCallback.CallBoxed(interpreter, []);
         }
 
         return true;
@@ -143,7 +143,7 @@ public class SharpTSTransform : SharpTSDuplex
             var flushDoneCallback = new TransformDoneCallback(callback, interpreter, this);
             try
             {
-                _flushCallback.Call(interpreter, [flushDoneCallback]);
+                _flushCallback.CallBoxed(interpreter, [flushDoneCallback]);
             }
             catch (Exception ex)
             {
@@ -152,7 +152,7 @@ public class SharpTSTransform : SharpTSDuplex
         }
         else
         {
-            callback?.Call(interpreter, []);
+            callback?.CallBoxed(interpreter, []);
         }
 
         // End the readable side
@@ -172,7 +172,7 @@ public class SharpTSTransform : SharpTSDuplex
 
         // Pass through by default
         PushToReadableSide(interpreter, chunk);
-        callback?.Call(interpreter, []);
+        callback?.CallBoxed(interpreter, []);
 
         return null;
     }
@@ -181,7 +181,7 @@ public class SharpTSTransform : SharpTSDuplex
     {
         // Default _flush implementation (for subclasses to override)
         var callback = args.Count > 0 ? args[0] as ISharpTSCallable : null;
-        callback?.Call(interpreter, []);
+        callback?.CallBoxed(interpreter, []);
         return null;
     }
 
@@ -189,7 +189,7 @@ public class SharpTSTransform : SharpTSDuplex
     {
         // Use the base push method to add to the readable buffer
         var push = base.GetMember("push") as BuiltInMethod;
-        push?.Bind(this).Call(interpreter, [chunk]);
+        push?.Bind(this).CallBoxed(interpreter, [chunk]);
     }
 
     public override string ToString() => "Transform {}";
@@ -213,6 +213,9 @@ public class SharpTSTransform : SharpTSDuplex
             _stream.PushToReadableSide(_interpreter, chunk);
             return null;
         }
+
+        public RuntimeValue CallV2(Interp interpreter, ReadOnlySpan<RuntimeValue> arguments)
+            => RuntimeValue.FromBoxed(Call(interpreter, CallableInterop.ToBoxedList(arguments)));
     }
 
     private class TransformDoneCallback : ISharpTSCallable
@@ -241,8 +244,11 @@ public class SharpTSTransform : SharpTSDuplex
                 _stream.PushToReadableSide(_interpreter, data);
             }
 
-            _callback?.Call(_interpreter, []);
+            _callback?.CallBoxed(_interpreter, []);
             return null;
         }
+
+        public RuntimeValue CallV2(Interp interpreter, ReadOnlySpan<RuntimeValue> arguments)
+            => RuntimeValue.FromBoxed(Call(interpreter, CallableInterop.ToBoxedList(arguments)));
     }
 }

--- a/Runtime/Types/SharpTSTransformConstructor.cs
+++ b/Runtime/Types/SharpTSTransformConstructor.cs
@@ -65,7 +65,7 @@ public sealed class SharpTSTransformConstructor : ISharpTSCallable
             if (options.GetProperty("encoding") is string encoding)
             {
                 var setEncoding = stream.GetMember("setEncoding") as Runtime.BuiltIns.BuiltInMethod;
-                setEncoding?.Bind(stream).Call(interpreter, [encoding]);
+                setEncoding?.Bind(stream).CallBoxed(interpreter, [encoding]);
             }
 
             // objectMode option - sets both readable and writable sides
@@ -77,6 +77,9 @@ public sealed class SharpTSTransformConstructor : ISharpTSCallable
 
         return stream;
     }
+
+    public RuntimeValue CallV2(Interp interpreter, ReadOnlySpan<RuntimeValue> arguments)
+        => RuntimeValue.FromBoxed(Call(interpreter, CallableInterop.ToBoxedList(arguments)));
 
     /// <summary>
     /// Gets a property from the Transform constructor (static properties/methods).

--- a/Runtime/Types/SharpTSWebStreamsConstructors.cs
+++ b/Runtime/Types/SharpTSWebStreamsConstructors.cs
@@ -22,6 +22,9 @@ public sealed class SharpTSReadableStreamConstructor : ISharpTSCallable
         return new SharpTSReadableStream(interpreter, src, strat);
     }
 
+    public RuntimeValue CallV2(Interp interpreter, ReadOnlySpan<RuntimeValue> arguments)
+        => RuntimeValue.FromBoxed(Call(interpreter, CallableInterop.ToBoxedList(arguments)));
+
     public object? GetProperty(string name)
     {
         // ReadableStream.from(iterable) — build a stream from an iterable.
@@ -64,12 +67,12 @@ public sealed class SharpTSReadableStreamConstructor : ISharpTSCallable
                 {
                     var chunk = pulled.Dequeue();
                     var enq = ctrl.GetMember("enqueue") as BuiltInMethod;
-                    enq?.Call(null!, [chunk]);
+                    enq?.CallBoxed(null!, [chunk]);
                 }
                 else
                 {
                     var close = ctrl.GetMember("close") as BuiltInMethod;
-                    close?.Call(null!, []);
+                    close?.CallBoxed(null!, []);
                 }
                 return SharpTSUndefined.Instance;
             }),
@@ -94,6 +97,9 @@ public sealed class SharpTSWritableStreamConstructor : ISharpTSCallable
         return new SharpTSWritableStream(interpreter, sink, strat);
     }
 
+    public RuntimeValue CallV2(Interp interpreter, ReadOnlySpan<RuntimeValue> arguments)
+        => RuntimeValue.FromBoxed(Call(interpreter, CallableInterop.ToBoxedList(arguments)));
+
     public override string ToString() => "[Function: WritableStream]";
 }
 
@@ -111,6 +117,9 @@ public sealed class SharpTSTransformStreamConstructor : ISharpTSCallable
         var rs = arguments.Count > 2 ? arguments[2] : null;
         return new SharpTSTransformStream(interpreter, transformer, ws, rs);
     }
+
+    public RuntimeValue CallV2(Interp interpreter, ReadOnlySpan<RuntimeValue> arguments)
+        => RuntimeValue.FromBoxed(Call(interpreter, CallableInterop.ToBoxedList(arguments)));
 
     public override string ToString() => "[Function: TransformStream]";
 }
@@ -133,6 +142,9 @@ public sealed class SharpTSByteLengthQueuingStrategyConstructor : ISharpTSCallab
         return new SharpTSByteLengthQueuingStrategy(hwm);
     }
 
+    public RuntimeValue CallV2(Interp interpreter, ReadOnlySpan<RuntimeValue> arguments)
+        => RuntimeValue.FromBoxed(Call(interpreter, CallableInterop.ToBoxedList(arguments)));
+
     public override string ToString() => "[Function: ByteLengthQueuingStrategy]";
 }
 
@@ -153,6 +165,9 @@ public sealed class SharpTSCountQueuingStrategyConstructor : ISharpTSCallable
         }
         return new SharpTSCountQueuingStrategy(hwm);
     }
+
+    public RuntimeValue CallV2(Interp interpreter, ReadOnlySpan<RuntimeValue> arguments)
+        => RuntimeValue.FromBoxed(Call(interpreter, CallableInterop.ToBoxedList(arguments)));
 
     public override string ToString() => "[Function: CountQueuingStrategy]";
 }

--- a/Runtime/Types/SharpTSWorker.cs
+++ b/Runtime/Types/SharpTSWorker.cs
@@ -314,7 +314,7 @@ public class SharpTSWorker : SharpTSEventEmitter, IDisposable
         {
             // Interpreter path - use BuiltInMethod
             var emitMethod = GetMember("emit") as BuiltInMethod;
-            emitMethod?.Call(_parentInterpreter, [eventName, data]);
+            emitMethod?.CallBoxed(_parentInterpreter, [eventName, data]);
         }
         else
         {
@@ -575,7 +575,7 @@ internal class WorkerMessageHandler
 
                     // Emit on parentPort
                     var emitMethod = parentPort.GetMember("emit") as BuiltInMethod;
-                    emitMethod?.Call(_interpreter, ["message", eventData]);
+                    emitMethod?.CallBoxed(_interpreter, ["message", eventData]);
                 }
             }
             catch (Exception ex)
@@ -649,6 +649,9 @@ internal class WorkerConstructor : ISharpTSCallable
         var options = arguments.Count > 1 ? arguments[1] as SharpTSObject : null;
         return new SharpTSWorker(filename, options, interpreter);
     }
+
+    public RuntimeValue CallV2(Interpreter interpreter, ReadOnlySpan<RuntimeValue> arguments)
+        => RuntimeValue.FromBoxed(Call(interpreter, CallableInterop.ToBoxedList(arguments)));
 }
 
 /// <summary>
@@ -662,4 +665,7 @@ internal class MessageChannelConstructor : ISharpTSCallable
     {
         return new SharpTSMessageChannel();
     }
+
+    public RuntimeValue CallV2(Interpreter interpreter, ReadOnlySpan<RuntimeValue> arguments)
+        => RuntimeValue.FromBoxed(Call(interpreter, CallableInterop.ToBoxedList(arguments)));
 }

--- a/Runtime/Types/SharpTSWritable.cs
+++ b/Runtime/Types/SharpTSWritable.cs
@@ -144,7 +144,7 @@ public class SharpTSWritable : SharpTSEventEmitter
             var writeArgs = new List<object?> { chunk, encoding ?? "utf8", cbWrapper };
             try
             {
-                _writeCallback.Call(interpreter, writeArgs);
+                _writeCallback.CallBoxed(interpreter, writeArgs);
             }
             catch (Exception ex)
             {
@@ -157,7 +157,7 @@ public class SharpTSWritable : SharpTSEventEmitter
             // Default behavior: just accept the data (sync completion)
             _pendingWrites--;
             _writableLength -= chunkSize;
-            callback?.Call(interpreter, []);
+            callback?.CallBoxed(interpreter, []);
             CheckDrain(interpreter);
         }
 
@@ -270,7 +270,7 @@ public class SharpTSWritable : SharpTSEventEmitter
             var finalCbWrapper = new WriteCallbackWrapper(null, interpreter, this, 0);
             try
             {
-                _finalCallback.Call(interpreter, [finalCbWrapper]);
+                _finalCallback.CallBoxed(interpreter, [finalCbWrapper]);
             }
             catch (Exception ex)
             {
@@ -279,7 +279,7 @@ public class SharpTSWritable : SharpTSEventEmitter
         }
 
         _finished = true;
-        callback?.Call(interpreter, []);
+        callback?.CallBoxed(interpreter, []);
         EmitFinish(interpreter);
 
         return this;
@@ -343,7 +343,7 @@ public class SharpTSWritable : SharpTSEventEmitter
             try
             {
                 var err = args.Count > 0 ? args[0] : null;
-                _destroyCallback.Call(interpreter, [err, new DestroyCallbackWrapper(interpreter, this)]);
+                _destroyCallback.CallBoxed(interpreter, [err, new DestroyCallbackWrapper(interpreter, this)]);
             }
             catch (Exception ex)
             {
@@ -435,11 +435,14 @@ public class SharpTSWritable : SharpTSEventEmitter
             _stream._pendingWrites--;
             _stream._writableLength -= _chunkSize;
             // Call the original callback
-            _callback?.Call(_interpreter, []);
+            _callback?.CallBoxed(_interpreter, []);
             // Check if we need to emit drain
             _stream.CheckDrain(_interpreter);
             return null;
         }
+
+        public RuntimeValue CallV2(Interp interpreter, ReadOnlySpan<RuntimeValue> arguments)
+            => RuntimeValue.FromBoxed(Call(interpreter, CallableInterop.ToBoxedList(arguments)));
     }
 
     /// <summary>
@@ -468,5 +471,8 @@ public class SharpTSWritable : SharpTSEventEmitter
             _stream.EmitClose(_interpreter);
             return null;
         }
+
+        public RuntimeValue CallV2(Interp interpreter, ReadOnlySpan<RuntimeValue> arguments)
+            => RuntimeValue.FromBoxed(Call(interpreter, CallableInterop.ToBoxedList(arguments)));
     }
 }

--- a/Runtime/Types/SharpTSWritableConstructor.cs
+++ b/Runtime/Types/SharpTSWritableConstructor.cs
@@ -72,6 +72,9 @@ public sealed class SharpTSWritableConstructor : ISharpTSCallable
         return stream;
     }
 
+    public RuntimeValue CallV2(Interp interpreter, ReadOnlySpan<RuntimeValue> arguments)
+        => RuntimeValue.FromBoxed(Call(interpreter, CallableInterop.ToBoxedList(arguments)));
+
     /// <summary>
     /// Gets a property from the Writable constructor (static properties/methods).
     /// </summary>

--- a/Runtime/Types/SharpTSWriteStream.cs
+++ b/Runtime/Types/SharpTSWriteStream.cs
@@ -88,10 +88,13 @@ public class SharpTSWriteStream : SharpTSWritable
             }
 
             // Call the done callback
-            callback?.Call(interpreter, []);
+            callback?.CallBoxed(interpreter, []);
 
             return null;
         }
+
+        public RuntimeValue CallV2(Interp interpreter, ReadOnlySpan<RuntimeValue> arguments)
+            => RuntimeValue.FromBoxed(Call(interpreter, CallableInterop.ToBoxedList(arguments)));
     }
 
     /// <summary>
@@ -110,6 +113,9 @@ public class SharpTSWriteStream : SharpTSWritable
             _stream.CloseFileStream(interpreter);
             return null;
         }
+
+        public RuntimeValue CallV2(Interp interpreter, ReadOnlySpan<RuntimeValue> arguments)
+            => RuntimeValue.FromBoxed(Call(interpreter, CallableInterop.ToBoxedList(arguments)));
     }
 
     private void CloseFileStream(Interp interpreter)

--- a/Runtime/Types/SharpTSZlibTransform.cs
+++ b/Runtime/Types/SharpTSZlibTransform.cs
@@ -212,15 +212,18 @@ public class SharpTSZlibTransform : SharpTSTransform
             try
             {
                 _stream.TransformChunk(interpreter, chunk);
-                callback?.Call(interpreter, [null]);
+                callback?.CallBoxed(interpreter, [null]);
             }
             catch (Exception ex)
             {
-                callback?.Call(interpreter, [ex.Message]);
+                callback?.CallBoxed(interpreter, [ex.Message]);
             }
 
             return null;
         }
+
+        public RuntimeValue CallV2(Interp interpreter, ReadOnlySpan<RuntimeValue> arguments)
+            => RuntimeValue.FromBoxed(Call(interpreter, CallableInterop.ToBoxedList(arguments)));
     }
 
     private class ZlibFlushCallback : ISharpTSCallable
@@ -236,14 +239,17 @@ public class SharpTSZlibTransform : SharpTSTransform
             try
             {
                 _stream.Flush(interpreter);
-                callback?.Call(interpreter, [null]);
+                callback?.CallBoxed(interpreter, [null]);
             }
             catch (Exception ex)
             {
-                callback?.Call(interpreter, [ex.Message]);
+                callback?.CallBoxed(interpreter, [ex.Message]);
             }
 
             return null;
         }
+
+        public RuntimeValue CallV2(Interp interpreter, ReadOnlySpan<RuntimeValue> arguments)
+            => RuntimeValue.FromBoxed(Call(interpreter, CallableInterop.ToBoxedList(arguments)));
     }
 }

--- a/Runtime/Types/TSFunctionCallableAdapter.cs
+++ b/Runtime/Types/TSFunctionCallableAdapter.cs
@@ -28,6 +28,9 @@ public class TSFunctionCallableAdapter : ISharpTSCallable
         return _function.Invoke(arguments.ToArray());
     }
 
+    public RuntimeValue CallV2(Interpreter interpreter, ReadOnlySpan<RuntimeValue> arguments)
+        => RuntimeValue.FromBoxed(Call(interpreter, CallableInterop.ToBoxedList(arguments)));
+
     /// <summary>
     /// Creates an ISharpTSCallable from an object that may be a TSFunction,
     /// ISharpTSCallable, or null.
@@ -67,6 +70,9 @@ public class TSFunctionCallableAdapter : ISharpTSCallable
             // Do nothing - user must add 'request' event listener
             return null;
         }
+
+        public RuntimeValue CallV2(Interpreter interpreter, ReadOnlySpan<RuntimeValue> arguments)
+            => RuntimeValue.FromBoxed(Call(interpreter, CallableInterop.ToBoxedList(arguments)));
     }
 
     /// <summary>
@@ -100,5 +106,8 @@ public class TSFunctionCallableAdapter : ISharpTSCallable
                 return null;
             }
         }
+
+        public RuntimeValue CallV2(Interpreter interpreter, ReadOnlySpan<RuntimeValue> arguments)
+            => RuntimeValue.FromBoxed(Call(interpreter, CallableInterop.ToBoxedList(arguments)));
     }
 }

--- a/Runtime/Types/VmContext.cs
+++ b/Runtime/Types/VmContext.cs
@@ -142,5 +142,8 @@ internal sealed class CompiledCallableAdapter(object target, MethodInfo invokeMe
         return invokeMethod.Invoke(target, [args]);
     }
 
+    public RuntimeValue CallV2(Interpreter interpreter, ReadOnlySpan<RuntimeValue> arguments)
+        => RuntimeValue.FromBoxed(Call(interpreter, CallableInterop.ToBoxedList(arguments)));
+
     public override string ToString() => target.ToString() ?? "<compiled function>";
 }

--- a/SharpTS.Test262/Test262Runner.cs
+++ b/SharpTS.Test262/Test262Runner.cs
@@ -914,6 +914,9 @@ function $DONE(err) {
             return null;
         }
 
+        public RuntimeValue CallV2(Interpreter interpreter, ReadOnlySpan<RuntimeValue> arguments)
+            => RuntimeValue.FromBoxed(Call(interpreter, CallableInterop.ToBoxedList(arguments)));
+
         public override string ToString() => "function $DONE() { [native code] }";
     }
 }


### PR DESCRIPTION
## PR 3 of 4: finish the RuntimeValue/V2 callable migration

Stacked on #175. Every remaining `ISharpTSCallable` implementor gains `CallV2`, and all ~140 remaining legacy `.Call(` invocation sites in `Runtime/` move to `CallBoxed`/span dispatch. After this PR, deleting the legacy `Call` from the interface (PR4) is a compiler-enforced cleanup.

### Approach (uniform per class)
- **Native body** where the class delegates to another callable or does simple value work (promise callbacks, deprecated/decorator wrappers, error toString, AsyncLocalStorage constructor, …) — legacy `Call` becomes a one-line delegator.
- **Boxed-body bridge** (`CallV2 => FromBoxed(Call(ToBoxedList(args)))`) where the body is inherently `object?`-based: stream plumbing, namespaces/prototype wrappers, network/module constructors and listeners, workers, typed-array constructors, `SharpTSProxy`'s apply surface, DotNet interop, `CompiledCallableAdapter` (its `object?[]` reflection contract is byte-identical), `Test262DoneCallback`.
- Exactly one real body per class; no mutual delegation anywhere.
- **`BuiltInAsyncMethod`** preserves its sync-throw → rejected-`SharpTSPromise` contract by routing `CallV2` through the existing `Call` body (span materialized first — args outlive suspension).
- Call-site flips audited for type fidelity: `FromBoxed→ToObject` round-trips double/string/bool/null/reference values identically; audit found no site passing raw non-double numerics (`DotNetDelegateShim` args are pre-normalized by `DotNetMarshaller`). One deliberate keeper: `SharpTSFetchGlobal`'s real body calls its concrete inner `BuiltInMethod` directly.

### Verification
- xUnit: **10,454 passed** (2 known environmental `PackagingTests` failures, reproduce on clean base).
- TS conformance: **31/31, zero baseline diff**.
- Test262 (Debug, subprocess worker, facts run separately): **0 regressions both modes**; drift is exactly the known stale-baseline set (17 compiled / 14 interpreted), totals byte-match the base-commit runs (compiled Pass=7866, interpreted Pass=3912/Fail=3735/RuntimeError=2716).