### PR TITLE
Bugfix batch: #213, #220 (+ scoping disposition for #221)

### DIFF
--- a/Compilation/RuntimeEmitter.Promises.Any.cs
+++ b/Compilation/RuntimeEmitter.Promises.Any.cs
@@ -362,14 +362,17 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Callvirt, _types.GetProperty(listType, "Count").GetGetMethod()!);
         il.Emit(OpCodes.Stloc, countLocal);
 
-        // Check for empty list - throw AggregateException
+        // ECMA-262 §27.2.4.3: empty iterable → reject with an AggregateError
+        // whose errors is []. Same guest-error construction as the
+        // all-rejected path; the outer catch turns the throw into a rejection.
         var notEmptyLabel = il.DefineLabel();
         il.Emit(OpCodes.Ldloc, countLocal);
         il.Emit(OpCodes.Brtrue, notEmptyLabel);
 
-        // Empty list - throw exception
-        il.Emit(OpCodes.Ldstr, "AggregateError: All promises were rejected");
-        il.Emit(OpCodes.Newobj, _types.GetConstructor(_types.Exception, [_types.String]));
+        il.Emit(OpCodes.Newobj, _types.GetConstructor(_types.ListOfObject, _types.EmptyTypes));  // errors = []
+        il.Emit(OpCodes.Ldnull);  // message (use default)
+        il.Emit(OpCodes.Newobj, runtime.TSAggregateErrorCtor);
+        il.Emit(OpCodes.Call, runtime.CreateException);
         il.Emit(OpCodes.Throw);
 
         il.MarkLabel(notEmptyLabel);

--- a/Compilation/RuntimeEmitter.TSNetClosures.cs
+++ b/Compilation/RuntimeEmitter.TSNetClosures.cs
@@ -398,6 +398,19 @@ public partial class RuntimeEmitter
             il.Emit(OpCodes.Callvirt, runtime.TSEventEmitterEmit);
             il.Emit(OpCodes.Pop);
 
+            // Skip 'close' if already emitted (e.g. an 'end' listener called
+            // destroy(), whose Destroy body fired 'close' synchronously).
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, socketField);
+            il.Emit(OpCodes.Ldfld, _netSocketCloseEmittedField);
+            il.Emit(OpCodes.Brtrue, checkReading);
+
+            // _socket._closeEmitted = true
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, socketField);
+            il.Emit(OpCodes.Ldc_I4_1);
+            il.Emit(OpCodes.Stfld, _netSocketCloseEmittedField);
+
             // _socket.Emit("close", new object[] { false })
             il.Emit(OpCodes.Ldarg_0);
             il.Emit(OpCodes.Ldfld, socketField);

--- a/Compilation/RuntimeEmitter.TSNetSocket.cs
+++ b/Compilation/RuntimeEmitter.TSNetSocket.cs
@@ -26,6 +26,7 @@ public partial class RuntimeEmitter
     private FieldBuilder _netSocketStreamField = null!;
     private FieldBuilder _netSocketConnectingField = null!;
     private FieldBuilder _netSocketDestroyedField = null!;
+    private FieldBuilder _netSocketCloseEmittedField = null!;
     private FieldBuilder _netSocketEndedField = null!;
     private FieldBuilder _netSocketBytesReadField = null!;
     private FieldBuilder _netSocketBytesWrittenField = null!;
@@ -78,6 +79,7 @@ public partial class RuntimeEmitter
         _netSocketStreamField = typeBuilder.DefineField("_stream", typeof(System.IO.Stream), FieldAttributes.Assembly);
         _netSocketConnectingField = typeBuilder.DefineField("_connecting", _types.Boolean, FieldAttributes.Assembly);
         _netSocketDestroyedField = typeBuilder.DefineField("_destroyed", _types.Boolean, FieldAttributes.Assembly);
+        _netSocketCloseEmittedField = typeBuilder.DefineField("_closeEmitted", _types.Boolean, FieldAttributes.Assembly);
         _netSocketEndedField = typeBuilder.DefineField("_ended", _types.Boolean, FieldAttributes.Private);
         _netSocketBytesReadField = typeBuilder.DefineField("_bytesRead", _types.Int32, FieldAttributes.Private);
         _netSocketBytesWrittenField = typeBuilder.DefineField("_bytesWritten", _types.Int32, FieldAttributes.Assembly);
@@ -1164,7 +1166,16 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Pop);
         il.EndExceptionBlock();
 
-        // Emit 'close' event: this.Emit("close", [error != null])
+        // Emit 'close' at most once per socket lifetime (Node semantics): the
+        // read-loop end closure may already have fired it before destroy().
+        // if (!_closeEmitted) { _closeEmitted = true; this.Emit("close", [error != null]) }
+        var closeAlreadyEmitted = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, _netSocketCloseEmittedField);
+        il.Emit(OpCodes.Brtrue, closeAlreadyEmitted);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Stfld, _netSocketCloseEmittedField);
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ldstr, "close");
         il.Emit(OpCodes.Ldc_I4_1);
@@ -1180,6 +1191,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Stelem_Ref);
         il.Emit(OpCodes.Callvirt, runtime.TSEventEmitterEmit);
         il.Emit(OpCodes.Pop);
+        il.MarkLabel(closeAlreadyEmitted);
 
         // Unref event loop if reading was started
         var noUnref = il.DefineLabel();

--- a/Runtime/Types/SharpTSSocket.cs
+++ b/Runtime/Types/SharpTSSocket.cs
@@ -20,6 +20,7 @@ public class SharpTSSocket : SharpTSEventEmitter
     private bool _connecting;
     protected internal bool _destroyed;
     private bool _ended;
+    private bool _closeEmitted;
     private int _bytesRead;
     private int _bytesWritten;
     private CancellationTokenSource? _readCts;
@@ -457,7 +458,7 @@ public class SharpTSSocket : SharpTSEventEmitter
             EmitEvent(interpreter, "error", [args[0].ToObject()]);
         }
 
-        EmitEvent(interpreter, "close", [hadError]);
+        EmitClose(interpreter, hadError);
         // Only unref if reading was started (StartReading does Ref)
         if (_readingStarted)
         {
@@ -465,6 +466,18 @@ public class SharpTSSocket : SharpTSEventEmitter
             _interpreter?.Unref();
         }
         return RuntimeValue.FromObject(this);
+    }
+
+    /// <summary>
+    /// Emits 'close' at most once per socket lifetime (Node semantics): the
+    /// read-loop EOF/error paths and Destroy can otherwise both fire it when a
+    /// handler destroys the socket in response to the remote end closing.
+    /// </summary>
+    private void EmitClose(Interp interpreter, bool hadError)
+    {
+        if (_closeEmitted) return;
+        _closeEmitted = true;
+        EmitEvent(interpreter, "close", [hadError]);
     }
 
     private RuntimeValue SetEncoding(Interp interpreter, RuntimeValue receiver, ReadOnlySpan<RuntimeValue> args)
@@ -596,7 +609,7 @@ public class SharpTSSocket : SharpTSEventEmitter
                             if (!_destroyed)
                             {
                                 EmitEvent(interpreter, "end", []);
-                                EmitEvent(interpreter, "close", [false]);
+                                EmitClose(interpreter, false);
                             }
                             if (_readingStarted)
                             {
@@ -627,7 +640,7 @@ public class SharpTSSocket : SharpTSEventEmitter
                     interpreter.ScheduleTimer(0, 0, () =>
                     {
                         EmitEvent(interpreter, "error", [new SharpTSError(ex.Message)]);
-                        EmitEvent(interpreter, "close", [true]);
+                        EmitClose(interpreter, true);
                         if (_readingStarted)
                         {
                             _readingStarted = false;

--- a/SharpTS.Tests/SharedTests/NetModuleTests.cs
+++ b/SharpTS.Tests/SharedTests/NetModuleTests.cs
@@ -234,6 +234,39 @@ public class NetModuleTests
 
     [Theory]
     [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void NetSocketCloseEmittedOnceWhenDestroyedAfterEnd(ExecutionMode mode)
+    {
+        // Node emits 'close' exactly once per socket lifetime. Calling destroy()
+        // from an 'end' handler used to fire it twice — once from Destroy and
+        // once from the read-loop EOF path (#213).
+        var files = new Dictionary<string, string>
+        {
+            ["./main.ts"] = """
+                import * as net from 'net';
+                const server = net.createServer((socket) => {
+                    socket.end();
+                });
+                server.listen(0, () => {
+                    const addr = server.address();
+                    const client = net.createConnection({ port: addr.port, host: '127.0.0.1' });
+                    let closes = 0;
+                    client.on('close', () => { closes++; });
+                    client.on('end', () => {
+                        client.destroy();
+                        setTimeout(() => {
+                            console.log('close events: ' + closes);
+                            server.close();
+                        }, 100);
+                    });
+                });
+                """
+        };
+        var output = TestHarness.RunModules(files, "./main.ts", mode);
+        Assert.Contains("close events: 1", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void NetSocketProperties(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>

--- a/SharpTS.Tests/SharedTests/PromiseMethodTests.cs
+++ b/SharpTS.Tests/SharedTests/PromiseMethodTests.cs
@@ -711,20 +711,25 @@ public class PromiseMethodTests
     [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void Any_EmptyArray_ThrowsAggregateError(ExecutionMode mode)
     {
+        // ECMA-262 §27.2.4.3: empty iterable rejects with an AggregateError
+        // whose errors is []. Compiled mode used to reject with a raw BCL
+        // Exception whose name read "Exception" (#220).
         var source = """
             async function main(): Promise<void> {
                 try {
                     await Promise.any([]);
                     console.log("should not reach");
-                } catch (e) {
+                } catch (e: any) {
                     console.log("caught");
+                    console.log(e.name);
+                    console.log(Array.isArray(e.errors) ? e.errors.length : "no errors");
                 }
             }
             main();
             """;
 
         var output = TestHarness.Run(source, mode);
-        Assert.Equal("caught\n", output);
+        Assert.Equal("caught\nAggregateError\n0\n", output);
     }
 
     #endregion


### PR DESCRIPTION
Second bugfix batch from the #205-#221 list. Issues #205-#212/#214-#216 were already fixed on main by PR #230 but never auto-closed — verified by smoke repro post-merge and closed with reference comments. This PR carries the two remaining code fixes, one commit per bug.

## Fixes

- **#213 — socket emits ''close'' twice**: calling `destroy()` from an `''end''` handler fired `close` once from `Destroy` and again from the read-loop EOF path (which had passed its `_destroyed` check before the listener ran). All close emissions now go through a `_closeEmitted` once-guard in **both modes**: an `EmitClose` helper covering the Destroy/EOF/read-error paths in the interpreter `SharpTSSocket`, and an equivalent `_closeEmitted` field checked by the emitted `Destroy` body and `$SocketReadEndClosure` in compiled output. Closes #213.
- **#220 — compiled `Promise.any([])` rejects with raw Exception**: the empty-iterable path in `RuntimeEmitter.Promises.Any.cs` predated the guest-error machinery and threw a raw BCL `Exception` (`e.name === "Exception"` compiled vs `"AggregateError"` interpreted). It now builds the same `$AggregateError(errors: [], message: null)` + `CreateException` the all-rejected path uses (ECMA-262 §27.2.4.3). Closes #220.

## #221 — scoped and parked, not fixed

Species machinery is currently unobservable from guest code, so implementing it would be dead code in both modes:

- Promise cannot be subclassed (`extends Promise` → "Superclass must be a class"; `extends Promise<T>` → checker error). Only `Error` is an extendable built-in → **#233** filed as the hard prerequisite.
- Promise instances cannot carry own properties, so the poisoned-`constructor` path is unreachable.
- `Symbol` is not a first-class global (`typeof Symbol` → `"undefined"`, aliasing fails) → **#234** filed.

Dependency order documented on #221: #234 → #233 → #221. The issue stays open per its own park-until-Test262-track note.

## Issues filed along the way

- #232 — `Promise.any` rejections fail `instanceof AggregateError` **and** `instanceof Error` in both modes, while direct `new AggregateError()` passes both.
- #233 — guest classes cannot extend built-in constructors (Promise, Array).
- #234 — `Symbol` not bound as a value-position global.

## Testing

- Full suite: **10,578/10,578 green** (3m21s).
- New regression test for #213 verified to fail (`close events: 2`) in both modes with the fix stashed.
- `Any_EmptyArray_ThrowsAggregateError` strengthened to assert `e.name` and `e.errors.length` — its previous "caught"-only assertion is what let #220 survive.