### PR TITLE
Symbol.prototype surface (#237) + Promise subclassing in both modes (#242)

### DIFF
--- a/Compilation/CallHandlers/GlobalFunctionHandler.cs
+++ b/Compilation/CallHandlers/GlobalFunctionHandler.cs
@@ -130,9 +130,13 @@ public class GlobalFunctionHandler : ICallHandler
         }
         else
         {
+            // StringFromValue (not Stringify): runs the spec ToString chain —
+            // user toString/@@toPrimitive on objects — with the §22.1.1.1
+            // Symbol exemption. Keeps this path consistent with the sync
+            // emitter's String(x) handling in ILEmitter.Calls.cs.
             emitter.EmitExpression(call.Arguments[0]);
             emitter.EmitBoxIfNeeded(call.Arguments[0]);
-            il.Emit(System.Reflection.Emit.OpCodes.Call, ctx.Runtime!.Stringify);
+            il.Emit(System.Reflection.Emit.OpCodes.Call, ctx.Runtime!.StringFromValueMethod);
         }
         emitter.SetStackType(StackType.String);
         return true;

--- a/Compilation/CallHandlers/SuperConstructorHandler.cs
+++ b/Compilation/CallHandlers/SuperConstructorHandler.cs
@@ -50,6 +50,15 @@ public class SuperConstructorHandler : ICallHandler
             return true;
         }
 
+        // Built-in Promise (#242): run the executor through
+        // PromiseFromExecutor and chain the resulting Task<object?> to
+        // $Promise's constructor.
+        if (ctx.CurrentSuperclassName == "Promise" && ctx.Runtime?.TSPromiseCtor != null)
+        {
+            EmitSuperPromiseCtorCall(emitter, call.Arguments);
+            return true;
+        }
+
         // Try class expression constructors
         if (ctx.CurrentClassExpr != null &&
             ctx.ClassExprSuperclass?.TryGetValue(ctx.CurrentClassExpr, out var superclassName) == true &&
@@ -173,6 +182,35 @@ public class SuperConstructorHandler : ICallHandler
             il.Emit(OpCodes.Stelem_Ref);
         }
         il.Emit(OpCodes.Call, ctx.Runtime!.TSArrayCtorFromCtorArgs);
+
+        il.Emit(OpCodes.Ldnull); // super() returns undefined
+        emitter.SetStackUnknown();
+    }
+
+    /// <summary>
+    /// Emits a super(executor) call that chains to $Promise's constructor:
+    /// PromiseFromExecutor(executor) produces the Task&lt;object?&gt; the base
+    /// wraps. PromiseFromExecutor also adopts a raw Task passed in place of
+    /// an executor — that's how derived-promise construction (inherited
+    /// statics, subclass-typed then results) reuses this same constructor.
+    /// </summary>
+    private static void EmitSuperPromiseCtorCall(IEmitterContext emitter, List<Expr> arguments)
+    {
+        var il = emitter.IL;
+        var ctx = emitter.Context;
+
+        il.Emit(OpCodes.Ldarg_0); // this
+        if (arguments.Count > 0)
+        {
+            emitter.EmitExpression(arguments[0]);
+            emitter.EmitBoxIfNeeded(arguments[0]);
+        }
+        else
+        {
+            il.Emit(OpCodes.Ldnull);
+        }
+        il.Emit(OpCodes.Call, ctx.Runtime!.PromiseFromExecutor);
+        il.Emit(OpCodes.Call, ctx.Runtime!.TSPromiseCtor);
 
         il.Emit(OpCodes.Ldnull); // super() returns undefined
         emitter.SetStackUnknown();

--- a/Compilation/EmittedRuntime.cs
+++ b/Compilation/EmittedRuntime.cs
@@ -811,6 +811,12 @@ public class EmittedRuntime
     public MethodBuilder PromiseAny { get; set; } = null!;
     public MethodBuilder PromiseFromExecutor { get; set; } = null!;
     public MethodBuilder PromiseWithResolvers { get; set; } = null!;
+    /// <summary>$Runtime.UnwrapPromiseReceiver(object) -> Task&lt;object?&gt; — $Promise (incl. #242 subclasses) → .Task; anything else is cast to Task&lt;object?&gt;. Used by then/catch/finally emission so promise-typed receivers work regardless of representation.</summary>
+    public MethodBuilder UnwrapPromiseReceiverMethod { get; set; } = null!;
+    /// <summary>$Runtime.NormalizePromiseList(object) -> object — when the arg is a List&lt;object?&gt;, returns a copy with $Promise elements (incl. #242 subclasses) replaced by their wrapped Task so the combinator state machines (which only test for Task&lt;object?&gt;) await them; non-list args pass through. Applied at every combinator entry.</summary>
+    public MethodBuilder NormalizePromiseListMethod { get; set; } = null!;
+    /// <summary>$Runtime.WrapDerivedPromiseResult(Task&lt;object?&gt; result, object receiver) -> object — when the receiver is a $Promise SUBCLASS (#242), constructs a receiver-typed promise around the result task via the subclass's (object executor) constructor (PromiseFromExecutor adopts the task); otherwise returns the task unchanged. The species-lite step for subclass then/catch/finally results.</summary>
+    public MethodBuilder WrapDerivedPromiseResultMethod { get; set; } = null!;
     public TypeBuilder PromiseResolveCallbackType { get; set; } = null!;
     public ConstructorBuilder PromiseResolveCallbackCtor { get; set; } = null!;
     public MethodBuilder PromiseResolveCallbackInvoke { get; set; } = null!;

--- a/Compilation/EmittedRuntime.cs
+++ b/Compilation/EmittedRuntime.cs
@@ -119,6 +119,8 @@ public class EmittedRuntime
     // Type coercion methods
     public MethodBuilder Stringify { get; set; } = null!;
     public MethodBuilder ToJsString { get; set; } = null!;
+    /// <summary>$Runtime.StringFromValue(object) -> string — ECMA-262 §22.1.1.1 String(value) call form: Symbol → SymbolDescriptiveString (via $TSSymbol.ToString()); everything else → ToJsString. Only the String() constructor-call form is exempt from ToString's Symbol TypeError; implicit coercions (template literals, concat) must keep throwing.</summary>
+    public MethodBuilder StringFromValueMethod { get; set; } = null!;
     public MethodBuilder ToNumber { get; set; } = null!;
     public MethodBuilder ConvertToNumber { get; set; } = null!;
     public MethodBuilder JsToInt32 { get; set; } = null!;

--- a/Compilation/ExpressionEmitterBase.CallHelpers.cs
+++ b/Compilation/ExpressionEmitterBase.CallHelpers.cs
@@ -551,6 +551,18 @@ public abstract partial class ExpressionEmitterBase
                 SetStackUnknown();
                 return true;
             }
+
+            // Promise subclasses (#242) inherit the Promise static side:
+            // emit the base Promise static (leaves Task<object?> on the
+            // stack), then construct the subclass around it via its executor
+            // constructor — PromiseFromExecutor adopts a raw task, so the
+            // result is a subclass-typed promise (NewPromiseCapability-lite).
+            if (methodGet.Name.Lexeme is "resolve" or "reject" or "all" or "race" or "allSettled" or "any" or "withResolvers"
+                && Ctx.ClassRegistry.IsPromiseSubclass(resolvedClassName)
+                && TryEmitDerivedPromiseStatic(resolvedClassName, classBuilder, methodGet.Name.Lexeme, c.Arguments))
+            {
+                return true;
+            }
         }
 
         // Promise instance methods: promise.then/catch/finally
@@ -1178,11 +1190,69 @@ public abstract partial class ExpressionEmitterBase
         SetStackUnknown();
     }
 
+    /// <summary>
+    /// Emits an inherited Promise static called off a Promise subclass (#242):
+    /// `MyPromise.resolve(v)` → base Promise static produces the Task&lt;object?&gt;,
+    /// then `newobj MyPromise(task)` — the subclass's executor constructor —
+    /// yields the subclass-typed promise (PromiseFromExecutor adopts a raw
+    /// task in place of an executor). Returns false (emitting nothing) when
+    /// the subclass constructor can't accept the task as its first argument.
+    /// </summary>
+    private bool TryEmitDerivedPromiseStatic(string resolvedClassName, Type classBuilder, string methodName, List<Expr> arguments)
+    {
+        if (Ctx.TypeEmitterRegistry?.GetStaticStrategy("Promise") is not { } promiseStatics)
+            return false;
+
+        // withResolvers returns a {promise, resolve, reject} object, not a
+        // task — delegate to the base emitter without subclass wrapping.
+        if (methodName == "withResolvers")
+        {
+            if (!promiseStatics.TryEmitStaticCall(this, methodName, arguments))
+                return false;
+            SetStackUnknown();
+            return true;
+        }
+
+        var subclassCtor = Ctx.ClassRegistry!.GetConstructorByQualifiedName(resolvedClassName);
+        if (subclassCtor == null)
+            return false;
+        var ctorParams = subclassCtor.GetParameters();
+        if (ctorParams.Length == 0 || ctorParams[0].ParameterType != typeof(object))
+            return false;
+
+        if (!promiseStatics.TryEmitStaticCall(this, methodName, arguments))
+            return false;
+
+        // Stack: Task<object?> — the constructor's first (executor) argument.
+        // Generic subclasses (MyPromise<T>) need the constructor token bound
+        // to a constructed instantiation; type args are erased to object.
+        System.Reflection.ConstructorInfo ctorToCall = subclassCtor;
+        if (classBuilder.IsGenericTypeDefinition)
+        {
+            var typeArgs = classBuilder.GetGenericArguments().Select(_ => typeof(object)).ToArray();
+            ctorToCall = TypeBuilder.GetConstructor(classBuilder.MakeGenericType(typeArgs), subclassCtor);
+        }
+
+        for (int i = 1; i < ctorParams.Length; i++)
+            EmitDefaultForType(ctorParams[i].ParameterType);
+
+        IL.Emit(OpCodes.Newobj, ctorToCall);
+        SetStackUnknown();
+        return true;
+    }
+
     protected void EmitPromiseInstanceMethodCall(Expr promise, string methodName, List<Expr> arguments)
     {
+        // Receivers may be raw Task<object?> OR $Promise objects (#242 Promise
+        // subclasses derive from $Promise) — keep the receiver for derived-result
+        // wrapping and unwrap to the task for the PromiseThen/Catch/Finally
+        // state machines.
         EmitExpression(promise);
         EnsureBoxed();
-        IL.Emit(OpCodes.Castclass, typeof(Task<object?>));
+        var promiseReceiverLocal = IL.DeclareLocal(typeof(object));
+        IL.Emit(OpCodes.Stloc, promiseReceiverLocal);
+        IL.Emit(OpCodes.Ldloc, promiseReceiverLocal);
+        IL.Emit(OpCodes.Call, Ctx.Runtime!.UnwrapPromiseReceiverMethod);
 
         switch (methodName)
         {
@@ -1200,6 +1270,10 @@ public abstract partial class ExpressionEmitterBase
                 IL.Emit(OpCodes.Call, Ctx.Runtime!.PromiseFinally);
                 break;
         }
+
+        // Subclass receivers get subclass-typed results (species-lite, #242).
+        IL.Emit(OpCodes.Ldloc, promiseReceiverLocal);
+        IL.Emit(OpCodes.Call, Ctx.Runtime!.WrapDerivedPromiseResultMethod);
         SetStackUnknown();
     }
 

--- a/Compilation/ExpressionEmitterBase.cs
+++ b/Compilation/ExpressionEmitterBase.cs
@@ -1566,6 +1566,18 @@ public abstract partial class ExpressionEmitterBase : IEmitterContext
             return true;
         }
 
+        // User class identifiers used as values: emit the class's Type token
+        // (the same representation ILEmitter's sync path produces) so
+        // `x instanceof MyClass` works inside state-machine bodies. Before
+        // the built-in arms so a user class shadowing a built-in name wins.
+        if (Ctx.Classes.TryGetValue(Ctx.ResolveClassName(name), out var userClassType))
+        {
+            IL.Emit(OpCodes.Ldtoken, userClassType);
+            IL.Emit(OpCodes.Call, Types.GetMethod(Types.Type, "GetTypeFromHandle", Types.RuntimeTypeHandle));
+            SetStackUnknown();
+            return true;
+        }
+
         // Built-in constructor identifiers used as values (#232): without these
         // arms, state-machine bodies (async/generator MoveNext emitters, which
         // don't run ILEmitter's EmitVariable) emit null for `Error`, `Date`,

--- a/Compilation/ILCompiler.Classes.Constructors.cs
+++ b/Compilation/ILCompiler.Classes.Constructors.cs
@@ -33,7 +33,9 @@ public partial class ILCompiler
                 ? ParameterTypeResolver.ResolveConstructorParameters(className, constructor.Parameters, _typeMapper, _typeMap)
                 : _classes.ErrorSubclasses.Contains(className)
                     ? [typeof(object)]  // Accept any value; converted to string by base Error constructor
-                    : [];
+                    : _classes.PromiseSubclasses.Contains(className)
+                        ? [typeof(object)]  // Executor arg, forwarded to PromiseFromExecutor (#242)
+                        : [];
             ctorBuilder = typeBuilder.DefineConstructor(
                 MethodAttributes.Public,
                 CallingConventions.Standard,
@@ -162,6 +164,13 @@ public partial class ILCompiler
         bool isDirectArraySubclass = classStmt.SuperclassExpr != null
             && Expr.GetSuperclassLeafName(classStmt.SuperclassExpr) == "Array"
             && (qualifiedSuperclass == null || !_classes.Builders.ContainsKey(qualifiedSuperclass));
+        // Direct `extends Promise` (#242): base is the emitted $Promise,
+        // chained via PromiseFromExecutor (which also adopts a raw
+        // Task<object?> in place of an executor — the derived-promise
+        // construction path).
+        bool isDirectPromiseSubclass = classStmt.SuperclassExpr != null
+            && Expr.GetSuperclassLeafName(classStmt.SuperclassExpr) == "Promise"
+            && (qualifiedSuperclass == null || !_classes.Builders.ContainsKey(qualifiedSuperclass));
         if (constructor == null && isDirectArraySubclass)
         {
             // No explicit constructor, extends Array — empty array per
@@ -170,6 +179,15 @@ public partial class ILCompiler
             il.Emit(OpCodes.Ldc_I4_0);
             il.Emit(OpCodes.Newarr, typeof(object));
             il.Emit(OpCodes.Call, _runtime.TSArrayCtorFromCtorArgs);
+        }
+        else if (constructor == null && isDirectPromiseSubclass)
+        {
+            // No explicit constructor, extends Promise — implicit
+            // `constructor(executor) { super(executor) }`.
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldarg_1); // executor (object?)
+            il.Emit(OpCodes.Call, _runtime.PromiseFromExecutor);
+            il.Emit(OpCodes.Call, _runtime.TSPromiseCtor);
         }
         else if (constructor == null && qualifiedSuperclass != null && isErrorSubclass)
         {
@@ -202,11 +220,12 @@ public partial class ILCompiler
 
             il.Emit(OpCodes.Call, ctorToCall);
         }
-        else if (!isErrorSubclass && !isDirectArraySubclass)
+        else if (!isErrorSubclass && !isDirectArraySubclass && !isDirectPromiseSubclass)
         {
             // Has explicit constructor (which should have super() call) or no superclass.
-            // For Error/Array subclasses with an explicit constructor, skip this — super()
-            // in the constructor body calls the base constructor via SuperConstructorHandler.
+            // For Error/Array/Promise subclasses with an explicit constructor, skip this —
+            // super() in the constructor body calls the base constructor via
+            // SuperConstructorHandler.
             il.Emit(OpCodes.Ldarg_0);
             il.Emit(OpCodes.Call, _types.ObjectDefaultCtor);
         }

--- a/Compilation/ILCompiler.Classes.Methods.cs
+++ b/Compilation/ILCompiler.Classes.Methods.cs
@@ -323,6 +323,11 @@ public partial class ILCompiler
                     // Error subclass with no constructor — accept a single message arg
                     ctorParamTypes = [typeof(object)];
                 }
+                else if (_classes.PromiseSubclasses.Contains(qualifiedClassName))
+                {
+                    // Promise subclass with no constructor — accept the executor arg (#242)
+                    ctorParamTypes = [typeof(object)];
+                }
                 else
                 {
                     ctorParamTypes = [];

--- a/Compilation/ILCompiler.Classes.cs
+++ b/Compilation/ILCompiler.Classes.cs
@@ -152,8 +152,17 @@ public partial class ILCompiler
             baseType = _runtime.TSArrayType;
         }
         else if (qualifiedSuperclassName != null && classStmt.SuperclassExpr != null
+            && Expr.GetSuperclassLeafName(classStmt.SuperclassExpr) == "Promise")
+        {
+            // `extends Promise` (#242): derive from the emitted $Promise, the
+            // promise object representation (wraps Task<object?>) — await,
+            // then/catch/finally, and instanceof Promise apply to instances
+            // unchanged.
+            baseType = _runtime.TSPromiseType;
+        }
+        else if (qualifiedSuperclassName != null && classStmt.SuperclassExpr != null
             && Expr.GetSuperclassLeafName(classStmt.SuperclassExpr) is
-                "Promise" or "Map" or "Set" or "WeakMap" or "WeakSet" or "Date" or "RegExp" or "Buffer")
+                "Map" or "Set" or "WeakMap" or "WeakSet" or "Date" or "RegExp" or "Buffer")
         {
             // Built-in constructors without a subclassing bridge (#233/#221):
             // fail loudly at compile time rather than silently extending
@@ -183,6 +192,18 @@ public partial class ILCompiler
         else if (qualifiedSuperclassName != null && _classes.ArraySubclasses.Contains(qualifiedSuperclassName))
         {
             _classes.ArraySubclasses.Add(qualifiedClassName);
+        }
+
+        // Track Promise subclass status (direct or transitive) for constructor
+        // base-call emission and static-side inheritance (#242)
+        if (classStmt.SuperclassExpr != null && Expr.GetSuperclassLeafName(classStmt.SuperclassExpr) == "Promise"
+            && !_classes.Builders.ContainsKey(qualifiedSuperclassName ?? ""))
+        {
+            _classes.PromiseSubclasses.Add(qualifiedClassName);
+        }
+        else if (qualifiedSuperclassName != null && _classes.PromiseSubclasses.Contains(qualifiedSuperclassName))
+        {
+            _classes.PromiseSubclasses.Add(qualifiedClassName);
         }
 
         // Set the parent type (defaults to Object if baseType is null)

--- a/Compilation/ILCompiler.State.cs
+++ b/Compilation/ILCompiler.State.cs
@@ -33,6 +33,13 @@ public partial class ILCompiler
         /// emission to chain to $Array's ctor-args constructor.
         /// </summary>
         public HashSet<string> ArraySubclasses { get; } = [];
+        /// <summary>
+        /// Qualified names of classes that (directly or transitively) extend the
+        /// built-in Promise (#242). Set during DefineClass; used by constructor
+        /// emission to chain to $Promise via PromiseFromExecutor and by static
+        /// dispatch to inherit the Promise static side.
+        /// </summary>
+        public HashSet<string> PromiseSubclasses { get; } = [];
         public Dictionary<string, ConstructorBuilder> Constructors { get; } = [];
         public Dictionary<string, List<ConstructorBuilder>> ConstructorOverloads { get; } = [];
         public Dictionary<string, Dictionary<string, FieldBuilder>> StaticFields { get; } = [];

--- a/Compilation/ILEmitter.Calls.MethodDispatch.cs
+++ b/Compilation/ILEmitter.Calls.MethodDispatch.cs
@@ -418,90 +418,9 @@ public partial class ILEmitter
         return true;
     }
 
-    /// <summary>
-    /// Emits a Promise instance method call (.then, .catch, .finally).
-    /// These methods take callbacks and return a new Promise (Task).
-    /// </summary>
-    private new void EmitPromiseInstanceMethodCall(Expr promise, string methodName, List<Expr> arguments)
-    {
-        // Emit the promise (should be Task<object?>)
-        EmitExpression(promise);
-        EmitBoxIfNeeded(promise);
-
-        // Cast to Task<object?> if needed
-        IL.Emit(OpCodes.Castclass, typeof(Task<object?>));
-
-        switch (methodName)
-        {
-            case "then":
-                // promise.then(onFulfilled?, onRejected?)
-                // PromiseThen(Task<object?> promise, object? onFulfilled, object? onRejected)
-
-                // onFulfilled callback (optional)
-                if (arguments.Count > 0)
-                {
-                    EmitExpression(arguments[0]);
-                    EmitBoxIfNeeded(arguments[0]);
-                }
-                else
-                {
-                    IL.Emit(OpCodes.Ldnull);
-                }
-
-                // onRejected callback (optional)
-                if (arguments.Count > 1)
-                {
-                    EmitExpression(arguments[1]);
-                    EmitBoxIfNeeded(arguments[1]);
-                }
-                else
-                {
-                    IL.Emit(OpCodes.Ldnull);
-                }
-
-                IL.Emit(OpCodes.Call, _ctx.Runtime!.PromiseThen);
-                break;
-
-            case "catch":
-                // promise.catch(onRejected)
-                // PromiseCatch(Task<object?> promise, object? onRejected)
-
-                if (arguments.Count > 0)
-                {
-                    EmitExpression(arguments[0]);
-                    EmitBoxIfNeeded(arguments[0]);
-                }
-                else
-                {
-                    IL.Emit(OpCodes.Ldnull);
-                }
-
-                IL.Emit(OpCodes.Call, _ctx.Runtime!.PromiseCatch);
-                break;
-
-            case "finally":
-                // promise.finally(onFinally)
-                // PromiseFinally(Task<object?> promise, object? onFinally)
-
-                if (arguments.Count > 0)
-                {
-                    EmitExpression(arguments[0]);
-                    EmitBoxIfNeeded(arguments[0]);
-                }
-                else
-                {
-                    IL.Emit(OpCodes.Ldnull);
-                }
-
-                IL.Emit(OpCodes.Call, _ctx.Runtime!.PromiseFinally);
-                break;
-
-            default:
-                // Unknown method - just return the promise unchanged
-                break;
-        }
-
-        SetStackUnknown();
-    }
-
+    // Promise instance method calls (.then/.catch/.finally) are emitted by
+    // ExpressionEmitterBase.EmitPromiseInstanceMethodCall — shared with the
+    // state-machine emitters. It unwraps $Promise receivers (incl. #242
+    // Promise subclasses) to their task and wraps results back into the
+    // receiver's subclass type.
 }

--- a/Compilation/ILEmitter.Calls.cs
+++ b/Compilation/ILEmitter.Calls.cs
@@ -48,9 +48,11 @@ public partial class ILEmitter
             switch (coerceVar.Name.Lexeme)
             {
                 case "String":
+                    // StringFromValue, not ToJsString: §22.1.1.1 exempts the
+                    // String() call form from ToString's Symbol TypeError.
                     EmitExpression(c.Arguments[0]);
                     EmitBoxIfNeeded(c.Arguments[0]);
-                    IL.Emit(OpCodes.Call, _ctx.Runtime!.ToJsString);
+                    IL.Emit(OpCodes.Call, _ctx.Runtime!.StringFromValueMethod);
                     SetStackUnknown();
                     return;
                 case "Number":

--- a/Compilation/Registries/ClassRegistry.cs
+++ b/Compilation/Registries/ClassRegistry.cs
@@ -363,6 +363,26 @@ public sealed class ClassRegistry
     }
 
     /// <summary>
+    /// True when the class (directly or transitively) extends the built-in
+    /// Promise (#242) — its superclass chain ends at the name "Promise"
+    /// without a user class claiming that name. Used for static-side
+    /// inheritance of the Promise built-ins (MyPromise.resolve etc.).
+    /// </summary>
+    public bool IsPromiseSubclass(string qualifiedClassName)
+    {
+        string? current = qualifiedClassName;
+        for (int depth = 0; current != null && depth < 64; depth++)
+        {
+            if (!_superclass.TryGetValue(current, out var superName) || superName == null)
+                return false;
+            if (!_builders.ContainsKey(superName))
+                return superName == "Promise";
+            current = superName;
+        }
+        return false;
+    }
+
+    /// <summary>
     /// Tries to get a static getter for a class.
     /// </summary>
     public bool TryGetStaticGetter(string qualifiedClassName, string propertyName, out MethodBuilder? getter)

--- a/Compilation/RuntimeEmitter.CoreUtilities.cs
+++ b/Compilation/RuntimeEmitter.CoreUtilities.cs
@@ -1833,6 +1833,37 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ret);
     }
 
+    // StringFromValue — ECMA-262 §22.1.1.1 String(value) constructor called as a
+    // function. Identical to ToJsString except that Symbol arguments return
+    // SymbolDescriptiveString instead of throwing: the String() call form is the
+    // single coercion site the spec exempts from ToString's Symbol TypeError.
+    private void EmitStringFromValue(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    {
+        var method = typeBuilder.DefineMethod(
+            "StringFromValue",
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.String,
+            [_types.Object]);
+        runtime.StringFromValueMethod = method;
+
+        var il = method.GetILGenerator();
+
+        // if (value is $TSSymbol) return value.ToString();  // "Symbol(desc)"
+        var notSymbolLabel = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Isinst, runtime.TSSymbolType);
+        il.Emit(OpCodes.Brfalse, notSymbolLabel);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Callvirt, _types.GetMethodNoParams(_types.Object, "ToString"));
+        il.Emit(OpCodes.Ret);
+        il.MarkLabel(notSymbolLabel);
+
+        // return ToJsString(value);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Call, runtime.ToJsString);
+        il.Emit(OpCodes.Ret);
+    }
+
     // ToJsString — ECMA-262 ToString protocol. For Dictionary/$Object receivers
     // with a user-defined "toString" function, invoke it and use the result.
     // Falls back to Stringify for primitives. Used by String.prototype methods

--- a/Compilation/RuntimeEmitter.CoreUtilities.cs
+++ b/Compilation/RuntimeEmitter.CoreUtilities.cs
@@ -3631,6 +3631,52 @@ public partial class RuntimeEmitter
         CheckBoxed(_types.Double,  "Number");
         CheckBoxed(_types.String,  "String");
 
+        // `x instanceof Promise`: the Promise identifier resolves to
+        // typeof(Task<object?>), but $Promise instances (and #242 Promise
+        // subclasses, which derive from $Promise) wrap their task instead of
+        // being one — accept them here; raw tasks fall through to the
+        // IsAssignableFrom below.
+        var notTaskTargetLabel = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, classTypeLocal);
+        il.Emit(OpCodes.Ldtoken, _types.TaskOfObject);
+        il.Emit(OpCodes.Call, _types.GetMethod(_types.Type, "GetTypeFromHandle", _types.RuntimeTypeHandle));
+        il.Emit(OpCodes.Bne_Un, notTaskTargetLabel);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Isinst, runtime.TSPromiseType);
+        il.Emit(OpCodes.Brtrue, trueLabel);
+        il.MarkLabel(notTaskTargetLabel);
+
+        // Generic class target: `b instanceof Box` emits the OPEN generic
+        // definition (Box`1) while instances carry constructed types
+        // (Box<object>) — IsAssignableFrom never matches across that gap.
+        // Walk the instance's base-type chain comparing generic definitions.
+        var notGenericDefLabel = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, classTypeLocal);
+        il.Emit(OpCodes.Callvirt, _types.Type.GetProperty("IsGenericTypeDefinition")!.GetGetMethod()!);
+        il.Emit(OpCodes.Brfalse, notGenericDefLabel);
+        var walkTypeLocal = il.DeclareLocal(_types.Type);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Callvirt, _types.GetMethodNoParams(_types.Object, "GetType"));
+        il.Emit(OpCodes.Stloc, walkTypeLocal);
+        var genericWalkLoop = il.DefineLabel();
+        var genericWalkNext = il.DefineLabel();
+        il.MarkLabel(genericWalkLoop);
+        il.Emit(OpCodes.Ldloc, walkTypeLocal);
+        il.Emit(OpCodes.Brfalse, falseLabel);
+        il.Emit(OpCodes.Ldloc, walkTypeLocal);
+        il.Emit(OpCodes.Callvirt, _types.Type.GetProperty("IsGenericType")!.GetGetMethod()!);
+        il.Emit(OpCodes.Brfalse, genericWalkNext);
+        il.Emit(OpCodes.Ldloc, walkTypeLocal);
+        il.Emit(OpCodes.Callvirt, _types.GetMethodNoParams(_types.Type, "GetGenericTypeDefinition"));
+        il.Emit(OpCodes.Ldloc, classTypeLocal);
+        il.Emit(OpCodes.Beq, trueLabel);
+        il.MarkLabel(genericWalkNext);
+        il.Emit(OpCodes.Ldloc, walkTypeLocal);
+        il.Emit(OpCodes.Callvirt, _types.Type.GetProperty("BaseType")!.GetGetMethod()!);
+        il.Emit(OpCodes.Stloc, walkTypeLocal);
+        il.Emit(OpCodes.Br, genericWalkLoop);
+        il.MarkLabel(notGenericDefLabel);
+
         // classType is Type, use it directly
         il.Emit(OpCodes.Ldloc, classTypeLocal);
         il.Emit(OpCodes.Ldarg_0);

--- a/Compilation/RuntimeEmitter.Objects.Properties.cs
+++ b/Compilation/RuntimeEmitter.Objects.Properties.cs
@@ -1578,6 +1578,32 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Isinst, _types.TaskOfObject);
         il.Emit(OpCodes.Brtrue, promiseLabel);
 
+        // User Promise subclass (#242): a guest class extending Promise
+        // derives from $Promise AND implements $IHasFields. Its class members
+        // (declared fields, getters, methods) take precedence over the
+        // built-in promise surface; the per-class GetProperty returns
+        // $Undefined on miss, in which case we fall through to the ordinary
+        // $Promise dispatch below. Mirrors the $Array subclass arm above.
+        var notPromiseSubclassLabel = il.DefineLabel();
+        var promiseSubclassMissLabel = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Isinst, runtime.TSPromiseType);
+        il.Emit(OpCodes.Brfalse, notPromiseSubclassLabel);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Isinst, runtime.IHasFieldsInterface);
+        il.Emit(OpCodes.Brfalse, notPromiseSubclassLabel);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Castclass, runtime.IHasFieldsInterface);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Callvirt, runtime.IHasFieldsGetProperty);
+        il.Emit(OpCodes.Dup);
+        il.Emit(OpCodes.Ldsfld, runtime.UndefinedInstance);
+        il.Emit(OpCodes.Beq, promiseSubclassMissLabel);
+        il.Emit(OpCodes.Ret);
+        il.MarkLabel(promiseSubclassMissLabel);
+        il.Emit(OpCodes.Pop);
+        il.MarkLabel(notPromiseSubclassLabel);
+
         // $Promise type (used by fetch, etc.) - check for then/catch/finally
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Isinst, runtime.TSPromiseType);

--- a/Compilation/RuntimeEmitter.PromisePrototypePopulate.cs
+++ b/Compilation/RuntimeEmitter.PromisePrototypePopulate.cs
@@ -59,6 +59,9 @@ public partial class RuntimeEmitter
             il.Emit(OpCodes.Ldarg_1);
             il.Emit(OpCodes.Ldarg_2);
             il.Emit(OpCodes.Call, runtime.PromiseThen);
+            // Promise-subclass receivers get subclass-typed results (#242).
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Call, runtime.WrapDerivedPromiseResultMethod);
             il.Emit(OpCodes.Ret);
         }
 
@@ -171,6 +174,9 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloc, taskLocal);
         il.Emit(OpCodes.Ldarg_1);
         il.Emit(OpCodes.Call, isCatch ? runtime.PromiseCatch : runtime.PromiseFinally);
+        // Promise-subclass receivers get subclass-typed results (#242).
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Call, runtime.WrapDerivedPromiseResultMethod);
         il.Emit(OpCodes.Br, endLabel);
 
         // Branch C: user object — look up `then`, validate callable, invoke.

--- a/Compilation/RuntimeEmitter.Promises.All.cs
+++ b/Compilation/RuntimeEmitter.Promises.All.cs
@@ -65,7 +65,7 @@ public partial class RuntimeEmitter
     /// <summary>
     /// Emits the PromiseAll wrapper method that creates and starts the state machine.
     /// </summary>
-    private void EmitPromiseAllWrapper(ILGenerator il, EmittedStateMachine sm)
+    private void EmitPromiseAllWrapper(ILGenerator il, EmittedStateMachine sm, EmittedRuntime runtime)
     {
         var smLocal = il.DeclareLocal(sm.Type);
 
@@ -78,9 +78,11 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldc_I4_M1);
         il.Emit(OpCodes.Stfld, sm.StateField);
 
-        // sm.iterable = arg0;
+        // sm.iterable = NormalizePromiseList(arg0); — $Promise elements
+        // (#242 subclasses) become their wrapped Task so the SM awaits them.
         il.Emit(OpCodes.Ldloca, smLocal);
         il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Call, runtime.NormalizePromiseListMethod);
         il.Emit(OpCodes.Stfld, sm.IterableField);
 
         // sm.<>t__builder = AsyncTaskMethodBuilder<object>.Create();

--- a/Compilation/RuntimeEmitter.Promises.AllSettled.cs
+++ b/Compilation/RuntimeEmitter.Promises.AllSettled.cs
@@ -329,7 +329,7 @@ public partial class RuntimeEmitter
     /// <summary>
     /// Emits the wrapper method for PromiseAllSettled.
     /// </summary>
-    private void EmitPromiseAllSettledWrapper(ILGenerator il, PromiseAllSettledStateMachine sm, MethodBuilder processElementSettled)
+    private void EmitPromiseAllSettledWrapper(ILGenerator il, PromiseAllSettledStateMachine sm, MethodBuilder processElementSettled, EmittedRuntime runtime)
     {
         var smLocal = il.DeclareLocal(sm.Type);
 
@@ -342,9 +342,10 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldc_I4_M1);
         il.Emit(OpCodes.Stfld, sm.StateField);
 
-        // sm.iterable = arg0
+        // sm.iterable = NormalizePromiseList(arg0) — see PromiseAll wrapper.
         il.Emit(OpCodes.Ldloca, smLocal);
         il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Call, runtime.NormalizePromiseListMethod);
         il.Emit(OpCodes.Stfld, sm.IterableField);
 
         // sm.<>t__builder = AsyncTaskMethodBuilder<object>.Create()

--- a/Compilation/RuntimeEmitter.Promises.Any.cs
+++ b/Compilation/RuntimeEmitter.Promises.Any.cs
@@ -283,7 +283,7 @@ public partial class RuntimeEmitter
     /// <summary>
     /// Emits the wrapper method for PromiseAny.
     /// </summary>
-    private void EmitPromiseAnyWrapper(ILGenerator il, PromiseAnyStateMachine sm)
+    private void EmitPromiseAnyWrapper(ILGenerator il, PromiseAnyStateMachine sm, EmittedRuntime runtime)
     {
         var smLocal = il.DeclareLocal(sm.Type);
 
@@ -296,9 +296,10 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldc_I4_M1);
         il.Emit(OpCodes.Stfld, sm.StateField);
 
-        // sm.iterable = arg0
+        // sm.iterable = NormalizePromiseList(arg0) — see PromiseAll wrapper.
         il.Emit(OpCodes.Ldloca, smLocal);
         il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Call, runtime.NormalizePromiseListMethod);
         il.Emit(OpCodes.Stfld, sm.IterableField);
 
         // sm.<>t__builder = AsyncTaskMethodBuilder<object>.Create()

--- a/Compilation/RuntimeEmitter.Promises.Executor.cs
+++ b/Compilation/RuntimeEmitter.Promises.Executor.cs
@@ -26,6 +26,205 @@ public partial class RuntimeEmitter
     {
         // Emit the PromiseFromExecutor method
         EmitPromiseFromExecutorMethod(runtimeType, runtime, runtime.PromiseResolveCallbackType, runtime.PromiseRejectCallbackType);
+
+        // Promise-subclass support (#242): receiver unwrapping + derived-result wrapping
+        EmitUnwrapPromiseReceiverMethod(runtimeType, runtime);
+        EmitWrapDerivedPromiseResultMethod(runtimeType, runtime);
+    }
+
+    /// <summary>
+    /// Emits NormalizePromiseList(object iterable) -> object: when the arg is
+    /// a List&lt;object?&gt;, returns a copy with $Promise elements (incl. #242
+    /// Promise subclasses) replaced by their wrapped Task — the combinator
+    /// state machines only test elements for Task&lt;object?&gt;, so without
+    /// this a subclass promise element would be treated as an already-resolved
+    /// plain value. Non-list args pass through unchanged.
+    /// </summary>
+    internal void EmitNormalizePromiseList(TypeBuilder runtimeType, EmittedRuntime runtime)
+    {
+        var method = runtimeType.DefineMethod(
+            "NormalizePromiseList",
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.Object,
+            [_types.Object]
+        );
+        runtime.NormalizePromiseListMethod = method;
+
+        var il = method.GetILGenerator();
+        var listType = _types.ListOfObject;
+        var passThroughLabel = il.DefineLabel();
+
+        var listLocal = il.DeclareLocal(listType);
+        var resultLocal = il.DeclareLocal(listType);
+        var indexLocal = il.DeclareLocal(_types.Int32);
+        var elementLocal = il.DeclareLocal(_types.Object);
+
+        // if (iterable is not List<object?>) return iterable;
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Isinst, listType);
+        il.Emit(OpCodes.Stloc, listLocal);
+        il.Emit(OpCodes.Ldloc, listLocal);
+        il.Emit(OpCodes.Brfalse, passThroughLabel);
+
+        // var result = new List<object?>(); for each element: $Promise → .Task
+        il.Emit(OpCodes.Newobj, _types.GetConstructor(listType, _types.EmptyTypes));
+        il.Emit(OpCodes.Stloc, resultLocal);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Stloc, indexLocal);
+
+        var loopStart = il.DefineLabel();
+        var loopEnd = il.DefineLabel();
+        var addRawLabel = il.DefineLabel();
+        var nextLabel = il.DefineLabel();
+
+        il.MarkLabel(loopStart);
+        il.Emit(OpCodes.Ldloc, indexLocal);
+        il.Emit(OpCodes.Ldloc, listLocal);
+        il.Emit(OpCodes.Callvirt, _types.GetProperty(listType, "Count").GetGetMethod()!);
+        il.Emit(OpCodes.Bge, loopEnd);
+
+        il.Emit(OpCodes.Ldloc, listLocal);
+        il.Emit(OpCodes.Ldloc, indexLocal);
+        il.Emit(OpCodes.Callvirt, _types.GetProperty(listType, "Item").GetGetMethod()!);
+        il.Emit(OpCodes.Stloc, elementLocal);
+
+        il.Emit(OpCodes.Ldloc, elementLocal);
+        il.Emit(OpCodes.Isinst, runtime.TSPromiseType);
+        il.Emit(OpCodes.Brfalse, addRawLabel);
+
+        // result.Add(((​$Promise)element).Task)
+        il.Emit(OpCodes.Ldloc, resultLocal);
+        il.Emit(OpCodes.Ldloc, elementLocal);
+        il.Emit(OpCodes.Castclass, runtime.TSPromiseType);
+        il.Emit(OpCodes.Callvirt, runtime.TSPromiseTaskGetter);
+        il.Emit(OpCodes.Callvirt, _types.GetMethod(listType, "Add", _types.Object));
+        il.Emit(OpCodes.Br, nextLabel);
+
+        // result.Add(element)
+        il.MarkLabel(addRawLabel);
+        il.Emit(OpCodes.Ldloc, resultLocal);
+        il.Emit(OpCodes.Ldloc, elementLocal);
+        il.Emit(OpCodes.Callvirt, _types.GetMethod(listType, "Add", _types.Object));
+
+        il.MarkLabel(nextLabel);
+        il.Emit(OpCodes.Ldloc, indexLocal);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Stloc, indexLocal);
+        il.Emit(OpCodes.Br, loopStart);
+
+        il.MarkLabel(loopEnd);
+        il.Emit(OpCodes.Ldloc, resultLocal);
+        il.Emit(OpCodes.Ret);
+
+        il.MarkLabel(passThroughLabel);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ret);
+    }
+
+    /// <summary>
+    /// Emits UnwrapPromiseReceiver(object receiver) -> Task&lt;object?&gt;:
+    /// $Promise instances (including #242 Promise subclasses) yield their
+    /// wrapped task; anything else is cast to Task&lt;object?&gt; (matching the
+    /// previous inline Castclass that broke for $Promise receivers).
+    /// </summary>
+    private void EmitUnwrapPromiseReceiverMethod(TypeBuilder runtimeType, EmittedRuntime runtime)
+    {
+        var method = runtimeType.DefineMethod(
+            "UnwrapPromiseReceiver",
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.TaskOfObject,
+            [_types.Object]
+        );
+        runtime.UnwrapPromiseReceiverMethod = method;
+
+        var il = method.GetILGenerator();
+        var notPromiseObjLabel = il.DefineLabel();
+
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Isinst, runtime.TSPromiseType);
+        il.Emit(OpCodes.Brfalse, notPromiseObjLabel);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Castclass, runtime.TSPromiseType);
+        il.Emit(OpCodes.Callvirt, runtime.TSPromiseTaskGetter);
+        il.Emit(OpCodes.Ret);
+
+        il.MarkLabel(notPromiseObjLabel);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Castclass, _types.TaskOfObject);
+        il.Emit(OpCodes.Ret);
+    }
+
+    /// <summary>
+    /// Emits WrapDerivedPromiseResult(Task&lt;object?&gt; result, object receiver) -> object:
+    /// when the receiver is a $Promise SUBCLASS instance (#242), constructs a
+    /// receiver-typed promise around the result task by invoking the
+    /// subclass's single-object (executor) constructor reflectively —
+    /// PromiseFromExecutor adopts a raw task, so the new instance wraps
+    /// `result`. Plain $Promise / Task receivers (and subclasses without a
+    /// matching constructor) return the task unchanged. This is the
+    /// species-lite step giving subclass-typed then/catch/finally results;
+    /// full SpeciesConstructor semantics remain tracked by #221.
+    /// </summary>
+    private void EmitWrapDerivedPromiseResultMethod(TypeBuilder runtimeType, EmittedRuntime runtime)
+    {
+        var method = runtimeType.DefineMethod(
+            "WrapDerivedPromiseResult",
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.Object,
+            [_types.TaskOfObject, _types.Object]
+        );
+        runtime.WrapDerivedPromiseResultMethod = method;
+
+        var il = method.GetILGenerator();
+        var returnResultLabel = il.DefineLabel();
+        var typeLocal = il.DeclareLocal(_types.Type);
+        var ctorLocal = il.DeclareLocal(typeof(ConstructorInfo));
+
+        // if (receiver is not $Promise) return result;
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Isinst, runtime.TSPromiseType);
+        il.Emit(OpCodes.Brfalse, returnResultLabel);
+
+        // if (receiver.GetType() == typeof($Promise)) return result;
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Callvirt, _types.GetMethodNoParams(_types.Object, "GetType"));
+        il.Emit(OpCodes.Stloc, typeLocal);
+        il.Emit(OpCodes.Ldloc, typeLocal);
+        il.Emit(OpCodes.Ldtoken, runtime.TSPromiseType);
+        il.Emit(OpCodes.Call, _types.GetMethod(_types.Type, "GetTypeFromHandle", _types.RuntimeTypeHandle));
+        il.Emit(OpCodes.Beq, returnResultLabel);
+
+        // var ctor = receiverType.GetConstructor(new[] { typeof(object) });
+        il.Emit(OpCodes.Ldloc, typeLocal);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Newarr, _types.Type);
+        il.Emit(OpCodes.Dup);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Ldtoken, _types.Object);
+        il.Emit(OpCodes.Call, _types.GetMethod(_types.Type, "GetTypeFromHandle", _types.RuntimeTypeHandle));
+        il.Emit(OpCodes.Stelem_Ref);
+        il.Emit(OpCodes.Callvirt, _types.Type.GetMethod("GetConstructor", [typeof(Type[])])!);
+        il.Emit(OpCodes.Stloc, ctorLocal);
+
+        // if (ctor == null) return result;
+        il.Emit(OpCodes.Ldloc, ctorLocal);
+        il.Emit(OpCodes.Brfalse, returnResultLabel);
+
+        // return ctor.Invoke(new object[] { result });
+        il.Emit(OpCodes.Ldloc, ctorLocal);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Newarr, _types.Object);
+        il.Emit(OpCodes.Dup);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Stelem_Ref);
+        il.Emit(OpCodes.Callvirt, typeof(ConstructorInfo).GetMethod("Invoke", [typeof(object[])])!);
+        il.Emit(OpCodes.Ret);
+
+        il.MarkLabel(returnResultLabel);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ret);
     }
 
     /// <summary>
@@ -307,6 +506,21 @@ public partial class RuntimeEmitter
         var resolveLocal = il.DeclareLocal(resolveCallbackType);
         var rejectLocal = il.DeclareLocal(rejectCallbackType);
         var argsLocal = il.DeclareLocal(typeof(object[]));
+
+        // Task adoption (#242): a raw Task<object?> in place of an executor is
+        // adopted as the promise's task directly. Promise-subclass constructors
+        // chain through here (super(executor) → PromiseFromExecutor → base
+        // $Promise ctor), so passing a task to that same constructor is the
+        // derived-promise construction path used by inherited statics
+        // (MyPromise.resolve) and subclass-typed then/catch/finally results.
+        var notTaskLabel = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Isinst, _types.TaskOfObject);
+        il.Emit(OpCodes.Brfalse, notTaskLabel);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Castclass, _types.TaskOfObject);
+        il.Emit(OpCodes.Ret);
+        il.MarkLabel(notTaskLabel);
 
         // TaskCompletionSource<object?> tcs = new TaskCompletionSource<object?>();
         var tcsCtor = typeof(TaskCompletionSource<object?>).GetConstructor([])!;

--- a/Compilation/RuntimeEmitter.Promises.Race.cs
+++ b/Compilation/RuntimeEmitter.Promises.Race.cs
@@ -71,7 +71,7 @@ public partial class RuntimeEmitter
     /// <summary>
     /// Emits the PromiseRace wrapper method that creates and starts the state machine.
     /// </summary>
-    private void EmitPromiseRaceWrapper(ILGenerator il, PromiseRaceStateMachine sm)
+    private void EmitPromiseRaceWrapper(ILGenerator il, PromiseRaceStateMachine sm, EmittedRuntime runtime)
     {
         var smLocal = il.DeclareLocal(sm.Type);
 
@@ -84,9 +84,10 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldc_I4_M1);
         il.Emit(OpCodes.Stfld, sm.StateField);
 
-        // sm.iterable = arg0;
+        // sm.iterable = NormalizePromiseList(arg0); — see PromiseAll wrapper.
         il.Emit(OpCodes.Ldloca, smLocal);
         il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Call, runtime.NormalizePromiseListMethod);
         il.Emit(OpCodes.Stfld, sm.IterableField);
 
         // sm.<>t__builder = AsyncTaskMethodBuilder<object>.Create();

--- a/Compilation/RuntimeEmitter.Promises.cs
+++ b/Compilation/RuntimeEmitter.Promises.cs
@@ -410,6 +410,12 @@ public partial class RuntimeEmitter
             il.Emit(OpCodes.Ret);
         }
 
+        // NormalizePromiseList — replaces $Promise elements (#242 Promise
+        // subclasses) with their wrapped Task so the combinator state machines
+        // (which only test elements for Task<object?>) await them. Emitted
+        // before the combinators; each wrapper applies it to its iterable.
+        EmitNormalizePromiseList(typeBuilder, runtime);
+
         // Promise.all(iterable) - async state machine using Task.WhenAll
         var promiseAllSM = DefinePromiseAllStateMachine(moduleBuilder);
         var all = typeBuilder.DefineMethod(
@@ -419,7 +425,7 @@ public partial class RuntimeEmitter
             [_types.Object]
         );
         runtime.PromiseAll = all;
-        EmitPromiseAllWrapper(all.GetILGenerator(), promiseAllSM);
+        EmitPromiseAllWrapper(all.GetILGenerator(), promiseAllSM, runtime);
         EmitPromiseAllMoveNext(promiseAllSM, runtime);
         promiseAllSM.Type.CreateType();
 
@@ -432,7 +438,7 @@ public partial class RuntimeEmitter
             [_types.Object]
         );
         runtime.PromiseRace = race;
-        EmitPromiseRaceWrapper(race.GetILGenerator(), promiseRaceSM);
+        EmitPromiseRaceWrapper(race.GetILGenerator(), promiseRaceSM, runtime);
         EmitPromiseRaceMoveNext(promiseRaceSM, runtime);
         promiseRaceSM.Type.CreateType();
 
@@ -458,7 +464,7 @@ public partial class RuntimeEmitter
             [_types.Object]
         );
         runtime.PromiseAllSettled = allSettled;
-        EmitPromiseAllSettledWrapper(allSettled.GetILGenerator(), promiseAllSettledSM, processElementSettled);
+        EmitPromiseAllSettledWrapper(allSettled.GetILGenerator(), promiseAllSettledSM, processElementSettled, runtime);
         EmitPromiseAllSettledMoveNext(promiseAllSettledSM, processElementSettled, runtime);
         promiseAllSettledSM.Type.CreateType();
 
@@ -498,7 +504,7 @@ public partial class RuntimeEmitter
             [_types.Object]
         );
         runtime.PromiseAny = any;
-        EmitPromiseAnyWrapper(any.GetILGenerator(), promiseAnySM);
+        EmitPromiseAnyWrapper(any.GetILGenerator(), promiseAnySM, runtime);
         EmitPromiseAnyMoveNext(promiseAnySM, anyState, handleAnyCompletionShim, runtime);
         promiseAnySM.Type.CreateType();
 

--- a/Compilation/RuntimeEmitter.RuntimeClass.cs
+++ b/Compilation/RuntimeEmitter.RuntimeClass.cs
@@ -626,6 +626,9 @@ public partial class RuntimeEmitter
         // HasOwnPropertyHelper's Symbol-key arm can call them).
         // ToJsString depends on GetProperty + InvokeMethodValue + Stringify; emit after those.
         EmitToJsString(typeBuilder, runtime);
+        // StringFromValue (String(x) call form) wraps ToJsString with the
+        // §22.1.1.1 Symbol exemption; emit right after it.
+        EmitStringFromValue(typeBuilder, runtime);
         // Equals body — must come after ToJsString since the Object-vs-String
         // branch calls runtime.ToJsString.
         EmitEquals(typeBuilder, runtime);

--- a/Compilation/RuntimeEmitter.TSSymbol.cs
+++ b/Compilation/RuntimeEmitter.TSSymbol.cs
@@ -398,6 +398,20 @@ public partial class RuntimeEmitter
         toStringIL.MarkLabel(doneToString);
         toStringIL.Emit(OpCodes.Ret);
 
+        // valueOf method: public object valueOf() => this — Symbol.prototype.valueOf
+        // (ECMA-262 §20.4.3.4). Dynamic dispatch resolves it via GetFieldsProperty's
+        // reflection fallback (IgnoreCase method lookup), the same path that already
+        // serves `description` and `toString` on symbol receivers.
+        var valueOfBuilder = typeBuilder.DefineMethod(
+            "valueOf",
+            MethodAttributes.Public | MethodAttributes.HideBySig,
+            _types.Object,
+            Type.EmptyTypes
+        );
+        var valueOfIL = valueOfBuilder.GetILGenerator();
+        valueOfIL.Emit(OpCodes.Ldarg_0);
+        valueOfIL.Emit(OpCodes.Ret);
+
         // ============================================================
         // Description property getter: public object get_description()
         // Returns the description string or $Undefined.Instance if null

--- a/Compilation/RuntimeTypes.Promise.cs
+++ b/Compilation/RuntimeTypes.Promise.cs
@@ -467,6 +467,14 @@ public static partial class RuntimeTypes
             throw new Exception("Runtime Error: Promise executor must be a function.");
         }
 
+        // Task adoption (#242): mirrors the emitted PromiseFromExecutor — a
+        // raw Task<object?> in place of an executor is adopted directly, the
+        // derived-promise construction path for Promise subclasses.
+        if (executor is Task<object?> adoptedTask)
+        {
+            return adoptedTask;
+        }
+
         var tcs = new TaskCompletionSource<object?>();
         bool settled = false;
         object settledLock = new();

--- a/Execution/Interpreter.Calls.cs
+++ b/Execution/Interpreter.Calls.cs
@@ -831,6 +831,20 @@ public partial class Interpreter
             return false;
         }
 
+        // Promise subclass instances (#242): real SharpTSPromises carrying a
+        // guest class — walk its chain (`p instanceof Promise` is handled by
+        // the SharpTSBuiltInConstructor arm above via `left is SharpTSPromise`).
+        if (left is SharpTSPromiseSubclassInstance subclassPromise)
+        {
+            SharpTSClass? current = subclassPromise.Klass;
+            while (current != null)
+            {
+                if (current.Name == targetClass.Name) return true;
+                current = current.Superclass;
+            }
+            return false;
+        }
+
         // Legacy path: SharpTSError instances created via BuiltInConstructorFactory
         // (not SharpTSInstance, but should still pass instanceof Error/TypeError/etc.)
         if (left is SharpTSError error && targetClass is SharpTSErrorClass)

--- a/Execution/Interpreter.Expressions.cs
+++ b/Execution/Interpreter.Expressions.cs
@@ -1106,6 +1106,11 @@ public partial class Interpreter
             {
                 superclass = SharpTSArrayClass.ArrayBase;
             }
+            // `extends Promise` (#242): same substitution, mirroring VisitClass.
+            if (superclass is SharpTSBuiltInConstructor { Name: BuiltInNames.Promise })
+            {
+                superclass = SharpTSPromiseClass.PromiseBase;
+            }
             if (superclass is not SharpTSClass)
             {
                 if (superclass is SharpTSBuiltInConstructor builtInCtor)
@@ -1215,8 +1220,8 @@ public partial class Interpreter
                 }
             }
 
-            // Mirror VisitClass: Error/Array superclasses need their dedicated
-            // SharpTSClass subtypes so instances get the right backing.
+            // Mirror VisitClass: Error/Array/Promise superclasses need their
+            // dedicated SharpTSClass subtypes so instances get the right backing.
             SharpTSClass klass = superclass is SharpTSErrorClass errorSuper
                 ? new SharpTSErrorClass(
                     className,
@@ -1232,6 +1237,17 @@ public partial class Interpreter
                 ? new SharpTSArrayClass(
                     className,
                     arraySuper,
+                    methods,
+                    staticMethods,
+                    staticProperties,
+                    getters,
+                    setters,
+                    classExpr.IsAbstract,
+                    instanceFields)
+                : superclass is SharpTSPromiseClass promiseSuper
+                ? new SharpTSPromiseClass(
+                    className,
+                    promiseSuper,
                     methods,
                     staticMethods,
                     staticProperties,

--- a/Execution/Interpreter.Helpers.cs
+++ b/Execution/Interpreter.Helpers.cs
@@ -369,65 +369,11 @@ public partial class Interpreter
             throw new InterpreterException("Promise executor must be callable.");
         }
 
+        // The executor wiring (host resolve/reject callbacks, promise
+        // flattening, throw-to-rejection) is shared with the Promise
+        // subclass bridge's super(executor) path (#242).
         var tcs = new TaskCompletionSource<object?>();
-        bool settled = false;
-        object settledLock = new();
-
-        // Create the resolve callback
-        var resolveCallback = new PromiseResolveCallback((value) =>
-        {
-            lock (settledLock)
-            {
-                if (settled) return;
-                settled = true;
-            }
-
-            // Handle promise flattening - if value is a Promise, wait for it
-            if (value is SharpTSPromise innerPromise)
-            {
-                innerPromise.Task.ContinueWith(t =>
-                {
-                    if (t.IsFaulted)
-                        tcs.TrySetException(t.Exception!.InnerException ?? t.Exception);
-                    else
-                        tcs.TrySetResult(t.Result);
-                }, TaskScheduler.Default);
-            }
-            else
-            {
-                tcs.TrySetResult(value);
-            }
-        });
-
-        // Create the reject callback
-        var rejectCallback = new PromiseRejectCallback((reason) =>
-        {
-            lock (settledLock)
-            {
-                if (settled) return;
-                settled = true;
-            }
-            tcs.TrySetException(new SharpTSPromiseRejectedException(reason));
-        });
-
-        // Call the executor synchronously with resolve and reject callbacks
-        try
-        {
-            callable.Call(this, [resolveCallback, rejectCallback]);
-        }
-        catch (Exception ex)
-        {
-            // If executor throws, reject the promise
-            lock (settledLock)
-            {
-                if (!settled)
-                {
-                    settled = true;
-                    tcs.TrySetException(new SharpTSPromiseRejectedException(ex.Message));
-                }
-            }
-        }
-
+        SharpTSPromiseClass.RunExecutor(this, callable, tcs);
         return new SharpTSPromise(tcs.Task);
     }
 

--- a/Execution/Interpreter.Properties.cs
+++ b/Execution/Interpreter.Properties.cs
@@ -612,6 +612,24 @@ public partial class Interpreter
                 return RuntimeValue.FromBoxed(RegExpConstructorObject);
         }
 
+        // Promise subclass instances (#242): own fields, class getters, and
+        // methods resolve before the built-in Promise members so user
+        // overrides win; then/catch/finally fall through to the category
+        // dispatch (PromiseBuiltIns wraps their results in the subclass).
+        if (obj is SharpTSPromiseSubclassInstance promiseSub)
+        {
+            if (memberName == "constructor")
+                return RuntimeValue.FromObject(promiseSub.Klass);
+            if (promiseSub.TryGetOwnProperty(memberName, out var ownProp))
+                return RuntimeValue.FromBoxed(ownProp);
+            var promiseGetter = promiseSub.Klass.FindGetter(memberName);
+            if (promiseGetter != null)
+                return RuntimeValue.FromBoxed(promiseGetter.BindThis(promiseSub).Call(this, []));
+            var promiseMethod = promiseSub.Klass.FindMethod(memberName);
+            if (promiseMethod != null)
+                return RuntimeValue.FromObject(SharpTSClass.BindMethodToReceiver(promiseMethod, promiseSub));
+        }
+
         var member = BuiltInRegistry.Instance.GetMemberByCategory(category, obj, memberName);
         if (member != null)
             return RuntimeValue.FromBoxed(BindBuiltInMember(member, obj));
@@ -749,6 +767,15 @@ public partial class Interpreter
         // shadowed them with a static property (handled above).
         if (memberName == "name") return klass.Name;
         if (memberName == "length") return 0.0;
+
+        // Promise subclasses (#242) inherit the Promise static side
+        // (resolve/reject/all/race/allSettled/any/withResolvers); inherited
+        // statics construct subclass-typed result promises.
+        if (klass is SharpTSPromiseClass promiseKlass)
+        {
+            var promiseStatic = Runtime.BuiltIns.PromiseBuiltIns.GetStaticMethod(memberName, promiseKlass);
+            if (promiseStatic != null) return promiseStatic;
+        }
 
         throw new InterpreterException($"Static member '{memberName}' does not exist on class '{klass.Name}'.");
     }
@@ -1085,6 +1112,22 @@ public partial class Interpreter
                 return SharpTSClass.BindMethodToReceiver(classMethod, subclassArray);
         }
 
+        // Promise subclass instances (#242): mirror the RV-path arm — own
+        // fields, class getters, and methods before built-in Promise members.
+        if (obj is SharpTSPromiseSubclassInstance promiseSub)
+        {
+            if (memberName == "constructor")
+                return promiseSub.Klass;
+            if (promiseSub.TryGetOwnProperty(memberName, out var promiseOwnProp))
+                return promiseOwnProp;
+            var promiseGetter = promiseSub.Klass.FindGetter(memberName);
+            if (promiseGetter != null)
+                return promiseGetter.BindThis(promiseSub).Call(this, []);
+            var promiseMethod = promiseSub.Klass.FindMethod(memberName);
+            if (promiseMethod != null)
+                return SharpTSClass.BindMethodToReceiver(promiseMethod, promiseSub);
+        }
+
         // Handle built-in instance members: strings, arrays, Math, Promise
         if (obj != null)
         {
@@ -1309,6 +1352,18 @@ public partial class Interpreter
                 if (ErrorBuiltIns.SetMember(error, memberName, value))
                     return value;
                 throw new InterpreterException($"Cannot set property '{memberName}' on Error.");
+
+            case TypeCategory.Promise when obj is SharpTSPromiseSubclassInstance promiseSub:
+                // Promise subclass instances (#242): class setters win, then
+                // own properties (declared fields and expando assignments).
+                var promiseSetter = promiseSub.Klass.FindSetter(memberName);
+                if (promiseSetter != null)
+                {
+                    promiseSetter.BindThis(promiseSub).Call(this, [value]);
+                    return value;
+                }
+                promiseSub.SetOwnProperty(memberName, value);
+                return value;
 
             case TypeCategory.Array when obj is SharpTSArray array:
                 if (memberName == "length")

--- a/Execution/Interpreter.cs
+++ b/Execution/Interpreter.cs
@@ -2079,11 +2079,18 @@ public partial class Interpreter : IDisposable
                 superclass = SharpTSArrayClass.ArrayBase;
             }
 
+            // `extends Promise` (#242): same substitution for the Promise
+            // constructor sentinel.
+            if (superclass is SharpTSBuiltInConstructor { Name: BuiltInNames.Promise })
+            {
+                superclass = SharpTSPromiseClass.PromiseBase;
+            }
+
             if (superclass is not SharpTSClass)
             {
                 // Built-in constructors that don't have a class bridge yet
-                // (Promise is the big one — see #221) get a precise error
-                // instead of the generic "Superclass must be a class".
+                // get a precise error instead of the generic
+                // "Superclass must be a class".
                 if (superclass is SharpTSBuiltInConstructor builtInCtor)
                 {
                     throw new InterpreterException(
@@ -2256,7 +2263,8 @@ public partial class Interpreter : IDisposable
         // If the superclass is an Error type, create a SharpTSErrorClass so that
         // instances carry error fields (name, message, stack) and instanceof works.
         // Likewise an Array superclass produces a SharpTSArrayClass whose
-        // instances are real arrays (#233).
+        // instances are real arrays (#233), and a Promise superclass produces a
+        // SharpTSPromiseClass whose instances are real promises (#242).
         SharpTSClass klass = superclass is SharpTSErrorClass errorSuper
             ? new SharpTSErrorClass(
                 classStmt.Name.Lexeme,
@@ -2280,6 +2288,25 @@ public partial class Interpreter : IDisposable
             ? new SharpTSArrayClass(
                 classStmt.Name.Lexeme,
                 arraySuper,
+                methods,
+                staticMethods,
+                staticProperties,
+                getters,
+                setters,
+                classStmt.IsAbstract,
+                instanceFields,
+                instancePrivateFields,
+                privateMethods,
+                staticPrivateFields,
+                staticPrivateMethods,
+                instanceAutoAccessors.Count > 0 ? instanceAutoAccessors : null,
+                staticAutoAccessors.Count > 0 ? staticAutoAccessors : null,
+                staticGetters.Count > 0 ? staticGetters : null,
+                staticSetters.Count > 0 ? staticSetters : null)
+            : superclass is SharpTSPromiseClass promiseSuper
+            ? new SharpTSPromiseClass(
+                classStmt.Name.Lexeme,
+                promiseSuper,
                 methods,
                 staticMethods,
                 staticProperties,

--- a/Runtime/BuiltIns/BuiltInAsyncMethod.cs
+++ b/Runtime/BuiltIns/BuiltInAsyncMethod.cs
@@ -31,6 +31,7 @@ public class BuiltInAsyncMethod : ISharpTSCallable, ISharpTSAsyncCallable
     private readonly int _minArity;
     private readonly int _maxArity;
     private readonly Func<Interpreter, object?, List<object?>, Task<object?>> _implementation;
+    private readonly Func<Interpreter, Task<object?>, SharpTSPromise>? _promiseFactory;
     private object? _receiver;
 
     // Cache for bound methods - uses weak references to avoid memory leaks
@@ -42,16 +43,24 @@ public class BuiltInAsyncMethod : ISharpTSCallable, ISharpTSAsyncCallable
         Func<Interpreter, object?, List<object?>, Task<object?>> implementation)
         : this(name, arity, arity, implementation) { }
 
+    /// <param name="promiseFactory">
+    /// Optional factory used to materialize the result promise from the
+    /// implementation's task. Promise subclasses (#242) pass one so derived
+    /// promises (then/catch/finally results, inherited statics) come out as
+    /// subclass instances; null means a plain <see cref="SharpTSPromise"/>.
+    /// </param>
     public BuiltInAsyncMethod(
         string name,
         int minArity,
         int maxArity,
-        Func<Interpreter, object?, List<object?>, Task<object?>> implementation)
+        Func<Interpreter, object?, List<object?>, Task<object?>> implementation,
+        Func<Interpreter, Task<object?>, SharpTSPromise>? promiseFactory = null)
     {
         _name = name;
         _minArity = minArity;
         _maxArity = maxArity;
         _implementation = implementation;
+        _promiseFactory = promiseFactory;
     }
 
     // Private constructor for creating bound instances
@@ -60,12 +69,14 @@ public class BuiltInAsyncMethod : ISharpTSCallable, ISharpTSAsyncCallable
         int minArity,
         int maxArity,
         Func<Interpreter, object?, List<object?>, Task<object?>> implementation,
+        Func<Interpreter, Task<object?>, SharpTSPromise>? promiseFactory,
         object? receiver)
     {
         _name = name;
         _minArity = minArity;
         _maxArity = maxArity;
         _implementation = implementation;
+        _promiseFactory = promiseFactory;
         _receiver = receiver;
     }
 
@@ -76,13 +87,13 @@ public class BuiltInAsyncMethod : ISharpTSCallable, ISharpTSAsyncCallable
         // Null receivers don't need caching
         if (receiver == null)
         {
-            return new BuiltInAsyncMethod(_name, _minArity, _maxArity, _implementation, null);
+            return new BuiltInAsyncMethod(_name, _minArity, _maxArity, _implementation, _promiseFactory, null);
         }
 
         // Value types can't be cached efficiently
         if (receiver.GetType().IsValueType)
         {
-            return new BuiltInAsyncMethod(_name, _minArity, _maxArity, _implementation, receiver);
+            return new BuiltInAsyncMethod(_name, _minArity, _maxArity, _implementation, _promiseFactory, receiver);
         }
 
         // Initialize cache lazily
@@ -95,7 +106,7 @@ public class BuiltInAsyncMethod : ISharpTSCallable, ISharpTSAsyncCallable
         }
 
         // Create new bound method and cache it
-        var bound = new BuiltInAsyncMethod(_name, _minArity, _maxArity, _implementation, receiver);
+        var bound = new BuiltInAsyncMethod(_name, _minArity, _maxArity, _implementation, _promiseFactory, receiver);
         _boundMethodCache.AddOrUpdate(receiver, bound);
         return bound;
     }
@@ -109,7 +120,7 @@ public class BuiltInAsyncMethod : ISharpTSCallable, ISharpTSAsyncCallable
         try
         {
             var task = _implementation(interpreter, _receiver, arguments);
-            return new SharpTSPromise(task);
+            return WrapResult(interpreter, task);
         }
         catch (Exception ex)
         {
@@ -120,9 +131,16 @@ public class BuiltInAsyncMethod : ISharpTSCallable, ISharpTSAsyncCallable
                 SharpTSPromiseRejectedException rex => rex.Reason,
                 _ => ex.Message
             };
-            return SharpTSPromise.Reject(errorValue);
+            if (_promiseFactory == null)
+                return SharpTSPromise.Reject(errorValue);
+            var tcs = new TaskCompletionSource<object?>();
+            tcs.SetException(new SharpTSPromiseRejectedException(errorValue));
+            return WrapResult(interpreter, tcs.Task);
         }
     }
+
+    private SharpTSPromise WrapResult(Interpreter interpreter, Task<object?> task)
+        => _promiseFactory != null ? _promiseFactory(interpreter, task) : new SharpTSPromise(task);
 
     /// <summary>
     /// Async call - awaits the implementation directly.

--- a/Runtime/BuiltIns/BuiltInRegistry.cs
+++ b/Runtime/BuiltIns/BuiltInRegistry.cs
@@ -324,14 +324,7 @@ public sealed class BuiltInRegistry
             FunctionBuiltIns.GetMember((ISharpTSCallable)instance, name));
 
         registry.RegisterCategoryType(TypeCategory.Symbol, (instance, name) =>
-        {
-            var symbol = (SharpTSSymbol)instance;
-            return name switch
-            {
-                "description" => symbol.Description ?? (object)SharpTSUndefined.Instance,
-                _ => null
-            };
-        });
+            SymbolBuiltIns.GetInstanceMember((SharpTSSymbol)instance, name));
     }
 
     private static void RegisterMathNamespace(BuiltInRegistry registry)
@@ -1247,16 +1240,9 @@ public sealed class BuiltInRegistry
 
     private static void RegisterSymbolType(BuiltInRegistry registry)
     {
-        // Symbol instance members (description property)
+        // Symbol instance members (description, toString, valueOf)
         registry.RegisterInstanceType(typeof(SharpTSSymbol), (instance, name) =>
-        {
-            var symbol = (SharpTSSymbol)instance;
-            return name switch
-            {
-                "description" => symbol.Description ?? (object)SharpTSUndefined.Instance,
-                _ => null
-            };
-        });
+            SymbolBuiltIns.GetInstanceMember((SharpTSSymbol)instance, name));
     }
 
     private static void RegisterAbortSignalNamespace(BuiltInRegistry registry)

--- a/Runtime/BuiltIns/PromiseBuiltIns.cs
+++ b/Runtime/BuiltIns/PromiseBuiltIns.cs
@@ -14,18 +14,25 @@ public static class PromiseBuiltIns
     /// Gets an instance member of a Promise.
     /// The interpreter is passed at call time through BuiltInAsyncMethod.
     /// </summary>
+    /// <remarks>
+    /// For Promise subclass instances (#242), then/catch/finally construct
+    /// their result promise via the receiver's guest class ("species-lite" —
+    /// the receiver's own class stands in for the spec's
+    /// SpeciesConstructor(promise.constructor) lookup, which #221 tracks).
+    /// </remarks>
     public static object? GetMember(SharpTSPromise receiver, string name)
     {
+        var factory = DerivedPromiseFactory(receiver);
         return name switch
         {
             "then" => new BuiltInAsyncMethod("then", 1, 2, (interp, recv, args) =>
-                ThenImpl((SharpTSPromise)recv!, args, interp)).Bind(receiver),
+                ThenImpl((SharpTSPromise)recv!, args, interp), factory).Bind(receiver),
 
             "catch" => new BuiltInAsyncMethod("catch", 1, 1, (interp, recv, args) =>
-                CatchImpl((SharpTSPromise)recv!, args, interp)).Bind(receiver),
+                CatchImpl((SharpTSPromise)recv!, args, interp), factory).Bind(receiver),
 
             "finally" => new BuiltInAsyncMethod("finally", 1, 1, (interp, recv, args) =>
-                FinallyImpl((SharpTSPromise)recv!, args, interp)).Bind(receiver),
+                FinallyImpl((SharpTSPromise)recv!, args, interp), factory).Bind(receiver),
 
             _ => null
         };
@@ -34,33 +41,63 @@ public static class PromiseBuiltIns
     /// <summary>
     /// Gets a static method from the Promise namespace.
     /// </summary>
-    public static ISharpTSCallable? GetStaticMethod(string name)
+    public static ISharpTSCallable? GetStaticMethod(string name) => GetStaticMethod(name, null);
+
+    /// <summary>
+    /// Gets a static method from the Promise static side. When
+    /// <paramref name="subclass"/> is a guest Promise subclass (#242), the
+    /// returned method constructs its result promise through that class so
+    /// inherited statics (e.g. <c>MyPromise.resolve(v)</c>) produce
+    /// subclass-typed instances.
+    /// </summary>
+    public static ISharpTSCallable? GetStaticMethod(string name, SharpTSPromiseClass? subclass)
     {
+        var factory = DerivedPromiseFactory(subclass);
         return name switch
         {
             "all" => new BuiltInAsyncMethod("all", 1, 1, (interp, _, args) =>
-                AllImpl(args, interp)),
+                AllImpl(args, interp), factory),
 
             "race" => new BuiltInAsyncMethod("race", 1, 1, (interp, _, args) =>
-                RaceImpl(args, interp)),
+                RaceImpl(args, interp), factory),
 
             "resolve" => new BuiltInAsyncMethod("resolve", 0, 1, (_, _, args) =>
-                ResolveImplAsync(args)),
+                ResolveImplAsync(args), factory),
 
             "reject" => new BuiltInAsyncMethod("reject", 1, 1, (_, _, args) =>
-                Task.FromResult(RejectImpl(args))),
+                Task.FromResult(RejectImpl(args)), factory),
 
             "allSettled" => new BuiltInAsyncMethod("allSettled", 1, 1, (interp, _, args) =>
-                AllSettledImpl(args, interp)),
+                AllSettledImpl(args, interp), factory),
 
             "any" => new BuiltInAsyncMethod("any", 1, 1, (interp, _, args) =>
-                AnyImpl(args, interp)),
+                AnyImpl(args, interp), factory),
 
-            "withResolvers" => BuiltInMethod.CreateV2("withResolvers", 0, static (_, _, _) =>
-                RuntimeValue.FromBoxed(WithResolversImpl())),
+            "withResolvers" => BuiltInMethod.CreateV2("withResolvers", 0, (interp, _, _) =>
+                RuntimeValue.FromBoxed(WithResolversImpl(interp, factory))),
 
             _ => null
         };
+    }
+
+    /// <summary>
+    /// Returns the derived-promise factory for a Promise subclass receiver or
+    /// subclass constructor, or null for plain promises (which keeps the
+    /// default <see cref="SharpTSPromise"/> wrapping).
+    /// </summary>
+    private static Func<Interpreter, Task<object?>, SharpTSPromise>? DerivedPromiseFactory(object? receiverOrClass)
+    {
+        var klass = receiverOrClass switch
+        {
+            SharpTSPromiseSubclassInstance sub => sub.Klass,
+            SharpTSPromiseClass pc => pc,
+            _ => null
+        };
+        // PromiseBase itself (the bridge singleton for the built-in
+        // constructor) keeps the plain wrapping.
+        if (klass == null || ReferenceEquals(klass, SharpTSPromiseClass.PromiseBase))
+            return null;
+        return (interp, task) => klass.ConstructDerived(interp, task);
     }
 
     #region Instance Methods
@@ -501,8 +538,12 @@ public static class PromiseBuiltIns
     /// <summary>
     /// Implementation of Promise.withResolvers()
     /// Returns {promise, resolve, reject} for external promise resolution.
+    /// The promise comes from <paramref name="promiseFactory"/> when called
+    /// off a Promise subclass (#242), else is a plain SharpTSPromise.
     /// </summary>
-    private static object? WithResolversImpl()
+    private static object? WithResolversImpl(
+        Interpreter interpreter,
+        Func<Interpreter, Task<object?>, SharpTSPromise>? promiseFactory)
     {
         var tcs = new TaskCompletionSource<object?>();
 
@@ -520,7 +561,9 @@ public static class PromiseBuiltIns
             return RuntimeValue.Null;
         });
 
-        var promise = new SharpTSPromise(tcs.Task);
+        var promise = promiseFactory != null
+            ? promiseFactory(interpreter, tcs.Task)
+            : new SharpTSPromise(tcs.Task);
 
         return new SharpTSObject(new Dictionary<string, object?>
         {

--- a/Runtime/BuiltIns/SymbolBuiltIns.cs
+++ b/Runtime/BuiltIns/SymbolBuiltIns.cs
@@ -67,4 +67,28 @@ public static class SymbolBuiltIns
             _ => null
         };
     }
+
+    /// <summary>
+    /// Gets an instance member for a symbol value (Symbol.prototype surface).
+    /// </summary>
+    /// <param name="symbol">The receiver symbol</param>
+    /// <param name="name">The member name (e.g., "description", "toString")</param>
+    /// <returns>The member value or bound method, or null if not found</returns>
+    public static object? GetInstanceMember(SharpTSSymbol symbol, string name)
+    {
+        return name switch
+        {
+            "description" => symbol.Description ?? (object)SharpTSUndefined.Instance,
+
+            // Symbol.prototype.toString - returns SymbolDescriptiveString, e.g. "Symbol(desc)"
+            "toString" => BuiltInMethod.CreateV2("toString", 0, (_, _, _) =>
+                RuntimeValue.FromString(symbol.ToString())),
+
+            // Symbol.prototype.valueOf - returns the symbol itself
+            "valueOf" => BuiltInMethod.CreateV2("valueOf", 0, (_, _, _) =>
+                RuntimeValue.FromSymbol(symbol)),
+
+            _ => null
+        };
+    }
 }

--- a/Runtime/Types/SharpTSPromiseClass.cs
+++ b/Runtime/Types/SharpTSPromiseClass.cs
@@ -1,0 +1,319 @@
+using SharpTS.Execution;
+using SharpTS.Parsing;
+
+namespace SharpTS.Runtime.Types;
+
+/// <summary>
+/// A <see cref="SharpTSPromise"/> created by a guest class that extends
+/// <c>Promise</c>. IS a promise (await, then/catch/finally, combinator
+/// participation, and <c>instanceof Promise</c> work unchanged) and
+/// additionally carries the guest class for method/getter lookup and
+/// <c>instanceof</c> brand checks, plus an own-property table for declared
+/// fields (base <see cref="SharpTSPromise"/> has no property storage).
+/// </summary>
+/// <seealso cref="SharpTSPromiseClass"/>
+public sealed class SharpTSPromiseSubclassInstance : SharpTSPromise
+{
+    private Dictionary<string, object?>? _ownProperties;
+
+    /// <summary>The guest class this promise was constructed by.</summary>
+    public SharpTSPromiseClass Klass { get; }
+
+    /// <summary>
+    /// The capability backing this promise — settled by <c>super(executor)</c>
+    /// (or directly when the subclass is constructed from an existing task,
+    /// e.g. by <see cref="SharpTSPromiseClass.ConstructDerived"/>).
+    /// </summary>
+    internal TaskCompletionSource<object?> Capability { get; }
+
+    public SharpTSPromiseSubclassInstance(SharpTSPromiseClass klass, TaskCompletionSource<object?> capability)
+        : base(capability.Task)
+    {
+        Klass = klass;
+        Capability = capability;
+    }
+
+    public bool TryGetOwnProperty(string name, out object? value)
+    {
+        if (_ownProperties != null && _ownProperties.TryGetValue(name, out value))
+            return true;
+        value = null;
+        return false;
+    }
+
+    public void SetOwnProperty(string name, object? value)
+        => (_ownProperties ??= [])[name] = value;
+}
+
+/// <summary>
+/// A <see cref="SharpTSClass"/> subclass representing <c>Promise</c> in a
+/// class hierarchy — the bridge that lets <c>class MyPromise extends Promise</c>
+/// work (#242). Mirrors the <see cref="SharpTSArrayClass"/> pattern: the base
+/// singleton stands in for the built-in constructor (its <c>constructor</c>
+/// method implements <c>super(executor)</c> semantics), and user subclasses
+/// override <see cref="Call"/> to produce promise-backed instances.
+/// </summary>
+/// <remarks>
+/// Scope: executor construction with <c>super(executor)</c>, instance
+/// methods/getters/fields, instanceof both ways, static-side inheritance of
+/// the Promise built-ins (<c>MyPromise.resolve</c> etc. construct
+/// subclass-typed results via <see cref="ConstructDerived"/>), and
+/// subclass-typed results from <c>then</c>/<c>catch</c>/<c>finally</c>.
+/// Derived-promise creation uses the receiver's own class directly
+/// ("species-lite") — the full SpeciesConstructor/NewPromiseCapability spec
+/// surface (constructor/@@species lookups, poisoned-getter synchronous
+/// throws) remains tracked by #221.
+/// </remarks>
+public class SharpTSPromiseClass : SharpTSClass
+{
+    /// <summary>
+    /// The singleton standing in for the built-in <c>Promise</c> constructor
+    /// at the root of guest Promise-subclass hierarchies.
+    /// </summary>
+    public static readonly SharpTSPromiseClass PromiseBase = new();
+
+    private SharpTSPromiseClass()
+        : base(
+            "Promise",
+            null,
+            methods: new Dictionary<string, ISharpTSCallable>
+            {
+                ["constructor"] = new PromiseConstructorCallable()
+            },
+            staticMethods: [],
+            staticProperties: [])
+    {
+    }
+
+    /// <summary>
+    /// Creates a user-defined Promise subclass (e.g. <c>class MyPromise extends Promise</c>).
+    /// </summary>
+    public SharpTSPromiseClass(
+        string name,
+        SharpTSPromiseClass superclass,
+        Dictionary<string, ISharpTSCallable> methods,
+        Dictionary<string, ISharpTSCallable> staticMethods,
+        Dictionary<string, object?> staticProperties,
+        Dictionary<string, SharpTSFunction>? getters = null,
+        Dictionary<string, SharpTSFunction>? setters = null,
+        bool isAbstract = false,
+        List<Stmt.Field>? instanceFields = null,
+        List<Stmt.Field>? instancePrivateFields = null,
+        Dictionary<string, ISharpTSCallable>? privateMethods = null,
+        Dictionary<string, object?>? staticPrivateFields = null,
+        Dictionary<string, ISharpTSCallable>? staticPrivateMethods = null,
+        List<Stmt.AutoAccessor>? instanceAutoAccessors = null,
+        Dictionary<string, object?>? staticAutoAccessors = null,
+        Dictionary<string, SharpTSFunction>? staticGetters = null,
+        Dictionary<string, SharpTSFunction>? staticSetters = null)
+        : base(
+            name,
+            superclass,
+            methods,
+            staticMethods,
+            staticProperties,
+            getters,
+            setters,
+            isAbstract,
+            instanceFields,
+            instancePrivateFields,
+            privateMethods,
+            staticPrivateFields,
+            staticPrivateMethods,
+            instanceAutoAccessors,
+            staticAutoAccessors,
+            staticGetters,
+            staticSetters)
+    {
+    }
+
+    /// <summary>
+    /// Constructs a <see cref="SharpTSPromiseSubclassInstance"/>, initialises
+    /// declared public fields as own properties, then runs the user
+    /// constructor (whose <c>super(executor)</c> resolves to
+    /// <see cref="PromiseConstructorCallable"/>) or, absent one, applies the
+    /// built-in Promise constructor semantics directly.
+    /// </summary>
+    public override object? Call(Interpreter interpreter, List<object?> arguments)
+    {
+        var capability = new TaskCompletionSource<object?>();
+        var instance = new SharpTSPromiseSubclassInstance(this, capability);
+
+        InitializeFieldsAsOwnProperties(interpreter, instance);
+
+        ISharpTSCallable? constructor = FindMethod("constructor");
+        bool hasUserConstructor = constructor is not PromiseConstructorCallable;
+
+        if (hasUserConstructor && constructor != null)
+        {
+            BindMethodToReceiver(constructor, instance).Call(interpreter, arguments);
+        }
+        else
+        {
+            RunExecutor(interpreter, RequireExecutor(arguments), capability);
+        }
+
+        return instance;
+    }
+
+    /// <summary>
+    /// Constructs a subclass instance settled from an existing task —
+    /// the species-lite stand-in for NewPromiseCapability used by inherited
+    /// statics (<c>MyPromise.resolve</c>) and by <c>then</c>/<c>catch</c>/
+    /// <c>finally</c> on subclass receivers. Runs the class's own
+    /// construction (field initialisers and any user constructor, fed a
+    /// no-op executor) so the result is a fully initialised instance.
+    /// </summary>
+    internal SharpTSPromise ConstructDerived(Interpreter interpreter, Task<object?> source)
+    {
+        var instance = (SharpTSPromiseSubclassInstance)Call(interpreter, [new CapturingExecutor()])!;
+        SettleFromTask(source, instance.Capability);
+        return instance;
+    }
+
+    /// <summary>
+    /// Runs a guest Promise executor against a capability: invokes it
+    /// synchronously with host resolve/reject callbacks (resolve flattens
+    /// promise values; both are first-settlement-wins) and converts a
+    /// throwing executor into a rejection. Shared by the base
+    /// <c>new Promise(executor)</c> path and the subclass bridge.
+    /// </summary>
+    internal static void RunExecutor(Interpreter interpreter, ISharpTSCallable executor, TaskCompletionSource<object?> tcs)
+    {
+        bool settled = false;
+        object settledLock = new();
+
+        var resolveCallback = new PromiseResolveCallback(value =>
+        {
+            lock (settledLock)
+            {
+                if (settled) return;
+                settled = true;
+            }
+
+            // Handle promise flattening - if value is a Promise, wait for it
+            if (value is SharpTSPromise innerPromise)
+            {
+                innerPromise.Task.ContinueWith(t =>
+                {
+                    if (t.IsFaulted)
+                        tcs.TrySetException(t.Exception!.InnerException ?? t.Exception);
+                    else
+                        tcs.TrySetResult(t.Result);
+                }, TaskScheduler.Default);
+            }
+            else
+            {
+                tcs.TrySetResult(value);
+            }
+        });
+
+        var rejectCallback = new PromiseRejectCallback(reason =>
+        {
+            lock (settledLock)
+            {
+                if (settled) return;
+                settled = true;
+            }
+            tcs.TrySetException(new SharpTSPromiseRejectedException(reason));
+        });
+
+        try
+        {
+            executor.Call(interpreter, [resolveCallback, rejectCallback]);
+        }
+        catch (Exception ex)
+        {
+            lock (settledLock)
+            {
+                if (!settled)
+                {
+                    settled = true;
+                    tcs.TrySetException(new SharpTSPromiseRejectedException(ex.Message));
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Settles a capability from a source task, flattening promise results
+    /// the same way an executor's resolve callback would.
+    /// </summary>
+    private static void SettleFromTask(Task<object?> source, TaskCompletionSource<object?> target)
+    {
+        source.ContinueWith(t =>
+        {
+            if (t.IsFaulted)
+                target.TrySetException(t.Exception!.InnerException ?? t.Exception);
+            else if (t.IsCanceled)
+                target.TrySetCanceled();
+            else if (t.Result is SharpTSPromise inner)
+                SettleFromTask(inner.Task, target);
+            else
+                target.TrySetResult(t.Result);
+        }, TaskContinuationOptions.ExecuteSynchronously);
+    }
+
+    private static ISharpTSCallable RequireExecutor(List<object?> arguments)
+    {
+        if (arguments.Count < 1 || arguments[0] is not ISharpTSCallable executor)
+            throw new InterpreterException("Promise executor must be callable.");
+        return executor;
+    }
+
+    /// <summary>
+    /// Initialises declared public instance fields (walking the superclass
+    /// chain root-first) as own properties on the promise instance.
+    /// </summary>
+    private void InitializeFieldsAsOwnProperties(Interpreter interpreter, SharpTSPromiseSubclassInstance instance)
+    {
+        if (Superclass is SharpTSPromiseClass parent)
+            parent.InitializeFieldsAsOwnProperties(interpreter, instance);
+
+        foreach (var field in InstanceFields)
+        {
+            object? value = field.Initializer != null
+                ? interpreter.Evaluate(field.Initializer)
+                : null;
+            string key = field.ComputedKey != null
+                ? interpreter.Evaluate(field.ComputedKey)?.ToString() ?? "undefined"
+                : field.Name.Lexeme;
+            instance.SetOwnProperty(key, value);
+        }
+    }
+
+    /// <summary>
+    /// Built-in Promise constructor callable — the target of <c>super(executor)</c>
+    /// in user subclass constructors. Wires the executor to the bound
+    /// receiver's capability.
+    /// </summary>
+    internal sealed class PromiseConstructorCallable : ISharpTSCallable, IReceiverBindable
+    {
+        private object? _boundReceiver;
+
+        public int Arity() => 1;
+
+        public ISharpTSCallable BindToReceiver(object receiver)
+            => new PromiseConstructorCallable { _boundReceiver = receiver };
+
+        public object? Call(Interpreter interpreter, List<object?> arguments)
+        {
+            var receiver = _boundReceiver ?? interpreter.GetCurrentThis();
+            if (receiver is SharpTSPromiseSubclassInstance instance)
+                RunExecutor(interpreter, RequireExecutor(arguments), instance.Capability);
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Placeholder executor passed to the class constructor by
+    /// <see cref="ConstructDerived"/>. Accepts (and discards) the
+    /// resolve/reject callbacks — the derived instance's capability is
+    /// settled from the source task instead.
+    /// </summary>
+    private sealed class CapturingExecutor : ISharpTSCallable
+    {
+        public int Arity() => 2;
+        public object? Call(Interpreter interpreter, List<object?> arguments) => null;
+    }
+}

--- a/SharpTS.Tests/SharedTests/ArraySubclassTests.cs
+++ b/SharpTS.Tests/SharedTests/ArraySubclassTests.cs
@@ -117,18 +117,17 @@ public class ArraySubclassTests
 
     [Theory]
     [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
-    public void ExtendsPromise_TypeChecksButRuntimeUnsupported(ExecutionMode mode)
+    public void ExtendsUnbridgedBuiltIn_PreciseRuntimeError(ExecutionMode mode)
     {
-        // #233: `extends Promise<T>` must pass the type checker (it used to be
-        // rejected with TS2315 "Cannot use type arguments with non-generic
-        // class"). The runtime bridge is tracked separately (#221) — until it
-        // lands, instantiating the hierarchy yields a precise error.
+        // Built-ins without a subclassing bridge (Error/Array/#233 and
+        // Promise/#242 have bridges; Map et al do not yet) keep yielding a
+        // precise error rather than the generic "Superclass must be a class".
         var source = """
-            class MyPromise<T> extends Promise<T> {}
+            class MyMap extends Map {}
             console.log("declared");
             """;
 
         var ex = Assert.ThrowsAny<Exception>(() => TestHarness.Run(source, mode));
-        Assert.Contains("cannot extend built-in 'Promise'", ex.Message);
+        Assert.Contains("cannot extend built-in 'Map'", ex.Message);
     }
 }

--- a/SharpTS.Tests/SharedTests/ClassTests.cs
+++ b/SharpTS.Tests/SharedTests/ClassTests.cs
@@ -594,4 +594,46 @@ public class ClassTests
         var output = TestHarness.Run(source, mode);
         Assert.Equal("any\ntrue\n", output);
     }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void InstanceofGenericClass_Works(ExecutionMode mode)
+    {
+        // Regression: compiled `b instanceof Box` emitted the OPEN generic
+        // definition while instances carry constructed types (Box<object>),
+        // so IsAssignableFrom never matched and the check was always false.
+        var source = """
+            class Box<T> { v: T; constructor(v: T) { this.v = v; } }
+            const b = new Box<number>(1);
+            console.log(b instanceof Box);
+            async function main() {
+                const b2 = new Box<string>("s");
+                console.log(b2 instanceof Box);
+            }
+            main();
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("true\ntrue\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void InstanceofUserClass_InsideAsyncFunction(ExecutionMode mode)
+    {
+        // Regression: state-machine emitters resolved user class identifiers
+        // to null inside async bodies, so `x instanceof MyClass` was always
+        // false there (built-ins were fixed in #232; user classes were not).
+        var source = """
+            class Plain { x: number = 1; }
+            async function main() {
+                const p = new Plain();
+                console.log(p instanceof Plain);
+            }
+            main();
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("true\n", output);
+    }
 }

--- a/SharpTS.Tests/SharedTests/PromiseSubclassTests.cs
+++ b/SharpTS.Tests/SharedTests/PromiseSubclassTests.cs
@@ -1,0 +1,237 @@
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests;
+
+/// <summary>
+/// Tests for guest classes extending the built-in Promise (#242).
+/// Runs against both interpreter and compiler.
+/// </summary>
+public class PromiseSubclassTests
+{
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ExtendsPromise_ExecutorConstructionAndBrand(ExecutionMode mode)
+    {
+        var source = """
+            class MyPromise<T> extends Promise<T> {}
+            async function main() {
+                const p = new MyPromise<number>((resolve, reject) => resolve(41));
+                console.log(p instanceof MyPromise);
+                console.log(p instanceof Promise);
+                console.log(await p);
+            }
+            main();
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("true\ntrue\n41\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ExtendsPromise_MethodsAndFields(ExecutionMode mode)
+    {
+        var source = """
+            class MyPromise<T> extends Promise<T> {
+                label: string = "mine";
+                tag(): string { return "MyPromise:" + this.label; }
+            }
+            async function main() {
+                const p = new MyPromise<number>((resolve) => resolve(1));
+                console.log(p.label);
+                console.log(p.tag());
+                p.label = "updated";
+                console.log(p.tag());
+            }
+            main();
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("mine\nMyPromise:mine\nMyPromise:updated\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ExtendsPromise_StaticSideInheritance_Resolve(ExecutionMode mode)
+    {
+        var source = """
+            class MyPromise<T> extends Promise<T> {}
+            async function main() {
+                const p = MyPromise.resolve(1);
+                console.log(p instanceof MyPromise);
+                console.log(p instanceof Promise);
+                console.log(await p);
+            }
+            main();
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("true\ntrue\n1\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ExtendsPromise_ThenReturnsSubclass(ExecutionMode mode)
+    {
+        var source = """
+            class MyPromise<T> extends Promise<T> {}
+            async function main() {
+                const p = new MyPromise<number>((resolve) => resolve(41));
+                const q = p.then(v => v + 1);
+                console.log(q instanceof MyPromise);
+                console.log(await q);
+            }
+            main();
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("true\n42\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ExtendsPromise_RejectAndCatch(ExecutionMode mode)
+    {
+        var source = """
+            class MyPromise<T> extends Promise<T> {}
+            async function main() {
+                const p = MyPromise.reject(new Error("boom")).catch((e: any) => "caught:" + e.message);
+                console.log(p instanceof MyPromise);
+                console.log(await p);
+            }
+            main();
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("true\ncaught:boom\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ExtendsPromise_UserConstructorWithSuper(ExecutionMode mode)
+    {
+        var source = """
+            class Tracked<T> extends Promise<T> {
+                created: string;
+                constructor(executor: (resolve: (v: T) => void, reject: (r: any) => void) => void) {
+                    super(executor);
+                    this.created = "yes";
+                }
+            }
+            async function main() {
+                const t = new Tracked<string>((resolve) => resolve("v"));
+                console.log(t.created);
+                console.log(t instanceof Tracked, t instanceof Promise);
+                console.log(await t);
+            }
+            main();
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("yes\ntrue true\nv\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ExtendsPromise_TransitiveSubclass(ExecutionMode mode)
+    {
+        var source = """
+            class MyPromise<T> extends Promise<T> {}
+            class Deeper<T> extends MyPromise<T> {}
+            async function main() {
+                const t = new Deeper<number>((resolve) => resolve(7));
+                console.log(t instanceof Deeper);
+                console.log(await t);
+                const d = Deeper.resolve("x");
+                console.log(d instanceof Deeper);
+                console.log(d instanceof MyPromise);
+                console.log(d instanceof Promise);
+                console.log(await d);
+            }
+            main();
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("true\n7\ntrue\ntrue\ntrue\nx\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ExtendsPromise_Combinators(ExecutionMode mode)
+    {
+        var source = """
+            class MyPromise<T> extends Promise<T> {}
+            async function main() {
+                const all = MyPromise.all([MyPromise.resolve(3), Promise.resolve(4)]);
+                console.log(all instanceof MyPromise);
+                const r = await all;
+                console.log(r[0] + r[1]);
+                const raced = MyPromise.race([MyPromise.resolve("first")]);
+                console.log(raced instanceof MyPromise);
+                console.log(await raced);
+            }
+            main();
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("true\n7\ntrue\nfirst\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ExtendsPromise_WithResolvers(ExecutionMode mode)
+    {
+        var source = """
+            class MyPromise<T> extends Promise<T> {}
+            async function main() {
+                const wr = MyPromise.withResolvers();
+                wr.resolve(9);
+                console.log(await wr.promise);
+            }
+            main();
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("9\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ExtendsPromise_DynamicDispatch_ThenKeepsBrand(ExecutionMode mode)
+    {
+        var source = """
+            class MyPromise<T> extends Promise<T> {}
+            async function main() {
+                const p: any = MyPromise.resolve(5);
+                const r = p.then((v: number) => v * 2);
+                console.log(r instanceof MyPromise);
+                console.log(await r);
+            }
+            main();
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("true\n10\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ExtendsPromise_BasePromiseUnaffected(ExecutionMode mode)
+    {
+        var source = """
+            class MyPromise<T> extends Promise<T> {}
+            async function main() {
+                const q = Promise.resolve(7);
+                console.log(q instanceof MyPromise);
+                console.log(q instanceof Promise);
+                console.log(await q.then(v => v * 2));
+            }
+            main();
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("false\ntrue\n14\n", output);
+    }
+
+}

--- a/SharpTS.Tests/SharedTests/SymbolTests.cs
+++ b/SharpTS.Tests/SharedTests/SymbolTests.cs
@@ -473,6 +473,70 @@ public class SymbolTests
 
     #endregion
 
+    #region Symbol.prototype Surface (#237)
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Symbol_ToString_ReturnsDescriptiveString(ExecutionMode mode)
+    {
+        var source = """
+            let s = Symbol("d");
+            console.log(s.toString());
+            let noDesc = Symbol();
+            console.log(noDesc.toString());
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("Symbol(d)\nSymbol()\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Symbol_ValueOf_ReturnsSelf(ExecutionMode mode)
+    {
+        var source = """
+            let s = Symbol("d");
+            console.log(s.valueOf() === s);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("true\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Symbol_StringCallForm_ReturnsDescriptiveString(ExecutionMode mode)
+    {
+        // ECMA-262 §22.1.1.1: the String() call form is exempt from ToString's
+        // Symbol TypeError and returns SymbolDescriptiveString instead.
+        var source = """
+            console.log(String(Symbol("d")));
+            console.log(String(Symbol()));
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("Symbol(d)\nSymbol()\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Symbol_AnyTyped_PrototypeMembers_Work(ExecutionMode mode)
+    {
+        // Dynamic-dispatch path (receiver statically `any`) must resolve the
+        // same Symbol.prototype surface as the typed path.
+        var source = """
+            const s: any = Symbol("dyn");
+            console.log(s.description);
+            console.log(s.toString());
+            console.log(s.valueOf() === s);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("dyn\nSymbol(dyn)\ntrue\n", output);
+    }
+
+    #endregion
+
     #region Symbol as First-Class Global (#234)
 
     [Theory]


### PR DESCRIPTION
Closes #237. Closes #242.

## Commits

**1. fix(symbol): Symbol.prototype surface gaps in both modes (#237)**
- Interp: `sym.toString()` / `sym.valueOf()` now resolve (shared `SymbolBuiltIns.GetInstanceMember`, de-duplicating the two registry sites).
- Compiled: `String(sym)` returns SymbolDescriptiveString per ECMA-262 §22.1.1.1 via a new `$Runtime.StringFromValue` used by BOTH the sync emitter and the async/generator path (which previously diverged through `Stringify`).
- Compiled: `sym.valueOf()` returned null on the dynamic-dispatch path — `$TSSymbol` now defines `valueOf()`.

**2. fix(compile): instanceof with user-class targets**
Two pre-existing gaps surfaced by #242''s acceptance test:
- `x instanceof GenericClass` was always false (open generic definition vs constructed instantiations) — fixed with a generic-definition walk in the InstanceOf helper.
- `x instanceof UserClass` inside async/generator bodies was always false (state-machine variable resolution emitted null for user class identifiers) — user-class arm added, mirroring the #232 built-in fix.
- `x instanceof Promise` now also accepts `$Promise` instances.

**3. feat(promise): guest classes can extend Promise in both modes (#242)**

The acceptance sketch from the issue now passes identically in both modes:
```ts
class MyPromise<T> extends Promise<T> {}
const p = MyPromise.resolve(1);        // static-side inheritance ✓
p instanceof MyPromise;                // true ✓
p instanceof Promise;                  // true ✓
p.then(v => ...)                       // returns MyPromise ✓
```
- **Interpreter**: `SharpTSPromiseClass`/`SharpTSPromiseSubclassInstance` bridge mirroring the #233 Array pattern; instances ARE `SharpTSPromise`s (await/combinators work unchanged); executor wiring shared with the base `new Promise(executor)` path; derived promises constructed through the class''s own construction (field initialisers + user ctor) then settled from the source task.
- **Compiled**: subclasses derive from the emitted `$Promise`; `PromiseFromExecutor` adopts a raw `Task<object?>` so the executor ctor doubles as the derived-promise ctor; static-side inheritance emits the base static + `newobj` subclass; `then`/`catch`/`finally` unwrap `$Promise` receivers (fixes a hard `Castclass Task` crash) and re-wrap results into the receiver''s type on both typed and dynamic paths; combinator inputs normalize `$Promise` elements to their tasks.
- Species-lite: derived creation uses the receiver''s own class; full SpeciesConstructor/NewPromiseCapability (poisoned ctor getters, `@@species` reads) remains tracked by #221.

## Issues filed along the way
- #245 — implicit symbol→string coercion (template literal, `+`) silently stringifies instead of throwing TypeError (both modes)
- #251 — compiled multi-arg `console.log` with an inline `await` emits invalid IL (pre-existing, reproduced on main)

## Testing
- Full suite green: 10,683 passed / 0 failed (the one failure during development was the now-obsolete `ExtendsPromise_TypeChecksButRuntimeUnsupported`, repurposed to assert the precise error for still-unbridged built-ins).
- New: `PromiseSubclassTests` (11 both-mode tests: executor ctor, fields/methods, static inheritance, then-returns-subclass, reject/catch, user ctor + super, transitive subclass, combinators, withResolvers, dynamic-dispatch brand, base-Promise isolation), 4 new `SymbolTests`, 2 instanceof regressions in `ClassTests`.
- `--compile --verify`: IL verification passes on the acceptance script.