### PR TITLE
fix(interp): event-loop liveness for Worker.terminate join and pipeTo abort teardown (#324, #325)

### DIFF
--- a/Runtime/Types/SharpTSWorker.cs
+++ b/Runtime/Types/SharpTSWorker.cs
@@ -394,11 +394,24 @@ public class SharpTSWorker : SharpTSEventEmitter, IDisposable
         _cts.Cancel();
         _parentToWorkerQueue.CompleteAdding();
 
+        // The thread join is real, always-completing work bounded at 5s. Ref the
+        // parent event loop for its duration so the interpreter's quiescence
+        // heuristic does not abandon a program whose only remaining work is
+        // `await worker.terminate()` when the worker takes >250ms to wind down
+        // (the #319/#320 native-I/O liveness class; #324). Unref once the join
+        // settles. The Ref is opt-in on having a parent interpreter — the
+        // compiled path (no _parentInterpreter) is unaffected.
+        var interp = _parentInterpreter;
+        interp?.Ref();
         var task = Task.Run<object?>(() =>
         {
             _thread.Join(5000); // Wait up to 5 seconds
             return (double)0;
         });
+        if (interp != null)
+        {
+            task.ContinueWith(_ => interp.Unref(), TaskScheduler.Default);
+        }
         return new SharpTSPromise(task);
     }
 

--- a/Runtime/Types/WebStreamsHelpers.cs
+++ b/Runtime/Types/WebStreamsHelpers.cs
@@ -164,12 +164,27 @@ internal static class WebStreamsHelpers
 
         async Task<object?> PumpAsync()
         {
+            // Scope a Ref to the abort/cancel/reject teardown so the source
+            // cancel() callback cannot be dropped by event-loop quiescence —
+            // same liveness fix as PipeTo (#325/#320 doctrine). The steady-state
+            // pipe stays un-Ref'd so an infinite source can never-settle.
+            bool teardownRefed = false;
+            void RefTeardown()
+            {
+                if (!teardownRefed)
+                {
+                    interp?.Ref();
+                    teardownRefed = true;
+                }
+            }
+
             try
             {
                 while (true)
                 {
                     if (signal != null && signal.Aborted)
                     {
+                        RefTeardown();
                         if (!preventAbort) await CallAbort(signal.Reason).ConfigureAwait(false);
                         if (!preventCancel) await source.CancelInternal(signal.Reason).Task.ConfigureAwait(false);
                         throw new SharpTSPromiseRejectedException(signal.Reason);
@@ -191,6 +206,7 @@ internal static class WebStreamsHelpers
             }
             catch (Exception ex)
             {
+                RefTeardown();
                 var reason = ex is SharpTSPromiseRejectedException pre ? pre.Reason : ex;
                 if (!preventAbort)
                 {
@@ -202,6 +218,10 @@ internal static class WebStreamsHelpers
                 }
                 if (source.Reader == reader) source.Reader = null;
                 throw;
+            }
+            finally
+            {
+                if (teardownRefed) interp?.Unref();
             }
         }
 
@@ -237,6 +257,26 @@ internal static class WebStreamsHelpers
 
         async Task<object?> PumpAsync()
         {
+            // The pipe promise itself is deliberately NOT Ref'd — an infinite
+            // source must be allowed to never settle, so a blanket Ref would
+            // hang the process (#319/#320 doctrine). But the abort/cancel/reject
+            // *teardown* sequence is real, bounded work that must fully drain:
+            // once an abort has been observed, the un-Ref'd continuation chain
+            // (abort dest → cancel source → reject) can take >250ms under load,
+            // and the quiescence give-up could let the process exit after
+            // "dest-aborted"/"pipe-rejected" but before the source cancel()
+            // callback flushes (the #325 flake). Scope a Ref to just the
+            // teardown so the loop stays alive until it completes, then Unref.
+            bool teardownRefed = false;
+            void RefTeardown()
+            {
+                if (!teardownRefed)
+                {
+                    interp?.Ref();
+                    teardownRefed = true;
+                }
+            }
+
             try
             {
                 while (true)
@@ -251,6 +291,7 @@ internal static class WebStreamsHelpers
 
                     if (signal != null && signal.Aborted)
                     {
+                        RefTeardown();
                         if (!preventAbort) await dest.AbortInternal(signal.Reason).ConfigureAwait(false);
                         if (!preventCancel) await source.CancelInternal(signal.Reason).Task.ConfigureAwait(false);
                         throw new SharpTSPromiseRejectedException(signal.Reason);
@@ -276,6 +317,10 @@ internal static class WebStreamsHelpers
             }
             catch (Exception ex)
             {
+                // Keep the loop alive across this teardown too (read/write error
+                // path, or the rethrow from the mid-pipe abort above, which has
+                // already Ref'd). Ref before the first teardown await.
+                RefTeardown();
                 var reason = ex is SharpTSPromiseRejectedException pre ? pre.Reason : ex;
                 if (!preventAbort && dest.State == SharpTSWritableStream.WritableState.Writable)
                 {
@@ -288,6 +333,10 @@ internal static class WebStreamsHelpers
                 if (source.Reader == reader) source.Reader = null;
                 if (dest.Writer == writer) dest.Writer = null;
                 throw;
+            }
+            finally
+            {
+                if (teardownRefed) interp?.Unref();
             }
         }
 

--- a/SharpTS.Tests/SharedTests/BuiltInModules/StreamsWebSemanticTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/StreamsWebSemanticTests.cs
@@ -337,12 +337,17 @@ public class StreamsWebSemanticTests
     #region pipeTo with AbortSignal
 
     /// <remarks>
-    /// Same event-loop interaction problem as <see cref="ReadableStream_PendingReadResolvedByLaterEnqueue"/>
-    /// — the <c>setTimeout</c>-driven abort never wakes up the pump loop's
-    /// awaiting read. Interpreter pipeTo WILL honour the signal if it's
-    /// already aborted when pipeTo starts; the mid-pipe abort path is what
-    /// hangs. Compiled-mode $ReadableStream.PipeTo doesn't extract the signal
-    /// from opts at all (not implemented). Both deferred.
+    /// Mid-pipe abort: a <c>setTimeout</c>-driven <c>ac.abort()</c> fires while
+    /// the pump is parked, the pump's per-iteration <c>Task.Yield</c> lets it
+    /// observe the signal, and it runs the abort/cancel/reject teardown.
+    /// Previously flaky under CI load: the teardown awaits ran as un-Ref'd
+    /// thread-pool continuations after the abort timer had Unref'd the loop, so
+    /// the 250ms quiescence give-up could exit before <c>source.cancel()</c>
+    /// flushed "source-canceled". Fixed in #325 — the pump now Refs the event
+    /// loop for the duration of the teardown sequence (see
+    /// <c>WebStreamsHelpers.PipeTo</c>), then Unrefs. Compiled-mode
+    /// <c>$ReadableStream.PipeTo</c> doesn't extract the signal from opts at all
+    /// (not implemented), so this stays InterpretedOnly.
     /// </remarks>
     [Theory]
     [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]

--- a/SharpTS.Tests/SharedTests/WorkerThreadsTests.cs
+++ b/SharpTS.Tests/SharedTests/WorkerThreadsTests.cs
@@ -439,4 +439,53 @@ public class WorkerThreadsTests
     }
 
     #endregion
+
+    #region Worker.terminate() event-loop liveness (#324)
+
+    /// <summary>
+    /// Regression for #324: when <c>await worker.terminate()</c> is the only
+    /// remaining top-level work and the worker takes longer than the event
+    /// loop's 250ms quiescence window to wind down, the parent must stay alive
+    /// until the terminate promise settles.
+    /// </summary>
+    /// <remarks>
+    /// The worker keeps its own event loop alive ~500ms via a pending timer, so
+    /// the parent's <c>_thread.Join</c> (inside <c>SharpTSWorker.Terminate</c>)
+    /// blocks well past the 250ms give-up. That join task is invisible to
+    /// <c>HasPendingEventLoopWork</c>; before the fix the parent abandoned the
+    /// terminate promise and exited without printing "terminated". The fix Refs
+    /// the parent loop for the join's duration. InterpretedOnly because the fix
+    /// targets the interpreter event loop; <c>__dirname</c> routes the harness
+    /// through the real-disk path so the spawned worker can load its script.
+    /// The assertion is positive (output present) and load-independent — under
+    /// load the join simply takes longer and the Ref keeps the loop alive for
+    /// it, so the test cannot flake the way a wall-clock window would.
+    /// </remarks>
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void Worker_Terminate_KeepsEventLoopAliveUntilSettled(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["worker_slow.ts"] = """
+                // Hold the worker's event loop open ~500ms so the parent's
+                // terminate() thread-join outlasts the 250ms quiescence window.
+                setTimeout(() => {}, 500);
+                """,
+            ["main.ts"] = """
+                import { Worker } from "worker_threads";
+                const w = new Worker(__dirname + "/worker_slow.ts");
+                async function run() {
+                    await w.terminate();
+                    console.log("terminated");
+                }
+                run();
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Contains("terminated", output);
+    }
+
+    #endregion
 }


### PR DESCRIPTION
## Summary

Closes #324 and #325 — two native-I/O liveness gaps from the #320 audit, both the same class as #319/#320: real, bounded work runs as **un-Ref'd thread-pool continuations** that the interpreter's 250ms quiescence heuristic (`HasPendingEventLoopWork`) can't see, so a program whose only remaining work is that teardown can exit before it drains.

### #324 — `Worker.terminate()` join abandoned by quiescence
`SharpTSWorker.Terminate()` returns a promise over `Task.Run(() => _thread.Join(5000))`. That join task was invisible to the loop, so `await worker.terminate()` as the sole top-level work dropped its post-await continuation when the worker took >250ms to wind down.

**Fix:** `interp?.Ref()` before the join, `Unref()` in a `ContinueWith`. Opt-in on having a parent interpreter (mirrors `DnsModuleInterpreter.RunRefed` / `FetchBuiltIns`); the compiled path is unaffected.

### #325 — `pipeTo` mid-pipe abort drops `source.cancel()`
`WebStreamsHelpers.PipeTo`'s abort → cancel → reject teardown ran its awaits (notably the guest `source.cancel()` callback) un-Ref'd after the abort timer Unref'd the loop, intermittently dropping `"source-canceled"` under CI load (the long-standing `ReadableStream_PipeTo_AbortSignalCancelsSourceAndAbortsDest` flake).

The steady-state pipe **must** stay un-Ref'd (an infinite source may never settle), so the Ref is **scoped to just the teardown**: Ref on first abort/error observation, Unref in `finally`. Applied to both the interpreter-dest path and the emitted-`$WritableStream`-dest path (`PipeToEmittedWritable`) to avoid an asymmetric gap.

## Verification
- Manual repro confirmed the #324 fix flips behavior (pre-fix: no output; fixed: `terminated`).
- New deterministic `InterpretedOnly` regression `Worker_Terminate_KeepsEventLoopAliveUntilSettled` — worker held alive ~500ms by its own timer; positive, load-independent assertion (more load → longer join → Ref keeps loop alive, so it cannot flake the way a wall-clock window would).
- Updated the now-stale flake remarks on the pipeTo abort test.
- Full suite green: **11015 passed**.

## Follow-up
Filed a separate issue for the Worker *running*-lifetime liveness gap (`SharpTSWorker.Ref`/`Unref` are no-ops), which #324 explicitly scoped out.