### PR TITLE
Fix #456: resolve IterableIterator/Iterator/WeakRef/FinalizationRegistry type references

### DIFF
--- a/SharpTS.Tests/TypeCheckerTests/DedicatedContainerTypeReferenceTests.cs
+++ b/SharpTS.Tests/TypeCheckerTests/DedicatedContainerTypeReferenceTests.cs
@@ -1,0 +1,311 @@
+using System;
+using SharpTS.Tests.Infrastructure;
+using SharpTS.TypeSystem.Exceptions;
+using Xunit;
+
+namespace SharpTS.Tests.TypeCheckerTests;
+
+/// <summary>
+/// The dedicated single/dual-argument built-in container records — <c>IterableIterator&lt;T&gt;</c> /
+/// <c>Iterator&lt;T&gt;</c> (=> <c>TypeInfo.Iterator</c>), <c>WeakRef&lt;T&gt;</c>,
+/// <c>FinalizationRegistry&lt;T&gt;</c> — now resolve from a type REFERENCE instead of degrading to
+/// <c>any</c> (#456, completing the Map/Set/WeakMap/WeakSet work in #347/PR&#160;#455). Resolving them
+/// exposed that the same-kind records lacked a compatibility arm: <c>Iterator</c>,
+/// <c>Generator</c>/<c>AsyncGenerator</c> and <c>FinalizationRegistry</c> all fell through to
+/// <c>return false</c>, so even <c>let g: Generator&lt;number&gt; = gen()</c> spuriously failed. The
+/// arms added here close that, with a sync <c>Generator</c> accepted where an <c>Iterator</c> is
+/// expected (it structurally IS one) so previously-<c>any</c> assignments do not regress.
+/// </summary>
+public class DedicatedContainerTypeReferenceTests
+{
+    // ---- IterableIterator / Iterator references are strongly typed (no longer `any`) ----
+
+    [Fact]
+    public void IterableIterator_FakeMemberRejected()
+    {
+        // The issue's headline example: `it` is now Iterator<number>, not `any`, so an unknown member
+        // is a type error instead of silently passing.
+        var source = """
+            let it: IterableIterator<number> = [1, 2, 3].values();
+            it.totallyFakeMethod();
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void Iterator_AltSpelling_FakeMemberRejected()
+    {
+        var source = """
+            let it: Iterator<number> = [1, 2, 3].values();
+            it.nope();
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void IterableIterator_FromArrayValues_Accepted()
+    {
+        var source = "let it: IterableIterator<number> = [1, 2, 3].values();";
+        TestHarness.RunInterpreted(source);
+    }
+
+    [Fact]
+    public void IterableIterator_FromMapEntries_Accepted()
+    {
+        // Map.entries() yields IterableIterator<[K, V]>; the tuple element type must line up.
+        var source = """
+            const m = new Map<string, number>();
+            let it: IterableIterator<[string, number]> = m.entries();
+            """;
+        TestHarness.RunInterpreted(source);
+    }
+
+    [Fact]
+    public void Iterator_ElementMismatch_Rejected()
+    {
+        // The element type is now real: an Iterator<number> source cannot satisfy IterableIterator<string>.
+        var source = """
+            function f(it: IterableIterator<number>): IterableIterator<string> { return it; }
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void Iterator_ThreeTypeArgs_LibSpelling_Accepted()
+    {
+        // lib.d.ts is Iterator<T, TReturn = any, TNext = any>; SharpTS keeps only the element type but
+        // must accept (and ignore) the optional TReturn/TNext, the same way Generator drops them.
+        var source = "let it: Iterator<number, void, undefined> = [1].values();";
+        TestHarness.RunInterpreted(source);
+    }
+
+    [Fact]
+    public void Iterator_TooManyTypeArgs_Rejected()
+    {
+        var source = "let it: Iterator<number, void, undefined, string> = [1].values();";
+        var ex = Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+        Assert.Equal("TS2314", ex.Diagnostic.TsCode);
+    }
+
+    // ---- Generator <-> Iterator direction (a sync Generator IS an IterableIterator) ----
+
+    [Fact]
+    public void Generator_SelfAssignment_Accepted()
+    {
+        // Regression of the bug resolving these records exposed: a same-record pair with no
+        // compatibility arm fell through to `return false`, so this failed before #456.
+        var source = """
+            function* gen(): Generator<number> { yield 1; }
+            let g: Generator<number> = gen();
+            """;
+        TestHarness.RunInterpreted(source);
+    }
+
+    [Fact]
+    public void AsyncGenerator_SelfAssignment_Accepted()
+    {
+        var source = """
+            async function* gen(): AsyncGenerator<number> { yield 1; }
+            let g: AsyncGenerator<number> = gen();
+            """;
+        TestHarness.RunInterpreted(source);
+    }
+
+    [Fact]
+    public void Generator_AssignableToIterableIterator_Accepted()
+    {
+        // Generator<T> extends IterableIterator<T>; without this arm the assignment would regress now
+        // that IterableIterator<number> is strongly typed rather than `any`.
+        var source = """
+            function* gen(): Generator<number> { yield 1; }
+            let it: IterableIterator<number> = gen();
+            """;
+        TestHarness.RunInterpreted(source);
+    }
+
+    [Fact]
+    public void StructuralIteratorObject_AssignableToIterator_Accepted()
+    {
+        // TS types Iterator<T> structurally: a hand-written object with a `next` method satisfies it.
+        // Guards the regression where making Iterator<T> a real type (was `any`) rejected such objects.
+        var source = """
+            function make(): Iterator<number> {
+              let i = 0;
+              return {
+                next(): IteratorResult<number> {
+                  return i < 3 ? { value: ++i, done: false } : { value: 0, done: true };
+                }
+              };
+            }
+            """;
+        TestHarness.RunInterpreted(source);
+    }
+
+    [Fact]
+    public void Iterator_NotAssignableToGenerator_Rejected()
+    {
+        // The relation is asymmetric: a plain Iterator is not a Generator.
+        var source = """
+            function f(it: IterableIterator<number>): Generator<number> { return it; }
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void AsyncGenerator_NotAssignableToSyncIterator_Rejected()
+    {
+        // Sync and async iterator hierarchies are distinct: an AsyncGenerator is not a sync Iterator.
+        var source = """
+            async function* agen(): AsyncGenerator<number> { yield 1; }
+            function f(): IterableIterator<number> { return agen(); }
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+
+    // ---- WeakRef references are strongly typed ----
+
+    [Fact]
+    public void WeakRef_DerefReturnsTargetOrUndefined()
+    {
+        // deref() returns T | undefined; reading a property without narrowing must be rejected under
+        // strictNullChecks because `undefined` has no members.
+        var source = """
+            let wr: WeakRef<{ name: string }> = new WeakRef({ name: "x" });
+            let n: string = wr.deref().name;
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void WeakRef_DerefWithNarrowing_Accepted()
+    {
+        var source = """
+            let wr: WeakRef<{ name: string }> = new WeakRef({ name: "x" });
+            let n: string = wr.deref()!.name;
+            """;
+        TestHarness.RunInterpreted(source);
+    }
+
+    [Fact]
+    public void WeakRef_TargetMismatch_Rejected()
+    {
+        var source = """
+            function f(a: WeakRef<{ a: number }>): WeakRef<{ b: number }> { return a; }
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void WeakRef_TooManyTypeArgs_Rejected()
+    {
+        var source = "let wr: WeakRef<object, string> = new WeakRef({});";
+        var ex = Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+        Assert.Equal("TS2314", ex.Diagnostic.TsCode);
+    }
+
+    // ---- FinalizationRegistry references are strongly typed ----
+
+    [Fact]
+    public void FinalizationRegistry_FakeMemberRejected()
+    {
+        var source = """
+            let fr: FinalizationRegistry<string> = new FinalizationRegistry((v: string) => {});
+            fr.nope();
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void FinalizationRegistry_RealMembersResolve()
+    {
+        // The strongly-typed registry still exposes register/unregister (i.e. resolution did not turn
+        // the type into something memberless). Kept in an UNCALLED function so only the type checker
+        // runs: the runtime register() target validation is orthogonal to #456, and its type-checker
+        // signature is independently imprecise (see the filed follow-up).
+        var source = """
+            function use(fr: FinalizationRegistry<string>): void {
+              fr.register("held");
+              fr.unregister("token");
+            }
+            """;
+        TestHarness.RunInterpreted(source);
+    }
+
+    [Fact]
+    public void FinalizationRegistry_HeldValueMismatch_Rejected()
+    {
+        var source = """
+            function f(a: FinalizationRegistry<string>): FinalizationRegistry<number> { return a; }
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void FinalizationRegistry_TooManyTypeArgs_Rejected()
+    {
+        var source = "let fr: FinalizationRegistry<string, number> = new FinalizationRegistry((v: string) => {});";
+        var ex = Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+        Assert.Equal("TS2314", ex.Diagnostic.TsCode);
+    }
+
+    // ---- conditional-type `infer` extraction (DecomposeBuiltInContainer) ----
+
+    [Fact]
+    public void ConditionalInfer_FromIterableIterator_BindsElement()
+    {
+        var source = """
+            type ElemOf<T> = T extends IterableIterator<infer V> ? V : "none";
+            function f(): ElemOf<IterableIterator<number>> { return "hello"; }
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void ConditionalInfer_FromIterableIterator_CorrectBranchAccepted()
+    {
+        var source = """
+            type ElemOf<T> = T extends IterableIterator<infer V> ? V : "none";
+            let x: ElemOf<IterableIterator<number>> = 5;
+            """;
+        TestHarness.RunInterpreted(source);
+    }
+
+    [Fact]
+    public void ConditionalInfer_FromWeakRef_BindsTarget()
+    {
+        var source = """
+            type TargetOf<T> = T extends WeakRef<infer V> ? V : never;
+            function f(): TargetOf<WeakRef<string>> { return 42; }
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void ConditionalInfer_FromFinalizationRegistry_BindsHeldValue()
+    {
+        var source = """
+            type HeldOf<T> = T extends FinalizationRegistry<infer V> ? V : never;
+            function f(): HeldOf<FinalizationRegistry<string>> { return 42; }
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+
+    // ---- regression guard: ordinary use of these annotations type-checks and runs in BOTH modes ----
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AnnotatedIterator_IteratesCorrectly(ExecutionMode mode)
+    {
+        // The annotation is type-level only; it must not perturb interpretation or IL codegen.
+        var source = """
+            function* gen(): Generator<number> { yield 1; yield 2; yield 3; }
+            let g: Generator<number> = gen();
+            let it: IterableIterator<number> = [10, 20].values();
+            let sum = 0;
+            for (const x of g) { sum += x; }
+            for (const y of it) { sum += y; }
+            console.log(sum);
+            """;
+        Assert.Equal("36\n", TestHarness.Run(source, mode));
+    }
+}

--- a/TypeSystem/TypeChecker.Compatibility.cs
+++ b/TypeSystem/TypeChecker.Compatibility.cs
@@ -835,6 +835,55 @@ public partial class TypeChecker
             return IsCompatible(expWeakRef.TargetType, actWeakRef.TargetType);
         }
 
+        // Iterator<T> compatibility (the IterableIterator/Iterator annotations resolved by
+        // ResolveGenericType and the records .keys()/.values()/.entries() produce). A dedicated
+        // iterator record or a sync Generator carries the element/yield type directly — a sync
+        // Generator structurally IS an iterator (Generator<T> extends IterableIterator<T> extends
+        // Iterator<T>), so it satisfies an Iterator-typed target too; without that, assigning a
+        // generator to an `IterableIterator<T>` annotation would regress now that the annotation is
+        // strongly typed rather than `any` (#456). AsyncGenerator is deliberately excluded: it belongs
+        // to the separate async-iterator hierarchy and is not a sync Iterator.
+        if (expected is TypeInfo.Iterator expIter)
+        {
+            if ((actual switch
+                {
+                    TypeInfo.Iterator it => it.ElementType,
+                    TypeInfo.Generator g => g.YieldType,
+                    _ => (TypeInfo?)null
+                }) is { } actualIterElem)
+            {
+                return IsCompatible(expIter.ElementType, actualIterElem);
+            }
+
+            // Honour TS's structural typing of the iterator protocol: any object exposing a callable
+            // `next` member satisfies `Iterator<T>` (e.g. returning a hand-written `{ next() {…} }`
+            // literal). SharpTS models next() as returning `any`, so the element type is not re-derived
+            // from a structural next here — this gates only that the protocol member is present. Without
+            // it such assignments would regress, since `Iterator<T>` is now a real type, not `any`.
+            if (GetMemberType(actual, "next") is TypeInfo.Function or TypeInfo.OverloadedFunction)
+                return true;
+            // Not an iterator-shaped source: fall through to the remaining (ultimately rejecting) rules.
+        }
+
+        // Generator<T1>/AsyncGenerator<T1> relate to the SAME kind when the yield types relate. These
+        // records resolved from a type reference before #456 but had no compatibility arm, so even
+        // `let g: Generator<number> = gen()` spuriously failed (every same-record pair without an arm
+        // falls through to `return false`); #456 completes the iterable-record family it touches.
+        if (expected is TypeInfo.Generator expGen && actual is TypeInfo.Generator actGen)
+        {
+            return IsCompatible(expGen.YieldType, actGen.YieldType);
+        }
+        if (expected is TypeInfo.AsyncGenerator expAsyncGen && actual is TypeInfo.AsyncGenerator actAsyncGen)
+        {
+            return IsCompatible(expAsyncGen.YieldType, actAsyncGen.YieldType);
+        }
+
+        // FinalizationRegistry<T1> is compatible with FinalizationRegistry<T2> if T1=T2 (#456).
+        if (expected is TypeInfo.FinalizationRegistry expFinReg && actual is TypeInfo.FinalizationRegistry actFinReg)
+        {
+            return IsCompatible(expFinReg.TargetType, actFinReg.TargetType);
+        }
+
         // Member accessibility (TypeScript private/protected): two object types are unrelated when a
         // member they share has a conflicting accessibility origin — a public member cannot satisfy a
         // private one, and two private members must originate from the same declaration. Applies in

--- a/TypeSystem/TypeChecker.Generics.Conditional.cs
+++ b/TypeSystem/TypeChecker.Generics.Conditional.cs
@@ -920,8 +920,9 @@ public partial class TypeChecker
     };
 
     /// <summary>
-    /// Decomposes a dedicated built-in container type (Map, Set, the weak variants, generators) into
-    /// its type arguments, so the conditional-type machinery can treat <c>Map&lt;…, infer V&gt;</c>
+    /// Decomposes a dedicated built-in container type (Map, Set, the weak variants, generators,
+    /// iterators, WeakRef, FinalizationRegistry) into its type arguments, so the conditional-type
+    /// machinery can treat <c>Map&lt;…, infer V&gt;</c> or <c>IterableIterator&lt;infer V&gt;</c>
     /// like a generic instantiation. These carry bespoke TypeInfo records rather than
     /// <see cref="TypeInfo.InstantiatedGeneric"/>. The set mirrors exactly the container names that
     /// <see cref="ResolveGenericType"/> resolves from a type reference — so an extends clause can
@@ -936,6 +937,9 @@ public partial class TypeChecker
         TypeInfo.WeakSet s => [s.ElementType],
         TypeInfo.Generator g => [g.YieldType],
         TypeInfo.AsyncGenerator g => [g.YieldType],
+        TypeInfo.Iterator it => [it.ElementType],
+        TypeInfo.WeakRef wr => [wr.TargetType],
+        TypeInfo.FinalizationRegistry fr => [fr.TargetType],
         _ => null
     };
 

--- a/TypeSystem/TypeChecker.Generics.cs
+++ b/TypeSystem/TypeChecker.Generics.cs
@@ -156,6 +156,30 @@ public partial class TypeChecker
                 throw new TypeCheckException($" WeakSet requires exactly 1 type argument, got {typeArgs.Count}.", tsCode: "TS2314");
             result = new TypeInfo.WeakSet(typeArgs[0]);
         }
+        // IterableIterator<T> / Iterator<T> references resolve to the dedicated Iterator record (the
+        // same one .keys()/.values()/.entries() already produce) instead of the `any` fallback, so the
+        // annotations are strongly typed and conditional-type check sides keep their element type
+        // (#456). The lib signature is Iterator<T, TReturn = any, TNext = any> — SharpTS models only the
+        // element type, so 1–3 arguments are accepted and TReturn/TNext are dropped, matching how the
+        // Generator arm above keeps only its yield type.
+        else if (baseName is "Iterator" or "IterableIterator")
+        {
+            if (typeArgs.Count is < 1 or > 3)
+                throw new TypeCheckException($" {baseName} requires between 1 and 3 type arguments, got {typeArgs.Count}.", tsCode: "TS2314");
+            result = new TypeInfo.Iterator(typeArgs[0]);
+        }
+        else if (baseName == "WeakRef")
+        {
+            if (typeArgs.Count != 1)
+                throw new TypeCheckException($" WeakRef requires exactly 1 type argument, got {typeArgs.Count}.", tsCode: "TS2314");
+            result = new TypeInfo.WeakRef(typeArgs[0]);
+        }
+        else if (baseName == "FinalizationRegistry")
+        {
+            if (typeArgs.Count != 1)
+                throw new TypeCheckException($" FinalizationRegistry requires exactly 1 type argument, got {typeArgs.Count}.", tsCode: "TS2314");
+            result = new TypeInfo.FinalizationRegistry(typeArgs[0]);
+        }
         // Handle built-in utility types
         else if (baseName == "Partial")
         {

--- a/TypeSystem/TypeChecker.TypeNodes.cs
+++ b/TypeSystem/TypeChecker.TypeNodes.cs
@@ -502,6 +502,7 @@ public partial class TypeChecker
     private static bool IsBuiltInGenericName(string name) => name is
         "Array" or "ReadonlyArray" or "Promise" or "Generator" or "AsyncGenerator" or
         "Map" or "Set" or "WeakMap" or "WeakSet" or
+        "Iterator" or "IterableIterator" or "WeakRef" or "FinalizationRegistry" or
         "Partial" or "Required" or "Readonly" or "Record" or "Pick" or "Omit" or
         "ReturnType" or "Parameters" or "ConstructorParameters" or "InstanceType" or
         "ThisType" or "Awaited" or "NonNullable" or "Extract" or "Exclude" or


### PR DESCRIPTION
Closes #456. Follow-up to #347 / PR #455, which made `Map`/`Set`/`WeakMap`/`WeakSet` type *references* resolve to their dedicated `TypeInfo` records.

## Problem
The remaining dedicated container records were only ever built from runtime expressions (`[].values()`, `new WeakRef(x)`). A type **reference** fell through `ResolveGenericType`'s `any` fallback, so these annotations were silently untyped:

```ts
let it: IterableIterator<number> = [].values();
it.totallyFakeMethod();   // no error before — `it` was `any`

type V<T> = T extends IterableIterator<infer U> ? U : never;   // U could not bind
```

## Changes
- **`ResolveGenericType`** (`TypeChecker.Generics.cs`) resolves `IterableIterator<T>`/`Iterator<T>` → `TypeInfo.Iterator`, `WeakRef<T>` → `TypeInfo.WeakRef`, `FinalizationRegistry<T>` → `TypeInfo.FinalizationRegistry`, each with a TS2314 arity check. `Iterator`/`IterableIterator` accept the lib signature's **1–3** args (`Iterator<T, TReturn, TNext>`) and keep only the element type (mirroring the `Generator` arm); `WeakRef`/`FinalizationRegistry` take exactly 1.
- **`IsBuiltInGenericName`** (`TypeChecker.TypeNodes.cs`): names added so both resolution paths agree.
- **`DecomposeBuiltInContainer`** (`TypeChecker.Generics.Conditional.cs`): the three records added so conditional-type `infer` extraction works.
- **`IsCompatible`** (`TypeChecker.Compatibility.cs`): resolving these as assignment *targets* exposed that the same-record pairs had **no compatibility arm** and fell through to `return false` — so even `let g: Generator<number> = gen()` spuriously failed. Added arms for `Iterator`, `Generator`, `AsyncGenerator`, `FinalizationRegistry`. The `Iterator` target additionally accepts:
  - a sync `Generator` (it structurally **is** an `IterableIterator`), and
  - any structural `{ next() {…} }` object (TS types the iterator protocol structurally) —

  without which assignments that worked while the annotation was `any` would regress. `AsyncGenerator` is excluded from the sync-iterator target (separate hierarchy).

Member-lookup (`GetIteratorMemberType`/`GetWeakRefMemberType`/`GetFinalizationRegistryMemberType`) and the `WeakRef` compatibility arm already existed.

## Tests
New `DedicatedContainerTypeReferenceTests` — strong-typing/member strictness, assignment compatibility (incl. the Generator→Iterator and structural-object directions, and the rejected reverse/async directions), conditional-`infer`, arity, plus a both-mode runtime guard.

- Full suite: **11477 passed, 0 failed**.
- TypeScript conformance: **31/31, baseline unchanged**.
- Test262: 0 failures (the suite host-crashes non-deterministically — known pre-existing flakiness, unrelated).

## Follow-ups filed
- #482 — `FinalizationRegistry.register()` type-checker signature treats the first param as the held value instead of the target object (pre-existing; surfaced once the registry is strongly typed).
- #483 — `AsyncIterator<T>`/`AsyncIterableIterator<T>` references still resolve to `any` (async parallel to this issue); also notes the pre-existing `Iterator`/`IterableIterator` single-record conflation.