### PR TITLE
fix(net): in-flight socket connect keeps the event loop alive

### DIFF
--- a/Runtime/Types/SharpTSSocket.cs
+++ b/Runtime/Types/SharpTSSocket.cs
@@ -161,6 +161,13 @@ public class SharpTSSocket : SharpTSEventEmitter
         _connecting = true;
         _client = new TcpClient();
 
+        // An in-flight connect is an active handle (Node semantics): keep the event
+        // loop alive until the connect resolves, otherwise its 'connect'/'error'
+        // continuation can be dropped if the loop's other handles (e.g. the peer
+        // server) drain to zero first. Released exactly once when the connect
+        // settles, inside the scheduled callback so the handle outlives delivery.
+        interpreter.Ref();
+
         // Start async connect via Task.Run
         var capturedHost = host;
         var capturedPort = port;
@@ -175,6 +182,7 @@ public class SharpTSSocket : SharpTSEventEmitter
                 {
                     EmitEvent(interpreter, "connect", []);
                     StartReading(interpreter);
+                    interpreter.Unref();
                 }, isInterval: false);
             }
             catch (Exception ex)
@@ -184,6 +192,7 @@ public class SharpTSSocket : SharpTSEventEmitter
                 interpreter.ScheduleTimer(0, 0, () =>
                 {
                     EmitEvent(interpreter, "error", [error]);
+                    interpreter.Unref();
                 }, isInterval: false);
             }
         });
@@ -204,6 +213,9 @@ public class SharpTSSocket : SharpTSEventEmitter
         _connecting = true;
         _isIpc = true;
         _pipePath = path;
+
+        // In-flight connect is an active handle until it settles — see Connect().
+        interpreter.Ref();
 
         _ = Task.Run(async () =>
         {
@@ -238,6 +250,7 @@ public class SharpTSSocket : SharpTSEventEmitter
                     StartReading(interpreter, readReady);
                     readReady.Wait(5000);
                     EmitEvent(interpreter, "connect", []);
+                    interpreter.Unref();
                 }, isInterval: false);
             }
             catch (Exception ex)
@@ -247,6 +260,7 @@ public class SharpTSSocket : SharpTSEventEmitter
                 interpreter.ScheduleTimer(0, 0, () =>
                 {
                     EmitEvent(interpreter, "error", [error]);
+                    interpreter.Unref();
                 }, isInterval: false);
             }
         });


### PR DESCRIPTION
## Summary

Fixes the `NetConnectPositionalPortHostCallback` CI failure (e.g. [run 27322581382](https://github.com/nickna/SharpTS/actions/runs/27322581382)), which was **not a flake** but a real interpreter event-loop bug.

## Root cause

The interpreter keeps the event loop alive via **active handles**. Every pending async op registers one — `setTimeout` (`TimerBuiltIns` `AttachRefTracking`), the server accept loop (`Ref` at `listen`), socket reading (`Ref` in `StartReading`). `RunEventLoop` exits on `!HasActiveHandles && _callbackQueue.Count == 0` (it checks handles, **not** the transient-timer queue).

An in-flight TCP/IPC **connect** was the one async op that registered **no handle**: `Connect()` launched `ConnectAsync` and scheduled its `connect`/`error` continuation via `ScheduleTimer(0,…)`, but nothing kept the loop alive while connecting. Its liveness was borrowed from the peer server handle — which the failing test's connection handler explicitly tears down (`socket.destroy(); server.close()`). Under CI scheduler load, the server-close path could drain handles to zero before the client's connect continuation was scheduled, so the loop exited and **the connect callback was silently dropped** → empty output → `"connect listener fired"` never printed.

Interpreted-only (compiled mode has its own loop); a pure timing race, which is why it only surfaced under load.

## Fix

Make the in-flight connect a proper active handle (Node semantics: *a pending connection keeps the event loop alive*): `Ref()` before the connect task, `Unref()` exactly once inside both the success and error continuations. Applied to the TCP and IPC connect paths in `Runtime/Types/SharpTSSocket.cs`.

## How it was proven

- Idle dev box: 400 iterations × 24 CPU burners → **0 failures** (race window too narrow).
- Injecting `Thread.Sleep(15)` into the connect continuation (simulating a descheduled thread under load) → **100% interpreted failure** with the exact CI error string.
- With this fix → **100% pass even with the injected delay**.

## Validation

- Net suite: **48/48**
- TLS + HTTP + dgram: **151/151**
- Refused-connect (error path): exits cleanly with `ECONNREFUSED`, no hang — Ref/Unref balanced
- Full suite: **10746/10747**; the single unrelated failure (`Process_Uptime_IncreasesOverTime`, a pre-existing `process.uptime()` monotonicity flake) passes 5/5 in isolation.