### PR TITLE
Fix #424: bind exported variable declarations in single-file (script) compilation

### DIFF
--- a/Compilation/ILCompiler.cs
+++ b/Compilation/ILCompiler.cs
@@ -1381,6 +1381,17 @@ public partial class ILCompiler
                 return;
             }
 
+            // Single-file (script) mode: `export const/let/var x = …` still declares
+            // the top-level binding `x`, so a closure capturing it needs a field on
+            // the entry-point display class exactly as a bare declaration would.
+            // Real modules (non-null path) bind exported vars through export fields,
+            // so leave those untouched.
+            if (path == null && stmt is Stmt.Export { Declaration: { } exportedDecl })
+            {
+                RegisterCapturedStmt(exportedDecl, captureKey, path, ref mv, ref mf);
+                return;
+            }
+
             string? varName = stmt switch
             {
                 Stmt.Var v => v.Name.Lexeme,
@@ -1490,6 +1501,18 @@ public partial class ILCompiler
             {
                 DefineModuleScopedTopLevelStaticField(inner, modulePath, moduleDict);
             }
+            return;
+        }
+
+        // Single-file (script) mode: `export const/let/var x = …` still declares the
+        // top-level binding `x`. Unwrap to the inner declaration so it gets a static
+        // field exactly like a bare declaration would; without this its initializer
+        // would have nowhere to store and references to `x` would throw at runtime.
+        // Real modules (non-null path) bind exported vars through export fields +
+        // per-init-method locals, so leave those untouched.
+        if (modulePath == null && stmt is Stmt.Export { Declaration: { } exportedDecl })
+        {
+            DefineModuleScopedTopLevelStaticField(exportedDecl, modulePath, moduleDict);
             return;
         }
 

--- a/Compilation/ILEmitter.Modules.cs
+++ b/Compilation/ILEmitter.Modules.cs
@@ -373,7 +373,20 @@ public partial class ILEmitter
     {
         if (_ctx.CurrentModulePath == null || _ctx.ModuleExportFields == null)
         {
-            // Not in module context
+            // Single-file (script) mode: there is no module to export into, so the
+            // `export` marker itself is inert. But a wrapped var/const declaration
+            // still needs its initializer to run and its binding stored — exactly
+            // as a bare `const x = …` would (its static/captured field was defined
+            // by DefineModuleScopedTopLevelStaticField / RegisterCapturedStmt). A
+            // Stmt.Sequence covers destructuring and multi-declarator forms
+            // (`export const { a } = o`, `export let a = 1, b = 2`). Function/class/
+            // enum/namespace declarations bind by name via the registries and need
+            // no entry-point store, so they stay no-ops here.
+            if (_ctx.CurrentModulePath == null &&
+                export.Declaration is Stmt.Var or Stmt.Const or Stmt.Sequence)
+            {
+                EmitStatement(export.Declaration);
+            }
             return;
         }
 

--- a/SharpTS.Tests/SharedTests/ModuleTests.cs
+++ b/SharpTS.Tests/SharedTests/ModuleTests.cs
@@ -131,6 +131,87 @@ public class ModuleTests
         Assert.Equal("1\n2\n", TestHarness.Run(source, mode));
     }
 
+    // ---- #424: exported variable declarations bound in single-file (script) compilation ----
+    // These compile a single file in script (non-module) mode (TestHarness.Run + Compiled →
+    // ILCompiler.Compile, not CompileModules). Before #424 the compiled script path dropped the
+    // initializer of an `export const/let/var` (EmitExport no-ops when CurrentModulePath == null)
+    // and never defined a backing field for the binding, so a later reference threw
+    // "ReferenceError: Undefined variable". They run in BOTH modes to pin the fix and guard the
+    // interpreter (which was already correct). The CLI routes any file with import/export through
+    // the module path, so no production program hit this — only the in-process single-file harness.
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ExportConst_SingleFile(ExecutionMode mode)
+    {
+        // The canonical #424 repro: a non-captured exported const must still be
+        // stored in its $topLevel_ static field and resolve when referenced.
+        var source = """
+            export const x = 5;
+            console.log(x);
+            """;
+
+        Assert.Equal("5\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ExportLet_SingleFile(ExecutionMode mode)
+    {
+        // `export let` is mutable — exercises the Stmt.Var arm and a later reassignment.
+        var source = """
+            export let count = 7;
+            count = count + 1;
+            console.log(count);
+            """;
+
+        Assert.Equal("8\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ExportVar_SingleFile(ExecutionMode mode)
+    {
+        var source = """
+            export var greeting = "hi";
+            console.log(greeting);
+            """;
+
+        Assert.Equal("hi\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ExportConst_CapturedByClosure_SingleFile(ExecutionMode mode)
+    {
+        // When a function (a separate compiled method) reads the exported binding, the
+        // closure analyzer marks it captured, so it lives on the entry-point display class
+        // rather than a static field. Exercises the RegisterCapturedStmt unwrap path.
+        var source = """
+            export const factor = 5;
+            function scale(n: number): number {
+                return n * factor;
+            }
+            console.log(scale(3));
+            """;
+
+        Assert.Equal("15\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ExportConst_MultiDeclarator_SingleFile(ExecutionMode mode)
+    {
+        // `export const a = 1, b = 2` desugars to Stmt.Export { Declaration: Stmt.Sequence };
+        // both the field-definition helpers and EmitExport must recurse through the sequence.
+        var source = """
+            export const a = 1, b = 2;
+            console.log(a + b);
+            """;
+
+        Assert.Equal("3\n", TestHarness.Run(source, mode));
+    }
+
     // ---- #395: exported async / generator / async-generator functions callable across modules ----
     // The three #392 tests above stay InterpretedOnly because they compile a single file in
     // script (non-module) mode, where exported function declarations are still not bound


### PR DESCRIPTION
## Summary

Fixes #424. `export const/let/var x = …` was **unbound** in the single-file ("script") compile path (`ILCompiler.Compile`, used by the in-process test harness `RunCompiled`/`RunCompiledInProcess`): a later reference threw `ReferenceError: Undefined variable 'x'`.

The interpreter and multi-module compiled mode were already correct, and the CLI routes any file containing `import`/`export` through `CompileModules`, so **no production program hit this** — only the in-process single-file harness. (Same zero-real-world-impact caveat as #417.)

## Root cause

Two cooperating gaps, both because `Stmt.Export { Declaration: Stmt.Var/Const }` was never unwrapped in the script path:

1. **No backing field defined.** `DefineModuleScopedTopLevelStaticField` and `RegisterCapturedStmt` (`Compilation/ILCompiler.cs`) switched only on `Stmt.Var`/`Stmt.Const`, returning early for `Stmt.Export`. So an exported var got neither a `$topLevel_` static field nor a captured display-class field.
2. **Initializer dropped.** The entry point dispatches a top-level `Stmt.Export` to `EmitExport` (`Compilation/ILEmitter.Modules.cs`), which no-ops in script mode (`CurrentModulePath == null`), so the wrapped `const x = 5` was never emitted.

## Fix

In the **script path only** (null module path — module mode is gated out and unchanged):
- Unwrap `Stmt.Export { Declaration }` to its inner declaration in both field-definition helpers, so the binding gets a static field (non-captured) or display-class field (captured) exactly like a bare declaration.
- In `EmitExport`, emit the wrapped `Stmt.Var`/`Stmt.Const`/`Stmt.Sequence` initializer (the `Sequence` case covers `export const { a } = o` and `export let a = 1, b = 2`).

Function/class/enum/namespace declarations bind by name via the registries and need no entry-point store, so they correctly stay no-ops here (per the #424 analysis).

## Tests

5 new `ModuleTests`, all run in **both** modes (`All`) to pin the fix and guard the interpreter:
- `ExportConst_SingleFile` (canonical repro), `ExportLet_SingleFile`, `ExportVar_SingleFile`
- `ExportConst_CapturedByClosure_SingleFile` (exercises the `RegisterCapturedStmt` path)
- `ExportConst_MultiDeclarator_SingleFile` (exercises the `Stmt.Sequence` path)

Verified they **fail in Compiled mode without the fix** with the exact `ReferenceError: Undefined variable` symptom from the issue. **Full suite: 11340 pass / 0 fail.**

## Related

- Filed #428 — separate pre-existing parser bug discovered along the way: `export const` is parsed as mutable (`Stmt.Var`), losing const-ness vs bare `const`. Intentionally not bundled here (it flips type-checker behavior and may shift the conformance baseline).
- Orthogonal to #417/#425 (exported **function/class** declarations in script mode) — different code paths; no overlap.