### PR TITLE
Fix #461: bind infer R for class-instance methods in conditional types

### DIFF
--- a/SharpTS.Tests/TypeCheckerTests/InferMatchClassMethodTests.cs
+++ b/SharpTS.Tests/TypeCheckerTests/InferMatchClassMethodTests.cs
@@ -1,0 +1,105 @@
+using SharpTS.Tests.Infrastructure;
+using SharpTS.TypeSystem.Exceptions;
+using Xunit;
+
+namespace SharpTS.Tests.TypeCheckerTests;
+
+/// <summary>
+/// Conditional-type infer matching against a class instance whose member is a <em>method</em> —
+/// <c>T extends { toJSON(): infer R } ? R : …</c> (#461). The infer-match property source previously
+/// collected a class's public fields and getters but not its methods, so the extends-side field
+/// <c>toJSON</c> was never found, the match failed, and the conditional silently took its false
+/// branch. The repro mirrors <c>microsoft/TypeScript</c>'s <c>conditional/inferTypes1.ts</c>
+/// (the <c>Jsonified</c>/<c>toJSON</c> example). Methods are surfaced only for this infer-match path,
+/// not for keyof/mapped-type key domains.
+/// </summary>
+public class InferMatchClassMethodTests
+{
+    [Fact]
+    public void ClassMethod_InfersReturnType_CorrectAssignmentAccepted()
+    {
+        // R binds to MyClass.toJSON's return type ("correct"); the matching literal is accepted.
+        var source = """
+            type J<T> = T extends { toJSON(): infer R } ? R : "no";
+            declare class MyClass { toJSON(): "correct"; }
+            const z: J<MyClass> = "correct";
+            """;
+        TestHarness.RunInterpreted(source);
+    }
+
+    [Fact]
+    public void ClassMethod_WrongAssignment_IsTypeError()
+    {
+        // J<MyClass> is "correct" (the true branch), so the false-branch literal "no" is rejected.
+        // Before the fix this was wrongly accepted because the match failed and resolved to "no".
+        var source = """
+            type J<T> = T extends { toJSON(): infer R } ? R : "no";
+            declare class MyClass { toJSON(): "correct"; }
+            const z: J<MyClass> = "no";
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void ClassMethod_InfersParameterType()
+    {
+        // P binds to the method's parameter type (number); a string assignment violates it.
+        var source = """
+            type Arg<T> = T extends { m(a: infer P): void } ? P : "no";
+            declare class C { m(a: number): void; }
+            const z: Arg<C> = "str";
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void NoSuchMethod_TakesFalseBranch()
+    {
+        // The class has no toJSON, so R never binds and the conditional resolves to its false
+        // branch ("no"); a number assignment violates that literal.
+        var source = """
+            type J<T> = T extends { toJSON(): infer R } ? R : "no";
+            declare class Other { name: string; }
+            const z: J<Other> = 42;
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void NoSuchMethod_FalseBranchValueAccepted()
+    {
+        var source = """
+            type J<T> = T extends { toJSON(): infer R } ? R : "no";
+            declare class Other { name: string; }
+            const z: J<Other> = "no";
+            """;
+        TestHarness.RunInterpreted(source);
+    }
+
+    [Fact]
+    public void PrivateMethod_NotMatched_TakesFalseBranch()
+    {
+        // A private method is not part of the class's public structural shape, so the extends-side
+        // public `toJSON` is not satisfied: the match fails and the false branch ("no") is taken,
+        // making the "no" assignment legal.
+        var source = """
+            type J<T> = T extends { toJSON(): infer R } ? R : "no";
+            declare class MyClass { private toJSON(): "correct"; }
+            const z: J<MyClass> = "no";
+            """;
+        TestHarness.RunInterpreted(source);
+    }
+
+    [Fact]
+    public void InterfaceMethod_StillMatches()
+    {
+        // Interface members already included methods; this locks that the shared path keeps working
+        // (R binds to "correct", so the false-branch literal "no" is rejected).
+        var source = """
+            type J<T> = T extends { toJSON(): infer R } ? R : "no";
+            interface I { toJSON(): "correct"; }
+            const z: J<I> = "no";
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+}

--- a/TypeSystem/TypeChecker.Generics.Conditional.cs
+++ b/TypeSystem/TypeChecker.Generics.Conditional.cs
@@ -625,7 +625,7 @@ public partial class TypeChecker
                     recCallSigs.Select(CallSignatureToFunction).ToList(), inferredTypes))
                 return false;
 
-            var checkProps = ExtractPropertiesWithTypes(checkType);
+            var checkProps = ExtractInferMatchProperties(checkType);
             foreach (var (key, extendsFieldType) in extendsRec.Fields)
             {
                 if (!checkProps.TryGetValue(key, out var checkFieldType))
@@ -648,7 +648,7 @@ public partial class TypeChecker
                     itfCallSigs.Select(CallSignatureToFunction).ToList(), inferredTypes))
                 return false;
 
-            var checkProps = ExtractPropertiesWithTypes(checkType);
+            var checkProps = ExtractInferMatchProperties(checkType);
             foreach (var (key, extendsFieldType) in extendsItf.Members)
             {
                 if (extendsItf.OptionalMembers.Contains(key))

--- a/TypeSystem/TypeChecker.Generics.UtilityTypes.cs
+++ b/TypeSystem/TypeChecker.Generics.UtilityTypes.cs
@@ -764,7 +764,16 @@ public partial class TypeChecker
     /// <summary>
     /// Extracts property names and their types from an object-like type.
     /// </summary>
-    private Dictionary<string, TypeInfo> ExtractPropertiesWithTypes(TypeInfo type)
+    /// <param name="includeMethods">
+    /// When true, a class's public methods are extracted alongside its fields and getters. Only the
+    /// conditional-type infer-match path (<see cref="CheckExtendsRecursive"/>, via
+    /// <see cref="ExtractInferMatchProperties"/>) sets this, so that a structural extends clause such
+    /// as <c>T extends { toJSON(): infer R }</c> can match a class instance whose <c>toJSON</c> is a
+    /// method rather than a function-typed field (#461). The default omits methods because the other
+    /// callers (keyof, mapped types, Pick/Omit/Record) model a class's key domain as data
+    /// properties only — folding methods into that domain is a separate, broader decision.
+    /// </param>
+    private Dictionary<string, TypeInfo> ExtractPropertiesWithTypes(TypeInfo type, bool includeMethods = false)
     {
         Dictionary<string, TypeInfo> props = [];
 
@@ -790,22 +799,43 @@ public partial class TypeChecker
                 // Public getters (property accessors)
                 foreach (var (name, propType) in cls.Getters)
                     props[name] = propType;
+                // Public methods (infer-match only). A field/getter of the same name already wins;
+                // methods cannot collide with either in a valid class, so TryAdd is purely defensive.
+                if (includeMethods)
+                {
+                    foreach (var (name, methodType) in cls.Methods)
+                    {
+                        if (cls.MethodAccess.GetValueOrDefault(name, Parsing.AccessModifier.Public) == Parsing.AccessModifier.Public)
+                            props.TryAdd(name, methodType);
+                    }
+                }
                 break;
 
             case TypeInfo.Instance inst:
-                return ExtractPropertiesWithTypes(inst.ClassType);
+                return ExtractPropertiesWithTypes(inst.ClassType, includeMethods);
 
             case TypeInfo.InstantiatedGeneric ig:
                 var expanded = ExpandInstantiatedGenericForKeyOf(ig);
-                return ExtractPropertiesWithTypes(expanded);
+                return ExtractPropertiesWithTypes(expanded, includeMethods);
 
             case TypeInfo.MappedType mapped:
                 var expandedMapped = ExpandMappedType(mapped);
-                return ExtractPropertiesWithTypes(expandedMapped);
+                return ExtractPropertiesWithTypes(expandedMapped, includeMethods);
         }
 
         return props;
     }
+
+    /// <summary>
+    /// Property extraction for conditional-type infer matching: like
+    /// <see cref="ExtractPropertiesWithTypes(TypeInfo, bool)"/> but also surfaces a class instance's
+    /// public methods, so an extends clause such as <c>T extends { toJSON(): infer R }</c> matches a
+    /// class whose member is a method (its <c>toJSON</c> renders structurally as a function-typed
+    /// property). Without this, the match silently fails and the conditional takes its false branch
+    /// (#461).
+    /// </summary>
+    private Dictionary<string, TypeInfo> ExtractInferMatchProperties(TypeInfo type) =>
+        ExtractPropertiesWithTypes(type, includeMethods: true);
 
     /// <summary>
     /// Extracts the set of optional property names from an object-like type.


### PR DESCRIPTION
## What

Fixes #461 — `T extends { method(): infer R } ? ... : ...` never bound `R` when `T` is a **class instance** whose `method` is declared as a method (not a function-typed field). The match failed and the conditional silently took its **false** branch.

```ts
type J<T> = T extends { toJSON(): infer R } ? R : "no";
declare class MyClass { toJSON(): "correct"; }
const z: J<MyClass> = "no";   // before: accepted (wrong); after: TS error ("no" ≠ "correct")
```

## Why

`ExtractPropertiesWithTypes` (`TypeSystem/TypeChecker.Generics.UtilityTypes.cs`) is the property source for `CheckExtendsRecursive`'s `Record`/`Interface` branches. For a `TypeInfo.Class` it collected public **fields** and **getters** but not **methods** (`cls.Methods`), so the extends-side field `toJSON` was never found and `R` was left unbound.

## How

- Add an opt-in `includeMethods` parameter to `ExtractPropertiesWithTypes` (default `false`), threaded through the `Instance`/`InstantiatedGeneric`/`MappedType` recursion.
- Add a method-inclusive `ExtractInferMatchProperties` wrapper, used **only** by the two `CheckExtendsRecursive` call sites.
- Extract **own public** methods only (filtered by `MethodAccess`, `TryAdd` so a field/getter wins) — mirrors the existing own field/getter handling. The keyof/mapped-type/`Pick`/`Omit` callers keep their data-property-only key domain (the issue explicitly flagged widening that as a separate decision).

Adding methods can only make *more* extends-side fields resolvable, so it can only turn currently-failing infer matches into successes — it can't break an existing match.

## Scope — why #462 is **not** included

#461 and #462 were filed to "land together" so `inferTypes1.ts` wouldn't regress. While implementing, I found that's **insufficient**: that conformance test's `const z2: string = ex.obj.nested.attr` is `Jsonified<Date>`, and **`Date`'s `toJSON` isn't type-modeled at all** (it lives only in `Runtime/`). So landing #462's conditional-detection scanners (which make the `Jsonified` conditional resolvable) regresses `inferTypes1.ts` with a spurious `TS2322` — `#461` covers the sibling `customClass: MyClass` line but not the `Date` line.

So **#461 lands alone** (it's complete and conformance-safe on its own; the direct-annotation repro uses the node path, which already recognizes the conditional). Filed for the rest:

- **#491** — built-in type records (Date/RegExp/…) have no type-level method signatures and aren't visible to infer-match. **This is the true blocker for #462's conditional scanners.**
- **#492** — infer-match ignores inherited class members (`ExtractPropertiesWithTypes` doesn't walk the superclass chain; pre-existing for fields/getters, same own-only limitation for the methods added here).
- Comment on **#462** documenting the full chain (#461 → #491 → #462's conditional part) and a **7th** `=>` mis-handling site beyond the six scanners listed there (the `ToTypeInfo` `Contains("=>")` dispatch — the actual cause of #462's tuple/indexed-access repros, fixable independently and conformance-safe).

## Testing

- New: `SharpTS.Tests/TypeCheckerTests/InferMatchClassMethodTests.cs` (7 tests: return/param infer, false-branch, private-method-excluded, interface-still-matches).
- Full suite: **11483 passed** (the only 2 failures are `DnsRecordTypeTests` live-network flakes that pass on isolated re-run).
- TypeScript conformance: **green** — `inferTypes1.ts` stays `Pass` (no regression).
- Test262: the `Diagnostic_NoRegressions` smoke test flags 2 Array-on-primitive-`this` tests — verified **pre-existing on `main`** (the #375/#454 unmasking; compiled baseline not regenerated), reproduced identically with this change stashed.

Closes #461.
