### PR TITLE
Fix #346: resolve as-cast/satisfies conditional targets node-first

### DIFF
--- a/Parsing/AST.cs
+++ b/Parsing/AST.cs
@@ -216,10 +216,15 @@ public abstract record Expr
     ) : Expr;
     // Spread expression for calls and array literals
     public record Spread(Expr Expression) : Expr;
-    // Type assertion: value as Type
-    public record TypeAssertion(Expr Expression, string TargetType) : Expr;
-    // Satisfies operator: value satisfies Type (TS 4.9+) - validates without widening
-    public record Satisfies(Expr Expression, string ConstraintType) : Expr;
+    // Type assertion: value as Type. TargetTypeNode is the structured form of TargetType (type-AST
+    // migration) when the parser could build one; the checker resolves it node-first so a composite
+    // target (e.g. a conditional type with a function-type extends clause) bypasses the string
+    // resolver's scanning hazards. Null for `as const` and any construct without node support.
+    public record TypeAssertion(Expr Expression, string TargetType, TypeNode? TargetTypeNode = null) : Expr;
+    // Satisfies operator: value satisfies Type (TS 4.9+) - validates without widening.
+    // ConstraintTypeNode mirrors TypeAssertion.TargetTypeNode: the structured form resolved
+    // node-first so a composite constraint bypasses the string resolver's scanning hazards.
+    public record Satisfies(Expr Expression, string ConstraintType, TypeNode? ConstraintTypeNode = null) : Expr;
     // Await expression: await expr (only valid inside async functions)
     public record Await(Token Keyword, Expr Expression) : Expr;
     // Dynamic import: import(pathExpr) - returns Promise of module namespace

--- a/Parsing/Parser.Expressions.cs
+++ b/Parsing/Parser.Expressions.cs
@@ -534,7 +534,7 @@ public partial class Parser
                 {
                     // Type assertion: expr as Type
                     string targetType = ParseTypeAnnotation();
-                    expr = new Expr.TypeAssertion(expr, targetType);
+                    expr = new Expr.TypeAssertion(expr, targetType, TakeTypeNode());
                 }
             }
             else if (Match(TokenType.SATISFIES))
@@ -542,7 +542,7 @@ public partial class Parser
                 // Satisfies operator: expr satisfies Type (TS 4.9+)
                 // Validates that expr matches Type without widening the inferred type
                 string constraintType = ParseTypeAnnotation();
-                expr = new Expr.Satisfies(expr, constraintType);
+                expr = new Expr.Satisfies(expr, constraintType, TakeTypeNode());
             }
             else if (Match(TokenType.BANG))
             {

--- a/SharpTS.Tests/TypeCheckerTests/FunctionSignatureInferTests.cs
+++ b/SharpTS.Tests/TypeCheckerTests/FunctionSignatureInferTests.cs
@@ -1,0 +1,137 @@
+using SharpTS.Tests.Infrastructure;
+using SharpTS.TypeSystem.Exceptions;
+using Xunit;
+
+namespace SharpTS.Tests.TypeCheckerTests;
+
+/// <summary>
+/// Function-type infer matching in conditional types (#346) — the bare-function sibling of
+/// <see cref="ConstructSignatureInferTests"/> (#316). A pattern like
+/// <c>T extends () =&gt; infer U ? U : ...</c> resolves the infer binding in parameter/return
+/// position.
+///
+/// The node path (a variable/return annotation) already resolved these correctly. The bug was in
+/// the STRING resolver, reached by an <c>as</c>-cast target: its top-level scanners treated the
+/// <c>&gt;</c> of an arrow <c>=&gt;</c> as a closing bracket, so the conditional's trailing
+/// <c>? :</c> was never seen and the whole alias garbled to
+/// <c>() =&gt; (any) =&gt; infer U ? U : "no"</c> instead of resolving to <c>string</c>. The fix routes
+/// an <c>as</c>-cast target through the same node resolver the annotation path uses
+/// (<c>Expr.TypeAssertion.TargetTypeNode</c>), bypassing the string scanner entirely.
+/// </summary>
+public class FunctionSignatureInferTests
+{
+    // ---- as-cast target (the form the bug reproduced on; exercises the node-routing fix) ----
+
+    [Fact]
+    public void AsCast_FunctionReturnInfer_ResolvesToInferredType()
+    {
+        // Ret<() => string> is string, so casting through it and assigning to a string is fine.
+        // Before the fix the cast target garbled to a function type, which a string assignment rejects.
+        var source = """
+            type Ret<T> = T extends () => infer U ? U : "no";
+            const s: string = (null as any as Ret<() => string>);
+            """;
+        TestHarness.RunInterpreted(source);
+    }
+
+    [Fact]
+    public void AsCast_FunctionReturnInfer_WrongAssignment_IsTypeError()
+    {
+        // The issue's canonical repro: Ret<() => string> is string, so assigning it to a number errors.
+        var source = """
+            type Ret<T> = T extends () => infer U ? U : "no";
+            let b: number = (null as any as Ret<() => string>);
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void AsCast_FunctionParameterInfer_ResolvesToInferredType()
+    {
+        // Param<(a: number) => void> is number; a number assignment is accepted.
+        var source = """
+            type Param<T> = T extends (a: infer P) => any ? P : "no";
+            const n: number = (null as any as Param<(a: number) => void>);
+            """;
+        TestHarness.RunInterpreted(source);
+    }
+
+    [Fact]
+    public void AsCast_NonFunction_TakesFalseBranch()
+    {
+        // string is not a function, so the conditional resolves to its false branch ("no"); a
+        // number assignment violates it.
+        var source = """
+            type Ret<T> = T extends () => infer U ? U : "no";
+            let y: number = (null as any as Ret<string>);
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void Satisfies_FunctionReturnInfer_ResolvesToInferredType()
+    {
+        // `satisfies` shares the string-resolver garble; its constraint now resolves node-first too.
+        // Ret<() => string> is string, which the string literal "hello" satisfies.
+        var source = """
+            type Ret<T> = T extends () => infer U ? U : "no";
+            const r = ("hello" satisfies Ret<() => string>);
+            """;
+        TestHarness.RunInterpreted(source);
+    }
+
+    [Fact]
+    public void Satisfies_FunctionReturnInfer_Violation_IsTypeError()
+    {
+        // 42 is not a string, so it does not satisfy Ret<() => string>.
+        var source = """
+            type Ret<T> = T extends () => infer U ? U : "no";
+            const r = (42 satisfies Ret<() => string>);
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+
+    // ---- annotation target (node path; locks in the underlying conditional resolution) ----
+
+    [Fact]
+    public void Annotation_FunctionReturnInfer_InfersReturnType()
+    {
+        var source = """
+            type Ret<T> = T extends () => infer U ? U : "no-match";
+            let x: Ret<() => { a: string }> = { a: "hi" };
+            """;
+        TestHarness.RunInterpreted(source);
+    }
+
+    [Fact]
+    public void Annotation_FunctionReturnInfer_WrongAssignment_IsTypeError()
+    {
+        var source = """
+            type Ret<T> = T extends () => infer U ? U : "no-match";
+            let x: Ret<() => { a: string }> = 42;
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void Annotation_FunctionParameterAndReturn_BothInfer()
+    {
+        // Two infer placeholders across param and return positions resolve into a tuple [A, R];
+        // the second element (R = string) rejects a number.
+        var source = """
+            type FP<T> = T extends (a: infer A) => infer R ? [A, R] : never;
+            let m: FP<(a: number) => string> = [1, 2];
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void Annotation_NonFunction_FalseBranchValueAccepted()
+    {
+        var source = """
+            type Ret<T> = T extends () => infer U ? U : "no-match";
+            let y: Ret<string> = "no-match";
+            """;
+        TestHarness.RunInterpreted(source);
+    }
+}

--- a/TypeSystem/TypeChecker.Expressions.cs
+++ b/TypeSystem/TypeChecker.Expressions.cs
@@ -353,7 +353,13 @@ public partial class TypeChecker
             return InferConstType(ta.Expression, sourceType);
         }
 
-        TypeInfo targetType = ToTypeInfo(ta.TargetType);
+        // Resolve the target node-first: a composite target such as a conditional type whose
+        // extends clause is a function type (`X extends () => infer U ? U : V`) is mis-scanned by
+        // the string resolver (the '>' of '=>' reads as a closing bracket, so the conditional's
+        // '?' is missed and the type garbles). The node path resolves it structurally; the string
+        // path stays the fallback for any node the migration doesn't cover yet (#346).
+        TypeInfo targetType = (ta.TargetTypeNode is { } targetNode ? TryToTypeInfo(targetNode) : null)
+            ?? ToTypeInfo(ta.TargetType);
 
         // Allow any <-> anything (escape hatch)
         if (sourceType is TypeInfo.Any || targetType is TypeInfo.Any)
@@ -369,7 +375,10 @@ public partial class TypeChecker
     private TypeInfo CheckSatisfies(Expr.Satisfies sat)
     {
         TypeInfo inferredType = CheckExpr(sat.Expression);
-        TypeInfo constraintType = ToTypeInfo(sat.ConstraintType);
+        // Node-first, mirroring CheckTypeAssertion (#346): a composite constraint such as a
+        // conditional with a function-type extends clause garbles in the string resolver.
+        TypeInfo constraintType = (sat.ConstraintTypeNode is { } constraintNode ? TryToTypeInfo(constraintNode) : null)
+            ?? ToTypeInfo(sat.ConstraintType);
 
         // Escape hatches - any/unknown constraints always pass
         if (constraintType is TypeInfo.Any or TypeInfo.Unknown)


### PR DESCRIPTION
## What & why

Fixes #346. A function type in a conditional's extends clause — `type Ret<T> = T extends () => infer U ? U : "no"` — garbled to `() => (any) => infer U ? U : "no"` instead of resolving to `string`.

The issue's stated root cause (the parser's `ParseFunctionTypeBody`) is **stale**: the parser already builds a correct `ConditionalTypeNode`, and the node-based type resolver added in #316 already resolves these conditionals — so **variable/return-type annotations already worked**. The only broken forms were the issue's own repro (an `as`-cast) and its sibling `satisfies`: `Expr.TypeAssertion`/`Expr.Satisfies` stored the target type as a **string only**, forcing the legacy string resolver. That resolver's top-level bracket scanners treat the `>` of an arrow `=>` as a closing bracket (it has no matching `<`), driving depth negative, so the conditional's `?` is never found and the type falls through to function-type parsing.

## The fix

Give `TypeAssertion` and `Satisfies` an optional `TypeNode` (the structured form the parser already produces via the `_lastTypeNode` side channel) and resolve it **node-first** in the checker, with the string path kept as a fallback. This routes the cast/`satisfies` target through the same node resolver annotations already use, bypassing the string scanner — advancing the type-AST migration rather than patching the fragile string path.

- `Parsing/AST.cs` — `TypeAssertion.TargetTypeNode` / `Satisfies.ConstraintTypeNode`
- `Parsing/Parser.Expressions.cs` — capture via `TakeTypeNode()`
- `TypeSystem/TypeChecker.Expressions.cs` — `CheckTypeAssertion` / `CheckSatisfies` resolve `TryToTypeInfo(node) ?? ToTypeInfo(string)`

## Why not fix the string scanner directly

I prototyped adding the `=>` guard to the string resolver's conditional-detection scanners. It's correct, but it **exposes a pre-existing infer-match bug** and regresses `conformance/types/conditional/inferTypes1.ts` — on `main` that test only "passes" because the unrecognized conditional garbles to `any` (assignable to anything). The node-routing approach avoids destabilizing the legacy string path. The two underlying string-resolver gaps are filed for a separate, paired fix:

- #461 — `T extends { method(): infer R }` never binds `R` for class instances (`ExtractPropertiesWithTypes` omits class methods)
- #462 — string resolver mis-scans `=>` in top-level depth scans (also breaks function-element tuples and indexed access); must land with #461

## Tests & verification

- New `SharpTS.Tests/TypeCheckerTests/FunctionSignatureInferTests.cs` (10 tests). The `as`-cast/`satisfies` positives fail on `main` and pass here; annotation cases lock in the node-path resolution. Sibling of `ConstructSignatureInferTests` (#316).
- Issue's exact repro now errors correctly: `Type 'string' is not assignable to type 'number'`.
- Full unit suite green (11367/0); TypeScript conformance green (31/0, no baseline drift).
