### PR TITLE
feat: measured variance for generic instantiations + strictFunctionTypes (#202)

### DIFF
--- a/Parsing/AST.cs
+++ b/Parsing/AST.cs
@@ -396,7 +396,10 @@ public abstract record Stmt
         List<CallSignature>? CallSignatures = null,
         List<ConstructorSignature>? ConstructorSignatures = null
     ) : Stmt;
-    public record InterfaceMember(Token Name, string Type, bool IsOptional = false, bool IsReadonly = false);
+    /// <param name="IsMethod">Declared with method syntax (<c>m(x): T</c>) rather than as a
+    /// function-typed property — method members keep bivariant parameter relating under
+    /// strictFunctionTypes.</param>
+    public record InterfaceMember(Token Name, string Type, bool IsOptional = false, bool IsReadonly = false, bool IsMethod = false);
     /// <summary>
     /// Index signature in interfaces: [key: string]: valueType, [key: number]: valueType, [key: symbol]: valueType
     /// </summary>

--- a/Parsing/Parser.Declarations.cs
+++ b/Parsing/Parser.Declarations.cs
@@ -333,7 +333,8 @@ public partial class Parser
 
                 bool computedOptional = Match(TokenType.QUESTION);
                 string computedType;
-                if (Check(TokenType.LEFT_PAREN) || Check(TokenType.LESS))
+                bool computedIsMethod = Check(TokenType.LEFT_PAREN) || Check(TokenType.LESS);
+                if (computedIsMethod)
                 {
                     computedType = ParseMethodSignature();
                 }
@@ -343,7 +344,7 @@ public partial class Parser
                     computedType = ParseTypeAnnotation();
                 }
                 ConsumeInterfaceMemberSeparator();
-                members.Add(new Stmt.InterfaceMember(computedTok, computedType, computedOptional, computedReadonly));
+                members.Add(new Stmt.InterfaceMember(computedTok, computedType, computedOptional, computedReadonly, computedIsMethod));
                 continue;
             }
 
@@ -355,7 +356,8 @@ public partial class Parser
             bool isOptional = Match(TokenType.QUESTION);
 
             string type;
-            if (Check(TokenType.LEFT_PAREN) || Check(TokenType.LESS))
+            bool isMethod = Check(TokenType.LEFT_PAREN) || Check(TokenType.LESS);
+            if (isMethod)
             {
                 // Method signature: methodName(params): returnType or methodName<T>(params): returnType
                 type = ParseMethodSignature();
@@ -368,7 +370,7 @@ public partial class Parser
             }
 
             ConsumeInterfaceMemberSeparator();
-            members.Add(new Stmt.InterfaceMember(memberName, type, isOptional, isReadonly));
+            members.Add(new Stmt.InterfaceMember(memberName, type, isOptional, isReadonly, isMethod));
         }
 
         Consume(TokenType.RIGHT_BRACE, "Expect '}' after interface body.");

--- a/Parsing/Parser.Types.cs
+++ b/Parsing/Parser.Types.cs
@@ -711,7 +711,8 @@ public partial class Parser
                 bool isOptional = Match(TokenType.QUESTION);
 
                 string propertyType;
-                if (Check(TokenType.LEFT_PAREN))
+                bool isMethodMember = Check(TokenType.LEFT_PAREN);
+                if (isMethodMember)
                 {
                     // Method signature: methodName(params): returnType
                     propertyType = ParseMethodSignature();
@@ -723,8 +724,10 @@ public partial class Parser
                     propertyType = ParseUnionType();
                 }
 
-                // Build member string
-                string member = isOptional ? $"{propertyName.Lexeme}?: {propertyType}" : $"{propertyName.Lexeme}: {propertyType}";
+                // Build member string. Method members carry a '#m' marker (stripped by
+                // ParseInlineObjectTypeInfo) so method-ness survives the string round-trip —
+                // under strictFunctionTypes methods keep bivariant parameter relating.
+                string member = $"{propertyName.Lexeme}{(isMethodMember ? "#m" : "")}{(isOptional ? "?" : "")}: {propertyType}";
                 members.Add(member);
             }
 

--- a/SharpTS.Tests/TypeCheckerTests/MeasuredVarianceTests.cs
+++ b/SharpTS.Tests/TypeCheckerTests/MeasuredVarianceTests.cs
@@ -1,0 +1,111 @@
+using SharpTS.Tests.Infrastructure;
+using SharpTS.TypeSystem.Exceptions;
+using Xunit;
+
+namespace SharpTS.Tests.TypeCheckerTests;
+
+/// <summary>
+/// Measured variance for same-generic instantiations (#202): when a generic interface's type
+/// parameters carry no explicit variance annotation, two instantiations relate by the variance
+/// MEASURED from the member positions the parameter occupies (tsc's getVariances model) — with
+/// the callback rule applied during measurement so callback-parameter positions count as outputs.
+/// </summary>
+public class MeasuredVarianceTests
+{
+    [Fact]
+    public void CovariantPosition_SubtypeInstantiation_IsAssignable()
+    {
+        var source = """
+            interface Base { foo: string; }
+            interface Derived extends Base { bar: string; }
+            interface Producer<T> { value: T; }
+            var p: Producer<Base>;
+            var q: Producer<Derived>;
+            p = q;
+            """;
+        TestHarness.RunInterpreted(source);
+    }
+
+    [Fact]
+    public void CovariantPosition_SupertypeInstantiation_IsError()
+    {
+        var source = """
+            interface Base { foo: string; }
+            interface Derived extends Base { bar: string; }
+            interface Producer<T> { value: T; }
+            var p: Producer<Base>;
+            var q: Producer<Derived>;
+            q = p;
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void CallbackParameterPosition_MeasuresCovariant()
+    {
+        // T appears only in a callback's parameter — an output position (tsc's Promise rule):
+        // P<Derived> assignable to P<Base>, not conversely.
+        var source = """
+            interface Base { foo: string; }
+            interface Derived extends Base { bar: string; }
+            interface P<T> {
+                then(cb: (value: T) => void): void;
+            }
+            var a: P<Base>;
+            var b: P<Derived>;
+            a = b;
+            """;
+        TestHarness.RunInterpreted(source);
+
+        var reverse = """
+            interface Base { foo: string; }
+            interface Derived extends Base { bar: string; }
+            interface P<T> {
+                then(cb: (value: T) => void): void;
+            }
+            var a: P<Base>;
+            var b: P<Derived>;
+            b = a;
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(reverse));
+    }
+
+    [Fact]
+    public void DirectMethodParameterPosition_MeasuresBivariant()
+    {
+        // T used directly as a method parameter measures bivariantly (tsc's method exemption),
+        // so both directions are accepted — TypeScript's well-known method unsoundness.
+        var source = """
+            interface Base { foo: string; }
+            interface Derived extends Base { bar: string; }
+            interface Sink<T> { put(value: T): void; }
+            var s: Sink<Base>;
+            var t: Sink<Derived>;
+            s = t;
+            t = s;
+            """;
+        TestHarness.RunInterpreted(source);
+    }
+
+    [Fact]
+    public void SelfReferentialConstraints_RelateViaApparentTypes()
+    {
+        // assignmentCompatWithGenericCallSignatures4: x = y is fine (the constraint chain
+        // discharges), y = x is not.
+        var source = """
+            interface I2<T> { p: T }
+            var x: <T extends I2<T>>(z: T) => void;
+            var y: <T extends I2<I2<T>>>(z: T) => void;
+            x = y;
+            """;
+        TestHarness.RunInterpreted(source);
+
+        var reverse = """
+            interface I2<T> { p: T }
+            var x: <T extends I2<T>>(z: T) => void;
+            var y: <T extends I2<I2<T>>>(z: T) => void;
+            y = x;
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(reverse));
+    }
+}

--- a/SharpTS.Tests/TypeCheckerTests/VarianceAnnotationTests.cs
+++ b/SharpTS.Tests/TypeCheckerTests/VarianceAnnotationTests.cs
@@ -278,9 +278,12 @@ public class VarianceAnnotationTests
     #region Invariance Tests (no modifier)
 
     [Fact]
-    public void Invariant_RequiresExactMatch_SubtypeFails()
+    public void Unannotated_MeasuredVariance_SubtypeAllowed()
     {
-        // Without variance modifier, Box<Dog> should NOT be assignable to Box<Animal>
+        // Without a variance modifier, instantiations of the same generic relate by MEASURED
+        // variance (tsc): `value: T` is covariant and the `assign` METHOD's parameter measures
+        // bivariantly (tsc's method exemption), so Box<T> measures covariant and Box<Dog> IS
+        // assignable to Box<Animal> — TypeScript's well-known method-bivariance unsoundness.
         var source = """
             interface Animal { name: string; }
             interface Dog extends Animal { bark(): void; }
@@ -295,13 +298,11 @@ public class VarianceAnnotationTests
                 assign(v: Dog): void { this.value = v; }
             }
 
-            // Invariance prevents this assignment
             let dogBox: Box<Dog> = new DogBox();
             let animalBox: Box<Animal> = dogBox;
             """;
 
-        var ex = Assert.ThrowsAny<Exception>(() => TestHarness.RunInterpreted(source));
-        Assert.Contains("not assignable", ex.Message);
+        TestHarness.RunInterpreted(source); // must not throw — matches tsc
     }
 
     [Fact]

--- a/SharpTS.TypeScriptConformance/TypeScriptConformanceMetadataParser.cs
+++ b/SharpTS.TypeScriptConformance/TypeScriptConformanceMetadataParser.cs
@@ -66,9 +66,19 @@ public static class TypeScriptConformanceMetadataParser
 
         if (filenameLineIndices.Count == 0)
         {
-            // Single-file test. Body = entire source.
+            // Single-file test. Body = the source with directive lines removed and leading blank
+            // lines dropped — matching tsc's TestCaseParser, whose *.errors.txt line numbers are
+            // in this stripped coordinate space. Keeping the directives (they parse as comments)
+            // shifts every diagnostic line on directive-headed tests.
             var basename = Path.GetFileName(testPath);
-            files.Add(new TypeScriptConformanceFile(basename, source));
+            var bodyLines = new List<string>(lines.Length);
+            foreach (var line in lines)
+            {
+                if (DirectiveRegex.IsMatch(line)) continue;
+                if (bodyLines.Count == 0 && line.Trim().Length == 0) continue;
+                bodyLines.Add(line);
+            }
+            files.Add(new TypeScriptConformanceFile(basename, string.Join('\n', bodyLines)));
         }
         else
         {

--- a/SharpTS.TypeScriptConformance/TypeScriptConformanceRunner.cs
+++ b/SharpTS.TypeScriptConformance/TypeScriptConformanceRunner.cs
@@ -138,7 +138,10 @@ public sealed class TypeScriptConformanceRunner
             bool strictNullChecks = metadata.StrictNullChecks ?? metadata.Strict;
             // Raise the error cap well above the product default (10) so we collect every diagnostic
             // a test expects — *.errors.txt baselines can list many errors in one file.
-            var checker = new TypeChecker(strictNullChecks: strictNullChecks, maxErrors: 1000);
+            var checker = new TypeChecker(
+                strictNullChecks: strictNullChecks,
+                maxErrors: 1000,
+                strictFunctionTypes: metadata.Strict);
             checkResult = checker.CheckWithRecovery(parseResult.Statements);
         }
         catch (Exception ex)

--- a/SharpTS.TypeScriptConformance/baselines/interpreted.txt
+++ b/SharpTS.TypeScriptConformance/baselines/interpreted.txt
@@ -7,7 +7,7 @@ tests/cases/conformance/types/conditional/inferTypes2.ts ParseError
 tests/cases/conformance/types/conditional/inferTypesInvalidExtendsDeclaration.ts Skipped:lib-drift
 tests/cases/conformance/types/conditional/inferTypesWithExtends1.ts ParseError
 tests/cases/conformance/types/conditional/inferTypesWithExtends2.ts Fail
-tests/cases/conformance/types/conditional/variance.ts Fail
+tests/cases/conformance/types/conditional/variance.ts Pass
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/anyAssignabilityInInheritance.ts Fail
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/anyAssignableToEveryType.ts Pass
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/anyAssignableToEveryType2.ts Pass
@@ -32,7 +32,7 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignme
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithGenericCallSignatures.ts Pass
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithGenericCallSignatures2.ts Pass
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithGenericCallSignatures3.ts Pass
-tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithGenericCallSignatures4.ts Fail
+tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithGenericCallSignatures4.ts Pass
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithGenericCallSignaturesWithOptionalParameters.ts Pass
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithNumericIndexer.ts Pass
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithNumericIndexer2.ts Fail

--- a/TypeSystem/TypeChecker.Compatibility.Signatures.cs
+++ b/TypeSystem/TypeChecker.Compatibility.Signatures.cs
@@ -271,8 +271,11 @@ public partial class TypeChecker
         for (int i = 0; i < count; i++)
             map[sig.TypeParams[i].Name] = new TypeInfo.TypeParameter($"{prefix}{i}");
 
+        // count+2 passes: `count` to link sibling chains (mirrors BuildGenericTypeParameters) plus
+        // two extra levels so SELF-referential constraints (T extends I2<T>) carry enough nested
+        // constraint depth for the apparent-type walks the relating performs.
         List<TypeInfo.TypeParameter> renamed = [];
-        for (int pass = 0; pass < Math.Max(1, count); pass++)
+        for (int pass = 0; pass < count + 2; pass++)
         {
             renamed = [];
             for (int i = 0; i < count; i++)
@@ -328,32 +331,74 @@ public partial class TypeChecker
         // only applies when the target has no rest parameter.
         if (!f1.HasRestParam && f2.MinArity > f1.ParamTypes.Count) return false;
 
-        // Compare parameter positions, expanding a rest parameter to its element type so it
-        // covers the other side's fixed parameters (e.g. `(...a: number[])` matches `(a, b)`).
-        int f1Fixed = f1.HasRestParam ? f1.ParamTypes.Count - 1 : f1.ParamTypes.Count;
-        int f2Fixed = f2.HasRestParam ? f2.ParamTypes.Count - 1 : f2.ParamTypes.Count;
-        int positions = Math.Max(f1Fixed, f2Fixed);
-        for (int i = 0; i < positions; i++)
+        // Both context flags apply to THIS shape relation only (tsc computes them per
+        // compareSignaturesRelated invocation): capture and clear so nested comparisons —
+        // parameter and return types — relate under their own rules.
+        bool inCallback = _inCallbackComparison;
+        _inCallbackComparison = false;
+        bool isMethodTarget = _methodBivarianceDepth > 0;
+        int savedMethodDepth = _methodBivarianceDepth;
+        _methodBivarianceDepth = 0;
+        try
         {
-            var fp1 = EffectiveParamType(f1, i);
-            var fp2 = EffectiveParamType(f2, i);
-            // A position absent on one side (and not covered by a rest param) is unconstrained.
-            if (fp1 is null || fp2 is null) continue;
-            // Parameters compare bivariantly — either direction suffices — matching tsc's default
-            // function-parameter relation (strictFunctionTypes is a later, opt-in tightening).
-            if (!IsCompatible(fp1, fp2) && !IsCompatible(fp2, fp1)) return false;
+            // Compare parameter positions, expanding a rest parameter to its element type so it
+            // covers the other side's fixed parameters (e.g. `(...a: number[])` matches `(a, b)`).
+            // Parameter relation: bivariant by default (tsc pre-strictFunctionTypes), strict
+            // contravariance under strictFunctionTypes — except for method-member targets (tsc's
+            // method exemption) — and contravariance-only inside a callback comparison.
+            bool bivariantParams = !inCallback && (!_strictFunctionTypes || isMethodTarget);
+
+            int f1Fixed = f1.HasRestParam ? f1.ParamTypes.Count - 1 : f1.ParamTypes.Count;
+            int f2Fixed = f2.HasRestParam ? f2.ParamTypes.Count - 1 : f2.ParamTypes.Count;
+            int positions = Math.Max(f1Fixed, f2Fixed);
+            for (int i = 0; i < positions; i++)
+            {
+                var fp1 = EffectiveParamType(f1, i);
+                var fp2 = EffectiveParamType(f2, i);
+                // A position absent on one side (and not covered by a rest param) is unconstrained.
+                if (fp1 is null || fp2 is null) continue;
+
+                // Callback rule (scoped to variance measurement): when both parameters are pure
+                // function types, relate them SWAPPED (target's callback as the source) with
+                // strict parameters inside — callbacks are output positions, so a type parameter
+                // used only in callback-parameter positions measures covariant (tsc's Promise
+                // rule, checker.ts compareSignaturesRelated).
+                if (_varianceMeasurementDepth > 0 && !inCallback &&
+                    fp1 is TypeInfo.Function targetCb && fp2 is TypeInfo.Function sourceCb)
+                {
+                    bool related;
+                    _inCallbackComparison = true;
+                    try { related = RelateFunctionShapes(sourceCb, targetCb); }
+                    finally { _inCallbackComparison = false; }
+                    if (!related) return false;
+                    continue;
+                }
+
+                // Contravariance: the target's parameter must be acceptable to the source.
+                if (!IsCompatible(fp2, fp1) && (!bivariantParams || !IsCompatible(fp1, fp2))) return false;
+            }
+            // When both have rest parameters, their element types must also be compatible.
+            if (f1.HasRestParam && f2.HasRestParam)
+            {
+                var e1 = EffectiveParamType(f1, f1.ParamTypes.Count);
+                var e2 = EffectiveParamType(f2, f2.ParamTypes.Count);
+                if (e1 is not null && e2 is not null &&
+                    !IsCompatible(e2, e1) && (!bivariantParams || !IsCompatible(e1, e2))) return false;
+            }
+            // Return type: if expected return type is void, any return type is acceptable
+            // This is standard TypeScript behavior - void context ignores the return value
+            if (f1.ReturnType is TypeInfo.Void) return true;
+            // Inside a (bivariant) callback comparison, return types relate bivariantly — tsc:
+            // "otherwise the containing type wouldn't be co-variant. For example,
+            // interface Foo<T> { add(cb: () => T): void } wouldn't be co-variant for T".
+            if (inCallback && IsCompatible(f2.ReturnType, f1.ReturnType)) return true;
+            // Otherwise, actual must be compatible with expected
+            return IsCompatible(f1.ReturnType, f2.ReturnType);
         }
-        // When both have rest parameters, their element types must also be compatible.
-        if (f1.HasRestParam && f2.HasRestParam)
+        finally
         {
-            var e1 = EffectiveParamType(f1, f1.ParamTypes.Count);
-            var e2 = EffectiveParamType(f2, f2.ParamTypes.Count);
-            if (e1 is not null && e2 is not null && !IsCompatible(e1, e2) && !IsCompatible(e2, e1)) return false;
+            _methodBivarianceDepth = savedMethodDepth;
+            _inCallbackComparison = inCallback;
         }
-        // Return type: if expected return type is void, any return type is acceptable
-        // This is standard TypeScript behavior - void context ignores the return value
-        if (f1.ReturnType is TypeInfo.Void) return true;
-        // Otherwise, actual must be compatible with expected
-        return IsCompatible(f1.ReturnType, f2.ReturnType);
     }
 }

--- a/TypeSystem/TypeChecker.Compatibility.Structural.cs
+++ b/TypeSystem/TypeChecker.Compatibility.Structural.cs
@@ -2,6 +2,8 @@ using SharpTS.Parsing;
 using SharpTS.Runtime.BuiltIns;
 using SharpTS.TypeSystem.Exceptions;
 
+using System.Collections.Frozen;
+
 namespace SharpTS.TypeSystem;
 
 /// <summary>
@@ -289,6 +291,133 @@ public partial class TypeChecker
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// Relates two instantiations of the SAME generic interface by MEASURED variance: each type
+    /// parameter's variance is computed once from the member positions it occupies (tsc's
+    /// getVariances model, via marker-type instantiations), then the type-argument pairs are
+    /// compared under those variances. This is the fallback when the (invariant-by-default)
+    /// declared-variance comparison rejects.
+    /// </summary>
+    private bool SameGenericInstantiationsStructurallyCompatible(
+        TypeInfo.GenericInterface gi,
+        TypeInfo.InstantiatedGeneric expectedIG,
+        TypeInfo.InstantiatedGeneric actualIG)
+    {
+        var measured = GetMeasuredVariances(gi);
+        for (int i = 0; i < expectedIG.TypeArguments.Count; i++)
+        {
+            var expectedArg = expectedIG.TypeArguments[i];
+            var actualArg = actualIG.TypeArguments[i];
+            bool compatible = (i < measured.Length ? measured[i] : TypeParameterVariance.Invariant) switch
+            {
+                TypeParameterVariance.Out => IsCompatible(expectedArg, actualArg),
+                TypeParameterVariance.In => IsCompatible(actualArg, expectedArg),
+                TypeParameterVariance.InOut => true,
+                _ => IsCompatible(expectedArg, actualArg) && IsCompatible(actualArg, expectedArg),
+            };
+            if (!compatible) return false;
+        }
+        return true;
+    }
+
+    /// <summary>Marker types for variance measurement: Sub is structurally assignable to Super
+    /// but not conversely (extra member).</summary>
+    private static readonly TypeInfo.Record VarianceMarkerSuper = new(
+        new Dictionary<string, TypeInfo> { ["'variance"] = new TypeInfo.Primitive(Parsing.TokenType.TYPE_STRING) }
+            .ToFrozenDictionary());
+    private static readonly TypeInfo.Record VarianceMarkerSub = new(
+        new Dictionary<string, TypeInfo>
+        {
+            ["'variance"] = new TypeInfo.Primitive(Parsing.TokenType.TYPE_STRING),
+            ["'sub"] = new TypeInfo.Primitive(Parsing.TokenType.TYPE_STRING),
+        }.ToFrozenDictionary());
+
+    private Dictionary<TypeInfo.GenericInterface, TypeParameterVariance[]>? _measuredVariances;
+    private HashSet<TypeInfo.GenericInterface>? _varianceMeasurementInProgress;
+
+    /// <summary>
+    /// Measures each type parameter's variance from the member positions it occupies: substitute
+    /// a sub/super marker pair into the parameter (others fixed to any), relate the substituted
+    /// member sets in both directions, and classify. Measurement happens with the CALLBACK
+    /// comparison rule enabled (see <see cref="_varianceMeasurementDepth"/>) so a parameter used
+    /// only in callback-parameter positions measures covariant — tsc's Promise/P&lt;T&gt; rule —
+    /// while a parameter used directly as a method parameter measures bivariant. Recursive
+    /// references measure as bivariant (skipped) rather than recursing forever.
+    /// </summary>
+    private TypeParameterVariance[] GetMeasuredVariances(TypeInfo.GenericInterface gi)
+    {
+        // Record equality on GenericInterface compares List/FrozenDictionary fields by reference,
+        // so the default comparer behaves as identity for distinct declarations — sufficient here.
+        _measuredVariances ??= [];
+        if (_measuredVariances.TryGetValue(gi, out var cached)) return cached;
+
+        _varianceMeasurementInProgress ??= [];
+        var result = new TypeParameterVariance[gi.TypeParams.Count];
+        if (!_varianceMeasurementInProgress.Add(gi))
+        {
+            // Already measuring this interface (self-referential member) — treat as bivariant for
+            // the nested occurrence; the outer measurement decides.
+            for (int i = 0; i < result.Length; i++) result[i] = TypeParameterVariance.InOut;
+            return result;
+        }
+        _varianceMeasurementDepth++;
+        try
+        {
+            for (int i = 0; i < gi.TypeParams.Count; i++)
+            {
+                Dictionary<string, TypeInfo> superSubs = [];
+                Dictionary<string, TypeInfo> subSubs = [];
+                for (int j = 0; j < gi.TypeParams.Count; j++)
+                {
+                    superSubs[gi.TypeParams[j].Name] = j == i ? VarianceMarkerSuper : new TypeInfo.Any();
+                    subSubs[gi.TypeParams[j].Name] = j == i ? VarianceMarkerSub : new TypeInfo.Any();
+                }
+                // Covariant: I<Sub> assignable to I<Super>; contravariant: the reverse.
+                bool covariant = SubstitutedMembersRelated(gi, expectedSubs: superSubs, actualSubs: subSubs);
+                bool contravariant = SubstitutedMembersRelated(gi, expectedSubs: subSubs, actualSubs: superSubs);
+                result[i] = covariant && contravariant ? TypeParameterVariance.InOut
+                    : covariant ? TypeParameterVariance.Out
+                    : contravariant ? TypeParameterVariance.In
+                    : TypeParameterVariance.Invariant;
+            }
+        }
+        finally
+        {
+            _varianceMeasurementDepth--;
+            _varianceMeasurementInProgress.Remove(gi);
+        }
+        _measuredVariances[gi] = result;
+        return result;
+    }
+
+    /// <summary>Substitutes both maps into every member and relates the results member-wise.</summary>
+    private bool SubstitutedMembersRelated(
+        TypeInfo.GenericInterface gi,
+        Dictionary<string, TypeInfo> expectedSubs,
+        Dictionary<string, TypeInfo> actualSubs)
+    {
+        foreach (var (name, memberType) in gi.Members)
+        {
+            var expectedMember = Substitute(memberType, expectedSubs);
+            var actualMember = Substitute(memberType, actualSubs);
+            bool isMethod = gi.MethodMembers?.Contains(name) == true;
+            if (!IsMemberCompatible(expectedMember, actualMember, isMethod)) return false;
+        }
+        return true;
+    }
+
+    /// <summary>
+    /// Relates one member pair, applying method bivariance: members declared with method syntax
+    /// compare their parameters bivariantly even under strictFunctionTypes (tsc's exemption).
+    /// </summary>
+    private bool IsMemberCompatible(TypeInfo expectedMember, TypeInfo actualMember, bool isMethod)
+    {
+        if (!isMethod) return IsCompatible(expectedMember, actualMember);
+        _methodBivarianceDepth++;
+        try { return IsCompatible(expectedMember, actualMember); }
+        finally { _methodBivarianceDepth--; }
     }
 
     /// <summary>

--- a/TypeSystem/TypeChecker.Compatibility.cs
+++ b/TypeSystem/TypeChecker.Compatibility.cs
@@ -99,18 +99,25 @@ public partial class TypeChecker
     /// </summary>
     private bool IsCompatible(TypeInfo expected, TypeInfo actual)
     {
+        // Under strictFunctionTypes the verdict for a function-typed pair depends on whether the
+        // comparison happens inside a method member (bivariant) or not (strict) — the same pair
+        // can legitimately differ between the two contexts, so bivariant-context results must not
+        // be cached or served from cache. Variance measurement likewise compares with the callback
+        // rule enabled, which ordinary comparisons don't.
+        bool uncacheable = (_strictFunctionTypes && _methodBivarianceDepth > 0) || _varianceMeasurementDepth > 0;
+
         // Level 1: Fast identity-based cache (reference equality)
         _identityCompatibilityCache ??= new(IdentityCacheKeyComparer.Instance);
         var identityKey = new IdentityCompatibilityCacheKey(expected, actual);
 
-        if (_identityCompatibilityCache.TryGetValue(identityKey, out var identityCached))
+        if (!uncacheable && _identityCompatibilityCache.TryGetValue(identityKey, out var identityCached))
             return identityCached;
 
         // Level 2: Structural equality cache (for different instances with same structure)
         _compatibilityCache ??= new(CompatibilityCacheKeyComparer.Instance);
         var structuralKey = (expected, actual);
 
-        if (_compatibilityCache.TryGetValue(structuralKey, out var structuralCached))
+        if (!uncacheable && _compatibilityCache.TryGetValue(structuralKey, out var structuralCached))
         {
             // Store in identity cache for future fast lookups
             _identityCompatibilityCache[identityKey] = structuralCached;
@@ -141,9 +148,12 @@ public partial class TypeChecker
             // Cache miss - compute result
             var result = IsCompatibleCore(expected, actual);
 
-            // Store in both caches
-            _compatibilityCache[structuralKey] = result;
-            _identityCompatibilityCache[identityKey] = result;
+            // Store in both caches (bivariant-context results are context-dependent — skip)
+            if (!uncacheable)
+            {
+                _compatibilityCache[structuralKey] = result;
+                _identityCompatibilityCache[identityKey] = result;
+            }
 
             return result;
         }
@@ -779,7 +789,8 @@ public partial class TypeChecker
                         if (!allExpectedOptional.Contains(member.Key))
                             return false;
                     }
-                    else if (!IsCompatible(member.Value, actualMemberType))
+                    else if (!IsMemberCompatible(member.Value, actualMemberType,
+                                 itf.IsMethodMember(member.Key) || actualItf.IsMethodMember(member.Key)))
                     {
                         return false;
                     }
@@ -805,9 +816,18 @@ public partial class TypeChecker
                 // Same generic interface - check type arguments with variance
                 if (expectedInterfaceIG.TypeArguments.Count != actualInterfaceIG.TypeArguments.Count)
                     return false;
-                if (!AreTypeArgumentsCompatible(gi.TypeParams, expectedInterfaceIG.TypeArguments, actualInterfaceIG.TypeArguments))
+                if (AreTypeArgumentsCompatible(gi.TypeParams, expectedInterfaceIG.TypeArguments, actualInterfaceIG.TypeArguments))
+                    return true;
+                // Unannotated type parameters compare invariantly above, but tsc relates two
+                // instantiations of the same generic by MEASURED variance (computed from member
+                // positions) — e.g. P<Derived> is assignable to P<Base> when T only occupies
+                // covariant positions. Explicit variance annotations are authoritative (tsc uses
+                // them as declared), so the measured fallback only applies when every parameter
+                // is unannotated.
+                if (gi.TypeParams.Any(tp => tp.Variance != TypeParameterVariance.Invariant))
                     return false;
-                return true;
+                return SameGenericInstantiationsStructurallyCompatible(
+                    gi, expectedInterfaceIG, actualInterfaceIG);
             }
 
             // Build substitution map for structural comparison
@@ -882,7 +902,8 @@ public partial class TypeChecker
                     if (!expRecord.IsFieldOptional(name))
                         return false;
                 }
-                else if (!IsCompatible(expectedFieldType, actualFieldType))
+                else if (!IsMemberCompatible(expectedFieldType, actualFieldType,
+                             expRecord.IsMethodMember(name) || actRecord.IsMethodMember(name)))
                 {
                     return false;
                 }

--- a/TypeSystem/TypeChecker.Statements.Interfaces.cs
+++ b/TypeSystem/TypeChecker.Statements.Interfaces.cs
@@ -66,6 +66,7 @@ public partial class TypeChecker
         Dictionary<string, List<TypeInfo.Function>> pendingOverloads = [];
         HashSet<string> optionalMembers = [];
         HashSet<string> readonlyMembers = [];
+        HashSet<string> methodMembers = [];
 
         using (new EnvironmentScope(this, interfaceTypeEnv))
         {
@@ -106,6 +107,10 @@ public partial class TypeChecker
                 if (member.IsReadonly)
                 {
                     readonlyMembers.Add(member.Name.Lexeme);
+                }
+                if (member.IsMethod)
+                {
+                    methodMembers.Add(member.Name.Lexeme);
                 }
             }
 
@@ -156,7 +161,8 @@ public partial class TypeChecker
                 optionalMembers.ToFrozenSet(),
                 CallSignatures: callSignatures,
                 ConstructorSignatures: constructorSignatures,
-                ReadonlyMembers: readonlyMembers.Count > 0 ? readonlyMembers.ToFrozenSet() : null
+                ReadonlyMembers: readonlyMembers.Count > 0 ? readonlyMembers.ToFrozenSet() : null,
+                MethodMembers: methodMembers.Count > 0 ? methodMembers.ToFrozenSet() : null
             );
             _environment.Define(interfaceStmt.Name.Lexeme, genericItfType);
         }
@@ -169,7 +175,8 @@ public partial class TypeChecker
                 Extends: extends,
                 CallSignatures: callSignatures,
                 ConstructorSignatures: constructorSignatures,
-                ReadonlyMembers: readonlyMembers.Count > 0 ? readonlyMembers.ToFrozenSet() : null
+                ReadonlyMembers: readonlyMembers.Count > 0 ? readonlyMembers.ToFrozenSet() : null,
+                MethodMembers: methodMembers.Count > 0 ? methodMembers.ToFrozenSet() : null
             );
             _environment.Define(interfaceStmt.Name.Lexeme, itfType);
         }
@@ -211,6 +218,7 @@ public partial class TypeChecker
         Dictionary<string, List<TypeInfo.Function>> pendingOverloads = []; // Track overloaded methods
         HashSet<string> optionalMembers = [];
         HashSet<string> readonlyMembers = [];
+        HashSet<string> methodMembers = [];
         TypeInfo? stringIndexType = null;
         TypeInfo? numberIndexType = null;
         TypeInfo? symbolIndexType = null;
@@ -252,6 +260,10 @@ public partial class TypeChecker
             if (member.IsReadonly)
             {
                 readonlyMembers.Add(member.Name.Lexeme);
+            }
+            if (member.IsMethod)
+            {
+                methodMembers.Add(member.Name.Lexeme);
             }
         }
 
@@ -390,7 +402,8 @@ public partial class TypeChecker
                 extends,
                 callSignatures,
                 constructorSignatures,
-                readonlyMembers.Count > 0 ? readonlyMembers.ToFrozenSet() : null
+                readonlyMembers.Count > 0 ? readonlyMembers.ToFrozenSet() : null,
+                methodMembers.Count > 0 ? methodMembers.ToFrozenSet() : null
             );
             _environment.Define(interfaceStmt.Name.Lexeme, genericItfType);
         }
@@ -406,7 +419,8 @@ public partial class TypeChecker
                 extends,
                 callSignatures,
                 constructorSignatures,
-                readonlyMembers.Count > 0 ? readonlyMembers.ToFrozenSet() : null
+                readonlyMembers.Count > 0 ? readonlyMembers.ToFrozenSet() : null,
+                methodMembers.Count > 0 ? methodMembers.ToFrozenSet() : null
             );
             _environment.Define(interfaceStmt.Name.Lexeme, itfType);
         }

--- a/TypeSystem/TypeChecker.TypeParsing.cs
+++ b/TypeSystem/TypeChecker.TypeParsing.cs
@@ -960,6 +960,7 @@ public partial class TypeChecker
 
         Dictionary<string, TypeInfo> fields = [];
         HashSet<string> optionalFields = [];
+        HashSet<string> methodMembers = [];
         TypeInfo? stringIndexType = null;
         TypeInfo? numberIndexType = null;
         TypeInfo? symbolIndexType = null;
@@ -1026,13 +1027,17 @@ public partial class TypeChecker
             string propName = m[..regularColonIdx].Trim();
             string propType = m[(regularColonIdx + 1)..].Trim();
 
-            // Check for optional marker (?) and track it
+            // Strip the optional marker (?) and the method marker (#m, emitted by the parser for
+            // method-syntax members) — order matches the emitted "name#m?:" form.
             bool isOptional = propName.EndsWith("?");
-            if (isOptional)
+            if (isOptional) propName = propName[..^1].Trim();
+            bool isMethod = propName.EndsWith("#m");
+            if (isMethod)
             {
-                propName = propName[..^1].Trim();
-                optionalFields.Add(propName);
+                propName = propName[..^2].Trim();
+                methodMembers.Add(propName);
             }
+            if (isOptional) optionalFields.Add(propName);
 
             fields[propName] = ToTypeInfo(propType);
         }
@@ -1059,7 +1064,8 @@ public partial class TypeChecker
             symbolIndexType,
             optionalFields.Count > 0 ? optionalFields.ToFrozenSet() : null,
             CallSignatures: recCallSigs,
-            ConstructorSignatures: recCtorSigs);
+            ConstructorSignatures: recCtorSigs,
+            MethodMembers: methodMembers.Count > 0 ? methodMembers.ToFrozenSet() : null);
     }
 
     /// <summary>

--- a/TypeSystem/TypeChecker.cs
+++ b/TypeSystem/TypeChecker.cs
@@ -70,10 +70,40 @@ public partial class TypeChecker
     /// </summary>
     private readonly bool _strictNullChecks;
 
+    /// <summary>
+    /// When true (TypeScript's <c>strictFunctionTypes</c>), function-type parameters compare
+    /// contravariantly; members declared with METHOD syntax keep the legacy bivariant comparison
+    /// (tsc's exemption). Defaults to false — the product keeps bivariant relating; the TS
+    /// conformance runner sets it from each test's <c>@strict</c> directive.
+    /// </summary>
+    private readonly bool _strictFunctionTypes;
+
+    /// <summary>
+    /// Non-zero while comparing members declared with method syntax — within such a comparison,
+    /// function parameters relate bivariantly even under <see cref="_strictFunctionTypes"/>.
+    /// </summary>
+    private int _methodBivarianceDepth;
+
+    /// <summary>
+    /// Non-zero while measuring a generic interface's type-parameter variances. Within
+    /// measurement, the callback comparison rule is enabled (both params pure function types →
+    /// relate swapped with strict parameters), so a parameter used only in callback-parameter
+    /// positions measures covariant — tsc's Promise rule.
+    /// </summary>
+    private int _varianceMeasurementDepth;
+
+    /// <summary>
+    /// True for the immediate signature relation spawned by the callback rule: its parameters
+    /// relate contravariantly only (no bivariant leg, no callback re-fire). Captured-and-cleared
+    /// at RelateFunctionShapes entry so it never leaks into nested comparisons.
+    /// </summary>
+    private bool _inCallbackComparison;
+
     /// <summary>Creates a type checker. <paramref name="strictNullChecks"/> defaults to true.</summary>
-    public TypeChecker(bool strictNullChecks = true, int maxErrors = 10)
+    public TypeChecker(bool strictNullChecks = true, int maxErrors = 10, bool strictFunctionTypes = false)
     {
         _strictNullChecks = strictNullChecks;
+        _strictFunctionTypes = strictFunctionTypes;
         _diagnostics.MaxErrors = maxErrors;
     }
 

--- a/TypeSystem/TypeInfo.cs
+++ b/TypeSystem/TypeInfo.cs
@@ -397,9 +397,21 @@ public abstract record TypeInfo
         FrozenSet<TypeInfo.Interface>? Extends = null,
         List<CallSignature>? CallSignatures = null,
         List<ConstructorSignature>? ConstructorSignatures = null,
-        FrozenSet<string>? ReadonlyMembers = null
+        FrozenSet<string>? ReadonlyMembers = null,
+        FrozenSet<string>? MethodMembers = null
     ) : TypeInfo
     {
+        /// <summary>True when the member (own or inherited) was declared with method syntax —
+        /// method members keep bivariant parameter relating under strictFunctionTypes.</summary>
+        public bool IsMethodMember(string name)
+        {
+            if (MethodMembers?.Contains(name) == true) return true;
+            if (Extends != null)
+                foreach (var baseItf in Extends)
+                    if (baseItf.IsMethodMember(name)) return true;
+            return false;
+        }
+
         public bool HasIndexSignature => StringIndexType != null || NumberIndexType != null || SymbolIndexType != null;
         public bool HasCallSignature => CallSignatures is { Count: > 0 };
         public bool HasConstructorSignature => ConstructorSignatures is { Count: > 0 };
@@ -705,9 +717,13 @@ public abstract record TypeInfo
         bool IsReadonly = false,
         FrozenSet<string>? GetterOnlyFields = null,
         List<CallSignature>? CallSignatures = null,
-        List<ConstructorSignature>? ConstructorSignatures = null
+        List<ConstructorSignature>? ConstructorSignatures = null,
+        FrozenSet<string>? MethodMembers = null
     ) : TypeInfo
     {
+        /// <summary>True when the field was declared with method syntax (`m(x): T`), which keeps
+        /// bivariant parameter relating under strictFunctionTypes (tsc's method exemption).</summary>
+        public bool IsMethodMember(string name) => MethodMembers?.Contains(name) ?? false;
         public bool HasIndexSignature => StringIndexType != null || NumberIndexType != null || SymbolIndexType != null;
 
         /// <summary>True when this object type has at least one call signature (`{ (x): T }`).</summary>
@@ -735,7 +751,11 @@ public abstract record TypeInfo
         public override string ToString()
         {
             var prefix = IsReadonly ? "readonly " : "";
-            var parts = Fields.Select(f => $"{f.Key}{(IsFieldOptional(f.Key) ? "?" : "")}: {f.Value}").ToList();
+            // Method-ness must be rendered: under strictFunctionTypes a method member and a
+            // property member of the same function type differ in assignability, and ToString is
+            // the compatibility-cache key.
+            var parts = Fields.Select(f =>
+                $"{f.Key}{(IsMethodMember(f.Key) ? "#m" : "")}{(IsFieldOptional(f.Key) ? "?" : "")}: {f.Value}").ToList();
             if (CallSignatures != null) parts.InsertRange(0, CallSignatures.Select(s => s.ToString()));
             if (ConstructorSignatures != null) parts.InsertRange(0, ConstructorSignatures.Select(s => s.ToString()));
             // Index signatures must be rendered so distinct index types don't collapse to the same
@@ -1246,7 +1266,8 @@ public abstract record TypeInfo
         FrozenSet<TypeInfo.Interface>? Extends = null,
         List<CallSignature>? CallSignatures = null,
         List<ConstructorSignature>? ConstructorSignatures = null,
-        FrozenSet<string>? ReadonlyMembers = null
+        FrozenSet<string>? ReadonlyMembers = null,
+        FrozenSet<string>? MethodMembers = null
     ) : TypeInfo
     {
         public bool HasIndexSignature => StringIndexType != null || NumberIndexType != null || SymbolIndexType != null;


### PR DESCRIPTION
Part of #80; implements the tractable portion of #202.

## What
- **Measured variance** (tsc's `getVariances`): two instantiations of the same generic interface relate by the variance computed from member positions — sub/super marker instantiations related structurally, cached per interface. Explicit `in`/`out` annotations stay authoritative; the measured fallback only applies when every parameter is unannotated. Measurement runs with tsc's **callback rule** enabled (both params pure function types → relate swapped, strict params inside, bivariant returns), so callback-parameter positions measure covariant (the Promise rule) while direct method parameters measure bivariant (the method exemption).
- **strictFunctionTypes** as an opt-in `TypeChecker` option (product default off; conformance runner sets it from `@strict`): function-type params compare contravariantly, method-syntax members keep bivariance. Method-ness is tracked end to end — `InterfaceMember.IsMethod`, `MethodMembers` on `Interface`/`GenericInterface`/`Record`, and a `#m` marker through the inline-object string pipeline (rendered in `Record.ToString` since the compat cache keys on renderings). Context-dependent comparisons bypass the cache.
- **Runner line-coordinate fix**: single-file test bodies now strip directive lines + leading blanks, matching tsc's TestCaseParser — `*.errors.txt` line numbers live in that stripped space, so every directive-headed test's diagnostics were off-by-N before.
- Alpha-renaming resolves constraint interiors `count+2` passes deep so self-referential constraints (`T extends I2<T>`) survive apparent-type walks.

## Result
- Conformance: **`assignmentCompatWithGenericCallSignatures4` and `types/conditional/variance` flip Fail → Pass** (Pass 51 → 53), 0 regressions.
- `covariantCallbacks` narrows from 8 wrong lines to 4 — the remainder needs the **always-on** callback rule, which requires tsc's `isInstantiatedGenericParameter` exclusion (alias-instantiation identity through the string pipeline). Documented in #202; blocked on the type-AST tech debt.
- Full unit suite green (2 known local-only packaging failures). One variance unit test updated to tsc semantics (method bivariance legalizes `Box<Dog> → Box<Animal>`). 5 new unit tests.