### PR TITLE
fix: TypeLoadException for generic classes in compiled mode

### DIFF
--- a/Compilation/CompilationContext.Classes.cs
+++ b/Compilation/CompilationContext.Classes.cs
@@ -35,6 +35,17 @@ public partial class CompilationContext
     // For static members: current class being compiled
     public TypeBuilder? CurrentClassBuilder { get; set; }
 
+    /// <summary>
+    /// The TypeBuilder whose method body the context's <see cref="CompilationContext.IL"/>
+    /// is generating, set ONLY when emitting directly into a class's own methods
+    /// (instance/static methods, constructors, accessors). Null for top-level code,
+    /// arrow display classes, and async/generator state machines — those bodies live on
+    /// other types even though <see cref="CurrentClassBuilder"/> still points at the class.
+    /// Used to decide whether the instantiated self-form of a generic class
+    /// (e.g. <c>Stack&lt;!T&gt;</c>) is expressible for direct member dispatch (#178).
+    /// </summary>
+    public TypeBuilder? EmittingTypeBuilder { get; set; }
+
     // For inheritance: current class's superclass name (if any)
     public string? CurrentSuperclassName { get; set; }
 

--- a/Compilation/EmitterTypeHelpers.cs
+++ b/Compilation/EmitterTypeHelpers.cs
@@ -63,6 +63,125 @@ internal static class EmitterTypeHelpers
                 $"No matching field on {closedGeneric} for open field {openField.DeclaringType}::{openField.Name}");
     }
 
+    /// <summary>
+    /// Resolves a field token for IL emitted inside methods of the field's own declaring type.
+    /// ECMA-335 (II.9.4) requires members of a generic type to be referenced through the
+    /// instantiated form (e.g. <c>Stack&lt;!T&gt;::__Items</c>) rather than a raw token whose
+    /// parent is the open TypeDef. Non-generic declaring types pass through unchanged.
+    /// </summary>
+    public static FieldInfo SelfFieldReference(FieldInfo field)
+    {
+        if (field.DeclaringType is TypeBuilder tb && tb.IsGenericTypeDefinition)
+            return TypeBuilder.GetField(tb.MakeGenericType(tb.GetGenericArguments()), field);
+        return field;
+    }
+
+    /// <summary>
+    /// Resolves a method token for IL emitted inside methods of the method's own declaring type.
+    /// Same ECMA-335 (II.9.4) rule as <see cref="SelfFieldReference"/>: members of a generic
+    /// type must be referenced through the instantiated form (e.g. <c>Stack&lt;!T&gt;::get_Items</c>).
+    /// Non-generic declaring types pass through unchanged.
+    /// </summary>
+    public static MethodInfo SelfMethodReference(MethodInfo method)
+    {
+        if (method.DeclaringType is TypeBuilder tb && tb.IsGenericTypeDefinition)
+            return TypeBuilder.GetMethod(tb.MakeGenericType(tb.GetGenericArguments()), method);
+        return method;
+    }
+
+    /// <summary>
+    /// Resolves the cast type and call target for direct (compile-time) dispatch of
+    /// <paramref name="method"/> on an instance statically typed as <paramref name="receiverClass"/>.
+    ///
+    /// A raw TypeDef token for an open generic class (e.g. <c>castclass Stack</c>) cannot be
+    /// loaded by the CLR — resolving it at JIT time throws <c>TypeLoadException: Could not load
+    /// type 'Stack'</c> (ECMA-335 II.9.4 requires the instantiated form). The instantiated
+    /// self-form <c>Stack&lt;!T&gt;</c> is only expressible in IL bodies that live on that same
+    /// generic type, where <c>!T</c> is in scope.
+    ///
+    /// Returns false when no valid token exists for the emission context — the caller must fall
+    /// back to runtime (dynamic) dispatch, which handles generic instances correctly.
+    /// </summary>
+    /// <param name="receiverClass">The class TypeBuilder the receiver is statically typed as.</param>
+    /// <param name="method">The method/accessor to invoke (may be declared on a generic base).</param>
+    /// <param name="emittingType">The TypeBuilder whose method body is currently being emitted,
+    /// or null when emitting into a function/state-machine/display-class body.</param>
+    public static bool TryResolveInstanceDispatch(
+        TypeBuilder receiverClass, MethodInfo method, Type? emittingType,
+        out Type castType, out MethodInfo callTarget)
+    {
+        castType = receiverClass;
+        callTarget = method;
+
+        if (receiverClass.IsGenericTypeDefinition)
+        {
+            // Stack<!T> is only meaningful inside Stack<T>'s own method bodies.
+            if (!ReferenceEquals(emittingType, receiverClass))
+                return false;
+            castType = receiverClass.MakeGenericType(receiverClass.GetGenericArguments());
+        }
+
+        // Methods declared on a generic (possibly base) class need a member reference
+        // through the instantiation found on the receiver's inheritance chain.
+        if (method.DeclaringType is TypeBuilder declType && declType.IsGenericTypeDefinition)
+        {
+            if (ReferenceEquals(declType, receiverClass))
+            {
+                callTarget = TypeBuilder.GetMethod(castType, method);
+                return true;
+            }
+
+            return TryResolveOnBaseChain(receiverClass, declType, method, emittingType, out callTarget);
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Resolves a call target for a method declared on a generic base class of
+    /// <paramref name="fromClass"/>, referencing it through the instantiated base
+    /// (e.g. <c>Base&lt;float64&gt;::count</c>) found on the inheritance chain.
+    /// A raw MethodDef token on the open base is not executable — invoking it throws
+    /// <c>InvalidOperationException: ... not fully instantiated</c>. Used for both
+    /// inherited-member dispatch and <c>super.method()</c> calls (#178).
+    /// Returns false when no expressible token exists for the emission context.
+    /// </summary>
+    public static bool TryResolveOnBaseChain(
+        TypeBuilder fromClass, TypeBuilder declType, MethodInfo method, Type? emittingType,
+        out MethodInfo callTarget)
+    {
+        callTarget = method;
+        for (Type? t = fromClass.BaseType; t != null; t = t.BaseType)
+        {
+            if (t.IsGenericType && ReferenceEquals(t.GetGenericTypeDefinition(), declType))
+            {
+                // An instantiation written in terms of fromClass's own type parameters
+                // (e.g. Base<!T>) is only expressible inside fromClass's bodies.
+                if (t.ContainsGenericParameters && !ReferenceEquals(emittingType, fromClass))
+                    return false;
+                callTarget = TypeBuilder.GetMethod(t, method);
+                return true;
+            }
+        }
+        return false; // no instantiation of the declaring type found
+    }
+
+    /// <summary>
+    /// Resolves the call target for <c>super.method()</c> / inherited-method dispatch when
+    /// the method may be declared on a generic base of <paramref name="currentClass"/>.
+    /// Pass-through for methods on non-generic types.
+    /// </summary>
+    public static bool TryResolveSuperCall(
+        TypeBuilder? currentClass, MethodInfo method, Type? emittingType, out MethodInfo callTarget)
+    {
+        callTarget = method;
+        if (method.DeclaringType is not TypeBuilder declType || !declType.IsGenericTypeDefinition)
+            return true;
+        if (currentClass == null)
+            return false;
+        return TryResolveOnBaseChain(currentClass, declType, method, emittingType, out callTarget);
+    }
+
     private static bool ContainsTypeBuilder(Type t)
     {
         if (t is TypeBuilder) return true;

--- a/Compilation/ExpressionEmitterBase.CallHelpers.cs
+++ b/Compilation/ExpressionEmitterBase.CallHelpers.cs
@@ -906,6 +906,13 @@ public abstract partial class ExpressionEmitterBase
         if (!Ctx.Classes.TryGetValue(className, out var classType2))
             return false;
 
+        // Generic classes need instantiated tokens (Stack<!T>), only expressible inside
+        // the class's own bodies — never the case for state-machine emitters, where
+        // EmittingTypeBuilder is null. Fall back to runtime dispatch there (#178).
+        if (!EmitterTypeHelpers.TryResolveInstanceDispatch(
+                classType2, methodBuilder, Ctx.EmittingTypeBuilder, out var castType, out var callTarget))
+            return false;
+
         var methodParams = methodBuilder.GetParameters();
         int expectedParamCount = methodParams.Length;
 
@@ -921,7 +928,7 @@ public abstract partial class ExpressionEmitterBase
 
         EmitExpression(receiver);
         EnsureBoxed();
-        IL.Emit(OpCodes.Castclass, classType2);
+        IL.Emit(OpCodes.Castclass, castType);
 
         for (int i = 0; i < argTemps.Count; i++)
         {
@@ -941,7 +948,7 @@ public abstract partial class ExpressionEmitterBase
             EmitDefaultForType(methodParams[i].ParameterType);
         }
 
-        IL.Emit(OpCodes.Callvirt, methodBuilder);
+        IL.Emit(OpCodes.Callvirt, callTarget);
         SetStackUnknown();
         return true;
     }
@@ -975,6 +982,12 @@ public abstract partial class ExpressionEmitterBase
         string resolvedSuperName = Ctx.ResolveClassName(superclassName);
         var methodBuilder = Ctx.ResolveInstanceMethod(resolvedSuperName, methodName);
         if (methodBuilder == null)
+            return false;
+
+        // Generic superclasses need the member referenced through the instantiated base
+        // (e.g. Base<float64>::count) — an open MethodDef token is not executable (#178)
+        if (!EmitterTypeHelpers.TryResolveSuperCall(
+                Ctx.CurrentClassBuilder, methodBuilder, Ctx.EmittingTypeBuilder, out var superTarget))
             return false;
 
         var methodParams = methodBuilder.GetParameters();
@@ -1018,7 +1031,7 @@ public abstract partial class ExpressionEmitterBase
             EmitDefaultForType(methodParams[i].ParameterType);
         }
 
-        IL.Emit(OpCodes.Call, methodBuilder);
+        IL.Emit(OpCodes.Call, superTarget);
         SetStackUnknown();
         return true;
     }

--- a/Compilation/ILCompiler.Classes.Accessors.cs
+++ b/Compilation/ILCompiler.Classes.Accessors.cs
@@ -113,6 +113,7 @@ public partial class ILCompiler
             IsInstanceMethod = !accessor.IsStatic,
             CurrentClassName = className,
             CurrentClassBuilder = typeBuilder,
+            EmittingTypeBuilder = typeBuilder,
             ClosureAnalyzer = _closures.Analyzer,
             ArrowMethods = _closures.ArrowMethods,
             ConstArrowBindings = _closures.ConstArrowBindings,

--- a/Compilation/ILCompiler.Classes.Constructors.cs
+++ b/Compilation/ILCompiler.Classes.Constructors.cs
@@ -88,6 +88,7 @@ public partial class ILCompiler
             // ES2022 Private Class Elements support
             CurrentClassName = className,
             CurrentClassBuilder = typeBuilder,
+            EmittingTypeBuilder = typeBuilder,
             // Registry services
             ClassRegistry = GetClassRegistry(),
             // Module-level variable access

--- a/Compilation/ILCompiler.Classes.HasFields.cs
+++ b/Compilation/ILCompiler.Classes.HasFields.cs
@@ -296,8 +296,9 @@ public partial class ILCompiler
                 il.Emit(OpCodes.Brfalse, nextLabel);
 
                 // return this.<getter>()
+                // (instantiated form for generic classes — open MethodDef tokens are unloadable, #178)
                 il.Emit(OpCodes.Ldarg_0);
-                il.Emit(OpCodes.Callvirt, getterMethod);
+                il.Emit(OpCodes.Callvirt, EmitterTypeHelpers.SelfMethodReference(getterMethod));
                 il.Emit(OpCodes.Ret);
 
                 il.MarkLabel(nextLabel);
@@ -376,7 +377,8 @@ public partial class ILCompiler
         var setFieldsLabel = il.DefineLabel();
 
         // 1. Check typed properties with backing fields (compile-time dispatch)
-        if (_typedInterop.PropertyBackingFields.TryGetValue(className, out var backingFields))
+        _typedInterop.PropertyBackingFields.TryGetValue(className, out var backingFields);
+        if (backingFields != null)
         {
             foreach (var (propName, backingField) in backingFields)
             {
@@ -398,6 +400,45 @@ public partial class ILCompiler
                 else if (backingField.FieldType != _types.Object)
                     il.Emit(OpCodes.Castclass, backingField.FieldType);
                 il.Emit(OpCodes.Stfld, backingField);
+                il.Emit(OpCodes.Ret);
+
+                il.MarkLabel(nextLabel);
+            }
+        }
+
+        // 1b. Check instance setters (accessors with `set` keyword). JS semantics: writing
+        // `obj.foo` where `foo` is a setter must INVOKE it — mirrors the getter dispatch in
+        // EmitGetPropertyBody. Without this, dynamic property writes (the main path for
+        // generic class instances) would store into _fields while reads keep hitting the
+        // accessor, silently desynchronizing the two. Backing-field names are handled above.
+        if (_classes.InstanceSetters.TryGetValue(className, out var instanceSetters))
+        {
+            foreach (var (setterPascalName, setterMethod) in instanceSetters)
+            {
+                if (backingFields != null && backingFields.ContainsKey(setterPascalName))
+                    continue;
+
+                var camelName = NamingConventions.ToCamelCase(setterPascalName);
+                var nextLabel = il.DefineLabel();
+
+                il.Emit(OpCodes.Ldarg_1);
+                il.Emit(OpCodes.Ldstr, camelName);
+                il.Emit(OpCodes.Call, _types.GetMethod(_types.String, "op_Equality", _types.String, _types.String));
+                il.Emit(OpCodes.Brfalse, nextLabel);
+
+                // this.set_<Name>(value)
+                il.Emit(OpCodes.Ldarg_0);
+                il.Emit(OpCodes.Ldarg_2);
+                var setterParams = setterMethod.GetParameters();
+                var paramType = setterParams.Length > 0 ? setterParams[0].ParameterType : _types.Object;
+                if (paramType.IsValueType)
+                    il.Emit(OpCodes.Unbox_Any, paramType);
+                else if (paramType != _types.Object)
+                    il.Emit(OpCodes.Castclass, paramType);
+                // (instantiated form for generic classes — open MethodDef tokens are unloadable, #178)
+                il.Emit(OpCodes.Callvirt, EmitterTypeHelpers.SelfMethodReference(setterMethod));
+                if (setterMethod.ReturnType != _types.Void)
+                    il.Emit(OpCodes.Pop);
                 il.Emit(OpCodes.Ret);
 
                 il.MarkLabel(nextLabel);

--- a/Compilation/ILCompiler.Classes.Methods.cs
+++ b/Compilation/ILCompiler.Classes.Methods.cs
@@ -733,6 +733,7 @@ public partial class ILCompiler
             DisplayClassFields = _closures.DisplayClassFields,
             DisplayClassConstructors = _closures.DisplayClassConstructors,
             CurrentClassBuilder = typeBuilder,
+            EmittingTypeBuilder = typeBuilder,
             FunctionRestParams = _functions.RestParams,
             FunctionsCapturingArguments = _functions.CapturingArguments,
             EnumMembers = _enums.Members,
@@ -948,6 +949,7 @@ public partial class ILCompiler
             // ES2022 Private Class Elements support
             CurrentClassName = typeBuilder.Name,
             CurrentClassBuilder = typeBuilder,
+            EmittingTypeBuilder = typeBuilder,
             // Registry services
             ClassRegistry = GetClassRegistry(),
             // Module-level variable access. For class method bodies we augment

--- a/Compilation/ILCompiler.Classes.Properties.cs
+++ b/Compilation/ILCompiler.Classes.Properties.cs
@@ -107,10 +107,14 @@ public partial class ILCompiler
             Type.EmptyTypes
         );
 
+        // Field tokens inside a generic type's methods must reference the instantiated
+        // form (Stack<!T>::field), not the open TypeDef — see EmitterTypeHelpers.SelfFieldReference
+        var backingFieldRef = EmitterTypeHelpers.SelfFieldReference(backingField);
+
         var getterIL = getter.GetILGenerator();
-        getterIL.Emit(OpCodes.Ldarg_0);             // this
-        getterIL.Emit(OpCodes.Ldfld, backingField); // this.__fieldName (typed value)
-        getterIL.Emit(OpCodes.Ret);                 // Return typed value directly
+        getterIL.Emit(OpCodes.Ldarg_0);                // this
+        getterIL.Emit(OpCodes.Ldfld, backingFieldRef); // this.__fieldName (typed value)
+        getterIL.Emit(OpCodes.Ret);                    // Return typed value directly
 
         property.SetGetMethod(getter);
 
@@ -136,7 +140,7 @@ public partial class ILCompiler
             var setterIL = setter.GetILGenerator();
             setterIL.Emit(OpCodes.Ldarg_0);          // this
             setterIL.Emit(OpCodes.Ldarg_1);          // value (already typed)
-            setterIL.Emit(OpCodes.Stfld, backingField);  // this.__fieldName = value
+            setterIL.Emit(OpCodes.Stfld, backingFieldRef);  // this.__fieldName = value
             setterIL.Emit(OpCodes.Ret);
 
             // Only link to PropertyBuilder for non-readonly (C# interop visibility)

--- a/Compilation/ILCompiler.Classes.Static.cs
+++ b/Compilation/ILCompiler.Classes.Static.cs
@@ -69,6 +69,7 @@ public partial class ILCompiler
             DisplayClassFields = _closures.DisplayClassFields,
             DisplayClassConstructors = _closures.DisplayClassConstructors,
             CurrentClassBuilder = typeBuilder,
+            EmittingTypeBuilder = typeBuilder,
             CurrentClassName = qualifiedClassName, // Required for static member access via 'this'
             FunctionRestParams = _functions.RestParams,
             FunctionsCapturingArguments = _functions.CapturingArguments,
@@ -264,6 +265,7 @@ public partial class ILCompiler
             DisplayClassFields = _closures.DisplayClassFields,
             DisplayClassConstructors = _closures.DisplayClassConstructors,
             CurrentClassBuilder = typeBuilder,
+            EmittingTypeBuilder = typeBuilder,
             FunctionRestParams = _functions.RestParams,
             FunctionsCapturingArguments = _functions.CapturingArguments,
             EnumMembers = _enums.Members,
@@ -488,6 +490,7 @@ public partial class ILCompiler
             DisplayClassFields = _closures.DisplayClassFields,
             DisplayClassConstructors = _closures.DisplayClassConstructors,
             CurrentClassBuilder = typeBuilder,
+            EmittingTypeBuilder = typeBuilder,
             FunctionRestParams = _functions.RestParams,
             FunctionsCapturingArguments = _functions.CapturingArguments,
             EnumMembers = _enums.Members,

--- a/Compilation/ILEmitter.Calls.MethodDispatch.cs
+++ b/Compilation/ILEmitter.Calls.MethodDispatch.cs
@@ -267,6 +267,12 @@ public partial class ILEmitter
         if (!_ctx.Classes.TryGetValue(className, out var classType))
             return false;
 
+        // Generic classes need instantiated tokens (Stack<!T>), only expressible inside
+        // the class's own bodies; otherwise fall back to runtime dispatch (#178)
+        if (!EmitterTypeHelpers.TryResolveInstanceDispatch(
+                classType, methodBuilder, _ctx.EmittingTypeBuilder, out var castType, out var callTarget))
+            return false;
+
         // Get target parameter types for proper conversion
         var targetParams = methodBuilder.GetParameters();
         int expectedParamCount = targetParams.Length;
@@ -285,7 +291,7 @@ public partial class ILEmitter
         // Emit: ((ClassName)receiver).method(args)
         EmitExpression(receiver);
         EmitBoxIfNeeded(receiver);
-        IL.Emit(OpCodes.Castclass, classType);
+        IL.Emit(OpCodes.Castclass, castType);
 
         // Emit leading regular arguments with type conversion.
         int regularArgsToEmit = Math.Min(arguments.Count, regularParamCount);
@@ -332,7 +338,7 @@ public partial class ILEmitter
         }
 
         // Emit the virtual call
-        IL.Emit(OpCodes.Callvirt, methodBuilder);
+        IL.Emit(OpCodes.Callvirt, callTarget);
         SetStackUnknown();
         return true;
     }
@@ -376,6 +382,12 @@ public partial class ILEmitter
         if (methodBuilder == null)
             return false;
 
+        // Generic superclasses need the member referenced through the instantiated base
+        // (e.g. Base<float64>::count) — an open MethodDef token is not executable (#178)
+        if (!EmitterTypeHelpers.TryResolveSuperCall(
+                _ctx.CurrentClassBuilder, methodBuilder, _ctx.EmittingTypeBuilder, out var superTarget))
+            return false;
+
         var methodParams = methodBuilder.GetParameters();
 
         // Emit: this.Base::method(args) via non-virtual Call
@@ -401,7 +413,7 @@ public partial class ILEmitter
         }
 
         // Use Call (NOT Callvirt) to bypass virtual dispatch
-        IL.Emit(OpCodes.Call, methodBuilder);
+        IL.Emit(OpCodes.Call, superTarget);
         SetStackUnknown();
         return true;
     }

--- a/Compilation/ILEmitter.Properties.cs
+++ b/Compilation/ILEmitter.Properties.cs
@@ -1131,11 +1131,17 @@ public partial class ILEmitter
         if (!_ctx.Classes.TryGetValue(className, out var classType))
             return false;
 
+        // Generic classes need instantiated tokens (Stack<!T>), only expressible inside
+        // the class's own bodies; otherwise fall back to runtime dispatch (#178)
+        if (!EmitterTypeHelpers.TryResolveInstanceDispatch(
+                classType, getterBuilder, _ctx.EmittingTypeBuilder, out var castType, out var getterTarget))
+            return false;
+
         // Emit: ((ClassName)receiver).get_PropertyName()
         EmitExpression(receiver);
         EmitBoxIfNeeded(receiver);
-        IL.Emit(OpCodes.Castclass, classType);
-        IL.Emit(OpCodes.Callvirt, getterBuilder);
+        IL.Emit(OpCodes.Castclass, castType);
+        IL.Emit(OpCodes.Callvirt, getterTarget);
 
         // Check the actual return type of the getter method
         // Field properties have typed getters, but explicit accessors return object
@@ -1208,6 +1214,12 @@ public partial class ILEmitter
         if (!_ctx.Classes.TryGetValue(className, out var classType))
             return false;
 
+        // Generic classes need instantiated tokens (Stack<!T>), only expressible inside
+        // the class's own bodies; otherwise fall back to runtime dispatch (#178)
+        if (!EmitterTypeHelpers.TryResolveInstanceDispatch(
+                classType, setterBuilder, _ctx.EmittingTypeBuilder, out var castType, out var setterTarget))
+            return false;
+
         // Get the actual parameter type of the setter method
         // Field properties have typed setters, but explicit accessors take object
         var setterParams = setterBuilder.GetParameters();
@@ -1244,7 +1256,7 @@ public partial class ILEmitter
 
         // Load receiver and cast to class type
         IL.Emit(OpCodes.Ldloc, receiverTemp);
-        IL.Emit(OpCodes.Castclass, classType);
+        IL.Emit(OpCodes.Castclass, castType);
 
         // Emit value and convert to setter parameter type
         EmitExpression(value);
@@ -1261,7 +1273,7 @@ public partial class ILEmitter
             var resultTemp = IL.DeclareLocal(_ctx.Types.Object);
             IL.Emit(OpCodes.Stloc, resultTemp);
             IL.Emit(OpCodes.Unbox_Any, setterParamType);
-            IL.Emit(OpCodes.Callvirt, setterBuilder);
+            IL.Emit(OpCodes.Callvirt, setterTarget);
             // Pop setter return value if not void (explicit accessors return object)
             if (!setterReturnsVoid)
             {
@@ -1280,7 +1292,7 @@ public partial class ILEmitter
             {
                 IL.Emit(OpCodes.Castclass, setterParamType);
             }
-            IL.Emit(OpCodes.Callvirt, setterBuilder);
+            IL.Emit(OpCodes.Callvirt, setterTarget);
             // Pop setter return value if not void (explicit accessors return object)
             if (!setterReturnsVoid)
             {

--- a/SharpTS.Tests/SharedTests/GenericsTests.cs
+++ b/SharpTS.Tests/SharedTests/GenericsTests.cs
@@ -159,6 +159,208 @@ public class GenericsTests
         Assert.Equal("age\n25\n", output);
     }
 
+    // Regression tests for #178: compiled mode emitted castclass/callvirt tokens against
+    // the open generic TypeDef inside the class's own method bodies, which the CLR refuses
+    // to load at JIT time (TypeLoadException: Could not load type 'Stack').
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void GenericClass_ArrayFieldAndGetter_Works(ExecutionMode mode)
+    {
+        var source = """
+            class Stack<T> {
+                private items: T[] = [];
+                push(item: T): void {
+                    this.items.push(item);
+                }
+                pop(): T | undefined {
+                    return this.items.pop();
+                }
+                peek(): T | undefined {
+                    return this.items[this.items.length - 1];
+                }
+                get size(): number {
+                    return this.items.length;
+                }
+            }
+            const stack = new Stack<number>();
+            stack.push(10);
+            stack.push(20);
+            stack.push(30);
+            console.log(stack.size);
+            console.log(stack.peek());
+            console.log(stack.pop());
+            console.log(stack.size);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("3\n30\n30\n2\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void GenericClass_NonGenericFields_Work(ExecutionMode mode)
+    {
+        var source = """
+            class Mixed<T> {
+                private maybe: T | undefined;
+                private label: string = "lbl";
+                private count: number = 0;
+                set(v: T): void {
+                    this.maybe = v;
+                    this.count = this.count + 1;
+                }
+                describe(): string {
+                    return this.label + ":" + this.count + ":" + this.maybe;
+                }
+            }
+            const m = new Mixed<number>();
+            m.set(42);
+            console.log(m.describe());
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("lbl:1:42\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void GenericClass_MethodCallingOwnMethod_Works(ExecutionMode mode)
+    {
+        var source = """
+            class Box<T> {
+                describe(): string {
+                    return "box:" + this.tag();
+                }
+                tag(): string {
+                    return "generic";
+                }
+            }
+            console.log(new Box<number>().describe());
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("box:generic\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void GenericClass_ExtendedByNonGeneric_InheritedFieldAndSuperCall_Work(ExecutionMode mode)
+    {
+        var source = """
+            class Base<T> {
+                protected stored: T[] = [];
+                put(v: T): void {
+                    this.stored.push(v);
+                }
+                count(): number {
+                    return this.stored.length;
+                }
+            }
+            class IntBag extends Base<number> {
+                sum(): number {
+                    let t = 0;
+                    for (const v of this.stored) {
+                        t += v;
+                    }
+                    return t + super.count();
+                }
+            }
+            const bag = new IntBag();
+            bag.put(5);
+            bag.put(7);
+            console.log(bag.sum() + " " + bag.count());
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("14 2\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void GenericClass_ExplicitAccessors_Work(ExecutionMode mode)
+    {
+        var source = """
+            class Temp<T> {
+                private _v: number = 0;
+                get value(): number {
+                    return this._v;
+                }
+                set value(n: number) {
+                    this._v = n;
+                }
+                bump(): number {
+                    this.value = this.value + 5;
+                    return this.value;
+                }
+            }
+            const t = new Temp<boolean>();
+            t.value = 10;
+            console.log(t.bump());
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("15\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void GenericClass_AsyncMethodTouchingFields_Works(ExecutionMode mode)
+    {
+        var source = """
+            class Repo<T> {
+                private items: T[] = [];
+                add(item: T): void {
+                    this.items.push(item);
+                }
+                async fetchAll(): Promise<number> {
+                    await Promise.resolve();
+                    return this.items.length;
+                }
+            }
+            async function main(): Promise<void> {
+                const r = new Repo<number>();
+                r.add(1);
+                r.add(2);
+                console.log(await r.fetchAll());
+            }
+            main();
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("2\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void GenericClass_GeneratorMethodTouchingFields_Works(ExecutionMode mode)
+    {
+        var source = """
+            class Seq<T> {
+                private items: T[] = [];
+                add(item: T): void {
+                    this.items.push(item);
+                }
+                *iterate(): Generator<T> {
+                    for (const x of this.items) {
+                        yield x;
+                    }
+                }
+            }
+            const s = new Seq<string>();
+            s.add("a");
+            s.add("b");
+            let out = "";
+            for (const v of s.iterate()) {
+                out += v;
+            }
+            console.log(out);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("ab\n", output);
+    }
+
     #endregion
 
     #region Generic Interfaces


### PR DESCRIPTION
Fixes #178

## Root cause (refined from the issue)

The issue pointed at the property accessors referencing the backing `FieldBuilder` directly. Empirically, raw FieldDef self-tokens are legal — the emitted `.ctor` already used them and JIT'd fine. The fatal tokens were in **method bodies**: direct member dispatch emitted `castclass Stack` + `callvirt Stack::get_Items()` against the **open generic TypeDef**, which the CLR refuses to resolve at JIT time (ECMA-335 II.9.4 requires the instantiated form). That is what produced `TypeLoadException: Could not load type 'Stack'` when the first field-touching method was JIT'd.

The bug was also broader than the trigger matrix suggested:

- a generic class with **no fields** crashed if one method called another (`this.tag()`)
- `super.count()` into a generic base failed with `InvalidOperationException: ... not fully instantiated` (raw MethodDef token via `call`)
- inherited members of a generic base accessed from a non-generic subclass hit the same class of failure

## Fix

- **`EmitterTypeHelpers`**: new `SelfFieldReference`/`SelfMethodReference` plus `TryResolveInstanceDispatch`/`TryResolveSuperCall` resolvers that produce instantiated tokens — `Stack<!T>` for self-dispatch inside the class''s own bodies, closed base instantiations (e.g. `Base<float64>`) for inherited/super members — and report when no token is expressible in the current emission context.
- **`CompilationContext.EmittingTypeBuilder`**: set only when emitting directly into a class''s own methods/ctors/accessors. Distinguishes those bodies from async/generator state machines and arrow display classes (where `CurrentClassBuilder` still points at the class but `!T` is not in scope). Where the instantiated form isn''t expressible, generic dispatch falls back to the runtime `GetProperty`/`InvokeMethodValue` path, which handles generic instances correctly.
- **Patched dispatch sites**: `ILEmitter` getter/setter/method dispatch, `ExpressionEmitterBase.TryEmitDirectMethodCall` (used by state-machine emitters), both `TryEmitSuperMethodCall` implementations, and the `$IHasFields.GetProperty` getter dispatch.
- **`EmitSetPropertyBody` now dispatches to explicit accessor setters**, mirroring `GetProperty`''s getter dispatch. Previously dynamic writes landed in `_fields` while reads invoked the accessor, silently desynchronizing values — and dynamic dispatch is the main path for generic class instances.

## Verification

- Issue''s full trigger matrix (`T[]`, `T | undefined`, plain `string` fields; no-field; exact-`T`), method-to-method calls, async + generator methods touching fields, non-generic subclass of generic base with `super`, explicit accessors, arrows capturing `this` — all pass compiled and match interpreter output.
- 7 new regression tests in `GenericsTests` (run in both interpreter and compiled modes).
- Full suite: 10,478 passed; the 2 `Pack_WithoutPackageJson` failures reproduce identically on clean `origin/main` (environment-related, pre-existing).
- Generic **class expressions** remain broken, but in the type checker and identically in both modes — a separate pre-existing gap, out of scope here.