### PR TITLE
Fix #426: pack rest args for cross-module imported async/generator functions

### DIFF
--- a/Compilation/ILCompiler.Async.cs
+++ b/Compilation/ILCompiler.Async.cs
@@ -20,8 +20,10 @@ public partial class ILCompiler
         var hasAsyncArrows = analysis.AsyncArrows.Count > 0;
         smBuilder.DefineStateMachine(funcStmt.Name.Lexeme, analysis, _types.Object, false, hasAsyncArrows);
 
-        // Define stub method (returns Task<object>)
-        var paramTypes = funcStmt.Parameters.Select(_ => _types.Object).ToArray();
+        // Define stub method (returns Task<object>).
+        // A trailing rest parameter is typed List<object> so the indirect
+        // ($TSFunction.Invoke) call path packs trailing args into it (#426).
+        var paramTypes = BuildStateMachineStubParamTypes(funcStmt);
         var stubMethod = _programType.DefineMethod(
             funcStmt.Name.Lexeme,
             MethodAttributes.Public | MethodAttributes.Static,

--- a/Compilation/ILCompiler.AsyncGenerators.cs
+++ b/Compilation/ILCompiler.AsyncGenerators.cs
@@ -27,8 +27,10 @@ public partial class ILCompiler
         _asyncGenerators.StateMachines[funcName] = smBuilder;
         _asyncGenerators.Functions[funcName] = funcStmt;
 
-        // Define the stub method that creates and returns the state machine
-        var paramTypes = funcStmt.Parameters.Select(_ => _types.Object).ToArray();
+        // Define the stub method that creates and returns the state machine.
+        // A trailing rest parameter is typed List<object> so the indirect
+        // ($TSFunction.Invoke) call path packs trailing args into it (#426).
+        var paramTypes = BuildStateMachineStubParamTypes(funcStmt);
         var methodBuilder = _programType.DefineMethod(
             funcName,
             MethodAttributes.Public | MethodAttributes.Static,

--- a/Compilation/ILCompiler.Functions.cs
+++ b/Compilation/ILCompiler.Functions.cs
@@ -159,6 +159,30 @@ public partial class ILCompiler
     }
 
     /// <summary>
+    /// Builds the parameter-type array for a state-machine stub method (async,
+    /// generator, or async-generator). Every parameter is typed <c>object</c>
+    /// except a trailing rest parameter, which is typed <c>List&lt;object&gt;</c>
+    /// — the marker that <c>$TSFunction.AdjustArgs</c> recognizes when it has to
+    /// pack the trailing call arguments into the rest list. State-machine stubs
+    /// invoked indirectly (e.g. a cross-module import routed through
+    /// <c>$TSFunction.Invoke</c>) rely on that marker; without it the indirect
+    /// path drops the first raw argument straight into the rest slot, so the
+    /// body's <c>for...of</c> over the rest value casts a scalar to
+    /// <c>IEnumerable</c> and crashes (#426). Same-module direct calls pack a
+    /// <c>$Array</c> (a <c>List&lt;object&gt;</c> subclass) via
+    /// EmitRestParameterCall, so both call paths stay type-compatible with the
+    /// <c>List&lt;object&gt;</c> slot. Mirrors the sync path's
+    /// <see cref="ParameterTypeResolver.ResolveParameters"/> rest handling.
+    /// </summary>
+    private Type[] BuildStateMachineStubParamTypes(Stmt.Function funcStmt)
+    {
+        var paramTypes = new Type[funcStmt.Parameters.Count];
+        for (int i = 0; i < funcStmt.Parameters.Count; i++)
+            paramTypes[i] = funcStmt.Parameters[i].IsRest ? _types.ListOfObject : _types.Object;
+        return paramTypes;
+    }
+
+    /// <summary>
     /// Creates a display class for a function's captured local variables.
     /// This is needed when local variables are captured by inner arrow functions.
     /// </summary>

--- a/Compilation/ILCompiler.Generators.cs
+++ b/Compilation/ILCompiler.Generators.cs
@@ -28,8 +28,10 @@ public partial class ILCompiler
         _generators.StateMachines[funcName] = smBuilder;
         _generators.Functions[funcName] = funcStmt;
 
-        // Define the stub method that creates and returns the state machine
-        var paramTypes = funcStmt.Parameters.Select(_ => _types.Object).ToArray();
+        // Define the stub method that creates and returns the state machine.
+        // A trailing rest parameter is typed List<object> so the indirect
+        // ($TSFunction.Invoke) call path packs trailing args into it (#426).
+        var paramTypes = BuildStateMachineStubParamTypes(funcStmt);
         var methodBuilder = _programType.DefineMethod(
             funcName,
             MethodAttributes.Public | MethodAttributes.Static,

--- a/SharpTS.Tests/SharedTests/CrossModuleRestParamTests.cs
+++ b/SharpTS.Tests/SharedTests/CrossModuleRestParamTests.cs
@@ -4,17 +4,17 @@ using Xunit;
 namespace SharpTS.Tests.SharedTests;
 
 /// <summary>
-/// Regression tests for compiler limitations surfaced by the Phase 3c `path`
-/// migration attempt. Both are pre-existing latent bugs that weren't hit by
-/// any previous stdlib migration — path's shape (rest-parameter APIs,
-/// namespace-like `posix`/`win32` sub-objects) is what exposes them.
+/// Regression tests for rest-parameter functions imported across module
+/// boundaries in compiled output. The first two cases cover plain functions
+/// and object-literal methods (surfaced by the Phase 3c `path` migration).
+/// The state-machine cases (generator / async / async-generator) cover #426:
+/// when invoked indirectly via <c>$TSFunction.Invoke</c>, the stub's trailing
+/// rest argument must be packed into the rest list. Before the fix the first
+/// raw argument was dropped straight into the rest slot, crashing the body's
+/// <c>for...of</c> with an InvalidCastException (scalar → IEnumerable). The
+/// stubs now type the rest parameter <c>List&lt;object&gt;</c> (the marker
+/// <c>$TSFunction.AdjustArgs</c> recognizes), mirroring the sync path.
 /// </summary>
-/// <remarks>
-/// These tests are currently <see cref="FactAttribute.Skip"/>-ped so they
-/// document the limitation without counting as a failing test. Removing
-/// <c>Skip</c> once either bug is fixed will cause the corresponding case
-/// to light up green.
-/// </remarks>
 public class CrossModuleRestParamTests
 {
     [Theory]
@@ -59,5 +59,152 @@ public class CrossModuleRestParamTests
 
         var output = TestHarness.RunModules(files, "main.ts", mode);
         Assert.Equal("hi\nhello world\n", output);
+    }
+
+    // ---- #426: state-machine functions (generator/async/async-generator) ----
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void GeneratorRestParam_AcrossModuleImport(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["gen.ts"] = """
+                export function* genA(...xs: number[]): Generator<number> {
+                    for (const x of xs) yield x * 10;
+                }
+                """,
+            ["main.ts"] = """
+                import { genA } from './gen';
+                let s = "";
+                for (const v of genA(1, 2)) s += v + ",";
+                console.log(s);
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("10,20,\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AsyncRestParam_AcrossModuleImport(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["asum.ts"] = """
+                export async function sum(...xs: number[]): Promise<number> {
+                    let t = 0;
+                    for (const x of xs) t += x;
+                    return t;
+                }
+                """,
+            ["main.ts"] = """
+                import { sum } from './asum';
+                sum(1, 2, 3).then(v => console.log("sum=" + v));
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("sum=6\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AsyncGeneratorRestParam_AcrossModuleImport(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["agen.ts"] = """
+                export async function* agenA(...xs: number[]): AsyncGenerator<number> {
+                    for (const x of xs) yield x + 100;
+                }
+                """,
+            // Consumed from a regular async function — a `for await...of` inside an
+            // async *arrow* hits an unrelated pre-existing emit bug (#430), not #426.
+            ["main.ts"] = """
+                import { agenA } from './agen';
+                async function consume(): Promise<void> {
+                    let s = "";
+                    for await (const v of agenA(1, 2, 3)) s += v + ",";
+                    console.log("agen=" + s);
+                }
+                consume();
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("agen=101,102,103,\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void GeneratorLeadingRegularParamThenRest_AcrossModuleImport(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["mixed.ts"] = """
+                export function* tagged(prefix: string, ...xs: number[]): Generator<string> {
+                    for (const x of xs) yield prefix + x;
+                }
+                """,
+            ["main.ts"] = """
+                import { tagged } from './mixed';
+                let s = "";
+                for (const v of tagged("n", 1, 2)) s += v + ",";
+                console.log(s);
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("n1,n2,\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void GeneratorEmptyRest_AcrossModuleImport(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["gen.ts"] = """
+                export function* genA(...xs: number[]): Generator<number> {
+                    for (const x of xs) yield x * 10;
+                }
+                """,
+            ["main.ts"] = """
+                import { genA } from './gen';
+                let s = "[";
+                for (const v of genA()) s += v + ",";
+                s += "]";
+                console.log(s);
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("[]\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void SpreadOfImportedGeneratorRestResult(ExecutionMode mode)
+    {
+        // Secondary #426 symptom: spreading the imported rest-param generator's
+        // result ([...genA(1, 2)]) previously failed IL verification ($Initialize
+        // BackwardBranch) before even reaching the runtime cast.
+        var files = new Dictionary<string, string>
+        {
+            ["gen.ts"] = """
+                export function* genA(...xs: number[]): Generator<number> {
+                    for (const x of xs) yield x * 10;
+                }
+                """,
+            ["main.ts"] = """
+                import { genA } from './gen';
+                console.log([...genA(1, 2)].join(","));
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("10,20\n", output);
     }
 }


### PR DESCRIPTION
Fixes #426.

## Problem

A **state-machine function** (async, generator, or async-generator) with a **rest parameter**, declared in one module and **imported** into another, crashed at runtime in compiled builds:

```
System.InvalidCastException: Unable to cast object of type 'System.Double'
to type 'System.Collections.IEnumerable'. at <genA>d__0.MoveNext()
```

Inside the function's `MoveNext`, the rest parameter held the first raw argument (a boxed `double`) instead of an array, so `for (const x of restParam)` threw. The interpreter was correct; only the compiled, **cross-module / indirect** call path was affected.

## Root cause

The three state-machine stub define sites typed **every** parameter as plain `object`:

```csharp
var paramTypes = funcStmt.Parameters.Select(_ => _types.Object).ToArray();
```

Same-module **direct** calls pack the rest array themselves (`EmitRestParameterCall`), so they worked. But cross-module imports route through `$TSFunction.Invoke` → `AdjustArgs`, which only packs trailing arguments into the rest list when the stub's **last parameter is typed `List<object>`** (the marker it inspects via the cached `_hasListRest` flag). With the rest slot typed `object`, no packing happened — the first raw argument landed in the slot and everything after it was dropped.

Sync functions never hit this because `ParameterTypeResolver.ResolveParameters` already types their rest parameter `List<object>`.

## Fix

A shared helper types a trailing rest parameter as `List<object>`, used by all three state-machine define sites (`DefineGeneratorFunction`, `DefineAsyncFunction`, `DefineAsyncGeneratorFunction`):

```csharp
private Type[] BuildStateMachineStubParamTypes(Stmt.Function funcStmt)
{
    var paramTypes = new Type[funcStmt.Parameters.Count];
    for (int i = 0; i < funcStmt.Parameters.Count; i++)
        paramTypes[i] = funcStmt.Parameters[i].IsRest ? _types.ListOfObject : _types.Object;
    return paramTypes;
}
```

Both call paths stay type-compatible: same-module direct calls pack a `$Array`, which **inherits from `List<object>`**, so it upcasts cleanly into the slot; the indirect path packs a plain `List<object>`. The state-machine `MoveNext` body iterates either via the same compiled-runtime dispatch.

Side benefits:
- The secondary symptom — spreading the imported generator's result (`[...genA(1, 2)]`), which previously failed IL verification (`$Initialize` BackwardBranch) — is also fixed.
- `$TSFunction`'s `.length` getter already skips `List<object>` params, so the imported function's `.length` now correctly excludes the rest parameter.

## Verification

- New: 6 cases in `CrossModuleRestParamTests` (`ExecutionModes.All` = interp + compiled): generator / async / async-generator rest imports, leading-param + rest, empty rest, and the spread symptom.
- Full suite: **11347 passed, 0 failed, 0 skipped**.

## Out of scope (filed separately)

While testing the async-generator case I found a **pre-existing, unrelated** bug: `for await...of` over an async generator inside an async **arrow** emits a synchronous `IEnumerable` iteration and crashes (`cast <ag>d__0 to IEnumerable`). It reproduces single-file with no rest parameter, and works fine inside a regular `async function`. Filed as #430. The async-generator test here consumes from a regular async function to stay on-topic.
