### PR TITLE
Fix #482: FinalizationRegistry.register signature (target first, heldValue: T second)

### DIFF
--- a/Runtime/BuiltIns/BuiltInTypes.cs
+++ b/Runtime/BuiltIns/BuiltInTypes.cs
@@ -559,14 +559,22 @@ public static class BuiltInTypes
     }
 
     /// <summary>
-    /// FinalizationRegistry has register() and unregister() methods.
+    /// FinalizationRegistry has register() and unregister() methods. <paramref name="targetType"/> is
+    /// the registry's element type T (the held value), not the GC target.
     /// </summary>
     public static TypeInfo? GetFinalizationRegistryMemberType(string name, TypeInfo targetType)
     {
         return name switch
         {
-            "register" => new TypeInfo.Function([targetType, new TypeInfo.Any(), new TypeInfo.Any()],
-                new TypeInfo.Undefined(), RequiredParams: 1),
+            // register(target: WeakKey, heldValue: T, unregisterToken?: WeakKey): void
+            // The GC target and unregister token are objects (modelled as `object` so a primitive is
+            // rejected at compile time, matching the runtime's "target must be an object" check); the
+            // SECOND parameter carries the registry's element type T. target and heldValue are required,
+            // the token optional. Before #456 the FinalizationRegistry<T> annotation degraded to `any`
+            // so this signature was unobserved, and T was mis-placed at parameter 0 — meaning no call
+            // satisfied both the checker and the runtime for a typed registry (#482).
+            "register" => new TypeInfo.Function([new TypeInfo.Object(), targetType, new TypeInfo.Object()],
+                new TypeInfo.Undefined(), RequiredParams: 2),
             "unregister" => new TypeInfo.Function([new TypeInfo.Any()],
                 new TypeInfo.Primitive(Parsing.TokenType.TYPE_BOOLEAN)),
             _ => null

--- a/SharpTS.Tests/TypeCheckerTests/DedicatedContainerTypeReferenceTests.cs
+++ b/SharpTS.Tests/TypeCheckerTests/DedicatedContainerTypeReferenceTests.cs
@@ -218,17 +218,59 @@ public class DedicatedContainerTypeReferenceTests
     [Fact]
     public void FinalizationRegistry_RealMembersResolve()
     {
-        // The strongly-typed registry still exposes register/unregister (i.e. resolution did not turn
-        // the type into something memberless). Kept in an UNCALLED function so only the type checker
-        // runs: the runtime register() target validation is orthogonal to #456, and its type-checker
-        // signature is independently imprecise (see the filed follow-up).
+        // The strongly-typed registry exposes register/unregister with the spec signature
+        // register(target: WeakKey, heldValue: T, unregisterToken?: WeakKey): the FIRST argument is the
+        // GC target (an object) and the SECOND is the held value of type T (#482, which corrected the
+        // earlier signature that mis-modelled the held value as the first and only required parameter).
+        // Kept in an UNCALLED function so only the type checker runs.
         var source = """
             function use(fr: FinalizationRegistry<string>): void {
-              fr.register("held");
-              fr.unregister("token");
+              const target = { id: 1 };
+              fr.register(target, "held");
+              fr.register(target, "held", target);
+              fr.unregister(target);
             }
             """;
         TestHarness.RunInterpreted(source);
+    }
+
+    [Fact]
+    public void FinalizationRegistry_Register_MissingHeldValue_Rejected()
+    {
+        // register requires BOTH target and heldValue, so a single argument no longer type-checks.
+        // Under the old signature `register("held")` type-checked (held value as the sole required
+        // param) but threw "target must be an object" at runtime — no call satisfied both (#482).
+        var source = """
+            function use(fr: FinalizationRegistry<string>): void {
+              fr.register("held");
+            }
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void FinalizationRegistry_Register_WrongHeldValueType_Rejected()
+    {
+        // The held value (second argument) must be T; a number is not a string.
+        var source = """
+            function use(fr: FinalizationRegistry<string>): void {
+              fr.register({ id: 1 }, 42);
+            }
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void FinalizationRegistry_Register_PrimitiveTarget_Rejected()
+    {
+        // The target must be an object (WeakKey); a primitive is rejected at compile time, matching the
+        // runtime's "target must be an object" validation.
+        var source = """
+            function use(fr: FinalizationRegistry<string>): void {
+              fr.register("not-an-object", "held");
+            }
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
     }
 
     [Fact]


### PR DESCRIPTION
Closes #482.

`GetFinalizationRegistryMemberType` modeled `register` as `(heldValue: T, any, any) => void` with `RequiredParams: 1` — treating the **first** parameter as the held value. The spec and the SharpTS runtime (`SharpTSFinalizationRegistry.Register`, which validates `target` is an object) take:

```ts
register(target: WeakKey, heldValue: T, unregisterToken?: WeakKey): void;
```

The mismatch was unobservable until #456 / #484 made `FinalizationRegistry<T>` annotations resolve from a type reference. Once typed, **no call shape satisfied both the checker and the runtime**:

```ts
let fr: FinalizationRegistry<string> = new FinalizationRegistry((v: string) => {});
fr.register("held");        // type-checked, but RUNTIME error "target must be an object"
fr.register(obj, "held");   // the correct call — FAILED type-checking (obj vs held type T)
```

### Fix
Signature → `[object, T, object]`, `RequiredParams: 2`:
- **target** (param 0) and **unregisterToken** (param 2) are `object` — a primitive target is now rejected at compile time, matching the runtime validation (the `IsCompatible` `object` arm accepts every non-primitive: records, arrays, instances, functions, …).
- **heldValue** (param 1) carries the element type `T`.
- `unregister` is unchanged.

Updated `FinalizationRegistry_RealMembersResolve` (it deliberately asserted the old buggy `register("held")` shape, deferring to this follow-up) and added coverage for missing-held-value, wrong-held-type, and primitive-target rejections.

### Validation
- Full suite **11692/11692**
- TypeScript conformance **31/31** (baseline unchanged)
- Existing runtime `FinalizationRegistryTests` (which use `register(obj, …)`) unaffected

Surfaced while implementing #456 (resolved concurrently by #484); this is the one piece #484 left open.