### PR TITLE
Fix #476: forward next(v) into the delegated iterator during yield*

### DIFF
--- a/Compilation/GeneratorMoveNextEmitter.Expressions.Yield.cs
+++ b/Compilation/GeneratorMoveNextEmitter.Expressions.Yield.cs
@@ -142,6 +142,26 @@ public partial class GeneratorMoveNextEmitter
         EnsureBoxed();
         _il.Emit(OpCodes.Stloc, iterableLocal);
 
+        // A delegated SharpTS generator implements $IGenerator. Store it directly in the
+        // delegate field and skip the Symbol.iterator/$IteratorWrapper setup below, which
+        // drives via IEnumerator.MoveNext() — a path with no slot to forward the outer's
+        // resume value. The per-element loop detects $IGenerator and drives it via
+        // next(sent) instead, forwarding next(v) into the delegate (ECMA-262 §14.4.14, #476).
+        var generatorInterfaceType = _ctx?.Runtime?.GeneratorInterfaceType;
+        if (generatorInterfaceType != null)
+        {
+            var notDelegatedGeneratorLabel = _il.DefineLabel();
+            _il.Emit(OpCodes.Ldloc, iterableLocal);
+            _il.Emit(OpCodes.Isinst, generatorInterfaceType);
+            _il.Emit(OpCodes.Brfalse, notDelegatedGeneratorLabel);
+            _il.Emit(OpCodes.Ldarg_0);
+            _il.Emit(OpCodes.Ldloc, iterableLocal);
+            _il.Emit(OpCodes.Castclass, typeof(System.Collections.IEnumerator));
+            _il.Emit(OpCodes.Stfld, delegatedField);
+            _il.Emit(OpCodes.Br, resumeLabel);
+            _il.MarkLabel(notDelegatedGeneratorLabel);
+        }
+
         // Handle Map/Set specially - convert to List before iteration. Each
         // arm checks the corresponding $Runtime method MethodBuilder for null;
         // when Map/Set emission is gated off, the dispatch arm is skipped.
@@ -238,40 +258,80 @@ public partial class GeneratorMoveNextEmitter
         // before the setup above, so the field already holds the live value (#400/#414).
         _helpers.RehydrateLiveSpillsAfterResume();
 
-        // Load the delegated enumerator from field
+        // Drive the delegate one step. Two paths converge on a single value via valueTemp:
+        //   - $IGenerator (a delegated SharpTS generator): call next(this.SentField) so the
+        //     outer's resume value reaches the inner's suspended yield (#476). The result is
+        //     a { value, done } record.
+        //   - IEnumerator (arrays, $IteratorWrapper, etc.): MoveNext()/Current, which carry
+        //     no resume slot — the sent value is irrelevant to those iterators.
+        var valueTemp = _il.DeclareLocal(typeof(object));
+        var genResultLocal = _il.DeclareLocal(typeof(object));
+        var yieldStarResultLocal = _il.DeclareLocal(typeof(object));
+        var haveValueLabel = _il.DefineLabel();
+        var doneCleanupLabel = _il.DefineLabel();
+        Label driveViaGeneratorLabel = default, genDoneLabel = default;
+        if (generatorInterfaceType != null)
+        {
+            driveViaGeneratorLabel = _il.DefineLabel();
+            genDoneLabel = _il.DefineLabel();
+
+            _il.Emit(OpCodes.Ldarg_0);
+            _il.Emit(OpCodes.Ldfld, delegatedField);
+            _il.Emit(OpCodes.Isinst, generatorInterfaceType);
+            _il.Emit(OpCodes.Brtrue, driveViaGeneratorLabel);
+        }
+
+        // IEnumerator path: advance, then read Current into valueTemp.
         _il.Emit(OpCodes.Ldarg_0);
         _il.Emit(OpCodes.Ldfld, delegatedField);
-
-        // Check if there are more elements
         _il.Emit(OpCodes.Callvirt, moveNext);
         _il.Emit(OpCodes.Brfalse, loopEnd);
-
-        // Get current value from delegated enumerator
         _il.Emit(OpCodes.Ldarg_0);
         _il.Emit(OpCodes.Ldfld, delegatedField);
         _il.Emit(OpCodes.Callvirt, current);
-
-        // Store in <>2__current
-        var valueTemp = _il.DeclareLocal(typeof(object));
         _il.Emit(OpCodes.Stloc, valueTemp);
+        _il.Emit(OpCodes.Br, haveValueLabel);
+
+        // $IGenerator path: result = delegate.next(this.SentField); branch on result.done.
+        if (generatorInterfaceType != null)
+        {
+            _il.MarkLabel(driveViaGeneratorLabel);
+            _il.Emit(OpCodes.Ldarg_0);
+            _il.Emit(OpCodes.Ldfld, delegatedField);
+            _il.Emit(OpCodes.Castclass, generatorInterfaceType);
+            _il.Emit(OpCodes.Ldarg_0);
+            _il.Emit(OpCodes.Ldfld, _builder.SentField);
+            _il.Emit(OpCodes.Callvirt, _ctx!.Runtime!.GeneratorNextMethod);
+            _il.Emit(OpCodes.Stloc, genResultLocal);
+
+            _il.Emit(OpCodes.Ldloc, genResultLocal);
+            _il.Emit(OpCodes.Call, _ctx.Runtime.GetIteratorDone);
+            _il.Emit(OpCodes.Brtrue, genDoneLabel);
+
+            _il.Emit(OpCodes.Ldloc, genResultLocal);
+            _il.Emit(OpCodes.Call, _ctx.Runtime.GetIteratorValue);
+            _il.Emit(OpCodes.Stloc, valueTemp);
+            // fall through to haveValue
+        }
+
+        // Yield the delegated value: store in <>2__current, set resume state, return true.
+        _il.MarkLabel(haveValueLabel);
         _il.Emit(OpCodes.Ldarg_0);
         _il.Emit(OpCodes.Ldloc, valueTemp);
         _il.Emit(OpCodes.Stfld, _builder.CurrentField);
-
-        // Set state and return true
         _il.Emit(OpCodes.Ldarg_0);
         _il.Emit(OpCodes.Ldc_I4, stateNumber);
         _il.Emit(OpCodes.Stfld, _builder.StateField);
-
         _il.Emit(OpCodes.Ldc_I4_1);
         _il.Emit(OpCodes.Ret);
 
-        // End of delegation — reached when delegated.MoveNext() returned false.
-        // ECMA-262 27.3: the completion value of `yield* expr` is the delegated iterator's
-        // return value (the value passed to its `return` statement). For SharpTS-emitted
-        // generators we store that value in the state machine's CurrentField (see EmitReturn
-        // in Statements.cs). IEnumerator.Current is a valid property even after MoveNext
-        // returned false for our generators — the runtime preserves the last-set value.
+        // End of delegation — reached when the delegate reports done.
+        // ECMA-262 §14.4.14: the completion value of `yield* expr` is the delegated
+        // iterator's return value. For the $IGenerator path it is the done record's `value`;
+        // for the IEnumerator path SharpTS-emitted generators store it in CurrentField (see
+        // EmitReturn in Statements.cs), which IEnumerator.Current still reports after MoveNext
+        // returned false. Non-SharpTS iterators (e.g. List<T>.Enumerator) throw on Current
+        // past the end, so that read is guarded and falls back to null.
         _il.MarkLabel(loopEnd);
 
         // Capture the delegated iterator's Current as the yield* result. Guard against
@@ -281,7 +341,6 @@ public partial class GeneratorMoveNextEmitter
         // ECMA-262 14.4.14 the `yield*` completion value is `undefined` — load the emitted
         // `$Undefined` sentinel, not CLR `null` (which would surface as JS `null`, #443). The
         // interpreter's DelegateYieldStar coerces its own null sentinel to `undefined` the same way.
-        var yieldStarResultLocal = _il.DeclareLocal(typeof(object));
         _il.Emit(OpCodes.Ldsfld, _ctx!.Runtime!.UndefinedInstance);
         _il.Emit(OpCodes.Stloc, yieldStarResultLocal);
         _il.BeginExceptionBlock();
@@ -292,6 +351,19 @@ public partial class GeneratorMoveNextEmitter
         _il.BeginCatchBlock(typeof(Exception));
         _il.Emit(OpCodes.Pop);
         _il.EndExceptionBlock();
+        if (generatorInterfaceType != null)
+        {
+            _il.Emit(OpCodes.Br, doneCleanupLabel);
+
+            // $IGenerator done: the completion value is the done record's `value`.
+            _il.MarkLabel(genDoneLabel);
+            _il.Emit(OpCodes.Ldloc, genResultLocal);
+            _il.Emit(OpCodes.Call, _ctx!.Runtime!.GetIteratorValue);
+            _il.Emit(OpCodes.Stloc, yieldStarResultLocal);
+            // fall through to doneCleanup
+        }
+
+        _il.MarkLabel(doneCleanupLabel);
 
         // Clear the delegated enumerator field
         _il.Emit(OpCodes.Ldarg_0);

--- a/Runtime/Types/SharpTSGenerator.cs
+++ b/Runtime/Types/SharpTSGenerator.cs
@@ -257,30 +257,50 @@ public class SharpTSGenerator : IEnumerable<object?>, IDisposable, ITypeCategori
 
     /// <summary>
     /// Shared <c>yield*</c> delegation loop used by both generator types.
-    /// For inner generators, iterates via <c>Next()</c> and captures the
+    /// For inner generators, iterates via <c>Next(sent)</c> and captures the
     /// completion value. For other iterables, iterates lazily with no return value.
     /// </summary>
-    internal static object? DelegateYieldStar(Interpreter interpreter, object? outerGen, object? iterable, Action<object?> suspend, Func<bool> isClosed)
+    /// <param name="suspend">
+    /// Suspends the outer generator with the delegated value and returns the value
+    /// passed to the outer's resuming <c>next(v)</c> (ECMA-262 §14.4.14): each value
+    /// the delegate yields is handed to <paramref name="suspend"/>, whose return is
+    /// forwarded into the delegate's next <c>next(v)</c>.
+    /// </param>
+    internal static object? DelegateYieldStar(Interpreter interpreter, object? outerGen, object? iterable, Func<object?, object?> suspend, Func<bool> isClosed)
     {
         switch (iterable)
         {
             case SharpTSGenerator gen:
+            {
+                // §14.4.14: the loop seeds `received` with undefined, so the first
+                // inner next() gets undefined; every later one forwards the outer's
+                // resume value. (A delegate suspended at its start ignores the
+                // argument, so seeding undefined matches when the outer was mid-yield.)
+                object? sent = SharpTSUndefined.Instance;
                 while (true)
                 {
                     if (isClosed()) return null;
-                    var r = gen.Next();
+                    var r = gen.Next(sent);
                     if (r.Done) return r.Value;
-                    suspend(r.Value);
+                    sent = suspend(r.Value);
                 }
+            }
             case SharpTSArrowGenerator agen:
+            {
+                object? sent = SharpTSUndefined.Instance;
                 while (true)
                 {
                     if (isClosed()) return null;
-                    var r = agen.Next();
+                    var r = agen.Next(sent);
                     if (r.Done) return r.Value;
-                    suspend(r.Value);
+                    sent = suspend(r.Value);
                 }
+            }
             default:
+                // Non-generator iterables (arrays, Maps, custom iterator objects) are
+                // driven lazily via GetIterableElements, which calls next() without an
+                // argument. Built-in iterators ignore the resume value; forwarding it to
+                // a custom iterator's next(v) is a separate gap (tracked in #476 notes).
                 foreach (var element in interpreter.GetIterableElements(iterable))
                 {
                     if (isClosed()) return null;

--- a/SharpTS.Tests/SharedTests/GeneratorTests.cs
+++ b/SharpTS.Tests/SharedTests/GeneratorTests.cs
@@ -98,6 +98,103 @@ public class GeneratorTests
         Assert.Equal("1\n2\n3\n4\n", output);
     }
 
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Generator_YieldStar_ForwardsSentValue(ExecutionMode mode)
+    {
+        // ECMA-262 §14.4.14: the value passed to the outer's next(v) is forwarded
+        // into the delegated iterator's next(v), so the inner yield resumes with it
+        // rather than undefined (issue #476).
+        var source = """
+            function* inner() {
+                const a = yield 1;
+                console.log("inner got", a);
+            }
+            function* outer() {
+                yield* inner();
+            }
+            const it = outer();
+            it.next();
+            it.next(99);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("inner got 99\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Generator_YieldStar_ForwardsAcrossYields_AndYieldsCompletionValue(ExecutionMode mode)
+    {
+        // Each next(v) feeds the inner's successive yields, and the delegate's
+        // return value becomes the value of the `yield*` expression.
+        var source = """
+            function* inner() {
+                const a = yield "a";
+                const b = yield "b";
+                return `inner:${a},${b}`;
+            }
+            function* outer() {
+                const ret = yield* inner();
+                console.log("ret", ret);
+                yield "after";
+            }
+            const it = outer();
+            console.log(it.next().value);
+            console.log(it.next(1).value);
+            console.log(it.next(2).value);
+            console.log(it.next(3).done);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("a\nb\nret inner:1,2\nafter\ntrue\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Generator_YieldStar_Nested_ForwardsSentValue(ExecutionMode mode)
+    {
+        // A resume value must thread through every level of nested delegation.
+        var source = """
+            function* a() {
+                const x = yield 1;
+                console.log("a got", x);
+            }
+            function* b() { yield* a(); }
+            function* c() { yield* b(); }
+            const it = c();
+            it.next();
+            it.next(42);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("a got 42\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Generator_YieldStar_InExpression_ForwardsSentValue(ExecutionMode mode)
+    {
+        // yield* as a sub-expression (operand-spill path) still forwards the resume
+        // value and yields the delegate's return value into the surrounding expression.
+        var source = """
+            function* inner() {
+                const x = yield 1;
+                return x + 10;
+            }
+            function* outer() {
+                const v = "R:" + (yield* inner());
+                console.log(v);
+            }
+            const it = outer();
+            it.next();
+            it.next(5);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("R:15\n", output);
+    }
+
     #endregion
 
     #region Control Flow


### PR DESCRIPTION
## What

Forwards the outer generator's `next(v)` resume value into the delegated iterator during `yield* inner`, fixing #476. Per ECMA-262 §14.4.14, the value passed to the outer generator's `next(v)` must reach the inner's suspended `yield`; both modes previously dropped it, so the inner always resumed with `undefined`.

This completes the resume-value work begun in #452 (PR #472), which deliberately left `yield*` forwarding out to stay focused.

## How

**Interpreter** (`SharpTSGenerator.DelegateYieldStar`): the `suspend` callback now returns the outer's resume value (signature `Action<object?>` → `Func<object?, object?>`), threaded into the inner's `Next(sent)`. The loop seeds `sent` with `undefined` so the first inner `next()` matches the spec's initial `NormalCompletion(undefined)`.

**Compiled** (`EmitYieldStar`): a delegated SharpTS generator implements `$IGenerator`, so it is now stored directly in the delegate field and driven via `next(this.SentField)` — the `IEnumerator.MoveNext()` path has no resume slot. Non-generator iterables (arrays, `$IteratorWrapper`, Map/Set) keep the `MoveNext()`/`Current` path, since their iterators ignore the resume value. Both done-paths converge on shared cleanup; the `yield*` completion value comes from the done record's `value` (`$IGenerator`) or `Current` (`IEnumerator`), unchanged from before.

## Testing

- 4 new shared tests (interp + compiled) covering: basic forwarding, forwarding across multiple yields + completion value, nested `yield*` (two levels), and `yield*` in expression context (operand-spill path).
- Output verified byte-for-byte against Node for every case.
- Compiled IL passes `--verify`.
- Full suite green: **11509 passed, 0 failed**. Generator/iterator/IL-verification subset: 588 passed.
- Test262 default subset is unaffected (no generator folders; `generators` is a skip-feature). Its testhost crash reproduces on clean `origin/main`, i.e. pre-existing and unrelated.

## Scope / follow-up

Forwarding `next(v)` to a **non-generator** custom iterator object's `next(v)` is a separate remaining gap (built-in iterables unaffected) — filed as #503. Pre-existing compiled-generator issues in this area (#497 accumulator spill, #499 completion-value clearing, #443 resume sentinel) are distinct mechanisms, not touched here; the `yield*` completion value reads the same `CurrentField` as before, so no regression.

Closes #476.
