### PR TITLE
feat(promise): SpeciesConstructor for then/catch/finally (#221)

### DIFF
--- a/Compilation/RuntimeEmitter.Promises.Executor.cs
+++ b/Compilation/RuntimeEmitter.Promises.Executor.cs
@@ -157,15 +157,26 @@ public partial class RuntimeEmitter
 
     /// <summary>
     /// Emits WrapDerivedPromiseResult(Task&lt;object?&gt; result, object receiver) -> object:
-    /// when the receiver is a $Promise SUBCLASS instance (#242), constructs a
-    /// receiver-typed promise around the result task by invoking the
-    /// subclass's single-object (executor) constructor reflectively —
-    /// PromiseFromExecutor adopts a raw task, so the new instance wraps
-    /// `result`. Plain $Promise / Task receivers (and subclasses without a
-    /// matching constructor) return the task unchanged. This is the
-    /// species-lite step giving subclass-typed then/catch/finally results;
-    /// full SpeciesConstructor semantics remain tracked by #221.
+    /// the then/catch/finally result construction through
+    /// SpeciesConstructor(receiver, %Promise%) (ECMA-262 §27.2.5.4, §7.3.22).
+    /// When the receiver is a $Promise SUBCLASS instance (#242), reads
+    /// <c>receiver.constructor[Symbol.species]</c> — i.e. the subclass's static
+    /// <c>@@species</c> getter, defaulting to the subclass itself when not
+    /// overridden — and constructs the result through it: <c>%Promise%</c> (or a
+    /// <c>@@species</c> yielding <c>Promise</c>/<c>undefined</c>/<c>null</c>)
+    /// returns the raw task, any other guest Promise class is built by invoking
+    /// its single-object (executor) constructor reflectively (PromiseFromExecutor
+    /// adopts a raw task, so the new instance wraps <c>result</c>).
     /// </summary>
+    /// <remarks>
+    /// Limitation: a <em>generic</em> Promise subclass with a <c>@@species</c>
+    /// override does not resolve the override — its static accessor is registered
+    /// under the open generic type definition while the receiver's runtime type
+    /// is closed, so the registry lookup misses and the result falls back to the
+    /// receiver's own class (the pre-existing #266 generic-class gap, tracked by
+    /// #351). A species that yields a non-Promise constructor (general
+    /// NewPromiseCapability) falls back to <c>%Promise%</c> — tracked by #349.
+    /// </remarks>
     private void EmitWrapDerivedPromiseResultMethod(TypeBuilder runtimeType, EmittedRuntime runtime)
     {
         var method = runtimeType.DefineMethod(
@@ -178,31 +189,69 @@ public partial class RuntimeEmitter
 
         var il = method.GetILGenerator();
         var returnResultLabel = il.DefineLabel();
-        var typeLocal = il.DeclareLocal(_types.Type);
+        var haveSpeciesLabel = il.DefineLabel();
+        var typeLocal = il.DeclareLocal(_types.Type);          // receiver's runtime type (= C)
+        var speciesTypeLocal = il.DeclareLocal(_types.Type);   // resolved SpeciesConstructor
+        var getterLocal = il.DeclareLocal(_types.Object);
         var ctorLocal = il.DeclareLocal(typeof(ConstructorInfo));
+        var getTypeFromHandle = _types.GetMethod(_types.Type, "GetTypeFromHandle", _types.RuntimeTypeHandle);
 
         // if (receiver is not $Promise) return result;
         il.Emit(OpCodes.Ldarg_1);
         il.Emit(OpCodes.Isinst, runtime.TSPromiseType);
         il.Emit(OpCodes.Brfalse, returnResultLabel);
 
-        // if (receiver.GetType() == typeof($Promise)) return result;
+        // var recvType = receiver.GetType();
         il.Emit(OpCodes.Ldarg_1);
         il.Emit(OpCodes.Callvirt, _types.GetMethodNoParams(_types.Object, "GetType"));
         il.Emit(OpCodes.Stloc, typeLocal);
+        // if (recvType == typeof($Promise)) return result;
         il.Emit(OpCodes.Ldloc, typeLocal);
         il.Emit(OpCodes.Ldtoken, runtime.TSPromiseType);
-        il.Emit(OpCodes.Call, _types.GetMethod(_types.Type, "GetTypeFromHandle", _types.RuntimeTypeHandle));
+        il.Emit(OpCodes.Call, getTypeFromHandle);
         il.Emit(OpCodes.Beq, returnResultLabel);
 
-        // var ctor = receiverType.GetConstructor(new[] { typeof(object) });
+        // SpeciesConstructor(receiver, %Promise%): C = recvType; species default = C.
         il.Emit(OpCodes.Ldloc, typeLocal);
+        il.Emit(OpCodes.Stloc, speciesTypeLocal); // speciesType = recvType (default)
+        // var getter = FindSymbolGetter(recvType, Symbol.species);  // static-slot lookup
+        il.Emit(OpCodes.Ldloc, typeLocal);
+        il.Emit(OpCodes.Ldsfld, runtime.SymbolSpecies);
+        il.Emit(OpCodes.Call, runtime.FindSymbolGetter);
+        il.Emit(OpCodes.Stloc, getterLocal);
+        // if (getter == null) use default species (= recvType).
+        il.Emit(OpCodes.Ldloc, getterLocal);
+        il.Emit(OpCodes.Brfalse, haveSpeciesLabel);
+
+        // var speciesVal = ((MethodBase)getter).Invoke(recvType, Array.Empty<object>());
+        il.Emit(OpCodes.Ldloc, getterLocal);
+        il.Emit(OpCodes.Castclass, _types.MethodBase);
+        il.Emit(OpCodes.Ldloc, typeLocal);  // receiver arg (ignored for a static getter)
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Newarr, _types.Object);
+        il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.MethodBase, "Invoke", _types.Object, _types.ObjectArray));
+        // speciesType = speciesVal as Type;
+        il.Emit(OpCodes.Isinst, _types.Type);
+        il.Emit(OpCodes.Stloc, speciesTypeLocal);
+        // if (speciesType == null) return result;  // undefined/null/non-Type species → %Promise%
+        il.Emit(OpCodes.Ldloc, speciesTypeLocal);
+        il.Emit(OpCodes.Brfalse, returnResultLabel);
+
+        il.MarkLabel(haveSpeciesLabel);
+        // if (speciesType == typeof(Task<object?>)) return result;  // %Promise%
+        il.Emit(OpCodes.Ldloc, speciesTypeLocal);
+        il.Emit(OpCodes.Ldtoken, _types.TaskOfObject);
+        il.Emit(OpCodes.Call, getTypeFromHandle);
+        il.Emit(OpCodes.Beq, returnResultLabel);
+
+        // var ctor = speciesType.GetConstructor(new[] { typeof(object) });
+        il.Emit(OpCodes.Ldloc, speciesTypeLocal);
         il.Emit(OpCodes.Ldc_I4_1);
         il.Emit(OpCodes.Newarr, _types.Type);
         il.Emit(OpCodes.Dup);
         il.Emit(OpCodes.Ldc_I4_0);
         il.Emit(OpCodes.Ldtoken, _types.Object);
-        il.Emit(OpCodes.Call, _types.GetMethod(_types.Type, "GetTypeFromHandle", _types.RuntimeTypeHandle));
+        il.Emit(OpCodes.Call, getTypeFromHandle);
         il.Emit(OpCodes.Stelem_Ref);
         il.Emit(OpCodes.Callvirt, _types.Type.GetMethod("GetConstructor", [typeof(Type[])])!);
         il.Emit(OpCodes.Stloc, ctorLocal);

--- a/Runtime/BuiltIns/PromiseBuiltIns.cs
+++ b/Runtime/BuiltIns/PromiseBuiltIns.cs
@@ -16,13 +16,15 @@ public static class PromiseBuiltIns
     /// </summary>
     /// <remarks>
     /// For Promise subclass instances (#242), then/catch/finally construct
-    /// their result promise via the receiver's guest class ("species-lite" —
-    /// the receiver's own class stands in for the spec's
-    /// SpeciesConstructor(promise.constructor) lookup, which #221 tracks).
+    /// their result promise through SpeciesConstructor(promise, %Promise%)
+    /// (ECMA-262 §27.2.5.4 step 3, §7.3.22) — i.e. the value of
+    /// <c>promise.constructor[Symbol.species]</c>, defaulting to the receiver's
+    /// own class when not overridden and to <c>%Promise%</c> when the override
+    /// yields <c>undefined</c>/<c>null</c> or <c>Promise</c> itself (#221).
     /// </remarks>
     public static object? GetMember(SharpTSPromise receiver, string name)
     {
-        var factory = DerivedPromiseFactory(receiver);
+        var factory = SpeciesPromiseFactory(receiver);
         return name switch
         {
             "then" => new BuiltInAsyncMethod("then", 1, 2, (interp, recv, args) =>
@@ -35,10 +37,9 @@ public static class PromiseBuiltIns
                 FinallyImpl((SharpTSPromise)recv!, args, interp), factory).Bind(receiver),
 
             // ECMA-262 §27.2.5.1: Promise.prototype.constructor is %Promise%.
-            // First SpeciesConstructor increment for #221 — then/catch/finally
-            // result construction still always uses %Promise%; species dispatch
-            // stays unobservable until guest classes can subclass Promise (#233)
-            // and Symbol is a first-class value (#234).
+            // (Subclass instances report their own class — see
+            // Interpreter.Properties.cs. then/catch/finally now consult
+            // SpeciesConstructor via SpeciesPromiseFactory, #221.)
             "constructor" => Interpreter.PromiseGlobalValue,
 
             _ => null
@@ -88,9 +89,15 @@ public static class PromiseBuiltIns
     }
 
     /// <summary>
-    /// Returns the derived-promise factory for a Promise subclass receiver or
-    /// subclass constructor, or null for plain promises (which keeps the
-    /// default <see cref="SharpTSPromise"/> wrapping).
+    /// Returns the derived-promise factory for a Promise subclass static-side
+    /// constructor, or null for the base Promise (which keeps the default
+    /// <see cref="SharpTSPromise"/> wrapping). Used by the static methods
+    /// (<c>resolve</c>/<c>reject</c>/<c>all</c>/<c>race</c>/<c>allSettled</c>/
+    /// <c>any</c>/<c>withResolvers</c>), which per ECMA-262 build their result
+    /// through the receiver constructor <c>C</c> <em>directly</em> (e.g.
+    /// §27.2.4.1 <c>Promise.all</c> step 2 <c>NewPromiseCapability(C)</c>) — no
+    /// <c>@@species</c> indirection (that applies only to the prototype methods;
+    /// see <see cref="SpeciesPromiseFactory"/>).
     /// </summary>
     private static Func<Interpreter, Task<object?>, SharpTSPromise>? DerivedPromiseFactory(object? receiverOrClass)
     {
@@ -105,6 +112,73 @@ public static class PromiseBuiltIns
         if (klass == null || ReferenceEquals(klass, SharpTSPromiseClass.PromiseBase))
             return null;
         return (interp, task) => klass.ConstructDerived(interp, task);
+    }
+
+    /// <summary>
+    /// Returns the result-promise factory for the prototype methods
+    /// (<c>then</c>/<c>catch</c>/<c>finally</c>), which per ECMA-262 §27.2.5.4
+    /// construct their result through <c>SpeciesConstructor(promise, %Promise%)</c>.
+    /// Plain promises (always <c>%Promise%</c>) keep the default wrapping
+    /// (null factory). For a subclass receiver the species lookup is performed
+    /// lazily, when the factory runs (i.e. when the method is invoked), so a
+    /// throwing <c>@@species</c> getter surfaces synchronously from the call and
+    /// the default — inherited <c>Promise[@@species]</c> returns the constructor
+    /// itself — yields the receiver's own class.
+    /// </summary>
+    private static Func<Interpreter, Task<object?>, SharpTSPromise>? SpeciesPromiseFactory(SharpTSPromise receiver)
+    {
+        if (receiver is not SharpTSPromiseSubclassInstance sub)
+            return null;
+        var klass = sub.Klass;
+        return (interp, task) =>
+        {
+            var species = ResolveSpeciesConstructor(klass, interp);
+            return species == null
+                ? new SharpTSPromise(task)              // %Promise%
+                : species.ConstructDerived(interp, task);
+        };
+    }
+
+    /// <summary>
+    /// Computes SpeciesConstructor(promise, %Promise%) (ECMA-262 §7.3.22) for a
+    /// Promise subclass receiver, returning the guest Promise class to construct
+    /// the result through, or <c>null</c> to mean <c>%Promise%</c> (the plain
+    /// built-in). Reads <c>C[@@species]</c> where <c>C</c> is the receiver's
+    /// class: a declared <c>static get [Symbol.species]()</c> or an expando
+    /// <c>(C as any)[Symbol.species]</c> (#262) override wins; absent either,
+    /// the inherited <c>Promise[@@species]</c> (which returns <c>this</c>) makes
+    /// the species the receiver's own class. An override that yields
+    /// <c>undefined</c>/<c>null</c> or <c>Promise</c> itself resolves to
+    /// <c>%Promise%</c>.
+    /// </summary>
+    /// <remarks>
+    /// A species override that returns a non-Promise constructor (the general
+    /// NewPromiseCapability path) is not yet supported and falls back to
+    /// <c>%Promise%</c> — tracked by #349. A poisoned <c>constructor</c> getter
+    /// (own accessor on the instance, <c>then/ctor-poisoned.js</c>) is likewise
+    /// out of scope — tracked by #350.
+    /// </remarks>
+    private static SharpTSPromiseClass? ResolveSpeciesConstructor(SharpTSPromiseClass klass, Interpreter interp)
+    {
+        object? species;
+        if (klass.FindStaticSymbolGetter(SharpTSSymbol.Species) is { } getter)
+            species = getter.BindStatic(klass).Call(interp, []);
+        else if (klass.TryGetStaticBySymbol(SharpTSSymbol.Species, out var expando))
+            species = expando;
+        else
+            // No own @@species: inherited Promise[@@species] returns `this`.
+            return klass;
+
+        return species switch
+        {
+            null or SharpTSUndefined => null,                                  // → %Promise%
+            SharpTSBuiltInConstructor { Name: BuiltInNames.Promise } => null,  // `return Promise`
+            SharpTSPromiseClass sc when ReferenceEquals(sc, SharpTSPromiseClass.PromiseBase) => null,
+            SharpTSPromiseClass sc => sc,
+            // Non-Promise species constructor: general NewPromiseCapability not
+            // yet supported (#349) — fall back to %Promise%.
+            _ => null
+        };
     }
 
     #region Instance Methods

--- a/Runtime/Types/SharpTSPromiseClass.cs
+++ b/Runtime/Types/SharpTSPromiseClass.cs
@@ -58,11 +58,12 @@ public sealed class SharpTSPromiseSubclassInstance : SharpTSPromise
 /// methods/getters/fields, instanceof both ways, static-side inheritance of
 /// the Promise built-ins (<c>MyPromise.resolve</c> etc. construct
 /// subclass-typed results via <see cref="ConstructDerived"/>), and
-/// subclass-typed results from <c>then</c>/<c>catch</c>/<c>finally</c>.
-/// Derived-promise creation uses the receiver's own class directly
-/// ("species-lite") — the full SpeciesConstructor/NewPromiseCapability spec
-/// surface (constructor/@@species lookups, poisoned-getter synchronous
-/// throws) remains tracked by #221.
+/// SpeciesConstructor-aware results from <c>then</c>/<c>catch</c>/<c>finally</c>
+/// (#221 — see <see cref="Runtime.BuiltIns.PromiseBuiltIns"/>
+/// <c>ResolveSpeciesConstructor</c>; the static methods build through the
+/// receiver constructor <c>C</c> directly per spec). Remaining spec surface:
+/// a non-Promise species constructor (general NewPromiseCapability, #349) and
+/// poisoned <c>constructor</c>/@@species getters (#350).
 /// </remarks>
 public class SharpTSPromiseClass : SharpTSClass
 {

--- a/SharpTS.Tests/SharedTests/PromiseSubclassTests.cs
+++ b/SharpTS.Tests/SharedTests/PromiseSubclassTests.cs
@@ -290,4 +290,194 @@ public class PromiseSubclassTests
         Assert.Equal("true\nfalse\ntrue\n", output);
     }
 
+    #region SpeciesConstructor (#221) — then/catch/finally consult @@species
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Species_ThenRedirectsToPlainPromise(ExecutionMode mode)
+    {
+        // ECMA-262 §27.2.5.4 / §7.3.22: then builds its result through
+        // SpeciesConstructor(promise, %Promise%) = promise.constructor[@@species].
+        // A subclass whose @@species returns Promise gets a PLAIN promise from
+        // then — not an instance of the subclass.
+        var source = """
+            class MyP extends Promise<number> {
+                static get [Symbol.species]() { return Promise; }
+            }
+            async function main() {
+                const q = MyP.resolve(1).then(v => v + 1);
+                console.log(q instanceof MyP);
+                console.log(q instanceof Promise);
+                console.log(await q);
+            }
+            main();
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("false\ntrue\n2\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Species_DefaultIsReceiverClass(ExecutionMode mode)
+    {
+        // No @@species override: the inherited Promise[@@species] returns the
+        // constructor itself, so then stays subclass-typed.
+        var source = """
+            class MyP extends Promise<number> {}
+            async function main() {
+                const q = MyP.resolve(1).then(v => v + 1);
+                console.log(q instanceof MyP);
+                console.log(await q);
+            }
+            main();
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("true\n2\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Species_ThenRedirectsToOtherSubclass(ExecutionMode mode)
+    {
+        // @@species may name a different Promise subclass; then constructs
+        // through it.
+        var source = """
+            class Other extends Promise<number> {}
+            class MyP extends Promise<number> {
+                static get [Symbol.species]() { return Other; }
+            }
+            async function main() {
+                const q = MyP.resolve(1).then(v => v);
+                console.log(q instanceof Other);
+                console.log(q instanceof MyP);
+                console.log(await q);
+            }
+            main();
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("true\nfalse\n1\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Species_UndefinedFallsBackToPromise(ExecutionMode mode)
+    {
+        // SpeciesConstructor: an @@species of undefined/null defaults to
+        // %Promise% (ECMA-262 §7.3.22 step 3-4).
+        var source = """
+            class MyP extends Promise<number> {
+                static get [Symbol.species]() { return undefined as any; }
+            }
+            async function main() {
+                const q = MyP.resolve(1).then(v => v);
+                console.log(q instanceof MyP);
+                console.log(q instanceof Promise);
+            }
+            main();
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("false\ntrue\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Species_CatchAndFinallyFollowSpecies(ExecutionMode mode)
+    {
+        // catch (= then(undefined, onRejected)) and finally also route their
+        // result through SpeciesConstructor.
+        var source = """
+            class MyP extends Promise<number> {
+                static get [Symbol.species]() { return Promise; }
+            }
+            async function main() {
+                const c = MyP.reject("x").catch(e => 0);
+                console.log(c instanceof MyP);
+                const f = MyP.resolve(1).finally(() => {});
+                console.log(f instanceof MyP);
+                console.log(await f);
+            }
+            main();
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("false\nfalse\n1\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Species_CombinatorsUseReceiverConstructorDirectly(ExecutionMode mode)
+    {
+        // Static methods (resolve/all/race) build through the receiver
+        // constructor C directly (e.g. §27.2.4.1 NewPromiseCapability(C)), NOT
+        // C[@@species] — so even with @@species → Promise they stay subclass-typed.
+        var source = """
+            class MyP extends Promise<number> {
+                static get [Symbol.species]() { return Promise; }
+            }
+            async function main() {
+                console.log(MyP.resolve(1) instanceof MyP);
+                console.log(MyP.all([1, 2]) instanceof MyP);
+                console.log(MyP.race([1, 2]) instanceof MyP);
+            }
+            main();
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("true\ntrue\ntrue\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void Species_GenericSubclassOverride_Interpreted(ExecutionMode mode)
+    {
+        // A GENERIC Promise subclass with a @@species override resolves
+        // correctly in the interpreter. Compiled mode currently falls back to
+        // the receiver class (its static accessor is registered under the open
+        // generic type while the receiver's runtime type is closed) — the
+        // pre-existing #266 generic-class gap, tracked by #351.
+        var source = """
+            class MyP<T> extends Promise<T> {
+                static get [Symbol.species]() { return Promise; }
+            }
+            async function main() {
+                const q = MyP.resolve(1).then(v => v);
+                console.log(q instanceof MyP);
+                console.log(q instanceof Promise);
+            }
+            main();
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("false\ntrue\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void Species_ExpandoOverride_Interpreted(ExecutionMode mode)
+    {
+        // A dynamically-assigned static @@species ((C as any)[Symbol.species] =
+        // Promise, #262) is consulted by then in the interpreter. Compiled mode
+        // only reads the declared-accessor registry, so the expando is not yet
+        // consulted there — tracked by #349.
+        var source = """
+            class MyP extends Promise<number> {}
+            (MyP as any)[Symbol.species] = Promise;
+            async function main() {
+                const q = MyP.resolve(1).then(v => v);
+                console.log(q instanceof MyP);
+                console.log(q instanceof Promise);
+            }
+            main();
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("false\ntrue\n", output);
+    }
+
+    #endregion
+
 }


### PR DESCRIPTION
Closes #221 (the SpeciesConstructor/NewPromiseCapability core).

## What

`Promise.prototype.then`/`catch`/`finally` now build their result promise through **`SpeciesConstructor(promise, %Promise%)`** (ECMA-262 §27.2.5.4 → §7.3.22) rather than always using the receiver's own class ("species-lite"). They read `promise.constructor[Symbol.species]`, defaulting to the receiver class when there is no override and to `%Promise%` when the override yields `Promise`, `undefined`, or `null`.

The static methods (`resolve`/`reject`/`all`/`race`/`allSettled`/`any`/`withResolvers`) keep using the receiver constructor `C` **directly** — which the spec already requires (e.g. §27.2.4.1 `Promise.all` step 2 `NewPromiseCapability(C)`), so the existing species-lite is correct there and is documented as such.

This is now observable from guest code thanks to the landed prerequisites: `extends Promise` (#242), `static get [Symbol.species]` parsing + dispatch (#261/#266), Symbol as a first-class value (#234).

```ts
class MyP extends Promise<number> {
  static get [Symbol.species]() { return Promise; }
}
MyP.resolve(1).then(v => v) instanceof MyP;   // false (was true) — species → %Promise%
MyP.all([1, 2]) instanceof MyP;               // true  — combinators use C directly
```

## How

- **Interpreter** (`Runtime/BuiltIns/PromiseBuiltIns.cs`): `SpeciesPromiseFactory` + `ResolveSpeciesConstructor`. The `@@species` lookup (declared static getter, or a `(C as any)[Symbol.species]` expando, #262) runs **lazily at call time**, so a throwing getter surfaces synchronously from the call and the inherited-`Promise[@@species]`-returns-`this` default resolves to the receiver class. Plain promises keep the null-factory fast path (species is always `%Promise%`), so there's no per-call overhead for the common case.
- **Compiled** (`Compilation/RuntimeEmitter.Promises.Executor.cs`): `WrapDerivedPromiseResult` consults the #266 static symbol-accessor registry via the receiver's runtime type and constructs the result through the resolved species `Type` (`%Promise%`/`Promise`/`undefined` → raw task; another guest Promise class → its executor constructor). No changes to the shared registry, so other symbol accessors are untouched.

## Tests

14 new cases in `PromiseSubclassTests` — both modes for the non-generic path (species → Promise / other subclass / undefined; catch+finally; combinators-use-C); interpreted-only for the generic-subclass and expando overrides that the compiled registry cannot yet resolve.

Full suite: **11068 passed, 0 failed**.

## Scope / follow-ups filed

- **#349** — species that resolves to a *non-Promise* constructor (general NewPromiseCapability); both modes fall back to `%Promise%`. Also covers the compiled-mode gap where a dynamically-set static `@@species` (expando) isn't consulted.
- **#350** — poisoned `constructor` getter synchronous throw (`then/ctor-poisoned.js`); needs own-accessor storage on promise instances.
- **#351** — a *generic* Promise subclass `@@species` override isn't resolved in compiled mode (the pre-existing #266 generic-class registry-key/invoke gap; also makes the guest-visible `MyP<T>[Symbol.species]` read throw). Falls back to the receiver class — no crash via `then`.

## Note for maintainer

Test262 species baselines may now flip Fail→Pass (the suite hard-fails on new-pass). `then/ctor-poisoned.js` stays Fail (depends on #350). The conformance suite no-ops in this worktree (no submodule), so its baseline was not regenerated here.