### PR TITLE
fix(compiled): derived Promise static dispatch from top-level body (#309)

### DIFF
--- a/Compilation/ExpressionEmitterBase.CallHelpers.cs
+++ b/Compilation/ExpressionEmitterBase.CallHelpers.cs
@@ -1355,7 +1355,7 @@ public abstract partial class ExpressionEmitterBase
     /// task in place of an executor). Returns false (emitting nothing) when
     /// the subclass constructor can't accept the task as its first argument.
     /// </summary>
-    private bool TryEmitDerivedPromiseStatic(string resolvedClassName, Type classBuilder, string methodName, List<Expr> arguments)
+    protected bool TryEmitDerivedPromiseStatic(string resolvedClassName, Type classBuilder, string methodName, List<Expr> arguments)
     {
         if (Ctx.TypeEmitterRegistry?.GetStaticStrategy("Promise") is not { } promiseStatics)
             return false;

--- a/Compilation/ILEmitter.Calls.cs
+++ b/Compilation/ILEmitter.Calls.cs
@@ -201,6 +201,19 @@ public partial class ILEmitter
                     SetStackUnknown();
                     return;
                 }
+
+                // Promise subclasses (#242/#309) inherit the Promise static side:
+                // MyP.resolve / MyP.reject / MyP.all etc. are not user-declared
+                // statics (so TryGetCallableStaticMethod above misses them) — emit
+                // the base Promise static and wrap the result in the subclass.
+                // Mirrors TryEmitGetCalleeViaBaseClass; the inline ILEmitter path
+                // had drifted and omitted this block, so MyP.resolve(1) threw.
+                if (methodGet.Name.Lexeme is "resolve" or "reject" or "all" or "race" or "allSettled" or "any" or "withResolvers"
+                    && _ctx.ClassRegistry.IsPromiseSubclass(resolvedClassName)
+                    && TryEmitDerivedPromiseStatic(resolvedClassName, classBuilder, methodGet.Name.Lexeme, c.Arguments))
+                {
+                    return;
+                }
             }
 
             // Instance method dispatch (Array/String/Map/Promise/etc.)

--- a/SharpTS.Tests/SharedTests/PromiseSubclassTests.cs
+++ b/SharpTS.Tests/SharedTests/PromiseSubclassTests.cs
@@ -236,6 +236,40 @@ public class PromiseSubclassTests
 
     [Theory]
     [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ExtendsPromise_TopLevelStaticThen(ExecutionMode mode)
+    {
+        // #309: the exact repro — inherited static + derived `then` dispatched
+        // from the top-level (synchronous) program body, NOT inside an async
+        // function. The async-body path (state machine) already worked; the
+        // main ILEmitter.EmitCall path had drifted and omitted the derived
+        // Promise-static block, so `MyP.resolve(1)` threw
+        // "TypeError: undefined is not a function" in compiled mode.
+        var source = """
+            class MyP extends Promise<number> {}
+            MyP.resolve(1).then(v => console.log("got", v));
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("got 1\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ExtendsPromise_TopLevelRejectCatch(ExecutionMode mode)
+    {
+        // #309 sibling: reject/catch on a non-generic subclass from the
+        // top-level body.
+        var source = """
+            class MyP extends Promise<number> {}
+            MyP.reject("boom").catch(e => console.log("caught", e));
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("caught boom\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void ExtendsPromise_ConstructorIdentity(ExecutionMode mode)
     {
         // ECMA-262 §27.2.5.1 / #221: subclass instances report the subclass


### PR DESCRIPTION
## Summary

Fixes #309. In compiled mode, calling an inherited static + derived `then` on a `Promise` subclass from the **top-level program body** threw `TypeError: undefined is not a function`; the interpreter printed `got 1`.

```ts
class MyP extends Promise<number> {}
MyP.resolve(1).then(v => console.log("got", v));
```

## Root cause

The main `ILEmitter.EmitCall` path holds a hand-rolled copy of the `Class.staticMethod()` dispatch that had drifted from the shared `TryEmitGetCalleeViaBaseClass` (used by the async state-machine emitters). The shared copy routes inherited Promise statics (`resolve`/`reject`/`all`/`race`/`allSettled`/`any`/`withResolvers`) through `TryEmitDerivedPromiseStatic`; the inline ILEmitter copy omitted that block. So `MyP.resolve` fell through to the generic `GetProperty` + `InvokeMethodValue` dynamic dispatch, which resolved the inherited static to `undefined` and threw.

Every existing `PromiseSubclassTests` case wrapped the static call inside `async function main()` — the state-machine path, which already had the block — so the top-level path was never exercised and the bug slipped through.

## Fix

- Make `TryEmitDerivedPromiseStatic` `protected` (was `private`) so the derived ILEmitter can reuse it instead of duplicating the body.
- Call it from the inline ILEmitter static-dispatch block, mirroring the shared path. No new logic, just closing the drift.

## Tests

- Added `ExtendsPromise_TopLevelStaticThen` (the exact #309 repro) and `ExtendsPromise_TopLevelRejectCatch`, both run against interpreter + compiler. Verified they fail on the compiled path pre-fix.
- Full suite: **11029 passed, 0 failed**.

## Follow-up filed

#332 — the broader, separate gap: inherited static **methods/fields/getters** on plain user-class subclasses (`class Sub extends Base {}`) also resolve to `undefined` in compiled mode (the interpreter is correct). That needs `ClassRegistry.TryGetStaticMethod`/`Field`/`Getter` to walk the superclass chain; out of scope here since #309 is Promise-specific.

🤖 Generated with [Claude Code](https://claude.com/claude-code)