### PR TITLE
fix(interp): typed-array/buffer instances recognized by instanceof (#334)

### DIFF
--- a/Execution/Interpreter.Calls.cs
+++ b/Execution/Interpreter.Calls.cs
@@ -746,8 +746,37 @@ public partial class Interpreter
         return false;
     }
 
+    /// <summary>
+    /// True when <paramref name="value"/> is a guest Object (non-primitive) —
+    /// the test underlying <c>x instanceof Object</c>. The primitives (undefined,
+    /// null, boolean, number, string, symbol, bigint) are the only values that
+    /// are NOT objects; callables/arrays/typed-arrays/namespaces are all objects.
+    /// </summary>
+    private static bool IsJsObject(object? value) => value switch
+    {
+        null => false,                                   // `null instanceof Object` === false
+        SharpTSUndefined => false,
+        bool or double or string => false,
+        SharpTSSymbol or SharpTSBigInt or System.Numerics.BigInteger => false,
+        _ => true,
+    };
+
     private object EvaluateInstanceof(object? left, object? right)
     {
+        // `x instanceof Object` — the `Object` global resolves to the namespace
+        // singleton (no SharpTSClass on the RHS), so brand-check structurally:
+        // every non-primitive guest value is an Object. Mirrors ECMA-262
+        // OrdinaryHasInstance reaching %Object.prototype% at the top of every
+        // ordinary object's prototype chain (#334).
+        if (right is SharpTSObjectNamespace)
+            return IsJsObject(left);
+
+        // Bare-value constructors for the built-in binary types (ArrayBuffer,
+        // SharedArrayBuffer, DataView, typed arrays) are plain ISharpTSCallables,
+        // so they carry their own instance predicate (#334).
+        if (right is IBuiltInTypeConstructor binaryCtor)
+            return binaryCtor.IsInstance(left);
+
         // Built-in constructor instanceof: val instanceof Map, val instanceof Set, etc.
         if (right is SharpTSBuiltInConstructor ctor)
         {

--- a/Runtime/BuiltIns/WorkerBuiltIns.cs
+++ b/Runtime/BuiltIns/WorkerBuiltIns.cs
@@ -111,11 +111,28 @@ public static class WorkerBuiltIns
 }
 
 /// <summary>
+/// Implemented by the bare-value constructors for built-in binary types
+/// (ArrayBuffer, SharedArrayBuffer, DataView, the typed arrays). These are
+/// plain <see cref="ISharpTSCallable"/>s — not <see cref="SharpTSBuiltInConstructor"/>
+/// or <see cref="SharpTSClass"/> — so the interpreter's <c>instanceof</c>
+/// evaluation can't brand-check their instances structurally. This predicate
+/// gives it a single hook to recognize the instance produced by each
+/// constructor value (#334).
+/// </summary>
+internal interface IBuiltInTypeConstructor
+{
+    /// <summary>Returns true if <paramref name="value"/> is an instance this constructor produces.</summary>
+    bool IsInstance(object? value);
+}
+
+/// <summary>
 /// SharedArrayBuffer constructor implementation.
 /// </summary>
-internal class SharedArrayBufferConstructorImpl : ISharpTSCallable
+internal class SharedArrayBufferConstructorImpl : ISharpTSCallable, IBuiltInTypeConstructor
 {
     public int Arity() => 1;
+
+    public bool IsInstance(object? value) => value is SharpTSSharedArrayBuffer;
 
     public object? Call(Interpreter interpreter, List<object?> arguments)
     {
@@ -138,9 +155,11 @@ internal class SharedArrayBufferConstructorImpl : ISharpTSCallable
 /// <summary>
 /// ArrayBuffer constructor implementation.
 /// </summary>
-internal class ArrayBufferConstructorImpl : ISharpTSCallable
+internal class ArrayBufferConstructorImpl : ISharpTSCallable, IBuiltInTypeConstructor
 {
     public int Arity() => 1;
+
+    public bool IsInstance(object? value) => value is SharpTSArrayBuffer;
 
     public object? Call(Interpreter interpreter, List<object?> arguments)
     {
@@ -167,11 +186,16 @@ internal class ArrayBufferConstructorImpl : ISharpTSCallable
 /// <summary>
 /// Generic TypedArray constructor implementation.
 /// </summary>
-internal class TypedArrayConstructorImpl<T> : ISharpTSCallable where T : SharpTSTypedArray
+internal class TypedArrayConstructorImpl<T> : ISharpTSCallable, IBuiltInTypeConstructor where T : SharpTSTypedArray
 {
     private readonly Func<int, T> _createFromLength;
     private readonly Func<SharpTSSharedArrayBuffer, int, int?, T> _createFromSharedBuffer;
     private readonly Func<SharpTSArrayBuffer, int, int?, T> _createFromArrayBuffer;
+
+    // Exact-type match: `new Int8Array(4) instanceof Uint8Array` is false in JS —
+    // each typed array directly extends the abstract %TypedArray% (not each other),
+    // so `value is T` brands against this constructor's concrete element type only.
+    public bool IsInstance(object? value) => value is T;
 
     public TypedArrayConstructorImpl(
         Func<int, T> createFromLength,
@@ -268,9 +292,11 @@ public class AtomicsSingleton
 /// <summary>
 /// DataView constructor implementation.
 /// </summary>
-internal class DataViewConstructorImpl : ISharpTSCallable
+internal class DataViewConstructorImpl : ISharpTSCallable, IBuiltInTypeConstructor
 {
     public int Arity() => 1;
+
+    public bool IsInstance(object? value) => value is SharpTSDataView;
 
     public object? Call(Interpreter interpreter, List<object?> arguments)
     {

--- a/SharpTS.Tests/SharedTests/BareBuiltInClassRefTests.cs
+++ b/SharpTS.Tests/SharedTests/BareBuiltInClassRefTests.cs
@@ -165,23 +165,55 @@ public class BareBuiltInClassRefTests
         Assert.Equal(string.Concat(System.Linq.Enumerable.Repeat(expectedLine, 14)), output);
     }
 
+    // ── #334: typed-array / buffer instances recognised by `instanceof` ───
+    // Compiled routes through the emitted Type token's IsAssignableFrom;
+    // interp brand-checks each constructor value's instance predicate
+    // (IBuiltInTypeConstructor). Both must agree with Node.
+
     [Theory]
-    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
-    public void TypedArrayCtors_BareValue_InstanceOf_Compiled(ExecutionMode mode)
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void TypedArrayCtors_InstanceOf_OwnConstructor(ExecutionMode mode)
     {
-        // With the constructor resolvable as a value, compiled `instanceof`
-        // routes through the emitted Type token's IsAssignableFrom and matches
-        // instances produced by `new`. (The interpreter does not yet recognise
-        // typed-array instances in `instanceof` at all — even against Object —
-        // tracked separately in #334.)
         var source = """
             console.log(new Int8Array(4) instanceof Int8Array);
             console.log(new Float64Array(2) instanceof Float64Array);
             console.log(new ArrayBuffer(8) instanceof ArrayBuffer);
+            console.log(new SharedArrayBuffer(8) instanceof SharedArrayBuffer);
             console.log(new DataView(new ArrayBuffer(8)) instanceof DataView);
             console.log(({} as any) instanceof Int8Array);
             """;
         var output = TestHarness.Run(source, mode);
-        Assert.Equal("true\ntrue\ntrue\ntrue\nfalse\n", output);
+        Assert.Equal("true\ntrue\ntrue\ntrue\ntrue\nfalse\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void TypedArrayCtors_InstanceOf_DistinctElementTypesDoNotMatch(ExecutionMode mode)
+    {
+        // Each typed array directly extends the abstract %TypedArray%, not each
+        // other — so cross-element-type `instanceof` is false (matches Node).
+        var source = """
+            console.log(new Int8Array(4) instanceof Uint8Array);
+            console.log(new Float32Array(2) instanceof Float64Array);
+            console.log(new ArrayBuffer(8) instanceof SharedArrayBuffer);
+            console.log(new Int8Array(4) instanceof ArrayBuffer);
+            """;
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("false\nfalse\nfalse\nfalse\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void BinaryTypes_InstanceOf_Object(ExecutionMode mode)
+    {
+        // Every typed-array / buffer / view instance is also an Object (#334).
+        var source = """
+            console.log(new Int8Array(4) instanceof Object);
+            console.log(new ArrayBuffer(8) instanceof Object);
+            console.log(new SharedArrayBuffer(8) instanceof Object);
+            console.log(new DataView(new ArrayBuffer(8)) instanceof Object);
+            """;
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("true\ntrue\ntrue\ntrue\n", output);
     }
 }


### PR DESCRIPTION
Closes #334.

## Problem

In the **interpreter**, instances produced by `new Int8Array(...)` / `new ArrayBuffer(...)` / `new DataView(...)` / `new SharedArrayBuffer(...)` were not recognized by `instanceof` — not against their own constructor, and not even against `Object`. Compiled mode was already correct (routes through the emitted Type token's `IsAssignableFrom`).

```js
new Int8Array(4) instanceof Int8Array   // interp: false → now true
new Int8Array(4) instanceof Object      // interp: false → now true
new ArrayBuffer(8) instanceof ArrayBuffer // interp: false → now true
```

## Root cause

The bare-value constructors for these binary types (`TypedArrayConstructorImpl<T>`, `ArrayBufferConstructorImpl`, `SharedArrayBufferConstructorImpl`, `DataViewConstructorImpl`) are plain `ISharpTSCallable`s — not `SharpTSBuiltInConstructor` or `SharpTSClass` — so every arm of `EvaluateInstanceof` fell through to `return false`.

Separately, `instanceof Object` was broadly broken in the interpreter: the `Object` global resolves to the `SharpTSObjectNamespace` singleton, which no arm handled, so even `{} instanceof Object` / `[] instanceof Object` / `new Map() instanceof Object` returned `false`.

## Fix

- Add a small `IBuiltInTypeConstructor { bool IsInstance(object?) }` interface implemented by the four constructor impls; `EvaluateInstanceof` dispatches to it. Typed arrays use an exact-element-type match (`value is T`) so `Int8Array(4) instanceof Uint8Array` stays `false`, matching Node (each typed array directly extends the abstract `%TypedArray%`).
- Add a correct `instanceof Object` arm: structurally brand-check — every non-primitive guest value is an Object (primitives `undefined`/`null`/`boolean`/`number`/`string`/`symbol`/`bigint` are excluded). This also fixes the broader pre-existing `{} instanceof Object` gap.

## Tests

Promotes the #331 `TypedArrayCtors_..._InstanceOf_Compiled` test to all modes and adds:
- `TypedArrayCtors_InstanceOf_OwnConstructor` (all modes)
- `TypedArrayCtors_InstanceOf_DistinctElementTypesDoNotMatch` (all modes)
- `BinaryTypes_InstanceOf_Object` (all modes)

Full suite: **11040/11040 passing**.

## Follow-up filed

Compiled mode wrongly returns `true` for primitive `instanceof Object` (`5 instanceof Object`, `"s" instanceof Object`, `true instanceof Object`, `undefined instanceof Object`) — see filed issue. Interp is now correct on these; the compiled over-broad behavior is out of scope here.