### PR TITLE
test(interp): lock in event-loop liveness for in-flight native I/O (#320)

### DIFF
--- a/Runtime/Types/SharpTSFetchResponse.cs
+++ b/Runtime/Types/SharpTSFetchResponse.cs
@@ -74,6 +74,14 @@ public class SharpTSFetchResponse : ITypeCategorized
             "redirected" => _redirected,
             "type" => "basic",
             "headers" => GetHeadersObject(),
+            // Body readers don't opt into refsEventLoopWhileInFlight (the #320 native-I/O
+            // liveness audit): fetch uses the default HttpCompletionOption.ResponseContentRead,
+            // so the body is already fully buffered by the time fetch()'s promise resolves
+            // (the in-flight network leg is Ref'd inside FetchBuiltIns). These reads drain that
+            // in-memory buffer and complete synchronously, so a Ref here would never fire. If
+            // fetch ever switches to ResponseHeadersRead / streamed bodies, these three must
+            // opt in (the read would then be real in-flight I/O that can outrun the 250ms
+            // quiescence window). See FetchBuiltIns.FetchImpl and BuiltInAsyncMethod.
             "json" => new BuiltInAsyncMethod("json", 0, JsonImpl).Bind(this),
             "text" => new BuiltInAsyncMethod("text", 0, TextImpl).Bind(this),
             "arrayBuffer" => new BuiltInAsyncMethod("arrayBuffer", 0, ArrayBufferImpl).Bind(this),

--- a/SharpTS.Tests/SharedTests/BuiltInModules/EventLoopNativeIoTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/EventLoopNativeIoTests.cs
@@ -7,19 +7,30 @@ namespace SharpTS.Tests.SharedTests.BuiltInModules;
 /// Event-loop liveness contract for in-flight native I/O: a program whose only pending work is
 /// a slow built-in async operation must NOT be abandoned by the interpreter's "never-settling
 /// promise" quiescence heuristic (WaitForPromise / RunEventLoop give up after 250ms without
-/// visible work). BuiltInAsyncMethod Refs the loop for the lifetime of the native task — the
-/// promise-API counterpart of the callback-API convention from #205.
+/// visible work). The promise-API counterpart of the callback-API convention from #205.
 ///
-/// Regression test for the FsPromisesNamespace_Stat empty-output CI failure: on a slow runner
-/// (AV scan, cold disk) the first fs write exceeded the 250ms quiescence window, the top-level
-/// promise was abandoned, and the program exited silently with no output. The injected latency
-/// (SHARPTS_TEST_FS_ASYNC_DELAY_MS) reproduces that timing deterministically: without the Ref
-/// accounting this test fails 100% of the time with empty output.
+/// Each native-async surface keeps the loop alive for the lifetime of its in-flight task by a
+/// Ref/Unref pair (fs.promises via BuiltInAsyncMethod's <c>refsEventLoopWhileInFlight</c>, dns
+/// via <c>RunRefed</c>, fetch and timers/promises via explicit Ref around the await). These
+/// tests are the regression guards for the #320 audit: each exercises one surface as the sole
+/// pending work with a latency decisively past the 250ms window, asserting only output
+/// correctness (never a wall-clock window — cf. the #295 flake-class rules) so they cannot
+/// themselves flake. Remove the corresponding Ref and the matching test fails 100% with empty
+/// output.
+///
+/// Interpreted mode only: the quiescence give-up is interpreter-specific. Compiled mode keeps
+/// continuations on the loop via the emitted $EventLoopSyncContext instead.
 /// </summary>
 public class EventLoopNativeIoTests
 {
+    /// <summary>
+    /// Regression for the FsPromisesNamespace_Stat empty-output CI failure: on a slow runner
+    /// (AV scan, cold disk) the first fs write exceeded the 250ms quiescence window, the top-level
+    /// promise was abandoned, and the program exited silently. SHARPTS_TEST_FS_ASYNC_DELAY_MS
+    /// reproduces that timing deterministically.
+    /// </summary>
     [Fact]
-    public void SlowNativeIo_KeepsInterpreterEventLoopAlive()
+    public void SlowFsPromisesIo_KeepsInterpreterEventLoopAlive()
     {
         // 600ms > 2x the 250ms quiescence window. Env var is process-wide, so concurrently
         // running fs tests also get the latency during this test's window — they still pass,
@@ -50,5 +61,60 @@ public class EventLoopNativeIoTests
         {
             Environment.SetEnvironmentVariable("SHARPTS_TEST_FS_ASYNC_DELAY_MS", null);
         }
+    }
+
+    /// <summary>
+    /// timers/promises setTimeout is the sole pending work. The 300ms delay (the promise's own
+    /// argument — no env seam needed, the latency is intrinsic and deterministic) is past the
+    /// 250ms window; without the Ref/Unref around Task.Delay in TimersPrimitiveInterpreter the
+    /// top-level promise is abandoned and the program prints nothing.
+    /// </summary>
+    [Fact]
+    public void SlowTimersPromise_KeepsInterpreterEventLoopAlive()
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import { setTimeout } from 'timers/promises';
+
+                async function test() {
+                    const value = await setTimeout(300, 'tick');
+                    console.log(value);
+                }
+
+                test();
+            """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", ExecutionMode.Interpreted);
+        Assert.Equal("tick\n", output);
+    }
+
+    /// <summary>
+    /// An in-flight fetch is the sole pending work. The mock server sleeps 400ms (server-side,
+    /// deterministic) before responding — past the 250ms window — so without the Ref/Unref around
+    /// the request in FetchBuiltIns the top-level promise is abandoned mid-request and the body
+    /// is never printed. Exercises the request leg (the slow leg); the subsequent res.text() reads
+    /// an already-buffered body and completes instantly (HttpCompletionOption.ResponseContentRead).
+    /// </summary>
+    [Fact]
+    public void SlowFetch_KeepsInterpreterEventLoopAlive()
+    {
+        using var server = new MockHttpServer();
+        server.AddDelayRoute("/slow", 400, "slow-body");
+        server.Start();
+
+        var source = $$"""
+            async function test() {
+                const res = await fetch('{{server.BaseUrl}}slow');
+                const text = await res.text();
+                console.log(text);
+            }
+
+            test();
+            """;
+
+        var output = TestHarness.Run(source, ExecutionMode.Interpreted);
+        Assert.Equal("slow-body\n", output);
     }
 }


### PR DESCRIPTION
Completes the audit epic #320 — the follow-up to #319, which fixed the "program exits silently with no output because its only pending work is a built-in async op slower than the 250ms quiescence window" class for `fs/promises`.

## Audit outcome

I went through every `BuiltInAsyncMethod` user and every direct `new SharpTSPromise(task)` adoption site listed in #320 and classified each by the doctrine *(real I/O that always completes → Ref the loop while in flight; state promise that may never settle → don't)*. The headline result: **every real slow-I/O surface was already Ref'd when its feature was built.** No production Ref changes were needed.

| Surface | Status | Mechanism |
|---|---|---|
| `fs/promises` (21) | ✅ already | `refsEventLoopWhileInFlight` (#319) |
| `dns.promises` + callback dns (14) | ✅ already | `RunRefed` wrapper + per-callback `Ref`/`Unref` |
| `fetch` | ✅ already | `Ref` around the in-flight request (`FetchImpl`) |
| `http.request`/`get` | ✅ already | delegates to `fetch` |
| `timers/promises` `setTimeout`/`setImmediate` | ✅ already | `Ref` around `Task.Delay` |
| Promise combinators (`then`/`catch`/`finally`/`all`/`race`/`allSettled`/`any`) | ✅ correctly un-Ref'd | chained off user promises (state) |
| async-generator `next`/`return`/`throw` | ✅ correctly un-Ref'd | generator-step state |
| `stream/promises` `pipeline`/`finished`, `promisify` | ✅ correctly un-Ref'd | TCS settled by callback (state) |
| constructible `Request`/`Response` body reads (6) | ✅ no Ref needed | in-memory body → synchronous completion |
| `SharpTSFetchResponse` `json`/`text`/`arrayBuffer` | ✅ no Ref needed | body eagerly buffered (`ResponseContentRead`) → reads complete synchronously |
| compiled-mode sibling (`$EventLoopSyncContext`) | ✅ already in main | — |

## What this PR changes

It's **tests + docs only** (no behavior change):

- **Two new regression guards** in `EventLoopNativeIoTests` so the class can't silently reappear on the timers and fetch surfaces:
  - `SlowTimersPromise_KeepsInterpreterEventLoopAlive` — `await setTimeout(300, 'tick')` as the sole top-level work. The 300ms latency is the promise's own argument (intrinsic, deterministic — no env seam).
  - `SlowFetch_KeepsInterpreterEventLoopAlive` — fetches a `MockHttpServer` route that sleeps 400ms **server-side** before responding.
  - Both assert **only output correctness** (no wall-clock window → cannot self-flake, per the #295 flake-class rules), and both were verified to **fail 100% with empty output** when their `Ref` is temporarily removed and pass with it (the #319 both-directions methodology).
  - The existing fs guard is renamed `SlowFsPromisesIo_*` for symmetry.
- An in-place classification comment at the `SharpTSFetchResponse` body-read site explaining why no `Ref` is needed today and the exact condition under which it would (a switch to streamed/`ResponseHeadersRead` bodies).

DNS is verified by inspection only — it's already correctly Ref'd, and DNS latency tests are a known CI flake source, so adding one would cut against the anti-flake stance.

## Gaps found and filed

- **#324** — `Worker.terminate()`'s `Task.Run(() => _thread.Join())` promise is un-Ref'd; a sole-pending-work `await worker.terminate()` with a slow shutdown can be abandoned. Niche; the fix needs an `Interpreter` threaded into `Terminate()`.
- **#325** — `ReadableStream.pipeTo` mid-pipe abort can drop the source `cancel()` callback under the quiescence race (the known `InterpretedOnly` streams flake). Not a simple opt-in Ref — the pipe promise may legitimately never settle; the fix is scoped abort-teardown sequencing.

## Verification

573/573 pass across the EventLoop / Timers / Fetch / Http / Streams / FsPromises / Dns suites. New guards proven in both directions.

Closes #320.