### PR TITLE
fix(compile): widen undefined-reachable number/bool locals, params, and inferred returns (#372)

### DIFF
--- a/Compilation/ILCompiler.ArrowFunctions.cs
+++ b/Compilation/ILCompiler.ArrowFunctions.cs
@@ -155,7 +155,7 @@ public partial class ILCompiler
             // Resolve typed parameters from annotations (optimization for numeric parameters)
             // Rest parameters always use List<object> to enable detection at invoke time
             var resolvedParamTypes = ParameterTypeResolver.ResolveParameters(
-                arrow.Parameters, _typeMapper, null); // null funcType - use annotations only
+                arrow.Parameters, _typeMapper, null, _typeMap); // null funcType - use annotations only
 
             // Store resolved types for use during arrow body emission
             _closures.ArrowParameterTypes[arrow] = resolvedParamTypes;

--- a/Compilation/ILCompiler.Functions.cs
+++ b/Compilation/ILCompiler.Functions.cs
@@ -62,7 +62,7 @@ public partial class ILCompiler
         var funcType = _typeMap?.GetFunctionType(qualifiedFunctionName)
                     ?? _typeMap?.GetFunctionType(funcStmt.Name.Lexeme);
         var paramTypes = ParameterTypeResolver.ResolveParameters(
-            funcStmt.Parameters, _typeMapper, funcType);
+            funcStmt.Parameters, _typeMapper, funcType, _typeMap);
 
         // Resolve typed return type (optimization: avoid boxing for : number returns).
         // Widen a number/boolean slot to object if the checker flagged an undefined-reachable

--- a/Compilation/ILCompiler.InnerFunctions.cs
+++ b/Compilation/ILCompiler.InnerFunctions.cs
@@ -241,7 +241,7 @@ public partial class ILCompiler
         {
             // Resolve parameter types (use annotations only, no TypeMap function type)
             var resolvedParamTypes = ParameterTypeResolver.ResolveParameters(
-                func.Parameters, _typeMapper, null);
+                func.Parameters, _typeMapper, null, _typeMap);
 
             Type[] paramTypes = new Type[func.Parameters.Count];
             for (int i = 0; i < func.Parameters.Count; i++)

--- a/Compilation/ILEmitter.Expressions.cs
+++ b/Compilation/ILEmitter.Expressions.cs
@@ -482,9 +482,16 @@ public partial class ILEmitter
         }
         else if (_ctx.TryGetParameter(a.Name.Lexeme, out var argIndex))
         {
-            // Parameters are always object type
+            // A parameter slot is not always object: a `: number` param is an unboxed `double`
+            // slot, a `: boolean` param a `bool` slot, a `: string` param a `string` slot. Box the
+            // value (the assignment's result, left on the stack), then convert the copy destined for
+            // the arg slot to the slot's declared type before Starg — storing a boxed object straight
+            // into a double/bool/string slot fails IL verification (StackUnexpected) and reads back
+            // garbage (#402). EmitConvertForParamSlot is a no-op for object slots (the common case and
+            // the #372-widened undefined-reachable params).
             EmitBoxIfNeeded(a.Value);
             IL.Emit(OpCodes.Dup);
+            _ctx.EmitConvertForParamSlot(IL, a.Name.Lexeme);
             IL.Emit(OpCodes.Starg, argIndex);
             SetStackUnknown();
         }

--- a/Compilation/ParameterTypeResolver.cs
+++ b/Compilation/ParameterTypeResolver.cs
@@ -17,16 +17,21 @@ public static class ParameterTypeResolver
     /// <param name="parameters">Parameters from AST</param>
     /// <param name="typeMapper">TypeMapper for converting TypeInfo to .NET Type</param>
     /// <param name="funcType">Function type from TypeMap (may be null)</param>
+    /// <param name="typeMap">
+    /// TypeMap used to consult the #372 undefined-reachable-parameter flag. May be null (e.g. arrow
+    /// resolution without a recorded function type), in which case no parameter is widened on that basis.
+    /// </param>
     /// <returns>Array of .NET types for each parameter</returns>
     public static Type[] ResolveParameters(
         List<Stmt.Parameter> parameters,
         TypeMapper typeMapper,
-        TSTypeInfo.Function? funcType)
+        TSTypeInfo.Function? funcType,
+        TypeMap? typeMap = null)
     {
         if (funcType == null || funcType.ParamTypes.Count != parameters.Count)
         {
             // Fallback: try to resolve from parameter type annotations
-            return parameters.Select(p => ResolveParameterType(p, typeMapper)).ToArray();
+            return parameters.Select(p => WidenIfUndefinedReachableParam(ResolveParameterType(p, typeMapper), p, typeMap)).ToArray();
         }
 
         // Map each parameter type, but use 'object' for:
@@ -72,9 +77,25 @@ public static class ParameterTypeResolver
                     return typeof(object);
                 }
 
-                return mappedType;
+                return WidenIfUndefinedReachableParam(mappedType, parameters[i], typeMap);
             })
             .ToArray();
+    }
+
+    /// <summary>
+    /// #372: widen a <c>number</c>/<c>boolean</c> parameter slot (unboxed <c>double</c>/<c>bool</c>) to
+    /// <c>object</c> when the type checker flagged it as possibly holding the runtime <c>undefined</c>
+    /// sentinel (a body reassignment of an <c>any</c>/<c>undefined</c> value, e.g.
+    /// <c>function p(x: number) { x = undefined as any; }</c>). The unboxed slot cannot carry the
+    /// sentinel — it would coerce to <c>NaN</c>/<c>false</c> (or raw garbage for a never-stored slot).
+    /// A no-op for any other type, so it is safe to apply at every parameter mapping site.
+    /// </summary>
+    private static Type WidenIfUndefinedReachableParam(Type mapped, Stmt.Parameter param, TypeMap? typeMap)
+    {
+        if ((mapped == typeof(double) || mapped == typeof(bool)) &&
+            typeMap != null && typeMap.IsUndefinedReachableNumericParam(param))
+            return typeof(object);
+        return mapped;
     }
 
     /// <summary>
@@ -226,7 +247,7 @@ public static class ParameterTypeResolver
         }
 
         if (funcType == null || funcType.ParamTypes.Count != parameters.Count)
-            return parameters.Select(p => ResolveParameterType(p, typeMapper)).ToArray();
+            return parameters.Select(p => WidenIfUndefinedReachableParam(ResolveParameterType(p, typeMapper), p, typeMap)).ToArray();
 
         // Map each parameter type, handling optional parameters and BigInteger
         return funcType.ParamTypes
@@ -260,7 +281,9 @@ public static class ParameterTypeResolver
                     return typeof(object);
                 }
 
-                return mappedType;
+                return i < parameters.Count
+                    ? WidenIfUndefinedReachableParam(mappedType, parameters[i], typeMap)
+                    : mappedType;
             })
             .ToArray();
     }
@@ -322,7 +345,7 @@ public static class ParameterTypeResolver
 
         var funcType = ExtractFunctionType(ctorTypeInfo);
         if (funcType == null || funcType.ParamTypes.Count != parameters.Count)
-            return parameters.Select(p => ResolveParameterType(p, typeMapper)).ToArray();
+            return parameters.Select(p => WidenIfUndefinedReachableParam(ResolveParameterType(p, typeMapper), p, typeMap)).ToArray();
 
         // Map each parameter type, handling optional parameters and BigInteger
         return funcType.ParamTypes
@@ -356,7 +379,9 @@ public static class ParameterTypeResolver
                     }
                 }
 
-                return mappedType;
+                return i < parameters.Count
+                    ? WidenIfUndefinedReachableParam(mappedType, parameters[i], typeMap)
+                    : mappedType;
             })
             .ToArray();
     }

--- a/SharpTS.Tests/CompilerTests/ILVerificationTests.cs
+++ b/SharpTS.Tests/CompilerTests/ILVerificationTests.cs
@@ -701,4 +701,126 @@ public class ILVerificationTests
         Assert.Equal("6\n43\n", output);
         Assert.Equal(output, TestHarness.RunInterpreted(source));
     }
+
+    // #372 case 1: an inferred-return (no annotation) function whose returned local holds the
+    // undefined sentinel. The return type is inferred as `number`, so it is double-slotted just like
+    // an explicit `: number` — but the #367 taint pass was gated on a declared number/boolean return
+    // and never ran here. The pass now runs regardless of return type, so the local and the inferred
+    // return slot are both widened to object and the sentinel survives.
+    [Fact]
+    public void TypedNumberLocal_InferredReturn_StaysUndefined()
+    {
+        var source = """
+            function inf(n: any) { let x: number = 0; x = undefined as any; return x; }
+            console.log(inf(1));
+            """;
+
+        var (errors, output) = TestHarness.CompileVerifyAndRun(source);
+
+        Assert.Empty(errors);
+        Assert.Equal("undefined\n", output);
+        Assert.Equal(output, TestHarness.RunInterpreted(source));
+    }
+
+    // #372 case 2: a `: number` local holding the undefined sentinel is observed by something other
+    // than a return (here `console.log`) inside a void function. The corruption happens at the local
+    // store, independent of any return, so object-slotting the local must not be gated on the return.
+    [Fact]
+    public void TypedNumberLocal_ObservedInVoidFunction_StaysUndefined()
+    {
+        var source = """
+            function obs(): void { let x: number = 0; x = undefined as any; console.log(x); }
+            obs();
+            """;
+
+        var (errors, output) = TestHarness.CompileVerifyAndRun(source);
+
+        Assert.Empty(errors);
+        Assert.Equal("undefined\n", output);
+        Assert.Equal(output, TestHarness.RunInterpreted(source));
+    }
+
+    // #372 case 3: a `: number` PARAMETER reassigned the undefined sentinel. A parameter has no local
+    // declaration to mark; it is matched by name in the taint pass and its arg slot widened to object.
+    // The same shape for a `: boolean` parameter widens the bool arg slot.
+    [Fact]
+    public void TypedNumberParam_ReassignedUndefined_StaysUndefined()
+    {
+        var source = """
+            function p(x: number): number { x = undefined as any; return x; }
+            function q(b: boolean): boolean { b = undefined as any; return b; }
+            console.log(p(1));
+            console.log(q(true));
+            """;
+
+        var (errors, output) = TestHarness.CompileVerifyAndRun(source);
+
+        Assert.Empty(errors);
+        Assert.Equal("undefined\nundefined\n", output);
+        Assert.Equal(output, TestHarness.RunInterpreted(source));
+    }
+
+    // #372: the same tainted-parameter shape inside an instance method, a static method, and a
+    // constructor — each resolves parameter slots through a different resolver, all of which must
+    // widen a flagged number/boolean parameter to object.
+    [Fact]
+    public void TypedNumberParam_ReassignedUndefined_InMethodStaticAndCtor_StaysUndefined()
+    {
+        var source = """
+            class C {
+                m(x: number): number { x = undefined as any; return x; }
+                static s(x: number): number { x = undefined as any; return x; }
+                constructor(n: number) { n = undefined as any; this.r = n; }
+                r: any;
+            }
+            const c = new C(5);
+            console.log(c.m(1));
+            console.log(C.s(2));
+            console.log(c.r);
+            """;
+
+        var (errors, output) = TestHarness.CompileVerifyAndRun(source);
+
+        Assert.Empty(errors);
+        Assert.Equal("undefined\nundefined\nundefined\n", output);
+        Assert.Equal(output, TestHarness.RunInterpreted(source));
+    }
+
+    // #372 (pre-existing param-assignment bug, discovered while fixing #372 and filed as a follow-up):
+    // reassigning a `: number` parameter with a SOUND numeric value would box the value and `Starg`
+    // it into the unboxed double arg slot, failing IL verification (StackUnexpected) and reading back
+    // garbage. The assignment now converts the value to the parameter slot's declared type first.
+    [Fact]
+    public void TypedNumberParam_SoundReassignment_ComputesCorrectly()
+    {
+        var source = """
+            function a(x: number): number { x = 99; return x; }
+            function c(x: number): number { x = x + 1; return x * 2; }
+            console.log(a(10));
+            console.log(c(10));
+            """;
+
+        var (errors, output) = TestHarness.CompileVerifyAndRun(source);
+
+        Assert.Empty(errors);
+        Assert.Equal("99\n22\n", output);
+        Assert.Equal(output, TestHarness.RunInterpreted(source));
+    }
+
+    // #372 guard: a `: number` parameter that never receives an `any`/`undefined` value keeps its
+    // sound unboxed double arg slot — the taint pass must not over-widen parameters either.
+    [Fact]
+    public void TypedNumberParam_SoundBody_StillUsesNumericValue()
+    {
+        var source = """
+            function scale(x: number): number { let y: number = x * 2; return y + 1; }
+            console.log(scale(10));
+            """;
+
+        var (errors, output) = TestHarness.CompileVerifyAndRun(source);
+
+        Assert.Empty(errors);
+        Assert.Equal("21\n", output);
+        Assert.Equal(output, TestHarness.RunInterpreted(source));
+    }
 }

--- a/TypeSystem/TypeChecker.Expressions.cs
+++ b/TypeSystem/TypeChecker.Expressions.cs
@@ -1260,11 +1260,10 @@ public partial class TypeChecker
                 // Block body - check statements
                 CheckStmtList(arrow.BlockBody);
 
-                // #367: flag returns of a number/boolean-typed local left holding the undefined
-                // sentinel by an `any`/`undefined` assignment (no-op unless the declared return is
-                // number/boolean). Expression-bodied arrows have no local-assignment-then-return
-                // shape, so only block bodies need this.
-                MarkUndefinedReachableLocalReturns(arrow.BlockBody);
+                // #367/#372: object-slot number/boolean-typed locals, parameters, and returns left
+                // holding the undefined sentinel by an `any`/`undefined` assignment. Expression-bodied
+                // arrows have no body statements that could reassign a slot, so only block bodies need this.
+                MarkUndefinedReachableNumericSlots(arrow.BlockBody, arrow.Parameters);
 
                 // Resolve inferred return type for block-body arrows
                 if (inferringArrowReturn)
@@ -1812,8 +1811,9 @@ public partial class TypeChecker
                         foreach (var bodyStmt in method.Body)
                             CheckStmt(bodyStmt);
 
-                        // #367: object-slot number-typed locals that may hold the undefined sentinel.
-                        MarkUndefinedReachableLocalReturns(method.Body);
+                        // #367/#372: object-slot number/boolean-typed locals, parameters, and returns
+                        // that may hold the undefined sentinel.
+                        MarkUndefinedReachableNumericSlots(method.Body, method.Parameters);
                     }
                 }
                 finally
@@ -1872,8 +1872,9 @@ public partial class TypeChecker
                         foreach (var bodyStmt in accessor.Body)
                             CheckStmt(bodyStmt);
 
-                        // #367: object-slot number-typed locals that may hold the undefined sentinel.
-                        MarkUndefinedReachableLocalReturns(accessor.Body);
+                        // #367/#372: object-slot number/boolean-typed locals and returns that may hold
+                        // the undefined sentinel. The setter parameter always uses an object slot.
+                        MarkUndefinedReachableNumericSlots(accessor.Body);
                     }
                     finally
                     {

--- a/TypeSystem/TypeChecker.Statements.Classes.cs
+++ b/TypeSystem/TypeChecker.Statements.Classes.cs
@@ -718,9 +718,10 @@ public partial class TypeChecker
                     {
                         CheckStmtList(method.Body);
 
-                        // #367: object-slot number-typed locals that an `any`/`undefined` value may
-                        // have left holding the sentinel, so a `return x` is not coerced to NaN.
-                        MarkUndefinedReachableLocalReturns(method.Body);
+                        // #367/#372: object-slot number/boolean-typed locals, parameters, and returns
+                        // that an `any`/`undefined` value may have left holding the sentinel, so they
+                        // are not coerced to NaN/false.
+                        MarkUndefinedReachableNumericSlots(method.Body, method.Parameters);
                     }
 
                     // Resolve inferred method return type
@@ -837,8 +838,10 @@ public partial class TypeChecker
                     {
                         CheckStmtList(accessor.Body);
 
-                        // #367: object-slot number-typed locals that may hold the undefined sentinel.
-                        MarkUndefinedReachableLocalReturns(accessor.Body);
+                        // #367/#372: object-slot number/boolean-typed locals and returns that may hold
+                        // the undefined sentinel. The setter parameter always uses an object slot, so
+                        // it never corrupts and is not passed.
+                        MarkUndefinedReachableNumericSlots(accessor.Body);
                     }
                     finally
                     {

--- a/TypeSystem/TypeChecker.Statements.Functions.cs
+++ b/TypeSystem/TypeChecker.Statements.Functions.cs
@@ -643,12 +643,12 @@ public partial class TypeChecker
 
                 CheckStmtList(body);
 
-                // #367: flag returns of a number/boolean-typed local that an `any`/`undefined`
-                // assignment may have left holding the undefined sentinel (no-op unless the declared
-                // return is number/boolean). Runs after the body so every sub-expression type is known.
-                // Skipped while speculating — it only matters for the emitted output of the real pass.
+                // #367/#372: object-slot any number/boolean-typed local, parameter, or return that an
+                // `any`/`undefined` assignment may have left holding the undefined sentinel. Runs after
+                // the body so every sub-expression type is known. Skipped while speculating — it only
+                // matters for the emitted output of the real pass.
                 if (!suppress)
-                    MarkUndefinedReachableLocalReturns(body);
+                    MarkUndefinedReachableNumericSlots(body, funcStmt.Parameters);
             }
             catch (Exception) when (suppress)
             {

--- a/TypeSystem/TypeChecker.Statements.cs
+++ b/TypeSystem/TypeChecker.Statements.cs
@@ -480,30 +480,42 @@ public partial class TypeChecker
     };
 
     /// <summary>
-    /// #367 residual of #344: a <c>number</c>/<c>boolean</c>-typed <em>local</em> can be unsoundly
-    /// assigned an <c>any</c>/<c>undefined</c> value (e.g. <c>let x: number = undefined as any</c>)
-    /// and so hold the runtime <c>undefined</c> sentinel — yet <c>return x</c> has static type
-    /// <c>number</c>/<c>boolean</c>, so the per-return #344 detection (which keys on the return
-    /// value's own type being <c>any</c>/<c>unknown</c>) never fires and the compiler's unboxed
-    /// slot coerces it to <c>NaN</c>/<c>false</c>. Run a whole-body taint pass <em>after</em> the
-    /// body is type-checked (every sub-expression's type is then in the <see cref="TypeMap"/>):
-    /// compute the set of locals that may hold the sentinel to a fixpoint — seeded by direct
-    /// <c>any</c>/<c>undefined</c> assignments and grown transitively through other tainted locals —
-    /// then flag any <c>return</c> of such a local so the compiler widens the slot back to object.
-    /// Order-independent, so a taint reaching an earlier return via a loop back-edge is still
-    /// caught. Over-approximates (no narrowing): at worst a needless object slot, never a wrong
-    /// value. Only meaningful when the declared return is <c>number</c>/<c>boolean</c> — methods,
-    /// async, and inferred-return functions already use an object slot, so they cannot corrupt.
+    /// #367/#372 residual of #344: a <c>number</c>/<c>boolean</c>-typed <em>local or parameter</em>
+    /// can be unsoundly assigned an <c>any</c>/<c>undefined</c> value (e.g.
+    /// <c>let x: number = undefined as any</c> or <c>x = undefined as any</c> on a <c>x: number</c>
+    /// parameter) and so hold the runtime <c>undefined</c> sentinel. A <c>number</c>/<c>boolean</c>
+    /// slot is unboxed (<c>double</c>/<c>bool</c>), which cannot carry the sentinel — storing it
+    /// coerces to <c>NaN</c>/<c>false</c> (a never-initialized double arg slot yields raw garbage).
+    /// The narrow static type at every later use (a <c>return x</c>, a <c>console.log(x)</c>, an
+    /// arithmetic op) reports <c>number</c>/<c>boolean</c>, hiding the taint from the per-expression
+    /// #344 detection.
+    ///
+    /// <para>
+    /// Run a whole-body taint pass <em>after</em> the body is type-checked (every sub-expression's
+    /// type is then in the <see cref="TypeMap"/>): compute the set of names that may hold the
+    /// sentinel to a fixpoint — seeded by direct <c>any</c>/<c>undefined</c> assignments and grown
+    /// transitively through other tainted names — then flag, so the compiler widens each affected
+    /// slot back to <c>object</c>:
+    /// <list type="bullet">
+    ///   <item>tainted local <em>declarations</em> (their unboxed double slot would corrupt at the store);</item>
+    ///   <item>tainted <em>parameters</em> (their unboxed double arg slot likewise corrupts on reassignment);</item>
+    ///   <item><em>returns</em> of a tainted name (the unboxed return slot would corrupt at the return).</item>
+    /// </list>
+    /// </para>
+    ///
+    /// Order-independent, so a taint reaching an earlier use via a loop back-edge is still caught.
+    /// Over-approximates (no narrowing): at worst a needless object slot, never a wrong value. Runs
+    /// regardless of the declared return type — unlike #367 it is not gated on a <c>number</c>/<c>boolean</c>
+    /// return, because the corruption happens at the local/param store, independent of how (or
+    /// whether) the value is returned. Each flag is a no-op unless the slot it names would otherwise
+    /// be unboxed, so widening returns/locals/params that are not numeric costs nothing.
     /// </summary>
-    private void MarkUndefinedReachableLocalReturns(IReadOnlyList<Stmt> body)
+    private void MarkUndefinedReachableNumericSlots(
+        IReadOnlyList<Stmt> body,
+        IReadOnlyList<Stmt.Parameter>? parameters = null)
     {
-        TypeInfo? declared = _currentFunctionReturnType;
-        if (_inAsyncFunction && declared is TypeInfo.Promise promised) declared = promised.ValueType;
-        if (declared is not TypeInfo.Primitive { Type: TokenType.TYPE_NUMBER or TokenType.TYPE_BOOLEAN })
-            return;
-
         var collected = ReturnLocalTaintCollector.Collect(body);
-        if (collected.Returns.Count == 0 || collected.Assignments.Count == 0) return;
+        if (collected.Assignments.Count == 0) return;
 
         var tainted = new HashSet<string>();
         bool changed = true;
@@ -522,11 +534,11 @@ public partial class TypeChecker
         }
         if (tainted.Count == 0) return;
 
-        // Local slot: object-slot every tainted number-typed local so its declaration does not get
-        // an unboxed double slot that would coerce the sentinel to NaN at the store (e.g. the
-        // intermediate `z` in `let y = undefined as any; let z = y; return z`). Both the declaration
-        // node and its initializer are flagged — `const` is recompiled through a fresh Stmt.Var that
-        // reuses the original initializer expression.
+        // Local slot: object-slot every tainted local so its declaration does not get an unboxed
+        // double slot that would coerce the sentinel to NaN at the store (e.g. the intermediate `z`
+        // in `let y = undefined as any; let z = y; return z`, or simply a local that is only logged).
+        // Both the declaration node and its initializer are flagged — `const` is recompiled through a
+        // fresh Stmt.Var that reuses the original initializer expression.
         foreach (var (name, node, initializer) in collected.Declarations)
         {
             if (!tainted.Contains(name)) continue;
@@ -534,7 +546,15 @@ public partial class TypeChecker
             if (initializer != null) _typeMap.MarkUndefinedReachableNumericLocal(initializer);
         }
 
-        // Return slot: flag returns of a tainted local so the compiler widens the otherwise-unboxed
+        // Parameter slot: object-slot every tainted parameter (e.g. `function p(x: number) { x =
+        // undefined as any; ... }`) so the compiler does not give it an unboxed double/bool arg slot.
+        // A parameter has no declaration node in `collected`; it is matched by name.
+        if (parameters != null)
+            foreach (var param in parameters)
+                if (tainted.Contains(param.Name.Lexeme))
+                    _typeMap.MarkUndefinedReachableNumericParam(param);
+
+        // Return slot: flag returns of a tainted name so the compiler widens the otherwise-unboxed
         // double/bool return slot back to object.
         foreach (var ret in collected.Returns)
             if (ValueMayBeUndefinedSentinel(ret, tainted))

--- a/TypeSystem/TypeMap.cs
+++ b/TypeSystem/TypeMap.cs
@@ -19,6 +19,7 @@ public class TypeMap
     private readonly Dictionary<Expr.ClassExpr, TypeInfo.Class> _classExprTypes = new(ReferenceEqualityComparer.Instance);
     private readonly HashSet<Expr> _undefinedReachableReturns = new(ReferenceEqualityComparer.Instance);
     private readonly HashSet<object> _undefinedReachableNumericLocals = new(ReferenceEqualityComparer.Instance);
+    private readonly HashSet<Stmt.Parameter> _undefinedReachableNumericParams = new(ReferenceEqualityComparer.Instance);
 
     /// <summary>
     /// Associates an expression with its resolved type.
@@ -91,6 +92,26 @@ public class TypeMap
     /// </summary>
     public bool IsUndefinedReachableNumericLocal(object declOrInitializer) =>
         _undefinedReachableNumericLocals.Contains(declOrInitializer);
+
+    /// <summary>
+    /// Flags a <c>number</c>/<c>boolean</c>-typed <em>parameter</em> that an <c>any</c>/<c>undefined</c>
+    /// value may have been (transitively) assigned in the body, leaving it holding the runtime
+    /// <c>undefined</c> sentinel (#372 — the parameter analogue of <see cref="MarkUndefinedReachableNumericLocal"/>).
+    /// A <c>: number</c> parameter compiles to an unboxed <c>double</c> arg slot (a <c>: boolean</c> to a
+    /// <c>bool</c> slot) which cannot carry the sentinel — storing it coerces to <c>NaN</c>/<c>false</c>
+    /// (or, for a never-initialized slot, raw garbage). The compiler's parameter resolver consults this
+    /// to widen just those parameter slots back to <c>object</c>. Keyed by reference on the
+    /// <see cref="Stmt.Parameter"/> node. Purely a compiler hint — caller-side checking still sees the
+    /// clean <c>number</c>/<c>boolean</c> parameter type.
+    /// </summary>
+    public void MarkUndefinedReachableNumericParam(Stmt.Parameter param) =>
+        _undefinedReachableNumericParams.Add(param);
+
+    /// <summary>
+    /// True if <paramref name="param"/> was flagged by <see cref="MarkUndefinedReachableNumericParam"/>.
+    /// </summary>
+    public bool IsUndefinedReachableNumericParam(Stmt.Parameter param) =>
+        _undefinedReachableNumericParams.Contains(param);
 
     /// <summary>
     /// Gets the resolved type for an expression, or null if not found.


### PR DESCRIPTION
Closes #372. Also fixes a pre-existing bug discovered along the way (#402).

## Problem

#367 (PR #371) fixed a `number`/`boolean`-typed **local** holding the `undefined` sentinel that is **returned** from a number/boolean-typed function. But the same unboxed-slot corruption happens anywhere the value is observed — the #367 taint pass was deliberately gated on a declared number/boolean return, so these were never reached:

```ts
// 1. inferred return (return slot inferred number, double-slotted)
function inf(n: any) { let x: number = 0; x = undefined as any; return x; }
console.log(inf(1));            // was: NaN

// 2. non-return observation in a void function
function obs(): void { let x: number = 0; x = undefined as any; console.log(x); }
obs();                         // was: NaN

// 3. reassigned number parameter (unboxed double arg slot)
function p(x: number): number { x = undefined as any; return x; }
console.log(p(1));             // was: garbage double (e.g. 1.3e-311)
```

All three now print `undefined`, matching the interpreter.

## Fix

- **Decouple the taint pass from the return-type gate.** It now runs for every function body and object-slots any tainted `number`/`boolean` local — the corruption occurs at the local store, independent of how (or whether) the value is returned. The early-out no longer requires a `return` (case 2 has none). Renamed `MarkUndefinedReachableLocalReturns` → `MarkUndefinedReachableNumericSlots`.
- **Object-slot tainted parameters.** The pass matches tainted names against the parameter list and flags them via a new `TypeMap.MarkUndefinedReachableNumericParam`; `ParameterTypeResolver` (free fn / arrow / inner fn, method, constructor) widens a flagged number/bool param slot to `object`. Setter params are already always `object`.
- **Inferred returns need no extra wiring** — the compiler already widens the return slot when the resolved (possibly-inferred) numeric return is flagged, which now happens because the gate is gone.

Each flag is a no-op unless the slot it names would otherwise be unboxed, so widening non-numeric slots costs nothing; the over-approximation is sound (at worst an occasional needless object slot, never a wrong value).

## Pre-existing bug also fixed (#402)

While fixing case 3 I found that reassigning **any** typed parameter (`number`/`boolean`/`string`) with even a sound value was already broken in compiled mode: the `Expr.Assign`→parameter emitter assumed every param slot was `object` and boxed before `Starg`, which is invalid IL (`StackUnexpected`) and reads back garbage.

```ts
function a(x: number): number { x = 99; return x; }       // was: garbage + IL error → now 99
function c(x: number): number { x = x + 1; return x * 2; } // was: garbage + IL error → now 22
```

Fixed by converting the value to the parameter slot's declared type via the existing `EmitConvertForParamSlot` helper (added in #284 for captured-parameter dual-writes) before `Starg`. This is the exact path #372 case 3 relies on, so sound and undefined-reachable param reassignment are now both correct.

## Tests

6 new `ILVerificationTests` (inferred return, void observation, number+boolean param, method/static/ctor params, sound param reassignment, sound-param over-widening guard). All assert compiled == interpreted and pass `--verify`.

Full suite: **11241 passed, 0 failed.**