### PR TITLE
Fix #492: conditional infer-match walks the superclass chain (and includes methods)

### DIFF
--- a/SharpTS.Tests/TypeCheckerTests/InheritedInferMatchTests.cs
+++ b/SharpTS.Tests/TypeCheckerTests/InheritedInferMatchTests.cs
@@ -1,0 +1,228 @@
+using SharpTS.Tests.Infrastructure;
+using SharpTS.TypeSystem.Exceptions;
+using Xunit;
+
+namespace SharpTS.Tests.TypeCheckerTests;
+
+/// <summary>
+/// Conditional-type <c>infer</c> matching against a class instance must see the class's full
+/// structural surface — public fields, getters, AND methods, merged across the entire superclass
+/// chain (#461 own methods, #492 inherited members). Previously the property source
+/// (<c>ExtractPropertiesWithTypes</c>) read only a class's OWN fields and getters, so a structural
+/// extends clause like <c>{ val: infer R }</c> silently took its false branch when <c>val</c> was a
+/// method or was inherited.
+///
+/// Each test pins the resolved conditional via an annotation: if <c>J&lt;C&gt;</c> resolves to the
+/// true branch (the inferred member type) the matching-typed assignment is accepted and the
+/// mismatched one throws; if it wrongly took the false branch (<c>"no"</c>) the expectations invert.
+/// Regular (non-<c>declare</c>) classes are used deliberately — <c>declare class</c> currently drops
+/// its <c>extends</c> clause entirely (a separate, broader bug tracked outside this fix), which would
+/// mask the member-source behavior under test here.
+/// </summary>
+public class InheritedInferMatchTests
+{
+    // ---- inherited FIELD (#492) ----
+
+    [Fact]
+    public void InheritedField_ResolvesToInferredType()
+    {
+        // val is declared on Base; Sub inherits it. J<Sub> must be "correct", so "correct" assigns.
+        var source = """
+            class Base { val: "correct" = "correct"; }
+            class Sub extends Base { extra(): void {} }
+            type J<T> = T extends { val: infer R } ? R : "no";
+            let x: J<Sub> = "correct";
+            """;
+        TestHarness.RunInterpreted(source);
+    }
+
+    [Fact]
+    public void InheritedField_WrongAssignment_IsTypeError()
+    {
+        // J<Sub> is "correct" (inherited), so a number violates it.
+        var source = """
+            class Base { val: "correct" = "correct"; }
+            class Sub extends Base { extra(): void {} }
+            type J<T> = T extends { val: infer R } ? R : "no";
+            let x: J<Sub> = 42;
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+
+    // ---- inherited GETTER (#492) ----
+
+    [Fact]
+    public void InheritedGetter_ResolvesToInferredType()
+    {
+        var source = """
+            class Base { get val(): "correct" { return "correct"; } }
+            class Sub extends Base { extra(): void {} }
+            type J<T> = T extends { val: infer R } ? R : "no";
+            let x: J<Sub> = "correct";
+            """;
+        TestHarness.RunInterpreted(source);
+    }
+
+    // ---- inherited METHOD (#492 method variant) ----
+
+    [Fact]
+    public void InheritedMethod_ResolvesToInferredReturnType()
+    {
+        // toJSON is an inherited method; { toJSON(): infer R } must bind R to its return type.
+        var source = """
+            class Base { toJSON(): "correct" { return "correct"; } }
+            class Sub extends Base { extra(): void {} }
+            type J<T> = T extends { toJSON(): infer R } ? R : "no";
+            let x: J<Sub> = "correct";
+            """;
+        TestHarness.RunInterpreted(source);
+    }
+
+    [Fact]
+    public void InheritedMethod_WrongAssignment_IsTypeError()
+    {
+        var source = """
+            class Base { toJSON(): "correct" { return "correct"; } }
+            class Sub extends Base { extra(): void {} }
+            type J<T> = T extends { toJSON(): infer R } ? R : "no";
+            let x: J<Sub> = 42;
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+
+    // ---- own METHOD (#461 — the prerequisite this fix also closes) ----
+
+    [Fact]
+    public void OwnMethod_ResolvesToInferredReturnType()
+    {
+        // A class's OWN method must be matchable too — the property source omitted methods entirely.
+        var source = """
+            class MyClass { toJSON(): "correct" { return "correct"; } }
+            type J<T> = T extends { toJSON(): infer R } ? R : "no";
+            let x: J<MyClass> = "correct";
+            """;
+        TestHarness.RunInterpreted(source);
+    }
+
+    // ---- deeper chain ----
+
+    [Fact]
+    public void TwoLevelInheritance_ResolvesToInferredType()
+    {
+        // val lives two levels up; the whole Superclass chain is merged.
+        var source = """
+            class A { val: "correct" = "correct"; }
+            class B extends A {}
+            class C extends B { extra(): void {} }
+            type J<T> = T extends { val: infer R } ? R : "no";
+            let x: J<C> = "correct";
+            """;
+        TestHarness.RunInterpreted(source);
+    }
+
+    [Fact]
+    public void DerivedMemberShadowsInherited()
+    {
+        // The derived declaration wins over the inherited one (own-wins precedence).
+        var source = """
+            class Base { val: "base" = "base"; }
+            class Sub extends Base { val: "derived" = "derived"; }
+            type J<T> = T extends { val: infer R } ? R : "no";
+            let x: J<Sub> = "derived";
+            """;
+        TestHarness.RunInterpreted(source);
+    }
+
+    [Fact]
+    public void DerivedMemberShadowsInherited_InheritedValueRejected()
+    {
+        var source = """
+            class Base { val: "base" = "base"; }
+            class Sub extends Base { val: "derived" = "derived"; }
+            type J<T> = T extends { val: infer R } ? R : "no";
+            let x: J<Sub> = "base";
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+
+    // ---- generic check type (the receiver is itself a generic instantiation) ----
+
+    [Fact]
+    public void GenericInstantiationCheckType_SubstitutesAndInfers()
+    {
+        // J<Box<number>> binds R to the substituted field type (number).
+        var source = """
+            class Box<T> { value: T; constructor(v: T) { this.value = v; } }
+            type J<T> = T extends { value: infer R } ? R : "no";
+            let x: J<Box<number>> = 123;
+            """;
+        TestHarness.RunInterpreted(source);
+    }
+
+    [Fact]
+    public void GenericInstantiationCheckType_WrongAssignment_IsTypeError()
+    {
+        var source = """
+            class Box<T> { value: T; constructor(v: T) { this.value = v; } }
+            type J<T> = T extends { value: infer R } ? R : "no";
+            let x: J<Box<number>> = "nope";
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+
+    // ---- exclusions / false-branch controls ----
+
+    [Fact]
+    public void PrivateInheritedMember_IsExcluded_TakesFalseBranch()
+    {
+        // A private inherited member is not part of the structural surface, so the match fails and
+        // J<Sub> is the false branch "no" — which "no" satisfies.
+        var source = """
+            class Base { private val: "correct" = "correct"; }
+            class Sub extends Base { extra(): void {} }
+            type J<T> = T extends { val: infer R } ? R : "no";
+            let x: J<Sub> = "no";
+            """;
+        TestHarness.RunInterpreted(source);
+    }
+
+    [Fact]
+    public void PrivateInheritedMember_TrueBranchValueRejected()
+    {
+        // Confirms the above really took the false branch: "correct" is not assignable to "no".
+        var source = """
+            class Base { private val: "correct" = "correct"; }
+            class Sub extends Base { extra(): void {} }
+            type J<T> = T extends { val: infer R } ? R : "no";
+            let x: J<Sub> = "correct";
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void AbsentMember_TakesFalseBranch()
+    {
+        // No val anywhere in the hierarchy → false branch.
+        var source = """
+            class Base { other: number = 1; }
+            class Sub extends Base {}
+            type J<T> = T extends { val: infer R } ? R : "no";
+            let x: J<Sub> = "no";
+            """;
+        TestHarness.RunInterpreted(source);
+    }
+
+    // ---- string-resolver (as-cast) path, to confirm the fix is independent of resolution route ----
+
+    [Fact]
+    public void AsCast_InheritedField_ResolvesToInferredType()
+    {
+        var source = """
+            class Base { val: "correct" = "correct"; }
+            class Sub extends Base {}
+            type J<T> = T extends { val: infer R } ? R : "no";
+            const s: "correct" = (null as any as J<Sub>);
+            """;
+        TestHarness.RunInterpreted(source);
+    }
+}

--- a/SharpTS.Tests/TypeCheckerTests/InheritedInferMatchTests.cs
+++ b/SharpTS.Tests/TypeCheckerTests/InheritedInferMatchTests.cs
@@ -225,4 +225,45 @@ public class InheritedInferMatchTests
             """;
         TestHarness.RunInterpreted(source);
     }
+
+    // ---- method shapes (params; interface parity) — the broader #461 surface ----
+
+    [Fact]
+    public void OwnMethod_ParameterInfer_IsTypeError()
+    {
+        // infer in PARAMETER position: P binds to the method's parameter type (number).
+        var source = """
+            class C { m(a: number): void {} }
+            type Arg<T> = T extends { m(a: infer P): void } ? P : "no";
+            let z: Arg<C> = "str";
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void InterfaceMethod_StillMatches()
+    {
+        // Interface members already carried methods; lock that the shared path keeps working
+        // (R binds to "correct", so the false-branch literal "no" is rejected).
+        var source = """
+            interface I { toJSON(): "correct"; }
+            type J<T> = T extends { toJSON(): infer R } ? R : "no";
+            let z: J<I> = "no";
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void DeclareClass_OwnMethod_Matches()
+    {
+        // An OWN method on a `declare class` matches — own members are unaffected by the separate
+        // declare-class-superclass-drop bug (#505); only inheritance is. This is the exact repro
+        // form from #461 / PR #498.
+        var source = """
+            declare class MyClass { toJSON(): "correct"; }
+            type J<T> = T extends { toJSON(): infer R } ? R : "no";
+            const z: J<MyClass> = "correct";
+            """;
+        TestHarness.RunInterpreted(source);
+    }
 }

--- a/TypeSystem/TypeChecker.Generics.Conditional.cs
+++ b/TypeSystem/TypeChecker.Generics.Conditional.cs
@@ -625,7 +625,7 @@ public partial class TypeChecker
                     recCallSigs.Select(CallSignatureToFunction).ToList(), inferredTypes))
                 return false;
 
-            var checkProps = ExtractPropertiesWithTypes(checkType);
+            var checkProps = ExtractInferMatchProperties(checkType);
             foreach (var (key, extendsFieldType) in extendsRec.Fields)
             {
                 if (!checkProps.TryGetValue(key, out var checkFieldType))
@@ -648,7 +648,7 @@ public partial class TypeChecker
                     itfCallSigs.Select(CallSignatureToFunction).ToList(), inferredTypes))
                 return false;
 
-            var checkProps = ExtractPropertiesWithTypes(checkType);
+            var checkProps = ExtractInferMatchProperties(checkType);
             foreach (var (key, extendsFieldType) in extendsItf.Members)
             {
                 if (extendsItf.OptionalMembers.Contains(key))
@@ -672,6 +672,34 @@ public partial class TypeChecker
         // Fall back to standard compatibility check (no infer patterns)
         return IsCompatible(extendsType, checkType);
     }
+
+    /// <summary>
+    /// Property source for the infer-match path — the <see cref="TypeInfo.Record"/>/<see cref="TypeInfo.Interface"/>
+    /// branches of <see cref="CheckExtendsRecursive"/>, which look up each extends-clause member on the
+    /// check type. For a class instance this contributes the full structural surface tsc matches against:
+    /// public fields, getters, AND methods, merged across the entire <c>Superclass</c> chain
+    /// (derived shadows inherited; the synthetic <c>constructor</c> and private/protected members are
+    /// excluded). Generic bases have their type arguments substituted.
+    ///
+    /// This is the deliberate divergence from <see cref="ExtractPropertiesWithTypes"/>, which stays
+    /// own-fields-and-getters-only because it also feeds keyof/mapped-type machinery (adding methods or
+    /// inherited members to a class's key domain there is a separate, broader decision). Routing only
+    /// the two infer-match call sites here keeps that blast radius contained while letting an extends
+    /// clause resolve against an inherited or method member (#461 own methods, #492 inherited members).
+    /// Adding members can only turn a currently-failing structural match into a success, never the
+    /// reverse, so it cannot perturb conditionals that already resolved. Non-class types defer to
+    /// <see cref="ExtractPropertiesWithTypes"/> unchanged.
+    /// </summary>
+    private Dictionary<string, TypeInfo> ExtractInferMatchProperties(TypeInfo type) => type switch
+    {
+        TypeInfo.Class cls => CollectPublicInstanceMembers(cls),
+        TypeInfo.Instance { ResolvedClassType: TypeInfo.Class instCls } => CollectPublicInstanceMembers(instCls),
+        TypeInfo.InstantiatedGeneric { GenericDefinition: TypeInfo.GenericClass gc } ig
+            => CollectGenericClassMembers(gc, ig.TypeArguments),
+        TypeInfo.Instance { ResolvedClassType: TypeInfo.InstantiatedGeneric { GenericDefinition: TypeInfo.GenericClass gc } ig }
+            => CollectGenericClassMembers(gc, ig.TypeArguments),
+        _ => ExtractPropertiesWithTypes(type)
+    };
 
     /// <summary>
     /// True when the type still contains type variables (type parameters, infer placeholders,


### PR DESCRIPTION
## What

A conditional type's structural extends clause — `T extends { val: infer R } ? R : "no"` — looks up each member on the check type. For a class instance the property source (`ExtractPropertiesWithTypes`) read only the class's **own fields and getters**: no methods, and no walk up the `Superclass` chain. So an **inherited** member, or any **method**, was invisible, the structural match failed, and the conditional silently took its **false** branch.

```ts
type J<T> = T extends { val: infer R } ? R : "no";
class Base { val: "correct" = "correct"; }
class Sub extends Base { extra(): void {} }
type X = J<Sub>;   // was "no" (false branch); now "correct" (val is inherited)
```

## Fix

Add `ExtractInferMatchProperties`, used **only** by the two `CheckExtendsRecursive` Record/Interface call sites. For a class instance it sources the full structural surface tsc matches against — public fields, getters, **and** methods, merged across the entire `Superclass` chain (derived-wins precedence; the synthetic `constructor` and private/protected members excluded), with generic-class type arguments substituted. It reuses the existing structural-compat collectors (`CollectPublicInstanceMembers` / `CollectGenericClassMembers`), so infer-matching stays **consistent** with structural assignability.

`ExtractPropertiesWithTypes` is deliberately left unchanged: it also feeds the `keyof`/mapped-type machinery, where adding methods or inherited members to a class's key domain is a separate, broader decision. Confining the change to the two infer-match call sites keeps the blast radius contained. Adding members can only turn a currently-failing structural match into a success — never the reverse — so conditionals that already resolved are unaffected.

## Scope note (#461)

#492's suggested fix is framed on "the method-inclusive `ExtractInferMatchProperties` path added in #461" — but #461 was never merged, so that path didn't exist, and #492's own repro includes a **method** variant ("affects inherited fields, getters, and methods uniformly"). The method-inclusion (#461) and the superclass walk (#492) are the **same code path**, so this single change closes both. Verified: own-method, inherited-field, inherited-getter, inherited-method, two-level inheritance, derived-shadows-inherited, and generic-receiver (`J<Box<number>>`) all resolve; private-inherited and truly-absent members correctly take the false branch.

## Tests

`SharpTS.Tests/TypeCheckerTests/InheritedInferMatchTests.cs` — 15 cases covering the above (positive + negative + exclusion + as-cast path). Tests use **regular** classes deliberately (see below).

- Full unit suite: **11565 passed, 0 failed**.
- TypeScript conformance: **31 passed, 0 failed** (no baseline shift).

## Pre-existing gaps found and filed separately

- **#505** — `declare class` drops its `extends` superclass entirely (`CheckDeclareClass` never resolves `SuperclassExpr`). This is broader than infer-matching (affects member access and assignability) and is why #492's verbatim `declare class` repro still needs that fix; this PR's tests use regular classes to exercise the member source under test without tripping it.
- **#506** — structural member collection doesn't walk a generic-instantiation superclass (`class Sub extends Base<number>`); a shared limitation of `CollectPublicInstanceMembers`/`CollectGenericClassMembers` affecting both structural assignability and (via this PR) infer-matching. Fixing it in the shared collectors repairs both together.

Closes #492. Closes #461.