### PR TITLE
fix(compile): exclude primitives/undefined from `instanceof Object` (#342)

### DIFF
--- a/Compilation/RuntimeEmitter.CoreUtilities.cs
+++ b/Compilation/RuntimeEmitter.CoreUtilities.cs
@@ -3674,6 +3674,36 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Castclass, _types.Type);
         il.Emit(OpCodes.Stloc, classTypeLocal);
 
+        // `x instanceof Object` — the bare `Object` identifier resolves to the
+        // System.Object Type token (see RuntimeEmitter.GlobalThis.cs), so apply
+        // JS Object semantics rather than the IsAssignableFrom fallback below:
+        // every .NET type is assignable to System.Object, so that fallback would
+        // wrongly say true for boxed primitives (double/bool/string), BigInteger,
+        // $TSSymbol, and the undefined sentinel. Per ECMA-262 OrdinaryHasInstance
+        // a primitive O short-circuits to false — so a guest value is an Object
+        // iff it is non-primitive (mirrors interp's IsJsObject, #342). Boxed
+        // primitive wrappers (`new Number(5)`) are $Object instances, not boxed
+        // doubles, so they correctly fall through to true.
+        var notObjectClassLabel = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, classTypeLocal);
+        il.Emit(OpCodes.Ldtoken, _types.Object);
+        il.Emit(OpCodes.Call, _types.GetMethod(_types.Type, "GetTypeFromHandle", _types.RuntimeTypeHandle));
+        il.Emit(OpCodes.Bne_Un, notObjectClassLabel);
+        void PrimitiveToFalse(Type primType)
+        {
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Isinst, primType);
+            il.Emit(OpCodes.Brtrue, falseLabel);
+        }
+        PrimitiveToFalse(_types.Boolean);
+        PrimitiveToFalse(_types.Double);
+        PrimitiveToFalse(_types.String);
+        PrimitiveToFalse(_types.BigInteger);
+        PrimitiveToFalse(runtime.TSSymbolType);
+        PrimitiveToFalse(runtime.UndefinedType);
+        il.Emit(OpCodes.Br, trueLabel);
+        il.MarkLabel(notObjectClassLabel);
+
         void CheckBoxed(Type primType, string typeTag)
         {
             var skip = il.DefineLabel();

--- a/SharpTS.Tests/SharedTests/BareBuiltInClassRefTests.cs
+++ b/SharpTS.Tests/SharedTests/BareBuiltInClassRefTests.cs
@@ -216,4 +216,44 @@ public class BareBuiltInClassRefTests
         var output = TestHarness.Run(source, mode);
         Assert.Equal("true\ntrue\ntrue\ntrue\n", output);
     }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Primitives_InstanceOf_Object_AreFalse(ExecutionMode mode)
+    {
+        // Per ECMA-262 OrdinaryHasInstance, a primitive (or undefined) operand
+        // short-circuits to false — only non-primitive objects satisfy
+        // `instanceof Object`. Compiled mode previously matched System.Object
+        // via IsAssignableFrom, which is true for every boxed primitive and the
+        // undefined sentinel (#342); interp already excluded them (#334).
+        var source = """
+            console.log((5) instanceof Object);
+            console.log("s" instanceof Object);
+            console.log(true instanceof Object);
+            console.log(null instanceof Object);
+            console.log(undefined instanceof Object);
+            console.log(Symbol("x") instanceof Object);
+            """;
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("false\nfalse\nfalse\nfalse\nfalse\nfalse\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Objects_InstanceOf_Object_AreTrue(ExecutionMode mode)
+    {
+        // Every non-primitive guest value — object/array literals, functions,
+        // and built-in instances — is an Object (#342). (Boxed-primitive
+        // wrappers like `new Number(5)` are also objects, but interp currently
+        // produces a bare primitive for those — see #360 — so they're excluded
+        // from this cross-mode test.)
+        var source = """
+            console.log(({}) instanceof Object);
+            console.log(([]) instanceof Object);
+            console.log((() => 1) instanceof Object);
+            console.log(new Map() instanceof Object);
+            """;
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("true\ntrue\ntrue\ntrue\n", output);
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #342. In **compiled** mode, `instanceof Object` was over-broad — primitives and `undefined` wrongly satisfied it:

| expression | before | after / Node |
|---|---|---|
| `5 instanceof Object` | **true** | false |
| `"s" instanceof Object` | **true** | false |
| `true instanceof Object` | **true** | false |
| `null instanceof Object` | false | false |
| `undefined instanceof Object` | **true** | false |
| `{}` / `[]` / `() => …` / `new Map()` `instanceof Object` | true | true |

## Root cause

The bare `Object` identifier lowers to the `System.Object` Type token (`RuntimeEmitter.GlobalThis.cs`). The emitted `InstanceOf` helper ends in `classType.IsAssignableFrom(instance.GetType())`, and **every** .NET type is assignable to `System.Object` — so boxed primitives (`double`/`bool`/`string`), `BigInteger`, `$TSSymbol`, and the `undefined` sentinel all matched.

## Fix

Add a JS-Object branch to the emitted `InstanceOf`: when `classType == typeof(System.Object)`, apply ECMA-262 OrdinaryHasInstance semantics — a primitive operand short-circuits to `false`, so return true only for non-primitive instances. This mirrors the interpreter's `IsJsObject` predicate added in #334/PR #341. Boxed-primitive wrappers (`new Number(5)`) are `$Object` instances, not boxed doubles, so they correctly remain `true`.

The branch is placed inside the existing `classType is Type` arm, before the boxed/Task/generic checks, and reuses local Isinst checks against the primitive types — no new runtime helper, no SharpTS.dll dependency, no allocation.

## Testing

- `--verify` IL verification passes.
- Adds cross-mode regression tests `Primitives_InstanceOf_Object_AreFalse` and `Objects_InstanceOf_Object_AreTrue`.
- Full suite green (11099 passed).

## Out-of-scope gaps found (filed separately)

- **#360** — interp `new Number/String/Boolean` return bare primitives instead of wrapper objects (so wrapper-object `instanceof Object` diverges from compiled/Node; excluded from the cross-mode test).
- **#361** — compiled `bigint instanceof X` rejected at compile time (`Unsupported bigint operator: INSTANCEOF`), so `10n instanceof Object` couldn't be added to the test.