### PR TITLE
fix: Object.values/entries enumerable filter, JSON identity, accessor top-level vars (#298, #299, #300)

### DIFF
--- a/Compilation/ILCompiler.Classes.Accessors.cs
+++ b/Compilation/ILCompiler.Classes.Accessors.cs
@@ -203,7 +203,17 @@ public partial class ILCompiler
             ClassExprBuilders = _classExprs.Builders,
             IsStrictMode = _isStrictMode,
             // Registry services
-            ClassRegistry = GetClassRegistry()
+            ClassRegistry = GetClassRegistry(),
+            // Top-level variable access. Accessor bodies are body-emission
+            // contexts like methods/constructors/static-blocks and must set the
+            // same four properties, or a bare top-level identifier (captured
+            // let/const, same-module ESM export, or import) falls through to the
+            // dynamic runtime lookup and throws ReferenceError. Use the
+            // class-method builder so same-module ESM exports resolve too. (#300)
+            TopLevelStaticVars = BuildClassMethodTopLevelStaticVarsForModule(_modules.CurrentPath),
+            CapturedTopLevelVars = BuildCapturedTopLevelVarsForModule(_modules.CurrentPath),
+            EntryPointDisplayClassFields = BuildEntryPointDisplayClassFieldsForModule(_modules.CurrentPath),
+            EntryPointDisplayClassStaticField = _closures.EntryPointDisplayClassStaticField
         };
 
         // Add class generic type parameters to context

--- a/Compilation/RuntimeEmitter.Objects.Iteration.cs
+++ b/Compilation/RuntimeEmitter.Objects.Iteration.cs
@@ -285,15 +285,37 @@ public partial class RuntimeEmitter
 
         var dictLoopStart = il.DefineLabel();
         var dictLoopEnd = il.DefineLabel();
+        var valDescLocal = il.DeclareLocal(runtime.CompiledPropertyDescriptorType);
         il.MarkLabel(dictLoopStart);
         il.Emit(OpCodes.Ldloca, enumeratorLocal);
         il.Emit(OpCodes.Call, enumeratorType.GetMethod("MoveNext")!);
         il.Emit(OpCodes.Brfalse, dictLoopEnd);
 
-        il.Emit(OpCodes.Ldloc, resultLocal);
+        // current = enumerator.Current
         il.Emit(OpCodes.Ldloca, enumeratorLocal);
         il.Emit(OpCodes.Call, enumeratorType.GetProperty("Current")!.GetGetMethod()!);
         il.Emit(OpCodes.Stloc, currentLocal);
+
+        // ECMA-262 §20.1.2.23 EnumerableOwnProperties: skip a key whose installed
+        // descriptor is non-enumerable. The Math/JSON singleton dicts carry their
+        // built-in methods with Enumerable=false, so without this filter
+        // Object.values leaks the built-ins while Object.keys (which already
+        // filters) does not — making keys and values mutually inconsistent.
+        var valIncludeLabel = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, dictLocal);
+        il.Emit(OpCodes.Ldloca, currentLocal);
+        il.Emit(OpCodes.Call, kvpType.GetProperty("Key")!.GetGetMethod()!);
+        il.Emit(OpCodes.Call, runtime.PDSGetPropertyDescriptor);
+        il.Emit(OpCodes.Stloc, valDescLocal);
+        il.Emit(OpCodes.Ldloc, valDescLocal);
+        il.Emit(OpCodes.Brfalse, valIncludeLabel);  // no descriptor → enumerable by default
+        il.Emit(OpCodes.Ldloc, valDescLocal);
+        il.Emit(OpCodes.Callvirt, runtime.CompiledPropertyDescriptorEnumerable.GetGetMethod()!);
+        il.Emit(OpCodes.Brfalse, dictLoopStart);  // non-enumerable → skip
+        il.MarkLabel(valIncludeLabel);
+
+        // result.Add(current.Value)
+        il.Emit(OpCodes.Ldloc, resultLocal);
         il.Emit(OpCodes.Ldloca, currentLocal);
         il.Emit(OpCodes.Call, kvpType.GetProperty("Value")!.GetGetMethod()!);
         il.Emit(OpCodes.Callvirt, listType.GetMethod("Add")!);
@@ -776,6 +798,24 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloca, enumeratorLocal);
         il.Emit(OpCodes.Call, enumeratorType.GetProperty("Current")!.GetGetMethod()!);
         il.Emit(OpCodes.Stloc, currentLocal);
+
+        // ECMA-262 §20.1.2.5 EnumerableOwnProperties: skip a key whose installed
+        // descriptor is non-enumerable, mirroring the GetKeys/GetValues filter so
+        // Object.entries stays consistent with Object.keys (the Math/JSON
+        // singleton built-ins carry Enumerable=false).
+        var entDescLocal = il.DeclareLocal(runtime.CompiledPropertyDescriptorType);
+        var entIncludeLabel = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, dictLocal);
+        il.Emit(OpCodes.Ldloca, currentLocal);
+        il.Emit(OpCodes.Call, kvpType.GetProperty("Key")!.GetGetMethod()!);
+        il.Emit(OpCodes.Call, runtime.PDSGetPropertyDescriptor);
+        il.Emit(OpCodes.Stloc, entDescLocal);
+        il.Emit(OpCodes.Ldloc, entDescLocal);
+        il.Emit(OpCodes.Brfalse, entIncludeLabel);  // no descriptor → enumerable by default
+        il.Emit(OpCodes.Ldloc, entDescLocal);
+        il.Emit(OpCodes.Callvirt, runtime.CompiledPropertyDescriptorEnumerable.GetGetMethod()!);
+        il.Emit(OpCodes.Brfalse, dictLoopStart);  // non-enumerable → skip
+        il.MarkLabel(entIncludeLabel);
 
         // var entry = new List<object?> { kvp.Key, kvp.Value };
         il.Emit(OpCodes.Newobj, listType.GetConstructor(Type.EmptyTypes)!);

--- a/Runtime/BuiltIns/JSONBuiltIns.cs
+++ b/Runtime/BuiltIns/JSONBuiltIns.cs
@@ -11,15 +11,18 @@ namespace SharpTS.Runtime.BuiltIns;
 /// </summary>
 public static class JSONBuiltIns
 {
-    public static object? GetStaticMethod(string name)
-    {
-        return name switch
-        {
-            "parse" => BuiltInMethod.CreateV2("parse", 1, 2, ParseJson),
-            "stringify" => BuiltInMethod.CreateV2("stringify", 1, 3, StringifyJson),
-            _ => null
-        };
-    }
+    // ECMA-262 25.5: JSON.parse / JSON.stringify are single built-in function
+    // objects, so repeated access must return the SAME callable (identity
+    // stability: `JSON.stringify === JSON.stringify`). Build the methods once
+    // into a cached lookup — mirroring MathBuiltIns — rather than synthesizing
+    // a fresh BuiltInMethod per access.
+    private static readonly BuiltInStaticMemberLookup _lookup =
+        BuiltInStaticBuilder.Create()
+            .MethodV2("parse", 1, 2, ParseJson)
+            .MethodV2("stringify", 1, 3, StringifyJson)
+            .Build();
+
+    public static object? GetStaticMethod(string name) => _lookup.GetMember(name);
 
     private static RuntimeValue ParseJson(Interpreter interp, RuntimeValue _, ReadOnlySpan<RuntimeValue> args)
     {

--- a/SharpTS.Tests/SharedTests/BuiltInSingletonValueFormTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInSingletonValueFormTests.cs
@@ -77,4 +77,20 @@ public class BuiltInSingletonValueFormTests
         var output = TestHarness.Run(source, mode);
         Assert.Equal("0\n", output);
     }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Json_StaticMethodIdentityIsStable(ExecutionMode mode)
+    {
+        // #299: JSON.parse / JSON.stringify are single built-in function objects
+        // per ECMA-262 §25.5, so repeated access returns the SAME callable.
+        // Previously the interpreter synthesized a fresh wrapper per access while
+        // compiled mode was already stable — both now agree.
+        var source = @"
+            console.log(JSON.stringify === JSON.stringify);
+            console.log(JSON.parse === JSON.parse);
+        ";
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("true\ntrue\n", output);
+    }
 }

--- a/SharpTS.Tests/SharedTests/BuiltInSingletonValueFormTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInSingletonValueFormTests.cs
@@ -93,4 +93,54 @@ public class BuiltInSingletonValueFormTests
         var output = TestHarness.Run(source, mode);
         Assert.Equal("true\ntrue\n", output);
     }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    public void Math_ValuesAndEntriesExcludeNonEnumerableBuiltIns(ExecutionMode mode)
+    {
+        // #298: Object.values/entries must apply the same own-enumerable filter
+        // Object.keys does. Math's built-in methods are non-enumerable, so only
+        // the user-assigned extra surfaces — keys, values, and entries agree.
+        var source = @"
+            const m: any = Math;
+            m.foo = 42;
+            console.log(Object.keys(m).length);
+            console.log(Object.values(m).length);
+            console.log(Object.values(m)[0]);
+            console.log(Object.entries(m).length);
+        ";
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("1\n1\n42\n1\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    public void Json_ValuesAndEntriesExcludeNonEnumerableBuiltIns(ExecutionMode mode)
+    {
+        // #298: same own-enumerable filter for the JSON singleton.
+        var source = @"
+            const j: any = JSON;
+            j.bar = 7;
+            console.log(Object.keys(j).length);
+            console.log(Object.values(j).length);
+            console.log(Object.entries(j).length);
+        ";
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("1\n1\n1\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void PlainObject_ValuesAndEntriesUnaffectedByEnumerableFilter(ExecutionMode mode)
+    {
+        // Guard the #298 fix: a plain object literal (no installed descriptors,
+        // enumerable by default) must still enumerate every own property.
+        var source = @"
+            const o = { a: 1, b: 2, c: 3 };
+            console.log(Object.values(o).join(','));
+            console.log(Object.entries(o).length);
+        ";
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("1,2,3\n3\n", output);
+    }
 }

--- a/SharpTS.Tests/SharedTests/GettersSettersTests.cs
+++ b/SharpTS.Tests/SharedTests/GettersSettersTests.cs
@@ -266,4 +266,55 @@ public class GettersSettersTests
     }
 
     #endregion
+
+    #region Top-level variable capture (#300)
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Getter_ResolvesCapturedTopLevelVariable(ExecutionMode mode)
+    {
+        // #300: in compiled mode an accessor body that referenced a top-level
+        // binding threw `ReferenceError: Undefined variable` because the accessor
+        // emit context omitted the four top-level-variable-access properties every
+        // other body-emission path sets. An ordinary method dodged it.
+        var source = """
+            let counter = 5;
+            const label = "v";
+            class D {
+                get tag(): string { return label + counter; }
+            }
+            console.log(new D().tag);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("v5\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void SetterAndStaticGetter_ResolveCapturedTopLevelVariable(ExecutionMode mode)
+    {
+        // Cover the setter and static-getter accessor shapes too — all share the
+        // EmitAccessorBody context that was missing top-level-var access.
+        var source = """
+            let base = 10;
+            const factor = 3;
+            class C {
+                _v: number = 0;
+                get scaled(): number { return this._v * factor + base; }
+                set scaled(n: number) { this._v = n - base; }
+                static get answer(): number { return base + 32; }
+            }
+            const c = new C();
+            c.scaled = 13;
+            console.log(c._v);
+            console.log(c.scaled);
+            console.log(C.answer);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("3\n19\n42\n", output);
+    }
+
+    #endregion
 }


### PR DESCRIPTION
Fixes three independent defects, each in its own commit, all off latest `main`. Full suite green: **10898 passed, 0 failed, 1 skipped**.

> Scope note: #296 and #297 are intentionally **not** included here — they are already fixed in open PR #301 (`fix/issues-287-288`). This PR covers only the three issues that are unaddressed elsewhere.

## Commits

### #300 — compiled accessor body can't resolve a captured top-level variable
A class **accessor** (getter/setter) body referencing a top-level binding — a captured `let`/`const`, a same-module ESM export, or an import — threw `ReferenceError: Undefined variable` in compiled mode, while an ordinary **method** body resolved the identical reference. `EmitAccessorBody` built its `CompilationContext` without the four top-level-variable-access properties (`TopLevelStaticVars`, `CapturedTopLevelVars`, `EntryPointDisplayClassFields`, `EntryPointDisplayClassStaticField`) that every other body-emission context sets — the accessor path was the lone omission among methods, constructors, static blocks, functions, arrows, async, and generators. Now sets all four, using `BuildClassMethodTopLevelStaticVarsForModule` to match the instance-method emit path so same-module ESM exports resolve too.

### #299 — interpreter JSON static-method identity is not stable
`JSON.stringify === JSON.stringify` was `false` in the interpreter (compiled mode already `true`). Per ECMA-262 §25.5, `JSON.parse`/`JSON.stringify` are single built-in function objects. `JSONBuiltIns.GetStaticMethod` synthesized a fresh `BuiltInMethod` per access via a `switch`. Now builds the two methods once into a cached `BuiltInStaticMemberLookup`, mirroring `MathBuiltIns`, so repeated access returns the same identity-cached instance.

### #298 — compiled Object.values/entries(Math) enumerate non-enumerable built-ins
`Object.values(Math)`/`Object.entries(Math)` enumerated Math's built-in methods (non-enumerable per ECMA-262 §17), while `Object.keys(Math)` correctly returned only user-assigned extras — so keys and values/entries disagreed. The emitted `GetKeys` dict loop consults each key's installed descriptor and skips non-enumerable keys; `GetValues`/`GetEntries` did not, so the Math/JSON singletons' built-ins (stored with `Enumerable=false` descriptors) leaked. Both now apply the same `PDSGetPropertyDescriptor` enumerable filter; keys with no descriptor (plain object literals) remain enumerable by default, so ordinary objects are unaffected.

## Tests
- `BuiltInSingletonValueFormTests`: JSON identity stability (both modes); `Object.values`/`entries` exclude non-enumerable built-ins for Math and JSON singletons (compiled); plain-object guard (both modes).
- `GettersSettersTests`: accessor getter resolves a captured top-level var (both modes); setter + static getter resolve captured top-level vars (both modes).

Closes #298, #299, #300.