### PR TITLE
Type-AST migration slice 1: function/constructor type nodes

### DIFF
--- a/Parsing/AST.cs
+++ b/Parsing/AST.cs
@@ -351,7 +351,7 @@ public abstract record Stmt
     /// Const variable declaration. Separate from Var for cleaner const-specific handling (e.g., unique symbol).
     /// Initializer is non-nullable since const always requires initialization.
     /// </summary>
-    public record Const(Token Name, string? TypeAnnotation, Expr Initializer) : Stmt;
+    public record Const(Token Name, string? TypeAnnotation, Expr Initializer, TypeNode? TypeAnnotationNode = null) : Stmt;
     /// <summary>
     /// Function or method declaration. Body is null for overload signatures (declaration only).
     /// ThisType is the explicit this parameter type annotation (e.g., this: MyClass).

--- a/Parsing/Parser.Declarations.cs
+++ b/Parsing/Parser.Declarations.cs
@@ -756,7 +756,7 @@ public partial class Parser
         }
 
         if (isConst)
-            return new Stmt.Const(name, typeAnnotation, initializer!);
+            return new Stmt.Const(name, typeAnnotation, initializer!, typeAnnotationNode);
         return new Stmt.Var(name, typeAnnotation, initializer, hasDefiniteAssignment, isVar, typeAnnotationNode);
     }
 

--- a/Parsing/Parser.Types.cs
+++ b/Parsing/Parser.Types.cs
@@ -75,8 +75,12 @@ public partial class Parser
     /// </summary>
     private string ParseFunctionTypeBody()
     {
+        int startLine = Previous().Line; // the '(' the caller consumed
         string? thisType = null;
+        TypeNode? thisTypeNode = null;
         List<string> paramTypes = [];
+        List<ParameterTypeNode> paramNodes = [];
+        bool nodeComplete = true; // false once any component lacks a node → whole type falls back
 
         // Check for 'this' parameter: (this: Window, ...)
         if (Check(TokenType.THIS) && PeekNext().Type == TokenType.COLON)
@@ -84,6 +88,8 @@ public partial class Parser
             Advance(); // consume 'this'
             Consume(TokenType.COLON, "Expect ':' after 'this' in function type.");
             thisType = ParseTypeAnnotation();
+            thisTypeNode = TakeTypeNode();
+            if (thisTypeNode is null) nodeComplete = false;
             if (Check(TokenType.COMMA))
             {
                 Advance(); // consume ','
@@ -104,29 +110,47 @@ public partial class Parser
                 // Parameter can be: name: type, name?: type, name (bare, implicit any),
                 // name? (bare optional, implicit any), or just a type expression.
                 string paramType;
+                string? paramName = null;
+                TypeNode? paramTypeNode;
                 if ((Check(TokenType.IDENTIFIER) || IsContextualKeyword(Peek().Type)) &&
                     (PeekNext().Type == TokenType.COLON || PeekNext().Type == TokenType.QUESTION))
                 {
-                    Advance(); // skip name (may be a contextual keyword, e.g. `set: Set<T>`)
+                    paramName = Advance().Lexeme; // name may be a contextual keyword, e.g. `set: Set<T>`
                     if (Match(TokenType.QUESTION))
                     {
                         isOptional = true;
                     }
                     // The type annotation is optional: `(x?) => R` / `(x) => R` give the parameter
                     // an implicit `any` type (the name is a label only).
-                    paramType = Match(TokenType.COLON) ? ParseTypeAnnotation() : "any";
+                    if (Match(TokenType.COLON))
+                    {
+                        paramType = ParseTypeAnnotation();
+                        paramTypeNode = TakeTypeNode();
+                    }
+                    else
+                    {
+                        paramType = "any";
+                        paramTypeNode = new NamedTypeNode("any", null, Previous().Line);
+                    }
                 }
                 else if (!isRest && Check(TokenType.IDENTIFIER) &&
                          (PeekNext().Type == TokenType.RIGHT_PAREN || PeekNext().Type == TokenType.COMMA))
                 {
                     // Bare parameter name with no annotation: implicit `any`.
-                    Advance(); // consume name
+                    paramName = Advance().Lexeme;
                     paramType = "any";
+                    paramTypeNode = new NamedTypeNode("any", null, Previous().Line);
                 }
                 else
                 {
                     paramType = ParseTypeAnnotation();
+                    paramTypeNode = TakeTypeNode();
                 }
+
+                if (paramTypeNode is null)
+                    nodeComplete = false;
+                else
+                    paramNodes.Add(new ParameterTypeNode(paramName, paramTypeNode, isOptional, isRest, paramTypeNode.Line));
 
                 // Preserve optional/rest info in the type string representation
                 if (isRest)
@@ -142,6 +166,12 @@ public partial class Parser
         Consume(TokenType.RIGHT_PAREN, "Expect ')' after function type parameters.");
         Consume(TokenType.ARROW, "Expect '=>' after function type parameters.");
         string returnType = ParseTypeAnnotation();
+        TypeNode? returnTypeNode = TakeTypeNode();
+
+        // Publish the structured form (or explicitly clear, so no nested node leaks out).
+        _lastTypeNode = nodeComplete && returnTypeNode is not null
+            ? new FunctionTypeNode(thisTypeNode, paramNodes, returnTypeNode, startLine)
+            : null;
 
         // Build the function type string
         if (thisType != null)
@@ -329,7 +359,11 @@ public partial class Parser
             }
             Consume(TokenType.LEFT_PAREN, "Expect '(' in constructor type.");
             string ctorBody = ParseFunctionTypeBody(); // returns "(params) => ReturnType"
-            _lastTypeNode = null;
+            // Generic constructor types await type-parameter scoping (slice 3), and a `this`
+            // parameter has no slot on a ConstructorSignature — both fall back to the string path.
+            _lastTypeNode = TakeTypeNode() is FunctionTypeNode { ThisType: null } ctorFn && genericPrefix.Length == 0
+                ? new ConstructorTypeNode(ctorFn.Parameters, ctorFn.ReturnType, ctorFn.Line)
+                : null;
             return $"{{ new {genericPrefix}{ctorBody} }}";
         }
 
@@ -482,6 +516,7 @@ public partial class Parser
             if (isFunctionType)
             {
                 typeName = ParseFunctionTypeBody();
+                typeNode = TakeTypeNode();
             }
             else
             {

--- a/Parsing/TypeNodes.cs
+++ b/Parsing/TypeNodes.cs
@@ -27,6 +27,20 @@ public sealed record ArrayTypeNode(TypeNode ElementType, int Line) : TypeNode(Li
 /// <summary>A union type: <c>A | B | C</c>.</summary>
 public sealed record UnionTypeNode(List<TypeNode> Members, int Line) : TypeNode(Line);
 
+/// <summary>A parameter inside a function or constructor type: <c>x: T</c>, <c>x?: T</c>,
+/// <c>...rest: T[]</c>. A bare name (<c>(x) =&gt; R</c>) gets an explicit <c>any</c> type node —
+/// the name is a label only, never resolved. Not itself a type.</summary>
+public sealed record ParameterTypeNode(string? Name, TypeNode Type, bool IsOptional, bool IsRest, int Line);
+
+/// <summary>A function type: <c>(a: T) =&gt; R</c>, optionally with a leading
+/// <c>this: X</c> pseudo-parameter (carried separately — it does not count toward arity).</summary>
+public sealed record FunctionTypeNode(TypeNode? ThisType, List<ParameterTypeNode> Parameters, TypeNode ReturnType, int Line) : TypeNode(Line);
+
+/// <summary>A constructor type: <c>new (a: T) =&gt; R</c>. Resolves to an object type carrying a
+/// single construct signature, mirroring the string path's <c>{ new (…) =&gt; R }</c> rendering.
+/// Generic constructor types (<c>new &lt;T&gt;(…) =&gt; R</c>) have no node yet (slice 3).</summary>
+public sealed record ConstructorTypeNode(List<ParameterTypeNode> Parameters, TypeNode ReturnType, int Line) : TypeNode(Line);
+
 /// <summary>
 /// Counters proving how much of the corpus the node path already covers — read by tests and
 /// dumped by the checker when <c>SHARPTS_TYPENODE_STATS=1</c>. Coarse by design (spike

--- a/SharpTS.Tests/TypeCheckerTests/TypeNodeSliceTests.cs
+++ b/SharpTS.Tests/TypeCheckerTests/TypeNodeSliceTests.cs
@@ -32,10 +32,62 @@ public class TypeNodeSliceTests
     {
         TypeNodeStats.Reset();
         TestHarness.RunInterpreted("""
-            var f: (x: number) => string = (x) => "s";
+            var f: { a: number } = { a: 1 };
             """);
         Assert.True(TypeNodeStats.StringFallbacks >= 1,
-            $"expected the function-type annotation to fall back, got {TypeNodeStats.StringFallbacks}");
+            $"expected the object-type annotation to fall back, got {TypeNodeStats.StringFallbacks}");
+    }
+
+    [Fact]
+    public void NodePath_EngagesForFunctionTypes()
+    {
+        TypeNodeStats.Reset();
+        TestHarness.RunInterpreted("""
+            var f: (x: number) => string = (x) => "s";
+            var g: () => void = () => {};
+            var h: (x: number, y?: string, ...rest: boolean[]) => number = (x) => x;
+            const k: (cb: (n: number) => void) => void = (cb) => cb(1);
+            """);
+        Assert.True(TypeNodeStats.NodeHits >= 4,
+            $"expected the node path for all four function-type annotations, got {TypeNodeStats.NodeHits}");
+        Assert.Equal(0, TypeNodeStats.StringFallbacks);
+    }
+
+    [Fact]
+    public void NodeResolved_FunctionTypeEnforcesParamAndReturn()
+    {
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted("""
+            var f: (x: number) => string = (x: string) => x;
+            """));
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted("""
+            var f: () => string = () => 1;
+            """));
+    }
+
+    [Fact]
+    public void NodeResolved_FunctionTypeArityHonorsOptionalAndRest()
+    {
+        // A two-required-param target rejects a source requiring three; optional/rest params
+        // must not count toward the node-built signature's required arity.
+        TestHarness.RunInterpreted("""
+            var f: (a: number, b: number, c?: number) => void = (a: number, b: number) => {};
+            """);
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted("""
+            var g: (a: number) => void = (a: number, b: number, c: number) => {};
+            """));
+    }
+
+    [Fact]
+    public void NodeResolved_ConstructorTypeIsConstructable()
+    {
+        TypeNodeStats.Reset();
+        TestHarness.RunInterpreted("""
+            class Widget { constructor(public id: number) {} }
+            var make: new (id: number) => Widget = Widget;
+            const w: Widget = new make(1);
+            """);
+        Assert.True(TypeNodeStats.NodeHits >= 1,
+            $"expected the constructor-type annotation on the node path, got {TypeNodeStats.NodeHits}");
     }
 
     [Fact]

--- a/TypeSystem/TypeChecker.Statements.cs
+++ b/TypeSystem/TypeChecker.Statements.cs
@@ -287,7 +287,7 @@ public partial class TypeChecker
         }
         else if (stmt.TypeAnnotation != null)
         {
-            constDeclaredType = ToTypeInfo(stmt.TypeAnnotation);
+            constDeclaredType = ResolveAnnotation(stmt.TypeAnnotation, stmt.TypeAnnotationNode)!;
             _environment.Define(stmt.Name.Lexeme, constDeclaredType);
             var initType = CheckExpr(stmt.Initializer);
             if (!IsCompatible(constDeclaredType, initType))

--- a/TypeSystem/TypeChecker.TypeNodes.cs
+++ b/TypeSystem/TypeChecker.TypeNodes.cs
@@ -1,3 +1,4 @@
+using System.Collections.Frozen;
 using SharpTS.Parsing;
 
 namespace SharpTS.TypeSystem;
@@ -56,9 +57,75 @@ public partial class TypeChecker
                 return members.Aggregate(CreateUnion);
             }
 
+            case FunctionTypeNode fn:
+            {
+                TypeInfo? thisType = null;
+                if (fn.ThisType is { } thisNode)
+                {
+                    if (TryToTypeInfo(thisNode) is not { } resolvedThis) return null;
+                    thisType = resolvedThis;
+                }
+                if (!TryResolveParameters(fn.Parameters, out var paramTypes, out int requiredParams, out bool hasRestParam))
+                    return null;
+                if (TryToTypeInfo(fn.ReturnType) is not { } returnType) return null;
+                return new TypeInfo.Function(paramTypes, returnType, requiredParams, hasRestParam, thisType);
+            }
+
+            // `new (…) => R` models as an object type carrying a single construct signature —
+            // the same shape the string path produces for its "{ new (…) => R }" rendering.
+            case ConstructorTypeNode ctor:
+            {
+                if (!TryResolveParameters(ctor.Parameters, out var paramTypes, out int requiredParams, out bool hasRestParam))
+                    return null;
+                if (TryToTypeInfo(ctor.ReturnType) is not { } returnType) return null;
+                var signature = new TypeInfo.ConstructorSignature(null, paramTypes, returnType, requiredParams, hasRestParam);
+                return new TypeInfo.Record(
+                    FrozenDictionary<string, TypeInfo>.Empty,
+                    ConstructorSignatures: [signature]);
+            }
+
             default:
                 return null;
         }
+    }
+
+    /// <summary>
+    /// Resolves a function/constructor type node's parameter list with the string path's arity
+    /// accounting: optional/rest parameters are not required, and nothing after the first
+    /// optional/rest parameter counts as required. False when any parameter type lacks a node-path
+    /// resolution (the whole signature then falls back to the string).
+    /// </summary>
+    private bool TryResolveParameters(
+        List<ParameterTypeNode> parameters,
+        out List<TypeInfo> paramTypes,
+        out int requiredParams,
+        out bool hasRestParam)
+    {
+        paramTypes = new List<TypeInfo>(parameters.Count);
+        requiredParams = 0;
+        hasRestParam = false;
+        bool sawOptionalOrRest = false;
+
+        foreach (var parameter in parameters)
+        {
+            if (TryToTypeInfo(parameter.Type) is not { } paramType) return false;
+            paramTypes.Add(paramType);
+
+            if (parameter.IsRest)
+            {
+                hasRestParam = true;
+                sawOptionalOrRest = true;
+            }
+            else if (parameter.IsOptional)
+            {
+                sawOptionalOrRest = true;
+            }
+            else if (!sawOptionalOrRest)
+            {
+                requiredParams++;
+            }
+        }
+        return true;
     }
 
     /// <summary>

--- a/TypeSystem/TypeChecker.TypeParsing.cs
+++ b/TypeSystem/TypeChecker.TypeParsing.cs
@@ -802,7 +802,11 @@ public partial class TypeChecker
             char c = paramsStr[i];
             if (c == '(' || c == '<' || c == '[' || c == '{')
                 depth++;
-            else if (c == ')' || c == '>' || c == ']' || c == '}')
+            // The '>' of an arrow '=>' is not a bracket — without this guard a function-typed
+            // parameter drives the depth negative and the comma before the next parameter is
+            // missed, fusing the rest of the list into one unparseable parameter (same family
+            // as the guard in SplitObjectMembers).
+            else if (c == ')' || c == ']' || c == '}' || (c == '>' && (i == 0 || paramsStr[i - 1] != '=')))
                 depth--;
             else if (c == ',' && depth == 0)
             {

--- a/docs/plans/type-ast-design.md
+++ b/docs/plans/type-ast-design.md
@@ -98,8 +98,15 @@ an equivalence test that converts both ways and asserts identical `TypeInfo` ren
 
 ### Order of subsequent slices (each independently shippable)
 
-1. Function/constructor type nodes (`(a: T) => R`, `new (...) => R`) — unlocks retiring the
-   `=>`-scanning bug family.
+1. ✅ **Shipped.** Function/constructor type nodes (`(a: T) => R`, `new (...) => R`), plus
+   `const` annotations wired into the node path. Coverage over the conformance corpus:
+   37% → 46.4% (254 node / 293 fallback). Generic function/constructor types
+   (`<T>(…) => R`) and `this`-parameter constructor types still fall back (slice 3).
+   Shipping this slice immediately caught the **fifth** `>`-of-`=>` instance: the node
+   path parsed `(x: (a: B) => D, y: (a2: B) => D) => R` correctly while the string path's
+   `SplitFunctionParams` fused both parameters into one — previously masked because both
+   sides of the comparison were equally mangled. The string path got the same arrow guard
+   `SplitObjectMembers` already had.
 2. Object-type / tuple / conditional / mapped nodes — the big checker-scanner retirement.
 3. Type aliases store nodes (kills alias string substitution; enables alias-instantiation
    identity for #202's variance cases).


### PR DESCRIPTION
Second increment of the type-AST migration (`docs/plans/type-ast-design.md`, follows #250).

## What

- **`FunctionTypeNode`** — `(a: T) => R`, including `this:` pseudo-parameters, optional (`x?:`) and rest (`...xs:`) parameters, with each parameter carried as a `ParameterTypeNode` (name kept as a label for future diagnostics).
- **`ConstructorTypeNode`** — `new (a: T) => R`, resolving to the same Record-with-one-`ConstructorSignature` shape the string path produces for its `{ new (…) => R }` rendering.
- **`const` declarations** join `var` on the node-first path (`Stmt.Const.TypeAnnotationNode`); the `unique symbol` special case is untouched (it keys off the string before resolution and produces no node).
- Resolution mirrors the string path's arity accounting exactly: optional/rest parameters are not required, and nothing after the first optional/rest counts as required.
- Generic signatures (`<T>(…) => R`, `new <T>(…) => R`) and `this`-parameter constructor types deliberately still fall back — type-parameter scoping is slice 3.

**Coverage over the conformance corpus: 37% → 46.4%** of annotations now resolve through the node path (254 node / 293 fallback). The remaining fallback is dominated by object types and generic signatures (slices 2–3).

## The slice paid for itself immediately

The node path's correct parse of
```ts
var a8: (x: (arg: Base) => Derived, y: (arg2: Base) => Derived) => (r: Base) => Derived;
```
regressed `assignmentCompatWith{Call,Construct}Signatures3` — because the **string** path was wrong: `SplitFunctionParams` treated the `>` of `=>` as a closing bracket, drove its depth negative at the first function-typed parameter, and fused everything after into one unparseable parameter. Both sides of the affected comparisons were equally mangled, so it had never surfaced. This is the **fifth** instance of the `>`-of-`=>` family; the fix is the same arrow guard `SplitObjectMembers` already had. (Retiring this bug family wholesale is exactly slice 1's purpose in the design doc.)

## Validation

- Conformance baseline byte-identical: **Pass 63 / Fail 14 / ParseError 1**, zero drift
- Unit suite: **10,691 passed, 0 failed** (slice tests extended: function-type node engagement, param/return enforcement, optional/rest arity, constructor-type constructability)