### PR TITLE
Fix #443: compiled generator resumed yield / yield* completion is undefined not null

### DIFF
--- a/Compilation/GeneratorMoveNextEmitter.Expressions.Yield.cs
+++ b/Compilation/GeneratorMoveNextEmitter.Expressions.Yield.cs
@@ -57,8 +57,9 @@ public partial class GeneratorMoveNextEmitter
         _helpers.RehydrateLiveSpillsAfterResume();
 
         // 6. The yield expression evaluates to the value passed to next(v), which
-        // next() stashed in SentField before driving MoveNext (ECMA-262 §27.5.3.3).
-        // A bare next()/for-of resume leaves it as the caller's sent value (undefined).
+        // next() stashed in SentField before driving MoveNext (ECMA-262 §27.5.3.3, #452).
+        // A bare next()/for-of resume leaves it as the caller's sent value (undefined) — so
+        // this also subsumes #443's resumed-yield case (`"x:" + (yield 1)` → `x:undefined`).
         _il.Emit(OpCodes.Ldarg_0);
         _il.Emit(OpCodes.Ldfld, _builder.SentField);
         SetStackUnknown();
@@ -275,9 +276,13 @@ public partial class GeneratorMoveNextEmitter
 
         // Capture the delegated iterator's Current as the yield* result. Guard against
         // non-SharpTS iterators (e.g. List<T>.Enumerator) that throw on Current after
-        // MoveNext returned false: wrap in try/catch and fall back to null.
+        // MoveNext returned false: wrap in try/catch and fall back to `undefined`.
+        // A non-generator iterable (array, string, Map/Set) has no return value, so per
+        // ECMA-262 14.4.14 the `yield*` completion value is `undefined` — load the emitted
+        // `$Undefined` sentinel, not CLR `null` (which would surface as JS `null`, #443). The
+        // interpreter's DelegateYieldStar coerces its own null sentinel to `undefined` the same way.
         var yieldStarResultLocal = _il.DeclareLocal(typeof(object));
-        _il.Emit(OpCodes.Ldnull);
+        _il.Emit(OpCodes.Ldsfld, _ctx!.Runtime!.UndefinedInstance);
         _il.Emit(OpCodes.Stloc, yieldStarResultLocal);
         _il.BeginExceptionBlock();
         _il.Emit(OpCodes.Ldarg_0);

--- a/Compilation/GeneratorMoveNextEmitter.Statements.cs
+++ b/Compilation/GeneratorMoveNextEmitter.Statements.cs
@@ -33,6 +33,16 @@ public partial class GeneratorMoveNextEmitter
             _il.Emit(OpCodes.Ldloc, returnValueTemp);
             _il.Emit(OpCodes.Stfld, _builder.CurrentField);
         }
+        else
+        {
+            // Bare `return;` completes the generator with `undefined`. Store the `$Undefined`
+            // sentinel into Current so the completion value read by `gen.next().value` after
+            // done — and by a delegating `yield* thisGenerator()` — is `undefined` rather than
+            // the stale last-yielded value still sitting in Current (#443).
+            _il.Emit(OpCodes.Ldarg_0);
+            _il.Emit(OpCodes.Ldsfld, _ctx!.Runtime!.UndefinedInstance);
+            _il.Emit(OpCodes.Stfld, _builder.CurrentField);
+        }
 
         // Generator return - set state to completed and return false
         _il.Emit(OpCodes.Ldarg_0);

--- a/Compilation/GeneratorMoveNextEmitter.cs
+++ b/Compilation/GeneratorMoveNextEmitter.cs
@@ -96,7 +96,17 @@ public partial class GeneratorMoveNextEmitter : StatementEmitterBase
             EmitStatement(stmt);
         }
 
-        // Fall through after body completes - mark as done and return false
+        // Fall through after body completes — the generator ran off the end with no `return`.
+        // Per ECMA-262 its completion value is `undefined`, so reset Current to the `$Undefined`
+        // sentinel: it currently still holds the last *yielded* value, which would otherwise
+        // surface as the completion value via `gen.next().value` after done, or as the result of
+        // a delegating `yield* thisGenerator()` (#443). An explicit `return X` takes the
+        // EmitReturn path instead and stores X in Current, so this only affects the no-return case.
+        _il.Emit(OpCodes.Ldarg_0);
+        _il.Emit(OpCodes.Ldsfld, _ctx!.Runtime!.UndefinedInstance);
+        _il.Emit(OpCodes.Stfld, _builder.CurrentField);
+
+        // Mark as done and return false
         _il.Emit(OpCodes.Ldarg_0);
         _il.Emit(OpCodes.Ldc_I4, -2);
         _il.Emit(OpCodes.Stfld, _builder.StateField);

--- a/SharpTS.Tests/SharedTests/GeneratorUndefinedValueTests.cs
+++ b/SharpTS.Tests/SharedTests/GeneratorUndefinedValueTests.cs
@@ -1,0 +1,164 @@
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests;
+
+/// <summary>
+/// Regression tests for #443: a compiled generator must produce the JavaScript <c>undefined</c>
+/// sentinel — not CLR <c>null</c> or a stale value — for
+/// <list type="bullet">
+/// <item>the value a resumed <c>yield</c> expression evaluates to when no value is threaded back
+/// in (every <c>for…of</c> / no-argument <c>.next()</c> resume), and</item>
+/// <item>the completion value of a delegating <c>yield* expr</c>.</item>
+/// </list>
+/// Before the fix the compiler emitted <c>ldnull</c> at the resume point and for the <c>yield*</c>
+/// completion, so e.g. <c>"x:" + (yield 1)</c> resumed to <c>"x:null"</c> instead of
+/// <c>"x:undefined"</c>, and <c>yield* inner()</c> over a no-return generator produced the last
+/// yielded value instead of <c>undefined</c>. The interpreter was already correct for these cases,
+/// so each test below asserts identical output across both modes.
+/// </summary>
+public class GeneratorUndefinedValueTests
+{
+    // ---- Resumed `yield` value (the issue's primary case) ----
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ResumedYield_ConcatenatedAsString_IsUndefined(ExecutionMode mode)
+    {
+        // The repro from #443: for…of resumes with no sent value, so `yield 1` evaluates to undefined.
+        var source = """
+            function* g() { console.log("x:" + (yield 1)); }
+            for (const v of g()) {}
+            """;
+        Assert.Equal("x:undefined\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ResumedYield_StoredInLocal_IsUndefined(ExecutionMode mode)
+    {
+        var source = """
+            function* g() { const r = yield 1; console.log("r=" + r); }
+            for (const v of g()) {}
+            """;
+        Assert.Equal("r=undefined\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ResumedYield_InArithmetic_IsNaN(ExecutionMode mode)
+    {
+        // undefined + 10 === NaN; exercises numeric coercion of the resumed sentinel, not just string.
+        var source = """
+            function* g() { console.log((yield 1) + 10); }
+            for (const v of g()) {}
+            """;
+        Assert.Equal("NaN\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void MultipleResumedYields_AreEachUndefined(ExecutionMode mode)
+    {
+        var source = """
+            function* g() { console.log("t:" + (yield 1) + "|" + (yield 2)); }
+            for (const v of g()) {}
+            """;
+        Assert.Equal("t:undefined|undefined\n", TestHarness.Run(source, mode));
+    }
+
+    // ---- `yield*` completion value ----
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void YieldStarOverArray_CompletionIsUndefined(ExecutionMode mode)
+    {
+        // A plain array has no return value, so the yield* completion value is undefined.
+        var source = """
+            function* g() { console.log("x:" + (yield* [1, 2])); }
+            for (const v of g()) {}
+            """;
+        Assert.Equal("x:undefined\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void YieldStarOverString_CompletionIsUndefined(ExecutionMode mode)
+    {
+        var source = """
+            function* g() { console.log("x:" + (yield* "ab")); }
+            for (const v of g()) {}
+            """;
+        Assert.Equal("x:undefined\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void YieldStarOverGeneratorNoReturn_CompletionIsUndefined(ExecutionMode mode)
+    {
+        // inner runs off the end (no `return`), so the yield* completion value is undefined —
+        // not the last yielded value (2), which the compiler previously produced.
+        var source = """
+            function* inner() { yield 1; yield 2; }
+            function* g() { console.log("x:" + (yield* inner())); }
+            for (const v of g()) {}
+            """;
+        Assert.Equal("x:undefined\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void YieldStarOverGeneratorBareReturn_CompletionIsUndefined(ExecutionMode mode)
+    {
+        var source = """
+            function* inner() { yield 1; return; }
+            function* g() { console.log("x:" + (yield* inner())); }
+            for (const v of g()) {}
+            """;
+        Assert.Equal("x:undefined\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void YieldStarOverGeneratorWithReturn_CompletionIsReturnValue(ExecutionMode mode)
+    {
+        // The fix must not regress the case that already worked: an explicit `return <value>`
+        // is the yield* completion value.
+        var source = """
+            function* inner() { yield 1; return "RET"; }
+            function* g() { const r = yield* inner(); console.log("got:" + r); }
+            for (const v of g()) {}
+            """;
+        Assert.Equal("got:RET\n", TestHarness.Run(source, mode));
+    }
+
+    // ---- Direct `.next().value` completion value ----
+    // These assert spec-correct behavior in COMPILED mode. The interpreter still reports `null`
+    // here (a separate, pre-existing gap tracked by #480), so they are compiled-only for now.
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    public void OffEndCompletionValue_IsUndefined_Compiled(ExecutionMode mode)
+    {
+        var source = """
+            function* g() { yield 1; }
+            const it = g();
+            console.log("a:" + it.next().value);
+            console.log("b:" + it.next().value);
+            """;
+        Assert.Equal("a:1\nb:undefined\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    public void BareReturnCompletionValue_IsUndefined_Compiled(ExecutionMode mode)
+    {
+        var source = """
+            function* g() { yield 1; return; }
+            const it = g();
+            console.log("a:" + it.next().value);
+            console.log("b:" + it.next().value);
+            """;
+        Assert.Equal("a:1\nb:undefined\n", TestHarness.Run(source, mode));
+    }
+}

--- a/SharpTS.Tests/SharedTests/GeneratorYieldSpillTests.cs
+++ b/SharpTS.Tests/SharedTests/GeneratorYieldSpillTests.cs
@@ -11,11 +11,11 @@ namespace SharpTS.Tests.SharedTests;
 /// <c>"a…"</c>). The fix mirrors live spill locals to state-machine fields at the yield and
 /// restores them on resume.
 ///
-/// These assert the spilled prefix is <em>present</em> rather than the exact line, because the
-/// value a resumed <c>yield</c> expression evaluates to differs between modes (interpreter:
-/// <c>undefined</c>; compiler: <c>null</c>) — a separate, pre-existing gap (compiled generators
-/// don't thread <c>.next(arg)</c> / the JS <c>undefined</c> sentinel back into the yield
-/// expression). The prefix-survival is what #414 fixes and is identical across modes.
+/// These now assert the <em>exact</em> output across both modes. They previously asserted only
+/// that the spilled prefix was present, because a resumed <c>yield</c> evaluated to CLR
+/// <c>null</c> in compiled mode versus JS <c>undefined</c> in the interpreter — that divergence
+/// is fixed by #443 (compiled generators now load the <c>$Undefined</c> sentinel for a resumed
+/// yield with no sent value), so the resume value is identical across modes.
 /// </summary>
 public class GeneratorYieldSpillTests
 {
@@ -27,8 +27,9 @@ public class GeneratorYieldSpillTests
             function* g() { console.log("PFX:" + (yield 1)); }
             for (const x of g()) {}
             """;
-        // Pre-fix compiled output was "0" (prefix lost). The prefix must now be present.
-        Assert.StartsWith("PFX:", TestHarness.Run(source, mode));
+        // Pre-fix compiled output was "0" (prefix lost). The prefix now survives (#414) and the
+        // resumed `yield 1` evaluates to `undefined` in both modes (#443).
+        Assert.Equal("PFX:undefined\n", TestHarness.Run(source, mode));
     }
 
     [Theory]
@@ -39,7 +40,7 @@ public class GeneratorYieldSpillTests
             function* g() { console.log("TAG:" + (yield 1) + "|" + (yield 2)); }
             for (const x of g()) {}
             """;
-        Assert.Contains("TAG:", TestHarness.Run(source, mode));
+        Assert.Equal("TAG:undefined|undefined\n", TestHarness.Run(source, mode));
     }
 
     [Theory]
@@ -50,7 +51,7 @@ public class GeneratorYieldSpillTests
             function* g() { console.log(`[${"head"}-${yield 1}]`); }
             for (const x of g()) {}
             """;
-        Assert.Contains("[head-", TestHarness.Run(source, mode));
+        Assert.Equal("[head-undefined]\n", TestHarness.Run(source, mode));
     }
 
     [Theory]
@@ -62,6 +63,8 @@ public class GeneratorYieldSpillTests
             function* g() { console.log("PFX:" + (yield* inner())); }
             for (const x of g()) {}
             """;
-        Assert.StartsWith("PFX:", TestHarness.Run(source, mode));
+        // `inner` runs off the end with no `return`, so the `yield*` completion value is
+        // `undefined` in both modes (#443).
+        Assert.Equal("PFX:undefined\n", TestHarness.Run(source, mode));
     }
 }


### PR DESCRIPTION
Fixes #443.

## Background

#443 has two halves. **#452 (`generator.next(v)`) landed concurrently and fixed the first** — a resumed `yield` with no sent value now reads the ctor-seeded `SentField` (undefined), so `"x:" + (yield 1)` already prints `x:undefined`. This PR was rebased onto that and **completes the second half: the `yield*` / generator completion value**, which #452 left as CLR `null` or a stale yielded value.

## Problem (remaining half)

```ts
function* inner() { yield 1; yield 2; }
function* g() { console.log("x:" + (yield* inner())); }
for (const v of g()) {}
```
- Interpreter: `x:undefined`
- Compiled (before): `x:2`  (the last *yielded* value, not the completion value)

## Fix

Three emit sites now load the emitted `$Undefined` sentinel where the completion value must be `undefined`:

| Site | Before | After |
|---|---|---|
| `EmitYieldStar` completion fallback (array / string / Map / Set — no return value) | `null` | `undefined` |
| Generator fall-through (ran off the end, no `return`) — resets `Current` | stale last-yielded value | `undefined` |
| `EmitReturn` bare `return;` branch — resets `Current` | stale last-yielded value | `undefined` |

An explicit `return X` is unchanged (still stored as the completion value), so `yield* genThatReturns()` keeps yielding the return value.

| Case | Spec | Interp | Compiled (before → after) |
|---|---|---|---|
| `yield* [1,2]` completion | `undefined` | `undefined` | `null` → **`undefined`** |
| `yield* gen()` (no `return`) | `undefined` | `undefined` | `2` → **`undefined`** |
| `yield* gen()` (`return 99`) | `99` | `99` | `99` → `99` |
| `gen.next().value` after done | `undefined` | `null`¹ | stale → **`undefined`** |

¹ The interpreter's direct-`.next()` completion path still reports `null` (pre-existing, tracked by #480), so the off-the-end / bare-`return;` `.next().value` tests are compiled-only.

### Why no `$IteratorWrapper` change

A compiled `yield* gen()` reads the delegated state machine's `Current` field directly (the `IEnumerable`/`GetEnumerator` path), **not** through `$IteratorWrapper` (which discards the final `{done:true}` value). So resetting `Current` to `undefined` on completion is sufficient and self-contained.

## Notes

- The sentinel is the **emitted** `$Undefined` type, so compiled standalone DLLs stay self-contained. All emitted IL passes `--verify`.
- Negligible runtime cost: one extra field store at generator completion; the `yield*` fallback swaps one instruction.

## Tests

- New `GeneratorUndefinedValueTests` — resume value and `yield*` completion (array / string / no-return / bare-return / with-return), asserted across **both** modes; compiled-only `.next().value`-after-done completion tests.
- `GeneratorYieldSpillTests` (#414) tightened from prefix-only to exact equality now that the resume value matches across modes.
- Full suite green: **11570 passed, 0 failed**.

## Related issues filed while investigating (pre-existing, out of scope)

- #480 — interpreter generator completion value is `null`/stale instead of `undefined`
- #481 — compiled **async** generator has the same resumed-yield / `yield*` null gap
- #489 — compiled generator `return null` produces an `undefined` completion value
- #497 — compiled accumulator `total += yield total` loses the running total across yields
- #477 (already on file) — compiled generator `try/finally` + `yield` emits invalid IL
