### PR TITLE
fix: ArraySetLength coercion order + stack guard in compiled invocation helpers (#180)

### DIFF
--- a/Compilation/RuntimeEmitter.Objects.Descriptors.cs
+++ b/Compilation/RuntimeEmitter.Objects.Descriptors.cs
@@ -133,13 +133,22 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Call, runtime.ToJsString);
         il.Emit(OpCodes.Stloc, propNameLocal);
 
-        // ECMA-262 10.4.2.4 ArraySetLength: validate that ToUint32(newLen) ===
-        // ToNumber(newLen) — i.e. an integer in [0, 2^32). Without this,
-        // \`Object.defineProperty([], 'length', {value: -1})\` silently stores
-        // -1 in the underlying dict instead of throwing RangeError.
+        // ECMA-262 10.4.2.4 ArraySetLength steps 3-4: newLen =
+        // ToUint32(Desc.[[Value]]), numberLen = ToNumber(Desc.[[Value]]) —
+        // exactly two coercions, in that order (test262 define-own-prop-
+        // length-coercion-order.js counts the valueOf calls). If
+        // SameValueZero(newLen, numberLen) is false → RangeError, which
+        // rejects NaN, ±Infinity, negatives, non-integers, and >= 2^32.
+        // The coerced newLen then REPLACES the descriptor's value (stashed
+        // into the synth dict after the overlay pass below) so the raw
+        // object never reaches the PDS — re-coercing a stored object value
+        // on a later redefine is what produced the unbounded
+        // ObjectDefineProperty ⇄ ToNumber recursion of issue #180.
         // Only fires for List<object> receivers (compiled-mode arrays) with
         // propName == "length" and a value-typed descriptor.
         var skipArrayLenCheck = il.DefineLabel();
+        var lenWasCoercedLocal = il.DeclareLocal(_types.Boolean);
+        var coercedLenLocal = il.DeclareLocal(_types.Object);
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Isinst, _types.ListOfObject);
         il.Emit(OpCodes.Brfalse, skipArrayLenCheck);
@@ -157,30 +166,61 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloca, lenValLocal);
         il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.DictionaryStringObject, "TryGetValue", _types.String, _types.Object.MakeByRefType()));
         il.Emit(OpCodes.Brfalse, skipArrayLenCheck);
-        // Coerce value via ToNumber — captures NaN, Infinity, non-numeric.
+        // First coercion (ToUint32's inner ToNumber) — valueOf call #1.
         var lenNumLocal = il.DeclareLocal(_types.Double);
+        var newLenLocal = il.DeclareLocal(_types.Double);
+        var numberLenLocal = il.DeclareLocal(_types.Double);
         il.Emit(OpCodes.Ldloc, lenValLocal);
         il.Emit(OpCodes.Call, runtime.ToNumber);
         il.Emit(OpCodes.Stloc, lenNumLocal);
-        // RangeError if NaN, Infinity, negative, non-integer, or >= 2^32.
+        // newLen = ToUint32(lenNum): NaN/±Inf → 0; else truncate, fmod 2^32,
+        // normalize into [0, 2^32).
+        var uintZeroLabel = il.DefineLabel();
+        var uintDoneLabel = il.DefineLabel();
         il.Emit(OpCodes.Ldloc, lenNumLocal);
         il.Emit(OpCodes.Call, _types.GetMethod(_types.Double, "IsNaN", _types.Double));
-        var rangeErrLabel = il.DefineLabel();
-        il.Emit(OpCodes.Brtrue, rangeErrLabel);
+        il.Emit(OpCodes.Brtrue, uintZeroLabel);
         il.Emit(OpCodes.Ldloc, lenNumLocal);
         il.Emit(OpCodes.Call, _types.GetMethod(_types.Double, "IsInfinity", _types.Double));
-        il.Emit(OpCodes.Brtrue, rangeErrLabel);
+        il.Emit(OpCodes.Brtrue, uintZeroLabel);
         il.Emit(OpCodes.Ldloc, lenNumLocal);
-        il.Emit(OpCodes.Ldc_R8, 0.0);
-        il.Emit(OpCodes.Blt, rangeErrLabel);
-        il.Emit(OpCodes.Ldloc, lenNumLocal);
+        il.Emit(OpCodes.Call, _types.GetMethod(_types.Math, "Truncate", _types.Double));
         il.Emit(OpCodes.Ldc_R8, 4294967296.0);
-        il.Emit(OpCodes.Bge, rangeErrLabel);
-        // Non-integer: floor(x) != x.
-        il.Emit(OpCodes.Ldloc, lenNumLocal);
-        il.Emit(OpCodes.Call, _types.GetMethod(_types.Math, "Floor", _types.Double));
-        il.Emit(OpCodes.Ldloc, lenNumLocal);
+        il.Emit(OpCodes.Rem);
+        il.Emit(OpCodes.Stloc, newLenLocal);
+        il.Emit(OpCodes.Ldloc, newLenLocal);
+        il.Emit(OpCodes.Ldc_R8, 0.0);
+        il.Emit(OpCodes.Bge, uintDoneLabel);
+        il.Emit(OpCodes.Ldloc, newLenLocal);
+        il.Emit(OpCodes.Ldc_R8, 4294967296.0);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Stloc, newLenLocal);
+        il.Emit(OpCodes.Br, uintDoneLabel);
+        il.MarkLabel(uintZeroLabel);
+        il.Emit(OpCodes.Ldc_R8, 0.0);
+        il.Emit(OpCodes.Stloc, newLenLocal);
+        il.MarkLabel(uintDoneLabel);
+        // Normalize -0 → +0 (x + 0.0 is identity for everything else).
+        il.Emit(OpCodes.Ldloc, newLenLocal);
+        il.Emit(OpCodes.Ldc_R8, 0.0);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Stloc, newLenLocal);
+        // Second coercion — valueOf call #2.
+        il.Emit(OpCodes.Ldloc, lenValLocal);
+        il.Emit(OpCodes.Call, runtime.ToNumber);
+        il.Emit(OpCodes.Stloc, numberLenLocal);
+        // SameValueZero(newLen, numberLen) — Bne_Un branches on unordered,
+        // so a NaN numberLen lands at rangeErr; ±0 compare equal.
+        var rangeErrLabel = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, newLenLocal);
+        il.Emit(OpCodes.Ldloc, numberLenLocal);
         il.Emit(OpCodes.Bne_Un, rangeErrLabel);
+        // Stash box(newLen) for the synth-dict override below.
+        il.Emit(OpCodes.Ldloc, newLenLocal);
+        il.Emit(OpCodes.Box, _types.Double);
+        il.Emit(OpCodes.Stloc, coercedLenLocal);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Stloc, lenWasCoercedLocal);
         il.Emit(OpCodes.Br, skipArrayLenCheck);
         il.MarkLabel(rangeErrLabel);
         il.Emit(OpCodes.Ldstr, "Invalid array length");
@@ -362,6 +402,20 @@ public partial class RuntimeEmitter
         EmitOverlay("configurable");
 
         il.MarkLabel(skipOverlayLabel);
+
+        // ECMA-262 10.4.2.4 ArraySetLength step 5: newLenDesc.[[Value]] =
+        // newLen. When the array-length coercion above ran, override the
+        // synth dict's "value" with the coerced uint32 so the descriptor
+        // (and the PDS entry it becomes) holds a plain number — never the
+        // raw object whose valueOf re-fires on later redefines (issue #180).
+        var skipLenValueOverride = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, lenWasCoercedLocal);
+        il.Emit(OpCodes.Brfalse, skipLenValueOverride);
+        il.Emit(OpCodes.Ldloc, synthDictLocal);
+        il.Emit(OpCodes.Ldstr, "value");
+        il.Emit(OpCodes.Ldloc, coercedLenLocal);
+        il.Emit(OpCodes.Callvirt, synthDictSetItem);
+        il.MarkLabel(skipLenValueOverride);
 
         il.Emit(OpCodes.Ldloc, synthDictLocal);
         il.Emit(OpCodes.Stloc, dictLocal);
@@ -995,6 +1049,17 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloc, propNameLocal);
         il.Emit(OpCodes.Ldstr, "length");
         il.Emit(OpCodes.Call, _types.GetMethod(_types.String, "op_Equality", _types.String, _types.String));
+        il.Emit(OpCodes.Brfalse, notListForLengthLabel);
+        // Gate on the INPUT descriptor having an own "value" — not on the
+        // post-merge descriptor slot. ECMA-262 §10.4.2.4 step 2: a define
+        // with no [[Value]] (e.g. {writable:false}) is OrdinaryDefineOwnProperty
+        // only and must never re-coerce or re-apply a previously stored
+        // length value (issue #180 recursion; stale-length truncation).
+        var lenApplyValLocal = il.DeclareLocal(_types.Object);
+        il.Emit(OpCodes.Ldloc, dictLocal);
+        il.Emit(OpCodes.Ldstr, "value");
+        il.Emit(OpCodes.Ldloca, lenApplyValLocal);
+        il.Emit(OpCodes.Callvirt, dictTryGetValue);
         il.Emit(OpCodes.Brfalse, notListForLengthLabel);
         il.Emit(OpCodes.Ldloc, wasGenericLocal);
         il.Emit(OpCodes.Brtrue, notListForLengthLabel);

--- a/Compilation/RuntimeEmitter.Objects.Invocation.cs
+++ b/Compilation/RuntimeEmitter.Objects.Invocation.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Reflection;
 using System.Reflection.Emit;
 
@@ -5,6 +6,29 @@ namespace SharpTS.Compilation;
 
 public partial class RuntimeEmitter
 {
+    /// <summary>
+    /// Emits a guest-recursion guard at the top of a dynamic-invocation
+    /// helper: (1) CheckCancellation, so deep non-loop recursion — which
+    /// never crosses a loop backedge — remains cooperatively cancellable;
+    /// (2) RuntimeHelpers.TryEnsureSufficientExecutionStack, converting an
+    /// imminent (uncatchable, process-killing) CLR StackOverflowException
+    /// into a catchable guest RangeError. Issue #180.
+    /// </summary>
+    private void EmitStackGuard(ILGenerator il, EmittedRuntime runtime)
+    {
+        if (runtime.CheckCancellationMethod != null)
+            il.Emit(OpCodes.Call, runtime.CheckCancellationMethod);
+        var stackOkLabel = il.DefineLabel();
+        il.Emit(OpCodes.Call, typeof(System.Runtime.CompilerServices.RuntimeHelpers)
+            .GetMethod("TryEnsureSufficientExecutionStack", Type.EmptyTypes)!);
+        il.Emit(OpCodes.Brtrue, stackOkLabel);
+        il.Emit(OpCodes.Ldstr, "Maximum call stack size exceeded");
+        il.Emit(OpCodes.Newobj, runtime.TSRangeErrorCtor);
+        il.Emit(OpCodes.Call, runtime.CreateException);
+        il.Emit(OpCodes.Throw);
+        il.MarkLabel(stackOkLabel);
+    }
+
     private void EmitGetArrayMethod(TypeBuilder typeBuilder, EmittedRuntime runtime)
     {
         // GetArrayMethod(object arr, string methodName) -> TSFunction or null
@@ -82,6 +106,7 @@ public partial class RuntimeEmitter
         runtime.InvokeValue = method;
 
         var il = method.GetILGenerator();
+        EmitStackGuard(il, runtime);
         var nullLabel = il.DefineLabel();
         var tsFunctionLabel = il.DefineLabel();
         var boundTsFunctionLabel = il.DefineLabel();
@@ -452,6 +477,7 @@ public partial class RuntimeEmitter
         runtime.InvokeMethodValue = method;
 
         var il = method.GetILGenerator();
+        EmitStackGuard(il, runtime);
         // Check if value is $TSFunction and call InvokeWithThis
         // arg0 = receiver, arg1 = function, arg2 = args
         var notTSFunctionLabel = il.DefineLabel();

--- a/SharpTS.Test262/baselines/compiled.txt
+++ b/SharpTS.Test262/baselines/compiled.txt
@@ -240,7 +240,7 @@ test/built-ins/Array/length/S15.4.5.1_A1.3_T1.js Pass
 test/built-ins/Array/length/S15.4.5.1_A1.3_T2.js Pass
 test/built-ins/Array/length/S15.4.5.2_A3_T4.js Pass
 test/built-ins/Array/length/define-own-prop-length-coercion-order-set.js Fail
-test/built-ins/Array/length/define-own-prop-length-coercion-order.js Timeout
+test/built-ins/Array/length/define-own-prop-length-coercion-order.js Pass
 test/built-ins/Array/length/define-own-prop-length-error.js Pass
 test/built-ins/Array/length/define-own-prop-length-no-value-order.js Fail
 test/built-ins/Array/length/define-own-prop-length-overflow-order.js Pass
@@ -4760,7 +4760,7 @@ test/built-ins/Object/defineProperties/15.2.3.7-6-a-119.js Pass
 test/built-ins/Object/defineProperties/15.2.3.7-6-a-12.js Fail
 test/built-ins/Object/defineProperties/15.2.3.7-6-a-120.js Fail
 test/built-ins/Object/defineProperties/15.2.3.7-6-a-121.js Pass
-test/built-ins/Object/defineProperties/15.2.3.7-6-a-122.js Fail
+test/built-ins/Object/defineProperties/15.2.3.7-6-a-122.js Pass
 test/built-ins/Object/defineProperties/15.2.3.7-6-a-123.js Pass
 test/built-ins/Object/defineProperties/15.2.3.7-6-a-124.js Pass
 test/built-ins/Object/defineProperties/15.2.3.7-6-a-125.js Pass
@@ -5468,7 +5468,7 @@ test/built-ins/Object/defineProperty/15.2.3.6-4-122.js Fail
 test/built-ins/Object/defineProperty/15.2.3.6-4-123.js Pass
 test/built-ins/Object/defineProperty/15.2.3.6-4-124.js Fail
 test/built-ins/Object/defineProperty/15.2.3.6-4-125.js Pass
-test/built-ins/Object/defineProperty/15.2.3.6-4-126.js Fail
+test/built-ins/Object/defineProperty/15.2.3.6-4-126.js Pass
 test/built-ins/Object/defineProperty/15.2.3.6-4-127.js Pass
 test/built-ins/Object/defineProperty/15.2.3.6-4-128.js Pass
 test/built-ins/Object/defineProperty/15.2.3.6-4-129.js Pass


### PR DESCRIPTION
Fixes #180.

## Problem

In compiled mode, `Object.defineProperty(array, "length", {value: obj})` stored the **raw object** as the PDS descriptor value. `ToNumber` then re-coerced it at the apply step, and every nested redefine re-coerced it again because the merge step copied the raw object back into each new descriptor. An object whose `valueOf` re-entered `defineProperty` produced unbounded `ObjectDefineProperty` ⇄ `ToNumber` mutual recursion, ending in an uncatchable `StackOverflowException` (exit `0xC00000FD`) that killed the whole process — and wedged a Test262 worker for ~5 minutes on every compiled regen, because the recursion never crossed a loop backedge where the cooperative-cancellation check lives.

## Fix

**Correctness — ECMA-262 §10.4.2.4 ArraySetLength steps 3–5** (`RuntimeEmitter.Objects.Descriptors.cs`):
- Coerce `Desc.[[Value]]` exactly twice up front — `newLen = ToUint32(v)`, `numberLen = ToNumber(v)` — and throw `RangeError` unless `SameValueZero(newLen, numberLen)`. This subsumes the old single-`ToNumber` NaN/Infinity/negative/non-integer checks and gives the spec-mandated **two** `valueOf` calls.
- Replace the descriptor''s value with the coerced `newLen` before it is parsed/stored, so a raw object never reaches the PDS.
- Gate the `TSArraySetLength` apply step on the *input* descriptor having an own `"value"` (not the post-merge slot), so `{writable: false}`-style redefines never re-coerce or re-apply a previously stored length.

**Robustness** (`RuntimeEmitter.Objects.Invocation.cs`):
- `EmitStackGuard` at the top of `$Runtime.InvokeValue` / `InvokeMethodValue`: `CheckCancellation` (so deep non-loop recursion remains cooperatively cancellable) + `RuntimeHelpers.TryEnsureSufficientExecutionStack`, converting imminent stack exhaustion into a catchable guest `RangeError: Maximum call stack size exceeded` for any future guest-level infinite recursion. BCL-only — no SharpTS.dll dependency in emitted output.

## Verification

- The repro from the issue now prints `valueOfCalls: 2`, throws `TypeError`, no stack overflow.
- A genuinely-infinite `valueOf` → `defineProperty` recursion now throws a catchable `RangeError`; process survives.
- `define-own-prop-length-coercion-order.js` via the Test262 worker: **Timeout → Pass** (compiled). Interpreted unchanged (Fail).
- Sweeps vs committed baseline, all in compiled mode: `Array/length` (30), `Object/defineProperty` (1131), `Object/defineProperties` + `Function` + `language/expressions/call` + `Array/prototype/sort` (1287) — **zero regressions**, three new passes (baselined): the coercion-order test plus `15.2.3.6-4-126.js` / `15.2.3.7-6-a-122.js` (`{value: null}` now correctly coerces length to 0).
- Full xUnit suite: 10478/10480 — the 2 failures are pre-existing packaging-env tests that fail identically on clean main.

Once merged, compiled-mode Test262 regens should drop by ~5 minutes (no more wedged worker waiting on the 5-min idle watchdog).