### PR TITLE
fix(compile): two ILVerify StackUnexpected gaps — typed-collection returns (#278) and generated GetProperty typed getters (#279)

### DIFF
--- a/Compilation/ILCompiler.Classes.HasFields.cs
+++ b/Compilation/ILCompiler.Classes.HasFields.cs
@@ -299,6 +299,13 @@ public partial class ILCompiler
                 // (instantiated form for generic classes — open MethodDef tokens are unloadable, #178)
                 il.Emit(OpCodes.Ldarg_0);
                 il.Emit(OpCodes.Callvirt, EmitterTypeHelpers.SelfMethodReference(getterMethod));
+                // GetProperty's return slot is object. A typed getter (e.g. `number` → double)
+                // returns a value type, and a generic-class getter returns a type parameter, so box
+                // the result to match the slot. Without this the verifier reports StackUnexpected —
+                // a value-type result reaching an object ret slot — even though it runs (the typed
+                // getter for a parameter property is reachable via the dynamic-dispatch path). (#279)
+                if (getterMethod.ReturnType.IsValueType || getterMethod.ReturnType.IsGenericParameter)
+                    il.Emit(OpCodes.Box, getterMethod.ReturnType);
                 il.Emit(OpCodes.Ret);
 
                 il.MarkLabel(nextLabel);

--- a/Compilation/ParameterTypeResolver.cs
+++ b/Compilation/ParameterTypeResolver.cs
@@ -140,6 +140,17 @@ public static class ParameterTypeResolver
             {
                 baseType = typeof(object);
             }
+
+            // Typed array/map/set returns map to List<T>/Dictionary<,>/HashSet<> (the strict
+            // collection types), but their runtime representation is a dynamic $Array/TSMap/TSSet
+            // carried as object — not CLR-assignable to the declared collection slot. Returning
+            // that value into a List<T> slot raises ILVerify StackUnexpected (and a castclass to
+            // the collection would throw InvalidCastException at runtime). Fall back to object so
+            // the dynamic value is returned directly. (#278)
+            if (typeMapper.IsDynamicRuntimeCollection(baseType))
+            {
+                baseType = typeof(object);
+            }
         }
 
         // Wrap async return types in Task<T>

--- a/Compilation/TypeMapper.cs
+++ b/Compilation/TypeMapper.cs
@@ -295,6 +295,23 @@ public class TypeMapper
         return _types.MakeGenericType(_types.HashSetOpen, elementType);
     }
 
+    /// <summary>
+    /// Reports whether <paramref name="mappedType"/> is one of the CLR collection types that
+    /// <see cref="MapTypeInfoStrict"/> produces for a typed array/map/set
+    /// (<c>List&lt;T&gt;</c>, <c>Dictionary&lt;,&gt;</c>, <c>HashSet&lt;T&gt;</c>). The runtime
+    /// representation of those TypeScript values is a dynamic <c>$Array</c>/<c>TSMap</c>/<c>TSSet</c>
+    /// carried as <see cref="object"/>, not an instance of the declared collection. A declared slot
+    /// of this CLR type (e.g. a method return) is therefore not assignable from the runtime value,
+    /// so callers must fall back to <see cref="object"/>. (#278)
+    /// </summary>
+    public bool IsDynamicRuntimeCollection(Type mappedType)
+    {
+        if (!mappedType.IsGenericType)
+            return false;
+        Type def = mappedType.GetGenericTypeDefinition();
+        return def == _types.ListOpen || def == _types.DictionaryOpen || def == _types.HashSetOpen;
+    }
+
     private Type MapPromiseTypeStrict(TypeInfo.Promise promise)
     {
         Type innerType = MapTypeInfoStrict(promise.ValueType);

--- a/SharpTS.Tests/CompilerTests/ILVerificationTests.cs
+++ b/SharpTS.Tests/CompilerTests/ILVerificationTests.cs
@@ -205,6 +205,33 @@ public class ILVerificationTests
     }
 
     [Fact]
+    public void FunctionReturningTypedCollection_PassesILVerification()
+    {
+        // A function declared `: number[]` (or Map/Set, or async Promise<T[]>) maps its return
+        // slot to List<T>/Dictionary<,>/HashSet<>, but the runtime value is a dynamic
+        // $Array/TSMap/TSSet carried as object — not CLR-assignable to the declared collection.
+        // That left an object on the stack where the verifier expected the collection, raising
+        // StackUnexpected even though it ran correctly. The return type now falls back to object. (#278)
+        var source = """
+            function nums(): number[] { return [1, 2, 3]; }
+            function strs(): string[] { return ["a", "b"]; }
+            function mkMap(): Map<string, number> { const m = new Map<string, number>(); m.set("x", 1); return m; }
+            function mkSet(): Set<number> { const s = new Set<number>(); s.add(5); return s; }
+            class Box { getNums(): number[] { return [7, 8]; } }
+            console.log(nums().length);
+            console.log(strs().join(","));
+            console.log(mkMap().get("x"));
+            console.log(mkSet().has(5));
+            console.log(new Box().getNums().length);
+            """;
+
+        var (errors, output) = TestHarness.CompileVerifyAndRun(source);
+
+        Assert.Empty(errors);
+        Assert.Equal("3\na,b\n1\ntrue\n2\n", output);
+    }
+
+    [Fact]
     public void TryCatchFinally_PassesILVerification()
     {
         var source = """

--- a/SharpTS.Tests/CompilerTests/ILVerificationTests.cs
+++ b/SharpTS.Tests/CompilerTests/ILVerificationTests.cs
@@ -232,6 +232,42 @@ public class ILVerificationTests
     }
 
     [Fact]
+    public void ClassGetPropertyWithTypedGetter_PassesILVerification()
+    {
+        // The compiler-generated GetProperty dispatch helper invokes a typed getter (e.g. the
+        // auto getter for a `public x: number` parameter property, or an explicit `get`) and
+        // returned its value-type result into GetProperty's object slot without boxing — the
+        // verifier reported StackUnexpected even though it ran. Generic-class getters returning a
+        // type parameter had the same gap. The getter result is now boxed. (#279)
+        var source = """
+            class Foo { constructor(public x: number) {} }
+            class Bar {
+                private _v: number = 10;
+                get doubled(): number { return this._v * 2; }
+                get label(): string { return "bar"; }
+                get flag(): boolean { return true; }
+            }
+            class Box<T> {
+                constructor(public item: T) {}
+                get value(): T { return this.item; }
+            }
+            function mkFoo(): Foo { return new Foo(7); }
+            const b = new Bar();
+            console.log(mkFoo().x);
+            console.log(b.doubled);
+            console.log(b.label);
+            console.log(b.flag);
+            console.log(new Box<number>(99).value);
+            console.log(new Box<string>("hi").value);
+            """;
+
+        var (errors, output) = TestHarness.CompileVerifyAndRun(source);
+
+        Assert.Empty(errors);
+        Assert.Equal("7\n20\nbar\ntrue\n99\nhi\n", output);
+    }
+
+    [Fact]
     public void TryCatchFinally_PassesILVerification()
     {
         var source = """


### PR DESCRIPTION
Fixes #278 and #279 — two compiled-mode `--verify` `StackUnexpected` failures where the program ran correctly but the emitted IL had a stack-type mismatch the verifier rejects. Both are in the same family as #275 (declared narrow slot vs. dynamic runtime representation).

## #278 — typed array/map/set returns

A function declared `: number[]` mapped its return slot to `List<double>` (and `Map`/`Set` to `Dictionary<,>`/`HashSet<>`), but those TypeScript values are represented at runtime as dynamic `$Array`/`TSMap`/`TSSet` carried as `object` — not CLR-assignable to the declared collection slot. The return expression then left an `object` where the verifier expected the collection, raising `StackUnexpected`.

A `castclass` to `List<T>` (the #275 approach for `string`) is **not** valid here — the value is a `$Array`, so the cast would throw `InvalidCastException`. Instead, reconcile the declared return type with the runtime representation by falling back to `object`, mirroring the existing `ResolveReturnType` fallbacks for `BigInteger`, `Delegate`, `Nullable<T>`, and `Union_*` structs.

- `TypeMapper.IsDynamicRuntimeCollection` recognizes the `List`/`Dictionary`/`HashSet` mapped types.
- `ParameterTypeResolver.ResolveReturnType` falls back to `object` for them (covers free functions, class methods, and `async Promise<T[]>` via the existing `Task<>` wrap).

## #279 — generated `GetProperty` typed getters

The compiler-generated `GetProperty` dynamic-dispatch helper has a branch that invokes an instance getter and returns its result into `GetProperty`'s `object` slot. A typed getter returns a value type (the auto getter for a `public x: number` parameter property returns `double`; a generic-class getter returns a type parameter), and the branch did `callvirt get_X; ret` with no `box` — so a value-type result reached an `object` ret slot and the verifier reported `StackUnexpected`.

Box the getter result when its return type is a value type or a generic parameter (`box` on a type parameter is valid IL and a no-op for reference `T`s), mirroring the value-type box already present in the backing-field branch directly above. This also closes a previously-unreported generic-class getter case.

## Tests
- Two new `ILVerificationTests` (compile + `--verify` + run) covering array/`Map`/`Set`/class-method collection returns, and parameter-property/explicit/generic-class getters.
- Full suite green: **10825 passed, 1 skipped (pre-existing), 0 failed**.

## Related
While verifying #279 I found that **named getters on class expressions** return `undefined` in compiled mode (the class-expression `GetProperty` emitter never dispatches accessors). That's a separate functional defect, not a verifier gap — filed as #283.