### PR TITLE
Type-AST migration slice 2: object-type and tuple nodes

### DIFF
--- a/Parsing/Parser.Declarations.cs
+++ b/Parsing/Parser.Declarations.cs
@@ -614,8 +614,13 @@ public partial class Parser
         }
 
         Consume(TokenType.LEFT_PAREN, "Expect '(' for method parameters.");
+        int startLine = Previous().Line;
         string? thisType = null;
+        TypeNode? thisTypeNode = null;
         List<string> paramTypes = [];
+        List<ParameterTypeNode> paramNodes = [];
+        // Generic signatures await type-parameter scoping (slice 3) — no node for those.
+        bool nodeComplete = genericPrefix.Length == 0;
 
         // Check for 'this' parameter in interface method
         if (Check(TokenType.THIS))
@@ -623,6 +628,8 @@ public partial class Parser
             Advance(); // consume 'this'
             Consume(TokenType.COLON, "Expect ':' after 'this' in this parameter.");
             thisType = ParseTypeAnnotation();
+            thisTypeNode = TakeTypeNode();
+            if (thisTypeNode is null) nodeComplete = false;
             if (Check(TokenType.COMMA))
             {
                 Advance(); // consume ','
@@ -634,10 +641,14 @@ public partial class Parser
             do
             {
                 bool isRest = Match(TokenType.DOT_DOT_DOT);
-                ConsumeIdentifierName("Expect parameter name.");
+                string paramName = ConsumeIdentifierName("Expect parameter name.").Lexeme;
                 bool isOptional = Match(TokenType.QUESTION);
                 Consume(TokenType.COLON, "Expect ':' after parameter name.");
                 string paramType = ParseTypeAnnotation();
+                if (TakeTypeNode() is { } paramTypeNode)
+                    paramNodes.Add(new ParameterTypeNode(paramName, paramTypeNode, isOptional, isRest, paramTypeNode.Line));
+                else
+                    nodeComplete = false;
                 // Encode rest/optional the same way ParseFunctionTypeBody does so the signature
                 // resolver models arity correctly.
                 if (isRest) paramType = "..." + paramType;
@@ -649,6 +660,12 @@ public partial class Parser
         Consume(TokenType.RIGHT_PAREN, "Expect ')' after parameters.");
         Consume(TokenType.COLON, "Expect ':' before return type.");
         string returnType = ParseTypeAnnotation();
+        TypeNode? returnTypeNode = TakeTypeNode();
+
+        // Publish the structured form (or explicitly clear, so no nested node leaks out).
+        _lastTypeNode = nodeComplete && returnTypeNode is not null
+            ? new FunctionTypeNode(thisTypeNode, paramNodes, returnTypeNode, startLine)
+            : null;
 
         if (thisType != null)
         {

--- a/Parsing/Parser.Types.cs
+++ b/Parsing/Parser.Types.cs
@@ -468,6 +468,7 @@ public partial class Parser
         if (Match(TokenType.LEFT_BRACKET))
         {
             typeName = ParseTupleType();
+            typeNode = TakeTypeNode();
         }
         // Handle inline object type syntax: { name: string; age?: number }
         // Assigns typeName (rather than returning) so postfix indexed access applies to
@@ -475,6 +476,7 @@ public partial class Parser
         else if (Match(TokenType.LEFT_BRACE))
         {
             typeName = ParseInlineObjectType();
+            typeNode = TakeTypeNode();
         }
         // Handle parenthesized types: (string | number) or function types: (x: number) => number
         else if (Match(TokenType.LEFT_PAREN))
@@ -647,7 +649,10 @@ public partial class Parser
     private string ParseTupleType()
     {
         // Already consumed LEFT_BRACKET
+        int startLine = Previous().Line;
         List<string> elements = [];
+        List<TupleElementNode> elementNodes = [];
+        bool nodeComplete = true;
 
         while (!Check(TokenType.RIGHT_BRACKET) && !IsAtEnd())
         {
@@ -655,6 +660,13 @@ public partial class Parser
             if (Match(TokenType.DOT_DOT_DOT))
             {
                 string spreadType = ParsePrimaryType();
+                // The resolver distinguishes a trailing rest (`...T[]`) from a variadic spread
+                // TEXTUALLY (EndsWith "[]"). Only carry a node when the structured view agrees —
+                // e.g. a grouped `...(T[])` reads as an array node but not as a "[]" suffix.
+                if (TakeTypeNode() is { } spreadNode && spreadType.EndsWith("[]") == spreadNode is ArrayTypeNode)
+                    elementNodes.Add(new TupleElementNode(null, spreadNode, false, true, spreadNode.Line));
+                else
+                    nodeComplete = false;
 
                 if (spreadType.EndsWith("[]"))
                 {
@@ -702,14 +714,27 @@ public partial class Parser
                 Consume(TokenType.COLON, ""); // consume colon
                 string innerType = ParseUnionType();
                 elementType = isOptional ? $"{name.Lexeme}?: {innerType}" : $"{name.Lexeme}: {innerType}";
+                // The resolver rejects type-keyword names ("string:", "object:", …) and reparses
+                // the whole element as a type — don't model those as named elements.
+                if (TakeTypeNode() is { } innerNode && IsValidTupleElementNameLexeme(name.Lexeme))
+                    elementNodes.Add(new TupleElementNode(name.Lexeme, innerNode, isOptional, false, innerNode.Line));
+                else
+                    nodeComplete = false;
             }
             else
             {
                 elementType = ParseUnionType(); // Support union elements like [string | number, boolean]
+                TypeNode? elementNode = TakeTypeNode();
 
                 // Check for optional marker on unnamed element
-                if (Match(TokenType.QUESTION))
+                bool isOptional = Match(TokenType.QUESTION);
+                if (isOptional)
                     elementType += "?";
+
+                if (elementNode is { })
+                    elementNodes.Add(new TupleElementNode(null, elementNode, isOptional, false, elementNode.Line));
+                else
+                    nodeComplete = false;
             }
 
             elements.Add(elementType);
@@ -719,21 +744,36 @@ public partial class Parser
         }
 
         Consume(TokenType.RIGHT_BRACKET, "Expect ']' after tuple type.");
+        _lastTypeNode = nodeComplete ? new TupleTypeNode(elementNodes, startLine) : null;
         return "[" + string.Join(", ", elements) + "]";
     }
+
+    /// <summary>
+    /// Mirror of the resolver's tuple-element-name validation: the string path only treats
+    /// <c>name:</c> as a label when it isn't a type keyword (otherwise the element re-parses as a
+    /// type). Token-level parsing already guarantees identifier shape; only the keyword list matters.
+    /// </summary>
+    private static bool IsValidTupleElementNameLexeme(string s) =>
+        s is not ("string" or "number" or "boolean" or "void" or "null" or "undefined"
+                or "unknown" or "never" or "any" or "symbol" or "bigint" or "object");
 
     private string ParseInlineObjectType()
     {
         // Already consumed LEFT_BRACE
         // Parses: { name: string; age?: number; greet(x: number): string; [key: string]: number }
         // Also handles mapped types: { [K in keyof T]: T[K] }, { +readonly [K in keyof T]-?: T[K] }
+        int startLine = Previous().Line;
         List<string> members = [];
+        List<ObjectTypeMemberNode> memberNodes = [];
+        bool nodeComplete = true;
 
         // Check for mapped type syntax: { [+/-readonly] [K in ...]: ... }
         // Mapped types have a single member that uses 'in' instead of ':'
         if (IsMappedTypeStart())
         {
-            return ParseMappedType();
+            string mapped = ParseMappedType();
+            _lastTypeNode = null; // mapped types have no node yet
+            return mapped;
         }
 
         while (!Check(TokenType.RIGHT_BRACE) && !IsAtEnd())
@@ -754,6 +794,7 @@ public partial class Parser
                 string computedName = raw.StartsWith("Symbol.") ? "@@" + raw["Symbol.".Length..] : "@@" + raw;
                 bool computedOptional = Match(TokenType.QUESTION);
                 string computedType;
+                int computedLine = Previous().Line;
                 if (Check(TokenType.LEFT_PAREN) || Check(TokenType.LESS))
                 {
                     computedType = ParseMethodSignature();
@@ -763,6 +804,11 @@ public partial class Parser
                     Consume(TokenType.COLON, "Expect ':' after computed member name.");
                     computedType = ParseUnionType();
                 }
+                // The string path renders computed members as plain fields (no method marker).
+                if (TakeTypeNode() is { } computedNode)
+                    memberNodes.Add(new PropertyMemberNode(computedName, computedNode, computedOptional, false, computedLine));
+                else
+                    nodeComplete = false;
                 members.Add($"{computedName}{(computedOptional ? "?" : "")}: {computedType}");
             }
             // Check for index signature: [key: string]: type
@@ -796,23 +842,38 @@ public partial class Parser
 
                 Consume(TokenType.RIGHT_BRACKET, "Expect ']' after index signature key type.");
                 Consume(TokenType.COLON, "Expect ':' after index signature.");
+                int indexLine = Previous().Line;
                 string valueType = ParseUnionType();
 
+                if (TakeTypeNode() is { } valueNode)
+                    memberNodes.Add(new IndexSignatureNode(keyType, valueNode, indexLine));
+                else
+                    nodeComplete = false;
                 members.Add($"[{keyType}]: {valueType}");
             }
             // Construct signature: new (params): ReturnType or new <T>(params): ReturnType
             else if (Check(TokenType.NEW))
             {
                 Advance(); // consume 'new'
+                int newLine = Previous().Line;
                 // ParseMethodSignature consumes optional <generics>, the params, and the return
                 // type, producing an arrow string "(params) => ret"; prefix "new " for a
                 // construct signature so ParseInlineObjectTypeInfo can tell the two apart.
                 members.Add("new " + ParseMethodSignature());
+                if (TakeTypeNode() is FunctionTypeNode ctorSig)
+                    memberNodes.Add(new ConstructSignatureMemberNode(ctorSig, newLine));
+                else
+                    nodeComplete = false;
             }
             // Call signature: (params): ReturnType or <T>(params): ReturnType
             else if (Check(TokenType.LEFT_PAREN) || (Check(TokenType.LESS) && IsCallSignatureStart()))
             {
+                int callLine = Peek().Line;
                 members.Add(ParseMethodSignature());
+                if (TakeTypeNode() is FunctionTypeNode callSig)
+                    memberNodes.Add(new CallSignatureMemberNode(callSig, callLine));
+                else
+                    nodeComplete = false;
             }
             else
             {
@@ -842,6 +903,11 @@ public partial class Parser
                     propertyType = ParseConditionalType();
                 }
 
+                if (TakeTypeNode() is { } propertyNode)
+                    memberNodes.Add(new PropertyMemberNode(propertyName.Lexeme, propertyNode, isOptional, isMethodMember, propertyName.Line));
+                else
+                    nodeComplete = false;
+
                 // Build member string. Method members carry a '#m' marker (stripped by
                 // ParseInlineObjectTypeInfo) so method-ness survives the string round-trip —
                 // under strictFunctionTypes methods keep bivariant parameter relating.
@@ -860,6 +926,7 @@ public partial class Parser
         }
 
         Consume(TokenType.RIGHT_BRACE, "Expect '}' after object type.");
+        _lastTypeNode = nodeComplete ? new ObjectTypeNode(memberNodes, startLine) : null;
         return "{ " + string.Join("; ", members) + " }";
     }
 

--- a/Parsing/TypeNodes.cs
+++ b/Parsing/TypeNodes.cs
@@ -41,6 +41,37 @@ public sealed record FunctionTypeNode(TypeNode? ThisType, List<ParameterTypeNode
 /// Generic constructor types (<c>new &lt;T&gt;(…) =&gt; R</c>) have no node yet (slice 3).</summary>
 public sealed record ConstructorTypeNode(List<ParameterTypeNode> Parameters, TypeNode ReturnType, int Line) : TypeNode(Line);
 
+/// <summary>An inline object type: <c>{ name: string; greet(x: number): void }</c>.
+/// Mapped types (<c>{ [K in keyof T]: … }</c>) have no node (slice 2 follow-up).</summary>
+public sealed record ObjectTypeNode(List<ObjectTypeMemberNode> Members, int Line) : TypeNode(Line);
+
+/// <summary>A member of an <see cref="ObjectTypeNode"/>. Not itself a type.</summary>
+public abstract record ObjectTypeMemberNode(int Line);
+
+/// <summary>A property or method member: <c>name: T</c>, <c>name?: T</c>, <c>name(x: T): R</c>.
+/// Computed names are carried in their string-path spelling (<c>@@iterator</c>). Method-syntax
+/// members keep <see cref="IsMethod"/> so bivariant parameter relating survives
+/// (the string path's <c>#m</c> marker).</summary>
+public sealed record PropertyMemberNode(string Name, TypeNode Type, bool IsOptional, bool IsMethod, int Line) : ObjectTypeMemberNode(Line);
+
+/// <summary>An index signature: <c>[k: string]: T</c>. <see cref="KeyKind"/> is
+/// <c>string</c>, <c>number</c>, or <c>symbol</c>.</summary>
+public sealed record IndexSignatureNode(string KeyKind, TypeNode ValueType, int Line) : ObjectTypeMemberNode(Line);
+
+/// <summary>A call signature member: <c>(x: T): R</c>.</summary>
+public sealed record CallSignatureMemberNode(FunctionTypeNode Signature, int Line) : ObjectTypeMemberNode(Line);
+
+/// <summary>A construct signature member: <c>new (x: T): R</c>.</summary>
+public sealed record ConstructSignatureMemberNode(FunctionTypeNode Signature, int Line) : ObjectTypeMemberNode(Line);
+
+/// <summary>A tuple type: <c>[string, n?: number, ...rest: boolean[]]</c>.</summary>
+public sealed record TupleTypeNode(List<TupleElementNode> Elements, int Line) : TypeNode(Line);
+
+/// <summary>One tuple element: optionally named, optional (<c>?</c>), or a spread/rest
+/// (<c>...T</c> / <c>...T[]</c>, distinguished at resolution by position and array-ness).
+/// Not itself a type.</summary>
+public sealed record TupleElementNode(string? Name, TypeNode Type, bool IsOptional, bool IsRest, int Line);
+
 /// <summary>
 /// Counters proving how much of the corpus the node path already covers — read by tests and
 /// dumped by the checker when <c>SHARPTS_TYPENODE_STATS=1</c>. Coarse by design (spike

--- a/SharpTS.Tests/TypeCheckerTests/TypeNodeSliceTests.cs
+++ b/SharpTS.Tests/TypeCheckerTests/TypeNodeSliceTests.cs
@@ -32,10 +32,66 @@ public class TypeNodeSliceTests
     {
         TypeNodeStats.Reset();
         TestHarness.RunInterpreted("""
-            var f: { a: number } = { a: 1 };
+            var xs: Array<number> = [1];
             """);
         Assert.True(TypeNodeStats.StringFallbacks >= 1,
-            $"expected the object-type annotation to fall back, got {TypeNodeStats.StringFallbacks}");
+            $"expected the generic-reference annotation to fall back, got {TypeNodeStats.StringFallbacks}");
+    }
+
+    [Fact]
+    public void NodePath_EngagesForObjectAndTupleTypes()
+    {
+        TypeNodeStats.Reset();
+        TestHarness.RunInterpreted("""
+            var o: { name: string; age?: number } = { name: "x" };
+            var m: { greet(x: number): string } = { greet: (x: number) => "hi" };
+            var ix: { [k: string]: number } = { a: 1 };
+            var t: [string, number?] = ["x"];
+            var nt: [first: string, rest: number] = ["x", 1];
+            """);
+        Assert.True(TypeNodeStats.NodeHits >= 5,
+            $"expected the node path for all five annotations, got {TypeNodeStats.NodeHits}");
+        Assert.Equal(0, TypeNodeStats.StringFallbacks);
+    }
+
+    [Fact]
+    public void NodeResolved_ObjectTypeEnforcesMembers()
+    {
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted("""
+            var o: { name: string } = { name: 1 };
+            """));
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted("""
+            var o: { name: string } = {};
+            """));
+        // Optional members may be absent but not mistyped.
+        TestHarness.RunInterpreted("""
+            var o: { name: string; age?: number } = { name: "x" };
+            """);
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted("""
+            var o: { name: string; age?: number } = { name: "x", age: "old" };
+            """));
+    }
+
+    [Fact]
+    public void NodeResolved_TupleEnforcesArityAndElementTypes()
+    {
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted("""
+            var t: [string, number] = ["x"];
+            """));
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted("""
+            var t: [string, number] = [1, "x"];
+            """));
+        TestHarness.RunInterpreted("""
+            var t: [string, ...number[]] = ["x", 1, 2, 3];
+            """);
+    }
+
+    [Fact]
+    public void NodeResolved_IndexSignatureEnforcesValueType()
+    {
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted("""
+            var ix: { [k: string]: number } = { a: "not a number" };
+            """));
     }
 
     [Fact]

--- a/TypeSystem/TypeChecker.TypeNodes.cs
+++ b/TypeSystem/TypeChecker.TypeNodes.cs
@@ -1,5 +1,6 @@
 using System.Collections.Frozen;
 using SharpTS.Parsing;
+using SharpTS.TypeSystem.Exceptions;
 
 namespace SharpTS.TypeSystem;
 
@@ -84,9 +85,151 @@ public partial class TypeChecker
                     ConstructorSignatures: [signature]);
             }
 
+            case ObjectTypeNode obj:
+                return TryResolveObjectType(obj);
+
+            case TupleTypeNode tuple:
+                return TryResolveTupleType(tuple);
+
             default:
                 return null;
         }
+    }
+
+    /// <summary>
+    /// Mirror of the string path's <c>ParseInlineObjectTypeInfo</c>: fields with optional/method
+    /// markers, index signatures by key kind, call/construct signatures, the
+    /// pure-single-call-signature→Function rule, and the same Record shape otherwise.
+    /// </summary>
+    private TypeInfo? TryResolveObjectType(ObjectTypeNode obj)
+    {
+        Dictionary<string, TypeInfo> fields = [];
+        HashSet<string> optionalFields = [];
+        HashSet<string> methodMembers = [];
+        TypeInfo? stringIndexType = null;
+        TypeInfo? numberIndexType = null;
+        TypeInfo? symbolIndexType = null;
+        List<FunctionTypeNode> callSignatures = [];
+        List<FunctionTypeNode> constructSignatures = [];
+
+        foreach (var member in obj.Members)
+        {
+            switch (member)
+            {
+                case PropertyMemberNode prop:
+                    if (TryToTypeInfo(prop.Type) is not { } propType) return null;
+                    if (prop.IsMethod) methodMembers.Add(prop.Name);
+                    if (prop.IsOptional) optionalFields.Add(prop.Name);
+                    fields[prop.Name] = propType;
+                    break;
+
+                case IndexSignatureNode index:
+                    if (TryToTypeInfo(index.ValueType) is not { } valueType) return null;
+                    switch (index.KeyKind)
+                    {
+                        case "string": stringIndexType = valueType; break;
+                        case "number": numberIndexType = valueType; break;
+                        case "symbol": symbolIndexType = valueType; break;
+                    }
+                    break;
+
+                case CallSignatureMemberNode call:
+                    callSignatures.Add(call.Signature);
+                    break;
+
+                case ConstructSignatureMemberNode ctor:
+                    constructSignatures.Add(ctor.Signature);
+                    break;
+
+                default:
+                    return null;
+            }
+        }
+
+        // A pure single call-signature object type is structurally a plain function type —
+        // same rule (and same this-type retention) as the string path.
+        if (callSignatures.Count == 1 && constructSignatures.Count == 0 && fields.Count == 0
+            && stringIndexType == null && numberIndexType == null && symbolIndexType == null)
+        {
+            return TryToTypeInfo(callSignatures[0]);
+        }
+
+        List<TypeInfo.CallSignature>? recCallSigs = null;
+        foreach (var signature in callSignatures)
+        {
+            // The string path's CallSignature copies drop a `this` type; mirror via the parts.
+            if (TryToTypeInfo(signature) is not TypeInfo.Function f) return null;
+            (recCallSigs ??= []).Add(new TypeInfo.CallSignature(null, f.ParamTypes, f.ReturnType, f.RequiredParams, f.HasRestParam, f.ParamNames));
+        }
+        List<TypeInfo.ConstructorSignature>? recCtorSigs = null;
+        foreach (var signature in constructSignatures)
+        {
+            if (TryToTypeInfo(signature) is not TypeInfo.Function f) return null;
+            (recCtorSigs ??= []).Add(new TypeInfo.ConstructorSignature(null, f.ParamTypes, f.ReturnType, f.RequiredParams, f.HasRestParam, f.ParamNames));
+        }
+
+        return new TypeInfo.Record(
+            fields.ToFrozenDictionary(),
+            stringIndexType,
+            numberIndexType,
+            symbolIndexType,
+            optionalFields.Count > 0 ? optionalFields.ToFrozenSet() : null,
+            CallSignatures: recCallSigs,
+            ConstructorSignatures: recCtorSigs,
+            MethodMembers: methodMembers.Count > 0 ? methodMembers.ToFrozenSet() : null);
+    }
+
+    /// <summary>
+    /// Mirror of the string path's <c>ParseTupleTypeInfo</c>: same element kinds, the same
+    /// trailing-rest rule (a last <c>...T[]</c> becomes the rest type; any other spread is a
+    /// variadic element), and the same TS1257 required-after-optional rejection.
+    /// </summary>
+    private TypeInfo? TryResolveTupleType(TupleTypeNode tuple)
+    {
+        List<TypeInfo.TupleElement> elements = [];
+        int requiredCount = 0;
+        bool seenOptional = false;
+        bool seenSpread = false;
+        TypeInfo? restType = null;
+
+        for (int i = 0; i < tuple.Elements.Count; i++)
+        {
+            var element = tuple.Elements[i];
+
+            if (element.IsRest)
+            {
+                // Trailing ...T[] is the tuple's rest type; the parser only carries a node for a
+                // spread when array-ness agrees between the string and structured views.
+                if (i == tuple.Elements.Count - 1 && element.Type is ArrayTypeNode arr)
+                {
+                    if (TryToTypeInfo(arr.ElementType) is not { } rest) return null;
+                    restType = rest;
+                    break;
+                }
+                if (TryToTypeInfo(element.Type) is not { } spreadInner) return null;
+                elements.Add(new TypeInfo.TupleElement(spreadInner, TupleElementKind.Spread, null));
+                seenSpread = true;
+                continue;
+            }
+
+            if (element.IsOptional)
+            {
+                seenOptional = true;
+            }
+            else if (seenOptional && !seenSpread)
+            {
+                throw new TypeCheckException("Required element cannot follow optional element in tuple.", tsCode: "TS1257");
+            }
+
+            if (TryToTypeInfo(element.Type) is not { } elementType) return null;
+            elements.Add(new TypeInfo.TupleElement(
+                elementType,
+                element.IsOptional ? TupleElementKind.Optional : TupleElementKind.Required,
+                element.Name));
+            if (!element.IsOptional) requiredCount++;
+        }
+
+        return new TypeInfo.Tuple(elements, requiredCount, restType);
     }
 
     /// <summary>

--- a/docs/plans/type-ast-design.md
+++ b/docs/plans/type-ast-design.md
@@ -107,7 +107,13 @@ an equivalence test that converts both ways and asserts identical `TypeInfo` ren
    `SplitFunctionParams` fused both parameters into one — previously masked because both
    sides of the comparison were equally mangled. The string path got the same arrow guard
    `SplitObjectMembers` already had.
-2. Object-type / tuple / conditional / mapped nodes — the big checker-scanner retirement.
+2. ✅ **Shipped (object + tuple).** `ObjectTypeNode` (properties with optional/method
+   markers, computed names in their `@@` spelling, index signatures, call/construct
+   signatures) and `TupleTypeNode` (named/optional/spread elements, trailing-rest rule,
+   TS1257 ordering). `ParseMethodSignature` became a node producer alongside
+   `ParseFunctionTypeBody`. Coverage: 46.4% → **65.3%** (357 node / 190 fallback).
+   Conditional and mapped types remain string-path — they tie into generic/alias
+   resolution, so they ride with slice 3.
 3. Type aliases store nodes (kills alias string substitution; enables alias-instantiation
    identity for #202's variance cases).
 4. Declaration handles on `TypeInfo.Interface/Class` resolved via nodes (kills the


### PR DESCRIPTION
Third increment of the type-AST migration (`docs/plans/type-ast-design.md`, follows #250 and #254).

## What

- **`ObjectTypeNode`** — inline object types with property members (optional `?`, method syntax preserved via `IsMethod`, mirroring the string path's `#m` marker for bivariant method relating), computed names in their `@@` spelling, index signatures (`string`/`number`/`symbol` keys), and call/construct signature members.
- **`TupleTypeNode`** — named (`first: string`), optional (`n?:`), and spread elements, with the string path's trailing-rest rule (`...T[]` at last position becomes the rest type) and its TS1257 required-after-optional rejection in the same order.
- **`ParseMethodSignature`** becomes a node producer alongside `ParseFunctionTypeBody`, so method members and call/construct signatures get `FunctionTypeNode`s.
- Mirror fidelity details: the pure-single-call-signature object resolves as a plain `Function` exactly like the string path (this-type retained there, dropped on `CallSignature`/`ConstructorSignature` copies); tuple element names that are type keywords fall back (the string path re-parses those as types); spread elements only carry a node when textual `[]`-suffix detection and structural array-ness agree (e.g. a grouped `...(T[])` falls back rather than diverge).
- Mapped types and conditional types deliberately stay string-path — they tie into generic/alias resolution (slice 3).

**Coverage over the conformance corpus: 46.4% → 65.3%** (357 node / 190 fallback). The remaining fallback is now dominated by generic references and conditional/mapped types — exactly slice 3's scope.

## Validation

- Conformance baseline byte-identical: **Pass 63 / Fail 14 / ParseError 1**, zero drift (on the first run, this time)
- Unit suite: **10,729 passed, 0 failed**; slice tests extended with object/tuple engagement and enforcement pins (member types, optionality, arity, index-signature values, rest elements)