### PR TITLE
Compiled-mode fixes: expando-static inheritance, globalThis value, ReadableStream.from, symbol accessors (#265 #271 #269 #266)

### DIFF
--- a/Compilation/EmittedRuntime.cs
+++ b/Compilation/EmittedRuntime.cs
@@ -389,6 +389,15 @@ public class EmittedRuntime
     // silently vanished.
     public FieldBuilder MathSingletonField { get; set; } = null!;
     /// <summary>
+    /// globalThis/global singleton — a sentinel object referenced from value
+    /// position (`var root = globalThis`) so root/context detection in packages
+    /// like lodash finds a real object instead of null (#271). Dynamic GetProperty/
+    /// GetIndex/SetProperty/SetIndex ref-test against this field and route to
+    /// GlobalThisGetProperty/GlobalThisSetProperty. The syntactic `globalThis.X`
+    /// path is still intercepted at compile time by GlobalThisStaticEmitter.
+    /// </summary>
+    public FieldBuilder GlobalThisSingletonField { get; set; } = null!;
+    /// <summary>
     /// Boolean.prototype singleton — a Dictionary&lt;string, object&gt; that surfaces
     /// when user code does <c>Boolean.prototype[0] = …</c> or
     /// <c>Boolean.prototype.length = …</c>. Read by GetProperty's Type-receiver

--- a/Compilation/EmittedRuntime.cs
+++ b/Compilation/EmittedRuntime.cs
@@ -1603,6 +1603,14 @@ public class EmittedRuntime
     // globalThis methods (ES2020)
     public MethodBuilder GlobalThisGetProperty { get; set; } = null!;
     public MethodBuilder GlobalThisSetProperty { get; set; } = null!;
+
+    // Symbol-keyed class accessor registry (#266). The field holds
+    // Dictionary<Type, Dictionary<object, object[]>>; each object[4] slot is
+    // {instanceGetter, instanceSetter, staticGetter, staticSetter} MethodInfos.
+    public FieldBuilder SymbolAccessorRegistryField { get; set; } = null!;
+    public MethodBuilder RegisterSymbolAccessor { get; set; } = null!;
+    public MethodBuilder FindSymbolGetter { get; set; } = null!;
+    public MethodBuilder FindSymbolSetter { get; set; } = null!;
     public FieldBuilder CachedFetchFunction { get; set; } = null!;
     public FieldBuilder CachedParseIntFunction { get; set; } = null!;
     public FieldBuilder CachedParseFloatFunction { get; set; } = null!;

--- a/Compilation/EmittedRuntime.cs
+++ b/Compilation/EmittedRuntime.cs
@@ -2760,6 +2760,11 @@ public class EmittedRuntime
     public MethodBuilder ReadableStreamCloseStream { get; set; } = null!;
     public MethodBuilder ReadableStreamErrorStream { get; set; } = null!;
     public MethodBuilder ReadableStreamRead { get; set; } = null!;
+    /// <summary>
+    /// Static $ReadableStream.From(object iterable) → object (#269) — eagerly
+    /// drains a guest iterable into a closed readable stream.
+    /// </summary>
+    public MethodBuilder ReadableStreamFrom { get; set; } = null!;
     public TypeBuilder ReadableStreamDefaultControllerType { get; set; } = null!;
     public TypeBuilder ReadableStreamDefaultReaderType { get; set; } = null!;
     public ConstructorBuilder ReadableStreamDefaultReaderCtor { get; set; } = null!;

--- a/Compilation/Emitters/GlobalThisStaticEmitter.cs
+++ b/Compilation/Emitters/GlobalThisStaticEmitter.cs
@@ -66,12 +66,14 @@ public sealed class GlobalThisStaticEmitter : IStaticTypeEmitterStrategy
         var ctx = emitter.Context;
         var il = ctx.IL;
 
-        // Self-reference: globalThis.globalThis
-        if (propertyName == "globalThis")
+        // Self-reference: globalThis.globalThis (and the Node alias global).
+        // Emit the runtime sentinel so the leaf access matches bare `globalThis`
+        // in value position — `globalThis.globalThis === globalThis` (#271).
+        // Deeper chains (globalThis.globalThis.Math.PI) are intercepted earlier by
+        // TryEmitGlobalThisChainedProperty, so this only fires for the leaf.
+        if (propertyName == "globalThis" || propertyName == "global")
         {
-            // Push null as a marker - globalThis is handled specially in property access chains
-            // When we see globalThis.globalThis.Math, the outer globalThis gets the same treatment
-            il.Emit(OpCodes.Ldnull);
+            il.Emit(OpCodes.Ldsfld, ctx.Runtime!.GlobalThisSingletonField);
             return true;
         }
 

--- a/Compilation/Emitters/ReadableStreamStaticEmitter.cs
+++ b/Compilation/Emitters/ReadableStreamStaticEmitter.cs
@@ -1,0 +1,44 @@
+using System.Reflection.Emit;
+using SharpTS.Parsing;
+
+namespace SharpTS.Compilation.Emitters;
+
+/// <summary>
+/// Emitter strategy for ReadableStream static method calls (#269). Currently
+/// only <c>ReadableStream.from(iterable)</c>, which eagerly drains a guest
+/// iterable into a closed readable stream via $ReadableStream.From. The
+/// interpreter's equivalent lives in SharpTSWebStreamsConstructors.
+/// </summary>
+public sealed class ReadableStreamStaticEmitter : IStaticTypeEmitterStrategy
+{
+    public bool TryEmitStaticCall(IEmitterContext emitter, string methodName, List<Expr> arguments)
+    {
+        var ctx = emitter.Context;
+        var il = ctx.IL;
+
+        switch (methodName)
+        {
+            case "from":
+                // ReadableStream.from(iterable) → $ReadableStream.From(iterable)
+                if (arguments.Count > 0)
+                {
+                    emitter.EmitExpression(arguments[0]);
+                    emitter.EmitBoxIfNeeded(arguments[0]);
+                }
+                else
+                {
+                    il.Emit(OpCodes.Ldnull);
+                }
+                il.Emit(OpCodes.Call, ctx.Runtime!.ReadableStreamFrom);
+                return true;
+
+            default:
+                return false;
+        }
+    }
+
+    public bool TryEmitStaticPropertyGet(IEmitterContext emitter, string propertyName)
+    {
+        return false;
+    }
+}

--- a/Compilation/ExpressionEmitterBase.CallHelpers.cs
+++ b/Compilation/ExpressionEmitterBase.CallHelpers.cs
@@ -815,10 +815,10 @@ public abstract partial class ExpressionEmitterBase
     /// lodash/core-js global-detection idiom: <c>Function('return this')()</c>.
     /// The Function constructor isn't supported in either mode, but this probe
     /// just means "give me globalThis". Compiled mode represents globalThis in
-    /// value position as null (see EmitVariable), so emit the same null —
-    /// packages probing via <c>freeGlobal || freeSelf || Function('return this')()</c>
-    /// keep their pre-#260 fallback behavior instead of hitting the
-    /// non-callable TypeError (the Function constructor result isn't callable).
+    /// value position as the runtime sentinel (#271, see EmitVariable), so emit
+    /// the same value — packages probing via
+    /// <c>freeGlobal || freeSelf || Function('return this')()</c> get a real
+    /// root object whose <c>.Object</c>/<c>.Math</c> resolve to real constructors.
     /// </summary>
     protected bool TryEmitFunctionReturnThisIdiom(Expr.Call c)
     {
@@ -829,7 +829,7 @@ public abstract partial class ExpressionEmitterBase
             && inner.Arguments[0] is Expr.Literal { Value: string body }
             && body.Trim() == "return this")
         {
-            IL.Emit(OpCodes.Ldnull);
+            IL.Emit(OpCodes.Ldsfld, Ctx.Runtime!.GlobalThisSingletonField);
             SetStackUnknown();
             return true;
         }

--- a/Compilation/ILCompiler.Classes.Accessors.cs
+++ b/Compilation/ILCompiler.Classes.Accessors.cs
@@ -10,24 +10,53 @@ namespace SharpTS.Compilation;
 public partial class ILCompiler
 {
     /// <summary>
-    /// Computed accessor names with non-literal keys (e.g. <c>static get [Symbol.species]()</c>)
-    /// have no static .NET member name to emit. The interpreter supports them; compiled
-    /// mode does not yet (#266) — fail loudly rather than emitting a broken
-    /// property literally named "&lt;computed&gt;". Literal keys (<c>get ["foo"]()</c>)
-    /// are folded to ordinary names by the parser and never reach this check.
+    /// Pre-defines a synthetic method for a symbol-keyed computed accessor (#266),
+    /// e.g. <c>static get [Symbol.species]()</c>. The method has no spec-visible
+    /// name; it is invoked reflectively via the runtime symbol-accessor registry.
+    /// Recorded in <see cref="ClassState.SymbolAccessors"/> for body emission and
+    /// for registration in the class .cctor.
     /// </summary>
-    private static void RejectComputedAccessor(Stmt.Accessor accessor)
+    private void DefineSymbolAccessorMethod(TypeBuilder typeBuilder, Stmt.Accessor accessor)
     {
-        if (accessor.ComputedKey != null)
+        string className = typeBuilder.Name;
+        if (!_classes.SymbolAccessors.TryGetValue(className, out var list))
         {
-            throw new Diagnostics.Exceptions.CompileException(
-                $"Accessors with computed names (line {accessor.Name.Line}) are not supported in compiled mode yet.");
+            list = [];
+            _classes.SymbolAccessors[className] = list;
+        }
+
+        bool isGetter = accessor.Kind.Type == TokenType.GET;
+        // Non-virtual instance methods so MethodBase.Invoke targets exactly the
+        // registered method; inheritance is handled by the registry's base-chain walk.
+        MethodAttributes attrs = MethodAttributes.Public | MethodAttributes.HideBySig;
+        if (accessor.IsStatic) attrs |= MethodAttributes.Static;
+        Type[] paramTypes = isGetter ? [] : [typeof(object)];
+
+        var methodBuilder = typeBuilder.DefineMethod(
+            $"$sym_{(isGetter ? "get" : "set")}_{list.Count}",
+            attrs,
+            typeof(object),
+            paramTypes);
+
+        list.Add((accessor, methodBuilder));
+    }
+
+    /// <summary>
+    /// Emits bodies for the symbol-keyed accessors recorded by
+    /// <see cref="DefineSymbolAccessorMethod"/> for this class.
+    /// </summary>
+    private void EmitSymbolAccessors(TypeBuilder typeBuilder, FieldInfo fieldsField)
+    {
+        if (!_classes.SymbolAccessors.TryGetValue(typeBuilder.Name, out var list))
+            return;
+        foreach (var (accessor, methodBuilder) in list)
+        {
+            EmitAccessorBody(typeBuilder, accessor, methodBuilder, fieldsField);
         }
     }
 
     private void EmitAccessor(TypeBuilder typeBuilder, Stmt.Accessor accessor, FieldInfo fieldsField)
     {
-        RejectComputedAccessor(accessor);
         // Use PascalCase naming convention: get_<PascalPropertyName> or set_<PascalPropertyName>
         string pascalName = NamingConventions.ToPascalCase(accessor.Name.Lexeme);
         string methodName = accessor.Kind.Type == TokenType.GET
@@ -110,6 +139,18 @@ public partial class ILCompiler
                 }
             }
         }
+
+        EmitAccessorBody(typeBuilder, accessor, methodBuilder, fieldsField);
+    }
+
+    /// <summary>
+    /// Emits decorators (if any) and the IL body for a resolved accessor method.
+    /// Shared by the string-named accessor path (<see cref="EmitAccessor"/>) and the
+    /// symbol-keyed computed accessor path (<see cref="EmitSymbolAccessors"/>).
+    /// </summary>
+    private void EmitAccessorBody(TypeBuilder typeBuilder, Stmt.Accessor accessor, MethodBuilder methodBuilder, FieldInfo fieldsField)
+    {
+        string className = typeBuilder.Name;
 
         // Apply accessor-level decorators as .NET attributes
         if (_decoratorMode != DecoratorMode.None)

--- a/Compilation/ILCompiler.Classes.ClassExpressions.cs
+++ b/Compilation/ILCompiler.Classes.ClassExpressions.cs
@@ -338,7 +338,14 @@ public partial class ILCompiler
         {
             foreach (var accessor in classExpr.Accessors)
             {
-                RejectComputedAccessor(accessor);
+                // Symbol-keyed accessors are supported on class *declarations* (#266)
+                // but not yet on class *expressions* (separate emission path with no
+                // .cctor registration hook) — tracked by #281.
+                if (accessor.ComputedKey != null)
+                {
+                    throw new Diagnostics.Exceptions.CompileException(
+                        $"Symbol-keyed computed accessors (line {accessor.Name.Line}) are not yet supported on class expressions in compiled mode (#281).");
+                }
                 string accessorName = accessor.Name.Lexeme;
                 string pascalName = NamingConventions.ToPascalCase(accessorName);
                 string methodName = accessor.Kind.Type == TokenType.GET

--- a/Compilation/ILCompiler.Classes.Methods.cs
+++ b/Compilation/ILCompiler.Classes.Methods.cs
@@ -444,7 +444,14 @@ public partial class ILCompiler
 
             foreach (var accessor in classStmt.Accessors)
             {
-                RejectComputedAccessor(accessor);
+                // Symbol-keyed computed accessors (#266) have no static .NET member
+                // name; pre-define a synthetic method here, register it in the class
+                // .cctor, and dispatch through the runtime symbol-accessor registry.
+                if (accessor.ComputedKey != null)
+                {
+                    DefineSymbolAccessorMethod(typeBuilder, accessor);
+                    continue;
+                }
                 string accessorName = accessor.Name.Lexeme;
                 string pascalName = NamingConventions.ToPascalCase(accessorName);
                 string methodName = accessor.Kind.Type == TokenType.GET
@@ -670,8 +677,12 @@ public partial class ILCompiler
         {
             foreach (var accessor in classStmt.Accessors)
             {
+                // Symbol-keyed computed accessors (#266) are emitted together below
+                // (their bodies live on synthetic methods pre-defined in Pass 1).
+                if (accessor.ComputedKey != null) continue;
                 EmitAccessor(typeBuilder, accessor, fieldsField);
             }
+            EmitSymbolAccessors(typeBuilder, fieldsField);
         }
 
         // Emit ES2022 private method bodies

--- a/Compilation/ILCompiler.Classes.Static.cs
+++ b/Compilation/ILCompiler.Classes.Static.cs
@@ -49,9 +49,11 @@ public partial class ILCompiler
         bool hasPrivateFieldStorage = _classes.PrivateFieldStorage.ContainsKey(qualifiedClassName);
         bool hasStaticPrivateFields = _classes.StaticPrivateFields.TryGetValue(qualifiedClassName, out var staticPrivateFields) && staticPrivateFields.Count > 0;
         bool hasStaticInitializers = classStmt.StaticInitializers != null && classStmt.StaticInitializers.Count > 0;
+        // Symbol-keyed computed accessors (#266) register in the .cctor.
+        bool hasSymbolAccessors = _classes.SymbolAccessors.ContainsKey(typeBuilder.Name);
 
-        // Only emit if there are static fields with initializers, static lock fields, private field storage, static auto-accessors, or static blocks
-        if (staticFieldsWithInit.Count == 0 && !hasStaticLockFields && !hasPrivateFieldStorage && !hasStaticPrivateFields && staticAutoAccessorsWithInit.Count == 0 && !hasStaticInitializers) return;
+        // Only emit if there are static fields with initializers, static lock fields, private field storage, static auto-accessors, static blocks, or symbol accessors
+        if (staticFieldsWithInit.Count == 0 && !hasStaticLockFields && !hasPrivateFieldStorage && !hasStaticPrivateFields && staticAutoAccessorsWithInit.Count == 0 && !hasStaticInitializers && !hasSymbolAccessors) return;
 
         var cctor = typeBuilder.DefineConstructor(
             MethodAttributes.Static | MethodAttributes.Private | MethodAttributes.SpecialName | MethodAttributes.RTSpecialName,
@@ -236,7 +238,63 @@ public partial class ILCompiler
             EmitAutoAccessorInitializer(emitter, autoAccessor, qualifiedClassName, isStatic: true);
         }
 
+        // Register symbol-keyed computed accessors (#266) in the runtime registry,
+        // keyed by this class's Type so dynamic bracket get/set can dispatch them.
+        EmitSymbolAccessorRegistrations(emitter, il, typeBuilder);
+
         il.Emit(OpCodes.Ret);
+    }
+
+    /// <summary>
+    /// Emits <c>$Runtime.RegisterSymbolAccessor(typeof(ThisClass), symbol, getter, setter, isStatic)</c>
+    /// for each symbol-keyed accessor recorded for this class (#266).
+    /// </summary>
+    private void EmitSymbolAccessorRegistrations(ILEmitter emitter, ILGenerator il, TypeBuilder typeBuilder)
+    {
+        if (!_classes.SymbolAccessors.TryGetValue(typeBuilder.Name, out var list))
+            return;
+
+        var getTypeFromHandle = _types.GetMethod(_types.Type, "GetTypeFromHandle", _types.RuntimeTypeHandle);
+        var getMethodFromHandle = _types.MethodBase.GetMethod(
+            "GetMethodFromHandle", [_types.RuntimeMethodHandle, _types.RuntimeTypeHandle])!;
+
+        foreach (var (accessor, method) in list)
+        {
+            bool isGetter = accessor.Kind.Type == TokenType.GET;
+
+            // owner: typeof(ThisClass)
+            il.Emit(OpCodes.Ldtoken, typeBuilder);
+            il.Emit(OpCodes.Call, getTypeFromHandle);
+
+            // symbol: evaluate the computed key expression
+            emitter.EmitExpression(accessor.ComputedKey!);
+            emitter.EmitBoxIfNeeded(accessor.ComputedKey!);
+
+            // getter MethodInfo (or null)
+            if (isGetter)
+                EmitMethodInfoLiteral(il, method, typeBuilder, getMethodFromHandle);
+            else
+                il.Emit(OpCodes.Ldnull);
+
+            // setter MethodInfo (or null)
+            if (isGetter)
+                il.Emit(OpCodes.Ldnull);
+            else
+                EmitMethodInfoLiteral(il, method, typeBuilder, getMethodFromHandle);
+
+            // isStatic
+            il.Emit(accessor.IsStatic ? OpCodes.Ldc_I4_1 : OpCodes.Ldc_I4_0);
+
+            il.Emit(OpCodes.Call, _runtime.RegisterSymbolAccessor);
+        }
+    }
+
+    private void EmitMethodInfoLiteral(ILGenerator il, MethodBuilder method, TypeBuilder declaringType, MethodInfo getMethodFromHandle)
+    {
+        il.Emit(OpCodes.Ldtoken, method);
+        il.Emit(OpCodes.Ldtoken, declaringType);
+        il.Emit(OpCodes.Call, getMethodFromHandle);
+        il.Emit(OpCodes.Castclass, _types.MethodInfo);
     }
 
     private void EmitStaticMethodBody(string className, Stmt.Function method)

--- a/Compilation/ILCompiler.State.cs
+++ b/Compilation/ILCompiler.State.cs
@@ -51,6 +51,10 @@ public partial class ILCompiler
         public Dictionary<string, Dictionary<string, MethodBuilder>> StaticSetters { get; } = [];
         public Dictionary<string, Dictionary<string, MethodBuilder>> PreDefinedMethods { get; } = [];
         public Dictionary<string, Dictionary<string, MethodBuilder>> PreDefinedAccessors { get; } = [];
+        // Symbol-keyed computed accessors (#266): class name (typeBuilder.Name) ->
+        // list of (accessor AST node, emitted getter/setter MethodBuilder). Used to
+        // emit the bodies and to register them in the class .cctor.
+        public Dictionary<string, List<(Parsing.Stmt.Accessor Accessor, MethodBuilder Method)>> SymbolAccessors { get; } = [];
         public Dictionary<string, FieldBuilder> InstanceFieldsField { get; } = [];
         public Dictionary<string, GenericTypeParameterBuilder[]> GenericParams { get; } = [];
 

--- a/Compilation/ILCompiler.cs
+++ b/Compilation/ILCompiler.cs
@@ -811,6 +811,7 @@ public partial class ILCompiler
         _typeEmitterRegistry.RegisterStatic("Response", new ResponseStaticEmitter());
         _typeEmitterRegistry.RegisterStatic("Iterator", new IteratorStaticEmitter());
         _typeEmitterRegistry.RegisterStatic("RegExp", new RegExpStaticEmitter());
+        _typeEmitterRegistry.RegisterStatic("ReadableStream", new ReadableStreamStaticEmitter());
 
         // Built-in module emitters
         _builtInModuleEmitterRegistry.Register(new OsModuleEmitter());

--- a/Compilation/ILEmitter.Expressions.cs
+++ b/Compilation/ILEmitter.Expressions.cs
@@ -102,18 +102,15 @@ public partial class ILEmitter
             return;
         }
 
-        if (name == "globalThis")
+        // globalThis / global (a Node alias) in value position resolve to the
+        // runtime sentinel (#271) so `var root = globalThis || global` is a real
+        // object whose dynamic GetProperty routes to GlobalThisGetProperty —
+        // lodash's runInContext reads `context.Object`/`context.Math` off it.
+        // The syntactic `globalThis.X` path is still intercepted at compile time.
+        if (name == "globalThis" || name == "global")
         {
-            EmitNullConstant(); // globalThis is handled specially in property access
-            return;
-        }
-
-        // `global` is a Node.js alias for globalThis. Mirror globalThis resolution so CJS
-        // packages (lodash) that sniff for `typeof global === 'object'` to find their
-        // ambient scope don't crash.
-        if (name == "global")
-        {
-            EmitNullConstant();
+            IL.Emit(OpCodes.Ldsfld, _ctx.Runtime!.GlobalThisSingletonField);
+            SetStackUnknown();
             return;
         }
 

--- a/Compilation/RuntimeEmitter.GlobalThis.cs
+++ b/Compilation/RuntimeEmitter.GlobalThis.cs
@@ -54,17 +54,15 @@ public partial class RuntimeEmitter
     /// </summary>
     private void EmitGlobalThisGetProperty(TypeBuilder typeBuilder, EmittedRuntime runtime)
     {
-        var method = typeBuilder.DefineMethod(
-            "GlobalThisGetProperty",
-            MethodAttributes.Public | MethodAttributes.Static,
-            _types.Object,
-            [_types.String]
-        );
-        runtime.GlobalThisGetProperty = method;
+        // Signature forward-declared by DefineRuntimeClassPhase1 (#271) so the
+        // property/index dispatchers emitted earlier can call it.
+        var method = (MethodBuilder)runtime.GlobalThisGetProperty;
 
         var il = method.GetILGenerator();
 
         var selfRefLabel = il.DefineLabel();
+        var globalThisRefLabel = il.DefineLabel();
+        var nullMarkerLabel = il.DefineLabel();
         var undefinedPropLabel = il.DefineLabel();
         var nanLabel = il.DefineLabel();
         var infinityLabel = il.DefineLabel();
@@ -91,11 +89,18 @@ public partial class RuntimeEmitter
 
         il.MarkLabel(checkBuiltInsLabel);
 
-        // Check for "globalThis" (self-reference)
+        // Check for "globalThis" / "global" (self-reference and Node alias) —
+        // value-form `globalThis.globalThis` / `globalThis.global` must return the
+        // sentinel so the identity `globalThis.globalThis === globalThis` holds and
+        // `freeSelf`-style probes keep a real object (#271).
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ldstr, "globalThis");
         il.Emit(OpCodes.Call, _types.GetMethod(_types.String, "op_Equality", _types.String, _types.String));
-        il.Emit(OpCodes.Brtrue, selfRefLabel);
+        il.Emit(OpCodes.Brtrue, globalThisRefLabel);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldstr, "global");
+        il.Emit(OpCodes.Call, _types.GetMethod(_types.String, "op_Equality", _types.String, _types.String));
+        il.Emit(OpCodes.Brtrue, globalThisRefLabel);
 
         // Check for "undefined"
         il.Emit(OpCodes.Ldarg_0);
@@ -210,28 +215,59 @@ public partial class RuntimeEmitter
         // GetProperty's Type branch.
         EmitTypeBranch("Symbol", runtime.TSSymbolType);
 
-        // Remaining named namespaces (Math, JSON, console, Error, Reflect,
-        // process) are represented as singletons in the runtime rather
-        // than .NET Type instances. Keep the null-marker behavior for those —
-        // compile-time static dispatch already routes through their dedicated
-        // namespace emitters.
-        string[] singletonNamespaces =
-        [
-            "Math", "JSON", "console", "Error", "Reflect", "process"
-        ];
-        foreach (var ns in singletonNamespaces)
+        // Error and the native-error subclasses are constructor functions; expose
+        // their .NET Type tokens so value-form `root.Error` / `root.TypeError`
+        // resolve to the real constructors (lodash's runInContext reads
+        // `context.Error` and `context.TypeError`). #271.
+        EmitTypeBranch("Error", runtime.TSErrorType);
+        EmitTypeBranch("TypeError", runtime.TSTypeErrorType);
+        EmitTypeBranch("RangeError", runtime.TSRangeErrorType);
+        EmitTypeBranch("ReferenceError", runtime.TSReferenceErrorType);
+        EmitTypeBranch("SyntaxError", runtime.TSSyntaxErrorType);
+        EmitTypeBranch("URIError", runtime.TSURIErrorType);
+        EmitTypeBranch("EvalError", runtime.TSEvalErrorType);
+        EmitTypeBranch("AggregateError", runtime.TSAggregateErrorType);
+
+        // Math / JSON are extensible singleton objects in the runtime — return the
+        // real Dictionary singletons so `root.Math`/`root.JSON` are usable values
+        // (un-degrades lodash's native Math bindings inside runInContext). #271.
+        void EmitSingletonBranch(string name, FieldBuilder field)
+        {
+            var notThisName = il.DefineLabel();
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldstr, name);
+            il.Emit(OpCodes.Call, strEquals);
+            il.Emit(OpCodes.Brfalse, notThisName);
+            il.Emit(OpCodes.Ldsfld, field);
+            il.Emit(OpCodes.Br, returnLabel);
+            il.MarkLabel(notThisName);
+        }
+        EmitSingletonBranch("Math", runtime.MathSingletonField);
+        EmitSingletonBranch("JSON", runtime.JsonSingletonField);
+
+        // console / Reflect / process have no value-form singleton representation;
+        // keep the historical null marker so syntactic dispatch (which fires before
+        // this value-form path) stays authoritative for them.
+        string[] nullMarkerNamespaces = ["console", "Reflect", "process"];
+        foreach (var ns in nullMarkerNamespaces)
         {
             il.Emit(OpCodes.Ldarg_0);
             il.Emit(OpCodes.Ldstr, ns);
             il.Emit(OpCodes.Call, strEquals);
-            il.Emit(OpCodes.Brtrue, selfRefLabel); // null marker
+            il.Emit(OpCodes.Brtrue, nullMarkerLabel);
         }
 
         // Default: return undefined
         il.Emit(OpCodes.Ldsfld, runtime.UndefinedInstance);
         il.Emit(OpCodes.Br, returnLabel);
 
-        // Self-reference: return null (marker for globalThis in property access chains)
+        // globalThis / global self-reference → the runtime sentinel (#271).
+        il.MarkLabel(globalThisRefLabel);
+        il.Emit(OpCodes.Ldsfld, runtime.GlobalThisSingletonField);
+        il.Emit(OpCodes.Br, returnLabel);
+
+        // Null marker for namespaces whose value-form access stays null (legacy).
+        il.MarkLabel(nullMarkerLabel);
         il.MarkLabel(selfRefLabel);
         il.Emit(OpCodes.Ldnull);
         il.Emit(OpCodes.Br, returnLabel);
@@ -323,13 +359,8 @@ public partial class RuntimeEmitter
     /// </summary>
     private void EmitGlobalThisSetProperty(TypeBuilder typeBuilder, EmittedRuntime runtime)
     {
-        var method = typeBuilder.DefineMethod(
-            "GlobalThisSetProperty",
-            MethodAttributes.Public | MethodAttributes.Static,
-            _types.Void,
-            [_types.String, _types.Object]
-        );
-        runtime.GlobalThisSetProperty = method;
+        // Signature forward-declared by DefineRuntimeClassPhase1 (#271).
+        var method = (MethodBuilder)runtime.GlobalThisSetProperty;
 
         var il = method.GetILGenerator();
 

--- a/Compilation/RuntimeEmitter.Objects.Index.cs
+++ b/Compilation/RuntimeEmitter.Objects.Index.cs
@@ -43,6 +43,20 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Call, runtime.IsSymbolMethod);
         il.Emit(OpCodes.Brtrue, symbolKeyLabel);
 
+        // globalThis/global sentinel (#271): `root[stringKey]` resolves through
+        // GlobalThisGetProperty (the index is coerced to a property-key string),
+        // mirroring the value-position GetProperty routing. Symbol keys are handled
+        // above by the per-object symbol-dict path.
+        var notGlobalThisIdxLabel = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldsfld, runtime.GlobalThisSingletonField);
+        il.Emit(OpCodes.Bne_Un, notGlobalThisIdxLabel);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Call, runtime.ToJsString);
+        il.Emit(OpCodes.Call, runtime.GlobalThisGetProperty);
+        il.Emit(OpCodes.Ret);
+        il.MarkLabel(notGlobalThisIdxLabel);
+
         // $Buffer (check before TypedArray — the emitted IsTypedArray helper
         // excludes $Buffer, and GetTypedArrayElement would throw for it).
         if (_features.UsesBuffer)
@@ -733,6 +747,20 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldarg_1);
         il.Emit(OpCodes.Call, runtime.IsSymbolMethod);
         il.Emit(OpCodes.Brtrue, symbolKeyLabel);
+
+        // globalThis/global sentinel (#271): `root[stringKey] = v` stores into the
+        // shared global-properties dictionary. Symbol keys fall through to the
+        // per-object symbol-dict path above.
+        var notGlobalThisIdxSetLabel = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldsfld, runtime.GlobalThisSingletonField);
+        il.Emit(OpCodes.Bne_Un, notGlobalThisIdxSetLabel);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Call, runtime.ToJsString);
+        il.Emit(OpCodes.Ldarg_2);
+        il.Emit(OpCodes.Call, runtime.GlobalThisSetProperty);
+        il.Emit(OpCodes.Ret);
+        il.MarkLabel(notGlobalThisIdxSetLabel);
 
         // $Buffer (check before TypedArray — IsTypedArray excludes $Buffer).
         if (_features.UsesBuffer)

--- a/Compilation/RuntimeEmitter.Objects.Index.cs
+++ b/Compilation/RuntimeEmitter.Objects.Index.cs
@@ -232,6 +232,44 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ret);
         il.MarkLabel(notJsonSingletonTagLabel);
 
+        // #265: symbol-keyed expando statics set on a base class constructor are
+        // readable through subclasses (`Base[Symbol.x] = v` visible as `Sub[Symbol.x]`).
+        // The per-object symbol dict is keyed by Type identity per-class, so walk the
+        // constructor's .NET base-type chain (D.BaseType === C) until a dict carries
+        // the key, mirroring the string-keyed walk in GetProperty's Type handler.
+        {
+            var notTypeForSymbolLabel = il.DefineLabel();
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Isinst, _types.Type);
+            il.Emit(OpCodes.Brfalse, notTypeForSymbolLabel);
+            var symWalkType = il.DeclareLocal(_types.Type);
+            var symWalkDict = il.DeclareLocal(_types.DictionaryObjectObject);
+            var symWalkVal = il.DeclareLocal(_types.Object);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Castclass, _types.Type);
+            il.Emit(OpCodes.Stloc, symWalkType);
+            var symWalkLoop = il.DefineLabel();
+            il.MarkLabel(symWalkLoop);
+            // symWalkType = symWalkType.BaseType;  (null terminates the chain)
+            il.Emit(OpCodes.Ldloc, symWalkType);
+            il.Emit(OpCodes.Callvirt, _types.GetProperty(_types.Type, "BaseType").GetGetMethod()!);
+            il.Emit(OpCodes.Stloc, symWalkType);
+            il.Emit(OpCodes.Ldloc, symWalkType);
+            il.Emit(OpCodes.Brfalse, notTypeForSymbolLabel);
+            // if (GetSymbolDict(symWalkType).TryGetValue(index, out val)) return val;
+            il.Emit(OpCodes.Ldloc, symWalkType);
+            il.Emit(OpCodes.Call, runtime.GetSymbolDictMethod);
+            il.Emit(OpCodes.Stloc, symWalkDict);
+            il.Emit(OpCodes.Ldloc, symWalkDict);
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Ldloca, symWalkVal);
+            il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.DictionaryObjectObject, "TryGetValue"));
+            il.Emit(OpCodes.Brfalse, symWalkLoop);
+            il.Emit(OpCodes.Ldloc, symWalkVal);
+            il.Emit(OpCodes.Ret);
+            il.MarkLabel(notTypeForSymbolLabel);
+        }
+
         // Return undefined for missing symbol properties (JavaScript semantics)
         il.Emit(OpCodes.Ldsfld, runtime.UndefinedInstance);
         il.Emit(OpCodes.Ret);

--- a/Compilation/RuntimeEmitter.Objects.Index.cs
+++ b/Compilation/RuntimeEmitter.Objects.Index.cs
@@ -175,6 +175,30 @@ public partial class RuntimeEmitter
         var symbolFoundLabel = il.DefineLabel();
         il.Emit(OpCodes.Brtrue, symbolFoundLabel);
 
+        // #266: symbol-keyed class accessor (`get [Symbol.x]() {...}`). After an
+        // own symbol data property misses, consult the per-class accessor registry
+        // (walking the base chain). A found getter is a MethodInfo invoked with the
+        // receiver — instance getters bind `this`, static getters ignore it.
+        {
+            var noSymGetterLabel = il.DefineLabel();
+            var symGetterLocal = il.DeclareLocal(_types.Object);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Call, runtime.FindSymbolGetter);
+            il.Emit(OpCodes.Stloc, symGetterLocal);
+            il.Emit(OpCodes.Ldloc, symGetterLocal);
+            il.Emit(OpCodes.Brfalse, noSymGetterLabel);
+            // return ((MethodBase)getter).Invoke(obj, Array.Empty<object>());
+            il.Emit(OpCodes.Ldloc, symGetterLocal);
+            il.Emit(OpCodes.Castclass, _types.MethodBase);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldc_I4_0);
+            il.Emit(OpCodes.Newarr, _types.Object);
+            il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.MethodBase, "Invoke", _types.Object, _types.ObjectArray));
+            il.Emit(OpCodes.Ret);
+            il.MarkLabel(noSymGetterLabel);
+        }
+
         // Not found in user-set symbol dict — fall back to prototype-keyed
         // well-known-symbol dispatch. Currently only RegExp.prototype carries
         // symbol-keyed methods (@@match/@@matchAll/@@replace/@@search/@@split,
@@ -880,6 +904,33 @@ public partial class RuntimeEmitter
         // strict).
         il.MarkLabel(symbolKeyLabel);
         {
+            // #266: symbol-keyed class accessor setter (`set [Symbol.x](v) {...}`).
+            // A registered setter takes the write (accessor semantics) instead of
+            // storing a data property. Found setter is a MethodInfo invoked with the
+            // receiver + value — instance setters bind `this`, static ignore it.
+            var noSymSetterLabel = il.DefineLabel();
+            var symSetterLocal = il.DeclareLocal(_types.Object);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Call, runtime.FindSymbolSetter);
+            il.Emit(OpCodes.Stloc, symSetterLocal);
+            il.Emit(OpCodes.Ldloc, symSetterLocal);
+            il.Emit(OpCodes.Brfalse, noSymSetterLabel);
+            // ((MethodBase)setter).Invoke(obj, new object[] { value }); return;
+            il.Emit(OpCodes.Ldloc, symSetterLocal);
+            il.Emit(OpCodes.Castclass, _types.MethodBase);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldc_I4_1);
+            il.Emit(OpCodes.Newarr, _types.Object);
+            il.Emit(OpCodes.Dup);
+            il.Emit(OpCodes.Ldc_I4_0);
+            il.Emit(OpCodes.Ldarg_2);
+            il.Emit(OpCodes.Stelem_Ref);
+            il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.MethodBase, "Invoke", _types.Object, _types.ObjectArray));
+            il.Emit(OpCodes.Pop);
+            il.Emit(OpCodes.Ret);
+            il.MarkLabel(noSymSetterLabel);
+
             var symDictLocal = il.DeclareLocal(_types.DictionaryObjectObject);
             il.Emit(OpCodes.Ldarg_0);
             il.Emit(OpCodes.Call, runtime.GetSymbolDictMethod);

--- a/Compilation/RuntimeEmitter.Objects.Properties.cs
+++ b/Compilation/RuntimeEmitter.Objects.Properties.cs
@@ -1390,6 +1390,20 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Brfalse, nullLabel);
 
+        // globalThis/global sentinel (#271): a value-position globalThis reads
+        // properties through GlobalThisGetProperty (user props → built-in
+        // constructors/singletons), so `root.Object`/`root.Math` resolve to real
+        // values. Checked first so the bare-object sentinel never falls through to
+        // the class-instance handler (which would report every member undefined).
+        var notGlobalThisLabel = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldsfld, runtime.GlobalThisSingletonField);
+        il.Emit(OpCodes.Bne_Un, notGlobalThisLabel);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Call, runtime.GlobalThisGetProperty);
+        il.Emit(OpCodes.Ret);
+        il.MarkLabel(notGlobalThisLabel);
+
         // __proto__ accessor (ECMA-262 Annex B.2.2.1): obj.__proto__ delegates
         // to Object.getPrototypeOf(obj). All object types support this — the
         // accessor lives on Object.prototype, but intercepting here avoids
@@ -3300,6 +3314,19 @@ public partial class RuntimeEmitter
         // null check
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Brfalse, nullLabel);
+
+        // globalThis/global sentinel (#271): `root.foo = v` stores into the shared
+        // global-properties dictionary, visible to subsequent GlobalThisGetProperty
+        // reads. Mirrors the syntactic `globalThis.foo = v` path.
+        var notGlobalThisSetLabel = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldsfld, runtime.GlobalThisSingletonField);
+        il.Emit(OpCodes.Bne_Un, notGlobalThisSetLabel);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Ldarg_2);
+        il.Emit(OpCodes.Call, runtime.GlobalThisSetProperty);
+        il.Emit(OpCodes.Ret);
+        il.MarkLabel(notGlobalThisSetLabel);
 
         // Proxy check: uses obj.GetType().FullName comparison (no SharpTS.dll dependency)
         var notProxyLabel = il.DefineLabel();

--- a/Compilation/RuntimeEmitter.Objects.Properties.cs
+++ b/Compilation/RuntimeEmitter.Objects.Properties.cs
@@ -1973,9 +1973,35 @@ public partial class RuntimeEmitter
             il.Emit(OpCodes.Ret);
             il.MarkLabel(noBuiltInMatchLabel);
 
-            // No static member matched — fall through to class-instance handler, which
-            // on a Type returns Undefined (the intended absent-property signal).
-            il.Emit(OpCodes.Br, classInstanceLabel);
+            // #265: walk the constructor's superclass chain for inherited expando
+            // statics. In Node a class constructor inherits from its parent
+            // constructor (Object.getPrototypeOf(D) === C), so a string-keyed static
+            // set on a base (`Base.foo = 1`) is readable through a subclass `D.foo`.
+            // PDS keys descriptors by the Type identity per-class with no parent
+            // awareness, so probe each ancestor's store here — after the subclass's
+            // own descriptors and declared members, matching own-before-inherited.
+            var walkTypeLocal = il.DeclareLocal(_types.Type);
+            var baseDescLocal = il.DeclareLocal(runtime.CompiledPropertyDescriptorType);
+            il.Emit(OpCodes.Ldloc, typeLocal);
+            il.Emit(OpCodes.Stloc, walkTypeLocal);
+            var baseWalkLoop = il.DefineLabel();
+            il.MarkLabel(baseWalkLoop);
+            // walkType = walkType.BaseType;  (null terminates the chain)
+            il.Emit(OpCodes.Ldloc, walkTypeLocal);
+            il.Emit(OpCodes.Callvirt, _types.GetProperty(_types.Type, "BaseType").GetGetMethod()!);
+            il.Emit(OpCodes.Stloc, walkTypeLocal);
+            il.Emit(OpCodes.Ldloc, walkTypeLocal);
+            il.Emit(OpCodes.Brfalse, classInstanceLabel);
+            // desc = PDSGetPropertyDescriptor(walkType, name);
+            il.Emit(OpCodes.Ldloc, walkTypeLocal);
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Call, runtime.PDSGetPropertyDescriptor);
+            il.Emit(OpCodes.Stloc, baseDescLocal);
+            il.Emit(OpCodes.Ldloc, baseDescLocal);
+            il.Emit(OpCodes.Brfalse, baseWalkLoop);
+            il.Emit(OpCodes.Ldloc, baseDescLocal);
+            il.Emit(OpCodes.Callvirt, runtime.CompiledPropertyDescriptorValue.GetGetMethod()!);
+            il.Emit(OpCodes.Ret);
         }
 
         // Callable wrapper handler: route .bind/.call/.apply/.length/.name through

--- a/Compilation/RuntimeEmitter.ReadableStream.cs
+++ b/Compilation/RuntimeEmitter.ReadableStream.cs
@@ -114,6 +114,12 @@ public partial class RuntimeEmitter
         runtime.ReadableStreamErrorStream = errorMethod;
         runtime.ReadableStreamRead = readMethod;
 
+        // Static ReadableStream.from(iterable) (#269) — must be defined before
+        // streamBuilder.CreateType() below. Uses the ctor + Enqueue + CloseStream
+        // just defined and the $Runtime.IterateToList primitive.
+        runtime.ReadableStreamFrom = EmitReadableStreamFromStatic(
+            streamBuilder, streamCtor, enqueueMethod, closeMethod, runtime);
+
         // Controller methods (forward to stream).
         EmitReadableControllerEnqueue(controllerBuilder, streamBuilder, enqueueMethod);
         EmitReadableControllerClose(controllerBuilder, streamBuilder, closeMethod);
@@ -353,6 +359,81 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldfld, _readableStreamQueueField);
         il.Emit(OpCodes.Ldarg_1);
         il.Emit(OpCodes.Callvirt, _listOfObject.GetMethod("Add", [typeof(object)])!);
+        il.Emit(OpCodes.Ret);
+
+        return method;
+    }
+
+    /// <summary>
+    /// Emits <c>public static object From(object iterable)</c> on $ReadableStream
+    /// (#269). Mirrors the interpreter's ReadableStream.from: eagerly drains the
+    /// iterable (via $Runtime.IterateToList, which honours the Symbol.iterator
+    /// protocol plus arrays/strings/sets) into a fresh stream's queue, then closes
+    /// it so a reader observes the elements followed by done.
+    /// </summary>
+    private MethodBuilder EmitReadableStreamFromStatic(
+        TypeBuilder streamBuilder,
+        ConstructorBuilder streamCtor,
+        MethodBuilder enqueueMethod,
+        MethodBuilder closeMethod,
+        EmittedRuntime runtime)
+    {
+        // Named lowercase "from" (not "From") so the dynamic property path —
+        // `(ReadableStream as any).from(...)` → GetProperty($ReadableStream, "from")
+        // → SafeGetMethod (case-sensitive) — finds it and wraps it in a $TSFunction
+        // callable. The static-emitter path calls it by MethodBuilder, so the name
+        // is irrelevant there.
+        var method = streamBuilder.DefineMethod(
+            "from",
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.Object,
+            [_types.Object]);
+
+        var il = method.GetILGenerator();
+
+        // var stream = new $ReadableStream(null, null);
+        var streamLocal = il.DeclareLocal(streamBuilder);
+        il.Emit(OpCodes.Ldnull);
+        il.Emit(OpCodes.Ldnull);
+        il.Emit(OpCodes.Newobj, streamCtor);
+        il.Emit(OpCodes.Stloc, streamLocal);
+
+        // var list = $Runtime.IterateToList(iterable, Symbol.iterator, typeof($Runtime));
+        var listLocal = il.DeclareLocal(_types.ListOfObject);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldsfld, runtime.SymbolIterator);
+        il.Emit(OpCodes.Ldtoken, runtime.RuntimeType);
+        il.Emit(OpCodes.Call, _types.GetMethod(_types.Type, "GetTypeFromHandle", _types.RuntimeTypeHandle));
+        il.Emit(OpCodes.Call, runtime.IterateToList);
+        il.Emit(OpCodes.Stloc, listLocal);
+
+        // for (int i = 0; i < list.Count; i++) stream.Enqueue(list[i]);
+        var iLocal = il.DeclareLocal(_types.Int32);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Stloc, iLocal);
+        var loopCond = il.DefineLabel();
+        var loopBody = il.DefineLabel();
+        il.Emit(OpCodes.Br, loopCond);
+        il.MarkLabel(loopBody);
+        il.Emit(OpCodes.Ldloc, streamLocal);
+        il.Emit(OpCodes.Ldloc, listLocal);
+        il.Emit(OpCodes.Ldloc, iLocal);
+        il.Emit(OpCodes.Callvirt, _listOfObject.GetMethod("get_Item", [_types.Int32])!);
+        il.Emit(OpCodes.Callvirt, enqueueMethod);
+        il.Emit(OpCodes.Ldloc, iLocal);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Stloc, iLocal);
+        il.MarkLabel(loopCond);
+        il.Emit(OpCodes.Ldloc, iLocal);
+        il.Emit(OpCodes.Ldloc, listLocal);
+        il.Emit(OpCodes.Callvirt, _listOfObject.GetProperty("Count")!.GetGetMethod()!);
+        il.Emit(OpCodes.Blt, loopBody);
+
+        // stream.CloseStream(); return stream;
+        il.Emit(OpCodes.Ldloc, streamLocal);
+        il.Emit(OpCodes.Callvirt, closeMethod);
+        il.Emit(OpCodes.Ldloc, streamLocal);
         il.Emit(OpCodes.Ret);
 
         return method;

--- a/Compilation/RuntimeEmitter.RuntimeClass.cs
+++ b/Compilation/RuntimeEmitter.RuntimeClass.cs
@@ -96,6 +96,15 @@ public partial class RuntimeEmitter
             FieldAttributes.Public | FieldAttributes.Static);
         runtime.MathSingletonField = mathSingletonField;
 
+        // globalThis/global sentinel (#271) — a plain object whose identity lets
+        // the dynamic property paths recognize a value-position globalThis and
+        // route reads/writes through GlobalThisGetProperty/GlobalThisSetProperty.
+        var globalThisSingletonField = typeBuilder.DefineField(
+            "_globalThisSingleton",
+            _types.Object,
+            FieldAttributes.Public | FieldAttributes.Static);
+        runtime.GlobalThisSingletonField = globalThisSingletonField;
+
         // Boolean / Number / String prototype singletons. Test262 patterns like
         //   Boolean.prototype[0] = true; Boolean.prototype.length = 1;
         //   Array.prototype.every.call(false, cb)
@@ -350,6 +359,10 @@ public partial class RuntimeEmitter
         // Initialize _mathSingleton = new Dictionary<string, object>()
         cctorIL.Emit(OpCodes.Newobj, _types.GetDefaultConstructor(_types.DictionaryStringObject));
         cctorIL.Emit(OpCodes.Stsfld, mathSingletonField);
+
+        // Initialize _globalThisSingleton = new object() (#271 sentinel identity)
+        cctorIL.Emit(OpCodes.Newobj, _types.GetDefaultConstructor(_types.Object));
+        cctorIL.Emit(OpCodes.Stsfld, globalThisSingletonField);
 
         // Boolean/Number/String prototype singletons (lazy-feeling but eagerly
         // initialized so Type→prototype lookups never hit a null).

--- a/Compilation/RuntimeEmitter.RuntimeClass.cs
+++ b/Compilation/RuntimeEmitter.RuntimeClass.cs
@@ -364,6 +364,9 @@ public partial class RuntimeEmitter
         cctorIL.Emit(OpCodes.Newobj, _types.GetDefaultConstructor(_types.Object));
         cctorIL.Emit(OpCodes.Stsfld, globalThisSingletonField);
 
+        // Initialize the symbol-keyed accessor registry (#266).
+        InitSymbolAccessorRegistry(cctorIL, runtime);
+
         // Boolean/Number/String prototype singletons (lazy-feeling but eagerly
         // initialized so Type→prototype lookups never hit a null).
         cctorIL.Emit(OpCodes.Newobj, _types.GetDefaultConstructor(_types.DictionaryStringObject));
@@ -950,6 +953,8 @@ public partial class RuntimeEmitter
         // Fill in LookupBuiltInStaticMember's body now that IsArray, NumberIs*,
         // StringFrom*, and TSFunctionCtor are all in place (#63).
         EmitLookupBuiltInStaticMemberBody(runtime);
+        // Fill in the symbol-keyed accessor registry helper bodies (#266).
+        EmitSymbolAccessorRegistryBodies(runtime);
         // Microtask method (queueMicrotask) - must come before timer infrastructure so ProcessMicrotasks is available
         EmitQueueMicrotaskMethod(typeBuilder, runtime);
         // Virtual timer infrastructure (must come before DateMethods which calls ProcessPendingTimers)

--- a/Compilation/RuntimeEmitter.RuntimeClassPhase1.cs
+++ b/Compilation/RuntimeEmitter.RuntimeClassPhase1.cs
@@ -60,6 +60,22 @@ public partial class RuntimeEmitter
             _types.Void,
             [_types.Object, _types.String, _types.Object]);
 
+        // Reserve GlobalThisGetProperty(string) → object and
+        // GlobalThisSetProperty(string, object) → void. EmitGlobalThisMethods
+        // (run much later) fills the bodies, but GetProperty/GetIndex/SetProperty/
+        // SetIndex — emitted before it — route the value-position globalThis
+        // sentinel through these, so the signatures must exist now (#271).
+        runtime.GlobalThisGetProperty = typeBuilder.DefineMethod(
+            "GlobalThisGetProperty",
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.Object,
+            [_types.String]);
+        runtime.GlobalThisSetProperty = typeBuilder.DefineMethod(
+            "GlobalThisSetProperty",
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.Void,
+            [_types.String, _types.Object]);
+
         // Reserve ToNumber(object) → double. Used by $RegExp's Symbol.split
         // to coerce `limit` per ECMA-262 §22.2.5.13 step 7 (and to throw
         // TypeError on Symbol limits). EmitToNumber later fills the body.

--- a/Compilation/RuntimeEmitter.RuntimeClassPhase1.cs
+++ b/Compilation/RuntimeEmitter.RuntimeClassPhase1.cs
@@ -76,6 +76,11 @@ public partial class RuntimeEmitter
             _types.Void,
             [_types.String, _types.Object]);
 
+        // Symbol-keyed class accessor registry (#266). GetIndex/SetIndex (emitted
+        // during EmitRuntimeClass) call FindSymbol{Getter,Setter}For, and class
+        // .cctors (emitted later still) call RegisterSymbolAccessor.
+        DefineSymbolAccessorRegistry(typeBuilder, runtime);
+
         // Reserve ToNumber(object) → double. Used by $RegExp's Symbol.split
         // to coerce `limit` per ECMA-262 §22.2.5.13 step 7 (and to throw
         // TypeError on Symbol limits). EmitToNumber later fills the body.

--- a/Compilation/RuntimeEmitter.SymbolAccessors.cs
+++ b/Compilation/RuntimeEmitter.SymbolAccessors.cs
@@ -1,0 +1,259 @@
+using System.Reflection;
+using System.Reflection.Emit;
+
+namespace SharpTS.Compilation;
+
+public partial class RuntimeEmitter
+{
+    // Slot layout inside each per-(Type,symbol) object[4].
+    private const int SymGetterInstanceSlot = 0;
+    private const int SymSetterInstanceSlot = 1;
+    private const int SymGetterStaticSlot = 2;
+    private const int SymSetterStaticSlot = 3;
+
+    private Type SymInnerDictType => _types.MakeGenericType(_types.DictionaryOpen, _types.Object, _types.ObjectArray);
+    private Type SymOuterDictType => _types.MakeGenericType(_types.DictionaryOpen, _types.Type, SymInnerDictType);
+
+    /// <summary>
+    /// Forward-declares the symbol-accessor registry field and its three helper
+    /// methods (#266). GetIndex/SetIndex — emitted before the bodies — call the
+    /// FindSymbol* methods, and class .cctors (emitted after all runtime methods)
+    /// call RegisterSymbolAccessor, so the signatures must exist up front.
+    /// </summary>
+    private void DefineSymbolAccessorRegistry(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    {
+        runtime.SymbolAccessorRegistryField = typeBuilder.DefineField(
+            "_symbolAccessors", SymOuterDictType,
+            FieldAttributes.Public | FieldAttributes.Static);
+
+        runtime.RegisterSymbolAccessor = typeBuilder.DefineMethod(
+            "RegisterSymbolAccessor",
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.Void,
+            [_types.Type, _types.Object, _types.Object, _types.Object, _types.Boolean]);
+
+        runtime.FindSymbolGetter = typeBuilder.DefineMethod(
+            "FindSymbolGetterFor",
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.Object,
+            [_types.Object, _types.Object]);
+
+        runtime.FindSymbolSetter = typeBuilder.DefineMethod(
+            "FindSymbolSetterFor",
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.Object,
+            [_types.Object, _types.Object]);
+    }
+
+    /// <summary>Emits the registry field initialization into the $Runtime cctor.</summary>
+    private void InitSymbolAccessorRegistry(ILGenerator cctorIL, EmittedRuntime runtime)
+    {
+        cctorIL.Emit(OpCodes.Newobj, _types.GetDefaultConstructor(SymOuterDictType));
+        cctorIL.Emit(OpCodes.Stsfld, runtime.SymbolAccessorRegistryField);
+    }
+
+    /// <summary>Fills the bodies of Register/FindGetter/FindSetter (#266).</summary>
+    private void EmitSymbolAccessorRegistryBodies(EmittedRuntime runtime)
+    {
+        var outer = SymOuterDictType;
+        var inner = SymInnerDictType;
+        var field = runtime.SymbolAccessorRegistryField;
+
+        var outerTryGetValue = outer.GetMethod("TryGetValue", [_types.Type, inner.MakeByRefType()])!;
+        var outerSetItem = outer.GetMethod("set_Item", [_types.Type, inner])!;
+        var innerTryGetValue = inner.GetMethod("TryGetValue", [_types.Object, _types.ObjectArray.MakeByRefType()])!;
+        var innerSetItem = inner.GetMethod("set_Item", [_types.Object, _types.ObjectArray])!;
+        var getBaseType = _types.GetProperty(_types.Type, "BaseType").GetGetMethod()!;
+        var getType = _types.GetMethod(_types.Object, "GetType");
+
+        EmitRegisterSymbolAccessorBody(runtime, inner, outerTryGetValue, outerSetItem, innerTryGetValue, innerSetItem);
+        EmitFindSymbolAccessorBody(runtime.FindSymbolGetter, field, inner,
+            SymGetterInstanceSlot, SymGetterStaticSlot, outerTryGetValue, innerTryGetValue, getBaseType, getType);
+        EmitFindSymbolAccessorBody(runtime.FindSymbolSetter, field, inner,
+            SymSetterInstanceSlot, SymSetterStaticSlot, outerTryGetValue, innerTryGetValue, getBaseType, getType);
+    }
+
+    private void EmitRegisterSymbolAccessorBody(
+        EmittedRuntime runtime, Type inner,
+        MethodInfo outerTryGetValue, MethodInfo outerSetItem,
+        MethodInfo innerTryGetValue, MethodInfo innerSetItem)
+    {
+        // RegisterSymbolAccessor(Type owner, object symbol, object getter, object setter, bool isStatic)
+        var il = runtime.RegisterSymbolAccessor.GetILGenerator();
+        var field = runtime.SymbolAccessorRegistryField;
+        var innerLocal = il.DeclareLocal(inner);
+        var slotLocal = il.DeclareLocal(_types.ObjectArray);
+
+        // if (symbol == null) return; — a non-well-known key that couldn't be
+        // resolved at .cctor time (e.g. a module-local Symbol whose binding isn't
+        // yet visible) must not crash the type initializer. Well-known-symbol keys
+        // (the common case: species/toStringTag/toPrimitive/iterator) are global
+        // constants and always resolve. Module-local Symbol keys tracked by #282.
+        var symbolOkLabel = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Brtrue, symbolOkLabel);
+        il.Emit(OpCodes.Ret);
+        il.MarkLabel(symbolOkLabel);
+
+        // if (!_symbolAccessors.TryGetValue(owner, out inner)) { inner = new(); _symbolAccessors[owner] = inner; }
+        var haveInner = il.DefineLabel();
+        il.Emit(OpCodes.Ldsfld, field);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldloca, innerLocal);
+        il.Emit(OpCodes.Callvirt, outerTryGetValue);
+        il.Emit(OpCodes.Brtrue, haveInner);
+        il.Emit(OpCodes.Newobj, _types.GetDefaultConstructor(inner));
+        il.Emit(OpCodes.Stloc, innerLocal);
+        il.Emit(OpCodes.Ldsfld, field);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldloc, innerLocal);
+        il.Emit(OpCodes.Callvirt, outerSetItem);
+        il.MarkLabel(haveInner);
+
+        // if (!inner.TryGetValue(symbol, out slot)) { slot = new object[4]; inner[symbol] = slot; }
+        var haveSlot = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, innerLocal);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Ldloca, slotLocal);
+        il.Emit(OpCodes.Callvirt, innerTryGetValue);
+        il.Emit(OpCodes.Brtrue, haveSlot);
+        il.Emit(OpCodes.Ldc_I4_4);
+        il.Emit(OpCodes.Newarr, _types.Object);
+        il.Emit(OpCodes.Stloc, slotLocal);
+        il.Emit(OpCodes.Ldloc, innerLocal);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Ldloc, slotLocal);
+        il.Emit(OpCodes.Callvirt, innerSetItem);
+        il.MarkLabel(haveSlot);
+
+        // if (getter != null) slot[isStatic ? 2 : 0] = getter;
+        EmitStoreSlotIfPresent(il, slotLocal, argIndex: 2, staticSlot: SymGetterStaticSlot, instanceSlot: SymGetterInstanceSlot);
+        // if (setter != null) slot[isStatic ? 3 : 1] = setter;
+        EmitStoreSlotIfPresent(il, slotLocal, argIndex: 3, staticSlot: SymSetterStaticSlot, instanceSlot: SymSetterInstanceSlot);
+
+        il.Emit(OpCodes.Ret);
+    }
+
+    // if (argN != null) slot[isStatic ? staticSlot : instanceSlot] = argN;
+    private static void EmitStoreSlotIfPresent(ILGenerator il, LocalBuilder slotLocal, int argIndex, int staticSlot, int instanceSlot)
+    {
+        var skip = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg, argIndex);
+        il.Emit(OpCodes.Brfalse, skip);
+        il.Emit(OpCodes.Ldloc, slotLocal);
+        // index = isStatic(arg4) ? staticSlot : instanceSlot
+        var useStatic = il.DefineLabel();
+        var haveIdx = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg, 4);
+        il.Emit(OpCodes.Brtrue, useStatic);
+        il.Emit(OpCodes.Ldc_I4, instanceSlot);
+        il.Emit(OpCodes.Br, haveIdx);
+        il.MarkLabel(useStatic);
+        il.Emit(OpCodes.Ldc_I4, staticSlot);
+        il.MarkLabel(haveIdx);
+        il.Emit(OpCodes.Ldarg, argIndex);
+        il.Emit(OpCodes.Stelem_Ref);
+        il.MarkLabel(skip);
+    }
+
+    // object FindSymbol{Getter,Setter}For(object obj, object symbol):
+    //   owner = obj is Type t ? t : obj.GetType();  idx = obj is Type ? staticSlot : instanceSlot;
+    //   for (; owner != null; owner = owner.BaseType)
+    //     if (reg.TryGetValue(owner, out inner) && inner.TryGetValue(symbol, out slot) && slot[idx] != null) return slot[idx];
+    //   return null;
+    private void EmitFindSymbolAccessorBody(
+        MethodBuilder method, FieldBuilder field, Type inner,
+        int instanceSlot, int staticSlot,
+        MethodInfo outerTryGetValue, MethodInfo innerTryGetValue, MethodInfo getBaseType, MethodInfo getType)
+    {
+        var il = method.GetILGenerator();
+        var ownerLocal = il.DeclareLocal(_types.Type);
+        var idxLocal = il.DeclareLocal(_types.Int32);
+        var innerLocal = il.DeclareLocal(inner);
+        var slotLocal = il.DeclareLocal(_types.ObjectArray);
+        var asTypeLocal = il.DeclareLocal(_types.Type);
+
+        var retNull = il.DefineLabel();
+
+        // if (_symbolAccessors == null) return null;
+        il.Emit(OpCodes.Ldsfld, field);
+        il.Emit(OpCodes.Brfalse, retNull);
+
+        // owner/idx from whether obj is a Type (static) or an instance.
+        var isType = il.DefineLabel();
+        var afterOwner = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Isinst, _types.Type);
+        il.Emit(OpCodes.Stloc, asTypeLocal);
+        il.Emit(OpCodes.Ldloc, asTypeLocal);
+        il.Emit(OpCodes.Brtrue, isType);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Callvirt, getType);
+        il.Emit(OpCodes.Stloc, ownerLocal);
+        il.Emit(OpCodes.Ldc_I4, instanceSlot);
+        il.Emit(OpCodes.Stloc, idxLocal);
+        il.Emit(OpCodes.Br, afterOwner);
+        il.MarkLabel(isType);
+        il.Emit(OpCodes.Ldloc, asTypeLocal);
+        il.Emit(OpCodes.Stloc, ownerLocal);
+        il.Emit(OpCodes.Ldc_I4, staticSlot);
+        il.Emit(OpCodes.Stloc, idxLocal);
+        il.MarkLabel(afterOwner);
+
+        // base-chain walk
+        var loopTop = il.DefineLabel();
+        var nextBase = il.DefineLabel();
+        var retIt = il.DefineLabel();
+        var runClassCtor = typeof(System.Runtime.CompilerServices.RuntimeHelpers)
+            .GetMethod("RunClassConstructor", [typeof(RuntimeTypeHandle)])!;
+        var getTypeHandle = _types.GetProperty(_types.Type, "TypeHandle").GetGetMethod()!;
+
+        il.MarkLabel(loopTop);
+        il.Emit(OpCodes.Ldloc, ownerLocal);
+        il.Emit(OpCodes.Brfalse, retNull);
+        // Static-side accessors are registered in the owner class's .cctor, which
+        // the CLR runs lazily — merely using the class as a Type value (typeof) does
+        // not trigger it. Force it so a static `Class[Symbol.x]` access sees the
+        // registration. Idempotent and cheap after the first run. (Instance-side
+        // accessors are already registered by the time an instance exists.)
+        {
+            var skipCctor = il.DefineLabel();
+            il.Emit(OpCodes.Ldloc, asTypeLocal);
+            il.Emit(OpCodes.Brfalse, skipCctor);
+            il.Emit(OpCodes.Ldloc, ownerLocal);
+            il.Emit(OpCodes.Callvirt, getTypeHandle);
+            il.Emit(OpCodes.Call, runClassCtor);
+            il.MarkLabel(skipCctor);
+        }
+        // if (!reg.TryGetValue(owner, out inner)) goto nextBase;
+        il.Emit(OpCodes.Ldsfld, field);
+        il.Emit(OpCodes.Ldloc, ownerLocal);
+        il.Emit(OpCodes.Ldloca, innerLocal);
+        il.Emit(OpCodes.Callvirt, outerTryGetValue);
+        il.Emit(OpCodes.Brfalse, nextBase);
+        // if (!inner.TryGetValue(symbol, out slot)) goto nextBase;
+        il.Emit(OpCodes.Ldloc, innerLocal);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Ldloca, slotLocal);
+        il.Emit(OpCodes.Callvirt, innerTryGetValue);
+        il.Emit(OpCodes.Brfalse, nextBase);
+        // v = slot[idx]; if (v != null) return v;
+        il.Emit(OpCodes.Ldloc, slotLocal);
+        il.Emit(OpCodes.Ldloc, idxLocal);
+        il.Emit(OpCodes.Ldelem_Ref);
+        il.Emit(OpCodes.Dup);
+        il.Emit(OpCodes.Brtrue, retIt);
+        il.Emit(OpCodes.Pop);
+        il.MarkLabel(nextBase);
+        il.Emit(OpCodes.Ldloc, ownerLocal);
+        il.Emit(OpCodes.Callvirt, getBaseType);
+        il.Emit(OpCodes.Stloc, ownerLocal);
+        il.Emit(OpCodes.Br, loopTop);
+
+        il.MarkLabel(retIt);
+        il.Emit(OpCodes.Ret);
+        il.MarkLabel(retNull);
+        il.Emit(OpCodes.Ldnull);
+        il.Emit(OpCodes.Ret);
+    }
+}

--- a/SharpTS.Tests/GlobalThisTests.cs
+++ b/SharpTS.Tests/GlobalThisTests.cs
@@ -150,4 +150,84 @@ public class GlobalThisTests
             """, mode);
         Assert.Contains("42", result);
     }
+
+    // #271: globalThis used in VALUE position (assigned to a variable, then
+    // dereferenced) must be a real object, not null. Before the fix compiled
+    // mode emitted null, so root/context detection in lodash-style packages got
+    // a null root and could not initialize.
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void GlobalThis_ValuePosition_IsRealObject(ExecutionMode mode)
+    {
+        var result = TestHarness.Run("""
+            const root: any = globalThis;
+            console.log(typeof root === "object");
+            console.log(root !== null);
+            console.log(root.globalThis === root);
+            """, mode);
+        Assert.Equal("true\ntrue\ntrue\n", result);
+    }
+
+    // Cross-mode: typeof checks and Object identity hold in both modes.
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void GlobalThis_ValuePosition_ResolvesConstructorTypeofs(ExecutionMode mode)
+    {
+        var result = TestHarness.Run("""
+            const root: any = globalThis;
+            console.log(root.Object === Object);
+            console.log(typeof root.Array === "function");
+            console.log(typeof root.Function === "function");
+            console.log(typeof root.TypeError === "function");
+            console.log(typeof root.Math === "object");
+            """, mode);
+        Assert.Equal("true\ntrue\ntrue\ntrue\ntrue\n", result);
+    }
+
+    // Compiled-only: the runtime sentinel routes constructor reads to real .NET
+    // Type tokens, so `root.Error === Error` holds (#271). The interpreter's
+    // SharpTSGlobalThis returns a distinct Error representation for this identity,
+    // which is an independent pre-existing quirk outside this fix's scope.
+    [Theory]
+    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    public void GlobalThis_ValuePosition_ResolvesErrorConstructorIdentity(ExecutionMode mode)
+    {
+        var result = TestHarness.Run("""
+            const root: any = globalThis;
+            console.log(root.Error === Error);
+            console.log(root.TypeError === TypeError);
+            """, mode);
+        Assert.Equal("true\ntrue\n", result);
+    }
+
+    // #271: writes through a value-position globalThis reference round-trip to
+    // subsequent reads (the lodash `root.foo = ...` pattern).
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void GlobalThis_ValuePosition_WriteRoundTrips(ExecutionMode mode)
+    {
+        var result = TestHarness.Run("""
+            const root: any = globalThis;
+            root.myProp = 42;
+            console.log(globalThis.myProp === 42);
+            root["dynKey"] = "hi";
+            console.log(globalThis.dynKey === "hi");
+            """, mode);
+        Assert.Equal("true\ntrue\n", result);
+    }
+
+    // #271: the lodash/core-js `Function('return this')()` global probe yields
+    // the same real globalThis value (compiled mode; the interpreter rejects the
+    // dynamic Function constructor, so this is compiled-only).
+    [Theory]
+    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    public void GlobalThis_FunctionReturnThisProbe_IsGlobalThis(ExecutionMode mode)
+    {
+        var result = TestHarness.Run("""
+            const probe: any = Function('return this')();
+            console.log(probe === globalThis);
+            console.log(probe.Object === Object);
+            """, mode);
+        Assert.Equal("true\ntrue\n", result);
+    }
 }

--- a/SharpTS.Tests/IntegrationTests/RealPackageSmokeTests.cs
+++ b/SharpTS.Tests/IntegrationTests/RealPackageSmokeTests.cs
@@ -496,10 +496,14 @@ public class RealPackageSmokeTests
     // silently evaluated to null: global/globalThis compile to null in value
     // position, so runInContext ran with a null context and every native ref
     // was undefined (which is also why chunk/flatten returned wrong values).
-    // With the #260 TypeError, init fails honestly at lodash's
-    // `funcToString.call(Object)`. Unskip when #271 (globalThis value
-    // representation) lands.
-    [SkippableFact(Skip = "compiled lodash cannot initialize without a globalThis value representation — see #271")]
+    // With the #260 TypeError, init failed honestly at lodash's
+    // `funcToString.call(Object)`. #271 gave globalThis a real value
+    // representation, so root/context detection now resolves real constructors —
+    // init gets past `funcToString.call(Object)`. It still throws later because
+    // value-form built-in singleton methods (e.g. `context.Math.max`) are not
+    // populated in compiled mode (the Math/JSON singleton dicts hold no method
+    // wrappers). Tracked by #276; unskip when that lands.
+    [SkippableFact(Skip = "compiled lodash init reaches value-form Math.max, unpopulated in compiled mode — see #276")]
     public void Lodash_Compiled()
     {
         SkipIfNoNpm();

--- a/SharpTS.Tests/SharedTests/ClassExpandoStaticTests.cs
+++ b/SharpTS.Tests/SharedTests/ClassExpandoStaticTests.cs
@@ -57,10 +57,10 @@ public class ClassExpandoStaticTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    // Compiled mode does not yet walk the constructor parent chain for expando
-    // statics (#265); Node inherits them via Object.getPrototypeOf(D) === C.
+    // Both modes walk the constructor parent chain for expando statics (#265);
+    // Node inherits them via Object.getPrototypeOf(D) === C.
     [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void ExpandoStatics_InheritedThroughSubclassChain(ExecutionMode mode)
     {
         var source = """
@@ -70,6 +70,49 @@ public class ClassExpandoStaticTests
             (C as any)[Symbol.species] = 2;
             console.log((D as any)["foo"] === 1);
             console.log((D as any)[Symbol.species] === 2);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("true\ntrue\n", output);
+    }
+
+    // An own expando static on the subclass shadows the inherited one (#265),
+    // and setting it on the subclass must not mutate the base's own value.
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ExpandoStatics_OwnShadowsInherited(ExecutionMode mode)
+    {
+        var source = """
+            class C {}
+            class D extends C {}
+            const sp = Symbol("sp");
+            (C as any)["foo"] = 1;
+            (C as any)[sp] = 1;
+            (D as any)["foo"] = 9;
+            (D as any)[sp] = 9;
+            console.log((D as any)["foo"] === 9);
+            console.log((D as any)[sp] === 9);
+            console.log((C as any)["foo"] === 1);
+            console.log((C as any)[sp] === 1);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("true\ntrue\ntrue\ntrue\n", output);
+    }
+
+    // A two-level chain resolves an expando static set on the grandparent (#265).
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ExpandoStatics_InheritedThroughTwoLevels(ExecutionMode mode)
+    {
+        var source = """
+            class A {}
+            class B extends A {}
+            class C extends B {}
+            (A as any)["foo"] = 7;
+            (A as any)[Symbol.species] = 8;
+            console.log((C as any)["foo"] === 7);
+            console.log((C as any)[Symbol.species] === 8);
             """;
 
         var output = TestHarness.Run(source, mode);

--- a/SharpTS.Tests/SharedTests/ComputedAccessorNameTests.cs
+++ b/SharpTS.Tests/SharedTests/ComputedAccessorNameTests.cs
@@ -6,13 +6,14 @@ namespace SharpTS.Tests.SharedTests;
 /// <summary>
 /// Tests for computed accessor names in class bodies (#261):
 /// get [Symbol.toStringTag]() / static get [Symbol.species]().
-/// Symbol-keyed accessors run interpreted only (compiled support tracked by #266);
-/// literal computed keys fold to ordinary names in the parser and run in both modes.
+/// Symbol-keyed accessors on class declarations run in both modes (compiled
+/// support added in #266); on class expressions they stay interpreted-only
+/// (#281). Literal computed keys fold to ordinary names in the parser.
 /// </summary>
 public class ComputedAccessorNameTests
 {
     [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void StaticSymbolGetter_SpeciesPattern(ExecutionMode mode)
     {
         var source = """
@@ -27,7 +28,7 @@ public class ComputedAccessorNameTests
     }
 
     [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void InstanceSymbolGetterAndSetter(ExecutionMode mode)
     {
         var source = """
@@ -47,7 +48,7 @@ public class ComputedAccessorNameTests
     }
 
     [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void StaticSymbolGetter_InheritedThroughSubclassChain(ExecutionMode mode)
     {
         var source = """
@@ -62,6 +63,8 @@ public class ComputedAccessorNameTests
         Assert.Equal("true\n", output);
     }
 
+    // Class expressions use a separate emission path with no .cctor registration
+    // hook; compiled symbol-accessor support there is tracked by #281.
     [Theory]
     [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
     public void SymbolAccessor_InClassExpression(ExecutionMode mode)
@@ -75,6 +78,29 @@ public class ComputedAccessorNameTests
 
         var output = TestHarness.Run(source, mode);
         Assert.Equal("expr\n", output);
+    }
+
+    // A get and set accessor for the SAME symbol must coexist (they merge into one
+    // registry slot) and the .cctor registration must not disturb static field init.
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void SymbolGetterAndSetter_SameKey_WithStaticField(ExecutionMode mode)
+    {
+        var source = """
+            class Box {
+                static tag: number = 7;
+                value: any = 0;
+                get [Symbol.toPrimitive]() { return this.value; }
+                set [Symbol.toPrimitive](v: any) { this.value = v * 2; }
+            }
+            const b = new Box();
+            (b as any)[Symbol.toPrimitive] = 21;
+            console.log((b as any)[Symbol.toPrimitive]);
+            console.log(Box.tag);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("42\n7\n", output);
     }
 
     [Theory]

--- a/SharpTS.Tests/SharedTests/NamespaceGlobalBindingTests.cs
+++ b/SharpTS.Tests/SharedTests/NamespaceGlobalBindingTests.cs
@@ -73,11 +73,11 @@ public class NamespaceGlobalBindingTests
         Assert.Equal("function\ntrue\nfunction function\n", output);
     }
 
-    // Compiled mode has no ReadableStream.from yet (#269) — before #260 the
-    // dispatch silently produced null and `typeof null === "object"` made this
-    // assertion pass for the wrong reason.
+    // ReadableStream.from(iterable) eagerly drains the iterable into a closed
+    // stream (#269). Both modes are covered now that compiled mode emits a
+    // $ReadableStream.from static (interp uses SharpTSWebStreamsConstructors).
     [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void WebStreamConstructors_From(ExecutionMode mode)
     {
         var source = """
@@ -87,6 +87,30 @@ public class NamespaceGlobalBindingTests
 
         var output = TestHarness.Run(source, mode);
         Assert.Equal("object\n", output);
+    }
+
+    // #269: the produced stream yields each element of the iterable followed by
+    // done — verified by draining it through a reader.
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void WebStreamConstructors_From_DrainsIterable(ExecutionMode mode)
+    {
+        var source = """
+            async function main() {
+                const s = (ReadableStream as any).from(["a", "b"]);
+                const r = s.getReader();
+                const a = await r.read();
+                const b = await r.read();
+                const c = await r.read();
+                console.log(a.value, a.done);
+                console.log(b.value, b.done);
+                console.log(c.done);
+            }
+            main();
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("a false\nb false\ntrue\n", output);
     }
 
     [Theory]


### PR DESCRIPTION
Fixes four compiled-mode gaps that #260's non-callable `TypeError` unmasked (it removed the silent-null behavior that was papering over them). Full suite: **10835 passed / 0 failed / 1 skipped** (lodash compiled, blocked on #276).

Each fix is its own commit with a focused regression test promoted to run in both interpreted and compiled modes.

### #265 — expando statics inherited through the subclass chain
Compiled mode stored string- and symbol-keyed expando statics per-class with no parent-chain fallback, so `Base.foo = 1` / `Base[sym] = 1` was invisible through a subclass constructor (Node inherits them via `Object.getPrototypeOf(D) === C`). `GetProperty`'s Type handler now walks the constructor's `.NET` base-type chain (real inheritance from `SetParent`) probing each ancestor's `PropertyDescriptorStore`; `GetIndex`'s symbol handler walks each ancestor's symbol dict. Own statics still shadow inherited ones.

### #271 — globalThis/global have a value representation
`globalThis`/`global` and the `Function('return this')()` probe compiled to `null` in value position, so the lodash-style `root = freeGlobal || freeSelf || Function('return this')()` pattern got a null root. Introduces a `$Runtime._globalThisSingleton` sentinel; value-position `globalThis`/`global`, the `Function('return this')()` idiom, and leaf `globalThis.globalThis` emit it, and the dynamic property/index get+set paths route it through `GlobalThisGetProperty`/`GlobalThisSetProperty` (now resolving `Math`/`JSON` singletons and the `Error` family). _Full lodash init additionally needs value-form singleton method dispatch (`Math.max`) — filed as #276._

### #269 — ReadableStream.from()
Compiled mode never implemented the `from` static (the old test passed only because `typeof null === "object"`). Emits a `$ReadableStream.from(object)` that drains the iterable via `$Runtime.IterateToList` then closes the stream, mirroring the interpreter. Named lowercase so the dynamic `(ReadableStream as any).from` path resolves it.

### #266 — symbol-keyed computed accessors (class declarations)
`get [Symbol.x]()` / `static get [Symbol.species]()` were rejected at compile time. Adds a `$Runtime` symbol-accessor registry (per-class, base-chain-walking) populated from each class `.cctor` and dispatched from the `GetIndex`/`SetIndex` symbol paths. Static-side lookups force the owner `.cctor` via `RunClassConstructor` (using a class as a value doesn't trigger it). Class **expressions** remain interpreter-only (#281); a module-local `Symbol` key is skipped rather than crashing (#282).

### #221 — Promise SpeciesConstructor — assessed, staying parked
Left Low/parked per the issue's own guidance; posted an [assessment](https://github.com/nickna/SharpTS/issues/221#issuecomment-4677702689). #266 makes a species override readable, but `then`/`catch`/`finally`/combinators don't consult SpeciesConstructor and compiled promises are raw `Task<object?>` with no object identity (the architectural blocker). An interp-only slice would reintroduce the mode divergence recent batches eliminated; the affected Test262 tests stay baselined Fail, so parking carries no regression risk.

### Follow-ups filed
- #276 — value-form built-in singleton methods (`Math.max`, `JSON.stringify`) unpopulated in compiled mode (blocks compiled lodash)
- #281 — symbol-keyed accessors on class *expressions*
- #282 — symbol-keyed accessor with a module-local `Symbol` key

Closes #265, #271, #269, #266.