### PR TITLE
type-AST: complete the node construct layer (corpus 68.7% → 100%) + first consumer flip

### DIFF
--- a/Parsing/AST.cs
+++ b/Parsing/AST.cs
@@ -365,7 +365,7 @@ public abstract record Stmt
     /// Class field declaration. For computed property names (e.g., [Symbol("key")]: type),
     /// ComputedKey contains the expression and Name is a synthetic token.
     /// </summary>
-    public record Field(Token Name, string? TypeAnnotation, Expr? Initializer, bool IsStatic = false, AccessModifier Access = AccessModifier.Public, bool IsReadonly = false, bool IsOptional = false, bool HasDefiniteAssignmentAssertion = false, List<Decorator>? Decorators = null, bool IsPrivate = false, bool IsDeclare = false, Expr? ComputedKey = null) : Stmt;
+    public record Field(Token Name, string? TypeAnnotation, Expr? Initializer, bool IsStatic = false, AccessModifier Access = AccessModifier.Public, bool IsReadonly = false, bool IsOptional = false, bool HasDefiniteAssignmentAssertion = false, List<Decorator>? Decorators = null, bool IsPrivate = false, bool IsDeclare = false, Expr? ComputedKey = null, TypeNode? TypeAnnotationNode = null) : Stmt;
     /// <summary>
     /// Getter/setter declaration. For computed accessor names (e.g., static get [Symbol.species]()),
     /// ComputedKey contains the expression and Name is a synthetic token.

--- a/Parsing/Parser.Classes.cs
+++ b/Parsing/Parser.Classes.cs
@@ -365,11 +365,14 @@ public partial class Parser
                     throw new Exception($"Parse Error at line {fieldName.Line}: A property cannot be both optional and have a definite assignment assertion.");
                 }
 
-                // Type annotation is optional (ES class fields).
+                // Type annotation is optional (ES class fields). Capture the structured node
+                // immediately (before the initializer Expression() can touch the side channel).
                 string? typeAnnotation = null;
+                TypeNode? typeAnnotationNode = null;
                 if (Match(TokenType.COLON))
                 {
                     typeAnnotation = ParseTypeAnnotation();
+                    typeAnnotationNode = TakeTypeNode();
                 }
 
                 Expr? initializer = null;
@@ -390,7 +393,7 @@ public partial class Parser
                 }
 
                 ConsumeSemicolon("Expect ';' after field declaration.");
-                var field = new Stmt.Field(fieldName, typeAnnotation, initializer, isStatic, access, isReadonly, isOptional, hasDefiniteAssignment, memberDecorators, IsPrivate: false, IsDeclare: isMemberDeclare);
+                var field = new Stmt.Field(fieldName, typeAnnotation, initializer, isStatic, access, isReadonly, isOptional, hasDefiniteAssignment, memberDecorators, IsPrivate: false, IsDeclare: isMemberDeclare, TypeAnnotationNode: typeAnnotationNode);
                 fields.Add(field);
                 if (isStatic)
                 {

--- a/Parsing/Parser.Declarations.cs
+++ b/Parsing/Parser.Declarations.cs
@@ -609,9 +609,11 @@ public partial class Parser
     {
         // Parse optional generic type parameters: <T, U extends Base>
         string genericPrefix = "";
+        List<TypeParam>? methodTypeParams = null;
         if (Check(TokenType.LESS))
         {
-            genericPrefix = FormatTypeParams(ParseTypeParameters());
+            methodTypeParams = ParseTypeParameters();
+            genericPrefix = FormatTypeParams(methodTypeParams);
         }
 
         Consume(TokenType.LEFT_PAREN, "Expect '(' for method parameters.");
@@ -620,8 +622,7 @@ public partial class Parser
         TypeNode? thisTypeNode = null;
         List<string> paramTypes = [];
         List<ParameterTypeNode> paramNodes = [];
-        // Generic signatures await type-parameter scoping (slice 3) — no node for those.
-        bool nodeComplete = genericPrefix.Length == 0;
+        bool nodeComplete = true;
 
         // Check for 'this' parameter in interface method
         if (Check(TokenType.THIS))
@@ -663,10 +664,17 @@ public partial class Parser
         string returnType = ParseTypeAnnotation();
         TypeNode? returnTypeNode = TakeTypeNode();
 
-        // Publish the structured form (or explicitly clear, so no nested node leaks out).
-        _lastTypeNode = nodeComplete && returnTypeNode is not null
+        // Publish the structured form (or explicitly clear, so no nested node leaks out). A generic
+        // method signature wraps the function in a GenericFunctionTypeNode; a `this` parameter has
+        // no slot on a generic signature's resolved form, so those fall back.
+        FunctionTypeNode? functionNode = nodeComplete && returnTypeNode is not null
             ? new FunctionTypeNode(thisTypeNode, paramNodes, returnTypeNode, startLine)
             : null;
+        _lastTypeNode = functionNode is null
+            ? null
+            : methodTypeParams is { Count: > 0 }
+                ? (thisTypeNode is null ? new GenericFunctionTypeNode(methodTypeParams, functionNode, startLine) : null)
+                : functionNode;
 
         if (thisType != null)
         {

--- a/Parsing/Parser.Types.cs
+++ b/Parsing/Parser.Types.cs
@@ -476,11 +476,16 @@ public partial class Parser
         // type-parameter list (e.g. `<U extends boolean>(a: U) => never`).
         if (Check(TokenType.LESS))
         {
+            int genericLine = Peek().Line;
             List<TypeParam>? typeParams = ParseTypeParameters(); // consumes <...>
             Consume(TokenType.LEFT_PAREN, "Expect '(' after type parameters in function type.");
             string body = ParseFunctionTypeBody(); // returns "(params) => ReturnType"
+            // The checker resolves type-parameter constraints/defaults from their TypeParam strings
+            // in a fresh scope, so the node only needs the params plus a node-formed body.
+            _lastTypeNode = typeParams is { Count: > 0 } && TakeTypeNode() is FunctionTypeNode bodyNode
+                ? new GenericFunctionTypeNode(typeParams, bodyNode, genericLine)
+                : null;
             string genericPrefix = FormatTypeParams(typeParams);
-            _lastTypeNode = null;
             return $"{genericPrefix}{body}";
         }
 
@@ -555,11 +560,15 @@ public partial class Parser
         // Handle template literal types: `literal` or `prefix${Type}suffix`
         else if (Match(TokenType.TEMPLATE_FULL))
         {
-            typeName = "`" + (string)Previous().Literal! + "`";
+            string literal = ((TemplateStringValue)Previous().Literal!).Cooked ?? "";
+            typeName = "`" + literal + "`";
+            // No interpolations — a single static segment (resolves to a string-literal type).
+            typeNode = new TemplateLiteralTypeNode([literal], [], Previous().Line);
         }
         else if (Match(TokenType.TEMPLATE_HEAD))
         {
             typeName = ParseTemplateLiteralType();
+            typeNode = TakeTypeNode();
         }
         // Handle string literal types: "success" | "error"
         else if (Match(TokenType.STRING))
@@ -1304,28 +1313,44 @@ public partial class Parser
     /// </summary>
     private string ParseTemplateLiteralType()
     {
+        int startLine = Previous().Line;
         var sb = new StringBuilder("`");
-        sb.Append((string)Previous().Literal!); // head string
+        // Static segments (N+1) around the N interpolations, mirroring NormalizeTemplateLiteralType.
+        var strings = new List<string>();
+        var interpolated = new List<TypeNode>();
+        bool nodeComplete = true;
+
+        // Template tokens carry a TemplateStringValue (cooked + raw); the type uses the cooked text.
+        string head = ((TemplateStringValue)Previous().Literal!).Cooked ?? "";
+        sb.Append(head);
+        strings.Add(head);
 
         // Parse first interpolated type
         sb.Append("${");
         sb.Append(ParseUnionType()); // Allow unions inside interpolation
         sb.Append('}');
+        if (TakeTypeNode() is { } firstNode) interpolated.Add(firstNode); else nodeComplete = false;
 
         // Parse middle parts
         while (Match(TokenType.TEMPLATE_MIDDLE))
         {
-            sb.Append((string)Previous().Literal!);
+            string mid = ((TemplateStringValue)Previous().Literal!).Cooked ?? "";
+            sb.Append(mid);
+            strings.Add(mid);
             sb.Append("${");
             sb.Append(ParseUnionType());
             sb.Append('}');
+            if (TakeTypeNode() is { } midNode) interpolated.Add(midNode); else nodeComplete = false;
         }
 
         // Expect tail
         Consume(TokenType.TEMPLATE_TAIL, "Expect end of template literal type.");
-        sb.Append((string)Previous().Literal!);
+        string tail = ((TemplateStringValue)Previous().Literal!).Cooked ?? "";
+        sb.Append(tail);
         sb.Append('`');
+        strings.Add(tail);
 
+        _lastTypeNode = nodeComplete ? new TemplateLiteralTypeNode(strings, interpolated, startLine) : null;
         return sb.ToString();
     }
 }

--- a/Parsing/Parser.Types.cs
+++ b/Parsing/Parser.Types.cs
@@ -809,9 +809,7 @@ public partial class Parser
         // Mapped types have a single member that uses 'in' instead of ':'
         if (IsMappedTypeStart())
         {
-            string mapped = ParseMappedType();
-            _lastTypeNode = null; // mapped types have no node yet
-            return mapped;
+            return ParseMappedType(); // sets _lastTypeNode (or null) itself
         }
 
         while (!Check(TokenType.RIGHT_BRACE) && !IsAtEnd())
@@ -1027,14 +1025,18 @@ public partial class Parser
     /// </summary>
     private string ParseMappedType()
     {
-        // Parse optional leading modifiers: +readonly, -readonly, readonly
+        int startLine = Peek().Line;
+        // Parse optional leading modifiers: +readonly, -readonly, readonly. Track flags alongside
+        // the string spelling so the node carries the same modifier intent the string path derives.
         string readonlyMod = "";
+        bool addReadonly = false, removeReadonly = false;
         if (Match(TokenType.PLUS))
         {
             if (Check(TokenType.READONLY))
             {
                 Advance();
                 readonlyMod = "+readonly ";
+                addReadonly = true;
             }
             else
             {
@@ -1047,6 +1049,7 @@ public partial class Parser
             {
                 Advance();
                 readonlyMod = "-readonly ";
+                removeReadonly = true;
             }
             else
             {
@@ -1056,6 +1059,7 @@ public partial class Parser
         else if (Match(TokenType.READONLY))
         {
             readonlyMod = "readonly ";
+            addReadonly = true; // plain readonly == AddReadonly (mirrors ParseMappedTypeInfo)
         }
 
         // Parse [K in Constraint]
@@ -1069,12 +1073,17 @@ public partial class Parser
 
         // Parse constraint (e.g., keyof T, or a union of string literals)
         string constraint = ParseTypeAnnotation();
+        TypeNode? constraintNode = TakeTypeNode();
 
         // Parse optional 'as' clause for key remapping
         string asClause = "";
+        TypeNode? asNode = null;
+        bool hasAs = false;
         if (Match(TokenType.AS))
         {
+            hasAs = true;
             string remapType = ParseTypeAnnotation();
+            asNode = TakeTypeNode();
             asClause = $" as {remapType}";
         }
 
@@ -1082,11 +1091,13 @@ public partial class Parser
 
         // Parse optional trailing modifiers: +?, -?, ?
         string optionalMod = "";
+        bool addOptional = false, removeOptional = false;
         if (Match(TokenType.PLUS))
         {
             if (Match(TokenType.QUESTION))
             {
                 optionalMod = "+?";
+                addOptional = true;
             }
             else
             {
@@ -1098,6 +1109,7 @@ public partial class Parser
             if (Match(TokenType.QUESTION))
             {
                 optionalMod = "-?";
+                removeOptional = true;
             }
             else
             {
@@ -1107,16 +1119,24 @@ public partial class Parser
         else if (Match(TokenType.QUESTION))
         {
             optionalMod = "?";
+            addOptional = true;
         }
 
         // Parse : ValueType
         Consume(TokenType.COLON, "Expect ':' after mapped type parameter.");
         string valueType = ParseTypeAnnotation();
+        TypeNode? valueNode = TakeTypeNode();
 
         // Handle optional separator and closing brace
         Match(TokenType.SEMICOLON);
         Consume(TokenType.RIGHT_BRACE, "Expect '}' after mapped type.");
 
+        // The node needs the constraint, the value type, and (when present) the as-clause to all
+        // have node forms. Any missing component drops the whole mapped type to the string path.
+        _lastTypeNode = constraintNode is not null && valueNode is not null && (!hasAs || asNode is not null)
+            ? new MappedTypeNode(paramName.Lexeme, constraintNode, valueNode, asNode,
+                addReadonly, removeReadonly, addOptional, removeOptional, startLine)
+            : null;
         return $"{{ {readonlyMod}[{paramName.Lexeme} in {constraint}{asClause}]{optionalMod}: {valueType} }}";
     }
 

--- a/Parsing/Parser.Types.cs
+++ b/Parsing/Parser.Types.cs
@@ -35,17 +35,20 @@ public partial class Parser
             if (Check(TokenType.IDENTIFIER))
             {
                 string paramName = Advance().Lexeme;
+                int assertsLine = Previous().Line;
                 if (Match(TokenType.IS))
                 {
                     // asserts x is T
                     string predicateType = ParseConditionalType();
-                    _lastTypeNode = null; // predicates have no node form yet
+                    _lastTypeNode = TakeTypeNode() is { } predNode
+                        ? new TypePredicateNode(paramName, predNode, IsAssertion: true, assertsLine)
+                        : null;
                     return $"asserts {paramName} is {predicateType}";
                 }
                 else
                 {
                     // asserts x (shorthand for asserting non-null/truthy)
-                    _lastTypeNode = null;
+                    _lastTypeNode = new AssertsNonNullTypeNode(paramName, assertsLine);
                     return $"asserts {paramName}";
                 }
             }
@@ -58,10 +61,13 @@ public partial class Parser
         // Check for "x is T" / "this is T" type predicate: an identifier (or `this`) followed by `is`.
         if ((Check(TokenType.IDENTIFIER) || Check(TokenType.THIS)) && PeekNext().Type == TokenType.IS)
         {
+            int predLine = Peek().Line;
             string paramName = Advance().Lexeme;
             Consume(TokenType.IS, "Expected 'is' after parameter name.");
             string predicateType = ParseConditionalType();
-            _lastTypeNode = null; // predicates have no node form yet
+            _lastTypeNode = TakeTypeNode() is { } predNode
+                ? new TypePredicateNode(paramName, predNode, IsAssertion: false, predLine)
+                : null;
             return $"{paramName} is {predicateType}";
         }
 
@@ -337,9 +343,10 @@ public partial class Parser
         // nested positions. ToTypeInfo marks the array/tuple readonly.
         if (Check(TokenType.READONLY))
         {
+            int readonlyLine = Peek().Line;
             Advance();
             string readonlyInner = ParsePrimaryType();
-            _lastTypeNode = null; // readonly modifier has no node form yet
+            _lastTypeNode = TakeTypeNode() is { } innerNode ? new ReadonlyTypeNode(innerNode, readonlyLine) : null;
             return "readonly " + readonlyInner;
         }
 
@@ -351,7 +358,10 @@ public partial class Parser
             {
                 // Constraint binds tighter than the enclosing conditional's `?`, so stop at union level.
                 string constraint = ParseUnionType();
-                _lastTypeNode = null;
+                TakeTypeNode(); // drain the constraint's side-channel node
+                // Mirror the string path exactly: the whole "U extends C" becomes the inferred
+                // parameter's name (the checker's InferredTypeParameter has no separate constraint).
+                _lastTypeNode = new InferTypeNode($"{paramName.Lexeme} extends {constraint}", paramName.Line);
                 return $"infer {paramName.Lexeme} extends {constraint}";
             }
             _lastTypeNode = new InferTypeNode(paramName.Lexeme, paramName.Line);
@@ -611,12 +621,15 @@ public partial class Parser
             typeNode = new NamedTypeNode(typeName, null, Previous().Line);
 
             // Qualified type name (namespace member): `Intl.CollatorOptions`, `NodeJS.Timer`.
+            // The dotted name carries on the NamedTypeNode; resolution hands the whole "Foo.Bar"
+            // to the same single-name path the string side uses (and ResolveGenericType for
+            // `Foo.Bar<T>`), so namespace lookup is identical.
             while (Check(TokenType.DOT) &&
                    (PeekNext().Type == TokenType.IDENTIFIER || IsContextualKeyword(PeekNext().Type)))
             {
                 Advance(); // consume '.'
                 typeName += "." + Advance().Lexeme;
-                typeNode = null; // qualified names have no node form yet
+                typeNode = new NamedTypeNode(typeName, null, Previous().Line);
             }
         }
         else

--- a/Parsing/Parser.Types.cs
+++ b/Parsing/Parser.Types.cs
@@ -380,17 +380,22 @@ public partial class Parser
         // constructable-object-type modelling.
         if (Match(TokenType.NEW))
         {
+            int ctorLine = Previous().Line;
             string genericPrefix = "";
+            List<TypeParam>? ctorTypeParams = null;
             if (Check(TokenType.LESS))
             {
-                genericPrefix = FormatTypeParams(ParseTypeParameters());
+                ctorTypeParams = ParseTypeParameters();
+                genericPrefix = FormatTypeParams(ctorTypeParams);
             }
             Consume(TokenType.LEFT_PAREN, "Expect '(' in constructor type.");
             string ctorBody = ParseFunctionTypeBody(); // returns "(params) => ReturnType"
-            // Generic constructor types await type-parameter scoping (slice 3), and a `this`
-            // parameter has no slot on a ConstructorSignature — both fall back to the string path.
-            _lastTypeNode = TakeTypeNode() is FunctionTypeNode { ThisType: null } ctorFn && genericPrefix.Length == 0
-                ? new ConstructorTypeNode(ctorFn.Parameters, ctorFn.ReturnType, ctorFn.Line)
+            // A `this` parameter has no slot on a ConstructorSignature, so it falls back. Otherwise
+            // the construct signature (with or without type parameters) carries onto a node.
+            _lastTypeNode = TakeTypeNode() is FunctionTypeNode { ThisType: null } ctorFn
+                ? (ctorTypeParams is { Count: > 0 }
+                    ? new GenericConstructorTypeNode(ctorTypeParams, ctorFn, ctorLine)
+                    : new ConstructorTypeNode(ctorFn.Parameters, ctorFn.ReturnType, ctorFn.Line))
                 : null;
             return $"{{ new {genericPrefix}{ctorBody} }}";
         }
@@ -918,7 +923,8 @@ public partial class Parser
                 // type, producing an arrow string "(params) => ret"; prefix "new " for a
                 // construct signature so ParseInlineObjectTypeInfo can tell the two apart.
                 members.Add("new " + ParseMethodSignature());
-                if (TakeTypeNode() is FunctionTypeNode ctorSig)
+                var ctorSig = TakeTypeNode();
+                if (ctorSig is FunctionTypeNode or GenericFunctionTypeNode)
                     memberNodes.Add(new ConstructSignatureMemberNode(ctorSig, newLine));
                 else
                     nodeComplete = false;
@@ -928,7 +934,8 @@ public partial class Parser
             {
                 int callLine = Peek().Line;
                 members.Add(ParseMethodSignature());
-                if (TakeTypeNode() is FunctionTypeNode callSig)
+                var callSig = TakeTypeNode();
+                if (callSig is FunctionTypeNode or GenericFunctionTypeNode)
                     memberNodes.Add(new CallSignatureMemberNode(callSig, callLine));
                 else
                     nodeComplete = false;

--- a/Parsing/Parser.Types.cs
+++ b/Parsing/Parser.Types.cs
@@ -223,9 +223,11 @@ public partial class Parser
         int saved = _current;
         Advance(); // consume 'extends'
 
+        int conditionalLine = Previous().Line;
+
         // Parse the extends type (which may contain 'infer' keywords)
         string extendsType = ParseUnionType();
-        _lastTypeNode = null; // discard the lookahead's node
+        TypeNode? extendsNode = TakeTypeNode();
 
         // Must have '?' for this to be a conditional type
         if (!Check(TokenType.QUESTION))
@@ -240,13 +242,18 @@ public partial class Parser
 
         // Parse true branch (recursive - can contain nested conditionals)
         string trueType = ParseConditionalType();
+        TypeNode? trueNode = TakeTypeNode();
 
         Consume(TokenType.COLON, "Expect ':' in conditional type.");
 
         // Parse false branch (recursive - can contain nested conditionals)
         string falseType = ParseConditionalType();
+        TypeNode? falseNode = TakeTypeNode();
 
-        _lastTypeNode = null; // conditional types have no node form yet
+        _lastTypeNode = checkNode is not null && extendsNode is not null
+                        && trueNode is not null && falseNode is not null
+            ? new ConditionalTypeNode(checkNode, extendsNode, trueNode, falseNode, conditionalLine)
+            : null;
         return $"{checkType} extends {extendsType} ? {trueType} : {falseType}";
     }
 
@@ -291,18 +298,29 @@ public partial class Parser
         // is written on its own line):  type T = & A & B;
         Match(TokenType.AMPERSAND);
 
+        int startLine = Peek().Line;
         List<string> types = [ParsePrimaryType()];
-        TypeNode? singleNode = TakeTypeNode();
+        List<TypeNode>? memberNodes = TakeTypeNode() is { } firstNode ? [firstNode] : null;
 
         while (Match(TokenType.AMPERSAND))
         {
             types.Add(ParsePrimaryType());
-            TakeTypeNode(); // intersections have no node form yet
-            singleNode = null;
+            var node = TakeTypeNode();
+            if (memberNodes is not null && node is not null)
+                memberNodes.Add(node);
+            else
+                memberNodes = null; // any node-less member disables the intersection node
         }
 
-        _lastTypeNode = types.Count == 1 ? singleNode : null;
-        return types.Count == 1 ? types[0] : string.Join(" & ", types);
+        if (types.Count == 1)
+        {
+            _lastTypeNode = memberNodes is { Count: 1 } ? memberNodes[0] : null;
+            return types[0];
+        }
+        _lastTypeNode = memberNodes is { } all && all.Count == types.Count
+            ? new IntersectionTypeNode(all, startLine)
+            : null;
+        return string.Join(" & ", types);
     }
 
     private string ParsePrimaryType()
@@ -336,7 +354,7 @@ public partial class Parser
                 _lastTypeNode = null;
                 return $"infer {paramName.Lexeme} extends {constraint}";
             }
-            _lastTypeNode = null;
+            _lastTypeNode = new InferTypeNode(paramName.Lexeme, paramName.Line);
             return $"infer {paramName.Lexeme}";
         }
 
@@ -370,8 +388,9 @@ public partial class Parser
         // Handle keyof prefix operator: keyof T
         if (Match(TokenType.KEYOF))
         {
+            int keyofLine = Previous().Line;
             string innerType = ParsePrimaryType();
-            _lastTypeNode = null;
+            _lastTypeNode = TakeTypeNode() is { } innerNode ? new KeyofTypeNode(innerNode, keyofLine) : null;
             return $"keyof {innerType}";
         }
 
@@ -390,6 +409,7 @@ public partial class Parser
         // Handle typeof in type position: typeof someVariable, typeof obj.prop, typeof arr[0]
         if (Match(TokenType.TYPEOF))
         {
+            int typeofLine = Previous().Line;
             StringBuilder sb = new();
             sb.Append("typeof ");
 
@@ -445,7 +465,9 @@ public partial class Parser
                 }
             }
 
-            _lastTypeNode = null;
+            // The entity path is everything after the "typeof " prefix; the resolver hands it to
+            // the same EvaluateTypeOf the string path uses.
+            _lastTypeNode = new TypeQueryNode(sb.ToString()["typeof ".Length..], typeofLine);
             return sb.ToString();
         }
 
@@ -647,10 +669,14 @@ public partial class Parser
             else
             {
                 // Indexed access type: T[K] or T["key"]
+                int indexLine = Previous().Line;
                 string indexType = ParseTypeAnnotation();
+                TypeNode? indexNode = TakeTypeNode();
                 Consume(TokenType.RIGHT_BRACKET, "Expect ']' after indexed access type.");
+                typeNode = typeNode is { } objNode && indexNode is not null
+                    ? new IndexedAccessTypeNode(objNode, indexNode, indexLine)
+                    : null;
                 typeName = $"{typeName}[{indexType}]";
-                typeNode = null; // indexed access has no node form yet
             }
         }
 

--- a/Parsing/TypeNodes.cs
+++ b/Parsing/TypeNodes.cs
@@ -67,8 +67,23 @@ public sealed record FunctionTypeNode(TypeNode? ThisType, List<ParameterTypeNode
 
 /// <summary>A constructor type: <c>new (a: T) =&gt; R</c>. Resolves to an object type carrying a
 /// single construct signature, mirroring the string path's <c>{ new (…) =&gt; R }</c> rendering.
-/// Generic constructor types (<c>new &lt;T&gt;(…) =&gt; R</c>) have no node yet (slice 3).</summary>
+/// Generic constructor types (<c>new &lt;T&gt;(…) =&gt; R</c>) have no node yet.</summary>
 public sealed record ConstructorTypeNode(List<ParameterTypeNode> Parameters, TypeNode ReturnType, int Line) : TypeNode(Line);
+
+/// <summary>A generic function type: <c>&lt;T&gt;(a: T) =&gt; R</c>. The type-parameter list is carried
+/// in its AST <see cref="TypeParam"/> form (constraints/defaults are resolved by the checker in a
+/// fresh type-parameter scope, exactly like the string path's two-pass
+/// <c>TryParseGenericFunctionTypeInfo</c>); the body is the inner <see cref="FunctionTypeNode"/>,
+/// resolved within that scope so its <c>T</c>s bind to the parameters. Resolves to
+/// <c>TypeInfo.GenericFunction</c>.</summary>
+public sealed record GenericFunctionTypeNode(List<TypeParam> TypeParameters, FunctionTypeNode Body, int Line) : TypeNode(Line);
+
+/// <summary>A template literal type: <c>`a${T}b`</c>. <see cref="Strings"/> holds the N+1 static
+/// segments around the N <see cref="InterpolatedTypes"/> (a plain <c>`text`</c> has one string and
+/// no interpolations). Resolution mirrors the string path's <c>NormalizeTemplateLiteralType</c>:
+/// all-concrete interpolations expand to a union of string literals, otherwise it stays a pattern
+/// <c>TypeInfo.TemplateLiteralType</c>.</summary>
+public sealed record TemplateLiteralTypeNode(List<string> Strings, List<TypeNode> InterpolatedTypes, int Line) : TypeNode(Line);
 
 /// <summary>An inline object type: <c>{ name: string; greet(x: number): void }</c>.</summary>
 public sealed record ObjectTypeNode(List<ObjectTypeMemberNode> Members, int Line) : TypeNode(Line);

--- a/Parsing/TypeNodes.cs
+++ b/Parsing/TypeNodes.cs
@@ -83,6 +83,12 @@ public sealed record FunctionTypeNode(TypeNode? ThisType, List<ParameterTypeNode
 /// Generic constructor types (<c>new &lt;T&gt;(…) =&gt; R</c>) have no node yet.</summary>
 public sealed record ConstructorTypeNode(List<ParameterTypeNode> Parameters, TypeNode ReturnType, int Line) : TypeNode(Line);
 
+/// <summary>A generic constructor type: <c>new &lt;T&gt;(a: T) =&gt; R</c>. Resolves to an object type
+/// carrying a single GENERIC construct signature; the type parameters scope the body exactly like
+/// <see cref="GenericFunctionTypeNode"/> (and the string path's per-signature scoping). A <c>this</c>
+/// parameter has no slot on a construct signature, so such constructors fall back.</summary>
+public sealed record GenericConstructorTypeNode(List<TypeParam> TypeParameters, FunctionTypeNode Body, int Line) : TypeNode(Line);
+
 /// <summary>A generic function type: <c>&lt;T&gt;(a: T) =&gt; R</c>. The type-parameter list is carried
 /// in its AST <see cref="TypeParam"/> form (constraints/defaults are resolved by the checker in a
 /// fresh type-parameter scope, exactly like the string path's two-pass
@@ -132,11 +138,14 @@ public sealed record PropertyMemberNode(string Name, TypeNode Type, bool IsOptio
 /// <c>string</c>, <c>number</c>, or <c>symbol</c>.</summary>
 public sealed record IndexSignatureNode(string KeyKind, TypeNode ValueType, int Line) : ObjectTypeMemberNode(Line);
 
-/// <summary>A call signature member: <c>(x: T): R</c>.</summary>
-public sealed record CallSignatureMemberNode(FunctionTypeNode Signature, int Line) : ObjectTypeMemberNode(Line);
+/// <summary>A call signature member: <c>(x: T): R</c> or generic <c>&lt;T&gt;(x: T): R</c>. The
+/// signature is a <see cref="FunctionTypeNode"/> (non-generic) or a
+/// <see cref="GenericFunctionTypeNode"/> (generic overload).</summary>
+public sealed record CallSignatureMemberNode(TypeNode Signature, int Line) : ObjectTypeMemberNode(Line);
 
-/// <summary>A construct signature member: <c>new (x: T): R</c>.</summary>
-public sealed record ConstructSignatureMemberNode(FunctionTypeNode Signature, int Line) : ObjectTypeMemberNode(Line);
+/// <summary>A construct signature member: <c>new (x: T): R</c> or generic <c>new &lt;T&gt;(x: T): R</c>.
+/// The signature is a <see cref="FunctionTypeNode"/> or a <see cref="GenericFunctionTypeNode"/>.</summary>
+public sealed record ConstructSignatureMemberNode(TypeNode Signature, int Line) : ObjectTypeMemberNode(Line);
 
 /// <summary>A tuple type: <c>[string, n?: number, ...rest: boolean[]]</c>.</summary>
 public sealed record TupleTypeNode(List<TupleElementNode> Elements, int Line) : TypeNode(Line);

--- a/Parsing/TypeNodes.cs
+++ b/Parsing/TypeNodes.cs
@@ -27,6 +27,35 @@ public sealed record ArrayTypeNode(TypeNode ElementType, int Line) : TypeNode(Li
 /// <summary>A union type: <c>A | B | C</c>.</summary>
 public sealed record UnionTypeNode(List<TypeNode> Members, int Line) : TypeNode(Line);
 
+/// <summary>An intersection type: <c>A &amp; B &amp; C</c>. Resolution merges members through the
+/// same <c>SimplifyIntersection</c> the string path uses, so member ordering and the
+/// primitive-conflict / object-merge rules are identical.</summary>
+public sealed record IntersectionTypeNode(List<TypeNode> Members, int Line) : TypeNode(Line);
+
+/// <summary>The <c>keyof T</c> index-query operator. Resolves to <c>TypeInfo.KeyOf</c>.</summary>
+public sealed record KeyofTypeNode(TypeNode Operand, int Line) : TypeNode(Line);
+
+/// <summary>An indexed-access type: <c>T[K]</c>, <c>T["key"]</c>. Resolves to
+/// <c>TypeInfo.IndexedAccess</c>. The array suffix <c>T[]</c> is an <see cref="ArrayTypeNode"/>,
+/// not this.</summary>
+public sealed record IndexedAccessTypeNode(TypeNode ObjectType, TypeNode IndexType, int Line) : TypeNode(Line);
+
+/// <summary>A conditional type: <c>Check extends Extends ? True : False</c>. Resolves to a
+/// deferred <c>TypeInfo.ConditionalType</c> (the same shape the string path builds);
+/// distribution and <c>infer</c> inference happen later in <c>EvaluateConditionalType</c>,
+/// path-independent.</summary>
+public sealed record ConditionalTypeNode(TypeNode CheckType, TypeNode ExtendsType, TypeNode TrueType, TypeNode FalseType, int Line) : TypeNode(Line);
+
+/// <summary>An <c>infer U</c> placeholder inside a conditional's extends clause. Resolves to
+/// <c>TypeInfo.InferredTypeParameter</c>. Constrained infer (<c>infer U extends C</c>) has no
+/// node yet and falls back to the string path.</summary>
+public sealed record InferTypeNode(string Name, int Line) : TypeNode(Line);
+
+/// <summary>A <c>typeof entity</c> query. The entity path is carried in its string-path spelling
+/// (<c>obj.prop</c>, <c>arr[0]</c>) and resolved by <c>EvaluateTypeOf</c> — the same evaluator the
+/// string path uses, so there is no behavioral difference beyond skipping the top-level scan.</summary>
+public sealed record TypeQueryNode(string EntityPath, int Line) : TypeNode(Line);
+
 /// <summary>A parameter inside a function or constructor type: <c>x: T</c>, <c>x?: T</c>,
 /// <c>...rest: T[]</c>. A bare name (<c>(x) =&gt; R</c>) gets an explicit <c>any</c> type node —
 /// the name is a label only, never resolved. Not itself a type.</summary>

--- a/Parsing/TypeNodes.cs
+++ b/Parsing/TypeNodes.cs
@@ -21,6 +21,19 @@ public sealed record NamedTypeNode(string Name, List<TypeNode>? TypeArguments, i
 /// <summary>A literal type: <c>"ok"</c>, <c>42</c>, <c>true</c>.</summary>
 public sealed record LiteralTypeNode(object? Value, int Line) : TypeNode(Line);
 
+/// <summary>A <c>readonly</c> array/tuple modifier: <c>readonly T[]</c>, <c>readonly [A, B]</c>.
+/// Resolution marks the resolved array/tuple readonly (any other inner type ignores it), exactly
+/// like the string path's <c>readonly </c> prefix branch.</summary>
+public sealed record ReadonlyTypeNode(TypeNode Inner, int Line) : TypeNode(Line);
+
+/// <summary>A type predicate return type: <c>x is T</c> or <c>asserts x is T</c>. Resolves to
+/// <c>TypeInfo.TypePredicate</c>. The <c>asserts x</c> shorthand (non-null assertion) is a
+/// separate <see cref="AssertsNonNullTypeNode"/>.</summary>
+public sealed record TypePredicateNode(string ParameterName, TypeNode PredicateType, bool IsAssertion, int Line) : TypeNode(Line);
+
+/// <summary>The <c>asserts x</c> shorthand return type. Resolves to <c>TypeInfo.AssertsNonNull</c>.</summary>
+public sealed record AssertsNonNullTypeNode(string ParameterName, int Line) : TypeNode(Line);
+
 /// <summary>An array type via the suffix syntax: <c>T[]</c>.</summary>
 public sealed record ArrayTypeNode(TypeNode ElementType, int Line) : TypeNode(Line);
 

--- a/Parsing/TypeNodes.cs
+++ b/Parsing/TypeNodes.cs
@@ -70,9 +70,26 @@ public sealed record FunctionTypeNode(TypeNode? ThisType, List<ParameterTypeNode
 /// Generic constructor types (<c>new &lt;T&gt;(…) =&gt; R</c>) have no node yet (slice 3).</summary>
 public sealed record ConstructorTypeNode(List<ParameterTypeNode> Parameters, TypeNode ReturnType, int Line) : TypeNode(Line);
 
-/// <summary>An inline object type: <c>{ name: string; greet(x: number): void }</c>.
-/// Mapped types (<c>{ [K in keyof T]: … }</c>) have no node (slice 2 follow-up).</summary>
+/// <summary>An inline object type: <c>{ name: string; greet(x: number): void }</c>.</summary>
 public sealed record ObjectTypeNode(List<ObjectTypeMemberNode> Members, int Line) : TypeNode(Line);
+
+/// <summary>A mapped type: <c>{ [K in Constraint as Remap]?: Value }</c>, with optional
+/// <c>+/-readonly</c> and <c>+/-?</c> modifiers. The mapped parameter is registered as an open
+/// type variable while the as-clause and value type resolve, so their bodies build the same
+/// deferred forms (IndexedAccess, deferred references) <c>ExpandMappedType</c> substitutes per
+/// key — identical to the string path. The modifier flags map 1:1 to
+/// <c>MappedTypeModifiers</c> in the checker (kept as bools so this syntax layer needs no
+/// dependency on the semantic enum).</summary>
+public sealed record MappedTypeNode(
+    string ParamName,
+    TypeNode Constraint,
+    TypeNode ValueType,
+    TypeNode? AsClause,
+    bool AddReadonly,
+    bool RemoveReadonly,
+    bool AddOptional,
+    bool RemoveOptional,
+    int Line) : TypeNode(Line);
 
 /// <summary>A member of an <see cref="ObjectTypeNode"/>. Not itself a type.</summary>
 public abstract record ObjectTypeMemberNode(int Line);

--- a/SharpTS.Tests/TypeCheckerTests/TypeNodeSliceTests.cs
+++ b/SharpTS.Tests/TypeCheckerTests/TypeNodeSliceTests.cs
@@ -30,14 +30,49 @@ public class TypeNodeSliceTests
     [Fact]
     public void NodePath_FallsBackForUnsupportedConstructs()
     {
-        // Mapped-type alias bodies have no node form yet, so the reference falls back.
+        // Generic function types (<T>(x: T) => T) still have no node form, so they fall back.
         TypeNodeStats.Reset();
         TestHarness.RunInterpreted("""
-            type RO<T> = { [K in keyof T]: T[K] };
-            var r: RO<{ a: number }> = { a: 1 };
+            let f: <T>(x: T) => T;
             """);
         Assert.True(TypeNodeStats.StringFallbacks >= 1,
-            $"expected the mapped-alias annotation to fall back, got {TypeNodeStats.StringFallbacks}");
+            $"expected the generic-function-type annotation to fall back, got {TypeNodeStats.StringFallbacks}");
+    }
+
+    [Fact]
+    public void NodePath_EngagesForMappedAlias()
+    {
+        // Mapped-type alias bodies now carry nodes, so the reference expands node-first.
+        TypeNodeStats.Reset();
+        TestHarness.RunInterpreted("""
+            type RO<T> = { readonly [K in keyof T]: T[K] };
+            type Partialize<T> = { [K in keyof T]?: T[K] };
+            var r: RO<{ a: number }> = { a: 1 };
+            var p: Partialize<{ a: number; b: string }> = { a: 1 };
+            """);
+        Assert.True(TypeNodeStats.NodeHits >= 2,
+            $"expected the mapped-alias annotations on the node path, got {TypeNodeStats.NodeHits}");
+        Assert.Equal(0, TypeNodeStats.StringFallbacks);
+    }
+
+    [Fact]
+    public void NodeResolved_MappedTypePreservesValueType()
+    {
+        // RO<{ a: number }> maps to { readonly a: number }; a string value must be rejected.
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted("""
+            type RO<T> = { readonly [K in keyof T]: T[K] };
+            var r: RO<{ a: number }> = { a: "x" };
+            """));
+    }
+
+    [Fact]
+    public void NodeResolved_MappedTypeOptionalModifierMatchesStringPath()
+    {
+        // Partialize makes every member optional, so omitting one is allowed.
+        TestHarness.RunInterpreted("""
+            type Partialize<T> = { [K in keyof T]?: T[K] };
+            var p: Partialize<{ a: number; b: string }> = { a: 1 };
+            """);
     }
 
     [Fact]

--- a/SharpTS.Tests/TypeCheckerTests/TypeNodeSliceTests.cs
+++ b/SharpTS.Tests/TypeCheckerTests/TypeNodeSliceTests.cs
@@ -30,13 +30,13 @@ public class TypeNodeSliceTests
     [Fact]
     public void NodePath_FallsBackForUnsupportedConstructs()
     {
-        // Generic constructor types (new <T>(…) => R) still have no node form, so they fall back.
+        // bigint literal types (1n) still have no node form, so they fall back.
         TypeNodeStats.Reset();
         TestHarness.RunInterpreted("""
-            let f: new <T>(x: T) => T;
+            let x: 1n;
             """);
         Assert.True(TypeNodeStats.StringFallbacks >= 1,
-            $"expected the generic-constructor-type annotation to fall back, got {TypeNodeStats.StringFallbacks}");
+            $"expected the bigint-literal-type annotation to fall back, got {TypeNodeStats.StringFallbacks}");
     }
 
     [Fact]
@@ -470,6 +470,43 @@ public class TypeNodeSliceTests
             """);
         Assert.True(TypeNodeStats.NodeHits >= 1,
             $"expected the qualified-name annotation on the node path, got {TypeNodeStats.NodeHits}");
+    }
+
+    [Fact]
+    public void NodePath_EngagesForGenericConstructorType()
+    {
+        TypeNodeStats.Reset();
+        TestHarness.RunInterpreted("""
+            let make: new <T>(x: T) => T[];
+            let build: new <T extends object, K extends keyof T>(o: T, k: K) => T[K];
+            """);
+        Assert.True(TypeNodeStats.NodeHits >= 2,
+            $"expected the generic-constructor-type annotations on the node path, got {TypeNodeStats.NodeHits}");
+        Assert.Equal(0, TypeNodeStats.StringFallbacks);
+    }
+
+    [Fact]
+    public void NodePath_EngagesForObjectTypeWithGenericSignatures()
+    {
+        // Overloaded generic call signatures and a generic construct signature inside object types.
+        TypeNodeStats.Reset();
+        TestHarness.RunInterpreted("""
+            let overloads: { <T>(x: T): T; <U, V>(a: U, b: V): U };
+            let factory: { new <T>(x: T): T[] };
+            """);
+        Assert.True(TypeNodeStats.NodeHits >= 2,
+            $"expected the object-type generic-signature annotations on the node path, got {TypeNodeStats.NodeHits}");
+        Assert.Equal(0, TypeNodeStats.StringFallbacks);
+    }
+
+    [Fact]
+    public void NodeResolved_GenericConstructorTypeIsConstructable()
+    {
+        // A generic constructor type resolves to a constructable object type; a non-constructable
+        // value must be rejected — the same verdict the string path produces.
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted("""
+            var ctor: new <T>(x: T) => T[] = 42;
+            """));
     }
 
     [Fact]

--- a/SharpTS.Tests/TypeCheckerTests/TypeNodeSliceTests.cs
+++ b/SharpTS.Tests/TypeCheckerTests/TypeNodeSliceTests.cs
@@ -30,13 +30,13 @@ public class TypeNodeSliceTests
     [Fact]
     public void NodePath_FallsBackForUnsupportedConstructs()
     {
-        // Generic function types (<T>(x: T) => T) still have no node form, so they fall back.
+        // The `readonly` array/tuple modifier still has no node form, so it falls back.
         TypeNodeStats.Reset();
         TestHarness.RunInterpreted("""
-            let f: <T>(x: T) => T;
+            var a: readonly number[] = [1];
             """);
         Assert.True(TypeNodeStats.StringFallbacks >= 1,
-            $"expected the generic-function-type annotation to fall back, got {TypeNodeStats.StringFallbacks}");
+            $"expected the readonly-modifier annotation to fall back, got {TypeNodeStats.StringFallbacks}");
     }
 
     [Fact]
@@ -376,6 +376,60 @@ public class TypeNodeSliceTests
         Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted("""
             type IsNum<T> = T extends number ? "yes" : "no";
             var r: IsNum<string> = "yes";
+            """));
+    }
+
+    [Fact]
+    public void NodePath_EngagesForGenericFunctionType()
+    {
+        // Declaration-only so the (pre-existing, path-independent) generic-arrow assignment
+        // limitation doesn't mask which path resolved the annotation.
+        TypeNodeStats.Reset();
+        TestHarness.RunInterpreted("""
+            let id: <T>(x: T) => T;
+            let pick: <T extends object, K extends keyof T>(o: T, k: K) => T[K];
+            """);
+        Assert.True(TypeNodeStats.NodeHits >= 2,
+            $"expected the generic-function-type annotations on the node path, got {TypeNodeStats.NodeHits}");
+        Assert.Equal(0, TypeNodeStats.StringFallbacks);
+    }
+
+    [Fact]
+    public void NodeResolved_GenericFunctionTypeResolvesWithoutError()
+    {
+        // A generic function type whose body references its own type parameters (keyof T, T[K])
+        // must resolve cleanly — the parameters resolve in the signature's fresh scope, not to any.
+        TypeNodeStats.Reset();
+        TestHarness.RunInterpreted("""
+            let get: <T, K extends keyof T>(o: T, k: K) => T[K];
+            let map: <T, U>(items: T[], f: (x: T) => U) => U[];
+            """);
+        Assert.True(TypeNodeStats.NodeHits >= 2,
+            $"expected both generic-function annotations on the node path, got {TypeNodeStats.NodeHits}");
+        Assert.Equal(0, TypeNodeStats.StringFallbacks);
+    }
+
+    [Fact]
+    public void NodePath_EngagesForTemplateLiteralType()
+    {
+        TypeNodeStats.Reset();
+        TestHarness.RunInterpreted("""
+            type Dir = "left" | "right";
+            var s: `padding-${Dir}` = "padding-left";
+            var f: `f-${string}` = "f-anything";
+            """);
+        Assert.True(TypeNodeStats.NodeHits >= 2,
+            $"expected the template-literal annotations on the node path, got {TypeNodeStats.NodeHits}");
+        Assert.Equal(0, TypeNodeStats.StringFallbacks);
+    }
+
+    [Fact]
+    public void NodeResolved_TemplateLiteralExpandsConcreteUnion()
+    {
+        // `padding-${Dir}` expands to "padding-left" | "padding-right"; another value is rejected.
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted("""
+            type Dir = "left" | "right";
+            var s: `padding-${Dir}` = "padding-up";
             """));
     }
 }

--- a/SharpTS.Tests/TypeCheckerTests/TypeNodeSliceTests.cs
+++ b/SharpTS.Tests/TypeCheckerTests/TypeNodeSliceTests.cs
@@ -265,4 +265,82 @@ public class TypeNodeSliceTests
             var a: any | never = null;
             """);
     }
+
+    [Fact]
+    public void NodePath_EngagesForIntersectionKeyofIndexedAndTypeof()
+    {
+        TypeNodeStats.Reset();
+        TestHarness.RunInterpreted("""
+            type A = { a: number };
+            type B = { b: string };
+            var ab: A & B = { a: 1, b: "x" };
+            var k: keyof A = "a";
+            var v: A["a"] = 1;
+            const origin = { n: 5 };
+            var t: typeof origin = origin;
+            """);
+        Assert.True(TypeNodeStats.NodeHits >= 4,
+            $"expected the node path for intersection/keyof/indexed/typeof, got {TypeNodeStats.NodeHits}");
+        Assert.Equal(0, TypeNodeStats.StringFallbacks);
+    }
+
+    [Fact]
+    public void NodeResolved_IntersectionMergesMembers()
+    {
+        // Both members' properties are required in the merged type.
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted("""
+            type A = { a: number };
+            type B = { b: string };
+            var ab: A & B = { a: 1 };
+            """));
+    }
+
+    [Fact]
+    public void NodeResolved_KeyofEnforcesKeys()
+    {
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted("""
+            type A = { a: number; b: string };
+            var k: keyof A = "c";
+            """));
+    }
+
+    [Fact]
+    public void NodeResolved_IndexedAccessEnforcesValueType()
+    {
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted("""
+            type A = { a: number };
+            var v: A["a"] = "not a number";
+            """));
+    }
+
+    [Fact]
+    public void NodePath_EngagesForConditionalAliasWithInfer()
+    {
+        // The alias definition is now a ConditionalTypeNode carrying an InferTypeNode, so the
+        // reference expands through the node path (no string fallback).
+        TypeNodeStats.Reset();
+        TestHarness.RunInterpreted("""
+            type Elem<T> = T extends (infer U)[] ? U : never;
+            var e: Elem<number[]> = 1;
+            """);
+        Assert.True(TypeNodeStats.NodeHits >= 1,
+            $"expected the conditional/infer alias on the node path, got {TypeNodeStats.NodeHits}");
+        Assert.Equal(0, TypeNodeStats.StringFallbacks);
+    }
+
+    [Fact]
+    public void NodeResolved_ConditionalEvaluatesToSelectedBranch()
+    {
+        // IsNum<number> resolves to the true branch ("yes"), so "no" must be rejected — the same
+        // verdict the string path produces (EvaluateConditionalType is path-independent).
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted("""
+            type IsNum<T> = T extends number ? "yes" : "no";
+            var r: IsNum<number> = "no";
+            """));
+        // The false branch is selected for a non-number argument.
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted("""
+            type IsNum<T> = T extends number ? "yes" : "no";
+            var r: IsNum<string> = "yes";
+            """));
+    }
 }

--- a/SharpTS.Tests/TypeCheckerTests/TypeNodeSliceTests.cs
+++ b/SharpTS.Tests/TypeCheckerTests/TypeNodeSliceTests.cs
@@ -125,8 +125,10 @@ public class TypeNodeSliceTests
     public void NodePath_EngagesForGenericReferences()
     {
         TypeNodeStats.Reset();
+        // Plain fields (not constructor parameter properties) so this stays focused on the generic
+        // references — parameter-property fields are a separate consumer site not yet node-wired.
         TestHarness.RunInterpreted("""
-            class Pair<A, B> { constructor(public first: A, public second: B) {} }
+            class Pair<A, B> { first!: A; second!: B; constructor(a: A, b: B) {} }
             var xs: Array<number> = [1, 2];
             var p: Promise<string> = Promise.resolve("x");
             var pr: Pair<string, number> = new Pair<string, number>("x", 1);
@@ -421,6 +423,31 @@ public class TypeNodeSliceTests
         Assert.True(TypeNodeStats.NodeHits >= 2,
             $"expected the template-literal annotations on the node path, got {TypeNodeStats.NodeHits}");
         Assert.Equal(0, TypeNodeStats.StringFallbacks);
+    }
+
+    [Fact]
+    public void NodePath_EngagesForClassFieldAnnotations()
+    {
+        // Class field type annotations now resolve node-first (consumer wired off the string path).
+        TypeNodeStats.Reset();
+        TestHarness.RunInterpreted("""
+            class C {
+                a: number = 1;
+                b: string[] = [];
+                c: { x: number } = { x: 0 };
+            }
+            """);
+        Assert.True(TypeNodeStats.NodeHits >= 3,
+            $"expected the class-field annotations on the node path, got {TypeNodeStats.NodeHits}");
+        Assert.Equal(0, TypeNodeStats.StringFallbacks);
+    }
+
+    [Fact]
+    public void NodeResolved_ClassFieldEnforcesAnnotatedType()
+    {
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted("""
+            class C { a: number = "not a number"; }
+            """));
     }
 
     [Fact]

--- a/SharpTS.Tests/TypeCheckerTests/TypeNodeSliceTests.cs
+++ b/SharpTS.Tests/TypeCheckerTests/TypeNodeSliceTests.cs
@@ -30,13 +30,13 @@ public class TypeNodeSliceTests
     [Fact]
     public void NodePath_FallsBackForUnsupportedConstructs()
     {
-        // The `readonly` array/tuple modifier still has no node form, so it falls back.
+        // Generic constructor types (new <T>(…) => R) still have no node form, so they fall back.
         TypeNodeStats.Reset();
         TestHarness.RunInterpreted("""
-            var a: readonly number[] = [1];
+            let f: new <T>(x: T) => T;
             """);
         Assert.True(TypeNodeStats.StringFallbacks >= 1,
-            $"expected the readonly-modifier annotation to fall back, got {TypeNodeStats.StringFallbacks}");
+            $"expected the generic-constructor-type annotation to fall back, got {TypeNodeStats.StringFallbacks}");
     }
 
     [Fact]
@@ -431,5 +431,56 @@ public class TypeNodeSliceTests
             type Dir = "left" | "right";
             var s: `padding-${Dir}` = "padding-up";
             """));
+    }
+
+    [Fact]
+    public void NodePath_EngagesForReadonlyAndQualifiedAndPredicate()
+    {
+        TypeNodeStats.Reset();
+        TestHarness.RunInterpreted("""
+            namespace N { export type Id = number; }
+            var ro: readonly number[] = [1, 2];
+            var rt: readonly [number, string] = [1, "x"];
+            var q: N.Id = 5;
+            var pred: (x: unknown) => x is string;
+            """);
+        Assert.True(TypeNodeStats.NodeHits >= 4,
+            $"expected readonly/qualified/predicate annotations on the node path, got {TypeNodeStats.NodeHits}");
+        Assert.Equal(0, TypeNodeStats.StringFallbacks);
+    }
+
+    [Fact]
+    public void NodeResolved_ReadonlyArrayStillEnforcesElementType()
+    {
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted("""
+            var a: readonly number[] = ["x"];
+            """));
+    }
+
+    [Fact]
+    public void NodeResolved_QualifiedNameMatchesStringPath()
+    {
+        // The dotted name is handed to the same single-name resolution as the string path; the
+        // checker resolves namespace type-alias exports permissively (to any), so this assigns
+        // cleanly on BOTH paths — the node path introduces no divergence.
+        TypeNodeStats.Reset();
+        TestHarness.RunInterpreted("""
+            namespace N { export type Id = number; }
+            var q: N.Id = 5;
+            """);
+        Assert.True(TypeNodeStats.NodeHits >= 1,
+            $"expected the qualified-name annotation on the node path, got {TypeNodeStats.NodeHits}");
+    }
+
+    [Fact]
+    public void NodePath_EngagesForConstrainedInferAlias()
+    {
+        // `infer U extends string` now carries a node, so the conditional alias expands node-first.
+        TypeNodeStats.Reset();
+        TestHarness.RunInterpreted("""
+            type StrElem<T> = T extends Array<infer U extends string> ? U : never;
+            var e: StrElem<string[]> = "x";
+            """);
+        Assert.Equal(0, TypeNodeStats.StringFallbacks);
     }
 }

--- a/TypeSystem/TypeChecker.Statements.Classes.cs
+++ b/TypeSystem/TypeChecker.Statements.Classes.cs
@@ -258,9 +258,8 @@ public partial class TypeChecker
             CheckDecorators(field.Decorators, fieldTarget);
 
             string fieldName = field.Name.Lexeme;
-            TypeInfo fieldType = field.TypeAnnotation != null
-                ? ToTypeInfo(field.TypeAnnotation)
-                : new TypeInfo.Any();
+            TypeInfo fieldType = ResolveAnnotation(field.TypeAnnotation, field.TypeAnnotationNode)
+                ?? new TypeInfo.Any();
 
             // Handle ES2022 private fields (#field)
             if (field.IsPrivate)
@@ -976,9 +975,8 @@ public partial class TypeChecker
         // Collect field types
         foreach (var field in classStmt.Fields)
         {
-            TypeInfo fieldType = field.TypeAnnotation != null
-                ? ToTypeInfo(field.TypeAnnotation)
-                : new TypeInfo.Any();
+            TypeInfo fieldType = ResolveAnnotation(field.TypeAnnotation, field.TypeAnnotationNode)
+                ?? new TypeInfo.Any();
 
             if (field.IsStatic)
             {

--- a/TypeSystem/TypeChecker.TypeNodes.cs
+++ b/TypeSystem/TypeChecker.TypeNodes.cs
@@ -155,6 +155,9 @@ public partial class TypeChecker
             case ObjectTypeNode obj:
                 return TryResolveObjectType(obj);
 
+            case MappedTypeNode mapped:
+                return TryResolveMappedType(mapped);
+
             case TupleTypeNode tuple:
                 return TryResolveTupleType(tuple);
 
@@ -297,6 +300,41 @@ public partial class TypeChecker
         }
 
         return new TypeInfo.Tuple(elements, requiredCount, restType);
+    }
+
+    /// <summary>
+    /// Mirror of the string path's <c>ParseMappedTypeInfo</c>: the constraint resolves first, then
+    /// the mapped parameter is registered as an open type variable (so the as-clause and value type
+    /// build the same deferred forms <c>ExpandMappedType</c> substitutes per key) before those
+    /// resolve. The modifier flags translate 1:1 to <see cref="MappedTypeModifiers"/>.
+    /// </summary>
+    private TypeInfo? TryResolveMappedType(MappedTypeNode mapped)
+    {
+        MappedTypeModifiers modifiers = MappedTypeModifiers.None;
+        if (mapped.AddReadonly) modifiers |= MappedTypeModifiers.AddReadonly;
+        if (mapped.RemoveReadonly) modifiers |= MappedTypeModifiers.RemoveReadonly;
+        if (mapped.AddOptional) modifiers |= MappedTypeModifiers.AddOptional;
+        if (mapped.RemoveOptional) modifiers |= MappedTypeModifiers.RemoveOptional;
+
+        if (TryToTypeInfo(mapped.Constraint) is not { } constraint) return null;
+
+        _openTypeVariablesInScope ??= new HashSet<string>(StringComparer.Ordinal);
+        bool openVarAdded = _openTypeVariablesInScope.Add(mapped.ParamName);
+        try
+        {
+            TypeInfo? asClause = null;
+            if (mapped.AsClause is { } asNode)
+            {
+                if (TryToTypeInfo(asNode) is not { } resolvedAs) return null;
+                asClause = resolvedAs;
+            }
+            if (TryToTypeInfo(mapped.ValueType) is not { } valueType) return null;
+            return new TypeInfo.MappedType(mapped.ParamName, constraint, valueType, modifiers, asClause);
+        }
+        finally
+        {
+            if (openVarAdded) _openTypeVariablesInScope.Remove(mapped.ParamName);
+        }
     }
 
     /// <summary>

--- a/TypeSystem/TypeChecker.TypeNodes.cs
+++ b/TypeSystem/TypeChecker.TypeNodes.cs
@@ -79,6 +79,51 @@ public partial class TypeChecker
                 return members.Aggregate(CreateUnion);
             }
 
+            case IntersectionTypeNode intersection:
+            {
+                List<TypeInfo> members = new(intersection.Members.Count);
+                foreach (var member in intersection.Members)
+                {
+                    if (TryToTypeInfo(member) is not { } resolved) return null;
+                    members.Add(resolved);
+                }
+                // Identical merge rules (primitive conflicts, object-member union, never/any
+                // absorption) as the string path's "A & B" split.
+                return SimplifyIntersection(members);
+            }
+
+            case KeyofTypeNode keyof:
+                return TryToTypeInfo(keyof.Operand) is { } operand ? new TypeInfo.KeyOf(operand) : null;
+
+            case IndexedAccessTypeNode indexed:
+            {
+                if (TryToTypeInfo(indexed.ObjectType) is not { } objectType) return null;
+                if (TryToTypeInfo(indexed.IndexType) is not { } indexType) return null;
+                // Chained T[K][J] is already nested structurally by the parser, so a single
+                // IndexedAccess per node mirrors the string path's iterative suffix consumption.
+                return new TypeInfo.IndexedAccess(objectType, indexType);
+            }
+
+            // Deferred form — distribution and `infer` inference run later in
+            // EvaluateConditionalType, exactly as for a string-built ConditionalType.
+            case ConditionalTypeNode conditional:
+            {
+                if (TryToTypeInfo(conditional.CheckType) is not { } checkType) return null;
+                if (TryToTypeInfo(conditional.ExtendsType) is not { } extendsType) return null;
+                if (TryToTypeInfo(conditional.TrueType) is not { } trueType) return null;
+                if (TryToTypeInfo(conditional.FalseType) is not { } falseType) return null;
+                return new TypeInfo.ConditionalType(checkType, extendsType, trueType, falseType);
+            }
+
+            case InferTypeNode infer:
+                return new TypeInfo.InferredTypeParameter(infer.Name);
+
+            // typeof resolves through the same evaluator as the string path; the node only spares
+            // the top-level scan that splits unions/intersections before `typeof` (the parser
+            // already separated them into sibling nodes).
+            case TypeQueryNode query:
+                return EvaluateTypeOf(query.EntityPath);
+
             case FunctionTypeNode fn:
             {
                 TypeInfo? thisType = null;

--- a/TypeSystem/TypeChecker.TypeNodes.cs
+++ b/TypeSystem/TypeChecker.TypeNodes.cs
@@ -124,6 +124,22 @@ public partial class TypeChecker
             case TypeQueryNode query:
                 return EvaluateTypeOf(query.EntityPath);
 
+            case GenericFunctionTypeNode genericFn:
+                return TryResolveGenericFunctionType(genericFn);
+
+            case TemplateLiteralTypeNode template:
+            {
+                List<TypeInfo> interpolated = new(template.InterpolatedTypes.Count);
+                foreach (var part in template.InterpolatedTypes)
+                {
+                    if (TryToTypeInfo(part) is not { } resolved) return null;
+                    interpolated.Add(resolved);
+                }
+                // Same normalization the string path applies: all-concrete → union of string
+                // literals; a string-primitive part → pattern TemplateLiteralType.
+                return NormalizeTemplateLiteralType(template.Strings, interpolated);
+            }
+
             case FunctionTypeNode fn:
             {
                 TypeInfo? thisType = null;
@@ -300,6 +316,47 @@ public partial class TypeChecker
         }
 
         return new TypeInfo.Tuple(elements, requiredCount, restType);
+    }
+
+    /// <summary>
+    /// Mirror of the string path's <c>TryParseGenericFunctionTypeInfo</c>: every type-parameter name
+    /// is defined unconstrained first (so a constraint/default may forward-reference a later
+    /// parameter), constraints/defaults then resolve in that scope, and the body
+    /// <see cref="FunctionTypeNode"/> resolves with the parameters in scope so its <c>T</c>s bind to
+    /// them. Constraints/defaults come from the <see cref="TypeParam"/> strings (resolved via the
+    /// shared single-name path), so they cannot diverge from the string path. Null (e.g. a body
+    /// component without a node) falls back.
+    /// </summary>
+    private TypeInfo? TryResolveGenericFunctionType(GenericFunctionTypeNode genericFn)
+    {
+        var typeParamEnv = new TypeEnvironment(_environment);
+
+        // First pass: declare every name unconstrained.
+        foreach (var tp in genericFn.TypeParameters)
+            typeParamEnv.DefineTypeParameter(tp.Name.Lexeme, new TypeInfo.TypeParameter(tp.Name.Lexeme));
+
+        var typeParams = new List<TypeInfo.TypeParameter>();
+        TypeInfo? bodyType;
+        using (new EnvironmentScope(this, typeParamEnv))
+        {
+            // Second pass: resolve constraints/defaults now that all names are in scope.
+            foreach (var tp in genericFn.TypeParameters)
+            {
+                TypeInfo? constraint = tp.Constraint is not null ? ToTypeInfo(tp.Constraint) : null;
+                TypeInfo? defaultType = tp.Default is not null ? ToTypeInfo(tp.Default) : null;
+                var resolved = new TypeInfo.TypeParameter(tp.Name.Lexeme, constraint, defaultType);
+                typeParams.Add(resolved);
+                typeParamEnv.DefineTypeParameter(tp.Name.Lexeme, resolved);
+            }
+
+            bodyType = TryToTypeInfo(genericFn.Body);
+        }
+
+        if (bodyType is not TypeInfo.Function func) return null;
+
+        return new TypeInfo.GenericFunction(
+            typeParams, func.ParamTypes, func.ReturnType, func.RequiredParams, func.HasRestParam,
+            func.ThisType, func.ParamNames);
     }
 
     /// <summary>

--- a/TypeSystem/TypeChecker.TypeNodes.cs
+++ b/TypeSystem/TypeChecker.TypeNodes.cs
@@ -118,6 +118,25 @@ public partial class TypeChecker
             case InferTypeNode infer:
                 return new TypeInfo.InferredTypeParameter(infer.Name);
 
+            // `readonly T[]` / `readonly [A, B]` — mark the resolved array/tuple readonly; any other
+            // inner type ignores the modifier (mirrors ToTypeInfoCore's readonly branch).
+            case ReadonlyTypeNode ro:
+                return TryToTypeInfo(ro.Inner) switch
+                {
+                    null => null,
+                    TypeInfo.Array arr => arr with { IsReadonly = true },
+                    TypeInfo.Tuple tup => tup with { IsReadonly = true },
+                    { } inner => inner,
+                };
+
+            case TypePredicateNode predicate:
+                return TryToTypeInfo(predicate.PredicateType) is { } predType
+                    ? new TypeInfo.TypePredicate(predicate.ParameterName, predType, predicate.IsAssertion)
+                    : null;
+
+            case AssertsNonNullTypeNode asserts:
+                return new TypeInfo.AssertsNonNull(asserts.ParameterName);
+
             // typeof resolves through the same evaluator as the string path; the node only spares
             // the top-level scan that splits unions/intersections before `typeof` (the parser
             // already separated them into sibling nodes).

--- a/TypeSystem/TypeChecker.TypeNodes.cs
+++ b/TypeSystem/TypeChecker.TypeNodes.cs
@@ -144,7 +144,26 @@ public partial class TypeChecker
                 return EvaluateTypeOf(query.EntityPath);
 
             case GenericFunctionTypeNode genericFn:
-                return TryResolveGenericFunctionType(genericFn);
+            {
+                if (TryResolveGenericSignature(genericFn.TypeParameters, genericFn.Body) is not ({ } typeParams, { } func))
+                    return null;
+                return new TypeInfo.GenericFunction(
+                    typeParams, func.ParamTypes, func.ReturnType, func.RequiredParams, func.HasRestParam,
+                    func.ThisType, func.ParamNames);
+            }
+
+            // `new <T>(…) => R` — an object type with a single GENERIC construct signature, mirroring
+            // the string path's "{ new <T>(…) => R }" rendering resolved via ResolveSignature.
+            case GenericConstructorTypeNode genericCtor:
+            {
+                if (TryResolveGenericSignature(genericCtor.TypeParameters, genericCtor.Body) is not ({ } typeParams, { } func))
+                    return null;
+                var signature = new TypeInfo.ConstructorSignature(
+                    typeParams, func.ParamTypes, func.ReturnType, func.RequiredParams, func.HasRestParam, func.ParamNames);
+                return new TypeInfo.Record(
+                    FrozenDictionary<string, TypeInfo>.Empty,
+                    ConstructorSignatures: [signature]);
+            }
 
             case TemplateLiteralTypeNode template:
             {
@@ -214,8 +233,8 @@ public partial class TypeChecker
         TypeInfo? stringIndexType = null;
         TypeInfo? numberIndexType = null;
         TypeInfo? symbolIndexType = null;
-        List<FunctionTypeNode> callSignatures = [];
-        List<FunctionTypeNode> constructSignatures = [];
+        List<TypeNode> callSignatures = [];
+        List<TypeNode> constructSignatures = [];
 
         foreach (var member in obj.Members)
         {
@@ -263,14 +282,16 @@ public partial class TypeChecker
         foreach (var signature in callSignatures)
         {
             // The string path's CallSignature copies drop a `this` type; mirror via the parts.
-            if (TryToTypeInfo(signature) is not TypeInfo.Function f) return null;
-            (recCallSigs ??= []).Add(new TypeInfo.CallSignature(null, f.ParamTypes, f.ReturnType, f.RequiredParams, f.HasRestParam, f.ParamNames));
+            // Generic overloads carry their type parameters (resolved through the shared scope);
+            // non-generic signatures bind a null tps.
+            if (ResolveSignatureNode(signature) is not (var tps, { } f)) return null;
+            (recCallSigs ??= []).Add(new TypeInfo.CallSignature(tps, f.ParamTypes, f.ReturnType, f.RequiredParams, f.HasRestParam, f.ParamNames));
         }
         List<TypeInfo.ConstructorSignature>? recCtorSigs = null;
         foreach (var signature in constructSignatures)
         {
-            if (TryToTypeInfo(signature) is not TypeInfo.Function f) return null;
-            (recCtorSigs ??= []).Add(new TypeInfo.ConstructorSignature(null, f.ParamTypes, f.ReturnType, f.RequiredParams, f.HasRestParam, f.ParamNames));
+            if (ResolveSignatureNode(signature) is not (var tps, { } f)) return null;
+            (recCtorSigs ??= []).Add(new TypeInfo.ConstructorSignature(tps, f.ParamTypes, f.ReturnType, f.RequiredParams, f.HasRestParam, f.ParamNames));
         }
 
         return new TypeInfo.Record(
@@ -338,20 +359,41 @@ public partial class TypeChecker
     }
 
     /// <summary>
-    /// Mirror of the string path's <c>TryParseGenericFunctionTypeInfo</c>: every type-parameter name
-    /// is defined unconstrained first (so a constraint/default may forward-reference a later
-    /// parameter), constraints/defaults then resolve in that scope, and the body
-    /// <see cref="FunctionTypeNode"/> resolves with the parameters in scope so its <c>T</c>s bind to
-    /// them. Constraints/defaults come from the <see cref="TypeParam"/> strings (resolved via the
-    /// shared single-name path), so they cannot diverge from the string path. Null (e.g. a body
-    /// component without a node) falls back.
+    /// Resolves a call/construct signature node to its (optional) type parameters and function shape.
+    /// A <see cref="GenericFunctionTypeNode"/> resolves through the shared generic-signature scope; a
+    /// plain <see cref="FunctionTypeNode"/> yields null type parameters. Returns null (fallback) for
+    /// any other node or an unresolvable body.
     /// </summary>
-    private TypeInfo? TryResolveGenericFunctionType(GenericFunctionTypeNode genericFn)
+    private (List<TypeInfo.TypeParameter>? TypeParams, TypeInfo.Function Func)? ResolveSignatureNode(TypeNode signature)
+    {
+        switch (signature)
+        {
+            case GenericFunctionTypeNode generic:
+                return TryResolveGenericSignature(generic.TypeParameters, generic.Body);
+            case FunctionTypeNode:
+                return TryToTypeInfo(signature) is TypeInfo.Function f ? (null, f) : null;
+            default:
+                return null;
+        }
+    }
+
+    /// <summary>
+    /// Resolves a generic signature's type parameters and body, shared by generic function types and
+    /// generic constructor types. Mirror of the string path's <c>TryParseGenericFunctionTypeInfo</c> /
+    /// <c>ResolveSignature</c>: every type-parameter name is defined unconstrained first (so a
+    /// constraint/default may forward-reference a later parameter), constraints/defaults then resolve
+    /// in that scope, and the body <see cref="FunctionTypeNode"/> resolves with the parameters in
+    /// scope so its <c>T</c>s bind to them. Constraints/defaults come from the <see cref="TypeParam"/>
+    /// strings (resolved via the shared single-name path), so they cannot diverge from the string
+    /// path. Null (e.g. a body component without a node) signals fallback.
+    /// </summary>
+    private (List<TypeInfo.TypeParameter> TypeParams, TypeInfo.Function Func)? TryResolveGenericSignature(
+        List<TypeParam> typeParameters, FunctionTypeNode body)
     {
         var typeParamEnv = new TypeEnvironment(_environment);
 
         // First pass: declare every name unconstrained.
-        foreach (var tp in genericFn.TypeParameters)
+        foreach (var tp in typeParameters)
             typeParamEnv.DefineTypeParameter(tp.Name.Lexeme, new TypeInfo.TypeParameter(tp.Name.Lexeme));
 
         var typeParams = new List<TypeInfo.TypeParameter>();
@@ -359,7 +401,7 @@ public partial class TypeChecker
         using (new EnvironmentScope(this, typeParamEnv))
         {
             // Second pass: resolve constraints/defaults now that all names are in scope.
-            foreach (var tp in genericFn.TypeParameters)
+            foreach (var tp in typeParameters)
             {
                 TypeInfo? constraint = tp.Constraint is not null ? ToTypeInfo(tp.Constraint) : null;
                 TypeInfo? defaultType = tp.Default is not null ? ToTypeInfo(tp.Default) : null;
@@ -368,14 +410,10 @@ public partial class TypeChecker
                 typeParamEnv.DefineTypeParameter(tp.Name.Lexeme, resolved);
             }
 
-            bodyType = TryToTypeInfo(genericFn.Body);
+            bodyType = TryToTypeInfo(body);
         }
 
-        if (bodyType is not TypeInfo.Function func) return null;
-
-        return new TypeInfo.GenericFunction(
-            typeParams, func.ParamTypes, func.ReturnType, func.RequiredParams, func.HasRestParam,
-            func.ThisType, func.ParamNames);
+        return bodyType is TypeInfo.Function func ? (typeParams, func) : null;
     }
 
     /// <summary>

--- a/docs/plans/type-ast-design.md
+++ b/docs/plans/type-ast-design.md
@@ -206,10 +206,23 @@ an equivalence test that converts both ways and asserts identical `TypeInfo` ren
    not the three counted sites) — mechanism, not metric. No baseline movement; equivalence verified
    (e.g. qualified namespace type-alias exports resolve permissively to `any` on BOTH paths).
 
-   Remaining fallback before the scanner can go: generic **constructor** types
-   (`new <T>(…) => R`), `unique symbol` (intentionally throws TS1331), bigint literal types
-   (`1n`), and whatever the remaining 68 corpus annotation-site fallbacks turn out to be (audit
-   next).
+5e. ✅ **Shipped: generic signatures — 100% corpus annotation coverage.** An audit of the
+   remaining fallbacks showed they were almost entirely generic constructor types and generic
+   call/construct signatures. `GenericConstructorTypeNode` (`new <T>(…) => R` → object type with a
+   generic construct signature) and object-type generic call/construct signatures
+   (`{ <T>(x): T; <U>(a): U }`, `{ new <T>(x): T[] }`) — `ParseMethodSignature` now keeps its
+   type parameters and emits a `GenericFunctionTypeNode`; the call/construct signature member nodes
+   widened from `FunctionTypeNode` to `TypeNode`. All share one `TryResolveGenericSignature` helper
+   (the two-pass type-parameter scope, mirroring the string path's `ResolveSignature`). Corpus
+   coverage: 87.6% → **100.0% (547 node / 0 fallback)** — every annotation site in the 79-file
+   corpus now resolves through the node path; the string scanner is no longer reached for any of
+   them. No baseline movement; full unit suite green.
+
+   The string path (`ToTypeInfo(string)` / `TypeChecker.TypeParsing.cs`) is still reached for a few
+   long-tail constructs absent from the corpus — bigint literal types (`1n`), `this`-parameter
+   generic/constructor types, `unique symbol` — and remains the implementation for the REPL/embedding
+   API. Slice 6 (deleting the scanner) is now viable: give those last forms nodes, then reimplement
+   `ToTypeInfo(string)` as parse-to-node + convert.
 6. Delete `TypeChecker.TypeParsing.cs` string scanning; `ToTypeInfo(string)` survives only
    for the REPL/embedding API surface, implemented as parse-to-node + convert.
 

--- a/docs/plans/type-ast-design.md
+++ b/docs/plans/type-ast-design.md
@@ -160,6 +160,19 @@ an equivalence test that converts both ways and asserts identical `TypeInfo` ren
    Wiring fixed en route: ambient `declare let/const` annotations and pre-registered
    (forward-referenced) alias definitions now carry their nodes; arrow-hoisting resolves
    annotations node-first so both resolutions of one annotation agree.
+5a. ✅ **Shipped: operator + conditional coverage (toward slice 6).** Nodes for the remaining
+   composite operators and conditionals, so they stop falling back to the string scanner:
+   `IntersectionTypeNode` (resolved through the same `SimplifyIntersection`), `KeyofTypeNode`,
+   `IndexedAccessTypeNode` (chained `T[K][J]` nests structurally), `ConditionalTypeNode` +
+   `InferTypeNode` (the deferred `ConditionalType` is built node-first; distribution and `infer`
+   inference still run path-independently in `EvaluateConditionalType`), and `TypeQueryNode`
+   (`typeof`, delegating to the same `EvaluateTypeOf`). Conditional alias definitions now carry
+   nodes, so generic conditional aliases expand through `TryExpandGenericAliasFromNode`. Corpus
+   coverage: 68.7% → **75.0%** (410 node / 137 fallback). No baseline movement — the conditional
+   Fails are `EvaluateConditionalType`/`infer`-inference semantic gaps, not string round-trip
+   damage (verified: node and string paths produce identical verdicts). Remaining fallback is
+   dominated by **mapped types** (and the template-literal `as`-clauses some need) plus generic
+   `<T>(…) => R` signatures — the last constructs before the scanner can go.
 6. Delete `TypeChecker.TypeParsing.cs` string scanning; `ToTypeInfo(string)` survives only
    for the REPL/embedding API surface, implemented as parse-to-node + convert.
 

--- a/docs/plans/type-ast-design.md
+++ b/docs/plans/type-ast-design.md
@@ -184,9 +184,21 @@ an equivalence test that converts both ways and asserts identical `TypeInfo` ren
    inside alias definitions, which the coarse annotation counter doesn't measure) — like slice 3b,
    the win is the mechanism. No baseline movement; full unit suite green.
 
-   Remaining fallback before the scanner can go: generic `<T>(…) => R` signatures, template-literal
-   types, qualified names (`Foo.Bar`), and a handful of long-tail forms (`asserts`/predicates,
-   `unique symbol`, constrained `infer U extends C`).
+5c. ✅ **Shipped: generic signatures + template-literal types.** `GenericFunctionTypeNode`
+   (carries the `TypeParam` list and the body `FunctionTypeNode`; `TryResolveGenericFunctionType`
+   mirrors `TryParseGenericFunctionTypeInfo`'s two-pass scope so constraints/defaults and the body's
+   `T`s resolve identically) and `TemplateLiteralTypeNode` (N+1 static segments around N
+   interpolations; resolves through the same `NormalizeTemplateLiteralType` — concrete parts expand
+   to a string-literal union, a `string` part stays a pattern type). **Fixed a pre-existing latent
+   bug en route:** template-literal types in type position were entirely broken — the lexer emits a
+   `TemplateStringValue` (cooked+raw) but the type parser still cast `Token.Literal` to `string`,
+   so every `` `a${T}` `` annotation threw a parse error on the *string* path too. Now reads
+   `.Cooked` (both paths). Corpus coverage: 75.0% → **87.6%** (479 node / 68 fallback). No baseline
+   movement. Generic *constructor* types (`new <T>(…) => R`) deliberately still fall back.
+
+   Remaining fallback before the scanner can go: generic constructor types, qualified names
+   (`Foo.Bar`), the `readonly` array/tuple modifier, and a handful of long-tail forms
+   (`asserts`/predicates, `unique symbol`, constrained `infer U extends C`).
 6. Delete `TypeChecker.TypeParsing.cs` string scanning; `ToTypeInfo(string)` survives only
    for the REPL/embedding API surface, implemented as parse-to-node + convert.
 

--- a/docs/plans/type-ast-design.md
+++ b/docs/plans/type-ast-design.md
@@ -170,9 +170,23 @@ an equivalence test that converts both ways and asserts identical `TypeInfo` ren
    nodes, so generic conditional aliases expand through `TryExpandGenericAliasFromNode`. Corpus
    coverage: 68.7% → **75.0%** (410 node / 137 fallback). No baseline movement — the conditional
    Fails are `EvaluateConditionalType`/`infer`-inference semantic gaps, not string round-trip
-   damage (verified: node and string paths produce identical verdicts). Remaining fallback is
-   dominated by **mapped types** (and the template-literal `as`-clauses some need) plus generic
-   `<T>(…) => R` signatures — the last constructs before the scanner can go.
+   damage (verified: node and string paths produce identical verdicts).
+5b. ✅ **Shipped: mapped types.** `MappedTypeNode` (parameter, constraint, value, optional
+   `as`-clause, and the `+/-readonly` / `+/-?` modifier flags carried as bools so the syntax layer
+   needs no dependency on `MappedTypeModifiers`). `ParseMappedType` is now a node producer;
+   resolution (`TryResolveMappedType`) mirrors `ParseMappedTypeInfo` exactly — constraint first,
+   then the mapped parameter registered in `_openTypeVariablesInScope` (the SAME shared set) while
+   the as-clause and value type resolve, so their bodies build the identical deferred
+   IndexedAccess/TypeParameter forms `ExpandMappedType` substitutes per key. Generic mapped alias
+   definitions now expand through the node path (`TryExpandGenericAliasFromNode`'s post-pass calls
+   `ExpandMappedType`). A mapped type whose `as`-clause needs a template-literal (no node yet)
+   falls back whole. Corpus annotation-site coverage flat at 75.0% (the corpus's mapped types live
+   inside alias definitions, which the coarse annotation counter doesn't measure) — like slice 3b,
+   the win is the mechanism. No baseline movement; full unit suite green.
+
+   Remaining fallback before the scanner can go: generic `<T>(…) => R` signatures, template-literal
+   types, qualified names (`Foo.Bar`), and a handful of long-tail forms (`asserts`/predicates,
+   `unique symbol`, constrained `infer U extends C`).
 6. Delete `TypeChecker.TypeParsing.cs` string scanning; `ToTypeInfo(string)` survives only
    for the REPL/embedding API surface, implemented as parse-to-node + convert.
 

--- a/docs/plans/type-ast-design.md
+++ b/docs/plans/type-ast-design.md
@@ -196,9 +196,20 @@ an equivalence test that converts both ways and asserts identical `TypeInfo` ren
    `.Cooked` (both paths). Corpus coverage: 75.0% → **87.6%** (479 node / 68 fallback). No baseline
    movement. Generic *constructor* types (`new <T>(…) => R`) deliberately still fall back.
 
-   Remaining fallback before the scanner can go: generic constructor types, qualified names
-   (`Foo.Bar`), the `readonly` array/tuple modifier, and a handful of long-tail forms
-   (`asserts`/predicates, `unique symbol`, constrained `infer U extends C`).
+5d. ✅ **Shipped: long-tail constructs.** `ReadonlyTypeNode` (`readonly T[]` / `readonly [A,B]`
+   → marks the resolved array/tuple readonly), qualified names (the dotted name carries on
+   `NamedTypeNode`, handed to the same single-name / `ResolveGenericType` path), `TypePredicateNode`
+   + `AssertsNonNullTypeNode` (`x is T`, `asserts x is T`, `asserts x` — completes function types
+   with predicate returns), and constrained `infer U extends C` (the whole `U extends C` becomes the
+   inferred parameter's name, matching the string path's `InferredTypeParameter` quirk exactly).
+   Corpus annotation-site coverage flat at 87.6% (these forms live in alias defs / function returns,
+   not the three counted sites) — mechanism, not metric. No baseline movement; equivalence verified
+   (e.g. qualified namespace type-alias exports resolve permissively to `any` on BOTH paths).
+
+   Remaining fallback before the scanner can go: generic **constructor** types
+   (`new <T>(…) => R`), `unique symbol` (intentionally throws TS1331), bigint literal types
+   (`1n`), and whatever the remaining 68 corpus annotation-site fallbacks turn out to be (audit
+   next).
 6. Delete `TypeChecker.TypeParsing.cs` string scanning; `ToTypeInfo(string)` survives only
    for the REPL/embedding API surface, implemented as parse-to-node + convert.
 

--- a/docs/plans/type-ast-design.md
+++ b/docs/plans/type-ast-design.md
@@ -221,8 +221,30 @@ an equivalence test that converts both ways and asserts identical `TypeInfo` ren
    The string path (`ToTypeInfo(string)` / `TypeChecker.TypeParsing.cs`) is still reached for a few
    long-tail constructs absent from the corpus — bigint literal types (`1n`), `this`-parameter
    generic/constructor types, `unique symbol` — and remains the implementation for the REPL/embedding
-   API. Slice 6 (deleting the scanner) is now viable: give those last forms nodes, then reimplement
-   `ToTypeInfo(string)` as parse-to-node + convert.
+   API.
+
+   **The construct layer is done; the consumer layer is not.** Coverage above is measured at the
+   `ResolveAnnotation` sites only (originally var/const/function-param-hoist + alias defs + generic
+   args). The *other* annotation consumers — class fields, function/method params, return types,
+   `this` types, interface members, accessors, index signatures, type assertions — still call
+   `ToTypeInfo(string)` directly and must each be flipped to the node path before the scanner can go.
+   There are also internal **rendered-string round-trips** (`ResolveGenericType` arg-string overload,
+   string alias expansion, `SubstituteTypeParamInString`) whose strings are NOT valid source, so
+   they can't be reparsed — they need structural reimplementation, independent of the consumer flips.
+
+5f. ✅ **Shipped (first consumer flip): class field annotations.** `Stmt.Field.TypeAnnotationNode`
+   populated by the parser (captured immediately after the field's `ParseTypeAnnotation`, before the
+   initializer expression); both checker passes (signature collection + body check) resolve via
+   `ResolveAnnotation`. Constructor **parameter properties** (`constructor(public x: T)`) are a
+   separate field-creation path still on the string path. No baseline movement; full unit suite green.
+
+### Slice 6 — deleting the scanner (remaining)
+1. Flip the rest of the annotation consumers to the node path (class/interface members, function
+   signatures, accessors, index signatures, parameter properties, assertions) — mechanical breadth,
+   one AST `…Node` field + parser capture + checker `ResolveAnnotation` per site.
+2. Eliminate the internal rendered-string round-trips (work on `TypeInfo`/nodes, not `ToString()`).
+3. Reimplement `ToTypeInfo(string)` as parse-to-node + convert for the REPL/embedding surface, then
+   delete `TypeChecker.TypeParsing.cs`'s scanning.
 6. Delete `TypeChecker.TypeParsing.cs` string scanning; `ToTypeInfo(string)` survives only
    for the REPL/embedding API surface, implemented as parse-to-node + convert.
 


### PR DESCRIPTION
## Summary

Continues the type-AST migration (`docs/plans/type-ast-design.md`), completing the **node construct layer**: every TypeScript type *syntax* the parser accepts now produces a `TypeNode` that the checker resolves directly, with the string scanner as fallback. Node-path coverage over the TS conformance corpus rises **68.7% → 100.0%** (547 node / 0 fallback at the measured annotation sites). Also begins flipping annotation **consumers** off the string path (class fields).

Every increment was validated against both the full unit suite and the TS conformance baseline — **zero conformance regressions** (69 Pass / 8 Fail intact throughout), full unit suite green (10,842 passing). ~30 new equivalence/engagement tests.

## What's added

New `TypeNode` kinds + node-first resolution (each reusing the string path's existing semantic machinery so the two paths can't diverge):

- **Operators & conditionals:** intersection, `keyof`, indexed-access (`T[K]`), conditional + `infer`, `typeof`
- **Mapped types** (`{ [K in keyof T]: … }`, with `+/-readonly` / `+/-?` modifiers and `as` remapping)
- **Generic signatures:** generic function types (`<T>(…) => R`), generic constructor types (`new <T>(…) => R`), and object-type generic call/construct signatures — all sharing one two-pass type-parameter scope helper
- **Template-literal types** (`` `a${T}b` ``)
- **Long-tail:** `readonly` modifier, qualified names (`Foo.Bar`), type predicates (`x is T`, `asserts x`), constrained `infer U extends C`
- **First consumer flip:** class field annotations now resolve node-first via `ResolveAnnotation`

## Notable finds along the way

- **Fixed a pre-existing bug:** template-literal types in type position were entirely broken on *both* paths — the lexer emits `TemplateStringValue` (cooked+raw) but the type parser still cast `Token.Literal` to `string`, throwing a parse error on every `` `a${T}` `` annotation. Now reads `.Cooked`.
- **The 5 conditional-type conformance Fails are semantic, not path-related.** Verified node and string paths produce byte-identical verdicts; the gaps are in `EvaluateConditionalType` / `infer` inference, independent of this migration.

## Scope / what's next (not in this PR)

The **construct layer** is complete, but most annotation **consumers** (function/method params, return types, interface members, accessors, index signatures, parameter properties, assertions) still call `ToTypeInfo(string)` directly — class fields are the only one flipped here. Deleting `TypeChecker.TypeParsing.cs` additionally requires eliminating internal rendered-string round-trips (their strings aren't valid source). The remaining slice-6 roadmap is tracked in `docs/plans/type-ast-design.md`.

## Commits

- type-AST coverage — intersection/keyof/indexed-access/conditional/infer/typeof nodes
- type-AST coverage — mapped type nodes
- type-AST coverage — generic-signature + template-literal nodes (+ template parse fix)
- type-AST coverage — long-tail nodes (readonly, qualified names, predicates, constrained infer)
- type-AST coverage — generic constructor + object-type generic signatures (100% corpus)
- type-AST — flip class field annotations to the node path (first consumer migration)