### PR TITLE
fix(type-checker): carry first-seen nested var annotation onto hoisted synthetic declaration (#363)

### DIFF
--- a/Parsing/VarHoister.cs
+++ b/Parsing/VarHoister.cs
@@ -48,7 +48,7 @@ public static class VarHoister
     /// </summary>
     public static List<Stmt> Hoist(List<Stmt> body)
     {
-        var collected = new List<Token>();
+        var collected = new List<(Token Name, string? TypeAnnotation, TypeNode? TypeAnnotationNode)>();
         var seen = new HashSet<string>(StringComparer.Ordinal);
         var rewritten = new List<Stmt>(body.Count);
         bool changed = false;
@@ -65,10 +65,12 @@ public static class VarHoister
         }
 
         // Prepend synthetic `var name;` declarations for each unique hoisted name.
+        // Carry the first-seen annotation so the type checker can detect TS2403 when a
+        // later declaration uses a different annotation (e.g. nested string then top-level number).
         var result = new List<Stmt>(collected.Count + rewritten.Count);
-        foreach (var nameToken in collected)
+        foreach (var (nameToken, typeAnnotation, typeAnnotationNode) in collected)
         {
-            result.Add(new Stmt.Var(nameToken, TypeAnnotation: null, Initializer: null, HasDefiniteAssignmentAssertion: false, IsVar: true));
+            result.Add(new Stmt.Var(nameToken, TypeAnnotation: typeAnnotation, TypeAnnotationNode: typeAnnotationNode, Initializer: null, HasDefiniteAssignmentAssertion: false, IsVar: true));
         }
         result.AddRange(rewritten);
         return result;
@@ -81,7 +83,7 @@ public static class VarHoister
     /// <param name="isTopLevel">True if this statement is directly inside the function/module
     /// body. Top-level vars are still rewritten to assignments (so the synthetic declarations
     /// at the top can hold the binding) but they appear in the same source-order position.</param>
-    private static Stmt RewriteAndCollect(Stmt stmt, List<Token> collected, HashSet<string> seen, bool isTopLevel, ref bool changed)
+    private static Stmt RewriteAndCollect(Stmt stmt, List<(Token Name, string? TypeAnnotation, TypeNode? TypeAnnotationNode)> collected, HashSet<string> seen, bool isTopLevel, ref bool changed)
     {
         switch (stmt)
         {
@@ -106,7 +108,7 @@ public static class VarHoister
 
                 if (seen.Add(v.Name.Lexeme))
                 {
-                    collected.Add(v.Name);
+                    collected.Add((v.Name, v.TypeAnnotation, v.TypeAnnotationNode));
                 }
                 changed = true;
                 if (v.Initializer == null)
@@ -315,7 +317,7 @@ public static class VarHoister
     /// Helper for rewriting a list of statements (used by TryCatch/Switch which carry
     /// <c>List&lt;Stmt&gt;</c> directly rather than wrapping in a Block).
     /// </summary>
-    private static List<Stmt> RewriteList(List<Stmt> list, List<Token> collected, HashSet<string> seen, ref bool changed)
+    private static List<Stmt> RewriteList(List<Stmt> list, List<(Token Name, string? TypeAnnotation, TypeNode? TypeAnnotationNode)> collected, HashSet<string> seen, ref bool changed)
     {
         var result = new List<Stmt>(list.Count);
         foreach (var s in list)

--- a/SharpTS.Tests/TypeCheckerTests/Round3ConformanceTests.cs
+++ b/SharpTS.Tests/TypeCheckerTests/Round3ConformanceTests.cs
@@ -141,6 +141,65 @@ public class Round3ConformanceTests
         Assert.Equal("TS2403", ex.Diagnostic.TsCode);
     }
 
+    // ── Issue #363: nested-first var declaration loses annotation to hoisting ──────────────────────
+
+    [Fact]
+    public void VarRedeclaration_NestedFirstAnnotation_DifferentType_IsTs2403Error()
+    {
+        // Issue #363: when the FIRST var declaration is inside a nested block, VarHoister
+        // previously dropped its annotation when synthesizing the hoisted `var name;`, making
+        // the baseline type `any` and silencing TS2403 for any top-level redeclaration.
+        var source = """
+            function h() {
+                if (true) { var z: string; }
+                var z: number;
+            }
+            """;
+        var ex = Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+        Assert.Equal("TS2403", ex.Diagnostic.TsCode);
+    }
+
+    [Fact]
+    public void VarRedeclaration_NestedFirstAnnotation_SameType_IsAccepted()
+    {
+        var source = """
+            function h() {
+                if (true) { var z: string; }
+                var z: string;
+            }
+            """;
+        TestHarness.RunInterpreted(source);
+    }
+
+    [Fact]
+    public void VarRedeclaration_NestedFirstWithInitializer_DifferentTopLevelType_IsTs2403Error()
+    {
+        // The annotation on the first nested declaration is carried to the synthetic hoisted var,
+        // so a top-level re-declaration with an incompatible initializer type still fires TS2403.
+        var source = """
+            function h() {
+                if (true) { var z: string = "hello"; }
+                var z: number;
+            }
+            """;
+        var ex = Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+        Assert.Equal("TS2403", ex.Diagnostic.TsCode);
+    }
+
+    [Fact]
+    public void VarRedeclaration_MultipleNestedAnnotations_SecondDiffers_IsTs2403Error()
+    {
+        // Two nested declarations conflict with each other; the second nested one fires TS2403.
+        var source = """
+            function h() {
+                if (true) { var z: string; }
+                if (false) { var z: number; }
+            }
+            """;
+        var ex = Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+        Assert.Equal("TS2403", ex.Diagnostic.TsCode);
+    }
+
     [Fact]
     public void VarShadowing_InNestedFunction_IsNotRedeclaration()
     {


### PR DESCRIPTION
## Summary

- **Root cause:** `VarHoister` collected only the `Token` (name) when a nested block's `var` was the first occurrence of that name. The synthetic `var name;` prepended at function scope had `TypeAnnotation: null`, so the declared type was `any`. The `CheckAssign` redeclaration check exits early when `declaredType is Any`, silencing TS2403 for any subsequent redeclaration.
- **Fix:** Widen `collected` from `List<Token>` to `List<(Token Name, string? TypeAnnotation, TypeNode? TypeAnnotationNode)>` and carry the first-seen annotation onto the synthetic hoisted declaration. The type checker's existing TS2403 path then fires correctly.
- **No emitter changes needed:** the synthetic `var` is processed through the normal `Stmt.Var` path in both the interpreter and IL compiler.

## Test plan

- [ ] `VarRedeclaration_NestedFirstAnnotation_DifferentType_IsTs2403Error` — exact repro from #363
- [ ] `VarRedeclaration_NestedFirstAnnotation_SameType_IsAccepted` — same type must not error
- [ ] `VarRedeclaration_NestedFirstWithInitializer_DifferentTopLevelType_IsTs2403Error` — annotation on first nested decl + incompatible top-level redecl
- [ ] `VarRedeclaration_MultipleNestedAnnotations_SecondDiffers_IsTs2403Error` — two conflicting nested declarations
- [ ] All 818 existing `TypeChecker` tests pass
- [ ] All 25 `CliVarTests` pass
- [ ] All 7 `VarHoistingTypeCheckTests` pass

Closes #363