### PR TITLE
fix(compiler): make exported async/generator functions callable across modules (#395)

### DIFF
--- a/Compilation/ILEmitter.Modules.cs
+++ b/Compilation/ILEmitter.Modules.cs
@@ -416,10 +416,10 @@ public partial class ILEmitter
                         IL.Emit(OpCodes.Ldsfld, staticField);
                         IL.Emit(OpCodes.Stsfld, defaultField);
                     }
-                    else if (_ctx.Functions.TryGetValue(_ctx.GetQualifiedFunctionName(name), out var funcBuilder))
+                    else if (TryResolveExportableFunction(name, out var funcBuilder))
                     {
-                        // Create TSFunction for function
-                        EmitFunctionReference(_ctx.GetQualifiedFunctionName(name), funcBuilder);
+                        // Create TSFunction for function (sync, async, generator, or async generator)
+                        EmitFunctionReference(name, funcBuilder);
                         IL.Emit(OpCodes.Stsfld, defaultField);
                     }
                     else if (_ctx.Classes.TryGetValue(_ctx.GetQualifiedClassName(name), out var classBuilder))
@@ -467,9 +467,9 @@ public partial class ILEmitter
                     IL.Emit(OpCodes.Ldsfld, staticField);
                     IL.Emit(OpCodes.Stsfld, field);
                 }
-                else if (_ctx.Functions.TryGetValue(_ctx.GetQualifiedFunctionName(name), out var funcBuilder))
+                else if (TryResolveExportableFunction(name, out var funcBuilder))
                 {
-                    EmitFunctionReference(_ctx.GetQualifiedFunctionName(name), funcBuilder);
+                    EmitFunctionReference(name, funcBuilder);
                     IL.Emit(OpCodes.Stsfld, field);
                 }
                 else if (_ctx.Classes.TryGetValue(_ctx.GetQualifiedClassName(name), out var classBuilder))
@@ -507,9 +507,9 @@ public partial class ILEmitter
                         IL.Emit(OpCodes.Ldsfld, staticField);
                         IL.Emit(OpCodes.Stsfld, field);
                     }
-                    else if (_ctx.Functions.TryGetValue(_ctx.GetQualifiedFunctionName(localName), out var funcBuilder))
+                    else if (TryResolveExportableFunction(localName, out var funcBuilder))
                     {
-                        EmitFunctionReference(_ctx.GetQualifiedFunctionName(localName), funcBuilder);
+                        EmitFunctionReference(localName, funcBuilder);
                         IL.Emit(OpCodes.Stsfld, field);
                     }
                     else if (_ctx.Classes.TryGetValue(_ctx.GetQualifiedClassName(localName), out var classBuilder))
@@ -571,6 +571,29 @@ public partial class ILEmitter
                 }
             }
         }
+    }
+
+    /// <summary>
+    /// Resolves a top-level function name to its emitted stub <see cref="MethodBuilder"/>,
+    /// covering every function flavor that registers into <see cref="CompilationContext.Functions"/>.
+    /// Sync functions are keyed by their module-qualified name, whereas async / generator /
+    /// async-generator functions register their stub under the simple name (see
+    /// <c>ILCompiler.Async</c> / <c>ILCompiler.Generators</c> / <c>ILCompiler.AsyncGenerators</c>,
+    /// which write <c>_functions.Builders[funcStmt.Name.Lexeme]</c> without module qualification).
+    /// The export-store branches must consult both keys; otherwise an <c>export async function</c>,
+    /// <c>export function*</c>, or <c>export async function*</c> leaves its export field null and the
+    /// importing module throws "object is not a function" on call (#395).
+    /// </summary>
+    private bool TryResolveExportableFunction(string name, out MethodBuilder method)
+    {
+        // Sync functions: module-qualified key.
+        if (_ctx.Functions.TryGetValue(_ctx.GetQualifiedFunctionName(name), out method!))
+            return true;
+        // Async / generator / async-generator stubs: simple (unqualified) key.
+        if (_ctx.Functions.TryGetValue(name, out method!))
+            return true;
+        method = null!;
+        return false;
     }
 
     /// <summary>

--- a/Parsing/Parser.Modules.cs
+++ b/Parsing/Parser.Modules.cs
@@ -223,14 +223,27 @@ public partial class Parser
             Expr? defaultExpr = null;
             Stmt? declaration = null;
 
-            // export default class Name { } or export default function name() { }
+            // export default class Name { }
+            // export default function name() { } / function* name() { }
+            // export default async function name() { } / async function* name() { }
             if (Match(TokenType.CLASS))
             {
                 declaration = ClassDeclaration(isAbstract: false);
             }
+            else if (Check(TokenType.ASYNC) && PeekNext().Type == TokenType.FUNCTION)
+            {
+                // `export default async function ...` — only claim ASYNC here when a
+                // `function` follows, so `export default async () => {}` still parses
+                // as a default async-arrow expression below.
+                Advance(); // consume 'async'
+                Advance(); // consume 'function'
+                bool isGenerator = Match(TokenType.STAR);
+                declaration = FunctionDeclaration("function", isAsync: true, isGenerator: isGenerator);
+            }
             else if (Match(TokenType.FUNCTION))
             {
-                declaration = FunctionDeclaration("function");
+                bool isGenerator = Match(TokenType.STAR);
+                declaration = FunctionDeclaration("function", isAsync: false, isGenerator: isGenerator);
             }
             else
             {

--- a/SharpTS.Tests/SharedTests/ModuleTests.cs
+++ b/SharpTS.Tests/SharedTests/ModuleTests.cs
@@ -74,9 +74,11 @@ public class ModuleTests
     }
 
     // These three guard the #392 parser fix (`export async function`,
-    // `export function*`, `export async function*`). They run InterpretedOnly:
-    // the parser fix is mode-independent, and compiled execution of exported
-    // state-machine functions is a separate gap tracked in #395.
+    // `export function*`, `export async function*`) in single-file form. They run
+    // InterpretedOnly: the parser fix is mode-independent, and single-file *script-mode*
+    // compilation does not bind exported function declarations at all (a broader gap that
+    // also affects plain sync functions, tracked in #417). Compiled cross-module execution of
+    // these exports is fixed by #395 — see the *_CrossModule tests below, which run in both modes.
     [Theory]
     [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
     public void ExportAsyncFunction_Parses(ExecutionMode mode)
@@ -127,6 +129,195 @@ public class ModuleTests
             """;
 
         Assert.Equal("1\n2\n", TestHarness.Run(source, mode));
+    }
+
+    // ---- #395: exported async / generator / async-generator functions callable across modules ----
+    // The three #392 tests above stay InterpretedOnly because they compile a single file in
+    // script (non-module) mode, where exported function declarations are still not bound
+    // (a separate, broader gap that also affects plain sync functions — see #417). These tests
+    // use the real cross-module path (RunModules), which
+    // is how the CLI compiles any file containing `export`. Before #395 the compiled export-store
+    // only consulted `_ctx.Functions` under the module-qualified name, missing async/generator
+    // stubs (keyed by simple name) — the import field stayed null and the call threw
+    // "object is not a function". They run in BOTH modes to pin the fix and guard the interpreter.
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void NamedExport_AsyncFunction_CrossModule(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["./utils.ts"] = """
+                export async function addAsync(a: number, b: number): Promise<number> {
+                    return a + b;
+                }
+                """,
+            ["./main.ts"] = """
+                import { addAsync } from './utils';
+                async function main() { console.log(await addAsync(3, 4)); }
+                main();
+                """
+        };
+
+        Assert.Equal("7\n", TestHarness.RunModules(files, "./main.ts", mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void NamedExport_GeneratorFunction_CrossModule(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["./utils.ts"] = """
+                export function* genCount(): Generator<number> {
+                    yield 1;
+                    yield 2;
+                    yield 3;
+                }
+                """,
+            ["./main.ts"] = """
+                import { genCount } from './utils';
+                for (const n of genCount()) console.log(n);
+                """
+        };
+
+        Assert.Equal("1\n2\n3\n", TestHarness.RunModules(files, "./main.ts", mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void NamedExport_AsyncGeneratorFunction_CrossModule(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["./utils.ts"] = """
+                export async function* genAsync(): AsyncGenerator<number> {
+                    yield 10;
+                    yield 20;
+                }
+                """,
+            ["./main.ts"] = """
+                import { genAsync } from './utils';
+                async function main() {
+                    for await (const n of genAsync()) console.log(n);
+                }
+                main();
+                """
+        };
+
+        Assert.Equal("10\n20\n", TestHarness.RunModules(files, "./main.ts", mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void NamedListExport_StateMachineFunctions_CrossModule(ExecutionMode mode)
+    {
+        // The `export { a, b, c }` list form is a distinct export-store branch from the
+        // inline `export async function ...` declaration form; cover it too.
+        var files = new Dictionary<string, string>
+        {
+            ["./utils.ts"] = """
+                async function addAsync(a: number, b: number): Promise<number> { return a + b; }
+                function* counter(): Generator<number> { yield 7; yield 8; }
+                async function* ag(): AsyncGenerator<number> { yield 99; }
+                export { addAsync, counter, ag };
+                """,
+            ["./main.ts"] = """
+                import { addAsync, counter, ag } from './utils';
+                async function main() {
+                    console.log(await addAsync(10, 5));
+                    for (const n of counter()) console.log(n);
+                    for await (const n of ag()) console.log(n);
+                }
+                main();
+                """
+        };
+
+        Assert.Equal("15\n7\n8\n99\n", TestHarness.RunModules(files, "./main.ts", mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void DefaultExport_AsyncFunction_CrossModule(ExecutionMode mode)
+    {
+        // `export default async function` / `export default function*` additionally required a
+        // parser fix: the `export default` dispatcher (unlike the non-default one fixed in #392)
+        // did not recognize `async`/`*`. With that in place the compiled $default export-store
+        // branch resolves the state-machine stub the same way as named exports.
+        var files = new Dictionary<string, string>
+        {
+            ["./util.ts"] = """
+                export default async function dbl(n: number): Promise<number> { return n * 2; }
+                """,
+            ["./main.ts"] = """
+                import dbl from './util';
+                async function main() { console.log(await dbl(21)); }
+                main();
+                """
+        };
+
+        Assert.Equal("42\n", TestHarness.RunModules(files, "./main.ts", mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void DefaultExport_GeneratorFunction_CrossModule(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["./util.ts"] = """
+                export default function* gen(): Generator<number> { yield 5; yield 6; }
+                """,
+            ["./main.ts"] = """
+                import gen from './util';
+                for (const n of gen()) console.log(n);
+                """
+        };
+
+        Assert.Equal("5\n6\n", TestHarness.RunModules(files, "./main.ts", mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void DefaultExport_AsyncGeneratorFunction_CrossModule(ExecutionMode mode)
+    {
+        // Guards the `async`+`*` combination in the `export default` parser branch.
+        var files = new Dictionary<string, string>
+        {
+            ["./util.ts"] = """
+                export default async function* ag(): AsyncGenerator<number> { yield 1; yield 2; }
+                """,
+            ["./main.ts"] = """
+                import ag from './util';
+                async function main() { for await (const n of ag()) console.log(n); }
+                main();
+                """
+        };
+
+        Assert.Equal("1\n2\n", TestHarness.RunModules(files, "./main.ts", mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void DefaultExport_AsyncArrow_StillParsesAsExpression(ExecutionMode mode)
+    {
+        // Guard: the `export default async function` parser branch must NOT swallow
+        // `export default async () => {}` — that's a default async-arrow *expression*,
+        // not a function declaration. The dispatcher uses a two-token lookahead
+        // (ASYNC followed by FUNCTION) so this keeps parsing via the expression path.
+        var files = new Dictionary<string, string>
+        {
+            ["./util.ts"] = """
+                export default async (n: number): Promise<number> => n + 1;
+                """,
+            ["./main.ts"] = """
+                import inc from './util';
+                async function main() { console.log(await inc(41)); }
+                main();
+                """
+        };
+
+        Assert.Equal("42\n", TestHarness.RunModules(files, "./main.ts", mode));
     }
 
     [Theory]


### PR DESCRIPTION
## Summary

Fixes #395 — compiled **exported async / generator / async-generator function declarations** were not callable across modules (the importing module threw `TypeError: object is not a function`). A plain sync `export function` worked; the state-machine flavors didn't.

### Root cause
The compiled export-store branches in `Compilation/ILEmitter.Modules.cs` resolved a named export's function value with `_ctx.Functions[GetQualifiedFunctionName(name)]`. Sync functions register under that **module-qualified** key (`$M_<mod>_<name>`), but async / generator / async-generator stubs register their `MethodBuilder` in the **same** `_functions.Builders` table under the **simple (unqualified)** name (see `ILCompiler.Async` / `ILCompiler.Generators` / `ILCompiler.AsyncGenerators`). So the lookup missed, the export field was left `null`, and the import-side call failed. (The bare value-reference path already worked because it uses `ResolveFunctionName`, which returns the simple name for these flavors.)

## Changes

- **`Compilation/ILEmitter.Modules.cs`** — new `TryResolveExportableFunction(name, out MethodBuilder)` helper that tries the module-qualified key, then the simple key. Applied to all three export-store branches: `$default`, named-declaration (`export async function f`), and named-list (`export { f }`). Forward-compatible — when #418 module-qualifies async/gen registration, the qualified lookup wins and the simple fallback becomes a no-op (no helper change needed).
- **`Parsing/Parser.Modules.cs`** — completed the `export default` dispatcher so `export default async function` / `export default function*` / `export default async function*` parse. The non-default dispatcher gained this in #392; the default one didn't. A two-token lookahead (`ASYNC` followed by `FUNCTION`) ensures `export default async () => {}` still parses as a default async-arrow **expression** (no regression). This makes the `$default` export-store branch reachable and tested rather than dead.
- **`SharpTS.Tests/SharedTests/ModuleTests.cs`** — 8 new cross-module tests (run in **both** interpreted and compiled modes via `RunModules`) covering named, default, and named-list exports of all three state-machine flavors, plus an async-arrow-default guard. The three #392 `*_Parses` tests stay `InterpretedOnly` and their comments now point at #417.

## Verification

- Cross-module repros (named / `export default` / `export { }` list) produce correct output in compiled mode and match the interpreter; `--compile … --verify` passes IL verification.
- **Full suite: 11284 passed, 0 failed.** Corrected-parser `ModuleTests`: **1312 passed, 0 failed.**

## Related issues filed during this work

- **#417** — single-file *script-mode* compilation never binds **any** exported function declaration (affects plain sync too); the single-file `Phase4_DefineDeclarations` / `Phase7_EmitMethodBodies` don't unwrap `Stmt.Export` the way the module phases do. No real-world impact — the CLI compiles any file with `import`/`export` as a module.
- **#418** — same-named async/generator functions in *different* modules collide because their registry keys are unqualified (the second definition clobbers the first → compile-time crash). Sync functions are module-qualified and unaffected.

Closes #395
