### PR TITLE
Discriminated-union assignability, union property writes, scope-safe alias cache

### DIFF
--- a/SharpTS.Tests/TypeCheckerTests/DiscriminatedUnionAssignabilityTests.cs
+++ b/SharpTS.Tests/TypeCheckerTests/DiscriminatedUnionAssignabilityTests.cs
@@ -1,0 +1,108 @@
+using SharpTS.Tests.Infrastructure;
+using SharpTS.TypeSystem.Exceptions;
+using Xunit;
+
+namespace SharpTS.Tests.TypeCheckerTests;
+
+/// <summary>
+/// Discriminated-union assignability (tsc's typeRelatedToDiscriminatedType, pinned by
+/// assignmentCompatWithDiscriminatedUnion): a source whose discriminant properties are unions
+/// of unit types relates to a union target when every discriminant combination lands on an
+/// assignable constituent.
+/// </summary>
+public class DiscriminatedUnionAssignabilityTests
+{
+    [Fact]
+    public void BooleanDiscriminant_CoversBothConstituents()
+    {
+        // IteratorResult shape: done: boolean splits across done: true / done: false.
+        TestHarness.RunInterpreted("""
+            type S = { done: boolean, value: number };
+            type T = { done: true, value: number } | { done: false, value: number };
+            declare let s: S;
+            declare let t: T;
+            t = s;
+            """);
+    }
+
+    [Fact]
+    public void LiteralUnionDiscriminant_MatchingCombinations_Assignable()
+    {
+        TestHarness.RunInterpreted("""
+            type S = { a: 0 | 2, b: 4 };
+            type T = { a: 0, b: 1 | 4 } | { a: 1, b: 2 } | { a: 2, b: 3 | 4 };
+            declare let s: S;
+            declare let t: T;
+            t = s;
+            """);
+    }
+
+    [Fact]
+    public void UnmatchedCombination_Rejected()
+    {
+        // a=2 lands on { a: 2, b: 3 } whose b rejects 4 — the combination has no home.
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted("""
+            type S = { a: 0 | 2, b: 4 };
+            type T = { a: 0, b: 1 | 4 } | { a: 1, b: 2 | 4 } | { a: 2, b: 3 };
+            declare let s: S;
+            declare let t: T;
+            t = s;
+            """));
+    }
+
+    [Fact]
+    public void MissingNonDiscriminantMember_Rejected()
+    {
+        // a=2 matches { a: 2, b: 3 | 4, c: string } on discriminants but S lacks 'c'.
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted("""
+            type S = { a: 0 | 2, b: 4 };
+            type T = { a: 0, b: 1 | 4 } | { a: 1, b: 2 } | { a: 2, b: 3 | 4, c: string };
+            declare let s: S;
+            declare let t: T;
+            t = s;
+            """));
+    }
+
+    [Fact]
+    public void UnionPropertyWrite_AcceptsUnionOfMemberTypes()
+    {
+        TestHarness.RunInterpreted("""
+            interface ILinearAxis { type: "linear"; }
+            interface ICategoricalAxis { type: "categorical"; }
+            type IAxis = ILinearAxis | ICategoricalAxis;
+            function getAxisType(): "linear" | "categorical" { return "categorical"; }
+            const good: IAxis = { type: "linear" };
+            good.type = getAxisType();
+            """);
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted("""
+            interface ILinearAxis { type: "linear"; }
+            interface ICategoricalAxis { type: "categorical"; }
+            type IAxis = ILinearAxis | ICategoricalAxis;
+            const good: IAxis = { type: "linear" };
+            good.type = "diagonal";
+            """));
+    }
+
+    [Fact]
+    public void SameNamedAliases_InDifferentNamespaces_ExpandIndependently()
+    {
+        // The alias expansion cache must not serve one namespace's T for another's —
+        // the second namespace's t = s is a genuine error.
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted("""
+            namespace First {
+                type S = { a: 0 | 2, b: 4 };
+                type T = { a: 0, b: 1 | 4 } | { a: 1, b: 2 } | { a: 2, b: 3 | 4 };
+                declare let s: S;
+                declare let t: T;
+                t = s;
+            }
+            namespace Second {
+                type S = { a: 0 | 2, b: 4 };
+                type T = { a: 0, b: 1 | 4 } | { a: 1, b: 2 | 4 } | { a: 2, b: 3 };
+                declare let s: S;
+                declare let t: T;
+                t = s;
+            }
+            """));
+    }
+}

--- a/TypeSystem/TypeChecker.Compatibility.DiscriminatedUnion.cs
+++ b/TypeSystem/TypeChecker.Compatibility.DiscriminatedUnion.cs
@@ -1,0 +1,206 @@
+using System.Collections.Frozen;
+
+namespace SharpTS.TypeSystem;
+
+/// <summary>
+/// Discriminated-union assignability — tsc's <c>typeRelatedToDiscriminatedType</c>
+/// (checker.ts): a source whose discriminant properties are unions of unit types can be
+/// assignable to a union target even when it is assignable to NO single constituent, as long
+/// as EVERY combination of its discriminant values lands on an assignable constituent.
+/// `{ done: boolean, value: number }` is assignable to
+/// `{ done: true, value: number } | { done: false, value: number }`.
+/// </summary>
+public partial class TypeChecker
+{
+    /// <summary>tsc caps the discriminant combination space at 25 (Example5 in the pinning test
+    /// EXPECTS the 27-combination case to fail).</summary>
+    private const int MaxDiscriminantCombinations = 25;
+
+    /// <summary>
+    /// True when <paramref name="source"/> (a non-union object-like or tuple) relates to the
+    /// union <paramref name="target"/> through discriminant analysis. Called only after the
+    /// plain some-constituent check has failed.
+    /// </summary>
+    private bool RelatedToDiscriminatedUnion(TypeInfo.Union target, TypeInfo source)
+    {
+        var targetTypes = target.FlattenedTypes;
+
+        if (source is TypeInfo.Tuple sourceTuple)
+            return TupleRelatedToDiscriminatedUnion(targetTypes, sourceTuple);
+
+        var members = NamedMembersWithOptionality(source).ToList();
+        if (members.Count == 0) return false;
+
+        // Discriminant candidates: source properties whose type is a unit (or union of units),
+        // present on EVERY target constituent, with a unit type in at least one of them.
+        List<(string Name, List<TypeInfo> Values)> discriminants = [];
+        foreach (var (name, type, _) in members)
+        {
+            var values = UnitConstituents(type);
+            if (values is null) continue;
+            bool onAll = true, anyUnit = false;
+            foreach (var constituent in targetTypes)
+            {
+                if (GetMemberTypeWithOptionality(constituent, name) is not { } member) { onAll = false; break; }
+                anyUnit |= UnitConstituents(member.Type) is not null;
+            }
+            if (onAll && anyUnit) discriminants.Add((name, values));
+        }
+        if (discriminants.Count == 0) return false;
+
+        long combinations = 1;
+        foreach (var (_, values) in discriminants)
+        {
+            combinations *= values.Count;
+            if (combinations > MaxDiscriminantCombinations) return false;
+        }
+
+        // Walk the cartesian product of discriminant values; each combination must land on a
+        // constituent that (a) accepts every discriminant value and (b) accepts the rest of the
+        // source with its discriminants narrowed to the combination.
+        var indices = new int[discriminants.Count];
+        while (true)
+        {
+            bool matched = false;
+            foreach (var constituent in targetTypes)
+            {
+                bool discriminantsAccepted = true;
+                for (int d = 0; d < discriminants.Count; d++)
+                {
+                    var (name, values) = discriminants[d];
+                    var combinationValue = values[indices[d]];
+                    var member = GetMemberTypeWithOptionality(constituent, name)!.Value;
+                    bool accepted = IsCompatible(member.Type, combinationValue) ||
+                        // An `undefined` discriminant value satisfies an optional member.
+                        (member.IsOptional && combinationValue is TypeInfo.Undefined);
+                    if (!accepted) { discriminantsAccepted = false; break; }
+                }
+                if (!discriminantsAccepted) continue;
+
+                if (IsCompatible(constituent, NarrowedSource(members, discriminants, indices)))
+                {
+                    matched = true;
+                    break;
+                }
+            }
+            if (!matched) return false;
+
+            int next = discriminants.Count - 1;
+            while (next >= 0 && ++indices[next] == discriminants[next].Values.Count)
+            {
+                indices[next] = 0;
+                next--;
+            }
+            if (next < 0) return true; // all combinations matched
+        }
+    }
+
+    /// <summary>The source with its discriminant properties narrowed to one combination.</summary>
+    private static TypeInfo.Record NarrowedSource(
+        List<(string Name, TypeInfo Type, bool IsOptional)> members,
+        List<(string Name, List<TypeInfo> Values)> discriminants,
+        int[] indices)
+    {
+        Dictionary<string, TypeInfo> fields = [];
+        HashSet<string> optionalFields = [];
+        foreach (var (name, type, isOptional) in members)
+        {
+            fields[name] = type;
+            if (isOptional) optionalFields.Add(name);
+        }
+        for (int d = 0; d < discriminants.Count; d++)
+            fields[discriminants[d].Name] = discriminants[d].Values[indices[d]];
+        return new TypeInfo.Record(
+            fields.ToFrozenDictionary(),
+            OptionalFields: optionalFields.Count > 0 ? optionalFields.ToFrozenSet() : null);
+    }
+
+    /// <summary>
+    /// Tuple flavor: discriminant POSITIONS instead of property names
+    /// (`["a" | "b", number]` vs `["a", number] | ["b", number] | ["c", string]`).
+    /// </summary>
+    private bool TupleRelatedToDiscriminatedUnion(IReadOnlyList<TypeInfo> targetTypes, TypeInfo.Tuple source)
+    {
+        if (targetTypes.Any(t => t is not TypeInfo.Tuple)) return false;
+
+        List<(int Position, List<TypeInfo> Values)> discriminants = [];
+        for (int i = 0; i < source.Elements.Count; i++)
+        {
+            var values = UnitConstituents(source.Elements[i].Type);
+            if (values is null || values.Count < 2) continue;
+            bool onAll = targetTypes.All(t => ((TypeInfo.Tuple)t).Elements.Count > i);
+            if (onAll) discriminants.Add((i, values));
+        }
+        if (discriminants.Count == 0) return false;
+
+        long combinations = 1;
+        foreach (var (_, values) in discriminants)
+        {
+            combinations *= values.Count;
+            if (combinations > MaxDiscriminantCombinations) return false;
+        }
+
+        var indices = new int[discriminants.Count];
+        while (true)
+        {
+            bool matched = targetTypes.Any(constituent =>
+                IsCompatible(constituent, NarrowedTuple(source, discriminants, indices)));
+            if (!matched) return false;
+
+            int next = discriminants.Count - 1;
+            while (next >= 0 && ++indices[next] == discriminants[next].Values.Count)
+            {
+                indices[next] = 0;
+                next--;
+            }
+            if (next < 0) return true;
+        }
+    }
+
+    private static TypeInfo.Tuple NarrowedTuple(
+        TypeInfo.Tuple source, List<(int Position, List<TypeInfo> Values)> discriminants, int[] indices)
+    {
+        var elements = new List<TypeInfo.TupleElement>(source.Elements);
+        for (int d = 0; d < discriminants.Count; d++)
+        {
+            var (position, values) = discriminants[d];
+            elements[position] = elements[position] with { Type = values[indices[d]] };
+        }
+        return source with { Elements = elements };
+    }
+
+    /// <summary>
+    /// The unit-type constituents of a discriminant-capable type: literals, undefined/null, with
+    /// `boolean` expanding to <c>true | false</c> (tsc models it as that union). Null when the
+    /// type contains any non-unit constituent (then it cannot discriminate).
+    /// </summary>
+    private static List<TypeInfo>? UnitConstituents(TypeInfo type)
+    {
+        List<TypeInfo> result = [];
+        foreach (var t in type is TypeInfo.Union u ? (IEnumerable<TypeInfo>)u.FlattenedTypes : [type])
+        {
+            switch (t)
+            {
+                case TypeInfo.StringLiteral or TypeInfo.NumberLiteral or TypeInfo.BooleanLiteral
+                    or TypeInfo.Undefined or TypeInfo.Null:
+                    result.Add(t);
+                    break;
+                case TypeInfo.Primitive { Type: Parsing.TokenType.TYPE_BOOLEAN }:
+                    result.Add(new TypeInfo.BooleanLiteral(true));
+                    result.Add(new TypeInfo.BooleanLiteral(false));
+                    break;
+                default:
+                    return null;
+            }
+        }
+        return result;
+    }
+
+    /// <summary>A constituent's member type and optionality, or null when absent.</summary>
+    private (TypeInfo Type, bool IsOptional)? GetMemberTypeWithOptionality(TypeInfo constituent, string name)
+    {
+        foreach (var (memberName, type, isOptional) in NamedMembersWithOptionality(constituent))
+            if (memberName == name) return (type, isOptional);
+        return null;
+    }
+}

--- a/TypeSystem/TypeChecker.Compatibility.cs
+++ b/TypeSystem/TypeChecker.Compatibility.cs
@@ -450,15 +450,20 @@ public partial class TypeChecker
         {
             var expectedTypes = expectedUnion.FlattenedTypes;
             var actualTypes = actualUnion.FlattenedTypes;
+            // Per source constituent: some-target-constituent first, then the discriminated
+            // path (a constituent may relate only through its discriminant combinations).
             return actualTypes.All(actualType =>
-                expectedTypes.Any(expectedType => IsCompatible(expectedType, actualType)));
+                expectedTypes.Any(expectedType => IsCompatible(expectedType, actualType)) ||
+                RelatedToDiscriminatedUnion(expectedUnion, actualType));
         }
 
-        // Union as expected: actual must match at least one member
+        // Union as expected: actual must match at least one member — or relate through the
+        // discriminated-union path (tsc typeRelatedToDiscriminatedType).
         if (expected is TypeInfo.Union expUnion)
         {
             var expTypes = expUnion.FlattenedTypes;
-            return expTypes.Any(t => IsCompatible(t, actual));
+            return expTypes.Any(t => IsCompatible(t, actual)) ||
+                RelatedToDiscriminatedUnion(expUnion, actual);
         }
 
         // Union as actual: all members must be compatible with expected

--- a/TypeSystem/TypeChecker.Properties.cs
+++ b/TypeSystem/TypeChecker.Properties.cs
@@ -649,6 +649,26 @@ public partial class TypeChecker
             }
             return CheckExpr(set.Value);
         }
+        // Property write on a union: every constituent must expose the member, and the value
+        // must be assignable to the union of the constituents' member types. (tsc permits
+        // discriminant-property writes that select a constituent — `axis.type = getAxisType()`
+        // where axis: ILinearAxis | ICategoricalAxis.)
+        if (objType is TypeInfo.Union unionObj)
+        {
+            List<TypeInfo> memberTypes = [];
+            foreach (var constituent in unionObj.FlattenedTypes)
+            {
+                if (constituent is TypeInfo.Any) { memberTypes.Add(constituent); continue; }
+                if (GetMemberTypeWithOptionality(constituent, set.Name.Lexeme) is not { } member)
+                    throw new TypeCheckException($" Property '{set.Name.Lexeme}' does not exist on type '{unionObj}'.", tsCode: "TS2339");
+                memberTypes.Add(member.Type);
+            }
+            var memberUnion = memberTypes.Aggregate(CreateUnion);
+            TypeInfo unionValueType = CheckExpr(set.Value);
+            if (!IsCompatible(memberUnion, unionValueType))
+                throw new TypeCheckException($" Cannot assign '{unionValueType}' to property '{set.Name.Lexeme}' of type '{memberUnion}'.", tsCode: "TS2322");
+            return unionValueType;
+        }
         throw new TypeCheckException("Only instances and objects have properties.", tsCode: "TS2339");
     }
 

--- a/TypeSystem/TypeChecker.TypeParsing.cs
+++ b/TypeSystem/TypeChecker.TypeParsing.cs
@@ -63,9 +63,13 @@ public partial class TypeChecker
         var aliasExpansion = _environment.GetTypeAlias(typeName);
         if (aliasExpansion != null)
         {
-            // Check cache first - reusing the same TypeInfo object enables identity-based caching
+            // Check cache first - reusing the same TypeInfo object enables identity-based caching.
+            // Keyed by name AND definition: two same-named aliases in different scopes (e.g.
+            // namespace-local `type T = …` redeclarations) must not share an expansion — the
+            // name alone served one namespace's T for another's.
+            string aliasCacheKey = $"{typeName}={aliasExpansion}";
             _expandedTypeAliasCache ??= new Dictionary<string, TypeInfo>(StringComparer.Ordinal);
-            if (_expandedTypeAliasCache.TryGetValue(typeName, out var cached))
+            if (_expandedTypeAliasCache.TryGetValue(aliasCacheKey, out var cached))
             {
                 return cached;
             }
@@ -97,7 +101,7 @@ public partial class TypeChecker
                 }
 
                 // Cache the expanded type for future use
-                _expandedTypeAliasCache[typeName] = expanded;
+                _expandedTypeAliasCache[aliasCacheKey] = expanded;
 
                 return expanded;
             }


### PR DESCRIPTION
Conformance round on the discriminated-union cluster (#226). `assignmentCompatWithDiscriminatedUnion`'s diff shrinks **10 extra errors → 1**; the test doesn't flip yet (see "remaining" below) but all the union machinery is now in place and pinned.

## The three mechanisms

**1. `typeRelatedToDiscriminatedType`** (tsc checker.ts): `{ done: boolean, value: number }` is assignable to `{ done: true, value: number } | { done: false, value: number }` even though it matches neither constituent alone. Implementation: find source properties that are units/unions-of-units (`boolean` expands to `true | false`) and discriminate the target; walk the cartesian product of their values (capped at 25, matching tsc — the 27-combination Example5 correctly stays an error); each combination must land on a constituent accepting both the discriminants and the narrowed residual source. Wired into both union-target compat branches, with a tuple flavor for element-position discriminants.

**2. Union property writes**: `axis.type = getAxisType()` on `ILinearAxis | ICategoricalAxis` was TS2339 ("Only instances and objects have properties") — there was no Union case in property-write checking at all. Now: every constituent must expose the member, and the value must be assignable to the union of member types (tsc's discriminant-write rule).

**3. Scope-safe alias expansion cache**: found when Example3's genuine error vanished in the full test but reproduced in isolation — the non-generic alias cache was keyed by **name alone**, so namespace `Example2`'s `type T = …` served its expansion for `Example3`'s different `T`. Same disease class as slice 4's namespace findings, in cache form. The key now includes the definition.

## Remaining (recorded in #226)

The last diff (`GH39357`) needs two genuinely separate features: **contextual tuple typing** for array literals (we have no contextual-type machinery; `[b, 1]` infers `("a" | "b" | "c" | 1)[]`, not a tuple) and **`||`-equality narrowing** (`b === "a" || b === "b"` doesn't narrow `b` in the branch). Parked with findings.

## Validation

- Conformance: **zero bucket drift** (Pass 69 / Fail 8 / ParseError 1 unchanged; the pinned test's internal diff is 10× smaller)
- Unit suite: **10,820 passed, 0 failed** with six new `DiscriminatedUnionAssignabilityTests` pins (boolean/literal discriminants, unmatched combinations, missing members, union writes, cross-namespace alias independence)