### PR TITLE
fix(compile): consult expando @@species in derived-Promise result wrap (#349)

### DIFF
--- a/Compilation/RuntimeEmitter.Promises.Executor.cs
+++ b/Compilation/RuntimeEmitter.Promises.Executor.cs
@@ -160,9 +160,11 @@ public partial class RuntimeEmitter
     /// the then/catch/finally result construction through
     /// SpeciesConstructor(receiver, %Promise%) (ECMA-262 §27.2.5.4, §7.3.22).
     /// When the receiver is a $Promise SUBCLASS instance (#242), reads
-    /// <c>receiver.constructor[Symbol.species]</c> — i.e. the subclass's static
-    /// <c>@@species</c> getter, defaulting to the subclass itself when not
-    /// overridden — and constructs the result through it: <c>%Promise%</c> (or a
+    /// <c>receiver.constructor[Symbol.species]</c> — the subclass's static
+    /// <c>@@species</c> getter, or, absent that, the expando assigned via
+    /// <c>(C as any)[Symbol.species] = …</c> (#262/#349), defaulting to the
+    /// subclass itself when neither is present — and constructs the result
+    /// through it: <c>%Promise%</c> (or a
     /// <c>@@species</c> yielding <c>Promise</c>/<c>undefined</c>/<c>null</c>)
     /// returns the raw task, any other guest Promise class is built by invoking
     /// its single-object (executor) constructor reflectively (PromiseFromExecutor
@@ -190,6 +192,7 @@ public partial class RuntimeEmitter
         var il = method.GetILGenerator();
         var returnResultLabel = il.DefineLabel();
         var haveSpeciesLabel = il.DefineLabel();
+        var expandoLookupLabel = il.DefineLabel();
         var typeLocal = il.DeclareLocal(_types.Type);          // receiver's runtime type (= C)
         var speciesTypeLocal = il.DeclareLocal(_types.Type);   // resolved SpeciesConstructor
         var getterLocal = il.DeclareLocal(_types.Object);
@@ -219,9 +222,10 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldsfld, runtime.SymbolSpecies);
         il.Emit(OpCodes.Call, runtime.FindSymbolGetter);
         il.Emit(OpCodes.Stloc, getterLocal);
-        // if (getter == null) use default species (= recvType).
+        // if (getter == null) consult the dynamically-assigned static @@species
+        // expando before defaulting (#349).
         il.Emit(OpCodes.Ldloc, getterLocal);
-        il.Emit(OpCodes.Brfalse, haveSpeciesLabel);
+        il.Emit(OpCodes.Brfalse, expandoLookupLabel);
 
         // var speciesVal = ((MethodBase)getter).Invoke(recvType, Array.Empty<object>());
         il.Emit(OpCodes.Ldloc, getterLocal);
@@ -236,6 +240,61 @@ public partial class RuntimeEmitter
         // if (speciesType == null) return result;  // undefined/null/non-Type species → %Promise%
         il.Emit(OpCodes.Ldloc, speciesTypeLocal);
         il.Emit(OpCodes.Brfalse, returnResultLabel);
+        il.Emit(OpCodes.Br, haveSpeciesLabel);  // declared accessor resolved → skip expando
+
+        // #349: no declared static @@species accessor — consult the expando
+        // assigned via `(C as any)[Symbol.species] = …` (#262), which the
+        // interpreter (ResolveSpeciesConstructor → TryGetStaticBySymbol) reads but
+        // compiled mode previously ignored. The expando is stored in the per-Type
+        // symbol dict (GetSymbolDict), so walk the receiver's runtime type and its
+        // base-type chain (inherited expando statics are visible on subclasses,
+        // #265), keying each level through SymbolRegistryKey so a generic
+        // subclass's closed runtime type (MyP&lt;object&gt;) reaches the expando
+        // stored under its open generic definition (MyP`1, #351). A found value
+        // has the same representation as a getter's return
+        // (a Type token; `Promise` → typeof(Task<object?>)), so it flows through
+        // the shared tail below. None found → the default species (= recvType,
+        // already in speciesType) — the inherited Promise[@@species] returns `this`.
+        il.MarkLabel(expandoLookupLabel);
+        var expandoOwnerLocal = il.DeclareLocal(_types.Type);
+        var expandoDictLocal = il.DeclareLocal(_types.DictionaryObjectObject);
+        var expandoValLocal = il.DeclareLocal(_types.Object);
+        var expandoLoopLabel = il.DefineLabel();
+        var haveExpandoLabel = il.DefineLabel();
+        var getBaseType = _types.GetProperty(_types.Type, "BaseType").GetGetMethod()!;
+        var dictTryGetValue = _types.GetMethod(_types.DictionaryObjectObject, "TryGetValue");
+
+        // owner = recvType;
+        il.Emit(OpCodes.Ldloc, typeLocal);
+        il.Emit(OpCodes.Stloc, expandoOwnerLocal);
+        il.MarkLabel(expandoLoopLabel);
+        // if (owner == null) goto haveSpecies;  // none found → default species
+        il.Emit(OpCodes.Ldloc, expandoOwnerLocal);
+        il.Emit(OpCodes.Brfalse, haveSpeciesLabel);
+        // if (GetSymbolDict(SymbolRegistryKey(owner)).TryGetValue(Symbol.species, out expandoVal)) goto haveExpando;
+        il.Emit(OpCodes.Ldloc, expandoOwnerLocal);
+        il.Emit(OpCodes.Call, runtime.SymbolRegistryKey);
+        il.Emit(OpCodes.Call, runtime.GetSymbolDictMethod);
+        il.Emit(OpCodes.Stloc, expandoDictLocal);
+        il.Emit(OpCodes.Ldloc, expandoDictLocal);
+        il.Emit(OpCodes.Ldsfld, runtime.SymbolSpecies);
+        il.Emit(OpCodes.Ldloca, expandoValLocal);
+        il.Emit(OpCodes.Callvirt, dictTryGetValue);
+        il.Emit(OpCodes.Brtrue, haveExpandoLabel);
+        // owner = owner.BaseType; continue;
+        il.Emit(OpCodes.Ldloc, expandoOwnerLocal);
+        il.Emit(OpCodes.Callvirt, getBaseType);
+        il.Emit(OpCodes.Stloc, expandoOwnerLocal);
+        il.Emit(OpCodes.Br, expandoLoopLabel);
+
+        il.MarkLabel(haveExpandoLabel);
+        // speciesType = expandoVal as Type;  // undefined/null/non-Type → %Promise%
+        il.Emit(OpCodes.Ldloc, expandoValLocal);
+        il.Emit(OpCodes.Isinst, _types.Type);
+        il.Emit(OpCodes.Stloc, speciesTypeLocal);
+        il.Emit(OpCodes.Ldloc, speciesTypeLocal);
+        il.Emit(OpCodes.Brfalse, returnResultLabel);
+        // fall through to the shared SpeciesConstructor tail.
 
         il.MarkLabel(haveSpeciesLabel);
         // #351: a species naming a generic Promise subclass resolves to the OPEN

--- a/SharpTS.Tests/SharedTests/PromiseSubclassTests.cs
+++ b/SharpTS.Tests/SharedTests/PromiseSubclassTests.cs
@@ -500,13 +500,14 @@ public class PromiseSubclassTests
     }
 
     [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
-    public void Species_ExpandoOverride_Interpreted(ExecutionMode mode)
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Species_ExpandoOverrideRedirectsToPlainPromise(ExecutionMode mode)
     {
         // A dynamically-assigned static @@species ((C as any)[Symbol.species] =
-        // Promise, #262) is consulted by then in the interpreter. Compiled mode
-        // only reads the declared-accessor registry, so the expando is not yet
-        // consulted there — tracked by #349.
+        // Promise, #262) — with no declared `static get [Symbol.species]()` — is
+        // consulted by then in BOTH modes (#349). Compiled mode previously read
+        // only the declared-accessor registry; it now also consults the per-Type
+        // symbol-expando dict.
         var source = """
             class MyP extends Promise<number> {}
             (MyP as any)[Symbol.species] = Promise;
@@ -514,12 +515,87 @@ public class PromiseSubclassTests
                 const q = MyP.resolve(1).then(v => v);
                 console.log(q instanceof MyP);
                 console.log(q instanceof Promise);
+                console.log(await q);
             }
             main();
             """;
 
         var output = TestHarness.Run(source, mode);
-        Assert.Equal("false\ntrue\n", output);
+        Assert.Equal("false\ntrue\n1\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Species_ExpandoOverrideRedirectsToOtherSubclass(ExecutionMode mode)
+    {
+        // The expando @@species may name another Promise subclass; then must
+        // construct its result through it, exactly as a declared getter would.
+        var source = """
+            class Other extends Promise<number> {}
+            class MyP extends Promise<number> {}
+            (MyP as any)[Symbol.species] = Other;
+            async function main() {
+                const q = MyP.resolve(1).then(v => v);
+                console.log(q instanceof Other);
+                console.log(q instanceof MyP);
+                console.log(await q);
+            }
+            main();
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("true\nfalse\n1\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Species_ExpandoOverrideInheritedThroughSubclass(ExecutionMode mode)
+    {
+        // An expando @@species set on a base class is visible on a subclass
+        // receiver (#265 base-chain walk): Sub.resolve(...).then(...) follows the
+        // base's @@species. Here Base's expando → Promise, so Sub's then result
+        // is a plain promise, not a Sub/Base instance.
+        var source = """
+            class Base extends Promise<number> {}
+            (Base as any)[Symbol.species] = Promise;
+            class Sub extends Base {}
+            async function main() {
+                const q = Sub.resolve(1).then(v => v);
+                console.log(q instanceof Sub);
+                console.log(q instanceof Base);
+                console.log(q instanceof Promise);
+                console.log(await q);
+            }
+            main();
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("false\nfalse\ntrue\n1\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Species_ExpandoOverrideOnGenericSubclass(ExecutionMode mode)
+    {
+        // An expando @@species on a GENERIC subclass: the assignment keys the
+        // open generic definition (MyP`1) while the then-receiver's runtime type
+        // is closed (MyP<object>). Compiled mode reconciles the two via
+        // SymbolRegistryKey (the same open-vs-closed bridge the declared-accessor
+        // path uses, #351) so the expando is found in both modes (#349).
+        var source = """
+            class MyP<T> extends Promise<T> {}
+            (MyP as any)[Symbol.species] = Promise;
+            async function main() {
+                const q = MyP.resolve(1).then(v => v);
+                console.log(q instanceof MyP);
+                console.log(q instanceof Promise);
+                console.log(await q);
+            }
+            main();
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("false\ntrue\n1\n", output);
     }
 
     #endregion


### PR DESCRIPTION
## Summary

Brings compiled-mode `then`/`catch`/`finally` SpeciesConstructor resolution to parity with the interpreter for a **dynamically-assigned static `@@species`** — `(C as any)[Symbol.species] = …` (#262). This is the "also in this class" sub-gap called out in #349.

Previously, compiled `WrapDerivedPromiseResult` resolved `SpeciesConstructor(receiver, %Promise%)` by reading **only** the declared static-accessor registry (`FindSymbolGetterFor`). An expando `@@species` was invisible to it, so a subclass whose species was assigned at runtime kept producing subclass-typed results instead of redirecting — diverging from the interpreter (`ResolveSpeciesConstructor → TryGetStaticBySymbol`).

## Fix

When no declared accessor is found, the emitted method now consults the per-Type symbol-expando dict (`GetSymbolDict`), walking the receiver's runtime type and its base-type chain (#265 inherited expando statics). Each level is keyed through `SymbolRegistryKey` so a generic subclass's **closed** runtime type (`MyP<object>`) reaches the expando stored under its **open** generic definition (`MyP\`1`) — the same open-vs-closed bridge the declared-accessor path already uses (#351).

A found value shares the declared-getter representation (a `Type` token; `Promise` → `typeof(Task<object?>)`), so it flows through the existing SpeciesConstructor tail unchanged. None found keeps the default species (= receiver class). The change only affects the subclass path; plain promises return at the early `$Promise` check, so there's no cost on the common path. Emitted IL passes `--verify`.

## Out of scope (still tracked by #349)

The **general NewPromiseCapability** path — an `@@species` that yields a *non-Promise* constructor — still falls back to `%Promise%` in both modes. While implementing this I confirmed it's a larger effort than the issue's framing suggests: the interpreter's `await` only adopts `SharpTSPromise`/`Task`, not arbitrary thenables, so a non-Promise species result wouldn't behave as a promise downstream even if constructed. Making it meaningful requires thenable adoption in `await` across both modes. Left deferred under #349 (commented there).

## Tests

The previously `InterpretedOnly` expando test is promoted to **both modes** and joined by redirect-to-other-subclass, inherited-through-subclass, and generic-subclass expando cases. Full Promise/Subclass/Symbol/Async suites green.