### PR TITLE
fix(check): report TS2403 for annotation-only duplicate var declarations (#336)

### DIFF
--- a/Parsing/AST.cs
+++ b/Parsing/AST.cs
@@ -110,7 +110,18 @@ public abstract record Expr
     /// <param name="IsVarRedeclaration">True when this assignment was synthesized by
     /// <see cref="VarHoister"/> from a duplicate <c>var</c> declaration — an incompatible value
     /// then reports TS2403 (subsequent declarations must have the same type), not TS2322.</param>
-    public record Assign(Token Name, Expr Value, bool IsVarRedeclaration = false) : Expr;
+    /// <param name="RedeclarationTypeAnnotation">Set (with <see cref="RedeclarationTypeAnnotationNode"/>)
+    /// when <see cref="VarHoister"/> synthesizes a self-assignment (<c>z = z</c>) for an
+    /// annotation-only duplicate <c>var</c> (<c>var z: T;</c> with no initializer). The type checker
+    /// compares THIS annotation — not the value's type — against the established declared type using
+    /// structural identity for TS2403. The self-assignment is a runtime no-op that preserves the
+    /// existing binding's value.</param>
+    public record Assign(
+        Token Name,
+        Expr Value,
+        bool IsVarRedeclaration = false,
+        string? RedeclarationTypeAnnotation = null,
+        TypeNode? RedeclarationTypeAnnotationNode = null) : Expr;
     public record Call(Expr Callee, Token Paren, List<string>? TypeArgs, List<Expr> Arguments, bool Optional = false) : Expr;
     public record Get(Expr Object, Token Name, bool Optional = false) : Expr;
     public record Set(Expr Object, Token Name, Expr Value) : Expr;

--- a/Parsing/VarHoister.cs
+++ b/Parsing/VarHoister.cs
@@ -99,7 +99,7 @@ public static class VarHoister
                     changed = true;
                     if (v.Initializer == null)
                     {
-                        return new Stmt.Expression(new Expr.Literal(null));
+                        return RewriteAnnotationOnlyDuplicate(v);
                     }
                     return new Stmt.Expression(new Expr.Assign(v.Name, v.Initializer, IsVarRedeclaration: true));
                 }
@@ -112,7 +112,7 @@ public static class VarHoister
                 if (v.Initializer == null)
                 {
                     // `var x;` → no-op (the synthetic declaration handles binding creation)
-                    return new Stmt.Expression(new Expr.Literal(null));
+                    return RewriteAnnotationOnlyDuplicate(v);
                 }
                 // `var x = expr` → `x = expr;`
                 return new Stmt.Expression(new Expr.Assign(v.Name, v.Initializer, IsVarRedeclaration: true));
@@ -288,6 +288,27 @@ public static class VarHoister
             default:
                 return stmt;
         }
+    }
+
+    /// <summary>
+    /// Rewrites a duplicate annotation-only <c>var</c> (<c>var x: T;</c> with no initializer) whose
+    /// binding already exists. Without a type annotation there is nothing to verify, so it collapses
+    /// to a no-op. With an annotation, it becomes a synthesized self-assignment <c>x = x</c> carrying
+    /// the annotation: a runtime no-op that preserves the existing value, but a checkable node the
+    /// type checker uses to report TS2403 when the annotation differs from the established type.
+    /// </summary>
+    private static Stmt RewriteAnnotationOnlyDuplicate(Stmt.Var v)
+    {
+        if (v.TypeAnnotation == null && v.TypeAnnotationNode == null)
+        {
+            return new Stmt.Expression(new Expr.Literal(null));
+        }
+        return new Stmt.Expression(new Expr.Assign(
+            v.Name,
+            new Expr.Variable(v.Name),
+            IsVarRedeclaration: true,
+            RedeclarationTypeAnnotation: v.TypeAnnotation,
+            RedeclarationTypeAnnotationNode: v.TypeAnnotationNode));
     }
 
     /// <summary>

--- a/SharpTS.Tests/IntegrationTests/CliVarTests.cs
+++ b/SharpTS.Tests/IntegrationTests/CliVarTests.cs
@@ -417,6 +417,44 @@ public class CliVarTests
     }
 
     [Fact]
+    public void Interpreted_VarRedeclarationAnnotationOnly_PreservesValue()
+    {
+        // Issue #336: an annotation-only duplicate of a matching type compiles to a self-assign
+        // (`z = z`) — a runtime no-op that must NOT reset the existing binding to undefined.
+        using var tempDir = CliTestHelper.CreateTempDirectory();
+        var script = tempDir.CreateFile("redecl-anno.ts", """
+            var y: string = "hello";
+            console.log(y);
+            var y: string;
+            console.log(y);
+            """);
+
+        var result = CliTestHelper.RunCli($"\"{script}\"", tempDir.Path);
+        Assert.Equal(0, result.ExitCode);
+        var lines = result.StandardOutput.Trim().Split('\n', StringSplitOptions.RemoveEmptyEntries);
+        Assert.Equal("hello", lines[0].Trim());
+        Assert.Equal("hello", lines[1].Trim());
+    }
+
+    [Fact]
+    public void Compiled_VarRedeclarationAnnotationOnly_PreservesValue()
+    {
+        using var tempDir = CliTestHelper.CreateTempDirectory();
+        var entry = tempDir.CreateFile("redecl-anno.ts", """
+            var y: string = "hello";
+            console.log(y);
+            var y: string;
+            console.log(y);
+            """);
+
+        var (exit, output) = CompileAndRun(tempDir, entry);
+        Assert.Equal(0, exit);
+        var lines = output.Trim().Split('\n', StringSplitOptions.RemoveEmptyEntries);
+        Assert.Equal("hello", lines[0].Trim());
+        Assert.Equal("hello", lines[1].Trim());
+    }
+
+    [Fact]
     public void Interpreted_VarRedeclarationMixedTopAndNested()
     {
         using var tempDir = CliTestHelper.CreateTempDirectory();

--- a/SharpTS.Tests/TypeCheckerTests/Round3ConformanceTests.cs
+++ b/SharpTS.Tests/TypeCheckerTests/Round3ConformanceTests.cs
@@ -90,6 +90,58 @@ public class Round3ConformanceTests
     }
 
     [Fact]
+    public void VarRedeclaration_AnnotationOnly_DifferentType_IsTs2403Error()
+    {
+        // Issue #336: an annotation-only duplicate (`var z: T;` with no initializer) was dropped
+        // by VarHoister to a bare no-op, losing the annotation, so TS2403 never fired.
+        var source = """
+            function h() {
+                var z: string;
+                var z: number;
+            }
+            """;
+        var ex = Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+        Assert.Equal("TS2403", ex.Diagnostic.TsCode);
+    }
+
+    [Fact]
+    public void VarRedeclaration_AnnotationOnly_SameType_IsAccepted()
+    {
+        var source = """
+            function h() {
+                var z: string;
+                var z: string;
+            }
+            """;
+        TestHarness.RunInterpreted(source);
+    }
+
+    [Fact]
+    public void VarRedeclaration_AnnotationOnly_AtTopLevel_IsTs2403Error()
+    {
+        var source = """
+            var z: string;
+            var z: number;
+            """;
+        var ex = Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+        Assert.Equal("TS2403", ex.Diagnostic.TsCode);
+    }
+
+    [Fact]
+    public void VarRedeclaration_AnnotationOnly_AfterInitializer_IsTs2403Error()
+    {
+        // First declaration carries the type via inference; annotation-only duplicate still checks.
+        var source = """
+            function h() {
+                var z = "hi";
+                var z: number;
+            }
+            """;
+        var ex = Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+        Assert.Equal("TS2403", ex.Diagnostic.TsCode);
+    }
+
+    [Fact]
     public void VarShadowing_InNestedFunction_IsNotRedeclaration()
     {
         var source = """

--- a/TypeSystem/TypeChecker.Expressions.cs
+++ b/TypeSystem/TypeChecker.Expressions.cs
@@ -1314,6 +1314,26 @@ public partial class TypeChecker
             throw new TypeCheckException($" Undefined variable '{assign.Name.Lexeme}'.", tsCode: "TS2304");
         }
 
+        // VarHoister synthesizes a self-assignment (`z = z`) carrying an explicit annotation when a
+        // later `var` re-declares an existing name with only a type annotation (no initializer).
+        // tsc's TS2403 requires subsequent declarations to have the SAME type — structural identity,
+        // not mere assignability — so compare the established declared type against the re-declared
+        // annotation with TypeInfoEqualityComparer, mirroring CheckVarRedeclaration. The synthesized
+        // value (`z`) is irrelevant to the check and is not type-checked.
+        if (assign.RedeclarationTypeAnnotation is not null || assign.RedeclarationTypeAnnotationNode is not null)
+        {
+            // `Any` covers the var-hoisting placeholder and explicit any-typed vars — neither participates.
+            if (declaredType is TypeInfo.Any) return declaredType;
+            var redeclaredType = ResolveAnnotation(assign.RedeclarationTypeAnnotation, assign.RedeclarationTypeAnnotationNode) ?? new TypeInfo.Any();
+            if (!TypeInfoEqualityComparer.Instance.Equals(declaredType, redeclaredType))
+            {
+                throw new TypeCheckException(
+                    $" Subsequent variable declarations must have the same type. Variable '{assign.Name.Lexeme}' must be of type '{declaredType}', but here has type '{redeclaredType}'.",
+                    line: assign.Name.Line, tsCode: "TS2403");
+            }
+            return declaredType;
+        }
+
         TypeInfo valueType = CheckExpr(assign.Value);
 
         if (!IsCompatible(declaredType, valueType))


### PR DESCRIPTION
Fixes #336.

## Problem

An annotation-only duplicate `var` (`var z: T;` with no initializer) produced no diagnostic where tsc reports **TS2403** ("Subsequent variable declarations must have the same type"):

```ts
function h() {
    var z: string;
    var z: number;   // tsc: TS2403. We: silent.
}
```

`VarHoister` rewrites duplicate `var`s, but for an annotation-only duplicate it returned a bare no-op (`Stmt.Expression(Expr.Literal(null))`), **dropping the type annotation**. So neither TS2403 path saw the second type: `CheckVarRedeclaration` never ran (no second `VisitVar`), and the synthesized-`Expr.Assign` path (PR #241) only fires for duplicates *with* initializers.

## Fix

`VarHoister` now rewrites an annotation-only duplicate to a synthesized self-assignment `z = z` carrying the annotation:
- **Runtime:** `z = z` is a no-op that preserves the existing binding's value (no reset to `undefined`). It rides the existing `Expr.Assign` emission in every mode (interpreter, sync/async/generator compiled), so **no per-emitter changes** were needed.
- **Type check:** `CheckAssign` compares the established declared type against the re-declared annotation with `TypeInfoEqualityComparer` (structural identity — matching `CheckVarRedeclaration`, not mere assignability), reporting TS2403 when they differ.

Untyped duplicates (`var z;`) still collapse to a no-op — nothing to verify.

Because distributivity already participates in `TypeInfo.CacheKey()`, the conformance `conditionalTypes1` f32 case (non-distributive `T1` vs distributive `T2`) now lights up — verified manually (the suite's TS submodule isn't initialized locally).

## Tests
- `Round3ConformanceTests`: annotation-only different-type (function + top-level), same-type accepted, after-initializer different-type — all assert `TS2403`.
- `CliVarTests`: interpreted + compiled value-preservation across an annotation-only redeclaration (guards the `z = z` self-assign no-op).
- Full suite: **11101 passed, 0 failed**. Compiled cases pass IL verification.

## Known gap (follow-up filed: #363)
TS2403 is still missed when the **first** declaration of a name is in a nested block — `VarHoister` hoists it to an annotation-less synthetic `var z;`, so the baseline types as `any`. This is broader than annotation-only (it also affects initializer duplicates whose first decl is nested) and pre-existing.
