### PR TITLE
fix(compile): install $EventLoopSyncContext on the multi-module entry point (#381)

### DIFF
--- a/Compilation/CompilationService.cs
+++ b/Compilation/CompilationService.cs
@@ -216,6 +216,11 @@ public static class CompilationService
             var priorErr = Console.Error;
             Console.SetOut(output);
             Console.SetError(output);
+            // The emitted Main installs $EventLoopSyncContext on the current thread
+            // (issues #319/#320/#381). For in-process embedding the calling thread is
+            // long-lived and may invoke Execute repeatedly, so restore the ambient
+            // context afterward rather than leaking the loop context onto the host.
+            var priorSyncContext = System.Threading.SynchronizationContext.Current;
             try
             {
                 mainMethod.Invoke(null, null);
@@ -229,6 +234,7 @@ public static class CompilationService
             }
             finally
             {
+                System.Threading.SynchronizationContext.SetSynchronizationContext(priorSyncContext);
                 Console.SetOut(priorOut);
                 Console.SetError(priorErr);
             }

--- a/Compilation/ILCompiler.Functions.cs
+++ b/Compilation/ILCompiler.Functions.cs
@@ -1003,71 +1003,13 @@ public partial class ILCompiler
                 continue;
             }
 
-            // Special handling for expression statements to wait for top-level async calls
+            // Special handling for expression statements to wait for top-level async
+            // calls — "top-level await" behavior. Shared with the module/script init
+            // bodies so every entry point pumps the loop the same way (see the remarks
+            // on EmitExpressionWithAsyncWait for why this must pump, not block).
             if (stmt is Stmt.Expression exprStmt)
             {
-                emitter.EmitExpression(exprStmt.Expr);
-
-                // Check if the result is a Task<object> or $Promise and wait for it
-                // This provides "top-level await" behavior for compiled code
-                // Box value types first (e.g., delete returns boolean)
-                emitter.Helpers.EnsureBoxed();
-                var exprResult = il.DeclareLocal(_types.Object);
-                il.Emit(OpCodes.Stloc, exprResult);
-
-                var notTaskLabel = il.DefineLabel();
-                var waitForTaskLabel = il.DefineLabel();
-                var isTaskLabel = il.DefineLabel();
-
-                // Check for Task<object> first
-                il.Emit(OpCodes.Ldloc, exprResult);
-                il.Emit(OpCodes.Isinst, _types.TaskOfObject);
-                il.Emit(OpCodes.Brtrue, isTaskLabel);
-
-                // Check for $Promise (async function return type)
-                il.Emit(OpCodes.Ldloc, exprResult);
-                il.Emit(OpCodes.Isinst, _runtime.TSPromiseType);
-                il.Emit(OpCodes.Brfalse, notTaskLabel);
-
-                // It's a $Promise - extract its underlying Task
-                il.Emit(OpCodes.Ldloc, exprResult);
-                il.Emit(OpCodes.Castclass, _runtime.TSPromiseType);
-                il.Emit(OpCodes.Callvirt, _runtime.TSPromiseTaskGetter);
-                il.Emit(OpCodes.Br, waitForTaskLabel);
-
-                // It's a Task<object> directly
-                il.MarkLabel(isTaskLabel);
-                il.Emit(OpCodes.Ldloc, exprResult);
-                il.Emit(OpCodes.Castclass, _types.TaskOfObject);
-
-                // Wait for the task via $EventLoop.WaitForTask: blocks while the
-                // event loop has work that could settle it (timers fire as part
-                // of the wait), checks cancellation each iteration, and returns
-                // false once the process is provably quiescent — a never-settling
-                // promise (`new Promise(() => {})`) must not block exit (matches
-                // Node). On false we skip GetResult and move on.
-                il.MarkLabel(waitForTaskLabel);
-                var taskLocal = il.DeclareLocal(_types.TaskOfObject);
-                il.Emit(OpCodes.Stloc, taskLocal);
-
-                il.Emit(OpCodes.Call, _runtime.EventLoopGetInstance);
-                il.Emit(OpCodes.Ldloc, taskLocal);
-                il.Emit(OpCodes.Callvirt, _runtime.EventLoopWaitForTask);
-                il.Emit(OpCodes.Brfalse, notTaskLabel);
-
-                // Task is complete — GetResult() to rethrow if faulted
-                il.Emit(OpCodes.Ldloc, taskLocal);
-                var getAwaiter = _types.GetMethodNoParams(_types.TaskOfObject, "GetAwaiter");
-                il.Emit(OpCodes.Call, getAwaiter);
-                var awaiterLocal = il.DeclareLocal(_types.TaskAwaiterOfObject);
-                il.Emit(OpCodes.Stloc, awaiterLocal);
-                il.Emit(OpCodes.Ldloca, awaiterLocal);
-                var getResult = _types.GetMethodNoParams(_types.TaskAwaiterOfObject, "GetResult");
-                il.Emit(OpCodes.Call, getResult);
-                il.Emit(OpCodes.Pop);  // Discard the result
-
-                il.MarkLabel(notTaskLabel);
-                // No pop needed - value is in local
+                EmitExpressionWithAsyncWait(il, emitter, exprStmt);
             }
             else
             {

--- a/Compilation/ILCompiler.Modules.cs
+++ b/Compilation/ILCompiler.Modules.cs
@@ -334,10 +334,21 @@ public partial class ILCompiler
     }
 
     /// <summary>
-    /// Emits an expression statement with special handling to wait for async return values.
-    /// If the expression returns a Task or Promise, waits for it to complete.
-    /// This provides "top-level await" behavior for compiled code.
+    /// Emits a top-level expression statement plus "top-level await" handling: if the
+    /// value is a <c>Task&lt;object&gt;</c> or <c>$Promise</c>, pump the event loop until
+    /// it settles via <see cref="EmittedRuntime.EventLoopWaitForTask"/>, then GetResult to
+    /// rethrow faults. Shared by the single-file entry point (<c>EmitDefaultEntryPoint</c>)
+    /// and every module/script init body so both wait the same way.
     /// </summary>
+    /// <remarks>
+    /// The wait MUST pump (drain the loop queue + fire timers), not block on
+    /// <c>GetResult()</c>: once <c>$EventLoopSyncContext</c> is installed (issues
+    /// #319/#320/#381), await continuations are Posted to the loop queue, so a thread
+    /// blocked in <c>GetResult()</c> would never drain them — the awaited promise could
+    /// never settle and the program would deadlock. <c>WaitForTask</c> runs the queue and
+    /// the timer processor on this thread until the task completes (or the loop proves
+    /// quiescent, matching Node's "a forever-pending top-level promise doesn't block exit").
+    /// </remarks>
     private void EmitExpressionWithAsyncWait(ILGenerator il, ILEmitter emitter, Stmt.Expression exprStmt)
     {
         emitter.EmitExpression(exprStmt.Expr);
@@ -372,8 +383,20 @@ public partial class ILCompiler
         il.Emit(OpCodes.Ldloc, exprResult);
         il.Emit(OpCodes.Castclass, _types.TaskOfObject);
 
-        // Wait for the task
+        // Pump the event loop until the task settles (drains Posted await
+        // continuations + fires timers). Returns false if the loop went quiescent
+        // with the task still pending (never-settling promise) — then skip GetResult.
         il.MarkLabel(waitForTaskLabel);
+        var taskLocal = il.DeclareLocal(_types.TaskOfObject);
+        il.Emit(OpCodes.Stloc, taskLocal);
+
+        il.Emit(OpCodes.Call, _runtime.EventLoopGetInstance);
+        il.Emit(OpCodes.Ldloc, taskLocal);
+        il.Emit(OpCodes.Callvirt, _runtime.EventLoopWaitForTask);
+        il.Emit(OpCodes.Brfalse, notTaskLabel);
+
+        // Task is complete — GetResult() to rethrow if faulted
+        il.Emit(OpCodes.Ldloc, taskLocal);
         var getAwaiter = _types.GetMethodNoParams(_types.TaskOfObject, "GetAwaiter");
         il.Emit(OpCodes.Call, getAwaiter);
         var awaiterLocal = il.DeclareLocal(_types.TaskAwaiterOfObject);
@@ -563,6 +586,14 @@ public partial class ILCompiler
         _entryPoint = mainMethod;
 
         var il = mainMethod.GetILGenerator();
+
+        // Install the event-loop SynchronizationContext before any module runs, so
+        // top-level async/await continuations (e.g. fetch) resume on the event-loop
+        // thread instead of escaping to the thread pool — the same durable fix the
+        // single-file entry point applies (issues #319/#320/#381). Module init bodies
+        // hold the first top-level awaits, so the context must be current before the
+        // first $Initialize call captures an awaiter.
+        EmitInstallEventLoopSyncContext(il);
 
         // Create entry-point display class instance if there are captured top-level variables
         if (_closures.EntryPointDisplayClass != null &&

--- a/SharpTS.Tests/CompilerTests/EntryPointSyncContextTests.cs
+++ b/SharpTS.Tests/CompilerTests/EntryPointSyncContextTests.cs
@@ -1,0 +1,114 @@
+using System.Reflection;
+using System.Threading;
+using SharpTS.Compilation;
+using SharpTS.Modules;
+using SharpTS.Parsing;
+using SharpTS.TypeSystem;
+using Xunit;
+
+namespace SharpTS.Tests.CompilerTests;
+
+/// <summary>
+/// Guards that every compiled entry point installs the emitted
+/// <c>$EventLoopSyncContext</c> before any top-level statement runs (issues
+/// #319/#320/#381). The install is what keeps a top-level <c>await fetch(...)</c>
+/// continuation on the event-loop thread instead of escaping to the thread pool —
+/// where it is invisible to the entry point's <c>WaitForTask</c> quiescence check
+/// and the still-settling promise gets abandoned under pool pressure.
+///
+/// Verified structurally rather than by timing: the emitted <c>Main</c> installs the
+/// context on its running thread and never restores it, so invoking <c>Main</c> and
+/// reading <see cref="SynchronizationContext.Current"/> immediately afterward — on the
+/// same thread — proves the install deterministically. A behavioral "did the
+/// continuation escape" test would depend on inducing thread-pool starvation and is
+/// inherently flaky (see the #295/#325 flake-class notes).
+///
+/// #381 specifically: the multi-module entry point (<c>EmitModulesEntryPoint</c>) was
+/// the one entry point that omitted the install, so a multi-file program with a
+/// top-level await lost the protection the single-file path already had.
+/// </summary>
+public class EntryPointSyncContextTests
+{
+    private const string EmittedSyncContextTypeName = "$EventLoopSyncContext";
+
+    [Fact]
+    public void SingleFileEntryPoint_InstallsEventLoopSyncContext()
+    {
+        var lexer = new Lexer("console.log('hi');");
+        var parser = new Parser(lexer.ScanTokens());
+        var statements = parser.ParseOrThrow();
+
+        var checker = new TypeChecker();
+        var typeMap = checker.Check(statements);
+        var deadCodeInfo = new DeadCodeAnalyzer(typeMap).Analyze(statements);
+
+        var compiler = new ILCompiler($"synccontext_single_{Guid.NewGuid():N}");
+        compiler.Compile(statements, typeMap, deadCodeInfo);
+
+        AssertMainInstallsEventLoopSyncContext(compiler);
+    }
+
+    [Fact]
+    public void MultiModuleEntryPoint_InstallsEventLoopSyncContext()
+    {
+        // Regression for #381: this entry point used to skip the install.
+        var virtualBase = Path.Combine(Path.GetTempPath(), $"sharpts_vfs_{Guid.NewGuid():N}");
+        var libPath = Path.GetFullPath(Path.Combine(virtualBase, "lib.ts"));
+        var mainPath = Path.GetFullPath(Path.Combine(virtualBase, "main.ts"));
+        var files = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            [libPath] = "export const x = 42;\n",
+            [mainPath] = "import { x } from './lib';\nconsole.log('entry ' + x);\n",
+        };
+
+        var resolver = new ModuleResolver(mainPath, files);
+        var entryModule = resolver.LoadModule(mainPath);
+        var modules = resolver.GetModulesInOrder(entryModule);
+
+        var checker = new TypeChecker();
+        var typeMap = checker.CheckModules(modules, resolver);
+        var deadCodeInfo = new DeadCodeAnalyzer(typeMap)
+            .Analyze(modules.SelectMany(m => m.Statements).ToList());
+
+        var compiler = new ILCompiler($"synccontext_modules_{Guid.NewGuid():N}");
+        compiler.CompileModules(modules, resolver, typeMap, deadCodeInfo);
+
+        AssertMainInstallsEventLoopSyncContext(compiler);
+    }
+
+    /// <summary>
+    /// Loads the compiled assembly, invokes <c>$Program.Main</c> on a dedicated thread,
+    /// and asserts the emitted event-loop SynchronizationContext is current on that
+    /// thread after Main returns. A dedicated thread (not a pool thread) keeps the
+    /// leaked-by-design install off recycled threads, so the test cannot pollute siblings.
+    /// </summary>
+    private static void AssertMainInstallsEventLoopSyncContext(ILCompiler compiler)
+    {
+        var assembly = Assembly.Load(compiler.SaveToBytes());
+        var programType = assembly.GetType("$Program")
+            ?? throw new InvalidOperationException("Compiled assembly has no $Program type");
+        var mainMethod = programType.GetMethod("Main", BindingFlags.Public | BindingFlags.Static)
+            ?? throw new InvalidOperationException("$Program has no public static Main method");
+
+        string? observedContextTypeName = null;
+        Exception? failure = null;
+
+        var thread = new Thread(() =>
+        {
+            try
+            {
+                mainMethod.Invoke(null, null);
+                observedContextTypeName = SynchronizationContext.Current?.GetType().Name;
+            }
+            catch (Exception ex)
+            {
+                failure = ex;
+            }
+        });
+        thread.Start();
+        Assert.True(thread.Join(TimeSpan.FromSeconds(30)), "Compiled Main did not return within 30s.");
+
+        Assert.Null(failure);
+        Assert.Equal(EmittedSyncContextTypeName, observedContextTypeName);
+    }
+}

--- a/SharpTS.Tests/Infrastructure/TestHarness.cs
+++ b/SharpTS.Tests/Infrastructure/TestHarness.cs
@@ -946,6 +946,10 @@ public static class TestHarness
             var task = Task.Run(() =>
             {
                 using var capture = AsyncLocalConsoleRedirector.Capture();
+                // The compiled Main installs an event-loop SynchronizationContext on
+                // this thread; restore the previous one so it doesn't leak onto the
+                // recycled Task.Run pool thread and disturb a sibling test.
+                var prevCtx = System.Threading.SynchronizationContext.Current;
                 try
                 {
                     mainMethod.Invoke(null, null);
@@ -953,6 +957,10 @@ public static class TestHarness
                 catch (TargetInvocationException tie) when (tie.InnerException is not null)
                 {
                     System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(tie.InnerException).Throw();
+                }
+                finally
+                {
+                    System.Threading.SynchronizationContext.SetSynchronizationContext(prevCtx);
                 }
                 return capture.GetOutput().Replace("\r\n", "\n");
             });


### PR DESCRIPTION
Fixes #381.

## Problem
`EmitModulesEntryPoint` (the multi-module compiled entry point) was the only entry point that never installed the emitted `$EventLoopSyncContext`. In a multi-file program, top-level `await` continuations (e.g. `fetch`, `timers/promises`) captured their awaiter without the loop context current, so they resumed on the thread pool instead of the event-loop thread — invisible to the entry point's `WaitForTask` quiescence check. Under pool pressure a still-settling top-level promise could be abandoned, the exact #319/#320 failure mode the install was meant to prevent. The single-file (`EmitDefaultEntryPoint`) and EXE-user-main paths already installed it.

## Investigation notes (per the issue)
- The install *does* work even though standalone `dotnet out.dll` runs `Main` on managed thread 2 — `SetSynchronizationContext` targets whatever thread `Main` runs on, and that thread also runs the top-level statements and `WaitForTask`, so the context follows correctly. The thread-2 detail is benign.
- The original #354 `ctx=null thread=2` observation was the **modules** entry point, which simply never emitted the install.

## Fix
1. **Install the context on the multi-module entry point.** One line: `EmitInstallEventLoopSyncContext(il)` at the top of `EmitModulesEntryPoint`.
2. **Make the module/script top-level-await wait *pump* instead of *block*.** Installing the context exposed a latent deadlock: `EmitExpressionWithAsyncWait` used a blocking `awaiter.GetResult()` rather than the pumping `$EventLoop.WaitForTask` the single-file path uses. Once continuations are Posted to the loop queue, a thread blocked in `GetResult()` never drains them → the awaited promise never settles → hang. Switched it to `WaitForTask`.
3. **Consolidated** the single-file entry point's near-identical inline block to call the same `EmitExpressionWithAsyncWait`, so every entry point waits identically (removes ~60 lines of duplicated IL emission).
4. **Restore the ambient `SynchronizationContext`** after the in-process `CompilationService.Execute` invoke (it leaked the loop context onto the embedding host thread — and the doc comment already claimed it restored) and after the in-memory module test-harness invoke, matching the single-file paths.

## Tests
- New `EntryPointSyncContextTests` deterministically asserts that both the single-file and multi-module compiled `Main` leave `$EventLoopSyncContext` installed on the thread that runs top-level statements. (A behavioral continuation-escape test is inherently flaky — see the #295/#325 flake-class notes — so this guards the install structurally.) Verified it fails without the fix.
- Full suite green: **11213 passed, 0 failed**. The fix also eliminated 17 pre-existing-but-masked hangs: before this change, adding the install alone made 17 `timers/promises` / `dns/promises` multi-module compiled tests deadlock for 30s each (the `GetResult()` blocking bug); the pumping wait resolves them and drops that suite from ~8min to ~31s.

## Filed along the way
- #392 — `export async function` fails to parse.
- #393 — compiled `timers/promises` helpers (`$M_promises_setTimeout`/`setImmediate`) fail IL verification (pre-existing on `main`; program still runs).