### PR TITLE
fix(compile): widen unsound number/boolean return slots (#344)

### DIFF
--- a/Compilation/ILCompiler.ArrowFunctions.cs
+++ b/Compilation/ILCompiler.ArrowFunctions.cs
@@ -167,8 +167,13 @@ public partial class ILCompiler
             var arrowTypeInfo = _typeMap?.Get(arrow);
             if (arrowTypeInfo is TypeSystem.TypeInfo.Function funcTypeInfo)
             {
+                // Widen a number/boolean slot to object if the checker flagged an undefined-reachable
+                // return (e.g. `(): number => undefined as any`) — the unboxed slot would coerce it (#344).
+                bool returnMayBeUndefined = arrow.ExpressionBody != null
+                    ? ReturnSlotAnalysis.ExpressionReturnMayBeUndefined(arrow.ExpressionBody, _typeMap)
+                    : ReturnSlotAnalysis.BlockReturnsMayBeUndefined(arrow.BlockBody, _typeMap);
                 var logicalReturnType = ParameterTypeResolver.ResolveReturnType(
-                    funcTypeInfo.ReturnType, isAsync: false, _typeMapper);
+                    funcTypeInfo.ReturnType, isAsync: false, _typeMapper, returnMayBeUndefined);
 
                 // Use typed return if:
                 // 1. Return type is not void (void methods need special handling)

--- a/Compilation/ILCompiler.Functions.cs
+++ b/Compilation/ILCompiler.Functions.cs
@@ -64,9 +64,12 @@ public partial class ILCompiler
         var paramTypes = ParameterTypeResolver.ResolveParameters(
             funcStmt.Parameters, _typeMapper, funcType);
 
-        // Resolve typed return type (optimization: avoid boxing for : number returns)
+        // Resolve typed return type (optimization: avoid boxing for : number returns).
+        // Widen a number/boolean slot to object if the checker flagged an undefined-reachable
+        // return (e.g. `return undefined as any`) — the unboxed slot would coerce it (#344).
+        bool returnMayBeUndefined = ReturnSlotAnalysis.BlockReturnsMayBeUndefined(funcStmt.Body, _typeMap);
         Type returnType = ParameterTypeResolver.ResolveReturnType(
-            funcType?.ReturnType, isAsync: false, _typeMapper);
+            funcType?.ReturnType, isAsync: false, _typeMapper, returnMayBeUndefined);
 
         var methodBuilder = _programType.DefineMethod(
             qualifiedFunctionName,

--- a/Compilation/ParameterTypeResolver.cs
+++ b/Compilation/ParameterTypeResolver.cs
@@ -96,11 +96,19 @@ public static class ParameterTypeResolver
     /// <param name="returnTypeInfo">Return type from TypeMap (may be null)</param>
     /// <param name="isAsync">Whether this is an async function</param>
     /// <param name="typeMapper">TypeMapper for conversion</param>
+    /// <param name="returnMayBeUndefined">
+    /// True when the type checker found a return value of static type <c>any</c>/<c>unknown</c>
+    /// flowing into this <c>number</c>/<c>boolean</c> return (e.g. <c>return undefined as any</c>).
+    /// An unboxed <c>double</c>/<c>bool</c> slot cannot carry the runtime <c>undefined</c> sentinel,
+    /// so it is widened to <c>object</c> for just those functions to avoid silently coercing
+    /// <c>undefined</c> to <c>NaN</c>/<c>false</c>. (#344)
+    /// </param>
     /// <returns>.NET type for the return value</returns>
     public static Type ResolveReturnType(
         TSTypeInfo? returnTypeInfo,
         bool isAsync,
-        TypeMapper typeMapper)
+        TypeMapper typeMapper,
+        bool returnMayBeUndefined = false)
     {
         Type baseType;
 
@@ -111,6 +119,15 @@ public static class ParameterTypeResolver
         else
         {
             baseType = typeMapper.MapTypeInfoStrict(returnTypeInfo);
+
+            // A `number`/`boolean` return reached by an `undefined`-admitting value (any/unknown)
+            // must use an object slot — the unboxed double/bool slot would coerce the runtime
+            // `undefined` sentinel to NaN/false. Only the genuinely-undefined-reachable functions
+            // pay this; the common sound numeric/boolean return keeps its unboxed slot. (#344)
+            if (returnMayBeUndefined && (baseType == typeof(double) || baseType == typeof(bool)))
+            {
+                baseType = typeof(object);
+            }
 
             // BigInteger returns need to stay as object because BigInt operations
             // in the emitter expect boxed values

--- a/Compilation/ReturnSlotAnalysis.cs
+++ b/Compilation/ReturnSlotAnalysis.cs
@@ -1,0 +1,90 @@
+using SharpTS.Parsing;
+using SharpTS.TypeSystem;
+
+namespace SharpTS.Compilation;
+
+/// <summary>
+/// Decides whether a function/arrow/method body has a return whose value can be the runtime
+/// <c>undefined</c> sentinel despite a <c>number</c>/<c>boolean</c> declared return type — the
+/// type checker flags those return-value expressions in the <see cref="TypeMap"/> (#344). The IL
+/// compiler consults this to widen the otherwise-unboxed <c>double</c>/<c>bool</c> return slot
+/// back to <c>object</c>, so a legitimate <c>undefined</c> is not coerced to <c>NaN</c>/<c>false</c>.
+/// </summary>
+internal static class ReturnSlotAnalysis
+{
+    /// <summary>
+    /// True if any <c>return</c> within <paramref name="body"/> — not crossing into a nested
+    /// function, arrow, or class — returns a value flagged undefined-reachable by the checker.
+    /// Nested functions own their own return slot and are analyzed separately, so traversal
+    /// stops at those boundaries.
+    /// </summary>
+    public static bool BlockReturnsMayBeUndefined(IReadOnlyList<Stmt>? body, TypeMap? typeMap)
+    {
+        if (body == null || typeMap == null) return false;
+        foreach (var stmt in body)
+        {
+            if (StatementHasFlaggedReturn(stmt, typeMap)) return true;
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// True if the expression-arrow body <paramref name="expr"/> was flagged undefined-reachable.
+    /// Expression-bodied arrows have no <c>Stmt.Return</c>; the body expression is the return value.
+    /// </summary>
+    public static bool ExpressionReturnMayBeUndefined(Expr? expr, TypeMap? typeMap) =>
+        expr != null && typeMap != null && typeMap.IsUndefinedReachableReturn(expr);
+
+    private static bool StatementHasFlaggedReturn(Stmt stmt, TypeMap typeMap)
+    {
+        switch (stmt)
+        {
+            case Stmt.Return ret:
+                return ret.Value != null && typeMap.IsUndefinedReachableReturn(ret.Value);
+
+            case Stmt.Block b:
+                return BlockReturnsMayBeUndefined(b.Statements, typeMap);
+
+            case Stmt.If i:
+                return StatementHasFlaggedReturn(i.ThenBranch, typeMap)
+                    || (i.ElseBranch != null && StatementHasFlaggedReturn(i.ElseBranch, typeMap));
+
+            case Stmt.While w:
+                return StatementHasFlaggedReturn(w.Body, typeMap);
+
+            case Stmt.DoWhile dw:
+                return StatementHasFlaggedReturn(dw.Body, typeMap);
+
+            case Stmt.For f:
+                return StatementHasFlaggedReturn(f.Body, typeMap);
+
+            case Stmt.ForOf fo:
+                return StatementHasFlaggedReturn(fo.Body, typeMap);
+
+            case Stmt.ForIn fi:
+                return StatementHasFlaggedReturn(fi.Body, typeMap);
+
+            case Stmt.LabeledStatement ls:
+                return StatementHasFlaggedReturn(ls.Statement, typeMap);
+
+            case Stmt.Switch sw:
+                if (sw.DefaultBody != null && BlockReturnsMayBeUndefined(sw.DefaultBody, typeMap))
+                    return true;
+                foreach (var c in sw.Cases)
+                    if (BlockReturnsMayBeUndefined(c.Body, typeMap)) return true;
+                return false;
+
+            case Stmt.TryCatch tc:
+                return BlockReturnsMayBeUndefined(tc.TryBlock, typeMap)
+                    || BlockReturnsMayBeUndefined(tc.CatchBlock, typeMap)
+                    || BlockReturnsMayBeUndefined(tc.FinallyBlock, typeMap);
+
+            // Nested function/class declarations own their own return slot — do not descend.
+            // Expression statements, variable declarations, throw/break/continue, etc. carry no
+            // reachable return for this function (any arrow inside an initializer is likewise a
+            // separate slot, flagged independently when its own body is analyzed).
+            default:
+                return false;
+        }
+    }
+}

--- a/SharpTS.Tests/CompilerTests/ILVerificationTests.cs
+++ b/SharpTS.Tests/CompilerTests/ILVerificationTests.cs
@@ -500,4 +500,89 @@ public class ILVerificationTests
         Assert.Empty(errors);
         Assert.Equal("hello world\nABC\n", output);
     }
+
+    // #344: a `: number` function whose body returns `undefined as any` would, with an
+    // unboxed `double` return slot, coerce the `undefined` sentinel to `NaN`. The checker
+    // flags the undefined-reachable return so the compiler widens the slot to object,
+    // matching the interpreter (`undefined`).
+    [Fact]
+    public void TypedNumberReturn_UndefinedAsAny_StaysUndefined()
+    {
+        var source = """
+            function f(n: any): number {
+                if (n > 2) return 42;
+                return undefined as any;
+            }
+            console.log(f(3));
+            console.log(f(1));
+            """;
+
+        var (errors, output) = TestHarness.CompileVerifyAndRun(source);
+
+        Assert.Empty(errors);
+        Assert.Equal("42\nundefined\n", output);
+        Assert.Equal(output, TestHarness.RunInterpreted(source));
+    }
+
+    // #344: the boolean analogue — an unboxed `bool` slot would coerce `undefined` to `false`.
+    [Fact]
+    public void TypedBooleanReturn_UndefinedAsAny_StaysUndefined()
+    {
+        var source = """
+            function g(n: any): boolean {
+                if (n > 2) return true;
+                return undefined as any;
+            }
+            console.log(g(3));
+            console.log(g(1));
+            """;
+
+        var (errors, output) = TestHarness.CompileVerifyAndRun(source);
+
+        Assert.Empty(errors);
+        Assert.Equal("true\nundefined\n", output);
+        Assert.Equal(output, TestHarness.RunInterpreted(source));
+    }
+
+    // #344: an expression-bodied arrow with a `: number` return whose ternary hides the
+    // `undefined` in a branch (`42 | any` collapses to `42` at the top level). The value-flow
+    // check recurses into ternary branches so the slot is still widened.
+    [Fact]
+    public void TypedNumberArrow_TernaryUndefinedBranch_StaysUndefined()
+    {
+        var source = """
+            const af = (n: any): number => (n > 2 ? 42 : (undefined as any));
+            console.log(af(3));
+            console.log(af(1));
+            """;
+
+        var (errors, output) = TestHarness.CompileVerifyAndRun(source);
+
+        Assert.Empty(errors);
+        Assert.Equal("42\nundefined\n", output);
+        Assert.Equal(output, TestHarness.RunInterpreted(source));
+    }
+
+    // #344 guard: a genuinely numeric/boolean function (no undefined in its value domain)
+    // keeps its sound unboxed slot — it must still verify and compute correctly. `area(2)+1`
+    // consumes the return numerically, exercising the unboxed double path.
+    [Fact]
+    public void TypedNumericReturn_SoundBody_StillWorks()
+    {
+        var source = """
+            function add(a: number, b: number): number { return a + b; }
+            function area(r: number): number { return r * r * 3; }
+            function isBig(n: number): boolean { return n > 10; }
+            console.log(add(2, 3));
+            console.log(area(2) + 1);
+            console.log(isBig(5));
+            console.log(isBig(20));
+            """;
+
+        var (errors, output) = TestHarness.CompileVerifyAndRun(source);
+
+        Assert.Empty(errors);
+        Assert.Equal("5\n13\nfalse\ntrue\n", output);
+        Assert.Equal(output, TestHarness.RunInterpreted(source));
+    }
 }

--- a/TypeSystem/TypeChecker.Expressions.cs
+++ b/TypeSystem/TypeChecker.Expressions.cs
@@ -1244,6 +1244,10 @@ public partial class TypeChecker
                     {
                         throw new TypeCheckException($" Arrow function declared to return '{returnType}' but expression evaluates to '{exprType}'.", tsCode: "TS2322");
                     }
+
+                    // Expression-bodied arrows have no Stmt.Return; the body expression is
+                    // the return value. Flag it the same way block returns are flagged (#344).
+                    MarkIfUndefinedReachableNumericReturn(arrow.ExpressionBody, exprType);
                 }
             }
             else if (arrow.BlockBody != null)

--- a/TypeSystem/TypeChecker.Statements.cs
+++ b/TypeSystem/TypeChecker.Statements.cs
@@ -361,6 +361,8 @@ public partial class TypeChecker
                     ? CheckExprWithContext(stmt.Value, expectedReturnType)
                     : new TypeInfo.Void();
 
+                MarkIfUndefinedReachableNumericReturn(stmt.Value, actualReturnType);
+
                 if (_inGeneratorFunction && expectedReturnType is TypeInfo.Void)
                 {
                     // Allow any return value in generators with no explicit return type
@@ -377,6 +379,58 @@ public partial class TypeChecker
         }
         return VoidResult.Instance;
     }
+
+    /// <summary>
+    /// When a return value whose runtime value can be the <c>undefined</c> sentinel (i.e. a
+    /// statically <c>any</c>/<c>unknown</c> value, e.g. <c>return undefined as any</c>) flows into
+    /// a declared <c>number</c>/<c>boolean</c> return type, the IL compiler would give the function
+    /// an unboxed <c>double</c>/<c>bool</c> return slot. That slot cannot carry <c>undefined</c>, so
+    /// it is silently coerced to <c>NaN</c>/<c>false</c> (#344). Record the value expression so the
+    /// compiler widens that one function's slot back to <c>object</c>. <c>any</c>/<c>unknown</c> are
+    /// the only statically-checked types whose runtime value can be <c>undefined</c> while still
+    /// satisfying a <c>number</c>/<c>boolean</c> annotation (an exact annotation otherwise rejects
+    /// <c>undefined</c>; an inferred return that admits it widens to a union → object slot).
+    /// Compiler hint only — caller-side checking still sees the clean <c>number</c>/<c>boolean</c>.
+    /// </summary>
+    private void MarkIfUndefinedReachableNumericReturn(Expr? value, TypeInfo actualType)
+    {
+        if (value == null) return;
+
+        TypeInfo declared = _currentFunctionReturnType ?? actualType;
+        if (_inAsyncFunction && declared is TypeInfo.Promise promised) declared = promised.ValueType;
+        if (declared is not TypeInfo.Primitive { Type: TokenType.TYPE_NUMBER or TokenType.TYPE_BOOLEAN })
+            return;
+
+        if (ReturnValueMayBeUndefinedSentinel(value))
+            _typeMap.MarkUndefinedReachableReturn(value);
+    }
+
+    /// <summary>
+    /// True if <paramref name="value"/> can evaluate to a runtime value of static type
+    /// <c>any</c>/<c>unknown</c> (which therefore can be the <c>undefined</c> sentinel). Recurses
+    /// through "pass-through" forms whose result is one of their operands — groupings, ternaries,
+    /// and <c>||</c>/<c>&amp;&amp;</c>/<c>??</c> — because those collapse a mixed branch type (e.g.
+    /// <c>42 | any</c> → <c>42</c>) and hide the <c>any</c> at the top level. Leaf types come from
+    /// the <see cref="TypeMap"/>, which has every sub-expression recorded by the time a return is
+    /// checked. Over-approximates (both ternary branches), which is sound: at worst a function that
+    /// could never produce <c>undefined</c> keeps an object slot.
+    /// </summary>
+    private bool ReturnValueMayBeUndefinedSentinel(Expr value) => value switch
+    {
+        Expr.Grouping g => ReturnValueMayBeUndefinedSentinel(g.Expression),
+        Expr.Ternary t => ReturnValueMayBeUndefinedSentinel(t.ThenBranch)
+                       || ReturnValueMayBeUndefinedSentinel(t.ElseBranch),
+        Expr.Logical l => ReturnValueMayBeUndefinedSentinel(l.Left)
+                       || ReturnValueMayBeUndefinedSentinel(l.Right),
+        _ => TypeAdmitsUndefinedSentinel(_typeMap.Get(value))
+    };
+
+    private static bool TypeAdmitsUndefinedSentinel(TypeInfo? type) => type switch
+    {
+        TypeInfo.Any or TypeInfo.Unknown or TypeInfo.Undefined => true,
+        TypeInfo.Union u => u.Types.Any(TypeAdmitsUndefinedSentinel),
+        _ => false
+    };
 
     internal VoidResult VisitExpression(Stmt.Expression stmt)
     {

--- a/TypeSystem/TypeMap.cs
+++ b/TypeSystem/TypeMap.cs
@@ -17,6 +17,7 @@ public class TypeMap
     private readonly Dictionary<string, TypeInfo.Class> _classTypes = new(StringComparer.Ordinal);
     private readonly Dictionary<string, TypeInfo.Function> _functionTypes = new(StringComparer.Ordinal);
     private readonly Dictionary<Expr.ClassExpr, TypeInfo.Class> _classExprTypes = new(ReferenceEqualityComparer.Instance);
+    private readonly HashSet<Expr> _undefinedReachableReturns = new(ReferenceEqualityComparer.Instance);
 
     /// <summary>
     /// Associates an expression with its resolved type.
@@ -52,6 +53,23 @@ public class TypeMap
     /// Gets the function type by name, or null if not found.
     /// </summary>
     public TypeInfo.Function? GetFunctionType(string functionName) => _functionTypes.GetValueOrDefault(functionName);
+
+    /// <summary>
+    /// Marks a return value expression as one that flows into a <c>number</c>/<c>boolean</c>
+    /// declared return type but whose static type (<c>any</c>/<c>unknown</c>) does not exclude
+    /// the runtime <c>undefined</c> sentinel (e.g. <c>return undefined as any</c>). The IL
+    /// compiler consults this to widen the otherwise-unboxed <c>double</c>/<c>bool</c> return
+    /// slot back to <c>object</c> for just those functions, so a legitimate <c>undefined</c>
+    /// is not silently coerced to <c>NaN</c>/<c>false</c>. Purely a compiler hint — caller-side
+    /// type checking still sees the clean <c>number</c>/<c>boolean</c> return type. (#344)
+    /// </summary>
+    public void MarkUndefinedReachableReturn(Expr returnValue) => _undefinedReachableReturns.Add(returnValue);
+
+    /// <summary>
+    /// True if <paramref name="returnValue"/> was flagged by
+    /// <see cref="MarkUndefinedReachableReturn"/>.
+    /// </summary>
+    public bool IsUndefinedReachableReturn(Expr returnValue) => _undefinedReachableReturns.Contains(returnValue);
 
     /// <summary>
     /// Gets the resolved type for an expression, or null if not found.


### PR DESCRIPTION
Closes #344.

## Problem

The typed-return optimization gives functions/arrows whose return type resolves to `number`/`boolean` an unboxed `double`/`bool` .NET return slot. When a legitimate `undefined` reaches such a return at runtime (e.g. `return undefined as any`), `EmitReturn` unboxes it (`EmitUnboxToDouble`/`Conv_I4`), silently corrupting `undefined` into `NaN` (number) or `false` (boolean).

This is the value-type analogue of #318 (string slots), but it corrupts **silently** instead of crashing/failing verification.

```ts
function f(n: any): number {
  if (n > 2) return 42;
  return undefined as any;
}
console.log(f(1)); // interp: undefined / compiled (before): NaN
```

## Why not just drop the slot (the #318 fix)?

Unlike a `string` slot — which buys nothing, since strings are reference types, so #318 dropped it outright — `double`/`bool` slots avoid real boxing on the common, sound numeric path. Dropping them unconditionally would regress perf. So only the genuinely-unsafe functions are widened.

## Fix

- **Type checker** flags a return value whose runtime value can be the `undefined` sentinel (static type `any`/`unknown`) flowing into a declared `number`/`boolean` return, recording the value expression in the `TypeMap`. This is a **compiler hint only** — caller-side checking still sees the clean `number`/`boolean` return type. The check recurses through *pass-through* forms (groupings, ternaries, `||`/`&&`/`??`) because those collapse a mixed branch type (`42 | any` → `42`) and hide the `any` at the top level. Wired into both the block-return path (`VisitReturn`) and the expression-bodied arrow path.
- **`ParameterTypeResolver.ResolveReturnType`** gains a `returnMayBeUndefined` flag that widens a `double`/`bool` slot to `object`, mirroring the existing string/bigint/nullable/Union fallbacks (and correctly handling the async `Task<T>` wrap).
- **`ReturnSlotAnalysis`** (new) scans a function/arrow body for any flagged return, stopping at nested function/arrow/class boundaries (those own their own slot). The function and arrow definition sites consult it.
- **Methods** already use `object` return slots (`ILCompiler.Classes.Methods.cs`), so they were never affected — no change needed there. Async/generator functions use `Task<object>`/`IEnumerable<object>`, also unaffected.

Sound numeric/boolean functions keep their unboxed slots → **zero perf regression on the common path**; only genuinely-undefined-reachable functions pay an object slot (and those were already unboxing at the return site, so the slot bought them nothing).

## Tests

Four regression tests in `ILVerificationTests` (each asserts compiled output verifies, is correct, and matches the interpreter):
- `: number` block body returning `undefined as any` stays `undefined` (was `NaN`)
- `: boolean` analogue stays `undefined` (was `false`)
- expression-bodied `: number` arrow with a ternary hiding `undefined` in a branch stays `undefined`
- a genuinely numeric/boolean body (incl. a return consumed numerically) still verifies and computes correctly — guards the unboxed fast path

Full suite green: **11125 passed**.

## Follow-up filed

- **#367** — a `number`/`boolean`-typed *local* unsoundly assigned `undefined` and then returned still coerces (the return expression is statically `number`, so #344's static `any`/`unknown` detection can't see it). Same deep-unsoundness class as out-of-bounds `arr[0]`; deliberate scope split to keep this fix static and perf-neutral.