### PR TITLE
fix: class-expression getter/setter dispatch in compiled mode (#283) + interpreter bracket-setter (#290)

### DIFF
--- a/Compilation/ILCompiler.Classes.HasFields.cs
+++ b/Compilation/ILCompiler.Classes.HasFields.cs
@@ -537,8 +537,42 @@ public partial class ILCompiler
         il.Emit(OpCodes.Ldloc, valueLocal);
         il.Emit(OpCodes.Ret);
 
-        // 3. Check instance methods (compile-time dispatch)
+        // 2c. Check instance getters (accessors with `get` keyword). Mirrors section 2c in
+        // EmitGetPropertyBody for class declarations: reading `obj.foo` where `foo` is a getter
+        // must INVOKE the getter and return its result. Without this, dynamic property access on
+        // a class-expression instance falls through to the method-wrapper path (or returns
+        // $Undefined for a getter with no same-named method) instead of the getter's value (#283).
+        // _classExprs.Getters mixes backing-field property getters with user `get` accessors, but
+        // backing-field names are already handled (and returned) by section 1, so those entries
+        // become dead branches here — matching the class-declaration registry's behavior.
         il.MarkLabel(tryMethodsLabel);
+        if (_classExprs.Getters.TryGetValue(classExpr, out var instanceGetters))
+        {
+            foreach (var (getterPascalName, getterMethod) in instanceGetters)
+            {
+                var camelName = NamingConventions.ToCamelCase(getterPascalName);
+                var nextLabel = il.DefineLabel();
+
+                il.Emit(OpCodes.Ldarg_1);
+                il.Emit(OpCodes.Ldstr, camelName);
+                il.Emit(OpCodes.Call, _types.GetMethod(_types.String, "op_Equality", _types.String, _types.String));
+                il.Emit(OpCodes.Brfalse, nextLabel);
+
+                // return this.<getter>()
+                // (instantiated form for generic classes — open MethodDef tokens are unloadable, #178)
+                il.Emit(OpCodes.Ldarg_0);
+                il.Emit(OpCodes.Callvirt, EmitterTypeHelpers.SelfMethodReference(getterMethod));
+                // GetProperty's return slot is object; box value-type / generic-parameter results
+                // to satisfy the verifier (#279).
+                if (getterMethod.ReturnType.IsValueType || getterMethod.ReturnType.IsGenericParameter)
+                    il.Emit(OpCodes.Box, getterMethod.ReturnType);
+                il.Emit(OpCodes.Ret);
+
+                il.MarkLabel(nextLabel);
+            }
+        }
+
+        // 3. Check instance methods (compile-time dispatch)
         if (_classExprs.InstanceMethods.TryGetValue(classExpr, out var instanceMethods))
         {
             // Check if this is a generic type - generic types require runtime reflection
@@ -631,6 +665,46 @@ public partial class ILCompiler
                 else if (backingField.FieldType != _types.Object)
                     il.Emit(OpCodes.Castclass, backingField.FieldType);
                 il.Emit(OpCodes.Stfld, backingField);
+                il.Emit(OpCodes.Ret);
+
+                il.MarkLabel(nextLabel);
+            }
+        }
+
+        // 1b. Check instance setters (accessors with `set` keyword). Mirrors section 1b in
+        // EmitSetPropertyBody for class declarations: writing `obj.foo` where `foo` is a setter
+        // must INVOKE it rather than storing into _fields, which would silently desynchronize
+        // reads (hitting the getter) from writes (hitting the dict) (#283). _classExprs.Setters
+        // mixes backing-field property setters with user `set` accessors; backing-field names are
+        // already handled (and returned) by section 1, so skip them here to avoid dead branches.
+        if (_classExprs.Setters.TryGetValue(classExpr, out var instanceSetters))
+        {
+            foreach (var (setterPascalName, setterMethod) in instanceSetters)
+            {
+                if (backingFields != null && backingFields.ContainsKey(setterPascalName))
+                    continue;
+
+                var camelName = NamingConventions.ToCamelCase(setterPascalName);
+                var nextLabel = il.DefineLabel();
+
+                il.Emit(OpCodes.Ldarg_1);
+                il.Emit(OpCodes.Ldstr, camelName);
+                il.Emit(OpCodes.Call, _types.GetMethod(_types.String, "op_Equality", _types.String, _types.String));
+                il.Emit(OpCodes.Brfalse, nextLabel);
+
+                // this.set_<Name>(value)
+                il.Emit(OpCodes.Ldarg_0);
+                il.Emit(OpCodes.Ldarg_2);
+                var setterParams = setterMethod.GetParameters();
+                var paramType = setterParams.Length > 0 ? setterParams[0].ParameterType : _types.Object;
+                if (paramType.IsValueType)
+                    il.Emit(OpCodes.Unbox_Any, paramType);
+                else if (paramType != _types.Object)
+                    il.Emit(OpCodes.Castclass, paramType);
+                // (instantiated form for generic classes — open MethodDef tokens are unloadable, #178)
+                il.Emit(OpCodes.Callvirt, EmitterTypeHelpers.SelfMethodReference(setterMethod));
+                if (setterMethod.ReturnType != _types.Void)
+                    il.Emit(OpCodes.Pop);
                 il.Emit(OpCodes.Ret);
 
                 il.MarkLabel(nextLabel);

--- a/Execution/Interpreter.Expressions.cs
+++ b/Execution/Interpreter.Expressions.cs
@@ -1051,7 +1051,23 @@ public partial class Interpreter
                 break;
 
             case IndexTarget.InstanceString t:
-                if (strictMode) t.Target.SetRawFieldStrict(t.Key, value, strictMode);
+                // Bracket assignment must invoke a declared setter / auto-accessor, mirroring
+                // dot assignment (SharpTSInstance.Set) and JS [[Set]] semantics. Without this the
+                // write lands in _fields while reads keep hitting the getter, silently
+                // desynchronizing the two (#290). Plain data writes stay on SetRawField so the
+                // defineProperty `writable:false` flag continues to be honored.
+                if (t.Target.GetClass().FindSetter(t.Key) != null
+                    || t.Target.GetClass().HasInstanceAutoAccessor(t.Key))
+                {
+                    // Set/SetStrict invoke the setter only when the instance has an interpreter
+                    // reference; the dot-assignment path primes it the same way (cold instances
+                    // created by `new` don't carry one until first member access).
+                    t.Target.SetInterpreter(this);
+                    var setToken = new Token(TokenType.IDENTIFIER, t.Key, null, 0);
+                    if (strictMode) t.Target.SetStrict(setToken, value, strictMode);
+                    else t.Target.Set(setToken, value);
+                }
+                else if (strictMode) t.Target.SetRawFieldStrict(t.Key, value, strictMode);
                 else t.Target.SetRawField(t.Key, value);
                 break;
 

--- a/SharpTS.Tests/SharedTests/ClassExpressionTests.cs
+++ b/SharpTS.Tests/SharedTests/ClassExpressionTests.cs
@@ -285,5 +285,26 @@ public class ClassExpressionTests
         Assert.Equal("42\n", output);
     }
 
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ClassExpression_Setter_DynamicAccess(ExecutionMode mode)
+    {
+        // Dynamic (bracket) assignment must invoke the setter in both modes. Compiled mode is
+        // covered by #283's SetProperty dispatch; the interpreter's bracket path is fixed by #290.
+        var source = """
+            const Counter = class {
+                private _n: number = 0;
+                get n(): number { return this._n; }
+                set n(v: number) { this._n = v * 2; }
+            };
+            const c = new Counter();
+            (c as any)["n"] = 5;
+            console.log((c as any)["n"]);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("10\n", output);
+    }
+
     #endregion
 }

--- a/SharpTS.Tests/SharedTests/ClassExpressionTests.cs
+++ b/SharpTS.Tests/SharedTests/ClassExpressionTests.cs
@@ -221,4 +221,69 @@ public class ClassExpressionTests
     }
 
     #endregion
+
+    #region Accessors (get / set)
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ClassExpression_Getter(ExecutionMode mode)
+    {
+        // Regression for #283: a named getter on a class expression returned undefined
+        // in compiled mode because the class-expr GetProperty body never dispatched accessors.
+        var source = """
+            const Widget = class {
+                constructor(public id: number) {}
+                get label(): string { return "w" + this.id; }
+                greet(): string { return "hi"; }
+            };
+            const w = new Widget(3);
+            console.log(w.id);
+            console.log(w.greet());
+            console.log(w.label);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("3\nhi\nw3\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ClassExpression_Getter_DynamicAccess(ExecutionMode mode)
+    {
+        // Dynamic (bracket) access also routes through the class-expr GetProperty body (#283).
+        var source = """
+            const Widget = class {
+                constructor(public id: number) {}
+                get label(): string { return "w" + this.id; }
+            };
+            const w = new Widget(7);
+            console.log((w as any)["label"]);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("w7\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ClassExpression_Setter(ExecutionMode mode)
+    {
+        // Symmetric gap (#283): the class-expr SetProperty body never dispatched setters,
+        // so writes landed in _fields while reads kept hitting the getter.
+        var source = """
+            const Counter = class {
+                private _n: number = 0;
+                get n(): number { return this._n; }
+                set n(v: number) { this._n = v * 2; }
+            };
+            const c = new Counter();
+            c.n = 21;
+            console.log(c.n);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("42\n", output);
+    }
+
+    #endregion
 }

--- a/SharpTS.Tests/SharedTests/GettersSettersTests.cs
+++ b/SharpTS.Tests/SharedTests/GettersSettersTests.cs
@@ -243,5 +243,27 @@ public class GettersSettersTests
         Assert.Equal("Alice\n", output);
     }
 
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Setter_InvokedViaBracketAssignment(ExecutionMode mode)
+    {
+        // Regression for #290: bracket assignment `obj["n"] = v` must invoke the declared setter,
+        // matching dot assignment and JS [[Set]] semantics. The interpreter previously stored
+        // straight into the field dictionary, desynchronizing reads (getter) from writes.
+        var source = """
+            class Counter {
+                private _n: number = 0;
+                get n(): number { return this._n; }
+                set n(v: number) { this._n = v * 2; }
+            }
+            const c = new Counter();
+            (c as any)["n"] = 5;
+            console.log((c as any)["n"]);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("10\n", output);
+    }
+
     #endregion
 }


### PR DESCRIPTION
## Summary

Fixes class-expression accessor dispatch in compiled mode (#283) and the symmetric interpreter-side bracket-assignment setter gap (#290) uncovered while verifying the fix. Both modes now agree on getter/setter behavior for class expressions and class declarations across static (`obj.foo`) and dynamic (`obj["foo"]`) access.

## Commits

### `fix(compile): dispatch getters/setters on class expressions (#283)`
A named `get`/`set` accessor on a class expression (`const C = class { get foo() {...} }`) returned `undefined` in compiled mode and silently dropped setter writes, while the interpreter was correct.

The class-declaration property bodies (`EmitGetPropertyBody` / `EmitSetPropertyBody`) dispatch instance accessors, but the class-expression counterparts (`EmitGetPropertyBodyForClassExpr` / `EmitSetPropertyBodyForClassExpr`) omitted those sections, so both static and dynamic access fell through to the dynamic `GetProperty` path and returned `$Undefined` / stored into `_fields`.

Mirrors the declaration dispatch into the class-expression bodies, reading the structurally-identical `_classExprs.Getters` / `_classExprs.Setters` registries, reusing the box-on-value-type/generic-parameter pattern (#279) and the `SelfMethodReference` instantiated-token pattern (#178). IL verification passes.

### `fix(interp): invoke setter on bracket-notation assignment (#290)`
`obj["foo"] = v` in the interpreter stored straight into the instance field dictionary (`SetRawField`), never invoking a declared `set foo(...)`, so reads kept hitting the getter and desynchronized from writes. Dot assignment and compiled mode both invoke the setter — this was an interpreter-only divergence affecting declarations and expressions.

`PerformIndexSet`'s `InstanceString` case now dispatches to `Set`/`SetStrict` (auto-accessor → setter → field precedence, same as dot assignment) when a matching setter/auto-accessor exists; plain data writes still use `SetRawField` so the `defineProperty` `writable:false` flag is honored. The instance's interpreter reference is primed first (cold `new` instances don't carry one until first member access). The shared `PerformIndexSet` also backs the async and compound/logical bracket paths.

## Testing

- New shared (interpreter + compiled) regression tests: `ClassExpression_Getter`, `ClassExpression_Getter_DynamicAccess`, `ClassExpression_Setter`, `ClassExpression_Setter_DynamicAccess`, `Setter_InvokedViaBracketAssignment`.
- Full suite green: **10860 passed, 0 failed, 1 skipped**.
- `--compile … --verify` passes for the class-expression accessor repro.

## Follow-up issues filed
- #291 — generic class expressions reject constructor arguments (type-checker, both modes).
- #293 — compiled mode: bracket write to a getter-only property shadows the getter (interpreter no-ops correctly).

Fixes #283. Fixes #290.
