### PR TITLE
fix(type-checker): pre-resolve forward-referenced local function return types (#383)

### DIFF
--- a/SharpTS.Tests/TypeCheckerTests/ForwardLocalFunctionReturnTypeTests.cs
+++ b/SharpTS.Tests/TypeCheckerTests/ForwardLocalFunctionReturnTypeTests.cs
@@ -1,0 +1,203 @@
+using System.Collections.Generic;
+using System.Linq;
+using SharpTS.Diagnostics;
+using SharpTS.Parsing;
+using SharpTS.Tests.Infrastructure;
+using SharpTS.TypeSystem;
+using SharpTS.TypeSystem.Exceptions;
+using Xunit;
+
+namespace SharpTS.Tests.TypeCheckerTests;
+
+/// <summary>
+/// Issue #383: a local <c>function</c> declaration's inferred return type must be available to
+/// calls that appear textually <em>before</em> the declaration in the same scope. Previously the
+/// checker hoisted such functions with an <c>any</c> return placeholder and only inferred the real
+/// type when the body was reached, so an earlier call typed as <c>any</c> and silently skipped
+/// assignment/return checks. Hoisting now speculatively pre-resolves the return type.
+/// </summary>
+public class ForwardLocalFunctionReturnTypeTests
+{
+    [Fact]
+    public void NestedForwardCall_AssignedToAnnotatedVar_IsTs2322Error()
+    {
+        var source = """
+            function h() {
+                var z: number = make();
+                function make() { return "hi"; }
+            }
+            """;
+        var ex = Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+        Assert.Equal("TS2322", ex.Diagnostic.TsCode);
+    }
+
+    [Fact]
+    public void TopLevelForwardCall_AssignedToAnnotatedVar_IsTs2322Error()
+    {
+        var source = """
+            var z: number = make();
+            function make() { return "hi"; }
+            """;
+        var ex = Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+        Assert.Equal("TS2322", ex.Diagnostic.TsCode);
+    }
+
+    [Fact]
+    public void ForwardCall_DeclaredBefore_StillReports_Control()
+    {
+        // The already-working ordering: the function is declared before the call.
+        var source = """
+            function h() {
+                function make() { return "hi"; }
+                var z: number = make();
+            }
+            """;
+        var ex = Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+        Assert.Equal("TS2322", ex.Diagnostic.TsCode);
+    }
+
+    [Fact]
+    public void ForwardCall_CompatibleType_IsNotError()
+    {
+        // The inferred return type (string) matches the annotation — no false positive.
+        var source = """
+            function h() {
+                var z: string = make();
+                function make() { return "hi"; }
+            }
+            """;
+        TestHarness.RunInterpreted(source);
+    }
+
+    [Fact]
+    public void ForwardCall_InReturnPosition_IsTs2322Error()
+    {
+        // The pre-resolved return type also drives the enclosing function's return check.
+        var source = """
+            function h(): number {
+                return make();
+                function make() { return "hi"; }
+            }
+            """;
+        var ex = Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+        Assert.Equal("TS2322", ex.Diagnostic.TsCode);
+    }
+
+    [Fact]
+    public void ForwardCall_NumericInference_AssignedToString_IsTs2322Error()
+    {
+        var source = """
+            function h() {
+                var z: string = compute();
+                function compute() { return 1 + 2; }
+            }
+            """;
+        var ex = Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+        Assert.Equal("TS2322", ex.Diagnostic.TsCode);
+    }
+
+    [Fact]
+    public void Issue378Interaction_HoistedVarFromForwardCall_IsTs2403Error()
+    {
+        // The residual #378 shape: a hoisted `var` whose first nested initializer is a
+        // forward-referenced local function call. The inferred return type (string) now flows into
+        // the hoisted binding so a later `var z: number;` conflicts.
+        var source = """
+            function h(c: boolean) {
+                if (c) { var z = make(); }
+                var z: number;
+                function make() { return "hi"; }
+            }
+            """;
+        var ex = Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+        Assert.Equal("TS2403", ex.Diagnostic.TsCode);
+    }
+
+    [Fact]
+    public void MutuallyRecursiveForwardFunctions_DoNotLoop()
+    {
+        // Mutual recursion between two un-annotated forward-referenced functions must terminate
+        // during speculative inference (each sees the other's `any` placeholder mid-flight) rather
+        // than recursing infinitely. Behavior is otherwise unchanged.
+        var source = """
+            function h(): boolean {
+                return isEven(4);
+                function isEven(n: number) { return n === 0 ? true : isOdd(n - 1); }
+                function isOdd(n: number) { return n === 0 ? false : isEven(n - 1); }
+            }
+            console.log(h());
+            """;
+        Assert.Equal("true", TestHarness.RunInterpreted(source).Trim());
+    }
+
+    [Fact]
+    public void RecursiveForwardFunction_DoesNotCrash()
+    {
+        // A self-recursive forward function: speculative inference must not recurse infinitely.
+        var source = """
+            function h() {
+                var z: number = fact(5);
+                function fact(n: number) {
+                    if (n <= 1) { return 1; }
+                    return n * fact(n - 1);
+                }
+                return z;
+            }
+            """;
+        // fact infers `number`, so assigning to a number var is fine — no error.
+        TestHarness.RunInterpreted(source);
+    }
+
+    [Fact]
+    public void ForwardFunctionInnerError_ReportedExactlyOnce()
+    {
+        // Speculative hoist-time inference checks the forward function's body with diagnostics
+        // suppressed; the real declaration pass reports them. An error inside the body must surface
+        // exactly once — never swallowed, never duplicated.
+        var source = """
+            function h() {
+                var z: string = make();
+                function make() { let bad: number = "x"; return "hi"; }
+            }
+            """;
+        var diagnostics = CheckWithRecovery(source);
+        Assert.Equal(1, diagnostics.Count(d => d.TsCode == "TS2322"));
+    }
+
+    [Fact]
+    public void ForwardCallAndInnerError_BothReported_Once()
+    {
+        // The forward-reference assignment error and an error inside the forward function are
+        // independent diagnostics: both surface, each once.
+        var source = """
+            function h() {
+                var z: number = make();
+                function make() { let bad: string = 5; return "hi"; }
+            }
+            """;
+        var diagnostics = CheckWithRecovery(source);
+        // `z = make()` (string→number) and `bad = 5` (number→string): two TS2322, no duplicates.
+        Assert.Equal(2, diagnostics.Count(d => d.TsCode == "TS2322"));
+    }
+
+    [Fact]
+    public void ForwardCall_RuntimeBehaviorUnchanged()
+    {
+        // Pre-resolution is a checker-only change: runtime hoisting/execution is unaffected.
+        var source = """
+            function h(): string {
+                return make();
+                function make() { return "hi"; }
+            }
+            console.log(h());
+            """;
+        Assert.Equal("hi", TestHarness.RunInterpreted(source).Trim());
+    }
+
+    private static IReadOnlyList<Diagnostic> CheckWithRecovery(string source)
+    {
+        var parseResult = new Parser(new Lexer(source).ScanTokens()).Parse();
+        Assert.True(parseResult.IsSuccess);
+        return new TypeChecker(maxErrors: 50).CheckWithRecovery(parseResult.Statements).Diagnostics;
+    }
+}

--- a/TypeSystem/TypeChecker.Statements.Functions.cs
+++ b/TypeSystem/TypeChecker.Statements.Functions.cs
@@ -42,7 +42,11 @@ public partial class TypeChecker
     /// </summary>
     private void HoistFunctionDeclarations(IEnumerable<Stmt> statements)
     {
-        foreach (var stmt in statements)
+        // Materialized once: the two passes below each iterate the statements.
+        var stmtList = statements as IReadOnlyList<Stmt> ?? statements.ToList();
+
+        // Pass 1: register each declaration's signature (un-annotated return types as `any`).
+        foreach (var stmt in stmtList)
         {
             // Handle top-level functions. Body-less declarations (ambient `declare function`,
             // overload signatures) hoist too — tsc resolves calls that precede the declaration.
@@ -61,7 +65,59 @@ public partial class TypeChecker
 
         // Hoist const/let/var declarations with function expressions
         // This enables mutual recursion like: const isEven = function(n) { return isOdd(n-1); };
-        HoistConstFunctionExpressions(statements);
+        HoistConstFunctionExpressions(stmtList);
+
+        // Pass 2: now that every sibling signature is registered, speculatively infer the return
+        // type of un-annotated functions so calls appearing earlier in the same scope type
+        // precisely instead of as `any` (#383). Done as a separate pass so sibling references
+        // resolve regardless of declaration order.
+        foreach (var stmt in stmtList)
+        {
+            if (stmt is Stmt.Function f2)
+                RefineHoistedFunctionReturnType(f2);
+            else if (stmt is Stmt.Export { Declaration: Stmt.Function ef2 })
+                RefineHoistedFunctionReturnType(ef2);
+        }
+    }
+
+    /// <summary>
+    /// Second hoisting pass for a single un-annotated <c>function</c> declaration: speculatively
+    /// infers its return type and registers the refined signature, so a call that textually
+    /// precedes the declaration in the same scope sees a concrete return type rather than
+    /// <c>any</c> (issue #383). The inferred type is memoized in <see cref="_hoistInferredReturnTypes"/>
+    /// and re-registered into each fresh scope on later passes without re-checking the body.
+    /// </summary>
+    private void RefineHoistedFunctionReturnType(Stmt.Function funcStmt)
+    {
+        // Only plain, implemented, non-generic, non-overloaded functions without a return
+        // annotation are eligible. Generics defer to the real pass; overload groups drive call
+        // sites from their explicit signatures, not the implementation's inferred return.
+        if (funcStmt.ReturnType != null || funcStmt.Body == null) return;
+        if (funcStmt.TypeParams is { Count: > 0 }) return;
+        string funcName = funcStmt.Name.Lexeme;
+        if (_pendingOverloadSignatures.ContainsKey(funcName)) return;
+        if (!_environment.IsDefinedLocally(funcName)) return;
+        if (_environment.Get(funcName) is not TypeInfo.Function hoisted || hoisted.ReturnType is not TypeInfo.Any)
+            return; // not our hoisted `any` placeholder (annotated, redefined, or already refined)
+
+        if (_hoistInferredReturnTypes.TryGetValue(funcStmt, out var cached))
+        {
+            // Re-register a previously inferred type into this (fresh) scope. A null value marks an
+            // in-progress (mutual recursion) or failed inference — leave the placeholder in place.
+            if (cached != null)
+                _environment.Define(funcName, new TypeInfo.Function(
+                    hoisted.ParamTypes, cached, hoisted.RequiredParams, hoisted.HasRestParam,
+                    hoisted.ThisType, hoisted.ParamNames));
+            return;
+        }
+
+        // Mark in-progress before inferring so mutual recursion terminates against the placeholder.
+        _hoistInferredReturnTypes[funcStmt] = null;
+        var funcEnv = new TypeEnvironment(_environment);
+        CheckFunctionBodyAndInferReturn(
+            funcStmt, funcEnv, hoisted.ParamTypes, hoisted.RequiredParams, hoisted.HasRestParam,
+            hoisted.ParamNames ?? new List<string>(), hoisted.ThisType, typeParams: null,
+            returnType: new TypeInfo.Inferred(), inferringReturnType: true, funcName, suppress: true);
     }
 
     /// <summary>
@@ -484,6 +540,36 @@ public partial class TypeChecker
             _typeMap.SetFunctionType(funcName, new TypeInfo.Function(gf.ParamTypes, gf.ReturnType, gf.RequiredParams, gf.HasRestParam, gf.ThisType));
         }
 
+        // Check the body and (when un-annotated) resolve & register the inferred return type.
+        CheckFunctionBodyAndInferReturn(
+            funcStmt, funcEnv, paramTypes, requiredParams, hasRest, paramNames,
+            thisType, typeParams, returnType, inferringReturnType, funcName, suppress: false);
+    }
+
+    /// <summary>
+    /// Binds parameters and checks a function body, resolving and registering the inferred return
+    /// type when the declaration carries no explicit return annotation. Shared by the normal
+    /// declaration pass (<paramref name="suppress"/> = false) and by hoisting's speculative
+    /// pre-resolution (<paramref name="suppress"/> = true, issue #383).
+    ///
+    /// In suppressed mode diagnostics are swallowed and the body is checked in recovery mode so
+    /// every <c>return</c> is seen; any failure degrades to leaving the hoisted <c>any</c>
+    /// placeholder. The real declaration pass re-checks the same body and reports diagnostics at
+    /// their proper locations, so suppressed checking never produces a duplicate or final error.
+    /// </summary>
+    private void CheckFunctionBodyAndInferReturn(
+        Stmt.Function funcStmt, TypeEnvironment funcEnv,
+        List<TypeInfo> paramTypes, int requiredParams, bool hasRest, List<string> paramNames,
+        TypeInfo? thisType, List<TypeInfo.TypeParameter>? typeParams,
+        TypeInfo returnType, bool inferringReturnType, string funcName, bool suppress)
+    {
+        // Both callers guarantee a body: CheckFunctionDeclaration returns early for body-less
+        // overload/ambient signatures, and RefineHoistedFunctionReturnType filters them out.
+        List<Stmt> body = funcStmt.Body!;
+
+        // The enclosing environment, where the (possibly refined) function type is registered.
+        TypeEnvironment previousEnv = _environment;
+
         // Add parameters to function environment and check body
         for (int i = 0; i < funcStmt.Parameters.Count; i++)
         {
@@ -491,7 +577,6 @@ public partial class TypeChecker
         }
 
         // Save and set context - function bodies are isolated from outer loop/switch/label context
-        TypeEnvironment previousEnv = _environment;
         TypeInfo? previousReturn = _currentFunctionReturnType;
         TypeInfo? previousThisType = _currentFunctionThisType;
         bool previousInAsync = _inAsyncFunction;
@@ -499,6 +584,7 @@ public partial class TypeChecker
         int previousLoopDepth = _loopDepth;
         int previousSwitchDepth = _switchDepth;
         var previousActiveLabels = new Dictionary<string, bool>(_activeLabels);
+        bool previousRecoveryMode = _recoveryMode;
 
         var previousInferredReturnTypes = _inferredReturnTypes;
 
@@ -518,6 +604,12 @@ public partial class TypeChecker
         _loopDepth = 0;
         _switchDepth = 0;
         _activeLabels.Clear();
+        if (suppress)
+        {
+            // Collect-and-discard: continue past errors to observe every `return`, record nothing.
+            _recoveryMode = true;
+            _suppressDiagnostics++;
+        }
 
         // Push a new scope for declared variable types and record parameter types
         PushDeclaredVariableScope();
@@ -540,24 +632,34 @@ public partial class TypeChecker
 
         try
         {
-            // Hoist inner function declarations so forward references resolve.
-            // JS spec hoists all `function` decls to the top of the containing
-            // scope before any statement executes; the TypeChecker needs to
-            // mirror that to accept well-formed mutually-recursive inner fns.
-            HoistFunctionDeclarations(funcStmt.Body);
+            bool bodyFailed = false;
+            try
+            {
+                // Hoist inner function declarations so forward references resolve.
+                // JS spec hoists all `function` decls to the top of the containing
+                // scope before any statement executes; the TypeChecker needs to
+                // mirror that to accept well-formed mutually-recursive inner fns.
+                HoistFunctionDeclarations(body);
 
-            CheckStmtList(funcStmt.Body);
+                CheckStmtList(body);
 
-            // #367: flag returns of a number/boolean-typed local that an `any`/`undefined`
-            // assignment may have left holding the undefined sentinel (no-op unless the declared
-            // return is number/boolean). Runs after the body so every sub-expression type is known.
-            MarkUndefinedReachableLocalReturns(funcStmt.Body);
+                // #367: flag returns of a number/boolean-typed local that an `any`/`undefined`
+                // assignment may have left holding the undefined sentinel (no-op unless the declared
+                // return is number/boolean). Runs after the body so every sub-expression type is known.
+                // Skipped while speculating — it only matters for the emitted output of the real pass.
+                if (!suppress)
+                    MarkUndefinedReachableLocalReturns(body);
+            }
+            catch (Exception) when (suppress)
+            {
+                // Speculative inference is best-effort: degrade to the `any` placeholder on any failure.
+                bodyFailed = true;
+            }
 
             // Resolve inferred return type from collected return expressions
-            if (inferringReturnType)
+            if (inferringReturnType && !bodyFailed)
             {
                 var collected = _inferredReturnTypes!;
-                _inferredReturnTypes = null;
 
                 TypeInfo inferredReturn;
                 if (collected.Count == 0)
@@ -588,10 +690,18 @@ public partial class TypeChecker
                     ? (TypeInfo)new TypeInfo.GenericFunction(typeParams, paramTypes, inferredReturn, requiredParams, hasRest, thisType, paramNames)
                     : new TypeInfo.Function(paramTypes, inferredReturn, requiredParams, hasRest, thisType, paramNames);
                 previousEnv.Define(funcName, updatedFuncType);
-                if (updatedFuncType is TypeInfo.Function uf)
-                    _typeMap.SetFunctionType(funcName, uf);
-                else if (updatedFuncType is TypeInfo.GenericFunction gf2)
-                    _typeMap.SetFunctionType(funcName, new TypeInfo.Function(gf2.ParamTypes, gf2.ReturnType, gf2.RequiredParams, gf2.HasRestParam, gf2.ThisType));
+                if (suppress)
+                {
+                    // Memoize so later passes re-register without re-checking the body.
+                    _hoistInferredReturnTypes[funcStmt] = inferredReturn;
+                }
+                else
+                {
+                    if (updatedFuncType is TypeInfo.Function uf)
+                        _typeMap.SetFunctionType(funcName, uf);
+                    else if (updatedFuncType is TypeInfo.GenericFunction gf2)
+                        _typeMap.SetFunctionType(funcName, new TypeInfo.Function(gf2.ParamTypes, gf2.ReturnType, gf2.RequiredParams, gf2.HasRestParam, gf2.ThisType));
+                }
             }
 
             // Validate that non-void functions return a value on all code paths
@@ -606,7 +716,7 @@ public partial class TypeChecker
                 !funcStmt.IsGenerator &&
                 !funcStmt.IsAsync)
             {
-                if (!DoesBlockDefinitelyReturn(funcStmt.Body))
+                if (!DoesBlockDefinitelyReturn(body))
                 {
                     throw new TypeCheckException($" Function '{funcStmt.Name.Lexeme}' must return a value of type '{returnType}'.", tsCode: "TS2366");
                 }
@@ -633,6 +743,11 @@ public partial class TypeChecker
             _activeLabels.Clear();
             foreach (var kvp in previousActiveLabels)
                 _activeLabels[kvp.Key] = kvp.Value;
+            if (suppress)
+            {
+                _recoveryMode = previousRecoveryMode;
+                _suppressDiagnostics--;
+            }
         }
     }
 

--- a/TypeSystem/TypeChecker.cs
+++ b/TypeSystem/TypeChecker.cs
@@ -444,6 +444,24 @@ public partial class TypeChecker
     private readonly DiagnosticCollector _diagnostics = new();
 
     /// <summary>
+    /// When &gt; 0, <see cref="RecordTypeError(TypeCheckException)"/> and its overload are no-ops.
+    /// Set during speculative hoist-time return-type inference (#383), which checks a function body
+    /// purely to learn its inferred return type and must not surface (duplicate) diagnostics — the
+    /// real declaration pass reports them at their proper locations.
+    /// </summary>
+    private int _suppressDiagnostics = 0;
+
+    /// <summary>
+    /// Memoizes the hoist-time speculatively-inferred return type of an un-annotated, forward-
+    /// referenced local <c>function</c> (#383), keyed by declaration identity (reference equality).
+    /// A null value marks an in-progress or failed inference: don't re-attempt, leave the hoisted
+    /// <c>any</c> placeholder in place. Non-null values are re-registered into each fresh function
+    /// scope on subsequent hoisting passes without re-checking the body.
+    /// </summary>
+    private readonly Dictionary<Stmt.Function, TypeInfo?> _hoistInferredReturnTypes =
+        new(ReferenceEqualityComparer.Instance);
+
+    /// <summary>
     /// Gets any diagnostics collected during module type checking.
     /// </summary>
     public IReadOnlyList<Diagnostic> GetDiagnostics() => _diagnostics.Diagnostics;
@@ -863,6 +881,8 @@ public partial class TypeChecker
     /// </summary>
     private void RecordTypeError(TypeCheckException ex)
     {
+        if (_suppressDiagnostics > 0) return;
+
         // Extract the core message by removing the "Type Error: " or "Type Error at line X: " prefix
         string message = ex.Message;
         if (message.StartsWith("Type Error at line"))
@@ -909,6 +929,8 @@ public partial class TypeChecker
     /// </summary>
     private void RecordTypeError(string message, int? line = null)
     {
+        if (_suppressDiagnostics > 0) return;
+
         SourceLocation? location = line.HasValue
             ? new SourceLocation(_filePath, line.Value)
             : null;


### PR DESCRIPTION
Fixes #383.

## Problem

A local `function` declaration whose inferred return type was needed by a call appearing textually **before** the declaration typed the call as `any`, silently skipping assignment/return checks:

```ts
function h() {
    var z: number = make();        // was silent; tsc reports TS2322
    function make() { return "hi"; }
}
```

Hoisting registered such functions with an `any` return placeholder and only inferred the real type when the body was later reached, so any earlier call missed it. This affected both module scope and nested function scope.

## Fix

`HoistFunctionDeclarations` now runs a **second pass** (`RefineHoistedFunctionReturnType`) that — once every sibling signature is registered in pass 1 — speculatively infers each un-annotated function's return type and registers the refined signature. Earlier-in-scope calls then resolve precisely regardless of declaration order.

The body-checking + return-inference logic that previously lived inline in `CheckFunctionDeclaration` is extracted into a shared `CheckFunctionBodyAndInferReturn(..., suppress)`:

- **Real pass** (`suppress: false`): unchanged behavior — checks the body and reports diagnostics.
- **Speculative pass** (`suppress: true`): diagnostics are swallowed and the body is checked in recovery mode so every `return` is observed; any failure degrades to leaving the `any` placeholder. The real declaration pass re-checks the same body and reports diagnostics **at their proper locations**, so suppressed checking never produces a duplicate or final error.

Inferred results are **memoized per declaration** (reference-keyed) and re-registered into each fresh scope on later passes without re-checking the body; an in-progress marker breaks mutual/self recursion. This bounds the extra work to ~2x body checks for un-annotated functions only — no exponential blow-up on nesting. **Generic** and **overloaded** functions defer to the real pass (see follow-up below).

This also caps the residual #378 gap: a hoisted `var` whose first nested initializer is a forward-referenced local call now infers a concrete type and reports TS2403.

## Tests

New `ForwardLocalFunctionReturnTypeTests` (12 cases): nested/top-level forward calls, the declared-before control, compatible (no-false-positive) cases, return-position checks, the #378 interaction, mutual/self recursion termination, runtime-unchanged, and **exactly-once / no-double-report** cardinality guards via recovery mode.

- Full suite: **11215 passed, 0 failed**.
- TypeScript conformance suite: **31 passed**, baseline unchanged.

## Follow-up

- #388 — forward-referenced **generic** local functions are still not pre-resolved (deliberately scoped out; needs generic call-resolution during speculation).