### PR TITLE
fix: derived-ctor super() verifier + class-expr inheritance + Math value-form parity (#287, #288)

### DIFF
--- a/Compilation/ILCompiler.Classes.ClassExpressions.cs
+++ b/Compilation/ILCompiler.Classes.ClassExpressions.cs
@@ -80,6 +80,18 @@ public partial class ILCompiler
             {
                 // Found in class declarations
             }
+            else if (_classExprs.VarToClassExpr.TryGetValue(superclassName, out var parentClassExpr)
+                     && _classExprs.Builders.TryGetValue(parentClassExpr, out var parentExprBuilder))
+            {
+                // Superclass is another class expression bound to a variable
+                // (e.g. `const A = class {}; const B = class extends A {}`).
+                // _classExprs.Names holds GENERATED names ($ClassExpr_N), so the
+                // by-generated-name scan below never matches the source variable
+                // name — without this, B's parent defaults to System.Object while
+                // super() still chains A..ctor, tripping ILVerify CallCtor /
+                // ThisUninitReturn (#287 family).
+                superTypeBuilder = parentExprBuilder;
+            }
             else
             {
                 // Check other class expressions by their generated name
@@ -587,21 +599,38 @@ public partial class ILCompiler
         il.Emit(OpCodes.Newobj, _types.DictionaryStringObjectCtor);
         il.Emit(OpCodes.Stfld, fieldsField);
 
+        // Emit constructor body first if present (contains super() call)
+        var emitter = new ILEmitter(ctx);
+
         // Determine if we need to call base constructor automatically
         // If there's an explicit constructor body, it should contain super() call
         bool hasExplicitSuperCall = constructor?.Body?.Any(stmt => ContainsSuperCall(stmt)) ?? false;
 
         if (!hasExplicitSuperCall)
         {
-            // No explicit super() - call parent constructor automatically
-            Type baseType = typeBuilder.BaseType ?? typeof(object);
+            // No explicit super() - call parent constructor automatically.
             il.Emit(OpCodes.Ldarg_0);
-            var baseCtor = baseType.GetConstructor([]) ?? _types.ObjectDefaultCtor;
-            il.Emit(OpCodes.Call, baseCtor);
-        }
 
-        // Emit constructor body first if present (contains super() call)
-        var emitter = new ILEmitter(ctx);
+            // When the superclass is another emitted class (declaration or
+            // expression), its base is a TypeBuilder — Type.GetConstructor is
+            // not supported on an unbaked TypeBuilder, so resolve the parent's
+            // ConstructorBuilder from the registries instead (#287 family). The
+            // implicit derived constructor forwards no args, so supply defaults
+            // for any base ctor parameters (parameterless in the common case).
+            var baseCtor = ResolveClassExprImplicitBaseConstructor(classExpr);
+            if (baseCtor != null)
+            {
+                foreach (var p in baseCtor.GetParameters())
+                    emitter.EmitDefaultForType(p.ParameterType);
+                il.Emit(OpCodes.Call, baseCtor);
+            }
+            else
+            {
+                Type baseType = typeBuilder.BaseType ?? typeof(object);
+                var fallbackCtor = baseType.GetConstructor([]) ?? _types.ObjectDefaultCtor;
+                il.Emit(OpCodes.Call, fallbackCtor);
+            }
+        }
         if (constructor != null)
         {
             // Define parameters with typed parameter types from constructor signature
@@ -667,6 +696,33 @@ public partial class ILCompiler
         }
 
         il.Emit(OpCodes.Ret);
+    }
+
+    /// <summary>
+    /// Resolves the parent constructor for a class expression's implicit
+    /// (no explicit super()) base-constructor call. The parent may be another
+    /// class expression bound to a variable or a class declaration; in both
+    /// cases the parent's base type is an unbaked TypeBuilder for which
+    /// Type.GetConstructor throws, so the ConstructorBuilder is pulled from the
+    /// emit-time registries instead. Returns null when the superclass is a
+    /// baked/built-in type (caller falls back to reflection).
+    /// </summary>
+    private System.Reflection.ConstructorInfo? ResolveClassExprImplicitBaseConstructor(Expr.ClassExpr classExpr)
+    {
+        if (!_classExprs.Superclass.TryGetValue(classExpr, out var superName) || superName == null)
+            return null;
+
+        // Parent is another class expression bound to a variable.
+        if (_classExprs.VarToClassExpr.TryGetValue(superName, out var parentExpr)
+            && _classExprs.Constructors.TryGetValue(parentExpr, out var exprCtor))
+            return exprCtor;
+
+        // Parent is a class declaration.
+        var resolved = GetDefinitionContext().ResolveClassName(superName);
+        if (_classes.Constructors.TryGetValue(resolved, out var declCtor))
+            return declCtor;
+
+        return null;
     }
 
     /// <summary>

--- a/Compilation/ILCompiler.Classes.Constructors.cs
+++ b/Compilation/ILCompiler.Classes.Constructors.cs
@@ -220,9 +220,18 @@ public partial class ILCompiler
 
             il.Emit(OpCodes.Call, ctorToCall);
         }
+        else if (constructor != null && qualifiedSuperclass != null && _classes.Constructors.ContainsKey(qualifiedSuperclass))
+        {
+            // Explicit constructor with a user-class superclass: the super(...)
+            // call in the body chains the base constructor via
+            // SuperConstructorHandler. Emitting Object..ctor here would call the
+            // WRONG base (Object instead of the real parent) and leave the
+            // verifier seeing a base-ctor `call` on an already-initialized
+            // `this` — ILVerify CallCtor (#287). Emit nothing; super() handles it.
+        }
         else if (!isErrorSubclass && !isDirectArraySubclass && !isDirectPromiseSubclass)
         {
-            // Has explicit constructor (which should have super() call) or no superclass.
+            // No superclass (base is Object): initialize via Object..ctor.
             // For Error/Array/Promise subclasses with an explicit constructor, skip this —
             // super() in the constructor body calls the base constructor via
             // SuperConstructorHandler.

--- a/Compilation/ILCompiler.Classes.HasFields.cs
+++ b/Compilation/ILCompiler.Classes.HasFields.cs
@@ -368,10 +368,11 @@ public partial class ILCompiler
             }
         }
 
-        // 4. Return $Undefined.Instance if nothing found
+        // 4. Not found on this class — delegate to the base class's GetProperty
+        // so inherited members resolve under dynamic dispatch (else fall back to
+        // returning $Undefined).
         il.MarkLabel(returnNullLabel);
-        il.Emit(OpCodes.Ldsfld, _runtime.UndefinedInstance);
-        il.Emit(OpCodes.Ret);
+        EmitGetPropertyBaseFallthrough(il, ResolveBaseStubClassName(classStmt), _classes.Builders[className].BaseType);
     }
 
     /// <summary>
@@ -627,10 +628,83 @@ public partial class ILCompiler
             }
         }
 
-        // 4. Return $Undefined.Instance if nothing found
+        // 4. Not found on this class — delegate to the base class's GetProperty
+        // so inherited members resolve under dynamic dispatch (else fall back to
+        // returning $Undefined).
         il.MarkLabel(returnNullLabel);
+        EmitGetPropertyBaseFallthrough(il, ResolveBaseStubClassName(classExpr), _classExprs.Builders[classExpr].BaseType);
+    }
+
+    /// <summary>
+    /// Emits the GetProperty inheritance fallthrough: when a class's own
+    /// compile-time dispatch finds nothing, delegate to the base class's
+    /// GetProperty so members inherited from a base class (methods, getters,
+    /// typed properties) resolve under DYNAMIC dispatch. Without this, an
+    /// inherited member accessed dynamically — e.g. `(x as any).inherited()`,
+    /// or ANY method call on a class-expression instance (always anonymously
+    /// typed, so always dynamically dispatched) — resolves to undefined and the
+    /// call throws "undefined is not a function". Falls back to returning
+    /// $Undefined when the base is System.Object or a built-in (no emitted
+    /// $IHasFields stub).
+    /// </summary>
+    private void EmitGetPropertyBaseFallthrough(ILGenerator il, string? baseClassName, Type? baseType)
+    {
+        if (baseClassName != null && _classes.HasFieldsStubs.TryGetValue(baseClassName, out var baseStubs))
+        {
+            // return base.GetProperty(name);  — non-virtual `call` to the
+            // specific base implementation (not callvirt, which would recurse
+            // into this class's own override). The chain terminates at the
+            // topmost emitted class whose base has no stub.
+            MethodInfo target = baseStubs.GetProperty;
+            if (baseType != null && baseType.IsGenericType && baseType.IsConstructedGenericType)
+                target = EmitterTypeHelpers.ResolveMethod(baseType, baseStubs.GetProperty);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Call, target);
+            il.Emit(OpCodes.Ret);
+            return;
+        }
+
         il.Emit(OpCodes.Ldsfld, _runtime.UndefinedInstance);
         il.Emit(OpCodes.Ret);
+    }
+
+    /// <summary>
+    /// Resolves the emitted base class name (a $IHasFields stub key) for a class
+    /// declaration's GetProperty inheritance fallthrough, or null when the base
+    /// is System.Object / a built-in without a stub.
+    /// </summary>
+    private string? ResolveBaseStubClassName(Stmt.Class classStmt)
+    {
+        if (classStmt.SuperclassExpr == null)
+            return null;
+        var leaf = Expr.GetSuperclassLeafName(classStmt.SuperclassExpr);
+        if (leaf == null)
+            return null;
+        var resolved = GetDefinitionContext().ResolveClassName(leaf);
+        return _classes.HasFieldsStubs.ContainsKey(resolved) ? resolved : null;
+    }
+
+    /// <summary>
+    /// Resolves the emitted base class name (a $IHasFields stub key) for a class
+    /// expression's GetProperty inheritance fallthrough. The superclass may be
+    /// another class expression bound to a variable or a class declaration.
+    /// </summary>
+    private string? ResolveBaseStubClassName(Expr.ClassExpr classExpr)
+    {
+        if (!_classExprs.Superclass.TryGetValue(classExpr, out var superName) || superName == null)
+            return null;
+
+        string? baseClassName;
+        if (_classExprs.VarToClassExpr.TryGetValue(superName, out var parentExpr)
+            && _classExprs.Names.TryGetValue(parentExpr, out var generatedName))
+            baseClassName = generatedName;
+        else
+            baseClassName = GetDefinitionContext().ResolveClassName(superName);
+
+        return baseClassName != null && _classes.HasFieldsStubs.ContainsKey(baseClassName)
+            ? baseClassName
+            : null;
     }
 
     /// <summary>

--- a/Runtime/BuiltIns/BuiltInRegistry.cs
+++ b/Runtime/BuiltIns/BuiltInRegistry.cs
@@ -333,7 +333,12 @@ public sealed class BuiltInRegistry
             Name: "Math",
             IsSingleton: true,
             SingletonFactory: () => SharpTSMath.Instance,
-            GetMethod: name => MathBuiltIns.GetMember(name) as BuiltInMethod
+            // Bind to the singleton so the namespace path (`Math.max`) returns
+            // the SAME receiver-cached method as the instance path (`m.max`,
+            // where m holds Math). Without this they yield distinct wrappers and
+            // `Math.max === Math.max` via different access forms is false. Bind
+            // caches by receiver, so identity is stable per spec (#288).
+            GetMethod: name => (MathBuiltIns.GetMember(name) as BuiltInMethod)?.Bind(SharpTSMath.Instance)
         ));
     }
 

--- a/Runtime/BuiltIns/ObjectBuiltIns.cs
+++ b/Runtime/BuiltIns/ObjectBuiltIns.cs
@@ -72,6 +72,14 @@ public static class ObjectBuiltIns
             var keys = dict.Keys.Select(k => (object?)k).ToList();
             return RuntimeValue.FromObject(new SharpTSArray(keys));
         }
+        // Math singleton: built-in members are non-enumerable, so the own
+        // enumerable keys are exactly the user-assigned extras (empty unless the
+        // program assigned to Math). Matches compiled mode (#288).
+        if (arg is SharpTSMath math)
+        {
+            var keys = math.OwnEnumerableProperties.Select(kv => (object?)kv.Key).ToList();
+            return RuntimeValue.FromObject(new SharpTSArray(keys));
+        }
         throw new Exception("Object.keys() requires an object argument");
     }
 
@@ -98,6 +106,12 @@ public static class ObjectBuiltIns
         if (arg is IDictionary<string, object?> dict)
         {
             return RuntimeValue.FromObject(new SharpTSArray(dict.Values.ToList()));
+        }
+        // Math singleton — see Object.keys (#288).
+        if (arg is SharpTSMath math)
+        {
+            var values = math.OwnEnumerableProperties.Select(kv => kv.Value).ToList();
+            return RuntimeValue.FromObject(new SharpTSArray(values));
         }
         throw new Exception("Object.values() requires an object argument");
     }
@@ -130,6 +144,13 @@ public static class ObjectBuiltIns
         if (arg is IDictionary<string, object?> dict)
         {
             var entries = dict.Select(kv =>
+                (object?)new SharpTSArray([(object?)kv.Key, kv.Value])).ToList();
+            return RuntimeValue.FromObject(new SharpTSArray(entries));
+        }
+        // Math singleton — see Object.keys (#288).
+        if (arg is SharpTSMath math)
+        {
+            var entries = math.OwnEnumerableProperties.Select(kv =>
                 (object?)new SharpTSArray([(object?)kv.Key, kv.Value])).ToList();
             return RuntimeValue.FromObject(new SharpTSArray(entries));
         }

--- a/Runtime/Types/SharpTSMath.cs
+++ b/Runtime/Types/SharpTSMath.cs
@@ -47,5 +47,13 @@ public class SharpTSMath
         _extras[name] = value;
     }
 
+    /// <summary>
+    /// The own enumerable properties of Math. All built-in members (abs, max,
+    /// PI, …) are non-enumerable per ECMA-262, so only user-assigned extras
+    /// appear here — empty in the common case. Backs Object.keys/values/entries.
+    /// </summary>
+    public IReadOnlyCollection<KeyValuePair<string, object?>> OwnEnumerableProperties
+        => _extras ?? (IReadOnlyCollection<KeyValuePair<string, object?>>)Array.Empty<KeyValuePair<string, object?>>();
+
     public override string ToString() => "[object Math]";
 }

--- a/SharpTS.Tests/CompilerTests/ILVerificationTests.cs
+++ b/SharpTS.Tests/CompilerTests/ILVerificationTests.cs
@@ -115,6 +115,38 @@ public class ILVerificationTests
     }
 
     [Fact]
+    public void DerivedConstructorWithSuper_PassesILVerification()
+    {
+        // A subclass with an EXPLICIT constructor calling super(...) emitted a
+        // base-ctor `call` (Object..ctor) before super() chained the real parent
+        // ctor, so the verifier saw a base-ctor call on an already-initialized /
+        // wrong-base `this` — CallCtor. The program ran correctly; the IL was
+        // merely unverifiable. Now the Object..ctor is skipped when super() will
+        // chain the real base. Covers no-arg and arg'd bases, parameter
+        // properties, multi-level chains, and generic bases. (#287)
+        var source = """
+            class A0 { constructor() {} }
+            class B0 extends A0 { constructor() { super(); } }
+            class A1 { constructor(public x: number) {} }
+            class B1 extends A1 { y: number; constructor() { super(5); this.y = 9; } }
+            class C1 extends B1 { constructor() { super(); } }
+            class Box<T> { constructor(public v: T) {} }
+            class IntBox extends Box<number> { constructor() { super(42); } }
+            console.log(new B0() instanceof A0);
+            const b1 = new B1();
+            console.log(b1.x, b1.y);
+            const c1 = new C1();
+            console.log(c1.x, c1.y);
+            console.log(new IntBox().v);
+            """;
+
+        var (errors, output) = TestHarness.CompileVerifyAndRun(source);
+
+        Assert.Empty(errors);
+        Assert.Equal("true\n5 9\n5 9\n42\n", output);
+    }
+
+    [Fact]
     public void Generators_PassesILVerification()
     {
         var source = """

--- a/SharpTS.Tests/CompilerTests/ILVerificationTests.cs
+++ b/SharpTS.Tests/CompilerTests/ILVerificationTests.cs
@@ -182,6 +182,38 @@ public class ILVerificationTests
     }
 
     [Fact]
+    public void ClassExpressionInheritedMethodDispatch_PassesILVerification()
+    {
+        // The compiled per-class GetProperty helper only dispatched a class's
+        // OWN members, so a method inherited from a base class resolved to
+        // undefined under the (always dynamic) class-expression dispatch and the
+        // call threw. GetProperty now delegates to the base class. Three-level
+        // chain exercises recursive delegation: Puppy inherits Dog.speak. (#297)
+        var source = """
+            const Animal = class {
+                constructor(public name: string) {}
+                speak(): string { return this.name + " makes a sound"; }
+            };
+            const Dog = class extends Animal {
+                constructor(name: string) { super(name); }
+                speak(): string { return this.name + " barks"; }
+            };
+            const Puppy = class extends Dog {
+                constructor() { super("Rex"); }
+            };
+            const p = new Puppy();
+            console.log(p.speak(), p.name, p instanceof Dog, p instanceof Animal);
+            """;
+
+        // Verify-only (see ClassExpressionExtendsClassExpression note). Runtime
+        // inherited-dispatch behavior is asserted by the shared-mode test
+        // ClassExpressionTests.ClassExpression_MultiLevelInheritedMethod.
+        var errors = TestHarness.CompileAndVerifyOnly(source);
+
+        Assert.Empty(errors);
+    }
+
+    [Fact]
     public void Generators_PassesILVerification()
     {
         var source = """

--- a/SharpTS.Tests/CompilerTests/ILVerificationTests.cs
+++ b/SharpTS.Tests/CompilerTests/ILVerificationTests.cs
@@ -147,6 +147,41 @@ public class ILVerificationTests
     }
 
     [Fact]
+    public void ClassExpressionExtendsClassExpression_PassesILVerification()
+    {
+        // A class expression extending ANOTHER class expression resolved its
+        // superclass by the generated $ClassExpr_N name instead of the source
+        // variable name, so the parent type was never set — the child silently
+        // extended System.Object while super() still chained the real parent
+        // ctor, tripping CallCtor / ThisUninitReturn, and `instanceof` against
+        // the parent returned false. With the parent type now set, the IL
+        // verifies and instanceof is correct. (#296)
+        var source = """
+            const Animal = class {
+                constructor(public name: string) {}
+                speak(): string { return this.name + " makes a sound"; }
+            };
+            const Dog = class extends Animal {
+                constructor(name: string) { super(name); }
+                speak(): string { return this.name + " barks"; }
+            };
+            const a = new Animal("Generic");
+            const d = new Dog("Fido");
+            console.log(a.speak());
+            console.log(d.speak(), d instanceof Animal);
+            """;
+
+        // Verify-only: the reference-assembly rewrite in CompileVerifyAndRun
+        // mangles the ldtoken-derived MethodInfo used by class-expression method
+        // dispatch (BadImageFormatException at run time). Runtime behavior of
+        // class-expression inheritance is covered by the shared-mode tests in
+        // ClassExpressionTests, which run the real compiled output.
+        var errors = TestHarness.CompileAndVerifyOnly(source);
+
+        Assert.Empty(errors);
+    }
+
+    [Fact]
     public void Generators_PassesILVerification()
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/BuiltInSingletonValueFormTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInSingletonValueFormTests.cs
@@ -47,13 +47,14 @@ public class BuiltInSingletonValueFormTests
     }
 
     [Theory]
-    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void Math_AsValue_MethodIdentityIsStable(ExecutionMode mode)
     {
-        // The value-form wrapper must be the same identity-cached $TSFunction the
-        // bare `Math.max` syntactic form hands out (ECMA-262: built-in methods are
-        // single objects). Interpreted mode synthesizes a fresh wrapper per read,
-        // so this is scoped to compiled mode.
+        // The value-form wrapper must be the same identity-cached method the bare
+        // `Math.max` syntactic form hands out (ECMA-262: built-in methods are
+        // single objects). The interpreter's namespace path now binds to the Math
+        // singleton, so it returns the same receiver-cached method as the
+        // instance path — identity holds in both modes (#288).
         var source = @"
             const m: any = Math;
             console.log(m.max === Math.max);
@@ -64,17 +65,38 @@ public class BuiltInSingletonValueFormTests
     }
 
     [Theory]
-    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void Math_AsValue_MethodsAreNonEnumerable(ExecutionMode mode)
     {
-        // Math's methods are non-enumerable per ECMA-262 §17, so populating the
-        // singleton must install non-enumerable descriptors — `Object.keys(Math)`
-        // stays empty.
+        // Math's methods are non-enumerable per ECMA-262 §17, so `Object.keys(Math)`
+        // is empty. Compiled mode installs non-enumerable descriptors; the
+        // interpreter treats the Math singleton's own enumerable properties as just
+        // its user-assigned extras (none here). Both modes return [] (#288).
         var source = @"
             const m: any = Math;
             console.log(Object.keys(m).length);
         ";
         var output = TestHarness.Run(source, mode);
         Assert.Equal("0\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void Math_AsValue_ValuesAndEntriesAreEmpty(ExecutionMode mode)
+    {
+        // Object.values/entries on Math return only its own enumerable properties;
+        // the built-in members are non-enumerable, so with no user extras the
+        // result is empty (previously the interpreter threw). Scoped to
+        // interpreted mode: compiled Object.values/entries(Math) currently also
+        // enumerate the non-enumerable built-in methods — tracked separately.
+        // (Tests avoid assigning to Math: its singleton is process-global, so an
+        // extra would leak into other in-process interpreted runs.) (#288)
+        var source = @"
+            const m: any = Math;
+            console.log(Object.values(m).length);
+            console.log(Object.entries(m).length);
+        ";
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("0\n0\n", output);
     }
 }

--- a/SharpTS.Tests/SharedTests/ClassExpressionTests.cs
+++ b/SharpTS.Tests/SharedTests/ClassExpressionTests.cs
@@ -143,6 +143,58 @@ public class ClassExpressionTests
         Assert.Equal("Rex barks\n", output);
     }
 
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ClassExpression_InheritedMethod_NotOverridden(ExecutionMode mode)
+    {
+        // A child class expression that does NOT override a parent method must
+        // still resolve it. Class-expression instances are anonymously typed, so
+        // every call is dynamically dispatched through the compiled
+        // GetProperty helper, which only covered a class's OWN members — an
+        // inherited method resolved to undefined and threw. Now GetProperty
+        // delegates to the base class. (#287 family)
+        var source = """
+            const Animal = class {
+                constructor(public name: string) {}
+                speak(): string { return this.name + " makes a sound"; }
+            };
+            const Dog = class extends Animal {
+                constructor(name: string) { super(name); }
+            };
+            const d = new Dog("Fido");
+            console.log(d.speak());
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("Fido makes a sound\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ClassExpression_MultiLevelInheritedMethod(ExecutionMode mode)
+    {
+        // Three-level class-expression chain: the grandchild inherits the
+        // grandparent's method (using `this`), exercising recursive base-class
+        // GetProperty delegation. (#287 family)
+        var source = """
+            const Animal = class {
+                constructor(public name: string) {}
+                speak(): string { return this.name + " sound"; }
+            };
+            const Dog = class extends Animal {
+                constructor(name: string) { super(name); }
+                speak(): string { return this.name + " barks"; }
+            };
+            const Puppy = class extends Dog {
+                constructor() { super("Rex"); }
+            };
+            console.log(new Puppy().speak());
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("Rex barks\n", output);
+    }
+
     #endregion
 
     #region Arrays and Variables

--- a/SharpTS.Tests/SharedTests/ClassTests.cs
+++ b/SharpTS.Tests/SharedTests/ClassTests.cs
@@ -29,6 +29,32 @@ public class ClassTests
 
     [Theory]
     [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void InheritedMethod_ResolvesUnderDynamicDispatch(ExecutionMode mode)
+    {
+        // Accessing an inherited method through an `any`-typed receiver forces
+        // DYNAMIC dispatch (compiled: $Runtime.GetProperty). The per-class
+        // GetProperty helper only knew the class's OWN members and returned
+        // undefined for inherited ones, so the call threw "undefined is not a
+        // function" — statically-typed receivers dodged this via direct virtual
+        // calls. GetProperty now delegates to the base class. (#287 family)
+        var source = """
+            class Animal {
+                constructor(public name: string) {}
+                speak(): string { return this.name + " sound"; }
+            }
+            class Dog extends Animal {
+                constructor(name: string) { super(name); }
+            }
+            const d: any = new Dog("Fido");
+            console.log(d.speak());
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("Fido sound\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void ClassMethod_CanBeInvoked(ExecutionMode mode)
     {
         var source = """


### PR DESCRIPTION
Fixes the two requested issues (#287, #288) plus three related defects found while testing, each in its own commit. Rebased onto latest `main`. Full suite green: **10900 passed, 0 failed**.

## Commits

### #287 — derived-ctor `super()` fails ILVerify CallCtor
A subclass with an explicit constructor calling `super(...)` emitted a base-ctor `call` to `System.Object::.ctor` before `super()` chained the real parent ctor, so the verifier saw a base-ctor call on a wrong/already-initialized `this` (`CallCtor`). The emitter now skips the `Object..ctor` call when the class has a user-class superclass whose `super(...)` will chain the base (mirroring the existing Error/Array/Promise handling).

### #296 (new) — class expression extending a class expression never set its parent
`const A = class {}; const B = class extends A {}` resolved the superclass by the generated `$ClassExpr_N` name instead of the source variable name, so `SetParent` was never called: `B` silently extended `System.Object` while `super()` chained the real parent ctor → `CallCtor`/`ThisUninitReturn`, and `instanceof` was wrong. Now resolves via `VarToClassExpr`, and the implicit base-ctor call uses the registered `ConstructorBuilder` instead of `Type.GetConstructor` on an unbaked `TypeBuilder`.

### #297 (new) — dynamic property access didn't resolve inherited members
The per-class `$IHasFields.GetProperty` only dispatched a class's OWN members and returned `$Undefined` otherwise — never delegating to the base. So inherited methods/getters resolved to undefined under dynamic dispatch (every class-expression method call, and inherited access via an `any` receiver), throwing "undefined is not a function". `GetProperty` now delegates to the base class's `GetProperty` when a member isn't found locally. Statically-typed receivers were unaffected (direct virtual calls). Reads only; `SetProperty`/`HasProperty` delegation noted as follow-up in #297.

### #288 — interpreter Math value-form diverged from compiled
- `m.max === Math.max` was false: the namespace path returned the unbound method while the instance path returned it bound to the singleton. The Math namespace `GetMethod` now binds to the singleton, so both paths return the same receiver-cached method (stable identity per ECMA-262).
- `Object.keys/values/entries(Math)` threw; the Math singleton is now a recognized receiver whose own enumerable properties are its user-assigned extras (built-ins are non-enumerable), matching compiled `Object.keys(Math)`.

## New issues filed while testing
- #296, #297 — fixed here (above).
- #298 — compiled `Object.values/entries(Math)` wrongly enumerate non-enumerable built-ins (interp values/entries assertions scoped InterpretedOnly until fixed).
- #299 — interp `JSON.stringify !== JSON.stringify` (JSON static methods not identity-stable).

## Tests
- `ILVerificationTests`: derived-ctor `super()`, class-expr-extends-class-expr, class-expr inherited dispatch (verify-clean).
- `ClassTests` / `ClassExpressionTests`: inherited-method dynamic dispatch (both modes), multi-level class-expr inheritance.
- `BuiltInSingletonValueFormTests`: Math identity + non-enumerable assertions promoted to run in both modes; values/entries empty case (interp).

Closes #287, #288, #296, #297.