### PR TITLE
Fix #347: bind infer from generic instantiation in the string-expansion path

### DIFF
--- a/SharpTS.Tests/TypeCheckerTests/ConditionalInferFromGenericInstantiationTests.cs
+++ b/SharpTS.Tests/TypeCheckerTests/ConditionalInferFromGenericInstantiationTests.cs
@@ -1,0 +1,183 @@
+using SharpTS.Tests.Infrastructure;
+using SharpTS.TypeSystem.Exceptions;
+using Xunit;
+
+namespace SharpTS.Tests.TypeCheckerTests;
+
+/// <summary>
+/// Conditional-type <c>infer</c> extracted from a generic INSTANTIATION on the extends side —
+/// <c>T extends Box&lt;infer V&gt; ? V : …</c>, <c>T extends Map&lt;any, infer V&gt; ? V : …</c> (#347).
+/// These flow through the string-expansion instantiation path (TypeChecker.Generics.cs), which
+/// previously lost the binding two ways: the check-side generic-class instance is wrapped in
+/// <c>TypeInfo.Instance</c> so the structural match never reached the type arguments, and the
+/// true-branch reference to the infer name was parsed with no binding in scope (collapsing to
+/// <c>any</c>). The built-in collections (Map/Set/WeakMap/WeakSet) additionally needed their type
+/// REFERENCES to resolve to their dedicated TypeInfo records rather than the <c>any</c> fallback.
+/// </summary>
+public class ConditionalInferFromGenericInstantiationTests
+{
+    // ---- user-defined generic class (the Box example) ----
+
+    [Fact]
+    public void UserGenericClass_InfersTypeArgument()
+    {
+        // Unbox<Box<number>> resolves to number; returning a string violates it.
+        var source = """
+            class Box<T> { value!: T; }
+            type Unbox<T> = T extends Box<infer V> ? V : "no";
+            function f(): Unbox<Box<number>> { return "hello"; }
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void UserGenericClass_InfersTypeArgument_CorrectAssignmentAccepted()
+    {
+        var source = """
+            class Box<T> { value!: T; }
+            type Unbox<T> = T extends Box<infer V> ? V : "no";
+            function f(): Unbox<Box<number>> { return 42; }
+            """;
+        TestHarness.RunInterpreted(source);
+    }
+
+    [Fact]
+    public void UserGenericClass_NoMatch_TakesFalseBranch()
+    {
+        // `string` is not a Box, so V never binds and the conditional resolves to its false branch
+        // ("no"); returning a number violates that literal.
+        var source = """
+            class Box<T> { value!: T; }
+            type Unbox<T> = T extends Box<infer V> ? V : "no";
+            function f(): Unbox<string> { return 42; }
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void UserGenericClass_NoMatch_FalseBranchValueAccepted()
+    {
+        var source = """
+            class Box<T> { value!: T; }
+            type Unbox<T> = T extends Box<infer V> ? V : "no";
+            function f(): Unbox<string> { return "no"; }
+            """;
+        TestHarness.RunInterpreted(source);
+    }
+
+    [Fact]
+    public void UserGenericClass_TwoTypeParams_InfersSelectedArgument()
+    {
+        // The infer is the SECOND type argument; the first matches `any`.
+        var source = """
+            class Pair<A, B> { a!: A; b!: B; }
+            type Second<T> = T extends Pair<any, infer V> ? V : never;
+            function f(): Second<Pair<string, number>> { return "hello"; }
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+
+    // ---- built-in collection instantiations (the Map example) ----
+
+    [Fact]
+    public void BuiltInMap_InfersValueType()
+    {
+        var source = """
+            type MapValue<T> = T extends Map<any, infer V> ? V : never;
+            let m: MapValue<Map<string, number>> = "not a number";
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void BuiltInMap_InfersValueType_CorrectAssignmentAccepted()
+    {
+        var source = """
+            type MapValue<T> = T extends Map<any, infer V> ? V : never;
+            let m: MapValue<Map<string, number>> = 5;
+            """;
+        TestHarness.RunInterpreted(source);
+    }
+
+    [Fact]
+    public void BuiltInMap_InfersKeyType()
+    {
+        var source = """
+            type MapKey<T> = T extends Map<infer K, any> ? K : never;
+            function f(): MapKey<Map<string, number>> { return 42; }
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void BuiltInSet_InfersElementType()
+    {
+        var source = """
+            type Elem<T> = T extends Set<infer V> ? V : "none";
+            function f(): Elem<Set<number>> { return "hello"; }
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void BuiltInWeakMap_InfersValueType()
+    {
+        var source = """
+            type WMValue<T> = T extends WeakMap<any, infer V> ? V : never;
+            function f(): WMValue<WeakMap<object, number>> { return "hello"; }
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void BuiltInGenerator_InfersYieldType()
+    {
+        var source = """
+            type Yield<T> = T extends Generator<infer V> ? V : "none";
+            function f(): Yield<Generator<number>> { return "hello"; }
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+
+    // ---- array instantiation through the alias string-expansion path ----
+
+    [Fact]
+    public void ArrayElement_InfersElementType()
+    {
+        var source = """
+            type Elem<T> = T extends (infer V)[] ? V : "none";
+            function f(): Elem<number[]> { return "hello"; }
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+
+    // ---- the dedicated-collection type references are now strongly typed (#347 sub-fix) ----
+
+    [Fact]
+    public void MapTypeReference_IsStronglyTyped_RejectsMismatchedValue()
+    {
+        // A Map<string, number> reference resolves to the dedicated Map type (not `any`), so an
+        // incompatible Map assignment is now caught.
+        var source = """
+            let m: Map<string, number> = new Map<string, string>();
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void MapTypeReference_CommonOperationsTypeCheck()
+    {
+        // Regression guard: strongly-typed Map/Set references must not produce spurious errors on
+        // ordinary member access and iteration.
+        var source = """
+            function use(m: Map<string, number>, s: Set<number>): void {
+              m.set("a", 1);
+              const v: number | null = m.get("a");
+              const sz: number = m.size + s.size;
+              for (const [k, val] of m) { console.log(k, val); }
+              for (const x of s) { console.log(x); }
+            }
+            """;
+        TestHarness.RunInterpreted(source);
+    }
+}

--- a/TypeSystem/TypeChecker.Generics.Conditional.cs
+++ b/TypeSystem/TypeChecker.Generics.Conditional.cs
@@ -375,6 +375,9 @@ public partial class TypeChecker
             case TypeInfo.InstantiatedGeneric ig:
                 foreach (var t in ig.TypeArguments) CollectConstrainedInfers(t, ref result);
                 break;
+            case TypeInfo.Instance inst:
+                CollectConstrainedInfers(inst.ResolvedClassType, ref result);
+                break;
             case TypeInfo.KeyOf keyOf:
                 CollectConstrainedInfers(keyOf.SourceType, ref result);
                 break;
@@ -384,6 +387,11 @@ public partial class TypeChecker
                 break;
             case TypeInfo.TemplateLiteralType tl:
                 foreach (var t in tl.InterpolatedTypes) CollectConstrainedInfers(t, ref result);
+                break;
+            // Built-in containers (Map<…, infer V extends C>, …): descend into their arguments (#347).
+            default:
+                if (DecomposeBuiltInContainer(type) is { } containerArgs)
+                    foreach (var t in containerArgs) CollectConstrainedInfers(t, ref result);
                 break;
         }
     }
@@ -427,6 +435,9 @@ public partial class TypeChecker
             case TypeInfo.InstantiatedGeneric ig:
                 foreach (var t in ig.TypeArguments) CollectReferencedInferNames(t, visit);
                 break;
+            case TypeInfo.Instance inst:
+                CollectReferencedInferNames(inst.ResolvedClassType, visit);
+                break;
             case TypeInfo.KeyOf keyOf:
                 CollectReferencedInferNames(keyOf.SourceType, visit);
                 break;
@@ -436,6 +447,11 @@ public partial class TypeChecker
                 break;
             case TypeInfo.TemplateLiteralType tl:
                 foreach (var t in tl.InterpolatedTypes) CollectReferencedInferNames(t, visit);
+                break;
+            // Built-in containers (Map<…, infer V>, Set<infer T>, …): descend into their arguments (#347).
+            default:
+                if (DecomposeBuiltInContainer(type) is { } containerArgs)
+                    foreach (var t in containerArgs) CollectReferencedInferNames(t, visit);
                 break;
         }
     }
@@ -546,10 +562,14 @@ public partial class TypeChecker
             return false;
         }
 
-        // InstantiatedGeneric matching (e.g., Box<infer T>)
-        if (extendsType is TypeInfo.InstantiatedGeneric extendsGeneric)
+        // InstantiatedGeneric matching (e.g., Box<infer T>, user-defined generic class/interface).
+        // A generic CLASS instance arrives wrapped in TypeInfo.Instance (Box<number> =>
+        // Instance(InstantiatedGeneric)); unwrap both sides so the type-argument match reaches the
+        // infer placeholders instead of falling through to a structural IsCompatible that cannot
+        // bind them (#347). UnwrapToInstantiatedGeneric is a no-op for an already-bare generic.
+        if (UnwrapToInstantiatedGeneric(extendsType) is { } extendsGeneric)
         {
-            if (checkType is TypeInfo.InstantiatedGeneric checkGeneric)
+            if (UnwrapToInstantiatedGeneric(checkType) is { } checkGeneric)
             {
                 // Must be same generic base
                 if (!IsSameGenericDefinition(checkGeneric.GenericDefinition, extendsGeneric.GenericDefinition))
@@ -562,6 +582,26 @@ public partial class TypeChecker
                 for (int i = 0; i < extendsGeneric.TypeArguments.Count; i++)
                 {
                     if (!CheckExtendsRecursive(checkGeneric.TypeArguments[i], extendsGeneric.TypeArguments[i], inferredTypes))
+                        return false;
+                }
+                return true;
+            }
+            return false;
+        }
+
+        // Built-in container matching (Map<…, infer V>, Set<infer T>, the weak variants, iterators,
+        // generators). These carry bespoke TypeInfo records rather than InstantiatedGeneric, so
+        // without this they fall through to a structural IsCompatible that cannot bind infers (#347).
+        // Same record kind (same runtime type) and arity → recurse over type arguments pairwise.
+        if (DecomposeBuiltInContainer(extendsType) is { } extendsArgs)
+        {
+            if (checkType.GetType() == extendsType.GetType()
+                && DecomposeBuiltInContainer(checkType) is { } checkArgs
+                && checkArgs.Count == extendsArgs.Count)
+            {
+                for (int i = 0; i < extendsArgs.Count; i++)
+                {
+                    if (!CheckExtendsRecursive(checkArgs[i], extendsArgs[i], inferredTypes))
                         return false;
                 }
                 return true;
@@ -653,12 +693,17 @@ public partial class TypeChecker
             || (t.RestElementType is { } rest && IsGenericTypeShape(rest)),
         TypeInfo.Function f => f.ParamTypes.Any(IsGenericTypeShape) || IsGenericTypeShape(f.ReturnType),
         TypeInfo.InstantiatedGeneric ig => ig.TypeArguments.Any(IsGenericTypeShape),
+        // A generic class instance (Box<infer V>) is wrapped in Instance; look through it so a
+        // type variable inside its arguments still defers the conditional / blocks eager resolution (#347).
+        TypeInfo.Instance inst => IsGenericTypeShape(inst.ResolvedClassType),
         TypeInfo.RecursiveTypeAlias rta => rta.TypeArguments is { } args && args.Any(IsGenericTypeShape),
         TypeInfo.Record r => r.Fields.Values.Any(IsGenericTypeShape),
         TypeInfo.MappedType => true,
         TypeInfo.IntrinsicStringType ist => IsGenericTypeShape(ist.Inner),
         TypeInfo.TemplateLiteralType tl => tl.InterpolatedTypes.Any(IsGenericTypeShape),
-        _ => false
+        // Built-in containers (Map/Set/weak variants/iterators/generators) carry type variables in
+        // their arguments just like a generic instantiation (#347).
+        _ => DecomposeBuiltInContainer(type) is { } containerArgs && containerArgs.Any(IsGenericTypeShape)
     };
 
     /// <summary>
@@ -861,6 +906,38 @@ public partial class TypeChecker
             ? sigs.Select(CallSignatureToFunction).ToList()
             : null;
     }
+
+    /// <summary>
+    /// Views a type as an <see cref="TypeInfo.InstantiatedGeneric"/>, transparently looking through the
+    /// <see cref="TypeInfo.Instance"/> wrapper that a generic class instance carries. Returns null when
+    /// the type denotes neither (so the caller falls through to other matching rules).
+    /// </summary>
+    private static TypeInfo.InstantiatedGeneric? UnwrapToInstantiatedGeneric(TypeInfo type) => type switch
+    {
+        TypeInfo.InstantiatedGeneric ig => ig,
+        TypeInfo.Instance { ResolvedClassType: TypeInfo.InstantiatedGeneric ig } => ig,
+        _ => null
+    };
+
+    /// <summary>
+    /// Decomposes a dedicated built-in container type (Map, Set, the weak variants, generators) into
+    /// its type arguments, so the conditional-type machinery can treat <c>Map&lt;…, infer V&gt;</c>
+    /// like a generic instantiation. These carry bespoke TypeInfo records rather than
+    /// <see cref="TypeInfo.InstantiatedGeneric"/>. The set mirrors exactly the container names that
+    /// <see cref="ResolveGenericType"/> resolves from a type reference — so an extends clause can
+    /// actually denote one of them; Array/Promise/Tuple keep their own dedicated match branches and
+    /// are excluded. Returns null for any other type (#347).
+    /// </summary>
+    private static IReadOnlyList<TypeInfo>? DecomposeBuiltInContainer(TypeInfo type) => type switch
+    {
+        TypeInfo.Map m => [m.KeyType, m.ValueType],
+        TypeInfo.WeakMap m => [m.KeyType, m.ValueType],
+        TypeInfo.Set s => [s.ElementType],
+        TypeInfo.WeakSet s => [s.ElementType],
+        TypeInfo.Generator g => [g.YieldType],
+        TypeInfo.AsyncGenerator g => [g.YieldType],
+        _ => null
+    };
 
     /// <summary>
     /// Checks if two generic definitions refer to the same generic type.

--- a/TypeSystem/TypeChecker.Generics.cs
+++ b/TypeSystem/TypeChecker.Generics.cs
@@ -128,6 +128,34 @@ public partial class TypeChecker
             }
             result = new TypeInfo.AsyncGenerator(typeArgs[0]);
         }
+        // The built-in collections carry dedicated TypeInfo records (with IsCompatible + member-type
+        // support) but were previously only constructed from `new Map()`/`new Set()` expressions — a
+        // type REFERENCE `Map<K, V>` fell through to the `any` fallback below, so annotations and
+        // conditional-type check sides lost their element types (#347, the `Map<…, infer V>` example).
+        else if (baseName == "Map")
+        {
+            if (typeArgs.Count != 2)
+                throw new TypeCheckException($" Map requires exactly 2 type arguments, got {typeArgs.Count}.", tsCode: "TS2314");
+            result = new TypeInfo.Map(typeArgs[0], typeArgs[1]);
+        }
+        else if (baseName == "Set")
+        {
+            if (typeArgs.Count != 1)
+                throw new TypeCheckException($" Set requires exactly 1 type argument, got {typeArgs.Count}.", tsCode: "TS2314");
+            result = new TypeInfo.Set(typeArgs[0]);
+        }
+        else if (baseName == "WeakMap")
+        {
+            if (typeArgs.Count != 2)
+                throw new TypeCheckException($" WeakMap requires exactly 2 type arguments, got {typeArgs.Count}.", tsCode: "TS2314");
+            result = new TypeInfo.WeakMap(typeArgs[0], typeArgs[1]);
+        }
+        else if (baseName == "WeakSet")
+        {
+            if (typeArgs.Count != 1)
+                throw new TypeCheckException($" WeakSet requires exactly 1 type argument, got {typeArgs.Count}.", tsCode: "TS2314");
+            result = new TypeInfo.WeakSet(typeArgs[0]);
+        }
         // Handle built-in utility types
         else if (baseName == "Partial")
         {

--- a/TypeSystem/TypeChecker.TypeNodes.cs
+++ b/TypeSystem/TypeChecker.TypeNodes.cs
@@ -501,6 +501,7 @@ public partial class TypeChecker
     /// </summary>
     private static bool IsBuiltInGenericName(string name) => name is
         "Array" or "ReadonlyArray" or "Promise" or "Generator" or "AsyncGenerator" or
+        "Map" or "Set" or "WeakMap" or "WeakSet" or
         "Partial" or "Required" or "Readonly" or "Record" or "Pick" or "Omit" or
         "ReturnType" or "Parameters" or "ConstructorParameters" or "InstanceType" or
         "ThisType" or "Awaited" or "NonNullable" or "Extract" or "Exclude" or

--- a/TypeSystem/TypeChecker.TypeParsing.cs
+++ b/TypeSystem/TypeChecker.TypeParsing.cs
@@ -1559,7 +1559,29 @@ public partial class TypeChecker
             return ToTypeInfo(matches ? trueTypeStr : falseTypeStr);
         }
 
-        TypeInfo trueType = ToTypeInfo(trueTypeStr);
+        // Infer names declared in the extends clause are in scope for the TRUE branch only (tsc).
+        // Bind each to the InferredTypeParameter it denotes so a reference like the `V` in
+        // `... extends Box<infer V> ? V : ...` resolves to that placeholder for
+        // EvaluateConditionalType to substitute — otherwise the string parser resolves a bare `V`
+        // to `any` and silently collapses the true branch (#347, mirroring the AST node path's #316
+        // fix in TypeChecker.TypeNodes.cs). The false branch never sees the infer names.
+        List<string>? inferNames = null;
+        CollectReferencedInferNames(extendsType, name => (inferNames ??= []).Add(name));
+
+        TypeInfo trueType;
+        if (inferNames is { Count: > 0 })
+        {
+            var inferEnv = new TypeEnvironment(_environment);
+            foreach (var name in inferNames)
+                inferEnv.DefineTypeParameter(name, new TypeInfo.InferredTypeParameter(name));
+            using (new EnvironmentScope(this, inferEnv))
+                trueType = ToTypeInfo(trueTypeStr);
+        }
+        else
+        {
+            trueType = ToTypeInfo(trueTypeStr);
+        }
+
         TypeInfo falseType = ToTypeInfo(falseTypeStr);
 
         return new TypeInfo.ConditionalType(checkType, extendsType, trueType, falseType);


### PR DESCRIPTION
Closes #347.

## Problem

Conditional types whose extends clause is a **generic instantiation** failed to bind the `infer` when the alias was instantiated through the string-expansion path:

```ts
class Box<T> { value!: T; }
type Unbox<T> = T extends Box<infer V> ? V : "no";
let x: string = (null as any as Unbox<Box<number>>);   // should error (number), didn't

type MapValue<T> = T extends Map<any, infer V> ? V : never;
let m: MapValue<Map<string, number>> = "not a number"; // should error (number), didn't
```

The AST node path already bound these correctly (via #316); the gap was the string-expansion instantiation path losing the binding.

## Root causes & fixes

The binding was lost three independent ways:

1. **`TypeInfo.Instance` wrapper not unwrapped.** A generic *class* instance arrives wrapped (`Box<number>` ⇒ `Instance(InstantiatedGeneric)`). Neither `CheckExtendsRecursive` nor `IsGenericTypeShape` looked through it, so `Box<number> extends Box<infer V>` fell through to a structural `IsCompatible` (which can't bind infers) and the eager-resolution gate mis-fired. Added `UnwrapToInstantiatedGeneric` and an `Instance` arm to `IsGenericTypeShape` / the infer-name collectors.

2. **True-branch infer reference parsed as `any`.** The reference to `V` in `… ? V : …` was parsed by the string parser with no binding in scope, collapsing the true branch to `any`. `TryParseConditionalType` now binds the extends-clause infer names in a child env before parsing the true branch — mirroring the node path's #316 fix.

3. **Built-in collection *references* resolved to `any`.** `Map`/`Set`/`WeakMap`/`WeakSet` carry bespoke `TypeInfo` records (not `InstantiatedGeneric`), and only `new Map()` ever built the typed form — the type *reference* `Map<K,V>` fell through to the `any` fallback. `ResolveGenericType` now resolves these references to their records (the `IsCompatible` + member-type infra already existed), and `DecomposeBuiltInContainer` lets the conditional matcher treat them like a generic instantiation. Side effect: `Map<K,V>`/`Set<T>` annotations are now **strongly typed** instead of `any`.

`Generator`/`AsyncGenerator` already resolved as references, so they're covered by `DecomposeBuiltInContainer` too.

## Validation

- Full unit suite: **11389 passed, 0 failed** (one live-network DNS smoke test flaked once, passes on retry — unrelated to type-checker changes).
- TS conformance: **31/31**, baseline unchanged (no diagnostic-distribution shift — the suites assert diagnostics, not result types, as noted in the issue).
- Probed common Map/Set/WeakMap operations (member access, iteration, `forEach`, arity errors, nested/generic positions, assignability) — no spurious errors; tsc-like behavior.
- New `ConditionalInferFromGenericInstantiationTests` (14 tests) covering user generic classes (Box, Pair), Map/Set/WeakMap/Generator, the array alias path, false-branch/no-match cases, and strong-typing regression guards.

## Follow-up

The remaining built-in container records — `IterableIterator`/`Iterator`, `WeakRef`, `FinalizationRegistry` — still resolve to `any` as type references (filed separately). Their resolution is the same shape as this fix but out of scope for #347's examples.