### PR TITLE
fix(compile): drop unsound string return slots (#318)

### DIFF
--- a/Compilation/ILCompiler.ArrowFunctions.cs
+++ b/Compilation/ILCompiler.ArrowFunctions.cs
@@ -1351,12 +1351,12 @@ public partial class ILCompiler
                 // Return type is bool - ensure unboxed bool on stack
                 emitter.EnsureBoolean();
             }
-            // For string and other reference types, no conversion needed.
-            // NOTE: a `: string` return slot with a statically-object value on the
-            // stack fails IL verification here (same family as #275), but a
-            // castclass is NOT safe — inferred-string expressions can produce
-            // $Undefined at runtime (e.g. `(n: any) => cond ? "x" : undefined`),
-            // which no string-typed slot can carry. See #318.
+            // For reference-typed returns, no conversion needed. Note that `string`
+            // return types never reach here as a narrow `string` slot:
+            // ParameterTypeResolver.ResolveReturnType maps them to object, because an
+            // inferred-string arrow body can produce $Undefined at runtime
+            // (e.g. `(n: any) => cond ? "x" : undefined`), which no string-typed slot
+            // can carry. See #318.
 
             il.Emit(OpCodes.Ret);
         }

--- a/Compilation/ILEmitter.Statements.cs
+++ b/Compilation/ILEmitter.Statements.cs
@@ -1159,22 +1159,11 @@ public partial class ILEmitter
                     }
                 }
             }
-            else if (returnType == _ctx.Types.String && _stackType != StackType.String)
-            {
-                // Runtime helpers (string concat `a + b`, member get `obj.name`) leave their
-                // result statically typed `object` on the stack even when the value is a string.
-                // A method declared `: string` then has an `object` where the verifier expects a
-                // string, raising StackUnexpected — it still runs because the value really is a
-                // string. Insert a castclass so the stack type matches the return slot; the cast
-                // is a no-op at runtime for an actual string (and passes null through). (#275)
-                //
-                // Other narrow reference return types (typed arrays/maps, classes mapped via
-                // MapTypeInfoStrict) are deliberately NOT cast here: their runtime representations
-                // are dynamic ($Array, TSObject, ...) that are not CLR-assignable to the declared
-                // type, so a castclass there would throw InvalidCastException at runtime.
-                IL.Emit(OpCodes.Castclass, _ctx.Types.String);
-            }
-            // For other types, the value should already be correct
+            // Note: `string` return types are never emitted as a narrow `string` slot —
+            // ParameterTypeResolver.ResolveReturnType maps them to object because a string
+            // slot cannot carry the `$Undefined` sentinel an inferred-string body can
+            // produce (see #318, which removed the #275 castclass that lived here).
+            // For other narrow types (double/bool handled above), the value is already correct.
         }
         else
         {

--- a/Compilation/ParameterTypeResolver.cs
+++ b/Compilation/ParameterTypeResolver.cs
@@ -125,6 +125,20 @@ public static class ParameterTypeResolver
                 baseType = typeof(object);
             }
 
+            // String return slots are unsound. TS inference admits `undefined` in a
+            // `string`-typed expression (e.g. `cond ? "x" : undefined` infers `string`;
+            // an explicit `: string` annotation is rejected for `return undefined`, so
+            // inference is the reachable path), but a .NET `string` slot cannot carry the
+            // `$Undefined` sentinel. A castclass at the return site throws
+            // InvalidCastException at runtime, and isinst/coercion corrupts `undefined`
+            // into null/"undefined" (observable through Map keys, typeof, ===). Unlike
+            // `double`/`bool` slots there is no boxing to avoid — strings are reference
+            // types — so a `string` slot buys nothing. Fall back to object. (#318)
+            if (baseType == typeof(string))
+            {
+                baseType = typeof(object);
+            }
+
             // Nullable value types (like number | null -> double?) need to stay as object
             // because the emitter doesn't have special handling for Nullable<T>
             if (Nullable.GetUnderlyingType(baseType) != null)

--- a/SharpTS.Tests/CompilerTests/ILVerificationTests.cs
+++ b/SharpTS.Tests/CompilerTests/ILVerificationTests.cs
@@ -412,4 +412,92 @@ public class ILVerificationTests
         Assert.Empty(errors);
         Assert.Equal("finally\ncaught\n", output);
     }
+
+    // #318: a `string`-inferred function body can legitimately return `$Undefined`
+    // (the checker infers `string` for `cond ? "x" : undefined`). A narrow `string`
+    // return slot cannot carry that sentinel — the prior #275 castclass crashed at
+    // runtime with InvalidCastException. ResolveReturnType now maps string->object.
+    [Fact]
+    public void InferredStringReturn_WithUndefinedBranch_BlockBody_DoesNotCrash()
+    {
+        var source = """
+            function pick(n: any) {
+                return n > 2 ? "big" : undefined;
+            }
+            console.log(pick(3));
+            console.log(pick(1));
+            """;
+
+        var (errors, output) = TestHarness.CompileVerifyAndRun(source);
+
+        Assert.Empty(errors);
+        Assert.Equal("big\nundefined\n", output);
+    }
+
+    // #318: expression-body arrow whose `string` return loads a captured variable
+    // through a display class leaves a statically-object value against the slot,
+    // which previously failed IL verification (StackUnexpected). No castclass is
+    // safe here (it would crash on $Undefined), so the slot is dropped to object.
+    // Verified separately from run: reference-assembly compilation (used by
+    // CompileVerifyAndRun) trips a distinct, pre-existing $TSFunction.ctor reflection
+    // bug for this captured-var arrow shape — see #343.
+    [Fact]
+    public void InferredStringReturn_CapturedVarArrow_PassesILVerification()
+    {
+        var source = """
+            const outer = () => {
+                let v = "a";
+                const setB = () => { v = v + "b"; };
+                const readV = () => v;
+                setB();
+                return readV();
+            };
+            console.log(outer());
+            """;
+
+        var errors = TestHarness.CompileAndVerifyOnly(source);
+        Assert.Empty(errors);
+
+        var output = TestHarness.RunCompiled(source);
+        Assert.Equal("ab\n", output);
+    }
+
+    // #318 guard: an undefined string-keyed group must stay `undefined` (not be
+    // coerced to null or "undefined"), which an isinst/Convert.ToString coercion
+    // at the return site would have corrupted — observable through Map keys.
+    [Fact]
+    public void InferredStringReturn_UndefinedMapKey_PreservedDoesNotCoerce()
+    {
+        var source = """
+            const items = [1, 2, 3, 4];
+            const g = Map.groupBy(items, (n: any) => n > 2 ? "big" : undefined);
+            console.log(g.get("big"));
+            console.log(g.get(undefined));
+            """;
+
+        var (errors, output) = TestHarness.CompileVerifyAndRun(source);
+
+        Assert.Empty(errors);
+        Assert.Equal("[3, 4]\n[1, 2]\n", output);
+    }
+
+    // #318 guard: a genuinely string-typed function (no undefined in its value
+    // domain) still verifies and returns the right string after the slot change.
+    [Fact]
+    public void TypedStringReturn_StillWorks()
+    {
+        var source = """
+            function greet(name: string): string {
+                return "hello " + name;
+            }
+            const up = (s: string): string => s.toUpperCase();
+            console.log(greet("world"));
+            console.log(up("abc"));
+            """;
+
+        var (errors, output) = TestHarness.CompileVerifyAndRun(source);
+
+        Assert.Empty(errors);
+        Assert.Equal("hello world\nABC\n", output);
+    }
 }


### PR DESCRIPTION
Closes #318.

## Problem

The typed-return optimization gave functions/arrows whose return type resolves to `string` a narrow `string` .NET return slot. But that slot cannot carry the `$Undefined` sentinel, while TS inference admits `undefined` in a `string`-typed expression (`cond ? "x" : undefined` infers `string`; an explicit `: string` annotation is *rejected* for `return undefined`, so inference is the only reachable path). Two compiled-mode-only failures resulted:

1. **Runtime crash** (block bodies): #275's `castclass string` in `EmitReturn` threw `InvalidCastException` the moment a real `$Undefined` reached the return.
2. **Unverifiable IL** (expression-body arrows): a statically-`object` value (e.g. a captured var loaded through a display class) against the `string` slot raised ILVerify `StackUnexpected`. No castclass is safe here — it would crash on `$Undefined` (broke `Map.groupBy` when attempted during #313).

## Fix

`ParameterTypeResolver.ResolveReturnType` now maps `string` → `object` — a single point covering functions, arrows, and methods (all return-slot resolution flows through it). Unlike `double`/`bool` slots, a `string` slot avoids **no** boxing (strings are reference types), so dropping it costs nothing. The now-dead #275 castclass branch in `EmitReturn` is removed, and the arrow-body comment updated.

## Tests

Four regression tests in `ILVerificationTests`:
- inferred-string block body with an undefined branch no longer crashes
- captured-var expression-body arrow passes IL verification (+ runs correctly)
- undefined Map-group key stays `undefined` (no null/"undefined" coercion)
- a genuinely string-typed function still verifies and returns correctly

Full suite green: 11058 passed.

## Follow-ups filed

- **#343** — pre-existing `--ref-asm` `BadImageFormatException` constructing `$TSFunction` over a captured-var arrow (reproduces on unmodified `main`, independent of this change; the captured-var regression test routes around it via `CompileAndVerifyOnly` + `RunCompiled`).
- **#344** — `double`/`bool` return slots silently coerce `undefined` to `NaN`/`false`. Deliberately *not* fixed here: those slots genuinely avoid boxing, so the #318 "just drop it" approach would regress perf on the sound path; the fix needs flow analysis to gate the unboxed slot.