### PR TITLE
fix(types): assign to deferred conditional requires both branches (#226)

### DIFF
--- a/SharpTS.TypeScriptConformance/baselines/interpreted.txt
+++ b/SharpTS.TypeScriptConformance/baselines/interpreted.txt
@@ -1,7 +1,7 @@
 # TS conformance baseline — do not hand-edit. Regenerate with SHARPTS_TSCONFORMANCE_UPDATE_BASELINE=1.
 tests/cases/conformance/types/conditional/conditionalTypes1.ts Fail
 tests/cases/conformance/types/conditional/conditionalTypes2.ts Fail
-tests/cases/conformance/types/conditional/conditionalTypesExcessProperties.ts Fail
+tests/cases/conformance/types/conditional/conditionalTypesExcessProperties.ts Pass
 tests/cases/conformance/types/conditional/inferTypes1.ts Fail
 tests/cases/conformance/types/conditional/inferTypes2.ts Pass
 tests/cases/conformance/types/conditional/inferTypesInvalidExtendsDeclaration.ts Skipped:lib-drift

--- a/TypeSystem/TypeChecker.Compatibility.cs
+++ b/TypeSystem/TypeChecker.Compatibility.cs
@@ -385,11 +385,25 @@ public partial class TypeChecker
         // conditional collapsed to `any` first, or the null rule rejects it sight unseen.
         if (expected is TypeInfo.ConditionalType expectedCondEarly)
         {
-            return IsCompatible(EvaluateConditionalType(expectedCondEarly), actual);
+            var evaluated = EvaluateConditionalType(expectedCondEarly);
+            // A conditional whose check type is still a naked type parameter can't be
+            // resolved to a branch (tsc defers it). Assigning *to* a deferred conditional
+            // is sound only when the source satisfies BOTH branches — the conditional could
+            // resolve to either at instantiation time. (checker.ts relateConditionalTypes.)
+            if (evaluated is TypeInfo.ConditionalType stillDeferred)
+                return IsCompatible(stillDeferred.TrueType, actual)
+                    && IsCompatible(stillDeferred.FalseType, actual);
+            return IsCompatible(evaluated, actual);
         }
         if (actual is TypeInfo.ConditionalType actualCondEarly)
         {
-            return IsCompatible(expected, EvaluateConditionalType(actualCondEarly));
+            var evaluated = EvaluateConditionalType(actualCondEarly);
+            // Assigning *from* a deferred conditional: both possible results must satisfy
+            // the target (the conditional's constraint is the union of its branches).
+            if (evaluated is TypeInfo.ConditionalType stillDeferred)
+                return IsCompatible(expected, stillDeferred.TrueType)
+                    && IsCompatible(expected, stillDeferred.FalseType);
+            return IsCompatible(expected, evaluated);
         }
 
         // Null compatibility (strictNullChecks: on — the off case is handled early in IsCompatibleCore)


### PR DESCRIPTION
## Summary

Part of the conditional-types cluster in #226. Fixes assignability **to/from a deferred conditional type** (one whose check type is still a naked type parameter, so tsc can't pick a branch).

Previously we evaluated such a conditional, got the same deferred type back, and recursed into `IsCompatible` on it — looping to the conditional-depth guard and silently passing. Net effect: **any value was assignable to a deferred-conditional-typed target**, e.g.

```ts
type Cond<T> = T extends string ? number : boolean;
function f<A>(c: Cond<A>) { c = "anything"; } // wrongly accepted
```

## Fix

tsc's rule (`checker.ts` `relateConditionalTypes`):
- Assigning **to** a deferred conditional `C ? X : Y` is sound only when the source is assignable to **both** branches `X` and `Y` (it could resolve to either at instantiation).
- Assigning **from** one requires **both** branches to satisfy the target (the conditional's constraint is the union of its branches).

Descending into the branches also removes the former infinite-recursion-to-permissive path.

## Result

- Flips `conditionalTypesExcessProperties` **Fail → Pass**.
- Conformance subset **Pass 70 → 71 / Fail 7 → 6**, 0 regressions.
- Full unit suite **10934 passed, 0 failed**.

## Not addressed

The remaining conditional-cluster Fails are genuinely deeper and out of scope here: `conditionalTypes1/2` (conditional-type variance), `inferTypes1`/`inferTypesWithExtends2` (infer-constraint semantics & validation diagnostics), and `inferTypesWithExtends1` (the speculative `infer T extends U ?` parser lookahead).