### PR TITLE
Fix #451: interpreter await-in-receiver increment throws spurious 'await' error

### DIFF
--- a/Execution/Interpreter.Expressions.cs
+++ b/Execution/Interpreter.Expressions.cs
@@ -144,8 +144,8 @@ public partial class Interpreter
             case Expr.LogicalAssign logical: return await EvaluateLogicalAssignAsync(logical);
             case Expr.LogicalSet logicalSet: return await EvaluateLogicalSetAsync(logicalSet);
             case Expr.LogicalSetIndex logicalSetIndex: return await EvaluateLogicalSetIndexAsync(logicalSetIndex);
-            case Expr.PrefixIncrement prefix: return EvaluatePrefixIncrement(prefix);
-            case Expr.PostfixIncrement postfix: return EvaluatePostfixIncrement(postfix);
+            case Expr.PrefixIncrement prefix: return await EvaluatePrefixIncrementAsync(prefix);
+            case Expr.PostfixIncrement postfix: return await EvaluatePostfixIncrementAsync(postfix);
             case Expr.ArrowFunction arrow: return EvaluateArrowFunction(arrow);
             case Expr.TemplateLiteral template: return await EvaluateTemplateLiteralAsync(template);
             case Expr.TaggedTemplateLiteral tagged: return await EvaluateTaggedTemplateLiteralAsync(tagged);

--- a/Execution/Interpreter.Helpers.cs
+++ b/Execution/Interpreter.Helpers.cs
@@ -186,42 +186,92 @@ public partial class Interpreter
         switch (operand)
         {
             case Expr.Variable variable:
-            {
-                double current = _environment.Get(variable.Name).AsNumber();
-                double newValue = current + delta;
-                _environment.Assign(variable.Name, RuntimeValue.FromNumber(newValue));
-                return RuntimeValue.FromNumber(returnOld ? current : newValue);
-            }
+                return IncrementVariable(variable, delta, returnOld);
 
             case Expr.Get get:
-            {
-                object? obj = Evaluate(get.Object);
-                if (TryGetProperty(obj, get.Name, out object? currentObj))
-                {
-                    double current = (double)currentObj!;
-                    double newValue = current + delta;
-                    if (TrySetProperty(obj, get.Name, newValue))
-                    {
-                        return RuntimeValue.FromNumber(returnOld ? current : newValue);
-                    }
-                }
-                break;
-            }
+                return IncrementProperty(Evaluate(get.Object), get.Name, delta, returnOld);
 
             case Expr.GetIndex getIndex:
             {
                 object? obj = Evaluate(getIndex.Object);
                 object? index = Evaluate(getIndex.Index);
-                if (TryGetIndex(obj, index, out object? currentObj))
-                {
-                    double current = (double)currentObj!;
-                    double newValue = current + delta;
-                    if (TrySetIndex(obj, index, newValue))
-                    {
-                        return RuntimeValue.FromNumber(returnOld ? current : newValue);
-                    }
-                }
-                break;
+                return IncrementIndex(obj, index, delta, returnOld);
+            }
+        }
+
+        throw new InterpreterException("Invalid increment operand.");
+    }
+
+    /// <summary>
+    /// Async counterpart of <see cref="EvaluateIncrement"/>. Resolves the operand's
+    /// receiver (and index) through the async-aware evaluator so an <c>await</c> or
+    /// thenable in the receiver/index — e.g. <c>(await foo()).n++</c>, <c>arr[await i()]--</c> —
+    /// is awaited rather than routed to the synchronous <c>VisitAwait</c>, which throws
+    /// "'await' can only be used inside async functions." The read-modify-write itself is
+    /// identical to the synchronous path. See issue #451.
+    /// </summary>
+    private async Task<RuntimeValue> EvaluateIncrementAsync(Expr operand, double delta, bool returnOld)
+    {
+        switch (operand)
+        {
+            case Expr.Variable variable:
+                return IncrementVariable(variable, delta, returnOld);
+
+            case Expr.Get get:
+                return IncrementProperty((await EvaluateAsync(get.Object)).ToObject(), get.Name, delta, returnOld);
+
+            case Expr.GetIndex getIndex:
+            {
+                object? obj = (await EvaluateAsync(getIndex.Object)).ToObject();
+                object? index = (await EvaluateAsync(getIndex.Index)).ToObject();
+                return IncrementIndex(obj, index, delta, returnOld);
+            }
+        }
+
+        throw new InterpreterException("Invalid increment operand.");
+    }
+
+    /// <summary>Increments a variable l-value, returning the old or new value.</summary>
+    private RuntimeValue IncrementVariable(Expr.Variable variable, double delta, bool returnOld)
+    {
+        double current = _environment.Get(variable.Name).AsNumber();
+        double newValue = current + delta;
+        _environment.Assign(variable.Name, RuntimeValue.FromNumber(newValue));
+        return RuntimeValue.FromNumber(returnOld ? current : newValue);
+    }
+
+    /// <summary>
+    /// Increments a property l-value on an already-resolved receiver. Shared by the
+    /// synchronous and async increment paths so the read-modify-write semantics stay identical.
+    /// </summary>
+    private RuntimeValue IncrementProperty(object? obj, Token name, double delta, bool returnOld)
+    {
+        if (TryGetProperty(obj, name, out object? currentObj))
+        {
+            double current = (double)currentObj!;
+            double newValue = current + delta;
+            if (TrySetProperty(obj, name, newValue))
+            {
+                return RuntimeValue.FromNumber(returnOld ? current : newValue);
+            }
+        }
+
+        throw new InterpreterException("Invalid increment operand.");
+    }
+
+    /// <summary>
+    /// Increments an indexed l-value on an already-resolved receiver/index. Shared by the
+    /// synchronous and async increment paths so the read-modify-write semantics stay identical.
+    /// </summary>
+    private RuntimeValue IncrementIndex(object? obj, object? index, double delta, bool returnOld)
+    {
+        if (TryGetIndex(obj, index, out object? currentObj))
+        {
+            double current = (double)currentObj!;
+            double newValue = current + delta;
+            if (TrySetIndex(obj, index, newValue))
+            {
+                return RuntimeValue.FromNumber(returnOld ? current : newValue);
             }
         }
 

--- a/Execution/Interpreter.Operators.cs
+++ b/Execution/Interpreter.Operators.cs
@@ -217,6 +217,26 @@ public partial class Interpreter
     }
 
     /// <summary>
+    /// Async counterpart of <see cref="EvaluatePrefixIncrement"/>; resolves an
+    /// <c>await</c>/thenable in the operand's receiver or index (issue #451).
+    /// </summary>
+    private Task<RuntimeValue> EvaluatePrefixIncrementAsync(Expr.PrefixIncrement prefix)
+    {
+        double delta = prefix.Operator.Type == TokenType.PLUS_PLUS ? 1 : -1;
+        return EvaluateIncrementAsync(prefix.Operand, delta, returnOld: false);
+    }
+
+    /// <summary>
+    /// Async counterpart of <see cref="EvaluatePostfixIncrement"/>; resolves an
+    /// <c>await</c>/thenable in the operand's receiver or index (issue #451).
+    /// </summary>
+    private Task<RuntimeValue> EvaluatePostfixIncrementAsync(Expr.PostfixIncrement postfix)
+    {
+        double delta = postfix.Operator.Type == TokenType.PLUS_PLUS ? 1 : -1;
+        return EvaluateIncrementAsync(postfix.Operand, delta, returnOld: true);
+    }
+
+    /// <summary>
     /// Evaluates the plus operator, handling both addition and string concatenation.
     /// </summary>
     /// <param name="left">The left operand.</param>

--- a/SharpTS.Tests/SharedTests/AwaitReceiverIncrementTests.cs
+++ b/SharpTS.Tests/SharedTests/AwaitReceiverIncrementTests.cs
@@ -1,0 +1,253 @@
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests;
+
+/// <summary>
+/// Regression tests for #451: a prefix/postfix increment or decrement whose operand
+/// is a member access with an <c>await</c> in the receiver (or index) — e.g.
+/// <c>(await foo()).n++</c>, <c>--(await foo())[i]</c>, <c>arr[await i()]++</c>.
+///
+/// In interpreter mode this threw a spurious "'await' can only be used inside async
+/// functions." Plain reads and assignments through the same await-receiver already
+/// worked; only <c>++</c>/<c>--</c> was broken, because <c>EvaluateIncrement</c> resolved
+/// the receiver/index with the synchronous evaluator (which routes <c>await</c> to the
+/// throwing <c>VisitAwait</c>). #451 adds an async-aware increment path.
+///
+/// Runs against both modes: compiled-mode member-access increment in async bodies
+/// (including an <c>await</c> in the receiver/index) was fixed by #357 / PR #453, so these
+/// double as an interpreter↔compiler parity check.
+/// </summary>
+public class AwaitReceiverIncrementTests
+{
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void PostfixIncrement_AwaitInGetReceiver_DoesNotThrow(ExecutionMode mode)
+    {
+        // The exact repro from issue #451.
+        var source = """
+            async function getObj() { return { n: 1 }; }
+            async function main() {
+                (await getObj()).n++;
+                console.log("ok");
+            }
+            main();
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("ok\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void PostfixIncrement_AwaitInGetReceiver_MutatesAndReturnsOld(ExecutionMode mode)
+    {
+        var source = """
+            const o = { n: 1 };
+            async function get() { return o; }
+            async function main() {
+                const old = (await get()).n++;
+                console.log(old, o.n);
+            }
+            main();
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("1 2\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void PrefixIncrement_AwaitInGetReceiver_ReturnsNew(ExecutionMode mode)
+    {
+        var source = """
+            const o = { n: 1 };
+            async function get() { return o; }
+            async function main() {
+                const val = ++(await get()).n;
+                console.log(val, o.n);
+            }
+            main();
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("2 2\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void PrefixDecrement_AwaitInGetIndexReceiver(ExecutionMode mode)
+    {
+        var source = """
+            const arr = [10, 20];
+            async function get() { return arr; }
+            async function main() {
+                const val = --(await get())[0];
+                console.log(val, arr[0]);
+            }
+            main();
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("9 9\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void PostfixIncrement_AwaitInIndexExpression(ExecutionMode mode)
+    {
+        var source = """
+            async function main() {
+                const arr = [5, 6];
+                arr[await Promise.resolve(0)]++;
+                console.log(arr[0], arr[1]);
+            }
+            main();
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("6 6\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void PostfixIncrement_AwaitInBothReceiverAndIndex(ExecutionMode mode)
+    {
+        var source = """
+            const m = [[1, 2], [3, 4]];
+            async function getMat() { return m; }
+            async function getIdx() { return 1; }
+            async function main() {
+                const old = (await getMat())[await getIdx()][0]++;
+                console.log(old, m[1][0]);
+            }
+            main();
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("3 4\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void PostfixIncrement_AwaitDeepInNestedReceiver(ExecutionMode mode)
+    {
+        var source = """
+            const o = { a: { b: 5 } };
+            async function get() { return o; }
+            async function main() {
+                const old = (await get()).a.b++;
+                console.log(old, o.a.b);
+            }
+            main();
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("5 6\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Increment_AwaitInReceiver_UsableAsSubexpression(ExecutionMode mode)
+    {
+        var source = """
+            const o = { n: 5 };
+            async function get() { return o; }
+            async function main() {
+                const z = (await get()).n++ + 100;
+                console.log(z, o.n);
+            }
+            main();
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("105 6\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ReadAndAssign_ThroughAwaitReceiver_StillWork(ExecutionMode mode)
+    {
+        // The issue notes these always worked; guard against the fix regressing them.
+        // `o` is annotated so the property stays `number` (a bare `{ n: 1 }` literal is
+        // mis-narrowed to the literal type `1` by the checker, rejecting `= 9`; that is an
+        // unrelated conformance bug — #458 — not in scope here).
+        var source = """
+            const o: { n: number } = { n: 1 };
+            async function get() { return o; }
+            async function main() {
+                const r = (await get()).n;
+                (await get()).n = 9;
+                console.log(r, o.n);
+            }
+            main();
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("1 9\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void PlainIncrements_StillWorkInsideAsyncFunction(ExecutionMode mode)
+    {
+        // Regression guard: variable / plain-receiver / plain-index increments
+        // (no await in the operand) must still work after rewiring the async path.
+        var source = """
+            async function main() {
+                let c = 0;
+                c++;
+                --c;
+                c--;
+                const p = { v: 7 };
+                p.v++;
+                const arr = [1];
+                arr[0]--;
+                console.log(c, p.v, arr[0]);
+            }
+            main();
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("-1 8 0\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AwaitInReceiver_InsideAsyncArrow(ExecutionMode mode)
+    {
+        var source = """
+            const o = { n: 1 };
+            async function get() { return o; }
+            const f = async () => { (await get()).n++; };
+            async function main() {
+                await f();
+                console.log(o.n);
+            }
+            main();
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("2\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AwaitInReceiver_InsideAsyncGenerator(ExecutionMode mode)
+    {
+        var source = """
+            const o = { n: 1 };
+            async function get() { return o; }
+            async function* g() { (await get()).n++; yield 99; }
+            async function main() {
+                const it = g();
+                const r = await it.next();
+                console.log(r.value, o.n);
+            }
+            main();
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("99 2\n", output);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #451. In **interpreter mode**, a prefix/postfix increment/decrement whose operand is a member access with an `await` in the **receiver** or **index** — e.g. `(await foo()).n++`, `--(await foo())[i]`, `arr[await i()]++` — threw a spurious `'await' can only be used inside async functions.` Reads and assignments through the same await-receiver already worked; only `++`/`--` was affected.

## Root cause

`EvaluateAsync` dispatched `Expr.PrefixIncrement`/`Expr.PostfixIncrement` to the **synchronous** `EvaluatePrefixIncrement`/`EvaluatePostfixIncrement`. Those resolve the operand's receiver/index via the synchronous `Evaluate`, which routes `Expr.Await` to `VisitAwait` — a method that unconditionally throws. The read/assign paths already had async-aware variants, which is why only increment was broken.

## Fix

- Add `EvaluateIncrementAsync` (+ thin `EvaluatePrefixIncrementAsync`/`EvaluatePostfixIncrementAsync` wrappers) that resolve the receiver/index through the async-aware `EvaluateAsync` (so an `await` or thenable is awaited/adopted) before performing the read-modify-write.
- Extract the read-modify-write into shared helpers `IncrementVariable` / `IncrementProperty` / `IncrementIndex`, so the **sync and async paths have byte-identical semantics** — the only difference is how the receiver/index is resolved (`Evaluate` vs `await EvaluateAsync`). No logic is duplicated.
- Rewire the two `EvaluateAsync` cases.

Covers `Get` and `GetIndex` operands; `await` in the receiver, the index, or both; nested member access (`(await x).a.b++`); and async function / async arrow / async generator contexts.

## Tests

`AwaitReceiverIncrementTests` — 12 cases run in **both modes** (interpreter ↔ compiled parity): the exact repro, prefix/postfix × Get/GetIndex, await-in-index, await-in-both, nested, increment-as-subexpression, async-arrow, async-generator, plus regression guards that plain increments and read/assign-through-await-receiver still work.

Compiled-mode member-access increment in async bodies — including an `await` in the receiver/index — was fixed by #357 / PR #453 (merged), so these double as a parity check. (Branch is rebased onto current `main`.)

## Issue filed along the way

- **#458** — TS conformance: `const`-bound object literals infer **literal** property types, so `const o = { n: 1 }; o.n = 9;` is wrongly rejected (real TS widens to `number`; `let` and an explicit annotation both work). Found while writing tests; unrelated to `await`. Re-verified on current `main`.

(I also filed **#457** for a compiled-mode "Label N has not been marked" on the await-in-receiver shape, but on re-verifying against current `main` it turned out to be already fixed by #453 — closed.)
