### PR TITLE
Type-AST migration slice 3b: generic alias expansion from definition nodes

### DIFF
--- a/Parsing/AST.cs
+++ b/Parsing/AST.cs
@@ -457,7 +457,7 @@ public abstract record Stmt
     // TS allows only 'any'/'unknown'; anything else is checker error TS1196.
     public record TryCatch(List<Stmt> TryBlock, Token? CatchParam, List<Stmt>? CatchBlock, List<Stmt>? FinallyBlock, string? CatchParamType = null) : Stmt;
     public record Throw(Token Keyword, Expr Value) : Stmt;
-    public record TypeAlias(Token Name, string TypeDefinition, List<TypeParam>? TypeParameters = null) : Stmt;
+    public record TypeAlias(Token Name, string TypeDefinition, List<TypeParam>? TypeParameters = null, TypeNode? TypeDefinitionNode = null) : Stmt;
     public record EnumMember(Token Name, Expr? Value);
     public record Enum(Token Name, List<EnumMember> Members, bool IsConst = false) : Stmt;
 

--- a/Parsing/Parser.Declarations.cs
+++ b/Parsing/Parser.Declarations.cs
@@ -213,9 +213,10 @@ public partial class Parser
         // - Conditional types: T extends U ? X : Y
         // The disambiguation is done in ParsePrimaryType
         string typeDef = ParseTypeAnnotation();
+        TypeNode? typeDefNode = TakeTypeNode();
 
         ConsumeSemicolon("Expect ';' after type alias.");
-        return new Stmt.TypeAlias(name, typeDef, typeParams);
+        return new Stmt.TypeAlias(name, typeDef, typeParams, typeDefNode);
     }
 
     private string ParseFunctionTypeDefinition()

--- a/SharpTS.Tests/TypeCheckerTests/TypeNodeSliceTests.cs
+++ b/SharpTS.Tests/TypeCheckerTests/TypeNodeSliceTests.cs
@@ -30,14 +30,60 @@ public class TypeNodeSliceTests
     [Fact]
     public void NodePath_FallsBackForUnsupportedConstructs()
     {
-        // Generic ALIAS references stay on the string path until alias definitions store nodes.
+        // Mapped-type alias bodies have no node form yet, so the reference falls back.
+        TypeNodeStats.Reset();
+        TestHarness.RunInterpreted("""
+            type RO<T> = { [K in keyof T]: T[K] };
+            var r: RO<{ a: number }> = { a: 1 };
+            """);
+        Assert.True(TypeNodeStats.StringFallbacks >= 1,
+            $"expected the mapped-alias annotation to fall back, got {TypeNodeStats.StringFallbacks}");
+    }
+
+    [Fact]
+    public void NodePath_EngagesForGenericAliasReferences()
+    {
         TypeNodeStats.Reset();
         TestHarness.RunInterpreted("""
             type Box<T> = { value: T };
+            type PairOf<A, B> = [A, B];
+            type Handler<T> = (item: T) => void;
             var b: Box<number> = { value: 1 };
+            var p: PairOf<string, number> = ["x", 1];
+            var h: Handler<string> = (s: string) => {};
             """);
-        Assert.True(TypeNodeStats.StringFallbacks >= 1,
-            $"expected the generic-alias annotation to fall back, got {TypeNodeStats.StringFallbacks}");
+        Assert.True(TypeNodeStats.NodeHits >= 3,
+            $"expected the node path for all three alias annotations, got {TypeNodeStats.NodeHits}");
+        Assert.Equal(0, TypeNodeStats.StringFallbacks);
+    }
+
+    [Fact]
+    public void NodeResolved_GenericAliasEnforcesSubstitutedArguments()
+    {
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted("""
+            type Box<T> = { value: T };
+            var b: Box<number> = { value: "no" };
+            """));
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted("""
+            type Handler<T> = (item: T) => void;
+            var h: Handler<string> = (n: number) => {};
+            """));
+        // Wrong arity carries the string path's TS2314.
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted("""
+            type Box<T> = { value: T };
+            var b: Box<number, string> = { value: 1 };
+            """));
+    }
+
+    [Fact]
+    public void NodeResolved_RecursiveAliasStillConverges()
+    {
+        // Self-referential alias: the recursion placeholder must fire on the node path the
+        // same way it does on the string path (no stack overflow, no spurious error).
+        TestHarness.RunInterpreted("""
+            type Tree<T> = { value: T; children: Tree<T>[] };
+            var t: Tree<number> = { value: 1, children: [{ value: 2, children: [] }] };
+            """);
     }
 
     [Fact]

--- a/TypeSystem/TypeChecker.Generics.cs
+++ b/TypeSystem/TypeChecker.Generics.cs
@@ -241,7 +241,7 @@ public partial class TypeChecker
             var genericAlias = _environment.GetGenericTypeAlias(baseName);
             if (genericAlias != null)
             {
-                var (definition, typeParamNames) = genericAlias.Value;
+                var (definition, typeParamNames, _) = genericAlias.Value;
                 if (typeArgs.Count != typeParamNames.Count)
                 {
                     throw new TypeCheckException($" Type alias '{baseName}' requires {typeParamNames.Count} type argument(s), got {typeArgs.Count}.", tsCode: "TS2314");

--- a/TypeSystem/TypeChecker.Statements.cs
+++ b/TypeSystem/TypeChecker.Statements.cs
@@ -94,7 +94,7 @@ public partial class TypeChecker
         {
             var typeParamNames = stmt.TypeParameters.Select(tp => tp.Name.Lexeme).ToList();
             ValidateTypeAliasSpreadConstraints(stmt);
-            _environment.DefineGenericTypeAlias(stmt.Name.Lexeme, stmt.TypeDefinition, typeParamNames);
+            _environment.DefineGenericTypeAlias(stmt.Name.Lexeme, stmt.TypeDefinition, typeParamNames, stmt.TypeDefinitionNode);
         }
         else
         {

--- a/TypeSystem/TypeChecker.TypeNodes.cs
+++ b/TypeSystem/TypeChecker.TypeNodes.cs
@@ -32,18 +32,25 @@ public partial class TypeChecker
 
             // Generic references resolve their argument nodes and reuse the SAME instantiation
             // machinery as the string path (built-in generics, utility types, generic
-            // classes/interfaces/functions — including its TS2314 arity errors). Generic ALIASES
-            // still fall back: their expansion is textual substitution of the ORIGINAL argument
-            // spellings, and re-rendered argument strings could shift recursion/instantiation
-            // keys. Aliases move off strings when their definitions are stored as nodes.
+            // classes/interfaces/functions — including its TS2314 arity errors). Generic alias
+            // references expand from their stored definition NODE when one exists, binding the
+            // type parameters in a child scope instead of substituting argument strings.
             case NamedTypeNode { TypeArguments: { } argNodes } named:
             {
-                if (_environment.GetGenericTypeAlias(named.Name) != null) return null;
                 List<TypeInfo> typeArgs = new(argNodes.Count);
                 foreach (var argNode in argNodes)
                 {
                     if (TryToTypeInfo(argNode) is not { } arg) return null;
                     typeArgs.Add(arg);
+                }
+                // ResolveGenericType handles built-in names BEFORE its alias lookup — a user
+                // alias named e.g. `Partial` is shadowed. Mirror that precedence here.
+                if (!IsBuiltInGenericName(named.Name) &&
+                    _environment.GetGenericTypeAlias(named.Name) is { } alias)
+                {
+                    return alias.DefinitionNode is { } definitionNode
+                        ? TryExpandGenericAliasFromNode(named.Name, definitionNode, alias.TypeParams, typeArgs)
+                        : null;
                 }
                 return ResolveGenericType(named.Name, typeArgs);
             }
@@ -244,6 +251,86 @@ public partial class TypeChecker
         }
 
         return new TypeInfo.Tuple(elements, requiredCount, restType);
+    }
+
+    /// <summary>
+    /// The generic names <see cref="ResolveGenericType"/> handles ahead of its alias lookup —
+    /// kept in its branch order. A user alias with one of these names is shadowed by the
+    /// built-in on BOTH paths.
+    /// </summary>
+    private static bool IsBuiltInGenericName(string name) => name is
+        "Array" or "ReadonlyArray" or "Promise" or "Generator" or "AsyncGenerator" or
+        "Partial" or "Required" or "Readonly" or "Record" or "Pick" or "Omit" or
+        "ReturnType" or "Parameters" or "ConstructorParameters" or "InstanceType" or
+        "ThisType" or "Awaited" or "NonNullable" or "Extract" or "Exclude" or
+        "Uppercase" or "Lowercase" or "Capitalize" or "Uncapitalize";
+
+    /// <summary>
+    /// Expands a generic alias from its definition node: the type parameters are bound to the
+    /// (already-resolved) arguments in a child scope and the definition resolves node-first —
+    /// no argument-string substitution, no definition re-parse. Mirrors the string path's
+    /// guards exactly: TS2314 arity, open-type-variable deferral, the TS2589 depth limit, the
+    /// recursion placeholder (same instantiation key derivation), and the same post-expansion
+    /// passes. Null (component without node support) falls back to the string path.
+    /// </summary>
+    private TypeInfo? TryExpandGenericAliasFromNode(
+        string baseName, TypeNode definitionNode, List<string> typeParamNames, List<TypeInfo> typeArgs)
+    {
+        if (typeArgs.Count != typeParamNames.Count)
+        {
+            throw new TypeCheckException(
+                $" Type alias '{baseName}' requires {typeParamNames.Count} type argument(s), got {typeArgs.Count}.",
+                tsCode: "TS2314");
+        }
+
+        // Open type variables (a mapped-type parameter mid-parse) defer instantiation, exactly
+        // like the string path (#185).
+        if (typeArgs.Any(ContainsOpenTypeVariable))
+            return new TypeInfo.RecursiveTypeAlias(baseName, typeArgs);
+
+        var typeArgStrings = typeArgs.Select(TypeInfoToString).ToList();
+        string aliasKey = $"{baseName}<{string.Join(",", typeArgStrings)}>";
+        _typeAliasExpansionStack ??= new HashSet<string>(StringComparer.Ordinal);
+
+        if (_typeAliasExpansionStack.Count >= MaxTypeAliasExpansionDepth)
+        {
+            throw new TypeCheckException(
+                " Type instantiation is excessively deep and possibly infinite.",
+                tsCode: "TS2589");
+        }
+
+        if (_typeAliasExpansionStack.Contains(aliasKey))
+            return new TypeInfo.RecursiveTypeAlias(baseName, typeArgs);
+
+        _typeAliasExpansionStack.Add(aliasKey);
+        try
+        {
+            var aliasEnv = new TypeEnvironment(_environment);
+            for (int i = 0; i < typeParamNames.Count; i++)
+                aliasEnv.DefineTypeParameter(typeParamNames[i], typeArgs[i]);
+
+            TypeInfo? result;
+            using (new EnvironmentScope(this, aliasEnv))
+            {
+                result = TryToTypeInfo(definitionNode);
+            }
+            if (result is null) return null;
+
+            // A nested alias may have expanded via the string path and produced a deferred
+            // conditional/mapped form — apply the same post-expansion passes as the string path.
+            if (result is TypeInfo.ConditionalType condResult && !ContainsOpenTypeVariable(condResult))
+                result = EvaluateConditionalType(condResult);
+            if (result is TypeInfo.MappedType mappedResult && !ContainsOpenTypeVariable(mappedResult))
+                result = ExpandMappedType(mappedResult);
+
+            result = FlattenTupleSpreads(result);
+            ValidateSpreadConstraints(result);
+            return result;
+        }
+        finally
+        {
+            _typeAliasExpansionStack.Remove(aliasKey);
+        }
     }
 
     /// <summary>

--- a/TypeSystem/TypeEnvironment.cs
+++ b/TypeSystem/TypeEnvironment.cs
@@ -19,7 +19,7 @@ namespace SharpTS.TypeSystem;
 public class TypeEnvironment : ScopeChain<TypeInfo, TypeEnvironment>
 {
     private readonly Dictionary<string, string> _typeAliases = new(StringComparer.Ordinal);
-    private readonly Dictionary<string, (string Definition, List<string> TypeParams)> _genericTypeAliases = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, (string Definition, List<string> TypeParams, TypeNode? DefinitionNode)> _genericTypeAliases = new(StringComparer.Ordinal);
     private readonly Dictionary<string, TypeInfo> _typeParameters = new(StringComparer.Ordinal);
     private readonly Dictionary<string, TypeInfo.Namespace> _namespaces = new(StringComparer.Ordinal);
     private readonly Dictionary<string, (TypeInfo Type, bool IsValue)> _importAliases = new(StringComparer.Ordinal);
@@ -99,17 +99,19 @@ public class TypeEnvironment : ScopeChain<TypeInfo, TypeEnvironment>
     }
 
     /// <summary>
-    /// Defines a generic type alias with type parameters.
+    /// Defines a generic type alias with type parameters. <paramref name="definitionNode"/> is
+    /// the structured form of the definition when the parser produced one (type-AST migration);
+    /// the string stays authoritative.
     /// </summary>
-    public void DefineGenericTypeAlias(string name, string definition, List<string> typeParams)
+    public void DefineGenericTypeAlias(string name, string definition, List<string> typeParams, TypeNode? definitionNode = null)
     {
-        _genericTypeAliases[name] = (definition, typeParams);
+        _genericTypeAliases[name] = (definition, typeParams, definitionNode);
     }
 
     /// <summary>
     /// Gets a generic type alias definition by name.
     /// </summary>
-    public (string Definition, List<string> TypeParams)? GetGenericTypeAlias(string name)
+    public (string Definition, List<string> TypeParams, TypeNode? DefinitionNode)? GetGenericTypeAlias(string name)
     {
         if (_genericTypeAliases.TryGetValue(name, out var alias))
             return alias;

--- a/docs/plans/type-ast-design.md
+++ b/docs/plans/type-ast-design.md
@@ -123,9 +123,17 @@ an equivalence test that converts both ways and asserts identical `TypeInfo` ren
      deliberately still fall back — their expansion is textual substitution of the
      ORIGINAL argument spellings, so node-resolved arguments could shift
      recursion/instantiation keys. Coverage: 65.3% → **68.7%**.
-   - 3b remaining: alias definitions stored as nodes, expansion via scoped node
-     resolution instead of `SubstituteTypeParamInString` (this is the part that buys
-     alias-instantiation identity). Mapped/conditional nodes ride with this.
+   - ✅ **3b shipped: alias definitions as nodes.** `Stmt.TypeAlias.TypeDefinitionNode` →
+     `TypeEnvironment` stores it beside the string; expansion binds the type parameters to
+     the resolved arguments in a child scope (`DefineTypeParameter` — consulted first by
+     name lookup) and resolves the definition node directly. No argument-string
+     substitution, no definition re-parse. Guards mirrored exactly: TS2314 arity,
+     open-type-variable deferral, TS2589 depth, recursion placeholder with the same key
+     derivation. Built-in generic names shadow aliases on both paths
+     (`IsBuiltInGenericName`). Aliases with mapped/conditional bodies naturally fall back
+     (those constructs have no nodes yet). Corpus coverage flat at 68.7% — the corpus's
+     aliases are mapped/conditional-heavy; the win is the mechanism (structural
+     instantiation), which is what slice 5's substitution-origin marking builds on.
 4. Declaration handles on `TypeInfo.Interface/Class` resolved via nodes (kills the
    `CacheKey()` workaround; fixes the cross-module diagnostic tests).
 5. Substitution-origin marking (unblocks #202's callback rule → `covariantCallbacks`).


### PR DESCRIPTION
Fifth increment of the type-AST migration (`docs/plans/type-ast-design.md`, follows #250, #254, #255, #258).

## What

This is the slice that replaces the heart of the old machinery: **alias expansion by text-pasting**. Today `type Box<T> = { value: T }` used as `Box<number>` works by substituting the string "number" into the definition text and re-reading the whole thing. Now:

- `Stmt.TypeAlias` carries the definition's `TypeNode`; `TypeEnvironment` stores it beside the authoritative string.
- A generic alias reference expands by **binding each type parameter to its resolved argument in a child scope** (`DefineTypeParameter` — the first thing name resolution consults) and resolving the definition node directly. No argument-string substitution, no re-parse.
- Every guard mirrors the string path exactly: TS2314 arity errors, open-type-variable deferral (the #185 family), the TS2589 depth limit, and the recursion placeholder — same instantiation-key derivation, same shared expansion stack, so mixed node/string recursion stays coherent.
- `IsBuiltInGenericName` mirrors `ResolveGenericType`'s precedence: a user alias named `Partial` is shadowed by the built-in on both paths.
- Aliases with mapped/conditional bodies have no node yet and fall back unchanged.

## Why corpus coverage is flat

Coverage stays at 68.7% — the conformance corpus's generic aliases are overwhelmingly mapped/conditional-bodied (still string-path by design). The value of this slice is the **mechanism**: alias instantiation is now structural (arguments are bound, not spliced as text), which is precisely the foundation slice 5's substitution-origin marking (#202 / covariantCallbacks) needs. New unit pins prove the path: alias engagement, substituted-argument enforcement, TS2314 arity, and recursive-alias convergence (`type Tree<T> = { value: T; children: Tree<T>[] }`).

## Validation

- Conformance baseline byte-identical: **Pass 63 / Fail 14 / ParseError 1**, zero drift
- Unit suite: **10,752 passed, 0 failed**