### PR TITLE
fix(compile): materialize own-shadow for inherited static-field writes (#339)

### DIFF
--- a/Compilation/EmittedRuntime.cs
+++ b/Compilation/EmittedRuntime.cs
@@ -2665,6 +2665,7 @@ public class EmittedRuntime
     public MethodBuilder PDSDefineProperty { get; set; } = null!;
     public MethodBuilder PDSDeleteProperty { get; set; } = null!;
     public MethodBuilder PDSGetPropertyDescriptor { get; set; } = null!;
+    public MethodBuilder PDSGetStaticShadow { get; set; } = null!;
 
     // cluster module — emitted types (no reflection to SharpTS.dll)
     // $ClusterContext: static class with [ThreadStatic] fields for worker detection

--- a/Compilation/ExpressionEmitterBase.Operators.cs
+++ b/Compilation/ExpressionEmitterBase.Operators.cs
@@ -313,6 +313,35 @@ public abstract partial class ExpressionEmitterBase
                 SetStackUnknown();
                 return;
             }
+
+            // Inherited static data field: read the current value (shadow-or-base), compute, then
+            // write the result as a per-subclass own shadow via SetProperty's Type arm (→ PDS) rather
+            // than mutating the base field. Matches JS own-shadow semantics and the plain-write path (#339).
+            if (Ctx.ClassRegistry!.TryGetCallableStaticField(resolvedClassName, cs.Name.Lexeme, compoundClassBuilder, out var inheritedField))
+            {
+                EmitStaticFieldLoadWithShadow(resolvedClassName, compoundClassBuilder, cs.Name.Lexeme, inheritedField!);
+                var inheritedCurrentTemp = IL.DeclareLocal(typeof(object));
+                IL.Emit(OpCodes.Stloc, inheritedCurrentTemp);
+
+                // Spill the RHS so an await inside it suspends with an empty stack.
+                var inheritedRhsTemp = SpillBoxed(cs.Value);
+
+                IL.Emit(OpCodes.Ldloc, inheritedCurrentTemp);
+                IL.Emit(OpCodes.Ldloc, inheritedRhsTemp);
+                EmitCompoundOperation(cs.Operator.Type);
+                var inheritedResultTemp = IL.DeclareLocal(typeof(object));
+                IL.Emit(OpCodes.Stloc, inheritedResultTemp);
+
+                IL.Emit(OpCodes.Ldtoken, compoundClassBuilder);
+                IL.Emit(OpCodes.Call, Types.TypeGetTypeFromHandle);
+                IL.Emit(OpCodes.Ldstr, cs.Name.Lexeme);
+                IL.Emit(OpCodes.Ldloc, inheritedResultTemp);
+                IL.Emit(OpCodes.Call, Ctx.Runtime!.SetProperty);
+
+                IL.Emit(OpCodes.Ldloc, inheritedResultTemp);
+                SetStackUnknown();
+                return;
+            }
         }
 
         // Dynamic property compound assignment

--- a/Compilation/ExpressionEmitterBase.cs
+++ b/Compilation/ExpressionEmitterBase.cs
@@ -1788,12 +1788,54 @@ public abstract partial class ExpressionEmitterBase : IEmitterContext
             string resolvedClassName = Ctx.ResolveClassName(classVar.Name.Lexeme);
             if (Ctx.ClassRegistry!.TryGetCallableStaticField(resolvedClassName, g.Name.Lexeme, staticFieldClassBuilder, out var staticField))
             {
-                IL.Emit(OpCodes.Ldsfld, staticField!);
-                SetStackUnknown();
+                EmitStaticFieldLoadWithShadow(resolvedClassName, staticFieldClassBuilder, g.Name.Lexeme, staticField!);
                 return true;
             }
         }
         return false;
+    }
+
+    /// <summary>
+    /// Loads a static data field read through <paramref name="resolvedClassName"/>. For a field the
+    /// class declares itself this is a plain <c>Ldsfld</c>. For an <em>inherited</em> static field
+    /// (declared on a base, resolved via the superclass walk) a subclass write creates a per-subclass
+    /// own shadow in $PropertyDescriptorStore keyed by the subclass Type — so the read first consults
+    /// that store (walking the Type chain) and only falls back to the declaring base's field when no
+    /// shadow exists. This matches interpreter / JS own-shadow semantics (issue #339). The shadow probe
+    /// is emitted only on the inherited path, leaving own-field reads a single load.
+    /// </summary>
+    protected void EmitStaticFieldLoadWithShadow(string resolvedClassName, System.Reflection.Emit.TypeBuilder classBuilder, string fieldName, System.Reflection.FieldInfo resolvedField)
+    {
+        // Own field: no subclass shadow can exist, emit a direct load.
+        if (Ctx.ClassRegistry!.TryGetOwnStaticField(resolvedClassName, fieldName, out _))
+        {
+            IL.Emit(OpCodes.Ldsfld, resolvedField);
+            SetStackUnknown();
+            return;
+        }
+
+        // Inherited field: probe for a runtime own-shadow on the subclass (or a nearer ancestor) first.
+        var shadowLocal = IL.DeclareLocal(Ctx.Runtime!.CompiledPropertyDescriptorType);
+        var noShadowLabel = IL.DefineLabel();
+        var doneLabel = IL.DefineLabel();
+
+        IL.Emit(OpCodes.Ldtoken, classBuilder);
+        IL.Emit(OpCodes.Call, Types.TypeGetTypeFromHandle);
+        IL.Emit(OpCodes.Ldstr, fieldName);
+        IL.Emit(OpCodes.Call, Ctx.Runtime!.PDSGetStaticShadow);
+        IL.Emit(OpCodes.Stloc, shadowLocal);
+
+        IL.Emit(OpCodes.Ldloc, shadowLocal);
+        IL.Emit(OpCodes.Brfalse, noShadowLabel);
+        IL.Emit(OpCodes.Ldloc, shadowLocal);
+        IL.Emit(OpCodes.Callvirt, Ctx.Runtime!.CompiledPropertyDescriptorValue.GetGetMethod()!);
+        IL.Emit(OpCodes.Br, doneLabel);
+
+        IL.MarkLabel(noShadowLabel);
+        IL.Emit(OpCodes.Ldsfld, resolvedField);
+
+        IL.MarkLabel(doneLabel);
+        SetStackUnknown();
     }
 
     #endregion

--- a/Compilation/ILEmitter.Operators.cs
+++ b/Compilation/ILEmitter.Operators.cs
@@ -991,6 +991,11 @@ public partial class ILEmitter
                 return;
             }
 
+            // Static data field via `Class.field` (own or inherited) — bind to the field / PDS shadow
+            // so the increment lands on the same storage the static-typed read consults (#339).
+            if (TryEmitStaticFieldIncrement(get, pi.Operator.Type == TokenType.PLUS_PLUS, isPrefix: true))
+                return;
+
             // Prefix increment on property: ++obj.prop
             // Get current value
             EmitExpression(get.Object);
@@ -1267,6 +1272,11 @@ public partial class ILEmitter
                 return;
             }
 
+            // Static data field via `Class.field` (own or inherited) — bind to the field / PDS shadow
+            // so the increment lands on the same storage the static-typed read consults (#339).
+            if (TryEmitStaticFieldIncrement(get, pi.Operator.Type == TokenType.PLUS_PLUS, isPrefix: false))
+                return;
+
             // Postfix increment on property: obj.prop++
             // Get current value
             EmitExpression(get.Object);
@@ -1350,6 +1360,79 @@ public partial class ILEmitter
         }
     }
 
+    /// <summary>
+    /// Emits <c>++</c>/<c>--</c> on a class's static data field accessed as <c>Class.field</c>
+    /// (member access). Returns false (emitting nothing) when <paramref name="get"/> is not a known
+    /// class's static field, so callers fall through to the generic property path. An own field is
+    /// read and written directly (mirroring plain assignment); an inherited field is read shadow-or-base
+    /// and the result written as a per-subclass own shadow via SetProperty's Type arm (→ PDS), matching
+    /// JS own-shadow semantics (#339). The dynamic GetProperty/SetProperty path used otherwise desyncs
+    /// with the Ldsfld-based static read (write lands in PDS, read sees the field), so binding here keeps
+    /// read and write on the same storage. <paramref name="isPrefix"/> selects the result (new vs old).
+    /// </summary>
+    private bool TryEmitStaticFieldIncrement(Expr.Get get, bool isIncrement, bool isPrefix)
+    {
+        if (get.Object is not Expr.Variable classVar)
+            return false;
+        string resolvedClassName = _ctx.ResolveClassName(classVar.Name.Lexeme);
+        if (!_ctx.Classes.TryGetValue(resolvedClassName, out var classBuilder))
+            return false;
+
+        bool own = _ctx.ClassRegistry!.TryGetOwnCallableStaticField(resolvedClassName, get.Name.Lexeme, classBuilder, out var ownField);
+        System.Reflection.FieldInfo? inheritedField = null;
+        if (!own && !_ctx.ClassRegistry!.TryGetCallableStaticField(resolvedClassName, get.Name.Lexeme, classBuilder, out inheritedField))
+            return false;
+
+        // Load current value and coerce to double (ToNumber semantics).
+        if (own)
+            IL.Emit(OpCodes.Ldsfld, ownField!);
+        else
+            EmitStaticFieldLoadWithShadow(resolvedClassName, classBuilder, get.Name.Lexeme, inheritedField!);
+        EmitUnboxToDouble();
+
+        // Postfix returns the original value — stash it before incrementing.
+        System.Reflection.Emit.LocalBuilder? oldValue = null;
+        if (!isPrefix)
+        {
+            oldValue = IL.DeclareLocal(_ctx.Types.Double);
+            IL.Emit(OpCodes.Dup);
+            IL.Emit(OpCodes.Stloc, oldValue);
+        }
+
+        IL.Emit(OpCodes.Ldc_R8, 1.0);
+        IL.Emit(isIncrement ? OpCodes.Add : OpCodes.Sub);
+        IL.Emit(OpCodes.Box, _ctx.Types.Double);
+        var newValue = IL.DeclareLocal(_ctx.Types.Object);
+        IL.Emit(OpCodes.Stloc, newValue);
+
+        // Write back to the same storage the matching read consults.
+        if (own)
+        {
+            IL.Emit(OpCodes.Ldloc, newValue);
+            IL.Emit(OpCodes.Stsfld, ownField!);
+        }
+        else
+        {
+            IL.Emit(OpCodes.Ldtoken, classBuilder);
+            IL.Emit(OpCodes.Call, _ctx.Types.TypeGetTypeFromHandle);
+            IL.Emit(OpCodes.Ldstr, get.Name.Lexeme);
+            IL.Emit(OpCodes.Ldloc, newValue);
+            IL.Emit(OpCodes.Call, _ctx.Runtime!.SetProperty);
+        }
+
+        if (isPrefix)
+        {
+            IL.Emit(OpCodes.Ldloc, newValue);
+        }
+        else
+        {
+            IL.Emit(OpCodes.Ldloc, oldValue!);
+            IL.Emit(OpCodes.Box, _ctx.Types.Double);
+        }
+        SetStackUnknown();
+        return true;
+    }
+
     protected override void EmitCompoundSet(Expr.CompoundSet cs)
     {
         // Static field fast path: this.staticField op= value inside a static method/block
@@ -1365,6 +1448,47 @@ public partial class ILEmitter
             IL.Emit(OpCodes.Ldloc, csResult);
             SetStackUnknown();
             return;
+        }
+
+        // Compound assignment on a class's static data field: `Class.field op= x`. The generic
+        // dynamic path below routes the write through SetProperty (→ PDS) while the static-typed
+        // read uses Ldsfld, so they desync. Bind own/inherited static fields explicitly here:
+        //   * own field   → read+write the field directly (mirror the plain-assignment path);
+        //   * inherited    → read shadow-or-base, then write a per-subclass own shadow via
+        //                    SetProperty's Type arm (→ PDS), matching JS own-shadow semantics (#339).
+        if (cs.Object is Expr.Variable classVarCS &&
+            _ctx.Classes.TryGetValue(_ctx.ResolveClassName(classVarCS.Name.Lexeme), out var classBuilderCS))
+        {
+            string resolvedClassNameCS = _ctx.ResolveClassName(classVarCS.Name.Lexeme);
+            if (_ctx.ClassRegistry!.TryGetOwnCallableStaticField(resolvedClassNameCS, cs.Name.Lexeme, classBuilderCS, out var ownFieldCS))
+            {
+                IL.Emit(OpCodes.Ldsfld, ownFieldCS!);
+                EmitCompoundOperation(cs.Operator.Type, cs.Value);
+                var ownResultCS = IL.DeclareLocal(_ctx.Types.Object);
+                IL.Emit(OpCodes.Stloc, ownResultCS);
+                IL.Emit(OpCodes.Ldloc, ownResultCS);
+                IL.Emit(OpCodes.Stsfld, ownFieldCS!);
+                IL.Emit(OpCodes.Ldloc, ownResultCS);
+                SetStackUnknown();
+                return;
+            }
+            if (_ctx.ClassRegistry!.TryGetCallableStaticField(resolvedClassNameCS, cs.Name.Lexeme, classBuilderCS, out var inheritedFieldCS))
+            {
+                EmitStaticFieldLoadWithShadow(resolvedClassNameCS, classBuilderCS, cs.Name.Lexeme, inheritedFieldCS!);
+                EmitCompoundOperation(cs.Operator.Type, cs.Value);
+                var inheritedResultCS = IL.DeclareLocal(_ctx.Types.Object);
+                IL.Emit(OpCodes.Stloc, inheritedResultCS);
+
+                IL.Emit(OpCodes.Ldtoken, classBuilderCS);
+                IL.Emit(OpCodes.Call, _ctx.Types.TypeGetTypeFromHandle);
+                IL.Emit(OpCodes.Ldstr, cs.Name.Lexeme);
+                IL.Emit(OpCodes.Ldloc, inheritedResultCS);
+                IL.Emit(OpCodes.Call, _ctx.Runtime!.SetProperty);
+
+                IL.Emit(OpCodes.Ldloc, inheritedResultCS);
+                SetStackUnknown();
+                return;
+            }
         }
 
         // Compound assignment on object property: obj.prop += x

--- a/Compilation/ILEmitter.Properties.External.cs
+++ b/Compilation/ILEmitter.Properties.External.cs
@@ -122,8 +122,7 @@ public partial class ILEmitter
         // Try to find static field using stored FieldBuilders
         if (_ctx.ClassRegistry!.TryGetCallableStaticField(className, propertyName, classBuilder, out var staticField))
         {
-            IL.Emit(OpCodes.Ldsfld, staticField!);
-            SetStackUnknown();
+            EmitStaticFieldLoadWithShadow(className, classBuilder, propertyName, staticField!);
             return true;
         }
 

--- a/Compilation/ILEmitter.Properties.cs
+++ b/Compilation/ILEmitter.Properties.cs
@@ -193,8 +193,7 @@ public partial class ILEmitter
                 // Use TryGetCallableStaticField to handle generic classes properly
                 if (_ctx.ClassRegistry!.TryGetCallableStaticField(resolvedClassName, g.Name.Lexeme, classBuilder, out var callableStaticField))
                 {
-                    IL.Emit(OpCodes.Ldsfld, callableStaticField!);
-                    SetStackUnknown();
+                    EmitStaticFieldLoadWithShadow(resolvedClassName, classBuilder, g.Name.Lexeme, callableStaticField!);
                     return;
                 }
 
@@ -219,8 +218,7 @@ public partial class ILEmitter
             // Try static field
             if (_ctx.ClassRegistry!.TryGetCallableStaticField(importedQualifiedClassName, g.Name.Lexeme, importedClassBuilder, out var importedStaticField))
             {
-                IL.Emit(OpCodes.Ldsfld, importedStaticField!);
-                SetStackUnknown();
+                EmitStaticFieldLoadWithShadow(importedQualifiedClassName, importedClassBuilder, g.Name.Lexeme, importedStaticField!);
                 return;
             }
         }

--- a/Compilation/RuntimeEmitter.PropertyDescriptorStore.cs
+++ b/Compilation/RuntimeEmitter.PropertyDescriptorStore.cs
@@ -288,6 +288,7 @@ public partial class RuntimeEmitter
         EmitPDSDefineProperty(typeBuilder, runtime, descriptorsField, descriptorsGetOrCreate, descriptorsDictType, descriptorsDictSetItem);
         EmitPDSDeleteProperty(typeBuilder, runtime, descriptorsField, descriptorsTryGet, descriptorsDictType, descriptorsDictContainsKey);
         EmitPDSGetPropertyDescriptor(typeBuilder, runtime, descriptorsField, descriptorsTryGet, descriptorsDictType, descriptorsDictTryGetValue);
+        EmitPDSGetStaticShadow(typeBuilder, runtime);
         EmitPDSGetEnumerableExtraKeys(typeBuilder, runtime, descriptorsField, descriptorsTryGet, descriptorsDictType, descriptorsDictTryGetValue);
         EmitPDSGetAllExtraKeys(typeBuilder, runtime, descriptorsField, descriptorsTryGet, descriptorsDictType, descriptorsDictTryGetValue);
 
@@ -1007,6 +1008,67 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ret);
 
         // return null
+        il.MarkLabel(returnNullLabel);
+        il.Emit(OpCodes.Ldnull);
+        il.Emit(OpCodes.Ret);
+    }
+
+    /// <summary>
+    /// Emits: public static $CompiledPropertyDescriptor? GetStaticShadow(object typeObj, string propertyKey)
+    /// Walks the constructor Type chain (typeObj and each <c>BaseType</c>) probing each class's PDS
+    /// store, returning the nearest own-shadow descriptor or null. A subclass static-field write
+    /// (<c>Sub.field = v</c>) stores a per-subclass shadow keyed by the subclass Type (the SetProperty
+    /// System.Type arm); inherited static-field reads consult this before falling back to the declaring
+    /// base's field so JS own-shadow semantics hold in compiled mode (issue #339). Mirrors the inline
+    /// ancestor walk already used by the dynamic type-property reader (#265).
+    /// </summary>
+    private void EmitPDSGetStaticShadow(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    {
+        var method = typeBuilder.DefineMethod(
+            "GetStaticShadow",
+            MethodAttributes.Public | MethodAttributes.Static,
+            runtime.CompiledPropertyDescriptorType,
+            [_types.Object, _types.String]
+        );
+        runtime.PDSGetStaticShadow = method;
+
+        var il = method.GetILGenerator();
+        var walkTypeLocal = il.DeclareLocal(_types.Type);
+        var descLocal = il.DeclareLocal(runtime.CompiledPropertyDescriptorType);
+
+        // Type walkType = typeObj as Type;  (null when the receiver isn't a constructor → return null)
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Isinst, _types.Type);
+        il.Emit(OpCodes.Stloc, walkTypeLocal);
+
+        var loopLabel = il.DefineLabel();
+        var returnNullLabel = il.DefineLabel();
+        il.MarkLabel(loopLabel);
+
+        // if (walkType == null) return null;
+        il.Emit(OpCodes.Ldloc, walkTypeLocal);
+        il.Emit(OpCodes.Brfalse, returnNullLabel);
+
+        // desc = GetPropertyDescriptor(walkType, propertyKey);
+        il.Emit(OpCodes.Ldloc, walkTypeLocal);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Call, runtime.PDSGetPropertyDescriptor);
+        il.Emit(OpCodes.Stloc, descLocal);
+
+        // if (desc != null) return desc;
+        il.Emit(OpCodes.Ldloc, descLocal);
+        var nextLabel = il.DefineLabel();
+        il.Emit(OpCodes.Brfalse, nextLabel);
+        il.Emit(OpCodes.Ldloc, descLocal);
+        il.Emit(OpCodes.Ret);
+
+        // walkType = walkType.BaseType; continue;
+        il.MarkLabel(nextLabel);
+        il.Emit(OpCodes.Ldloc, walkTypeLocal);
+        il.Emit(OpCodes.Callvirt, _types.GetProperty(_types.Type, "BaseType").GetGetMethod()!);
+        il.Emit(OpCodes.Stloc, walkTypeLocal);
+        il.Emit(OpCodes.Br, loopLabel);
+
         il.MarkLabel(returnNullLabel);
         il.Emit(OpCodes.Ldnull);
         il.Emit(OpCodes.Ret);

--- a/SharpTS.Tests/SharedTests/StaticMembersTests.cs
+++ b/SharpTS.Tests/SharedTests/StaticMembersTests.cs
@@ -398,8 +398,6 @@ public class StaticMembersTests
     public void InheritedStatic_FieldWriteDoesNotCorruptBase(ExecutionMode mode)
     {
         // A static-field write through the subclass must not mutate the base's storage.
-        // (Creating the JS own-shadow on the subclass is a separate gap in compiled mode; here we
-        // pin the invariant that the base value is preserved in both modes.)
         var source = """
             class Base {
                 static n: number = 1;
@@ -410,6 +408,144 @@ public class StaticMembersTests
             """;
 
         Assert.Equal("1\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void InheritedStatic_FieldWriteCreatesOwnShadow(ExecutionMode mode)
+    {
+        // Writing an inherited static field through a subclass creates a per-subclass own shadow:
+        // the subclass reads the new value while the base keeps its own (#339).
+        var source = """
+            class Base { static n: number = 1; }
+            class Sub extends Base {}
+            Sub.n = 42;
+            console.log(Base.n);
+            console.log(Sub.n);
+            """;
+
+        Assert.Equal("1\n42\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void InheritedStatic_ShadowReadBeforeWriteSeesBase(ExecutionMode mode)
+    {
+        // Before a subclass write, an inherited-field read resolves the live base value; after the
+        // write it resolves the subclass's own shadow, leaving the base untouched (#339).
+        var source = """
+            class Base { static n: number = 1; }
+            class Sub extends Base {}
+            console.log(Sub.n);
+            Base.n = 7;
+            console.log(Sub.n);
+            Sub.n = 42;
+            console.log(Sub.n);
+            Base.n = 9;
+            console.log(Sub.n);
+            console.log(Base.n);
+            """;
+
+        Assert.Equal("1\n7\n42\n42\n9\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void InheritedStatic_ShadowNearestAncestorWins(ExecutionMode mode)
+    {
+        // A shadow on an intermediate ancestor is visible to a deeper subclass until that subclass
+        // installs its own shadow (proto-chain order), without disturbing the base field (#339).
+        var source = """
+            class A { static tag: string = "a"; }
+            class B extends A {}
+            class C extends B {}
+            B.tag = "b";
+            console.log(C.tag);
+            C.tag = "c";
+            console.log(C.tag);
+            console.log(B.tag);
+            console.log(A.tag);
+            """;
+
+        Assert.Equal("b\nc\nb\na\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void InheritedStatic_ShadowSiblingsAreIsolated(ExecutionMode mode)
+    {
+        // Each subclass owns its shadow; a write through one sibling is invisible to the other and
+        // to the base (#339).
+        var source = """
+            class P { static v: number = 0; }
+            class X extends P {}
+            class Y extends P {}
+            X.v = 1;
+            console.log(X.v);
+            console.log(Y.v);
+            console.log(P.v);
+            """;
+
+        Assert.Equal("1\n0\n0\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void InheritedStatic_ShadowFromGenericBase(ExecutionMode mode)
+    {
+        // Writing an inherited static declared on a generic base creates the subclass shadow without
+        // touching the (type-erased) base storage (#339).
+        var source = """
+            class Box<T> { static kind: string = "box"; }
+            class IntBox extends Box<number> {}
+            IntBox.kind = "intbox";
+            console.log(IntBox.kind);
+            console.log(Box.kind);
+            """;
+
+        Assert.Equal("intbox\nbox\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void StaticField_OwnCompoundAndIncrementViaClassName(ExecutionMode mode)
+    {
+        // Read-modify-write of an own static field accessed as `Class.field` must land on the field
+        // that `Class.field` reads back (compound and ++/--), not a divergent dynamic store.
+        var source = """
+            class Counter { static count: number = 10; }
+            Counter.count += 3;
+            console.log(Counter.count);
+            Counter.count++;
+            console.log(Counter.count);
+            console.log(Counter.count++);
+            console.log(Counter.count);
+            console.log(--Counter.count);
+            """;
+
+        Assert.Equal("13\n14\n14\n15\n14\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void InheritedStatic_CompoundAndIncrementCreateShadow(ExecutionMode mode)
+    {
+        // Read-modify-write through a subclass reads the inherited value, then writes the result to
+        // the subclass's own shadow, leaving the base untouched (#339).
+        var source = """
+            class P { static c: number = 100; }
+            class S extends P {}
+            S.c += 5;
+            console.log(S.c);
+            console.log(P.c);
+            S.c++;
+            console.log(S.c);
+            console.log(P.c);
+            console.log(S.c++);
+            console.log(S.c);
+            """;
+
+        Assert.Equal("105\n100\n106\n100\n106\n107\n", TestHarness.Run(source, mode));
     }
 
     #endregion


### PR DESCRIPTION
## Summary

Fixes #339. In compiled mode, writing a static **data field** through a subclass (`Sub.field = v`, where `field` is an inherited static declared on a base) failed to surface the per-subclass own shadow on a subsequent read: `Sub.field` kept resolving the inherited base value.

The write was already correct — `SetProperty`'s `System.Type` arm stores a per-subclass shadow in `$PropertyDescriptorStore` keyed by the subclass Type, and base storage was never corrupted. The bug was purely on the **read** side: the static-typed read emitted `Ldsfld` against the declaring base field and never consulted the shadow.

```ts
class Base { static n: number = 1; }
class Sub extends Base {}
Sub.n = 42;
console.log(Base.n);  // 1   (both modes — base intact)
console.log(Sub.n);   // was: interp 42 / compiled 1  →  now: 42 / 42
```

## What changed

**Read side.** Inherited static-field reads now route through a shared `EmitStaticFieldLoadWithShadow` helper, which probes a new emitted runtime helper `$PropertyDescriptorStore.GetStaticShadow` (walks the subclass Type chain so a nearer-ancestor shadow wins) before falling back to the declaring base's `Ldsfld`. **Own-field reads stay a single `Ldsfld`** — the shadow probe is emitted only on the inherited path. Wired at every static-field read site: the main `Class.field` path, imported-class aliases, the external/`this`-static path, and the async state-machine path.

**Read-modify-write.** `Class.field op= x` and `Class.field++`/`--` for known classes now bind to the field (own) or the shadow (inherited) so the increment lands on the same storage the read consults — for compound and for prefix/postfix increment. This also fixes a **pre-existing bug**: member-access RMW on an *own* static field (`Counter.count++`, `Counter.count += 3`) previously wrote the dynamic PDS store while the static read used `Ldsfld`, so the update was invisible.

## Semantics verified against the interpreter (the oracle)

Multi-level chain (nearest-ancestor shadow wins), sibling isolation, read-before-write (sees live base), generic base, own + inherited compound/`++`/`--`, and the async path — all match interp in compiled mode and pass `--verify`.

## Tests

Added 8 theories to `StaticMembersTests` (both modes): own-shadow read, read-before-write, nearest-ancestor-wins, sibling isolation, generic base, own RMW via `Class.field`, and inherited RMW shadow creation. Updated the stale comment on `InheritedStatic_FieldWriteDoesNotCorruptBase`. Full suite green: **11078 passed, 0 failed**.

## Standalone-DLL constraint

`GetStaticShadow` is emitted into the standalone `$PropertyDescriptorStore`; all read/write sites use emitted-runtime + BCL tokens only — no `SharpTS.dll` reference introduced. Compiled outputs remain fully standalone (confirmed: repro DLL runs with no co-located `SharpTS.dll`).

## Follow-ups filed (pre-existing, out of scope)

- #357 — member-access increment (`obj.prop++`) emits `StackUnderflow` IL inside async/generator bodies (general, not static-specific).
- #358 — compiled dynamic read of an inherited *declared* static through a class-as-value (`(Sub as any).field`) returns `undefined` before any shadow exists.