### PR TITLE
Fix #512: structurally decompose built-in object types (keyof + structural assignability)

### DIFF
--- a/Runtime/BuiltIns/BuiltInTypes.cs
+++ b/Runtime/BuiltIns/BuiltInTypes.cs
@@ -1065,4 +1065,105 @@ public static class BuiltInTypes
             _ => null
         };
     }
+
+    // ==================== APPARENT MEMBERS OF DECOMPOSABLE BUILT-INS (#512) ====================
+    //
+    // The dedicated built-in object types (Date, RegExp, Map, Set, the weak/iterator variants,
+    // Promise, …) model their instance members through the name-keyed GetXxxMemberType switches
+    // above. Those switches alone are not enumerable, so keyof, structural assignability, and
+    // conditional infer-matching could not treat these types structurally (a Date was not a
+    // `keyof`-able / `{ getTime(): number }`-assignable shape). The two methods below project a
+    // built-in TypeInfo onto its apparent members — a name list for keyof and a per-name type
+    // resolver for assignability/infer-matching — so all three consumers share one source of truth.
+    //
+    // The XxxMemberNames lists must stay in sync with the corresponding GetXxxMemberType switch:
+    // every listed name must resolve there (BuiltInApparentMembersTests asserts this), and a member
+    // added to a switch should be added to its list so keyof keeps seeing it.
+
+    private static readonly string[] DateInstanceMemberNames =
+    [
+        "getTime", "getFullYear", "getMonth", "getDate", "getDay", "getHours", "getMinutes",
+        "getSeconds", "getMilliseconds", "getTimezoneOffset",
+        "setTime", "setFullYear", "setMonth", "setDate", "setHours", "setMinutes", "setSeconds",
+        "setMilliseconds",
+        "toString", "toISOString", "toDateString", "toTimeString", "toJSON", "valueOf",
+    ];
+
+    private static readonly string[] RegExpMemberNames =
+    [
+        "source", "flags", "global", "ignoreCase", "multiline", "dotAll", "sticky", "unicode",
+        "unicodeSets", "hasIndices", "lastIndex", "test", "exec", "toString",
+    ];
+
+    private static readonly string[] MapMemberNames =
+        ["size", "get", "set", "has", "delete", "clear", "keys", "values", "entries", "forEach"];
+
+    private static readonly string[] SetMemberNames =
+    [
+        "size", "add", "has", "delete", "clear", "keys", "values", "entries", "forEach",
+        "union", "intersection", "difference", "symmetricDifference",
+        "isSubsetOf", "isSupersetOf", "isDisjointFrom",
+    ];
+
+    private static readonly string[] WeakMapMemberNames = ["get", "set", "has", "delete"];
+
+    private static readonly string[] WeakSetMemberNames = ["add", "has", "delete"];
+
+    private static readonly string[] WeakRefMemberNames = ["deref"];
+
+    private static readonly string[] FinalizationRegistryMemberNames = ["register", "unregister"];
+
+    private static readonly string[] PromiseMemberNames = ["then", "catch", "finally"];
+
+    private static readonly string[] IteratorMemberNames =
+    [
+        "next", "return", "throw", "map", "filter", "take", "drop", "flatMap", "reduce",
+        "toArray", "forEach", "some", "every", "find",
+    ];
+
+    /// <summary>
+    /// Resolves the type of a single instance member on a structurally-decomposable built-in object
+    /// type (Date/RegExp/Map/Set/Promise and the weak/iterator variants), or null when
+    /// <paramref name="type"/> is not such a type or the member is absent. Delegates to the same
+    /// per-type GetXxxMemberType resolvers that <c>value.member</c> reads use, so member access,
+    /// structural assignability, and conditional infer-matching agree on one model. The set of
+    /// handled types matches <see cref="GetInstanceMemberNames"/>.
+    /// </summary>
+    public static TypeInfo? GetInstanceMemberType(TypeInfo type, string name) => type switch
+    {
+        TypeInfo.Date => GetDateInstanceMemberType(name),
+        TypeInfo.RegExp => GetRegExpMemberType(name),
+        TypeInfo.Map m => GetMapMemberType(name, m.KeyType, m.ValueType),
+        TypeInfo.Set s => GetSetMemberType(name, s.ElementType),
+        TypeInfo.WeakMap wm => GetWeakMapMemberType(name, wm.KeyType, wm.ValueType),
+        TypeInfo.WeakSet ws => GetWeakSetMemberType(name, ws.ElementType),
+        TypeInfo.WeakRef wr => GetWeakRefMemberType(name, wr.TargetType),
+        TypeInfo.FinalizationRegistry fr => GetFinalizationRegistryMemberType(name, fr.TargetType),
+        TypeInfo.Promise p => GetPromiseMemberType(name, p.ValueType),
+        TypeInfo.Iterator it => GetIteratorMemberType(name, it.ElementType),
+        TypeInfo.Generator g => GetIteratorMemberType(name, g.YieldType),
+        TypeInfo.AsyncGenerator ag => GetIteratorMemberType(name, ag.YieldType),
+        _ => null
+    };
+
+    /// <summary>
+    /// Returns the apparent instance member names of a structurally-decomposable built-in object type
+    /// (the same set <see cref="GetInstanceMemberType"/> resolves), or null when <paramref name="type"/>
+    /// is not such a type. Used by keyof to surface a built-in's members as a key union. The names are
+    /// type-argument independent, so a single list serves every instantiation of a generic built-in.
+    /// </summary>
+    public static IReadOnlyList<string>? GetInstanceMemberNames(TypeInfo type) => type switch
+    {
+        TypeInfo.Date => DateInstanceMemberNames,
+        TypeInfo.RegExp => RegExpMemberNames,
+        TypeInfo.Map => MapMemberNames,
+        TypeInfo.Set => SetMemberNames,
+        TypeInfo.WeakMap => WeakMapMemberNames,
+        TypeInfo.WeakSet => WeakSetMemberNames,
+        TypeInfo.WeakRef => WeakRefMemberNames,
+        TypeInfo.FinalizationRegistry => FinalizationRegistryMemberNames,
+        TypeInfo.Promise => PromiseMemberNames,
+        TypeInfo.Iterator or TypeInfo.Generator or TypeInfo.AsyncGenerator => IteratorMemberNames,
+        _ => null
+    };
 }

--- a/SharpTS.Tests/SharedTests/BuiltInStructuralTypeTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInStructuralTypeTests.cs
@@ -1,0 +1,178 @@
+using SharpTS.Tests.Infrastructure;
+using SharpTS.TypeSystem.Exceptions;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests;
+
+/// <summary>
+/// Structural decomposition of dedicated built-in object types — Date, RegExp, Map, Set, Promise and
+/// the weak/iterator variants (#512). These types model their instance members through name-keyed
+/// resolvers in <c>BuiltInTypes</c>; before #512 those resolvers were not enumerable, so:
+/// <list type="bullet">
+///   <item><c>keyof Date</c> produced <c>never</c> (no member was a valid key); and</item>
+///   <item>a built-in instance was not assignable to a matching structural type
+///   (<c>const o: { getTime(): number } = new Date()</c> errored).</item>
+/// </list>
+/// A shared apparent-members projection (<c>BuiltInTypes.GetInstanceMemberNames</c> /
+/// <c>GetInstanceMemberType</c>) now backs keyof, structural assignability, and infer-matching, so
+/// these match <c>tsc</c>. keyof/assignability are type-check-time, so both execution modes exercise
+/// the same logic; running both also confirms the value executes after the check passes.
+/// </summary>
+public class BuiltInStructuralTypeTests
+{
+    // ----- keyof over built-ins -----
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void KeyOf_Date_AcceptsMemberName(ExecutionMode mode)
+    {
+        var source = """
+            const k: keyof Date = "getTime";
+            console.log(k);
+            """;
+        Assert.Equal("getTime\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void KeyOf_RegExp_AcceptsMemberName(ExecutionMode mode)
+    {
+        var source = """
+            const k: keyof RegExp = "source";
+            console.log(k);
+            """;
+        Assert.Equal("source\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void KeyOf_Map_AcceptsMemberName(ExecutionMode mode)
+    {
+        var source = """
+            const k: keyof Map<string, number> = "get";
+            console.log(k);
+            """;
+        Assert.Equal("get\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void KeyOf_Set_AcceptsMemberName(ExecutionMode mode)
+    {
+        var source = """
+            const k: keyof Set<number> = "add";
+            console.log(k);
+            """;
+        Assert.Equal("add\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void KeyOf_Promise_AcceptsMemberName(ExecutionMode mode)
+    {
+        var source = """
+            const k: keyof Promise<number> = "then";
+            console.log(k);
+            """;
+        Assert.Equal("then\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void KeyOf_Date_RejectsNonMember(ExecutionMode mode)
+    {
+        // keyof Date is the union of its members; a non-member literal must not be assignable.
+        var source = """
+            const k: keyof Date = "notAMember";
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.Run(source, mode));
+    }
+
+    // ----- structural assignability with a built-in source -----
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Structural_Date_AssignableToMatchingShape(ExecutionMode mode)
+    {
+        var source = """
+            const d = new Date();
+            const o: { getTime(): number } = d;
+            console.log(typeof o.getTime());
+            """;
+        Assert.Equal("number\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Structural_Map_AssignableToMatchingShape(ExecutionMode mode)
+    {
+        var source = """
+            const m = new Map<string, number>();
+            m.set("a", 1);
+            const o: { get(k: string): number | null; size: number } = m;
+            console.log(o.size);
+            """;
+        Assert.Equal("1\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Structural_RegExp_AssignableToMatchingShape(ExecutionMode mode)
+    {
+        var source = """
+            const re = /abc/g;
+            const o: { source: string; test(s: string): boolean } = re;
+            console.log(o.test("xabcy"));
+            """;
+        Assert.Equal("true\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Structural_Date_MissingMember_Rejected(ExecutionMode mode)
+    {
+        var source = """
+            const d = new Date();
+            const o: { bogusMember(): number } = d;
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Structural_Date_WrongMemberType_Rejected(ExecutionMode mode)
+    {
+        // getTime returns number, not string — width subtyping must still type-check member types.
+        var source = """
+            const d = new Date();
+            const o: { getTime(): string } = d;
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.Run(source, mode));
+    }
+
+    // ----- keyof feeding indexed access and mapped types over a built-in -----
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void IndexedAccess_OverBuiltIn_ResolvesMemberType(ExecutionMode mode)
+    {
+        var source = """
+            type GetTimeFn = Date["getTime"];
+            const f: GetTimeFn = new Date().getTime;
+            console.log(typeof f);
+            """;
+        Assert.Equal("function\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void MappedType_OverKeyOfBuiltIn_TypeChecks(ExecutionMode mode)
+    {
+        var source = """
+            type Flags = { [K in keyof Set<number>]: boolean };
+            const f = {} as Flags;
+            console.log(typeof f);
+            """;
+        Assert.Equal("object\n", TestHarness.Run(source, mode));
+    }
+}

--- a/SharpTS.Tests/TypeCheckerTests/BuiltInApparentMembersTests.cs
+++ b/SharpTS.Tests/TypeCheckerTests/BuiltInApparentMembersTests.cs
@@ -1,0 +1,87 @@
+using SharpTS.Runtime.BuiltIns;
+using SharpTS.TypeSystem;
+using Xunit;
+
+namespace SharpTS.Tests.TypeCheckerTests;
+
+/// <summary>
+/// Guards the shared apparent-members projection for decomposable built-in object types (#512):
+/// <see cref="BuiltInTypes.GetInstanceMemberNames"/> (used by keyof) and
+/// <see cref="BuiltInTypes.GetInstanceMemberType"/> (used by structural assignability and
+/// conditional infer-matching) must agree on one model. The two are authored from separate
+/// declarations (a name list and a name-keyed resolver switch), so this test pins them together:
+/// every advertised member name must resolve to a non-null type. Without this, a name added to one
+/// but not the other would make <c>keyof T</c> surface a key whose <c>T[K]</c> cannot be resolved.
+/// </summary>
+public class BuiltInApparentMembersTests
+{
+    private static readonly TypeInfo Any = new TypeInfo.Any();
+
+    /// <summary>Representative instances of every structurally-decomposable built-in type.</summary>
+    public static IEnumerable<object[]> DecomposableTypes()
+    {
+        yield return ["Date", new TypeInfo.Date()];
+        yield return ["RegExp", new TypeInfo.RegExp()];
+        yield return ["Map", new TypeInfo.Map(Any, Any)];
+        yield return ["Set", new TypeInfo.Set(Any)];
+        yield return ["WeakMap", new TypeInfo.WeakMap(Any, Any)];
+        yield return ["WeakSet", new TypeInfo.WeakSet(Any)];
+        yield return ["WeakRef", new TypeInfo.WeakRef(Any)];
+        yield return ["FinalizationRegistry", new TypeInfo.FinalizationRegistry(Any)];
+        yield return ["Promise", new TypeInfo.Promise(Any)];
+        yield return ["Iterator", new TypeInfo.Iterator(Any)];
+        yield return ["Generator", new TypeInfo.Generator(Any)];
+        yield return ["AsyncGenerator", new TypeInfo.AsyncGenerator(Any)];
+    }
+
+    [Theory]
+    [MemberData(nameof(DecomposableTypes))]
+    public void EveryAdvertisedMemberNameResolves(string label, TypeInfo type)
+    {
+        var names = BuiltInTypes.GetInstanceMemberNames(type);
+        Assert.NotNull(names);
+        Assert.NotEmpty(names);
+
+        foreach (var name in names)
+        {
+            Assert.True(
+                BuiltInTypes.GetInstanceMemberType(type, name) is not null,
+                $"keyof {label} advertises member '{name}' but GetInstanceMemberType could not resolve it. " +
+                $"The {label} member-name list and its GetXxxMemberType resolver have drifted apart.");
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(DecomposableTypes))]
+    public void AbsentMemberDoesNotResolve(string label, TypeInfo type)
+    {
+        // The resolver must not over-match: a name that is not a real member resolves to null, so an
+        // infer-match / structural check against it correctly fails.
+        Assert.Null(BuiltInTypes.GetInstanceMemberType(type, "definitelyNotARealMember"));
+        Assert.DoesNotContain("definitelyNotARealMember", BuiltInTypes.GetInstanceMemberNames(type)!);
+    }
+
+    [Fact]
+    public void IteratorVariantsShareOneMemberList()
+    {
+        // Iterator/Generator/AsyncGenerator all project through GetIteratorMemberType, so they expose
+        // the identical apparent-member set.
+        var iterator = BuiltInTypes.GetInstanceMemberNames(new TypeInfo.Iterator(Any));
+        var generator = BuiltInTypes.GetInstanceMemberNames(new TypeInfo.Generator(Any));
+        var asyncGenerator = BuiltInTypes.GetInstanceMemberNames(new TypeInfo.AsyncGenerator(Any));
+
+        Assert.Equal(iterator, generator);
+        Assert.Equal(iterator, asyncGenerator);
+    }
+
+    [Fact]
+    public void NonDecomposableTypesReturnNull()
+    {
+        // Types without a dedicated apparent-members model are not decomposable here; keyof/assignability
+        // handle them through their own paths (records, interfaces, classes, string/array index sigs).
+        Assert.Null(BuiltInTypes.GetInstanceMemberNames(new TypeInfo.String()));
+        Assert.Null(BuiltInTypes.GetInstanceMemberNames(new TypeInfo.Array(Any)));
+        Assert.Null(BuiltInTypes.GetInstanceMemberNames(Any));
+        Assert.Null(BuiltInTypes.GetInstanceMemberType(new TypeInfo.String(), "length"));
+    }
+}

--- a/TypeSystem/TypeChecker.Compatibility.Structural.cs
+++ b/TypeSystem/TypeChecker.Compatibility.Structural.cs
@@ -15,7 +15,12 @@ public partial class TypeChecker
     {
         foreach (var member in requiredMembers)
         {
-            TypeInfo? actualMemberType = GetMemberType(actual, member.Key);
+            // GetMemberType resolves members for object-like and primitive-wrapper sources (records,
+            // interfaces, classes, string/array/tuple). A structurally-decomposable built-in object
+            // type (Date, RegExp, Map, Set, …) carries its members in BuiltInTypes' per-type model,
+            // so fall back to that — letting a `Date` satisfy `{ getTime(): number }` etc. (#512).
+            TypeInfo? actualMemberType = GetMemberType(actual, member.Key)
+                ?? BuiltInTypes.GetInstanceMemberType(actual, member.Key);
 
             // If member is optional and not present, that's OK
             if (actualMemberType == null && (optionalMembers?.Contains(member.Key) ?? false))

--- a/TypeSystem/TypeChecker.Generics.Conditional.cs
+++ b/TypeSystem/TypeChecker.Generics.Conditional.cs
@@ -680,27 +680,13 @@ public partial class TypeChecker
     /// Resolves the type of a single instance member on a dedicated built-in type record
     /// (Date/RegExp/Map/Set/Promise and the weak/iterator variants) for conditional-type infer
     /// matching — e.g. so <c>T extends { toJSON(): infer R }</c> can see <c>Date.toJSON: () =&gt; string</c>
-    /// (#491). Delegates to the same <see cref="BuiltInTypes"/> model that ordinary <c>value.member</c>
-    /// reads use, so both agree on one source of truth. Returns null when <paramref name="checkType"/>
-    /// is not such a record or the member is absent — the infer match then fails (false branch), exactly
-    /// as the previous empty-dictionary lookup did.
+    /// (#491). Delegates to <see cref="BuiltInTypes.GetInstanceMemberType"/>, the same apparent-members
+    /// model that <c>value.member</c> reads, keyof, and structural assignability use, so they agree on
+    /// one source of truth (#512). Returns null when <paramref name="checkType"/> is not such a record
+    /// or the member is absent — the infer match then fails (false branch), exactly as before.
     /// </summary>
-    private static TypeInfo? ResolveBuiltInRecordMember(TypeInfo checkType, string memberName) => checkType switch
-    {
-        TypeInfo.Date => BuiltInTypes.GetDateInstanceMemberType(memberName),
-        TypeInfo.RegExp => BuiltInTypes.GetRegExpMemberType(memberName),
-        TypeInfo.Map m => BuiltInTypes.GetMapMemberType(memberName, m.KeyType, m.ValueType),
-        TypeInfo.Set s => BuiltInTypes.GetSetMemberType(memberName, s.ElementType),
-        TypeInfo.WeakMap wm => BuiltInTypes.GetWeakMapMemberType(memberName, wm.KeyType, wm.ValueType),
-        TypeInfo.WeakSet ws => BuiltInTypes.GetWeakSetMemberType(memberName, ws.ElementType),
-        TypeInfo.WeakRef wr => BuiltInTypes.GetWeakRefMemberType(memberName, wr.TargetType),
-        TypeInfo.FinalizationRegistry fr => BuiltInTypes.GetFinalizationRegistryMemberType(memberName, fr.TargetType),
-        TypeInfo.Promise p => BuiltInTypes.GetPromiseMemberType(memberName, p.ValueType),
-        TypeInfo.Iterator it => BuiltInTypes.GetIteratorMemberType(memberName, it.ElementType),
-        TypeInfo.Generator g => BuiltInTypes.GetIteratorMemberType(memberName, g.YieldType),
-        TypeInfo.AsyncGenerator ag => BuiltInTypes.GetIteratorMemberType(memberName, ag.YieldType),
-        _ => null
-    };
+    private static TypeInfo? ResolveBuiltInRecordMember(TypeInfo checkType, string memberName)
+        => BuiltInTypes.GetInstanceMemberType(checkType, memberName);
 
     /// <summary>
     /// True when the type still contains type variables (type parameters, infer placeholders,

--- a/TypeSystem/TypeChecker.Generics.MappedTypes.cs
+++ b/TypeSystem/TypeChecker.Generics.MappedTypes.cs
@@ -151,6 +151,13 @@ public partial class TypeChecker
                 break;
         }
 
+        // Structurally-decomposable built-in object types (Date, RegExp, Map, Set, the weak/iterator
+        // variants, Promise, …) have no dedicated case above, so they reach here with no keys. Surface
+        // their apparent members as a key union, matching tsc's `keyof Date` etc. (#512).
+        if (Runtime.BuiltIns.BuiltInTypes.GetInstanceMemberNames(type) is { } builtInMemberNames)
+            foreach (var memberName in builtInMemberNames)
+                keys.Add(new TypeInfo.StringLiteral(memberName));
+
         return keys.Distinct(TypeInfoEqualityComparer.Instance).ToList();
     }
 


### PR DESCRIPTION
## Summary

Closes #512.

Built-in object types (`Date`, `RegExp`, `Map`, `Set`, the weak/iterator variants, `Promise`) modeled their instance members through name-keyed `GetXxxMemberType` switches in `BuiltInTypes`. Those switches aren't enumerable, so `keyof` and structural assignability could not treat these types structurally — both of these errored, where `tsc` accepts them:

```ts
const k: keyof Date = "getTime";              // was: not assignable to keyof Date
const o: { getTime(): number } = new Date();  // was: Date not assignable to { getTime(): number }
```

## Approach

A shared **apparent-members projection** over the decomposable built-in set, added in `BuiltInTypes` (one source of truth):

- `GetInstanceMemberType(TypeInfo, name)` — per-name type resolver (delegates to the existing `GetXxxMemberType` resolvers)
- `GetInstanceMemberNames(TypeInfo)` — enumerable member-name list per type

reused by all three consumers the issue called out:

| Consumer | Change |
|---|---|
| `keyof` (`ExtractKeys`) | surfaces the member names as a key union |
| structural assignability (`CheckStructuralCompatibility`) | falls back to the projection for a built-in **source**, so it satisfies a matching `{ … }` shape |
| conditional infer-matching (`ResolveBuiltInRecordMember`) | now **delegates** to the projection, replacing its duplicated switch (behavior-preserving) |

Covered set (matches the existing infer-match set): Date, RegExp, Map, Set, WeakMap, WeakSet, WeakRef, FinalizationRegistry, Promise, Iterator, Generator, AsyncGenerator.

### Design notes

- **Drift guard.** The per-type member-name lists sit beside the resolvers in `BuiltInTypes`; a forward-consistency unit test (`BuiltInApparentMembersTests`) asserts every advertised name resolves to a non-null type, so `keyof` can never surface a key whose `T[K]` can't be resolved.
- **Surgical assignability hook.** The built-in fallback is scoped to `CheckStructuralCompatibility` rather than the broadly-shared `GetMemberType`. This keeps the iterator-protocol arm in `IsCompatibleCore` (the `next`-presence heuristic) untouched, so an `AsyncGenerator` still isn't assignable to a sync `Iterator<T>`, while narrowing call sites that use `GetMemberType` are unaffected.
- **Performance.** `keyof` needs only the name list (no per-member `TypeInfo` allocation); assignability/infer-match resolve members by name on demand. No new per-call dictionary allocation.

## Tests

- `BuiltInStructuralTypeTests` (both interpreter + compiler): `keyof` and structural assignability for Date/RegExp/Map/Set/Promise; negatives (invalid key, missing member, mistyped member); indexed access `Date["getTime"]`; mapped type over `keyof Set<number>`.
- `BuiltInApparentMembersTests`: names↔resolver consistency, no over-match, iterator-variant list sharing, non-decomposable types return null.
- Existing `InferMatchBuiltInMemberTests` (#491 regression) still green.
- Full unit suite: **11,779 passed, 0 failed**.
- TypeScript conformance subset (`assignmentCompatibility` + `conditional`): **31/31**, committed baseline unchanged.
- Test262 not run: it is untyped JavaScript with no `keyof`/annotations, this change is type-checker-only and strictly more permissive (never introduces an error), and the infer-match edit is behavior-preserving — so its outcomes can't shift.

## Follow-ups filed

- #527 — `keyof` over index-signature built-ins (string/Array/Tuple) still yields `never` (needs index-signature keys, distinct mechanism)
- #530 — extend the projection to the remaining object built-ins (Error/Buffer/EventEmitter/Abort*/Timeout)
- #528 — `Error`/`TypeError`/… type references resolve to `any` (blocks Error decomposition)
- #529 — weak-type check (TS2559) ignores built-in source members
