### PR TITLE
fix(types): `infer U extends C` constraints + speculative parser lookahead (#226)

### DIFF
--- a/Parsing/Parser.Types.cs
+++ b/Parsing/Parser.Types.cs
@@ -15,6 +15,17 @@ public partial class Parser
     /// </summary>
     private TypeNode? _lastTypeNode;
 
+    /// <summary>
+    /// True while parsing a position where conditional types are not allowed: the extends clause
+    /// of a conditional type and the constraint of an <c>infer</c> declaration (tsc's
+    /// DisallowConditionalTypes context). Read by the <c>infer ... extends</c> disambiguation:
+    /// in an allow-conditionals context, `infer U extends T ?` re-parses with `extends` starting a
+    /// conditional type instead of a constraint. Bracketed sub-positions (grouped types, tuple
+    /// elements, object members, mapped-type clauses, type arguments) re-allow conditionals by
+    /// re-entering <see cref="ParseConditionalType"/>, which saves/clears/restores the flag.
+    /// </summary>
+    private bool _disallowConditionalTypes;
+
     /// <summary>Reads and clears the node for the most recent type-parse call.</summary>
     private TypeNode? TakeTypeNode()
     {
@@ -214,6 +225,23 @@ public partial class Parser
     /// </summary>
     private string ParseConditionalType()
     {
+        // Entering a full-type position re-allows conditional types (tsc: parseType resets the
+        // DisallowConditionalTypes context). Restored before every return so an enclosing extends
+        // clause keeps its disallow state after a bracketed sub-parse.
+        bool savedDisallow = _disallowConditionalTypes;
+        _disallowConditionalTypes = false;
+        try
+        {
+            return ParseConditionalTypeCore();
+        }
+        finally
+        {
+            _disallowConditionalTypes = savedDisallow;
+        }
+    }
+
+    private string ParseConditionalTypeCore()
+    {
         string checkType = ParseUnionType();
         TypeNode? checkNode = TakeTypeNode();
 
@@ -231,8 +259,12 @@ public partial class Parser
 
         int conditionalLine = Previous().Line;
 
-        // Parse the extends type (which may contain 'infer' keywords)
+        // Parse the extends type (which may contain 'infer' keywords). Conditional types are
+        // not allowed directly in an extends clause, which is what lets `infer U extends C`
+        // keep its constraint here (X13-style) while re-allowing inside brackets.
+        _disallowConditionalTypes = true;
         string extendsType = ParseUnionType();
+        _disallowConditionalTypes = false;
         TypeNode? extendsNode = TakeTypeNode();
 
         // Must have '?' for this to be a conditional type
@@ -354,15 +386,33 @@ public partial class Parser
         if (Match(TokenType.INFER))
         {
             Token paramName = Consume(TokenType.IDENTIFIER, "Expect type parameter name after 'infer'.");
-            if (Match(TokenType.EXTENDS))
+            if (Check(TokenType.EXTENDS))
             {
-                // Constraint binds tighter than the enclosing conditional's `?`, so stop at union level.
+                int savedPos = _current;
+                bool outerDisallow = _disallowConditionalTypes;
+                Advance(); // consume 'extends'
+                // The constraint itself never contains a top-level conditional (tsc parses it in a
+                // DisallowConditionalTypes context); union level is the ceiling.
+                _disallowConditionalTypes = true;
                 string constraint = ParseUnionType();
-                TakeTypeNode(); // drain the constraint's side-channel node
-                // Mirror the string path exactly: the whole "U extends C" becomes the inferred
-                // parameter's name (the checker's InferredTypeParameter has no separate constraint).
-                _lastTypeNode = new InferTypeNode($"{paramName.Lexeme} extends {constraint}", paramName.Line);
-                return $"infer {paramName.Lexeme} extends {constraint}";
+                TypeNode? constraintNode = TakeTypeNode();
+                _disallowConditionalTypes = outerDisallow;
+                if (!outerDisallow && Check(TokenType.QUESTION))
+                {
+                    // `infer U extends T ?` where conditional types are allowed: the `extends`
+                    // starts a conditional type whose check type is the bare `infer U`, not a
+                    // constraint (tsc's speculative lookahead). Backtrack to before 'extends'.
+                    _current = savedPos;
+                }
+                else
+                {
+                    // Node requires the constraint node; a constraint without node support drops
+                    // the whole infer to the string path rather than losing the constraint.
+                    _lastTypeNode = constraintNode is not null
+                        ? new InferTypeNode(paramName.Lexeme, paramName.Line, constraintNode)
+                        : null;
+                    return $"infer {paramName.Lexeme} extends {constraint}";
+                }
             }
             _lastTypeNode = new InferTypeNode(paramName.Lexeme, paramName.Line);
             return $"infer {paramName.Lexeme}";

--- a/Parsing/TypeNodes.cs
+++ b/Parsing/TypeNodes.cs
@@ -59,10 +59,11 @@ public sealed record IndexedAccessTypeNode(TypeNode ObjectType, TypeNode IndexTy
 /// path-independent.</summary>
 public sealed record ConditionalTypeNode(TypeNode CheckType, TypeNode ExtendsType, TypeNode TrueType, TypeNode FalseType, int Line) : TypeNode(Line);
 
-/// <summary>An <c>infer U</c> placeholder inside a conditional's extends clause. Resolves to
-/// <c>TypeInfo.InferredTypeParameter</c>. Constrained infer (<c>infer U extends C</c>) has no
-/// node yet and falls back to the string path.</summary>
-public sealed record InferTypeNode(string Name, int Line) : TypeNode(Line);
+/// <summary>An <c>infer U</c> placeholder inside a conditional's extends clause, optionally
+/// constrained (<c>infer U extends C</c>). Resolves to <c>TypeInfo.InferredTypeParameter</c>;
+/// the constraint gates the match in <c>EvaluateConditionalType</c> (an inferred type that does
+/// not satisfy it sends the conditional to its false branch).</summary>
+public sealed record InferTypeNode(string Name, int Line, TypeNode? Constraint = null) : TypeNode(Line);
 
 /// <summary>A <c>typeof entity</c> query. The entity path is carried in its string-path spelling
 /// (<c>obj.prop</c>, <c>arr[0]</c>) and resolved by <c>EvaluateTypeOf</c> — the same evaluator the

--- a/SharpTS.Tests/TypeCheckerTests/InferConstraintTests.cs
+++ b/SharpTS.Tests/TypeCheckerTests/InferConstraintTests.cs
@@ -1,0 +1,126 @@
+using SharpTS.Tests.Infrastructure;
+using SharpTS.TypeSystem.Exceptions;
+using Xunit;
+
+namespace SharpTS.Tests.TypeCheckerTests;
+
+/// <summary>
+/// `infer U extends C` constraints (TS 4.7) from the #226 cluster: the constraint gates the
+/// conditional's match, repeated same-named infers union their candidates, and the parser's
+/// speculative lookahead re-reads `infer U extends T ?` as a conditional type where conditional
+/// types are allowed. Declaration-site rules: TS2838 (non-identical constraints) and TS2304
+/// (constraint referencing a sibling infer).
+/// </summary>
+public class InferConstraintTests
+{
+    [Fact]
+    public void InferConstraint_Satisfied_TakesTrueBranch()
+    {
+        var source = """
+            type First<T> = T extends [infer U extends string] ? U : "fell-through";
+            let x: First<["a"]> = "a";
+            """;
+        TestHarness.RunInterpreted(source);
+    }
+
+    [Fact]
+    public void InferConstraint_Violated_TakesFalseBranch()
+    {
+        var source = """
+            type First<T> = T extends [infer U extends string] ? U : "fell-through";
+            let x: First<[1]> = "fell-through";
+            """;
+        TestHarness.RunInterpreted(source);
+    }
+
+    [Fact]
+    public void RepeatedInfer_UnionsCandidates()
+    {
+        var source = """
+            type Both<T> = T extends { a: infer U, b: infer U } ? U : never;
+            let x: Both<{ a: string, b: number }> = 1;
+            let y: Both<{ a: string, b: number }> = "s";
+            """;
+        TestHarness.RunInterpreted(source);
+    }
+
+    [Fact]
+    public void RepeatedInfer_ConstraintAppliesToMergedUnion()
+    {
+        // The constraint on one declaration governs the merged inference: "a" | 1 fails
+        // `extends string`, so the conditional takes its false branch.
+        var source = """
+            type Q<T> = T extends { a: infer U extends string, b: infer U } ? U : "no";
+            let x: Q<{ a: "a", b: 1 }> = "no";
+            let y: Q<{ a: "a", b: "b" }> = "a";
+            """;
+        TestHarness.RunInterpreted(source);
+    }
+
+    [Fact]
+    public void InferExtendsFollowedByQuestion_ParsesAsConditional_WhereAllowed()
+    {
+        // Inside parentheses conditional types are allowed, so `infer U extends number ? 1 : 0`
+        // is a conditional whose check type is the bare `infer U` (tsc speculative lookahead) —
+        // with constraint parsing this line would be a parse error ("Expect ')'"). The unbound
+        // inner infer resolves the inner conditional to 0, so the outer match is false (as tsc).
+        var source = """
+            type X10<T> = T extends (infer U extends number ? 1 : 0) ? "matched" : "not";
+            let x: X10<5> = "not";
+            """;
+        TestHarness.RunInterpreted(source);
+    }
+
+    [Fact]
+    public void InferExtendsFollowedByQuestion_KeepsConstraint_InExtendsClause()
+    {
+        // Directly in an extends clause conditional types are NOT allowed, so the `extends`
+        // binds to the infer as a constraint and the `?` belongs to the outer conditional.
+        var source = """
+            type X13<T> = T extends infer U extends number ? U : "no";
+            let x: X13<5> = 5;
+            let y: X13<"s"> = "no";
+            """;
+        TestHarness.RunInterpreted(source);
+    }
+
+    [Fact]
+    public void SameInfer_DifferentConstraints_IsTS2838()
+    {
+        var source = """
+            type X1<T> = T extends { a: infer U extends string, b: infer U extends number } ? U : never;
+            """;
+        var ex = Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+        Assert.Contains("identical constraints", ex.Message);
+    }
+
+    [Fact]
+    public void SameInfer_OneMissingConstraint_IsNotAnError()
+    {
+        var source = """
+            type X8<T> = T extends { a: infer U extends string, b: infer U } ? U : never;
+            type X9<T> = T extends { a: infer U, b: infer U extends string } ? U : never;
+            """;
+        TestHarness.RunInterpreted(source);
+    }
+
+    [Fact]
+    public void ConstraintReferencingSiblingInfer_IsTS2304()
+    {
+        var source = """
+            type X2<T> = T extends { a: infer U, b: infer V extends U } ? [U, V] : never;
+            """;
+        var ex = Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+        Assert.Contains("Cannot find name 'U'", ex.Message);
+    }
+
+    [Fact]
+    public void ConstraintReferencingOuterTypeParameter_IsNotAnError()
+    {
+        // A name that is also an outer type parameter resolves to the outer declaration.
+        var source = """
+            type Pick2<U, T> = T extends { a: infer V extends U } ? V : never;
+            """;
+        TestHarness.RunInterpreted(source);
+    }
+}

--- a/SharpTS.TypeScriptConformance/baselines/interpreted.txt
+++ b/SharpTS.TypeScriptConformance/baselines/interpreted.txt
@@ -5,8 +5,8 @@ tests/cases/conformance/types/conditional/conditionalTypesExcessProperties.ts Pa
 tests/cases/conformance/types/conditional/inferTypes1.ts Fail
 tests/cases/conformance/types/conditional/inferTypes2.ts Pass
 tests/cases/conformance/types/conditional/inferTypesInvalidExtendsDeclaration.ts Skipped:lib-drift
-tests/cases/conformance/types/conditional/inferTypesWithExtends1.ts ParseError
-tests/cases/conformance/types/conditional/inferTypesWithExtends2.ts Fail
+tests/cases/conformance/types/conditional/inferTypesWithExtends1.ts Pass
+tests/cases/conformance/types/conditional/inferTypesWithExtends2.ts Pass
 tests/cases/conformance/types/conditional/variance.ts Pass
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/anyAssignabilityInInheritance.ts Pass
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/anyAssignableToEveryType.ts Pass

--- a/TypeSystem/TypeChecker.Generics.Conditional.cs
+++ b/TypeSystem/TypeChecker.Generics.Conditional.cs
@@ -95,6 +95,13 @@ public partial class TypeChecker
             // Perform the extends check with infer pattern matching
             var (matches, inferredTypes) = CheckExtendsWithInfer(checkType, extendsType);
 
+            // `infer U extends C`: the final inferred type (after all candidate sites unioned)
+            // must satisfy the constraint, or the conditional resolves to its false branch.
+            // Checked after matching, not per binding site, so `{ a: infer U extends string,
+            // b: infer U }` applies the constraint to the merged inference (tsc semantics).
+            if (matches)
+                matches = InferConstraintsSatisfied(extendsType, inferredTypes);
+
             // Merge inferred types into substitutions
             var newSubstitutions = new Dictionary<string, TypeInfo>(substitutions);
             foreach (var (name, type) in inferredTypes)
@@ -161,7 +168,11 @@ public partial class TypeChecker
                     SubstituteWithoutConditionalEval(cond.TrueType, substitutions),
                     SubstituteWithoutConditionalEval(cond.FalseType, substitutions)),
             TypeInfo.InferredTypeParameter infer =>
-                substitutions.TryGetValue(infer.Name, out var inferSub) ? inferSub : type,
+                substitutions.TryGetValue(infer.Name, out var inferSub)
+                    ? inferSub
+                    : infer.Constraint is { } inferConstraint
+                        ? infer with { Constraint = SubstituteWithoutConditionalEval(inferConstraint, substitutions) }
+                        : type,
             _ => type
         };
     }
@@ -293,6 +304,77 @@ public partial class TypeChecker
     }
 
     /// <summary>
+    /// Verifies every constrained <c>infer</c> declaration in an extends clause against its final
+    /// inferred binding. Unbound infers are not failures (the structural match decides those).
+    /// </summary>
+    private bool InferConstraintsSatisfied(TypeInfo extendsType, Dictionary<string, TypeInfo> inferredTypes)
+    {
+        List<TypeInfo.InferredTypeParameter>? constrained = null;
+        CollectConstrainedInfers(extendsType, ref constrained);
+        if (constrained is null) return true;
+        foreach (var infer in constrained)
+        {
+            if (inferredTypes.TryGetValue(infer.Name, out var bound) && !IsCompatible(infer.Constraint!, bound))
+                return false;
+        }
+        return true;
+    }
+
+    /// <summary>
+    /// Walks the extends-clause type for constrained infer declarations. Mirrors the shapes
+    /// <see cref="CheckExtendsRecursive"/> descends into; nested conditional types are their own
+    /// inference scope, so descent stops there (their constraints are checked when they evaluate).
+    /// </summary>
+    private static void CollectConstrainedInfers(TypeInfo type, ref List<TypeInfo.InferredTypeParameter>? result)
+    {
+        switch (type)
+        {
+            case TypeInfo.InferredTypeParameter { Constraint: not null } infer:
+                (result ??= []).Add(infer);
+                break;
+            case TypeInfo.Array arr:
+                CollectConstrainedInfers(arr.ElementType, ref result);
+                break;
+            case TypeInfo.Promise promise:
+                CollectConstrainedInfers(promise.ValueType, ref result);
+                break;
+            case TypeInfo.Function func:
+                foreach (var p in func.ParamTypes) CollectConstrainedInfers(p, ref result);
+                CollectConstrainedInfers(func.ReturnType, ref result);
+                break;
+            case TypeInfo.Tuple tuple:
+                foreach (var elem in tuple.Elements) CollectConstrainedInfers(elem.Type, ref result);
+                if (tuple.RestElementType is { } rest) CollectConstrainedInfers(rest, ref result);
+                break;
+            case TypeInfo.Union union:
+                foreach (var t in union.Types) CollectConstrainedInfers(t, ref result);
+                break;
+            case TypeInfo.Intersection intersection:
+                foreach (var t in intersection.Types) CollectConstrainedInfers(t, ref result);
+                break;
+            case TypeInfo.Record rec:
+                foreach (var (_, t) in rec.Fields) CollectConstrainedInfers(t, ref result);
+                break;
+            case TypeInfo.Interface itf:
+                foreach (var (_, t) in itf.Members) CollectConstrainedInfers(t, ref result);
+                break;
+            case TypeInfo.InstantiatedGeneric ig:
+                foreach (var t in ig.TypeArguments) CollectConstrainedInfers(t, ref result);
+                break;
+            case TypeInfo.KeyOf keyOf:
+                CollectConstrainedInfers(keyOf.SourceType, ref result);
+                break;
+            case TypeInfo.IndexedAccess ia:
+                CollectConstrainedInfers(ia.ObjectType, ref result);
+                CollectConstrainedInfers(ia.IndexType, ref result);
+                break;
+            case TypeInfo.TemplateLiteralType tl:
+                foreach (var t in tl.InterpolatedTypes) CollectConstrainedInfers(t, ref result);
+                break;
+        }
+    }
+
+    /// <summary>
     /// Recursively checks the extends relationship, extracting infer bindings.
     /// </summary>
     private bool CheckExtendsRecursive(
@@ -305,8 +387,11 @@ public partial class TypeChecker
         {
             if (inferredTypes.TryGetValue(inferParam.Name, out var existing))
             {
-                // Already inferred - check consistency
-                return IsCompatible(existing, checkType) || IsCompatible(checkType, existing);
+                // Multiple declarations of the same infer name accumulate a union (tsc unions
+                // covariant inference candidates: `{ a: infer U, b: infer U }` infers a | b).
+                // Constraint satisfaction is checked against the final union after the match.
+                inferredTypes[inferParam.Name] = CreateUnion(existing, checkType);
+                return true;
             }
             inferredTypes[inferParam.Name] = checkType;
             return true;

--- a/TypeSystem/TypeChecker.Generics.Substitution.cs
+++ b/TypeSystem/TypeChecker.Generics.Substitution.cs
@@ -86,9 +86,14 @@ public partial class TypeChecker
             // Conditional types: evaluate with current substitutions
             TypeInfo.ConditionalType cond =>
                 EvaluateConditionalType(cond, substitutions),
-            // Inferred type parameters: substitute if bound, else keep as-is
+            // Inferred type parameters: substitute if bound, else keep as-is (substituting any
+            // outer type parameters referenced by the constraint)
             TypeInfo.InferredTypeParameter infer =>
-                substitutions.TryGetValue(infer.Name, out var inferSub) ? inferSub : type,
+                substitutions.TryGetValue(infer.Name, out var inferSub)
+                    ? inferSub
+                    : infer.Constraint is { } inferConstraint
+                        ? infer with { Constraint = Substitute(inferConstraint, substitutions) }
+                        : type,
             // Recursive type alias: substitute type arguments if present
             TypeInfo.RecursiveTypeAlias rta =>
                 rta.TypeArguments is { Count: > 0 }

--- a/TypeSystem/TypeChecker.Statements.cs
+++ b/TypeSystem/TypeChecker.Statements.cs
@@ -100,6 +100,10 @@ public partial class TypeChecker
         {
             _environment.DefineTypeAlias(stmt.Name.Lexeme, stmt.TypeDefinition);
         }
+        // After defining (so the alias stays usable even when a clause is malformed): validate
+        // the infer declarations of every conditional type in the alias body.
+        var outerTypeParams = stmt.TypeParameters?.Select(tp => tp.Name.Lexeme).ToHashSet(StringComparer.Ordinal);
+        ValidateInferDeclarations(stmt.TypeDefinitionNode, outerTypeParams);
         return VoidResult.Instance;
     }
 
@@ -1000,6 +1004,178 @@ public partial class TypeChecker
                          ifStmt.ElseBranch != null && AlwaysTerminates(ifStmt.ElseBranch),
         _ => false
     };
+
+    /// <summary>
+    /// Validates the <c>infer</c> declarations of every conditional type in a type node tree:
+    /// all declarations of one infer name within an extends clause must have identical constraints
+    /// (TS2838; declarations without a constraint are exempt), and an infer constraint cannot
+    /// reference other infer parameters declared in the same extends clause (TS2304 — they are not
+    /// in scope there). No-op when the annotation has no node (string fallback).
+    /// </summary>
+    private void ValidateInferDeclarations(TypeNode? node, HashSet<string>? outerTypeParams)
+    {
+        if (node is null) return;
+        if (node is ConditionalTypeNode conditional)
+            ValidateInferClauseOf(conditional, outerTypeParams);
+        foreach (var child in TypeNodeChildren(node))
+            ValidateInferDeclarations(child, outerTypeParams);
+    }
+
+    private void ValidateInferClauseOf(ConditionalTypeNode conditional, HashSet<string>? outerTypeParams)
+    {
+        List<InferTypeNode>? infers = null;
+        CollectClauseInfers(conditional.ExtendsType, ref infers);
+        if (infers is null) return;
+
+        // TS2838: among same-named declarations, every *constrained* one must agree.
+        foreach (var group in infers.GroupBy(i => i.Name))
+        {
+            TypeInfo? first = null;
+            foreach (var decl in group)
+            {
+                if (decl.Constraint is null) continue;
+                var constraint = TryToTypeInfo(decl.Constraint);
+                if (constraint is null) continue; // unresolvable constraint — don't guess
+                if (first is null)
+                {
+                    first = constraint;
+                }
+                else if (!TypeInfoEqualityComparer.Instance.Equals(first, constraint))
+                {
+                    throw new TypeCheckException(
+                        $"All declarations of '{group.Key}' must have identical constraints.",
+                        decl.Line, tsCode: "TS2838");
+                }
+            }
+        }
+
+        // TS2304: sibling infer parameters are not in scope inside a constraint. A name that is
+        // also an outer type parameter resolves to the outer declaration instead — no error.
+        var clauseNames = infers.Select(i => i.Name).ToHashSet(StringComparer.Ordinal);
+        if (outerTypeParams is not null)
+            clauseNames.ExceptWith(outerTypeParams);
+        foreach (var decl in infers)
+        {
+            if (decl.Constraint is { } constraintNode &&
+                FindReferenceTo(constraintNode, clauseNames) is { } reference)
+            {
+                throw new TypeCheckException(
+                    $"Cannot find name '{reference.Name}'.", reference.Line, tsCode: "TS2304");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Collects the infer declarations belonging to one extends clause. Nested conditional types
+    /// are their own inference scope, so descent stops at them.
+    /// </summary>
+    private static void CollectClauseInfers(TypeNode node, ref List<InferTypeNode>? result)
+    {
+        if (node is ConditionalTypeNode) return;
+        if (node is InferTypeNode infer)
+            (result ??= []).Add(infer);
+        foreach (var child in TypeNodeChildren(node))
+            CollectClauseInfers(child, ref result);
+    }
+
+    /// <summary>
+    /// Finds the first bare type reference to one of <paramref name="names"/> inside a constraint
+    /// (stopping at nested conditional scopes), or null.
+    /// </summary>
+    private static NamedTypeNode? FindReferenceTo(TypeNode node, HashSet<string> names)
+    {
+        if (node is ConditionalTypeNode) return null;
+        if (node is NamedTypeNode named && named.TypeArguments is null && names.Contains(named.Name))
+            return named;
+        foreach (var child in TypeNodeChildren(node))
+        {
+            if (FindReferenceTo(child, names) is { } found)
+                return found;
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Enumerates the direct child type nodes of a node, across every node shape.
+    /// </summary>
+    private static IEnumerable<TypeNode> TypeNodeChildren(TypeNode node)
+    {
+        switch (node)
+        {
+            case NamedTypeNode { TypeArguments: { } args }:
+                foreach (var a in args) yield return a;
+                break;
+            case ReadonlyTypeNode r:
+                yield return r.Inner;
+                break;
+            case TypePredicateNode p:
+                yield return p.PredicateType;
+                break;
+            case ArrayTypeNode a:
+                yield return a.ElementType;
+                break;
+            case UnionTypeNode u:
+                foreach (var m in u.Members) yield return m;
+                break;
+            case IntersectionTypeNode i:
+                foreach (var m in i.Members) yield return m;
+                break;
+            case KeyofTypeNode k:
+                yield return k.Operand;
+                break;
+            case IndexedAccessTypeNode ia:
+                yield return ia.ObjectType;
+                yield return ia.IndexType;
+                break;
+            case ConditionalTypeNode c:
+                yield return c.CheckType;
+                yield return c.ExtendsType;
+                yield return c.TrueType;
+                yield return c.FalseType;
+                break;
+            case InferTypeNode { Constraint: { } constraint }:
+                yield return constraint;
+                break;
+            case FunctionTypeNode f:
+                if (f.ThisType is { } thisType) yield return thisType;
+                foreach (var param in f.Parameters) yield return param.Type;
+                yield return f.ReturnType;
+                break;
+            case ConstructorTypeNode ct:
+                foreach (var param in ct.Parameters) yield return param.Type;
+                yield return ct.ReturnType;
+                break;
+            case GenericConstructorTypeNode gc:
+                yield return gc.Body;
+                break;
+            case GenericFunctionTypeNode gf:
+                yield return gf.Body;
+                break;
+            case TemplateLiteralTypeNode tl:
+                foreach (var t in tl.InterpolatedTypes) yield return t;
+                break;
+            case ObjectTypeNode o:
+                foreach (var member in o.Members)
+                {
+                    switch (member)
+                    {
+                        case PropertyMemberNode prop: yield return prop.Type; break;
+                        case IndexSignatureNode idx: yield return idx.ValueType; break;
+                        case CallSignatureMemberNode call: yield return call.Signature; break;
+                        case ConstructSignatureMemberNode ctor: yield return ctor.Signature; break;
+                    }
+                }
+                break;
+            case MappedTypeNode m:
+                yield return m.Constraint;
+                yield return m.ValueType;
+                if (m.AsClause is { } asClause) yield return asClause;
+                break;
+            case TupleTypeNode tu:
+                foreach (var elem in tu.Elements) yield return elem.Type;
+                break;
+        }
+    }
 
     /// <summary>
     /// Validates that any spread elements in a type alias definition reference type parameters

--- a/TypeSystem/TypeChecker.TypeNodes.cs
+++ b/TypeSystem/TypeChecker.TypeNodes.cs
@@ -116,7 +116,11 @@ public partial class TypeChecker
             }
 
             case InferTypeNode infer:
-                return new TypeInfo.InferredTypeParameter(infer.Name);
+                if (infer.Constraint is null)
+                    return new TypeInfo.InferredTypeParameter(infer.Name);
+                return TryToTypeInfo(infer.Constraint) is { } inferConstraint
+                    ? new TypeInfo.InferredTypeParameter(infer.Name, inferConstraint)
+                    : null;
 
             // `readonly T[]` / `readonly [A, B]` — mark the resolved array/tuple readonly; any other
             // inner type ignores the modifier (mirrors ToTypeInfoCore's readonly branch).

--- a/TypeSystem/TypeChecker.TypeParsing.cs
+++ b/TypeSystem/TypeChecker.TypeParsing.cs
@@ -158,10 +158,16 @@ public partial class TypeChecker
             return new TypeInfo.KeyOf(innerType);
         }
 
-        // Handle infer keyword for conditional types: "infer U"
+        // Handle infer keyword for conditional types: "infer U" or "infer U extends C"
         if (typeName.StartsWith("infer "))
         {
             string paramName = typeName[6..].Trim();
+            int extendsIdx = paramName.IndexOf(" extends ", StringComparison.Ordinal);
+            if (extendsIdx > 0 && IsValidIdentifier(paramName[..extendsIdx]))
+            {
+                TypeInfo constraint = ToTypeInfo(paramName[(extendsIdx + 9)..].Trim());
+                return new TypeInfo.InferredTypeParameter(paramName[..extendsIdx], constraint);
+            }
             return new TypeInfo.InferredTypeParameter(paramName);
         }
 

--- a/TypeSystem/TypeInfo.cs
+++ b/TypeSystem/TypeInfo.cs
@@ -1473,9 +1473,14 @@ public abstract record TypeInfo
     /// Used for pattern matching: T extends Array&lt;infer U&gt; ? U : T
     /// </summary>
     /// <param name="Name">The name of the inferred type parameter (e.g., "U")</param>
-    public record InferredTypeParameter(string Name) : TypeInfo
+    /// <param name="Constraint">Optional constraint (<c>infer U extends C</c>): after a structural
+    /// match, the inferred type must satisfy it or the conditional takes its false branch.</param>
+    public record InferredTypeParameter(string Name, TypeInfo? Constraint = null) : TypeInfo
     {
-        public override string ToString() => $"infer {Name}";
+        // Constraint must participate in ToString: CacheKey/TypeInfoEqualityComparer compare via
+        // ToString, and `infer U extends string` vs `infer U extends number` must not collide.
+        public override string ToString() =>
+            Constraint is null ? $"infer {Name}" : $"infer {Name} extends {Constraint}";
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

Implements the TS 4.7 `infer U extends C` feature properly — the next #226 cluster. Flips **inferTypesWithExtends1** (ParseError -> Pass) and **inferTypesWithExtends2** (Fail -> Pass); conformance subset now **75 Pass / 4 Fail** (remaining: conditionalTypes1/2, inferTypes1, stringIndexer3).

## Parser

- New `DisallowConditionalTypes` context flag (tsc parity): set while parsing a conditional's extends clause and an infer constraint; cleared on re-entry to `ParseConditionalType`, which is how every bracketed position (groups, tuple elements, object members, mapped-type clauses) re-allows conditionals.
- Speculative lookahead: `infer U extends T ?` in an allow-conditionals context backtracks and re-parses with `extends` starting a conditional type (the X10-X18 forms in inferTypesWithExtends1, previously a hard ParseError); in an extends clause the constraint is kept and the `?` belongs to the outer conditional (X13/X14).
- Tech-debt removal: `InferTypeNode` now carries the constraint as a real `TypeNode`; previously the parser smuggled `"U extends C"` into the *name*, so the checker's `InferredTypeParameter` bound under a garbage key and the true branch never resolved.

## Checker

- `TypeInfo.InferredTypeParameter` gains `Constraint` (included in `ToString` — `CacheKey`/equality must not collide across different constraints).
- After a structural match, every constrained infer's **final** inferred type must satisfy its constraint or the conditional takes the false branch. Checked post-merge, so `{ a: infer U extends string, b: infer U }` applies the constraint to the merged inference (tsc semantics).
- Repeated same-named infer declarations now **union** their candidates (`{ a: infer U, b: infer U }` infers `a | b`) instead of failing the match on inconsistency.
- Both substitution paths substitute outer type parameters referenced inside a pending infer's constraint.
- Declaration-site validation on type aliases (node path; string-fallback aliases are a no-op):
  - **TS2838** "All declarations of 'U' must have identical constraints" — unconstrained declarations exempt (X8/X9 stay clean).
  - **TS2304** "Cannot find name 'U'" — an infer constraint cannot reference a sibling infer from the same extends clause; names that are also outer type parameters resolve outward and stay legal.

## Testing

- `SharpTS.Tests`: new `InferConstraintTests` (10 tests) covering constraint gating, union accumulation, merged-constraint behavior, both lookahead directions, TS2838/TS2304, and the outer-type-param exemption.
- Full suite: 10956 passed / 0 failed.
- TS conformance: baseline regenerated, suite green.

## Follow-up filed

- #316 — construct-signature infer (`new (...) => infer U`) never binds; noticed while verifying X4.