### PR TITLE
Fix #477: compiled generator with yield in try/catch/finally

### DIFF
--- a/Compilation/GeneratorMoveNextEmitter.Statements.TryCatch.cs
+++ b/Compilation/GeneratorMoveNextEmitter.Statements.TryCatch.cs
@@ -1,0 +1,442 @@
+using System.Reflection;
+using System.Reflection.Emit;
+using SharpTS.Parsing;
+
+namespace SharpTS.Compilation;
+
+public partial class GeneratorMoveNextEmitter
+{
+    // When emitting inside a flag-based try that has a finally, a `return` statement cannot
+    // `ret` directly — the finally must run first. It jumps here instead (after recording the
+    // pending return). Saved/restored around each try so nested finallys chain.
+    private Label? _returnCleanupLabel;
+
+    // Set by a `return` inside a flag-based try/finally so that, once the finally(s) have run,
+    // MoveNext completes (returns false). Declared lazily; a finally that itself yields suspends
+    // MoveNext between the return and the completion check, so this must be a state-machine field
+    // (not an IL local, which the re-entry would reset) — mirrors the async generator's
+    // ReturnRequestedField. Defaults to false on the freshly-allocated state machine and is set
+    // at most once (the generator is completing), so it never needs resetting.
+    private FieldBuilder? _pendingReturnField;
+
+    private FieldBuilder GetPendingReturnField() =>
+        _pendingReturnField ??= _builder.StateMachineType.DefineField(
+            "<>pendingReturn", typeof(bool), FieldAttributes.Private);
+
+    /// <summary>
+    /// Emits try/catch/finally. When a yield crosses the protected region, real IL exception
+    /// blocks cannot be used (the state-dispatch switch can't branch into a protected region,
+    /// and `yield`'s `ret` is illegal inside one), so a flag-based scheme is emitted instead.
+    /// </summary>
+    protected override void EmitTryCatch(Stmt.TryCatch t)
+    {
+        bool hasYields = ContainsYield(t.TryBlock)
+            || (t.CatchBlock != null && ContainsYield(t.CatchBlock))
+            || (t.FinallyBlock != null && ContainsYield(t.FinallyBlock));
+
+        if (hasYields)
+            EmitTryCatchWithYields(t);
+        else
+            EmitSimpleTryCatch(t);
+    }
+
+    /// <summary>
+    /// No yield crosses the protected region — real IL exception blocks are correct and cheapest.
+    /// This is the original generator try/catch emission, unchanged.
+    /// </summary>
+    private void EmitSimpleTryCatch(Stmt.TryCatch t)
+    {
+        _il.BeginExceptionBlock();
+
+        foreach (var stmt in t.TryBlock)
+            EmitStatement(stmt);
+
+        if (t.CatchBlock != null)
+        {
+            _il.BeginCatchBlock(typeof(Exception));
+
+            if (t.CatchParam != null)
+            {
+                // Stack has the .NET exception; wrap to the TS value and bind to the catch param.
+                _il.Emit(OpCodes.Call, _ctx!.Runtime!.WrapException);
+                StoreCaughtExceptionToParam(t.CatchParam.Lexeme);
+            }
+            else
+            {
+                _il.Emit(OpCodes.Pop);
+            }
+
+            foreach (var stmt in t.CatchBlock)
+                EmitStatement(stmt);
+        }
+
+        if (t.FinallyBlock != null)
+        {
+            _il.BeginFinallyBlock();
+            foreach (var stmt in t.FinallyBlock)
+                EmitStatement(stmt);
+        }
+
+        _il.EndExceptionBlock();
+    }
+
+    /// <summary>
+    /// Binds the caught exception value (on the IL stack) to the catch parameter, honouring
+    /// whether the parameter was hoisted to a state-machine field (used across a yield) or lives
+    /// in an IL local. Storing to a fresh local unconditionally — the previous behaviour — lost
+    /// the value whenever the catch parameter was hoisted, because reads resolve the field first.
+    /// </summary>
+    private void StoreCaughtExceptionToParam(string name)
+    {
+        if (GetHoistedVariableField(name) == null)
+        {
+            // Not hoisted: register a local so the catch body's reads resolve to it.
+            var exLocal = _il.DeclareLocal(typeof(object));
+            _ctx!.Locals.RegisterLocal(name, exLocal);
+        }
+
+        // Resolver stores to the hoisted field if present, otherwise the registered local.
+        Resolver.TryStoreVariable(name);
+    }
+
+    /// <summary>
+    /// Flag-based try/catch/finally for the case where a yield (or yield*) lives inside the
+    /// protected region. Synchronous segments of the try body are wrapped in mini IL try/catch
+    /// blocks that capture any exception into a flag local; suspension points and non-local exits
+    /// are emitted at the top level (outside any protected region) so their resume labels are
+    /// reachable from the state-dispatch switch and their `ret`/`br` are legal.
+    /// </summary>
+    private void EmitTryCatchWithYields(Stmt.TryCatch t)
+    {
+        var caughtExceptionLocal = _il.DeclareLocal(typeof(object));
+        var afterTryBodyLabel = _il.DefineLabel();
+
+        // No exception captured yet.
+        _il.Emit(OpCodes.Ldnull);
+        _il.Emit(OpCodes.Stloc, caughtExceptionLocal);
+
+        // A `return` inside this try must run the finally before completing, so point its cleanup
+        // at the catch/finally entry. On the return path the exception flag is null, so the catch
+        // is skipped and the finally runs. Only meaningful when a finally is present; without one,
+        // a `return` completes directly (it is emitted at the top level, so `ret` is legal).
+        var previousCleanupLabel = _returnCleanupLabel;
+        if (t.FinallyBlock != null)
+            _returnCleanupLabel = afterTryBodyLabel;
+
+        EmitTryBodyWithYields(t.TryBlock, caughtExceptionLocal, afterTryBodyLabel);
+
+        _returnCleanupLabel = previousCleanupLabel;
+
+        _il.MarkLabel(afterTryBodyLabel);
+
+        // Catch: runs only when the try body captured an exception.
+        if (t.CatchBlock != null)
+        {
+            var skipCatchLabel = _il.DefineLabel();
+            _il.Emit(OpCodes.Ldloc, caughtExceptionLocal);
+            _il.Emit(OpCodes.Brfalse, skipCatchLabel);
+
+            if (t.CatchParam != null)
+            {
+                _il.Emit(OpCodes.Ldloc, caughtExceptionLocal);
+                StoreCaughtExceptionToParam(t.CatchParam.Lexeme);
+            }
+
+            // Catch handles it; clear the flag so the post-finally rethrow below is skipped.
+            _il.Emit(OpCodes.Ldnull);
+            _il.Emit(OpCodes.Stloc, caughtExceptionLocal);
+
+            foreach (var stmt in t.CatchBlock)
+                EmitStatement(stmt);
+
+            _il.MarkLabel(skipCatchLabel);
+        }
+
+        // Finally: always runs — on normal completion, after a caught exception, or on a pending
+        // return that routed here.
+        if (t.FinallyBlock != null)
+        {
+            foreach (var stmt in t.FinallyBlock)
+                EmitStatement(stmt);
+
+            // After the finally, propagate a pending `return` — to the next enclosing finally if
+            // there is one, otherwise complete MoveNext.
+            if (_pendingReturnField != null)
+            {
+                var noPendingReturnLabel = _il.DefineLabel();
+                _il.Emit(OpCodes.Ldarg_0);
+                _il.Emit(OpCodes.Ldfld, _pendingReturnField);
+                _il.Emit(OpCodes.Brfalse, noPendingReturnLabel);
+
+                if (previousCleanupLabel != null)
+                    _il.Emit(OpCodes.Br, previousCleanupLabel.Value);
+                else
+                {
+                    _il.Emit(OpCodes.Ldc_I4_0);
+                    _il.Emit(OpCodes.Ret);
+                }
+
+                _il.MarkLabel(noPendingReturnLabel);
+            }
+        }
+
+        // Rethrow an uncaught exception once the finally has run (try/finally with no catch).
+        if (t.CatchBlock == null)
+        {
+            var noExceptionLabel = _il.DefineLabel();
+            _il.Emit(OpCodes.Ldloc, caughtExceptionLocal);
+            _il.Emit(OpCodes.Brfalse, noExceptionLabel);
+
+            _il.Emit(OpCodes.Ldloc, caughtExceptionLocal);
+            _il.Emit(OpCodes.Call, _ctx!.Runtime!.CreateException);
+            _il.Emit(OpCodes.Throw);
+
+            _il.MarkLabel(noExceptionLabel);
+        }
+    }
+
+    /// <summary>
+    /// Walks the try body, wrapping runs of plain statements in mini IL try/catch blocks while
+    /// emitting suspension points and non-local exits (return/break/continue) at the top level.
+    /// </summary>
+    private void EmitTryBodyWithYields(List<Stmt> tryBody, LocalBuilder caughtExceptionLocal, Label afterTryLabel)
+    {
+        List<Stmt> syncSegment = [];
+
+        foreach (var stmt in tryBody)
+        {
+            if (IsSegmentBreaker(stmt))
+            {
+                // Flush the accumulated plain statements first.
+                if (syncSegment.Count > 0)
+                {
+                    EmitSyncSegmentInTry(syncSegment, caughtExceptionLocal);
+                    syncSegment.Clear();
+                }
+
+                // If an earlier segment threw, skip the suspension/exit and head to catch/finally.
+                _il.Emit(OpCodes.Ldloc, caughtExceptionLocal);
+                _il.Emit(OpCodes.Brtrue, afterTryLabel);
+
+                // Emitted at the top level: a yield's `ret`/resume label and a return's `br` are
+                // only legal outside a protected region.
+                EmitStatement(stmt);
+            }
+            else
+            {
+                syncSegment.Add(stmt);
+            }
+        }
+
+        if (syncSegment.Count > 0)
+            EmitSyncSegmentInTry(syncSegment, caughtExceptionLocal);
+    }
+
+    /// <summary>
+    /// Emits a run of plain (non-suspending, non-exiting) statements inside a real IL try/catch
+    /// that records any thrown exception into <paramref name="caughtExceptionLocal"/>.
+    /// </summary>
+    private void EmitSyncSegmentInTry(List<Stmt> statements, LocalBuilder caughtExceptionLocal)
+    {
+        // An earlier segment may already have thrown — don't run this one.
+        var skipLabel = _il.DefineLabel();
+        _il.Emit(OpCodes.Ldloc, caughtExceptionLocal);
+        _il.Emit(OpCodes.Brtrue, skipLabel);
+
+        _il.BeginExceptionBlock();
+        foreach (var stmt in statements)
+            EmitStatement(stmt);
+
+        _il.BeginCatchBlock(typeof(Exception));
+        _il.Emit(OpCodes.Call, _ctx!.Runtime!.WrapException);
+        _il.Emit(OpCodes.Stloc, caughtExceptionLocal);
+        _il.EndExceptionBlock();
+
+        _il.MarkLabel(skipLabel);
+    }
+
+    #region Suspension / control-exit detection
+
+    /// <summary>
+    /// A statement must be emitted at the top level (rather than inside a mini try/catch segment)
+    /// if it contains a suspension point or a control-flow exit that leaves the try region. Both
+    /// would otherwise produce illegal IL inside the segment's protected region.
+    /// </summary>
+    private static bool IsSegmentBreaker(Stmt stmt) =>
+        ContainsYieldInStmt(stmt) || ContainsEscapingExit(stmt, insideLoop: false, insideSwitch: false);
+
+    private static bool ContainsYield(List<Stmt> statements)
+    {
+        foreach (var stmt in statements)
+            if (ContainsYieldInStmt(stmt))
+                return true;
+        return false;
+    }
+
+    private static bool ContainsYieldInStmt(Stmt stmt)
+    {
+        switch (stmt)
+        {
+            case Stmt.Expression e:
+                return ContainsYieldInExpr(e.Expr);
+            case Stmt.Var v:
+                return v.Initializer != null && ContainsYieldInExpr(v.Initializer);
+            case Stmt.Const c:
+                return ContainsYieldInExpr(c.Initializer);
+            case Stmt.Return r:
+                return r.Value != null && ContainsYieldInExpr(r.Value);
+            case Stmt.If i:
+                return ContainsYieldInExpr(i.Condition)
+                    || ContainsYieldInStmt(i.ThenBranch)
+                    || (i.ElseBranch != null && ContainsYieldInStmt(i.ElseBranch));
+            case Stmt.While w:
+                return ContainsYieldInExpr(w.Condition) || ContainsYieldInStmt(w.Body);
+            case Stmt.DoWhile dw:
+                return ContainsYieldInStmt(dw.Body) || ContainsYieldInExpr(dw.Condition);
+            case Stmt.For f:
+                return (f.Initializer != null && ContainsYieldInStmt(f.Initializer))
+                    || (f.Condition != null && ContainsYieldInExpr(f.Condition))
+                    || (f.Increment != null && ContainsYieldInExpr(f.Increment))
+                    || ContainsYieldInStmt(f.Body);
+            case Stmt.ForOf fo:
+                return ContainsYieldInExpr(fo.Iterable) || ContainsYieldInStmt(fo.Body);
+            case Stmt.ForIn fi:
+                return ContainsYieldInExpr(fi.Object) || ContainsYieldInStmt(fi.Body);
+            case Stmt.Block b:
+                return b.Statements != null && ContainsYield(b.Statements);
+            case Stmt.Sequence seq:
+                return ContainsYield(seq.Statements);
+            case Stmt.LabeledStatement ls:
+                return ContainsYieldInStmt(ls.Statement);
+            case Stmt.Switch s:
+                foreach (var c in s.Cases)
+                {
+                    if (ContainsYieldInExpr(c.Value) || ContainsYield(c.Body))
+                        return true;
+                }
+                return s.DefaultBody != null && ContainsYield(s.DefaultBody);
+            case Stmt.TryCatch t:
+                return ContainsYield(t.TryBlock)
+                    || (t.CatchBlock != null && ContainsYield(t.CatchBlock))
+                    || (t.FinallyBlock != null && ContainsYield(t.FinallyBlock));
+            case Stmt.Throw th:
+                return ContainsYieldInExpr(th.Value);
+            case Stmt.Print p:
+                return ContainsYieldInExpr(p.Expr);
+            default:
+                return false;
+        }
+    }
+
+    private static bool ContainsYieldInExpr(Expr expr)
+    {
+        switch (expr)
+        {
+            case Expr.Yield:
+                return true;
+            case Expr.Comma c:
+                return ContainsYieldInExpr(c.Left) || ContainsYieldInExpr(c.Right);
+            case Expr.Binary b:
+                return ContainsYieldInExpr(b.Left) || ContainsYieldInExpr(b.Right);
+            case Expr.Logical l:
+                return ContainsYieldInExpr(l.Left) || ContainsYieldInExpr(l.Right);
+            case Expr.Unary u:
+                return ContainsYieldInExpr(u.Right);
+            case Expr.Delete d:
+                return ContainsYieldInExpr(d.Operand);
+            case Expr.Grouping g:
+                return ContainsYieldInExpr(g.Expression);
+            case Expr.Call c:
+                if (ContainsYieldInExpr(c.Callee)) return true;
+                foreach (var arg in c.Arguments)
+                    if (ContainsYieldInExpr(arg)) return true;
+                return false;
+            case Expr.Assign a:
+                return ContainsYieldInExpr(a.Value);
+            case Expr.CompoundAssign ca:
+                return ContainsYieldInExpr(ca.Value);
+            case Expr.Ternary t:
+                return ContainsYieldInExpr(t.Condition)
+                    || ContainsYieldInExpr(t.ThenBranch)
+                    || ContainsYieldInExpr(t.ElseBranch);
+            case Expr.Get g:
+                return ContainsYieldInExpr(g.Object);
+            case Expr.Set s:
+                return ContainsYieldInExpr(s.Object) || ContainsYieldInExpr(s.Value);
+            case Expr.GetIndex gi:
+                return ContainsYieldInExpr(gi.Object) || ContainsYieldInExpr(gi.Index);
+            case Expr.SetIndex si:
+                return ContainsYieldInExpr(si.Object) || ContainsYieldInExpr(si.Index) || ContainsYieldInExpr(si.Value);
+            default:
+                return false;
+        }
+    }
+
+    /// <summary>
+    /// Detects return/break/continue that would transfer control out of the surrounding try
+    /// region. Over-approximates conservatively (labeled break/continue are always treated as
+    /// escaping): a false positive only costs a statement some mini-segment exception coverage,
+    /// whereas a false negative would emit a `br`/`ret` inside a protected region (illegal IL).
+    /// Nested function/arrow bodies are not traversed (their returns are their own).
+    /// </summary>
+    private static bool ContainsEscapingExit(Stmt stmt, bool insideLoop, bool insideSwitch)
+    {
+        switch (stmt)
+        {
+            case Stmt.Return:
+                return true;
+            case Stmt.Break b:
+                return b.Label != null || !(insideLoop || insideSwitch);
+            case Stmt.Continue c:
+                return c.Label != null || !insideLoop;
+            case Stmt.If i:
+                return ContainsEscapingExit(i.ThenBranch, insideLoop, insideSwitch)
+                    || (i.ElseBranch != null && ContainsEscapingExit(i.ElseBranch, insideLoop, insideSwitch));
+            case Stmt.Block b:
+                if (b.Statements == null) return false;
+                foreach (var s in b.Statements)
+                    if (ContainsEscapingExit(s, insideLoop, insideSwitch)) return true;
+                return false;
+            case Stmt.Sequence seq:
+                foreach (var s in seq.Statements)
+                    if (ContainsEscapingExit(s, insideLoop, insideSwitch)) return true;
+                return false;
+            case Stmt.While w:
+                return ContainsEscapingExit(w.Body, insideLoop: true, insideSwitch);
+            case Stmt.DoWhile dw:
+                return ContainsEscapingExit(dw.Body, insideLoop: true, insideSwitch);
+            case Stmt.For f:
+                return ContainsEscapingExit(f.Body, insideLoop: true, insideSwitch);
+            case Stmt.ForOf fo:
+                return ContainsEscapingExit(fo.Body, insideLoop: true, insideSwitch);
+            case Stmt.ForIn fi:
+                return ContainsEscapingExit(fi.Body, insideLoop: true, insideSwitch);
+            case Stmt.Switch s:
+                foreach (var c in s.Cases)
+                    foreach (var cs in c.Body)
+                        if (ContainsEscapingExit(cs, insideLoop, insideSwitch: true)) return true;
+                if (s.DefaultBody != null)
+                    foreach (var ds in s.DefaultBody)
+                        if (ContainsEscapingExit(ds, insideLoop, insideSwitch: true)) return true;
+                return false;
+            case Stmt.LabeledStatement ls:
+                return ContainsEscapingExit(ls.Statement, insideLoop, insideSwitch);
+            case Stmt.TryCatch t:
+                if (ContainsEscapingExit2(t.TryBlock, insideLoop, insideSwitch)) return true;
+                if (t.CatchBlock != null && ContainsEscapingExit2(t.CatchBlock, insideLoop, insideSwitch)) return true;
+                if (t.FinallyBlock != null && ContainsEscapingExit2(t.FinallyBlock, insideLoop, insideSwitch)) return true;
+                return false;
+            default:
+                return false;
+        }
+    }
+
+    private static bool ContainsEscapingExit2(List<Stmt> statements, bool insideLoop, bool insideSwitch)
+    {
+        foreach (var s in statements)
+            if (ContainsEscapingExit(s, insideLoop, insideSwitch)) return true;
+        return false;
+    }
+
+    #endregion
+}

--- a/Compilation/GeneratorMoveNextEmitter.Statements.cs
+++ b/Compilation/GeneratorMoveNextEmitter.Statements.cs
@@ -34,50 +34,30 @@ public partial class GeneratorMoveNextEmitter
             _il.Emit(OpCodes.Stfld, _builder.CurrentField);
         }
 
-        // Generator return - set state to completed and return false
+        // Generator return - set state to completed.
         _il.Emit(OpCodes.Ldarg_0);
         _il.Emit(OpCodes.Ldc_I4, -2);
         _il.Emit(OpCodes.Stfld, _builder.StateField);
+
+        // Inside a flag-based try/finally, the finally must run before the generator actually
+        // completes. Record a pending return and branch to the cleanup point instead of `ret`
+        // (which is also illegal here — this return statement is emitted outside the protected
+        // segment, but the finally is emitted after it). See EmitTryCatchWithYields.
+        if (_returnCleanupLabel != null)
+        {
+            _il.Emit(OpCodes.Ldarg_0);
+            _il.Emit(OpCodes.Ldc_I4_1);
+            _il.Emit(OpCodes.Stfld, GetPendingReturnField());
+            _il.Emit(OpCodes.Br, _returnCleanupLabel.Value);
+            return;
+        }
+
         _il.Emit(OpCodes.Ldc_I4_0);
         _il.Emit(OpCodes.Ret);
     }
 
-    protected override void EmitTryCatch(Stmt.TryCatch t)
-    {
-        _il.BeginExceptionBlock();
-
-        foreach (var stmt in t.TryBlock)
-            EmitStatement(stmt);
-
-        if (t.CatchBlock != null)
-        {
-            _il.BeginCatchBlock(typeof(Exception));
-
-            if (t.CatchParam != null)
-            {
-                var exLocal = _il.DeclareLocal(typeof(object));
-                _ctx!.Locals.RegisterLocal(t.CatchParam.Lexeme, exLocal);
-                _il.Emit(OpCodes.Call, _ctx.Runtime!.WrapException);
-                _il.Emit(OpCodes.Stloc, exLocal);
-            }
-            else
-            {
-                _il.Emit(OpCodes.Pop);
-            }
-
-            foreach (var stmt in t.CatchBlock)
-                EmitStatement(stmt);
-        }
-
-        if (t.FinallyBlock != null)
-        {
-            _il.BeginFinallyBlock();
-            foreach (var stmt in t.FinallyBlock)
-                EmitStatement(stmt);
-        }
-
-        _il.EndExceptionBlock();
-    }
+    // EmitTryCatch lives in GeneratorMoveNextEmitter.Statements.TryCatch.cs — it needs
+    // suspension-aware (flag-based) handling when a yield crosses the protected region.
 
     #endregion
 

--- a/SharpTS.Tests/SharedTests/GeneratorTryFinallyTests.cs
+++ b/SharpTS.Tests/SharedTests/GeneratorTryFinallyTests.cs
@@ -1,0 +1,298 @@
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests;
+
+/// <summary>
+/// Regression tests for #477: a compiled generator with a <c>yield</c> inside <c>try</c>/
+/// <c>catch</c>/<c>finally</c> previously emitted invalid IL (<c>InvalidProgramException</c> in
+/// <c>MoveNext</c>) — the state-dispatch switch branched into the protected region and the
+/// <c>yield</c>'s <c>ret</c> sat inside it, both illegal. The fix emits a flag-based scheme: the
+/// try body's synchronous runs are wrapped in mini IL try/catch blocks that record any exception
+/// into a flag, while the yields (and any non-local exits) are emitted at the top level so their
+/// resume labels are reachable and their <c>ret</c>/<c>br</c> are legal.
+///
+/// Run against both modes; the interpreter already behaved correctly, so these double as a
+/// cross-mode parity guard. Cases that depend on still-open gaps are documented inline and
+/// intentionally not asserted here: generator <c>.throw()</c>/<c>.return()</c> injecting through
+/// a suspended <c>try</c> (#478), <c>break</c>/<c>continue</c> running an enclosing <c>finally</c>
+/// (#500), and the completion value of a normally-finished generator (#499) are out of scope.
+/// </summary>
+public class GeneratorTryFinallyTests
+{
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void YieldInTryFinally_RunsFinallyAfterBody(ExecutionMode mode)
+    {
+        // The exact repro from #477.
+        var source = """
+            function* g() {
+              try {
+                yield 1;
+                yield 2;
+              } finally {
+                console.log("fin");
+              }
+            }
+            for (const v of g()) console.log(v);
+            """;
+
+        Assert.Equal("1\n2\nfin\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void YieldThenThrowInTry_CaughtWithValue(ExecutionMode mode)
+    {
+        // The yield resumes, then a synchronous throw in the same try body is caught — and the
+        // thrown value reaches the catch parameter (it is hoisted to a field because it is used
+        // after the yield; storing it only to a fresh local previously lost it).
+        var source = """
+            function* g() {
+              try {
+                yield 1;
+                throw "boom";
+              } catch (e) {
+                console.log("caught " + e);
+              }
+            }
+            for (const v of g()) console.log(v);
+            """;
+
+        Assert.Equal("1\ncaught boom\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void YieldInTry_CatchAndFinally_ThenYieldAfter(ExecutionMode mode)
+    {
+        var source = """
+            function* g() {
+              try {
+                yield 1;
+              } catch (e) {
+                console.log("c");
+              } finally {
+                console.log("fin");
+              }
+              yield 9;
+            }
+            for (const v of g()) console.log(v);
+            """;
+
+        Assert.Equal("1\nfin\n9\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void YieldInTryFinally_InsideLoop_RunsFinallyEachIteration(ExecutionMode mode)
+    {
+        var source = """
+            function* g() {
+              for (let i = 0; i < 3; i++) {
+                try {
+                  yield i;
+                } finally {
+                  console.log("f" + i);
+                }
+              }
+            }
+            for (const v of g()) console.log(v);
+            """;
+
+        Assert.Equal("0\nf0\n1\nf1\n2\nf2\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void NestedTryFinally_WithYield_RunsBothFinallysInnerThenOuter(ExecutionMode mode)
+    {
+        var source = """
+            function* g() {
+              try {
+                try {
+                  yield 1;
+                } finally {
+                  console.log("inner");
+                }
+              } finally {
+                console.log("outer");
+              }
+            }
+            for (const v of g()) console.log(v);
+            """;
+
+        Assert.Equal("1\ninner\nouter\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void YieldStarInTryFinally_DelegatesThenRunsFinally(ExecutionMode mode)
+    {
+        var source = """
+            function* inner() { yield 2; yield 3; }
+            function* g() {
+              try {
+                yield 1;
+                yield* inner();
+                yield 4;
+              } finally {
+                console.log("fin");
+              }
+            }
+            for (const v of g()) console.log(v);
+            """;
+
+        Assert.Equal("1\n2\n3\n4\nfin\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void FinallyThatYields_IsDriven(ExecutionMode mode)
+    {
+        var source = """
+            function* g() {
+              try {
+                yield 1;
+              } finally {
+                yield 2;
+                yield 3;
+              }
+            }
+            for (const v of g()) console.log(v);
+            """;
+
+        Assert.Equal("1\n2\n3\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ReturnInsideTryFinally_RunsFinallyBeforeCompleting(ExecutionMode mode)
+    {
+        // `return` inside the try must run the finally before the generator completes; the
+        // statement after the return must not execute.
+        var source = """
+            function* g() {
+              try {
+                yield 1;
+                return;
+                yield 99;
+              } finally {
+                console.log("fin");
+              }
+            }
+            for (const v of g()) console.log(v);
+            """;
+
+        Assert.Equal("1\nfin\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ReturnInsideNestedTryFinally_RunsAllEnclosingFinallys(ExecutionMode mode)
+    {
+        var source = """
+            function* g() {
+              try {
+                try {
+                  yield 1;
+                  return;
+                } finally {
+                  console.log("inner");
+                }
+              } finally {
+                console.log("outer");
+              }
+              yield 99;
+            }
+            for (const v of g()) console.log(v);
+            """;
+
+        Assert.Equal("1\ninner\nouter\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ReturnInTry_WithYieldingFinally_CompletesAfterFinallyYields(ExecutionMode mode)
+    {
+        // The finally itself yields, suspending MoveNext between the `return` and the completion
+        // check. The pending-return state must survive that suspension (it lives in a field, not a
+        // local), so the generator completes after the finally rather than running `yield 99`.
+        var source = """
+            function* g() {
+              try {
+                yield 1;
+                return;
+              } finally {
+                yield 2;
+              }
+              yield 99;
+            }
+            for (const v of g()) console.log(v);
+            """;
+
+        Assert.Equal("1\n2\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void NextValue_DeliveredToYieldInsideTry(ExecutionMode mode)
+    {
+        // The value passed to next() must reach a yield expression sitting inside a try.
+        var source = """
+            function* g() {
+              try {
+                const x = yield 1;
+                console.log("got " + x);
+              } finally {
+                console.log("fin");
+              }
+            }
+            const it = g();
+            it.next();
+            it.next(10);
+            """;
+
+        Assert.Equal("got 10\nfin\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void HoistedCatchParam_SimplePath_ReceivesThrownValue(ExecutionMode mode)
+    {
+        // Catch parameter used after a yield is hoisted to a field; the try here has no yield
+        // (simple IL try/catch path). Storing the caught value only to a local previously lost
+        // it — this guards the field-aware bind for the simple path too.
+        var source = """
+            function* g() {
+              yield 0;
+              try {
+                throw "boom";
+              } catch (e) {
+                yield e;
+              }
+            }
+            for (const v of g()) console.log(v);
+            """;
+
+        Assert.Equal("0\nboom\n", TestHarness.Run(source, mode));
+    }
+
+    // ---- IL-verification guards (the heart of #477: emitted IL must verify) ----
+
+    [Theory]
+    [InlineData("function* g() { try { yield 1; yield 2; } finally { console.log('f'); } } for (const v of g()) {}")]
+    [InlineData("function* g() { try { yield 1; throw 'x'; } catch (e) { console.log(e); } } for (const v of g()) {}")]
+    [InlineData("function* g() { try { yield 1; } catch (e) {} finally { console.log('f'); } yield 2; } for (const v of g()) {}")]
+    [InlineData("function* g() { for (let i=0;i<2;i++){ try { yield i; } finally { console.log(i); } } } for (const v of g()) {}")]
+    [InlineData("function* g() { try { try { yield 1; } finally { console.log('a'); } } finally { console.log('b'); } } for (const v of g()) {}")]
+    [InlineData("function* g() { try { yield 1; return; } finally { console.log('f'); } } for (const v of g()) {}")]
+    [InlineData("function* g() { try { yield 1; } finally { yield 2; } } for (const v of g()) {}")]
+    [InlineData("function* g() { while (true) { try { yield 1; break; } finally { console.log('f'); } } } for (const v of g()) {}")]
+    [InlineData("function* inner(){ yield 2; } function* g() { try { yield 1; yield* inner(); } finally { console.log('f'); } } for (const v of g()) {}")]
+    public void GeneratorTryFinallyWithYield_EmitsVerifiableIL(string source)
+    {
+        var errors = TestHarness.CompileAndVerifyOnly(source);
+        Assert.Empty(errors);
+    }
+}


### PR DESCRIPTION
## Summary

Closes #477. A compiled generator whose `try`/`catch`/`finally` contained a `yield` emitted invalid IL (`InvalidProgramException` in `MoveNext`): the state-dispatch switch branched into the protected region and the `yield`'s `ret` sat inside it — both illegal.

```ts
function* g() {
  try { yield 1; yield 2; } finally { console.log("fin"); }
}
for (const v of g()) console.log(v);   // was: InvalidProgramException; now: 1 / 2 / fin
```

## Approach

When a `yield`/`yield*` crosses the protected region, real IL exception blocks can't be used. The fix emits a **flag-based** scheme — mirroring the already-proven `AsyncGeneratorMoveNextEmitter`:

- The try body's synchronous runs are wrapped in mini IL try/catch blocks that record any exception into a flag local.
- Yields and non-local exits are emitted at the **top level**, so their resume labels are reachable from the dispatch switch and their `ret`/`br` are legal.
- Catch runs only if the flag is set; the finally is emitted inline and always runs; an uncaught exception is rethrown after it.
- When no yield crosses the region, the original real IL try/catch is kept unchanged (`EmitSimpleTryCatch`).

A `return` statement inside such a try is routed through the enclosing `finally`(s) via a **pending-return state-machine field** (a field, not a local, so it survives a finally that itself yields), then completes — works single-level and nested.

### Also fixed (same code path)

A pre-existing bug in both the simple and flag paths: a **hoisted catch parameter** (one used after a `yield`) lost its value, because the caught value was stored only to a fresh local while reads resolve the hoisted field first. The bind now goes through the variable resolver (field-if-hoisted, else local).

## Correctness scope

Handled correctly (interpreter parity, both modes tested): yields in try/catch/finally, synchronous `throw` caught with its value, finally on normal completion and on exception, multiple yields, yields across a loop in a try, nested try/finally, `yield*` in a try, a finally that itself yields, `next(v)` delivered to a yield inside a try, and `return` through (single/nested/yielding) finally.

## Testing

- New `GeneratorTryFinallyTests` (run in **both** interpreter and compiled modes) + 9 IL-verification guards via `CompileAndVerifyOnly`.
- Full suite green (11,534 passed).
- Test262 / TS-conformance baselines unaffected (Test262 subset has no generator folders; the change is codegen-only and TS-conformance is type-checker-only).

## Out-of-scope gaps found & filed

- #499 — normal-completion value is the last yielded value, not `undefined` (affects all compiled generators)
- #500 — `break`/`continue` and `throw`-from-`catch` don't run an enclosing `finally`
- #501 — nested generator function declaration inside a generator body fails to compile
- #478 already tracks `gen.return()`/`throw()` running `finally`.