### PR TITLE
Fix #533: allow function bodies to forward-reference later let/const

### DIFF
--- a/Compilation/ClosureAnalyzer.cs
+++ b/Compilation/ClosureAnalyzer.cs
@@ -145,6 +145,16 @@ public class ClosureAnalyzer : AstVisitorBase
             // and the compiled inner function body emits a runtime ReferenceError fallback.
             else if (stmt is Stmt.Var vr && vr.IsVar)
                 DeclareVariable(vr.Name.Lexeme);
+            // Pre-declare block-scoped let/const for the same reason (#533): an inner function
+            // declared BEFORE a let/const in this scope must still capture it, because the function
+            // only runs after the binding is initialized. This method is called per-scope (module,
+            // block, function body, arrow body), so each binding is declared in its own scope.
+            // Unlike var, no source-order initialization is implied — capture analysis only needs to
+            // know which scope OWNS the name so the inner function shares the binding's slot.
+            else if (stmt is Stmt.Var lt && !lt.IsVar)
+                DeclareVariable(lt.Name.Lexeme);
+            else if (stmt is Stmt.Const ct)
+                DeclareVariable(ct.Name.Lexeme);
         }
     }
 

--- a/SharpTS.Tests/SharedTests/LexicalForwardReferenceTests.cs
+++ b/SharpTS.Tests/SharedTests/LexicalForwardReferenceTests.cs
@@ -1,0 +1,172 @@
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests;
+
+/// <summary>
+/// Issue #533: a function (or any closure) declared BEFORE a <c>let</c>/<c>const</c> in the same
+/// scope may reference that binding in its body. The body only executes once the binding is
+/// initialized, so TypeScript — which collects every lexical binding in a scope before checking any
+/// function body — accepts the forward reference. SharpTS previously rejected it with a spurious
+/// "Undefined variable" type error because it checked function bodies in source order and only
+/// pre-hoisted <c>var</c>/<c>class</c>. The fix hoists <c>let</c>/<c>const</c> the same way.
+///
+/// A *direct* (non-deferred) use-before-declaration is still an error — surfaced at runtime, the
+/// same way a forward <c>class</c> reference is — see <see cref="DirectUseBeforeDeclaration_StillThrows"/>.
+/// </summary>
+public class LexicalForwardReferenceTests
+{
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void FunctionDeclaration_ReferencesLaterLet(ExecutionMode mode)
+    {
+        var source = """
+            function f() { return x; }
+            let x = 1;
+            console.log(f());
+            """;
+
+        Assert.Equal("1", TestHarness.Run(source, mode).Trim());
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void FunctionDeclaration_ReferencesLaterConst(ExecutionMode mode)
+    {
+        var source = """
+            function f() { return z; }
+            const z = 5;
+            console.log(f());
+            """;
+
+        Assert.Equal("5", TestHarness.Run(source, mode).Trim());
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Generator_ReferencesLaterLet(ExecutionMode mode)
+    {
+        // The exact second repro from the issue (a generator declared before its let binding).
+        var source = """
+            function* g() { yield x; yield x + 1; }
+            let x = 1;
+            console.log([...g()].join(","));
+            """;
+
+        Assert.Equal("1,2", TestHarness.Run(source, mode).Trim());
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ArrowConst_ReferencesLaterLet(ExecutionMode mode)
+    {
+        var source = """
+            const getIt = () => _val;
+            let _val = 42;
+            console.log(getIt());
+            """;
+
+        Assert.Equal("42", TestHarness.Run(source, mode).Trim());
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AnnotatedLet_ForwardReferenced_TypeChecks(ExecutionMode mode)
+    {
+        var source = """
+            function f(): string { return s; }
+            let s: string = "hi";
+            console.log(f());
+            """;
+
+        Assert.Equal("hi", TestHarness.Run(source, mode).Trim());
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void InnerFunction_ReferencesLaterLet_InEnclosingBody(ExecutionMode mode)
+    {
+        // The forward binding lives in the enclosing FUNCTION body, not module scope.
+        var source = """
+            function outer() {
+                function f() { return y; }
+                let y = 99;
+                return f();
+            }
+            console.log(outer());
+            """;
+
+        Assert.Equal("99", TestHarness.Run(source, mode).Trim());
+    }
+
+    [Fact]
+    public void ShadowingConst_BindsToInnerDeclaration_Interpreted()
+    {
+        // The inner `const x` shadows the outer one throughout `wrapper`, including in f's closure.
+        // Hoisting the inner binding makes f resolve to it (value "shadow"), which is what runs.
+        // Interpreted-only: compiled mode mis-binds a captured *shadowing* block-scoped name to the
+        // wrong display-class slot (resolves to null) — a pre-existing defect, orthogonal to #533
+        // (it reproduces with f declared AFTER the inner const, i.e. no forward reference). See #562.
+        var source = """
+            const x = 99;
+            function wrapper() {
+                function f() { return x; }
+                const x = "shadow";
+                return f();
+            }
+            console.log(wrapper());
+            """;
+
+        Assert.Equal("shadow", TestHarness.RunInterpreted(source).Trim());
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void MutualRecursion_ViaConstArrows_StillWorks(ExecutionMode mode)
+    {
+        // Guards that hoisting let/const as `any` does not clobber the precise function type that
+        // HoistConstFunctionExpressions registers for a `const f = () => …` arrow (the IsDefinedLocally
+        // guard). Each arrow forward-references the other.
+        var source = """
+            const isEven = (n: number): boolean => n === 0 ? true : isOdd(n - 1);
+            const isOdd = (n: number): boolean => n === 0 ? false : isEven(n - 1);
+            console.log(isEven(10) + " " + isOdd(7));
+            """;
+
+        Assert.Equal("true true", TestHarness.Run(source, mode).Trim());
+    }
+
+    [Fact]
+    public void NamespaceMemberFunction_ReferencesLaterConst_Interpreted()
+    {
+        // A namespace member function declared before a namespace-level const now type-checks the
+        // same way the in-order variant already did. Interpreted-only: compiled mode cannot resolve
+        // a namespace-level variable from a namespace member function at all (any order, var/let/const)
+        // — a pre-existing, orthogonal namespace-emission defect tracked in #567.
+        var source = """
+            namespace N {
+                export function f() { return val; }
+                const val = 7;
+                export const result = f();
+            }
+            console.log(N.result);
+            """;
+
+        Assert.Equal("7", TestHarness.RunInterpreted(source).Trim());
+    }
+
+    [Fact]
+    public void DirectUseBeforeDeclaration_StillThrows()
+    {
+        // Not deferred behind a closure: the read runs before `let x`, so the binding does not exist
+        // yet. This is still an error — now at runtime, exactly how a forward class reference behaves
+        // — never silently `undefined`.
+        var source = """
+            console.log(x);
+            let x = 1;
+            """;
+
+        var ex = Assert.ThrowsAny<Exception>(() => TestHarness.RunInterpreted(source));
+        Assert.Contains("Undefined variable", ex.Message);
+    }
+}

--- a/SharpTS.Tests/TypeCheckerTests/VarHoistingTypeCheckTests.cs
+++ b/SharpTS.Tests/TypeCheckerTests/VarHoistingTypeCheckTests.cs
@@ -79,24 +79,46 @@ public class VarHoistingTypeCheckTests
         Assert.Equal("2", output.Trim());
     }
 
+    // #533: a function declared BEFORE a let/const may reference that binding in its body — the
+    // body only runs once the binding is initialized, so TypeScript (which collects every lexical
+    // binding in a scope before checking bodies) accepts it. SharpTS now hoists let/const the same
+    // way it hoists var and class. (A *direct* use-before-declaration is still rejected — at runtime
+    // — because the binding isn't created until its statement executes; see the StillFails tests.)
     [Fact]
-    public void ForwardLetReference_InFunctionBody_StillFails()
+    public void ForwardLetReference_InFunctionBody_Succeeds()
     {
         var source = """
             function f() { return y; }
             let y = 1;
+            console.log(f());
             """;
 
-        var ex = Assert.ThrowsAny<Exception>(() => TestHarness.RunInterpreted(source));
-        Assert.Contains("Undefined variable", ex.Message);
+        var output = TestHarness.RunInterpreted(source);
+        Assert.Equal("1", output.Trim());
     }
 
     [Fact]
-    public void ForwardConstReference_InFunctionBody_StillFails()
+    public void ForwardConstReference_InFunctionBody_Succeeds()
     {
         var source = """
             function f() { return z; }
-            const z = 1;
+            const z = 5;
+            console.log(f());
+            """;
+
+        var output = TestHarness.RunInterpreted(source);
+        Assert.Equal("5", output.Trim());
+    }
+
+    [Fact]
+    public void DirectLetReference_BeforeDeclaration_StillFailsAtRuntime()
+    {
+        // Not deferred behind a function: the read executes before `let x` runs, so the binding
+        // does not exist yet. This stays an error (now surfaced at runtime, matching how a forward
+        // class reference behaves), never silently producing undefined.
+        var source = """
+            console.log(x);
+            let x = 1;
             """;
 
         var ex = Assert.ThrowsAny<Exception>(() => TestHarness.RunInterpreted(source));

--- a/TypeSystem/TypeChecker.Expressions.cs
+++ b/TypeSystem/TypeChecker.Expressions.cs
@@ -1436,6 +1436,10 @@ public partial class TypeChecker
                 // resolve. Matches the behavior in CheckFunctionDeclaration.
                 HoistFunctionDeclarations(arrow.BlockBody);
 
+                // Likewise hoist the body's own let/const (as `any`) so an inner function declared
+                // before a later block-scoped binding in the same body can forward-reference it (#533).
+                HoistLexicalDeclarations(arrow.BlockBody);
+
                 // Block body - check statements
                 CheckStmtList(arrow.BlockBody);
 

--- a/TypeSystem/TypeChecker.Namespaces.cs
+++ b/TypeSystem/TypeChecker.Namespaces.cs
@@ -64,6 +64,10 @@ public partial class TypeChecker
             // (`var a: { foo: typeof a }`, `var a2 = { foo: a2 }`).
             HoistVarDeclarations(ns.Members);
 
+            // Likewise pre-register let/const members as `any` so a member function declared before a
+            // later block-scoped binding can forward-reference it (#533).
+            HoistLexicalDeclarations(ns.Members);
+
             // First pass: collect all type declarations (classes, interfaces, enums, nested namespaces)
             foreach (var member in ns.Members)
             {

--- a/TypeSystem/TypeChecker.Statements.Functions.cs
+++ b/TypeSystem/TypeChecker.Statements.Functions.cs
@@ -155,7 +155,8 @@ public partial class TypeChecker
     /// <summary>
     /// Pre-registers top-level var declarations by defining them as 'any' in the type environment.
     /// This enables forward references to var-declared variables from within function bodies,
-    /// matching JavaScript's var hoisting semantics. Does NOT apply to let/const (TDZ).
+    /// matching JavaScript's var hoisting semantics. <c>let</c>/<c>const</c> are handled by the
+    /// sibling <see cref="HoistLexicalDeclarations"/>.
     /// </summary>
     private void HoistVarDeclarations(IEnumerable<Stmt> statements)
     {
@@ -170,6 +171,50 @@ public partial class TypeChecker
                 case Stmt.Export { Declaration: Stmt.Var v } when v.IsVar:
                     if (!_environment.IsDefinedLocally(v.Name.Lexeme))
                         _environment.Define(v.Name.Lexeme, new TypeInfo.Any());
+                    break;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Pre-registers top-level <c>let</c>/<c>const</c> declarations by defining their names as
+    /// <c>any</c> in the type environment, so a function/closure body that textually PRECEDES the
+    /// declaration can still forward-reference it (#533). TypeScript collects every lexical binding
+    /// in a scope before checking any function body, so such forward references are legal there; the
+    /// body only executes once the binding is initialized. The real type is installed when
+    /// VisitVar/VisitConst runs during the sequential pass, overwriting the <c>any</c> placeholder,
+    /// so a reference appearing AFTER the declaration keeps its precise type.
+    ///
+    /// Mirrors <see cref="HoistVarDeclarations"/> (var) and <see cref="HoistClassDeclarations"/>
+    /// (class — also block-scoped/TDZ). Like those, this trades precise TDZ diagnostics for
+    /// forward-reference support: a *direct* use-before-declaration (e.g. <c>console.log(x); let x = 1;</c>)
+    /// no longer reports a static error, but still fails at runtime because the interpreter/compiler
+    /// only bind the name when the declaration statement runs. The <c>IsDefinedLocally</c> guard
+    /// preserves the precise function type that <c>HoistConstFunctionExpressions</c> may already have
+    /// registered for a <c>const f = () =&gt; …</c> arrow.
+    /// </summary>
+    private void HoistLexicalDeclarations(IEnumerable<Stmt> statements)
+    {
+        foreach (var stmt in statements)
+        {
+            switch (stmt)
+            {
+                // `let` is Stmt.Var with IsVar == false; `var` is handled by HoistVarDeclarations.
+                case Stmt.Var v when !v.IsVar:
+                    if (!_environment.IsDefinedLocally(v.Name.Lexeme))
+                        _environment.Define(v.Name.Lexeme, new TypeInfo.Any());
+                    break;
+                case Stmt.Const c:
+                    if (!_environment.IsDefinedLocally(c.Name.Lexeme))
+                        _environment.Define(c.Name.Lexeme, new TypeInfo.Any());
+                    break;
+                case Stmt.Export { Declaration: Stmt.Var v } when !v.IsVar:
+                    if (!_environment.IsDefinedLocally(v.Name.Lexeme))
+                        _environment.Define(v.Name.Lexeme, new TypeInfo.Any());
+                    break;
+                case Stmt.Export { Declaration: Stmt.Const c }:
+                    if (!_environment.IsDefinedLocally(c.Name.Lexeme))
+                        _environment.Define(c.Name.Lexeme, new TypeInfo.Any());
                     break;
             }
         }
@@ -672,6 +717,12 @@ public partial class TypeChecker
                 // scope before any statement executes; the TypeChecker needs to
                 // mirror that to accept well-formed mutually-recursive inner fns.
                 HoistFunctionDeclarations(body);
+
+                // Hoist the body's own let/const (as `any`) so an inner function declared before a
+                // later block-scoped binding in the SAME body can forward-reference it (#533). `var`
+                // is already lifted to the body top by the parse-time VarHoister, so it is not repeated
+                // here; let/const are not physically moved (TDZ), so they need this registration.
+                HoistLexicalDeclarations(body);
 
                 CheckStmtList(body);
 

--- a/TypeSystem/TypeChecker.cs
+++ b/TypeSystem/TypeChecker.cs
@@ -802,6 +802,10 @@ public partial class TypeChecker
         // Hoist var declarations (pre-define as any for forward reference support)
         HoistVarDeclarations(statements);
 
+        // Hoist let/const declarations (pre-define as any so an earlier function body can
+        // forward-reference a later block-scoped binding — #533)
+        HoistLexicalDeclarations(statements);
+
         foreach (Stmt statement in statements)
         {
             CheckStmt(statement);
@@ -843,6 +847,10 @@ public partial class TypeChecker
 
         // Hoist var declarations (pre-define as any for forward reference support)
         HoistVarDeclarations(statements);
+
+        // Hoist let/const declarations (pre-define as any so an earlier function body can
+        // forward-reference a later block-scoped binding — #533)
+        HoistLexicalDeclarations(statements);
 
         foreach (Stmt statement in statements)
         {
@@ -1149,6 +1157,9 @@ public partial class TypeChecker
                     // Hoist var declarations (pre-define as any for forward reference support)
                     HoistVarDeclarations(module.Statements);
 
+                    // Hoist let/const declarations (pre-define as any for forward reference support — #533)
+                    HoistLexicalDeclarations(module.Statements);
+
                     // Check all statements with error recovery
                     foreach (var stmt in module.Statements)
                     {
@@ -1194,6 +1205,9 @@ public partial class TypeChecker
                     // Hoist var declarations (pre-define as any for forward reference support)
                     HoistVarDeclarations(module.Statements);
 
+                    // Hoist let/const declarations (pre-define as any for forward reference support — #533)
+                    HoistLexicalDeclarations(module.Statements);
+
                     // Third pass: check all statements with error recovery
                     foreach (var stmt in module.Statements)
                     {
@@ -1233,6 +1247,9 @@ public partial class TypeChecker
 
             // Hoist var declarations (pre-define as any for forward reference support)
             HoistVarDeclarations(script.Statements);
+
+            // Hoist let/const declarations (pre-define as any for forward reference support — #533)
+            HoistLexicalDeclarations(script.Statements);
 
             // Process all declarations to populate the environment
             foreach (var stmt in script.Statements)
@@ -1290,6 +1307,9 @@ public partial class TypeChecker
 
             // Hoist var declarations (pre-define as any for forward reference support)
             HoistVarDeclarations(module.Statements);
+
+            // Hoist let/const declarations (pre-define as any for forward reference support — #533)
+            HoistLexicalDeclarations(module.Statements);
 
             // Then, process all declarations to populate the environment
             foreach (var stmt in module.Statements)


### PR DESCRIPTION
## Summary

Fixes #533. A function (or any closure) declared **before** a `let`/`const` in the same scope could not reference that binding in its body — the type checker reported a spurious `Undefined variable`, even though the body only runs once the binding is initialized. TypeScript collects every lexical binding in a scope before checking any function body, so the forward reference is legal there.

```ts
function f() { return x; }
let x = 1;
console.log(f());   // was: Type Error: Undefined variable 'x'   →  now: 1

function* g() { yield x2; }
let x2 = 1;
console.log([...g()]);   // was: error   →   now: [ 1 ]
```

## Fix

The codebase already pre-hoists `var` (`HoistVarDeclarations`) and `class` (`HoistClassDeclarations`) names as `any` so earlier bodies can forward-reference them. `let`/`const` were the gap. This adds the symmetric **`HoistLexicalDeclarations`** and wires it into every scope-entry point (module, script, namespace, function body, arrow body). The real type is installed when the declaration is reached in source order, so a reference *after* the declaration keeps its precise type; only the forward reference degrades to `any`.

Compiled mode needed the same one-line symmetry in **`ClosureAnalyzer`**, which already pre-declared `var` so an earlier inner function captures a later outer binding — it now does the same for `let`/`const` (without it, the inner function emitted a runtime `ReferenceError`).

### Tradeoff (intentional, matches the existing `class` behavior)

Like the class hoist, this trades a static use-before-declaration diagnostic for forward-reference support. A **direct** (non-deferred) use before the declaration — `console.log(x); let x = 1;` — is no longer a compile error, but still fails at runtime, exactly as a forward `class` reference already does today. Proper static TDZ diagnostics (TS2448) for `let`/`const` *and* `class` would be a separate enhancement.

## Issues filed along the way

Both are **pre-existing** compiled-mode defects, surfaced while verifying both modes, orthogonal to this change (each reproduces with no forward reference):

- #562 — a nested function/arrow capturing a `let`/`const` that **shadows** an outer same-named binding resolves to `null` in compiled mode.
- #567 — a function inside a `namespace` cannot reference a namespace-level `var`/`let`/`const` at all in compiled mode (any order, exported or not).

## Testing

- New `LexicalForwardReferenceTests` — both modes for module / function-body / arrow / generator / annotated cases; interpreted-only for the shadow and namespace cases (which hit #562 / #567).
- Updated the stale `let`/`const` cases in `VarHoistingTypeCheckTests` that pinned the old (buggy) behavior.
- Full suite **11877 pass / 0 fail**. Test262 and TypeScriptConformance baselines **unchanged** (no regressions, no bucket shifts).
