### PR TITLE
Fix #454: ToObject-box a primitive `this` in Array.prototype iteration methods (+ defineProperties getter dispatch)

### DIFF
--- a/Compilation/ILEmitter.Calls.cs
+++ b/Compilation/ILEmitter.Calls.cs
@@ -420,7 +420,17 @@ public partial class ILEmitter
         var prevReceiverLocal = IL.DeclareLocal(_ctx.Types.Object);
         IL.Emit(OpCodes.Ldsfld, runtime.CurrentArrayLikeReceiverField);
         IL.Emit(OpCodes.Stloc, prevReceiverLocal);
+        // ECMA-262 §23.1.3: O = ToObject(this value). The callback's final
+        // "array" argument is O, so a primitive receiver must surface as its
+        // wrapper object — `Array.prototype.forEach.call("ab", cb)` passes a
+        // String wrapper (`typeof obj === "object"`, `obj instanceof String`),
+        // not the bare string. ToObject is identity for objects/arrays and
+        // returns an empty object for null/undefined (the spec TypeError still
+        // fires later at materialization, before the callback ever reads this).
+        // Materialization below keeps using the raw receiver, observationally
+        // identical to O for every shape this path supports. (#454)
         IL.Emit(OpCodes.Ldloc, receiverLocal);
+        IL.Emit(OpCodes.Call, runtime.ToObjectMethod);
         IL.Emit(OpCodes.Stsfld, runtime.CurrentArrayLikeReceiverField);
 
         var methodArgs = c.Arguments.Skip(1).ToList();

--- a/Runtime/BuiltIns/BuiltInConstructorFactory.cs
+++ b/Runtime/BuiltIns/BuiltInConstructorFactory.cs
@@ -187,6 +187,24 @@ public static class BuiltInConstructorFactory
     public static RuntimeValue TryCreateRV(string className, List<object?> args, Interpreter interpreter)
         => RuntimeValue.FromBoxed(TryCreate(className, args, interpreter));
 
+    /// <summary>
+    /// ECMA-262 §7.1.18 ToObject for the primitive cases: wraps a
+    /// <c>string</c>/<c>number</c>/<c>boolean</c> primitive in its boxed wrapper
+    /// object (so <c>typeof</c> is <c>"object"</c> and <c>instanceof</c> works),
+    /// reusing the same <c>new String/Number/Boolean</c> layout as #360. Every
+    /// other value — already-object values, arrays, <c>null</c>, <c>undefined</c>,
+    /// symbols, bigint — is returned unchanged; callers that must reject
+    /// <c>null</c>/<c>undefined</c> guard before calling. Mirrors compiled mode's
+    /// <c>$Runtime.ToObject</c> (see <c>RuntimeEmitter.BoxedPrimitives.EmitToObject</c>).
+    /// </summary>
+    public static object? ToObject(object? value) => value switch
+    {
+        string => CreateBoxedString(new[] { value }),
+        double => CreateBoxedNumber(new[] { value }),
+        bool => CreateBoxedBoolean(new[] { value }),
+        _ => value,
+    };
+
     #region Constructor Implementations
 
     private static object CreateDate(IReadOnlyList<object?> args)

--- a/Runtime/BuiltIns/ObjectBuiltIns.cs
+++ b/Runtime/BuiltIns/ObjectBuiltIns.cs
@@ -781,42 +781,77 @@ public static class ObjectBuiltIns
         var target = args[0];
         var props = args[1];
 
-        if (target == null)
+        if (target is null or SharpTSUndefined)
         {
             throw new Exception("TypeError: Object.defineProperties called on null or undefined");
         }
 
-        if (props == null)
+        if (props is null or SharpTSUndefined)
         {
             throw new Exception("TypeError: Cannot convert undefined or null to object");
         }
 
-        // Get keys from the properties object
-        IEnumerable<string> keys = props switch
+        // ECMA-262 §19.1.2.3 ObjectDefineProperties: for each own ENUMERABLE
+        // property key of props, read its descriptor object via Get — firing any
+        // accessor getter with `this` bound to props — then DefineProperty on the
+        // target. Reading via Get (not the raw field) matters when props is a
+        // boxed primitive wrapper carrying an accessor descriptor, e.g.
+        // `Object.defineProperties(o, new Number(n))` where the descriptor lives
+        // behind a getter whose body inspects `this instanceof Number`. (#454)
+        if (props is SharpTSObject obj)
         {
-            SharpTSObject obj => obj.Fields.Keys,
-            SharpTSInstance inst => inst.GetFieldNames(),
-            Dictionary<string, object?> dict => dict.Keys,
+            foreach (var key in OwnEnumerablePropertyKeys(obj))
+            {
+                var descriptor = interpreter.GetProperty(obj, key);
+                DefineProperty(interpreter, [target, key, descriptor]);
+            }
+            return target;
+        }
+
+        // SharpTSInstance / plain Dictionary carriers store data only (no
+        // separate accessor storage), so a raw field read already matches Get.
+        IEnumerable<KeyValuePair<string, object?>> entries = props switch
+        {
+            SharpTSInstance inst => inst.GetFieldNames()
+                .Select(k => new KeyValuePair<string, object?>(k, inst.GetRawField(k))),
+            Dictionary<string, object?> dict => dict,
             _ => throw new Exception("TypeError: Property descriptions must be an object")
         };
 
-        foreach (var key in keys)
+        foreach (var entry in entries)
         {
-            // Get the descriptor for this key
-            object? descriptor = props switch
-            {
-                SharpTSObject obj => obj.Fields.TryGetValue(key, out var v) ? v : null,
-                SharpTSInstance inst => inst.GetRawField(key),
-                Dictionary<string, object?> dict => dict.TryGetValue(key, out var v) ? v : null,
-                _ => null
-            };
-
-            // Delegate to defineProperty
-            DefineProperty(interpreter, [target, key, descriptor]);
+            DefineProperty(interpreter, [target, entry.Key, entry.Value]);
         }
 
         return target;
     }
+
+    /// <summary>
+    /// Own enumerable string-keyed property names of <paramref name="obj"/> —
+    /// enumerable data fields plus enumerable accessor (getter/setter)
+    /// properties — excluding the internal slots that back boxed primitive
+    /// wrappers (<c>new String/Number/Boolean</c>), which must stay invisible to
+    /// enumeration per ECMA-262. Accessor names are stored disjointly from data
+    /// fields (see <see cref="SharpTSObject.AccessorPropertyNames"/>).
+    /// </summary>
+    private static IEnumerable<string> OwnEnumerablePropertyKeys(SharpTSObject obj)
+    {
+        foreach (var key in obj.Fields.Keys)
+            if (!IsBoxedPrimitiveInternalSlot(key) && obj.GetPropertyFlags(key).Enumerable)
+                yield return key;
+        foreach (var key in obj.AccessorPropertyNames)
+            if (obj.GetPropertyFlags(key).Enumerable)
+                yield return key;
+    }
+
+    /// <summary>
+    /// True for the internal-slot field names used by boxed primitive wrappers
+    /// (see <see cref="BuiltInConstructorFactory"/>). They hold [[StringData]] /
+    /// [[NumberData]] / [[BooleanData]] plus the wrapper's type tag — not real
+    /// own properties — so enumeration-based spec operations must skip them.
+    /// </summary>
+    private static bool IsBoxedPrimitiveInternalSlot(string key)
+        => key is "__primitiveType" or "__primitiveValue";
 
     /// <summary>
     /// Object.getOwnPropertyDescriptors(obj) - returns all own property descriptors.

--- a/Runtime/Types/SharpTSArrayGlobal.cs
+++ b/Runtime/Types/SharpTSArrayGlobal.cs
@@ -142,26 +142,34 @@ internal sealed class ArrayPrototypeMethodWrapper : ISharpTSCallable
                 $"Array.prototype.{_name} called on null or undefined"));
         }
 
-        // Fast path: receiver is a real array.
-        if (_receiver is SharpTSArray arr)
+        // ECMA-262 §23.1.3: every Array.prototype method begins with
+        // `O = ToObject(this value)`. A primitive receiver (string/number/
+        // boolean) therefore becomes its wrapper object, so the callback's
+        // final "array" argument (O) is an object — e.g.
+        // `Array.prototype.forEach.call("ab", cb)` passes a String wrapper
+        // (`typeof obj === "object"`, `obj instanceof String === true`),
+        // not the bare `"ab"`. Objects/arrays are returned unchanged. (#454)
+        object? receiver = BuiltIns.BuiltInConstructorFactory.ToObject(_receiver);
+
+        // Fast path: receiver is a real array (ToObject is identity for objects).
+        if (receiver is SharpTSArray arr)
             return _inner.Bind(arr).Call(interpreter, arguments);
 
-        // Slow path: receiver is array-like (object with `length` + indexed
-        // props, or a string). ECMA-262 spec: ToObject(this), then iterate via
-        // LengthOfArrayLike(O) / HasProperty(O, i) / Get(O, i). Materialize
-        // into a temp SharpTSArray for dispatch, but wrap any callable
-        // argument so the callback sees the ORIGINAL receiver as its final
-        // "array" parameter — per spec, callbacks get O, not the internal
-        // materialization.
-        if (TryMaterializeArrayLike(_receiver, interpreter, out var tempArr))
+        // Slow path: receiver is array-like (a wrapper object with `length` +
+        // indexed props, e.g. a boxed String, or any object exposing them).
+        // Iterate via LengthOfArrayLike(O) / HasProperty(O, i) / Get(O, i)
+        // by materializing into a temp SharpTSArray for dispatch, but wrap any
+        // callable argument so the callback sees O as its final "array"
+        // parameter — per spec, callbacks get O, not the internal materialization.
+        if (TryMaterializeArrayLike(receiver, interpreter, out var tempArr))
         {
-            var wrappedArgs = WrapCallbackArguments(arguments, tempArr, _receiver);
+            var wrappedArgs = WrapCallbackArguments(arguments, tempArr, receiver);
             return _inner.Bind(tempArr).Call(interpreter, wrappedArgs);
         }
 
         // Fallback: receiver type we can't coerce — let the inner method try.
         // It will likely throw a meaningful error.
-        return _inner.Bind(_receiver).Call(interpreter, arguments);
+        return _inner.Bind(receiver).Call(interpreter, arguments);
     }
 
     /// <summary>
@@ -213,14 +221,10 @@ internal sealed class ArrayPrototypeMethodWrapper : ISharpTSCallable
                 tempArr = new SharpTSArray(list);
                 return true;
             }
-            case string s:
-            {
-                var list = new List<object?>(s.Length);
-                for (int i = 0; i < s.Length; i++)
-                    list.Add(s[i].ToString());
-                tempArr = new SharpTSArray(list);
-                return true;
-            }
+            // A primitive string receiver never reaches here: Call() runs it
+            // through ToObject first, so it arrives as a boxed String wrapper
+            // (SharpTSObject with `length` + indexed char slots) handled by the
+            // SharpTSObject case above.
             default:
                 return false;
         }

--- a/SharpTS.Test262/baselines/interpreted.txt
+++ b/SharpTS.Test262/baselines/interpreted.txt
@@ -423,7 +423,7 @@ test/built-ins/Array/prototype/every/15.4.4.16-1-3.js RuntimeError
 test/built-ins/Array/prototype/every/15.4.4.16-1-4.js RuntimeError
 test/built-ins/Array/prototype/every/15.4.4.16-1-5.js RuntimeError
 test/built-ins/Array/prototype/every/15.4.4.16-1-6.js RuntimeError
-test/built-ins/Array/prototype/every/15.4.4.16-1-7.js Fail
+test/built-ins/Array/prototype/every/15.4.4.16-1-7.js Pass
 test/built-ins/Array/prototype/every/15.4.4.16-1-8.js Fail
 test/built-ins/Array/prototype/every/15.4.4.16-1-9.js RuntimeError
 test/built-ins/Array/prototype/every/15.4.4.16-2-1.js Pass
@@ -619,7 +619,7 @@ test/built-ins/Array/prototype/every/15.4.4.16-8-5.js RuntimeError
 test/built-ins/Array/prototype/every/15.4.4.16-8-6.js RuntimeError
 test/built-ins/Array/prototype/every/15.4.4.16-8-7.js RuntimeError
 test/built-ins/Array/prototype/every/15.4.4.16-8-8.js RuntimeError
-test/built-ins/Array/prototype/every/call-with-boolean.js RuntimeError
+test/built-ins/Array/prototype/every/call-with-boolean.js Pass
 test/built-ins/Array/prototype/every/callbackfn-resize-arraybuffer.js RuntimeError
 test/built-ins/Array/prototype/every/length.js Fail
 test/built-ins/Array/prototype/every/name.js Fail
@@ -663,7 +663,7 @@ test/built-ins/Array/prototype/filter/15.4.4.20-1-3.js RuntimeError
 test/built-ins/Array/prototype/filter/15.4.4.20-1-4.js RuntimeError
 test/built-ins/Array/prototype/filter/15.4.4.20-1-5.js RuntimeError
 test/built-ins/Array/prototype/filter/15.4.4.20-1-6.js RuntimeError
-test/built-ins/Array/prototype/filter/15.4.4.20-1-7.js Fail
+test/built-ins/Array/prototype/filter/15.4.4.20-1-7.js Pass
 test/built-ins/Array/prototype/filter/15.4.4.20-1-8.js Fail
 test/built-ins/Array/prototype/filter/15.4.4.20-1-9.js RuntimeError
 test/built-ins/Array/prototype/filter/15.4.4.20-10-1.js Pass
@@ -868,7 +868,7 @@ test/built-ins/Array/prototype/filter/15.4.4.20-9-c-iii-6.js Pass
 test/built-ins/Array/prototype/filter/15.4.4.20-9-c-iii-7.js Pass
 test/built-ins/Array/prototype/filter/15.4.4.20-9-c-iii-8.js Pass
 test/built-ins/Array/prototype/filter/15.4.4.20-9-c-iii-9.js Pass
-test/built-ins/Array/prototype/filter/call-with-boolean.js RuntimeError
+test/built-ins/Array/prototype/filter/call-with-boolean.js Pass
 test/built-ins/Array/prototype/filter/callbackfn-resize-arraybuffer.js RuntimeError
 test/built-ins/Array/prototype/filter/create-ctor-non-object.js Fail
 test/built-ins/Array/prototype/filter/create-ctor-poisoned.js Fail
@@ -1042,7 +1042,7 @@ test/built-ins/Array/prototype/forEach/15.4.4.18-1-3.js RuntimeError
 test/built-ins/Array/prototype/forEach/15.4.4.18-1-4.js RuntimeError
 test/built-ins/Array/prototype/forEach/15.4.4.18-1-5.js RuntimeError
 test/built-ins/Array/prototype/forEach/15.4.4.18-1-6.js RuntimeError
-test/built-ins/Array/prototype/forEach/15.4.4.18-1-7.js Fail
+test/built-ins/Array/prototype/forEach/15.4.4.18-1-7.js Pass
 test/built-ins/Array/prototype/forEach/15.4.4.18-1-8.js Fail
 test/built-ins/Array/prototype/forEach/15.4.4.18-1-9.js RuntimeError
 test/built-ins/Array/prototype/forEach/15.4.4.18-2-1.js Pass
@@ -1211,7 +1211,7 @@ test/built-ins/Array/prototype/forEach/15.4.4.18-8-8.js RuntimeError
 test/built-ins/Array/prototype/forEach/15.4.4.18-8-9.js RuntimeError
 test/built-ins/Array/prototype/forEach/S15.4.4.18_A1.js Pass
 test/built-ins/Array/prototype/forEach/S15.4.4.18_A2.js Pass
-test/built-ins/Array/prototype/forEach/call-with-boolean.js RuntimeError
+test/built-ins/Array/prototype/forEach/call-with-boolean.js Pass
 test/built-ins/Array/prototype/forEach/callbackfn-resize-arraybuffer.js RuntimeError
 test/built-ins/Array/prototype/forEach/length.js Fail
 test/built-ins/Array/prototype/forEach/name.js Fail
@@ -1697,7 +1697,7 @@ test/built-ins/Array/prototype/map/15.4.4.19-1-3.js RuntimeError
 test/built-ins/Array/prototype/map/15.4.4.19-1-4.js RuntimeError
 test/built-ins/Array/prototype/map/15.4.4.19-1-5.js RuntimeError
 test/built-ins/Array/prototype/map/15.4.4.19-1-6.js RuntimeError
-test/built-ins/Array/prototype/map/15.4.4.19-1-7.js Fail
+test/built-ins/Array/prototype/map/15.4.4.19-1-7.js Pass
 test/built-ins/Array/prototype/map/15.4.4.19-1-8.js Fail
 test/built-ins/Array/prototype/map/15.4.4.19-1-9.js RuntimeError
 test/built-ins/Array/prototype/map/15.4.4.19-2-1.js Pass
@@ -1874,7 +1874,7 @@ test/built-ins/Array/prototype/map/15.4.4.19-9-6.js Pass
 test/built-ins/Array/prototype/map/15.4.4.19-9-7.js Pass
 test/built-ins/Array/prototype/map/15.4.4.19-9-8.js Pass
 test/built-ins/Array/prototype/map/15.4.4.19-9-9.js Pass
-test/built-ins/Array/prototype/map/call-with-boolean.js RuntimeError
+test/built-ins/Array/prototype/map/call-with-boolean.js Pass
 test/built-ins/Array/prototype/map/callbackfn-resize-arraybuffer.js RuntimeError
 test/built-ins/Array/prototype/map/create-ctor-non-object.js Fail
 test/built-ins/Array/prototype/map/create-ctor-poisoned.js Fail
@@ -1963,7 +1963,7 @@ test/built-ins/Array/prototype/reduce/15.4.4.21-1-3.js RuntimeError
 test/built-ins/Array/prototype/reduce/15.4.4.21-1-4.js RuntimeError
 test/built-ins/Array/prototype/reduce/15.4.4.21-1-5.js RuntimeError
 test/built-ins/Array/prototype/reduce/15.4.4.21-1-6.js RuntimeError
-test/built-ins/Array/prototype/reduce/15.4.4.21-1-7.js Fail
+test/built-ins/Array/prototype/reduce/15.4.4.21-1-7.js Pass
 test/built-ins/Array/prototype/reduce/15.4.4.21-1-8.js Fail
 test/built-ins/Array/prototype/reduce/15.4.4.21-1-9.js RuntimeError
 test/built-ins/Array/prototype/reduce/15.4.4.21-10-1.js Pass
@@ -2202,7 +2202,7 @@ test/built-ins/Array/prototype/reduce/15.4.4.21-9-c-ii-5.js Pass
 test/built-ins/Array/prototype/reduce/15.4.4.21-9-c-ii-7.js Pass
 test/built-ins/Array/prototype/reduce/15.4.4.21-9-c-ii-8.js Fail
 test/built-ins/Array/prototype/reduce/15.4.4.21-9-c-ii-9.js Pass
-test/built-ins/Array/prototype/reduce/call-with-boolean.js RuntimeError
+test/built-ins/Array/prototype/reduce/call-with-boolean.js Pass
 test/built-ins/Array/prototype/reduce/callbackfn-resize-arraybuffer.js RuntimeError
 test/built-ins/Array/prototype/reduce/length.js Fail
 test/built-ins/Array/prototype/reduce/name.js Fail
@@ -2223,7 +2223,7 @@ test/built-ins/Array/prototype/reduceRight/15.4.4.22-1-3.js RuntimeError
 test/built-ins/Array/prototype/reduceRight/15.4.4.22-1-4.js RuntimeError
 test/built-ins/Array/prototype/reduceRight/15.4.4.22-1-5.js RuntimeError
 test/built-ins/Array/prototype/reduceRight/15.4.4.22-1-6.js RuntimeError
-test/built-ins/Array/prototype/reduceRight/15.4.4.22-1-7.js Fail
+test/built-ins/Array/prototype/reduceRight/15.4.4.22-1-7.js Pass
 test/built-ins/Array/prototype/reduceRight/15.4.4.22-1-8.js Fail
 test/built-ins/Array/prototype/reduceRight/15.4.4.22-1-9.js RuntimeError
 test/built-ins/Array/prototype/reduceRight/15.4.4.22-10-1.js Pass
@@ -2461,7 +2461,7 @@ test/built-ins/Array/prototype/reduceRight/15.4.4.22-9-c-ii-5.js Pass
 test/built-ins/Array/prototype/reduceRight/15.4.4.22-9-c-ii-7.js Pass
 test/built-ins/Array/prototype/reduceRight/15.4.4.22-9-c-ii-8.js Fail
 test/built-ins/Array/prototype/reduceRight/15.4.4.22-9-c-ii-9.js Pass
-test/built-ins/Array/prototype/reduceRight/call-with-boolean.js RuntimeError
+test/built-ins/Array/prototype/reduceRight/call-with-boolean.js Pass
 test/built-ins/Array/prototype/reduceRight/callbackfn-resize-arraybuffer.js RuntimeError
 test/built-ins/Array/prototype/reduceRight/length-near-integer-limit.js Fail
 test/built-ins/Array/prototype/reduceRight/length.js Fail
@@ -2592,7 +2592,7 @@ test/built-ins/Array/prototype/some/15.4.4.17-1-3.js RuntimeError
 test/built-ins/Array/prototype/some/15.4.4.17-1-4.js RuntimeError
 test/built-ins/Array/prototype/some/15.4.4.17-1-5.js RuntimeError
 test/built-ins/Array/prototype/some/15.4.4.17-1-6.js RuntimeError
-test/built-ins/Array/prototype/some/15.4.4.17-1-7.js Fail
+test/built-ins/Array/prototype/some/15.4.4.17-1-7.js Pass
 test/built-ins/Array/prototype/some/15.4.4.17-1-8.js Fail
 test/built-ins/Array/prototype/some/15.4.4.17-1-9.js RuntimeError
 test/built-ins/Array/prototype/some/15.4.4.17-2-1.js Pass
@@ -2790,7 +2790,7 @@ test/built-ins/Array/prototype/some/15.4.4.17-8-5.js RuntimeError
 test/built-ins/Array/prototype/some/15.4.4.17-8-6.js RuntimeError
 test/built-ins/Array/prototype/some/15.4.4.17-8-7.js RuntimeError
 test/built-ins/Array/prototype/some/15.4.4.17-8-8.js RuntimeError
-test/built-ins/Array/prototype/some/call-with-boolean.js RuntimeError
+test/built-ins/Array/prototype/some/call-with-boolean.js Pass
 test/built-ins/Array/prototype/some/callbackfn-resize-arraybuffer.js RuntimeError
 test/built-ins/Array/prototype/some/length.js Fail
 test/built-ins/Array/prototype/some/name.js Fail
@@ -4452,9 +4452,9 @@ test/built-ins/Object/defineProperties/15.2.3.7-2-16.js RuntimeError
 test/built-ins/Object/defineProperties/15.2.3.7-2-18.js RuntimeError
 test/built-ins/Object/defineProperties/15.2.3.7-2-2.js Fail
 test/built-ins/Object/defineProperties/15.2.3.7-2-3.js RuntimeError
-test/built-ins/Object/defineProperties/15.2.3.7-2-4.js RuntimeError
+test/built-ins/Object/defineProperties/15.2.3.7-2-4.js Pass
 test/built-ins/Object/defineProperties/15.2.3.7-2-5.js RuntimeError
-test/built-ins/Object/defineProperties/15.2.3.7-2-6.js RuntimeError
+test/built-ins/Object/defineProperties/15.2.3.7-2-6.js Pass
 test/built-ins/Object/defineProperties/15.2.3.7-2-7.js RuntimeError
 test/built-ins/Object/defineProperties/15.2.3.7-2-8.js RuntimeError
 test/built-ins/Object/defineProperties/15.2.3.7-2-9.js RuntimeError

--- a/SharpTS.Tests/SharedTests/ArrayPrototypeToObjectTests.cs
+++ b/SharpTS.Tests/SharedTests/ArrayPrototypeToObjectTests.cs
@@ -1,0 +1,231 @@
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests;
+
+/// <summary>
+/// ECMA-262 §23.1.3: every <c>Array.prototype</c> iteration method begins with
+/// <c>O = ToObject(this value)</c>. When such a method is borrowed onto a
+/// primitive receiver via <c>.call</c>, the callback's final "array" argument is
+/// therefore a wrapper object — <c>Array.prototype.forEach.call("ab", cb)</c>
+/// passes a String wrapper (<c>typeof obj === "object"</c>,
+/// <c>obj instanceof String === true</c>), not the bare <c>"ab"</c>.
+///
+/// Object.defineProperties (§19.1.2.3 ObjectDefineProperties) likewise reads each
+/// own enumerable key of its Properties argument via <c>Get</c>, firing accessor
+/// getters with <c>this</c> bound to the (possibly boxed) Properties object.
+///
+/// Regression coverage for #454. Runs in both interpreter and compiled mode.
+/// </summary>
+public class ArrayPrototypeToObjectTests
+{
+    // ── callback's `obj` argument is a wrapper object for a primitive `this` ──
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ForEach_OnStringPrimitive_CallbackReceivesStringWrapper(ExecutionMode mode)
+    {
+        var source = """
+            let saw: string = "";
+            Array.prototype.forEach.call("ab" as any, function (ch: any, i: any, obj: any): void {
+                saw += (typeof obj) + ":" + (obj instanceof String) + ";";
+            });
+            console.log(saw);
+            """;
+        Assert.Equal("object:true;object:true;\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Map_OnStringPrimitive_ObjArgIsStringWrapper(ExecutionMode mode)
+    {
+        var source = """
+            let r = Array.prototype.map.call("ab" as any, function (ch: any, i: any, obj: any): any {
+                return obj instanceof String;
+            });
+            console.log(JSON.stringify(r));
+            """;
+        Assert.Equal("[true,true]\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Filter_OnStringPrimitive_ObjArgIsStringWrapper(ExecutionMode mode)
+    {
+        // Keeps every element because `obj instanceof String` is true for each.
+        var source = """
+            let r = Array.prototype.filter.call("ab" as any, function (ch: any, i: any, obj: any): any {
+                return obj instanceof String;
+            });
+            console.log(JSON.stringify(r));
+            """;
+        Assert.Equal("[\"a\",\"b\"]\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Some_OnStringPrimitive_ObjArgIsStringWrapper(ExecutionMode mode)
+    {
+        var source = """
+            console.log(Array.prototype.some.call("ab" as any, function (ch: any, i: any, obj: any): any {
+                return obj instanceof String;
+            }));
+            """;
+        Assert.Equal("true\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Every_OnStringPrimitive_ObjArgIsStringWrapper(ExecutionMode mode)
+    {
+        // Mirrors Test262 built-ins/Array/prototype/every/15.4.4.16-1-7.js:
+        // callback returns !(obj instanceof String); every must short-circuit
+        // to false because obj IS a String wrapper.
+        var source = """
+            console.log(Array.prototype.every.call("ab" as any, function (ch: any, i: any, obj: any): any {
+                return !(obj instanceof String);
+            }));
+            """;
+        Assert.Equal("false\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Reduce_OnStringPrimitive_ObjArgIsStringWrapper(ExecutionMode mode)
+    {
+        var source = """
+            let r = Array.prototype.reduce.call("ab" as any, function (acc: any, ch: any, i: any, obj: any): any {
+                return acc + ((obj instanceof String) ? "T" : "F");
+            }, "");
+            console.log(r);
+            """;
+        Assert.Equal("TT\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ReduceRight_OnStringPrimitive_ObjArgIsStringWrapper(ExecutionMode mode)
+    {
+        var source = """
+            let r = Array.prototype.reduceRight.call("ab" as any, function (acc: any, ch: any, i: any, obj: any): any {
+                return acc + ((obj instanceof String) ? "T" : "F");
+            }, "");
+            console.log(r);
+            """;
+        Assert.Equal("TT\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Map_OnStringPrimitive_ElementsAreChars(ExecutionMode mode)
+    {
+        // The element argument (kValue) is still the per-index character string,
+        // independent of the wrapper-ised `obj` argument.
+        var source = """
+            let r = Array.prototype.map.call("ab" as any, function (ch: any): any { return ch + "!"; });
+            console.log(JSON.stringify(r));
+            """;
+        Assert.Equal("[\"a!\",\"b!\"]\n", TestHarness.Run(source, mode));
+    }
+
+    // ── String OBJECT receiver: ToObject is identity, wrapper passes through ──
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Every_OnStringObject_ObjArgIsStringWrapper(ExecutionMode mode)
+    {
+        // Mirrors Test262 .../every/15.4.4.16-1-8.js.
+        var source = """
+            let s: any = new String("ab");
+            console.log(Array.prototype.every.call(s, function (ch: any, i: any, obj: any): any {
+                return !(obj instanceof String);
+            }));
+            """;
+        Assert.Equal("false\n", TestHarness.Run(source, mode));
+    }
+
+    // ── plain array-like / real array receivers must be unaffected ───────────
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Map_OnRealArray_ObjArgIsTheArray(ExecutionMode mode)
+    {
+        var source = """
+            let r = Array.prototype.map.call([1, 2, 3], function (x: any, i: any, obj: any): any {
+                return Array.isArray(obj) ? x * 10 : -1;
+            });
+            console.log(JSON.stringify(r));
+            """;
+        Assert.Equal("[10,20,30]\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Map_OnPlainArrayLike_PassesReceiverThrough(ExecutionMode mode)
+    {
+        var source = """
+            let o: any = { length: 2, 0: "a", 1: "b" };
+            let r = Array.prototype.map.call(o, function (x: any): any { return x + "!"; });
+            console.log(JSON.stringify(r));
+            """;
+        Assert.Equal("[\"a!\",\"b!\"]\n", TestHarness.Run(source, mode));
+    }
+
+    // ── Object.defineProperties reads Properties via Get (accessor getters) ──
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void DefineProperties_BooleanObjectProperties_GetterThisIsWrapper(ExecutionMode mode)
+    {
+        // Mirrors Test262 built-ins/Object/defineProperties/15.2.3.7-2-4.js:
+        // the Properties argument is a Boolean wrapper carrying an enumerable
+        // accessor; its getter must run with `this` === that wrapper.
+        var source = """
+            let obj: any = {};
+            let props: any = new Boolean(true);
+            let result: boolean = false;
+            Object.defineProperty(props, "prop", {
+                get: function (this: any): any { result = this instanceof Boolean; return {}; },
+                enumerable: true
+            });
+            Object.defineProperties(obj, props);
+            console.log(result);
+            """;
+        Assert.Equal("true\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void DefineProperties_NumberObjectProperties_GetterThisIsWrapper(ExecutionMode mode)
+    {
+        // Mirrors Test262 .../defineProperties/15.2.3.7-2-6.js.
+        var source = """
+            let obj: any = {};
+            let props: any = new Number(-12);
+            let result: boolean = false;
+            Object.defineProperty(props, "prop", {
+                get: function (this: any): any { result = this instanceof Number; return {}; },
+                enumerable: true
+            });
+            Object.defineProperties(obj, props);
+            console.log(result);
+            """;
+        Assert.Equal("true\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void DefineProperties_SkipsNonEnumerableSourceProperty(ExecutionMode mode)
+    {
+        // ObjectDefineProperties only processes own ENUMERABLE keys of Properties.
+        var source = """
+            let props: any = {};
+            Object.defineProperty(props, "shown", { value: { value: 7 }, enumerable: true });
+            Object.defineProperty(props, "hidden", { value: { value: 9 }, enumerable: false });
+            let target: any = {};
+            Object.defineProperties(target, props);
+            console.log(target.shown + "," + target.hidden);
+            """;
+        Assert.Equal("7,undefined\n", TestHarness.Run(source, mode));
+    }
+}


### PR DESCRIPTION
Closes #454.

## Problem

ECMA-262 §23.1.3 starts every `Array.prototype` iteration method with `O = ToObject(this value)`. When borrowed onto a **primitive** receiver via `.call`, SharpTS passed the bare primitive through where the spec requires a wrapper object:

```ts
Array.prototype.forEach.call("ab" as any, (ch, i, obj) => {
  console.log(typeof obj, obj instanceof String); // was: "string" false  — should be: "object" true
});
```

Affects **both** interpreter and compiled modes. `Object.defineProperties` had a related interpreter gap: it read the Properties object's raw fields instead of doing a spec `Get`, so accessor descriptors were never enumerated and their getters never ran (with `this` bound to the Properties object).

## Fix

- **Interpreter array methods** (`Runtime/Types/SharpTSArrayGlobal.cs`): `ArrayPrototypeMethodWrapper` runs the receiver through a new `BuiltInConstructorFactory.ToObject` (reusing the #360 boxed-wrapper layout) before materializing the array-like and binding the callback. String primitives → String wrapper; number/boolean primitives → wrapper with no own length, making the method a spec no-op (0 iterations) instead of throwing. The now-unreachable raw-string materialization branch is removed.
- **Compiled array methods** (`Compilation/ILEmitter.Calls.cs`): `TryEmitArrayPrototypeCall` routes the callback's `O` thread-static through `$Runtime.ToObject`. Materialization keeps using the raw receiver (observationally identical for the supported shapes), preserving the spec `TypeError` for `null`/`undefined`. This makes the affected tests pass for the *right* reason and keeps them correct once #375 (the bare-primitive `instanceof` bug that currently masks the gap in compiled mode) is fixed.
- **`Object.defineProperties`** (`Runtime/BuiltIns/ObjectBuiltIns.cs`): the interpreter path now follows §19.1.2.3 — enumerate own **enumerable** data + accessor properties (skipping boxed-wrapper internal slots) and read each descriptor via `Get`, firing accessor getters with `this` bound to the Properties object.

## Testing

- New `SharpTS.Tests/SharedTests/ArrayPrototypeToObjectTests.cs` — 14 theories × 2 modes (all 7 iteration methods on a string primitive, String-object receiver, real-array / plain array-like receivers, and the `defineProperties` getter-`this` + enumerable-filter cases).
- Full `SharedTests` suite green: **8633 passed, 0 failed** (both modes).
- Test262 interpreted baseline updated for the directly-fixed tests: `{every,some,filter,map,forEach,reduce,reduceRight}/15.4.4.*-1-7` and `.../call-with-boolean`, plus `defineProperties/15.2.3.7-2-4,-2-6` (all → Pass). **Compiled baseline unchanged** (these already passed, masked by #375). A focused `defineProperties`-folder regen confirmed no interpreter regressions.

## Follow-ups filed (out of scope)

- **#474** — interpreter `Number.prototype`/`Boolean.prototype` index/length assignment + boxed-wrapper prototype-chain reads. This blocks the `15.4.4.*-1-3`/`-1-5` Number/Boolean **primitive** variants, which still `RuntimeError` in the interpreter (compiled mode already handles them). The issue itself flagged this as "a second, related gap."
- **#475** — boxed-wrapper internal slots (`__primitiveType`/`__primitiveValue`) leak into `Object.keys`/`values`/`entries`, and interpreter `Object.keys` ignores descriptor enumerability.

Note: the object-variant tests (`-1-4/-1-6/-1-8`) already pass on `main` via the #360/#376 boxed-wrapper work; the committed baseline is independently stale for them (and other post-#376 tests). That broader staleness is left to a periodic full regen — this PR only updates the lines whose behaviour it changes.
