### PR TITLE
Fix #428: parse `export const` as const, not a mutable var

### DIFF
--- a/Execution/Interpreter.cs
+++ b/Execution/Interpreter.cs
@@ -1886,6 +1886,8 @@ public partial class Interpreter : IDisposable
             Stmt.Function f => f.Name.Lexeme,
             Stmt.Class c => c.Name.Lexeme,
             Stmt.Var v => v.Name.Lexeme,
+            // `export const x = …` now parses as Stmt.Const (was Stmt.Var before #428).
+            Stmt.Const c => c.Name.Lexeme,
             Stmt.Enum e => e.Name.Lexeme,
             _ => throw new InterpreterException($"Cannot get name of declaration type {decl.GetType().Name}")
         };
@@ -1902,6 +1904,8 @@ public partial class Interpreter : IDisposable
             Stmt.Function f => f.Name,
             Stmt.Class c => c.Name,
             Stmt.Var v => v.Name,
+            // `export const x = …` now parses as Stmt.Const (was Stmt.Var before #428).
+            Stmt.Const c => c.Name,
             Stmt.Enum e => e.Name,
             _ => throw new InterpreterException($"Cannot get value of declaration type {decl.GetType().Name}")
         };

--- a/Parsing/Parser.Modules.cs
+++ b/Parsing/Parser.Modules.cs
@@ -325,7 +325,11 @@ public partial class Parser
             }
             else
             {
-                decl = VarDeclaration();
+                // Pass isConst:true so `export const x = 5` produces a Stmt.Const, matching
+                // the bare-`const` path (Parser.Declarations.cs). Without it the declaration
+                // was a mutable Stmt.Var — reassignment went unflagged and the literal type was
+                // widened (`export const x = 5` inferred `number` instead of `5`). See #428.
+                decl = VarDeclaration(isConst: true);
             }
         }
         else if (Match(TokenType.LET))

--- a/SharpTS.Tests/ParserTests/StatementParsingTests.cs
+++ b/SharpTS.Tests/ParserTests/StatementParsingTests.cs
@@ -404,6 +404,49 @@ public class StatementParsingTests
         Assert.Null(varStmt.Initializer);
     }
 
+    // ---- #428: `export const` must parse as Stmt.Const, matching the bare-`const` path ----
+    // Before #428 the export dispatcher called VarDeclaration() without isConst:true, so
+    // `export const x = 5` produced a mutable Stmt.Var — reassignment went unflagged and the
+    // literal type was widened (`number` instead of `5`).
+
+    [Fact]
+    public void ExportConst_ParsesAsConst()
+    {
+        var statements = Parse("export const x = 5;");
+        var export = Assert.IsType<Stmt.Export>(statements[0]);
+        var constStmt = Assert.IsType<Stmt.Const>(export.Declaration);
+        Assert.Equal("x", constStmt.Name.Lexeme);
+        Assert.NotNull(constStmt.Initializer);
+    }
+
+    [Fact]
+    public void ExportLet_StaysMutableVar()
+    {
+        // Regression guard: `let` is mutable, so it must remain a Stmt.Var.
+        var statements = Parse("export let x = 5;");
+        var export = Assert.IsType<Stmt.Export>(statements[0]);
+        var varStmt = Assert.IsType<Stmt.Var>(export.Declaration);
+        Assert.Equal("x", varStmt.Name.Lexeme);
+    }
+
+    [Fact]
+    public void ExportVar_StaysMutableVar()
+    {
+        var statements = Parse("export var x = 5;");
+        var export = Assert.IsType<Stmt.Export>(statements[0]);
+        var varStmt = Assert.IsType<Stmt.Var>(export.Declaration);
+        Assert.True(varStmt.IsVar);
+    }
+
+    [Fact]
+    public void ExportConst_NoInitializer_IsParseError()
+    {
+        // `export const x;` (non-ambient) is a parse error, consistent with bare `const x;`
+        // and matching tsc's TS1155 "'const' declarations must be initialized." Before #428
+        // this was silently accepted as a mutable Stmt.Var.
+        Assert.ThrowsAny<System.Exception>(() => Parse("export const x;"));
+    }
+
     #endregion
 
     #region Expression Statements

--- a/SharpTS.Tests/SharedTests/ModuleTests.cs
+++ b/SharpTS.Tests/SharedTests/ModuleTests.cs
@@ -231,6 +231,84 @@ public class ModuleTests
         Assert.Equal("3\n", TestHarness.Run(source, mode));
     }
 
+    // ---- #428: `export const` keeps const-ness (was parsed as a mutable Stmt.Var) ----
+    // The parser dispatched `export const` through VarDeclaration() with the default
+    // isConst:false, so it became a mutable Stmt.Var: reassignment went unflagged and the
+    // literal type was widened. After #428 it is a Stmt.Const, matching bare `const`. The
+    // type-checker/interpreter export helpers (GetDeclarationName / GetDeclaredType /
+    // GetDeclaredName / GetDeclaredValue) gained the Stmt.Const arm they previously lacked.
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ExportConst_Reassignment_IsTypeError(ExecutionMode mode)
+    {
+        // The canonical #428 repro: reassigning an `export const` must be rejected, just like
+        // bare `const`. The narrowed literal type ('5') surfaces in the diagnostic.
+        var source = """
+            export const y = 5;
+            y = 6;
+            """;
+
+        var ex = Assert.ThrowsAny<TypeCheckException>(() => TestHarness.Run(source, mode));
+        Assert.Contains("'y'", ex.Message);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ExportConst_LiteralTypeNarrowed(ExecutionMode mode)
+    {
+        // `export const x = 5` must infer the literal type `5`, not the widened `number`.
+        // Assigning it into a `5`-typed binding only type-checks when the narrowing happened.
+        var source = """
+            export const x = 5;
+            const exact: 5 = x;
+            console.log(exact);
+            """;
+
+        Assert.Equal("5\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ExportConst_NarrowedType_FlowsCrossModule(ExecutionMode mode)
+    {
+        // The narrowed literal type of an exported const must survive import into another
+        // module (exercises the GetDeclarationName/GetDeclaredType export-table helpers).
+        var files = new Dictionary<string, string>
+        {
+            ["./values.ts"] = """
+                export const MAX = 100;
+                """,
+            ["./main.ts"] = """
+                import { MAX } from './values';
+                const exact: 100 = MAX;
+                console.log(exact);
+                """
+        };
+
+        Assert.Equal("100\n", TestHarness.RunModules(files, "./main.ts", mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ExportConst_CrossModule_Runs(ExecutionMode mode)
+    {
+        // A plain exported const imported and used across modules still binds and runs
+        // (guards the Stmt.Const arm added to the interpreter's GetDeclaredName/Value).
+        var files = new Dictionary<string, string>
+        {
+            ["./config.ts"] = """
+                export const greeting = "hello";
+                """,
+            ["./main.ts"] = """
+                import { greeting } from './config';
+                console.log(greeting);
+                """
+        };
+
+        Assert.Equal("hello\n", TestHarness.RunModules(files, "./main.ts", mode));
+    }
+
     // ---- #395: exported async / generator / async-generator functions callable across modules ----
     // The single-file tests above exercise script (non-module) mode via TestHarness.Run; since
     // #417 they run in both modes (the compiled script path now binds exported declarations).

--- a/TypeSystem/TypeChecker.cs
+++ b/TypeSystem/TypeChecker.cs
@@ -1504,6 +1504,8 @@ public partial class TypeChecker
             Stmt.Function f => f.Name.Lexeme,
             Stmt.Class c => c.Name.Lexeme,
             Stmt.Var v => v.Name.Lexeme,
+            // `export const x = …` now parses as Stmt.Const (was Stmt.Var before #428).
+            Stmt.Const c => c.Name.Lexeme,
             Stmt.Interface i => i.Name.Lexeme,
             Stmt.TypeAlias t => t.Name.Lexeme,
             Stmt.Enum e => e.Name.Lexeme,
@@ -1522,6 +1524,9 @@ public partial class TypeChecker
             Stmt.Function f => _environment.Get(f.Name.Lexeme) ?? new TypeInfo.Any(),
             Stmt.Class c => _environment.Get(c.Name.Lexeme) ?? new TypeInfo.Any(),
             Stmt.Var v => _environment.Get(v.Name.Lexeme) ?? new TypeInfo.Any(),
+            // `export const x = …` now parses as Stmt.Const (was Stmt.Var before #428). The
+            // environment holds the narrowed literal type recorded by VisitConst.
+            Stmt.Const c => _environment.Get(c.Name.Lexeme) ?? new TypeInfo.Any(),
             Stmt.Interface i => _environment.Get(i.Name.Lexeme) ?? new TypeInfo.Any(),
             Stmt.TypeAlias t => ToTypeInfo(t.TypeDefinition),
             Stmt.Enum e => _environment.Get(e.Name.Lexeme) ?? new TypeInfo.Any(),


### PR DESCRIPTION
## Summary

Fixes #428. `export const x = 5` was parsed as a **mutable** binding (`Stmt.Var`) instead of a `const` (`Stmt.Const`), because the export dispatcher in `Parser.Modules.cs` called `VarDeclaration()` with the default `isConst: false`. Two observable symptoms, both now matching the bare-`const` path:

| Source | Before | After (= `tsc`) |
|---|---|---|
| `export const y = 5;`<br>`y = 6;` | ❌ ran, printed `6` | ✅ type error |
| `export const x = 5` | inferred `number` | inferred `5` |

## Changes

- **`Parsing/Parser.Modules.cs`** — the one-line root-cause fix: `VarDeclaration(isConst: true)` in the `export const` (non-enum) branch, mirroring the bare-`const` path.
- **`TypeSystem/TypeChecker.cs`** — `GetDeclarationName` / `GetDeclaredType` gain the `Stmt.Const` arm. `GetDeclarationName` previously **threw** `"Cannot get name of declaration type Const"` for every module-exported const (this is what broke ~579 tests the moment the parser was fixed).
- **`Execution/Interpreter.cs`** — `GetDeclaredName` / `GetDeclaredValue` gain the `Stmt.Const` arm.

These four helpers are the *only* places that lacked `Stmt.Const` handling: they are reached exclusively via `export <decl>`, and `export const` was the single form that uniquely produced a `Stmt.Var`. Every other phase (closure analysis, IL emission, dead-code analysis, namespace-member compilation) already handled `Stmt.Const`, because bare `const` always produced it — so no compiler changes were needed and compiled-mode tests pass unchanged.

### Edge cases

- `export const x;` (no initializer, non-ambient) now correctly errors (`'const' declarations must be initialized` — matches bare `const x;` and `tsc` TS1155) instead of being silently accepted as a mutable var.
- Ambient `declare`-block const (`declare module { export const x: T; }`) is **unaffected** — it parses through `AmbientVarDeclaration`, a separate path.

## Tests

Parser-level (`StatementParsingTests`): `export const`→`Stmt.Const`; `export let`/`export var` stay `Stmt.Var`; no-initializer is a parse error.

Behavior (`ModuleTests`, both interpreted + compiled): reassignment is a type error; literal type is narrowed; the narrowed type flows across an `import`; a plain exported const still binds and runs cross-module.

## Verification

- Full suite: **11446 passed** (+12 new tests; count 11436→11448). The only failures were pre-existing **live-DNS network flakes** (`dns.resolveNs`/`resolve4`), confirmed flaky by retry and unrelated to this change.
- **TS conformance**: 31/31, no baseline drift.
- **Test262** (interpreter + compiled): 21 passed, 3 skipped, 0 failed, no baseline drift.

Neither conformance baseline shifted — the active subsets contain no `export const`, and the helper changes are purely additive.

## Follow-ups filed

- #467 — same root cause for **namespace-scoped** `const`/`export const` (`Parser.Namespaces.cs`); kept separate because the namespace-member type-checker/interpreter paths need their own `Stmt.Const` arms (the checker's `default` arm type-checks const but doesn't register it as a namespace export).
- #468 — module-mode type errors are double-reported and lack line/column info (pre-existing, orthogonal; surfaced while diffing diagnostics here).
