### PR TITLE
fix(typechecker): pre-resolve forward-referenced generic local function return types (#388)

### DIFF
--- a/SharpTS.Tests/TypeCheckerTests/ForwardLocalFunctionReturnTypeTests.cs
+++ b/SharpTS.Tests/TypeCheckerTests/ForwardLocalFunctionReturnTypeTests.cs
@@ -194,6 +194,137 @@ public class ForwardLocalFunctionReturnTypeTests
         Assert.Equal("hi", TestHarness.RunInterpreted(source).Trim());
     }
 
+    // ---- Issue #388: forward-referenced GENERIC local functions ----
+    // The #383 speculative pass originally skipped generics, so a generic function's return type
+    // stayed `any` at call sites preceding its declaration and assignment checks were silently
+    // skipped. The pass now infers the generic return in terms of its type parameters and
+    // re-instantiates it at the call site.
+
+    [Fact]
+    public void ForwardGenericCall_ExplicitTypeArg_AssignedToAnnotatedVar_IsTs2322Error()
+    {
+        var source = """
+            function h() {
+                var z: number = make<string>("hi");
+                function make<T>(x: T) { return x; }
+            }
+            """;
+        var ex = Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+        Assert.Equal("TS2322", ex.Diagnostic.TsCode);
+    }
+
+    [Fact]
+    public void TopLevelForwardGenericCall_IsTs2322Error()
+    {
+        var source = """
+            var z: number = make<string>("hi");
+            function make<T>(x: T) { return x; }
+            """;
+        var ex = Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+        Assert.Equal("TS2322", ex.Diagnostic.TsCode);
+    }
+
+    [Fact]
+    public void ForwardGenericCall_InferredTypeArg_IsTs2322Error()
+    {
+        // No explicit type argument — T is inferred from the call argument, then the instantiated
+        // return type drives the assignment check.
+        var source = """
+            function h() {
+                var z: number = make("hi");
+                function make<T>(x: T) { return x; }
+            }
+            """;
+        var ex = Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+        Assert.Equal("TS2322", ex.Diagnostic.TsCode);
+    }
+
+    [Fact]
+    public void ForwardGenericCall_MultipleTypeParams_IsTs2322Error()
+    {
+        var source = """
+            function h() {
+                var z: number = pick<string, number>("a", 1);
+                function pick<A, B>(a: A, b: B) { return a; }
+            }
+            """;
+        var ex = Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+        Assert.Equal("TS2322", ex.Diagnostic.TsCode);
+    }
+
+    [Fact]
+    public void ForwardGenericCall_CompatibleType_IsNotError()
+    {
+        // The instantiated return type (string) matches the annotation — no false positive.
+        var source = """
+            function h() {
+                var z: string = make<string>("hi");
+                function make<T>(x: T) { return x; }
+            }
+            """;
+        TestHarness.RunInterpreted(source);
+    }
+
+    [Fact]
+    public void ForwardGenericCall_TypeParamUsedInBody_IsTs2322Error()
+    {
+        // The type parameter is referenced inside the body (`let y: T = x`), so the speculative
+        // body check must have T in scope; the inferred return is still expressed in terms of T.
+        var source = """
+            function h() {
+                var z: number = wrap<string>("a");
+                function wrap<T>(x: T) { let y: T = x; return y; }
+            }
+            """;
+        var ex = Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+        Assert.Equal("TS2322", ex.Diagnostic.TsCode);
+    }
+
+    [Fact]
+    public void ForwardGenericAsyncCall_ReturnsPromise_IsTs2322Error()
+    {
+        // The inferred return is wrapped in Promise<T>; instantiating with <string> yields
+        // Promise<string>, which is not assignable to number.
+        var source = """
+            function h() {
+                var z: number = make<string>("hi");
+                async function make<T>(x: T) { return x; }
+            }
+            """;
+        var ex = Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+        Assert.Equal("TS2322", ex.Diagnostic.TsCode);
+    }
+
+    [Fact]
+    public void RecursiveForwardGenericFunction_DoesNotLoop()
+    {
+        // A self-recursive generic forward function must terminate during speculative inference
+        // (it sees its own `any` placeholder mid-flight) rather than recursing infinitely.
+        var source = """
+            function h() {
+                var z = rec<number>(5);
+                function rec<T>(n: T) { return rec<T>(n); }
+                return z;
+            }
+            """;
+        TestHarness.RunInterpreted(source);
+    }
+
+    [Fact]
+    public void ForwardGenericFunctionInnerError_ReportedExactlyOnce()
+    {
+        // Speculative inference suppresses diagnostics; the real pass reports them. An error inside
+        // the generic forward function's body must surface exactly once.
+        var source = """
+            function h() {
+                var z: string = make<string>("hi");
+                function make<T>(x: T) { let bad: number = "x"; return x; }
+            }
+            """;
+        var diagnostics = CheckWithRecovery(source);
+        Assert.Equal(1, diagnostics.Count(d => d.TsCode == "TS2322"));
+    }
+
     private static IReadOnlyList<Diagnostic> CheckWithRecovery(string source)
     {
         var parseResult = new Parser(new Lexer(source).ScanTokens()).Parse();

--- a/TypeSystem/TypeChecker.Compatibility.cs
+++ b/TypeSystem/TypeChecker.Compatibility.cs
@@ -104,7 +104,14 @@ public partial class TypeChecker
         // can legitimately differ between the two contexts, so bivariant-context results must not
         // be cached or served from cache. Variance measurement likewise compares with the callback
         // rule enabled, which ordinary comparisons don't.
-        bool uncacheable = (_strictFunctionTypes && _methodBivarianceDepth > 0) || _varianceMeasurementDepth > 0;
+        //
+        // Speculative hoist-time inference (#383/#388, _suppressDiagnostics > 0) runs in recovery
+        // mode and may carry a different open-type-variable scope than the real pass — e.g. a naked
+        // type parameter that is in scope during real checking but not during speculation relates
+        // differently (naked vs its constraint). Its verdicts are therefore non-authoritative and
+        // must neither be written to nor served from the shared cache, or they poison the real pass.
+        bool uncacheable = (_strictFunctionTypes && _methodBivarianceDepth > 0)
+            || _varianceMeasurementDepth > 0 || _suppressDiagnostics > 0;
 
         // Level 1: Fast identity-based cache (reference equality)
         _identityCompatibilityCache ??= new(IdentityCacheKeyComparer.Instance);

--- a/TypeSystem/TypeChecker.Statements.Functions.cs
+++ b/TypeSystem/TypeChecker.Statements.Functions.cs
@@ -89,34 +89,66 @@ public partial class TypeChecker
     /// </summary>
     private void RefineHoistedFunctionReturnType(Stmt.Function funcStmt)
     {
-        // Only plain, implemented, non-generic, non-overloaded functions without a return
-        // annotation are eligible. Generics defer to the real pass; overload groups drive call
-        // sites from their explicit signatures, not the implementation's inferred return.
+        // Only plain, implemented, non-overloaded functions without a return annotation are
+        // eligible. Overload groups drive call sites from their explicit signatures, not the
+        // implementation's inferred return. Generic functions ARE handled here (#388): their
+        // inferred return is expressed in terms of the type parameters and re-instantiated at
+        // each call site, so a call preceding the declaration types precisely instead of `any`.
         if (funcStmt.ReturnType != null || funcStmt.Body == null) return;
-        if (funcStmt.TypeParams is { Count: > 0 }) return;
         string funcName = funcStmt.Name.Lexeme;
         if (_pendingOverloadSignatures.ContainsKey(funcName)) return;
         if (!_environment.IsDefinedLocally(funcName)) return;
-        if (_environment.Get(funcName) is not TypeInfo.Function hoisted || hoisted.ReturnType is not TypeInfo.Any)
-            return; // not our hoisted `any` placeholder (annotated, redefined, or already refined)
+
+        // Recognize our hoisted `any`-return placeholder: a non-generic function hoists as a plain
+        // Function, a generic one as a GenericFunction (carrying its type parameters). Anything else
+        // (annotated, redefined, or already refined) is left untouched.
+        List<TypeInfo> paramTypes;
+        int requiredParams;
+        bool hasRest;
+        List<string>? paramNames;
+        TypeInfo? thisType;
+        List<TypeInfo.TypeParameter>? typeParams;
+        switch (_environment.Get(funcName))
+        {
+            case TypeInfo.GenericFunction { ReturnType: TypeInfo.Any } gh:
+                paramTypes = gh.ParamTypes; requiredParams = gh.RequiredParams; hasRest = gh.HasRestParam;
+                paramNames = gh.ParamNames; thisType = gh.ThisType; typeParams = gh.TypeParams;
+                break;
+            case TypeInfo.Function { ReturnType: TypeInfo.Any } fh:
+                paramTypes = fh.ParamTypes; requiredParams = fh.RequiredParams; hasRest = fh.HasRestParam;
+                paramNames = fh.ParamNames; thisType = fh.ThisType; typeParams = null;
+                break;
+            default:
+                return;
+        }
 
         if (_hoistInferredReturnTypes.TryGetValue(funcStmt, out var cached))
         {
             // Re-register a previously inferred type into this (fresh) scope. A null value marks an
             // in-progress (mutual recursion) or failed inference — leave the placeholder in place.
             if (cached != null)
-                _environment.Define(funcName, new TypeInfo.Function(
-                    hoisted.ParamTypes, cached, hoisted.RequiredParams, hoisted.HasRestParam,
-                    hoisted.ThisType, hoisted.ParamNames));
+            {
+                _environment.Define(funcName, typeParams is { Count: > 0 }
+                    ? new TypeInfo.GenericFunction(typeParams, paramTypes, cached, requiredParams, hasRest, thisType, paramNames)
+                    : new TypeInfo.Function(paramTypes, cached, requiredParams, hasRest, thisType, paramNames));
+            }
             return;
         }
 
         // Mark in-progress before inferring so mutual recursion terminates against the placeholder.
         _hoistInferredReturnTypes[funcStmt] = null;
         var funcEnv = new TypeEnvironment(_environment);
+        // A generic function's parameter and return types reference its type parameters. Define them
+        // in the body environment (the same TypeParameter instances the hoisted signature carries) so
+        // references inside the body resolve and the inferred return is expressed in those terms.
+        if (typeParams is { Count: > 0 })
+        {
+            foreach (var tp in typeParams)
+                funcEnv.DefineTypeParameter(tp.Name, tp);
+        }
         CheckFunctionBodyAndInferReturn(
-            funcStmt, funcEnv, hoisted.ParamTypes, hoisted.RequiredParams, hoisted.HasRestParam,
-            hoisted.ParamNames ?? new List<string>(), hoisted.ThisType, typeParams: null,
+            funcStmt, funcEnv, paramTypes, requiredParams, hasRest,
+            paramNames ?? new List<string>(), thisType, typeParams,
             returnType: new TypeInfo.Inferred(), inferringReturnType: true, funcName, suppress: true);
     }
 


### PR DESCRIPTION
Closes #388.

## Problem

The #383 speculative hoist-time return-type inference pass deliberately **skipped generic functions**. As a result, a call appearing textually *before* a generic local `function`'s declaration typed its return as `any` and silently skipped assignment/return checks:

```ts
function h() {
    var z: number = make<string>("hi");   // tsc: TS2322. We: silent (before this fix).
    function make<T>(x: T) { return x; }
}
```

Non-generic forward functions, parameters, literals, and calls to already-declared functions all worked; only the generic forward-reference shape leaked.

## Fix

**`RefineHoistedFunctionReturnType`** now handles generics:
- Recognizes the `GenericFunction` `any`-return placeholder (alongside the plain `Function` one).
- Defines the function's type parameters in the speculative body environment (the same `TypeParameter` instances the hoisted signature carries) so references inside the body resolve.
- Threads the type params through `CheckFunctionBodyAndInferReturn`, whose tail already builds a `GenericFunction` with the inferred return. The inferred return is expressed in terms of the type parameters and re-instantiated at each call site (substitution is name-based, so memo re-registration is safe).

**Compatibility-cache isolation during speculation.** Surfacing generic relations through the speculative pass exposed a latent bug: the speculative pass runs in recovery mode with a potentially different *open-type-variable scope* than the real pass, so a naked type parameter can relate differently (naked vs its constraint). The structural compatibility cache is keyed only by `(expected, actual)`, so speculation wrote a non-authoritative `true` that the real pass then served — suppressing the real error. Marking `_suppressDiagnostics > 0` as `uncacheable` prevents speculation from reading or writing the shared cache. (This would have affected any forward function whose body performs structural/generic relations; primitive-only bodies never tripped it.)

## Tests

9 new cases in `ForwardLocalFunctionReturnTypeTests` (explicit & inferred type args, multiple type params, type-param-used-in-body, async→`Promise<T>`, recursion termination, exactly-once inner-error reporting, no-false-positive). 

- Full suite: **11279 pass** (was failing `GenericInterfaceIndexerTests.OpenInstantiationIndexer_AsTarget_RejectsConcreteValues` before the cache-isolation fix — now green).
- TS conformance: **31 pass**, baseline unchanged.