### PR TITLE
Fix #456: resolve IterableIterator/Iterator/WeakRef/FinalizationRegistry type references

### DIFF
--- a/Runtime/BuiltIns/BuiltInTypes.cs
+++ b/Runtime/BuiltIns/BuiltInTypes.cs
@@ -556,14 +556,21 @@ public static class BuiltInTypes
     }
 
     /// <summary>
-    /// FinalizationRegistry has register() and unregister() methods.
+    /// FinalizationRegistry has register() and unregister() methods. <paramref name="targetType"/> is
+    /// the registry's element type T (the held value), not the GC target.
     /// </summary>
     public static TypeInfo? GetFinalizationRegistryMemberType(string name, TypeInfo targetType)
     {
         return name switch
         {
-            "register" => new TypeInfo.Function([targetType, new TypeInfo.Any(), new TypeInfo.Any()],
-                new TypeInfo.Undefined(), RequiredParams: 1),
+            // register(target: WeakKey, heldValue: T, unregisterToken?: WeakKey): void
+            // The GC target and unregister token are arbitrary objects — SharpTS does not model the
+            // WeakKey type precisely, so `any` keeps them permissive — while heldValue carries the
+            // registry's element type T. target and heldValue are required; the token is optional.
+            // (Before #456 the FinalizationRegistry<T> annotation degraded to `any`, so this signature
+            // was never observed against an explicit T; T was previously mis-placed at parameter 0.)
+            "register" => new TypeInfo.Function([new TypeInfo.Any(), targetType, new TypeInfo.Any()],
+                new TypeInfo.Undefined(), RequiredParams: 2),
             "unregister" => new TypeInfo.Function([new TypeInfo.Any()],
                 new TypeInfo.Primitive(Parsing.TokenType.TYPE_BOOLEAN)),
             _ => null

--- a/SharpTS.Tests/TypeCheckerTests/DedicatedContainerTypeReferenceTests.cs
+++ b/SharpTS.Tests/TypeCheckerTests/DedicatedContainerTypeReferenceTests.cs
@@ -1,0 +1,334 @@
+using SharpTS.Tests.Infrastructure;
+using SharpTS.TypeSystem.Exceptions;
+using Xunit;
+
+namespace SharpTS.Tests.TypeCheckerTests;
+
+/// <summary>
+/// The single-/dual-argument dedicated built-in container records — <c>IterableIterator&lt;T&gt;</c> /
+/// <c>Iterator&lt;T&gt;</c> (=> <c>TypeInfo.Iterator</c>), <c>WeakRef&lt;T&gt;</c>,
+/// <c>FinalizationRegistry&lt;T&gt;</c> — now resolve from a type REFERENCE instead of degrading to
+/// <c>any</c> (#456, completing the Map/Set/WeakMap/WeakSet work in #347 / PR&#160;#455). Resolving
+/// them also surfaced that the dedicated iterable records lacked a compatibility arm: <c>Iterator</c>,
+/// <c>Generator</c>/<c>AsyncGenerator</c> and <c>FinalizationRegistry</c> all fell through to the
+/// final <c>return false</c>, so even <c>let g: Generator&lt;number&gt; = gen()</c> spuriously failed.
+/// The arms added with this change close that, with a sync <c>Generator</c> accepted where an
+/// <c>Iterator</c> is expected (it structurally IS one) so previously-<c>any</c> assignments do not
+/// regress.
+/// </summary>
+public class DedicatedContainerTypeReferenceTests
+{
+    // ---- IterableIterator / Iterator references are strongly typed (no longer `any`) ----
+
+    [Fact]
+    public void IterableIterator_FakeMember_Rejected()
+    {
+        // The issue's headline example: `it` is now Iterator<number>, not `any`, so an unknown member
+        // is a compile-time type error instead of silently passing and throwing at runtime.
+        var source = """
+            let it: IterableIterator<number> = [1, 2, 3].values();
+            it.totallyFakeMethod();
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void Iterator_AltSpelling_FakeMember_Rejected()
+    {
+        // `Iterator<T>` and `IterableIterator<T>` both resolve to the same TypeInfo.Iterator record.
+        var source = """
+            let it: Iterator<number> = [1, 2, 3].values();
+            it.nope();
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void IterableIterator_FromArrayValues_Accepted()
+    {
+        TestHarness.RunInterpreted("let it: IterableIterator<number> = [1, 2, 3].values();");
+    }
+
+    [Fact]
+    public void IterableIterator_FromMapEntries_Accepted()
+    {
+        // Map.entries() yields IterableIterator<[K, V]>; the tuple element type must line up.
+        var source = """
+            const m = new Map<string, number>();
+            let it: IterableIterator<[string, number]> = m.entries();
+            """;
+        TestHarness.RunInterpreted(source);
+    }
+
+    [Fact]
+    public void Iterator_ElementMismatch_Rejected()
+    {
+        // The element type is now real: an Iterator<number> cannot satisfy IterableIterator<string>.
+        var source = "function f(it: IterableIterator<number>): IterableIterator<string> { return it; }";
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void Iterator_ThreeTypeArgs_LibSpelling_Accepted()
+    {
+        // lib.d.ts is Iterator<T, TReturn = any, TNext = any>; SharpTS keeps only the element type but
+        // must accept (and ignore) the optional TReturn/TNext, the same way Generator drops them.
+        TestHarness.RunInterpreted("let it: Iterator<number, void, undefined> = [1].values();");
+    }
+
+    [Fact]
+    public void Iterator_TooManyTypeArgs_RejectedWithTs2707()
+    {
+        // A defaulted type-parameter range (1..3) uses TS2707 ("requires between N and M"), the code
+        // tsc emits here — not the exact-count TS2314 the single-arity records below use.
+        var source = "let it: Iterator<number, void, undefined, string> = [1].values();";
+        var ex = Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+        Assert.Equal("TS2707", ex.Diagnostic.TsCode);
+    }
+
+    // ---- Generator <-> Iterator direction (a sync Generator IS an IterableIterator) ----
+
+    [Fact]
+    public void Generator_SelfAssignment_Accepted()
+    {
+        // Regression that resolving these records exposed: a same-record pair with no compatibility arm
+        // fell through to `return false`, so this spuriously failed before this change.
+        var source = """
+            function* gen(): Generator<number> { yield 1; }
+            let g: Generator<number> = gen();
+            """;
+        TestHarness.RunInterpreted(source);
+    }
+
+    [Fact]
+    public void AsyncGenerator_SelfAssignment_Accepted()
+    {
+        var source = """
+            async function* gen(): AsyncGenerator<number> { yield 1; }
+            let g: AsyncGenerator<number> = gen();
+            """;
+        TestHarness.RunInterpreted(source);
+    }
+
+    [Fact]
+    public void Generator_AssignableToIterableIterator_Accepted()
+    {
+        // Generator<T> extends IterableIterator<T>; without this arm the assignment would regress now
+        // that IterableIterator<number> is strongly typed rather than `any`.
+        var source = """
+            function* gen(): Generator<number> { yield 1; }
+            let it: IterableIterator<number> = gen();
+            """;
+        TestHarness.RunInterpreted(source);
+    }
+
+    [Fact]
+    public void Iterator_NotAssignableToGenerator_Rejected()
+    {
+        // The relation is asymmetric: a plain Iterator is not a Generator.
+        var source = "function f(it: IterableIterator<number>): Generator<number> { return it; }";
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void AsyncGenerator_NotAssignableToSyncIterator_Rejected()
+    {
+        // Sync and async iterator hierarchies are distinct: an AsyncGenerator is not a sync Iterator.
+        var source = """
+            async function* agen(): AsyncGenerator<number> { yield 1; }
+            function f(): IterableIterator<number> { return agen(); }
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void StructuralIteratorObject_AssignableToIterator_Accepted()
+    {
+        // tsc types Iterator<T> structurally: a hand-written object with a `next` method satisfies it.
+        // Before #456 this was accepted because the annotation was `any`; rejecting it now would regress
+        // the idiom (e.g. ArrayStaticTests.Array_From_CustomIterator). The element type is intentionally
+        // not re-checked for structural sources — that, and structural for...of, are tracked in #485.
+        var source = """
+            function make(): Iterator<number> {
+              let i = 0;
+              return {
+                next(): IteratorResult<number> {
+                  return i < 3 ? { value: ++i, done: false } : { value: 0, done: true };
+                }
+              };
+            }
+            """;
+        TestHarness.RunInterpreted(source);
+    }
+
+    // ---- WeakRef references are strongly typed ----
+
+    [Fact]
+    public void WeakRef_FakeMember_Rejected()
+    {
+        var source = """
+            let wr: WeakRef<{ name: string }> = new WeakRef({ name: "x" });
+            wr.totallyFakeMethod();
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void WeakRef_Deref_ReturnsTargetType_Accepted()
+    {
+        // deref() returns T | undefined; the non-null assertion narrows to the target's member type.
+        // (Truthiness `if (d)` narrowing of T | undefined is a separate, pre-existing gap, so `!` is
+        // used here to keep the test focused on #456's strong typing of the deref() return.)
+        var source = """
+            let wr: WeakRef<{ name: string }> = new WeakRef({ name: "x" });
+            let n: string = wr.deref()!.name;
+            """;
+        TestHarness.RunInterpreted(source);
+    }
+
+    [Fact]
+    public void WeakRef_Deref_TargetMemberMismatch_Rejected()
+    {
+        // The target type is real, so reading a non-existent member off it is an error.
+        var source = """
+            let wr: WeakRef<{ name: string }> = new WeakRef({ name: "x" });
+            let n: number = wr.deref()!.missing;
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void WeakRef_TargetMismatch_Rejected()
+    {
+        var source = "function f(a: WeakRef<{ a: number }>): WeakRef<{ b: number }> { return a; }";
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void WeakRef_TooManyTypeArgs_RejectedWithTs2314()
+    {
+        var source = "let wr: WeakRef<object, string> = new WeakRef({});";
+        var ex = Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+        Assert.Equal("TS2314", ex.Diagnostic.TsCode);
+    }
+
+    // ---- FinalizationRegistry references are strongly typed ----
+
+    [Fact]
+    public void FinalizationRegistry_FakeMember_Rejected()
+    {
+        var source = """
+            let fr: FinalizationRegistry<string> = new FinalizationRegistry((v: string) => {});
+            fr.nope();
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void FinalizationRegistry_Register_TargetThenHeldValue_Accepted()
+    {
+        // register(target: WeakKey, heldValue: T, unregisterToken?: WeakKey). The target is an
+        // arbitrary object and the SECOND argument carries the element type T — the previously
+        // unobserved signature (annotation was `any`) had T mis-placed at parameter 0, which this
+        // change corrects.
+        var source = """
+            function use(fr: FinalizationRegistry<string>): void {
+              const target = { id: 1 };
+              fr.register(target, "held");
+              fr.register(target, "held", target);
+              fr.unregister(target);
+            }
+            """;
+        TestHarness.RunInterpreted(source);
+    }
+
+    [Fact]
+    public void FinalizationRegistry_Register_WrongHeldValueType_Rejected()
+    {
+        // The held value (second argument) must match T; a number is not a string.
+        var source = """
+            function use(fr: FinalizationRegistry<string>): void {
+              fr.register({ id: 1 }, 42);
+            }
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void FinalizationRegistry_HeldValueMismatch_Rejected()
+    {
+        var source = "function f(a: FinalizationRegistry<string>): FinalizationRegistry<number> { return a; }";
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void FinalizationRegistry_TooManyTypeArgs_RejectedWithTs2314()
+    {
+        var source = "let fr: FinalizationRegistry<string, number> = new FinalizationRegistry((v: string) => {});";
+        var ex = Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+        Assert.Equal("TS2314", ex.Diagnostic.TsCode);
+    }
+
+    // ---- conditional-type `infer` extraction (DecomposeBuiltInContainer) ----
+
+    [Fact]
+    public void ConditionalInfer_FromIterableIterator_BindsElement()
+    {
+        var source = """
+            type ElemOf<T> = T extends IterableIterator<infer V> ? V : "none";
+            function f(): ElemOf<IterableIterator<number>> { return "hello"; }
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void ConditionalInfer_FromIterableIterator_CorrectBranchAccepted()
+    {
+        var source = """
+            type ElemOf<T> = T extends IterableIterator<infer V> ? V : "none";
+            let x: ElemOf<IterableIterator<number>> = 5;
+            """;
+        TestHarness.RunInterpreted(source);
+    }
+
+    [Fact]
+    public void ConditionalInfer_FromWeakRef_BindsTarget()
+    {
+        var source = """
+            type TargetOf<T> = T extends WeakRef<infer V> ? V : never;
+            function f(): TargetOf<WeakRef<string>> { return 42; }
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void ConditionalInfer_FromFinalizationRegistry_BindsHeldValue()
+    {
+        var source = """
+            type HeldOf<T> = T extends FinalizationRegistry<infer V> ? V : never;
+            function f(): HeldOf<FinalizationRegistry<string>> { return 42; }
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+
+    // ---- regression guard: ordinary use of these annotations type-checks and runs in BOTH modes ----
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AnnotatedIterables_BehaveIdenticallyAcrossModes(ExecutionMode mode)
+    {
+        // The annotations are type-level only; they must not perturb interpretation or IL codegen.
+        var source = """
+            function* gen(): Generator<number> { yield 1; yield 2; yield 3; }
+            let g: Generator<number> = gen();
+            let it: IterableIterator<number> = [10, 20].values();
+            let sum = 0;
+            for (const x of g) { sum += x; }
+            for (const y of it) { sum += y; }
+            const wr: WeakRef<{ v: number }> = new WeakRef({ v: 100 });
+            sum += wr.deref()!.v;
+            console.log(sum);
+            """;
+        Assert.Equal("136\n", TestHarness.Run(source, mode));
+    }
+}

--- a/TypeSystem/TypeChecker.Compatibility.cs
+++ b/TypeSystem/TypeChecker.Compatibility.cs
@@ -835,6 +835,62 @@ public partial class TypeChecker
             return IsCompatible(expWeakRef.TargetType, actWeakRef.TargetType);
         }
 
+        // Iterator<T> / IterableIterator<T> share one record (TypeInfo.Iterator) — the type that
+        // .keys()/.values()/.entries() and array/set/map iteration produce, and that the
+        // IterableIterator<T>/Iterator<T> annotations now resolve to (#456). The element type is
+        // covariant. A sync Generator structurally IS an IterableIterator (Generator<T> extends
+        // IterableIterator<T> extends Iterator<T>), so a generator satisfies an Iterator-typed target;
+        // without this, assigning a generator to a now-strongly-typed IterableIterator<T> annotation
+        // would regress from the prior `any`. AsyncGenerator is excluded — async iterators are a
+        // distinct hierarchy. A source that is neither an iterator record nor a generator falls through
+        // (so a plain Iterator is rejected for the Generator-typed target handled just below).
+        if (expected is TypeInfo.Iterator expIter)
+        {
+            TypeInfo? actualElement = actual switch
+            {
+                TypeInfo.Iterator actIter => actIter.ElementType,
+                TypeInfo.Generator actGenAsIter => actGenAsIter.YieldType,
+                _ => null
+            };
+            if (actualElement is not null)
+                return IsCompatible(expIter.ElementType, actualElement);
+
+            // tsc types Iterator<T> structurally, so an object literal / interface / class instance
+            // that supplies a callable `next` member satisfies it (e.g. the hand-written iterators that
+            // `[Symbol.iterator]()` returns). Before #456 the annotation was `any` and accepted these
+            // outright; rejecting them now would regress that idiom. SharpTS models iterables nominally
+            // elsewhere and does not model IteratorResult<T> (a `next` method's return resolves to
+            // `any`), so the element type is not re-derived from `next` — this is permissive on the
+            // element type while still rejecting non-iterator objects (arrays/maps/strings have no
+            // `next`). Full structural iterator/iterable typing is tracked in #485.
+            if (GetMemberType(actual, "next") is TypeInfo.Function or TypeInfo.GenericFunction or TypeInfo.OverloadedFunction)
+                return true;
+        }
+
+        // Generator<T> / AsyncGenerator<T> relate to the SAME kind with a covariant yield type. These
+        // records were already resolvable from a type reference (Generator/AsyncGenerator predate #456
+        // in ResolveGenericType) but had no compatibility arm, so even `let g: Generator<number> =
+        // gen()` spuriously failed — a same-record pair with no arm falls through to the final
+        // `return false`. Adding the arm completes the dedicated-iterable-record family #456 touches. A
+        // plain Iterator is intentionally NOT accepted for a Generator target (the relation is
+        // asymmetric: Generator extends IterableIterator, not the reverse).
+        if (expected is TypeInfo.Generator expGen && actual is TypeInfo.Generator actGen)
+        {
+            return IsCompatible(expGen.YieldType, actGen.YieldType);
+        }
+        if (expected is TypeInfo.AsyncGenerator expAsyncGen && actual is TypeInfo.AsyncGenerator actAsyncGen)
+        {
+            return IsCompatible(expAsyncGen.YieldType, actAsyncGen.YieldType);
+        }
+
+        // FinalizationRegistry<T1> is compatible with FinalizationRegistry<T2> when the held-value
+        // types relate (#456 makes FinalizationRegistry<T> resolve to this record; like the other
+        // dedicated container records it would otherwise fall through to `return false`).
+        if (expected is TypeInfo.FinalizationRegistry expFinReg && actual is TypeInfo.FinalizationRegistry actFinReg)
+        {
+            return IsCompatible(expFinReg.TargetType, actFinReg.TargetType);
+        }
+
         // Member accessibility (TypeScript private/protected): two object types are unrelated when a
         // member they share has a conflicting accessibility origin — a public member cannot satisfy a
         // private one, and two private members must originate from the same declaration. Applies in

--- a/TypeSystem/TypeChecker.Generics.Conditional.cs
+++ b/TypeSystem/TypeChecker.Generics.Conditional.cs
@@ -920,13 +920,14 @@ public partial class TypeChecker
     };
 
     /// <summary>
-    /// Decomposes a dedicated built-in container type (Map, Set, the weak variants, generators) into
-    /// its type arguments, so the conditional-type machinery can treat <c>Map&lt;…, infer V&gt;</c>
+    /// Decomposes a dedicated built-in container type (Map, Set, the weak variants, generators,
+    /// iterators, WeakRef, FinalizationRegistry) into its type arguments, so the conditional-type
+    /// machinery can treat <c>Map&lt;…, infer V&gt;</c> or <c>IterableIterator&lt;infer V&gt;</c>
     /// like a generic instantiation. These carry bespoke TypeInfo records rather than
     /// <see cref="TypeInfo.InstantiatedGeneric"/>. The set mirrors exactly the container names that
     /// <see cref="ResolveGenericType"/> resolves from a type reference — so an extends clause can
     /// actually denote one of them; Array/Promise/Tuple keep their own dedicated match branches and
-    /// are excluded. Returns null for any other type (#347).
+    /// are excluded. Returns null for any other type (#347, #456).
     /// </summary>
     private static IReadOnlyList<TypeInfo>? DecomposeBuiltInContainer(TypeInfo type) => type switch
     {
@@ -936,6 +937,9 @@ public partial class TypeChecker
         TypeInfo.WeakSet s => [s.ElementType],
         TypeInfo.Generator g => [g.YieldType],
         TypeInfo.AsyncGenerator g => [g.YieldType],
+        TypeInfo.Iterator it => [it.ElementType],
+        TypeInfo.WeakRef wr => [wr.TargetType],
+        TypeInfo.FinalizationRegistry fr => [fr.TargetType],
         _ => null
     };
 

--- a/TypeSystem/TypeChecker.Generics.cs
+++ b/TypeSystem/TypeChecker.Generics.cs
@@ -156,6 +156,37 @@ public partial class TypeChecker
                 throw new TypeCheckException($" WeakSet requires exactly 1 type argument, got {typeArgs.Count}.", tsCode: "TS2314");
             result = new TypeInfo.WeakSet(typeArgs[0]);
         }
+        // IterableIterator<T> / Iterator<T> references resolve to the dedicated Iterator record — the
+        // same one .keys()/.values()/.entries() and array/set/map iteration already produce — instead
+        // of the `any` fallback, so the annotation is strongly typed and conditional-type check sides
+        // keep their element type (#456). The lib signature is Iterator<T, TReturn = any, TNext = any>
+        // (IterableIterator likewise gained TReturn/TNext in recent lib): SharpTS models only the
+        // element type, so 1–3 arguments are accepted and the optional TReturn/TNext are dropped, the
+        // same way the Generator arm above keeps only its yield type. Out-of-range is TS2707 ("between
+        // M and N"), the code tsc uses for a defaulted range, not the exact-count TS2314. (The
+        // Generator/AsyncGenerator arms still require exactly 1 arg and reject their own TReturn/TNext
+        // — a pre-existing gap tracked in #487.)
+        else if (baseName is "Iterator" or "IterableIterator")
+        {
+            if (typeArgs.Count is < 1 or > 3)
+                throw new TypeCheckException($" {baseName} requires between 1 and 3 type arguments, got {typeArgs.Count}.", tsCode: "TS2707");
+            result = new TypeInfo.Iterator(typeArgs[0]);
+        }
+        // WeakRef<T> / FinalizationRegistry<T> references resolve to their dedicated records — which
+        // already carry IsCompatible + member-type support (exercised by `new WeakRef()` /
+        // `new FinalizationRegistry()` today) — rather than degrading to `any` (#456).
+        else if (baseName == "WeakRef")
+        {
+            if (typeArgs.Count != 1)
+                throw new TypeCheckException($" WeakRef requires exactly 1 type argument, got {typeArgs.Count}.", tsCode: "TS2314");
+            result = new TypeInfo.WeakRef(typeArgs[0]);
+        }
+        else if (baseName == "FinalizationRegistry")
+        {
+            if (typeArgs.Count != 1)
+                throw new TypeCheckException($" FinalizationRegistry requires exactly 1 type argument, got {typeArgs.Count}.", tsCode: "TS2314");
+            result = new TypeInfo.FinalizationRegistry(typeArgs[0]);
+        }
         // Handle built-in utility types
         else if (baseName == "Partial")
         {

--- a/TypeSystem/TypeChecker.TypeNodes.cs
+++ b/TypeSystem/TypeChecker.TypeNodes.cs
@@ -502,6 +502,7 @@ public partial class TypeChecker
     private static bool IsBuiltInGenericName(string name) => name is
         "Array" or "ReadonlyArray" or "Promise" or "Generator" or "AsyncGenerator" or
         "Map" or "Set" or "WeakMap" or "WeakSet" or
+        "Iterator" or "IterableIterator" or "WeakRef" or "FinalizationRegistry" or
         "Partial" or "Required" or "Readonly" or "Record" or "Pick" or "Omit" or
         "ReturnType" or "Parameters" or "ConstructorParameters" or "InstanceType" or
         "ThisType" or "Awaited" or "NonNullable" or "Extract" or "Exclude" or


### PR DESCRIPTION
Closes #456.

`IterableIterator<T>` / `Iterator<T>`, `WeakRef<T>`, and `FinalizationRegistry<T>` carry dedicated `TypeInfo` records that were only ever constructed from *expressions* (`[].values()`, `new WeakRef()`, …). A type **reference** in annotation position fell through to the `any` fallback, so the annotation was untyped and conditional-type `infer` could not extract its element. This completes the Map/Set/WeakMap/WeakSet work from #347 / PR #455, across the same four seams.

```ts
let it: IterableIterator<number> = [].values();
it.totallyFakeMethod();   // now a compile-time error (was `any` → runtime TypeError)

type ElemOf<T> = T extends IterableIterator<infer V> ? V : never;
let x: ElemOf<IterableIterator<number>> = "no";  // now errors (V binds to number)
```

### Changes
- **`ResolveGenericType`** — `Iterator`/`IterableIterator` → `TypeInfo.Iterator` (accepts the lib's `Iterator<T, TReturn = any, TNext = any>`: 1–3 args, keeps `T`, out-of-range is **TS2707**); `WeakRef`/`FinalizationRegistry` → their records (exactly 1 arg, **TS2314**).
- **`IsBuiltInGenericName`** — add the four names so the built-in shadows a like-named user alias on both resolution paths (mirrors the Map/Set precedent).
- **`DecomposeBuiltInContainer`** — add the three records so conditional `infer` binds.
- **`IsCompatible`** — these dedicated iterable records had **no compatibility arm** and fell through to the final `return false`, so even `let g: Generator<number> = gen()` already failed. Added covariant arms for `Iterator`/`Generator`/`AsyncGenerator`/`FinalizationRegistry`. A sync `Generator` satisfies an `Iterator` target, and a structurally-typed object with a callable `next` satisfies `Iterator<T>` (tsc types it structurally; exercised by `ArrayStaticTests.Array_From_CustomIterator`) — both keep positions that were `any` before from regressing.

### Rider: `FinalizationRegistry.register` signature
Corrected to `register(target: WeakKey, heldValue: T, unregisterToken?)` — `T` was mis-placed at parameter 0. Previously unobserved (the annotation was `any`); the strongly-typed annotation now makes the primary `register(target, held)` usage type-check.

### Validation
- Full suite **11479/11479**
- TypeScript conformance **31/31** (baseline unchanged)
- Test262 **0 logical failures** (its test-host crash reproduces identically on clean `main` — environmental, unrelated)
- Manual checks pass in interpreted **and** compiled modes (IL verifies)

### Follow-ups filed
- #485 — iterables modeled nominally: structural element typing, structural `for...of`, and `IteratorResult<T>`/`Iterable<T>` not modeled
- #486 — truthiness `if (x)` narrowing doesn't remove `null`/`undefined`
- #487 — `Generator<T>`/`AsyncGenerator<T>` references reject the lib's optional `TReturn`/`TNext`
- #488 — generator function expression in IIFE/call position: `yield` not recognized