### PR TITLE
dns: extend fake-server testing, shrink live-DNS tests to a smoke set

### DIFF
--- a/Compilation/EmittedRuntime.cs
+++ b/Compilation/EmittedRuntime.cs
@@ -2487,6 +2487,8 @@ public class EmittedRuntime
     public MethodBuilder DnsDoQuery { get; set; } = null!;
 
     // DNS wire protocol helpers (emitted into output assembly)
+    public MethodBuilder DnsGetTimeoutMs { get; set; } = null!;
+    public MethodBuilder DnsParseServerEndpoint { get; set; } = null!;
     public MethodBuilder DnsGetSystemDns { get; set; } = null!;
     public MethodBuilder DnsBuildQuery { get; set; } = null!;
     public MethodBuilder DnsSendReceive { get; set; } = null!;

--- a/Compilation/RuntimeEmitter.Dns.cs
+++ b/Compilation/RuntimeEmitter.Dns.cs
@@ -20,6 +20,8 @@ public partial class RuntimeEmitter
         EmitDnsGetLookupService(typeBuilder, runtime);
 
         // DNS wire protocol helpers (emitted into output assembly, BCL-only)
+        EmitDnsGetTimeoutMsMethod(typeBuilder, runtime);
+        EmitDnsParseServerEndpointMethod(typeBuilder, runtime);
         EmitDnsReadUInt16(typeBuilder, runtime);
         EmitDnsReadUInt32(typeBuilder, runtime);
         EmitDnsReadCharString(typeBuilder, runtime);
@@ -1022,7 +1024,7 @@ public partial class RuntimeEmitter
     private void EmitDnsReadExact(TypeBuilder typeBuilder, EmittedRuntime runtime)
     {
         // Signature: void DnsReadExact(NetworkStream stream, byte[] buf, int offset, int count)
-        // Uses Task.Wait(5000) for reliable cross-platform timeout.
+        // Uses Task.Wait(DnsGetTimeoutMs()) for reliable cross-platform timeout.
         var method = typeBuilder.DefineMethod(
             "DnsReadExact",
             MethodAttributes.Public | MethodAttributes.Static,
@@ -1057,9 +1059,9 @@ public partial class RuntimeEmitter
             [typeof(byte[]), _types.Int32, _types.Int32, typeof(CancellationToken)])!);
         il.Emit(OpCodes.Stloc, readTaskLocal);
 
-        // if (!readTask.Wait(5000)) throw SocketException(TimedOut)
+        // if (!readTask.Wait(DnsGetTimeoutMs())) throw SocketException(TimedOut)
         il.Emit(OpCodes.Ldloc, readTaskLocal);
-        il.Emit(OpCodes.Ldc_I4, 5000);
+        il.Emit(OpCodes.Call, runtime.DnsGetTimeoutMs);
         il.Emit(OpCodes.Callvirt, typeof(Task).GetMethod("Wait", [_types.Int32])!);
         var waitOkLabel = il.DefineLabel();
         il.Emit(OpCodes.Brtrue, waitOkLabel);
@@ -1469,7 +1471,97 @@ public partial class RuntimeEmitter
     }
 
     /// <summary>
+    /// Emits DnsGetTimeoutMs: per-attempt DNS timeout in milliseconds.
+    /// SHARPTS_DNS_TIMEOUT_MS overrides the 5s default — mirrors
+    /// DnsWireProtocol.TimeoutMs so fake-server tests can exercise the timeout
+    /// path quickly in compiled mode too.
+    /// Signature: int DnsGetTimeoutMs()
+    /// </summary>
+    private void EmitDnsGetTimeoutMsMethod(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    {
+        var method = typeBuilder.DefineMethod(
+            "DnsGetTimeoutMs",
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.Int32,
+            Type.EmptyTypes);
+        runtime.DnsGetTimeoutMs = method;
+
+        var il = method.GetILGenerator();
+
+        var envLocal = il.DeclareLocal(_types.String);
+        var valueLocal = il.DeclareLocal(_types.Int32);
+        var defaultLabel = il.DefineLabel();
+
+        // string env = Environment.GetEnvironmentVariable("SHARPTS_DNS_TIMEOUT_MS")
+        il.Emit(OpCodes.Ldstr, "SHARPTS_DNS_TIMEOUT_MS");
+        il.Emit(OpCodes.Call, typeof(Environment).GetMethod("GetEnvironmentVariable", [_types.String])!);
+        il.Emit(OpCodes.Stloc, envLocal);
+
+        // if (env == null || !int.TryParse(env, out value) || value <= 0) goto default
+        il.Emit(OpCodes.Ldloc, envLocal);
+        il.Emit(OpCodes.Brfalse, defaultLabel);
+
+        il.Emit(OpCodes.Ldloc, envLocal);
+        il.Emit(OpCodes.Ldloca, valueLocal);
+        il.Emit(OpCodes.Call, _types.Int32.GetMethod("TryParse", [_types.String, _types.Int32.MakeByRefType()])!);
+        il.Emit(OpCodes.Brfalse, defaultLabel);
+
+        il.Emit(OpCodes.Ldloc, valueLocal);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Ble, defaultLabel);
+
+        // return value
+        il.Emit(OpCodes.Ldloc, valueLocal);
+        il.Emit(OpCodes.Ret);
+
+        // return 5000
+        il.MarkLabel(defaultLabel);
+        il.Emit(OpCodes.Ldc_I4, 5000);
+        il.Emit(OpCodes.Ret);
+    }
+
+    /// <summary>
+    /// Emits DnsParseServerEndpoint: parses a DNS server address that may carry a
+    /// port ("8.8.8.8", "127.0.0.1:5353", "[::1]:5353"); a missing port defaults
+    /// to 53. Mirrors the port handling in DnsWireProtocol.SendReceive.
+    /// Signature: IPEndPoint DnsParseServerEndpoint(string server)
+    /// </summary>
+    private void EmitDnsParseServerEndpointMethod(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    {
+        var method = typeBuilder.DefineMethod(
+            "DnsParseServerEndpoint",
+            MethodAttributes.Public | MethodAttributes.Static,
+            typeof(IPEndPoint),
+            [_types.String]);
+        runtime.DnsParseServerEndpoint = method;
+
+        var il = method.GetILGenerator();
+
+        var endpointLocal = il.DeclareLocal(typeof(IPEndPoint));
+        var doneLabel = il.DefineLabel();
+
+        // var endpoint = IPEndPoint.Parse(server)  — a bare address parses with Port == 0
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Call, typeof(IPEndPoint).GetMethod("Parse", [_types.String])!);
+        il.Emit(OpCodes.Stloc, endpointLocal);
+
+        // if (endpoint.Port == 0) endpoint.Port = 53
+        il.Emit(OpCodes.Ldloc, endpointLocal);
+        il.Emit(OpCodes.Callvirt, typeof(IPEndPoint).GetProperty("Port")!.GetGetMethod()!);
+        il.Emit(OpCodes.Brtrue, doneLabel);
+
+        il.Emit(OpCodes.Ldloc, endpointLocal);
+        il.Emit(OpCodes.Ldc_I4, 53);
+        il.Emit(OpCodes.Callvirt, typeof(IPEndPoint).GetProperty("Port")!.GetSetMethod()!);
+
+        il.MarkLabel(doneLabel);
+        il.Emit(OpCodes.Ldloc, endpointLocal);
+        il.Emit(OpCodes.Ret);
+    }
+
+    /// <summary>
     /// Emits DnsGetSystemDns: returns the system's primary DNS server address as string.
+    /// SHARPTS_DNS_SERVER overrides discovery (mirrors DnsWireProtocol.GetSystemDnsServer).
     /// Signature: string DnsGetSystemDns()
     /// </summary>
     private void EmitDnsGetSystemDnsMethod(TypeBuilder typeBuilder, EmittedRuntime runtime)
@@ -1485,6 +1577,21 @@ public partial class RuntimeEmitter
 
         var resultLocal = il.DeclareLocal(_types.String); // 0
         var returnLabel = il.DefineLabel();
+
+        // string env = Environment.GetEnvironmentVariable("SHARPTS_DNS_SERVER");
+        // if (!string.IsNullOrEmpty(env)) return env;
+        var envLocal = il.DeclareLocal(_types.String);
+        var noOverrideLabel = il.DefineLabel();
+        il.Emit(OpCodes.Ldstr, "SHARPTS_DNS_SERVER");
+        il.Emit(OpCodes.Call, typeof(Environment).GetMethod("GetEnvironmentVariable", [_types.String])!);
+        il.Emit(OpCodes.Stloc, envLocal);
+        il.Emit(OpCodes.Ldloc, envLocal);
+        il.Emit(OpCodes.Call, _types.String.GetMethod("IsNullOrEmpty", [_types.String])!);
+        il.Emit(OpCodes.Brtrue, noOverrideLabel);
+        il.Emit(OpCodes.Ldloc, envLocal);
+        il.Emit(OpCodes.Ret);
+
+        il.MarkLabel(noOverrideLabel);
 
         il.BeginExceptionBlock();
 
@@ -1784,6 +1891,12 @@ public partial class RuntimeEmitter
         var resultLocal = il.DeclareLocal(typeof(byte[])); // 0
         var returnLabel = il.DefineLabel();
 
+        // var endpoint = DnsParseServerEndpoint(server) — handles "host" and "host:port"
+        var endpointLocal = il.DeclareLocal(typeof(IPEndPoint));
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Call, runtime.DnsParseServerEndpoint);
+        il.Emit(OpCodes.Stloc, endpointLocal);
+
         // using var tcp = new TcpClient()
         var tcpLocal = il.DeclareLocal(typeof(TcpClient)); // 1
         il.Emit(OpCodes.Newobj, typeof(TcpClient).GetConstructor(Type.EmptyTypes)!);
@@ -1791,18 +1904,21 @@ public partial class RuntimeEmitter
 
         il.BeginExceptionBlock();
 
-        // tcp.SendTimeout = 5000
+        // tcp.SendTimeout = DnsGetTimeoutMs()
         il.Emit(OpCodes.Ldloc, tcpLocal);
-        il.Emit(OpCodes.Ldc_I4, 5000);
+        il.Emit(OpCodes.Call, runtime.DnsGetTimeoutMs);
         il.Emit(OpCodes.Callvirt, typeof(TcpClient).GetProperty("SendTimeout")!.GetSetMethod()!);
 
-        // tcp.ConnectAsync(server, 53).WaitAsync(TimeSpan.FromMilliseconds(5000)).GetAwaiter().GetResult()
+        // tcp.ConnectAsync(endpoint.Address, endpoint.Port).WaitAsync(TimeSpan.FromMilliseconds(DnsGetTimeoutMs())).GetAwaiter().GetResult()
         il.Emit(OpCodes.Ldloc, tcpLocal);
-        il.Emit(OpCodes.Ldarg_1); // server
-        il.Emit(OpCodes.Ldc_I4, 53);
-        il.Emit(OpCodes.Callvirt, typeof(TcpClient).GetMethod("ConnectAsync", [_types.String, _types.Int32])!);
+        il.Emit(OpCodes.Ldloc, endpointLocal);
+        il.Emit(OpCodes.Callvirt, typeof(IPEndPoint).GetProperty("Address")!.GetGetMethod()!);
+        il.Emit(OpCodes.Ldloc, endpointLocal);
+        il.Emit(OpCodes.Callvirt, typeof(IPEndPoint).GetProperty("Port")!.GetGetMethod()!);
+        il.Emit(OpCodes.Callvirt, typeof(TcpClient).GetMethod("ConnectAsync", [typeof(IPAddress), _types.Int32])!);
         // Task.WaitAsync(TimeSpan) for reliable timeout
-        il.Emit(OpCodes.Ldc_R8, 5000.0);
+        il.Emit(OpCodes.Call, runtime.DnsGetTimeoutMs);
+        il.Emit(OpCodes.Conv_R8);
         il.Emit(OpCodes.Call, typeof(TimeSpan).GetMethod("FromMilliseconds", [typeof(double)])!);
         il.Emit(OpCodes.Callvirt, typeof(Task).GetMethod("WaitAsync", [typeof(TimeSpan)])!);
         var connectAwaiterLocal = il.DeclareLocal(typeof(TaskAwaiter));
@@ -1945,12 +2061,10 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Call, runtime.DnsGetSystemDns);
         il.Emit(OpCodes.Stloc, serverLocal);
 
-        // var endpoint = new IPEndPoint(IPAddress.Parse(server), 53)
+        // var endpoint = DnsParseServerEndpoint(server) — handles "host" and "host:port"
         var endpointLocal = il.DeclareLocal(typeof(IPEndPoint)); // 1
         il.Emit(OpCodes.Ldloc, serverLocal);
-        il.Emit(OpCodes.Call, typeof(IPAddress).GetMethod("Parse", [_types.String])!);
-        il.Emit(OpCodes.Ldc_I4, 53);
-        il.Emit(OpCodes.Newobj, typeof(IPEndPoint).GetConstructor([typeof(IPAddress), _types.Int32])!);
+        il.Emit(OpCodes.Call, runtime.DnsParseServerEndpoint);
         il.Emit(OpCodes.Stloc, endpointLocal);
 
         // byte[] result = null
@@ -1979,10 +2093,10 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Newobj, typeof(UdpClient).GetConstructor(Type.EmptyTypes)!);
         il.Emit(OpCodes.Stloc, udpLocal);
 
-        // udp.Client.SendTimeout = 5000
+        // udp.Client.SendTimeout = DnsGetTimeoutMs()
         il.Emit(OpCodes.Ldloc, udpLocal);
         il.Emit(OpCodes.Callvirt, typeof(UdpClient).GetProperty("Client")!.GetGetMethod()!);
-        il.Emit(OpCodes.Ldc_I4, 5000);
+        il.Emit(OpCodes.Call, runtime.DnsGetTimeoutMs);
         il.Emit(OpCodes.Callvirt, typeof(Socket).GetProperty("SendTimeout")!.GetSetMethod()!);
 
         // udp.Send(query, query.Length, endpoint)
@@ -2020,9 +2134,9 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Call, valueTaskType.GetMethod("AsTask")!);
         il.Emit(OpCodes.Stloc, taskLocal);
 
-        // if (!task.Wait(5000)) { udp.Close(); throw SocketException(TimedOut); }
+        // if (!task.Wait(DnsGetTimeoutMs())) { udp.Close(); throw SocketException(TimedOut); }
         il.Emit(OpCodes.Ldloc, taskLocal);
-        il.Emit(OpCodes.Ldc_I4, 5000);
+        il.Emit(OpCodes.Call, runtime.DnsGetTimeoutMs);
         il.Emit(OpCodes.Callvirt, typeof(Task).GetMethod("Wait", [_types.Int32])!);
         var waitOkLabel = il.DefineLabel();
         il.Emit(OpCodes.Brtrue, waitOkLabel);
@@ -2051,6 +2165,40 @@ public partial class RuntimeEmitter
         // udp.Dispose()
         il.Emit(OpCodes.Ldloc, udpLocal);
         il.Emit(OpCodes.Callvirt, typeof(UdpClient).GetMethod("Dispose", Type.EmptyTypes)!);
+
+        // Discard datagrams whose transaction ID doesn't echo the query's (stale
+        // or spoofed response) and retry; if no matching response ever arrives
+        // this falls out of the retry loop into the ETIMEOUT throw — mirrors
+        // DnsWireProtocol.SendReceive.
+        // if (response.Length < 2 || response[0] != query[0] || response[1] != query[1]) continue;
+        var idMismatchLabel = il.DefineLabel();
+        var idOkLabel = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, responseLocal);
+        il.Emit(OpCodes.Ldlen);
+        il.Emit(OpCodes.Conv_I4);
+        il.Emit(OpCodes.Ldc_I4_2);
+        il.Emit(OpCodes.Blt, idMismatchLabel);
+
+        il.Emit(OpCodes.Ldloc, responseLocal);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Ldelem_U1);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Ldelem_U1);
+        il.Emit(OpCodes.Bne_Un, idMismatchLabel);
+
+        il.Emit(OpCodes.Ldloc, responseLocal);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Ldelem_U1);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Ldelem_U1);
+        il.Emit(OpCodes.Beq, idOkLabel);
+
+        il.MarkLabel(idMismatchLabel);
+        il.Emit(OpCodes.Leave, retryIncrement);
+
+        il.MarkLabel(idOkLabel);
 
         // Check TC (truncation) bit — byte[2], bit 1
         // if (response.Length >= 3 && (response[2] & 0x02) != 0) -> TCP fallback

--- a/Runtime/BuiltIns/Modules/DnsWireProtocol.cs
+++ b/Runtime/BuiltIns/Modules/DnsWireProtocol.cs
@@ -27,8 +27,23 @@ public static class DnsWireProtocol
 
     private static readonly Random _rng = new();
     private const int DnsPort = 53;
-    private const int TimeoutMs = 5000;
+    private const int DefaultTimeoutMs = 5000;
     private const int MaxRetries = 2;
+
+    /// <summary>
+    /// Per-attempt timeout. SHARPTS_DNS_TIMEOUT_MS overrides the 5s default so
+    /// fake-server tests can exercise the timeout path without waiting
+    /// (1 + MaxRetries) × 5s. The emitted IL wire protocol honors the same
+    /// variable (RuntimeEmitter.Dns.cs, DnsGetTimeoutMs).
+    /// </summary>
+    private static int TimeoutMs
+    {
+        get
+        {
+            var env = Environment.GetEnvironmentVariable("SHARPTS_DNS_TIMEOUT_MS");
+            return env != null && int.TryParse(env, out var ms) && ms > 0 ? ms : DefaultTimeoutMs;
+        }
+    }
 
     /// <summary>
     /// Resolves DNS records of the given type for the hostname.
@@ -175,6 +190,13 @@ public static class DnsWireProtocol
 
                 var response = receiveTask.Result.Buffer;
 
+                // Discard datagrams whose transaction ID doesn't echo the query's
+                // (stale or spoofed response) and retry; if no matching response
+                // ever arrives this falls through to the ETIMEOUT below, like a
+                // resolver that never answered.
+                if (response.Length < 2 || response[0] != query[0] || response[1] != query[1])
+                    continue;
+
                 // Check TC (truncation) bit — byte 2, bit 1
                 if (response.Length >= 3 && (response[2] & 0x02) != 0)
                 {
@@ -270,6 +292,13 @@ public static class DnsWireProtocol
     /// </summary>
     public static string GetSystemDnsServer()
     {
+        // SHARPTS_DNS_SERVER overrides discovery ("host" or "host:port") — lets
+        // tests point the resolver at a loopback fake server. The emitted IL
+        // honors the same variable (RuntimeEmitter.Dns.cs, DnsGetSystemDns).
+        var overrideServer = Environment.GetEnvironmentVariable("SHARPTS_DNS_SERVER");
+        if (!string.IsNullOrEmpty(overrideServer))
+            return overrideServer;
+
         try
         {
             foreach (var ni in NetworkInterface.GetAllNetworkInterfaces())

--- a/SharpTS.Tests/Infrastructure/DnsFakeServerEnvCollection.cs
+++ b/SharpTS.Tests/Infrastructure/DnsFakeServerEnvCollection.cs
@@ -1,0 +1,16 @@
+using Xunit;
+
+namespace SharpTS.Tests.Infrastructure;
+
+/// <summary>
+/// Collection for tests that redirect DNS resolution through the
+/// SHARPTS_DNS_SERVER / SHARPTS_DNS_TIMEOUT_MS environment variables. Those are
+/// process-global, so the collection disables parallelization: nothing else may
+/// run while a test has the resolver pointed at a loopback fake server, or
+/// unrelated network tests would be redirected too.
+/// </summary>
+[CollectionDefinition(Name, DisableParallelization = true)]
+public sealed class DnsFakeServerEnvCollection
+{
+    public const string Name = "DnsFakeServerEnv";
+}

--- a/SharpTS.Tests/Infrastructure/DnsPackets.cs
+++ b/SharpTS.Tests/Infrastructure/DnsPackets.cs
@@ -1,0 +1,194 @@
+using System.Net;
+using System.Text;
+
+namespace SharpTS.Tests.Infrastructure;
+
+/// <summary>
+/// Builders and inspectors for RFC 1035 DNS packets, for use with
+/// <see cref="FakeDnsServer"/> responders. Responses echo the request's
+/// transaction ID and question section; answer records default to a compression
+/// pointer at the question name (0xC00C), as real resolvers emit.
+/// </summary>
+public static class DnsPackets
+{
+    /// <summary>Compression pointer to the question name at offset 12.</summary>
+    public static byte[] PointerToQuestionName => [0xC0, 0x0C];
+
+    // ---- request inspectors -------------------------------------------------
+
+    /// <summary>QTYPE of the (single) question in a request.</summary>
+    public static int QueryType(byte[] request)
+    {
+        var offset = SkipQuestionName(request);
+        return (request[offset] << 8) | request[offset + 1];
+    }
+
+    /// <summary>Dotted question name of a request.</summary>
+    public static string QueryName(byte[] request)
+    {
+        var sb = new StringBuilder();
+        var offset = 12;
+        while (request[offset] != 0)
+        {
+            var len = request[offset++];
+            if (sb.Length > 0)
+                sb.Append('.');
+            sb.Append(Encoding.ASCII.GetString(request, offset, len));
+            offset += len;
+        }
+        return sb.ToString();
+    }
+
+    private static int SkipQuestionName(byte[] request)
+    {
+        var offset = 12;
+        while (request[offset] != 0)
+            offset += request[offset] + 1;
+        return offset + 1;
+    }
+
+    private static int QuestionEnd(byte[] request) => SkipQuestionName(request) + 4; // QTYPE + QCLASS
+
+    // ---- response builders --------------------------------------------------
+
+    /// <summary>
+    /// Builds a response echoing the request's ID and question, with the given
+    /// rcode and pre-encoded answer records (see <see cref="Record"/>).
+    /// </summary>
+    public static byte[] Response(byte[] request, byte rcode = 0, params byte[][] answers)
+    {
+        var questionEnd = QuestionEnd(request);
+        var response = new List<byte>(questionEnd + answers.Sum(a => a.Length));
+        for (var i = 0; i < questionEnd; i++)
+            response.Add(request[i]);
+        response[2] = 0x81;                       // QR=1, RD=1
+        response[3] = (byte)(0x80 | (rcode & 0x0F)); // RA=1
+        response[6] = (byte)(answers.Length >> 8);   // ANCOUNT
+        response[7] = (byte)(answers.Length & 0xFF);
+        foreach (var answer in answers)
+            response.AddRange(answer);
+        return response.ToArray();
+    }
+
+    /// <summary>Response with the TC bit set and no answers — forces TCP fallback.</summary>
+    public static byte[] Truncated(byte[] request)
+    {
+        var response = Response(request);
+        response[2] = 0x83; // QR=1, TC=1, RD=1
+        return response;
+    }
+
+    /// <summary>Copy of a response with its transaction ID flipped.</summary>
+    public static byte[] WithCorruptedId(byte[] response)
+    {
+        var corrupted = (byte[])response.Clone();
+        corrupted[0] ^= 0xFF;
+        corrupted[1] ^= 0xFF;
+        return corrupted;
+    }
+
+    /// <summary>
+    /// Encodes one resource record: NAME (defaults to a compression pointer at
+    /// the question name), TYPE, CLASS IN, TTL 60, RDLENGTH, RDATA.
+    /// </summary>
+    public static byte[] Record(int type, byte[] rdata, byte[]? name = null)
+    {
+        name ??= PointerToQuestionName;
+        var record = new List<byte>(name.Length + 10 + rdata.Length);
+        record.AddRange(name);
+        record.Add((byte)(type >> 8));
+        record.Add((byte)(type & 0xFF));
+        record.AddRange([0x00, 0x01]);             // CLASS = IN
+        record.AddRange([0x00, 0x00, 0x00, 0x3C]); // TTL = 60
+        record.Add((byte)(rdata.Length >> 8));
+        record.Add((byte)(rdata.Length & 0xFF));
+        record.AddRange(rdata);
+        return record.ToArray();
+    }
+
+    // ---- name encoders ------------------------------------------------------
+
+    /// <summary>Uncompressed name: "a.b" → [1]a[1]b[0].</summary>
+    public static byte[] Name(string dotted)
+    {
+        var bytes = new List<byte>();
+        foreach (var label in dotted.TrimEnd('.').Split('.'))
+        {
+            var labelBytes = Encoding.ASCII.GetBytes(label);
+            bytes.Add((byte)labelBytes.Length);
+            bytes.AddRange(labelBytes);
+        }
+        bytes.Add(0x00);
+        return bytes.ToArray();
+    }
+
+    /// <summary>
+    /// Labels followed by a pointer to the question name: "mail" decodes to
+    /// "mail.&lt;question name&gt;". Exercises the label-then-jump path of name
+    /// decompression.
+    /// </summary>
+    public static byte[] LabelsThenPointer(string labels)
+    {
+        var bytes = new List<byte>();
+        foreach (var label in labels.TrimEnd('.').Split('.'))
+        {
+            var labelBytes = Encoding.ASCII.GetBytes(label);
+            bytes.Add((byte)labelBytes.Length);
+            bytes.AddRange(labelBytes);
+        }
+        bytes.AddRange(PointerToQuestionName);
+        return bytes.ToArray();
+    }
+
+    // ---- RDATA builders -----------------------------------------------------
+
+    public static byte[] A(string ip) => IPAddress.Parse(ip).GetAddressBytes();
+
+    public static byte[] Aaaa(string ip) => IPAddress.Parse(ip).GetAddressBytes();
+
+    public static byte[] Mx(int preference, byte[] exchange) =>
+        [.. UInt16(preference), .. exchange];
+
+    public static byte[] Txt(params string[] chunks)
+    {
+        var rdata = new List<byte>();
+        foreach (var chunk in chunks)
+        {
+            var bytes = Encoding.UTF8.GetBytes(chunk);
+            rdata.Add((byte)bytes.Length);
+            rdata.AddRange(bytes);
+        }
+        return rdata.ToArray();
+    }
+
+    public static byte[] Srv(int priority, int weight, int port, byte[] target) =>
+        [.. UInt16(priority), .. UInt16(weight), .. UInt16(port), .. target];
+
+    public static byte[] Soa(byte[] mname, byte[] rname, uint serial, uint refresh,
+        uint retry, uint expire, uint minimum) =>
+        [.. mname, .. rname, .. UInt32(serial), .. UInt32(refresh), .. UInt32(retry),
+         .. UInt32(expire), .. UInt32(minimum)];
+
+    public static byte[] Caa(byte flags, string tag, string value)
+    {
+        var tagBytes = Encoding.ASCII.GetBytes(tag);
+        var valueBytes = Encoding.UTF8.GetBytes(value);
+        return [flags, (byte)tagBytes.Length, .. tagBytes, .. valueBytes];
+    }
+
+    public static byte[] Naptr(int order, int preference, string flags, string service,
+        string regexp, byte[] replacement) =>
+        [.. UInt16(order), .. UInt16(preference), .. CharString(flags),
+         .. CharString(service), .. CharString(regexp), .. replacement];
+
+    private static byte[] CharString(string value)
+    {
+        var bytes = Encoding.UTF8.GetBytes(value);
+        return [(byte)bytes.Length, .. bytes];
+    }
+
+    private static byte[] UInt16(int value) => [(byte)(value >> 8), (byte)(value & 0xFF)];
+
+    private static byte[] UInt32(uint value) =>
+        [(byte)(value >> 24), (byte)(value >> 16), (byte)(value >> 8), (byte)value];
+}

--- a/SharpTS.Tests/Infrastructure/FakeDnsServer.cs
+++ b/SharpTS.Tests/Infrastructure/FakeDnsServer.cs
@@ -1,0 +1,158 @@
+using System.Net;
+using System.Net.Sockets;
+
+namespace SharpTS.Tests.Infrastructure;
+
+/// <summary>
+/// Loopback DNS server for deterministic wire-protocol tests. Exercises the real
+/// client code (actual UDP/TCP sockets, actual packet bytes) and only replaces the
+/// remote endpoint, so retry, truncation, decoding and timeout behavior can be
+/// pinned without depending on the runner's network path.
+///
+/// The UDP responder receives the raw query and a zero-based query index and
+/// returns the response datagram, or null to deliberately not answer (the client
+/// then runs into its receive timeout). When a TCP responder is provided, the
+/// server also listens on the same port number over TCP and speaks the 2-byte
+/// length-prefixed framing of RFC 1035 §4.2.2 — used to test TC-bit fallback.
+///
+/// CI constraint (macOS, dotnet/runtime#81378, #64551): receive loops must use
+/// async receives only — Dispose() does NOT unblock a thread stuck in a
+/// synchronous Receive() there and wedges the whole testhost. Shutdown works by
+/// closing the sockets and catching the resulting exceptions.
+/// </summary>
+public sealed class FakeDnsServer : IDisposable
+{
+    public delegate byte[]? UdpResponder(byte[] request, int queryIndex);
+
+    private readonly UdpClient _udp;
+    private readonly TcpListener? _tcp;
+    private readonly UdpResponder _udpResponder;
+    private readonly Func<byte[], byte[]>? _tcpResponder;
+    private int _queryCount;
+    private int _tcpQueryCount;
+
+    public FakeDnsServer(UdpResponder udpResponder, Func<byte[], byte[]>? tcpResponder = null)
+    {
+        _udpResponder = udpResponder;
+        _tcpResponder = tcpResponder;
+
+        if (tcpResponder is null)
+        {
+            _udp = new UdpClient(new IPEndPoint(IPAddress.Loopback, 0));
+        }
+        else
+        {
+            // The client derives both endpoints from one "host:port" address, so
+            // UDP and TCP must share the port number. Bind TCP on an ephemeral
+            // port first, then bind UDP to the same number — the protocols have
+            // separate port namespaces, so it is normally free.
+            (_tcp, _udp) = BindSamePortPair();
+        }
+
+        Port = ((IPEndPoint)_udp.Client.LocalEndPoint!).Port;
+        Address = $"127.0.0.1:{Port}";
+        Task.Run(ServeUdp);
+        if (_tcp is not null)
+            Task.Run(ServeTcp);
+    }
+
+    /// <summary>Server address in "127.0.0.1:port" form.</summary>
+    public string Address { get; }
+
+    public int Port { get; }
+
+    /// <summary>Number of UDP queries received (including deliberately unanswered ones).</summary>
+    public int QueryCount => Volatile.Read(ref _queryCount);
+
+    /// <summary>Number of TCP queries received.</summary>
+    public int TcpQueryCount => Volatile.Read(ref _tcpQueryCount);
+
+    private static (TcpListener Tcp, UdpClient Udp) BindSamePortPair()
+    {
+        // Probe random high ports rather than asking the OS for an ephemeral TCP
+        // port: ephemeral allocation is sequential, and on Windows the handed-out
+        // TCP port can sit inside a UDP *excluded* port range (WSAEACCES), so a
+        // small retry loop would burn every attempt in the same window.
+        for (var attempt = 0; ; attempt++)
+        {
+            var port = Random.Shared.Next(20000, 60000);
+            TcpListener? tcp = null;
+            try
+            {
+                tcp = new TcpListener(IPAddress.Loopback, port);
+                tcp.Start();
+                return (tcp, new UdpClient(new IPEndPoint(IPAddress.Loopback, port)));
+            }
+            catch (SocketException) when (attempt < 49)
+            {
+                tcp?.Stop();
+            }
+        }
+    }
+
+    private async Task ServeUdp()
+    {
+        try
+        {
+            while (true)
+            {
+                var query = await _udp.ReceiveAsync().ConfigureAwait(false);
+                var index = Interlocked.Increment(ref _queryCount) - 1;
+                var response = _udpResponder(query.Buffer, index);
+                if (response is null)
+                    continue; // deliberately unanswered — client times out
+                await _udp.SendAsync(response, response.Length, query.RemoteEndPoint)
+                    .ConfigureAwait(false);
+            }
+        }
+        catch (ObjectDisposedException) { }
+        catch (SocketException) { }
+    }
+
+    private async Task ServeTcp()
+    {
+        try
+        {
+            while (true)
+            {
+                using var client = await _tcp!.AcceptTcpClientAsync().ConfigureAwait(false);
+                var stream = client.GetStream();
+                var lengthPrefix = await ReadExactAsync(stream, 2).ConfigureAwait(false);
+                var queryLength = (lengthPrefix[0] << 8) | lengthPrefix[1];
+                var request = await ReadExactAsync(stream, queryLength).ConfigureAwait(false);
+                Interlocked.Increment(ref _tcpQueryCount);
+
+                var response = _tcpResponder!(request);
+                var framed = new byte[response.Length + 2];
+                framed[0] = (byte)(response.Length >> 8);
+                framed[1] = (byte)(response.Length & 0xFF);
+                response.CopyTo(framed, 2);
+                await stream.WriteAsync(framed).ConfigureAwait(false);
+            }
+        }
+        catch (ObjectDisposedException) { }
+        catch (SocketException) { }
+        catch (IOException) { }
+    }
+
+    private static async Task<byte[]> ReadExactAsync(NetworkStream stream, int count)
+    {
+        var buffer = new byte[count];
+        var offset = 0;
+        while (offset < count)
+        {
+            var read = await stream.ReadAsync(buffer.AsMemory(offset, count - offset))
+                .ConfigureAwait(false);
+            if (read == 0)
+                throw new IOException("client closed the connection mid-frame");
+            offset += read;
+        }
+        return buffer;
+    }
+
+    public void Dispose()
+    {
+        _udp.Dispose();
+        _tcp?.Dispose();
+    }
+}

--- a/SharpTS.Tests/RuntimeTests/DnsWireProtocolFakeServerTests.cs
+++ b/SharpTS.Tests/RuntimeTests/DnsWireProtocolFakeServerTests.cs
@@ -1,0 +1,259 @@
+using SharpTS.Runtime.BuiltIns.Modules;
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.RuntimeTests;
+
+/// <summary>
+/// Pins DnsWireProtocol behavior against a loopback fake DNS server: per-record-type
+/// RDATA decoding, name decompression, TC-bit TCP fallback, error rcodes, malformed
+/// responses and transaction-ID validation. These tests pass the server address
+/// explicitly, so they are independent of env-var seams and safe to run in parallel.
+/// (The compiled-IL twin of this wire protocol is covered by
+/// SharedTests.BuiltInModules.DnsFakeServerModuleTests.)
+/// </summary>
+public class DnsWireProtocolFakeServerTests
+{
+    private static FakeDnsServer SingleRecordServer(int type, byte[] rdata, byte[]? name = null) =>
+        new((request, _) => DnsPackets.Response(request, 0, DnsPackets.Record(type, rdata, name)));
+
+    [Fact]
+    public void Query_ARecord_DecodesAddress()
+    {
+        using var server = SingleRecordServer(DnsWireProtocol.TypeA, DnsPackets.A("93.184.216.34"));
+
+        var result = (List<object?>)DnsWireProtocol.Query("example.com", DnsWireProtocol.TypeA, server.Address);
+
+        Assert.Equal("93.184.216.34", Assert.Single(result));
+    }
+
+    [Fact]
+    public void Query_AaaaRecord_DecodesAddress()
+    {
+        using var server = SingleRecordServer(DnsWireProtocol.TypeAAAA, DnsPackets.Aaaa("2606:2800:220:1:248:1893:25c8:1946"));
+
+        var result = (List<object?>)DnsWireProtocol.Query("example.com", DnsWireProtocol.TypeAAAA, server.Address);
+
+        Assert.Equal("2606:2800:220:1:248:1893:25c8:1946", Assert.Single(result));
+    }
+
+    [Fact]
+    public void Query_Mx_DecodesCompressedExchangeName()
+    {
+        // exchange = label "mail" + pointer to the question name → "mail.example.com";
+        // exercises the label-then-jump path of ReadName.
+        using var server = SingleRecordServer(DnsWireProtocol.TypeMX,
+            DnsPackets.Mx(10, DnsPackets.LabelsThenPointer("mail")));
+
+        var result = (List<object?>)DnsWireProtocol.Query("example.com", DnsWireProtocol.TypeMX, server.Address);
+
+        var record = Assert.IsType<Dictionary<string, object?>>(Assert.Single(result));
+        Assert.Equal("mail.example.com", record["exchange"]);
+        Assert.Equal(10.0, record["priority"]);
+    }
+
+    [Fact]
+    public void Query_Txt_DecodesMultipleChunks()
+    {
+        using var server = SingleRecordServer(DnsWireProtocol.TypeTXT,
+            DnsPackets.Txt("chunk-one", "chunk-two"));
+
+        var result = (List<object?>)DnsWireProtocol.Query("example.com", DnsWireProtocol.TypeTXT, server.Address);
+
+        var chunks = Assert.IsType<List<object?>>(Assert.Single(result));
+        Assert.Equal(new object?[] { "chunk-one", "chunk-two" }, chunks);
+    }
+
+    [Fact]
+    public void Query_Srv_DecodesAllFields()
+    {
+        using var server = SingleRecordServer(DnsWireProtocol.TypeSRV,
+            DnsPackets.Srv(priority: 1, weight: 5, port: 5060, DnsPackets.LabelsThenPointer("sip")));
+
+        var result = (List<object?>)DnsWireProtocol.Query("example.com", DnsWireProtocol.TypeSRV, server.Address);
+
+        var record = Assert.IsType<Dictionary<string, object?>>(Assert.Single(result));
+        Assert.Equal("sip.example.com", record["name"]);
+        Assert.Equal(5060.0, record["port"]);
+        Assert.Equal(1.0, record["priority"]);
+        Assert.Equal(5.0, record["weight"]);
+    }
+
+    [Theory]
+    [InlineData(DnsWireProtocol.TypeNS)]
+    [InlineData(DnsWireProtocol.TypeCNAME)]
+    [InlineData(DnsWireProtocol.TypePTR)]
+    public void Query_NameRecord_DecodesPointerOnlyRdata(int type)
+    {
+        // RDATA is a bare compression pointer at the question name.
+        using var server = SingleRecordServer(type, DnsPackets.PointerToQuestionName);
+
+        var result = (List<object?>)DnsWireProtocol.Query("example.com", type, server.Address);
+
+        Assert.Equal("example.com", Assert.Single(result));
+    }
+
+    [Fact]
+    public void Query_Soa_DecodesAllFields()
+    {
+        using var server = SingleRecordServer(DnsWireProtocol.TypeSOA,
+            DnsPackets.Soa(
+                DnsPackets.LabelsThenPointer("ns1"),
+                DnsPackets.LabelsThenPointer("hostmaster"),
+                serial: 2024010101, refresh: 7200, retry: 900, expire: 1209600, minimum: 86400));
+
+        var record = (Dictionary<string, object?>)DnsWireProtocol.Query("example.com", DnsWireProtocol.TypeSOA, server.Address);
+
+        Assert.Equal("ns1.example.com", record["nsname"]);
+        Assert.Equal("hostmaster.example.com", record["hostmaster"]);
+        Assert.Equal(2024010101.0, record["serial"]);
+        Assert.Equal(7200.0, record["refresh"]);
+        Assert.Equal(900.0, record["retry"]);
+        Assert.Equal(1209600.0, record["expire"]);
+        Assert.Equal(86400.0, record["minttl"]);
+    }
+
+    [Fact]
+    public void Query_Caa_DecodesFlagsTagAndValue()
+    {
+        using var server = SingleRecordServer(DnsWireProtocol.TypeCAA,
+            DnsPackets.Caa(flags: 0x80, "issue", "ca.example.net"));
+
+        var result = (List<object?>)DnsWireProtocol.Query("example.com", DnsWireProtocol.TypeCAA, server.Address);
+
+        var record = Assert.IsType<Dictionary<string, object?>>(Assert.Single(result));
+        Assert.Equal(128.0, record["critical"]);
+        Assert.Equal("ca.example.net", record["issue"]);
+    }
+
+    [Fact]
+    public void Query_Naptr_DecodesAllFields()
+    {
+        using var server = SingleRecordServer(DnsWireProtocol.TypeNAPTR,
+            DnsPackets.Naptr(order: 100, preference: 50, "s", "SIP+D2T", "",
+                DnsPackets.LabelsThenPointer("_sip._tcp")));
+
+        var result = (List<object?>)DnsWireProtocol.Query("example.com", DnsWireProtocol.TypeNAPTR, server.Address);
+
+        var record = Assert.IsType<Dictionary<string, object?>>(Assert.Single(result));
+        Assert.Equal(100.0, record["order"]);
+        Assert.Equal(50.0, record["preference"]);
+        Assert.Equal("s", record["flags"]);
+        Assert.Equal("SIP+D2T", record["service"]);
+        Assert.Equal("", record["regexp"]);
+        Assert.Equal("_sip._tcp.example.com", record["replacement"]);
+    }
+
+    [Fact]
+    public void Query_UncompressedAnswerName_Parses()
+    {
+        // Answer NAME spelled out as labels instead of the usual pointer.
+        using var server = SingleRecordServer(DnsWireProtocol.TypeTXT,
+            DnsPackets.Txt("plain"), name: DnsPackets.Name("example.com"));
+
+        var result = (List<object?>)DnsWireProtocol.Query("example.com", DnsWireProtocol.TypeTXT, server.Address);
+
+        var chunks = Assert.IsType<List<object?>>(Assert.Single(result));
+        Assert.Equal("plain", Assert.Single(chunks));
+    }
+
+    [Fact]
+    public void Query_SkipsRecordsOfOtherTypes()
+    {
+        // CNAME + TXT in one response; a TXT query must skip the CNAME via RDLENGTH.
+        using var server = new FakeDnsServer((request, _) => DnsPackets.Response(request, 0,
+            DnsPackets.Record(DnsWireProtocol.TypeCNAME, DnsPackets.Name("alias.example.net")),
+            DnsPackets.Record(DnsWireProtocol.TypeTXT, DnsPackets.Txt("after-cname"))));
+
+        var result = (List<object?>)DnsWireProtocol.Query("example.com", DnsWireProtocol.TypeTXT, server.Address);
+
+        var chunks = Assert.IsType<List<object?>>(Assert.Single(result));
+        Assert.Equal("after-cname", Assert.Single(chunks));
+    }
+
+    [Fact]
+    public void Query_TruncatedUdpResponse_FallsBackToTcp()
+    {
+        using var server = new FakeDnsServer(
+            (request, _) => DnsPackets.Truncated(request),
+            tcpResponder: request => DnsPackets.Response(request, 0,
+                DnsPackets.Record(DnsWireProtocol.TypeTXT, DnsPackets.Txt("via-tcp"))));
+
+        var result = (List<object?>)DnsWireProtocol.Query("example.com", DnsWireProtocol.TypeTXT, server.Address);
+
+        var chunks = Assert.IsType<List<object?>>(Assert.Single(result));
+        Assert.Equal("via-tcp", Assert.Single(chunks));
+        Assert.Equal(1, server.QueryCount);
+        Assert.Equal(1, server.TcpQueryCount);
+    }
+
+    [Theory]
+    [InlineData((byte)1, "EFORMERR")]
+    [InlineData((byte)3, "ENOTFOUND")]
+    [InlineData((byte)4, "ENOTIMP")]
+    public void Query_NonTransientErrorRcode_ThrowsWithoutRetry(byte rcode, string expectedCode)
+    {
+        using var server = new FakeDnsServer((request, _) => DnsPackets.Response(request, rcode));
+
+        var ex = Assert.Throws<Exception>(() =>
+            DnsWireProtocol.Query("example.com", DnsWireProtocol.TypeTXT, server.Address));
+
+        Assert.Contains(expectedCode, ex.Message);
+        Assert.Equal(1, server.QueryCount); // unlike SERVFAIL/REFUSED, these are final
+    }
+
+    [Fact]
+    public void Query_NoMatchingAnswers_ThrowsEnodata()
+    {
+        using var server = new FakeDnsServer((request, _) => DnsPackets.Response(request));
+
+        var ex = Assert.Throws<Exception>(() =>
+            DnsWireProtocol.Query("example.com", DnsWireProtocol.TypeTXT, server.Address));
+
+        Assert.Contains("ENODATA", ex.Message);
+    }
+
+    [Fact]
+    public void Query_ShortResponse_ThrowsEaiFail()
+    {
+        // 5 bytes with a valid transaction ID — passes the ID check, fails header parsing.
+        using var server = new FakeDnsServer((request, _) =>
+            [request[0], request[1], 0x81, 0x80, 0x00]);
+
+        var ex = Assert.Throws<Exception>(() =>
+            DnsWireProtocol.Query("example.com", DnsWireProtocol.TypeTXT, server.Address));
+
+        Assert.Contains("EAI_FAIL", ex.Message);
+    }
+
+    [Fact]
+    public void Query_MismatchedTransactionId_DiscardedThenRetried()
+    {
+        using var server = new FakeDnsServer((request, index) =>
+        {
+            var response = DnsPackets.Response(request, 0,
+                DnsPackets.Record(DnsWireProtocol.TypeTXT, DnsPackets.Txt("hello")));
+            return index == 0 ? DnsPackets.WithCorruptedId(response) : response;
+        });
+
+        var result = (List<object?>)DnsWireProtocol.Query("example.com", DnsWireProtocol.TypeTXT, server.Address);
+
+        var chunks = Assert.IsType<List<object?>>(Assert.Single(result));
+        Assert.Equal("hello", Assert.Single(chunks));
+        Assert.Equal(2, server.QueryCount);
+    }
+
+    [Fact]
+    public void Query_PersistentMismatchedTransactionId_ThrowsEtimeoutAfterRetries()
+    {
+        using var server = new FakeDnsServer((request, _) =>
+            DnsPackets.WithCorruptedId(DnsPackets.Response(request, 0,
+                DnsPackets.Record(DnsWireProtocol.TypeTXT, DnsPackets.Txt("spoofed")))));
+
+        var ex = Assert.Throws<Exception>(() =>
+            DnsWireProtocol.Query("example.com", DnsWireProtocol.TypeTXT, server.Address));
+
+        Assert.Contains("ETIMEOUT", ex.Message);
+        Assert.Equal(3, server.QueryCount); // initial attempt + MaxRetries (2)
+    }
+}

--- a/SharpTS.Tests/RuntimeTests/DnsWireProtocolRetryTests.cs
+++ b/SharpTS.Tests/RuntimeTests/DnsWireProtocolRetryTests.cs
@@ -1,6 +1,5 @@
-using System.Net;
-using System.Net.Sockets;
 using SharpTS.Runtime.BuiltIns.Modules;
+using SharpTS.Tests.Infrastructure;
 using Xunit;
 
 namespace SharpTS.Tests.RuntimeTests;
@@ -15,12 +14,17 @@ public class DnsWireProtocolRetryTests
     private const byte Servfail = 2;
     private const byte Refused = 5;
 
+    private static byte[] TxtHello(byte[] request) =>
+        DnsPackets.Response(request, 0,
+            DnsPackets.Record(DnsWireProtocol.TypeTXT, DnsPackets.Txt("hello")));
+
     [Theory]
     [InlineData(Servfail)]
     [InlineData(Refused)]
     public void Query_TransientErrorThenSuccess_Retries(byte rcode)
     {
-        using var server = new FakeDnsServer(rcode, errorCount: 1);
+        using var server = new FakeDnsServer((request, index) =>
+            index < 1 ? DnsPackets.Response(request, rcode) : TxtHello(request));
 
         var result = DnsWireProtocol.Query("example.com", DnsWireProtocol.TypeTXT, server.Address);
 
@@ -33,93 +37,13 @@ public class DnsWireProtocolRetryTests
     [Fact]
     public void Query_PersistentServfail_ThrowsEservfailAfterRetries()
     {
-        using var server = new FakeDnsServer(Servfail, errorCount: int.MaxValue);
+        using var server = new FakeDnsServer((request, _) =>
+            DnsPackets.Response(request, Servfail));
 
         var ex = Assert.Throws<Exception>(() =>
             DnsWireProtocol.Query("example.com", DnsWireProtocol.TypeTXT, server.Address));
 
         Assert.Contains("ESERVFAIL", ex.Message);
         Assert.Equal(3, server.QueryCount); // initial attempt + MaxRetries (2)
-    }
-
-    /// <summary>
-    /// Minimal loopback DNS server: answers the first <c>errorCount</c> queries
-    /// with the given error rcode, then with a one-record TXT answer ("hello").
-    /// </summary>
-    private sealed class FakeDnsServer : IDisposable
-    {
-        private readonly UdpClient _udp;
-        private readonly byte _errorRcode;
-        private readonly int _errorCount;
-        private int _queryCount;
-
-        public FakeDnsServer(byte errorRcode, int errorCount)
-        {
-            _errorRcode = errorRcode;
-            _errorCount = errorCount;
-            _udp = new UdpClient(new IPEndPoint(IPAddress.Loopback, 0));
-            var port = ((IPEndPoint)_udp.Client.LocalEndPoint!).Port;
-            Address = $"127.0.0.1:{port}";
-            Task.Run(ServeLoop);
-        }
-
-        public string Address { get; }
-        public int QueryCount => Volatile.Read(ref _queryCount);
-
-        // Async receive only: on macOS, Dispose does not unblock a thread in a
-        // synchronous Receive (see the SendReceive timeout comment in
-        // DnsWireProtocol.cs) — a sync loop here deadlocks the testhost there.
-        // Closing the socket does complete a pending async receive on all OSes.
-        private async Task ServeLoop()
-        {
-            try
-            {
-                while (true)
-                {
-                    var query = await _udp.ReceiveAsync().ConfigureAwait(false);
-                    var count = Interlocked.Increment(ref _queryCount);
-                    var response = count <= _errorCount
-                        ? BuildErrorResponse(query.Buffer, _errorRcode)
-                        : BuildTxtResponse(query.Buffer);
-                    await _udp.SendAsync(response, response.Length, query.RemoteEndPoint)
-                        .ConfigureAwait(false);
-                }
-            }
-            catch (ObjectDisposedException) { }
-            catch (SocketException) { }
-        }
-
-        private static byte[] BuildErrorResponse(byte[] request, byte rcode)
-        {
-            var response = (byte[])request.Clone(); // header + question echo
-            response[2] = 0x81; // QR=1, RD=1
-            response[3] = rcode;
-            return response;
-        }
-
-        private static byte[] BuildTxtResponse(byte[] request)
-        {
-            var response = new List<byte>(request); // echo header + question
-            response[2] = 0x81; // QR=1, RD=1
-            response[3] = 0x80; // RA=1, rcode=0
-            response[7] = 1;    // ANCOUNT = 1
-
-            // Answer NAME: uncompressed copy of the question name
-            var nameEnd = 12;
-            while (request[nameEnd] != 0)
-                nameEnd += request[nameEnd] + 1;
-            for (var i = 12; i <= nameEnd; i++)
-                response.Add(request[i]);
-
-            response.AddRange(new byte[] { 0x00, 0x10 }); // TYPE = TXT
-            response.AddRange(new byte[] { 0x00, 0x01 }); // CLASS = IN
-            response.AddRange(new byte[] { 0x00, 0x00, 0x00, 0x3C }); // TTL = 60
-            response.AddRange(new byte[] { 0x00, 0x06 }); // RDLENGTH
-            response.Add(0x05); // TXT string length
-            response.AddRange("hello"u8.ToArray());
-            return response.ToArray();
-        }
-
-        public void Dispose() => _udp.Dispose();
     }
 }

--- a/SharpTS.Tests/SharedTests/BuiltInModules/DnsFakeServerModuleTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/DnsFakeServerModuleTests.cs
@@ -1,0 +1,257 @@
+using SharpTS.Runtime.BuiltIns.Modules;
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests.BuiltInModules;
+
+/// <summary>
+/// Behavioral DNS tests against a loopback fake server, in both interpreted and
+/// compiled modes. SHARPTS_DNS_SERVER redirects the "system DNS server" of both
+/// runtimes at the fake, so in compiled mode these exercise the emitted IL wire
+/// protocol (RuntimeEmitter.Dns.cs: DnsSendReceive, DnsSendViaTcp, DnsParseResponse,
+/// DnsParseRecord, DnsReadName) — the historically drift-prone twin of
+/// DnsWireProtocol — with deterministic, exact-value assertions that live-DNS
+/// tests could never make.
+/// </summary>
+[Collection(DnsFakeServerEnvCollection.Name)]
+public class DnsFakeServerModuleTests
+{
+    /// <summary>
+    /// Runs main.ts with the given source while SHARPTS_DNS_SERVER points at the
+    /// fake server (and optionally a short SHARPTS_DNS_TIMEOUT_MS for timeout tests).
+    /// </summary>
+    private static string RunWithFakeDns(FakeDnsServer server, string source, ExecutionMode mode, int? timeoutMs = null)
+    {
+        Environment.SetEnvironmentVariable("SHARPTS_DNS_SERVER", server.Address);
+        if (timeoutMs is int ms)
+            Environment.SetEnvironmentVariable("SHARPTS_DNS_TIMEOUT_MS", ms.ToString());
+        try
+        {
+            return TestHarness.RunModules(new Dictionary<string, string> { ["main.ts"] = source }, "main.ts", mode);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("SHARPTS_DNS_SERVER", null);
+            Environment.SetEnvironmentVariable("SHARPTS_DNS_TIMEOUT_MS", null);
+        }
+    }
+
+    /// <summary>
+    /// Fake server answering every record type with one canonical record. Names in
+    /// RDATA use compression pointers at the question name, as real resolvers emit.
+    /// </summary>
+    private static FakeDnsServer CreateRecordServer() => new((request, _) =>
+    {
+        var qtype = DnsPackets.QueryType(request);
+        var rdata = qtype switch
+        {
+            DnsWireProtocol.TypeMX => DnsPackets.Mx(10, DnsPackets.LabelsThenPointer("mail")),
+            DnsWireProtocol.TypeTXT => DnsPackets.Txt("v=spf1 -all"),
+            DnsWireProtocol.TypeNS => DnsPackets.LabelsThenPointer("ns1"),
+            DnsWireProtocol.TypeSOA => DnsPackets.Soa(
+                DnsPackets.LabelsThenPointer("ns1"), DnsPackets.LabelsThenPointer("hostmaster"),
+                serial: 2024010101, refresh: 7200, retry: 900, expire: 1209600, minimum: 86400),
+            DnsWireProtocol.TypeSRV => DnsPackets.Srv(priority: 1, weight: 5, port: 5060,
+                DnsPackets.LabelsThenPointer("sip")),
+            DnsWireProtocol.TypeCAA => DnsPackets.Caa(flags: 0x80, "issue", "ca.example.net"),
+            DnsWireProtocol.TypeCNAME => DnsPackets.LabelsThenPointer("canonical"),
+            DnsWireProtocol.TypePTR => DnsPackets.Name("host.example.net"),
+            DnsWireProtocol.TypeNAPTR => DnsPackets.Naptr(order: 100, preference: 50, "s", "SIP+D2T", "",
+                DnsPackets.LabelsThenPointer("_sip._tcp")),
+            _ => null
+        };
+        return rdata is null
+            ? DnsPackets.Response(request, 3) // NXDOMAIN
+            : DnsPackets.Response(request, 0, DnsPackets.Record(qtype, rdata));
+    });
+
+    // Exactly one top-level dns call per program: dns callback wrappers invoked
+    // from inside another callback never fire in compiled mode (see issue filed
+    // from this work) — and concurrent top-level calls would interleave output.
+    private static readonly (string Method, string Logs, string Expected)[] RecordTypeAssertions =
+    [
+        ("resolveMx", "console.log(r[0].exchange); console.log(r[0].priority);",
+            "mail.fake.test\n10\n"),
+        ("resolveTxt", "console.log(r[0][0]);",
+            "v=spf1 -all\n"),
+        ("resolveNs", "console.log(r[0]);",
+            "ns1.fake.test\n"),
+        ("resolveSoa", "console.log(r.nsname); console.log(r.hostmaster); console.log(r.serial); console.log(r.minttl);",
+            "ns1.fake.test\nhostmaster.fake.test\n2024010101\n86400\n"),
+        ("resolveSrv", "console.log(r[0].name); console.log(r[0].port); console.log(r[0].priority); console.log(r[0].weight);",
+            "sip.fake.test\n5060\n1\n5\n"),
+        ("resolveCaa", "console.log(r[0].critical); console.log(r[0].issue);",
+            "128\nca.example.net\n"),
+        ("resolveCname", "console.log(r[0]);",
+            "canonical.fake.test\n"),
+        ("resolvePtr", "console.log(r[0]);",
+            "host.example.net\n"),
+        ("resolveNaptr", "console.log(r[0].order); console.log(r[0].preference); console.log(r[0].flags); console.log(r[0].service); console.log(r[0].replacement);",
+            "100\n50\ns\nSIP+D2T\n_sip._tcp.fake.test\n"),
+    ];
+
+    public static IEnumerable<object[]> RecordTypeCases()
+    {
+        foreach (var modeRow in ExecutionModes.All)
+            foreach (var (method, logs, expected) in RecordTypeAssertions)
+                yield return [modeRow[0], method, logs, expected];
+    }
+
+    [Theory]
+    [MemberData(nameof(RecordTypeCases))]
+    public void ResolveRecordType_FakeServer_ExactValues(ExecutionMode mode, string method, string logs, string expected)
+    {
+        using var server = CreateRecordServer();
+        var output = RunWithFakeDns(server, $$"""
+            import * as dns from 'dns';
+            dns.{{method}}('fake.test', (err: any, r: any) => {
+                console.log(err === null);
+                {{logs}}
+            });
+            """, mode);
+
+        Assert.Equal("true\n" + expected, output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Resolve_WithMxRrtype_FakeServer_ExactValues(ExecutionMode mode)
+    {
+        using var server = CreateRecordServer();
+        var output = RunWithFakeDns(server, """
+            import * as dns from 'dns';
+            dns.resolve('fake.test', 'MX', (err: any, records: any) => {
+                console.log(err === null);
+                console.log(records[0].exchange);
+                console.log(records[0].priority);
+            });
+            """, mode);
+
+        Assert.Equal("true\nmail.fake.test\n10\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void DnsPromises_ResolveMxAndTxt_FakeServer_ExactValues(ExecutionMode mode)
+    {
+        using var server = CreateRecordServer();
+        var output = RunWithFakeDns(server, """
+            import dns from 'dns/promises';
+            async function main() {
+                const mx: any = await dns.resolveMx('fake.test');
+                console.log(mx[0].exchange);
+                console.log(mx[0].priority);
+                const txt: any = await dns.resolveTxt('fake.test');
+                console.log(txt[0][0]);
+            }
+            main();
+            """, mode);
+
+        Assert.Equal("mail.fake.test\n10\nv=spf1 -all\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ResolveTxt_TruncatedUdp_FallsBackToTcp(ExecutionMode mode)
+    {
+        using var server = new FakeDnsServer(
+            (request, _) => DnsPackets.Truncated(request),
+            tcpResponder: request => DnsPackets.Response(request, 0,
+                DnsPackets.Record(DnsWireProtocol.TypeTXT, DnsPackets.Txt("via-tcp"))));
+
+        var output = RunWithFakeDns(server, """
+            import * as dns from 'dns';
+            dns.resolveTxt('fake.test', (err: any, records: any) => {
+                console.log(err === null);
+                console.log(records[0][0]);
+            });
+            """, mode);
+
+        Assert.Equal("true\nvia-tcp\n", output);
+        Assert.Equal(1, server.TcpQueryCount);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ResolveMx_Nxdomain_CallsBackWithError(ExecutionMode mode)
+    {
+        using var server = new FakeDnsServer((request, _) => DnsPackets.Response(request, 3));
+
+        var output = RunWithFakeDns(server, """
+            import * as dns from 'dns';
+            dns.resolveMx('fake.test', (err: any, records: any) => {
+                console.log(err !== null);
+                console.log(records === null);
+            });
+            """, mode);
+
+        Assert.Equal("true\ntrue\n", output);
+        Assert.Equal(1, server.QueryCount); // NXDOMAIN is final — no retry
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ResolveNs_Nxdomain_Promise_Rejects(ExecutionMode mode)
+    {
+        using var server = new FakeDnsServer((request, _) => DnsPackets.Response(request, 3));
+
+        var output = RunWithFakeDns(server, """
+            import dns from 'dns/promises';
+            async function main() {
+                try {
+                    await dns.resolveNs('fake.test');
+                    console.log('no error');
+                } catch (e) {
+                    console.log('error caught');
+                }
+            }
+            main();
+            """, mode);
+
+        Assert.Equal("error caught\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ResolveMx_ServerNeverAnswers_TimesOutAfterRetries(ExecutionMode mode)
+    {
+        using var server = new FakeDnsServer((_, _) => null); // swallow every query
+
+        var output = RunWithFakeDns(server, """
+            import * as dns from 'dns';
+            dns.resolveMx('fake.test', (err: any, records: any) => {
+                console.log(err !== null);
+                console.log(records === null);
+            });
+            """, mode, timeoutMs: 250);
+
+        Assert.Equal("true\ntrue\n", output);
+        Assert.Equal(3, server.QueryCount); // initial attempt + MaxRetries (2)
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Resolver_SetServers_QueriesFakeServer(ExecutionMode mode)
+    {
+        // No env redirection here: the Resolver is pointed at the fake explicitly
+        // via setServers, covering the DnsResolverInstance custom-server path
+        // (which both runtimes share) end to end.
+        using var server = CreateRecordServer();
+
+        var source = $$"""
+            import { Resolver } from 'dns';
+            const resolver = new Resolver();
+            resolver.setServers(['{{server.Address}}']);
+            resolver.resolveMx('fake.test', (err: any, records: any) => {
+                console.log(err === null);
+                console.log(records[0].exchange);
+                console.log(records[0].priority);
+            });
+            """;
+
+        var output = TestHarness.RunModules(
+            new Dictionary<string, string> { ["main.ts"] = source }, "main.ts", mode);
+
+        Assert.Equal("true\nmail.fake.test\n10\n", output);
+    }
+}

--- a/SharpTS.Tests/SharedTests/BuiltInModules/DnsRecordTypeTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/DnsRecordTypeTests.cs
@@ -4,86 +4,38 @@ using Xunit;
 namespace SharpTS.Tests.SharedTests.BuiltInModules;
 
 /// <summary>
-/// Tests for DNS record type resolution methods: resolveMx, resolveTxt, resolveSrv,
-/// resolveCname, resolveNs, resolveSoa, resolvePtr, resolveCaa, resolveNaptr.
-/// Callback-based tests run in both interpreter and compiled modes.
-/// Promise-based tests (dns/promises) remain interpreter-only.
-/// Uses well-known public domains to test real DNS resolution.
+/// DNS record-type resolution: API surface tests (no network) plus a minimal live
+/// smoke set against a stable public domain, tolerant of transient resolver
+/// failure on CI runners. All behavioral coverage (record decoding, compression,
+/// truncation, rcodes, retries, timeouts) lives in the deterministic fake-server
+/// suites: RuntimeTests.DnsWireProtocolFakeServerTests (interpreter wire protocol)
+/// and DnsFakeServerModuleTests (both runtimes, exact-value assertions).
 /// </summary>
 public class DnsRecordTypeTests
 {
-    #region resolveMx Tests
+    #region Live smoke tests (network-tolerant)
+
+    // A single callback-based and a single promise-based live query. Success
+    // asserts the result shape; a transient resolver failure (err / throw) is
+    // treated as a skip — live DNS on CI runners is a known flake source, and
+    // the behavioral assertions are pinned by the fake-server suites.
 
     [Theory]
     [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
-    public void ResolveMx_Callback_ReturnsArray(ExecutionMode mode)
+    public void LiveSmoke_ResolveMx_Callback(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
         {
             ["main.ts"] = """
                 import * as dns from 'dns';
                 dns.resolveMx('google.com', (err: any, addresses: any) => {
-                    console.log(err === null);
-                    console.log(Array.isArray(addresses));
-                    console.log(addresses.length > 0);
-                    // Each MX record has exchange and priority
-                    const first = addresses[0];
-                    console.log(typeof first.exchange === 'string');
-                    console.log(typeof first.priority === 'number');
-                });
-                """
-        };
-
-        var output = TestHarness.RunModules(files, "main.ts", mode);
-        Assert.Equal("true\ntrue\ntrue\ntrue\ntrue\n", output);
-    }
-
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
-    public void ResolveMx_Promise_ReturnsArray(ExecutionMode mode)
-    {
-        var files = new Dictionary<string, string>
-        {
-            ["main.ts"] = """
-                import dns from 'dns/promises';
-                async function main() {
-                    const records = await dns.resolveMx('google.com');
-                    console.log(Array.isArray(records));
-                    console.log(records.length > 0);
-                    console.log(typeof records[0].exchange === 'string');
-                    console.log(typeof records[0].priority === 'number');
-                }
-                main();
-                """
-        };
-
-        var output = TestHarness.RunModules(files, "main.ts", mode);
-        Assert.Equal("true\ntrue\ntrue\ntrue\n", output);
-    }
-
-    #endregion
-
-    #region resolveTxt Tests
-
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
-    public void ResolveTxt_Callback_ReturnsArrayOfArrays(ExecutionMode mode)
-    {
-        var files = new Dictionary<string, string>
-        {
-            ["main.ts"] = """
-                import * as dns from 'dns';
-                dns.resolveTxt('google.com', (err: any, records: any) => {
                     if (err === null) {
-                        console.log(true);
-                        console.log(Array.isArray(records));
-                        console.log(records.length > 0);
-                        // Each TXT record is an array of strings (chunks)
-                        console.log(Array.isArray(records[0]));
-                        console.log(typeof records[0][0] === 'string');
+                        console.log(Array.isArray(addresses));
+                        console.log(addresses.length > 0);
+                        console.log(typeof addresses[0].exchange === 'string');
+                        console.log(typeof addresses[0].priority === 'number');
                     } else {
-                        // DNS may be unavailable on CI
-                        console.log(true);
+                        // Transient resolver failure on CI — skip
                         console.log(true);
                         console.log(true);
                         console.log(true);
@@ -94,12 +46,12 @@ public class DnsRecordTypeTests
         };
 
         var output = TestHarness.RunModules(files, "main.ts", mode);
-        Assert.Equal("true\ntrue\ntrue\ntrue\ntrue\n", output);
+        Assert.Equal("true\ntrue\ntrue\ntrue\n", output);
     }
 
     [Theory]
     [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
-    public void ResolveTxt_Promise_ReturnsArrayOfArrays(ExecutionMode mode)
+    public void LiveSmoke_ResolveNs_Promise(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
         {
@@ -107,12 +59,12 @@ public class DnsRecordTypeTests
                 import dns from 'dns/promises';
                 async function main() {
                     try {
-                        const records = await dns.resolveTxt('google.com');
-                        console.log(Array.isArray(records));
-                        console.log(records.length > 0);
-                        console.log(Array.isArray(records[0]));
+                        const nameservers = await dns.resolveNs('google.com');
+                        console.log(Array.isArray(nameservers));
+                        console.log(nameservers.length > 0);
+                        console.log(typeof nameservers[0] === 'string');
                     } catch (e) {
-                        // DNS may be unavailable on CI
+                        // Transient resolver failure on CI — skip
                         console.log(true);
                         console.log(true);
                         console.log(true);
@@ -125,351 +77,6 @@ public class DnsRecordTypeTests
         var output = TestHarness.RunModules(files, "main.ts", mode);
         Assert.Equal("true\ntrue\ntrue\n", output);
     }
-
-    #endregion
-
-    #region resolveNs Tests
-
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
-    public void ResolveNs_Callback_ReturnsStringArray(ExecutionMode mode)
-    {
-        var files = new Dictionary<string, string>
-        {
-            ["main.ts"] = """
-                import * as dns from 'dns';
-                dns.resolveNs('google.com', (err: any, nameservers: any) => {
-                    console.log(err === null);
-                    console.log(Array.isArray(nameservers));
-                    console.log(nameservers.length > 0);
-                    console.log(typeof nameservers[0] === 'string');
-                });
-                """
-        };
-
-        var output = TestHarness.RunModules(files, "main.ts", mode);
-        Assert.Equal("true\ntrue\ntrue\ntrue\n", output);
-    }
-
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
-    public void ResolveNs_Promise_ReturnsStringArray(ExecutionMode mode)
-    {
-        var files = new Dictionary<string, string>
-        {
-            ["main.ts"] = """
-                import dns from 'dns/promises';
-                async function main() {
-                    const nameservers = await dns.resolveNs('google.com');
-                    console.log(Array.isArray(nameservers));
-                    console.log(nameservers.length > 0);
-                    console.log(typeof nameservers[0] === 'string');
-                }
-                main();
-                """
-        };
-
-        var output = TestHarness.RunModules(files, "main.ts", mode);
-        Assert.Equal("true\ntrue\ntrue\n", output);
-    }
-
-    #endregion
-
-    #region resolveSoa Tests
-
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
-    public void ResolveSoa_Callback_ReturnsObject(ExecutionMode mode)
-    {
-        var files = new Dictionary<string, string>
-        {
-            ["main.ts"] = """
-                import * as dns from 'dns';
-                dns.resolveSoa('google.com', (err: any, soa: any) => {
-                    console.log(err === null);
-                    console.log(typeof soa === 'object');
-                    console.log(typeof soa.nsname === 'string');
-                    console.log(typeof soa.hostmaster === 'string');
-                    console.log(typeof soa.serial === 'number');
-                    console.log(typeof soa.refresh === 'number');
-                    console.log(typeof soa.retry === 'number');
-                    console.log(typeof soa.expire === 'number');
-                    console.log(typeof soa.minttl === 'number');
-                });
-                """
-        };
-
-        var output = TestHarness.RunModules(files, "main.ts", mode);
-        Assert.Equal("true\ntrue\ntrue\ntrue\ntrue\ntrue\ntrue\ntrue\ntrue\n", output);
-    }
-
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
-    public void ResolveSoa_Promise_ReturnsObject(ExecutionMode mode)
-    {
-        var files = new Dictionary<string, string>
-        {
-            ["main.ts"] = """
-                import dns from 'dns/promises';
-                async function main() {
-                    const soa = await dns.resolveSoa('google.com');
-                    console.log(typeof soa === 'object');
-                    console.log(typeof soa.nsname === 'string');
-                    console.log(typeof soa.hostmaster === 'string');
-                    console.log(typeof soa.serial === 'number');
-                }
-                main();
-                """
-        };
-
-        var output = TestHarness.RunModules(files, "main.ts", mode);
-        Assert.Equal("true\ntrue\ntrue\ntrue\n", output);
-    }
-
-    #endregion
-
-    #region resolveCname Tests
-
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
-    public void ResolveCname_Callback_ReturnsStringArray(ExecutionMode mode)
-    {
-        // www.google.com typically has a CNAME record
-        var files = new Dictionary<string, string>
-        {
-            ["main.ts"] = """
-                import * as dns from 'dns';
-                dns.resolveCname('www.google.com', (err: any, cnames: any) => {
-                    // CNAME may or may not exist - check for either success or ENODATA
-                    if (err === null) {
-                        console.log(Array.isArray(cnames));
-                        console.log(cnames.length > 0);
-                        console.log(typeof cnames[0] === 'string');
-                    } else {
-                        // Some domains don't have CNAME records
-                        console.log(true);
-                        console.log(true);
-                        console.log(true);
-                    }
-                });
-                """
-        };
-
-        var output = TestHarness.RunModules(files, "main.ts", mode);
-        Assert.Equal("true\ntrue\ntrue\n", output);
-    }
-
-    #endregion
-
-    #region resolveCaa Tests
-
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
-    public void ResolveCaa_Callback_ReturnsArray(ExecutionMode mode)
-    {
-        // google.com has CAA records
-        var files = new Dictionary<string, string>
-        {
-            ["main.ts"] = """
-                import * as dns from 'dns';
-                dns.resolveCaa('google.com', (err: any, records: any) => {
-                    if (err === null) {
-                        console.log(Array.isArray(records));
-                        console.log(records.length > 0);
-                        console.log(typeof records[0] === 'object');
-                    } else {
-                        // CAA may not be available
-                        console.log(true);
-                        console.log(true);
-                        console.log(true);
-                    }
-                });
-                """
-        };
-
-        var output = TestHarness.RunModules(files, "main.ts", mode);
-        Assert.Equal("true\ntrue\ntrue\n", output);
-    }
-
-    #endregion
-
-    #region dns.resolve with rrtype Tests
-
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
-    public void Resolve_WithMxRrtype_ReturnsArray(ExecutionMode mode)
-    {
-        var files = new Dictionary<string, string>
-        {
-            ["main.ts"] = """
-                import * as dns from 'dns';
-                dns.resolve('google.com', 'MX', (err: any, records: any) => {
-                    console.log(err === null);
-                    console.log(Array.isArray(records));
-                    console.log(records.length > 0);
-                    console.log(typeof records[0].exchange === 'string');
-                    console.log(typeof records[0].priority === 'number');
-                });
-                """
-        };
-
-        var output = TestHarness.RunModules(files, "main.ts", mode);
-        Assert.Equal("true\ntrue\ntrue\ntrue\ntrue\n", output);
-    }
-
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
-    public void Resolve_WithTxtRrtype_ReturnsArray(ExecutionMode mode)
-    {
-        var files = new Dictionary<string, string>
-        {
-            ["main.ts"] = """
-                import * as dns from 'dns';
-                dns.resolve('google.com', 'TXT', (err: any, records: any) => {
-                    if (err === null) {
-                        console.log(true);
-                        console.log(Array.isArray(records));
-                        console.log(records.length > 0);
-                    } else {
-                        // DNS may be unavailable on CI
-                        console.log(true);
-                        console.log(true);
-                        console.log(true);
-                    }
-                });
-                """
-        };
-
-        var output = TestHarness.RunModules(files, "main.ts", mode);
-        Assert.Equal("true\ntrue\ntrue\n", output);
-    }
-
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
-    public void Resolve_WithNsRrtype_ReturnsArray(ExecutionMode mode)
-    {
-        var files = new Dictionary<string, string>
-        {
-            ["main.ts"] = """
-                import * as dns from 'dns';
-                dns.resolve('google.com', 'NS', (err: any, records: any) => {
-                    console.log(err === null);
-                    console.log(Array.isArray(records));
-                    console.log(records.length > 0);
-                    console.log(typeof records[0] === 'string');
-                });
-                """
-        };
-
-        var output = TestHarness.RunModules(files, "main.ts", mode);
-        Assert.Equal("true\ntrue\ntrue\ntrue\n", output);
-    }
-
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
-    public void Resolve_WithSoaRrtype_ReturnsObject(ExecutionMode mode)
-    {
-        var files = new Dictionary<string, string>
-        {
-            ["main.ts"] = """
-                import * as dns from 'dns';
-                dns.resolve('google.com', 'SOA', (err: any, soa: any) => {
-                    console.log(err === null);
-                    console.log(typeof soa === 'object');
-                    console.log(typeof soa.nsname === 'string');
-                });
-                """
-        };
-
-        var output = TestHarness.RunModules(files, "main.ts", mode);
-        Assert.Equal("true\ntrue\ntrue\n", output);
-    }
-
-    #endregion
-
-    #region dns.promises.resolve with rrtype Tests
-
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
-    public void DnsPromises_Resolve_WithMxRrtype(ExecutionMode mode)
-    {
-        var files = new Dictionary<string, string>
-        {
-            ["main.ts"] = """
-                import dns from 'dns/promises';
-                async function main() {
-                    const records: any = await dns.resolve('google.com', 'MX');
-                    console.log(Array.isArray(records));
-                    console.log(records.length > 0);
-                    console.log(typeof records[0].exchange === 'string');
-                }
-                main();
-                """
-        };
-
-        var output = TestHarness.RunModules(files, "main.ts", mode);
-        Assert.Equal("true\ntrue\ntrue\n", output);
-    }
-
-    #endregion
-
-    #region Import Tests for New Methods
-
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
-    public void Dns_Import_NewMethods_Exist(ExecutionMode mode)
-    {
-        var files = new Dictionary<string, string>
-        {
-            ["main.ts"] = """
-                import * as dns from 'dns';
-                console.log(typeof dns.resolveMx === 'function');
-                console.log(typeof dns.resolveTxt === 'function');
-                console.log(typeof dns.resolveSrv === 'function');
-                console.log(typeof dns.resolveCname === 'function');
-                console.log(typeof dns.resolveNs === 'function');
-                console.log(typeof dns.resolveSoa === 'function');
-                console.log(typeof dns.resolvePtr === 'function');
-                console.log(typeof dns.resolveCaa === 'function');
-                console.log(typeof dns.resolveNaptr === 'function');
-                """
-        };
-
-        var output = TestHarness.RunModules(files, "main.ts", mode);
-        Assert.Equal("true\ntrue\ntrue\ntrue\ntrue\ntrue\ntrue\ntrue\ntrue\n", output);
-    }
-
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
-    public void DnsPromises_Import_NewMethods_Exist(ExecutionMode mode)
-    {
-        var files = new Dictionary<string, string>
-        {
-            ["main.ts"] = """
-                import dns from 'dns/promises';
-                console.log(typeof dns.resolveMx === 'function');
-                console.log(typeof dns.resolveTxt === 'function');
-                console.log(typeof dns.resolveSrv === 'function');
-                console.log(typeof dns.resolveCname === 'function');
-                console.log(typeof dns.resolveNs === 'function');
-                console.log(typeof dns.resolveSoa === 'function');
-                console.log(typeof dns.resolvePtr === 'function');
-                console.log(typeof dns.resolveCaa === 'function');
-                console.log(typeof dns.resolveNaptr === 'function');
-                """
-        };
-
-        var output = TestHarness.RunModules(files, "main.ts", mode);
-        Assert.Equal("true\ntrue\ntrue\ntrue\ntrue\ntrue\ntrue\ntrue\ntrue\n", output);
-    }
-
-    #endregion
-
-    #region Compiled Mode Tests
-
-    // Note: Simplified AllModes duplicates were removed. The detailed tests above
-    // (ResolveMx_Callback_ReturnsArray, ResolveNs_Callback_ReturnsStringArray, etc.)
-    // now run in All modes and provide strictly more coverage.
 
     #endregion
 
@@ -520,7 +127,55 @@ public class DnsRecordTypeTests
 
     #endregion
 
-    #region Named Import Tests
+    #region API surface tests (no network)
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Dns_Import_NewMethods_Exist(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import * as dns from 'dns';
+                console.log(typeof dns.resolveMx === 'function');
+                console.log(typeof dns.resolveTxt === 'function');
+                console.log(typeof dns.resolveSrv === 'function');
+                console.log(typeof dns.resolveCname === 'function');
+                console.log(typeof dns.resolveNs === 'function');
+                console.log(typeof dns.resolveSoa === 'function');
+                console.log(typeof dns.resolvePtr === 'function');
+                console.log(typeof dns.resolveCaa === 'function');
+                console.log(typeof dns.resolveNaptr === 'function');
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("true\ntrue\ntrue\ntrue\ntrue\ntrue\ntrue\ntrue\ntrue\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void DnsPromises_Import_NewMethods_Exist(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import dns from 'dns/promises';
+                console.log(typeof dns.resolveMx === 'function');
+                console.log(typeof dns.resolveTxt === 'function');
+                console.log(typeof dns.resolveSrv === 'function');
+                console.log(typeof dns.resolveCname === 'function');
+                console.log(typeof dns.resolveNs === 'function');
+                console.log(typeof dns.resolveSoa === 'function');
+                console.log(typeof dns.resolvePtr === 'function');
+                console.log(typeof dns.resolveCaa === 'function');
+                console.log(typeof dns.resolveNaptr === 'function');
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("true\ntrue\ntrue\ntrue\ntrue\ntrue\ntrue\ntrue\ntrue\n", output);
+    }
 
     [Theory]
     [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]


### PR DESCRIPTION
Closes #225.

## What

Moves DNS behavioral coverage off live resolvers (a recurring CI flake source) onto a loopback fake server that exercises the real wire code — actual UDP/TCP sockets, actual packet bytes — in **both** runtimes, then shrinks the live tests to a tolerant smoke set.

### Test infrastructure

- **`FakeDnsServer`** — extracted from `DnsWireProtocolRetryTests` and extended: per-query UDP responder (return `null` to deliberately not answer → timeout path), optional TCP listener on the same port speaking RFC 1035 length-prefixed framing (TC-bit fallback), `QueryCount`/`TcpQueryCount`. Written for the worst CI platform per the issue: async receives only, shutdown via socket close (macOS `Dispose`-vs-sync-`Receive` wedge, dotnet/runtime#81378). Port pairing probes random high ports because Windows UDP excluded-port ranges can swallow sequential ephemeral allocations.
- **`DnsPackets`** — RFC 1035 response builders: per-record-type RDATA (A/AAAA/MX/TXT/SRV/SOA/CAA/NS/PTR/CNAME/NAPTR), compression pointers in answer names and RDATA (including the label-then-pointer jump path), truncation, arbitrary rcodes, corrupted transaction IDs, plus request inspectors (QTYPE/QNAME).

### Runtime seam (both runtimes, kept in lockstep)

- `SHARPTS_DNS_SERVER` overrides system-DNS discovery (`"host"` or `"host:port"`); `SHARPTS_DNS_TIMEOUT_MS` overrides the 5s per-attempt timeout. Honored by `DnsWireProtocol` and by the emitted IL (`DnsGetSystemDns`, new `DnsGetTimeoutMs`).
- The emitted IL hardcoded port 53 (`IPAddress.Parse` + `53`) in both UDP and TCP paths — a custom server could never carry a port. New emitted `DnsParseServerEndpoint` (IPEndPoint.Parse, port 0 → 53) mirrors the interpreter''s host:port handling. All emitted helpers are pure BCL; standalone outputs are unaffected.
- **Transaction-ID validation** (new behavior, mirrored in both paths): responses whose ID doesn''t echo the query are discarded and retried; persistent mismatch surfaces `ETIMEOUT` after the retry budget.

### New suites

- **`DnsWireProtocolFakeServerTests`** (24 tests) — pins `DnsWireProtocol` directly: record decoding for every type, name decompression (pointer-only, label+pointer, uncompressed), skipping non-matching record types, TC→TCP fallback, rcode mapping (EFORMERR/ENOTFOUND/ENOTIMP final vs SERVFAIL/REFUSED retried), ENODATA, short/malformed responses, ID validation.
- **`DnsFakeServerModuleTests`** (32 tests) — TS programs through the harness in **interpreted and compiled** modes with exact-value assertions. In compiled mode these execute the emitted IL twin (`DnsSendReceive`, `DnsSendViaTcp`/`DnsReadExact`, `DnsParseResponse`/`DnsParseRecord`, `DnsReadName`) that the issue notes has historically drifted: all 9 record types, `dns.resolve(host, rrtype)`, dns/promises, NXDOMAIN errors (callback + rejection), TC→TCP fallback, silent-server timeout (pins the 3-attempt retry count in both modes), and `Resolver.setServers` against the fake. Env-var tests live in a `DisableParallelization` collection since the variables are process-global.

### Live tests shrunk

`DnsRecordTypeTests` drops the google.com breadth (8 live theories × both modes) and keeps: no-network API-surface tests, invalid-domain error tests, and two skip-on-transient-failure live smoke queries (callback MX + promise NS).

## Found along the way

Filed #239: in compiled mode, callback-based `dns.*` calls made from inside another callback never invoke their callback (interpreter is fine). The module tests issue one top-level dns call per program to sidestep it; the fake server gives a deterministic harness for fixing it.

## Testing

- New DNS suites + existing DNS tests: 136/136 pass.
- Full suite: **10,605/10,605 pass**.
- `--compile --verify`: IL verification passes on a DNS-using program.