### PR TITLE
Bugfix batch: #190-#197, #199

### DIFF
--- a/Compilation/ExpressionEmitterBase.Operators.cs
+++ b/Compilation/ExpressionEmitterBase.Operators.cs
@@ -164,10 +164,12 @@ public abstract partial class ExpressionEmitterBase
             string name = v.Name.Lexeme;
             double delta = pi.Operator.Type == TokenType.PLUS_PLUS ? 1.0 : -1.0;
 
-            // Load current value, convert to double, add delta, box
+            // Load current value, convert to double, add delta, box.
+            // ConvertToNumber implements ECMA-262 ToNumber (undefined→NaN);
+            // Convert.ToDouble throws InvalidCastException on $Undefined (#190).
             EmitVariable(v);
             EnsureBoxed();
-            IL.Emit(OpCodes.Call, Types.ConvertToDoubleFromObject);
+            IL.Emit(OpCodes.Call, Ctx.Runtime?.ConvertToNumber ?? Types.ConvertToDoubleFromObject);
             IL.Emit(OpCodes.Ldc_R8, delta);
             IL.Emit(OpCodes.Add);
             IL.Emit(OpCodes.Box, typeof(double));
@@ -194,8 +196,8 @@ public abstract partial class ExpressionEmitterBase
             EnsureBoxed();
             IL.Emit(OpCodes.Dup);  // Dup original for expression result
 
-            // Convert to double, add delta, box
-            IL.Emit(OpCodes.Call, Types.ConvertToDoubleFromObject);
+            // Convert to double, add delta, box (ToNumber semantics — see EmitPrefixIncrement)
+            IL.Emit(OpCodes.Call, Ctx.Runtime?.ConvertToNumber ?? Types.ConvertToDoubleFromObject);
             IL.Emit(OpCodes.Ldc_R8, delta);
             IL.Emit(OpCodes.Add);
             IL.Emit(OpCodes.Box, typeof(double));

--- a/Compilation/ExpressionEmitterBase.cs
+++ b/Compilation/ExpressionEmitterBase.cs
@@ -1038,8 +1038,16 @@ public abstract partial class ExpressionEmitterBase : IEmitterContext
             {
                 IL.Emit(OpCodes.Dup);
                 IL.Emit(OpCodes.Ldc_I4, i);
-                EmitExpression(a.Elements[i]);
-                EnsureBoxed();
+                if (a.IsHole(i))
+                {
+                    // Elided position → true ECMA-262 hole, not an undefined element.
+                    IL.Emit(OpCodes.Ldsfld, Ctx.Runtime!.ArrayHoleInstance);
+                }
+                else
+                {
+                    EmitExpression(a.Elements[i]);
+                    EnsureBoxed();
+                }
                 IL.Emit(OpCodes.Stelem_Ref);
             }
 
@@ -1066,8 +1074,15 @@ public abstract partial class ExpressionEmitterBase : IEmitterContext
                     IL.Emit(OpCodes.Newarr, typeof(object));
                     IL.Emit(OpCodes.Dup);
                     IL.Emit(OpCodes.Ldc_I4_0);
-                    EmitExpression(a.Elements[i]);
-                    EnsureBoxed();
+                    if (a.IsHole(i))
+                    {
+                        IL.Emit(OpCodes.Ldsfld, Ctx.Runtime!.ArrayHoleInstance);
+                    }
+                    else
+                    {
+                        EmitExpression(a.Elements[i]);
+                        EnsureBoxed();
+                    }
                     IL.Emit(OpCodes.Stelem_Ref);
                     IL.Emit(OpCodes.Call, Ctx.Runtime!.CreateArray);
                 }

--- a/Compilation/ILEmitter.Properties.Literals.cs
+++ b/Compilation/ILEmitter.Properties.Literals.cs
@@ -34,8 +34,16 @@ public partial class ILEmitter
             {
                 IL.Emit(OpCodes.Dup);
                 IL.Emit(OpCodes.Ldc_I4, i);
-                EmitExpression(a.Elements[i]);
-                EmitBoxIfNeeded(a.Elements[i]);
+                if (a.IsHole(i))
+                {
+                    // Elided position → true ECMA-262 hole, not an undefined element.
+                    IL.Emit(OpCodes.Ldsfld, _ctx.Runtime!.ArrayHoleInstance);
+                }
+                else
+                {
+                    EmitExpression(a.Elements[i]);
+                    EmitBoxIfNeeded(a.Elements[i]);
+                }
                 IL.Emit(OpCodes.Stelem_Ref);
             }
 
@@ -66,8 +74,15 @@ public partial class ILEmitter
                     IL.Emit(OpCodes.Newarr, _ctx.Types.Object);
                     IL.Emit(OpCodes.Dup);
                     IL.Emit(OpCodes.Ldc_I4, 0);
-                    EmitExpression(a.Elements[i]);
-                    EmitBoxIfNeeded(a.Elements[i]);
+                    if (a.IsHole(i))
+                    {
+                        IL.Emit(OpCodes.Ldsfld, _ctx.Runtime!.ArrayHoleInstance);
+                    }
+                    else
+                    {
+                        EmitExpression(a.Elements[i]);
+                        EmitBoxIfNeeded(a.Elements[i]);
+                    }
                     IL.Emit(OpCodes.Stelem_Ref);
                     IL.Emit(OpCodes.Call, _ctx.Runtime!.CreateArray);
                 }

--- a/Compilation/RuntimeEmitter.CoreUtilities.cs
+++ b/Compilation/RuntimeEmitter.CoreUtilities.cs
@@ -3026,6 +3026,18 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Isinst, _types.String);
         il.Emit(OpCodes.Brtrue, stringLabel);
 
+        // .NET interop: boxed non-double numerics (float, int, long, decimal, …)
+        // arrive via @DotNetType calls. Convert them numerically rather than
+        // falling through to NaN (EnsureDouble routes through this method).
+        var notConvertibleLabel = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, argLocal);
+        il.Emit(OpCodes.Isinst, typeof(IConvertible));
+        il.Emit(OpCodes.Brfalse, notConvertibleLabel);
+        il.Emit(OpCodes.Ldloc, argLocal);
+        il.Emit(OpCodes.Call, _types.GetMethod(_types.Convert, "ToDouble", _types.Object));
+        il.Emit(OpCodes.Ret);
+        il.MarkLabel(notConvertibleLabel);
+
         // everything else => NaN
         il.Emit(OpCodes.Br, nanLabel);
 

--- a/Compilation/RuntimeEmitter.FsWatcher.cs
+++ b/Compilation/RuntimeEmitter.FsWatcher.cs
@@ -385,28 +385,47 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldc_I4, 5007);
         il.Emit(OpCodes.Stloc, intervalLocal);
 
-        // Check if arg1 is options dict with "interval"
+        // Check if arg1 is an options bag with "interval". Compiled object literals
+        // are Dictionary<string, object?> — NOT $IHasFields (only class instances
+        // implement that) — so both shapes must be handled or literal options bags
+        // (the normal calling convention) are silently ignored.
         var afterOptionsLabel = il.DefineLabel();
+        var haveValueLabel = il.DefineLabel();
+        var notHasFieldsLabel = il.DefineLabel();
+        var intervalObjLocal = il.DeclareLocal(_types.Object);
+
+        // if (arg1 is $IHasFields hf) intervalObj = hf.GetProperty("interval")
         il.Emit(OpCodes.Ldarg_1);
         il.Emit(OpCodes.Isinst, runtime.IHasFieldsInterface);
-        il.Emit(OpCodes.Brfalse, afterOptionsLabel);
-
+        il.Emit(OpCodes.Brfalse, notHasFieldsLabel);
         il.Emit(OpCodes.Ldarg_1);
         il.Emit(OpCodes.Castclass, runtime.IHasFieldsInterface);
         il.Emit(OpCodes.Ldstr, "interval");
         il.Emit(OpCodes.Callvirt, runtime.IHasFieldsGetProperty);
-        var intervalObjLocal = il.DeclareLocal(_types.Object);
         il.Emit(OpCodes.Stloc, intervalObjLocal);
+        il.Emit(OpCodes.Br, haveValueLabel);
 
-        var notDoubleLabel = il.DefineLabel();
+        // else if (arg1 is Dictionary<string, object> d) d.TryGetValue("interval", out intervalObj)
+        il.MarkLabel(notHasFieldsLabel);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Isinst, _types.DictionaryStringObject);
+        il.Emit(OpCodes.Brfalse, afterOptionsLabel);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Castclass, _types.DictionaryStringObject);
+        il.Emit(OpCodes.Ldstr, "interval");
+        il.Emit(OpCodes.Ldloca, intervalObjLocal);
+        il.Emit(OpCodes.Callvirt, _types.DictionaryStringObject.GetMethod("TryGetValue")!);
+        il.Emit(OpCodes.Pop);
+
+        // if (intervalObj is double) interval = (int)(double)intervalObj
+        il.MarkLabel(haveValueLabel);
         il.Emit(OpCodes.Ldloc, intervalObjLocal);
         il.Emit(OpCodes.Isinst, typeof(double));
-        il.Emit(OpCodes.Brfalse, notDoubleLabel);
+        il.Emit(OpCodes.Brfalse, afterOptionsLabel);
         il.Emit(OpCodes.Ldloc, intervalObjLocal);
         il.Emit(OpCodes.Unbox_Any, typeof(double));
         il.Emit(OpCodes.Conv_I4);
         il.Emit(OpCodes.Stloc, intervalLocal);
-        il.MarkLabel(notDoubleLabel);
 
         il.MarkLabel(afterOptionsLabel);
 

--- a/Compilation/RuntimeEmitter.Promises.Race.cs
+++ b/Compilation/RuntimeEmitter.Promises.Race.cs
@@ -171,16 +171,21 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Castclass, listType);
         il.Emit(OpCodes.Stloc, listLocal);
 
-        // Check for empty list - return null immediately
+        // ECMA-262 §27.2.4.5: race over an empty iterable returns a promise that
+        // NEVER settles — there are no competitors. Route a never-completing task
+        // through the winning-task await machinery instead of settling with null.
         var notEmptyLabel = il.DefineLabel();
+        var awaitWinningTaskLabel = il.DefineLabel();
         il.Emit(OpCodes.Ldloc, listLocal);
         il.Emit(OpCodes.Callvirt, listType.GetProperty("Count")!.GetGetMethod()!);
         il.Emit(OpCodes.Brtrue, notEmptyLabel);
 
-        // Empty list - return null
-        il.Emit(OpCodes.Ldnull);
-        il.Emit(OpCodes.Stloc, resultLocal);
-        il.Emit(OpCodes.Leave, setResultLabel);
+        // winningTask = new TaskCompletionSource<object?>().Task (never completes)
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Newobj, typeof(TaskCompletionSource<object?>).GetConstructor(Type.EmptyTypes)!);
+        il.Emit(OpCodes.Callvirt, typeof(TaskCompletionSource<object?>).GetProperty("Task")!.GetGetMethod()!);
+        il.Emit(OpCodes.Stfld, sm.WinningTaskField);
+        il.Emit(OpCodes.Br, awaitWinningTaskLabel);
 
         il.MarkLabel(notEmptyLabel);
 
@@ -303,7 +308,9 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Call, whenAnyAwaiterType.GetMethod("GetResult")!);
         il.Emit(OpCodes.Stfld, sm.WinningTaskField);
 
-        // Get awaiter for winning task
+        // Get awaiter for winning task (empty-iterable path jumps here with a
+        // never-completing winningTask already stored)
+        il.MarkLabel(awaitWinningTaskLabel);
         var resultAwaiterLocal = il.DeclareLocal(resultAwaiterType);
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ldfld, sm.WinningTaskField);

--- a/Compilation/RuntimeEmitter.Promises.Then.cs
+++ b/Compilation/RuntimeEmitter.Promises.Then.cs
@@ -142,25 +142,28 @@ public partial class RuntimeEmitter
 
         // Labels
         var state0Label = il.DefineLabel();  // Resume after promise await
-        var state1Label = il.DefineLabel();  // Resume after flatten await
+        var state1Label = il.DefineLabel();  // Resume after flatten await (inside handler try)
         var continue0Label = il.DefineLabel();
         var continue1Label = il.DefineLabel();
         var checkFlattenLabel = il.DefineLabel();
         var setResultLabel = il.DefineLabel();
         var returnLabel = il.DefineLabel();
-        var catchLabel = il.DefineLabel();
+        var handlerTryStartLabel = il.DefineLabel();  // First instruction of the onFulfilled guard try
 
         // Begin outer try block
         il.BeginExceptionBlock();
 
-        // State dispatch
+        // State dispatch. State 1 resumes inside the nested onFulfilled guard
+        // try — IL only permits entering a protected region at its first
+        // instruction, so branch there and let the nested dispatch take over
+        // (same shape Roslyn emits for await-inside-try).
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ldfld, sm.StateField);
         il.Emit(OpCodes.Brfalse, state0Label);  // state == 0
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ldfld, sm.StateField);
         il.Emit(OpCodes.Ldc_I4_1);
-        il.Emit(OpCodes.Beq, state1Label);  // state == 1
+        il.Emit(OpCodes.Beq, handlerTryStartLabel);  // state == 1
 
         // ========== STATE -1: Initial - await input promise ==========
 
@@ -239,6 +242,23 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Br, noCallbackLabel);
         il.MarkLabel(onFulfilledCallableLabel);
 
+        // ========== onFulfilled guard try ==========
+        // ECMA-262 §27.2.5.4: "input promise rejected" and "onFulfilled threw"
+        // are distinct — a throwing onFulfilled (or a rejecting thenable it
+        // returned) rejects the OUTPUT promise and must NOT dispatch to this
+        // same then's onRejected (which only handles rejection of the input
+        // promise). Guard the invocation + flatten await with a nested try
+        // whose catch rejects the builder task directly (#195).
+        var fulfillExceptionLocal = il.DeclareLocal(typeof(Exception));
+        il.BeginExceptionBlock();
+        il.MarkLabel(handlerTryStartLabel);
+
+        // Nested dispatch: state 1 (flatten await resume) re-enters here.
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, sm.StateField);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Beq, state1Label);
+
         // Invoke callback: result = InvokeCallback(onFulfilled, value)
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ldfld, sm.OnFulfilledField);
@@ -295,13 +315,28 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldflda, sm.FlattenAwaiterField);
         il.Emit(OpCodes.Call, awaiterType.GetMethod("GetResult")!);
         il.Emit(OpCodes.Stloc, resultLocal);
-        il.Emit(OpCodes.Br, setResultLabel);
+        il.Emit(OpCodes.Leave, setResultLabel);
 
         // ========== checkFlattenLabel: callback returned non-Task ==========
         il.MarkLabel(checkFlattenLabel);
         il.Emit(OpCodes.Ldloc, callbackResultLocal);
         il.Emit(OpCodes.Stloc, resultLocal);
-        il.Emit(OpCodes.Br, setResultLabel);
+        il.Emit(OpCodes.Leave, setResultLabel);
+
+        // onFulfilled threw (or its returned thenable rejected) — reject the
+        // output promise; deliberately bypasses the outer catch's onRejected
+        // dispatch.
+        il.BeginCatchBlock(typeof(Exception));
+        il.Emit(OpCodes.Stloc, fulfillExceptionLocal);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldc_I4, -2);
+        il.Emit(OpCodes.Stfld, sm.StateField);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldflda, sm.BuilderField);
+        il.Emit(OpCodes.Ldloc, fulfillExceptionLocal);
+        il.Emit(OpCodes.Call, sm.BuilderType.GetMethod("SetException")!);
+        il.Emit(OpCodes.Leave, returnLabel);
+        il.EndExceptionBlock();
 
         // ========== noCallbackLabel: no callback, use original value ==========
         il.MarkLabel(noCallbackLabel);

--- a/Compilation/RuntimeEmitter.TSNetSocket.cs
+++ b/Compilation/RuntimeEmitter.TSNetSocket.cs
@@ -569,8 +569,9 @@ public partial class RuntimeEmitter
             [_types.Object]
         );
 
-        // Also emit the static ConvertToWindowsPipeName helper
+        // Also emit the static ConvertToWindowsPipeName / WindowsPipeExists helpers
         var convertMethod = EmitConvertToWindowsPipeName(typeBuilder);
+        var pipeExistsMethod = EmitWindowsPipeExists(typeBuilder);
 
         var wil = worker.GetILGenerator();
 
@@ -625,6 +626,26 @@ public partial class RuntimeEmitter
             wil.Emit(OpCodes.Ldfld, _netSocketConnectHostField);
             wil.Emit(OpCodes.Call, convertMethod);
             wil.Emit(OpCodes.Stloc, pipeNameLocal);
+
+            // if (!WindowsPipeExists(pipeName))
+            //     throw new FileNotFoundException("no such named pipe '" + _connectHost + "'");
+            // Node raises ENOENT immediately for a missing pipe; the timed Connect below
+            // cannot distinguish "missing" from "busy" (it retries CreateFile until the
+            // timeout expires), so pre-check existence and keep the 5s budget for the
+            // exists-but-busy case only. FileNotFoundException maps to ENOENT in
+            // GetSocketErrorCode.
+            var pipeExists = wil.DefineLabel();
+            wil.Emit(OpCodes.Ldloc, pipeNameLocal);
+            wil.Emit(OpCodes.Call, pipeExistsMethod);
+            wil.Emit(OpCodes.Brtrue, pipeExists);
+            wil.Emit(OpCodes.Ldstr, "no such named pipe '");
+            wil.Emit(OpCodes.Ldarg_0);
+            wil.Emit(OpCodes.Ldfld, _netSocketConnectHostField);
+            wil.Emit(OpCodes.Ldstr, "'");
+            wil.Emit(OpCodes.Call, _types.String.GetMethod("Concat", [_types.String, _types.String, _types.String])!);
+            wil.Emit(OpCodes.Newobj, typeof(System.IO.FileNotFoundException).GetConstructor([_types.String])!);
+            wil.Emit(OpCodes.Throw);
+            wil.MarkLabel(pipeExists);
 
             // var pipeClient = new NamedPipeClientStream(".", pipeName, PipeDirection.InOut, PipeOptions.Asynchronous)
             var pipeLocal = wil.DeclareLocal(typeof(NamedPipeClientStream));
@@ -730,6 +751,58 @@ public partial class RuntimeEmitter
         // return Path.GetFileName(path)
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Call, typeof(System.IO.Path).GetMethod("GetFileName", [_types.String])!);
+        il.Emit(OpCodes.Ret);
+
+        return method;
+    }
+
+    /// <summary>
+    /// Emits: public static bool WindowsPipeExists(string pipeName)
+    /// Mirrors SharpTSSocket.WindowsPipeExists: enumerate \\.\pipe\ and compare full
+    /// entry paths case-insensitively (enumeration is the safe probe; CreateFile-based
+    /// checks can consume a pipe instance). Returns true on enumeration failure so the
+    /// connect timeout still governs.
+    /// </summary>
+    private MethodBuilder EmitWindowsPipeExists(TypeBuilder typeBuilder)
+    {
+        var method = typeBuilder.DefineMethod(
+            "WindowsPipeExists",
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.Boolean,
+            [_types.String]
+        );
+
+        var il = method.GetILGenerator();
+        var resultLocal = il.DeclareLocal(_types.Boolean);
+        var end = il.DefineLabel();
+
+        il.BeginExceptionBlock();
+
+        // result = Directory.GetFiles(@"\\.\pipe\")
+        //     .Contains(@"\\.\pipe\" + pipeName, StringComparer.OrdinalIgnoreCase)
+        il.Emit(OpCodes.Ldstr, @"\\.\pipe\");
+        il.Emit(OpCodes.Call, typeof(System.IO.Directory).GetMethod("GetFiles", [_types.String])!);
+        il.Emit(OpCodes.Ldstr, @"\\.\pipe\");
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Call, _types.String.GetMethod("Concat", [_types.String, _types.String])!);
+        il.Emit(OpCodes.Call, typeof(StringComparer).GetProperty("OrdinalIgnoreCase")!.GetGetMethod()!);
+        var containsWithComparer = typeof(System.Linq.Enumerable).GetMethods()
+            .Single(m => m.Name == "Contains" && m.GetParameters().Length == 3)
+            .MakeGenericMethod(_types.String);
+        il.Emit(OpCodes.Call, containsWithComparer);
+        il.Emit(OpCodes.Stloc, resultLocal);
+        il.Emit(OpCodes.Leave, end);
+
+        il.BeginCatchBlock(_types.Exception);
+        il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Stloc, resultLocal);
+        il.Emit(OpCodes.Leave, end);
+
+        il.EndExceptionBlock();
+
+        il.MarkLabel(end);
+        il.Emit(OpCodes.Ldloc, resultLocal);
         il.Emit(OpCodes.Ret);
 
         return method;

--- a/Compilation/StateMachineEmitHelpers.cs
+++ b/Compilation/StateMachineEmitHelpers.cs
@@ -110,8 +110,28 @@ public class StateMachineEmitHelpers
     {
         if (_stackType != StackType.Double)
         {
-            _il.Emit(OpCodes.Call, _types.GetMethod(_types.Convert, "ToDouble", [_types.Object]));
+            EmitToNumberCoercion();
             _stackType = StackType.Double;
+        }
+    }
+
+    /// <summary>
+    /// Emits boxed-object → double conversion. Prefers $Runtime.ConvertToNumber,
+    /// which implements ECMA-262 ToNumber (undefined→NaN, null→0, booleans,
+    /// hex/Infinity strings, ToPrimitive on objects) — Convert.ToDouble instead
+    /// throws InvalidCastException on $Undefined because it isn't IConvertible
+    /// (#190). Falls back to Convert.ToDouble for emit contexts where the
+    /// runtime helper isn't available.
+    /// </summary>
+    private void EmitToNumberCoercion()
+    {
+        if (_runtime != null)
+        {
+            _il.Emit(OpCodes.Call, _runtime.ConvertToNumber);
+        }
+        else
+        {
+            _il.Emit(OpCodes.Call, _types.GetMethod(_types.Convert, "ToDouble", [_types.Object]));
         }
     }
 
@@ -450,7 +470,7 @@ public class StateMachineEmitHelpers
 
     public void EmitConvertToDouble()
     {
-        _il.Emit(OpCodes.Call, _types.GetMethod(_types.Convert, "ToDouble", [_types.Object]));
+        EmitToNumberCoercion();
         _stackType = StackType.Double;
     }
 
@@ -643,7 +663,7 @@ public class StateMachineEmitHelpers
     {
         emitOperand();
         EnsureBoxed();
-        _il.Emit(OpCodes.Call, _types.GetMethod(_types.Convert, "ToDouble", [_types.Object]));
+        EmitToNumberCoercion();
         _il.Emit(OpCodes.Neg);
         _il.Emit(OpCodes.Box, _types.Double);
         SetStackUnknown();

--- a/Execution/Interpreter.Calls.cs
+++ b/Execution/Interpreter.Calls.cs
@@ -501,18 +501,18 @@ public partial class Interpreter
 
         return desc switch
         {
-            OperatorDescriptor.Plus when left is string || right is string =>
-                RuntimeValue.FromString(string.Concat(
-                    left as string ?? Stringify(left),
-                    right as string ?? Stringify(right))),
-            OperatorDescriptor.Plus => RuntimeValue.FromNumber((double)left! + (double)right!),
-            OperatorDescriptor.Arithmetic => RuntimeValue.FromNumber(EvaluateArithmetic(op.Type, (double)left!, (double)right!)),
-            OperatorDescriptor.Power => RuntimeValue.FromNumber(Math.Pow((double)left!, (double)right!)),
+            // EvaluatePlus handles string concat, object ToPrimitive concat, and
+            // numeric addition with ToNumber coercion (undefined→NaN, null→0,
+            // booleans→0/1) — a raw (double) cast crashed with
+            // InvalidCastException on any-typed undefined operands (#190).
+            OperatorDescriptor.Plus => RuntimeValue.FromBoxed(EvaluatePlus(left, right)),
+            OperatorDescriptor.Arithmetic => RuntimeValue.FromNumber(EvaluateArithmetic(op.Type, CoerceToNumber(left), CoerceToNumber(right))),
+            OperatorDescriptor.Power => RuntimeValue.FromNumber(Math.Pow(CoerceToNumber(left), CoerceToNumber(right))),
             // JS AbstractRelationalComparison: string vs string → lexicographic.
             OperatorDescriptor.Comparison =>
                 left is string ls && right is string rs
                     ? RuntimeValue.FromBoolean(EvaluateStringComparison(op.Type, ls, rs))
-                    : RuntimeValue.FromBoolean(EvaluateComparison(op.Type, (double)left!, (double)right!)),
+                    : RuntimeValue.FromBoolean(EvaluateComparison(op.Type, CoerceToNumber(left), CoerceToNumber(right))),
             OperatorDescriptor.Equality eq => RuntimeValue.FromBoolean(EvaluateEquality(left, right, eq.IsStrict, eq.IsNegated)),
             OperatorDescriptor.Bitwise or OperatorDescriptor.BitwiseShift =>
                 RuntimeValue.FromNumber(EvaluateBitwise(op.Type, ToInt32(left), ToInt32(right))),
@@ -543,14 +543,15 @@ public partial class Interpreter
         return desc switch
         {
             OperatorDescriptor.Plus => EvaluatePlus(left, right),
-            OperatorDescriptor.Arithmetic => EvaluateArithmetic(op.Type, (double)left!, (double)right!),
-            OperatorDescriptor.Power => Math.Pow((double)left!, (double)right!),
+            // ECMA-262 ToNumber coercion: undefined→NaN, null→0, booleans→0/1 (#190).
+            OperatorDescriptor.Arithmetic => EvaluateArithmetic(op.Type, CoerceToNumber(left), CoerceToNumber(right)),
+            OperatorDescriptor.Power => Math.Pow(CoerceToNumber(left), CoerceToNumber(right)),
             // JS AbstractRelationalComparison: if both are strings, compare
             // lexicographically; otherwise coerce to number.
             OperatorDescriptor.Comparison =>
                 left is string ls && right is string rs
                     ? EvaluateStringComparison(op.Type, ls, rs)
-                    : EvaluateComparison(op.Type, (double)left!, (double)right!),
+                    : EvaluateComparison(op.Type, CoerceToNumber(left), CoerceToNumber(right)),
             OperatorDescriptor.Equality eq => EvaluateEquality(left, right, eq.IsStrict, eq.IsNegated),
             OperatorDescriptor.Bitwise or OperatorDescriptor.BitwiseShift =>
                 EvaluateBitwise(op.Type, ToInt32(left), ToInt32(right)),
@@ -678,13 +679,13 @@ public partial class Interpreter
     /// Converts a boxed double to a 32-bit signed integer per ECMA-262 ToInt32.
     /// </summary>
     /// <seealso href="https://tc39.es/ecma262/#sec-toint32">ECMAScript ToInt32</seealso>
-    private static int ToInt32(object? value) => JsToInt32((double)value!);
+    private static int ToInt32(object? value) => JsToInt32(CoerceToNumber(value));
 
     /// <summary>
     /// Converts a boxed double to a 32-bit unsigned integer per ECMA-262 ToUint32.
     /// </summary>
     /// <seealso href="https://tc39.es/ecma262/#sec-touint32">ECMAScript ToUint32</seealso>
-    private static uint ToUint32(object? value) => JsToUint32((double)value!);
+    private static uint ToUint32(object? value) => JsToUint32(CoerceToNumber(value));
 
     // ECMA-262 ToInt32 / ToUint32 on a double. Unlike C#'s saturating (int) cast,
     // non-finite → 0 and out-of-range doubles wrap modulo 2^32. Mirrors JsToInt32 in

--- a/Execution/Interpreter.Expressions.cs
+++ b/Execution/Interpreter.Expressions.cs
@@ -675,8 +675,15 @@ public partial class Interpreter
     private async ValueTask<object?> EvaluateArrayCore(IEvaluationContext ctx, Expr.ArrayLiteral array)
     {
         var evaluated = new List<(bool isSpread, object? value)>();
-        foreach (var e in array.Elements)
+        for (int i = 0; i < array.Elements.Count; i++)
         {
+            // Elided positions ([1, , 3]) become true holes, not undefined elements.
+            if (array.IsHole(i))
+            {
+                evaluated.Add((false, ArrayHole.Instance));
+                continue;
+            }
+            var e = array.Elements[i];
             var isSpread = e is Expr.Spread;
             var value = (await ctx.EvaluateExprAsync(isSpread ? ((Expr.Spread)e).Expression : e)).ToObject();
             evaluated.Add((isSpread, value));
@@ -696,8 +703,15 @@ public partial class Interpreter
     private RuntimeValue EvaluateArray(Expr.ArrayLiteral array)
     {
         var evaluated = new List<(bool isSpread, object? value)>();
-        foreach (var e in array.Elements)
+        for (int i = 0; i < array.Elements.Count; i++)
         {
+            // Elided positions ([1, , 3]) become true holes, not undefined elements.
+            if (array.IsHole(i))
+            {
+                evaluated.Add((false, ArrayHole.Instance));
+                continue;
+            }
+            var e = array.Elements[i];
             var isSpread = e is Expr.Spread;
             var value = Evaluate(isSpread ? ((Expr.Spread)e).Expression : e);
             evaluated.Add((isSpread, value));

--- a/Execution/Interpreter.Operators.cs
+++ b/Execution/Interpreter.Operators.cs
@@ -237,8 +237,23 @@ public partial class Interpreter
                 left as string ?? Stringify(left),
                 right as string ?? Stringify(right));
         }
-        throw new InterpreterException("Operands must be two numbers or two strings.");
+        // ECMA-262 §13.15.3: with an object operand, ToPrimitive (default hint)
+        // yields a string for arrays/plain objects, so `+` concatenates.
+        if (IsObjectLike(left) || IsObjectLike(right))
+        {
+            return string.Concat(Stringify(left), Stringify(right));
+        }
+        // Both primitives, neither a string: numeric addition with ToNumber
+        // coercion (undefined→NaN, null→0, booleans→0/1) per #190.
+        return CoerceToNumber(left) + CoerceToNumber(right);
     }
+
+    /// <summary>
+    /// True for guest object values — anything that is not a JS primitive
+    /// (number, string, boolean, null, undefined, bigint, symbol).
+    /// </summary>
+    private static bool IsObjectLike(object? value) =>
+        value is not (null or double or string or bool or SharpTSUndefined or SharpTSBigInt or SharpTSSymbol);
 
     /// <summary>
     /// Evaluates a unary operator expression.
@@ -310,6 +325,12 @@ public partial class Interpreter
     /// strings parsed (empty/whitespace→0, otherwise NaN on parse failure).
     /// Numbers pass through unchanged.
     /// </summary>
+    /// <summary>
+    /// Boxed-value overload of <see cref="CoerceToNumber(RuntimeValue)"/> for the
+    /// legacy object?-based slow paths.
+    /// </summary>
+    private static double CoerceToNumber(object? value) => CoerceToNumber(RuntimeValue.FromBoxed(value));
+
     private static double CoerceToNumber(RuntimeValue rv)
     {
         if (rv.IsNumber) return rv.AsNumber();

--- a/Execution/Interpreter.cs
+++ b/Execution/Interpreter.cs
@@ -427,12 +427,10 @@ public partial class Interpreter : IDisposable
             _virtualTimerQueue.Enqueue(timer, fireTime);
             _hasScheduledTimers = true;
         }
-        // Wake the event loop if the timer fires soon (within 10ms)
-        // This ensures immediate timers (setTimeout(fn, 0)) are processed promptly
-        if (delayMs <= 10)
-        {
-            WakeEventLoop();
-        }
+        // Always wake the event loop: it may be blocked in a wait whose timeout was
+        // computed before this timer existed (up to 60s when the queue was empty), so a
+        // cross-thread schedule with any delay must force a timeout recomputation.
+        WakeEventLoop();
         return timer;
     }
 

--- a/Packaging/PackageJsonLoader.cs
+++ b/Packaging/PackageJsonLoader.cs
@@ -20,6 +20,12 @@ public static class PackageJsonLoader
     /// <param name="startDirectory">Directory to start searching from.</param>
     /// <param name="stopDirectory">Optional directory to stop searching at (exclusive). If specified, the search will not look in this directory or its parents.</param>
     /// <returns>Loaded PackageJson or null if not found.</returns>
+    /// <remarks>
+    /// The upward walk also stops (exclusive) at the system temp root and the
+    /// user profile root: a package.json sitting in those directories is ambient
+    /// noise from unrelated tooling, not the manifest of the project being
+    /// packed. Each ceiling is still searched when it IS the start directory.
+    /// </remarks>
     public static PackageJson? FindAndLoad(string startDirectory, string? stopDirectory = null)
     {
         var dir = new DirectoryInfo(startDirectory);
@@ -27,6 +33,16 @@ public static class PackageJsonLoader
             ? new DirectoryInfo(stopDirectory).FullName.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
             : null;
 
+        var ceilings = new[]
+            {
+                Path.GetTempPath(),
+                Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)
+            }
+            .Where(p => !string.IsNullOrEmpty(p))
+            .Select(p => Path.GetFullPath(p).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar))
+            .ToArray();
+
+        bool isStartDirectory = true;
         while (dir != null)
         {
             // Stop if we've reached the stop directory
@@ -37,11 +53,20 @@ public static class PackageJsonLoader
                 return null;
             }
 
+            // Stop when the walk ASCENDS into a ceiling directory; only search
+            // a ceiling when the caller started there.
+            if (!isStartDirectory &&
+                ceilings.Any(c => string.Equals(currentPath, c, StringComparison.OrdinalIgnoreCase)))
+            {
+                return null;
+            }
+
             var packageJsonPath = Path.Combine(dir.FullName, "package.json");
             if (File.Exists(packageJsonPath))
             {
                 return Load(packageJsonPath);
             }
+            isStartDirectory = false;
             dir = dir.Parent;
         }
 

--- a/Parsing/AST.cs
+++ b/Parsing/AST.cs
@@ -123,7 +123,16 @@ public abstract record Expr
     /// Callee can be a Variable (class name), Get (namespace path), or any expression.
     /// </summary>
     public record New(Expr Callee, List<string>? TypeArgs, List<Expr> Arguments) : Expr;
-    public record ArrayLiteral(List<Expr> Elements) : Expr;
+    /// <summary>
+    /// Array literal. Elided positions ([1, , 3]) carry an undefined literal in
+    /// Elements (so the type checker and destructuring see a uniform shape) plus
+    /// their index in HoleIndices so evaluation/emission can produce a true
+    /// ECMA-262 hole instead of an undefined element.
+    /// </summary>
+    public record ArrayLiteral(List<Expr> Elements, IReadOnlySet<int>? HoleIndices = null) : Expr
+    {
+        public bool IsHole(int index) => HoleIndices?.Contains(index) == true;
+    }
     public record ObjectLiteral(List<Property> Properties) : Expr
     {
         /// <summary>

--- a/Parsing/Parser.Expressions.cs
+++ b/Parsing/Parser.Expressions.cs
@@ -750,14 +750,17 @@ public partial class Parser
         if (Match(TokenType.LEFT_BRACKET))
         {
             List<Expr> elements = [];
+            HashSet<int>? holeIndices = null;
             // Array literal supports holes (elisions): [,,1] or [,-0].
             // Leading/interior commas without a preceding element produce
-            // `undefined` holes; a trailing comma does not.
+            // holes (undefined literal + index in HoleIndices); a trailing
+            // comma does not.
             while (!Check(TokenType.RIGHT_BRACKET))
             {
                 if (Match(TokenType.COMMA))
                 {
-                    // Elided slot before anything — push undefined.
+                    // Elided slot before anything — record a hole.
+                    (holeIndices ??= []).Add(elements.Count);
                     elements.Add(new Expr.Literal(SharpTS.Runtime.Types.SharpTSUndefined.Instance));
                     continue;
                 }
@@ -775,7 +778,7 @@ public partial class Parser
                 if (!Match(TokenType.COMMA)) break;
             }
             Consume(TokenType.RIGHT_BRACKET, "Expect ']' after array elements.");
-            return new Expr.ArrayLiteral(elements);
+            return new Expr.ArrayLiteral(elements, holeIndices);
         }
 
         if (Match(TokenType.LEFT_BRACE))

--- a/Runtime/BuiltIns/PromiseBuiltIns.cs
+++ b/Runtime/BuiltIns/PromiseBuiltIns.cs
@@ -253,12 +253,14 @@ public static class PromiseBuiltIns
             throw new Exception("Runtime Error: Promise.race requires an array argument.");
         }
 
-        // Empty array never settles - return a promise that never resolves
+        // Empty array never settles — there are no competitors to race.
+        // BuiltInAsyncMethod wraps this method's Task in the promise it hands
+        // to the guest, so returning a SharpTSPromise here would settle that
+        // outer promise immediately WITH a promise object (#196). Await a task
+        // that never completes instead so the outer promise stays pending.
         if (array.Length == 0)
         {
-            // Create a TaskCompletionSource that never completes
-            var neverCompletingTcs = new TaskCompletionSource<object?>();
-            return new SharpTSPromise(neverCompletingTcs.Task);
+            return await new TaskCompletionSource<object?>().Task;
         }
 
         var tasks = new List<Task<object?>>();

--- a/Runtime/BuiltIns/PromiseBuiltIns.cs
+++ b/Runtime/BuiltIns/PromiseBuiltIns.cs
@@ -76,28 +76,21 @@ public static class PromiseBuiltIns
         var onFulfilled = args.Count > 0 ? args[0] as ISharpTSCallable : null;
         var onRejected = args.Count > 1 ? args[1] as ISharpTSCallable : null;
 
+        // ECMA-262 §27.2.5.4: onRejected only handles rejection of the INPUT
+        // promise. Guard only the input await with the rejection dispatch —
+        // a throwing onFulfilled (or a rejecting thenable it returned) must
+        // reject the output promise, not invoke this same then's onRejected
+        // (#195). Handler invocation happens after this try.
+        object? value;
         try
         {
-            // Wait for the promise to settle
-            var value = await promise.GetValueAsync();
-
-            // If fulfilled, call onFulfilled callback
-            if (onFulfilled != null)
-            {
-                var result = CallCallback(onFulfilled, [value], interpreter);
-                return await UnwrapResult(result);
-            }
-
-            // No onFulfilled callback - pass through value
-            return value;
+            value = await promise.GetValueAsync();
         }
         catch (SharpTSPromiseRejectedException ex)
         {
-            // If rejected, call onRejected callback
             if (onRejected != null)
             {
-                var result = CallCallback(onRejected, [ex.Reason], interpreter);
-                return await UnwrapResult(result);
+                return await InvokeHandler(onRejected, ex.Reason, interpreter);
             }
 
             // No onRejected callback - re-throw to propagate rejection
@@ -105,13 +98,40 @@ public static class PromiseBuiltIns
         }
         catch (AggregateException aggEx) when (aggEx.InnerException is SharpTSPromiseRejectedException rejEx)
         {
-            // Handle wrapped rejection exception
             if (onRejected != null)
             {
-                var result = CallCallback(onRejected, [rejEx.Reason], interpreter);
-                return await UnwrapResult(result);
+                return await InvokeHandler(onRejected, rejEx.Reason, interpreter);
             }
             throw rejEx;
+        }
+
+        // Fulfilled: call onFulfilled (its throw rejects the output promise)
+        if (onFulfilled != null)
+        {
+            return await InvokeHandler(onFulfilled, value, interpreter);
+        }
+
+        // No onFulfilled callback - pass through value
+        return value;
+    }
+
+    /// <summary>
+    /// Invokes a then/catch reaction handler. A throwing handler rejects the
+    /// output promise with the thrown value (ECMA-262 §27.2.5.4) instead of
+    /// letting the guest ThrowException fault the task as a host error.
+    /// A rejected promise returned by the handler propagates unchanged.
+    /// </summary>
+    private static async Task<object?> InvokeHandler(
+        ISharpTSCallable handler, object? arg, Interpreter interpreter)
+    {
+        try
+        {
+            var result = CallCallback(handler, [arg], interpreter);
+            return await UnwrapResult(result);
+        }
+        catch (Exceptions.ThrowException tex)
+        {
+            throw new SharpTSPromiseRejectedException(tex.Value);
         }
     }
 
@@ -135,8 +155,7 @@ public static class PromiseBuiltIns
         {
             if (onRejected != null)
             {
-                var result = CallCallback(onRejected, [ex.Reason], interpreter);
-                return await UnwrapResult(result);
+                return await InvokeHandler(onRejected, ex.Reason, interpreter);
             }
             throw;
         }
@@ -144,8 +163,7 @@ public static class PromiseBuiltIns
         {
             if (onRejected != null)
             {
-                var result = CallCallback(onRejected, [rejEx.Reason], interpreter);
-                return await UnwrapResult(result);
+                return await InvokeHandler(onRejected, rejEx.Reason, interpreter);
             }
             throw rejEx;
         }

--- a/Runtime/Types/SharpTSSocket.cs
+++ b/Runtime/Types/SharpTSSocket.cs
@@ -210,9 +210,13 @@ public class SharpTSSocket : SharpTSEventEmitter
                 if (OperatingSystem.IsWindows())
                 {
                     var pipeName = ConvertToWindowsPipeName(path);
+                    // Node raises ENOENT immediately for a missing pipe. NamedPipeClientStream's
+                    // timed Connect cannot distinguish "missing" from "busy" — it retries
+                    // CreateFile until the timeout expires — so pre-check existence and keep
+                    // the 5s budget only for the exists-but-busy case it is actually for.
+                    if (!WindowsPipeExists(pipeName))
+                        throw new FileNotFoundException($"no such named pipe '{path}'");
                     var pipeClient = new NamedPipeClientStream(".", pipeName, PipeDirection.InOut, PipeOptions.Asynchronous);
-                    // Use timeout to avoid blocking forever if no server is listening.
-                    // Node.js throws ENOENT for missing pipes; 5s matches typical socket timeouts.
                     await pipeClient.ConnectAsync(5000);
                     _stream = pipeClient;
                 }
@@ -272,6 +276,30 @@ public class SharpTSSocket : SharpTSEventEmitter
             : $"{code}: {ex.Message}, {syscall}";
 
         return new SharpTSError(msg) { Code = code, Syscall = syscall };
+    }
+
+    /// <summary>
+    /// Checks whether a Windows named pipe currently exists. Enumerating the pipe
+    /// directory is the safe probe — CreateFile-based checks (File.Exists) can
+    /// consume a pipe instance or interfere with WaitNamedPipe semantics.
+    /// Returns true on enumeration failure so the connect timeout still governs.
+    /// </summary>
+    internal static bool WindowsPipeExists(string pipeName)
+    {
+        try
+        {
+            var fullPath = @"\\.\pipe\" + pipeName;
+            foreach (var entry in Directory.EnumerateFiles(@"\\.\pipe\"))
+            {
+                if (string.Equals(entry, fullPath, StringComparison.OrdinalIgnoreCase))
+                    return true;
+            }
+            return false;
+        }
+        catch
+        {
+            return true;
+        }
     }
 
     /// <summary>

--- a/SharpTS.Test262/BatchedSubprocessRunner.cs
+++ b/SharpTS.Test262/BatchedSubprocessRunner.cs
@@ -151,17 +151,18 @@ public sealed class BatchedSubprocessRunner
             int id = slotIndex;
             slotTasks[slotIndex] = Task.Run(() =>
             {
+                int spawnIndex = 0;
                 while (true)
                 {
                     if (!workQueue.TryPeek(out _)) return; // queue empty → slot done
-                    var worker = new PersistentWorker(BuildWorkerArgs(), workQueue, OnResult, IdleResultBudget, id);
+                    var worker = new PersistentWorker(BuildWorkerArgs(), workQueue, OnResult, IdleResultBudget, id, spawnIndex++);
                     slotDisposables.Add(worker);
                     worker.Start();
                     worker.WaitForCompletion();
                     // Worker exited (memory ceiling, watchdog, crash, or queue
                     // drained). Loop checks queue and respawns if more work
-                    // remains. The new worker reuses the same slot id for
-                    // trace-file naming continuity.
+                    // remains. The new worker reuses the same slot id; the spawn
+                    // index keeps trace files unique across respawns.
                 }
             });
         }
@@ -304,15 +305,18 @@ public sealed class BatchedSubprocessRunner
         private bool _doneSeen;
 
         public PersistentWorker(string[] args, ConcurrentQueue<string> queue,
-            Action<string, string> onResult, TimeSpan idleBudget, int id)
+            Action<string, string> onResult, TimeSpan idleBudget, int id, int spawnIndex = 0)
         {
             _queue = queue;
             _onResult = onResult;
             _idleBudget = idleBudget;
             _id = id;
+            // Trace file is unique per spawn, not per slot: the previous worker's
+            // parent-side StreamWriter stays open until RunAll's finally block, so a
+            // respawn reopening worker_{id}.log would hit a sharing violation.
             _trace = new WorkerTrace(TraceDir is null
                 ? null
-                : Path.Combine(TraceDir, $"worker_{id:D2}.log"));
+                : Path.Combine(TraceDir, $"worker_{id:D2}_{spawnIndex}.log"));
 
             var psi = new ProcessStartInfo("dotnet")
             {
@@ -326,7 +330,7 @@ public sealed class BatchedSubprocessRunner
             // subprocess can also log into our trace dir.
             if (TraceDir is not null)
                 psi.Environment["SHARPTS_TEST262_WORKER_TRACE"] =
-                    Path.Combine(TraceDir, $"worker_{id:D2}_subprocess.log");
+                    Path.Combine(TraceDir, $"worker_{id:D2}_{spawnIndex}_subprocess.log");
             _proc = Process.Start(psi)
                 ?? throw new InvalidOperationException("failed to start Test262 worker");
             _trace.Log("spawned PID={0}", _proc.Id);

--- a/TypeSystem/TypeChecker.Operators.cs
+++ b/TypeSystem/TypeChecker.Operators.cs
@@ -552,6 +552,10 @@ public partial class TypeChecker
             return new TypeInfo.Undefined();
         if (unary.Operator.Type == TokenType.MINUS)
         {
+            // tsc types -x as number when x is any; IsBigInt(any) is true via
+            // IsTypeOfKind, which would mis-type -x as bigint and make any
+            // enclosing binary expression take the bigint emit path (#190).
+            if (right is TypeInfo.Any) return new TypeInfo.Primitive(TokenType.TYPE_NUMBER);
             if (IsBigInt(right)) return new TypeInfo.BigInt();
             if (IsNumber(right)) return new TypeInfo.Primitive(TokenType.TYPE_NUMBER);
             throw new TypeCheckException("Unary '-' expects a number or bigint.", tsCode: "TS2362");
@@ -560,6 +564,8 @@ public partial class TypeChecker
              return new TypeInfo.Primitive(TokenType.TYPE_BOOLEAN);
         if (unary.Operator.Type == TokenType.TILDE)
         {
+            // Same any→number rule as unary minus above.
+            if (right is TypeInfo.Any) return new TypeInfo.Primitive(TokenType.TYPE_NUMBER);
             if (IsBigInt(right)) return new TypeInfo.BigInt();
             if (IsNumber(right)) return new TypeInfo.Primitive(TokenType.TYPE_NUMBER);
             throw new TypeCheckException("Bitwise NOT requires a numeric operand.", tsCode: "TS2362");


### PR DESCRIPTION
Fixes #190, fixes #191, fixes #192, fixes #193, fixes #194, fixes #195, fixes #196, fixes #197, fixes #199.

One commit per bug, in dependency-friendly order:

## Semantics (both modes)

- **#190 — arithmetic on undefined → NaN.** Interpreter binary slow paths now use ECMA-262 ToNumber coercion instead of raw `(double)` casts; compiled `EnsureDouble`/unary/increment emitters call `$Runtime.ConvertToNumber` instead of `Convert.ToDouble` (which threw on `$Undefined` and crashed the process). `ConvertToNumber` gained an `IConvertible` fallback so boxed non-double numerics from `@DotNetType` interop keep converting. Bonus: the type checker typed `-x`/`~x` on `any` as bigint (`IsBigInt(any)` is true via `IsTypeOfKind`), which made any enclosing binary fail at compile time — now typed `number` per tsc.
- **#191 — `[1, , 3]` creates true holes.** `ArrayLiteral` records elided indices (elements keep the undefined literal so type checking and destructuring are untouched); the interpreter stores `ArrayHole.Instance` and the IL emitters load `$ArrayHole.Instance`, in both simple and spread paths. `1 in a` is now false; map/forEach skip; map preserves the hole.
- **#196 — `Promise.race([])` stays forever pending.** Interp: the never-settling promise was being returned as the task *result*, settling the outer promise with a promise object; now awaits a never-completing TCS. Compiled: the empty-list branch called `SetResult(null)`; now routes a never-completing task through the winning-task await. `all([])`/`allSettled([])`/`any([])` verified correct in both modes.
- **#195 (part 1) — throwing onFulfilled rejects the output promise.** Compiled `$PromiseThen_SM` guarded input `GetResult` and the handler invocation with one try, conflating "input rejected" with "handler threw"; the handler + flatten await now sit in a nested guard try whose catch rejects the builder task (state-1 resume re-enters via first-instruction dispatch, the Roslyn await-inside-try shape). The interpreter had the same conflation for rejecting thenables and faulted the task on handler throws; both fixed. SpeciesConstructor lookup (part 2) is intentionally deferred per the issue, now that `then` is restructured.

## Perf / latency

- **#192 — missing named pipe → immediate ENOENT.** Pre-check existence by enumerating `\\.\pipe\` (safe probe) in both the interpreted socket and the compiled `$NetSocket` emitter; the 5s `Connect` budget now only covers exists-but-busy. `IpcSocket_ConnectErrorCode` drops from ~5-6s to ms.
- **#193 — compiled `fs.watchFile` honors `{ interval }`.** Option extraction handled only `$IHasFields`; compiled object literals are `Dictionary<string, object?>`. Now handles both (mirrors `EmitExtractBooleanOption`). 6.7s → sub-second.
- **#194 — cross-thread timers wake the event loop.** Dropped the `delayMs <= 10` wake heuristic; a blocked `TryTake` could otherwise sleep up to 60s past a new timer''s due time.

## Harness / tests

- **#197 — traced Test262 regens survive worker recycle.** Trace files are now `worker_{id}_{spawnIndex}.log`; the recycled slot no longer reopens a file whose writer is still live.
- **#199 — Pack_WithoutPackageJson tests.** Root cause was environmental, not a regression: `--pack`''s package.json discovery walked to the filesystem root and adopted stray manifests (npm scratch in `%TEMP%`, `{}` in the user profile). The walk now stops at the temp/profile roots (still searched when they are the start directory). All 106 packaging tests pass locally now.

## Validation

- Full suite: **10,517 passed, 0 failed** (previously 10,484 with 2 local packaging failures). Suite wall time dropped 13m18s → 1m6s from the intrinsic-wait fixes.
- Each semantic fix verified against Node behavior with repro scripts in both interpreted and compiled modes.

Noticed in passing (not fixed here): compiled `Promise.any([])` rejects with `name === "Exception"` instead of `AggregateError`.