### PR TITLE
Fix #375: compiled bare primitive instanceof Number/String/Boolean wrongly true

### DIFF
--- a/Compilation/RuntimeEmitter.CoreUtilities.cs
+++ b/Compilation/RuntimeEmitter.CoreUtilities.cs
@@ -3704,6 +3704,15 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Br, trueLabel);
         il.MarkLabel(notObjectClassLabel);
 
+        // When classType is one of the primitive wrapper types (Number/String/
+        // Boolean, which lower to the System.Double/String/Boolean Type tokens),
+        // the decision is TERMINAL: per ECMA-262 OrdinaryHasInstance only a boxed
+        // wrapper object (`new Number(5)`) is an instance — a bare primitive is
+        // NOT. Branch to true iff `instance` carries the matching __primitiveType
+        // marker, else to false. Falling through to the IsAssignableFrom fallback
+        // below would wrongly match a bare boxed double/string/bool, since e.g.
+        // IsAssignableFrom(double, double) is true (#375). Mirrors the terminal
+        // `Object` branch above.
         void CheckBoxed(Type primType, string typeTag)
         {
             var skip = il.DefineLabel();
@@ -3711,11 +3720,12 @@ public partial class RuntimeEmitter
             il.Emit(OpCodes.Ldtoken, primType);
             il.Emit(OpCodes.Call, _types.GetMethod(_types.Type, "GetTypeFromHandle", _types.RuntimeTypeHandle));
             il.Emit(OpCodes.Bne_Un, skip);
-            // classType is the primitive type — check marker
+            // classType is the primitive wrapper type — true iff boxed marker matches.
             il.Emit(OpCodes.Ldarg_0);
             il.Emit(OpCodes.Ldstr, typeTag);
             il.Emit(OpCodes.Call, runtime.IsBoxedPrimitiveOfTypeMethod);
             il.Emit(OpCodes.Brtrue, trueLabel);
+            il.Emit(OpCodes.Br, falseLabel);
             il.MarkLabel(skip);
         }
         CheckBoxed(_types.Boolean, "Boolean");

--- a/SharpTS.Tests/SharedTests/PrimitiveWrapperTests.cs
+++ b/SharpTS.Tests/SharedTests/PrimitiveWrapperTests.cs
@@ -89,11 +89,12 @@ public class PrimitiveWrapperTests
     }
 
     // ── primitive (non-new) is NOT an instance ───────────────────────────────
-    // Interpreter-only: compiled mode treats bare primitives differently for instanceof
-    // (pre-existing gap, tracked separately).
+    // Per ECMA-262 OrdinaryHasInstance a bare primitive is never an instance of
+    // its wrapper constructor; only boxed `new Number(5)` wrappers are. Both modes
+    // now agree (#360 interp, #375 compiled).
 
     [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void Number_Bare_NotInstanceofNumber(ExecutionMode mode)
     {
         var output = TestHarness.Run("console.log((5 as any) instanceof Number);", mode);
@@ -101,10 +102,18 @@ public class PrimitiveWrapperTests
     }
 
     [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void String_Bare_NotInstanceofString(ExecutionMode mode)
     {
         var output = TestHarness.Run("console.log(('x' as any) instanceof String);", mode);
+        Assert.Equal("false\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Boolean_Bare_NotInstanceofBoolean(ExecutionMode mode)
+    {
+        var output = TestHarness.Run("console.log((true as any) instanceof Boolean);", mode);
         Assert.Equal("false\n", output);
     }
 


### PR DESCRIPTION
## Summary

Closes #375. In compiled mode `5 instanceof Number`, `'x' instanceof String`, and `true instanceof Boolean` returned `true`. Per ECMA-262 OrdinaryHasInstance a bare primitive is never an instance of its wrapper constructor — Node and the interpreter (since #360) return `false`.

## Root cause

`Number`/`String`/`Boolean` lower to the `System.Double`/`String`/`Boolean` Type tokens (`RuntimeEmitter.GlobalThis.cs`). In compiled `EmitInstanceOf` (`RuntimeEmitter.CoreUtilities.cs`), the `CheckBoxed` helper recognizes boxed wrappers (`new Number(5)`), but when it *didn't* match it fell through to the final `IsAssignableFrom(instance.GetType(), classType)` — and `IsAssignableFrom(typeof(double), typeof(double))` is `true`, so a bare boxed double matched.

## Fix

Make `CheckBoxed` **terminal** for the three primitive wrapper types, mirroring the existing terminal `Object` branch directly above it: branch to `true` iff the instance carries the matching `__primitiveType` marker, else to `false` — never fall through to `IsAssignableFrom`. One extra `Br falseLabel` per type; IL verifies.

- `new Number(5) instanceof Number` → still `true` (boxed wrapper)
- `5 instanceof Number` → now `false`
- `new Number(5) instanceof Object` → still `true`; `5 instanceof Object` → still `false`

## Tests

- Widened `Number_Bare_NotInstanceofNumber` / `String_Bare_NotInstanceofString` from `InterpretedOnly` to `All`, added `Boolean_Bare_NotInstanceofBoolean`.
- `PrimitiveWrapperTests` (42) + all instanceof tests (80) green in both modes; `--compile --verify` passes; manual repro matches Node exactly (`false false false true true true false true`).

## ⚠️ Conformance impact — please read

This is a **strictly-correct** fix, but it **unmasks a separate pre-existing bug** (filed as #454): SharpTS array iteration methods don't `ToObject`-box a primitive `this`. ~21 compiled Test262 tests in `built-ins/Array/prototype/{every,filter,forEach,map,reduce,reduceRight,some}` (the `-1-3`/`-1-5`/`-1-7` boxed-`this` variants) were passing in **compiled** mode *only because* this instanceof bug returned `true` for the bare primitive — two bugs canceling out. With instanceof fixed, they now correctly **fail**, matching **interpreter** mode (which already fails/errors them). They are pre-existing latent failures, not new regressions.

**No baseline change is committed here.** The `SharpTS.Test262/baselines/compiled.txt` regen needs to happen in a stable environment: a local full regen produced 226 changed lines dominated by pre-existing nondeterminism (e.g. 77 `Fail→RuntimeError`, `Timeout→Fail`, `ParseError→Pass` — transitions an instanceof change cannot cause). My change's effect is cleanly isolatable to exactly those 21 files (all `Pass→Fail`). The Test262 project isn't in `SharpTS.sln`, so normal CI is unaffected; recommend regenerating `compiled.txt` when next running the conformance suite.

## Issues filed along the way

- #449 — compiled `Symbol() instanceof Symbol` returns `true` (same root cause; Symbol additionally needs cross-mode boxed-wrapper handling, so out of scope here).
- #454 — array iteration methods (and `Object.defineProperties`) don't `ToObject`-box a primitive `this` (the gap this fix unmasks).