### PR TITLE
fix(interp): in-flight fs.promises I/O must keep the event loop alive

### DIFF
--- a/Runtime/BuiltIns/BuiltInAsyncMethod.cs
+++ b/Runtime/BuiltIns/BuiltInAsyncMethod.cs
@@ -32,6 +32,7 @@ public class BuiltInAsyncMethod : ISharpTSCallable, ISharpTSAsyncCallable
     private readonly int _maxArity;
     private readonly Func<Interpreter, object?, List<object?>, Task<object?>> _implementation;
     private readonly Func<Interpreter, Task<object?>, SharpTSPromise>? _promiseFactory;
+    private readonly bool _refsEventLoopWhileInFlight;
     private object? _receiver;
 
     // Cache for bound methods - uses weak references to avoid memory leaks
@@ -49,18 +50,28 @@ public class BuiltInAsyncMethod : ISharpTSCallable, ISharpTSAsyncCallable
     /// promises (then/catch/finally results, inherited statics) come out as
     /// subclass instances; null means a plain <see cref="SharpTSPromise"/>.
     /// </param>
+    /// <param name="refsEventLoopWhileInFlight">
+    /// True for built-ins whose task is real native I/O that always completes (fs, dns, …):
+    /// the in-flight task Refs the event loop so the quiescence heuristics cannot abandon a
+    /// program whose only pending work is that I/O (the promise-API counterpart of the
+    /// callback-API Ref convention from #205). Must stay false for state promises that may
+    /// legitimately never settle (reader.closed, pipeline of an unfinished stream, then-
+    /// chaining) — those would otherwise hold the loop open forever.
+    /// </param>
     public BuiltInAsyncMethod(
         string name,
         int minArity,
         int maxArity,
         Func<Interpreter, object?, List<object?>, Task<object?>> implementation,
-        Func<Interpreter, Task<object?>, SharpTSPromise>? promiseFactory = null)
+        Func<Interpreter, Task<object?>, SharpTSPromise>? promiseFactory = null,
+        bool refsEventLoopWhileInFlight = false)
     {
         _name = name;
         _minArity = minArity;
         _maxArity = maxArity;
         _implementation = implementation;
         _promiseFactory = promiseFactory;
+        _refsEventLoopWhileInFlight = refsEventLoopWhileInFlight;
     }
 
     // Private constructor for creating bound instances
@@ -70,6 +81,7 @@ public class BuiltInAsyncMethod : ISharpTSCallable, ISharpTSAsyncCallable
         int maxArity,
         Func<Interpreter, object?, List<object?>, Task<object?>> implementation,
         Func<Interpreter, Task<object?>, SharpTSPromise>? promiseFactory,
+        bool refsEventLoopWhileInFlight,
         object? receiver)
     {
         _name = name;
@@ -77,6 +89,7 @@ public class BuiltInAsyncMethod : ISharpTSCallable, ISharpTSAsyncCallable
         _maxArity = maxArity;
         _implementation = implementation;
         _promiseFactory = promiseFactory;
+        _refsEventLoopWhileInFlight = refsEventLoopWhileInFlight;
         _receiver = receiver;
     }
 
@@ -87,13 +100,13 @@ public class BuiltInAsyncMethod : ISharpTSCallable, ISharpTSAsyncCallable
         // Null receivers don't need caching
         if (receiver == null)
         {
-            return new BuiltInAsyncMethod(_name, _minArity, _maxArity, _implementation, _promiseFactory, null);
+            return new BuiltInAsyncMethod(_name, _minArity, _maxArity, _implementation, _promiseFactory, _refsEventLoopWhileInFlight, null);
         }
 
         // Value types can't be cached efficiently
         if (receiver.GetType().IsValueType)
         {
-            return new BuiltInAsyncMethod(_name, _minArity, _maxArity, _implementation, _promiseFactory, receiver);
+            return new BuiltInAsyncMethod(_name, _minArity, _maxArity, _implementation, _promiseFactory, _refsEventLoopWhileInFlight, receiver);
         }
 
         // Initialize cache lazily
@@ -106,7 +119,7 @@ public class BuiltInAsyncMethod : ISharpTSCallable, ISharpTSAsyncCallable
         }
 
         // Create new bound method and cache it
-        var bound = new BuiltInAsyncMethod(_name, _minArity, _maxArity, _implementation, _promiseFactory, receiver);
+        var bound = new BuiltInAsyncMethod(_name, _minArity, _maxArity, _implementation, _promiseFactory, _refsEventLoopWhileInFlight, receiver);
         _boundMethodCache.AddOrUpdate(receiver, bound);
         return bound;
     }
@@ -120,6 +133,7 @@ public class BuiltInAsyncMethod : ISharpTSCallable, ISharpTSAsyncCallable
         try
         {
             var task = _implementation(interpreter, _receiver, arguments);
+            KeepEventLoopAliveUntilComplete(interpreter, task);
             return WrapResult(interpreter, task);
         }
         catch (Exception ex)
@@ -148,7 +162,30 @@ public class BuiltInAsyncMethod : ISharpTSCallable, ISharpTSAsyncCallable
     public async Task<object?> CallAsync(Interpreter interpreter, List<object?> arguments)
     {
         ValidateArguments(arguments);
-        return await _implementation(interpreter, _receiver, arguments);
+        var task = _implementation(interpreter, _receiver, arguments);
+        KeepEventLoopAliveUntilComplete(interpreter, task);
+        return await task;
+    }
+
+    /// <summary>
+    /// Refs the event loop for the lifetime of an in-flight native task (opt-in via
+    /// <c>refsEventLoopWhileInFlight</c>). An I/O built-in's thread-pool task is otherwise
+    /// invisible to <c>HasPendingEventLoopWork</c>, so the "never-settling promise" quiescence
+    /// heuristic in <c>WaitForPromise</c>/<c>RunEventLoop</c> would abandon a program whose only
+    /// pending work is real I/O slower than the quiescence window (the fs-on-slow-CI empty-output
+    /// failure class). Mirrors Node: in-flight I/O keeps the process alive; a bare pending
+    /// promise does not.
+    /// </summary>
+    private void KeepEventLoopAliveUntilComplete(Interpreter interpreter, Task task)
+    {
+        if (!_refsEventLoopWhileInFlight || task.IsCompleted) return;
+        interpreter.Ref();
+        task.ContinueWith(
+            static (_, state) => ((Interpreter)state!).Unref(),
+            interpreter,
+            CancellationToken.None,
+            TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
     }
 
     private void ValidateArguments(List<object?> arguments)

--- a/Runtime/BuiltIns/Modules/Interpreter/FsAsyncHelpers.cs
+++ b/Runtime/BuiltIns/Modules/Interpreter/FsAsyncHelpers.cs
@@ -9,6 +9,18 @@ namespace SharpTS.Runtime.BuiltIns.Modules.Interpreter;
 public static class FsAsyncHelpers
 {
     /// <summary>
+    /// Test-only latency injection: when SHARPTS_TEST_FS_ASYNC_DELAY_MS is set, async fs
+    /// operations stall that long before doing real work. Deterministically reproduces the
+    /// slow-I/O timing of loaded CI machines (AV scans, cold disks) that exposed the
+    /// event-loop quiescence give-up on in-flight native tasks. Read per call so a test can
+    /// scope it with try/finally. Same env-var seam pattern as SHARPTS_DNS_SERVER (#225).
+    /// </summary>
+    private static Task InjectedTestLatency()
+        => int.TryParse(Environment.GetEnvironmentVariable("SHARPTS_TEST_FS_ASYNC_DELAY_MS"), out var ms) && ms > 0
+            ? Task.Delay(ms)
+            : Task.CompletedTask;
+
+    /// <summary>
     /// Asynchronously reads the entire contents of a file.
     /// </summary>
     /// <param name="path">The path to the file.</param>
@@ -16,6 +28,7 @@ public static class FsAsyncHelpers
     /// <returns>A string if encoding is provided, otherwise a SharpTSBuffer.</returns>
     public static async Task<object?> ReadFileAsync(string path, object? encoding)
     {
+        await InjectedTestLatency();
         if (encoding != null)
         {
             // Return as string
@@ -37,6 +50,7 @@ public static class FsAsyncHelpers
     /// <param name="options">Optional options (encoding, mode, flag).</param>
     public static async Task WriteFileAsync(string path, object? data, object? options)
     {
+        await InjectedTestLatency();
         if (data is SharpTSBuffer buffer)
         {
             await File.WriteAllBytesAsync(path, buffer.Data);

--- a/Runtime/BuiltIns/Modules/Interpreter/FsPromisesModuleInterpreter.cs
+++ b/Runtime/BuiltIns/Modules/Interpreter/FsPromisesModuleInterpreter.cs
@@ -20,27 +20,27 @@ public static class FsPromisesModuleInterpreter
     {
         return new Dictionary<string, object?>
         {
-            ["readFile"] = new BuiltInAsyncMethod("readFile", 1, 2, ReadFile),
-            ["writeFile"] = new BuiltInAsyncMethod("writeFile", 2, 3, WriteFile),
-            ["appendFile"] = new BuiltInAsyncMethod("appendFile", 2, 3, AppendFile),
-            ["stat"] = new BuiltInAsyncMethod("stat", 1, 2, Stat),
-            ["lstat"] = new BuiltInAsyncMethod("lstat", 1, 2, Lstat),
-            ["unlink"] = new BuiltInAsyncMethod("unlink", 1, 1, Unlink),
-            ["mkdir"] = new BuiltInAsyncMethod("mkdir", 1, 2, Mkdir),
-            ["rmdir"] = new BuiltInAsyncMethod("rmdir", 1, 2, Rmdir),
-            ["rm"] = new BuiltInAsyncMethod("rm", 1, 2, Rm),
-            ["readdir"] = new BuiltInAsyncMethod("readdir", 1, 2, Readdir),
-            ["rename"] = new BuiltInAsyncMethod("rename", 2, 2, Rename),
-            ["copyFile"] = new BuiltInAsyncMethod("copyFile", 2, 3, CopyFile),
-            ["access"] = new BuiltInAsyncMethod("access", 1, 2, Access),
-            ["chmod"] = new BuiltInAsyncMethod("chmod", 2, 2, Chmod),
-            ["truncate"] = new BuiltInAsyncMethod("truncate", 1, 2, Truncate),
-            ["utimes"] = new BuiltInAsyncMethod("utimes", 3, 3, Utimes),
-            ["readlink"] = new BuiltInAsyncMethod("readlink", 1, 2, Readlink),
-            ["realpath"] = new BuiltInAsyncMethod("realpath", 1, 2, Realpath),
-            ["symlink"] = new BuiltInAsyncMethod("symlink", 2, 3, Symlink),
-            ["link"] = new BuiltInAsyncMethod("link", 2, 2, Link),
-            ["mkdtemp"] = new BuiltInAsyncMethod("mkdtemp", 1, 2, Mkdtemp),
+            ["readFile"] = new BuiltInAsyncMethod("readFile", 1, 2, ReadFile, refsEventLoopWhileInFlight: true),
+            ["writeFile"] = new BuiltInAsyncMethod("writeFile", 2, 3, WriteFile, refsEventLoopWhileInFlight: true),
+            ["appendFile"] = new BuiltInAsyncMethod("appendFile", 2, 3, AppendFile, refsEventLoopWhileInFlight: true),
+            ["stat"] = new BuiltInAsyncMethod("stat", 1, 2, Stat, refsEventLoopWhileInFlight: true),
+            ["lstat"] = new BuiltInAsyncMethod("lstat", 1, 2, Lstat, refsEventLoopWhileInFlight: true),
+            ["unlink"] = new BuiltInAsyncMethod("unlink", 1, 1, Unlink, refsEventLoopWhileInFlight: true),
+            ["mkdir"] = new BuiltInAsyncMethod("mkdir", 1, 2, Mkdir, refsEventLoopWhileInFlight: true),
+            ["rmdir"] = new BuiltInAsyncMethod("rmdir", 1, 2, Rmdir, refsEventLoopWhileInFlight: true),
+            ["rm"] = new BuiltInAsyncMethod("rm", 1, 2, Rm, refsEventLoopWhileInFlight: true),
+            ["readdir"] = new BuiltInAsyncMethod("readdir", 1, 2, Readdir, refsEventLoopWhileInFlight: true),
+            ["rename"] = new BuiltInAsyncMethod("rename", 2, 2, Rename, refsEventLoopWhileInFlight: true),
+            ["copyFile"] = new BuiltInAsyncMethod("copyFile", 2, 3, CopyFile, refsEventLoopWhileInFlight: true),
+            ["access"] = new BuiltInAsyncMethod("access", 1, 2, Access, refsEventLoopWhileInFlight: true),
+            ["chmod"] = new BuiltInAsyncMethod("chmod", 2, 2, Chmod, refsEventLoopWhileInFlight: true),
+            ["truncate"] = new BuiltInAsyncMethod("truncate", 1, 2, Truncate, refsEventLoopWhileInFlight: true),
+            ["utimes"] = new BuiltInAsyncMethod("utimes", 3, 3, Utimes, refsEventLoopWhileInFlight: true),
+            ["readlink"] = new BuiltInAsyncMethod("readlink", 1, 2, Readlink, refsEventLoopWhileInFlight: true),
+            ["realpath"] = new BuiltInAsyncMethod("realpath", 1, 2, Realpath, refsEventLoopWhileInFlight: true),
+            ["symlink"] = new BuiltInAsyncMethod("symlink", 2, 3, Symlink, refsEventLoopWhileInFlight: true),
+            ["link"] = new BuiltInAsyncMethod("link", 2, 2, Link, refsEventLoopWhileInFlight: true),
+            ["mkdtemp"] = new BuiltInAsyncMethod("mkdtemp", 1, 2, Mkdtemp, refsEventLoopWhileInFlight: true),
             ["constants"] = FsModuleInterpreter.CreateConstants()
         };
     }
@@ -407,3 +407,4 @@ public static class FsPromisesModuleInterpreter
         return new NodeError(code, ex.Message, syscall, path);
     }
 }
+

--- a/SharpTS.Tests/SharedTests/BuiltInModules/EventLoopNativeIoTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/EventLoopNativeIoTests.cs
@@ -1,0 +1,54 @@
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests.BuiltInModules;
+
+/// <summary>
+/// Event-loop liveness contract for in-flight native I/O: a program whose only pending work is
+/// a slow built-in async operation must NOT be abandoned by the interpreter's "never-settling
+/// promise" quiescence heuristic (WaitForPromise / RunEventLoop give up after 250ms without
+/// visible work). BuiltInAsyncMethod Refs the loop for the lifetime of the native task — the
+/// promise-API counterpart of the callback-API convention from #205.
+///
+/// Regression test for the FsPromisesNamespace_Stat empty-output CI failure: on a slow runner
+/// (AV scan, cold disk) the first fs write exceeded the 250ms quiescence window, the top-level
+/// promise was abandoned, and the program exited silently with no output. The injected latency
+/// (SHARPTS_TEST_FS_ASYNC_DELAY_MS) reproduces that timing deterministically: without the Ref
+/// accounting this test fails 100% of the time with empty output.
+/// </summary>
+public class EventLoopNativeIoTests
+{
+    [Fact]
+    public void SlowNativeIo_KeepsInterpreterEventLoopAlive()
+    {
+        // 600ms > 2x the 250ms quiescence window. Env var is process-wide, so concurrently
+        // running fs tests also get the latency during this test's window — they still pass,
+        // just slower; the value is kept as small as decisively-over-the-window allows.
+        Environment.SetEnvironmentVariable("SHARPTS_TEST_FS_ASYNC_DELAY_MS", "600");
+        try
+        {
+            var files = new Dictionary<string, string>
+            {
+                ["main.ts"] = """
+                    import * as fs from 'fs';
+
+                    async function test() {
+                        await fs.promises.writeFile('test-eventloop-slowio.txt', 'content');
+                        const stats = await fs.promises.stat('test-eventloop-slowio.txt');
+                        await fs.promises.unlink('test-eventloop-slowio.txt');
+                        console.log(stats.isFile());
+                    }
+
+                    test();
+                """
+            };
+
+            var output = TestHarness.RunModules(files, "main.ts", ExecutionMode.Interpreted);
+            Assert.Equal("true\n", output);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("SHARPTS_TEST_FS_ASYNC_DELAY_MS", null);
+        }
+    }
+}


### PR DESCRIPTION
## Root cause (proven, not speculated)

The CI failure of `FsPromisesNamespace_Stat` (Interpreted, Windows) — empty output instead of `"true\n"` — is **not a flaky test**. It is a product bug in event-loop quiescence accounting:

1. Top-level `test()` returns a pending promise; `WaitForPromise` ticks the loop and **gives up after 250ms** of no visible work ("never-settling promise" heuristic, `Interpreter.cs`).
2. A built-in''s in-flight thread-pool task (`fs.promises.writeFile` → `File.WriteAllTextAsync`) is **invisible** to `HasPendingEventLoopWork()` — nothing Refs it.
3. On a slow runner (Defender scanning a freshly created file, cold disk), the first write exceeds 250ms → the top-level promise is abandoned → `RunEventLoop` sees no handles, no callbacks → program exits silently. Empty output, exit 0.

**Deterministic reproduction:** injecting `await Task.Delay(400)` into `WriteFileAsync` makes the test fail 100% of the time with the exact CI signature (Interpreted only; Compiled passes — it blocks on the entry-point promise instead). With the fix, it passes 100% under the same injected delay.

## Fix

`BuiltInAsyncMethod` gains opt-in `refsEventLoopWhileInFlight`: `Ref()` when the native task starts, `Unref()` on completion (`ContinueWith`, ExecuteSynchronously). This is the **promise-API counterpart of the existing callback-API convention from #205** — `fs.writeFile(path, cb)` already does `interpreter.Ref(); // released by ScheduleCallback` — the promise side simply never got it.

Opt-in rather than blanket, mirroring Node (in-flight I/O keeps the process alive; a bare pending promise does not): a blanket Ref deterministically hung 4 tests on promises that legitimately never settle (`reader.closed`, `pipeline()` of an unfinished stream, then-chaining). All 21 `fs/promises` methods opt in.

## Regression test

`EventLoopNativeIoTests.SlowNativeIo_KeepsInterpreterEventLoopAlive`: a new `SHARPTS_TEST_FS_ASYNC_DELAY_MS` env seam (same pattern as `SHARPTS_DNS_SERVER`, #225) injects 600ms latency into async fs ops and runs the exact failing scenario. Verified both directions: **fails 100% without the fix** (empty output), passes with it. No wall-clock-window assertions — it asserts output correctness under injected latency, so it cannot itself flake (cf. the #295 flake-class rules).

## Verification

- Full suite: 10980 / 10980 passed.
- The 4 tests that a blanket Ref hung (`StreamPromisesTests` ×2, `ReadableStreamReader_ReadAndClosed_AreThenable`, `TopLevelThen_ResolvedLater_RunsCallbackWithItsParameter`) all pass with the opt-in design.

## Remaining family audit

Tracked in the follow-up issue: other `BuiltInAsyncMethod` users (dns ×14, http ×2, timers/promises ×2, fetch/Request/Response ×9) and direct `new SharpTSPromise(task)` adoption sites need the same in-flight-I/O classification, plus the compiled-mode sibling (`fix/event-loop-quiescence-false-skip` branch).