### PR TITLE
fix(interp): Math value-form identity + Object.keys/values/entries pa…

### DIFF
--- a/Runtime/BuiltIns/BuiltInRegistry.cs
+++ b/Runtime/BuiltIns/BuiltInRegistry.cs
@@ -333,7 +333,12 @@ public sealed class BuiltInRegistry
             Name: "Math",
             IsSingleton: true,
             SingletonFactory: () => SharpTSMath.Instance,
-            GetMethod: name => MathBuiltIns.GetMember(name) as BuiltInMethod
+            // Bind to the singleton so the namespace path (`Math.max`) returns
+            // the SAME receiver-cached method as the instance path (`m.max`,
+            // where m holds Math). Without this they yield distinct wrappers and
+            // `Math.max === Math.max` via different access forms is false. Bind
+            // caches by receiver, so identity is stable per spec (#288).
+            GetMethod: name => (MathBuiltIns.GetMember(name) as BuiltInMethod)?.Bind(SharpTSMath.Instance)
         ));
     }
 

--- a/Runtime/BuiltIns/ObjectBuiltIns.cs
+++ b/Runtime/BuiltIns/ObjectBuiltIns.cs
@@ -72,6 +72,14 @@ public static class ObjectBuiltIns
             var keys = dict.Keys.Select(k => (object?)k).ToList();
             return RuntimeValue.FromObject(new SharpTSArray(keys));
         }
+        // Math singleton: built-in members are non-enumerable, so the own
+        // enumerable keys are exactly the user-assigned extras (empty unless the
+        // program assigned to Math). Matches compiled mode (#288).
+        if (arg is SharpTSMath math)
+        {
+            var keys = math.OwnEnumerableProperties.Select(kv => (object?)kv.Key).ToList();
+            return RuntimeValue.FromObject(new SharpTSArray(keys));
+        }
         throw new Exception("Object.keys() requires an object argument");
     }
 
@@ -98,6 +106,12 @@ public static class ObjectBuiltIns
         if (arg is IDictionary<string, object?> dict)
         {
             return RuntimeValue.FromObject(new SharpTSArray(dict.Values.ToList()));
+        }
+        // Math singleton — see Object.keys (#288).
+        if (arg is SharpTSMath math)
+        {
+            var values = math.OwnEnumerableProperties.Select(kv => kv.Value).ToList();
+            return RuntimeValue.FromObject(new SharpTSArray(values));
         }
         throw new Exception("Object.values() requires an object argument");
     }
@@ -130,6 +144,13 @@ public static class ObjectBuiltIns
         if (arg is IDictionary<string, object?> dict)
         {
             var entries = dict.Select(kv =>
+                (object?)new SharpTSArray([(object?)kv.Key, kv.Value])).ToList();
+            return RuntimeValue.FromObject(new SharpTSArray(entries));
+        }
+        // Math singleton — see Object.keys (#288).
+        if (arg is SharpTSMath math)
+        {
+            var entries = math.OwnEnumerableProperties.Select(kv =>
                 (object?)new SharpTSArray([(object?)kv.Key, kv.Value])).ToList();
             return RuntimeValue.FromObject(new SharpTSArray(entries));
         }

--- a/Runtime/Types/SharpTSMath.cs
+++ b/Runtime/Types/SharpTSMath.cs
@@ -47,5 +47,13 @@ public class SharpTSMath
         _extras[name] = value;
     }
 
+    /// <summary>
+    /// The own enumerable properties of Math. All built-in members (abs, max,
+    /// PI, …) are non-enumerable per ECMA-262, so only user-assigned extras
+    /// appear here — empty in the common case. Backs Object.keys/values/entries.
+    /// </summary>
+    public IReadOnlyCollection<KeyValuePair<string, object?>> OwnEnumerableProperties
+        => _extras ?? (IReadOnlyCollection<KeyValuePair<string, object?>>)Array.Empty<KeyValuePair<string, object?>>();
+
     public override string ToString() => "[object Math]";
 }

--- a/SharpTS.Tests/SharedTests/BuiltInSingletonValueFormTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInSingletonValueFormTests.cs
@@ -47,13 +47,14 @@ public class BuiltInSingletonValueFormTests
     }
 
     [Theory]
-    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void Math_AsValue_MethodIdentityIsStable(ExecutionMode mode)
     {
-        // The value-form wrapper must be the same identity-cached $TSFunction the
-        // bare `Math.max` syntactic form hands out (ECMA-262: built-in methods are
-        // single objects). Interpreted mode synthesizes a fresh wrapper per read,
-        // so this is scoped to compiled mode.
+        // The value-form wrapper must be the same identity-cached method the bare
+        // `Math.max` syntactic form hands out (ECMA-262: built-in methods are
+        // single objects). The interpreter's namespace path now binds to the Math
+        // singleton, so it returns the same receiver-cached method as the
+        // instance path — identity holds in both modes (#288).
         var source = @"
             const m: any = Math;
             console.log(m.max === Math.max);
@@ -64,17 +65,38 @@ public class BuiltInSingletonValueFormTests
     }
 
     [Theory]
-    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void Math_AsValue_MethodsAreNonEnumerable(ExecutionMode mode)
     {
-        // Math's methods are non-enumerable per ECMA-262 §17, so populating the
-        // singleton must install non-enumerable descriptors — `Object.keys(Math)`
-        // stays empty.
+        // Math's methods are non-enumerable per ECMA-262 §17, so `Object.keys(Math)`
+        // is empty. Compiled mode installs non-enumerable descriptors; the
+        // interpreter treats the Math singleton's own enumerable properties as just
+        // its user-assigned extras (none here). Both modes return [] (#288).
         var source = @"
             const m: any = Math;
             console.log(Object.keys(m).length);
         ";
         var output = TestHarness.Run(source, mode);
         Assert.Equal("0\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void Math_AsValue_ValuesAndEntriesAreEmpty(ExecutionMode mode)
+    {
+        // Object.values/entries on Math return only its own enumerable properties;
+        // the built-in members are non-enumerable, so with no user extras the
+        // result is empty (previously the interpreter threw). Scoped to
+        // interpreted mode: compiled Object.values/entries(Math) currently also
+        // enumerate the non-enumerable built-in methods — tracked separately.
+        // (Tests avoid assigning to Math: its singleton is process-global, so an
+        // extra would leak into other in-process interpreted runs.) (#288)
+        var source = @"
+            const m: any = Math;
+            console.log(Object.values(m).length);
+            console.log(Object.entries(m).length);
+        ";
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("0\n0\n", output);
     }
 }


### PR DESCRIPTION
…rity (#288)

Two interpreter-only divergences from compiled mode when Math is used as a value:

1. Method identity — `m.max === Math.max` was false. The namespace path (`Math.max`) returned the unbound BuiltInMethod from MathBuiltIns, while the instance path (`m.max`, m holding Math) returned that method Bound to the singleton receiver, so the two access forms yielded distinct wrappers. The Math namespace's static GetMethod now binds to the SharpTSMath singleton; Bind caches by receiver, so both paths return the same method and identity is stable (ECMA-262: built-in methods are single objects).

2. Object.keys/values/entries(Math) threw "requires an object argument". The Math singleton is now a recognized receiver: its built-in members are non-enumerable per ECMA-262 §17, so the own enumerable properties are exactly the user-assigned extras (empty in the common case) — matching compiled Object.keys(Math).

The two compiled-only assertions in BuiltInSingletonValueFormTests now run in both modes.