### PR TITLE
Fix #421: self-referential const capture snapshots stale value (compiled net hang)

### DIFF
--- a/Compilation/CompilationContext.Closures.cs
+++ b/Compilation/CompilationContext.Closures.cs
@@ -21,6 +21,29 @@ public partial class CompilationContext
     // gets the same direct-delegate dispatch as the inline-arrow form.
     public Dictionary<string, ArrowFunction> ConstArrowBindings { get; set; } = [];
 
+    // ============================================
+    // Self-referential capture write-back (issue #421)
+    // ============================================
+
+    /// <summary>
+    /// Name of the variable currently being declared whose initializer may
+    /// create a closure capturing that same variable (e.g.
+    /// <c>const s = make(() =&gt; s)</c>). Set by the variable-declaration emitter
+    /// around the initializer, consulted by the arrow display-class populator.
+    /// Null when not emitting a self-capturable declaration initializer.
+    /// </summary>
+    public string? SelfCaptureVarName { get; set; }
+
+    /// <summary>
+    /// Display-class instances + fields that captured <see cref="SelfCaptureVarName"/>
+    /// during the current initializer. Each closure populates its field with a
+    /// SNAPSHOT of the local taken before the assignment (so it sees the stale
+    /// value); the declaration emitter writes the freshly-assigned value back into
+    /// these fields after the store. Preserves per-iteration fresh-binding because
+    /// each iteration creates a distinct display-class instance.
+    /// </summary>
+    public List<(LocalBuilder DcInstance, FieldBuilder Field)>? SelfCaptureWriteBacks { get; set; }
+
     // Display classes for capturing closures (arrow node -> type builder)
     public Dictionary<ArrowFunction, TypeBuilder> DisplayClasses { get; set; } = [];
 

--- a/Compilation/ILEmitter.Calls.Closures.cs
+++ b/Compilation/ILEmitter.Calls.Closures.cs
@@ -342,6 +342,22 @@ public partial class ILEmitter
         {
             if (selfRefSkipName != null && capturedVar == selfRefSkipName) continue;
 
+            // Self-referential capture (issue #421): this arrow captures the
+            // variable currently being declared, whose initializer creates this
+            // arrow. The field is about to be populated with a snapshot of the
+            // local taken BEFORE the assignment — the stale/previous value. Stash
+            // the display-class instance so the declaration emitter can write the
+            // post-initializer value back into this field. Per-iteration freshness
+            // is preserved: each iteration builds a distinct DC instance.
+            if (_ctx.SelfCaptureVarName != null && capturedVar == _ctx.SelfCaptureVarName
+                && _ctx.SelfCaptureWriteBacks != null)
+            {
+                var dcInstanceLocal = IL.DeclareLocal(displayClass);
+                IL.Emit(OpCodes.Dup);
+                IL.Emit(OpCodes.Stloc, dcInstanceLocal);
+                _ctx.SelfCaptureWriteBacks.Add((dcInstanceLocal, field));
+            }
+
             IL.Emit(OpCodes.Dup); // Keep display class on stack
 
             // Load the captured variable's current value

--- a/Compilation/ILEmitter.Statements.cs
+++ b/Compilation/ILEmitter.Statements.cs
@@ -161,6 +161,19 @@ public partial class ILEmitter
 
         if (v.Initializer != null)
         {
+            // Self-referential capture write-back (issue #421): a closure created
+            // in the initializer that captures THIS variable (e.g.
+            // `const s = make(() => s)`) snapshots the local's value before this
+            // assignment, so it sees the stale/previous value (or null on the first
+            // loop iteration). Track the captured closures' display-class fields and
+            // write the freshly-assigned value back into them after the store —
+            // giving the closure the live value while keeping per-iteration
+            // fresh-binding (each iteration builds a distinct display class).
+            var savedSelfCaptureName = _ctx.SelfCaptureVarName;
+            var savedSelfCaptureWriteBacks = _ctx.SelfCaptureWriteBacks;
+            _ctx.SelfCaptureVarName = v.Name.Lexeme;
+            _ctx.SelfCaptureWriteBacks = [];
+
             EmitExpression(v.Initializer);
 
             if (_ctx.Types.IsDouble(localType))
@@ -174,6 +187,18 @@ public partial class ILEmitter
                 EmitBoxIfNeeded(v.Initializer);
             }
             IL.Emit(OpCodes.Stloc, local);
+
+            foreach (var (dcInstance, field) in _ctx.SelfCaptureWriteBacks)
+            {
+                IL.Emit(OpCodes.Ldloc, dcInstance);
+                IL.Emit(OpCodes.Ldloc, local);
+                if (_ctx.Types.IsDouble(localType))
+                    IL.Emit(OpCodes.Box, _ctx.Types.Double);
+                IL.Emit(OpCodes.Stfld, field);
+            }
+
+            _ctx.SelfCaptureVarName = savedSelfCaptureName;
+            _ctx.SelfCaptureWriteBacks = savedSelfCaptureWriteBacks;
         }
         else
         {

--- a/SharpTS.Tests/SharedTests/InnerFunctionArrowCaptureTests.cs
+++ b/SharpTS.Tests/SharedTests/InnerFunctionArrowCaptureTests.cs
@@ -305,4 +305,51 @@ public class InnerFunctionArrowCaptureTests
         var output = TestHarness.Run(source, mode);
         Assert.Equal("8008\n", output);
     }
+
+    // #421: a `const`/`let` whose initializer creates a closure capturing that
+    // same variable (self-reference). The closure's display-class field was
+    // populated with a snapshot of the local taken BEFORE the assignment, so it
+    // saw the stale/previous value — null on the first loop iteration. The
+    // declaration now writes the freshly-assigned value back into the closure's
+    // DC field after the store, while keeping per-iteration fresh-binding.
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void SelfReferentialConst_SingleDeclaration_ClosureSeesValue(ExecutionMode mode)
+    {
+        var source = """
+            function make(cb: any) { return { cb: cb, val: 42 }; }
+            const thing = make(() => thing);
+            console.log(thing.cb() === thing);
+            console.log(thing.cb().val);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("true\n42\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void SelfReferentialConst_InLoop_EachClosureSeesOwnBinding(ExecutionMode mode)
+    {
+        // The first iteration's closure captured null (snapshot before the
+        // assignment); every other iteration captured the PREVIOUS iteration's
+        // value (off-by-one). Each closure must return its OWN object — the
+        // per-iteration fresh binding — so the self-reference identity holds.
+        var source = """
+            function make(id: number, cb: any) { return { id: id, cb: cb }; }
+            const things: any[] = [];
+            for (let i = 0; i < 5; i++) {
+              const thing = make(i, () => thing);
+              things.push(thing);
+            }
+            let wrong = 0;
+            for (let k = 0; k < things.length; k++) {
+              if (things[k].cb() !== things[k]) wrong++;
+            }
+            console.log(wrong);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("0\n", output);
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #421 — a compiled program that opens many concurrent short-lived TCP sockets (each: server accepts → `socket.destroy(); server.close()`; client `connect(...)` → `client.destroy()`) delivered all callbacks but then **hung** forever.

## Root cause (not the ticket's hypothesis)

The ticket guessed a read-`Ref()` leak in the socket read worker. Instrumenting the emitted `$EventLoop.Ref/Unref` with stack traces showed the leak was exactly **one `$NetServer.Listen` Ref unmatched by a `$NetServer.Close` Unref** — one server's `close()` was skipped.

That `close()` threw `TypeError: object is not a function` (swallowed by the event-loop drain's `try/catch`), because `server.close()` is a dynamic dispatch and `server` had resolved to **`null`**.

The real defect is a **compiler closure-capture bug**, fully deterministic (the concurrency was a red herring):

```ts
const server = net.createServer((sock) => { sock.destroy(); server.close(); });
```

The connection-listener closure captures `server`, but `server` is assigned the **result** of `createServer`, whose argument is that very closure (self-reference). Captured variables are populated into the per-arrow display class by a **snapshot of the local taken at arrow-creation time — before the assignment**. So the closure sees the stale/previous value; in a loop the first iteration sees `null` and every other iteration is off-by-one (server[k]'s listener closes server[k-1]). server[0]'s listener calls `null.close()` → throws → its listen `Ref` leaks → the loop never quiesces → hang.

Minimal isolation (no net, no concurrency), compiled mode:

```ts
function make(cb: any) { return { cb }; }
const things: any[] = [];
for (let i = 0; i < 12; i++) { const thing = make(() => thing); things.push(thing); }
// before: things[0].cb() === null ; every other off-by-one. interpreter: correct.
```

## Fix

After a declaration's initializer runs, write the freshly-assigned value back into any closure display-class field that captured that same variable. Per-iteration fresh-binding is preserved because each iteration builds a distinct display class.

- `CompilationContext.Closures.cs` — transient `SelfCaptureVarName` + `SelfCaptureWriteBacks` state.
- `ILEmitter.Calls.Closures.cs` — `EmitCapturingArrowDisplayInstance` stashes the DC instance when it populates the field for the variable being declared.
- `ILEmitter.Statements.cs` — `EmitVarDeclaration` sets up the collection around the initializer and emits the write-back after the store.

## Tests

- New deterministic regression tests in `InnerFunctionArrowCaptureTests.cs` (`SelfReferentialConst_SingleDeclaration_ClosureSeesValue`, `SelfReferentialConst_InLoop_EachClosureSeesOwnBinding`) — both execution modes.
- Full suite **11334 passed / 0 failed**; Test262 conformance **no regression**.
- The #421 net repro now exits cleanly.

## Follow-up filed

#431 — a separate, pre-existing bug found along the way: a **number-typed** loop-local captured by a closure emits invalid IL (`StackUnexpected` → segfault) because the local-capture path doesn't box the unboxed `double` before storing into the `object` display-class field. Independent of #421 (which has no captured number locals).
