### PR TITLE
fix(compile): typed-array / ArrayBuffer constructors resolvable as bare values (#331)

### DIFF
--- a/Compilation/ExpressionEmitterBase.cs
+++ b/Compilation/ExpressionEmitterBase.cs
@@ -1712,6 +1712,27 @@ public abstract partial class ExpressionEmitterBase : IEmitterContext
             // Real emitted types since #222 (always emitted).
             "MessageChannel" => Ctx.Runtime!.TSMessageChannelType,
             "MessagePort" => Ctx.Runtime!.TSMessagePortType,
+            // Typed-array / buffer constructors in value position (#331) — the
+            // bare-identifier form (`var x = Int8Array`, `typeof Uint8Array`,
+            // `x instanceof ArrayBuffer`). `new Int8Array(...)` is intercepted
+            // earlier as a New expression; these tokens only serve value uses.
+            // Null (feature off) falls through to ThrowUndefinedVariable, exactly
+            // like the web-streams entries above — and the same bare identifier
+            // that reaches here flags HasAnyTypedArray, so the type is emitted.
+            "ArrayBuffer" => Ctx.Runtime!.ArrayBufferType,
+            "SharedArrayBuffer" => Ctx.Runtime!.SharedArrayBufferType,
+            "DataView" => Ctx.Runtime!.DataViewType,
+            "Int8Array" => Ctx.Runtime!.Int8ArrayType,
+            "Uint8Array" => Ctx.Runtime!.Uint8ArrayType,
+            "Uint8ClampedArray" => Ctx.Runtime!.Uint8ClampedArrayType,
+            "Int16Array" => Ctx.Runtime!.Int16ArrayType,
+            "Uint16Array" => Ctx.Runtime!.Uint16ArrayType,
+            "Int32Array" => Ctx.Runtime!.Int32ArrayType,
+            "Uint32Array" => Ctx.Runtime!.Uint32ArrayType,
+            "Float32Array" => Ctx.Runtime!.Float32ArrayType,
+            "Float64Array" => Ctx.Runtime!.Float64ArrayType,
+            "BigInt64Array" => Ctx.Runtime!.BigInt64ArrayType,
+            "BigUint64Array" => Ctx.Runtime!.BigUint64ArrayType,
             _ => null
         };
         if (t == null) return false;
@@ -1922,6 +1943,12 @@ public abstract partial class ExpressionEmitterBase : IEmitterContext
             or "WeakMap" or "WeakSet" or "Promise" or "Buffer" or "Function"
             or "Object" or "String" or "Number" or "Boolean"
             or "TextEncoder" or "TextDecoder") return true;
+        // Typed-array / buffer constructors as values (#331) — without this,
+        // `typeof Int8Array` is "undefined" though TryEmitBuiltInClassType
+        // resolves them. The same identifier flags HasAnyTypedArray, so the
+        // backing type is emitted.
+        if (name is "ArrayBuffer" or "SharedArrayBuffer" or "DataView"
+            || Runtime.BuiltIns.BuiltInNames.IsTypedArrayName(name)) return true;
         // CJS magic names visible in CJS bodies: `module` is registered in TopLevelStaticVars
         // so the earlier check catches it; `exports` and `require` are handled by special
         // emitter paths (TryEmitCjsVariable, TryEmitCjsRequireCall) — without this,

--- a/SharpTS.Tests/SharedTests/BareBuiltInClassRefTests.cs
+++ b/SharpTS.Tests/SharedTests/BareBuiltInClassRefTests.cs
@@ -135,4 +135,53 @@ public class BareBuiltInClassRefTests
         var output = TestHarness.Run(source, mode);
         Assert.Equal("false\nfalse\nfalse\nfalse\n", output);
     }
+
+    // ── #331: typed-array / buffer constructors as bare values ────────────
+    // `new Int8Array(...)` was intercepted as a New expression, but the
+    // bare-identifier form (`var x = Int8Array`, `typeof Uint8Array`,
+    // `x instanceof ArrayBuffer`) threw `Undefined variable` in compiled mode.
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void TypedArrayCtors_BareValue_TypeofAndTag(ExecutionMode mode)
+    {
+        // One representative per element width/signedness/kind plus the three
+        // buffer/view constructors — every value must report typeof "function"
+        // and brand "[object Function]" (the #314 tag rule applied to the
+        // System.Type tokens these resolve to).
+        var source = """
+            var ctors: any[] = [
+                Int8Array, Uint8Array, Uint8ClampedArray, Int16Array, Uint16Array,
+                Int32Array, Uint32Array, Float32Array, Float64Array,
+                BigInt64Array, BigUint64Array,
+                ArrayBuffer, SharedArrayBuffer, DataView,
+            ];
+            for (var i = 0; i < ctors.length; i++) {
+                console.log(typeof ctors[i], Object.prototype.toString.call(ctors[i]));
+            }
+            """;
+        var output = TestHarness.Run(source, mode);
+        var expectedLine = "function [object Function]\n";
+        Assert.Equal(string.Concat(System.Linq.Enumerable.Repeat(expectedLine, 14)), output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    public void TypedArrayCtors_BareValue_InstanceOf_Compiled(ExecutionMode mode)
+    {
+        // With the constructor resolvable as a value, compiled `instanceof`
+        // routes through the emitted Type token's IsAssignableFrom and matches
+        // instances produced by `new`. (The interpreter does not yet recognise
+        // typed-array instances in `instanceof` at all — even against Object —
+        // tracked separately in #334.)
+        var source = """
+            console.log(new Int8Array(4) instanceof Int8Array);
+            console.log(new Float64Array(2) instanceof Float64Array);
+            console.log(new ArrayBuffer(8) instanceof ArrayBuffer);
+            console.log(new DataView(new ArrayBuffer(8)) instanceof DataView);
+            console.log(({} as any) instanceof Int8Array);
+            """;
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("true\ntrue\ntrue\ntrue\nfalse\n", output);
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #331. In compiled mode, `new Int8Array(...)` / `new ArrayBuffer(...)` worked (the constructor is intercepted as a `New` expression), but the **bare-identifier value form** — `var x = Int8Array`, `typeof Uint8Array`, `x instanceof ArrayBuffer` — threw `Undefined variable`. The interpreter exposed these as values fine.

The backing runtime types are already emitted whenever a typed-array identifier appears (the feature detector flags `HasAnyTypedArray` on every `Expr.Variable`); only the name→token mapping in value position was missing.

## Changes

- **`TryEmitBuiltInClassType`** (shared by `ILEmitter.EmitVariable` and the state-machine emitters, so both top-level and async/generator bodies are covered) gains entries for `ArrayBuffer`, `SharedArrayBuffer`, `DataView` and the 11 typed arrays, emitting an `Ldtoken` of the matching emitted type. Null when the feature is off → falls through to `ThrowUndefinedVariable`, exactly like the existing web-streams entries.
- **`IsKnownVariable`** gains the same names so `typeof Int8Array` is `"function"` rather than `"undefined"`.

Used the live `runtime.{ArrayBuffer,SharedArrayBuffer,DataView,Int8Array,…}Type` fields (the `TS`-prefixed parallel fields — `TSArrayBufferType`, `TSInt8ArrayType`, … — turned out to be dead/never-assigned).

## Side effect (positive)

Compiled `new Int8Array(4) instanceof Int8Array` / `instanceof ArrayBuffer` now route through the emitted Type token's `IsAssignableFrom` and return `true` (they **threw** before). The emitted tokens reference the output module's own types, so the DLL stays standalone — verified with `--verify` (IL passes) and confirmed no `SharpTS.dll` is co-located.

## Out of scope / filed

- **#334** — the **interpreter** does not recognize typed-array instances in `instanceof` at all (even against `Object`). Broader, pre-existing; the compiled side is fixed here as a side effect. The new compiled-only `instanceof` test documents the divergence.
- `BigInt` is still undefined as a global in both modes (separate larger gap, noted in #331).

## Testing

- `BareBuiltInClassRefTests` gains typeof + `Object.prototype.toString` tag coverage for all 14 constructors (both modes) and a compiled-only `instanceof` check.
- Full suite: **11029/11029 pass**.
- Manual sweep in both modes; standalone DLL runs without `SharpTS.dll`.

Closes #331.