### PR TITLE
fix(type-checker): infer hoisted var type from first nested initializer for TS2403 (#378)

### DIFF
--- a/Parsing/AST.cs
+++ b/Parsing/AST.cs
@@ -357,7 +357,14 @@ public abstract record Stmt
     /// <param name="TypeAnnotationNode">Structured form of <c>TypeAnnotation</c> when the
     /// construct has node support (type-AST migration); null otherwise — consumers fall back to
     /// the string.</param>
-    public record Var(Token Name, string? TypeAnnotation, Expr? Initializer, bool HasDefiniteAssignmentAssertion = false, bool IsVar = false, TypeNode? TypeAnnotationNode = null) : Stmt;
+    /// <param name="HoistTypeInferenceInitializer">Set by <see cref="VarHoister"/> on a synthetic
+    /// hoisted <c>var</c> whose first real declaration was a nested, annotation-less initializer
+    /// (e.g. <c>if (c) { var z = "hello"; }</c>). The binding has no <c>Initializer</c> here (the
+    /// initializer runs at its original, rewritten position) and no annotation, so its declared type
+    /// would otherwise default to <c>any</c> — suppressing TS2403 for a later <c>var z: number;</c>.
+    /// The type checker infers the binding's declared type from this expression (widened, errors
+    /// suppressed since they surface at the original site); the interpreter and IL compiler ignore it.</param>
+    public record Var(Token Name, string? TypeAnnotation, Expr? Initializer, bool HasDefiniteAssignmentAssertion = false, bool IsVar = false, TypeNode? TypeAnnotationNode = null, Expr? HoistTypeInferenceInitializer = null) : Stmt;
     /// <summary>
     /// Const variable declaration. Separate from Var for cleaner const-specific handling (e.g., unique symbol).
     /// Initializer is non-nullable since const always requires initialization.

--- a/Parsing/VarHoister.cs
+++ b/Parsing/VarHoister.cs
@@ -48,7 +48,7 @@ public static class VarHoister
     /// </summary>
     public static List<Stmt> Hoist(List<Stmt> body)
     {
-        var collected = new List<(Token Name, string? TypeAnnotation, TypeNode? TypeAnnotationNode)>();
+        var collected = new List<(Token Name, string? TypeAnnotation, TypeNode? TypeAnnotationNode, Expr? InitializerForInference)>();
         var seen = new HashSet<string>(StringComparer.Ordinal);
         var rewritten = new List<Stmt>(body.Count);
         bool changed = false;
@@ -67,10 +67,13 @@ public static class VarHoister
         // Prepend synthetic `var name;` declarations for each unique hoisted name.
         // Carry the first-seen annotation so the type checker can detect TS2403 when a
         // later declaration uses a different annotation (e.g. nested string then top-level number).
+        // When the first declaration had no annotation but an initializer, carry the initializer
+        // (for type inference only) so the binding's declared type is the initializer's type rather
+        // than `any` — otherwise a later `var z: number;` / `var z = 5;` would not report TS2403.
         var result = new List<Stmt>(collected.Count + rewritten.Count);
-        foreach (var (nameToken, typeAnnotation, typeAnnotationNode) in collected)
+        foreach (var (nameToken, typeAnnotation, typeAnnotationNode, initializerForInference) in collected)
         {
-            result.Add(new Stmt.Var(nameToken, TypeAnnotation: typeAnnotation, TypeAnnotationNode: typeAnnotationNode, Initializer: null, HasDefiniteAssignmentAssertion: false, IsVar: true));
+            result.Add(new Stmt.Var(nameToken, TypeAnnotation: typeAnnotation, TypeAnnotationNode: typeAnnotationNode, Initializer: null, HasDefiniteAssignmentAssertion: false, IsVar: true, HoistTypeInferenceInitializer: initializerForInference));
         }
         result.AddRange(rewritten);
         return result;
@@ -83,7 +86,7 @@ public static class VarHoister
     /// <param name="isTopLevel">True if this statement is directly inside the function/module
     /// body. Top-level vars are still rewritten to assignments (so the synthetic declarations
     /// at the top can hold the binding) but they appear in the same source-order position.</param>
-    private static Stmt RewriteAndCollect(Stmt stmt, List<(Token Name, string? TypeAnnotation, TypeNode? TypeAnnotationNode)> collected, HashSet<string> seen, bool isTopLevel, ref bool changed)
+    private static Stmt RewriteAndCollect(Stmt stmt, List<(Token Name, string? TypeAnnotation, TypeNode? TypeAnnotationNode, Expr? InitializerForInference)> collected, HashSet<string> seen, bool isTopLevel, ref bool changed)
     {
         switch (stmt)
         {
@@ -108,7 +111,12 @@ public static class VarHoister
 
                 if (seen.Add(v.Name.Lexeme))
                 {
-                    collected.Add((v.Name, v.TypeAnnotation, v.TypeAnnotationNode));
+                    // Carry the initializer for type inference only when there is no annotation
+                    // to carry — an explicit annotation already establishes the declared type.
+                    Expr? initForInference = v.TypeAnnotation == null && v.TypeAnnotationNode == null
+                        ? v.Initializer
+                        : null;
+                    collected.Add((v.Name, v.TypeAnnotation, v.TypeAnnotationNode, initForInference));
                 }
                 changed = true;
                 if (v.Initializer == null)
@@ -317,7 +325,7 @@ public static class VarHoister
     /// Helper for rewriting a list of statements (used by TryCatch/Switch which carry
     /// <c>List&lt;Stmt&gt;</c> directly rather than wrapping in a Block).
     /// </summary>
-    private static List<Stmt> RewriteList(List<Stmt> list, List<(Token Name, string? TypeAnnotation, TypeNode? TypeAnnotationNode)> collected, HashSet<string> seen, ref bool changed)
+    private static List<Stmt> RewriteList(List<Stmt> list, List<(Token Name, string? TypeAnnotation, TypeNode? TypeAnnotationNode, Expr? InitializerForInference)> collected, HashSet<string> seen, ref bool changed)
     {
         var result = new List<Stmt>(list.Count);
         foreach (var s in list)

--- a/SharpTS.Tests/TypeCheckerTests/Round3ConformanceTests.cs
+++ b/SharpTS.Tests/TypeCheckerTests/Round3ConformanceTests.cs
@@ -200,6 +200,69 @@ public class Round3ConformanceTests
         Assert.Equal("TS2403", ex.Diagnostic.TsCode);
     }
 
+    // ── Issue #378: nested-first var with an initializer but no annotation ─────────────────────────
+
+    [Fact]
+    public void VarRedeclaration_NestedFirstInitializerNoAnnotation_AnnotatedRedeclaration_IsTs2403Error()
+    {
+        // Issue #378: the first declaration is nested and has only an initializer (no annotation),
+        // so #363's annotation-carrying produced nothing — the hoisted `var z;` defaulted to `any`
+        // and silenced TS2403. The initializer is now carried for type inference, establishing
+        // `string` as the binding's type so a later `var z: number;` conflicts.
+        var source = """
+            function h(c: boolean) {
+                if (c) { var z = "hello"; }
+                var z: number;
+            }
+            """;
+        var ex = Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+        Assert.Equal("TS2403", ex.Diagnostic.TsCode);
+    }
+
+    [Fact]
+    public void VarRedeclaration_NestedFirstInitializerNoAnnotation_InitializerRedeclaration_IsTs2403Error()
+    {
+        // The fully-initializer variant: nested `var z = "hello"` then top-level `var z = 5`.
+        var source = """
+            function h(c: boolean) {
+                if (c) { var z = "hello"; }
+                var z = 5;
+            }
+            """;
+        var ex = Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+        Assert.Equal("TS2403", ex.Diagnostic.TsCode);
+    }
+
+    [Fact]
+    public void VarRedeclaration_NestedFirstInitializerNoAnnotation_SameType_IsNotError()
+    {
+        // The inferred type widens the literal (string, not "hello"), so a same-type redeclaration
+        // passes silently — matching tsc.
+        var source = """
+            function h(c: boolean) {
+                if (c) { var z = "hello"; }
+                var z = "world";
+            }
+            """;
+        TestHarness.RunInterpreted(source);
+    }
+
+    [Fact]
+    public void VarRedeclaration_NestedFirstInitializerNoAnnotation_RuntimeStillHoists()
+    {
+        // The carried initializer is type-inference-only: it must not run at the hoisted position,
+        // so `z` is undefined when the nested branch is skipped.
+        var source = """
+            function f(c: boolean): string | undefined {
+                if (c) { var z = "hello"; }
+                return z;
+            }
+            console.log(f(true));
+            console.log(f(false));
+            """;
+        Assert.Equal("hello\nundefined", TestHarness.RunInterpreted(source).Trim().Replace("\r\n", "\n"));
+    }
+
     [Fact]
     public void VarShadowing_InNestedFunction_IsNotRedeclaration()
     {

--- a/TypeSystem/TypeChecker.Statements.cs
+++ b/TypeSystem/TypeChecker.Statements.cs
@@ -144,6 +144,15 @@ public partial class TypeChecker
         // Node-first annotation resolution (type-AST migration), string fallback.
         TypeInfo? declaredType = ResolveAnnotation(stmt.TypeAnnotation, stmt.TypeAnnotationNode);
 
+        // VarHoister carries the first nested declaration's initializer onto the synthetic hoisted
+        // `var` (which itself has no Initializer) when that declaration had no annotation. Infer the
+        // binding's declared type from it so a later `var z: number;` / `var z = 5;` reports TS2403
+        // instead of being silenced by an `any` placeholder. (See Stmt.Var.HoistTypeInferenceInitializer.)
+        if (declaredType is null && stmt.Initializer is null && stmt.HoistTypeInferenceInitializer is { } inferenceSource)
+        {
+            declaredType = InferHoistedVarType(inferenceSource);
+        }
+
         if (stmt.HasDefiniteAssignmentAssertion)
         {
             _environment.Define(stmt.Name.Lexeme, declaredType!);
@@ -255,6 +264,30 @@ public partial class TypeChecker
                 $" Subsequent variable declarations must have the same type. Variable '{stmt.Name.Lexeme}' must be of type '{previous}', but here has type '{newType}'.",
                 line: stmt.Name.Line, tsCode: "TS2403");
         }
+    }
+
+    /// <summary>
+    /// Infers the declared type of a hoisted <c>var</c> from the first nested declaration's
+    /// initializer (carried on <see cref="Stmt.Var.HoistTypeInferenceInitializer"/>). The literal
+    /// type is widened to match how <c>var x = expr;</c> is normally typed, and top-level
+    /// null/undefined widen to <c>any</c>. Errors are suppressed and degrade to <c>any</c>: the
+    /// initializer is also checked at its original (rewritten) position, where any real diagnostic
+    /// is reported with the correct location. The speculative check runs in its own narrowing scope
+    /// so it leaves no narrowings behind.
+    /// </summary>
+    private TypeInfo? InferHoistedVarType(Expr initializer)
+    {
+        PushEmptyNarrowingScope();
+        try
+        {
+            TypeInfo inferred = WidenLiteralType(CheckExpr(initializer));
+            if (inferred is TypeInfo.Null or TypeInfo.Undefined)
+                return new TypeInfo.Any();
+            return inferred;
+        }
+        catch (TypeMismatchException) { return null; }
+        catch (TypeCheckException) { return null; }
+        finally { PopNarrowingScope(); }
     }
 
     internal VoidResult VisitConst(Stmt.Const stmt)


### PR DESCRIPTION
Closes #378.

## Problem

The residual gap left after #363/PR #374. When the **first** `var` declaration is in a nested block and has only an **initializer** (no annotation), tsc reports TS2403 but SharpTS was silent:

```ts
function f(c: boolean) {
    if (c) { var z = "hello"; }
    var z: number;   // tsc: TS2403. We: silent.
}
function g(c: boolean) {
    if (c) { var z = "hello"; }
    var z = 5;       // tsc: TS2403 (string vs number). We: silent.
}
```

#363 widened `VarHoister.collected` to carry the first-seen *annotation* onto the synthetic hoisted `var z;`. But an initializer-only first declaration has no annotation to carry, so the hoisted binding defaulted to `any`, and `CheckAssign`'s early-return for `Any` suppressed TS2403 for every later redeclaration.

## Fix

`VarHoister` now also carries the first declaration's **initializer expression** (only when there is no annotation) onto the synthetic var, via a new type-inference-only field `Stmt.Var.HoistTypeInferenceInitializer`. The type checker infers the binding's declared type from it — literal-widened, with `null`/`undefined` widening to `any`, mirroring how `var x = expr;` is normally typed — so a later `var z: number;` / `var z = 5;` reports TS2403.

Key properties (no new technical debt):
- The initializer still executes **only at its original rewritten position**. The interpreter and IL compiler ignore the new field (it's used only by the checker), so runtime behavior is unchanged — verified `hello`/`undefined` output in both interpreted and compiled modes.
- The speculative inference runs in **its own narrowing scope** (push/pop) so it leaves no narrowings behind, and **suppresses errors** (degrading to `any`) since any real diagnostic surfaces at the original site — avoiding duplicate diagnostics. The checker is per-statement fail-fast/collect, so suppression here keeps a single, correctly-located error.

## Coverage

Matches the checker's existing resolution at the hoist position: literals, parameters, and calls to **already-declared** functions all infer correctly. A first initializer that is a **forward-referenced** local function call cannot be resolved — but that is a pre-existing checker limitation that affects ordinary `var z: T = make()` too (filed #383), not specific to this fix.

## Tests

Four new tests in `Round3ConformanceTests` (annotated-redeclaration TS2403, initializer-redeclaration TS2403, same-type silent, runtime-still-hoists). Full suite green (11192 passed); TypeScript conformance suite green (no regressions or new-passes).