### PR TITLE
Fix #413: await-safe spilling of rest/spread call arguments

### DIFF
--- a/Compilation/ExpressionEmitterBase.CallHelpers.cs
+++ b/Compilation/ExpressionEmitterBase.CallHelpers.cs
@@ -148,7 +148,7 @@ public abstract partial class ExpressionEmitterBase
 
                 if (hasRestParam)
                 {
-                    EmitRestParameterCall(c.Arguments, restInfo.RegularParamCount);
+                    EmitRestParameterCall(c.Arguments, restInfo.RegularParamCount, targetMethod.GetParameters());
                 }
                 else
                 {
@@ -394,26 +394,36 @@ public abstract partial class ExpressionEmitterBase
     }
 
     /// <summary>
-    /// Emits arguments for a function call with rest parameter, handling spreads.
-    /// Emits regular args first, then builds an array for the rest parameter.
+    /// Emits arguments for a function call with rest parameter, handling spreads: loads the
+    /// leading regular arguments, then builds the trailing rest array.
     /// </summary>
-    private void EmitRestParameterCall(List<Expr> arguments, int regularCount)
+    /// <remarks>
+    /// Every argument is spilled to a local up front via <see cref="SpillBoxed"/> before any
+    /// array is assembled. State-machine emitters can suspend (<c>await</c>) inside any
+    /// argument; assembling the rest array inline would leave the array reference (and the
+    /// regular args) on the IL evaluation stack across the suspension, which produces invalid
+    /// IL (<c>PathStackDepth</c>, #413). SpillBoxed also registers each value so it survives
+    /// the MoveNext re-entry (#400). In non-suspending emitters (ILEmitter) these are plain
+    /// locals the JIT collapses away.
+    /// </remarks>
+    private void EmitRestParameterCall(List<Expr> arguments, int regularCount, ParameterInfo[] targetParams)
     {
         bool hasSpreads = arguments.Any(a => a is Expr.Spread);
 
-        // Emit regular arguments (before rest param)
+        // Spill every argument (spreads spill their inner expression) before touching the stack.
+        var argLocals = new LocalBuilder[arguments.Count];
+        for (int i = 0; i < arguments.Count; i++)
+            argLocals[i] = SpillBoxed(arguments[i] is Expr.Spread spread ? spread.Expression : arguments[i]);
+
+        // Load regular arguments (before rest param) from their locals, coercing each boxed
+        // object back to the parameter's declared CLR type — free-function params are emitted
+        // with their real type (e.g. string, double), so passing a bare object would fail
+        // verification (StackUnexpected). The rest List<object> always takes boxed elements.
         for (int i = 0; i < Math.Min(regularCount, arguments.Count); i++)
         {
-            if (arguments[i] is Expr.Spread spread)
-            {
-                EmitExpression(spread.Expression);
-                EnsureBoxed();
-            }
-            else
-            {
-                EmitExpression(arguments[i]);
-                EnsureBoxed();
-            }
+            IL.Emit(OpCodes.Ldloc, argLocals[i]);
+            if (i < targetParams.Length)
+                EmitCoerceBoxedToType(targetParams[i].ParameterType);
         }
 
         // Pad regular args with nulls if needed
@@ -424,7 +434,7 @@ public abstract partial class ExpressionEmitterBase
         int restArgsCount = Math.Max(0, arguments.Count - regularCount);
         if (hasSpreads && restArgsCount > 0)
         {
-            EmitSpreadArray(arguments, regularCount, restArgsCount);
+            EmitSpreadArrayFromLocals(arguments, argLocals, regularCount, restArgsCount);
             EmitExpandCallArgs();
             IL.Emit(OpCodes.Call, Ctx.Runtime!.CreateArray);
         }
@@ -436,8 +446,7 @@ public abstract partial class ExpressionEmitterBase
             {
                 IL.Emit(OpCodes.Dup);
                 IL.Emit(OpCodes.Ldc_I4, i);
-                EmitExpression(arguments[regularCount + i]);
-                EnsureBoxed();
+                IL.Emit(OpCodes.Ldloc, argLocals[regularCount + i]);
                 IL.Emit(OpCodes.Stelem_Ref);
             }
             IL.Emit(OpCodes.Call, Ctx.Runtime!.CreateArray);
@@ -452,10 +461,13 @@ public abstract partial class ExpressionEmitterBase
     }
 
     /// <summary>
-    /// Emits an args array and isSpread bool array for arguments starting at offset.
-    /// Leaves both arrays on the stack (args array first, then isSpread array on top).
+    /// Emits an args array and isSpread bool array from pre-spilled argument locals (a slice of
+    /// <paramref name="argLocals"/> starting at <paramref name="offset"/>). Leaves both arrays
+    /// on the stack (args array first, then isSpread array on top). Reads from locals rather
+    /// than re-emitting expressions so no <c>await</c> can suspend while the arrays are stacked
+    /// (#413); the caller is responsible for having spilled the values.
     /// </summary>
-    private void EmitSpreadArray(List<Expr> arguments, int offset, int count)
+    private void EmitSpreadArrayFromLocals(List<Expr> arguments, LocalBuilder[] argLocals, int offset, int count)
     {
         IL.Emit(OpCodes.Ldc_I4, count);
         IL.Emit(OpCodes.Newarr, Types.Object);
@@ -463,17 +475,7 @@ public abstract partial class ExpressionEmitterBase
         {
             IL.Emit(OpCodes.Dup);
             IL.Emit(OpCodes.Ldc_I4, i);
-            var arg = arguments[offset + i];
-            if (arg is Expr.Spread spread)
-            {
-                EmitExpression(spread.Expression);
-                EnsureBoxed();
-            }
-            else
-            {
-                EmitExpression(arg);
-                EnsureBoxed();
-            }
+            IL.Emit(OpCodes.Ldloc, argLocals[offset + i]);
             IL.Emit(OpCodes.Stelem_Ref);
         }
 
@@ -490,6 +492,21 @@ public abstract partial class ExpressionEmitterBase
                 IL.Emit(OpCodes.Stelem_I1);
             }
         }
+    }
+
+    /// <summary>
+    /// Coerces the boxed object currently on the stack to <paramref name="targetType"/>:
+    /// unbox for value types, downcast for reference types, no-op for object. Used when
+    /// loading a previously-spilled (boxed) argument into a typed parameter slot.
+    /// </summary>
+    private void EmitCoerceBoxedToType(Type targetType)
+    {
+        if (targetType == typeof(object) || targetType == Types.Object)
+            return;
+        if (targetType.IsValueType)
+            IL.Emit(OpCodes.Unbox_Any, targetType);
+        else
+            IL.Emit(OpCodes.Castclass, targetType);
     }
 
     /// <summary>

--- a/SharpTS.Tests/CompilerTests/ILVerificationTests.cs
+++ b/SharpTS.Tests/CompilerTests/ILVerificationTests.cs
@@ -66,6 +66,50 @@ public class ILVerificationTests
     }
 
     [Fact]
+    public void AwaitInRestParamCallArg_PassesILVerification()
+    {
+        // #413: await inside an argument of a call whose args are assembled as a rest/varargs
+        // array. The args must be spilled off the IL evaluation stack before the array is built;
+        // otherwise the array reference sits stacked across the suspension and the MoveNext body
+        // fails verification with PathStackDepth (and throws InvalidProgramException at runtime).
+        var source = """
+            function g(...a: any[]): string { return a.join(","); }
+            async function m() {
+                console.log(g("x", await new Promise<number>(r => setTimeout(() => r(1), 5))));
+            }
+            m();
+            """;
+
+        // Verify-only: the executor arrow captures variables, which trips the in-memory
+        // reference-assembly run path (see #343); verification alone is the precise guard here.
+        var errors = TestHarness.CompileAndVerifyOnly(source);
+
+        Assert.Empty(errors);
+    }
+
+    [Fact]
+    public void AwaitWithRegularParamBeforeRestParamCall_PassesILVerification()
+    {
+        // #413 variant: a typed regular parameter precedes the rest parameter, and the await is
+        // in a rest-position argument. The regular arg is spilled as a boxed object and must be
+        // coerced back to its declared (string) slot when loaded for the call.
+        // (The rest-join result is hoisted to a local so the body avoids the unrelated #434
+        // BackwardBranch verify bug — `<expr> + rest.join(...)` directly — keeping this test
+        // focused on the #413 call-site fix.)
+        var source = """
+            function h(x: string, ...rest: any[]): string { const s = rest.join(","); return x + "|" + s; }
+            async function m() {
+                console.log(h("X", "y", await new Promise<string>(r => setTimeout(() => r("Z"), 5))));
+            }
+            m();
+            """;
+
+        var errors = TestHarness.CompileAndVerifyOnly(source);
+
+        Assert.Empty(errors);
+    }
+
+    [Fact]
     public void Closures_PassesILVerification()
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/AwaitDeferredSpillTests.cs
+++ b/SharpTS.Tests/SharedTests/AwaitDeferredSpillTests.cs
@@ -147,6 +147,54 @@ public class AwaitDeferredSpillTests
             """, mode));
     }
 
+    // #413: a top-level function with a rest parameter, whose call args are assembled into an
+    // object[]/List<object> on the IL stack. An await inside such an argument must spill the
+    // already-evaluated args off the evaluation stack before the array is built — otherwise the
+    // array reference sits stacked across the suspension (invalid IL, PathStackDepth) and earlier
+    // args are lost on MoveNext re-entry. `g` is all-rest; `h` has a typed regular param first.
+    // `h`'s rest-join is hoisted to a local so the body avoids the unrelated #434 BackwardBranch
+    // verify bug (`<expr> + rest.join(...)` directly), keeping these tests focused on #413.
+    private const string RestScaffold =
+        "function g(...a: any[]): string { return a.join(\",\"); }\n" +
+        "function h(x: string, ...rest: any[]): string { const s = rest.join(\",\"); return x + \"|\" + s; }\n";
+
+    private static string RunRest(string body, ExecutionMode mode)
+        => TestHarness.Run(Defer + RestScaffold + "async function m() {\n" + body + "\n}\nm();\n", mode);
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void RestParamCall_DeferredAwaitArg(ExecutionMode mode)
+    {
+        // The exact issue repro shape: await in the second (rest) argument.
+        Assert.Equal("x,1\n", RunRest("""console.log(g("x", await defer(1, 5)));""", mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void RestParamCall_RegularParamSurvivesDeferredAwait(ExecutionMode mode)
+    {
+        // `h`'s typed regular param "X" is spilled before the deferred await in the rest arg;
+        // it must survive the suspension and be coerced back to its declared string slot.
+        Assert.Equal("X|y,Z\n", RunRest("""console.log(h("X", "y", await defer("Z", 5)));""", mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void RestParamCall_TwoDeferredAwaits(ExecutionMode mode)
+    {
+        Assert.Equal("p,q\n", RunRest("""console.log(g(await defer("p", 5), await defer("q", 5)));""", mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void RestParamCall_SpreadBetweenDeferredAwaits(ExecutionMode mode)
+    {
+        // Spread element plus deferred awaits on both sides — exercises the spread/ExpandCallArgs
+        // path, which must also read pre-spilled locals rather than re-evaluating across the await.
+        Assert.Equal("0,10,20,30\n", RunRest(
+            """const arr = [10, 20]; console.log(g(await defer(0, 5), ...arr, await defer(30, 5)));""", mode));
+    }
+
     [Theory]
     [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void DeferredThenableSpecies_PrefixSurvives(ExecutionMode mode)


### PR DESCRIPTION
## Summary

Fixes #413. In compiled mode, `await`-ing inside an argument of a call to a **rest-parameter** function produced invalid IL (`PathStackDepth`) and threw `InvalidProgramException` at runtime. `EmitRestParameterCall` assembled the args array inline on the IL evaluation stack (`EmitExpression` for each argument *between* `Newarr` and the call), so an `await` suspended the state machine with the array reference — and any leading regular args — still stacked.

### Repro (now fixed)
```ts
function g(...a: any[]): string { return a.join(); }
async function m() {
  console.log(g("x", await new Promise<number>(r => setTimeout(() => r(1), 5))));
}
m();
```
`--compile … --verify` previously reported `<m>d__0.MoveNext: PathStackDepth`; now verifies and prints `x,1` (matching the interpreter).

## Approach

Spill every argument to a local up front via `SpillBoxed` (the existing await-safe pattern used by `EmitFunctionValueCall`, array/object literals, template literals, etc.), then load the regular args and build the rest array **purely from locals** — nothing is evaluated while arrays sit on the stack. `SpillBoxed` also registers each value so it survives the `MoveNext` re-entry of a *deferred* suspension (#400), which I verified holds (a typed regular param before a deferred await is preserved).

Because regular args are spilled as boxed objects, they are coerced back to their declared parameter slot when loaded (new `EmitCoerceBoxedToType`) — free-function params carry their real CLR type (e.g. `string`, `double`), so passing a bare `object` would otherwise fail verification with `StackUnexpected`. `EmitSpreadArray` becomes `EmitSpreadArrayFromLocals` (reads pre-spilled locals). The synchronous `ILEmitter` path goes through the same code; the extra locals are round-trips the JIT collapses.

## Tests

- `AwaitDeferredSpillTests` (both interpreter + compiler): issue repro; typed regular param surviving a deferred await; two awaits; spread between awaits.
- `ILVerificationTests`: verify-only guards for the rest-param and regular-param-before-rest shapes.
- Full suite: **11,345 passed, 0 failed**.

## Out-of-scope bugs found and filed

While investigating I confirmed three pre-existing bugs on `main` (untouched by this fix) and filed them rather than expanding scope:
- #434 — synchronous `<expr> + rest.join(...)` emits invalid IL (`BackwardBranch`).
- #436 — fixed-arity free-function call: `f(x, await deferred)` loses `x` (and fails verify).
- #439 — method-call (static / instance / optional-chain) with `await` after an earlier arg: invalid IL and runtime crash (e.g. `NullReferenceException`).

These are the same await-stack-spill class as #413 but in distinct dispatch paths (the latter two touch hot call paths and warrant their own perf-reviewed fixes).
