### PR TITLE
fix: non-callable invocation TypeError (#260), computed accessor names (#261), class expando statics (#262)

### DIFF
--- a/Compilation/AsyncMoveNextEmitter.Statements.Loops.cs
+++ b/Compilation/AsyncMoveNextEmitter.Statements.Loops.cs
@@ -171,9 +171,16 @@ public partial class AsyncMoveNextEmitter
                 var returnFnLocal = _il.DeclareLocal(_types.Object);
                 _il.Emit(OpCodes.Stloc, returnFnLocal);
 
-                // If no return method, skip cleanup
+                // If no return method, skip cleanup — iterator.return() is
+                // optional per the iterator protocol. GetProperty reports a
+                // missing member as either null or $Undefined, and
+                // InvokeMethodValue now throws TypeError for both (#260), so
+                // guard against both here.
                 _il.Emit(OpCodes.Ldloc, returnFnLocal);
                 _il.Emit(OpCodes.Brfalse, endLabel);
+                _il.Emit(OpCodes.Ldloc, returnFnLocal);
+                _il.Emit(OpCodes.Isinst, _ctx.Runtime.UndefinedType);
+                _il.Emit(OpCodes.Brtrue, endLabel);
 
                 // Call: InvokeMethodValue(asyncIterator, returnFn, [])
                 _il.Emit(OpCodes.Ldloc, asyncIteratorLocal);

--- a/Compilation/ExpressionEmitterBase.CallHelpers.cs
+++ b/Compilation/ExpressionEmitterBase.CallHelpers.cs
@@ -35,11 +35,20 @@ public abstract partial class ExpressionEmitterBase
         if (TryEmitCjsRequireCall(c))
             return;
 
+        if (TryEmitFunctionReturnThisIdiom(c))
+            return;
+
         // Handler chain covers: console methods, fetch, parseInt/parseFloat/isNaN/isFinite,
         // setTimeout/clearTimeout/setInterval/clearInterval/queueMicrotask, Symbol/BigInt/Date/Error,
         // Date.now(), Math/JSON/Object/Array/Number/Promise/Symbol statics, built-in module methods,
         // __objectRest
         if (_callHandlers.TryHandle(this, c))
+            return;
+
+        // Optional-chain method calls (a.b?.m(x)) short-circuit to undefined
+        // when a link is nullish — must be explicit now that InvokeMethodValue
+        // throws for non-callable callees (#260).
+        if (TryEmitOptionalChainMethodCall(c))
             return;
 
         // Special case: super.method() call — emit non-virtual Call to base method
@@ -698,6 +707,23 @@ public abstract partial class ExpressionEmitterBase
         var calleeLocal = IL.DeclareLocal(Types.Object);
         IL.Emit(OpCodes.Stloc, calleeLocal);
 
+        // Optional link in the callee chain (a?.[0](), (x?.f)()): a nullish
+        // callee means the chain short-circuited — yield undefined instead of
+        // letting InvokeMethodValue throw (#260). The Expr.Get-callee shape is
+        // intercepted earlier by TryEmitOptionalChainMethodCall.
+        Label? optChainNullishLabel = null;
+        Label? optChainEndLabel = null;
+        if (HasOptionalLink(c.Callee))
+        {
+            optChainNullishLabel = IL.DefineLabel();
+            optChainEndLabel = IL.DefineLabel();
+            IL.Emit(OpCodes.Ldloc, calleeLocal);
+            IL.Emit(OpCodes.Brfalse, optChainNullishLabel.Value);
+            IL.Emit(OpCodes.Ldloc, calleeLocal);
+            IL.Emit(OpCodes.Isinst, Ctx.Runtime!.UndefinedType);
+            IL.Emit(OpCodes.Brtrue, optChainNullishLabel.Value);
+        }
+
         // Evaluate all arguments into temps first (await-safe for async emitters)
         List<LocalBuilder> argTemps = [];
         List<bool> isSpread = [];
@@ -773,7 +799,138 @@ public abstract partial class ExpressionEmitterBase
         IL.Emit(OpCodes.Ldloc, calleeLocal);
         IL.Emit(OpCodes.Ldloc, argsLocal);
         IL.Emit(OpCodes.Call, Ctx.Runtime!.InvokeMethodValue);
+
+        if (optChainNullishLabel != null)
+        {
+            IL.Emit(OpCodes.Br, optChainEndLabel!.Value);
+            IL.MarkLabel(optChainNullishLabel.Value);
+            IL.Emit(OpCodes.Ldsfld, Ctx.Runtime!.UndefinedInstance);
+            IL.MarkLabel(optChainEndLabel.Value);
+        }
+
         SetStackUnknown();
+    }
+
+    /// <summary>
+    /// lodash/core-js global-detection idiom: <c>Function('return this')()</c>.
+    /// The Function constructor isn't supported in either mode, but this probe
+    /// just means "give me globalThis". Compiled mode represents globalThis in
+    /// value position as null (see EmitVariable), so emit the same null —
+    /// packages probing via <c>freeGlobal || freeSelf || Function('return this')()</c>
+    /// keep their pre-#260 fallback behavior instead of hitting the
+    /// non-callable TypeError (the Function constructor result isn't callable).
+    /// </summary>
+    protected bool TryEmitFunctionReturnThisIdiom(Expr.Call c)
+    {
+        if (c.Arguments.Count == 0
+            && c.Callee is Expr.Call inner
+            && inner.Callee is Expr.Variable { Name.Lexeme: "Function" }
+            && inner.Arguments.Count == 1
+            && inner.Arguments[0] is Expr.Literal { Value: string body }
+            && body.Trim() == "return this")
+        {
+            IL.Emit(OpCodes.Ldnull);
+            SetStackUnknown();
+            return true;
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// True when the expression chain contains an optional link (<c>?.</c>),
+    /// mirroring the interpreter's HasOptionalInChain: a call at the end of such
+    /// a chain short-circuits to undefined when the callee resolves nullish
+    /// (ECMA-262 §13.3 OptionalExpression) instead of throwing.
+    /// </summary>
+    protected static bool HasOptionalLink(Expr expr) => expr switch
+    {
+        Expr.Get g => g.Optional || HasOptionalLink(g.Object),
+        Expr.GetIndex gi => gi.Optional || HasOptionalLink(gi.Object),
+        Expr.Call call => call.Optional || HasOptionalLink(call.Callee),
+        Expr.Grouping gr => HasOptionalLink(gr.Expression),
+        Expr.TypeAssertion ta => HasOptionalLink(ta.Expression),
+        _ => false
+    };
+
+    /// <summary>
+    /// Intercepts a method call whose callee chain contains an optional link
+    /// (<c>a.b?.m(x)</c>, <c>a?.b.m(x)</c>) and emits a receiver-preserving
+    /// dynamic dispatch that short-circuits to undefined when the receiver or
+    /// resolved method is nullish. Before #260 these shapes leaned on
+    /// InvokeMethodValue's silent null for the short-circuit; now that the
+    /// fallback throws, the chain semantics must be emitted explicitly.
+    /// Returns false when the call doesn't match (callee isn't a Get with an
+    /// optional link, or the call itself is optional — EmitOptionalCall owns
+    /// <c>?.()</c>).
+    /// </summary>
+    protected bool TryEmitOptionalChainMethodCall(Expr.Call c)
+    {
+        if (c.Optional || c.Callee is not Expr.Get g || !HasOptionalLink(g))
+            return false;
+
+        EmitExpression(g.Object);
+        EnsureBoxed();
+        var recvLocal = IL.DeclareLocal(Types.Object);
+        IL.Emit(OpCodes.Stloc, recvLocal);
+
+        var nullishLabel = IL.DefineLabel();
+        var endLabel = IL.DefineLabel();
+
+        IL.Emit(OpCodes.Ldloc, recvLocal);
+        IL.Emit(OpCodes.Brfalse, nullishLabel);
+        IL.Emit(OpCodes.Ldloc, recvLocal);
+        IL.Emit(OpCodes.Isinst, Ctx.Runtime!.UndefinedType);
+        IL.Emit(OpCodes.Brtrue, nullishLabel);
+
+        // GetProperty can't resolve most string prototype methods (see
+        // EmitDynamicMethodCallPreservingThis) — keep its string fast path.
+        if (IsRuntimeDispatchableStringMethod(g.Name.Lexeme))
+        {
+            var notStringLabel = IL.DefineLabel();
+            IL.Emit(OpCodes.Ldloc, recvLocal);
+            IL.Emit(OpCodes.Isinst, Types.String);
+            IL.Emit(OpCodes.Brfalse, notStringLabel);
+            EmitRuntimeStringMethod(recvLocal, g.Name.Lexeme, c.Arguments);
+            IL.Emit(OpCodes.Br, endLabel);
+            IL.MarkLabel(notStringLabel);
+        }
+
+        // fn = GetProperty(recv, name); nullish fn short-circuits to undefined,
+        // matching the interpreter's HasOptionalInChain rule.
+        IL.Emit(OpCodes.Ldloc, recvLocal);
+        IL.Emit(OpCodes.Ldstr, g.Name.Lexeme);
+        IL.Emit(OpCodes.Call, Ctx.Runtime!.GetProperty);
+        var fnLocal = IL.DeclareLocal(Types.Object);
+        IL.Emit(OpCodes.Stloc, fnLocal);
+        IL.Emit(OpCodes.Ldloc, fnLocal);
+        IL.Emit(OpCodes.Brfalse, nullishLabel);
+        IL.Emit(OpCodes.Ldloc, fnLocal);
+        IL.Emit(OpCodes.Isinst, Ctx.Runtime!.UndefinedType);
+        IL.Emit(OpCodes.Brtrue, nullishLabel);
+
+        // InvokeMethodValue(recv, fn, args) — args evaluated only on the
+        // non-nullish path, per spec.
+        IL.Emit(OpCodes.Ldloc, recvLocal);
+        IL.Emit(OpCodes.Ldloc, fnLocal);
+        IL.Emit(OpCodes.Ldc_I4, c.Arguments.Count);
+        IL.Emit(OpCodes.Newarr, Types.Object);
+        for (int i = 0; i < c.Arguments.Count; i++)
+        {
+            IL.Emit(OpCodes.Dup);
+            IL.Emit(OpCodes.Ldc_I4, i);
+            EmitExpression(c.Arguments[i]);
+            EnsureBoxed();
+            IL.Emit(OpCodes.Stelem_Ref);
+        }
+        IL.Emit(OpCodes.Call, Ctx.Runtime!.InvokeMethodValue);
+        IL.Emit(OpCodes.Br, endLabel);
+
+        IL.MarkLabel(nullishLabel);
+        IL.Emit(OpCodes.Ldsfld, Ctx.Runtime!.UndefinedInstance);
+
+        IL.MarkLabel(endLabel);
+        SetStackUnknown();
+        return true;
     }
 
     /// <summary>

--- a/Compilation/ILCompiler.Classes.Accessors.cs
+++ b/Compilation/ILCompiler.Classes.Accessors.cs
@@ -9,8 +9,25 @@ namespace SharpTS.Compilation;
 /// </summary>
 public partial class ILCompiler
 {
+    /// <summary>
+    /// Computed accessor names with non-literal keys (e.g. <c>static get [Symbol.species]()</c>)
+    /// have no static .NET member name to emit. The interpreter supports them; compiled
+    /// mode does not yet (#266) — fail loudly rather than emitting a broken
+    /// property literally named "&lt;computed&gt;". Literal keys (<c>get ["foo"]()</c>)
+    /// are folded to ordinary names by the parser and never reach this check.
+    /// </summary>
+    private static void RejectComputedAccessor(Stmt.Accessor accessor)
+    {
+        if (accessor.ComputedKey != null)
+        {
+            throw new Diagnostics.Exceptions.CompileException(
+                $"Accessors with computed names (line {accessor.Name.Line}) are not supported in compiled mode yet.");
+        }
+    }
+
     private void EmitAccessor(TypeBuilder typeBuilder, Stmt.Accessor accessor, FieldInfo fieldsField)
     {
+        RejectComputedAccessor(accessor);
         // Use PascalCase naming convention: get_<PascalPropertyName> or set_<PascalPropertyName>
         string pascalName = NamingConventions.ToPascalCase(accessor.Name.Lexeme);
         string methodName = accessor.Kind.Type == TokenType.GET

--- a/Compilation/ILCompiler.Classes.ClassExpressions.cs
+++ b/Compilation/ILCompiler.Classes.ClassExpressions.cs
@@ -338,6 +338,7 @@ public partial class ILCompiler
         {
             foreach (var accessor in classExpr.Accessors)
             {
+                RejectComputedAccessor(accessor);
                 string accessorName = accessor.Name.Lexeme;
                 string pascalName = NamingConventions.ToPascalCase(accessorName);
                 string methodName = accessor.Kind.Type == TokenType.GET

--- a/Compilation/ILCompiler.Classes.Methods.cs
+++ b/Compilation/ILCompiler.Classes.Methods.cs
@@ -444,6 +444,7 @@ public partial class ILCompiler
 
             foreach (var accessor in classStmt.Accessors)
             {
+                RejectComputedAccessor(accessor);
                 string accessorName = accessor.Name.Lexeme;
                 string pascalName = NamingConventions.ToPascalCase(accessorName);
                 string methodName = accessor.Kind.Type == TokenType.GET

--- a/Compilation/ILEmitter.Calls.cs
+++ b/Compilation/ILEmitter.Calls.cs
@@ -38,6 +38,9 @@ public partial class ILEmitter
         // `'[object Math]' === Object.prototype.toString.call(Math)`.
         if (TryEmitObjectPrototypeToStringCall(c)) return;
 
+        // Function('return this')() — global-detection probe; see helper doc.
+        if (TryEmitFunctionReturnThisIdiom(c)) return;
+
         // `String(x)` / `Number(x)` / `Boolean(x)` — non-`new` coercion calls.
         // Compiled mode would otherwise resolve `String` as `typeof(string)` and
         // try to "call" the Type, which devolves to Stringify → wrong format for
@@ -153,6 +156,12 @@ public partial class ILEmitter
             // Handler chain: static types, Date.now, built-in modules, process streams,
             // globalThis chaining, imported/class-expr/this statics
             if (_callHandlers.TryHandle(this, c))
+                return;
+
+            // Optional-chain method calls (a.b?.m(x)) short-circuit to undefined
+            // when a link is nullish — must be explicit now that InvokeMethodValue
+            // throws for non-callable callees (#260).
+            if (TryEmitOptionalChainMethodCall(c))
                 return;
 
             // module.promises.methodName() (fs.promises, dns.promises, stream.promises)

--- a/Compilation/RuntimeEmitter.Objects.Invocation.cs
+++ b/Compilation/RuntimeEmitter.Objects.Invocation.cs
@@ -29,6 +29,22 @@ public partial class RuntimeEmitter
         il.MarkLabel(stackOkLabel);
     }
 
+    /// <summary>
+    /// Emits a guest TypeError throw — "&lt;typeof callee&gt; is not a function" —
+    /// matching the interpreter's message for invoking a non-callable (#260).
+    /// <paramref name="loadCallee"/> must push the callee value onto the stack.
+    /// </summary>
+    private void EmitThrowNotAFunction(ILGenerator il, EmittedRuntime runtime, Action loadCallee)
+    {
+        loadCallee();
+        il.Emit(OpCodes.Call, runtime.TypeOf);
+        il.Emit(OpCodes.Ldstr, " is not a function");
+        il.Emit(OpCodes.Call, _types.GetMethod(_types.String, "Concat", _types.String, _types.String));
+        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
+        il.Emit(OpCodes.Call, runtime.CreateException);
+        il.Emit(OpCodes.Throw);
+    }
+
     private void EmitGetArrayMethod(TypeBuilder typeBuilder, EmittedRuntime runtime)
     {
         // GetArrayMethod(object arr, string methodName) -> TSFunction or null
@@ -121,8 +137,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Brfalse, nullLabel);
 
         // ECMA-262 §22.2.6: a RegExp object is not callable — calling one throws
-        // TypeError rather than falling through to the null fallback. Targeted
-        // so the general non-callable→null behavior is unchanged.
+        // TypeError. Checked early so it doesn't fall into the dispatch chain.
         if (runtime.TSRegExpType != null)
         {
             var notRegExpCallee = il.DefineLabel();
@@ -266,15 +281,17 @@ public partial class RuntimeEmitter
         var notProxyLabel = il.DefineLabel();
         EmitProxyInvokeCheck(il, () => il.Emit(OpCodes.Ldarg_0), () => il.Emit(OpCodes.Ldarg_1), notProxyLabel);
 
+        // ECMA-262 §7.3.13: invoking a non-callable throws TypeError. This was
+        // a silent `return null` for years, which masked dispatch regressions
+        // (#239) — see #260.
         il.MarkLabel(notProxyLabel);
-        il.Emit(OpCodes.Ldnull);
-        il.Emit(OpCodes.Ret);
+        EmitThrowNotAFunction(il, runtime, () => il.Emit(OpCodes.Ldarg_0));
 
         // Type dispatch — currently only Array (IList<object>) has a runtime
         // constructor helper wired up. Other built-in Type constructors
-        // (Date, Map, Set, RegExp, Promise, …) called without `new` return
-        // null, matching pre-fix behavior; they can be wired in incrementally
-        // as usage patterns surface.
+        // (Date, Map, Set, RegExp, Promise, …) called without `new` throw a
+        // TypeError below; they can be wired in incrementally as usage
+        // patterns surface.
         il.MarkLabel(typeCalleeLabel);
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Castclass, _types.Type);
@@ -315,6 +332,11 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ret);
         il.MarkLabel(notSymbolTypeLabel);
 
+        // A built-in constructor Type without a call-form helper (e.g. the
+        // aliased `var f = Object; f(x)` pattern lodash uses). These ARE
+        // callable in JS, so the #260 throwing fallback must not fire here;
+        // unwired ones keep returning null until their call forms are wired
+        // in incrementally (#61).
         il.Emit(OpCodes.Ldnull);
         il.Emit(OpCodes.Ret);
 
@@ -489,9 +511,10 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Callvirt, runtime.MethodCallableInvoke);
         il.Emit(OpCodes.Ret);
 
+        // Null callee: `f(x)` where f is null. Throws TypeError per ECMA-262
+        // (previously a silent `return null` — #260).
         il.MarkLabel(nullLabel);
-        il.Emit(OpCodes.Ldnull);
-        il.Emit(OpCodes.Ret);
+        EmitThrowNotAFunction(il, runtime, () => il.Emit(OpCodes.Ldarg_0));
     }
 
     private void EmitInvokeMethodValue(TypeBuilder typeBuilder, EmittedRuntime runtime)
@@ -510,20 +533,19 @@ public partial class RuntimeEmitter
         // arg0 = receiver, arg1 = function, arg2 = args
         var notTSFunctionLabel = il.DefineLabel();
 
-        // if (function == null) return null immediately — we can't fall through to the
-        // later Isinst chain because it ends with a proxy check that calls GetType() on
-        // the function value, which NREs on null.
+        // if (function == null) throw TypeError immediately — we can't fall through to
+        // the later Isinst chain because it ends with a proxy check that calls GetType()
+        // on the function value, which NREs on null. This was a silent `return null`
+        // for years, which masked dispatch regressions like #239 — see #260.
         var notNullLabel = il.DefineLabel();
         il.Emit(OpCodes.Ldarg_1);
         il.Emit(OpCodes.Brtrue, notNullLabel);
-        il.Emit(OpCodes.Ldnull);
-        il.Emit(OpCodes.Ret);
+        EmitThrowNotAFunction(il, runtime, () => il.Emit(OpCodes.Ldarg_1));
         il.MarkLabel(notNullLabel);
 
         // ECMA-262 §22.2.6: a RegExp object has no [[Call]] — calling one
-        // (`/x/()`, `RegExp("a","g")()`) must throw TypeError, not fall through
-        // to the null fallback (which would silently return null). Targeted
-        // check so the general non-callable→null behavior is untouched.
+        // (`/x/()`, `RegExp("a","g")()`) must throw TypeError. Checked early
+        // so it doesn't fall into the dispatch chain.
         if (runtime.TSRegExpType != null)
         {
             var notRegExpCallee = il.DefineLabel();
@@ -825,9 +847,10 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.MethodInfo, "Invoke", _types.Object, _types.ObjectArray));
         il.Emit(OpCodes.Ret);
 
+        // Unrecognized non-callable (plain object, number, $Undefined, …):
+        // throw TypeError per ECMA-262 instead of silently returning null (#260).
         il.MarkLabel(noCallMethodLabel);
-        il.Emit(OpCodes.Ldnull);
-        il.Emit(OpCodes.Ret);
+        EmitThrowNotAFunction(il, runtime, () => il.Emit(OpCodes.Ldarg_1));
     }
 
     /// <summary>
@@ -902,8 +925,10 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Dup);
         il.Emit(OpCodes.Stloc, enumLocal);
         il.Emit(OpCodes.Brtrue, synthLabel);
-        // Not an enumerator and no JS method → preserve prior behavior:
-        // InvokeMethodValue(recv, fn, args) (fn is null/undefined → null).
+        // Not an enumerator and no JS method → InvokeMethodValue(recv, fn, args).
+        // fn is null/undefined here, so this throws TypeError ("undefined is not
+        // a function") — matching JS for an explicit `it.next()` / `it.return()`
+        // call on a receiver without that member (#260; previously a silent null).
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ldloc, fn);
         il.Emit(OpCodes.Ldarg_2);

--- a/Execution/IndexTarget.cs
+++ b/Execution/IndexTarget.cs
@@ -25,6 +25,12 @@ public abstract record IndexTarget
     public sealed record InstanceSymbol(SharpTSInstance Target, SharpTSSymbol Key) : IndexTarget;
     public sealed record GlobalThis(SharpTSGlobalThis Target, string Key) : IndexTarget;
     public sealed record HeadersString(SharpTSHeaders Target, string Key) : IndexTarget;
+    /// <summary>
+    /// Class constructor expando statics — Node allows arbitrary string/symbol-keyed
+    /// statics on class objects (<c>(C as any)["foo"] = 1</c>, <c>(C as any)[Symbol.species] = P</c>).
+    /// </summary>
+    public sealed record ClassString(SharpTSClass Target, string Key) : IndexTarget;
+    public sealed record ClassSymbol(SharpTSClass Target, SharpTSSymbol Key) : IndexTarget;
 
     // Get-only targets
     public sealed record EnumReverse(SharpTSEnum Target, double Index) : IndexTarget;

--- a/Execution/Interpreter.Async.cs
+++ b/Execution/Interpreter.Async.cs
@@ -640,7 +640,7 @@ public partial class Interpreter
         }
 
         object? index = (await EvaluateAsync(getIndex.Index)).ToObject();
-        return RuntimeValue.FromBoxed(EvaluateIndexGet(obj, index));
+        return PerformIndexGet(getIndex.Object, obj, index);
     }
 
     private async Task<RuntimeValue> EvaluateSetIndexAsync(Expr.SetIndex setIndex)
@@ -648,7 +648,7 @@ public partial class Interpreter
         object? obj = (await EvaluateAsync(setIndex.Object)).ToObject();
         object? index = (await EvaluateAsync(setIndex.Index)).ToObject();
         object? value = (await EvaluateAsync(setIndex.Value)).ToObject();
-        return RuntimeValue.FromBoxed(EvaluateIndexSet(obj, index, value));
+        return PerformIndexSet(obj, index, value);
     }
 
     private async Task<RuntimeValue> EvaluateCompoundAssignAsync(Expr.CompoundAssign compound)
@@ -675,10 +675,10 @@ public partial class Interpreter
     {
         object? obj = (await EvaluateAsync(compoundSetIndex.Object)).ToObject();
         object? index = (await EvaluateAsync(compoundSetIndex.Index)).ToObject();
-        object? currentValue = EvaluateIndexGet(obj, index);
+        object? currentValue = PerformIndexGet(compoundSetIndex.Object, obj, index).ToObject();
         object? operandValue = (await EvaluateAsync(compoundSetIndex.Value)).ToObject();
         object? result = ApplyCompoundOperator(compoundSetIndex.Operator.Type, currentValue, operandValue);
-        return RuntimeValue.FromBoxed(EvaluateIndexSet(obj, index, result));
+        return PerformIndexSet(obj, index, result);
     }
 
     private async Task<RuntimeValue> EvaluateLogicalAssignAsync(Expr.LogicalAssign logical)
@@ -738,7 +738,7 @@ public partial class Interpreter
     {
         object? obj = (await EvaluateAsync(logical.Object)).ToObject();
         object? index = (await EvaluateAsync(logical.Index)).ToObject();
-        object? currentValue = EvaluateIndexGet(obj, index);
+        object? currentValue = PerformIndexGet(logical.Object, obj, index).ToObject();
 
         switch (logical.Operator.Type)
         {
@@ -754,7 +754,7 @@ public partial class Interpreter
         }
 
         object? newValue = (await EvaluateAsync(logical.Value)).ToObject();
-        return RuntimeValue.FromBoxed(EvaluateIndexSet(obj, index, newValue));
+        return PerformIndexSet(obj, index, newValue);
     }
 
     private async Task<RuntimeValue> EvaluateTemplateLiteralAsync(Expr.TemplateLiteral template)
@@ -784,126 +784,4 @@ public partial class Interpreter
         return RuntimeValue.FromBoxed(callable.Call(this, args));
     }
 
-    // Helper methods for index operations
-    private object? EvaluateIndexGet(object? obj, object? index)
-    {
-        // Proxy interception for index access
-        if (obj is SharpTSProxy proxy)
-        {
-            string key = index is SharpTSSymbol ? index.ToString()! : Stringify(index);
-            return proxy.TrapGet(key, this);
-        }
-
-        if (obj is SharpTSArray array && index is double idx)
-        {
-            return array.Get((int)idx);
-        }
-        if (obj is SharpTSEnum enumObj && index is double enumIdx)
-        {
-            return enumObj.GetReverse(enumIdx);
-        }
-        // Handle symbol keys - return undefined for missing symbol properties
-        if (index is SharpTSSymbol symbol)
-        {
-            if (obj is SharpTSObject symObj)
-            {
-                return symObj.GetBySymbol(symbol) ?? SharpTSUndefined.Instance;
-            }
-            if (obj is SharpTSInstance symInst)
-            {
-                return symInst.GetBySymbol(symbol) ?? SharpTSUndefined.Instance;
-            }
-        }
-        if (obj is SharpTSObject sharpObj && index is string strKey)
-        {
-            return sharpObj.GetProperty(strKey);
-        }
-        if (obj is SharpTSObject numObj && index is double numKey)
-        {
-            return numObj.GetProperty(numKey.ToString());
-        }
-        if (obj is SharpTSInstance instance && index is string instanceKey)
-        {
-            return instance.Get(new Token(TokenType.IDENTIFIER, instanceKey, null, 0));
-        }
-        if (obj is SharpTSHeaders headers && index is string headerKey)
-        {
-            return (object?)headers.Get(headerKey) ?? SharpTSUndefined.Instance;
-        }
-        if (obj is string str && index is double strIdx)
-        {
-            int i = (int)strIdx;
-            return (i >= 0 && i < str.Length) ? (object)str[i].ToString() : SharpTSUndefined.Instance;
-        }
-        throw new InterpreterException("Index access not supported on this type.");
-    }
-
-    private object? EvaluateIndexSet(object? obj, object? index, object? value)
-    {
-        // Proxy interception for index set
-        if (obj is SharpTSProxy proxy)
-        {
-            string key = index is SharpTSSymbol ? index.ToString()! : Stringify(index);
-            proxy.TrapSet(key, value, this);
-            return value;
-        }
-
-        bool strictMode = _environment.IsStrictMode;
-
-        if (obj is SharpTSArray array && index is double idx)
-        {
-            if (strictMode)
-            {
-                array.SetStrict((int)idx, value, strictMode);
-            }
-            else
-            {
-                array.Set((int)idx, value);
-            }
-            return value;
-        }
-        if (obj is SharpTSObject sharpObj && index is string strKey)
-        {
-            if (strictMode)
-            {
-                sharpObj.SetPropertyStrict(strKey, value, strictMode);
-            }
-            else
-            {
-                sharpObj.SetProperty(strKey, value);
-            }
-            return value;
-        }
-        if (obj is SharpTSObject numObj && index is double numKey)
-        {
-            if (strictMode)
-            {
-                numObj.SetPropertyStrict(numKey.ToString(), value, strictMode);
-            }
-            else
-            {
-                numObj.SetProperty(numKey.ToString(), value);
-            }
-            return value;
-        }
-        if (obj is SharpTSInstance instance && index is string instanceKey)
-        {
-            if (strictMode)
-            {
-                instance.SetRawFieldStrict(instanceKey, value, strictMode);
-            }
-            else
-            {
-                instance.SetRawField(instanceKey, value);
-            }
-            return value;
-        }
-        // Math[n] = v — Math is extensible per ECMA-262.
-        if (obj is SharpTSMath math)
-        {
-            math.SetExtra(Stringify(index), value);
-            return value;
-        }
-        throw new InterpreterException("Index assignment not supported on this type.");
-    }
 }

--- a/Execution/Interpreter.Expressions.cs
+++ b/Execution/Interpreter.Expressions.cs
@@ -745,6 +745,10 @@ public partial class Interpreter
         (SharpTSInstance instance, _) => new IndexTarget.InstanceString(instance, PropertyKeyConverter.ToPropertyKeyString(index)),
         (SharpTSGlobalThis globalThis, string globalKey) => new IndexTarget.GlobalThis(globalThis, globalKey),
         (SharpTSHeaders headers, string headerKey) => new IndexTarget.HeadersString(headers, headerKey),
+        // Class constructors accept expando statics (Node: `C["foo"] = 1`,
+        // `C[Symbol.species] = P`). #262.
+        (SharpTSClass cls, SharpTSSymbol clsSym) => new IndexTarget.ClassSymbol(cls, clsSym),
+        (SharpTSClass cls, _) => new IndexTarget.ClassString(cls, PropertyKeyConverter.ToPropertyKeyString(index)),
         (string str, double strIdx) => new IndexTarget.StringChar(str, (int)strIdx),
         _ => new IndexTarget.Unsupported(obj, index)
     };
@@ -769,7 +773,18 @@ public partial class Interpreter
         }
 
         object? index = Evaluate(getIndex.Index);
+        return PerformIndexGet(getIndex.Object, obj, index);
+    }
 
+    /// <summary>
+    /// Performs an index read on already-evaluated operands. Shared by the sync
+    /// evaluator and the async evaluator (Interpreter.Async.cs) so both contexts
+    /// dispatch identically. <paramref name="objectExpr"/> is the unevaluated
+    /// receiver expression, needed only to synthesize a Get for the dot-notation
+    /// fallback path.
+    /// </summary>
+    private RuntimeValue PerformIndexGet(Expr objectExpr, object? obj, object? index)
+    {
         // Proxy: intercept index access via get trap
         if (obj is SharpTSProxy proxy)
         {
@@ -826,7 +841,7 @@ public partial class Interpreter
         if (obj != null && index is string strIndexKey)
         {
             var syntheticName = new Token(TokenType.IDENTIFIER, strIndexKey, null, 0);
-            var syntheticGet = new Expr.Get(getIndex.Object, syntheticName, Optional: false);
+            var syntheticGet = new Expr.Get(objectExpr, syntheticName, Optional: false);
             return EvaluateGetOnObject(syntheticGet, obj);
         }
 
@@ -866,6 +881,13 @@ public partial class Interpreter
             IndexTarget.ObjectSymbol t => t.Target.GetBySymbol(t.Key) ?? SharpTSUndefined.Instance,
             IndexTarget.InstanceString t => t.Target.Get(new Token(TokenType.IDENTIFIER, t.Key, null, 0)),
             IndexTarget.InstanceSymbol t => t.Target.GetBySymbol(t.Key) ?? SharpTSUndefined.Instance,
+            // String keys on classes are normally intercepted by the synthetic-Get
+            // path above; this arm catches non-string keys (numbers, booleans)
+            // after ToPropertyKey normalization.
+            IndexTarget.ClassString t => EvaluateGetOnClass(t.Target, t.Key),
+            IndexTarget.ClassSymbol t => t.Target.TryGetStaticBySymbol(t.Key, out var clsSymVal)
+                ? clsSymVal ?? SharpTSUndefined.Instance
+                : SharpTSUndefined.Instance,
             IndexTarget.GlobalThis t => t.Target.GetProperty(t.Key),
             IndexTarget.HeadersString t => (object?)t.Target.Get(t.Key) ?? SharpTSUndefined.Instance,
             IndexTarget.StringChar t => (t.Index >= 0 && t.Index < t.Target.Length)
@@ -890,6 +912,16 @@ public partial class Interpreter
         object? obj = Evaluate(setIndex.Object);
         object? index = Evaluate(setIndex.Index);
         object? value = Evaluate(setIndex.Value);
+        return PerformIndexSet(obj, index, value);
+    }
+
+    /// <summary>
+    /// Performs an index assignment on already-evaluated operands. Shared by the
+    /// sync evaluator and the async evaluator (Interpreter.Async.cs) so both
+    /// contexts dispatch identically.
+    /// </summary>
+    private RuntimeValue PerformIndexSet(object? obj, object? index, object? value)
+    {
         bool strictMode = _environment.IsStrictMode;
 
         // Proxy: intercept index assignment via set trap
@@ -997,6 +1029,14 @@ public partial class Interpreter
             case IndexTarget.InstanceSymbol t:
                 if (strictMode) t.Target.SetBySymbolStrict(t.Key, value, strictMode);
                 else t.Target.SetBySymbol(t.Key, value);
+                break;
+
+            case IndexTarget.ClassString t:
+                t.Target.SetStaticProperty(t.Key, value);
+                break;
+
+            case IndexTarget.ClassSymbol t:
+                t.Target.SetStaticBySymbol(t.Key, value);
                 break;
 
             case IndexTarget.GlobalThis t:

--- a/Execution/Interpreter.Expressions.cs
+++ b/Execution/Interpreter.Expressions.cs
@@ -880,14 +880,12 @@ public partial class Interpreter
             IndexTarget.ObjectString t => t.Target.GetProperty(t.Key),
             IndexTarget.ObjectSymbol t => t.Target.GetBySymbol(t.Key) ?? SharpTSUndefined.Instance,
             IndexTarget.InstanceString t => t.Target.Get(new Token(TokenType.IDENTIFIER, t.Key, null, 0)),
-            IndexTarget.InstanceSymbol t => t.Target.GetBySymbol(t.Key) ?? SharpTSUndefined.Instance,
+            IndexTarget.InstanceSymbol t => GetInstanceSymbolValue(t.Target, t.Key),
             // String keys on classes are normally intercepted by the synthetic-Get
             // path above; this arm catches non-string keys (numbers, booleans)
             // after ToPropertyKey normalization.
             IndexTarget.ClassString t => EvaluateGetOnClass(t.Target, t.Key),
-            IndexTarget.ClassSymbol t => t.Target.TryGetStaticBySymbol(t.Key, out var clsSymVal)
-                ? clsSymVal ?? SharpTSUndefined.Instance
-                : SharpTSUndefined.Instance,
+            IndexTarget.ClassSymbol t => GetClassSymbolValue(t.Target, t.Key),
             IndexTarget.GlobalThis t => t.Target.GetProperty(t.Key),
             IndexTarget.HeadersString t => (object?)t.Target.Get(t.Key) ?? SharpTSUndefined.Instance,
             IndexTarget.StringChar t => (t.Index >= 0 && t.Index < t.Target.Length)
@@ -896,6 +894,37 @@ public partial class Interpreter
             IndexTarget.Unsupported => throw new InterpreterException("Index access not supported on this type."),
             _ => throw new InterpreterException("Index access not supported on this type.")
         });
+    }
+
+    /// <summary>
+    /// Reads a symbol-keyed member from an instance: own symbol data property
+    /// first, then a declared symbol-keyed getter (`get [Symbol.x]()`) from the
+    /// class chain.
+    /// </summary>
+    private object? GetInstanceSymbolValue(SharpTSInstance instance, SharpTSSymbol symbol)
+    {
+        object? own = instance.GetBySymbol(symbol);
+        if (own != null) return own;
+        if (instance.GetClass().FindSymbolGetter(symbol) is { } getter)
+        {
+            return getter.Bind(instance).Call(this, []);
+        }
+        return SharpTSUndefined.Instance;
+    }
+
+    /// <summary>
+    /// Reads a symbol-keyed static from a class: a declared static symbol-keyed
+    /// getter (`static get [Symbol.species]()`) wins over expando data statics.
+    /// </summary>
+    private object? GetClassSymbolValue(SharpTSClass klass, SharpTSSymbol symbol)
+    {
+        if (klass.FindStaticSymbolGetter(symbol) is { } getter)
+        {
+            return getter.BindStatic(klass).Call(this, []);
+        }
+        return klass.TryGetStaticBySymbol(symbol, out var value)
+            ? value ?? SharpTSUndefined.Instance
+            : SharpTSUndefined.Instance;
     }
 
     /// <summary>
@@ -1027,6 +1056,14 @@ public partial class Interpreter
                 break;
 
             case IndexTarget.InstanceSymbol t:
+                // A declared symbol-keyed setter (`set [Symbol.x](v)`) intercepts
+                // assignment unless shadowed by an own symbol data property.
+                if (t.Target.GetBySymbol(t.Key) == null
+                    && t.Target.GetClass().FindSymbolSetter(t.Key) is { } symSetter)
+                {
+                    symSetter.Bind(t.Target).Call(this, [value]);
+                    break;
+                }
                 if (strictMode) t.Target.SetBySymbolStrict(t.Key, value, strictMode);
                 else t.Target.SetBySymbol(t.Key, value);
                 break;
@@ -1036,6 +1073,11 @@ public partial class Interpreter
                 break;
 
             case IndexTarget.ClassSymbol t:
+                if (t.Target.FindStaticSymbolSetter(t.Key) is { } staticSymSetter)
+                {
+                    staticSymSetter.BindStatic(t.Target).Call(this, [value]);
+                    break;
+                }
                 t.Target.SetStaticBySymbol(t.Key, value);
                 break;
 
@@ -1234,6 +1276,7 @@ public partial class Interpreter
             // Create accessor functions
             Dictionary<string, SharpTSFunction> getters = [];
             Dictionary<string, SharpTSFunction> setters = [];
+            List<(SharpTSSymbol Symbol, SharpTSFunction Func, bool IsStatic, bool IsGetter)>? symbolAccessors = null;
 
             if (classExpr.Accessors != null)
             {
@@ -1248,14 +1291,29 @@ public partial class Interpreter
                         accessor.ReturnType);
 
                     SharpTSFunction func = new(funcStmt, _environment);
+                    bool isGetter = accessor.Kind.Type == TokenType.GET;
+                    string nameKey = accessor.Name.Lexeme;
 
-                    if (accessor.Kind.Type == TokenType.GET)
+                    // Computed accessor names, evaluated at class-definition time
+                    // (mirrors VisitClass).
+                    if (accessor.ComputedKey != null)
                     {
-                        getters[accessor.Name.Lexeme] = func;
+                        object? key = Evaluate(accessor.ComputedKey);
+                        if (key is SharpTSSymbol symbolKey)
+                        {
+                            (symbolAccessors ??= []).Add((symbolKey, func, accessor.IsStatic, isGetter));
+                            continue;
+                        }
+                        nameKey = PropertyKeyConverter.ToPropertyKeyString(key);
+                    }
+
+                    if (isGetter)
+                    {
+                        getters[nameKey] = func;
                     }
                     else
                     {
-                        setters[accessor.Name.Lexeme] = func;
+                        setters[nameKey] = func;
                     }
                 }
             }
@@ -1305,6 +1363,14 @@ public partial class Interpreter
                     setters,
                     classExpr.IsAbstract,
                     instanceFields);
+
+            if (symbolAccessors != null)
+            {
+                foreach (var (symbol, func, isStatic, isGetter) in symbolAccessors)
+                {
+                    klass.AddSymbolAccessor(symbol, func, isStatic, isGetter);
+                }
+            }
 
             // Execute static initializers in declaration order (if present)
             if (hasStaticInitializers)

--- a/Execution/Interpreter.cs
+++ b/Execution/Interpreter.cs
@@ -2251,6 +2251,10 @@ public partial class Interpreter : IDisposable
         Dictionary<string, SharpTSFunction> staticGetters = [];
         Dictionary<string, SharpTSFunction> staticSetters = [];
 
+        // Symbol-keyed accessors can't go into the string dictionaries; collected
+        // here and attached to the class after construction.
+        List<(SharpTSSymbol Symbol, SharpTSFunction Func, bool IsStatic, bool IsGetter)>? symbolAccessors = null;
+
         if (classStmt.Accessors != null)
         {
             foreach (var accessor in classStmt.Accessors)
@@ -2265,11 +2269,29 @@ public partial class Interpreter : IDisposable
                     accessor.ReturnType);
 
                 SharpTSFunction func = new(funcStmt, _environment);
+                bool isGetter = accessor.Kind.Type == TokenType.GET;
+
+                // Computed accessor names (`get [Symbol.toStringTag]()`,
+                // `static get [Symbol.species]()`) are evaluated at
+                // class-definition time, like computed field keys.
+                if (accessor.ComputedKey != null)
+                {
+                    object? key = Evaluate(accessor.ComputedKey);
+                    if (key is SharpTSSymbol symbolKey)
+                    {
+                        (symbolAccessors ??= []).Add((symbolKey, func, accessor.IsStatic, isGetter));
+                        continue;
+                    }
+                    string keyStr = PropertyKeyConverter.ToPropertyKeyString(key);
+                    if (isGetter) (accessor.IsStatic ? staticGetters : getters)[keyStr] = func;
+                    else (accessor.IsStatic ? staticSetters : setters)[keyStr] = func;
+                    continue;
+                }
 
                 var targetGet = accessor.IsStatic ? staticGetters : getters;
                 var targetSet = accessor.IsStatic ? staticSetters : setters;
 
-                if (accessor.Kind.Type == TokenType.GET)
+                if (isGetter)
                 {
                     targetGet[accessor.Name.Lexeme] = func;
                 }
@@ -2384,6 +2406,14 @@ public partial class Interpreter : IDisposable
                 staticAutoAccessors.Count > 0 ? staticAutoAccessors : null,
                 staticGetters.Count > 0 ? staticGetters : null,
                 staticSetters.Count > 0 ? staticSetters : null);
+
+        if (symbolAccessors != null)
+        {
+            foreach (var (symbol, func, isStatic, isGetter) in symbolAccessors)
+            {
+                klass.AddSymbolAccessor(symbol, func, isStatic, isGetter);
+            }
+        }
 
         // Execute static initializers in declaration order (if present)
         if (hasStaticInitializers)

--- a/Parsing/AST.cs
+++ b/Parsing/AST.cs
@@ -366,7 +366,11 @@ public abstract record Stmt
     /// ComputedKey contains the expression and Name is a synthetic token.
     /// </summary>
     public record Field(Token Name, string? TypeAnnotation, Expr? Initializer, bool IsStatic = false, AccessModifier Access = AccessModifier.Public, bool IsReadonly = false, bool IsOptional = false, bool HasDefiniteAssignmentAssertion = false, List<Decorator>? Decorators = null, bool IsPrivate = false, bool IsDeclare = false, Expr? ComputedKey = null) : Stmt;
-    public record Accessor(Token Name, Token Kind, Parameter? SetterParam, List<Stmt> Body, string? ReturnType, AccessModifier Access = AccessModifier.Public, bool IsAbstract = false, bool IsOverride = false, List<Decorator>? Decorators = null, bool IsStatic = false) : Stmt;
+    /// <summary>
+    /// Getter/setter declaration. For computed accessor names (e.g., static get [Symbol.species]()),
+    /// ComputedKey contains the expression and Name is a synthetic token.
+    /// </summary>
+    public record Accessor(Token Name, Token Kind, Parameter? SetterParam, List<Stmt> Body, string? ReturnType, AccessModifier Access = AccessModifier.Public, bool IsAbstract = false, bool IsOverride = false, List<Decorator>? Decorators = null, bool IsStatic = false, Expr? ComputedKey = null) : Stmt;
     /// <summary>
     /// Auto-accessor field declaration (TypeScript 4.9+): accessor name: Type = initializer
     /// Automatically generates a private backing field with implicit getter/setter.

--- a/Parsing/Parser.Classes.cs
+++ b/Parsing/Parser.Classes.cs
@@ -198,7 +198,7 @@ public partial class Parser
                 }
 
                 Token kind = Advance(); // consume 'get' or 'set'
-                Token accessorName = Consume(TokenType.IDENTIFIER, "Expect property name after 'get'/'set'.");
+                (Token accessorName, Expr? accessorComputedKey) = ParseAccessorName();
                 Consume(TokenType.LEFT_PAREN, "Expect '(' after accessor name.");
 
                 Stmt.Parameter? setterParam = null;
@@ -235,7 +235,7 @@ public partial class Parser
                     body = Block();
                 }
 
-                accessors.Add(new Stmt.Accessor(accessorName, kind, setterParam, body, returnType, access, isMemberAbstract, isOverride, memberDecorators, isStatic));
+                accessors.Add(new Stmt.Accessor(accessorName, kind, setterParam, body, returnType, access, isMemberAbstract, isOverride, memberDecorators, isStatic, accessorComputedKey));
             }
             // Check for private field: #name...
             else if (Peek().Type == TokenType.PRIVATE_IDENTIFIER)
@@ -724,7 +724,7 @@ public partial class Parser
                 }
 
                 Token kind = Advance(); // consume 'get' or 'set'
-                Token accessorName = Consume(TokenType.IDENTIFIER, "Expect property name after 'get'/'set'.");
+                (Token accessorName, Expr? accessorComputedKey) = ParseAccessorName();
                 Consume(TokenType.LEFT_PAREN, "Expect '(' after accessor name.");
 
                 Stmt.Parameter? setterParam = null;
@@ -750,7 +750,7 @@ public partial class Parser
                 Consume(TokenType.LEFT_BRACE, "Expect '{' before accessor body.");
                 List<Stmt> body = Block();
 
-                accessors.Add(new Stmt.Accessor(accessorName, kind, setterParam, body, returnType, access, IsStatic: isStatic));
+                accessors.Add(new Stmt.Accessor(accessorName, kind, setterParam, body, returnType, access, IsStatic: isStatic, ComputedKey: accessorComputedKey));
             }
             // Check for private field/method: #name...
             else if (Peek().Type == TokenType.PRIVATE_IDENTIFIER)

--- a/Parsing/Parser.cs
+++ b/Parsing/Parser.cs
@@ -353,6 +353,36 @@ public partial class Parser(List<Token> tokens, DecoratorMode decoratorMode = De
         return ConsumePropertyName(message);
     }
 
+    /// <summary>
+    /// Parses an accessor name in a class body: an identifier/keyword/string/number
+    /// property name, or a computed name <c>[expr]</c> (e.g. <c>get [Symbol.species]()</c>).
+    /// For computed names the returned token is synthetic and the key expression is
+    /// carried separately (mirrors Stmt.Field.ComputedKey).
+    /// </summary>
+    private (Token Name, Expr? ComputedKey) ParseAccessorName()
+    {
+        if (Match(TokenType.LEFT_BRACKET))
+        {
+            Expr computedKey = Expression();
+            Consume(TokenType.RIGHT_BRACKET, "Expect ']' after computed accessor name.");
+
+            // Literal string/number keys are static names — fold them so every
+            // phase (checker, interpreter, compiler) treats `get ["foo"]()`
+            // exactly like `get foo()`.
+            if (computedKey is Expr.Literal { Value: string s })
+            {
+                return (new Token(TokenType.IDENTIFIER, s, null, Previous().Line), null);
+            }
+            if (computedKey is Expr.Literal { Value: double d })
+            {
+                return (new Token(TokenType.IDENTIFIER, d.ToString(System.Globalization.CultureInfo.InvariantCulture), null, Previous().Line), null);
+            }
+
+            return (new Token(TokenType.IDENTIFIER, "<computed>", null, Previous().Line), computedKey);
+        }
+        return (ConsumePropertyNameOrLiteral("Expect property name after 'get'/'set'."), null);
+    }
+
     private Token ConsumePropertyName(string message)
     {
         Token current = Peek();

--- a/Parsing/Visitors/AstVisitorBase.cs
+++ b/Parsing/Visitors/AstVisitorBase.cs
@@ -439,12 +439,16 @@ public abstract class AstVisitorBase
 
     protected virtual void VisitField(Stmt.Field stmt)
     {
+        if (stmt.ComputedKey != null)
+            Visit(stmt.ComputedKey);
         if (stmt.Initializer != null)
             Visit(stmt.Initializer);
     }
 
     protected virtual void VisitAccessor(Stmt.Accessor stmt)
     {
+        if (stmt.ComputedKey != null)
+            Visit(stmt.ComputedKey);
         foreach (var s in stmt.Body)
             Visit(s);
     }

--- a/Runtime/Types/SharpTSClass.cs
+++ b/Runtime/Types/SharpTSClass.cs
@@ -250,6 +250,35 @@ public class SharpTSClass(
         _staticProperties[name] = value;
     }
 
+    // Symbol-keyed expando statics (`(C as any)[Symbol.species] = V`). Node allows
+    // arbitrary statics on class constructors; string keys reuse _staticProperties.
+    // Lazy — most classes never receive symbol-keyed statics.
+    private Dictionary<SharpTSSymbol, object?>? _staticSymbolProperties;
+
+    public void SetStaticBySymbol(SharpTSSymbol symbol, object? value)
+    {
+        (_staticSymbolProperties ??= [])[symbol] = value;
+    }
+
+    /// <summary>
+    /// Looks up a symbol-keyed static, walking the superclass chain — class
+    /// constructors inherit from the parent constructor per ECMA-262, so
+    /// e.g. a Symbol.species set on a base class is visible on subclasses.
+    /// </summary>
+    public bool TryGetStaticBySymbol(SharpTSSymbol symbol, out object? value)
+    {
+        if (_staticSymbolProperties != null && _staticSymbolProperties.TryGetValue(symbol, out value))
+        {
+            return true;
+        }
+        if (Superclass != null)
+        {
+            return Superclass.TryGetStaticBySymbol(symbol, out value);
+        }
+        value = null;
+        return false;
+    }
+
     public SharpTSFunction? FindGetter(string name)
     {
         // Check cache first

--- a/Runtime/Types/SharpTSClass.cs
+++ b/Runtime/Types/SharpTSClass.cs
@@ -279,6 +279,39 @@ public class SharpTSClass(
         return false;
     }
 
+    // Symbol-keyed declared accessors (`get [Symbol.toStringTag]() {...}`,
+    // `static get [Symbol.species]() {...}`). Computed accessor keys are
+    // evaluated at class-definition time; symbol-valued keys land here,
+    // string-valued keys go into the regular getter/setter dictionaries.
+    // Lazy — most classes declare none.
+    private Dictionary<SharpTSSymbol, SharpTSFunction>? _symbolGetters;
+    private Dictionary<SharpTSSymbol, SharpTSFunction>? _symbolSetters;
+    private Dictionary<SharpTSSymbol, SharpTSFunction>? _staticSymbolGetters;
+    private Dictionary<SharpTSSymbol, SharpTSFunction>? _staticSymbolSetters;
+
+    public void AddSymbolAccessor(SharpTSSymbol symbol, SharpTSFunction func, bool isStatic, bool isGetter)
+    {
+        switch (isStatic, isGetter)
+        {
+            case (true, true): (_staticSymbolGetters ??= [])[symbol] = func; break;
+            case (true, false): (_staticSymbolSetters ??= [])[symbol] = func; break;
+            case (false, true): (_symbolGetters ??= [])[symbol] = func; break;
+            case (false, false): (_symbolSetters ??= [])[symbol] = func; break;
+        }
+    }
+
+    public SharpTSFunction? FindSymbolGetter(SharpTSSymbol symbol)
+        => _symbolGetters?.GetValueOrDefault(symbol) ?? Superclass?.FindSymbolGetter(symbol);
+
+    public SharpTSFunction? FindSymbolSetter(SharpTSSymbol symbol)
+        => _symbolSetters?.GetValueOrDefault(symbol) ?? Superclass?.FindSymbolSetter(symbol);
+
+    public SharpTSFunction? FindStaticSymbolGetter(SharpTSSymbol symbol)
+        => _staticSymbolGetters?.GetValueOrDefault(symbol) ?? Superclass?.FindStaticSymbolGetter(symbol);
+
+    public SharpTSFunction? FindStaticSymbolSetter(SharpTSSymbol symbol)
+        => _staticSymbolSetters?.GetValueOrDefault(symbol) ?? Superclass?.FindStaticSymbolSetter(symbol);
+
     public SharpTSFunction? FindGetter(string name)
     {
         // Check cache first

--- a/SharpTS.Tests/IntegrationTests/RealPackageSmokeTests.cs
+++ b/SharpTS.Tests/IntegrationTests/RealPackageSmokeTests.cs
@@ -492,7 +492,14 @@ public class RealPackageSmokeTests
         Assert.Equal("function", result.StandardOutput.Split('\n')[0].Trim());
     }
 
-    [SkippableFact]
+    // Pre-#260, compiled lodash "loaded" only because non-callable dispatches
+    // silently evaluated to null: global/globalThis compile to null in value
+    // position, so runInContext ran with a null context and every native ref
+    // was undefined (which is also why chunk/flatten returned wrong values).
+    // With the #260 TypeError, init fails honestly at lodash's
+    // `funcToString.call(Object)`. Unskip when #271 (globalThis value
+    // representation) lands.
+    [SkippableFact(Skip = "compiled lodash cannot initialize without a globalThis value representation — see #271")]
     public void Lodash_Compiled()
     {
         SkipIfNoNpm();

--- a/SharpTS.Tests/SharedTests/ClassExpandoStaticTests.cs
+++ b/SharpTS.Tests/SharedTests/ClassExpandoStaticTests.cs
@@ -1,0 +1,78 @@
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests;
+
+/// <summary>
+/// Tests for expando statics on class constructors via bracket assignment (#262).
+/// Node allows arbitrary string/symbol-keyed statics on class objects.
+/// </summary>
+public class ClassExpandoStaticTests
+{
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void StringKeyedExpandoStatic_RoundTrips(ExecutionMode mode)
+    {
+        var source = """
+            class C {}
+            (C as any)["foo"] = 1;
+            console.log((C as any)["foo"] === 1);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("true\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void SymbolKeyedExpandoStatic_RoundTrips(ExecutionMode mode)
+    {
+        var source = """
+            class C {}
+            (C as any)[Symbol.species] = 2;
+            console.log((C as any)[Symbol.species] === 2);
+            console.log((C as any)[Symbol.iterator] === undefined);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("true\ntrue\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ExpandoStatics_InAsyncContext_RoundTrip(ExecutionMode mode)
+    {
+        var source = """
+            class C {}
+            async function go() {
+                (C as any)["bar"] = 3;
+                (C as any)[Symbol.toPrimitive] = 4;
+                console.log((C as any)["bar"] === 3);
+                console.log((C as any)[Symbol.toPrimitive] === 4);
+            }
+            go();
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("true\ntrue\n", output);
+    }
+
+    // Compiled mode does not yet walk the constructor parent chain for expando
+    // statics (#265); Node inherits them via Object.getPrototypeOf(D) === C.
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void ExpandoStatics_InheritedThroughSubclassChain(ExecutionMode mode)
+    {
+        var source = """
+            class C {}
+            class D extends C {}
+            (C as any)["foo"] = 1;
+            (C as any)[Symbol.species] = 2;
+            console.log((D as any)["foo"] === 1);
+            console.log((D as any)[Symbol.species] === 2);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("true\ntrue\n", output);
+    }
+}

--- a/SharpTS.Tests/SharedTests/ComputedAccessorNameTests.cs
+++ b/SharpTS.Tests/SharedTests/ComputedAccessorNameTests.cs
@@ -1,0 +1,110 @@
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests;
+
+/// <summary>
+/// Tests for computed accessor names in class bodies (#261):
+/// get [Symbol.toStringTag]() / static get [Symbol.species]().
+/// Symbol-keyed accessors run interpreted only (compiled support tracked by #266);
+/// literal computed keys fold to ordinary names in the parser and run in both modes.
+/// </summary>
+public class ComputedAccessorNameTests
+{
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void StaticSymbolGetter_SpeciesPattern(ExecutionMode mode)
+    {
+        var source = """
+            class MyP extends Promise<any> {
+                static get [Symbol.species]() { return Promise; }
+            }
+            console.log((MyP as any)[Symbol.species] === Promise);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("true\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void InstanceSymbolGetterAndSetter(ExecutionMode mode)
+    {
+        var source = """
+            class Tagged {
+                stored: any = null;
+                get [Symbol.toStringTag]() { return "Tagged!"; }
+                set [Symbol.toPrimitive](v: any) { this.stored = v; }
+            }
+            const t = new Tagged();
+            console.log((t as any)[Symbol.toStringTag]);
+            (t as any)[Symbol.toPrimitive] = 42;
+            console.log(t.stored);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("Tagged!\n42\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void StaticSymbolGetter_InheritedThroughSubclassChain(ExecutionMode mode)
+    {
+        var source = """
+            class Base {
+                static get [Symbol.species]() { return Base; }
+            }
+            class Sub extends Base {}
+            console.log((Sub as any)[Symbol.species] === Base);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("true\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void SymbolAccessor_InClassExpression(ExecutionMode mode)
+    {
+        var source = """
+            const C = class {
+                get [Symbol.toStringTag]() { return "expr"; }
+            };
+            console.log((new C() as any)[Symbol.toStringTag]);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("expr\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void LiteralComputedKeys_FoldToOrdinaryNames(ExecutionMode mode)
+    {
+        var source = """
+            class Lit {
+                get ["foo"]() { return 7; }
+            }
+            console.log(new Lit().foo);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("7\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void StringAndKeywordAccessorNames_Parse(ExecutionMode mode)
+    {
+        var source = """
+            class Kw {
+                get "quoted"() { return 1; }
+                get type() { return 2; }
+            }
+            console.log(new Kw()["quoted"], new Kw().type);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("1 2\n", output);
+    }
+}

--- a/SharpTS.Tests/SharedTests/NamespaceGlobalBindingTests.cs
+++ b/SharpTS.Tests/SharedTests/NamespaceGlobalBindingTests.cs
@@ -67,12 +67,26 @@ public class NamespaceGlobalBindingTests
             const rs = new ctor({ start(c: any) { c.enqueue(1); c.close(); } });
             console.log(rs instanceof (ReadableStream as any));
             console.log(typeof (WritableStream as any), typeof (TransformStream as any));
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("function\ntrue\nfunction function\n", output);
+    }
+
+    // Compiled mode has no ReadableStream.from yet (#269) — before #260 the
+    // dispatch silently produced null and `typeof null === "object"` made this
+    // assertion pass for the wrong reason.
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void WebStreamConstructors_From(ExecutionMode mode)
+    {
+        var source = """
             const fromStream = (ReadableStream as any).from(["a"]);
             console.log(typeof fromStream);
             """;
 
         var output = TestHarness.Run(source, mode);
-        Assert.Equal("function\ntrue\nfunction function\nobject\n", output);
+        Assert.Equal("object\n", output);
     }
 
     [Theory]

--- a/SharpTS.Tests/SharedTests/NonCallableInvocationTests.cs
+++ b/SharpTS.Tests/SharedTests/NonCallableInvocationTests.cs
@@ -1,0 +1,127 @@
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests;
+
+/// <summary>
+/// Tests for invoking non-callable values (#260). Both modes must throw a guest
+/// TypeError ("&lt;typeof&gt; is not a function") instead of silently evaluating to
+/// null — the compiled-mode silent no-op masked dispatch regressions like #239.
+/// </summary>
+public class NonCallableInvocationTests
+{
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void NullCallee_ThrowsTypeError(ExecutionMode mode)
+    {
+        var source = """
+            const f: any = null;
+            try {
+                f("x");
+                console.log("no throw");
+            } catch (e: any) {
+                console.log(e instanceof TypeError, e.message);
+            }
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("true object is not a function\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void UndefinedAndMissingMethod_ThrowTypeError(ExecutionMode mode)
+    {
+        var source = """
+            function check(label: string, fn: () => void) {
+                try { fn(); console.log(label, "no throw"); }
+                catch (e: any) { console.log(label, e instanceof TypeError, e.message); }
+            }
+            const u: any = undefined;
+            check("u", () => u());
+            const obj: any = {};
+            check("missing", () => obj.nope());
+            const withNull: any = { m: null };
+            check("nullMember", () => withNull.m(1));
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal(
+            "u true undefined is not a function\n" +
+            "missing true undefined is not a function\n" +
+            "nullMember true object is not a function\n",
+            output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void NonCallablePrimitive_ThrowsTypeError(ExecutionMode mode)
+    {
+        var source = """
+            const n: any = 42;
+            try { n(); console.log("no throw"); }
+            catch (e: any) { console.log(e instanceof TypeError, e.message); }
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("true number is not a function\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void OptionalCall_OfNullish_ReturnsUndefined(ExecutionMode mode)
+    {
+        var source = """
+            const g: any = null;
+            console.log(g?.());
+            const h: any = { m: undefined };
+            console.log(h.m?.());
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("undefined\nundefined\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void OptionalChainMethodCall_ShortCircuitsWholeChain(ExecutionMode mode)
+    {
+        // ECMA-262 §13.3: a.b?.m(x) yields undefined when a.b is nullish — the
+        // call must not be attempted. Compiled mode used to lean on the silent
+        // non-callable no-op for this (surfaced by the yaml package's
+        // tag.test?.test(value) once #260 made the fallback throw).
+        var source = """
+            const o: any = {};
+            console.log(o.test?.test("x"));
+            const arr: any = [{ a: 1 }, { test: /x/ }];
+            console.log(arr.find((t: any) => t.test?.test("x"))?.test + "");
+            const n: any = null;
+            console.log(n?.m());
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("undefined\n/x/\nundefined\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ForAwaitBreak_WithoutIteratorReturn_DoesNotThrow(ExecutionMode mode)
+    {
+        // iterator.return() is optional per the iterator protocol; the for-await
+        // cleanup path must skip it (not throw) when absent.
+        var source = """
+            async function* gen() { yield 1; yield 2; }
+            async function main() {
+                for await (const v of gen()) {
+                    console.log("got", v);
+                    break;
+                }
+                console.log("done");
+            }
+            main();
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("got 1\ndone\n", output);
+    }
+}

--- a/TypeSystem/TypeChecker.Statements.Classes.cs
+++ b/TypeSystem/TypeChecker.Statements.Classes.cs
@@ -303,6 +303,13 @@ public partial class TypeChecker
                     : DecoratorTarget.Setter;
                 CheckDecorators(accessor.Decorators, accessorTarget);
 
+                // Computed accessor names (get [Symbol.x]()) have no static member
+                // name to register; their bodies are still checked later.
+                if (accessor.ComputedKey != null)
+                {
+                    continue;
+                }
+
                 string propName = accessor.Name.Lexeme;
 
                 if (accessor.Kind.Type == TokenType.GET)
@@ -782,7 +789,11 @@ public partial class TypeChecker
                     TypeInfo accessorReturnType;
                     if (accessor.Kind.Type == TokenType.GET)
                     {
-                        accessorReturnType = classTypeForBody.Getters[accessor.Name.Lexeme];
+                        // Computed-name accessors aren't registered in Getters/Setters
+                        // (no static member name); derive types from the declaration.
+                        accessorReturnType = accessor.ComputedKey != null
+                            ? (accessor.ReturnType != null ? ToTypeInfo(accessor.ReturnType) : new TypeInfo.Any())
+                            : classTypeForBody.Getters[accessor.Name.Lexeme];
                     }
                     else
                     {
@@ -791,7 +802,9 @@ public partial class TypeChecker
                         // Add setter parameter to environment
                         if (accessor.SetterParam != null)
                         {
-                            TypeInfo setterParamType = classTypeForBody.Setters[accessor.Name.Lexeme];
+                            TypeInfo setterParamType = accessor.ComputedKey != null
+                                ? (accessor.SetterParam.Type != null ? ToTypeInfo(accessor.SetterParam.Type) : new TypeInfo.Any())
+                                : classTypeForBody.Setters[accessor.Name.Lexeme];
                             accessorEnv.Define(accessor.SetterParam.Name.Lexeme, setterParamType);
                         }
                     }
@@ -988,6 +1001,12 @@ public partial class TypeChecker
         {
             foreach (var accessor in classStmt.Accessors)
             {
+                // Computed accessor names have no static member name to register.
+                if (accessor.ComputedKey != null)
+                {
+                    continue;
+                }
+
                 TypeInfo accessorType = accessor.ReturnType != null
                     ? ToTypeInfo(accessor.ReturnType)
                     : new TypeInfo.Any();

--- a/TypeSystem/TypeChecker.Validation.cs
+++ b/TypeSystem/TypeChecker.Validation.cs
@@ -279,6 +279,12 @@ public partial class TypeChecker
         {
             foreach (var accessor in classStmt.Accessors)
             {
+                // Computed accessor names can't be validated against parent members.
+                if (accessor.ComputedKey != null)
+                {
+                    continue;
+                }
+
                 if (accessor.IsOverride)
                 {
                     string propertyName = accessor.Name.Lexeme;


### PR DESCRIPTION
Fixes #260, fixes #261, fixes #262.

One commit per issue, ordered by dependency (each later fix builds on the earlier ones' tests passing).

## #262 — interp: bracket assignment on class objects (`fecac9c3`)

`(C as any)["foo"] = 1` / `(C as any)[Symbol.species] = 2` now store expando statics on the class. String keys reuse `_staticProperties`; symbol keys get a lazy map on `SharpTSClass` whose reads walk the superclass chain (Node: `Object.getPrototypeOf(D) === C`). New `IndexTarget.ClassString/ClassSymbol` arms.

**Architecture:** the async evaluator's ad-hoc `EvaluateIndexGet/Set` copies (missing functions, instance symbols, Math, RegExp symbols, classes) are deleted; both contexts now share `PerformIndexGet/PerformIndexSet` extracted from the sync path.

Follow-up filed: #265 (compiled mode doesn't inherit expando statics through the subclass chain).

## #261 — parser: computed accessor names in class bodies (`cbf715e4`)

`static get [Symbol.species]()` / `get [Symbol.toStringTag]()` now parse (class declarations and class expressions), plus string/number-literal and keyword accessor names. `Stmt.Accessor.ComputedKey` mirrors `Stmt.Field.ComputedKey`.

- Literal computed keys (`get ["foo"]()`) fold to ordinary names in the parser, so every phase treats them as plain accessors in both modes.
- Symbol keys are evaluated at class-definition time and registered in symbol-keyed accessor maps on `SharpTSClass` (superclass-walking finders); bracket get/set on instances and classes dispatches through them, including setter interception.
- Type checker skips member registration for computed names but still checks accessor bodies; `AstVisitorBase` now visits `ComputedKey` on fields and accessors.
- Compiled mode rejects non-literal computed accessor names with a clear `CompileException` instead of emitting a broken `<computed>` property — real support tracked by #266.

This unblocks the lead blocker for the remaining #221 scope (Symbol.species overrides are now declarable + readable in the interpreter).

## #260 — compiled: non-callable invocation throws TypeError (`ec491d4e`)

`InvokeValue`/`InvokeMethodValue` fallbacks (null callee, unrecognized non-callable, missing member) now throw a guest `TypeError: <typeof> is not a function`, matching the interpreter — the silent `return null` masked dispatch regressions like #239.

Audit of all ~80 emitted call sites (details in commit message); reliances on the old no-op fixed alongside:
- **Optional-chain method calls** `a.b?.m(x)` now emit explicit ECMA-262 short-circuit semantics (was leaning on the no-op; silently broke yaml's `tag.test?.test(value)`).
- for-await `return()` cleanup now skips `$Undefined` as well as null (iterator.return is optional).
- `Function('return this')()` global-probe idiom (lodash/core-js) emits the compiled globalThis-as-value convention (null) instead of tripping the TypeError.
- Type-token callees (aliased built-in constructors, `var f = Object; f(x)`) keep the silent-null fallback — they ARE callable in JS (#61 tracks wiring call forms).

Newly visible pre-existing gaps, filed and scoped in tests: #269 (`ReadableStream.from` unimplemented compiled — its test was asserting on `typeof null === "object"`), #271 (`globalThis`/`global` compile to null in value position; compiled lodash cannot initialize — smoke test skipped with reference).

## Testing

- Full suite: **10777 passed, 0 failed, 1 skipped** (the documented #271 lodash skip).
- New shared regression suites: `ClassExpandoStaticTests`, `ComputedAccessorNameTests`, `NonCallableInvocationTests` (both modes where supported; interp-only cases annotated with their tracking issue).

## Issues filed during this batch

#265, #266, #269, #271.