### PR TITLE
Fix #452: deliver generator.next(v) to the resumed yield

### DIFF
--- a/Compilation/Emitters/IteratorEmitter.cs
+++ b/Compilation/Emitters/IteratorEmitter.cs
@@ -109,6 +109,18 @@ public sealed class IteratorEmitter : ITypeEmitterStrategy
             case "next":
                 emitter.EmitExpression(receiver);
                 emitter.EmitBoxIfNeeded(receiver);
+                // The value passed to next(v) is delivered to the resumed yield for
+                // generators (#452); a bare next() resumes with undefined. Plain
+                // iterators ignore it.
+                if (arguments.Count > 0)
+                {
+                    emitter.EmitExpression(arguments[0]);
+                    emitter.EmitBoxIfNeeded(arguments[0]);
+                }
+                else
+                {
+                    il.Emit(OpCodes.Ldsfld, ctx.Runtime!.UndefinedInstance);
+                }
                 il.Emit(OpCodes.Call, ctx.Runtime!.IteratorNext);
                 return true;
 

--- a/Compilation/GeneratorMoveNextEmitter.Expressions.Yield.cs
+++ b/Compilation/GeneratorMoveNextEmitter.Expressions.Yield.cs
@@ -56,8 +56,11 @@ public partial class GeneratorMoveNextEmitter
         // Restore spill temps from their fields on the resumed path.
         _helpers.RehydrateLiveSpillsAfterResume();
 
-        // 6. yield expression evaluates to undefined (null) when resumed
-        _il.Emit(OpCodes.Ldnull);
+        // 6. The yield expression evaluates to the value passed to next(v), which
+        // next() stashed in SentField before driving MoveNext (ECMA-262 §27.5.3.3).
+        // A bare next()/for-of resume leaves it as the caller's sent value (undefined).
+        _il.Emit(OpCodes.Ldarg_0);
+        _il.Emit(OpCodes.Ldfld, _builder.SentField);
         SetStackUnknown();
     }
 

--- a/Compilation/GeneratorStateMachineBuilder.cs
+++ b/Compilation/GeneratorStateMachineBuilder.cs
@@ -26,6 +26,10 @@ public class GeneratorStateMachineBuilder
     public FieldBuilder StateField { get; private set; } = null!;
     public FieldBuilder CurrentField { get; private set; } = null!;
 
+    // The value passed to next(v); read by a resumed yield expression (ECMA-262
+    // §27.5.3.3 — `yield expr` evaluates to the argument of the resuming next).
+    public FieldBuilder SentField { get; private set; } = null!;
+
     // Hoisted variables (become struct fields) - delegated to HoistingManager
     public Dictionary<string, FieldBuilder> HoistedParameters => _hoisting.HoistedParameters;
     public Dictionary<string, FieldBuilder> HoistedLocals => _hoisting.HoistedLocals;
@@ -125,6 +129,7 @@ public class GeneratorStateMachineBuilder
         // Define core fields
         DefineStateField();
         DefineCurrentField();
+        DefineSentField();
 
         // Define hoisted variables using HoistingManager
         _hoisting = new HoistingManager(_stateMachineType, _types.Object);
@@ -193,6 +198,17 @@ public class GeneratorStateMachineBuilder
         );
     }
 
+    private void DefineSentField()
+    {
+        // <>3__sent - the value passed to next(v), delivered to the resumed yield.
+        // Stored by next() before driving MoveNext; read on the resume path.
+        SentField = _stateMachineType.DefineField(
+            "<>3__sent",
+            _types.Object,
+            FieldAttributes.Private
+        );
+    }
+
     private void DefineConstructor()
     {
         // Define default constructor
@@ -210,6 +226,15 @@ public class GeneratorStateMachineBuilder
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ldc_I4_M1);
         il.Emit(OpCodes.Stfld, StateField);
+        // Seed the sent value with undefined so a yield resumed without an explicit
+        // next(v) — for...of and yield* delegation drive MoveNext directly, never
+        // setting SentField — evaluates to undefined rather than the null default.
+        if (_runtime?.UndefinedInstance != null)
+        {
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldsfld, _runtime.UndefinedInstance);
+            il.Emit(OpCodes.Stfld, SentField);
+        }
         il.Emit(OpCodes.Ret);
     }
 
@@ -391,12 +416,18 @@ public class GeneratorStateMachineBuilder
             "next",
             MethodAttributes.Public | MethodAttributes.Virtual | MethodAttributes.Final | MethodAttributes.HideBySig | MethodAttributes.NewSlot,
             _types.Object,
-            Type.EmptyTypes
+            [_types.Object]
         );
 
         var nextIL = NextMethod.GetILGenerator();
         var doneLabel = nextIL.DefineLabel();
         var endLabel = nextIL.DefineLabel();
+
+        // Stash the sent value so the resumed yield (read of SentField in MoveNext)
+        // sees it. Set before MoveNext so the resume path observes the new value.
+        nextIL.Emit(OpCodes.Ldarg_0);
+        nextIL.Emit(OpCodes.Ldarg_1);
+        nextIL.Emit(OpCodes.Stfld, SentField);
 
         // Call MoveNext()
         nextIL.Emit(OpCodes.Ldarg_0);

--- a/Compilation/RuntimeEmitter.Generator.cs
+++ b/Compilation/RuntimeEmitter.Generator.cs
@@ -23,14 +23,15 @@ public partial class RuntimeEmitter
         );
         runtime.GeneratorInterfaceType = interfaceBuilder;
 
-        // Define next() method: object next()
-        // This wraps MoveNext + Current into a single call returning iterator result
-        // Using lowercase to match JavaScript API
+        // Define next(object value) method: object next(object value)
+        // Wraps MoveNext + Current into a single call returning an iterator result.
+        // The value argument becomes the result of the resumed yield (ECMA-262
+        // §27.5.1.2). Using lowercase to match the JavaScript API.
         var nextMethod = interfaceBuilder.DefineMethod(
             "next",
             MethodAttributes.Public | MethodAttributes.Virtual | MethodAttributes.Abstract | MethodAttributes.HideBySig | MethodAttributes.NewSlot,
             _types.Object,
-            Type.EmptyTypes
+            [_types.Object]
         );
         runtime.GeneratorNextMethod = nextMethod;
 

--- a/Compilation/RuntimeEmitter.IteratorHelpers.cs
+++ b/Compilation/RuntimeEmitter.IteratorHelpers.cs
@@ -1124,18 +1124,40 @@ public partial class RuntimeEmitter
 
     private void EmitIteratorNext(TypeBuilder typeBuilder, EmittedRuntime runtime)
     {
-        // static object IteratorNext(object source)
+        // static object IteratorNext(object source, object sent)
         // Calls MoveNext on the source (which should already be an IEnumerator from prior normalization
         // or a lazy iterator type). Returns a Dictionary<string, object?> with value and done.
+        // `sent` is the value passed to next(v); it only has an effect for SharpTS
+        // generators, which thread it into the resumed yield (#452).
         var method = typeBuilder.DefineMethod(
             "IteratorNext", MethodAttributes.Public | MethodAttributes.Static,
-            _types.Object, [_types.Object]);
+            _types.Object, [_types.Object, _types.Object]);
         runtime.IteratorNext = method;
 
         var il = method.GetILGenerator();
         var enumLocal = il.DeclareLocal(_types.IEnumeratorOfObject);
         var dictLocal = il.DeclareLocal(_types.DictionaryStringObject);
         var doneLabel = il.DefineLabel();
+
+        // SharpTS generators implement $IGenerator. Route through next(value) so the
+        // sent value reaches the suspended yield; the call also drives MoveNext and
+        // builds the {value,done} result. Other sources (BCL enumerators from
+        // array.values(), user iterators) carry no resume slot — fall through and
+        // drive MoveNext directly (the sent value is ignored, matching the spec's
+        // "the next method of a built-in iterator ignores its argument").
+        if (runtime.GeneratorInterfaceType != null)
+        {
+            var notGeneratorLabel = il.DefineLabel();
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Isinst, runtime.GeneratorInterfaceType);
+            il.Emit(OpCodes.Brfalse, notGeneratorLabel);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Castclass, runtime.GeneratorInterfaceType);
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Callvirt, runtime.GeneratorNextMethod);
+            il.Emit(OpCodes.Ret);
+            il.MarkLabel(notGeneratorLabel);
+        }
 
         // Normalize source to IEnumerator<object>
         il.Emit(OpCodes.Ldarg_0);

--- a/Compilation/RuntimeEmitter.Objects.Invocation.cs
+++ b/Compilation/RuntimeEmitter.Objects.Invocation.cs
@@ -924,6 +924,43 @@ public partial class RuntimeEmitter
         var notEnumeratorLabel = il.DefineLabel();
         var returnBranchLabel = il.DefineLabel();
 
+        // SharpTS generators implement $IGenerator. For an explicit next(v), call
+        // $IGenerator.next(value) directly so the sent value reaches the suspended
+        // yield with the correct default — a bare next() must resume with undefined,
+        // not the null that GetProperty+InvokeMethodValue would pad in for a missing
+        // argument (#452). User iterators carrying their own next() keep the
+        // GetProperty path below (they don't implement $IGenerator).
+        if (runtime.GeneratorInterfaceType != null)
+        {
+            var notGeneratorNextLabel = il.DefineLabel();
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Ldstr, "next");
+            il.Emit(OpCodes.Call, _types.StringOpEquality);
+            il.Emit(OpCodes.Brfalse, notGeneratorNextLabel);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Isinst, runtime.GeneratorInterfaceType);
+            il.Emit(OpCodes.Brfalse, notGeneratorNextLabel);
+            // ((​$IGenerator)recv).next(args.Length > 0 ? args[0] : undefined)
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Castclass, runtime.GeneratorInterfaceType);
+            var sentArgLabel = il.DefineLabel();
+            var sentDoneLabel = il.DefineLabel();
+            il.Emit(OpCodes.Ldarg_2);
+            il.Emit(OpCodes.Ldlen);
+            il.Emit(OpCodes.Conv_I4);
+            il.Emit(OpCodes.Brtrue, sentArgLabel);
+            il.Emit(OpCodes.Ldsfld, runtime.UndefinedInstance);
+            il.Emit(OpCodes.Br, sentDoneLabel);
+            il.MarkLabel(sentArgLabel);
+            il.Emit(OpCodes.Ldarg_2);
+            il.Emit(OpCodes.Ldc_I4_0);
+            il.Emit(OpCodes.Ldelem_Ref);
+            il.MarkLabel(sentDoneLabel);
+            il.Emit(OpCodes.Callvirt, runtime.GeneratorNextMethod);
+            il.Emit(OpCodes.Ret);
+            il.MarkLabel(notGeneratorNextLabel);
+        }
+
         // Resolve the JS-level member first. Generators and user-defined
         // iterators expose a real `next`/`return` callable here; only when the
         // receiver has NO such member (a bare BCL enumerator) do we synthesize

--- a/Execution/Interpreter.Async.cs
+++ b/Execution/Interpreter.Async.cs
@@ -277,7 +277,7 @@ public partial class Interpreter
             // Handle generator methods
             return methodName switch
             {
-                "next" => gen.Next(),
+                "next" => gen.Next(args.Count > 0 ? args[0] : SharpTSUndefined.Instance),
                 "return" => gen.Return(args.Count > 0 ? args[0] : null),
                 "throw" => gen.Throw(args.Count > 0 ? args[0] : null),
                 _ => throw new InterpreterException($"Generator does not have method '{methodName}'.")

--- a/Execution/Interpreter.Expressions.cs
+++ b/Execution/Interpreter.Expressions.cs
@@ -183,7 +183,14 @@ public partial class Interpreter
         if (YieldCallback != null)
         {
             var result = YieldCallback(value, yieldExpr.IsDelegating);
-            return RuntimeValue.FromBoxed(result ?? SharpTSUndefined.Instance);
+            // For a plain `yield`, the callback returns the exact value passed to the
+            // resuming next(v) — delivered verbatim so `next(null)` yields null and a
+            // bare next() yields undefined (the generator normalizes that to undefined).
+            // For `yield*`, the completion value of a non-generator delegate is undefined;
+            // coalesce null → undefined to preserve that.
+            if (yieldExpr.IsDelegating)
+                return RuntimeValue.FromBoxed(result ?? SharpTSUndefined.Instance);
+            return RuntimeValue.FromBoxed(result);
         }
 
         throw new YieldException(value, yieldExpr.IsDelegating);

--- a/Runtime/BuiltIns/BuiltInTypes.cs
+++ b/Runtime/BuiltIns/BuiltInTypes.cs
@@ -1006,7 +1006,9 @@ public static class BuiltInTypes
     {
         return name switch
         {
-            "next" => new TypeInfo.Function([], AnyType),
+            // next accepts an optional value (ECMA-262 §27.5.1.2: the argument
+            // becomes the result of the resumed yield expression).
+            "next" => new TypeInfo.Function([AnyType], AnyType, RequiredParams: 0),
             "return" => new TypeInfo.Function([AnyType], AnyType, RequiredParams: 0),
             "throw" => new TypeInfo.Function([AnyType], AnyType, RequiredParams: 0),
             "map" => new TypeInfo.Function(

--- a/Runtime/BuiltIns/GeneratorBuiltIns.cs
+++ b/Runtime/BuiltIns/GeneratorBuiltIns.cs
@@ -18,11 +18,14 @@ public static class GeneratorBuiltIns
     {
         return name switch
         {
-            "next" => BuiltInMethod.CreateV2("next", 0, 0, static (_, receiver, _) =>
+            "next" => BuiltInMethod.CreateV2("next", 0, 1, static (_, receiver, args) =>
             {
                 if (receiver.ToObject() is SharpTSGenerator gen)
                 {
-                    return RuntimeValue.FromObject(gen.Next());
+                    // ECMA-262 §27.5.3.3: the argument becomes the result of the
+                    // resumed yield. A bare next() resumes with undefined.
+                    object? sent = args.Length > 0 ? args[0].ToObject() : SharpTSUndefined.Instance;
+                    return RuntimeValue.FromObject(gen.Next(sent));
                 }
                 throw new Exception("Runtime Error: next() called on non-generator.");
             }),

--- a/Runtime/Types/SharpTSGenerator.cs
+++ b/Runtime/Types/SharpTSGenerator.cs
@@ -37,6 +37,11 @@ public class SharpTSGenerator : IEnumerable<object?>, IDisposable, ITypeCategori
     private State _state = State.NotStarted;
     private object? _yieldedValue;
     private object? _returnValue;
+    // The value passed to the next/return call that resumes the suspended yield.
+    // ECMA-262 §27.5.3.3: `yield expr` evaluates to the argument of the resuming
+    // `next(v)`. Defaults to undefined so a yield resumed without an explicit value
+    // (for...of, yield* delegation, bare next()) evaluates to undefined.
+    private object? _sentValue = SharpTSUndefined.Instance;
     private bool _closed;
     private Exception? _workerException;
 
@@ -52,9 +57,21 @@ public class SharpTSGenerator : IEnumerable<object?>, IDisposable, ITypeCategori
     }
 
     /// <summary>
+    /// Advances the generator to the next yield point, resuming the suspended
+    /// <c>yield</c> with <c>undefined</c> (the implicit value for for...of,
+    /// yield* delegation, and a bare <c>next()</c>).
+    /// </summary>
+    public SharpTSIteratorResult Next() => Next(SharpTSUndefined.Instance);
+
+    /// <summary>
     /// Advances the generator to the next yield point.
     /// </summary>
-    public SharpTSIteratorResult Next()
+    /// <param name="sentValue">
+    /// The value the resumed <c>yield</c> expression evaluates to (ECMA-262 §27.5.3.3).
+    /// Ignored on the first call, which only starts the body — there is no suspended
+    /// yield waiting to receive it.
+    /// </param>
+    public SharpTSIteratorResult Next(object? sentValue)
     {
         if (_closed || _state == State.Completed)
             return new SharpTSIteratorResult(_returnValue, done: true);
@@ -70,7 +87,9 @@ public class SharpTSGenerator : IEnumerable<object?>, IDisposable, ITypeCategori
         }
         else
         {
-            // Resume: restore generator's environment and signal worker
+            // Resume: hand the sent value to the suspended yield, restore the
+            // generator's environment, and signal the worker.
+            _sentValue = sentValue;
             _state = State.Running;
             _callerReady.Set();
         }
@@ -177,8 +196,8 @@ public class SharpTSGenerator : IEnumerable<object?>, IDisposable, ITypeCategori
         {
             return DelegateYieldStar(_interpreter, this, value, v => SuspendWithValue(v), () => _closed);
         }
-        SuspendWithValue(value);
-        return null;
+        // A plain `yield` evaluates to the value passed to the resuming next(v).
+        return SuspendWithValue(value);
     }
 
     /// <summary>
@@ -218,8 +237,10 @@ public class SharpTSGenerator : IEnumerable<object?>, IDisposable, ITypeCategori
 
     /// <summary>
     /// Suspends the worker thread, passing a single yielded value to the caller.
+    /// Returns the value supplied to the resuming <c>next(v)</c> call, which becomes
+    /// the result of the <c>yield</c> expression.
     /// </summary>
-    private void SuspendWithValue(object? value)
+    private object? SuspendWithValue(object? value)
     {
         _yieldedValue = value;
         _state = State.Suspended;
@@ -238,6 +259,8 @@ public class SharpTSGenerator : IEnumerable<object?>, IDisposable, ITypeCategori
         _callerYieldCallback = _interpreter.YieldCallback;
         _interpreter.SetEnvironment(generatorEnv);
         _interpreter.YieldCallback = HandleYieldCallback;
+
+        return _sentValue;
     }
 
     // IEnumerable implementation for for...of integration
@@ -290,6 +313,9 @@ public class SharpTSArrowGenerator : IEnumerable<object?>, IDisposable
     private State _state = State.NotStarted;
     private object? _yieldedValue;
     private object? _returnValue;
+    // The value passed to the resuming next(v); becomes the result of the suspended
+    // yield (ECMA-262 §27.5.3.3). Defaults to undefined for implicit resumes.
+    private object? _sentValue = SharpTSUndefined.Instance;
     private bool _closed;
     private Exception? _workerException;
 
@@ -303,7 +329,13 @@ public class SharpTSArrowGenerator : IEnumerable<object?>, IDisposable
         _interpreter = interpreter;
     }
 
-    public SharpTSIteratorResult Next()
+    public SharpTSIteratorResult Next() => Next(SharpTSUndefined.Instance);
+
+    /// <summary>
+    /// Advances the generator, resuming the suspended <c>yield</c> with
+    /// <paramref name="sentValue"/> (ECMA-262 §27.5.3.3). Ignored on the first call.
+    /// </summary>
+    public SharpTSIteratorResult Next(object? sentValue)
     {
         if (_closed || _state == State.Completed)
             return new SharpTSIteratorResult(_returnValue, done: true);
@@ -318,6 +350,7 @@ public class SharpTSArrowGenerator : IEnumerable<object?>, IDisposable
         }
         else
         {
+            _sentValue = sentValue;
             _state = State.Running;
             _callerReady.Set();
         }
@@ -397,11 +430,10 @@ public class SharpTSArrowGenerator : IEnumerable<object?>, IDisposable
         {
             return SharpTSGenerator.DelegateYieldStar(_interpreter, this, value, v => SuspendWithValue(v), () => _closed);
         }
-        SuspendWithValue(value);
-        return null;
+        return SuspendWithValue(value);
     }
 
-    private void SuspendWithValue(object? value)
+    private object? SuspendWithValue(object? value)
     {
         _yieldedValue = value;
         _state = State.Suspended;
@@ -420,6 +452,8 @@ public class SharpTSArrowGenerator : IEnumerable<object?>, IDisposable
         _callerYieldCallback = _interpreter.YieldCallback;
         _interpreter.SetEnvironment(generatorEnv);
         _interpreter.YieldCallback = HandleYieldCallback;
+
+        return _sentValue;
     }
 
     public IEnumerator<object?> GetEnumerator()

--- a/SharpTS.Tests/SharedTests/GeneratorTests.cs
+++ b/SharpTS.Tests/SharedTests/GeneratorTests.cs
@@ -265,6 +265,159 @@ public class GeneratorTests
 
     #endregion
 
+    #region Resume Values (next(v)) — issue #452
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Generator_NextWithValue_DeliveredToYield(ExecutionMode mode)
+    {
+        // ECMA-262 §27.5.3.3: `yield expr` evaluates to the argument of the
+        // resuming next(v). The first next() only starts the body.
+        var source = """
+            function* g() {
+                const x = yield 1;
+                console.log("got", x);
+                const y = yield 2;
+                console.log("got", y);
+                return 99;
+            }
+            const it = g();
+            console.log("first", it.next().value);
+            console.log("r1", it.next(42).value);
+            console.log("r2", it.next(43).value);
+            console.log("done", it.next().done);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("first 1\ngot 42\nr1 2\ngot 43\nr2 99\ndone true\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Generator_AccumulatorPattern_UsesSentValues(ExecutionMode mode)
+    {
+        // The classic two-way generator: each next(n) feeds the running total.
+        var source = """
+            function* adder() {
+                let total = 0;
+                while (true) {
+                    const n = yield total;
+                    total += n;
+                }
+            }
+            const a = adder();
+            console.log(a.next().value);
+            console.log(a.next(5).value);
+            console.log(a.next(10).value);
+            console.log(a.next(3).value);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("0\n5\n15\n18\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Generator_BareNext_ResumesWithUndefined(ExecutionMode mode)
+    {
+        var source = """
+            function* g() {
+                const x = yield 1;
+                console.log(x, typeof x);
+            }
+            const it = g();
+            it.next();
+            it.next();
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("undefined undefined\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Generator_NextWithNull_ResumesWithNull(ExecutionMode mode)
+    {
+        // next(null) must deliver null (typeof "object"), distinct from a bare
+        // next() which resumes with undefined.
+        var source = """
+            function* g() {
+                const x = yield 1;
+                console.log(x, typeof x);
+            }
+            const it = g();
+            it.next();
+            it.next(null);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("null object\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Generator_ForOf_ResumesYieldWithUndefined(ExecutionMode mode)
+    {
+        // for...of drives the generator without passing a value, so a yield used
+        // as an expression resolves to undefined (not null).
+        var source = """
+            function* g() {
+                const x = yield 10;
+                console.log("resumed", x, typeof x);
+            }
+            for (const v of g()) {
+                console.log("yielded", v);
+            }
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("yielded 10\nresumed undefined undefined\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Generator_SentValue_UsedInExpression(ExecutionMode mode)
+    {
+        var source = """
+            function* g() {
+                const doubled = (yield 1) * 2;
+                console.log("doubled", doubled);
+            }
+            const it = g();
+            it.next();
+            it.next(21);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("doubled 42\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Generator_InstanceMethod_NextWithValue_AndThis(ExecutionMode mode)
+    {
+        var source = """
+            class Echo {
+                prefix: string = "msg:";
+                *run() {
+                    const first = yield "ready";
+                    console.log(this.prefix + first);
+                    const second = yield "more";
+                    console.log(this.prefix + second);
+                }
+            }
+            const g = new Echo().run();
+            console.log(g.next().value);
+            g.next("hello");
+            g.next("world");
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("ready\nmsg:hello\nmsg:world\n", output);
+    }
+
+    #endregion
+
     #region Yield* with String
 
     [Theory]


### PR DESCRIPTION
## Summary

Closes #452. A `yield` expression must evaluate to the value passed to the next `iterator.next(v)` (ECMA-262 §27.5.3.3). Neither mode implemented this:

- **Interpreter**: `gen.next(42)` threw `'next' expects 0-0 arguments but got 1.` — the resume argument was rejected outright.
- **Compiled**: `gen.next(42)` was accepted but the suspended `yield` resolved to `null`.

Both now thread the sent value through to the resumed `yield`, with parity across modes.

```ts
function* g() { const x = yield 1; console.log("got", x); }
const it = g();
it.next();      // start
it.next(42);    // got 42   ✓ (was: error / got null)
```

## Changes

**Interpreter** (`Runtime/Types/SharpTSGenerator.cs`, both `SharpTSGenerator` and `SharpTSArrowGenerator`)
- Thread the sent value through the thread-coroutine: `Next(sentValue)` stores it, `SuspendWithValue` returns it, and the plain-`yield` callback returns it. Defaults to `undefined` for implicit resumes (`for...of`, `yield*`, bare `next()`).
- `GeneratorBuiltIns.next` arity `0-0` → `0-1`; forwards the argument (`undefined` when absent). `Interpreter.Async.cs` generator dispatch forwards it too.
- `EvaluateYield` delivers the resume value verbatim for a plain `yield` so `next(null)` yields `null`; `yield*` completion keeps the existing `null → undefined` coalescing.

**Compiler** (state machine + dispatch)
- New `<>3__sent` field, seeded to `undefined` in the ctor; `next(value)` stashes the argument before driving `MoveNext`; the resumed `yield` reads it instead of pushing `null`.
- `$IGenerator.next` gains an `object` parameter. Both the typed path (`IteratorEmitter` → `IteratorNext`) and the any-typed path (`IteratorProtocolCall`) deliver the sent value, routing generators through `$IGenerator.next(value)` so a bare `next()` resumes with `undefined` (not the `null` that arg-padding would otherwise yield).

**Type checker**: generator/iterator `next` now accepts an optional argument.

## Tests

Adds 7 shared interpreter/compiled parity tests in `GeneratorTests.cs`: resume value delivery, the two-way accumulator pattern, `next()`/`next(null)`/`for...of` defaults, sent value used in an expression, and an instance-method generator using `this`.

- Full unit suite green: **11422 passed** (only the pre-existing live-DNS network flakes, which pass on retry).
- TypeScript conformance: clean (31/31).
- Test262 differ: clean — interpreted & compiled outcomes identical to baseline (no regression/new-pass).
- Emitted IL passes `--verify` for all scenarios.

## Out of scope (filed as follow-ups)

- #473 — async generators (`async function*`) have the same gap (interp `next` arity 0-0; compiled async-gen `yield` resolves to null).
- #476 — `yield*` does not forward `next(v)` to the delegated iterator (both modes, consistent).
- #478 — `return(v)`/`throw(v)` on a suspended generator do not resume the body to run `finally`.
- #477 — a `try`/`finally` + `yield` generator emits invalid IL in compiled mode (pre-existing, reproduces on `main`).