### PR TITLE
Symbol coercion TypeError (#245) + two compiled promise/async fixes

### DIFF
--- a/Compilation/AsyncMoveNextEmitter.Expressions.cs
+++ b/Compilation/AsyncMoveNextEmitter.Expressions.cs
@@ -95,6 +95,7 @@ public partial class AsyncMoveNextEmitter
         if (_currentTryCatchExceptionLocal != null)
         {
             var getResultDoneLabel = _il.DefineLabel();
+            var exceptionCaughtLabel = _il.DefineLabel();
             _il.BeginExceptionBlock();
             _il.Emit(OpCodes.Ldarg_0);
             _il.Emit(OpCodes.Ldflda, awaiterField);
@@ -107,8 +108,21 @@ public partial class AsyncMoveNextEmitter
             _il.Emit(OpCodes.Stloc, _currentTryCatchExceptionLocal);
             _il.Emit(OpCodes.Ldnull);
             _il.Emit(OpCodes.Stloc, resultTemp);
-            _il.Emit(OpCodes.Leave, getResultDoneLabel);
+            _il.Emit(OpCodes.Leave, exceptionCaughtLabel);
             _il.EndExceptionBlock();
+
+            // A rejected awaitable must abandon the rest of the try body, not
+            // resume it with a null result (which ran BOTH the success path and
+            // the catch). Jump straight to the try-exit so the statement-level
+            // catch dispatch in EmitTryCatchWithAwaits sees the exception local.
+            _il.MarkLabel(exceptionCaughtLabel);
+            if (_currentTryCatchSkipLabel != null)
+            {
+                _il.Emit(OpCodes.Br, _currentTryCatchSkipLabel.Value);
+            }
+            // No skip target (shouldn't happen — the local and label are set
+            // together): fall through with the null result as before.
+
             _il.MarkLabel(getResultDoneLabel);
             _il.Emit(OpCodes.Ldloc, resultTemp);
         }

--- a/Compilation/AsyncMoveNextEmitter.Operators.cs
+++ b/Compilation/AsyncMoveNextEmitter.Operators.cs
@@ -41,9 +41,11 @@ public partial class AsyncMoveNextEmitter
 
         for (int i = 0; i < exprTemps.Count; i++)
         {
-            // Load expression value from temp and convert to string
+            // Load expression value from temp and convert to string.
+            // StringifyCoerce: interpolation is an implicit ToString coercion —
+            // Symbol parts throw TypeError (ECMA-262 §7.1.17).
             _il.Emit(OpCodes.Ldloc, exprTemps[i]);
-            _il.Emit(OpCodes.Call, _ctx!.Runtime!.Stringify);
+            _il.Emit(OpCodes.Call, _ctx!.Runtime!.StringifyCoerce);
             _il.Emit(OpCodes.Call, Types.StringConcat2);
 
             // Emit next string part

--- a/Compilation/AsyncMoveNextEmitter.Statements.TryCatch.cs
+++ b/Compilation/AsyncMoveNextEmitter.Statements.TryCatch.cs
@@ -271,6 +271,7 @@ public partial class AsyncMoveNextEmitter
 
         // Set context for await exception handling
         var previousExceptionLocal = _currentTryCatchExceptionLocal;
+        var previousSkipLabel = _currentTryCatchSkipLabel;
         var afterTryLabel = _il.DefineLabel();
         _currentTryCatchExceptionLocal = caughtExceptionLocal;
         _currentTryCatchSkipLabel = afterTryLabel;
@@ -325,9 +326,11 @@ public partial class AsyncMoveNextEmitter
 
         _il.MarkLabel(afterTryLabel);
 
-        // Restore context
+        // Restore context (the skip label must be restored alongside its
+        // exception local — nulling it left outer-try awaits after a nested
+        // try with no exit target).
         _currentTryCatchExceptionLocal = previousExceptionLocal;
-        _currentTryCatchSkipLabel = null;
+        _currentTryCatchSkipLabel = previousSkipLabel;
     }
 
     private void EmitSegmentInTry(List<Stmt> statements, LocalBuilder caughtExceptionLocal)

--- a/Compilation/EmittedRuntime.cs
+++ b/Compilation/EmittedRuntime.cs
@@ -121,6 +121,8 @@ public class EmittedRuntime
     public MethodBuilder ToJsString { get; set; } = null!;
     /// <summary>$Runtime.StringFromValue(object) -> string — ECMA-262 §22.1.1.1 String(value) call form: Symbol → SymbolDescriptiveString (via $TSSymbol.ToString()); everything else → ToJsString. Only the String() constructor-call form is exempt from ToString's Symbol TypeError; implicit coercions (template literals, concat) must keep throwing.</summary>
     public MethodBuilder StringFromValueMethod { get; set; } = null!;
+    /// <summary>$Runtime.StringifyCoerce(object) -> string — Stringify with the ECMA-262 §7.1.17 Symbol guard: implicit ToString coercion sites (template-literal interpolation, string <c>+</c>/<c>+=</c> concatenation) throw TypeError for Symbol values. Console formatting and the String() call form must NOT route through this.</summary>
+    public MethodBuilder StringifyCoerce { get; set; } = null!;
     public MethodBuilder ToNumber { get; set; } = null!;
     public MethodBuilder ConvertToNumber { get; set; } = null!;
     public MethodBuilder JsToInt32 { get; set; } = null!;

--- a/Compilation/ExpressionEmitterBase.cs
+++ b/Compilation/ExpressionEmitterBase.cs
@@ -947,7 +947,9 @@ public abstract partial class ExpressionEmitterBase : IEmitterContext
         for (int i = 0; i < exprTemps.Count; i++)
         {
             IL.Emit(OpCodes.Ldloc, exprTemps[i]);
-            IL.Emit(OpCodes.Call, Ctx.Runtime!.Stringify);
+            // StringifyCoerce: interpolation is an implicit ToString coercion —
+            // Symbol parts throw TypeError (ECMA-262 §7.1.17).
+            IL.Emit(OpCodes.Call, Ctx.Runtime!.StringifyCoerce);
             IL.Emit(OpCodes.Call, Types.StringConcat2);
 
             if (i + 1 < tl.Strings.Count)

--- a/Compilation/ILEmitter.Operators.cs
+++ b/Compilation/ILEmitter.Operators.cs
@@ -424,15 +424,21 @@ public partial class ILEmitter
         // Special case: string concatenation with +=
         if (ca.Operator.Type == TokenType.PLUS_EQUAL && IsStringExpression(ca.Value))
         {
-            // Load current value as object
+            // Load current value, StringifyCoerce'd: JS-compatible conversion
+            // (null → "null", undefined → "undefined") that throws TypeError
+            // for Symbol operands (§7.1.17) — String.Concat(object, object)
+            // did neither.
             EmitVariable(new Expr.Variable(ca.Name));
+            EmitBoxIfNeeded(new Expr.Variable(ca.Name));
+            IL.Emit(OpCodes.Call, _ctx.Runtime!.StringifyCoerce);
 
-            // Load right side as object
+            // Load right side, StringifyCoerce'd
             EmitExpression(ca.Value);
             EmitBoxIfNeeded(ca.Value);
+            IL.Emit(OpCodes.Call, _ctx.Runtime!.StringifyCoerce);
 
             // String concatenation
-            IL.Emit(OpCodes.Call, _ctx.Types.GetMethod(_ctx.Types.String, "Concat", _ctx.Types.Object, _ctx.Types.Object));
+            IL.Emit(OpCodes.Call, _ctx.Types.GetMethod(_ctx.Types.String, "Concat", _ctx.Types.String, _ctx.Types.String));
             IL.Emit(OpCodes.Dup);
 
             // Store result
@@ -1395,10 +1401,15 @@ public partial class ILEmitter
 
         if (opType == TokenType.PLUS_EQUAL && IsStringExpression(value))
         {
-            // String concatenation - we know right side is a string at compile time
+            // String concatenation - we know right side is a string at compile time.
+            // StringifyCoerce both operands: JS-compatible conversion (null →
+            // "null", undefined → "undefined") that throws TypeError for Symbol
+            // operands (§7.1.17) — String.Concat(object, object) did neither.
+            IL.Emit(OpCodes.Call, _ctx.Runtime!.StringifyCoerce);
             EmitExpression(value);
             EmitBoxIfNeeded(value);
-            IL.Emit(OpCodes.Call, _ctx.Types.GetMethod(_ctx.Types.String, "Concat", _ctx.Types.Object, _ctx.Types.Object));
+            IL.Emit(OpCodes.Call, _ctx.Runtime!.StringifyCoerce);
+            IL.Emit(OpCodes.Call, _ctx.Types.GetMethod(_ctx.Types.String, "Concat", _ctx.Types.String, _ctx.Types.String));
             return;
         }
 
@@ -1699,7 +1710,9 @@ public partial class ILEmitter
             {
                 EmitExpression(part);
                 EmitBoxIfNeeded(part);
-                IL.Emit(OpCodes.Call, _ctx.Runtime!.Stringify);
+                // StringifyCoerce: `+` concat is an implicit ToString coercion —
+                // Symbol operands throw TypeError (ECMA-262 §7.1.17).
+                IL.Emit(OpCodes.Call, _ctx.Runtime!.StringifyCoerce);
             }
         }
 
@@ -1730,7 +1743,8 @@ public partial class ILEmitter
             {
                 EmitExpression(parts[i]);       // Value
                 EmitBoxIfNeeded(parts[i]);
-                IL.Emit(OpCodes.Call, _ctx.Runtime!.Stringify);
+                // StringifyCoerce: throws TypeError for Symbol operands (§7.1.17).
+                IL.Emit(OpCodes.Call, _ctx.Runtime!.StringifyCoerce);
             }
 
             IL.Emit(OpCodes.Stelem_Ref);    // Store in array

--- a/Compilation/RuntimeEmitter.CoreUtilities.cs
+++ b/Compilation/RuntimeEmitter.CoreUtilities.cs
@@ -1864,6 +1864,33 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ret);
     }
 
+    // StringifyCoerce — Stringify behind the ECMA-262 §7.1.17 Symbol guard.
+    // Implicit ToString coercion sites (template-literal interpolation, string
+    // +/+= concatenation) must throw TypeError for Symbol operands; everything
+    // else keeps Stringify's display semantics. Signature forward-declared by
+    // DefineRuntimeClassPhase1 because $Runtime.Add's string-concat arm is
+    // emitted before this body is filled.
+    private void EmitStringifyCoerce(EmittedRuntime runtime)
+    {
+        var il = runtime.StringifyCoerce.GetILGenerator();
+
+        // if (value is $TSSymbol) throw TypeError
+        var notSymbolLabel = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Isinst, runtime.TSSymbolType);
+        il.Emit(OpCodes.Brfalse, notSymbolLabel);
+        il.Emit(OpCodes.Ldstr, "Cannot convert a Symbol value to a string");
+        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
+        il.Emit(OpCodes.Call, runtime.CreateException);
+        il.Emit(OpCodes.Throw);
+        il.MarkLabel(notSymbolLabel);
+
+        // return Stringify(value);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Call, runtime.Stringify);
+        il.Emit(OpCodes.Ret);
+    }
+
     // ToJsString — ECMA-262 ToString protocol. For Dictionary/$Object receivers
     // with a user-defined "toString" function, invoke it and use the result.
     // Falls back to Stringify for primitives. Used by String.prototype methods
@@ -3987,12 +4014,13 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Box, _types.Double);
         il.Emit(OpCodes.Ret);
 
-        // String concat - use Stringify for JS-compatible conversion (null->"null", bool->"true"/"false")
+        // String concat - StringifyCoerce: JS-compatible conversion (null->"null",
+        // bool->"true"/"false") that throws TypeError for Symbol operands (§7.1.17).
         il.MarkLabel(stringConcatLabel);
         il.Emit(OpCodes.Ldloc, leftLocal);
-        il.Emit(OpCodes.Call, runtime.Stringify);
+        il.Emit(OpCodes.Call, runtime.StringifyCoerce);
         il.Emit(OpCodes.Ldloc, rightLocal);
-        il.Emit(OpCodes.Call, runtime.Stringify);
+        il.Emit(OpCodes.Call, runtime.StringifyCoerce);
         il.Emit(OpCodes.Call, _types.GetMethod(_types.String, "Concat", _types.String, _types.String));
         il.Emit(OpCodes.Ret);
     }

--- a/Compilation/RuntimeEmitter.Objects.Templates.cs
+++ b/Compilation/RuntimeEmitter.Objects.Templates.cs
@@ -46,12 +46,14 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloc, lengthLocal);
         il.Emit(OpCodes.Bge, loopEnd);
 
-        // sb.Append(Stringify(parts[index]))
+        // sb.Append(StringifyCoerce(parts[index])) — template-literal
+        // interpolation is an implicit ToString coercion, so Symbol parts
+        // throw TypeError (§7.1.17).
         il.Emit(OpCodes.Ldloc, sbLocal);
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ldloc, indexLocal);
         il.Emit(OpCodes.Ldelem_Ref);
-        il.Emit(OpCodes.Call, runtime.Stringify);
+        il.Emit(OpCodes.Call, runtime.StringifyCoerce);
         il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.StringBuilder, "Append", _types.String));
         il.Emit(OpCodes.Pop); // discard StringBuilder return value
 

--- a/Compilation/RuntimeEmitter.Promises.Executor.cs
+++ b/Compilation/RuntimeEmitter.Promises.Executor.cs
@@ -459,12 +459,14 @@ public partial class RuntimeEmitter
 
             il.MarkLabel(endLockLabel);
 
-            // tcs.TrySetException(new Exception(reason?.ToString() ?? "Promise rejected"))
+            // tcs.TrySetException(new $PromiseRejectedException(reason)) —
+            // the carrier whose Reason the then/catch state machines extract,
+            // so `new Promise((res, rej) => rej(err)).catch(e => ...)` hands
+            // the guest value through unchanged (mirrors the interpreter's
+            // SharpTSPromiseRejectedException; #232 reason-preservation).
             il.Emit(OpCodes.Ldloc, tcsLocal);
             il.Emit(OpCodes.Ldloc, reasonLocal);
-            il.Emit(OpCodes.Callvirt, _types.GetMethodNoParams(_types.Object, "ToString"));
-            var exceptionCtor = _types.GetConstructor(_types.Exception, [_types.String]);
-            il.Emit(OpCodes.Newobj, exceptionCtor);
+            il.Emit(OpCodes.Newobj, runtime.TSPromiseRejectedExceptionCtor);
             var trySetException = typeof(TaskCompletionSource<object?>).GetMethod("TrySetException", [typeof(Exception)])!;
             il.Emit(OpCodes.Callvirt, trySetException);
             il.Emit(OpCodes.Pop);

--- a/Compilation/RuntimeEmitter.RuntimeClass.cs
+++ b/Compilation/RuntimeEmitter.RuntimeClass.cs
@@ -639,6 +639,10 @@ public partial class RuntimeEmitter
         // StringFromValue (String(x) call form) wraps ToJsString with the
         // §22.1.1.1 Symbol exemption; emit right after it.
         EmitStringFromValue(typeBuilder, runtime);
+        // StringifyCoerce (implicit-coercion sites) wraps Stringify with the
+        // §7.1.17 Symbol TypeError; the body needs TSSymbolType/TSTypeErrorCtor,
+        // both bound by this point (ToJsString's Symbol arm uses them too).
+        EmitStringifyCoerce(runtime);
         // Equals body — must come after ToJsString since the Object-vs-String
         // branch calls runtime.ToJsString.
         EmitEquals(typeBuilder, runtime);

--- a/Compilation/RuntimeEmitter.RuntimeClassPhase1.cs
+++ b/Compilation/RuntimeEmitter.RuntimeClassPhase1.cs
@@ -80,6 +80,17 @@ public partial class RuntimeEmitter
             _types.String,
             [_types.Object]);
 
+        // Reserve StringifyCoerce(object) → string — Stringify plus the
+        // ECMA-262 §7.1.17 Symbol guard (implicit ToString coercion throws
+        // TypeError for Symbol values). Reserved here because $Runtime.Add's
+        // string-concat arm (emitted before EmitToJsString) references it;
+        // EmitStringifyCoerce fills the body later.
+        runtime.StringifyCoerce = typeBuilder.DefineMethod(
+            "StringifyCoerce",
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.String,
+            [_types.Object]);
+
         // Reserve JsToInt32(object) → int. ECMA-262 §7.1.6 ToInt32 chain
         // (ToNumber → ToPrimitive → valueOf). Forward-declared so $RegExp's
         // Symbol.match empty-match advance can read `lastIndex` and propagate

--- a/Execution/Interpreter.Calls.cs
+++ b/Execution/Interpreter.Calls.cs
@@ -1012,11 +1012,16 @@ public partial class Interpreter
         // String concatenation path
         if (op == TokenType.PLUS_EQUAL && left.IsString)
         {
+            // ECMA-262 §7.1.17: a Symbol operand cannot be coerced to a string.
+            ThrowIfSymbolStringCoercion(right.ToObject());
             return RuntimeValue.FromString(string.Concat(left.AsStringUnsafe(), Stringify(right.ToObject())));
         }
 
         // Fallback for mixed types
         object? l2 = left.ToObject(), r2 = right.ToObject();
+        // ECMA-262 §7.1.17: a string `+=` Symbol operand cannot coerce to string.
+        if (op == TokenType.PLUS_EQUAL && l2 is string)
+            ThrowIfSymbolStringCoercion(r2);
         return op switch
         {
             TokenType.PLUS_EQUAL => RuntimeValue.FromBoxed(
@@ -1098,6 +1103,9 @@ public partial class Interpreter
             result.Append(strings[i]);
             if (i < evaluatedExprs.Count)
             {
+                // ECMA-262 §7.1.17: template-literal interpolation is an
+                // implicit ToString coercion — a Symbol substitution throws.
+                ThrowIfSymbolStringCoercion(evaluatedExprs[i]);
                 result.Append(Stringify(evaluatedExprs[i]));
             }
         }

--- a/Execution/Interpreter.Operators.cs
+++ b/Execution/Interpreter.Operators.cs
@@ -232,6 +232,9 @@ public partial class Interpreter
         if (left is double l && right is double r) return l + r;
         if (left is string || right is string)
         {
+            // ECMA-262 §7.1.17: a Symbol operand cannot be coerced to a string.
+            ThrowIfSymbolStringCoercion(left);
+            ThrowIfSymbolStringCoercion(right);
             // Avoid calling Stringify on values that are already strings
             return string.Concat(
                 left as string ?? Stringify(left),
@@ -241,6 +244,8 @@ public partial class Interpreter
         // yields a string for arrays/plain objects, so `+` concatenates.
         if (IsObjectLike(left) || IsObjectLike(right))
         {
+            ThrowIfSymbolStringCoercion(left);
+            ThrowIfSymbolStringCoercion(right);
             return string.Concat(Stringify(left), Stringify(right));
         }
         // Both primitives, neither a string: numeric addition with ToNumber
@@ -254,6 +259,21 @@ public partial class Interpreter
     /// </summary>
     private static bool IsObjectLike(object? value) =>
         value is not (null or double or string or bool or SharpTSUndefined or SharpTSBigInt or SharpTSSymbol);
+
+    /// <summary>
+    /// ECMA-262 §7.1.17 ToString: Symbol values throw a TypeError when
+    /// implicitly coerced to a string (template-literal interpolation,
+    /// <c>+</c> concatenation). Only the explicit <c>String()</c> call form and
+    /// <c>Symbol.prototype.toString()</c> are exempt — those route through
+    /// dedicated paths, not this guard. <c>console.log</c> formatting also
+    /// bypasses this (it is not a language-level coercion).
+    /// </summary>
+    internal static void ThrowIfSymbolStringCoercion(object? value)
+    {
+        if (value is SharpTSSymbol)
+            throw new ThrowException(new SharpTSTypeError(
+                "Cannot convert a Symbol value to a string"));
+    }
 
     /// <summary>
     /// Evaluates a unary operator expression.

--- a/SharpTS.Tests/SharedTests/AsyncTryCatchTests.cs
+++ b/SharpTS.Tests/SharedTests/AsyncTryCatchTests.cs
@@ -264,4 +264,92 @@ public class AsyncTryCatchTests
         var output = TestHarness.Run(source, mode);
         Assert.Equal("inner: original\nouter: wrapped: original\n", output);
     }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AsyncTryCatch_AwaitEmbeddedInCallArgument_RejectionSkipsStatement(ExecutionMode mode)
+    {
+        // Regression: when the await is embedded in a larger statement
+        // (not hoisted to `let x = await ...`), a rejection used to resume the
+        // statement with a null result — console.log printed "null" AND the
+        // catch ran. The rejected await must abandon the rest of the try body.
+        var source = """
+            async function throwError(): Promise<string> {
+                await Promise.resolve();
+                throw new TypeError("boom");
+            }
+            async function main(): Promise<void> {
+                try {
+                    console.log(await throwError());
+                } catch (e) {
+                    console.log("caught", e.message);
+                }
+            }
+            main();
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("caught boom\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AsyncTryCatch_AwaitEmbeddedInConcat_RejectionSkipsStatement(ExecutionMode mode)
+    {
+        // The await must be the FIRST operand: `"v:" + (await ...)` inside a
+        // try block trips a separate pre-existing emitter bug (await with IL
+        // operands already on the stack emits an invalid program — #253).
+        var source = """
+            async function throwError(): Promise<string> {
+                throw new TypeError("boom");
+            }
+            async function main(): Promise<void> {
+                try {
+                    const x = (await throwError()) + ":v";
+                    console.log(x);
+                } catch (e) {
+                    console.log("caught", e.message);
+                }
+            }
+            main();
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("caught boom\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AsyncTryCatch_AwaitAfterNestedTry_RejectionStillCaught(ExecutionMode mode)
+    {
+        // Regression: emitting a nested try-with-awaits cleared the outer
+        // try's await-exit label instead of restoring it, so a rejected await
+        // in the outer try AFTER the nested try lost its exit target.
+        // (Single-argument console.log calls only — multi-arg calls with an
+        // await argument hit the separate await-hoisting emitter bug, #253.)
+        var source = """
+            async function ok(): Promise<number> {
+                return 1;
+            }
+            async function throwError(): Promise<string> {
+                throw new TypeError("late");
+            }
+            async function main(): Promise<void> {
+                try {
+                    try {
+                        console.log(await ok());
+                    } catch (e) {
+                        console.log("inner caught");
+                    }
+                    console.log(await throwError());
+                } catch (e) {
+                    console.log("outer caught " + e.message);
+                }
+            }
+            main();
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("1\nouter caught late\n", output);
+    }
 }

--- a/SharpTS.Tests/SharedTests/PromiseMethodTests.cs
+++ b/SharpTS.Tests/SharedTests/PromiseMethodTests.cs
@@ -1064,4 +1064,31 @@ public class PromiseMethodTests
     }
 
     #endregion
+
+    #region Executor rejection reason
+
+    /// <summary>
+    /// The executor reject callback must hand the guest value through
+    /// unchanged — the compiled $PromiseRejectCallback used to re-wrap it as
+    /// new Exception(reason.ToString()), so catch handlers saw a host string
+    /// ("Error: nope") instead of the rejected error object (#232 family).
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ExecutorReject_PreservesGuestReason(ExecutionMode mode)
+    {
+        var source = """
+            async function main(): Promise<void> {
+                const p = new Promise<number>((resolve, reject) => { reject(new TypeError("raw")); });
+                const v = await p.catch((e: any) => (e instanceof TypeError) + ":" + e.message);
+                console.log(v);
+            }
+            main();
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("true:raw\n", output);
+    }
+
+    #endregion
 }

--- a/SharpTS.Tests/SharedTests/SymbolTests.cs
+++ b/SharpTS.Tests/SharedTests/SymbolTests.cs
@@ -537,6 +537,117 @@ public class SymbolTests
 
     #endregion
 
+    #region Implicit Symbol-to-String Coercion Throws (#245)
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Symbol_TemplateLiteralInterpolation_ThrowsTypeError(ExecutionMode mode)
+    {
+        // ECMA-262 §7.1.17 ToString: implicit coercion of a Symbol throws.
+        var source = """
+            const s = Symbol("d");
+            try {
+                const t = `value: ${s}`;
+                console.log("no throw", t);
+            } catch (e) {
+                console.log(e instanceof TypeError, e.message);
+            }
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("true Cannot convert a Symbol value to a string\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Symbol_StringPlusConcat_ThrowsTypeError(ExecutionMode mode)
+    {
+        var source = """
+            const s = Symbol("d");
+            try {
+                const t = "x" + (s as any);
+                console.log("no throw", t);
+            } catch (e) {
+                console.log(e instanceof TypeError, e.message);
+            }
+            try {
+                const t = (s as any) + "x";
+                console.log("no throw", t);
+            } catch (e) {
+                console.log(e instanceof TypeError, e.message);
+            }
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal(
+            "true Cannot convert a Symbol value to a string\n" +
+            "true Cannot convert a Symbol value to a string\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Symbol_PlusEqualConcat_ThrowsTypeError(ExecutionMode mode)
+    {
+        var source = """
+            const s = Symbol("d");
+            let acc = "x";
+            try {
+                acc += (s as any);
+                console.log("no throw", acc);
+            } catch (e) {
+                console.log(e instanceof TypeError, e.message);
+            }
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("true Cannot convert a Symbol value to a string\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Symbol_TemplateLiteralInAsyncFunction_ThrowsTypeError(ExecutionMode mode)
+    {
+        // The async/generator state-machine emitters build template literals
+        // through a separate path than the sync emitter — cover it explicitly.
+        var source = """
+            const s = Symbol("d");
+            async function f(): Promise<string> {
+                await Promise.resolve();
+                return `v: ${s}`;
+            }
+            async function main(): Promise<void> {
+                try {
+                    console.log(await f());
+                } catch (e) {
+                    console.log(e instanceof TypeError, e.message);
+                }
+            }
+            main();
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("true Cannot convert a Symbol value to a string\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Symbol_ExplicitForms_StillStringify(ExecutionMode mode)
+    {
+        // Only implicit coercion throws: String(sym), sym.toString(), and
+        // console.log(sym) formatting all keep returning "Symbol(d)".
+        var source = """
+            const s = Symbol("d");
+            console.log(String(s));
+            console.log(s.toString());
+            console.log(s);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("Symbol(d)\nSymbol(d)\nSymbol(d)\n", output);
+    }
+
+    #endregion
+
     #region Symbol as First-Class Global (#234)
 
     [Theory]


### PR DESCRIPTION
Batch PR for the requested issues (#245, #242, #237, #221), **rescoped after PR #252 merged mid-stream**: #252 (from the parallel session) already landed the #237 Symbol.prototype surface and the #242/#221 Promise-subclass + species lift, closing both issues. This PR was rebuilt on current main and keeps only the work that is still missing there — verified by probing main directly. One commit per fix; full suite green (10747 tests).

## Commits

### 1. `fix(compile)`: rejected await inside try/catch ran BOTH the try tail and the catch
`console.log(await rejecting())` inside try/catch printed `null` **and** ran the catch: the await's GetResult wrap stored the exception in the tracking local and resumed the statement with a null result, so the remainder of the try body executed before the statement-boundary check dispatched to the catch. The catch arm now branches straight to the try-exit. Also restores the nested-try skip label instead of nulling it (a rejected await in the outer try after a nested try lost its exit target). Existing tests missed this because they always hoisted the await to its own statement. Regression tests in `AsyncTryCatchTests` (shapes chosen to avoid the pre-existing #251/#253 invalid-IL bug).

### 2. `fix`: implicit symbol-to-string coercion throws TypeError in both modes (#245) — closes #245
ECMA-262 §7.1.17: template-literal interpolation and string `+`/`+=` with a Symbol operand must throw; SharpTS silently produced `"Symbol(d)"` in both modes.
- Interpreter: guards in template-literal substitution, the binary `+` string/object arms, and the `+=` string paths.
- Compiled: new `$Runtime.StringifyCoerce` (phase-1 reserved; Stringify behind the Symbol guard) routed through `$Runtime.Add`'s concat arm, `ConcatTemplate`, both two-phase template-literal emitters, the string-concat-chain optimizer, and both `+=` fast paths — the latter previously used `String.Concat(object, object)` directly, so this also fixes `null`/`undefined` operands stringifying as `""` instead of `"null"`/`"undefined"` there.
- `String(sym)`, `sym.toString()`, and `console.log(sym)` formatting intentionally keep returning `Symbol(d)`. 5 new dual-mode tests.

### 3. `fix(compile)`: executor reject callback preserves the guest rejection reason
`new Promise((res, rej) => rej(new TypeError("raw"))).catch(e => ...)` in compiled mode handed the handler a re-wrapped host string (`e instanceof TypeError` → false, `e.message` → `"TypeError: raw"`); interpreted mode was correct. `$PromiseRejectCallback` now settles with `$PromiseRejectedException(reason)`, the carrier the then/catch state machines already extract (#232 reason-preservation family). Dual-mode regression test in `PromiseMethodTests`.

## Issue disposition
- #245 — fixed here, closes on merge.
- #237, #242 — already fixed and closed by #252; nothing further needed.
- #221 — #252's species lift covers the practical surface; remaining Test262-fidelity gaps (poisoned-`constructor` sync throw, user `Symbol.species` overrides) are noted on the issue.
- #251 — pre-existing compiled-async invalid-IL bug (await with live IL-stack operands), encountered repeatedly while testing this batch; #253 was filed for it independently and is being closed as a duplicate (root-cause analysis copied over). Needs an await-hoisting prepass.

## Testing
`dotnet test`: 10747 passed, 0 failed, on this branch (current main + 3 commits).