### PR TITLE
test(compile): close #402 with boolean/string typed-param reassignment coverage

### DIFF
--- a/SharpTS.Tests/CompilerTests/ILVerificationTests.cs
+++ b/SharpTS.Tests/CompilerTests/ILVerificationTests.cs
@@ -823,4 +823,44 @@ public class ILVerificationTests
         Assert.Equal("21\n", output);
         Assert.Equal(output, TestHarness.RunInterpreted(source));
     }
+
+    // #402: the same StackUnexpected corruption applied to `: boolean` params, which compile to an
+    // unboxed `bool` arg slot. Reassigning one (literal or computed) must Unbox_Any the boxed value
+    // back to bool before Starg.
+    [Fact]
+    public void TypedBooleanParam_SoundReassignment_ComputesCorrectly()
+    {
+        var source = """
+            function a(x: boolean): boolean { x = false; return x; }
+            function c(x: boolean): boolean { x = !x; return x; }
+            console.log(a(true));
+            console.log(c(true));
+            """;
+
+        var (errors, output) = TestHarness.CompileVerifyAndRun(source);
+
+        Assert.Empty(errors);
+        Assert.Equal("false\nfalse\n", output);
+        Assert.Equal(output, TestHarness.RunInterpreted(source));
+    }
+
+    // #402: a `: string` param compiles to a `string` arg slot (a reference type), so the conversion
+    // before Starg is a `castclass` rather than `Unbox_Any`. Reassigning one must not box-and-Starg
+    // an `object` into the `string` slot.
+    [Fact]
+    public void TypedStringParam_SoundReassignment_ComputesCorrectly()
+    {
+        var source = """
+            function a(x: string): string { x = "hi"; return x; }
+            function c(x: string): string { x = x + "!"; return x; }
+            console.log(a("a"));
+            console.log(c("a"));
+            """;
+
+        var (errors, output) = TestHarness.CompileVerifyAndRun(source);
+
+        Assert.Empty(errors);
+        Assert.Equal("hi\na!\n", output);
+        Assert.Equal(output, TestHarness.RunInterpreted(source));
+    }
 }


### PR DESCRIPTION
Closes #402.

## Background

The #402 bug — reassigning a typed parameter (`: number`/`: boolean`/`: string`) corrupted the value and failed IL verification (`StackUnexpected`), because the assignment emitter unconditionally `box`ed the value before `Starg` into an unboxed/typed arg slot — was **fixed as part of the #372 work** (PR #403). `ILEmitter.Expressions.cs` now calls `CompilationContext.EmitConvertForParamSlot` before `Starg`, converting the boxed value to the slot's declared type (`Unbox_Any` for value-type slots, `castclass` for reference-type slots, no-op for object slots).

That fix shipped with regression coverage for **`: number` only** (`TypedNumberParam_SoundReassignment_ComputesCorrectly`), even though #402 explicitly covers `: boolean` and `: string` — which exercise different conversion paths (`Unbox_Any` to `bool` vs `castclass` to `string`).

## Change

Adds the two missing regression tests next to the existing number test:

- `TypedBooleanParam_SoundReassignment_ComputesCorrectly` — `bool` slot, `Unbox_Any` path (literal and computed `!x` reassignment).
- `TypedStringParam_SoundReassignment_ComputesCorrectly` — `string` slot, `castclass` path (literal and computed `x + "!"` reassignment).

Both compile, pass IL verification, and match the interpreter. I also verified ad-hoc that `: bigint` params and assignment-as-expression-value (`let y = (x = 5)`) work — no adjacent gaps found.

Test-only change; no production code touched.

## Verification

```
Passed!  - Failed: 0, Passed: 3, Skipped: 0  (Number/Boolean/String SoundReassignment)
```