### PR TITLE
Fix #493: model `as const` as readonly; preserve literal types as array elements and spread members

### DIFF
--- a/SharpTS.Tests/TypeCheckerTests/ConstInitializerWideningTests.cs
+++ b/SharpTS.Tests/TypeCheckerTests/ConstInitializerWideningTests.cs
@@ -119,4 +119,94 @@ public class ConstInitializerWideningTests
         var source = "const o = { a: { n: 1 } as const, b: { m: 2 } }; o.b.m = 5; console.log(o.b.m);";
         Assert.Equal("5\n", TestHarness.Run(source, mode));
     }
+
+    // --- #493: `as const` literal types survive `const`-initializer widening regardless of the
+    // nesting position (array element, spread member), and `as const` members model readonly. ---
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AsConstArrayElement_KeepsLiteralType(ExecutionMode mode)
+    {
+        // `as const` on an *array element* inside a fresh array literal is no longer widened away:
+        // `arr` is `{ readonly n: 1 }[]`, so `arr[0].n` is `1`, assignable to a `1`-typed binding.
+        var source = "const arr = [{ n: 1 } as const]; const y: 1 = arr[0].n; console.log(y);";
+        Assert.Equal("1\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void SpreadOfAsConstObject_KeepsLiteralType(ExecutionMode mode)
+    {
+        // Spreading an `as const` object into a fresh object literal preserves the (already-fixed)
+        // literal member types: `o.a` is `1` (not widened to `number`).
+        var source = "const x = { a: 1 } as const; const o = { ...x }; const y: 1 = o.a; console.log(y);";
+        Assert.Equal("1\n", TestHarness.Run(source, mode));
+    }
+
+    [Fact]
+    public void AsConstObject_MemberWrite_ReportsReadonlyTS2540()
+    {
+        // Writing through an `as const` member is a read-only violation (TS2540), not a literal-type
+        // mismatch (TS2322).
+        var ex = Assert.ThrowsAny<TypeCheckException>(() =>
+            TestHarness.RunInterpreted("const x = { a: 1 } as const; x.a = 9;"));
+        Assert.Equal("TS2540", ex.Diagnostic.TsCode);
+    }
+
+    [Fact]
+    public void AsConstArrayElement_MemberWrite_ReportsReadonlyTS2540()
+    {
+        // The `as const` element is a readonly record, so writing its member is rejected with TS2540.
+        var ex = Assert.ThrowsAny<TypeCheckException>(() =>
+            TestHarness.RunInterpreted("const arr = [{ n: 1 } as const]; arr[0].n = 9;"));
+        Assert.Equal("TS2540", ex.Diagnostic.TsCode);
+    }
+
+    [Fact]
+    public void DeepNestedAsConst_MemberWrite_ReportsReadonlyTS2540()
+    {
+        // `as const` is deep: every nested member is readonly, so `o.a.b.c = 9` is a TS2540 violation.
+        var ex = Assert.ThrowsAny<TypeCheckException>(() =>
+            TestHarness.RunInterpreted("const o = { a: { b: { c: 1 } } } as const; o.a.b.c = 9;"));
+        Assert.Equal("TS2540", ex.Diagnostic.TsCode);
+    }
+
+    [Fact]
+    public void SpreadOfAsConst_FieldIsWritable_ReadonlyDropped()
+    {
+        // The spread *drops* readonly (the result object is a plain literal), so the field is writable
+        // — assigning the same literal value is allowed.
+        TestHarness.RunInterpreted("const x = { a: 1 } as const; const o = { ...x }; o.a = 1;");
+    }
+
+    [Fact]
+    public void SpreadOfAsConst_FieldKeepsLiteralType_RejectsOtherValueWithTS2322()
+    {
+        // The spread preserves the literal type `1` (mutable), so writing a different value is a
+        // literal-type mismatch (TS2322), NOT a readonly violation.
+        var ex = Assert.ThrowsAny<TypeCheckException>(() =>
+            TestHarness.RunInterpreted("const x = { a: 1 } as const; const o = { ...x }; o.a = 2;"));
+        Assert.Equal("TS2322", ex.Diagnostic.TsCode);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void SpreadOfFreshObjectLiteral_Widens(ExecutionMode mode)
+    {
+        // Spreading a *fresh* inline object literal still widens its members (unlike an `as const`
+        // source), so `o.a` is `number` and `o.a = 2` is allowed.
+        var source = "const o = { ...{ a: 1 } }; o.a = 2; console.log(o.a);";
+        Assert.Equal("2\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void MixedSpread_PlainSourceWidens_AsConstSourcePreserved(ExecutionMode mode)
+    {
+        // A plain spread member widens (`o.a` is `number`, writable) while a later `as const` spread
+        // member preserves its literal type (`o.b` is `2`). Later members win.
+        var source = "const base = { a: 1 }; const ov = { b: 2 } as const; " +
+                     "const o = { ...base, ...ov }; const yb: 2 = o.b; o.a = 99; console.log(o.a, yb);";
+        Assert.Equal("99 2\n", TestHarness.Run(source, mode));
+    }
 }

--- a/TypeSystem/TypeChecker.Expressions.cs
+++ b/TypeSystem/TypeChecker.Expressions.cs
@@ -417,18 +417,24 @@ public partial class TypeChecker
     }
 
     /// <summary>
-    /// Converts an array literal to a tuple type with literal element types.
+    /// Converts an array literal to a readonly tuple type with literal element types.
+    /// The tuple is marked <see cref="TypeInfo.Tuple.IsReadonly"/> because <c>as const</c> produces
+    /// readonly literal-typed elements; this both rejects element writes and protects the literal
+    /// element types from <c>const</c>-initializer widening (#493 — see <see cref="WidenLiteralType"/>).
     /// </summary>
     private TypeInfo InferConstArrayType(Expr.ArrayLiteral arr)
     {
         var elementTypes = arr.Elements
             .Select(e => InferConstType(e, CheckExpr(e)))
             .ToList();
-        return TypeInfo.Tuple.FromTypes(elementTypes, elementTypes.Count);
+        return TypeInfo.Tuple.FromTypes(elementTypes, elementTypes.Count, isReadonly: true);
     }
 
     /// <summary>
-    /// Converts an object literal to a record type with literal property types.
+    /// Converts an object literal to a readonly record type with literal property types.
+    /// The record is marked <see cref="TypeInfo.Record.IsReadonly"/> because <c>as const</c> produces
+    /// readonly literal-typed members; this both rejects member writes with TS2540 and protects the
+    /// literal member types from <c>const</c>-initializer widening (#493 — see <see cref="WidenLiteralType"/>).
     /// </summary>
     private TypeInfo InferConstObjectType(Expr.ObjectLiteral obj)
     {
@@ -480,6 +486,7 @@ public partial class TypeChecker
         // Properties with a getter but no setter are getter-only
         var getterOnly = getters.Except(setters).ToFrozenSet();
         return new TypeInfo.Record(fields.ToFrozenDictionary(),
+            IsReadonly: true,
             GetterOnlyFields: getterOnly.Count > 0 ? getterOnly : null);
     }
 
@@ -806,6 +813,13 @@ public partial class TypeChecker
             TypeInfo.StringLiteral => new TypeInfo.String(),
             TypeInfo.BooleanLiteral => new TypeInfo.Primitive(TokenType.TYPE_BOOLEAN),
             TypeInfo.Union u => new TypeInfo.Union(u.FlattenedTypes.Select(WidenLiteralType).ToList()),
+            // `as const` (and other readonly) arrays/tuples/records keep their literal element/member
+            // types — readonly literal types are never widened (#493). Without this, an `as const`
+            // sitting as an array *element* or a spread *member* (positions where `const`-initializer
+            // widening recurses through a fresh literal) would be widened away.
+            TypeInfo.Array { IsReadonly: true } => type,
+            TypeInfo.Tuple { IsReadonly: true } => type,
+            TypeInfo.Record { IsReadonly: true } => type,
             TypeInfo.Array arr => new TypeInfo.Array(WidenLiteralType(arr.ElementType)),
             TypeInfo.Record rec => new TypeInfo.Record(
                 rec.Fields.ToDictionary(kv => kv.Key, kv => WidenLiteralType(kv.Value)).ToFrozenDictionary(),
@@ -824,10 +838,11 @@ public partial class TypeChecker
     /// types widened to their base types (<c>const o = { n: 1 }</c> ⇒ <c>{ n: number }</c>), which
     /// keeps a later <c>o.n = 9</c> legal. A bare primitive literal keeps its literal type
     /// (<c>const x = 1</c> ⇒ <c>1</c>), and <c>as const</c> assertions keep their readonly literal
-    /// types — including a <c>as const</c> nested inside a plain object literal. Non-literal
-    /// initializers (variables, calls, …) are not "fresh" and pass through unchanged.
+    /// types — including an <c>as const</c> nested inside a plain object literal, sitting as an array
+    /// element, or spread into a plain object literal (#493). Non-literal initializers (variables,
+    /// calls, …) are not "fresh" and pass through unchanged.
     /// </summary>
-    private static TypeInfo WidenConstInitializerType(Expr initializer, TypeInfo inferredType)
+    private TypeInfo WidenConstInitializerType(Expr initializer, TypeInfo inferredType)
         => WidenFreshLiteralsForConst(initializer, inferredType, topLevel: true);
 
     /// <summary>
@@ -837,17 +852,11 @@ public partial class TypeChecker
     /// (<c>const x = 1</c> ⇒ <c>1</c>); inside an object literal it is widened
     /// (<c>{ a: 1 }</c> ⇒ <c>{ a: number }</c>), mirroring the <c>let</c> path.
     /// </summary>
-    private static TypeInfo WidenFreshLiteralsForConst(Expr expr, TypeInfo type, bool topLevel)
+    private TypeInfo WidenFreshLiteralsForConst(Expr expr, TypeInfo type, bool topLevel)
     {
         // `satisfies` and parentheses are transparent to widening:
         // `const o = ({ n: 1 }) satisfies T` widens exactly like `const o = { n: 1 }`.
-        Expr inner = expr;
-        while (true)
-        {
-            if (inner is Expr.Satisfies sat) { inner = sat.Expression; continue; }
-            if (inner is Expr.Grouping grp) { inner = grp.Expression; continue; }
-            break;
-        }
+        Expr inner = UnwrapTransparentForWidening(expr);
 
         switch (inner)
         {
@@ -855,13 +864,13 @@ public partial class TypeChecker
             case Expr.TypeAssertion { TargetType: "const" }:
                 return type;
 
-            // A fresh object literal widens each member; a member that is itself `as const` (or a
-            // non-fresh reference) is preserved by recursing on its value expression.
+            // A fresh object literal widens each member; a member that is itself `as const`, or a
+            // spread of a non-fresh source, is preserved per-member (see WidenConstObjectLiteralFields).
             case Expr.ObjectLiteral obj when type is TypeInfo.Record rec:
                 return WidenConstObjectLiteralFields(obj, rec);
 
-            // A fresh array literal widens its element type. Element expressions are collapsed into
-            // a single element type during inference, so an `as const` *element* is not kept.
+            // A fresh array literal widens its element type. An `as const` *element* produced a
+            // readonly record/tuple, which WidenLiteralType leaves intact, so it survives (#493).
             case Expr.ArrayLiteral when type is TypeInfo.Array arr:
                 return new TypeInfo.Array(WidenLiteralType(arr.ElementType));
 
@@ -877,33 +886,56 @@ public partial class TypeChecker
 
     /// <summary>
     /// Widens the fields of a fresh object-literal <see cref="TypeInfo.Record"/> for a <c>const</c>
-    /// binding. Direct (<c>name: value</c>) members recurse so a nested <c>as const</c> member keeps
-    /// its literal types; spread/computed/accessor members widen conservatively. Other record
-    /// metadata (optional/getter-only/index signatures, …) is preserved.
+    /// binding, mirroring TypeScript's freshness rules. A direct <c>name: value</c> member is fresh:
+    /// its value expression is widened (recursing so a nested <c>as const</c> survives). A spread
+    /// member contributes its source's fields: spreading a <em>fresh</em> inline object literal
+    /// widens them (recursively), while spreading a <em>non-fresh</em> source (an <c>as const</c>, a
+    /// variable, a call) preserves their already-fixed literal types verbatim — this is what keeps
+    /// <c>const o = { ...({ a: 1 } as const) }</c> at <c>{ a: 1 }</c> (#493). Members are processed in
+    /// source order so a later member overrides an earlier one (JS spread/override order). A field not
+    /// resolved to any member (a computed key, or a non-enumerable spread source) widens
+    /// conservatively, and other record metadata (optional/getter-only/index signatures, …) is preserved.
     /// </summary>
-    private static TypeInfo WidenConstObjectLiteralFields(Expr.ObjectLiteral obj, TypeInfo.Record rec)
+    private TypeInfo WidenConstObjectLiteralFields(Expr.ObjectLiteral obj, TypeInfo.Record rec)
     {
-        // Map each statically-named, non-spread `name: value` member to its value expression.
-        var valueExprByName = new Dictionary<string, Expr>();
+        // Resolve, per final field name, the widened member type by walking members in source order
+        // so the last writer for a name wins — matching how `rec` itself was merged during inference.
+        var resolved = new Dictionary<string, TypeInfo>();
         foreach (var prop in obj.Properties)
         {
-            if (prop.IsSpread || prop.Kind != Expr.ObjectPropertyKind.Value) continue;
-            string? name = prop.Key switch
+            if (prop.IsSpread)
             {
-                Expr.IdentifierKey ik => ik.Name.Lexeme,
-                Expr.LiteralKey { Literal.Literal: string s } => s,
-                _ => null,
-            };
-            if (name != null) valueExprByName[name] = prop.Value;
+                Expr source = UnwrapTransparentForWidening(prop.Value);
+                // The spread source was already type-checked while inferring this object literal;
+                // re-checking an r-value here is idempotent and surfaces no new diagnostics.
+                TypeInfo sourceType = CheckExpr(prop.Value);
+                if (source is Expr.ObjectLiteral innerObj && sourceType is TypeInfo.Record innerRec)
+                {
+                    // Fresh inline object-literal spread: widen its members recursively.
+                    var widenedInner = (TypeInfo.Record)WidenConstObjectLiteralFields(innerObj, innerRec);
+                    foreach (var (k, v) in widenedInner.Fields)
+                        resolved[k] = v;
+                }
+                else
+                {
+                    // Non-fresh spread (`as const`, a variable, a call, …): preserve the source's
+                    // already-fixed field types verbatim, so spread `as const` literals survive.
+                    foreach (var k in EnumerateRecordLikeFieldNames(sourceType))
+                        if (rec.Fields.TryGetValue(k, out var preserved))
+                            resolved[k] = preserved;
+                }
+            }
+            else if (prop.Kind == Expr.ObjectPropertyKind.Value &&
+                     TryGetStaticFieldNameForWidening(prop.Key, out var name) &&
+                     rec.Fields.TryGetValue(name, out var directType))
+            {
+                resolved[name] = WidenFreshLiteralsForConst(prop.Value, directType, topLevel: false);
+            }
         }
 
         var widenedFields = new Dictionary<string, TypeInfo>(rec.Fields.Count);
         foreach (var (name, fieldType) in rec.Fields)
-        {
-            widenedFields[name] = valueExprByName.TryGetValue(name, out var valueExpr)
-                ? WidenFreshLiteralsForConst(valueExpr, fieldType, topLevel: false)
-                : WidenLiteralType(fieldType);
-        }
+            widenedFields[name] = resolved.TryGetValue(name, out var w) ? w : WidenLiteralType(fieldType);
 
         return rec with
         {
@@ -912,6 +944,40 @@ public partial class TypeChecker
             NumberIndexType = rec.NumberIndexType != null ? WidenLiteralType(rec.NumberIndexType) : null,
             SymbolIndexType = rec.SymbolIndexType != null ? WidenLiteralType(rec.SymbolIndexType) : null,
         };
+    }
+
+    /// <summary>
+    /// Unwraps the widening-transparent wrappers (<c>satisfies</c> and parentheses) so widening sees
+    /// the underlying literal/assertion shape.
+    /// </summary>
+    private static Expr UnwrapTransparentForWidening(Expr expr)
+    {
+        while (true)
+        {
+            if (expr is Expr.Satisfies sat) { expr = sat.Expression; continue; }
+            if (expr is Expr.Grouping grp) { expr = grp.Expression; continue; }
+            return expr;
+        }
+    }
+
+    /// <summary>Enumerates the statically known field names a spread source contributes.</summary>
+    private static IEnumerable<string> EnumerateRecordLikeFieldNames(TypeInfo sourceType) => sourceType switch
+    {
+        TypeInfo.Record rec => rec.Fields.Keys,
+        TypeInfo.Interface iface => iface.GetAllMembers().Select(m => m.Key),
+        _ => [],
+    };
+
+    /// <summary>Resolves the static field name of a <c>name: value</c> object-literal member key.</summary>
+    private static bool TryGetStaticFieldNameForWidening(Expr.PropertyKey? key, out string name)
+    {
+        name = key switch
+        {
+            Expr.IdentifierKey ik => ik.Name.Lexeme,
+            Expr.LiteralKey { Literal.Literal: string s } => s,
+            _ => null!,
+        };
+        return name != null;
     }
 
     private TypeInfo CheckArray(Expr.ArrayLiteral array)

--- a/TypeSystem/TypeChecker.Properties.cs
+++ b/TypeSystem/TypeChecker.Properties.cs
@@ -583,6 +583,13 @@ public partial class TypeChecker
         {
              if (record.Fields.TryGetValue(set.Name.Lexeme, out var fieldType))
              {
+                 // A readonly record (`as const`, `Readonly<T>`, a const type parameter) rejects all
+                 // member writes with TS2540, in preference to the literal-type mismatch TS2322 the
+                 // value-compatibility check below would otherwise report (#493).
+                 if (record.IsReadonly)
+                 {
+                     throw new TypeCheckException($" Cannot assign to '{set.Name.Lexeme}' because it is a read-only property.", tsCode: "TS2540");
+                 }
                  TypeInfo valueType = CheckExpr(set.Value);
                  // Getter-only properties: allow at type-check time, runtime handles sloppy/strict
                  if (record.IsGetterOnly(set.Name.Lexeme))


### PR DESCRIPTION
Closes #493. Follow-up to #458 (now merged); rebased onto `main`, so this is a single, self-contained commit.

## Problem

`as const` records/tuples were built with `IsReadonly = false`, making them structurally indistinguishable from plain object/array literals. #458's `const`-initializer widening therefore widened an `as const` away whenever it sat where widening recurses through a *fresh* literal:

| Source | Before | After / tsc |
|---|---|---|
| `const arr = [{ n: 1 } as const]; const y: 1 = arr[0].n;` | ❌ `number` not assignable to `1` | ✅ `arr[0].n` is `1` |
| `const x = { a: 1 } as const; const o = { ...x }; const y: 1 = o.a;` | ❌ `number` not assignable to `1` | ✅ `o.a` is `1` |
| `const x = { a: 1 } as const; x.a = 9;` | `TS2322` (literal mismatch) | ✅ `TS2540` (read-only) |

## Fix (type-checker only, shared by both execution modes)

- **`InferConstObjectType` / `InferConstArrayType`** mark their record/tuple `IsReadonly` (deeply — nested `as const` members recurse through the same path).
- **`WidenLiteralType`** leaves readonly arrays/tuples/records intact, so an `as const` array *element* survives widening.
- **`WidenConstObjectLiteralFields`** now follows TS *freshness* rules per member: a direct `name: value` member widens (recursing so a nested `as const` survives); a spread of a *fresh* inline object literal widens recursively; a spread of a *non-fresh* source (`as const`, a variable, a call) preserves its already-fixed literal types — so spread `as const` members survive. Members resolve in source order (later wins), matching JS spread/override.
- **`CheckSet`** rejects a write to a readonly record member with `TS2540`.

The spread *drops* readonly but *keeps* the literal type, matching `tsc`: `const o = { ...({ a: 1 } as const) }` is `{ a: 1 }` — `o.a` is writable, but `o.a = 2` is `TS2322` (a literal mismatch), **not** a `TS2540` readonly violation.

## Tests & verification

- `ConstInitializerWideningTests.cs` (+9), covering both #493 cases, deep-readonly writes (TS2540), spread writability/literal-typing (TS2322), fresh-inline-spread widening, and mixed last-writer-wins spread — interpreted and compiled.
- Full suite green (only the unrelated live-DNS network flake `ResolveNs_InvalidDomain` is environmental); TypeScript conformance **31/31 unchanged**. `IsReadonly` is not consulted anywhere in compatibility, so marking `as const` readonly does not shift assignability.

## Follow-up filed

- #509 — index writes to readonly tuples/arrays with a *compatible* value should be `TS2542` (orthogonal; the `readonly T[]` half predates `as const` readonly modeling).