### PR TITLE
Fix #478: run finally blocks when generator.return()/throw() resume a suspended generator

### DIFF
--- a/Execution/Interpreter.Statements.cs
+++ b/Execution/Interpreter.Statements.cs
@@ -258,6 +258,14 @@ public partial class Interpreter
                 }
             }
         }
+        catch (GeneratorReturnException grex)
+        {
+            // A generator.return(v) abrupt completion injected at a yield point reached this
+            // block with no enclosing try. Settle it as a Return so resources are still
+            // disposed and the value flows out to the generator body (ECMA-262 §27.5.3.4).
+            // It is not a guest throw, so leave pendingError null.
+            blockResult = ExecutionResult.Return(RuntimeValue.FromBoxed(grex.Value));
+        }
         catch (Exception ex)
         {
             // Capture host exceptions as pending errors
@@ -575,6 +583,13 @@ public partial class Interpreter
                 }
             }
         }
+        catch (GeneratorReturnException grex)
+        {
+            // A generator.return(v) abrupt completion injected at a yield point inside this
+            // try. A return is not catchable, so bypass the catch clause and record a Return;
+            // the finally block below still runs (ECMA-262 §27.5.3.4).
+            pendingResult = ExecutionResult.Return(RuntimeValue.FromBoxed(grex.Value));
+        }
         catch (Exception ex)
         {
             // Treat host exceptions as guest throws
@@ -630,6 +645,13 @@ public partial class Interpreter
                         }
                     }
                     return (true, ExecutionResult.Success());
+                }
+                catch (GeneratorReturnException grex)
+                {
+                    // generator.return(v) injected at a yield inside this catch block:
+                    // propagate as a Return (which runs the enclosing finally) rather than
+                    // re-throwing it as a guest error (ECMA-262 §27.5.3.4).
+                    return (true, ExecutionResult.Return(RuntimeValue.FromBoxed(grex.Value)));
                 }
                 catch (Exception ex)
                 {

--- a/Runtime/BuiltIns/GeneratorBuiltIns.cs
+++ b/Runtime/BuiltIns/GeneratorBuiltIns.cs
@@ -33,7 +33,8 @@ public static class GeneratorBuiltIns
             {
                 if (receiver.ToObject() is SharpTSGenerator gen)
                 {
-                    object? value = args.Length > 0 ? args[0].ToObject() : null;
+                    // A bare return() resumes with the value undefined (ECMA-262 §27.5.3.4).
+                    object? value = args.Length > 0 ? args[0].ToObject() : SharpTSUndefined.Instance;
                     return RuntimeValue.FromObject(gen.Return(value));
                 }
                 throw new Exception("Runtime Error: return() called on non-generator.");
@@ -42,7 +43,8 @@ public static class GeneratorBuiltIns
             {
                 if (receiver.ToObject() is SharpTSGenerator gen)
                 {
-                    object? error = args.Length > 0 ? args[0].ToObject() : null;
+                    // A bare throw() throws undefined (ECMA-262 §27.5.3.4).
+                    object? error = args.Length > 0 ? args[0].ToObject() : SharpTSUndefined.Instance;
                     return RuntimeValue.FromObject(gen.Throw(error));
                 }
                 throw new Exception("Runtime Error: throw() called on non-generator.");

--- a/Runtime/Exceptions/GeneratorReturnException.cs
+++ b/Runtime/Exceptions/GeneratorReturnException.cs
@@ -1,0 +1,22 @@
+namespace SharpTS.Runtime.Exceptions;
+
+/// <summary>
+/// Control-flow exception representing a <c>return</c> abrupt completion injected into a
+/// suspended generator by <c>generator.return(v)</c> (ECMA-262 §27.5.3.4).
+/// </summary>
+/// <remarks>
+/// Thrown from the generator worker thread at the suspended <c>yield</c> point so the
+/// completion unwinds through any active <c>try</c>/<c>finally</c> blocks — running their
+/// <c>finally</c> handlers — exactly as a <c>return v;</c> statement at that point would.
+///
+/// Unlike <see cref="ThrowException"/>, this is NOT a guest <c>throw</c>: it must bypass
+/// <c>catch</c> clauses. The interpreter's <c>try</c>/<c>catch</c> and block executors
+/// recognize it and convert it to an <see cref="Execution.ExecutionResult"/> of type
+/// <c>Return</c>, which the existing abrupt-completion machinery routes through
+/// <c>finally</c> handlers and out to the generator body.
+/// </remarks>
+public sealed class GeneratorReturnException(object? value) : Exception
+{
+    /// <summary>The value supplied to <c>generator.return(value)</c>.</summary>
+    public object? Value { get; } = value;
+}

--- a/Runtime/Types/SharpTSGenerator.cs
+++ b/Runtime/Types/SharpTSGenerator.cs
@@ -36,12 +36,24 @@ public class SharpTSGenerator : IEnumerable<object?>, IDisposable, ITypeCategori
     private enum State { NotStarted, Suspended, Running, Completed }
     private State _state = State.NotStarted;
     private object? _yieldedValue;
-    private object? _returnValue;
+    // The generator's completion value. Defaults to undefined so a body that falls off the
+    // end (or a no-arg return()) reports { value: undefined, done: true }, not C# null.
+    private object? _returnValue = SharpTSUndefined.Instance;
     // The value passed to the next/return call that resumes the suspended yield.
     // ECMA-262 §27.5.3.3: `yield expr` evaluates to the argument of the resuming
     // `next(v)`. Defaults to undefined so a yield resumed without an explicit value
     // (for...of, yield* delegation, bare next()) evaluates to undefined.
     private object? _sentValue = SharpTSUndefined.Instance;
+
+    // How the suspended yield is resumed (ECMA-262 §27.5.3.4). A plain next(v) resumes
+    // normally; return(v)/throw(e) inject an abrupt completion at the yield point so any
+    // active try/finally blocks run before the generator settles. The resuming call sets
+    // this (and _injectedValue) before signaling the worker, which reads it on wake.
+    private enum ResumeKind { Next, Return, Throw }
+    private ResumeKind _resumeKind = ResumeKind.Next;
+    // Value carried by an abrupt resume: the return value for Return, the error for Throw.
+    private object? _injectedValue;
+
     private bool _closed;
     private Exception? _workerException;
 
@@ -73,8 +85,11 @@ public class SharpTSGenerator : IEnumerable<object?>, IDisposable, ITypeCategori
     /// </param>
     public SharpTSIteratorResult Next(object? sentValue)
     {
+        // A finished or disposed generator yields nothing more. The completion value is
+        // delivered exactly once (when the body finishes); later next() calls report
+        // undefined (ECMA-262 §27.5.3.3 → CreateIterResultObject(undefined, true)).
         if (_closed || _state == State.Completed)
-            return new SharpTSIteratorResult(_returnValue, done: true);
+            return new SharpTSIteratorResult(SharpTSUndefined.Instance, done: true);
 
         // Save caller's environment
         _callerEnv = _interpreter.Environment;
@@ -89,12 +104,78 @@ public class SharpTSGenerator : IEnumerable<object?>, IDisposable, ITypeCategori
         {
             // Resume: hand the sent value to the suspended yield, restore the
             // generator's environment, and signal the worker.
+            _resumeKind = ResumeKind.Next;
             _sentValue = sentValue;
             _state = State.Running;
             _callerReady.Set();
         }
 
-        // Wait for worker to yield or complete
+        return AwaitWorker();
+    }
+
+    /// <summary>
+    /// Resumes a suspended generator with a <c>return</c> abrupt completion, running any
+    /// active <c>try</c>/<c>finally</c> blocks before it settles as done
+    /// (ECMA-262 §27.5.3.4). A not-yet-started generator is closed without running its
+    /// body; an already-finished one simply reports the supplied value. If a <c>finally</c>
+    /// block yields, the generator suspends there and this returns that yielded value.
+    /// </summary>
+    public SharpTSIteratorResult Return(object? value = null)
+    {
+        // Never started: close without running the body — there is no finally to run.
+        if (_state == State.NotStarted)
+        {
+            _state = State.Completed;
+            return new SharpTSIteratorResult(value, done: true);
+        }
+
+        // Already finished/disposed: report { value, done: true } (no body to resume).
+        if (_closed || _state == State.Completed)
+            return new SharpTSIteratorResult(value, done: true);
+
+        // Suspended: inject the return at the yield point so finally blocks run. The body's
+        // completion (which a finally block may override) becomes the reported value.
+        _callerEnv = _interpreter.Environment;
+        _resumeKind = ResumeKind.Return;
+        _injectedValue = value;
+        _state = State.Running;
+        _callerReady.Set();
+
+        return AwaitWorker();
+    }
+
+    /// <summary>
+    /// Resumes a suspended generator with a <c>throw</c> abrupt completion at the yield
+    /// point, running active <c>catch</c>/<c>finally</c> blocks (ECMA-262 §27.5.3.4). If a
+    /// <c>catch</c> handles it the generator continues (and may yield again); otherwise the
+    /// error propagates to this caller. A not-yet-started or finished generator just throws.
+    /// </summary>
+    public SharpTSIteratorResult Throw(object? error = null)
+    {
+        // Never started or already finished/disposed: nothing to resume — just throw.
+        if (_state == State.NotStarted || _closed || _state == State.Completed)
+        {
+            _state = State.Completed;
+            throw ThrowException.FromResult(error);
+        }
+
+        // Suspended: inject the throw at the yield point so catch/finally blocks run.
+        _callerEnv = _interpreter.Environment;
+        _resumeKind = ResumeKind.Throw;
+        _injectedValue = error;
+        _state = State.Running;
+        _callerReady.Set();
+
+        return AwaitWorker();
+    }
+
+    /// <summary>
+    /// Blocks until the worker reaches its next yield or completes, then either rethrows a
+    /// worker exception (an uncaught throw or a finally that threw) or builds the iterator
+    /// result. Shared by <see cref="Next(object?)"/>, <see cref="Return"/> and <see cref="Throw"/>.
+    /// </summary>
+    private SharpTSIteratorResult AwaitWorker()
+    {
         _workerReady.Wait();
         _workerReady.Reset();
 
@@ -110,39 +191,6 @@ public class SharpTSGenerator : IEnumerable<object?>, IDisposable, ITypeCategori
             return new SharpTSIteratorResult(_returnValue, done: true);
 
         return new SharpTSIteratorResult(_yieldedValue, done: false);
-    }
-
-    /// <summary>
-    /// Closes the generator and returns a result with the given value.
-    /// </summary>
-    public SharpTSIteratorResult Return(object? value = null)
-    {
-        _closed = true;
-        _returnValue = value;
-
-        // If the worker is suspended, wake it so it can exit
-        if (_state == State.Suspended)
-        {
-            _callerReady.Set();
-        }
-
-        return new SharpTSIteratorResult(value, done: true);
-    }
-
-    /// <summary>
-    /// Throws an exception at the current yield point.
-    /// </summary>
-    public SharpTSIteratorResult Throw(object? error = null)
-    {
-        _closed = true;
-
-        if (_state == State.Suspended)
-        {
-            _callerReady.Set();
-        }
-
-        string message = error?.ToString() ?? "Generator.throw() called";
-        throw new ThrowException(error ?? message);
     }
 
     /// <summary>
@@ -169,6 +217,13 @@ public class SharpTSGenerator : IEnumerable<object?>, IDisposable, ITypeCategori
             if (result.Type == ExecutionResult.ResultType.Return)
             {
                 _returnValue = result.Value.ToObject();
+            }
+            else if (result.Type == ExecutionResult.ResultType.Throw)
+            {
+                // An uncaught guest throw — from the body itself or from a throw(e) injection
+                // that no catch handled — completes the generator abnormally and propagates
+                // to the resuming next()/throw() caller.
+                _workerException = ThrowException.FromResult(result.Value.ToObject());
             }
         }
         catch (Exception ex) when (ex is not ThreadInterruptedException)
@@ -251,7 +306,7 @@ public class SharpTSGenerator : IEnumerable<object?>, IDisposable, ITypeCategori
         _interpreter.YieldCallback = _callerYieldCallback;
 
         _workerReady.Set();    // Signal caller that value is ready
-        _callerReady.Wait();   // Wait for next Next() call
+        _callerReady.Wait();   // Wait for the resuming next/return/throw call
         _callerReady.Reset();
 
         // Save caller state (may have changed), restore generator state
@@ -260,7 +315,24 @@ public class SharpTSGenerator : IEnumerable<object?>, IDisposable, ITypeCategori
         _interpreter.SetEnvironment(generatorEnv);
         _interpreter.YieldCallback = HandleYieldCallback;
 
-        return _sentValue;
+        // Inject the abrupt completion requested by return(v)/throw(e) at this yield point
+        // (ECMA-262 §27.5.3.4). The exception unwinds through any active try/finally blocks
+        // on the worker's call stack — running their finally handlers — before settling.
+        // Consume the resume kind so a later wake that doesn't set it (e.g. Dispose) resumes
+        // normally instead of re-injecting a stale abrupt completion.
+        var kind = _resumeKind;
+        var injected = _injectedValue;
+        _resumeKind = ResumeKind.Next;
+        _injectedValue = null;
+        switch (kind)
+        {
+            case ResumeKind.Return:
+                throw new GeneratorReturnException(injected);
+            case ResumeKind.Throw:
+                throw ThrowException.FromResult(injected);
+            default:
+                return _sentValue;
+        }
     }
 
     // IEnumerable implementation for for...of integration
@@ -312,10 +384,20 @@ public class SharpTSArrowGenerator : IEnumerable<object?>, IDisposable
     private enum State { NotStarted, Suspended, Running, Completed }
     private State _state = State.NotStarted;
     private object? _yieldedValue;
-    private object? _returnValue;
+    // The generator's completion value. Defaults to undefined so a body that falls off the
+    // end (or a no-arg return()) reports { value: undefined, done: true }, not C# null.
+    private object? _returnValue = SharpTSUndefined.Instance;
     // The value passed to the resuming next(v); becomes the result of the suspended
     // yield (ECMA-262 §27.5.3.3). Defaults to undefined for implicit resumes.
     private object? _sentValue = SharpTSUndefined.Instance;
+
+    // How the suspended yield is resumed (ECMA-262 §27.5.3.4): a plain next(v), or a
+    // return(v)/throw(e) that injects an abrupt completion so active try/finally blocks run.
+    private enum ResumeKind { Next, Return, Throw }
+    private ResumeKind _resumeKind = ResumeKind.Next;
+    // Value carried by an abrupt resume: the return value for Return, the error for Throw.
+    private object? _injectedValue;
+
     private bool _closed;
     private Exception? _workerException;
 
@@ -337,8 +419,10 @@ public class SharpTSArrowGenerator : IEnumerable<object?>, IDisposable
     /// </summary>
     public SharpTSIteratorResult Next(object? sentValue)
     {
+        // A finished/disposed generator delivers undefined; the completion value is reported
+        // only once, when the body finishes (ECMA-262 §27.5.3.3).
         if (_closed || _state == State.Completed)
-            return new SharpTSIteratorResult(_returnValue, done: true);
+            return new SharpTSIteratorResult(SharpTSUndefined.Instance, done: true);
 
         _callerEnv = _interpreter.Environment;
 
@@ -350,11 +434,66 @@ public class SharpTSArrowGenerator : IEnumerable<object?>, IDisposable
         }
         else
         {
+            _resumeKind = ResumeKind.Next;
             _sentValue = sentValue;
             _state = State.Running;
             _callerReady.Set();
         }
 
+        return AwaitWorker();
+    }
+
+    /// <summary>
+    /// Resumes a suspended generator with a <c>return</c> abrupt completion, running active
+    /// <c>try</c>/<c>finally</c> blocks (ECMA-262 §27.5.3.4). See <see cref="SharpTSGenerator.Return"/>.
+    /// </summary>
+    public SharpTSIteratorResult Return(object? value = null)
+    {
+        if (_state == State.NotStarted)
+        {
+            _state = State.Completed;
+            return new SharpTSIteratorResult(value, done: true);
+        }
+
+        if (_closed || _state == State.Completed)
+            return new SharpTSIteratorResult(value, done: true);
+
+        _callerEnv = _interpreter.Environment;
+        _resumeKind = ResumeKind.Return;
+        _injectedValue = value;
+        _state = State.Running;
+        _callerReady.Set();
+
+        return AwaitWorker();
+    }
+
+    /// <summary>
+    /// Resumes a suspended generator with a <c>throw</c> abrupt completion, running active
+    /// <c>catch</c>/<c>finally</c> blocks (ECMA-262 §27.5.3.4). See <see cref="SharpTSGenerator.Throw"/>.
+    /// </summary>
+    public SharpTSIteratorResult Throw(object? error = null)
+    {
+        if (_state == State.NotStarted || _closed || _state == State.Completed)
+        {
+            _state = State.Completed;
+            throw ThrowException.FromResult(error);
+        }
+
+        _callerEnv = _interpreter.Environment;
+        _resumeKind = ResumeKind.Throw;
+        _injectedValue = error;
+        _state = State.Running;
+        _callerReady.Set();
+
+        return AwaitWorker();
+    }
+
+    /// <summary>
+    /// Blocks until the worker yields again or completes, rethrowing a worker exception or
+    /// building the iterator result. Shared by next/return/throw.
+    /// </summary>
+    private SharpTSIteratorResult AwaitWorker()
+    {
         _workerReady.Wait();
         _workerReady.Reset();
 
@@ -370,22 +509,6 @@ public class SharpTSArrowGenerator : IEnumerable<object?>, IDisposable
             return new SharpTSIteratorResult(_returnValue, done: true);
 
         return new SharpTSIteratorResult(_yieldedValue, done: false);
-    }
-
-    public SharpTSIteratorResult Return(object? value = null)
-    {
-        _closed = true;
-        _returnValue = value;
-        if (_state == State.Suspended) _callerReady.Set();
-        return new SharpTSIteratorResult(value, done: true);
-    }
-
-    public SharpTSIteratorResult Throw(object? error = null)
-    {
-        _closed = true;
-        if (_state == State.Suspended) _callerReady.Set();
-        string message = error?.ToString() ?? "Generator.throw() called";
-        throw new ThrowException(error ?? message);
     }
 
     private void RunBody()
@@ -408,6 +531,12 @@ public class SharpTSArrowGenerator : IEnumerable<object?>, IDisposable
                 if (result.Type == ExecutionResult.ResultType.Return)
                 {
                     _returnValue = result.Value.ToObject();
+                }
+                else if (result.Type == ExecutionResult.ResultType.Throw)
+                {
+                    // An uncaught guest throw — from the body or an unhandled throw(e)
+                    // injection — propagates to the resuming next()/throw() caller.
+                    _workerException = ThrowException.FromResult(result.Value.ToObject());
                 }
             }
         }
@@ -453,7 +582,22 @@ public class SharpTSArrowGenerator : IEnumerable<object?>, IDisposable
         _interpreter.SetEnvironment(generatorEnv);
         _interpreter.YieldCallback = HandleYieldCallback;
 
-        return _sentValue;
+        // Inject the abrupt completion requested by return(v)/throw(e) (ECMA-262 §27.5.3.4),
+        // unwinding through active try/finally blocks on the worker's call stack. Consume the
+        // resume kind so a later non-setting wake (e.g. Dispose) resumes normally.
+        var kind = _resumeKind;
+        var injected = _injectedValue;
+        _resumeKind = ResumeKind.Next;
+        _injectedValue = null;
+        switch (kind)
+        {
+            case ResumeKind.Return:
+                throw new GeneratorReturnException(injected);
+            case ResumeKind.Throw:
+                throw ThrowException.FromResult(injected);
+            default:
+                return _sentValue;
+        }
     }
 
     public IEnumerator<object?> GetEnumerator()

--- a/SharpTS.Tests/SharedTests/GeneratorTests.cs
+++ b/SharpTS.Tests/SharedTests/GeneratorTests.cs
@@ -485,4 +485,292 @@ public class GeneratorTests
     }
 
     #endregion
+
+    #region return()/throw() resume suspended generator (ECMA-262 §27.5.3.4) — issue #478
+
+    // These are interpreter-only: a try/finally combined with yield currently emits invalid
+    // IL in compiled mode (tracked in issue #477), so the compiled path can't be observed yet.
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void Generator_Return_RunsFinally_AndReportsValue(ExecutionMode mode)
+    {
+        // The repro from issue #478: return(v) on a suspended generator resumes it as an
+        // abrupt completion, running the active finally block, then settles { value, done }.
+        var source = """
+            function* g() {
+                try {
+                    yield 1;
+                    yield 2;
+                } finally {
+                    console.log("finally ran");
+                }
+            }
+            const it = g();
+            const a = it.next();
+            console.log(a.value, a.done);
+            const b = it.return(99);
+            console.log(b.value, b.done);
+            const c = it.next();
+            console.log(c.value, c.done);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        // Node: 1 false / finally ran / 99 true / undefined true
+        Assert.Equal("1 false\nfinally ran\n99 true\nundefined true\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void Generator_Throw_CaughtByTryCatch_Continues(ExecutionMode mode)
+    {
+        // throw(e) injects the error at the yield point; an enclosing catch handles it and
+        // the generator keeps running (and may yield again).
+        var source = """
+            function* g() {
+                try {
+                    yield 1;
+                    yield 2;
+                } catch (e) {
+                    console.log("caught " + e);
+                    yield 99;
+                }
+            }
+            const it = g();
+            console.log(it.next().value);
+            const r = it.throw("boom");
+            console.log(r.value, r.done);
+            const done = it.next();
+            console.log(done.value, done.done);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("1\ncaught boom\n99 false\nundefined true\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void Generator_Throw_RunsFinally_ThenPropagates(ExecutionMode mode)
+    {
+        // throw(e) with only a finally (no catch): the finally runs, then the error propagates
+        // to the throw() caller.
+        var source = """
+            function* g() {
+                try {
+                    yield 1;
+                } finally {
+                    console.log("finally C");
+                }
+            }
+            const it = g();
+            it.next();
+            try {
+                it.throw("boomC");
+            } catch (e) {
+                console.log("outer caught " + e);
+            }
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("finally C\nouter caught boomC\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void Generator_Return_RunsNestedFinallyInnerToOuter(ExecutionMode mode)
+    {
+        var source = """
+            function* g() {
+                try {
+                    try {
+                        yield 1;
+                    } finally {
+                        console.log("inner");
+                    }
+                } finally {
+                    console.log("outer");
+                }
+            }
+            const it = g();
+            it.next();
+            const r = it.return(5);
+            console.log(r.value, r.done);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("inner\nouter\n5 true\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void Generator_Return_FinallyThatYields_DefersCompletion(ExecutionMode mode)
+    {
+        // A finally that yields suspends the pending return; the return value is delivered
+        // only once the finally completes on a later next().
+        var source = """
+            function* g() {
+                try {
+                    yield 1;
+                } finally {
+                    yield 99;
+                }
+            }
+            const it = g();
+            it.next();
+            const a = it.return(5);
+            console.log(a.value, a.done);
+            const b = it.next();
+            console.log(b.value, b.done);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("99 false\n5 true\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void Generator_Return_FinallyReturnOverridesValue(ExecutionMode mode)
+    {
+        // A finally that returns its own value overrides the value passed to return().
+        var source = """
+            function* g() {
+                try {
+                    yield 1;
+                } finally {
+                    return 7;
+                }
+            }
+            const it = g();
+            it.next();
+            const r = it.return(99);
+            console.log(r.value, r.done);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("7 true\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void Generator_Return_FinallyThrowOverridesReturn(ExecutionMode mode)
+    {
+        // A finally that throws overrides the pending return with the thrown error.
+        var source = """
+            function* g() {
+                try {
+                    yield 1;
+                } finally {
+                    throw "finally-err";
+                }
+            }
+            const it = g();
+            it.next();
+            try {
+                it.return(5);
+            } catch (e) {
+                console.log("caught " + e);
+            }
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("caught finally-err\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void Generator_ReturnAndThrow_OnNotStarted_DoNotRunBody(ExecutionMode mode)
+    {
+        // return()/throw() on a generator that hasn't started close it without running the
+        // body, so the finally never runs (ECMA-262 §27.5.3.4).
+        var source = """
+            function* g() {
+                try {
+                    yield 1;
+                } finally {
+                    console.log("should NOT run");
+                }
+            }
+            const a = g();
+            const r = a.return(8);
+            console.log(r.value, r.done);
+            const b = g();
+            try {
+                b.throw("x");
+            } catch (e) {
+                console.log("threw " + e);
+            }
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("8 true\nthrew x\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void Generator_NextAfterCompletion_ReportsUndefined(ExecutionMode mode)
+    {
+        // Once a generator finishes, its completion value is delivered exactly once; further
+        // next() calls report { value: undefined, done: true }.
+        var source = """
+            function* g() {
+                yield 1;
+                return 42;
+            }
+            const it = g();
+            it.next();
+            const done = it.next();
+            console.log(done.value, done.done);
+            const after = it.next();
+            console.log(after.value, after.done);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("42 true\nundefined true\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void Generator_UncaughtThrowInBody_PropagatesToNext(ExecutionMode mode)
+    {
+        // An uncaught throw inside the body surfaces to the next() caller rather than being
+        // swallowed (regression guard for the worker's abnormal-completion handling).
+        var source = """
+            function* g() {
+                yield 1;
+                throw "bodyboom";
+            }
+            const it = g();
+            it.next();
+            try {
+                it.next();
+            } catch (e) {
+                console.log("caught " + e);
+            }
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("caught bodyboom\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void Generator_BareReturn_ReportsUndefinedValue(ExecutionMode mode)
+    {
+        // A no-argument return() resumes with undefined.
+        var source = """
+            function* g() {
+                yield 1;
+                yield 2;
+            }
+            const it = g();
+            it.next();
+            const r = it.return();
+            console.log(r.value, r.done);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("undefined true\n", output);
+    }
+
+    #endregion
 }


### PR DESCRIPTION
## Summary

Fixes #478. Per ECMA-262 §27.5.3.4, calling `gen.return(v)` or `gen.throw(e)` on a **suspended** generator must resume it at the suspension point as an abrupt completion, running any active `try`/`finally` (and `catch`) blocks. SharpTS previously just closed the generator and returned/threw immediately, so `finally` never ran:

```ts
function* g() {
  try { yield 1; yield 2; } finally { console.log("finally ran"); }
}
const it = g();
it.next();      // 1
it.return(99);  // BEFORE: nothing.  NOW: prints "finally ran", returns { value: 99, done: true }
```

This is an **interpreter-only** fix — a `try`/`finally` combined with `yield` currently emits invalid IL in compiled mode (tracked separately in #477), so the compiled path can't be observed yet.

## What changed

**`SharpTSGenerator` / `SharpTSArrowGenerator`** (`Runtime/Types/SharpTSGenerator.cs`)
- `return()`/`throw()` on a suspended generator now inject a return/throw abrupt completion at the yield point and **wait for the worker** (like `next()` already did), so the unwinding runs `finally`/`catch` before the generator settles.
  - A `finally` that **yields** defers the completion (the yielded value is reported; the return value arrives on the next `next()`).
  - A `finally` that **returns**/**throws** overrides the pending completion.
  - A **not-started** generator is closed without running its body (no `finally`).
- The resume kind is consumed (reset to `Next`) after the worker reads it, so a later non-setting wake (e.g. `Dispose()`) can't re-inject a stale abrupt completion.

**Abrupt-completion plumbing**
- New `GeneratorReturnException` (`Runtime/Exceptions/`) models the `return` completion, which must bypass `catch` but still run `finally`. `ExecuteBlock`, `ExecuteTryCatch`, and `HandleCatchBlock` (sync) convert it to an `ExecutionResult.Return` so the existing finally machinery routes it. `throw()` reuses `ThrowException` and flows through the normal guest-throw path, so `catch`/`finally` already work for it.
- `RunBody` now surfaces an uncaught `ExecutionResult.Throw` from the body as the worker exception (it was previously **dropped**), so an uncaught throw — including an unhandled `throw(e)` — propagates to the `next()`/`throw()` caller instead of silently completing the generator.

**Completion-value conformance (related)**
- A generator body that falls off the end, and a no-arg `return()`/`throw()`, now report `undefined` instead of C# `null`; `next()` after completion reports `undefined` (the completion value is delivered exactly once). Previously these surfaced as `null` via `JSON.stringify`.

## Tests

Adds 11 interpreter-only tests (`GeneratorTests.cs`): finally-on-return, throw into `catch`/`finally`, nested `finally` (inner→outer), `finally` that yields/returns/throws, `return`/`throw` on a not-started generator, `next()` after completion, uncaught-body-throw propagation, and bare `return()`.

All 11,560 solution tests pass (one pre-existing flaky network test, `DnsPromises_Lookup`, fails intermittently and passes on isolated retry — unrelated). The Test262 default subset is unaffected (it doesn't run `GeneratorPrototype`/generator-statement folders, and the only sampled diffs are the pre-existing #454 array-`this`-boxing tests, which behave identically on `main`).

## Follow-ups filed

- #477 (pre-existing) — compiled `try`/`finally`+`yield` emits invalid IL, blocking compiled-mode observation.
- #514 — `yield*` does not forward `return()`/`throw()` to the delegated iterator (inner `finally` skipped); the `return`/`throw` arm of §14.4.14, distinct from #476 (`next(v)` forwarding).
- #515 — re-entrant generator `next()`/`return()`/`throw()` hangs instead of throwing the spec `TypeError` ("Generator is already running").
