### PR TITLE
Fix #393: non-async Promise<T> return slot fails IL verification

### DIFF
--- a/Compilation/ParameterTypeResolver.cs
+++ b/Compilation/ParameterTypeResolver.cs
@@ -203,6 +203,22 @@ public static class ParameterTypeResolver
             {
                 baseType = typeof(object);
             }
+
+            // A non-async function/arrow declared to return `Promise<T>` maps (strictly) to
+            // Task<T>/Task, but its body never produces a real CLR Task — it returns the runtime
+            // `$TSPromise` carried as object (e.g. the timers/promises re-export wrappers, which
+            // return $Runtime.SetTimeoutPromise(...)). That object is not CLR-assignable to the
+            // Task slot, so the `ret` raises ILVerify StackUnexpected; the JIT tolerates the
+            // reference-type store (the program still runs), but `--verify` rejects it, and a
+            // castclass at the return site would throw InvalidCastException since the value is not
+            // a Task. Fall back to object so the dynamic promise is returned directly. Async
+            // functions don't reach this resolver — they hardcode a Task<object> stub whose state
+            // machine builds a real Task. (#393)
+            if (!isAsync && (baseType == typeof(Task) ||
+                (baseType.IsGenericType && baseType.GetGenericTypeDefinition() == typeof(Task<>))))
+            {
+                baseType = typeof(object);
+            }
         }
 
         // Wrap async return types in Task<T>

--- a/SharpTS.Tests/CompilerTests/ILVerificationTests.cs
+++ b/SharpTS.Tests/CompilerTests/ILVerificationTests.cs
@@ -331,6 +331,58 @@ public class ILVerificationTests
     }
 
     [Fact]
+    public void NonAsyncFunctionReturningPromise_PassesILVerification()
+    {
+        // A NON-async function/arrow declared `: Promise<T>` maps its return slot (strictly) to
+        // Task<T>, but the body returns the runtime $TSPromise carried as object — not CLR-assignable
+        // to the Task slot. That left an object on the stack where the verifier expected Task<T>,
+        // raising StackUnexpected even though it ran (the JIT tolerates the reference-type store).
+        // The return type now falls back to object. Async functions are unaffected: they hardcode a
+        // Task<object> stub whose state machine builds a real Task. Covers both a top-level function
+        // and an arrow (both route through ParameterTypeResolver.ResolveReturnType). (#393)
+        var source = """
+            function wrap(): Promise<number> { return Promise.resolve(42); }
+            const arrow = (): Promise<string> => Promise.resolve("hi");
+            async function main() {
+                console.log(await wrap());
+                console.log(await arrow());
+            }
+            main();
+            """;
+
+        var (errors, output) = TestHarness.CompileVerifyAndRun(source);
+
+        Assert.Empty(errors);
+        Assert.Equal("42\nhi\n", output);
+    }
+
+    [Fact]
+    public void TimersPromisesImport_PassesILVerification()
+    {
+        // Exact #393 repro: importing timers/promises emitted the re-export wrappers
+        // $M_promises_setTimeout / $M_promises_setImmediate as non-async functions declared
+        // `: Promise<any>`, whose Task<object> return slot didn't match the object the body
+        // produced (StackUnexpected). setInterval returns AsyncIterable<any> (→ object slot) and
+        // was always clean. Verifies the whole module — covers all three wrappers regardless of
+        // which member is imported (all are emitted). (#393)
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import { setTimeout } from 'timers/promises';
+                async function main() {
+                    const r = await setTimeout(10, 'tick');
+                    console.log(r);
+                }
+                main();
+                """
+        };
+
+        var errors = TestHarness.CompileModulesAndVerifyOnly(files, "main.ts");
+
+        Assert.Empty(errors);
+    }
+
+    [Fact]
     public void ClassGetPropertyWithTypedGetter_PassesILVerification()
     {
         // The compiler-generated GetProperty dispatch helper invokes a typed getter (e.g. the

--- a/SharpTS.Tests/Infrastructure/TestHarness.cs
+++ b/SharpTS.Tests/Infrastructure/TestHarness.cs
@@ -1181,6 +1181,64 @@ public static class TestHarness
     }
 
     /// <summary>
+    /// Compiles a multi-module program (via the <see cref="ILCompiler.CompileModules"/> pipeline,
+    /// the same path the CLI uses for any file with imports) and verifies the generated IL without
+    /// running it. Use this — not <see cref="CompileAndVerifyOnly"/> — whenever the program has
+    /// <c>import</c>s (including stdlib modules like <c>timers/promises</c>), since the single-file
+    /// <see cref="ILCompiler.Compile"/> path does not resolve module dependencies. Catches bad IL in
+    /// emitted module helpers that still runs under the JIT (e.g. #393), which the run-only
+    /// <see cref="RunModules"/> path cannot detect.
+    /// </summary>
+    /// <param name="files">Map of module path → source.</param>
+    /// <param name="entryPoint">Entry module path (key into <paramref name="files"/>).</param>
+    /// <returns>List of verification errors (empty when the IL is valid).</returns>
+    public static List<string> CompileModulesAndVerifyOnly(Dictionary<string, string> files, string entryPoint)
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"sharpts_module_verify_{Guid.NewGuid()}");
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            foreach (var (path, content) in files)
+            {
+                var fullPath = Path.Combine(tempDir, path.TrimStart('.', '/', '\\'));
+                var dir = Path.GetDirectoryName(fullPath);
+                if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+                    Directory.CreateDirectory(dir);
+                File.WriteAllText(fullPath, content);
+            }
+
+            var entryPath = Path.Combine(tempDir, entryPoint.TrimStart('.', '/', '\\'));
+            var dllPath = Path.Combine(tempDir, "test_modules.dll");
+
+            var resolver = new ModuleResolver(entryPath);
+            var entryModule = resolver.LoadModule(entryPath);
+            var allModules = resolver.GetModulesInOrder(entryModule);
+
+            var checker = new TypeChecker();
+            var typeMap = checker.CheckModules(allModules, resolver);
+
+            var allStatements = allModules.SelectMany(m => m.Statements).ToList();
+            var deadCodeAnalyzer = new DeadCodeAnalyzer(typeMap);
+            var deadCodeInfo = deadCodeAnalyzer.Analyze(allStatements);
+
+            // Use reference assemblies for IL verification compatibility (matches CompileAndVerifyOnly).
+            var sdkPath = SdkResolver.FindReferenceAssembliesPath();
+            var compiler = new ILCompiler("test_modules", preserveConstEnums: false, useReferenceAssemblies: true, sdkPath: sdkPath);
+            compiler.CompileModules(allModules, resolver, typeMap, deadCodeInfo);
+            compiler.Save(dllPath);
+
+            // Filter out expected "Failed to load assembly 'SharpTS'" errors (the verifier can't
+            // resolve the SharpTS runtime, which standalone output late-binds anyway).
+            return VerifyIL(dllPath).Where(e => !e.Contains("Failed to load assembly")).ToList();
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, true); } catch { /* ignore cleanup errors */ }
+        }
+    }
+
+    /// <summary>
     /// Compiles TypeScript source and verifies the generated IL.
     /// </summary>
     /// <param name="source">TypeScript source code</param>


### PR DESCRIPTION
## Summary

Fixes #393. Any compiled program importing `timers/promises` failed `--verify`:

```
[IL Error] $Program.$M_promises_setTimeout: StackUnexpected - Unexpected type on the stack.
[IL Error] $Program.$M_promises_setImmediate: StackUnexpected - Unexpected type on the stack.
```

### Root cause

The `timers/promises` re-export wrappers (`stdlib/node/timers/promises.ts`) are **non-async** functions declared `: Promise<any>` that return the primitive's result directly. `ParameterTypeResolver.ResolveReturnType` mapped `Promise<T>` (strictly) to `Task<T>`, so the emitted method declared a `Task<object>` return slot — but the body returns the runtime `$TSPromise` carried as `object`, which is not CLR-assignable to `Task<object>`. The `ret` therefore left an `object` where the verifier expected `Task<object>` (`StackUnexpected`). The JIT tolerates the reference-type store, so the program *ran* correctly; only `--verify` rejected it.

`setInterval` returns `AsyncIterable<any>` (→ `object` slot), which is why it was always clean.

### Fix

`ResolveReturnType` now falls back to `object` for a **non-async** `Promise<T>` return, mirroring the existing `#278` (dynamic collections) and `#318` (string) fallbacks — a non-async body never produces a real CLR `Task`, and a castclass at the return site would throw `InvalidCastException` since the value isn't a `Task`, so `object` is the only correct slot. Async functions are unaffected: they don't use this resolver — they hardcode a `Task<object>` stub whose state machine builds a real `Task`.

The fix is general: it also covers any user-written function/arrow of the same shape, and `util.promisify`'s returned wrapper.

## Tests

- `NonAsyncFunctionReturningPromise_PassesILVerification` — root-cause guard; covers both a top-level function and an arrow (both route through `ResolveReturnType`). Confirmed to fail pre-fix (`$Program.wrap` + `$Program.<>Arrow_0`).
- `TimersPromisesImport_PassesILVerification` — the exact issue repro, verifying the whole module.
- New `TestHarness.CompileModulesAndVerifyOnly` helper — IL-verifies **module-compiled** output. This was a genuine gap: the existing module tests only *run* the program (which succeeds despite bad IL), so nothing caught this class of bug. `CompileAndVerifyOnly` can't be used because it uses the single-file compile path, which doesn't resolve `import`s.

Full suite: **11337 passed, 0 failed**.

## Out-of-scope bug filed

While testing `util.promisify` I found a **separate, pre-existing** IL-verification bug (different method, error code `BackwardBranch`, and trigger): string-concatenating `arr.join()` after an `arr.push()` loop. Filed as #437 with a minimal repro. It makes any program importing `util` fail `--verify` (via `$M_util_inspectValue`), though such programs still run. Not addressed here.
