### PR TITLE
fix(compile): value-form Math/JSON singleton methods (#276); confirm #279

### DIFF
--- a/Compilation/EmittedRuntime.cs
+++ b/Compilation/EmittedRuntime.cs
@@ -419,6 +419,18 @@ public class EmittedRuntime
     /// the Array helper MethodBuilders are defined.
     /// </summary>
     public MethodBuilder ArrayPrototypePopulateMethod { get; set; } = null!;
+    /// <summary>
+    /// Populates <see cref="MathSingletonField"/> with $TSFunction wrappers for
+    /// the Math static methods (max/min/floor/…) so value-form access
+    /// (<c>const m = Math; m.max(1,2)</c>) resolves. Idempotent. See issue #276.
+    /// </summary>
+    public MethodBuilder MathSingletonPopulateMethod { get; set; } = null!;
+    /// <summary>
+    /// Populates <see cref="JsonSingletonField"/> with $TSFunction wrappers for
+    /// JSON.parse / JSON.stringify so value-form access
+    /// (<c>const j = JSON; j.stringify(x)</c>) resolves. Idempotent. See issue #276.
+    /// </summary>
+    public MethodBuilder JsonSingletonPopulateMethod { get; set; } = null!;
     /// <summary>Populates <see cref="StringPrototypeField"/> with $TSFunction wrappers; idempotent.</summary>
     public MethodBuilder StringPrototypePopulateMethod { get; set; } = null!;
     /// <summary>Populates <see cref="NumberPrototypeField"/> with $TSFunction wrappers; idempotent.</summary>

--- a/Compilation/Emitters/JSONStaticEmitter.cs
+++ b/Compilation/Emitters/JSONStaticEmitter.cs
@@ -150,6 +150,22 @@ public sealed class JSONStaticEmitter : IStaticTypeEmitterStrategy
         return true;
     }
 
+    /// <summary>
+    /// Canonical source of the spec-stable JSON static methods exposed in value
+    /// form, with the matching <c>$Runtime</c> method and ECMA-262 §17 spec
+    /// length. Consumed both by <see cref="TryEmitStaticPropertyGet"/>
+    /// (<c>let p = JSON.parse</c>) and by the JSON singleton populate step that
+    /// fills <c>_jsonSingleton</c> for value-form receivers
+    /// (<c>const j = JSON; j.stringify(x)</c>, issue #276). The rawJSON/isRawJSON
+    /// proposal stubs are intentionally excluded — they exist only to satisfy
+    /// typeof/isConstructor probes, not to be invoked off a JSON value.
+    /// </summary>
+    internal static IEnumerable<(string Name, MethodInfo? Method, int Length)> EnumerateValueFormMethods(EmittedRuntime runtime)
+    {
+        yield return ("parse",     runtime.JsonParse, 2);
+        yield return ("stringify", runtime.JsonStringify, 3);
+    }
+
     public bool HasStaticProperty(string memberName) =>
         memberName is "parse" or "stringify";
 }

--- a/Compilation/Emitters/MathStaticEmitter.cs
+++ b/Compilation/Emitters/MathStaticEmitter.cs
@@ -447,48 +447,7 @@ public sealed class MathStaticEmitter : IStaticTypeEmitterStrategy
         // Stage 4z5: tuple of (adapter, jsName, jsLength) so .name reports
         // the JS-spec name (lowercase) instead of the .NET adapter method
         // name (e.g. "MathFloorAdapter") and .length reports the spec length.
-        // Spec lengths from ECMA-262 21.3.2:
-        //   pow/atan2/imul/max/min ... → 2
-        //   hypot → 2 (per spec); others → 1; random → 0.
-        (MethodInfo? adapter, int len) info = propertyName switch
-        {
-            "floor"  => (runtime.MathFloorAdapter, 1),
-            "ceil"   => (runtime.MathCeilAdapter, 1),
-            "abs"    => (runtime.MathAbsAdapter, 1),
-            "sqrt"   => (runtime.MathSqrtAdapter, 1),
-            "round"  => (runtime.MathRoundAdapter, 1),
-            "trunc"  => (runtime.MathTruncAdapter, 1),
-            "sign"   => (runtime.MathSignAdapter, 1),
-            "sin"    => (runtime.MathSinAdapter, 1),
-            "cos"    => (runtime.MathCosAdapter, 1),
-            "tan"    => (runtime.MathTanAdapter, 1),
-            "log"    => (runtime.MathLogAdapter, 1),
-            "exp"    => (runtime.MathExpAdapter, 1),
-            "pow"    => (runtime.MathPowAdapter, 2),
-            "max"    => (runtime.MathMaxAdapter, 2),
-            "min"    => (runtime.MathMinAdapter, 2),
-            "random" => (runtime.Random, 0),
-            "asin"   => (runtime.MathAsinAdapter, 1),
-            "acos"   => (runtime.MathAcosAdapter, 1),
-            "atan"   => (runtime.MathAtanAdapter, 1),
-            "atan2"  => (runtime.MathAtan2Adapter, 2),
-            "sinh"   => (runtime.MathSinhAdapter, 1),
-            "cosh"   => (runtime.MathCoshAdapter, 1),
-            "tanh"   => (runtime.MathTanhAdapter, 1),
-            "asinh"  => (runtime.MathAsinhAdapter, 1),
-            "acosh"  => (runtime.MathAcoshAdapter, 1),
-            "atanh"  => (runtime.MathAtanhAdapter, 1),
-            "cbrt"   => (runtime.MathCbrtAdapter, 1),
-            "log10"  => (runtime.MathLog10Adapter, 1),
-            "log2"   => (runtime.MathLog2Adapter, 1),
-            "log1p"  => (runtime.MathLog1pAdapter, 1),
-            "expm1"  => (runtime.MathExpm1Adapter, 1),
-            "fround" => (runtime.MathFroundAdapter, 1),
-            "clz32"  => (runtime.MathClz32Adapter, 1),
-            "imul"   => (runtime.MathImulAdapter, 2),
-            "hypot"  => (runtime.MathHypotAdapter, 2),
-            _ => (null, 0)
-        };
+        (MethodInfo? adapter, int len) info = ResolveValueFormMethod(runtime, propertyName);
         if (info.adapter == null) return false;
 
         // $TSFunction.GetOrCreate(MethodInfo, name, length) — cached identity
@@ -503,6 +462,67 @@ public sealed class MathStaticEmitter : IStaticTypeEmitterStrategy
         il.Emit(OpCodes.Ldc_I4, info.len);
         il.Emit(OpCodes.Call, runtime.TSFunctionGetOrCreate);
         return true;
+    }
+
+    /// <summary>
+    /// Canonical source of the Math static methods exposed in value form, with
+    /// the matching <c>$Runtime</c> adapter and ECMA-262 21.3.2 spec length.
+    /// Consumed both by <see cref="TryEmitStaticPropertyGet"/> (syntactic
+    /// <c>var f = Math.floor</c>) and by the Math singleton populate step that
+    /// fills <c>_mathSingleton</c> for value-form receivers
+    /// (<c>const m = Math; m.floor(x)</c>, issue #276). Single source of truth so
+    /// the two paths can never drift on names/lengths.
+    /// </summary>
+    internal static IEnumerable<(string Name, MethodInfo? Adapter, int Length)> EnumerateValueFormMethods(EmittedRuntime runtime)
+    {
+        yield return ("floor",  runtime.MathFloorAdapter, 1);
+        yield return ("ceil",   runtime.MathCeilAdapter, 1);
+        yield return ("abs",    runtime.MathAbsAdapter, 1);
+        yield return ("sqrt",   runtime.MathSqrtAdapter, 1);
+        yield return ("round",  runtime.MathRoundAdapter, 1);
+        yield return ("trunc",  runtime.MathTruncAdapter, 1);
+        yield return ("sign",   runtime.MathSignAdapter, 1);
+        yield return ("sin",    runtime.MathSinAdapter, 1);
+        yield return ("cos",    runtime.MathCosAdapter, 1);
+        yield return ("tan",    runtime.MathTanAdapter, 1);
+        yield return ("log",    runtime.MathLogAdapter, 1);
+        yield return ("exp",    runtime.MathExpAdapter, 1);
+        yield return ("pow",    runtime.MathPowAdapter, 2);
+        yield return ("max",    runtime.MathMaxAdapter, 2);
+        yield return ("min",    runtime.MathMinAdapter, 2);
+        yield return ("random", runtime.Random, 0);
+        yield return ("asin",   runtime.MathAsinAdapter, 1);
+        yield return ("acos",   runtime.MathAcosAdapter, 1);
+        yield return ("atan",   runtime.MathAtanAdapter, 1);
+        yield return ("atan2",  runtime.MathAtan2Adapter, 2);
+        yield return ("sinh",   runtime.MathSinhAdapter, 1);
+        yield return ("cosh",   runtime.MathCoshAdapter, 1);
+        yield return ("tanh",   runtime.MathTanhAdapter, 1);
+        yield return ("asinh",  runtime.MathAsinhAdapter, 1);
+        yield return ("acosh",  runtime.MathAcoshAdapter, 1);
+        yield return ("atanh",  runtime.MathAtanhAdapter, 1);
+        yield return ("cbrt",   runtime.MathCbrtAdapter, 1);
+        yield return ("log10",  runtime.MathLog10Adapter, 1);
+        yield return ("log2",   runtime.MathLog2Adapter, 1);
+        yield return ("log1p",  runtime.MathLog1pAdapter, 1);
+        yield return ("expm1",  runtime.MathExpm1Adapter, 1);
+        yield return ("fround", runtime.MathFroundAdapter, 1);
+        yield return ("clz32",  runtime.MathClz32Adapter, 1);
+        yield return ("imul",   runtime.MathImulAdapter, 2);
+        yield return ("hypot",  runtime.MathHypotAdapter, 2);
+    }
+
+    /// <summary>
+    /// Looks up a single value-form Math method by name. Returns
+    /// <c>(null, 0)</c> if the name is not a value-form method.
+    /// </summary>
+    internal static (MethodInfo? adapter, int len) ResolveValueFormMethod(EmittedRuntime runtime, string propertyName)
+    {
+        foreach (var (name, adapter, len) in EnumerateValueFormMethods(runtime))
+        {
+            if (name == propertyName) return (adapter, len);
+        }
+        return (null, 0);
     }
 
     public bool HasStaticProperty(string memberName) =>

--- a/Compilation/RuntimeEmitter.BuiltinSingletonPopulate.cs
+++ b/Compilation/RuntimeEmitter.BuiltinSingletonPopulate.cs
@@ -1,0 +1,125 @@
+using System.Reflection;
+using System.Reflection.Emit;
+using SharpTS.Compilation.Emitters;
+
+namespace SharpTS.Compilation;
+
+public partial class RuntimeEmitter
+{
+    // Math.* / JSON.* are normally intercepted at compile time by the dedicated
+    // static emitters (MathStaticEmitter / JSONStaticEmitter) before the
+    // receiver is evaluated as a value. When the singleton is used as a *value*
+    // (`const m = Math; m.max(1, 2)` or `globalThis.Math.max`), dispatch falls
+    // through to the runtime `_mathSingleton` / `_jsonSingleton` dictionaries.
+    // Those dicts were created empty and never populated, so the lookup returned
+    // undefined. These populate steps fill them with $TSFunction wrappers — the
+    // same identity-cached wrappers the value-form static emitters hand out — so
+    // value-form access matches the bare syntactic form. Mirrors
+    // EmitArrayPrototypePopulate / EmitObjectPrototypePopulate. See issue #276.
+
+    private void DefineMathSingletonPopulateShell(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    {
+        runtime.MathSingletonPopulateMethod = typeBuilder.DefineMethod(
+            "_MathSingletonPopulate",
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.Void,
+            Type.EmptyTypes);
+    }
+
+    private void DefineJsonSingletonPopulateShell(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    {
+        runtime.JsonSingletonPopulateMethod = typeBuilder.DefineMethod(
+            "_JsonSingletonPopulate",
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.Void,
+            Type.EmptyTypes);
+    }
+
+    private void EmitMathSingletonPopulate(EmittedRuntime runtime) =>
+        EmitBuiltinSingletonPopulate(
+            runtime.MathSingletonPopulateMethod,
+            runtime.MathSingletonField,
+            runtime,
+            MathStaticEmitter.EnumerateValueFormMethods(runtime));
+
+    private void EmitJsonSingletonPopulate(EmittedRuntime runtime) =>
+        EmitBuiltinSingletonPopulate(
+            runtime.JsonSingletonPopulateMethod,
+            runtime.JsonSingletonField,
+            runtime,
+            JSONStaticEmitter.EnumerateValueFormMethods(runtime));
+
+    /// <summary>
+    /// Fills a built-in singleton dictionary with identity-cached $TSFunction
+    /// wrappers (one per value-form method) plus a non-enumerable PDS descriptor
+    /// for each, matching ECMA-262 §17 built-in attributes. Idempotent: bails if
+    /// the dict already has entries. Entries whose backing MethodBuilder is null
+    /// (e.g. JSON helpers when the program doesn't use JSON) are skipped, so the
+    /// body is always valid IL regardless of feature gating.
+    /// </summary>
+    private void EmitBuiltinSingletonPopulate(
+        MethodBuilder method,
+        FieldBuilder singletonField,
+        EmittedRuntime runtime,
+        IEnumerable<(string Name, MethodInfo? Backing, int Length)> methods)
+    {
+        var il = method.GetILGenerator();
+        var setItem = _types.GetMethod(_types.DictionaryStringObject, "set_Item",
+            _types.String, _types.Object);
+        var getMethodFromHandle = _types.GetMethod(_types.MethodBase, "GetMethodFromHandle",
+            _types.RuntimeMethodHandle, _types.RuntimeTypeHandle);
+
+        // Idempotent: cctor calls this once, but a future static-init reordering
+        // shouldn't double-fill.
+        var doFillLabel = il.DefineLabel();
+        il.Emit(OpCodes.Ldsfld, singletonField);
+        il.Emit(OpCodes.Callvirt, _types.GetProperty(_types.DictionaryStringObject, "Count").GetGetMethod()!);
+        il.Emit(OpCodes.Brfalse, doFillLabel);
+        il.Emit(OpCodes.Ret);
+        il.MarkLabel(doFillLabel);
+
+        var descLocal = il.DeclareLocal(runtime.CompiledPropertyDescriptorType);
+        void InstallNonEnumerable(string jsName, System.Action emitValue)
+        {
+            il.Emit(OpCodes.Newobj, runtime.CompiledPropertyDescriptorCtor);
+            il.Emit(OpCodes.Stloc, descLocal);
+            il.Emit(OpCodes.Ldloc, descLocal);
+            emitValue();
+            il.Emit(OpCodes.Callvirt, runtime.CompiledPropertyDescriptorValue.GetSetMethod()!);
+            il.Emit(OpCodes.Ldloc, descLocal);
+            il.Emit(OpCodes.Ldc_I4_0);
+            il.Emit(OpCodes.Callvirt, runtime.CompiledPropertyDescriptorEnumerable.GetSetMethod()!);
+            il.Emit(OpCodes.Ldsfld, singletonField);
+            il.Emit(OpCodes.Ldstr, jsName);
+            il.Emit(OpCodes.Ldloc, descLocal);
+            il.Emit(OpCodes.Call, runtime.PDSDefineProperty);
+            il.Emit(OpCodes.Pop);
+        }
+
+        var fnLocal = il.DeclareLocal(_types.Object);
+        foreach (var (jsName, backing, jsLength) in methods)
+        {
+            if (backing is null) continue;
+            // $TSFunction.GetOrCreate(MethodInfo, name, length) — cached identity
+            // so `m.max === Math.max` (same instance the value-form static
+            // emitter hands out).
+            il.Emit(OpCodes.Ldtoken, backing);
+            il.Emit(OpCodes.Ldtoken, backing.DeclaringType!);
+            il.Emit(OpCodes.Call, getMethodFromHandle);
+            il.Emit(OpCodes.Castclass, _types.MethodInfo);
+            il.Emit(OpCodes.Ldstr, jsName);
+            il.Emit(OpCodes.Ldc_I4, jsLength);
+            il.Emit(OpCodes.Call, runtime.TSFunctionGetOrCreate);
+            il.Emit(OpCodes.Stloc, fnLocal);
+            // Fast-path dict store (covers `m.max`) + non-enumerable descriptor
+            // (so `Object.keys(Math)` / for-in don't surface the methods).
+            il.Emit(OpCodes.Ldsfld, singletonField);
+            il.Emit(OpCodes.Ldstr, jsName);
+            il.Emit(OpCodes.Ldloc, fnLocal);
+            il.Emit(OpCodes.Callvirt, setItem);
+            InstallNonEnumerable(jsName, () => il.Emit(OpCodes.Ldloc, fnLocal));
+        }
+
+        il.Emit(OpCodes.Ret);
+    }
+}

--- a/Compilation/RuntimeEmitter.RuntimeClass.cs
+++ b/Compilation/RuntimeEmitter.RuntimeClass.cs
@@ -326,6 +326,8 @@ public partial class RuntimeEmitter
         // referenced. Idempotent — populate methods early-return if Count > 0.
         DefineObjectPrototypePopulateShell(typeBuilder, runtime);
         DefineArrayPrototypePopulateShell(typeBuilder, runtime);
+        DefineMathSingletonPopulateShell(typeBuilder, runtime);
+        DefineJsonSingletonPopulateShell(typeBuilder, runtime);
         DefineStringPrototypePopulateShell(typeBuilder, runtime);
         DefineNumberPrototypePopulateShell(typeBuilder, runtime);
         DefineBooleanPrototypePopulateShell(typeBuilder, runtime);
@@ -477,6 +479,11 @@ public partial class RuntimeEmitter
         cctorIL.Emit(OpCodes.Call, runtime.ErrorPrototypePopulateMethod);
         cctorIL.Emit(OpCodes.Call, runtime.FunctionPrototypePopulateMethod);
         cctorIL.Emit(OpCodes.Call, runtime.RegExpPrototypePopulateMethod);
+        // Math / JSON value-form singletons (`const m = Math; m.max(...)`). Each
+        // populate is idempotent and skips null backings, so calling the JSON one
+        // unconditionally is safe even when the program doesn't use JSON (#276).
+        cctorIL.Emit(OpCodes.Call, runtime.MathSingletonPopulateMethod);
+        cctorIL.Emit(OpCodes.Call, runtime.JsonSingletonPopulateMethod);
 
         cctorIL.Emit(OpCodes.Ret);
 
@@ -915,6 +922,12 @@ public partial class RuntimeEmitter
             EmitJsonStringify(typeBuilder, runtime);
             EmitJsonStringifyFull(typeBuilder, runtime);
         }
+        // Math / JSON value-form singleton populate bodies. Emitted here — after
+        // EmitMathAdapters (Math.*Adapter) and the JSON methods above — so their
+        // backing MethodBuilders are resolved. JSON helpers are null when JSON is
+        // unused; EmitBuiltinSingletonPopulate skips null backings. (#276)
+        EmitMathSingletonPopulate(runtime);
+        EmitJsonSingletonPopulate(runtime);
         // BigInt methods — gated on UsesBigInt. Detector flips it on for any
         // `123n` literal, bare `BigInt` identifier, or BigInt64Array/BigUint64Array
         // typed-array reference. EmitBigIntBinary in ILEmitter.Operators.cs only

--- a/SharpTS.Tests/SharedTests/BuiltInSingletonValueFormTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInSingletonValueFormTests.cs
@@ -1,0 +1,80 @@
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests;
+
+/// <summary>
+/// Regression for #276: in compiled mode, accessing a built-in singleton's
+/// method through a <em>value</em> (rather than the bare <c>Math.method(...)</c>
+/// syntactic form) yielded <c>undefined</c>. The dedicated static emitters
+/// (MathStaticEmitter / JSONStaticEmitter) intercept <c>Math.max(...)</c> at
+/// compile time before the receiver is evaluated; when the singleton is used as
+/// a value the lookup fell through to the runtime <c>_mathSingleton</c> /
+/// <c>_jsonSingleton</c> dictionaries, which were created empty and never
+/// populated. They are now lazily populated with the same identity-cached
+/// <c>$TSFunction</c> wrappers the value-form static emitters hand out.
+/// </summary>
+public class BuiltInSingletonValueFormTests
+{
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Math_AsValue_MethodsDispatch(ExecutionMode mode)
+    {
+        var source = @"
+            const m: any = Math;
+            console.log(typeof m.max);
+            console.log(m.max(1, 2));
+            console.log(m.min(5, 3, 8));
+            console.log(m.floor(3.7));
+            console.log(m.abs(-4));
+        ";
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("function\n2\n3\n3\n4\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Json_AsValue_MethodsDispatch(ExecutionMode mode)
+    {
+        var source = @"
+            const j: any = JSON;
+            console.log(typeof j.stringify);
+            console.log(j.stringify({ a: 1 }));
+            console.log(j.parse('{""b"":2}').b);
+        ";
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("function\n{\"a\":1}\n2\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    public void Math_AsValue_MethodIdentityIsStable(ExecutionMode mode)
+    {
+        // The value-form wrapper must be the same identity-cached $TSFunction the
+        // bare `Math.max` syntactic form hands out (ECMA-262: built-in methods are
+        // single objects). Interpreted mode synthesizes a fresh wrapper per read,
+        // so this is scoped to compiled mode.
+        var source = @"
+            const m: any = Math;
+            console.log(m.max === Math.max);
+            console.log(m.floor === Math.floor);
+        ";
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("true\ntrue\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    public void Math_AsValue_MethodsAreNonEnumerable(ExecutionMode mode)
+    {
+        // Math's methods are non-enumerable per ECMA-262 §17, so populating the
+        // singleton must install non-enumerable descriptors — `Object.keys(Math)`
+        // stays empty.
+        var source = @"
+            const m: any = Math;
+            console.log(Object.keys(m).length);
+        ";
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("0\n", output);
+    }
+}


### PR DESCRIPTION
## Summary

Batch targeting issues #276, #279, #281, #282. After investigation, this PR ships the **#276** fix and **confirms #279** is already resolved in `main`; **#281/#282 are deferred** (see below).

### #276 — value-form built-in singleton methods (Math.max, JSON.stringify, …) ✅ fixed

`Math.max(...)` / `JSON.stringify(...)` are intercepted at compile time by the dedicated static emitters before the receiver is evaluated as a value. When the singleton is used as a **value** (`const m = Math; m.max(1, 2)`, `globalThis.Math.max`, `const j = JSON; j.stringify(x)`), dispatch fell through to the runtime `_mathSingleton` / `_jsonSingleton` dictionaries — which were created empty and never populated, so the lookup returned `undefined`.

Added lazy populate steps (mirroring `EmitArrayPrototypePopulate` / `EmitObjectPrototypePopulate`) that fill both dicts with the **same identity-cached `$TSFunction` wrappers** the value-form static emitters hand out, plus non-enumerable PDS descriptors per ECMA-262 §17. The method/length tables now live in a **single source** on each emitter (`EnumerateValueFormMethods`), consumed by both the value-form property-get path and the new populate step so they can't drift.

Result in compiled mode:
- `typeof m.max === "function"`, `m.max(1,2) === 2`, `m.floor(3.7) === 3`
- `m.max === Math.max` (identity-stable)
- `Object.keys(Math)` stays empty (methods non-enumerable)
- `const j = JSON; j.stringify({a:1})` / `j.parse(...)` work

New regression tests in `BuiltInSingletonValueFormTests` (cross-mode for dispatch; compiled-only for identity + non-enumerability, since the interpreter has pre-existing gaps — filed as #288).

### #279 — generated `<Class>.GetProperty` ILVerify StackUnexpected ✅ already fixed

Already resolved in `main` by PR #284 (commit `5ef653e0`). The exact repro and a broad sweep of `GetProperty` shapes (typed/string/boolean getters, generic type-parameter getters, getters returning arrays/maps/sets/tuples/unions, inheritance, Error subclasses, static getters) all pass `--verify`. Covered by `ILVerificationTests.ClassGetPropertyWithTypedGetter_PassesILVerification`. No code change needed; commented on the issue recommending close.

### #281 / #282 — deferred ⏸️

Both explicitly "reuse the runtime registry + dispatch from **#266** as-is," but #266 is not in `main` — it lives in the still-open PR #285. On an origin/main base the symbol-accessor infrastructure doesn't exist (`RejectComputedAccessor` throws for every computed accessor), so there's nothing to extend. Deferred until #285 merges, at which point they build cleanly on the real #266 without duplicating it.

## New bugs filed during this batch

- **#287** — compiled: derived-class constructor with explicit `super(...)` fails ILVerify `CallCtor` (runs correctly; verifier-only, same family as #275/#278/#279).
- **#288** — interpreter: value-form Math singleton diverges from compiled (`Object.keys(Math)` throws; `Math.max !== Math.max`).

## Testing

Full suite green: **10831 passed, 1 skipped** (the pre-existing `Lodash_Compiled`), 0 failed.