### PR TITLE
fix(compile): keep event loop alive during in-flight net.connect (#419)

### DIFF
--- a/Compilation/RuntimeEmitter.TSNetClosures.cs
+++ b/Compilation/RuntimeEmitter.TSNetClosures.cs
@@ -549,6 +549,13 @@ public partial class RuntimeEmitter
             il.Emit(OpCodes.Callvirt, runtime.NetSocketStartReading);
 
             il.MarkLabel(done);
+
+            // Release the in-flight-connect Ref taken in $TSNetSocket.Connect, after
+            // the 'connect' event has been delivered (and reading started), so the
+            // handle outlives delivery. Mirrors SharpTSSocket's interpreter.Unref().
+            il.Emit(OpCodes.Call, runtime.EventLoopGetInstance);
+            il.Emit(OpCodes.Call, runtime.EventLoopUnref);
+
             il.Emit(OpCodes.Ret);
         }
 
@@ -641,6 +648,12 @@ public partial class RuntimeEmitter
             il.Emit(OpCodes.Stelem_Ref);
             il.Emit(OpCodes.Callvirt, runtime.TSEventEmitterEmit);
             il.Emit(OpCodes.Pop);
+
+            // Release the in-flight-connect Ref taken in $TSNetSocket.Connect, after
+            // the 'error' event has been delivered. Mirrors SharpTSSocket's
+            // interpreter.Unref() on the failure path.
+            il.Emit(OpCodes.Call, runtime.EventLoopGetInstance);
+            il.Emit(OpCodes.Call, runtime.EventLoopUnref);
 
             il.Emit(OpCodes.Ret);
         }

--- a/Compilation/RuntimeEmitter.TSNetSocket.cs
+++ b/Compilation/RuntimeEmitter.TSNetSocket.cs
@@ -413,6 +413,19 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldc_I4_1);
         il.Emit(OpCodes.Stfld, _netSocketConnectingField);
 
+        // An in-flight connect is an active handle (Node semantics): keep the event
+        // loop alive until the connect resolves, otherwise its 'connect'/'error'
+        // continuation can be dropped if the loop's other handles (e.g. the peer
+        // server) drain to zero before the thread-pool connect worker schedules its
+        // closure. Mirrors SharpTSSocket.Connect's interpreter.Ref()/Unref() pair —
+        // the emitted socket previously omitted it, leaving net.connect flaky under
+        // load (the connect closure could miss the $EventLoop quiescence window).
+        // Released exactly once inside the scheduled OK/ERR closure so the handle
+        // outlives delivery. One Ref here balances exactly one closure (TCP and IPC
+        // workers each schedule exactly one of OK/ERR).
+        il.Emit(OpCodes.Call, runtime.EventLoopGetInstance);
+        il.Emit(OpCodes.Call, runtime.EventLoopRef);
+
         // ── Branch: IPC vs TCP ──
         var ipcConnect = il.DefineLabel();
         var connectDone = il.DefineLabel();


### PR DESCRIPTION
Closes #419.

## Problem
`NetModuleTests.NetConnectPositionalPortHostCallback(mode: Compiled)` flakes in CI under load (it caused the spurious failure on PR #408): the socket's `'connect'` event is sometimes never delivered. Compiled-only; the interpreted variant always passes.

## Root cause
The interpreter `SharpTSSocket.Connect` treats an in-flight connect as an active handle — `interpreter.Ref()` before the async connect, `interpreter.Unref()` inside the scheduled `'connect'`/`'error'` callback — with a comment describing exactly this hazard (“its connect/error continuation can be dropped if the loop's other handles drain to zero first”). The emitted compiled `$TSNetSocket`, which is meant to mirror `SharpTSSocket`, queued its `_ConnectWorker` on the thread pool and returned **without ever `$EventLoop.Ref()`-ing**. So between `connect()` returning and the worker calling `$EventLoop.Schedule(closure)`, the loop has no handle for the in-flight connect; if the peer server drains first (the test does `socket.destroy(); server.close()` on accept), a quiescence check can win the race under load and the event is dropped.

## Fix
Mirror the interpreter in the emitted socket:
- `$TSNetSocket.Connect`: `$EventLoop.GetInstance().Ref()` after `_connecting = true` (covers TCP + IPC paths).
- `$SocketConnectOkClosure.Run` / `$SocketConnectErrClosure.Run`: `$EventLoop.GetInstance().Unref()` after the event is delivered. Each connect worker schedules exactly one of OK/ERR, so one Ref balances one Unref.

Uses the same `EventLoopGetInstance`+`EventLoopRef` pattern already used by `StartReading`. Same native-I/O liveness class as #319/#320/#324/#329/#354.

## Validation
- All 48 `NetModuleTests` pass (both modes).
- Empirically confirmed the in-flight connect now keeps the loop alive; the interpreter path (the proven reference implementation) does exactly this.

## Out of scope / follow-up
While investigating I found a **separate, pre-existing** hang: many concurrent connect+`destroy()` sockets leak a read-lifetime event-loop handle so the process never exits (reproduces with **and** without this fix). Filed as **#421**; not addressed here to keep this fix minimal.