### PR TITLE
fix(compile): flag AbortSignal.any precisely for SharpTS.dll co-location (#116)

### DIFF
--- a/Compilation/RuntimeEmitter.AbortController.cs
+++ b/Compilation/RuntimeEmitter.AbortController.cs
@@ -693,6 +693,15 @@ public partial class RuntimeEmitter
     /// </summary>
     private void EmitAbortSignalStaticAny(TypeBuilder typeBuilder, EmittedRuntime runtime)
     {
+        // The body below late-binds to RuntimeTypes.AbortSignalAnyCompiled via
+        // Type.GetType("…, SharpTS"); its normal execution needs SharpTS.dll present.
+        // Record the runtime dependency only when the program actually references
+        // AbortSignal.any — the coarse UsesAbortController flag (set by ordinary
+        // AbortController / fetch-with-signal usage that is pure IL) would otherwise
+        // force an unnecessary SharpTS.dll copy for the common case (#116).
+        if (_features.UsesAbortSignalAny)
+            runtime.RequireSharpTSRuntime("AbortSignal.any");
+
         var method = typeBuilder.DefineMethod(
             "AbortSignalAny",
             MethodAttributes.Public | MethodAttributes.Static,

--- a/Compilation/RuntimeFeatureDetector.cs
+++ b/Compilation/RuntimeFeatureDetector.cs
@@ -69,6 +69,7 @@ public sealed class RuntimeFeatureDetector
             UsesTty = false,
             UsesPerf = false,
             UsesAbortController = false,
+            UsesAbortSignalAny = false,
             UsesProxy = false,
             UsesDynamicImport = false,
             UsesAsyncGenerator = false,
@@ -144,6 +145,13 @@ public sealed class RuntimeFeatureDetector
         // fetch's request handler honours AbortSignal cancellation. Imply
         // UsesAbortController so AbortSignalGetAborted/GetReason exist.
         if (_set.UsesWebStreams || _set.UsesFetch || _set.UsesHttp)
+        {
+            _set.UsesAbortController = true;
+        }
+        // AbortSignal.any is emitted as part of the AbortController method cluster
+        // and registered on the AbortSignal namespace singleton, so it needs the
+        // base AbortController machinery present.
+        if (_set.UsesAbortSignalAny)
         {
             _set.UsesAbortController = true;
         }
@@ -500,6 +508,14 @@ public sealed class RuntimeFeatureDetector
         if (memberName == "isTTY")
         {
             _set.UsesTty = true;
+        }
+        // `AbortSignal.any([...])` late-binds to RuntimeTypes.AbortSignalAnyCompiled via
+        // reflection on its normal path, so a program that actually calls it needs SharpTS.dll
+        // co-located at runtime. This precise flag drives RequireSharpTSRuntime("AbortSignal.any")
+        // without penalising the common, pure-IL AbortController + fetch case (#116).
+        if (objectName == "AbortSignal" && memberName == "any")
+        {
+            _set.UsesAbortSignalAny = true;
         }
     }
 

--- a/Compilation/RuntimeFeatureSet.cs
+++ b/Compilation/RuntimeFeatureSet.cs
@@ -60,6 +60,7 @@ public sealed class RuntimeFeatureSet
     public bool UsesTty { get; set; } = true;               // 'tty' module / process.stdout.isTTY — just isatty(fd)
     public bool UsesPerf { get; set; } = true;              // performance.now() / performance.timeOrigin (host-tied primitive)
     public bool UsesAbortController { get; set; } = true;   // AbortController / AbortSignal identifiers
+    public bool UsesAbortSignalAny { get; set; } = true;    // AbortSignal.any([...]) — late-binds to SharpTS runtime, needs SharpTS.dll co-located
     public bool UsesProxy { get; set; } = true;             // `new Proxy(...)` / bare `Proxy` identifier
     public bool UsesDynamicImport { get; set; } = true;     // `import(specifier)` syntax (Expr.DynamicImport)
     public bool UsesAsyncGenerator { get; set; } = true;    // `async function*` / async generators

--- a/SharpTS.Tests/CompilerTests/RuntimeDependencySignalTests.cs
+++ b/SharpTS.Tests/CompilerTests/RuntimeDependencySignalTests.cs
@@ -70,4 +70,31 @@ public class RuntimeDependencySignalTests
         Assert.DoesNotContain("Intl", reasons);
         Assert.DoesNotContain("vm module", reasons);
     }
+
+    [Fact]
+    public void AbortSignalAny_RequiresRuntime()
+    {
+        var reasons = ReasonsFor("""
+            const c1 = new AbortController();
+            const c2 = new AbortController();
+            const combined = AbortSignal.any([c1.signal, c2.signal]);
+            console.log(combined.aborted);
+            """);
+        Assert.Contains("AbortSignal.any", reasons);
+    }
+
+    [Fact]
+    public void AbortControllerWithoutAny_StaysStandalone()
+    {
+        // Plain AbortController usage (incl. fetch-with-signal) compiles to pure IL —
+        // it must NOT drag in a SharpTS.dll copy (#116).
+        var reasons = ReasonsFor("""
+            const c = new AbortController();
+            c.signal.addEventListener("abort", () => console.log("aborted"));
+            c.abort();
+            console.log(c.signal.aborted);
+            """);
+        Assert.DoesNotContain("AbortSignal.any", reasons);
+        Assert.Empty(reasons);
+    }
 }


### PR DESCRIPTION
Closes #116.

## Background

#115 introduced a semantic "needs-SharpTS-at-runtime" signal (`EmittedRuntime.RequiredSharpTSRuntimeReasons`, surfaced via `ILCompiler.RequiredSharpTSRuntimeReasons`) so the CLI co-locates `SharpTS.dll` with compiled output **only when** a feature genuinely late-binds into the runtime on its normal path (eval, Proxy, Intl, vm, dns, `@DotNetType` dynamic events).

`AbortSignal.any` late-binds to `RuntimeTypes.AbortSignalAnyCompiled` and so genuinely requires SharpTS at runtime — but its emission was gated only by the **coarse** `RuntimeFeatureSet.UsesAbortController` flag, which is also set by ordinary `AbortController` / `fetch(..., { signal })` usage that is pure IL. #115 deliberately left it unflagged to avoid forcing a copy for that common case, leaving a real standalone `AbortSignal.any` program to hit graceful degradation (throw).

## Fix

- New precise `RuntimeFeatureSet.UsesAbortSignalAny` flag.
- `RuntimeFeatureDetector` sets it only on an `AbortSignal.any` member access, and implies `UsesAbortController` from it (the method is emitted as part of the AbortController cluster + AbortSignal namespace singleton).
- `RequireSharpTSRuntime("AbortSignal.any")` is recorded at the `EmitAbortSignalStaticAny` emit site, gated on the new flag — mirroring how Proxy/dns/Intl/vm record their reasons at their own emit sites.

## Acceptance — verified end-to-end

- A program using only `AbortController` (incl. `fetch` with a signal) → **no** `SharpTS.dll` copy (output dir holds only `plain.dll` + `runtimeconfig.json`; empty reason set).
- A program using `AbortSignal.any([...])` → `Copied SharpTS.dll next to output — required at runtime by: AbortSignal.any`; the co-located DLL runs (`combined.aborted` → `false`).

## Tests

`RuntimeDependencySignalTests`:
- `AbortSignalAny_RequiresRuntime` — reason reported.
- `AbortControllerWithoutAny_StaysStandalone` — plain AbortController has an empty reason set.

CompilerTests + EmitterSync + RuntimeTypeSync (178) green; AbortController + RuntimeDependencySignal (41) green.