### PR TITLE
fix(compile): consult @@species on generic Promise subclasses (#351)

### DIFF
--- a/Compilation/EmittedRuntime.cs
+++ b/Compilation/EmittedRuntime.cs
@@ -1629,6 +1629,13 @@ public class EmittedRuntime
     public MethodBuilder RegisterSymbolAccessor { get; set; } = null!;
     public MethodBuilder FindSymbolGetter { get; set; } = null!;
     public MethodBuilder FindSymbolSetter { get; set; } = null!;
+    // #351 generic-class support helpers: map a (possibly generic) owner type to
+    // its registry key (the open generic definition) and to a closed type usable
+    // for cctor + reflective Invoke, and close an accessor MethodInfo declared on
+    // an open generic definition onto that closed type.
+    public MethodBuilder SymbolRegistryKey { get; set; } = null!;
+    public MethodBuilder SymbolClosedOwner { get; set; } = null!;
+    public MethodBuilder CloseSymbolAccessor { get; set; } = null!;
     public FieldBuilder CachedFetchFunction { get; set; } = null!;
     public FieldBuilder CachedParseIntFunction { get; set; } = null!;
     public FieldBuilder CachedParseFloatFunction { get; set; } = null!;

--- a/Compilation/RuntimeEmitter.Promises.Executor.cs
+++ b/Compilation/RuntimeEmitter.Promises.Executor.cs
@@ -169,12 +169,12 @@ public partial class RuntimeEmitter
     /// adopts a raw task, so the new instance wraps <c>result</c>).
     /// </summary>
     /// <remarks>
-    /// Limitation: a <em>generic</em> Promise subclass with a <c>@@species</c>
-    /// override does not resolve the override — its static accessor is registered
-    /// under the open generic type definition while the receiver's runtime type
-    /// is closed, so the registry lookup misses and the result falls back to the
-    /// receiver's own class (the pre-existing #266 generic-class gap, tracked by
-    /// #351). A species that yields a non-Promise constructor (general
+    /// Generic Promise subclasses (#351): the static <c>@@species</c> accessor is
+    /// registered under the open generic definition (MyP`1) while the receiver's
+    /// runtime type is closed (MyP&lt;object&gt;); FindSymbolGetterFor reconciles
+    /// the two (SymbolRegistryKey/CloseSymbolAccessor) and a species naming a
+    /// generic subclass is closed via SymbolClosedOwner before construction.
+    /// A species that yields a non-Promise constructor (general
     /// NewPromiseCapability) falls back to <c>%Promise%</c> — tracked by #349.
     /// </remarks>
     private void EmitWrapDerivedPromiseResultMethod(TypeBuilder runtimeType, EmittedRuntime runtime)
@@ -238,6 +238,14 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Brfalse, returnResultLabel);
 
         il.MarkLabel(haveSpeciesLabel);
+        // #351: a species naming a generic Promise subclass resolves to the OPEN
+        // generic definition (MyP`1) — uninstantiable. Close it on `object` so the
+        // GetConstructor/Invoke below target a constructable type. Closed and
+        // non-generic species (incl. the default species = receiver's closed type)
+        // pass through unchanged.
+        il.Emit(OpCodes.Ldloc, speciesTypeLocal);
+        il.Emit(OpCodes.Call, runtime.SymbolClosedOwner);
+        il.Emit(OpCodes.Stloc, speciesTypeLocal);
         // if (speciesType == typeof(Task<object?>)) return result;  // %Promise%
         il.Emit(OpCodes.Ldloc, speciesTypeLocal);
         il.Emit(OpCodes.Ldtoken, _types.TaskOfObject);

--- a/Compilation/RuntimeEmitter.SymbolAccessors.cs
+++ b/Compilation/RuntimeEmitter.SymbolAccessors.cs
@@ -43,6 +43,26 @@ public partial class RuntimeEmitter
             MethodAttributes.Public | MethodAttributes.Static,
             _types.Object,
             [_types.Object, _types.Object]);
+
+        // #351 generic-class helpers (forward-declared; bodies filled alongside
+        // the Find* bodies). FindSymbol* calls them in its base-chain walk.
+        runtime.SymbolRegistryKey = typeBuilder.DefineMethod(
+            "SymbolRegistryKey",
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.Type,
+            [_types.Type]);
+
+        runtime.SymbolClosedOwner = typeBuilder.DefineMethod(
+            "SymbolClosedOwner",
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.Type,
+            [_types.Type]);
+
+        runtime.CloseSymbolAccessor = typeBuilder.DefineMethod(
+            "CloseSymbolAccessor",
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.Object,
+            [_types.Object, _types.Type]);
     }
 
     /// <summary>Emits the registry field initialization into the $Runtime cctor.</summary>
@@ -67,10 +87,149 @@ public partial class RuntimeEmitter
         var getType = _types.GetMethod(_types.Object, "GetType");
 
         EmitRegisterSymbolAccessorBody(runtime, inner, outerTryGetValue, outerSetItem, innerTryGetValue, innerSetItem);
-        EmitFindSymbolAccessorBody(runtime.FindSymbolGetter, field, inner,
+        EmitSymbolGenericHelperBodies(runtime);
+        EmitFindSymbolAccessorBody(runtime, runtime.FindSymbolGetter, field, inner,
             SymGetterInstanceSlot, SymGetterStaticSlot, outerTryGetValue, innerTryGetValue, getBaseType, getType);
-        EmitFindSymbolAccessorBody(runtime.FindSymbolSetter, field, inner,
+        EmitFindSymbolAccessorBody(runtime, runtime.FindSymbolSetter, field, inner,
             SymSetterInstanceSlot, SymSetterStaticSlot, outerTryGetValue, innerTryGetValue, getBaseType, getType);
+    }
+
+    /// <summary>
+    /// Emits the #351 generic-class helper bodies: SymbolRegistryKey,
+    /// SymbolClosedOwner, and CloseSymbolAccessor. The registry is keyed by the
+    /// open generic type definition (a class .cctor registers via
+    /// <c>typeof(ThisClass)</c>, which for a generic class is the open
+    /// definition), while receiver runtime types are closed (e.g. MyP&lt;object&gt;)
+    /// and a static class reference is the open definition. These reconcile the
+    /// two so the base-chain walk both finds the slot and produces an invokable
+    /// (closed) accessor MethodInfo.
+    /// </summary>
+    private void EmitSymbolGenericHelperBodies(EmittedRuntime runtime)
+    {
+        var isConstructedGeneric = _types.Type.GetProperty("IsConstructedGenericType")!.GetGetMethod()!;
+        var isGenericTypeDef = _types.Type.GetProperty("IsGenericTypeDefinition")!.GetGetMethod()!;
+        var getGenericTypeDef = _types.GetMethodNoParams(_types.Type, "GetGenericTypeDefinition");
+        var getGenericArgs = _types.GetMethodNoParams(_types.Type, "GetGenericArguments");
+        var makeGenericType = _types.GetMethod(_types.Type, "MakeGenericType", _types.MakeArrayType(_types.Type));
+        var getTypeFromHandle = _types.GetMethod(_types.Type, "GetTypeFromHandle", _types.RuntimeTypeHandle);
+        var getTypeHandle = _types.GetProperty(_types.Type, "TypeHandle").GetGetMethod()!;
+        var getMethodHandle = _types.GetProperty(_types.MethodBase, "MethodHandle").GetGetMethod()!;
+        var getDeclaringType = _types.GetProperty(typeof(System.Reflection.MemberInfo), "DeclaringType").GetGetMethod()!;
+        var containsGenericParams = _types.Type.GetProperty("ContainsGenericParameters")!.GetGetMethod()!;
+        var getMethodFromHandle = _types.GetMethod(_types.MethodBase, "GetMethodFromHandle",
+            _types.RuntimeMethodHandle, _types.RuntimeTypeHandle);
+
+        // ---- SymbolRegistryKey(Type owner) ----
+        // return owner.IsConstructedGenericType ? owner.GetGenericTypeDefinition() : owner;
+        {
+            var il = runtime.SymbolRegistryKey.GetILGenerator();
+            var notConstructed = il.DefineLabel();
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Callvirt, isConstructedGeneric);
+            il.Emit(OpCodes.Brfalse, notConstructed);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Callvirt, getGenericTypeDef);
+            il.Emit(OpCodes.Ret);
+            il.MarkLabel(notConstructed);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ret);
+        }
+
+        // ---- SymbolClosedOwner(Type owner) ----
+        // An open generic definition (a bare generic class reference, e.g. MyP`1)
+        // has no instantiation; close it on `object` for each type parameter so it
+        // can drive cctor execution and reflective Invoke. Closed/non-generic
+        // owners pass through.
+        {
+            var il = runtime.SymbolClosedOwner.GetILGenerator();
+            var notOpenDef = il.DefineLabel();
+            var argsLocal = il.DeclareLocal(_types.MakeArrayType(_types.Type));
+            var iLocal = il.DeclareLocal(_types.Int32);
+
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Callvirt, isGenericTypeDef);
+            il.Emit(OpCodes.Brfalse, notOpenDef);
+
+            // var args = owner.GetGenericArguments();
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Callvirt, getGenericArgs);
+            il.Emit(OpCodes.Stloc, argsLocal);
+
+            // for (i = 0; i < args.Length; i++) args[i] = typeof(object);
+            var loopTop = il.DefineLabel();
+            var loopCheck = il.DefineLabel();
+            il.Emit(OpCodes.Ldc_I4_0);
+            il.Emit(OpCodes.Stloc, iLocal);
+            il.Emit(OpCodes.Br, loopCheck);
+            il.MarkLabel(loopTop);
+            il.Emit(OpCodes.Ldloc, argsLocal);
+            il.Emit(OpCodes.Ldloc, iLocal);
+            il.Emit(OpCodes.Ldtoken, _types.Object);
+            il.Emit(OpCodes.Call, getTypeFromHandle);
+            il.Emit(OpCodes.Stelem_Ref);
+            il.Emit(OpCodes.Ldloc, iLocal);
+            il.Emit(OpCodes.Ldc_I4_1);
+            il.Emit(OpCodes.Add);
+            il.Emit(OpCodes.Stloc, iLocal);
+            il.MarkLabel(loopCheck);
+            il.Emit(OpCodes.Ldloc, iLocal);
+            il.Emit(OpCodes.Ldloc, argsLocal);
+            il.Emit(OpCodes.Ldlen);
+            il.Emit(OpCodes.Conv_I4);
+            il.Emit(OpCodes.Blt, loopTop);
+
+            // return owner.MakeGenericType(args);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldloc, argsLocal);
+            il.Emit(OpCodes.Callvirt, makeGenericType);
+            il.Emit(OpCodes.Ret);
+
+            il.MarkLabel(notOpenDef);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ret);
+        }
+
+        // ---- CloseSymbolAccessor(object mi, Type closedOwner) ----
+        // var m = mi as MethodInfo;
+        // if (m != null && m.DeclaringType != null && m.DeclaringType.ContainsGenericParameters)
+        //     return MethodBase.GetMethodFromHandle(m.MethodHandle, closedOwner.TypeHandle);
+        // return mi;
+        {
+            var il = runtime.CloseSymbolAccessor.GetILGenerator();
+            var passThrough = il.DefineLabel();
+            var mLocal = il.DeclareLocal(_types.MethodInfo);
+            var dtLocal = il.DeclareLocal(_types.Type);
+
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Isinst, _types.MethodInfo);
+            il.Emit(OpCodes.Stloc, mLocal);
+            il.Emit(OpCodes.Ldloc, mLocal);
+            il.Emit(OpCodes.Brfalse, passThrough);
+
+            // dt = m.DeclaringType;
+            il.Emit(OpCodes.Ldloc, mLocal);
+            il.Emit(OpCodes.Callvirt, getDeclaringType);
+            il.Emit(OpCodes.Stloc, dtLocal);
+            il.Emit(OpCodes.Ldloc, dtLocal);
+            il.Emit(OpCodes.Brfalse, passThrough);
+
+            // if (!dt.ContainsGenericParameters) pass through
+            il.Emit(OpCodes.Ldloc, dtLocal);
+            il.Emit(OpCodes.Callvirt, containsGenericParams);
+            il.Emit(OpCodes.Brfalse, passThrough);
+
+            // return GetMethodFromHandle(m.MethodHandle, closedOwner.TypeHandle);
+            il.Emit(OpCodes.Ldloc, mLocal);
+            il.Emit(OpCodes.Callvirt, getMethodHandle);
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Callvirt, getTypeHandle);
+            il.Emit(OpCodes.Call, getMethodFromHandle);
+            il.Emit(OpCodes.Ret);
+
+            il.MarkLabel(passThrough);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ret);
+        }
     }
 
     private void EmitRegisterSymbolAccessorBody(
@@ -158,16 +317,22 @@ public partial class RuntimeEmitter
 
     // object FindSymbol{Getter,Setter}For(object obj, object symbol):
     //   owner = obj is Type t ? t : obj.GetType();  idx = obj is Type ? staticSlot : instanceSlot;
-    //   for (; owner != null; owner = owner.BaseType)
-    //     if (reg.TryGetValue(owner, out inner) && inner.TryGetValue(symbol, out slot) && slot[idx] != null) return slot[idx];
+    //   for (; owner != null; owner = owner.BaseType) {
+    //     closed = SymbolClosedOwner(owner);           // #351: a closed type to drive cctor + Invoke
+    //     key = SymbolRegistryKey(owner);              // #351: registry is keyed by the open generic def
+    //     if (reg.TryGetValue(key, out inner) && inner.TryGetValue(symbol, out slot) && slot[idx] != null)
+    //       return CloseSymbolAccessor(slot[idx], closed);  // #351: close a generic-def accessor before Invoke
+    //   }
     //   return null;
     private void EmitFindSymbolAccessorBody(
+        EmittedRuntime runtime,
         MethodBuilder method, FieldBuilder field, Type inner,
         int instanceSlot, int staticSlot,
         MethodInfo outerTryGetValue, MethodInfo innerTryGetValue, MethodInfo getBaseType, MethodInfo getType)
     {
         var il = method.GetILGenerator();
         var ownerLocal = il.DeclareLocal(_types.Type);
+        var closedOwnerLocal = il.DeclareLocal(_types.Type);
         var idxLocal = il.DeclareLocal(_types.Int32);
         var innerLocal = il.DeclareLocal(inner);
         var slotLocal = il.DeclareLocal(_types.ObjectArray);
@@ -211,23 +376,33 @@ public partial class RuntimeEmitter
         il.MarkLabel(loopTop);
         il.Emit(OpCodes.Ldloc, ownerLocal);
         il.Emit(OpCodes.Brfalse, retNull);
+        // #351: closed = SymbolClosedOwner(owner) — for an open generic-class
+        // reference (MyP`1) this is a fully-closed instantiation that can drive
+        // both cctor execution and reflective Invoke; closed/non-generic owners
+        // pass through unchanged.
+        il.Emit(OpCodes.Ldloc, ownerLocal);
+        il.Emit(OpCodes.Call, runtime.SymbolClosedOwner);
+        il.Emit(OpCodes.Stloc, closedOwnerLocal);
         // Static-side accessors are registered in the owner class's .cctor, which
         // the CLR runs lazily — merely using the class as a Type value (typeof) does
         // not trigger it. Force it so a static `Class[Symbol.x]` access sees the
         // registration. Idempotent and cheap after the first run. (Instance-side
         // accessors are already registered by the time an instance exists.)
+        // Run the cctor on the CLOSED owner: an open generic definition has no
+        // runnable static initializer (#351).
         {
             var skipCctor = il.DefineLabel();
             il.Emit(OpCodes.Ldloc, asTypeLocal);
             il.Emit(OpCodes.Brfalse, skipCctor);
-            il.Emit(OpCodes.Ldloc, ownerLocal);
+            il.Emit(OpCodes.Ldloc, closedOwnerLocal);
             il.Emit(OpCodes.Callvirt, getTypeHandle);
             il.Emit(OpCodes.Call, runClassCtor);
             il.MarkLabel(skipCctor);
         }
-        // if (!reg.TryGetValue(owner, out inner)) goto nextBase;
+        // if (!reg.TryGetValue(SymbolRegistryKey(owner), out inner)) goto nextBase;
         il.Emit(OpCodes.Ldsfld, field);
         il.Emit(OpCodes.Ldloc, ownerLocal);
+        il.Emit(OpCodes.Call, runtime.SymbolRegistryKey);
         il.Emit(OpCodes.Ldloca, innerLocal);
         il.Emit(OpCodes.Callvirt, outerTryGetValue);
         il.Emit(OpCodes.Brfalse, nextBase);
@@ -237,7 +412,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloca, slotLocal);
         il.Emit(OpCodes.Callvirt, innerTryGetValue);
         il.Emit(OpCodes.Brfalse, nextBase);
-        // v = slot[idx]; if (v != null) return v;
+        // v = slot[idx]; if (v != null) return CloseSymbolAccessor(v, closed);
         il.Emit(OpCodes.Ldloc, slotLocal);
         il.Emit(OpCodes.Ldloc, idxLocal);
         il.Emit(OpCodes.Ldelem_Ref);
@@ -251,6 +426,9 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Br, loopTop);
 
         il.MarkLabel(retIt);
+        // stack: [v]  →  CloseSymbolAccessor(v, closed)
+        il.Emit(OpCodes.Ldloc, closedOwnerLocal);
+        il.Emit(OpCodes.Call, runtime.CloseSymbolAccessor);
         il.Emit(OpCodes.Ret);
         il.MarkLabel(retNull);
         il.Emit(OpCodes.Ldnull);

--- a/SharpTS.Tests/SharedTests/PromiseSubclassTests.cs
+++ b/SharpTS.Tests/SharedTests/PromiseSubclassTests.cs
@@ -431,14 +431,13 @@ public class PromiseSubclassTests
     }
 
     [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
-    public void Species_GenericSubclassOverride_Interpreted(ExecutionMode mode)
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Species_GenericSubclassOverride(ExecutionMode mode)
     {
-        // A GENERIC Promise subclass with a @@species override resolves
-        // correctly in the interpreter. Compiled mode currently falls back to
-        // the receiver class (its static accessor is registered under the open
-        // generic type while the receiver's runtime type is closed) — the
-        // pre-existing #266 generic-class gap, tracked by #351.
+        // A GENERIC Promise subclass with a @@species override resolves in both
+        // modes. The static accessor is registered under the open generic
+        // definition (MyP`1) while the receiver's runtime type is closed
+        // (MyP<object>); compiled mode reconciles the two (#351).
         var source = """
             class MyP<T> extends Promise<T> {
                 static get [Symbol.species]() { return Promise; }
@@ -453,6 +452,51 @@ public class PromiseSubclassTests
 
         var output = TestHarness.Run(source, mode);
         Assert.Equal("false\ntrue\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Species_GenericSubclassRedirectsToOtherGenericSubclass(ExecutionMode mode)
+    {
+        // A generic subclass whose @@species names ANOTHER generic Promise
+        // subclass: then must construct through that (also generic) species. In
+        // compiled mode the species value is the open generic definition
+        // (Other`1) and is closed before construction (#351).
+        var source = """
+            class Other<T> extends Promise<T> {}
+            class MyP<T> extends Promise<T> {
+                static get [Symbol.species]() { return Other; }
+            }
+            async function main() {
+                const q = MyP.resolve(1).then(v => v);
+                console.log(q instanceof Other);
+                console.log(q instanceof MyP);
+                console.log(await q);
+            }
+            main();
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("true\nfalse\n1\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Species_GenericSubclassStaticReadResolvesOverride(ExecutionMode mode)
+    {
+        // The guest-visible static read `(MyP as any)[Symbol.species]` of a
+        // generic subclass: the class reference is the open generic definition
+        // (MyP`1), and reading the static @@species getter must close it before
+        // reflective Invoke rather than crashing / returning undefined (#351).
+        var source = """
+            class MyP<T> extends Promise<T> {
+                static get [Symbol.species]() { return Promise; }
+            }
+            console.log((MyP as any)[Symbol.species] === Promise);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("true\n", output);
     }
 
     [Theory]


### PR DESCRIPTION
Fixes #351.

## Problem

The #266 symbol-accessor registry is keyed by the **open** generic type definition — a class `.cctor` registers via `typeof(ThisClass)`, which for a generic class is `MyP\`1`. But lookups arrive with the **closed** receiver type (`MyP<object>`), or — for a bare generic class reference used as a value — the open definition whose accessor `MethodInfo` cannot be reflectively `Invoke`'d (`ContainsGenericParameters` is true).

Two compiled-mode symptoms (interpreter was already correct):

- `then`/`catch`/`finally` on a generic Promise subclass ignored its `static get [Symbol.species]` override and stayed subclass-typed instead of redirecting.
- `(MyP as any)[Symbol.species]` read `undefined`.

## Fix

Reconcile open-vs-closed inside the shared #266 registry path with three BCL-only `$Runtime` helpers:

- **`SymbolRegistryKey(owner)`** — normalizes a closed generic receiver to its open-generic-definition lookup key.
- **`SymbolClosedOwner(owner)`** — closes a bare open generic definition on `object` per type parameter, yielding an instantiation that can both drive `.cctor` execution and back a reflective `Invoke`.
- **`CloseSymbolAccessor(mi, closedOwner)`** — closes an accessor `MethodInfo` declared on an open generic definition onto the closed owner before it's invoked.

`WrapDerivedPromiseResult` additionally closes a `@@species` value that itself names another generic subclass before constructing through it.

The fix is general — it also repairs static `@@toStringTag` / `@@toPrimitive` on generic classes (the same #266 path).

## Verification

- New/updated tests in `PromiseSubclassTests`: `Species_GenericSubclassOverride` promoted to **both** modes; added `Species_GenericSubclassRedirectsToOtherGenericSubclass` and `Species_GenericSubclassStaticReadResolvesOverride`.
- Full suite green: **11130 passed, 0 failed**.
- Output DLL stays fully **standalone** (no SharpTS.dll co-located) and passes `--verify` (ILVerify).
- Confirmed constrained (`class C<T extends Named>`) and multi-param (`class Pair<K,V>`) generics work — TS constraints erase to `object` at the CLR level.

A species that yields a non-Promise constructor (general `NewPromiseCapability`) still falls back to `%Promise%` — already tracked by #349.