### PR TITLE
Type-AST migration slice 3a: generic references on the node path

### DIFF
--- a/Parsing/Parser.Types.cs
+++ b/Parsing/Parser.Types.cs
@@ -602,13 +602,25 @@ public partial class Parser
             Advance(); // consume <
             if (IsTypeStart())
             {
+                List<TypeNode>? argNodes = [];
                 List<string> typeArgs = [ParseTypeAnnotation()];
+                if (TakeTypeNode() is { } firstArgNode) argNodes.Add(firstArgNode);
+                else argNodes = null;
                 while (Match(TokenType.COMMA))
+                {
                     typeArgs.Add(ParseTypeAnnotation());
+                    // Always drain the side channel, even once a previous argument had no node.
+                    var argNode = TakeTypeNode();
+                    if (argNodes is not null && argNode is not null) argNodes.Add(argNode);
+                    else argNodes = null;
+                }
                 if (MatchGreaterInTypeContext())
                 {
                     typeName = $"{typeName}<{string.Join(", ", typeArgs)}>";
-                    typeNode = null; // generic references: slice 2 (alias-expansion parity)
+                    // Attach argument nodes to the bare reference (qualified names stay node-less).
+                    typeNode = typeNode is NamedTypeNode { TypeArguments: null } bare && argNodes is not null
+                        ? bare with { TypeArguments = argNodes }
+                        : null;
                 }
                 else
                     _current = saved; // Backtrack if not a valid generic type

--- a/SharpTS.Tests/TypeCheckerTests/TypeNodeSliceTests.cs
+++ b/SharpTS.Tests/TypeCheckerTests/TypeNodeSliceTests.cs
@@ -30,12 +30,47 @@ public class TypeNodeSliceTests
     [Fact]
     public void NodePath_FallsBackForUnsupportedConstructs()
     {
+        // Generic ALIAS references stay on the string path until alias definitions store nodes.
         TypeNodeStats.Reset();
         TestHarness.RunInterpreted("""
-            var xs: Array<number> = [1];
+            type Box<T> = { value: T };
+            var b: Box<number> = { value: 1 };
             """);
         Assert.True(TypeNodeStats.StringFallbacks >= 1,
-            $"expected the generic-reference annotation to fall back, got {TypeNodeStats.StringFallbacks}");
+            $"expected the generic-alias annotation to fall back, got {TypeNodeStats.StringFallbacks}");
+    }
+
+    [Fact]
+    public void NodePath_EngagesForGenericReferences()
+    {
+        TypeNodeStats.Reset();
+        TestHarness.RunInterpreted("""
+            class Pair<A, B> { constructor(public first: A, public second: B) {} }
+            var xs: Array<number> = [1, 2];
+            var p: Promise<string> = Promise.resolve("x");
+            var pr: Pair<string, number> = new Pair<string, number>("x", 1);
+            var part: Partial<{ a: number; b: string }> = { a: 1 };
+            """);
+        Assert.True(TypeNodeStats.NodeHits >= 4,
+            $"expected the node path for all four generic annotations, got {TypeNodeStats.NodeHits}");
+        Assert.Equal(0, TypeNodeStats.StringFallbacks);
+    }
+
+    [Fact]
+    public void NodeResolved_GenericReferencesEnforceArguments()
+    {
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted("""
+            var xs: Array<number> = ["not a number"];
+            """));
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted("""
+            class Pair<A, B> { constructor(public first: A, public second: B) {} }
+            var p: Pair<string, number> = new Pair<number, string>(1, "x");
+            """));
+        // Utility-type expansion through the node path: Partial makes members optional,
+        // but still rejects mistyped ones.
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted("""
+            var part: Partial<{ a: number }> = { a: "no" };
+            """));
     }
 
     [Fact]

--- a/TypeSystem/TypeChecker.TypeNodes.cs
+++ b/TypeSystem/TypeChecker.TypeNodes.cs
@@ -30,9 +30,23 @@ public partial class TypeChecker
             case NamedTypeNode { TypeArguments: null } named:
                 return ToTypeInfo(named.Name);
 
-            // Generic references are slice 2 (alias expansion needs argument strings today).
-            case NamedTypeNode:
-                return null;
+            // Generic references resolve their argument nodes and reuse the SAME instantiation
+            // machinery as the string path (built-in generics, utility types, generic
+            // classes/interfaces/functions — including its TS2314 arity errors). Generic ALIASES
+            // still fall back: their expansion is textual substitution of the ORIGINAL argument
+            // spellings, and re-rendered argument strings could shift recursion/instantiation
+            // keys. Aliases move off strings when their definitions are stored as nodes.
+            case NamedTypeNode { TypeArguments: { } argNodes } named:
+            {
+                if (_environment.GetGenericTypeAlias(named.Name) != null) return null;
+                List<TypeInfo> typeArgs = new(argNodes.Count);
+                foreach (var argNode in argNodes)
+                {
+                    if (TryToTypeInfo(argNode) is not { } arg) return null;
+                    typeArgs.Add(arg);
+                }
+                return ResolveGenericType(named.Name, typeArgs);
+            }
 
             case LiteralTypeNode lit:
                 return lit.Value switch

--- a/docs/plans/type-ast-design.md
+++ b/docs/plans/type-ast-design.md
@@ -116,6 +116,16 @@ an equivalence test that converts both ways and asserts identical `TypeInfo` ren
    resolution, so they ride with slice 3.
 3. Type aliases store nodes (kills alias string substitution; enables alias-instantiation
    identity for #202's variance cases).
+   - ✅ **3a shipped: generic references.** `NamedTypeNode.TypeArguments` is built by the
+     parser; the checker resolves argument nodes and reuses `ResolveGenericType`'s
+     existing `TypeInfo`-args overload (built-in generics, utility types, generic
+     classes/interfaces/functions, same TS2314 arity errors). Generic **aliases**
+     deliberately still fall back — their expansion is textual substitution of the
+     ORIGINAL argument spellings, so node-resolved arguments could shift
+     recursion/instantiation keys. Coverage: 65.3% → **68.7%**.
+   - 3b remaining: alias definitions stored as nodes, expansion via scoped node
+     resolution instead of `SubstituteTypeParamInString` (this is the part that buys
+     alias-instantiation identity). Mapped/conditional nodes ride with this.
 4. Declaration handles on `TypeInfo.Interface/Class` resolved via nodes (kills the
    `CacheKey()` workaround; fixes the cross-module diagnostic tests).
 5. Substitution-origin marking (unblocks #202's callback rule → `covariantCallbacks`).


### PR DESCRIPTION
Fourth increment of the type-AST migration (`docs/plans/type-ast-design.md`, follows #250, #254, #255).

## What

- The parser's generic-argument tail now builds `NamedTypeNode.TypeArguments` (each argument captured from the existing side channel; qualified names stay node-less).
- The checker resolves generic references node-first: argument nodes resolve to `TypeInfo`, then flow into **`ResolveGenericType`'s existing `TypeInfo`-args overload** — so built-in generics (`Array`, `Promise`, `Generator`…), all utility types (`Partial`, `Pick`, `ReturnType`…), and generic class/interface/function instantiation share the string path's machinery exactly, including TS2314 arity errors and the #185 open-type-variable deferral.
- **Generic aliases deliberately still fall back.** Alias expansion is textual: the original argument spellings are substituted into the definition string, and recursion/instantiation keys derive from those spellings. Feeding re-rendered strings through that machinery is exactly the kind of silent divergence this migration exists to kill — so aliases wait for slice 3b, where definitions are stored as nodes and expansion becomes scoped node resolution.

**Coverage over the conformance corpus: 65.3% → 68.7%** (376 node / 171 fallback). With generic references done, the remaining fallback is generic *signatures* (`<T>(x: T) => T`), alias references, mapped/conditional types, qualified names, and indexed access — all tied to the slice 3b/scoping work.

## Validation

- Conformance baseline byte-identical: **Pass 63 / Fail 14 / ParseError 1**, zero drift
- Unit suite: **10,731 passed** (one `Fs_RenameSync_Parity` temp-dir flake, passes in isolation); slice tests extended with generic-reference engagement and enforcement pins (element types, instantiated class members, utility-type expansion)