### PR TITLE
Fix #418: module-qualify async/generator stub registries (cross-module same-name collision)

### DIFF
--- a/Compilation/ILCompiler.Async.cs
+++ b/Compilation/ILCompiler.Async.cs
@@ -15,6 +15,13 @@ public partial class ILCompiler
         // Analyze the async function for await points and hoisted variables
         var analysis = _async.Analyzer.Analyze(funcStmt);
 
+        // Module-qualify the stub/registry keys (#418) so two modules that each declare a
+        // same-named async function don't clobber each other. Single-file compilation returns
+        // the simple name unchanged. The readable state-machine type name stays the simple name
+        // (the builder's counter already disambiguates `<name>d__N`).
+        var ctx = GetDefinitionContext();
+        string qualifiedFunctionName = ctx.GetQualifiedFunctionName(funcStmt.Name.Lexeme);
+
         // Create state machine builder
         var smBuilder = new AsyncStateMachineBuilder(_moduleBuilder, _types, _async.StateMachineCounter++);
         var hasAsyncArrows = analysis.AsyncArrows.Count > 0;
@@ -23,22 +30,20 @@ public partial class ILCompiler
         // Define stub method (returns Task<object>)
         var paramTypes = funcStmt.Parameters.Select(_ => _types.Object).ToArray();
         var stubMethod = _programType.DefineMethod(
-            funcStmt.Name.Lexeme,
+            qualifiedFunctionName,
             MethodAttributes.Public | MethodAttributes.Static,
             _types.TaskOfObject,
             paramTypes
         );
 
         // Store for later body emission
-        _functions.Builders[funcStmt.Name.Lexeme] = stubMethod;
-        _async.StateMachines[funcStmt.Name.Lexeme] = smBuilder;
-        _async.Functions[funcStmt.Name.Lexeme] = funcStmt;
+        _functions.Builders[qualifiedFunctionName] = stubMethod;
+        _async.StateMachines[qualifiedFunctionName] = smBuilder;
+        _async.Functions[qualifiedFunctionName] = funcStmt;
 
         // Create function-level display class for captured locals (same as sync functions).
         // This enables closure mutation sharing between the async state machine and sync inner arrows.
         // Variables also captured by async arrows are excluded since they use the hoisted field mechanism.
-        var ctx = GetDefinitionContext();
-        string qualifiedFunctionName = ctx.GetQualifiedFunctionName(funcStmt.Name.Lexeme);
         _closures.FunctionAstNodes[qualifiedFunctionName] = funcStmt;
 
         // Collect variables captured by async arrows (these can't use the function DC)
@@ -524,8 +529,11 @@ public partial class ILCompiler
                 ArrowFunctionDCFields = _closures.ArrowFunctionDCFields.Count > 0 ? _closures.ArrowFunctionDCFields : null,
             };
 
-            // Set function DC info if this async function has captured locals
-            var qualifiedName = GetDefinitionContext().GetQualifiedFunctionName(funcName);
+            // Set function DC info if this async function has captured locals.
+            // funcName is already the module-qualified registry key (#418) — and the
+            // closure registries are keyed by that same qualified name — so use it
+            // directly rather than re-qualifying (which would double-prefix).
+            var qualifiedName = funcName;
             if (_closures.FunctionDisplayClassFields.TryGetValue(qualifiedName, out var funcDCFields))
             {
                 ctx.FunctionDisplayClassFields = funcDCFields;
@@ -720,11 +728,13 @@ public partial class ILCompiler
             }
         }
 
-        // Initialize function display class for closure mutation sharing
+        // Initialize function display class for closure mutation sharing.
+        // FunctionDCField is only set for top-level async functions, whose stub method
+        // name is already the module-qualified registry/closure key (#418) — use it
+        // directly rather than re-qualifying.
         if (smBuilder.FunctionDCField != null)
         {
-            var funcName = stubMethod.Name;
-            var qualifiedName = GetDefinitionContext().GetQualifiedFunctionName(funcName);
+            var qualifiedName = stubMethod.Name;
             if (_closures.FunctionDisplayClassCtors.TryGetValue(qualifiedName, out var dcCtor))
             {
                 il.Emit(OpCodes.Ldloca, smLocal);

--- a/Compilation/ILCompiler.AsyncGenerators.cs
+++ b/Compilation/ILCompiler.AsyncGenerators.cs
@@ -17,6 +17,12 @@ public partial class ILCompiler
     {
         string funcName = funcStmt.Name.Lexeme;
 
+        // Module-qualify the stub/registry keys (#418) so two modules that each declare a
+        // same-named async-generator function don't clobber each other. Single-file
+        // compilation returns the simple name unchanged. The readable state-machine type name
+        // keeps the simple name (the builder's counter already disambiguates `<name>d__N`).
+        string qualifiedName = GetDefinitionContext().GetQualifiedFunctionName(funcName);
+
         // Analyze the async generator function for yield/await points and hoisted variables
         var analysis = _asyncGenerators.Analyzer.Analyze(funcStmt);
 
@@ -24,27 +30,28 @@ public partial class ILCompiler
         var smBuilder = new AsyncGeneratorStateMachineBuilder(_moduleBuilder, _types, _asyncGenerators.StateMachineCounter++);
         smBuilder.DefineStateMachine(funcName, analysis, isInstanceMethod: false, runtime: _runtime);
 
-        _asyncGenerators.StateMachines[funcName] = smBuilder;
-        _asyncGenerators.Functions[funcName] = funcStmt;
+        _asyncGenerators.StateMachines[qualifiedName] = smBuilder;
+        _asyncGenerators.Functions[qualifiedName] = funcStmt;
 
         // Define the stub method that creates and returns the state machine
         var paramTypes = funcStmt.Parameters.Select(_ => _types.Object).ToArray();
         var methodBuilder = _programType.DefineMethod(
-            funcName,
+            qualifiedName,
             MethodAttributes.Public | MethodAttributes.Static,
             _types.IAsyncEnumerableOfObject,  // Async generator returns IAsyncEnumerable<object>
             paramTypes
         );
 
-        _functions.Builders[funcName] = methodBuilder;
+        _functions.Builders[qualifiedName] = methodBuilder;
 
-        // Track rest parameter info
+        // Track rest parameter info (keyed by the qualified name so ResolveFunctionName-based
+        // call-site lookups in ExpressionEmitterBase find it).
         var restParam = funcStmt.Parameters.FirstOrDefault(p => p.IsRest);
         if (restParam != null)
         {
             int restIndex = funcStmt.Parameters.IndexOf(restParam);
             int regularCount = funcStmt.Parameters.Count(p => !p.IsRest);
-            _functions.RestParams[funcName] = (restIndex, regularCount);
+            _functions.RestParams[qualifiedName] = (restIndex, regularCount);
         }
     }
 

--- a/Compilation/ILCompiler.Functions.cs
+++ b/Compilation/ILCompiler.Functions.cs
@@ -18,9 +18,7 @@ public partial class ILCompiler
         // Must check this FIRST since it has both IsAsync and IsGenerator true
         if (funcStmt.IsAsync && funcStmt.IsGenerator)
         {
-            // Record mapping for Phase-7 state-machine emission (see _functionDefinitionModule).
-            if (_modules.CurrentPath != null)
-                _functionDefinitionModule[funcStmt.Name.Lexeme] = _modules.CurrentPath;
+            RegisterStateMachineFunctionModule(funcStmt);
             DefineAsyncGeneratorFunction(funcStmt);
             return;
         }
@@ -28,8 +26,7 @@ public partial class ILCompiler
         // Check if this is an async function - use native IL state machine
         if (funcStmt.IsAsync)
         {
-            if (_modules.CurrentPath != null)
-                _functionDefinitionModule[funcStmt.Name.Lexeme] = _modules.CurrentPath;
+            RegisterStateMachineFunctionModule(funcStmt);
             DefineAsyncFunction(funcStmt);
             return;
         }
@@ -37,8 +34,7 @@ public partial class ILCompiler
         // Check if this is a generator function - use generator state machine
         if (funcStmt.IsGenerator)
         {
-            if (_modules.CurrentPath != null)
-                _functionDefinitionModule[funcStmt.Name.Lexeme] = _modules.CurrentPath;
+            RegisterStateMachineFunctionModule(funcStmt);
             DefineGeneratorFunction(funcStmt);
             return;
         }
@@ -156,6 +152,33 @@ public partial class ILCompiler
 
         // Create function-level display class if this function has captured locals
         DefineFunctionDisplayClass(funcStmt, qualifiedFunctionName);
+    }
+
+    /// <summary>
+    /// Module-qualifies the registry bookkeeping for an async / generator / async-generator
+    /// top-level function so two modules declaring a same-named state-machine function no
+    /// longer clobber each other (#418). Mirrors what <see cref="DefineFunction"/> does for
+    /// sync functions: the stub/state-machine registries are keyed by the module-qualified
+    /// name (see <c>DefineAsyncFunction</c> / <c>DefineGeneratorFunction</c> /
+    /// <c>DefineAsyncGeneratorFunction</c>), so this records:
+    /// <list type="bullet">
+    /// <item><see cref="_functionDefinitionModule"/> keyed by the <em>qualified</em> name, which
+    /// the Phase-7 emission loops use to restore <c>_modules.CurrentPath</c> per function.</item>
+    /// <item><c>_modules.FunctionToModule</c> keyed by the simple name, so
+    /// <see cref="CompilationContext.ResolveFunctionName"/> qualifies call-site / value
+    /// references to the now-qualified stub key.</item>
+    /// </list>
+    /// No-op in single-file compilation (<c>CurrentPath == null</c>): there the qualified name
+    /// equals the simple name and the registries stay under the simple key.
+    /// </summary>
+    private void RegisterStateMachineFunctionModule(Stmt.Function funcStmt)
+    {
+        if (_modules.CurrentPath == null)
+            return;
+
+        string qualifiedName = GetDefinitionContext().GetQualifiedFunctionName(funcStmt.Name.Lexeme);
+        _functionDefinitionModule[qualifiedName] = _modules.CurrentPath;
+        _modules.FunctionToModule[funcStmt.Name.Lexeme] = _modules.CurrentPath;
     }
 
     /// <summary>

--- a/Compilation/ILCompiler.Generators.cs
+++ b/Compilation/ILCompiler.Generators.cs
@@ -18,6 +18,12 @@ public partial class ILCompiler
     {
         string funcName = funcStmt.Name.Lexeme;
 
+        // Module-qualify the stub/registry keys (#418) so two modules that each declare a
+        // same-named generator function don't clobber each other. Single-file compilation
+        // returns the simple name unchanged. The readable state-machine type name keeps the
+        // simple name (the builder's counter already disambiguates `<name>d__N`).
+        string qualifiedName = GetDefinitionContext().GetQualifiedFunctionName(funcName);
+
         // Analyze the generator function for yield points and hoisted variables
         var analysis = _generators.Analyzer.Analyze(funcStmt);
 
@@ -25,27 +31,28 @@ public partial class ILCompiler
         var smBuilder = new GeneratorStateMachineBuilder(_moduleBuilder, _types, _generators.StateMachineCounter++);
         smBuilder.DefineStateMachine(funcName, analysis, isInstanceMethod: false, runtime: _runtime);
 
-        _generators.StateMachines[funcName] = smBuilder;
-        _generators.Functions[funcName] = funcStmt;
+        _generators.StateMachines[qualifiedName] = smBuilder;
+        _generators.Functions[qualifiedName] = funcStmt;
 
         // Define the stub method that creates and returns the state machine
         var paramTypes = funcStmt.Parameters.Select(_ => _types.Object).ToArray();
         var methodBuilder = _programType.DefineMethod(
-            funcName,
+            qualifiedName,
             MethodAttributes.Public | MethodAttributes.Static,
             _types.IEnumerableOfObject,  // Generator returns IEnumerable<object>
             paramTypes
         );
 
-        _functions.Builders[funcName] = methodBuilder;
+        _functions.Builders[qualifiedName] = methodBuilder;
 
-        // Track rest parameter info
+        // Track rest parameter info (keyed by the qualified name so ResolveFunctionName-based
+        // call-site lookups in ExpressionEmitterBase find it).
         var restParam = funcStmt.Parameters.FirstOrDefault(p => p.IsRest);
         if (restParam != null)
         {
             int restIndex = funcStmt.Parameters.IndexOf(restParam);
             int regularCount = funcStmt.Parameters.Count(p => !p.IsRest);
-            _functions.RestParams[funcName] = (restIndex, regularCount);
+            _functions.RestParams[qualifiedName] = (restIndex, regularCount);
         }
     }
 

--- a/Compilation/ILCompiler.cs
+++ b/Compilation/ILCompiler.cs
@@ -132,13 +132,22 @@ public partial class ILCompiler
     // into lib.ts's resolver.
     private readonly Dictionary<string, Dictionary<string, FieldBuilder>> _moduleTopLevelStaticVars = [];
 
-    // Simple function name -> owning module path. Populated in DefineFunction
-    // for every top-level function (including async/generator). Used to
-    // restore _modules.CurrentPath during Phase-7 body emission so per-module
-    // lookups resolve against the right module's storage. Distinct from
-    // _modules.FunctionToModule, which ResolveFunctionName treats as "qualify
-    // the method name" — async stubs don't use qualified names, so they
-    // mustn't be added there.
+    // Function name -> owning module path. Used to restore _modules.CurrentPath
+    // during Phase-7 body emission so per-module lookups resolve against the
+    // right module's storage.
+    //
+    // Keying differs by flavor, matching how each reader looks the entry up:
+    //  * async / generator / async-generator functions register via
+    //    RegisterStateMachineFunctionModule keyed by the module-QUALIFIED name,
+    //    because the Phase-7 state-machine emission loops iterate the
+    //    *.StateMachines registries (also keyed by the qualified name since #418)
+    //    and restore the module by that same key.
+    //  * sync functions register keyed by the SIMPLE name (Functions.cs).
+    // These flavors also populate _modules.FunctionToModule (keyed by simple name)
+    // so ResolveFunctionName qualifies call-site / value references. Pre-#418 the
+    // state-machine flavors used simple stub names and were deliberately kept out of
+    // FunctionToModule; #418 qualified their stubs, making that entry both safe and
+    // required to disambiguate same-named functions across modules.
     //
     // For script files (which share global scope), the stored path IS the
     // script's own path; <see cref="NormalizeToEmissionPath"/> translates it

--- a/Compilation/ILEmitter.Modules.cs
+++ b/Compilation/ILEmitter.Modules.cs
@@ -576,20 +576,23 @@ public partial class ILEmitter
     /// <summary>
     /// Resolves a top-level function name to its emitted stub <see cref="MethodBuilder"/>,
     /// covering every function flavor that registers into <see cref="CompilationContext.Functions"/>.
-    /// Sync functions are keyed by their module-qualified name, whereas async / generator /
-    /// async-generator functions register their stub under the simple name (see
-    /// <c>ILCompiler.Async</c> / <c>ILCompiler.Generators</c> / <c>ILCompiler.AsyncGenerators</c>,
-    /// which write <c>_functions.Builders[funcStmt.Name.Lexeme]</c> without module qualification).
-    /// The export-store branches must consult both keys; otherwise an <c>export async function</c>,
-    /// <c>export function*</c>, or <c>export async function*</c> leaves its export field null and the
-    /// importing module throws "object is not a function" on call (#395).
+    /// Every flavor — sync and async / generator / async-generator alike — registers its stub
+    /// under the module-qualified name (since #418; <c>ILCompiler.Async</c> /
+    /// <c>ILCompiler.Generators</c> / <c>ILCompiler.AsyncGenerators</c> key
+    /// <c>_functions.Builders</c> by <see cref="CompilationContext.GetQualifiedFunctionName"/>),
+    /// so the qualified lookup is the live path. The simple-name fallback is retained as a
+    /// defensive measure for any stub registered before module qualification was wired up.
+    /// Without resolving the stub here, an <c>export async function</c>, <c>export function*</c>,
+    /// or <c>export async function*</c> leaves its export field null and the importing module
+    /// throws "object is not a function" on call (#395).
     /// </summary>
     private bool TryResolveExportableFunction(string name, out MethodBuilder method)
     {
-        // Sync functions: module-qualified key.
+        // All function flavors: module-qualified key (matches single-file too, where the
+        // qualified name collapses to the simple name).
         if (_ctx.Functions.TryGetValue(_ctx.GetQualifiedFunctionName(name), out method!))
             return true;
-        // Async / generator / async-generator stubs: simple (unqualified) key.
+        // Defensive fallback: simple (unqualified) key.
         if (_ctx.Functions.TryGetValue(name, out method!))
             return true;
         method = null!;

--- a/SharpTS.Tests/SharedTests/CrossModuleNameCollisionTests.cs
+++ b/SharpTS.Tests/SharedTests/CrossModuleNameCollisionTests.cs
@@ -133,4 +133,165 @@ public class CrossModuleNameCollisionTests
         Assert.Contains("arch-len: true", output);
         Assert.Contains("pid-typeof: number", output);
     }
+
+    // ---- #418: same-named async / generator / async-generator functions across modules ----
+    // Sync top-level functions register their stub/builders under the module-qualified name
+    // (`$M_<module>_<name>`), so two modules never collide. Pre-#418 the state-machine flavors
+    // (async / generator / async-generator) registered every piece of their state — stub
+    // MethodBuilder, state-machine builder, AST node, _functionDefinitionModule — under the
+    // SIMPLE name. A second `async function dup` in another module overwrote the first's stub,
+    // orphaning it (no body emitted) and crashing emission with "The invoked member is not
+    // supported before the type is created." #418 module-qualifies these registries to match
+    // sync. These run in BOTH modes: compiled pins the fix, interpreted guards the (already
+    // correct) reference behavior.
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void TwoModulesDeclaringSameAsyncFunctionName(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["a.ts"] = """
+                export async function dup(): Promise<string> { return 'A'; }
+                """,
+            ["b.ts"] = """
+                export async function dup(): Promise<string> { return 'B'; }
+                """,
+            ["main.ts"] = """
+                import { dup as dupA } from './a';
+                import { dup as dupB } from './b';
+                async function main() { console.log(await dupA(), await dupB()); }
+                main();
+                """
+        };
+
+        Assert.Equal("A B\n", TestHarness.RunModules(files, "main.ts", mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void TwoModulesDeclaringSameGeneratorFunctionName(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["a.ts"] = """
+                export function* dup(): Generator<string> { yield 'A1'; yield 'A2'; }
+                """,
+            ["b.ts"] = """
+                export function* dup(): Generator<string> { yield 'B1'; yield 'B2'; }
+                """,
+            ["main.ts"] = """
+                import { dup as dupA } from './a';
+                import { dup as dupB } from './b';
+                console.log([...dupA()].join(','));
+                console.log([...dupB()].join(','));
+                """
+        };
+
+        Assert.Equal("A1,A2\nB1,B2\n", TestHarness.RunModules(files, "main.ts", mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void TwoModulesDeclaringSameAsyncGeneratorFunctionName(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["a.ts"] = """
+                export async function* dup(): AsyncGenerator<string> { yield 'A1'; yield 'A2'; }
+                """,
+            ["b.ts"] = """
+                export async function* dup(): AsyncGenerator<string> { yield 'B1'; yield 'B2'; }
+                """,
+            ["main.ts"] = """
+                import { dup as dupA } from './a';
+                import { dup as dupB } from './b';
+                async function main() {
+                    for await (const v of dupA()) console.log(v);
+                    for await (const v of dupB()) console.log(v);
+                }
+                main();
+                """
+        };
+
+        Assert.Equal("A1\nA2\nB1\nB2\n", TestHarness.RunModules(files, "main.ts", mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void TwoModulesDefaultExportingSameAsyncFunctionName(ExecutionMode mode)
+    {
+        // The `export default` store branch is distinct from named exports; cover the
+        // collision there too.
+        var files = new Dictionary<string, string>
+        {
+            ["a.ts"] = """
+                export default async function dup(): Promise<string> { return 'DA'; }
+                """,
+            ["b.ts"] = """
+                export default async function dup(): Promise<string> { return 'DB'; }
+                """,
+            ["main.ts"] = """
+                import dupA from './a';
+                import dupB from './b';
+                async function main() { console.log(await dupA(), await dupB()); }
+                main();
+                """
+        };
+
+        Assert.Equal("DA DB\n", TestHarness.RunModules(files, "main.ts", mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void TwoModulesMixingAsyncAndSyncSameFunctionName(ExecutionMode mode)
+    {
+        // One module's `dup` is async (qualified state-machine stub), the other's is sync
+        // (qualified plain stub). Each must resolve to its own module's definition.
+        var files = new Dictionary<string, string>
+        {
+            ["a.ts"] = """
+                export async function dup(): Promise<string> { return 'async'; }
+                """,
+            ["b.ts"] = """
+                export function dup(): string { return 'sync'; }
+                """,
+            ["main.ts"] = """
+                import { dup as dupA } from './a';
+                import { dup as dupB } from './b';
+                async function main() { console.log(await dupA(), dupB()); }
+                main();
+                """
+        };
+
+        Assert.Equal("async sync\n", TestHarness.RunModules(files, "main.ts", mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void TwoModulesSameAsyncFunctionNameEachCapturingOwnModuleConst(ExecutionMode mode)
+    {
+        // Each colliding async function captures a module-level const of the same name. Beyond
+        // disambiguating the stub, emission must restore the correct module context per function
+        // so each reads its OWN module's binding (not the other's).
+        var files = new Dictionary<string, string>
+        {
+            ["a.ts"] = """
+                const tag = 'CA';
+                export async function dup(): Promise<string> { return tag; }
+                """,
+            ["b.ts"] = """
+                const tag = 'CB';
+                export async function dup(): Promise<string> { return tag; }
+                """,
+            ["main.ts"] = """
+                import { dup as dupA } from './a';
+                import { dup as dupB } from './b';
+                async function main() { console.log(await dupA(), await dupB()); }
+                main();
+                """
+        };
+
+        Assert.Equal("CA CB\n", TestHarness.RunModules(files, "main.ts", mode));
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #418. Compiled **multi-module** builds crashed with `The invoked member is not supported before the type is created.` whenever two different modules each declared an **async / generator / async-generator** function with the **same name**. Plain sync functions were unaffected.

### Root cause

Sync top-level functions register their stub `MethodBuilder` and bookkeeping under the **module-qualified** name (`$M_<module>_<name>`), so two modules never collide. The three state-machine flavors instead keyed every registry by the **simple** name:

- `_functions.Builders`, `_async/_generators/_asyncGenerators.StateMachines`, `.Functions`
- `_functions.RestParams` (generators / async-generators)
- `_functionDefinitionModule`

So a second `async function dup` in another module overwrote the first module's stub, orphaning it (no body emitted) and tripping `MethodBuilder.GetParameters()` on a not-yet-created type during emission.

### Fix

Mirror the sync path:

- Async / generator / async-generator definitions now key their stub method name **and** registries by `GetQualifiedFunctionName(...)`.
- New `RegisterStateMachineFunctionModule` helper records `_functionDefinitionModule` under the qualified key (matching the Phase-7 emission loops, which iterate the now-qualified `*.StateMachines`) and populates `_modules.FunctionToModule` so `ResolveFunctionName` qualifies call-site / value references to the qualified stub.
- The two emission-time re-qualification spots in `ILCompiler.Async` (which would have double-prefixed the already-qualified iteration key / stub name) now use the qualified key directly.
- `TryResolveExportableFunction` (#395) already tried the qualified key first, so the export-store path now resolves the qualified stub for the non-colliding case and disambiguates per module for the colliding case. Comment updated.

**Single-file compilation is unchanged** — `GetQualifiedFunctionName` collapses to the simple name when `CurrentModulePath` is null, so registries stay under the simple key.

### Tests

6 new same-name cross-module collision tests in `CrossModuleNameCollisionTests`, each run in **both** interpreted and compiled modes:

- async, generator, async-generator (named import)
- `export default async` collision
- mixed async (one module) + sync (other module)
- two same-named async fns each capturing their own module-level `const` (verifies per-function module-context restore during emission)

Full suite green: **11342 passed, 0 failed**. All compiled repros also pass `--verify`.

### Repro (now works)

```ts
// a.ts
export async function dup(): Promise<string> { return "A"; }
// b.ts
export async function dup(): Promise<string> { return "B"; }
// main.ts
import { dup as dupA } from './a';
import { dup as dupB } from './b';
async function main() { console.log("a:", await dupA()); console.log("b:", await dupB()); }
main();
```
```
$ dotnet run -- --compile main.ts -o main.dll --verify && dotnet main.dll
IL verification passed.
a: A
b: B
```

### Follow-up filed

- #426 (pre-existing, orthogonal, confirmed on `origin/main`): cross-module **imported** async / generator functions with **rest parameters** crash at runtime — the state-machine stub prologue doesn't pack trailing args into the rest array, so `for...of restParam` casts a scalar to `IEnumerable`. Not addressed here.