### PR TITLE
Fix #399: compiled arrow inside a plain function used as constructor mis-captures `this`

### DIFF
--- a/Compilation/ILEmitter.Calls.Closures.cs
+++ b/Compilation/ILEmitter.Calls.Closures.cs
@@ -363,29 +363,22 @@ public partial class ILEmitter
             // Load the captured variable's current value
             if (capturedVar == "this")
             {
-                // Arrow-spec semantics: `this` is lexically captured from the enclosing
-                // non-arrow scope. When THIS arrow's own display class already has a
-                // captured `this` field (i.e. we're inside a parent arrow's body and the
-                // parent captured the class's `this`), propagate it from there. Don't use
-                // bare Ldarg_0 in that case — inside an arrow-body the arg0 slot is the
-                // display class instance itself, not the enclosing class's `this`, and
-                // passing the DC into a nested arrow caused InvalidCastException /
-                // NullReferenceException at use sites (minimatch's
-                // `.map(s => s.map(ss => this.parse(ss)))` hit this).
-                if (_ctx.CapturedFields != null && _ctx.CapturedFields.TryGetValue("this", out var outerThisField))
-                {
-                    IL.Emit(OpCodes.Ldarg_0);
-                    IL.Emit(OpCodes.Ldfld, outerThisField);
-                }
-                else if (_ctx.IsInstanceMethod)
-                {
-                    // Direct class-method body: Ldarg_0 IS the enclosing instance.
-                    IL.Emit(OpCodes.Ldarg_0);
-                }
-                else
-                {
-                    IL.Emit(OpCodes.Ldnull);
-                }
+                // `this` is lexically captured from the enclosing non-arrow scope.
+                // Snapshot it via the shared resolver so the capture matches a bare
+                // `this` read in this same enclosing body — every context shape is
+                // handled identically:
+                //   - parent arrow body that captured `this` → load from the $DisplayClass field
+                //   - object-method-shorthand arrow (`__this`) → the __this parameter
+                //   - direct class-method body                → Ldarg_0
+                //   - static-constructor context              → the class Type
+                //   - plain function invoked via `new`        → thread-local set by NewOnFunction
+                // The previous hand-rolled subset here only handled the first two
+                // shapes and fell back to Ldnull, so an arrow nested in a plain
+                // `function` used as a constructor captured `this == null` (#399).
+                // Routing through LoadThis() also picks up the minimatch
+                // `.map(s => s.map(ss => this.parse(ss)))` chain (case 1 fires for the
+                // parent arrow; class-method arg0 for the outermost).
+                _resolver.LoadThis();
             }
             else if (_ctx.TryGetParameter(capturedVar, out var argIndex))
             {

--- a/SharpTS.Tests/SharedTests/ObjectFeatureTests.cs
+++ b/SharpTS.Tests/SharedTests/ObjectFeatureTests.cs
@@ -588,6 +588,117 @@ public class ObjectFeatureTests
 
     [Theory]
     [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Function_New_ArrowCapturesConstructedThis_DirectNew(ExecutionMode mode)
+    {
+        // #399: an arrow declared inside a plain `function` invoked with `new` must
+        // lexically capture the freshly-constructed `this`. In compiled mode the
+        // arrow's captured-`this` field was populated by a hand-rolled subset of the
+        // `this`-resolution chain that fell back to Ldnull for plain function bodies
+        // (which resolve `this` via the NewOnFunction thread-local), so the arrow saw
+        // `this == null`. The fix routes the capture through the shared LoadThis().
+        var source = """
+            function Cap(this: any, cb: () => void) {
+                this.tag = 'cap';
+                const arrow = () => { console.log('arrow: ' + this.tag); };
+                arrow();
+            }
+            new (Cap as any)(() => {});
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("arrow: cap\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Function_New_ArrowCapturesConstructedThis_DynamicNewViaValue(ExecutionMode mode)
+    {
+        // #399, dynamic-new form: the callee is a runtime value (`new C(...)`), so the
+        // compiled path goes through NewOnFunction. The nested arrow must still capture
+        // the constructed `this`.
+        var source = """
+            function Cap(this: any, cb: () => void) {
+                this.tag = 'cap';
+                const arrow = () => { console.log('arrow: ' + this.tag); };
+                arrow();
+            }
+            const C: any = Cap;
+            new C(() => {});
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("arrow: cap\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Function_New_NestedArrowsCaptureConstructedThis(ExecutionMode mode)
+    {
+        // #399, deep nesting: an arrow inside an arrow inside a function-as-constructor.
+        // The inner arrow's `this` propagates as a capture up through the outer arrow,
+        // so the outer arrow's display class carries `this` and the inner reads it from
+        // that field — the function body's snapshot of `this` must be the real instance.
+        var source = """
+            function Cap(this: any) {
+                this.tag = 'deep';
+                const outer = () => {
+                    const inner = () => 'inner: ' + this.tag;
+                    return inner();
+                };
+                console.log(outer());
+            }
+            new (Cap as any)();
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("inner: deep\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Function_New_ArrowOnInstanceEscapesAndKeepsThis(ExecutionMode mode)
+    {
+        // #399, escaping arrow: the arrow is stored on the instance and invoked AFTER
+        // the constructor activation returns. Because `this` is snapshotted into the
+        // arrow's display class at creation time, the captured instance must survive.
+        var source = """
+            function Make(this: any, v: string) {
+                this.v = v;
+                this.get = () => 'escaped: ' + this.v;
+            }
+            const o: any = new (Make as any)('X');
+            console.log(o.get());
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("escaped: X\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Function_New_ClassMethodArrowThis_StillWorks(ExecutionMode mode)
+    {
+        // #399 regression guard: routing captured-`this` through LoadThis() must not
+        // disturb the class-method-arrow path (the minimatch
+        // `.map(row => row.map(ss => this.x))` chain). Here the outermost capture
+        // resolves to the class method's arg0; the nested arrow reads it from the
+        // outer arrow's captured-`this` field.
+        var source = """
+            class Parser {
+                prefix = 'P:';
+                parseAll(items: string[][]): string {
+                    return items.map(row => row.map(s => this.prefix + s).join(',')).join(' | ');
+                }
+            }
+            console.log(new Parser().parseAll([['a', 'b'], ['c']]));
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("P:a,P:b | P:c\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void Function_Call_RoutesPropertyWritesToTarget(ExecutionMode mode)
     {
         // `Fn.call(target, ...)` must mutate `target`. Compiled path needed


### PR DESCRIPTION
## What & why

Closes #399. In **compiled mode**, an arrow declared inside a plain `function` invoked with `new` captured `this == null` instead of the freshly-constructed instance. The interpreter was already correct.

```ts
function Cap(this: any, cb: () => void) {
  this.tag = "cap";
  const arrow = () => { console.log("arrow: this.tag=" + this.tag); };
  arrow();
}
new (Cap as any)(() => {});   // compiled printed "...=null"; now "...=cap"
```

## Root cause

An arrow's captured `this` is snapshotted into its display-class field at the arrow's **creation site** (inside the enclosing function body). The population code in `EmitDisplayInstanceFieldPopulation` (`Compilation/ILEmitter.Calls.Closures.cs`) hand-rolled only a **partial subset** of the `this`-resolution chain:

- ✅ parent-arrow body that captured `this` → load from `$DisplayClass` field
- ✅ class instance-method body → `Ldarg_0`
- ❌ **everything else → `Ldnull`**

A plain function body resolves `this` via the thread-local that `$Runtime.NewOnFunction` sets before invoking the constructor (`LocalVariableResolver.LoadThis()` step 5). The hand-rolled fallback never consulted it, so the arrow snapshotted `null`.

## Fix

Route the captured-`this` snapshot through the shared `_resolver.LoadThis()` — the **exact** path a bare `this` read uses in the same body. This handles every enclosing-context shape uniformly (parent-arrow DC field, `__this` param, class-method `arg0`, static-ctor class `Type`, and the `NewOnFunction` thread-local) and **removes the divergent duplicate logic** (net −23/+? lines in the branch). No new runtime state; a snapshot of `this` at creation time is semantically correct because a function activation's `this` never changes.

## Testing

- 5 new theories in `ObjectFeatureTests` (run **both** interpreted + compiled, interpreter as oracle): direct `new`, dynamic `new` via value, nested arrows, an arrow escaping on the instance and called after the activation returns, and a class-method nested-map regression guard (the minimatch `.map(row => row.map(ss => this.x))` shape).
- `--verify` passes on the repro (valid IL).
- Full suite: **11385 passed, 0 failed**.

## Filed along the way (pre-existing, orthogonal — not addressed here)

- #445 — compiled: a function with a typed-array parameter (`T[]`) emits unverifiable IL (`StackUnexpected`) at call sites (benign at runtime).
- #446 — interpreted: `new F()` where `F` returns a function yields `this` instead of the returned function (compiled is already correct).
