### PR TITLE
fix(interp): missing static read through class-as-value returns undefined (#398)

### DIFF
--- a/Execution/Interpreter.Properties.cs
+++ b/Execution/Interpreter.Properties.cs
@@ -785,7 +785,12 @@ public partial class Interpreter
             if (promiseStatic != null) return promiseStatic;
         }
 
-        throw new InterpreterException($"Static member '{memberName}' does not exist on class '{klass.Name}'.");
+        // ECMA-262 §7.3.2 (Get): reading an absent own/inherited property
+        // returns `undefined` — it never throws. A statically-typed
+        // `Klass.missing` is already rejected at compile time (TS2339), so
+        // reaching here means the read came through an `any`/dynamic value
+        // position; mirror compiled mode and JS by yielding `undefined`.
+        return SharpTSUndefined.Instance;
     }
 
     /// <summary>

--- a/SharpTS.Tests/SharedTests/StaticMembersTests.cs
+++ b/SharpTS.Tests/SharedTests/StaticMembersTests.cs
@@ -635,4 +635,57 @@ public class StaticMembersTests
     }
 
     #endregion
+
+    #region Missing Static Read Through Class-As-Value (#398)
+
+    // ECMA-262 §7.3.2 (Get): reading a *missing* own/inherited property returns `undefined` — it
+    // never throws. A statically-typed `Klass.missing` is already a compile-time error (TS2339), so
+    // these reads come through an `any`/value position. Compiled mode was already correct; the
+    // interpreter previously threw "Static member 'x' does not exist on class 'y'." (#398).
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void MissingStaticAsValue_OnSubclass(ExecutionMode mode)
+    {
+        var source = """
+            class Base {}
+            class Sub extends Base {}
+            const S: any = Sub;
+            console.log(S.nope);
+            """;
+
+        Assert.Equal("undefined\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void MissingStaticAsValue_OnPlainClass(ExecutionMode mode)
+    {
+        var source = """
+            class C { static known: number = 1; }
+            const K: any = C;
+            console.log(K.known);
+            console.log(K.missing);
+            """;
+
+        Assert.Equal("1\nundefined\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void MissingStaticAsValue_UsedInExpression(ExecutionMode mode)
+    {
+        // A missing read yielding `undefined` participates in normal coercion rather than aborting.
+        var source = """
+            class Base {}
+            class Sub extends Base {}
+            const S: any = Sub;
+            console.log(S.nope === undefined);
+            console.log(typeof S.nope);
+            """;
+
+        Assert.Equal("true\nundefined\n", TestHarness.Run(source, mode));
+    }
+
+    #endregion
 }


### PR DESCRIPTION
## Summary

Fixes #398. In **interpreter mode**, a dynamic / `any`-typed read of a **missing** static member through a class used as a runtime value threw a runtime error, where ECMAScript (and SharpTS compiled mode) return `undefined`.

```ts
class Base {}
class Sub extends Base {}
const S: any = Sub;
console.log(S.nope);   // node/compiled: undefined ; interp (before): throws
```

Before: `Runtime Error: Static member 'nope' does not exist on class 'Sub'.`
After: `undefined`

## Fix

`EvaluateGetOnClass` (`Execution/Interpreter.Properties.cs`) already walks the superclass chain for inherited statics (`FindStaticMethod` / `GetStaticProperty` / `FindStaticGetter` / `HasStaticAutoAccessor`), so the only non-spec behavior was the terminal `throw`. Per ECMA-262 §7.3.2 (Get), reading an absent own/inherited property returns `undefined` and never throws.

A statically-typed `Klass.missing` is still rejected at compile time (TS2339), so reaching the runtime read means the access came through an `any` / value position — yielding `SharpTSUndefined.Instance` now mirrors compiled mode, the record-read path, and JS.

## Tests

Added a `#398` region in `StaticMembersTests.cs` covering missing reads on a subclass, on a plain class (alongside a present static), and in expression position (`=== undefined`, `typeof`). All run **both** modes (compiled was already correct) to guard the parity.

- New tests: 6 (3 × interp/compiled), all pass.
- Static-member-related suites (StaticMembers / PromiseSubclass / ClassExpression): 209 pass, 0 fail.

## Scope notes

- Interpreter only; compiled mode unchanged.
- No new technical debt; the fix removes a non-spec throw and reuses the existing inheritance walk. No emitter changes.