### PR TITLE
Fix #462: string type resolver mis-scans `=>` as a closing bracket

### DIFF
--- a/SharpTS.Tests/TypeCheckerTests/StringTypeResolverArrowScanTests.cs
+++ b/SharpTS.Tests/TypeCheckerTests/StringTypeResolverArrowScanTests.cs
@@ -1,0 +1,132 @@
+using SharpTS.Tests.Infrastructure;
+using SharpTS.TypeSystem.Exceptions;
+using Xunit;
+
+namespace SharpTS.Tests.TypeCheckerTests;
+
+/// <summary>
+/// The string-based type resolver (<c>TypeChecker.TypeParsing.cs</c>) tracks bracket-nesting depth
+/// to find top-level operators. Several scanners treated <b>every</b> <c>&gt;</c> as a closing
+/// bracket — including the <c>&gt;</c> of an arrow <c>=&gt;</c>, which has no matching <c>&lt;</c> —
+/// so a single function type in a string-resolved composite drove the depth negative and subsequent
+/// top-level tokens were missed (#462). The fix applies the established <c>=&gt;</c> guard
+/// (<c>i == 0 || s[i - 1] != '='</c>) to the six previously-unguarded scanners
+/// (<c>SplitTupleElements</c>, <c>TryParseIndexedAccessType</c>, <c>FindTopLevelKeyword</c>,
+/// <c>FindTopLevelChar</c>, <c>FindConditionalElseColon</c>, <c>FindTopLevelAs</c>), matching the
+/// sibling scanners that already guarded it.
+/// </summary>
+public class StringTypeResolverArrowScanTests
+{
+    // ---- SplitTupleElements: a tuple element that is itself a function type ----
+
+    [Fact]
+    public void TupleWithFunctionElement_RejectsNonFunction()
+    {
+        // Without the guard, the ',' separating the two elements is read at negative depth (the '>'
+        // of '() => number' having consumed a phantom bracket), so the tuple is mis-split and
+        // element 0's function type is lost — a string is then wrongly accepted in slot 0.
+        var source = """
+            type Pair = [() => number, string];
+            const bad: Pair = ["notfn", "x"];
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void TupleWithFunctionElement_AcceptsMatchingTuple()
+    {
+        var source = """
+            type Pair = [() => number, string];
+            const ok: Pair = [() => 1, "x"];
+            """;
+        TestHarness.RunInterpreted(source);
+    }
+
+    // ---- TryParseIndexedAccessType: indexing an inline object whose member is a function type ----
+
+    [Fact]
+    public void IndexedAccessIntoArrowMember_ResolvesToFunctionType()
+    {
+        // `{ a: () => number }["a"]` is `() => number`; the arrow inside the object previously drove
+        // the index-bracket scan negative so the `["a"]` was never found and the whole type garbled
+        // to something a bare number satisfied.
+        var source = """
+            type X = { a: () => number }["a"];
+            const bad: X = 5;
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void IndexedAccessIntoArrowMember_AcceptsFunction()
+    {
+        var source = """
+            type X = { a: () => number }["a"];
+            const ok: X = () => 1;
+            """;
+        TestHarness.RunInterpreted(source);
+    }
+
+    // ---- conditional detection over a function-typed extends clause, via the string path ----
+    // A generic alias instantiation expands through string substitution (TypeChecker.Generics.cs),
+    // forcing the conditional through FindTopLevelKeyword(" extends ") / FindTopLevelChar('?') /
+    // FindConditionalElseColon(':'). A top-level `=> ` in the check or extends type used to hide the
+    // `extends`/`?`/`:` from those scans, so the conditional was not recognized and collapsed to `any`.
+
+    [Fact]
+    public void ConditionalFunctionExtends_StringPath_InfersReturnType()
+    {
+        // Ret<() => string> resolves to string; returning a number violates it.
+        var source = """
+            type Ret<T> = T extends () => infer U ? U : "no";
+            function f(): Ret<() => string> { return 42; }
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void ConditionalFunctionExtends_StringPath_AcceptsInferredReturn()
+    {
+        var source = """
+            type Ret<T> = T extends () => infer U ? U : "no";
+            function f(): Ret<() => string> { return "hello"; }
+            """;
+        TestHarness.RunInterpreted(source);
+    }
+
+    [Fact]
+    public void ConditionalFunctionExtends_NonFunction_TakesFalseBranch()
+    {
+        // `string` is not callable, so U never binds and the conditional resolves to its false
+        // branch ("no"); a number return violates that literal.
+        var source = """
+            type Ret<T> = T extends () => infer U ? U : "no";
+            function f(): Ret<string> { return 42; }
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void NestedConditionalWithArrows_SelectsOuterElseBranch()
+    {
+        // The nested conditional in the true branch contributes its own '?'/':' pair; the outer
+        // else-colon scan (FindConditionalElseColon) must stay ternary-depth aware AND skip the
+        // arrow's '>'. Ret<() => number> -> A=number -> (number extends string ? ...) is false ->
+        // "other"; returning "s" (the inner THEN literal) must be rejected.
+        var source = """
+            type Ret<T> = T extends () => infer A ? (A extends string ? "s" : "other") : "no";
+            function f(): Ret<() => number> { return "s"; }
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void NestedConditionalWithArrows_AcceptsSelectedBranch()
+    {
+        var source = """
+            type Ret<T> = T extends () => infer A ? (A extends string ? "s" : "other") : "no";
+            function f(): Ret<() => number> { return "other"; }
+            """;
+        TestHarness.RunInterpreted(source);
+    }
+}

--- a/TypeSystem/TypeChecker.TypeParsing.cs
+++ b/TypeSystem/TypeChecker.TypeParsing.cs
@@ -249,9 +249,14 @@ public partial class TypeChecker
             return ParseInlineObjectTypeInfo(typeName);
         }
 
-        // Check for function type syntax: "(params) => returnType"
-        // Must check BEFORE parenthesized types since both start with "("
-        if (typeName.Contains("=>"))
+        // Check for function type syntax: "(params) => returnType". The arrow must be at the TOP
+        // level — a nested arrow belongs to a composite that the branches below own: a function-typed
+        // tuple element ("[() => number, string]"), an indexed-access member
+        // ("{ a: () => number }[\"a\"]"), or a parenthesized "(() => number)". A bare Contains("=>")
+        // here misroutes those into ParseFunctionTypeInfo, which finds no top-level arrow and collapses
+        // them to `any` (#462). Contains is a cheap pre-filter before the O(n) FindOutermostArrow scan.
+        // Must check BEFORE parenthesized types since both start with "(".
+        if (typeName.Contains("=>") && FindOutermostArrow(typeName) >= 0)
         {
             return ParseFunctionTypeInfo(typeName);
         }
@@ -966,7 +971,7 @@ public partial class TypeChecker
         {
             char c = inner[i];
             if (c == '(' || c == '[' || c == '<') depth++;
-            else if (c == ')' || c == ']' || c == '>') depth--;
+            else if (c == ')' || c == ']' || (c == '>' && (i == 0 || inner[i - 1] != '='))) depth--;  // Skip > in =>
             else if (c == ',' && depth == 0)
             {
                 ReadOnlySpan<char> segment = inner[start..i];
@@ -1256,7 +1261,7 @@ public partial class TypeChecker
         {
             char c = typeName[i];
             if (c == '<' || c == '(' || c == '{') depth++;
-            else if (c == '>' || c == ')' || c == '}') depth--;
+            else if (c == ')' || c == '}' || (c == '>' && (i == 0 || typeName[i - 1] != '='))) depth--;  // Skip > in =>
             else if (c == '[' && depth == 0)
             {
                 // Empty `[]` is an array suffix, part of the base type — keep scanning.
@@ -1499,7 +1504,7 @@ public partial class TypeChecker
         {
             char c = str[i];
             if (c == '<' || c == '(' || c == '[' || c == '{') depth++;
-            else if (c == '>' || c == ')' || c == ']' || c == '}') depth--;
+            else if (c == ')' || c == ']' || c == '}' || (c == '>' && (i == 0 || str[i - 1] != '='))) depth--;  // Skip > in =>
             else if (depth == 0 && str.Substring(i, 4) == " as " &&
                      (i + 4 >= str.Length || !char.IsLetterOrDigit(str[i + 4])))
             {
@@ -1598,7 +1603,7 @@ public partial class TypeChecker
         {
             char c = str[i];
             if (c == '<' || c == '(' || c == '[' || c == '{') depth++;
-            else if (c == '>' || c == ')' || c == ']' || c == '}') depth--;
+            else if (c == ')' || c == ']' || c == '}' || (c == '>' && (i == 0 || str[i - 1] != '='))) depth--;  // Skip > in =>
             else if (depth == 0 && str.Substring(i, keyword.Length) == keyword)
             {
                 return i;
@@ -1620,7 +1625,7 @@ public partial class TypeChecker
         {
             char c = str[i];
             if (c == '<' || c == '(' || c == '[' || c == '{') depth++;
-            else if (c == '>' || c == ')' || c == ']' || c == '}') depth--;
+            else if (c == ')' || c == ']' || c == '}' || (c == '>' && (i == 0 || str[i - 1] != '='))) depth--;  // Skip > in =>
             else if (depth == 0 && c == '?') ternaryDepth++;
             else if (depth == 0 && c == ':')
             {
@@ -1642,7 +1647,7 @@ public partial class TypeChecker
         {
             char c = str[i];
             if (c == '<' || c == '(' || c == '[' || c == '{') depth++;
-            else if (c == '>' || c == ')' || c == ']' || c == '}') depth--;
+            else if (c == ')' || c == ']' || c == '}' || (c == '>' && (i == 0 || str[i - 1] != '='))) depth--;  // Skip > in =>
             else if (depth == 0 && c == target)
             {
                 return i;


### PR DESCRIPTION
Closes #462.

> Rescoped: this PR originally also carried #461 + the Date/built-in infer-match work, but the maintainer merged independent fixes for #461 (`11d67ae7`) and #491 (`fc47c919`, Date.toJSON + built-in infer-match) to `main` in the meantime. Those changes are dropped here; this PR is now **just the scanner fix**, rebased onto current `main`.

## The bug

The string-based type resolver's depth-scans treated every `>` as a closing bracket, including the `>` of an arrow `=>` (which has no matching `<`), driving the bracket depth negative so subsequent top-level tokens were missed.

```ts
type Pair = [() => number, string];
const bad: Pair = ["notfn", "x"];        // was wrongly accepted

type X = { a: () => number }["a"];
const bad2: X = 5;                       // was wrongly accepted
```

## The fix

- Applied the established `=>` guard (`i == 0 || s[i-1] != '='`) to the **six** previously-unguarded scanners (`SplitTupleElements`, `TryParseIndexedAccessType`, `FindTopLevelKeyword`, `FindTopLevelChar`, `FindConditionalElseColon`, `FindTopLevelAs`), so the file's scanners agree with the five siblings that already guarded it.
- **Plus a prior dispatch bug** the issue didn't mention: the scanner fix alone did not make the tuple/indexed repros above pass. `ToTypeInfoCore` matched a bare `typeName.Contains("=>")` and routed any composite with a *nested* arrow into `ParseFunctionTypeInfo`, which found no top-level arrow and collapsed it to `any`. Fixed by requiring a **top-level** arrow (`Contains("=>") && FindOutermostArrow(...) >= 0`).

## Verification

- New tests in `StringTypeResolverArrowScanTests` cover the tuple, indexed-access, and conditional-detection scanners (the latter compose with main's #461/#491 infer-match).
- Full unit suite green (one live-network DNS test flaked and passes on retry — unrelated).
- TypeScript conformance: no baseline drift.

## Follow-up

- #510 — a **seventh** `=>`-mis-scan scanner (`TryParseGenericFunctionTypeInfo`) not in #462's enumerated six: `<T extends () => number>(x: T) => T` garbles to `any`.