### PR TITLE
fix(compile): persist await-spilled values across deferred suspension (#400)

### DIFF
--- a/Compilation/AsyncMoveNextEmitter.Expressions.cs
+++ b/Compilation/AsyncMoveNextEmitter.Expressions.cs
@@ -75,6 +75,11 @@ public partial class AsyncMoveNextEmitter
         _il.Emit(OpCodes.Ldc_I4, stateNumber);
         _il.Emit(OpCodes.Stfld, _builder.StateField);
 
+        // Mirror live spill temps to fields before AwaitUnsafeOnCompleted boxes the state
+        // machine: IL locals do not survive the MoveNext re-entry, and writes after the box
+        // would not reach the continuation's snapshot (#400). Suspending path only.
+        _helpers.PersistLiveSpillsBeforeSuspend();
+
         _il.Emit(OpCodes.Ldarg_0);
         _il.Emit(OpCodes.Ldflda, _builder.BuilderField);
         _il.Emit(OpCodes.Ldarg_0);
@@ -89,6 +94,10 @@ public partial class AsyncMoveNextEmitter
         _il.Emit(OpCodes.Ldarg_0);
         _il.Emit(OpCodes.Ldc_I4_M1);
         _il.Emit(OpCodes.Stfld, _builder.StateField);
+
+        // Restore spill temps from their fields — only on the resumed path; the
+        // synchronously-completed path (below) never persisted and keeps its locals.
+        _helpers.RehydrateLiveSpillsAfterResume();
 
         // 8. Continue point
         _il.MarkLabel(continueLabel);

--- a/Compilation/AsyncMoveNextEmitter.Operators.cs
+++ b/Compilation/AsyncMoveNextEmitter.Operators.cs
@@ -29,11 +29,9 @@ public partial class AsyncMoveNextEmitter
         var exprTemps = new List<LocalBuilder>();
         for (int i = 0; i < tl.Expressions.Count; i++)
         {
-            EmitExpression(tl.Expressions[i]);
-            EnsureBoxed();
-            var temp = _il.DeclareLocal(typeof(object));
-            _il.Emit(OpCodes.Stloc, temp);
-            exprTemps.Add(temp);
+            // SpillBoxed registers each temp so an await in a later interpolation persists
+            // the earlier ones across the suspension (#400).
+            exprTemps.Add(SpillBoxed(tl.Expressions[i]));
         }
 
         // Phase 2: Build string from temps (no awaits, stack safe)

--- a/Compilation/AsyncMoveNextEmitter.cs
+++ b/Compilation/AsyncMoveNextEmitter.cs
@@ -133,6 +133,10 @@ public partial class AsyncMoveNextEmitter : StatementEmitterBase, IEmitterContex
         _analysis = analysis;
         _il = builder.MoveNextMethod.GetILGenerator();
         _types = types;
+        // A spilled value live across an await must survive the MoveNext re-entry in a
+        // state-machine field, not a transient IL local (#400).
+        _helpers.EnablePersistentSpills(name => _builder.StateMachineType.DefineField(
+            name, _types.Object, System.Reflection.FieldAttributes.Private));
     }
 
     /// <summary>

--- a/Compilation/ExpressionEmitterBase.Operators.cs
+++ b/Compilation/ExpressionEmitterBase.Operators.cs
@@ -216,11 +216,8 @@ public abstract partial class ExpressionEmitterBase
         var skipLabel = IL.DefineLabel();
         var endLabel = IL.DefineLabel();
 
-        // Store object
-        EmitExpression(ls.Object);
-        EnsureBoxed();
-        var objLocal = IL.DeclareLocal(typeof(object));
-        IL.Emit(OpCodes.Stloc, objLocal);
+        // Store object (registered so an await inside ls.Value persists it — #400)
+        var objLocal = SpillBoxed(ls.Object);
 
         // Get current value
         IL.Emit(OpCodes.Ldloc, objLocal);
@@ -253,16 +250,9 @@ public abstract partial class ExpressionEmitterBase
         var skipLabel = IL.DefineLabel();
         var endLabel = IL.DefineLabel();
 
-        // Store object and index
-        EmitExpression(lsi.Object);
-        EnsureBoxed();
-        var objLocal = IL.DeclareLocal(typeof(object));
-        IL.Emit(OpCodes.Stloc, objLocal);
-
-        EmitExpression(lsi.Index);
-        EnsureBoxed();
-        var indexLocal = IL.DeclareLocal(typeof(object));
-        IL.Emit(OpCodes.Stloc, indexLocal);
+        // Store object and index (registered so an await inside lsi.Value persists them — #400)
+        var objLocal = SpillBoxed(lsi.Object);
+        var indexLocal = SpillBoxed(lsi.Index);
 
         // Get current value
         IL.Emit(OpCodes.Ldloc, objLocal);
@@ -320,8 +310,8 @@ public abstract partial class ExpressionEmitterBase
             if (Ctx.ClassRegistry!.TryGetCallableStaticField(resolvedClassName, cs.Name.Lexeme, compoundClassBuilder, out var inheritedField))
             {
                 EmitStaticFieldLoadWithShadow(resolvedClassName, compoundClassBuilder, cs.Name.Lexeme, inheritedField!);
-                var inheritedCurrentTemp = IL.DeclareLocal(typeof(object));
-                IL.Emit(OpCodes.Stloc, inheritedCurrentTemp);
+                // Registered so an await inside cs.Value persists it across the suspension (#400).
+                var inheritedCurrentTemp = _helpers.SpillStoreObject();
 
                 // Spill the RHS so an await inside it suspends with an empty stack.
                 var inheritedRhsTemp = SpillBoxed(cs.Value);
@@ -344,17 +334,14 @@ public abstract partial class ExpressionEmitterBase
             }
         }
 
-        // Dynamic property compound assignment
-        EmitExpression(cs.Object);
-        EnsureBoxed();
-        var objTemp = IL.DeclareLocal(typeof(object));
-        IL.Emit(OpCodes.Stloc, objTemp);
+        // Dynamic property compound assignment. objTemp and currentTemp are registered so
+        // an await inside cs.Value persists them across the suspension (#400).
+        var objTemp = SpillBoxed(cs.Object);
 
         IL.Emit(OpCodes.Ldloc, objTemp);
         IL.Emit(OpCodes.Ldstr, cs.Name.Lexeme);
         IL.Emit(OpCodes.Call, Ctx.Runtime!.GetProperty);
-        var currentTemp = IL.DeclareLocal(typeof(object));
-        IL.Emit(OpCodes.Stloc, currentTemp);
+        var currentTemp = _helpers.SpillStoreObject();
 
         // Spill the value so an await inside it suspends with an empty stack
         // (the current property value must not stay on the stack across it).
@@ -381,21 +368,15 @@ public abstract partial class ExpressionEmitterBase
     /// </summary>
     protected virtual void EmitCompoundSetIndex(Expr.CompoundSetIndex csi)
     {
-        EmitExpression(csi.Object);
-        EnsureBoxed();
-        var objTemp = IL.DeclareLocal(typeof(object));
-        IL.Emit(OpCodes.Stloc, objTemp);
-
-        EmitExpression(csi.Index);
-        EnsureBoxed();
-        var indexTemp = IL.DeclareLocal(typeof(object));
-        IL.Emit(OpCodes.Stloc, indexTemp);
+        // objTemp, indexTemp and currentTemp are registered so an await inside csi.Value
+        // persists them across the suspension (#400).
+        var objTemp = SpillBoxed(csi.Object);
+        var indexTemp = SpillBoxed(csi.Index);
 
         IL.Emit(OpCodes.Ldloc, objTemp);
         IL.Emit(OpCodes.Ldloc, indexTemp);
         IL.Emit(OpCodes.Call, Ctx.Runtime!.GetIndex);
-        var currentTemp = IL.DeclareLocal(typeof(object));
-        IL.Emit(OpCodes.Stloc, currentTemp);
+        var currentTemp = _helpers.SpillStoreObject();
 
         // Spill the value so an await inside it suspends with an empty stack
         // (the current element value must not stay on the stack across it).

--- a/Compilation/ExpressionEmitterBase.cs
+++ b/Compilation/ExpressionEmitterBase.cs
@@ -335,9 +335,10 @@ public abstract partial class ExpressionEmitterBase : IEmitterContext
     {
         EmitExpression(e);
         EnsureBoxed();
-        var local = IL.DeclareLocal(typeof(object));
-        IL.Emit(OpCodes.Stloc, local);
-        return local;
+        // Register the temp so a suspension (await) inside a *later* operand of the same
+        // expression persists this value to a field and rehydrates it on resume (#400).
+        // In non-state-machine emitters this is just a plain local.
+        return _helpers.SpillStoreObject();
     }
 
     /// <summary>
@@ -951,16 +952,12 @@ public abstract partial class ExpressionEmitterBase : IEmitterContext
             return;
         }
 
-        // Phase 1: Evaluate all expressions to temps (awaits/yields happen here)
+        // Phase 1: Evaluate all expressions to temps (awaits/yields happen here).
+        // SpillBoxed registers each temp so an await in a later interpolation persists
+        // the earlier ones across the suspension (#400).
         var exprTemps = new List<LocalBuilder>();
         for (int i = 0; i < tl.Expressions.Count; i++)
-        {
-            EmitExpression(tl.Expressions[i]);
-            EnsureBoxed();
-            var temp = IL.DeclareLocal(typeof(object));
-            IL.Emit(OpCodes.Stloc, temp);
-            exprTemps.Add(temp);
-        }
+            exprTemps.Add(SpillBoxed(tl.Expressions[i]));
 
         // Phase 2: Build string from temps (no awaits, stack safe)
         IL.Emit(OpCodes.Ldstr, tl.Strings[0]);
@@ -988,21 +985,14 @@ public abstract partial class ExpressionEmitterBase : IEmitterContext
     /// </summary>
     protected virtual void EmitTaggedTemplateLiteral(Expr.TaggedTemplateLiteral ttl)
     {
-        // Phase 1: Evaluate tag and all expressions to temps
-        EmitExpression(ttl.Tag);
-        EnsureBoxed();
-        var tagTemp = IL.DeclareLocal(typeof(object));
-        IL.Emit(OpCodes.Stloc, tagTemp);
+        // Phase 1: Evaluate tag and all expressions to temps. SpillBoxed registers each
+        // so an await in a later interpolation persists the tag and earlier expressions
+        // across the suspension (#400).
+        var tagTemp = SpillBoxed(ttl.Tag);
 
         var exprTemps = new List<LocalBuilder>();
         for (int i = 0; i < ttl.Expressions.Count; i++)
-        {
-            EmitExpression(ttl.Expressions[i]);
-            EnsureBoxed();
-            var temp = IL.DeclareLocal(typeof(object));
-            IL.Emit(OpCodes.Stloc, temp);
-            exprTemps.Add(temp);
-        }
+            exprTemps.Add(SpillBoxed(ttl.Expressions[i]));
 
         // Phase 2: Build arrays and call from temps
         IL.Emit(OpCodes.Ldloc, tagTemp);

--- a/Compilation/StateMachineEmitHelpers.cs
+++ b/Compilation/StateMachineEmitHelpers.cs
@@ -57,6 +57,90 @@ public class StateMachineEmitHelpers
         _runtime = runtime;
     }
 
+    #region Persistent Spills (#400)
+
+    // A spilled value temp. `Field` is allocated lazily the first time the temp is
+    // found live at a real suspension point.
+    private sealed class SpillEntry
+    {
+        public required LocalBuilder Local;
+        public FieldBuilder? Field;
+    }
+
+    private Func<string, FieldBuilder>? _defineSpillField;
+    private int _spillFieldCount;
+    // Spill temps created since the last statement boundary. A temp that is still
+    // registered when a suspension is emitted is live across it (operands are spilled
+    // up front, then loaded), so it must survive the MoveNext re-entry in a field.
+    private readonly List<SpillEntry> _liveSpills = new();
+
+    /// <summary>
+    /// Enables persistent spills for a state-machine emitter whose MoveNext can suspend.
+    /// IL evaluation-stack temps do not survive a MoveNext re-entry, so a value spilled
+    /// before an <c>await</c> and used after it must be mirrored to a state-machine field
+    /// (#400). The factory defines a fresh object field on the state-machine type.
+    /// Without this call, <see cref="SpillStoreObject"/> just declares a plain local.
+    /// </summary>
+    public void EnablePersistentSpills(Func<string, FieldBuilder> defineSpillField)
+        => _defineSpillField = defineSpillField;
+
+    /// <summary>
+    /// Pops the boxed value on top of the stack into a fresh object local and returns it.
+    /// When persistent spills are enabled, the local is also registered so that a later
+    /// suspension persists it to a field (#400). Stack: [value] -> [].
+    /// </summary>
+    public LocalBuilder SpillStoreObject()
+    {
+        var local = _il.DeclareLocal(_types.Object);
+        _il.Emit(OpCodes.Stloc, local);
+        if (_defineSpillField != null)
+            _liveSpills.Add(new SpillEntry { Local = local });
+        return local;
+    }
+
+    /// <summary>
+    /// Drops all registered spill temps. Called at statement boundaries: spill temps are
+    /// consumed within the expression that created them and never cross a statement, so
+    /// clearing keeps the live set (and the per-suspension persist/rehydrate cost) small.
+    /// </summary>
+    public void ClearLiveSpills() => _liveSpills.Clear();
+
+    /// <summary>
+    /// Mirrors every live spill local to a backing field. Emitted at a suspension point
+    /// just before the state machine yields control, so the values survive the re-entry.
+    /// Fields are allocated lazily and reused across suspensions. Stack-neutral. (#400)
+    /// </summary>
+    public void PersistLiveSpillsBeforeSuspend()
+    {
+        if (_defineSpillField == null) return;
+        foreach (var entry in _liveSpills)
+        {
+            entry.Field ??= _defineSpillField($"<>s__spill{_spillFieldCount++}");
+            _il.Emit(OpCodes.Ldarg_0);
+            _il.Emit(OpCodes.Ldloc, entry.Local);
+            _il.Emit(OpCodes.Stfld, entry.Field);
+        }
+    }
+
+    /// <summary>
+    /// Reloads every persisted spill local from its backing field. Emitted only on the
+    /// resumed path of a suspension (the synchronously-completed path never persisted, so
+    /// its locals are still intact). Stack-neutral. (#400)
+    /// </summary>
+    public void RehydrateLiveSpillsAfterResume()
+    {
+        if (_defineSpillField == null) return;
+        foreach (var entry in _liveSpills)
+        {
+            if (entry.Field == null) continue;
+            _il.Emit(OpCodes.Ldarg_0);
+            _il.Emit(OpCodes.Ldfld, entry.Field);
+            _il.Emit(OpCodes.Stloc, entry.Local);
+        }
+    }
+
+    #endregion
+
     #region Label Operations
 
     /// <summary>
@@ -1129,9 +1213,9 @@ public class StateMachineEmitHelpers
         for (int i = start; i < call.Arguments.Count; i++)
         {
             emitArgumentBoxed(call.Arguments[i]);
-            var temp = _il.DeclareLocal(_types.Object);
-            _il.Emit(OpCodes.Stloc, temp);
-            temps.Add(temp);
+            // Register each arg temp so a suspension in a later arg persists the earlier
+            // ones across the MoveNext re-entry (#400).
+            temps.Add(SpillStoreObject());
         }
         return temps;
     }

--- a/Compilation/StatementEmitterBase.cs
+++ b/Compilation/StatementEmitterBase.cs
@@ -198,6 +198,10 @@ public abstract class StatementEmitterBase : ExpressionEmitterBase
         if (IsDead(stmt))
             return;
 
+        // Spill temps never cross a statement boundary, so drop the live set here to keep
+        // the per-suspension persist/rehydrate cost proportional to one statement (#400).
+        _helpers.ClearLiveSpills();
+
         switch (stmt)
         {
             case Stmt.Expression e:

--- a/SharpTS.Tests/SharedTests/AwaitDeferredSpillTests.cs
+++ b/SharpTS.Tests/SharedTests/AwaitDeferredSpillTests.cs
@@ -1,0 +1,179 @@
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests;
+
+/// <summary>
+/// Regression tests for #400: a value spilled before an <c>await</c> and used after it
+/// must survive the suspension. Unlike <see cref="AwaitStackSpillTests"/> (which awaits a
+/// plain value that completes synchronously and so never suspends), every await here is a
+/// genuinely <em>deferred</em> promise (resolved from a later event-loop turn via
+/// <c>setTimeout</c>), so the compiled state machine actually re-enters MoveNext. Before
+/// the fix the prefix/operand spilled to an IL local was lost on re-entry, because only
+/// state-machine fields survive a MoveNext re-entry — the compiler printed the suffix only.
+/// Runs against both interpreter and compiler.
+/// </summary>
+public class AwaitDeferredSpillTests
+{
+    // A promise that settles from a later event-loop turn, forcing the awaiting state
+    // machine to actually suspend and resume (rather than complete synchronously).
+    private const string Defer =
+        "function defer(v: any, ms: number): Promise<any> { return new Promise(r => setTimeout(() => r(v), ms)); }\n";
+
+    private static string Run(string body, ExecutionMode mode)
+        => TestHarness.Run(Defer + "class C { x: any = 0; }\nasync function m() {\n" + body + "\n}\nm();\n", mode);
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void BinaryConcat_PrefixSurvivesDeferredAwait(ExecutionMode mode)
+    {
+        // The exact shape from the issue: the "concat: " prefix is pushed before the await.
+        Assert.Equal("concat: 6\n", Run("""console.log("concat: " + (await defer(6, 5)));""", mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void BinaryConcat_TwoDeferredAwaits(ExecutionMode mode)
+    {
+        Assert.Equal("L-R\n", Run("""console.log((await defer("L", 5)) + "-" + (await defer("R", 5)));""", mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void TemplateLiteral_TwoDeferredAwaits(ExecutionMode mode)
+    {
+        Assert.Equal("a1-2\n", Run("""console.log(`${"a"}${await defer(1, 5)}-${await defer(2, 5)}`);""", mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void TaggedTemplate_DeferredAwait(ExecutionMode mode)
+    {
+        Assert.Equal("p|7\n", Run(
+            """
+            const tag = (s: any, v: any) => s[0] + "|" + v;
+            console.log(tag`p${await defer(7, 5)}`);
+            """, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ConsoleLog_MultiArg_DeferredAwaitBetweenArgs(ExecutionMode mode)
+    {
+        Assert.Equal("A B C\n", Run("""console.log("A", await defer("B", 5), "C");""", mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ArrayLiteral_DeferredAwaitBetweenElements(ExecutionMode mode)
+    {
+        Assert.Equal("[x, 9, y]\n", Run("""console.log(["x", await defer(9, 5), "y"]);""", mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ObjectLiteral_DeferredAwaitAfterEarlierProperty(ExecutionMode mode)
+    {
+        Assert.Equal("""{"a":"x","b":10}""" + "\n", Run(
+            """console.log(JSON.stringify({ a: "x", b: await defer(10, 5) }));""", mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ComputedKeyObjectLiteral_DeferredAwait(ExecutionMode mode)
+    {
+        Assert.Equal("""{"dyn":12,"other":99}""" + "\n", Run(
+            """
+            const k: any = "dyn";
+            console.log(JSON.stringify({ [k]: await defer(12, 5), other: 99 }));
+            """, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void IndexSet_DeferredAwaitInIndexAndValue(ExecutionMode mode)
+    {
+        Assert.Equal("8\nZ\n", Run(
+            """
+            const arr: any = [1, 2, 3];
+            arr[0] = await defer(8, 5);
+            console.log(arr[0]);
+            arr[await defer(0, 5)] = "Z";
+            console.log(arr[0]);
+            """, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void CompoundAssign_DeferredAwaitRhs(ExecutionMode mode)
+    {
+        Assert.Equal("17\n17\n", Run(
+            """
+            const c = new C();
+            c.x = 10;
+            c.x += await defer(7, 5);
+            console.log(c.x);
+            const arr: any = [10];
+            arr[0] += await defer(7, 5);
+            console.log(arr[0]);
+            """, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void LogicalAssign_DeferredAwaitRhs(ExecutionMode mode)
+    {
+        Assert.Equal("11\n11\n", Run(
+            """
+            const c = new C();
+            c.x = null;
+            c.x ??= await defer(11, 5);
+            console.log(c.x);
+            const arr: any = [0];
+            arr[0] ||= await defer(11, 5);
+            console.log(arr[0]);
+            """, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void PropertySet_DeferredAwaitValue(ExecutionMode mode)
+    {
+        Assert.Equal("5\n", Run(
+            """
+            const o: any = {};
+            o.field = await defer(5, 5);
+            console.log(o.field);
+            """, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void DeferredThenableSpecies_PrefixSurvives(ExecutionMode mode)
+    {
+        // The original issue repro: a Promise subclass whose @@species is a general
+        // (non-Promise) thenable that settles its callback from a later turn (#349/#390).
+        var source = """
+            class Thenable {
+              v: any = undefined;
+              settled = false;
+              cb: any = undefined;
+              constructor(executor: (res: any, rej: any) => void) {
+                executor(
+                  (x: any) => { this.v = x; this.settled = true; if (this.cb) this.cb(x); },
+                  (_e: any) => {});
+              }
+              then(onF: any) { if (this.settled) onF(this.v); else this.cb = onF; }
+            }
+            class P extends Promise<number> {
+              static get [Symbol.species]() { return Thenable as any; }
+            }
+            async function main() {
+              const r: any = P.resolve(5).then((x: number) => x + 1);
+              console.log("concat: " + (await r));
+            }
+            main();
+            """;
+        Assert.Equal("concat: 6\n", TestHarness.Run(source, mode));
+    }
+}


### PR DESCRIPTION
Closes #400.

## Problem

In **compiled mode**, a value spilled to an IL local *before* an `await` was lost when the awaitable actually **suspended** (a deferred/macrotask settlement) and the state machine re-entered `MoveNext`. Only state-machine *fields* survive a `MoveNext` re-entry; IL locals are reinitialized. The classic symptom is a string-concat prefix vanishing:

```ts
async function main() {
  const t = new Promise<number>(r => setTimeout(() => r(5), 10));
  console.log("concat: " + (await t));   // interp: "concat: 5"   compiled (before): "5"
}
main();
```

The interpreter was already correct. The existing `AwaitStackSpillTests` passed *spuriously* — they `await 5`, which becomes `Task.FromResult` (`IsCompleted == true`), so the state machine never actually suspends and the spill local survives within the single `MoveNext` invocation.

## Fix

A register-spill + persist-at-await mechanism in the async state-machine emitter:

- **`StateMachineEmitHelpers`** gains `SpillStoreObject` (declares a temp and registers it as a live spill when persistence is enabled), `PersistLiveSpillsBeforeSuspend`, `RehydrateLiveSpillsAfterResume`, and `ClearLiveSpills`.
- **`SpillBoxed`** (and the converted manual-temp sites) now register their temp.
- **`AsyncMoveNextEmitter.EmitAwait`** persists every live spill to a lazily-allocated state-machine field **before `AwaitUnsafeOnCompleted` boxes the struct** (writes after the box would not reach the continuation's snapshot), and rehydrates them from those fields **only on the resumed path** (the synchronously-completed path keeps its locals untouched).
- The live set is **cleared per statement** (spill temps never cross a statement boundary), and fields are allocated **only for temps actually live at a suspension** — so await-free code and the synchronous-completion fast path pay nothing.

No per-site "does a later operand await?" analysis (which would be error-prone); coverage is by routing spills through the registering helper. Covers binary operators, template & tagged-template literals, array/object literals (incl. computed keys), index/property set, compound (`+=`) and logical (`??=`/`||=`) assignment, and multi-arg `console.log`.

## Tests

New `AwaitDeferredSpillTests` (interpreter + compiler) exercise every shape with a **genuinely deferred** promise (`setTimeout`-settled) so the compiled state machine really suspends — including the exact `@@species` deferred-thenable repro from the issue. Full suite green: **11,286 passed, 0 failed**.

## Follow-ups filed

Adjacent **pre-existing** gaps this surfaced but does not cover (confirmed present on `main`):

- #413 — `await` inside a spread/rest-param call argument emits invalid IL (`PathStackDepth`).
- #414 — async arrows / async generators emit invalid IL for cross-await spills (`StackUnexpected`); plus the `yield`-suspension equivalent (this PR persists at `await` points only).