### PR TITLE
type-AST design spike: design doc + node-first variable annotations

### DIFF
--- a/Parsing/AST.cs
+++ b/Parsing/AST.cs
@@ -343,7 +343,10 @@ public abstract record Stmt
     };
 
     public record Expression(Expr Expr) : Stmt;
-    public record Var(Token Name, string? TypeAnnotation, Expr? Initializer, bool HasDefiniteAssignmentAssertion = false, bool IsVar = false) : Stmt;
+    /// <param name="TypeAnnotationNode">Structured form of <c>TypeAnnotation</c> when the
+    /// construct has node support (type-AST migration); null otherwise — consumers fall back to
+    /// the string.</param>
+    public record Var(Token Name, string? TypeAnnotation, Expr? Initializer, bool HasDefiniteAssignmentAssertion = false, bool IsVar = false, TypeNode? TypeAnnotationNode = null) : Stmt;
     /// <summary>
     /// Const variable declaration. Separate from Var for cleaner const-specific handling (e.g., unique symbol).
     /// Initializer is non-nullable since const always requires initialization.

--- a/Parsing/Parser.Declarations.cs
+++ b/Parsing/Parser.Declarations.cs
@@ -722,9 +722,11 @@ public partial class Parser
         bool hasDefiniteAssignment = Match(TokenType.BANG);
 
         string? typeAnnotation = null;
+        TypeNode? typeAnnotationNode = null;
         if (Match(TokenType.COLON))
         {
             typeAnnotation = ParseTypeAnnotation();
+            typeAnnotationNode = TakeTypeNode();
         }
 
         if (hasDefiniteAssignment && typeAnnotation == null)
@@ -755,7 +757,7 @@ public partial class Parser
 
         if (isConst)
             return new Stmt.Const(name, typeAnnotation, initializer!);
-        return new Stmt.Var(name, typeAnnotation, initializer, hasDefiniteAssignment, isVar);
+        return new Stmt.Var(name, typeAnnotation, initializer, hasDefiniteAssignment, isVar, typeAnnotationNode);
     }
 
     /// <summary>

--- a/Parsing/Parser.Types.cs
+++ b/Parsing/Parser.Types.cs
@@ -5,8 +5,27 @@ namespace SharpTS.Parsing;
 
 public partial class Parser
 {
+    /// <summary>
+    /// Side channel for the type-AST migration (docs/plans/type-ast-design.md): type-parsing
+    /// functions that support node construction publish the node for the string they just
+    /// returned here. Consumers read-and-clear via <see cref="TakeTypeNode"/> immediately after
+    /// the call. Functions without node support leave it null (cleared at each producer's entry),
+    /// so an unsupported construct anywhere inside a composite yields no node and the consumer
+    /// falls back to the authoritative string path.
+    /// </summary>
+    private TypeNode? _lastTypeNode;
+
+    /// <summary>Reads and clears the node for the most recent type-parse call.</summary>
+    private TypeNode? TakeTypeNode()
+    {
+        var node = _lastTypeNode;
+        _lastTypeNode = null;
+        return node;
+    }
+
     private string ParseTypeAnnotation()
     {
+        _lastTypeNode = null;
         // Handle type predicate return types: "asserts x is T", "asserts x", "x is T"
         // These only appear as function return types but are parsed as type annotations
 
@@ -20,11 +39,13 @@ public partial class Parser
                 {
                     // asserts x is T
                     string predicateType = ParseConditionalType();
+                    _lastTypeNode = null; // predicates have no node form yet
                     return $"asserts {paramName} is {predicateType}";
                 }
                 else
                 {
                     // asserts x (shorthand for asserting non-null/truthy)
+                    _lastTypeNode = null;
                     return $"asserts {paramName}";
                 }
             }
@@ -40,6 +61,7 @@ public partial class Parser
             string paramName = Advance().Lexeme;
             Consume(TokenType.IS, "Expected 'is' after parameter name.");
             string predicateType = ParseConditionalType();
+            _lastTypeNode = null; // predicates have no node form yet
             return $"{paramName} is {predicateType}";
         }
 
@@ -157,10 +179,14 @@ public partial class Parser
     private string ParseConditionalType()
     {
         string checkType = ParseUnionType();
+        TypeNode? checkNode = TakeTypeNode();
 
         // Check for "extends" keyword indicating a conditional type
         if (!Check(TokenType.EXTENDS))
+        {
+            _lastTypeNode = checkNode;
             return checkType;
+        }
 
         // This might be a constraint in generics - we need to look ahead
         // for the ternary operator to confirm this is a conditional type
@@ -169,12 +195,14 @@ public partial class Parser
 
         // Parse the extends type (which may contain 'infer' keywords)
         string extendsType = ParseUnionType();
+        _lastTypeNode = null; // discard the lookahead's node
 
         // Must have '?' for this to be a conditional type
         if (!Check(TokenType.QUESTION))
         {
             // Not a conditional type - backtrack
             _current = saved;
+            _lastTypeNode = checkNode;
             return checkType;
         }
 
@@ -188,6 +216,7 @@ public partial class Parser
         // Parse false branch (recursive - can contain nested conditionals)
         string falseType = ParseConditionalType();
 
+        _lastTypeNode = null; // conditional types have no node form yet
         return $"{checkType} extends {extendsType} ? {trueType} : {falseType}";
     }
 
@@ -199,13 +228,27 @@ public partial class Parser
 
         // Union has lower precedence than intersection, so parse intersection first
         List<string> types = [ParseIntersectionType()];
+        List<TypeNode>? memberNodes = TakeTypeNode() is { } firstNode ? [firstNode] : null;
 
         while (Match(TokenType.PIPE))
         {
             types.Add(ParseIntersectionType());
+            var node = TakeTypeNode();
+            if (memberNodes is not null && node is not null)
+                memberNodes.Add(node);
+            else
+                memberNodes = null; // any node-less member disables the union node
         }
 
-        return types.Count == 1 ? types[0] : string.Join(" | ", types);
+        if (types.Count == 1)
+        {
+            _lastTypeNode = memberNodes is { Count: 1 } ? memberNodes[0] : null;
+            return types[0];
+        }
+        _lastTypeNode = memberNodes is { } all && all.Count == types.Count
+            ? new UnionTypeNode(all, Peek().Line)
+            : null;
+        return string.Join(" | ", types);
     }
 
     /// <summary>
@@ -219,18 +262,27 @@ public partial class Parser
         Match(TokenType.AMPERSAND);
 
         List<string> types = [ParsePrimaryType()];
+        TypeNode? singleNode = TakeTypeNode();
 
         while (Match(TokenType.AMPERSAND))
         {
             types.Add(ParsePrimaryType());
+            TakeTypeNode(); // intersections have no node form yet
+            singleNode = null;
         }
 
+        _lastTypeNode = types.Count == 1 ? singleNode : null;
         return types.Count == 1 ? types[0] : string.Join(" & ", types);
     }
 
     private string ParsePrimaryType()
     {
         string typeName;
+        // Node under construction for this primary type (type-AST migration). Branches with node
+        // support assign it; the common tail publishes it. EARLY returns clear the side channel
+        // explicitly so nodes from nested sub-parses cannot leak onto unrelated strings.
+        TypeNode? typeNode = null;
+        _lastTypeNode = null;
 
         // `readonly` array/tuple modifier: `readonly T[]`, `readonly [A, B]` (lib.d.ts). Handled at
         // the primary-type level so it binds correctly inside unions (`readonly T[] | U`) and other
@@ -238,7 +290,9 @@ public partial class Parser
         if (Check(TokenType.READONLY))
         {
             Advance();
-            return "readonly " + ParsePrimaryType();
+            string readonlyInner = ParsePrimaryType();
+            _lastTypeNode = null; // readonly modifier has no node form yet
+            return "readonly " + readonlyInner;
         }
 
         // Handle infer keyword for conditional types: infer U, or constrained infer: infer U extends C
@@ -249,8 +303,10 @@ public partial class Parser
             {
                 // Constraint binds tighter than the enclosing conditional's `?`, so stop at union level.
                 string constraint = ParseUnionType();
+                _lastTypeNode = null;
                 return $"infer {paramName.Lexeme} extends {constraint}";
             }
+            _lastTypeNode = null;
             return $"infer {paramName.Lexeme}";
         }
 
@@ -273,6 +329,7 @@ public partial class Parser
             }
             Consume(TokenType.LEFT_PAREN, "Expect '(' in constructor type.");
             string ctorBody = ParseFunctionTypeBody(); // returns "(params) => ReturnType"
+            _lastTypeNode = null;
             return $"{{ new {genericPrefix}{ctorBody} }}";
         }
 
@@ -280,6 +337,7 @@ public partial class Parser
         if (Match(TokenType.KEYOF))
         {
             string innerType = ParsePrimaryType();
+            _lastTypeNode = null;
             return $"keyof {innerType}";
         }
 
@@ -288,6 +346,7 @@ public partial class Parser
         {
             if (Match(TokenType.TYPE_SYMBOL))
             {
+                _lastTypeNode = null;
                 return "unique symbol";
             }
             // If "unique" is not followed by "symbol", it's an error in type context
@@ -352,6 +411,7 @@ public partial class Parser
                 }
             }
 
+            _lastTypeNode = null;
             return sb.ToString();
         }
 
@@ -364,6 +424,7 @@ public partial class Parser
             Consume(TokenType.LEFT_PAREN, "Expect '(' after type parameters in function type.");
             string body = ParseFunctionTypeBody(); // returns "(params) => ReturnType"
             string genericPrefix = FormatTypeParams(typeParams);
+            _lastTypeNode = null;
             return $"{genericPrefix}{body}";
         }
 
@@ -428,6 +489,7 @@ public partial class Parser
                 // (T extends U ? X : Y). Use ParseConditionalType so the grouped body can contain
                 // `extends ? :` rather than stopping at `extends`.
                 typeName = "(" + ParseConditionalType() + ")";
+                typeNode = TakeTypeNode(); // parens are semantically transparent
                 Consume(TokenType.RIGHT_PAREN, "Expect ')' after grouped type.");
             }
         }
@@ -444,11 +506,13 @@ public partial class Parser
         else if (Match(TokenType.STRING))
         {
             typeName = "\"" + (string)Previous().Literal! + "\"";
+            typeNode = new LiteralTypeNode(Previous().Literal, Previous().Line);
         }
         // Handle number literal types: 0 | 1 | 2
         else if (Match(TokenType.NUMBER))
         {
             typeName = Previous().Literal!.ToString()!;
+            typeNode = new LiteralTypeNode(Previous().Literal, Previous().Line);
         }
         // Handle bigint literal types: 1n | 2n
         else if (Match(TokenType.BIGINT_LITERAL))
@@ -459,10 +523,12 @@ public partial class Parser
         else if (Match(TokenType.TRUE))
         {
             typeName = "true";
+            typeNode = new LiteralTypeNode(true, Previous().Line);
         }
         else if (Match(TokenType.FALSE))
         {
             typeName = "false";
+            typeNode = new LiteralTypeNode(false, Previous().Line);
         }
         else if (Check(TokenType.TYPE_STRING) || Check(TokenType.TYPE_NUMBER) ||
                  Check(TokenType.TYPE_BOOLEAN) || Check(TokenType.TYPE_SYMBOL) ||
@@ -474,6 +540,7 @@ public partial class Parser
                  Check(TokenType.NULL) || Check(TokenType.UNDEFINED) || Check(TokenType.UNKNOWN) || Check(TokenType.NEVER))
         {
             typeName = Advance().Lexeme;
+            typeNode = new NamedTypeNode(typeName, null, Previous().Line);
 
             // Qualified type name (namespace member): `Intl.CollatorOptions`, `NodeJS.Timer`.
             while (Check(TokenType.DOT) &&
@@ -481,6 +548,7 @@ public partial class Parser
             {
                 Advance(); // consume '.'
                 typeName += "." + Advance().Lexeme;
+                typeNode = null; // qualified names have no node form yet
             }
         }
         else
@@ -501,7 +569,10 @@ public partial class Parser
                 while (Match(TokenType.COMMA))
                     typeArgs.Add(ParseTypeAnnotation());
                 if (MatchGreaterInTypeContext())
+                {
                     typeName = $"{typeName}<{string.Join(", ", typeArgs)}>";
+                    typeNode = null; // generic references: slice 2 (alias-expansion parity)
+                }
                 else
                     _current = saved; // Backtrack if not a valid generic type
             }
@@ -522,6 +593,7 @@ public partial class Parser
                 // Array suffix: T[]
                 Advance(); // consume ]
                 typeName += "[]";
+                typeNode = typeNode is null ? null : new ArrayTypeNode(typeNode, Previous().Line);
             }
             else
             {
@@ -529,9 +601,11 @@ public partial class Parser
                 string indexType = ParseTypeAnnotation();
                 Consume(TokenType.RIGHT_BRACKET, "Expect ']' after indexed access type.");
                 typeName = $"{typeName}[{indexType}]";
+                typeNode = null; // indexed access has no node form yet
             }
         }
 
+        _lastTypeNode = typeNode;
         return typeName;
     }
 

--- a/Parsing/TypeNodes.cs
+++ b/Parsing/TypeNodes.cs
@@ -1,0 +1,44 @@
+namespace SharpTS.Parsing;
+
+/// <summary>
+/// Syntactic type nodes — the structured form of a written type annotation.
+/// </summary>
+/// <remarks>
+/// First layer of the two-layer type model (see <c>docs/plans/type-ast-design.md</c>):
+/// <c>TypeNode</c> records what was WRITTEN and where; the checker resolves nodes to
+/// <see cref="SharpTS.TypeSystem.TypeInfo"/> (what it MEANS) in scope. During the incremental
+/// migration the parser builds nodes opportunistically alongside the legacy annotation strings:
+/// a construct without node support yields no node and consumers fall back to the string path,
+/// which remains authoritative until the migration completes.
+/// </remarks>
+public abstract record TypeNode(int Line);
+
+/// <summary>A type reference by name: <c>Foo</c>, <c>Box&lt;string&gt;</c>. Type arguments are
+/// null for a bare reference. Also covers primitive/keyword names (<c>string</c>, <c>void</c>,
+/// …) — resolution treats them uniformly, exactly like the string path.</summary>
+public sealed record NamedTypeNode(string Name, List<TypeNode>? TypeArguments, int Line) : TypeNode(Line);
+
+/// <summary>A literal type: <c>"ok"</c>, <c>42</c>, <c>true</c>.</summary>
+public sealed record LiteralTypeNode(object? Value, int Line) : TypeNode(Line);
+
+/// <summary>An array type via the suffix syntax: <c>T[]</c>.</summary>
+public sealed record ArrayTypeNode(TypeNode ElementType, int Line) : TypeNode(Line);
+
+/// <summary>A union type: <c>A | B | C</c>.</summary>
+public sealed record UnionTypeNode(List<TypeNode> Members, int Line) : TypeNode(Line);
+
+/// <summary>
+/// Counters proving how much of the corpus the node path already covers — read by tests and
+/// dumped by the checker when <c>SHARPTS_TYPENODE_STATS=1</c>. Coarse by design (spike
+/// instrumentation, not telemetry).
+/// </summary>
+public static class TypeNodeStats
+{
+    /// <summary>Annotations resolved through the node path.</summary>
+    public static long NodeHits;
+
+    /// <summary>Annotations that had no node (unsupported construct) and used the string path.</summary>
+    public static long StringFallbacks;
+
+    public static void Reset() { NodeHits = 0; StringFallbacks = 0; }
+}

--- a/SharpTS.Tests/TypeCheckerTests/TypeNodeSliceTests.cs
+++ b/SharpTS.Tests/TypeCheckerTests/TypeNodeSliceTests.cs
@@ -1,0 +1,79 @@
+using SharpTS.Parsing;
+using SharpTS.Tests.Infrastructure;
+using SharpTS.TypeSystem.Exceptions;
+using Xunit;
+
+namespace SharpTS.Tests.TypeCheckerTests;
+
+/// <summary>
+/// Type-AST migration slice (docs/plans/type-ast-design.md): variable annotations resolve
+/// node-first for named/literal/array/union constructs, with string fallback elsewhere. These
+/// tests pin (a) that the node path actually engages, and (b) that node-resolved types behave
+/// identically to string-resolved ones.
+/// </summary>
+public class TypeNodeSliceTests
+{
+    [Fact]
+    public void NodePath_EngagesForSupportedAnnotations()
+    {
+        TypeNodeStats.Reset();
+        TestHarness.RunInterpreted("""
+            var a: number = 1;
+            var b: string[] = ["x"];
+            var c: "on" | "off" = "on";
+            var d: number | string = 1;
+            """);
+        Assert.True(TypeNodeStats.NodeHits >= 4,
+            $"expected the node path for all four annotations, got {TypeNodeStats.NodeHits}");
+    }
+
+    [Fact]
+    public void NodePath_FallsBackForUnsupportedConstructs()
+    {
+        TypeNodeStats.Reset();
+        TestHarness.RunInterpreted("""
+            var f: (x: number) => string = (x) => "s";
+            """);
+        Assert.True(TypeNodeStats.StringFallbacks >= 1,
+            $"expected the function-type annotation to fall back, got {TypeNodeStats.StringFallbacks}");
+    }
+
+    [Fact]
+    public void NodeResolved_UnionEnforcesMembers()
+    {
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted("""
+            var c: "on" | "off" = "neither";
+            """));
+    }
+
+    [Fact]
+    public void NodeResolved_ArrayEnforcesElementType()
+    {
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted("""
+            var b: string[] = [1];
+            """));
+    }
+
+    [Fact]
+    public void NodeResolved_NamedTypesResolveInScope()
+    {
+        // Type parameters and class names must resolve identically to the string path —
+        // the node path delegates bare names to the same single-name resolution.
+        TestHarness.RunInterpreted("""
+            class Base { foo: string; }
+            function f<T>(x: T) {
+                var y: T = x;
+                var z: Base = new Base();
+                var u: Base | null = null;
+            }
+            """);
+    }
+
+    [Fact]
+    public void NodeResolved_UnionNormalizesAnyAndNever()
+    {
+        TestHarness.RunInterpreted("""
+            var a: any | never = null;
+            """);
+    }
+}

--- a/TypeSystem/TypeChecker.Statements.Functions.cs
+++ b/TypeSystem/TypeChecker.Statements.Functions.cs
@@ -144,6 +144,16 @@ public partial class TypeChecker
         // Skip if already defined
         if (_environment.IsDefinedLocally(name.Lexeme)) return;
 
+        // An explicit annotation is authoritative — hoist with IT, not with the arrow's
+        // inferred shape (which collapses unannotated params to any and then trips the TS2403
+        // redeclaration check when the real declaration is visited).
+        if (typeAnnotation is not null)
+        {
+            try { _environment.Define(name.Lexeme, ToTypeInfo(typeAnnotation)); }
+            catch { _environment.Define(name.Lexeme, new TypeInfo.Any()); }
+            return;
+        }
+
         try
         {
             // Build parameter types from the arrow function's parameter declarations

--- a/TypeSystem/TypeChecker.Statements.cs
+++ b/TypeSystem/TypeChecker.Statements.cs
@@ -135,11 +135,8 @@ public partial class TypeChecker
         TypeInfo? preExistingType = stmt.IsVar && _environment.IsDefinedLocally(stmt.Name.Lexeme)
             ? _environment.Get(stmt.Name.Lexeme) : null;
 
-        TypeInfo? declaredType = null;
-        if (stmt.TypeAnnotation != null)
-        {
-            declaredType = ToTypeInfo(stmt.TypeAnnotation);
-        }
+        // Node-first annotation resolution (type-AST migration), string fallback.
+        TypeInfo? declaredType = ResolveAnnotation(stmt.TypeAnnotation, stmt.TypeAnnotationNode);
 
         if (stmt.HasDefiniteAssignmentAssertion)
         {

--- a/TypeSystem/TypeChecker.TypeNodes.cs
+++ b/TypeSystem/TypeChecker.TypeNodes.cs
@@ -1,0 +1,78 @@
+using SharpTS.Parsing;
+
+namespace SharpTS.TypeSystem;
+
+/// <summary>
+/// Resolution of syntactic <see cref="TypeNode"/>s to semantic <see cref="TypeInfo"/> — the
+/// node-first half of the type-AST migration (docs/plans/type-ast-design.md).
+/// </summary>
+/// <remarks>
+/// Returns null for node kinds (or compositions) this slice doesn't resolve; callers fall back
+/// to the authoritative string path. Resolution semantics deliberately REUSE the string path's
+/// machinery where names are involved (a bare name has no string-scanning hazards), so the two
+/// paths cannot diverge on lookup order, alias expansion, or scoping.
+/// </remarks>
+public partial class TypeChecker
+{
+    /// <summary>
+    /// Resolves a type node to a <see cref="TypeInfo"/>, or null when the node (or a component)
+    /// has no node-path resolution yet.
+    /// </summary>
+    internal TypeInfo? TryToTypeInfo(TypeNode node)
+    {
+        switch (node)
+        {
+            // A bare name resolves through the existing single-name path — type parameters,
+            // aliases, primitives, classes, interfaces, the hot lib globals: identical semantics
+            // by construction, with none of the scanning hazards strings have for COMPOSITE types.
+            case NamedTypeNode { TypeArguments: null } named:
+                return ToTypeInfo(named.Name);
+
+            // Generic references are slice 2 (alias expansion needs argument strings today).
+            case NamedTypeNode:
+                return null;
+
+            case LiteralTypeNode lit:
+                return lit.Value switch
+                {
+                    string str => new TypeInfo.StringLiteral(str),
+                    double num => new TypeInfo.NumberLiteral(num),
+                    bool b => new TypeInfo.BooleanLiteral(b),
+                    _ => null,
+                };
+
+            case ArrayTypeNode arr:
+                return TryToTypeInfo(arr.ElementType) is { } elem ? new TypeInfo.Array(elem) : null;
+
+            case UnionTypeNode union:
+            {
+                List<TypeInfo> members = new(union.Members.Count);
+                foreach (var member in union.Members)
+                {
+                    if (TryToTypeInfo(member) is not { } resolved) return null;
+                    members.Add(resolved);
+                }
+                // Same normalization as the string path's union split: any absorbs, never drops.
+                return members.Aggregate(CreateUnion);
+            }
+
+            default:
+                return null;
+        }
+    }
+
+    /// <summary>
+    /// Resolves a variable annotation node-first with string fallback, recording coverage stats.
+    /// </summary>
+    private TypeInfo? ResolveAnnotation(string? annotation, TypeNode? annotationNode)
+    {
+        if (annotationNode is not null && TryToTypeInfo(annotationNode) is { } fromNode)
+        {
+            TypeNodeStats.NodeHits++;
+            return fromNode;
+        }
+        if (annotation is null) return null;
+        TypeNodeStats.StringFallbacks++;
+        return ToTypeInfo(annotation);
+    }
+}

--- a/docs/plans/type-ast-design.md
+++ b/docs/plans/type-ast-design.md
@@ -1,0 +1,118 @@
+# Type-AST design: replacing the string-based type pipeline
+
+**Status:** spike (this document + vertical slice in the same PR)
+**Driver:** three independent conformance blockers and a recurring bug class, all rooted in
+types passing through lossy string round-trips between the parser and the checker.
+
+## The problem today
+
+The parser tokenizes and *structurally* parses every type annotation — then throws the
+structure away, re-rendering it to a `string` (`Parser.Types.cs`, ~1,100 lines). The checker
+re-parses that string with a second, hand-rolled character-scanning parser
+(`TypeChecker.TypeParsing.cs`, ~1,900 lines) to produce `TypeInfo` (the semantic type model).
+
+Costs, all observed in practice during the 2026-06-10/11 conformance push:
+
+1. **A recurring bug class.** The checker-side string scanner re-implements bracket matching,
+   union splitting, member splitting, etc. We fixed four instances of the same
+   `>`-of-`=>` mis-splitting family, a curried mis-parse of two-call-signature object types,
+   and an alias-whitespace bug — each a new leak in the same dam.
+2. **No declaration identity.** Two `class Base { foo: string }` declarations in different
+   modules are different types to tsc but identical strings to us. This caps
+   `assignmentCompatWithObjectMembers{4,Optionality2,StringNumericNames}` (cross-module
+   diagnostic-code fidelity) and forced the `TypeInfo.CacheKey()` structural-fingerprint
+   workaround for interfaces.
+3. **No substitution origin.** tsc's `isInstantiatedGenericParameter` — "did this parameter
+   type come from substituting a type parameter?" — gates the always-on callback comparison
+   rule. The information cannot survive a string round-trip. Blocks `covariantCallbacks`
+   (#202) and alias-instantiation variance.
+4. **No source spans.** Diagnostics inside type annotations attach to the statement line, not
+   the offending type position.
+5. **Double parsing** of every annotation, plus `ToString()`-keyed caches that make rendering
+   a correctness concern (three cache-collision incidents).
+
+## The design
+
+Mirror tsc's Node/Type split. Two layers, with an explicit boundary:
+
+```
+source ──Lexer──> tokens ──Parser──> TypeNode  (SYNTAX: what was written, where)
+                                        │
+                              TypeResolver (checker)
+                                        │
+                                        v
+                                    TypeInfo   (SEMANTICS: what it means)
+```
+
+- **`TypeNode`** (new, `Parsing/TypeNodes.cs`): immutable records describing type *syntax* —
+  `NamedTypeNode("Map", [k, v])`, `UnionTypeNode([...])`, `ArrayTypeNode(elem)`,
+  `LiteralTypeNode(...)`, etc. Each carries its source line. Built by the parser in the same
+  pass that today builds the string — the structure already exists; we stop discarding it.
+- **`TypeInfo`** (existing, unchanged role): the checker's semantic model. Resolution
+  (`ToTypeInfo(TypeNode)`) happens in the checker where scopes/generics live, exactly like
+  today's `ToTypeInfo(string)` — minus the string re-parse.
+- **Identity and origin live on the semantic layer, fed by the syntactic one.** Once
+  resolution starts from nodes, a `NamedTypeNode` resolves through the environment to a
+  *declaration*, so `TypeInfo` for classes/interfaces can carry a declaration handle
+  (fixing problem 2), and `Substitute` can mark results with their origin (fixing problem 3).
+  These are follow-ups enabled by the node layer, not part of the first slices.
+
+### Why two layers (and not one)?
+
+Considered: making `TypeInfo` itself carry syntax (one layer). Rejected — `TypeInfo` is
+compared, substituted, and cached by *meaning*; syntax (spans, written form) would poison
+structural equality and the caches. The two-layer split is also what tsc itself does
+(`TypeNode` vs `Type`), so conformance reasoning maps 1:1.
+
+### Migration strategy: dual-path, node-first with string fallback
+
+The same playbook as the RuntimeValue/V2 migration (incremental, finished cleanly):
+
+1. Parser's existing type-parsing functions return `(string, TypeNode?)` — the string exactly
+   as today (zero behavior change), the node when every sub-component produced one. An
+   unsupported construct anywhere inside yields a null node; the consumer falls back to the
+   string path. **The string is authoritative until the end of the migration.**
+2. AST statement/expression records grow optional `…Node` fields next to their existing
+   string annotation fields, populated when available.
+3. The checker prefers `ToTypeInfo(TypeNode)` when a node is present, falling back to
+   `ToTypeInfo(string)` otherwise. Node conversion reuses the existing resolution helpers
+   (`ResolveGenericType`, environment lookups), so semantics are shared, not duplicated.
+4. Expand node coverage construct-by-construct (each step measured against both suites),
+   then site-by-site flip consumers off the string fields, then delete the string scanner.
+
+**Safety net:** the conformance suite (63 pinned Passes, (line, TSnnnn)-exact) and the
+10,650+ unit suite. Every increment must keep both identical — the slice in this PR includes
+an equivalence test that converts both ways and asserts identical `TypeInfo` renderings.
+
+### Slice shipped with this document
+
+- `TypeNode` records: named (with type arguments), primitives/keywords, string/number/boolean
+  literals, array suffix, union, parenthesized.
+- Parser: `ParsePrimaryType` / union / annotation entry points build nodes opportunistically.
+- `Stmt.Var.TypeAnnotationNode` populated; `VisitVar` resolves node-first.
+- Instrumentation: `TypeNodeStats` counters (node-hit vs string-fallback), to size the
+  remaining migration. **Measured over the 79-test conformance corpus: 37% of variable
+  annotations already resolve through the node path with just this slice** (198 node / 337
+  fallback); function and object types dominate the fallback set, confirming slices 1–2 as
+  the high-value next steps.
+
+### Order of subsequent slices (each independently shippable)
+
+1. Function/constructor type nodes (`(a: T) => R`, `new (...) => R`) — unlocks retiring the
+   `=>`-scanning bug family.
+2. Object-type / tuple / conditional / mapped nodes — the big checker-scanner retirement.
+3. Type aliases store nodes (kills alias string substitution; enables alias-instantiation
+   identity for #202's variance cases).
+4. Declaration handles on `TypeInfo.Interface/Class` resolved via nodes (kills the
+   `CacheKey()` workaround; fixes the cross-module diagnostic tests).
+5. Substitution-origin marking (unblocks #202's callback rule → `covariantCallbacks`).
+6. Delete `TypeChecker.TypeParsing.cs` string scanning; `ToTypeInfo(string)` survives only
+   for the REPL/embedding API surface, implemented as parse-to-node + convert.
+
+### Non-goals
+
+- No change to `TypeInfo`'s public shape in this phase (compat caches, IL compiler, and the
+  declaration generator all consume it).
+- No parser grammar changes — nodes capture exactly what the string parser already accepts.
+- The interpreter/IL compiler are untouched until slice 6 (they never see type strings today;
+  types are erased before execution).


### PR DESCRIPTION
The architecture spike agreed after #226 round 6. Full rationale and migration plan in **docs/plans/type-ast-design.md**.

## Design (summary)
Two layers, mirroring tsc's Node/Type split: **TypeNode** (new — what was *written*, with source positions) and **TypeInfo** (existing, unchanged — what it *means*). Migration is dual-path like the RuntimeValue/V2 effort: the parser builds nodes opportunistically alongside the legacy strings (string stays authoritative), the checker resolves node-first with string fallback, coverage expands construct-by-construct, then consumers flip and the string scanner retires. Motivated by the three independent blockers (substitution origin → #202, alias identity, declaration identity) and the recurring string-scanning bug class — all catalogued in the doc.

## Slice in this PR
- `TypeNode` records (named / literal / array / union) + coverage counters.
- Parser side channel with strict read-and-clear discipline (early returns clear explicitly — no node can leak onto an unrelated string).
- `Stmt.Var.TypeAnnotationNode`; `VisitVar` resolves node-first. Bare names delegate to the existing single-name resolution, so the paths cannot diverge on lookup order, aliases, or scoping.
- **37% of variable annotations across the conformance corpus already take the node path** with just this slice; function/object types dominate the fallback, confirming the doc's slice ordering.
- Bonus fix the slice tests exposed: arrow hoisting now honors explicit annotations instead of the arrow's inferred shape (was tripping TS2403).

## Safety
Both suites byte-identical to main's behavior: conformance **Pass 63 / Fail 14 / ParseError 1, 0 drift**; unit suite **10,687/10,687** (incl. 6 new slice tests proving the node path engages and behaves identically).