### PR TITLE
Fix #458: widen object/array-literal property types for const bindings

### DIFF
--- a/SharpTS.Tests/TypeCheckerTests/ConstInitializerWideningTests.cs
+++ b/SharpTS.Tests/TypeCheckerTests/ConstInitializerWideningTests.cs
@@ -1,0 +1,122 @@
+using SharpTS.Tests.Infrastructure;
+using SharpTS.TypeSystem.Exceptions;
+using Xunit;
+
+namespace SharpTS.Tests.TypeCheckerTests;
+
+/// <summary>
+/// Regression tests for #458: a <c>const</c>-bound object/array literal must infer WIDENED
+/// property/element types (<c>const o = { n: 1 }</c> ⇒ <c>{ n: number }</c>), so reassigning a
+/// property to another value of the same base type is allowed. <c>const</c> freezes the binding,
+/// not the mutability or declared type of an object literal's members — only <c>as const</c>
+/// produces readonly literal-typed members. This is type-checker behaviour, shared by the
+/// interpreted and compiled modes.
+/// </summary>
+public class ConstInitializerWideningTests
+{
+    // --- The headline bug: property/element reassignment on a const object/array literal ---
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ConstObjectLiteral_PropertyReassign_Allowed(ExecutionMode mode)
+    {
+        // `const o = { n: 1 }` has type `{ n: number }`, so `o.n = 9` is legal TypeScript.
+        var output = TestHarness.Run("const o = { n: 1 }; o.n = 9; console.log(o.n);", mode);
+        Assert.Equal("9\n", output);
+    }
+
+    [Fact]
+    public void ConstObjectLiteral_StringProperty_Reassign_Ok()
+    {
+        TestHarness.RunInterpreted("const o = { s: \"a\" }; o.s = \"b\"; console.log(o.s);");
+    }
+
+    [Fact]
+    public void ConstObjectLiteral_NestedProperty_Reassign_Ok()
+    {
+        // Widening recurses: `o.p` is `{ n: number }`, so `o.p.n = 9` is allowed.
+        TestHarness.RunInterpreted("const o = { p: { n: 1 } }; o.p.n = 9; console.log(o.p.n);");
+    }
+
+    [Fact]
+    public void ConstArrayLiteral_ElementReassign_Ok()
+    {
+        // `const arr = [1, 1, 1]` is `number[]`, not `1[]`, so `arr[0] = 9` is allowed.
+        TestHarness.RunInterpreted("const arr = [1, 1, 1]; arr[0] = 9; console.log(arr[0]);");
+    }
+
+    [Fact]
+    public void ConstObjectLiteral_SatisfiesObjectType_Reassign_Ok()
+    {
+        // `satisfies` is transparent to literal widening: `o` is still `{ n: number }`.
+        TestHarness.RunInterpreted("const o = { n: 1 } satisfies { n: number }; o.n = 9; console.log(o.n);");
+    }
+
+    [Fact]
+    public void ExportConstObjectLiteral_PropertyReassign_Ok()
+    {
+        // `export const` routes through the same VisitConst inference path.
+        TestHarness.RunInterpreted("export const o = { n: 1 }; o.n = 9;");
+    }
+
+    // --- const still preserves TOP-LEVEL primitive literal types ---
+
+    [Fact]
+    public void ConstPrimitiveLiteral_KeepsLiteralType()
+    {
+        // `const x = 1` is the literal type `1` (not `number`), assignable to a `1`-typed binding.
+        TestHarness.RunInterpreted("const x = 1; const y: 1 = x; console.log(y);");
+    }
+
+    // --- `as const` must STILL reject member reassignment (readonly literal types) ---
+
+    [Fact]
+    public void AsConstObject_PropertyReassign_Rejected()
+    {
+        Assert.ThrowsAny<TypeCheckException>(() =>
+            TestHarness.RunInterpreted("const o = { n: 1 } as const; o.n = 9;"));
+    }
+
+    [Fact]
+    public void AsConstArray_ElementReassign_Rejected()
+    {
+        Assert.ThrowsAny<TypeCheckException>(() =>
+            TestHarness.RunInterpreted("const arr = [1, 2, 3] as const; arr[0] = 9;"));
+    }
+
+    [Fact]
+    public void ConstAliasOfAsConst_PropertyReassign_Rejected()
+    {
+        // Aliasing an `as const` value is not a fresh object literal — its literal types are
+        // preserved, so the reassignment through the alias is still rejected.
+        Assert.ThrowsAny<TypeCheckException>(() =>
+            TestHarness.RunInterpreted("const a = { n: 1 } as const; const o = a; o.n = 9;"));
+    }
+
+    // --- A nested `as const` member inside a plain const object literal is still preserved ---
+
+    [Fact]
+    public void ConstObjectLiteral_NestedAsConstMember_KeepsLiteralType()
+    {
+        // `o.p.n` is `1` (the nested `as const` is not widened away), so it is assignable to `1`.
+        TestHarness.RunInterpreted("const o = { p: { n: 1 } as const }; const y: 1 = o.p.n; console.log(y);");
+    }
+
+    [Fact]
+    public void ConstObjectLiteral_NestedAsConstMember_Reassign_Rejected()
+    {
+        // The nested `as const` keeps `o.p.n` at literal type `1`, so reassigning it is rejected.
+        Assert.ThrowsAny<TypeCheckException>(() =>
+            TestHarness.RunInterpreted("const o = { p: { n: 1 } as const }; o.p.n = 9;"));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ConstObjectLiteral_MixedPlainAndAsConstMembers(ExecutionMode mode)
+    {
+        // In the same object literal, a plain member widens (`o.b.m = 5` is allowed) while an
+        // `as const` member keeps its literal types (`o.a.n` stays `1`).
+        var source = "const o = { a: { n: 1 } as const, b: { m: 2 } }; o.b.m = 5; console.log(o.b.m);";
+        Assert.Equal("5\n", TestHarness.Run(source, mode));
+    }
+}

--- a/TypeSystem/TypeChecker.Expressions.cs
+++ b/TypeSystem/TypeChecker.Expressions.cs
@@ -808,6 +808,103 @@ public partial class TypeChecker
         };
     }
 
+    /// <summary>
+    /// Widens the inferred type of an un-annotated <c>const</c> initializer to match TypeScript.
+    /// A <c>const</c> binding freezes the <em>binding</em>, not the mutability of an object/array
+    /// literal's members, so a fresh object- or array-literal initializer has its property/element
+    /// types widened to their base types (<c>const o = { n: 1 }</c> ⇒ <c>{ n: number }</c>), which
+    /// keeps a later <c>o.n = 9</c> legal. A bare primitive literal keeps its literal type
+    /// (<c>const x = 1</c> ⇒ <c>1</c>), and <c>as const</c> assertions keep their readonly literal
+    /// types — including a <c>as const</c> nested inside a plain object literal. Non-literal
+    /// initializers (variables, calls, …) are not "fresh" and pass through unchanged.
+    /// </summary>
+    private static TypeInfo WidenConstInitializerType(Expr initializer, TypeInfo inferredType)
+        => WidenFreshLiteralsForConst(initializer, inferredType, topLevel: true);
+
+    /// <summary>
+    /// Recursively widens the literal types produced by <em>fresh</em> object/array literals for a
+    /// <c>const</c> binding, while preserving <c>as const</c> assertions and non-literal
+    /// expressions. At the binding top level a bare primitive literal is preserved
+    /// (<c>const x = 1</c> ⇒ <c>1</c>); inside an object literal it is widened
+    /// (<c>{ a: 1 }</c> ⇒ <c>{ a: number }</c>), mirroring the <c>let</c> path.
+    /// </summary>
+    private static TypeInfo WidenFreshLiteralsForConst(Expr expr, TypeInfo type, bool topLevel)
+    {
+        // `satisfies` and parentheses are transparent to widening:
+        // `const o = ({ n: 1 }) satisfies T` widens exactly like `const o = { n: 1 }`.
+        Expr inner = expr;
+        while (true)
+        {
+            if (inner is Expr.Satisfies sat) { inner = sat.Expression; continue; }
+            if (inner is Expr.Grouping grp) { inner = grp.Expression; continue; }
+            break;
+        }
+
+        switch (inner)
+        {
+            // `as const` keeps its readonly literal property/element types.
+            case Expr.TypeAssertion { TargetType: "const" }:
+                return type;
+
+            // A fresh object literal widens each member; a member that is itself `as const` (or a
+            // non-fresh reference) is preserved by recursing on its value expression.
+            case Expr.ObjectLiteral obj when type is TypeInfo.Record rec:
+                return WidenConstObjectLiteralFields(obj, rec);
+
+            // A fresh array literal widens its element type. Element expressions are collapsed into
+            // a single element type during inference, so an `as const` *element* is not kept.
+            case Expr.ArrayLiteral when type is TypeInfo.Array arr:
+                return new TypeInfo.Array(WidenLiteralType(arr.ElementType));
+
+            // A bare primitive literal: preserved at the binding top level, widened inside a literal.
+            case Expr.Literal:
+                return topLevel ? type : WidenLiteralType(type);
+
+            // Variables, calls, non-const assertions, …: not fresh — preserve as-is.
+            default:
+                return type;
+        }
+    }
+
+    /// <summary>
+    /// Widens the fields of a fresh object-literal <see cref="TypeInfo.Record"/> for a <c>const</c>
+    /// binding. Direct (<c>name: value</c>) members recurse so a nested <c>as const</c> member keeps
+    /// its literal types; spread/computed/accessor members widen conservatively. Other record
+    /// metadata (optional/getter-only/index signatures, …) is preserved.
+    /// </summary>
+    private static TypeInfo WidenConstObjectLiteralFields(Expr.ObjectLiteral obj, TypeInfo.Record rec)
+    {
+        // Map each statically-named, non-spread `name: value` member to its value expression.
+        var valueExprByName = new Dictionary<string, Expr>();
+        foreach (var prop in obj.Properties)
+        {
+            if (prop.IsSpread || prop.Kind != Expr.ObjectPropertyKind.Value) continue;
+            string? name = prop.Key switch
+            {
+                Expr.IdentifierKey ik => ik.Name.Lexeme,
+                Expr.LiteralKey { Literal.Literal: string s } => s,
+                _ => null,
+            };
+            if (name != null) valueExprByName[name] = prop.Value;
+        }
+
+        var widenedFields = new Dictionary<string, TypeInfo>(rec.Fields.Count);
+        foreach (var (name, fieldType) in rec.Fields)
+        {
+            widenedFields[name] = valueExprByName.TryGetValue(name, out var valueExpr)
+                ? WidenFreshLiteralsForConst(valueExpr, fieldType, topLevel: false)
+                : WidenLiteralType(fieldType);
+        }
+
+        return rec with
+        {
+            Fields = widenedFields.ToFrozenDictionary(),
+            StringIndexType = rec.StringIndexType != null ? WidenLiteralType(rec.StringIndexType) : null,
+            NumberIndexType = rec.NumberIndexType != null ? WidenLiteralType(rec.NumberIndexType) : null,
+            SymbolIndexType = rec.SymbolIndexType != null ? WidenLiteralType(rec.SymbolIndexType) : null,
+        };
+    }
+
     private TypeInfo CheckArray(Expr.ArrayLiteral array)
     {
         if (array.Elements.Count == 0) return new TypeInfo.Array(new TypeInfo.Any()); // Empty array is any[]? or generic?

--- a/TypeSystem/TypeChecker.Statements.cs
+++ b/TypeSystem/TypeChecker.Statements.cs
@@ -337,7 +337,7 @@ public partial class TypeChecker
         else
         {
             _environment.Define(stmt.Name.Lexeme, new TypeInfo.Any());
-            constDeclaredType = CheckExpr(stmt.Initializer);
+            constDeclaredType = WidenConstInitializerType(stmt.Initializer, CheckExpr(stmt.Initializer));
             _environment.Define(stmt.Name.Lexeme, constDeclaredType);
         }
 


### PR DESCRIPTION
Closes #458.

## Problem

A `const`-bound object literal inferred **literal** property types, so reassigning a property to another value of the same base type was wrongly rejected:

```ts
const o = { n: 1 };
o.n = 9;   // ❌ Type Error: Cannot assign '9' to property 'n' of type '1'
```

TypeScript widens object-literal property types to their base types regardless of `const`/`let` — `const o = { n: 1 }` has type `{ n: number }`. `const` freezes the *binding*, not the mutability of its members; only `as const` produces readonly literal-typed members.

## Root cause

`const` declarations dispatch to `VisitConst` (a separate `Stmt.Const` node), whose no-annotation branch stored the inferred initializer type **without widening** — unlike `let`/`var` (`VisitVar`), which call `WidenLiteralType`. `CheckObject` produces fresh literal property types and the binding site is what widens them; `VisitConst` skipped that step.

## Fix

Type-checker only (both run modes share it). `VisitConst` now widens the inferred type via a new `WidenConstInitializerType` (in `TypeChecker.Expressions.cs`, beside the existing static `WidenLiteralType`).

It is **expression-gated** rather than type-only, because `as const` records are not marked readonly (`InferConstObjectType` only sets `GetterOnlyFields`) and are therefore structurally identical to plain literal records. The helper:

- unwraps `satisfies` / parentheses (transparent to widening);
- preserves `as const` assertions;
- widens **fresh** object literals, recursing per-member so a directly-named nested `as const` member keeps its literal types (and `rec with { … }` preserves optional/getter-only/index metadata);
- widens fresh array literals' element types;
- preserves a top-level bare primitive literal (`const x = 1` ⇒ `1`), widening one only when it is *inside* a literal;
- leaves variable/call references untouched, so `const o = someAsConstVar` keeps the aliased literal types.

## Behaviour

| Source | Before | After |
|---|---|---|
| `const o = { n: 1 }; o.n = 9` | ❌ rejected | ✅ ok |
| `const o = { p: { n: 1 } }; o.p.n = 9` | ❌ rejected | ✅ ok |
| `const arr = [1,1,1]; arr[0] = 9` | ❌ rejected | ✅ ok |
| `const o = { n: 1 } satisfies { n: number }; o.n = 9` | ❌ rejected | ✅ ok |
| `const x = 1` keeps literal type `1` | ✅ | ✅ |
| `const o = { n: 1 } as const; o.n = 9` | ✅ rejected | ✅ rejected |
| `const o = { p: { n: 1 } as const }; o.p.n` is `1` | ✅ | ✅ |

## Tests

`SharpTS.Tests/TypeCheckerTests/ConstInitializerWideningTests.cs` (15 cases): headline/nested/array/`satisfies`/`export const` acceptance, top-level-literal preservation, `as const` (object/array/alias/nested-write) rejection, and a both-modes runtime check of a mixed object where a plain member widens while an `as const` member is preserved.

- Full unit suite: 11464 passed (the lone failure was `DnsRecordTypeTests.ResolveNs_InvalidDomain`, a pre-existing network flake that passes in isolation).
- TypeScript conformance: 31/31, baseline unchanged.
- Test262: 21 passed / 3 skipped / 0 failed, baseline unchanged.

## Follow-up

Filed #493 for residual `as const` modeling gaps: an `as const` at the **array-element** level inside a fresh array literal, or **spread** into a fresh object literal, is still widened away (no value-expression maps 1:1 to those type positions), and `as const` member writes report `TS2322` instead of `TS2540`. The root fix is to model `as const` results as readonly.
