### PR TITLE
fix(worker): drop inert stdio/resourceLimits options (#407)

### DIFF
--- a/Runtime/Types/SharpTSWorker.cs
+++ b/Runtime/Types/SharpTSWorker.cs
@@ -29,11 +29,7 @@ public class SharpTSWorker : SharpTSEventEmitter, IDisposable
     private readonly CancellationTokenSource _cts = new();
     private readonly string _scriptPath;
     private readonly object? _workerData;
-    private readonly object? _stdin;
-    private readonly object? _stdout;
-    private readonly object? _stderr;
     private readonly SharpTSArray? _transferList;
-    private readonly SharpTSArray? _resourceLimits;
     private volatile bool _isRunning;
     private volatile bool _isTerminated;
     private Exception? _workerError;
@@ -125,15 +121,22 @@ public class SharpTSWorker : SharpTSEventEmitter, IDisposable
         // Capture sync context for compiled code to marshal callbacks to main thread
         _syncContext = SynchronizationContext.Current;
 
-        // Extract options
+        // Extract options. Only workerData and transferList are honored: the worker
+        // runs an isolated interpreter on a dedicated thread in this same process, so
+        // the worker's console output already shares the parent's stdout/stderr by
+        // default. The Node stdio options (stdin/stdout/stderr) and resourceLimits are
+        // intentionally NOT supported:
+        //   - stdin/stdout/stderr=true would have to expose per-worker Readable/Writable
+        //     streams and divert the worker off the shared (process-global) Console,
+        //     which is not thread-safe in a single-process model.
+        //   - resourceLimits maps to V8 heap/stack sizing (maxOldGenerationSizeMb, …)
+        //     for which the .NET runtime exposes no per-thread equivalent.
+        // They are not read here (rather than read-and-ignored) so the dead fields can't
+        // masquerade as support. See issue #407.
         if (options != null)
         {
             _workerData = options.GetProperty("workerData");
             _transferList = options.GetProperty("transferList") as SharpTSArray;
-            _stdin = options.GetProperty("stdin");
-            _stdout = options.GetProperty("stdout");
-            _stderr = options.GetProperty("stderr");
-            _resourceLimits = options.GetProperty("resourceLimits") as SharpTSArray;
         }
 
         // Clone workerData for transfer to worker

--- a/STATUS.md
+++ b/STATUS.md
@@ -449,7 +449,7 @@ SharpTS implements 20+ Node.js built-in modules accessible via `import ... from 
 | `timers` | ✅ | setTimeout, clearTimeout, setInterval, clearInterval, setImmediate, clearImmediate |
 | `timers/promises` | ✅ | Promise-based setTimeout, setImmediate, setInterval |
 | `perf_hooks` | ✅ | performance.now(), timeOrigin, mark(), measure(), getEntries(), getEntriesByName(), getEntriesByType(), clearMarks(), clearMeasures(); PerformanceObserver |
-| `worker_threads` | ✅ | Worker, isMainThread, parentPort, workerData, MessageChannel, MessagePort |
+| `worker_threads` | ✅ | Worker, isMainThread, parentPort, workerData, MessageChannel, MessagePort. Worker `stdin`/`stdout`/`stderr` and `resourceLimits` options are not supported (workers share the parent's console; resourceLimits has no .NET equivalent) |
 | `async_hooks` | ✅ | AsyncLocalStorage: run, getStore, enterWith, exit, disable; async context propagation via .NET AsyncLocal |
 
 ### Module Implementation Source

--- a/SharpTS.Tests/SharedTests/WorkerThreadsTests.cs
+++ b/SharpTS.Tests/SharedTests/WorkerThreadsTests.cs
@@ -566,4 +566,48 @@ public class WorkerThreadsTests
     }
 
     #endregion
+
+    #region Unsupported Worker options (#407)
+
+    /// <summary>
+    /// Regression for #407: the Worker <c>stdin</c>/<c>stdout</c>/<c>stderr</c> and
+    /// <c>resourceLimits</c> options are intentionally unsupported, but supplying
+    /// them in the options bag must not break construction — the worker still
+    /// spawns, runs, and posts back. The bag also carries the honored
+    /// <c>workerData</c>/<c>transferList</c> options so this exercises the
+    /// unsupported keys coexisting with supported ones. Before the fix these keys
+    /// were read into inert dead fields (and <c>resourceLimits</c> was mistyped as
+    /// <c>SharpTSArray</c>); now they are simply ignored. <c>resourceLimits</c> is
+    /// passed as an object, not an array — the shape that always yielded null under
+    /// the old <c>as SharpTSArray</c> read, confirming the bag no longer trips on it.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Worker_UnsupportedStdioAndResourceLimitsOptions_AreIgnored(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["worker_echo.ts"] = """
+                setTimeout(() => { postMessage("ran"); }, 50);
+                """,
+            ["main.ts"] = """
+                import { Worker } from "worker_threads";
+                const w = new Worker(__dirname + "/worker_echo.ts", {
+                    workerData: 42,
+                    stdout: true,
+                    stderr: true,
+                    stdin: true,
+                    resourceLimits: { maxOldGenerationSizeMb: 16 },
+                });
+                w.on("message", (e: any) => {
+                    console.log("received:" + e.data);
+                });
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Contains("received:ran", output);
+    }
+
+    #endregion
 }


### PR DESCRIPTION
Closes #407.

## Problem
`SharpTSWorker` read `stdin`/`stdout`/`stderr`/`resourceLimits` from the Worker options bag into private fields (`_stdin`, `_stdout`, `_stderr`, `_resourceLimits`), but **nothing consumed them** in either runtime — inert dead fields. `_resourceLimits` was also mistyped `as SharpTSArray` (Node's `resourceLimits` is an object), so it would have been null even if read.

## Resolution
These options can't be meaningfully supported in SharpTS's single-process model, so per the issue's second suggested option they are no longer read and are documented as unsupported:

- **stdin/stdout/stderr** — `true` would require exposing per-worker `Readable`/`Writable` streams and diverting the worker off the shared, process-global `Console` (not thread-safe). The default Node behavior (worker output piped to the parent) already holds, since SharpTS workers share the parent's console.
- **resourceLimits** — maps to V8 heap/stack sizing (`maxOldGenerationSizeMb`, …) for which the .NET runtime exposes no per-thread equivalent.

`workerData` and `transferList` (the honored options) are unchanged.

## Changes
- `Runtime/Types/SharpTSWorker.cs` — remove the four inert fields and stop reading them; document why they're unsupported.
- `STATUS.md` — note the unsupported Worker options.
- `WorkerThreadsTests.cs` — both-modes regression test that an options bag carrying the unsupported keys (with `resourceLimits` as an **object**) doesn't break construction and the worker still runs.

## Verification
`dotnet test --filter WorkerThreadsTests` → 60 passed (interpreter + compiled).

## Gap filed along the way
- **#410** — Worker scripts run in single-file *script* mode, so any `import` (including the canonical `import { workerData, parentPort } from "worker_threads"`) fails with "Import statements require module mode"; only the bare injected globals work today.