### PR TITLE
Fix #497: hoist loop-carried locals across yield in while/do-while/for/for-in generators

### DIFF
--- a/Compilation/GeneratorStateAnalyzer.cs
+++ b/Compilation/GeneratorStateAnalyzer.cs
@@ -38,9 +38,13 @@ public class GeneratorStateAnalyzer : AstVisitorBase
     private readonly HashSet<string> _variablesUsedAfterYield = [];
     private readonly HashSet<string> _variablesDeclaredBeforeYield = [];
     private readonly HashSet<string> _capturedVariables = [];  // Variables from outer scopes
-    private readonly List<Stmt.ForOf> _forOfLoopsWithYield = [];  // for...of loops containing yields
-    private readonly Stack<Stmt.ForOf> _forOfStack = new();  // Track nested for...of loops
-    private readonly Dictionary<Stmt.ForOf, HashSet<string>> _variablesUsedInLoopBody = new();  // Variables used in each for...of body
+    private readonly List<Stmt.ForOf> _forOfLoopsWithYield = [];  // for...of loops containing yields (enumerator hoisting)
+    // Loop bodies currently being analyzed (innermost on top). A loop whose body contains a
+    // yield re-executes after the yield resumes, so every local used anywhere in it is live
+    // across the suspension and must be hoisted to a state-machine field — otherwise the IL
+    // local is wiped on MoveNext re-entry and reads back as its default. This applies to every
+    // loop form (while/do-while/for/for-in/for-of), not just for...of (#497).
+    private readonly Stack<LoopScope> _loopStack = new();
     private int _yieldCounter = 0;
     private bool _seenYield = false;
     private bool _usesThis = false;
@@ -102,12 +106,38 @@ public class GeneratorStateAnalyzer : AstVisitorBase
         _variablesDeclaredBeforeYield.Clear();
         _capturedVariables.Clear();
         _forOfLoopsWithYield.Clear();
-        _forOfStack.Clear();
-        _variablesUsedInLoopBody.Clear();
+        _loopStack.Clear();
         _yieldCounter = 0;
         _seenYield = false;
         _usesThis = false;
         _hasYieldStar = false;
+    }
+
+    /// <summary>
+    /// Tracks one enclosing loop body during analysis: the variables it touches and whether a
+    /// yield occurs anywhere inside it. <see cref="ForOf"/> is non-null only for for...of loops,
+    /// which additionally need their enumerator hoisted to a field.
+    /// </summary>
+    private sealed class LoopScope(Stmt.ForOf? forOf)
+    {
+        public readonly HashSet<string> UsedVariables = [];
+        public bool ContainsYield;
+        public readonly Stmt.ForOf? ForOf = forOf;
+    }
+
+    private void EnterLoop(Stmt.ForOf? forOf = null) => _loopStack.Push(new LoopScope(forOf));
+
+    // On leaving a loop body that contained a yield, hoist every local it used: the body
+    // re-executes after the yield resumes, so those values must survive the suspension (#497).
+    private void ExitLoop()
+    {
+        var scope = _loopStack.Pop();
+        if (!scope.ContainsYield) return;
+        foreach (var name in scope.UsedVariables)
+        {
+            if (_declaredVariables.Contains(name))
+                _variablesUsedAfterYield.Add(name);
+        }
     }
 
     #region Statement Visitor Overrides
@@ -128,28 +158,30 @@ public class GeneratorStateAnalyzer : AstVisitorBase
         base.VisitConst(stmt);
     }
 
+    protected override void VisitWhile(Stmt.While stmt)
+    {
+        EnterLoop();
+        base.VisitWhile(stmt);  // condition + body
+        ExitLoop();
+    }
+
+    protected override void VisitDoWhile(Stmt.DoWhile stmt)
+    {
+        EnterLoop();
+        base.VisitDoWhile(stmt);  // body + condition
+        ExitLoop();
+    }
+
     protected override void VisitForOf(Stmt.ForOf stmt)
     {
         _declaredVariables.Add(stmt.Variable.Lexeme);
         if (!_seenYield)
             _variablesDeclaredBeforeYield.Add(stmt.Variable.Lexeme);
 
-        // Track for...of loops to detect yields inside them
-        _forOfStack.Push(stmt);
-        _variablesUsedInLoopBody[stmt] = [];
-        base.VisitForOf(stmt);
-        _forOfStack.Pop();
-
-        // If this loop contains a yield, all variables used in its body need hoisting
-        // because the loop body will re-execute after yield resumes
-        if (_forOfLoopsWithYield.Contains(stmt))
-        {
-            foreach (var varName in _variablesUsedInLoopBody[stmt])
-            {
-                if (_declaredVariables.Contains(varName))
-                    _variablesUsedAfterYield.Add(varName);
-            }
-        }
+        // Pass the loop node so a yield inside also records it for enumerator hoisting.
+        EnterLoop(stmt);
+        base.VisitForOf(stmt);  // iterable + body
+        ExitLoop();
     }
 
     protected override void VisitForIn(Stmt.ForIn stmt)
@@ -157,32 +189,26 @@ public class GeneratorStateAnalyzer : AstVisitorBase
         _declaredVariables.Add(stmt.Variable.Lexeme);
         if (!_seenYield)
             _variablesDeclaredBeforeYield.Add(stmt.Variable.Lexeme);
-        base.VisitForIn(stmt);
+        EnterLoop();
+        base.VisitForIn(stmt);  // object + body
+        ExitLoop();
     }
 
     protected override void VisitFor(Stmt.For stmt)
     {
-        // Visit initializer first (may declare loop variable)
+        // The initializer runs once before the loop, so it stays outside the loop scope; the
+        // loop variable it declares is still tracked through its uses in condition/body/increment.
         if (stmt.Initializer != null)
             Visit(stmt.Initializer);
 
-        // Track variables used in condition and increment
+        // Condition, body, and increment all re-execute each iteration.
+        EnterLoop();
         if (stmt.Condition != null)
             Visit(stmt.Condition);
-
-        // Track the for loop body for yield detection
-        bool hadYieldBefore = _seenYield;
         Visit(stmt.Body);
-
-        // If body contains yield, variables declared in initializer need hoisting
-        if (_seenYield && !hadYieldBefore)
-        {
-            // The loop will re-execute, so any variable used in condition/increment/body
-            // that was declared before the loop needs to be hoisted
-        }
-
         if (stmt.Increment != null)
             Visit(stmt.Increment);
+        ExitLoop();
     }
 
     protected override void VisitTryCatch(Stmt.TryCatch stmt)
@@ -234,11 +260,13 @@ public class GeneratorStateAnalyzer : AstVisitorBase
         if (expr.IsDelegating)
             _hasYieldStar = true;
 
-        // Record all for...of loops we're currently inside - they need enumerator hoisting
-        foreach (var forOf in _forOfStack)
+        // Mark every enclosing loop as containing a yield so its body's locals get hoisted
+        // (ExitLoop), and record any enclosing for...of loop for enumerator hoisting.
+        foreach (var scope in _loopStack)
         {
-            if (!_forOfLoopsWithYield.Contains(forOf))
-                _forOfLoopsWithYield.Add(forOf);
+            scope.ContainsYield = true;
+            if (scope.ForOf != null && !_forOfLoopsWithYield.Contains(scope.ForOf))
+                _forOfLoopsWithYield.Add(scope.ForOf);
         }
     }
 
@@ -252,12 +280,9 @@ public class GeneratorStateAnalyzer : AstVisitorBase
             _capturedVariables.Add(name);
         }
 
-        // Track variables used in for...of loop bodies (for hoisting when loop contains yield)
-        foreach (var loop in _forOfStack)
-        {
-            if (_variablesUsedInLoopBody.TryGetValue(loop, out var vars))
-                vars.Add(name);
-        }
+        // Track variables used in any enclosing loop body (hoisted when the loop contains a yield).
+        foreach (var scope in _loopStack)
+            scope.UsedVariables.Add(name);
 
         if (_seenYield && _declaredVariables.Contains(name))
             _variablesUsedAfterYield.Add(name);

--- a/SharpTS.Tests/SharedTests/GeneratorTests.cs
+++ b/SharpTS.Tests/SharedTests/GeneratorTests.cs
@@ -415,6 +415,106 @@ public class GeneratorTests
 
     [Theory]
     [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Generator_AccumulatorPattern_CompoundAssignAcrossYield(ExecutionMode mode)
+    {
+        // #497: the same two-way accumulator, but the running total is read *before* the yield
+        // as the LHS of `+=`, so it is loop-carried across the suspension. The sibling test
+        // Generator_AccumulatorPattern_UsesSentValues sidesteps this by reading `total` after
+        // the yield. Pre-fix the compiled state machine left `total` in an IL local that the
+        // MoveNext re-entry wiped, so each resume recomputed `0 + n` (5, 10, 3) instead of the
+        // running total. The analyzer now hoists loop-body locals of any yielding loop.
+        var source = """
+            function* adder() {
+                let total = 0;
+                while (true) {
+                    total += yield total;
+                }
+            }
+            const a = adder();
+            console.log(a.next().value);
+            console.log(a.next(5).value);
+            console.log(a.next(10).value);
+            console.log(a.next(3).value);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("0\n5\n15\n18\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Generator_AccumulatorPattern_CompoundAssignAcrossYield_DoWhile(ExecutionMode mode)
+    {
+        // #497: do-while is one of the loop forms that lacked loop-body hoisting pre-fix.
+        var source = """
+            function* adder() {
+                let total = 0;
+                do {
+                    total += yield total;
+                } while (true);
+            }
+            const a = adder();
+            console.log(a.next().value);
+            console.log(a.next(5).value);
+            console.log(a.next(10).value);
+            console.log(a.next(3).value);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("0\n5\n15\n18\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Generator_AccumulatorPattern_CompoundAssignAcrossYield_For(ExecutionMode mode)
+    {
+        // #497: an unbounded for(;;) likewise lacked loop-body hoisting pre-fix.
+        var source = """
+            function* adder() {
+                let total = 0;
+                for (;;) {
+                    total += yield total;
+                }
+            }
+            const a = adder();
+            console.log(a.next().value);
+            console.log(a.next(5).value);
+            console.log(a.next(10).value);
+            console.log(a.next(3).value);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("0\n5\n15\n18\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Generator_LoopCarriedLocal_ReadBeforeYield_SurvivesAcrossIterations(ExecutionMode mode)
+    {
+        // #497 (general shape): a counted for-loop whose induction-adjacent local is read in the
+        // loop body before the yield. The accumulator must persist across the loop back-edge.
+        var source = """
+            function* g() {
+                let sum = 0;
+                for (let i = 0; i < 3; i++) {
+                    sum = sum + (yield sum);
+                }
+                return sum;
+            }
+            const it = g();
+            console.log(it.next().value);    // 0
+            console.log(it.next(10).value);  // 10
+            console.log(it.next(20).value);  // 30
+            console.log(it.next(30).value);  // 60 (return)
+            console.log(it.next().done);     // true
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("0\n10\n30\n60\ntrue\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void Generator_BareNext_ResumesWithUndefined(ExecutionMode mode)
     {
         var source = """


### PR DESCRIPTION
## Summary

Fixes #497. In **compiled mode**, the canonical two-way generator accumulator lost its running total across yields when the running variable was read *before* the yield (as the LHS of `+=`) inside a `while`/`do-while`/`for` loop:

```ts
function* adder() {
  let total = 0;
  while (true) { total += yield total; }
}
const it = adder();
it.next();                      // start
it.next(5).value;               // 5   (both modes)
it.next(10).value;              // interp: 15   compiled: 10  ← was BUG
```

The interpreter was always correct.

## Root cause

`GeneratorStateAnalyzer` decides which locals are hoisted to state-machine fields via "used after a yield". A loop body *re-executes*, so a use *before* the yield on iteration N+1 reads a value that must survive the yield on iteration N. The analyzer handled this for `for...of` (via `_forOfStack` / `_variablesUsedInLoopBody`) but **not** for `while`, `do-while`, `for`, or `for-in`. So `total` stayed an IL local, which the `MoveNext` re-entry wipes — each resume recomputed `0 + n`.

`for...of` was the only loop form that worked; `while` / `do-while` / `for(;;)` all failed identically. (The issue's `for` example only appeared to work because it read `total` *after* the loop, which independently flags it.)

## Fix

Generalize the `for...of`-only loop-body tracking into a single `LoopScope` stack used by every loop form. On leaving a loop body that contained a yield, every local it touched is marked used-after-yield (and thus hoisted). The `for...of` enumerator-hoisting concern is preserved via a `ForOf` reference carried on each scope. This also deletes the previously-dead `VisitFor` branch and removes the loop-form asymmetry (latent debt). Net complexity goes **down**.

Tracking variable *reads* (the existing `VisitVariable` mechanism) is sufficient for observable correctness: a compound-assign target that is never read elsewhere is unobservable, so hoisting it is unnecessary. Over-approximation remains safe (worst case: one unneeded field), consistent with the existing design.

## Testing

- New regression tests in `GeneratorTests.cs` cover the `while` / `do-while` / `for(;;)` accumulator shapes plus a counted for-loop, asserted **identical across interpreted and compiled modes** via `ExecutionModes.All`.
- Full suite: **11745 passed, 0 failed, 0 skipped**.
- `--compile … --verify` passes IL verification on the fixed shapes.

## Out of scope (filed separately)

Two pre-existing, unrelated compiled-generator bugs surfaced while testing (both confirmed on clean `origin/main`):

- **#547** — a `for-in` loop containing a `yield` terminates after the first key (for-in iteration state isn't hoisted, unlike for-of's enumerator).
- **#499** (already open) — explicit `return X` re-entry leaks `X` on the next `next()` via the `_returnFalseLabel` path; left a comment confirming the headline fall-through half is now fixed while this half remains.