### PR TITLE
TS conformance: conditional-type relation semantics — conditionalTypes2 & inferTypes1 flip to Pass

### DIFF
--- a/SharpTS.TypeScriptConformance/baselines/interpreted.txt
+++ b/SharpTS.TypeScriptConformance/baselines/interpreted.txt
@@ -1,8 +1,8 @@
 # TS conformance baseline — do not hand-edit. Regenerate with SHARPTS_TSCONFORMANCE_UPDATE_BASELINE=1.
 tests/cases/conformance/types/conditional/conditionalTypes1.ts Fail
-tests/cases/conformance/types/conditional/conditionalTypes2.ts Fail
+tests/cases/conformance/types/conditional/conditionalTypes2.ts Pass
 tests/cases/conformance/types/conditional/conditionalTypesExcessProperties.ts Pass
-tests/cases/conformance/types/conditional/inferTypes1.ts Fail
+tests/cases/conformance/types/conditional/inferTypes1.ts Pass
 tests/cases/conformance/types/conditional/inferTypes2.ts Pass
 tests/cases/conformance/types/conditional/inferTypesInvalidExtendsDeclaration.ts Skipped:lib-drift
 tests/cases/conformance/types/conditional/inferTypesWithExtends1.ts Pass

--- a/TypeSystem/TypeChecker.Compatibility.Structural.cs
+++ b/TypeSystem/TypeChecker.Compatibility.Structural.cs
@@ -319,6 +319,29 @@ public partial class TypeChecker
         TypeInfo.InstantiatedGeneric expectedIG,
         TypeInfo.InstantiatedGeneric actualIG)
     {
+        // Conditional-typed members can't be variance-measured with the concrete marker records:
+        // substituting a marker into `T extends string ? T : number` EVALUATES the conditional
+        // (marker isn't a string → both sides collapse to `number` → everything measures
+        // bivariant). Relate the two instantiations member-wise instead — the deferred
+        // conditionals then compare through the conditional relation rules, which see the real
+        // type arguments (conditionalTypes2 Covariant/Contravariant/Invariant).
+        if (gi.Members.Values.Any(ContainsConditionalType))
+        {
+            Dictionary<string, TypeInfo> expSubs = [], actSubs = [];
+            for (int i = 0; i < gi.TypeParams.Count && i < expectedIG.TypeArguments.Count; i++)
+            {
+                expSubs[gi.TypeParams[i].Name] = expectedIG.TypeArguments[i];
+                actSubs[gi.TypeParams[i].Name] = actualIG.TypeArguments[i];
+            }
+            foreach (var (name, memberType) in gi.Members)
+            {
+                bool isMethod = gi.MethodMembers?.Contains(name) == true;
+                if (!IsMemberCompatible(Substitute(memberType, expSubs), Substitute(memberType, actSubs), isMethod))
+                    return false;
+            }
+            return true;
+        }
+
         var measured = GetMeasuredVariances(gi);
         for (int i = 0; i < expectedIG.TypeArguments.Count; i++)
         {
@@ -335,6 +358,28 @@ public partial class TypeChecker
         }
         return true;
     }
+
+    /// <summary>
+    /// True when a type contains a conditional type anywhere a member comparison could reach —
+    /// gates the member-wise fallback in <see cref="SameGenericInstantiationsStructurallyCompatible"/>.
+    /// </summary>
+    private static bool ContainsConditionalType(TypeInfo type) => type switch
+    {
+        TypeInfo.ConditionalType => true,
+        TypeInfo.Array arr => ContainsConditionalType(arr.ElementType),
+        TypeInfo.Promise p => ContainsConditionalType(p.ValueType),
+        TypeInfo.Function f => f.ParamTypes.Any(ContainsConditionalType) || ContainsConditionalType(f.ReturnType),
+        TypeInfo.Tuple t => t.Elements.Any(e => ContainsConditionalType(e.Type))
+            || (t.RestElementType is { } rest && ContainsConditionalType(rest)),
+        TypeInfo.Union u => u.Types.Any(ContainsConditionalType),
+        TypeInfo.Intersection i => i.Types.Any(ContainsConditionalType),
+        TypeInfo.Record r => r.Fields.Values.Any(ContainsConditionalType),
+        TypeInfo.InstantiatedGeneric ig => ig.TypeArguments.Any(ContainsConditionalType),
+        TypeInfo.KeyOf k => ContainsConditionalType(k.SourceType),
+        TypeInfo.IndexedAccess ia => ContainsConditionalType(ia.ObjectType) || ContainsConditionalType(ia.IndexType),
+        TypeInfo.MappedType m => ContainsConditionalType(m.Constraint) || ContainsConditionalType(m.ValueType),
+        _ => false
+    };
 
     /// <summary>Marker types for variance measurement: Sub is structurally assignable to Super
     /// but not conversely (extra member).</summary>

--- a/TypeSystem/TypeChecker.Compatibility.TypeGuards.cs
+++ b/TypeSystem/TypeChecker.Compatibility.TypeGuards.cs
@@ -230,6 +230,27 @@ public partial class TypeChecker
                 TypeInfo? currentType = _environment.Get(varName);
 
                 TypeInfo narrowedType = pred.PredicateType;
+
+                // A generic predicate (`isFunction<T>(value: T): value is Extract<T, Function>`)
+                // narrows by the predicate type INSTANTIATED at this call site — the declaration
+                // form references the callee's own type parameters, which mean nothing here.
+                // `isFunction(x)` with `x: string | (() => string)` must narrow to `() => string`
+                // (the conditional distributes over the inferred union), not to a dangling
+                // `T extends Function ? T : never`.
+                if (calleeType is TypeInfo.GenericFunction predGf && predGf.TypeParams.Count > 0)
+                {
+                    var argTypes = call.Arguments
+                        .Select(a => a is Expr.Variable v
+                            ? _environment.Get(v.Name.Lexeme) ?? new TypeInfo.Any()
+                            : CheckExpr(a))
+                        .ToList();
+                    var typeArgs = InferTypeArguments(predGf, argTypes);
+                    var subs = new Dictionary<string, TypeInfo>();
+                    for (int i = 0; i < predGf.TypeParams.Count && i < typeArgs.Count; i++)
+                        subs[predGf.TypeParams[i].Name] = typeArgs[i];
+                    narrowedType = Substitute(narrowedType, subs);
+                }
+
                 TypeInfo? excludedType = currentType != null
                     ? ExcludeTypeFromUnion(currentType, narrowedType)
                     : null;

--- a/TypeSystem/TypeChecker.Compatibility.cs
+++ b/TypeSystem/TypeChecker.Compatibility.cs
@@ -293,6 +293,53 @@ public partial class TypeChecker
             return IsCompatible(expected, ExpandRecursiveTypeAlias(actualRTA));
         }
 
+        // Conditional types resolve or defer before anything else decides (null rules, the
+        // type-parameter rules, primitives). A conditional that evaluates to a concrete type
+        // restarts the comparison with the result; one that stays deferred goes through tsc's
+        // relation rules for deferred conditionals below.
+        if (expected is TypeInfo.ConditionalType expectedCondRaw)
+        {
+            var evaluated = EvaluateConditionalType(expectedCondRaw);
+            if (evaluated is not TypeInfo.ConditionalType) return IsCompatible(evaluated, actual);
+            expected = evaluated;
+        }
+        if (actual is TypeInfo.ConditionalType actualCondRaw)
+        {
+            var evaluated = EvaluateConditionalType(actualCondRaw);
+            if (evaluated is not TypeInfo.ConditionalType) return IsCompatible(expected, evaluated);
+            actual = evaluated;
+        }
+        if (expected is TypeInfo.ConditionalType || actual is TypeInfo.ConditionalType)
+        {
+            // Two deferred conditionals relate pairwise when their extends types are identical
+            // and their check types relate in either direction: then true branch must relate to
+            // true branch and false to false (checker.ts: conditional-to-conditional rule).
+            // `Covariant<B> → Covariant<A>` (B extends A) relates this way without variance
+            // machinery. On failure, fall through to the one-sided rules.
+            if (expected is TypeInfo.ConditionalType expPair && actual is TypeInfo.ConditionalType actPair &&
+                TypeInfoEqualityComparer.Instance.Equals(expPair.ExtendsType, actPair.ExtendsType) &&
+                (IsCompatible(expPair.CheckType, actPair.CheckType) || IsCompatible(actPair.CheckType, expPair.CheckType)) &&
+                IsCompatible(expPair.TrueType, actPair.TrueType) &&
+                IsCompatible(expPair.FalseType, actPair.FalseType))
+            {
+                return true;
+            }
+
+            // Assigning FROM a deferred conditional: it is assignable wherever one of its
+            // constraints is (distributive constraint, then the default true∩extends | false
+            // union — see GetConditionalConstraints).
+            if (actual is TypeInfo.ConditionalType sourceCond)
+            {
+                return GetConditionalConstraints(sourceCond).Any(c => IsCompatible(expected, c));
+            }
+
+            // Assigning TO a deferred conditional is sound only when the source satisfies BOTH
+            // branches — the conditional could resolve to either at instantiation time.
+            var targetCond = (TypeInfo.ConditionalType)expected;
+            return IsCompatible(targetCond.TrueType, actual)
+                && IsCompatible(targetCond.FalseType, actual);
+        }
+
         // Type predicate compatibility:
         // - Regular type predicate (x is T): expects boolean return
         // - Assertion type predicate (asserts x is T): expects void return (function throws if assertion fails)
@@ -326,11 +373,14 @@ public partial class TypeChecker
         }
 
         // Expected is a bare type parameter and the source is some other type. An arbitrary concrete
-        // type is NOT assignable to a type parameter — only `never`. (any / inferred and, under
-        // non-strict, null / undefined are already accepted earlier in IsCompatibleCore; a source type
-        // parameter is handled by the case above.) This is the strict TypeScript rule.
+        // type is NOT assignable to a type parameter — only `never`, or an intersection one of whose
+        // constituents is (T & Function → T). (any / inferred and, under non-strict, null / undefined
+        // are already accepted earlier in IsCompatibleCore; a source type parameter is handled by the
+        // case above.) This is the strict TypeScript rule.
         if (expected is TypeInfo.TypeParameter)
         {
+            if (actual is TypeInfo.Intersection actIntForTp)
+                return actIntForTp.FlattenedTypes.Any(t => IsCompatible(expected, t));
             return actual is TypeInfo.Never;
         }
 
@@ -378,32 +428,6 @@ public partial class TypeChecker
         if (actual is TypeInfo.Object)
         {
             return expected is TypeInfo.Object or TypeInfo.Any or TypeInfo.Unknown;
-        }
-
-        // Conditional types must expand before the null/undefined/primitive rules below decide —
-        // `const a: Weird = null` where `type Weird = any extends infer U ? U : never` needs the
-        // conditional collapsed to `any` first, or the null rule rejects it sight unseen.
-        if (expected is TypeInfo.ConditionalType expectedCondEarly)
-        {
-            var evaluated = EvaluateConditionalType(expectedCondEarly);
-            // A conditional whose check type is still a naked type parameter can't be
-            // resolved to a branch (tsc defers it). Assigning *to* a deferred conditional
-            // is sound only when the source satisfies BOTH branches — the conditional could
-            // resolve to either at instantiation time. (checker.ts relateConditionalTypes.)
-            if (evaluated is TypeInfo.ConditionalType stillDeferred)
-                return IsCompatible(stillDeferred.TrueType, actual)
-                    && IsCompatible(stillDeferred.FalseType, actual);
-            return IsCompatible(evaluated, actual);
-        }
-        if (actual is TypeInfo.ConditionalType actualCondEarly)
-        {
-            var evaluated = EvaluateConditionalType(actualCondEarly);
-            // Assigning *from* a deferred conditional: both possible results must satisfy
-            // the target (the conditional's constraint is the union of its branches).
-            if (evaluated is TypeInfo.ConditionalType stillDeferred)
-                return IsCompatible(expected, stillDeferred.TrueType)
-                    && IsCompatible(expected, stillDeferred.FalseType);
-            return IsCompatible(expected, evaluated);
         }
 
         // Null compatibility (strictNullChecks: on — the off case is handled early in IsCompatibleCore)
@@ -502,6 +526,17 @@ public partial class TypeChecker
             return actTypes.Any(t => IsCompatible(expected, t));
         }
 
+        // keyof X ← keyof Y with generic operands compares the OPERANDS, contravariantly:
+        // Y's keys include X's exactly when X is assignable to Y (keyof B accepts keyof A
+        // when B extends A — B has at least A's keys). Expansion can't decide this (generic
+        // operands have no concrete key set).
+        if (expected is TypeInfo.KeyOf expKoPair && actual is TypeInfo.KeyOf actKoPair &&
+            (IsGenericTypeShape(expKoPair.SourceType) || IsGenericTypeShape(actKoPair.SourceType)))
+        {
+            return TypeInfoEqualityComparer.Instance.Equals(expKoPair.SourceType, actKoPair.SourceType)
+                || IsCompatible(actKoPair.SourceType, expKoPair.SourceType);
+        }
+
         // KeyOf type compatibility - must evaluate to compare
         // Special handling for keyof T where T is a type parameter - don't try to expand
         if (expected is TypeInfo.KeyOf expectedKeyOf)
@@ -552,18 +587,6 @@ public partial class TypeChecker
         if (actual is TypeInfo.IndexedAccess actualIA)
         {
             TypeInfo expandedActual = ResolveIndexedAccess(actualIA, new Dictionary<string, TypeInfo>());
-            return IsCompatible(expected, expandedActual);
-        }
-
-        // Conditional type compatibility - evaluate then compare
-        if (expected is TypeInfo.ConditionalType expectedCond)
-        {
-            TypeInfo expandedExpected = EvaluateConditionalType(expectedCond);
-            return IsCompatible(expandedExpected, actual);
-        }
-        if (actual is TypeInfo.ConditionalType actualCond)
-        {
-            TypeInfo expandedActual = EvaluateConditionalType(actualCond);
             return IsCompatible(expected, expandedActual);
         }
 

--- a/TypeSystem/TypeChecker.Generics.Conditional.cs
+++ b/TypeSystem/TypeChecker.Generics.Conditional.cs
@@ -55,24 +55,25 @@ public partial class TypeChecker
             // Apply current substitutions to the check type
             TypeInfo checkType = SubstituteWithoutConditionalEval(conditional.CheckType, substitutions);
 
-            // If check type is still a naked type parameter (not substituted), defer evaluation
-            if (checkType is TypeInfo.TypeParameter)
+            // Distribution happens only for DISTRIBUTIVE conditionals (declared with a naked
+            // type-parameter check). A literal `string | number extends string ? A : B` does not
+            // distribute in tsc — the union is checked as a whole.
+            if (conditional.IsDistributive && checkType is TypeInfo.Union union)
             {
-                // Return unevaluated conditional with substitutions applied
+                return DistributeConditionalOverUnion(conditional, union, substitutions);
+            }
+
+            // A check type that still contains type variables (naked parameter, parameter inside
+            // an array/function/intersection, a nested deferred conditional, ...) can't be decided
+            // yet — defer, preserving the declaration's distributivity (tsc isGenericType deferral).
+            if (IsGenericTypeShape(checkType))
+            {
                 return new TypeInfo.ConditionalType(
                     checkType,
                     SubstituteWithoutConditionalEval(conditional.ExtendsType, substitutions),
                     SubstituteWithoutConditionalEval(conditional.TrueType, substitutions),
                     SubstituteWithoutConditionalEval(conditional.FalseType, substitutions)
-                );
-            }
-
-            // Distribution: if check type is a union (either from substitution or directly), distribute
-            // This handles both: T extends U ? X : Y where T substitutes to union,
-            // and directly expanded types like: string | number extends U ? X : Y
-            if (checkType is TypeInfo.Union union)
-            {
-                return DistributeConditionalOverUnion(conditional, union, substitutions);
+                ) { IsDistributive = conditional.IsDistributive };
             }
 
             // Apply substitutions to the extends type
@@ -166,7 +167,8 @@ public partial class TypeChecker
                     SubstituteWithoutConditionalEval(cond.CheckType, substitutions),
                     SubstituteWithoutConditionalEval(cond.ExtendsType, substitutions),
                     SubstituteWithoutConditionalEval(cond.TrueType, substitutions),
-                    SubstituteWithoutConditionalEval(cond.FalseType, substitutions)),
+                    SubstituteWithoutConditionalEval(cond.FalseType, substitutions))
+                { IsDistributive = cond.IsDistributive },
             TypeInfo.InferredTypeParameter infer =>
                 substitutions.TryGetValue(infer.Name, out var inferSub)
                     ? inferSub
@@ -551,6 +553,163 @@ public partial class TypeChecker
 
         // Fall back to standard compatibility check (no infer patterns)
         return IsCompatible(extendsType, checkType);
+    }
+
+    /// <summary>
+    /// True when the type still contains type variables (type parameters, infer placeholders,
+    /// deferred conditionals) anywhere instantiation could reach — tsc's isGenericType, used to
+    /// decide whether a conditional's check type can be decided now or must defer.
+    /// </summary>
+    private static bool IsGenericTypeShape(TypeInfo type) => type switch
+    {
+        TypeInfo.TypeParameter or TypeInfo.InferredTypeParameter => true,
+        // A conditional that reaches this point is deferred (concrete ones evaluate away).
+        TypeInfo.ConditionalType => true,
+        TypeInfo.KeyOf k => IsGenericTypeShape(k.SourceType),
+        TypeInfo.IndexedAccess ia => IsGenericTypeShape(ia.ObjectType) || IsGenericTypeShape(ia.IndexType),
+        TypeInfo.Intersection i => i.Types.Any(IsGenericTypeShape),
+        TypeInfo.Union u => u.Types.Any(IsGenericTypeShape),
+        TypeInfo.Array arr => IsGenericTypeShape(arr.ElementType),
+        TypeInfo.Promise p => IsGenericTypeShape(p.ValueType),
+        TypeInfo.Tuple t => t.Elements.Any(e => IsGenericTypeShape(e.Type))
+            || (t.RestElementType is { } rest && IsGenericTypeShape(rest)),
+        TypeInfo.Function f => f.ParamTypes.Any(IsGenericTypeShape) || IsGenericTypeShape(f.ReturnType),
+        TypeInfo.InstantiatedGeneric ig => ig.TypeArguments.Any(IsGenericTypeShape),
+        TypeInfo.RecursiveTypeAlias rta => rta.TypeArguments is { } args && args.Any(IsGenericTypeShape),
+        TypeInfo.Record r => r.Fields.Values.Any(IsGenericTypeShape),
+        TypeInfo.MappedType => true,
+        TypeInfo.IntrinsicStringType ist => IsGenericTypeShape(ist.Inner),
+        TypeInfo.TemplateLiteralType tl => tl.InterpolatedTypes.Any(IsGenericTypeShape),
+        _ => false
+    };
+
+    /// <summary>
+    /// In-progress guard for <see cref="GetConditionalConstraint"/> — self-referential
+    /// constraints (e.g. <c>T76&lt;T extends T[]&gt;</c>) would otherwise recurse forever.
+    /// </summary>
+    [ThreadStatic]
+    private static HashSet<string>? _conditionalConstraintInProgress;
+
+    /// <summary>
+    /// The assignability constraint of a DEFERRED conditional type, mirroring tsc's two-step
+    /// rule for relating a conditional source to a non-conditional target:
+    /// 1. Distributive constraint: for a distributive conditional whose check type is a
+    ///    constrained type parameter, the conditional applied to that constraint
+    ///    (<c>ZeroOf&lt;T extends number|string&gt;</c> ⇒ <c>0 | ""</c>).
+    /// 2. Default constraint: union of the true branch instantiated with
+    ///    <c>check ∩ extends</c> for the check parameter (tsc's substitution-type narrowing —
+    ///    <c>Extract&lt;T, Foo&gt;</c> constrains to <c>T &amp; Foo</c>) and the false branch.
+    /// Infer placeholders are erased to their declared constraint (or unknown).
+    /// Returns null when no useful constraint can be computed.
+    /// </summary>
+    private List<TypeInfo> GetConditionalConstraints(TypeInfo.ConditionalType cond)
+    {
+        var key = cond.CacheKey();
+        _conditionalConstraintInProgress ??= new(StringComparer.Ordinal);
+        if (!_conditionalConstraintInProgress.Add(key)) return [];
+        try
+        {
+            List<TypeInfo> constraints = [];
+
+            // Step 1: distributive constraint over the check parameter's own constraint.
+            if (cond.IsDistributive && cond.CheckType is TypeInfo.TypeParameter tp &&
+                ApparentTypeOf(tp) is { } tpConstraint)
+            {
+                var instantiated = EvaluateConditionalType(cond, new() { [tp.Name] = tpConstraint });
+                if (instantiated is not (TypeInfo.Never or TypeInfo.ConditionalType))
+                    constraints.Add(instantiated);
+            }
+
+            // Step 2: default constraint — true branch under check ∩ extends, unioned with false.
+            Dictionary<string, TypeInfo> subs = [];
+            CollectInferSubstitutions(cond.ExtendsType, subs);
+            var erasedExtends = subs.Count > 0
+                ? SubstituteWithoutConditionalEval(cond.ExtendsType, subs)
+                : cond.ExtendsType;
+            TypeInfo trueConstraint;
+            if (cond.CheckType is TypeInfo.TypeParameter checkTp)
+            {
+                subs[checkTp.Name] = SimplifyIntersection([checkTp, erasedExtends]);
+                trueConstraint = Substitute(cond.TrueType, subs);
+            }
+            else if (TypeInfoEqualityComparer.Instance.Equals(cond.TrueType, cond.CheckType))
+            {
+                // tsc narrows true-branch occurrences of the check type via substitution types
+                // even when the check is itself a composite (`Extract<Extract<T, Foo>, Bar>`:
+                // the outer true branch is the inner conditional narrowed by ∩ Bar). We have no
+                // substitution-type node, but the Extract/Exclude shape — true branch IS the
+                // check type — covers the cases that reach here. A conditional check resolves to
+                // its own constraint first so the intersection's object members can merge.
+                var checkUpperBound = cond.CheckType is TypeInfo.ConditionalType innerCond &&
+                    GetConditionalConstraints(innerCond) is { Count: > 0 } innerConstraints
+                        ? innerConstraints[^1]
+                        : cond.CheckType;
+                trueConstraint = SimplifyIntersection([checkUpperBound, erasedExtends]);
+            }
+            else
+            {
+                trueConstraint = subs.Count > 0 ? Substitute(cond.TrueType, subs) : cond.TrueType;
+            }
+            constraints.Add(CreateUnion(trueConstraint, cond.FalseType));
+            return constraints;
+        }
+        catch (TypeCheckException)
+        {
+            // Constraint computation is best-effort: a depth/circularity failure here must not
+            // surface as a checker diagnostic — callers fall back to stricter rules.
+            return [];
+        }
+        finally
+        {
+            _conditionalConstraintInProgress.Remove(key);
+        }
+    }
+
+    /// <summary>
+    /// Maps every <c>infer</c> placeholder in an extends clause to its declared constraint (or
+    /// unknown), so branch types referencing them can be used as a constraint approximation.
+    /// </summary>
+    private static void CollectInferSubstitutions(TypeInfo extendsType, Dictionary<string, TypeInfo> subs)
+    {
+        switch (extendsType)
+        {
+            case TypeInfo.InferredTypeParameter infer:
+                subs.TryAdd(infer.Name, infer.Constraint ?? new TypeInfo.Unknown());
+                break;
+            case TypeInfo.Array arr: CollectInferSubstitutions(arr.ElementType, subs); break;
+            case TypeInfo.Promise p: CollectInferSubstitutions(p.ValueType, subs); break;
+            case TypeInfo.Function f:
+                foreach (var pt in f.ParamTypes) CollectInferSubstitutions(pt, subs);
+                CollectInferSubstitutions(f.ReturnType, subs);
+                break;
+            case TypeInfo.Tuple t:
+                foreach (var e in t.Elements) CollectInferSubstitutions(e.Type, subs);
+                if (t.RestElementType is { } rest) CollectInferSubstitutions(rest, subs);
+                break;
+            case TypeInfo.Union u:
+                foreach (var m in u.Types) CollectInferSubstitutions(m, subs);
+                break;
+            case TypeInfo.Intersection i:
+                foreach (var m in i.Types) CollectInferSubstitutions(m, subs);
+                break;
+            case TypeInfo.Record r:
+                foreach (var (_, v) in r.Fields) CollectInferSubstitutions(v, subs);
+                break;
+            case TypeInfo.Interface itf:
+                foreach (var (_, v) in itf.Members) CollectInferSubstitutions(v, subs);
+                break;
+            case TypeInfo.InstantiatedGeneric ig:
+                foreach (var a in ig.TypeArguments) CollectInferSubstitutions(a, subs);
+                break;
+            case TypeInfo.KeyOf k: CollectInferSubstitutions(k.SourceType, subs); break;
+            case TypeInfo.IndexedAccess ia:
+                CollectInferSubstitutions(ia.ObjectType, subs);
+                CollectInferSubstitutions(ia.IndexType, subs);
+                break;
+            case TypeInfo.TemplateLiteralType tl:
+                foreach (var it in tl.InterpolatedTypes) CollectInferSubstitutions(it, subs);
+                break;
+        }
     }
 
     /// <summary>

--- a/TypeSystem/TypeChecker.Generics.Inference.cs
+++ b/TypeSystem/TypeChecker.Generics.Inference.cs
@@ -19,9 +19,29 @@ public partial class TypeChecker
         Dictionary<string, TypeInfo> inferred = [];
 
         // Try to infer each type parameter from the corresponding argument
-        for (int i = 0; i < gf.ParamTypes.Count && i < argTypes.Count; i++)
+        int regularParams = gf.HasRestParam ? gf.ParamTypes.Count - 1 : gf.ParamTypes.Count;
+        for (int i = 0; i < regularParams && i < argTypes.Count; i++)
         {
             InferFromType(gf.ParamTypes[i], argTypes[i], inferred);
+        }
+
+        // Rest parameter: `...args: T[]` infers the element from every remaining argument;
+        // `...args: A` where A is itself a type parameter (A extends any[]) infers A as the
+        // TUPLE of the remaining argument types — pairing A with a single argument type would
+        // produce a non-array inference that trips A's constraint (inferTypes1 invoker).
+        if (gf.HasRestParam && gf.ParamTypes.Count > 0)
+        {
+            var restDeclared = gf.ParamTypes[^1];
+            var restArgs = argTypes.Skip(regularParams).ToList();
+            if (restDeclared is TypeInfo.Array restArr)
+            {
+                foreach (var restArg in restArgs)
+                    InferFromType(restArr.ElementType, restArg, inferred);
+            }
+            else if (restDeclared is TypeInfo.TypeParameter && restArgs.Count > 0)
+            {
+                InferFromType(restDeclared, TypeInfo.Tuple.FromTypes(restArgs, restArgs.Count), inferred);
+            }
         }
 
         // Build result list in order of type parameters

--- a/TypeSystem/TypeChecker.Generics.UtilityTypes.cs
+++ b/TypeSystem/TypeChecker.Generics.UtilityTypes.cs
@@ -15,6 +15,21 @@ namespace SharpTS.TypeSystem;
 public partial class TypeChecker
 {
     /// <summary>
+    /// True when a type's shape can't be inspected yet — a type variable or a construct whose
+    /// resolution depends on one (a deferred conditional, T[K], keyof T). The conditional-shaped
+    /// utility expanders (Extract, Exclude, NonNullable, ReturnType, ...) must DEFER for these
+    /// instead of eagerly evaluating: `Extract&lt;Extract&lt;T, Foo&gt;, Bar&gt;` collapses to never if the
+    /// inner deferred conditional is fed through the eager path.
+    /// </summary>
+    private static bool IsAbstractTypeReference(TypeInfo type) => type switch
+    {
+        TypeInfo.TypeParameter or TypeInfo.InferredTypeParameter or TypeInfo.ConditionalType
+            or TypeInfo.IndexedAccess or TypeInfo.KeyOf or TypeInfo.MappedType => true,
+        TypeInfo.Intersection i => i.Types.Any(IsAbstractTypeReference),
+        _ => false
+    };
+
+    /// <summary>
     /// Expands Partial&lt;T&gt; to an interface where all properties are optional.
     /// Equivalent to: { [K in keyof T]?: T[K] }
     /// </summary>
@@ -361,8 +376,8 @@ public partial class TypeChecker
     /// </summary>
     private TypeInfo ExpandReturnType(TypeInfo functionType)
     {
-        // Handle type parameters - defer evaluation
-        if (functionType is TypeInfo.TypeParameter)
+        // Defer for type variables and constructs that depend on them
+        if (IsAbstractTypeReference(functionType))
         {
             // Return a conditional type for lazy evaluation
             return new TypeInfo.ConditionalType(
@@ -370,7 +385,7 @@ public partial class TypeChecker
                 new TypeInfo.Function([new TypeInfo.Any()], new TypeInfo.Any(), HasRestParam: true),
                 new TypeInfo.InferredTypeParameter("R"),
                 new TypeInfo.Never()
-            );
+            ) { IsDistributive = true };
         }
 
         // Handle unions - distribute over union members
@@ -411,15 +426,15 @@ public partial class TypeChecker
     /// </summary>
     private TypeInfo ExpandParameters(TypeInfo functionType)
     {
-        // Handle type parameters - defer evaluation
-        if (functionType is TypeInfo.TypeParameter)
+        // Defer for type variables and constructs that depend on them
+        if (IsAbstractTypeReference(functionType))
         {
             return new TypeInfo.ConditionalType(
                 functionType,
                 new TypeInfo.Function([new TypeInfo.Any()], new TypeInfo.Any(), HasRestParam: true),
                 new TypeInfo.InferredTypeParameter("P"),
                 new TypeInfo.Never()
-            );
+            ) { IsDistributive = true };
         }
 
         // Handle unions - distribute over union members
@@ -457,15 +472,15 @@ public partial class TypeChecker
     /// </summary>
     private TypeInfo ExpandConstructorParameters(TypeInfo classType)
     {
-        // Handle type parameters - defer evaluation
-        if (classType is TypeInfo.TypeParameter)
+        // Defer for type variables and constructs that depend on them
+        if (IsAbstractTypeReference(classType))
         {
             return new TypeInfo.ConditionalType(
                 classType,
                 new TypeInfo.Any(), // Represents constructor type
                 new TypeInfo.InferredTypeParameter("P"),
                 new TypeInfo.Never()
-            );
+            ) { IsDistributive = true };
         }
 
         // Handle unions - distribute
@@ -551,15 +566,15 @@ public partial class TypeChecker
     /// </summary>
     private TypeInfo ExpandInstanceType(TypeInfo classType)
     {
-        // Handle type parameters - defer evaluation
-        if (classType is TypeInfo.TypeParameter)
+        // Defer for type variables and constructs that depend on them
+        if (IsAbstractTypeReference(classType))
         {
             return new TypeInfo.ConditionalType(
                 classType,
                 new TypeInfo.Any(),
                 new TypeInfo.InferredTypeParameter("R"),
                 new TypeInfo.Never()
-            );
+            ) { IsDistributive = true };
         }
 
         // Handle unions - distribute
@@ -596,15 +611,15 @@ public partial class TypeChecker
     /// </summary>
     private TypeInfo ExpandAwaited(TypeInfo type)
     {
-        // Handle type parameters - defer evaluation
-        if (type is TypeInfo.TypeParameter)
+        // Defer for type variables and constructs that depend on them
+        if (IsAbstractTypeReference(type))
         {
             return new TypeInfo.ConditionalType(
                 type,
                 new TypeInfo.Promise(new TypeInfo.Any()),
                 new TypeInfo.InferredTypeParameter("U"),
                 type
-            );
+            ) { IsDistributive = true };
         }
 
         // Handle unions - distribute
@@ -637,15 +652,15 @@ public partial class TypeChecker
     /// </summary>
     private TypeInfo ExpandNonNullable(TypeInfo type)
     {
-        // Handle type parameters - defer evaluation
-        if (type is TypeInfo.TypeParameter)
+        // Defer for type variables and constructs that depend on them
+        if (IsAbstractTypeReference(type))
         {
             return new TypeInfo.ConditionalType(
                 type,
                 new TypeInfo.Union([new TypeInfo.Null(), new TypeInfo.Undefined()]),
                 new TypeInfo.Never(),
                 type
-            );
+            ) { IsDistributive = true };
         }
 
         // Handle unions - filter out null and undefined
@@ -678,15 +693,15 @@ public partial class TypeChecker
     /// </summary>
     private TypeInfo ExpandExtract(TypeInfo type, TypeInfo constraint)
     {
-        // Handle type parameters - defer evaluation
-        if (type is TypeInfo.TypeParameter)
+        // Defer for type variables and constructs that depend on them
+        if (IsAbstractTypeReference(type))
         {
             return new TypeInfo.ConditionalType(
                 type,
                 constraint,
                 type,
                 new TypeInfo.Never()
-            );
+            ) { IsDistributive = true };
         }
 
         // Handle unions - filter members assignable to constraint
@@ -714,15 +729,15 @@ public partial class TypeChecker
     /// </summary>
     private TypeInfo ExpandExclude(TypeInfo type, TypeInfo constraint)
     {
-        // Handle type parameters - defer evaluation
-        if (type is TypeInfo.TypeParameter)
+        // Defer for type variables and constructs that depend on them
+        if (IsAbstractTypeReference(type))
         {
             return new TypeInfo.ConditionalType(
                 type,
                 constraint,
                 new TypeInfo.Never(),
                 type
-            );
+            ) { IsDistributive = true };
         }
 
         // Handle unions - filter out members assignable to constraint

--- a/TypeSystem/TypeChecker.Generics.cs
+++ b/TypeSystem/TypeChecker.Generics.cs
@@ -310,6 +310,17 @@ public partial class TypeChecker
                     // Parse the expanded definition
                     result = ToTypeInfo(expanded);
 
+                    // The string pipeline substitutes arguments BEFORE parsing, so a distributive
+                    // alias (`type Check<T> = T extends ...` — naked-param check) instantiated
+                    // with a union parses as a union-checked conditional and would lose its
+                    // distributivity. Recover the flag from the DECLARED definition's check side.
+                    if (result is TypeInfo.ConditionalType parsedCond && !parsedCond.IsDistributive)
+                    {
+                        int declExtendsIdx = FindTopLevelKeyword(definition, " extends ");
+                        if (declExtendsIdx > 0 && typeParamNames.Contains(definition[..declExtendsIdx].Trim()))
+                            result = parsedCond with { IsDistributive = true };
+                    }
+
                     // An instantiation whose arguments are fully concrete can apply its result
                     // now — downstream consumers (property access in particular) operate on
                     // the resolved type, not on a raw ConditionalType/MappedType node (#185).

--- a/TypeSystem/TypeChecker.Properties.Index.cs
+++ b/TypeSystem/TypeChecker.Properties.Index.cs
@@ -40,6 +40,24 @@ public partial class TypeChecker
             return new TypeInfo.Any();
         }
 
+        // A deferred conditional is indexed through its constraint — `x[0]` where
+        // `x: T extends (infer U)[] ? U[] : never` reads through `unknown[]`
+        // (conditionalTypes1 f22/f23). Evaluate first: a concrete check resolves to a branch.
+        if (objType is TypeInfo.ConditionalType condObj)
+        {
+            var evaluated = EvaluateConditionalType(condObj);
+            if (evaluated is TypeInfo.ConditionalType stillDeferred)
+            {
+                foreach (var constraint in GetConditionalConstraints(stillDeferred))
+                {
+                    if (CheckGetIndexOnType(constraint, indexType, getIndex) is { } viaConstraint)
+                        return viaConstraint;
+                }
+                return new TypeInfo.Any();
+            }
+            return CheckGetIndexOnType(evaluated, indexType, getIndex);
+        }
+
         // Optional bracket access: strip null/undefined from object type
         if (getIndex.Optional && objType is TypeInfo.Union optUnion)
         {
@@ -120,6 +138,16 @@ public partial class TypeChecker
                 return new TypeInfo.Any();
             }
 
+            // A generic key whose constraint is key-like (K extends string | number | symbol)
+            // indexes a generic object the same way a plain string key does — T[K] can only be
+            // judged at instantiation (inferTypes1 invoker: obj[key] with obj: T, key: K).
+            if (indexType is TypeInfo.TypeParameter genericKeyForTp &&
+                ApparentTypeOf(genericKeyForTp) is { } keyLikeApparent &&
+                IsCompatible(KeyLikeUnion, keyLikeApparent))
+            {
+                return new TypeInfo.Any();
+            }
+
             // Unconstrained type parameter can't be indexed with arbitrary types
             throw new TypeCheckException($" Cannot index type parameter '{objTp.Name}' with type '{indexType}'.", tsCode: "TS7053");
         }
@@ -145,6 +173,16 @@ public partial class TypeChecker
         if (indexType is TypeInfo.Any)
         {
             return new TypeInfo.Any();
+        }
+
+        // A generic key (K extends string | number | symbol) reaching an object with an index
+        // signature resolves to the signature's value type — `obj[key]` where
+        // `obj: Record<K, V>` is V (inferTypes1 invoker).
+        if (indexType is TypeInfo.TypeParameter genericKey &&
+            ApparentTypeOf(genericKey) is { } keyApparent && IsCompatible(KeyLikeUnion, keyApparent))
+        {
+            if (objType is TypeInfo.Record { StringIndexType: { } recIdxType }) return recIdxType;
+            if (objType is TypeInfo.Interface { StringIndexType: { } itfIdxType }) return itfIdxType;
         }
 
         // Handle string index on objects/interfaces

--- a/TypeSystem/TypeChecker.Statements.AliasValidation.cs
+++ b/TypeSystem/TypeChecker.Statements.AliasValidation.cs
@@ -1,0 +1,373 @@
+using SharpTS.Parsing;
+using SharpTS.TypeSystem.Exceptions;
+
+namespace SharpTS.TypeSystem;
+
+/// <summary>
+/// Declaration-time validation of type-alias bodies: infer placement (TS1338), out-of-scope
+/// infer references (TS2304), generic-reference type-argument constraints (TS2344), and
+/// mapped-type key constraints (TS2322). tsc reports these when it CHECKS the alias
+/// declaration; lazy expansion alone never surfaces them.
+/// </summary>
+public partial class TypeChecker
+{
+    /// <summary>
+    /// Declared constraint strings per generic-alias type parameter, keyed by alias name.
+    /// <see cref="TypeEnvironment.DefineGenericTypeAlias"/> stores only parameter NAMES, and
+    /// reference-site TS2344 validation needs the constraints. Checker-scoped (not
+    /// scope-aware) — same-named aliases in different scopes share an entry, acceptable for a
+    /// best-effort validation that skips when in doubt.
+    /// </summary>
+    private Dictionary<string, List<string?>>? _aliasParamConstraints;
+
+    private void RecordAliasParamConstraints(Stmt.TypeAlias stmt)
+    {
+        if (stmt.TypeParameters is not { Count: > 0 } tps) return;
+        _aliasParamConstraints ??= new(StringComparer.Ordinal);
+        _aliasParamConstraints[stmt.Name.Lexeme] = tps.Select(tp => tp.Constraint).ToList();
+    }
+
+    /// <summary>
+    /// Validates an alias body's type-node tree. Runs after the alias is defined so the alias
+    /// stays usable when its body is malformed. Throws on the first violation (per-statement
+    /// recovery reports it and moves on).
+    /// </summary>
+    private void ValidateAliasBody(Stmt.TypeAlias stmt)
+    {
+        if (stmt.TypeDefinitionNode is not { } body) return;
+
+        // Bind the alias's own type parameters (with constraints) so references inside the
+        // body resolve to TypeParameter — constraint checks then go through apparent types.
+        var aliasEnv = new TypeEnvironment(_environment);
+        if (stmt.TypeParameters is { Count: > 0 } tps)
+        {
+            var previous = _environment;
+            _environment = aliasEnv;
+            try { BuildGenericTypeParameters(tps, aliasEnv); }
+            catch (TypeCheckException) { /* malformed constraint — reported elsewhere */ }
+            finally { _environment = previous; }
+        }
+
+        var previousEnv = _environment;
+        _environment = aliasEnv;
+        try
+        {
+            ValidateAliasBodyNode(body, inferLegal: false, infersOutOfScope: null);
+        }
+        finally
+        {
+            _environment = previousEnv;
+        }
+    }
+
+    private void ValidateAliasBodyNode(TypeNode node, bool inferLegal, HashSet<string>? infersOutOfScope)
+    {
+        switch (node)
+        {
+            case InferTypeNode infer when !inferLegal:
+                throw new TypeCheckException(
+                    " 'infer' declarations are only permitted in the 'extends' clause of a conditional type.",
+                    infer.Line, tsCode: "TS1338");
+
+            case NamedTypeNode { TypeArguments: null } bare:
+                // A name that is only bound as an infer of an enclosing conditional, referenced
+                // from a position where infers are not in scope (check type, false branch).
+                // Restricted to KNOWN infer names — general unknown-name TS2304 is parked (the
+                // any-fallback is load-bearing in deferred-resolution contexts).
+                if (infersOutOfScope is not null && infersOutOfScope.Contains(bare.Name) &&
+                    _environment.GetTypeParameter(bare.Name) is null &&
+                    _environment.GetTypeAlias(bare.Name) is null &&
+                    _environment.GetGenericTypeAlias(bare.Name) is null)
+                {
+                    throw new TypeCheckException(
+                        $" Cannot find name '{bare.Name}'.", bare.Line, tsCode: "TS2304");
+                }
+                return;
+
+            case NamedTypeNode { TypeArguments: { } argNodes } genericRef:
+                ValidateGenericReferenceArguments(genericRef, argNodes);
+                foreach (var arg in argNodes)
+                    ValidateAliasBodyNode(arg, inferLegal, infersOutOfScope);
+                return;
+
+            case MappedTypeNode mapped:
+            {
+                // The `in` clause's keys must be key-like (tsc TS2322: "Type 'T' is not
+                // assignable to type 'string | number | symbol'"). Conditional-type narrowing
+                // of the key source is handled by the conditional case re-binding parameters.
+                // A type-parameter key is judged by its apparent type: unconstrained = error
+                // (inferTypes1 `string extends T ? { [P in T]: void } : T`), undecidable
+                // constraint (keyof any) = skip.
+                var keys = TryToTypeInfo(mapped.Constraint);
+                if (keys is TypeInfo.TypeParameter keyParam)
+                    keys = ApparentTypeOf(keyParam) ?? new TypeInfo.Unknown();
+                if (keys is not null && !IsGenericKeySourceUndecidable(keys) &&
+                    !IsCompatible(KeyLikeUnion, keys))
+                {
+                    throw new TypeCheckException(
+                        $" Type '{TryToTypeInfo(mapped.Constraint)}' is not assignable to type 'string | number | symbol'.",
+                        mapped.Line, tsCode: "TS2322");
+                }
+                foreach (var child in TypeNodeChildren(node))
+                    ValidateAliasBodyNode(child, inferLegal, infersOutOfScope);
+                return;
+            }
+
+            case ConditionalTypeNode conditional:
+            {
+                List<InferTypeNode>? clauseInfers = null;
+                CollectClauseInfers(conditional.ExtendsType, ref clauseInfers);
+                var inferNames = clauseInfers?.Select(i => i.Name).ToHashSet(StringComparer.Ordinal);
+
+                HashSet<string>? outOfScope = infersOutOfScope;
+                if (inferNames is not null)
+                {
+                    outOfScope = infersOutOfScope is null ? inferNames : [.. infersOutOfScope, .. inferNames];
+                }
+
+                // Check type and false branch: infers of THIS clause are not in scope. Legality
+                // of `infer` PLACEMENT is inherited, not reset — once inside some enclosing
+                // extends clause, a nested conditional's check position may declare infers
+                // (inferTypesWithExtends1 X10/X11/X15/X17).
+                ValidateAliasBodyNode(conditional.CheckType, inferLegal, outOfScope);
+                ValidateAliasBodyNode(conditional.FalseType, inferLegal, outOfScope);
+
+                // Extends clause: infer declarations are legal here.
+                ValidateAliasBodyNode(conditional.ExtendsType, inferLegal: true, infersOutOfScope);
+
+                // True branch: this clause's infers are in scope, bound with their positional
+                // constraint (the constraint of the parameter slot the infer occupies — tsc
+                // checks `T70<U>` against U's inferred constraint, inferTypes1 T73). A naked
+                // type-parameter check is narrowed by the extends type (substitution-type
+                // semantics), so `T extends string ? { [P in T]: void } : T` passes the
+                // mapped-key rule while the un-narrowed form fails it.
+                var trueEnv = new TypeEnvironment(_environment);
+                if (clauseInfers is not null)
+                {
+                    var positional = CollectPositionalInferConstraints(conditional.ExtendsType);
+                    foreach (var infer in clauseInfers)
+                    {
+                        TypeInfo? constraint = infer.Constraint is { } cNode ? TryToTypeInfo(cNode) : null;
+                        if (constraint is null && positional is not null)
+                            positional.TryGetValue(infer.Name, out constraint);
+                        trueEnv.DefineTypeParameter(infer.Name, new TypeInfo.TypeParameter(infer.Name, constraint));
+                    }
+                }
+                if (conditional.CheckType is NamedTypeNode { TypeArguments: null } checkRef &&
+                    _environment.GetTypeParameter(checkRef.Name) is TypeInfo.TypeParameter checkParam &&
+                    TryToTypeInfo(conditional.ExtendsType) is { } extendsResolved &&
+                    !ContainsConditionalType(extendsResolved))
+                {
+                    var narrowed = checkParam.Constraint is { } existing
+                        ? SimplifyIntersection([existing, extendsResolved])
+                        : extendsResolved;
+                    trueEnv.DefineTypeParameter(checkRef.Name, checkParam with { Constraint = narrowed });
+                }
+                var previousEnv = _environment;
+                _environment = trueEnv;
+                try
+                {
+                    ValidateAliasBodyNode(conditional.TrueType, inferLegal, infersOutOfScope);
+                }
+                finally
+                {
+                    _environment = previousEnv;
+                }
+                return;
+            }
+
+            default:
+                foreach (var child in TypeNodeChildren(node))
+                    ValidateAliasBodyNode(child, inferLegal, infersOutOfScope);
+                return;
+        }
+    }
+
+    private static readonly TypeInfo KeyLikeUnion = new TypeInfo.Union(
+        [new TypeInfo.String(), new TypeInfo.Primitive(TokenType.TYPE_NUMBER), new TypeInfo.Symbol()]);
+
+    /// <summary>
+    /// Key sources whose membership can't be decided at declaration time (deferred conditionals,
+    /// indexed accesses, keyof over generics) are skipped rather than guessed.
+    /// </summary>
+    private static bool IsGenericKeySourceUndecidable(TypeInfo keys) => keys switch
+    {
+        TypeInfo.KeyOf or TypeInfo.IndexedAccess or TypeInfo.ConditionalType
+            or TypeInfo.InferredTypeParameter or TypeInfo.MappedType or TypeInfo.RecursiveTypeAlias => true,
+        TypeInfo.Union u => u.Types.Any(IsGenericKeySourceUndecidable),
+        TypeInfo.Intersection i => i.Types.Any(IsGenericKeySourceUndecidable),
+        _ => false
+    };
+
+    /// <summary>
+    /// Derives the constraint each unconstrained <c>infer</c> inherits from the parameter slot
+    /// it occupies in the extends clause: in <c>T extends T72&lt;infer U&gt;</c> where
+    /// <c>T72&lt;T extends number&gt;</c>, U's constraint is <c>number</c>. Only generic-reference
+    /// argument slots are mined — other positions contribute nothing.
+    /// </summary>
+    private Dictionary<string, TypeInfo>? CollectPositionalInferConstraints(TypeNode extendsNode)
+    {
+        Dictionary<string, TypeInfo>? result = null;
+        Walk(extendsNode);
+        return result;
+
+        void Walk(TypeNode node)
+        {
+            if (node is NamedTypeNode { TypeArguments: { } args } reference)
+            {
+                var constraints = GetReferenceParamConstraintStrings(reference.Name);
+                for (int i = 0; i < args.Count; i++)
+                {
+                    if (args[i] is InferTypeNode { Constraint: null } infer &&
+                        constraints is not null && i < constraints.Count &&
+                        constraints[i] is { } constraintStr)
+                    {
+                        TypeInfo? constraint = null;
+                        try { constraint = ToTypeInfo(constraintStr); } catch (TypeCheckException) { }
+                        if (constraint is not null && !IsGenericTypeShape(constraint))
+                        {
+                            result ??= new(StringComparer.Ordinal);
+                            // An infer occupying multiple slots must satisfy ALL of them — the
+                            // effective constraint is the intersection (T74<infer U, infer U>
+                            // with slots number/string ⇒ never, which satisfies everything;
+                            // tsc reports no error there).
+                            result[infer.Name] = result.TryGetValue(infer.Name, out var existing)
+                                ? SimplifyIntersection([existing, constraint])
+                                : constraint;
+                        }
+                    }
+                }
+            }
+            if (node is ConditionalTypeNode) return; // nested clause = its own scope
+            foreach (var child in TypeNodeChildren(node))
+                Walk(child);
+        }
+    }
+
+    /// <summary>Declared constraint strings for a referenced generic's parameters, or null.</summary>
+    private List<string?>? GetReferenceParamConstraintStrings(string name)
+    {
+        if (_aliasParamConstraints is not null && _aliasParamConstraints.TryGetValue(name, out var fromAlias))
+            return fromAlias;
+        return _environment.Get(name) switch
+        {
+            TypeInfo.GenericClass gc => gc.TypeParams.Select(tp => tp.Constraint?.ToString()).ToList(),
+            TypeInfo.GenericInterface gi => gi.TypeParams.Select(tp => tp.Constraint?.ToString()).ToList(),
+            _ => null
+        };
+    }
+
+    /// <summary>
+    /// TS2344: every type argument of a generic reference must satisfy the referenced
+    /// parameter's declared constraint. Skips slots whose constraint (or argument) is still
+    /// generic — those can only be judged at instantiation time.
+    /// </summary>
+    private void ValidateGenericReferenceArguments(NamedTypeNode reference, List<TypeNode> argNodes)
+    {
+        // Built-in function-shaped utility types: tsc's lib declares
+        // `ReturnType<T extends (...args: any) => any>` and the abstract-constructor pair.
+        if (reference.Name is "ReturnType" or "Parameters")
+        {
+            ValidateUtilityArg(reference, argNodes, RequireCallable);
+            return;
+        }
+        if (reference.Name is "InstanceType" or "ConstructorParameters")
+        {
+            ValidateUtilityArg(reference, argNodes, RequireConstructable);
+            return;
+        }
+
+        var constraints = GetReferenceParamConstraintStrings(reference.Name);
+        if (constraints is null) return;
+        for (int i = 0; i < argNodes.Count && i < constraints.Count; i++)
+        {
+            if (constraints[i] is not { } constraintStr) continue;
+            TypeInfo? constraint = null;
+            try { constraint = ToTypeInfo(constraintStr); } catch (TypeCheckException) { }
+            // A constraint that still references the target's own parameters (T76<T extends T[]>)
+            // can't be judged against an outer-scope argument — skip.
+            if (constraint is null || IsGenericTypeShape(constraint)) continue;
+
+            // Same `Function`-global discrimination as the built-in utilities: it satisfies no
+            // concrete call signature, but resolves to a shape that would.
+            if (constraint is TypeInfo.Function &&
+                argNodes[i] is NamedTypeNode { Name: "Function", TypeArguments: null })
+            {
+                throw new TypeCheckException(
+                    $" Type 'Function' does not satisfy the constraint '{constraint}'.",
+                    reference.Line, tsCode: "TS2344");
+            }
+
+            if (TryToTypeInfo(argNodes[i]) is not { } arg) continue;
+            // Generic arguments are judged by their own constraint when they have one.
+            if (arg is TypeInfo.TypeParameter { Constraint: { } argConstraint } argParam)
+            {
+                if (!IsGenericTypeShape(argConstraint) && !IsCompatible(constraint, argConstraint))
+                {
+                    throw new TypeCheckException(
+                        $" Type '{argParam.Name}' does not satisfy the constraint '{constraint}'.",
+                        reference.Line, tsCode: "TS2344");
+                }
+                continue;
+            }
+            if (arg is TypeInfo.InferredTypeParameter || IsGenericTypeShape(arg)) continue;
+            if (!IsCompatible(constraint, arg))
+            {
+                throw new TypeCheckException(
+                    $" Type '{arg}' does not satisfy the constraint '{constraint}'.",
+                    reference.Line, tsCode: "TS2344");
+            }
+        }
+    }
+
+    private void ValidateUtilityArg(NamedTypeNode reference, List<TypeNode> argNodes, Func<TypeInfo, bool> satisfies)
+    {
+        if (argNodes.Count != 1) return;
+        // The global `Function` interface has no concrete call/construct signature — tsc
+        // rejects it against both shapes ("Type 'Function' provides no match for the
+        // signature"). Our resolution collapses it to a catch-all function type, so the
+        // discrimination has to happen on the reference node.
+        if (argNodes[0] is NamedTypeNode { Name: "Function", TypeArguments: null })
+            ThrowUtilityConstraintError(reference, new TypeInfo.Interface("Function",
+                System.Collections.Frozen.FrozenDictionary<string, TypeInfo>.Empty,
+                System.Collections.Frozen.FrozenSet<string>.Empty));
+        if (TryToTypeInfo(argNodes[0]) is not { } arg) return;
+        if (arg is TypeInfo.TypeParameter { Constraint: { } tpConstraint })
+        {
+            if (!IsGenericTypeShape(tpConstraint) && !satisfies(tpConstraint))
+                ThrowUtilityConstraintError(reference, arg);
+            return;
+        }
+        if (arg is TypeInfo.Any or TypeInfo.Never or TypeInfo.InferredTypeParameter) return;
+        if (IsGenericTypeShape(arg)) return;
+        if (!satisfies(arg)) ThrowUtilityConstraintError(reference, arg);
+    }
+
+    private static void ThrowUtilityConstraintError(NamedTypeNode reference, TypeInfo arg) =>
+        throw new TypeCheckException(
+            $" Type '{arg}' does not satisfy the constraint of '{reference.Name}'.",
+            reference.Line, tsCode: "TS2344");
+
+    /// <summary>Shapes acceptable to `T extends (...args: any) => any`.</summary>
+    private bool RequireCallable(TypeInfo arg) => arg switch
+    {
+        TypeInfo.Function or TypeInfo.GenericFunction or TypeInfo.OverloadedFunction => true,
+        TypeInfo.Union u => u.FlattenedTypes.All(RequireCallable),
+        TypeInfo.Intersection i => i.FlattenedTypes.Any(RequireCallable),
+        TypeInfo.Record r => r.IsCallable,
+        TypeInfo.Interface itf => itf.CallSignatures is { Count: > 0 },
+        _ => false
+    };
+
+    /// <summary>Shapes acceptable to `T extends abstract new (...args: any) => any`.</summary>
+    private bool RequireConstructable(TypeInfo arg) => arg switch
+    {
+        TypeInfo.Class or TypeInfo.MutableClass or TypeInfo.GenericClass => true,
+        TypeInfo.InstantiatedGeneric { GenericDefinition: TypeInfo.GenericClass } => true,
+        TypeInfo.Union u => u.FlattenedTypes.All(RequireConstructable),
+        TypeInfo.Intersection i => i.FlattenedTypes.Any(RequireConstructable),
+        TypeInfo.Record r => r.IsConstructable,
+        TypeInfo.Interface itf => itf.ConstructorSignatures is { Count: > 0 },
+        _ => false
+    };
+}

--- a/TypeSystem/TypeChecker.Statements.Functions.cs
+++ b/TypeSystem/TypeChecker.Statements.Functions.cs
@@ -44,13 +44,16 @@ public partial class TypeChecker
     {
         foreach (var stmt in statements)
         {
-            // Handle top-level functions
-            if (stmt is Stmt.Function funcStmt && funcStmt.Body != null)
+            // Handle top-level functions. Body-less declarations (ambient `declare function`,
+            // overload signatures) hoist too — tsc resolves calls that precede the declaration.
+            // For an overload group only the first signature lands here; the visit pass installs
+            // the full OverloadedFunction when it reaches the group.
+            if (stmt is Stmt.Function funcStmt)
             {
                 HoistSingleFunction(funcStmt);
             }
             // Handle exported functions
-            else if (stmt is Stmt.Export export && export.Declaration is Stmt.Function exportedFunc && exportedFunc.Body != null)
+            else if (stmt is Stmt.Export export && export.Declaration is Stmt.Function exportedFunc)
             {
                 HoistSingleFunction(exportedFunc);
             }

--- a/TypeSystem/TypeChecker.Statements.cs
+++ b/TypeSystem/TypeChecker.Statements.cs
@@ -104,6 +104,8 @@ public partial class TypeChecker
         // the infer declarations of every conditional type in the alias body.
         var outerTypeParams = stmt.TypeParameters?.Select(tp => tp.Name.Lexeme).ToHashSet(StringComparer.Ordinal);
         ValidateInferDeclarations(stmt.TypeDefinitionNode, outerTypeParams);
+        RecordAliasParamConstraints(stmt);
+        ValidateAliasBody(stmt);
         return VoidResult.Instance;
     }
 

--- a/TypeSystem/TypeChecker.TypeNodes.cs
+++ b/TypeSystem/TypeChecker.TypeNodes.cs
@@ -112,7 +112,15 @@ public partial class TypeChecker
                 if (TryToTypeInfo(conditional.ExtendsType) is not { } extendsType) return null;
                 if (TryToTypeInfo(conditional.TrueType) is not { } trueType) return null;
                 if (TryToTypeInfo(conditional.FalseType) is not { } falseType) return null;
-                return new TypeInfo.ConditionalType(checkType, extendsType, trueType, falseType);
+                // Distributivity comes from the DECLARED check node: a bare name that refers to
+                // a type parameter, whether still unbound (resolves to TypeParameter) or already
+                // bound to its argument by an alias instantiation scope. A bare name referring
+                // to a concrete alias (`type Y = Letters extends "a" ? ...`) does NOT distribute.
+                bool distributive = checkType is TypeInfo.TypeParameter ||
+                    (conditional.CheckType is NamedTypeNode { TypeArguments: null } checkRef &&
+                     _environment.GetTypeParameter(checkRef.Name) is not null);
+                return new TypeInfo.ConditionalType(checkType, extendsType, trueType, falseType)
+                    { IsDistributive = distributive };
             }
 
             case InferTypeNode infer:

--- a/TypeSystem/TypeChecker.TypeParsing.cs
+++ b/TypeSystem/TypeChecker.TypeParsing.cs
@@ -447,6 +447,12 @@ public partial class TypeChecker
         if (types.Count == 0) return new TypeInfo.Unknown();
         if (types.Count == 1) return types[0];
 
+        // Flatten nested intersections so their object constituents participate in the member
+        // merge below — `(T & { foo }) & { bar }` must merge the two records, not hide the first
+        // inside an opaque inner intersection.
+        if (types.Any(t => t is TypeInfo.Intersection))
+            types = types.SelectMany(t => t is TypeInfo.Intersection nested ? nested.FlattenedTypes : [t]).ToList();
+
         // Check for never (absorbs everything)
         if (types.Any(t => t is TypeInfo.Never))
             return new TypeInfo.Never();
@@ -1511,8 +1517,11 @@ public partial class TypeChecker
         string extendsTypeStr = remainder[..questionIndex].Trim();
         string afterQuestion = remainder[(questionIndex + 1)..].Trim();
 
-        // Find the ':' at the top level
-        int colonIndex = FindTopLevelChar(afterQuestion, ':');
+        // Find the ':' belonging to THIS conditional. A nested conditional in the true branch
+        // (`T extends U ? A extends B ? X : Y : Z`) contributes its own '?'/':' pair, so the scan
+        // must be ternary-depth aware — taking the first top-level ':' would split inside the
+        // nested conditional and silently mangle both branches.
+        int colonIndex = FindConditionalElseColon(afterQuestion);
         if (colonIndex < 0) return null;
 
         string trueTypeStr = afterQuestion[..colonIndex].Trim();
@@ -1542,6 +1551,30 @@ public partial class TypeChecker
             else if (depth == 0 && str.Substring(i, keyword.Length) == keyword)
             {
                 return i;
+            }
+        }
+        return -1;
+    }
+
+    /// <summary>
+    /// Finds the ':' that closes the current conditional's true branch, skipping ':'s that
+    /// belong to nested conditionals (each top-level '?' opens one). Bracketed regions are
+    /// opaque as in <see cref="FindTopLevelChar"/>.
+    /// </summary>
+    private static int FindConditionalElseColon(string str)
+    {
+        int depth = 0;
+        int ternaryDepth = 0;
+        for (int i = 0; i < str.Length; i++)
+        {
+            char c = str[i];
+            if (c == '<' || c == '(' || c == '[' || c == '{') depth++;
+            else if (c == '>' || c == ')' || c == ']' || c == '}') depth--;
+            else if (depth == 0 && c == '?') ternaryDepth++;
+            else if (depth == 0 && c == ':')
+            {
+                if (ternaryDepth == 0) return i;
+                ternaryDepth--;
             }
         }
         return -1;

--- a/TypeSystem/TypeChecker.cs
+++ b/TypeSystem/TypeChecker.cs
@@ -967,6 +967,7 @@ public partial class TypeChecker
         {
             _environment.DefineTypeAlias(typeAlias.Name.Lexeme, typeAlias.TypeDefinition);
         }
+        RecordAliasParamConstraints(typeAlias);
     }
 
     /// <summary>

--- a/TypeSystem/TypeInfo.cs
+++ b/TypeSystem/TypeInfo.cs
@@ -1464,8 +1464,23 @@ public abstract record TypeInfo
         TypeInfo FalseType
     ) : TypeInfo
     {
+        /// <summary>
+        /// Whether the conditional distributes over unions. Fixed at the DECLARATION (true iff the
+        /// declared check type is a naked type parameter) and preserved across substitution:
+        /// <c>Foo&lt;T &amp; U&gt;</c> where <c>type Foo&lt;X&gt; = X extends string ? ... </c> stays
+        /// distributive even though the instantiated check type is an intersection, while a
+        /// textually identical inline <c>T &amp; U extends string ? ...</c> is not. tsc treats the
+        /// two as DIFFERENT types (conditionalTypes1 f32), so the flag participates in CacheKey.
+        /// </summary>
+        public bool IsDistributive { get; init; } = CheckType is TypeParameter;
+
         public override string ToString() =>
             $"{CheckType} extends {ExtendsType} ? {TrueType} : {FalseType}";
+
+        // Only mark the key when the flag diverges from what the rendering implies, so
+        // pre-existing cache keys stay stable for the common case.
+        internal override string CacheKey() =>
+            IsDistributive == (CheckType is TypeParameter) ? ToString() : $"{ToString()}@nondist";
     }
 
     /// <summary>


### PR DESCRIPTION
Part of #226 / #80. The conditional-type evaluation cluster: **subset Pass 74 → 76, Fail 4 → 2, no regressions.** Full suite 11014/11014.

## Deferred-conditional core (mirrors checker.ts)

- **`ConditionalType.IsDistributive`** — fixed at the declaration (naked type-parameter check), preserved across substitution, participates in `CacheKey()` identity. Literal-union checks no longer distribute (`string | number extends string ? A : B` is checked whole, per tsc); distributive aliases instantiated with unions still distribute — both the string-substitution and node instantiation paths restore the root's flag.
- **Generic-check deferral** — a conditional defers when its check type contains ANY type variable, not only when it IS a naked parameter. `Extract<Extract<T, Foo>, Bar>` used to collapse to `never` through the eager utility expanders; the `Expand*` helpers now defer on abstract type references (type params, deferred conditionals, `T[K]`, `keyof T`).
- **`GetConditionalConstraints`** — tsc's two-step constraint for relating a deferred conditional source: the distributive constraint (conditional applied to the check parameter's own constraint: `ZeroOf<T extends number|string>` ⇒ `0 | ""`), then the default constraint (true branch under `check ∩ extends` substitution — the substitution-type narrowing that bounds `Extract<T, Foo>` by `T & Foo` — with infer placeholders erased to their constraints, unioned with the false branch).
- **Relation rules** (moved ahead of the type-parameter/null rules, which previously rejected conditional sources sight unseen):
  - conditional ↔ conditional: identical extends types + check types related in either direction ⇒ branches related pairwise (`Covariant<B> → Covariant<A>` works without variance machinery),
  - source-deferred: assignable wherever one of its constraints is,
  - target-deferred: source must satisfy both branches (unchanged),
  - intersection sources accepted by type-parameter targets via constituents (`T & Function → T`).
- **`keyof` ↔ `keyof`** with generic operands compares the operands contravariantly (`keyof B` accepts `keyof A` when `B extends A`).
- **Generic interfaces with conditional-typed members** relate member-wise: the marker-based variance measurement evaluates the member conditional away (markers aren't strings) and measured everything bivariant — the Covariant/Contravariant/Invariant trio in conditionalTypes2 now behaves per tsc.

## String-path parser fix

`TryParseConditionalType`'s `:` scan is now ternary-depth aware. A nested conditional in a true branch (`T extends U ? T extends V ? T : never : never` — the `Extract2` idiom) was split at the wrong colon and **both branches silently resolved to `any`**, which also produced false negatives anywhere such an alias was used.

## Alias-declaration validation (new `TypeChecker.Statements.AliasValidation.cs`)

tsc reports these when checking the declaration; lazy expansion alone never surfaces them:
- **TS1338** — `infer` outside an extends clause (legality inherited through nesting: `X10`–`X17` in inferTypesWithExtends1 stay clean),
- **TS2304** — known infer names referenced from check/false positions (kept narrow: the general unknown-name TS2304 remains parked on the load-bearing any-fallback),
- **TS2344** — type-argument constraint checks for generic alias references and the built-in `ReturnType`/`Parameters`/`InstanceType`/`ConstructorParameters` shapes; positional infer constraints (an `infer U` in `T72<infer U>` inherits `T72`'s parameter constraint) intersect across repeated slots; the global `Function` is discriminated at the node level (it satisfies no concrete signature),
- **TS2322** — mapped-type key constraint (`[P in T]` requires key-like `T`), with true-branch narrowing so `T extends string ? { [P in T]: void } : T` passes while the un-narrowed form fails.

## Supporting fixes

- declare-function hoisting: calls preceding a `declare function` resolve (TS2304 extra in conditionalTypes2),
- generic type-predicate narrowing instantiates the predicate type with call-site inference (`isFunction(x)` with a union narrows to the distributed result, not a dangling declaration-scope conditional),
- rest-parameter inference: `(...args: A)` infers `A` as the argument TUPLE instead of unifying `A` with a single argument type,
- `obj[key]` with `obj: T extends Record<K, V>`, `key: K` resolves through the index signature / returns `any` for bare generic objects instead of TS7053,
- deferred conditionals are indexable through their constraints (`x[0]` where `x: T extends (infer U)[] ? U[] : never`).

## Remaining conditional-cluster work

`conditionalTypes1` stays Fail with its diff reduced to the mapped-type relation rules + DeepReadonly/readonly-mapped enforcement + generic assignment narrowing — catalogued in **#337**. The annotation-only duplicate-`var` TS2403 gap it also exposed is **#336**. `assignmentCompatWithStringIndexer3` remains parked on the any-fallback discipline.