### PR TITLE
Fix compiled-mode generic inference (#274) and string-return verification (#275)

### DIFF
--- a/Compilation/ILEmitter.Calls.Constructors.cs
+++ b/Compilation/ILEmitter.Calls.Constructors.cs
@@ -111,12 +111,24 @@ public partial class ILEmitter
     /// </summary>
     private void EmitTypedClassConstruction(TypeBuilder typeBuilder, ConstructorBuilder ctorBuilder, string resolvedClassName, Expr.New n)
     {
+        var genericParams = _ctx.ClassRegistry!.GetGenericParams(resolvedClassName);
+        bool isGeneric = genericParams != null && genericParams.Length > 0;
+
+        // Generic class with inferred type arguments (e.g. `new Box(5)` for `class Box<T>`).
+        // Emitting Newobj against the open generic TypeDef throws TypeLoadException at load
+        // time (ECMA-335 II.9.4 — the open definition is not a loadable type). Infer the
+        // closed type from the constructor arguments before constructing. (#274)
+        if (isGeneric && (n.TypeArgs == null || n.TypeArgs.Count == 0))
+        {
+            EmitInferredGenericClassConstruction(typeBuilder, ctorBuilder, genericParams!, n);
+            return;
+        }
+
         Type targetType = typeBuilder;
         ConstructorInfo targetCtor = ctorBuilder;
 
-        // Handle generic class instantiation (e.g., new Box<number>(42))
-        if (n.TypeArgs != null && n.TypeArgs.Count > 0 &&
-            _ctx.ClassRegistry!.GetGenericParams(resolvedClassName) != null)
+        // Handle generic class instantiation with explicit type arguments (e.g., new Box<number>(42))
+        if (isGeneric && n.TypeArgs != null && n.TypeArgs.Count > 0)
         {
             Type[] typeArgs = n.TypeArgs.Select(ResolveTypeArg).ToArray();
             targetType = typeBuilder.MakeGenericType(typeArgs);
@@ -138,6 +150,94 @@ public partial class ILEmitter
 
         for (int i = n.Arguments.Count; i < expectedParamCount; i++)
             EmitDefaultForType(ctorParams[i].ParameterType);
+
+        IL.Emit(OpCodes.Newobj, targetCtor);
+        SetStackUnknown();
+    }
+
+    /// <summary>
+    /// Constructs a generic class whose type arguments were left to inference
+    /// (e.g. <c>new Box(5)</c> for <c>class Box&lt;T&gt;</c>). Arguments are emitted into
+    /// typed locals so their <em>actual</em> stack types can drive type-argument inference:
+    /// each type parameter that appears directly as a constructor parameter type is bound to
+    /// the corresponding argument's CLR type, and any parameter not pinned by an argument
+    /// falls back to <c>System.Object</c>. The open generic is then closed before <c>Newobj</c>,
+    /// avoiding the <c>TypeLoadException</c> the CLR raises when asked to load the open TypeDef. (#274)
+    ///
+    /// Inferring from observed stack types (rather than predicting them) keeps the closed
+    /// constructor's generic-parameter slots in exact agreement with the emitted values, so no
+    /// per-argument boxing/unboxing fix-ups are needed for those positions.
+    /// </summary>
+    private void EmitInferredGenericClassConstruction(
+        TypeBuilder typeBuilder, ConstructorBuilder ctorBuilder,
+        GenericTypeParameterBuilder[] genericParams, Expr.New n)
+    {
+        var openParams = ctorBuilder.GetParameters();
+
+        // 1. Emit each argument into a typed local, recording its stack type.
+        var argSlots = new List<(LocalBuilder local, Type clrType, StackType stackType)>(n.Arguments.Count);
+        foreach (var arg in n.Arguments)
+        {
+            EmitExpression(arg);
+            StackType st = StackType;
+            Type clr = st switch
+            {
+                StackType.Double => _ctx.Types.Double,
+                StackType.Boolean => _ctx.Types.Boolean,
+                StackType.String => _ctx.Types.String,
+                _ => _ctx.Types.Object
+            };
+            if (clr == _ctx.Types.Object)
+                EmitBoxIfNeeded(arg);
+            var local = IL.DeclareLocal(clr);
+            IL.Emit(OpCodes.Stloc, local);
+            argSlots.Add((local, clr, st));
+        }
+
+        // 2. Bind each type parameter from a constructor parameter that is exactly that
+        //    type parameter (the open ctor's parameter types reference the generic params).
+        var inferred = new Type?[genericParams.Length];
+        for (int p = 0; p < openParams.Length && p < argSlots.Count; p++)
+        {
+            var pt = openParams[p].ParameterType;
+            if (pt.IsGenericParameter && pt.GenericParameterPosition < inferred.Length
+                && inferred[pt.GenericParameterPosition] == null)
+            {
+                inferred[pt.GenericParameterPosition] = argSlots[p].clrType;
+            }
+        }
+
+        // 3. Fill any parameter no argument pinned. Object is the erased-generic default and
+        //    matches the interpreter, which treats unconstrained type parameters as `any`.
+        for (int i = 0; i < inferred.Length; i++)
+            inferred[i] ??= _ctx.Types.Object;
+
+        Type targetType = typeBuilder.MakeGenericType(inferred!);
+        ConstructorInfo targetCtor = EmitterTypeHelpers.ResolveConstructor(targetType, ctorBuilder);
+
+        // 4. Reload arguments. Generic-parameter slots already hold a value whose CLR type
+        //    equals the closed parameter type, so they load as-is; concrete parameters get the
+        //    standard conversion against their (open == closed) parameter type.
+        for (int i = 0; i < openParams.Length; i++)
+        {
+            var pt = openParams[i].ParameterType;
+            if (i < argSlots.Count)
+            {
+                IL.Emit(OpCodes.Ldloc, argSlots[i].local);
+                SetStackType(argSlots[i].stackType);
+                if (!pt.IsGenericParameter)
+                    EmitConversionForParameter(n.Arguments[i], pt);
+            }
+            else if (pt.IsGenericParameter)
+            {
+                // Under-applied generic-typed parameter: default for the closed type.
+                EmitDefaultForType(inferred[pt.GenericParameterPosition]!);
+            }
+            else
+            {
+                EmitDefaultForType(pt);
+            }
+        }
 
         IL.Emit(OpCodes.Newobj, targetCtor);
         SetStackUnknown();

--- a/Compilation/ILEmitter.Statements.cs
+++ b/Compilation/ILEmitter.Statements.cs
@@ -1159,7 +1159,22 @@ public partial class ILEmitter
                     }
                 }
             }
-            // For other types (string, etc.), the value should already be correct
+            else if (returnType == _ctx.Types.String && _stackType != StackType.String)
+            {
+                // Runtime helpers (string concat `a + b`, member get `obj.name`) leave their
+                // result statically typed `object` on the stack even when the value is a string.
+                // A method declared `: string` then has an `object` where the verifier expects a
+                // string, raising StackUnexpected — it still runs because the value really is a
+                // string. Insert a castclass so the stack type matches the return slot; the cast
+                // is a no-op at runtime for an actual string (and passes null through). (#275)
+                //
+                // Other narrow reference return types (typed arrays/maps, classes mapped via
+                // MapTypeInfoStrict) are deliberately NOT cast here: their runtime representations
+                // are dynamic ($Array, TSObject, ...) that are not CLR-assignable to the declared
+                // type, so a castclass there would throw InvalidCastException at runtime.
+                IL.Emit(OpCodes.Castclass, _ctx.Types.String);
+            }
+            // For other types, the value should already be correct
         }
         else
         {

--- a/SharpTS.Tests/CompilerTests/ILVerificationTests.cs
+++ b/SharpTS.Tests/CompilerTests/ILVerificationTests.cs
@@ -181,6 +181,30 @@ public class ILVerificationTests
     }
 
     [Fact]
+    public void FunctionReturningStringConcat_PassesILVerification()
+    {
+        // A `: string` function whose body produces a runtime-helper result (string concat
+        // or member get) previously left an `object` on the stack where the verifier expected
+        // a string, raising StackUnexpected even though it ran correctly. (#275)
+        var source = """
+            function cat(a: string): string { return "hi " + a; }
+            function viaLocal(a: string): string { let r = "x" + a; return r; }
+            function withNumber(a: number): string { return "val=" + a; }
+            interface Named { name: string; }
+            function pick(n: Named): string { return n.name; }
+            console.log(cat("z"));
+            console.log(viaLocal("y"));
+            console.log(withNumber(42));
+            console.log(pick({ name: "w" }));
+            """;
+
+        var (errors, output) = TestHarness.CompileVerifyAndRun(source);
+
+        Assert.Empty(errors);
+        Assert.Equal("hi z\nxy\nval=42\nw\n", output);
+    }
+
+    [Fact]
     public void TryCatchFinally_PassesILVerification()
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/GenericsTests.cs
+++ b/SharpTS.Tests/SharedTests/GenericsTests.cs
@@ -117,6 +117,33 @@ public class GenericsTests
 
     [Theory]
     [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void GenericClass_InferredTypeArguments_Works(ExecutionMode mode)
+    {
+        // `new Box(5)` relies on type-argument inference from the constructor argument.
+        // In compiled mode this previously emitted Newobj against the open generic TypeDef
+        // and threw TypeLoadException at load time. (#274)
+        var source = """
+            class Box<T> {
+                constructor(public v: T) {}
+                get(): T { return this.v; }
+            }
+            console.log(new Box(5).get());
+            console.log(new Box("hello").get());
+            console.log(new Box(true).get());
+
+            class Pair<A, B> {
+                constructor(public a: A, public b: B) {}
+            }
+            let p = new Pair("x", 42);
+            console.log(p.a, p.b);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("5\nhello\ntrue\nx 42\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void GenericClass_WithMethod_Works(ExecutionMode mode)
     {
         var source = """


### PR DESCRIPTION
Two compiled-mode (IL) fixes, each in its own commit with a both-modes/verification regression test.

## #274 — `new Box(5)` (inferred generic type args) throws `TypeLoadException`

Instantiating a generic class **without** explicit type arguments (relying on inference) emitted `Newobj` against the **open** generic TypeDef, which the CLR refuses to load (ECMA-335 II.9.4) → `TypeLoadException: Could not load type 'Box'` at runtime, even though `--verify` passed. Explicit type args (`new Box<number>(5)`) already worked.

**Fix:** `EmitInferredGenericClassConstruction` emits each constructor argument into a typed local, reads its *actual* stack type, and binds each type parameter that appears directly as a constructor parameter to the corresponding argument's CLR type (unbound parameters fall back to `System.Object`, matching the interpreter's erased-generic treatment). The open generic is closed before `Newobj`. Inferring from observed stack types keeps the closed ctor's generic slots in exact agreement with the emitted values, so those positions need no boxing fix-ups.

## #275 — `: string` function doing concat/member-access fails `--verify` with `StackUnexpected`

A function declared `: string` whose body produced a runtime-helper result (string concat `"hi " + a`, or member get `obj.name`) left that result statically typed `object` on the stack, mismatching the `System.String` return slot. It ran correctly (the value really is a string); only the verifier flagged it.

**Fix:** `EmitReturn` now inserts a `castclass System.String` when a string-returning function has a non-string stack type. The cast is a runtime no-op for an actual string and passes null through. Narrow reference return types whose runtime representation is dynamic (typed arrays → `$Array`, etc.) are deliberately **not** cast, since that would throw at runtime — those remain a separate, pre-existing gap (filed as #278).

## Bugs filed while investigating
- **#278** — `: number[]` (and typed `Map`/`Set`) returns fail `--verify`: declared `List<T>`/`Dictionary`/`HashSet` return vs dynamic `$Array`/`TSObject` runtime value. Not safe to fix via `castclass`; needs return-type/representation reconciliation.
- **#279** — generated `<Class>.GetProperty` helper fails `--verify` with `StackUnexpected` (runs correctly).

## Testing
- New regression tests: `GenericsTests.GenericClass_InferredTypeArguments_Works` (both interpreter and compiler), `ILVerificationTests.FunctionReturningStringConcat_PassesILVerification`.
- Full suite green: **10817 passed, 1 skipped, 0 failed**.

Closes #274
Closes #275