### PR TITLE
feat: parser gaps — export declare, ctor types in type args, bigint literals, any-conditionals, union normalization (#226)

### DIFF
--- a/Parsing/Parser.Expressions.cs
+++ b/Parsing/Parser.Expressions.cs
@@ -115,6 +115,11 @@ public partial class Parser
                 if (_isStrictMode && (variable.Name.Lexeme == "eval" || variable.Name.Lexeme == "arguments"))
                     throw new Exception("SyntaxError: Unexpected eval or arguments in strict mode");
                 return onVariable(variable.Name, value);
+            // `undefined = v` must PARSE (it's an identifier-shaped target) and fail in the
+            // CHECKER with TS2539 ("Cannot assign to 'undefined' because it is not a variable")
+            // — tsc treats this as a semantic error, not a parse error.
+            case Expr.Literal lit when lit.Value is SharpTS.Runtime.Types.SharpTSUndefined:
+                return onVariable(new Token(TokenType.IDENTIFIER, "undefined", null, Previous().Line), value);
             case Expr.Get get:
                 return onGet(get, value);
             case Expr.GetPrivate getPrivate when onGetPrivate != null:

--- a/Parsing/Parser.Modules.cs
+++ b/Parsing/Parser.Modules.cs
@@ -306,9 +306,14 @@ public partial class Parser
                 decl = VarDeclaration();
             }
         }
-        else if (Match(TokenType.LET) || Match(TokenType.VAR))
+        else if (Match(TokenType.LET))
         {
             decl = VarDeclaration();
+        }
+        else if (Match(TokenType.VAR))
+        {
+            // IsVar so the declaration participates in var hoisting (VarHoister).
+            decl = VarDeclaration(isConst: false, isVar: true);
         }
         else if (Match(TokenType.INTERFACE))
         {
@@ -325,6 +330,11 @@ public partial class Parser
         else if (Match(TokenType.NAMESPACE))
         {
             decl = NamespaceDeclaration(isExported: true);
+        }
+        else if (Match(TokenType.DECLARE))
+        {
+            // `export declare function/const/…` — an exported ambient declaration.
+            decl = AmbientDeclaration();
         }
         else
         {

--- a/Parsing/Parser.Types.cs
+++ b/Parsing/Parser.Types.cs
@@ -300,7 +300,10 @@ public partial class Parser
             StringBuilder sb = new();
             sb.Append("typeof ");
 
-            Token first = Consume(TokenType.IDENTIFIER, "Expect identifier after 'typeof' in type position.");
+            // `typeof undefined` / `typeof this` are valid queries alongside identifiers.
+            Token first = Check(TokenType.UNDEFINED) || Check(TokenType.THIS)
+                ? Advance()
+                : Consume(TokenType.IDENTIFIER, "Expect identifier after 'typeof' in type position.");
             sb.Append(first.Lexeme);
 
             // Handle property paths and index access: typeof obj.prop, typeof arr[0], typeof obj["key"]
@@ -446,6 +449,11 @@ public partial class Parser
         else if (Match(TokenType.NUMBER))
         {
             typeName = Previous().Literal!.ToString()!;
+        }
+        // Handle bigint literal types: 1n | 2n
+        else if (Match(TokenType.BIGINT_LITERAL))
+        {
+            typeName = Previous().Literal!.ToString()! + "n";
         }
         // Handle boolean literal types: true | false
         else if (Match(TokenType.TRUE))
@@ -721,7 +729,8 @@ public partial class Parser
                 {
                     // Property: name: type
                     Consume(TokenType.COLON, "Expect ':' after property name in object type.");
-                    propertyType = ParseUnionType();
+                    // Member values may be conditional types: { x: T extends number ? T : string }
+                    propertyType = ParseConditionalType();
                 }
 
                 // Build member string. Method members carry a '#m' marker (stripped by

--- a/Parsing/Parser.cs
+++ b/Parsing/Parser.cs
@@ -514,6 +514,10 @@ public partial class Parser(List<Token> tokens, DecoratorMode decoratorMode = De
         Check(TokenType.READONLY) ||  // readonly array/tuple modifier: readonly T[], readonly [A, B]
         Check(TokenType.TYPE_SYMBOL) || Check(TokenType.TYPE_BIGINT) ||  // symbol / bigint primitive types
         Check(TokenType.SYMBOL) || Check(TokenType.BIGINT) ||  // `Symbol` / `BigInt` as type names
+        Check(TokenType.BIGINT_LITERAL) ||  // bigint literal types: 1n | 2n
+        Check(TokenType.NEW) ||  // constructor types: new (x) => T (e.g. inside InstanceType<...>)
+        Check(TokenType.ABSTRACT) ||  // abstract constructor types: abstract new (x) => T
+        Check(TokenType.LESS) ||  // generic function types: <T>(x: T) => T as a type argument
         Check(TokenType.THIS);  // polymorphic `this` type
 
     // ============== GENERIC TYPE CLOSING BRACKET HANDLING ==============

--- a/SharpTS.Tests/TypeCheckerTests/Round5ParserGapsTests.cs
+++ b/SharpTS.Tests/TypeCheckerTests/Round5ParserGapsTests.cs
@@ -1,0 +1,90 @@
+using SharpTS.Tests.Infrastructure;
+using SharpTS.TypeSystem.Exceptions;
+using Xunit;
+
+namespace SharpTS.Tests.TypeCheckerTests;
+
+/// <summary>
+/// Round-5 fixes (#226 parser-gap cluster): export declare, constructor types as generic type
+/// arguments, conditional types as object-member values, bigint literal types,
+/// typeof undefined, TS2539 for assigning to undefined, the any-check-type conditional rule,
+/// and union normalization (any absorbs, never drops).
+/// </summary>
+public class Round5ParserGapsTests
+{
+    [Fact]
+    public void ExportDeclareFunction_Parses()
+    {
+        TestHarness.RunInterpreted("""
+            export declare function foo<T>(obj: T): T;
+            """);
+    }
+
+    [Fact]
+    public void ConstructorType_AsGenericTypeArgument_Parses()
+    {
+        TestHarness.RunInterpreted("""
+            type A3 = InstanceType<new (x: string) => string>;
+            type A5 = InstanceType<abstract new (x: string) => string>;
+            """);
+    }
+
+    [Fact]
+    public void ConditionalType_AsObjectMemberValue_Parses()
+    {
+        TestHarness.RunInterpreted("""
+            type BadNested<T> = { x: T extends number ? T : string };
+            """);
+    }
+
+    [Fact]
+    public void BigintLiteralTypes_Parse()
+    {
+        TestHarness.RunInterpreted("""
+            type B = 1n | 2n;
+            """);
+    }
+
+    [Fact]
+    public void AssigningToUndefined_IsTs2539_NotParseError()
+    {
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted("""
+            var x = undefined = null;
+            """));
+    }
+
+    [Fact]
+    public void TypeofUndefined_Resolves()
+    {
+        // Under the product's strictNullChecks default, null is not assignable to undefined —
+        // the point here is that `typeof undefined` PARSES and resolves to the undefined type.
+        TestHarness.RunInterpreted("""
+            var y: typeof undefined = undefined;
+            """);
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted("""
+            var y: typeof undefined = "not undefined";
+            """));
+    }
+
+    [Fact]
+    public void AnyCheckType_ConditionalYieldsBothBranches()
+    {
+        // `any extends infer U ? U : never` is any | never = any — null assignable.
+        TestHarness.RunInterpreted("""
+            type Weird = any extends infer U ? U : never;
+            const a: Weird = null;
+            const b: string = a;
+            """);
+    }
+
+    [Fact]
+    public void UnionNormalization_AnyAbsorbs_NeverDrops()
+    {
+        TestHarness.RunInterpreted("""
+            const c1: any | never = null;
+            function probe(x: string | never) {
+                let s: string = x;
+            }
+            """);
+    }
+}

--- a/SharpTS.TypeScriptConformance/baselines/interpreted.txt
+++ b/SharpTS.TypeScriptConformance/baselines/interpreted.txt
@@ -2,8 +2,8 @@
 tests/cases/conformance/types/conditional/conditionalTypes1.ts Fail
 tests/cases/conformance/types/conditional/conditionalTypes2.ts Fail
 tests/cases/conformance/types/conditional/conditionalTypesExcessProperties.ts Fail
-tests/cases/conformance/types/conditional/inferTypes1.ts ParseError
-tests/cases/conformance/types/conditional/inferTypes2.ts ParseError
+tests/cases/conformance/types/conditional/inferTypes1.ts Fail
+tests/cases/conformance/types/conditional/inferTypes2.ts Pass
 tests/cases/conformance/types/conditional/inferTypesInvalidExtendsDeclaration.ts Skipped:lib-drift
 tests/cases/conformance/types/conditional/inferTypesWithExtends1.ts ParseError
 tests/cases/conformance/types/conditional/inferTypesWithExtends2.ts Fail
@@ -70,7 +70,7 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/everyTyp
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/genericCallWithObjectTypeArgsAndInitializers.ts Pass
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/intersectionIncludingPropFromGlobalAugmentation.ts Pass
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/nullAssignableToEveryType.ts Pass
-tests/cases/conformance/types/typeRelationships/assignmentCompatibility/nullAssignedToUndefined.ts ParseError
+tests/cases/conformance/types/typeRelationships/assignmentCompatibility/nullAssignedToUndefined.ts Pass
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/numberAssignableToEnum.ts Pass
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/optionalPropertyAssignableToStringIndexSignature.ts Pass
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/typeParameterAssignability.ts Pass

--- a/TypeSystem/TypeChecker.Compatibility.cs
+++ b/TypeSystem/TypeChecker.Compatibility.cs
@@ -380,6 +380,18 @@ public partial class TypeChecker
             return expected is TypeInfo.Object or TypeInfo.Any or TypeInfo.Unknown;
         }
 
+        // Conditional types must expand before the null/undefined/primitive rules below decide —
+        // `const a: Weird = null` where `type Weird = any extends infer U ? U : never` needs the
+        // conditional collapsed to `any` first, or the null rule rejects it sight unseen.
+        if (expected is TypeInfo.ConditionalType expectedCondEarly)
+        {
+            return IsCompatible(EvaluateConditionalType(expectedCondEarly), actual);
+        }
+        if (actual is TypeInfo.ConditionalType actualCondEarly)
+        {
+            return IsCompatible(expected, EvaluateConditionalType(actualCondEarly));
+        }
+
         // Null compatibility (strictNullChecks: on — the off case is handled early in IsCompatibleCore)
         if (actual is TypeInfo.Null)
         {

--- a/TypeSystem/TypeChecker.Expressions.cs
+++ b/TypeSystem/TypeChecker.Expressions.cs
@@ -1215,6 +1215,13 @@ public partial class TypeChecker
         // For assignment, check against the DECLARED type, not the narrowed type
         // This allows reassigning within narrowed scopes (e.g., x = "found" when x was narrowed to null)
         // Use GetDeclaredType to get the original declared type, not the potentially narrowed type
+        // tsc: assigning to `undefined` is TS2539 ("Cannot assign to 'undefined' because it is
+        // not a variable") — the parser lets it through as an identifier-shaped target.
+        if (assign.Name.Lexeme == "undefined")
+        {
+            throw new TypeCheckException($" Cannot assign to 'undefined' because it is not a variable.", line: assign.Name.Line, tsCode: "TS2539");
+        }
+
         var declaredType = GetDeclaredType(assign.Name.Lexeme);
         if (declaredType == null)
         {

--- a/TypeSystem/TypeChecker.Generics.Conditional.cs
+++ b/TypeSystem/TypeChecker.Generics.Conditional.cs
@@ -78,6 +78,20 @@ public partial class TypeChecker
             // Apply substitutions to the extends type
             TypeInfo extendsType = SubstituteWithoutConditionalEval(conditional.ExtendsType, substitutions);
 
+            // tsc: `any extends X ? A : B` yields A | B — an `any` check type matches BOTH
+            // branches. Infer placeholders bind from the wildcard match, so
+            // `any extends infer U ? U : never` is `any | never` = `any`.
+            if (checkType is TypeInfo.Any)
+            {
+                var (_, anyInferred) = CheckExtendsWithInfer(checkType, extendsType);
+                var trueSubs = new Dictionary<string, TypeInfo>(substitutions);
+                foreach (var (name, type) in anyInferred)
+                    trueSubs[name] = type;
+                return CreateUnion(
+                    Substitute(conditional.TrueType, trueSubs),
+                    Substitute(conditional.FalseType, substitutions));
+            }
+
             // Perform the extends check with infer pattern matching
             var (matches, inferredTypes) = CheckExtendsWithInfer(checkType, extendsType);
 

--- a/TypeSystem/TypeChecker.Generics.Inference.cs
+++ b/TypeSystem/TypeChecker.Generics.Inference.cs
@@ -170,6 +170,14 @@ public partial class TypeChecker
         else
             members.Add(b);
 
+        // tsc union normalization: `any` absorbs everything (any | X = any) and `never`
+        // disappears (never | X = X).
+        if (members.Any(m => m is TypeInfo.Any))
+            return new TypeInfo.Any();
+        members.RemoveAll(m => m is TypeInfo.Never);
+        if (members.Count == 0)
+            return new TypeInfo.Never();
+
         // Deduplicate (simple reference equality for now)
         var unique = members.Distinct().ToList();
         return unique.Count == 1 ? unique[0] : new TypeInfo.Union(unique);

--- a/TypeSystem/TypeChecker.TypeParsing.cs
+++ b/TypeSystem/TypeChecker.TypeParsing.cs
@@ -179,6 +179,12 @@ public partial class TypeChecker
             if (parts.Count > 1)  // Only create union if we actually split at top level
             {
                 var types = parts.Select(ToTypeInfo).ToList();
+                // tsc union normalization: `any` absorbs everything; `never` disappears.
+                if (types.Any(t => t is TypeInfo.Any))
+                    return new TypeInfo.Any();
+                types.RemoveAll(t => t is TypeInfo.Never);
+                if (types.Count == 0) return new TypeInfo.Never();
+                if (types.Count == 1) return types[0];
                 return new TypeInfo.Union(types);
             }
         }
@@ -1716,6 +1722,9 @@ public partial class TypeChecker
 
         // Look up first identifier in environment
         string firstName = accessors[0].Name;
+        // `typeof undefined` — the global undefined has no environment binding.
+        if (firstName == "undefined" && accessors.Count == 1)
+            return new TypeInfo.Undefined();
         TypeInfo? currentType = _environment.Get(firstName);
 
         if (currentType == null)


### PR DESCRIPTION
Part of #80; round 5 — the parser-gap cluster. Onion-peeling: each fix surfaced the next construct in the inferTypes files.

## Parser
- `export declare …` accepted (delegates to AmbientDeclaration); `export var` now carries `IsVar` for the hoister.
- Constructor types as generic type arguments (`InstanceType<new (x) => T>`): `IsTypeStart` accepts `new`/`abstract`/`<`.
- Conditional types as object-member values: `{ x: T extends number ? T : string }`.
- Bigint literal types (`1n | 2n`); `typeof undefined`/`typeof this` in type position.
- `undefined = v` parses and fails in the **checker** with TS2539 (tsc semantics).

## Checker
- `any extends X ? A : B` yields `A | B` (tsc's any-check-type rule, with infer binding) — so `any extends infer U ? U : never` is `any`.
- Conditional types expand **before** the null/undefined compat rules decide.
- Union normalization at creation (both `CreateUnion` and written annotations): `any` absorbs, `never` drops.

## Result
- **`nullAssignedToUndefined` and `inferTypes2`: ParseError → Pass**; `inferTypes1`: ParseError → Fail (off the parse wall; remainder is conditional-evaluation work).
- Subset: **Pass 60 → 62, Fail 14 → 15, ParseError 4 → 1**, 0 regressions. The last ParseError (`inferTypesWithExtends1`) is the deliberately-tricky speculative `infer U extends T ?` lookahead — noted in #226.
- Full unit suite green (10,600 incl. 8 new tests).