### PR TITLE
fix(compile): event-loop SynchronizationContext — durable fix for compiled async/network CI flakes

### DIFF
--- a/Compilation/EmittedRuntime.cs
+++ b/Compilation/EmittedRuntime.cs
@@ -2691,6 +2691,16 @@ public class EmittedRuntime
     public MethodBuilder EventLoopWaitForTask { get; set; } = null!;
     public FieldBuilder EventLoopTimerProcessorField { get; set; } = null!;
 
+    /// <summary>
+    /// Parameterless constructor of the emitted <c>$EventLoopSyncContext</c> (a
+    /// <see cref="System.Threading.SynchronizationContext"/> subclass whose
+    /// <c>Post</c> schedules continuations onto the event-loop queue). The entry
+    /// point installs an instance via <c>SetSynchronizationContext</c> so
+    /// async/await continuations resume on the event-loop thread instead of
+    /// escaping to the thread pool.
+    /// </summary>
+    public ConstructorBuilder EventLoopSyncContextCtor { get; set; } = null!;
+
     // ============================================================
     // $NetServer — emitted TCP server (extends $EventEmitter)
     // ============================================================

--- a/Compilation/ILCompiler.Functions.cs
+++ b/Compilation/ILCompiler.Functions.cs
@@ -847,6 +847,25 @@ public partial class ILCompiler
     }
 
     /// <summary>
+    /// Emits, at the top of an entry-point Main, the install of the event-loop
+    /// SynchronizationContext so async/await continuations resume on the
+    /// event-loop thread instead of escaping to the thread pool (Node
+    /// semantics). Must run before the first top-level await — the first awaiter
+    /// captures whatever context is current. Standalone-safe: the ctor is in the
+    /// emitted assembly and <see cref="System.Threading.SynchronizationContext"/>
+    /// is BCL. In-process hosts (the test harness, CompilationService) save and
+    /// restore the ambient context around the Main invoke; a real EXE simply
+    /// exits, so no restore is emitted here.
+    /// </summary>
+    private void EmitInstallEventLoopSyncContext(ILGenerator il)
+    {
+        il.Emit(OpCodes.Newobj, _runtime.EventLoopSyncContextCtor);
+        il.Emit(OpCodes.Call, typeof(System.Threading.SynchronizationContext).GetMethod(
+            "SetSynchronizationContext",
+            System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static)!);
+    }
+
+    /// <summary>
     /// Emits the default entry point where top-level statements run as the program.
     /// Used for DLL target or EXE without user-defined main().
     /// </summary>
@@ -862,6 +881,7 @@ public partial class ILCompiler
         _entryPoint = mainMethod;
 
         var il = mainMethod.GetILGenerator();
+        EmitInstallEventLoopSyncContext(il);
         var ctx = new CompilationContext(il, _typeMapper, _functions.Builders, _classes.Builders, _types)
         {
             ClosureAnalyzer = _closures.Analyzer,
@@ -1076,6 +1096,7 @@ public partial class ILCompiler
         _entryPoint = mainMethod;
 
         var il = mainMethod.GetILGenerator();
+        EmitInstallEventLoopSyncContext(il);
         var ctx = new CompilationContext(il, _typeMapper, _functions.Builders, _classes.Builders, _types)
         {
             ClosureAnalyzer = _closures.Analyzer,

--- a/Compilation/RuntimeEmitter.TSEventLoop.cs
+++ b/Compilation/RuntimeEmitter.TSEventLoop.cs
@@ -103,6 +103,127 @@ public partial class RuntimeEmitter
         EmitEventLoopWaitForTask(typeBuilder, runtime);
 
         typeBuilder.CreateType();
+
+        // Emit the SynchronizationContext that routes await continuations back to
+        // this loop. Done after $EventLoop is finalized so it can reference
+        // GetInstance/Schedule.
+        EmitEventLoopSyncContext(moduleBuilder, runtime);
+    }
+
+    /// <summary>
+    /// Emits <c>$EventLoopSyncContext</c>, a <see cref="SynchronizationContext"/>
+    /// whose <c>Post</c> enqueues the continuation onto <c>$EventLoop._queue</c>
+    /// (via <c>Schedule</c>) so async/await continuations resume on the
+    /// event-loop thread instead of a thread-pool thread. Without it, a
+    /// Task-backed promise (e.g. <c>fetch</c>) settles on a pool thread and its
+    /// continuation is dispatched back to the pool — invisible to the entry
+    /// point's WaitForTask busy-check, so under pool pressure the gap exceeds the
+    /// quiescence window and the still-settling top-level promise is abandoned.
+    /// Standalone-safe: references only BCL types and the emitted $EventLoop.
+    /// </summary>
+    private void EmitEventLoopSyncContext(ModuleBuilder moduleBuilder, EmittedRuntime runtime)
+    {
+        // --- Closure: holds (SendOrPostCallback d, object state); Run() => d(state). ---
+        var closure = moduleBuilder.DefineType(
+            "$SyncContextClosure",
+            TypeAttributes.Public | TypeAttributes.Sealed | TypeAttributes.BeforeFieldInit,
+            _types.Object);
+        var dField = closure.DefineField("_d", typeof(SendOrPostCallback), FieldAttributes.Public);
+        var stateField = closure.DefineField("_state", _types.Object, FieldAttributes.Public);
+
+        var closureCtor = closure.DefineConstructor(
+            MethodAttributes.Public, CallingConventions.Standard, Type.EmptyTypes);
+        {
+            var cil = closureCtor.GetILGenerator();
+            cil.Emit(OpCodes.Ldarg_0);
+            cil.Emit(OpCodes.Call, _types.GetDefaultConstructor(_types.Object));
+            cil.Emit(OpCodes.Ret);
+        }
+
+        var runMethod = closure.DefineMethod(
+            "Run", MethodAttributes.Public, typeof(void), Type.EmptyTypes);
+        {
+            var ril = runMethod.GetILGenerator();
+            // _d(_state)
+            ril.Emit(OpCodes.Ldarg_0);
+            ril.Emit(OpCodes.Ldfld, dField);
+            ril.Emit(OpCodes.Ldarg_0);
+            ril.Emit(OpCodes.Ldfld, stateField);
+            ril.Emit(OpCodes.Callvirt, typeof(SendOrPostCallback).GetMethod("Invoke")!);
+            ril.Emit(OpCodes.Ret);
+        }
+        closure.CreateType();
+
+        // --- $EventLoopSyncContext : SynchronizationContext ---
+        var sc = moduleBuilder.DefineType(
+            "$EventLoopSyncContext",
+            TypeAttributes.Public | TypeAttributes.Sealed | TypeAttributes.BeforeFieldInit,
+            typeof(SynchronizationContext));
+
+        var scCtor = sc.DefineConstructor(
+            MethodAttributes.Public, CallingConventions.Standard, Type.EmptyTypes);
+        {
+            var cil = scCtor.GetILGenerator();
+            cil.Emit(OpCodes.Ldarg_0);
+            cil.Emit(OpCodes.Call, typeof(SynchronizationContext).GetConstructor(Type.EmptyTypes)!);
+            cil.Emit(OpCodes.Ret);
+        }
+        runtime.EventLoopSyncContextCtor = scCtor;
+
+        // public override void Post(SendOrPostCallback d, object state)
+        //   => $EventLoop.GetInstance().Schedule(new Action(new $SyncContextClosure{ _d=d, _state=state }.Run));
+        var post = sc.DefineMethod(
+            "Post",
+            MethodAttributes.Public | MethodAttributes.Virtual | MethodAttributes.HideBySig,
+            typeof(void), [typeof(SendOrPostCallback), _types.Object]);
+        {
+            var pil = post.GetILGenerator();
+            var c = pil.DeclareLocal(closure);
+            pil.Emit(OpCodes.Newobj, closureCtor);
+            pil.Emit(OpCodes.Stloc, c);
+            pil.Emit(OpCodes.Ldloc, c);
+            pil.Emit(OpCodes.Ldarg_1);
+            pil.Emit(OpCodes.Stfld, dField);
+            pil.Emit(OpCodes.Ldloc, c);
+            pil.Emit(OpCodes.Ldarg_2);
+            pil.Emit(OpCodes.Stfld, stateField);
+            pil.Emit(OpCodes.Call, runtime.EventLoopGetInstance);
+            pil.Emit(OpCodes.Ldloc, c);
+            pil.Emit(OpCodes.Ldftn, runMethod);
+            pil.Emit(OpCodes.Newobj, typeof(Action).GetConstructor([_types.Object, typeof(IntPtr)])!);
+            pil.Emit(OpCodes.Callvirt, runtime.EventLoopSchedule);
+            pil.Emit(OpCodes.Ret);
+        }
+        sc.DefineMethodOverride(post, typeof(SynchronizationContext).GetMethod("Post")!);
+
+        // public override void Send(SendOrPostCallback d, object state) => Post(d, state);
+        var send = sc.DefineMethod(
+            "Send",
+            MethodAttributes.Public | MethodAttributes.Virtual | MethodAttributes.HideBySig,
+            typeof(void), [typeof(SendOrPostCallback), _types.Object]);
+        {
+            var sil = send.GetILGenerator();
+            sil.Emit(OpCodes.Ldarg_0);
+            sil.Emit(OpCodes.Ldarg_1);
+            sil.Emit(OpCodes.Ldarg_2);
+            sil.Emit(OpCodes.Callvirt, post);
+            sil.Emit(OpCodes.Ret);
+        }
+        sc.DefineMethodOverride(send, typeof(SynchronizationContext).GetMethod("Send")!);
+
+        // public override SynchronizationContext CreateCopy() => this;
+        var copy = sc.DefineMethod(
+            "CreateCopy",
+            MethodAttributes.Public | MethodAttributes.Virtual | MethodAttributes.HideBySig,
+            typeof(SynchronizationContext), Type.EmptyTypes);
+        {
+            var kil = copy.GetILGenerator();
+            kil.Emit(OpCodes.Ldarg_0);
+            kil.Emit(OpCodes.Ret);
+        }
+        sc.DefineMethodOverride(copy, typeof(SynchronizationContext).GetMethod("CreateCopy")!);
+
+        sc.CreateType();
     }
 
     private void EmitEventLoopGetInstance(TypeBuilder typeBuilder, EmittedRuntime runtime,
@@ -389,9 +510,12 @@ public partial class RuntimeEmitter
         // -1 while busy.
         var quiescentStartLocal = il.DeclareLocal(typeof(long));
         var waitMsLocal = il.DeclareLocal(_types.Int32);
+        var actionLocal = il.DeclareLocal(typeof(Action));
 
         var loopTop = il.DefineLabel();
         var notDone = il.DefineLabel();
+        var drainTop = il.DefineLabel();
+        var drainEnd = il.DefineLabel();
         var skipTimers = il.DefineLabel();
         var busyLabel = il.DefineLabel();
         var sleepLabel = il.DefineLabel();
@@ -418,6 +542,29 @@ public partial class RuntimeEmitter
         // ignored until process teardown.
         if (runtime.CheckCancellationMethod != null)
             il.Emit(OpCodes.Call, runtime.CheckCancellationMethod);
+
+        // Drain queued callbacks on THIS (event-loop) thread. async/await
+        // continuations are Posted here by $EventLoopSyncContext when their
+        // awaited Task settles on a thread-pool thread; running them may settle
+        // the task we're waiting on. Without this drain a Posted continuation
+        // would sit in the queue unexecuted — the awaited promise would never
+        // complete and would be misjudged as never-settling once the queue
+        // looked empty. Re-checks task completion after each callback.
+        il.MarkLabel(drainTop);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, _eventLoopQueueField);
+        il.Emit(OpCodes.Ldloca, actionLocal);
+        il.Emit(OpCodes.Callvirt, typeof(ConcurrentQueue<Action>).GetMethod("TryDequeue", [typeof(Action).MakeByRefType()])!);
+        il.Emit(OpCodes.Brfalse, drainEnd);
+        il.Emit(OpCodes.Ldloc, actionLocal);
+        il.Emit(OpCodes.Callvirt, typeof(Action).GetMethod("Invoke")!);
+        // if (task.IsCompleted) return true; else keep draining
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Callvirt, typeof(Task).GetProperty("IsCompleted")!.GetGetMethod()!);
+        il.Emit(OpCodes.Brfalse, drainTop);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Ret);
+        il.MarkLabel(drainEnd);
 
         // waitMs = -1; if (_timerProcessor != null) waitMs = _timerProcessor.Invoke();
         // Invoke fires due timers (their callbacks may settle the task) and

--- a/SharpTS.Tests/Infrastructure/TestHarness.cs
+++ b/SharpTS.Tests/Infrastructure/TestHarness.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Reflection;
+using System.Runtime.ExceptionServices;
 using SharpTS.Compilation;
 using SharpTS.Execution;
 using SharpTS.Modules;
@@ -299,13 +300,21 @@ public static class TestHarness
         var task = Task.Run(() =>
         {
             using var capture = AsyncLocalConsoleRedirector.Capture();
+            // The compiled Main installs an event-loop SynchronizationContext on
+            // this thread; restore the previous one so it doesn't leak onto the
+            // recycled Task.Run pool thread and disturb a sibling test.
+            var prevCtx = System.Threading.SynchronizationContext.Current;
             try
             {
                 mainMethod.Invoke(null, null);
             }
             catch (TargetInvocationException tie) when (tie.InnerException is not null)
             {
-                System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(tie.InnerException).Throw();
+                ExceptionDispatchInfo.Capture(tie.InnerException).Throw();
+            }
+            finally
+            {
+                System.Threading.SynchronizationContext.SetSynchronizationContext(prevCtx);
             }
             return capture.GetOutput().Replace("\r\n", "\n");
         });
@@ -539,7 +548,9 @@ public static class TestHarness
         using var capture = AsyncLocalConsoleRedirector.Capture();
         var programType = assembly.GetType("$Program");
         var mainMethod = programType?.GetMethod("Main", BindingFlags.Public | BindingFlags.Static);
-        mainMethod?.Invoke(null, null);
+        var prevCtx = System.Threading.SynchronizationContext.Current;
+        try { mainMethod?.Invoke(null, null); }
+        finally { System.Threading.SynchronizationContext.SetSynchronizationContext(prevCtx); }
 
         return (assembly, capture.GetOutput().Replace("\r\n", "\n"));
     }
@@ -872,11 +883,13 @@ public static class TestHarness
             var task = Task.Run(() =>
             {
                 using var capture = AsyncLocalConsoleRedirector.Capture();
+                var prevCtx = System.Threading.SynchronizationContext.Current;
                 try { mainMethod.Invoke(null, null); }
                 catch (TargetInvocationException tie) when (tie.InnerException is not null)
                 {
-                    System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(tie.InnerException).Throw();
+                    ExceptionDispatchInfo.Capture(tie.InnerException).Throw();
                 }
+                finally { System.Threading.SynchronizationContext.SetSynchronizationContext(prevCtx); }
                 return capture.GetOutput().Replace("\r\n", "\n");
             });
 

--- a/SharpTS.Tests/SharedTests/AsyncCallbackResumeTests.cs
+++ b/SharpTS.Tests/SharedTests/AsyncCallbackResumeTests.cs
@@ -37,7 +37,7 @@ public class AsyncCallbackResumeTests
     }
 
     [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void AsyncCallback_ResumesWithModuleScope_AfterAwait(ExecutionMode mode)
     {
         // #207: an async arrow passed to a built-in (server.listen) suspends at
@@ -65,7 +65,7 @@ public class AsyncCallbackResumeTests
     }
 
     [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void AsyncCallback_FetchAfterAwait_InListenCallback(ExecutionMode mode)
     {
         // The full #207 repro: await fetch() against the just-started server,

--- a/SharpTS.Tests/SharedTests/EventLoopContinuationTests.cs
+++ b/SharpTS.Tests/SharedTests/EventLoopContinuationTests.cs
@@ -1,0 +1,58 @@
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests;
+
+/// <summary>
+/// Regression tests for the compiled-mode event-loop continuation handling.
+///
+/// A Task-backed promise (e.g. <c>fetch</c>) settles on a thread-pool thread, so
+/// its <c>await</c> continuation is scheduled via <c>TaskAwaiter.OnCompleted</c>,
+/// which captures the ambient <see cref="System.Threading.SynchronizationContext"/>.
+/// Compiled mode now installs an event-loop sync context at the entry point, so
+/// those continuations resume on the event-loop thread (Node semantics) instead
+/// of escaping to the pool. Before that, a saturated/loaded pool could delay the
+/// escaped continuation past the entry point's 250ms quiescence window, causing
+/// the still-settling top-level promise to be abandoned and the program to print
+/// nothing — the macOS-CI flake behind the FetchCookie failures.
+///
+/// These exercise the post-await path deterministically: code after two
+/// sequential awaited fetches must run, see its closure binding, and print.
+/// </summary>
+public class EventLoopContinuationTests : IDisposable
+{
+    private readonly MockHttpServer _server;
+
+    public EventLoopContinuationTests()
+    {
+        _server = new MockHttpServer();
+        _server.AddTextRoute("/a", "AA");
+        _server.AddTextRoute("/b", "BB");
+        _server.Start();
+    }
+
+    public void Dispose() => _server.Dispose();
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void TopLevelAsync_SequentialFetches_RunsContinuationAfterAwait(ExecutionMode mode)
+    {
+        // The continuation after each await (and the closure capture of `tag`)
+        // must run for this to print. Mirrors the FetchCookie pattern that
+        // flaked on macOS CI.
+        var source = $$"""
+            const tag: string = "OK";
+            async function main(): Promise<void> {
+                const a: any = await fetch('{{_server.BaseUrl}}a');
+                const ta: string = await a.text();
+                const b: any = await fetch('{{_server.BaseUrl}}b');
+                const tb: string = await b.text();
+                console.log(tag + ":" + ta + tb);
+            }
+            main();
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("OK:AABB\n", output);
+    }
+}


### PR DESCRIPTION
## Problem

The recurring compiled-mode network/async CI flakes — empty output, predominantly on macOS (e.g. #285's `FetchCookieTests.Cookies_OmitDoesNotStoreSetCookie` expected `"[]\n"`, got `""`) — share **one** root cause, not many. Prior fixes (#229 mDNS hosts, `feeb7907` socket-connect Ref, #41 HTTP drain, #238 interpreter sync-context, #273 TypeNodeStats) were point-patches on the same wound.

## Root cause

Compiled mode installed **no `SynchronizationContext`** (the #238 sync-context fix was interpreter-only). A Task-backed promise (`fetch` = `Task.Run`) settles on a thread-pool thread, so its `await` continuation is dispatched **back to the pool** via `TaskAwaiter.OnCompleted` with no captured context. That continuation is **invisible to the entry point's `$EventLoop.WaitForTask` busy-check**, which abandons a top-level promise after 250ms of apparent quiescence (the Test262 never-settle escape). Under thread-pool pressure (loaded macOS CI) the post-`fetch` continuation waits past 250ms for hill-climbing → the still-settling promise is silently skipped → empty output.

During the spike I confirmed that **timer/TCS-backed promises run continuations inline on the main thread** and never escape — which is why only Task-backed (`fetch`) promises under pool pressure flake, and why a timer-based repro can't reproduce it.

## Fix (3 parts, standalone-safe — BCL-only refs)

1. Emit `$EventLoopSyncContext : SynchronizationContext` whose `Post` enqueues the continuation onto `$EventLoop._queue` via `Schedule`.
2. Install it at the top of each compiled `Main` (`EmitInstallEventLoopSyncContext`, both entry-point emitters) so the first awaiter captures it.
3. Drain `_queue` each iteration in `WaitForTask` — without the drain a Posted continuation never runs and the awaited promise hangs.

Continuations now land in the queue **immediately** at task completion (pool-pressure-independent) and run on the main event-loop thread. The never-settle escape is preserved: a genuinely idle program has an empty queue, so the drain is a no-op and it still exits at 250ms.

`TestHarness` saves/restores `SynchronizationContext.Current` around the in-process `Main` invoke (Main runs on a recycled `Task.Run` pool thread; leaking the context would disturb sibling tests).

## Validation

- **Full suite: 10829 passed / 0 failed / 1 skipped** (known lodash/#276 skip).
- Release async/network slice: 1347 passed. Standalone + IL-verify: 91 passed.
- The `AsyncCallbackResumeTests` fetch-after-await / resume-with-module-scope patterns were gated **`InterpretedOnly` precisely because compiled continuations escaped** — they now pass in **Compiled** mode (real new coverage).
- Adds `EventLoopContinuationTests` for the #285 shape (both modes).

## Not yet run

- **Test262 compiled baseline** — exercises this async path. Never-settle behavior is preserved by design, but worth a pre-merge run since it's a core-async change.
- The deferred test-infra hardening from the investigation (bind/connect `127.0.0.1` instead of `localhost`; a scoped retry collection) remains available as belt-and-suspenders; this PR fixes the mechanism directly.
