### PR TITLE
fix(compile): honor compiled Worker workerData option (#380)

### DIFF
--- a/Compilation/Emitters/Modules/WorkerThreadsModuleEmitter.cs
+++ b/Compilation/Emitters/Modules/WorkerThreadsModuleEmitter.cs
@@ -88,8 +88,11 @@ public sealed class WorkerThreadsModuleEmitter : IBuiltInModuleEmitter
         var ctx = emitter.Context;
         var il = ctx.IL;
 
-        // workerData is stored as a thread-local, access via runtime helper
-        // For now, return null in compiled code (workers load from file, not inline)
+        // workerData is only defined in worker context, and worker child scripts
+        // always run under the interpreter (SharpTSWorker.RunWorkerScript news up an
+        // Interpreter), which binds the cloned workerData via env.Define. This
+        // compiled path is therefore only ever reached on the MAIN thread, where
+        // Node's workerData is null — so null is the correct value here (#380).
         il.Emit(OpCodes.Ldnull);
         return true;
     }

--- a/Runtime/Types/SharpTSWorker.cs
+++ b/Runtime/Types/SharpTSWorker.cs
@@ -96,7 +96,7 @@ public class SharpTSWorker : SharpTSEventEmitter, IDisposable
     /// emitted <c>$EventLoop.Schedule</c>). Used to deliver worker events to the
     /// parent without relying on an ambient <see cref="SynchronizationContext"/>.
     /// </param>
-    public SharpTSWorker(string filename, SharpTSObject? options, Interpreter? parentInterpreter,
+    public SharpTSWorker(string filename, object? options, Interpreter? parentInterpreter,
         Action? eventLoopRef = null, Action? eventLoopUnref = null, Action<Action>? eventLoopSchedule = null)
     {
         _loopSchedule = eventLoopSchedule;
@@ -133,10 +133,17 @@ public class SharpTSWorker : SharpTSEventEmitter, IDisposable
         //     for which the .NET runtime exposes no per-thread equivalent.
         // They are not read here (rather than read-and-ignored) so the dead fields can't
         // masquerade as support. See issue #407.
+        //
+        // The bag is a SharpTSObject in interpreter mode and a Dictionary<string, object?>
+        // (a compiled object literal) in compiled mode; ReadOption reads through both so
+        // workerData/transferList are honored either way (#380). transferList stays typed
+        // as SharpTSArray: a compiled List<object?> transferList yields null here (so
+        // workerData still clones), and cross-boundary MessagePort transfer in compiled
+        // mode is a separate gap (#406).
         if (options != null)
         {
-            _workerData = options.GetProperty("workerData");
-            _transferList = options.GetProperty("transferList") as SharpTSArray;
+            _workerData = ReadOption(options, "workerData");
+            _transferList = ReadOption(options, "transferList") as SharpTSArray;
         }
 
         // Clone workerData for transfer to worker
@@ -177,6 +184,20 @@ public class SharpTSWorker : SharpTSEventEmitter, IDisposable
     }
 
     /// <summary>
+    /// Reads a named property from a worker options bag regardless of how the bag is
+    /// represented: a <see cref="SharpTSObject"/> in interpreter mode, or a
+    /// <see cref="Dictionary{TKey,TValue}"/> (a compiled object literal) in compiled
+    /// mode (#380). Returns null when the property is absent or the bag is an
+    /// unsupported shape (e.g. a compiled options literal that uses accessors).
+    /// </summary>
+    private static object? ReadOption(object? options, string name) => options switch
+    {
+        SharpTSObject obj => obj.GetProperty(name),
+        IDictionary<string, object?> dict => dict.TryGetValue(name, out var v) ? v : null,
+        _ => null,
+    };
+
+    /// <summary>
     /// Factory used by compiled output to construct a worker whose running-lifetime
     /// keep-alive is accounted against the emitted <c>$EventLoop</c> singleton rather
     /// than an <see cref="Interpreter"/> (which does not exist at runtime in compiled
@@ -186,9 +207,9 @@ public class SharpTSWorker : SharpTSEventEmitter, IDisposable
     /// </summary>
     /// <param name="filename">Path to the TypeScript file to execute.</param>
     /// <param name="options">
-    /// Worker options. Only <see cref="SharpTSObject"/> option bags are honored today;
-    /// a compiled object literal is currently ignored (see issue for workerData/
-    /// transferList marshaling in compiled mode).
+    /// Worker options bag — a compiled object literal (<c>Dictionary&lt;string, object?&gt;</c>).
+    /// Passed through to the constructor, which reads <c>workerData</c>/<c>transferList</c>
+    /// via <see cref="ReadOption"/> regardless of representation (#380).
     /// </param>
     /// <param name="eventLoopRef">The emitted <c>$EventLoop</c> instance's <c>Ref</c>.</param>
     /// <param name="eventLoopUnref">The emitted <c>$EventLoop</c> instance's <c>Unref</c>.</param>
@@ -196,7 +217,7 @@ public class SharpTSWorker : SharpTSEventEmitter, IDisposable
         string filename, object? options, Action eventLoopRef, Action eventLoopUnref,
         Action<Action> eventLoopSchedule)
     {
-        return new SharpTSWorker(filename, options as SharpTSObject, parentInterpreter: null,
+        return new SharpTSWorker(filename, options, parentInterpreter: null,
             eventLoopRef, eventLoopUnref, eventLoopSchedule);
     }
 

--- a/SharpTS.Tests/SharedTests/WorkerThreadsTests.cs
+++ b/SharpTS.Tests/SharedTests/WorkerThreadsTests.cs
@@ -610,4 +610,77 @@ public class WorkerThreadsTests
     }
 
     #endregion
+
+    #region Worker options bag — workerData (#380)
+
+    /// <summary>
+    /// Regression for #380: a worker spawned with a <c>workerData</c> option must see
+    /// that value via <c>worker_threads.workerData</c>. In compiled mode the options
+    /// bag is a <c>Dictionary&lt;string, object?&gt;</c> (a compiled object literal),
+    /// not a <c>SharpTSObject</c>; before the fix the constructor's
+    /// <c>options as SharpTSObject</c> cast yielded null and the entire bag was
+    /// dropped, so a compiled worker saw <c>workerData === undefined</c>.
+    /// </summary>
+    /// <remarks>
+    /// The worker child script always runs under the interpreter, so it reads
+    /// workerData through <c>env.Define</c>; the fix is purely in how the parent
+    /// (compiled or interpreted) marshals the options bag into <c>SharpTSWorker</c>.
+    /// <c>__dirname</c> routes the harness through the real-disk path so the worker
+    /// can load its script.
+    /// </remarks>
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Worker_WorkerData_PrimitiveIsVisibleInWorker(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["worker_data.ts"] = """
+                // workerData/postMessage resolve as worker-context globals (no import).
+                postMessage("data:" + workerData);
+                """,
+            ["main.ts"] = """
+                import { Worker } from "worker_threads";
+                const w = new Worker(__dirname + "/worker_data.ts", { workerData: 123 });
+                w.on("message", (e: any) => {
+                    console.log("received:" + e.data);
+                });
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Contains("received:data:123", output);
+    }
+
+    /// <summary>
+    /// #380: an object <c>workerData</c> is structured-cloned across the boundary and
+    /// its fields are readable in the worker. Exercises the compiled
+    /// <c>Dictionary&lt;string, object?&gt;</c> clone path as well as the interpreter
+    /// <c>SharpTSObject</c> path.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Worker_WorkerData_ObjectIsClonedAndVisibleInWorker(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["worker_data_obj.ts"] = """
+                // workerData/postMessage resolve as worker-context globals (no import).
+                postMessage("got:" + workerData.name + ":" + workerData.count);
+                """,
+            ["main.ts"] = """
+                import { Worker } from "worker_threads";
+                const w = new Worker(__dirname + "/worker_data_obj.ts", {
+                    workerData: { name: "alice", count: 7 }
+                });
+                w.on("message", (e: any) => {
+                    console.log("received:" + e.data);
+                });
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Contains("received:got:alice:7", output);
+    }
+
+    #endregion
 }


### PR DESCRIPTION
Closes #380.

## Problem
A compiled program that spawns `new Worker(f, { workerData: 123 })` saw `workerData === undefined` inside the worker. The options bag is a compiled object literal (`Dictionary<string, object?>`), but `SharpTSWorker.CreateForCompiledLoop` cast it with `options as SharpTSObject`, which yields null for that type — silently dropping `workerData`, `transferList`, and stdio. The interpreter path passes a real `SharpTSObject`, so it was unaffected.

## Fix
- `SharpTSWorker` ctor now takes `object?` options and reads each property through a new representation-agnostic `ReadOption` helper that handles **both** a `SharpTSObject` (interpreter) and an `IDictionary<string, object?>` (compiled literal).
- `CreateForCompiledLoop` passes the bag straight through instead of `as SharpTSObject`.
- `workerData` then structured-clones across the boundary (`StructuredClone` already supports compiled `Dictionary`/`List`/etc.) and is delivered to the worker. The worker child script always runs **interpreted** (`RunWorkerScript` news up an `Interpreter`), so it reads `workerData` via `env.Define` — the fix is purely in how the parent marshals the bag.

### Why `EmitWorkerData` is left returning null
Because worker child scripts always run interpreted, the compiled `worker_threads.workerData` path is only ever reached on the **main thread**, where Node's `workerData` is legitimately null. The PR corrects the stale comment there rather than changing behavior.

## Scope / follow-ups
- `transferList`/`resourceLimits` stay `SharpTSArray`-typed: a compiled `List<object?>` transferList yields null (so `workerData` still clones), and cross-boundary MessagePort transfer in compiled mode is a separate gap → **#406**.
- `stdin`/`stdout`/`stderr`/`resourceLimits` are parsed but inert in both modes → **#407**.

## Tests
New `WorkerThreadsTests` (both interpreter + compiled):
- `Worker_WorkerData_PrimitiveIsVisibleInWorker` — `workerData: 123` round-trips.
- `Worker_WorkerData_ObjectIsClonedAndVisibleInWorker` — object `workerData` is cloned and its fields readable.

Full `WorkerThreadsTests` suite green (62 passed).