### PR TITLE
fix(interp): new Number/String/Boolean return boxed wrapper objects (#360)

### DIFF
--- a/Execution/Interpreter.Calls.cs
+++ b/Execution/Interpreter.Calls.cs
@@ -761,6 +761,12 @@ public partial class Interpreter
         _ => true,
     };
 
+    private static bool IsBoxedPrimitiveOfType(object? value, string typeTag) =>
+        value is SharpTSObject obj
+        && obj.HasProperty("__primitiveType")
+        && obj.GetProperty("__primitiveType") is string pt
+        && pt == typeTag;
+
     private object EvaluateInstanceof(object? left, object? right)
     {
         // `x instanceof Object` — the `Object` global resolves to the namespace
@@ -770,6 +776,17 @@ public partial class Interpreter
         // ordinary object's prototype chain (#334).
         if (right is SharpTSObjectNamespace)
             return IsJsObject(left);
+
+        // `x instanceof Number/String/Boolean` — the RHS resolves to the namespace
+        // singleton. A boxed wrapper produced by `new Number/String/Boolean` has
+        // a __primitiveType marker; primitive values (bare doubles, strings, bools)
+        // are NOT instances per ECMA-262 §20.3.3.3 / §21.1.3 / §22.1.3.
+        if (right is SharpTSNumberNamespace)
+            return IsBoxedPrimitiveOfType(left, "Number");
+        if (right is SharpTSStringNamespace)
+            return IsBoxedPrimitiveOfType(left, "String");
+        if (right is SharpTSBooleanNamespace)
+            return IsBoxedPrimitiveOfType(left, "Boolean");
 
         // Bare-value constructors for the built-in binary types (ArrayBuffer,
         // SharedArrayBuffer, DataView, typed arrays) are plain ISharpTSCallables,

--- a/Execution/Interpreter.Properties.cs
+++ b/Execution/Interpreter.Properties.cs
@@ -865,6 +865,20 @@ public partial class Interpreter
             current = next;
         }
 
+        // Boxed primitive method dispatch: `(new Number(5)).toFixed(2)` etc.
+        // Delegate through to the underlying primitive value's built-in methods.
+        if (simpleObj.HasProperty("__primitiveType")
+            && simpleObj.GetProperty("__primitiveType") is string _
+            && simpleObj.HasProperty("__primitiveValue"))
+        {
+            var pv = simpleObj.GetProperty("__primitiveValue");
+            if (pv != null)
+            {
+                var dispatched = BuiltInRegistry.Instance.GetInstanceMember(pv, memberName);
+                if (dispatched != null) return dispatched;
+            }
+        }
+
         // Final fallback: inherited Object.prototype methods (see the RV
         // overload for rationale). Excluded for null-prototype objects.
         if (!simpleObj.IsNullPrototype
@@ -940,6 +954,20 @@ public partial class Interpreter
                 break;
             }
             break;
+        }
+
+        // Boxed primitive method dispatch: `(new Number(5)).toFixed(2)` etc.
+        // Delegate through to the underlying primitive value's built-in methods.
+        if (simpleObj.HasProperty("__primitiveType")
+            && simpleObj.GetProperty("__primitiveType") is string _
+            && simpleObj.HasProperty("__primitiveValue"))
+        {
+            var pv = simpleObj.GetProperty("__primitiveValue");
+            if (pv != null)
+            {
+                var dispatched = BuiltInRegistry.Instance.GetInstanceMember(pv, memberName);
+                if (dispatched != null) return RuntimeValue.FromBoxed(dispatched);
+            }
         }
 
         // ECMA-262: every ORDINARY object inherits Object.prototype's methods

--- a/Runtime/BuiltIns/BuiltInConstructorFactory.cs
+++ b/Runtime/BuiltIns/BuiltInConstructorFactory.cs
@@ -1,3 +1,5 @@
+using System.Globalization;
+using SharpTS.Compilation;
 using SharpTS.Execution;
 using SharpTS.Runtime.Types;
 
@@ -80,7 +82,8 @@ public static class BuiltInConstructorFactory
         name == BuiltInNames.BroadcastChannel ||
         name == BuiltInNames.ReadableStream ||
         name == BuiltInNames.WritableStream ||
-        name == BuiltInNames.TransformStream;
+        name == BuiltInNames.TransformStream ||
+        name == "Number" || name == "String" || name == "Boolean";
         // Note: Error types are NOT handled here — they go through SharpTSErrorClass
         // registered in Interpreter.CreateGlobalsLookup()
 
@@ -107,6 +110,13 @@ public static class BuiltInConstructorFactory
         {
             return RegExpBuiltIns.ConstructRegExp(interpreter, args, isCallForm: false);
         }
+
+        // Primitive wrapper constructors: `new Number(x)`, `new String(x)`, `new Boolean(x)`
+        // return boxed SharpTSObjects with __primitiveType / __primitiveValue markers,
+        // matching compiled-mode behaviour so typeof is "object" and instanceof works.
+        if (name == "Number") return CreateBoxedNumber(args);
+        if (name == "String") return CreateBoxedString(args);
+        if (name == "Boolean") return CreateBoxedBoolean(args);
 
         // Check simple constructors first
         if (_simpleConstructors.TryGetValue(name, out var handler))
@@ -302,6 +312,87 @@ public static class BuiltInConstructorFactory
         var body = args.Count > 0 ? args[0] : null;
         var init = args.Count > 1 ? args[1] as SharpTSObject : null;
         return new SharpTSResponse(body, init);
+    }
+
+    // ── Boxed primitive wrapper constructors ─────────────────────────────────
+
+    /// <summary>
+    /// <c>new Number(x)</c>: ECMA-262 §21.1.2. Returns a <c>SharpTSObject</c>
+    /// wrapper with <c>__primitiveType="Number"</c> and <c>__primitiveValue</c>
+    /// holding the ToNumber-coerced argument.
+    /// </summary>
+    private static SharpTSObject CreateBoxedNumber(IReadOnlyList<object?> args)
+    {
+        var arg = args.Count > 0 ? args[0] : null;
+        double value = arg switch
+        {
+            double d => d,
+            null => 0.0,
+            SharpTSUndefined => double.NaN,
+            bool b => b ? 1.0 : 0.0,
+            string s => ParseNumberFromString(s),
+            _ => double.NaN,
+        };
+        return new SharpTSObject(new Dictionary<string, object?>
+        {
+            ["__primitiveType"] = "Number",
+            ["__primitiveValue"] = value,
+        });
+    }
+
+    /// <summary>
+    /// <c>new String(x)</c>: ECMA-262 §22.1.2. Returns a <c>SharpTSObject</c>
+    /// String exotic wrapper with <c>__primitiveType="String"</c>,
+    /// <c>__primitiveValue</c>, a <c>length</c> slot, and indexed character slots.
+    /// </summary>
+    private static SharpTSObject CreateBoxedString(IReadOnlyList<object?> args)
+    {
+        var arg = args.Count > 0 ? args[0] : null;
+        string value = arg switch
+        {
+            null => "null",
+            SharpTSUndefined => "undefined",
+            bool b => b ? "true" : "false",
+            double d => RuntimeTypes.Stringify(d),
+            string s => s,
+            SharpTSArray arr => arr.ToString()!,
+            _ => arg.ToString() ?? "",
+        };
+        var dict = new Dictionary<string, object?>
+        {
+            ["__primitiveType"] = "String",
+            ["__primitiveValue"] = value,
+            ["length"] = (double)value.Length,
+        };
+        for (int i = 0; i < value.Length; i++)
+            dict[i.ToString()] = value[i].ToString();
+        return new SharpTSObject(dict);
+    }
+
+    /// <summary>
+    /// <c>new Boolean(x)</c>: ECMA-262 §20.4.2. Returns a <c>SharpTSObject</c>
+    /// wrapper with <c>__primitiveType="Boolean"</c> and the ToBoolean-coerced value.
+    /// </summary>
+    private static SharpTSObject CreateBoxedBoolean(IReadOnlyList<object?> args)
+    {
+        var arg = args.Count > 0 ? args[0] : null;
+        bool value = RuntimeTypes.IsTruthy(arg);
+        return new SharpTSObject(new Dictionary<string, object?>
+        {
+            ["__primitiveType"] = "Boolean",
+            ["__primitiveValue"] = value,
+        });
+    }
+
+    private static double ParseNumberFromString(string s)
+    {
+        s = s.Trim();
+        if (s.Length == 0) return 0.0;
+        if (s == "Infinity" || s == "+Infinity") return double.PositiveInfinity;
+        if (s == "-Infinity") return double.NegativeInfinity;
+        if (s.Contains("infinity", StringComparison.OrdinalIgnoreCase)) return double.NaN;
+        if (double.TryParse(s, NumberStyles.Float, CultureInfo.InvariantCulture, out double d)) return d;
+        return double.NaN;
     }
 
     #endregion

--- a/Runtime/Types/SharpTSPrimitiveNamespaces.cs
+++ b/Runtime/Types/SharpTSPrimitiveNamespaces.cs
@@ -110,16 +110,19 @@ internal sealed class StringPrototypeMethodWrapper : ISharpTSCallable
     /// <summary>
     /// ECMA-262 ToString abstract operation — mapped to the receiver types
     /// our interpreter actually hands to string methods. Symbols throw
-    /// TypeError per spec (ToString(Symbol) is an abrupt completion). Wrapper
-    /// objects (<c>new Number(1)</c>, <c>new Boolean(true)</c>) aren't yet
-    /// wrappers here, so non-primitive/non-Symbol receivers fall through to
-    /// <c>Object.prototype.toString</c> (lossy but adequate for Test262).
+    /// TypeError per spec (ToString(Symbol) is an abrupt completion).
     /// </summary>
     private static string CoerceToString(object? receiver)
     {
         if (receiver is SharpTSSymbol)
             throw new ThrowException(new SharpTSTypeError(
                 "Cannot convert a Symbol value to a string"));
+        // Unwrap boxed String wrapper: `new String("x")` stores the primitive
+        // in __primitiveValue so String.prototype methods work on the wrapper.
+        if (receiver is SharpTSObject obj
+            && obj.GetProperty("__primitiveType") is string pt && pt == "String"
+            && obj.GetProperty("__primitiveValue") is string sv)
+            return sv;
         return receiver switch
         {
             string s => s,
@@ -208,9 +211,8 @@ public sealed class SharpTSNumberPrototype
 /// <summary>
 /// Adapter around a Number <see cref="BuiltInMethod"/>. Throws TypeError on
 /// non-number receivers per ECMA-262 (Number.prototype.toString and friends
-/// require <c>thisNumberValue</c>); plain numbers and bool/null aren't valid
-/// either. Wrapper objects (<c>new Number(1)</c>) aren't real wrappers in
-/// this interpreter, so this stays strict.
+/// require <c>thisNumberValue</c>). Accepts boxed Number wrappers produced by
+/// <c>new Number(x)</c> by extracting their <c>__primitiveValue</c>.
 /// </summary>
 internal sealed class NumberPrototypeMethodWrapper : ISharpTSCallable
 {
@@ -240,12 +242,23 @@ internal sealed class NumberPrototypeMethodWrapper : ISharpTSCallable
 
     public object? Call(Interpreter interpreter, List<object?> arguments)
     {
-        if (!_hasReceiver || _receiver is not double d)
+        if (!_hasReceiver)
         {
             throw new ThrowException(new SharpTSTypeError(
                 $"Number.prototype.{_name} requires that 'this' be a Number"));
         }
-
+        // Unwrap boxed Number wrapper produced by `new Number(x)`.
+        var numValue = _receiver is SharpTSObject obj
+            && obj.GetProperty("__primitiveType") is string pt && pt == "Number"
+            && obj.GetProperty("__primitiveValue") is double wv
+            ? (double?)wv : null;
+        if (numValue is not null)
+            return _inner.Bind(numValue.Value).Call(interpreter, arguments);
+        if (_receiver is not double d)
+        {
+            throw new ThrowException(new SharpTSTypeError(
+                $"Number.prototype.{_name} requires that 'this' be a Number"));
+        }
         return _inner.Bind(d).Call(interpreter, arguments);
     }
 
@@ -339,12 +352,23 @@ internal sealed class BooleanPrototypeMethodWrapper : ISharpTSCallable
 
     public object? Call(Interpreter interpreter, List<object?> arguments)
     {
-        if (!_hasReceiver || _receiver is not bool b)
+        if (!_hasReceiver)
         {
             throw new ThrowException(new SharpTSTypeError(
                 $"Boolean.prototype.{_name} requires that 'this' be a Boolean"));
         }
-        return _isToString ? (b ? "true" : "false") : (object)b;
+        // Unwrap boxed Boolean wrapper produced by `new Boolean(x)`.
+        bool boolValue;
+        if (_receiver is SharpTSObject obj
+            && obj.GetProperty("__primitiveType") is string pt && pt == "Boolean"
+            && obj.GetProperty("__primitiveValue") is bool wv)
+            boolValue = wv;
+        else if (_receiver is bool b)
+            boolValue = b;
+        else
+            throw new ThrowException(new SharpTSTypeError(
+                $"Boolean.prototype.{_name} requires that 'this' be a Boolean"));
+        return _isToString ? (boolValue ? "true" : "false") : (object)boolValue;
     }
 
     public override string ToString() => $"function {_name}() {{ [native code] }}";

--- a/SharpTS.Tests/SharedTests/PrimitiveWrapperTests.cs
+++ b/SharpTS.Tests/SharedTests/PrimitiveWrapperTests.cs
@@ -1,0 +1,188 @@
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests;
+
+/// <summary>
+/// Verifies that <c>new Number(x)</c>, <c>new String(x)</c>, and
+/// <c>new Boolean(x)</c> produce boxed wrapper objects in both interpreter
+/// and compiled mode, matching Node.js / ECMA-262 semantics (#360).
+/// </summary>
+public class PrimitiveWrapperTests
+{
+    // ── typeof ───────────────────────────────────────────────────────────────
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Number_NewWrapper_TypeofIsObject(ExecutionMode mode)
+    {
+        var output = TestHarness.Run("console.log(typeof new Number(5));", mode);
+        Assert.Equal("object\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void String_NewWrapper_TypeofIsObject(ExecutionMode mode)
+    {
+        var output = TestHarness.Run("console.log(typeof new String('x'));", mode);
+        Assert.Equal("object\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Boolean_NewWrapper_TypeofIsObject(ExecutionMode mode)
+    {
+        var output = TestHarness.Run("console.log(typeof new Boolean(true));", mode);
+        Assert.Equal("object\n", output);
+    }
+
+    // ── instanceof Object ────────────────────────────────────────────────────
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Number_NewWrapper_InstanceofObject(ExecutionMode mode)
+    {
+        var output = TestHarness.Run("console.log(new Number(5) instanceof Object);", mode);
+        Assert.Equal("true\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void String_NewWrapper_InstanceofObject(ExecutionMode mode)
+    {
+        var output = TestHarness.Run("console.log(new String('x') instanceof Object);", mode);
+        Assert.Equal("true\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Boolean_NewWrapper_InstanceofObject(ExecutionMode mode)
+    {
+        var output = TestHarness.Run("console.log(new Boolean(true) instanceof Object);", mode);
+        Assert.Equal("true\n", output);
+    }
+
+    // ── instanceof own constructor ───────────────────────────────────────────
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Number_NewWrapper_InstanceofNumber(ExecutionMode mode)
+    {
+        var output = TestHarness.Run("console.log(new Number(5) instanceof Number);", mode);
+        Assert.Equal("true\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void String_NewWrapper_InstanceofString(ExecutionMode mode)
+    {
+        var output = TestHarness.Run("console.log(new String('x') instanceof String);", mode);
+        Assert.Equal("true\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Boolean_NewWrapper_InstanceofBoolean(ExecutionMode mode)
+    {
+        var output = TestHarness.Run("console.log(new Boolean(false) instanceof Boolean);", mode);
+        Assert.Equal("true\n", output);
+    }
+
+    // ── primitive (non-new) is NOT an instance ───────────────────────────────
+    // Interpreter-only: compiled mode treats bare primitives differently for instanceof
+    // (pre-existing gap, tracked separately).
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void Number_Bare_NotInstanceofNumber(ExecutionMode mode)
+    {
+        var output = TestHarness.Run("console.log((5 as any) instanceof Number);", mode);
+        Assert.Equal("false\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void String_Bare_NotInstanceofString(ExecutionMode mode)
+    {
+        var output = TestHarness.Run("console.log(('x' as any) instanceof String);", mode);
+        Assert.Equal("false\n", output);
+    }
+
+    // ── call form still coerces (no wrapper) ────────────────────────────────
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Number_CallForm_ReturnsPrimitive(ExecutionMode mode)
+    {
+        var output = TestHarness.Run("console.log(typeof Number('42'));", mode);
+        Assert.Equal("number\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void String_CallForm_ReturnsPrimitive(ExecutionMode mode)
+    {
+        var output = TestHarness.Run("console.log(typeof String(42));", mode);
+        Assert.Equal("string\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Boolean_CallForm_ReturnsPrimitive(ExecutionMode mode)
+    {
+        var output = TestHarness.Run("console.log(typeof Boolean(1));", mode);
+        Assert.Equal("boolean\n", output);
+    }
+
+    // ── wrapper primitive value / conversion ─────────────────────────────────
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Number_NoArg_WrapsZero(ExecutionMode mode)
+    {
+        var output = TestHarness.Run("console.log(new Number() instanceof Number);", mode);
+        Assert.Equal("true\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void String_Length_MatchesPrimitive(ExecutionMode mode)
+    {
+        var output = TestHarness.Run("console.log(new String('hello').length);", mode);
+        Assert.Equal("5\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void String_IndexedAccess_ReturnsChar(ExecutionMode mode)
+    {
+        var output = TestHarness.Run("console.log((new String('hi') as any)[0]);", mode);
+        Assert.Equal("h\n", output);
+    }
+
+    // ── method dispatch on wrappers ──────────────────────────────────────────
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Number_ToFixed_WorksOnWrapper(ExecutionMode mode)
+    {
+        var output = TestHarness.Run("console.log((new Number(5) as any).toFixed(2));", mode);
+        Assert.Equal("5.00\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void String_ToUpperCase_WorksOnWrapper(ExecutionMode mode)
+    {
+        var output = TestHarness.Run("console.log((new String('hello') as any).toUpperCase());", mode);
+        Assert.Equal("HELLO\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Boolean_ToString_WorksOnWrapper(ExecutionMode mode)
+    {
+        var output = TestHarness.Run("console.log((new Boolean(true) as any).toString());", mode);
+        Assert.Equal("true\n", output);
+    }
+}


### PR DESCRIPTION
## Summary

- `new Number(5)`, `new String('x')`, `new Boolean(true)` in interpreter mode now return `SharpTSObject` boxed wrappers (matching compiled mode and Node.js)
- `typeof new Number(5)` → `"object"` (was `"number"`)
- `new Number(5) instanceof Object` → `true` (was `false`)
- `new Number(5) instanceof Number` → `true` (was `false`)
- Method dispatch on wrappers works: `(new Number(5)).toFixed(2)` → `"5.00"`

## Root cause

The interpreter resolved `Number`/`String`/`Boolean` as `ISharpTSCallable` namespace singletons. When called via `new`, these singletons' `Call()` method applied type coercion (returning a bare primitive) instead of constructing a wrapper object.

## Changes

| File | Change |
|------|--------|
| `Runtime/BuiltIns/BuiltInConstructorFactory.cs` | Add Number/String/Boolean to `IsBuiltIn()`; add factory methods producing `SharpTSObject` with `__primitiveType`/`__primitiveValue` (String gets length+indexed-char exotic layout) |
| `Execution/Interpreter.Calls.cs` | Add `IsBoxedPrimitiveOfType` helper + three `instanceof` branches for the namespace singletons |
| `Execution/Interpreter.Properties.cs` | Boxed-primitive method dispatch in both `EvaluateGetOnRecord` variants via `BuiltInRegistry.GetInstanceMember` on the unwrapped primitive value |
| `Runtime/Types/SharpTSPrimitiveNamespaces.cs` | `NumberPrototypeMethodWrapper` + `BooleanPrototypeMethodWrapper` unwrap boxed receivers; `StringPrototypeMethodWrapper.CoerceToString` unwraps boxed strings |
| `SharpTS.Tests/SharedTests/PrimitiveWrapperTests.cs` | 38 tests: typeof, instanceof Object/ctor, call-form coercion, length/indexed, method dispatch |

## Test plan

- [x] 38 new `PrimitiveWrapperTests` all pass
- [x] Full suite 11,175/11,175 green (no regressions)
- [x] Filed #375 for the pre-existing compiled-mode gap (`5 instanceof Number` returns `true` in compiled mode)

Closes #360