### PR TITLE
Bugfix batch: Symbol first-class global (#234), combinator AggregateError instanceof (#232), extends Array (#233)

### DIFF
--- a/Compilation/CallHandlers/SuperConstructorHandler.cs
+++ b/Compilation/CallHandlers/SuperConstructorHandler.cs
@@ -40,6 +40,16 @@ public class SuperConstructorHandler : ICallHandler
             return true;
         }
 
+        // Built-in Array (#233): chain to $Array's ctor-args constructor,
+        // which applies ECMA-262 Array(...) semantics (single numeric arg
+        // sets the length; otherwise args become elements). Only reached when
+        // no user class claimed the name via ClassRegistry above.
+        if (ctx.CurrentSuperclassName == "Array" && ctx.Runtime?.TSArrayCtorFromCtorArgs != null)
+        {
+            EmitSuperArrayCtorCall(emitter, call.Arguments);
+            return true;
+        }
+
         // Try class expression constructors
         if (ctx.CurrentClassExpr != null &&
             ctx.ClassExprSuperclass?.TryGetValue(ctx.CurrentClassExpr, out var superclassName) == true &&
@@ -136,6 +146,33 @@ public class SuperConstructorHandler : ICallHandler
         }
 
         il.Emit(OpCodes.Call, baseCtor);
+
+        il.Emit(OpCodes.Ldnull); // super() returns undefined
+        emitter.SetStackUnknown();
+    }
+
+    /// <summary>
+    /// Emits a super(...) call that chains to $Array's ctor-args constructor:
+    /// builds an object[] from the evaluated arguments and calls
+    /// $Array(object?[] ctorArgs).
+    /// </summary>
+    private static void EmitSuperArrayCtorCall(IEmitterContext emitter, List<Expr> arguments)
+    {
+        var il = emitter.IL;
+        var ctx = emitter.Context;
+
+        il.Emit(OpCodes.Ldarg_0); // this
+        il.Emit(OpCodes.Ldc_I4, arguments.Count);
+        il.Emit(OpCodes.Newarr, typeof(object));
+        for (int i = 0; i < arguments.Count; i++)
+        {
+            il.Emit(OpCodes.Dup);
+            il.Emit(OpCodes.Ldc_I4, i);
+            emitter.EmitExpression(arguments[i]);
+            emitter.EmitBoxIfNeeded(arguments[i]);
+            il.Emit(OpCodes.Stelem_Ref);
+        }
+        il.Emit(OpCodes.Call, ctx.Runtime!.TSArrayCtorFromCtorArgs);
 
         il.Emit(OpCodes.Ldnull); // super() returns undefined
         emitter.SetStackUnknown();

--- a/Compilation/EmittedRuntime.cs
+++ b/Compilation/EmittedRuntime.cs
@@ -1213,6 +1213,8 @@ public class EmittedRuntime
     /// </summary>
     public MethodBuilder CallArgsPoolGet { get; set; } = null!;
     public ConstructorBuilder TSArrayCtor { get; set; } = null!;
+    /// <summary>$Array(object?[] ctorArgs) — ECMA-262 Array-constructor semantics for guest classes extending Array (#233): implicit ctors and super(...) chain through this.</summary>
+    public ConstructorBuilder TSArrayCtorFromCtorArgs { get; set; } = null!;
     public MethodBuilder TSArrayElementsGetter { get; set; } = null!;
     public MethodBuilder TSArrayIsFrozenGetter { get; set; } = null!;
     public MethodBuilder TSArrayIsSealedGetter { get; set; } = null!;

--- a/Compilation/ExpressionEmitterBase.cs
+++ b/Compilation/ExpressionEmitterBase.cs
@@ -1566,7 +1566,78 @@ public abstract partial class ExpressionEmitterBase : IEmitterContext
             return true;
         }
 
+        // Built-in constructor identifiers used as values (#232): without these
+        // arms, state-machine bodies (async/generator MoveNext emitters, which
+        // don't run ILEmitter's EmitVariable) emit null for `Error`, `Date`,
+        // `Map`, … — so `e instanceof Error` inside an async function was
+        // always false. Positioned after the user-variable checks so local
+        // shadowing wins, mirroring ILEmitter's resolution order.
+        if (TryEmitErrorTypeToken(name)) return true;
+        if (TryEmitBuiltInClassType(name)) return true;
+
         return false;
+    }
+
+    /// <summary>
+    /// Resolves a built-in Error constructor name (Error, TypeError, …,
+    /// AggregateError) by emitting the matching emitted-runtime Type token.
+    /// The InstanceOf runtime helper uses Type.IsAssignableFrom against it.
+    /// </summary>
+    protected bool TryEmitErrorTypeToken(string name)
+    {
+        if (!Runtime.BuiltIns.BuiltInNames.IsErrorTypeName(name)) return false;
+        var errorType = name switch
+        {
+            "Error" => Ctx.Runtime!.TSErrorType,
+            "TypeError" => Ctx.Runtime!.TSTypeErrorType,
+            "RangeError" => Ctx.Runtime!.TSRangeErrorType,
+            "ReferenceError" => Ctx.Runtime!.TSReferenceErrorType,
+            "SyntaxError" => Ctx.Runtime!.TSSyntaxErrorType,
+            "URIError" => Ctx.Runtime!.TSURIErrorType,
+            "EvalError" => Ctx.Runtime!.TSEvalErrorType,
+            "AggregateError" => Ctx.Runtime!.TSAggregateErrorType,
+            _ => Ctx.Runtime!.TSErrorType
+        };
+        IL.Emit(OpCodes.Ldtoken, errorType);
+        IL.Emit(OpCodes.Call, Types.GetMethod(Types.Type, "GetTypeFromHandle", Types.RuntimeTypeHandle));
+        SetStackUnknown();
+        return true;
+    }
+
+    /// <summary>
+    /// Resolves a bare reference to a built-in global class name (Date, Map,
+    /// Set, etc.) by emitting the matching .NET Type token. The InstanceOf
+    /// runtime helper then uses Type.IsAssignableFrom to check membership
+    /// against `new X()` instances, so `instanceof Date` works whether the
+    /// user is in script code or inside an embedded stdlib module.
+    /// </summary>
+    protected bool TryEmitBuiltInClassType(string name)
+    {
+        Type? t = name switch
+        {
+            "Date" => Ctx.Runtime!.TSDateType,
+            "RegExp" => Ctx.Runtime!.TSRegExpType,
+            "TextEncoder" => Ctx.Runtime!.TSTextEncoderType,
+            "TextDecoder" => Ctx.Runtime!.TSTextDecoderType,
+            "Buffer" => Ctx.Runtime!.TSBufferType,
+            "Array" => Types.IListOfObject, // covers both List<object> and $Array
+            "Map" => Types.DictionaryObjectObject,
+            "Set" => Types.HashSetOfObject,
+            "WeakMap" => Types.ConditionalWeakTableObjectObject,
+            "WeakSet" => Types.ConditionalWeakTableObjectObject,
+            "Promise" => Types.TaskOfObject,
+            "Function" => Ctx.Runtime!.TSFunctionType,
+            // Symbol (#234): the value-form $TSSymbol token. ILEmitter handles
+            // bare Symbol in its own pseudo-variable arm; this entry covers the
+            // state-machine emitters that resolve through this base path.
+            "Symbol" => Ctx.Runtime!.TSSymbolType,
+            _ => null
+        };
+        if (t == null) return false;
+        IL.Emit(OpCodes.Ldtoken, t);
+        IL.Emit(OpCodes.Call, Types.GetMethod(Types.Type, "GetTypeFromHandle", Types.RuntimeTypeHandle));
+        SetStackUnknown();
+        return true;
     }
 
     /// <summary>

--- a/Compilation/ILCompiler.Classes.Constructors.cs
+++ b/Compilation/ILCompiler.Classes.Constructors.cs
@@ -157,7 +157,21 @@ public partial class ILCompiler
         string? qualifiedSuperclass = classStmt.SuperclassExpr != null ? defCtx.ResolveClassName(Expr.GetSuperclassLeafName(classStmt.SuperclassExpr)!) : null;
         bool isErrorSubclass = classStmt.SuperclassExpr != null
             && Runtime.BuiltIns.BuiltInNames.IsErrorTypeName(Expr.GetSuperclassLeafName(classStmt.SuperclassExpr)!);
-        if (constructor == null && qualifiedSuperclass != null && isErrorSubclass)
+        // Direct `extends Array` (#233): base is the emitted $Array, chained
+        // via its ctor-args constructor.
+        bool isDirectArraySubclass = classStmt.SuperclassExpr != null
+            && Expr.GetSuperclassLeafName(classStmt.SuperclassExpr) == "Array"
+            && (qualifiedSuperclass == null || !_classes.Builders.ContainsKey(qualifiedSuperclass));
+        if (constructor == null && isDirectArraySubclass)
+        {
+            // No explicit constructor, extends Array — empty array per
+            // implicit `constructor(...args) { super(...args) }` with no args.
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldc_I4_0);
+            il.Emit(OpCodes.Newarr, typeof(object));
+            il.Emit(OpCodes.Call, _runtime.TSArrayCtorFromCtorArgs);
+        }
+        else if (constructor == null && qualifiedSuperclass != null && isErrorSubclass)
         {
             // No explicit constructor, extends Error — forward message arg to base Error constructor
             il.Emit(OpCodes.Ldarg_0);
@@ -188,11 +202,11 @@ public partial class ILCompiler
 
             il.Emit(OpCodes.Call, ctorToCall);
         }
-        else if (!isErrorSubclass)
+        else if (!isErrorSubclass && !isDirectArraySubclass)
         {
             // Has explicit constructor (which should have super() call) or no superclass.
-            // For Error subclasses with an explicit constructor, skip this — super() in the
-            // constructor body calls the Error base constructor via SuperConstructorHandler.
+            // For Error/Array subclasses with an explicit constructor, skip this — super()
+            // in the constructor body calls the base constructor via SuperConstructorHandler.
             il.Emit(OpCodes.Ldarg_0);
             il.Emit(OpCodes.Call, _types.ObjectDefaultCtor);
         }

--- a/Compilation/ILCompiler.Classes.cs
+++ b/Compilation/ILCompiler.Classes.cs
@@ -142,6 +142,26 @@ public partial class ILCompiler
             // Built-in error types: extend the emitted $Error/$TypeError/etc.
             baseType = GetEmittedErrorType(Expr.GetSuperclassLeafName(classStmt.SuperclassExpr)!);
         }
+        else if (qualifiedSuperclassName != null && classStmt.SuperclassExpr != null
+            && Expr.GetSuperclassLeafName(classStmt.SuperclassExpr) == "Array")
+        {
+            // `extends Array` (#233): derive from the emitted $Array, which
+            // itself inherits List<object?> — every IList-based array dispatch
+            // (push/length/iteration/Array.isArray/instanceof Array) applies
+            // to instances unchanged.
+            baseType = _runtime.TSArrayType;
+        }
+        else if (qualifiedSuperclassName != null && classStmt.SuperclassExpr != null
+            && Expr.GetSuperclassLeafName(classStmt.SuperclassExpr) is
+                "Promise" or "Map" or "Set" or "WeakMap" or "WeakSet" or "Date" or "RegExp" or "Buffer")
+        {
+            // Built-in constructors without a subclassing bridge (#233/#221):
+            // fail loudly at compile time rather than silently extending
+            // System.Object and misbehaving at runtime. Mirrors the
+            // interpreter's "subclassing this built-in is not supported yet".
+            throw new Diagnostics.Exceptions.CompileException(
+                $"Class '{classStmt.Name.Lexeme}' cannot extend built-in '{Expr.GetSuperclassLeafName(classStmt.SuperclassExpr)}': subclassing this built-in is not supported yet.");
+        }
 
         // Track Error subclass status (direct or transitive)
         if (classStmt.SuperclassExpr != null && Runtime.BuiltIns.BuiltInNames.IsErrorTypeName(Expr.GetSuperclassLeafName(classStmt.SuperclassExpr)!))
@@ -151,6 +171,18 @@ public partial class ILCompiler
         else if (qualifiedSuperclassName != null && _classes.ErrorSubclasses.Contains(qualifiedSuperclassName))
         {
             _classes.ErrorSubclasses.Add(qualifiedClassName);
+        }
+
+        // Track Array subclass status (direct or transitive) for constructor
+        // base-call emission (#233)
+        if (classStmt.SuperclassExpr != null && Expr.GetSuperclassLeafName(classStmt.SuperclassExpr) == "Array"
+            && !_classes.Builders.ContainsKey(qualifiedSuperclassName ?? ""))
+        {
+            _classes.ArraySubclasses.Add(qualifiedClassName);
+        }
+        else if (qualifiedSuperclassName != null && _classes.ArraySubclasses.Contains(qualifiedSuperclassName))
+        {
+            _classes.ArraySubclasses.Add(qualifiedClassName);
         }
 
         // Set the parent type (defaults to Object if baseType is null)

--- a/Compilation/ILCompiler.State.cs
+++ b/Compilation/ILCompiler.State.cs
@@ -27,6 +27,12 @@ public partial class ILCompiler
         /// Set during DefineClass and used by HasFields to emit Error property fallback.
         /// </summary>
         public HashSet<string> ErrorSubclasses { get; } = [];
+        /// <summary>
+        /// Qualified names of classes that (directly or transitively) extend the
+        /// built-in Array (#233). Set during DefineClass; used by constructor
+        /// emission to chain to $Array's ctor-args constructor.
+        /// </summary>
+        public HashSet<string> ArraySubclasses { get; } = [];
         public Dictionary<string, ConstructorBuilder> Constructors { get; } = [];
         public Dictionary<string, List<ConstructorBuilder>> ConstructorOverloads { get; } = [];
         public Dictionary<string, Dictionary<string, FieldBuilder>> StaticFields { get; } = [];

--- a/Compilation/ILEmitter.Expressions.cs
+++ b/Compilation/ILEmitter.Expressions.cs
@@ -281,25 +281,8 @@ public partial class ILEmitter
         }
 
         // Check if it's a built-in Error constructor — push the emitted Type object
-        if (Runtime.BuiltIns.BuiltInNames.IsErrorTypeName(name))
-        {
-            var errorType = name switch
-            {
-                "Error" => _ctx.Runtime!.TSErrorType,
-                "TypeError" => _ctx.Runtime!.TSTypeErrorType,
-                "RangeError" => _ctx.Runtime!.TSRangeErrorType,
-                "ReferenceError" => _ctx.Runtime!.TSReferenceErrorType,
-                "SyntaxError" => _ctx.Runtime!.TSSyntaxErrorType,
-                "URIError" => _ctx.Runtime!.TSURIErrorType,
-                "EvalError" => _ctx.Runtime!.TSEvalErrorType,
-                "AggregateError" => _ctx.Runtime!.TSAggregateErrorType,
-                _ => _ctx.Runtime!.TSErrorType
-            };
-            IL.Emit(OpCodes.Ldtoken, errorType);
-            IL.Emit(OpCodes.Call, _ctx.Types.GetMethod(_ctx.Types.Type, "GetTypeFromHandle", _ctx.Types.RuntimeTypeHandle));
-            SetStackUnknown();
+        if (TryEmitErrorTypeToken(name))
             return;
-        }
 
         // Built-in classes referenced as values (e.g. `instanceof Date`,
         // `x === Map`, passing Date as an arg). Emit the .NET Type object for
@@ -333,37 +316,9 @@ public partial class ILEmitter
         EmitNullConstant();
     }
 
-    /// <summary>
-    /// Resolves a bare reference to a built-in global class name (Date, Map,
-    /// Set, etc.) by emitting the matching .NET Type token. The InstanceOf
-    /// runtime helper then uses Type.IsAssignableFrom to check membership
-    /// against `new X()` instances, so `instanceof Date` works whether the
-    /// user is in script code or inside an embedded stdlib module.
-    /// </summary>
-    private bool TryEmitBuiltInClassType(string name)
-    {
-        Type? t = name switch
-        {
-            "Date" => _ctx.Runtime!.TSDateType,
-            "RegExp" => _ctx.Runtime!.TSRegExpType,
-            "TextEncoder" => _ctx.Runtime!.TSTextEncoderType,
-            "TextDecoder" => _ctx.Runtime!.TSTextDecoderType,
-            "Buffer" => _ctx.Runtime!.TSBufferType,
-            "Array" => _ctx.Types.IListOfObject, // covers both List<object> and $Array
-            "Map" => _ctx.Types.DictionaryObjectObject,
-            "Set" => _ctx.Types.HashSetOfObject,
-            "WeakMap" => _ctx.Types.ConditionalWeakTableObjectObject,
-            "WeakSet" => _ctx.Types.ConditionalWeakTableObjectObject,
-            "Promise" => _ctx.Types.TaskOfObject,
-            "Function" => _ctx.Runtime!.TSFunctionType,
-            _ => null
-        };
-        if (t == null) return false;
-        IL.Emit(OpCodes.Ldtoken, t);
-        IL.Emit(OpCodes.Call, _ctx.Types.GetMethod(_ctx.Types.Type, "GetTypeFromHandle", _ctx.Types.RuntimeTypeHandle));
-        SetStackUnknown();
-        return true;
-    }
+    // TryEmitBuiltInClassType and TryEmitErrorTypeToken are inherited from
+    // ExpressionEmitterBase so state-machine emitters resolve built-in
+    // constructor identifiers identically (#232).
 
     // IsKnownVariable is inherited from ExpressionEmitterBase
 

--- a/Compilation/ILEmitter.Expressions.cs
+++ b/Compilation/ILEmitter.Expressions.cs
@@ -115,7 +115,17 @@ public partial class ILEmitter
 
         if (name == "Symbol")
         {
-            EmitNullConstant(); // Symbol is handled specially in property access via SymbolStaticEmitter
+            // Bare `Symbol` resolves to the $TSSymbol Type token (#234) — the
+            // same value-form pattern as Array/Number/String. typeof → "function",
+            // aliased member access hits GetProperty's Type branch (well-known
+            // symbols are public static fields with their JS names; for/keyFor
+            // route through LookupBuiltInStaticMember), and the call form
+            // dispatches via InvokeValue's Type-callee branch. Direct
+            // `Symbol.iterator` / `Symbol(...)` sites still compile through
+            // SymbolStaticEmitter / BuiltInConstructorHandler first.
+            IL.Emit(OpCodes.Ldtoken, _ctx.Runtime!.TSSymbolType);
+            IL.Emit(OpCodes.Call, _ctx.Types.GetMethod(_ctx.Types.Type, "GetTypeFromHandle", _ctx.Types.RuntimeTypeHandle));
+            SetStackUnknown();
             return;
         }
 

--- a/Compilation/RuntimeEmitter.BuiltInStaticDispatch.cs
+++ b/Compilation/RuntimeEmitter.BuiltInStaticDispatch.cs
@@ -171,6 +171,15 @@ public partial class RuntimeEmitter
         EmitObjectMethodLookup("isFrozen",                runtime.ObjectIsFrozen, 1);
         EmitObjectMethodLookup("isSealed",                runtime.ObjectIsSealed, 1);
 
+        // Symbol.* (#234) — bare `Symbol` resolves to the $TSSymbol Type token.
+        // Well-known symbols (iterator, species, …) are public static FIELDS
+        // carrying their JS names, so GetProperty's static-field probe resolves
+        // them before this table is consulted. Only the static methods need
+        // entries: their .NET names are For/KeyFor, which the case-sensitive
+        // static-method probe misses.
+        EmitLookup(runtime.TSSymbolType, "for", runtime.SymbolFor, 1);
+        EmitLookup(runtime.TSSymbolType, "keyFor", runtime.SymbolKeyFor, 1);
+
         // Math.* deliberately not handled here — bare `Math` emits the null
         // pseudo-variable (not a Type token), so its value-form access goes
         // through MathStaticEmitter.TryEmitStaticPropertyGet at compile time.

--- a/Compilation/RuntimeEmitter.GlobalThis.cs
+++ b/Compilation/RuntimeEmitter.GlobalThis.cs
@@ -204,15 +204,20 @@ public partial class RuntimeEmitter
         EmitTypeBranch("Number", _types.Double);
         EmitTypeBranch("String", _types.String);
         EmitTypeBranch("Boolean", _types.Boolean);
+        // Symbol (#234) — the $TSSymbol Type token, so `typeof Symbol` is
+        // "function", `globalThis.Symbol === Symbol` holds, and aliased
+        // member access resolves the well-known-symbol static fields via
+        // GetProperty's Type branch.
+        EmitTypeBranch("Symbol", runtime.TSSymbolType);
 
         // Remaining named namespaces (Math, JSON, console, Error, Reflect,
-        // process, Symbol) are represented as singletons in the runtime rather
+        // process) are represented as singletons in the runtime rather
         // than .NET Type instances. Keep the null-marker behavior for those —
         // compile-time static dispatch already routes through their dedicated
         // namespace emitters.
         string[] singletonNamespaces =
         [
-            "Math", "JSON", "console", "Error", "Reflect", "process", "Symbol"
+            "Math", "JSON", "console", "Error", "Reflect", "process"
         ];
         foreach (var ns in singletonNamespaces)
         {

--- a/Compilation/RuntimeEmitter.Objects.Invocation.cs
+++ b/Compilation/RuntimeEmitter.Objects.Invocation.cs
@@ -287,6 +287,34 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Call, runtime.ArrayConstructor);
         il.Emit(OpCodes.Ret);
         il.MarkLabel(notArrayTypeLabel);
+
+        // $TSSymbol (#234): bare `Symbol` resolves to the $TSSymbol Type token,
+        // so the aliased call form (`const f = Symbol; f("desc")`) lands here.
+        // Mirrors BuiltInConstructorHandler.EmitSymbol: description is
+        // Stringify(args[0]) when present, null otherwise.
+        var notSymbolTypeLabel = il.DefineLabel();
+        var symbolNoDescLabel = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Castclass, _types.Type);
+        il.Emit(OpCodes.Ldtoken, runtime.TSSymbolType);
+        il.Emit(OpCodes.Call, _types.Type.GetMethod("GetTypeFromHandle", [_types.RuntimeTypeHandle])!);
+        il.Emit(OpCodes.Call, _types.Type.GetMethod("op_Equality", [_types.Type, _types.Type])!);
+        il.Emit(OpCodes.Brfalse, notSymbolTypeLabel);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Ldlen);
+        il.Emit(OpCodes.Brfalse, symbolNoDescLabel);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Ldelem_Ref);
+        il.Emit(OpCodes.Call, runtime.Stringify);
+        il.Emit(OpCodes.Newobj, runtime.TSSymbolCtor);
+        il.Emit(OpCodes.Ret);
+        il.MarkLabel(symbolNoDescLabel);
+        il.Emit(OpCodes.Ldnull);
+        il.Emit(OpCodes.Newobj, runtime.TSSymbolCtor);
+        il.Emit(OpCodes.Ret);
+        il.MarkLabel(notSymbolTypeLabel);
+
         il.Emit(OpCodes.Ldnull);
         il.Emit(OpCodes.Ret);
 

--- a/Compilation/RuntimeEmitter.Objects.Properties.cs
+++ b/Compilation/RuntimeEmitter.Objects.Properties.cs
@@ -1466,6 +1466,31 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Isinst, _types.DictionaryStringObject);
         il.Emit(OpCodes.Brtrue, dictLabel);
 
+        // User Array subclass (#233): a guest class extending Array derives
+        // from $Array AND implements $IHasFields. Its class members (declared
+        // fields, getters, methods) take precedence over the built-in array
+        // surface; the per-class GetProperty returns $Undefined on miss, in
+        // which case we fall through to the ordinary $Array dispatch below.
+        var notArraySubclassLabel = il.DefineLabel();
+        var arraySubclassMissLabel = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Isinst, runtime.TSArrayType);
+        il.Emit(OpCodes.Brfalse, notArraySubclassLabel);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Isinst, runtime.IHasFieldsInterface);
+        il.Emit(OpCodes.Brfalse, notArraySubclassLabel);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Castclass, runtime.IHasFieldsInterface);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Callvirt, runtime.IHasFieldsGetProperty);
+        il.Emit(OpCodes.Dup);
+        il.Emit(OpCodes.Ldsfld, runtime.UndefinedInstance);
+        il.Emit(OpCodes.Beq, arraySubclassMissLabel);
+        il.Emit(OpCodes.Ret);
+        il.MarkLabel(arraySubclassMissLabel);
+        il.Emit(OpCodes.Pop);
+        il.MarkLabel(notArraySubclassLabel);
+
         // $Array - check for "length" (inherits List<object?>; MUST come
         // BEFORE the plain List check so sparse-aware length is used —
         // otherwise `new Array(10_000_000).length` returns 0).

--- a/Compilation/RuntimeEmitter.Promises.AllSettled.cs
+++ b/Compilation/RuntimeEmitter.Promises.AllSettled.cs
@@ -112,7 +112,7 @@ public partial class RuntimeEmitter
     /// Handles a single element with try/catch, returns {status, value/reason} dictionary.
     /// Uses a single try/catch and converts all exceptions to "rejected" dictionaries.
     /// </summary>
-    private void EmitProcessElementSettledMoveNext(ProcessElementSettledStateMachine sm)
+    private void EmitProcessElementSettledMoveNext(ProcessElementSettledStateMachine sm, EmittedRuntime runtime)
     {
         var il = sm.MoveNextMethod.GetILGenerator();
         var dictType = typeof(Dictionary<string, object?>);
@@ -228,7 +228,9 @@ public partial class RuntimeEmitter
         il.BeginCatchBlock(typeof(Exception));
         il.Emit(OpCodes.Stloc, exceptionLocal);
 
-        // Create Dictionary { ["status"] = "rejected", ["reason"] = ex.Message }
+        // Create Dictionary { ["status"] = "rejected", ["reason"] = WrapException(ex) }
+        // — the guest rejection value (thrown error object / rejection reason),
+        // not the host exception's Message string (#232).
         il.Emit(OpCodes.Newobj, dictType.GetConstructor(Type.EmptyTypes)!);
         il.Emit(OpCodes.Stloc, dictLocal);
 
@@ -240,7 +242,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloc, dictLocal);
         il.Emit(OpCodes.Ldstr, "reason");
         il.Emit(OpCodes.Ldloc, exceptionLocal);
-        il.Emit(OpCodes.Callvirt, typeof(Exception).GetProperty("Message")!.GetGetMethod()!);
+        il.Emit(OpCodes.Call, runtime.WrapException);
         il.Emit(OpCodes.Callvirt, dictType.GetMethod("set_Item")!);
 
         il.Emit(OpCodes.Ldloc, dictLocal);

--- a/Compilation/RuntimeEmitter.Promises.Any.cs
+++ b/Compilation/RuntimeEmitter.Promises.Any.cs
@@ -143,13 +143,16 @@ public partial class RuntimeEmitter
         // try block
         il.BeginExceptionBlock();
 
-        // state.RejectionReasons.Add(task.Exception?.Message ?? "Unknown error")
+        // state.RejectionReasons.Add(WrapException(task.Exception.InnerException ?? task.Exception))
+        // — the guest rejection VALUE, not the AggregateException wrapper's
+        // Message, so `e.errors` matches what each promise rejected with (#232).
         il.Emit(OpCodes.Ldarg_1);
         il.Emit(OpCodes.Ldfld, anyState.RejectionReasonsField);
 
-        // Get exception message
         var hasExceptionLabel = il.DefineLabel();
+        var unwrapDoneLabel = il.DefineLabel();
         var afterExceptionLabel = il.DefineLabel();
+        var aggExLocal = il.DeclareLocal(_types.Exception);
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Callvirt, _types.GetProperty(_types.Task, "Exception").GetGetMethod()!);
         il.Emit(OpCodes.Dup);
@@ -158,8 +161,19 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldstr, "Unknown error");
         il.Emit(OpCodes.Br, afterExceptionLabel);
 
+        // Unwrap the AggregateException Task.Exception always wraps faults in;
+        // WrapException then yields the guest value (__tsValue / rejection
+        // Reason / message dictionary fallback).
         il.MarkLabel(hasExceptionLabel);
-        il.Emit(OpCodes.Callvirt, _types.GetProperty(_types.Exception, "Message").GetGetMethod()!);
+        il.Emit(OpCodes.Stloc, aggExLocal);
+        il.Emit(OpCodes.Ldloc, aggExLocal);
+        il.Emit(OpCodes.Callvirt, _types.GetProperty(_types.Exception, "InnerException").GetGetMethod()!);
+        il.Emit(OpCodes.Dup);
+        il.Emit(OpCodes.Brtrue, unwrapDoneLabel);
+        il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Ldloc, aggExLocal);
+        il.MarkLabel(unwrapDoneLabel);
+        il.Emit(OpCodes.Call, runtime.WrapException);
 
         il.MarkLabel(afterExceptionLabel);
         il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.ListOfObject, "Add", [_types.Object]));

--- a/Compilation/RuntimeEmitter.Promises.cs
+++ b/Compilation/RuntimeEmitter.Promises.cs
@@ -446,7 +446,7 @@ public partial class RuntimeEmitter
         );
         runtime.ProcessElementSettled = processElementSettled;
         EmitProcessElementSettledWrapper(processElementSettled.GetILGenerator(), processElementSettledSM);
-        EmitProcessElementSettledMoveNext(processElementSettledSM);
+        EmitProcessElementSettledMoveNext(processElementSettledSM, runtime);
         processElementSettledSM.Type.CreateType();
 
         // Promise.allSettled(iterable) - async state machine using helper + WhenAll

--- a/Compilation/RuntimeEmitter.TSArray.cs
+++ b/Compilation/RuntimeEmitter.TSArray.cs
@@ -150,6 +150,10 @@ public partial class RuntimeEmitter
         EmitTSArraySetLength(typeBuilder, runtime, tryCollapseSparse, syncLength);
         EmitTSArrayDeleteAt(typeBuilder, runtime, syncLength);
 
+        // Constructor-args overload for guest classes extending Array (#233) —
+        // must be emitted after SetLength, whose MethodBuilder it calls.
+        EmitTSArraySubclassConstructor(typeBuilder, runtime);
+
         EmitTSArrayToString(typeBuilder, runtime);
         // IList<object?> impl is inherited from List<object?> — no explicit
         // bridges needed (was the old composition-based approach).
@@ -182,6 +186,87 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Conv_I8);
         il.Emit(OpCodes.Stfld, _tsArrayLengthField);
 
+        il.Emit(OpCodes.Ret);
+    }
+
+    /// <summary>
+    /// <c>public $Array(object?[] ctorArgs)</c> — ECMA-262 §23.1.1.1 Array
+    /// constructor semantics applied to a fresh instance, for guest classes
+    /// extending Array (#233): their emitted constructors chain here (both the
+    /// implicit-constructor path and explicit <c>super(...)</c> calls). A
+    /// single numeric argument sets the length (holes); any other shape
+    /// appends the arguments as elements.
+    /// </summary>
+    private void EmitTSArraySubclassConstructor(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    {
+        var ctor = typeBuilder.DefineConstructor(
+            MethodAttributes.Public,
+            CallingConventions.Standard,
+            [_types.ObjectArray]
+        );
+        runtime.TSArrayCtorFromCtorArgs = ctor;
+
+        var il = ctor.GetILGenerator();
+        var elementsLabel = il.DefineLabel();
+        var loopStart = il.DefineLabel();
+        var loopCheck = il.DefineLabel();
+        var doneLabel = il.DefineLabel();
+        var iLocal = il.DeclareLocal(_types.Int32);
+
+        // base() — empty List<object?>
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Call, _types.GetDefaultConstructor(_types.ListOfObject));
+        // _length starts at 0 (field default)
+
+        // if (ctorArgs.Length == 1 && ctorArgs[0] is double) { SetLength((long)d); return; }
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Ldlen);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Bne_Un, elementsLabel);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Ldelem_Ref);
+        il.Emit(OpCodes.Isinst, _types.Double);
+        il.Emit(OpCodes.Brfalse, elementsLabel);
+
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Ldelem_Ref);
+        il.Emit(OpCodes.Unbox_Any, _types.Double);
+        il.Emit(OpCodes.Conv_I8);
+        il.Emit(OpCodes.Call, runtime.TSArraySetLength);
+        il.Emit(OpCodes.Br, doneLabel);
+
+        // else: append each ctor arg as an element, then sync _length.
+        il.MarkLabel(elementsLabel);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Stloc, iLocal);
+        il.Emit(OpCodes.Br, loopCheck);
+        il.MarkLabel(loopStart);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Ldloc, iLocal);
+        il.Emit(OpCodes.Ldelem_Ref);
+        il.Emit(OpCodes.Callvirt, _tsArrayListAdd!);
+        il.Emit(OpCodes.Ldloc, iLocal);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Stloc, iLocal);
+        il.MarkLabel(loopCheck);
+        il.Emit(OpCodes.Ldloc, iLocal);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Ldlen);
+        il.Emit(OpCodes.Blt, loopStart);
+
+        // _length = (long)Count
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Callvirt, _tsArrayListCountGetter!);
+        il.Emit(OpCodes.Conv_I8);
+        il.Emit(OpCodes.Stfld, _tsArrayLengthField);
+
+        il.MarkLabel(doneLabel);
         il.Emit(OpCodes.Ret);
     }
 

--- a/Execution/Interpreter.Calls.cs
+++ b/Execution/Interpreter.Calls.cs
@@ -817,6 +817,20 @@ public partial class Interpreter
             return false;
         }
 
+        // Array subclass instances (#233): real SharpTSArrays carrying a guest
+        // class — walk its chain (`m instanceof Array` is handled by the
+        // SharpTSArrayGlobal arm above via `left is SharpTSArray`).
+        if (left is SharpTSArraySubclassInstance subclassArray)
+        {
+            SharpTSClass? current = subclassArray.Klass;
+            while (current != null)
+            {
+                if (current.Name == targetClass.Name) return true;
+                current = current.Superclass;
+            }
+            return false;
+        }
+
         // Legacy path: SharpTSError instances created via BuiltInConstructorFactory
         // (not SharpTSInstance, but should still pass instanceof Error/TypeError/etc.)
         if (left is SharpTSError error && targetClass is SharpTSErrorClass)

--- a/Execution/Interpreter.Expressions.cs
+++ b/Execution/Interpreter.Expressions.cs
@@ -306,7 +306,9 @@ public partial class Interpreter
     private RuntimeValue EvaluateSuper(Expr.Super expr)
     {
         SharpTSClass superclass = _environment.Get(expr.Keyword).AsObject<SharpTSClass>()!;
-        SharpTSInstance instance = _environment.Get(new Token(TokenType.THIS, "this", null, 0)).AsObject<SharpTSInstance>()!;
+        // `this` is usually a SharpTSInstance, but built-in-backed instances
+        // (Array subclass instances) are SharpTSArrays — bind generically.
+        object? thisReceiver = _environment.Get(new Token(TokenType.THIS, "this", null, 0)).ToObject();
 
         // super() with null Method means constructor call
         string methodName = expr.Method?.Lexeme ?? "constructor";
@@ -324,7 +326,7 @@ public partial class Interpreter
             throw new InterpreterException($"Undefined property '{methodName}'.");
         }
 
-        return RuntimeValue.FromObject(SharpTSClass.BindMethod(method, instance));
+        return RuntimeValue.FromObject(SharpTSClass.BindMethodToReceiver(method, thisReceiver!));
     }
 
     /// <summary>
@@ -1098,8 +1100,19 @@ public partial class Interpreter
         if (classExpr.SuperclassExpr != null)
         {
             superclass = Evaluate(classExpr.SuperclassExpr);
+            // `extends Array` (#233): substitute the SharpTSArrayClass bridge,
+            // mirroring VisitClass.
+            if (superclass is SharpTSArrayGlobal)
+            {
+                superclass = SharpTSArrayClass.ArrayBase;
+            }
             if (superclass is not SharpTSClass)
             {
+                if (superclass is SharpTSBuiltInConstructor builtInCtor)
+                {
+                    throw new InterpreterException(
+                        $"Class expression cannot extend built-in '{builtInCtor.Name}': subclassing this built-in is not supported yet.");
+                }
                 throw new InterpreterException("Superclass must be a class.");
             }
         }
@@ -1202,16 +1215,40 @@ public partial class Interpreter
                 }
             }
 
-            SharpTSClass klass = new(
-                className,
-                (SharpTSClass?)superclass,
-                methods,
-                staticMethods,
-                staticProperties,
-                getters,
-                setters,
-                classExpr.IsAbstract,
-                instanceFields);
+            // Mirror VisitClass: Error/Array superclasses need their dedicated
+            // SharpTSClass subtypes so instances get the right backing.
+            SharpTSClass klass = superclass is SharpTSErrorClass errorSuper
+                ? new SharpTSErrorClass(
+                    className,
+                    errorSuper,
+                    methods,
+                    staticMethods,
+                    staticProperties,
+                    getters,
+                    setters,
+                    classExpr.IsAbstract,
+                    instanceFields)
+                : superclass is SharpTSArrayClass arraySuper
+                ? new SharpTSArrayClass(
+                    className,
+                    arraySuper,
+                    methods,
+                    staticMethods,
+                    staticProperties,
+                    getters,
+                    setters,
+                    classExpr.IsAbstract,
+                    instanceFields)
+                : new SharpTSClass(
+                    className,
+                    (SharpTSClass?)superclass,
+                    methods,
+                    staticMethods,
+                    staticProperties,
+                    getters,
+                    setters,
+                    classExpr.IsAbstract,
+                    instanceFields);
 
             // Execute static initializers in declaration order (if present)
             if (hasStaticInitializers)

--- a/Execution/Interpreter.Properties.cs
+++ b/Execution/Interpreter.Properties.cs
@@ -1026,7 +1026,14 @@ public partial class Interpreter
             // process-wide static FrozenDictionary).
             if (memberName == "prototype" && ctor.Name == BuiltInNames.RegExp)
                 return GetRegExpPrototype();
-            return ctor.GetMember(memberName) ?? SharpTSUndefined.Instance;
+            var ctorMember = ctor.GetMember(memberName);
+            // Materialize constant-wrapping members (e.g. Symbol.species via an
+            // alias: `const S = Symbol; S.species`) the same way the syntactic
+            // path in EvaluateGet does — otherwise the alias path returns the
+            // BuiltInMethod wrapper and identity with the direct form breaks.
+            if (ctorMember is BuiltInMethod { IsConstant: true } ctorConstant)
+                return ctorConstant.Call(this, []);
+            return ctorMember ?? SharpTSUndefined.Instance;
         }
 
         // Handle plain Dictionary<string, object?> objects (e.g., segment items from Intl.Segments)

--- a/Execution/Interpreter.Properties.cs
+++ b/Execution/Interpreter.Properties.cs
@@ -623,7 +623,7 @@ public partial class Interpreter
     /// Property access on arrays. Checks named properties and ISharpTSPropertyAccessor
     /// before falling through to built-in array members.
     /// </summary>
-    private static RuntimeValue EvaluateGetOnArrayRV(object obj, string memberName)
+    private RuntimeValue EvaluateGetOnArrayRV(object obj, string memberName)
     {
         // ISharpTSPropertyAccessor check (handles SharpTSTemplateStringsArray.raw)
         if (obj is ISharpTSPropertyAccessor accessor && accessor.HasProperty(memberName))
@@ -632,6 +632,21 @@ public partial class Interpreter
         // Named properties from Object.defineProperty
         if (obj is SharpTSArray array && array.HasNamedProperty(memberName))
             return RuntimeValue.FromBoxed(array.GetNamedProperty(memberName));
+
+        // Array subclass instances (#233): class getters and methods resolve
+        // before built-in Array members so user overrides win; declared fields
+        // were handled above as named properties (own props shadow methods).
+        if (obj is SharpTSArraySubclassInstance subclassArray)
+        {
+            if (memberName == "constructor")
+                return RuntimeValue.FromObject(subclassArray.Klass);
+            var classGetter = subclassArray.Klass.FindGetter(memberName);
+            if (classGetter != null)
+                return RuntimeValue.FromBoxed(classGetter.BindThis(subclassArray).Call(this, []));
+            var classMethod = subclassArray.Klass.FindMethod(memberName);
+            if (classMethod != null)
+                return RuntimeValue.FromObject(SharpTSClass.BindMethodToReceiver(classMethod, subclassArray));
+        }
 
         // Numeric-string index on $Array — `arr["0"]` is equivalent to
         // `arr[0]` per JS semantics. ECMA-262 §10.4.2 (Array exotic objects)
@@ -1053,6 +1068,21 @@ public partial class Interpreter
         if (obj is SharpTSArray array && array.HasNamedProperty(memberName))
         {
             return array.GetNamedProperty(memberName);
+        }
+
+        // Array subclass instances (#233): class getters and methods resolve
+        // before the built-in Array members so user overrides win; fields were
+        // handled above as named properties (own properties shadow methods).
+        if (obj is SharpTSArraySubclassInstance subclassArray)
+        {
+            if (memberName == "constructor")
+                return subclassArray.Klass;
+            var classGetter = subclassArray.Klass.FindGetter(memberName);
+            if (classGetter != null)
+                return classGetter.BindThis(subclassArray).Call(this, []);
+            var classMethod = subclassArray.Klass.FindMethod(memberName);
+            if (classMethod != null)
+                return SharpTSClass.BindMethodToReceiver(classMethod, subclassArray);
         }
 
         // Handle built-in instance members: strings, arrays, Math, Promise

--- a/Execution/Interpreter.cs
+++ b/Execution/Interpreter.cs
@@ -2070,8 +2070,25 @@ public partial class Interpreter : IDisposable
         {
             superclass = Evaluate(classStmt.SuperclassExpr);
 
+            // `extends Array` (#233): the Array global is a constructor
+            // singleton, not a SharpTSClass — substitute the SharpTSArrayClass
+            // bridge so the class machinery (super(), method lookup,
+            // instanceof) sees a real superclass.
+            if (superclass is SharpTSArrayGlobal)
+            {
+                superclass = SharpTSArrayClass.ArrayBase;
+            }
+
             if (superclass is not SharpTSClass)
             {
+                // Built-in constructors that don't have a class bridge yet
+                // (Promise is the big one — see #221) get a precise error
+                // instead of the generic "Superclass must be a class".
+                if (superclass is SharpTSBuiltInConstructor builtInCtor)
+                {
+                    throw new InterpreterException(
+                        $"Class '{classStmt.Name.Lexeme}' cannot extend built-in '{builtInCtor.Name}': subclassing this built-in is not supported yet.");
+                }
                 throw new InterpreterException("Superclass must be a class.");
             }
         }
@@ -2238,10 +2255,31 @@ public partial class Interpreter : IDisposable
 
         // If the superclass is an Error type, create a SharpTSErrorClass so that
         // instances carry error fields (name, message, stack) and instanceof works.
+        // Likewise an Array superclass produces a SharpTSArrayClass whose
+        // instances are real arrays (#233).
         SharpTSClass klass = superclass is SharpTSErrorClass errorSuper
             ? new SharpTSErrorClass(
                 classStmt.Name.Lexeme,
                 errorSuper,
+                methods,
+                staticMethods,
+                staticProperties,
+                getters,
+                setters,
+                classStmt.IsAbstract,
+                instanceFields,
+                instancePrivateFields,
+                privateMethods,
+                staticPrivateFields,
+                staticPrivateMethods,
+                instanceAutoAccessors.Count > 0 ? instanceAutoAccessors : null,
+                staticAutoAccessors.Count > 0 ? staticAutoAccessors : null,
+                staticGetters.Count > 0 ? staticGetters : null,
+                staticSetters.Count > 0 ? staticSetters : null)
+            : superclass is SharpTSArrayClass arraySuper
+            ? new SharpTSArrayClass(
+                classStmt.Name.Lexeme,
+                arraySuper,
                 methods,
                 staticMethods,
                 staticProperties,

--- a/Execution/Interpreter.cs
+++ b/Execution/Interpreter.cs
@@ -192,6 +192,18 @@ public partial class Interpreter : IDisposable
         // MessageChannel as a value (construction already worked by name).
         globals[BuiltInNames.MessageChannel] = WorkerBuiltIns.MessageChannelConstructor;
 
+        // Symbol as a value-position global (#234): `typeof Symbol`,
+        // `const f = Symbol`, and `(Symbol as any).species` need a real
+        // binding. Its namespace is registered as non-singleton (member
+        // access routes through SymbolBuiltIns via GetMember), so the
+        // singleton loop above didn't bind it. The factory implements the
+        // call form Symbol(description); JS has no `new Symbol()`.
+        globals[BuiltInNames.Symbol] = new SharpTSBuiltInConstructor(
+            BuiltInNames.Symbol,
+            args => new SharpTSSymbol(args.Count > 0 && args[0] is not SharpTSUndefined
+                ? args[0]?.ToString()
+                : null));
+
         // Promise needs a bare-reference global so `x instanceof Promise`,
         // `typeof Promise === 'function'`, and stdlib modules that carry
         // Promise as a value can type-check/run. Its namespace is registered

--- a/Runtime/BuiltIns/GlobalFunctionHandlers.cs
+++ b/Runtime/BuiltIns/GlobalFunctionHandlers.cs
@@ -67,9 +67,12 @@ internal static class GlobalFunctionHandlers
         if (arguments.Count > 0)
         {
             var arg = await evaluateArg(arguments[0]);
-            description = arg.ToObject()?.ToString();
+            // ECMA-262 §20.4.1.1: Symbol(undefined) has no description.
+            description = arg.IsUndefined ? null : arg.ToObject()?.ToString();
         }
-        return RuntimeValue.FromObject(new SharpTSSymbol(description));
+        // FromSymbol (not FromObject) so the result carries ValueKind.Symbol —
+        // otherwise `typeof Symbol("x")` reports "object".
+        return RuntimeValue.FromSymbol(new SharpTSSymbol(description));
     }
 
     private static async ValueTask<RuntimeValue> HandleBigInt(

--- a/Runtime/BuiltIns/PromiseBuiltIns.cs
+++ b/Runtime/BuiltIns/PromiseBuiltIns.cs
@@ -344,33 +344,13 @@ public static class PromiseBuiltIns
                 });
                 results.Add(outcome);
             }
-            catch (SharpTSPromiseRejectedException ex)
-            {
-                // Create rejected outcome object
-                var outcome = new SharpTSObject(new Dictionary<string, object?>
-                {
-                    ["status"] = "rejected",
-                    ["reason"] = ex.Reason
-                });
-                results.Add(outcome);
-            }
-            catch (AggregateException aggEx) when (aggEx.InnerException is SharpTSPromiseRejectedException rejEx)
-            {
-                // Handle wrapped rejection exception
-                var outcome = new SharpTSObject(new Dictionary<string, object?>
-                {
-                    ["status"] = "rejected",
-                    ["reason"] = rejEx.Reason
-                });
-                results.Add(outcome);
-            }
             catch (Exception ex)
             {
-                // Handle other exceptions as rejections
+                // Create rejected outcome object carrying the guest rejection value
                 var outcome = new SharpTSObject(new Dictionary<string, object?>
                 {
                     ["status"] = "rejected",
-                    ["reason"] = ex.Message
+                    ["reason"] = ExtractRejectionReason(ex)
                 });
                 results.Add(outcome);
             }
@@ -401,16 +381,13 @@ public static class PromiseBuiltIns
             throw new Exception("Runtime Error: Promise.any requires an array argument.");
         }
 
-        // Empty array rejects immediately with AggregateError
+        // Empty array rejects immediately with AggregateError. Must be a real
+        // SharpTSAggregateError — the same representation `new AggregateError()`
+        // produces — so `e instanceof AggregateError` holds (#232).
         if (array.Length == 0)
         {
-            var aggregateError = new SharpTSObject(new Dictionary<string, object?>
-            {
-                ["name"] = "AggregateError",
-                ["message"] = "All promises were rejected",
-                ["errors"] = new SharpTSArray([])
-            });
-            throw new SharpTSPromiseRejectedException(aggregateError);
+            throw new SharpTSPromiseRejectedException(
+                new SharpTSAggregateError(new SharpTSArray([])));
         }
 
         var state = new AnyState { PendingCount = array.Length };
@@ -442,18 +419,30 @@ public static class PromiseBuiltIns
             // First fulfillment wins
             state.Tcs.TrySetResult(result);
         }
-        catch (SharpTSPromiseRejectedException ex)
-        {
-            HandleRejectionForAny(ex.Reason, state);
-        }
-        catch (AggregateException aggEx) when (aggEx.InnerException is SharpTSPromiseRejectedException rejEx)
-        {
-            HandleRejectionForAny(rejEx.Reason, state);
-        }
         catch (Exception ex)
         {
-            HandleRejectionForAny(ex.Message, state);
+            HandleRejectionForAny(ExtractRejectionReason(ex), state);
         }
+    }
+
+    /// <summary>
+    /// Extracts the guest rejection value from a faulted-promise exception:
+    /// the rejection Reason, a guest-thrown value (ThrowException from a
+    /// `throw` inside an async function), either of those wrapped in the
+    /// AggregateException that Task faults arrive in, or — last resort —
+    /// the host exception message. Keeps `e.errors` / allSettled `reason`
+    /// carrying what the promise actually rejected with (#232).
+    /// </summary>
+    private static object? ExtractRejectionReason(Exception ex)
+    {
+        if (ex is AggregateException agg && agg.InnerException is Exception inner)
+            ex = inner;
+        return ex switch
+        {
+            SharpTSPromiseRejectedException rejected => rejected.Reason,
+            Exceptions.ThrowException thrown => thrown.Value,
+            _ => ex.Message
+        };
     }
 
     /// <summary>
@@ -466,16 +455,12 @@ public static class PromiseBuiltIns
             state.RejectionReasons.Add(reason);
             state.PendingCount--;
 
-            // If all promises rejected, reject with AggregateError
+            // If all promises rejected, reject with a real SharpTSAggregateError
+            // so `e instanceof AggregateError` / `instanceof Error` hold (#232).
             if (state.PendingCount == 0)
             {
-                // Create an AggregateError-like object with errors array
-                var aggregateError = new SharpTSObject(new Dictionary<string, object?>
-                {
-                    ["name"] = "AggregateError",
-                    ["message"] = "All promises were rejected",
-                    ["errors"] = new SharpTSArray(state.RejectionReasons)
-                });
+                var aggregateError = new SharpTSAggregateError(
+                    new SharpTSArray(state.RejectionReasons));
 
                 state.Tcs.TrySetException(new SharpTSPromiseRejectedException(aggregateError));
             }

--- a/Runtime/Types/SharpTSArrayClass.cs
+++ b/Runtime/Types/SharpTSArrayClass.cs
@@ -1,0 +1,199 @@
+using SharpTS.Execution;
+using SharpTS.Parsing;
+using SharpTS.Runtime.Exceptions;
+
+namespace SharpTS.Runtime.Types;
+
+/// <summary>
+/// A <see cref="SharpTSArray"/> created by a guest class that extends
+/// <c>Array</c>. IS an array (all array built-ins, indexing, iteration, and
+/// <c>Array.isArray</c> work unchanged) and additionally carries the guest
+/// class for method/getter lookup and <c>instanceof</c> brand checks.
+/// </summary>
+/// <seealso cref="SharpTSArrayClass"/>
+public sealed class SharpTSArraySubclassInstance(SharpTSClass klass) : SharpTSArray
+{
+    /// <summary>The guest class this array was constructed by.</summary>
+    public SharpTSClass Klass { get; } = klass;
+}
+
+/// <summary>
+/// A <see cref="SharpTSClass"/> subclass representing <c>Array</c> in a class
+/// hierarchy — the bridge that lets <c>class MyArray extends Array</c> work
+/// (#233). Mirrors the <see cref="SharpTSErrorClass"/> pattern: the base
+/// singleton stands in for the built-in constructor (its <c>constructor</c>
+/// method implements <c>super(...)</c> semantics), and user subclasses
+/// override <see cref="Call"/> to produce array-backed instances.
+/// </summary>
+/// <remarks>
+/// v1 scope: instance methods, getters/setters, public fields (stored as
+/// named properties on the array), constructors with <c>super(...)</c>, and
+/// instanceof both ways. Static-side inheritance of Array built-ins
+/// (<c>MyArray.from</c>) and Symbol.species-driven derived creation are
+/// tracked separately.
+/// </remarks>
+public class SharpTSArrayClass : SharpTSClass
+{
+    /// <summary>
+    /// The singleton standing in for the built-in <c>Array</c> constructor at
+    /// the root of guest Array-subclass hierarchies.
+    /// </summary>
+    public static readonly SharpTSArrayClass ArrayBase = new();
+
+    private SharpTSArrayClass()
+        : base(
+            "Array",
+            null,
+            methods: new Dictionary<string, ISharpTSCallable>
+            {
+                ["constructor"] = new ArrayConstructorCallable()
+            },
+            staticMethods: [],
+            staticProperties: [])
+    {
+    }
+
+    /// <summary>
+    /// Creates a user-defined Array subclass (e.g. <c>class MyArray extends Array</c>).
+    /// </summary>
+    public SharpTSArrayClass(
+        string name,
+        SharpTSArrayClass superclass,
+        Dictionary<string, ISharpTSCallable> methods,
+        Dictionary<string, ISharpTSCallable> staticMethods,
+        Dictionary<string, object?> staticProperties,
+        Dictionary<string, SharpTSFunction>? getters = null,
+        Dictionary<string, SharpTSFunction>? setters = null,
+        bool isAbstract = false,
+        List<Stmt.Field>? instanceFields = null,
+        List<Stmt.Field>? instancePrivateFields = null,
+        Dictionary<string, ISharpTSCallable>? privateMethods = null,
+        Dictionary<string, object?>? staticPrivateFields = null,
+        Dictionary<string, ISharpTSCallable>? staticPrivateMethods = null,
+        List<Stmt.AutoAccessor>? instanceAutoAccessors = null,
+        Dictionary<string, object?>? staticAutoAccessors = null,
+        Dictionary<string, SharpTSFunction>? staticGetters = null,
+        Dictionary<string, SharpTSFunction>? staticSetters = null)
+        : base(
+            name,
+            superclass,
+            methods,
+            staticMethods,
+            staticProperties,
+            getters,
+            setters,
+            isAbstract,
+            instanceFields,
+            instancePrivateFields,
+            privateMethods,
+            staticPrivateFields,
+            staticPrivateMethods,
+            instanceAutoAccessors,
+            staticAutoAccessors,
+            staticGetters,
+            staticSetters)
+    {
+    }
+
+    /// <summary>
+    /// ECMA-262 §23.1.1.1 Array(...values) applied to an existing instance:
+    /// a single numeric argument sets the length (holes, not undefineds);
+    /// any other argument shape appends the arguments as elements.
+    /// </summary>
+    internal static void InitializeFromArrayArguments(SharpTSArray array, List<object?> arguments)
+    {
+        if (arguments.Count == 1 && arguments[0] is double d)
+        {
+            if (d < 0 || d > uint.MaxValue || Math.Floor(d) != d)
+                throw new ThrowException(new SharpTSRangeError("Invalid array length."));
+            array.SetLength((long)d);
+            return;
+        }
+        array.AddRange(arguments);
+    }
+
+    /// <summary>
+    /// Constructs a <see cref="SharpTSArraySubclassInstance"/>, initialises
+    /// declared public fields as named properties, then runs the user
+    /// constructor (whose <c>super(...)</c> resolves to
+    /// <see cref="ArrayConstructorCallable"/>) or, absent one, applies the
+    /// built-in Array constructor semantics directly.
+    /// </summary>
+    public override object? Call(Interpreter interpreter, List<object?> arguments)
+    {
+        var instance = new SharpTSArraySubclassInstance(this);
+
+        InitializeFieldsAsNamedProperties(interpreter, instance);
+
+        ISharpTSCallable? constructor = FindMethod("constructor");
+        bool hasUserConstructor = constructor is not ArrayConstructorCallable;
+
+        if (hasUserConstructor && constructor != null)
+        {
+            BindMethodToReceiver(constructor, instance).Call(interpreter, arguments);
+        }
+        else
+        {
+            InitializeFromArrayArguments(instance, arguments);
+        }
+
+        return instance;
+    }
+
+    /// <summary>
+    /// Initialises declared public instance fields (walking the superclass
+    /// chain root-first) as named properties on the array instance — arrays
+    /// store expando properties via the named-property table rather than
+    /// SharpTSInstance fields.
+    /// </summary>
+    private void InitializeFieldsAsNamedProperties(Interpreter interpreter, SharpTSArraySubclassInstance instance)
+    {
+        if (Superclass is SharpTSArrayClass parent)
+            parent.InitializeFieldsAsNamedProperties(interpreter, instance);
+
+        foreach (var field in InstanceFields)
+        {
+            object? value = field.Initializer != null
+                ? interpreter.Evaluate(field.Initializer)
+                : null;
+            string key = field.ComputedKey != null
+                ? interpreter.Evaluate(field.ComputedKey)?.ToString() ?? "undefined"
+                : field.Name.Lexeme;
+            instance.SetNamedProperty(key, value);
+        }
+    }
+
+    /// <summary>
+    /// Built-in Array constructor callable — the target of <c>super(...)</c>
+    /// in user subclass constructors. Applies Array constructor semantics to
+    /// the bound receiver.
+    /// </summary>
+    internal sealed class ArrayConstructorCallable : ISharpTSCallable, IReceiverBindable
+    {
+        private object? _boundReceiver;
+
+        public int Arity() => 0; // All args optional
+
+        public ISharpTSCallable BindToReceiver(object receiver)
+            => new ArrayConstructorCallable { _boundReceiver = receiver };
+
+        public object? Call(Interpreter interpreter, List<object?> arguments)
+        {
+            var receiver = _boundReceiver ?? interpreter.GetCurrentThis();
+            if (receiver is SharpTSArray array)
+                InitializeFromArrayArguments(array, arguments);
+            return null;
+        }
+    }
+}
+
+/// <summary>
+/// Interface for callables that can be bound to an arbitrary receiver (not
+/// just <see cref="SharpTSInstance"/>). The receiver-typed counterpart of
+/// <see cref="IInstanceBindable"/>, used by class machinery when instances
+/// are backed by built-in value types (e.g. Array subclass instances).
+/// </summary>
+public interface IReceiverBindable
+{
+    ISharpTSCallable BindToReceiver(object receiver);
+}

--- a/Runtime/Types/SharpTSClass.cs
+++ b/Runtime/Types/SharpTSClass.cs
@@ -52,6 +52,9 @@ public class SharpTSClass(
     private readonly FrozenDictionary<string, SharpTSFunction> _staticSetters = staticSetters?.ToFrozenDictionary() ?? FrozenDictionary<string, SharpTSFunction>.Empty;
     private readonly List<Stmt.Field> _instanceFields = instanceFields ?? [];
 
+    /// <summary>Declared public instance fields, for subclasses that initialize them onto non-SharpTSInstance receivers (e.g. Array-backed instances).</summary>
+    protected IReadOnlyList<Stmt.Field> InstanceFields => _instanceFields;
+
     // Method lookup cache - avoids repeated inheritance chain walks
     // Key: method name, Value: method (null means not found in entire chain)
     private readonly Dictionary<string, ISharpTSCallable?> _methodCache = [];
@@ -122,6 +125,25 @@ public class SharpTSClass(
             SharpTSAsyncGeneratorFunction asyncGenFunc => asyncGenFunc.Bind(instance),
             IInstanceBindable bindable => bindable.BindTo(instance),
             _ => method // For other callables that don't need binding
+        };
+    }
+
+    /// <summary>
+    /// Binds a method to an arbitrary receiver. Receivers that are
+    /// <see cref="SharpTSInstance"/> route through <see cref="BindMethod"/>;
+    /// built-in-backed instances (e.g. Array subclass instances, which are
+    /// <see cref="SharpTSArray"/>s) bind `this` via <see cref="SharpTSFunction.BindThis"/>
+    /// — the method's closure still resolves `super` lexically.
+    /// </summary>
+    public static ISharpTSCallable BindMethodToReceiver(ISharpTSCallable method, object receiver)
+    {
+        if (receiver is SharpTSInstance instance)
+            return BindMethod(method, instance);
+        return method switch
+        {
+            SharpTSFunction func => func.BindThis(receiver),
+            IReceiverBindable bindable => bindable.BindToReceiver(receiver),
+            _ => method
         };
     }
 

--- a/SharpTS.Tests/SharedTests/ArraySubclassTests.cs
+++ b/SharpTS.Tests/SharedTests/ArraySubclassTests.cs
@@ -1,0 +1,134 @@
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests;
+
+/// <summary>
+/// Tests for guest classes extending the built-in Array (#233).
+/// Runs against both interpreter and compiler.
+/// </summary>
+public class ArraySubclassTests
+{
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ExtendsArray_ArrayBehaviorAndBrand(ExecutionMode mode)
+    {
+        var source = """
+            class MyArray extends Array {}
+            const m: any = new MyArray();
+            m.push(1);
+            m.push(2);
+            console.log(m.length);
+            console.log(m[0], m[1]);
+            console.log(m instanceof MyArray);
+            console.log(m instanceof Array);
+            console.log(Array.isArray(m));
+            console.log(JSON.stringify(m));
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("2\n1 2\ntrue\ntrue\ntrue\n[1,2]\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ExtendsArray_MethodsFieldsAndIteration(ExecutionMode mode)
+    {
+        var source = """
+            class SumList extends Array {
+                tag: string = "sum";
+                total(): number {
+                    let t = 0;
+                    for (const x of this as any) t += x;
+                    return t;
+                }
+            }
+            const s: any = new SumList();
+            s.push(3);
+            s.push(4);
+            console.log(s.total());
+            console.log(s.tag);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("7\nsum\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ExtendsArray_ConstructorWithSuper(ExecutionMode mode)
+    {
+        var source = """
+            class Stack extends Array {
+                constructor() { super(); }
+                peek(): any { return this[this.length - 1]; }
+            }
+            const s: any = new Stack();
+            s.push("a");
+            s.push("b");
+            console.log(s.peek());
+            console.log(s.length, s instanceof Stack, s instanceof Array);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("b\n2 true true\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ExtendsArray_SuperWithLengthArgument(ExecutionMode mode)
+    {
+        // ECMA-262 §23.1.1.1: a single numeric constructor argument sets the
+        // length (holes), other shapes append the arguments as elements.
+        var source = """
+            class Sized extends Array {
+                constructor(n: number) { super(n); }
+            }
+            class Pair extends Array {
+                constructor(a: any, b: any) { super(a, b); }
+            }
+            const z: any = new Sized(3);
+            console.log(z.length);
+            const p: any = new Pair("x", "y");
+            console.log(p.length, p[0], p[1]);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("3\n2 x y\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ExtendsArray_GetterResolves(ExecutionMode mode)
+    {
+        var source = """
+            class Peekable extends Array {
+                get top(): any { return this[this.length - 1]; }
+            }
+            const p: any = new Peekable();
+            p.push(10);
+            p.push(20);
+            console.log(p.top);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("20\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void ExtendsPromise_TypeChecksButRuntimeUnsupported(ExecutionMode mode)
+    {
+        // #233: `extends Promise<T>` must pass the type checker (it used to be
+        // rejected with TS2315 "Cannot use type arguments with non-generic
+        // class"). The runtime bridge is tracked separately (#221) — until it
+        // lands, instantiating the hierarchy yields a precise error.
+        var source = """
+            class MyPromise<T> extends Promise<T> {}
+            console.log("declared");
+            """;
+
+        var ex = Assert.ThrowsAny<Exception>(() => TestHarness.Run(source, mode));
+        Assert.Contains("cannot extend built-in 'Promise'", ex.Message);
+    }
+}

--- a/SharpTS.Tests/SharedTests/PromiseMethodTests.cs
+++ b/SharpTS.Tests/SharedTests/PromiseMethodTests.cs
@@ -732,6 +732,106 @@ public class PromiseMethodTests
         Assert.Equal("caught\nAggregateError\n0\n", output);
     }
 
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Any_RejectionIsInstanceofAggregateError(ExecutionMode mode)
+    {
+        // #232: the combinator's rejection must be the same representation
+        // `new AggregateError()` produces, so instanceof checks hold.
+        var source = """
+            async function main(): Promise<void> {
+                try {
+                    await Promise.any([Promise.reject("e1")]);
+                } catch (e: any) {
+                    console.log(e instanceof AggregateError);
+                    console.log(e instanceof Error);
+                }
+                try {
+                    await Promise.any([]);
+                } catch (e: any) {
+                    console.log(e instanceof AggregateError, e instanceof Error);
+                }
+            }
+            main();
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("true\ntrue\ntrue true\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Any_ErrorsCarryGuestRejectionValues(ExecutionMode mode)
+    {
+        // #232: e.errors must hold what each promise rejected with — the
+        // guest values themselves, not host exception wrapper messages.
+        var source = """
+            async function thrower(): Promise<number> {
+                throw new Error("boom");
+            }
+            async function main(): Promise<void> {
+                try {
+                    await Promise.any([Promise.reject(new TypeError("t1")), thrower()]);
+                } catch (e: any) {
+                    console.log(e.errors.length);
+                    console.log(e.errors[0] instanceof TypeError, e.errors[0].message);
+                    console.log(e.errors[1] instanceof Error, e.errors[1].message);
+                }
+            }
+            main();
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("2\ntrue t1\ntrue boom\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AllSettled_ReasonCarriesGuestValue(ExecutionMode mode)
+    {
+        // #232 (adjacent): allSettled's rejected outcome must carry the guest
+        // rejection value, including guest throws from async functions.
+        var source = """
+            async function thrower(): Promise<number> {
+                throw new RangeError("r1");
+            }
+            async function main(): Promise<void> {
+                const results: any = await Promise.allSettled([thrower()]);
+                console.log(results[0].status);
+                console.log(results[0].reason instanceof RangeError, results[0].reason.message);
+            }
+            main();
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("rejected\ntrue r1\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    public void InstanceofError_InsideAsyncFunction(ExecutionMode mode)
+    {
+        // #232 root cause in compiled mode: state-machine bodies (async
+        // functions) resolved built-in constructor identifiers to null, so
+        // EVERY `x instanceof Error/Map/Date` inside async was false.
+        var source = """
+            async function main(): Promise<void> {
+                const e: any = new Error("x");
+                console.log(e instanceof Error);
+                const t: any = new TypeError("x");
+                console.log(t instanceof TypeError, t instanceof Error);
+                const m: any = new Map();
+                console.log(m instanceof Map);
+                const d: any = new Date();
+                console.log(d instanceof Date);
+            }
+            main();
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("true\ntrue true\ntrue\ntrue\n", output);
+    }
+
     #endregion
 
     #region Promise Executor Constructor Tests

--- a/SharpTS.Tests/SharedTests/SymbolTests.cs
+++ b/SharpTS.Tests/SharedTests/SymbolTests.cs
@@ -472,4 +472,90 @@ public class SymbolTests
     }
 
     #endregion
+
+    #region Symbol as First-Class Global (#234)
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Symbol_TypeofGlobal_IsFunction(ExecutionMode mode)
+    {
+        var source = """
+            console.log(typeof Symbol);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("function\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Symbol_TypeofCallResult_IsSymbol(ExecutionMode mode)
+    {
+        var source = """
+            console.log(typeof Symbol("x"));
+            console.log(typeof Symbol());
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("symbol\nsymbol\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Symbol_Aliased_CallCreatesSymbol(ExecutionMode mode)
+    {
+        var source = """
+            const f: any = Symbol;
+            const s = f("aliased");
+            console.log(typeof s);
+            console.log(s.description);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("symbol\naliased\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Symbol_Aliased_WellKnownIdentity(ExecutionMode mode)
+    {
+        var source = """
+            const f: any = Symbol;
+            console.log(f.species === Symbol.species);
+            console.log(f.iterator === Symbol.iterator);
+            console.log(typeof f.asyncIterator);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("true\ntrue\nsymbol\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Symbol_Aliased_ForAndKeyFor(ExecutionMode mode)
+    {
+        var source = """
+            const f: any = Symbol;
+            const shared = f.for("registry-key");
+            console.log(shared === Symbol.for("registry-key"));
+            console.log(f.keyFor(shared));
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("true\nregistry-key\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Symbol_CastExpression_MemberAccess(ExecutionMode mode)
+    {
+        var source = """
+            console.log((Symbol as any).species === Symbol.species);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("true\n", output);
+    }
+
+    #endregion
 }

--- a/TypeSystem/TypeChecker.Statements.Classes.cs
+++ b/TypeSystem/TypeChecker.Statements.Classes.cs
@@ -37,32 +37,45 @@ public partial class TypeChecker
                     // Instantiate the generic class with the type arguments
                     superclass = InstantiateGenericClass(gc, typeArgs);
                 }
+                else if (superType is TypeInfo.Any)
+                {
+                    // Built-in generic globals (Promise<T>, Array<T>) resolve to
+                    // Any in value position; `extends Promise<T>` must not be
+                    // rejected as "non-generic" (#233). Validate the type args
+                    // resolve, then fall through to the Any placeholder below.
+                    foreach (var typeArg in classStmt.SuperclassTypeArgs)
+                        ToTypeInfo(typeArg);
+                }
                 else
                 {
                     throw new TypeCheckException($"Cannot use type arguments with non-generic class '{Expr.GetSuperclassLeafName(classStmt.SuperclassExpr)}'", tsCode: "TS2315");
                 }
             }
-            else if (superType is TypeInfo.Instance si && si.ClassType is TypeInfo.Class sic)
-                superclass = sic;
-            else if (superType is TypeInfo.Class sc)
-                superclass = sc;
-            else if (superType is TypeInfo.GenericClass gc)
+            if (superclass == null)
             {
-                // Generic class without type arguments - error
-                throw new TypeCheckException($"Generic class '{gc.Name}' requires type arguments", tsCode: "TS2314");
+                if (superType is TypeInfo.Instance si && si.ClassType is TypeInfo.Class sic)
+                    superclass = sic;
+                else if (superType is TypeInfo.Class sc)
+                    superclass = sc;
+                else if (superType is TypeInfo.GenericClass gc2)
+                {
+                    // Generic class without type arguments - error
+                    throw new TypeCheckException($"Generic class '{gc2.Name}' requires type arguments", tsCode: "TS2314");
+                }
+                else if (superType is TypeInfo.Any)
+                {
+                    // Allow extending Any-typed globals (e.g. Error, TypeError,
+                    // Promise<T>, Array). Create a placeholder class so super()
+                    // calls and constructor validation type-check correctly
+                    // (accept any number of args).
+                    var placeholder = new TypeInfo.MutableClass(Expr.GetSuperclassLeafName(classStmt.SuperclassExpr)!);
+                    placeholder.Methods["constructor"] = new TypeInfo.Function(
+                        [new TypeInfo.Any()], new TypeInfo.Void(), RequiredParams: 0, HasRestParam: true);
+                    superclass = placeholder;
+                }
+                else
+                    throw new TypeCheckException("Superclass must be a class", tsCode: "TS2507");
             }
-            else if (superType is TypeInfo.Any)
-            {
-                // Allow extending Any-typed globals (e.g. Error, TypeError).
-                // Create a placeholder class so super() calls and constructor
-                // validation type-check correctly (accept any number of args).
-                var placeholder = new TypeInfo.MutableClass(Expr.GetSuperclassLeafName(classStmt.SuperclassExpr)!);
-                placeholder.Methods["constructor"] = new TypeInfo.Function(
-                    [new TypeInfo.Any()], new TypeInfo.Void(), RequiredParams: 0, HasRestParam: true);
-                superclass = placeholder;
-            }
-            else
-                throw new TypeCheckException("Superclass must be a class", tsCode: "TS2507");
         }
 
         // Handle generic type parameters


### PR DESCRIPTION
One commit per issue. All three fixed in BOTH interpreter and compiled modes; full suite green (10,608 passed, +24 new tests).

## Fixes #234 — Symbol as a first-class global value
- **Interp**: `Symbol` bound in globals as a `SharpTSBuiltInConstructor` whose factory implements the call form. `typeof Symbol === "function"`, aliasing, and cast-expression member access all work. The aliased-constructor fallback path now materializes `IsConstant` members like the syntactic path does, so `f.species === Symbol.species` holds for any aliased built-in constructor. `typeof Symbol("x")` no longer reports "object" (result now carries `ValueKind.Symbol`); `Symbol(undefined)` has no description per spec.
- **Compiled**: bare `Symbol` resolves to the `$TSSymbol` Type token (the established Array/Number/String value-form pattern). Well-known symbols resolve via the existing Type-branch static-field probe with full identity; `for`/`keyFor` added to `LookupBuiltInStaticMember`; `InvokeValue`'s Type-callee dispatch constructs symbols for the aliased call form; `globalThis.Symbol === Symbol` holds.

## Fixes #232 — combinator AggregateError instanceof + rejection-reason fidelity
- **Interp**: `Promise.any` builds a real `SharpTSAggregateError` (same representation as `new AggregateError()`), so `instanceof AggregateError`/`Error` hold. New `ExtractRejectionReason` helper unwraps rejections (incl. guest `throw` inside async functions) so `e.errors[i]` / `allSettled` `reason` carry the guest values, not host message strings.
- **Compiled — the root cause was much broader than the issue**: async/generator state-machine bodies resolve variables through `ExpressionEmitterBase.TryEmitGlobalVariable`, which had no arms for built-in constructor identifiers — so **every** `x instanceof Error/Date/Map/…` inside an async function was `false`. The Error-token and built-in-class-type resolution is now hoisted into the shared base (deduplicating the sync emitter), placed after user-variable resolution so shadowing still wins. `Promise.any`/`allSettled` rejection collection now routes through `WrapException` instead of capturing wrapper `.Message` strings.

## Fixes #233 — guest classes extending built-ins (Array landed; Promise → #242)
- **Type checker**: `extends Promise<T>` / `Array<T>` no longer rejected with TS2315; type args are validated and the Any-placeholder superclass applies.
- **Interp**: new `SharpTSArrayClass` bridge (mirrors `SharpTSErrorClass`); instances are `SharpTSArraySubclassInstance` — real `SharpTSArray`s carrying the guest class. Array built-ins, indexing, iteration, JSON, `Array.isArray`, `instanceof` (both ways), fields, getters, methods, `super()`/`super(n)`/`super(...items)` all work. `EvaluateSuper`/`BindMethodToReceiver` now accept arbitrary receivers — groundwork #242/#221 needs. Bonus: class *expressions* extending Error now get `SharpTSErrorClass` backing (previously silently lost error-field initialization).
- **Compiled**: Array subclasses derive from the emitted `$Array` (inherits `List<object?>`), so all IList-based dispatch applies unchanged. New `$Array(object?[] ctorArgs)` ctor implements ECMA-262 Array constructor semantics for implicit ctors and `super(...)`; `GetProperty` consults the subclass's `$IHasFields` surface before `$Array` dispatch.
- **Both modes**: unsupported built-in superclasses (Promise/Map/Set/WeakMap/WeakSet/Date/RegExp/Buffer) now fail with a precise 'subclassing this built-in is not supported yet' error — compiled previously extended `System.Object` silently and misbehaved.

## Issues filed along the way
- #237 — Symbol.prototype surface gaps (interp `sym.toString()` missing; compiled `String(sym)` throws) — pre-existing, reproduced on main.
- #242 — `extends Promise` (both modes), gated on the #221 promise-identity lift per #233's scope note; also tracks Array static-side inheritance (`MyArray.from`) and Symbol.species-driven derived creation.

## v1 scope notes (documented in #242)
- Array subclass *static-side* inheritance (`MyArray.from`) and species-driven `map`/`filter` returning the subclass are not in this batch.
- Interp: `async` methods on Array subclasses don't bind `this` (receiver-bindable path covers sync functions + `IReceiverBindable`).

## Testing
- `dotnet test`: 10,608 passed / 0 failed (was 10,584 before the batch; +24 new regression tests across SymbolTests, PromiseMethodTests, and new ArraySubclassTests).
- Each fix verified manually in both modes before its commit.