### PR TITLE
Fix #491: resolve built-in type records' members in conditional infer-match

### DIFF
--- a/Compilation/EmittedRuntime.cs
+++ b/Compilation/EmittedRuntime.cs
@@ -1077,6 +1077,7 @@ public class EmittedRuntime
     public MethodBuilder DateToISOString { get; set; } = null!;
     public MethodBuilder DateToDateString { get; set; } = null!;
     public MethodBuilder DateToTimeString { get; set; } = null!;
+    public MethodBuilder DateToJSON { get; set; } = null!;
     public MethodBuilder DateValueOf { get; set; } = null!;
 
     // RegExp support - $Runtime wrapper methods

--- a/Compilation/Emitters/DateEmitter.cs
+++ b/Compilation/Emitters/DateEmitter.cs
@@ -137,6 +137,11 @@ public sealed class DateEmitter : ITypeEmitterStrategy
                 il.Emit(OpCodes.Call, ctx.Runtime!.DateToTimeString);
                 return true;
 
+            // toJSON (no arguments, returns string | null as object)
+            case "toJSON":
+                il.Emit(OpCodes.Call, ctx.Runtime!.DateToJSON);
+                return true;
+
             // valueOf (no arguments, returns double)
             case "valueOf":
                 il.Emit(OpCodes.Call, ctx.Runtime!.DateValueOf);

--- a/Compilation/RuntimeEmitter.Date.cs
+++ b/Compilation/RuntimeEmitter.Date.cs
@@ -37,6 +37,7 @@ public partial class RuntimeEmitter
         EmitDateToISOString(typeBuilder, runtime);
         EmitDateToDateString(typeBuilder, runtime);
         EmitDateToTimeString(typeBuilder, runtime);
+        EmitDateToJSON(typeBuilder, runtime);
         EmitDateValueOf(typeBuilder, runtime);
     }
 
@@ -645,6 +646,43 @@ public partial class RuntimeEmitter
 
         il.MarkLabel(invalidLabel);
         il.Emit(OpCodes.Ldstr, "Invalid Date");
+        il.Emit(OpCodes.Ret);
+    }
+
+    // ECMA-262 §21.4.4.37: toJSON returns the ISO string, or null for a non-finite (Invalid)
+    // date. Returns object (string | null), mirroring DateBuiltIns' interpreted implementation.
+    private void EmitDateToJSON(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    {
+        var method = typeBuilder.DefineMethod(
+            "DateToJSON",
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.Object,
+            [_types.Object]
+        );
+        runtime.DateToJSON = method;
+
+        var il = method.GetILGenerator();
+        var nullLabel = il.DefineLabel();
+
+        // Non-Date receiver → null (lenient; unreachable when the type checker is satisfied).
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Isinst, runtime.TSDateType);
+        il.Emit(OpCodes.Brfalse, nullLabel);
+
+        // Invalid (NaN timestamp) → null, before ToISOString's RangeError throw can be reached.
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Castclass, runtime.TSDateType);
+        il.Emit(OpCodes.Callvirt, runtime.TSDateMethods["GetTime"]);
+        il.Emit(OpCodes.Call, _types.Double.GetMethod("IsNaN")!);
+        il.Emit(OpCodes.Brtrue, nullLabel);
+
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Castclass, runtime.TSDateType);
+        il.Emit(OpCodes.Callvirt, runtime.TSDateMethods["ToISOString"]);
+        il.Emit(OpCodes.Ret);
+
+        il.MarkLabel(nullLabel);
+        il.Emit(OpCodes.Ldnull);
         il.Emit(OpCodes.Ret);
     }
 

--- a/Runtime/BuiltIns/BuiltInTypes.cs
+++ b/Runtime/BuiltIns/BuiltInTypes.cs
@@ -371,6 +371,9 @@ public static class BuiltInTypes
             "toISOString" => new TypeInfo.Function([], StringType),
             "toDateString" => new TypeInfo.Function([], StringType),
             "toTimeString" => new TypeInfo.Function([], StringType),
+            // lib.es5: `toJSON(key?: any): string` (used by JSON.stringify and matched by
+            // `T extends { toJSON(): infer R }`, see #491). Runtime impl in DateBuiltIns.
+            "toJSON" => new TypeInfo.Function([], StringType),
             "valueOf" => new TypeInfo.Function([], NumberType),
 
             _ => null

--- a/Runtime/BuiltIns/DateBuiltIns.cs
+++ b/Runtime/BuiltIns/DateBuiltIns.cs
@@ -66,6 +66,11 @@ public static class DateBuiltIns
             .MethodV2("toISOString", 0, (_, date, _) => RuntimeValue.FromString(date.ToISOString()))
             .MethodV2("toDateString", 0, (_, date, _) => RuntimeValue.FromString(date.ToDateString()))
             .MethodV2("toTimeString", 0, (_, date, _) => RuntimeValue.FromString(date.ToTimeString()))
+            // ECMA-262 §21.4.4.37: toJSON returns the ISO string, or null for a non-finite
+            // (Invalid) date — guard so we never reach ToISOString's RangeError throw.
+            .MethodV2("toJSON", 0, (_, date, _) => double.IsNaN(date.GetTime())
+                ? RuntimeValue.Null
+                : RuntimeValue.FromString(date.ToISOString()))
             .MethodV2("valueOf", 0, (_, date, _) => RuntimeValue.FromNumber(date.ValueOf()))
             .Build();
 

--- a/SharpTS.Tests/SharedTests/DateTests.cs
+++ b/SharpTS.Tests/SharedTests/DateTests.cs
@@ -249,6 +249,33 @@ public class DateTests
 
     [Theory]
     [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Date_ToJSON_ReturnsISOString(ExecutionMode mode)
+    {
+        // toJSON returns the same ISO string as toISOString for a valid date (#491).
+        var source = @"
+            let d = new Date('2024-06-15T12:00:00Z');
+            console.log(d.toJSON() === d.toISOString());
+        ";
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("true\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Date_ToJSON_InvalidDate_ReturnsNull(ExecutionMode mode)
+    {
+        // ECMA-262 §21.4.4.37: toJSON returns null for a non-finite (Invalid) date,
+        // rather than throwing the way toISOString does.
+        var source = @"
+            let d = new Date(NaN);
+            console.log(d.toJSON());
+        ";
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("null\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void Date_ValueOf_ReturnsTimestamp(ExecutionMode mode)
     {
         var source = @"

--- a/SharpTS.Tests/TypeCheckerTests/InferMatchBuiltInMemberTests.cs
+++ b/SharpTS.Tests/TypeCheckerTests/InferMatchBuiltInMemberTests.cs
@@ -1,0 +1,119 @@
+using SharpTS.Tests.Infrastructure;
+using SharpTS.TypeSystem.Exceptions;
+using Xunit;
+
+namespace SharpTS.Tests.TypeCheckerTests;
+
+/// <summary>
+/// Conditional-type <c>infer</c> matching against the instance members of a dedicated built-in
+/// type record — Date, RegExp, Map, Set, Promise and the weak/iterator variants (#491).
+///
+/// The property source for the Record/Interface extends branches of <c>CheckExtendsRecursive</c>
+/// (<c>ExtractPropertiesWithTypes</c>) has no case for these records, so a pattern like
+/// <c>T extends { toJSON(): infer R }</c> against <c>Date</c> silently took its FALSE branch. The fix
+/// resolves the extends-side member through the same <c>BuiltInTypes</c> model that ordinary
+/// <c>value.member</c> reads use (e.g. <c>Date.prototype.toJSON: () =&gt; string</c>).
+///
+/// Each positive test assigns a value valid for the TRUE branch but rejected by the false branch
+/// (<c>"no"</c>), so it only type-checks once the member is found. Type resolution is
+/// mode-independent; the interpreter harness exercises it.
+///
+/// Sibling coverage: class instance methods / inherited members in infer matching (#461, #492) are
+/// tested in <c>InheritedInferMatchTests</c>.
+/// </summary>
+public class InferMatchBuiltInMemberTests
+{
+    [Fact]
+    public void Date_ToJSON_InferBindsString()
+    {
+        // Date.prototype.toJSON(): string — the canonical #491 repro. A plain string is accepted
+        // only if J<Date> widened to `string` (true branch); the false branch "no" rejects "hello".
+        var source = """
+            type J<T> = T extends { toJSON(): infer R } ? R : "no";
+            let s: J<Date> = "hello";
+            """;
+        TestHarness.RunInterpreted(source);
+    }
+
+    [Fact]
+    public void Date_ToJSON_InferIsString_NotAny()
+    {
+        // Guard against the conditional garbling to `any` (which would accept 42): J<Date> is
+        // precisely `string`, so a number assignment must error.
+        var source = """
+            type J<T> = T extends { toJSON(): infer R } ? R : "no";
+            let n: J<Date> = 42;
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void Date_AlreadyModeledMember_GetTime_InferBindsNumber()
+    {
+        // getTime(): number was already modeled; it now participates in infer matching too.
+        var source = """
+            type J<T> = T extends { getTime(): infer R } ? R : "no";
+            let n: J<Date> = 123;
+            """;
+        TestHarness.RunInterpreted(source);
+    }
+
+    [Fact]
+    public void RegExp_Source_InferBindsString()
+    {
+        // RegExp.source is a string property (not a method) — exercises the non-method branch.
+        var source = """
+            type Src<T> = T extends { source: infer R } ? R : "no";
+            let s: Src<RegExp> = "[a-z]+";
+            """;
+        TestHarness.RunInterpreted(source);
+    }
+
+    [Fact]
+    public void Map_Get_InferBindsValueOrNull()
+    {
+        // Map<string, number>.get(k): number | null — null is valid for the true branch only.
+        var source = """
+            type GetRet<T> = T extends { get(k: string): infer R } ? R : "no";
+            let v: GetRet<Map<string, number>> = null;
+            """;
+        TestHarness.RunInterpreted(source);
+    }
+
+    [Fact]
+    public void Set_Has_InferBindsBoolean()
+    {
+        // Set<number>.has(e): boolean — a boolean is valid for the true branch only.
+        var source = """
+            type HasRet<T> = T extends { has(e: number): infer R } ? R : "no";
+            let b: HasRet<Set<number>> = true;
+            """;
+        TestHarness.RunInterpreted(source);
+    }
+
+    [Fact]
+    public void Promise_Then_PresenceTakesTrueBranch()
+    {
+        // The extends clause only checks for the presence of `then`; Promise has it, so the
+        // conditional takes its true branch ("yes"). Before the fix it fell through to "no".
+        var source = """
+            type HasThen<T> = T extends { then: infer _R } ? "yes" : "no";
+            let y: HasThen<Promise<number>> = "yes";
+            """;
+        TestHarness.RunInterpreted(source);
+    }
+
+    [Fact]
+    public void BuiltInRecord_AbsentMember_TakesFalseBranch()
+    {
+        // A member the built-in record does NOT have must still fail the match (false branch),
+        // so the resolver does not over-match. "no" is accepted; any other value is not.
+        var source = """
+            type N<T> = T extends { definitelyNotAMember(): infer R } ? R : "no";
+            let s: N<Date> = "no";
+            let bad: N<Date> = "other";
+            """;
+        var ex = Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+        Assert.Contains("\"no\"", ex.Message);
+    }
+}

--- a/TypeSystem/TypeChecker.Generics.Conditional.cs
+++ b/TypeSystem/TypeChecker.Generics.Conditional.cs
@@ -1,4 +1,5 @@
 using SharpTS.TypeSystem.Exceptions;
+using SharpTS.Runtime.BuiltIns;
 using System.Collections.Frozen;
 
 namespace SharpTS.TypeSystem;
@@ -629,8 +630,9 @@ public partial class TypeChecker
             foreach (var (key, extendsFieldType) in extendsRec.Fields)
             {
                 if (!checkProps.TryGetValue(key, out var checkFieldType))
-                    return false;
-                if (!CheckExtendsRecursive(checkFieldType, extendsFieldType, inferredTypes))
+                    checkFieldType = ResolveBuiltInRecordMember(checkType, key);
+                if (checkFieldType is null
+                    || !CheckExtendsRecursive(checkFieldType, extendsFieldType, inferredTypes))
                     return false;
             }
             return true;
@@ -655,8 +657,9 @@ public partial class TypeChecker
                     continue; // Optional members don't need to exist
 
                 if (!checkProps.TryGetValue(key, out var checkFieldType))
-                    return false;
-                if (!CheckExtendsRecursive(checkFieldType, extendsFieldType, inferredTypes))
+                    checkFieldType = ResolveBuiltInRecordMember(checkType, key);
+                if (checkFieldType is null
+                    || !CheckExtendsRecursive(checkFieldType, extendsFieldType, inferredTypes))
                     return false;
             }
             return true;
@@ -672,6 +675,32 @@ public partial class TypeChecker
         // Fall back to standard compatibility check (no infer patterns)
         return IsCompatible(extendsType, checkType);
     }
+
+    /// <summary>
+    /// Resolves the type of a single instance member on a dedicated built-in type record
+    /// (Date/RegExp/Map/Set/Promise and the weak/iterator variants) for conditional-type infer
+    /// matching — e.g. so <c>T extends { toJSON(): infer R }</c> can see <c>Date.toJSON: () =&gt; string</c>
+    /// (#491). Delegates to the same <see cref="BuiltInTypes"/> model that ordinary <c>value.member</c>
+    /// reads use, so both agree on one source of truth. Returns null when <paramref name="checkType"/>
+    /// is not such a record or the member is absent — the infer match then fails (false branch), exactly
+    /// as the previous empty-dictionary lookup did.
+    /// </summary>
+    private static TypeInfo? ResolveBuiltInRecordMember(TypeInfo checkType, string memberName) => checkType switch
+    {
+        TypeInfo.Date => BuiltInTypes.GetDateInstanceMemberType(memberName),
+        TypeInfo.RegExp => BuiltInTypes.GetRegExpMemberType(memberName),
+        TypeInfo.Map m => BuiltInTypes.GetMapMemberType(memberName, m.KeyType, m.ValueType),
+        TypeInfo.Set s => BuiltInTypes.GetSetMemberType(memberName, s.ElementType),
+        TypeInfo.WeakMap wm => BuiltInTypes.GetWeakMapMemberType(memberName, wm.KeyType, wm.ValueType),
+        TypeInfo.WeakSet ws => BuiltInTypes.GetWeakSetMemberType(memberName, ws.ElementType),
+        TypeInfo.WeakRef wr => BuiltInTypes.GetWeakRefMemberType(memberName, wr.TargetType),
+        TypeInfo.FinalizationRegistry fr => BuiltInTypes.GetFinalizationRegistryMemberType(memberName, fr.TargetType),
+        TypeInfo.Promise p => BuiltInTypes.GetPromiseMemberType(memberName, p.ValueType),
+        TypeInfo.Iterator it => BuiltInTypes.GetIteratorMemberType(memberName, it.ElementType),
+        TypeInfo.Generator g => BuiltInTypes.GetIteratorMemberType(memberName, g.YieldType),
+        TypeInfo.AsyncGenerator ag => BuiltInTypes.GetIteratorMemberType(memberName, ag.YieldType),
+        _ => null
+    };
 
     /// <summary>
     /// True when the type still contains type variables (type parameters, infer placeholders,


### PR DESCRIPTION
## What

Conditional-type `infer` matching against a **built-in type record** silently took the false branch:

```ts
type J<T> = T extends { toJSON(): infer R } ? R : "no";
type D = J<Date>;   // was "no"; now string  (Date.prototype.toJSON: () => string)
```

The property source for the `Record`/`Interface` extends branches of `CheckExtendsRecursive` (`ExtractPropertiesWithTypes`) has **no case for the dedicated built-in records** (Date/RegExp/Map/Set/Promise and the weak/iterator variants), so the extends-side member was never found and the match failed.

## How

- **Per-key fallback.** A new `ResolveBuiltInRecordMember(checkType, key)` resolves the extends-side member against the existing `BuiltInTypes` model — *the same source of truth ordinary `value.member` reads use*. The issue's premise that "there are no type-level signatures for these built-ins" was outdated: the signatures already live in `Runtime/BuiltIns/BuiltInTypes.cs` (`GetDateInstanceMemberType`/`GetMapMemberType`/…); they just weren't consulted here. Resolved lazily per key → no member enumeration, no leakage into `keyof`/mapped-type key domains.
- **`Date.prototype.toJSON`.** The repro needs `Date.toJSON: () => string`, modeled at *neither* the type nor runtime layer. Added across all three: type (`BuiltInTypes.GetDateInstanceMemberType`), interpreter (`DateBuiltIns`), and compiled (`DateEmitter` + new `RuntimeEmitter.Date.EmitDateToJSON`, returning the ISO string or `null` for an Invalid date). Emitted IL passes ILVerify.

## Scope & relation to #461/#492/PR #511

This is deliberately scoped to **built-in records**. Class-instance methods (#461) and inherited members (#492) in infer matching are handled by the in-flight **#511**. The two are orthogonal and **compose**: built-in records have no structural members, so #511's `ExtractInferMatchProperties` falls through to the same per-key fallback added here. The only overlap is the call-site line (`ExtractPropertiesWithTypes` vs `ExtractInferMatchProperties`) — a trivial merge whichever lands second.

## Tests

- New `InferMatchBuiltInMemberTests` (8): Date/RegExp/Map/Set/Promise members, an already-modeled member, and an absent-member→false-branch guard.
- `Date.toJSON` runtime tests (both modes): valid date → ISO string; Invalid date → `null`.
- Full suite green (**11568**); TypeScript conformance unchanged (**31/31**).

## Conformance note

The 2 sampled Test262 failures (`Array.prototype.filter/some` with `instanceof String`) **reproduce byte-identically on `origin/main` without this change** — pre-existing flakiness rooted in #454 (primitive `this` not ToObject-boxed), not introduced here. Verified by stashing and re-running on clean base.

## Follow-ups

- Filed #516 — fuller `Date` prototype still unmodeled (UTC getters/setters, `toUTCString`, `toLocale*`).
- Unblocks #462 (the `=>`-scan string-scanner companion fix).

Closes #491.