### PR TITLE
fix(interp): a running Worker keeps the parent event loop alive (#329)

### DIFF
--- a/Runtime/Types/SharpTSWorker.cs
+++ b/Runtime/Types/SharpTSWorker.cs
@@ -39,6 +39,17 @@ public class SharpTSWorker : SharpTSEventEmitter, IDisposable
     private Exception? _workerError;
     private Interpreter? _parentInterpreter;
 
+    // Event-loop keep-alive accounting against the parent interpreter. Node keeps
+    // the parent process alive for a running Worker's lifetime by default;
+    // worker.unref() opts out and worker.ref() opts back in. Without this, a
+    // parent whose only pending work is a worker's 'message' listener can hit the
+    // 250ms quiescence give-up and exit before the worker posts (#329 — same
+    // native-I/O liveness class as #319/#320/#324). Guarded by _refLock so the
+    // parent (ref/unref) and the worker thread (exit) can't race the count.
+    private readonly object _refLock = new();
+    private bool _refed;             // currently holding one parent-loop Ref for the running worker
+    private bool _refReleased;       // worker exited/terminated — ref/unref are permanent no-ops
+
     // For compiled code support - enables Worker communication without interpreter
     private readonly SynchronizationContext? _syncContext;
     private readonly ConcurrentQueue<Action> _pendingCallbacks = new();
@@ -103,7 +114,41 @@ public class SharpTSWorker : SharpTSEventEmitter, IDisposable
         };
 
         _isRunning = true;
+
+        // Default-on Node semantics: a running worker keeps the parent loop alive.
+        // Establish the Ref before starting the thread so the worker can never exit
+        // (and Unref) before we've counted it.
+        lock (_refLock)
+        {
+            if (_parentInterpreter != null)
+            {
+                _refed = true;
+                _parentInterpreter.Ref();
+            }
+        }
+
         _thread.Start();
+    }
+
+    /// <summary>
+    /// Drops the running-worker keep-alive Ref against the parent loop and marks it
+    /// permanently released, so a later <see cref="Ref"/>/<see cref="Unref"/> from
+    /// guest code becomes a no-op. Idempotent and safe to call from either the parent
+    /// thread (terminate) or the worker thread (exit).
+    /// </summary>
+    private void ReleaseRunningRef()
+    {
+        lock (_refLock)
+        {
+            if (_refReleased)
+                return;
+            _refReleased = true;
+            if (_refed)
+            {
+                _refed = false;
+                _parentInterpreter?.Unref();
+            }
+        }
     }
 
     /// <summary>
@@ -126,6 +171,12 @@ public class SharpTSWorker : SharpTSEventEmitter, IDisposable
             _isRunning = false;
             _parentToWorkerQueue.CompleteAdding();
             _workerToParentQueue.CompleteAdding();
+
+            // Worker is done — stop keeping the parent loop alive (Node unrefs an
+            // exited worker). Released before the exit event is enqueued so the
+            // parent's only remaining work is that event's delivery timer, which
+            // Refs the loop itself for its in-flight window.
+            ReleaseRunningRef();
 
             // Notify parent that worker has exited
             EnqueueExitToParent(0);
@@ -163,8 +214,10 @@ public class SharpTSWorker : SharpTSEventEmitter, IDisposable
             throw new Exception($"Worker script parse error: {parseResult.Diagnostics.FirstOrDefault()?.Message ?? "Unknown error"}");
         }
 
-        // Type check
-        var typeChecker = new TypeChecker();
+        // Type check. AsWorkerContext lets the worker-scoped globals (parentPort,
+        // postMessage, workerData, threadId, isMainThread) resolve instead of
+        // failing as undefined — they're bound below by SetupWorkerGlobals.
+        var typeChecker = new TypeChecker().AsWorkerContext();
         var typeMap = typeChecker.Check(parseResult.Statements);
 
         // Set up message handling loop
@@ -394,6 +447,12 @@ public class SharpTSWorker : SharpTSEventEmitter, IDisposable
         _cts.Cancel();
         _parentToWorkerQueue.CompleteAdding();
 
+        // The worker is being torn down — drop its running keep-alive Ref now
+        // rather than waiting for the worker thread's finally, so the only loop
+        // keep-alive from here is the bounded join Ref below. Idempotent with the
+        // worker-thread finally's ReleaseRunningRef.
+        ReleaseRunningRef();
+
         // The thread join is real, always-completing work bounded at 5s. Ref the
         // parent event loop for its duration so the interpreter's quiescence
         // heuristic does not abandon a program whose only remaining work is
@@ -416,19 +475,39 @@ public class SharpTSWorker : SharpTSEventEmitter, IDisposable
     }
 
     /// <summary>
-    /// Gets a reference to the worker.
+    /// Opts the worker back into keeping the parent event loop alive (Node's
+    /// <c>worker.ref()</c>). No-op once the worker has exited or been terminated,
+    /// or in compiled mode (no parent interpreter).
     /// </summary>
     public SharpTSWorker Ref()
     {
+        lock (_refLock)
+        {
+            if (!_refReleased && !_refed && _parentInterpreter != null)
+            {
+                _refed = true;
+                _parentInterpreter.Ref();
+            }
+        }
         return this;
     }
 
     /// <summary>
-    /// Releases the worker reference.
+    /// Opts the worker out of keeping the parent event loop alive (Node's
+    /// <c>worker.unref()</c>). The worker keeps running; the parent is just free to
+    /// exit if the worker is its only remaining work. No-op once the worker has
+    /// exited/terminated, or in compiled mode (no parent interpreter).
     /// </summary>
     public void Unref()
     {
-        // In our implementation, this is a no-op since we don't track refs
+        lock (_refLock)
+        {
+            if (_refed)
+            {
+                _refed = false;
+                _parentInterpreter?.Unref();
+            }
+        }
     }
 
     /// <summary>

--- a/SharpTS.Tests/SharedTests/TimerTests.cs
+++ b/SharpTS.Tests/SharedTests/TimerTests.cs
@@ -121,12 +121,26 @@ public class TimerTests
     [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void SetTimeout_Unref_AllowsExit_Interpreted(ExecutionMode mode)
     {
-        // unref() should allow the program to exit without running the timer
+        // unref() drops a timer's hold on the event loop: the program exits once
+        // the *ref'd* work is done, without waiting for (or running) the unref'd
+        // timer. A ref'd short timer fires "alive" and keeps the loop alive until
+        // it does; the unref'd timer is scheduled far in the future and must never
+        // fire — its only hold on the loop was removed by unref(), so the program
+        // exits long before it is due.
+        //
+        // This is a positive, load-independent assertion (anti-flake doctrine): the
+        // ref'd timer fires whenever it is due, so there is no wall-clock race, and
+        // the unref'd timer's far-future delay means it cannot fire within any
+        // plausible exit window regardless of CI load. The earlier version asserted
+        // empty output for a 10ms unref'd timer, which flaked when a slow/loaded
+        // runner's startup outran the 10ms and the shutdown drain fired the now-due
+        // timer before the exit check.
         var source = @"
-            setTimeout(() => { console.log('should not run'); }, 10).unref();
+            setTimeout(() => { console.log('should not run'); }, 60000).unref();
+            setTimeout(() => { console.log('alive'); }, 10);
         ";
         var output = TestHarness.Run(source, mode);
-        Assert.Equal(string.Empty, output);
+        Assert.Equal("alive\n", output);
     }
 
     #endregion

--- a/SharpTS.Tests/SharedTests/WorkerThreadsTests.cs
+++ b/SharpTS.Tests/SharedTests/WorkerThreadsTests.cs
@@ -488,4 +488,79 @@ public class WorkerThreadsTests
     }
 
     #endregion
+
+    #region Running-Worker event-loop liveness (#329)
+
+    /// <summary>
+    /// Regression for #329: a running worker must keep the parent event loop alive
+    /// by default (Node semantics). The worker posts a message back ~400ms after
+    /// spawn — past the parent loop's 250ms quiescence window — and the parent's
+    /// only pending work is the <c>'message'</c> listener. Before the fix nothing
+    /// Ref'd the parent for the worker's running lifetime, so the parent abandoned
+    /// the wait at 250ms and exited without ever printing the message.
+    /// </summary>
+    /// <remarks>
+    /// InterpretedOnly: the keep-alive Ref is against the interpreter event loop;
+    /// compiled mode has no parent interpreter. <c>__dirname</c> routes the harness
+    /// through the real-disk path so the worker can load its script. The assertion
+    /// is positive and load-independent — under load the worker simply posts later
+    /// and the running-Ref keeps the parent alive until it does, so the test cannot
+    /// flake the way a wall-clock window would.
+    /// </remarks>
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void Worker_RunningWorker_KeepsParentLoopAliveUntilMessage(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["worker_delayed.ts"] = """
+                // Post back after >250ms, holding the worker's own loop open via the
+                // pending timer until it fires. The worker then exits naturally.
+                setTimeout(() => { postMessage("from-worker"); }, 400);
+                """,
+            ["main.ts"] = """
+                import { Worker } from "worker_threads";
+                const w = new Worker(__dirname + "/worker_delayed.ts");
+                // The 'message' listener is the parent's ONLY pending work — the
+                // running worker must keep the loop alive long enough to deliver.
+                w.on("message", (e: any) => {
+                    console.log("received:" + e.data);
+                });
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Contains("received:from-worker", output);
+    }
+
+    /// <summary>
+    /// <c>worker.ref()</c> / <c>worker.unref()</c> are callable, chainable, and a
+    /// <c>ref()</c> after an <c>unref()</c> restores the keep-alive so a later
+    /// delayed message is still delivered (positive, load-independent assertion).
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void Worker_UnrefThenRef_RestoresKeepAlive(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["worker_delayed.ts"] = """
+                setTimeout(() => { postMessage("again"); }, 400);
+                """,
+            ["main.ts"] = """
+                import { Worker } from "worker_threads";
+                const w = new Worker(__dirname + "/worker_delayed.ts");
+                w.on("message", (e: any) => {
+                    console.log("received:" + e.data);
+                });
+                w.unref(); // opt out of keep-alive...
+                w.ref();   // ...then opt back in — message must still arrive.
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Contains("received:again", output);
+    }
+
+    #endregion
 }

--- a/TypeSystem/TypeChecker.Expressions.cs
+++ b/TypeSystem/TypeChecker.Expressions.cs
@@ -1384,6 +1384,13 @@ public partial class TypeChecker
             if (name.Lexeme == "module" || name.Lexeme == "exports" || name.Lexeme == "global")
                 return new TypeInfo.Any();
         }
+        // Worker-scoped globals — only valid inside a worker_threads worker script,
+        // where SharpTSWorker.SetupWorkerGlobals binds them at runtime. Gated on
+        // worker context so they stay undefined (TS2304) on the main thread, matching
+        // Node (these are not main-thread globals).
+        if (_isWorkerContext && name.Lexeme is "parentPort" or "postMessage"
+            or "workerData" or "threadId" or "isMainThread")
+            return new TypeInfo.Any();
         // Worker Threads globals
         if (name.Lexeme == "structuredClone") return new TypeInfo.Any(); // structuredClone() global function
         if (name.Lexeme == "SharedArrayBuffer") return new TypeInfo.Any(); // SharedArrayBuffer constructor

--- a/TypeSystem/TypeChecker.cs
+++ b/TypeSystem/TypeChecker.cs
@@ -99,6 +99,12 @@ public partial class TypeChecker
     /// </summary>
     private bool _inCallbackComparison;
 
+    /// <summary>
+    /// True when checking a worker_threads worker script — enables the worker-scoped
+    /// globals in <see cref="LookupVariable"/>. Set via <see cref="AsWorkerContext"/>.
+    /// </summary>
+    private bool _isWorkerContext;
+
     /// <summary>Creates a type checker. <paramref name="strictNullChecks"/> defaults to true.</summary>
     public TypeChecker(bool strictNullChecks = true, int maxErrors = 10, bool strictFunctionTypes = false)
     {
@@ -493,6 +499,19 @@ public partial class TypeChecker
     public TypeChecker WithFilePath(string? filePath)
     {
         _filePath = filePath;
+        return this;
+    }
+
+    /// <summary>
+    /// Marks this checker as running a worker_threads worker script, so the
+    /// worker-scoped globals (<c>parentPort</c>, <c>postMessage</c>, <c>workerData</c>,
+    /// <c>threadId</c>, <c>isMainThread</c>) resolve as <c>any</c> instead of TS2304.
+    /// These are bound at runtime by <see cref="SharpTS.Runtime.Types.SharpTSWorker"/>'s
+    /// SetupWorkerGlobals and are not visible on the main thread, mirroring Node.
+    /// </summary>
+    public TypeChecker AsWorkerContext()
+    {
+        _isWorkerContext = true;
         return this;
     }
 


### PR DESCRIPTION
Closes #329.

## Problem
`SharpTSWorker.Ref()` / `Unref()` were no-ops, and nothing kept the parent interpreter's event loop alive for a worker's running lifetime. A parent whose only pending work was a worker's `on('message', ...)` listener could hit the 250ms quiescence give-up and exit before the worker posted — the same native-I/O liveness class as #319/#320/#324, but for the steady-state worker rather than its teardown.

## Fix
Give `SharpTSWorker` real ref accounting against the parent interpreter, mirroring `SharpTSBroadcastChannel.Ref/Unref`:
- Ref the parent loop when the worker starts running (default-on, Node semantics); Unref when the worker exits (`WorkerThreadMain` finally) or on `terminate()`.
- `worker.ref()` / `worker.unref()` toggle that ref so guest code can opt out, matching Node.
- All transitions guarded by a lock so the parent (ref/unref) and the worker thread (exit) can't race the count; permanently a no-op once the worker has exited/terminated. Compiled mode (no `_parentInterpreter`) is unaffected, as the issue noted.

## Incidental fix (blocked the required test)
The worker's `TypeChecker` rejected the worker-scoped globals (`parentPort`/`postMessage`/`workerData`/`threadId`/`isMainThread`) as `TS2304`, so **any** worker script referencing them failed to run. This was never caught because there were no `new Worker(...)` spawn tests. Added `TypeChecker.AsWorkerContext()` which resolves those names as `any` **only** inside a worker (they stay undefined on the main thread, matching Node), wired in from `RunWorkerScript`.

Filed #354 for the equivalent compiled-mode worker liveness gap (separate, as the issue scoped it out).

## Tests
Adds `new Worker(...)` spawn coverage (the suite had none):
- `Worker_RunningWorker_KeepsParentLoopAliveUntilMessage` — worker posts back after a >250ms delay with the parent's only pending work being the message listener; reliably received. Positive, load-independent assertion per the anti-flake doctrine.
- `Worker_UnrefThenRef_RestoresKeepAlive` — `unref()` then `ref()` restores the keep-alive and the delayed message still arrives.

Full suite green (11,060 passed).
