### PR TITLE
Add IL-verification regression guards for await-in-receiver increment (#457)

### DIFF
--- a/SharpTS.Tests/CompilerTests/ILVerificationTests.cs
+++ b/SharpTS.Tests/CompilerTests/ILVerificationTests.cs
@@ -193,6 +193,84 @@ public class ILVerificationTests
         Assert.Equal("12 101 100\n", output);
     }
 
+    // #457: an increment/decrement whose operand's RECEIVER or INDEX contains an `await` —
+    // (await getObj()).n++, --(await getArr())[0], arr[await idx()]++ — emitted invalid IL.
+    // The await inside the receiver/index allocates an async resume label (and a state-dispatch
+    // jump-table entry); the increment must still emit that await so the label is marked. Before
+    // #357's Get/GetIndex arms the base emitter skipped the operand entirely, so the label was
+    // defined and branched to but never marked ("Label N has not been marked") at Save time — a
+    // distinct symptom of the same gap that produced #357's StackUnderflow for a plain receiver.
+    // These pin all three await positions across the async function, async arrow, and async
+    // generator state-machine emitters; SpillBoxed emits the await (suspending with an empty stack)
+    // and stores the result before the read-modify-write.
+
+    [Fact]
+    public void AsyncFunctionAwaitInReceiverIncrement_PassesILVerification()
+    {
+        var source = """
+            let capO: { n: number } = { n: 0 };
+            let capA: number[] = [];
+            async function mkO(): Promise<{ n: number }> { capO = { n: 1 }; return capO; }
+            async function mkA(): Promise<number[]> { capA = [10, 20]; return capA; }
+            async function idx(): Promise<number> { return 0; }
+            async function go(): Promise<void> {
+                (await mkO()).n++;        // await in Get receiver:   capO.n -> 2
+                --(await mkA())[1];       // await in GetIndex recv:  capA[1] -> 19
+                const arr = [5, 6];
+                arr[await idx()]++;       // await in index position: arr[0] -> 6
+                console.log(capO.n, capA[1], arr[0]);
+            }
+            go();
+            """;
+
+        var (errors, output) = TestHarness.CompileVerifyAndRun(source);
+
+        Assert.Empty(errors);
+        Assert.Equal("2 19 6\n", output);
+    }
+
+    [Fact]
+    public void AsyncArrowAwaitInReceiverIncrement_PassesILVerification()
+    {
+        var source = """
+            let cap: { c: number } = { c: 0 };
+            async function mk(): Promise<{ c: number }> { cap = { c: 41 }; return cap; }
+            const run = async (): Promise<void> => {
+                ++(await mk()).c;         // cap.c -> 42
+                console.log(cap.c);
+            };
+            run();
+            """;
+
+        var (errors, output) = TestHarness.CompileVerifyAndRun(source);
+
+        Assert.Empty(errors);
+        Assert.Equal("42\n", output);
+    }
+
+    [Fact]
+    public void AsyncGeneratorAwaitInReceiverIncrement_PassesILVerification()
+    {
+        var source = """
+            let cap: number[] = [];
+            async function mk(): Promise<number[]> { cap = [100]; return cap; }
+            async function* agen(): AsyncGenerator<number> {
+                (await mk())[0]++;        // cap[0] -> 101
+                yield cap[0];
+            }
+            async function main(): Promise<void> {
+                const ag = agen();
+                console.log((await ag.next()).value);
+            }
+            main();
+            """;
+
+        var (errors, output) = TestHarness.CompileVerifyAndRun(source);
+
+        Assert.Empty(errors);
+        Assert.Equal("101\n", output);
+    }
+
     // ---- #414: async-arrow / generator spill across a suspension ----
 
     [Fact]


### PR DESCRIPTION
## Summary

[#457](https://github.com/nickna/SharpTS/issues/457) — a prefix/postfix increment whose operand's **receiver or index contains an `await`** (`(await getObj()).n++`, `--(await getArr())[0]`, `arr[await idx()]++`) — was **already fixed** by #357 / PR #453 and the issue is closed. This PR adds the one piece of regression coverage that was still missing: **formal IL-verification** of these shapes.

## Why this is the await-in-receiver symptom of the same #357 gap

In the async state machine, each `await` pre-allocates a resume label and a state-dispatch jump-table entry; `EmitAwait` is what *marks* that label. Before #453, the base state-machine increment emitter handled only `Expr.Variable` operands and skipped `Expr.Get`/`Expr.GetIndex` entirely — so the `await` inside the receiver/index was **never emitted**, leaving its resume label defined-and-branched-to but never marked (`"Label N has not been marked"` at `Save` time). A *plain* receiver had no await to count, so the same gap surfaced as #357's `StackUnderflow` instead. #453's `SpillBoxed(receiver/index)` arms fixed both: the await is emitted (suspending with an empty IL stack) and its result stored before the read-modify-write.

## Why add these tests

The behavioral fix is well covered by `AwaitReceiverIncrementTests` (interpreter↔compiled parity, PR #459). But those run the compiled program; **nothing runs the formal IL verifier** on await-in-receiver increment. The async-emitter area has a documented history of *invalid-but-runnable* IL (#318, #413, #414) that behavioral run-tests don't catch. These three facts pin ILVerify cleanliness across the three state-machine emitters, mirroring the `ILVerificationTests` added for the plain-receiver case alongside PR #453.

## Tests

Three `[Fact]`s in `ILVerificationTests` (`CompileVerifyAndRun` → asserts clean IL **and** correct output):

- `AsyncFunctionAwaitInReceiverIncrement_PassesILVerification` — all three await positions (Get receiver, GetIndex receiver, index) in an async function.
- `AsyncArrowAwaitInReceiverIncrement_PassesILVerification` — async-arrow state-machine emitter.
- `AsyncGeneratorAwaitInReceiverIncrement_PassesILVerification` — async-generator state-machine emitter.

Full suite green (11461 before this change); the three target classes (`ILVerificationTests`, `AwaitReceiverIncrementTests`, `AsyncMemberIncrementTests`) pass: 87/87.

## Note

Closes nothing new — #457 is already closed as fixed. This is a regression guard. Two unrelated gaps found while investigating are filed separately (nested `function` declaration inside an async body fails to compile; interpreter member/index increment hard-casts instead of applying ToNumber).
