### PR TITLE
fix(parser): parse `export async function` and `export function*` (#392)

### DIFF
--- a/Parsing/Parser.Modules.cs
+++ b/Parsing/Parser.Modules.cs
@@ -282,9 +282,18 @@ public partial class Parser
 
         // export function/class/const/let/interface/type/enum
         Stmt? decl = null;
-        if (Match(TokenType.FUNCTION))
+        if (Match(TokenType.ASYNC))
         {
-            decl = FunctionDeclaration("function");
+            // export async function foo() {}  /  export async function* foo() {}
+            Consume(TokenType.FUNCTION, "Expect 'function' after 'async'.");
+            bool isGenerator = Match(TokenType.STAR);
+            decl = FunctionDeclaration("function", isAsync: true, isGenerator: isGenerator);
+        }
+        else if (Match(TokenType.FUNCTION))
+        {
+            // export function foo() {}  /  export function* foo() {}
+            bool isGenerator = Match(TokenType.STAR);
+            decl = FunctionDeclaration("function", isAsync: false, isGenerator: isGenerator);
         }
         else if (Match(TokenType.CLASS))
         {

--- a/SharpTS.Tests/SharedTests/ModuleTests.cs
+++ b/SharpTS.Tests/SharedTests/ModuleTests.cs
@@ -73,6 +73,62 @@ public class ModuleTests
         Assert.Equal("7\n", output);
     }
 
+    // These three guard the #392 parser fix (`export async function`,
+    // `export function*`, `export async function*`). They run InterpretedOnly:
+    // the parser fix is mode-independent, and compiled execution of exported
+    // state-machine functions is a separate gap tracked in #395.
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void ExportAsyncFunction_Parses(ExecutionMode mode)
+    {
+        // Regression: `export async function` previously failed to parse
+        // ("Expect declaration after 'export'"). See issue #392.
+        var source = """
+            export async function add(a: number, b: number): Promise<number> {
+                return a + b;
+            }
+            async function main() { console.log(await add(3, 4)); }
+            main();
+            """;
+
+        Assert.Equal("7\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void ExportGeneratorFunction_Parses(ExecutionMode mode)
+    {
+        // Regression: `export function*` previously failed to parse ("Expect
+        // function name") because the export dispatcher never consumed the `*`.
+        var source = """
+            export function* g(): Generator<number> {
+                yield 1;
+                yield 2;
+            }
+            for (const x of g()) console.log(x);
+            """;
+
+        Assert.Equal("1\n2\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void ExportAsyncGeneratorFunction_Parses(ExecutionMode mode)
+    {
+        // Regression: `export async function*` shares the same export dispatcher
+        // path as `export async function` (issue #392).
+        var source = """
+            export async function* ag(): AsyncGenerator<number> {
+                yield 1;
+                yield 2;
+            }
+            async function main() { for await (const x of ag()) console.log(x); }
+            main();
+            """;
+
+        Assert.Equal("1\n2\n", TestHarness.Run(source, mode));
+    }
+
     [Theory]
     [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void NamedExport_Class(ExecutionMode mode)


### PR DESCRIPTION
## Summary

Fixes #392. The `export` declaration dispatcher in `Parser.Modules.cs` had branches for `function`, `class`, `const`, `let`, etc., but none for a leading `async` modifier — so an exported async function declaration threw at parse time:

```ts
export async function foo() { return 1; }
// Error: Expect declaration after 'export'.
```

This adds an `async function` branch (mirroring the non-exported async-function path in `Parser.Declarations.cs`, including async generators), and fixes the adjacent **`export function*`** gap found alongside it: the sync `function` branch never consumed the generator `*`, so `export function*` threw "Expect function name".

All four forms now parse and run in both modes for single-file / interpreter use:
- `export async function foo() {}`
- `export function* g() {}`
- `export async function* ag() {}`
- (`export function foo() {}` — already worked)

## Tests

Three regression tests in `ModuleTests` cover the async-function, generator, and async-generator export forms. They run `InterpretedOnly` because the parser fix is mode-independent and compiled execution of exported **state-machine** functions is a separate, pre-existing gap — see below.

## Follow-up filed: #395

While verifying, I found that compiled mode can't yet *execute* exported async/generator functions (cross-module: `TypeError: object is not a function`). Root cause: the compiled export-store path (`ILEmitter.Modules.cs`) only consults `_ctx.Functions`, but async/generator/async-generator declarations register in separate registries (`_async.Functions`, `_generators.Functions`, `_asyncGenerators.Functions`), so the export field is left null. Plain sync `export function` works. This was never reachable before (the source didn't parse); it's tracked in #395, not fixed here, to keep this PR scoped to the parser.

## Verification

- New tests pass.
- Full suite: 11236 passed, 0 failed.