### PR TITLE
fix(typecheck): isolate TypeNodeStats counters per logical flow (test-isolation race)

### DIFF
--- a/Parsing/TypeNodes.cs
+++ b/Parsing/TypeNodes.cs
@@ -77,13 +77,38 @@ public sealed record TupleElementNode(string? Name, TypeNode Type, bool IsOption
 /// dumped by the checker when <c>SHARPTS_TYPENODE_STATS=1</c>. Coarse by design (spike
 /// instrumentation, not telemetry).
 /// </summary>
+/// <remarks>
+/// Backed by <see cref="AsyncLocal{T}"/> so each logical flow has its own counters. The test
+/// harness runs the checker inside <c>Task.Run</c>, so the increments land on a pool thread while
+/// the test reads the counters on its own thread — AsyncLocal flows the same holder across that
+/// boundary, and concurrent tests are sibling flows that never see each other's values. A plain
+/// static (or <c>[ThreadStatic]</c>) breaks one of those two requirements: a shared static lets
+/// xUnit's parallel collections corrupt the counter (a string fallback in one test fails an
+/// unrelated test's <c>Assert.Equal(0, StringFallbacks)</c>); [ThreadStatic] severs the checker's
+/// pool-thread writes from the test thread's reads. Call <see cref="Reset"/> before the checked
+/// run so the holder is established on the originating flow and flows down into the worker.
+/// </remarks>
 public static class TypeNodeStats
 {
+    private sealed class Counters { public long NodeHits; public long StringFallbacks; }
+
+    private static readonly AsyncLocal<Counters?> _current = new();
+
+    private static Counters Current => _current.Value ??= new Counters();
+
     /// <summary>Annotations resolved through the node path.</summary>
-    public static long NodeHits;
+    public static long NodeHits
+    {
+        get => Current.NodeHits;
+        set => Current.NodeHits = value;
+    }
 
     /// <summary>Annotations that had no node (unsupported construct) and used the string path.</summary>
-    public static long StringFallbacks;
+    public static long StringFallbacks
+    {
+        get => Current.StringFallbacks;
+        set => Current.StringFallbacks = value;
+    }
 
-    public static void Reset() { NodeHits = 0; StringFallbacks = 0; }
+    public static void Reset() => _current.Value = new Counters();
 }


### PR DESCRIPTION
## Summary

`TypeNodeSliceTests.NodePath_EngagesForGenericAliasReferences` failed non-deterministically on CI (macOS in [PR #267's run](https://github.com/nickna/SharpTS/actions/runs/27324037764/job/80721167712)) with `Assert.Equal() Failure: Expected 0, Actual 1`. It passes in isolation — this is a **test-isolation race on global state**, not a real type-checker regression. Split out from #267 (the net fix) since it's unrelated code from the type-AST migration (#264).

## Root cause

`TypeNodeStats` exposes two plain mutable statics:

```csharp
public static class TypeNodeStats {
    public static long NodeHits;
    public static long StringFallbacks;
    public static void Reset() { NodeHits = 0; StringFallbacks = 0; }
}
```

The coverage tests do `Reset()` → type-check → `Assert.Equal(0, StringFallbacks)`. xUnit runs test **collections in parallel**, so any *other* concurrently-running test whose type-check takes a string fallback bumps the shared counter in the window between an unrelated test's `Reset()` and its assert → `Expected 0, Actual 1`. Which OS loses the race is pure scheduling luck.

## Fix

Back the counters with `AsyncLocal<T>`. Two constraints have to hold simultaneously:

1. **Cross-thread within a test** — the harness runs the checker inside `Task.Run` (`TestHarness.RunInterpreted`), so increments happen on a pool thread while the test reads on its own thread. `AsyncLocal` flows the same holder across that boundary (the harness already documents/relies on this: *"AsyncLocal flows into Task.Run"*).
2. **Isolation across tests** — concurrent tests are sibling async flows, so they never see each other's holder.

`[ThreadStatic]` satisfies (2) but breaks (1) — I tried it first and it failed 7 `NodeHits` assertions because the checker's pool-thread writes never reached the test thread's reads. A plain static satisfies (1) but breaks (2) — the current bug. `AsyncLocal` is the only option that satisfies both.

## Validation

- `TypeNodeSliceTests`: **19/19**
- Full suite under parallel load: **10758/10758**, exit 0 — the contamination window is closed.