### PR TITLE
fix(compile): increment/decrement of a captured parameter dual-writes the arg slot (#321)

### DIFF
--- a/Compilation/ILEmitter.Operators.cs
+++ b/Compilation/ILEmitter.Operators.cs
@@ -842,6 +842,16 @@ public partial class ILEmitter
                 }
                 IL.Emit(OpCodes.Ldloc, temp);
                 IL.Emit(OpCodes.Stfld, funcDCField);
+                // Captured PARAMETER of this function: also sync the arg slot —
+                // reads resolve parameters before the DC, so a DC-only store
+                // leaves later same-body reads seeing the stale argument (#321).
+                if (_ctx.FunctionDisplayClassLocal != null &&
+                    _ctx.TryGetParameter(v.Name.Lexeme, out var funcParamSync))
+                {
+                    IL.Emit(OpCodes.Ldloc, temp);
+                    _ctx.EmitConvertForParamSlot(IL, v.Name.Lexeme);
+                    IL.Emit(OpCodes.Starg, funcParamSync);
+                }
                 // Box result if needed
                 if (isTypedDouble)
                 {
@@ -873,6 +883,14 @@ public partial class ILEmitter
                 }
                 IL.Emit(OpCodes.Ldloc, temp);
                 IL.Emit(OpCodes.Stfld, arrowDCField);
+                // Captured PARAMETER of this arrow: also sync the arg slot (#321).
+                if (_ctx.ArrowScopeDisplayClassLocal != null &&
+                    _ctx.TryGetParameter(v.Name.Lexeme, out var arrowParamSync))
+                {
+                    IL.Emit(OpCodes.Ldloc, temp);
+                    _ctx.EmitConvertForParamSlot(IL, v.Name.Lexeme);
+                    IL.Emit(OpCodes.Starg, arrowParamSync);
+                }
                 // Box result if needed
                 if (isTypedDouble)
                 {
@@ -1101,6 +1119,16 @@ public partial class ILEmitter
                 }
                 IL.Emit(OpCodes.Ldloc, temp);
                 IL.Emit(OpCodes.Stfld, funcDCField);
+                // Captured PARAMETER of this function: also sync the arg slot —
+                // reads resolve parameters before the DC, so a DC-only store
+                // leaves later same-body reads seeing the stale argument (#321).
+                if (_ctx.FunctionDisplayClassLocal != null &&
+                    _ctx.TryGetParameter(v.Name.Lexeme, out var funcParamSync))
+                {
+                    IL.Emit(OpCodes.Ldloc, temp);
+                    _ctx.EmitConvertForParamSlot(IL, v.Name.Lexeme);
+                    IL.Emit(OpCodes.Starg, funcParamSync);
+                }
 
                 // Original value is still on stack, box it
                 IL.Emit(OpCodes.Box, _ctx.Types.Double);
@@ -1131,6 +1159,14 @@ public partial class ILEmitter
                 }
                 IL.Emit(OpCodes.Ldloc, temp);
                 IL.Emit(OpCodes.Stfld, arrowDCField);
+                // Captured PARAMETER of this arrow: also sync the arg slot (#321).
+                if (_ctx.ArrowScopeDisplayClassLocal != null &&
+                    _ctx.TryGetParameter(v.Name.Lexeme, out var arrowParamSync))
+                {
+                    IL.Emit(OpCodes.Ldloc, temp);
+                    _ctx.EmitConvertForParamSlot(IL, v.Name.Lexeme);
+                    IL.Emit(OpCodes.Starg, arrowParamSync);
+                }
 
                 // Original value is still on stack, box it
                 IL.Emit(OpCodes.Box, _ctx.Types.Double);

--- a/SharpTS.Tests/SharedTests/InnerFunctionArrowCaptureTests.cs
+++ b/SharpTS.Tests/SharedTests/InnerFunctionArrowCaptureTests.cs
@@ -243,4 +243,66 @@ public class InnerFunctionArrowCaptureTests
         var output = TestHarness.Run(source, mode);
         Assert.Equal("function\ntrue\n", output);
     }
+
+    // #321: ++/-- on a parameter captured into a scope display class must
+    // dual-write the arg slot, not just the DC field. Same-body reads resolve
+    // the arg slot before the DC, so a DC-only store leaves the direct read
+    // seeing the stale original argument while the closure read sees the new
+    // value. Mirrors the assignment-path dual-write from #307/#313.
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void CapturedParam_PostfixIncrement_SyncsArgSlotAndDC(ExecutionMode mode)
+    {
+        var source = """
+            const outer = () => {
+              function counter2(n: number) {
+                n++;
+                const read = () => n;
+                return n * 1000 + read();   // direct (arg slot) + closure (DC)
+              }
+              return counter2(7);
+            };
+            console.log(outer());
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("8008\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void CapturedParam_PrefixDecrement_SyncsArgSlotAndDC(ExecutionMode mode)
+    {
+        // Prefix form + decrement + arrow parameter (arrow scope DC branch).
+        var source = """
+            const a1 = (n: number) => {
+              --n;
+              const read = () => n;
+              return n * 1000 + read();
+            };
+            console.log(a1(7));
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("6006\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void CapturedUntypedParam_PostfixIncrement_SyncsArgSlotAndDC(ExecutionMode mode)
+    {
+        // Untyped (any) parameter: arg slot is object, so the dual-write must
+        // not emit an unbox/castclass conversion (EmitConvertForParamSlot no-op).
+        var source = """
+            function g1(n) {
+              n++;
+              const read = () => n;
+              return n * 1000 + read();
+            }
+            console.log(g1(7));
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("8008\n", output);
+    }
 }


### PR DESCRIPTION
Fixes #321.

## Problem

In compiled mode, `++`/`--` on a parameter captured into a function or arrow scope display class wrote only the DC field, not the parameter's arg slot. Same-body reads resolve the arg slot before the DC (`LocalVariableResolver` path 1), so a direct read saw the stale original argument while a closure read saw the incremented value.

```ts
const outer = () => {
  function counter2(n: number) {
    n++;
    const read = () => n;
    return n * 1000 + read();   // direct read (arg slot) vs closure read (DC)
  }
  return counter2(7);
};
console.log(outer());
```

| | before | after |
|---|---|---|
| interpreter | `8008` | `8008` |
| compiled | `7008` ❌ | `8008` ✅ |

## Fix

Mirror the assignment-path dual-write (the #307 fix, extended with slot-type conversion in the #313 PR): after storing the incremented value to the DC field, also `Starg` the parameter slot when `TryGetParameter` hits, converting the boxed value to the slot's declared type first via `EmitConvertForParamSlot` so typed slots stay IL-verifiable.

Applied to all four affected branches in `ILEmitter.Operators.cs`: prefix/postfix × function-DC / arrow-scope-DC. The sync is guarded on `FunctionDisplayClassLocal` / `ArrowScopeDisplayClassLocal != null` so it only fires when the parameter belongs to the current frame's arg slots, exactly matching the assignment path. The entry-point-DC and captured-field branches are untouched (top-level vars / closures are never current-frame parameters).

## Verification

- New regression tests in `InnerFunctionArrowCaptureTests` cover postfix/prefix, inc/dec, function vs arrow param, and an untyped (`any`) param (exercising the `EmitConvertForParamSlot` no-op path). All pass in both interpreter and compiled modes.
- `--verify` (ILVerify) passes on the compiled edge-case suite.
- Full suite: 11014 passed, 0 failed.