### PR TITLE
Compiled & interp class/Math fixes: #297 #296 #287 #281 #300 #288 (+ verify #282/#276); supersedes #301

### DIFF
--- a/Compilation/ILCompiler.Classes.Accessors.cs
+++ b/Compilation/ILCompiler.Classes.Accessors.cs
@@ -203,7 +203,16 @@ public partial class ILCompiler
             ClassExprBuilders = _classExprs.Builders,
             IsStrictMode = _isStrictMode,
             // Registry services
-            ClassRegistry = GetClassRegistry()
+            ClassRegistry = GetClassRegistry(),
+            // Module-level / captured top-level variable access. Without these an
+            // accessor body that references a top-level binding (a captured `let`,
+            // a same-module export, an import) throws ReferenceError at runtime —
+            // every other body-emission context (methods, ctors, functions, …)
+            // sets them; the accessor path was the lone omission.
+            TopLevelStaticVars = BuildClassMethodTopLevelStaticVarsForModule(_modules.CurrentPath),
+            CapturedTopLevelVars = BuildCapturedTopLevelVarsForModule(_modules.CurrentPath),
+            EntryPointDisplayClassFields = BuildEntryPointDisplayClassFieldsForModule(_modules.CurrentPath),
+            EntryPointDisplayClassStaticField = _closures.EntryPointDisplayClassStaticField
         };
 
         // Add class generic type parameters to context

--- a/Compilation/ILCompiler.Classes.ClassExpressions.cs
+++ b/Compilation/ILCompiler.Classes.ClassExpressions.cs
@@ -80,6 +80,18 @@ public partial class ILCompiler
             {
                 // Found in class declarations
             }
+            else if (_classExprs.VarToClassExpr.TryGetValue(superclassName, out var parentClassExpr)
+                     && _classExprs.Builders.TryGetValue(parentClassExpr, out var parentExprBuilder))
+            {
+                // Superclass is another class expression bound to a variable
+                // (e.g. `const A = class {}; const B = class extends A {}`).
+                // _classExprs.Names holds GENERATED names ($ClassExpr_N), so the
+                // by-generated-name scan below never matches the source variable
+                // name — without this, B's parent defaults to System.Object while
+                // super() still chains A..ctor, tripping ILVerify CallCtor /
+                // ThisUninitReturn (#287 family).
+                superTypeBuilder = parentExprBuilder;
+            }
             else
             {
                 // Check other class expressions by their generated name
@@ -587,21 +599,38 @@ public partial class ILCompiler
         il.Emit(OpCodes.Newobj, _types.DictionaryStringObjectCtor);
         il.Emit(OpCodes.Stfld, fieldsField);
 
+        // Emit constructor body first if present (contains super() call)
+        var emitter = new ILEmitter(ctx);
+
         // Determine if we need to call base constructor automatically
         // If there's an explicit constructor body, it should contain super() call
         bool hasExplicitSuperCall = constructor?.Body?.Any(stmt => ContainsSuperCall(stmt)) ?? false;
 
         if (!hasExplicitSuperCall)
         {
-            // No explicit super() - call parent constructor automatically
-            Type baseType = typeBuilder.BaseType ?? typeof(object);
+            // No explicit super() - call parent constructor automatically.
             il.Emit(OpCodes.Ldarg_0);
-            var baseCtor = baseType.GetConstructor([]) ?? _types.ObjectDefaultCtor;
-            il.Emit(OpCodes.Call, baseCtor);
-        }
 
-        // Emit constructor body first if present (contains super() call)
-        var emitter = new ILEmitter(ctx);
+            // When the superclass is another emitted class (declaration or
+            // expression), its base is a TypeBuilder — Type.GetConstructor is
+            // not supported on an unbaked TypeBuilder, so resolve the parent's
+            // ConstructorBuilder from the registries instead (#287 family). The
+            // implicit derived constructor forwards no args, so supply defaults
+            // for any base ctor parameters (parameterless in the common case).
+            var baseCtor = ResolveClassExprImplicitBaseConstructor(classExpr);
+            if (baseCtor != null)
+            {
+                foreach (var p in baseCtor.GetParameters())
+                    emitter.EmitDefaultForType(p.ParameterType);
+                il.Emit(OpCodes.Call, baseCtor);
+            }
+            else
+            {
+                Type baseType = typeBuilder.BaseType ?? typeof(object);
+                var fallbackCtor = baseType.GetConstructor([]) ?? _types.ObjectDefaultCtor;
+                il.Emit(OpCodes.Call, fallbackCtor);
+            }
+        }
         if (constructor != null)
         {
             // Define parameters with typed parameter types from constructor signature
@@ -667,6 +696,33 @@ public partial class ILCompiler
         }
 
         il.Emit(OpCodes.Ret);
+    }
+
+    /// <summary>
+    /// Resolves the parent constructor for a class expression's implicit
+    /// (no explicit super()) base-constructor call. The parent may be another
+    /// class expression bound to a variable or a class declaration; in both
+    /// cases the parent's base type is an unbaked TypeBuilder for which
+    /// Type.GetConstructor throws, so the ConstructorBuilder is pulled from the
+    /// emit-time registries instead. Returns null when the superclass is a
+    /// baked/built-in type (caller falls back to reflection).
+    /// </summary>
+    private System.Reflection.ConstructorInfo? ResolveClassExprImplicitBaseConstructor(Expr.ClassExpr classExpr)
+    {
+        if (!_classExprs.Superclass.TryGetValue(classExpr, out var superName) || superName == null)
+            return null;
+
+        // Parent is another class expression bound to a variable.
+        if (_classExprs.VarToClassExpr.TryGetValue(superName, out var parentExpr)
+            && _classExprs.Constructors.TryGetValue(parentExpr, out var exprCtor))
+            return exprCtor;
+
+        // Parent is a class declaration.
+        var resolved = GetDefinitionContext().ResolveClassName(superName);
+        if (_classes.Constructors.TryGetValue(resolved, out var declCtor))
+            return declCtor;
+
+        return null;
     }
 
     /// <summary>

--- a/Compilation/ILCompiler.Classes.ClassExpressions.cs
+++ b/Compilation/ILCompiler.Classes.ClassExpressions.cs
@@ -511,7 +511,15 @@ public partial class ILCompiler
             VarToClassExpr = _classExprs.VarToClassExpr,
             IsStrictMode = _isStrictMode,
             // Registry services
-            ClassRegistry = GetClassRegistry()
+            ClassRegistry = GetClassRegistry(),
+            // Module-level / captured top-level variable access — without these a
+            // class-expression method or accessor body referencing a top-level
+            // binding throws ReferenceError at runtime (same omission #300 fixed
+            // for class-declaration accessor bodies).
+            TopLevelStaticVars = BuildClassMethodTopLevelStaticVarsForModule(_modules.CurrentPath),
+            CapturedTopLevelVars = BuildCapturedTopLevelVarsForModule(_modules.CurrentPath),
+            EntryPointDisplayClassFields = BuildEntryPointDisplayClassFieldsForModule(_modules.CurrentPath),
+            EntryPointDisplayClassStaticField = _closures.EntryPointDisplayClassStaticField
         };
     }
 

--- a/Compilation/ILCompiler.Classes.ClassExpressions.cs
+++ b/Compilation/ILCompiler.Classes.ClassExpressions.cs
@@ -350,13 +350,15 @@ public partial class ILCompiler
         {
             foreach (var accessor in classExpr.Accessors)
             {
-                // Symbol-keyed accessors are supported on class *declarations* (#266)
-                // but not yet on class *expressions* (separate emission path with no
-                // .cctor registration hook) — tracked by #281.
+                // Symbol-keyed computed accessor (#281): define a synthetic
+                // $sym_get/set_N method recorded in _classes.SymbolAccessors keyed
+                // by this class's generated name. It is registered in the class-
+                // expression .cctor and dispatched through the $Runtime symbol-
+                // accessor registry, mirroring the class-declaration path (#266).
                 if (accessor.ComputedKey != null)
                 {
-                    throw new Diagnostics.Exceptions.CompileException(
-                        $"Symbol-keyed computed accessors (line {accessor.Name.Line}) are not yet supported on class expressions in compiled mode (#281).");
+                    DefineSymbolAccessorMethod(typeBuilder, accessor);
+                    continue;
                 }
                 string accessorName = accessor.Name.Lexeme;
                 string pascalName = NamingConventions.ToPascalCase(accessorName);
@@ -434,12 +436,17 @@ public partial class ILCompiler
         {
             foreach (var accessor in classExpr.Accessors)
             {
-                if (!accessor.IsAbstract)
+                // Symbol-keyed accessors are emitted below from _classes.SymbolAccessors
+                // (their synthetic methods aren't in _classExprs.Getters/Setters).
+                if (!accessor.IsAbstract && accessor.ComputedKey == null)
                 {
                     EmitClassExpressionAccessor(classExpr, typeBuilder, accessor, fieldsField);
                 }
             }
         }
+
+        // Emit symbol-keyed computed accessor bodies (#281)
+        EmitClassExpressionSymbolAccessors(classExpr, typeBuilder, fieldsField);
 
         // Emit $IHasFields interface method bodies (now that method builders are available)
         EmitHasFieldsInterfaceMethodBodies(className, classExpr);
@@ -530,8 +537,11 @@ public partial class ILCompiler
     {
         bool hasStaticFields = classExpr.Fields.Any(f => f.IsStatic && f.Initializer != null);
         bool hasStaticInitializers = classExpr.StaticInitializers?.Count > 0;
+        // Symbol-keyed computed accessors (#281) register in the .cctor, keyed by
+        // this class's generated name (mirrors the class-declaration path #266).
+        bool hasSymbolAccessors = _classes.SymbolAccessors.ContainsKey(typeBuilder.Name);
 
-        if (!hasStaticFields && !hasStaticInitializers) return;
+        if (!hasStaticFields && !hasStaticInitializers && !hasSymbolAccessors) return;
 
         var cctor = typeBuilder.DefineConstructor(
             MethodAttributes.Static | MethodAttributes.Private | MethodAttributes.SpecialName | MethodAttributes.RTSpecialName,
@@ -578,6 +588,10 @@ public partial class ILCompiler
                 il.Emit(OpCodes.Stsfld, staticField);
             }
         }
+
+        // Register symbol-keyed computed accessors (#281) in the runtime registry,
+        // keyed by this class's Type so dynamic bracket get/set can dispatch them.
+        EmitSymbolAccessorRegistrations(emitter, il, typeBuilder);
 
         il.Emit(OpCodes.Ret);
     }
@@ -872,6 +886,49 @@ public partial class ILCompiler
     /// <summary>
     /// Emits an accessor body for a class expression.
     /// </summary>
+    /// <summary>
+    /// Emits the bodies of the synthetic symbol-keyed accessor methods (#281)
+    /// recorded for a class expression by <see cref="DefineSymbolAccessorMethod"/>.
+    /// Uses the class-expression compilation context (so `this`, fields, and
+    /// top-level bindings resolve) rather than the class-declaration accessor path.
+    /// </summary>
+    private void EmitClassExpressionSymbolAccessors(
+        Expr.ClassExpr classExpr,
+        TypeBuilder typeBuilder,
+        FieldInfo fieldsField)
+    {
+        if (!_classes.SymbolAccessors.TryGetValue(typeBuilder.Name, out var list))
+            return;
+
+        foreach (var (accessor, methodBuilder) in list)
+        {
+            var il = methodBuilder.GetILGenerator();
+            var ctx = CreateClassExpressionContext(il, classExpr, typeBuilder, accessor.IsStatic ? null : fieldsField);
+            ctx.IsInstanceMethod = !accessor.IsStatic;
+
+            if (accessor.Kind.Type == TokenType.SET && accessor.SetterParam != null)
+            {
+                var accessorParams = methodBuilder.GetParameters();
+                Type? paramType = accessorParams.Length > 0 ? accessorParams[0].ParameterType : null;
+                // Instance setter: arg0 is `this`, value at index 1. Static: value at index 0.
+                int paramIndex = accessor.IsStatic ? 0 : 1;
+                ctx.DefineParameter(accessor.SetterParam.Name.Lexeme, paramIndex, paramType);
+            }
+
+            var emitter = new ILEmitter(ctx);
+            foreach (var stmt in accessor.Body)
+                emitter.EmitStatement(stmt);
+
+            if (emitter.HasDeferredReturns)
+                emitter.FinalizeReturns();
+            else
+            {
+                il.Emit(OpCodes.Ldnull);
+                il.Emit(OpCodes.Ret);
+            }
+        }
+    }
+
     private void EmitClassExpressionAccessor(
         Expr.ClassExpr classExpr,
         TypeBuilder typeBuilder,

--- a/Compilation/ILCompiler.Classes.Constructors.cs
+++ b/Compilation/ILCompiler.Classes.Constructors.cs
@@ -220,9 +220,18 @@ public partial class ILCompiler
 
             il.Emit(OpCodes.Call, ctorToCall);
         }
+        else if (constructor != null && qualifiedSuperclass != null && _classes.Constructors.ContainsKey(qualifiedSuperclass))
+        {
+            // Explicit constructor with a user-class superclass: the super(...)
+            // call in the body chains the base constructor via
+            // SuperConstructorHandler. Emitting Object..ctor here would call the
+            // WRONG base (Object instead of the real parent) and leave the
+            // verifier seeing a base-ctor `call` on an already-initialized
+            // `this` — ILVerify CallCtor (#287). Emit nothing; super() handles it.
+        }
         else if (!isErrorSubclass && !isDirectArraySubclass && !isDirectPromiseSubclass)
         {
-            // Has explicit constructor (which should have super() call) or no superclass.
+            // No superclass (base is Object): initialize via Object..ctor.
             // For Error/Array/Promise subclasses with an explicit constructor, skip this —
             // super() in the constructor body calls the base constructor via
             // SuperConstructorHandler.

--- a/Compilation/ILCompiler.Classes.HasFields.cs
+++ b/Compilation/ILCompiler.Classes.HasFields.cs
@@ -368,10 +368,11 @@ public partial class ILCompiler
             }
         }
 
-        // 4. Return $Undefined.Instance if nothing found
+        // 4. Not found on this class — delegate to the base class's GetProperty
+        // so inherited members resolve under dynamic dispatch (else fall back to
+        // returning $Undefined).
         il.MarkLabel(returnNullLabel);
-        il.Emit(OpCodes.Ldsfld, _runtime.UndefinedInstance);
-        il.Emit(OpCodes.Ret);
+        EmitGetPropertyBaseFallthrough(il, ResolveBaseStubClassName(classStmt), _classes.Builders[className].BaseType);
     }
 
     /// <summary>
@@ -627,10 +628,83 @@ public partial class ILCompiler
             }
         }
 
-        // 4. Return $Undefined.Instance if nothing found
+        // 4. Not found on this class — delegate to the base class's GetProperty
+        // so inherited members resolve under dynamic dispatch (else fall back to
+        // returning $Undefined).
         il.MarkLabel(returnNullLabel);
+        EmitGetPropertyBaseFallthrough(il, ResolveBaseStubClassName(classExpr), _classExprs.Builders[classExpr].BaseType);
+    }
+
+    /// <summary>
+    /// Emits the GetProperty inheritance fallthrough: when a class's own
+    /// compile-time dispatch finds nothing, delegate to the base class's
+    /// GetProperty so members inherited from a base class (methods, getters,
+    /// typed properties) resolve under DYNAMIC dispatch. Without this, an
+    /// inherited member accessed dynamically — e.g. `(x as any).inherited()`,
+    /// or ANY method call on a class-expression instance (always anonymously
+    /// typed, so always dynamically dispatched) — resolves to undefined and the
+    /// call throws "undefined is not a function". Falls back to returning
+    /// $Undefined when the base is System.Object or a built-in (no emitted
+    /// $IHasFields stub).
+    /// </summary>
+    private void EmitGetPropertyBaseFallthrough(ILGenerator il, string? baseClassName, Type? baseType)
+    {
+        if (baseClassName != null && _classes.HasFieldsStubs.TryGetValue(baseClassName, out var baseStubs))
+        {
+            // return base.GetProperty(name);  — non-virtual `call` to the
+            // specific base implementation (not callvirt, which would recurse
+            // into this class's own override). The chain terminates at the
+            // topmost emitted class whose base has no stub.
+            MethodInfo target = baseStubs.GetProperty;
+            if (baseType != null && baseType.IsGenericType && baseType.IsConstructedGenericType)
+                target = EmitterTypeHelpers.ResolveMethod(baseType, baseStubs.GetProperty);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Call, target);
+            il.Emit(OpCodes.Ret);
+            return;
+        }
+
         il.Emit(OpCodes.Ldsfld, _runtime.UndefinedInstance);
         il.Emit(OpCodes.Ret);
+    }
+
+    /// <summary>
+    /// Resolves the emitted base class name (a $IHasFields stub key) for a class
+    /// declaration's GetProperty inheritance fallthrough, or null when the base
+    /// is System.Object / a built-in without a stub.
+    /// </summary>
+    private string? ResolveBaseStubClassName(Stmt.Class classStmt)
+    {
+        if (classStmt.SuperclassExpr == null)
+            return null;
+        var leaf = Expr.GetSuperclassLeafName(classStmt.SuperclassExpr);
+        if (leaf == null)
+            return null;
+        var resolved = GetDefinitionContext().ResolveClassName(leaf);
+        return _classes.HasFieldsStubs.ContainsKey(resolved) ? resolved : null;
+    }
+
+    /// <summary>
+    /// Resolves the emitted base class name (a $IHasFields stub key) for a class
+    /// expression's GetProperty inheritance fallthrough. The superclass may be
+    /// another class expression bound to a variable or a class declaration.
+    /// </summary>
+    private string? ResolveBaseStubClassName(Expr.ClassExpr classExpr)
+    {
+        if (!_classExprs.Superclass.TryGetValue(classExpr, out var superName) || superName == null)
+            return null;
+
+        string? baseClassName;
+        if (_classExprs.VarToClassExpr.TryGetValue(superName, out var parentExpr)
+            && _classExprs.Names.TryGetValue(parentExpr, out var generatedName))
+            baseClassName = generatedName;
+        else
+            baseClassName = GetDefinitionContext().ResolveClassName(superName);
+
+        return baseClassName != null && _classes.HasFieldsStubs.ContainsKey(baseClassName)
+            ? baseClassName
+            : null;
     }
 
     /// <summary>

--- a/SharpTS.Tests/CompilerTests/ILVerificationTests.cs
+++ b/SharpTS.Tests/CompilerTests/ILVerificationTests.cs
@@ -115,6 +115,38 @@ public class ILVerificationTests
     }
 
     [Fact]
+    public void DerivedConstructorWithSuper_PassesILVerification()
+    {
+        // A subclass with an EXPLICIT constructor calling super(...) emitted a
+        // base-ctor `call` (Object..ctor) before super() chained the real parent
+        // ctor, so the verifier saw a base-ctor call on an already-initialized /
+        // wrong-base `this` — CallCtor. The program ran correctly; the IL was
+        // merely unverifiable. Now the Object..ctor is skipped when super() will
+        // chain the real base. Covers no-arg and arg'd bases, parameter
+        // properties, multi-level chains, and generic bases. (#287)
+        var source = """
+            class A0 { constructor() {} }
+            class B0 extends A0 { constructor() { super(); } }
+            class A1 { constructor(public x: number) {} }
+            class B1 extends A1 { y: number; constructor() { super(5); this.y = 9; } }
+            class C1 extends B1 { constructor() { super(); } }
+            class Box<T> { constructor(public v: T) {} }
+            class IntBox extends Box<number> { constructor() { super(42); } }
+            console.log(new B0() instanceof A0);
+            const b1 = new B1();
+            console.log(b1.x, b1.y);
+            const c1 = new C1();
+            console.log(c1.x, c1.y);
+            console.log(new IntBox().v);
+            """;
+
+        var (errors, output) = TestHarness.CompileVerifyAndRun(source);
+
+        Assert.Empty(errors);
+        Assert.Equal("true\n5 9\n5 9\n42\n", output);
+    }
+
+    [Fact]
     public void Generators_PassesILVerification()
     {
         var source = """

--- a/SharpTS.Tests/CompilerTests/ILVerificationTests.cs
+++ b/SharpTS.Tests/CompilerTests/ILVerificationTests.cs
@@ -182,6 +182,38 @@ public class ILVerificationTests
     }
 
     [Fact]
+    public void ClassExpressionInheritedMethodDispatch_PassesILVerification()
+    {
+        // The compiled per-class GetProperty helper only dispatched a class's
+        // OWN members, so a method inherited from a base class resolved to
+        // undefined under the (always dynamic) class-expression dispatch and the
+        // call threw. GetProperty now delegates to the base class. Three-level
+        // chain exercises recursive delegation: Puppy inherits Dog.speak. (#297)
+        var source = """
+            const Animal = class {
+                constructor(public name: string) {}
+                speak(): string { return this.name + " makes a sound"; }
+            };
+            const Dog = class extends Animal {
+                constructor(name: string) { super(name); }
+                speak(): string { return this.name + " barks"; }
+            };
+            const Puppy = class extends Dog {
+                constructor() { super("Rex"); }
+            };
+            const p = new Puppy();
+            console.log(p.speak(), p.name, p instanceof Dog, p instanceof Animal);
+            """;
+
+        // Verify-only (see ClassExpressionExtendsClassExpression note). Runtime
+        // inherited-dispatch behavior is asserted by the shared-mode test
+        // ClassExpressionTests.ClassExpression_MultiLevelInheritedMethod.
+        var errors = TestHarness.CompileAndVerifyOnly(source);
+
+        Assert.Empty(errors);
+    }
+
+    [Fact]
     public void Generators_PassesILVerification()
     {
         var source = """

--- a/SharpTS.Tests/CompilerTests/ILVerificationTests.cs
+++ b/SharpTS.Tests/CompilerTests/ILVerificationTests.cs
@@ -147,6 +147,41 @@ public class ILVerificationTests
     }
 
     [Fact]
+    public void ClassExpressionExtendsClassExpression_PassesILVerification()
+    {
+        // A class expression extending ANOTHER class expression resolved its
+        // superclass by the generated $ClassExpr_N name instead of the source
+        // variable name, so the parent type was never set — the child silently
+        // extended System.Object while super() still chained the real parent
+        // ctor, tripping CallCtor / ThisUninitReturn, and `instanceof` against
+        // the parent returned false. With the parent type now set, the IL
+        // verifies and instanceof is correct. (#296)
+        var source = """
+            const Animal = class {
+                constructor(public name: string) {}
+                speak(): string { return this.name + " makes a sound"; }
+            };
+            const Dog = class extends Animal {
+                constructor(name: string) { super(name); }
+                speak(): string { return this.name + " barks"; }
+            };
+            const a = new Animal("Generic");
+            const d = new Dog("Fido");
+            console.log(a.speak());
+            console.log(d.speak(), d instanceof Animal);
+            """;
+
+        // Verify-only: the reference-assembly rewrite in CompileVerifyAndRun
+        // mangles the ldtoken-derived MethodInfo used by class-expression method
+        // dispatch (BadImageFormatException at run time). Runtime behavior of
+        // class-expression inheritance is covered by the shared-mode tests in
+        // ClassExpressionTests, which run the real compiled output.
+        var errors = TestHarness.CompileAndVerifyOnly(source);
+
+        Assert.Empty(errors);
+    }
+
+    [Fact]
     public void Generators_PassesILVerification()
     {
         var source = """

--- a/SharpTS.Tests/IntegrationTests/RealPackageSmokeTests.cs
+++ b/SharpTS.Tests/IntegrationTests/RealPackageSmokeTests.cs
@@ -502,8 +502,11 @@ public class RealPackageSmokeTests
     // init gets past `funcToString.call(Object)`. It still throws later because
     // value-form built-in singleton methods (e.g. `context.Math.max`) are not
     // populated in compiled mode (the Math/JSON singleton dicts hold no method
-    // wrappers). Tracked by #276; unskip when that lands.
-    [SkippableFact(Skip = "compiled lodash init reaches value-form Math.max, unpopulated in compiled mode — see #276")]
+    // wrappers). #276 populated those wrappers and got init past `context.Math.max`,
+    // but compiled init now fails one step deeper in lodash's `getNative` helper
+    // ("object is not a function") — a separate value-form dispatch gap tracked by
+    // #302. Unskip when that lands.
+    [SkippableFact(Skip = "compiled lodash init fails in getNative ('object is not a function') after #276 — see #302")]
     public void Lodash_Compiled()
     {
         SkipIfNoNpm();

--- a/SharpTS.Tests/SharedTests/ClassExpressionTests.cs
+++ b/SharpTS.Tests/SharedTests/ClassExpressionTests.cs
@@ -143,6 +143,58 @@ public class ClassExpressionTests
         Assert.Equal("Rex barks\n", output);
     }
 
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ClassExpression_InheritedMethod_NotOverridden(ExecutionMode mode)
+    {
+        // A child class expression that does NOT override a parent method must
+        // still resolve it. Class-expression instances are anonymously typed, so
+        // every call is dynamically dispatched through the compiled
+        // GetProperty helper, which only covered a class's OWN members — an
+        // inherited method resolved to undefined and threw. Now GetProperty
+        // delegates to the base class. (#287 family)
+        var source = """
+            const Animal = class {
+                constructor(public name: string) {}
+                speak(): string { return this.name + " makes a sound"; }
+            };
+            const Dog = class extends Animal {
+                constructor(name: string) { super(name); }
+            };
+            const d = new Dog("Fido");
+            console.log(d.speak());
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("Fido makes a sound\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ClassExpression_MultiLevelInheritedMethod(ExecutionMode mode)
+    {
+        // Three-level class-expression chain: the grandchild inherits the
+        // grandparent's method (using `this`), exercising recursive base-class
+        // GetProperty delegation. (#287 family)
+        var source = """
+            const Animal = class {
+                constructor(public name: string) {}
+                speak(): string { return this.name + " sound"; }
+            };
+            const Dog = class extends Animal {
+                constructor(name: string) { super(name); }
+                speak(): string { return this.name + " barks"; }
+            };
+            const Puppy = class extends Dog {
+                constructor() { super("Rex"); }
+            };
+            console.log(new Puppy().speak());
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("Rex barks\n", output);
+    }
+
     #endregion
 
     #region Arrays and Variables

--- a/SharpTS.Tests/SharedTests/ClassExpressionTests.cs
+++ b/SharpTS.Tests/SharedTests/ClassExpressionTests.cs
@@ -358,5 +358,29 @@ public class ClassExpressionTests
         Assert.Equal("10\n", output);
     }
 
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ClassExpression_MethodBody_ResolvesCapturedTopLevelVariable(ExecutionMode mode)
+    {
+        // Regression for #300: a class-expression method or accessor body
+        // referencing a top-level binding (a captured `let` here) threw
+        // "ReferenceError: Undefined variable" in compiled mode —
+        // CreateClassExpressionContext omitted the top-level-variable-access
+        // wiring, the same gap #300 fixed for class-declaration accessors.
+        var source = """
+            let counter = 7;
+            const Box = class {
+                m(): string { return "m" + counter; }
+                get tag(): string { return "t" + counter; }
+            };
+            const b = new Box();
+            console.log(b.m());
+            console.log(b.tag);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("m7\nt7\n", output);
+    }
+
     #endregion
 }

--- a/SharpTS.Tests/SharedTests/ClassTests.cs
+++ b/SharpTS.Tests/SharedTests/ClassTests.cs
@@ -29,6 +29,32 @@ public class ClassTests
 
     [Theory]
     [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void InheritedMethod_ResolvesUnderDynamicDispatch(ExecutionMode mode)
+    {
+        // Accessing an inherited method through an `any`-typed receiver forces
+        // DYNAMIC dispatch (compiled: $Runtime.GetProperty). The per-class
+        // GetProperty helper only knew the class's OWN members and returned
+        // undefined for inherited ones, so the call threw "undefined is not a
+        // function" — statically-typed receivers dodged this via direct virtual
+        // calls. GetProperty now delegates to the base class. (#287 family)
+        var source = """
+            class Animal {
+                constructor(public name: string) {}
+                speak(): string { return this.name + " sound"; }
+            }
+            class Dog extends Animal {
+                constructor(name: string) { super(name); }
+            }
+            const d: any = new Dog("Fido");
+            console.log(d.speak());
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("Fido sound\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void ClassMethod_CanBeInvoked(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/ComputedAccessorNameTests.cs
+++ b/SharpTS.Tests/SharedTests/ComputedAccessorNameTests.cs
@@ -7,8 +7,9 @@ namespace SharpTS.Tests.SharedTests;
 /// Tests for computed accessor names in class bodies (#261):
 /// get [Symbol.toStringTag]() / static get [Symbol.species]().
 /// Symbol-keyed accessors on class declarations run in both modes (compiled
-/// support added in #266); on class expressions they stay interpreted-only
-/// (#281). Literal computed keys fold to ordinary names in the parser.
+/// support added in #266; module-local Symbol keys confirmed by #282); on class
+/// expressions they stay interpreted-only (#281). Literal computed keys fold to
+/// ordinary names in the parser.
 /// </summary>
 public class ComputedAccessorNameTests
 {
@@ -101,6 +102,32 @@ public class ComputedAccessorNameTests
 
         var output = TestHarness.Run(source, mode);
         Assert.Equal("42\n7\n", output);
+    }
+
+    // Regression for #282: a MODULE-LOCAL Symbol key (not a well-known symbol)
+    // must register and dispatch in compiled mode. The key expression is
+    // evaluated in the lazily-run class .cctor, which executes after the
+    // top-level binding is assigned, so `key` resolves correctly. Getter and
+    // setter share one registry slot.
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void SymbolAccessor_ModuleLocalKey(ExecutionMode mode)
+    {
+        var source = """
+            const key = Symbol("k");
+            class Box {
+                _v: number = 10;
+                get [key]() { return this._v; }
+                set [key](x: number) { this._v = x; }
+            }
+            const b = new Box() as any;
+            console.log(b[key]);
+            b[key] = 42;
+            console.log(b[key]);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("10\n42\n", output);
     }
 
     [Theory]

--- a/SharpTS.Tests/SharedTests/ComputedAccessorNameTests.cs
+++ b/SharpTS.Tests/SharedTests/ComputedAccessorNameTests.cs
@@ -6,10 +6,10 @@ namespace SharpTS.Tests.SharedTests;
 /// <summary>
 /// Tests for computed accessor names in class bodies (#261):
 /// get [Symbol.toStringTag]() / static get [Symbol.species]().
-/// Symbol-keyed accessors on class declarations run in both modes (compiled
-/// support added in #266; module-local Symbol keys confirmed by #282); on class
-/// expressions they stay interpreted-only (#281). Literal computed keys fold to
-/// ordinary names in the parser.
+/// Symbol-keyed accessors run in both modes on class declarations (compiled
+/// support added in #266; module-local Symbol keys confirmed by #282) and on
+/// class expressions (compiled support added in #281). Literal computed keys
+/// fold to ordinary names in the parser.
 /// </summary>
 public class ComputedAccessorNameTests
 {
@@ -64,10 +64,12 @@ public class ComputedAccessorNameTests
         Assert.Equal("true\n", output);
     }
 
-    // Class expressions use a separate emission path with no .cctor registration
-    // hook; compiled symbol-accessor support there is tracked by #281.
+    // Regression for #281: symbol-keyed computed accessors on class EXPRESSIONS.
+    // The class-expression emission path gained a .cctor registration hook +
+    // synthetic-method body emission mirroring the class-declaration path (#266),
+    // so these now run in both modes.
     [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void SymbolAccessor_InClassExpression(ExecutionMode mode)
     {
         var source = """
@@ -79,6 +81,48 @@ public class ComputedAccessorNameTests
 
         var output = TestHarness.Run(source, mode);
         Assert.Equal("expr\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void SymbolAccessor_InClassExpression_GetterSetterWithFieldAndModuleLocalKey(ExecutionMode mode)
+    {
+        // Getter + setter sharing one symbol slot, a well-known key reading an
+        // instance field, and a module-local Symbol key — all on a class
+        // expression. (#281)
+        var source = """
+            const mk = Symbol("mk");
+            const C = class {
+                _v: number = 5;
+                get [Symbol.toStringTag]() { return "tag" + this._v; }
+                get [mk]() { return this._v; }
+                set [mk](x: number) { this._v = x; }
+            };
+            const c = new C() as any;
+            console.log(c[Symbol.toStringTag], c[mk]);
+            c[mk] = 99;
+            console.log(c[Symbol.toStringTag], c[mk]);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("tag5 5\ntag99 99\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void SymbolAccessor_InClassExpression_Static(ExecutionMode mode)
+    {
+        // Static symbol-keyed getter on a class expression dispatches through the
+        // registry's static slot. (#281)
+        var source = """
+            const C = class {
+                static get [Symbol.toStringTag]() { return "StaticTag"; }
+            };
+            console.log((C as any)[Symbol.toStringTag]);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("StaticTag\n", output);
     }
 
     // A get and set accessor for the SAME symbol must coexist (they merge into one

--- a/SharpTS.Tests/SharedTests/GettersSettersTests.cs
+++ b/SharpTS.Tests/SharedTests/GettersSettersTests.cs
@@ -265,5 +265,31 @@ public class GettersSettersTests
         Assert.Equal("10\n", output);
     }
 
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AccessorBody_ResolvesCapturedTopLevelVariable(ExecutionMode mode)
+    {
+        // Regression for #300: a getter/setter body referencing a top-level
+        // binding (here a captured `let`) threw "ReferenceError: Undefined
+        // variable" in compiled mode — EmitAccessorBody was the lone body-
+        // emission context that omitted the top-level-variable-access wiring
+        // every other context (methods, ctors, functions, …) sets. A normal
+        // method body resolving the same identifier always worked.
+        var source = """
+            let counter = 5;
+            class Box {
+                get tag(): string { return "v" + counter; }
+                set tag(v: string) { counter = counter + v.length; }
+            }
+            const b = new Box();
+            console.log(b.tag);
+            b.tag = "abc";
+            console.log(b.tag);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("v5\nv8\n", output);
+    }
+
     #endregion
 }


### PR DESCRIPTION
Batch of compiled-mode (IL) class fixes. Each issue is a separate commit; full suite green (10908 passed, 1 intentional skip).

## Fixes

### #297 — inherited members under dynamic dispatch (reads)
The per-class `$IHasFields.GetProperty` helper only dispatched a class's **own** members and returned `$Undefined` otherwise, so a member **inherited** from a base class resolved to `undefined` under dynamic dispatch (an `any`-typed receiver, or *any* method call on a class-expression instance — always anonymously typed). `GetProperty` now emits a non-virtual `call base.GetProperty(name)` when the member isn't found locally and the base is an emitted user class, terminating at the topmost emitted class. Reads only; `SetProperty`/`HasProperty` base delegation remain the follow-up the issue notes.

### #296 — class expression extending another class expression
The base-type resolver matched the source variable name against `_classExprs.Names` (which holds the *generated* `$ClassExpr_N` names), so `SetParent` was never called: the child silently extended `System.Object` while `super(...)` chained the real parent ctor → ILVerify `CallCtor`/`ThisUninitReturn`, and `instanceof` returned `false`. Now consults `_classExprs.VarToClassExpr` and resolves the implicit base ctor via the registered `ConstructorBuilder`.

### #287 (prerequisite of the above CallCtor family)
A subclass with an explicit `super(...)` emitted `Object..ctor` before `super()` chained the real parent ctor → ILVerify `CallCtor`. The Object ctor is now skipped when a user-class superclass with an emitted ctor exists (mirroring the Error/Array/Promise handling).

### #281 — symbol-keyed computed accessors on class expressions
Class expressions had no hook for the symbol-accessor machinery added for class declarations in #266, so `const C = class { get [Symbol.toStringTag]() {…} }` threw a `CompileException`. The class-expression emitter now mirrors the declaration path: define synthetic `$sym_get/set_N` methods, emit their bodies in the class-expression context, and register them in the class `.cctor` via the shared `EmitSymbolAccessorRegistrations`. Runtime registry + dispatch from #266 reused unchanged.

### #300 — accessor & class-expression bodies couldn't see top-level variables (new, found here)
`EmitAccessorBody` and `CreateClassExpressionContext` were the only two body-emission contexts that omitted the four top-level-variable-access properties every other context sets, so a getter/setter or class-expression member body referencing a captured `let`/`const`, a same-module export, or an import threw `ReferenceError: Undefined variable` in compiled mode. Both contexts now wire them up.

## Verified already-fixed on main (regression tests added / scope confirmed)

- **#282** (module-local Symbol-keyed accessor): passes on main; existing coverage only exercised well-known symbols, so a both-modes getter+setter regression test for the module-local case is added.
- **#276** (value-form `Math.max`/`JSON.stringify`): passes on main with comprehensive existing coverage. Un-skipping `Lodash_Compiled` revealed lodash init now gets past `context.Math.max` but fails one step deeper in `getNative` — filed as **#302** and the skip re-pointed there.

## Issues filed during this batch
- **#300** — accessor/class-expr bodies can't resolve top-level variables (fixed here).
- **#302** — compiled lodash init fails in `getNative` after #276 (separate value-form dispatch gap).

## Testing
`dotnet build` clean; `dotnet test` → 10908 passed, 1 skipped (`Lodash_Compiled`, gated on #302). New regression tests cover inherited dynamic dispatch (decl + class-expr, multi-level), class-expr-extends-class-expr verification, derived-ctor verification, symbol accessors on class expressions (getter/setter/well-known/module-local/static), and accessor/class-expr top-level-variable resolution.