### PR TITLE
Fix #486: truthiness narrowing removes null/undefined from a union

### DIFF
--- a/SharpTS.Tests/TypeCheckerTests/NarrowingTests/TruthinessNarrowingTests.cs
+++ b/SharpTS.Tests/TypeCheckerTests/NarrowingTests/TruthinessNarrowingTests.cs
@@ -1,0 +1,244 @@
+using SharpTS.Tests.Infrastructure;
+using SharpTS.TypeSystem.Exceptions;
+using Xunit;
+
+namespace SharpTS.Tests.TypeCheckerTests.NarrowingTests;
+
+/// <summary>
+/// Tests for truthiness narrowing (#486): a <c>if (x)</c> / <c>if (!x)</c> guard removes
+/// always-falsy constituents (null, undefined, void, and the false/0/"" literal types) from
+/// the truthy branch and always-truthy constituents from the falsy branch — the same way the
+/// explicit <c>!== null/undefined</c> and <c>typeof</c> guards already narrow. Covers bare
+/// variables, property-access paths, negation, and the &amp;&amp; / ternary / loop forms that
+/// share the guard analyzer.
+/// </summary>
+public class TruthinessNarrowingTests
+{
+    [Fact]
+    public void Truthiness_StringOrUndefined_NarrowsToStringInThen()
+    {
+        // The exact repro from #486.
+        var source = """
+            function f(d: string | undefined): number {
+                if (d) { return d.length; }
+                return 0;
+            }
+            console.log(f("hello"));
+            console.log(f(undefined));
+            """;
+
+        Assert.Equal("5\n0\n", TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void Truthiness_StringOrNull_NarrowsToStringInThen()
+    {
+        var source = """
+            function k(x: string | null): number {
+                if (x) { return x.length; }
+                return 0;
+            }
+            console.log(k("abc"));
+            """;
+
+        Assert.Equal("3\n", TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void Truthiness_ObjectUnion_NarrowsAwayUndefinedInThen()
+    {
+        var source = """
+            function g(x: { n: number } | undefined): number {
+                if (x) { return x.n; }
+                return 0;
+            }
+            console.log(g({ n: 5 }));
+            """;
+
+        Assert.Equal("5\n", TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void Truthiness_Negation_NarrowsAfterEarlyReturn()
+    {
+        // `if (!d) return` narrows d to the truthy type for the code that follows.
+        var source = """
+            function f(d: string | undefined): number {
+                if (!d) return 0;
+                return d.length;
+            }
+            console.log(f("hiya"));
+            """;
+
+        Assert.Equal("4\n", TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void Truthiness_NegationEarlyReturn_TripleUnion()
+    {
+        var source = """
+            function f(x: { n: number } | null | undefined): number {
+                if (!x) return -1;
+                return x.n;
+            }
+            console.log(f({ n: 9 }));
+            console.log(f(null));
+            console.log(f(undefined));
+            """;
+
+        Assert.Equal("9\n-1\n-1\n", TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void Truthiness_DoubleNegation_NarrowsLikeTruthy()
+    {
+        var source = """
+            function f(x: string | undefined): number {
+                if (!!x) { return x.length; }
+                return 0;
+            }
+            console.log(f("hello"));
+            """;
+
+        Assert.Equal("5\n", TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void Truthiness_LogicalAnd_NarrowsRightOperand()
+    {
+        // `x && x.n` must narrow x for the right operand (the std defensive-access idiom).
+        var source = """
+            function h(x: { n: number } | undefined): number {
+                return (x && x.n) || 0;
+            }
+            console.log(h({ n: 7 }));
+            console.log(h(undefined));
+            """;
+
+        Assert.Equal("7\n0\n", TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void Truthiness_Ternary_NarrowsThenBranch()
+    {
+        var source = """
+            function f(x: { n: number } | null): number {
+                return x ? x.n : 0;
+            }
+            console.log(f({ n: 8 }));
+            console.log(f(null));
+            """;
+
+        Assert.Equal("8\n0\n", TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void Truthiness_PropertyPath_NarrowsNestedAccess()
+    {
+        var source = """
+            type Box = { inner: { x: number } | undefined };
+            function f(b: Box): number {
+                if (b.inner) { return b.inner.x; }
+                return 0;
+            }
+            console.log(f({ inner: { x: 42 } }));
+            console.log(f({ inner: undefined }));
+            """;
+
+        Assert.Equal("42\n0\n", TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void Truthiness_WhileCondition_NarrowsBody()
+    {
+        var source = """
+            function f(x: string | undefined): number {
+                let total = 0;
+                let i = 0;
+                while (x) { total += x.length; i++; if (i > 2) break; }
+                return total;
+            }
+            console.log(f("ab"));
+            """;
+
+        Assert.Equal("6\n", TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void Truthiness_FalsyNumberLiteralUnion_NarrowedAway()
+    {
+        // 0 is always-falsy: the truthy branch keeps only 1 | 2.
+        var source = """
+            function f(x: 0 | 1 | 2): number {
+                if (x) { return x; }
+                return 99;
+            }
+            console.log(f(0));
+            console.log(f(2));
+            """;
+
+        Assert.Equal("99\n2\n", TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void Truthiness_ElseBranch_KeepsStringSinceEmptyStringIsFalsy()
+    {
+        // The falsy branch keeps `string` (an empty string is falsy), so `string | undefined`
+        // stays `string | undefined` in the else — matching tsc's getTypeWithFacts(Falsy).
+        var source = """
+            function f(d: string | undefined): string {
+                if (d) { return d.toUpperCase(); }
+                return d === undefined ? "U" : d.toUpperCase();
+            }
+            console.log(f("ab"));
+            console.log(f(""));
+            console.log(f(undefined));
+            """;
+
+        Assert.Equal("AB\n\nU\n", TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void Truthiness_Compiled_MatchesInterpreted()
+    {
+        // Narrowing is a type-check-time concern; confirm the guarded program also compiles
+        // and runs identically under the IL backend.
+        var source = """
+            function f(d: string | undefined): number {
+                if (d) { return d.length; }
+                return 0;
+            }
+            console.log(f("compiled"));
+            """;
+
+        Assert.Equal("8\n", TestHarness.RunCompiled(source));
+    }
+
+    [Fact]
+    public void Truthiness_UnguardedAccess_StillErrors()
+    {
+        // Sanity: truthiness narrowing must not make unguarded access on a nullable type pass.
+        var source = """
+            function f(d: string | undefined): number {
+                return d.length;
+            }
+            """;
+
+        Assert.Throws<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void Truthiness_DoesNotLeakPastEmptyThenBlock()
+    {
+        // After `if (d) {}` (no early exit), d is back to `string | undefined`: accessing it
+        // unguarded afterwards must still error.
+        var source = """
+            function f(d: string | undefined): number {
+                if (d) { }
+                return d.length;
+            }
+            """;
+
+        Assert.Throws<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+}

--- a/TypeSystem/TypeChecker.Compatibility.TypeGuards.cs
+++ b/TypeSystem/TypeChecker.Compatibility.TypeGuards.cs
@@ -765,7 +765,58 @@ public partial class TypeChecker
             }
         }
 
+        // Pattern: truthiness guard — `if (path)`, `if (obj.prop)`, `if (!path)`, etc.
+        // Placed last so the explicit `=== null` / `!== null` forms above keep their precise
+        // (literal-preserving) handling; truthiness is the general fallback.
+        var truthiness = AnalyzePathTruthinessGuard(condition);
+        if (truthiness.Path != null)
+        {
+            return truthiness;
+        }
+
         return (null, null, null);
+    }
+
+    /// <summary>
+    /// Analyzes a truthiness guard on a narrowable path: <c>if (x)</c>, <c>if (obj.prop)</c>,
+    /// <c>if (!x)</c>, and groupings/double-negations thereof. The truthy branch keeps the
+    /// constituents that can be truthy (always-falsy ones removed); the falsy branch keeps the
+    /// constituents that can be falsy (always-truthy ones removed). A leading <c>!</c> swaps the
+    /// two branches. Returns no narrowing when the expression is not a stable path or when
+    /// neither branch refines the type.
+    /// </summary>
+    private (Narrowing.NarrowingPath? Path, TypeInfo? NarrowedType, TypeInfo? ExcludedType) AnalyzePathTruthinessGuard(Expr condition)
+    {
+        bool negated = false;
+        Expr expr = condition;
+
+        // Peel parentheses and logical-not so `!x`, `!!x`, and `(x)` resolve to the underlying
+        // path with the correct branch polarity.
+        while (true)
+        {
+            if (expr is Expr.Grouping g) { expr = g.Expression; continue; }
+            if (expr is Expr.Unary { Operator.Type: TokenType.BANG } notExpr)
+            {
+                negated = !negated;
+                expr = notExpr.Right;
+                continue;
+            }
+            break;
+        }
+
+        var path = Narrowing.NarrowingPathExtractor.TryExtract(expr);
+        if (path == null || !Narrowing.NarrowingPathExtractor.IsWithinDepthLimit(path))
+        {
+            return (null, null, null);
+        }
+
+        var (truthy, falsy) = ComputeTruthinessNarrowing(CheckExpr(expr));
+        if (truthy == null || falsy == null)
+        {
+            return (null, null, null);
+        }
+
+        return negated ? (path, falsy, truthy) : (path, truthy, falsy);
     }
 
     /// <summary>
@@ -1196,6 +1247,100 @@ public partial class TypeChecker
 
         return (null, null, null);
     }
+
+    /// <summary>
+    /// Splits a type into its truthy and falsy projections for truthiness narrowing
+    /// (<c>if (x)</c>), mirroring tsc's <c>getTypeWithFacts(TypeFacts.Truthy / .Falsy)</c>: the
+    /// truthy projection drops constituents that are always falsy; the falsy projection drops
+    /// constituents that are always truthy. An emptied projection becomes <c>never</c>.
+    /// Returns <c>(null, null)</c> when neither branch refines the type — e.g. a lone
+    /// <c>string</c>/<c>number</c>/<c>boolean</c>, or <c>any</c>/<c>unknown</c>, whose values
+    /// straddle both branches — so callers can skip applying a no-op guard.
+    /// </summary>
+    private static (TypeInfo? Truthy, TypeInfo? Falsy) ComputeTruthinessNarrowing(TypeInfo currentType)
+    {
+        // any/unknown straddle both branches: tsc keeps `any` as-is, and member access on
+        // `unknown` still requires a further guard, so leave both untouched here.
+        if (currentType is TypeInfo.Any or TypeInfo.Unknown)
+        {
+            return (null, null);
+        }
+
+        IEnumerable<TypeInfo> constituents =
+            currentType is TypeInfo.Union union ? union.FlattenedTypes : [currentType];
+
+        var truthy = new List<TypeInfo>();
+        var falsy = new List<TypeInfo>();
+        foreach (var t in constituents)
+        {
+            if (t is TypeInfo.Never) continue;       // bottom type inhabits neither branch
+            if (!IsAlwaysFalsy(t)) truthy.Add(t);    // can be truthy → keep in the truthy branch
+            if (!IsAlwaysTruthy(t)) falsy.Add(t);    // can be falsy  → keep in the falsy branch
+        }
+
+        static TypeInfo Build(List<TypeInfo> parts) =>
+            parts.Count == 0 ? new TypeInfo.Never() :
+            parts.Count == 1 ? parts[0] :
+            new TypeInfo.Union(parts);
+
+        TypeInfo truthyType = Build(truthy);
+        TypeInfo falsyType = Build(falsy);
+
+        // No-op when neither branch refines the type (e.g. a lone `string`): both projections
+        // equal the original, so report "no narrowing" rather than redefining to itself.
+        if (TypeInfoEqualityComparer.Instance.Equals(truthyType, currentType) &&
+            TypeInfoEqualityComparer.Instance.Equals(falsyType, currentType))
+        {
+            return (null, null);
+        }
+
+        return (truthyType, falsyType);
+    }
+
+    /// <summary>
+    /// True when every value of the type is falsy in JS: <c>null</c>, <c>undefined</c>,
+    /// <c>void</c>, and the falsy literal types (<c>false</c>, <c>0</c>, <c>""</c>).
+    /// Deliberately conservative — a false positive would wrongly drop a constituent from the
+    /// truthy branch (a soundness bug), so only definite cases qualify.
+    /// </summary>
+    private static bool IsAlwaysFalsy(TypeInfo type) => type switch
+    {
+        TypeInfo.Null or TypeInfo.Undefined or TypeInfo.Void => true,
+        TypeInfo.BooleanLiteral { Value: false } => true,
+        TypeInfo.NumberLiteral n => n.Value == 0,            // 0 and -0 (NaN literals don't occur)
+        TypeInfo.StringLiteral s => s.Value.Length == 0,
+        _ => false
+    };
+
+    /// <summary>
+    /// True when every value of the type is truthy in JS: object-like types (objects, arrays,
+    /// functions, class instances, symbols, built-in references) and the non-falsy literal
+    /// types. Deliberately conservative — under-approximating only costs precision in the falsy
+    /// branch (never correctness), so ambiguous/unmodeled types (general <c>string</c>/
+    /// <c>number</c>/<c>boolean</c>/<c>bigint</c>, <c>enum</c>, type parameters, intersections,
+    /// template-literal types) return false.
+    /// </summary>
+    private static bool IsAlwaysTruthy(TypeInfo type) => type switch
+    {
+        TypeInfo.BooleanLiteral { Value: true } => true,
+        TypeInfo.NumberLiteral n => n.Value != 0 && !double.IsNaN(n.Value),
+        TypeInfo.StringLiteral s => s.Value.Length > 0,
+        // Object-like types are truthy regardless of contents (even empty arrays/objects/`{}`).
+        TypeInfo.Object or TypeInfo.Record or TypeInfo.Array or TypeInfo.Tuple or
+        TypeInfo.Instance or TypeInfo.Class or TypeInfo.MutableClass or TypeInfo.Interface or
+        TypeInfo.Function or TypeInfo.GenericFunction or TypeInfo.OverloadedFunction or
+        TypeInfo.GenericOverloadedFunction or TypeInfo.Symbol or TypeInfo.UniqueSymbol or
+        TypeInfo.Map or TypeInfo.Set or TypeInfo.WeakMap or TypeInfo.WeakSet or
+        TypeInfo.WeakRef or TypeInfo.FinalizationRegistry or TypeInfo.Iterator or
+        TypeInfo.Generator or TypeInfo.AsyncGenerator or TypeInfo.AsyncIterable or
+        TypeInfo.Date or TypeInfo.RegExp or TypeInfo.Error or TypeInfo.Promise or
+        TypeInfo.Buffer or TypeInfo.EventEmitter or TypeInfo.AbortController or
+        TypeInfo.AbortSignal or TypeInfo.Worker or TypeInfo.MessagePort or
+        TypeInfo.MessageChannel or TypeInfo.SharedArrayBuffer or TypeInfo.ArrayBuffer or
+        TypeInfo.DataView or TypeInfo.TypedArray or TypeInfo.Timeout or
+        TypeInfo.Namespace or TypeInfo.Module => true,
+        _ => false
+    };
 
     private bool TypeMatchesTypeof(TypeInfo type, string typeofResult) => typeofResult switch
     {


### PR DESCRIPTION
Closes #486.

## What

A truthiness guard now narrows a union the same way the existing `!== null/undefined` and `typeof` guards already do:

```ts
function f(d: string | undefined): number {
  if (d) { return d.length; }   // was: Type Error: Object is possibly null or undefined
  return 0;
}
```

The truthy branch drops always-falsy constituents (`null`, `undefined`, `void`, and the `false`/`0`/`""` literal types); the falsy branch drops always-truthy ones — mirroring tsc's `getTypeWithFacts(Truthy/Falsy)`.

Covers bare variables, property-access paths, `this`, `!`/`!!`/grouping, and the `&&` / `||` / ternary / `if` / `while` / `for` forms — e.g. `if (!d) return; d.length`, `x && x.n`, `x ? x.n : 0`, `if (b.inner) b.inner.x`.

## How

One hook: `AnalyzePathTruthinessGuard`, added as the final fallback in `AnalyzePathTypeGuard` (`TypeSystem/TypeChecker.Compatibility.TypeGuards.cs`). Every narrowing caller (`AnalyzeCompoundTypeGuards`, `CheckLogical`, `CheckTernary`, `AnalyzeLoopConditionNarrowings`) routes leaves through this analyzer first, so a single place covers all forms — no per-caller edits. The legacy `=== null` / `typeof` patterns run ahead of it and are untouched (truthiness is the general fallback).

`ComputeTruthinessNarrowing` + the `IsAlwaysFalsy` / `IsAlwaysTruthy` classifiers are deliberately conservative:
- `IsAlwaysFalsy` is kept tight (only definite cases) — a false positive there would unsoundly drop a constituent from the truthy branch.
- `IsAlwaysTruthy` under-approximates (missing an object-like type only costs precision in the falsy branch, never correctness).
- `any` / `unknown` and bare general primitives (`string`/`number`/`boolean`) are left untouched (no-op), so nothing over-narrows.

## Tests / validation

- **Unit suite: 11752 passed, 0 failed**
- **15 new tests** in `TruthinessNarrowingTests.cs` (positive forms + negatives: unguarded access still errors, narrowing doesn't leak past an empty `if`, plus a compiled-mode check)
- **TypeScript conformance: 31 passed, 0 failed** — no baseline drift (its subset is assignment-compatibility + conditional *types*, not control-flow narrowing)
- Narrowing is type-check-time only, so runtime is unchanged in both interpreted and compiled modes.

## Follow-ups filed (pre-existing, surfaced while testing)

- #556 — loop-condition narrowing is over-invalidated when the body reassigns the guarded variable (hits `!== undefined` identically; not introduced here)
- #557 — a general `boolean` isn't narrowed to `true`/`false` under truthiness (the only general-primitive case tsc narrows)
