### PR TITLE
fix(compile+interp): bypass bigint-arithmetic path for instanceof/in (#361)

### DIFF
--- a/Compilation/ILEmitter.Operators.cs
+++ b/Compilation/ILEmitter.Operators.cs
@@ -17,8 +17,9 @@ public partial class ILEmitter
         if (TryEmitConstantFolded(b))
             return;
 
-        // Check for bigint operations first
-        if (IsBigIntOperation(b))
+        // instanceof/in are valid with any operand type — bypass bigint-arithmetic path
+        // so a bigint LHS gets boxed and flows through the normal InstanceOf/HasIn runtime call.
+        if (IsBigIntOperation(b) && b.Operator.Type is not (TokenType.IN or TokenType.INSTANCEOF))
         {
             EmitBigIntBinary(b);
             return;

--- a/Execution/Interpreter.Calls.cs
+++ b/Execution/Interpreter.Calls.cs
@@ -485,13 +485,18 @@ public partial class Interpreter
     /// </summary>
     private RuntimeValue EvaluateBinaryOperationRV(Token op, RuntimeValue leftRV, RuntimeValue rightRV)
     {
-        // Check for BigInt (Kind == BigInt, not Object)
-        System.Numerics.BigInteger? leftBigInt = leftRV.IsBigInt ? leftRV.AsBigInt().Value : null;
-        System.Numerics.BigInteger? rightBigInt = rightRV.IsBigInt ? rightRV.AsBigInt().Value : null;
-
-        if (leftBigInt.HasValue || rightBigInt.HasValue)
+        // instanceof/in are valid with any operand — fall through to the normal path below
+        // so a bigint operand gets unboxed to object and reaches EvaluateInstanceof/EvaluateIn.
+        if (op.Type is not (TokenType.INSTANCEOF or TokenType.IN))
         {
-            return EvaluateBigIntBinaryRV(op.Type, leftRV, rightRV, leftBigInt, rightBigInt);
+            // Check for BigInt (Kind == BigInt, not Object)
+            System.Numerics.BigInteger? leftBigInt = leftRV.IsBigInt ? leftRV.AsBigInt().Value : null;
+            System.Numerics.BigInteger? rightBigInt = rightRV.IsBigInt ? rightRV.AsBigInt().Value : null;
+
+            if (leftBigInt.HasValue || rightBigInt.HasValue)
+            {
+                return EvaluateBigIntBinaryRV(op.Type, leftRV, rightRV, leftBigInt, rightBigInt);
+            }
         }
 
         object? left = leftRV.ToObject();

--- a/SharpTS.Tests/SharedTests/BigIntTests.cs
+++ b/SharpTS.Tests/SharedTests/BigIntTests.cs
@@ -458,4 +458,34 @@ public class BigIntTests
     }
 
     #endregion
+
+    #region Instanceof Tests
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void BigInt_InstanceOf_Object_IsFalse(ExecutionMode mode)
+    {
+        // bigint is a primitive; instanceof must return false, not throw a
+        // compile error. Compiled mode previously rejected INSTANCEOF in the
+        // bigint-arithmetic path (#361).
+        var source = """
+            console.log((10n) instanceof Object);
+            """;
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("false\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void BigInt_InstanceOf_UserClass_IsFalse(ExecutionMode mode)
+    {
+        var source = """
+            class Foo {}
+            console.log((42n) instanceof Foo);
+            """;
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("false\n", output);
+    }
+
+    #endregion
 }


### PR DESCRIPTION
## Summary

- `instanceof` and `in` are valid with any LHS operand type but were routed through the bigint-arithmetic dispatch when the LHS (or RHS) was typed as `bigint`, causing a compile error (`Unsupported bigint operator: INSTANCEOF`) in compiled mode and a runtime error (`Cannot mix bigint and other types in operations`) in interpreted mode.
- Fix: guard the bigint-arithmetic branch in both the IL emitter and the interpreter's `EvaluateBinaryOperationRV` to skip it for `INSTANCEOF` and `IN` operators, so a bigint operand gets boxed/unboxed normally and reaches `$Runtime.InstanceOf` / `EvaluateInstanceof`.
- `10n instanceof Object` now correctly returns `false` in both modes (bigint is a primitive; ECMA-262 OrdinaryHasInstance short-circuits on non-objects).

## Files changed

- `Compilation/ILEmitter.Operators.cs` — add `b.Operator.Type is not (IN or INSTANCEOF)` guard before `EmitBigIntBinary`
- `Execution/Interpreter.Calls.cs` — wrap bigint-detection block in `EvaluateBinaryOperationRV` with the same guard
- `SharpTS.Tests/SharedTests/BigIntTests.cs` — add `BigInt_InstanceOf_Object_IsFalse` and `BigInt_InstanceOf_UserClass_IsFalse` (both modes)

## Test plan
- [ ] `BigInt_InstanceOf_Object_IsFalse` passes (Interpreted + Compiled)
- [ ] `BigInt_InstanceOf_UserClass_IsFalse` passes (Interpreted + Compiled)
- [ ] Full suite: 11141/11141 pass, no regressions

Closes #361