### PR TITLE
Bugfix batch: #222 #223 #224 #228 (+ #238), promise.constructor increment for #221

### DIFF
--- a/Compilation/EmittedRuntime.cs
+++ b/Compilation/EmittedRuntime.cs
@@ -584,6 +584,7 @@ public class EmittedRuntime
     // Invocation methods
     public MethodBuilder InvokeValue { get; set; } = null!;
     public MethodBuilder InvokeMethodValue { get; set; } = null!;
+    public MethodBuilder ConstructDynamicValue { get; set; } = null!;
     public MethodBuilder GetSuperMethod { get; set; } = null!;
 
     // Dynamic JS iterator-protocol bridge (.next()/.return()) for any-typed
@@ -2098,6 +2099,13 @@ public class EmittedRuntime
     // $AsyncLocalStorage support
     public Type TSAsyncLocalStorageType { get; set; } = null!;
     public ConstructorBuilder TSAsyncLocalStorageCtor { get; set; } = null!;
+
+    // Value-position namespace singletons (#224). Null when the matching
+    // feature flag is off — EmitVariable guards on the populate method.
+    public FieldBuilder? AbortSignalNamespaceField { get; set; }
+    public MethodBuilder? AbortSignalNamespacePopulate { get; set; }
+    public FieldBuilder? IntlNamespaceField { get; set; }
+    public MethodBuilder? IntlNamespacePopulate { get; set; }
 
     // $AbortController / $AbortSignal support
     public MethodBuilder FireAbortEvent { get; set; } = null!;

--- a/Compilation/ExpressionEmitterBase.cs
+++ b/Compilation/ExpressionEmitterBase.cs
@@ -1348,44 +1348,42 @@ public abstract partial class ExpressionEmitterBase : IEmitterContext
         }
         else
         {
-            // Fallback: try to load via resolver
-            var stackType = Resolver.TryLoadVariable(className);
-            if (stackType != null)
+            // Dynamic-callee fallback (#224): the callee is not a known class
+            // name, so evaluate it as a VALUE (aliased built-in constructor,
+            // namespace-singleton member like `I.NumberFormat`, arbitrary
+            // expression) and construct through ConstructDynamicValue, which
+            // dispatches Type → Activator, callable → InvokeValue, and throws
+            // TypeError for non-constructables. Replaces the old behavior of
+            // silently yielding null when the name didn't resolve.
+            EmitExpression(n.Callee);
+            EnsureBoxed();
+            var ctorTemp = IL.DeclareLocal(typeof(object));
+            IL.Emit(OpCodes.Stloc, ctorTemp);
+
+            List<LocalBuilder> argTemps = [];
+            foreach (var arg in n.Arguments)
             {
-                var typeTemp = IL.DeclareLocal(typeof(object));
-                IL.Emit(OpCodes.Stloc, typeTemp);
-
-                List<LocalBuilder> argTemps = [];
-                foreach (var arg in n.Arguments)
-                {
-                    EmitExpression(arg);
-                    EnsureBoxed();
-                    var temp = IL.DeclareLocal(typeof(object));
-                    IL.Emit(OpCodes.Stloc, temp);
-                    argTemps.Add(temp);
-                }
-
-                IL.Emit(OpCodes.Ldloc, typeTemp);
-                IL.Emit(OpCodes.Ldc_I4, n.Arguments.Count);
-                IL.Emit(OpCodes.Newarr, Ctx.Types.Object);
-
-                for (int i = 0; i < argTemps.Count; i++)
-                {
-                    IL.Emit(OpCodes.Dup);
-                    IL.Emit(OpCodes.Ldc_I4, i);
-                    IL.Emit(OpCodes.Ldloc, argTemps[i]);
-                    IL.Emit(OpCodes.Stelem_Ref);
-                }
-
-                var createInstanceMethod = Ctx.Types.GetMethod(Ctx.Types.Activator, "CreateInstance", Ctx.Types.Type, Ctx.Types.ObjectArray);
-                IL.Emit(OpCodes.Call, createInstanceMethod!);
-                SetStackUnknown();
+                EmitExpression(arg);
+                EnsureBoxed();
+                var temp = IL.DeclareLocal(typeof(object));
+                IL.Emit(OpCodes.Stloc, temp);
+                argTemps.Add(temp);
             }
-            else
+
+            IL.Emit(OpCodes.Ldloc, ctorTemp);
+            IL.Emit(OpCodes.Ldc_I4, n.Arguments.Count);
+            IL.Emit(OpCodes.Newarr, Ctx.Types.Object);
+
+            for (int i = 0; i < argTemps.Count; i++)
             {
-                IL.Emit(OpCodes.Ldnull);
-                SetStackType(StackType.Null);
+                IL.Emit(OpCodes.Dup);
+                IL.Emit(OpCodes.Ldc_I4, i);
+                IL.Emit(OpCodes.Ldloc, argTemps[i]);
+                IL.Emit(OpCodes.Stelem_Ref);
             }
+
+            IL.Emit(OpCodes.Call, Ctx.Runtime!.ConstructDynamicValue);
+            SetStackUnknown();
         }
     }
 
@@ -1574,6 +1572,36 @@ public abstract partial class ExpressionEmitterBase : IEmitterContext
         // shadowing wins, mirroring ILEmitter's resolution order.
         if (TryEmitErrorTypeToken(name)) return true;
         if (TryEmitBuiltInClassType(name)) return true;
+        if (TryEmitNamespaceSingleton(name)) return true;
+
+        return false;
+    }
+
+    /// <summary>
+    /// AbortSignal / Intl in value position (#224) — resolve to the lazily
+    /// populated namespace singleton dicts. Direct static forms
+    /// (`AbortSignal.abort(x)`, `new Intl.NumberFormat(...)`) are still
+    /// intercepted at compile time before the receiver is evaluated, so these
+    /// arms only serve aliasing/typeof/argument-passing uses. Shared by
+    /// ILEmitter.EmitVariable and the state-machine emitters' global path.
+    /// </summary>
+    protected bool TryEmitNamespaceSingleton(string name)
+    {
+        if (name == "AbortSignal" && Ctx.Runtime!.AbortSignalNamespacePopulate != null)
+        {
+            IL.Emit(OpCodes.Call, Ctx.Runtime!.AbortSignalNamespacePopulate);
+            IL.Emit(OpCodes.Ldsfld, Ctx.Runtime!.AbortSignalNamespaceField!);
+            SetStackUnknown();
+            return true;
+        }
+
+        if (name == "Intl" && Ctx.Runtime!.IntlNamespacePopulate != null)
+        {
+            IL.Emit(OpCodes.Call, Ctx.Runtime!.IntlNamespacePopulate);
+            IL.Emit(OpCodes.Ldsfld, Ctx.Runtime!.IntlNamespaceField!);
+            SetStackUnknown();
+            return true;
+        }
 
         return false;
     }
@@ -1631,6 +1659,11 @@ public abstract partial class ExpressionEmitterBase : IEmitterContext
             // bare Symbol in its own pseudo-variable arm; this entry covers the
             // state-machine emitters that resolve through this base path.
             "Symbol" => Ctx.Runtime!.TSSymbolType,
+            // Pure-IL web-streams types (#224) — TypeBuilders are null when
+            // UsesWebStreams is off, which falls through to ThrowUndefinedVariable.
+            "ReadableStream" => Ctx.Runtime!.ReadableStreamType,
+            "WritableStream" => Ctx.Runtime!.WritableStreamType,
+            "TransformStream" => Ctx.Runtime!.TransformStreamType,
             _ => null
         };
         if (t == null) return false;

--- a/Compilation/ExpressionEmitterBase.cs
+++ b/Compilation/ExpressionEmitterBase.cs
@@ -1664,6 +1664,9 @@ public abstract partial class ExpressionEmitterBase : IEmitterContext
             "ReadableStream" => Ctx.Runtime!.ReadableStreamType,
             "WritableStream" => Ctx.Runtime!.WritableStreamType,
             "TransformStream" => Ctx.Runtime!.TransformStreamType,
+            // Real emitted types since #222 (always emitted).
+            "MessageChannel" => Ctx.Runtime!.TSMessageChannelType,
+            "MessagePort" => Ctx.Runtime!.TSMessagePortType,
             _ => null
         };
         if (t == null) return false;

--- a/Compilation/ILEmitter.Expressions.cs
+++ b/Compilation/ILEmitter.Expressions.cs
@@ -92,6 +92,10 @@ public partial class ILEmitter
             return;
         }
 
+        // AbortSignal / Intl value-position namespace singletons (#224) —
+        // shared with the state-machine emitters via the base helper.
+        if (TryEmitNamespaceSingleton(name)) return;
+
         if (name == "process")
         {
             EmitNullConstant(); // process is handled specially in property access

--- a/Compilation/RuntimeEmitter.DynamicConstruct.cs
+++ b/Compilation/RuntimeEmitter.DynamicConstruct.cs
@@ -1,0 +1,75 @@
+using System.Reflection;
+using System.Reflection.Emit;
+
+namespace SharpTS.Compilation;
+
+public partial class RuntimeEmitter
+{
+    /// <summary>
+    /// Emits ConstructDynamicValue: (object ctor, object[] args) → object.
+    ///
+    /// The runtime construct path for `new x(...)` when the callee is a VALUE
+    /// rather than a compile-time-resolvable class name — e.g. an aliased
+    /// built-in (`const C = ReadableStream; new C(...)`), a member of a
+    /// namespace singleton (`const I = Intl; new I.NumberFormat(...)`), or any
+    /// expression callee (`new (getCtor())()`). Mirrors ReflectConstruct's
+    /// target dispatch (#224):
+    ///   - System.Type → Activator.CreateInstance(type, args)
+    ///   - plain object / null / undefined → TypeError "not a constructor"
+    ///   - everything else ($TSFunction etc.) → NewOnFunction, the shared JS
+    ///     `new` protocol (fresh `this`, return-object-wins, IsConstructor
+    ///     policy) — same routing ILEmitter's fallback construction uses.
+    /// Must be emitted AFTER EmitNewOnFunction so runtime.NewOnFunction is set.
+    /// </summary>
+    private void EmitConstructDynamicValue(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    {
+        var method = typeBuilder.DefineMethod(
+            "ConstructDynamicValue",
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.Object,
+            [_types.Object, _types.ObjectArray]
+        );
+        runtime.ConstructDynamicValue = method;
+
+        var il = method.GetILGenerator();
+        var throwLabel = il.DefineLabel();
+
+        // null / $Undefined → TypeError
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Brfalse, throwLabel);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Isinst, runtime.UndefinedType);
+        il.Emit(OpCodes.Brtrue, throwLabel);
+
+        // System.Type (built-in or user class reference) → Activator.CreateInstance(type, args)
+        var notTypeLabel = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Isinst, _types.Type);
+        il.Emit(OpCodes.Brfalse, notTypeLabel);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Castclass, _types.Type);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Call, _types.GetMethod(typeof(Activator), "CreateInstance", _types.Type, _types.ObjectArray));
+        il.Emit(OpCodes.Ret);
+        il.MarkLabel(notTypeLabel);
+
+        // Plain objects have no [[Construct]] → TypeError. (Namespace
+        // singletons like AbortSignal/Math land here: `new AbortSignal()`
+        // must throw per WebIDL "Illegal constructor".)
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Isinst, _types.DictionaryStringObject);
+        il.Emit(OpCodes.Brtrue, throwLabel);
+
+        // Callable values ($TSFunction and wrappers) → NewOnFunction(ctor, args)
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Call, runtime.NewOnFunction);
+        il.Emit(OpCodes.Ret);
+
+        il.MarkLabel(throwLabel);
+        il.Emit(OpCodes.Ldstr, "Value is not a constructor");
+        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
+        il.Emit(OpCodes.Call, runtime.CreateException);
+        il.Emit(OpCodes.Throw);
+    }
+}

--- a/Compilation/RuntimeEmitter.Functions.NewOp.cs
+++ b/Compilation/RuntimeEmitter.Functions.NewOp.cs
@@ -66,6 +66,20 @@ public partial class RuntimeEmitter
         il.MarkLabel(skipConstructorCheckLabel);
         il.MarkLabel(isConstructorOkLabel);
 
+        // `new <plain object>` — plain objects have no [[Construct]] (#224):
+        // throw TypeError instead of the legacy silent null. Namespace
+        // singletons (AbortSignal, Intl, Math) land here when constructed
+        // directly, matching WebIDL "Illegal constructor" behavior.
+        var notPlainObjectLabel = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Isinst, _types.DictionaryStringObject);
+        il.Emit(OpCodes.Brfalse, notPlainObjectLabel);
+        il.Emit(OpCodes.Ldstr, "not a constructor");
+        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
+        il.Emit(OpCodes.Call, runtime.CreateException);
+        il.Emit(OpCodes.Throw);
+        il.MarkLabel(notPlainObjectLabel);
+
         // newObj = new $Object(new Dictionary<string, object>())
         var dictCtor = _types.GetDefaultConstructor(_types.DictionaryStringObject);
         il.Emit(OpCodes.Newobj, dictCtor);

--- a/Compilation/RuntimeEmitter.MessageChannel.cs
+++ b/Compilation/RuntimeEmitter.MessageChannel.cs
@@ -1,0 +1,465 @@
+using System.Reflection;
+using System.Reflection.Emit;
+
+namespace SharpTS.Compilation;
+
+/// <summary>
+/// Emits the standalone <c>$MessagePort</c> / <c>$MessageChannel</c> classes
+/// for compiled mode (#222).
+/// </summary>
+/// <remarks>
+/// Pure-IL implementations of Node's worker_threads MessageChannel pair —
+/// BCL types only (no SharpTS.dll dependency). <c>$MessagePort</c> inherits
+/// the emitted <c>$EventEmitter</c> so on/once/off/emit come for free, and
+/// overrides the <c>OnListenerAdded</c> virtual hook so registering a
+/// 'message' listener implicitly starts the port (matches the interpreter's
+/// post-#209 <c>SharpTSMessagePort</c> semantics):
+///   - postMessage(v)  → structured-clones v, enqueues to the PARTNER port,
+///     schedules its Drain on the $EventLoop when it has started
+///   - on('message')   → implicit Start(): Ref the event loop + drain queued
+///   - listener receives the cloned value DIRECTLY (not a {data} wrapper)
+///   - close()         → stops delivery, Unrefs so the process can exit
+/// Must be emitted AFTER EmitRuntimeClass (uses $Runtime.StructuredClone)
+/// and after $EventEmitter / $EventLoop.
+/// NOTE: Must stay in sync with SharpTS.Runtime.Types.SharpTSMessagePort.
+/// </remarks>
+public partial class RuntimeEmitter
+{
+    private TypeBuilder _messagePortType = null!;
+    private FieldBuilder _messagePortPartnerField = null!;
+    private FieldBuilder _messagePortPendingField = null!;
+    private FieldBuilder _messagePortStartedField = null!;
+    private FieldBuilder _messagePortClosedField = null!;
+    private FieldBuilder _messagePortRefedField = null!;
+    private ConstructorBuilder _messagePortCtor = null!;
+    private MethodBuilder _messagePortDrain = null!;
+    private MethodBuilder _messagePortStart = null!;
+    private MethodBuilder _messagePortRef = null!;
+    private MethodBuilder _messagePortUnref = null!;
+
+    private void EmitMessageChannelTypes(ModuleBuilder moduleBuilder, EmittedRuntime runtime)
+    {
+        EmitMessagePortClass(moduleBuilder, runtime);
+        EmitMessageChannelClass(moduleBuilder, runtime);
+        EmitCreateMessageChannelHelper(runtime);
+    }
+
+    private void EmitMessagePortClass(ModuleBuilder moduleBuilder, EmittedRuntime runtime)
+    {
+        var typeBuilder = moduleBuilder.DefineType(
+            "$MessagePort",
+            TypeAttributes.Public | TypeAttributes.Class | TypeAttributes.BeforeFieldInit,
+            runtime.TSEventEmitterType
+        );
+        _messagePortType = typeBuilder;
+
+        // Assembly-visible so $MessageChannel's ctor can pair the ports.
+        _messagePortPartnerField = typeBuilder.DefineField("_partner", _types.Object, FieldAttributes.Assembly);
+        _messagePortPendingField = typeBuilder.DefineField("_pending", _types.ConcurrentQueueOfObject, FieldAttributes.Assembly);
+        _messagePortStartedField = typeBuilder.DefineField("_started", _types.Boolean, FieldAttributes.Assembly);
+        _messagePortClosedField = typeBuilder.DefineField("_closed", _types.Boolean, FieldAttributes.Assembly);
+        _messagePortRefedField = typeBuilder.DefineField("_refed", _types.Boolean, FieldAttributes.Assembly);
+
+        EmitMessagePortConstructorIl(typeBuilder, runtime);
+        EmitMessagePortDrain(typeBuilder, runtime);
+        EmitMessagePortRef(typeBuilder, runtime);
+        EmitMessagePortUnref(typeBuilder, runtime);
+        EmitMessagePortStart(typeBuilder, runtime);
+        EmitMessagePortPostMessage(typeBuilder, runtime);
+        EmitMessagePortClose(typeBuilder, runtime);
+        EmitMessagePortOnListenerAdded(typeBuilder, runtime);
+
+        typeBuilder.CreateType();
+
+        runtime.TSMessagePortType = typeBuilder;
+    }
+
+    private void EmitMessagePortConstructorIl(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    {
+        var ctor = typeBuilder.DefineConstructor(
+            MethodAttributes.Public,
+            CallingConventions.Standard,
+            Type.EmptyTypes
+        );
+        _messagePortCtor = ctor;
+
+        var il = ctor.GetILGenerator();
+
+        // base() — $EventEmitter parameterless ctor
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Call, runtime.TSEventEmitterCtor);
+
+        // _pending = new ConcurrentQueue<object>()
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Newobj, _types.ConcurrentQueueOfObject.GetConstructor(Type.EmptyTypes)!);
+        il.Emit(OpCodes.Stfld, _messagePortPendingField);
+
+        // Not refed at construction — an unstarted port must not keep the
+        // process alive (Node: only a started port with pending work does).
+        il.Emit(OpCodes.Ret);
+    }
+
+    /// <summary>
+    /// Drain() — dequeues pending messages and emits each as a 'message'
+    /// event with the cloned value directly (Node worker_threads semantics,
+    /// not a DOM-style {data} wrapper).
+    /// </summary>
+    private void EmitMessagePortDrain(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    {
+        var method = typeBuilder.DefineMethod(
+            "Drain",
+            MethodAttributes.Public,
+            _types.Void,
+            Type.EmptyTypes
+        );
+        _messagePortDrain = method;
+
+        var il = method.GetILGenerator();
+        var loopTop = il.DefineLabel();
+        var exitLabel = il.DefineLabel();
+        var msgLocal = il.DeclareLocal(_types.Object);
+        var argsLocal = il.DeclareLocal(_types.ObjectArray);
+
+        // if (!_started || _closed) return — messages stay queued until Start().
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, _messagePortStartedField);
+        il.Emit(OpCodes.Brfalse, exitLabel);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, _messagePortClosedField);
+        il.Emit(OpCodes.Brtrue, exitLabel);
+
+        il.MarkLabel(loopTop);
+
+        // if (!_pending.TryDequeue(out msg)) return
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, _messagePortPendingField);
+        il.Emit(OpCodes.Ldloca, msgLocal);
+        il.Emit(OpCodes.Callvirt, _types.ConcurrentQueueOfObject.GetMethod("TryDequeue", [_types.Object.MakeByRefType()])!);
+        il.Emit(OpCodes.Brfalse, exitLabel);
+
+        // this.Emit("message", new object[1] { msg })
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Newarr, _types.Object);
+        il.Emit(OpCodes.Stloc, argsLocal);
+        il.Emit(OpCodes.Ldloc, argsLocal);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Ldloc, msgLocal);
+        il.Emit(OpCodes.Stelem_Ref);
+
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldstr, "message");
+        il.Emit(OpCodes.Ldloc, argsLocal);
+        il.Emit(OpCodes.Callvirt, runtime.TSEventEmitterEmit);
+        il.Emit(OpCodes.Pop);
+
+        il.Emit(OpCodes.Br, loopTop);
+
+        il.MarkLabel(exitLabel);
+        il.Emit(OpCodes.Ret);
+    }
+
+    private void EmitMessagePortRef(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    {
+        var method = typeBuilder.DefineMethod("Ref", MethodAttributes.Public, _types.Void, Type.EmptyTypes);
+        _messagePortRef = method;
+
+        var il = method.GetILGenerator();
+        var alreadyRefedLabel = il.DefineLabel();
+
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, _messagePortRefedField);
+        il.Emit(OpCodes.Brtrue, alreadyRefedLabel);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Stfld, _messagePortRefedField);
+        il.Emit(OpCodes.Call, runtime.EventLoopGetInstance);
+        il.Emit(OpCodes.Callvirt, runtime.EventLoopRef);
+        il.MarkLabel(alreadyRefedLabel);
+        il.Emit(OpCodes.Ret);
+    }
+
+    private void EmitMessagePortUnref(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    {
+        var method = typeBuilder.DefineMethod("Unref", MethodAttributes.Public, _types.Void, Type.EmptyTypes);
+        _messagePortUnref = method;
+
+        var il = method.GetILGenerator();
+        var notRefedLabel = il.DefineLabel();
+
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, _messagePortRefedField);
+        il.Emit(OpCodes.Brfalse, notRefedLabel);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Stfld, _messagePortRefedField);
+        il.Emit(OpCodes.Call, runtime.EventLoopGetInstance);
+        il.Emit(OpCodes.Callvirt, runtime.EventLoopUnref);
+        il.MarkLabel(notRefedLabel);
+        il.Emit(OpCodes.Ret);
+    }
+
+    /// <summary>
+    /// Start() — begins message delivery: Refs the event loop (a started,
+    /// unclosed port keeps the process alive) and schedules a Drain for
+    /// anything queued before the port started.
+    /// </summary>
+    private void EmitMessagePortStart(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    {
+        var method = typeBuilder.DefineMethod("Start", MethodAttributes.Public, _types.Void, Type.EmptyTypes);
+        _messagePortStart = method;
+
+        var il = method.GetILGenerator();
+        var exitLabel = il.DefineLabel();
+
+        // if (_started || _closed) return
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, _messagePortStartedField);
+        il.Emit(OpCodes.Brtrue, exitLabel);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, _messagePortClosedField);
+        il.Emit(OpCodes.Brtrue, exitLabel);
+
+        // _started = true
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Stfld, _messagePortStartedField);
+
+        // this.Ref()
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Call, _messagePortRef);
+
+        // $EventLoop.GetInstance().Schedule(new Action(this.Drain))
+        il.Emit(OpCodes.Call, runtime.EventLoopGetInstance);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldftn, _messagePortDrain);
+        il.Emit(OpCodes.Newobj, typeof(Action).GetConstructor([_types.Object, typeof(IntPtr)])!);
+        il.Emit(OpCodes.Callvirt, runtime.EventLoopSchedule);
+
+        il.MarkLabel(exitLabel);
+        il.Emit(OpCodes.Ret);
+    }
+
+    /// <summary>
+    /// PostMessage(object msg) — structured-clones the value and enqueues it
+    /// to the partner port; delivery is scheduled (async) once the partner
+    /// has started.
+    /// </summary>
+    private void EmitMessagePortPostMessage(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    {
+        var method = typeBuilder.DefineMethod(
+            "PostMessage",
+            MethodAttributes.Public,
+            _types.Void,
+            [_types.Object]
+        );
+
+        var il = method.GetILGenerator();
+        var exitLabel = il.DefineLabel();
+        var partnerLocal = il.DeclareLocal(typeBuilder);
+        var clonedLocal = il.DeclareLocal(_types.Object);
+
+        // if (_closed) return
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, _messagePortClosedField);
+        il.Emit(OpCodes.Brtrue, exitLabel);
+
+        // partner = _partner as $MessagePort; if (partner == null || partner._closed) return
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, _messagePortPartnerField);
+        il.Emit(OpCodes.Isinst, typeBuilder);
+        il.Emit(OpCodes.Stloc, partnerLocal);
+        il.Emit(OpCodes.Ldloc, partnerLocal);
+        il.Emit(OpCodes.Brfalse, exitLabel);
+        il.Emit(OpCodes.Ldloc, partnerLocal);
+        il.Emit(OpCodes.Ldfld, _messagePortClosedField);
+        il.Emit(OpCodes.Brtrue, exitLabel);
+
+        // cloned = $Runtime.StructuredClone(msg, null)
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Ldnull);
+        il.Emit(OpCodes.Call, runtime.StructuredCloneClone);
+        il.Emit(OpCodes.Stloc, clonedLocal);
+
+        // partner._pending.Enqueue(cloned)
+        il.Emit(OpCodes.Ldloc, partnerLocal);
+        il.Emit(OpCodes.Ldfld, _messagePortPendingField);
+        il.Emit(OpCodes.Ldloc, clonedLocal);
+        il.Emit(OpCodes.Callvirt, _types.ConcurrentQueueOfObject.GetMethod("Enqueue", [_types.Object])!);
+
+        // if (partner._started) $EventLoop.GetInstance().Schedule(new Action(partner.Drain))
+        il.Emit(OpCodes.Ldloc, partnerLocal);
+        il.Emit(OpCodes.Ldfld, _messagePortStartedField);
+        il.Emit(OpCodes.Brfalse, exitLabel);
+        il.Emit(OpCodes.Call, runtime.EventLoopGetInstance);
+        il.Emit(OpCodes.Ldloc, partnerLocal);
+        il.Emit(OpCodes.Ldftn, _messagePortDrain);
+        il.Emit(OpCodes.Newobj, typeof(Action).GetConstructor([_types.Object, typeof(IntPtr)])!);
+        il.Emit(OpCodes.Callvirt, runtime.EventLoopSchedule);
+
+        il.MarkLabel(exitLabel);
+        il.Emit(OpCodes.Ret);
+    }
+
+    private void EmitMessagePortClose(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    {
+        var method = typeBuilder.DefineMethod("Close", MethodAttributes.Public, _types.Void, Type.EmptyTypes);
+
+        var il = method.GetILGenerator();
+        var alreadyClosedLabel = il.DefineLabel();
+
+        // if (_closed) return
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, _messagePortClosedField);
+        il.Emit(OpCodes.Brtrue, alreadyClosedLabel);
+
+        // _closed = true
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Stfld, _messagePortClosedField);
+
+        // this.Unref()
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Call, _messagePortUnref);
+
+        // this.Emit("close", new object[0])
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldstr, "close");
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Newarr, _types.Object);
+        il.Emit(OpCodes.Callvirt, runtime.TSEventEmitterEmit);
+        il.Emit(OpCodes.Pop);
+
+        il.MarkLabel(alreadyClosedLabel);
+        il.Emit(OpCodes.Ret);
+    }
+
+    /// <summary>
+    /// Overrides $EventEmitter.OnListenerAdded: registering a 'message'
+    /// listener implicitly starts the port (Node worker_threads semantics).
+    /// Covers on/once/addListener/prepend* — they all funnel through
+    /// AddListenerInternal, which Callvirts this hook.
+    /// </summary>
+    private void EmitMessagePortOnListenerAdded(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    {
+        var method = typeBuilder.DefineMethod(
+            "OnListenerAdded",
+            MethodAttributes.Public | MethodAttributes.Virtual,
+            _types.Void,
+            [_types.String]
+        );
+        typeBuilder.DefineMethodOverride(method, runtime.TSEventEmitterOnListenerAdded);
+
+        var il = method.GetILGenerator();
+        var exitLabel = il.DefineLabel();
+
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Ldstr, "message");
+        il.Emit(OpCodes.Call, _types.GetMethod(_types.String, "op_Equality", _types.String, _types.String));
+        il.Emit(OpCodes.Brfalse, exitLabel);
+
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Call, _messagePortStart);
+
+        il.MarkLabel(exitLabel);
+        il.Emit(OpCodes.Ret);
+    }
+
+    private void EmitMessageChannelClass(ModuleBuilder moduleBuilder, EmittedRuntime runtime)
+    {
+        var typeBuilder = moduleBuilder.DefineType(
+            "$MessageChannel",
+            TypeAttributes.Public | TypeAttributes.Class | TypeAttributes.BeforeFieldInit
+        );
+
+        var port1Field = typeBuilder.DefineField("_port1", _types.Object, FieldAttributes.Private);
+        var port2Field = typeBuilder.DefineField("_port2", _types.Object, FieldAttributes.Private);
+
+        var ctor = typeBuilder.DefineConstructor(
+            MethodAttributes.Public,
+            CallingConventions.Standard,
+            Type.EmptyTypes
+        );
+        {
+            var il = ctor.GetILGenerator();
+            var p1Local = il.DeclareLocal(_messagePortType);
+            var p2Local = il.DeclareLocal(_messagePortType);
+
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Call, _types.GetDefaultConstructor(_types.Object));
+
+            // p1 = new $MessagePort(); p2 = new $MessagePort()
+            il.Emit(OpCodes.Newobj, _messagePortCtor);
+            il.Emit(OpCodes.Stloc, p1Local);
+            il.Emit(OpCodes.Newobj, _messagePortCtor);
+            il.Emit(OpCodes.Stloc, p2Local);
+
+            // p1._partner = p2; p2._partner = p1
+            il.Emit(OpCodes.Ldloc, p1Local);
+            il.Emit(OpCodes.Ldloc, p2Local);
+            il.Emit(OpCodes.Stfld, _messagePortPartnerField);
+            il.Emit(OpCodes.Ldloc, p2Local);
+            il.Emit(OpCodes.Ldloc, p1Local);
+            il.Emit(OpCodes.Stfld, _messagePortPartnerField);
+
+            // _port1 = p1; _port2 = p2
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldloc, p1Local);
+            il.Emit(OpCodes.Stfld, port1Field);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldloc, p2Local);
+            il.Emit(OpCodes.Stfld, port2Field);
+
+            il.Emit(OpCodes.Ret);
+        }
+
+        // Port1/Port2 getter properties — `channel.port1` resolves via the
+        // case-insensitive PascalCase reflection fallback in GetFieldsProperty
+        // (same mechanism as $BroadcastChannel's `bc.name` → get_Name).
+        EmitReadOnlyObjectProperty(typeBuilder, "Port1", port1Field);
+        EmitReadOnlyObjectProperty(typeBuilder, "Port2", port2Field);
+
+        typeBuilder.CreateType();
+
+        runtime.TSMessageChannelType = typeBuilder;
+        _messageChannelCtorBuilder = ctor;
+    }
+
+    private ConstructorBuilder _messageChannelCtorBuilder = null!;
+
+    private void EmitReadOnlyObjectProperty(TypeBuilder typeBuilder, string propertyName, FieldBuilder backingField)
+    {
+        var getter = typeBuilder.DefineMethod(
+            "get_" + propertyName,
+            MethodAttributes.Public | MethodAttributes.SpecialName | MethodAttributes.HideBySig,
+            _types.Object,
+            Type.EmptyTypes
+        );
+        var il = getter.GetILGenerator();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, backingField);
+        il.Emit(OpCodes.Ret);
+
+        var prop = typeBuilder.DefineProperty(propertyName, PropertyAttributes.None, _types.Object, Type.EmptyTypes);
+        prop.SetGetMethod(getter);
+    }
+
+    /// <summary>
+    /// $Runtime.CreateMessageChannel() — kept as the public construction entry
+    /// (TryEmitBuiltInConstructor calls it for `new MessageChannel()`).
+    /// </summary>
+    private void EmitCreateMessageChannelHelper(EmittedRuntime runtime)
+    {
+        var method = _runtimeTypeBuilder!.DefineMethod(
+            "CreateMessageChannel",
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.Object,
+            Type.EmptyTypes
+        );
+
+        var il = method.GetILGenerator();
+        il.Emit(OpCodes.Newobj, _messageChannelCtorBuilder);
+        il.Emit(OpCodes.Ret);
+
+        runtime.TSMessageChannelCtor = method;
+    }
+}

--- a/Compilation/RuntimeEmitter.NamespaceSingletons.cs
+++ b/Compilation/RuntimeEmitter.NamespaceSingletons.cs
@@ -1,0 +1,110 @@
+using System.Reflection;
+using System.Reflection.Emit;
+
+namespace SharpTS.Compilation;
+
+public partial class RuntimeEmitter
+{
+    /// <summary>
+    /// Value-position namespace singletons for AbortSignal and Intl (#224).
+    ///
+    /// Direct forms (`AbortSignal.abort(x)`, `new Intl.NumberFormat(...)`) are
+    /// intercepted at compile time by AbortSignalStaticEmitter /
+    /// TryEmitIntlConstructor and never touch these. The singletons only
+    /// surface when the namespace is used as a VALUE — bare reference,
+    /// aliasing (`const I = Intl`), `typeof`, passing as an argument — the
+    /// same role MathSingletonField/JsonSingletonField play for Math/JSON.
+    /// Members are $TSFunction wrappers over the existing $Runtime helpers, so
+    /// aliased calls (`A.abort('r')`) and aliased construction
+    /// (`new I.NumberFormat(...)` via NewOnFunction + the IsConstructor
+    /// CreateIntl* exemption) reuse one implementation.
+    ///
+    /// Lazily populated: the populate shell is called before each bare-
+    /// reference load; the field doubles as the populated flag.
+    /// </summary>
+    private void EmitNamespaceSingletons(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    {
+        if (_features.UsesAbortController)
+        {
+            (runtime.AbortSignalNamespaceField, runtime.AbortSignalNamespacePopulate) =
+                EmitNamespaceSingleton(typeBuilder, runtime, "AbortSignal",
+                [
+                    ("abort", runtime.AbortSignalAbort, 1),
+                    ("timeout", runtime.AbortSignalTimeout, 1),
+                    ("any", runtime.AbortSignalAny, 1),
+                ]);
+        }
+
+        if (_features.UsesIntl)
+        {
+            (runtime.IntlNamespaceField, runtime.IntlNamespacePopulate) =
+                EmitNamespaceSingleton(typeBuilder, runtime, "Intl",
+                [
+                    ("NumberFormat", runtime.CreateIntlNumberFormat, 2),
+                    ("DateTimeFormat", runtime.CreateIntlDateTimeFormat, 2),
+                    ("Collator", runtime.CreateIntlCollator, 2),
+                    ("PluralRules", runtime.CreateIntlPluralRules, 2),
+                    ("RelativeTimeFormat", runtime.CreateIntlRelativeTimeFormat, 2),
+                    ("ListFormat", runtime.CreateIntlListFormat, 2),
+                    ("Segmenter", runtime.CreateIntlSegmenter, 2),
+                    ("DisplayNames", runtime.CreateIntlDisplayNames, 2),
+                ]);
+        }
+    }
+
+    private (FieldBuilder Field, MethodBuilder Populate) EmitNamespaceSingleton(
+        TypeBuilder typeBuilder,
+        EmittedRuntime runtime,
+        string namespaceName,
+        (string JsName, MethodBuilder Helper, int JsLength)[] members)
+    {
+        var field = typeBuilder.DefineField(
+            $"_{namespaceName}Namespace",
+            _types.DictionaryStringObject,
+            FieldAttributes.Public | FieldAttributes.Static);
+
+        var method = typeBuilder.DefineMethod(
+            $"_{namespaceName}NamespacePopulate",
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.Void,
+            Type.EmptyTypes);
+
+        var il = method.GetILGenerator();
+        var setItem = _types.GetMethod(_types.DictionaryStringObject, "set_Item",
+            _types.String, _types.Object);
+
+        // Already populated? (field doubles as the flag)
+        var doFillLabel = il.DefineLabel();
+        il.Emit(OpCodes.Ldsfld, field);
+        il.Emit(OpCodes.Brfalse, doFillLabel);
+        il.Emit(OpCodes.Ret);
+        il.MarkLabel(doFillLabel);
+
+        var dictLocal = il.DeclareLocal(_types.DictionaryStringObject);
+        il.Emit(OpCodes.Newobj, _types.GetDefaultConstructor(_types.DictionaryStringObject));
+        il.Emit(OpCodes.Stloc, dictLocal);
+
+        foreach (var (jsName, helper, jsLength) in members)
+        {
+            // dict[jsName] = $TSFunction.GetOrCreate(helper, jsName, jsLength)
+            // — GetOrCreate keys on MethodInfo so the wrapper identity is
+            // shared with any other path exposing the same helper.
+            il.Emit(OpCodes.Ldloc, dictLocal);
+            il.Emit(OpCodes.Ldstr, jsName);
+            il.Emit(OpCodes.Ldtoken, helper);
+            il.Emit(OpCodes.Call, _types.GetMethod(_types.MethodBase, "GetMethodFromHandle", _types.RuntimeMethodHandle));
+            il.Emit(OpCodes.Castclass, _types.MethodInfo);
+            il.Emit(OpCodes.Ldstr, jsName);
+            il.Emit(OpCodes.Ldc_I4, jsLength);
+            il.Emit(OpCodes.Call, runtime.TSFunctionGetOrCreate);
+            il.Emit(OpCodes.Callvirt, setItem);
+        }
+
+        // Publish last so a half-filled dict is never observable.
+        il.Emit(OpCodes.Ldloc, dictLocal);
+        il.Emit(OpCodes.Stsfld, field);
+        il.Emit(OpCodes.Ret);
+
+        return (field, method);
+    }
+}

--- a/Compilation/RuntimeEmitter.Objects.Properties.cs
+++ b/Compilation/RuntimeEmitter.Objects.Properties.cs
@@ -2533,6 +2533,21 @@ public partial class RuntimeEmitter
         EmitPromiseProtoLookup("catch");
         EmitPromiseProtoLookup("finally");
 
+        // ECMA-262 §27.2.5.1: Promise.prototype.constructor is %Promise%.
+        // Bare `Promise` resolves to typeof(Task<object?>) in compiled mode
+        // (TryEmitBuiltInClassType / GlobalThisGetProperty), so return the
+        // same Type token here for identity:
+        // `Promise.resolve(1).constructor === Promise` (#221 increment).
+        var notPromiseCtorLabel = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Ldstr, "constructor");
+        il.Emit(OpCodes.Call, _types.GetMethod(_types.String, "op_Equality", _types.String, _types.String));
+        il.Emit(OpCodes.Brfalse, notPromiseCtorLabel);
+        il.Emit(OpCodes.Ldtoken, _types.TaskOfObject);
+        il.Emit(OpCodes.Call, _types.GetMethod(_types.Type, "GetTypeFromHandle", _types.RuntimeTypeHandle));
+        il.Emit(OpCodes.Ret);
+        il.MarkLabel(notPromiseCtorLabel);
+
         // Unknown promise property - return null
         il.Emit(OpCodes.Ldnull);
         il.Emit(OpCodes.Ret);

--- a/Compilation/RuntimeEmitter.Objects.Properties.cs
+++ b/Compilation/RuntimeEmitter.Objects.Properties.cs
@@ -2608,6 +2608,62 @@ public partial class RuntimeEmitter
         var foundLabel = il.DefineLabel();
         il.Emit(OpCodes.Brtrue, foundLabel);
 
+        // $AbortSignal dict surface (#224): "aborted"/"reason"/"onabort" on a
+        // dynamically-typed signal receiver. The typed path intercepts at
+        // compile time (AbortSignalEmitter); an `any` receiver lands here.
+        // Signals are identified by their "_reasonSet" internal slot — the
+        // public keys are computed from the CancellationToken, so they are
+        // never own dict entries and always reach this miss path. Name screen
+        // runs first to keep ordinary dict misses cheap.
+        if (_features.UsesAbortController)
+        {
+            var notSignalPropLabel = il.DefineLabel();
+            var signalNameMatchLabel = il.DefineLabel();
+            var strEq = _types.GetMethod(_types.String, "op_Equality", _types.String, _types.String);
+
+            foreach (var signalProp in new[] { "aborted", "reason", "onabort" })
+            {
+                il.Emit(OpCodes.Ldarg_1);
+                il.Emit(OpCodes.Ldstr, signalProp);
+                il.Emit(OpCodes.Call, strEq);
+                il.Emit(OpCodes.Brtrue, signalNameMatchLabel);
+            }
+            il.Emit(OpCodes.Br, notSignalPropLabel);
+
+            il.MarkLabel(signalNameMatchLabel);
+            il.Emit(OpCodes.Ldloc, dictLocal);
+            il.Emit(OpCodes.Ldstr, "_reasonSet");
+            il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.DictionaryStringObject, "ContainsKey", _types.String));
+            il.Emit(OpCodes.Brfalse, notSignalPropLabel);
+
+            var notSignalAbortedLabel = il.DefineLabel();
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Ldstr, "aborted");
+            il.Emit(OpCodes.Call, strEq);
+            il.Emit(OpCodes.Brfalse, notSignalAbortedLabel);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Call, runtime.AbortSignalGetAborted);
+            il.Emit(OpCodes.Box, _types.Boolean);
+            il.Emit(OpCodes.Ret);
+            il.MarkLabel(notSignalAbortedLabel);
+
+            var notSignalReasonLabel = il.DefineLabel();
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Ldstr, "reason");
+            il.Emit(OpCodes.Call, strEq);
+            il.Emit(OpCodes.Brfalse, notSignalReasonLabel);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Call, runtime.AbortSignalGetReason);
+            il.Emit(OpCodes.Ret);
+            il.MarkLabel(notSignalReasonLabel);
+
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Call, runtime.AbortSignalGetOnAbort);
+            il.Emit(OpCodes.Ret);
+
+            il.MarkLabel(notSignalPropLabel);
+        }
+
         // Property not found on object - check prototype chain
         // Get prototype: $PropertyDescriptorStore.GetPrototype(obj)
         il.Emit(OpCodes.Ldarg_0);

--- a/Compilation/RuntimeEmitter.Reflect.cs
+++ b/Compilation/RuntimeEmitter.Reflect.cs
@@ -485,7 +485,17 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Br, notRuntimeLabel);
 
         il.MarkLabel(declaringTypeIsRuntimeLabel);
-        // declaring type is an emitted-runtime helper class → not constructable
+        // Declaring type is an emitted-runtime helper class. One exception
+        // (#224): the Intl factory helpers (CreateIntlNumberFormat etc.) ARE
+        // constructors per ECMA-402 — `new Intl.NumberFormat(...)` through a
+        // value-position alias routes them into NewOnFunction, whose
+        // IsConstructor gate would otherwise reject them.
+        il.Emit(OpCodes.Ldloc, miLocal);
+        il.Emit(OpCodes.Callvirt, _types.GetProperty(typeof(System.Reflection.MemberInfo), "Name").GetGetMethod()!);
+        il.Emit(OpCodes.Ldstr, "CreateIntl");
+        il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.String, "StartsWith", _types.String));
+        il.Emit(OpCodes.Brtrue, notRuntimeLabel);
+        // → not constructable
         il.Emit(OpCodes.Ldc_I4_0);
         il.Emit(OpCodes.Ret);
         il.MarkLabel(notRuntimeLabel);

--- a/Compilation/RuntimeEmitter.RuntimeClass.cs
+++ b/Compilation/RuntimeEmitter.RuntimeClass.cs
@@ -616,6 +616,16 @@ public partial class RuntimeEmitter
         EmitPromiseMethods(typeBuilder, runtime);
         // TypedArray detection helpers must come before GetProperty (which uses IsTypedArrayMethod)
         EmitTypedArrayDetectionHelpers(typeBuilder, runtime);
+        // AbortController/AbortSignal methods must come before GetProperty,
+        // whose dict-receiver branch dispatches "aborted"/"reason"/"onabort"
+        // to the signal getters (#224). FireAbortEvent must precede
+        // EmitAbortControllerMethods (which references it). Gated on
+        // UsesAbortController, also implied by UsesWebStreams/fetch/http.
+        if (_features.UsesAbortController)
+        {
+            EmitFireAbortEvent(typeBuilder, runtime);
+            EmitAbortControllerMethods(typeBuilder, runtime);
+        }
         // String/Number/Boolean populate shells already defined above
         // (before cctor) so the cctor can call them eagerly.
         EmitGetProperty(typeBuilder, runtime);
@@ -983,14 +993,9 @@ public partial class RuntimeEmitter
             runtime.RequireSharpTSRuntime("Proxy");
             EmitProxyMethods(typeBuilder, runtime);
         }
-        // AbortController/AbortSignal methods (FireAbortEvent must be emitted
-        // before AbortController methods). Gated on UsesAbortController, also
-        // implied by UsesWebStreams (ReadableStream pipeTo checks abort state).
-        if (_features.UsesAbortController)
-        {
-            EmitFireAbortEvent(typeBuilder, runtime);
-            EmitAbortControllerMethods(typeBuilder, runtime);
-        }
+        // AbortController/AbortSignal methods were moved earlier (above
+        // EmitGetProperty) — its dict-receiver branch dispatches to the
+        // signal getters (#224).
         // Dynamic import support. Module registry + WrapTaskAsPromise stay
         // unconditional (used by multi-module bundling and dns/fs/http/timer
         // promise wrappers). The actual `import(specifier)` impl is gated

--- a/Compilation/RuntimeEmitter.Worker.cs
+++ b/Compilation/RuntimeEmitter.Worker.cs
@@ -29,8 +29,9 @@ public partial class RuntimeEmitter
             EmitAtomicsHelpersPure(runtimeType, runtime);
         }
 
-        // MessageChannel constructor helper
-        EmitMessageChannelHelper(runtimeType, runtime);
+        // MessageChannel/MessagePort moved to RuntimeEmitter.MessageChannel.cs —
+        // emitted after EmitRuntimeClass because $MessagePort.PostMessage calls
+        // $Runtime.StructuredClone (#222).
 
         // Worker constructor helper
         EmitWorkerHelper(runtimeType, runtime);
@@ -1212,55 +1213,6 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ret);
 
         runtime.TSTypedArraySet = method;
-    }
-
-    /// <summary>
-    /// Emits MessageChannel constructor helper.
-    /// Uses direct constructor invocation.
-    /// </summary>
-    private void EmitMessageChannelHelper(TypeBuilder runtimeType, EmittedRuntime runtime)
-    {
-        var method = runtimeType.DefineMethod(
-            "CreateMessageChannel",
-            MethodAttributes.Public | MethodAttributes.Static,
-            _types.Object,
-            Type.EmptyTypes
-        );
-
-        var il = method.GetILGenerator();
-        var channelLocal = il.DeclareLocal(_types.DictionaryStringObject);
-        var port1Local = il.DeclareLocal(_types.Object);
-        var port2Local = il.DeclareLocal(_types.Object);
-
-        // channel = new Dictionary<string, object>()
-        il.Emit(OpCodes.Newobj, _types.DictionaryStringObjectCtor);
-        il.Emit(OpCodes.Stloc, channelLocal);
-
-        // port1 = new object()
-        il.Emit(OpCodes.Newobj, _types.GetDefaultConstructor(_types.Object));
-        il.Emit(OpCodes.Stloc, port1Local);
-
-        // port2 = new object()
-        il.Emit(OpCodes.Newobj, _types.GetDefaultConstructor(_types.Object));
-        il.Emit(OpCodes.Stloc, port2Local);
-
-        // channel["port1"] = port1
-        il.Emit(OpCodes.Ldloc, channelLocal);
-        il.Emit(OpCodes.Ldstr, "port1");
-        il.Emit(OpCodes.Ldloc, port1Local);
-        il.Emit(OpCodes.Callvirt, _types.DictionaryStringObjectSetItem);
-
-        // channel["port2"] = port2
-        il.Emit(OpCodes.Ldloc, channelLocal);
-        il.Emit(OpCodes.Ldstr, "port2");
-        il.Emit(OpCodes.Ldloc, port2Local);
-        il.Emit(OpCodes.Callvirt, _types.DictionaryStringObjectSetItem);
-
-        il.Emit(OpCodes.Ldloc, channelLocal);
-        il.Emit(OpCodes.Ret);
-
-        runtime.TSMessageChannelType = _types.DictionaryStringObject;
-        runtime.TSMessageChannelCtor = method;
     }
 
     /// <summary>

--- a/Compilation/RuntimeEmitter.cs
+++ b/Compilation/RuntimeEmitter.cs
@@ -380,6 +380,15 @@ public partial class RuntimeEmitter
         // the $Runtime type itself all being defined.
         EmitNewOnFunction(_runtimeTypeBuilder!, runtime);
 
+        // Dynamic-callee `new x(...)` dispatch for state-machine emitters (#224).
+        // Must follow EmitNewOnFunction — it calls through runtime.NewOnFunction.
+        EmitConstructDynamicValue(_runtimeTypeBuilder!, runtime);
+
+        // AbortSignal / Intl value-position singletons (#224). Must follow
+        // EmitRuntimeClass — they wrap the AbortSignal*/CreateIntl* helpers
+        // emitted there.
+        EmitNamespaceSingletons(_runtimeTypeBuilder!, runtime);
+
         // Emit $BroadcastChannel — extends $EventEmitter, dispatches via $EventLoop,
         // and clones messages via $Runtime.StructuredClone (populated during EmitRuntimeClass
         // → EmitWorkerHelpers → EmitStructuredCloneHelper).

--- a/Compilation/RuntimeEmitter.cs
+++ b/Compilation/RuntimeEmitter.cs
@@ -397,6 +397,13 @@ public partial class RuntimeEmitter
         if (features.UsesBroadcastChannel)
             EmitBroadcastChannelClass(moduleBuilder, runtime);
 
+        // Emit $MessagePort/$MessageChannel — same constraints as
+        // $BroadcastChannel ($EventEmitter base, $EventLoop dispatch,
+        // $Runtime.StructuredClone for per-message cloning). Unconditional,
+        // matching the previous CreateMessageChannel helper (#222).
+        // NOTE: Must stay in sync with SharpTS.Runtime.Types.SharpTSMessagePort
+        EmitMessageChannelTypes(moduleBuilder, runtime);
+
         // Web Streams — gated on UsesWebStreams. The only external references are
         // user-code `new ReadableStream(...)`/`new WritableStream(...)`/`new TransformStream(...)`
         // in ExpressionEmitterBase.Constructors.cs, which only fire when the

--- a/Execution/Interpreter.UnhandledRejections.cs
+++ b/Execution/Interpreter.UnhandledRejections.cs
@@ -1,0 +1,97 @@
+using SharpTS.Runtime.Exceptions;
+using SharpTS.Runtime.Types;
+
+namespace SharpTS.Execution;
+
+/// <summary>
+/// Unhandled-rejection reporting for guest callbacks invoked by built-in code (#228).
+/// </summary>
+/// <remarks>
+/// When C# built-in code invokes a guest callback (timer callbacks, fs/dns/crypto
+/// completion callbacks, EventEmitter listeners, http server callbacks), the
+/// callback's return value is discarded — there is no guest-visible promise that
+/// anyone could attach a rejection handler to. If the callback is async and
+/// rejects, the rejection used to vanish completely: no output, no exit-code
+/// signal, and any event-loop Refs the callback would have released stayed
+/// leaked (the silent-hang symptom behind #207). These helpers give every such
+/// invocation site Node's default behavior: report the rejection on stderr and
+/// make the process exit nonzero.
+/// </remarks>
+public partial class Interpreter
+{
+    /// <summary>
+    /// True once any unhandled promise rejection has been reported. The CLI
+    /// turns this into a nonzero process exit code after the event loop drains,
+    /// matching Node's default unhandled-rejection behavior.
+    /// </summary>
+    public bool HadUnhandledRejection { get; private set; }
+
+    /// <summary>
+    /// Invokes a guest callback whose result the caller would otherwise discard,
+    /// and reports the rejection if the callback was async and its promise faults.
+    /// Built-in invocation sites should prefer this over calling
+    /// <c>callback.Call(...)</c> directly and dropping the result.
+    /// </summary>
+    public void InvokeGuestCallback(ISharpTSCallable callback, List<object?> args)
+    {
+        ObserveDiscardedCallbackResult(callback.Call(this, args));
+    }
+
+    /// <summary>
+    /// Observes a guest-callback result that the built-in caller is about to
+    /// discard. If it is a promise (or raw task) that rejects, the rejection is
+    /// reported as unhandled — synchronously if already faulted, otherwise via a
+    /// continuation when it settles. Non-promise results are ignored.
+    /// </summary>
+    public void ObserveDiscardedCallbackResult(object? result)
+    {
+        Task<object?>? task = result switch
+        {
+            SharpTSPromise promise => promise.Task,
+            Task<object?> t => t,
+            _ => null,
+        };
+        if (task == null) return;
+
+        if (task.IsCompleted)
+        {
+            if (task.IsFaulted)
+            {
+                ReportUnhandledRejection(task.Exception!.InnerException ?? task.Exception!);
+            }
+            return;
+        }
+
+        task.ContinueWith(
+            t => ReportUnhandledRejection(t.Exception!.InnerException ?? t.Exception!),
+            CancellationToken.None,
+            TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
+    }
+
+    private void ReportUnhandledRejection(Exception exception)
+    {
+        HadUnhandledRejection = true;
+
+        string message = exception switch
+        {
+            SharpTSPromiseRejectedException rejected => rejected.Message,
+            ThrowException thrown => SharpTSPromiseRejectedException.FormatReason(thrown.Value),
+            _ => exception.Message,
+        };
+
+        try
+        {
+            Error.WriteLine($"Unhandled promise rejection: {message}");
+            if (exception is SharpTSPromiseRejectedException { RejectionStack: { } stack })
+            {
+                Error.WriteLine(stack);
+            }
+        }
+        catch
+        {
+            // Reporting must never take down the event loop (e.g. a closed
+            // stderr writer during shutdown). The exit-code flag is already set.
+        }
+    }
+}

--- a/Execution/Interpreter.cs
+++ b/Execution/Interpreter.cs
@@ -48,6 +48,16 @@ public partial class Interpreter : IDisposable
         InterpreterRegistry.Create();
 
     /// <summary>
+    /// The %Promise% constructor sentinel registered when no Promise singleton
+    /// claimed the global first. MUST be declared before
+    /// <see cref="_globalConstants"/> — static initializers run in textual
+    /// order and CreateGlobalsLookup reads this field.
+    /// </summary>
+    internal static readonly SharpTSBuiltInConstructor PromiseConstructorSentinel = new(
+        BuiltInNames.Promise,
+        _ => throw new Exception("Runtime Error: Use 'new Promise(executor)' syntax."));
+
+    /// <summary>
     /// Frozen dictionary of global constants and built-in singletons for fast lookup.
     /// Combines global constants (NaN, Infinity, undefined) with built-in namespaces
     /// (Math, JSON, Object, etc.) into a single lookup to minimize dictionary operations.
@@ -213,13 +223,21 @@ public partial class Interpreter : IDisposable
         // own dedicated path and does not route through this factory.
         if (!globals.ContainsKey(BuiltInNames.Promise))
         {
-            globals[BuiltInNames.Promise] = new SharpTSBuiltInConstructor(
-                BuiltInNames.Promise,
-                _ => throw new Exception("Runtime Error: Use 'new Promise(executor)' syntax."));
+            globals[BuiltInNames.Promise] = PromiseConstructorSentinel;
         }
 
         return globals.ToFrozenDictionary();
     }
+
+    /// <summary>
+    /// The value bare <c>Promise</c> resolves to — whatever the global table
+    /// actually holds (a registry singleton when one exists, otherwise
+    /// <see cref="PromiseConstructorSentinel"/>). Surfaced as
+    /// <c>promise.constructor</c> by PromiseBuiltIns.GetMember so the
+    /// ECMA-262 §27.2.5.1 identity holds:
+    /// <c>Promise.resolve(1).constructor === Promise</c> (#221).
+    /// </summary>
+    internal static object PromiseGlobalValue => _globalConstants[BuiltInNames.Promise];
 
     private RuntimeEnvironment _environment = new();
     private readonly Dictionary<Expr, int> _locals = []; // Depth for resolved variables

--- a/Execution/Interpreter.cs
+++ b/Execution/Interpreter.cs
@@ -734,14 +734,30 @@ public partial class Interpreter : IDisposable
     /// This provides Node.js-compatible single-threaded semantics where all user callbacks
     /// execute on the main thread, while I/O operations run on the ThreadPool.
     /// </remarks>
+    /// <summary>
+    /// Installs the interpreter's SynchronizationContext on the current thread so
+    /// async/await continuations post back to the event loop queue instead of
+    /// resuming on thread-pool threads. Continuations that escape to the thread
+    /// pool race the main thread over the ambient environment, which surfaces as
+    /// spurious "Undefined variable" errors in then-callbacks. Must be installed
+    /// before the FIRST top-level statement runs — promise chains started at module
+    /// top level capture whatever context is current at their first await.
+    /// Returns the previous context; callers restore it when execution finishes.
+    /// </summary>
+    private SynchronizationContext? InstallEventLoopSyncContext()
+    {
+        _eventLoopSyncContext ??= new InterpreterSynchronizationContext(EnqueueCallback);
+        var previous = SynchronizationContext.Current;
+        SynchronizationContext.SetSynchronizationContext(_eventLoopSyncContext);
+        return previous;
+    }
+
     public void RunEventLoop()
     {
-        // Set up SynchronizationContext so async/await continuations come back to this thread.
-        // InterpretModules also sets this up earlier so module-init awaits have the correct
-        // context; this assignment is idempotent for the nested case.
-        _eventLoopSyncContext ??= new InterpreterSynchronizationContext(EnqueueCallback);
-        var previousSyncContext = SynchronizationContext.Current;
-        SynchronizationContext.SetSynchronizationContext(_eventLoopSyncContext);
+        // Set up SynchronizationContext so async/await continuations come back to this
+        // thread. Interpret/InterpretModules also set this up earlier so top-level
+        // awaits have the correct context; this assignment is idempotent for that case.
+        var previousSyncContext = InstallEventLoopSyncContext();
 
         try
         {
@@ -1023,6 +1039,7 @@ public partial class Interpreter : IDisposable
         _typeMap = typeMap;
         LastUncaughtError = null;
         ProcessBuiltIns.ResetScriptStartTime();
+        var previousSyncContext = InstallEventLoopSyncContext();
         try
         {
             // Check for "use strict" directive at file level
@@ -1086,6 +1103,10 @@ public partial class Interpreter : IDisposable
         {
             Out.WriteLine($"Runtime Error: {error.Message}");
             throw;
+        }
+        finally
+        {
+            SynchronizationContext.SetSynchronizationContext(previousSyncContext);
         }
     }
 
@@ -1189,6 +1210,7 @@ public partial class Interpreter : IDisposable
             EntryModulePath = modules[^1].Path;
         }
 
+        var previousSyncContext = InstallEventLoopSyncContext();
         try
         {
             // Create a shared script environment for script files (they share global scope)
@@ -1243,6 +1265,10 @@ public partial class Interpreter : IDisposable
         {
             Out.WriteLine($"Runtime Error: {error.Message}");
             throw;
+        }
+        finally
+        {
+            SynchronizationContext.SetSynchronizationContext(previousSyncContext);
         }
     }
 

--- a/Program.cs
+++ b/Program.cs
@@ -197,6 +197,14 @@ static void RunModuleFile(string absolutePath, DecoratorMode decoratorMode, bool
         }
 
         interpreter.InterpretModules(allModules, resolver, typeMap);
+
+        // Node default: an unhandled promise rejection makes the process
+        // exit nonzero. The rejection itself was already reported to stderr
+        // by the interpreter when it was observed (#228).
+        if (interpreter.HadUnhandledRejection)
+        {
+            Environment.Exit(1);
+        }
     }
     catch (SharpTS.Runtime.Exceptions.ThrowException tex)
     {
@@ -274,6 +282,13 @@ static void Run(string source, DecoratorMode decoratorMode, bool emitDecoratorMe
 
         // Interpretation Phase
         interpreter.Interpret(parseResult.Statements, typeMap);
+
+        // Node default: an unhandled promise rejection makes the process
+        // exit nonzero (#228).
+        if (interpreter.HadUnhandledRejection)
+        {
+            Environment.Exit(1);
+        }
     }
     catch (SharpTSException ex)
     {

--- a/Runtime/BuiltIns/Modules/Interpreter/CryptoModuleInterpreter.cs
+++ b/Runtime/BuiltIns/Modules/Interpreter/CryptoModuleInterpreter.cs
@@ -694,8 +694,14 @@ public static class CryptoModuleInterpreter
     {
         interpreter.ScheduleTimer(0, 0, () =>
         {
-            callback.Call(interpreter, [error, result]);
-            interpreter.Unref();
+            try
+            {
+                interpreter.InvokeGuestCallback(callback, [error, result]);
+            }
+            finally
+            {
+                interpreter.Unref();
+            }
         }, isInterval: false);
     }
 

--- a/Runtime/BuiltIns/Modules/Interpreter/DnsModuleInterpreter.cs
+++ b/Runtime/BuiltIns/Modules/Interpreter/DnsModuleInterpreter.cs
@@ -152,10 +152,10 @@ public static class DnsModuleInterpreter
                 interpreter.ScheduleTimer(0, 0, () =>
                 {
                     if (result is SharpTSObject single)
-                        callback.Call(interpreter,
+                        interpreter.InvokeGuestCallback(callback,
                             [null, single.Fields["address"], single.Fields["family"]]);
                     else
-                        callback.Call(interpreter, [null, result]);
+                        interpreter.InvokeGuestCallback(callback, [null, result]);
                     interpreter.Unref();
                 }, isInterval: false);
             }
@@ -163,7 +163,7 @@ public static class DnsModuleInterpreter
             {
                 interpreter.ScheduleTimer(0, 0, () =>
                 {
-                    callback.Call(interpreter,
+                    interpreter.InvokeGuestCallback(callback,
                         [CreateDnsError(ExtractErrorCode(ex), hostname), null, null]);
                     interpreter.Unref();
                 }, isInterval: false);
@@ -263,7 +263,7 @@ public static class DnsModuleInterpreter
                 var result = LookupServiceCore(address, port);
                 interpreter.ScheduleTimer(0, 0, () =>
                 {
-                    callback.Call(interpreter,
+                    interpreter.InvokeGuestCallback(callback,
                         [null, result.Fields["hostname"], result.Fields["service"]]);
                     interpreter.Unref();
                 }, isInterval: false);
@@ -272,7 +272,7 @@ public static class DnsModuleInterpreter
             {
                 interpreter.ScheduleTimer(0, 0, () =>
                 {
-                    callback.Call(interpreter,
+                    interpreter.InvokeGuestCallback(callback,
                         [CreateDnsError(ExtractErrorCode(ex), address), null, null]);
                     interpreter.Unref();
                 }, isInterval: false);
@@ -390,7 +390,7 @@ public static class DnsModuleInterpreter
                 var result = WrapDnsResult(raw);
                 interpreter.ScheduleTimer(0, 0, () =>
                 {
-                    callback.Call(interpreter, [null, result]);
+                    interpreter.InvokeGuestCallback(callback, [null, result]);
                     interpreter.Unref();
                 }, isInterval: false);
             }
@@ -398,7 +398,7 @@ public static class DnsModuleInterpreter
             {
                 interpreter.ScheduleTimer(0, 0, () =>
                 {
-                    callback.Call(interpreter, [CreateDnsError(ExtractErrorCode(ex), hostname), null]);
+                    interpreter.InvokeGuestCallback(callback, [CreateDnsError(ExtractErrorCode(ex), hostname), null]);
                     interpreter.Unref();
                 }, isInterval: false);
             }
@@ -422,7 +422,7 @@ public static class DnsModuleInterpreter
                 var wrapped = new SharpTSArray(result);
                 interpreter.ScheduleTimer(0, 0, () =>
                 {
-                    callback.Call(interpreter, [null, wrapped]);
+                    interpreter.InvokeGuestCallback(callback, [null, wrapped]);
                     interpreter.Unref();
                 }, isInterval: false);
             }
@@ -430,7 +430,7 @@ public static class DnsModuleInterpreter
             {
                 interpreter.ScheduleTimer(0, 0, () =>
                 {
-                    callback.Call(interpreter, [CreateDnsError(ExtractErrorCode(ex), hostname), null]);
+                    interpreter.InvokeGuestCallback(callback, [CreateDnsError(ExtractErrorCode(ex), hostname), null]);
                     interpreter.Unref();
                 }, isInterval: false);
             }
@@ -453,7 +453,7 @@ public static class DnsModuleInterpreter
                 var wrapped = new SharpTSArray(result);
                 interpreter.ScheduleTimer(0, 0, () =>
                 {
-                    callback.Call(interpreter, [null, wrapped]);
+                    interpreter.InvokeGuestCallback(callback, [null, wrapped]);
                     interpreter.Unref();
                 }, isInterval: false);
             }
@@ -461,7 +461,7 @@ public static class DnsModuleInterpreter
             {
                 interpreter.ScheduleTimer(0, 0, () =>
                 {
-                    callback.Call(interpreter, [CreateDnsError(ExtractErrorCode(ex), ip), null]);
+                    interpreter.InvokeGuestCallback(callback, [CreateDnsError(ExtractErrorCode(ex), ip), null]);
                     interpreter.Unref();
                 }, isInterval: false);
             }
@@ -486,7 +486,7 @@ public static class DnsModuleInterpreter
                 var result = WrapDnsResult(raw);
                 interpreter.ScheduleTimer(0, 0, () =>
                 {
-                    callback.Call(interpreter, [null, result]);
+                    interpreter.InvokeGuestCallback(callback, [null, result]);
                     interpreter.Unref();
                 }, isInterval: false);
             }
@@ -494,7 +494,7 @@ public static class DnsModuleInterpreter
             {
                 interpreter.ScheduleTimer(0, 0, () =>
                 {
-                    callback.Call(interpreter, [CreateDnsError(ExtractErrorCode(ex), hostname), null]);
+                    interpreter.InvokeGuestCallback(callback, [CreateDnsError(ExtractErrorCode(ex), hostname), null]);
                     interpreter.Unref();
                 }, isInterval: false);
             }
@@ -586,7 +586,7 @@ public static class DnsModuleInterpreter
                 var result = WrapDnsResult(raw);
                 interpreter.ScheduleTimer(0, 0, () =>
                 {
-                    callback.Call(interpreter, [null, result]);
+                    interpreter.InvokeGuestCallback(callback, [null, result]);
                     interpreter.Unref();
                 }, isInterval: false);
             }
@@ -594,7 +594,7 @@ public static class DnsModuleInterpreter
             {
                 interpreter.ScheduleTimer(0, 0, () =>
                 {
-                    callback.Call(interpreter, [CreateDnsError(ExtractErrorCode(ex), hostname), null]);
+                    interpreter.InvokeGuestCallback(callback, [CreateDnsError(ExtractErrorCode(ex), hostname), null]);
                     interpreter.Unref();
                 }, isInterval: false);
             }
@@ -644,7 +644,7 @@ public static class DnsModuleInterpreter
                 var result = WrapDnsResult(raw);
                 interpreter.ScheduleTimer(0, 0, () =>
                 {
-                    callback.Call(interpreter, [null, result]);
+                    interpreter.InvokeGuestCallback(callback, [null, result]);
                     interpreter.Unref();
                 }, isInterval: false);
             }
@@ -652,7 +652,7 @@ public static class DnsModuleInterpreter
             {
                 interpreter.ScheduleTimer(0, 0, () =>
                 {
-                    callback.Call(interpreter, [CreateDnsError(ExtractErrorCode(ex), hostname), null]);
+                    interpreter.InvokeGuestCallback(callback, [CreateDnsError(ExtractErrorCode(ex), hostname), null]);
                     interpreter.Unref();
                 }, isInterval: false);
             }
@@ -678,7 +678,7 @@ public static class DnsModuleInterpreter
                 var result = ResolveAddresses(hostname, AddressFamily.InterNetwork);
                 interpreter.ScheduleTimer(0, 0, () =>
                 {
-                    callback.Call(interpreter, [null, result]);
+                    interpreter.InvokeGuestCallback(callback, [null, result]);
                     interpreter.Unref();
                 }, isInterval: false);
             }
@@ -686,7 +686,7 @@ public static class DnsModuleInterpreter
             {
                 interpreter.ScheduleTimer(0, 0, () =>
                 {
-                    callback.Call(interpreter, [CreateDnsError(GetErrorCode(ex), hostname), null]);
+                    interpreter.InvokeGuestCallback(callback, [CreateDnsError(GetErrorCode(ex), hostname), null]);
                     interpreter.Unref();
                 }, isInterval: false);
             }
@@ -712,7 +712,7 @@ public static class DnsModuleInterpreter
                 var result = ResolveAddresses(hostname, AddressFamily.InterNetworkV6);
                 interpreter.ScheduleTimer(0, 0, () =>
                 {
-                    callback.Call(interpreter, [null, result]);
+                    interpreter.InvokeGuestCallback(callback, [null, result]);
                     interpreter.Unref();
                 }, isInterval: false);
             }
@@ -720,7 +720,7 @@ public static class DnsModuleInterpreter
             {
                 interpreter.ScheduleTimer(0, 0, () =>
                 {
-                    callback.Call(interpreter, [CreateDnsError(GetErrorCode(ex), hostname), null]);
+                    interpreter.InvokeGuestCallback(callback, [CreateDnsError(GetErrorCode(ex), hostname), null]);
                     interpreter.Unref();
                 }, isInterval: false);
             }
@@ -750,7 +750,7 @@ public static class DnsModuleInterpreter
                 var hostnames = new SharpTSArray(new List<object?> { hostEntry.HostName });
                 interpreter.ScheduleTimer(0, 0, () =>
                 {
-                    callback.Call(interpreter, [null, hostnames]);
+                    interpreter.InvokeGuestCallback(callback, [null, hostnames]);
                     interpreter.Unref();
                 }, isInterval: false);
             }
@@ -758,7 +758,7 @@ public static class DnsModuleInterpreter
             {
                 interpreter.ScheduleTimer(0, 0, () =>
                 {
-                    callback.Call(interpreter, [CreateDnsError(GetErrorCode(ex), ip), null]);
+                    interpreter.InvokeGuestCallback(callback, [CreateDnsError(GetErrorCode(ex), ip), null]);
                     interpreter.Unref();
                 }, isInterval: false);
             }
@@ -766,7 +766,7 @@ public static class DnsModuleInterpreter
             {
                 interpreter.ScheduleTimer(0, 0, () =>
                 {
-                    callback.Call(interpreter, [CreateDnsError("EAI_FAIL", ip), null]);
+                    interpreter.InvokeGuestCallback(callback, [CreateDnsError("EAI_FAIL", ip), null]);
                     interpreter.Unref();
                 }, isInterval: false);
             }

--- a/Runtime/BuiltIns/Modules/Interpreter/FsModuleInterpreter.cs
+++ b/Runtime/BuiltIns/Modules/Interpreter/FsModuleInterpreter.cs
@@ -960,7 +960,7 @@ public static class FsModuleInterpreter
         {
             try
             {
-                callback.Call(interpreter, [error, result]);
+                interpreter.InvokeGuestCallback(callback, [error, result]);
             }
             finally
             {

--- a/Runtime/BuiltIns/PromiseBuiltIns.cs
+++ b/Runtime/BuiltIns/PromiseBuiltIns.cs
@@ -27,6 +27,13 @@ public static class PromiseBuiltIns
             "finally" => new BuiltInAsyncMethod("finally", 1, 1, (interp, recv, args) =>
                 FinallyImpl((SharpTSPromise)recv!, args, interp)).Bind(receiver),
 
+            // ECMA-262 §27.2.5.1: Promise.prototype.constructor is %Promise%.
+            // First SpeciesConstructor increment for #221 — then/catch/finally
+            // result construction still always uses %Promise%; species dispatch
+            // stays unobservable until guest classes can subclass Promise (#233)
+            // and Symbol is a first-class value (#234).
+            "constructor" => Interpreter.PromiseGlobalValue,
+
             _ => null
         };
     }

--- a/Runtime/BuiltIns/TimerBuiltIns.cs
+++ b/Runtime/BuiltIns/TimerBuiltIns.cs
@@ -36,7 +36,7 @@ public static class TimerBuiltIns
             {
                 try
                 {
-                    callback.Call(interpreter, args);
+                    interpreter.InvokeGuestCallback(callback, args);
                 }
                 finally
                 {
@@ -94,7 +94,7 @@ public static class TimerBuiltIns
         {
             if (!cts.IsCancellationRequested && !interpreter.IsDisposed)
             {
-                callback.Call(interpreter, args);
+                interpreter.InvokeGuestCallback(callback, args);
             }
         }, isInterval: true);
 

--- a/Runtime/Types/SharpTSEventEmitter.cs
+++ b/Runtime/Types/SharpTSEventEmitter.cs
@@ -199,7 +199,10 @@ public class SharpTSEventEmitter : ITypeCategorized
     {
         if (listener is ISharpTSCallable callable)
         {
-            callable.Call(interpreter!, eventArgs);
+            var result = callable.Call(interpreter!, eventArgs);
+            // An async listener's promise is unreachable from guest code —
+            // report its rejection instead of swallowing it (#228).
+            interpreter?.ObserveDiscardedCallbackResult(result);
         }
         else
         {

--- a/Runtime/Types/SharpTSHttpServer.cs
+++ b/Runtime/Types/SharpTSHttpServer.cs
@@ -161,7 +161,7 @@ public class SharpTSHttpServer : SharpTSEventEmitter, IDisposable
         // Call the listening callback
         if (callback != null)
         {
-            callback.Call(interpreter, new List<object?>());
+            interpreter.InvokeGuestCallback(callback, new List<object?>());
         }
 
         // Emit 'listening' event
@@ -217,7 +217,10 @@ public class SharpTSHttpServer : SharpTSEventEmitter, IDisposable
         _isListening = true;
         interpreter.Ref();
 
-        callback?.Call(interpreter, new List<object?>());
+        if (callback != null)
+        {
+            interpreter.InvokeGuestCallback(callback, new List<object?>());
+        }
         EmitEvent("listening", new List<object?>());
 
         return this;
@@ -309,7 +312,10 @@ public class SharpTSHttpServer : SharpTSEventEmitter, IDisposable
         {
             interp.ScheduleTimer(0, 0, () =>
             {
-                callback?.Call(interp, new List<object?>());
+                if (callback != null)
+                {
+                    interp.InvokeGuestCallback(callback, new List<object?>());
+                }
                 EmitEvent("close", new List<object?>());
             }, isInterval: false);
         }

--- a/Runtime/Types/SharpTSPromise.cs
+++ b/Runtime/Types/SharpTSPromise.cs
@@ -141,13 +141,18 @@ public class SharpTSPromiseRejectedException : Exception
     public string? RejectionStack { get; }
 
     public SharpTSPromiseRejectedException(object? reason)
-        : base(FormatMessage(reason))
+        : base(FormatReason(reason))
     {
         Reason = reason;
         RejectionStack = CaptureStack(reason);
     }
 
-    private static string FormatMessage(object? reason)
+    /// <summary>
+    /// Formats a rejection reason for host-side display ("Error: message" for
+    /// error values, ToString otherwise). Also used by unhandled-rejection
+    /// reporting so the reason renders the same way everywhere.
+    /// </summary>
+    internal static string FormatReason(object? reason)
     {
         if (reason is SharpTSError error)
             return $"{error.Name}: {error.Message}";

--- a/Runtime/Types/SharpTSReadableStream.cs
+++ b/Runtime/Types/SharpTSReadableStream.cs
@@ -428,7 +428,7 @@ public class SharpTSReadableStream : ITypeCategorized
             "cancel" => BuiltInMethod.CreateV2("cancel", 1, (_, _, args) =>
             {
                 var reason = args.Length > 0 ? args[0].ToObject() : SharpTSUndefined.Instance;
-                return RuntimeValue.FromObject(CancelInternal(reason).Task);
+                return RuntimeValue.FromObject(CancelInternal(reason));
             }),
             "pipeTo" => BuiltInMethod.CreateV2("pipeTo", 1, 2, (interp, _, args) =>
             {
@@ -436,7 +436,7 @@ public class SharpTSReadableStream : ITypeCategorized
                 var opts = args.Length > 1 ? args[1].ToObject() : null;
                 // PipeToAny accepts both interpreter SharpTSWritableStream and
                 // pure-IL emitted $WritableStream destinations.
-                return RuntimeValue.FromObject(WebStreamsHelpers.PipeToAny(interp, this, dest, opts).Task);
+                return RuntimeValue.FromObject(WebStreamsHelpers.PipeToAny(interp, this, dest, opts));
             }),
             "pipeThrough" => BuiltInMethod.CreateV2("pipeThrough", 1, 2, (interp, recv, args) =>
             {
@@ -515,6 +515,8 @@ public class SharpTSReadableStreamDefaultReader : ITypeCategorized
     internal readonly TaskCompletionSource<object?> ClosedTcs =
         new(TaskCreationOptions.RunContinuationsAsynchronously);
 
+    private SharpTSPromise? _closedPromise;
+
     internal SharpTSReadableStreamDefaultReader(SharpTSReadableStream stream)
     {
         _stream = stream;
@@ -526,16 +528,14 @@ public class SharpTSReadableStreamDefaultReader : ITypeCategorized
     {
         return name switch
         {
-            "closed" => ClosedTcs.Task,
+            "closed" => _closedPromise ??= new SharpTSPromise(ClosedTcs.Task),
             "read" => BuiltInMethod.CreateV2("read", 0, (_, _, _) =>
             {
                 if (_stream.Reader != this)
                 {
-                    var tcs = new TaskCompletionSource<object?>();
-                    tcs.SetException(new SharpTSPromiseRejectedException("TypeError: Reader is no longer attached to its stream"));
-                    return RuntimeValue.FromObject(tcs.Task);
+                    return RuntimeValue.FromObject(SharpTSPromise.Reject("TypeError: Reader is no longer attached to its stream"));
                 }
-                return RuntimeValue.FromBoxed(_stream.ReadInternal());
+                return RuntimeValue.FromObject(new SharpTSPromise(_stream.ReadInternal()));
             }),
             "releaseLock" => BuiltInMethod.CreateV2("releaseLock", 0, (_, _, _) =>
             {
@@ -551,12 +551,10 @@ public class SharpTSReadableStreamDefaultReader : ITypeCategorized
             {
                 if (_stream.Reader != this)
                 {
-                    var tcs = new TaskCompletionSource<object?>();
-                    tcs.SetException(new SharpTSPromiseRejectedException("TypeError: Reader is no longer attached to its stream"));
-                    return RuntimeValue.FromObject(tcs.Task);
+                    return RuntimeValue.FromObject(SharpTSPromise.Reject("TypeError: Reader is no longer attached to its stream"));
                 }
                 var reason = args.Length > 0 ? args[0].ToObject() : SharpTSUndefined.Instance;
-                return RuntimeValue.FromObject(_stream.CancelInternal(reason).Task);
+                return RuntimeValue.FromObject(_stream.CancelInternal(reason));
             }),
             _ => null,
         };

--- a/Runtime/Types/SharpTSWritableStream.cs
+++ b/Runtime/Types/SharpTSWritableStream.cs
@@ -376,11 +376,11 @@ public class SharpTSWritableStream : ITypeCategorized
             "abort" => BuiltInMethod.CreateV2("abort", 1, (_, _, args) =>
             {
                 var reason = args.Length > 0 ? args[0].ToObject() : SharpTSUndefined.Instance;
-                return RuntimeValue.FromBoxed(AbortInternal(reason));
+                return RuntimeValue.FromObject(new SharpTSPromise(AbortInternal(reason)));
             }),
             "close" => BuiltInMethod.CreateV2("close", 0, (_, _, _) =>
             {
-                return RuntimeValue.FromBoxed(CloseAsyncInternal());
+                return RuntimeValue.FromObject(new SharpTSPromise(CloseAsyncInternal()));
             }),
             _ => null,
         };
@@ -429,9 +429,13 @@ public class SharpTSWritableStreamDefaultWriter : ITypeCategorized
     private TaskCompletionSource<object?> _readyTcs =
         new(TaskCreationOptions.RunContinuationsAsynchronously);
 
+    private SharpTSPromise? _readyPromise;
+
     // closed resolves when the stream closes cleanly, rejects on error.
     private readonly TaskCompletionSource<object?> _closedTcs =
         new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    private SharpTSPromise? _closedPromise;
 
     internal SharpTSWritableStreamDefaultWriter(SharpTSWritableStream stream)
     {
@@ -467,8 +471,8 @@ public class SharpTSWritableStreamDefaultWriter : ITypeCategorized
         return name switch
         {
             "desiredSize" => (object)_stream.DesiredSize,
-            "closed" => _closedTcs.Task,
-            "ready" => _readyTcs.Task,
+            "closed" => _closedPromise ??= new SharpTSPromise(_closedTcs.Task),
+            "ready" => GetReadyPromise(),
             "write" => BuiltInMethod.CreateV2("write", 1, (_, _, args) =>
             {
                 var chunk = args.Length > 0 ? args[0].ToObject() : SharpTSUndefined.Instance;
@@ -478,16 +482,16 @@ public class SharpTSWritableStreamDefaultWriter : ITypeCategorized
                 {
                     _readyTcs = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
                 }
-                return RuntimeValue.FromBoxed(task);
+                return RuntimeValue.FromObject(new SharpTSPromise(task));
             }),
             "close" => BuiltInMethod.CreateV2("close", 0, (_, _, _) =>
             {
-                return RuntimeValue.FromBoxed(_stream.CloseAsyncInternal());
+                return RuntimeValue.FromObject(new SharpTSPromise(_stream.CloseAsyncInternal()));
             }),
             "abort" => BuiltInMethod.CreateV2("abort", 1, (_, _, args) =>
             {
                 var reason = args.Length > 0 ? args[0].ToObject() : SharpTSUndefined.Instance;
-                return RuntimeValue.FromBoxed(_stream.AbortInternal(reason));
+                return RuntimeValue.FromObject(new SharpTSPromise(_stream.AbortInternal(reason)));
             }),
             "releaseLock" => BuiltInMethod.CreateV2("releaseLock", 0, (_, _, _) =>
             {
@@ -499,6 +503,17 @@ public class SharpTSWritableStreamDefaultWriter : ITypeCategorized
             }),
             _ => null,
         };
+    }
+
+    private SharpTSPromise GetReadyPromise()
+    {
+        // _readyTcs is replaced when the queue saturates, so the cached
+        // promise is only valid while it still wraps the current tcs.
+        if (_readyPromise == null || _readyPromise.Task != _readyTcs.Task)
+        {
+            _readyPromise = new SharpTSPromise(_readyTcs.Task);
+        }
+        return _readyPromise;
     }
 
     public override string ToString() => "WritableStreamDefaultWriter {}";

--- a/SharpTS.Tests/SharedTests/AsyncAwaitTests.cs
+++ b/SharpTS.Tests/SharedTests/AsyncAwaitTests.cs
@@ -801,4 +801,40 @@ public class AsyncAwaitTests
     }
 
     #endregion
+
+    #region Top-level then-continuations stay on the event loop (#238)
+
+    /// <summary>
+    /// #238: a then-chain started at module top level must have its continuation
+    /// run on the interpreter's event loop. Before the fix, the continuation
+    /// captured a null SynchronizationContext (it was installed only in
+    /// RunEventLoop, after top-level statements), resumed on a thread-pool
+    /// thread, and raced the main thread's ambient environment — surfacing as
+    /// "Undefined variable 'v'" for the callback's own parameter, or as
+    /// silently missing output.
+    /// </summary>
+    /// <remarks>
+    /// Interpreter-only: in compiled mode a top-level <c>p.then(...)</c>
+    /// expression statement blocks on the promise at the entry point, so a
+    /// resolve that happens in a later statement would deadlock — a separate
+    /// known compiled-mode behavior, not what this test pins.
+    /// </remarks>
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void TopLevelThen_ResolvedLater_RunsCallbackWithItsParameter(ExecutionMode mode)
+    {
+        var source = """
+            let resolveFn: any;
+            const p = new Promise((resolve) => { resolveFn = resolve; });
+            p.then((v: any) => console.log("then:", v.tag));
+            resolveFn({ tag: "ok" });
+            console.log("end");
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Contains("then: ok", output);
+        Assert.Contains("end", output);
+    }
+
+    #endregion
 }

--- a/SharpTS.Tests/SharedTests/BuiltInModules/StreamsWebSemanticTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/StreamsWebSemanticTests.cs
@@ -633,4 +633,65 @@ public class StreamsWebSemanticTests
     }
 
     #endregion
+
+    #region Promise-object surfaces (#223: reader/writer promises must support .then)
+
+    /// <summary>
+    /// #223: <c>reader.read()</c>/<c>reader.closed</c>/<c>reader.cancel()</c>
+    /// must return Promise objects usable with <c>.then()</c>/<c>.catch()</c>,
+    /// not raw Tasks whose property access throws.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void ReadableStreamReader_ReadAndClosed_AreThenable(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import { ReadableStream as RS } from "stream/web";
+                const rs = new (RS as any)({ start(c: any) { c.enqueue("z"); c.close(); } });
+                const reader = rs.getReader();
+                reader.closed.then(() => console.log("closed-resolved"));
+                reader.read().then((r: any) => console.log("read:", r.value, r.done));
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Contains("read: z false", output);
+        Assert.Contains("closed-resolved", output);
+    }
+
+    /// <summary>
+    /// #223 audit follow-through: writer <c>write()</c>/<c>close()</c>/<c>ready</c>/
+    /// <c>closed</c> must be thenable Promise objects as well.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void WritableStreamWriter_WriteReadyClosed_AreThenable(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                const chunks: string[] = [];
+                const ws = new WritableStream({
+                    write(chunk) { chunks.push(chunk as string); }
+                });
+                const writer = (ws as any).getWriter();
+                writer.ready.then(() => console.log("ready"));
+                writer.write("a").then(() => {
+                    console.log("wrote:", chunks.join(","));
+                    writer.close().then(() => console.log("close-resolved"));
+                    writer.closed.then(() => console.log("closed-resolved"));
+                });
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Contains("ready", output);
+        Assert.Contains("wrote: a", output);
+        Assert.Contains("close-resolved", output);
+        Assert.Contains("closed-resolved", output);
+    }
+
+    #endregion
 }

--- a/SharpTS.Tests/SharedTests/NamespaceGlobalBindingTests.cs
+++ b/SharpTS.Tests/SharedTests/NamespaceGlobalBindingTests.cs
@@ -4,15 +4,17 @@ using Xunit;
 namespace SharpTS.Tests.SharedTests;
 
 /// <summary>
-/// Tests for built-in namespaces/constructors bound as value-position globals
-/// (#208): AbortSignal, Intl, ReadableStream, WritableStream, TransformStream,
-/// MessageChannel. Interpreter-only — the compiled-mode globals are tracked
-/// separately.
+/// Tests for built-in namespaces/constructors bound as value-position globals:
+/// AbortSignal, Intl, ReadableStream, WritableStream, TransformStream,
+/// MessageChannel. Interpreter bindings landed with #208; compiled-mode
+/// equivalents with #224 (namespace singletons + ConstructDynamicValue +
+/// the GetProperty abort-signal dict branch). MessageChannel stays
+/// interpreter-only until #222 gives compiled mode real port objects.
 /// </summary>
 public class NamespaceGlobalBindingTests
 {
     [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void AbortSignal_StaticAbort_Resolves(ExecutionMode mode)
     {
         var source = """
@@ -26,7 +28,7 @@ public class NamespaceGlobalBindingTests
     }
 
     [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void AbortSignal_DirectConstruction_Throws(ExecutionMode mode)
     {
         var source = """
@@ -42,7 +44,7 @@ public class NamespaceGlobalBindingTests
     }
 
     [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void Intl_ValuePosition_AndMemberConstruction(ExecutionMode mode)
     {
         var source = """
@@ -56,7 +58,7 @@ public class NamespaceGlobalBindingTests
     }
 
     [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void WebStreamConstructors_ValuePosition_AndInstanceof(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/NamespaceGlobalBindingTests.cs
+++ b/SharpTS.Tests/SharedTests/NamespaceGlobalBindingTests.cs
@@ -8,8 +8,8 @@ namespace SharpTS.Tests.SharedTests;
 /// AbortSignal, Intl, ReadableStream, WritableStream, TransformStream,
 /// MessageChannel. Interpreter bindings landed with #208; compiled-mode
 /// equivalents with #224 (namespace singletons + ConstructDynamicValue +
-/// the GetProperty abort-signal dict branch). MessageChannel stays
-/// interpreter-only until #222 gives compiled mode real port objects.
+/// the GetProperty abort-signal dict branch) and #222 (real emitted
+/// $MessageChannel/$MessagePort types).
 /// </summary>
 public class NamespaceGlobalBindingTests
 {
@@ -76,7 +76,7 @@ public class NamespaceGlobalBindingTests
     }
 
     [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void MessageChannel_ValuePosition(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/PromiseMethodTests.cs
+++ b/SharpTS.Tests/SharedTests/PromiseMethodTests.cs
@@ -1036,4 +1036,32 @@ public class PromiseMethodTests
     }
 
     #endregion
+
+    #region promise.constructor (#221 SpeciesConstructor increment)
+
+    /// <summary>
+    /// ECMA-262 §27.2.5.1: Promise.prototype.constructor is %Promise%, so
+    /// <c>promise.constructor === Promise</c> must hold by identity. This is
+    /// the observable subset of #221's SpeciesConstructor work — species
+    /// dispatch itself stays unobservable until guest classes can subclass
+    /// Promise (#233) and Symbol is a first-class value (#234).
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void PromiseConstructorProperty_IsPromiseGlobal(ExecutionMode mode)
+    {
+        var source = """
+            const p = Promise.resolve(1);
+            console.log((p as any).constructor === Promise);
+            console.log(typeof (p as any).constructor);
+            async function f(): Promise<number> { return 2; }
+            const q: any = f();
+            console.log(q.constructor === Promise);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("true\nfunction\ntrue\n", output);
+    }
+
+    #endregion
 }

--- a/SharpTS.Tests/SharedTests/UnhandledRejectionTests.cs
+++ b/SharpTS.Tests/SharedTests/UnhandledRejectionTests.cs
@@ -1,0 +1,170 @@
+using SharpTS.Execution;
+using SharpTS.Modules;
+using SharpTS.Parsing;
+using SharpTS.TypeSystem;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests;
+
+/// <summary>
+/// #228: exceptions in async callbacks invoked by built-ins (timers, fs/dns
+/// callbacks, EventEmitter listeners) must not be silently swallowed. The
+/// built-in invocation sites observe the discarded promise and report a
+/// faulted one to stderr, flagging <see cref="Interpreter.HadUnhandledRejection"/>
+/// so the CLI exits nonzero — Node's default unhandled-rejection behavior.
+/// </summary>
+/// <remarks>
+/// Interpreter-only by construction: the tests need the interpreter's stderr
+/// stream and <c>HadUnhandledRejection</c> flag, which the shared TestHarness
+/// (stdout-only) does not expose. Compiled mode has its own callback dispatch
+/// and is out of scope for #228.
+/// </remarks>
+public class UnhandledRejectionTests
+{
+    private static (string Stdout, string Stderr, bool HadUnhandledRejection) RunCapturingStderr(string source)
+    {
+        var task = Task.Run(() =>
+        {
+            var stdout = new StringWriter();
+            var stderr = new StringWriter();
+
+            var lexer = new Lexer(source);
+            var tokens = lexer.ScanTokens();
+            var parser = new Parser(tokens);
+            var statements = parser.ParseOrThrow();
+
+            var checker = new TypeChecker();
+            var typeMap = checker.Check(statements);
+
+            using var interpreter = new Interpreter(stdout: stdout, stderr: stderr);
+            interpreter.Interpret(statements, typeMap);
+
+            return (stdout.ToString().Replace("\r\n", "\n"),
+                    stderr.ToString().Replace("\r\n", "\n"),
+                    interpreter.HadUnhandledRejection);
+        });
+
+        Assert.True(task.Wait(TimeSpan.FromSeconds(30)), "interpreter run timed out");
+        return task.Result;
+    }
+
+    private static (string Stdout, string Stderr, bool HadUnhandledRejection) RunModuleCapturingStderr(string source)
+    {
+        var task = Task.Run(() =>
+        {
+            var stdout = new StringWriter();
+            var stderr = new StringWriter();
+
+            // In-memory virtual module fs (same pattern as TestHarness.RunModulesInterpreted);
+            // the GUID base path is never created on disk — it just keys the virtual map.
+            var virtualBase = Path.Combine(Path.GetTempPath(), $"sharpts_vfs_{Guid.NewGuid():N}");
+            var entryPath = Path.GetFullPath(Path.Combine(virtualBase, "main.ts"));
+            var virtualFiles = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                [entryPath] = source,
+            };
+
+            var resolver = new ModuleResolver(entryPath, virtualFiles);
+            var entryModule = resolver.LoadModule(entryPath);
+            var allModules = resolver.GetModulesInOrder(entryModule);
+
+            var checker = new TypeChecker();
+            var typeMap = checker.CheckModules(allModules, resolver);
+
+            using var interpreter = new Interpreter(stdout: stdout, stderr: stderr);
+            interpreter.InterpretModules(allModules, resolver, typeMap);
+
+            return (stdout.ToString().Replace("\r\n", "\n"),
+                    stderr.ToString().Replace("\r\n", "\n"),
+                    interpreter.HadUnhandledRejection);
+        });
+
+        Assert.True(task.Wait(TimeSpan.FromSeconds(30)), "interpreter run timed out");
+        return task.Result;
+    }
+
+    [Fact]
+    public void AsyncTimerCallback_Throw_IsReportedAsUnhandledRejection()
+    {
+        var (stdout, stderr, flagged) = RunCapturingStderr("""
+            setTimeout(async () => {
+                throw new Error("boom from timer");
+            }, 0);
+            console.log("scheduled");
+            """);
+
+        Assert.Contains("scheduled", stdout);
+        Assert.Contains("Unhandled promise rejection", stderr);
+        Assert.Contains("boom from timer", stderr);
+        Assert.True(flagged);
+    }
+
+    [Fact]
+    public void AsyncTimerCallback_ThrowAfterAwait_IsReportedAsUnhandledRejection()
+    {
+        // The #207 shape: the rejection happens after a resume, where it used
+        // to vanish without any output at all.
+        var (_, stderr, flagged) = RunCapturingStderr("""
+            setTimeout(async () => {
+                await Promise.resolve();
+                throw new Error("boom after await");
+            }, 0);
+            """);
+
+        Assert.Contains("Unhandled promise rejection", stderr);
+        Assert.Contains("boom after await", stderr);
+        Assert.True(flagged);
+    }
+
+    [Fact]
+    public void AsyncEventListener_Rejection_IsReportedAsUnhandledRejection()
+    {
+        var (stdout, stderr, flagged) = RunModuleCapturingStderr("""
+            import { EventEmitter } from "events";
+            const emitter = new EventEmitter();
+            emitter.on("tick", async () => {
+                throw new Error("boom from listener");
+            });
+            emitter.emit("tick");
+            console.log("emitted");
+            """);
+
+        Assert.Contains("emitted", stdout);
+        Assert.Contains("Unhandled promise rejection", stderr);
+        Assert.Contains("boom from listener", stderr);
+        Assert.True(flagged);
+    }
+
+    [Fact]
+    public void AsyncTimerCallback_Success_IsNotReported()
+    {
+        var (stdout, stderr, flagged) = RunCapturingStderr("""
+            setTimeout(async () => {
+                await Promise.resolve();
+                console.log("done");
+            }, 0);
+            """);
+
+        Assert.Contains("done", stdout);
+        Assert.DoesNotContain("Unhandled promise rejection", stderr);
+        Assert.False(flagged);
+    }
+
+    [Fact]
+    public void AsyncCallbackWithInternalCatch_IsNotReported()
+    {
+        var (stdout, stderr, flagged) = RunCapturingStderr("""
+            setTimeout(async () => {
+                try {
+                    throw new Error("caught internally");
+                } catch {
+                    console.log("handled");
+                }
+            }, 0);
+            """);
+
+        Assert.Contains("handled", stdout);
+        Assert.DoesNotContain("Unhandled promise rejection", stderr);
+        Assert.False(flagged);
+    }
+}

--- a/SharpTS.Tests/SharedTests/WorkerThreadsTests.cs
+++ b/SharpTS.Tests/SharedTests/WorkerThreadsTests.cs
@@ -293,16 +293,15 @@ public class WorkerThreadsTests
         Assert.Equal("true\ntrue\ntrue\n", output);
     }
 
-    // Interpreter-only: the compiled-mode MessageChannel drops messages
-    // entirely (listener never fires) — tracked separately from #209.
     [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void MessageChannel_PortOnMessage_ReceivesPostedValue(ExecutionMode mode)
     {
-        // #209: port.on() must dispatch through the port's own member table
-        // (postMessage/start/close reachable), a 'message' listener implicitly
-        // starts the port, and the listener receives the cloned value directly
-        // per Node worker_threads semantics.
+        // #209 (interpreter) / #222 (compiled $MessagePort): port.on() must
+        // dispatch through the port's own member table (postMessage/start/
+        // close reachable), a 'message' listener implicitly starts the port,
+        // and the listener receives the cloned value directly per Node
+        // worker_threads semantics.
         var source = @"
             let channel: any = new MessageChannel();
             channel.port2.on('message', (value: any) => {
@@ -314,6 +313,29 @@ public class WorkerThreadsTests
         ";
         var output = TestHarness.Run(source, mode);
         Assert.Contains("received: hello", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void MessageChannel_MessagesPostedBeforeListener_DeliveredInOrderAfterImplicitStart(ExecutionMode mode)
+    {
+        // #222: messages posted before any listener exists must queue and be
+        // delivered (in order) once a 'message' listener implicitly starts
+        // the port.
+        var source = @"
+            let channel: any = new MessageChannel();
+            channel.port1.postMessage('first');
+            channel.port1.postMessage('second');
+            channel.port2.on('message', (value: any) => {
+                console.log('got: ' + value);
+                if (value === 'second') {
+                    channel.port1.close();
+                    channel.port2.close();
+                }
+            });
+        ";
+        var output = TestHarness.Run(source, mode);
+        Assert.Contains("got: first\ngot: second", output);
     }
 
     #endregion


### PR DESCRIPTION
One commit per issue; full suite green after each (10,596 tests at HEAD).

## Fixes

### #238 — interpreter: top-level promise continuations escaped the event loop *(found & filed during this batch)*
`InterpreterSynchronizationContext` was installed only inside `RunEventLoop`, which runs **after** module top-level statements. Async built-ins suspending at top level (e.g. `ThenImpl`) captured a null context, resumed on thread-pool threads, and raced the main thread's ambient environment — spurious `Undefined variable` for a then-callback's own parameter, or silently dropped output. The context is now installed at the start of `Interpret`/`InterpretModules` (restored in `finally`). Two stale comments claiming this already happened are corrected.

### #223 — interpreter: web-streams surfaces returned raw Tasks
`reader.read()/cancel()/closed`, `stream.cancel()/pipeTo()`, writable `abort()/close()`, writer `write()/close()/abort()/ready/closed` all returned raw `Task<object?>` — awaitable, but any `.then()/.catch()` access threw *"Only instances and objects have properties"*. All wrapped in `SharpTSPromise` at the member-dispatch boundary; `closed`/`ready` cache their promise object.

### #228 — interpreter: async-callback rejections silently swallowed
New `Interpreter.ObserveDiscardedCallbackResult`/`InvokeGuestCallback`: built-in invocation sites that discard a guest callback's result (timers, fs/dns/crypto completion callbacks, EventEmitter listeners, http server callbacks) now observe the promise and report a faulted one to stderr (`Unhandled promise rejection: …` + rejection stack), setting `HadUnhandledRejection`; the CLI exits 1 after the loop drains — Node's default behavior. The #207 silent-hang shape (`throw` after `await` in a timer callback) now reports loudly.

### #224 — compiled: AbortSignal/Intl/web-streams globals in value position
- `AbortSignal.abort('r')` signals: `aborted`/`reason`/`onabort` now resolve through dynamically-typed receivers (GetProperty dict-miss dispatch keyed on the `_reasonSet` internal slot).
- Bare `AbortSignal`/`Intl` resolve to lazily-populated namespace singletons (Math/JSON pattern) wrapping the existing helpers.
- Bare `ReadableStream`/`WritableStream`/`TransformStream` emit their pure-IL Type tokens (typeof/alias/instanceof/construction work).
- `new` on dynamic values: new `ConstructDynamicValue` (Type → Activator, callable → NewOnFunction, plain object → TypeError) replaces the silent-null fallback in state-machine emitters; `NewOnFunction` throws TypeError for plain-object callees; `IsConstructor` exempts the `CreateIntl*` factories (constructors per ECMA-402), so `const I = Intl; new I.NumberFormat('en-US')` works.
- `NamespaceGlobalBindingTests` flip to `ExecutionModes.All`.

### #222 — compiled: MessageChannel port messaging delivered nothing
Replaced the Dictionary-with-`new object()`-placeholder channel with real pure-IL `$MessagePort`/`$MessageChannel` types modeled on `$BroadcastChannel`: `$MessagePort` extends the emitted `$EventEmitter` and overrides its `OnListenerAdded` hook for implicit-start-on-'message'; `postMessage` structured-clones to the partner's queue with async $EventLoop delivery (listener receives the value directly, queued messages delivered in order after start); started ports Ref the loop, `close()` Unrefs. Value-position `MessageChannel`/`MessagePort` + instanceof now work too. Tests flip to `ExecutionModes.All` + new queued-before-listener ordering test.

## Advances (not closed)

### #221 — Promise SpeciesConstructor/NewPromiseCapability
Implemented the observable subset available today: `promise.constructor === Promise` holds by identity in **both** modes (ECMA-262 §27.2.5.1). Full species dispatch is unobservable until its prerequisites land — #233 (guest classes cannot extend Promise, so SpeciesConstructor always resolves to %Promise%) and #234 (Symbol not first-class) — per the analysis already recorded on those issues. then/catch/finally continue constructing through %Promise%.

## New issues filed during this batch
- #238 — sync-context gap (fixed here)
- #246 — `instanceof AbortSignal` unreliable: interpreter false-negative, compiled matches ANY plain object (pre-existing, surfaced while testing #224)

Fixes #222. Fixes #223. Fixes #224. Fixes #228. Fixes #238.