### PR TITLE
fix: true fix for #185 — defer open alias instantiation + canonical TS2589 depth guard

### DIFF
--- a/SharpTS.Tests/TypeCheckerTests/RecursiveAliasInstantiationTests.cs
+++ b/SharpTS.Tests/TypeCheckerTests/RecursiveAliasInstantiationTests.cs
@@ -1,0 +1,80 @@
+using SharpTS.Tests.Infrastructure;
+using SharpTS.TypeSystem.Exceptions;
+using Xunit;
+
+namespace SharpTS.Tests.TypeCheckerTests;
+
+/// <summary>
+/// Regression tests for #185: DeepReadonly-style aliases (a generic alias referenced from a
+/// mapped type's value with the mapped parameter in its arguments, e.g.
+/// <c>{ [P in Keys&lt;T&gt;]: DeepReadonly&lt;T[P]&gt; }</c>) used to expand eagerly with the unbound
+/// parameter baked into the instantiation key — Part[P], Part[P][P], … — recursing until the
+/// process died with a stack overflow. Such references now defer until the key is substituted,
+/// and genuinely divergent instantiations are bounded by the TS2589 depth guard.
+/// </summary>
+public class RecursiveAliasInstantiationTests
+{
+    private const string DeepReadonlyPrelude = """
+        type NonFunctionPropertyNames<T> = { [K in keyof T]: T[K] extends Function ? never : K }[keyof T];
+        type DeepReadonlyObject<T> = { readonly [P in NonFunctionPropertyNames<T>]: DeepReadonly<T[P]> };
+        type DeepReadonly<T> = T extends any[] ? T : T extends object ? DeepReadonlyObject<T> : T;
+        """;
+
+    [Fact]
+    public void DeepReadonlyStyleAlias_OverFlatInterface_Converges()
+    {
+        var source = DeepReadonlyPrelude + """
+
+            interface Flat { id: number; name: string; }
+            function f(part: DeepReadonly<Flat>) {
+                let name: string = part.name;
+                let id: number = part.id;
+            }
+            """;
+        TestHarness.RunInterpreted(source);
+    }
+
+    [Fact]
+    public void DeepReadonlyStyleAlias_OverSelfRecursiveInterface_Converges()
+    {
+        // Part references itself (subparts: Part[]) — the instantiation cycle must hit the
+        // in-flight same-key guard and terminate instead of growing a fresh key each round.
+        var source = DeepReadonlyPrelude + """
+
+            interface Part { id: number; name: string; subparts: Part[]; }
+            function f(part: DeepReadonly<Part>) {
+                let name: string = part.name;
+            }
+            """;
+        TestHarness.RunInterpreted(source);
+    }
+
+    [Fact]
+    public void MappedValueWithWrongPropertyType_StillChecks()
+    {
+        // The deferred alias must still resolve to the real property type per key — assigning
+        // the (readonly-mapped) string property to a number must fail.
+        var source = DeepReadonlyPrelude + """
+
+            interface Flat { id: number; name: string; }
+            function f(part: DeepReadonly<Flat>) {
+                let bad: number = part.name;
+            }
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void GrowingAliasInstantiation_ReportsTs2589_InsteadOfOverflowing()
+    {
+        // Each round derives a fresh instantiation key (Grow<number>, Grow<number[]>, …), so
+        // the same-key cycle guard can never fire; the depth guard must stop it with the
+        // canonical TS2589 instead of a process-killing stack overflow.
+        var source = """
+            type Grow<T> = { v: Grow<T[]> };
+            let x: Grow<number> = null as any;
+            """;
+        var ex = Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+        Assert.Contains("excessively deep", ex.Message);
+    }
+}

--- a/TypeSystem/TypeChecker.Generics.MappedTypes.cs
+++ b/TypeSystem/TypeChecker.Generics.MappedTypes.cs
@@ -220,6 +220,13 @@ public partial class TypeChecker
             constraint = EvaluateKeyOf(sourceType);
         }
 
+        // Key-filtering aliases (NonFunctionPropertyNames<T> = { ... }[keyof T]) leave an
+        // indexed access as the constraint — resolve it to its union of keys (#185).
+        if (constraint is TypeInfo.IndexedAccess constraintIa)
+        {
+            constraint = ResolveIndexedAccess(constraintIa, outerSubstitutions);
+        }
+
         // Extract individual keys
         List<TypeInfo> keys = constraint switch
         {
@@ -341,6 +348,10 @@ public partial class TypeChecker
             TypeInfo.IndexedAccess ia => ResolveIndexedAccess(ia, subs),
             TypeInfo.Array arr => new TypeInfo.Array(ResolveIndexedAccessTypes(arr.ElementType, subs)),
             TypeInfo.Union union => new TypeInfo.Union(union.Types.Select(t => ResolveIndexedAccessTypes(t, subs)).ToList()),
+            // A deferred generic alias reference (#185) carries its arguments unresolved —
+            // resolve T[K] inside them so the eventual expansion sees concrete arguments.
+            TypeInfo.RecursiveTypeAlias rta when rta.TypeArguments is { Count: > 0 } =>
+                new TypeInfo.RecursiveTypeAlias(rta.AliasName, rta.TypeArguments.Select(t => ResolveIndexedAccessTypes(t, subs)).ToList()),
             TypeInfo.Function func => new TypeInfo.Function(
                 func.ParamTypes.Select(p => ResolveIndexedAccessTypes(p, subs)).ToList(),
                 ResolveIndexedAccessTypes(func.ReturnType, subs),
@@ -362,6 +373,17 @@ public partial class TypeChecker
         if (objectType is TypeInfo.TypeParameter tp && subs.TryGetValue(tp.Name, out var subObj))
         {
             objectType = subObj;
+        }
+
+        // keyof in index position resolves to the union of keys, and a concrete mapped
+        // object expands so per-key property lookup sees real fields (#185).
+        if (indexType is TypeInfo.KeyOf kof)
+        {
+            indexType = EvaluateKeyOf(Substitute(kof.SourceType, subs));
+        }
+        if (objectType is TypeInfo.MappedType objMapped && !ContainsOpenTypeVariable(objMapped))
+        {
+            objectType = ExpandMappedType(objMapped, subs);
         }
 
         // Get the property type for the given key

--- a/TypeSystem/TypeChecker.Generics.cs
+++ b/TypeSystem/TypeChecker.Generics.cs
@@ -243,6 +243,18 @@ public partial class TypeChecker
                 string aliasKey = $"{baseName}<{string.Join(",", typeArgStrings)}>";
                 _typeAliasExpansionStack ??= new HashSet<string>(StringComparer.Ordinal);
 
+                // tsc bounds instantiation with a hard depth limit (checker.ts instantiationDepth →
+                // TS2589). Without one, alias expansions whose instantiation key never repeats —
+                // e.g. DeepReadonly<T> over a self-referential interface, where the still-unbound
+                // mapped param accumulates: Part[P], Part[P][P], … — recurse until stack overflow
+                // instead of hitting the same-key guard below. See #185.
+                if (_typeAliasExpansionStack.Count >= MaxTypeAliasExpansionDepth)
+                {
+                    throw new TypeCheckException(
+                        " Type instantiation is excessively deep and possibly infinite.",
+                        tsCode: "TS2589");
+                }
+
                 // Recursive reference detected - return deferred placeholder
                 if (_typeAliasExpansionStack.Contains(aliasKey))
                 {

--- a/TypeSystem/TypeChecker.Generics.cs
+++ b/TypeSystem/TypeChecker.Generics.cs
@@ -236,6 +236,23 @@ public partial class TypeChecker
                     throw new TypeCheckException($" Type alias '{baseName}' requires {typeParamNames.Count} type argument(s), got {typeArgs.Count}.", tsCode: "TS2314");
                 }
 
+                // A type argument that mentions a still-open type variable (a mapped-type
+                // parameter mid-parse) cannot be instantiated yet — eager expansion would
+                // substitute an open term and derive a fresh instantiation key every round
+                // (Part[P], Part[P][P], … — the #185 regress), never converging. Defer:
+                // ExpandMappedType substitutes the concrete key into the arguments and
+                // ExpandRecursiveTypeAlias finishes the instantiation on demand.
+                if (typeArgs.Any(ContainsOpenTypeVariable))
+                {
+                    TypeInfo deferredAlias = new TypeInfo.RecursiveTypeAlias(baseName, typeArgs);
+                    while (suffix.StartsWith("[]"))
+                    {
+                        deferredAlias = new TypeInfo.Array(deferredAlias);
+                        suffix = suffix[2..];
+                    }
+                    return deferredAlias;
+                }
+
                 // Lazily compute string representations for type alias expansion
                 typeArgStrings ??= typeArgs.Select(TypeInfoToString).ToList();
 
@@ -282,6 +299,20 @@ public partial class TypeChecker
                     // Parse the expanded definition
                     result = ToTypeInfo(expanded);
 
+                    // An instantiation whose arguments are fully concrete can apply its result
+                    // now — downstream consumers (property access in particular) operate on
+                    // the resolved type, not on a raw ConditionalType/MappedType node (#185).
+                    // EvaluateConditionalType itself defers when the check type is still a
+                    // naked type parameter, so generic-context instantiations stay deferred.
+                    if (result is TypeInfo.ConditionalType condResult && !ContainsOpenTypeVariable(condResult))
+                    {
+                        result = EvaluateConditionalType(condResult);
+                    }
+                    if (result is TypeInfo.MappedType mappedResult && !ContainsOpenTypeVariable(mappedResult))
+                    {
+                        result = ExpandMappedType(mappedResult);
+                    }
+
                     // Flatten any spread elements that contain concrete tuples
                     result = FlattenTupleSpreads(result);
 
@@ -316,6 +347,40 @@ public partial class TypeChecker
         }
 
         return result;
+    }
+
+    /// <summary>
+    /// True when the type mentions a type variable that is currently open — a mapped-type
+    /// parameter whose owning body is mid-parse (see <c>_openTypeVariablesInScope</c>).
+    /// Such a type is not yet instantiable; generic alias references over it are deferred (#185).
+    /// </summary>
+    private static bool ContainsOpenTypeVariable(TypeInfo type)
+    {
+        if (_openTypeVariablesInScope is not { Count: > 0 }) return false;
+        return Walk(type);
+
+        static bool Walk(TypeInfo t) => t switch
+        {
+            TypeInfo.TypeParameter tp => _openTypeVariablesInScope!.Contains(tp.Name),
+            TypeInfo.Array a => Walk(a.ElementType),
+            TypeInfo.Union u => u.Types.Any(Walk),
+            TypeInfo.Intersection i => i.Types.Any(Walk),
+            TypeInfo.IndexedAccess ia => Walk(ia.ObjectType) || Walk(ia.IndexType),
+            TypeInfo.KeyOf k => Walk(k.SourceType),
+            TypeInfo.RecursiveTypeAlias rta => rta.TypeArguments?.Any(Walk) ?? false,
+            TypeInfo.ConditionalType c => Walk(c.CheckType) || Walk(c.ExtendsType) || Walk(c.TrueType) || Walk(c.FalseType),
+            TypeInfo.Promise p => Walk(p.ValueType),
+            TypeInfo.Tuple tup => tup.Elements.Any(e => Walk(e.Type)) || (tup.RestElementType is { } rest && Walk(rest)),
+            TypeInfo.Record r => r.Fields.Values.Any(Walk)
+                || (r.StringIndexType is { } sit && Walk(sit))
+                || (r.NumberIndexType is { } nit && Walk(nit))
+                || (r.SymbolIndexType is { } yit && Walk(yit)),
+            TypeInfo.Function f => f.ParamTypes.Any(Walk) || Walk(f.ReturnType),
+            TypeInfo.MappedType m => Walk(m.Constraint) || Walk(m.ValueType) || (m.AsClause is { } asc && Walk(asc)),
+            TypeInfo.IntrinsicStringType ist => Walk(ist.Inner),
+            TypeInfo.TemplateLiteralType tlt => tlt.InterpolatedTypes.Any(Walk),
+            _ => false
+        };
     }
 
     /// <summary>

--- a/TypeSystem/TypeChecker.TypeParsing.cs
+++ b/TypeSystem/TypeChecker.TypeParsing.cs
@@ -294,6 +294,11 @@ public partial class TypeChecker
                 "'unique symbol' type is only valid on const declarations initialized with Symbol().", tsCode: "TS1331");
         }
         if (typeName == "bigint") return new TypeInfo.BigInt();
+        // The global Function type: any callable, i.e. (...args: any[]) => any. Parsing it to
+        // Any made `T[K] extends Function` filters (FunctionPropertyNames et al.) match every
+        // property — `X extends any` is always true — emptying the mapped result (#185).
+        if (typeName == "Function") return new TypeInfo.Function(
+            [new TypeInfo.Array(new TypeInfo.Any())], new TypeInfo.Any(), RequiredParams: 0, HasRestParam: true);
         if (typeName == "void") return new TypeInfo.Void();
         if (typeName == "null") return new TypeInfo.Null();
         if (typeName == "undefined") return new TypeInfo.Undefined();
@@ -301,6 +306,15 @@ public partial class TypeChecker
         if (typeName == "never") return new TypeInfo.Never();
         if (typeName == "object") return new TypeInfo.Object();
         if (typeName == "Buffer") return new TypeInfo.Buffer();
+
+        // A mapped-type parameter in scope (e.g. P in `{ [P in K]: DeepReadonly<T[P]> }`)
+        // parses to a TypeParameter so the body builds deferred forms (IndexedAccess,
+        // deferred alias references) that ExpandMappedType substitutes per key — instead
+        // of dissolving to Any or eagerly instantiating with an open argument (#185).
+        if (_openTypeVariablesInScope is { Count: > 0 } && _openTypeVariablesInScope.Contains(typeName))
+        {
+            return new TypeInfo.TypeParameter(typeName);
+        }
 
         TypeInfo? type = _environment.Get(typeName);
         if (type is TypeInfo.MutableClass mutableClass)
@@ -1217,15 +1231,14 @@ public partial class TypeChecker
         string paramName = bracketContent[..inIndex].Trim();
         string afterIn = bracketContent[(inIndex + 4)..].Trim();
 
-        // Check for 'as' clause
-        TypeInfo? asClause = null;
+        // Check for 'as' clause (parsed later, with the mapped parameter in scope)
         string constraintStr;
+        string? asTypeStr = null;
         int asIndex = FindTopLevelAs(afterIn);
         if (asIndex >= 0)
         {
             constraintStr = afterIn[..asIndex].Trim();
-            string asTypeStr = afterIn[(asIndex + 3)..].Trim();
-            asClause = ToTypeInfo(asTypeStr);
+            asTypeStr = afterIn[(asIndex + 3)..].Trim();
         }
         else
         {
@@ -1256,7 +1269,23 @@ public partial class TypeChecker
             throw new TypeCheckException("Expected ':' after mapped type parameter.");
 
         string valueTypeStr = afterBracket[1..].Trim();
-        TypeInfo valueType = ToTypeInfo(valueTypeStr);
+
+        // The mapped parameter is a bound type variable inside the as-clause and the value
+        // type (`[P in K as Uppercase<P>]: DeepReadonly<T[P]>`). Register it so those bodies
+        // parse to deferred forms that ExpandMappedType substitutes per key (#185).
+        TypeInfo? asClause = null;
+        TypeInfo valueType;
+        _openTypeVariablesInScope ??= new HashSet<string>(StringComparer.Ordinal);
+        bool openVarAdded = _openTypeVariablesInScope.Add(paramName);
+        try
+        {
+            if (asTypeStr is not null) asClause = ToTypeInfo(asTypeStr);
+            valueType = ToTypeInfo(valueTypeStr);
+        }
+        finally
+        {
+            if (openVarAdded) _openTypeVariablesInScope.Remove(paramName);
+        }
 
         return new TypeInfo.MappedType(paramName, constraint, valueType, modifiers, asClause);
     }

--- a/TypeSystem/TypeChecker.cs
+++ b/TypeSystem/TypeChecker.cs
@@ -484,6 +484,16 @@ public partial class TypeChecker
     private static int _typeAliasExpansionDepth;
 
     /// <summary>
+    /// Names of type variables that are bound but not yet substitutable — mapped-type
+    /// parameters whose owning body is currently being parsed (e.g. P while parsing the
+    /// value type of <c>{ [P in K]: DeepReadonly&lt;T[P]&gt; }</c>). Identifiers matching these
+    /// parse to <see cref="TypeInfo.TypeParameter"/>, and generic alias references whose
+    /// arguments mention them are deferred instead of instantiated (#185).
+    /// </summary>
+    [ThreadStatic]
+    private static HashSet<string>? _openTypeVariablesInScope;
+
+    /// <summary>
     /// Maximum recursion depth for string-based type resolution (ToTypeInfo and the
     /// generic/mapped/indexed-access helpers that funnel back through it). A backstop
     /// against pathological self-referential type strings: it converts what would be an


### PR DESCRIPTION
Closes #185. No harness, test, or baseline modifications — checker-side only, per the canon-tests-stay-canon constraint.

## Root cause
The crash was not legitimate deep recursion. A generic alias referenced from a mapped type's value with the mapped parameter in its arguments — the `DeepReadonly` pattern, `{ [P in Keys<T>]: DeepReadonly<T[P]> }` — was instantiated **eagerly while `P` was still unbound**. Each round baked the open parameter into a fresh instantiation key (`Part[P]`, `Part[P][P]`, …), so the existing same-key cycle guard could never fire and expansion recursed until the process died. tsc never instantiates these until the parameter is substituted (lazy instantiation + identity-cached types), and additionally bounds runaway instantiation with TS2589.

This PR mirrors both behaviors:

## Commit 1 — canonical TS2589 depth bound
`ResolveGenericType`'s alias branch (the one unguarded instantiation path; the non-generic path already had TS2456 and `ExpandRecursiveTypeAlias` a counter) now reports **TS2589 "Type instantiation is excessively deep and possibly infinite"** — tsc's own guard (checker.ts `instantiationDepth`) — instead of dying. This is canon behavior, not an evasion.

## Commit 2 — the true fix: deferral until substitution
- `ParseMappedTypeInfo` registers the mapped parameter as an **open type variable** while parsing the as-clause/value type; identifiers naming it parse to `TypeParameter` instead of dissolving to `Any`.
- `ResolveGenericType` **defers** alias references whose arguments mention an open variable, reusing the existing `RecursiveTypeAlias` lazy machinery; `ExpandMappedType` substitutes the concrete key per property and the alias expands on demand — converging via the same-key guard.
- Conversely, fully-concrete instantiation results are **applied eagerly** (`EvaluateConditionalType` / `ExpandMappedType`) so property access sees real object types, not raw nodes.
- `ResolveIndexedAccess` evaluates `keyof` indices and expands concrete mapped objects; `ExpandMappedType` resolves indexed-access constraints — so key-filtering aliases (`{ … }[keyof T]`) produce real key unions.
- The global `Function` type parses as `(...args: any[]) => any` instead of `Any`, so `T[K] extends Function` filters discriminate instead of matching everything.

## Correctness wins beyond the crash
- `DeepReadonly<T>` over flat **and self-recursive** interfaces converges and types members correctly (`part.name: string` works; assigning it to `number`/`boolean` errors).
- `NonFunctionPropertyNames<Flat>` now accepts exactly `"id" | "name"` — on main it silently accepted **any** string.
- Genuinely divergent instantiations (`type Grow<T> = { v: Grow<T[]> }`) report TS2589 instead of killing the process.

## Validation
- **`dotnet test SharpTS.TypeScriptConformance` now passes natively on Windows** (31/31) — previously it could not complete at all here — with **zero baseline drift** (`conditionalTypes1.ts` stays `Fail`; its remaining diffs are other gaps, e.g. interfaces extending `ReadonlyArray<T>`, which the crash previously masked).
- Full unit suite: green minus the 2 pre-existing packaging failures.
- New `RecursiveAliasInstantiationTests` (4 tests): convergence over flat/recursive interfaces, per-key value-type correctness, TS2589 on divergence.

## Follow-up (not this PR)
The string-based type pipeline (substitute-into-string + re-parse) remains the underlying architectural debt — a parsed type AST with identity-cached lazy instantiation is the long-term shape (relates to the dual-runtime/tech-debt track). The deferral above makes the current pipeline converge the way tsc's does without that rewrite.