### PR TITLE
fix(compile): resolve inherited declared static read through class-as-value (#358)

### DIFF
--- a/Compilation/RuntimeEmitter.Objects.Properties.cs
+++ b/Compilation/RuntimeEmitter.Objects.Properties.cs
@@ -1987,15 +1987,29 @@ public partial class RuntimeEmitter
             il.Emit(OpCodes.Ret);
             il.MarkLabel(noBuiltInMatchLabel);
 
-            // #265: walk the constructor's superclass chain for inherited expando
+            // #265/#358: walk the constructor's superclass chain for inherited
             // statics. In Node a class constructor inherits from its parent
-            // constructor (Object.getPrototypeOf(D) === C), so a string-keyed static
-            // set on a base (`Base.foo = 1`) is readable through a subclass `D.foo`.
-            // PDS keys descriptors by the Type identity per-class with no parent
-            // awareness, so probe each ancestor's store here — after the subclass's
-            // own descriptors and declared members, matching own-before-inherited.
+            // constructor (Object.getPrototypeOf(D) === C), so a static set on a
+            // base — whether a string-keyed expando (`Base.foo = 1`) or a declared
+            // static field/method (`static n = 7`) — is readable through a subclass
+            // `D.foo` / `D.n`. Neither PDS (keyed by Type identity per-class with no
+            // parent awareness) nor the own-only reflection probes above
+            // (Public|Static finds no inherited statics without FlattenHierarchy)
+            // crosses the chain, so probe each ancestor here. At every level the
+            // order mirrors the subclass's own probes: PDS shadow first
+            // (shadow-before-declared, so an expando write on an ancestor wins over
+            // its declared field — #339 keeps nearer-subclass shadows out of this
+            // walk by resolving them above), then declared static method, then
+            // declared static field. Declared-member probes are gated on
+            // $IHasFields so only emitted user classes are inspected — this skips
+            // System.Object / runtime base types ($Array/$Promise/$Error) whose
+            // BCL statics (e.g. Object.Equals) would otherwise bleed through.
+            const BindingFlags declaredStaticPublic =
+                BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly;
             var walkTypeLocal = il.DeclareLocal(_types.Type);
             var baseDescLocal = il.DeclareLocal(runtime.CompiledPropertyDescriptorType);
+            var baseStaticMethodLocal = il.DeclareLocal(_types.MethodInfo);
+            var baseStaticFieldLocal = il.DeclareLocal(typeof(FieldInfo));
             il.Emit(OpCodes.Ldloc, typeLocal);
             il.Emit(OpCodes.Stloc, walkTypeLocal);
             var baseWalkLoop = il.DefineLabel();
@@ -2006,15 +2020,53 @@ public partial class RuntimeEmitter
             il.Emit(OpCodes.Stloc, walkTypeLocal);
             il.Emit(OpCodes.Ldloc, walkTypeLocal);
             il.Emit(OpCodes.Brfalse, classInstanceLabel);
-            // desc = PDSGetPropertyDescriptor(walkType, name);
+            // desc = PDSGetPropertyDescriptor(walkType, name);  (expando shadow)
             il.Emit(OpCodes.Ldloc, walkTypeLocal);
             il.Emit(OpCodes.Ldarg_1);
             il.Emit(OpCodes.Call, runtime.PDSGetPropertyDescriptor);
             il.Emit(OpCodes.Stloc, baseDescLocal);
             il.Emit(OpCodes.Ldloc, baseDescLocal);
-            il.Emit(OpCodes.Brfalse, baseWalkLoop);
+            var baseProbeDeclaredLabel = il.DefineLabel();
+            il.Emit(OpCodes.Brfalse, baseProbeDeclaredLabel);
             il.Emit(OpCodes.Ldloc, baseDescLocal);
             il.Emit(OpCodes.Callvirt, runtime.CompiledPropertyDescriptorValue.GetGetMethod()!);
+            il.Emit(OpCodes.Ret);
+
+            // No expando shadow on this ancestor — probe its declared statics, but
+            // only when it is an emitted user class ($IHasFields.IsAssignableFrom).
+            il.MarkLabel(baseProbeDeclaredLabel);
+            il.Emit(OpCodes.Ldtoken, runtime.IHasFieldsInterface);
+            il.Emit(OpCodes.Call, _types.GetMethod(_types.Type, "GetTypeFromHandle", _types.RuntimeTypeHandle));
+            il.Emit(OpCodes.Ldloc, walkTypeLocal);
+            il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.Type, "IsAssignableFrom", _types.Type));
+            il.Emit(OpCodes.Brfalse, baseWalkLoop);
+
+            // declared static method → $TSFunction(null, methodInfo)
+            il.Emit(OpCodes.Ldloc, walkTypeLocal);
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Ldc_I4, (int)declaredStaticPublic);
+            il.Emit(OpCodes.Call, runtime.SafeGetMethod);
+            il.Emit(OpCodes.Stloc, baseStaticMethodLocal);
+            il.Emit(OpCodes.Ldloc, baseStaticMethodLocal);
+            var noBaseStaticMethodLabel = il.DefineLabel();
+            il.Emit(OpCodes.Brfalse, noBaseStaticMethodLabel);
+            il.Emit(OpCodes.Ldnull);
+            il.Emit(OpCodes.Ldloc, baseStaticMethodLocal);
+            il.Emit(OpCodes.Newobj, runtime.TSFunctionCtor);
+            il.Emit(OpCodes.Ret);
+            il.MarkLabel(noBaseStaticMethodLabel);
+
+            // declared static field → field.GetValue(null)
+            il.Emit(OpCodes.Ldloc, walkTypeLocal);
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Ldc_I4, (int)declaredStaticPublic);
+            il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.Type, "GetField", _types.String, typeof(BindingFlags)));
+            il.Emit(OpCodes.Stloc, baseStaticFieldLocal);
+            il.Emit(OpCodes.Ldloc, baseStaticFieldLocal);
+            il.Emit(OpCodes.Brfalse, baseWalkLoop);
+            il.Emit(OpCodes.Ldloc, baseStaticFieldLocal);
+            il.Emit(OpCodes.Ldnull);
+            il.Emit(OpCodes.Callvirt, _types.GetMethod(typeof(FieldInfo), "GetValue", _types.Object));
             il.Emit(OpCodes.Ret);
         }
 

--- a/SharpTS.Tests/SharedTests/StaticMembersTests.cs
+++ b/SharpTS.Tests/SharedTests/StaticMembersTests.cs
@@ -549,4 +549,90 @@ public class StaticMembersTests
     }
 
     #endregion
+
+    #region Inherited Static Read Through Class-As-Value (#358)
+
+    // A dynamic / value-position read (`(Sub as any).field`) of an inherited *declared* static must
+    // resolve up the superclass chain even when no per-subclass own shadow exists yet. In compiled
+    // mode this goes through the runtime System.Type reader, which previously probed only the
+    // subclass's own declared statics and ancestor expando shadows — never an ancestor's *declared*
+    // static (#358). The interpreter was already correct.
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void InheritedStaticAsValue_DeclaredFieldPreShadow(ExecutionMode mode)
+    {
+        var source = """
+            class Base { static n: number = 7; }
+            class Sub extends Base {}
+            const S: any = Sub;
+            console.log(S.n);
+            """;
+
+        Assert.Equal("7\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void InheritedStaticAsValue_DeclaredMethod(ExecutionMode mode)
+    {
+        var source = """
+            class Base { static greet(): string { return "hi"; } }
+            class Sub extends Base {}
+            const S: any = Sub;
+            console.log(S.greet());
+            """;
+
+        Assert.Equal("hi\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void InheritedStaticAsValue_MultiLevelChain(ExecutionMode mode)
+    {
+        var source = """
+            class Base { static n: number = 7; static greet(): string { return "hi"; } }
+            class Mid extends Base {}
+            class Sub extends Mid {}
+            const S: any = Sub;
+            console.log(S.n);
+            console.log(S.greet());
+            """;
+
+        Assert.Equal("7\nhi\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void InheritedStaticAsValue_OwnShadowWinsOverDeclared(ExecutionMode mode)
+    {
+        // Once a per-subclass own shadow exists, the dynamic read returns it, not the base value.
+        var source = """
+            class Base { static m: number = 10; }
+            class Sub extends Base {}
+            (Sub as any).m = 99;
+            console.log((Sub as any).m);
+            console.log(Base.m);
+            """;
+
+        Assert.Equal("99\n10\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void InheritedStaticAsValue_AncestorExpandoWinsOverDeclared(ExecutionMode mode)
+    {
+        // An expando shadow written on an ancestor (shadow-before-declared) is seen through the
+        // subclass before the ancestor's declared field — proto-chain order at each level.
+        var source = """
+            class Base { static k: number = 1; }
+            class Sub extends Base {}
+            (Base as any).k = 50;
+            console.log((Sub as any).k);
+            """;
+
+        Assert.Equal("50\n", TestHarness.Run(source, mode));
+    }
+
+    #endregion
 }


### PR DESCRIPTION
Closes #358.

## Problem

In **compiled mode**, a dynamic / value-position read of an inherited **declared** static returned `undefined` when no per-subclass own shadow had been written yet:

```ts
class Base { static n: number = 7; }
class Sub extends Base {}
const S: any = Sub;
console.log(S.n);   // interp: 7 ; compiled (before): undefined
```

The statically-typed `Sub.n` read was already correct (#332), and writes + shadowed reads were correct (#339). This was the orthogonal dynamic-path gap: the emitted `System.Type` property reader (`RuntimeEmitter.Objects.Properties.cs`) walked ancestors only for **expando** shadows (#265), never for an ancestor's **declared** static field/method.

## Fix

Extend the ancestor walk in the `System.Type` reader so that at each level it mirrors the subclass's own probe order:

1. PDS expando shadow (already done) — *shadow-before-declared*, so an expando write on an ancestor wins over its declared field.
2. **declared static method** → `$TSFunction(null, methodInfo)` *(new)*
3. **declared static field** → `field.GetValue(null)` *(new)*

The declared-member probes are gated on `$IHasFields.IsAssignableFrom(walkType)` so only emitted user classes are inspected — this skips `System.Object` and runtime base types (`$Array`/`$Promise`/`$Error`) whose BCL statics (e.g. `Object.Equals`) would otherwise bleed through as JS property values. Reflection uses `DeclaredOnly | Public | Static` so each level surfaces only its own statics. Standalone-safe (emitted-runtime + BCL only, no `SharpTS.dll` reference).

## Verification

- New repro: compiled now prints `7`; `--verify` passes.
- Ordering/guards confirmed: multi-level chains, own-shadow-wins, ancestor-expando-wins, and `S.Equals`/missing props still return `undefined` (no BCL bleed-through).
- 5 new shared interp+compiled regression tests in `StaticMembersTests` (`#358` region).
- Full suite: **11235 passed, 0 failed**.

## Follow-up filed

- #398 — interpreter throws `Static member 'x' does not exist` on a dynamic/`any`-typed read of a *missing* static (`(Sub as any).nope`); JS returns `undefined`. Out of scope here (compiled mode already returns `undefined`).