### PR TITLE
fix(promise): then/catch/finally accept 0-argument calls (#382)

### DIFF
--- a/Runtime/BuiltIns/PromiseBuiltIns.cs
+++ b/Runtime/BuiltIns/PromiseBuiltIns.cs
@@ -26,13 +26,17 @@ public static class PromiseBuiltIns
     {
         return name switch
         {
-            "then" => new BuiltInAsyncMethod("then", 1, 2, (interp, recv, args) =>
+            // Per ECMA-262 the handler arguments are all optional: §27.2.5.4
+            // then(onFulfilled?, onRejected?), §27.2.5.1 catch(onRejected?),
+            // §27.2.5.3 finally(onFinally?). minArity is 0; maxArity pins the
+            // spec shape. The impls null-default any missing args (#382).
+            "then" => new BuiltInAsyncMethod("then", 0, 2, (interp, recv, args) =>
                 ThenImpl((SharpTSPromise)recv!, args, interp), speciesResolver: SpeciesResolver).Bind(receiver),
 
-            "catch" => new BuiltInAsyncMethod("catch", 1, 1, (interp, recv, args) =>
+            "catch" => new BuiltInAsyncMethod("catch", 0, 1, (interp, recv, args) =>
                 CatchImpl((SharpTSPromise)recv!, args, interp), speciesResolver: SpeciesResolver).Bind(receiver),
 
-            "finally" => new BuiltInAsyncMethod("finally", 1, 1, (interp, recv, args) =>
+            "finally" => new BuiltInAsyncMethod("finally", 0, 1, (interp, recv, args) =>
                 FinallyImpl((SharpTSPromise)recv!, args, interp), speciesResolver: SpeciesResolver).Bind(receiver),
 
             // ECMA-262 §27.2.5.1: Promise.prototype.constructor is %Promise%.

--- a/SharpTS.Tests/SharedTests/PromiseMethodTests.cs
+++ b/SharpTS.Tests/SharedTests/PromiseMethodTests.cs
@@ -112,6 +112,59 @@ public class PromiseMethodTests
         Assert.Equal("42\n", output);
     }
 
+    // Per ECMA-262 the handler arguments to then/catch/finally are all
+    // optional, so a zero-argument call is legal and acts as a pass-through
+    // (then/catch) or no-op (finally). Previously the interpreter registered
+    // these with minArity 1 and threw "expects 1-2 arguments but got 0" (#382).
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Then_ZeroArgs_PassesValueThrough(ExecutionMode mode)
+    {
+        var source = """
+            async function main(): Promise<void> {
+                let result = await Promise.resolve(5).then();
+                console.log(result);
+            }
+            main();
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("5\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Catch_ZeroArgs_PassesValueThrough(ExecutionMode mode)
+    {
+        var source = """
+            async function main(): Promise<void> {
+                let result = await Promise.resolve(7).catch();
+                console.log(result);
+            }
+            main();
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("7\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Finally_ZeroArgs_PassesValueThrough(ExecutionMode mode)
+    {
+        var source = """
+            async function main(): Promise<void> {
+                let result = await Promise.resolve(9).finally();
+                console.log(result);
+            }
+            main();
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("9\n", output);
+    }
+
     #endregion
 
     #region Promise.catch() Tests


### PR DESCRIPTION
## Summary

`Promise.prototype.then`, `.catch`, and `.finally` were registered with `minArity: 1` in the interpreter (`Runtime/BuiltIns/PromiseBuiltIns.cs` `GetMember`), so a zero-argument call threw a spurious runtime error:

```ts
Promise.resolve(5).then();   // was: Runtime Error: 'then' expects 1-2 arguments but got 0.
```

Per ECMA-262 the handler arguments are all optional (§27.2.5.4 `then`, §27.2.5.1 `catch`, §27.2.5.3 `finally`). The impls (`ThenImpl`/`CatchImpl`/`FinallyImpl`) already null-default missing args, so the correct minimum arity is **0**; `maxArity` still pins the spec shape (2 / 1 / 1).

Compiled mode already accepted 0 args (it emits `ldnull` for missing handlers), so this was an interpreter-only divergence. Fixes #382.

## Changes

- `PromiseBuiltIns.GetMember`: change the three registrations from `(name, 1, …)` to `(name, 0, …)`.
- Added regression tests (`Then/Catch/Finally_ZeroArgs_PassesValueThrough`) running in both interpreter and compiled modes.

## Testing

- New tests pass in both modes (6/6).
- `PromiseMethodTests`, `PromiseSubclassTests`, `AsyncAwaitTests` all green (240/240).