### PR TITLE
ci: register macOS runner hostname in /etc/hosts to skip 5s mDNS timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,9 +33,14 @@ jobs:
       # HttpListener's Prefixes.Add (Kerberos SPN setup) burns mDNSResponder's
       # full 5s timeout for every guest program that calls http server.listen().
       # Resolving it from /etc/hosts short-circuits that — saves ~2min of test time.
+      # Both address families are required: with only the 127.0.0.1 entry, the
+      # AAAA half of the dual-stack lookup still goes to mDNS and waits out the
+      # same 5s (measured on macos-latest: A-only 5053ms, A+AAAA 10ms).
       - name: Register hostname in /etc/hosts (macOS mDNS workaround)
         if: runner.os == 'macOS'
-        run: echo "127.0.0.1 $(hostname)" | sudo tee -a /etc/hosts
+        run: |
+          echo "127.0.0.1 $(hostname)" | sudo tee -a /etc/hosts
+          echo "::1 $(hostname)" | sudo tee -a /etc/hosts
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # The runner's hostname is an mDNS-only `.local` name that nothing on the
+      # network answers for, so the Dns.GetHostEntry call inside the managed
+      # HttpListener's Prefixes.Add (Kerberos SPN setup) burns mDNSResponder's
+      # full 5s timeout for every guest program that calls http server.listen().
+      # Resolving it from /etc/hosts short-circuits that — saves ~2min of test time.
+      - name: Register hostname in /etc/hosts (macOS mDNS workaround)
+        if: runner.os == 'macOS'
+        run: echo "127.0.0.1 $(hostname)" | sudo tee -a /etc/hosts
+
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:


### PR DESCRIPTION
## Why

The macOS CI job's Test step runs ~2x slower than Ubuntu/Windows (5m13s vs 2m28s on PR #219's run). A timing probe on macos-latest isolated the cause:

- Every guest program that calls http `server.listen()` pays exactly ~5.0s, in both interpreted and compiled modes, even with zero requests — all 22 `HttpEventTests` hit it (~110s of the ~165s gap).
- The cost is in .NET's managed `HttpListener`: `Prefixes.Add` → `ServiceNameStore` (Kerberos SPN setup) → `Dns.GetHostEntry` for the machine's own hostname. Measured: `Prefixes.Add` 5018ms, `Start`/`Stop`/raw socket bind+listen all ≤3ms, `Dns.GetHostEntry(hostname)` 5002ms.
- GitHub macOS runners have mDNS-only hostnames (e.g. `sat12-…-02E63FF01E26.local`). `.local` names never go to ordinary DNS — macOS multicasts via mDNSResponder, nothing on the runner network answers, and the query waits out the full ~5s timeout. The lookup then *succeeds* via fallback, so nothing ever errored — tests just ran 5s late, once per listener.

Ubuntu doesn't hit this because its hostname is already in `/etc/hosts`; Windows uses the http.sys-backed `HttpListener`, which doesn't run this code path.

## Fix

Append `127.0.0.1 $(hostname)` to `/etc/hosts` on the macOS job before tests. `getaddrinfo` consults the hosts file before mDNS, so the lookup short-circuits instantly. The resolved address is only used to build SPN strings (never to bind/connect), so 127.0.0.1 is safe.

Expected effect: macOS Test step drops by roughly 2 minutes, in line with the other OSes. The residual gap is the live-DNS `DnsRecordTypeTests` (#225).