### PR TITLE
Fix #515: throw TypeError on re-entrant generator next()/return()/throw() instead of deadlocking

### DIFF
--- a/Runtime/Types/SharpTSGenerator.cs
+++ b/Runtime/Types/SharpTSGenerator.cs
@@ -69,6 +69,23 @@ public class SharpTSGenerator : IEnumerable<object?>, IDisposable, ITypeCategori
     }
 
     /// <summary>
+    /// Rejects a re-entrant resume. ECMA-262 §27.5.3.3 (GeneratorValidate) requires
+    /// <c>next</c>/<c>return</c>/<c>throw</c> on a generator whose state is <c>executing</c> to
+    /// throw a <c>TypeError</c>. The only way a guest call observes <see cref="State.Running"/>
+    /// is re-entrancy — the body advancing itself — because a non-re-entrant caller is blocked in
+    /// <see cref="AwaitWorker"/> for the whole running window. Without this guard the re-entrant
+    /// call (which runs on the worker thread) would signal the worker to resume itself and then
+    /// wait on the same worker-ready event, deadlocking both threads (#515). Checked before the
+    /// started/completed branches, matching the spec (executing is rejected before completed is
+    /// observed).
+    /// </summary>
+    private void ThrowIfExecuting()
+    {
+        if (_state == State.Running)
+            throw new ThrowException(new SharpTSTypeError("Generator is already running"));
+    }
+
+    /// <summary>
     /// Advances the generator to the next yield point, resuming the suspended
     /// <c>yield</c> with <c>undefined</c> (the implicit value for for...of,
     /// yield* delegation, and a bare <c>next()</c>).
@@ -85,6 +102,8 @@ public class SharpTSGenerator : IEnumerable<object?>, IDisposable, ITypeCategori
     /// </param>
     public SharpTSIteratorResult Next(object? sentValue)
     {
+        ThrowIfExecuting();
+
         // A finished or disposed generator yields nothing more. The completion value is
         // delivered exactly once (when the body finishes); later next() calls report
         // undefined (ECMA-262 §27.5.3.3 → CreateIterResultObject(undefined, true)).
@@ -122,6 +141,8 @@ public class SharpTSGenerator : IEnumerable<object?>, IDisposable, ITypeCategori
     /// </summary>
     public SharpTSIteratorResult Return(object? value = null)
     {
+        ThrowIfExecuting();
+
         // Never started: close without running the body — there is no finally to run.
         if (_state == State.NotStarted)
         {
@@ -152,6 +173,8 @@ public class SharpTSGenerator : IEnumerable<object?>, IDisposable, ITypeCategori
     /// </summary>
     public SharpTSIteratorResult Throw(object? error = null)
     {
+        ThrowIfExecuting();
+
         // Never started or already finished/disposed: nothing to resume — just throw.
         if (_state == State.NotStarted || _closed || _state == State.Completed)
         {
@@ -411,6 +434,17 @@ public class SharpTSArrowGenerator : IEnumerable<object?>, IDisposable
         _interpreter = interpreter;
     }
 
+    /// <summary>
+    /// Rejects a re-entrant resume with a <c>TypeError</c> (ECMA-262 §27.5.3.3). See
+    /// <see cref="SharpTSGenerator.ThrowIfExecuting"/> — observing <see cref="State.Running"/>
+    /// from a guest call means the body is advancing itself, which would otherwise deadlock (#515).
+    /// </summary>
+    private void ThrowIfExecuting()
+    {
+        if (_state == State.Running)
+            throw new ThrowException(new SharpTSTypeError("Generator is already running"));
+    }
+
     public SharpTSIteratorResult Next() => Next(SharpTSUndefined.Instance);
 
     /// <summary>
@@ -419,6 +453,8 @@ public class SharpTSArrowGenerator : IEnumerable<object?>, IDisposable
     /// </summary>
     public SharpTSIteratorResult Next(object? sentValue)
     {
+        ThrowIfExecuting();
+
         // A finished/disposed generator delivers undefined; the completion value is reported
         // only once, when the body finishes (ECMA-262 §27.5.3.3).
         if (_closed || _state == State.Completed)
@@ -449,6 +485,8 @@ public class SharpTSArrowGenerator : IEnumerable<object?>, IDisposable
     /// </summary>
     public SharpTSIteratorResult Return(object? value = null)
     {
+        ThrowIfExecuting();
+
         if (_state == State.NotStarted)
         {
             _state = State.Completed;
@@ -473,6 +511,8 @@ public class SharpTSArrowGenerator : IEnumerable<object?>, IDisposable
     /// </summary>
     public SharpTSIteratorResult Throw(object? error = null)
     {
+        ThrowIfExecuting();
+
         if (_state == State.NotStarted || _closed || _state == State.Completed)
         {
             _state = State.Completed;

--- a/SharpTS.Tests/SharedTests/GeneratorTests.cs
+++ b/SharpTS.Tests/SharedTests/GeneratorTests.cs
@@ -773,4 +773,144 @@ public class GeneratorTests
     }
 
     #endregion
+
+    #region Re-entrant next()/return()/throw() — "already running" (ECMA-262 §27.5.3.3) — issue #515
+
+    // ECMA-262 §27.5.3.3 (GeneratorValidate): calling next/return/throw on a generator whose state
+    // is `executing` throws a TypeError ("Generator is already running"). The only way to reach
+    // that state from a guest call is re-entrancy — the body advancing itself. Before the fix the
+    // interpreter's thread-coroutine deadlocked (the re-entrant call ran on the worker thread and
+    // waited on the same worker-ready signal it would have to set). These are InterpretedOnly: the
+    // compiled state-machine path doesn't hang but currently surfaces the wrong error (tracked by a
+    // separate issue), so it can't share these assertions yet.
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void Generator_ReentrantNext_ThrowsTypeErrorThenResumes(ExecutionMode mode)
+    {
+        // The re-entrant next() throws a catchable TypeError; once caught, the generator is still
+        // suspended-able and resumes normally (the guard must not corrupt its running state).
+        var source = """
+            let it: any;
+            function* g() {
+                try { it.next(); }
+                catch (e: any) { console.log(e instanceof TypeError, e.name, e.message); }
+                yield 1;
+            }
+            it = g();
+            const r = it.next();
+            console.log(r.value, r.done);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("true TypeError Generator is already running\n1 false\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void Generator_ReentrantNext_UncaughtPropagatesToResumingCaller(ExecutionMode mode)
+    {
+        // An uncaught re-entrant next() completes the generator abnormally and the TypeError
+        // surfaces to the outer next() that resumed it — matching Node's uncaught behavior.
+        var source = """
+            let it: any;
+            function* g() { it.next(); yield 1; }
+            it = g();
+            try { it.next(); }
+            catch (e: any) { console.log("outer caught", e.message); }
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("outer caught Generator is already running\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void Generator_ReentrantReturn_ThrowsTypeErrorThenResumes(ExecutionMode mode)
+    {
+        var source = """
+            let it: any;
+            function* g() {
+                try { it.return(0); }
+                catch (e: any) { console.log("return ->", e.message); }
+                yield 1;
+            }
+            it = g();
+            const r = it.next();
+            console.log(r.value, r.done);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("return -> Generator is already running\n1 false\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void Generator_ReentrantThrow_ThrowsTypeErrorThenResumes(ExecutionMode mode)
+    {
+        // The "already running" guard takes precedence over the injected throw(e): the caller's
+        // error never reaches the body — it gets a TypeError instead.
+        var source = """
+            let it: any;
+            function* g() {
+                try { it.throw("boom"); }
+                catch (e: any) { console.log("throw ->", e.message); }
+                yield 1;
+            }
+            it = g();
+            const r = it.next();
+            console.log(r.value, r.done);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("throw -> Generator is already running\n1 false\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void Generator_ReentrantThroughYieldStar_ThrowsTypeError(ExecutionMode mode)
+    {
+        // The outer generator is still `executing` while it delegates via yield*, so an inner
+        // generator that calls the outer's next() must observe "already running".
+        var source = """
+            let outer: any;
+            function* inner() {
+                try { outer.next(); }
+                catch (e: any) { console.log("deleg ->", e.message); }
+                yield 5;
+            }
+            function* g() { yield* inner(); }
+            outer = g();
+            const r = outer.next();
+            console.log(r.value, r.done);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("deleg -> Generator is already running\n5 false\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void GeneratorExpression_ReentrantNext_ThrowsTypeError(ExecutionMode mode)
+    {
+        // A generator function *expression* uses a distinct runtime class (SharpTSArrowGenerator);
+        // its guard is exercised here. `var` (not `let`) sidesteps an unrelated type-checker scoping
+        // bug for generator function expressions that close over block-scoped variables.
+        var source = """
+            var it: any;
+            const g = function*() {
+                try { it.next(); }
+                catch (e: any) { console.log("expr ->", e.message); }
+                yield 7;
+            };
+            it = g();
+            const r = it.next();
+            console.log(r.value, r.done);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("expr -> Generator is already running\n7 false\n", output);
+    }
+
+    #endregion
 }


### PR DESCRIPTION
## Summary

Fixes #515. Per ECMA-262 §27.5.3.3 (GeneratorValidate), calling `next()`/`return()`/`throw()` on a generator whose state is `executing` must throw `TypeError: Generator is already running`. The interpreter instead **deadlocked**: a re-entrant call (a generator advancing itself) runs on the generator's worker thread, so signaling the worker to resume and then waiting on the worker-ready event blocked both the worker and the original caller forever.

### Repro (from the issue)

```ts
let it: any;
function* g() { console.log("body start"); it.next(); yield 1; }
it = g();
it.next();   // before: prints "body start" then hangs forever
```

**Node:** throws `TypeError: Generator is already running`.
**SharpTS after this change:** same — prints `body start`, then the `TypeError` (catchable; uncaught it propagates to the resuming `next()` caller, matching Node).

## The fix

Add a `ThrowIfExecuting()` guard at the top of `Next`/`Return`/`Throw` in both `SharpTSGenerator` (function declarations & methods) and `SharpTSArrowGenerator` (function expressions). It throws when `_state == State.Running` — a state only observable **re-entrantly**, because a non-re-entrant caller is always blocked in `AwaitWorker` for the entire running window. So it is a no-op for all normal generator use, and is checked before the started/completed branches to match the spec's ordering (executing is rejected before completed is observed).

Handled cases (verified): plain `next()`, `return()`, `throw()`, re-entrancy through `yield*` delegation, and the function-expression generator class.

## Scope / mode parity

Tests are `InterpretedOnly`. The compiled state-machine path does **not** deadlock but currently surfaces the wrong error (`TypeError: undefined is not a function`) — filed as **#521** so those tests can be promoted to both modes once it's fixed. Async generators use a different (Task-based, request-queued) implementation per ECMA-262 §27.6 and are correctly unaffected.

## Tests

New `GeneratorTests` region "Re-entrant next()/return()/throw()" — 6 tests covering the throw, the catch-then-resume continuation, uncaught propagation, `yield*` re-entrancy, and the generator-expression class. The harness's 30s timeout means a regression (re-introduced hang) fails fast rather than hanging CI.

Full suite green: **11,695 passed, 0 failed**.

## Issues filed along the way

- **#521** — compiled re-entrant generator throws `undefined is not a function` instead of "already running" (companion compiled-mode gap).
- **#522** — type checker rejects generator function *expressions* that close over `let`/`const` outer variables (pre-existing; unrelated to this fix, hit while writing tests — worked around with `var`).