### PR TITLE
Fix #355: compiled pipeTo observes event-loop-driven mid-pipe AbortSignal

### DIFF
--- a/Compilation/RuntimeEmitter.ReadableStream.cs
+++ b/Compilation/RuntimeEmitter.ReadableStream.cs
@@ -1059,6 +1059,21 @@ public partial class RuntimeEmitter
 
         il.MarkLabel(loopTop);
 
+        // #355: When a signal is present, drive the event loop one tick at the
+        // top of each iteration — BEFORE the abort check below — so an abort
+        // delivered through the event loop actually fires. The pump is a
+        // synchronous blocking loop (each Read()/Write() is GetAwaiter().GetResult()'d
+        // on this thread), so without this the main thread never yields and a
+        // mid-pipe `setTimeout(() => ac.abort(), 0)` callback can't run: only a
+        // signal already aborted when a read is reached would ever be observed.
+        // $Runtime.ProcessPendingTimers — the same routine $EventLoop.Run()/
+        // WaitForTask invoke — drains microtasks and fires due timers, so this
+        // also covers a microtask-driven abort (`Promise.resolve().then(() => ac.abort())`).
+        // Scoped to the signal path: non-aborting pipes keep their existing
+        // ordering and pay nothing. All references are same-DLL emitted types,
+        // so the pure-IL stream stays standalone (no SharpTS.dll dependency).
+        EmitPumpEventLoopForSignal(il, signalLocal, runtime);
+
         // Per-iteration signal check. If signal != null AND signal.aborted,
         // call writer.abort(reason) + source.cancel(reason), then throw so
         // the PipeTo task is rejected.
@@ -1280,6 +1295,38 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloca, awaiterLocal);
         il.Emit(OpCodes.Call, _types.GetMethodNoParams(_types.TaskAwaiterOfObject, "GetResult"));
         // Stack: [object]
+    }
+
+    /// <summary>
+    /// Emits a one-tick drive of the emitted event loop for the <c>PipeTo</c>
+    /// pump so an event-loop-driven mid-pipe <c>AbortSignal</c> can fire while
+    /// the synchronous pump holds the main thread (#355).
+    /// </summary>
+    /// <remarks>
+    /// Emits the equivalent of:
+    /// <code>
+    /// if (signal != null) $Runtime.ProcessPendingTimers();  // drains microtasks + fires due timers
+    /// </code>
+    /// <c>ProcessPendingTimers</c> self-initializes (so it's safe even when no
+    /// timer was ever scheduled — the no-timer case still drains the microtask
+    /// queue, covering a <c>Promise.then()</c>-driven abort) and is the same
+    /// routine <c>$EventLoop.Run()</c>/<c>WaitForTask</c> invoke. Stack on
+    /// entry/exit: empty. References only same-DLL emitted <c>$Runtime</c>, so
+    /// the pure-IL stream stays standalone (no SharpTS.dll dependency).
+    /// </remarks>
+    private void EmitPumpEventLoopForSignal(ILGenerator il, LocalBuilder signalLocal, EmittedRuntime runtime)
+    {
+        var skipLabel = il.DefineLabel();
+
+        // if (signal == null) skip — keep the pump cost on the signal path only.
+        il.Emit(OpCodes.Ldloc, signalLocal);
+        il.Emit(OpCodes.Brfalse, skipLabel);
+
+        // $Runtime.ProcessPendingTimers() → int ms-until-next-timer (discarded).
+        il.Emit(OpCodes.Call, runtime.ProcessPendingTimers);
+        il.Emit(OpCodes.Pop);
+
+        il.MarkLabel(skipLabel);
     }
 
     /// <summary>

--- a/SharpTS.Tests/SharedTests/BuiltInModules/StreamsWebSemanticTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/StreamsWebSemanticTests.cs
@@ -351,16 +351,21 @@ public class StreamsWebSemanticTests
     /// flushed "source-canceled". Fixed in #325 — the pump now Refs the event
     /// loop for the duration of the teardown sequence (see
     /// <c>WebStreamsHelpers.PipeTo</c>), then Unrefs. Compiled-mode
-    /// <c>$ReadableStream.PipeTo</c> does extract the signal and check
-    /// <c>aborted</c> per iteration, but its pump sync-awaits each read on the
-    /// calling thread, so an event-loop-driven mid-pipe abort (the
-    /// <c>setTimeout(() => ac.abort())</c> here) never gets a chance to fire —
-    /// the abort is only observed for signals already aborted when a read is
-    /// reached (#355). So this stays InterpretedOnly.
+    /// <c>$ReadableStream.PipeTo</c> extracts the signal and checks
+    /// <c>aborted</c> per iteration, and as of #355 also drives the event-loop
+    /// timer processor once per iteration when a signal is present (see
+    /// <c>RuntimeEmitter.EmitPumpEventLoopForSignal</c>), so the
+    /// <c>setTimeout(() => ac.abort())</c> here actually fires mid-pipe rather
+    /// than being starved by the synchronous pump. The deterministic
+    /// compiled-mode coverage for that fix is
+    /// <see cref="ReadableStream_PipeTo_MidPipeAbortSignal_Compiled"/>; this
+    /// guest test stays InterpretedOnly only because its end-to-end assertion
+    /// flakes under CI load in interpreter mode (real thread-pool continuation
+    /// timing) — the compiled variant runs synchronously and is deterministic.
     ///
     /// This guest-level test asserts the end-to-end behavior but only flakes
-    /// under load; the deterministic regression guard for the fix itself is
-    /// <see cref="PipeTo_MidPipeAbort_RefsEventLoopAcrossTeardown"/>.
+    /// under load; the deterministic regression guard for the interpreter fix
+    /// itself is <see cref="PipeTo_MidPipeAbort_RefsEventLoopAcrossTeardown"/>.
     /// </remarks>
     [Theory]
     [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
@@ -702,6 +707,63 @@ public class StreamsWebSemanticTests
                         await source.pipeTo(dest, { signal: ac.signal });
                         console.log("pipe-completed-normally");
                     } catch {
+                        console.log("pipe-rejected");
+                    }
+                }
+                run();
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Contains("dest-aborted", output);
+        Assert.Contains("source-canceled", output);
+        Assert.Contains("pipe-rejected", output);
+        Assert.DoesNotContain("pipe-completed-normally", output);
+    }
+
+    /// <summary>
+    /// #355: a mid-pipe abort delivered through the event loop
+    /// (<c>setTimeout(() =&gt; ac.abort(), 0)</c>) must abort the destination,
+    /// cancel the source, and reject the pipe — even though the compiled pump
+    /// is a synchronous blocking loop.
+    /// </summary>
+    /// <remarks>
+    /// Compiled-mode only, and deterministic here. The source is an infinite
+    /// synchronous-pull stream, so before the fix the sync pump spun forever
+    /// reading chunks and the abort timer never got a chance to run (the whole
+    /// test would hang to the harness timeout). The fix drives the event-loop
+    /// timer processor once per pump iteration when a signal is present (see
+    /// <c>RuntimeEmitter.EmitPumpEventLoopForSignal</c>), so the
+    /// <c>setTimeout(0)</c> callback fires on the first iteration, mutates the
+    /// signal, and the existing per-iteration <c>aborted</c> check runs the
+    /// abort/cancel/reject teardown. Unlike the interpreter variant
+    /// (<see cref="ReadableStream_PipeTo_AbortSignalCancelsSourceAndAbortsDest"/>),
+    /// the entire sequence runs synchronously on the main thread, so there is
+    /// no thread-pool continuation race and the assertion is load-independent.
+    /// </remarks>
+    [Theory]
+    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    public void ReadableStream_PipeTo_MidPipeAbortSignal_Compiled(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                let i = 0;
+                const source = new ReadableStream({
+                    pull(c) { c.enqueue(i++); },
+                    cancel(reason) { console.log("source-canceled"); }
+                });
+                const dest = new WritableStream({
+                    write(chunk) { /* accept everything */ },
+                    abort(reason) { console.log("dest-aborted"); }
+                });
+                const ac = new AbortController();
+                setTimeout(() => ac.abort(), 0);
+                async function run() {
+                    try {
+                        await source.pipeTo(dest, { signal: ac.signal });
+                        console.log("pipe-completed-normally");
+                    } catch (e) {
                         console.log("pipe-rejected");
                     }
                 }


### PR DESCRIPTION
## Summary
Closes #355. Compiled-mode `$ReadableStream.PipeTo` (`Compilation/RuntimeEmitter.ReadableStream.cs`, `EmitReadableStreamPipeTo`) runs a **synchronous** pump — each `Read()`/`Write()` is `GetAwaiter().GetResult()`'d on the calling thread. That blocks the main thread between reads, so a mid-pipe abort delivered through the event loop (`setTimeout(() => ac.abort(), 0)`) could never fire: the timer callback can't run while the pump holds the thread. Compiled mode therefore honored a *pre-aborted* signal but silently ignored an *async mid-pipe* abort — and an infinite synchronous-pull source piped with such a signal would hang forever.

## Fix
When a signal is present, drive `$Runtime.ProcessPendingTimers` once at the **top of each pump iteration, before** the existing per-iteration `aborted` check (new `EmitPumpEventLoopForSignal` helper). `ProcessPendingTimers` is the same routine `$EventLoop.Run()`/`WaitForTask` invoke: it drains the microtask queue and fires due timers, and self-initializes so it's safe even when no timer was ever scheduled. A `setTimeout(0)` abort is immediately due, so it fires on the first iteration, `ac.abort()` mutates the signal in place, and the existing check observes it and runs the abort/cancel/reject teardown. Because it drains microtasks too, a `Promise.resolve().then(() => ac.abort())` abort is covered as well.

- **Scoped to the signal path** — non-aborting pipes (incl. `pipeThrough`/transform) keep their exact existing ordering and pay only a null check per iteration.
- **Standalone preserved** — references only same-DLL emitted `$Runtime`; the compiled streams DLL records no `RequireSharpTSRuntime` reason and does not co-locate SharpTS.dll. Verified by running a standalone compiled repro with SharpTS.dll absent.

## Tests
- New deterministic `ReadableStream_PipeTo_MidPipeAbortSignal_Compiled` (CompiledOnly): infinite sync source + `setTimeout(0)` abort. Asserts `dest-aborted` / `source-canceled` / `pipe-rejected`. Without the fix this hangs to the harness timeout, so it's a real regression guard; with the fix it runs synchronously and deterministically (no thread-pool race like the interpreter variant).
- Refreshed the remarks on the (still `InterpretedOnly`, load-flaky) guest test `ReadableStream_PipeTo_AbortSignalCancelsSourceAndAbortsDest`.
- Full suite green: **11362 passed, 0 failed, 0 skipped**.

## Follow-up filed
- #448 — residual sync-pump limitation: a push-style source whose chunks (or whose *delayed* abort) arrive via the event loop still deadlocks the compiled pump, because the `Read()` itself blocks. The durable fix is a cooperative/async pump, as noted in #355.