### PR TITLE
Fix #414: spill across suspension in async arrows & generators (+ verifiable self-boxed kickoff)

### DIFF
--- a/Compilation/AsyncArrowMoveNextEmitter.Operators.cs
+++ b/Compilation/AsyncArrowMoveNextEmitter.Operators.cs
@@ -78,6 +78,11 @@ public partial class AsyncArrowMoveNextEmitter
         _il.Emit(OpCodes.Ldc_I4, stateNum);
         _il.Emit(OpCodes.Stfld, _builder.StateField);
 
+        // Mirror live spill temps to fields before AwaitUnsafeOnCompleted boxes the state
+        // machine struct: IL locals do not survive the MoveNext re-entry, and writes after
+        // the box would not reach the continuation's snapshot (#400/#414). Suspending path only.
+        _helpers.PersistLiveSpillsBeforeSuspend();
+
         _il.Emit(OpCodes.Ldarg_0);
         _il.Emit(OpCodes.Ldflda, _builder.BuilderField);
         _il.Emit(OpCodes.Ldarg_0);
@@ -94,6 +99,10 @@ public partial class AsyncArrowMoveNextEmitter
         _il.Emit(OpCodes.Ldarg_0);
         _il.Emit(OpCodes.Ldc_I4_M1);
         _il.Emit(OpCodes.Stfld, _builder.StateField);
+
+        // Restore spill temps from their fields — only on the resumed path; the
+        // synchronously-completed path (below) never persisted and keeps its locals.
+        _helpers.RehydrateLiveSpillsAfterResume();
 
         // 8. Continue point
         _il.MarkLabel(continueLabel);

--- a/Compilation/AsyncArrowMoveNextEmitter.cs
+++ b/Compilation/AsyncArrowMoveNextEmitter.cs
@@ -118,6 +118,10 @@ public partial class AsyncArrowMoveNextEmitter : StatementEmitterBase, IEmitterC
         _analysis = analysis;
         _types = types;
         _il = builder.MoveNextMethod.GetILGenerator();
+        // A value spilled across an await must survive the MoveNext re-entry in a
+        // state-machine field, not a transient IL local (#400/#414).
+        _helpers.EnablePersistentSpills(name => _builder.StateMachineType.DefineField(
+            name, _types.Object, System.Reflection.FieldAttributes.Private));
     }
 
     /// <summary>

--- a/Compilation/AsyncArrowStateMachineBuilder.cs
+++ b/Compilation/AsyncArrowStateMachineBuilder.cs
@@ -401,34 +401,19 @@ public class AsyncArrowStateMachineBuilder
         il.Emit(OpCodes.Stfld, StateField);
 
         // If this arrow has nested async arrows, box and store self reference before Start
+        // so the nested arrows capture the one shared instance. Box once and run the box via
+        // a verifiable ref (see helper for the #414 fix).
         if (SelfBoxedField != null)
         {
-            // Box the state machine
-            il.Emit(OpCodes.Ldloc, smLocal);
-            il.Emit(OpCodes.Box, _stateMachineType);
-            var boxedLocal = il.DeclareLocal(_types.Object);
-            il.Emit(OpCodes.Stloc, boxedLocal);
-
-            // Store in sm.<>__selfBoxed (access through the boxed reference since we already boxed)
-            il.Emit(OpCodes.Ldloc, boxedLocal);
-            il.Emit(OpCodes.Unbox, _stateMachineType);
-            il.Emit(OpCodes.Ldloc, boxedLocal);
-            il.Emit(OpCodes.Stfld, SelfBoxedField);
-
-            // Now call Start on the boxed instance's builder
-            il.Emit(OpCodes.Ldloc, boxedLocal);
-            il.Emit(OpCodes.Unbox, _stateMachineType);
-            il.Emit(OpCodes.Ldflda, BuilderField);
-            il.Emit(OpCodes.Ldloc, boxedLocal);
-            il.Emit(OpCodes.Unbox, _stateMachineType);
-            il.Emit(OpCodes.Call, GetBuilderStartMethod());
-
-            // return builder.Task from boxed instance
-            il.Emit(OpCodes.Ldloc, boxedLocal);
-            il.Emit(OpCodes.Unbox, _stateMachineType);
-            il.Emit(OpCodes.Ldflda, BuilderField);
-            il.Emit(OpCodes.Call, GetBuilderTaskGetter());
-            il.Emit(OpCodes.Ret);
+            StateMachineEmitHelpers.EmitSelfBoxedStartAndReturnTask(
+                il,
+                smLocal,
+                _stateMachineType,
+                SelfBoxedField,
+                BuilderField,
+                GetBuilderStartMethod(),
+                GetBuilderTaskGetter(),
+                _types);
         }
         else
         {

--- a/Compilation/GeneratorMoveNextEmitter.Expressions.Yield.cs
+++ b/Compilation/GeneratorMoveNextEmitter.Expressions.Yield.cs
@@ -41,12 +41,20 @@ public partial class GeneratorMoveNextEmitter
         _il.Emit(OpCodes.Ldc_I4, stateNumber);
         _il.Emit(OpCodes.Stfld, _builder.StateField);
 
+        // Mirror live spill temps to fields before returning: IL locals do not survive the
+        // MoveNext re-entry, so a value spilled before this yield and used after it would be
+        // lost (#400/#414). The state machine is a class, so the fields persist directly.
+        _helpers.PersistLiveSpillsBeforeSuspend();
+
         // 4. Return true (has value)
         _il.Emit(OpCodes.Ldc_I4_1);
         _il.Emit(OpCodes.Ret);
 
         // 5. Mark the resume label (jumped to from state switch)
         _il.MarkLabel(resumeLabel);
+
+        // Restore spill temps from their fields on the resumed path.
+        _helpers.RehydrateLiveSpillsAfterResume();
 
         // 6. yield expression evaluates to undefined (null) when resumed
         _il.Emit(OpCodes.Ldnull);
@@ -103,6 +111,13 @@ public partial class GeneratorMoveNextEmitter
                 _il.Emit(OpCodes.Stfld, field);
             }
         }
+
+        // Mirror operand spill temps (SpillBoxed locals, e.g. the left side of
+        // `"x" + (yield* g())`) to fields up front. Unlike the on-stack spill above, these
+        // live in locals that the per-element re-entry would wipe. Persisting before the
+        // resume label means the field is valid on both the first fall-through and every
+        // state-dispatch re-entry, where it is rehydrated (#400/#414).
+        _helpers.PersistLiveSpillsBeforeSuspend();
 
         var moveNext = typeof(System.Collections.IEnumerator).GetMethod("MoveNext")!;
         var current = typeof(System.Collections.IEnumerator).GetProperty("Current")!.GetGetMethod()!;
@@ -212,8 +227,12 @@ public partial class GeneratorMoveNextEmitter
         _il.Emit(OpCodes.Ldloc, enumTemp);
         _il.Emit(OpCodes.Stfld, delegatedField);
 
-        // This label is where we resume from state dispatch
+        // This label is where we resume from state dispatch (and the per-element loop top).
         _il.MarkLabel(resumeLabel);
+
+        // Restore operand spill temps. Safe on the first fall-through too: they were persisted
+        // before the setup above, so the field already holds the live value (#400/#414).
+        _helpers.RehydrateLiveSpillsAfterResume();
 
         // Load the delegated enumerator from field
         _il.Emit(OpCodes.Ldarg_0);

--- a/Compilation/GeneratorMoveNextEmitter.cs
+++ b/Compilation/GeneratorMoveNextEmitter.cs
@@ -52,6 +52,10 @@ public partial class GeneratorMoveNextEmitter : StatementEmitterBase
         _analysis = analysis;
         _il = builder.MoveNextMethod.GetILGenerator();
         _types = types;
+        // A value spilled across a yield must survive the MoveNext re-entry in a
+        // state-machine field, not a transient IL local (#400/#414).
+        _helpers.EnablePersistentSpills(name => _builder.StateMachineType.DefineField(
+            name, _types.Object, System.Reflection.FieldAttributes.Private));
     }
 
     /// <summary>

--- a/Compilation/ILCompiler.Async.cs
+++ b/Compilation/ILCompiler.Async.cs
@@ -552,9 +552,12 @@ public partial class ILCompiler
         }
         _modules.CurrentPath = savedPath;
 
-        // Finalize all async arrow state machine types
+        // Finalize nested async arrow state machine types. Standalone (top-level) arrows are
+        // finalized in EmitTopLevelAsyncArrowBodies AFTER their MoveNext is emitted — creating
+        // them here would freeze the type before that pass can define spill fields (#400/#414).
         foreach (var (_, arrowBuilder) in _async.ArrowBuilders)
         {
+            if (arrowBuilder.IsStandalone) continue;
             arrowBuilder.CreateType();
         }
     }
@@ -765,34 +768,17 @@ public partial class ILCompiler
         // and store the boxed reference so async arrows can share the same instance
         if (smBuilder.SelfBoxedField != null)
         {
-            // Box the state machine to get a heap-allocated copy
-            il.Emit(OpCodes.Ldloc, smLocal);
-            il.Emit(OpCodes.Box, smBuilder.StateMachineType);
-            var boxedLocal = il.DeclareLocal(typeof(object));
-            il.Emit(OpCodes.Stloc, boxedLocal);
-
-            // Store the boxed reference in the state machine
-            // Use Unbox to get a pointer to the boxed value, then store the reference there
-            il.Emit(OpCodes.Ldloc, boxedLocal);
-            il.Emit(OpCodes.Unbox, smBuilder.StateMachineType);
-            il.Emit(OpCodes.Ldloc, boxedLocal);
-            il.Emit(OpCodes.Stfld, smBuilder.SelfBoxedField);
-
-            // Now call Start on the BOXED state machine (cast to IAsyncStateMachine)
-            // builder.Start expects ref TSM, so we use Unbox to get the pointer
-            il.Emit(OpCodes.Ldloc, boxedLocal);
-            il.Emit(OpCodes.Unbox, smBuilder.StateMachineType);
-            il.Emit(OpCodes.Ldflda, smBuilder.BuilderField);
-            il.Emit(OpCodes.Ldloc, boxedLocal);
-            il.Emit(OpCodes.Unbox, smBuilder.StateMachineType);
-            il.Emit(OpCodes.Call, smBuilder.GetBuilderStartMethod());
-
-            // return boxed.<>t__builder.Task
-            il.Emit(OpCodes.Ldloc, boxedLocal);
-            il.Emit(OpCodes.Unbox, smBuilder.StateMachineType);
-            il.Emit(OpCodes.Ldflda, smBuilder.BuilderField);
-            il.Emit(OpCodes.Call, smBuilder.GetBuilderTaskGetter());
-            il.Emit(OpCodes.Ret);
+            // This function defines async arrows that must share its boxed state machine.
+            // Box once and run the box via a verifiable ref (see helper for the #414 fix).
+            StateMachineEmitHelpers.EmitSelfBoxedStartAndReturnTask(
+                il,
+                smLocal,
+                smBuilder.StateMachineType,
+                smBuilder.SelfBoxedField,
+                smBuilder.BuilderField,
+                smBuilder.GetBuilderStartMethod(),
+                smBuilder.GetBuilderTaskGetter(),
+                _types);
         }
         else
         {

--- a/Compilation/StateMachineEmitHelpers.cs
+++ b/Compilation/StateMachineEmitHelpers.cs
@@ -141,6 +141,73 @@ public class StateMachineEmitHelpers
 
     #endregion
 
+    #region Self-Boxed State Machine Kickoff (#414)
+
+    // System.Runtime.CompilerServices.Unsafe.Unbox<T>(object) : ref T — a BCL helper
+    // (forwarded into CoreLib), so emitting a call to it keeps standalone DLLs free of a
+    // SharpTS.dll dependency. Resolved once, instantiated per state-machine type.
+    private static readonly MethodInfo UnsafeUnboxOpen =
+        typeof(System.Runtime.CompilerServices.Unsafe)
+            .GetMethod(nameof(System.Runtime.CompilerServices.Unsafe.Unbox),
+                       BindingFlags.Public | BindingFlags.Static)!;
+
+    /// <summary>
+    /// Emits the kickoff tail for an async state machine that pre-boxes itself so nested
+    /// async arrows can capture the one shared instance: box the SM once, record the box in
+    /// <paramref name="selfBoxedField"/>, run it via <paramref name="startMethod"/>, and
+    /// return its <c>builder.Task</c>.
+    ///
+    /// The naive form re-emits <c>unbox</c> per use, but <c>unbox</c> yields a
+    /// controlled-mutability managed pointer that ILVerify rejects when stored, used with
+    /// <c>ldflda</c>, or passed as a <c>ref</c> arg (#414: StackUnexpected on the kickoff).
+    /// <see cref="System.Runtime.CompilerServices.Unsafe.Unbox{T}"/> returns an ordinary
+    /// <c>ref T</c> instead, taken once into a byref local and reused — verifiable and a
+    /// single unbox at runtime. Stack: [] -&gt; [] (ends in <c>ret</c>).
+    /// </summary>
+    public static void EmitSelfBoxedStartAndReturnTask(
+        ILGenerator il,
+        LocalBuilder smLocal,
+        Type stateMachineType,
+        FieldInfo selfBoxedField,
+        FieldInfo builderField,
+        MethodInfo startMethod,
+        MethodInfo taskGetter,
+        TypeProvider types)
+    {
+        var unbox = UnsafeUnboxOpen.MakeGenericMethod(stateMachineType);
+
+        // object boxed = (object)sm;  (heap copy shared with nested arrows)
+        il.Emit(OpCodes.Ldloc, smLocal);
+        il.Emit(OpCodes.Box, stateMachineType);
+        var boxedLocal = il.DeclareLocal(types.Object);
+        il.Emit(OpCodes.Stloc, boxedLocal);
+
+        // ref TSM smRef = ref Unsafe.Unbox<TSM>(boxed);  (verifiable byref into the box)
+        il.Emit(OpCodes.Ldloc, boxedLocal);
+        il.Emit(OpCodes.Call, unbox);
+        var smRef = il.DeclareLocal(stateMachineType.MakeByRefType());
+        il.Emit(OpCodes.Stloc, smRef);
+
+        // smRef.<>__selfBoxed = boxed;
+        il.Emit(OpCodes.Ldloc, smRef);
+        il.Emit(OpCodes.Ldloc, boxedLocal);
+        il.Emit(OpCodes.Stfld, selfBoxedField);
+
+        // smRef.<>t__builder.Start(ref smRef);
+        il.Emit(OpCodes.Ldloc, smRef);
+        il.Emit(OpCodes.Ldflda, builderField);
+        il.Emit(OpCodes.Ldloc, smRef);
+        il.Emit(OpCodes.Call, startMethod);
+
+        // return smRef.<>t__builder.Task;
+        il.Emit(OpCodes.Ldloc, smRef);
+        il.Emit(OpCodes.Ldflda, builderField);
+        il.Emit(OpCodes.Call, taskGetter);
+        il.Emit(OpCodes.Ret);
+    }
+
+    #endregion
+
     #region Label Operations
 
     /// <summary>

--- a/SharpTS.Tests/CompilerTests/ILVerificationTests.cs
+++ b/SharpTS.Tests/CompilerTests/ILVerificationTests.cs
@@ -65,6 +65,76 @@ public class ILVerificationTests
         Assert.Equal("42\n", output);
     }
 
+    // ---- #414: async-arrow / generator spill across a suspension ----
+
+    [Fact]
+    public void AsyncFunctionContainingAsyncArrow_PassesILVerification()
+    {
+        // #414 Defect A: the self-boxed kickoff for an async function that defines an async
+        // arrow re-emitted `unbox` (a controlled-mutability managed pointer ILVerify rejects).
+        // The kickoff now takes a single verifiable `Unsafe.Unbox<T>` byref.
+        var source = """
+            async function m() {
+                const f = async () => { return 1; };
+                await f();
+            }
+            m();
+            """;
+
+        var errors = TestHarness.CompileAndVerifyOnly(source);
+
+        Assert.Empty(errors);
+    }
+
+    [Fact]
+    public void StandaloneAsyncArrowSpillAcrossAwait_PassesILVerification()
+    {
+        // #414 Defect B: a value spilled before an await in an async arrow. The await is of an
+        // inline `new Promise(...)`; awaiting a *function call* in an async arrow trips a
+        // separate pre-existing IL gap that would mask this one.
+        var source = """
+            const f = async () => {
+                const a = "A" + (await new Promise<number>(r => setTimeout(() => r(1), 5)));
+                const b = a + "B" + (await new Promise<number>(r => setTimeout(() => r(2), 3)));
+                console.log(b);
+            };
+            f();
+            """;
+
+        var errors = TestHarness.CompileAndVerifyOnly(source);
+
+        Assert.Empty(errors);
+    }
+
+    [Fact]
+    public void GeneratorSpillAcrossYield_PassesILVerification()
+    {
+        // #414 Defect E: a value spilled before a yield in a generator.
+        var source = """
+            function* g() { console.log("PFX:" + (yield 1) + "|" + (yield 2)); }
+            for (const x of g()) {}
+            """;
+
+        var errors = TestHarness.CompileAndVerifyOnly(source);
+
+        Assert.Empty(errors);
+    }
+
+    [Fact]
+    public void GeneratorSpillAcrossYieldStar_PassesILVerification()
+    {
+        // #414 Defect E: a value spilled before a yield* delegation.
+        var source = """
+            function* inner() { yield 1; yield 2; }
+            function* g() { console.log("PFX:" + (yield* inner())); }
+            for (const x of g()) {}
+            """;
+
+        var errors = TestHarness.CompileAndVerifyOnly(source);
+
+        Assert.Empty(errors);
+    }
+
     [Fact]
     public void Closures_PassesILVerification()
     {

--- a/SharpTS.Tests/SharedTests/AsyncArrowDeferredSpillTests.cs
+++ b/SharpTS.Tests/SharedTests/AsyncArrowDeferredSpillTests.cs
@@ -1,0 +1,107 @@
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests;
+
+/// <summary>
+/// Regression tests for #414: the async-<em>arrow</em> counterpart of #400. A value spilled
+/// before an <c>await</c> inside an async arrow and used after it must survive the suspension.
+/// Each await is a genuinely deferred promise (settled from a later event-loop turn via
+/// <c>setTimeout</c>), so the compiled arrow state machine actually re-enters MoveNext. Before
+/// the fix the spilled operand lived in an IL local that the re-entry wiped, so the compiler
+/// dropped the prefix (printing only the suffix). Two arrow forms are covered: nested inside an
+/// async function, and a standalone top-level arrow. Runs against both interpreter and compiler.
+///
+/// The awaited expression is an inline <c>new Promise(...)</c> rather than a call to a helper:
+/// awaiting a <em>function call</em> inside an async arrow currently emits separately-invalid
+/// IL (a pre-existing gap, unrelated to spills), which would muddy these spill regressions.
+/// </summary>
+public class AsyncArrowDeferredSpillTests
+{
+    // An inline deferred promise (settles from a later event-loop turn).
+    private static string Defer(object v, int ms)
+        => $"new Promise<number>(r => setTimeout(() => r({v}), {ms}))";
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void NestedArrow_BinaryConcat_PrefixSurvivesDeferredAwait(ExecutionMode mode)
+    {
+        // The exact shape from the issue.
+        var source = $$"""
+            async function m() {
+              const f = async () => { console.log("z" + (await {{Defer(1, 5)}})); };
+              await f();
+            }
+            m();
+            """;
+        Assert.Equal("z1\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void StandaloneArrow_BinaryConcat_PrefixSurvivesDeferredAwait(ExecutionMode mode)
+    {
+        var source = $$"""
+            const f = async () => { console.log("z" + (await {{Defer(1, 5)}})); };
+            f();
+            """;
+        Assert.Equal("z1\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void StandaloneArrow_TwoDeferredAwaits(ExecutionMode mode)
+    {
+        var source = $$"""
+            const f = async () => {
+              const a = "A" + (await {{Defer(1, 5)}});
+              const b = a + "B" + (await {{Defer(2, 3)}});
+              console.log(b);
+            };
+            f();
+            """;
+        Assert.Equal("A1B2\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void StandaloneArrow_TemplateLiteral_DeferredAwaits(ExecutionMode mode)
+    {
+        var source = $$"""
+            const f = async () => { console.log(`v=${"q"}-${await {{Defer(5, 5)}}}-${await {{Defer(6, 3)}}}`); };
+            f();
+            """;
+        Assert.Equal("v=q-5-6\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void StandaloneArrow_ArrayAndObject_DeferredAwaits(ExecutionMode mode)
+    {
+        var source = $$"""
+            const f = async () => {
+              const a = ["x", await {{Defer(1, 5)}}, "y"];
+              const o = { k: "z" + (await {{Defer(2, 3)}}) };
+              console.log(a.join(","), o.k);
+            };
+            f();
+            """;
+        Assert.Equal("x,1,y z2\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void NestedArrow_CapturesOuterLocalAndSpillsAcrossAwait(ExecutionMode mode)
+    {
+        // Arrow captures an outer local (prefix) AND spills it across the await.
+        var source = $$"""
+            async function m() {
+              const prefix = "PRE";
+              const f = async () => { console.log(prefix + "-" + (await {{Defer(7, 5)}})); };
+              await f();
+            }
+            m();
+            """;
+        Assert.Equal("PRE-7\n", TestHarness.Run(source, mode));
+    }
+}

--- a/SharpTS.Tests/SharedTests/GeneratorYieldSpillTests.cs
+++ b/SharpTS.Tests/SharedTests/GeneratorYieldSpillTests.cs
@@ -1,0 +1,67 @@
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests;
+
+/// <summary>
+/// Regression tests for #414: a value spilled before a <c>yield</c> (or <c>yield*</c>) and
+/// used after it must survive the generator's MoveNext re-entry. Before the fix the spilled
+/// operand lived in an IL local that the re-entry wiped, so the compiler replaced the prefix
+/// with a garbage value (e.g. <c>"a" + (yield "b")</c> resumed to <c>"0"</c> instead of
+/// <c>"a…"</c>). The fix mirrors live spill locals to state-machine fields at the yield and
+/// restores them on resume.
+///
+/// These assert the spilled prefix is <em>present</em> rather than the exact line, because the
+/// value a resumed <c>yield</c> expression evaluates to differs between modes (interpreter:
+/// <c>undefined</c>; compiler: <c>null</c>) — a separate, pre-existing gap (compiled generators
+/// don't thread <c>.next(arg)</c> / the JS <c>undefined</c> sentinel back into the yield
+/// expression). The prefix-survival is what #414 fixes and is identical across modes.
+/// </summary>
+public class GeneratorYieldSpillTests
+{
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void BinaryConcat_PrefixSurvivesYield(ExecutionMode mode)
+    {
+        var source = """
+            function* g() { console.log("PFX:" + (yield 1)); }
+            for (const x of g()) {}
+            """;
+        // Pre-fix compiled output was "0" (prefix lost). The prefix must now be present.
+        Assert.StartsWith("PFX:", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void MultipleYields_PrefixSurvives(ExecutionMode mode)
+    {
+        var source = """
+            function* g() { console.log("TAG:" + (yield 1) + "|" + (yield 2)); }
+            for (const x of g()) {}
+            """;
+        Assert.Contains("TAG:", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void TemplateLiteral_PrefixSurvivesYield(ExecutionMode mode)
+    {
+        var source = """
+            function* g() { console.log(`[${"head"}-${yield 1}]`); }
+            for (const x of g()) {}
+            """;
+        Assert.Contains("[head-", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void YieldStar_PrefixSurvivesDelegation(ExecutionMode mode)
+    {
+        var source = """
+            function* inner() { yield 1; yield 2; }
+            function* g() { console.log("PFX:" + (yield* inner())); }
+            for (const x of g()) {}
+            """;
+        Assert.StartsWith("PFX:", TestHarness.Run(source, mode));
+    }
+}


### PR DESCRIPTION
Closes #414.

## Problem

In compiled mode, the repro from #414 —
```ts
async function m() {
  const f = async () => { console.log("z" + (await new Promise<number>(r => setTimeout(() => r(1), 5)))); };
  await f();
}
m();
```
— failed `--verify` with `StackUnexpected` and printed `1` instead of `z1`. Triage found this is **two** independent defects (plus the analogous generator case):

1. **Unverifiable self-boxed kickoff.** An async function/arrow that *contains* an async arrow pre-boxes its state machine so the arrow can capture the one shared instance. The kickoff re-emitted `unbox` per use (4×), and `unbox` yields a *controlled-mutability managed pointer* that ILVerify rejects when stored / used with `ldflda` / passed as a `ref` arg — the 4 `StackUnexpected` errors. (Present whenever an async fn defines an async arrow, independent of any spill; the IL still ran on the JIT.)

2. **Spill loss across `await` in an async arrow.** The #400 persistent-spill mechanism (mirror live spill locals to state-machine fields across a suspension, since only fields survive a MoveNext re-entry) was wired only into the regular async-function emitter, so `"z"` was lost in the arrow.

3. **Spill loss across `yield` / `yield*` in a generator** — the same mechanism was missing for generators (`"a" + (yield "b")` resumed to `"0"`).

## Fix

1. **`StateMachineEmitHelpers.EmitSelfBoxedStartAndReturnTask`** consolidates the two duplicated kickoff sites (`ILCompiler.Async.cs`, `AsyncArrowStateMachineBuilder.cs`) and takes a single verifiable `System.Runtime.CompilerServices.Unsafe.Unbox<T>` byref instead of re-`unbox`ing. `Unsafe` is a BCL helper (forwarded into CoreLib), so standalone DLLs stay free of a SharpTS.dll dependency.

2. **Async arrows:** enable persistent spills in `AsyncArrowMoveNextEmitter` and persist/rehydrate at its await point (mirrors `AsyncMoveNextEmitter`). This exposed an ordering bug — standalone async arrows were `CreateType()`'d in the `EmitAsyncStateMachineBodies` finalization loop *before* `EmitTopLevelAsyncArrowBodies` emitted their MoveNext, freezing the type before the spill field could be defined; standalone arrows are now finalized only after their MoveNext.

3. **Generators:** enable persistent spills in `GeneratorMoveNextEmitter` and persist/rehydrate across `yield` and `yield*` (the latter persists before its loop-top resume label so the field is valid on the first fall-through too).

## Tests

- `AsyncArrowDeferredSpillTests` and `GeneratorYieldSpillTests` (both interpreter and compiler), covering nested/standalone arrows, multi-await, template/array/object spills, capture+spill, and yield/yield*.
- Four IL-verification facts in `ILVerificationTests`.
- Full suite: **11354 pass, 0 fail.**

## Out of scope — filed separately

Triage surfaced several pre-existing, unrelated gaps (all verify-only / JIT-runnable except #430). Filed rather than fixed here to keep this change focused:

- #441 — awaiting a function-call result inside an async arrow emits invalid IL (arrow-specific).
- #442 — `new Promise(executor)` inside a function body fails `--verify`.
- #443 — compiled generator: a resumed `yield` evaluates to `null` instead of `undefined`.
- Commented on #430 (compiled async-generator `await` consumption) with a broader no-output variant.