### PR TITLE
Fix #499: compiled generator next() after completion replays the stale value

### DIFF
--- a/Compilation/GeneratorMoveNextEmitter.cs
+++ b/Compilation/GeneratorMoveNextEmitter.cs
@@ -113,8 +113,20 @@ public partial class GeneratorMoveNextEmitter : StatementEmitterBase
         _il.Emit(OpCodes.Ldc_I4_0);
         _il.Emit(OpCodes.Ret);
 
-        // Return false label (generator completed)
+        // Return false label — re-entry on an already-completed generator (state == -2):
+        // `gen.next()` called after the generator finished, or after `gen.return(v)`.
+        // Per ECMA-262 27.5.1.2, a completed generator's `next()` always reports
+        // `{ value: undefined, done: true }` — the completion value was already consumed by the
+        // call that finished it. Reset Current to the `$Undefined` sentinel so a stale value does
+        // not leak: an explicit `return X` left X in Current, and `gen.return(v)`
+        // (GeneratorStateMachineBuilder) leaves the last *yielded* value there untouched — either
+        // of which the done-path read of Current in `next()` would otherwise re-surface (#499).
+        // The first MoveNext to complete takes the fall-through / EmitReturn path above (which set
+        // the correct completion value), not this label, so genuine completion values are kept.
         _il.MarkLabel(_returnFalseLabel);
+        _il.Emit(OpCodes.Ldarg_0);
+        _il.Emit(OpCodes.Ldsfld, _ctx!.Runtime!.UndefinedInstance);
+        _il.Emit(OpCodes.Stfld, _builder.CurrentField);
         _il.Emit(OpCodes.Ldc_I4_0);
         _il.Emit(OpCodes.Ret);
     }

--- a/SharpTS.Tests/SharedTests/GeneratorUndefinedValueTests.cs
+++ b/SharpTS.Tests/SharedTests/GeneratorUndefinedValueTests.cs
@@ -161,4 +161,61 @@ public class GeneratorUndefinedValueTests
             """;
         Assert.Equal("a:1\nb:undefined\n", TestHarness.Run(source, mode));
     }
+
+    // ---- #499: `next()` on an already-completed generator yields undefined ----
+    // After a generator completes, every subsequent `.next()` must report
+    // `{ value: undefined, done: true }` (ECMA-262 27.5.1.2). The compiled state machine
+    // previously left a stale value in its Current field on the already-completed re-entry path
+    // (state == -2 → `_returnFalseLabel`), so `.next()` re-surfaced the last `return`ed or yielded
+    // value. The interpreter is already correct for these cases, so they assert cross-mode parity.
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void NextAfterExplicitReturn_IsUndefined(ExecutionMode mode)
+    {
+        // `return 42` is surfaced exactly once; the next `.next()` reports undefined, not 42.
+        var source = """
+            function* g() { yield 1; return 42; }
+            const it = g();
+            console.log("a:" + it.next().value);
+            console.log("b:" + it.next().value);
+            console.log("c:" + it.next().value);
+            console.log("d:" + it.next().value);
+            """;
+        Assert.Equal("a:1\nb:42\nc:undefined\nd:undefined\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void NextAfterReturnMethod_IsUndefined(ExecutionMode mode)
+    {
+        // `gen.return(99)` closes the generator with 99; the next `.next()` reports undefined,
+        // not the stale last-yielded value (1) that the compiler previously leaked.
+        var source = """
+            function* g() { yield 1; yield 2; }
+            const it = g();
+            it.next();
+            const r = it.return(99);
+            console.log("ret:" + r.value + "," + r.done);
+            console.log("after:" + it.next().value);
+            """;
+        Assert.Equal("ret:99,true\nafter:undefined\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void NextAfterOffEndCompletion_StaysUndefined(ExecutionMode mode)
+    {
+        // Repeated `.next()` past a no-return completion keeps reporting undefined (never the
+        // last yielded value). This is the issue's literal repro, extended past the first done.
+        var source = """
+            function* g() { yield 1; yield 11; }
+            const it = g();
+            it.next();
+            it.next();
+            console.log("a:" + it.next().value);
+            console.log("b:" + it.next().value);
+            """;
+        Assert.Equal("a:undefined\nb:undefined\n", TestHarness.Run(source, mode));
+    }
 }


### PR DESCRIPTION
## What

Closes #499. A compiled generator that has already completed (`state == -2`) re-enters `MoveNext` at the `_returnFalseLabel` path, which returned `false` **without** clearing `CurrentField`. Because the emitted `next()` reads `Current` on the done path, calling `.next()` again on a finished generator re-surfaced the last value instead of `undefined`.

```ts
function* g() { yield 1; return 42; }
const it = g();
it.next();        // { value: 1,  done: false }
it.next();        // { value: 42, done: true }   ← return value, delivered once (correct)
it.next().value;  // was 42  →  now undefined
```

The same leak surfaced the last *yielded* value after `gen.return(v)` (which sets `state = -2` but never touches `Current`).

## Fix

#443 already reset `Current` to the emitted `$Undefined` sentinel on the **fall-through** (off-the-end) and **bare `return;`** paths. This PR completes #499 by mirroring that reset on the remaining **`_returnFalseLabel`** (already-completed re-entry) path — exactly the two paths the issue's "Likely cause" calls out.

The first `MoveNext` to complete still takes the fall-through / `EmitReturn` path (which stores the genuine completion value), so `yield* genThatReturns()` and a generator's sole `return X` are unchanged — only a *post-completion* `.next()` now reports `undefined`. Three IL instructions; all emitted IL passes `--verify`.

## Tests

Added three theories to `GeneratorUndefinedValueTests` (run in **both** modes — the interpreter is already correct, so they assert cross-mode parity):
- `NextAfterExplicitReturn_IsUndefined` — `return X` delivered once, then `undefined`.
- `NextAfterReturnMethod_IsUndefined` — `gen.return(v)` then `.next()` → `undefined` (was the stale yielded value).
- `NextAfterOffEndCompletion_StaysUndefined` — repeated `.next()` past an off-end completion stays `undefined`.

Full suite green: **11743 passed, 0 failed**. Test262 default subset shows 0 failures (it runs no generator folders, so the baseline is unaffected; the run ends in the known pre-existing testhost crash). Verified the `yield*`-surfaces-return-value and `for…of`-discards-return-value behaviours are unregressed in both modes.

## Notes / related

- Also resolves the **compiled** half of #480 repro #3 (the sync-interpreter halves of #480 remain open).
- Filed #540 for the **async-generator** analogue, which leaks in both modes and is not covered by #480 (sync) or #481 (compiled async resumed-`yield` / `yield*` / off-end *value*).
