### PR TITLE
feat(types): mapped-type relations + assignment narrowing (#337 items 1-3)

### DIFF
--- a/SharpTS.Tests/TypeCheckerTests/GenericMappedTypeRelationTests.cs
+++ b/SharpTS.Tests/TypeCheckerTests/GenericMappedTypeRelationTests.cs
@@ -1,0 +1,142 @@
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.TypeCheckerTests;
+
+/// <summary>
+/// Relation rules for deferred mapped / key-filter types over an open type parameter
+/// (issue #337, items 1 &amp; 2 — the conditionalTypes1 f7/f8 and DeepReadonly cluster):
+/// <list type="bullet">
+/// <item>the key-filter idiom <c>{ [K in keyof T]: T[K] extends Function ? K : never }[keyof T]</c>
+/// resolves to a deferred conditional so FunctionPropertyNames / NonFunctionPropertyNames relate
+/// structurally instead of collapsing to <c>any</c>;</item>
+/// <item><c>Pick&lt;T, K&gt;</c> over a deferred key filter relates homomorphically to <c>T</c>;</item>
+/// <item>a <c>readonly [P in K]</c> mapped type marks its members read-only and the key filter
+/// drops <c>never</c> arms (so function-typed keys disappear);</item>
+/// <item>an interface may extend <c>ReadonlyArray&lt;…&gt;</c>, yielding a read-only numeric index.</item>
+/// </list>
+/// </summary>
+public class GenericMappedTypeRelationTests
+{
+    private const string KeyFilterPreamble = """
+        type FunctionPropertyNames<T> = { [K in keyof T]: T[K] extends Function ? K : never }[keyof T];
+        type NonFunctionPropertyNames<T> = { [K in keyof T]: T[K] extends Function ? never : K }[keyof T];
+        type FunctionProperties<T> = Pick<T, FunctionPropertyNames<T>>;
+        type NonFunctionProperties<T> = Pick<T, NonFunctionPropertyNames<T>>;
+        """;
+
+    private static void ExpectOk(string body)
+    {
+        var src = KeyFilterPreamble + "\n" + body + "\nconsole.log(\"ok\");\n";
+        Assert.Equal("ok\n", TestHarness.RunInterpreted(src));
+    }
+
+    private static void ExpectError(string body)
+    {
+        var src = KeyFilterPreamble + "\n" + body + "\nconsole.log(\"ok\");\n";
+        Assert.ThrowsAny<SharpTS.TypeSystem.Exceptions.TypeCheckException>(
+            () => TestHarness.RunInterpreted(src));
+    }
+
+    // ---- f8: keyof T vs the key-filter name unions ----
+
+    [Fact]
+    public void KeyFilterNames_SubsetOfKeyof_AssignableToKeyof() =>
+        ExpectOk("function f<T>(x: keyof T, y: FunctionPropertyNames<T>) { x = y; }");
+
+    [Fact]
+    public void Keyof_NotAssignableToKeyFilterName() =>
+        ExpectError("function f<T>(x: keyof T, y: FunctionPropertyNames<T>) { y = x; }");
+
+    [Fact]
+    public void FunctionNames_NotAssignableToNonFunctionNames() =>
+        ExpectError("function f<T>(y: FunctionPropertyNames<T>, z: NonFunctionPropertyNames<T>) { y = z; }");
+
+    // ---- f7: T vs Pick over the key filter ----
+
+    [Fact]
+    public void TypeParam_AssignableToHomomorphicPick() =>
+        ExpectOk("function f<T>(x: T, y: FunctionProperties<T>) { y = x; }");
+
+    [Fact]
+    public void HomomorphicPick_NotAssignableToTypeParam() =>
+        ExpectError("function f<T>(x: T, y: FunctionProperties<T>) { x = y; }");
+
+    [Fact]
+    public void DifferentKeyFilterPicks_NotAssignable() =>
+        ExpectError("function f<T>(y: FunctionProperties<T>, z: NonFunctionProperties<T>) { y = z; }");
+
+    // ---- item 2: readonly mapped properties + function-key drop ----
+
+    [Fact]
+    public void DeepReadonlyObject_DropsFunctionProperties_AndIsReadonly()
+    {
+        // NonFunctionPropertyNames<Part> drops `updatePart`, so it is absent (TS2339); the
+        // remaining properties are readonly (TS2540 on write).
+        var src = """
+            interface Part { id: number; name: string; updatePart(n: string): void; }
+            type NonFunctionPropertyNames<T> = { [K in keyof T]: T[K] extends Function ? never : K }[keyof T];
+            type DRO<T> = { readonly [P in NonFunctionPropertyNames<T>]: T[P]; };
+            function f(p: DRO<Part>) { let n: string = p.name; p.updatePart("x"); }
+            """;
+        Assert.ThrowsAny<SharpTS.TypeSystem.Exceptions.TypeCheckException>(
+            () => TestHarness.RunInterpreted(src));
+    }
+
+    [Fact]
+    public void ReadonlyMappedProperty_RejectsAssignment()
+    {
+        var src = """
+            type NonFunctionPropertyNames<T> = { [K in keyof T]: T[K] extends Function ? never : K }[keyof T];
+            type DRO<T> = { readonly [P in NonFunctionPropertyNames<T>]: T[P]; };
+            function f(p: DRO<{ id: number }>) { p.id = 5; }
+            """;
+        Assert.ThrowsAny<SharpTS.TypeSystem.Exceptions.TypeCheckException>(
+            () => TestHarness.RunInterpreted(src));
+    }
+
+    // ---- item 2: interface extends ReadonlyArray / Array ----
+
+    [Fact]
+    public void InterfaceExtendsReadonlyArray_AcceptedAndIndexReadable()
+    {
+        var src = """
+            interface RA extends ReadonlyArray<number> {}
+            function f(r: RA) { let x: number = r[0]; }
+            console.log("ok");
+            """;
+        Assert.Equal("ok\n", TestHarness.RunInterpreted(src));
+    }
+
+    [Fact]
+    public void ReadonlyArrayIndex_RejectsWrite()
+    {
+        var src = """
+            interface RA extends ReadonlyArray<number> {}
+            function f(r: RA) { r[0] = 5; }
+            """;
+        Assert.ThrowsAny<SharpTS.TypeSystem.Exceptions.TypeCheckException>(
+            () => TestHarness.RunInterpreted(src));
+    }
+
+    [Fact]
+    public void MutableArrayIndex_AllowsWrite()
+    {
+        var src = """
+            interface MA extends Array<number> {}
+            function f(m: MA) { m[0] = 5; }
+            console.log("ok");
+            """;
+        Assert.Equal("ok\n", TestHarness.RunInterpreted(src));
+    }
+
+    [Fact]
+    public void GenericInterfaceExtendsReadonlyArray_IndexReadsElement_RejectsWrite()
+    {
+        // Exercises the instantiated-generic flatten path: RA<number> flattens to an interface
+        // whose substituted numeric index signature is `number` and read-only.
+        ExpectOk("interface RA<T> extends ReadonlyArray<T> {}\nfunction f(r: RA<number>) { let x: number = r[0]; }");
+        Assert.ThrowsAny<SharpTS.TypeSystem.Exceptions.TypeCheckException>(() => TestHarness.RunInterpreted(
+            "interface RA<T> extends ReadonlyArray<T> {}\nfunction f(r: RA<number>) { r[0] = 5; }\n"));
+    }
+}

--- a/SharpTS.Tests/TypeCheckerTests/NarrowingTests/GenericAssignmentNarrowingTests.cs
+++ b/SharpTS.Tests/TypeCheckerTests/NarrowingTests/GenericAssignmentNarrowingTests.cs
@@ -1,0 +1,85 @@
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.TypeCheckerTests.NarrowingTests;
+
+/// <summary>
+/// Narrowing of a reference whose declared type is a bare type parameter, by assignment
+/// (issue #337, item 3). tsc treats the constraint as the narrowing domain: after
+/// <c>x = y</c> where <c>x: T</c> (T constrained) and <c>y</c> is a deferred conditional
+/// like <c>NonNullable&lt;T&gt;</c>, <c>x</c> reads as that conditional's concrete base type,
+/// so a subsequent <c>let s: string = x</c> type-checks. An <em>unconstrained</em> <c>T</c>
+/// yields no base type and is left alone, and a bare-type-parameter RHS is never reduced to
+/// its constraint (which would break in-chain assignments).
+/// </summary>
+public class GenericAssignmentNarrowingTests
+{
+    [Fact]
+    public void ConstrainedTypeParam_AssignedNonNullable_NarrowsToBaseType()
+    {
+        // x: T (T extends string | undefined), y: NonNullable<T>.
+        // After `x = y`, x reads as `string`, so `let s1: string = x` must NOT error.
+        var source = """
+            function f<T extends string | undefined>(x: T, y: NonNullable<T>) {
+                x = y;
+                let s1: string = x;
+            }
+            console.log("ok");
+            """;
+
+        Assert.Equal("ok\n", TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void UnconstrainedTypeParam_AssignedNonNullable_StillErrors()
+    {
+        // f1 from conditionalTypes1.ts: T is unconstrained, so NonNullable<T> has no concrete
+        // base type. x stays `T` and `let s1: string = x` must STILL be a type error.
+        var source = """
+            function f<T>(x: T, y: NonNullable<T>) {
+                x = y;
+                let s1: string = x;
+            }
+            console.log("ok");
+            """;
+
+        Assert.ThrowsAny<SharpTS.TypeSystem.Exceptions.TypeCheckException>(
+            () => TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void ConstrainedTypeParam_AssignBackToConditional_StillErrors()
+    {
+        // f2's `y = x` line: even after `x = y` narrows x, assigning x back into the
+        // NonNullable<T> slot is unsound (x's base type `string` isn't assignable to a bare
+        // type parameter), so it must still error.
+        var source = """
+            function f<T extends string | undefined>(x: T, y: NonNullable<T>) {
+                x = y;
+                y = x;
+            }
+            console.log("ok");
+            """;
+
+        Assert.ThrowsAny<SharpTS.TypeSystem.Exceptions.TypeCheckException>(
+            () => TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void TypeParamChain_AssignedBareTypeParam_NotReducedToConstraint()
+    {
+        // Regression guard (typeParameterAssignability2/3): a bare-type-parameter RHS must not
+        // be collapsed to its constraint. After `u = t`, a later `v = u` must still type-check
+        // because u stays within the T extends U extends V chain (not flattened to Date).
+        var source = """
+            function foo<T extends U, U extends V, V extends Date>(t: T, u: U, v: V) {
+                u = t;
+                v = u;
+                v = t;
+            }
+            console.log("ok");
+            """;
+
+        Assert.Equal("ok\n", TestHarness.RunInterpreted(source));
+    }
+}

--- a/TypeSystem/TypeChecker.Compatibility.Helpers.cs
+++ b/TypeSystem/TypeChecker.Compatibility.Helpers.cs
@@ -87,6 +87,34 @@ public partial class TypeChecker
     }
 
     /// <summary>
+    /// The concrete base type an assigned value contributes when narrowing a reference whose
+    /// declared type is a bare type parameter — tsc's narrow-by-assignment over the constraint
+    /// domain. Only a deferred distributive conditional (e.g. <c>NonNullable&lt;T&gt;</c>,
+    /// <c>Extract&lt;T, …&gt;</c>) whose check parameter is constrained yields a base type: the
+    /// type it evaluates to when that parameter is instantiated with its constraint (so
+    /// <c>NonNullable&lt;T&gt;</c> with <c>T extends string | undefined</c> → <c>string</c>).
+    ///
+    /// A bare type parameter assigned value (e.g. <c>u = t</c> with <c>t: T</c>) is deliberately
+    /// NOT reduced to its constraint: collapsing it to the constraint would make a later
+    /// in-chain assignment (<c>v = u</c> with <c>V</c> the constraint) spuriously fail. Returns
+    /// null in every case where no concrete base can be derived — the caller then leaves the
+    /// reference at its declared type rather than installing a vacuous (or harmful) narrowing.
+    /// </summary>
+    private TypeInfo? AssignmentNarrowedBaseType(TypeInfo value)
+    {
+        if (value is TypeInfo.ConditionalType cond &&
+            cond.IsDistributive && cond.CheckType is TypeInfo.TypeParameter checkTp &&
+            ApparentTypeOf(checkTp) is { } checkConstraint)
+        {
+            var instantiated = EvaluateConditionalType(
+                cond, new Dictionary<string, TypeInfo> { [checkTp.Name] = checkConstraint });
+            if (instantiated is not (TypeInfo.ConditionalType or TypeInfo.Never or TypeInfo.Any or TypeInfo.Unknown))
+                return instantiated;
+        }
+        return null;
+    }
+
+    /// <summary>
     /// True when <paramref name="cls"/> (or any class in its hierarchy) carries a nominal brand,
     /// i.e. declares a private or protected member. TypeScript compares classes structurally for
     /// assignment except when the target type is so branded, in which case it requires the source

--- a/TypeSystem/TypeChecker.Compatibility.cs
+++ b/TypeSystem/TypeChecker.Compatibility.cs
@@ -165,6 +165,83 @@ public partial class TypeChecker
     }
 
     /// <summary>
+    /// Resolves a mapped type's key domain (its <c>in</c> constraint) the same way
+    /// <see cref="ExpandMappedType"/> does — evaluating <c>keyof</c> and resolving a key-filter
+    /// indexed access — but without enumerating it into fields. Used to decide whether the
+    /// domain is concrete (enumerable) or deferred.
+    /// </summary>
+    private TypeInfo ResolveMappedKeyDomain(TypeInfo.MappedType mapped)
+    {
+        TypeInfo domain = mapped.Constraint;
+        if (domain is TypeInfo.KeyOf keyOf)
+            domain = EvaluateKeyOf(keyOf.SourceType);
+        if (domain is TypeInfo.IndexedAccess indexed)
+            domain = ResolveIndexedAccess(indexed, new Dictionary<string, TypeInfo>());
+        return domain;
+    }
+
+    /// <summary>
+    /// True when a mapped type's key domain can't be enumerated to concrete keys — it stays a
+    /// deferred conditional (the key-filter idiom) or a generic <c>keyof T</c> / bare type
+    /// parameter. Concrete key sets (string literals, unions of them) are NOT deferred.
+    /// </summary>
+    private static bool IsDeferredKeyDomain(TypeInfo domain) => domain switch
+    {
+        TypeInfo.ConditionalType => true,
+        TypeInfo.KeyOf { SourceType: TypeInfo.TypeParameter } => true,
+        TypeInfo.TypeParameter => true,
+        _ => false
+    };
+
+    /// <summary>
+    /// Structural relation for a target mapped type whose key domain is DEFERRED, where ordinary
+    /// expansion would yield an empty object (so distinct key-filters compare equal and a
+    /// homomorphic projection of <c>T</c> fails against <c>T</c>). Mirrors tsc:
+    /// <list type="bullet">
+    /// <item>source is another mapped type <c>{ [P in K2]: V2 }</c>: relate iff the target's keys
+    /// are a subset of the source's (<c>K1 ⊆ K2</c>, contravariant) and the source value relates
+    /// to the target value (covariant);</item>
+    /// <item>source is the projected object itself for a homomorphic <c>{ [P in K]: X[P] }</c>:
+    /// relate iff <c>K ⊆ keyof X</c> (every filtered key is a real key of the source).</item>
+    /// </list>
+    /// Returns false (deferring to ordinary expansion) for enumerable domains or shapes it does
+    /// not recognise. See #337 item 1 (f7: FunctionProperties / NonFunctionProperties).
+    /// </summary>
+    private bool TryRelateDeferredMappedType(TypeInfo.MappedType target, TypeInfo source, out bool result)
+    {
+        result = false;
+        TypeInfo domain = ResolveMappedKeyDomain(target);
+        if (!IsDeferredKeyDomain(domain)) return false;  // enumerable — ordinary expansion handles it
+
+        if (source is TypeInfo.MappedType sourceMapped)
+        {
+            TypeInfo sourceDomain = ResolveMappedKeyDomain(sourceMapped);
+            // keys(target) ⊆ keys(source)  ⟺  the target domain is assignable to the source domain.
+            bool keysSubset = IsCompatible(sourceDomain, domain);
+            // Align the two mapped parameters, then require source value → target value.
+            var align = new Dictionary<string, TypeInfo>
+            {
+                [sourceMapped.ParameterName] = new TypeInfo.TypeParameter(target.ParameterName)
+            };
+            bool valuesRelate = IsCompatible(target.ValueType, Substitute(sourceMapped.ValueType, align));
+            result = keysSubset && valuesRelate;
+            return true;
+        }
+
+        // Homomorphic projection `{ [P in K]: X[P] }` assigned from a source equal to X: the
+        // source already has every property the projection names as long as K ⊆ keyof X.
+        if (target.ValueType is TypeInfo.IndexedAccess { ObjectType: var projected, IndexType: TypeInfo.TypeParameter indexParam } &&
+            indexParam.Name == target.ParameterName &&
+            TypeInfoEqualityComparer.Instance.Equals(projected, source))
+        {
+            result = IsCompatible(new TypeInfo.KeyOf(source), domain);
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
     /// Expands a recursive type alias placeholder to its full type.
     /// Used for lazy expansion during compatibility checks.
     /// Uses _expandedTypeAliasCache to ensure the same TypeInfo object is reused,
@@ -291,6 +368,33 @@ public partial class TypeChecker
         if (actual is TypeInfo.RecursiveTypeAlias actualRTA)
         {
             return IsCompatible(expected, ExpandRecursiveTypeAlias(actualRTA));
+        }
+
+        // A key-filter indexed access over a homomorphic mapped type with a generic key domain
+        // (`{ [K in keyof T]: F(K) }[keyof T]`, e.g. FunctionPropertyNames<T>) resolves to a
+        // deferred conditional. Surface that BEFORE the keyof/type-parameter rules below, which
+        // would otherwise reject the raw IndexedAccess outright and never reach the deferred-
+        // conditional relation logic (#337 item 1). Scoped to the conditional result so ordinary
+        // `T[K]` accesses keep their existing (later) handling.
+        if (expected is TypeInfo.IndexedAccess expectedIaPre &&
+            ResolveIndexedAccess(expectedIaPre, new Dictionary<string, TypeInfo>()) is TypeInfo.ConditionalType expectedIaCond)
+        {
+            expected = expectedIaCond;
+        }
+        if (actual is TypeInfo.IndexedAccess actualIaPre &&
+            ResolveIndexedAccess(actualIaPre, new Dictionary<string, TypeInfo>()) is TypeInfo.ConditionalType actualIaCond)
+        {
+            actual = actualIaCond;
+        }
+
+        // A target mapped type over a deferred key domain (Pick<T, FunctionPropertyNames<T>>, …)
+        // is related structurally, BEFORE the type-parameter rules below — those would otherwise
+        // reject a homomorphic projection `Pick<T, K> ← T` (source is a bare type parameter) and
+        // never reach the mapped-type logic (#337 item 1, f7).
+        if (expected is TypeInfo.MappedType earlyMapped &&
+            TryRelateDeferredMappedType(earlyMapped, actual, out var earlyMappedRelated))
+        {
+            return earlyMappedRelated;
         }
 
         // Conditional types resolve or defer before anything else decides (null rules, the
@@ -566,7 +670,8 @@ public partial class TypeChecker
             return IsCompatible(expected, expandedActual);
         }
 
-        // Mapped type compatibility - expand lazily then compare
+        // Mapped type compatibility - expand lazily then compare. (Deferred-key-domain mapped
+        // targets are related structurally earlier, before the type-parameter rules.)
         if (expected is TypeInfo.MappedType expectedMapped)
         {
             TypeInfo expandedExpected = ExpandMappedType(expectedMapped);

--- a/TypeSystem/TypeChecker.Expressions.cs
+++ b/TypeSystem/TypeChecker.Expressions.cs
@@ -1339,6 +1339,22 @@ public partial class TypeChecker
         // This ensures subsequent uses of the variable see the correct (un-narrowed) type.
         _environment.Define(assign.Name.Lexeme, declaredType);
 
+        // tsc narrows a reference whose declared type is a bare type parameter by assignment:
+        // the constraint is the narrowing domain, so after `x = y` the reference reads as the
+        // assigned value's base (apparent) type. This is what makes
+        //   function f2<T extends string | undefined>(x: T, y: NonNullable<T>) {
+        //       x = y; let s: string = x;  // ok — x reads as `string` here
+        //   }
+        // type-check, while leaving an *unconstrained* `T` (no derivable base type) at `T` so its
+        // assignments still error. Only install when a concrete narrower type can be derived.
+        if (declaredType is TypeInfo.TypeParameter &&
+            AssignmentNarrowedBaseType(valueType) is { } narrowed &&
+            narrowed is not (TypeInfo.Any or TypeInfo.Unknown) &&
+            !TypeInfoEqualityComparer.Instance.Equals(narrowed, declaredType))
+        {
+            AddNarrowing(assignedPath, narrowed);
+        }
+
         return valueType;
     }
 

--- a/TypeSystem/TypeChecker.Generics.Conditional.cs
+++ b/TypeSystem/TypeChecker.Generics.Conditional.cs
@@ -55,6 +55,17 @@ public partial class TypeChecker
             // Apply current substitutions to the check type
             TypeInfo checkType = SubstituteWithoutConditionalEval(conditional.CheckType, substitutions);
 
+            // A check type that is an indexed access over a CONCRETE object (e.g. `Part["updatePart"]`
+            // in the key-filter idiom) must be resolved to the member type before the extends-test,
+            // or the structural match against `Function` fails and the filter picks the wrong branch
+            // (#337 item 2). Generic accesses (`T[K]`) stay unresolved so the deferral below fires.
+            if (checkType is TypeInfo.IndexedAccess checkIndexed && !IsGenericTypeShape(checkIndexed))
+            {
+                var resolvedCheck = ResolveIndexedAccess(checkIndexed, substitutions);
+                if (resolvedCheck is not (TypeInfo.IndexedAccess or TypeInfo.Any))
+                    checkType = resolvedCheck;
+            }
+
             // Distribution happens only for DISTRIBUTIVE conditionals (declared with a naked
             // type-parameter check). A literal `string | number extends string ? A : B` does not
             // distribute in tsc — the union is checked as a whole.
@@ -500,7 +511,18 @@ public partial class TypeChecker
         if (extendsType is TypeInfo.Function extendsFunc)
         {
             if (checkType is TypeInfo.Function checkFunc)
-                return MatchSignatureWithInfer(checkFunc, extendsFunc, inferredTypes);
+            {
+                // Without infer placeholders to bind, `check extends F` is the ordinary
+                // assignability question — `(s: string) => void` IS a `Function` (modelled as
+                // `(...args: any[]) => any`). Strict signature unification wrongly rejects it,
+                // which broke the `T[K] extends Function` key-filter (#337 item 2). Reserve
+                // MatchSignatureWithInfer for targets that actually carry infers.
+                bool hasInfer = false;
+                CollectReferencedInferNames(extendsFunc, _ => hasInfer = true);
+                return hasInfer
+                    ? MatchSignatureWithInfer(checkFunc, extendsFunc, inferredTypes)
+                    : IsCompatible(extendsType, checkType);
+            }
             return false;
         }
 

--- a/TypeSystem/TypeChecker.Generics.MappedTypes.cs
+++ b/TypeSystem/TypeChecker.Generics.MappedTypes.cs
@@ -240,6 +240,8 @@ public partial class TypeChecker
         // Build the resulting object type
         Dictionary<string, TypeInfo> fields = [];
         HashSet<string> optionalFields = [];
+        HashSet<string> readonlyFields = [];
+        bool addsReadonly = mapped.Modifiers.HasFlag(MappedTypeModifiers.AddReadonly);
 
         foreach (var key in keys)
         {
@@ -261,15 +263,27 @@ public partial class TypeChecker
                 finalKeyName = remappedKey;
             }
 
-            // Substitute K with the current key in the value type
+            // Substitute K with the current key in the value type. The key-filter idiom
+            // `{ [K in keyof T]: T[K] extends Function ? K : never }` carries a conditional in the
+            // value position whose check is itself a `T[K]` indexed access. Substituting with eager
+            // conditional evaluation collapses it on an UNRESOLVED check (the access still reads
+            // `Part[K]`), so the extends-test against `Function` fails and every key survives. So
+            // substitute WITHOUT conditional eval, resolve the indexed accesses (including the one
+            // in the check), then evaluate — the `never` arms now drop the filtered keys (#337 item 2).
             var localSubs = new Dictionary<string, TypeInfo>(outerSubstitutions)
             {
                 [mapped.ParameterName] = key
             };
-            TypeInfo valueType = Substitute(mapped.ValueType, localSubs);
+            TypeInfo valueType = SubstituteWithoutConditionalEval(mapped.ValueType, localSubs);
 
             // Handle indexed access in value type (e.g., T[K])
             valueType = ResolveIndexedAccessTypes(valueType, localSubs);
+
+            if (valueType is TypeInfo.ConditionalType valueCond && !ContainsOpenTypeVariable(valueCond))
+            {
+                var resolvedCheck = ResolveIndexedAccessTypes(valueCond.CheckType, localSubs);
+                valueType = EvaluateConditionalType(valueCond with { CheckType = resolvedCheck });
+            }
 
             fields[finalKeyName] = valueType;
 
@@ -279,11 +293,16 @@ public partial class TypeChecker
                 optionalFields.Add(finalKeyName);
             }
             // For -?, we don't add to optionalFields (making it required)
+            if (addsReadonly)
+            {
+                readonlyFields.Add(finalKeyName);
+            }
         }
 
-        // Return as Interface to preserve optional info
-        return optionalFields.Count > 0
-            ? new TypeInfo.Interface("", fields.ToFrozenDictionary(), optionalFields.ToFrozenSet())
+        // Return as Interface to preserve optional / readonly info (a Record can carry neither).
+        return optionalFields.Count > 0 || readonlyFields.Count > 0
+            ? new TypeInfo.Interface("", fields.ToFrozenDictionary(), optionalFields.ToFrozenSet(),
+                ReadonlyMembers: readonlyFields.Count > 0 ? readonlyFields.ToFrozenSet() : null)
             : new TypeInfo.Record(fields.ToFrozenDictionary());
     }
 
@@ -381,6 +400,27 @@ public partial class TypeChecker
         {
             indexType = EvaluateKeyOf(Substitute(kof.SourceType, subs));
         }
+
+        // Indexing a homomorphic mapped type by a generic key domain that can't be enumerated
+        // to concrete keys — `{ [K in keyof T]: F(K) }[keyof T]` with T still a bare type
+        // parameter. EvaluateKeyOf leaves the index as `keyof T`, so expanding the mapped type
+        // would produce an empty object (no concrete fields) and the access would collapse to
+        // `any`, making the key-filter aliases FunctionPropertyNames<T> / NonFunctionPropertyNames<T>
+        // compare vacuously. tsc instead substitutes the mapped parameter K with the index
+        // domain into the value template, so the access resolves to the deferred
+        // `T[keyof T] extends Function ? keyof T : never`, which the deferred-conditional
+        // relation rules then compare structurally (#337 item 1). The remaining concrete cases
+        // fall through to enumeration/expansion below.
+        if (objectType is TypeInfo.MappedType genMapped &&
+            indexType is TypeInfo.KeyOf or TypeInfo.TypeParameter)
+        {
+            var valueSubs = new Dictionary<string, TypeInfo>(subs)
+            {
+                [genMapped.ParameterName] = indexType
+            };
+            return ResolveIndexedAccessTypes(Substitute(genMapped.ValueType, valueSubs), valueSubs);
+        }
+
         if (objectType is TypeInfo.MappedType objMapped && !ContainsOpenTypeVariable(objMapped))
         {
             objectType = ExpandMappedType(objMapped, subs);

--- a/TypeSystem/TypeChecker.Generics.cs
+++ b/TypeSystem/TypeChecker.Generics.cs
@@ -90,12 +90,13 @@ public partial class TypeChecker
         {
             // Array<T> is the generic spelling of T[] — without this it would fall through the
             // user-generics lookup to `any`, making every Array<T>-typed position vacuously
-            // compatible. ReadonlyArray<T> is modeled as T[] (readonlyness isn't tracked yet).
+            // compatible. ReadonlyArray<T> carries the readonly flag so an interface extending it
+            // (DeepReadonlyArray) gets a read-only numeric index signature (#337 item 2).
             if (typeArgs.Count != 1)
             {
                 throw new TypeCheckException($" {baseName} requires exactly 1 type argument, got {typeArgs.Count}.", tsCode: "TS2314");
             }
-            result = new TypeInfo.Array(typeArgs[0]);
+            result = new TypeInfo.Array(typeArgs[0], IsReadonly: baseName == "ReadonlyArray");
         }
         else if (baseName == "Promise")
         {
@@ -330,7 +331,13 @@ public partial class TypeChecker
                     {
                         result = EvaluateConditionalType(condResult);
                     }
-                    if (result is TypeInfo.MappedType mappedResult && !ContainsOpenTypeVariable(mappedResult))
+                    // A mapped type over a DEFERRED key domain (a generic key-filter such as
+                    // Pick<T, FunctionPropertyNames<T>>) must stay a MappedType node: enumerating
+                    // it now would yield an empty object and lose the key filter, so it has to
+                    // reach the relation rules deferred (#337 item 1, mirrors the conditional case
+                    // just above). Concrete domains still expand eagerly for downstream consumers.
+                    if (result is TypeInfo.MappedType mappedResult && !ContainsOpenTypeVariable(mappedResult)
+                        && !IsDeferredKeyDomain(ResolveMappedKeyDomain(mappedResult)))
                     {
                         result = ExpandMappedType(mappedResult);
                     }

--- a/TypeSystem/TypeChecker.Properties.Index.cs
+++ b/TypeSystem/TypeChecker.Properties.Index.cs
@@ -40,6 +40,15 @@ public partial class TypeChecker
             return new TypeInfo.Any();
         }
 
+        // A non-recursive instantiated generic interface flattens so its numeric index signature
+        // (substituted) is reachable. Recursive aliases (DeepReadonly<Part[]>) are intentionally
+        // NOT force-expanded here — that re-enters the self-referential mapped/conditional chain
+        // and trips the instantiation-depth guard; resolving them lazily is tracked as follow-up.
+        if (objType is TypeInfo.InstantiatedGeneric igObj && !ContainsOpenTypeVariable(igObj)
+            && FlattenInstantiatedInterface(igObj) is { } flatObj
+            && flatObj.NumberIndexType is not (null or TypeInfo.RecursiveTypeAlias))
+            objType = flatObj;
+
         // A deferred conditional is indexed through its constraint — `x[0]` where
         // `x: T extends (infer U)[] ? U[] : never` reads through `unknown[]`
         // (conditionalTypes1 f22/f23). Evaluate first: a concrete check resolves to a branch.
@@ -377,6 +386,23 @@ public partial class TypeChecker
         if (objType is TypeInfo.Any)
         {
             return valueType;
+        }
+
+        // Flatten a non-recursive instantiated generic interface so its (substituted) numeric
+        // index signature — including its read-only flag — drives the checks below. Recursive
+        // aliases are left deferred (see the matching note in CheckGetIndex).
+        if (objType is TypeInfo.InstantiatedGeneric igSet && !ContainsOpenTypeVariable(igSet)
+            && FlattenInstantiatedInterface(igSet) is { } flatSet
+            && flatSet.NumberIndexType is not (null or TypeInfo.RecursiveTypeAlias))
+            objType = flatSet;
+
+        // Writing through a read-only numeric index signature (an interface that extends
+        // ReadonlyArray<…>) is rejected — #337 item 2 (TS2542).
+        if ((IsNumber(indexType) || indexType is TypeInfo.NumberLiteral) &&
+            objType is TypeInfo.Interface { ReadonlyNumberIndex: true })
+        {
+            throw new TypeCheckException(
+                $" Index signature in type '{objType}' only permits reading.", tsCode: "TS2542");
         }
 
         // Handle Union types - verify assignment is valid for all union members

--- a/TypeSystem/TypeChecker.Properties.cs
+++ b/TypeSystem/TypeChecker.Properties.cs
@@ -579,6 +579,12 @@ public partial class TypeChecker
             {
                 if (member.Key == set.Name.Lexeme)
                 {
+                    // readonly members (incl. those produced by a `readonly [P in K]` mapped type,
+                    // e.g. DeepReadonlyObject<T>) reject assignment — #337 item 2.
+                    if (itf.IsMemberReadonly(set.Name.Lexeme))
+                    {
+                        throw new TypeCheckException($" Cannot assign to '{set.Name.Lexeme}' because it is a read-only property.", tsCode: "TS2540");
+                    }
                     TypeInfo valueType = CheckExpr(set.Value);
                     if (!IsCompatible(member.Value, valueType))
                     {

--- a/TypeSystem/TypeChecker.Statements.Interfaces.cs
+++ b/TypeSystem/TypeChecker.Statements.Interfaces.cs
@@ -222,6 +222,7 @@ public partial class TypeChecker
         TypeInfo? stringIndexType = null;
         TypeInfo? numberIndexType = null;
         TypeInfo? symbolIndexType = null;
+        bool readonlyNumberIndex = false;
 
         using (new EnvironmentScope(this, interfaceTypeEnv))
         {
@@ -351,6 +352,16 @@ public partial class TypeChecker
                     // position resolves to its Instance type, so unwrap that first.)
                     extendsList.Add(ClassAsInterfaceBase(extendClass));
                 }
+                else if (extendType is TypeInfo.Array extendArray)
+                {
+                    // `interface I<T> extends ReadonlyArray<E>` (or Array<E>): model the array base
+                    // as a numeric index signature of its element type, read-only for ReadonlyArray.
+                    // This is what lets DeepReadonlyArray index-access resolve and reject writes
+                    // (#337 item 2). The element type carries the interface's own type parameters
+                    // and is substituted at instantiation by FlattenInstantiatedInterface.
+                    numberIndexType = extendArray.ElementType;
+                    if (extendArray.IsReadonly) readonlyNumberIndex = true;
+                }
                 else
                 {
                     throw new TypeCheckException($" Interface '{interfaceStmt.Name.Lexeme}' can only extend other interfaces, but '{extendTypeName}' is not an interface.", tsCode: "TS2312");
@@ -418,7 +429,8 @@ public partial class TypeChecker
                 callSignatures,
                 constructorSignatures,
                 readonlyMembers.Count > 0 ? readonlyMembers.ToFrozenSet() : null,
-                methodMembers.Count > 0 ? methodMembers.ToFrozenSet() : null
+                methodMembers.Count > 0 ? methodMembers.ToFrozenSet() : null,
+                readonlyNumberIndex
             );
             _environment.Define(interfaceStmt.Name.Lexeme, genericItfType);
         }
@@ -435,7 +447,8 @@ public partial class TypeChecker
                 callSignatures,
                 constructorSignatures,
                 readonlyMembers.Count > 0 ? readonlyMembers.ToFrozenSet() : null,
-                methodMembers.Count > 0 ? methodMembers.ToFrozenSet() : null
+                methodMembers.Count > 0 ? methodMembers.ToFrozenSet() : null,
+                ReadonlyNumberIndex: readonlyNumberIndex
             );
             _environment.Define(interfaceStmt.Name.Lexeme, itfType);
         }
@@ -563,7 +576,8 @@ public partial class TypeChecker
             gi.CallSignatures,
             gi.ConstructorSignatures,
             gi.ReadonlyMembers,
-            gi.MethodMembers);
+            gi.MethodMembers,
+            ReadonlyNumberIndex: gi.ReadonlyNumberIndex);
     }
 
     /// <summary>

--- a/TypeSystem/TypeInfo.cs
+++ b/TypeSystem/TypeInfo.cs
@@ -450,7 +450,8 @@ public abstract record TypeInfo
         List<ConstructorSignature>? ConstructorSignatures = null,
         FrozenSet<string>? ReadonlyMembers = null,
         FrozenSet<string>? MethodMembers = null,
-        FrozenDictionary<string, MemberAccessBrand>? MemberBrands = null
+        FrozenDictionary<string, MemberAccessBrand>? MemberBrands = null,
+        bool ReadonlyNumberIndex = false
     ) : TypeInfo
     {
         /// <summary>True when the member (own or inherited) was declared with method syntax —
@@ -1355,7 +1356,8 @@ public abstract record TypeInfo
         List<CallSignature>? CallSignatures = null,
         List<ConstructorSignature>? ConstructorSignatures = null,
         FrozenSet<string>? ReadonlyMembers = null,
-        FrozenSet<string>? MethodMembers = null
+        FrozenSet<string>? MethodMembers = null,
+        bool ReadonlyNumberIndex = false
     ) : TypeInfo
     {
         public bool HasIndexSignature => StringIndexType != null || NumberIndexType != null || SymbolIndexType != null;


### PR DESCRIPTION
## Summary

Implements the `conditionalTypes1.ts` mapped-types round from #337 — items 1, 2 (non-recursive), and 3. The polarity issues in f7/f8 turned out not to be relation-rule bugs but the key-filter aliases being destroyed before reaching the relation.

### Item 1 — f7/f8 mapped-type relations (complete)
- `ResolveIndexedAccess`: indexing a homomorphic mapped type by a generic key domain (`{ [K in keyof T]: F(K) }[keyof T]`, open `T`) now resolves **structurally** to the deferred `T[keyof T] extends Function ? keyof T : never`, instead of expanding to an empty object and collapsing to `any`. (The old open-`T` guard relied on `_openTypeVariablesInScope`, which is empty during relations.)
- `IsCompatibleCore` surfaces those key-filter indexed accesses to the deferred-conditional rules **before** the keyof/type-parameter rules that used to reject the raw `IndexedAccess`.
- `Pick<T, deferredKeyFilter>` stays a `MappedType` (not eagerly expanded to `{}`) and relates via new `TryRelateDeferredMappedType`: two key-filter Picks compare by `keys(target) ⊆ keys(source)` + value covariance; a homomorphic `Pick<T, K> ← T` is accepted when `K ⊆ keyof T`.

### Item 2 — DeepReadonly (non-recursive parts complete)
- `ExpandMappedType` evaluates the key-filter value conditional with a **resolved** `T[K]` check (substitute without eager conditional-eval → resolve the indexed access → evaluate), so function-typed keys drop → `part.updatePart(...)` = **TS2339**. Infer-free `X extends Function` now uses assignability rather than strict signature unification (a `(s: string) => void` *is* a `Function`).
- `readonly [P in K]` propagates into `Interface.ReadonlyMembers`; interface property writes reject it → `part.id = …` = **TS2540**.
- `interface … extends ReadonlyArray<E>` / `Array<E>` is accepted (no more **TS2312**) and modeled with a numeric index signature, read-only for `ReadonlyArray` (new `Interface`/`GenericInterface.ReadonlyNumberIndex`); writes through it = **TS2542**. End-to-end for non-recursive cases (incl. `RA<T>` via `FlattenInstantiatedInterface`).

### Item 3 — assignment narrowing
A reference whose declared type is a **bare type parameter** narrows by assignment to the assigned value's concrete base type (`NonNullable<T>` with `T extends string | undefined` → `string`), so `function f2<T extends string | undefined>(x: T, y: NonNullable<T>) { x = y; let s: string = x; }` type-checks. Unconstrained `T` and bare-type-parameter RHS are deliberately left untouched (the latter regressed `typeParameterAssignability2/3`).

## Remaining (filed #365)
Only the **recursive** array case in `f10` is left: `part.subparts` (`DeepReadonly<Part[]>`) must resolve to `DeepReadonlyArray<Part>` to be indexed, but forcing that re-enters the self-referential chain and trips the `TS2589` depth guard. Needs the lazy/identity-cached recursion from the #185 family. `conditionalTypes1.ts` flips to Pass once #365 + #336 (TS2403, shipped in #364) land.

## Testing
- New: `GenericMappedTypeRelationTests` (12), `GenericAssignmentNarrowingTests` (4).
- Full unit suite (11099) and TS-conformance suite green throughout; no baseline drift.

Closes part of #337 (items 1–3). Refs #365, #336.
