### PR TITLE
Fix #516: model the full Date prototype (UTC getters/setters, toUTCString, toLocale*, getYear/setYear)

### DIFF
--- a/Compilation/EmittedRuntime.cs
+++ b/Compilation/EmittedRuntime.cs
@@ -1079,6 +1079,30 @@ public class EmittedRuntime
     public MethodBuilder DateToTimeString { get; set; } = null!;
     public MethodBuilder DateToJSON { get; set; } = null!;
     public MethodBuilder DateValueOf { get; set; } = null!;
+    // UTC getters (issue #516)
+    public MethodBuilder DateGetUTCFullYear { get; set; } = null!;
+    public MethodBuilder DateGetUTCMonth { get; set; } = null!;
+    public MethodBuilder DateGetUTCDate { get; set; } = null!;
+    public MethodBuilder DateGetUTCDay { get; set; } = null!;
+    public MethodBuilder DateGetUTCHours { get; set; } = null!;
+    public MethodBuilder DateGetUTCMinutes { get; set; } = null!;
+    public MethodBuilder DateGetUTCSeconds { get; set; } = null!;
+    public MethodBuilder DateGetUTCMilliseconds { get; set; } = null!;
+    // UTC setters (issue #516)
+    public MethodBuilder DateSetUTCFullYear { get; set; } = null!;
+    public MethodBuilder DateSetUTCMonth { get; set; } = null!;
+    public MethodBuilder DateSetUTCDate { get; set; } = null!;
+    public MethodBuilder DateSetUTCHours { get; set; } = null!;
+    public MethodBuilder DateSetUTCMinutes { get; set; } = null!;
+    public MethodBuilder DateSetUTCSeconds { get; set; } = null!;
+    public MethodBuilder DateSetUTCMilliseconds { get; set; } = null!;
+    // Conversion + legacy (issue #516)
+    public MethodBuilder DateToUTCString { get; set; } = null!;
+    public MethodBuilder DateToLocaleDateString { get; set; } = null!;
+    public MethodBuilder DateToLocaleTimeString { get; set; } = null!;
+    public MethodBuilder DateToLocaleString { get; set; } = null!;
+    public MethodBuilder DateGetYear { get; set; } = null!;
+    public MethodBuilder DateSetYear { get; set; } = null!;
 
     // RegExp support - $Runtime wrapper methods
     public MethodBuilder RegExpCoerceArg { get; set; } = null!;

--- a/Compilation/Emitters/DateEmitter.cs
+++ b/Compilation/Emitters/DateEmitter.cs
@@ -74,6 +74,52 @@ public sealed class DateEmitter : ITypeEmitterStrategy
                 il.Emit(OpCodes.Box, ctx.Types.Double);
                 return true;
 
+            // UTC getters + legacy getYear (no arguments, return double)
+            case "getUTCFullYear":
+                il.Emit(OpCodes.Call, ctx.Runtime!.DateGetUTCFullYear);
+                il.Emit(OpCodes.Box, ctx.Types.Double);
+                return true;
+
+            case "getUTCMonth":
+                il.Emit(OpCodes.Call, ctx.Runtime!.DateGetUTCMonth);
+                il.Emit(OpCodes.Box, ctx.Types.Double);
+                return true;
+
+            case "getUTCDate":
+                il.Emit(OpCodes.Call, ctx.Runtime!.DateGetUTCDate);
+                il.Emit(OpCodes.Box, ctx.Types.Double);
+                return true;
+
+            case "getUTCDay":
+                il.Emit(OpCodes.Call, ctx.Runtime!.DateGetUTCDay);
+                il.Emit(OpCodes.Box, ctx.Types.Double);
+                return true;
+
+            case "getUTCHours":
+                il.Emit(OpCodes.Call, ctx.Runtime!.DateGetUTCHours);
+                il.Emit(OpCodes.Box, ctx.Types.Double);
+                return true;
+
+            case "getUTCMinutes":
+                il.Emit(OpCodes.Call, ctx.Runtime!.DateGetUTCMinutes);
+                il.Emit(OpCodes.Box, ctx.Types.Double);
+                return true;
+
+            case "getUTCSeconds":
+                il.Emit(OpCodes.Call, ctx.Runtime!.DateGetUTCSeconds);
+                il.Emit(OpCodes.Box, ctx.Types.Double);
+                return true;
+
+            case "getUTCMilliseconds":
+                il.Emit(OpCodes.Call, ctx.Runtime!.DateGetUTCMilliseconds);
+                il.Emit(OpCodes.Box, ctx.Types.Double);
+                return true;
+
+            case "getYear":
+                il.Emit(OpCodes.Call, ctx.Runtime!.DateGetYear);
+                il.Emit(OpCodes.Box, ctx.Types.Double);
+                return true;
+
             // Simple setters (single argument, return double)
             case "setTime":
                 EmitSingleDoubleArgOrNaN(emitter, arguments);
@@ -90,6 +136,25 @@ public sealed class DateEmitter : ITypeEmitterStrategy
             case "setMilliseconds":
                 EmitSingleDoubleArgOrNaN(emitter, arguments);
                 il.Emit(OpCodes.Call, ctx.Runtime!.DateSetMilliseconds);
+                il.Emit(OpCodes.Box, ctx.Types.Double);
+                return true;
+
+            // UTC simple setters + legacy setYear (single argument, return double)
+            case "setUTCDate":
+                EmitSingleDoubleArgOrNaN(emitter, arguments);
+                il.Emit(OpCodes.Call, ctx.Runtime!.DateSetUTCDate);
+                il.Emit(OpCodes.Box, ctx.Types.Double);
+                return true;
+
+            case "setUTCMilliseconds":
+                EmitSingleDoubleArgOrNaN(emitter, arguments);
+                il.Emit(OpCodes.Call, ctx.Runtime!.DateSetUTCMilliseconds);
+                il.Emit(OpCodes.Box, ctx.Types.Double);
+                return true;
+
+            case "setYear":
+                EmitSingleDoubleArgOrNaN(emitter, arguments);
+                il.Emit(OpCodes.Call, ctx.Runtime!.DateSetYear);
                 il.Emit(OpCodes.Box, ctx.Types.Double);
                 return true;
 
@@ -124,6 +189,37 @@ public sealed class DateEmitter : ITypeEmitterStrategy
                 il.Emit(OpCodes.Box, ctx.Types.Double);
                 return true;
 
+            // UTC multi-argument setters (variadic, packaged as object[])
+            case "setUTCFullYear":
+                EmitArgsArray(emitter, arguments);
+                il.Emit(OpCodes.Call, ctx.Runtime!.DateSetUTCFullYear);
+                il.Emit(OpCodes.Box, ctx.Types.Double);
+                return true;
+
+            case "setUTCMonth":
+                EmitArgsArray(emitter, arguments);
+                il.Emit(OpCodes.Call, ctx.Runtime!.DateSetUTCMonth);
+                il.Emit(OpCodes.Box, ctx.Types.Double);
+                return true;
+
+            case "setUTCHours":
+                EmitArgsArray(emitter, arguments);
+                il.Emit(OpCodes.Call, ctx.Runtime!.DateSetUTCHours);
+                il.Emit(OpCodes.Box, ctx.Types.Double);
+                return true;
+
+            case "setUTCMinutes":
+                EmitArgsArray(emitter, arguments);
+                il.Emit(OpCodes.Call, ctx.Runtime!.DateSetUTCMinutes);
+                il.Emit(OpCodes.Box, ctx.Types.Double);
+                return true;
+
+            case "setUTCSeconds":
+                EmitArgsArray(emitter, arguments);
+                il.Emit(OpCodes.Call, ctx.Runtime!.DateSetUTCSeconds);
+                il.Emit(OpCodes.Box, ctx.Types.Double);
+                return true;
+
             // Conversion methods (no arguments, return string)
             case "toISOString":
                 il.Emit(OpCodes.Call, ctx.Runtime!.DateToISOString);
@@ -135,6 +231,23 @@ public sealed class DateEmitter : ITypeEmitterStrategy
 
             case "toTimeString":
                 il.Emit(OpCodes.Call, ctx.Runtime!.DateToTimeString);
+                return true;
+
+            case "toUTCString":
+                il.Emit(OpCodes.Call, ctx.Runtime!.DateToUTCString);
+                return true;
+
+            // toLocale* (locale/options args accepted by the type checker but ignored at runtime)
+            case "toLocaleDateString":
+                il.Emit(OpCodes.Call, ctx.Runtime!.DateToLocaleDateString);
+                return true;
+
+            case "toLocaleTimeString":
+                il.Emit(OpCodes.Call, ctx.Runtime!.DateToLocaleTimeString);
+                return true;
+
+            case "toLocaleString":
+                il.Emit(OpCodes.Call, ctx.Runtime!.DateToLocaleString);
                 return true;
 
             // toJSON (no arguments, returns string | null as object)

--- a/Compilation/RuntimeEmitter.Date.cs
+++ b/Compilation/RuntimeEmitter.Date.cs
@@ -39,6 +39,149 @@ public partial class RuntimeEmitter
         EmitDateToTimeString(typeBuilder, runtime);
         EmitDateToJSON(typeBuilder, runtime);
         EmitDateValueOf(typeBuilder, runtime);
+
+        // UTC getters + legacy getYear (#516): 0-arg, return double, NaN on non-Date.
+        runtime.DateGetUTCFullYear = EmitDateDoubleGetter(typeBuilder, runtime, "DateGetUTCFullYear", "GetUTCFullYear");
+        runtime.DateGetUTCMonth = EmitDateDoubleGetter(typeBuilder, runtime, "DateGetUTCMonth", "GetUTCMonth");
+        runtime.DateGetUTCDate = EmitDateDoubleGetter(typeBuilder, runtime, "DateGetUTCDate", "GetUTCDate");
+        runtime.DateGetUTCDay = EmitDateDoubleGetter(typeBuilder, runtime, "DateGetUTCDay", "GetUTCDay");
+        runtime.DateGetUTCHours = EmitDateDoubleGetter(typeBuilder, runtime, "DateGetUTCHours", "GetUTCHours");
+        runtime.DateGetUTCMinutes = EmitDateDoubleGetter(typeBuilder, runtime, "DateGetUTCMinutes", "GetUTCMinutes");
+        runtime.DateGetUTCSeconds = EmitDateDoubleGetter(typeBuilder, runtime, "DateGetUTCSeconds", "GetUTCSeconds");
+        runtime.DateGetUTCMilliseconds = EmitDateDoubleGetter(typeBuilder, runtime, "DateGetUTCMilliseconds", "GetUTCMilliseconds");
+        runtime.DateGetYear = EmitDateDoubleGetter(typeBuilder, runtime, "DateGetYear", "GetYear");
+
+        // UTC setters (#516). Multi-arg setters package args as object[] (primary arg read);
+        // single-arg setters take a direct double. Legacy setYear takes a direct double.
+        runtime.DateSetUTCFullYear = EmitDateArgsArraySetter(typeBuilder, runtime, "DateSetUTCFullYear", "SetUTCFullYear");
+        runtime.DateSetUTCMonth = EmitDateArgsArraySetter(typeBuilder, runtime, "DateSetUTCMonth", "SetUTCMonth");
+        runtime.DateSetUTCDate = EmitDateDoubleArgSetter(typeBuilder, runtime, "DateSetUTCDate", "SetUTCDate");
+        runtime.DateSetUTCHours = EmitDateArgsArraySetter(typeBuilder, runtime, "DateSetUTCHours", "SetUTCHours");
+        runtime.DateSetUTCMinutes = EmitDateArgsArraySetter(typeBuilder, runtime, "DateSetUTCMinutes", "SetUTCMinutes");
+        runtime.DateSetUTCSeconds = EmitDateArgsArraySetter(typeBuilder, runtime, "DateSetUTCSeconds", "SetUTCSeconds");
+        runtime.DateSetUTCMilliseconds = EmitDateDoubleArgSetter(typeBuilder, runtime, "DateSetUTCMilliseconds", "SetUTCMilliseconds");
+        runtime.DateSetYear = EmitDateDoubleArgSetter(typeBuilder, runtime, "DateSetYear", "SetYear");
+
+        // Conversion methods (#516): return string, "Invalid Date" on non-Date.
+        runtime.DateToUTCString = EmitDateStringMethod(typeBuilder, runtime, "DateToUTCString", "ToUTCString");
+        runtime.DateToLocaleDateString = EmitDateStringMethod(typeBuilder, runtime, "DateToLocaleDateString", "ToLocaleDateString");
+        runtime.DateToLocaleTimeString = EmitDateStringMethod(typeBuilder, runtime, "DateToLocaleTimeString", "ToLocaleTimeString");
+        runtime.DateToLocaleString = EmitDateStringMethod(typeBuilder, runtime, "DateToLocaleString", "ToLocaleString");
+    }
+
+    /// <summary>
+    /// Emits a static $Runtime helper for a 0-arg $TSDate getter returning a double
+    /// (NaN when the receiver is not a $TSDate). Returns the emitted method.
+    /// </summary>
+    private MethodBuilder EmitDateDoubleGetter(TypeBuilder typeBuilder, EmittedRuntime runtime, string runtimeName, string instanceMethodName)
+    {
+        var method = typeBuilder.DefineMethod(
+            runtimeName,
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.Double,
+            [_types.Object]
+        );
+        EmitDateInstanceMethodCall(typeBuilder, runtime, runtimeName, instanceMethodName, method);
+        return method;
+    }
+
+    /// <summary>
+    /// Emits a static $Runtime helper for a $TSDate setter taking a single double argument
+    /// (NaN when the receiver is not a $TSDate). Returns the emitted method.
+    /// </summary>
+    private MethodBuilder EmitDateDoubleArgSetter(TypeBuilder typeBuilder, EmittedRuntime runtime, string runtimeName, string instanceMethodName)
+    {
+        var method = typeBuilder.DefineMethod(
+            runtimeName,
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.Double,
+            [_types.Object, _types.Double]
+        );
+
+        var il = method.GetILGenerator();
+        var invalidLabel = il.DefineLabel();
+
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Isinst, runtime.TSDateType);
+        il.Emit(OpCodes.Brfalse, invalidLabel);
+
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Castclass, runtime.TSDateType);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Callvirt, runtime.TSDateMethods[instanceMethodName]);
+        il.Emit(OpCodes.Ret);
+
+        il.MarkLabel(invalidLabel);
+        il.Emit(OpCodes.Ldc_R8, double.NaN);
+        il.Emit(OpCodes.Ret);
+        return method;
+    }
+
+    /// <summary>
+    /// Emits a static $Runtime helper for a multi-arg $TSDate setter whose arguments are
+    /// packaged as object[]; only the primary argument (index 0) is honored, matching the
+    /// other compiled Date setters (#536) (NaN when the receiver is not a $TSDate). Returns the method.
+    /// </summary>
+    private MethodBuilder EmitDateArgsArraySetter(TypeBuilder typeBuilder, EmittedRuntime runtime, string runtimeName, string instanceMethodName)
+    {
+        var method = typeBuilder.DefineMethod(
+            runtimeName,
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.Double,
+            [_types.Object, _types.ObjectArray]
+        );
+
+        var il = method.GetILGenerator();
+        var invalidLabel = il.DefineLabel();
+
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Isinst, runtime.TSDateType);
+        il.Emit(OpCodes.Brfalse, invalidLabel);
+
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Castclass, runtime.TSDateType);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Ldelem_Ref);
+        il.Emit(OpCodes.Unbox_Any, _types.Double);
+        il.Emit(OpCodes.Callvirt, runtime.TSDateMethods[instanceMethodName]);
+        il.Emit(OpCodes.Ret);
+
+        il.MarkLabel(invalidLabel);
+        il.Emit(OpCodes.Ldc_R8, double.NaN);
+        il.Emit(OpCodes.Ret);
+        return method;
+    }
+
+    /// <summary>
+    /// Emits a static $Runtime helper for a 0-arg $TSDate conversion method returning a string
+    /// ("Invalid Date" when the receiver is not a $TSDate). Returns the emitted method.
+    /// </summary>
+    private MethodBuilder EmitDateStringMethod(TypeBuilder typeBuilder, EmittedRuntime runtime, string runtimeName, string instanceMethodName)
+    {
+        var method = typeBuilder.DefineMethod(
+            runtimeName,
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.String,
+            [_types.Object]
+        );
+
+        var il = method.GetILGenerator();
+        var invalidLabel = il.DefineLabel();
+
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Isinst, runtime.TSDateType);
+        il.Emit(OpCodes.Brfalse, invalidLabel);
+
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Castclass, runtime.TSDateType);
+        il.Emit(OpCodes.Callvirt, runtime.TSDateMethods[instanceMethodName]);
+        il.Emit(OpCodes.Ret);
+
+        il.MarkLabel(invalidLabel);
+        il.Emit(OpCodes.Ldstr, "Invalid Date");
+        il.Emit(OpCodes.Ret);
+        return method;
     }
 
     private void EmitDateNow(TypeBuilder typeBuilder, EmittedRuntime runtime)

--- a/Compilation/RuntimeEmitter.TSDate.cs
+++ b/Compilation/RuntimeEmitter.TSDate.cs
@@ -46,30 +46,58 @@ public partial class RuntimeEmitter
         // Instance getter methods
         EmitTSDateGetTime(typeBuilder, runtime);
         EmitTSDateGetFullYear(typeBuilder, runtime);
-        EmitTSDateGetMonth(typeBuilder, runtime);
+        EmitSimpleDateGetter(typeBuilder, runtime, "GetMonth", "Month", subtractAfter: 1);
         EmitTSDateGetDate(typeBuilder, runtime);
-        EmitTSDateGetDay(typeBuilder, runtime);
+        EmitSimpleDateGetter(typeBuilder, runtime, "GetDay", "DayOfWeek");
         EmitTSDateGetHours(typeBuilder, runtime);
         EmitTSDateGetMinutes(typeBuilder, runtime);
         EmitTSDateGetSeconds(typeBuilder, runtime);
         EmitTSDateGetMilliseconds(typeBuilder, runtime);
         EmitTSDateGetTimezoneOffset(typeBuilder, runtime);
 
-        // Instance setter methods
+        // UTC getter methods (#516)
+        EmitSimpleDateGetter(typeBuilder, runtime, "GetUTCFullYear", "Year", utc: true);
+        EmitSimpleDateGetter(typeBuilder, runtime, "GetUTCMonth", "Month", utc: true, subtractAfter: 1);
+        EmitSimpleDateGetter(typeBuilder, runtime, "GetUTCDate", "Day", utc: true);
+        EmitSimpleDateGetter(typeBuilder, runtime, "GetUTCDay", "DayOfWeek", utc: true);
+        EmitSimpleDateGetter(typeBuilder, runtime, "GetUTCHours", "Hour", utc: true);
+        EmitSimpleDateGetter(typeBuilder, runtime, "GetUTCMinutes", "Minute", utc: true);
+        EmitSimpleDateGetter(typeBuilder, runtime, "GetUTCSeconds", "Second", utc: true);
+        EmitSimpleDateGetter(typeBuilder, runtime, "GetUTCMilliseconds", "Millisecond", utc: true);
+        // Legacy getYear: local-time year minus 1900 (Annex B, #516)
+        EmitSimpleDateGetter(typeBuilder, runtime, "GetYear", "Year", subtractAfter: 1900);
+
+        // Instance setter methods (all route through the shared component setter)
         EmitTSDateSetTime(typeBuilder, runtime);
-        EmitTSDateSetFullYear(typeBuilder, runtime);
-        EmitTSDateSetMonth(typeBuilder, runtime);
-        EmitTSDateSetDate(typeBuilder, runtime);
-        EmitTSDateSetHours(typeBuilder, runtime);
-        EmitTSDateSetMinutes(typeBuilder, runtime);
-        EmitTSDateSetSeconds(typeBuilder, runtime);
-        EmitTSDateSetMilliseconds(typeBuilder, runtime);
+        EmitDateComponentSetter(typeBuilder, runtime, "SetFullYear", DateComponent.Year, utc: false);
+        EmitDateComponentSetter(typeBuilder, runtime, "SetMonth", DateComponent.Month, utc: false);
+        EmitDateComponentSetter(typeBuilder, runtime, "SetDate", DateComponent.Day, utc: false);
+        EmitDateComponentSetter(typeBuilder, runtime, "SetHours", DateComponent.Hour, utc: false);
+        EmitDateComponentSetter(typeBuilder, runtime, "SetMinutes", DateComponent.Minute, utc: false);
+        EmitDateComponentSetter(typeBuilder, runtime, "SetSeconds", DateComponent.Second, utc: false);
+        EmitDateComponentSetter(typeBuilder, runtime, "SetMilliseconds", DateComponent.Millisecond, utc: false);
+
+        // UTC setter methods (#516)
+        EmitDateComponentSetter(typeBuilder, runtime, "SetUTCFullYear", DateComponent.Year, utc: true);
+        EmitDateComponentSetter(typeBuilder, runtime, "SetUTCMonth", DateComponent.Month, utc: true);
+        EmitDateComponentSetter(typeBuilder, runtime, "SetUTCDate", DateComponent.Day, utc: true);
+        EmitDateComponentSetter(typeBuilder, runtime, "SetUTCHours", DateComponent.Hour, utc: true);
+        EmitDateComponentSetter(typeBuilder, runtime, "SetUTCMinutes", DateComponent.Minute, utc: true);
+        EmitDateComponentSetter(typeBuilder, runtime, "SetUTCSeconds", DateComponent.Second, utc: true);
+        EmitDateComponentSetter(typeBuilder, runtime, "SetUTCMilliseconds", DateComponent.Millisecond, utc: true);
+        // Legacy setYear (Annex B, #516) — emitted after SetFullYear, which it delegates to.
+        EmitTSDateSetYear(typeBuilder, runtime);
 
         // Conversion methods
         EmitTSDateToString(typeBuilder, runtime);
         EmitTSDateToISOString(typeBuilder, runtime);
         EmitTSDateToDateString(typeBuilder, runtime);
         EmitTSDateToTimeString(typeBuilder, runtime);
+        EmitTSDateToUTCString(typeBuilder, runtime);
+        // toLocale* format in local time using the host's current culture (#516)
+        EmitTSDateLocaleString(typeBuilder, runtime, "ToLocaleDateString", "d");
+        EmitTSDateLocaleString(typeBuilder, runtime, "ToLocaleTimeString", "T");
+        EmitTSDateLocaleString(typeBuilder, runtime, "ToLocaleString", "G");
         EmitTSDateValueOf(typeBuilder, runtime);
 
         typeBuilder.CreateType();
@@ -459,75 +487,9 @@ public partial class RuntimeEmitter
         EmitSimpleDateGetter(typeBuilder, runtime, "GetFullYear", "Year");
     }
 
-    private void EmitTSDateGetMonth(TypeBuilder typeBuilder, EmittedRuntime runtime)
-    {
-        // Month needs -1 adjustment (JS is 0-indexed)
-        var method = typeBuilder.DefineMethod(
-            "GetMonth",
-            MethodAttributes.Public,
-            _types.Double,
-            Type.EmptyTypes
-        );
-        runtime.TSDateMethods["GetMonth"] = method;
-
-        var il = method.GetILGenerator();
-        var validLabel = il.DefineLabel();
-
-        il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Ldfld, _tsDateIsInvalidField);
-        il.Emit(OpCodes.Brfalse, validLabel);
-        il.Emit(OpCodes.Ldc_R8, double.NaN);
-        il.Emit(OpCodes.Ret);
-
-        il.MarkLabel(validLabel);
-        var localTimeLocal = il.DeclareLocal(_types.DateTime);
-        il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Ldflda, _tsDateUtcDateTimeField);
-        il.Emit(OpCodes.Call, _types.DateTime.GetMethod("ToLocalTime")!);
-        il.Emit(OpCodes.Stloc, localTimeLocal);
-        il.Emit(OpCodes.Ldloca, localTimeLocal);
-        il.Emit(OpCodes.Call, _types.DateTime.GetProperty("Month")!.GetGetMethod()!);
-        il.Emit(OpCodes.Ldc_I4_1);
-        il.Emit(OpCodes.Sub);
-        il.Emit(OpCodes.Conv_R8);
-        il.Emit(OpCodes.Ret);
-    }
-
     private void EmitTSDateGetDate(TypeBuilder typeBuilder, EmittedRuntime runtime)
     {
         EmitSimpleDateGetter(typeBuilder, runtime, "GetDate", "Day");
-    }
-
-    private void EmitTSDateGetDay(TypeBuilder typeBuilder, EmittedRuntime runtime)
-    {
-        // DayOfWeek returns enum, cast to int then double
-        var method = typeBuilder.DefineMethod(
-            "GetDay",
-            MethodAttributes.Public,
-            _types.Double,
-            Type.EmptyTypes
-        );
-        runtime.TSDateMethods["GetDay"] = method;
-
-        var il = method.GetILGenerator();
-        var validLabel = il.DefineLabel();
-
-        il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Ldfld, _tsDateIsInvalidField);
-        il.Emit(OpCodes.Brfalse, validLabel);
-        il.Emit(OpCodes.Ldc_R8, double.NaN);
-        il.Emit(OpCodes.Ret);
-
-        il.MarkLabel(validLabel);
-        var localTimeLocal = il.DeclareLocal(_types.DateTime);
-        il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Ldflda, _tsDateUtcDateTimeField);
-        il.Emit(OpCodes.Call, _types.DateTime.GetMethod("ToLocalTime")!);
-        il.Emit(OpCodes.Stloc, localTimeLocal);
-        il.Emit(OpCodes.Ldloca, localTimeLocal);
-        il.Emit(OpCodes.Call, _types.DateTime.GetProperty("DayOfWeek")!.GetGetMethod()!);
-        il.Emit(OpCodes.Conv_R8);
-        il.Emit(OpCodes.Ret);
     }
 
     private void EmitTSDateGetHours(TypeBuilder typeBuilder, EmittedRuntime runtime)
@@ -550,7 +512,13 @@ public partial class RuntimeEmitter
         EmitSimpleDateGetter(typeBuilder, runtime, "GetMilliseconds", "Millisecond");
     }
 
-    private void EmitSimpleDateGetter(TypeBuilder typeBuilder, EmittedRuntime runtime, string methodName, string propertyName)
+    /// <summary>
+    /// Emits a zero-argument $TSDate getter returning a DateTime component as a double.
+    /// When <paramref name="utc"/> is true the stored UTC instant is read directly; otherwise
+    /// it is converted to local time first. <paramref name="subtractAfter"/> offsets the result
+    /// (e.g. 1 for the 0-indexed month, 1900 for the Annex B getYear).
+    /// </summary>
+    private void EmitSimpleDateGetter(TypeBuilder typeBuilder, EmittedRuntime runtime, string methodName, string propertyName, bool utc = false, int subtractAfter = 0)
     {
         var method = typeBuilder.DefineMethod(
             methodName,
@@ -570,13 +538,27 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ret);
 
         il.MarkLabel(validLabel);
-        var localTimeLocal = il.DeclareLocal(_types.DateTime);
-        il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Ldflda, _tsDateUtcDateTimeField);
-        il.Emit(OpCodes.Call, _types.DateTime.GetMethod("ToLocalTime")!);
-        il.Emit(OpCodes.Stloc, localTimeLocal);
-        il.Emit(OpCodes.Ldloca, localTimeLocal);
+        if (utc)
+        {
+            // Read the UTC instant directly; the property getter is called on the field address.
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldflda, _tsDateUtcDateTimeField);
+        }
+        else
+        {
+            var localTimeLocal = il.DeclareLocal(_types.DateTime);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldflda, _tsDateUtcDateTimeField);
+            il.Emit(OpCodes.Call, _types.DateTime.GetMethod("ToLocalTime")!);
+            il.Emit(OpCodes.Stloc, localTimeLocal);
+            il.Emit(OpCodes.Ldloca, localTimeLocal);
+        }
         il.Emit(OpCodes.Call, _types.DateTime.GetProperty(propertyName)!.GetGetMethod()!);
+        if (subtractAfter != 0)
+        {
+            il.Emit(OpCodes.Ldc_I4, subtractAfter);
+            il.Emit(OpCodes.Sub);
+        }
         il.Emit(OpCodes.Conv_R8);
         il.Emit(OpCodes.Ret);
     }
@@ -674,254 +656,262 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ret);
     }
 
-    // Date setters: modify date component, store in UTC, return new timestamp
-    private void EmitTSDateSetFullYear(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    /// <summary>Identifies which component a <see cref="EmitDateComponentSetter"/> replaces.</summary>
+    private enum DateComponent { Year, Month, Day, Hour, Minute, Second, Millisecond }
+
+    /// <summary>
+    /// Emits a $TSDate setter that replaces a single date component (keeping the others) and
+    /// returns the new timestamp. The instant is rebuilt with DateTime.Add* from a normalized
+    /// base so overflowing components roll over per JavaScript semantics (e.g. setMonth(13)
+    /// advances the year); an out-of-range result (e.g. a year beyond DateTime's domain) is
+    /// caught and marks the date Invalid, mirroring <see cref="Runtime.Types.SharpTSDate"/>.
+    /// When <paramref name="utc"/> is true the instant is read and written directly in UTC;
+    /// otherwise it round-trips through local time. Only the primary argument is honored —
+    /// optional trailing arguments are dropped in compiled mode (tracked in #536).
+    /// </summary>
+    private void EmitDateComponentSetter(TypeBuilder typeBuilder, EmittedRuntime runtime, string methodName, DateComponent component, bool utc)
     {
-        var method = typeBuilder.DefineMethod("SetFullYear", MethodAttributes.Public, _types.Double, [_types.Double]);
-        runtime.TSDateMethods["SetFullYear"] = method;
+        var method = typeBuilder.DefineMethod(methodName, MethodAttributes.Public, _types.Double, [_types.Double]);
+        runtime.TSDateMethods[methodName] = method;
 
         var il = method.GetILGenerator();
-        var invalidLabel = il.DefineLabel();
+        var computeLabel = il.DefineLabel();
         var endLabel = il.DefineLabel();
+        var dtLocal = il.DeclareLocal(_types.DateTime);
+        var cur = il.DeclareLocal(_types.DateTime);
+        int kind = utc ? 1 : 2; // DateTimeKind.Utc = 1, Local = 2
 
-        // Check if invalid
+        // if (_isInvalid) return GetTime(); // stays NaN
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ldfld, _tsDateIsInvalidField);
-        il.Emit(OpCodes.Brtrue, invalidLabel);
-
-        // Get local time components
-        var localTimeLocal = il.DeclareLocal(_types.DateTime);
+        il.Emit(OpCodes.Brfalse, computeLabel);
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Ldflda, _tsDateUtcDateTimeField);
-        il.Emit(OpCodes.Call, _types.DateTime.GetMethod("ToLocalTime")!);
-        il.Emit(OpCodes.Stloc, localTimeLocal);
+        il.Emit(OpCodes.Call, _tsDateGetTimeMethod);
+        il.Emit(OpCodes.Ret);
 
-        // Create new DateTime with new year
-        var newDateLocal = il.DeclareLocal(_types.DateTime);
-        il.Emit(OpCodes.Ldarg_1);
-        il.Emit(OpCodes.Conv_I4);  // year
-        il.Emit(OpCodes.Ldloca, localTimeLocal);
-        il.Emit(OpCodes.Call, _types.DateTime.GetProperty("Month")!.GetGetMethod()!);
-        il.Emit(OpCodes.Ldloca, localTimeLocal);
-        il.Emit(OpCodes.Call, _types.DateTime.GetProperty("Day")!.GetGetMethod()!);
-        il.Emit(OpCodes.Ldloca, localTimeLocal);
-        il.Emit(OpCodes.Call, _types.DateTime.GetProperty("Hour")!.GetGetMethod()!);
-        il.Emit(OpCodes.Ldloca, localTimeLocal);
-        il.Emit(OpCodes.Call, _types.DateTime.GetProperty("Minute")!.GetGetMethod()!);
-        il.Emit(OpCodes.Ldloca, localTimeLocal);
-        il.Emit(OpCodes.Call, _types.DateTime.GetProperty("Second")!.GetGetMethod()!);
-        il.Emit(OpCodes.Ldloca, localTimeLocal);
-        il.Emit(OpCodes.Call, _types.DateTime.GetProperty("Millisecond")!.GetGetMethod()!);
-        il.Emit(OpCodes.Ldc_I4_2);  // DateTimeKind.Local
+        il.MarkLabel(computeLabel);
+        // dt = utc ? _utcDateTime : _utcDateTime.ToLocalTime();
+        if (utc)
+        {
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, _tsDateUtcDateTimeField);
+            il.Emit(OpCodes.Stloc, dtLocal);
+        }
+        else
+        {
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldflda, _tsDateUtcDateTimeField);
+            il.Emit(OpCodes.Call, _types.DateTime.GetMethod("ToLocalTime")!);
+            il.Emit(OpCodes.Stloc, dtLocal);
+        }
+
+        il.BeginExceptionBlock();
+
+        // cur = new DateTime(year, 1, 1, 0, 0, 0, kind)
+        PushDateComponentValue(il, dtLocal, component, DateComponent.Year, "Year", 0);
+        il.Emit(OpCodes.Ldc_I4_1); // month
+        il.Emit(OpCodes.Ldc_I4_1); // day
+        il.Emit(OpCodes.Ldc_I4_0); // hour
+        il.Emit(OpCodes.Ldc_I4_0); // minute
+        il.Emit(OpCodes.Ldc_I4_0); // second
+        il.Emit(OpCodes.Ldc_I4, kind);
         il.Emit(OpCodes.Newobj, _types.DateTime.GetConstructor([
-            _types.Int32, _types.Int32, _types.Int32, _types.Int32, _types.Int32, _types.Int32, _types.Int32, _types.DateTimeKind
+            _types.Int32, _types.Int32, _types.Int32, _types.Int32, _types.Int32, _types.Int32, _types.DateTimeKind
         ])!);
-        il.Emit(OpCodes.Stloc, newDateLocal);
+        il.Emit(OpCodes.Stloc, cur);
 
-        // Store as UTC
+        // cur = cur.AddMonths(month0)   (month0 = 0-indexed month to add)
+        il.Emit(OpCodes.Ldloca, cur);
+        PushDateComponentValue(il, dtLocal, component, DateComponent.Month, "Month", 1);
+        il.Emit(OpCodes.Call, _types.DateTime.GetMethod("AddMonths")!);
+        il.Emit(OpCodes.Stloc, cur);
+
+        // cur = cur.AddDays(day - 1)
+        il.Emit(OpCodes.Ldloca, cur);
+        PushDateComponentValue(il, dtLocal, component, DateComponent.Day, "Day", 0);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Sub);
+        il.Emit(OpCodes.Conv_R8);
+        il.Emit(OpCodes.Call, _types.DateTime.GetMethod("AddDays")!);
+        il.Emit(OpCodes.Stloc, cur);
+
+        // cur = cur.AddHours(hour)
+        il.Emit(OpCodes.Ldloca, cur);
+        PushDateComponentValue(il, dtLocal, component, DateComponent.Hour, "Hour", 0);
+        il.Emit(OpCodes.Conv_R8);
+        il.Emit(OpCodes.Call, _types.DateTime.GetMethod("AddHours")!);
+        il.Emit(OpCodes.Stloc, cur);
+
+        // cur = cur.AddMinutes(minute)
+        il.Emit(OpCodes.Ldloca, cur);
+        PushDateComponentValue(il, dtLocal, component, DateComponent.Minute, "Minute", 0);
+        il.Emit(OpCodes.Conv_R8);
+        il.Emit(OpCodes.Call, _types.DateTime.GetMethod("AddMinutes")!);
+        il.Emit(OpCodes.Stloc, cur);
+
+        // cur = cur.AddSeconds(second)
+        il.Emit(OpCodes.Ldloca, cur);
+        PushDateComponentValue(il, dtLocal, component, DateComponent.Second, "Second", 0);
+        il.Emit(OpCodes.Conv_R8);
+        il.Emit(OpCodes.Call, _types.DateTime.GetMethod("AddSeconds")!);
+        il.Emit(OpCodes.Stloc, cur);
+
+        // cur = cur.AddMilliseconds(millisecond)
+        il.Emit(OpCodes.Ldloca, cur);
+        PushDateComponentValue(il, dtLocal, component, DateComponent.Millisecond, "Millisecond", 0);
+        il.Emit(OpCodes.Conv_R8);
+        il.Emit(OpCodes.Call, _types.DateTime.GetMethod("AddMilliseconds")!);
+        il.Emit(OpCodes.Stloc, cur);
+
+        // _utcDateTime = utc ? cur : cur.ToUniversalTime();
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Ldloca, newDateLocal);
-        il.Emit(OpCodes.Call, _types.DateTime.GetMethod("ToUniversalTime")!);
+        if (utc)
+        {
+            il.Emit(OpCodes.Ldloc, cur);
+        }
+        else
+        {
+            il.Emit(OpCodes.Ldloca, cur);
+            il.Emit(OpCodes.Call, _types.DateTime.GetMethod("ToUniversalTime")!);
+        }
         il.Emit(OpCodes.Stfld, _tsDateUtcDateTimeField);
-        il.Emit(OpCodes.Br, endLabel);
+        il.Emit(OpCodes.Leave, endLabel);
 
-        il.MarkLabel(invalidLabel);
+        // catch { _isInvalid = true; }
+        il.BeginCatchBlock(_types.Exception);
+        il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Stfld, _tsDateIsInvalidField);
+        il.Emit(OpCodes.Leave, endLabel);
+        il.EndExceptionBlock();
+
         il.MarkLabel(endLabel);
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Call, _tsDateGetTimeMethod);
         il.Emit(OpCodes.Ret);
     }
 
-    private void EmitTSDateSetMonth(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    /// <summary>
+    /// Pushes the int value for one slot of the DateTime rebuilt by <see cref="EmitDateComponentSetter"/>:
+    /// the setter argument (truncated toward zero, matching <c>(int)value</c> in SharpTSDate) when this
+    /// slot is the one being set, otherwise the current component read from <paramref name="dtLocal"/>
+    /// (minus <paramref name="subtract"/>, e.g. 1 to convert .NET's 1-indexed month to 0-indexed).
+    /// </summary>
+    private void PushDateComponentValue(ILGenerator il, LocalBuilder dtLocal, DateComponent target, DateComponent slot, string propertyName, int subtract)
     {
-        var method = typeBuilder.DefineMethod("SetMonth", MethodAttributes.Public, _types.Double, [_types.Double]);
-        runtime.TSDateMethods["SetMonth"] = method;
+        if (target == slot)
+        {
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Conv_I4);
+        }
+        else
+        {
+            il.Emit(OpCodes.Ldloca, dtLocal);
+            il.Emit(OpCodes.Call, _types.DateTime.GetProperty(propertyName)!.GetGetMethod()!);
+            if (subtract != 0)
+            {
+                il.Emit(OpCodes.Ldc_I4, subtract);
+                il.Emit(OpCodes.Sub);
+            }
+        }
+    }
+
+    // ECMA-262 Annex B B.2.4.2: setYear maps 0-99 to 1900-1999, then delegates to SetFullYear.
+    private void EmitTSDateSetYear(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    {
+        var method = typeBuilder.DefineMethod("SetYear", MethodAttributes.Public, _types.Double, [_types.Double]);
+        runtime.TSDateMethods["SetYear"] = method;
 
         var il = method.GetILGenerator();
-        var invalidLabel = il.DefineLabel();
-        var endLabel = il.DefineLabel();
+        var computeLabel = il.DefineLabel();
+        var skipMapLabel = il.DefineLabel();
+        var yLocal = il.DeclareLocal(_types.Int32);
 
+        // if (_isInvalid) return GetTime();
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ldfld, _tsDateIsInvalidField);
-        il.Emit(OpCodes.Brtrue, invalidLabel);
-
-        var localTimeLocal = il.DeclareLocal(_types.DateTime);
+        il.Emit(OpCodes.Brfalse, computeLabel);
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Ldflda, _tsDateUtcDateTimeField);
-        il.Emit(OpCodes.Call, _types.DateTime.GetMethod("ToLocalTime")!);
-        il.Emit(OpCodes.Stloc, localTimeLocal);
+        il.Emit(OpCodes.Call, _tsDateGetTimeMethod);
+        il.Emit(OpCodes.Ret);
 
-        var newDateLocal = il.DeclareLocal(_types.DateTime);
-        il.Emit(OpCodes.Ldloca, localTimeLocal);
-        il.Emit(OpCodes.Call, _types.DateTime.GetProperty("Year")!.GetGetMethod()!);
+        il.MarkLabel(computeLabel);
+        // int y = (int)year;
         il.Emit(OpCodes.Ldarg_1);
         il.Emit(OpCodes.Conv_I4);
-        il.Emit(OpCodes.Ldc_I4_1);
-        il.Emit(OpCodes.Add);  // month + 1 (JS is 0-based)
-        il.Emit(OpCodes.Ldloca, localTimeLocal);
-        il.Emit(OpCodes.Call, _types.DateTime.GetProperty("Day")!.GetGetMethod()!);
-        il.Emit(OpCodes.Ldloca, localTimeLocal);
-        il.Emit(OpCodes.Call, _types.DateTime.GetProperty("Hour")!.GetGetMethod()!);
-        il.Emit(OpCodes.Ldloca, localTimeLocal);
-        il.Emit(OpCodes.Call, _types.DateTime.GetProperty("Minute")!.GetGetMethod()!);
-        il.Emit(OpCodes.Ldloca, localTimeLocal);
-        il.Emit(OpCodes.Call, _types.DateTime.GetProperty("Second")!.GetGetMethod()!);
-        il.Emit(OpCodes.Ldloca, localTimeLocal);
-        il.Emit(OpCodes.Call, _types.DateTime.GetProperty("Millisecond")!.GetGetMethod()!);
-        il.Emit(OpCodes.Ldc_I4_2);
-        il.Emit(OpCodes.Newobj, _types.DateTime.GetConstructor([
-            _types.Int32, _types.Int32, _types.Int32, _types.Int32, _types.Int32, _types.Int32, _types.Int32, _types.DateTimeKind
-        ])!);
-        il.Emit(OpCodes.Stloc, newDateLocal);
+        il.Emit(OpCodes.Stloc, yLocal);
+        // if (y < 0 || y > 99) goto skipMap;
+        il.Emit(OpCodes.Ldloc, yLocal);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Blt, skipMapLabel);
+        il.Emit(OpCodes.Ldloc, yLocal);
+        il.Emit(OpCodes.Ldc_I4, 99);
+        il.Emit(OpCodes.Bgt, skipMapLabel);
+        // y += 1900;
+        il.Emit(OpCodes.Ldloc, yLocal);
+        il.Emit(OpCodes.Ldc_I4, 1900);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Stloc, yLocal);
 
+        il.MarkLabel(skipMapLabel);
+        // return SetFullYear((double)y);
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Ldloca, newDateLocal);
-        il.Emit(OpCodes.Call, _types.DateTime.GetMethod("ToUniversalTime")!);
-        il.Emit(OpCodes.Stfld, _tsDateUtcDateTimeField);
-        il.Emit(OpCodes.Br, endLabel);
-
-        il.MarkLabel(invalidLabel);
-        il.MarkLabel(endLabel);
-        il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Call, _tsDateGetTimeMethod);
+        il.Emit(OpCodes.Ldloc, yLocal);
+        il.Emit(OpCodes.Conv_R8);
+        il.Emit(OpCodes.Call, runtime.TSDateMethods["SetFullYear"]);
         il.Emit(OpCodes.Ret);
     }
 
-    private void EmitTSDateSetDate(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    // RFC 7231 UTC string, e.g. "Thu, 01 Jan 1970 00:00:00 GMT".
+    private void EmitTSDateToUTCString(TypeBuilder typeBuilder, EmittedRuntime runtime)
     {
-        var method = typeBuilder.DefineMethod("SetDate", MethodAttributes.Public, _types.Double, [_types.Double]);
-        runtime.TSDateMethods["SetDate"] = method;
+        var method = typeBuilder.DefineMethod("ToUTCString", MethodAttributes.Public, _types.String, Type.EmptyTypes);
+        runtime.TSDateMethods["ToUTCString"] = method;
 
         var il = method.GetILGenerator();
-        var invalidLabel = il.DefineLabel();
-        var endLabel = il.DefineLabel();
+        var validLabel = il.DefineLabel();
 
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ldfld, _tsDateIsInvalidField);
-        il.Emit(OpCodes.Brtrue, invalidLabel);
+        il.Emit(OpCodes.Brfalse, validLabel);
+        il.Emit(OpCodes.Ldstr, "Invalid Date");
+        il.Emit(OpCodes.Ret);
 
+        il.MarkLabel(validLabel);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldflda, _tsDateUtcDateTimeField);
+        il.Emit(OpCodes.Ldstr, "ddd, dd MMM yyyy HH:mm:ss 'GMT'");
+        il.Emit(OpCodes.Call, typeof(CultureInfo).GetProperty("InvariantCulture")!.GetGetMethod()!);
+        il.Emit(OpCodes.Call, _types.DateTime.GetMethod("ToString", [_types.String, typeof(IFormatProvider)])!);
+        il.Emit(OpCodes.Ret);
+    }
+
+    // toLocale* family: format in local time using the host's current culture (#516).
+    private void EmitTSDateLocaleString(TypeBuilder typeBuilder, EmittedRuntime runtime, string methodName, string format)
+    {
+        var method = typeBuilder.DefineMethod(methodName, MethodAttributes.Public, _types.String, Type.EmptyTypes);
+        runtime.TSDateMethods[methodName] = method;
+
+        var il = method.GetILGenerator();
+        var validLabel = il.DefineLabel();
+
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, _tsDateIsInvalidField);
+        il.Emit(OpCodes.Brfalse, validLabel);
+        il.Emit(OpCodes.Ldstr, "Invalid Date");
+        il.Emit(OpCodes.Ret);
+
+        il.MarkLabel(validLabel);
         var localTimeLocal = il.DeclareLocal(_types.DateTime);
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ldflda, _tsDateUtcDateTimeField);
         il.Emit(OpCodes.Call, _types.DateTime.GetMethod("ToLocalTime")!);
         il.Emit(OpCodes.Stloc, localTimeLocal);
-
-        var newDateLocal = il.DeclareLocal(_types.DateTime);
         il.Emit(OpCodes.Ldloca, localTimeLocal);
-        il.Emit(OpCodes.Call, _types.DateTime.GetProperty("Year")!.GetGetMethod()!);
-        il.Emit(OpCodes.Ldloca, localTimeLocal);
-        il.Emit(OpCodes.Call, _types.DateTime.GetProperty("Month")!.GetGetMethod()!);
-        il.Emit(OpCodes.Ldarg_1);
-        il.Emit(OpCodes.Conv_I4);  // day
-        il.Emit(OpCodes.Ldloca, localTimeLocal);
-        il.Emit(OpCodes.Call, _types.DateTime.GetProperty("Hour")!.GetGetMethod()!);
-        il.Emit(OpCodes.Ldloca, localTimeLocal);
-        il.Emit(OpCodes.Call, _types.DateTime.GetProperty("Minute")!.GetGetMethod()!);
-        il.Emit(OpCodes.Ldloca, localTimeLocal);
-        il.Emit(OpCodes.Call, _types.DateTime.GetProperty("Second")!.GetGetMethod()!);
-        il.Emit(OpCodes.Ldloca, localTimeLocal);
-        il.Emit(OpCodes.Call, _types.DateTime.GetProperty("Millisecond")!.GetGetMethod()!);
-        il.Emit(OpCodes.Ldc_I4_2);
-        il.Emit(OpCodes.Newobj, _types.DateTime.GetConstructor([
-            _types.Int32, _types.Int32, _types.Int32, _types.Int32, _types.Int32, _types.Int32, _types.Int32, _types.DateTimeKind
-        ])!);
-        il.Emit(OpCodes.Stloc, newDateLocal);
-
-        il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Ldloca, newDateLocal);
-        il.Emit(OpCodes.Call, _types.DateTime.GetMethod("ToUniversalTime")!);
-        il.Emit(OpCodes.Stfld, _tsDateUtcDateTimeField);
-        il.Emit(OpCodes.Br, endLabel);
-
-        il.MarkLabel(invalidLabel);
-        il.MarkLabel(endLabel);
-        il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Call, _tsDateGetTimeMethod);
-        il.Emit(OpCodes.Ret);
-    }
-
-    private void EmitTSDateSetHours(TypeBuilder typeBuilder, EmittedRuntime runtime)
-    {
-        var method = typeBuilder.DefineMethod("SetHours", MethodAttributes.Public, _types.Double, [_types.Double]);
-        runtime.TSDateMethods["SetHours"] = method;
-
-        var il = method.GetILGenerator();
-        var invalidLabel = il.DefineLabel();
-        var endLabel = il.DefineLabel();
-
-        il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Ldfld, _tsDateIsInvalidField);
-        il.Emit(OpCodes.Brtrue, invalidLabel);
-
-        var localTimeLocal = il.DeclareLocal(_types.DateTime);
-        il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Ldflda, _tsDateUtcDateTimeField);
-        il.Emit(OpCodes.Call, _types.DateTime.GetMethod("ToLocalTime")!);
-        il.Emit(OpCodes.Stloc, localTimeLocal);
-
-        var newDateLocal = il.DeclareLocal(_types.DateTime);
-        il.Emit(OpCodes.Ldloca, localTimeLocal);
-        il.Emit(OpCodes.Call, _types.DateTime.GetProperty("Year")!.GetGetMethod()!);
-        il.Emit(OpCodes.Ldloca, localTimeLocal);
-        il.Emit(OpCodes.Call, _types.DateTime.GetProperty("Month")!.GetGetMethod()!);
-        il.Emit(OpCodes.Ldloca, localTimeLocal);
-        il.Emit(OpCodes.Call, _types.DateTime.GetProperty("Day")!.GetGetMethod()!);
-        il.Emit(OpCodes.Ldarg_1);
-        il.Emit(OpCodes.Conv_I4);  // hours
-        il.Emit(OpCodes.Ldloca, localTimeLocal);
-        il.Emit(OpCodes.Call, _types.DateTime.GetProperty("Minute")!.GetGetMethod()!);
-        il.Emit(OpCodes.Ldloca, localTimeLocal);
-        il.Emit(OpCodes.Call, _types.DateTime.GetProperty("Second")!.GetGetMethod()!);
-        il.Emit(OpCodes.Ldloca, localTimeLocal);
-        il.Emit(OpCodes.Call, _types.DateTime.GetProperty("Millisecond")!.GetGetMethod()!);
-        il.Emit(OpCodes.Ldc_I4_2);
-        il.Emit(OpCodes.Newobj, _types.DateTime.GetConstructor([
-            _types.Int32, _types.Int32, _types.Int32, _types.Int32, _types.Int32, _types.Int32, _types.Int32, _types.DateTimeKind
-        ])!);
-        il.Emit(OpCodes.Stloc, newDateLocal);
-
-        il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Ldloca, newDateLocal);
-        il.Emit(OpCodes.Call, _types.DateTime.GetMethod("ToUniversalTime")!);
-        il.Emit(OpCodes.Stfld, _tsDateUtcDateTimeField);
-        il.Emit(OpCodes.Br, endLabel);
-
-        il.MarkLabel(invalidLabel);
-        il.MarkLabel(endLabel);
-        il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Call, _tsDateGetTimeMethod);
-        il.Emit(OpCodes.Ret);
-    }
-
-    private void EmitTSDateSetMinutes(TypeBuilder typeBuilder, EmittedRuntime runtime)
-    {
-        EmitDateSetterStub(typeBuilder, runtime, "SetMinutes", [_types.Double]);
-    }
-
-    private void EmitTSDateSetSeconds(TypeBuilder typeBuilder, EmittedRuntime runtime)
-    {
-        EmitDateSetterStub(typeBuilder, runtime, "SetSeconds", [_types.Double]);
-    }
-
-    private void EmitTSDateSetMilliseconds(TypeBuilder typeBuilder, EmittedRuntime runtime)
-    {
-        EmitDateSetterStub(typeBuilder, runtime, "SetMilliseconds", [_types.Double]);
-    }
-
-    private void EmitDateSetterStub(TypeBuilder typeBuilder, EmittedRuntime runtime, string name, Type[] paramTypes)
-    {
-        // Stub setter for less common setters - just returns current time
-        var method = typeBuilder.DefineMethod(
-            name,
-            MethodAttributes.Public,
-            _types.Double,
-            paramTypes
-        );
-        runtime.TSDateMethods[name] = method;
-
-        var il = method.GetILGenerator();
-        il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Call, _tsDateGetTimeMethod);
+        il.Emit(OpCodes.Ldstr, format);
+        il.Emit(OpCodes.Call, typeof(CultureInfo).GetProperty("CurrentCulture")!.GetGetMethod()!);
+        il.Emit(OpCodes.Call, _types.DateTime.GetMethod("ToString", [_types.String, typeof(IFormatProvider)])!);
         il.Emit(OpCodes.Ret);
     }
 

--- a/Runtime/BuiltIns/BuiltInTypes.cs
+++ b/Runtime/BuiltIns/BuiltInTypes.cs
@@ -356,25 +356,54 @@ public static class BuiltInTypes
             "getMilliseconds" => new TypeInfo.Function([], NumberType),
             "getTimezoneOffset" => new TypeInfo.Function([], NumberType),
 
-            // Setters - all return number (the new timestamp)
+            // UTC getters - all return number
+            "getUTCFullYear" => new TypeInfo.Function([], NumberType),
+            "getUTCMonth" => new TypeInfo.Function([], NumberType),
+            "getUTCDate" => new TypeInfo.Function([], NumberType),
+            "getUTCDay" => new TypeInfo.Function([], NumberType),
+            "getUTCHours" => new TypeInfo.Function([], NumberType),
+            "getUTCMinutes" => new TypeInfo.Function([], NumberType),
+            "getUTCSeconds" => new TypeInfo.Function([], NumberType),
+            "getUTCMilliseconds" => new TypeInfo.Function([], NumberType),
+
+            // Setters - all return number (the new timestamp). Trailing components
+            // are optional per lib.es5 (e.g. setFullYear(year, month?, date?)).
             "setTime" => new TypeInfo.Function([NumberType], NumberType),
-            "setFullYear" => new TypeInfo.Function([NumberType], NumberType),  // month, date optional
-            "setMonth" => new TypeInfo.Function([NumberType], NumberType),     // date optional
+            "setFullYear" => new TypeInfo.Function([NumberType, NumberType, NumberType], NumberType, RequiredParams: 1),
+            "setMonth" => new TypeInfo.Function([NumberType, NumberType], NumberType, RequiredParams: 1),
             "setDate" => new TypeInfo.Function([NumberType], NumberType),
-            "setHours" => new TypeInfo.Function([NumberType], NumberType),     // min, sec, ms optional
-            "setMinutes" => new TypeInfo.Function([NumberType], NumberType),   // sec, ms optional
-            "setSeconds" => new TypeInfo.Function([NumberType], NumberType),   // ms optional
+            "setHours" => new TypeInfo.Function([NumberType, NumberType, NumberType, NumberType], NumberType, RequiredParams: 1),
+            "setMinutes" => new TypeInfo.Function([NumberType, NumberType, NumberType], NumberType, RequiredParams: 1),
+            "setSeconds" => new TypeInfo.Function([NumberType, NumberType], NumberType, RequiredParams: 1),
             "setMilliseconds" => new TypeInfo.Function([NumberType], NumberType),
+
+            // UTC setters - mirror the local setters' optional-trailing-component shape
+            "setUTCFullYear" => new TypeInfo.Function([NumberType, NumberType, NumberType], NumberType, RequiredParams: 1),
+            "setUTCMonth" => new TypeInfo.Function([NumberType, NumberType], NumberType, RequiredParams: 1),
+            "setUTCDate" => new TypeInfo.Function([NumberType], NumberType),
+            "setUTCHours" => new TypeInfo.Function([NumberType, NumberType, NumberType, NumberType], NumberType, RequiredParams: 1),
+            "setUTCMinutes" => new TypeInfo.Function([NumberType, NumberType, NumberType], NumberType, RequiredParams: 1),
+            "setUTCSeconds" => new TypeInfo.Function([NumberType, NumberType], NumberType, RequiredParams: 1),
+            "setUTCMilliseconds" => new TypeInfo.Function([NumberType], NumberType),
 
             // Conversion methods
             "toString" => new TypeInfo.Function([], StringType),
             "toISOString" => new TypeInfo.Function([], StringType),
             "toDateString" => new TypeInfo.Function([], StringType),
             "toTimeString" => new TypeInfo.Function([], StringType),
+            "toUTCString" => new TypeInfo.Function([], StringType),
+            // toLocale* accept optional (locales?, options?) per lib.es2020.date.
+            "toLocaleDateString" => new TypeInfo.Function([AnyType, AnyType], StringType, RequiredParams: 0),
+            "toLocaleTimeString" => new TypeInfo.Function([AnyType, AnyType], StringType, RequiredParams: 0),
+            "toLocaleString" => new TypeInfo.Function([AnyType, AnyType], StringType, RequiredParams: 0),
             // lib.es5: `toJSON(key?: any): string` (used by JSON.stringify and matched by
             // `T extends { toJSON(): infer R }`, see #491). Runtime impl in DateBuiltIns.
             "toJSON" => new TypeInfo.Function([], StringType),
             "valueOf" => new TypeInfo.Function([], NumberType),
+
+            // Legacy methods (ECMA-262 Annex B), declared on Date in lib.es5.
+            "getYear" => new TypeInfo.Function([], NumberType),
+            "setYear" => new TypeInfo.Function([NumberType], NumberType),
 
             _ => null
         };

--- a/Runtime/BuiltIns/DateBuiltIns.cs
+++ b/Runtime/BuiltIns/DateBuiltIns.cs
@@ -30,6 +30,15 @@ public static class DateBuiltIns
             .MethodV2("getSeconds", 0, (_, date, _) => RuntimeValue.FromNumber(date.GetSeconds()))
             .MethodV2("getMilliseconds", 0, (_, date, _) => RuntimeValue.FromNumber(date.GetMilliseconds()))
             .MethodV2("getTimezoneOffset", 0, (_, date, _) => RuntimeValue.FromNumber(date.GetTimezoneOffset()))
+            // UTC Getter Methods
+            .MethodV2("getUTCFullYear", 0, (_, date, _) => RuntimeValue.FromNumber(date.GetUTCFullYear()))
+            .MethodV2("getUTCMonth", 0, (_, date, _) => RuntimeValue.FromNumber(date.GetUTCMonth()))
+            .MethodV2("getUTCDate", 0, (_, date, _) => RuntimeValue.FromNumber(date.GetUTCDate()))
+            .MethodV2("getUTCDay", 0, (_, date, _) => RuntimeValue.FromNumber(date.GetUTCDay()))
+            .MethodV2("getUTCHours", 0, (_, date, _) => RuntimeValue.FromNumber(date.GetUTCHours()))
+            .MethodV2("getUTCMinutes", 0, (_, date, _) => RuntimeValue.FromNumber(date.GetUTCMinutes()))
+            .MethodV2("getUTCSeconds", 0, (_, date, _) => RuntimeValue.FromNumber(date.GetUTCSeconds()))
+            .MethodV2("getUTCMilliseconds", 0, (_, date, _) => RuntimeValue.FromNumber(date.GetUTCMilliseconds()))
             // Setter Methods
             .MethodV2("setTime", 1, (_, date, args) =>
                 RuntimeValue.FromNumber(date.SetTime(args[0].AsNumber())))
@@ -61,17 +70,56 @@ public static class DateBuiltIns
                     args.Length > 1 && args[1].Kind != ValueKind.Undefined ? (double?)args[1].AsNumber() : null)))
             .MethodV2("setMilliseconds", 1, (_, date, args) =>
                 RuntimeValue.FromNumber(date.SetMilliseconds(args[0].AsNumber())))
+            // UTC Setter Methods
+            .MethodV2("setUTCFullYear", 1, 3, (_, date, args) =>
+                RuntimeValue.FromNumber(date.SetUTCFullYear(
+                    args[0].AsNumber(),
+                    args.Length > 1 && args[1].Kind != ValueKind.Undefined ? (double?)args[1].AsNumber() : null,
+                    args.Length > 2 && args[2].Kind != ValueKind.Undefined ? (double?)args[2].AsNumber() : null)))
+            .MethodV2("setUTCMonth", 1, 2, (_, date, args) =>
+                RuntimeValue.FromNumber(date.SetUTCMonth(
+                    args[0].AsNumber(),
+                    args.Length > 1 && args[1].Kind != ValueKind.Undefined ? (double?)args[1].AsNumber() : null)))
+            .MethodV2("setUTCDate", 1, (_, date, args) =>
+                RuntimeValue.FromNumber(date.SetUTCDate(args[0].AsNumber())))
+            .MethodV2("setUTCHours", 1, 4, (_, date, args) =>
+                RuntimeValue.FromNumber(date.SetUTCHours(
+                    args[0].AsNumber(),
+                    args.Length > 1 && args[1].Kind != ValueKind.Undefined ? (double?)args[1].AsNumber() : null,
+                    args.Length > 2 && args[2].Kind != ValueKind.Undefined ? (double?)args[2].AsNumber() : null,
+                    args.Length > 3 && args[3].Kind != ValueKind.Undefined ? (double?)args[3].AsNumber() : null)))
+            .MethodV2("setUTCMinutes", 1, 3, (_, date, args) =>
+                RuntimeValue.FromNumber(date.SetUTCMinutes(
+                    args[0].AsNumber(),
+                    args.Length > 1 && args[1].Kind != ValueKind.Undefined ? (double?)args[1].AsNumber() : null,
+                    args.Length > 2 && args[2].Kind != ValueKind.Undefined ? (double?)args[2].AsNumber() : null)))
+            .MethodV2("setUTCSeconds", 1, 2, (_, date, args) =>
+                RuntimeValue.FromNumber(date.SetUTCSeconds(
+                    args[0].AsNumber(),
+                    args.Length > 1 && args[1].Kind != ValueKind.Undefined ? (double?)args[1].AsNumber() : null)))
+            .MethodV2("setUTCMilliseconds", 1, (_, date, args) =>
+                RuntimeValue.FromNumber(date.SetUTCMilliseconds(args[0].AsNumber())))
             // Conversion Methods
             .MethodV2("toString", 0, (_, date, _) => RuntimeValue.FromString(date.ToString()!))
             .MethodV2("toISOString", 0, (_, date, _) => RuntimeValue.FromString(date.ToISOString()))
             .MethodV2("toDateString", 0, (_, date, _) => RuntimeValue.FromString(date.ToDateString()))
             .MethodV2("toTimeString", 0, (_, date, _) => RuntimeValue.FromString(date.ToTimeString()))
+            .MethodV2("toUTCString", 0, (_, date, _) => RuntimeValue.FromString(date.ToUTCString()))
+            // toLocale* accept optional (locales, options) per lib.es2020.date; the runtime
+            // ignores them (formats with the host culture) — see SharpTSDate for rationale.
+            .MethodV2("toLocaleDateString", 0, 2, (_, date, _) => RuntimeValue.FromString(date.ToLocaleDateString()))
+            .MethodV2("toLocaleTimeString", 0, 2, (_, date, _) => RuntimeValue.FromString(date.ToLocaleTimeString()))
+            .MethodV2("toLocaleString", 0, 2, (_, date, _) => RuntimeValue.FromString(date.ToLocaleString()))
             // ECMA-262 §21.4.4.37: toJSON returns the ISO string, or null for a non-finite
             // (Invalid) date — guard so we never reach ToISOString's RangeError throw.
             .MethodV2("toJSON", 0, (_, date, _) => double.IsNaN(date.GetTime())
                 ? RuntimeValue.Null
                 : RuntimeValue.FromString(date.ToISOString()))
             .MethodV2("valueOf", 0, (_, date, _) => RuntimeValue.FromNumber(date.ValueOf()))
+            // Legacy methods (ECMA-262 Annex B)
+            .MethodV2("getYear", 0, (_, date, _) => RuntimeValue.FromNumber(date.GetYear()))
+            .MethodV2("setYear", 1, (_, date, args) =>
+                RuntimeValue.FromNumber(date.SetYear(args[0].AsNumber())))
             .Build();
 
     /// <summary>

--- a/Runtime/Types/SharpTSDate.cs
+++ b/Runtime/Types/SharpTSDate.cs
@@ -242,6 +242,65 @@ public class SharpTSDate : ITypeCategorized
         return -TimeZoneInfo.Local.GetUtcOffset(_utcDateTime).TotalMinutes;
     }
 
+    // ========== UTC Getter Methods ==========
+    // These read the stored UTC instant directly, with no local-time conversion.
+
+    /// <summary>Returns the 4-digit year in UTC.</summary>
+    public double GetUTCFullYear()
+    {
+        if (_isInvalid) return double.NaN;
+        return _utcDateTime.Year;
+    }
+
+    /// <summary>Returns the month (0-11) in UTC. 0 = January, 11 = December.</summary>
+    public double GetUTCMonth()
+    {
+        if (_isInvalid) return double.NaN;
+        return _utcDateTime.Month - 1; // Convert to 0-indexed
+    }
+
+    /// <summary>Returns the day of the month (1-31) in UTC.</summary>
+    public double GetUTCDate()
+    {
+        if (_isInvalid) return double.NaN;
+        return _utcDateTime.Day;
+    }
+
+    /// <summary>Returns the day of the week (0-6) in UTC. 0 = Sunday, 6 = Saturday.</summary>
+    public double GetUTCDay()
+    {
+        if (_isInvalid) return double.NaN;
+        return (double)_utcDateTime.DayOfWeek;
+    }
+
+    /// <summary>Returns the hour (0-23) in UTC.</summary>
+    public double GetUTCHours()
+    {
+        if (_isInvalid) return double.NaN;
+        return _utcDateTime.Hour;
+    }
+
+    /// <summary>Returns the minutes (0-59) in UTC.</summary>
+    public double GetUTCMinutes()
+    {
+        if (_isInvalid) return double.NaN;
+        return _utcDateTime.Minute;
+    }
+
+    /// <summary>Returns the seconds (0-59) in UTC.</summary>
+    public double GetUTCSeconds()
+    {
+        if (_isInvalid) return double.NaN;
+        return _utcDateTime.Second;
+    }
+
+    /// <summary>Returns the milliseconds (0-999) in UTC.</summary>
+    public double GetUTCMilliseconds()
+    {
+        if (_isInvalid) return double.NaN;
+        return _utcDateTime.Millisecond;
+    }
+
     // ========== Setter Methods ==========
     // All setters mutate the date and return the new timestamp
 
@@ -444,6 +503,186 @@ public class SharpTSDate : ITypeCategorized
         return GetTime();
     }
 
+    // ========== UTC Setter Methods ==========
+    // These build the new instant directly in UTC; no local-time round-trip.
+    // Overflowing components roll over (e.g. setUTCMonth(13) advances the year),
+    // matching JavaScript semantics via DateTime's Add* methods.
+
+    /// <summary>
+    /// Sets the UTC full year, optionally also month and day. Returns the new timestamp.
+    /// </summary>
+    public double SetUTCFullYear(double year, double? month = null, double? date = null)
+    {
+        if (_isInvalid) return double.NaN;
+
+        var utc = _utcDateTime;
+        int newYear = (int)year;
+        int newMonth = month.HasValue ? (int)month.Value + 1 : utc.Month; // Convert 0-indexed to 1-indexed
+        int newDay = date.HasValue ? (int)date.Value : utc.Day;
+
+        try
+        {
+            _utcDateTime = new DateTime(newYear, 1, 1, utc.Hour, utc.Minute, utc.Second, utc.Millisecond, DateTimeKind.Utc)
+                .AddMonths(newMonth - 1)
+                .AddDays(newDay - 1);
+        }
+        catch
+        {
+            _isInvalid = true;
+        }
+
+        return GetTime();
+    }
+
+    /// <summary>
+    /// Sets the UTC month (0-indexed), optionally also day. Returns the new timestamp.
+    /// </summary>
+    public double SetUTCMonth(double month, double? date = null)
+    {
+        if (_isInvalid) return double.NaN;
+
+        var utc = _utcDateTime;
+        int newDay = date.HasValue ? (int)date.Value : utc.Day;
+
+        try
+        {
+            _utcDateTime = new DateTime(utc.Year, 1, 1, utc.Hour, utc.Minute, utc.Second, utc.Millisecond, DateTimeKind.Utc)
+                .AddMonths((int)month)
+                .AddDays(newDay - 1);
+        }
+        catch
+        {
+            _isInvalid = true;
+        }
+
+        return GetTime();
+    }
+
+    /// <summary>
+    /// Sets the UTC day of the month. Returns the new timestamp.
+    /// </summary>
+    public double SetUTCDate(double date)
+    {
+        if (_isInvalid) return double.NaN;
+
+        var utc = _utcDateTime;
+
+        try
+        {
+            _utcDateTime = new DateTime(utc.Year, utc.Month, 1, utc.Hour, utc.Minute, utc.Second, utc.Millisecond, DateTimeKind.Utc)
+                .AddDays((int)date - 1);
+        }
+        catch
+        {
+            _isInvalid = true;
+        }
+
+        return GetTime();
+    }
+
+    /// <summary>
+    /// Sets the UTC hour, optionally also minutes, seconds, and milliseconds. Returns the new timestamp.
+    /// </summary>
+    public double SetUTCHours(double hours, double? min = null, double? sec = null, double? ms = null)
+    {
+        if (_isInvalid) return double.NaN;
+
+        var utc = _utcDateTime;
+        int newHours = (int)hours;
+        int newMin = min.HasValue ? (int)min.Value : utc.Minute;
+        int newSec = sec.HasValue ? (int)sec.Value : utc.Second;
+        int newMs = ms.HasValue ? (int)ms.Value : utc.Millisecond;
+
+        try
+        {
+            _utcDateTime = new DateTime(utc.Year, utc.Month, utc.Day, 0, 0, 0, 0, DateTimeKind.Utc)
+                .AddHours(newHours)
+                .AddMinutes(newMin)
+                .AddSeconds(newSec)
+                .AddMilliseconds(newMs);
+        }
+        catch
+        {
+            _isInvalid = true;
+        }
+
+        return GetTime();
+    }
+
+    /// <summary>
+    /// Sets the UTC minutes, optionally also seconds and milliseconds. Returns the new timestamp.
+    /// </summary>
+    public double SetUTCMinutes(double min, double? sec = null, double? ms = null)
+    {
+        if (_isInvalid) return double.NaN;
+
+        var utc = _utcDateTime;
+        int newMin = (int)min;
+        int newSec = sec.HasValue ? (int)sec.Value : utc.Second;
+        int newMs = ms.HasValue ? (int)ms.Value : utc.Millisecond;
+
+        try
+        {
+            _utcDateTime = new DateTime(utc.Year, utc.Month, utc.Day, utc.Hour, 0, 0, 0, DateTimeKind.Utc)
+                .AddMinutes(newMin)
+                .AddSeconds(newSec)
+                .AddMilliseconds(newMs);
+        }
+        catch
+        {
+            _isInvalid = true;
+        }
+
+        return GetTime();
+    }
+
+    /// <summary>
+    /// Sets the UTC seconds, optionally also milliseconds. Returns the new timestamp.
+    /// </summary>
+    public double SetUTCSeconds(double sec, double? ms = null)
+    {
+        if (_isInvalid) return double.NaN;
+
+        var utc = _utcDateTime;
+        int newSec = (int)sec;
+        int newMs = ms.HasValue ? (int)ms.Value : utc.Millisecond;
+
+        try
+        {
+            _utcDateTime = new DateTime(utc.Year, utc.Month, utc.Day, utc.Hour, utc.Minute, 0, 0, DateTimeKind.Utc)
+                .AddSeconds(newSec)
+                .AddMilliseconds(newMs);
+        }
+        catch
+        {
+            _isInvalid = true;
+        }
+
+        return GetTime();
+    }
+
+    /// <summary>
+    /// Sets the UTC milliseconds. Returns the new timestamp.
+    /// </summary>
+    public double SetUTCMilliseconds(double ms)
+    {
+        if (_isInvalid) return double.NaN;
+
+        var utc = _utcDateTime;
+
+        try
+        {
+            _utcDateTime = new DateTime(utc.Year, utc.Month, utc.Day, utc.Hour, utc.Minute, utc.Second, 0, DateTimeKind.Utc)
+                .AddMilliseconds((int)ms);
+        }
+        catch
+        {
+            _isInvalid = true;
+        }
+
+        return GetTime();
+    }
+
     // ========== Conversion Methods ==========
 
     /// <summary>
@@ -500,11 +739,71 @@ public class SharpTSDate : ITypeCategorized
     }
 
     /// <summary>
+    /// Returns the date as a UTC string in RFC 7231 format, e.g. "Thu, 01 Jan 1970 00:00:00 GMT".
+    /// </summary>
+    public string ToUTCString()
+    {
+        if (_isInvalid) return "Invalid Date";
+        return _utcDateTime.ToString("ddd, dd MMM yyyy HH:mm:ss 'GMT'", CultureInfo.InvariantCulture);
+    }
+
+    // The toLocale* family formats in local time using the host's current culture.
+    // Locale/options arguments (lib.es2020.date) are accepted by the type checker but
+    // not yet honored at runtime — full Intl-options support would route through
+    // SharpTSIntlDateTimeFormat (see #539). Output is implementation-defined per
+    // ECMA-262, so callers should not depend on the exact format.
+
+    /// <summary>Returns the date portion as a locale-formatted string in local time.</summary>
+    public string ToLocaleDateString()
+    {
+        if (_isInvalid) return "Invalid Date";
+        return _utcDateTime.ToLocalTime().ToString("d", CultureInfo.CurrentCulture);
+    }
+
+    /// <summary>Returns the time portion as a locale-formatted string in local time.</summary>
+    public string ToLocaleTimeString()
+    {
+        if (_isInvalid) return "Invalid Date";
+        return _utcDateTime.ToLocalTime().ToString("T", CultureInfo.CurrentCulture);
+    }
+
+    /// <summary>Returns the full date and time as a locale-formatted string in local time.</summary>
+    public string ToLocaleString()
+    {
+        if (_isInvalid) return "Invalid Date";
+        return _utcDateTime.ToLocalTime().ToString("G", CultureInfo.CurrentCulture);
+    }
+
+    /// <summary>
     /// Returns the primitive value (timestamp) of the date.
     /// </summary>
     public double ValueOf()
     {
         return GetTime();
+    }
+
+    // ========== Legacy Methods (ECMA-262 Annex B) ==========
+
+    /// <summary>
+    /// ECMA-262 Annex B B.2.4.1: returns the local-time year minus 1900.
+    /// </summary>
+    public double GetYear()
+    {
+        if (_isInvalid) return double.NaN;
+        return _utcDateTime.ToLocalTime().Year - 1900;
+    }
+
+    /// <summary>
+    /// ECMA-262 Annex B B.2.4.2: sets the local-time year, mapping 0-99 to 1900-1999.
+    /// Returns the new timestamp.
+    /// </summary>
+    public double SetYear(double year)
+    {
+        if (_isInvalid) return double.NaN;
+
+        int y = (int)year;
+        if (y >= 0 && y <= 99) y += 1900;
+        return SetFullYear(y);
     }
 
     /// <summary>

--- a/SharpTS.Tests/SharedTests/DateTests.cs
+++ b/SharpTS.Tests/SharedTests/DateTests.cs
@@ -345,4 +345,152 @@ public class DateTests
     }
 
     #endregion
+
+    #region UTC, Locale, and Legacy Methods (issue #516)
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Date_UTCGetters_ReadEpochInUTC(ExecutionMode mode)
+    {
+        // UTC getters read the stored instant directly, so the result is timezone-independent.
+        var source = @"
+            let d = new Date(0);
+            console.log(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate(), d.getUTCDay());
+            console.log(d.getUTCHours(), d.getUTCMinutes(), d.getUTCSeconds(), d.getUTCMilliseconds());
+        ";
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("1970 0 1 4\n0 0 0 0\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Date_UTCSetters_MutateInUTC(ExecutionMode mode)
+    {
+        // Single-argument setters behave identically in both modes (no optional args dropped).
+        var source = @"
+            let d = new Date(0);
+            d.setUTCFullYear(2020);
+            d.setUTCMonth(5);
+            d.setUTCDate(15);
+            d.setUTCHours(13);
+            d.setUTCMinutes(30);
+            d.setUTCSeconds(45);
+            d.setUTCMilliseconds(500);
+            console.log(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate());
+            console.log(d.getUTCHours(), d.getUTCMinutes(), d.getUTCSeconds(), d.getUTCMilliseconds());
+        ";
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("2020 5 15\n13 30 45 500\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Date_SetUTCMonth_RollsOver(ExecutionMode mode)
+    {
+        // setUTCMonth(13) advances into the next year (month 1 = February).
+        var source = @"
+            let d = new Date(0);
+            d.setUTCFullYear(2024);
+            d.setUTCMonth(13);
+            console.log(d.getUTCFullYear(), d.getUTCMonth());
+        ";
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("2025 1\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Date_ToUTCString_FormatsInRFC7231(ExecutionMode mode)
+    {
+        var source = @"
+            let d = new Date(0);
+            console.log(d.toUTCString());
+        ";
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("Thu, 01 Jan 1970 00:00:00 GMT\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Date_ToLocaleMethods_ReturnStrings(ExecutionMode mode)
+    {
+        // Output is locale/host-defined, so assert only that they return non-empty strings.
+        var source = @"
+            let d = new Date(0);
+            console.log(typeof d.toLocaleDateString(), d.toLocaleDateString().length > 0);
+            console.log(typeof d.toLocaleTimeString(), d.toLocaleTimeString().length > 0);
+            console.log(typeof d.toLocaleString(), d.toLocaleString().length > 0);
+        ";
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("string true\nstring true\nstring true\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Date_GetYearAndSetYear_AnnexB(ExecutionMode mode)
+    {
+        // getYear/setYear operate in local time; constructing and reading locally is TZ-independent.
+        // setYear maps 0-99 to 1900-1999 but leaves four-digit years unchanged.
+        var source = @"
+            let d = new Date(2024, 5, 15);
+            console.log(d.getYear());
+            d.setYear(99);
+            console.log(d.getFullYear());
+            d.setYear(2005);
+            console.log(d.getFullYear());
+        ";
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("124\n1999\n2005\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Date_InvalidDate_NewMembersDegradeGracefully(ExecutionMode mode)
+    {
+        var source = @"
+            let d = new Date(NaN);
+            console.log(d.toUTCString());
+            console.log(d.toLocaleDateString());
+            console.log(Number.isNaN(d.getUTCFullYear()));
+            console.log(Number.isNaN(d.setUTCSeconds(30)));
+        ";
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("Invalid Date\nInvalid Date\ntrue\ntrue\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Date_SetMinutesAndSeconds_MutateInBothModes(ExecutionMode mode)
+    {
+        // Regression guard: compiled setMinutes/setSeconds/setMilliseconds were previously
+        // no-op stubs (issue #516 fix). Local get/set round-trips are timezone-independent.
+        var source = @"
+            let d = new Date(2024, 0, 1, 10, 20, 30, 40);
+            d.setMinutes(45);
+            d.setSeconds(50);
+            d.setMilliseconds(123);
+            console.log(d.getMinutes(), d.getSeconds(), d.getMilliseconds());
+        ";
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("45 50 123\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void Date_UTCSetters_OptionalArgs_Interpreted(ExecutionMode mode)
+    {
+        // The interpreter honors the optional trailing arguments of the multi-argument UTC
+        // setters. (Compiled mode currently honors only the primary argument — tracked separately.)
+        var source = @"
+            let d = new Date(0);
+            d.setUTCFullYear(2020, 5, 15);
+            d.setUTCHours(13, 30, 45, 500);
+            console.log(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate());
+            console.log(d.getUTCHours(), d.getUTCMinutes(), d.getUTCSeconds(), d.getUTCMilliseconds());
+        ";
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("2020 5 15\n13 30 45 500\n", output);
+    }
+
+    #endregion
 }


### PR DESCRIPTION
Closes #516.

The `Date` prototype was only partially modeled. This adds the standard instance members that were failing type-checking with **TS2339** and had no runtime implementation in either mode, following the same three-layer pattern (#491) — type model, interpreter, and compiler all kept in sync.

## Members added

- **UTC getters:** `getUTCFullYear`, `getUTCMonth`, `getUTCDate`, `getUTCDay`, `getUTCHours`, `getUTCMinutes`, `getUTCSeconds`, `getUTCMilliseconds`
- **UTC setters:** `setUTCFullYear`, `setUTCMonth`, `setUTCDate`, `setUTCHours`, `setUTCMinutes`, `setUTCSeconds`, `setUTCMilliseconds`
- **Conversion:** `toUTCString` (RFC 7231, e.g. `Thu, 01 Jan 1970 00:00:00 GMT`), `toLocaleDateString`, `toLocaleTimeString`, `toLocaleString`
- **Legacy (Annex B):** `getYear`, `setYear`

## How

| Layer | Change |
|-------|--------|
| Type | `BuiltInTypes.GetDateInstanceMemberType` — signatures for all new members (UTC setters use `RequiredParams` for optional trailing components; `toLocale*` accept optional `locales`/`options`). Also relaxes the existing local setter signatures to accept their optional components per lib.es5. |
| Interpreter | `SharpTSDate` (UTC getters/setters read & write the stored UTC instant directly; `toUTCString`/`toLocale*`; Annex B) + `DateBuiltIns` dispatch. |
| Compiler | Emitted `$TSDate` methods + `$Runtime.Date*` wrappers + `DateEmitter` dispatch. The getters/setters are consolidated behind shared emitters (`EmitSimpleDateGetter` gains `utc`/`subtractAfter`; new `EmitDateComponentSetter` rebuilds the instant overflow-safely with a try/catch). |

`SharpTSDate` stores UTC internally, so the UTC accessors are exact and **timezone-independent** (which makes them cleanly testable). Overflowing components roll over per JS semantics (e.g. `setUTCMonth(13)` advances the year).

### Bonus fix

Consolidating the compiled setters fixed a **pre-existing bug**: `$TSDate.SetMinutes`/`SetSeconds`/`SetMilliseconds` were no-op stubs, so compiled `setMinutes`/`setSeconds`/`setMilliseconds` silently did nothing. They now mutate correctly (regression test added).

## Tests

- New shared `DateTests` (both interpreter & compiled): UTC getters, single-arg UTC setters, `setUTCMonth` rollover, `toUTCString`, `toLocale*`, `getYear`/`setYear`, invalid-date degradation, and a `setMinutes`/`setSeconds`/`setMilliseconds` regression guard.
- Interpreter-only test pinning the multi-arg-setter optional-argument behavior.
- `RuntimeTypeSyncTests` enforces `SharpTSDate` ↔ `$TSDate` method parity.
- Full unit suite (**11706**), TypeScript conformance (**31/31**, no baseline shift), and Test262 `Diagnostic_NoRegressions` all green. (No `built-ins/Date/` tests are in the Test262 sampled subset, so the baseline is unaffected.)

## Known gaps filed

- #536 — compiled multi-argument setters honor only the primary argument (interpreter & types support the optional ones). Covered by an interpreter-only test documenting the divergence.
- #537 — pre-existing: single-`double`-arg setters as bare statements/assignments fail strict ILVerify (`StackUnexpected`) though they run correctly.
- #538 — `Date.UTC` / `Date.parse` statics still unmodeled.
- #539 — `toLocale*` ignores the `locales`/`options` arguments (uses host culture).