### PR TITLE
fix(compiled): running Worker keeps the event loop alive; ref/unref work (#354)

### DIFF
--- a/Compilation/ExpressionEmitterBase.Constructors.cs
+++ b/Compilation/ExpressionEmitterBase.Constructors.cs
@@ -461,6 +461,11 @@ public abstract partial class ExpressionEmitterBase
             case "Worker":
                 if (arguments.Count == 0)
                     throw new CompileException("Worker constructor requires at least 1 argument (filename).");
+                // A Worker runs an interpreter for its child script and is
+                // constructed by reflection into SharpTS.dll, so the runtime must
+                // be co-located (#354). Record the soft dependency so the CLI
+                // copies SharpTS.dll next to the output.
+                Ctx.Runtime!.RequireSharpTSRuntime("Worker");
                 EmitExpression(arguments[0]);
                 EnsureBoxed();
                 IL.Emit(OpCodes.Call, Ctx.Runtime!.Stringify);

--- a/Compilation/RuntimeEmitter.Worker.cs
+++ b/Compilation/RuntimeEmitter.Worker.cs
@@ -1221,7 +1221,15 @@ public partial class RuntimeEmitter
     /// </summary>
     private void EmitWorkerHelper(TypeBuilder runtimeType, EmittedRuntime runtime)
     {
-        // CreateWorker(string filename, object? options, Interpreter? parentInterpreter)
+        // CreateWorker(string filename, object? options, object? parentInterpreter)
+        //
+        // Constructs a SharpTSWorker via reflection (keeping the standalone DLL
+        // free of a hard SharpTS.dll reference) and binds the emitted $EventLoop
+        // singleton's Ref/Unref as the worker's keep-alive handle, so a running
+        // worker holds the compiled event loop open by default — Node semantics,
+        // and the compiled-mode half of the #329 premature-exit fix (#354). The
+        // worker itself runs an interpreter for its child script, so SharpTS.dll
+        // must be co-located; the emit site records that via RequireSharpTSRuntime.
         var method = runtimeType.DefineMethod(
             "CreateWorker",
             MethodAttributes.Public | MethodAttributes.Static,
@@ -1230,9 +1238,87 @@ public partial class RuntimeEmitter
         );
 
         var il = method.GetILGenerator();
-        il.Emit(OpCodes.Ldstr, "Worker is not supported in standalone compiled output.");
+
+        var typeLocal = il.DeclareLocal(_types.Type);
+        var loopLocal = il.DeclareLocal(runtime.EventLoopType);
+        var refLocal = il.DeclareLocal(typeof(Action));
+        var unrefLocal = il.DeclareLocal(typeof(Action));
+        var scheduleLocal = il.DeclareLocal(typeof(Action<Action>));
+        var argsLocal = il.DeclareLocal(_types.ObjectArray);
+        var actionCtor = typeof(Action).GetConstructor([_types.Object, typeof(IntPtr)])!;
+        var actionOfActionCtor = typeof(Action<Action>).GetConstructor([_types.Object, typeof(IntPtr)])!;
+
+        // Type t = Type.GetType("SharpTS.Runtime.Types.SharpTSWorker, SharpTS");
+        il.Emit(OpCodes.Ldstr, "SharpTS.Runtime.Types.SharpTSWorker, SharpTS");
+        il.Emit(OpCodes.Call, _types.GetMethod(_types.Type, "GetType", _types.String));
+        il.Emit(OpCodes.Stloc, typeLocal);
+
+        // if (t == null) throw — SharpTS.dll must be co-located for Worker.
+        var typeOk = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, typeLocal);
+        il.Emit(OpCodes.Brtrue, typeOk);
+        il.Emit(OpCodes.Ldstr, "Worker requires the SharpTS runtime (SharpTS.dll) to be present. " +
+                               "Compile without --standalone so it is co-located with the output.");
         il.Emit(OpCodes.Newobj, _types.InvalidOperationExceptionCtorString);
         il.Emit(OpCodes.Throw);
+        il.MarkLabel(typeOk);
+
+        // var loop = $EventLoop.GetInstance();
+        il.Emit(OpCodes.Call, runtime.EventLoopGetInstance);
+        il.Emit(OpCodes.Stloc, loopLocal);
+
+        // Action ref = new Action(loop, $EventLoop.Ref);
+        il.Emit(OpCodes.Ldloc, loopLocal);
+        il.Emit(OpCodes.Ldftn, runtime.EventLoopRef);
+        il.Emit(OpCodes.Newobj, actionCtor);
+        il.Emit(OpCodes.Stloc, refLocal);
+
+        // Action unref = new Action(loop, $EventLoop.Unref);
+        il.Emit(OpCodes.Ldloc, loopLocal);
+        il.Emit(OpCodes.Ldftn, runtime.EventLoopUnref);
+        il.Emit(OpCodes.Newobj, actionCtor);
+        il.Emit(OpCodes.Stloc, unrefLocal);
+
+        // Action<Action> schedule = new Action<Action>(loop, $EventLoop.Schedule);
+        il.Emit(OpCodes.Ldloc, loopLocal);
+        il.Emit(OpCodes.Ldftn, runtime.EventLoopSchedule);
+        il.Emit(OpCodes.Newobj, actionOfActionCtor);
+        il.Emit(OpCodes.Stloc, scheduleLocal);
+
+        // object[] args = { filename, options, ref, unref, schedule };
+        il.Emit(OpCodes.Ldc_I4_5);
+        il.Emit(OpCodes.Newarr, _types.Object);
+        il.Emit(OpCodes.Stloc, argsLocal);
+        il.Emit(OpCodes.Ldloc, argsLocal);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Ldarg_0); // filename
+        il.Emit(OpCodes.Stelem_Ref);
+        il.Emit(OpCodes.Ldloc, argsLocal);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Ldarg_1); // options
+        il.Emit(OpCodes.Stelem_Ref);
+        il.Emit(OpCodes.Ldloc, argsLocal);
+        il.Emit(OpCodes.Ldc_I4_2);
+        il.Emit(OpCodes.Ldloc, refLocal);
+        il.Emit(OpCodes.Stelem_Ref);
+        il.Emit(OpCodes.Ldloc, argsLocal);
+        il.Emit(OpCodes.Ldc_I4_3);
+        il.Emit(OpCodes.Ldloc, unrefLocal);
+        il.Emit(OpCodes.Stelem_Ref);
+        il.Emit(OpCodes.Ldloc, argsLocal);
+        il.Emit(OpCodes.Ldc_I4_4);
+        il.Emit(OpCodes.Ldloc, scheduleLocal);
+        il.Emit(OpCodes.Stelem_Ref);
+
+        // return t.GetMethod("CreateForCompiledLoop").Invoke(null, args);
+        // (arg 2, parentInterpreter, is unused in compiled mode — always null.)
+        il.Emit(OpCodes.Ldloc, typeLocal);
+        il.Emit(OpCodes.Ldstr, "CreateForCompiledLoop");
+        il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.Type, "GetMethod", _types.String));
+        il.Emit(OpCodes.Ldnull);
+        il.Emit(OpCodes.Ldloc, argsLocal);
+        il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.MethodInfo, "Invoke", _types.Object, _types.ObjectArray));
+        il.Emit(OpCodes.Ret);
 
         runtime.TSWorkerType = _types.Object;
         runtime.TSWorkerCtor = method;

--- a/Runtime/Types/SharpTSWorker.cs
+++ b/Runtime/Types/SharpTSWorker.cs
@@ -50,6 +50,21 @@ public class SharpTSWorker : SharpTSEventEmitter, IDisposable
     private bool _refed;             // currently holding one parent-loop Ref for the running worker
     private bool _refReleased;       // worker exited/terminated — ref/unref are permanent no-ops
 
+    // The keep-alive primitive, abstracted so the same accounting drives both
+    // runtimes: in interpreter mode these are the parent Interpreter's Ref/Unref;
+    // in compiled mode (no parent interpreter) they are the emitted $EventLoop
+    // singleton's Ref/Unref, injected via CreateForCompiledLoop (#354). Null only
+    // when there is neither — then ref/unref are no-ops.
+    private readonly Action? _loopRef;
+    private readonly Action? _loopUnref;
+
+    // Compiled-mode callback marshal: the emitted $EventLoop's Schedule(Action),
+    // which enqueues onto the loop and wakes it. Injected (rather than captured
+    // from SynchronizationContext.Current, which is not reliably the installed
+    // event-loop context at worker-construction time) so worker→parent event
+    // delivery lands on the loop thread deterministically (#354).
+    private readonly Action<Action>? _loopSchedule;
+
     // For compiled code support - enables Worker communication without interpreter
     private readonly SynchronizationContext? _syncContext;
     private readonly ConcurrentQueue<Action> _pendingCallbacks = new();
@@ -73,11 +88,39 @@ public class SharpTSWorker : SharpTSEventEmitter, IDisposable
     /// <param name="filename">Path to the TypeScript file to execute.</param>
     /// <param name="options">Optional worker options (workerData, transferList, etc.).</param>
     /// <param name="parentInterpreter">The parent interpreter for message delivery.</param>
-    public SharpTSWorker(string filename, SharpTSObject? options, Interpreter? parentInterpreter)
+    /// <param name="eventLoopRef">
+    /// Compiled-mode keep-alive Ref (the emitted <c>$EventLoop</c>'s <c>Ref</c>). When
+    /// supplied it takes precedence over <paramref name="parentInterpreter"/> for
+    /// event-loop accounting; in interpreter mode it is left null and the parent
+    /// interpreter's Ref/Unref are used instead (#354).
+    /// </param>
+    /// <param name="eventLoopUnref">Compiled-mode keep-alive Unref, paired with <paramref name="eventLoopRef"/>.</param>
+    /// <param name="eventLoopSchedule">
+    /// Compiled-mode marshal that runs an action on the event-loop thread (the
+    /// emitted <c>$EventLoop.Schedule</c>). Used to deliver worker events to the
+    /// parent without relying on an ambient <see cref="SynchronizationContext"/>.
+    /// </param>
+    public SharpTSWorker(string filename, SharpTSObject? options, Interpreter? parentInterpreter,
+        Action? eventLoopRef = null, Action? eventLoopUnref = null, Action<Action>? eventLoopSchedule = null)
     {
+        _loopSchedule = eventLoopSchedule;
         ThreadId = Interlocked.Increment(ref _nextThreadId);
         _scriptPath = filename;
         _parentInterpreter = parentInterpreter;
+
+        // Resolve the keep-alive handle once: explicit delegates (compiled mode)
+        // win over the parent interpreter (interpreter mode). Both arms feed the
+        // identical Ref accounting below, so the #329 fix now covers both runtimes.
+        if (eventLoopRef != null && eventLoopUnref != null)
+        {
+            _loopRef = eventLoopRef;
+            _loopUnref = eventLoopUnref;
+        }
+        else if (parentInterpreter != null)
+        {
+            _loopRef = parentInterpreter.Ref;
+            _loopUnref = parentInterpreter.Unref;
+        }
 
         // Capture sync context for compiled code to marshal callbacks to main thread
         _syncContext = SynchronizationContext.Current;
@@ -120,14 +163,38 @@ public class SharpTSWorker : SharpTSEventEmitter, IDisposable
         // (and Unref) before we've counted it.
         lock (_refLock)
         {
-            if (_parentInterpreter != null)
+            if (_loopRef != null)
             {
                 _refed = true;
-                _parentInterpreter.Ref();
+                _loopRef();
             }
         }
 
         _thread.Start();
+    }
+
+    /// <summary>
+    /// Factory used by compiled output to construct a worker whose running-lifetime
+    /// keep-alive is accounted against the emitted <c>$EventLoop</c> singleton rather
+    /// than an <see cref="Interpreter"/> (which does not exist at runtime in compiled
+    /// programs). The emitted <c>$Runtime.CreateWorker</c> resolves this method by
+    /// reflection — keeping the standalone DLL free of a hard SharpTS.dll reference —
+    /// and passes the loop's <c>Ref</c>/<c>Unref</c> as delegates (#354).
+    /// </summary>
+    /// <param name="filename">Path to the TypeScript file to execute.</param>
+    /// <param name="options">
+    /// Worker options. Only <see cref="SharpTSObject"/> option bags are honored today;
+    /// a compiled object literal is currently ignored (see issue for workerData/
+    /// transferList marshaling in compiled mode).
+    /// </param>
+    /// <param name="eventLoopRef">The emitted <c>$EventLoop</c> instance's <c>Ref</c>.</param>
+    /// <param name="eventLoopUnref">The emitted <c>$EventLoop</c> instance's <c>Unref</c>.</param>
+    public static SharpTSWorker CreateForCompiledLoop(
+        string filename, object? options, Action eventLoopRef, Action eventLoopUnref,
+        Action<Action> eventLoopSchedule)
+    {
+        return new SharpTSWorker(filename, options as SharpTSObject, parentInterpreter: null,
+            eventLoopRef, eventLoopUnref, eventLoopSchedule);
     }
 
     /// <summary>
@@ -146,7 +213,7 @@ public class SharpTSWorker : SharpTSEventEmitter, IDisposable
             if (_refed)
             {
                 _refed = false;
-                _parentInterpreter?.Unref();
+                _loopUnref?.Invoke();
             }
         }
     }
@@ -279,11 +346,12 @@ public class SharpTSWorker : SharpTSEventEmitter, IDisposable
             var cloned = StructuredClone.Clone(message, transfer);
             _workerToParentQueue.Add(new SharpTSMessagePort.ClonedMessage(cloned, transfer));
 
-            // Schedule delivery on parent thread
-            _parentInterpreter?.ScheduleTimer(0, 0, () =>
-            {
-                DeliverMessagesToParent();
-            }, false);
+            // Schedule delivery on the parent thread. Routed through
+            // ScheduleOnMainThread so compiled mode (no parent interpreter) marshals
+            // the delivery onto the $EventLoop via the captured sync context — a bare
+            // _parentInterpreter?.ScheduleTimer here would silently drop every worker
+            // message in compiled programs (#354).
+            ScheduleOnMainThread(DeliverMessagesToParent);
         }
         catch (StructuredClone.DataCloneError e)
         {
@@ -343,6 +411,11 @@ public class SharpTSWorker : SharpTSEventEmitter, IDisposable
         {
             // Interpreter path - use timer for callback delivery
             _parentInterpreter.ScheduleTimer(0, 0, action, false);
+        }
+        else if (_loopSchedule != null)
+        {
+            // Compiled path - marshal onto the emitted $EventLoop deterministically.
+            _loopSchedule(action);
         }
         else if (_syncContext != null)
         {
@@ -454,22 +527,22 @@ public class SharpTSWorker : SharpTSEventEmitter, IDisposable
         ReleaseRunningRef();
 
         // The thread join is real, always-completing work bounded at 5s. Ref the
-        // parent event loop for its duration so the interpreter's quiescence
-        // heuristic does not abandon a program whose only remaining work is
-        // `await worker.terminate()` when the worker takes >250ms to wind down
-        // (the #319/#320 native-I/O liveness class; #324). Unref once the join
-        // settles. The Ref is opt-in on having a parent interpreter — the
-        // compiled path (no _parentInterpreter) is unaffected.
-        var interp = _parentInterpreter;
-        interp?.Ref();
+        // owning event loop for its duration so the quiescence heuristic does not
+        // abandon a program whose only remaining work is `await worker.terminate()`
+        // when the worker takes >250ms to wind down (the #319/#320 native-I/O
+        // liveness class; #324). Unref once the join settles. Accounted against the
+        // parent interpreter (interpreter mode) or the emitted $EventLoop (compiled
+        // mode, #354); a no-op when neither is present.
+        var loopUnref = _loopUnref;
+        _loopRef?.Invoke();
         var task = Task.Run<object?>(() =>
         {
             _thread.Join(5000); // Wait up to 5 seconds
             return (double)0;
         });
-        if (interp != null)
+        if (_loopRef != null && loopUnref != null)
         {
-            task.ContinueWith(_ => interp.Unref(), TaskScheduler.Default);
+            task.ContinueWith(_ => loopUnref(), TaskScheduler.Default);
         }
         return new SharpTSPromise(task);
     }
@@ -477,16 +550,16 @@ public class SharpTSWorker : SharpTSEventEmitter, IDisposable
     /// <summary>
     /// Opts the worker back into keeping the parent event loop alive (Node's
     /// <c>worker.ref()</c>). No-op once the worker has exited or been terminated,
-    /// or in compiled mode (no parent interpreter).
+    /// or when no event loop owns the worker.
     /// </summary>
     public SharpTSWorker Ref()
     {
         lock (_refLock)
         {
-            if (!_refReleased && !_refed && _parentInterpreter != null)
+            if (!_refReleased && !_refed && _loopRef != null)
             {
                 _refed = true;
-                _parentInterpreter.Ref();
+                _loopRef();
             }
         }
         return this;
@@ -496,7 +569,7 @@ public class SharpTSWorker : SharpTSEventEmitter, IDisposable
     /// Opts the worker out of keeping the parent event loop alive (Node's
     /// <c>worker.unref()</c>). The worker keeps running; the parent is just free to
     /// exit if the worker is its only remaining work. No-op once the worker has
-    /// exited/terminated, or in compiled mode (no parent interpreter).
+    /// exited/terminated, or when no event loop owns the worker.
     /// </summary>
     public void Unref()
     {
@@ -505,7 +578,7 @@ public class SharpTSWorker : SharpTSEventEmitter, IDisposable
             if (_refed)
             {
                 _refed = false;
-                _parentInterpreter?.Unref();
+                _loopUnref?.Invoke();
             }
         }
     }

--- a/SharpTS.Tests/SharedTests/WorkerThreadsTests.cs
+++ b/SharpTS.Tests/SharedTests/WorkerThreadsTests.cs
@@ -454,15 +454,16 @@ public class WorkerThreadsTests
     /// blocks well past the 250ms give-up. That join task is invisible to
     /// <c>HasPendingEventLoopWork</c>; before the fix the parent abandoned the
     /// terminate promise and exited without printing "terminated". The fix Refs
-    /// the parent loop for the join's duration. InterpretedOnly because the fix
-    /// targets the interpreter event loop; <c>__dirname</c> routes the harness
-    /// through the real-disk path so the spawned worker can load its script.
-    /// The assertion is positive (output present) and load-independent — under
-    /// load the join simply takes longer and the Ref keeps the loop alive for
-    /// it, so the test cannot flake the way a wall-clock window would.
+    /// the parent loop for the join's duration — the parent interpreter loop
+    /// (interpreter mode) or the emitted <c>$EventLoop</c> (compiled mode, #354).
+    /// <c>__dirname</c> routes the harness through the real-disk path so the
+    /// spawned worker can load its script. The assertion is positive (output
+    /// present) and load-independent — under load the join simply takes longer and
+    /// the Ref keeps the loop alive for it, so the test cannot flake the way a
+    /// wall-clock window would.
     /// </remarks>
     [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void Worker_Terminate_KeepsEventLoopAliveUntilSettled(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -500,15 +501,17 @@ public class WorkerThreadsTests
     /// the wait at 250ms and exited without ever printing the message.
     /// </summary>
     /// <remarks>
-    /// InterpretedOnly: the keep-alive Ref is against the interpreter event loop;
-    /// compiled mode has no parent interpreter. <c>__dirname</c> routes the harness
+    /// The keep-alive Ref is against whichever loop owns the worker: the parent
+    /// interpreter (interpreter mode) or the emitted <c>$EventLoop</c> (compiled
+    /// mode, #354 — worker→parent delivery is marshalled onto the loop via the
+    /// injected <c>$EventLoop.Schedule</c>). <c>__dirname</c> routes the harness
     /// through the real-disk path so the worker can load its script. The assertion
     /// is positive and load-independent — under load the worker simply posts later
     /// and the running-Ref keeps the parent alive until it does, so the test cannot
     /// flake the way a wall-clock window would.
     /// </remarks>
     [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void Worker_RunningWorker_KeepsParentLoopAliveUntilMessage(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -539,7 +542,7 @@ public class WorkerThreadsTests
     /// delayed message is still delivered (positive, load-independent assertion).
     /// </summary>
     [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void Worker_UnrefThenRef_RestoresKeepAlive(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>


### PR DESCRIPTION
Closes #354.

## Problem
Follow-up to #329 / PR #353, which fixed the interpreter case and explicitly deferred compiled mode. In compiled output:
- `new Worker(...)` threw `"Worker is not supported in standalone compiled output."` outright.
- The #353 keep-alive Ref was a no-op (no parent interpreter), so a running worker did not keep the compiled `$EventLoop` alive, and `worker.ref()/unref()` did nothing.

## Fix
- **Unified keep-alive accounting** (`SharpTSWorker`): the Ref bookkeeping no longer hard-depends on `_parentInterpreter`. It now drives a pair of `Action _loopRef/_loopUnref` delegates — interpreter mode feeds them `interp.Ref/Unref`; compiled mode injects the emitted `$EventLoop`'s `Ref/Unref`. The same (already battle-tested) accounting now covers both runtimes, so the default running-worker keep-alive, `ref()`, `unref()`, and the `terminate()` join-Ref all work compiled.
- **Deterministic delivery**: worker→parent events are marshalled onto the loop via an injected `$EventLoop.Schedule` delegate instead of `SynchronizationContext.Current` (which is not reliably the installed event-loop context at worker-construction time in standalone runs — see filed follow-up). `PostMessageToParent` now routes through `ScheduleOnMainThread`, which previously dropped every message in compiled mode.
- **Construction**: emitted `$Runtime.CreateWorker` reflectively constructs `SharpTSWorker` via a new `CreateForCompiledLoop` factory, keeping the standalone DLL free of a hard `SharpTS.dll` reference. The `new Worker` emit site records `RequireSharpTSRuntime("Worker")` so the CLI co-locates `SharpTS.dll` (the worker runs an interpreter for its child script).
- **Tests**: the three Worker event-loop liveness tests (#329 running-worker, #329 unref/ref, #324 terminate) now run in **both** modes.

## Verification
- Compiled spawn delivers messages; `unref()` opts out (early exit at ~72ms before a 400ms message); `ref()`-after-`unref()` restores keep-alive; `terminate()` keeps the loop alive until settled.
- Emitted IL passes `--verify`.
- `WorkerThreadsTests` (58) + Cluster/MessageChannel/BroadcastChannel/Timer/EventLoop/StructuredClone (241) all green.

## Follow-ups filed
- Compiled-mode Worker options (`workerData`/`transferList`/stdio) marshaling — a compiled object-literal options bag is currently ignored.
- Standalone compiled programs run top-level code with `SynchronizationContext.Current == null` despite the `$EventLoopSyncContext` install at `Main` entry.