### PR TITLE
fix(promise): general NewPromiseCapability for non-Promise @@species + thenable await (#349)

### DIFF
--- a/Compilation/AsyncArrowMoveNextEmitter.Operators.cs
+++ b/Compilation/AsyncArrowMoveNextEmitter.Operators.cs
@@ -38,7 +38,9 @@ public partial class AsyncArrowMoveNextEmitter
         _il.Emit(OpCodes.Brtrue, isTaskLabel);
 
         _il.MarkLabel(wrapValueLabel);
-        _il.Emit(OpCodes.Call, typeof(Task).GetMethod("FromResult")!.MakeGenericMethod(typeof(object)));
+        // Adopt an ordinary thenable (e.g. a general non-Promise then/catch/finally
+        // species result, #349); non-thenables become Task.FromResult(value).
+        _il.Emit(OpCodes.Call, _ctx!.Runtime!.CoerceAwaitableToTaskMethod);
         _il.Emit(OpCodes.Stloc, taskLocal);
         _il.Emit(OpCodes.Br, haveTaskLabel);
 

--- a/Compilation/AsyncGeneratorMoveNextEmitter.Expressions.cs
+++ b/Compilation/AsyncGeneratorMoveNextEmitter.Expressions.cs
@@ -449,9 +449,11 @@ public partial class AsyncGeneratorMoveNextEmitter
         _il.Emit(OpCodes.Isinst, typeof(Task<object>));
         _il.Emit(OpCodes.Brtrue, isTaskLabel);
 
-        // Not a Promise or Task - wrap in Task.FromResult
+        // Not a Promise or Task - adopt an ordinary thenable (e.g. a general
+        // non-Promise then/catch/finally species result, #349); non-thenables
+        // become Task.FromResult(value).
         _il.MarkLabel(wrapValueLabel);
-        _il.Emit(OpCodes.Call, typeof(Task).GetMethod("FromResult")!.MakeGenericMethod(typeof(object)));
+        _il.Emit(OpCodes.Call, _ctx!.Runtime!.CoerceAwaitableToTaskMethod);
         _il.Emit(OpCodes.Stloc, taskLocal);
         _il.Emit(OpCodes.Br, haveTaskLabel);
 

--- a/Compilation/AsyncMoveNextEmitter.Expressions.cs
+++ b/Compilation/AsyncMoveNextEmitter.Expressions.cs
@@ -35,7 +35,9 @@ public partial class AsyncMoveNextEmitter
         _il.Emit(OpCodes.Brtrue, isTaskLabel);
 
         _il.MarkLabel(wrapValueLabel);
-        _il.Emit(OpCodes.Call, typeof(Task).GetMethod("FromResult")!.MakeGenericMethod(typeof(object)));
+        // Adopt an ordinary thenable (e.g. a general non-Promise then/catch/finally
+        // species result, #349); non-thenables become Task.FromResult(value).
+        _il.Emit(OpCodes.Call, _ctx!.Runtime!.CoerceAwaitableToTaskMethod);
         _il.Emit(OpCodes.Stloc, taskLocal);
         _il.Emit(OpCodes.Br, haveTaskLabel);
 

--- a/Compilation/EmittedRuntime.cs
+++ b/Compilation/EmittedRuntime.cs
@@ -845,8 +845,17 @@ public class EmittedRuntime
     public MethodBuilder UnwrapPromiseReceiverMethod { get; set; } = null!;
     /// <summary>$Runtime.NormalizePromiseList(object) -> object — when the arg is a List&lt;object?&gt;, returns a copy with $Promise elements (incl. #242 subclasses) replaced by their wrapped Task so the combinator state machines (which only test for Task&lt;object?&gt;) await them; non-list args pass through. Applied at every combinator entry.</summary>
     public MethodBuilder NormalizePromiseListMethod { get; set; } = null!;
-    /// <summary>$Runtime.WrapDerivedPromiseResult(Task&lt;object?&gt; result, object receiver) -> object — when the receiver is a $Promise SUBCLASS (#242), constructs a receiver-typed promise around the result task via the subclass's (object executor) constructor (PromiseFromExecutor adopts the task); otherwise returns the task unchanged. The species-lite step for subclass then/catch/finally results.</summary>
+    /// <summary>$Runtime.WrapDerivedPromiseResult(Task&lt;object?&gt; result, object receiver) -> object — the SpeciesConstructor step for subclass then/catch/finally results (#242). For a $Promise SUBCLASS species, constructs a receiver-typed promise around the result task via the subclass's (object executor) constructor (PromiseFromExecutor adopts the task); for a general non-Promise species, routes to NewPromiseCapabilityResult (#349); for %Promise% (or no subclass receiver) returns the task unchanged.</summary>
     public MethodBuilder WrapDerivedPromiseResultMethod { get; set; } = null!;
+    /// <summary>$Runtime.NewPromiseCapabilityResult(Type species, Task&lt;object?&gt; result) -> object — the general NewPromiseCapability (#349): constructs <c>new species(executor)</c>, capturing the resolve/reject the executor is handed via a <see cref="PromiseCapabilityType"/> holder, then adopts <c>result</c> into that capability (settlement scheduled on the event-loop SynchronizationContext) and returns the constructed (non-Promise) object. Body emitted late (after ConstructDynamicValue); the stub is pre-declared so WrapDerivedPromiseResult can call it.</summary>
+    public MethodBuilder NewPromiseCapabilityResultMethod { get; set; } = null!;
+    /// <summary>$Runtime.CoerceAwaitableToTask(object value) -> Task&lt;object?&gt; — the await coercion for a value that is neither a $Promise nor a Task&lt;object?&gt;: an ordinary thenable (a value whose <c>then</c> member is callable) is adopted by invoking <c>then(resolve, reject)</c> into a fresh capability (#349); anything else becomes Task.FromResult(value). Called at every state-machine await's wrap-value site.</summary>
+    public MethodBuilder CoerceAwaitableToTaskMethod { get; set; } = null!;
+    /// <summary>$PromiseCapability — the host executor handed to a general (non-Promise) species constructor by NewPromiseCapabilityResult (#349): captures the resolve/reject functions (Capture, exposed as a Func&lt;object[],object&gt;) and drives them when the source task settles (Settle, an Action&lt;Task&lt;object&gt;&gt; continuation).</summary>
+    public TypeBuilder PromiseCapabilityType { get; set; } = null!;
+    public ConstructorBuilder PromiseCapabilityCtor { get; set; } = null!;
+    public MethodBuilder PromiseCapabilityCaptureMethod { get; set; } = null!;
+    public MethodBuilder PromiseCapabilitySettleMethod { get; set; } = null!;
     public TypeBuilder PromiseResolveCallbackType { get; set; } = null!;
     public ConstructorBuilder PromiseResolveCallbackCtor { get; set; } = null!;
     public MethodBuilder PromiseResolveCallbackInvoke { get; set; } = null!;

--- a/Compilation/RuntimeEmitter.Promises.Capability.cs
+++ b/Compilation/RuntimeEmitter.Promises.Capability.cs
@@ -1,0 +1,354 @@
+using System.Reflection;
+using System.Reflection.Emit;
+
+namespace SharpTS.Compilation;
+
+/// <summary>
+/// Emits the general NewPromiseCapability support (#349): the result of
+/// <c>then</c>/<c>catch</c>/<c>finally</c> when <c>SpeciesConstructor</c> resolves
+/// to a constructor that is <em>not</em> <c>%Promise%</c> or a guest
+/// <c>class … extends Promise</c> (ECMA-262 §27.2.4.5 + §27.2.5.4 step 7). The
+/// result is <c>new S((resolve, reject) =&gt; …)</c> with the captured capability
+/// adopting the settled source task; <c>S</c> may be any guest class and the
+/// returned object need not be a $Promise.
+/// </summary>
+public partial class RuntimeEmitter
+{
+    /// <summary>
+    /// Emits the <c>$PromiseCapability</c> holder type and fills the
+    /// pre-declared <see cref="EmittedRuntime.NewPromiseCapabilityResultMethod"/>
+    /// body. Must be called AFTER <c>EmitConstructDynamicValue</c> and after the
+    /// $Runtime helpers it depends on (<c>InvokeValue</c>, <c>WrapException</c>,
+    /// <c>ConstructDynamicValue</c>) are emitted, but while <c>$Runtime</c> is
+    /// still open for new method bodies.
+    /// </summary>
+    internal void EmitPromiseCapabilitySupport(ModuleBuilder moduleBuilder, EmittedRuntime runtime)
+    {
+        EmitPromiseCapabilityType(moduleBuilder, runtime);
+        EmitNewPromiseCapabilityResultBody(runtime);
+        EmitCoerceAwaitableToTask(runtime);
+    }
+
+    /// <summary>
+    /// Emits <c>CoerceAwaitableToTask(object value) -> Task&lt;object&gt;</c>: the
+    /// await coercion for a value that reached the state machine's wrap-value
+    /// path (already known not to be a $Promise or Task). An ordinary thenable
+    /// (a value whose <c>then</c> member is callable, by <c>typeof</c>) is
+    /// adopted — <c>then(resolve, reject)</c> settles a fresh capability whose
+    /// task is awaited (ECMA-262 await → PromiseResolve, §27.2.1.3.2); anything
+    /// else is wrapped with Task.FromResult (#349).
+    /// </summary>
+    private void EmitCoerceAwaitableToTask(EmittedRuntime runtime)
+    {
+        var method = _runtimeTypeBuilder!.DefineMethod(
+            "CoerceAwaitableToTask",
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.TaskOfObject,
+            [_types.Object]);
+        runtime.CoerceAwaitableToTaskMethod = method;
+
+        var il = method.GetILGenerator();
+        var wrapLabel = il.DefineLabel();
+        var tcsType = typeof(TaskCompletionSource<object?>);
+
+        var thenLocal = il.DeclareLocal(_types.Object);
+        var tcsLocal = il.DeclareLocal(tcsType);
+        var lockLocal = il.DeclareLocal(_types.Object);
+
+        // if (value == null) goto wrap;
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Brfalse, wrapLabel);
+
+        // then = GetProperty(value, "then");
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldstr, "then");
+        il.Emit(OpCodes.Call, runtime.GetProperty);
+        il.Emit(OpCodes.Stloc, thenLocal);
+
+        // if (TypeOf(then) != "function") goto wrap;
+        il.Emit(OpCodes.Ldloc, thenLocal);
+        il.Emit(OpCodes.Call, runtime.TypeOf);
+        il.Emit(OpCodes.Ldstr, "function");
+        il.Emit(OpCodes.Call, _types.GetMethod(_types.String, "op_Equality", _types.String, _types.String));
+        il.Emit(OpCodes.Brfalse, wrapLabel);
+
+        // var tcs = new TaskCompletionSource<object?>(); var lockObj = new object();
+        il.Emit(OpCodes.Newobj, tcsType.GetConstructor(Type.EmptyTypes)!);
+        il.Emit(OpCodes.Stloc, tcsLocal);
+        il.Emit(OpCodes.Newobj, _types.Object.GetConstructor(Type.EmptyTypes)!);
+        il.Emit(OpCodes.Stloc, lockLocal);
+
+        // try { InvokeMethodValue(value, then,
+        //          new object[] { new $PromiseResolveCallback(tcs, lock),
+        //                         new $PromiseRejectCallback(tcs, lock) }); }
+        // catch (Exception e) { tcs.TrySetException(new $PromiseRejectedException(WrapException(e))); }
+        var exLocal = il.DeclareLocal(_types.Exception);
+        var endTryLabel = il.DefineLabel();
+        il.BeginExceptionBlock();
+
+        il.Emit(OpCodes.Ldarg_0);                       // receiver = value
+        il.Emit(OpCodes.Ldloc, thenLocal);              // function = then
+        il.Emit(OpCodes.Ldc_I4_2);
+        il.Emit(OpCodes.Newarr, _types.Object);
+        il.Emit(OpCodes.Dup);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Ldloc, tcsLocal);
+        il.Emit(OpCodes.Ldloc, lockLocal);
+        il.Emit(OpCodes.Newobj, runtime.PromiseResolveCallbackCtor);
+        il.Emit(OpCodes.Stelem_Ref);
+        il.Emit(OpCodes.Dup);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Ldloc, tcsLocal);
+        il.Emit(OpCodes.Ldloc, lockLocal);
+        il.Emit(OpCodes.Newobj, runtime.PromiseRejectCallbackCtor);
+        il.Emit(OpCodes.Stelem_Ref);
+        il.Emit(OpCodes.Call, runtime.InvokeMethodValue);
+        il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Leave, endTryLabel);
+
+        il.BeginCatchBlock(_types.Exception);
+        il.Emit(OpCodes.Stloc, exLocal);
+        il.Emit(OpCodes.Ldloc, tcsLocal);
+        il.Emit(OpCodes.Ldloc, exLocal);
+        il.Emit(OpCodes.Call, runtime.WrapException);
+        il.Emit(OpCodes.Newobj, runtime.TSPromiseRejectedExceptionCtor);
+        il.Emit(OpCodes.Callvirt, tcsType.GetMethod("TrySetException", [_types.Exception])!);
+        il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Leave, endTryLabel);
+        il.EndExceptionBlock();
+        il.MarkLabel(endTryLabel);
+
+        // return tcs.Task;
+        il.Emit(OpCodes.Ldloc, tcsLocal);
+        il.Emit(OpCodes.Callvirt, tcsType.GetProperty("Task")!.GetGetMethod()!);
+        il.Emit(OpCodes.Ret);
+
+        // wrap: return Task.FromResult(value);
+        il.MarkLabel(wrapLabel);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Call, typeof(Task).GetMethod("FromResult")!.MakeGenericMethod(_types.Object));
+        il.Emit(OpCodes.Ret);
+    }
+
+    /// <summary>
+    /// Emits the <c>$PromiseCapability</c> type: two object slots (Resolve,
+    /// Reject), a <c>Capture(object[])</c> executor body (stored as the resolve/
+    /// reject the species hands it), and a <c>Settle(Task&lt;object&gt;)</c>
+    /// continuation that drives the captured callbacks when the source settles.
+    /// </summary>
+    private void EmitPromiseCapabilityType(ModuleBuilder moduleBuilder, EmittedRuntime runtime)
+    {
+        var typeBuilder = moduleBuilder.DefineType(
+            "$PromiseCapability",
+            TypeAttributes.Public | TypeAttributes.Sealed,
+            _types.Object);
+
+        var resolveField = typeBuilder.DefineField("Resolve", _types.Object, FieldAttributes.Public);
+        var rejectField = typeBuilder.DefineField("Reject", _types.Object, FieldAttributes.Public);
+
+        var ctor = typeBuilder.DefineConstructor(
+            MethodAttributes.Public, CallingConventions.Standard, Type.EmptyTypes);
+        {
+            var il = ctor.GetILGenerator();
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Call, _types.Object.GetConstructor(Type.EmptyTypes)!);
+            il.Emit(OpCodes.Ret);
+        }
+
+        // object Capture(object[] args): Resolve = args[0]; Reject = args[1];
+        // return undefined. This is the executor the species constructor invokes
+        // (recognised by InvokeValue as a Func<object[], object>). Per
+        // NewPromiseCapability (§27.2.1.5) it is meant to run once; a benign
+        // re-entry simply overwrites the slots (the realistic species calls it
+        // exactly once, synchronously, from its constructor).
+        var capture = typeBuilder.DefineMethod(
+            "Capture", MethodAttributes.Public, _types.Object, [_types.ObjectArray]);
+        {
+            var il = capture.GetILGenerator();
+            var noResolveLabel = il.DefineLabel();
+            var noRejectLabel = il.DefineLabel();
+
+            // if (args.Length > 0) this.Resolve = args[0];
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Ldlen);
+            il.Emit(OpCodes.Conv_I4);
+            il.Emit(OpCodes.Ldc_I4_0);
+            il.Emit(OpCodes.Ble, noResolveLabel);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Ldc_I4_0);
+            il.Emit(OpCodes.Ldelem_Ref);
+            il.Emit(OpCodes.Stfld, resolveField);
+            il.MarkLabel(noResolveLabel);
+
+            // if (args.Length > 1) this.Reject = args[1];
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Ldlen);
+            il.Emit(OpCodes.Conv_I4);
+            il.Emit(OpCodes.Ldc_I4_1);
+            il.Emit(OpCodes.Ble, noRejectLabel);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Ldc_I4_1);
+            il.Emit(OpCodes.Ldelem_Ref);
+            il.Emit(OpCodes.Stfld, rejectField);
+            il.MarkLabel(noRejectLabel);
+
+            il.Emit(OpCodes.Ldsfld, runtime.UndefinedInstance);
+            il.Emit(OpCodes.Ret);
+        }
+
+        // void Settle(Task<object> t): drives the captured capability from the
+        // settled source. Faulted -> Reject(WrapException(t.Exception)); else ->
+        // Resolve(t.Result). A missing (never-captured) callback is skipped so a
+        // species that ignored the executor simply never settles instead of
+        // throwing. Runs on the event-loop SynchronizationContext (the scheduler
+        // passed to ContinueWith), so the guest callbacks resume on the loop
+        // thread rather than the thread pool (#319/#320).
+        var settle = typeBuilder.DefineMethod(
+            "Settle", MethodAttributes.Public, typeof(void), [_types.TaskOfObject]);
+        {
+            var il = settle.GetILGenerator();
+            var faultedLabel = il.DefineLabel();
+            var doRejectLabel = il.DefineLabel();
+            var doResolveLabel = il.DefineLabel();
+            var retLabel = il.DefineLabel();
+            var argLocal = il.DeclareLocal(_types.Object);
+
+            // if (t.IsFaulted) goto faulted;
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Callvirt, _types.GetProperty(_types.Task, "IsFaulted").GetGetMethod()!);
+            il.Emit(OpCodes.Brtrue, faultedLabel);
+
+            // arg = t.Result; callback = this.Resolve; (resolve path)
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Callvirt, _types.GetProperty(_types.TaskOfObject, "Result").GetGetMethod()!);
+            il.Emit(OpCodes.Stloc, argLocal);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, resolveField);
+            il.Emit(OpCodes.Brfalse, retLabel);     // no resolve captured → skip
+            il.Emit(OpCodes.Br, doResolveLabel);
+
+            // faulted: arg = WrapException(t.Exception.InnerException); callback = this.Reject.
+            // Task.Exception is an AggregateException; WrapException unwraps
+            // TargetInvocationException and reads $PromiseRejectedException.Reason
+            // but not AggregateException, so peel the first inner first.
+            il.MarkLabel(faultedLabel);
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Callvirt, _types.GetProperty(_types.Task, "Exception").GetGetMethod()!);
+            il.Emit(OpCodes.Callvirt, _types.GetProperty(_types.Exception, "InnerException").GetGetMethod()!);
+            il.Emit(OpCodes.Call, runtime.WrapException);
+            il.Emit(OpCodes.Stloc, argLocal);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, rejectField);
+            il.Emit(OpCodes.Brfalse, retLabel);     // no reject captured → skip
+            // fall through to doReject
+
+            il.MarkLabel(doRejectLabel);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, rejectField);
+            EmitInvokeCapabilityCallback(il, runtime, argLocal);
+            il.Emit(OpCodes.Br, retLabel);
+
+            il.MarkLabel(doResolveLabel);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, resolveField);
+            EmitInvokeCapabilityCallback(il, runtime, argLocal);
+
+            il.MarkLabel(retLabel);
+            il.Emit(OpCodes.Ret);
+        }
+
+        typeBuilder.CreateType();
+        runtime.PromiseCapabilityType = typeBuilder;
+        runtime.PromiseCapabilityCtor = ctor;
+        runtime.PromiseCapabilityCaptureMethod = capture;
+        runtime.PromiseCapabilitySettleMethod = settle;
+    }
+
+    /// <summary>
+    /// Emits, with the callback value already on the stack, the call
+    /// <c>InvokeValue(callback, new object[] { arg })</c> and discards the
+    /// result.
+    /// </summary>
+    private void EmitInvokeCapabilityCallback(ILGenerator il, EmittedRuntime runtime, LocalBuilder argLocal)
+    {
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Newarr, _types.Object);
+        il.Emit(OpCodes.Dup);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Ldloc, argLocal);
+        il.Emit(OpCodes.Stelem_Ref);
+        il.Emit(OpCodes.Call, runtime.InvokeValue);
+        il.Emit(OpCodes.Pop);
+    }
+
+    /// <summary>
+    /// Fills the body of the pre-declared
+    /// <c>NewPromiseCapabilityResult(Type species, Task&lt;object&gt; result)</c>:
+    /// constructs <c>new species(executor)</c> through ConstructDynamicValue
+    /// (Type → Activator), captures the resolve/reject, schedules adoption of
+    /// <paramref name="result"/> onto the current SynchronizationContext, and
+    /// returns the constructed object.
+    /// </summary>
+    private void EmitNewPromiseCapabilityResultBody(EmittedRuntime runtime)
+    {
+        var method = runtime.NewPromiseCapabilityResultMethod;
+        var il = method.GetILGenerator();
+
+        var capabilityType = runtime.PromiseCapabilityType;
+        var funcType = _types.FuncObjectArrayToObject;                 // Func<object[], object>
+        var actionType = typeof(Action<Task<object?>>);
+        var schedulerType = typeof(System.Threading.Tasks.TaskScheduler);
+        var syncContextType = typeof(System.Threading.SynchronizationContext);
+
+        var capabilityLocal = il.DeclareLocal(capabilityType);
+        var instanceLocal = il.DeclareLocal(_types.Object);
+        var schedulerLocal = il.DeclareLocal(schedulerType);
+        var useDefaultLabel = il.DefineLabel();
+        var haveSchedulerLabel = il.DefineLabel();
+
+        // var cap = new $PromiseCapability();
+        il.Emit(OpCodes.Newobj, runtime.PromiseCapabilityCtor);
+        il.Emit(OpCodes.Stloc, capabilityLocal);
+
+        // var executor = new Func<object[], object>(cap.Capture);
+        // var instance = ConstructDynamicValue(species, new object[] { executor });
+        il.Emit(OpCodes.Ldarg_0);                                       // species (object)
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Newarr, _types.Object);
+        il.Emit(OpCodes.Dup);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Ldloc, capabilityLocal);
+        il.Emit(OpCodes.Ldftn, runtime.PromiseCapabilityCaptureMethod);
+        il.Emit(OpCodes.Newobj, funcType.GetConstructor([_types.Object, typeof(IntPtr)])!);
+        il.Emit(OpCodes.Stelem_Ref);
+        il.Emit(OpCodes.Call, runtime.ConstructDynamicValue);
+        il.Emit(OpCodes.Stloc, instanceLocal);
+
+        // var scheduler = SynchronizationContext.Current != null
+        //     ? TaskScheduler.FromCurrentSynchronizationContext()
+        //     : TaskScheduler.Default;
+        il.Emit(OpCodes.Call, syncContextType.GetProperty("Current")!.GetGetMethod()!);
+        il.Emit(OpCodes.Brfalse, useDefaultLabel);
+        il.Emit(OpCodes.Call, schedulerType.GetMethod("FromCurrentSynchronizationContext", Type.EmptyTypes)!);
+        il.Emit(OpCodes.Br, haveSchedulerLabel);
+        il.MarkLabel(useDefaultLabel);
+        il.Emit(OpCodes.Call, schedulerType.GetProperty("Default")!.GetGetMethod()!);
+        il.MarkLabel(haveSchedulerLabel);
+        il.Emit(OpCodes.Stloc, schedulerLocal);
+
+        // result.ContinueWith(new Action<Task<object>>(cap.Settle), scheduler);
+        il.Emit(OpCodes.Ldarg_1);                                       // result : Task<object>
+        il.Emit(OpCodes.Ldloc, capabilityLocal);
+        il.Emit(OpCodes.Ldftn, runtime.PromiseCapabilitySettleMethod);
+        il.Emit(OpCodes.Newobj, actionType.GetConstructor([_types.Object, typeof(IntPtr)])!);
+        il.Emit(OpCodes.Ldloc, schedulerLocal);
+        il.Emit(OpCodes.Callvirt, _types.TaskOfObject.GetMethod("ContinueWith", [actionType, schedulerType])!);
+        il.Emit(OpCodes.Pop);
+
+        // return instance;
+        il.Emit(OpCodes.Ldloc, instanceLocal);
+        il.Emit(OpCodes.Ret);
+    }
+}

--- a/Compilation/RuntimeEmitter.Promises.Executor.cs
+++ b/Compilation/RuntimeEmitter.Promises.Executor.cs
@@ -29,6 +29,17 @@ public partial class RuntimeEmitter
 
         // Promise-subclass support (#242): receiver unwrapping + derived-result wrapping
         EmitUnwrapPromiseReceiverMethod(runtimeType, runtime);
+
+        // Pre-declare the general NewPromiseCapability helper (#349) so
+        // WrapDerivedPromiseResult can call it; the body and the $PromiseCapability
+        // type are emitted later (EmitPromiseCapabilitySupport, after
+        // ConstructDynamicValue) when all of its dependencies are available.
+        runtime.NewPromiseCapabilityResultMethod = runtimeType.DefineMethod(
+            "NewPromiseCapabilityResult",
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.Object,
+            [_types.Type, _types.TaskOfObject]);
+
         EmitWrapDerivedPromiseResultMethod(runtimeType, runtime);
     }
 
@@ -166,9 +177,11 @@ public partial class RuntimeEmitter
     /// subclass itself when neither is present — and constructs the result
     /// through it: <c>%Promise%</c> (or a
     /// <c>@@species</c> yielding <c>Promise</c>/<c>undefined</c>/<c>null</c>)
-    /// returns the raw task, any other guest Promise class is built by invoking
-    /// its single-object (executor) constructor reflectively (PromiseFromExecutor
-    /// adopts a raw task, so the new instance wraps <c>result</c>).
+    /// returns the raw task; a guest Promise SUBCLASS is built by invoking its
+    /// single-object (executor) constructor reflectively (PromiseFromExecutor
+    /// adopts a raw task, so the new instance wraps <c>result</c>); a general
+    /// non-Promise species is built through NewPromiseCapabilityResult (#349, see
+    /// below).
     /// </summary>
     /// <remarks>
     /// Generic Promise subclasses (#351): the static <c>@@species</c> accessor is
@@ -176,8 +189,11 @@ public partial class RuntimeEmitter
     /// runtime type is closed (MyP&lt;object&gt;); FindSymbolGetterFor reconciles
     /// the two (SymbolRegistryKey/CloseSymbolAccessor) and a species naming a
     /// generic subclass is closed via SymbolClosedOwner before construction.
-    /// A species that yields a non-Promise constructor (general
-    /// NewPromiseCapability) falls back to <c>%Promise%</c> — tracked by #349.
+    /// A species that is NOT a $Promise subclass (a general guest constructor)
+    /// is routed to <see cref="EmittedRuntime.NewPromiseCapabilityResultMethod"/>
+    /// (#349): the (object)→PromiseFromExecutor task-adoption path below only
+    /// works for $Promise subclasses, so a general class is constructed with a
+    /// real capturing executor and the result task adopted into its capability.
     /// </remarks>
     private void EmitWrapDerivedPromiseResultMethod(TypeBuilder runtimeType, EmittedRuntime runtime)
     {
@@ -339,6 +355,26 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldtoken, _types.TaskOfObject);
         il.Emit(OpCodes.Call, getTypeFromHandle);
         il.Emit(OpCodes.Beq, returnResultLabel);
+
+        // #349 general NewPromiseCapability: a species that is NOT a $Promise
+        // subclass cannot be settled by the (object)→PromiseFromExecutor task-
+        // adoption path below — its (object) executor ctor would receive the raw
+        // task and throw "object is not a function". Route it through
+        // NewPromiseCapabilityResult, which constructs new S(executor) with a
+        // capturing capability and adopts the result task into it.
+        // if (!typeof($Promise).IsAssignableFrom(speciesType))
+        //     return NewPromiseCapabilityResult(speciesType, result);
+        var promiseSubclassLabel = il.DefineLabel();
+        il.Emit(OpCodes.Ldtoken, runtime.TSPromiseType);
+        il.Emit(OpCodes.Call, getTypeFromHandle);
+        il.Emit(OpCodes.Ldloc, speciesTypeLocal);
+        il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.Type, "IsAssignableFrom", _types.Type));
+        il.Emit(OpCodes.Brtrue, promiseSubclassLabel);
+        il.Emit(OpCodes.Ldloc, speciesTypeLocal);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Call, runtime.NewPromiseCapabilityResultMethod);
+        il.Emit(OpCodes.Ret);
+        il.MarkLabel(promiseSubclassLabel);
 
         // var ctor = speciesType.GetConstructor(new[] { typeof(object) });
         il.Emit(OpCodes.Ldloc, speciesTypeLocal);

--- a/Compilation/RuntimeEmitter.cs
+++ b/Compilation/RuntimeEmitter.cs
@@ -384,6 +384,12 @@ public partial class RuntimeEmitter
         // Must follow EmitNewOnFunction — it calls through runtime.NewOnFunction.
         EmitConstructDynamicValue(_runtimeTypeBuilder!, runtime);
 
+        // General NewPromiseCapability (#349): the $PromiseCapability holder type
+        // and the body of the pre-declared NewPromiseCapabilityResult helper.
+        // Must follow EmitConstructDynamicValue (it calls through that helper) and
+        // EmitRuntimeClass (depends on InvokeValue / WrapException).
+        EmitPromiseCapabilitySupport(moduleBuilder, runtime);
+
         // AbortSignal / Intl value-position singletons (#224). Must follow
         // EmitRuntimeClass — they wrap the AbortSignal*/CreateIntl* helpers
         // emitted there.

--- a/Execution/Interpreter.Expressions.cs
+++ b/Execution/Interpreter.Expressions.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Numerics;
 using SharpTS.Modules;
@@ -212,8 +213,74 @@ public partial class Interpreter
             return RuntimeValue.FromBoxed(await AwaitPreservingEnvironment(task));
         }
 
+        // Thenable adoption (ECMA-262 await → PromiseResolve, §25.6.4.5 step 8 /
+        // §27.2.1.3.2): an ordinary object exposing a callable `then` is adopted
+        // by invoking then(resolve, reject) and awaiting the captured capability.
+        // SharpTSPromise is handled above; only plain guest thenables reach here —
+        // including the general non-Promise then/catch/finally species results
+        // produced by NewPromiseCapability (#349).
+        if (TryGetThenable(value, out var thenFn))
+        {
+            return RuntimeValue.FromBoxed(await AwaitPreservingEnvironment(AdoptThenable(value!, thenFn)));
+        }
+
         // Await on non-Promise returns the value (TypeScript behavior)
         return RuntimeValue.FromBoxed(value);
+    }
+
+    /// <summary>
+    /// Detects an ordinary guest thenable: a <see cref="SharpTSObject"/> or
+    /// <see cref="SharpTSInstance"/> with a callable <c>then</c> member.
+    /// Promise/Task values are recognised by the caller before this is reached.
+    /// </summary>
+    private bool TryGetThenable(object? value, [NotNullWhen(true)] out ISharpTSCallable? thenFn)
+    {
+        thenFn = null;
+        if (value is not (SharpTSObject or SharpTSInstance))
+            return false;
+        if (GetProperty(value, "then") is ISharpTSCallable fn)
+        {
+            thenFn = fn;
+            return true;
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Adopts a guest thenable into a host task: invokes <c>then(resolve, reject)</c>
+    /// with the receiver bound, settling the returned task from whichever callback
+    /// fires first. A synchronous throw from <c>then</c> rejects the task
+    /// (ECMA-262 §27.2.1.3.2 — a throw after resolve/reject is ignored).
+    /// </summary>
+    private Task<object?> AdoptThenable(object thenable, ISharpTSCallable thenFn)
+    {
+        var tcs = new TaskCompletionSource<object?>();
+        var resolve = new PromiseResolveCallback(v =>
+        {
+            // Flatten a promise resolution value the same way the executor
+            // resolve callback does, so `await` yields the eventual value.
+            if (v is SharpTSPromise inner)
+                inner.Task.ContinueWith(t =>
+                {
+                    if (t.IsFaulted)
+                        tcs.TrySetException(t.Exception!.InnerException ?? t.Exception);
+                    else
+                        tcs.TrySetResult(t.Result);
+                }, TaskScheduler.Default);
+            else
+                tcs.TrySetResult(v);
+        });
+        var reject = new PromiseRejectCallback(r => tcs.TrySetException(new SharpTSPromiseRejectedException(r)));
+
+        try
+        {
+            SharpTSClass.BindMethodToReceiver(thenFn, thenable).Call(this, [resolve, reject]);
+        }
+        catch (ThrowException tex)
+        {
+            tcs.TrySetException(new SharpTSPromiseRejectedException(tex.Value));
+        }
+        return tcs.Task;
     }
 
     /// <summary>

--- a/Runtime/BuiltIns/BuiltInAsyncMethod.cs
+++ b/Runtime/BuiltIns/BuiltInAsyncMethod.cs
@@ -31,8 +31,8 @@ public class BuiltInAsyncMethod : ISharpTSCallable, ISharpTSAsyncCallable
     private readonly int _minArity;
     private readonly int _maxArity;
     private readonly Func<Interpreter, object?, List<object?>, Task<object?>> _implementation;
-    private readonly Func<Interpreter, Task<object?>, SharpTSPromise>? _promiseFactory;
-    private readonly Func<Interpreter, object?, Func<Interpreter, Task<object?>, SharpTSPromise>?>? _speciesResolver;
+    private readonly Func<Interpreter, Task<object?>, object?>? _promiseFactory;
+    private readonly Func<Interpreter, object?, Func<Interpreter, Task<object?>, object?>?>? _speciesResolver;
     private readonly bool _refsEventLoopWhileInFlight;
     private object? _receiver;
 
@@ -74,9 +74,9 @@ public class BuiltInAsyncMethod : ISharpTSCallable, ISharpTSAsyncCallable
         int minArity,
         int maxArity,
         Func<Interpreter, object?, List<object?>, Task<object?>> implementation,
-        Func<Interpreter, Task<object?>, SharpTSPromise>? promiseFactory = null,
+        Func<Interpreter, Task<object?>, object?>? promiseFactory = null,
         bool refsEventLoopWhileInFlight = false,
-        Func<Interpreter, object?, Func<Interpreter, Task<object?>, SharpTSPromise>?>? speciesResolver = null)
+        Func<Interpreter, object?, Func<Interpreter, Task<object?>, object?>?>? speciesResolver = null)
     {
         _name = name;
         _minArity = minArity;
@@ -93,9 +93,9 @@ public class BuiltInAsyncMethod : ISharpTSCallable, ISharpTSAsyncCallable
         int minArity,
         int maxArity,
         Func<Interpreter, object?, List<object?>, Task<object?>> implementation,
-        Func<Interpreter, Task<object?>, SharpTSPromise>? promiseFactory,
+        Func<Interpreter, Task<object?>, object?>? promiseFactory,
         bool refsEventLoopWhileInFlight,
-        Func<Interpreter, object?, Func<Interpreter, Task<object?>, SharpTSPromise>?>? speciesResolver,
+        Func<Interpreter, object?, Func<Interpreter, Task<object?>, object?>?>? speciesResolver,
         object? receiver)
     {
         _name = name;
@@ -179,9 +179,9 @@ public class BuiltInAsyncMethod : ISharpTSCallable, ISharpTSAsyncCallable
         }
     }
 
-    private static SharpTSPromise WrapResult(
+    private static object? WrapResult(
         Interpreter interpreter,
-        Func<Interpreter, Task<object?>, SharpTSPromise>? factory,
+        Func<Interpreter, Task<object?>, object?>? factory,
         Task<object?> task)
         => factory != null ? factory(interpreter, task) : new SharpTSPromise(task);
 

--- a/Runtime/BuiltIns/PromiseBuiltIns.cs
+++ b/Runtime/BuiltIns/PromiseBuiltIns.cs
@@ -120,7 +120,7 @@ public static class PromiseBuiltIns
     /// call time before the rejected-promise conversion, so a poisoned
     /// <c>constructor</c>/<c>@@species</c> getter throws synchronously (#350).
     /// </summary>
-    private static readonly Func<Interpreter, object?, Func<Interpreter, Task<object?>, SharpTSPromise>?> SpeciesResolver =
+    private static readonly Func<Interpreter, object?, Func<Interpreter, Task<object?>, object?>?> SpeciesResolver =
         static (interp, recv) => ResolveResultPromiseFactory((SharpTSPromise)recv!, interp);
 
     /// <summary>
@@ -144,7 +144,7 @@ public static class PromiseBuiltIns
     /// or <c>%Promise%</c> (plain); a subclass then reads its static
     /// <c>@@species</c> (#221).
     /// </remarks>
-    private static Func<Interpreter, Task<object?>, SharpTSPromise>? ResolveResultPromiseFactory(
+    private static Func<Interpreter, Task<object?>, object?>? ResolveResultPromiseFactory(
         SharpTSPromise receiver, Interpreter interp)
     {
         if (receiver.TryGetAccessor("constructor", out var ctorGetter, out _) && ctorGetter != null)
@@ -158,18 +158,127 @@ public static class PromiseBuiltIns
     }
 
     /// <summary>
-    /// Wraps a resolved species class into a result-promise factory, or returns
-    /// null (meaning <c>%Promise%</c>, the plain wrapping) when species is null.
+    /// Wraps a resolved species constructor into a result-promise factory, or
+    /// returns null (meaning <c>%Promise%</c>, the plain wrapping) when species
+    /// is null.
     /// </summary>
-    private static Func<Interpreter, Task<object?>, SharpTSPromise>? SpeciesMaterializer(SharpTSPromiseClass? species)
-        => species == null ? null : (interp, task) => species.ConstructDerived(interp, task);
+    /// <remarks>
+    /// A <see cref="SharpTSPromiseClass"/> species takes the fast subclass path
+    /// (<see cref="SharpTSPromiseClass.ConstructDerived"/>). A species that is a
+    /// general (non-Promise) guest class goes through the spec's
+    /// NewPromiseCapability (§27.2.4.5): the result is
+    /// <c>new S((resolve, reject) =&gt; …)</c> with the captured capability
+    /// adopting the settled task (#349). Any other species value (a non-class,
+    /// e.g. a number, or a plain function used as a constructor) conservatively
+    /// falls back to <c>%Promise%</c> rather than throwing the spec's
+    /// <c>TypeError</c> (§7.3.22 step 5) — tracked by #390.
+    /// </remarks>
+    private static Func<Interpreter, Task<object?>, object?>? SpeciesMaterializer(object? species)
+        => species switch
+        {
+            null => null,
+            SharpTSPromiseClass pc => (interp, task) => pc.ConstructDerived(interp, task),
+            SharpTSClass cls => (interp, task) => ConstructPromiseCapabilityAndAdopt(interp, cls, task),
+            _ => null
+        };
+
+    /// <summary>
+    /// General NewPromiseCapability over an arbitrary (non-Promise) guest
+    /// constructor <c>S</c> (ECMA-262 §27.2.4.5 + §27.2.5.4 step 7). Constructs
+    /// <c>new S(executor)</c>, capturing the resolve/reject the executor is
+    /// handed, then adopts the settled <paramref name="source"/> task into that
+    /// capability and returns the constructed object — which need not be a
+    /// SharpTSPromise (it behaves as a promise downstream only insofar as it is a
+    /// thenable; <c>await</c> adopts thenables, #349).
+    /// </summary>
+    private static object? ConstructPromiseCapabilityAndAdopt(
+        Interpreter interp, SharpTSClass speciesCtor, Task<object?> source)
+    {
+        var capability = new PromiseCapabilityExecutor();
+        object? promiseObject = speciesCtor.Call(interp, [capability]);
+
+        // §27.2.1.5 step 4: the resolve/reject the executor stored must be callable.
+        if (capability.ResolveFn is not { } resolveFn || capability.RejectFn is not { } rejectFn)
+            throw new InterpreterException(
+                "Promise resolve or reject function is not callable");
+
+        // Adopt the source task into the captured capability. Awaiting inside this
+        // helper captures the interpreter's SynchronizationContext, so the guest
+        // resolve/reject callbacks resume on the event-loop thread rather than
+        // escaping to the thread pool (#319/#320).
+        _ = AdoptIntoCapability(source, resolveFn, rejectFn, interp);
+        return promiseObject;
+    }
+
+    private static async Task AdoptIntoCapability(
+        Task<object?> source, ISharpTSCallable resolveFn, ISharpTSCallable rejectFn, Interpreter interp)
+    {
+        object? value;
+        try
+        {
+            value = await source;
+        }
+        catch (SharpTSPromiseRejectedException ex)
+        {
+            InvokeCapabilityCallback(rejectFn, ex.Reason, interp);
+            return;
+        }
+        catch (Exception ex)
+        {
+            InvokeCapabilityCallback(rejectFn, ex.Message, interp);
+            return;
+        }
+        InvokeCapabilityCallback(resolveFn, value, interp);
+    }
+
+    /// <summary>
+    /// Invokes a captured capability resolve/reject callback. A throw from the
+    /// guest callback has nowhere to propagate (the adopting task is detached),
+    /// so it is reported like an uncaught microtask rather than crashing the loop.
+    /// </summary>
+    private static void InvokeCapabilityCallback(ISharpTSCallable callback, object? arg, Interpreter interp)
+    {
+        try
+        {
+            callback.Call(interp, [arg]);
+        }
+        catch (Exceptions.ThrowException tex)
+        {
+            Console.Error.WriteLine($"Uncaught (in promise capability): {interp.Stringify(tex.Value)}");
+        }
+    }
+
+    /// <summary>
+    /// The host executor handed to a general species constructor by
+    /// <see cref="ConstructPromiseCapabilityAndAdopt"/>. Per
+    /// NewPromiseCapability (§27.2.1.5) it captures the resolve/reject functions
+    /// the constructor passes it; calling it more than once, or with already-set
+    /// slots, is a TypeError.
+    /// </summary>
+    private sealed class PromiseCapabilityExecutor : ISharpTSCallable
+    {
+        public ISharpTSCallable? ResolveFn { get; private set; }
+        public ISharpTSCallable? RejectFn { get; private set; }
+
+        public int Arity() => 2;
+
+        public object? Call(Interpreter interpreter, List<object?> arguments)
+        {
+            if (ResolveFn != null || RejectFn != null)
+                throw new InterpreterException("Promise executor was already invoked");
+            ResolveFn = arguments.Count > 0 ? arguments[0] as ISharpTSCallable : null;
+            RejectFn = arguments.Count > 1 ? arguments[1] as ISharpTSCallable : null;
+            return SharpTSUndefined.Instance;
+        }
+    }
 
     /// <summary>
     /// Computes SpeciesConstructor(promise, %Promise%) (ECMA-262 §7.3.22) for a
-    /// Promise subclass receiver, returning the guest Promise class to construct
-    /// the result through, or <c>null</c> to mean <c>%Promise%</c> (the plain
-    /// built-in). Reads <c>C[@@species]</c> where <c>C</c> is the receiver's
-    /// class: a declared <c>static get [Symbol.species]()</c> or an expando
+    /// Promise subclass receiver, returning the constructor to build the result
+    /// through (a guest Promise subclass, or a general non-Promise class), or
+    /// <c>null</c> to mean <c>%Promise%</c> (the plain built-in). Reads
+    /// <c>C[@@species]</c> where <c>C</c> is the receiver's class: a declared
+    /// <c>static get [Symbol.species]()</c> or an expando
     /// <c>(C as any)[Symbol.species]</c> (#262) override wins; absent either,
     /// the inherited <c>Promise[@@species]</c> (which returns <c>this</c>) makes
     /// the species the receiver's own class. An override that yields
@@ -177,14 +286,13 @@ public static class PromiseBuiltIns
     /// <c>%Promise%</c>.
     /// </summary>
     /// <remarks>
-    /// A species override that returns a non-Promise constructor (the general
-    /// NewPromiseCapability path) is not yet supported and falls back to
-    /// <c>%Promise%</c> — tracked by #349. A poisoned own <c>constructor</c>
-    /// getter (<c>then/ctor-poisoned.js</c>, #350) is handled earlier, in
-    /// <see cref="ResolveResultPromiseFactory"/>, which reads
-    /// <c>Get(promise, "constructor")</c> before reaching here.
+    /// A species override that returns a general non-Promise class is materialized
+    /// through NewPromiseCapability by <see cref="SpeciesMaterializer"/> (#349). A
+    /// poisoned own <c>constructor</c> getter (<c>then/ctor-poisoned.js</c>, #350)
+    /// is handled earlier, in <see cref="ResolveResultPromiseFactory"/>, which
+    /// reads <c>Get(promise, "constructor")</c> before reaching here.
     /// </remarks>
-    private static SharpTSPromiseClass? ResolveSpeciesConstructor(SharpTSPromiseClass klass, Interpreter interp)
+    private static object? ResolveSpeciesConstructor(SharpTSPromiseClass klass, Interpreter interp)
     {
         object? species;
         if (klass.FindStaticSymbolGetter(SharpTSSymbol.Species) is { } getter)
@@ -200,10 +308,10 @@ public static class PromiseBuiltIns
             null or SharpTSUndefined => null,                                  // → %Promise%
             SharpTSBuiltInConstructor { Name: BuiltInNames.Promise } => null,  // `return Promise`
             SharpTSPromiseClass sc when ReferenceEquals(sc, SharpTSPromiseClass.PromiseBase) => null,
-            SharpTSPromiseClass sc => sc,
-            // Non-Promise species constructor: general NewPromiseCapability not
-            // yet supported (#349) — fall back to %Promise%.
-            _ => null
+            // A Promise subclass or a general non-Promise class flows to
+            // SpeciesMaterializer, which picks the subclass fast path or the
+            // general NewPromiseCapability path (#349) respectively.
+            _ => species
         };
     }
 

--- a/SharpTS.Tests/SharedTests/PromiseSubclassTests.cs
+++ b/SharpTS.Tests/SharedTests/PromiseSubclassTests.cs
@@ -600,6 +600,155 @@ public class PromiseSubclassTests
 
     #endregion
 
+    #region General NewPromiseCapability (#349) — non-Promise species + thenable await
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Species_NonPromiseConstructor_BuildsThroughIt(ExecutionMode mode)
+    {
+        // ECMA-262 §27.2.5.4 step 7 / §27.2.4.5: when @@species resolves to a
+        // constructor that is NOT %Promise% or a Promise subclass, then/catch/
+        // finally build the result through `new S(executor)` (general
+        // NewPromiseCapability) and adopt the captured capability — the result is
+        // an instance of S, not a Promise (#349). A `then` member makes it a
+        // thenable, which `await` adopts back to the settled value.
+        var source = """
+            class Thenable {
+                _value: any = undefined;
+                _settled: boolean = false;
+                _cb: any = undefined;
+                constructor(executor: (res: any, rej: any) => void) {
+                    executor(
+                        (v: any) => { this._value = v; this._settled = true; if (this._cb) this._cb(v); },
+                        (_e: any) => {});
+                }
+                then(onF: any, _onR?: any) {
+                    if (this._settled) onF(this._value); else this._cb = onF;
+                }
+            }
+            class P extends Promise<number> {
+                static get [Symbol.species]() { return Thenable as any; }
+            }
+            async function main() {
+                const r: any = P.resolve(10).then((x: number) => x + 1);
+                console.log(r instanceof Thenable);
+                console.log(r instanceof Promise);
+                console.log(await r);
+            }
+            main();
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("true\nfalse\n11\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Species_NonPromiseConstructor_AdoptsRejection(ExecutionMode mode)
+    {
+        // The captured capability's reject is driven when the source task faults
+        // (here a catch handler that rethrows): the species instance records the
+        // rejection reason, unwrapped to the guest value (not an AggregateException).
+        var source = """
+            class Box {
+                err: any = undefined;
+                ok: any = undefined;
+                constructor(ex: (res: any, rej: any) => void) {
+                    ex((v: any) => { this.ok = v; }, (e: any) => { this.err = e; });
+                }
+            }
+            class Q extends Promise<number> {
+                static get [Symbol.species]() { return Box as any; }
+            }
+            const q: any = Q.reject("boom").catch((e: string) => { throw "rethrow:" + e; });
+            console.log(q instanceof Box);
+            setTimeout(() => { console.log(q.err, q.ok); }, 30);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("true\nrethrow:boom undefined\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Species_ExpandoNonPromiseConstructor_BuildsThroughIt(ExecutionMode mode)
+    {
+        // The general NewPromiseCapability path is reached through an EXPANDO
+        // @@species ((C as any)[Symbol.species] = S, #262) just as through a
+        // declared getter.
+        var source = """
+            class Thenable {
+                v: any = undefined;
+                settled: boolean = false;
+                cb: any = undefined;
+                constructor(executor: (res: any, rej: any) => void) {
+                    executor(
+                        (x: any) => { this.v = x; this.settled = true; if (this.cb) this.cb(x); },
+                        (_e: any) => {});
+                }
+                then(onF: any) { if (this.settled) onF(this.v); else this.cb = onF; }
+            }
+            class P extends Promise<number> {}
+            (P as any)[Symbol.species] = Thenable;
+            async function main() {
+                const r: any = P.resolve(5).then((x: number) => x * 2);
+                console.log(r instanceof Thenable);
+                console.log(r instanceof Promise);
+                console.log(await r);
+            }
+            main();
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("true\nfalse\n10\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Await_AdoptsPlainThenable(ExecutionMode mode)
+    {
+        // `await` on an ordinary object whose `then` is callable adopts it
+        // (ECMA-262 await → PromiseResolve), independent of any Promise species.
+        var source = """
+            const resolving = { then(onF: any, _onR: any) { onF("hello"); } };
+            const rejecting = { then(_onF: any, onR: any) { onR("nope"); } };
+            async function main() {
+                console.log(await resolving);
+                try {
+                    await rejecting;
+                } catch (e) {
+                    console.log("caught:" + e);
+                }
+            }
+            main();
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("hello\ncaught:nope\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Await_NonThenableObjectPassesThrough(ExecutionMode mode)
+    {
+        // An object WITHOUT a callable `then` is not a thenable: `await` returns
+        // it unchanged rather than hanging or adopting.
+        var source = """
+            async function main() {
+                const o = { value: 42, then: 7 };
+                const r: any = await o;
+                console.log(r.value);
+                console.log(r.then);
+            }
+            main();
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("42\n7\n", output);
+    }
+
+    #endregion
+
     #region Poisoned constructor getter (#350) — then/catch/finally throw synchronously
 
     [Theory]


### PR DESCRIPTION
Closes #349.

## What

Completes #349: `then`/`catch`/`finally` now build their result through an **arbitrary non-Promise `SpeciesConstructor`** (ECMA-262 §27.2.5.4 step 7 → §27.2.4.5 NewPromiseCapability), in **both interpreter and compiled modes**, plus the stated prerequisite — `await` adopting ordinary thenables — in both modes.

The expando-`@@species` sub-gap was already shipped in #370; this PR delivers the issue's **primary** subject (general NewPromiseCapability over a non-Promise constructor).

## How

When `promise.constructor[@@species]` resolves to a constructor that is neither `%Promise%` nor a `class … extends Promise`, the result is `new S((resolve, reject) => …)` and the captured capability adopts the settled source task. The returned object is an instance of `S` (not a Promise) — and behaves as a promise downstream only insofar as it is a thenable, which `await` now adopts.

- **Interpreter** (`PromiseBuiltIns`): `ResolveSpeciesConstructor` returns the resolved species; `SpeciesMaterializer` routes a general `SharpTSClass` through `ConstructPromiseCapabilityAndAdopt` (constructs `S` with a capturing executor, adopts via an `await`-driven helper that resumes on the event-loop `SynchronizationContext`, #319/#320). The then/catch/finally result-promise factory is widened from `SharpTSPromise` to `object?`.
- **Compiled**: `WrapDerivedPromiseResult` routes any species that is **not** a `$Promise` subclass to a new `$Runtime.NewPromiseCapabilityResult`, backed by a `$PromiseCapability` holder (a `Func<object[],object>` capture executor + an `Action<Task<object>>` settle continuation scheduled on the current `SynchronizationContext`). Construction goes through `ConstructDynamicValue`/`Activator` — **fully standalone**, no `SharpTS.dll` dependency (verified).
- **`await` thenable adoption**: interpreter `EvaluateAwaitAsync` (`TryGetThenable`/`AdoptThenable`) + compiled `CoerceAwaitableToTask` at the three state-machine await wrap-value sites. The hot path (`await` of a `$Promise`/`Task`) is untouched; only `await` of a non-promise value probes for a callable `then`.

## Latent bug fixed

A non-Promise species exposing an `(object)` executor constructor previously had `new S(rawTask)` invoked (the raw task passed as the executor), throwing `TypeError: object is not a function`. It now goes through the capability path.

## Tests

5 new theories (×2 modes) in `PromiseSubclassTests` under a new "General NewPromiseCapability (#349)" region: non-Promise species construction, rejection adoption (reason unwrapped from the `AggregateException`), expando non-Promise species, plain-thenable `await` (resolve + reject), and non-thenable pass-through. Full suite green (**11215 passed**), IL verification passes, compiled output confirmed standalone.

## Follow-up

Filed #390 for residual spec edges (non-constructor `@@species` should `TypeError` per §7.3.22 step 5; function-valued species constructor).