### PR TITLE
Fix #417: bind exported declarations in single-file (script) compilation

### DIFF
--- a/Compilation/ILCompiler.cs
+++ b/Compilation/ILCompiler.cs
@@ -602,26 +602,13 @@ public partial class ILCompiler
     /// </summary>
     private void Phase4_DefineDeclarations(List<Stmt> statements)
     {
-        // Define all declarations
+        // Define all declarations. Delegates to the shared per-statement helper so
+        // single-file (script) mode unwraps `export`-wrapped declarations exactly like
+        // the module path does — without it, `export function f() {}` never defines its
+        // MethodBuilder and call sites can't resolve `f` (issue #417).
         foreach (var stmt in statements)
         {
-            if (stmt is Stmt.Class classStmt)
-            {
-                DefineClass(classStmt);
-            }
-            else if (stmt is Stmt.Function funcStmt)
-            {
-                if (funcStmt.Body == null) continue; // Skip overload signatures
-                DefineFunction(funcStmt);
-            }
-            else if (stmt is Stmt.Enum enumStmt)
-            {
-                DefineEnum(enumStmt);
-            }
-            else if (stmt is Stmt.Namespace nsStmt)
-            {
-                DefineNamespaceFields(nsStmt);
-            }
+            DefineDeclarationFromStatement(stmt);
         }
 
         // Define static fields for top-level variables captured by async functions
@@ -675,22 +662,13 @@ public partial class ILCompiler
     /// </summary>
     private void Phase7_EmitMethodBodies(List<Stmt> statements)
     {
+        // Delegates to the shared per-statement helper so single-file (script) mode
+        // unwraps `export`-wrapped declarations like the module path does — otherwise an
+        // exported function's body is never emitted and its call site can't resolve the
+        // name (issue #417).
         foreach (var stmt in statements)
         {
-            if (stmt is Stmt.Class classStmt)
-            {
-                EmitClassMethods(classStmt);
-            }
-            else if (stmt is Stmt.Function funcStmt)
-            {
-                if (funcStmt.Body == null) continue; // Skip overload signatures
-                EmitFunctionBody(funcStmt);
-                EmitFunctionOverloads(funcStmt);
-            }
-            else if (stmt is Stmt.Namespace nsStmt)
-            {
-                EmitNamespaceMemberBodies(nsStmt);
-            }
+            EmitMethodBodyFromStatement(stmt);
         }
 
         EmitClassExpressionBodies();
@@ -1094,6 +1072,12 @@ public partial class ILCompiler
             case Stmt.Function funcStmt when funcStmt.Body != null:
                 EmitFunctionBody(funcStmt);
                 EmitFunctionOverloads(funcStmt);
+                break;
+            case Stmt.Namespace nsStmt:
+                // Mirrors the Stmt.Namespace arm in DefineDeclarationFromStatement so the
+                // define/emit helpers stay symmetric. EmitNamespaceMemberBodies internally
+                // unwraps exported members, so an `export namespace` reaches its members.
+                EmitNamespaceMemberBodies(nsStmt);
                 break;
             case Stmt.Export { Declaration: not null } export:
                 EmitMethodBodyFromStatement(export.Declaration);

--- a/SharpTS.Tests/SharedTests/ModuleTests.cs
+++ b/SharpTS.Tests/SharedTests/ModuleTests.cs
@@ -74,13 +74,15 @@ public class ModuleTests
     }
 
     // These three guard the #392 parser fix (`export async function`,
-    // `export function*`, `export async function*`) in single-file form. They run
-    // InterpretedOnly: the parser fix is mode-independent, and single-file *script-mode*
-    // compilation does not bind exported function declarations at all (a broader gap that
-    // also affects plain sync functions, tracked in #417). Compiled cross-module execution of
-    // these exports is fixed by #395 — see the *_CrossModule tests below, which run in both modes.
+    // `export function*`, `export async function*`) in single-file form. Since #417 they
+    // run in BOTH modes: single-file *script-mode* compilation now unwraps `export`-wrapped
+    // declarations (Phase4/Phase7 delegate to the shared define/emit helpers), so an exported
+    // function is bound and callable just like in the interpreter. The plain-sync single-file
+    // case — the broader gap #417 also fixed — is covered by ExportSyncFunction_SingleFile below.
+    // Compiled cross-module execution of these exports is additionally covered by the
+    // *_CrossModule tests further down (#395).
     [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void ExportAsyncFunction_Parses(ExecutionMode mode)
     {
         // Regression: `export async function` previously failed to parse
@@ -97,7 +99,7 @@ public class ModuleTests
     }
 
     [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void ExportGeneratorFunction_Parses(ExecutionMode mode)
     {
         // Regression: `export function*` previously failed to parse ("Expect
@@ -114,7 +116,7 @@ public class ModuleTests
     }
 
     [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void ExportAsyncGeneratorFunction_Parses(ExecutionMode mode)
     {
         // Regression: `export async function*` shares the same export dispatcher
@@ -131,15 +133,31 @@ public class ModuleTests
         Assert.Equal("1\n2\n", TestHarness.Run(source, mode));
     }
 
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ExportSyncFunction_SingleFile(ExecutionMode mode)
+    {
+        // Regression for #417: a plain `export function` in a single-file (script-mode)
+        // *compilation* was never bound — Phase4/Phase7 didn't unwrap Stmt.Export — so the
+        // call site threw "ReferenceError: Undefined variable 'f'". This is the broader gap
+        // that #417 fixed beyond the async/generator cases above. The interpreter always
+        // handled it; this pins the compiled single-file path too.
+        var source = """
+            export function f(): number { return 5; }
+            console.log(f());
+            """;
+
+        Assert.Equal("5\n", TestHarness.Run(source, mode));
+    }
+
     // ---- #395: exported async / generator / async-generator functions callable across modules ----
-    // The three #392 tests above stay InterpretedOnly because they compile a single file in
-    // script (non-module) mode, where exported function declarations are still not bound
-    // (a separate, broader gap that also affects plain sync functions — see #417). These tests
-    // use the real cross-module path (RunModules), which
-    // is how the CLI compiles any file containing `export`. Before #395 the compiled export-store
-    // only consulted `_ctx.Functions` under the module-qualified name, missing async/generator
-    // stubs (keyed by simple name) — the import field stayed null and the call threw
-    // "object is not a function". They run in BOTH modes to pin the fix and guard the interpreter.
+    // The single-file tests above exercise script (non-module) mode via TestHarness.Run; since
+    // #417 they run in both modes (the compiled script path now binds exported declarations).
+    // The tests below instead use the real cross-module path (RunModules), which is how the CLI
+    // compiles any file containing `export`. Before #395 the compiled export-store only consulted
+    // `_ctx.Functions` under the module-qualified name, missing async/generator stubs (keyed by
+    // simple name) — the import field stayed null and the call threw "object is not a function".
+    // They run in BOTH modes to pin the fix and guard the interpreter.
 
     [Theory]
     [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]


### PR DESCRIPTION
Closes #417.

## Problem

In **single-file, non-module ("script") compilation** — the path `ILCompiler.Compile(...)` that `TestHarness.RunCompiled` / `RunCompiledInProcess` uses — an `export`-wrapped declaration was never bound, so calling it threw:

| Source (compiled, script mode) | Before |
|---|---|
| `export function f(): number { return 5; }` + `f()` | `ReferenceError: Undefined variable 'f'` |
| `export async function f(): Promise<number> {…}` + `await f()` | `TypeError: object is not a function` |
| `export function* g(): Generator<number> {…}` + `for…of g()` | `ReferenceError: Undefined variable 'g'` |
| `export class C {…}` + `new C()` | (also failed) |

The interpreter and **multi-module** compiled mode (post-#395) already handled all of these. The CLI routes any file with `import`/`export` through `CompileModules`, so this only affected the in-process single-file test harness — which is why the three `export async/gen` regression tests were pinned `InterpretedOnly`.

## Root cause

The single-file phases `Phase4_DefineDeclarations` / `Phase7_EmitMethodBodies` had an inline `if/else` over `Stmt.Class`/`Function`/`Enum`/`Namespace` but did **not** unwrap `Stmt.Export { Declaration }`. The module phases already do, via `DefineDeclarationFromStatement` / `EmitMethodBodyFromStatement`.

## Fix

Delegate both single-file phases to the shared `*FromStatement` helpers instead of duplicating the dispatch. This removes the duplicated switch and fixes sync / async / generator / async-generator functions **and** classes uniformly (`DefineFunction` / `EmitFunctionBody` already dispatch to the state-machine variants internally).

`EmitMethodBodyFromStatement` was missing the `Stmt.Namespace` arm that `DefineDeclarationFromStatement` already had (so the two helpers are now symmetric, and Phase7's prior `EmitNamespaceMemberBodies` behavior is preserved). `EmitNamespaceMemberBodies` had a single call site (script-mode Phase7), so module mode never emitted namespace member bodies before — it now does so consistently, with no double-emission (it remains the sole emitter).

`EmitExport`'s entry-point early-return in script mode stays correct: functions/classes bind by name through the registries and need no entry-point store.

## Tests

- Flipped `ExportAsyncFunction_Parses`, `ExportGeneratorFunction_Parses`, `ExportAsyncGeneratorFunction_Parses` from `InterpretedOnly` → `All`.
- Added `ExportSyncFunction_SingleFile` (the plain-sync case, the broader gap #417 called out).
- Updated the now-stale comments that explained why those tests were interpreted-only.
- **Full suite: 11,335 passed, 0 failed.**

## Follow-up filed

Exported **variable** declarations (`export const/let/var`) in script-mode compilation remain a separate gap (entry-point `EmitExport` no-ops in script mode; the var-field passes don't unwrap `Stmt.Export`). Filed as #424. No real-world impact — same module-routing caveat as #417.