### PR TITLE
fix(compiled): inherit static methods/fields/getters on user-class subclasses (#332)

### DIFF
--- a/Compilation/ExpressionEmitterBase.Operators.cs
+++ b/Compilation/ExpressionEmitterBase.Operators.cs
@@ -294,10 +294,11 @@ public abstract partial class ExpressionEmitterBase
     {
         // Handle static field compound assignment: Class.field += x
         if (cs.Object is Expr.Variable classVar &&
-            Ctx.Classes.TryGetValue(Ctx.ResolveClassName(classVar.Name.Lexeme), out _))
+            Ctx.Classes.TryGetValue(Ctx.ResolveClassName(classVar.Name.Lexeme), out var compoundClassBuilder))
         {
             string resolvedClassName = Ctx.ResolveClassName(classVar.Name.Lexeme);
-            if (Ctx.ClassRegistry!.TryGetStaticField(resolvedClassName, cs.Name.Lexeme, out var staticField))
+            // Compound assignment binds the data field own-only (write side); see TryGetOwnCallableStaticField.
+            if (Ctx.ClassRegistry!.TryGetOwnCallableStaticField(resolvedClassName, cs.Name.Lexeme, compoundClassBuilder, out var staticField))
             {
                 EmitExpression(cs.Value);
                 EnsureBoxed();

--- a/Compilation/ExpressionEmitterBase.cs
+++ b/Compilation/ExpressionEmitterBase.cs
@@ -657,10 +657,10 @@ public abstract partial class ExpressionEmitterBase : IEmitterContext
 
         // Handle static field assignment: Class.field = value
         if (s.Object is Expr.Variable classVar &&
-            Ctx.Classes.TryGetValue(Ctx.ResolveClassName(classVar.Name.Lexeme), out _))
+            Ctx.Classes.TryGetValue(Ctx.ResolveClassName(classVar.Name.Lexeme), out var staticSetClassBuilder))
         {
             string resolvedClassName = Ctx.ResolveClassName(classVar.Name.Lexeme);
-            if (Ctx.ClassRegistry!.TryGetStaticField(resolvedClassName, s.Name.Lexeme, out var staticField))
+            if (Ctx.ClassRegistry!.TryGetOwnCallableStaticField(resolvedClassName, s.Name.Lexeme, staticSetClassBuilder, out var staticField))
             {
                 EmitExpression(s.Value);
                 EnsureBoxed();
@@ -1762,10 +1762,10 @@ public abstract partial class ExpressionEmitterBase : IEmitterContext
     protected virtual bool TryEmitStaticFieldAccess(Expr.Get g)
     {
         if (g.Object is Expr.Variable classVar &&
-            Ctx.Classes.TryGetValue(Ctx.ResolveClassName(classVar.Name.Lexeme), out _))
+            Ctx.Classes.TryGetValue(Ctx.ResolveClassName(classVar.Name.Lexeme), out var staticFieldClassBuilder))
         {
             string resolvedClassName = Ctx.ResolveClassName(classVar.Name.Lexeme);
-            if (Ctx.ClassRegistry!.TryGetStaticField(resolvedClassName, g.Name.Lexeme, out var staticField))
+            if (Ctx.ClassRegistry!.TryGetCallableStaticField(resolvedClassName, g.Name.Lexeme, staticFieldClassBuilder, out var staticField))
             {
                 IL.Emit(OpCodes.Ldsfld, staticField!);
                 SetStackUnknown();

--- a/Compilation/ILEmitter.Properties.External.cs
+++ b/Compilation/ILEmitter.Properties.External.cs
@@ -69,7 +69,9 @@ public partial class ILEmitter
         if (_ctx.IsInstanceMethod || _ctx.CurrentClassBuilder == null) return false;
         var name = _ctx.CurrentClassName;
         if (name == null) return false;
-        if (!_ctx.ClassRegistry!.TryGetStaticField(name, get.Name.Lexeme, out var fb) || fb == null)
+        // Own-only: this resolver feeds read-modify-write operator paths (postfix/prefix/compound),
+        // which must bind to a field the class itself declares (inherited-field writes create a shadow).
+        if (!_ctx.ClassRegistry!.TryGetOwnStaticField(name, get.Name.Lexeme, out var fb) || fb == null)
             return false;
         className = name;
         field = fb;
@@ -83,7 +85,7 @@ public partial class ILEmitter
     private bool EmitStaticMemberAccess(string className, System.Reflection.Emit.TypeBuilder classBuilder, string propertyName)
     {
         // Try static getter first (for auto-accessors and explicit static accessors)
-        if (_ctx.ClassRegistry!.TryGetStaticGetter(className, propertyName, out var staticGetter))
+        if (_ctx.ClassRegistry!.TryGetCallableStaticGetter(className, propertyName, classBuilder, out var staticGetter))
         {
             IL.Emit(OpCodes.Call, staticGetter!);
 
@@ -118,7 +120,7 @@ public partial class ILEmitter
         }
 
         // Try to find static field using stored FieldBuilders
-        if (_ctx.ClassRegistry!.TryGetStaticField(className, propertyName, out var staticField))
+        if (_ctx.ClassRegistry!.TryGetCallableStaticField(className, propertyName, classBuilder, out var staticField))
         {
             IL.Emit(OpCodes.Ldsfld, staticField!);
             SetStackUnknown();
@@ -144,7 +146,7 @@ public partial class ILEmitter
     private bool EmitStaticMemberSet(string className, System.Reflection.Emit.TypeBuilder classBuilder, string propertyName, Expr value)
     {
         // Try static setter first (for auto-accessors and explicit static accessors)
-        if (_ctx.ClassRegistry!.TryGetStaticSetter(className, propertyName, out var staticSetter))
+        if (_ctx.ClassRegistry!.TryGetCallableStaticSetter(className, propertyName, classBuilder, out var staticSetter))
         {
             // The setter's parameter type is authoritative — auto-accessors use typed params
             // (Double/Boolean/String), explicit accessors use Object. Either way this matches
@@ -179,8 +181,9 @@ public partial class ILEmitter
             return true;
         }
 
-        // Try static fields - use TryGetCallableStaticField to handle generic classes properly
-        if (_ctx.ClassRegistry!.TryGetCallableStaticField(className, propertyName, classBuilder, out var callableStaticField))
+        // Try static fields own-only — a data-field write through a subclass creates an own shadow,
+        // it must not mutate the base's storage (see TryGetOwnCallableStaticField).
+        if (_ctx.ClassRegistry!.TryGetOwnCallableStaticField(className, propertyName, classBuilder, out var callableStaticField))
         {
             EmitExpression(value);
             EmitBoxIfNeeded(value);

--- a/Compilation/ILEmitter.Properties.cs
+++ b/Compilation/ILEmitter.Properties.cs
@@ -151,7 +151,7 @@ public partial class ILEmitter
             if (_ctx.Classes.TryGetValue(resolvedClassName, out var classBuilder))
             {
                 // Try static getter first (for auto-accessors and explicit static accessors)
-                if (_ctx.ClassRegistry!.TryGetStaticGetter(resolvedClassName, g.Name.Lexeme, out var staticGetter))
+                if (_ctx.ClassRegistry!.TryGetCallableStaticGetter(resolvedClassName, g.Name.Lexeme, classBuilder, out var staticGetter))
                 {
                     IL.Emit(OpCodes.Call, staticGetter!);
 
@@ -209,7 +209,7 @@ public partial class ILEmitter
             _ctx.Classes.TryGetValue(importedQualifiedClassName, out var importedClassBuilder))
         {
             // Try static getter first
-            if (_ctx.ClassRegistry!.TryGetStaticGetter(importedQualifiedClassName, g.Name.Lexeme, out var importedStaticGetter))
+            if (_ctx.ClassRegistry!.TryGetCallableStaticGetter(importedQualifiedClassName, g.Name.Lexeme, importedClassBuilder, out var importedStaticGetter))
             {
                 IL.Emit(OpCodes.Call, importedStaticGetter!);
                 SetStackUnknown();

--- a/Compilation/Registries/ClassRegistry.cs
+++ b/Compilation/Registries/ClassRegistry.cs
@@ -331,9 +331,82 @@ public sealed class ClassRegistry
     #region Static Member Lookups
 
     /// <summary>
-    /// Tries to get a static field for a class.
+    /// Walks the superclass chain (starting at <paramref name="qualifiedClassName"/>) looking for the
+    /// nearest class that declares the named member in <paramref name="table"/>. Static members are
+    /// inherited by subclasses in TS/JS, but the underlying .NET token references the *declaring* class,
+    /// so callers need both the member and the class that owns it. The walk starts at the requested
+    /// class so a subclass redeclaration (shadowing) wins over an inherited member.
+    /// </summary>
+    private bool TryResolveStaticMember<T>(
+        Dictionary<string, Dictionary<string, T>> table,
+        string qualifiedClassName,
+        string memberName,
+        out string declaringClass,
+        out T member)
+    {
+        string? current = qualifiedClassName;
+        for (int depth = 0; current != null && depth < 64; depth++)
+        {
+            if (table.TryGetValue(current, out var members) && members.TryGetValue(memberName, out var m))
+            {
+                declaringClass = current;
+                member = m;
+                return true;
+            }
+            current = _superclass.GetValueOrDefault(current);
+        }
+
+        declaringClass = null!;
+        member = default!;
+        return false;
+    }
+
+    /// <summary>
+    /// When <paramref name="declaringClass"/> is generic, returns its TypeBuilder closed over
+    /// <c>object</c> for every type parameter (matching the type-erased instantiation used everywhere
+    /// else for class statics), so the resolved member token targets a concrete type. Returns null for
+    /// non-generic declaring classes, in which case the raw builder/token is already concrete.
+    /// </summary>
+    private Type? GetClosedGenericDeclaringType(string declaringClass, string requestedClass, TypeBuilder requestedBuilder)
+    {
+        if (!_genericParams.TryGetValue(declaringClass, out var gps) || gps.Length == 0)
+            return null;
+
+        // For the requested (own) class the caller already handed us the builder; otherwise look up
+        // the declaring base's builder. Both are entries in the same _builders dictionary.
+        var declaringBuilder = declaringClass == requestedClass
+            ? requestedBuilder
+            : _builders.GetValueOrDefault(declaringClass);
+        if (declaringBuilder == null)
+            return null;
+
+        var typeArgs = new Type[gps.Length];
+        for (int i = 0; i < gps.Length; i++)
+            typeArgs[i] = typeof(object);
+        return declaringBuilder.MakeGenericType(typeArgs);
+    }
+
+    /// <summary>
+    /// Tries to get a static field for a class, walking the superclass chain so inherited
+    /// statics resolve (the FieldBuilder references the declaring class's token).
     /// </summary>
     public bool TryGetStaticField(string qualifiedClassName, string fieldName, out FieldBuilder? field)
+    {
+        if (TryResolveStaticMember(_staticFields, qualifiedClassName, fieldName, out _, out var f))
+        {
+            field = f;
+            return true;
+        }
+
+        field = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Tries to get a static field declared directly on the class (no superclass walk). Used by
+    /// write/read-modify-write sites that must bind only to a field the class itself declares.
+    /// </summary>
+    public bool TryGetOwnStaticField(string qualifiedClassName, string fieldName, out FieldBuilder? field)
     {
         if (_staticFields.TryGetValue(qualifiedClassName, out var classFields) &&
             classFields.TryGetValue(fieldName, out var f))
@@ -347,12 +420,12 @@ public sealed class ClassRegistry
     }
 
     /// <summary>
-    /// Tries to get a static method for a class.
+    /// Tries to get a static method for a class, walking the superclass chain so inherited
+    /// statics resolve (the MethodBuilder references the declaring class's token).
     /// </summary>
     public bool TryGetStaticMethod(string qualifiedClassName, string methodName, out MethodBuilder? method)
     {
-        if (_staticMethods.TryGetValue(qualifiedClassName, out var classMethods) &&
-            classMethods.TryGetValue(methodName, out var m))
+        if (TryResolveStaticMember(_staticMethods, qualifiedClassName, methodName, out _, out var m))
         {
             method = m;
             return true;
@@ -387,8 +460,7 @@ public sealed class ClassRegistry
     /// </summary>
     public bool TryGetStaticGetter(string qualifiedClassName, string propertyName, out MethodBuilder? getter)
     {
-        if (_staticGetters.TryGetValue(qualifiedClassName, out var classGetters) &&
-            classGetters.TryGetValue(propertyName, out var g))
+        if (TryResolveStaticMember(_staticGetters, qualifiedClassName, propertyName, out _, out var g))
         {
             getter = g;
             return true;
@@ -399,12 +471,11 @@ public sealed class ClassRegistry
     }
 
     /// <summary>
-    /// Tries to get a static setter for a class.
+    /// Tries to get a static setter for a class, walking the superclass chain.
     /// </summary>
     public bool TryGetStaticSetter(string qualifiedClassName, string propertyName, out MethodBuilder? setter)
     {
-        if (_staticSetters.TryGetValue(qualifiedClassName, out var classSetters) &&
-            classSetters.TryGetValue(propertyName, out var s))
+        if (TryResolveStaticMember(_staticSetters, qualifiedClassName, propertyName, out _, out var s))
         {
             setter = s;
             return true;
@@ -523,26 +594,81 @@ public sealed class ClassRegistry
     /// </summary>
     public bool TryGetCallableStaticMethod(string qualifiedClassName, string methodName, TypeBuilder classBuilder, out System.Reflection.MethodInfo? method)
     {
-        if (!TryGetStaticMethod(qualifiedClassName, methodName, out var methodBuilder))
+        if (!TryResolveStaticMember(_staticMethods, qualifiedClassName, methodName, out var declaringClass, out var methodBuilder))
         {
             method = null;
             return false;
         }
 
-        // For generic classes, we need to call the method on a closed generic type
-        if (_genericParams.TryGetValue(qualifiedClassName, out var gps) && gps.Length > 0)
-        {
-            // Create a closed generic type using object for all type parameters
-            var typeArgs = new Type[gps.Length];
-            for (int i = 0; i < gps.Length; i++)
-                typeArgs[i] = typeof(object);
+        // When the method is declared on (or inherited from) a generic class, call it on a closed
+        // generic type — the declaring class's, not the requested subclass's.
+        var closedType = GetClosedGenericDeclaringType(declaringClass, qualifiedClassName, classBuilder);
+        method = closedType != null
+            ? EmitterTypeHelpers.ResolveMethod(closedType, methodBuilder!)
+            : methodBuilder;
+        return true;
+    }
 
-            var closedType = classBuilder.MakeGenericType(typeArgs);
-            method = EmitterTypeHelpers.ResolveMethod(closedType, methodBuilder!);
-            return true;
+    /// <summary>
+    /// Gets a static getter that can be called, walking the superclass chain and handling generic
+    /// declaring classes by resolving against a closed generic type. For non-generic classes returns
+    /// the MethodBuilder directly (its token already references the declaring class).
+    /// </summary>
+    public bool TryGetCallableStaticGetter(string qualifiedClassName, string propertyName, TypeBuilder classBuilder, out System.Reflection.MethodInfo? getter)
+    {
+        if (!TryResolveStaticMember(_staticGetters, qualifiedClassName, propertyName, out var declaringClass, out var getterBuilder))
+        {
+            getter = null;
+            return false;
         }
 
-        method = methodBuilder;
+        var closedType = GetClosedGenericDeclaringType(declaringClass, qualifiedClassName, classBuilder);
+        getter = closedType != null
+            ? EmitterTypeHelpers.ResolveMethod(closedType, getterBuilder!)
+            : getterBuilder;
+        return true;
+    }
+
+    /// <summary>
+    /// Gets a static *data field* declared directly on the class (no superclass walk), resolving
+    /// against a closed generic type for generic classes. Used by assignment sites: per JS semantics
+    /// a write through a subclass (<c>Sub.field = v</c>) creates an own shadow on the subclass and must
+    /// NOT mutate the base's storage, so writes only bind to a field the class itself declares.
+    /// (Inherited-static-field writes through a subclass would need runtime shadow storage — see #332
+    /// follow-up; reads, getters, setters and methods are inherited and use the chain-walking lookups.)
+    /// </summary>
+    public bool TryGetOwnCallableStaticField(string qualifiedClassName, string fieldName, TypeBuilder classBuilder, out System.Reflection.FieldInfo? field)
+    {
+        if (!_staticFields.TryGetValue(qualifiedClassName, out var classFields) ||
+            !classFields.TryGetValue(fieldName, out var fieldBuilder))
+        {
+            field = null;
+            return false;
+        }
+
+        var closedType = GetClosedGenericDeclaringType(qualifiedClassName, qualifiedClassName, classBuilder);
+        field = closedType != null
+            ? EmitterTypeHelpers.ResolveField(closedType, fieldBuilder)
+            : fieldBuilder;
+        return true;
+    }
+
+    /// <summary>
+    /// Gets a static setter that can be called, walking the superclass chain and handling generic
+    /// declaring classes by resolving against a closed generic type.
+    /// </summary>
+    public bool TryGetCallableStaticSetter(string qualifiedClassName, string propertyName, TypeBuilder classBuilder, out System.Reflection.MethodInfo? setter)
+    {
+        if (!TryResolveStaticMember(_staticSetters, qualifiedClassName, propertyName, out var declaringClass, out var setterBuilder))
+        {
+            setter = null;
+            return false;
+        }
+
+        var closedType = GetClosedGenericDeclaringType(declaringClass, qualifiedClassName, classBuilder);
+        setter = closedType != null
+            ? EmitterTypeHelpers.ResolveMethod(closedType, setterBuilder!)
+            : setterBuilder;
         return true;
     }
 
@@ -553,25 +679,18 @@ public sealed class ClassRegistry
     /// </summary>
     public bool TryGetCallableStaticField(string qualifiedClassName, string fieldName, TypeBuilder classBuilder, out System.Reflection.FieldInfo? field)
     {
-        if (!TryGetStaticField(qualifiedClassName, fieldName, out var fieldBuilder))
+        if (!TryResolveStaticMember(_staticFields, qualifiedClassName, fieldName, out var declaringClass, out var fieldBuilder))
         {
             field = null;
             return false;
         }
 
-        // For generic classes, we need to access the field on a closed generic type
-        if (_genericParams.TryGetValue(qualifiedClassName, out var gps) && gps.Length > 0)
-        {
-            var typeArgs = new Type[gps.Length];
-            for (int i = 0; i < gps.Length; i++)
-                typeArgs[i] = typeof(object);
-
-            var closedType = classBuilder.MakeGenericType(typeArgs);
-            field = EmitterTypeHelpers.ResolveField(closedType, fieldBuilder!);
-            return true;
-        }
-
-        field = fieldBuilder;
+        // When the field is declared on (or inherited from) a generic class, access it on a closed
+        // generic type — the declaring class's, not the requested subclass's.
+        var closedType = GetClosedGenericDeclaringType(declaringClass, qualifiedClassName, classBuilder);
+        field = closedType != null
+            ? EmitterTypeHelpers.ResolveField(closedType, fieldBuilder!)
+            : fieldBuilder;
         return true;
     }
 

--- a/SharpTS.Tests/SharedTests/StaticMembersTests.cs
+++ b/SharpTS.Tests/SharedTests/StaticMembersTests.cs
@@ -287,4 +287,130 @@ public class StaticMembersTests
     }
 
     #endregion
+
+    #region Inherited Static Members (#332)
+
+    // Static members declared on a base user class are inherited by subclasses. In compiled mode the
+    // .NET token references the *declaring* class, so resolution walks the superclass chain (#332).
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void InheritedStatic_Method(ExecutionMode mode)
+    {
+        var source = """
+            class Base {
+                static greet(): string { return "hi"; }
+            }
+            class Sub extends Base {}
+            console.log(Sub.greet());
+            """;
+
+        Assert.Equal("hi\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void InheritedStatic_Field(ExecutionMode mode)
+    {
+        var source = """
+            class Base {
+                static count: number = 5;
+            }
+            class Sub extends Base {}
+            console.log(Sub.count);
+            """;
+
+        Assert.Equal("5\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void InheritedStatic_Getter(ExecutionMode mode)
+    {
+        var source = """
+            class Base {
+                static get label(): string { return "L"; }
+            }
+            class Sub extends Base {}
+            console.log(Sub.label);
+            """;
+
+        Assert.Equal("L\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void InheritedStatic_MultiLevelChain(ExecutionMode mode)
+    {
+        var source = """
+            class A {
+                static who(): string { return "A"; }
+                static tag: string = "a";
+            }
+            class B extends A {}
+            class C extends B {}
+            console.log(C.who());
+            console.log(C.tag);
+            """;
+
+        Assert.Equal("A\na\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void InheritedStatic_SubclassShadowWins(ExecutionMode mode)
+    {
+        var source = """
+            class Parent {
+                static who(): string { return "Parent"; }
+            }
+            class Child extends Parent {
+                static who(): string { return "Child"; }
+            }
+            console.log(Child.who());
+            console.log(Parent.who());
+            """;
+
+        Assert.Equal("Child\nParent\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void InheritedStatic_FromGenericBase(ExecutionMode mode)
+    {
+        var source = """
+            class Box<T> {
+                static kind: string = "box";
+                static make(): string { return "made"; }
+                static get tag(): string { return "T"; }
+            }
+            class IntBox extends Box<number> {}
+            console.log(IntBox.make());
+            console.log(IntBox.kind);
+            console.log(IntBox.tag);
+            """;
+
+        Assert.Equal("made\nbox\nT\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void InheritedStatic_FieldWriteDoesNotCorruptBase(ExecutionMode mode)
+    {
+        // A static-field write through the subclass must not mutate the base's storage.
+        // (Creating the JS own-shadow on the subclass is a separate gap in compiled mode; here we
+        // pin the invariant that the base value is preserved in both modes.)
+        var source = """
+            class Base {
+                static n: number = 1;
+            }
+            class Sub extends Base {}
+            Sub.n = 42;
+            console.log(Base.n);
+            """;
+
+        Assert.Equal("1\n", TestHarness.Run(source, mode));
+    }
+
+    #endregion
 }


### PR DESCRIPTION
@
Fixes #332.

## Problem

In compiled mode, a static member (method, field, or getter) declared on a base **user class** was not found when accessed through a subclass — methods threw `TypeError: undefined is not a function`, fields/getters silently read `undefined`. The interpreter handled all three correctly.

```ts
class Base {
  static greet() { return "hi"; }
  static count = 5;
  static get label() { return "L"; }
}
class Sub extends Base {}
Sub.greet();  // was: TypeError ; now: "hi"
Sub.count;    // was: undefined ; now: 5
Sub.label;    // was: undefined ; now: "L"
```

This is the general form of the `Promise`-subclass gap fixed in #309 (which was special-cased via `TryEmitDerivedPromiseStatic`); plain user-class static inheritance had no equivalent.

## Root cause

`ClassRegistry.TryGetStatic{Method,Field,Getter}` looked up only the *exact* classs own members and did not walk the `_superclass` chain (unlike the instance-member resolvers `ResolveInstanceMethod`/`Getter`/`Setter`). Misses fell through to generic dynamic dispatch, which resolved the member to `undefined`.

## Fix

- Static-member lookups now walk the superclass chain via a shared `TryResolveStaticMember<T>` helper. The walk starts at the requested class, so a subclass redeclaration correctly **shadows** an inherited member.
- The callable variants (`TryGetCallableStatic{Method,Field,Getter,Setter}`) instantiate the **declaring** classs closed generic type — not the requested subclasss — so the emitted `Call`/`Ldsfld`/getter token targets the type that actually owns the member, including when the base is generic (`class IntBox extends Box<number>`).
- Reads, methods, getters and setters are inherited and walk the chain. Static **data-field writes** stay own-only (`TryGetOwn{Callable,}StaticField`): per JS semantics `Sub.field = v` creates an own shadow on the subclass and must not mutate base storage. Materializing that own shadow in compiled mode is a separate, narrower gap — filed as **#339**; base storage is correctly preserved in both modes (pinned by a test).

## Tests

New `StaticMembersTests` region: inherited method/field/getter, multi-level chain, subclass-shadow-wins, generic base, and write-doesnt-corrupt-base — all green in **both** interpreter and compiled modes.

Full suite: **11046 passed, 0 failed**.

## Follow-up filed

- #339 — compiled static-field write through a subclass doesnt create the JS own shadow (reads inherited base value; base not corrupted).
@