### PR TITLE
fix(compile): inner function declarations in arrows capture by live reference (#307) — fixes compiled lodash (#302)

### DIFF
--- a/Compilation/ClosureAnalyzer.cs
+++ b/Compilation/ClosureAnalyzer.cs
@@ -45,6 +45,12 @@ public class ClosureAnalyzer : AstVisitorBase
     // Maps function node → set of its local variables that are captured by inner closures
     private readonly Dictionary<object, HashSet<string>> _functionCapturedLocals = [];
 
+    // Maps capturing function node → (captured name → defining function node).
+    // Records WHICH enclosing scope provides each captured variable, so the
+    // compiler can route the access to the correct display class without
+    // name-matching across unrelated scopes (which aliases shadowed names).
+    private readonly Dictionary<object, Dictionary<string, object>> _captureSources = [];
+
     // ============================================
     // Performance optimization: Inverse index
     // ============================================
@@ -88,6 +94,19 @@ public class ClosureAnalyzer : AstVisitorBase
     public bool HasCapturedLocals(object functionNode)
     {
         return _functionCapturedLocals.TryGetValue(functionNode, out var locals) && locals.Count > 0;
+    }
+
+    /// <summary>
+    /// Returns the function/arrow AST node whose scope defines the variable
+    /// <paramref name="name"/> captured by <paramref name="functionNode"/>,
+    /// or null when the variable is top-level (or not a recorded capture).
+    /// </summary>
+    public object? GetCaptureSource(object functionNode, string name)
+    {
+        return _captureSources.TryGetValue(functionNode, out var sources) &&
+               sources.TryGetValue(name, out var src)
+            ? src
+            : null;
     }
 
 
@@ -185,6 +204,16 @@ public class ClosureAnalyzer : AstVisitorBase
                     _functionCapturedLocals[definingFunc] = capturedLocals;
                 }
                 capturedLocals.Add(name);
+
+                // Record the defining scope for this capture. Within a single
+                // function's analysis the scope stack is fixed, so repeated
+                // references resolve to the same defining function.
+                if (!_captureSources.TryGetValue(_currentFunction, out var sources))
+                {
+                    sources = [];
+                    _captureSources[_currentFunction] = sources;
+                }
+                sources[name] = definingFunc;
             }
         }
     }

--- a/Compilation/CompilationContext.Closures.cs
+++ b/Compilation/CompilationContext.Closures.cs
@@ -170,6 +170,37 @@ public partial class CompilationContext
     /// </summary>
     public HashSet<string>? ParentArrowCapturedLocals { get; set; }
 
+    /// <summary>
+    /// A captured variable's live access path when it lives on an ancestor
+    /// arrow's scope DC referenced by an EXTRA (non-primary) reference field:
+    /// load <see cref="RefField"/> off the current display class (arg0), then
+    /// load/store <see cref="VarField"/> on that scope DC instance.
+    /// </summary>
+    public readonly record struct ExtraScopeBinding(FieldBuilder RefField, FieldBuilder VarField);
+
+    /// <summary>
+    /// Per-name live bindings for captured variables whose source scope DC is
+    /// referenced by an extra reference field on the current closure's display
+    /// class. Populated from the analyzer's capture-source record, so entries
+    /// are shadow-correct for THIS closure. Checked by LocalVariableResolver
+    /// after the primary parent-DC path.
+    /// </summary>
+    public Dictionary<string, ExtraScopeBinding>? ExtraArrowScopeBindings { get; set; }
+
+    /// <summary>
+    /// The current closure's own EXTRA ancestor-scope reference fields, keyed
+    /// by source arrow. Used to chain references into closures created inside
+    /// this body (type-matched against the new closure's reference fields).
+    /// </summary>
+    public Dictionary<ArrowFunction, FieldBuilder>? CurrentArrowScopeDCExtraFields { get; set; }
+
+    /// <summary>
+    /// Global map of every arrow's EXTRA ancestor-scope reference fields
+    /// (closure arrow → source arrow → field). The creation-site emitter
+    /// populates these alongside the primary $arrowDC field.
+    /// </summary>
+    public Dictionary<ArrowFunction, Dictionary<ArrowFunction, FieldBuilder>>? ArrowScopeDCExtraFieldsByArrow { get; set; }
+
     // ============================================
     // Inner Function Support
     // ============================================

--- a/Compilation/EmittedRuntime.cs
+++ b/Compilation/EmittedRuntime.cs
@@ -563,6 +563,12 @@ public class EmittedRuntime
     public MethodBuilder ObjectDefineProperties { get; set; } = null!;
     public MethodBuilder ObjectGetOwnPropertyDescriptors { get; set; } = null!;
     public MethodBuilder ObjectCreate { get; set; } = null!;
+    /// <summary>
+    /// Value-form dispatch wrapper for Object.create: maps a null (reflection-
+    /// padded, i.e. absent) props slot to $Undefined before delegating, so
+    /// under-application doesn't trip ObjectCreate's explicit-null TypeError.
+    /// </summary>
+    public MethodBuilder ObjectCreateValueForm { get; set; } = null!;
     public MethodBuilder ObjectPreventExtensions { get; set; } = null!;
     public MethodBuilder ObjectIsExtensible { get; set; } = null!;
     public MethodBuilder GetOwnPropertySymbols { get; set; } = null!;

--- a/Compilation/Emitters/ObjectStaticEmitter.cs
+++ b/Compilation/Emitters/ObjectStaticEmitter.cs
@@ -323,7 +323,12 @@ public sealed class ObjectStaticEmitter : IStaticTypeEmitterStrategy
             "defineProperties"     => runtime.ObjectDefineProperties,
             "getOwnPropertyDescriptor"  => runtime.ObjectGetOwnPropertyDescriptor,
             "getOwnPropertyDescriptors" => runtime.ObjectGetOwnPropertyDescriptors,
-            "create"               => runtime.ObjectCreate,
+            // Value-form wrapper (NOT raw ObjectCreate): under-application via
+            // $TSFunction pads props with null, which the raw method must
+            // treat as the explicit-null TypeError. Must match the runtime
+            // LookupBuiltInStaticMember entry so wrapper identity holds across
+            // both access forms.
+            "create"               => runtime.ObjectCreateValueForm,
             "assign"               => runtime.ObjectAssign,
             "is"                   => runtime.ObjectIs,
             "hasOwn"               => runtime.ObjectHasOwn,

--- a/Compilation/ILCompiler.ArrowFunctions.cs
+++ b/Compilation/ILCompiler.ArrowFunctions.cs
@@ -17,6 +17,11 @@ public partial class ILCompiler
     // resolves against the wrong module's storage.
     private readonly Dictionary<Expr.ArrowFunction, string?> _arrowToModule = new(ReferenceEqualityComparer.Instance);
     private readonly Dictionary<Expr.ArrowFunction, Expr.ArrowFunction?> _arrowParent = new(ReferenceEqualityComparer.Instance);
+    // Immediately enclosing callable (Expr.ArrowFunction or Stmt.Function) of each
+    // collected arrow — i.e. the body whose emission context creates the arrow's
+    // display class. Unlike _arrowParent this does NOT skip function-declaration
+    // boundaries; used to thread $arrowScopeDC references for inner functions (#307).
+    private readonly Dictionary<Expr.ArrowFunction, object?> _arrowEnclosingCallable = new(ReferenceEqualityComparer.Instance);
     private readonly HashSet<Expr.ArrowFunction> _arrowsNeedingFunctionDC = new(ReferenceEqualityComparer.Instance);
     private readonly HashSet<Expr.ArrowFunction> _arrowsNeedingArrowDC = new(ReferenceEqualityComparer.Instance);
     // Maps each collected arrow (or `function` expression) to the AST node of
@@ -37,6 +42,12 @@ public partial class ILCompiler
     private Stmt.Function? _currentEnclosingFunctionStmt;
     private Expr.ArrowFunction? _currentParentArrow;
     private string? _currentCollectClassName;
+    // The IMMEDIATELY enclosing callable (Expr.ArrowFunction or Stmt.Function) during
+    // collection. Unlike _currentParentArrow (nearest ancestor arrow, which skips
+    // function-declaration boundaries), this tells CollectInnerFunction whether an
+    // inner function declaration is hoisted directly into an arrow's body — the
+    // case that needs a live $arrowScopeDC reference instead of value snapshots (#307).
+    private object? _currentEnclosingCallable;
 
     private void CollectAndDefineArrowFunctions(List<Stmt> statements)
     {
@@ -109,6 +120,13 @@ public partial class ILCompiler
 
         // Propagate arrow scope DC requirements through arrow nesting
         PropagateArrowDCRequirements();
+
+        // Resolve which arrow scope DC (if any) each inner function declaration
+        // reads its captures from, marking intermediate arrows that must carry
+        // the reference (#307). Runs after arrows' own $arrowDC sources are
+        // assigned so threading conflicts are detected, and before the define
+        // loop below so marked arrows get their $arrowDC field.
+        ResolveInnerFunctionArrowScopeSources();
 
         // Define methods and display classes
         foreach (var (arrow, captures) in _collectedArrows)
@@ -256,6 +274,25 @@ public partial class ILCompiler
                     arrowDCField = displayClass.DefineField("$arrowDC", arrowScopeDC, FieldAttributes.Public);
                 }
 
+                // EXTRA ancestor scope DC references (multi-source captures) —
+                // one field per additional source arrow beyond the primary.
+                Dictionary<Expr.ArrowFunction, FieldBuilder>? extraScopeDCFields = null;
+                if (_arrowExtraScopeSources.TryGetValue(arrow, out var extraScopeSources))
+                {
+                    int extraIdx = 0;
+                    foreach (var extraSource in extraScopeSources)
+                    {
+                        if (ReferenceEquals(extraSource, sourceArrow))
+                            continue;
+                        if (!_closures.ArrowScopeDisplayClasses.TryGetValue(extraSource, out var extraDC))
+                            continue;
+                        var refField = displayClass.DefineField($"$arrowDC{++extraIdx}", extraDC, FieldAttributes.Public);
+                        (extraScopeDCFields ??= new(ReferenceEqualityComparer.Instance))[extraSource] = refField;
+                    }
+                    if (extraScopeDCFields != null)
+                        _arrowScopeDCExtraFields[arrow] = extraScopeDCFields;
+                }
+
                 foreach (var capturedVar in captures)
                 {
                     // Skip top-level captured vars - they'll be accessed through $entryPointDC
@@ -276,6 +313,14 @@ public partial class ILCompiler
                     if (needsArrowDC && sourceArrow != null &&
                         _closures.ArrowScopeDisplayClassFields.TryGetValue(sourceArrow, out var arrowFields) &&
                         arrowFields.ContainsKey(capturedVar))
+                        continue;
+
+                    // Skip vars covered by an EXTRA ancestor scope DC reference
+                    if (extraScopeDCFields != null &&
+                        _closures.Analyzer.GetCaptureSource(arrow, capturedVar) is Expr.ArrowFunction extraSrc &&
+                        extraScopeDCFields.ContainsKey(extraSrc) &&
+                        _closures.ArrowScopeDisplayClassFields.TryGetValue(extraSrc, out var extraSrcFields) &&
+                        extraSrcFields.ContainsKey(capturedVar))
                         continue;
 
                     var field = displayClass.DefineField(capturedVar, _types.Object, FieldAttributes.Public);
@@ -379,12 +424,14 @@ public partial class ILCompiler
 
                     var previousEnclosing = _currentEnclosingFunctionName;
                     var previousEnclosingStmt = _currentEnclosingFunctionStmt;
+                    var previousCallable = _currentEnclosingCallable;
                     if (_functionNestingDepth == 0)
                     {
                         // Top-level function: use its qualified name as enclosing context
                         _currentEnclosingFunctionName = GetDefinitionContext().GetQualifiedFunctionName(f.Name.Lexeme);
                         _currentEnclosingFunctionStmt = f;
                     }
+                    _currentEnclosingCallable = f;
 
                     _functionNestingDepth++;
                     foreach (var s in f.Body)
@@ -393,6 +440,7 @@ public partial class ILCompiler
 
                     _currentEnclosingFunctionName = previousEnclosing;
                     _currentEnclosingFunctionStmt = previousEnclosingStmt;
+                    _currentEnclosingCallable = previousCallable;
                 }
                 foreach (var p in f.Parameters)
                     if (p.DefaultValue != null)
@@ -546,8 +594,11 @@ public partial class ILCompiler
 
                 // Track parent arrow for function DC propagation
                 _arrowParent[af] = _currentParentArrow;
+                _arrowEnclosingCallable[af] = _currentEnclosingCallable;
                 var previousParent = _currentParentArrow;
+                var previousCallable = _currentEnclosingCallable;
                 _currentParentArrow = af;
+                _currentEnclosingCallable = af;
 
                 // Entering an arrow body is the same as entering a function body for the
                 // purpose of "inner function declaration" classification: `function X() {}`
@@ -567,6 +618,7 @@ public partial class ILCompiler
                 _functionNestingDepth--;
 
                 _currentParentArrow = previousParent;
+                _currentEnclosingCallable = previousCallable;
                 break;
             case Expr.Binary b:
                 CollectArrowsFromExpr(b.Left);
@@ -706,6 +758,11 @@ public partial class ILCompiler
             case Expr.ClassExpr ce:
                 // Collect the class expression for later definition
                 CollectClassExpression(ce);
+                // Method/accessor bodies are separate callables — an inner function
+                // declaration inside them is NOT hoisted into the enclosing arrow's
+                // body, so clear the immediate-callable marker while walking them.
+                var prevCallableCE = _currentEnclosingCallable;
+                _currentEnclosingCallable = null;
                 // Also collect arrows inside class expression methods
                 foreach (var method in ce.Methods)
                     if (method.Body != null)
@@ -720,6 +777,7 @@ public partial class ILCompiler
                     foreach (var accessor in ce.Accessors)
                         foreach (var s in accessor.Body)
                             CollectArrowsFromStmt(s);
+                _currentEnclosingCallable = prevCallableCE;
                 break;
         }
     }
@@ -848,17 +906,53 @@ public partial class ILCompiler
     /// </summary>
     private void PropagateArrowDCRequirements()
     {
-        // First, identify arrows that directly capture arrow-scope locals
+        var collectedInnerFuncs = new HashSet<Stmt.Function>(ReferenceEqualityComparer.Instance);
+        foreach (var (f, _, _) in _collectedInnerFunctions)
+            collectedInnerFuncs.Add(f);
+
+        // First, identify arrows that directly capture arrow-scope locals.
+        // The source arrow is resolved from the analyzer's capture-source record
+        // (the scope that actually DEFINES each captured variable), not by name-
+        // matching across every scope DC — name matching aliased same-named
+        // variables across unrelated scopes and picked sources in arbitrary
+        // dictionary order. When captures span multiple ancestor arrow scopes,
+        // the single $arrowDC slot is bound to the candidate covering the most
+        // captures whose chain can be threaded; the rest fall back to copy-field
+        // population through the chained DC (see EmitDisplayInstanceFieldPopulation).
+        // Collection order is outer-to-inner, so an enclosing arrow's own needs
+        // are settled before nested closures thread pass-throughs onto it.
         foreach (var (arrow, captures) in _collectedArrows)
         {
-            foreach (var (parentArrow, arrowDCFields) in _closures.ArrowScopeDisplayClassFields)
+            Dictionary<Expr.ArrowFunction, int>? candidates = null;
+            foreach (var c in captures)
             {
-                if (captures.Any(c => arrowDCFields.ContainsKey(c)))
-                {
-                    _arrowsNeedingArrowDC.Add(arrow);
-                    _closures.ArrowScopeDCSource[arrow] = parentArrow;
-                    break;
-                }
+                if (_closures.Analyzer.GetCaptureSource(arrow, c) is not Expr.ArrowFunction sa)
+                    continue;
+                if (!_closures.ArrowScopeDisplayClassFields.TryGetValue(sa, out var fields) ||
+                    !fields.ContainsKey(c))
+                    continue;
+                candidates ??= new(ReferenceEqualityComparer.Instance);
+                candidates[sa] = candidates.TryGetValue(sa, out var n) ? n + 1 : 1;
+            }
+            if (candidates == null)
+                continue;
+
+            // Nearest threadable candidate claims the primary $arrowDC slot
+            // (unless pass-through threading already did); the rest become
+            // EXTRA reference fields. The $arrowDC is populated at the arrow's
+            // creation site (the enclosing callable's body), so chains are
+            // walked from there.
+            _arrowEnclosingCallable.TryGetValue(arrow, out var start);
+            foreach (var sa in OrderByAncestorProximity(start, candidates))
+            {
+                if (!ReferenceEquals(start, sa) && !TryThreadArrowScopeSource(start, sa, collectedInnerFuncs))
+                    continue; // unreachable chain — this source keeps snapshot semantics
+
+                _arrowsNeedingArrowDC.Add(arrow);
+                if (!_closures.ArrowScopeDCSource.TryGetValue(arrow, out var existingSrc))
+                    _closures.ArrowScopeDCSource[arrow] = sa;
+                else if (!ReferenceEquals(existingSrc, sa))
+                    AddExtraScopeSource(_arrowExtraScopeSources, arrow, sa);
             }
         }
 
@@ -989,6 +1083,7 @@ public partial class ILCompiler
             ArrowFunctionDCFields = _closures.ArrowFunctionDCFields.Count > 0 ? _closures.ArrowFunctionDCFields : null,
             // Arrow scope display class for nested arrow functions
             ArrowScopeDCFields = _closures.ArrowScopeDCFields.Count > 0 ? _closures.ArrowScopeDCFields : null,
+            ArrowScopeDCExtraFieldsByArrow = _arrowScopeDCExtraFields.Count > 0 ? _arrowScopeDCExtraFields : null,
             // Inner function metadata — required for any `function X() {}` declared INSIDE this
             // arrow body to be reachable from sibling statements. Without this, IIFE-style
             // wrappers that declare nested functions (lodash's `(function() { function basePropertyOf() {...} }())`)
@@ -1079,6 +1174,16 @@ public partial class ILCompiler
                 }
             }
 
+            // EXTRA ancestor scope references (multi-source captures): per-name
+            // live bindings, plus the raw ref fields for chaining into closures
+            // created in this body.
+            if (_arrowScopeDCExtraFields.TryGetValue(arrow, out var ownExtraScopeRefs))
+            {
+                ctx.CurrentArrowScopeDCExtraFields = ownExtraScopeRefs;
+                ctx.ExtraArrowScopeBindings = BuildExtraScopeBindings(
+                    arrow, _closures.Analyzer.GetCaptures(arrow), ownExtraScopeRefs);
+            }
+
             // Get resolved parameter types for this arrow (for typed parameter optimization)
             _closures.ArrowParameterTypes.TryGetValue(arrow, out var arrowParamTypes);
 
@@ -1139,17 +1244,27 @@ public partial class ILCompiler
             ctx.ArrowScopeDisplayClassLocal = arrowScopeDCLocal;
             ctx.ArrowScopeDisplayClassFields = _closures.ArrowScopeDisplayClassFields[arrow];
             ctx.CapturedArrowLocals = _closures.Analyzer.GetCapturedLocals(arrow);
+        }
 
-            // Initialize captured parameters into the arrow scope display class.
-            // This mirrors the equivalent code in ILCompiler.Functions.cs lines 287-305.
-            // Without this, inner arrows that read parameters via $arrowDC get null.
+        var emitter = new ILEmitter(ctx);
+
+        // Emit default parameter checks
+        emitter.EmitDefaultParameters(arrow.Parameters, displayClass != null, arrow.HasOwnThis);
+
+        // Initialize captured parameters into the arrow scope display class.
+        // This mirrors the equivalent code in ILCompiler.Functions.cs.
+        // Without this, inner arrows that read parameters via $arrowDC get null.
+        // Runs AFTER EmitDefaultParameters (which writes defaults via Starg) so
+        // the DC fields see defaulted values, not the raw missing-arg padding.
+        if (ctx.ArrowScopeDisplayClassLocal != null)
+        {
             for (int i = 0; i < arrow.Parameters.Count; i++)
             {
                 var paramName = arrow.Parameters[i].Name.Lexeme;
-                if (ctx.CapturedArrowLocals.Contains(paramName) &&
-                    ctx.ArrowScopeDisplayClassFields.TryGetValue(paramName, out var arrowDCField))
+                if (ctx.CapturedArrowLocals!.Contains(paramName) &&
+                    ctx.ArrowScopeDisplayClassFields!.TryGetValue(paramName, out var arrowDCField))
                 {
-                    il.Emit(OpCodes.Ldloc, arrowScopeDCLocal);
+                    il.Emit(OpCodes.Ldloc, ctx.ArrowScopeDisplayClassLocal);
                     // Arg index must match DefineParameter calls (lines 841-858 / 866-883):
                     //   instance (displayClass != null): params at i+1, or i+2 with HasOwnThis
                     //   static (displayClass == null):   params at i,   or i+1 with HasOwnThis
@@ -1160,11 +1275,6 @@ public partial class ILCompiler
                 }
             }
         }
-
-        var emitter = new ILEmitter(ctx);
-
-        // Emit default parameter checks
-        emitter.EmitDefaultParameters(arrow.Parameters, displayClass != null, arrow.HasOwnThis);
 
         // Bind the `arguments` array-like for function expressions (HasOwnThis=true).
         // True arrows don't get their own `arguments` per ECMA-262. Matches the same

--- a/Compilation/ILCompiler.Classes.Constructors.cs
+++ b/Compilation/ILCompiler.Classes.Constructors.cs
@@ -106,6 +106,7 @@ public partial class ILCompiler
             ArrowEntryPointDCFields = _closures.ArrowEntryPointDCFields.Count > 0 ? _closures.ArrowEntryPointDCFields : null,
             ArrowFunctionDCFields = _closures.ArrowFunctionDCFields.Count > 0 ? _closures.ArrowFunctionDCFields : null,
             ArrowScopeDCFields = _closures.ArrowScopeDCFields.Count > 0 ? _closures.ArrowScopeDCFields : null,
+            ArrowScopeDCExtraFieldsByArrow = _arrowScopeDCExtraFields.Count > 0 ? _arrowScopeDCExtraFields : null,
             // Constructors have a void signature; without this the `return;`
             // inside a ctor body defaults to object and emits `ldnull` before
             // the `ret`, producing an invalid method.

--- a/Compilation/ILCompiler.Classes.Methods.cs
+++ b/Compilation/ILCompiler.Classes.Methods.cs
@@ -788,6 +788,7 @@ public partial class ILCompiler
             ArrowEntryPointDCFields = _closures.ArrowEntryPointDCFields.Count > 0 ? _closures.ArrowEntryPointDCFields : null,
             ArrowFunctionDCFields = _closures.ArrowFunctionDCFields.Count > 0 ? _closures.ArrowFunctionDCFields : null,
             ArrowScopeDCFields = _closures.ArrowScopeDCFields.Count > 0 ? _closures.ArrowScopeDCFields : null,
+            ArrowScopeDCExtraFieldsByArrow = _arrowScopeDCExtraFields.Count > 0 ? _arrowScopeDCExtraFields : null,
             // CJS resolution — needed so `exports`, `module.exports`, and `require(...)`
             // work inside class method bodies nested in a CJS module.
             ModuleResolver = _modules.Resolver,

--- a/Compilation/ILCompiler.Functions.cs
+++ b/Compilation/ILCompiler.Functions.cs
@@ -293,6 +293,7 @@ public partial class ILCompiler
             CapturedFunctionLocals = capturedLocals,
             ArrowFunctionDCFields = _closures.ArrowFunctionDCFields.Count > 0 ? _closures.ArrowFunctionDCFields : null,
             ArrowScopeDCFields = _closures.ArrowScopeDCFields.Count > 0 ? _closures.ArrowScopeDCFields : null,
+            ArrowScopeDCExtraFieldsByArrow = _arrowScopeDCExtraFields.Count > 0 ? _arrowScopeDCExtraFields : null,
             // Inner function support
             InnerFunctionMethods = _innerFunctionMethods,
             InnerFunctionDisplayClasses = _innerFunctionDisplayClasses,

--- a/Compilation/ILCompiler.Functions.cs
+++ b/Compilation/ILCompiler.Functions.cs
@@ -330,28 +330,6 @@ public partial class ILCompiler
             ctx.DefineParameter(funcStmt.Parameters[i].Name.Lexeme, i, paramType);
         }
 
-        // Initialize captured parameters into the function display class
-        // This must happen after parameter definitions so we have correct indices
-        if (displayLocal != null && capturedLocals != null && _closures.FunctionDisplayClassFields.TryGetValue(qualifiedFunctionName, out var funcDCFieldMap))
-        {
-            for (int i = 0; i < funcStmt.Parameters.Count; i++)
-            {
-                var paramName = funcStmt.Parameters[i].Name.Lexeme;
-                if (capturedLocals.Contains(paramName) && funcDCFieldMap.TryGetValue(paramName, out var field))
-                {
-                    il.Emit(OpCodes.Ldloc, displayLocal);
-                    il.Emit(OpCodes.Ldarg, i);
-                    // Box if the parameter is a value type (numbers are double)
-                    Type paramType = i < methodParams.Length ? methodParams[i].ParameterType : typeof(object);
-                    if (paramType.IsValueType)
-                    {
-                        il.Emit(OpCodes.Box, paramType);
-                    }
-                    il.Emit(OpCodes.Stfld, field);
-                }
-            }
-        }
-
         var emitter = new ILEmitter(ctx);
 
         // Top-level functions should always have a body
@@ -375,6 +353,29 @@ public partial class ILCompiler
             isInstanceMethod: false,
             hasOwnThis: false,
             paramTypes: resolvedParamTypes);
+
+        // Initialize captured parameters into the function display class. Runs
+        // AFTER EmitDefaultParameters (which writes defaults back via Starg) so
+        // closures see the defaulted value, not the missing-arg padding.
+        if (displayLocal != null && capturedLocals != null && _closures.FunctionDisplayClassFields.TryGetValue(qualifiedFunctionName, out var funcDCFieldMap))
+        {
+            for (int i = 0; i < funcStmt.Parameters.Count; i++)
+            {
+                var paramName = funcStmt.Parameters[i].Name.Lexeme;
+                if (capturedLocals.Contains(paramName) && funcDCFieldMap.TryGetValue(paramName, out var field))
+                {
+                    il.Emit(OpCodes.Ldloc, displayLocal);
+                    il.Emit(OpCodes.Ldarg, i);
+                    // Box if the parameter is a value type (numbers are double)
+                    Type paramType = i < methodParams.Length ? methodParams[i].ParameterType : typeof(object);
+                    if (paramType.IsValueType)
+                    {
+                        il.Emit(OpCodes.Box, paramType);
+                    }
+                    il.Emit(OpCodes.Stfld, field);
+                }
+            }
+        }
 
         // If the body references `arguments`, materialize the JS-spec array-like
         // from the declared parameters and bind it as a local. Arrow functions

--- a/Compilation/ILCompiler.InnerFunctions.cs
+++ b/Compilation/ILCompiler.InnerFunctions.cs
@@ -22,6 +22,38 @@ public partial class ILCompiler
     private readonly Dictionary<Stmt.Function, FieldBuilder> _innerFunctionFunctionDCFields = new(ReferenceEqualityComparer.Instance);
     private readonly Dictionary<Stmt.Function, Type[]> _innerFunctionParamTypes = new(ReferenceEqualityComparer.Instance);
 
+    // #307: inner function declarations that capture variables living on an
+    // ancestor arrow's scope display class get a live $arrowScopeDC reference
+    // (populated at hoist time) instead of hoist-time value snapshots —
+    // hoisting runs BEFORE the body statements that assign those variables,
+    // so snapshots read null/stale. The reference is threaded through
+    // intermediate callables when the source arrow isn't the immediate parent.
+    private readonly Dictionary<Stmt.Function, object> _innerFunctionParentCallable = new(ReferenceEqualityComparer.Instance);
+    private readonly Dictionary<Stmt.Function, FieldBuilder> _innerFunctionArrowScopeDCFields = new(ReferenceEqualityComparer.Instance);
+    private readonly Dictionary<Stmt.Function, Expr.ArrowFunction> _innerFunctionArrowScopeDCSource = new(ReferenceEqualityComparer.Instance);
+
+    // EXTRA (non-primary) ancestor scope DC sources. A closure capturing from
+    // more than one ancestor arrow scope gets one reference field per source —
+    // the single primary slot can't represent multi-source captures (lodash's
+    // shortOut closure reads nativeNow from runInContext AND HOT_SPAN from the
+    // outer IIFE). Sets are accumulated during threading; fields are defined
+    // alongside the primary in the respective define passes.
+    private readonly Dictionary<Stmt.Function, HashSet<Expr.ArrowFunction>> _innerFunctionExtraScopeSources = new(ReferenceEqualityComparer.Instance);
+    private readonly Dictionary<Expr.ArrowFunction, HashSet<Expr.ArrowFunction>> _arrowExtraScopeSources = new(ReferenceEqualityComparer.Instance);
+    private readonly Dictionary<Stmt.Function, Dictionary<Expr.ArrowFunction, FieldBuilder>> _innerFunctionArrowScopeDCExtraFields = new(ReferenceEqualityComparer.Instance);
+    private readonly Dictionary<Expr.ArrowFunction, Dictionary<Expr.ArrowFunction, FieldBuilder>> _arrowScopeDCExtraFields = new(ReferenceEqualityComparer.Instance);
+
+    private static void AddExtraScopeSource<TKey>(Dictionary<TKey, HashSet<Expr.ArrowFunction>> map, TKey key, Expr.ArrowFunction source)
+        where TKey : notnull
+    {
+        if (!map.TryGetValue(key, out var set))
+        {
+            set = new HashSet<Expr.ArrowFunction>(ReferenceEqualityComparer.Instance);
+            map[key] = set;
+        }
+        set.Add(source);
+    }
+
     // Nesting depth tracker: 0 = top level, 1+ = inside a function body
     private int _functionNestingDepth;
 
@@ -44,6 +76,154 @@ public partial class ILCompiler
         // as a sentinel so downstream dict lookups return "no match" instead of throwing
         // ArgumentNullException.
         _collectedInnerFunctions.Add((funcStmt, captures, _currentEnclosingFunctionName ?? ""));
+
+        // Record the callable whose body this declaration is hoisted into.
+        if (_currentEnclosingCallable != null)
+            _innerFunctionParentCallable[funcStmt] = _currentEnclosingCallable;
+    }
+
+    /// <summary>
+    /// Resolves, for every collected inner function declaration, the ancestor arrow
+    /// whose scope display class provides its captured variables (#307), and marks
+    /// every intermediate callable between the function and that arrow so the live
+    /// DC reference can be threaded through at hoist/creation time. Must run after
+    /// arrow scope display classes are defined and arrows' own $arrowDC sources are
+    /// assigned (PropagateArrowDCRequirements), but before arrow methods/display
+    /// classes are defined.
+    /// </summary>
+    private void ResolveInnerFunctionArrowScopeSources()
+    {
+        var collectedSet = new HashSet<Stmt.Function>(ReferenceEqualityComparer.Instance);
+        foreach (var (f, _, _) in _collectedInnerFunctions)
+            collectedSet.Add(f);
+
+        // Collection order is outer-to-inner, so a parent's own capture needs are
+        // resolved before any child threads a pass-through requirement onto it.
+        foreach (var (func, captures, _) in _collectedInnerFunctions)
+        {
+            // Candidate source arrows: the analyzer-recorded defining scope of each
+            // captured variable, when that scope is an arrow owning a scope DC with
+            // a matching field.
+            Dictionary<Expr.ArrowFunction, int>? candidates = null;
+            foreach (var c in captures)
+            {
+                if (_closures.Analyzer.GetCaptureSource(func, c) is not Expr.ArrowFunction sa)
+                    continue;
+                if (!_closures.ArrowScopeDisplayClassFields.TryGetValue(sa, out var fields) ||
+                    !fields.ContainsKey(c))
+                    continue;
+                candidates ??= new(ReferenceEqualityComparer.Instance);
+                candidates[sa] = candidates.TryGetValue(sa, out var n) ? n + 1 : 1;
+            }
+            if (candidates == null)
+                continue;
+
+            // Nearest threadable candidate becomes the PRIMARY $arrowScopeDC source
+            // (unless pass-through threading already claimed the slot); every other
+            // threadable candidate gets an EXTRA reference field.
+            _innerFunctionParentCallable.TryGetValue(func, out var start);
+            foreach (var sa in OrderByAncestorProximity(start, candidates))
+            {
+                if (!TryThreadArrowScopeSource(start, sa, collectedSet))
+                    continue; // unreachable chain — this source keeps snapshot semantics
+                if (!_innerFunctionArrowScopeDCSource.TryGetValue(func, out var existing))
+                    _innerFunctionArrowScopeDCSource[func] = sa;
+                else if (!ReferenceEquals(existing, sa))
+                    AddExtraScopeSource(_innerFunctionExtraScopeSources, func, sa);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Orders candidate source arrows by proximity along the enclosing-callable
+    /// chain starting at <paramref name="start"/> — nearest ancestor first. The
+    /// single $arrowScopeDC/$arrowDC slot can only bind one source; the nearest
+    /// scope is the one whose variables are assigned in the same bodies that
+    /// hoist these closures, so it's the scope that NEEDS live reads (lodash's
+    /// runInContext helpers). Farther scopes' variables are typically assigned
+    /// before the closure is created, so their copy-field snapshots hold the
+    /// right values when reachable.
+    /// </summary>
+    private IEnumerable<Expr.ArrowFunction> OrderByAncestorProximity(
+        object? start, Dictionary<Expr.ArrowFunction, int> candidates)
+    {
+        var node = start;
+        int guard = 0;
+        while (node != null && ++guard <= 256)
+        {
+            if (node is Expr.ArrowFunction ia)
+            {
+                if (candidates.ContainsKey(ia))
+                    yield return ia;
+                _arrowEnclosingCallable.TryGetValue(ia, out node);
+            }
+            else if (node is Stmt.Function pf)
+            {
+                _innerFunctionParentCallable.TryGetValue(pf, out node);
+            }
+            else
+            {
+                yield break;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Walks the enclosing-callable chain from <paramref name="start"/> up to
+    /// <paramref name="source"/>. On success, marks every intermediate so it
+    /// carries a live reference to the source's scope DC: the primary slot
+    /// ($arrowDC / $arrowScopeDC source) when free or already bound to this
+    /// source, otherwise an EXTRA reference field. Fails (committing nothing)
+    /// when the chain is broken — async arrow or uncollected function boundary.
+    /// </summary>
+    private bool TryThreadArrowScopeSource(object? start, Expr.ArrowFunction source, HashSet<Stmt.Function> collectedSet)
+    {
+        var arrowsToMark = new List<Expr.ArrowFunction>();
+        var passThroughFuncs = new List<Stmt.Function>();
+
+        var node = start;
+        int guard = 0;
+        while (node != null && !ReferenceEquals(node, source))
+        {
+            if (++guard > 256)
+                return false;
+
+            if (node is Expr.ArrowFunction ia)
+            {
+                if (ia.IsAsync)
+                    return false;
+                arrowsToMark.Add(ia);
+                _arrowEnclosingCallable.TryGetValue(ia, out node);
+            }
+            else if (node is Stmt.Function pf && collectedSet.Contains(pf))
+            {
+                passThroughFuncs.Add(pf);
+                _innerFunctionParentCallable.TryGetValue(pf, out node);
+            }
+            else
+            {
+                return false;
+            }
+        }
+        if (node == null)
+            return false;
+
+        foreach (var ia in arrowsToMark)
+        {
+            _arrowsNeedingArrowDC.Add(ia);
+            if (!_closures.ArrowScopeDCSource.TryGetValue(ia, out var iaSrc))
+                _closures.ArrowScopeDCSource[ia] = source;
+            else if (!ReferenceEquals(iaSrc, source))
+                AddExtraScopeSource(_arrowExtraScopeSources, ia, source);
+        }
+        foreach (var pf in passThroughFuncs)
+        {
+            if (!_innerFunctionArrowScopeDCSource.TryGetValue(pf, out var pfSrc))
+                _innerFunctionArrowScopeDCSource[pf] = source;
+            else if (!ReferenceEquals(pfSrc, source))
+                AddExtraScopeSource(_innerFunctionExtraScopeSources, pf, source);
+        }
+        return true;
     }
 
     /// <summary>
@@ -85,7 +265,21 @@ public partial class ILCompiler
             bool needsEntryPointDC = _closures.EntryPointDisplayClass != null &&
                 captures.Any(c => _closures.CapturedTopLevelVars.Contains(c));
 
-            if (captures.Count == 0 && !needsFunctionDC)
+            // #307: captured vars that live on an ancestor arrow's scope display
+            // class are accessed LIVE via a $arrowScopeDC reference, not copied at
+            // hoist time (the copy would run before the arrow body assigns them).
+            // The source was resolved by ResolveInnerFunctionArrowScopeSources —
+            // it may also be a pass-through requirement from a nested function.
+            Expr.ArrowFunction? arrowScopeSource = null;
+            Dictionary<string, FieldBuilder>? arrowScopeSourceFields = null;
+            if (_innerFunctionArrowScopeDCSource.TryGetValue(func, out var resolvedSource) &&
+                _closures.ArrowScopeDisplayClassFields.TryGetValue(resolvedSource, out arrowScopeSourceFields))
+            {
+                arrowScopeSource = resolvedSource;
+            }
+            _innerFunctionExtraScopeSources.TryGetValue(func, out var extraScopeSources);
+
+            if (captures.Count == 0 && !needsFunctionDC && arrowScopeSource == null && extraScopeSources == null)
             {
                 // Non-capturing: static method on $Program
                 var methodBuilder = _programType.DefineMethod(
@@ -125,6 +319,28 @@ public partial class ILCompiler
                     functionDCField = displayClass.DefineField("$functionDC", funcDC, FieldAttributes.Public);
                 }
 
+                FieldBuilder? arrowScopeDCField = null;
+                if (arrowScopeSource != null &&
+                    _closures.ArrowScopeDisplayClasses.TryGetValue(arrowScopeSource, out var arrowScopeDC))
+                {
+                    arrowScopeDCField = displayClass.DefineField("$arrowScopeDC", arrowScopeDC, FieldAttributes.Public);
+                }
+
+                Dictionary<Expr.ArrowFunction, FieldBuilder>? extraScopeDCFields = null;
+                if (extraScopeSources != null)
+                {
+                    int extraIdx = 0;
+                    foreach (var extraSource in extraScopeSources)
+                    {
+                        if (ReferenceEquals(extraSource, arrowScopeSource))
+                            continue;
+                        if (!_closures.ArrowScopeDisplayClasses.TryGetValue(extraSource, out var extraDC))
+                            continue;
+                        var refField = displayClass.DefineField($"$arrowScopeDC{++extraIdx}", extraDC, FieldAttributes.Public);
+                        (extraScopeDCFields ??= new(ReferenceEqualityComparer.Instance))[extraSource] = refField;
+                    }
+                }
+
                 foreach (var capturedVar in captures)
                 {
                     // Skip top-level captured vars - accessed through $entryPointDC
@@ -135,6 +351,20 @@ public partial class ILCompiler
                     if (needsFunctionDC && sourceFunctionForDC != null &&
                         _closures.FunctionDisplayClassFields.TryGetValue(sourceFunctionForDC, out var funcFields) &&
                         funcFields.ContainsKey(capturedVar))
+                        continue;
+
+                    // Skip enclosing-arrow scope vars - accessed live through $arrowScopeDC
+                    if (arrowScopeDCField != null &&
+                        arrowScopeSourceFields!.ContainsKey(capturedVar) &&
+                        ReferenceEquals(_closures.Analyzer.GetCaptureSource(func, capturedVar), arrowScopeSource))
+                        continue;
+
+                    // Skip vars covered by an EXTRA ancestor scope DC reference
+                    if (extraScopeDCFields != null &&
+                        _closures.Analyzer.GetCaptureSource(func, capturedVar) is Expr.ArrowFunction extraSrc &&
+                        extraScopeDCFields.ContainsKey(extraSrc) &&
+                        _closures.ArrowScopeDisplayClassFields.TryGetValue(extraSrc, out var extraSrcFields) &&
+                        extraSrcFields.ContainsKey(capturedVar))
                         continue;
 
                     var field = displayClass.DefineField(capturedVar, _types.Object, FieldAttributes.Public);
@@ -148,6 +378,12 @@ public partial class ILCompiler
 
                 if (functionDCField != null)
                     _innerFunctionFunctionDCFields[func] = functionDCField;
+
+                if (arrowScopeDCField != null)
+                    _innerFunctionArrowScopeDCFields[func] = arrowScopeDCField;
+
+                if (extraScopeDCFields != null)
+                    _innerFunctionArrowScopeDCExtraFields[func] = extraScopeDCFields;
 
                 // Default constructor
                 var ctorBuilder = displayClass.DefineConstructor(
@@ -237,6 +473,7 @@ public partial class ILCompiler
                 EntryPointDisplayClassStaticField = _closures.EntryPointDisplayClassStaticField,
                 ArrowFunctionDCFields = _closures.ArrowFunctionDCFields.Count > 0 ? _closures.ArrowFunctionDCFields : null,
                 ArrowScopeDCFields = _closures.ArrowScopeDCFields.Count > 0 ? _closures.ArrowScopeDCFields : null,
+            ArrowScopeDCExtraFieldsByArrow = _arrowScopeDCExtraFields.Count > 0 ? _arrowScopeDCExtraFields : null,
                 InnerFunctionMethods = _innerFunctionMethods,
                 InnerFunctionDisplayClasses = _innerFunctionDisplayClasses,
                 InnerFunctionDCFields = _innerFunctionDCFields,
@@ -297,6 +534,30 @@ public partial class ILCompiler
                         ctx.FunctionDisplayClassFields = funcDCFields;
                         ctx.CapturedFunctionLocals = [.. funcDCFields.Keys];
                     }
+                }
+
+                // Set $arrowScopeDC field (#307): route captured enclosing-arrow
+                // locals through the live reference so reads/writes hit the arrow's
+                // scope DC (LocalVariableResolver parent-DC paths). Restrict the
+                // name set to this function's own analyzer-confirmed captures so
+                // names shadowed by locals/params keep their normal resolution.
+                if (_innerFunctionArrowScopeDCFields.TryGetValue(func, out var arrowScopeRefField) &&
+                    _innerFunctionArrowScopeDCSource.TryGetValue(func, out var arrowScopeSrc) &&
+                    _closures.ArrowScopeDisplayClassFields.TryGetValue(arrowScopeSrc, out var srcArrowFields))
+                {
+                    ctx.CurrentArrowScopeDCField = arrowScopeRefField;
+                    ctx.ParentArrowScopeDisplayClassFields = srcArrowFields;
+                    ctx.ParentArrowCapturedLocals = [.. captures.Where(c =>
+                        srcArrowFields.ContainsKey(c) &&
+                        ReferenceEquals(_closures.Analyzer.GetCaptureSource(func, c), arrowScopeSrc))];
+                }
+
+                // EXTRA ancestor scope references: per-name live bindings plus the
+                // raw ref fields for chaining into closures created in this body.
+                if (_innerFunctionArrowScopeDCExtraFields.TryGetValue(func, out var ownExtraRefs))
+                {
+                    ctx.CurrentArrowScopeDCExtraFields = ownExtraRefs;
+                    ctx.ExtraArrowScopeBindings = BuildExtraScopeBindings(func, captures, ownExtraRefs);
                 }
 
                 // Parameters start at index 1 (display class is arg 0)
@@ -447,6 +708,17 @@ public partial class ILCompiler
                     }
                 }
 
+                // Populate $arrowScopeDC (and any extra ancestor refs) with live
+                // REFERENCES to the source scope DCs (#307). The reference is valid
+                // at hoist time even though the DC's variable fields are assigned
+                // later by body statements — that's the point: reads go through the
+                // reference at call time.
+                if (_innerFunctionArrowScopeDCFields.TryGetValue(funcStmt, out var arrowScopeDCRefField))
+                    EmitScopeDCRefStoreOnTop(il, ctx, arrowScopeDCRefField);
+                if (_innerFunctionArrowScopeDCExtraFields.TryGetValue(funcStmt, out var extraRefFields))
+                    foreach (var refField in extraRefFields.Values)
+                        EmitScopeDCRefStoreOnTop(il, ctx, refField);
+
                 // Stash the DC instance in a temp local so Pass 2 can populate its captured
                 // variable fields after every peer hoist has stored its final TSFunction.
                 var dcTemp = il.DeclareLocal(displayClass);
@@ -553,6 +825,19 @@ public partial class ILCompiler
                     il.Emit(OpCodes.Ldloc, ctx.ArrowScopeDisplayClassLocal);
                     il.Emit(OpCodes.Ldfld, arrowField);
                 }
+                else if (ctx.ParentArrowScopeDisplayClassFields?.TryGetValue(capturedVar, out var parentArrowField) == true &&
+                         ctx.CurrentArrowScopeDCField != null)
+                {
+                    // Captured from an ancestor arrow's scope DC reachable through
+                    // the enclosing closure's $arrowDC/$arrowScopeDC reference.
+                    // Happens when the inner function's single $arrowScopeDC slot
+                    // is bound to a DIFFERENT (closer) source arrow, so this var
+                    // falls back to a copy-field — populate it from the chained
+                    // ancestor DC instead of emitting null (lodash reIsHostCtor).
+                    il.Emit(OpCodes.Ldarg_0);
+                    il.Emit(OpCodes.Ldfld, ctx.CurrentArrowScopeDCField);
+                    il.Emit(OpCodes.Ldfld, parentArrowField);
+                }
                 else if (ctx.TopLevelStaticVars != null && ctx.TopLevelStaticVars.TryGetValue(capturedVar, out var topField))
                 {
                     il.Emit(OpCodes.Ldsfld, topField);
@@ -567,6 +852,73 @@ public partial class ILCompiler
                 }
 
                 il.Emit(OpCodes.Stfld, field);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Builds the per-name live bindings for a closure's captures that route
+    /// through EXTRA ancestor scope DC references. Only analyzer-confirmed
+    /// (closure, name) → source pairs are included, so shadowed names keep
+    /// their normal resolution.
+    /// </summary>
+    private Dictionary<string, CompilationContext.ExtraScopeBinding>? BuildExtraScopeBindings(
+        object closureNode, IEnumerable<string> captures, Dictionary<Expr.ArrowFunction, FieldBuilder> extraRefs)
+    {
+        Dictionary<string, CompilationContext.ExtraScopeBinding>? bindings = null;
+        foreach (var c in captures)
+        {
+            if (_closures.Analyzer.GetCaptureSource(closureNode, c) is not Expr.ArrowFunction src)
+                continue;
+            if (!extraRefs.TryGetValue(src, out var refField))
+                continue;
+            if (!_closures.ArrowScopeDisplayClassFields.TryGetValue(src, out var srcFields) ||
+                !srcFields.TryGetValue(c, out var varField))
+                continue;
+            (bindings ??= [])[c] = new CompilationContext.ExtraScopeBinding(refField, varField);
+        }
+        return bindings;
+    }
+
+    /// <summary>
+    /// With a display-class instance on top of the stack, stores a reference to
+    /// the ancestor scope DC matching <paramref name="refField"/>'s type into
+    /// that field, sourcing it from whatever the current emission context can
+    /// reach: the body's own scope-DC local, the primary $arrowDC/$arrowScopeDC
+    /// reference, or an extra ancestor reference. Leaves the instance on the
+    /// stack. No-op (field stays null) when the context can't reach the DC —
+    /// threading should have prevented that.
+    /// </summary>
+    private static void EmitScopeDCRefStoreOnTop(ILGenerator il, CompilationContext ctx, FieldBuilder refField)
+    {
+        if (ctx.ArrowScopeDisplayClassLocal != null &&
+            ctx.ArrowScopeDisplayClassLocal.LocalType == refField.FieldType)
+        {
+            il.Emit(OpCodes.Dup);
+            il.Emit(OpCodes.Ldloc, ctx.ArrowScopeDisplayClassLocal);
+            il.Emit(OpCodes.Stfld, refField);
+            return;
+        }
+        if (ctx.CurrentArrowScopeDCField != null &&
+            ctx.CurrentArrowScopeDCField.FieldType == refField.FieldType)
+        {
+            il.Emit(OpCodes.Dup);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, ctx.CurrentArrowScopeDCField);
+            il.Emit(OpCodes.Stfld, refField);
+            return;
+        }
+        if (ctx.CurrentArrowScopeDCExtraFields != null)
+        {
+            foreach (var ownRef in ctx.CurrentArrowScopeDCExtraFields.Values)
+            {
+                if (ownRef.FieldType != refField.FieldType)
+                    continue;
+                il.Emit(OpCodes.Dup);
+                il.Emit(OpCodes.Ldarg_0);
+                il.Emit(OpCodes.Ldfld, ownRef);
+                il.Emit(OpCodes.Stfld, refField);
+                return;
             }
         }
     }

--- a/Compilation/ILEmitter.Calls.Closures.cs
+++ b/Compilation/ILEmitter.Calls.Closures.cs
@@ -260,23 +260,69 @@ public partial class ILEmitter
             }
         }
 
-        // Populate $arrowDC field if this arrow captures arrow-scope variables
+        // Populate $arrowDC field if this arrow captures arrow-scope variables.
+        // When both a scope-DC local (this context's own DC) and a chained
+        // reference field are available, pick by DC TYPE: the new arrow may
+        // reference a GRANDPARENT scope DC that only the chain field carries.
         if (_ctx.ArrowScopeDCFields?.TryGetValue(af, out var arrowScopeDCField) == true)
         {
-            if (_ctx.ArrowScopeDisplayClassLocal != null)
+            bool localMatches = _ctx.ArrowScopeDisplayClassLocal != null &&
+                _ctx.ArrowScopeDisplayClassLocal.LocalType == arrowScopeDCField.FieldType;
+            bool chainMatches = _ctx.CurrentArrowScopeDCField != null &&
+                _ctx.CurrentArrowScopeDCField.FieldType == arrowScopeDCField.FieldType;
+
+            if (localMatches || (_ctx.ArrowScopeDisplayClassLocal != null && !chainMatches))
             {
                 // In parent arrow body - use local variable
                 IL.Emit(OpCodes.Dup);
-                IL.Emit(OpCodes.Ldloc, _ctx.ArrowScopeDisplayClassLocal);
+                IL.Emit(OpCodes.Ldloc, _ctx.ArrowScopeDisplayClassLocal!);
                 IL.Emit(OpCodes.Stfld, arrowScopeDCField);
             }
-            else if (_ctx.CurrentArrowScopeDCField != null)
+            else if (chainMatches)
             {
-                // In nested arrow body - chain through parent's $arrowDC field
+                // In nested closure body - chain through the $arrowDC /
+                // $arrowScopeDC reference field
+                IL.Emit(OpCodes.Dup);
+                IL.Emit(OpCodes.Ldarg_0);
+                IL.Emit(OpCodes.Ldfld, _ctx.CurrentArrowScopeDCField!);
+                IL.Emit(OpCodes.Stfld, arrowScopeDCField);
+            }
+            else if (!EmitScopeDCRefFromExtras(arrowScopeDCField) && _ctx.CurrentArrowScopeDCField != null)
+            {
+                // Legacy fallback: no type-matching source available — keep the
+                // historical chain-through behavior.
                 IL.Emit(OpCodes.Dup);
                 IL.Emit(OpCodes.Ldarg_0);
                 IL.Emit(OpCodes.Ldfld, _ctx.CurrentArrowScopeDCField);
                 IL.Emit(OpCodes.Stfld, arrowScopeDCField);
+            }
+        }
+
+        // EXTRA ancestor scope DC references (multi-source captures): populate
+        // each one from whatever this context can reach by DC type.
+        if (_ctx.ArrowScopeDCExtraFieldsByArrow?.TryGetValue(af, out var extraScopeRefFields) == true)
+        {
+            foreach (var extraRefField in extraScopeRefFields.Values)
+            {
+                if (_ctx.ArrowScopeDisplayClassLocal != null &&
+                    _ctx.ArrowScopeDisplayClassLocal.LocalType == extraRefField.FieldType)
+                {
+                    IL.Emit(OpCodes.Dup);
+                    IL.Emit(OpCodes.Ldloc, _ctx.ArrowScopeDisplayClassLocal);
+                    IL.Emit(OpCodes.Stfld, extraRefField);
+                }
+                else if (_ctx.CurrentArrowScopeDCField != null &&
+                         _ctx.CurrentArrowScopeDCField.FieldType == extraRefField.FieldType)
+                {
+                    IL.Emit(OpCodes.Dup);
+                    IL.Emit(OpCodes.Ldarg_0);
+                    IL.Emit(OpCodes.Ldfld, _ctx.CurrentArrowScopeDCField);
+                    IL.Emit(OpCodes.Stfld, extraRefField);
+                }
+                else
+                {
+                    EmitScopeDCRefFromExtras(extraRefField);
+                }
             }
         }
 
@@ -340,6 +386,30 @@ public partial class ILEmitter
                 IL.Emit(OpCodes.Ldarg_0); // this (display class)
                 IL.Emit(OpCodes.Ldfld, capturedField);
             }
+            else if (_ctx.CapturedArrowLocals?.Contains(capturedVar) == true &&
+                     _ctx.ArrowScopeDisplayClassFields?.TryGetValue(capturedVar, out var ownScopeField) == true &&
+                     _ctx.ArrowScopeDisplayClassLocal != null)
+            {
+                // Variable lives on the creating scope's arrow scope DC (e.g. a
+                // hoisted inner function declaration stored there). Without this
+                // branch the populate falls through to Locals and emits null.
+                IL.Emit(OpCodes.Ldloc, _ctx.ArrowScopeDisplayClassLocal);
+                IL.Emit(OpCodes.Ldfld, ownScopeField);
+            }
+            else if (_ctx.ParentArrowScopeDisplayClassFields?.TryGetValue(capturedVar, out var parentScopeField) == true &&
+                     _ctx.CurrentArrowScopeDCField != null)
+            {
+                // Variable lives on an ancestor arrow's scope DC reachable through
+                // the creating closure's $arrowDC/$arrowScopeDC reference. Arises
+                // when the new arrow's single $arrowDC slot is bound to a different
+                // source scope, so this variable became a copy-field. Keyed on the
+                // fields map alone (not the creating closure's own capture set) —
+                // the variable belongs to the NEW closure's captures, which the
+                // creating closure may not share.
+                IL.Emit(OpCodes.Ldarg_0);
+                IL.Emit(OpCodes.Ldfld, _ctx.CurrentArrowScopeDCField);
+                IL.Emit(OpCodes.Ldfld, parentScopeField);
+            }
             else if (_ctx.CapturedTopLevelVars?.Contains(capturedVar) == true &&
                      _ctx.EntryPointDisplayClassFields?.TryGetValue(capturedVar, out var entryPointField) == true)
             {
@@ -398,6 +468,29 @@ public partial class ILEmitter
 
             IL.Emit(OpCodes.Stfld, field);
         }
+    }
+
+    /// <summary>
+    /// With a new display instance on top of the stack, tries to populate
+    /// <paramref name="targetField"/> (a scope-DC reference field) from one of
+    /// the current closure's own EXTRA ancestor-scope reference fields, matched
+    /// by DC type. Returns false when no extra reference matches.
+    /// </summary>
+    private bool EmitScopeDCRefFromExtras(FieldBuilder targetField)
+    {
+        if (_ctx.CurrentArrowScopeDCExtraFields == null)
+            return false;
+        foreach (var ownRef in _ctx.CurrentArrowScopeDCExtraFields.Values)
+        {
+            if (ownRef.FieldType != targetField.FieldType)
+                continue;
+            IL.Emit(OpCodes.Dup);
+            IL.Emit(OpCodes.Ldarg_0);
+            IL.Emit(OpCodes.Ldfld, ownRef);
+            IL.Emit(OpCodes.Stfld, targetField);
+            return true;
+        }
+        return false;
     }
 
     /// <summary>

--- a/Compilation/ILEmitter.Expressions.cs
+++ b/Compilation/ILEmitter.Expressions.cs
@@ -366,6 +366,15 @@ public partial class ILEmitter
 
             IL.Emit(OpCodes.Ldloc, temp);
             IL.Emit(OpCodes.Stfld, funcDCField);
+            // Captured PARAMETER of this function: also sync the arg slot —
+            // reads resolve parameters before the DC, so a DC-only store would
+            // leave later same-body reads seeing the stale argument.
+            if (_ctx.FunctionDisplayClassLocal != null &&
+                _ctx.TryGetParameter(a.Name.Lexeme, out var funcParamSync))
+            {
+                IL.Emit(OpCodes.Ldloc, temp);
+                IL.Emit(OpCodes.Starg, funcParamSync);
+            }
             SetStackUnknown();
             return;
         }
@@ -399,6 +408,51 @@ public partial class ILEmitter
 
             IL.Emit(OpCodes.Ldloc, temp);
             IL.Emit(OpCodes.Stfld, arrowDCField);
+            // Captured PARAMETER of this arrow: also sync the arg slot — reads
+            // resolve parameters before the scope DC, so a DC-only store would
+            // leave later same-body reads seeing the stale argument (lodash's
+            // `context = context || root; ... context.Date` failure mode).
+            if (_ctx.ArrowScopeDisplayClassLocal != null &&
+                _ctx.TryGetParameter(a.Name.Lexeme, out var arrowParamSync))
+            {
+                IL.Emit(OpCodes.Ldloc, temp);
+                IL.Emit(OpCodes.Starg, arrowParamSync);
+            }
+            SetStackUnknown();
+            return;
+        }
+
+        // 1c. PARENT arrow's scope DC, reachable through the current closure's
+        // $arrowDC / $arrowScopeDC reference field. Mirrors LocalVariableResolver
+        // store path 1c; without this branch the assignment falls through to the
+        // "Unknown target" tail and leaves a dangling value on the stack.
+        if (_ctx.ParentArrowCapturedLocals?.Contains(a.Name.Lexeme) == true &&
+            _ctx.ParentArrowScopeDisplayClassFields?.TryGetValue(a.Name.Lexeme, out var parentArrowDCField) == true &&
+            _ctx.CurrentArrowScopeDCField != null)
+        {
+            EmitBoxIfNeeded(a.Value);
+            IL.Emit(OpCodes.Dup);
+            var temp = IL.DeclareLocal(_ctx.Types.Object);
+            IL.Emit(OpCodes.Stloc, temp);
+            IL.Emit(OpCodes.Ldarg_0);
+            IL.Emit(OpCodes.Ldfld, _ctx.CurrentArrowScopeDCField);
+            IL.Emit(OpCodes.Ldloc, temp);
+            IL.Emit(OpCodes.Stfld, parentArrowDCField);
+            SetStackUnknown();
+            return;
+        }
+
+        // 1d. EXTRA ancestor arrow scope DCs — mirror of LocalVariableResolver 1d.
+        if (_ctx.ExtraArrowScopeBindings?.TryGetValue(a.Name.Lexeme, out var extraAssignBinding) == true)
+        {
+            EmitBoxIfNeeded(a.Value);
+            IL.Emit(OpCodes.Dup);
+            var temp = IL.DeclareLocal(_ctx.Types.Object);
+            IL.Emit(OpCodes.Stloc, temp);
+            IL.Emit(OpCodes.Ldarg_0);
+            IL.Emit(OpCodes.Ldfld, extraAssignBinding.RefField);
+            IL.Emit(OpCodes.Ldloc, temp);
+            IL.Emit(OpCodes.Stfld, extraAssignBinding.VarField);
             SetStackUnknown();
             return;
         }

--- a/Compilation/LocalVariableResolver.cs
+++ b/Compilation/LocalVariableResolver.cs
@@ -132,6 +132,18 @@ public class LocalVariableResolver : IVariableResolver
             return StackType.Unknown;
         }
 
+        // 2d. EXTRA ancestor arrow scope DCs — per-name bindings for captures
+        // whose source scope is referenced by a non-primary $arrowDC{n} /
+        // $arrowScopeDC{n} field (closures capturing from multiple ancestor
+        // arrow scopes). Analyzer-confirmed entries only, so shadowing-safe.
+        if (_ctx.ExtraArrowScopeBindings?.TryGetValue(name, out var extraBinding) == true)
+        {
+            _il.Emit(OpCodes.Ldarg_0);
+            _il.Emit(OpCodes.Ldfld, extraBinding.RefField);
+            _il.Emit(OpCodes.Ldfld, extraBinding.VarField);
+            return StackType.Unknown;
+        }
+
         // (Removed: the old CapturedArrowLocals + $arrowDC chain path. With
         // ParentArrowCapturedLocals now the dedicated parent slot, the old
         // path was emitting broken Ldarg_0 sequences in non-display-class
@@ -206,6 +218,7 @@ public class LocalVariableResolver : IVariableResolver
             _ctx.ArrowScopeDisplayClassFields?.ContainsKey(name) == true) return true;
         if (_ctx.ParentArrowCapturedLocals?.Contains(name) == true &&
             _ctx.ParentArrowScopeDisplayClassFields?.ContainsKey(name) == true) return true;
+        if (_ctx.ExtraArrowScopeBindings?.ContainsKey(name) == true) return true;
         if (_ctx.Locals.HasLocal(name)) return true;
         if (_ctx.CapturedFields?.ContainsKey(name) == true) return true;
         if (_ctx.CapturedTopLevelVars?.Contains(name) == true &&
@@ -231,6 +244,13 @@ public class LocalVariableResolver : IVariableResolver
                 _il.Emit(OpCodes.Ldloc, _ctx.FunctionDisplayClassLocal);
                 _il.Emit(OpCodes.Ldloc, temp);
                 _il.Emit(OpCodes.Stfld, funcDCField);
+                // Captured PARAMETER: also sync the arg slot — reads resolve
+                // parameters before the function DC (see 1b's mirror comment).
+                if (_ctx.TryGetParameter(name, out var funcParamSync))
+                {
+                    _il.Emit(OpCodes.Ldloc, temp);
+                    _il.Emit(OpCodes.Starg, funcParamSync);
+                }
                 return true;
             }
 
@@ -283,6 +303,16 @@ public class LocalVariableResolver : IVariableResolver
             _il.Emit(OpCodes.Ldloc, _ctx.ArrowScopeDisplayClassLocal);
             _il.Emit(OpCodes.Ldloc, tempArrow);
             _il.Emit(OpCodes.Stfld, arrowDCFieldStore);
+            // Captured PARAMETER: also sync the arg slot. Reads resolve
+            // parameters before the scope DC, so a DC-only store would leave
+            // later same-body reads seeing the stale argument (lodash:
+            // `context = context || root; ... context.Date` read the original
+            // undefined arg after the reassignment).
+            if (_ctx.TryGetParameter(name, out var arrowParamSync))
+            {
+                _il.Emit(OpCodes.Ldloc, tempArrow);
+                _il.Emit(OpCodes.Starg, arrowParamSync);
+            }
             return true;
         }
 
@@ -313,6 +343,18 @@ public class LocalVariableResolver : IVariableResolver
                 _il.Emit(OpCodes.Stfld, storeField);
                 return true;
             }
+        }
+
+        // 1d. EXTRA ancestor arrow scope DCs — mirror of read path 2d.
+        if (_ctx.ExtraArrowScopeBindings?.TryGetValue(name, out var extraStoreBinding) == true)
+        {
+            var tempExtra = _il.DeclareLocal(_types.Object);
+            _il.Emit(OpCodes.Stloc, tempExtra);
+            _il.Emit(OpCodes.Ldarg_0);
+            _il.Emit(OpCodes.Ldfld, extraStoreBinding.RefField);
+            _il.Emit(OpCodes.Ldloc, tempExtra);
+            _il.Emit(OpCodes.Stfld, extraStoreBinding.VarField);
+            return true;
         }
 
         // 2. Locals

--- a/Compilation/RuntimeEmitter.BuiltInStaticDispatch.cs
+++ b/Compilation/RuntimeEmitter.BuiltInStaticDispatch.cs
@@ -162,7 +162,10 @@ public partial class RuntimeEmitter
         EmitObjectMethodLookup("defineProperties",        runtime.ObjectDefineProperties, 2);
         EmitObjectMethodLookup("getOwnPropertyDescriptor",  runtime.ObjectGetOwnPropertyDescriptor, 2);
         EmitObjectMethodLookup("getOwnPropertyDescriptors", runtime.ObjectGetOwnPropertyDescriptors, 1);
-        EmitObjectMethodLookup("create",                  runtime.ObjectCreate, 2);
+        // create routes through the value-form wrapper: reflection dispatch
+        // pads the missing props arg with null, which raw ObjectCreate must
+        // treat as the explicit-null TypeError case.
+        EmitObjectMethodLookup("create",                  runtime.ObjectCreateValueForm, 2);
         EmitObjectMethodLookup("assign",                  runtime.ObjectAssign, 2);
         EmitObjectMethodLookup("is",                      runtime.ObjectIs, 2);
         EmitObjectMethodLookup("hasOwn",                  runtime.ObjectHasOwn, 2);

--- a/Compilation/RuntimeEmitter.BuiltInStaticDispatch.cs
+++ b/Compilation/RuntimeEmitter.BuiltInStaticDispatch.cs
@@ -180,6 +180,15 @@ public partial class RuntimeEmitter
         EmitLookup(runtime.TSSymbolType, "for", runtime.SymbolFor, 1);
         EmitLookup(runtime.TSSymbolType, "keyFor", runtime.SymbolKeyFor, 1);
 
+        // Date.* — bare `Date` resolves to the $TSDate Type token. The static
+        // is .NET-cased ("Now"), so the case-sensitive static-method probe in
+        // GetProperty misses it; route through $Runtime.DateNow so value-form
+        // dispatch (`var nativeNow = Date.now;` — lodash's shortOut idiom)
+        // matches the syntactic Date.now() path, virtual timers included.
+        // Null when UsesDate is off — Date can't be referenced then anyway.
+        if (runtime.DateNow != null)
+            EmitLookup(runtime.TSDateType, "now", runtime.DateNow, 0);
+
         // Math.* deliberately not handled here — bare `Math` emits the null
         // pseudo-variable (not a Type token), so its value-form access goes
         // through MathStaticEmitter.TryEmitStaticPropertyGet at compile time.

--- a/Compilation/RuntimeEmitter.Objects.Invocation.cs
+++ b/Compilation/RuntimeEmitter.Objects.Invocation.cs
@@ -332,8 +332,41 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ret);
         il.MarkLabel(notSymbolTypeLabel);
 
-        // A built-in constructor Type without a call-form helper (e.g. the
-        // aliased `var f = Object; f(x)` pattern lodash uses). These ARE
+        // Object call form (`var f = Object; f(x)` — lodash's overArg ToObject
+        // coercion). ECMA-262 §20.1.1.1: undefined/null/missing → fresh plain
+        // object; everything else → ToObject. Objects pass through unchanged;
+        // primitives are returned as-is (this runtime treats primitives as
+        // their own object forms — same convention as the syntactic path).
+        var notObjectTypeLabel = il.DefineLabel();
+        var objectFreshLabel = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Castclass, _types.Type);
+        il.Emit(OpCodes.Ldtoken, _types.Object);
+        il.Emit(OpCodes.Call, _types.Type.GetMethod("GetTypeFromHandle", [_types.RuntimeTypeHandle])!);
+        il.Emit(OpCodes.Call, _types.Type.GetMethod("op_Equality", [_types.Type, _types.Type])!);
+        il.Emit(OpCodes.Brfalse, notObjectTypeLabel);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Ldlen);
+        il.Emit(OpCodes.Brfalse, objectFreshLabel);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Ldelem_Ref);
+        il.Emit(OpCodes.Brfalse, objectFreshLabel);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Ldelem_Ref);
+        il.Emit(OpCodes.Isinst, runtime.UndefinedType);
+        il.Emit(OpCodes.Brtrue, objectFreshLabel);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Ldelem_Ref);
+        il.Emit(OpCodes.Ret);
+        il.MarkLabel(objectFreshLabel);
+        il.Emit(OpCodes.Newobj, _types.DictionaryStringObjectCtor);
+        il.Emit(OpCodes.Ret);
+        il.MarkLabel(notObjectTypeLabel);
+
+        // A built-in constructor Type without a call-form helper. These ARE
         // callable in JS, so the #260 throwing fallback must not fire here;
         // unwired ones keep returning null until their call forms are wired
         // in incrementally (#61).

--- a/Compilation/RuntimeEmitter.Objects.Prototype.cs
+++ b/Compilation/RuntimeEmitter.Objects.Prototype.cs
@@ -177,6 +177,46 @@ public partial class RuntimeEmitter
         // Return result
         il.Emit(OpCodes.Ldloc, resultLocal);
         il.Emit(OpCodes.Ret);
+
+        EmitObjectCreateValueForm(typeBuilder, runtime);
+    }
+
+    /// <summary>
+    /// Emits the VALUE-FORM dispatch wrapper for Object.create. Reflection
+    /// dispatch through $TSFunction pads missing args with CLR null, which
+    /// ObjectCreate must treat as explicit JS null (TypeError per ECMA-262
+    /// §20.1.2.2 step 3 / test262 15.2.3.5-4-3). This wrapper maps a
+    /// null props slot — which through this path means ABSENT — to the
+    /// $Undefined singleton before delegating, so `var oc = Object.create;
+    /// oc(proto)` works. The syntactic call path emits the sentinel for the
+    /// missing arg itself and keeps calling ObjectCreate directly, preserving
+    /// the explicit-null throw.
+    /// </summary>
+    private void EmitObjectCreateValueForm(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    {
+        var method = typeBuilder.DefineMethod(
+            "ObjectCreateValueForm",
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.Object,
+            [_types.Object, _types.Object]
+        );
+        runtime.ObjectCreateValueForm = method;
+
+        var il = method.GetILGenerator();
+        var propsPresentLabel = il.DefineLabel();
+
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Brtrue, propsPresentLabel);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldsfld, runtime.UndefinedInstance);
+        il.Emit(OpCodes.Call, runtime.ObjectCreate);
+        il.Emit(OpCodes.Ret);
+
+        il.MarkLabel(propsPresentLabel);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Call, runtime.ObjectCreate);
+        il.Emit(OpCodes.Ret);
     }
 
     /// <summary>

--- a/Compilation/RuntimeEmitter.RuntimeClass.cs
+++ b/Compilation/RuntimeEmitter.RuntimeClass.cs
@@ -963,9 +963,6 @@ public partial class RuntimeEmitter
         // Number.prototype populate body — must come AFTER EmitNumberMethods so
         // NumberToFixed/etc. MethodBuilders are non-null.
         EmitNumberPrototypePopulate(typeBuilder, runtime);
-        // Fill in LookupBuiltInStaticMember's body now that IsArray, NumberIs*,
-        // StringFrom*, and TSFunctionCtor are all in place (#63).
-        EmitLookupBuiltInStaticMemberBody(runtime);
         // Fill in the symbol-keyed accessor registry helper bodies (#266).
         EmitSymbolAccessorRegistryBodies(runtime);
         // Microtask method (queueMicrotask) - must come before timer infrastructure so ProcessMicrotasks is available
@@ -975,6 +972,11 @@ public partial class RuntimeEmitter
         // Date methods
         if (_features.UsesDate)
             EmitDateMethods(typeBuilder, runtime);
+        // Fill in LookupBuiltInStaticMember's body now that IsArray, NumberIs*,
+        // StringFrom*, TSFunctionCtor (#63) and DateNow (value-form `Date.now`,
+        // gated on UsesDate) are all in place. Only the body is late — the
+        // MethodBuilder was defined early, so earlier emitters can call it.
+        EmitLookupBuiltInStaticMemberBody(runtime);
         // RegExp methods moved earlier — emitted before EmitStringPrototypePopulate.
         // Error methods
         EmitErrorMethods(typeBuilder, runtime);

--- a/Compilation/RuntimeEmitter.TSFunction.cs
+++ b/Compilation/RuntimeEmitter.TSFunction.cs
@@ -1518,34 +1518,13 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloc, argsLengthLocal);
         il.Emit(OpCodes.Call, _types.ArrayType.GetMethod("Copy", [_types.ArrayType, _types.ArrayType, _types.Int32])!);
 
-        // Fill the padded tail with the $Undefined singleton, matching the
-        // direct-call emitter's missing-arg convention (see EmitDefaultParameters
-        // in ILEmitter.Helpers.cs). Null padding is observably different for
-        // callees that distinguish absent/undefined from explicit null — e.g.
-        // value-form Object.create(proto) threw "Cannot convert undefined or
-        // null to object" because the padded props slot read as JS null.
-        if (runtime.UndefinedInstance != null)
-        {
-            var padLoopStart = il.DefineLabel();
-            var padLoopEnd = il.DefineLabel();
-            il.Emit(OpCodes.Ldloc, argsLengthLocal);
-            il.Emit(OpCodes.Stloc, indexLocal);
-            il.MarkLabel(padLoopStart);
-            il.Emit(OpCodes.Ldloc, indexLocal);
-            il.Emit(OpCodes.Ldloc, paramCountLocal);
-            il.Emit(OpCodes.Bge, padLoopEnd);
-            il.Emit(OpCodes.Ldloc, resultLocal);
-            il.Emit(OpCodes.Ldloc, indexLocal);
-            il.Emit(OpCodes.Ldsfld, runtime.UndefinedInstance);
-            il.Emit(OpCodes.Stelem_Ref);
-            il.Emit(OpCodes.Ldloc, indexLocal);
-            il.Emit(OpCodes.Ldc_I4_1);
-            il.Emit(OpCodes.Add);
-            il.Emit(OpCodes.Stloc, indexLocal);
-            il.Emit(OpCodes.Br, padLoopStart);
-            il.MarkLabel(padLoopEnd);
-        }
-
+        // Missing args pad as null. NOT the $Undefined singleton: emitted
+        // built-ins broadly use null-checks for optional-arg absence (stream
+        // write/end callbacks, encodings, ...), so sentinel padding makes them
+        // treat the slot as a real argument. The one built-in that must
+        // distinguish absent (skip) from explicit JS null (throw) — value-form
+        // Object.create's props — gets a dedicated wrapper instead
+        // (ObjectCreateValueForm in RuntimeEmitter.Objects.Prototype.cs).
         il.Emit(OpCodes.Ldloc, resultLocal);
         il.Emit(OpCodes.Ret);
 

--- a/Compilation/RuntimeEmitter.TSFunction.cs
+++ b/Compilation/RuntimeEmitter.TSFunction.cs
@@ -1509,7 +1509,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloc, paramCountLocal);
         il.Emit(OpCodes.Bge, needsTrimming);
 
-        // Pad with nulls: result = new object[paramCount]; Array.Copy(args, result, argsLength)
+        // Pad missing args: result = new object[paramCount]; Array.Copy(args, result, argsLength)
         il.Emit(OpCodes.Ldloc, paramCountLocal);
         il.Emit(OpCodes.Newarr, _types.Object);
         il.Emit(OpCodes.Stloc, resultLocal);
@@ -1517,6 +1517,35 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloc, resultLocal);
         il.Emit(OpCodes.Ldloc, argsLengthLocal);
         il.Emit(OpCodes.Call, _types.ArrayType.GetMethod("Copy", [_types.ArrayType, _types.ArrayType, _types.Int32])!);
+
+        // Fill the padded tail with the $Undefined singleton, matching the
+        // direct-call emitter's missing-arg convention (see EmitDefaultParameters
+        // in ILEmitter.Helpers.cs). Null padding is observably different for
+        // callees that distinguish absent/undefined from explicit null — e.g.
+        // value-form Object.create(proto) threw "Cannot convert undefined or
+        // null to object" because the padded props slot read as JS null.
+        if (runtime.UndefinedInstance != null)
+        {
+            var padLoopStart = il.DefineLabel();
+            var padLoopEnd = il.DefineLabel();
+            il.Emit(OpCodes.Ldloc, argsLengthLocal);
+            il.Emit(OpCodes.Stloc, indexLocal);
+            il.MarkLabel(padLoopStart);
+            il.Emit(OpCodes.Ldloc, indexLocal);
+            il.Emit(OpCodes.Ldloc, paramCountLocal);
+            il.Emit(OpCodes.Bge, padLoopEnd);
+            il.Emit(OpCodes.Ldloc, resultLocal);
+            il.Emit(OpCodes.Ldloc, indexLocal);
+            il.Emit(OpCodes.Ldsfld, runtime.UndefinedInstance);
+            il.Emit(OpCodes.Stelem_Ref);
+            il.Emit(OpCodes.Ldloc, indexLocal);
+            il.Emit(OpCodes.Ldc_I4_1);
+            il.Emit(OpCodes.Add);
+            il.Emit(OpCodes.Stloc, indexLocal);
+            il.Emit(OpCodes.Br, padLoopStart);
+            il.MarkLabel(padLoopEnd);
+        }
+
         il.Emit(OpCodes.Ldloc, resultLocal);
         il.Emit(OpCodes.Ret);
 

--- a/SharpTS.Tests/IntegrationTests/RealPackageSmokeTests.cs
+++ b/SharpTS.Tests/IntegrationTests/RealPackageSmokeTests.cs
@@ -503,15 +503,15 @@ public class RealPackageSmokeTests
     // value-form built-in singleton methods (e.g. `context.Math.max`) are not
     // populated in compiled mode (the Math/JSON singleton dicts hold no method
     // wrappers). #276 populated those wrappers and got init past `context.Math.max`,
-    // but compiled init still fails inside lodash's `getNative` helper
+    // but compiled init still failed inside lodash's `getNative` helper
     // ("object is not a function"). #302's original hypothesis (a value-form
-    // dispatch gap) was DISPROVEN while triaging: the true root cause (#307) is a
+    // dispatch gap) was DISPROVEN while triaging: the true root cause (#307) was a
     // closure bug — inner function declarations nested in an arrow/function-
-    // expression capture enclosing locals by snapshot (at hoist time) instead of
+    // expression captured enclosing locals by snapshot (at hoist time) instead of
     // by live reference, so `getValue` / `Object` / `symToStringTag` read back
-    // null (`typeof null === "object"` → "object is not a function"). Unskip when
-    // #307 lands.
-    [SkippableFact(Skip = "compiled lodash init fails in getNative ('object is not a function') — closure snapshot-vs-live-capture bug, see #307 (root cause of #302)")]
+    // null (`typeof null === "object"` → "object is not a function"). #307's
+    // $arrowScopeDC live-reference fix got init past that.
+    [SkippableFact]
     public void Lodash_Compiled()
     {
         SkipIfNoNpm();
@@ -525,9 +525,9 @@ public class RealPackageSmokeTests
         var (exit, output) = CompileAndRun(script);
         Assert.Equal(0, exit);
         // See Lodash_Interpreter above for rationale.
-        Assert.Equal("function", output.Split('\n')[0].Trim());
-        // Note: _.chunk and _.flatten still return wrong values in compiled
-        // mode — separate behavioral bug tracked outside #40/#59. Strengthen
-        // these assertions once that's resolved.
+        var lines = output.Split('\n').Select(l => l.Trim()).ToArray();
+        Assert.Equal("function", lines[0]);
+        Assert.Equal("[[1, 2], [3, 4]]", lines[1]);
+        Assert.Equal("[1, 2, 3, 4]", lines[2]);
     }
 }

--- a/SharpTS.Tests/SharedTests/InnerFunctionArrowCaptureTests.cs
+++ b/SharpTS.Tests/SharedTests/InnerFunctionArrowCaptureTests.cs
@@ -1,0 +1,246 @@
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests;
+
+/// <summary>
+/// Regression tests for #307: inner function declarations nested inside
+/// arrow functions / function expressions must capture enclosing locals by
+/// live reference, not by value-snapshot taken at hoist time. Function
+/// declarations hoist to the top of the enclosing body — before the
+/// statements that assign the captured variables run — so snapshots read
+/// null/stale. Compiled mode routes these captures through a live
+/// $arrowScopeDC reference to the enclosing arrow's scope display class
+/// (threaded through intermediate scopes, with extra per-source references
+/// when captures span multiple ancestor arrow scopes). Root cause of the
+/// lodash init failure (#302).
+/// </summary>
+public class InnerFunctionArrowCaptureTests
+{
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void FunctionDecl_InArrow_ReadsConstAssignedAfterHoist(ExecutionMode mode)
+    {
+        // Minimal repro from #307: bgt is hoisted before `const Obj = 42` runs.
+        var source = """
+            const ric = () => {
+              const Obj = 42;
+              function bgt() { return Obj; }
+              return bgt;
+            };
+            console.log(ric()());
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("42\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void FunctionDecl_GrandparentArrowCapture_ThroughIntermediateArrow(ExecutionMode mode)
+    {
+        var source = """
+            const outer = () => {
+              const g = "grand";
+              const mid = () => {
+                function leaf() { return g; }
+                return leaf;
+              };
+              return mid();
+            };
+            console.log(outer()());
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("grand\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void FunctionDecl_GrandparentArrowCapture_ThroughIntermediateFunctionDecl(ExecutionMode mode)
+    {
+        // The intermediate scope is a function DECLARATION: the live reference
+        // must pass through its display class ($arrowScopeDC pass-through).
+        var source = """
+            const outer = () => {
+              const g = "grand2";
+              function mid() {
+                function leaf() { return g; }
+                return leaf;
+              }
+              return mid();
+            };
+            console.log(outer()());
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("grand2\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void FunctionDecl_InArrow_MutationsVisibleBothWays(ExecutionMode mode)
+    {
+        // Writes from the arrow body must be visible inside the function
+        // declaration, and the function's writes must be visible outside.
+        var source = """
+            const outer = () => {
+              let counter = 0;
+              function bump() { counter = counter + 1; return counter; }
+              counter = 10;
+              bump();
+              bump();
+              return counter;
+            };
+            console.log(outer());
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("12\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void FunctionDecls_InFunctionExpression_PeerReferences(ExecutionMode mode)
+    {
+        // lodash idiom: hoisted peers referencing each other before their
+        // textual position, inside a function-expression wrapper.
+        var source = """
+            const outer = function() {
+              function getValue(o: any, k: string) { return o == null ? undefined : o[k]; }
+              function getNative(o: any, k: string) { const v = getValue(o, k); return v; }
+              var nativeCreate = getNative({create: 99}, 'create');
+              return nativeCreate;
+            };
+            console.log(outer());
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("99\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void FunctionDecl_HoistedBeforeVarAssignment_CalledAfter(ExecutionMode mode)
+    {
+        var source = """
+            const outer = function() {
+              var dep: any;
+              function reader() { return dep; }
+              dep = "assigned-later";
+              return reader();
+            };
+            console.log(outer());
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("assigned-later\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Closure_CapturesFromTwoAncestorArrowScopes(ExecutionMode mode)
+    {
+        // lodash shortOut shape: the returned closure captures `tag` from the
+        // OUTER wrapper and `nativeNow` from the inner function expression —
+        // two distinct ancestor arrow scopes, both assigned after the points
+        // where snapshots would have been taken. Requires the extra
+        // (multi-source) scope DC references.
+        var source = """
+            const result = (function() {
+              var tag: any;
+              var run = (function run(context: any) {
+                var nativeNow: any;
+                function shortOut(func: any) {
+                  return function() {
+                    return func(nativeNow()) + "/" + tag;
+                  };
+                }
+                var wrapped = shortOut(function(x: any) { return "v" + x; });
+                nativeNow = function() { return 7; };
+                return wrapped;
+              });
+              tag = "T";
+              return run(null)();
+            })();
+            console.log(result);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("v7/T\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void CapturedParameter_ReassignedInBody_ReadsStayCurrent(ExecutionMode mode)
+    {
+        // lodash runInContext shape: a captured parameter is reassigned at the
+        // top of the body; later reads in the SAME body must see the new value
+        // (stores go to the scope DC — the arg slot must stay in sync).
+        var source = """
+            const run = function(context: any) {
+              context = context == null ? { Date: "real" } : context;
+              var d = context.Date;
+              function reader() { return context.Date; }
+              return d + "/" + reader();
+            };
+            console.log(run(null));
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("real/real\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ValueForm_ObjectCall_Coerces(ExecutionMode mode)
+    {
+        // lodash overArg(Object.keys, Object): `Object` held as a value and
+        // invoked as a function (ToObject). Objects pass through unchanged.
+        var source = """
+            var transform: any = Object;
+            var keysFn: any = Object.keys;
+            function overArg(func: any, t: any) { return function(arg: any) { return func(t(arg)); }; }
+            var nativeKeys = overArg(keysFn, transform);
+            console.log(nativeKeys({a: 1, b: 2}).length);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("2\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ValueForm_ObjectCreate_SingleArg(ExecutionMode mode)
+    {
+        // Value-form Object.create(proto) under-application: the padded props
+        // argument must read as ABSENT/undefined, not as JS null (which throws
+        // per ECMA-262 §20.1.2.2 step 3).
+        var source = """
+            var oc: any = Object.create;
+            var p = { x: 1 };
+            var o = oc(p);
+            console.log(o.x);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("1\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ValueForm_DateNow_AsValue(ExecutionMode mode)
+    {
+        // lodash: `var nativeNow = Date.now;` then nativeNow() — value-form
+        // static member access on the Date constructor.
+        var source = """
+            var d0 = new Date();
+            var nativeNow: any = Date.now;
+            console.log(typeof nativeNow);
+            console.log(nativeNow() > 0);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("function\ntrue\n", output);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #307 — in compiled mode, an inner **function declaration** nested in an **arrow / function expression** captured enclosing locals by **value-snapshot at hoist time** (before the body statements that assign them ran), so closures read back null/stale. The interpreter was already correct. This was the true root cause of #302 (compiled lodash init dying in `getNative` with "object is not a function").

Closes #307. Closes #302 (`RealPackageSmokeTests.Lodash_Compiled` is un-skipped and now also asserts correct `chunk`/`flatten` values — compiled lodash both initializes AND computes correctly).

## Mechanism

Per the issue''s suggested fix, mirroring the existing `$arrowDC` machinery:

- **`ClosureAnalyzer` capture sources** — records which scope *defines* each captured variable, so routing is shadow-correct instead of name-matched across unrelated display classes.
- **`$arrowScopeDC` live reference** — inner functions whose captures live on an ancestor arrow''s scope DC get a reference field populated at hoist time (the reference is valid then; the DC''s variable fields fill in as the body executes). Reads/stores route through the existing parent-DC resolver paths; `ILEmitter.EmitAssign` gains the matching branches.
- **Threading through intermediates** — both grandparent sub-cases from the issue (intermediate arrow, intermediate function declaration) work: intermediate arrows are marked as needing `$arrowDC`, intermediate inner functions get a pass-through `$arrowScopeDC`, walked along the enclosing-callable chain recorded at collection time.
- **Multi-source captures** — a closure capturing from *more than one* ancestor arrow scope (lodash''s `shortOut` closure reads `nativeNow` from `runInContext` AND `HOT_SPAN`/`HOT_COUNT` from the outer IIFE) gets one **extra** reference field per additional source, with per-name `ExtraArrowScopeBindings` resolution. The single primary slot binds the **nearest** ancestor.
- **`PropagateArrowDCRequirements`** detection is now analyzer-driven and ancestor-restricted (previously: first name match in arbitrary dictionary-enumeration order — an aliasing bug class this codebase has hit before).
- **Captured-parameter store sync** — stores to captured params now also update the arg slot; reads resolve params before the scope DC, so DC-only stores left same-body reads stale (lodash''s `context = context || root; ... context.Date` read the original padded arg).
- **Prologue ordering** — captured params are copied into scope/function DCs *after* default-parameter application (both arrow and top-level function bodies), so closures observe defaulted values.

## Value-form built-in gaps unmasked by lodash init

Each verified with a minimal repro, both modes:

- **Value-form `Object.create(proto)`** under-application threw "Cannot convert undefined or null to object": reflection dispatch pads missing args with null, which raw `ObjectCreate` must treat as the explicit-null TypeError (test262 15.2.3.5-4-3). A dedicated `ObjectCreateValueForm` wrapper maps the padded-null props slot to `$Undefined`; both lookup tables reference it so wrapper identity holds across access forms. (A first attempt padded `$Undefined` from `AdjustArgs` directly — reverted: emitted built-ins broadly use null-checks for optional-arg absence, and the string-coercion helper stringified the sentinel into a literal `"undefined"` for defaulted string params.)
- **Value-form `Date.now`** (`var nativeNow = Date.now`) resolved to undefined — added to `LookupBuiltInStaticMember` (whose body emission moved after `EmitDateMethods`; only the body is late, the MethodBuilder was always defined early).
- **`Object` called as a function** (`overArg(Object.keys, Object)`) returned null silently — wired ECMA-262 §20.1.1.1 ToObject semantics into the Type-callee dispatch (the documented unwired case from #61).

## Tests

- New `InnerFunctionArrowCaptureTests` (11 theories × interp/compiled): minimal repro, both grandparent threading sub-cases, bidirectional mutation visibility, hoisted peer references, captured-param reassignment, multi-ancestor-scope captures, and the three value-form repros.
- `Lodash_Compiled` un-skipped with strengthened assertions.
- Full suite: **10,957 passed, 0 failed, 0 skipped**. IL verification passes on all repro compilations.

## Follow-ups filed

- #313 — sibling closures capturing an inner function''s mutable local don''t share storage (inner function declarations have no scope DC of their own; same family, distinct mechanism, discovered while validating this fix).
- #314 — built-in constructor Type tokens mis-tag in toString-tag dispatch (`lodash isFunction(Object)` is false; benign for lodash via its host-ctor path).

## Known residual limitation

Sources whose chains can''t be threaded (async-arrow intermediates, class-method boundaries) keep snapshot semantics — same behavior as before this PR, now confined to those shapes.