### PR TITLE
Fix #500: compiled generator runs enclosing finally on break/continue/throw-from-catch

### DIFF
--- a/Compilation/GeneratorMoveNextEmitter.Statements.TryCatch.cs
+++ b/Compilation/GeneratorMoveNextEmitter.Statements.TryCatch.cs
@@ -6,22 +6,310 @@ namespace SharpTS.Compilation;
 
 public partial class GeneratorMoveNextEmitter
 {
-    // When emitting inside a flag-based try that has a finally, a `return` statement cannot
-    // `ret` directly — the finally must run first. It jumps here instead (after recording the
-    // pending return). Saved/restored around each try so nested finallys chain.
-    private Label? _returnCleanupLabel;
+    // ---- Unified exit-scope stack (#500) --------------------------------------------------------
+    //
+    // A non-local exit (return / break / continue / a throw from a catch or finally) that crosses a
+    // flag-based try/finally must run the enclosing finally(s) before transferring control. Because a
+    // finally can itself yield, the routing state has to survive a MoveNext re-entry, so it lives in
+    // state-machine fields rather than IL locals.
+    //
+    // The scheme mirrors how Roslyn lowers iterator try/finally: each exit is assigned an integer
+    // "pending action" code, stored in `<>pendingExit`, and branches to the innermost enclosing
+    // finally's cleanup label. After each finally body runs, a dispatch (EmitFinallyDispatch) inspects
+    // the code and either chains to the next outer finally or, if this finally is the last one the exit
+    // must traverse, performs the terminal action (complete / rethrow / jump to a loop label). The set
+    // of finallys an exit traverses — and which one is terminal — is known at exit-emission time (the
+    // scopes are on a stack), so each frame's per-code routing is recorded then.
 
-    // Set by a `return` inside a flag-based try/finally so that, once the finally(s) have run,
-    // MoveNext completes (returns false). Declared lazily; a finally that itself yields suspends
-    // MoveNext between the return and the completion check, so this must be a state-machine field
-    // (not an IL local, which the re-entry would reset) — mirrors the async generator's
-    // ReturnRequestedField. Defaults to false on the freshly-allocated state machine and is set
-    // at most once (the generator is completing), so it never needs resetting.
-    private FieldBuilder? _pendingReturnField;
+    private interface IExitScope;
 
-    private FieldBuilder GetPendingReturnField() =>
-        _pendingReturnField ??= _builder.StateMachineType.DefineField(
-            "<>pendingReturn", typeof(bool), FieldAttributes.Private);
+    /// <summary>A loop (or switch / labeled statement) that <c>break</c>/<c>continue</c> can target.</summary>
+    private sealed class LoopScope : IExitScope
+    {
+        public required Label BreakLabel;
+        public required Label ContinueLabel;
+        public string? LabelName;
+
+        // Lazily assigned the first time a break/continue to this loop must run an intervening
+        // finally; identifies that exit in the `<>pendingExit` field. Unset while the loop's
+        // break/continue need no finally routing (the common case → a direct branch).
+        public int? BreakCode;
+        public int? ContinueCode;
+    }
+
+    /// <summary>A flag-based <c>try</c> that has a <c>finally</c>; its finally runs on any exit that crosses it.</summary>
+    private sealed class FinallyScope : IExitScope
+    {
+        public required Label CleanupLabel;
+
+        // code → where control goes after this finally for that pending exit: a chain to the next
+        // outer finally's cleanup label, or null meaning "this finally is terminal for the exit".
+        public readonly Dictionary<int, Label?> Dispatch = [];
+    }
+
+    // Innermost-last stack of loop and finally scopes currently open at the emission point. Replaces
+    // the base class's `_loopLabels` (the loop-scope methods below are overridden to use this) so loops
+    // and finallys share one ordering — needed to know which finallys lie between a break and its loop.
+    private readonly List<IExitScope> _exitScopes = [];
+
+    private const int ExitCodeReturn = 1;
+    private const int ExitCodeThrow = 2;
+    private int _nextExitCode = 3; // break/continue codes are allocated from here
+
+    // code → emits the terminal action for that code (invoked when a finally is terminal for it).
+    private readonly Dictionary<int, Action> _exitTerminals = [];
+
+    // Depth of real IL exception blocks (EmitSimpleTryCatch / EmitSyncSegmentInTry) open around the
+    // current emission point. While > 0, a `br`/`ret` out of the region would be illegal, so exits are
+    // left to the existing per-path handling instead of being routed through the finally machinery.
+    private int _protectedRegionDepth;
+
+    // True while emitting a catch or finally body. A `throw` there must run the enclosing finally(s);
+    // a `throw` in a try body is instead captured by its sync-segment mini try/catch (and so must not
+    // be routed). Saved/restored around each region so nesting is handled correctly.
+    private bool _inHandlerBody;
+
+    // `<>pendingExit` (int): the code of an in-flight non-local exit, or 0 when none. A finally that
+    // yields suspends MoveNext mid-routing, so this must be a field (a local would reset on re-entry).
+    // Set once per exit and cleared by the terminal dispatch; defaults to 0 on a fresh state machine.
+    private FieldBuilder? _pendingExitField;
+
+    private FieldBuilder GetPendingExitField() =>
+        _pendingExitField ??= _builder.StateMachineType.DefineField(
+            "<>pendingExit", typeof(int), FieldAttributes.Private);
+
+    // `<>pendingException` (object): the value of a `throw` being routed through finally(s), held
+    // across any suspension in those finallys until the terminal dispatch rethrows it.
+    private FieldBuilder? _pendingExceptionField;
+
+    private FieldBuilder GetPendingExceptionField() =>
+        _pendingExceptionField ??= _builder.StateMachineType.DefineField(
+            "<>pendingException", typeof(object), FieldAttributes.Private);
+
+    // ---- Loop-scope methods (override the base stack to use `_exitScopes`) -----------------------
+
+    protected override void EnterLoop(Label breakLabel, Label continueLabel, string? labelName = null)
+        => _exitScopes.Add(new LoopScope { BreakLabel = breakLabel, ContinueLabel = continueLabel, LabelName = labelName });
+
+    protected override void ExitLoop()
+    {
+        // Well-nested: any try opened inside the loop body has already been closed, so the top of the
+        // stack is this loop's LoopScope.
+        _exitScopes.RemoveAt(_exitScopes.Count - 1);
+    }
+
+    protected override (Label BreakLabel, Label ContinueLabel, string? LabelName)? CurrentLoop
+    {
+        get
+        {
+            var loop = CurrentLoopScope();
+            return loop == null ? null : (loop.BreakLabel, loop.ContinueLabel, loop.LabelName);
+        }
+    }
+
+    protected override (Label BreakLabel, Label ContinueLabel, string? LabelName)? FindLabeledLoop(string labelName)
+    {
+        var loop = FindLabeledLoopScope(labelName);
+        return loop == null ? null : (loop.BreakLabel, loop.ContinueLabel, loop.LabelName);
+    }
+
+    private LoopScope? CurrentLoopScope()
+    {
+        for (int i = _exitScopes.Count - 1; i >= 0; i--)
+            if (_exitScopes[i] is LoopScope ls)
+                return ls;
+        return null;
+    }
+
+    private LoopScope? FindLabeledLoopScope(string labelName)
+    {
+        for (int i = _exitScopes.Count - 1; i >= 0; i--)
+            if (_exitScopes[i] is LoopScope ls && ls.LabelName == labelName)
+                return ls;
+        return null;
+    }
+
+    // ---- Non-local exit overrides ---------------------------------------------------------------
+
+    /// <summary>
+    /// A <c>break</c> must run any finally between it and the target loop before jumping out.
+    /// </summary>
+    protected override void EmitBreak(Stmt.Break b)
+    {
+        var loop = b.Label != null ? FindLabeledLoopScope(b.Label.Lexeme) : CurrentLoopScope();
+        if (loop == null) return; // matches the base: a break with no resolvable target is a no-op
+
+        if (_protectedRegionDepth == 0)
+        {
+            var chain = FinallyFramesAbove(loop);
+            if (chain.Count > 0)
+            {
+                int code = loop.BreakCode ??= _nextExitCode++;
+                _exitTerminals.TryAdd(code, () => _il.Emit(OpCodes.Br, loop.BreakLabel));
+                RouteThroughFinallys(chain, code);
+                return;
+            }
+        }
+
+        EmitBranchToLabel(loop.BreakLabel);
+    }
+
+    /// <summary>
+    /// A <c>continue</c> must run any finally between it and the target loop before jumping to the
+    /// loop's continue point.
+    /// </summary>
+    protected override void EmitContinue(Stmt.Continue c)
+    {
+        var loop = c.Label != null ? FindLabeledLoopScope(c.Label.Lexeme) : CurrentLoopScope();
+        if (loop == null) return;
+
+        if (_protectedRegionDepth == 0)
+        {
+            var chain = FinallyFramesAbove(loop);
+            if (chain.Count > 0)
+            {
+                int code = loop.ContinueCode ??= _nextExitCode++;
+                _exitTerminals.TryAdd(code, () => _il.Emit(OpCodes.Br, loop.ContinueLabel));
+                RouteThroughFinallys(chain, code);
+                return;
+            }
+        }
+
+        EmitBranchToLabel(loop.ContinueLabel);
+    }
+
+    /// <summary>
+    /// A <c>throw</c> in a catch or finally body must run the enclosing finally(s) before the
+    /// exception propagates. A throw in a try body is captured by its sync-segment mini try/catch
+    /// (handled by the catch arm), so it is not routed here.
+    /// </summary>
+    protected override void EmitThrow(Stmt.Throw t)
+    {
+        if (_inHandlerBody && _protectedRegionDepth == 0)
+        {
+            var chain = ActiveFinallyFrames();
+            if (chain.Count > 0)
+            {
+                EmitExpression(t.Value);
+                EnsureBoxed();
+                var thrown = _il.DeclareLocal(typeof(object));
+                _il.Emit(OpCodes.Stloc, thrown);
+                _il.Emit(OpCodes.Ldarg_0);
+                _il.Emit(OpCodes.Ldloc, thrown);
+                _il.Emit(OpCodes.Stfld, GetPendingExceptionField());
+
+                RegisterThrowTerminal();
+                RouteThroughFinallys(chain, ExitCodeThrow);
+                return;
+            }
+        }
+
+        base.EmitThrow(t);
+    }
+
+    // ---- Routing helpers ------------------------------------------------------------------------
+
+    /// <summary>All open finally scopes, innermost first.</summary>
+    private List<FinallyScope> ActiveFinallyFrames()
+    {
+        var result = new List<FinallyScope>();
+        for (int i = _exitScopes.Count - 1; i >= 0; i--)
+            if (_exitScopes[i] is FinallyScope fs)
+                result.Add(fs);
+        return result;
+    }
+
+    /// <summary>The finally scopes between the current point and <paramref name="target"/>, innermost first.</summary>
+    private List<FinallyScope> FinallyFramesAbove(LoopScope target)
+    {
+        var result = new List<FinallyScope>();
+        for (int i = _exitScopes.Count - 1; i >= 0; i--)
+        {
+            if (ReferenceEquals(_exitScopes[i], target)) break;
+            if (_exitScopes[i] is FinallyScope fs)
+                result.Add(fs);
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Records <paramref name="code"/>'s per-frame routing across <paramref name="chain"/> (each frame
+    /// chains to the next, the outermost is terminal), then sets the pending-exit field and branches to
+    /// the innermost finally. The caller must have prepared any value the terminal needs (e.g. the
+    /// thrown value, or the Current/return state) beforehand.
+    /// </summary>
+    private void RouteThroughFinallys(List<FinallyScope> chain, int code)
+    {
+        for (int i = 0; i < chain.Count; i++)
+        {
+            // The last frame in the chain is terminal for this code (null); the rest chain outward.
+            Label? next = i < chain.Count - 1 ? chain[i + 1].CleanupLabel : null;
+            chain[i].Dispatch[code] = next; // idempotent: the same code always routes a frame the same way
+        }
+
+        _il.Emit(OpCodes.Ldarg_0);
+        _il.Emit(OpCodes.Ldc_I4, code);
+        _il.Emit(OpCodes.Stfld, GetPendingExitField());
+        _il.Emit(OpCodes.Br, chain[0].CleanupLabel);
+    }
+
+    /// <summary>
+    /// Emitted after a finally body: for each pending-exit code that routes through this frame, either
+    /// chain to the next outer finally or, if terminal here, clear the pending field and run the
+    /// terminal action. A pending value of 0 (none) and codes not handled here fall through unchanged.
+    /// </summary>
+    private void EmitFinallyDispatch(FinallyScope frame)
+    {
+        foreach (var (code, next) in frame.Dispatch)
+        {
+            var skip = _il.DefineLabel();
+            _il.Emit(OpCodes.Ldarg_0);
+            _il.Emit(OpCodes.Ldfld, GetPendingExitField());
+            _il.Emit(OpCodes.Ldc_I4, code);
+            _il.Emit(OpCodes.Bne_Un, skip);
+
+            if (next.HasValue)
+            {
+                // Not terminal here — keep the pending code and run the next outer finally.
+                _il.Emit(OpCodes.Br, next.Value);
+            }
+            else
+            {
+                // Terminal: the exit has run every finally it needed to. Clear the flag first so a
+                // break/continue resumes the generator with clean state.
+                _il.Emit(OpCodes.Ldarg_0);
+                _il.Emit(OpCodes.Ldc_I4_0);
+                _il.Emit(OpCodes.Stfld, GetPendingExitField());
+                _exitTerminals[code]();
+            }
+
+            _il.MarkLabel(skip);
+        }
+    }
+
+    private void RegisterReturnTerminal() => _exitTerminals.TryAdd(ExitCodeReturn, () =>
+    {
+        // The generator completes. State -2 is re-asserted here because a yielding finally between the
+        // `return` and this point overwrote it with the finally's resume state.
+        _il.Emit(OpCodes.Ldarg_0);
+        _il.Emit(OpCodes.Ldc_I4, -2);
+        _il.Emit(OpCodes.Stfld, _builder.StateField);
+        _il.Emit(OpCodes.Ldc_I4_0);
+        _il.Emit(OpCodes.Ret);
+    });
+
+    private void RegisterThrowTerminal() => _exitTerminals.TryAdd(ExitCodeThrow, () =>
+    {
+        // The routed exception has run every enclosing finally; propagate it now. The generator is
+        // completing (throwing), so mark it done first.
+        _il.Emit(OpCodes.Ldarg_0);
+        _il.Emit(OpCodes.Ldc_I4, -2);
+        _il.Emit(OpCodes.Stfld, _builder.StateField);
+        _il.Emit(OpCodes.Ldarg_0);
+        _il.Emit(OpCodes.Ldfld, GetPendingExceptionField());
+        _il.Emit(OpCodes.Call, _ctx!.Runtime!.CreateException);
+        _il.Emit(OpCodes.Throw);
+    });
 
     /// <summary>
     /// Emits try/catch/finally. When a yield crosses the protected region, real IL exception
@@ -46,6 +334,9 @@ public partial class GeneratorMoveNextEmitter
     /// </summary>
     private void EmitSimpleTryCatch(Stmt.TryCatch t)
     {
+        // A real IL protected region is open: a routed `br`/`ret` out of it would be illegal, so
+        // exits emitted inside fall back to their per-path handling (see the exit overrides).
+        _protectedRegionDepth++;
         _il.BeginExceptionBlock();
 
         foreach (var stmt in t.TryBlock)
@@ -78,6 +369,7 @@ public partial class GeneratorMoveNextEmitter
         }
 
         _il.EndExceptionBlock();
+        _protectedRegionDepth--;
     }
 
     /// <summary>
@@ -115,21 +407,27 @@ public partial class GeneratorMoveNextEmitter
         _il.Emit(OpCodes.Ldnull);
         _il.Emit(OpCodes.Stloc, caughtExceptionLocal);
 
-        // A `return` inside this try must run the finally before completing, so point its cleanup
-        // at the catch/finally entry. On the return path the exception flag is null, so the catch
-        // is skipped and the finally runs. Only meaningful when a finally is present; without one,
-        // a `return` completes directly (it is emitted at the top level, so `ret` is legal).
-        var previousCleanupLabel = _returnCleanupLabel;
+        // A non-local exit inside this try (or its catch) must run the finally before transferring
+        // control, so register a finally scope whose cleanup is the catch/finally entry. On those exit
+        // paths the exception flag is null, so the catch is skipped and the finally runs. Without a
+        // finally there is nothing to route through, so no scope is pushed and exits go directly.
+        FinallyScope? frame = null;
         if (t.FinallyBlock != null)
-            _returnCleanupLabel = afterTryBodyLabel;
+        {
+            frame = new FinallyScope { CleanupLabel = afterTryBodyLabel };
+            _exitScopes.Add(frame);
+        }
 
+        // Throws in the try body are captured by their sync segments, not routed.
+        bool previousInHandler = _inHandlerBody;
+        _inHandlerBody = false;
         EmitTryBodyWithYields(t.TryBlock, caughtExceptionLocal, afterTryBodyLabel);
-
-        _returnCleanupLabel = previousCleanupLabel;
+        _inHandlerBody = previousInHandler;
 
         _il.MarkLabel(afterTryBodyLabel);
 
-        // Catch: runs only when the try body captured an exception.
+        // Catch: runs only when the try body captured an exception. The finally scope is still open, so
+        // a non-local exit (including a throw) from the catch body runs this finally too.
         if (t.CatchBlock != null)
         {
             var skipCatchLabel = _il.DefineLabel();
@@ -142,42 +440,33 @@ public partial class GeneratorMoveNextEmitter
                 StoreCaughtExceptionToParam(t.CatchParam.Lexeme);
             }
 
-            // Catch handles it; clear the flag so the post-finally rethrow below is skipped.
+            // Catch handles it; clear the flag so the post-finally rethrow below is skipped — and so a
+            // routed exit re-entering afterTryBodyLabel skips the catch rather than re-running it.
             _il.Emit(OpCodes.Ldnull);
             _il.Emit(OpCodes.Stloc, caughtExceptionLocal);
 
+            _inHandlerBody = true;
             foreach (var stmt in t.CatchBlock)
                 EmitStatement(stmt);
+            _inHandlerBody = previousInHandler;
 
             _il.MarkLabel(skipCatchLabel);
         }
 
-        // Finally: always runs — on normal completion, after a caught exception, or on a pending
-        // return that routed here.
+        // The finally itself is outside its own scope: an exit within it runs the *enclosing* finallys.
+        if (frame != null)
+            _exitScopes.RemoveAt(_exitScopes.Count - 1);
+
+        // Finally: always runs — on normal completion, after a caught exception, or on a routed exit.
         if (t.FinallyBlock != null)
         {
+            _inHandlerBody = true;
             foreach (var stmt in t.FinallyBlock)
                 EmitStatement(stmt);
+            _inHandlerBody = previousInHandler;
 
-            // After the finally, propagate a pending `return` — to the next enclosing finally if
-            // there is one, otherwise complete MoveNext.
-            if (_pendingReturnField != null)
-            {
-                var noPendingReturnLabel = _il.DefineLabel();
-                _il.Emit(OpCodes.Ldarg_0);
-                _il.Emit(OpCodes.Ldfld, _pendingReturnField);
-                _il.Emit(OpCodes.Brfalse, noPendingReturnLabel);
-
-                if (previousCleanupLabel != null)
-                    _il.Emit(OpCodes.Br, previousCleanupLabel.Value);
-                else
-                {
-                    _il.Emit(OpCodes.Ldc_I4_0);
-                    _il.Emit(OpCodes.Ret);
-                }
-
-                _il.MarkLabel(noPendingReturnLabel);
-            }
+            // After the finally, dispatch any pending non-local exit that routed through here.
+            EmitFinallyDispatch(frame!);
         }
 
         // Rethrow an uncaught exception once the finally has run (try/finally with no catch).
@@ -187,6 +476,10 @@ public partial class GeneratorMoveNextEmitter
             _il.Emit(OpCodes.Ldloc, caughtExceptionLocal);
             _il.Emit(OpCodes.Brfalse, noExceptionLabel);
 
+            // Mark the generator done before the exception leaves MoveNext.
+            _il.Emit(OpCodes.Ldarg_0);
+            _il.Emit(OpCodes.Ldc_I4, -2);
+            _il.Emit(OpCodes.Stfld, _builder.StateField);
             _il.Emit(OpCodes.Ldloc, caughtExceptionLocal);
             _il.Emit(OpCodes.Call, _ctx!.Runtime!.CreateException);
             _il.Emit(OpCodes.Throw);
@@ -243,6 +536,8 @@ public partial class GeneratorMoveNextEmitter
         _il.Emit(OpCodes.Ldloc, caughtExceptionLocal);
         _il.Emit(OpCodes.Brtrue, skipLabel);
 
+        // A real IL protected region is open across the segment body (see _protectedRegionDepth).
+        _protectedRegionDepth++;
         _il.BeginExceptionBlock();
         foreach (var stmt in statements)
             EmitStatement(stmt);
@@ -251,6 +546,7 @@ public partial class GeneratorMoveNextEmitter
         _il.Emit(OpCodes.Call, _ctx!.Runtime!.WrapException);
         _il.Emit(OpCodes.Stloc, caughtExceptionLocal);
         _il.EndExceptionBlock();
+        _protectedRegionDepth--;
 
         _il.MarkLabel(skipLabel);
     }

--- a/Compilation/GeneratorMoveNextEmitter.Statements.cs
+++ b/Compilation/GeneratorMoveNextEmitter.Statements.cs
@@ -44,22 +44,25 @@ public partial class GeneratorMoveNextEmitter
             _il.Emit(OpCodes.Stfld, _builder.CurrentField);
         }
 
-        // Generator return - set state to completed.
+        // Generator return - set state to completed (the fast path below rets immediately; a routed
+        // return re-asserts this at its terminal, since a yielding finally would overwrite it).
         _il.Emit(OpCodes.Ldarg_0);
         _il.Emit(OpCodes.Ldc_I4, -2);
         _il.Emit(OpCodes.Stfld, _builder.StateField);
 
-        // Inside a flag-based try/finally, the finally must run before the generator actually
-        // completes. Record a pending return and branch to the cleanup point instead of `ret`
-        // (which is also illegal here — this return statement is emitted outside the protected
-        // segment, but the finally is emitted after it). See EmitTryCatchWithYields.
-        if (_returnCleanupLabel != null)
+        // Inside a flag-based try/finally, the enclosing finally(s) must run before the generator
+        // actually completes. Route the return through them instead of `ret` (which is also illegal
+        // here — this return is emitted outside the protected segment, but a finally is emitted after
+        // it). See the exit-routing machinery in GeneratorMoveNextEmitter.Statements.TryCatch.cs.
+        if (_protectedRegionDepth == 0)
         {
-            _il.Emit(OpCodes.Ldarg_0);
-            _il.Emit(OpCodes.Ldc_I4_1);
-            _il.Emit(OpCodes.Stfld, GetPendingReturnField());
-            _il.Emit(OpCodes.Br, _returnCleanupLabel.Value);
-            return;
+            var chain = ActiveFinallyFrames();
+            if (chain.Count > 0)
+            {
+                RegisterReturnTerminal();
+                RouteThroughFinallys(chain, ExitCodeReturn);
+                return;
+            }
         }
 
         _il.Emit(OpCodes.Ldc_I4_0);
@@ -216,6 +219,10 @@ public partial class GeneratorMoveNextEmitter
     // - EmitStatement (dispatch)
     // - EmitIf, EmitWhile, EmitDoWhile (control flow)
     // - EmitForIn (loops with DeclareLoopVariable/EmitStoreLoopVariable overrides)
-    // - EmitBlock, EmitBreak, EmitContinue, EmitLabeledStatement
-    // - EmitSwitch, EmitThrow, EmitPrint
+    // - EmitBlock, EmitLabeledStatement, EmitSwitch, EmitPrint
+    //
+    // EmitBreak, EmitContinue and EmitThrow are overridden in
+    // GeneratorMoveNextEmitter.Statements.TryCatch.cs so a non-local exit runs any enclosing
+    // flag-based finally before transferring control (#500); the loop-scope methods
+    // (EnterLoop/ExitLoop/CurrentLoop/FindLabeledLoop) are overridden there for the same reason.
 }

--- a/SharpTS.Tests/Compilation/EmitterSyncTests.cs
+++ b/SharpTS.Tests/Compilation/EmitterSyncTests.cs
@@ -102,6 +102,14 @@ public class EmitterSyncTests
             "EmitYield",            // Core: yield value + suspend
             "EmitSuper",            // This field indirection
             "EmitDynamicImport",    // Dynamic import fallback
+            // --- #500: non-local exits must run an enclosing flag-based finally first ---
+            "EmitBreak",            // Route a break leaving a try through its finally(s)
+            "EmitContinue",         // Route a continue leaving a try through its finally(s)
+            "EmitThrow",            // Route a throw in a catch/finally body through the finally(s)
+            "EnterLoop",            // Loops share the unified _exitScopes stack with finally scopes
+            "ExitLoop",             // (so break/continue can find the finallys between them and the loop)
+            "get_CurrentLoop",      // Loop lookups read _exitScopes instead of the base loop stack
+            "FindLabeledLoop",      // Labeled loop lookups read _exitScopes
         },
         [typeof(AsyncGeneratorMoveNextEmitter)] = new()
         {

--- a/SharpTS.Tests/SharedTests/GeneratorTryFinallyTests.cs
+++ b/SharpTS.Tests/SharedTests/GeneratorTryFinallyTests.cs
@@ -13,10 +13,13 @@ namespace SharpTS.Tests.SharedTests;
 /// resume labels are reachable and their <c>ret</c>/<c>br</c> are legal.
 ///
 /// Run against both modes; the interpreter already behaved correctly, so these double as a
-/// cross-mode parity guard. Cases that depend on still-open gaps are documented inline and
-/// intentionally not asserted here: generator <c>.throw()</c>/<c>.return()</c> injecting through
-/// a suspended <c>try</c> (#478), <c>break</c>/<c>continue</c> running an enclosing <c>finally</c>
-/// (#500), and the completion value of a normally-finished generator (#499) are out of scope.
+/// cross-mode parity guard. #500 extended the compiled scheme so that every non-local exit
+/// (<c>break</c>/<c>continue</c> leaving the try, and a <c>throw</c> or <c>return</c> from a catch
+/// or finally body) runs the enclosing <c>finally</c>(s) before transferring control — previously
+/// only <c>return</c> from the try body did. Cases that depend on still-open gaps are documented
+/// inline and intentionally not asserted here: generator <c>.throw()</c>/<c>.return()</c> injecting
+/// through a suspended <c>try</c> (#478) and the completion value of a normally-finished generator
+/// (#499) are out of scope.
 /// </summary>
 public class GeneratorTryFinallyTests
 {
@@ -234,6 +237,197 @@ public class GeneratorTryFinallyTests
         Assert.Equal("1\n2\n", TestHarness.Run(source, mode));
     }
 
+    // ---- #500: non-local exits other than a try-body return must run the enclosing finally ----
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void BreakOutOfTryFinally_RunsFinallyBeforeBreaking(ExecutionMode mode)
+    {
+        // The exact #500 repro: break leaving the try must run the finally first.
+        var source = """
+            function* g() {
+              while (true) {
+                try { yield 1; break; } finally { console.log("FIN"); }
+              }
+            }
+            for (const v of g()) console.log(v);
+            """;
+
+        Assert.Equal("1\nFIN\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ContinueOutOfTryFinally_RunsFinallyThatIteration(ExecutionMode mode)
+    {
+        // `continue` from inside the try must run the finally before jumping to the next iteration,
+        // and the code after the continue must be skipped on that iteration only.
+        var source = """
+            function* g() {
+              for (let i = 0; i < 3; i++) {
+                try {
+                  yield i;
+                  if (i === 1) continue;
+                  console.log("after" + i);
+                } finally {
+                  console.log("fin" + i);
+                }
+              }
+            }
+            for (const v of g()) console.log("got" + v);
+            """;
+
+        Assert.Equal("got0\nafter0\nfin0\ngot1\nfin1\ngot2\nafter2\nfin2\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ThrowFromCatch_RunsFinallyThenPropagates(ExecutionMode mode)
+    {
+        // The exact #500 repro: a throw inside the catch must still run the finally before the
+        // exception propagates out of the generator to the consumer.
+        var source = """
+            function* g() {
+              try { yield 1; throw "a"; } catch (e) { throw "b"; } finally { console.log("FIN"); }
+            }
+            try { for (const v of g()) console.log(v); } catch (e) { console.log("outer " + e); }
+            """;
+
+        Assert.Equal("1\nFIN\nouter b\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ReturnFromCatch_RunsFinallyBeforeCompleting(ExecutionMode mode)
+    {
+        // A `return` from the catch body must run the finally; the yield after the try must not run.
+        var source = """
+            function* g() {
+              try { yield 1; throw "x"; } catch (e) { return; } finally { console.log("FIN"); }
+              yield 99;
+            }
+            for (const v of g()) console.log(v);
+            """;
+
+        Assert.Equal("1\nFIN\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void BreakThroughNestedFinallys_RunsInnerThenOuter(ExecutionMode mode)
+    {
+        // A break that leaves two enclosing trys runs both finallys, innermost first.
+        var source = """
+            function* g() {
+              while (true) {
+                try {
+                  try { yield 1; break; } finally { console.log("inner"); }
+                } finally { console.log("outer"); }
+              }
+            }
+            for (const v of g()) console.log("v" + v);
+            """;
+
+        Assert.Equal("v1\ninner\nouter\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void LabeledBreakToOuterLoop_RunsInterveningFinally(ExecutionMode mode)
+    {
+        // A labeled break targeting the outer loop runs the finally of the inner loop's try.
+        var source = """
+            function* g() {
+              outer: for (let i = 0; i < 3; i++) {
+                for (let j = 0; j < 3; j++) {
+                  try { yield i * 10 + j; if (j === 1) break outer; } finally { console.log("fin" + i + j); }
+                }
+              }
+            }
+            for (const v of g()) console.log("v" + v);
+            """;
+
+        Assert.Equal("v0\nfin00\nv1\nfin01\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void BreakToLoopBetweenTwoTrys_RunsOnlyInnerFinally(ExecutionMode mode)
+    {
+        // The break targets a loop that sits *between* two trys: only the finally inside that loop
+        // runs at the break; the outer finally runs once, later, when the generator completes.
+        var source = """
+            function* g() {
+              try {
+                for (let i = 0; i < 3; i++) {
+                  try { yield i; if (i === 1) break; } finally { console.log("inner" + i); }
+                }
+                console.log("after-loop");
+              } finally { console.log("OUTER"); }
+            }
+            for (const v of g()) console.log("v" + v);
+            """;
+
+        Assert.Equal("v0\ninner0\nv1\ninner1\nafter-loop\nOUTER\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void BreakWithYieldingFinally_DrivesFinallyThenBreaks(ExecutionMode mode)
+    {
+        // The finally that runs on the break path itself yields; the break completes only after the
+        // finally's yields are driven, then control resumes after the loop.
+        var source = """
+            function* g() {
+              while (true) {
+                try { yield 1; break; } finally { yield 2; }
+              }
+              yield 3;
+            }
+            for (const v of g()) console.log("v" + v);
+            """;
+
+        Assert.Equal("v1\nv2\nv3\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ThrowFromFinally_RunsEnclosingFinallyThenPropagates(ExecutionMode mode)
+    {
+        // A throw raised inside a finally body must still run the enclosing finally before it
+        // propagates to the consumer.
+        var source = """
+            function* g() {
+              try {
+                try { yield 1; } finally { throw "boom"; }
+              } finally { console.log("OUTER"); }
+            }
+            try { for (const v of g()) console.log("v" + v); } catch (e) { console.log("caught " + e); }
+            """;
+
+        Assert.Equal("v1\nOUTER\ncaught boom\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void BreakOutOfInnerCatchlessTry_RunsOuterFinally(ExecutionMode mode)
+    {
+        // The break leaves an inner try/catch that has no finally, nested in an outer try-with-
+        // finally; the outer finally must still run on the way out.
+        var source = """
+            function* g() {
+              while (true) {
+                try {
+                  try { yield 1; break; } catch (e) {}
+                } finally { console.log("OUTERFIN"); }
+              }
+            }
+            for (const v of g()) console.log("v" + v);
+            """;
+
+        Assert.Equal("v1\nOUTERFIN\n", TestHarness.Run(source, mode));
+    }
+
     [Theory]
     [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void NextValue_DeliveredToYieldInsideTry(ExecutionMode mode)
@@ -290,6 +484,15 @@ public class GeneratorTryFinallyTests
     [InlineData("function* g() { try { yield 1; } finally { yield 2; } } for (const v of g()) {}")]
     [InlineData("function* g() { while (true) { try { yield 1; break; } finally { console.log('f'); } } } for (const v of g()) {}")]
     [InlineData("function* inner(){ yield 2; } function* g() { try { yield 1; yield* inner(); } finally { console.log('f'); } } for (const v of g()) {}")]
+    // #500 control-flow shapes: continue, throw-from-catch, return-from-catch, nested-finally break,
+    // labeled break, break to a loop sitting between two trys, and a yielding finally on the break path.
+    [InlineData("function* g() { for (let i=0;i<2;i++){ try { yield i; continue; } finally { console.log('f'); } } } for (const v of g()) {}")]
+    [InlineData("function* g() { try { yield 1; throw 'a'; } catch (e) { throw 'b'; } finally { console.log('f'); } } try { for (const v of g()) {} } catch (e) {}")]
+    [InlineData("function* g() { try { yield 1; throw 'a'; } catch (e) { return; } finally { console.log('f'); } } for (const v of g()) {}")]
+    [InlineData("function* g() { while (true) { try { try { yield 1; break; } finally { console.log('a'); } } finally { console.log('b'); } } } for (const v of g()) {}")]
+    [InlineData("function* g() { outer: for(let i=0;i<2;i++){ for(let j=0;j<2;j++){ try { yield j; break outer; } finally { console.log('f'); } } } } for (const v of g()) {}")]
+    [InlineData("function* g() { try { for(let i=0;i<2;i++){ try { yield i; break; } finally { console.log('a'); } } } finally { console.log('b'); } } for (const v of g()) {}")]
+    [InlineData("function* g() { while (true) { try { yield 1; break; } finally { yield 2; } } } for (const v of g()) {}")]
     public void GeneratorTryFinallyWithYield_EmitsVerifiableIL(string source)
     {
         var errors = TestHarness.CompileAndVerifyOnly(source);


### PR DESCRIPTION
Closes #500.

## Problem

A compiled generator using the flag-based `try`/`finally` emission (a `yield` inside the protected region — see #477) only routed a **`return` from the try body** through the enclosing `finally`(s). Every other non-local exit skipped the finally:

- `break` / `continue` that leaves the try
- a `throw` from a `catch` body (and, found here, a `return` from a `catch`)

```ts
function* g() {
  while (true) { try { yield 1; break; } finally { console.log("FIN"); } }
}
for (const v of g()) console.log(v);
// interpreter / Node: 1, FIN  —  compiled (before): 1   (no FIN)
```

The emitted IL was valid; this was a missing-semantics gap. The interpreter already matched Node, so this brings the compiler to parity.

## Fix

Generalize the return-only routing into a **Roslyn-style pending-action dispatch** (all in `GeneratorMoveNextEmitter.Statements.TryCatch.cs`):

- Loops and flag-based finally scopes share one **`_exitScopes`** stack, so a `break`/`continue` knows exactly which finallys lie between it and its target loop — and runs only those (a loop sitting *between* two trys runs the inner finally but not the outer).
- Each non-local exit is assigned an integer code stored in a **`<>pendingExit`** state-machine field (so it survives a suspension when a finally itself yields) and branches to the innermost finally's cleanup. After each finally body, a dispatch either **chains** to the next outer finally or, when **terminal**, completes / rethrows / jumps to the loop label.
- The finally scope is kept **active while emitting the catch body**, so a `throw`/`return`/`break` from a catch runs that finally too. A routed `throw` carries its value in **`<>pendingException`**.
- Throws in a *try body* stay captured by their sync-segment mini `try`/`catch` — `_protectedRegionDepth` and `_inHandlerBody` gate routing so a throw is only routed from a catch/finally body and never as a `br` out of a real IL exception region.

## Tests

- Behavioral (both modes): break, continue, throw-from-catch, return-from-catch, nested finallys (inner→outer), labeled break, **break to a loop between two trys** (only the inner finally runs), a **yielding finally on the break path**, and a break out of a catchless inner try nested in an outer try-with-finally.
- IL-verification guards for each new control-flow shape.
- New emitter overrides registered in the `EmitterSyncTests` allowlist.
- Full suite green (11,754 passed); Test262 subset has no generator folders, so its baselines are unaffected.

## Follow-ups filed (pre-existing, out of scope)

- #554 — simple (no-yield) generator `try`/`finally` + `return`/`break`/`continue` emits invalid IL (`InvalidProgramException`); different mechanism (needs `Leave`).
- #555 — a `return <value>` is lost when the finally yields (wrong completion value); adjacent to #499.
- #558 — labeled `continue` to an outer `for` loop re-runs the initializer (infinite loop), both modes, non-generators too. With this PR the finally *does* run first; the hang is the downstream continue-target placement.
- #559 — async-generator analog of #500: `break`/`continue` emit invalid IL, `throw`-from-catch skips the finally.