### PR TITLE
Fix #406: cross-runtime MessagePort transfer into a worker (both modes)

### DIFF
--- a/Runtime/BuiltIns/BuiltInRegistry.cs
+++ b/Runtime/BuiltIns/BuiltInRegistry.cs
@@ -1039,6 +1039,12 @@ public sealed class BuiltInRegistry
         registry.RegisterInstanceType(typeof(SharpTSMessagePort), (instance, name) =>
             ((SharpTSMessagePort)instance).GetMember(name));
 
+        // Register the worker-side bridge for a compiled $MessagePort transferred
+        // into an interpreter worker. Instance lookup is exact-type, so this distinct
+        // type needs its own registration to reach its GetMember (#406).
+        registry.RegisterInstanceType(typeof(CompiledMessagePortBridge), (instance, name) =>
+            ((CompiledMessagePortBridge)instance).GetMember(name));
+
         // Register the worker-side parentPort (postMessage + EventEmitter members).
         // Instance lookup is exact-type, so the WorkerParentPort subclass needs
         // its own registration to reach its GetMember (#209).

--- a/Runtime/Types/CompiledMessagePortBridge.cs
+++ b/Runtime/Types/CompiledMessagePortBridge.cs
@@ -1,0 +1,257 @@
+using System.Collections.Concurrent;
+using System.Reflection;
+using SharpTS.Runtime.BuiltIns;
+using Interp = SharpTS.Execution.Interpreter;
+
+namespace SharpTS.Runtime.Types;
+
+/// <summary>
+/// Worker-side adapter that lets an interpreter worker drive a MessagePort that a
+/// COMPILED parent created and transferred via <c>workerData</c>/<c>transferList</c> (#406).
+/// </summary>
+/// <remarks>
+/// A compiled parent's <c>MessageChannel</c> produces two emitted <c>$MessagePort</c>
+/// objects (see <c>RuntimeEmitter.MessageChannel.cs</c>) that communicate in-process:
+/// <c>postMessage</c> enqueues a structured clone to the partner's internal
+/// <c>_pending</c> queue and, if the partner has started, schedules the partner's
+/// <c>Drain</c> on the process-global <c>$EventLoop</c>. A worker always runs the
+/// interpreter on its own thread, so it cannot call methods on the raw emitted type
+/// and cannot safely be driven by the parent's <c>$EventLoop</c> (a different thread).
+///
+/// This bridge wraps the transferred compiled port and presents the interpreter
+/// MessagePort surface (<c>postMessage</c>/<c>on</c>/<c>once</c>/<c>start</c>/
+/// <c>close</c> plus the inherited EventEmitter members):
+/// <list type="bullet">
+/// <item><b>send</b> — <c>postMessage(v)</c> structured-clones <c>v</c> (copy
+/// semantics) then reflectively invokes the compiled port's <c>PostMessage</c>,
+/// reusing its enqueue-to-partner + schedule-drain-on-<c>$EventLoop</c> logic so the
+/// parent's compiled listeners run on the parent loop thread.</item>
+/// <item><b>receive</b> — the compiled partner's posts are always enqueued to the
+/// transferred port's <c>_pending</c> queue (the drain is only <i>scheduled</i> when
+/// the port has started, which this transferred port never does on the compiled
+/// side). A recurring timer on the WORKER interpreter's loop drains that queue and
+/// emits <c>'message'</c> to the worker's listeners on the worker thread. The
+/// interval timer also keeps the worker loop alive while the port is open, matching
+/// Node's "a listening port is ref'd" semantics (#406, same liveness class as #329).</item>
+/// </list>
+///
+/// All access to the emitted type is via reflection cached at adoption time, since
+/// this class lives in SharpTS.dll while the compiled port lives in the output
+/// assembly. The field/method names mirrored here (<c>PostMessage</c>, <c>_pending</c>)
+/// MUST stay in sync with <c>RuntimeEmitter.MessageChannel.cs</c>.
+/// </remarks>
+public sealed class CompiledMessagePortBridge : SharpTSEventEmitter
+{
+    // The poll cadence for draining the compiled port's incoming queue onto the
+    // worker loop. Matches WorkerMessageHandler's 10ms parent→worker poll so the
+    // two worker-bound delivery paths feel identical.
+    private const int PollIntervalMs = 10;
+
+    private readonly object _compiledPort;               // transferred emitted $MessagePort
+    private readonly MethodInfo _postMessageMethod;      // $MessagePort.PostMessage(object)
+    private readonly ConcurrentQueue<object> _incoming;  // $MessagePort._pending
+
+    // The worker interpreter that owns delivery. Captured the first time the worker
+    // attaches a 'message' listener / starts the port; null until then.
+    private Interp? _owner;
+    private Interp.VirtualTimer? _pollTimer;
+    private bool _started;
+    private bool _closed;
+    private bool _loopRefed;
+
+    // RuntimeCategory deliberately not overridden — see SharpTSMessagePort. The base
+    // returns Unknown for subclasses, routing member access through the per-type
+    // registration in BuiltInRegistry, which reaches this class's GetMember.
+
+    private CompiledMessagePortBridge(object compiledPort, MethodInfo postMessageMethod, ConcurrentQueue<object> incoming)
+    {
+        _compiledPort = compiledPort;
+        _postMessageMethod = postMessageMethod;
+        _incoming = incoming;
+    }
+
+    /// <summary>
+    /// True when <paramref name="value"/> is a compiled-mode emitted <c>$MessagePort</c>.
+    /// Detected by type name (the type cannot be referenced from SharpTS.dll), the same
+    /// approach <see cref="StructuredClone"/> uses for <c>$ArrayBuffer</c>/<c>$SharedArrayBuffer</c>.
+    /// </summary>
+    public static bool IsEmittedMessagePort(object? value) => value?.GetType().Name == "$MessagePort";
+
+    /// <summary>
+    /// Adopts a transferred compiled <c>$MessagePort</c> into a worker-usable bridge.
+    /// Caches the reflection handles for the port's <c>PostMessage</c> method and
+    /// <c>_pending</c> queue. Throws <see cref="StructuredClone.DataCloneError"/> if the
+    /// emitted shape doesn't match what <c>RuntimeEmitter.MessageChannel.cs</c> emits.
+    /// </summary>
+    public static CompiledMessagePortBridge Adopt(object compiledPort)
+    {
+        var type = compiledPort.GetType();
+
+        var postMessage = type.GetMethod("PostMessage", [typeof(object)])
+            ?? throw new StructuredClone.DataCloneError(
+                "Cannot transfer $MessagePort: no PostMessage(object) method (emitted shape changed?)");
+
+        var pendingField = type.GetField("_pending", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new StructuredClone.DataCloneError(
+                "Cannot transfer $MessagePort: no _pending field (emitted shape changed?)");
+
+        if (pendingField.GetValue(compiledPort) is not ConcurrentQueue<object> incoming)
+            throw new StructuredClone.DataCloneError(
+                "Cannot transfer $MessagePort: _pending is not a ConcurrentQueue<object>");
+
+        return new CompiledMessagePortBridge(compiledPort, postMessage, incoming);
+    }
+
+    /// <summary>
+    /// Posts a message to the compiled partner port. Structured-clones for copy
+    /// semantics, then hands off to the compiled port's own delivery (enqueue +
+    /// schedule the partner's drain on the parent <c>$EventLoop</c>).
+    /// </summary>
+    private void PostMessage(object? message)
+    {
+        if (_closed)
+            return;
+
+        // Copy semantics: clone on the worker side before handing to the compiled
+        // port. The compiled PostMessage re-clones via its own (standalone) routine,
+        // but that is a pass-through no-op for interpreter-shaped values, so the net
+        // effect is exactly one structured copy and the worker never shares a mutable
+        // graph with the parent.
+        var clone = StructuredClone.Clone(message);
+        _postMessageMethod.Invoke(_compiledPort, [clone]);
+    }
+
+    /// <summary>
+    /// Begins delivery: schedules a recurring drain of the compiled port's incoming
+    /// queue onto the worker loop. Idempotent. No-op until an owner interpreter has
+    /// been captured (via the first <c>on('message')</c>/<c>start()</c>).
+    /// </summary>
+    private void Start()
+    {
+        if (_started || _closed || _owner == null)
+            return;
+
+        _started = true;
+
+        // Keep the worker loop alive while the port is open. RunEventLoop's exit
+        // check counts active handles and queued callbacks but NOT scheduled timers,
+        // so the poll interval alone would not hold the loop open — without this Ref
+        // the worker can quiesce and exit before the parent's message is ever polled
+        // (Node: a listening port is ref'd; #406, same liveness class as #329).
+        if (!_loopRefed)
+        {
+            _loopRefed = true;
+            _owner.Ref();
+        }
+
+        // The interval timer drains _incoming on the worker loop thread. Delay 0 so
+        // anything the parent already posted before the worker started is delivered
+        // on the next tick; the partner's posts land in _incoming asynchronously, so
+        // the loop must poll (the compiled enqueue cannot wake this interpreter).
+        // An event-driven alternative is tracked as a follow-up (#465).
+        _pollTimer = _owner.ScheduleTimer(0, PollIntervalMs, Pump, isInterval: true);
+    }
+
+    /// <summary>
+    /// Drains the compiled port's incoming queue, emitting each message to the
+    /// worker's 'message' listeners. Runs on the worker loop thread.
+    /// </summary>
+    private void Pump()
+    {
+        if (_closed || _owner == null)
+            return;
+
+        // The compiled sender already structured-cloned each payload before enqueuing,
+        // so values here are independent copies — emit them directly (Node semantics:
+        // the listener receives the value, not a {data} wrapper).
+        while (_incoming.TryDequeue(out var message))
+        {
+            EmitEvent(_owner, "message", [message]);
+        }
+    }
+
+    /// <summary>
+    /// Stops worker-side delivery and cancels the poll timer so the worker loop can
+    /// quiesce and the worker can exit. Emits 'close' to the worker's listeners.
+    /// </summary>
+    private void Close()
+    {
+        if (_closed)
+            return;
+
+        _closed = true;
+
+        if (_pollTimer != null)
+        {
+            _pollTimer.IsCancelled = true;
+            _pollTimer = null;
+        }
+
+        // Release the keep-alive Ref so the worker loop can quiesce and the worker
+        // thread can exit.
+        if (_loopRefed && _owner != null)
+        {
+            _loopRefed = false;
+            _owner.Unref();
+        }
+
+        if (_owner != null)
+            EmitEvent(_owner, "close", []);
+    }
+
+    /// <summary>
+    /// Interpreter member dispatch. Adds the MessagePort surface on top of the
+    /// inherited EventEmitter members; attaching a 'message' listener implicitly
+    /// starts the port (Node worker_threads semantics, mirroring SharpTSMessagePort).
+    /// </summary>
+    public new object? GetMember(string name)
+    {
+        return name switch
+        {
+            "postMessage" => BuiltInMethod.CreateV2("postMessage", 1, 2, (_, _, args) =>
+            {
+                if (args.Length == 0)
+                    throw new Exception("postMessage requires at least one argument");
+                // A transferList on a re-post from the worker is not supported across
+                // this bridge (the worker re-transferring a compiled port); the second
+                // argument is ignored rather than rejected.
+                PostMessage(args[0].ToObject());
+                return RuntimeValue.Null;
+            }),
+
+            "start" => BuiltInMethod.CreateV2("start", 0, (interp, _, _) =>
+            {
+                _owner ??= interp;
+                Start();
+                return RuntimeValue.Null;
+            }),
+
+            "close" => BuiltInMethod.CreateV2("close", 0, (interp, _, _) =>
+            {
+                _owner ??= interp;
+                Close();
+                return RuntimeValue.Null;
+            }),
+
+            "on" or "addListener" or "once" => BuiltInMethod.CreateV2(name, 2, (interp, _, args) =>
+            {
+                var eventName = args[0].ToObject()?.ToString()
+                    ?? throw new Exception("Event name must be a string");
+                var listener = args[1].ToObject()
+                    ?? throw new Exception("Listener must be a function");
+                AddListenerDirect(eventName, listener, once: name == "once");
+                if (eventName == "message")
+                {
+                    _owner ??= interp;
+                    Start();
+                }
+                return RuntimeValue.FromObject(this);
+            }),
+
+            // Inherit EventEmitter methods (off/emit/listeners/...).
+            _ => base.GetMember(name)
+        };
+    }
+
+    public override string ToString() => _closed ? "MessagePort { closed }" : "MessagePort {}";
+}

--- a/Runtime/Types/SharpTSMessagePort.cs
+++ b/Runtime/Types/SharpTSMessagePort.cs
@@ -41,6 +41,24 @@ public class SharpTSMessagePort : SharpTSEventEmitter
     private bool _neutered;
 
     /// <summary>
+    /// Whether this port (and its partner) have been transferred to a worker on
+    /// another thread. The two ports of a channel live in the same process but on
+    /// different event-loop threads once one is handed to a worker, so delivery
+    /// must be marshalled onto each owner's loop rather than emitted synchronously
+    /// on the poster's thread, and a started port must keep its owner's loop alive
+    /// (Node semantics for a listening port). See <see cref="MarkTransferredAcrossThreads"/>
+    /// and #406.
+    /// </summary>
+    private bool _crossThread;
+
+    /// <summary>
+    /// Whether this port currently holds a keep-alive Ref against its owner loop
+    /// (only ever true for a started, unclosed cross-thread port). Guards against
+    /// double Ref/Unref.
+    /// </summary>
+    private bool _loopRefed;
+
+    /// <summary>
     /// The interpreter to use for event dispatch (set when added to a context).
     /// </summary>
     internal Interp? OwnerInterpreter { get; set; }
@@ -71,6 +89,32 @@ public class SharpTSMessagePort : SharpTSEventEmitter
     internal void Neuter()
     {
         _neutered = true;
+    }
+
+    /// <summary>
+    /// Marks this port and its partner as having been transferred across an
+    /// event-loop-thread boundary (one of the pair was handed to a worker). After
+    /// this, message delivery is marshalled onto each port's owner-loop thread and
+    /// a started port Refs that loop so a worker waiting only on a transferred port
+    /// stays alive until the port closes (#406). Idempotent; recurses once to the
+    /// partner.
+    /// </summary>
+    internal void MarkTransferredAcrossThreads()
+    {
+        if (_crossThread)
+            return;
+        _crossThread = true;
+
+        // If the port was already started before the transfer was recorded (the
+        // listener was attached before the worker spawned), take the keep-alive Ref
+        // now — Start() won't run again.
+        if (_started && !_closed && !_loopRefed && OwnerInterpreter != null)
+        {
+            _loopRefed = true;
+            OwnerInterpreter.Ref();
+        }
+
+        _partner?.MarkTransferredAcrossThreads();
     }
 
     /// <summary>
@@ -105,10 +149,16 @@ public class SharpTSMessagePort : SharpTSEventEmitter
 
         _queue.Add(message);
 
-        // If started, trigger message delivery
+        // If started, trigger message delivery.
         if (_started && OwnerInterpreter != null)
         {
-            DeliverPendingMessages();
+            if (_crossThread)
+                // The poster runs on the partner's thread (e.g. a worker), not on
+                // this port's owner loop. Marshal delivery onto the owner loop so
+                // guest 'message' listeners run on the correct, single thread.
+                OwnerInterpreter.EnqueueCallback(DeliverPendingMessages);
+            else
+                DeliverPendingMessages();
         }
     }
 
@@ -122,10 +172,23 @@ public class SharpTSMessagePort : SharpTSEventEmitter
 
         _started = true;
 
-        // Deliver any queued messages
+        // A started cross-thread port keeps its owner loop alive (Node: a port with
+        // a 'message' listener is ref'd). Without this a worker whose only pending
+        // work is a transferred port would quiesce and exit before any message
+        // arrives (#406 — same liveness class as #329).
+        if (_crossThread && !_loopRefed && OwnerInterpreter != null)
+        {
+            _loopRefed = true;
+            OwnerInterpreter.Ref();
+        }
+
+        // Deliver any queued messages.
         if (OwnerInterpreter != null)
         {
-            DeliverPendingMessages();
+            if (_crossThread)
+                OwnerInterpreter.EnqueueCallback(DeliverPendingMessages);
+            else
+                DeliverPendingMessages();
         }
     }
 
@@ -139,6 +202,13 @@ public class SharpTSMessagePort : SharpTSEventEmitter
 
         _closed = true;
         _queue.CompleteAdding();
+
+        // Release the keep-alive Ref so the owner loop can quiesce and exit.
+        if (_loopRefed && OwnerInterpreter != null)
+        {
+            _loopRefed = false;
+            OwnerInterpreter.Unref();
+        }
 
         // Emit close event
         if (OwnerInterpreter != null)

--- a/Runtime/Types/SharpTSWorker.cs
+++ b/Runtime/Types/SharpTSWorker.cs
@@ -29,7 +29,10 @@ public class SharpTSWorker : SharpTSEventEmitter, IDisposable
     private readonly CancellationTokenSource _cts = new();
     private readonly string _scriptPath;
     private readonly object? _workerData;
-    private readonly SharpTSArray? _transferList;
+    // Honored from either runtime: the interpreter SharpTSArray and a compiled
+    // List<object?> both implement IEnumerable<object?>, so StructuredClone.Clone
+    // receives the transfer list regardless of how the parent built it (#406).
+    private readonly IEnumerable<object?>? _transferList;
     private volatile bool _isRunning;
     private volatile bool _isTerminated;
     private Exception? _workerError;
@@ -136,14 +139,15 @@ public class SharpTSWorker : SharpTSEventEmitter, IDisposable
         //
         // The bag is a SharpTSObject in interpreter mode and a Dictionary<string, object?>
         // (a compiled object literal) in compiled mode; ReadOption reads through both so
-        // workerData/transferList are honored either way (#380). transferList stays typed
-        // as SharpTSArray: a compiled List<object?> transferList yields null here (so
-        // workerData still clones), and cross-boundary MessagePort transfer in compiled
-        // mode is a separate gap (#406).
+        // workerData/transferList are honored either way (#380). transferList is read as
+        // IEnumerable<object?> so both the interpreter SharpTSArray and a compiled
+        // List<object?> survive — a transferred MessagePort is then adopted by the worker
+        // (cross-thread for interpreter ports, via CompiledMessagePortBridge for compiled
+        // $MessagePort) inside StructuredClone.Clone (#406).
         if (options != null)
         {
             _workerData = ReadOption(options, "workerData");
-            _transferList = ReadOption(options, "transferList") as SharpTSArray;
+            _transferList = ReadOption(options, "transferList") as IEnumerable<object?>;
         }
 
         // Clone workerData for transfer to worker

--- a/Runtime/Types/StructuredClone.cs
+++ b/Runtime/Types/StructuredClone.cs
@@ -27,21 +27,27 @@ public static class StructuredClone
     /// Clones a value using the structured clone algorithm.
     /// </summary>
     /// <param name="value">The value to clone.</param>
-    /// <param name="transfer">Optional array of transferable objects.</param>
+    /// <param name="transfer">
+    /// Optional list of transferable objects. Accepts both the interpreter
+    /// <see cref="SharpTSArray"/> and a compiled <c>List&lt;object?&gt;</c> (both are
+    /// <see cref="IEnumerable{T}"/> of <c>object?</c>), so a transfer list survives
+    /// from either runtime (#406).
+    /// </param>
     /// <returns>A deep clone of the value.</returns>
-    public static object? Clone(object? value, SharpTSArray? transfer = null)
+    public static object? Clone(object? value, IEnumerable<object?>? transfer = null)
     {
         var cloned = new Dictionary<object, object>();
         var transferred = new HashSet<object>();
 
-        // Process transfer list
+        // Process transfer list. A transferable is either the interpreter
+        // SharpTSMessagePort or the emitted compiled $MessagePort (#406).
         if (transfer != null)
         {
             foreach (var item in transfer)
             {
-                if (item is SharpTSMessagePort)
+                if (item is SharpTSMessagePort || CompiledMessagePortBridge.IsEmittedMessagePort(item))
                 {
-                    transferred.Add(item);
+                    transferred.Add(item!);
                 }
                 else if (item != null)
                 {
@@ -153,6 +159,15 @@ public static class StructuredClone
             // EventEmitter - cannot be cloned (has listeners)
             SharpTSEventEmitter => throw new DataCloneError("EventEmitter cannot be cloned"),
 
+            // Emitted $MessagePort from compiled code - transferred (never cloned).
+            // When in the transfer set, adopt it into a worker-usable bridge so the
+            // worker's interpreter can drive the compiled port; otherwise reject,
+            // matching the interpreter SharpTSMessagePort arms above (#406).
+            _ when CompiledMessagePortBridge.IsEmittedMessagePort(value) && transferred.Contains(value)
+                => CompiledMessagePortBridge.Adopt(value),
+            _ when CompiledMessagePortBridge.IsEmittedMessagePort(value)
+                => throw new DataCloneError("MessagePort cannot be cloned, only transferred"),
+
             // Emitted $SharedArrayBuffer type from compiled code - pass by reference
             // Check by type name since we can't reference the dynamically emitted type
             _ when value.GetType().Name == "$SharedArrayBuffer" => value,
@@ -227,8 +242,14 @@ public static class StructuredClone
 
     private static SharpTSMessagePort TransferMessagePort(SharpTSMessagePort port)
     {
-        // Neutering happens on the sending side; the port is handed to the receiver
-        port.Neuter();
+        // A worker transfer hands the SAME port object to the worker's interpreter,
+        // which runs on another thread in this process. Neutering it (the browser
+        // semantics, where transfer detaches the sender's handle) would make the
+        // shared object unusable on the RECEIVING side too, since both sides see
+        // one object. Instead mark it and its partner cross-thread: each port then
+        // marshals delivery onto its own owner-loop thread and a started port keeps
+        // that loop alive (#406).
+        port.MarkTransferredAcrossThreads();
         return port;
     }
 

--- a/SharpTS.Tests/SharedTests/WorkerThreadsTests.cs
+++ b/SharpTS.Tests/SharedTests/WorkerThreadsTests.cs
@@ -683,4 +683,146 @@ public class WorkerThreadsTests
     }
 
     #endregion
+
+    #region MessagePort transfer to a worker (#406)
+
+    /// <summary>
+    /// Regression for #406: a <c>MessagePort</c> created in the parent and listed in
+    /// a Worker's <c>transferList</c> must be usable inside the worker — the worker
+    /// can attach a listener and post back through it, round-tripping with the
+    /// partner port retained by the parent.
+    /// </summary>
+    /// <remarks>
+    /// This exercises the full cross-runtime/cross-thread contract. In compiled mode
+    /// the channel ports are the emitted <c>$MessagePort</c> type and the transferred
+    /// port is adopted by the worker's interpreter via <c>CompiledMessagePortBridge</c>
+    /// (which forwards posts to the compiled partner on the parent's <c>$EventLoop</c>
+    /// and drains the partner's posts onto the worker loop). In interpreter mode the
+    /// ports are <c>SharpTSMessagePort</c>; transfer marks the pair cross-thread so
+    /// delivery marshals onto each owner's loop instead of the poster's thread, and a
+    /// started port keeps its loop alive. Before the fix the compiled
+    /// <c>transferList</c> (a <c>List&lt;object?&gt;</c>) was dropped and the
+    /// <c>$MessagePort</c> failed to clone; the interpreter port was neutered on
+    /// transfer (unusable by the receiver) and delivered on the wrong thread.
+    /// <para>
+    /// Load-independent: the parent's "ping" is queued on the port until the worker
+    /// attaches its listener (whenever that happens), the started ports keep both
+    /// loops alive until each side closes, and the assertion is a positive
+    /// output-present check — so it cannot flake under load.
+    /// </para>
+    /// </remarks>
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Worker_TransferredMessagePort_RoundTripsBetweenParentAndWorker(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["worker_port.ts"] = """
+                // The transferred port arrives via workerData. Echo each message
+                // back through it, then close so the worker's loop can quiesce.
+                const port: any = workerData.port;
+                port.on("message", (m: any) => {
+                    port.postMessage("pong:" + m);
+                    port.close();
+                });
+                """,
+            ["main.ts"] = """
+                import { Worker, MessageChannel } from "worker_threads";
+                const { port1, port2 } = new MessageChannel();
+                const w = new Worker(__dirname + "/worker_port.ts", {
+                    workerData: { port: port1 },
+                    transferList: [port1],
+                });
+                port2.on("message", (m: any) => {
+                    console.log("received:" + m);
+                    port2.close();
+                });
+                port2.postMessage("ping");
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Contains("received:pong:ping", output);
+    }
+
+    /// <summary>
+    /// #406: an object posted across a transferred port is structured-cloned in both
+    /// directions, so each side reads independent field values (exercises the
+    /// compiled <c>Dictionary&lt;string, object?&gt;</c> clone path through the bridge
+    /// as well as the interpreter <c>SharpTSObject</c> path).
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Worker_TransferredMessagePort_StructuredClonesObjectPayloads(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["worker_port_obj.ts"] = """
+                const port: any = workerData.port;
+                port.on("message", (m: any) => {
+                    port.postMessage({ tag: "reply", value: m.value + 1 });
+                    port.close();
+                });
+                """,
+            ["main.ts"] = """
+                import { Worker, MessageChannel } from "worker_threads";
+                const { port1, port2 } = new MessageChannel();
+                const w = new Worker(__dirname + "/worker_port_obj.ts", {
+                    workerData: { port: port1 },
+                    transferList: [port1],
+                });
+                port2.on("message", (m: any) => {
+                    console.log("received:" + m.tag + ":" + m.value);
+                    port2.close();
+                });
+                port2.postMessage({ tag: "req", value: 41 });
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Contains("received:reply:42", output);
+    }
+
+    /// <summary>
+    /// #406: a <c>MessagePort</c> placed in <c>workerData</c> WITHOUT being listed in
+    /// <c>transferList</c> must be rejected (a port can only be transferred, never
+    /// cloned), in both modes — not silently shared and not an opaque crash.
+    /// </summary>
+    /// <remarks>
+    /// Compiled mode surfaces the error message via <c>e.message</c>; interpreter mode
+    /// currently surfaces worker-construction failures as a raw string (a separate,
+    /// pre-existing quirk — see issue filed alongside #406), so the guest reads
+    /// whichever is present. Either way the rejection text is observable.
+    /// </remarks>
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Worker_MessagePortInWorkerDataWithoutTransfer_IsRejected(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["worker_noop.ts"] = """
+                console.log("worker-should-not-start");
+                """,
+            ["main.ts"] = """
+                import { Worker, MessageChannel } from "worker_threads";
+                const { port1, port2 } = new MessageChannel();
+                try {
+                    // port1 is in workerData but NOT in a transferList.
+                    const w = new Worker(__dirname + "/worker_noop.ts", {
+                        workerData: { port: port1 },
+                    });
+                    console.log("constructed-without-error");
+                } catch (e: any) {
+                    console.log("caught:" + (e && e.message ? e.message : e));
+                }
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Contains("MessagePort cannot be cloned", output);
+        Assert.DoesNotContain("constructed-without-error", output);
+        Assert.DoesNotContain("worker-should-not-start", output);
+    }
+
+    #endregion
 }


### PR DESCRIPTION
Closes #406.

## Problem
A `MessagePort` created in the parent and listed in a Worker's `transferList` was unusable inside the worker — and the feature was broken **end-to-end in both modes**, not just compiled:

- **Interpreter:** the transferred port was `Neuter()`-ed. Since SharpTS models a channel as a single shared object pair in one process, neutering the object broke it for the *receiver* (the worker). Delivery also ran synchronously on the poster's thread — a cross-thread race once the two ports live on different event-loop threads.
- **Compiled:** the `transferList` (a compiled `List<object?>`) was silently dropped by an `as SharpTSArray` read, and the emitted `$MessagePort` had no transfer handling, so cloning `workerData` threw `Cannot clone value of type $MessagePort`.

## Approach
The worker always runs the interpreter on its own thread (same process). The fix makes a transferred port deliver on the **right** loop and keep that loop alive while listening — gated so same-thread channels are untouched.

- **`SharpTSMessagePort`** — `MarkTransferredAcrossThreads()` flags a transferred port *and its partner* cross-thread. Cross-thread ports marshal delivery onto each owner's event loop (`EnqueueCallback`) instead of the poster's thread, and a started one `Ref`s its owner loop (Node: a listening port is ref'd) so a worker waiting only on a transferred port stays alive until close. Same-thread ports keep synchronous delivery and no ref — **zero blast radius** on existing `MessageChannel` behavior.
- **`StructuredClone`** — `transfer` widened to `IEnumerable<object?>` (both `SharpTSArray` and compiled `List<object?>` survive); recognizes the emitted `$MessagePort` and transfers it (or rejects with the standard "cannot be cloned, only transferred" when it isn't in the list). Worker transfer no longer neuters.
- **`CompiledMessagePortBridge`** (new) — worker-side adapter for a compiled `$MessagePort`. `postMessage` structured-clones then forwards to the compiled port's `PostMessage` (delivering to the parent's listeners on the parent `$EventLoop`); receive drains the compiled port's `_pending` queue on the worker loop via a `Ref`'d interval timer. Reflection into the emitted type is cached at adoption. Registered in `BuiltInRegistry` for exact-type dispatch.
- **`SharpTSWorker`** — reads `transferList` as `IEnumerable<object?>`.

## Root-caused a flake, didn't paper over it
First cut hung under load: `RunEventLoop`'s exit check counts active handles and queued callbacks but **not scheduled timers**, so the bridge's poll timer alone didn't hold the worker loop open — the worker could quiesce before the parent's message was polled (won in isolation, lost under load). Fixed by `Ref`-ing the worker loop on start (mirroring the interpreter path), `Unref` on close. Now load-independent.

## Tests
New `WorkerThreadsTests` (both modes, load-independent): round-trip parent↔worker, object payloads (structured clone across the boundary), and rejection of a port placed in `workerData` without a `transferList`. Full suite green: **11416 passed, 0 failed**; the new cases pass repeatedly with no flakes.

## Filed along the way
- #464 — interpreter `Worker` construction errors surface to guest `catch` as a raw string, not an `Error` (pre-existing, general to built-in callables).
- #465 — bridge follow-ups: event-driven (vs. 10ms poll) receive, `receiveMessageOnPort` on a bridged port, worker→worker transfer.