### PR TITLE
fix(types): bind infer in construct/call-signature conditional types (#316)

### DIFF
--- a/SharpTS.Tests/TypeCheckerTests/ConstructSignatureInferTests.cs
+++ b/SharpTS.Tests/TypeCheckerTests/ConstructSignatureInferTests.cs
@@ -1,0 +1,83 @@
+using SharpTS.Tests.Infrastructure;
+using SharpTS.TypeSystem.Exceptions;
+using Xunit;
+
+namespace SharpTS.Tests.TypeCheckerTests;
+
+/// <summary>
+/// Construct- and call-signature infer matching in conditional types (#316). A pattern like
+/// <c>T extends new (...) =&gt; infer U ? U : ...</c> models the extends side as an object type
+/// carrying a construct signature; the match must recurse into the signature so the infer binding
+/// in parameter/return position resolves. Two collaborating fixes make these work: substitution
+/// preserves a record's construct/call signatures (they were dropped, collapsing both sides to an
+/// empty object), and a conditional's infer names are bound in scope for its true branch (the
+/// reference otherwise falls back to <c>any</c>).
+/// </summary>
+public class ConstructSignatureInferTests
+{
+    [Fact]
+    public void ConstructSignatureReturn_InfersInstanceType()
+    {
+        // U binds to the construct signature's return type; assigning a number errors (TS2322).
+        var source = """
+            type InstanceOf<T> = T extends new () => infer U ? U : "no-match";
+            let x: InstanceOf<new () => { a: string }> = { a: "hi" };
+            """;
+        TestHarness.RunInterpreted(source);
+    }
+
+    [Fact]
+    public void ConstructSignatureReturn_WrongAssignment_IsTypeError()
+    {
+        var source = """
+            type InstanceOf<T> = T extends new () => infer U ? U : "no-match";
+            let x: InstanceOf<new () => { a: string }> = 42;
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void ConstructSignatureParameter_InfersParamType()
+    {
+        // P binds to the constructor's parameter type (number); a string assignment errors.
+        var source = """
+            type CtorParam<T> = T extends new (a: infer P) => any ? P : "no-match";
+            let p: CtorParam<new (a: number) => object> = "str";
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void NonConstructable_TakesFalseBranch()
+    {
+        // `string` carries no construct signature, so the match fails and U never binds: the
+        // conditional resolves to its false branch ("no-match"), which a number assignment violates.
+        var source = """
+            type InstanceOf<T> = T extends new () => infer U ? U : "no-match";
+            let y: InstanceOf<string> = 42;
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void NonConstructable_FalseBranchValueAccepted()
+    {
+        var source = """
+            type InstanceOf<T> = T extends new () => infer U ? U : "no-match";
+            let y: InstanceOf<string> = "no-match";
+            """;
+        TestHarness.RunInterpreted(source);
+    }
+
+    [Fact]
+    public void CallSignatureReturn_InfersReturnType()
+    {
+        // The object-literal call signature `{ (): infer U }` mirrors the construct path: U binds to
+        // the return type, so a number assignment to the inferred string errors.
+        var source = """
+            type Ret<T> = T extends { (): infer U } ? U : "no-match";
+            let r: Ret<{ (): string }> = 42;
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+}

--- a/TypeSystem/TypeChecker.Generics.Conditional.cs
+++ b/TypeSystem/TypeChecker.Generics.Conditional.cs
@@ -80,12 +80,16 @@ public partial class TypeChecker
             TypeInfo extendsType = SubstituteWithoutConditionalEval(conditional.ExtendsType, substitutions);
 
             // tsc: `any extends X ? A : B` yields A | B — an `any` check type matches BOTH
-            // branches. Infer placeholders bind from the wildcard match, so
-            // `any extends infer U ? U : never` is `any | never` = `any`.
+            // branches, and every infer placeholder in the extends clause resolves to `any`. So
+            // `any extends Foo<infer U> ? U : never` is `any | never` = `any`. Seed every true-branch
+            // infer reference with `any` first (the structural match against `any` cannot bind them,
+            // and the extends clause may even have collapsed to `any` upstream), then overlay any
+            // more-specific bindings the wildcard match did produce.
             if (checkType is TypeInfo.Any)
             {
                 var (_, anyInferred) = CheckExtendsWithInfer(checkType, extendsType);
                 var trueSubs = new Dictionary<string, TypeInfo>(substitutions);
+                CollectReferencedInferNames(conditional.TrueType, name => trueSubs[name] = new TypeInfo.Any());
                 foreach (var (name, type) in anyInferred)
                     trueSubs[name] = type;
                 return CreateUnion(
@@ -147,10 +151,7 @@ public partial class TypeChecker
             TypeInfo.Union union =>
                 new TypeInfo.Union(union.Types.Select(t => SubstituteWithoutConditionalEval(t, substitutions)).ToList()),
             TypeInfo.Record rec =>
-                new TypeInfo.Record(
-                    rec.Fields.ToDictionary(
-                        kvp => kvp.Key,
-                        kvp => SubstituteWithoutConditionalEval(kvp.Value, substitutions)).ToFrozenDictionary()),
+                SubstituteRecordMembers(rec, t => SubstituteWithoutConditionalEval(t, substitutions)),
             TypeInfo.InstantiatedGeneric ig =>
                 new TypeInfo.InstantiatedGeneric(
                     ig.GenericDefinition,
@@ -377,6 +378,58 @@ public partial class TypeChecker
     }
 
     /// <summary>
+    /// Invokes <paramref name="visit"/> with the name of every <see cref="TypeInfo.InferredTypeParameter"/>
+    /// referenced within <paramref name="type"/>. Used by the <c>any extends …</c> branch to resolve
+    /// the true branch's infer placeholders to <c>any</c>.
+    /// </summary>
+    private static void CollectReferencedInferNames(TypeInfo type, Action<string> visit)
+    {
+        switch (type)
+        {
+            case TypeInfo.InferredTypeParameter infer:
+                visit(infer.Name);
+                if (infer.Constraint is { } c) CollectReferencedInferNames(c, visit);
+                break;
+            case TypeInfo.Array arr:
+                CollectReferencedInferNames(arr.ElementType, visit);
+                break;
+            case TypeInfo.Promise promise:
+                CollectReferencedInferNames(promise.ValueType, visit);
+                break;
+            case TypeInfo.Function func:
+                foreach (var p in func.ParamTypes) CollectReferencedInferNames(p, visit);
+                CollectReferencedInferNames(func.ReturnType, visit);
+                break;
+            case TypeInfo.Tuple tuple:
+                foreach (var elem in tuple.Elements) CollectReferencedInferNames(elem.Type, visit);
+                if (tuple.RestElementType is { } rest) CollectReferencedInferNames(rest, visit);
+                break;
+            case TypeInfo.Union union:
+                foreach (var t in union.Types) CollectReferencedInferNames(t, visit);
+                break;
+            case TypeInfo.Intersection intersection:
+                foreach (var t in intersection.Types) CollectReferencedInferNames(t, visit);
+                break;
+            case TypeInfo.Record rec:
+                foreach (var (_, t) in rec.Fields) CollectReferencedInferNames(t, visit);
+                break;
+            case TypeInfo.InstantiatedGeneric ig:
+                foreach (var t in ig.TypeArguments) CollectReferencedInferNames(t, visit);
+                break;
+            case TypeInfo.KeyOf keyOf:
+                CollectReferencedInferNames(keyOf.SourceType, visit);
+                break;
+            case TypeInfo.IndexedAccess ia:
+                CollectReferencedInferNames(ia.ObjectType, visit);
+                CollectReferencedInferNames(ia.IndexType, visit);
+                break;
+            case TypeInfo.TemplateLiteralType tl:
+                foreach (var t in tl.InterpolatedTypes) CollectReferencedInferNames(t, visit);
+                break;
+        }
+    }
+
+    /// <summary>
     /// Recursively checks the extends relationship, extracting infer bindings.
     /// </summary>
     private bool CheckExtendsRecursive(
@@ -447,26 +500,7 @@ public partial class TypeChecker
         if (extendsType is TypeInfo.Function extendsFunc)
         {
             if (checkType is TypeInfo.Function checkFunc)
-            {
-                // Function assignability is contravariant in parameters, covariant in return
-                // For infer in parameters, we infer from the check function's params
-                // For infer in return, we infer from the check function's return
-
-                // Match parameters (check function should have at least as many params)
-                for (int i = 0; i < extendsFunc.ParamTypes.Count; i++)
-                {
-                    TypeInfo extendsParam = extendsFunc.ParamTypes[i];
-                    TypeInfo checkParam = i < checkFunc.ParamTypes.Count
-                        ? checkFunc.ParamTypes[i]
-                        : new TypeInfo.Any();
-
-                    if (!CheckExtendsRecursive(checkParam, extendsParam, inferredTypes))
-                        return false;
-                }
-
-                // Match return type (covariant)
-                return CheckExtendsRecursive(checkFunc.ReturnType, extendsFunc.ReturnType, inferredTypes);
-            }
+                return MatchSignatureWithInfer(checkFunc, extendsFunc, inferredTypes);
             return false;
         }
 
@@ -516,6 +550,19 @@ public partial class TypeChecker
         // Record/object type matching
         if (extendsType is TypeInfo.Record extendsRec)
         {
+            // `new (...) => infer U` / `(...) => infer U` model as object types carrying construct or
+            // call signatures (see TypeChecker.TypeNodes.cs). Match those structurally so infer
+            // placeholders in parameter/return positions bind — the field loop alone vacuously
+            // succeeds and leaves U dangling (#316).
+            if (extendsRec.ConstructorSignatures is { Count: > 0 } recCtorSigs
+                && !MatchSignaturesWithInfer(GetCheckConstructorSignatures(checkType),
+                    recCtorSigs.Select(ConstructorSignatureToFunction).ToList(), inferredTypes))
+                return false;
+            if (extendsRec.CallSignatures is { Count: > 0 } recCallSigs
+                && !MatchSignaturesWithInfer(GetCheckCallSignatures(checkType),
+                    recCallSigs.Select(CallSignatureToFunction).ToList(), inferredTypes))
+                return false;
+
             var checkProps = ExtractPropertiesWithTypes(checkType);
             foreach (var (key, extendsFieldType) in extendsRec.Fields)
             {
@@ -530,6 +577,15 @@ public partial class TypeChecker
         // Interface matching
         if (extendsType is TypeInfo.Interface extendsItf)
         {
+            if (extendsItf.ConstructorSignatures is { Count: > 0 } itfCtorSigs
+                && !MatchSignaturesWithInfer(GetCheckConstructorSignatures(checkType),
+                    itfCtorSigs.Select(ConstructorSignatureToFunction).ToList(), inferredTypes))
+                return false;
+            if (extendsItf.CallSignatures is { Count: > 0 } itfCallSigs
+                && !MatchSignaturesWithInfer(GetCheckCallSignatures(checkType),
+                    itfCallSigs.Select(CallSignatureToFunction).ToList(), inferredTypes))
+                return false;
+
             var checkProps = ExtractPropertiesWithTypes(checkType);
             foreach (var (key, extendsFieldType) in extendsItf.Members)
             {
@@ -710,6 +766,78 @@ public partial class TypeChecker
                 foreach (var it in tl.InterpolatedTypes) CollectInferSubstitutions(it, subs);
                 break;
         }
+    }
+
+    /// <summary>
+    /// Matches a single function-shaped signature (plain function, or the function denoted by a call
+    /// or construct signature) extracting infer bindings. Parameters are inference positions
+    /// (covariant capture, like tsc), the return type is covariant. Shared by the Function branch and
+    /// the call/construct-signature branches of <see cref="CheckExtendsRecursive"/>.
+    /// </summary>
+    private bool MatchSignatureWithInfer(
+        TypeInfo.Function checkFunc,
+        TypeInfo.Function extendsFunc,
+        Dictionary<string, TypeInfo> inferredTypes)
+    {
+        // Match parameters (check function should have at least as many params; missing ones bind to any)
+        for (int i = 0; i < extendsFunc.ParamTypes.Count; i++)
+        {
+            TypeInfo extendsParam = extendsFunc.ParamTypes[i];
+            TypeInfo checkParam = i < checkFunc.ParamTypes.Count
+                ? checkFunc.ParamTypes[i]
+                : new TypeInfo.Any();
+
+            if (!CheckExtendsRecursive(checkParam, extendsParam, inferredTypes))
+                return false;
+        }
+
+        // Match return type (covariant)
+        return CheckExtendsRecursive(checkFunc.ReturnType, extendsFunc.ReturnType, inferredTypes);
+    }
+
+    /// <summary>
+    /// Matches each extends-side signature against some check-side signature, extracting infer
+    /// bindings. Returns false when the check side carries no compatible signatures (e.g. a
+    /// non-constructable type against a construct-signature pattern), which steers the conditional
+    /// to its false branch instead of vacuously succeeding.
+    /// </summary>
+    private bool MatchSignaturesWithInfer(
+        List<TypeInfo.Function>? checkSigs,
+        List<TypeInfo.Function> extendsSigs,
+        Dictionary<string, TypeInfo> inferredTypes)
+    {
+        if (checkSigs is not { Count: > 0 })
+            return false;
+        foreach (var extendsSig in extendsSigs)
+        {
+            if (!checkSigs.Any(cs => MatchSignatureWithInfer(cs, extendsSig, inferredTypes)))
+                return false;
+        }
+        return true;
+    }
+
+    /// <summary>
+    /// Construct signatures carried by the check side of an extends clause, viewed as the constructor
+    /// functions they denote. Returns null when the type carries no construct signature. (A class
+    /// value — <c>typeof C</c> — reaches infer matching through <see cref="ExpandInstanceType"/>'s
+    /// dedicated path, not here.)
+    /// </summary>
+    private static List<TypeInfo.Function>? GetCheckConstructorSignatures(TypeInfo type) =>
+        GetConstructorSignatures(type) is { Count: > 0 } sigs
+            ? sigs.Select(ConstructorSignatureToFunction).ToList()
+            : null;
+
+    /// <summary>
+    /// Call signatures carried by the check side of an extends clause, viewed as the functions they
+    /// denote (a plain function is its own call signature). Returns null when the type is not callable.
+    /// </summary>
+    private static List<TypeInfo.Function>? GetCheckCallSignatures(TypeInfo type)
+    {
+        if (type is TypeInfo.Function f)
+            return [f];
+        return GetCallSignatures(type) is { Count: > 0 } sigs
+            ? sigs.Select(CallSignatureToFunction).ToList()
+            : null;
     }
 
     /// <summary>

--- a/TypeSystem/TypeChecker.Generics.Substitution.cs
+++ b/TypeSystem/TypeChecker.Generics.Substitution.cs
@@ -59,6 +59,10 @@ public partial class TypeChecker
                 new TypeInfo.SpreadType(Substitute(spread.Inner, substitutions)),
             TypeInfo.Union union =>
                 new TypeInfo.Union(union.Types.Select(t => Substitute(t, substitutions)).ToList()),
+            // NOTE: fields only. Preserving call/construct signatures here would feed generic
+            // construct-signature *assignment* relating (which erases/instantiates via Substitute)
+            // types it does not yet compare correctly, regressing assignmentCompatWithConstructSignatures.
+            // The conditional-type path that #316 needs preserves them in SubstituteWithoutConditionalEval.
             TypeInfo.Record rec =>
                 new TypeInfo.Record(
                     rec.Fields.ToDictionary(
@@ -105,6 +109,35 @@ public partial class TypeChecker
             _ => type
         };
     }
+
+    /// <summary>
+    /// Rebuilds a record applying <paramref name="sub"/> to every type-carrying member — fields,
+    /// index signatures, and the parameter/return types of call and construct signatures — while
+    /// preserving structural metadata (optional/readonly/getter-only/method flags). Used by
+    /// <see cref="SubstituteWithoutConditionalEval"/>: the naive "copy Fields only" rebuild silently
+    /// dropped construct/call signatures and index types, leaving <c>T extends new (...) =&gt; infer
+    /// U</c> with an empty object on both sides so U never bound (#316).
+    /// </summary>
+    private static TypeInfo.Record SubstituteRecordMembers(TypeInfo.Record rec, Func<TypeInfo, TypeInfo> sub) =>
+        new(
+            rec.Fields.ToDictionary(kvp => kvp.Key, kvp => sub(kvp.Value)).ToFrozenDictionary(),
+            rec.StringIndexType is { } sit ? sub(sit) : null,
+            rec.NumberIndexType is { } nit ? sub(nit) : null,
+            rec.SymbolIndexType is { } yit ? sub(yit) : null,
+            rec.OptionalFields,
+            rec.IsReadonly,
+            rec.GetterOnlyFields,
+            rec.CallSignatures?.Select(cs => cs with
+            {
+                ParamTypes = cs.ParamTypes.Select(sub).ToList(),
+                ReturnType = sub(cs.ReturnType)
+            }).ToList(),
+            rec.ConstructorSignatures?.Select(cs => cs with
+            {
+                ParamTypes = cs.ParamTypes.Select(sub).ToList(),
+                ReturnType = sub(cs.ReturnType)
+            }).ToList(),
+            rec.MethodMembers);
 
     /// <summary>
     /// Substitutes type parameters in a tuple with flattening of spread elements.

--- a/TypeSystem/TypeChecker.TypeNodes.cs
+++ b/TypeSystem/TypeChecker.TypeNodes.cs
@@ -109,8 +109,39 @@ public partial class TypeChecker
             case ConditionalTypeNode conditional:
             {
                 if (TryToTypeInfo(conditional.CheckType) is not { } checkType) return null;
-                if (TryToTypeInfo(conditional.ExtendsType) is not { } extendsType) return null;
-                if (TryToTypeInfo(conditional.TrueType) is not { } trueType) return null;
+
+                // Infer variables declared in the extends clause are in scope for the TRUE branch
+                // only (tsc). Bind each name to the inferred-type-parameter it denotes so a
+                // reference like the `U` in `T extends ... infer U ? U : ...` resolves to that
+                // placeholder — EvaluateConditionalType then substitutes it with the matched type.
+                // Without this the reference falls back to `any`, silently collapsing the true
+                // branch to `any` (#316). Binding to an InferredTypeParameter (not a plain type
+                // parameter) keeps the established leniency when matching fails to bind it: an
+                // unresolved infer placeholder stays uncomparable rather than surfacing as a stray
+                // type parameter. The extends clause is resolved in the same scope, harmlessly:
+                // `infer U` itself resolves via InferTypeNode, not this name binding.
+                List<InferTypeNode>? clauseInfers = null;
+                CollectClauseInfers(conditional.ExtendsType, ref clauseInfers);
+
+                TypeInfo? extendsType, trueType;
+                if (clauseInfers is { Count: > 0 })
+                {
+                    var inferEnv = new TypeEnvironment(_environment);
+                    foreach (var inf in clauseInfers)
+                        inferEnv.DefineTypeParameter(inf.Name, new TypeInfo.InferredTypeParameter(inf.Name));
+                    using (new EnvironmentScope(this, inferEnv))
+                    {
+                        extendsType = TryToTypeInfo(conditional.ExtendsType);
+                        trueType = TryToTypeInfo(conditional.TrueType);
+                    }
+                }
+                else
+                {
+                    extendsType = TryToTypeInfo(conditional.ExtendsType);
+                    trueType = TryToTypeInfo(conditional.TrueType);
+                }
+
+                if (extendsType is null || trueType is null) return null;
                 if (TryToTypeInfo(conditional.FalseType) is not { } falseType) return null;
                 // Distributivity comes from the DECLARED check node: a bare name that refers to
                 // a type parameter, whether still unbound (resolves to TypeParameter) or already


### PR DESCRIPTION
Fixes #316.

## Problem

`type InstanceOf<T> = T extends new () => infer U ? U : "no-match"` never bound `U`. `CheckExtendsRecursive` had structural infer-matching for arrays, promises, functions, tuples, generics, records and template literals — but not **construct (or call) signatures**. The extends side `new () => infer U` models as an object type carrying a construct signature; the field loop matched it vacuously (no fields), so `U` stayed a dangling placeholder. Because `Compatibility` treats an unresolved infer as uncomparable in one direction only, wrong assignments type-checked silently:

```ts
let x: InstanceOf<new () => { a: string }> = 42; // no error before; tsc: TS2322
```

## Fix

Three collaborating changes (all type-checker only):

1. **Signature matching** — `CheckExtendsRecursive` now matches an extends-side record/interface's construct and call signatures against the check side, recursing into parameter/return positions via a shared `MatchSignatureWithInfer` (the existing `Function` branch now reuses it too). A non-constructable/non-callable check side fails the match and correctly steers to the false branch instead of succeeding vacuously.

2. **Signature-preserving substitution** — `SubstituteWithoutConditionalEval` rebuilt a record from its **fields only**, silently dropping construct/call signatures and index types, so both sides of the conditional collapsed to an empty `{}`. It now rebuilds every type-carrying member (`SubstituteRecordMembers`). The general `Substitute` is deliberately left fields-only — preserving signatures there feeds generic construct-signature *assignment* relating types it does not yet compare correctly (would regress `assignmentCompatWithConstructSignatures5`).

3. **True-branch infer scope** — a conditional's infer names are now bound in scope for its true branch (as `InferredTypeParameter`s), so the `U` in `... ? U : ...` resolves to the placeholder `EvaluateConditionalType` substitutes rather than falling back to `any`. The `any extends X` branch seeds those placeholders with `any` to preserve the established leniency where the infer cannot bind.

## Tests

- New `ConstructSignatureInferTests` (construct return/param infer, call-signature infer, non-constructable → false branch, both value-accepted and wrong-assignment cases).
- Full suite green (**11038 passed**); TypeScript conformance green (**0 regressions**, Pass 73/Fail 5).

## Follow-ups filed

- #346 — function type in an extends clause mis-parses (`() => infer U ? …` greedily consumes the conditional); the function-infer-in-extends sibling.
- #347 — `infer` from a generic instantiation (`Box<infer V>`, `Map<…, infer V>`) doesn't bind via the textual string-expansion instantiation path; the general latent bug this work surfaced. Resolves with the type-AST migration.

Out of scope here: `typeof SomeClass extends new () => infer U` (class-as-constructor synthesis) — it hits unrelated `typeof`+conditional resolution gaps; `InstanceType<T>` already covers user classes through its dedicated `ExpandInstanceType` path.
