### PR TITLE
Bugfix batch: #205-#212, #214-#216 (V2-migration follow-up bugs)

### DIFF
--- a/Compilation/EmittedRuntime.cs
+++ b/Compilation/EmittedRuntime.cs
@@ -1045,6 +1045,11 @@ public class EmittedRuntime
     public MethodBuilder RegExpGetGlobal { get; set; } = null!;
     public MethodBuilder RegExpGetIgnoreCase { get; set; } = null!;
     public MethodBuilder RegExpGetMultiline { get; set; } = null!;
+    public MethodBuilder RegExpGetSticky { get; set; } = null!;
+    public MethodBuilder RegExpGetUnicode { get; set; } = null!;
+    public MethodBuilder RegExpGetDotAll { get; set; } = null!;
+    public MethodBuilder RegExpGetHasIndices { get; set; } = null!;
+    public MethodBuilder RegExpGetUnicodeSets { get; set; } = null!;
     public MethodBuilder RegExpGetLastIndex { get; set; } = null!;
     public MethodBuilder RegExpSetLastIndex { get; set; } = null!;
     public MethodBuilder StringMatchRegExp { get; set; } = null!;

--- a/Compilation/Emitters/Modules/NetModuleEmitter.cs
+++ b/Compilation/Emitters/Modules/NetModuleEmitter.cs
@@ -76,29 +76,22 @@ public sealed class NetModuleEmitter : IBuiltInModuleEmitter
         var ctx = emitter.Context;
         var il = ctx.IL;
 
-        // Emit options/port argument
-        if (arguments.Count > 0)
+        // Node signature: connect(options|port|path[, host][, connectListener]).
+        // Emit up to three positional args; missing ones are null.
+        for (int i = 0; i < 3; i++)
         {
-            emitter.EmitExpression(arguments[0]);
-            emitter.EmitBoxIfNeeded(arguments[0]);
-        }
-        else
-        {
-            il.Emit(OpCodes.Ldnull);
-        }
-
-        // Emit callback argument (optional)
-        if (arguments.Count > 1)
-        {
-            emitter.EmitExpression(arguments[1]);
-            emitter.EmitBoxIfNeeded(arguments[1]);
-        }
-        else
-        {
-            il.Emit(OpCodes.Ldnull);
+            if (arguments.Count > i)
+            {
+                emitter.EmitExpression(arguments[i]);
+                emitter.EmitBoxIfNeeded(arguments[i]);
+            }
+            else
+            {
+                il.Emit(OpCodes.Ldnull);
+            }
         }
 
-        // Call $Runtime.NetCreateConnection(options, callback)
+        // Call $Runtime.NetCreateConnection(options, hostOrCallback, callback)
         il.Emit(OpCodes.Call, ctx.Runtime!.NetCreateConnection);
         emitter.SetStackUnknown();
         return true;

--- a/Compilation/Emitters/RegExpEmitter.cs
+++ b/Compilation/Emitters/RegExpEmitter.cs
@@ -17,6 +17,11 @@ public sealed class RegExpEmitter : ITypeEmitterStrategy
         var ctx = emitter.Context;
         var il = ctx.IL;
 
+        // Bail before emitting the receiver for unknown methods — emitting
+        // first and returning false would leave an orphaned stack value.
+        if (methodName is not ("test" or "exec"))
+            return false;
+
         // Emit the RegExp object
         emitter.EmitExpression(receiver);
         emitter.EmitBoxIfNeeded(receiver);
@@ -30,14 +35,11 @@ public sealed class RegExpEmitter : ITypeEmitterStrategy
                 il.Emit(OpCodes.Box, ctx.Types.Boolean);
                 return true;
 
-            case "exec":
-                // regex.exec(str) -> array|null
+            default:
+                // exec: regex.exec(str) -> array|null
                 EmitStringArgOrEmpty(emitter, arguments);
                 il.Emit(OpCodes.Call, ctx.Runtime!.RegExpExec);
                 return true;
-
-            default:
-                return false;
         }
     }
 
@@ -50,42 +52,45 @@ public sealed class RegExpEmitter : ITypeEmitterStrategy
         var ctx = emitter.Context;
         var il = ctx.IL;
 
+        // Resolve the handler BEFORE emitting the receiver: returning false
+        // after emitting would leave an orphaned value on the IL stack and
+        // produce an invalid program when the caller falls back to another
+        // emission path.
+        var getter = propertyName switch
+        {
+            "source" => ctx.Runtime!.RegExpGetSource,
+            "flags" => ctx.Runtime!.RegExpGetFlags,
+            "global" => ctx.Runtime!.RegExpGetGlobal,
+            "ignoreCase" => ctx.Runtime!.RegExpGetIgnoreCase,
+            "multiline" => ctx.Runtime!.RegExpGetMultiline,
+            "sticky" => ctx.Runtime!.RegExpGetSticky,
+            "unicode" => ctx.Runtime!.RegExpGetUnicode,
+            "dotAll" => ctx.Runtime!.RegExpGetDotAll,
+            "hasIndices" => ctx.Runtime!.RegExpGetHasIndices,
+            "unicodeSets" => ctx.Runtime!.RegExpGetUnicodeSets,
+            "lastIndex" => ctx.Runtime!.RegExpGetLastIndex,
+            _ => null
+        };
+        if (getter is null)
+            return false;
+
         emitter.EmitExpression(receiver);
         emitter.EmitBoxIfNeeded(receiver);
+        il.Emit(OpCodes.Call, getter);
 
         switch (propertyName)
         {
             case "source":
-                il.Emit(OpCodes.Call, ctx.Runtime!.RegExpGetSource);
-                return true;
-
             case "flags":
-                il.Emit(OpCodes.Call, ctx.Runtime!.RegExpGetFlags);
-                return true;
-
-            case "global":
-                il.Emit(OpCodes.Call, ctx.Runtime!.RegExpGetGlobal);
-                il.Emit(OpCodes.Box, ctx.Types.Boolean);
-                return true;
-
-            case "ignoreCase":
-                il.Emit(OpCodes.Call, ctx.Runtime!.RegExpGetIgnoreCase);
-                il.Emit(OpCodes.Box, ctx.Types.Boolean);
-                return true;
-
-            case "multiline":
-                il.Emit(OpCodes.Call, ctx.Runtime!.RegExpGetMultiline);
-                il.Emit(OpCodes.Box, ctx.Types.Boolean);
-                return true;
-
+                break; // already a string reference
             case "lastIndex":
-                il.Emit(OpCodes.Call, ctx.Runtime!.RegExpGetLastIndex);
                 il.Emit(OpCodes.Box, ctx.Types.Double);
-                return true;
-
+                break;
             default:
-                return false;
+                il.Emit(OpCodes.Box, ctx.Types.Boolean);
+                break;
         }
+        return true;
     }
 
     /// <summary>

--- a/Compilation/ILEmitter.Properties.BuiltIns.cs
+++ b/Compilation/ILEmitter.Properties.BuiltIns.cs
@@ -92,6 +92,24 @@ public partial class ILEmitter
                 IL.Emit(OpCodes.Box, _ctx.Types.Boolean);
                 SetStackUnknown();
                 return true;
+            case "sticky":
+            case "unicode":
+            case "dotAll":
+            case "hasIndices":
+            case "unicodeSets":
+                EmitExpression(g.Object);
+                EmitBoxIfNeeded(g.Object);
+                IL.Emit(OpCodes.Call, propName switch
+                {
+                    "sticky" => _ctx.Runtime!.RegExpGetSticky,
+                    "unicode" => _ctx.Runtime!.RegExpGetUnicode,
+                    "dotAll" => _ctx.Runtime!.RegExpGetDotAll,
+                    "hasIndices" => _ctx.Runtime!.RegExpGetHasIndices,
+                    _ => _ctx.Runtime!.RegExpGetUnicodeSets,
+                });
+                IL.Emit(OpCodes.Box, _ctx.Types.Boolean);
+                SetStackUnknown();
+                return true;
             case "lastIndex":
                 EmitExpression(g.Object);
                 EmitBoxIfNeeded(g.Object);

--- a/Compilation/RuntimeEmitter.Net.cs
+++ b/Compilation/RuntimeEmitter.Net.cs
@@ -47,8 +47,10 @@ public partial class RuntimeEmitter
     }
 
     /// <summary>
-    /// Emits: public static object NetCreateConnection(object? options, object? callback)
+    /// Emits: public static object NetCreateConnection(object? options, object? hostOrCallback, object? callback)
     /// Creates a $NetSocket directly and calls Connect (no reflection needed).
+    /// Node signature: connect(options|port|path[, host][, connectListener]) —
+    /// the socket's Connect does the positional-arg parsing.
     /// </summary>
     private void EmitNetCreateConnection(TypeBuilder typeBuilder, EmittedRuntime runtime)
     {
@@ -56,7 +58,7 @@ public partial class RuntimeEmitter
             "NetCreateConnection",
             MethodAttributes.Public | MethodAttributes.Static,
             _types.Object,
-            [_types.Object, _types.Object]
+            [_types.Object, _types.Object, _types.Object]
         );
         runtime.NetCreateConnection = method;
         runtime.RegisterBuiltInModuleMethod("net", "createConnection", method);
@@ -69,15 +71,15 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Newobj, runtime.NetSocketCtor);
         il.Emit(OpCodes.Stloc, socketLocal);
 
-        // socket.Connect(options, callback, null)
+        // socket.Connect(options, hostOrCallback, callback)
         var noOptions = il.DefineLabel();
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Brfalse, noOptions);
 
         il.Emit(OpCodes.Ldloc, socketLocal);
-        il.Emit(OpCodes.Ldarg_0); // options
-        il.Emit(OpCodes.Ldarg_1); // callback
-        il.Emit(OpCodes.Ldnull);  // third arg
+        il.Emit(OpCodes.Ldarg_0); // options/port/path
+        il.Emit(OpCodes.Ldarg_1); // host or callback
+        il.Emit(OpCodes.Ldarg_2); // callback
         il.Emit(OpCodes.Callvirt, runtime.NetSocketConnect);
         il.Emit(OpCodes.Pop);
 

--- a/Compilation/RuntimeEmitter.RegExp.cs
+++ b/Compilation/RuntimeEmitter.RegExp.cs
@@ -24,6 +24,11 @@ public partial class RuntimeEmitter
         EmitRegExpGetGlobal(typeBuilder, runtime);
         EmitRegExpGetIgnoreCase(typeBuilder, runtime);
         EmitRegExpGetMultiline(typeBuilder, runtime);
+        runtime.RegExpGetSticky = EmitRegExpGetFlagBool(typeBuilder, runtime, "RegExpGetSticky", 'y');
+        runtime.RegExpGetUnicode = EmitRegExpGetFlagBool(typeBuilder, runtime, "RegExpGetUnicode", 'u');
+        runtime.RegExpGetDotAll = EmitRegExpGetFlagBool(typeBuilder, runtime, "RegExpGetDotAll", 's');
+        runtime.RegExpGetHasIndices = EmitRegExpGetFlagBool(typeBuilder, runtime, "RegExpGetHasIndices", 'd');
+        runtime.RegExpGetUnicodeSets = EmitRegExpGetFlagBool(typeBuilder, runtime, "RegExpGetUnicodeSets", 'v');
         EmitRegExpGetLastIndex(typeBuilder, runtime);
         EmitRegExpSetLastIndex(typeBuilder, runtime);
         EmitStringMatchRegExp(typeBuilder, runtime);
@@ -625,6 +630,47 @@ public partial class RuntimeEmitter
         il.MarkLabel(notRegExpLabel);
         il.Emit(OpCodes.Ldc_I4_0);
         il.Emit(OpCodes.Ret);
+    }
+
+    /// <summary>
+    /// Emits a flag-bit getter (sticky/unicode/dotAll/hasIndices/unicodeSets)
+    /// that reads the $RegExp flags string and tests for
+    /// <paramref name="flagChar"/>. These flags have no dedicated instance
+    /// getter on $RegExp (unlike global/ignoreCase/multiline), so the wrapper
+    /// derives them from the flags string the same way the prototype
+    /// accessors do. Non-RegExp receivers return false, matching the other
+    /// RegExpGet* wrappers.
+    /// </summary>
+    private MethodBuilder EmitRegExpGetFlagBool(TypeBuilder typeBuilder, EmittedRuntime runtime, string name, char flagChar)
+    {
+        var method = typeBuilder.DefineMethod(
+            name,
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.Boolean,
+            [_types.Object]
+        );
+
+        var il = method.GetILGenerator();
+        var notRegExpLabel = il.DefineLabel();
+        var regexpLocal = il.DeclareLocal(runtime.TSRegExpType);
+
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Isinst, runtime.TSRegExpType);
+        il.Emit(OpCodes.Stloc, regexpLocal);
+
+        il.Emit(OpCodes.Ldloc, regexpLocal);
+        il.Emit(OpCodes.Brfalse, notRegExpLabel);
+
+        il.Emit(OpCodes.Ldloc, regexpLocal);
+        il.Emit(OpCodes.Callvirt, runtime.TSRegExpFlagsGetter);
+        il.Emit(OpCodes.Ldc_I4, (int)flagChar);
+        il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.String, "Contains", _types.Char));
+        il.Emit(OpCodes.Ret);
+
+        il.MarkLabel(notRegExpLabel);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Ret);
+        return method;
     }
 
     private void EmitRegExpGetLastIndex(TypeBuilder typeBuilder, EmittedRuntime runtime)

--- a/Compilation/RuntimeEmitter.TSHttpServer.cs
+++ b/Compilation/RuntimeEmitter.TSHttpServer.cs
@@ -1009,8 +1009,54 @@ public partial class RuntimeEmitter
         listeningProp.SetGetMethod(getListening);
     }
 
+    /// <summary>
+    /// Emits <c>private static int ProbeFreePort()</c>: binds a temporary
+    /// TcpListener on loopback port 0 and returns the OS-assigned port.
+    /// HttpListener has no dynamic-port support, so <c>listen(0)</c> needs
+    /// the probe (#214). Small release/re-bind race window — standard
+    /// practice for this workaround. BCL-only, safe for standalone DLLs.
+    /// </summary>
+    private MethodBuilder EmitHttpServerProbeFreePort(TypeBuilder typeBuilder)
+    {
+        var method = typeBuilder.DefineMethod(
+            "ProbeFreePort",
+            MethodAttributes.Private | MethodAttributes.Static,
+            _types.Int32,
+            Type.EmptyTypes
+        );
+
+        var il = method.GetILGenerator();
+        var tcpListenerType = typeof(System.Net.Sockets.TcpListener);
+        var probeLocal = il.DeclareLocal(tcpListenerType);
+        var portLocal = il.DeclareLocal(_types.Int32);
+
+        // var probe = new TcpListener(IPAddress.Loopback, 0); probe.Start();
+        il.Emit(OpCodes.Ldsfld, typeof(IPAddress).GetField("Loopback")!);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Newobj, tcpListenerType.GetConstructor([typeof(IPAddress), _types.Int32])!);
+        il.Emit(OpCodes.Stloc, probeLocal);
+        il.Emit(OpCodes.Ldloc, probeLocal);
+        il.Emit(OpCodes.Callvirt, tcpListenerType.GetMethod("Start", Type.EmptyTypes)!);
+
+        // port = ((IPEndPoint)probe.LocalEndpoint).Port;
+        il.Emit(OpCodes.Ldloc, probeLocal);
+        il.Emit(OpCodes.Callvirt, tcpListenerType.GetProperty("LocalEndpoint")!.GetGetMethod()!);
+        il.Emit(OpCodes.Castclass, typeof(IPEndPoint));
+        il.Emit(OpCodes.Callvirt, typeof(IPEndPoint).GetProperty("Port")!.GetGetMethod()!);
+        il.Emit(OpCodes.Stloc, portLocal);
+
+        // probe.Stop(); return port;
+        il.Emit(OpCodes.Ldloc, probeLocal);
+        il.Emit(OpCodes.Callvirt, tcpListenerType.GetMethod("Stop")!);
+        il.Emit(OpCodes.Ldloc, portLocal);
+        il.Emit(OpCodes.Ret);
+        return method;
+    }
+
     private void EmitHttpServerListen(TypeBuilder typeBuilder, EmittedRuntime runtime, Type httpListenerType)
     {
+        var probeFreePort = EmitHttpServerProbeFreePort(typeBuilder);
+
         // public object Listen(double port, object? callback)
         var method = typeBuilder.DefineMethod(
             "Listen",
@@ -1021,6 +1067,17 @@ public partial class RuntimeEmitter
         runtime.TSHttpServerListen = method;
 
         var il = method.GetILGenerator();
+
+        // listen(0): substitute an OS-assigned ephemeral port before any
+        // use of the port argument (#214).
+        var portNonZeroLabel = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Conv_I4);
+        il.Emit(OpCodes.Brtrue, portNonZeroLabel);
+        il.Emit(OpCodes.Call, probeFreePort);
+        il.Emit(OpCodes.Conv_R8);
+        il.Emit(OpCodes.Starg_S, (byte)1);
+        il.MarkLabel(portNonZeroLabel);
 
         // Store port
         il.Emit(OpCodes.Ldarg_0);

--- a/Execution/Interpreter.Async.cs
+++ b/Execution/Interpreter.Async.cs
@@ -21,6 +21,30 @@ public partial class Interpreter
     /// Asynchronously executes a block of statements.
     /// Uses registry-based dispatch via ExecuteStatementAsync.
     /// </summary>
+    /// <summary>
+    /// Awaits a guest task while preserving the interpreter's ambient
+    /// environment across the suspension (#207). The resume may run on a
+    /// later event-loop turn — after other callbacks ran, or after the
+    /// module-init/top-level frame that was active at suspension time
+    /// finished and restored <c>_environment</c> to an outer scope. The
+    /// tree-walk resolves variables through the ambient environment, so a
+    /// resumed async frame that doesn't re-assert its scope sees the wrong
+    /// chain ("Undefined variable 'x'" for closure/module bindings).
+    /// Every await of a guest-pending task must route through here.
+    /// </summary>
+    internal async Task<object?> AwaitPreservingEnvironment(Task<object?> task)
+    {
+        var saved = _environment;
+        try
+        {
+            return await task;
+        }
+        finally
+        {
+            _environment = saved;
+        }
+    }
+
     internal async Task<ExecutionResult> ExecuteBlockAsync(List<Stmt> statements, RuntimeEnvironment environment)
     {
         using (PushScope(environment))
@@ -56,7 +80,7 @@ public partial class Interpreter
             foreach (var item in syncIterator)
             {
                 // For 'for await...of', unwrap promises from sync iterators
-                object? value = forOf.IsAsync && item is Task<object?> t ? await t : item;
+                object? value = forOf.IsAsync && item is Task<object?> t ? await AwaitPreservingEnvironment(t) : item;
 
                 var result = await ExecuteLoopBodyAsync(forOf.Variable.Lexeme, value, forOf.Body);
                 if (result.Type == ExecutionResult.ResultType.Break && result.TargetLabel == null) return ExecutionResult.Success();
@@ -180,9 +204,9 @@ public partial class Interpreter
 
             // Await the result if it's a promise/task
             if (nextResult is SharpTSPromise promise)
-                nextResult = await promise.Task;
+                nextResult = await AwaitPreservingEnvironment(promise.Task);
             else if (nextResult is Task<object?> task)
-                nextResult = await task;
+                nextResult = await AwaitPreservingEnvironment(task);
 
             // Check if the result is an iterator result object
             bool done = false;

--- a/Execution/Interpreter.Calls.cs
+++ b/Execution/Interpreter.Calls.cs
@@ -773,6 +773,16 @@ public partial class Interpreter
         if (right is SharpTSBufferConstructor)
             return left is SharpTSBuffer;
 
+        // Web-streams constructor wrapper singletons (the same values
+        // stream/web exports and the ReadableStream/WritableStream/
+        // TransformStream globals bind — #208).
+        if (right is SharpTSReadableStreamConstructor)
+            return left is SharpTSReadableStream;
+        if (right is SharpTSWritableStreamConstructor)
+            return left is SharpTSWritableStream;
+        if (right is SharpTSTransformStreamConstructor)
+            return left is SharpTSTransformStream;
+
         // Array is registered as a namespace singleton (SharpTSArrayGlobal), not
         // as a SharpTSBuiltInConstructor — so `arr instanceof Array` lands here.
         // Real arrays AND the Array.prototype dict itself satisfy the check

--- a/Execution/Interpreter.Expressions.cs
+++ b/Execution/Interpreter.Expressions.cs
@@ -198,7 +198,7 @@ public partial class Interpreter
         // Unwrap Promise
         if (value is SharpTSPromise promise)
         {
-            return RuntimeValue.FromBoxed(await promise.GetValueAsync());
+            return RuntimeValue.FromBoxed(await AwaitPreservingEnvironment(promise.GetValueAsync()));
         }
 
         // Raw Task<object?> — returned by runtime methods (e.g., Web Streams
@@ -209,7 +209,7 @@ public partial class Interpreter
         // not unwrap).
         if (value is Task<object?> task)
         {
-            return RuntimeValue.FromBoxed(await task);
+            return RuntimeValue.FromBoxed(await AwaitPreservingEnvironment(task));
         }
 
         // Await on non-Promise returns the value (TypeScript behavior)

--- a/Execution/Interpreter.cs
+++ b/Execution/Interpreter.cs
@@ -167,6 +167,31 @@ public partial class Interpreter : IDisposable
                 globals[name] = new SharpTSGlobalFunction(name);
         }
 
+        // Bind value-position globals for built-ins that were previously only
+        // reachable through special-cased `new` expressions or member access
+        // (#208): bare `AbortSignal`/`Intl`/`ReadableStream`/... otherwise
+        // throw "Undefined variable".
+        //
+        // AbortSignal and Intl are namespace-style globals: member access on
+        // SharpTSBuiltInConstructor routes through the namespace registry
+        // (AbortSignal.abort/timeout/any, Intl.NumberFormat/...), while
+        // direct construction throws per spec (AbortSignal has no public
+        // constructor; Intl is not a constructor).
+        globals["AbortSignal"] = new SharpTSBuiltInConstructor("AbortSignal",
+            _ => throw new Exception("Runtime Error: TypeError: AbortSignal cannot be constructed directly. Use AbortSignal.abort(), AbortSignal.timeout(), or AbortController."));
+        globals["Intl"] = new SharpTSBuiltInConstructor("Intl",
+            _ => throw new Exception("Runtime Error: TypeError: Intl is not a constructor."));
+
+        // Web-streams constructors: the same singletons stream/web exports,
+        // so `new ReadableStream(...)`, `ReadableStream.from(...)`, and
+        // value-position references all share one identity.
+        globals[BuiltInNames.ReadableStream] = Runtime.Types.SharpTSReadableStreamConstructor.Instance;
+        globals[BuiltInNames.WritableStream] = Runtime.Types.SharpTSWritableStreamConstructor.Instance;
+        globals[BuiltInNames.TransformStream] = Runtime.Types.SharpTSTransformStreamConstructor.Instance;
+
+        // MessageChannel as a value (construction already worked by name).
+        globals[BuiltInNames.MessageChannel] = WorkerBuiltIns.MessageChannelConstructor;
+
         // Promise needs a bare-reference global so `x instanceof Promise`,
         // `typeof Promise === 'function'`, and stdlib modules that carry
         // Promise as a value can type-check/run. Its namespace is registered

--- a/Parsing/AST.cs
+++ b/Parsing/AST.cs
@@ -447,7 +447,9 @@ public abstract record Stmt
     public record LabeledStatement(Token Label, Stmt Statement) : Stmt;
     public record SwitchCase(Expr Value, List<Stmt> Body);
     public record Switch(Expr Subject, List<SwitchCase> Cases, List<Stmt>? DefaultBody) : Stmt;
-    public record TryCatch(List<Stmt> TryBlock, Token? CatchParam, List<Stmt>? CatchBlock, List<Stmt>? FinallyBlock) : Stmt;
+    // CatchParamType: optional catch-binding annotation text (`catch (e: unknown)`).
+    // TS allows only 'any'/'unknown'; anything else is checker error TS1196.
+    public record TryCatch(List<Stmt> TryBlock, Token? CatchParam, List<Stmt>? CatchBlock, List<Stmt>? FinallyBlock, string? CatchParamType = null) : Stmt;
     public record Throw(Token Keyword, Expr Value) : Stmt;
     public record TypeAlias(Token Name, string TypeDefinition, List<TypeParam>? TypeParameters = null) : Stmt;
     public record EnumMember(Token Name, Expr? Value);

--- a/Parsing/Parser.Statements.cs
+++ b/Parsing/Parser.Statements.cs
@@ -377,6 +377,7 @@ public partial class Parser
         List<Stmt> tryBlock = Block();
 
         Token? catchParam = null;
+        string? catchParamType = null;
         List<Stmt>? catchBlock = null;
         List<Stmt>? finallyBlock = null;
 
@@ -387,6 +388,13 @@ public partial class Parser
             {
                 Consume(TokenType.LEFT_PAREN, "Expect '(' after 'catch'.");
                 catchParam = Consume(TokenType.IDENTIFIER, "Expect catch parameter name.");
+                // TS catch-binding annotation: `catch (e: any)` / `(e: unknown)`.
+                // Parse any annotation here; restricting it to any/unknown is the
+                // type checker's job (TS1196), not a parse error (#215).
+                if (Match(TokenType.COLON))
+                {
+                    catchParamType = ParseTypeAnnotation();
+                }
                 Consume(TokenType.RIGHT_PAREN, "Expect ')' after catch parameter.");
             }
             // else: catchParam remains null for parameterless catch
@@ -406,7 +414,7 @@ public partial class Parser
             throw new Exception("Try statement must have catch or finally clause.");
         }
 
-        return new Stmt.TryCatch(tryBlock, catchParam, catchBlock, finallyBlock);
+        return new Stmt.TryCatch(tryBlock, catchParam, catchBlock, finallyBlock, catchParamType);
     }
 
     private Stmt ThrowStatement()

--- a/Runtime/BuiltIns/BuiltInRegistry.cs
+++ b/Runtime/BuiltIns/BuiltInRegistry.cs
@@ -1035,6 +1035,12 @@ public sealed class BuiltInRegistry
         registry.RegisterInstanceType(typeof(SharpTSMessagePort), (instance, name) =>
             ((SharpTSMessagePort)instance).GetMember(name));
 
+        // Register the worker-side parentPort (postMessage + EventEmitter members).
+        // Instance lookup is exact-type, so the WorkerParentPort subclass needs
+        // its own registration to reach its GetMember (#209).
+        registry.RegisterInstanceType(typeof(WorkerParentPort), (instance, name) =>
+            ((WorkerParentPort)instance).GetMember(name));
+
         // Register MessageChannel instance members
         registry.RegisterInstanceType(typeof(SharpTSMessageChannel), (instance, name) =>
             ((SharpTSMessageChannel)instance).GetMember(name));

--- a/Runtime/BuiltIns/BuiltInRegistry.cs
+++ b/Runtime/BuiltIns/BuiltInRegistry.cs
@@ -998,6 +998,12 @@ public sealed class BuiltInRegistry
             ((SharpTSQueuingStrategy)instance).GetMember(name));
         registry.RegisterInstanceType(typeof(SharpTSCountQueuingStrategy), (instance, name) =>
             ((SharpTSQueuingStrategy)instance).GetMember(name));
+
+        // The constructor wrapper itself carries static members
+        // (ReadableStream.from) — without this registration, property access
+        // on the imported constructor never reaches GetProperty (#210).
+        registry.RegisterInstanceType(typeof(SharpTSReadableStreamConstructor), (instance, name) =>
+            ((SharpTSReadableStreamConstructor)instance).GetProperty(name));
     }
 
     private static void RegisterWorkerTypes(BuiltInRegistry registry)

--- a/Runtime/BuiltIns/BuiltInTypes.cs
+++ b/Runtime/BuiltIns/BuiltInTypes.cs
@@ -390,6 +390,11 @@ public static class BuiltInTypes
             "global" => BooleanType,
             "ignoreCase" => BooleanType,
             "multiline" => BooleanType,
+            "dotAll" => BooleanType,
+            "sticky" => BooleanType,
+            "unicode" => BooleanType,
+            "unicodeSets" => BooleanType,
+            "hasIndices" => BooleanType,
             "lastIndex" => NumberType,
 
             // Methods. ECMA-262 §22.2.6.{2,8,16} — test/exec coerce the

--- a/Runtime/BuiltIns/Modules/Interpreter/DnsModuleInterpreter.cs
+++ b/Runtime/BuiltIns/Modules/Interpreter/DnsModuleInterpreter.cs
@@ -107,6 +107,13 @@ public static class DnsModuleInterpreter
     /// <summary>
     /// dns.lookup(hostname[, options][, callback]) - Resolves a hostname to an IP address.
     /// </summary>
+    /// <remarks>
+    /// With a callback (the Node contract), resolution runs off-thread and the
+    /// callback is invoked asynchronously with (err, address, family) — or
+    /// (err, addresses) when options.all is set — with Ref/Unref keeping the
+    /// event loop alive (#206). Without a callback (no such form in Node) the
+    /// legacy synchronous direct-return behavior is preserved.
+    /// </remarks>
     private static RuntimeValue Lookup(Interp interpreter, RuntimeValue receiver, ReadOnlySpan<RuntimeValue> args)
     {
         if (args.Length == 0 || !args[0].IsString)
@@ -132,6 +139,45 @@ public static class DnsModuleInterpreter
             }
         }
 
+        var callback = args[^1].ToObject() as ISharpTSCallable;
+        if (callback == null)
+            return RuntimeValue.FromBoxed(LookupCore(hostname, family, all));
+
+        interpreter.Ref();
+        _ = Task.Run(() =>
+        {
+            try
+            {
+                var result = LookupCore(hostname, family, all);
+                interpreter.ScheduleTimer(0, 0, () =>
+                {
+                    if (result is SharpTSObject single)
+                        callback.Call(interpreter,
+                            [null, single.Fields["address"], single.Fields["family"]]);
+                    else
+                        callback.Call(interpreter, [null, result]);
+                    interpreter.Unref();
+                }, isInterval: false);
+            }
+            catch (Exception ex)
+            {
+                interpreter.ScheduleTimer(0, 0, () =>
+                {
+                    callback.Call(interpreter,
+                        [CreateDnsError(ExtractErrorCode(ex), hostname), null, null]);
+                    interpreter.Unref();
+                }, isInterval: false);
+            }
+        });
+        return RuntimeValue.Undefined;
+    }
+
+    /// <summary>
+    /// Shared dns.lookup resolution: returns a single {address, family} object,
+    /// or an array of them when <paramref name="all"/> is set.
+    /// </summary>
+    private static object? LookupCore(string hostname, int family, bool all)
+    {
         try
         {
             var hostEntry = Dns.GetHostEntry(hostname);
@@ -161,7 +207,7 @@ public static class DnsModuleInterpreter
                     };
                     results.Add(new SharpTSObject(fields));
                 }
-                return RuntimeValue.FromObject(new SharpTSArray(results));
+                return new SharpTSArray(results);
             }
             else
             {
@@ -172,7 +218,7 @@ public static class DnsModuleInterpreter
                     ["address"] = addr.ToString(),
                     ["family"] = addr.AddressFamily == AddressFamily.InterNetwork ? 4.0 : 6.0
                 };
-                return RuntimeValue.FromObject(new SharpTSObject(fields));
+                return new SharpTSObject(fields);
             }
         }
         catch (SocketException ex)
@@ -184,6 +230,12 @@ public static class DnsModuleInterpreter
     /// <summary>
     /// dns.lookupService(address, port[, callback]) - Resolves address and port to hostname and service.
     /// </summary>
+    /// <remarks>
+    /// With a callback (the Node contract), resolution runs off-thread and the
+    /// callback receives (err, hostname, service) with Ref/Unref keeping the
+    /// event loop alive (#206). Without a callback the legacy synchronous
+    /// direct-return form is preserved.
+    /// </remarks>
     private static RuntimeValue LookupService(Interp interpreter, RuntimeValue receiver, ReadOnlySpan<RuntimeValue> args)
     {
         if (args.Length < 2)
@@ -199,6 +251,41 @@ public static class DnsModuleInterpreter
 
         int port = (int)portNum;
 
+        var callback = args[^1].ToObject() as ISharpTSCallable;
+        if (callback == null)
+            return RuntimeValue.FromObject(LookupServiceCore(address, port));
+
+        interpreter.Ref();
+        _ = Task.Run(() =>
+        {
+            try
+            {
+                var result = LookupServiceCore(address, port);
+                interpreter.ScheduleTimer(0, 0, () =>
+                {
+                    callback.Call(interpreter,
+                        [null, result.Fields["hostname"], result.Fields["service"]]);
+                    interpreter.Unref();
+                }, isInterval: false);
+            }
+            catch (Exception ex)
+            {
+                interpreter.ScheduleTimer(0, 0, () =>
+                {
+                    callback.Call(interpreter,
+                        [CreateDnsError(ExtractErrorCode(ex), address), null, null]);
+                    interpreter.Unref();
+                }, isInterval: false);
+            }
+        });
+        return RuntimeValue.Undefined;
+    }
+
+    /// <summary>
+    /// Shared dns.lookupService resolution: returns a {hostname, service} object.
+    /// </summary>
+    private static SharpTSObject LookupServiceCore(string address, int port)
+    {
         try
         {
             // Parse the IP address
@@ -214,7 +301,7 @@ public static class DnsModuleInterpreter
                 // Note: .NET doesn't have built-in service name lookup, so we just return the port
                 ["service"] = port.ToString()
             };
-            return RuntimeValue.FromObject(new SharpTSObject(fields));
+            return new SharpTSObject(fields);
         }
         catch (SocketException ex)
         {

--- a/Runtime/BuiltIns/Modules/Interpreter/FsModuleInterpreter.cs
+++ b/Runtime/BuiltIns/Modules/Interpreter/FsModuleInterpreter.cs
@@ -947,11 +947,25 @@ public static class FsModuleInterpreter
     /// <summary>
     /// Schedules an async callback on the interpreter's event loop.
     /// </summary>
+    /// <remarks>
+    /// Pairs with the <c>interpreter.Ref()</c> taken at each async dispatch
+    /// site (#205): a pending fs callback counts as outstanding work, so the
+    /// loop is released only after the callback has run (or failed). Every
+    /// Task.Run body in this file calls ScheduleCallback exactly once — on
+    /// the success path or the catch path — keeping the pairing balanced.
+    /// </remarks>
     private static void ScheduleCallback(Interp interpreter, ISharpTSCallable callback, object? error, object? result)
     {
         interpreter.ScheduleTimer(0, 0, () =>
         {
-            callback.Call(interpreter, [error, result]);
+            try
+            {
+                callback.Call(interpreter, [error, result]);
+            }
+            finally
+            {
+                interpreter.Unref();
+            }
         }, isInterval: false);
     }
 
@@ -992,6 +1006,7 @@ public static class FsModuleInterpreter
             }
         }
 
+        interpreter.Ref(); // released by ScheduleCallback after the callback runs (#205)
         _ = Task.Run(async () =>
         {
             try
@@ -1016,6 +1031,7 @@ public static class FsModuleInterpreter
         var callback = GetCallback(args);
         var options = args.Length == 4 ? args[2].ToObject() : null;
 
+        interpreter.Ref(); // released by ScheduleCallback after the callback runs (#205)
         _ = Task.Run(async () =>
         {
             try
@@ -1040,6 +1056,7 @@ public static class FsModuleInterpreter
         var callback = GetCallback(args);
         var options = args.Length == 4 ? args[2].ToObject() : null;
 
+        interpreter.Ref(); // released by ScheduleCallback after the callback runs (#205)
         _ = Task.Run(async () =>
         {
             try
@@ -1062,6 +1079,7 @@ public static class FsModuleInterpreter
         var path = args[0].ToObject()?.ToString() ?? "";
         var callback = GetCallback(args);
 
+        interpreter.Ref(); // released by ScheduleCallback after the callback runs (#205)
         _ = Task.Run(async () =>
         {
             try
@@ -1084,6 +1102,7 @@ public static class FsModuleInterpreter
         var path = args[0].ToObject()?.ToString() ?? "";
         var callback = GetCallback(args);
 
+        interpreter.Ref(); // released by ScheduleCallback after the callback runs (#205)
         _ = Task.Run(async () =>
         {
             try
@@ -1106,6 +1125,7 @@ public static class FsModuleInterpreter
         var path = args[0].ToObject()?.ToString() ?? "";
         var callback = GetCallback(args);
 
+        interpreter.Ref(); // released by ScheduleCallback after the callback runs (#205)
         _ = Task.Run(async () =>
         {
             try
@@ -1129,6 +1149,7 @@ public static class FsModuleInterpreter
         var callback = GetCallback(args);
         var options = args.Length == 3 ? args[1].ToObject() : null;
 
+        interpreter.Ref(); // released by ScheduleCallback after the callback runs (#205)
         _ = Task.Run(async () =>
         {
             try
@@ -1152,6 +1173,7 @@ public static class FsModuleInterpreter
         var callback = GetCallback(args);
         var options = args.Length == 3 ? args[1].ToObject() : null;
 
+        interpreter.Ref(); // released by ScheduleCallback after the callback runs (#205)
         _ = Task.Run(async () =>
         {
             try
@@ -1175,6 +1197,7 @@ public static class FsModuleInterpreter
         var callback = GetCallback(args);
         var options = args.Length == 3 ? args[1].ToObject() : null;
 
+        interpreter.Ref(); // released by ScheduleCallback after the callback runs (#205)
         _ = Task.Run(async () =>
         {
             try
@@ -1198,6 +1221,7 @@ public static class FsModuleInterpreter
         var newPath = args[1].ToObject()?.ToString() ?? "";
         var callback = GetCallback(args);
 
+        interpreter.Ref(); // released by ScheduleCallback after the callback runs (#205)
         _ = Task.Run(async () =>
         {
             try
@@ -1222,6 +1246,7 @@ public static class FsModuleInterpreter
         var callback = GetCallback(args);
         var mode = args.Length == 4 ? args[2].ToObject() : null;
 
+        interpreter.Ref(); // released by ScheduleCallback after the callback runs (#205)
         _ = Task.Run(async () =>
         {
             try
@@ -1245,6 +1270,7 @@ public static class FsModuleInterpreter
         var callback = GetCallback(args);
         var mode = args.Length == 3 ? args[1].ToObject() : null;
 
+        interpreter.Ref(); // released by ScheduleCallback after the callback runs (#205)
         _ = Task.Run(async () =>
         {
             try
@@ -1268,6 +1294,7 @@ public static class FsModuleInterpreter
         var mode = args[1].ToObject();
         var callback = GetCallback(args);
 
+        interpreter.Ref(); // released by ScheduleCallback after the callback runs (#205)
         _ = Task.Run(async () =>
         {
             try
@@ -1291,6 +1318,7 @@ public static class FsModuleInterpreter
         var callback = GetCallback(args);
         var len = args.Length == 3 ? args[1].ToObject() : null;
 
+        interpreter.Ref(); // released by ScheduleCallback after the callback runs (#205)
         _ = Task.Run(async () =>
         {
             try
@@ -1315,6 +1343,7 @@ public static class FsModuleInterpreter
         var mtime = args[2].ToObject();
         var callback = GetCallback(args);
 
+        interpreter.Ref(); // released by ScheduleCallback after the callback runs (#205)
         _ = Task.Run(async () =>
         {
             try
@@ -1337,6 +1366,7 @@ public static class FsModuleInterpreter
         var path = args[0].ToObject()?.ToString() ?? "";
         var callback = GetCallback(args);
 
+        interpreter.Ref(); // released by ScheduleCallback after the callback runs (#205)
         _ = Task.Run(async () =>
         {
             try
@@ -1359,6 +1389,7 @@ public static class FsModuleInterpreter
         var path = args[0].ToObject()?.ToString() ?? "";
         var callback = GetCallback(args);
 
+        interpreter.Ref(); // released by ScheduleCallback after the callback runs (#205)
         _ = Task.Run(async () =>
         {
             try
@@ -1383,6 +1414,7 @@ public static class FsModuleInterpreter
         var callback = GetCallback(args);
         var type = args.Length == 4 ? args[2].ToObject() : null;
 
+        interpreter.Ref(); // released by ScheduleCallback after the callback runs (#205)
         _ = Task.Run(async () =>
         {
             try
@@ -1406,6 +1438,7 @@ public static class FsModuleInterpreter
         var newPath = args[1].ToObject()?.ToString() ?? "";
         var callback = GetCallback(args);
 
+        interpreter.Ref(); // released by ScheduleCallback after the callback runs (#205)
         _ = Task.Run(async () =>
         {
             try
@@ -1428,6 +1461,7 @@ public static class FsModuleInterpreter
         var prefix = args[0].ToObject()?.ToString() ?? "";
         var callback = GetCallback(args);
 
+        interpreter.Ref(); // released by ScheduleCallback after the callback runs (#205)
         _ = Task.Run(async () =>
         {
             try

--- a/Runtime/BuiltIns/Modules/Interpreter/NetModuleInterpreter.cs
+++ b/Runtime/BuiltIns/Modules/Interpreter/NetModuleInterpreter.cs
@@ -23,8 +23,10 @@ public static class NetModuleInterpreter
         return new Dictionary<string, object?>
         {
             ["createServer"] = BuiltInMethod.CreateV2("createServer", 0, 2, CreateServer),
-            ["createConnection"] = BuiltInMethod.CreateV2("createConnection", 1, 2, CreateConnection),
-            ["connect"] = BuiltInMethod.CreateV2("connect", 1, 2, CreateConnection),
+            // Node signature: connect(options|port|path[, host][, connectListener])
+            // — three positional args; the socket's own connect does the parsing.
+            ["createConnection"] = BuiltInMethod.CreateV2("createConnection", 1, 3, CreateConnection),
+            ["connect"] = BuiltInMethod.CreateV2("connect", 1, 3, CreateConnection),
             ["isIP"] = BuiltInMethod.CreateV2("isIP", 1, IsIP),
             ["isIPv4"] = BuiltInMethod.CreateV2("isIPv4", 1, IsIPv4),
             ["isIPv6"] = BuiltInMethod.CreateV2("isIPv6", 1, IsIPv6),

--- a/Runtime/BuiltIns/RegExpBuiltIns.cs
+++ b/Runtime/BuiltIns/RegExpBuiltIns.cs
@@ -218,6 +218,11 @@ public static class RegExpBuiltIns
             "global" => receiver.Global,
             "ignoreCase" => receiver.IgnoreCase,
             "multiline" => receiver.Multiline,
+            "dotAll" => receiver.Flags.Contains('s'),
+            "sticky" => receiver.Sticky,
+            "unicode" => receiver.Unicode,
+            "unicodeSets" => receiver.Flags.Contains('v'),
+            "hasIndices" => receiver.Flags.Contains('d'),
             "lastIndex" => (double)receiver.LastIndex,
 
             // ========== Methods ==========
@@ -374,6 +379,8 @@ public static class RegExpBuiltIns
         DefineAccessor("dotAll", _protoDotAllGetter);
         DefineAccessor("sticky", _protoStickyGetter);
         DefineAccessor("unicode", _protoUnicodeGetter);
+        DefineAccessor("unicodeSets", _protoUnicodeSetsGetter);
+        DefineAccessor("hasIndices", _protoHasIndicesGetter);
         return proto;
     }
 
@@ -443,6 +450,8 @@ public static class RegExpBuiltIns
     private static readonly BuiltInMethod _protoDotAllGetter = MakeProtoFlagGetter("dotAll", 's');
     private static readonly BuiltInMethod _protoStickyGetter = MakeProtoFlagGetter("sticky", 'y');
     private static readonly BuiltInMethod _protoUnicodeGetter = MakeProtoFlagGetter("unicode", 'u');
+    private static readonly BuiltInMethod _protoUnicodeSetsGetter = MakeProtoFlagGetter("unicodeSets", 'v');
+    private static readonly BuiltInMethod _protoHasIndicesGetter = MakeProtoFlagGetter("hasIndices", 'd');
 
     /// <summary>
     /// §22.2.5.12 <c>get RegExp.prototype.source</c>: a real RegExp returns its

--- a/Runtime/Types/SharpTSHttpServer.cs
+++ b/Runtime/Types/SharpTSHttpServer.cs
@@ -81,7 +81,10 @@ public class SharpTSHttpServer : SharpTSEventEmitter, IDisposable
                     return server.Close(args);
                 return receiver;
             }).Bind(this),
-            "address" => GetAddress(),
+            // Node API: server.address() is a method returning
+            // { address, family, port } (or null before listen).
+            "address" => new BuiltInMethod("address", 0, (interp, receiver, args) =>
+                receiver is SharpTSHttpServer server ? server.GetAddress() : null).Bind(this),
             // Inherit EventEmitter methods for on, once, off, emit, removeAllListeners, etc.
             _ => base.GetMember(name)
         };
@@ -120,6 +123,15 @@ public class SharpTSHttpServer : SharpTSEventEmitter, IDisposable
         if (ClusterContext.IsWorker)
             return RuntimeValue.FromBoxed(ListenAsClusterWorker(interpreter, callback));
 
+        // Node semantics: listen(0) binds an OS-assigned ephemeral port.
+        // HttpListener has no dynamic-port support ("The parameter is
+        // incorrect"), so probe a free port by binding a temporary
+        // TcpListener and handing its assigned port to HttpListener. There
+        // is a small race window between release and re-bind, which is
+        // standard practice for this workaround (#214).
+        if (_port == 0)
+            _port = ProbeFreePort();
+
         _listener = new HttpListener();
         _listener.Prefixes.Add($"http://+:{_port}/");
 
@@ -154,6 +166,24 @@ public class SharpTSHttpServer : SharpTSEventEmitter, IDisposable
         EmitEvent("listening", new List<object?>());
 
         return RuntimeValue.FromObject(this);
+    }
+
+    /// <summary>
+    /// Finds a free TCP port by binding a temporary listener on the loopback
+    /// interface with port 0 and reading back the OS-assigned port.
+    /// </summary>
+    private static int ProbeFreePort()
+    {
+        var probe = new System.Net.Sockets.TcpListener(System.Net.IPAddress.Loopback, 0);
+        probe.Start();
+        try
+        {
+            return ((System.Net.IPEndPoint)probe.LocalEndpoint).Port;
+        }
+        finally
+        {
+            probe.Stop();
+        }
     }
 
     /// <summary>

--- a/Runtime/Types/SharpTSHttpServer.cs
+++ b/Runtime/Types/SharpTSHttpServer.cs
@@ -83,8 +83,10 @@ public class SharpTSHttpServer : SharpTSEventEmitter, IDisposable
             }).Bind(this),
             // Node API: server.address() is a method returning
             // { address, family, port } (or null before listen).
-            "address" => new BuiltInMethod("address", 0, (interp, receiver, args) =>
-                receiver is SharpTSHttpServer server ? server.GetAddress() : null).Bind(this),
+            "address" => BuiltInMethod.CreateV2("address", 0, (_, receiver, _) =>
+                RuntimeValue.FromBoxed(receiver.ToObject() is SharpTSHttpServer server
+                    ? server.GetAddress()
+                    : null)).Bind(this),
             // Inherit EventEmitter methods for on, once, off, emit, removeAllListeners, etc.
             _ => base.GetMember(name)
         };

--- a/Runtime/Types/SharpTSHttpServer.cs
+++ b/Runtime/Types/SharpTSHttpServer.cs
@@ -344,16 +344,18 @@ public class SharpTSHttpServer : SharpTSEventEmitter, IDisposable
 
         if (_listener == null) return null;
 
-        var prefix = _listener.Prefixes.FirstOrDefault();
-        if (prefix == null) return null;
-
-        // Parse the prefix to extract port
-        var uri = new Uri(prefix);
+        // Report the tracked port directly. Parsing the listener prefix with
+        // new Uri(...) throws "Invalid URI: The hostname could not be parsed"
+        // for the wildcard form "http://+:port/" — which is exactly what
+        // Listen registers on Linux/macOS (the wildcard only fails on Windows
+        // without admin rights, where the 127.0.0.1 fallback kicks in).
+        // _port is authoritative: listen(0) replaces it with the probed
+        // ephemeral port before HttpListener starts (#214).
         return new SharpTSObject(new Dictionary<string, object?>
         {
             ["address"] = "0.0.0.0",
             ["family"] = "IPv4",
-            ["port"] = (double)uri.Port
+            ["port"] = (double)_port
         });
     }
 

--- a/Runtime/Types/SharpTSMessagePort.cs
+++ b/Runtime/Types/SharpTSMessagePort.cs
@@ -45,8 +45,12 @@ public class SharpTSMessagePort : SharpTSEventEmitter
     /// </summary>
     internal Interp? OwnerInterpreter { get; set; }
 
-    /// <inheritdoc />
-    public override TypeCategory RuntimeCategory => TypeCategory.EventEmitter;
+    // NOTE: RuntimeCategory deliberately NOT overridden to EventEmitter.
+    // The base virtual returns Unknown for subclasses, which routes property
+    // access through the per-type instance registration (BuiltInRegistry) and
+    // reaches this class's GetMember. Forcing the EventEmitter category here
+    // dispatched through a base-typed cast, so the port-specific members
+    // (postMessage/start/close) resolved as undefined (#209).
 
     /// <summary>
     /// Represents a cloned message ready for delivery.
@@ -153,14 +157,10 @@ public class SharpTSMessagePort : SharpTSEventEmitter
 
         while (_queue.TryTake(out var message))
         {
-            // Create MessageEvent-like object
-            var eventData = new SharpTSObject(new Dictionary<string, object?>
-            {
-                ["data"] = message.Data,
-                ["ports"] = message.Transfer ?? new SharpTSArray()
-            });
-
-            EmitEvent("message", [eventData]);
+            // Node worker_threads semantics: 'message' listeners receive the
+            // cloned input value of postMessage() directly (not a browser-style
+            // MessageEvent wrapper).
+            EmitEvent("message", [message.Data]);
         }
     }
 
@@ -200,6 +200,26 @@ public class SharpTSMessagePort : SharpTSEventEmitter
             {
                 Close();
                 return RuntimeValue.Null;
+            }),
+
+            // Node semantics: attaching a 'message' listener implicitly starts
+            // the port (https://nodejs.org/api/worker_threads.html#event-message).
+            // MessageChannel-created ports also have no owner interpreter until
+            // someone interacts with them, so capture it here — without it,
+            // queued messages are never delivered.
+            "on" or "addListener" or "once" => new BuiltInMethod(name, 2, (interp, recv, args) =>
+            {
+                var eventName = args[0]?.ToString()
+                    ?? throw new Exception("Event name must be a string");
+                var listener = args[1]
+                    ?? throw new Exception("Listener must be a function");
+                AddListenerDirect(eventName, listener, once: name == "once");
+                if (eventName == "message")
+                {
+                    OwnerInterpreter ??= interp;
+                    Start();
+                }
+                return this;
             }),
 
             // Inherit EventEmitter methods

--- a/Runtime/Types/SharpTSMessagePort.cs
+++ b/Runtime/Types/SharpTSMessagePort.cs
@@ -207,11 +207,11 @@ public class SharpTSMessagePort : SharpTSEventEmitter
             // MessageChannel-created ports also have no owner interpreter until
             // someone interacts with them, so capture it here — without it,
             // queued messages are never delivered.
-            "on" or "addListener" or "once" => new BuiltInMethod(name, 2, (interp, recv, args) =>
+            "on" or "addListener" or "once" => BuiltInMethod.CreateV2(name, 2, (interp, _, args) =>
             {
-                var eventName = args[0]?.ToString()
+                var eventName = args[0].ToObject()?.ToString()
                     ?? throw new Exception("Event name must be a string");
-                var listener = args[1]
+                var listener = args[1].ToObject()
                     ?? throw new Exception("Listener must be a function");
                 AddListenerDirect(eventName, listener, once: name == "once");
                 if (eventName == "message")
@@ -219,7 +219,7 @@ public class SharpTSMessagePort : SharpTSEventEmitter
                     OwnerInterpreter ??= interp;
                     Start();
                 }
-                return this;
+                return RuntimeValue.FromObject(this);
             }),
 
             // Inherit EventEmitter methods

--- a/Runtime/Types/SharpTSWorker.cs
+++ b/Runtime/Types/SharpTSWorker.cs
@@ -492,7 +492,10 @@ internal class WorkerParentPort : SharpTSEventEmitter
 {
     private readonly SharpTSWorker _worker;
 
-    public override TypeCategory RuntimeCategory => TypeCategory.EventEmitter;
+    // RuntimeCategory deliberately not overridden — see SharpTSMessagePort.
+    // The EventEmitter category dispatched through a base-typed cast that
+    // hid this class's postMessage (#209); the per-type registration in
+    // BuiltInRegistry reaches the derived GetMember instead.
 
     public WorkerParentPort(SharpTSWorker worker)
     {

--- a/SharpTS.Tests/ParserTests/TypedCatchBindingTests.cs
+++ b/SharpTS.Tests/ParserTests/TypedCatchBindingTests.cs
@@ -1,0 +1,67 @@
+using SharpTS.Parsing;
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.ParserTests;
+
+/// <summary>
+/// Tests for typed catch bindings (#215): `catch (e: any)` and
+/// `catch (e: unknown)` parse per the TS spec; any other annotation parses
+/// but produces checker error TS1196 — never a parse error.
+/// </summary>
+public class TypedCatchBindingTests
+{
+    private static List<Stmt> Parse(string source)
+    {
+        var lexer = new Lexer(source);
+        var tokens = lexer.ScanTokens();
+        var parser = new Parser(tokens);
+        return parser.ParseOrThrow();
+    }
+
+    [Theory]
+    [InlineData("any")]
+    [InlineData("unknown")]
+    [InlineData("string")]
+    public void CatchBindingAnnotation_Parses(string annotation)
+    {
+        var stmts = Parse($"try {{ throw 1; }} catch (e: {annotation}) {{ }}");
+        var tryCatch = Assert.IsType<Stmt.TryCatch>(stmts[0]);
+        Assert.Equal("e", tryCatch.CatchParam?.Lexeme);
+        Assert.Equal(annotation, tryCatch.CatchParamType);
+    }
+
+    [Fact]
+    public void CatchBinding_NoAnnotation_TypeIsNull()
+    {
+        var stmts = Parse("try { throw 1; } catch (e) { }");
+        var tryCatch = Assert.IsType<Stmt.TryCatch>(stmts[0]);
+        Assert.Null(tryCatch.CatchParamType);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void CatchBinding_AnyAndUnknown_Run(ExecutionMode mode)
+    {
+        var source = """
+            try { throw 1; } catch (e: any) { console.log("any", e); }
+            try { throw 2; } catch (e: unknown) { console.log("unknown"); }
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("any 1\nunknown\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void CatchBinding_OtherAnnotation_IsTypeErrorNotParseError(ExecutionMode mode)
+    {
+        var source = """
+            try { throw 1; } catch (e: string) { console.log(e); }
+            """;
+
+        var ex = Assert.ThrowsAny<SharpTS.TypeSystem.Exceptions.TypeCheckException>(
+            () => TestHarness.Run(source, mode));
+        Assert.Contains("must be 'any' or 'unknown'", ex.Message);
+    }
+}

--- a/SharpTS.Tests/SharedTests/AsyncCallbackResumeTests.cs
+++ b/SharpTS.Tests/SharedTests/AsyncCallbackResumeTests.cs
@@ -1,0 +1,90 @@
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests;
+
+/// <summary>
+/// Regression tests for #205/#207: pending fs callbacks keep the event loop
+/// alive, and async callbacks invoked by built-ins keep their scope chain
+/// across await suspensions (the resumed frame must still see module-level
+/// bindings).
+/// </summary>
+public class AsyncCallbackResumeTests
+{
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void FsReadFile_Callback_KeepsProcessAlive(ExecutionMode mode)
+    {
+        // #205: with no other pending work, the process must stay alive until
+        // the readFile callback has fired.
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import * as fs from "fs";
+                import * as os from "os";
+                import * as path from "path";
+                const p = path.join(os.tmpdir(), "sharpts-i205-" + process.pid + ".txt");
+                fs.writeFileSync(p, "hello");
+                fs.readFile(p, "utf8", (err: any, data: any) => {
+                    console.log("callback fired:", data);
+                    fs.unlinkSync(p);
+                });
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("callback fired: hello\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void AsyncCallback_ResumesWithModuleScope_AfterAwait(ExecutionMode mode)
+    {
+        // #207: an async arrow passed to a built-in (server.listen) suspends at
+        // its first await; the resumed continuation must still resolve
+        // module-level bindings ('server') — previously the interpreter's
+        // ambient environment had been restored to the outer scope by then and
+        // the continuation died with "Undefined variable", leaking the server
+        // handle and hanging the process.
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import * as http from "http";
+                const server: any = http.createServer((req: any, res: any) => res.end("ok"));
+                server.listen(0, async () => {
+                    console.log("before await");
+                    await new Promise((r: any) => setTimeout(r, 10));
+                    console.log("after await");
+                    server.close();
+                });
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("before await\nafter await\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void AsyncCallback_FetchAfterAwait_InListenCallback(ExecutionMode mode)
+    {
+        // The full #207 repro: await fetch() against the just-started server,
+        // then use module bindings after the await.
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import * as http from "http";
+                const server: any = http.createServer((req: any, res: any) => res.end("ok"));
+                server.listen(0, async () => {
+                    const port = server.address().port;
+                    const r: any = await fetch("http://127.0.0.1:" + port + "/");
+                    console.log("status", r.status);
+                    server.close();
+                });
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("status 200\n", output);
+    }
+}

--- a/SharpTS.Tests/SharedTests/BuiltInModules/DnsModuleTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/DnsModuleTests.cs
@@ -204,9 +204,90 @@ public class DnsModuleTests
         Assert.Equal("error thrown\n", output);
     }
 
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void Dns_Lookup_Callback_InvokedWithAddressAndFamily(ExecutionMode mode)
+    {
+        // #206: the callback form must invoke (err, address, family)
+        // asynchronously and keep the event loop alive until it fires.
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import { lookup } from 'dns';
+                lookup('localhost', (err: any, address: any, family: any) => {
+                    console.log(err === null);
+                    console.log(address === '127.0.0.1' || address === '::1');
+                    console.log(family === 4 || family === 6);
+                });
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("true\ntrue\ntrue\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void Dns_Lookup_Callback_AllOption_ReceivesArray(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import { lookup } from 'dns';
+                lookup('localhost', { all: true }, (err: any, addresses: any) => {
+                    console.log(err === null);
+                    console.log(addresses.length > 0);
+                    console.log(typeof addresses[0].address === 'string');
+                });
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("true\ntrue\ntrue\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void Dns_Lookup_Callback_InvalidHostname_ReceivesError(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import { lookup } from 'dns';
+                lookup('this.hostname.definitely.does.not.exist.example', (err: any, address: any) => {
+                    console.log(err !== null);
+                    console.log(address === null);
+                });
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("true\ntrue\n", output);
+    }
+
     #endregion
 
     #region dns.lookupService Tests
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void Dns_LookupService_Callback_InvokedWithHostnameAndService(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import { lookupService } from 'dns';
+                lookupService('127.0.0.1', 80, (err: any, hostname: any, service: any) => {
+                    console.log(err === null);
+                    console.log(typeof hostname === 'string');
+                    console.log(service === '80');
+                });
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("true\ntrue\ntrue\n", output);
+    }
 
     [Theory]
     [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]

--- a/SharpTS.Tests/SharedTests/BuiltInModules/StreamsWebBasicTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/StreamsWebBasicTests.cs
@@ -46,6 +46,34 @@ public class StreamsWebBasicTests
         Assert.Equal("hello false\nworld false\nundefined true\n", output);
     }
 
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void ReadableStream_From_ImportedConstructor(ExecutionMode mode)
+    {
+        // #210: static-property dispatch on the imported constructor wrapper
+        // (ReadableStream.from) must route through its GetProperty.
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import { ReadableStream as RS } from "stream/web";
+                const rs = (RS as any).from(["x", "y"]);
+                const reader = rs.getReader();
+                async function run() {
+                    const r1 = await reader.read();
+                    console.log(r1.value, r1.done);
+                    const r2 = await reader.read();
+                    console.log(r2.value, r2.done);
+                    const r3 = await reader.read();
+                    console.log(r3.value, r3.done);
+                }
+                run();
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("x false\ny false\nundefined true\n", output);
+    }
+
     #endregion
 
     #region Read result JS semantics (regression: MakeReadResult must behave like a real object)

--- a/SharpTS.Tests/SharedTests/HttpModuleTests.cs
+++ b/SharpTS.Tests/SharedTests/HttpModuleTests.cs
@@ -102,6 +102,30 @@ public class HttpModuleTests : IDisposable
 
     [Theory]
     [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void HttpListenZero_BindsEphemeralPort(ExecutionMode mode)
+    {
+        // #214: HttpListener has no dynamic-port support, so listen(0) probes
+        // a free port. server.address() must report the assigned port.
+        var files = new Dictionary<string, string>
+        {
+            ["./main.ts"] = """
+                import * as http from 'http';
+                const server: any = http.createServer((req: any, res: any) => {
+                    res.end('OK');
+                });
+                server.listen(0, () => {
+                    const addr = server.address();
+                    console.log(typeof addr.port === 'number' && addr.port > 0);
+                    server.close();
+                });
+                """
+        };
+        var output = TestHarness.RunModules(files, "./main.ts", mode);
+        Assert.Equal("true\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void HttpStatusCodes(ExecutionMode mode)
     {
         // Test STATUS_CODES constant

--- a/SharpTS.Tests/SharedTests/NamespaceGlobalBindingTests.cs
+++ b/SharpTS.Tests/SharedTests/NamespaceGlobalBindingTests.cs
@@ -1,0 +1,90 @@
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests;
+
+/// <summary>
+/// Tests for built-in namespaces/constructors bound as value-position globals
+/// (#208): AbortSignal, Intl, ReadableStream, WritableStream, TransformStream,
+/// MessageChannel. Interpreter-only — the compiled-mode globals are tracked
+/// separately.
+/// </summary>
+public class NamespaceGlobalBindingTests
+{
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void AbortSignal_StaticAbort_Resolves(ExecutionMode mode)
+    {
+        var source = """
+            const s: any = AbortSignal.abort("why");
+            console.log(s.aborted);
+            console.log(s.reason);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("true\nwhy\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void AbortSignal_DirectConstruction_Throws(ExecutionMode mode)
+    {
+        var source = """
+            try {
+                new (AbortSignal as any)();
+            } catch (e) {
+                console.log("threw");
+            }
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("threw\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void Intl_ValuePosition_AndMemberConstruction(ExecutionMode mode)
+    {
+        var source = """
+            const I: any = Intl;
+            const nf = new I.NumberFormat("en-US");
+            console.log(nf.format(1234.5));
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("1,234.5\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void WebStreamConstructors_ValuePosition_AndInstanceof(ExecutionMode mode)
+    {
+        var source = """
+            const ctor: any = ReadableStream;
+            console.log(typeof ctor);
+            const rs = new ctor({ start(c: any) { c.enqueue(1); c.close(); } });
+            console.log(rs instanceof (ReadableStream as any));
+            console.log(typeof (WritableStream as any), typeof (TransformStream as any));
+            const fromStream = (ReadableStream as any).from(["a"]);
+            console.log(typeof fromStream);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("function\ntrue\nfunction function\nobject\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void MessageChannel_ValuePosition(ExecutionMode mode)
+    {
+        var source = """
+            const MC: any = MessageChannel;
+            console.log(typeof MC);
+            const mc = new MC();
+            console.log(!!mc.port1, !!mc.port2);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("function\ntrue true\n", output);
+    }
+}

--- a/SharpTS.Tests/SharedTests/NetModuleTests.cs
+++ b/SharpTS.Tests/SharedTests/NetModuleTests.cs
@@ -175,6 +175,33 @@ public class NetModuleTests
 
     [Theory]
     [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void NetConnectPositionalPortHostCallback(ExecutionMode mode)
+    {
+        // Node signature: net.connect(port[, host][, connectListener]) — the
+        // three-positional-arg idiom was rejected with an arity error (#211).
+        var files = new Dictionary<string, string>
+        {
+            ["./main.ts"] = """
+                import * as net from 'net';
+                const server = net.createServer((socket) => {
+                    socket.destroy();
+                    server.close();
+                });
+                server.listen(0, () => {
+                    const addr = server.address();
+                    const client = net.connect(addr.port, '127.0.0.1', () => {
+                        console.log('connect listener fired');
+                        client.destroy();
+                    });
+                });
+                """
+        };
+        var output = TestHarness.RunModules(files, "./main.ts", mode);
+        Assert.Contains("connect listener fired", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void NetSocketWriteAndReceive(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>

--- a/SharpTS.Tests/SharedTests/RegExpFlagPropertyTests.cs
+++ b/SharpTS.Tests/SharedTests/RegExpFlagPropertyTests.cs
@@ -1,0 +1,57 @@
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests;
+
+/// <summary>
+/// Tests for the newer RegExp flag accessor properties on instances
+/// (sticky/dotAll/hasIndices/unicode/unicodeSets — issue #212).
+/// Runs against both interpreter and compiler.
+/// </summary>
+public class RegExpFlagPropertyTests
+{
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void FlagProperties_SetFlags_ReadTrue(ExecutionMode mode)
+    {
+        var source = """
+            console.log(/a/y.sticky);
+            console.log(/a/s.dotAll);
+            console.log(/a/d.hasIndices);
+            console.log(/a/u.unicode);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("true\ntrue\ntrue\ntrue\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void FlagProperties_UnsetFlags_ReadFalse(ExecutionMode mode)
+    {
+        var source = """
+            console.log(/a/.sticky);
+            console.log(/a/.dotAll);
+            console.log(/a/.hasIndices);
+            console.log(/a/.unicode);
+            console.log(/a/.unicodeSets);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("false\nfalse\nfalse\nfalse\nfalse\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void FlagsString_IncludesHasIndicesAndSticky(ExecutionMode mode)
+    {
+        var source = """
+            console.log(/a/d.flags);
+            console.log(/a/y.flags);
+            console.log(/a/s.flags);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("d\ny\ns\n", output);
+    }
+}

--- a/SharpTS.Tests/SharedTests/WorkerThreadsTests.cs
+++ b/SharpTS.Tests/SharedTests/WorkerThreadsTests.cs
@@ -293,6 +293,29 @@ public class WorkerThreadsTests
         Assert.Equal("true\ntrue\ntrue\n", output);
     }
 
+    // Interpreter-only: the compiled-mode MessageChannel drops messages
+    // entirely (listener never fires) — tracked separately from #209.
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void MessageChannel_PortOnMessage_ReceivesPostedValue(ExecutionMode mode)
+    {
+        // #209: port.on() must dispatch through the port's own member table
+        // (postMessage/start/close reachable), a 'message' listener implicitly
+        // starts the port, and the listener receives the cloned value directly
+        // per Node worker_threads semantics.
+        var source = @"
+            let channel: any = new MessageChannel();
+            channel.port2.on('message', (value: any) => {
+                console.log('received: ' + value);
+                channel.port1.close();
+                channel.port2.close();
+            });
+            channel.port1.postMessage('hello');
+        ";
+        var output = TestHarness.Run(source, mode);
+        Assert.Contains("received: hello", output);
+    }
+
     #endregion
 
     #region StructuredClone Tests

--- a/SharpTS.Tests/TypeCheckerTests/DisjunctionEarlyReturnNarrowingTests.cs
+++ b/SharpTS.Tests/TypeCheckerTests/DisjunctionEarlyReturnNarrowingTests.cs
@@ -1,0 +1,114 @@
+using SharpTS.Modules;
+using SharpTS.Tests.Infrastructure;
+using SharpTS.TypeSystem;
+using Xunit;
+
+namespace SharpTS.Tests.TypeCheckerTests;
+
+/// <summary>
+/// Tests for #216: narrowing after an early-return `||` guard
+/// (`if (x == null || x.length === 0) return;` must narrow x afterward),
+/// the events-module import that exposed it, and module-file attribution
+/// on diagnostics raised inside module sources.
+/// </summary>
+public class DisjunctionEarlyReturnNarrowingTests
+{
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void DisjunctionNullGuard_EarlyReturn_NarrowsAfter(ExecutionMode mode)
+    {
+        var source = """
+            function f(arr: string[] | null): number {
+                if (arr == null || arr.length === 0) return 0;
+                return arr.length;
+            }
+            console.log(f(["a", "b"]));
+            console.log(f(null));
+            console.log(f([]));
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("2\n0\n0\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void NestedDisjunctionGuard_EarlyReturn_NarrowsAll(ExecutionMode mode)
+    {
+        var source = """
+            function f(a: string | null, b: string | null): number {
+                if (a == null || b == null || a.length === 0) return 0;
+                return a.length + b.length;
+            }
+            console.log(f("ab", "c"));
+            console.log(f(null, "c"));
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("3\n0\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void EventsModuleImport_TypeChecksAndRuns(ExecutionMode mode)
+    {
+        // The original #216 repro: importing EventEmitter triggered a
+        // null-property-access diagnostic inside the events module source.
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import { EventEmitter } from "events";
+                const ee: any = new EventEmitter();
+                ee.on("x", () => {});
+                console.log(ee.eventNames().length);
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("1\n", output);
+    }
+
+    [Fact]
+    public void ModuleDiagnostics_CarryFileAttribution()
+    {
+        // Sub-problem 2 of #216: diagnostics raised inside a module source
+        // must name the file, not report a bare line number.
+        var tempDir = Path.Combine(Path.GetTempPath(), $"sharpts_i216_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            File.WriteAllText(Path.Combine(tempDir, "main.ts"), """
+                import { f } from "./dep";
+                console.log(f(["a"]));
+                """);
+            File.WriteAllText(Path.Combine(tempDir, "dep.ts"), """
+                export function f(arr: string[] | null): number {
+                    return arr.length;
+                }
+                """);
+
+            var entryPath = Path.Combine(tempDir, "main.ts");
+            var resolver = new ModuleResolver(entryPath);
+            var entryModule = resolver.LoadModule(entryPath);
+            var modules = resolver.GetModulesInOrder(entryModule);
+
+            var checker = new TypeChecker();
+            checker.CheckModules(modules, resolver);
+
+            // (The diagnostic is recorded once per checking pass — assert on
+            // attribution, not cardinality.)
+            var diagnostics = checker.GetDiagnostics()
+                .Where(d => d.Message.Contains("length")).ToList();
+            Assert.NotEmpty(diagnostics);
+            Assert.All(diagnostics, d =>
+            {
+                Assert.NotNull(d.Location?.FilePath);
+                Assert.Contains("dep.ts", d.Location!.FilePath!);
+            });
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+}

--- a/TypeSystem/BuiltInModuleTypes.cs
+++ b/TypeSystem/BuiltInModuleTypes.cs
@@ -1541,8 +1541,9 @@ public static class BuiltInModuleTypes
         return new Dictionary<string, TypeInfo>
         {
             ["createServer"] = new TypeInfo.Function([anyType, anyType], serverType, RequiredParams: 0),
-            ["createConnection"] = new TypeInfo.Function([anyType, anyType], socketType, RequiredParams: 1),
-            ["connect"] = new TypeInfo.Function([anyType, anyType], socketType, RequiredParams: 1),
+            // connect(options|port|path[, host][, connectListener]) — three positional args
+            ["createConnection"] = new TypeInfo.Function([anyType, anyType, anyType], socketType, RequiredParams: 1),
+            ["connect"] = new TypeInfo.Function([anyType, anyType, anyType], socketType, RequiredParams: 1),
             ["isIP"] = new TypeInfo.Function([stringType], numberType),
             ["isIPv4"] = new TypeInfo.Function([stringType], booleanType),
             ["isIPv6"] = new TypeInfo.Function([stringType], booleanType),

--- a/TypeSystem/BuiltInModuleTypes.cs
+++ b/TypeSystem/BuiltInModuleTypes.cs
@@ -1292,16 +1292,17 @@ public static class BuiltInModuleTypes
 
         return new Dictionary<string, TypeInfo>
         {
-            // dns.lookup(hostname, [options]) -> { address, family }
+            // dns.lookup(hostname[, options][, callback]) -> { address, family }
+            // (sync direct-return form when no callback; Node form invokes the callback)
             ["lookup"] = new TypeInfo.Function(
-                [stringType, anyType],
+                [stringType, anyType, anyType],
                 lookupResultType,
                 RequiredParams: 1
             ),
 
-            // dns.lookupService(address, port) -> { hostname, service }
+            // dns.lookupService(address, port[, callback]) -> { hostname, service }
             ["lookupService"] = new TypeInfo.Function(
-                [stringType, numberType],
+                [stringType, numberType, anyType],
                 lookupServiceResultType,
                 RequiredParams: 2
             ),

--- a/TypeSystem/TypeChecker.Compatibility.TypeGuards.cs
+++ b/TypeSystem/TypeChecker.Compatibility.TypeGuards.cs
@@ -710,6 +710,82 @@ public partial class TypeChecker
     }
 
     /// <summary>
+    /// Flattens an <c>||</c> chain and collects the type guard of each
+    /// disjunct (#216). Callers use the EXCLUDED types: in contexts where the
+    /// whole disjunction is known false — the right operand of <c>||</c>, or
+    /// code following a terminating <c>if (a == null || b == null) return;</c>
+    /// — De Morgan gives the negation of every disjunct. Disjuncts that are
+    /// not simple guards (including nested <c>&amp;&amp;</c>, whose negation
+    /// is itself a disjunction) contribute nothing. Later disjuncts are
+    /// analyzed under the accumulated exclusions of earlier ones so that
+    /// CheckExpr calls inside the analysis (e.g. <c>a.length === 0</c> after
+    /// <c>a == null</c>) see the narrowed receiver.
+    /// </summary>
+    private List<(Narrowing.NarrowingPath Path, TypeInfo NarrowedType, TypeInfo ExcludedType)> CollectDisjunctGuards(Expr condition)
+    {
+        var narrowings = new List<(Narrowing.NarrowingPath Path, TypeInfo NarrowedType, TypeInfo ExcludedType)>();
+
+        void Walk(Expr expr)
+        {
+            if (expr is Expr.Logical orExpr && orExpr.Operator.Type == TokenType.OR_OR)
+            {
+                Walk(orExpr.Left);
+
+                // Analyze the right disjunct with the left disjuncts' excluded
+                // types in scope (mirrors the && handling above).
+                if (narrowings.Count > 0)
+                {
+                    var narrowedEnv = new TypeEnvironment(_environment);
+                    var narrowedCtx = Narrowing.NarrowingContext.Empty;
+                    foreach (var (path, _, excludedType) in narrowings)
+                    {
+                        if (path is Narrowing.NarrowingPath.Variable v)
+                            narrowedEnv.Define(v.Name, excludedType);
+                        else
+                            narrowedCtx = narrowedCtx.WithNarrowing(path, excludedType);
+                    }
+
+                    using (new EnvironmentScope(this, narrowedEnv))
+                    {
+                        bool pushed = !narrowedCtx.IsEmpty;
+                        if (pushed) PushNarrowingContext(narrowedCtx);
+                        try
+                        {
+                            Walk(orExpr.Right);
+                        }
+                        finally
+                        {
+                            if (pushed) PopNarrowingContext();
+                        }
+                    }
+                }
+                else
+                {
+                    Walk(orExpr.Right);
+                }
+                return;
+            }
+
+            var guard = AnalyzePathTypeGuard(expr);
+            if (guard.Path != null && guard.NarrowedType != null && guard.ExcludedType != null)
+            {
+                narrowings.Add((guard.Path, guard.NarrowedType, guard.ExcludedType));
+                return;
+            }
+
+            var legacyGuard = AnalyzeTypeGuard(expr);
+            if (legacyGuard.VarName != null && legacyGuard.NarrowedType != null && legacyGuard.ExcludedType != null)
+            {
+                narrowings.Add((new Narrowing.NarrowingPath.Variable(legacyGuard.VarName),
+                    legacyGuard.NarrowedType, legacyGuard.ExcludedType));
+            }
+        }
+
+        Walk(condition);
+        return narrowings;
+    }
+
+    /// <summary>
     /// Analyzes a null check for a narrowable path.
     /// </summary>
     private (Narrowing.NarrowingPath? Path, TypeInfo? NarrowedType, TypeInfo? ExcludedType) AnalyzePathNullCheck(

--- a/TypeSystem/TypeChecker.Operators.cs
+++ b/TypeSystem/TypeChecker.Operators.cs
@@ -120,9 +120,15 @@ public partial class TypeChecker
 
         // Apply expression-level narrowing for the right operand
         // For &&: right is evaluated when left is truthy, so apply "narrowed" types
-        // For ||: right is evaluated when left is falsy, so apply "excluded" types
+        // For ||: right is evaluated when left is falsy, so apply "excluded" types.
+        //   The || case decomposes a disjunction LHS (De Morgan: !(A || B) =
+        //   !A && !B), so `a == null || b == null || a.length` narrows both
+        //   a and b for the last operand (#216). An && LHS contributes nothing
+        //   to || — its negation is itself a disjunction.
         TypeInfo rightType;
-        var narrowings = AnalyzeCompoundTypeGuards(logical.Left);
+        var narrowings = logical.Operator.Type == TokenType.OR_OR
+            ? CollectDisjunctGuards(logical.Left)
+            : AnalyzeCompoundTypeGuards(logical.Left);
 
         if (narrowings.Count > 0)
         {

--- a/TypeSystem/TypeChecker.Statements.ControlFlow.cs
+++ b/TypeSystem/TypeChecker.Statements.ControlFlow.cs
@@ -1,4 +1,5 @@
 using SharpTS.Parsing;
+using SharpTS.TypeSystem.Exceptions;
 
 namespace SharpTS.TypeSystem;
 
@@ -59,11 +60,26 @@ public partial class TypeChecker
             CheckStmt(stmt);
         }
 
+        // TS1196: a catch-binding annotation must be exactly 'any' or 'unknown'.
+        // The parser accepts any annotation (#215); the restriction is a
+        // checker diagnostic, matching tsc — never a parse error.
+        if (tryCatch.CatchParamType is { } catchAnnotation
+            && catchAnnotation != "any" && catchAnnotation != "unknown")
+        {
+            throw new TypeOperationException(
+                "Catch clause variable type annotation must be 'any' or 'unknown' if specified.",
+                tryCatch.CatchParam?.Line,
+                tsCode: "TS1196");
+        }
+
         // Check catch block with its parameter in scope
         if (tryCatch.CatchBlock != null && tryCatch.CatchParam != null)
         {
             TypeEnvironment catchEnv = new(_environment);
-            catchEnv.Define(tryCatch.CatchParam.Lexeme, new TypeInfo.Any());
+            catchEnv.Define(tryCatch.CatchParam.Lexeme,
+                tryCatch.CatchParamType == "unknown"
+                    ? new TypeInfo.Unknown()
+                    : new TypeInfo.Any());
 
             TypeEnvironment prevEnv = _environment;
             _environment = catchEnv;

--- a/TypeSystem/TypeChecker.Statements.cs
+++ b/TypeSystem/TypeChecker.Statements.cs
@@ -412,9 +412,42 @@ public partial class TypeChecker
             {
                 CheckStmt(stmt.ThenBranch);
                 if (stmt.ElseBranch != null) CheckStmt(stmt.ElseBranch);
+
+                // `if (A || B) return;` — when the then-branch always
+                // terminates and there is no else, the code after the if sees
+                // the negation of EVERY disjunct (De Morgan): apply each
+                // disjunct's excluded type. Handles the early-return guard
+                // idiom `if (x == null || x.length === 0) return;` (#216) —
+                // compound analysis only decomposes &&, and the legacy guard
+                // can't see through ||.
+                if (stmt.ElseBranch == null
+                    && AlwaysTerminates(stmt.ThenBranch)
+                    && stmt.Condition is Expr.Logical { } topOr
+                    && topOr.Operator.Type == TokenType.OR_OR)
+                {
+                    ApplyDisjunctExclusions(topOr);
+                }
             }
         }
         return VoidResult.Instance;
+    }
+
+    /// <summary>
+    /// Applies each disjunct's excluded type to the current environment.
+    /// Used after a terminating then-branch with no else, where the negation
+    /// of every disjunct is known to hold. Variable paths only — property
+    /// path exclusions would need a narrowing-context push scoped to the
+    /// rest of the enclosing block, which the context stack doesn't model.
+    /// </summary>
+    private void ApplyDisjunctExclusions(Expr.Logical orExpr)
+    {
+        foreach (var (path, _, excludedType) in CollectDisjunctGuards(orExpr))
+        {
+            if (path is Narrowing.NarrowingPath.Variable varPath)
+            {
+                _environment.Define(varPath.Name, excludedType);
+            }
+        }
     }
 
     /// <summary>

--- a/TypeSystem/TypeChecker.cs
+++ b/TypeSystem/TypeChecker.cs
@@ -1043,6 +1043,11 @@ public partial class TypeChecker
         foreach (var module in modules)
         {
             _currentModule = module;
+            // Attribute diagnostics to the module being checked — without
+            // this, errors raised inside module sources (including built-in
+            // module declarations like events.ts) render as bare
+            // "at line N" with no file context (#216).
+            _filePath = module.Path;
             if (module.IsScript)
             {
                 // Scripts use shared environment and don't export
@@ -1063,6 +1068,7 @@ public partial class TypeChecker
             }
 
             _currentModule = module;
+            _filePath = module.Path; // diagnostic attribution — see first pass (#216)
 
             if (module.IsScript)
             {
@@ -1146,6 +1152,7 @@ public partial class TypeChecker
         }
 
         _currentModule = null;
+        _filePath = null;
         return _typeMap;
     }
 


### PR DESCRIPTION
Fixes the eleven bugs filed during the V2 delegate-body migration, one commit per bug, rebased onto main after the v2-migration merge (#218). All new built-in registrations use the CreateV2 form.

## Fixes

- **#212 — RegExp flag properties**: `sticky`/`dotAll`/`hasIndices`/`unicode`/`unicodeSets` now readable on instances in both modes (interpreter GetMember arms + prototype accessors, type-checker member types, compiled $Runtime flag getters). Also fixes a latent IL stack-imbalance bug in `RegExpEmitter` (receiver emitted before the property was known to be handled) and the `d`/`v` chars missing from `.flags`.
- **#211 — net.connect arity**: module-level `connect`/`createConnection` accept the `(port, host, connectListener)` three-positional Node form in both modes; previously compiled mode silently treated the host string as the callback.
- **#209 — MessagePort dispatch**: removed the `RuntimeCategory => EventEmitter` overrides that routed property access through a base-typed cast (hiding `postMessage`/`start`/`close`); registered `WorkerParentPort` as an instance type; `'message'` listeners now implicitly start the port and receive the cloned value directly per Node semantics.
- **#210 — ReadableStream.from**: the imported constructor wrapper is registered as an instance type so its static `from` dispatches (same pattern as `SharpTSBufferConstructor`).
- **#208 — namespace globals**: `AbortSignal`, `Intl`, `ReadableStream`, `WritableStream`, `TransformStream`, `MessageChannel` bound as value-position globals; web-streams `instanceof` recognizes the wrapper singletons; `AbortSignal`/`Intl` direct construction throws per spec.
- **#214 — http listen(0)**: probes a free port via a temporary loopback TcpListener before starting HttpListener (interpreter + emitted $HttpServer, BCL-only IL); interpreter `server.address()` is now a method per the Node API.
- **#215 — typed catch bindings**: `catch (e: any)` / `(e: unknown)` parse; any other annotation is checker error TS1196, not a parse error. TS conformance: no bucket changes.
- **#206 — dns.lookup callbacks**: `lookup`/`lookupService` callback forms now resolve off-thread and invoke their callbacks with Ref/Unref keep-alive; the legacy synchronous no-callback form is preserved.
- **#205 — fs callback keep-alive**: all 20 callback-form fs dispatch sites Ref the event loop until `ScheduleCallback` releases it after the callback runs.
- **#207 — async callback resume**: root-caused via stack dump — the continuation *did* resume but the tree-walk's ambient `_environment` had been restored to an outer scope by then, so module bindings resolved as "Undefined variable" and the rejection was silently dropped (hanging the process via the leaked server Ref). `AwaitPreservingEnvironment` re-asserts the suspended frame's environment after every guest-task await (await expr, for-await unwrap, async-iterator next).
- **#216 — events import type error**: two fixes — narrowing after early-return `||` guards (`CollectDisjunctGuards` decomposes disjunctions De Morgan-style for the `||` RHS and post-terminating-if code), and `CheckModules` now attributes diagnostics to the module file (`Type Error at <path>:line:col`).

## Issues filed along the way

- #222 — compiled-mode MessageChannel drops messages
- #223 — web-streams reader promises are raw Tasks (`.then()` throws)
- #224 — compiled-mode AbortSignal/Intl/web-streams globals unusable
- #228 — exceptions in async callbacks invoked by built-ins are silently swallowed (how #207 stayed hidden)

## Testing

- Full suite: 10,571/10,571 green after the rebase.
- TS conformance suite: 31/31, no bucket changes (run for #215 and #216).
- New regression tests per fix (interpreter-only where the compiled-mode equivalent is tracked by a filed issue).