### PR TITLE
fix(verify): resolve IL verification against the runtime directory

### DIFF
--- a/Compilation/ILVerifier.cs
+++ b/Compilation/ILVerifier.cs
@@ -9,11 +9,13 @@ namespace SharpTS.Compilation;
 /// </summary>
 public class ILVerifier : IResolver, IDisposable
 {
-    private readonly string _sdkPath;
+    private readonly string? _sdkPath;
     private readonly Dictionary<string, PEReader> _assemblyCache = new();
     private bool _disposed;
 
-    public ILVerifier(string sdkPath)
+    /// <param name="sdkPath">Optional extra probe directory (e.g. an explicit --sdk-path).
+    /// Probed after the shared-framework runtime directory.</param>
+    public ILVerifier(string? sdkPath = null)
     {
         _sdkPath = sdkPath;
     }
@@ -121,49 +123,50 @@ public class ILVerifier : IResolver, IDisposable
         if (_assemblyCache.TryGetValue(name, out var cached))
             return cached;
 
-        // Try to find in SDK reference assemblies
-        var dllPath = Path.Combine(_sdkPath, $"{name}.dll");
-        if (File.Exists(dllPath))
-        {
-            FileStream? stream = null;
-            try
-            {
-                stream = File.OpenRead(dllPath);
-                var reader = new PEReader(stream);
-                _assemblyCache[name] = reader;
-                return reader;
-            }
-            catch
-            {
-                stream?.Dispose();
-                throw;
-            }
-        }
-
-        // Try runtime assemblies as fallback
+        // Resolve from the shared-framework runtime directory first. Emitted assemblies
+        // reference System.Private.CoreLib (not the ref-assembly contract surface), and
+        // the runtime directory contains both CoreLib and the type-forwarding facades,
+        // so every reference resolves in one consistent universe. Mixing ref assemblies
+        // with CoreLib from the runtime dir makes core type identities diverge and
+        // ILVerify flags nearly every stack interaction (issue #189).
         var runtimePath = Path.GetDirectoryName(typeof(object).Assembly.Location);
         if (runtimePath != null)
         {
-            var runtimeDll = Path.Combine(runtimePath, $"{name}.dll");
-            if (File.Exists(runtimeDll))
-            {
-                FileStream? stream = null;
-                try
-                {
-                    stream = File.OpenRead(runtimeDll);
-                    var reader = new PEReader(stream);
-                    _assemblyCache[name] = reader;
-                    return reader;
-                }
-                catch
-                {
-                    stream?.Dispose();
-                    throw;
-                }
-            }
+            var reader = TryLoad(name, runtimePath);
+            if (reader != null)
+                return reader;
+        }
+
+        // Fall back to the explicit SDK path, if one was given
+        if (_sdkPath != null)
+        {
+            var reader = TryLoad(name, _sdkPath);
+            if (reader != null)
+                return reader;
         }
 
         return null;
+    }
+
+    private PEReader? TryLoad(string assemblyName, string directory)
+    {
+        var dllPath = Path.Combine(directory, $"{assemblyName}.dll");
+        if (!File.Exists(dllPath))
+            return null;
+
+        FileStream? stream = null;
+        try
+        {
+            stream = File.OpenRead(dllPath);
+            var reader = new PEReader(stream);
+            _assemblyCache[assemblyName] = reader;
+            return reader;
+        }
+        catch
+        {
+            stream?.Dispose();
+            throw;
+        }
     }
 
     public PEReader? ResolveModule(AssemblyNameInfo referencingAssembly, string fileName)

--- a/Program.cs
+++ b/Program.cs
@@ -696,15 +696,9 @@ static void GenerateRuntimeConfig(string outputPath)
 
 static void VerifyCompiledAssembly(string outputPath, string? sdkPath)
 {
-    // Find SDK path for IL verification
-    var verifierSdkPath = sdkPath ?? SdkResolver.FindReferenceAssembliesPath();
-    if (verifierSdkPath == null)
-    {
-        Console.WriteLine("Warning: Cannot verify IL - SDK reference assemblies not found.");
-        return;
-    }
-
-    using var verifier = new ILVerifier(verifierSdkPath);
+    // The verifier resolves against the shared-framework runtime directory;
+    // an explicit --sdk-path is only an additional probe location.
+    using var verifier = new ILVerifier(sdkPath);
     using var stream = File.OpenRead(outputPath);
     verifier.VerifyAndReport(stream);
 }

--- a/SharpTS.Tests/CompilerTests/ILVerificationTests.cs
+++ b/SharpTS.Tests/CompilerTests/ILVerificationTests.cs
@@ -10,37 +10,6 @@ namespace SharpTS.Tests.CompilerTests;
 /// </summary>
 public class ILVerificationTests
 {
-    // Known IL errors in runtime types that need future investigation.
-    // These are false positives caused by host-runtime method tokens that don't match
-    // the reference assemblies used by ILVerify. All work correctly at runtime.
-    private static readonly HashSet<string> KnownRuntimeErrors = new()
-    {
-        // URL helper methods use Uri.TryCreate with byref parameters
-        "$Runtime.UrlParse",
-        "$Runtime.UrlResolve",
-        // CookieJar helpers use System.Net.CookieContainer methods that resolve against
-        // the host runtime — same Uri/CookieContainer reference-assembly mismatch as
-        // the URL helpers above. All three work correctly at runtime.
-        "$Runtime.CookieJarGetCookies",
-        "$Runtime.CookieJarSetCookie",
-        "$Runtime.CookieJarClear",
-        // Headers, URL, URLSearchParams use List<string>/Dictionary methods resolved
-        // against host runtime rather than reference assemblies
-        "$Headers.",
-        "$URL.",
-        "$URLSearchParams.",
-        // Web Streams emitted types use Task/TaskCompletionSource/Queue methods resolved
-        // against host runtime rather than reference assemblies
-        "$ReadableStream",
-        "$WritableStream",
-        "$TransformStream",
-    };
-
-    private static List<string> FilterKnownErrors(List<string> errors)
-    {
-        return errors.Where(e => !KnownRuntimeErrors.Any(known => e.Contains(known))).ToList();
-    }
-
     [Fact]
     public void BasicArithmetic_PassesILVerification()
     {
@@ -50,9 +19,8 @@ public class ILVerificationTests
             """;
 
         var (errors, output) = TestHarness.CompileVerifyAndRun(source);
-        var unexpectedErrors = FilterKnownErrors(errors);
 
-        Assert.Empty(unexpectedErrors);
+        Assert.Empty(errors);
         Assert.Equal("15\n", output);
     }
 
@@ -71,8 +39,7 @@ public class ILVerificationTests
 
         var (errors, output) = TestHarness.CompileVerifyAndRun(source);
 
-        var unexpectedErrors = FilterKnownErrors(errors);
-        Assert.Empty(unexpectedErrors);
+        Assert.Empty(errors);
         Assert.Equal("7\n", output);
     }
 
@@ -94,8 +61,7 @@ public class ILVerificationTests
 
         var (errors, output) = TestHarness.CompileVerifyAndRun(source);
 
-        var unexpectedErrors = FilterKnownErrors(errors);
-        Assert.Empty(unexpectedErrors);
+        Assert.Empty(errors);
         Assert.Equal("42\n", output);
     }
 
@@ -118,9 +84,8 @@ public class ILVerificationTests
 
         // For now, just verify IL without running (runtime has issues with rewritten assemblies)
         var errors = TestHarness.CompileAndVerifyOnly(source);
-        var unexpectedErrors = FilterKnownErrors(errors);
 
-        Assert.Empty(unexpectedErrors);
+        Assert.Empty(errors);
     }
 
     [Fact]
@@ -145,8 +110,7 @@ public class ILVerificationTests
 
         var (errors, output) = TestHarness.CompileVerifyAndRun(source);
 
-        var unexpectedErrors = FilterKnownErrors(errors);
-        Assert.Empty(unexpectedErrors);
+        Assert.Empty(errors);
         Assert.Equal("Woof!\n", output);
     }
 
@@ -167,9 +131,53 @@ public class ILVerificationTests
 
         var (errors, output) = TestHarness.CompileVerifyAndRun(source);
 
-        var unexpectedErrors = FilterKnownErrors(errors);
-        Assert.Empty(unexpectedErrors);
+        Assert.Empty(errors);
         Assert.Equal("1\n2\n3\n", output);
+    }
+
+    // Regression test for issue #189: CLI `--compile … --verify` output is NOT
+    // rewritten to reference-assembly facades (it binds to System.Private.CoreLib),
+    // and verifying it against the ref-assembly universe produced thousands of
+    // false StackUnexpected/ThrowOrCatchOnlyExceptionType errors.
+    [Fact]
+    public void CoreLibBoundOutput_PassesILVerification()
+    {
+        var source = """
+            let arr = [1, 2, 3];
+            let doubled = arr.map(x => x * 2);
+            console.log(doubled);
+            """;
+
+        var tempDir = Path.Combine(Path.GetTempPath(), $"sharpts_test_{Guid.NewGuid()}");
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            var dllPath = Path.Combine(tempDir, "test.dll");
+
+            var lexer = new SharpTS.Parsing.Lexer(source);
+            var tokens = lexer.ScanTokens();
+            var parser = new SharpTS.Parsing.Parser(tokens);
+            var statements = parser.ParseOrThrow();
+
+            var checker = new SharpTS.TypeSystem.TypeChecker();
+            var typeMap = checker.Check(statements);
+
+            var deadCodeAnalyzer = new SharpTS.Compilation.DeadCodeAnalyzer(typeMap);
+            var deadCodeInfo = deadCodeAnalyzer.Analyze(statements);
+
+            // useReferenceAssemblies: false — same shape as plain CLI --compile output
+            var compiler = new SharpTS.Compilation.ILCompiler("test", preserveConstEnums: false, useReferenceAssemblies: false, sdkPath: null);
+            compiler.Compile(statements, typeMap, deadCodeInfo);
+            compiler.Save(dllPath);
+
+            var errors = TestHarness.VerifyIL(dllPath);
+
+            Assert.Empty(errors);
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, true); } catch { /* ignore cleanup errors */ }
+        }
     }
 
     [Fact]
@@ -191,8 +199,7 @@ public class ILVerificationTests
 
         var (errors, output) = TestHarness.CompileVerifyAndRun(source);
 
-        var unexpectedErrors = FilterKnownErrors(errors);
-        Assert.Empty(unexpectedErrors);
+        Assert.Empty(errors);
         Assert.Equal("finally\ncaught\n", output);
     }
 }

--- a/SharpTS.Tests/Infrastructure/TestHarness.cs
+++ b/SharpTS.Tests/Infrastructure/TestHarness.cs
@@ -1102,11 +1102,7 @@ public static class TestHarness
     /// <returns>List of verification error messages (empty if valid)</returns>
     public static List<string> VerifyIL(string dllPath)
     {
-        var sdkPath = SdkResolver.FindReferenceAssembliesPath();
-        if (sdkPath == null)
-            throw new InvalidOperationException("Could not find .NET SDK reference assemblies for IL verification");
-
-        using var verifier = new ILVerifier(sdkPath);
+        using var verifier = new ILVerifier();
         using var stream = File.OpenRead(dllPath);
         return verifier.Verify(stream);
     }

--- a/docs/plans/issue-189-ilverifier-resolution.md
+++ b/docs/plans/issue-189-ilverifier-resolution.md
@@ -1,0 +1,111 @@
+# Issue #189 — `--verify` false positives: ILVerifier mixes ref-assembly and runtime-assembly resolution
+
+Branch: `fix/189-ilverifier-runtime-resolution` (worktree `.claude/worktrees/issue-189-ilverify-resolution`)
+
+## Problem
+
+`--compile … --verify` reports ~2,386 false IL errors (`StackUnexpected`,
+`ThrowOrCatchOnlyExceptionType`) on any compiled program. The IL is fine — the
+same DLL verifies clean (815 method bodies, 0 errors) when the ILVerify
+resolver points solely at the shared-framework runtime directory.
+
+## Root cause (confirmed in code)
+
+Two facts collide:
+
+1. **What the output references.** `ILCompiler.SaveToBytes`
+   (`Compilation/ILCompiler.cs:1238`) only rewrites assembly references from
+   `System.Private.CoreLib` to the ref-assembly facade surface when
+   `_useReferenceAssemblies` is true **or** the output references SharpTS.
+   The plain CLI path (`--compile` without `--reference-assemblies`) emits via
+   `PersistedAssemblyBuilder`, so the DLL references **System.Private.CoreLib**
+   directly.
+
+2. **Where the verifier resolves from.** `Program.cs:700` defaults the
+   verifier SDK path to `SdkResolver.FindReferenceAssembliesPath()` (contract
+   assemblies). `ILVerifier.ResolveAssembly` (`Compilation/ILVerifier.cs:116`)
+   probes that path **first** and falls back to the runtime directory only for
+   files missing there. `System.Private.CoreLib.dll` does not exist in
+   ref-assembly directories, so it falls back to the runtime dir while the
+   facades (`System.Runtime`, …) resolve from ref assemblies. Mixed universe →
+   core type identities never unify → ILVerify flags nearly every stack
+   interaction.
+
+The unit-test path (`TestHarness.CompileAndVerifyOnly` / `CompileVerifyAndRun`)
+masks this because it compiles with `useReferenceAssemblies: true`, so the
+rewriter makes the DLL reference facades and the ref-assembly universe is
+self-consistent.
+
+## Fix
+
+Make `ILVerifier` resolve from the **runtime directory first** (the shared
+framework dir contains both `System.Private.CoreLib` and the type-forwarding
+facades, so both rewritten and non-rewritten output verify in one unified
+universe — this is exactly the spike's 0-error reference implementation,
+`SharpTS-spike-csmerge/spike/MergeTool/Verifier.cs`).
+
+### Steps
+
+1. **`Compilation/ILVerifier.cs`**
+   - Make the constructor's SDK path optional: `ILVerifier(string? sdkPath = null)`.
+   - In `ResolveAssembly`, swap probe order:
+     1. runtime directory (`Path.GetDirectoryName(typeof(object).Assembly.Location)`)
+     2. `_sdkPath` (only if provided — kept as an explicit `--sdk-path`
+        escape hatch / extra probe dir)
+   - Extract the duplicated "open + cache PEReader" block into a small local
+     helper while in there.
+
+2. **`Program.cs` (`VerifyCompiledAssembly`, ~line 697)**
+   - Stop defaulting to `SdkResolver.FindReferenceAssembliesPath()`; pass the
+     user's `--sdk-path` through as-is (may be null). Delete the
+     "Cannot verify IL - SDK reference assemblies not found" early-return —
+     the runtime dir always exists.
+
+3. **`SharpTS.Tests/Infrastructure/TestHarness.cs` (`VerifyIL`, ~line 1103)**
+   - Drop the `FindReferenceAssembliesPath()` lookup + throw; construct
+     `ILVerifier()` with no SDK path.
+
+### Non-goals / leave alone
+
+- `AssemblyReferenceLoader` and `ILCompiler`'s use of ref assemblies for
+  **compilation** metadata — correct as-is; ref assemblies are the right
+  surface for compile-time reference resolution, just not for verifying
+  CoreLib-bound output.
+- Resolving user `--reference` DLLs / SharpTS.dll during verification (the
+  existing "Failed to load assembly" filter in TestHarness covers this);
+  separate issue if ever needed.
+
+## Verification
+
+1. **Repro before/after** (Release build, per repo conventions):
+   `dotnet run -c Release -- --compile tmp/map.ts -o tmp/out.dll --verify`
+   with a trivial `arr.map(x => x * 2)` script — expect
+   "IL verification passed." (was 2,386 errors).
+2. **Rewritten path still clean:** existing IL-verification unit tests
+   (`CompileAndVerifyOnly` / `CompileVerifyAndRun` consumers) must still pass —
+   facades in the runtime dir type-forward to CoreLib, and ILVerify follows
+   forwarders, but this is the one assumption worth proving with the suite.
+3. **`--sdk-path` still honored:** spot-check that passing an explicit
+   `--sdk-path` doesn't crash (probed second now).
+4. Full `dotnet test` run, output piped to a file and read (per
+   feedback_test_runs memory).
+
+## Outcome notes (implementation)
+
+- Implemented as planned; repro went from 2,386 errors to "IL verification
+  passed.", and the DLL still runs (`[2, 4, 6]`). Explicit `--sdk-path`
+  re-checked and still passes.
+- Bonus: the `KnownRuntimeErrors` allowlist in
+  `SharpTS.Tests/CompilerTests/ILVerificationTests.cs` (URL/CookieJar/Headers/
+  Web Streams "known IL errors") was entirely an artifact of the same mixed
+  resolution universe — removed, and all IL-verification tests now assert
+  zero errors unfiltered.
+- Added regression test `CoreLibBoundOutput_PassesILVerification` compiling
+  with `useReferenceAssemblies: false` (the CLI shape) and asserting zero
+  verification errors.
+
+## Risk
+
+Low. The change narrows resolution to one self-consistent universe; the only
+behavioral risk is the test-harness (facade-referencing) DLLs, covered by the
+existing suite. No change to emitted IL.


### PR DESCRIPTION
## Summary

Fixes #189 — `--compile … --verify` reported thousands of false IL errors (`StackUnexpected`, `ThrowOrCatchOnlyExceptionType`) on any compiled program.

### Root cause

Two facts collided:

- `ILCompiler.SaveToBytes` only rewrites assembly references from `System.Private.CoreLib` to the ref-assembly facades when `useReferenceAssemblies` is set or the output references SharpTS. Plain CLI `--compile` output binds directly to **System.Private.CoreLib**.
- `ILVerifier.ResolveAssembly` probed SDK *reference* assemblies first, falling back to the runtime directory only for missing files. `System.Private.CoreLib.dll` doesn't exist in ref-assembly directories, so it alone fell back — facades from one universe, CoreLib from another. Core type identities never unified and ILVerify flagged nearly every stack interaction.

The unit-test path masked this because `TestHarness` compiles with `useReferenceAssemblies: true`, making the ref-assembly universe self-consistent.

### Fix

- `ILVerifier` resolves from the shared-framework runtime directory first — it contains both CoreLib and the type-forwarding facades, so rewritten and non-rewritten output both verify in one consistent universe. An explicit `--sdk-path` is kept as a secondary probe location.
- `Program.cs` no longer defaults the verifier to `SdkResolver.FindReferenceAssembliesPath()`; `TestHarness.VerifyIL` likewise. Compilation's use of ref assemblies is untouched (correct for compile-time metadata).

### Bonus

The `KnownRuntimeErrors` allowlist in `ILVerificationTests` (URL/CookieJar/Headers/Web Streams "known IL errors") was entirely an artifact of the same mixed universe — removed; all IL-verification tests now assert **zero** errors unfiltered.

## Testing

- Repro (`--compile map.ts -o out.dll --verify`, Release): **2,386 errors → 0** ("IL verification passed."), DLL still runs (`[2, 4, 6]`).
- Explicit `--sdk-path` pointing at the ref-assembly pack still passes.
- New regression test `CoreLibBoundOutput_PassesILVerification` compiles with `useReferenceAssemblies: false` (the CLI shape) and asserts zero verification errors.
- Full suite: 10,494 passed, 2 failed — both (`Pack_WithoutPackageJson_*`) reproduce identically on clean `origin/main` with the change stashed; pre-existing and unrelated.