### PR TITLE
fix(promise): poisoned `constructor` getter throws synchronously from then/catch/finally (#350)

### DIFF
--- a/Compilation/RuntimeEmitter.Promises.Executor.cs
+++ b/Compilation/RuntimeEmitter.Promises.Executor.cs
@@ -199,6 +199,35 @@ public partial class RuntimeEmitter
         var ctorLocal = il.DeclareLocal(typeof(ConstructorInfo));
         var getTypeFromHandle = _types.GetMethod(_types.Type, "GetTypeFromHandle", _types.RuntimeTypeHandle);
 
+        // #350: SpeciesConstructor(promise, %Promise%) step 1 = Get(promise,
+        // "constructor"). An own `constructor` getter installed via
+        // Object.defineProperty (a poisoned getter, test262 then/ctor-poisoned)
+        // is stored in $PropertyDescriptorStore keyed on the receiver. Invoke it
+        // for its side effect FIRST — this runs synchronously right after the
+        // then/catch/finally state machine returns its task, so a throw
+        // propagates synchronously out of the `.then()` expression (a
+        // ReturnIfAbrupt before PerformPromiseThen) rather than rejecting the
+        // result. Applies to plain promises (raw Task / base $Promise) too, so
+        // it precedes the $Promise-subclass narrowing below. The getter's RETURN
+        // value does not redirect species (the receiver's own class still drives
+        // the result) — own-constructor-returns-a-value is the #349/#350 remainder.
+        var poisonGetterLocal = il.DeclareLocal(_types.Object);
+        var noPoisonGetterLabel = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Brfalse, noPoisonGetterLabel);   // null receiver → skip
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Ldstr, "constructor");
+        il.Emit(OpCodes.Ldloca, poisonGetterLocal);
+        il.Emit(OpCodes.Call, runtime.PDSTryGetGetter);
+        il.Emit(OpCodes.Brfalse, noPoisonGetterLabel);
+        il.Emit(OpCodes.Ldarg_1);                        // receiver
+        il.Emit(OpCodes.Ldloc, poisonGetterLocal);       // getter
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Newarr, _types.Object);          // empty args
+        il.Emit(OpCodes.Call, runtime.InvokeMethodValue);
+        il.Emit(OpCodes.Pop);                            // discard; only the throw matters
+        il.MarkLabel(noPoisonGetterLabel);
+
         // if (receiver is not $Promise) return result;
         il.Emit(OpCodes.Ldarg_1);
         il.Emit(OpCodes.Isinst, runtime.TSPromiseType);

--- a/Execution/Interpreter.Properties.cs
+++ b/Execution/Interpreter.Properties.cs
@@ -612,22 +612,30 @@ public partial class Interpreter
                 return RuntimeValue.FromBoxed(RegExpConstructorObject);
         }
 
-        // Promise subclass instances (#242): own fields, class getters, and
-        // methods resolve before the built-in Promise members so user
-        // overrides win; then/catch/finally fall through to the category
-        // dispatch (PromiseBuiltIns wraps their results in the subclass).
-        if (obj is SharpTSPromiseSubclassInstance promiseSub)
+        // Promise instances: own accessor/data properties installed via
+        // Object.defineProperty resolve first, so a poisoned `constructor`
+        // getter fires and propagates (test262 then/ctor-poisoned, #350). For
+        // subclass instances (#242), declared fields/class getters/methods then
+        // resolve before the built-in Promise members so user overrides win;
+        // then/catch/finally fall through to the category dispatch
+        // (PromiseBuiltIns wraps their results per SpeciesConstructor).
+        if (obj is SharpTSPromise promise)
         {
-            if (memberName == "constructor")
-                return RuntimeValue.FromObject(promiseSub.Klass);
-            if (promiseSub.TryGetOwnProperty(memberName, out var ownProp))
+            if (promise.TryGetAccessor(memberName, out var ownGetter, out _) && ownGetter != null)
+                return RuntimeValue.FromBoxed(ownGetter.Call(this, []));
+            if (promise.TryGetOwnProperty(memberName, out var ownProp))
                 return RuntimeValue.FromBoxed(ownProp);
-            var promiseGetter = promiseSub.Klass.FindGetter(memberName);
-            if (promiseGetter != null)
-                return RuntimeValue.FromBoxed(promiseGetter.BindThis(promiseSub).Call(this, []));
-            var promiseMethod = promiseSub.Klass.FindMethod(memberName);
-            if (promiseMethod != null)
-                return RuntimeValue.FromObject(SharpTSClass.BindMethodToReceiver(promiseMethod, promiseSub));
+            if (promise is SharpTSPromiseSubclassInstance promiseSub)
+            {
+                if (memberName == "constructor")
+                    return RuntimeValue.FromObject(promiseSub.Klass);
+                var promiseGetter = promiseSub.Klass.FindGetter(memberName);
+                if (promiseGetter != null)
+                    return RuntimeValue.FromBoxed(promiseGetter.BindThis(promiseSub).Call(this, []));
+                var promiseMethod = promiseSub.Klass.FindMethod(memberName);
+                if (promiseMethod != null)
+                    return RuntimeValue.FromObject(SharpTSClass.BindMethodToReceiver(promiseMethod, promiseSub));
+            }
         }
 
         var member = BuiltInRegistry.Instance.GetMemberByCategory(category, obj, memberName);
@@ -1140,20 +1148,26 @@ public partial class Interpreter
                 return SharpTSClass.BindMethodToReceiver(classMethod, subclassArray);
         }
 
-        // Promise subclass instances (#242): mirror the RV-path arm — own
-        // fields, class getters, and methods before built-in Promise members.
-        if (obj is SharpTSPromiseSubclassInstance promiseSub)
+        // Promise instances: mirror the RV-path arm — own accessor/data
+        // properties (poisoned `constructor` getter, #350) before subclass
+        // fields/getters/methods, all before the built-in Promise members.
+        if (obj is SharpTSPromise promise)
         {
-            if (memberName == "constructor")
-                return promiseSub.Klass;
-            if (promiseSub.TryGetOwnProperty(memberName, out var promiseOwnProp))
+            if (promise.TryGetAccessor(memberName, out var ownGetter, out _) && ownGetter != null)
+                return ownGetter.Call(this, []);
+            if (promise.TryGetOwnProperty(memberName, out var promiseOwnProp))
                 return promiseOwnProp;
-            var promiseGetter = promiseSub.Klass.FindGetter(memberName);
-            if (promiseGetter != null)
-                return promiseGetter.BindThis(promiseSub).Call(this, []);
-            var promiseMethod = promiseSub.Klass.FindMethod(memberName);
-            if (promiseMethod != null)
-                return SharpTSClass.BindMethodToReceiver(promiseMethod, promiseSub);
+            if (promise is SharpTSPromiseSubclassInstance promiseSub)
+            {
+                if (memberName == "constructor")
+                    return promiseSub.Klass;
+                var promiseGetter = promiseSub.Klass.FindGetter(memberName);
+                if (promiseGetter != null)
+                    return promiseGetter.BindThis(promiseSub).Call(this, []);
+                var promiseMethod = promiseSub.Klass.FindMethod(memberName);
+                if (promiseMethod != null)
+                    return SharpTSClass.BindMethodToReceiver(promiseMethod, promiseSub);
+            }
         }
 
         // Handle built-in instance members: strings, arrays, Math, Promise

--- a/Runtime/BuiltIns/BuiltInAsyncMethod.cs
+++ b/Runtime/BuiltIns/BuiltInAsyncMethod.cs
@@ -32,6 +32,7 @@ public class BuiltInAsyncMethod : ISharpTSCallable, ISharpTSAsyncCallable
     private readonly int _maxArity;
     private readonly Func<Interpreter, object?, List<object?>, Task<object?>> _implementation;
     private readonly Func<Interpreter, Task<object?>, SharpTSPromise>? _promiseFactory;
+    private readonly Func<Interpreter, object?, Func<Interpreter, Task<object?>, SharpTSPromise>?>? _speciesResolver;
     private readonly bool _refsEventLoopWhileInFlight;
     private object? _receiver;
 
@@ -58,13 +59,24 @@ public class BuiltInAsyncMethod : ISharpTSCallable, ISharpTSAsyncCallable
     /// legitimately never settle (reader.closed, pipeline of an unfinished stream, then-
     /// chaining) — those would otherwise hold the loop open forever.
     /// </param>
+    /// <param name="speciesResolver">
+    /// Optional synchronous pre-step run at call time, BEFORE the rejected-promise
+    /// try below, that returns the result-promise <paramref name="promiseFactory"/>
+    /// to use for this invocation. Takes precedence over <paramref name="promiseFactory"/>.
+    /// Promise.prototype.then/catch/finally pass one so they can read
+    /// <c>SpeciesConstructor(promise, %Promise%)</c> (ECMA-262 §27.2.5.4 step 3 —
+    /// a ReturnIfAbrupt before PerformPromiseThen): a poisoned <c>constructor</c>/
+    /// <c>@@species</c> getter throws SYNCHRONOUSLY out of the call rather than
+    /// rejecting the result promise (test262 then/ctor-poisoned, #350).
+    /// </param>
     public BuiltInAsyncMethod(
         string name,
         int minArity,
         int maxArity,
         Func<Interpreter, object?, List<object?>, Task<object?>> implementation,
         Func<Interpreter, Task<object?>, SharpTSPromise>? promiseFactory = null,
-        bool refsEventLoopWhileInFlight = false)
+        bool refsEventLoopWhileInFlight = false,
+        Func<Interpreter, object?, Func<Interpreter, Task<object?>, SharpTSPromise>?>? speciesResolver = null)
     {
         _name = name;
         _minArity = minArity;
@@ -72,6 +84,7 @@ public class BuiltInAsyncMethod : ISharpTSCallable, ISharpTSAsyncCallable
         _implementation = implementation;
         _promiseFactory = promiseFactory;
         _refsEventLoopWhileInFlight = refsEventLoopWhileInFlight;
+        _speciesResolver = speciesResolver;
     }
 
     // Private constructor for creating bound instances
@@ -82,6 +95,7 @@ public class BuiltInAsyncMethod : ISharpTSCallable, ISharpTSAsyncCallable
         Func<Interpreter, object?, List<object?>, Task<object?>> implementation,
         Func<Interpreter, Task<object?>, SharpTSPromise>? promiseFactory,
         bool refsEventLoopWhileInFlight,
+        Func<Interpreter, object?, Func<Interpreter, Task<object?>, SharpTSPromise>?>? speciesResolver,
         object? receiver)
     {
         _name = name;
@@ -90,6 +104,7 @@ public class BuiltInAsyncMethod : ISharpTSCallable, ISharpTSAsyncCallable
         _implementation = implementation;
         _promiseFactory = promiseFactory;
         _refsEventLoopWhileInFlight = refsEventLoopWhileInFlight;
+        _speciesResolver = speciesResolver;
         _receiver = receiver;
     }
 
@@ -100,13 +115,13 @@ public class BuiltInAsyncMethod : ISharpTSCallable, ISharpTSAsyncCallable
         // Null receivers don't need caching
         if (receiver == null)
         {
-            return new BuiltInAsyncMethod(_name, _minArity, _maxArity, _implementation, _promiseFactory, _refsEventLoopWhileInFlight, null);
+            return new BuiltInAsyncMethod(_name, _minArity, _maxArity, _implementation, _promiseFactory, _refsEventLoopWhileInFlight, _speciesResolver, null);
         }
 
         // Value types can't be cached efficiently
         if (receiver.GetType().IsValueType)
         {
-            return new BuiltInAsyncMethod(_name, _minArity, _maxArity, _implementation, _promiseFactory, _refsEventLoopWhileInFlight, receiver);
+            return new BuiltInAsyncMethod(_name, _minArity, _maxArity, _implementation, _promiseFactory, _refsEventLoopWhileInFlight, _speciesResolver, receiver);
         }
 
         // Initialize cache lazily
@@ -119,7 +134,7 @@ public class BuiltInAsyncMethod : ISharpTSCallable, ISharpTSAsyncCallable
         }
 
         // Create new bound method and cache it
-        var bound = new BuiltInAsyncMethod(_name, _minArity, _maxArity, _implementation, _promiseFactory, _refsEventLoopWhileInFlight, receiver);
+        var bound = new BuiltInAsyncMethod(_name, _minArity, _maxArity, _implementation, _promiseFactory, _refsEventLoopWhileInFlight, _speciesResolver, receiver);
         _boundMethodCache.AddOrUpdate(receiver, bound);
         return bound;
     }
@@ -130,11 +145,22 @@ public class BuiltInAsyncMethod : ISharpTSCallable, ISharpTSAsyncCallable
     public object? Call(Interpreter interpreter, List<object?> arguments)
     {
         ValidateArguments(arguments);
+
+        // Resolve the result-promise factory SYNCHRONOUSLY before entering the
+        // try below. For then/catch/finally this performs the SpeciesConstructor
+        // read (§27.2.5.4 step 3), so a poisoned constructor/@@species getter
+        // throws synchronously out of this call instead of being swallowed into
+        // a rejected promise by the catch (#350). Absent a resolver, the static
+        // factory (subclass-typed inherited statics, #242) is used.
+        var factory = _speciesResolver != null
+            ? _speciesResolver(interpreter, _receiver)
+            : _promiseFactory;
+
         try
         {
             var task = _implementation(interpreter, _receiver, arguments);
             KeepEventLoopAliveUntilComplete(interpreter, task);
-            return WrapResult(interpreter, task);
+            return WrapResult(interpreter, factory, task);
         }
         catch (Exception ex)
         {
@@ -145,16 +171,19 @@ public class BuiltInAsyncMethod : ISharpTSCallable, ISharpTSAsyncCallable
                 SharpTSPromiseRejectedException rex => rex.Reason,
                 _ => ex.Message
             };
-            if (_promiseFactory == null)
+            if (factory == null)
                 return SharpTSPromise.Reject(errorValue);
             var tcs = new TaskCompletionSource<object?>();
             tcs.SetException(new SharpTSPromiseRejectedException(errorValue));
-            return WrapResult(interpreter, tcs.Task);
+            return WrapResult(interpreter, factory, tcs.Task);
         }
     }
 
-    private SharpTSPromise WrapResult(Interpreter interpreter, Task<object?> task)
-        => _promiseFactory != null ? _promiseFactory(interpreter, task) : new SharpTSPromise(task);
+    private static SharpTSPromise WrapResult(
+        Interpreter interpreter,
+        Func<Interpreter, Task<object?>, SharpTSPromise>? factory,
+        Task<object?> task)
+        => factory != null ? factory(interpreter, task) : new SharpTSPromise(task);
 
     /// <summary>
     /// Async call - awaits the implementation directly.

--- a/Runtime/BuiltIns/ObjectBuiltIns.cs
+++ b/Runtime/BuiltIns/ObjectBuiltIns.cs
@@ -580,6 +580,24 @@ public static class ObjectBuiltIns
                 }
                 success = true;
                 break;
+            case SharpTSPromise promise:
+                // Promise instances are objects; user code may install own
+                // accessor or data properties — notably a poisoned `constructor`
+                // getter that must fire when then/catch/finally resolve
+                // SpeciesConstructor (test262 then/ctor-poisoned, #350). Storage
+                // lives on the base SharpTSPromise so plain and subclass promises
+                // both accept defineProperty. Attribute-only descriptors preserve
+                // the existing value per ECMA-262 §10.1.6.3.
+                if (descriptor.Get != null || descriptor.Set != null)
+                {
+                    promise.DefineAccessor(propertyKey, descriptor.Get, descriptor.Set);
+                }
+                else if (DescriptorHasValueOrAccessor(descriptorArg))
+                {
+                    promise.SetOwnProperty(propertyKey, descriptor.Value);
+                }
+                success = true;
+                break;
             default:
                 throw new Exception("TypeError: Object.defineProperty called on non-object");
         }

--- a/Runtime/BuiltIns/PromiseBuiltIns.cs
+++ b/Runtime/BuiltIns/PromiseBuiltIns.cs
@@ -24,22 +24,21 @@ public static class PromiseBuiltIns
     /// </remarks>
     public static object? GetMember(SharpTSPromise receiver, string name)
     {
-        var factory = SpeciesPromiseFactory(receiver);
         return name switch
         {
             "then" => new BuiltInAsyncMethod("then", 1, 2, (interp, recv, args) =>
-                ThenImpl((SharpTSPromise)recv!, args, interp), factory).Bind(receiver),
+                ThenImpl((SharpTSPromise)recv!, args, interp), speciesResolver: SpeciesResolver).Bind(receiver),
 
             "catch" => new BuiltInAsyncMethod("catch", 1, 1, (interp, recv, args) =>
-                CatchImpl((SharpTSPromise)recv!, args, interp), factory).Bind(receiver),
+                CatchImpl((SharpTSPromise)recv!, args, interp), speciesResolver: SpeciesResolver).Bind(receiver),
 
             "finally" => new BuiltInAsyncMethod("finally", 1, 1, (interp, recv, args) =>
-                FinallyImpl((SharpTSPromise)recv!, args, interp), factory).Bind(receiver),
+                FinallyImpl((SharpTSPromise)recv!, args, interp), speciesResolver: SpeciesResolver).Bind(receiver),
 
             // ECMA-262 §27.2.5.1: Promise.prototype.constructor is %Promise%.
             // (Subclass instances report their own class — see
             // Interpreter.Properties.cs. then/catch/finally now consult
-            // SpeciesConstructor via SpeciesPromiseFactory, #221.)
+            // SpeciesConstructor via the SpeciesResolver pre-step, #221/#350.)
             "constructor" => Interpreter.PromiseGlobalValue,
 
             _ => null
@@ -115,29 +114,55 @@ public static class PromiseBuiltIns
     }
 
     /// <summary>
-    /// Returns the result-promise factory for the prototype methods
-    /// (<c>then</c>/<c>catch</c>/<c>finally</c>), which per ECMA-262 §27.2.5.4
-    /// construct their result through <c>SpeciesConstructor(promise, %Promise%)</c>.
-    /// Plain promises (always <c>%Promise%</c>) keep the default wrapping
-    /// (null factory). For a subclass receiver the species lookup is performed
-    /// lazily, when the factory runs (i.e. when the method is invoked), so a
-    /// throwing <c>@@species</c> getter surfaces synchronously from the call and
-    /// the default — inherited <c>Promise[@@species]</c> returns the constructor
-    /// itself — yields the receiver's own class.
+    /// The synchronous SpeciesConstructor pre-step shared by
+    /// <c>then</c>/<c>catch</c>/<c>finally</c> (passed to
+    /// <see cref="BuiltInAsyncMethod"/> as its <c>speciesResolver</c>). Run at
+    /// call time before the rejected-promise conversion, so a poisoned
+    /// <c>constructor</c>/<c>@@species</c> getter throws synchronously (#350).
     /// </summary>
-    private static Func<Interpreter, Task<object?>, SharpTSPromise>? SpeciesPromiseFactory(SharpTSPromise receiver)
+    private static readonly Func<Interpreter, object?, Func<Interpreter, Task<object?>, SharpTSPromise>?> SpeciesResolver =
+        static (interp, recv) => ResolveResultPromiseFactory((SharpTSPromise)recv!, interp);
+
+    /// <summary>
+    /// Computes the result-promise factory for the prototype methods
+    /// (<c>then</c>/<c>catch</c>/<c>finally</c>) per ECMA-262 §27.2.5.4 step 3,
+    /// <c>SpeciesConstructor(promise, %Promise%)</c> (§7.3.22). Returns null to
+    /// mean <c>%Promise%</c> (plain wrapping) or a factory that constructs the
+    /// result through a guest Promise class.
+    /// </summary>
+    /// <remarks>
+    /// §7.3.22 step 1 is <c>Get(promise, "constructor")</c>: an own
+    /// <c>constructor</c> accessor installed via <c>Object.defineProperty</c>
+    /// (a poisoned getter, test262 then/ctor-poisoned, #350) is invoked here and
+    /// a throw propagates synchronously. The getter's RETURN value does not
+    /// redirect species — the receiver's own class still drives the result; an
+    /// own <c>constructor</c> that resolves to a DIFFERENT constructor (or an own
+    /// data property, or the general non-Promise NewPromiseCapability) is the
+    /// #349/#350 remainder, and is kept symmetric with the compiled
+    /// <c>WrapDerivedPromiseResult</c> path. Absent an own override, the inherited
+    /// <c>Promise.prototype.constructor</c> is the receiver's own class (subclass)
+    /// or <c>%Promise%</c> (plain); a subclass then reads its static
+    /// <c>@@species</c> (#221).
+    /// </remarks>
+    private static Func<Interpreter, Task<object?>, SharpTSPromise>? ResolveResultPromiseFactory(
+        SharpTSPromise receiver, Interpreter interp)
     {
-        if (receiver is not SharpTSPromiseSubclassInstance sub)
-            return null;
-        var klass = sub.Klass;
-        return (interp, task) =>
-        {
-            var species = ResolveSpeciesConstructor(klass, interp);
-            return species == null
-                ? new SharpTSPromise(task)              // %Promise%
-                : species.ConstructDerived(interp, task);
-        };
+        if (receiver.TryGetAccessor("constructor", out var ctorGetter, out _) && ctorGetter != null)
+            ctorGetter.Call(interp, []);   // side effect only: a poisoned getter throws → propagates
+
+        // The receiver's own class drives species: a subclass reads its static
+        // @@species (#221); a plain promise stays %Promise% (null factory).
+        return receiver is SharpTSPromiseSubclassInstance sub
+            ? SpeciesMaterializer(ResolveSpeciesConstructor(sub.Klass, interp))
+            : null;
     }
+
+    /// <summary>
+    /// Wraps a resolved species class into a result-promise factory, or returns
+    /// null (meaning <c>%Promise%</c>, the plain wrapping) when species is null.
+    /// </summary>
+    private static Func<Interpreter, Task<object?>, SharpTSPromise>? SpeciesMaterializer(SharpTSPromiseClass? species)
+        => species == null ? null : (interp, task) => species.ConstructDerived(interp, task);
 
     /// <summary>
     /// Computes SpeciesConstructor(promise, %Promise%) (ECMA-262 §7.3.22) for a
@@ -154,9 +179,10 @@ public static class PromiseBuiltIns
     /// <remarks>
     /// A species override that returns a non-Promise constructor (the general
     /// NewPromiseCapability path) is not yet supported and falls back to
-    /// <c>%Promise%</c> — tracked by #349. A poisoned <c>constructor</c> getter
-    /// (own accessor on the instance, <c>then/ctor-poisoned.js</c>) is likewise
-    /// out of scope — tracked by #350.
+    /// <c>%Promise%</c> — tracked by #349. A poisoned own <c>constructor</c>
+    /// getter (<c>then/ctor-poisoned.js</c>, #350) is handled earlier, in
+    /// <see cref="ResolveResultPromiseFactory"/>, which reads
+    /// <c>Get(promise, "constructor")</c> before reaching here.
     /// </remarks>
     private static SharpTSPromiseClass? ResolveSpeciesConstructor(SharpTSPromiseClass klass, Interpreter interp)
     {

--- a/Runtime/Types/SharpTSPromise.cs
+++ b/Runtime/Types/SharpTSPromise.cs
@@ -22,6 +22,56 @@ public class SharpTSPromise : ITypeCategorized
 
     private readonly Task<object?> _task;
 
+    // Own properties installed on a promise instance via Object.defineProperty
+    // (and, for subclass instances, declared fields). Base promises have none
+    // until user code adds one — a poisoned `constructor` getter
+    // (Object.defineProperty(p, "constructor", { get() { throw … } }), test262
+    // then/ctor-poisoned, #350) is the motivating case. Both dictionaries are
+    // lazily allocated so plain promises stay allocation-free.
+    private Dictionary<string, object?>? _ownProperties;
+    private Dictionary<string, (ISharpTSCallable? Getter, ISharpTSCallable? Setter)>? _accessors;
+
+    /// <summary>
+    /// Reads an own data property installed on this promise instance.
+    /// </summary>
+    public bool TryGetOwnProperty(string name, out object? value)
+    {
+        if (_ownProperties != null && _ownProperties.TryGetValue(name, out value))
+            return true;
+        value = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Stores an own data property on this promise instance.
+    /// </summary>
+    public void SetOwnProperty(string name, object? value)
+        => (_ownProperties ??= [])[name] = value;
+
+    /// <summary>
+    /// Registers an own accessor pair from <c>Object.defineProperty</c>. Either
+    /// half may be null (one-sided accessor); a later definition on the same key
+    /// replaces the previous one.
+    /// </summary>
+    public void DefineAccessor(string name, ISharpTSCallable? getter, ISharpTSCallable? setter)
+        => (_accessors ??= [])[name] = (getter, setter);
+
+    /// <summary>
+    /// Looks up an own accessor for <paramref name="name"/>. Returns true and
+    /// the (getter, setter) pair when one is registered.
+    /// </summary>
+    public bool TryGetAccessor(string name, out ISharpTSCallable? getter, out ISharpTSCallable? setter)
+    {
+        if (_accessors != null && _accessors.TryGetValue(name, out var pair))
+        {
+            (getter, setter) = pair;
+            return true;
+        }
+        getter = null;
+        setter = null;
+        return false;
+    }
+
     /// <summary>
     /// Creates a Promise wrapping an existing Task.
     /// </summary>

--- a/Runtime/Types/SharpTSPromiseClass.cs
+++ b/Runtime/Types/SharpTSPromiseClass.cs
@@ -14,8 +14,6 @@ namespace SharpTS.Runtime.Types;
 /// <seealso cref="SharpTSPromiseClass"/>
 public sealed class SharpTSPromiseSubclassInstance : SharpTSPromise
 {
-    private Dictionary<string, object?>? _ownProperties;
-
     /// <summary>The guest class this promise was constructed by.</summary>
     public SharpTSPromiseClass Klass { get; }
 
@@ -32,17 +30,6 @@ public sealed class SharpTSPromiseSubclassInstance : SharpTSPromise
         Klass = klass;
         Capability = capability;
     }
-
-    public bool TryGetOwnProperty(string name, out object? value)
-    {
-        if (_ownProperties != null && _ownProperties.TryGetValue(name, out value))
-            return true;
-        value = null;
-        return false;
-    }
-
-    public void SetOwnProperty(string name, object? value)
-        => (_ownProperties ??= [])[name] = value;
 }
 
 /// <summary>
@@ -61,9 +48,11 @@ public sealed class SharpTSPromiseSubclassInstance : SharpTSPromise
 /// SpeciesConstructor-aware results from <c>then</c>/<c>catch</c>/<c>finally</c>
 /// (#221 — see <see cref="Runtime.BuiltIns.PromiseBuiltIns"/>
 /// <c>ResolveSpeciesConstructor</c>; the static methods build through the
-/// receiver constructor <c>C</c> directly per spec). Remaining spec surface:
-/// a non-Promise species constructor (general NewPromiseCapability, #349) and
-/// poisoned <c>constructor</c>/@@species getters (#350).
+/// receiver constructor <c>C</c> directly per spec). A poisoned own
+/// <c>constructor</c> getter makes then/catch/finally throw synchronously (#350,
+/// via <c>PromiseBuiltIns.ResolveResultPromiseFactory</c>). Remaining spec
+/// surface: a non-Promise species constructor (general NewPromiseCapability,
+/// #349).
 /// </remarks>
 public class SharpTSPromiseClass : SharpTSClass
 {

--- a/SharpTS.Tests/SharedTests/PromiseSubclassTests.cs
+++ b/SharpTS.Tests/SharedTests/PromiseSubclassTests.cs
@@ -600,4 +600,131 @@ public class PromiseSubclassTests
 
     #endregion
 
+    #region Poisoned constructor getter (#350) — then/catch/finally throw synchronously
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void PoisonedConstructor_ThenThrowsSynchronously(ExecutionMode mode)
+    {
+        // ECMA-262 §27.2.5.4 step 3 resolves SpeciesConstructor(promise, %Promise%)
+        // via §7.3.22 step 1 = Get(promise, "constructor") BEFORE PerformPromiseThen
+        // (a ReturnIfAbrupt). An own `constructor` getter installed via
+        // Object.defineProperty that throws must therefore make `then` throw
+        // SYNCHRONOUSLY — not return a rejected promise. test262
+        // built-ins/Promise/prototype/then/ctor-poisoned.js.
+        var source = """
+            const p = new Promise<number>(function () {});
+            Object.defineProperty(p, "constructor", {
+                get() { throw new Error("poisoned"); }
+            });
+            let threw = false;
+            try {
+                p.then(v => v);
+            } catch (e) {
+                threw = true;
+                console.log((e as Error).message);
+            }
+            console.log(threw);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("poisoned\ntrue\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void PoisonedConstructor_CatchThrowsSynchronously(ExecutionMode mode)
+    {
+        // catch delegates to then, so the same synchronous SpeciesConstructor
+        // read applies.
+        var source = """
+            const p = new Promise<number>(function () {});
+            Object.defineProperty(p, "constructor", {
+                get() { throw new Error("poisoned-catch"); }
+            });
+            let threw = false;
+            try {
+                p.catch(() => 0);
+            } catch (e) {
+                threw = true;
+                console.log((e as Error).message);
+            }
+            console.log(threw);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("poisoned-catch\ntrue\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void PoisonedConstructor_FinallyThrowsSynchronously(ExecutionMode mode)
+    {
+        // finally also resolves SpeciesConstructor for its result promise.
+        var source = """
+            const p = new Promise<number>(function () {});
+            Object.defineProperty(p, "constructor", {
+                get() { throw new Error("poisoned-finally"); }
+            });
+            let threw = false;
+            try {
+                p.finally(() => {});
+            } catch (e) {
+                threw = true;
+                console.log((e as Error).message);
+            }
+            console.log(threw);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("poisoned-finally\ntrue\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void PoisonedConstructor_DoesNotAffectNormalThen(ExecutionMode mode)
+    {
+        // Regression guard: a promise WITHOUT a poisoned `constructor` accessor
+        // still resolves through %Promise% and `then` works normally.
+        var source = """
+            async function main() {
+                const r = await Promise.resolve(1).then(v => v + 10);
+                console.log(r);
+            }
+            main();
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("11\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void PoisonedConstructor_OwnAccessorWinsOverSubclassConstructor(ExecutionMode mode)
+    {
+        // An own `constructor` accessor on a Promise SUBCLASS instance shadows the
+        // synthetic `constructor` (which otherwise reports the subclass), so its
+        // poisoned getter still fires from then.
+        var source = """
+            class MyP extends Promise<number> {}
+            const p = new MyP((resolve) => resolve(1));
+            Object.defineProperty(p, "constructor", {
+                get() { throw new Error("poisoned-sub"); }
+            });
+            let threw = false;
+            try {
+                p.then(v => v);
+            } catch (e) {
+                threw = true;
+                console.log((e as Error).message);
+            }
+            console.log(threw);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("poisoned-sub\ntrue\n", output);
+    }
+
+    #endregion
+
 }


### PR DESCRIPTION
Closes #350.

## Problem

ECMA-262 §27.2.5.4 step 3 resolves `SpeciesConstructor(promise, %Promise%)` via §7.3.22 step 1 = `Get(promise, "constructor")`, **before** `PerformPromiseThen` (a `ReturnIfAbrupt`). So a poisoned own `constructor` getter:

```ts
const p = Promise.resolve("foo");
Object.defineProperty(p, "constructor", { get() { throw new Error("x"); } });
p.then(f, g);   // must throw SYNCHRONOUSLY, not reject the result promise
```

SharpTS read the receiver class directly and never consulted a guest-visible own `constructor`, so the poisoned getter never fired. `built-ins/Promise/prototype/then/ctor-poisoned.js` was baselined `Fail`/`RuntimeError`.

## Fix

**Storage.** Own data-property + accessor storage is consolidated onto the base `SharpTSPromise` (the subclass `SharpTSPromiseSubclassInstance` inherits it), so `Object.defineProperty` can target *plain* promises — not just subclass instances.

**Interpreter.**
- `Object.defineProperty` accepts a `SharpTSPromise` target (mirrors the existing RegExp branch).
- Promise property GET consults own accessors first, so a poisoned `constructor` getter fires (also makes a plain `promise.constructor` read invoke it).
- `BuiltInAsyncMethod` gains an optional synchronous `speciesResolver` pre-step that runs the SpeciesConstructor read **outside** the rejected-promise `try`, so a poisoned `constructor`/`@@species` getter throws synchronously out of the `then`/`catch`/`finally` call instead of being swallowed into a rejection.

**Compiled.** `WrapDerivedPromiseResult` reads the own `constructor` getter from `$PropertyDescriptorStore` at the top and invokes it for its throw side-effect (IL-verified), before the `$Promise`-subclass species narrowing — so it covers plain promises (raw `Task` / base `$Promise`) too.

The getter's **return value** does not redirect species (the receiver's own class still drives the result); an own `constructor` that resolves to a *different* constructor (or an own data property, or the general non-Promise NewPromiseCapability) is the #349/#350 remainder, kept symmetric across both modes.

## Tests

5 new `PromiseSubclassTests` × both modes: `then`/`catch`/`finally` throw synchronously on a poisoned getter; a normal `then` is unaffected; an own `constructor` accessor wins over a subclass's synthetic `constructor`. Verified against the **real test262 assembled harness** (`sta.js` + `assert.js` + the test) in both interpreted and compiled mode. Full xUnit suite green (11198).

## test262 baseline

`then/ctor-poisoned.js` now passes in both modes (verified via the assembled-harness CLI). The committed baselines are **left unchanged here**: the in-process interpreter regen is environmentally flaky locally (test-host CLR crash `0x80131506` + cross-test pollution flipping unrelated Array/JSON/String entries), so committing a regenerated baseline would add noise. A clean regen should pick this up separately.

## Follow-ups filed

- **#382** — `then`/`catch`/`finally` reject 0-argument calls (`p.then()`), an orthogonal arity bug discovered here. `ctor-poisoned` itself uses `then(f, g)` so it does not need it; kept out to keep this PR focused on the SpeciesConstructor read.