### PR TITLE
fix(compile): object-slot number locals that may hold undefined (#367)

### DIFF
--- a/Compilation/ILEmitter.Statements.cs
+++ b/Compilation/ILEmitter.Statements.cs
@@ -207,6 +207,15 @@ public partial class ILEmitter
     /// </summary>
     private bool CanUseUnboxedLocal(Stmt.Var v)
     {
+        // #367: a number-typed local that an `any`/`undefined` value may have (transitively) been
+        // assigned must use an object slot — an unboxed double slot would coerce the runtime
+        // `undefined` sentinel to NaN at the store. The type checker flags such declarations (and,
+        // for `const`, the reused initializer expression) in the TypeMap.
+        if (_ctx.TypeMap != null &&
+            (_ctx.TypeMap.IsUndefinedReachableNumericLocal(v) ||
+             (v.Initializer != null && _ctx.TypeMap.IsUndefinedReachableNumericLocal(v.Initializer))))
+            return false;
+
         // Check if this is an optimized for loop counter
         if (_optimizedLoopCounterName != null && v.Name.Lexeme == _optimizedLoopCounterName)
             return true;

--- a/SharpTS.Tests/CompilerTests/ILVerificationTests.cs
+++ b/SharpTS.Tests/CompilerTests/ILVerificationTests.cs
@@ -585,4 +585,120 @@ public class ILVerificationTests
         Assert.Equal("5\n13\nfalse\ntrue\n", output);
         Assert.Equal(output, TestHarness.RunInterpreted(source));
     }
+
+    // #367: a `: number` LOCAL unsoundly assigned `undefined as any` and then returned. The
+    // return expression is statically `number`, so the #344 detection (which keys on the return
+    // value's own type) cannot see it. The taint pass object-slots the local so the unboxed
+    // double slot does not coerce the sentinel to NaN, matching the interpreter (`undefined`).
+    [Fact]
+    public void TypedNumberLocal_HoldingUndefined_ReturnedStaysUndefined()
+    {
+        var source = """
+            function h(n: any): number {
+                let x: number = undefined as any;
+                if (n > 2) x = 42;
+                return x;
+            }
+            console.log(h(1));
+            console.log(h(5));
+            """;
+
+        var (errors, output) = TestHarness.CompileVerifyAndRun(source);
+
+        Assert.Empty(errors);
+        Assert.Equal("undefined\n42\n", output);
+        Assert.Equal(output, TestHarness.RunInterpreted(source));
+    }
+
+    // #367: taint reaches the returned local transitively (`z = y` where `y` holds the sentinel).
+    // The numeric-typed initializer of `z` would otherwise give it an unboxed double slot that
+    // coerces `undefined` to NaN at the store, before the return is even reached.
+    [Fact]
+    public void TypedNumberLocal_TransitiveTaint_StaysUndefined()
+    {
+        var source = """
+            function trans(): number {
+                let y: number = undefined as any;
+                let z: number = y;
+                return z;
+            }
+            console.log(trans());
+            """;
+
+        var (errors, output) = TestHarness.CompileVerifyAndRun(source);
+
+        Assert.Empty(errors);
+        Assert.Equal("undefined\n", output);
+        Assert.Equal(output, TestHarness.RunInterpreted(source));
+    }
+
+    // #367: the taint assignment is lexically AFTER the return that observes it, reachable only
+    // via a loop back-edge. The whole-body taint pass is order-independent, so the earlier return
+    // is still flagged and the local object-slotted.
+    [Fact]
+    public void TypedNumberLocal_LoopBackEdgeTaint_StaysUndefined()
+    {
+        var source = """
+            function loop(n: number): number {
+                let x: number = 0;
+                for (let i = 0; i < n; i++) {
+                    if (i > 0) return x;
+                    x = undefined as any;
+                }
+                return 7;
+            }
+            console.log(loop(2));
+            console.log(loop(0));
+            """;
+
+        var (errors, output) = TestHarness.CompileVerifyAndRun(source);
+
+        Assert.Empty(errors);
+        Assert.Equal("undefined\n7\n", output);
+        Assert.Equal(output, TestHarness.RunInterpreted(source));
+    }
+
+    // #367: the same local-slot corruption inside a class method and getter (their `return`
+    // already uses an object slot, but the unboxed local would coerce the sentinel first).
+    [Fact]
+    public void TypedNumberLocal_InMethodAndGetter_StaysUndefined()
+    {
+        var source = """
+            class C {
+                m(): number { let x: number = 0; x = undefined as any; return x; }
+                get g(): number { let y: number = 1; y = undefined as any; return y; }
+            }
+            const c = new C();
+            console.log(c.m());
+            console.log(c.g);
+            """;
+
+        var (errors, output) = TestHarness.CompileVerifyAndRun(source);
+
+        Assert.Empty(errors);
+        Assert.Equal("undefined\nundefined\n", output);
+        Assert.Equal(output, TestHarness.RunInterpreted(source));
+    }
+
+    // #367 guard: a `: number` local that never receives an `any`/`undefined` value keeps its
+    // sound unboxed double slot and computes correctly — the taint pass must not over-widen.
+    [Fact]
+    public void TypedNumberLocal_SoundBody_StillUsesNumericValue()
+    {
+        var source = """
+            function clean(n: number): number {
+                let x: number = 5;
+                if (n > 2) x = 42;
+                return x + 1;
+            }
+            console.log(clean(1));
+            console.log(clean(10));
+            """;
+
+        var (errors, output) = TestHarness.CompileVerifyAndRun(source);
+
+        Assert.Empty(errors);
+        Assert.Equal("6\n43\n", output);
+        Assert.Equal(output, TestHarness.RunInterpreted(source));
+    }
 }

--- a/TypeSystem/ReturnLocalTaintCollector.cs
+++ b/TypeSystem/ReturnLocalTaintCollector.cs
@@ -1,0 +1,81 @@
+using SharpTS.Parsing;
+using SharpTS.Parsing.Visitors;
+
+namespace SharpTS.TypeSystem;
+
+/// <summary>
+/// Collects, within a single function body and not crossing into a nested function, arrow, or
+/// class, every value assigned to a local — variable/const declarations with an initializer and
+/// plain/logical assignments — together with every <c>return</c> value. Feeds the type checker's
+/// local-taint return analysis (#367): a <c>number</c>/<c>boolean</c>-typed local that is unsoundly
+/// assigned an <c>any</c>/<c>undefined</c> value can hold the runtime <c>undefined</c> sentinel,
+/// which the compiler's unboxed return slot would coerce to <c>NaN</c>/<c>false</c>.
+/// </summary>
+/// <remarks>
+/// Order-independent by design: it gathers the whole body before the checker computes taint to a
+/// fixpoint, so a taint that reaches an earlier return via a loop back-edge is still caught.
+/// </remarks>
+internal sealed class ReturnLocalTaintCollector : AstVisitorBase
+{
+    public List<(string Name, Expr Value)> Assignments { get; } = new();
+    public List<Expr> Returns { get; } = new();
+    /// <summary>Variable/const declarations: the declaration node and (if any) its initializer.</summary>
+    public List<(string Name, Stmt Node, Expr? Initializer)> Declarations { get; } = new();
+
+    public static ReturnLocalTaintCollector Collect(IReadOnlyList<Stmt> body)
+    {
+        var collector = new ReturnLocalTaintCollector();
+        foreach (var stmt in body) collector.Visit(stmt);
+        return collector;
+    }
+
+    protected override void VisitVar(Stmt.Var stmt)
+    {
+        Declarations.Add((stmt.Name.Lexeme, stmt, stmt.Initializer));
+        if (stmt.Initializer != null)
+        {
+            Assignments.Add((stmt.Name.Lexeme, stmt.Initializer));
+            Visit(stmt.Initializer);
+        }
+    }
+
+    protected override void VisitConst(Stmt.Const stmt)
+    {
+        Declarations.Add((stmt.Name.Lexeme, stmt, stmt.Initializer));
+        Assignments.Add((stmt.Name.Lexeme, stmt.Initializer));
+        Visit(stmt.Initializer);
+    }
+
+    protected override void VisitAssign(Expr.Assign expr)
+    {
+        Assignments.Add((expr.Name.Lexeme, expr.Value));
+        Visit(expr.Value);
+    }
+
+    // `x ||= e` / `x &&= e` / `x ??= e` can leave `x` holding `e`'s value (or, for `??=`/`&&=`,
+    // an already-undefined `x`). Treat the right-hand side as a value flowing into the local.
+    protected override void VisitLogicalAssign(Expr.LogicalAssign expr)
+    {
+        Assignments.Add((expr.Name.Lexeme, expr.Value));
+        Visit(expr.Value);
+    }
+
+    protected override void VisitReturn(Stmt.Return stmt)
+    {
+        if (stmt.Value != null)
+        {
+            Returns.Add(stmt.Value);
+            Visit(stmt.Value);
+        }
+    }
+
+    // Nested function, arrow, and class bodies own their own return slot and are analyzed
+    // independently when each is type-checked — do not descend into them here.
+    protected override void VisitFunction(Stmt.Function stmt) { }
+    protected override void VisitArrowFunction(Expr.ArrowFunction expr) { }
+    protected override void VisitClass(Stmt.Class stmt) { }
+    protected override void VisitClassExpr(Expr.ClassExpr expr) { }
+    protected override void VisitAccessor(Stmt.Accessor stmt) { }
+    protected override void VisitStaticBlock(Stmt.StaticBlock stmt) { }
+    protected override void VisitField(Stmt.Field stmt) { }
+}

--- a/TypeSystem/TypeChecker.Expressions.cs
+++ b/TypeSystem/TypeChecker.Expressions.cs
@@ -1260,6 +1260,12 @@ public partial class TypeChecker
                 // Block body - check statements
                 CheckStmtList(arrow.BlockBody);
 
+                // #367: flag returns of a number/boolean-typed local left holding the undefined
+                // sentinel by an `any`/`undefined` assignment (no-op unless the declared return is
+                // number/boolean). Expression-bodied arrows have no local-assignment-then-return
+                // shape, so only block bodies need this.
+                MarkUndefinedReachableLocalReturns(arrow.BlockBody);
+
                 // Resolve inferred return type for block-body arrows
                 if (inferringArrowReturn)
                 {
@@ -1805,6 +1811,9 @@ public partial class TypeChecker
                     {
                         foreach (var bodyStmt in method.Body)
                             CheckStmt(bodyStmt);
+
+                        // #367: object-slot number-typed locals that may hold the undefined sentinel.
+                        MarkUndefinedReachableLocalReturns(method.Body);
                     }
                 }
                 finally
@@ -1862,6 +1871,9 @@ public partial class TypeChecker
                     {
                         foreach (var bodyStmt in accessor.Body)
                             CheckStmt(bodyStmt);
+
+                        // #367: object-slot number-typed locals that may hold the undefined sentinel.
+                        MarkUndefinedReachableLocalReturns(accessor.Body);
                     }
                     finally
                     {

--- a/TypeSystem/TypeChecker.Statements.Classes.cs
+++ b/TypeSystem/TypeChecker.Statements.Classes.cs
@@ -717,6 +717,10 @@ public partial class TypeChecker
                     if (method.Body != null)
                     {
                         CheckStmtList(method.Body);
+
+                        // #367: object-slot number-typed locals that an `any`/`undefined` value may
+                        // have left holding the sentinel, so a `return x` is not coerced to NaN.
+                        MarkUndefinedReachableLocalReturns(method.Body);
                     }
 
                     // Resolve inferred method return type
@@ -832,6 +836,9 @@ public partial class TypeChecker
                     try
                     {
                         CheckStmtList(accessor.Body);
+
+                        // #367: object-slot number-typed locals that may hold the undefined sentinel.
+                        MarkUndefinedReachableLocalReturns(accessor.Body);
                     }
                     finally
                     {

--- a/TypeSystem/TypeChecker.Statements.Functions.cs
+++ b/TypeSystem/TypeChecker.Statements.Functions.cs
@@ -548,6 +548,11 @@ public partial class TypeChecker
 
             CheckStmtList(funcStmt.Body);
 
+            // #367: flag returns of a number/boolean-typed local that an `any`/`undefined`
+            // assignment may have left holding the undefined sentinel (no-op unless the declared
+            // return is number/boolean). Runs after the body so every sub-expression type is known.
+            MarkUndefinedReachableLocalReturns(funcStmt.Body);
+
             // Resolve inferred return type from collected return expressions
             if (inferringReturnType)
             {

--- a/TypeSystem/TypeChecker.Statements.cs
+++ b/TypeSystem/TypeChecker.Statements.cs
@@ -405,6 +405,9 @@ public partial class TypeChecker
             _typeMap.MarkUndefinedReachableReturn(value);
     }
 
+    private bool ReturnValueMayBeUndefinedSentinel(Expr value) =>
+        ValueMayBeUndefinedSentinel(value, taintedLocals: null);
+
     /// <summary>
     /// True if <paramref name="value"/> can evaluate to a runtime value of static type
     /// <c>any</c>/<c>unknown</c> (which therefore can be the <c>undefined</c> sentinel). Recurses
@@ -414,14 +417,25 @@ public partial class TypeChecker
     /// the <see cref="TypeMap"/>, which has every sub-expression recorded by the time a return is
     /// checked. Over-approximates (both ternary branches), which is sound: at worst a function that
     /// could never produce <c>undefined</c> keeps an object slot.
+    /// <para>
+    /// When <paramref name="taintedLocals"/> is supplied (#367), a leaf reference to one of those
+    /// locals also counts: a <c>number</c>/<c>boolean</c>-typed local statically reports its narrow
+    /// type at a <c>return</c>, hiding that an earlier <c>any</c>/<c>undefined</c> assignment left it
+    /// holding the sentinel. The same predicate grows the taint set (transitive assignments) and
+    /// flags the returns, so both stay in lock-step.
+    /// </para>
     /// </summary>
-    private bool ReturnValueMayBeUndefinedSentinel(Expr value) => value switch
+    private bool ValueMayBeUndefinedSentinel(Expr value, HashSet<string>? taintedLocals) => value switch
     {
-        Expr.Grouping g => ReturnValueMayBeUndefinedSentinel(g.Expression),
-        Expr.Ternary t => ReturnValueMayBeUndefinedSentinel(t.ThenBranch)
-                       || ReturnValueMayBeUndefinedSentinel(t.ElseBranch),
-        Expr.Logical l => ReturnValueMayBeUndefinedSentinel(l.Left)
-                       || ReturnValueMayBeUndefinedSentinel(l.Right),
+        Expr.Grouping g => ValueMayBeUndefinedSentinel(g.Expression, taintedLocals),
+        Expr.Ternary t => ValueMayBeUndefinedSentinel(t.ThenBranch, taintedLocals)
+                       || ValueMayBeUndefinedSentinel(t.ElseBranch, taintedLocals),
+        Expr.Logical l => ValueMayBeUndefinedSentinel(l.Left, taintedLocals)
+                       || ValueMayBeUndefinedSentinel(l.Right, taintedLocals),
+        Expr.NullishCoalescing n => ValueMayBeUndefinedSentinel(n.Left, taintedLocals)
+                                 || ValueMayBeUndefinedSentinel(n.Right, taintedLocals),
+        Expr.Assign a => ValueMayBeUndefinedSentinel(a.Value, taintedLocals),
+        Expr.Variable v when taintedLocals != null && taintedLocals.Contains(v.Name.Lexeme) => true,
         _ => TypeAdmitsUndefinedSentinel(_typeMap.Get(value))
     };
 
@@ -431,6 +445,68 @@ public partial class TypeChecker
         TypeInfo.Union u => u.Types.Any(TypeAdmitsUndefinedSentinel),
         _ => false
     };
+
+    /// <summary>
+    /// #367 residual of #344: a <c>number</c>/<c>boolean</c>-typed <em>local</em> can be unsoundly
+    /// assigned an <c>any</c>/<c>undefined</c> value (e.g. <c>let x: number = undefined as any</c>)
+    /// and so hold the runtime <c>undefined</c> sentinel — yet <c>return x</c> has static type
+    /// <c>number</c>/<c>boolean</c>, so the per-return #344 detection (which keys on the return
+    /// value's own type being <c>any</c>/<c>unknown</c>) never fires and the compiler's unboxed
+    /// slot coerces it to <c>NaN</c>/<c>false</c>. Run a whole-body taint pass <em>after</em> the
+    /// body is type-checked (every sub-expression's type is then in the <see cref="TypeMap"/>):
+    /// compute the set of locals that may hold the sentinel to a fixpoint — seeded by direct
+    /// <c>any</c>/<c>undefined</c> assignments and grown transitively through other tainted locals —
+    /// then flag any <c>return</c> of such a local so the compiler widens the slot back to object.
+    /// Order-independent, so a taint reaching an earlier return via a loop back-edge is still
+    /// caught. Over-approximates (no narrowing): at worst a needless object slot, never a wrong
+    /// value. Only meaningful when the declared return is <c>number</c>/<c>boolean</c> — methods,
+    /// async, and inferred-return functions already use an object slot, so they cannot corrupt.
+    /// </summary>
+    private void MarkUndefinedReachableLocalReturns(IReadOnlyList<Stmt> body)
+    {
+        TypeInfo? declared = _currentFunctionReturnType;
+        if (_inAsyncFunction && declared is TypeInfo.Promise promised) declared = promised.ValueType;
+        if (declared is not TypeInfo.Primitive { Type: TokenType.TYPE_NUMBER or TokenType.TYPE_BOOLEAN })
+            return;
+
+        var collected = ReturnLocalTaintCollector.Collect(body);
+        if (collected.Returns.Count == 0 || collected.Assignments.Count == 0) return;
+
+        var tainted = new HashSet<string>();
+        bool changed = true;
+        while (changed)
+        {
+            changed = false;
+            foreach (var (name, assignedValue) in collected.Assignments)
+            {
+                if (tainted.Contains(name)) continue;
+                if (ValueMayBeUndefinedSentinel(assignedValue, tainted))
+                {
+                    tainted.Add(name);
+                    changed = true;
+                }
+            }
+        }
+        if (tainted.Count == 0) return;
+
+        // Local slot: object-slot every tainted number-typed local so its declaration does not get
+        // an unboxed double slot that would coerce the sentinel to NaN at the store (e.g. the
+        // intermediate `z` in `let y = undefined as any; let z = y; return z`). Both the declaration
+        // node and its initializer are flagged — `const` is recompiled through a fresh Stmt.Var that
+        // reuses the original initializer expression.
+        foreach (var (name, node, initializer) in collected.Declarations)
+        {
+            if (!tainted.Contains(name)) continue;
+            _typeMap.MarkUndefinedReachableNumericLocal(node);
+            if (initializer != null) _typeMap.MarkUndefinedReachableNumericLocal(initializer);
+        }
+
+        // Return slot: flag returns of a tainted local so the compiler widens the otherwise-unboxed
+        // double/bool return slot back to object.
+        foreach (var ret in collected.Returns)
+            if (ValueMayBeUndefinedSentinel(ret, tainted))
+                _typeMap.MarkUndefinedReachableReturn(ret);
+    }
 
     internal VoidResult VisitExpression(Stmt.Expression stmt)
     {

--- a/TypeSystem/TypeMap.cs
+++ b/TypeSystem/TypeMap.cs
@@ -18,6 +18,7 @@ public class TypeMap
     private readonly Dictionary<string, TypeInfo.Function> _functionTypes = new(StringComparer.Ordinal);
     private readonly Dictionary<Expr.ClassExpr, TypeInfo.Class> _classExprTypes = new(ReferenceEqualityComparer.Instance);
     private readonly HashSet<Expr> _undefinedReachableReturns = new(ReferenceEqualityComparer.Instance);
+    private readonly HashSet<object> _undefinedReachableNumericLocals = new(ReferenceEqualityComparer.Instance);
 
     /// <summary>
     /// Associates an expression with its resolved type.
@@ -70,6 +71,26 @@ public class TypeMap
     /// <see cref="MarkUndefinedReachableReturn"/>.
     /// </summary>
     public bool IsUndefinedReachableReturn(Expr returnValue) => _undefinedReachableReturns.Contains(returnValue);
+
+    /// <summary>
+    /// Flags a <c>number</c>-typed local variable declaration whose value may be the runtime
+    /// <c>undefined</c> sentinel because an <c>any</c>/<c>undefined</c> value was (transitively)
+    /// assigned to it (#367). Without this the IL compiler would give the local an unboxed
+    /// <c>double</c> slot, coercing the sentinel to <c>NaN</c> at the store — so it must use an
+    /// object slot instead. Keyed by reference, by either the declaration <see cref="Stmt"/> node
+    /// or its initializer <see cref="Expr"/> (the compiler synthesizes a fresh <c>Stmt.Var</c> for
+    /// <c>const</c> but reuses the original initializer expression, so both are recorded). Purely a
+    /// compiler hint — caller-side type checking still sees the clean <c>number</c> type.
+    /// </summary>
+    public void MarkUndefinedReachableNumericLocal(object declOrInitializer) =>
+        _undefinedReachableNumericLocals.Add(declOrInitializer);
+
+    /// <summary>
+    /// True if <paramref name="declOrInitializer"/> was flagged by
+    /// <see cref="MarkUndefinedReachableNumericLocal"/>.
+    /// </summary>
+    public bool IsUndefinedReachableNumericLocal(object declOrInitializer) =>
+        _undefinedReachableNumericLocals.Contains(declOrInitializer);
 
     /// <summary>
     /// Gets the resolved type for an expression, or null if not found.


### PR DESCRIPTION
## Summary

Closes #367 — the residual of #344 where a `number`/`boolean`-typed **local** unsoundly assigned an `any`/`undefined` value, then returned, compiled to `NaN`/`false` instead of `undefined`.

`#344` fixed the case where the *return value's own* static type is `any`/`unknown`. This one is invisible to that detection: `return x` where `x: number` is statically `number`. Two distinct slots corrupt the sentinel:

1. The **local's** unboxed `double` slot coerces `undefined`→`NaN` at the *store* (`let x: number = 0; x = undefined as any`).
2. The **return** slot coerces it again (already handled by the #344 `ReturnSlotAnalysis` seam).

## Approach

After a function/arrow/method/accessor body with a `number`/`boolean` return is type-checked (so every sub-expression type is in the `TypeMap`), run an order-independent taint pass (`ReturnLocalTaintCollector` + a fixpoint in `MarkUndefinedReachableLocalReturns`):

- Compute the set of locals that may hold the sentinel — seeded by direct `any`/`undefined` assignments, grown transitively through other tainted locals (`let z: number = y`).
- **Flag returns** of a tainted local → the compiler widens the return slot to `object`.
- **Flag the tainted locals' declarations** → `CanUseUnboxedLocal` gives them an `object` slot instead of an unboxed `double`.

Order-independent, so a taint reaching an earlier return via a **loop back-edge** is still caught. Over-approximate (no narrowing): at worst a needless object slot, never a wrong value. Clean number locals keep their sound unboxed `double` slot (verified by a guard test). The reused `ValueMayBeUndefinedSentinel` predicate already recurses through grouping/ternary/`||`/`&&` pass-throughs; this PR also adds the missing `??` (`NullishCoalescing`) case.

## Tests

5 new cases in `ILVerificationTests` (each asserts compiled IL verifies, runs correctly, and matches the interpreter): local-with-any-init, transitive taint, loop back-edge, method+getter, and a sound-body guard. Full suite: **11137 passed, 0 failed**.

## Out of scope (filed as follow-up)

The same unboxed-`double`-slot root cause also corrupts: inferred-return functions, non-return observations (`console.log`/arithmetic in void functions), and reassigned `number` parameters. These are outside #367's return scope — filed separately.