### PR TITLE
Fix #357: member-access increment emits StackUnderflow IL in async/generator bodies

### DIFF
--- a/Compilation/ExpressionEmitterBase.Operators.cs
+++ b/Compilation/ExpressionEmitterBase.Operators.cs
@@ -177,7 +177,43 @@ public abstract partial class ExpressionEmitterBase
             // Dup new value (expression result), then store
             IL.Emit(OpCodes.Dup);
             EmitStoreVariable(name);
+            SetStackUnknown();
+            return;
         }
+
+        // ++obj.prop — read via GetProperty, write via SetProperty. The synchronous ILEmitter
+        // overrides handle Get/GetIndex operands; without this arm the base (used by every
+        // state-machine MoveNext) emitted nothing and the surrounding statement underflowed the
+        // stack (#357).
+        if (pi.Operand is Expr.Get get)
+        {
+            // Class.field++ on a static data field needs the own/inherited shadow handling so the
+            // write lands on the storage the static-typed read consults (#339) — the generic
+            // GetProperty/SetProperty path below would desync with the Ldsfld read.
+            if (TryEmitStaticFieldIncrement(get, isPrefix: true, pi.Operator.Type))
+                return;
+
+            var objLocal = SpillBoxed(get.Object);
+            EmitMemberAccessIncrement(
+                isPrefix: true, pi.Operator.Type, objLocal,
+                emitKey: () => IL.Emit(OpCodes.Ldstr, get.Name.Lexeme),
+                Ctx.Runtime!.GetProperty, Ctx.Runtime!.SetProperty);
+            return;
+        }
+
+        // ++arr[i] — read via GetIndex, write via SetIndex.
+        if (pi.Operand is Expr.GetIndex gi)
+        {
+            var objLocal = SpillBoxed(gi.Object);
+            var indexLocal = SpillBoxed(gi.Index);
+            EmitMemberAccessIncrement(
+                isPrefix: true, pi.Operator.Type, objLocal,
+                emitKey: () => IL.Emit(OpCodes.Ldloc, indexLocal),
+                Ctx.Runtime!.GetIndex, Ctx.Runtime!.SetIndex);
+            return;
+        }
+
+        // Unknown operand — keep the stack state defined for the verifier.
         SetStackUnknown();
     }
 
@@ -204,8 +240,164 @@ public abstract partial class ExpressionEmitterBase
 
             // Store incremented value (original remains on stack)
             EmitStoreVariable(name);
+            SetStackUnknown();
+            return;
         }
+
+        // obj.prop++ — read via GetProperty, write via SetProperty (mirrors ++obj.prop; see #357).
+        if (poi.Operand is Expr.Get get)
+        {
+            // Class.field++ on a static data field — own/inherited shadow handling (#339); see prefix.
+            if (TryEmitStaticFieldIncrement(get, isPrefix: false, poi.Operator.Type))
+                return;
+
+            var objLocal = SpillBoxed(get.Object);
+            EmitMemberAccessIncrement(
+                isPrefix: false, poi.Operator.Type, objLocal,
+                emitKey: () => IL.Emit(OpCodes.Ldstr, get.Name.Lexeme),
+                Ctx.Runtime!.GetProperty, Ctx.Runtime!.SetProperty);
+            return;
+        }
+
+        // arr[i]++ — read via GetIndex, write via SetIndex.
+        if (poi.Operand is Expr.GetIndex gi)
+        {
+            var objLocal = SpillBoxed(gi.Object);
+            var indexLocal = SpillBoxed(gi.Index);
+            EmitMemberAccessIncrement(
+                isPrefix: false, poi.Operator.Type, objLocal,
+                emitKey: () => IL.Emit(OpCodes.Ldloc, indexLocal),
+                Ctx.Runtime!.GetIndex, Ctx.Runtime!.SetIndex);
+            return;
+        }
+
+        // Unknown operand — keep the stack state defined for the verifier.
         SetStackUnknown();
+    }
+
+    /// <summary>
+    /// Emits <c>++</c>/<c>--</c> for a member-access operand (<c>obj.prop</c> or <c>arr[i]</c>) in
+    /// a state-machine body. The receiver (and index) must already be spilled into <paramref name="objLocal"/>
+    /// (and captured by <paramref name="emitKey"/>) via <see cref="SpillBoxed"/>, so any await/yield inside
+    /// them has already suspended with an empty stack and is evaluated exactly once; from here the
+    /// read → ToNumber → write sequence is straight-line with no suspension point, so plain locals suffice.
+    /// <paramref name="emitKey"/> pushes the property name (Ldstr) or index local (Ldloc) and is invoked
+    /// once for the read and once for the write. <paramref name="isPrefix"/> selects the result: prefix
+    /// returns the new value, postfix the ToNumber-coerced original (ECMA-262 §13.4).
+    /// </summary>
+    private void EmitMemberAccessIncrement(
+        bool isPrefix, TokenType op, LocalBuilder objLocal, Action emitKey,
+        MethodBuilder getMethod, MethodBuilder setMethod)
+    {
+        double delta = op == TokenType.PLUS_PLUS ? 1.0 : -1.0;
+
+        // Read current value and coerce to a number (undefined→NaN, never throws — #190).
+        IL.Emit(OpCodes.Ldloc, objLocal);
+        emitKey();
+        IL.Emit(OpCodes.Call, getMethod);
+        IL.Emit(OpCodes.Call, Ctx.Runtime?.ConvertToNumber ?? Types.ConvertToDoubleFromObject);
+
+        var newValue = IL.DeclareLocal(typeof(object));
+        var resultValue = IL.DeclareLocal(typeof(object));
+        EmitIncrementComputeStoreResult(isPrefix, delta, newValue, resultValue);
+
+        // Write the incremented value back to the same member.
+        IL.Emit(OpCodes.Ldloc, objLocal);
+        emitKey();
+        IL.Emit(OpCodes.Ldloc, newValue);
+        IL.Emit(OpCodes.Call, setMethod);
+
+        IL.Emit(OpCodes.Ldloc, resultValue);
+        SetStackUnknown();
+    }
+
+    /// <summary>
+    /// Given the current numeric value on the stack as an unboxed <c>double</c>, computes the
+    /// incremented value and stores two boxed locals: <paramref name="newValue"/> (to write back)
+    /// and <paramref name="resultValue"/> (what the expression evaluates to — the new value for
+    /// prefix, the ToNumber-coerced original for postfix). Consumes the stack value.
+    /// </summary>
+    private void EmitIncrementComputeStoreResult(
+        bool isPrefix, double delta, LocalBuilder newValue, LocalBuilder resultValue)
+    {
+        if (isPrefix)
+        {
+            // Stack: [current:double] → compute new, return it.
+            IL.Emit(OpCodes.Ldc_R8, delta);
+            IL.Emit(OpCodes.Add);
+            IL.Emit(OpCodes.Box, typeof(double));
+            IL.Emit(OpCodes.Dup);
+            IL.Emit(OpCodes.Stloc, newValue);
+            IL.Emit(OpCodes.Stloc, resultValue);
+        }
+        else
+        {
+            // Stack: [current:double] → stash the coerced original as the result, then compute new.
+            IL.Emit(OpCodes.Dup);
+            IL.Emit(OpCodes.Box, typeof(double));
+            IL.Emit(OpCodes.Stloc, resultValue);
+            IL.Emit(OpCodes.Ldc_R8, delta);
+            IL.Emit(OpCodes.Add);
+            IL.Emit(OpCodes.Box, typeof(double));
+            IL.Emit(OpCodes.Stloc, newValue);
+        }
+    }
+
+    /// <summary>
+    /// Emits <c>++</c>/<c>--</c> on a class's static data field accessed as <c>Class.field</c>.
+    /// Returns false (emitting nothing) when <paramref name="get"/> is not a known class's static
+    /// data field, so callers fall through to the generic property path. Mirrors the own/inherited
+    /// shadow handling of <see cref="EmitCompoundSet"/> (#339): an own field is read and written
+    /// directly; an inherited field is read shadow-or-base and the result written as a per-subclass
+    /// own shadow via SetProperty's Type arm (→ PDS). Binding here keeps the read and write on the
+    /// same storage as the static-typed <c>Ldsfld</c> read, which the generic dynamic path desyncs with.
+    /// </summary>
+    private bool TryEmitStaticFieldIncrement(Expr.Get get, bool isPrefix, TokenType op)
+    {
+        if (get.Object is not Expr.Variable classVar)
+            return false;
+        string resolvedClassName = Ctx.ResolveClassName(classVar.Name.Lexeme);
+        if (!Ctx.Classes.TryGetValue(resolvedClassName, out var classBuilder))
+            return false;
+
+        double delta = op == TokenType.PLUS_PLUS ? 1.0 : -1.0;
+        var newValue = IL.DeclareLocal(typeof(object));
+        var resultValue = IL.DeclareLocal(typeof(object));
+
+        // Own static data field — read+write the field directly (write side is own-only).
+        if (Ctx.ClassRegistry!.TryGetOwnCallableStaticField(resolvedClassName, get.Name.Lexeme, classBuilder, out var ownField))
+        {
+            IL.Emit(OpCodes.Ldsfld, ownField!);
+            IL.Emit(OpCodes.Call, Ctx.Runtime?.ConvertToNumber ?? Types.ConvertToDoubleFromObject);
+            EmitIncrementComputeStoreResult(isPrefix, delta, newValue, resultValue);
+
+            IL.Emit(OpCodes.Ldloc, newValue);
+            IL.Emit(OpCodes.Stsfld, ownField!);
+
+            IL.Emit(OpCodes.Ldloc, resultValue);
+            SetStackUnknown();
+            return true;
+        }
+
+        // Inherited static data field — read shadow-or-base, write a per-subclass own shadow (→ PDS).
+        if (Ctx.ClassRegistry!.TryGetCallableStaticField(resolvedClassName, get.Name.Lexeme, classBuilder, out var inheritedField))
+        {
+            EmitStaticFieldLoadWithShadow(resolvedClassName, classBuilder, get.Name.Lexeme, inheritedField!);
+            IL.Emit(OpCodes.Call, Ctx.Runtime?.ConvertToNumber ?? Types.ConvertToDoubleFromObject);
+            EmitIncrementComputeStoreResult(isPrefix, delta, newValue, resultValue);
+
+            IL.Emit(OpCodes.Ldtoken, classBuilder);
+            IL.Emit(OpCodes.Call, Types.TypeGetTypeFromHandle);
+            IL.Emit(OpCodes.Ldstr, get.Name.Lexeme);
+            IL.Emit(OpCodes.Ldloc, newValue);
+            IL.Emit(OpCodes.Call, Ctx.Runtime!.SetProperty);
+
+            IL.Emit(OpCodes.Ldloc, resultValue);
+            SetStackUnknown();
+            return true;
+        }
+
+        return false;
     }
 
     /// <summary>

--- a/SharpTS.Tests/CompilerTests/ILVerificationTests.cs
+++ b/SharpTS.Tests/CompilerTests/ILVerificationTests.cs
@@ -65,6 +65,134 @@ public class ILVerificationTests
         Assert.Equal("42\n", output);
     }
 
+    // #357: a member-access increment (obj.prop++ / ++obj.prop / arr[i]++ / --arr[i]) inside an
+    // async/generator body underflowed the state machine's MoveNext — the shared base emitter only
+    // handled Expr.Variable operands and emitted nothing for Expr.Get/Expr.GetIndex. These pin the
+    // four distinct state-machine emitter contexts (async function, generator, async arrow, async
+    // generator) plus both operand kinds (property and index).
+
+    [Fact]
+    public void AsyncFunctionPropertyIncrement_PassesILVerification()
+    {
+        var source = """
+            async function go(): Promise<void> {
+                const obj = { x: 1 };
+                const a = obj.x++;   // postfix returns the original
+                const b = ++obj.x;   // prefix returns the new value
+                console.log(a, b, obj.x);
+            }
+            go();
+            """;
+
+        var (errors, output) = TestHarness.CompileVerifyAndRun(source);
+
+        Assert.Empty(errors);
+        Assert.Equal("1 3 3\n", output);
+    }
+
+    [Fact]
+    public void AsyncFunctionIndexIncrement_PassesILVerification()
+    {
+        var source = """
+            async function go(): Promise<void> {
+                const arr = [5, 6];
+                const a = arr[0]++;  // postfix returns the original
+                const b = --arr[1];  // prefix decrement returns the new value
+                console.log(a, b, arr[0], arr[1]);
+            }
+            go();
+            """;
+
+        var (errors, output) = TestHarness.CompileVerifyAndRun(source);
+
+        Assert.Empty(errors);
+        Assert.Equal("5 5 6 5\n", output);
+    }
+
+    [Fact]
+    public void GeneratorMemberIncrement_PassesILVerification()
+    {
+        var source = """
+            function* gen(): Generator<number> {
+                const o = { n: 5 };
+                o.n++;
+                yield o.n;
+                yield --o.n;
+            }
+            const g = gen();
+            console.log(g.next().value, g.next().value);
+            """;
+
+        var (errors, output) = TestHarness.CompileVerifyAndRun(source);
+
+        Assert.Empty(errors);
+        Assert.Equal("6 5\n", output);
+    }
+
+    [Fact]
+    public void AsyncArrowMemberIncrement_PassesILVerification()
+    {
+        var source = """
+            const run = async (): Promise<void> => {
+                const o = { c: 41 };
+                console.log(++o.c, o.c);
+            };
+            run();
+            """;
+
+        var (errors, output) = TestHarness.CompileVerifyAndRun(source);
+
+        Assert.Empty(errors);
+        Assert.Equal("42 42\n", output);
+    }
+
+    [Fact]
+    public void AsyncGeneratorMemberIncrement_PassesILVerification()
+    {
+        var source = """
+            async function* agen(): AsyncGenerator<number> {
+                const arr = [100];
+                arr[0]++;
+                yield arr[0];
+            }
+            async function main(): Promise<void> {
+                const ag = agen();
+                console.log((await ag.next()).value);
+            }
+            main();
+            """;
+
+        var (errors, output) = TestHarness.CompileVerifyAndRun(source);
+
+        Assert.Empty(errors);
+        Assert.Equal("101\n", output);
+    }
+
+    [Fact]
+    public void AsyncStaticFieldIncrement_PassesILVerification()
+    {
+        // Class.field++ inside async needs the own/inherited static-field shadow handling (#339)
+        // that EmitCompoundSet already has; the generic dynamic path would desync the write (→ PDS)
+        // from the static-typed Ldsfld read (count would print 10, not 12).
+        var source = """
+            class Base { static shared: number = 100; }
+            class Derived extends Base {}
+            class Counter { static count: number = 10; }
+            async function go(): Promise<void> {
+                Counter.count++;     // own field: 11
+                ++Counter.count;     // own field: 12
+                Derived.shared++;    // inherited: own-shadow 101, Base.shared stays 100
+                console.log(Counter.count, Derived.shared, Base.shared);
+            }
+            go();
+            """;
+
+        var (errors, output) = TestHarness.CompileVerifyAndRun(source);
+
+        Assert.Empty(errors);
+        Assert.Equal("12 101 100\n", output);
+    }
+
     [Fact]
     public void Closures_PassesILVerification()
     {

--- a/SharpTS.Tests/SharedTests/AsyncMemberIncrementTests.cs
+++ b/SharpTS.Tests/SharedTests/AsyncMemberIncrementTests.cs
@@ -1,0 +1,110 @@
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests;
+
+/// <summary>
+/// Member-access increment/decrement (obj.prop++, ++obj.prop, arr[i]--, --arr[i]) inside
+/// async/generator bodies, exercised in both interpreter and compiler modes.
+///
+/// Regression guard for #357: in compiled mode the state-machine MoveNext emitter shared a base
+/// implementation of EmitPrefixIncrement/EmitPostfixIncrement that only handled plain-variable
+/// operands; member-access operands emitted nothing and underflowed the IL stack. The interpreter
+/// was already correct, so these parity theories pin both modes to the same JS semantics.
+/// </summary>
+public class AsyncMemberIncrementTests
+{
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AsyncFunction_PropertyAndIndex_AllForms(ExecutionMode mode)
+    {
+        var source = """
+            async function go(): Promise<void> {
+                const obj = { x: 1, y: 10 };
+                const arr = [5, 6, 7];
+                obj.x++;     // 2
+                ++obj.y;     // 11
+                arr[0]--;    // 4
+                --arr[1];    // 5
+                console.log(obj.x, obj.y, arr[0], arr[1], arr[2]);
+            }
+            go();
+            """;
+
+        Assert.Equal("2 11 4 5 7\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AsyncFunction_ResultValueSemantics(ExecutionMode mode)
+    {
+        // Postfix yields the (ToNumber-coerced) original; prefix yields the new value.
+        var source = """
+            async function go(): Promise<void> {
+                const obj = { x: 5 };
+                const a = obj.x++;   // a = 5, obj.x = 6
+                const b = ++obj.x;   // b = 7, obj.x = 7
+                console.log(a, b, obj.x);
+            }
+            go();
+            """;
+
+        Assert.Equal("5 7 7\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Generator_MemberIncrement(ExecutionMode mode)
+    {
+        var source = """
+            function* gen(): Generator<number> {
+                const o = { n: 5 };
+                const arr = [1, 2];
+                o.n++;
+                arr[0]--;
+                yield o.n;     // 6
+                yield arr[0];  // 0
+            }
+            const g = gen();
+            console.log(g.next().value, g.next().value);
+            """;
+
+        Assert.Equal("6 0\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AsyncArrow_MemberIncrement(ExecutionMode mode)
+    {
+        var source = """
+            const run = async (): Promise<void> => {
+                const o = { c: 41 };
+                ++o.c;
+                console.log(o.c);
+            };
+            run();
+            """;
+
+        Assert.Equal("42\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AsyncGenerator_MemberIncrement(ExecutionMode mode)
+    {
+        var source = """
+            async function* agen(): AsyncGenerator<number> {
+                const o = { n: 100 };
+                o.n++;
+                yield o.n;
+            }
+            async function main(): Promise<void> {
+                const ag = agen();
+                console.log((await ag.next()).value);
+            }
+            main();
+            """;
+
+        Assert.Equal("101\n", TestHarness.Run(source, mode));
+    }
+}


### PR DESCRIPTION
## Summary

Closes #357. In **compiled mode**, a prefix/postfix increment/decrement on a *member-access* operand (`obj.prop++`, `++obj.prop`, `arr[i]--`, `--arr[i]`) inside an `async function`, generator, async arrow, or async generator produced malformed IL — `ILVerify` reported `StackUnderflow` in the state machine's `MoveNext` and the program faulted at runtime.

The shared base emitter `ExpressionEmitterBase.EmitPrefixIncrement` / `EmitPostfixIncrement` (used by all four state-machine `MoveNext` emitters) only handled `Expr.Variable` operands; for `Expr.Get` / `Expr.GetIndex` it emitted nothing and fell through to `SetStackUnknown()`, leaving the surrounding statement to underflow the stack. The synchronous `ILEmitter` overrides already handled these operands — only the state-machine base did not.

## Fix

`Compilation/ExpressionEmitterBase.Operators.cs` — add `Expr.Get` / `Expr.GetIndex` arms to both base methods:

- **General property/index** (`obj.prop`, `arr[i]`): spill the receiver (and index) into registered locals via `SpillBoxed` so any `await`/`yield` inside them suspends with an empty stack and is evaluated **exactly once** (the sync path evaluates the receiver twice). Then read → `ToNumber` → write straight-line via `GetProperty`/`SetProperty` or `GetIndex`/`SetIndex`. Prefix returns the new value; postfix the `ToNumber`-coerced original (ECMA-262 §13.4). `ConvertToNumber` is used for the coercion (undefined→NaN, never throws — #190).
- **Static data field** (`Class.field++`): routed through the same own/inherited shadow handling `EmitCompoundSet` already uses (#339), so the write lands on the storage the static-typed `Ldsfld` read consults rather than desyncing via the dynamic PDS path (which otherwise made the increment silently vanish — `count` printed `10` instead of `12`).

Shared arithmetic factored into `EmitIncrementComputeStoreResult`; static-field binding into `TryEmitStaticFieldIncrement`.

## Tests

- `CompilerTests/ILVerificationTests.cs` — IL-clean + correct-output guards for each distinct state-machine context (async function, generator, async arrow, async generator) and operand kind (property, index, own/inherited static field).
- `SharedTests/AsyncMemberIncrementTests.cs` — parameterized interpreter/compiler parity for property, index, result-value semantics, and all four contexts.

Full suite: 11389/11390 pass (the one failure is the unrelated `DnsRecordTypeTests.LiveSmoke_ResolveNs_Promise` live-network test, which passes on re-run).

## Bugs found & filed (orthogonal, pre-existing)

- #451 — interpreter throws a spurious `'await' can only be used inside async functions` for `(await expr).prop++` (read/assign on the same await-receiver work; only increment fails). Compiled mode is correct after this PR.
- #452 — `yield` does not receive the value passed to `generator.next(v)` (interpreter rejects the argument; compiled resolves the `yield` to `null`).