### PR TITLE
fix(typecheck): numeric indexing of a union of tuples (#311)

### DIFF
--- a/SharpTS.Tests/TypeCheckerTests/ContextualTupleTypingTests.cs
+++ b/SharpTS.Tests/TypeCheckerTests/ContextualTupleTypingTests.cs
@@ -113,16 +113,56 @@ public class ContextualTupleTypingTests
     [Fact]
     public void TupleValueFlowsAtRuntime()
     {
-        // Indexing the union directly (m[0]) hits a separate CheckGetIndex gap (#311),
-        // so the runtime shape is observed via JSON.stringify instead.
+        // Indexing the union directly (m[0]/m[1]) distributes over the constituents
+        // (#311). The discriminant and payload flow through to runtime.
         var result = TestHarness.RunInterpreted("""
             type A = ["a", number] | ["c", string];
             function make(cond: boolean): A {
                 return cond ? ["a", 1] : ["c", "z"];
             }
-            console.log(JSON.stringify(make(true)));
-            console.log(JSON.stringify(make(false)));
+            const m = make(true);
+            console.log(m[0]);
+            console.log(m[1]);
+            console.log(make(false)[0]);
+            console.log(make(false)[1]);
             """);
-        Assert.Equal("[\"a\",1]\n[\"c\",\"z\"]\n", result);
+        Assert.Equal("a\n1\nc\nz\n", result);
+    }
+
+    [Fact]
+    public void IndexingUnionOfTuples_DistributesOverConstituents()
+    {
+        // tsc accepts numeric indexing of a union of tuples when every constituent
+        // supports the index, unioning the element types: m[0]: "a" | "c",
+        // m[1]: number | string. The annotated slots pin the inferred element types.
+        var result = TestHarness.RunInterpreted("""
+            type A = ["a", number] | ["c", string];
+            const m: A = ["c", "z"];
+            const d: "a" | "c" = m[0];
+            const v: number | string = m[1];
+            console.log(d, v);
+            """);
+        Assert.Equal("c z\n", result);
+    }
+
+    [Fact]
+    public void IndexingUnionOfTuples_DynamicIndex_UnionsAllElements()
+    {
+        TestHarness.RunInterpreted("""
+            type A = ["a", number] | ["c", string];
+            const m: A = ["a", 1];
+            const i: number = 0;
+            const v: string | number = m[i];
+            """);
+    }
+
+    [Fact]
+    public void IndexingUnionOfTuples_OutOfBounds_StillRejected()
+    {
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted("""
+            type A = ["a", number] | ["c", string];
+            declare const m: A;
+            const v = m[5];
+            """));
     }
 }

--- a/TypeSystem/TypeChecker.Properties.Index.cs
+++ b/TypeSystem/TypeChecker.Properties.Index.cs
@@ -558,6 +558,25 @@ public partial class TypeChecker
         // Handle number index
         if (IsNumber(indexType) || indexType is TypeInfo.NumberLiteral)
         {
+            // Tuple indexing — mirrors the main CheckGetIndex path so that a union of
+            // tuples (e.g. `["a", number] | ["c", string]`) distributes `m[0]` over each
+            // constituent and unions the element types. A literal index yields the exact
+            // element; a dynamic index yields the union of all element types.
+            if (objType is TypeInfo.Tuple tupleType)
+            {
+                if (getIndex.Index is Expr.Literal { Value: double idx })
+                {
+                    int i = (int)idx;
+                    if (i >= 0 && i < tupleType.ElementTypes.Count)
+                        return tupleType.ElementTypes[i];
+                    if (tupleType.RestElementType != null && i >= tupleType.ElementTypes.Count)
+                        return tupleType.RestElementType;
+                    // Out of bounds for this constituent — signal failure so the union
+                    // path reports the index as invalid across the whole union.
+                    return null;
+                }
+                return ComputeTupleElementUnion(tupleType);
+            }
             if (objType is TypeInfo.Array arrayType)
                 return arrayType.ElementType;
             // TypedArray index access returns number
@@ -566,6 +585,9 @@ public partial class TypeChecker
             // Buffer index access returns number (Buffer is a Uint8Array subclass)
             if (objType is TypeInfo.Buffer)
                 return new TypeInfo.Primitive(Parsing.TokenType.TYPE_NUMBER);
+            // String indexed by number yields a single-character string.
+            if (objType is TypeInfo.String or TypeInfo.StringLiteral)
+                return new TypeInfo.String();
             if (objType is TypeInfo.Interface itf3 && itf3.NumberIndexType != null)
                 return itf3.NumberIndexType;
             if (objType is TypeInfo.Record rec3 && rec3.NumberIndexType != null)


### PR DESCRIPTION
## Summary

Fixes #311 — `CheckGetIndexOnType`, the per-constituent helper the union index path delegates to, had no `TypeInfo.Tuple` case. Each tuple member returned `null`, so the union path rejected:

```ts
type A = ["a", number] | ["c", string];
declare const m: A;
const x = m[0]; // was: Type Error: Index type "0" is not valid for indexing all members of union...
```

tsc distributes a numeric index over the constituents and unions the element types when every constituent supports the index: `m[0]: "a" | "c"`, `m[1]: number | string`.

## Fix

Mirror the main `CheckGetIndex` tuple logic into the helper:
- literal index → exact element (or rest element)
- out-of-bounds → `null`, so the union path still reports the index invalid (`m[5]` stays an error)
- dynamic index → `ComputeTupleElementUnion`

Also added the `String`-indexed-by-number case to the helper for parity with the main path.

The write path (`m[0] = v` on a tuple union) is intentionally left rejecting — tsc also rejects writing to a discriminant slot of a tuple union because the write is unsafe for at least one constituent.

## Tests

- Un-skipped the direct-indexing form in `ContextualTupleTypingTests.TupleValueFlowsAtRuntime` (previously worked around via `JSON.stringify`, per the issue note).
- Added `IndexingUnionOfTuples_DistributesOverConstituents`, `_DynamicIndex_UnionsAllElements`, `_OutOfBounds_StillRejected`.
- 351 index/tuple/union tests pass; no regressions.