### PR TITLE
fix(dns): retry SERVFAIL/REFUSED responses like socket errors

### DIFF
--- a/Compilation/RuntimeEmitter.Dns.cs
+++ b/Compilation/RuntimeEmitter.Dns.cs
@@ -2069,17 +2069,55 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Brfalse, noTcCheckLabel);
 
         // TCP fallback: result = DnsSendViaTcp(query, server)
+        var rcodeCheckLabel = il.DefineLabel();
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ldloc, serverLocal);
         il.Emit(OpCodes.Call, runtime.DnsSendViaTcp);
         il.Emit(OpCodes.Stloc, resultLocal);
-        il.Emit(OpCodes.Leave, returnLabel);
+        il.Emit(OpCodes.Br, rcodeCheckLabel);
 
         il.MarkLabel(noTcCheckLabel);
 
         // No truncation: result = response
         il.Emit(OpCodes.Ldloc, responseLocal);
         il.Emit(OpCodes.Stloc, resultLocal);
+
+        // SERVFAIL/REFUSED are usually transient resolver conditions — retry
+        // them like socket errors (mirrors DnsWireProtocol.SendReceive). On the
+        // last attempt the response is returned so parsing surfaces the error.
+        // if (attempt < 2 && result.Length >= 4 && ((result[3] & 0x0F) == 2 || (result[3] & 0x0F) == 5)) continue;
+        il.MarkLabel(rcodeCheckLabel);
+        var acceptResponseLabel = il.DefineLabel();
+        var retryRcodeLabel = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, attemptLocal);
+        il.Emit(OpCodes.Ldc_I4_2);
+        il.Emit(OpCodes.Bge, acceptResponseLabel);
+
+        il.Emit(OpCodes.Ldloc, resultLocal);
+        il.Emit(OpCodes.Ldlen);
+        il.Emit(OpCodes.Conv_I4);
+        il.Emit(OpCodes.Ldc_I4_4);
+        il.Emit(OpCodes.Blt, acceptResponseLabel);
+
+        var rcodeLocal = il.DeclareLocal(_types.Int32);
+        il.Emit(OpCodes.Ldloc, resultLocal);
+        il.Emit(OpCodes.Ldc_I4_3);
+        il.Emit(OpCodes.Ldelem_U1);
+        il.Emit(OpCodes.Ldc_I4, 0x0F);
+        il.Emit(OpCodes.And);
+        il.Emit(OpCodes.Stloc, rcodeLocal);
+
+        il.Emit(OpCodes.Ldloc, rcodeLocal);
+        il.Emit(OpCodes.Ldc_I4_2);
+        il.Emit(OpCodes.Beq, retryRcodeLabel);
+        il.Emit(OpCodes.Ldloc, rcodeLocal);
+        il.Emit(OpCodes.Ldc_I4_5);
+        il.Emit(OpCodes.Bne_Un, acceptResponseLabel);
+
+        il.MarkLabel(retryRcodeLabel);
+        il.Emit(OpCodes.Leave, retryIncrement);
+
+        il.MarkLabel(acceptResponseLabel);
         il.Emit(OpCodes.Leave, returnLabel);
 
         // catch (SocketException) when (attempt < MaxRetries)

--- a/Runtime/BuiltIns/Modules/DnsWireProtocol.cs
+++ b/Runtime/BuiltIns/Modules/DnsWireProtocol.cs
@@ -179,7 +179,16 @@ public static class DnsWireProtocol
                 if (response.Length >= 3 && (response[2] & 0x02) != 0)
                 {
                     // Retry with TCP
-                    return SendViaTcp(query, endpoint);
+                    response = SendViaTcp(query, endpoint);
+                }
+
+                // SERVFAIL/REFUSED are usually transient resolver conditions —
+                // retry them like socket errors. On the last attempt the response
+                // is returned so ParseResponse surfaces ESERVFAIL/EREFUSED.
+                if (attempt < MaxRetries && response.Length >= 4
+                    && (response[3] & 0x0F) is 2 or 5)
+                {
+                    continue;
                 }
 
                 return response;

--- a/SharpTS.Tests/RuntimeTests/DnsWireProtocolRetryTests.cs
+++ b/SharpTS.Tests/RuntimeTests/DnsWireProtocolRetryTests.cs
@@ -66,19 +66,23 @@ public class DnsWireProtocolRetryTests
         public string Address { get; }
         public int QueryCount => Volatile.Read(ref _queryCount);
 
-        private void ServeLoop()
+        // Async receive only: on macOS, Dispose does not unblock a thread in a
+        // synchronous Receive (see the SendReceive timeout comment in
+        // DnsWireProtocol.cs) — a sync loop here deadlocks the testhost there.
+        // Closing the socket does complete a pending async receive on all OSes.
+        private async Task ServeLoop()
         {
             try
             {
                 while (true)
                 {
-                    IPEndPoint? remote = null;
-                    var request = _udp.Receive(ref remote!);
+                    var query = await _udp.ReceiveAsync().ConfigureAwait(false);
                     var count = Interlocked.Increment(ref _queryCount);
                     var response = count <= _errorCount
-                        ? BuildErrorResponse(request, _errorRcode)
-                        : BuildTxtResponse(request);
-                    _udp.Send(response, response.Length, remote);
+                        ? BuildErrorResponse(query.Buffer, _errorRcode)
+                        : BuildTxtResponse(query.Buffer);
+                    await _udp.SendAsync(response, response.Length, query.RemoteEndPoint)
+                        .ConfigureAwait(false);
                 }
             }
             catch (ObjectDisposedException) { }

--- a/SharpTS.Tests/RuntimeTests/DnsWireProtocolRetryTests.cs
+++ b/SharpTS.Tests/RuntimeTests/DnsWireProtocolRetryTests.cs
@@ -1,0 +1,121 @@
+using System.Net;
+using System.Net.Sockets;
+using SharpTS.Runtime.BuiltIns.Modules;
+using Xunit;
+
+namespace SharpTS.Tests.RuntimeTests;
+
+/// <summary>
+/// Tests DnsWireProtocol retry behavior against a local fake DNS server.
+/// SERVFAIL/REFUSED responses are transient resolver conditions and must be
+/// retried like socket errors before surfacing an error.
+/// </summary>
+public class DnsWireProtocolRetryTests
+{
+    private const byte Servfail = 2;
+    private const byte Refused = 5;
+
+    [Theory]
+    [InlineData(Servfail)]
+    [InlineData(Refused)]
+    public void Query_TransientErrorThenSuccess_Retries(byte rcode)
+    {
+        using var server = new FakeDnsServer(rcode, errorCount: 1);
+
+        var result = DnsWireProtocol.Query("example.com", DnsWireProtocol.TypeTXT, server.Address);
+
+        var records = Assert.IsType<List<object?>>(result);
+        var record = Assert.IsType<List<object?>>(Assert.Single(records));
+        Assert.Equal("hello", Assert.Single(record));
+        Assert.Equal(2, server.QueryCount);
+    }
+
+    [Fact]
+    public void Query_PersistentServfail_ThrowsEservfailAfterRetries()
+    {
+        using var server = new FakeDnsServer(Servfail, errorCount: int.MaxValue);
+
+        var ex = Assert.Throws<Exception>(() =>
+            DnsWireProtocol.Query("example.com", DnsWireProtocol.TypeTXT, server.Address));
+
+        Assert.Contains("ESERVFAIL", ex.Message);
+        Assert.Equal(3, server.QueryCount); // initial attempt + MaxRetries (2)
+    }
+
+    /// <summary>
+    /// Minimal loopback DNS server: answers the first <c>errorCount</c> queries
+    /// with the given error rcode, then with a one-record TXT answer ("hello").
+    /// </summary>
+    private sealed class FakeDnsServer : IDisposable
+    {
+        private readonly UdpClient _udp;
+        private readonly byte _errorRcode;
+        private readonly int _errorCount;
+        private int _queryCount;
+
+        public FakeDnsServer(byte errorRcode, int errorCount)
+        {
+            _errorRcode = errorRcode;
+            _errorCount = errorCount;
+            _udp = new UdpClient(new IPEndPoint(IPAddress.Loopback, 0));
+            var port = ((IPEndPoint)_udp.Client.LocalEndPoint!).Port;
+            Address = $"127.0.0.1:{port}";
+            Task.Run(ServeLoop);
+        }
+
+        public string Address { get; }
+        public int QueryCount => Volatile.Read(ref _queryCount);
+
+        private void ServeLoop()
+        {
+            try
+            {
+                while (true)
+                {
+                    IPEndPoint? remote = null;
+                    var request = _udp.Receive(ref remote!);
+                    var count = Interlocked.Increment(ref _queryCount);
+                    var response = count <= _errorCount
+                        ? BuildErrorResponse(request, _errorRcode)
+                        : BuildTxtResponse(request);
+                    _udp.Send(response, response.Length, remote);
+                }
+            }
+            catch (ObjectDisposedException) { }
+            catch (SocketException) { }
+        }
+
+        private static byte[] BuildErrorResponse(byte[] request, byte rcode)
+        {
+            var response = (byte[])request.Clone(); // header + question echo
+            response[2] = 0x81; // QR=1, RD=1
+            response[3] = rcode;
+            return response;
+        }
+
+        private static byte[] BuildTxtResponse(byte[] request)
+        {
+            var response = new List<byte>(request); // echo header + question
+            response[2] = 0x81; // QR=1, RD=1
+            response[3] = 0x80; // RA=1, rcode=0
+            response[7] = 1;    // ANCOUNT = 1
+
+            // Answer NAME: uncompressed copy of the question name
+            var nameEnd = 12;
+            while (request[nameEnd] != 0)
+                nameEnd += request[nameEnd] + 1;
+            for (var i = 12; i <= nameEnd; i++)
+                response.Add(request[i]);
+
+            response.AddRange(new byte[] { 0x00, 0x10 }); // TYPE = TXT
+            response.AddRange(new byte[] { 0x00, 0x01 }); // CLASS = IN
+            response.AddRange(new byte[] { 0x00, 0x00, 0x00, 0x3C }); // TTL = 60
+            response.AddRange(new byte[] { 0x00, 0x06 }); // RDLENGTH
+            response.Add(0x05); // TXT string length
+            response.AddRange("hello"u8.ToArray());
+            return response.ToArray();
+        }
+
+        public void Dispose() => _udp.Dispose();
+    }
+}


### PR DESCRIPTION
## Summary

A transient SERVFAIL from the upstream resolver previously failed a DNS query instantly: `SendReceive` only retried `SocketException`, and the RCODE check lived in `ParseResponse` — after the retry loop had already returned. One transient resolver hiccup meant immediate failure, which is the root cause of the macOS CI flake on #218 (`ResolveSoa_Promise_ReturnsObject` failed in 290ms with empty output — a fast RCODE error, not a timeout).

## Changes

- **`DnsWireProtocol.SendReceive`**: after receiving a response (UDP or TCP-truncation fallback), check the RCODE byte; SERVFAIL (2) and REFUSED (5) now retry like socket errors, up to `MaxRetries`. On the final attempt the response is returned untouched so `ParseResponse` still surfaces the proper `ESERVFAIL`/`EREFUSED` error. Covers the interpreter and compiled-mode `dns.Resolver` (late-binds to this C#).
- **`RuntimeEmitter.Dns.cs` (`EmitDnsSendReceiveMethod`)**: same check mirrored into the emitted IL used by compiled programs'' plain `dns.resolve*` calls — both the TCP-fallback and UDP paths funnel through a shared rcode check that branches back into the retry loop.

NXDOMAIN/NOTIMP are deliberately **not** retried — those are authoritative answers; retrying would just add latency to legitimate "not found" results.

## Tests

- New `DnsWireProtocolRetryTests` with a loopback fake DNS server (`Query` accepts `127.0.0.1:port`):
  - SERVFAIL-then-success and REFUSED-then-success each succeed in exactly 2 queries
  - persistent SERVFAIL still throws `ESERVFAIL` after exactly 3 attempts (initial + `MaxRetries`)
- All 92 dns tests pass in interpreted and compiled modes (compiled tests JIT the modified emitted method)
- ILVerify passes on a compiled dns program (`--compile --verify`)