### PR TITLE
fix: await stack-spilling (#251), nested dns callbacks (#239), instanceof AbortSignal (#246), Promise subclass .constructor (#221 increment)

### DIFF
--- a/Compilation/AsyncMoveNextEmitter.Operators.cs
+++ b/Compilation/AsyncMoveNextEmitter.Operators.cs
@@ -60,9 +60,13 @@ public partial class AsyncMoveNextEmitter
 
     protected override void EmitTaggedTemplateLiteral(Expr.TaggedTemplateLiteral ttl)
     {
-        // 1. Emit the tag function reference
-        EmitExpression(ttl.Tag);
-        EnsureBoxed();
+        // Spill the tag and interpolated expressions first: an await inside any of them
+        // must suspend with an empty stack (same two-phase pattern as EmitTemplateLiteral).
+        var tagLocal = SpillBoxed(ttl.Tag);
+        var exprLocals = ttl.Expressions.Select(SpillBoxed).ToList();
+
+        // 1. Load the tag function reference
+        _il.Emit(OpCodes.Ldloc, tagLocal);
 
         // 2. Create cooked strings array (object?[] to allow null for invalid escapes)
         _il.Emit(OpCodes.Ldc_I4, ttl.CookedStrings.Count);
@@ -93,15 +97,14 @@ public partial class AsyncMoveNextEmitter
             _il.Emit(OpCodes.Stelem_Ref);
         }
 
-        // 4. Create expressions array
-        _il.Emit(OpCodes.Ldc_I4, ttl.Expressions.Count);
+        // 4. Create expressions array (from the pre-spilled locals)
+        _il.Emit(OpCodes.Ldc_I4, exprLocals.Count);
         _il.Emit(OpCodes.Newarr, typeof(object));
-        for (int i = 0; i < ttl.Expressions.Count; i++)
+        for (int i = 0; i < exprLocals.Count; i++)
         {
             _il.Emit(OpCodes.Dup);
             _il.Emit(OpCodes.Ldc_I4, i);
-            EmitExpression(ttl.Expressions[i]);
-            EnsureBoxed();
+            _il.Emit(OpCodes.Ldloc, exprLocals[i]);
             _il.Emit(OpCodes.Stelem_Ref);
         }
 
@@ -110,67 +113,9 @@ public partial class AsyncMoveNextEmitter
         SetStackUnknown();
     }
 
-    protected override void EmitSet(Expr.Set s)
-    {
-        // Handle globalThis.x = value
-        if (s.Object is Expr.Variable gtVar && gtVar.Name.Lexeme == "globalThis")
-        {
-            EmitExpression(s.Value);
-            EnsureBoxed();
-            var gtResultTemp = _il.DeclareLocal(typeof(object));
-            _il.Emit(OpCodes.Stloc, gtResultTemp);
-            _il.Emit(OpCodes.Ldstr, s.Name.Lexeme);
-            _il.Emit(OpCodes.Ldloc, gtResultTemp);
-            _il.Emit(OpCodes.Call, _ctx!.Runtime!.GlobalThisSetProperty);
-            _il.Emit(OpCodes.Ldloc, gtResultTemp);
-            SetStackUnknown();
-            return;
-        }
-
-        // Handle static field assignment: Class.field = value
-        if (s.Object is Expr.Variable classVar &&
-            _ctx!.Classes.TryGetValue(_ctx.ResolveClassName(classVar.Name.Lexeme), out var classBuilder))
-        {
-            string resolvedClassName = _ctx.ResolveClassName(classVar.Name.Lexeme);
-            if (_ctx.ClassRegistry!.TryGetStaticField(resolvedClassName, s.Name.Lexeme, out var staticField))
-            {
-                // Emit value
-                EmitExpression(s.Value);
-                EnsureBoxed();
-
-                // Dup for expression result (assignment returns the value)
-                _il.Emit(OpCodes.Dup);
-
-                // Store to static field
-                _il.Emit(OpCodes.Stsfld, staticField!);
-                SetStackUnknown();
-                return;
-            }
-        }
-
-        // Type-first dispatch: property setter via TypeEmitterRegistry
-        if (TryEmitTypeRegistryPropertySet(s)) return;
-
-        // Default: dynamic property assignment
-        // Build stack for SetProperty(obj, name, value)
-        EmitExpression(s.Object);
-        EnsureBoxed();
-        _il.Emit(OpCodes.Ldstr, s.Name.Lexeme);
-        EmitExpression(s.Value);
-        EnsureBoxed();
-
-        // Dup value for expression result (assignment returns the value)
-        _il.Emit(OpCodes.Dup);
-        var resultTemp = _il.DeclareLocal(typeof(object));
-        _il.Emit(OpCodes.Stloc, resultTemp);
-
-        // Call SetProperty (returns void)
-        _il.Emit(OpCodes.Call, _ctx!.Runtime!.SetProperty);
-
-        // Put result back on stack
-        _il.Emit(OpCodes.Ldloc, resultTemp);
-        SetStackUnknown();
-    }
+    // EmitSet is inherited from ExpressionEmitterBase: it covers the same cases
+    // (globalThis, static fields, registry, dynamic SetProperty) plus CommonJS
+    // module.exports, and spills operands so awaits inside Value are suspension-safe.
 
     protected override void EmitGetPrivate(Expr.GetPrivate gp)
     {
@@ -207,9 +152,10 @@ public partial class AsyncMoveNextEmitter
             var dictType = typeof(Dictionary<string, object?>);
             var dictLocal = _il.DeclareLocal(dictType);
 
+            // Spill the object so an await inside it doesn't suspend with the storage field on the stack.
+            var objLocal = SpillBoxed(gp.Object);
             _il.Emit(OpCodes.Ldsfld, storageField);
-            EmitExpression(gp.Object);
-            EnsureBoxed();
+            _il.Emit(OpCodes.Ldloc, objLocal);
             _il.Emit(OpCodes.Ldloca, dictLocal);
             var tryGetValueMethod = cwtType.GetMethod("TryGetValue", [typeof(object), dictType.MakeByRefType()])!;
             _il.Emit(OpCodes.Callvirt, tryGetValueMethod);
@@ -280,9 +226,10 @@ public partial class AsyncMoveNextEmitter
             var dictLocal = _il.DeclareLocal(dictType);
             var valueLocal = _il.DeclareLocal(typeof(object));
 
+            // Spill the object so an await inside it doesn't suspend with the storage field on the stack.
+            var objLocal = SpillBoxed(sp.Object);
             _il.Emit(OpCodes.Ldsfld, storageField);
-            EmitExpression(sp.Object);
-            EnsureBoxed();
+            _il.Emit(OpCodes.Ldloc, objLocal);
             _il.Emit(OpCodes.Ldloca, dictLocal);
             var tryGetValueMethod = cwtType.GetMethod("TryGetValue", [typeof(object), dictType.MakeByRefType()])!;
             _il.Emit(OpCodes.Callvirt, tryGetValueMethod);
@@ -344,11 +291,10 @@ public partial class AsyncMoveNextEmitter
             classVar.Name.Lexeme == _ctx!.CurrentClassShortName &&
             _ctx!.ClassRegistry!.TryGetStaticPrivateMethod(className, methodName, out var staticMethod))
         {
-            foreach (var arg in cp.Arguments)
-            {
-                EmitExpression(arg);
-                EnsureBoxed();
-            }
+            // Spill args so an await inside one doesn't suspend with earlier args on the stack.
+            var argLocals = cp.Arguments.Select(SpillBoxed).ToList();
+            foreach (var argLocal in argLocals)
+                _il.Emit(OpCodes.Ldloc, argLocal);
             _il.Emit(OpCodes.Call, staticMethod!);
             SetStackUnknown();
             return;
@@ -383,15 +329,15 @@ public partial class AsyncMoveNextEmitter
                 _il.Emit(OpCodes.Throw);
                 _il.MarkLabel(validLabel);
 
+                // Spill args so an await inside one doesn't suspend with the receiver on the stack.
+                var argLocals = cp.Arguments.Select(SpillBoxed).ToList();
+
                 _il.Emit(OpCodes.Ldloc, objLocal);
                 if (_ctx.CurrentClassBuilder != null)
                     _il.Emit(OpCodes.Castclass, _ctx.CurrentClassBuilder);
 
-                foreach (var arg in cp.Arguments)
-                {
-                    EmitExpression(arg);
-                    EnsureBoxed();
-                }
+                foreach (var argLocal in argLocals)
+                    _il.Emit(OpCodes.Ldloc, argLocal);
 
                 _il.Emit(OpCodes.Callvirt, instanceMethod!);
                 SetStackUnknown();
@@ -400,17 +346,16 @@ public partial class AsyncMoveNextEmitter
             else
             {
                 // No private field storage (class has private methods but no private fields)
-                // Skip brand check - just emit the call directly
-                EmitExpression(cp.Object);
-                EnsureBoxed();
+                // Skip brand check - spill receiver and args, then emit the call directly
+                var objLocal = SpillBoxed(cp.Object);
+                var argLocals = cp.Arguments.Select(SpillBoxed).ToList();
+
+                _il.Emit(OpCodes.Ldloc, objLocal);
                 if (_ctx.CurrentClassBuilder != null)
                     _il.Emit(OpCodes.Castclass, _ctx.CurrentClassBuilder);
 
-                foreach (var arg in cp.Arguments)
-                {
-                    EmitExpression(arg);
-                    EnsureBoxed();
-                }
+                foreach (var argLocal in argLocals)
+                    _il.Emit(OpCodes.Ldloc, argLocal);
 
                 _il.Emit(OpCodes.Callvirt, instanceMethod!);
                 SetStackUnknown();
@@ -439,23 +384,6 @@ public partial class AsyncMoveNextEmitter
             _il.Emit(OpCodes.Ldstr, "Cannot access private members outside of class context");
             _il.Emit(OpCodes.Newobj, Types.InvalidOperationExceptionCtorString);
             _il.Emit(OpCodes.Throw);
-        }
-    }
-
-    /// <summary>
-    /// Emits an object[] array from argument expressions.
-    /// </summary>
-    private void EmitArgumentArray(List<Expr> arguments)
-    {
-        _il.Emit(OpCodes.Ldc_I4, arguments.Count);
-        _il.Emit(OpCodes.Newarr, typeof(object));
-        for (int i = 0; i < arguments.Count; i++)
-        {
-            _il.Emit(OpCodes.Dup);
-            _il.Emit(OpCodes.Ldc_I4, i);
-            EmitExpression(arguments[i]);
-            EnsureBoxed();
-            _il.Emit(OpCodes.Stelem_Ref);
         }
     }
 

--- a/Compilation/CallHandlers/BuiltInModuleHandler.cs
+++ b/Compilation/CallHandlers/BuiltInModuleHandler.cs
@@ -1,3 +1,4 @@
+using System.Reflection.Emit;
 using SharpTS.Compilation.Emitters;
 using SharpTS.Parsing;
 
@@ -6,7 +7,8 @@ namespace SharpTS.Compilation.CallHandlers;
 /// <summary>
 /// Handles built-in module method calls: path.join, fs.readFileSync, os.platform, etc.
 /// Also handles nested calls like util.types.isArray().
-/// Delegates to BuiltInModuleEmitterRegistry for module-specific emission.
+/// Delegates to BuiltInModuleEmitterRegistry for module-specific emission, falling back
+/// to $Runtime wrapper methods registered via RegisterBuiltInModuleMethod.
 /// </summary>
 public class BuiltInModuleHandler : ICallHandler
 {
@@ -30,6 +32,15 @@ public class BuiltInModuleHandler : ICallHandler
                 emitter.SetStackUnknown();
                 return true;
             }
+
+            // Fall back to the $Runtime wrapper registered for this method
+            // (RegisterBuiltInModuleMethod — dns.resolve4, fs callbacks, ...).
+            // Without this, the call only worked where the namespace object
+            // happened to be reachable as an entry-point local: inside any
+            // function/arrow body the variable resolved to null and the call
+            // silently no-opped (#239).
+            if (TryEmitRegisteredModuleMethodCall(emitter, builtInModuleName, builtInGet.Name.Lexeme, call.Arguments))
+                return true;
         }
 
         // Try nested module method call: module.namespace.method() (e.g., util.types.isArray)
@@ -69,5 +80,53 @@ public class BuiltInModuleHandler : ICallHandler
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// Emits a direct static call to a $Runtime module wrapper registered via
+    /// RegisterBuiltInModuleMethod. Only fires for the uniform object-in/object-out
+    /// wrapper shape; anything else keeps the previous fallthrough behavior.
+    /// </summary>
+    private static bool TryEmitRegisteredModuleMethodCall(
+        IEmitterContext emitter, string moduleName, string methodName, List<Expr> arguments)
+    {
+        var ctx = emitter.Context;
+        var helper = ctx.Runtime?.GetBuiltInModuleMethod(moduleName, methodName);
+        if (helper == null)
+            return false;
+
+        var parameters = helper.GetParameters();
+        if (parameters.Any(p => p.ParameterType != typeof(object)) ||
+            (helper.ReturnType != typeof(object) && helper.ReturnType != typeof(void)))
+            return false;
+
+        var il = ctx.IL;
+
+        // Evaluate every argument into a temp local first: extra arguments must
+        // still be evaluated for side effects, and state-machine emitters require
+        // an empty IL stack across an await inside any argument.
+        var temps = new List<LocalBuilder>();
+        foreach (var arg in arguments)
+        {
+            emitter.EmitExpression(arg);
+            emitter.EmitBoxIfNeeded(arg);
+            var temp = il.DeclareLocal(typeof(object));
+            il.Emit(OpCodes.Stloc, temp);
+            temps.Add(temp);
+        }
+
+        for (int i = 0; i < parameters.Length; i++)
+        {
+            if (i < temps.Count)
+                il.Emit(OpCodes.Ldloc, temps[i]);
+            else
+                il.Emit(OpCodes.Ldnull);
+        }
+
+        il.Emit(OpCodes.Call, helper);
+        if (helper.ReturnType == typeof(void))
+            il.Emit(OpCodes.Ldnull);
+        emitter.SetStackUnknown();
+        return true;
     }
 }

--- a/Compilation/ExpressionEmitterBase.Operators.cs
+++ b/Compilation/ExpressionEmitterBase.Operators.cs
@@ -231,13 +231,11 @@ public abstract partial class ExpressionEmitterBase
         EmitLogicalConditionCheck(ls.Operator.Type, skipLabel);
 
         IL.Emit(OpCodes.Pop);
+        // Spill the value so an await inside it suspends with an empty stack.
+        var resultLocal = SpillBoxed(ls.Value);
         IL.Emit(OpCodes.Ldloc, objLocal);
         IL.Emit(OpCodes.Ldstr, ls.Name.Lexeme);
-        EmitExpression(ls.Value);
-        EnsureBoxed();
-        var resultLocal = IL.DeclareLocal(typeof(object));
-        IL.Emit(OpCodes.Dup);
-        IL.Emit(OpCodes.Stloc, resultLocal);
+        IL.Emit(OpCodes.Ldloc, resultLocal);
         IL.Emit(OpCodes.Call, Ctx.Runtime!.SetProperty);
         IL.Emit(OpCodes.Ldloc, resultLocal);
         IL.Emit(OpCodes.Br, endLabel);
@@ -275,13 +273,11 @@ public abstract partial class ExpressionEmitterBase
         EmitLogicalConditionCheck(lsi.Operator.Type, skipLabel);
 
         IL.Emit(OpCodes.Pop);
+        // Spill the value so an await inside it suspends with an empty stack.
+        var resultLocal = SpillBoxed(lsi.Value);
         IL.Emit(OpCodes.Ldloc, objLocal);
         IL.Emit(OpCodes.Ldloc, indexLocal);
-        EmitExpression(lsi.Value);
-        EnsureBoxed();
-        var resultLocal = IL.DeclareLocal(typeof(object));
-        IL.Emit(OpCodes.Dup);
-        IL.Emit(OpCodes.Stloc, resultLocal);
+        IL.Emit(OpCodes.Ldloc, resultLocal);
         IL.Emit(OpCodes.Call, Ctx.Runtime!.SetIndex);
         IL.Emit(OpCodes.Ldloc, resultLocal);
         IL.Emit(OpCodes.Br, endLabel);
@@ -327,9 +323,15 @@ public abstract partial class ExpressionEmitterBase
         IL.Emit(OpCodes.Ldloc, objTemp);
         IL.Emit(OpCodes.Ldstr, cs.Name.Lexeme);
         IL.Emit(OpCodes.Call, Ctx.Runtime!.GetProperty);
+        var currentTemp = IL.DeclareLocal(typeof(object));
+        IL.Emit(OpCodes.Stloc, currentTemp);
 
-        EmitExpression(cs.Value);
-        EnsureBoxed();
+        // Spill the value so an await inside it suspends with an empty stack
+        // (the current property value must not stay on the stack across it).
+        var rhsTemp = SpillBoxed(cs.Value);
+
+        IL.Emit(OpCodes.Ldloc, currentTemp);
+        IL.Emit(OpCodes.Ldloc, rhsTemp);
         EmitCompoundOperation(cs.Operator.Type);
 
         var resultLocal = IL.DeclareLocal(typeof(object));
@@ -362,9 +364,15 @@ public abstract partial class ExpressionEmitterBase
         IL.Emit(OpCodes.Ldloc, objTemp);
         IL.Emit(OpCodes.Ldloc, indexTemp);
         IL.Emit(OpCodes.Call, Ctx.Runtime!.GetIndex);
+        var currentTemp = IL.DeclareLocal(typeof(object));
+        IL.Emit(OpCodes.Stloc, currentTemp);
 
-        EmitExpression(csi.Value);
-        EnsureBoxed();
+        // Spill the value so an await inside it suspends with an empty stack
+        // (the current element value must not stay on the stack across it).
+        var valueTemp = SpillBoxed(csi.Value);
+
+        IL.Emit(OpCodes.Ldloc, currentTemp);
+        IL.Emit(OpCodes.Ldloc, valueTemp);
         EmitCompoundOperation(csi.Operator.Type);
 
         var resultLocal = IL.DeclareLocal(typeof(object));

--- a/Compilation/ExpressionEmitterBase.cs
+++ b/Compilation/ExpressionEmitterBase.cs
@@ -325,6 +325,22 @@ public abstract partial class ExpressionEmitterBase : IEmitterContext
     }
 
     /// <summary>
+    /// Emits an expression boxed and spills it into a fresh object local.
+    /// State-machine emitters (the only users of these base implementations) can suspend
+    /// inside any subexpression (await); values left on the IL evaluation stack across a
+    /// suspension produce invalid IL, so multi-operand emission must evaluate each operand
+    /// into a local first — the same await-safe pattern as EmitFunctionValueCall.
+    /// </summary>
+    protected LocalBuilder SpillBoxed(Expr e)
+    {
+        EmitExpression(e);
+        EnsureBoxed();
+        var local = IL.DeclareLocal(typeof(object));
+        IL.Emit(OpCodes.Stloc, local);
+        return local;
+    }
+
+    /// <summary>
     /// Emits a binary operator expression. Default boxes both operands and delegates to TryEmitBinaryOperator.
     /// ILEmitter overrides with stack-type-tracked fast paths.
     /// </summary>
@@ -337,10 +353,11 @@ public abstract partial class ExpressionEmitterBase : IEmitterContext
             return;
         }
 
-        EmitExpression(b.Left);
-        EnsureBoxed();
-        EmitExpression(b.Right);
-        EnsureBoxed();
+        // Spill operands so an await inside Right doesn't suspend with Left on the stack.
+        var leftLocal = SpillBoxed(b.Left);
+        var rightLocal = SpillBoxed(b.Right);
+        IL.Emit(OpCodes.Ldloc, leftLocal);
+        IL.Emit(OpCodes.Ldloc, rightLocal);
 
         // `in` and `instanceof` are binary operators not covered by TryEmitBinaryOperator.
         switch (b.Operator.Type)
@@ -380,13 +397,21 @@ public abstract partial class ExpressionEmitterBase : IEmitterContext
     /// </summary>
     private void EmitBitwiseOrShiftBinary(Expr.Binary b)
     {
+        // Spill the coerced left operand so an await inside Right suspends with an empty stack.
         EmitExpression(b.Left);
         EnsureBoxed();
         IL.Emit(OpCodes.Call, Ctx.Runtime!.JsToInt32);
+        var leftLocal = IL.DeclareLocal(typeof(int));
+        IL.Emit(OpCodes.Stloc, leftLocal);
 
         EmitExpression(b.Right);
         EnsureBoxed();
         IL.Emit(OpCodes.Call, Ctx.Runtime!.JsToInt32);
+        var rightLocal = IL.DeclareLocal(typeof(int));
+        IL.Emit(OpCodes.Stloc, rightLocal);
+
+        IL.Emit(OpCodes.Ldloc, leftLocal);
+        IL.Emit(OpCodes.Ldloc, rightLocal);
 
         switch (b.Operator.Type)
         {
@@ -437,8 +462,8 @@ public abstract partial class ExpressionEmitterBase : IEmitterContext
             return;
         }
 
-        EmitExpression(gi.Object);
-        EnsureBoxed();
+        // Spill the object so an await inside Index doesn't suspend with it on the stack.
+        var objLocal = SpillBoxed(gi.Object);
 
         if (gi.Optional)
         {
@@ -446,22 +471,22 @@ public abstract partial class ExpressionEmitterBase : IEmitterContext
             var endLabel = IL.DefineLabel();
 
             // Check for null
-            IL.Emit(OpCodes.Dup);
+            IL.Emit(OpCodes.Ldloc, objLocal);
             IL.Emit(OpCodes.Brfalse, nullishLabel);
 
             // Check for undefined
-            IL.Emit(OpCodes.Dup);
+            IL.Emit(OpCodes.Ldloc, objLocal);
             IL.Emit(OpCodes.Isinst, Ctx.Runtime!.UndefinedType);
             IL.Emit(OpCodes.Brtrue, nullishLabel);
 
             // Not nullish — proceed with index access
-            EmitExpression(gi.Index);
-            EnsureBoxed();
+            var idxLocal = SpillBoxed(gi.Index);
+            IL.Emit(OpCodes.Ldloc, objLocal);
+            IL.Emit(OpCodes.Ldloc, idxLocal);
             IL.Emit(OpCodes.Call, Ctx.Runtime!.GetIndex);
             IL.Emit(OpCodes.Br, endLabel);
 
             IL.MarkLabel(nullishLabel);
-            IL.Emit(OpCodes.Pop);
             IL.Emit(OpCodes.Ldsfld, Ctx.Runtime!.UndefinedInstance);
 
             IL.MarkLabel(endLabel);
@@ -469,8 +494,9 @@ public abstract partial class ExpressionEmitterBase : IEmitterContext
         }
         else
         {
-            EmitExpression(gi.Index);
-            EnsureBoxed();
+            var idxLocal = SpillBoxed(gi.Index);
+            IL.Emit(OpCodes.Ldloc, objLocal);
+            IL.Emit(OpCodes.Ldloc, idxLocal);
             IL.Emit(OpCodes.Call, Ctx.Runtime!.GetIndex);
             SetStackUnknown();
         }
@@ -500,15 +526,13 @@ public abstract partial class ExpressionEmitterBase : IEmitterContext
             return;
         }
 
-        EmitExpression(si.Value);
-        EnsureBoxed();
-        var valueLocal = IL.DeclareLocal(typeof(object));
-        IL.Emit(OpCodes.Stloc, valueLocal);
+        // Spill everything so an await inside any operand suspends with an empty stack.
+        var valueLocal = SpillBoxed(si.Value);
+        var objLocal = SpillBoxed(si.Object);
+        var idxLocal = SpillBoxed(si.Index);
 
-        EmitExpression(si.Object);
-        EnsureBoxed();
-        EmitExpression(si.Index);
-        EnsureBoxed();
+        IL.Emit(OpCodes.Ldloc, objLocal);
+        IL.Emit(OpCodes.Ldloc, idxLocal);
         IL.Emit(OpCodes.Ldloc, valueLocal);
         IL.Emit(OpCodes.Call, Ctx.Runtime!.SetIndex);
 
@@ -650,19 +674,16 @@ public abstract partial class ExpressionEmitterBase : IEmitterContext
         // Type-first dispatch: property setter via TypeEmitterRegistry
         if (TryEmitTypeRegistryPropertySet(s)) return;
 
-        // Default: dynamic property assignment
-        EmitExpression(s.Object);
-        EnsureBoxed();
+        // Default: dynamic property assignment.
+        // Spill operands so an await inside Value doesn't suspend with the object on the stack.
+        var objLocal = SpillBoxed(s.Object);
+        var valueLocal = SpillBoxed(s.Value);
+
+        IL.Emit(OpCodes.Ldloc, objLocal);
         IL.Emit(OpCodes.Ldstr, s.Name.Lexeme);
-        EmitExpression(s.Value);
-        EnsureBoxed();
-
-        IL.Emit(OpCodes.Dup);
-        var resultTemp = IL.DeclareLocal(typeof(object));
-        IL.Emit(OpCodes.Stloc, resultTemp);
-
+        IL.Emit(OpCodes.Ldloc, valueLocal);
         IL.Emit(OpCodes.Call, Ctx.Runtime!.SetProperty);
-        IL.Emit(OpCodes.Ldloc, resultTemp);
+        IL.Emit(OpCodes.Ldloc, valueLocal);
         SetStackUnknown();
     }
 
@@ -1031,6 +1052,16 @@ public abstract partial class ExpressionEmitterBase : IEmitterContext
     {
         bool hasSpreads = a.Elements.Any(e => e is Expr.Spread);
 
+        // Evaluate all elements into locals first so an await inside any element
+        // suspends with an empty stack (holes need no evaluation).
+        var elementLocals = new LocalBuilder?[a.Elements.Count];
+        for (int i = 0; i < a.Elements.Count; i++)
+        {
+            if (a.IsHole(i))
+                continue;
+            elementLocals[i] = SpillBoxed(a.Elements[i] is Expr.Spread spread ? spread.Expression : a.Elements[i]);
+        }
+
         if (!hasSpreads)
         {
             IL.Emit(OpCodes.Ldc_I4, a.Elements.Count);
@@ -1040,15 +1071,14 @@ public abstract partial class ExpressionEmitterBase : IEmitterContext
             {
                 IL.Emit(OpCodes.Dup);
                 IL.Emit(OpCodes.Ldc_I4, i);
-                if (a.IsHole(i))
+                if (elementLocals[i] == null)
                 {
                     // Elided position → true ECMA-262 hole, not an undefined element.
                     IL.Emit(OpCodes.Ldsfld, Ctx.Runtime!.ArrayHoleInstance);
                 }
                 else
                 {
-                    EmitExpression(a.Elements[i]);
-                    EnsureBoxed();
+                    IL.Emit(OpCodes.Ldloc, elementLocals[i]!);
                 }
                 IL.Emit(OpCodes.Stelem_Ref);
             }
@@ -1065,10 +1095,9 @@ public abstract partial class ExpressionEmitterBase : IEmitterContext
                 IL.Emit(OpCodes.Dup);
                 IL.Emit(OpCodes.Ldc_I4, i);
 
-                if (a.Elements[i] is Expr.Spread spread)
+                if (a.Elements[i] is Expr.Spread)
                 {
-                    EmitExpression(spread.Expression);
-                    EnsureBoxed();
+                    IL.Emit(OpCodes.Ldloc, elementLocals[i]!);
                 }
                 else
                 {
@@ -1076,14 +1105,13 @@ public abstract partial class ExpressionEmitterBase : IEmitterContext
                     IL.Emit(OpCodes.Newarr, typeof(object));
                     IL.Emit(OpCodes.Dup);
                     IL.Emit(OpCodes.Ldc_I4_0);
-                    if (a.IsHole(i))
+                    if (elementLocals[i] == null)
                     {
                         IL.Emit(OpCodes.Ldsfld, Ctx.Runtime!.ArrayHoleInstance);
                     }
                     else
                     {
-                        EmitExpression(a.Elements[i]);
-                        EnsureBoxed();
+                        IL.Emit(OpCodes.Ldloc, elementLocals[i]!);
                     }
                     IL.Emit(OpCodes.Stelem_Ref);
                     IL.Emit(OpCodes.Call, Ctx.Runtime!.CreateArray);
@@ -1116,14 +1144,16 @@ public abstract partial class ExpressionEmitterBase : IEmitterContext
         }
         else if (!hasSpreads && !hasComputedKeys)
         {
+            // Spill values first so an await inside any value suspends with an empty stack.
+            var valueLocals = o.Properties.Select(p => SpillBoxed(p.Value)).ToList();
+
             IL.Emit(OpCodes.Newobj, Types.DictionaryStringObjectCtor);
 
-            foreach (var prop in o.Properties)
+            for (int i = 0; i < o.Properties.Count; i++)
             {
                 IL.Emit(OpCodes.Dup);
-                EmitStaticPropertyKey(prop.Key!);
-                EmitExpression(prop.Value);
-                EnsureBoxed();
+                EmitStaticPropertyKey(o.Properties[i].Key!);
+                IL.Emit(OpCodes.Ldloc, valueLocals[i]);
                 IL.Emit(OpCodes.Callvirt, Types.DictionaryStringObjectSetItem);
             }
 
@@ -1131,31 +1161,38 @@ public abstract partial class ExpressionEmitterBase : IEmitterContext
         }
         else
         {
+            // Spill computed keys and values first (evaluation order: key before value, per property).
+            var keyLocals = new LocalBuilder?[o.Properties.Count];
+            var valueLocals = new LocalBuilder[o.Properties.Count];
+            for (int i = 0; i < o.Properties.Count; i++)
+            {
+                if (o.Properties[i].Key is Expr.ComputedKey ck)
+                    keyLocals[i] = SpillBoxed(ck.Expression);
+                valueLocals[i] = SpillBoxed(o.Properties[i].Value);
+            }
+
             IL.Emit(OpCodes.Newobj, Types.DictionaryStringObjectNullableCtor);
 
-            foreach (var prop in o.Properties)
+            for (int i = 0; i < o.Properties.Count; i++)
             {
+                var prop = o.Properties[i];
                 IL.Emit(OpCodes.Dup);
 
                 if (prop.IsSpread)
                 {
-                    EmitExpression(prop.Value);
-                    EnsureBoxed();
+                    IL.Emit(OpCodes.Ldloc, valueLocals[i]);
                     IL.Emit(OpCodes.Call, Ctx.Runtime!.MergeIntoObject);
                 }
-                else if (prop.Key is Expr.ComputedKey ck)
+                else if (prop.Key is Expr.ComputedKey)
                 {
-                    EmitExpression(ck.Expression);
-                    EnsureBoxed();
-                    EmitExpression(prop.Value);
-                    EnsureBoxed();
+                    IL.Emit(OpCodes.Ldloc, keyLocals[i]!);
+                    IL.Emit(OpCodes.Ldloc, valueLocals[i]);
                     IL.Emit(OpCodes.Call, Ctx.Runtime!.SetIndex);
                 }
                 else
                 {
                     EmitStaticPropertyKey(prop.Key!);
-                    EmitExpression(prop.Value);
-                    EnsureBoxed();
+                    IL.Emit(OpCodes.Ldloc, valueLocals[i]);
                     IL.Emit(OpCodes.Callvirt, Types.DictionaryStringObjectNullableSetItem);
                 }
             }
@@ -1178,40 +1215,34 @@ public abstract partial class ExpressionEmitterBase : IEmitterContext
 
         foreach (var prop in o.Properties)
         {
+            // Spill the value first so an await inside it suspends with an empty stack.
+            var valueLocal = SpillBoxed(prop.Value);
+
             if (prop.IsSpread)
             {
                 IL.Emit(OpCodes.Ldloc, objLocal);
-                EmitExpression(prop.Value);
-                EnsureBoxed();
+                IL.Emit(OpCodes.Ldloc, valueLocal);
                 IL.Emit(OpCodes.Call, Ctx.Runtime!.MergeIntoTSObject);
                 continue;
             }
 
             string propKey = GetPropertyKeyString(prop.Key!);
 
+            IL.Emit(OpCodes.Ldloc, objLocal);
+            IL.Emit(OpCodes.Ldstr, propKey);
+            IL.Emit(OpCodes.Ldloc, valueLocal);
+
             switch (prop.Kind)
             {
                 case Expr.ObjectPropertyKind.Getter:
-                    IL.Emit(OpCodes.Ldloc, objLocal);
-                    IL.Emit(OpCodes.Ldstr, propKey);
-                    EmitExpression(prop.Value);
-                    EnsureBoxed();
                     IL.Emit(OpCodes.Callvirt, Ctx.Runtime!.TSObjectDefineGetter);
                     break;
 
                 case Expr.ObjectPropertyKind.Setter:
-                    IL.Emit(OpCodes.Ldloc, objLocal);
-                    IL.Emit(OpCodes.Ldstr, propKey);
-                    EmitExpression(prop.Value);
-                    EnsureBoxed();
                     IL.Emit(OpCodes.Callvirt, Ctx.Runtime!.TSObjectDefineSetter);
                     break;
 
                 default:
-                    IL.Emit(OpCodes.Ldloc, objLocal);
-                    IL.Emit(OpCodes.Ldstr, propKey);
-                    EmitExpression(prop.Value);
-                    EnsureBoxed();
                     IL.Emit(OpCodes.Callvirt, Ctx.Runtime!.TSObjectSetProperty);
                     break;
             }

--- a/Compilation/RuntimeEmitter.CoreUtilities.cs
+++ b/Compilation/RuntimeEmitter.CoreUtilities.cs
@@ -3568,6 +3568,40 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldarg_1);
         il.Emit(OpCodes.Brfalse, falseLabel);
 
+        // A plain Dictionary RHS is never a constructor — letting it reach the
+        // IsAssignableFrom fallback matched EVERY dict-shaped value (object
+        // literals, namespace singletons, module namespaces), so
+        // `{} instanceof AbortSignal` was true (#246). The AbortSignal
+        // namespace singleton brand-checks signal dicts via their
+        // "_reasonSet" slot; any other dict RHS is false.
+        var notDictRhsLabel = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Isinst, _types.DictionaryStringObject);
+        il.Emit(OpCodes.Brfalse, notDictRhsLabel);
+
+        if (runtime.AbortSignalNamespaceField != null)
+        {
+            var lhsDictLocal = il.DeclareLocal(_types.DictionaryStringObject);
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Ldsfld, runtime.AbortSignalNamespaceField);
+            il.Emit(OpCodes.Bne_Un, falseLabel);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Isinst, _types.DictionaryStringObject);
+            il.Emit(OpCodes.Stloc, lhsDictLocal);
+            il.Emit(OpCodes.Ldloc, lhsDictLocal);
+            il.Emit(OpCodes.Brfalse, falseLabel);
+            il.Emit(OpCodes.Ldloc, lhsDictLocal);
+            il.Emit(OpCodes.Ldstr, "_reasonSet");
+            il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.DictionaryStringObject, "ContainsKey", _types.String));
+            il.Emit(OpCodes.Ret);
+        }
+        else
+        {
+            il.Emit(OpCodes.Br, falseLabel);
+        }
+
+        il.MarkLabel(notDictRhsLabel);
+
         // Per JS spec, `instance instanceof F` where F is a user function walks
         // instance's prototype chain looking for F.prototype. Compiled mode's
         // legacy InstanceOf used .NET IsAssignableFrom, which is type-system

--- a/Compilation/RuntimeEmitter.NamespaceSingletons.cs
+++ b/Compilation/RuntimeEmitter.NamespaceSingletons.cs
@@ -22,12 +22,32 @@ public partial class RuntimeEmitter
     /// Lazily populated: the populate shell is called before each bare-
     /// reference load; the field doubles as the populated flag.
     /// </summary>
+    /// <summary>
+    /// Pre-defines the namespace singleton fields so earlier $Runtime methods
+    /// can reference them — InstanceOf brand-checks the AbortSignal singleton
+    /// (#246) and is emitted before the populate bodies (which need the
+    /// AbortSignal*/CreateIntl* helpers emitted later in EmitRuntimeClass).
+    /// </summary>
+    private void DefineNamespaceSingletonFields(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    {
+        if (_features.UsesAbortController)
+            runtime.AbortSignalNamespaceField = DefineNamespaceSingletonField(typeBuilder, "AbortSignal");
+        if (_features.UsesIntl)
+            runtime.IntlNamespaceField = DefineNamespaceSingletonField(typeBuilder, "Intl");
+    }
+
+    private FieldBuilder DefineNamespaceSingletonField(TypeBuilder typeBuilder, string namespaceName) =>
+        typeBuilder.DefineField(
+            $"_{namespaceName}Namespace",
+            _types.DictionaryStringObject,
+            FieldAttributes.Public | FieldAttributes.Static);
+
     private void EmitNamespaceSingletons(TypeBuilder typeBuilder, EmittedRuntime runtime)
     {
         if (_features.UsesAbortController)
         {
-            (runtime.AbortSignalNamespaceField, runtime.AbortSignalNamespacePopulate) =
-                EmitNamespaceSingleton(typeBuilder, runtime, "AbortSignal",
+            runtime.AbortSignalNamespacePopulate =
+                EmitNamespaceSingleton(typeBuilder, runtime, "AbortSignal", runtime.AbortSignalNamespaceField!,
                 [
                     ("abort", runtime.AbortSignalAbort, 1),
                     ("timeout", runtime.AbortSignalTimeout, 1),
@@ -37,8 +57,8 @@ public partial class RuntimeEmitter
 
         if (_features.UsesIntl)
         {
-            (runtime.IntlNamespaceField, runtime.IntlNamespacePopulate) =
-                EmitNamespaceSingleton(typeBuilder, runtime, "Intl",
+            runtime.IntlNamespacePopulate =
+                EmitNamespaceSingleton(typeBuilder, runtime, "Intl", runtime.IntlNamespaceField!,
                 [
                     ("NumberFormat", runtime.CreateIntlNumberFormat, 2),
                     ("DateTimeFormat", runtime.CreateIntlDateTimeFormat, 2),
@@ -52,17 +72,13 @@ public partial class RuntimeEmitter
         }
     }
 
-    private (FieldBuilder Field, MethodBuilder Populate) EmitNamespaceSingleton(
+    private MethodBuilder EmitNamespaceSingleton(
         TypeBuilder typeBuilder,
         EmittedRuntime runtime,
         string namespaceName,
+        FieldBuilder field,
         (string JsName, MethodBuilder Helper, int JsLength)[] members)
     {
-        var field = typeBuilder.DefineField(
-            $"_{namespaceName}Namespace",
-            _types.DictionaryStringObject,
-            FieldAttributes.Public | FieldAttributes.Static);
-
         var method = typeBuilder.DefineMethod(
             $"_{namespaceName}NamespacePopulate",
             MethodAttributes.Public | MethodAttributes.Static,
@@ -105,6 +121,6 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Stsfld, field);
         il.Emit(OpCodes.Ret);
 
-        return (field, method);
+        return method;
     }
 }

--- a/Compilation/RuntimeEmitter.Objects.Properties.cs
+++ b/Compilation/RuntimeEmitter.Objects.Properties.cs
@@ -2566,8 +2566,12 @@ public partial class RuntimeEmitter
         // `Promise.resolve(1).constructor === Promise` (#221 increment).
         // #242 subclass instances ($Promise-derived emitted classes) return
         // their own class token instead, so `MyP.resolve(1).constructor === MyP`.
+        // Generic subclasses carry constructed types (MyP<object>) while bare
+        // `MyP` emits the open definition — return the definition (same gap
+        // InstanceOf's generic-definition walk handles).
         var notPromiseCtorLabel = il.DefineLabel();
         var defaultPromiseCtorLabel = il.DefineLabel();
+        var nonGenericCtorLabel = il.DefineLabel();
         il.Emit(OpCodes.Ldarg_1);
         il.Emit(OpCodes.Ldstr, "constructor");
         il.Emit(OpCodes.Call, _types.GetMethod(_types.String, "op_Equality", _types.String, _types.String));
@@ -2575,13 +2579,22 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Isinst, runtime.TSPromiseType);
         il.Emit(OpCodes.Brfalse, defaultPromiseCtorLabel);
+        var ctorTypeLocal = il.DeclareLocal(_types.Type);
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Callvirt, _types.GetMethodNoParams(_types.Object, "GetType"));
+        il.Emit(OpCodes.Stloc, ctorTypeLocal);
+        il.Emit(OpCodes.Ldloc, ctorTypeLocal);
         il.Emit(OpCodes.Ldtoken, runtime.TSPromiseType);
         il.Emit(OpCodes.Call, _types.GetMethod(_types.Type, "GetTypeFromHandle", _types.RuntimeTypeHandle));
         il.Emit(OpCodes.Beq, defaultPromiseCtorLabel);
-        il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Callvirt, _types.GetMethodNoParams(_types.Object, "GetType"));
+        il.Emit(OpCodes.Ldloc, ctorTypeLocal);
+        il.Emit(OpCodes.Callvirt, _types.Type.GetProperty("IsGenericType")!.GetGetMethod()!);
+        il.Emit(OpCodes.Brfalse, nonGenericCtorLabel);
+        il.Emit(OpCodes.Ldloc, ctorTypeLocal);
+        il.Emit(OpCodes.Callvirt, _types.GetMethodNoParams(_types.Type, "GetGenericTypeDefinition"));
+        il.Emit(OpCodes.Ret);
+        il.MarkLabel(nonGenericCtorLabel);
+        il.Emit(OpCodes.Ldloc, ctorTypeLocal);
         il.Emit(OpCodes.Ret);
         il.MarkLabel(defaultPromiseCtorLabel);
         il.Emit(OpCodes.Ldtoken, _types.TaskOfObject);

--- a/Compilation/RuntimeEmitter.Objects.Properties.cs
+++ b/Compilation/RuntimeEmitter.Objects.Properties.cs
@@ -2564,11 +2564,26 @@ public partial class RuntimeEmitter
         // (TryEmitBuiltInClassType / GlobalThisGetProperty), so return the
         // same Type token here for identity:
         // `Promise.resolve(1).constructor === Promise` (#221 increment).
+        // #242 subclass instances ($Promise-derived emitted classes) return
+        // their own class token instead, so `MyP.resolve(1).constructor === MyP`.
         var notPromiseCtorLabel = il.DefineLabel();
+        var defaultPromiseCtorLabel = il.DefineLabel();
         il.Emit(OpCodes.Ldarg_1);
         il.Emit(OpCodes.Ldstr, "constructor");
         il.Emit(OpCodes.Call, _types.GetMethod(_types.String, "op_Equality", _types.String, _types.String));
         il.Emit(OpCodes.Brfalse, notPromiseCtorLabel);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Isinst, runtime.TSPromiseType);
+        il.Emit(OpCodes.Brfalse, defaultPromiseCtorLabel);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Callvirt, _types.GetMethodNoParams(_types.Object, "GetType"));
+        il.Emit(OpCodes.Ldtoken, runtime.TSPromiseType);
+        il.Emit(OpCodes.Call, _types.GetMethod(_types.Type, "GetTypeFromHandle", _types.RuntimeTypeHandle));
+        il.Emit(OpCodes.Beq, defaultPromiseCtorLabel);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Callvirt, _types.GetMethodNoParams(_types.Object, "GetType"));
+        il.Emit(OpCodes.Ret);
+        il.MarkLabel(defaultPromiseCtorLabel);
         il.Emit(OpCodes.Ldtoken, _types.TaskOfObject);
         il.Emit(OpCodes.Call, _types.GetMethod(_types.Type, "GetTypeFromHandle", _types.RuntimeTypeHandle));
         il.Emit(OpCodes.Ret);

--- a/Compilation/RuntimeEmitter.RuntimeClass.cs
+++ b/Compilation/RuntimeEmitter.RuntimeClass.cs
@@ -566,6 +566,10 @@ public partial class RuntimeEmitter
         // Pre-define IsBoxedPrimitiveOfType shell so InstanceOf can reference
         // it. Body emitted later (after the prototype singletons are defined).
         DefineIsBoxedPrimitiveOfTypeShell(typeBuilder, runtime);
+        // Pre-define the AbortSignal/Intl namespace singleton fields so
+        // InstanceOf can brand-check the AbortSignal singleton (#246).
+        // Populate bodies are emitted later (EmitNamespaceSingletons).
+        DefineNamespaceSingletonFields(typeBuilder, runtime);
         // InstanceOf walks the prototype chain via GetFunctionMethod (for the
         // `F.prototype` fetch) — must be emitted AFTER GetFunctionMethod so
         // `runtime.GetFunctionMethod` is populated when InstanceOf references it.

--- a/Compilation/StateMachineEmitHelpers.cs
+++ b/Compilation/StateMachineEmitHelpers.cs
@@ -1115,6 +1115,44 @@ public class StateMachineEmitHelpers
     #region Console Intrinsics
 
     /// <summary>
+    /// Evaluates call arguments (from <paramref name="start"/>) into temp locals, in order.
+    /// State-machine emitters can suspend (await) inside emitArgumentBoxed; a value left on
+    /// the IL evaluation stack across a suspension produces invalid IL, so arguments must be
+    /// spilled to locals before the args array is assembled.
+    /// </summary>
+    private List<LocalBuilder> SpillArgumentsToLocals(
+        SharpTS.Parsing.Expr.Call call,
+        Action<SharpTS.Parsing.Expr> emitArgumentBoxed,
+        int start = 0)
+    {
+        var temps = new List<LocalBuilder>();
+        for (int i = start; i < call.Arguments.Count; i++)
+        {
+            emitArgumentBoxed(call.Arguments[i]);
+            var temp = _il.DeclareLocal(_types.Object);
+            _il.Emit(OpCodes.Stloc, temp);
+            temps.Add(temp);
+        }
+        return temps;
+    }
+
+    /// <summary>
+    /// Builds an object[] on the stack from previously spilled argument locals.
+    /// </summary>
+    private void EmitArgsArrayFromLocals(List<LocalBuilder> temps)
+    {
+        _il.Emit(OpCodes.Ldc_I4, temps.Count);
+        _il.Emit(OpCodes.Newarr, _types.Object);
+        for (int i = 0; i < temps.Count; i++)
+        {
+            _il.Emit(OpCodes.Dup);
+            _il.Emit(OpCodes.Ldc_I4, i);
+            _il.Emit(OpCodes.Ldloc, temps[i]);
+            _il.Emit(OpCodes.Stelem_Ref);
+        }
+    }
+
+    /// <summary>
     /// Checks if the call expression is a console.log call (either Variable or Get pattern).
     /// </summary>
     public static bool IsConsoleLogCall(SharpTS.Parsing.Expr.Call call)
@@ -1164,16 +1202,8 @@ public class StateMachineEmitHelpers
         }
         else if (consoleLogMultipleMethod != null)
         {
-            // Multiple arguments - use ConsoleLogMultiple
-            _il.Emit(OpCodes.Ldc_I4, call.Arguments.Count);
-            _il.Emit(OpCodes.Newarr, _types.Object);
-            for (int i = 0; i < call.Arguments.Count; i++)
-            {
-                _il.Emit(OpCodes.Dup);
-                _il.Emit(OpCodes.Ldc_I4, i);
-                emitArgumentBoxed(call.Arguments[i]);
-                _il.Emit(OpCodes.Stelem_Ref);
-            }
+            // Multiple arguments - use ConsoleLogMultiple (args spilled for await-safety)
+            EmitArgsArrayFromLocals(SpillArgumentsToLocals(call, emitArgumentBoxed));
             _il.Emit(OpCodes.Call, consoleLogMultipleMethod);
         }
         else
@@ -1371,18 +1401,10 @@ public class StateMachineEmitHelpers
         }
         else
         {
-            // Condition + message args
-            emitArgumentBoxed(call.Arguments[0]);
-            // Build array of remaining args
-            _il.Emit(OpCodes.Ldc_I4, call.Arguments.Count - 1);
-            _il.Emit(OpCodes.Newarr, _types.Object);
-            for (int i = 1; i < call.Arguments.Count; i++)
-            {
-                _il.Emit(OpCodes.Dup);
-                _il.Emit(OpCodes.Ldc_I4, i - 1);
-                emitArgumentBoxed(call.Arguments[i]);
-                _il.Emit(OpCodes.Stelem_Ref);
-            }
+            // Condition + message args (all spilled for await-safety)
+            var temps = SpillArgumentsToLocals(call, emitArgumentBoxed);
+            _il.Emit(OpCodes.Ldloc, temps[0]);
+            EmitArgsArrayFromLocals(temps.GetRange(1, temps.Count - 1));
             _il.Emit(OpCodes.Call, runtime.ConsoleAssertMultiple);
         }
         _il.Emit(OpCodes.Ldnull);
@@ -1397,23 +1419,18 @@ public class StateMachineEmitHelpers
         Action<SharpTS.Parsing.Expr> emitArgumentBoxed,
         EmittedRuntime runtime)
     {
-        if (call.Arguments.Count >= 1)
-        {
-            emitArgumentBoxed(call.Arguments[0]);
-        }
+        // Both operands spilled for await-safety (data must not sit on the stack across
+        // a suspension inside the columns argument).
+        var tableTemps = SpillArgumentsToLocals(call, emitArgumentBoxed);
+        if (tableTemps.Count >= 1)
+            _il.Emit(OpCodes.Ldloc, tableTemps[0]);
         else
-        {
             _il.Emit(OpCodes.Ldnull);
-        }
 
-        if (call.Arguments.Count >= 2)
-        {
-            emitArgumentBoxed(call.Arguments[1]);
-        }
+        if (tableTemps.Count >= 2)
+            _il.Emit(OpCodes.Ldloc, tableTemps[1]);
         else
-        {
             _il.Emit(OpCodes.Ldnull);
-        }
         _il.Emit(OpCodes.Call, runtime.ConsoleTable);
         _il.Emit(OpCodes.Ldnull);
         SetStackUnknown();
@@ -1460,16 +1477,8 @@ public class StateMachineEmitHelpers
         }
         else
         {
-            // Multiple arguments - build array
-            _il.Emit(OpCodes.Ldc_I4, call.Arguments.Count);
-            _il.Emit(OpCodes.Newarr, _types.Object);
-            for (int i = 0; i < call.Arguments.Count; i++)
-            {
-                _il.Emit(OpCodes.Dup);
-                _il.Emit(OpCodes.Ldc_I4, i);
-                emitArgumentBoxed(call.Arguments[i]);
-                _il.Emit(OpCodes.Stelem_Ref);
-            }
+            // Multiple arguments (spilled for await-safety)
+            EmitArgsArrayFromLocals(SpillArgumentsToLocals(call, emitArgumentBoxed));
             _il.Emit(OpCodes.Call, runtime.ConsoleGroupMultiple);
         }
         _il.Emit(OpCodes.Ldnull);
@@ -1496,16 +1505,8 @@ public class StateMachineEmitHelpers
         }
         else
         {
-            // Multiple arguments - build array
-            _il.Emit(OpCodes.Ldc_I4, call.Arguments.Count);
-            _il.Emit(OpCodes.Newarr, _types.Object);
-            for (int i = 0; i < call.Arguments.Count; i++)
-            {
-                _il.Emit(OpCodes.Dup);
-                _il.Emit(OpCodes.Ldc_I4, i);
-                emitArgumentBoxed(call.Arguments[i]);
-                _il.Emit(OpCodes.Stelem_Ref);
-            }
+            // Multiple arguments (spilled for await-safety)
+            EmitArgsArrayFromLocals(SpillArgumentsToLocals(call, emitArgumentBoxed));
             _il.Emit(OpCodes.Call, runtime.ConsoleTraceMultiple);
         }
         _il.Emit(OpCodes.Ldnull);
@@ -1534,16 +1535,8 @@ public class StateMachineEmitHelpers
         }
         else
         {
-            // Multiple arguments
-            _il.Emit(OpCodes.Ldc_I4, call.Arguments.Count);
-            _il.Emit(OpCodes.Newarr, _types.Object);
-            for (int i = 0; i < call.Arguments.Count; i++)
-            {
-                _il.Emit(OpCodes.Dup);
-                _il.Emit(OpCodes.Ldc_I4, i);
-                emitArgumentBoxed(call.Arguments[i]);
-                _il.Emit(OpCodes.Stelem_Ref);
-            }
+            // Multiple arguments (spilled for await-safety)
+            EmitArgsArrayFromLocals(SpillArgumentsToLocals(call, emitArgumentBoxed));
             _il.Emit(OpCodes.Call, multipleArgMethod);
         }
 
@@ -1572,16 +1565,8 @@ public class StateMachineEmitHelpers
         }
         else
         {
-            // Multiple arguments
-            _il.Emit(OpCodes.Ldc_I4, call.Arguments.Count);
-            _il.Emit(OpCodes.Newarr, _types.Object);
-            for (int i = 0; i < call.Arguments.Count; i++)
-            {
-                _il.Emit(OpCodes.Dup);
-                _il.Emit(OpCodes.Ldc_I4, i);
-                emitArgumentBoxed(call.Arguments[i]);
-                _il.Emit(OpCodes.Stelem_Ref);
-            }
+            // Multiple arguments (spilled for await-safety)
+            EmitArgsArrayFromLocals(SpillArgumentsToLocals(call, emitArgumentBoxed));
             _il.Emit(OpCodes.Call, multipleArgMethod);
         }
 

--- a/Execution/Interpreter.Calls.cs
+++ b/Execution/Interpreter.Calls.cs
@@ -763,6 +763,10 @@ public partial class Interpreter
                 "TextDecoder" => left is SharpTSTextDecoder,
                 "Promise" => left is SharpTSPromise || left is System.Threading.Tasks.Task,
                 "Buffer" => left is SharpTSBuffer,
+                // The AbortSignal global is a namespace-style sentinel (no public
+                // constructor) — brand-check the runtime instance type (#246).
+                "AbortSignal" => left is SharpTSAbortSignal,
+                "AbortController" => left is SharpTSAbortController,
                 _ => false
             };
         }

--- a/Execution/Interpreter.Expressions.cs
+++ b/Execution/Interpreter.Expressions.cs
@@ -127,9 +127,9 @@ public partial class Interpreter
             case Expr.Call call: return await EvaluateCallAsync(call);
             case Expr.Get get: return await EvaluateGetAsync(get);
             case Expr.Set set: return await EvaluateSetAsync(set);
-            case Expr.GetPrivate gp: return EvaluateGetPrivate(gp);
-            case Expr.SetPrivate sp: return EvaluateSetPrivate(sp);
-            case Expr.CallPrivate cp: return EvaluateCallPrivate(cp);
+            case Expr.GetPrivate gp: return await EvaluateGetPrivateAsync(gp);
+            case Expr.SetPrivate sp: return await EvaluateSetPrivateAsync(sp);
+            case Expr.CallPrivate cp: return await EvaluateCallPrivateAsync(cp);
             case Expr.This thisExpr: return EvaluateThis(thisExpr);
             case Expr.New newExpr: return await EvaluateNewAsync(newExpr);
             case Expr.ArrayLiteral array: return await EvaluateArrayAsync(array);

--- a/Execution/Interpreter.Properties.cs
+++ b/Execution/Interpreter.Properties.cs
@@ -1509,10 +1509,16 @@ public partial class Interpreter
     /// Evaluates a private field access expression (obj.#field).
     /// </summary>
     private RuntimeValue EvaluateGetPrivate(Expr.GetPrivate expr)
-    {
-        object? obj = Evaluate(expr.Object);
-        string fieldName = expr.Name.Lexeme;
+        => GetPrivateCore(Evaluate(expr.Object), expr.Name.Lexeme);
 
+    /// <summary>
+    /// Async variant — the object expression may contain await.
+    /// </summary>
+    private async Task<RuntimeValue> EvaluateGetPrivateAsync(Expr.GetPrivate expr)
+        => GetPrivateCore((await EvaluateAsync(expr.Object)).ToObject(), expr.Name.Lexeme);
+
+    private RuntimeValue GetPrivateCore(object? obj, string fieldName)
+    {
         // Handle static private field access on class
         if (obj is SharpTSClass klass)
         {
@@ -1542,11 +1548,22 @@ public partial class Interpreter
     /// Evaluates a private field assignment expression (obj.#field = value).
     /// </summary>
     private RuntimeValue EvaluateSetPrivate(Expr.SetPrivate expr)
-    {
-        object? obj = Evaluate(expr.Object);
-        RuntimeValue value = EvaluateRV(expr.Value);
-        string fieldName = expr.Name.Lexeme;
+        => SetPrivateCore(Evaluate(expr.Object), EvaluateRV(expr.Value), expr.Name.Lexeme);
 
+    /// <summary>
+    /// Async variant — the value (or object) expression may contain await,
+    /// which the sync evaluator rejects ("'await' can only be used inside
+    /// async functions") even when the enclosing method is async.
+    /// </summary>
+    private async Task<RuntimeValue> EvaluateSetPrivateAsync(Expr.SetPrivate expr)
+    {
+        object? obj = (await EvaluateAsync(expr.Object)).ToObject();
+        RuntimeValue value = await EvaluateAsync(expr.Value);
+        return SetPrivateCore(obj, value, expr.Name.Lexeme);
+    }
+
+    private RuntimeValue SetPrivateCore(object? obj, RuntimeValue value, string fieldName)
+    {
         // Handle static private field assignment on class
         if (obj is SharpTSClass klass)
         {
@@ -1580,15 +1597,34 @@ public partial class Interpreter
     private RuntimeValue EvaluateCallPrivate(Expr.CallPrivate expr)
     {
         object? obj = Evaluate(expr.Object);
-        string methodName = expr.Name.Lexeme;
 
-        // Evaluate arguments
         List<object?> arguments = [];
         foreach (var arg in expr.Arguments)
         {
             arguments.Add(Evaluate(arg));
         }
 
+        return CallPrivateCore(obj, arguments, expr.Name.Lexeme);
+    }
+
+    /// <summary>
+    /// Async variant — arguments (or the object) may contain await.
+    /// </summary>
+    private async Task<RuntimeValue> EvaluateCallPrivateAsync(Expr.CallPrivate expr)
+    {
+        object? obj = (await EvaluateAsync(expr.Object)).ToObject();
+
+        List<object?> arguments = [];
+        foreach (var arg in expr.Arguments)
+        {
+            arguments.Add((await EvaluateAsync(arg)).ToObject());
+        }
+
+        return CallPrivateCore(obj, arguments, expr.Name.Lexeme);
+    }
+
+    private RuntimeValue CallPrivateCore(object? obj, List<object?> arguments, string methodName)
+    {
         // Handle static private method call on class
         if (obj is SharpTSClass klass)
         {

--- a/SharpTS.Tests/Compilation/EmitterSyncTests.cs
+++ b/SharpTS.Tests/Compilation/EmitterSyncTests.cs
@@ -51,7 +51,6 @@ public class EmitterSyncTests
             "EmitCallPrivate",      // Private method calls in async context
             "EmitGetPrivate",       // Private field access in async context
             "EmitSetPrivate",       // Private field assignment in async context
-            "EmitSet",              // Property set with await-safe temp storage
             "EmitNullishCoalescing", // Nullish coalescing with await-safe evaluation
             "EmitTemplateLiteral",  // Template literals with await-safe temp storage
             "EmitTaggedTemplateLiteral", // Tagged template literals in async context

--- a/SharpTS.Tests/SharedTests/AbortControllerTests.cs
+++ b/SharpTS.Tests/SharedTests/AbortControllerTests.cs
@@ -244,4 +244,22 @@ public class AbortControllerTests
         var output = TestHarness.Run(source, mode);
         Assert.Equal("1\n", output);
     }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AbortSignal_InstanceOf_BrandChecks(ExecutionMode mode)
+    {
+        // #246: interpreter returned false for real signals (no brand linkage
+        // on the AbortSignal sentinel); compiled returned true for ANY plain
+        // object (Dictionary IsAssignableFrom fallback).
+        var source = @"
+            const s: any = AbortSignal.abort('x');
+            console.log(s instanceof (AbortSignal as any));
+            console.log(({} as any) instanceof (AbortSignal as any));
+            const c = new AbortController();
+            console.log(c.signal instanceof (AbortSignal as any));
+        ";
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("true\nfalse\ntrue\n", output);
+    }
 }

--- a/SharpTS.Tests/SharedTests/AwaitStackSpillTests.cs
+++ b/SharpTS.Tests/SharedTests/AwaitStackSpillTests.cs
@@ -1,0 +1,183 @@
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests;
+
+/// <summary>
+/// Regression tests for #251: an await suspending inside a subexpression must
+/// reach the async state-machine boundary with an empty IL evaluation stack.
+/// Each shape here previously compiled to invalid IL (InvalidProgramException
+/// at MoveNext JIT) because a value was left stacked below the await.
+/// Runs against both interpreter and compiler.
+/// </summary>
+public class AwaitStackSpillTests
+{
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ConsoleLog_MultiArg_InlineAwait(ExecutionMode mode)
+    {
+        var source = """
+            async function m() {
+                const t: any = 5;
+                console.log("t1", await t);
+                console.log("m", await t, "n", await t);
+            }
+            m();
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("t1 5\nm 5 n 5\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void BinaryOperands_InlineAwait(ExecutionMode mode)
+    {
+        var source = """
+            async function m() {
+                const t: any = 5;
+                console.log("x" + (await t));
+                console.log(1 < await t);
+                console.log(7 & await t);
+                console.log(1 << await t);
+            }
+            m();
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("x5\ntrue\n5\n32\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ArrayAndObjectLiterals_InlineAwait(ExecutionMode mode)
+    {
+        var source = """
+            async function m() {
+                const t: any = 5;
+                console.log([1, await t]);
+                console.log({ a: await t });
+                const k: any = "dyn";
+                console.log({ [k]: await t });
+                console.log([...[await t], 2]);
+            }
+            m();
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("[1, 5]\n{ a: 5 }\n{ dyn: 5 }\n[5, 2]\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void PropertyAndIndexAssignment_InlineAwait(ExecutionMode mode)
+    {
+        var source = """
+            class C { x: any = 0; }
+            async function m() {
+                const t: any = 5;
+                const c = new C();
+                c.x = await t;
+                console.log(c.x);
+                const arr: any = [9, 8, 7];
+                console.log(arr[await t - 4]);
+                arr[0] = await t;
+                console.log(arr[0]);
+            }
+            m();
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("5\n8\n5\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void CompoundAndLogicalAssignment_InlineAwait(ExecutionMode mode)
+    {
+        var source = """
+            class C { x: any = 0; }
+            async function m() {
+                const t: any = 5;
+                const c = new C();
+                c.x = 1;
+                c.x += await t;
+                console.log(c.x);
+                const arr: any = [1];
+                arr[0] += await t;
+                console.log(arr[0]);
+                c.x = null;
+                c.x ??= await t;
+                console.log(c.x);
+                arr[0] = 0;
+                arr[0] ||= await t;
+                console.log(arr[0]);
+            }
+            m();
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("6\n6\n5\n5\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void TaggedTemplate_InlineAwait(ExecutionMode mode)
+    {
+        var source = """
+            async function m() {
+                const t: any = 5;
+                const tag = (s: any, v: any) => s[0] + v;
+                console.log(tag`a${await t}`);
+            }
+            m();
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("a5\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void PrivateMembers_InlineAwait(ExecutionMode mode)
+    {
+        var source = """
+            class W {
+                #p: any = 1;
+                #m(a: any) { return a; }
+                async go() {
+                    const t: any = 5;
+                    this.#p = await t;
+                    return this.#m(await t) + this.#p;
+                }
+            }
+            async function m() {
+                const w = new W();
+                console.log(await w.go());
+            }
+            m();
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("10\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ConsoleError_MultiArg_InlineAwait_DoesNotCrash(ExecutionMode mode)
+    {
+        var source = """
+            async function m() {
+                const t: any = 5;
+                console.log("before");
+                console.error("e1", await t);
+                console.log("after");
+            }
+            m();
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Contains("before\n", output);
+        Assert.Contains("after\n", output);
+    }
+}

--- a/SharpTS.Tests/SharedTests/BuiltInModules/DnsAsyncTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/DnsAsyncTests.cs
@@ -50,6 +50,71 @@ public class DnsAsyncTests
 
     [Theory]
     [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Resolve4_NestedInsideCallback_CallbackFires(ExecutionMode mode)
+    {
+        // #239: in compiled mode, dns.* calls inside another callback (or any
+        // function body) resolved the module member dynamically to null and
+        // silently dropped the callback.
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import * as dns from 'dns';
+                dns.resolve4('localhost', (err: any, a: any) => {
+                    console.log('outer ' + (err === null));
+                    dns.resolve4('localhost', (err2: any, b: any) => {
+                        console.log('inner ' + (err2 === null));
+                    });
+                });
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("outer true\ninner true\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Resolve4_InsideTimerCallback_CallbackFires(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import * as dns from 'dns';
+                setTimeout(() => {
+                    dns.resolve4('localhost', (err: any, a: any) => {
+                        console.log('dns-in-timer ' + (err === null));
+                    });
+                }, 20);
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("dns-in-timer true\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Resolve4_InsideFunctionBody_CallbackFires(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import * as dns from 'dns';
+                function go() {
+                    dns.resolve4('localhost', (err: any, a: any) => {
+                        console.log('fn ' + (err === null));
+                    });
+                }
+                go();
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("fn true\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void Reverse_Loopback(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>

--- a/SharpTS.Tests/SharedTests/PromiseSubclassTests.cs
+++ b/SharpTS.Tests/SharedTests/PromiseSubclassTests.cs
@@ -234,4 +234,26 @@ public class PromiseSubclassTests
         Assert.Equal("false\ntrue\n14\n", output);
     }
 
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ExtendsPromise_ConstructorIdentity(ExecutionMode mode)
+    {
+        // ECMA-262 §27.2.5.1 / #221: subclass instances report the subclass
+        // as .constructor; plain promises report Promise.
+        var source = """
+            class MyPromise<T> extends Promise<T> {}
+            async function main() {
+                const p = MyPromise.resolve(1);
+                console.log(p.constructor === MyPromise);
+                console.log(p.constructor === Promise);
+                const q = Promise.resolve(1);
+                console.log(q.constructor === Promise);
+            }
+            main();
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("true\nfalse\ntrue\n", output);
+    }
+
 }


### PR DESCRIPTION
Bugfix batch for #251, #239, #246, and the implementable increment of #221. One commit per fix, plus regression tests. Full suite green (10775/10775), rebased onto current main.

## #251 — await suspending inside a subexpression emitted invalid IL (Fixes #251)

`console.log("t1", await t)` was the reported case, but probing showed a broad class: any value left on the IL evaluation stack when an await suspends kills the async MoveNext at JIT (`InvalidProgramException`). Broken shapes included binary/bitwise operands, array & object literals (incl. spreads/computed keys/accessors), property/index get & set, compound (`c.x += await t`) and logical (`c.x ??= await t`) assignment, tagged templates, private member access/calls, and all console multi-arg methods.

Call arguments and template literals already used the documented temps-first pattern; this applies it to the remaining sites via a shared `SpillBoxed` helper in `ExpressionEmitterBase` (used only by state-machine emitters — ILEmitter overrides stay on their fast paths). Also deleted `AsyncMoveNextEmitter.EmitSet` (a stale near-duplicate of the base implementation, now covered with spilling plus CJS handling) and dead `EmitArgumentArray`; the `EmitterSyncTests` override allowlist guard caught and confirmed the removal.

The interpreter had a sibling of the same class: `EvaluateAsync` routed private get/set/call through the **sync** evaluators, so `this.#p = await t` in an async method threw "await can only be used inside async functions". Fixed with async variants sharing the sync cores.

## #239 — compiled dns callbacks dropped outside top-level (Fixes #239)

Root cause was not the event loop: `dns.resolve4` has no static call-site interception (the dns module emitter only handles `lookup`/`lookupService`), so the call dispatched dynamically through the namespace object — which is materialized as an **entry-point local**. Inside any function, arrow, or callback body the `dns` variable resolved to null and the call silently no-opped. The issue repro was a special case of "any dns call in any nested body".

`BuiltInModuleHandler` now falls back to the `$Runtime` wrapper registered via `RegisterBuiltInModuleMethod` and emits a direct static call (uniform object-in/object-out wrappers only), with arguments spilled to locals (await-safe, side effects preserved). This also upgrades previously dynamic top-level dispatch to direct calls.

The masking enabler — invoking a null callee silently returns null instead of throwing TypeError — is filed as #260.

## #246 — instanceof AbortSignal (Fixes #246)

- Interpreter: added `AbortSignal`/`AbortController` brand arms to the `SharpTSBuiltInConstructor` instanceof switch (`SharpTSAbortSignal`/`SharpTSAbortController`).
- Compiled: a plain-`Dictionary` RHS reached the `IsAssignableFrom` fallback, which matches every dict-shaped value — `{} instanceof AbortSignal` was `true`. `InstanceOf` now handles dict RHS explicitly: the AbortSignal namespace singleton brand-checks signal dicts via their `_reasonSet` slot; any other dict RHS (object literals, Math/JSON/Intl singletons, module namespaces) is `false`. The singleton fields are pre-defined before `EmitInstanceOf` (same shell pattern as `IsBoxedPrimitiveOfType`) to avoid the emission-order trap.

## #221 — Promise SpeciesConstructor (increment; issue stays open)

With the old prerequisites (#233/#234/#242) closed, re-triaged what is observable today:

- **Shipped here**: compiled subclass instances now report their own class as `.constructor` (`MyP.resolve(1).constructor === MyP`, incl. generic subclasses via the open-definition mapping). Interpreter already correct.
- **Verified working (species-lite, both modes)**: `then`/`catch`/`finally` + all four combinators return receiver-class-typed promises.
- **Still parked**: true `constructor[Symbol.species]` lookup + NewPromiseCapability. Species overrides are currently undefinable from guest code — `static get [Symbol.species]()` does not parse (filed #261) and dynamic class expando assignment throws in the interpreter (filed #262). Details in the issue comment.

## New issues filed from gaps found during the batch

- #260 — compiled: invoking a non-callable silently returns null instead of TypeError (masked #239)
- #261 — parser: computed accessor names in class bodies unsupported (blocks #221)
- #262 — interpreter: bracket assignment on class objects throws; compiled supports it (blocks #221)

## Tests

New `AwaitStackSpillTests` (8 shapes × both modes), nested/timer/function-body dns callback tests, AbortSignal instanceof brand checks, and Promise subclass constructor identity — all running against interpreter and compiler.