### PR TITLE
Fix #519: interp JSON.stringify(undefined) returns undefined, not null

### DIFF
--- a/Runtime/BuiltIns/JSONBuiltIns.cs
+++ b/Runtime/BuiltIns/JSONBuiltIns.cs
@@ -243,7 +243,13 @@ public static class JSONBuiltIns
             return RuntimeValue.FromString(sb.ToString());
         }
 
-        return RuntimeValue.Null;
+        // ECMA-262 25.5.2.1 step 12 returns whatever SerializeJSONProperty
+        // yields. A top-level value that serializes to nothing — undefined, a
+        // function, or a symbol — makes SerializeJSONProperty return the JS
+        // value `undefined` (steps 3, 9, 11), NOT null. `StringifyValue`
+        // signals that case by returning false, so surface `undefined` here.
+        // (Compiled mode does the same; see RuntimeEmitter.Json.Stringify.cs.)
+        return RuntimeValue.Undefined;
     }
 
     private static bool StringifyValue(Interpreter interp, object? value, object? key,

--- a/SharpTS.Test262/baselines/interpreted.txt
+++ b/SharpTS.Test262/baselines/interpreted.txt
@@ -3335,7 +3335,7 @@ test/built-ins/JSON/stringify/value-bigint-tojson-receiver.js Fail
 test/built-ins/JSON/stringify/value-bigint-tojson.js RuntimeError
 test/built-ins/JSON/stringify/value-bigint.js Fail
 test/built-ins/JSON/stringify/value-boolean-object.js Pass
-test/built-ins/JSON/stringify/value-function.js Fail
+test/built-ins/JSON/stringify/value-function.js Pass
 test/built-ins/JSON/stringify/value-number-negative-zero.js Pass
 test/built-ins/JSON/stringify/value-number-non-finite.js Pass
 test/built-ins/JSON/stringify/value-number-object.js RuntimeError
@@ -3343,11 +3343,11 @@ test/built-ins/JSON/stringify/value-object-abrupt.js Fail
 test/built-ins/JSON/stringify/value-object-circular.js Fail
 test/built-ins/JSON/stringify/value-object-proxy-revoked.js Fail
 test/built-ins/JSON/stringify/value-object-proxy.js Fail
-test/built-ins/JSON/stringify/value-primitive-top-level.js Fail
+test/built-ins/JSON/stringify/value-primitive-top-level.js Pass
 test/built-ins/JSON/stringify/value-string-escape-ascii.js Fail
 test/built-ins/JSON/stringify/value-string-escape-unicode.js Fail
 test/built-ins/JSON/stringify/value-string-object.js RuntimeError
-test/built-ins/JSON/stringify/value-symbol.js Fail
+test/built-ins/JSON/stringify/value-symbol.js Pass
 test/built-ins/JSON/stringify/value-tojson-abrupt.js Fail
 test/built-ins/JSON/stringify/value-tojson-arguments.js Fail
 test/built-ins/JSON/stringify/value-tojson-array-circular.js Fail

--- a/SharpTS.Tests/SharedTests/JSONTests.cs
+++ b/SharpTS.Tests/SharedTests/JSONTests.cs
@@ -182,6 +182,40 @@ public class JSONTests
 
     [Theory]
     [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void JSON_Stringify_Undefined_ReturnsUndefinedNotNull(ExecutionMode mode)
+    {
+        // ECMA-262 25.5.2.1 step 12: a top-level undefined makes
+        // SerializeJSONProperty return the JS value `undefined`, NOT null.
+        // Regression for #519 (interpreter previously coerced it to null).
+        // `typeof` distinguishes JS undefined ("undefined") from null
+        // ("object"), so this fails loudly if the old behavior returns.
+        var source = """
+            let r: any = JSON.stringify(undefined);
+            console.log(typeof r);
+            console.log(r);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("undefined\nundefined\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void JSON_Stringify_Function_ReturnsUndefined(ExecutionMode mode)
+    {
+        // ECMA-262 25.5.2.3 step 9: a top-level callable serializes to the JS
+        // value `undefined` (same root cause / fix as the undefined case).
+        var source = """
+            let r: any = JSON.stringify((): number => 1);
+            console.log(typeof r);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("undefined\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void JSON_Stringify_Object(ExecutionMode mode)
     {
         var source = """


### PR DESCRIPTION
## Summary

Closes #519. In **interpreter mode**, `JSON.stringify(undefined)` returned `null` instead of `undefined`. Per ECMA-262 §25.5.2.1 step 12, `JSON.stringify` returns whatever `SerializeJSONProperty` yields, and a top-level value that serializes to nothing — `undefined`, a function, or a symbol — makes `SerializeJSONProperty` return the JS value `undefined` (steps 3, 9, 11), not `null`. **Compiled mode was already correct.**

```ts
console.log("r", JSON.stringify(undefined));
// before: r null     after: r undefined   (matches Node + compiled mode)
```

## Fix

`StringifyJson` (`Runtime/BuiltIns/JSONBuiltIns.cs`) already detects the unserializable-top-level case — `StringifyValue` returns `false` — but coerced it to `RuntimeValue.Null`. Changed that single return to `RuntimeValue.Undefined`, mirroring the compiled emitter (`RuntimeEmitter.Json.Stringify.cs`, which maps the same case to `UndefinedInstance`). This also corrects the top-level function and symbol cases (same code path), matching the spec and Node.

Nested behavior is unchanged and already correct: an `undefined`/function property value is omitted from object output, and an array hole/undefined element serializes to `null`.

## Tests

- Added `JSON_Stringify_Undefined_ReturnsUndefinedNotNull` and `JSON_Stringify_Function_ReturnsUndefined` (both run in interpreter **and** compiled modes). They use `typeof` to distinguish JS `undefined` (`"undefined"`) from `null` (`"object"`), so the old behavior fails loudly.
- Full unit suite green: **11,693 passed, 0 failed**.

## Test262

This flips three interpreted-baseline entries from `Fail` → `Pass` (`value-function.js`, `value-primitive-top-level.js`, `value-symbol.js`); compiled already passed them. The baseline lines were updated **surgically** (verified each flips deterministically in isolation and in a full-folder run) rather than via full regen.

While verifying I found that several other `JSON/stringify` baseline entries (the `*-object`/boxed-primitive cluster) diverge from the committed baseline today — confirmed **identical before and after this change**, i.e. pre-existing staleness from #360 (boxed wrappers) not unwrapping in interpreter `JSON.stringify`. Filed as #524; left those baseline lines untouched here.