### PR TITLE
Fix #559: compiled async generator runs enclosing finally on break/continue/return/throw

### DIFF
--- a/Compilation/AsyncGeneratorMoveNextEmitter.Statements.TryCatch.cs
+++ b/Compilation/AsyncGeneratorMoveNextEmitter.Statements.TryCatch.cs
@@ -1,0 +1,761 @@
+using System.Reflection;
+using System.Reflection.Emit;
+using SharpTS.Parsing;
+
+namespace SharpTS.Compilation;
+
+public partial class AsyncGeneratorMoveNextEmitter
+{
+    // ---- Unified exit-scope stack (#559, the async analog of #500) -------------------------------
+    //
+    // A non-local exit (return / break / continue / a throw from a catch or finally) that crosses a
+    // flag-based try/finally must run the enclosing finally(s) before transferring control. Because a
+    // finally can itself yield or await, the routing state has to survive a MoveNextAsync re-entry, so
+    // it lives in state-machine fields rather than IL locals.
+    //
+    // This mirrors GeneratorMoveNextEmitter.Statements.TryCatch.cs exactly; only two things differ for
+    // the async generator: the terminal actions return `ValueTask<bool>` (via EmitReturnValueTaskBool)
+    // rather than a bare `ret false`, and the routing coexists with the pre-existing external
+    // `generator.return()` path (the `__returnRequested` flag checked at each yield resume and after
+    // each finally — see EmitYield and EmitTryCatchWithSuspensions). The two never collide: the
+    // external path uses `__returnRequested` and is consulted before the dispatch, while in-body exits
+    // use `<>pendingExit` and are dispatched only when `__returnRequested` is clear.
+
+    private interface IExitScope;
+
+    /// <summary>A loop (or switch / labeled statement) that <c>break</c>/<c>continue</c> can target.</summary>
+    private sealed class LoopScope : IExitScope
+    {
+        public required Label BreakLabel;
+        public required Label ContinueLabel;
+        public string? LabelName;
+
+        // Lazily assigned the first time a break/continue to this loop must run an intervening
+        // finally; identifies that exit in the `<>pendingExit` field. Unset while the loop's
+        // break/continue need no finally routing (the common case → a direct branch).
+        public int? BreakCode;
+        public int? ContinueCode;
+    }
+
+    /// <summary>A flag-based <c>try</c> that has a <c>finally</c>; its finally runs on any exit that crosses it.</summary>
+    private sealed class FinallyScope : IExitScope
+    {
+        public required Label CleanupLabel;
+
+        // code → where control goes after this finally for that pending exit: a chain to the next
+        // outer finally's cleanup label, or null meaning "this finally is terminal for the exit".
+        public readonly Dictionary<int, Label?> Dispatch = [];
+    }
+
+    // Innermost-last stack of loop and finally scopes currently open at the emission point. Replaces
+    // the base class's `_loopLabels` (the loop-scope methods below are overridden to use this) so loops
+    // and finallys share one ordering — needed to know which finallys lie between a break and its loop.
+    private readonly List<IExitScope> _exitScopes = [];
+
+    private const int ExitCodeReturn = 1;
+    private const int ExitCodeThrow = 2;
+    private int _nextExitCode = 3; // break/continue codes are allocated from here
+
+    // code → emits the terminal action for that code (invoked when a finally is terminal for it).
+    private readonly Dictionary<int, Action> _exitTerminals = [];
+
+    // Depth of real IL exception blocks (EmitSimpleTryCatch / EmitSyncSegmentInTry) open around the
+    // current emission point. While > 0, a `br`/`ret` out of the region would be illegal, so exits are
+    // left to the existing per-path handling instead of being routed through the finally machinery.
+    // This is independent of CompilationContext.ExceptionBlockDepth (which only counts simple try
+    // blocks and drives the Leave-vs-Br choice in EmitBranchToLabel).
+    private int _protectedRegionDepth;
+
+    // True while emitting a catch or finally body. A `throw` there must run the enclosing finally(s);
+    // a `throw` in a try body is instead captured by its sync-segment mini try/catch (and so must not
+    // be routed). Saved/restored around each region so nesting is handled correctly.
+    private bool _inHandlerBody;
+
+    // `<>pendingExit` (int): the code of an in-flight non-local exit, or 0 when none. A finally that
+    // yields/awaits suspends MoveNextAsync mid-routing, so this must be a field (a local would reset on
+    // re-entry). Set once per exit and cleared by the terminal dispatch; defaults to 0 on a fresh
+    // state machine.
+    private FieldBuilder? _pendingExitField;
+
+    private FieldBuilder GetPendingExitField() =>
+        _pendingExitField ??= _builder.StateMachineType.DefineField(
+            "<>pendingExit", typeof(int), FieldAttributes.Private);
+
+    // `<>pendingException` (object): the value of a `throw` being routed through finally(s), held
+    // across any suspension in those finallys until the terminal dispatch rethrows it.
+    private FieldBuilder? _pendingExceptionField;
+
+    private FieldBuilder GetPendingExceptionField() =>
+        _pendingExceptionField ??= _builder.StateMachineType.DefineField(
+            "<>pendingException", typeof(object), FieldAttributes.Private);
+
+    // ---- Loop-scope methods (override the base stack to use `_exitScopes`) -----------------------
+
+    protected override void EnterLoop(Label breakLabel, Label continueLabel, string? labelName = null)
+        => _exitScopes.Add(new LoopScope { BreakLabel = breakLabel, ContinueLabel = continueLabel, LabelName = labelName });
+
+    protected override void ExitLoop()
+    {
+        // Well-nested: any try opened inside the loop body has already been closed, so the top of the
+        // stack is this loop's LoopScope.
+        _exitScopes.RemoveAt(_exitScopes.Count - 1);
+    }
+
+    protected override (Label BreakLabel, Label ContinueLabel, string? LabelName)? CurrentLoop
+    {
+        get
+        {
+            var loop = CurrentLoopScope();
+            return loop == null ? null : (loop.BreakLabel, loop.ContinueLabel, loop.LabelName);
+        }
+    }
+
+    protected override (Label BreakLabel, Label ContinueLabel, string? LabelName)? FindLabeledLoop(string labelName)
+    {
+        var loop = FindLabeledLoopScope(labelName);
+        return loop == null ? null : (loop.BreakLabel, loop.ContinueLabel, loop.LabelName);
+    }
+
+    private LoopScope? CurrentLoopScope()
+    {
+        for (int i = _exitScopes.Count - 1; i >= 0; i--)
+            if (_exitScopes[i] is LoopScope ls)
+                return ls;
+        return null;
+    }
+
+    private LoopScope? FindLabeledLoopScope(string labelName)
+    {
+        for (int i = _exitScopes.Count - 1; i >= 0; i--)
+            if (_exitScopes[i] is LoopScope ls && ls.LabelName == labelName)
+                return ls;
+        return null;
+    }
+
+    // ---- Non-local exit overrides ---------------------------------------------------------------
+
+    /// <summary>
+    /// A <c>break</c> must run any finally between it and the target loop before jumping out.
+    /// </summary>
+    protected override void EmitBreak(Stmt.Break b)
+    {
+        var loop = b.Label != null ? FindLabeledLoopScope(b.Label.Lexeme) : CurrentLoopScope();
+        if (loop == null) return; // matches the base: a break with no resolvable target is a no-op
+
+        if (_protectedRegionDepth == 0)
+        {
+            var chain = FinallyFramesAbove(loop);
+            if (chain.Count > 0)
+            {
+                int code = loop.BreakCode ??= _nextExitCode++;
+                _exitTerminals.TryAdd(code, () => _il.Emit(OpCodes.Br, loop.BreakLabel));
+                RouteThroughFinallys(chain, code);
+                return;
+            }
+        }
+
+        EmitBranchToLabel(loop.BreakLabel);
+    }
+
+    /// <summary>
+    /// A <c>continue</c> must run any finally between it and the target loop before jumping to the
+    /// loop's continue point.
+    /// </summary>
+    protected override void EmitContinue(Stmt.Continue c)
+    {
+        var loop = c.Label != null ? FindLabeledLoopScope(c.Label.Lexeme) : CurrentLoopScope();
+        if (loop == null) return;
+
+        if (_protectedRegionDepth == 0)
+        {
+            var chain = FinallyFramesAbove(loop);
+            if (chain.Count > 0)
+            {
+                int code = loop.ContinueCode ??= _nextExitCode++;
+                _exitTerminals.TryAdd(code, () => _il.Emit(OpCodes.Br, loop.ContinueLabel));
+                RouteThroughFinallys(chain, code);
+                return;
+            }
+        }
+
+        EmitBranchToLabel(loop.ContinueLabel);
+    }
+
+    /// <summary>
+    /// A <c>throw</c> in a catch or finally body must run the enclosing finally(s) before the
+    /// exception propagates. A throw in a try body is captured by its sync-segment mini try/catch
+    /// (handled by the catch arm), so it is not routed here.
+    /// </summary>
+    protected override void EmitThrow(Stmt.Throw t)
+    {
+        if (_inHandlerBody && _protectedRegionDepth == 0)
+        {
+            var chain = ActiveFinallyFrames();
+            if (chain.Count > 0)
+            {
+                EmitExpression(t.Value);
+                EnsureBoxed();
+                var thrown = _il.DeclareLocal(typeof(object));
+                _il.Emit(OpCodes.Stloc, thrown);
+                _il.Emit(OpCodes.Ldarg_0);
+                _il.Emit(OpCodes.Ldloc, thrown);
+                _il.Emit(OpCodes.Stfld, GetPendingExceptionField());
+
+                RegisterThrowTerminal();
+                RouteThroughFinallys(chain, ExitCodeThrow);
+                return;
+            }
+        }
+
+        base.EmitThrow(t);
+    }
+
+    // ---- Routing helpers ------------------------------------------------------------------------
+
+    /// <summary>All open finally scopes, innermost first.</summary>
+    private List<FinallyScope> ActiveFinallyFrames()
+    {
+        var result = new List<FinallyScope>();
+        for (int i = _exitScopes.Count - 1; i >= 0; i--)
+            if (_exitScopes[i] is FinallyScope fs)
+                result.Add(fs);
+        return result;
+    }
+
+    /// <summary>The finally scopes between the current point and <paramref name="target"/>, innermost first.</summary>
+    private List<FinallyScope> FinallyFramesAbove(LoopScope target)
+    {
+        var result = new List<FinallyScope>();
+        for (int i = _exitScopes.Count - 1; i >= 0; i--)
+        {
+            if (ReferenceEquals(_exitScopes[i], target)) break;
+            if (_exitScopes[i] is FinallyScope fs)
+                result.Add(fs);
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Records <paramref name="code"/>'s per-frame routing across <paramref name="chain"/> (each frame
+    /// chains to the next, the outermost is terminal), then sets the pending-exit field and branches to
+    /// the innermost finally. The caller must have prepared any value the terminal needs (e.g. the
+    /// thrown value, or the Current/return state) beforehand.
+    /// </summary>
+    private void RouteThroughFinallys(List<FinallyScope> chain, int code)
+    {
+        for (int i = 0; i < chain.Count; i++)
+        {
+            // The last frame in the chain is terminal for this code (null); the rest chain outward.
+            Label? next = i < chain.Count - 1 ? chain[i + 1].CleanupLabel : null;
+            chain[i].Dispatch[code] = next; // idempotent: the same code always routes a frame the same way
+        }
+
+        _il.Emit(OpCodes.Ldarg_0);
+        _il.Emit(OpCodes.Ldc_I4, code);
+        _il.Emit(OpCodes.Stfld, GetPendingExitField());
+        _il.Emit(OpCodes.Br, chain[0].CleanupLabel);
+    }
+
+    /// <summary>
+    /// Emitted after a finally body: for each pending-exit code that routes through this frame, either
+    /// chain to the next outer finally or, if terminal here, clear the pending field and run the
+    /// terminal action. A pending value of 0 (none) and codes not handled here fall through unchanged.
+    /// </summary>
+    private void EmitFinallyDispatch(FinallyScope frame)
+    {
+        foreach (var (code, next) in frame.Dispatch)
+        {
+            var skip = _il.DefineLabel();
+            _il.Emit(OpCodes.Ldarg_0);
+            _il.Emit(OpCodes.Ldfld, GetPendingExitField());
+            _il.Emit(OpCodes.Ldc_I4, code);
+            _il.Emit(OpCodes.Bne_Un, skip);
+
+            if (next.HasValue)
+            {
+                // Not terminal here — keep the pending code and run the next outer finally.
+                _il.Emit(OpCodes.Br, next.Value);
+            }
+            else
+            {
+                // Terminal: the exit has run every finally it needed to. Clear the flag first so a
+                // break/continue resumes the generator with clean state.
+                _il.Emit(OpCodes.Ldarg_0);
+                _il.Emit(OpCodes.Ldc_I4_0);
+                _il.Emit(OpCodes.Stfld, GetPendingExitField());
+                _exitTerminals[code]();
+            }
+
+            _il.MarkLabel(skip);
+        }
+    }
+
+    private void RegisterReturnTerminal() => _exitTerminals.TryAdd(ExitCodeReturn, () =>
+    {
+        // The generator completes. State -2 is re-asserted here because a yielding finally between the
+        // `return` and this point overwrote it with the finally's resume state.
+        _il.Emit(OpCodes.Ldarg_0);
+        _il.Emit(OpCodes.Ldc_I4, -2);
+        _il.Emit(OpCodes.Stfld, _builder.StateField);
+        EmitReturnValueTaskBool(false);
+    });
+
+    private void RegisterThrowTerminal() => _exitTerminals.TryAdd(ExitCodeThrow, () =>
+    {
+        // The routed exception has run every enclosing finally; propagate it now. The generator is
+        // completing (throwing), so mark it done first.
+        _il.Emit(OpCodes.Ldarg_0);
+        _il.Emit(OpCodes.Ldc_I4, -2);
+        _il.Emit(OpCodes.Stfld, _builder.StateField);
+        _il.Emit(OpCodes.Ldarg_0);
+        _il.Emit(OpCodes.Ldfld, GetPendingExceptionField());
+        _il.Emit(OpCodes.Call, _ctx!.Runtime!.CreateException);
+        _il.Emit(OpCodes.Throw);
+    });
+
+    // ---- Try/catch emission ---------------------------------------------------------------------
+
+    protected override void EmitTryCatch(Stmt.TryCatch t)
+    {
+        // Check if this try block contains any suspension points (yield or await)
+        bool hasSuspensionsInTry = ContainsSuspension(t.TryBlock);
+        bool hasSuspensionsInCatch = t.CatchBlock != null && ContainsSuspension(t.CatchBlock);
+        bool hasSuspensionsInFinally = t.FinallyBlock != null && ContainsSuspension(t.FinallyBlock);
+
+        if (hasSuspensionsInTry || hasSuspensionsInCatch || hasSuspensionsInFinally)
+        {
+            // Cannot use IL exception blocks when suspension points exist inside them
+            // because: (1) state switch can't jump into protected regions,
+            // (2) yield/return can't use 'ret' inside try blocks,
+            // (3) 'leave' from try/finally would trigger finally prematurely on yield.
+            // Use flag-based exception tracking instead.
+            EmitTryCatchWithSuspensions(t);
+        }
+        else
+        {
+            // No suspension points - safe to use IL exception blocks
+            EmitSimpleTryCatch(t);
+        }
+    }
+
+    private void EmitSimpleTryCatch(Stmt.TryCatch t)
+    {
+        // A real IL protected region is open: a routed `br`/`ret` out of it would be illegal, so
+        // exits emitted inside fall back to their per-path handling (see the exit overrides).
+        _protectedRegionDepth++;
+        _ctx!.ExceptionBlockDepth++;
+        _il.BeginExceptionBlock();
+
+        foreach (var stmt in t.TryBlock)
+            EmitStatement(stmt);
+
+        if (t.CatchBlock != null)
+        {
+            _il.BeginCatchBlock(typeof(Exception));
+
+            if (t.CatchParam != null)
+            {
+                var exLocal = _il.DeclareLocal(typeof(object));
+                _ctx!.Locals.RegisterLocal(t.CatchParam.Lexeme, exLocal);
+                _il.Emit(OpCodes.Call, _ctx.Runtime!.WrapException);
+                _il.Emit(OpCodes.Stloc, exLocal);
+            }
+            else
+            {
+                _il.Emit(OpCodes.Pop);
+            }
+
+            foreach (var stmt in t.CatchBlock)
+                EmitStatement(stmt);
+        }
+
+        if (t.FinallyBlock != null)
+        {
+            _il.BeginFinallyBlock();
+            foreach (var stmt in t.FinallyBlock)
+                EmitStatement(stmt);
+        }
+
+        _il.EndExceptionBlock();
+        _ctx!.ExceptionBlockDepth--;
+        _protectedRegionDepth--;
+    }
+
+    /// <summary>
+    /// Flag-based try/catch/finally for the case where a suspension (yield / yield* / await) lives
+    /// inside the protected region. Synchronous segments of the try body are wrapped in mini IL
+    /// try/catch blocks that capture any exception into a flag local; suspension points and non-local
+    /// exits are emitted at the top level (outside any protected region) so their resume labels are
+    /// reachable from the state-dispatch switch and their `ret`/`br` are legal.
+    /// </summary>
+    private void EmitTryCatchWithSuspensions(Stmt.TryCatch t)
+    {
+        var caughtExceptionLocal = _il.DeclareLocal(typeof(object));
+        var afterTryBodyLabel = _il.DefineLabel();
+        var afterTryCatchLabel = _il.DefineLabel();
+
+        // No exception captured yet.
+        _il.Emit(OpCodes.Ldnull);
+        _il.Emit(OpCodes.Stloc, caughtExceptionLocal);
+
+        // Two finally-running mechanisms share `afterTryBodyLabel` as the cleanup entry:
+        //   1. External `generator.return()`: a suspended yield observes `__returnRequested` on resume
+        //      and jumps here to run the finally (see EmitYield). `_returnCleanupLabel` carries the
+        //      label down to those yields and is only meaningful while emitting *this* try's body.
+        //   2. In-body non-local exits (#559): break/continue/return/throw register a FinallyScope and
+        //      route through it; on those paths the exception flag is null, so the catch is skipped and
+        //      the finally runs.
+        // Without a finally there is nothing to run, so neither is set up and exits go directly.
+        var previousCleanupLabel = _returnCleanupLabel;
+        FinallyScope? frame = null;
+        if (t.FinallyBlock != null)
+        {
+            _returnCleanupLabel = afterTryBodyLabel;
+            frame = new FinallyScope { CleanupLabel = afterTryBodyLabel };
+            _exitScopes.Add(frame);
+        }
+
+        // Throws in the try body are captured by their sync segments, not routed.
+        bool previousInHandler = _inHandlerBody;
+        _inHandlerBody = false;
+        EmitTryBodyWithSuspensions(t.TryBlock, caughtExceptionLocal, afterTryBodyLabel);
+        _inHandlerBody = previousInHandler;
+
+        // Restore the enclosing try's cleanup label (its yields must route to it, not ours).
+        _returnCleanupLabel = previousCleanupLabel;
+
+        _il.MarkLabel(afterTryBodyLabel);
+
+        // Catch: runs only when the try body captured an exception. The finally scope is still open, so
+        // a non-local exit (including a throw) from the catch body runs this finally too.
+        if (t.CatchBlock != null)
+        {
+            var skipCatchLabel = _il.DefineLabel();
+            _il.Emit(OpCodes.Ldloc, caughtExceptionLocal);
+            _il.Emit(OpCodes.Brfalse, skipCatchLabel);
+
+            // Store exception in catch param if needed
+            if (t.CatchParam != null)
+            {
+                var exLocal = _il.DeclareLocal(typeof(object));
+                _ctx!.Locals.RegisterLocal(t.CatchParam.Lexeme, exLocal);
+                _il.Emit(OpCodes.Ldloc, caughtExceptionLocal);
+                _il.Emit(OpCodes.Stloc, exLocal);
+            }
+
+            // Catch handles it; clear the flag so the post-finally rethrow below is skipped — and so a
+            // routed exit re-entering afterTryBody skips the catch rather than re-running it.
+            _il.Emit(OpCodes.Ldnull);
+            _il.Emit(OpCodes.Stloc, caughtExceptionLocal);
+
+            _inHandlerBody = true;
+            foreach (var stmt in t.CatchBlock)
+                EmitStatement(stmt);
+            _inHandlerBody = previousInHandler;
+
+            _il.MarkLabel(skipCatchLabel);
+        }
+
+        // The finally itself is outside its own scope: an exit within it runs the *enclosing* finallys.
+        if (frame != null)
+            _exitScopes.RemoveAt(_exitScopes.Count - 1);
+
+        // Finally: always runs — on normal completion, after a caught exception, or on a routed exit.
+        if (t.FinallyBlock != null)
+        {
+            _inHandlerBody = true;
+            foreach (var stmt in t.FinallyBlock)
+                EmitStatement(stmt);
+            _inHandlerBody = previousInHandler;
+
+            // External return() (mechanism 1): __returnRequested set → complete the generator now that
+            // the finally has run. Checked before the in-body dispatch because the two use different
+            // flags (__returnRequested vs <>pendingExit) and an external return never sets the latter.
+            var noReturnRequestedLabel = _il.DefineLabel();
+            _il.Emit(OpCodes.Ldarg_0);
+            _il.Emit(OpCodes.Ldfld, _builder.ReturnRequestedField);
+            _il.Emit(OpCodes.Brfalse, noReturnRequestedLabel);
+
+            _il.Emit(OpCodes.Ldarg_0);
+            _il.Emit(OpCodes.Ldc_I4, -2);
+            _il.Emit(OpCodes.Stfld, _builder.StateField);
+            EmitReturnValueTaskBool(false);
+
+            _il.MarkLabel(noReturnRequestedLabel);
+
+            // In-body non-local exit (mechanism 2): dispatch any pending exit that routed through here.
+            EmitFinallyDispatch(frame!);
+
+            // Rethrow an uncaught exception once the finally has run (try/finally with no catch).
+            if (t.CatchBlock == null)
+            {
+                var noExceptionLabel = _il.DefineLabel();
+                _il.Emit(OpCodes.Ldloc, caughtExceptionLocal);
+                _il.Emit(OpCodes.Brfalse, noExceptionLabel);
+
+                // Mark the generator done before the exception leaves MoveNextAsync.
+                _il.Emit(OpCodes.Ldarg_0);
+                _il.Emit(OpCodes.Ldc_I4, -2);
+                _il.Emit(OpCodes.Stfld, _builder.StateField);
+                _il.Emit(OpCodes.Ldloc, caughtExceptionLocal);
+                _il.Emit(OpCodes.Call, _ctx!.Runtime!.CreateException);
+                _il.Emit(OpCodes.Throw);
+
+                _il.MarkLabel(noExceptionLabel);
+            }
+        }
+
+        _il.MarkLabel(afterTryCatchLabel);
+    }
+
+    /// <summary>
+    /// Walks the try body, wrapping runs of plain statements in mini IL try/catch blocks while
+    /// emitting suspension points and non-local exits (return/break/continue) at the top level.
+    /// </summary>
+    private void EmitTryBodyWithSuspensions(List<Stmt> tryBody, LocalBuilder caughtExceptionLocal, Label afterTryLabel)
+    {
+        List<Stmt> syncSegment = [];
+
+        foreach (var stmt in tryBody)
+        {
+            if (IsSegmentBreaker(stmt))
+            {
+                // Flush the accumulated plain statements first.
+                if (syncSegment.Count > 0)
+                {
+                    EmitSyncSegmentInTry(syncSegment, caughtExceptionLocal);
+                    syncSegment.Clear();
+                }
+
+                // If an earlier segment threw, skip the suspension/exit and head to catch/finally.
+                _il.Emit(OpCodes.Ldloc, caughtExceptionLocal);
+                _il.Emit(OpCodes.Brtrue, afterTryLabel);
+
+                // Emitted at the top level: a yield/await's `ret`/resume label and a return's `ret` or a
+                // break/continue's `br` are only legal outside a protected region.
+                EmitStatement(stmt);
+            }
+            else
+            {
+                syncSegment.Add(stmt);
+            }
+        }
+
+        if (syncSegment.Count > 0)
+            EmitSyncSegmentInTry(syncSegment, caughtExceptionLocal);
+    }
+
+    /// <summary>
+    /// Emits a run of plain (non-suspending, non-exiting) statements inside a real IL try/catch
+    /// that records any thrown exception into <paramref name="caughtExceptionLocal"/>.
+    /// </summary>
+    private void EmitSyncSegmentInTry(List<Stmt> statements, LocalBuilder caughtExceptionLocal)
+    {
+        // An earlier segment may already have thrown — don't run this one.
+        var skipLabel = _il.DefineLabel();
+        _il.Emit(OpCodes.Ldloc, caughtExceptionLocal);
+        _il.Emit(OpCodes.Brtrue, skipLabel);
+
+        // A real IL protected region is open across the segment body (see _protectedRegionDepth).
+        _protectedRegionDepth++;
+        _il.BeginExceptionBlock();
+        foreach (var stmt in statements)
+            EmitStatement(stmt);
+
+        _il.BeginCatchBlock(typeof(Exception));
+        _il.Emit(OpCodes.Call, _ctx!.Runtime!.WrapException);
+        _il.Emit(OpCodes.Stloc, caughtExceptionLocal);
+        _il.EndExceptionBlock();
+        _protectedRegionDepth--;
+
+        _il.MarkLabel(skipLabel);
+    }
+
+    #region Suspension / control-exit detection
+
+    /// <summary>
+    /// A statement must be emitted at the top level (rather than inside a mini try/catch segment)
+    /// if it contains a suspension point or a control-flow exit that leaves the try region. Both
+    /// would otherwise produce illegal IL inside the segment's protected region.
+    /// </summary>
+    private static bool IsSegmentBreaker(Stmt stmt) =>
+        ContainsSuspensionInStmt(stmt) || ContainsEscapingExit(stmt, insideLoop: false, insideSwitch: false);
+
+    private static bool ContainsSuspension(List<Stmt> statements)
+    {
+        foreach (var stmt in statements)
+        {
+            if (ContainsSuspensionInStmt(stmt))
+                return true;
+        }
+        return false;
+    }
+
+    private static bool ContainsSuspensionInStmt(Stmt stmt)
+    {
+        switch (stmt)
+        {
+            case Stmt.Expression e:
+                return ContainsSuspensionInExpr(e.Expr);
+            case Stmt.Var v:
+                return v.Initializer != null && ContainsSuspensionInExpr(v.Initializer);
+            case Stmt.Const c:
+                return ContainsSuspensionInExpr(c.Initializer);
+            case Stmt.Return r:
+                return r.Value != null && ContainsSuspensionInExpr(r.Value);
+            case Stmt.If i:
+                return ContainsSuspensionInExpr(i.Condition) ||
+                       ContainsSuspensionInStmt(i.ThenBranch) ||
+                       (i.ElseBranch != null && ContainsSuspensionInStmt(i.ElseBranch));
+            case Stmt.While w:
+                return ContainsSuspensionInExpr(w.Condition) || ContainsSuspensionInStmt(w.Body);
+            case Stmt.DoWhile dw:
+                return ContainsSuspensionInStmt(dw.Body) || ContainsSuspensionInExpr(dw.Condition);
+            case Stmt.For f:
+                return (f.Initializer != null && ContainsSuspensionInStmt(f.Initializer)) ||
+                       (f.Condition != null && ContainsSuspensionInExpr(f.Condition)) ||
+                       (f.Increment != null && ContainsSuspensionInExpr(f.Increment)) ||
+                       ContainsSuspensionInStmt(f.Body);
+            case Stmt.ForOf fo:
+                return ContainsSuspensionInExpr(fo.Iterable) || ContainsSuspensionInStmt(fo.Body);
+            case Stmt.ForIn fi:
+                return ContainsSuspensionInExpr(fi.Object) || ContainsSuspensionInStmt(fi.Body);
+            case Stmt.Block b:
+                return b.Statements != null && ContainsSuspension(b.Statements);
+            case Stmt.Sequence seq:
+                return ContainsSuspension(seq.Statements);
+            case Stmt.LabeledStatement ls:
+                return ContainsSuspensionInStmt(ls.Statement);
+            case Stmt.Switch s:
+                foreach (var c in s.Cases)
+                {
+                    if (ContainsSuspensionInExpr(c.Value) || ContainsSuspension(c.Body))
+                        return true;
+                }
+                return s.DefaultBody != null && ContainsSuspension(s.DefaultBody);
+            case Stmt.TryCatch t:
+                return ContainsSuspension(t.TryBlock) ||
+                       (t.CatchBlock != null && ContainsSuspension(t.CatchBlock)) ||
+                       (t.FinallyBlock != null && ContainsSuspension(t.FinallyBlock));
+            case Stmt.Throw th:
+                return ContainsSuspensionInExpr(th.Value);
+            case Stmt.Print p:
+                return ContainsSuspensionInExpr(p.Expr);
+            default:
+                return false;
+        }
+    }
+
+    private static bool ContainsSuspensionInExpr(Expr expr)
+    {
+        switch (expr)
+        {
+            case Expr.Yield:
+            case Expr.Await:
+                return true;
+            case Expr.Comma c:
+                return ContainsSuspensionInExpr(c.Left) || ContainsSuspensionInExpr(c.Right);
+            case Expr.Binary b:
+                return ContainsSuspensionInExpr(b.Left) || ContainsSuspensionInExpr(b.Right);
+            case Expr.Logical l:
+                return ContainsSuspensionInExpr(l.Left) || ContainsSuspensionInExpr(l.Right);
+            case Expr.Unary u:
+                return ContainsSuspensionInExpr(u.Right);
+            case Expr.Delete d:
+                return ContainsSuspensionInExpr(d.Operand);
+            case Expr.Grouping g:
+                return ContainsSuspensionInExpr(g.Expression);
+            case Expr.Call c:
+                if (ContainsSuspensionInExpr(c.Callee)) return true;
+                foreach (var arg in c.Arguments)
+                    if (ContainsSuspensionInExpr(arg)) return true;
+                return false;
+            case Expr.Assign a:
+                return ContainsSuspensionInExpr(a.Value);
+            case Expr.CompoundAssign ca:
+                return ContainsSuspensionInExpr(ca.Value);
+            case Expr.Ternary t:
+                return ContainsSuspensionInExpr(t.Condition) ||
+                       ContainsSuspensionInExpr(t.ThenBranch) ||
+                       ContainsSuspensionInExpr(t.ElseBranch);
+            case Expr.Get g:
+                return ContainsSuspensionInExpr(g.Object);
+            case Expr.Set s:
+                return ContainsSuspensionInExpr(s.Object) || ContainsSuspensionInExpr(s.Value);
+            case Expr.GetIndex gi:
+                return ContainsSuspensionInExpr(gi.Object) || ContainsSuspensionInExpr(gi.Index);
+            case Expr.SetIndex si:
+                return ContainsSuspensionInExpr(si.Object) || ContainsSuspensionInExpr(si.Index) || ContainsSuspensionInExpr(si.Value);
+            default:
+                return false;
+        }
+    }
+
+    /// <summary>
+    /// Detects return/break/continue that would transfer control out of the surrounding try
+    /// region. Over-approximates conservatively (labeled break/continue are always treated as
+    /// escaping): a false positive only costs a statement some mini-segment exception coverage,
+    /// whereas a false negative would emit a `br`/`ret` inside a protected region (illegal IL).
+    /// Nested function/arrow bodies are not traversed (their returns are their own).
+    /// </summary>
+    private static bool ContainsEscapingExit(Stmt stmt, bool insideLoop, bool insideSwitch)
+    {
+        switch (stmt)
+        {
+            case Stmt.Return:
+                return true;
+            case Stmt.Break b:
+                return b.Label != null || !(insideLoop || insideSwitch);
+            case Stmt.Continue c:
+                return c.Label != null || !insideLoop;
+            case Stmt.If i:
+                return ContainsEscapingExit(i.ThenBranch, insideLoop, insideSwitch)
+                    || (i.ElseBranch != null && ContainsEscapingExit(i.ElseBranch, insideLoop, insideSwitch));
+            case Stmt.Block b:
+                if (b.Statements == null) return false;
+                foreach (var s in b.Statements)
+                    if (ContainsEscapingExit(s, insideLoop, insideSwitch)) return true;
+                return false;
+            case Stmt.Sequence seq:
+                foreach (var s in seq.Statements)
+                    if (ContainsEscapingExit(s, insideLoop, insideSwitch)) return true;
+                return false;
+            case Stmt.While w:
+                return ContainsEscapingExit(w.Body, insideLoop: true, insideSwitch);
+            case Stmt.DoWhile dw:
+                return ContainsEscapingExit(dw.Body, insideLoop: true, insideSwitch);
+            case Stmt.For f:
+                return ContainsEscapingExit(f.Body, insideLoop: true, insideSwitch);
+            case Stmt.ForOf fo:
+                return ContainsEscapingExit(fo.Body, insideLoop: true, insideSwitch);
+            case Stmt.ForIn fi:
+                return ContainsEscapingExit(fi.Body, insideLoop: true, insideSwitch);
+            case Stmt.Switch s:
+                foreach (var c in s.Cases)
+                    foreach (var cs in c.Body)
+                        if (ContainsEscapingExit(cs, insideLoop, insideSwitch: true)) return true;
+                if (s.DefaultBody != null)
+                    foreach (var ds in s.DefaultBody)
+                        if (ContainsEscapingExit(ds, insideLoop, insideSwitch: true)) return true;
+                return false;
+            case Stmt.LabeledStatement ls:
+                return ContainsEscapingExit(ls.Statement, insideLoop, insideSwitch);
+            case Stmt.TryCatch t:
+                if (ContainsEscapingExit2(t.TryBlock, insideLoop, insideSwitch)) return true;
+                if (t.CatchBlock != null && ContainsEscapingExit2(t.CatchBlock, insideLoop, insideSwitch)) return true;
+                if (t.FinallyBlock != null && ContainsEscapingExit2(t.FinallyBlock, insideLoop, insideSwitch)) return true;
+                return false;
+            default:
+                return false;
+        }
+    }
+
+    private static bool ContainsEscapingExit2(List<Stmt> statements, bool insideLoop, bool insideSwitch)
+    {
+        foreach (var s in statements)
+            if (ContainsEscapingExit(s, insideLoop, insideSwitch)) return true;
+        return false;
+    }
+
+    #endregion
+}

--- a/Compilation/AsyncGeneratorMoveNextEmitter.Statements.cs
+++ b/Compilation/AsyncGeneratorMoveNextEmitter.Statements.cs
@@ -13,21 +13,43 @@ public partial class AsyncGeneratorMoveNextEmitter
 
     protected override void EmitReturn(Stmt.Return r)
     {
-        // Async generator return - store return value in Current and set state to completed
-        // The return value will be available in the {value: returnValue, done: true} result
+        // Async generator return - store the return value in Current (read as the completion value),
+        // then complete the state machine — unless an enclosing flag-based try/finally must run first.
         if (r.Value != null)
         {
-            // Evaluate return value and store in CurrentField
-            _il.Emit(OpCodes.Ldarg_0);
+            // Evaluate fully before touching the frame: the value may itself contain a yield/await
+            // whose suspension `ret`s out, which is only legal with an empty evaluation stack (so the
+            // `this` for the Stfld is loaded only after the value is in a local).
             EmitExpression(r.Value);
             EnsureBoxed();
+            var returnValueTemp = _il.DeclareLocal(typeof(object));
+            _il.Emit(OpCodes.Stloc, returnValueTemp);
+            _il.Emit(OpCodes.Ldarg_0);
+            _il.Emit(OpCodes.Ldloc, returnValueTemp);
             _il.Emit(OpCodes.Stfld, _builder.CurrentField);
         }
 
-        // Set state to -2 (completed)
+        // Set state to -2 (completed). The direct path below returns immediately; a routed return
+        // re-asserts this at its terminal, since a yielding finally would overwrite it.
         _il.Emit(OpCodes.Ldarg_0);
         _il.Emit(OpCodes.Ldc_I4, -2);
         _il.Emit(OpCodes.Stfld, _builder.StateField);
+
+        // Inside a flag-based try/finally, the enclosing finally(s) must run before the generator
+        // actually completes. Route the return through them instead of returning directly (a `ret`
+        // here is also illegal — this return is emitted outside the protected segment, but a finally
+        // is emitted after it). See AsyncGeneratorMoveNextEmitter.Statements.TryCatch.cs.
+        if (_protectedRegionDepth == 0)
+        {
+            var chain = ActiveFinallyFrames();
+            if (chain.Count > 0)
+            {
+                RegisterReturnTerminal();
+                RouteThroughFinallys(chain, ExitCodeReturn);
+                return;
+            }
+        }
+
         EmitReturnValueTaskBool(false);
     }
 
@@ -260,11 +282,15 @@ public partial class AsyncGeneratorMoveNextEmitter
         ExitLoop();
     }
 
-    // EmitPrint, EmitDoWhile, EmitForIn, EmitThrow, EmitSwitch:
+    // EmitPrint, EmitDoWhile, EmitForIn, EmitSwitch:
     // inherited from StatementEmitterBase (identical logic; EmitForIn uses
     // DeclareLoopVariable/EmitStoreLoopVariable overrides for hoisted fields)
     // Note: base EmitSwitch also fixes a bug where labeled breaks inside switch
     // cases were incorrectly treated as switch breaks.
+    //
+    // EmitReturn (above), EmitBreak/EmitContinue/EmitThrow, the loop-scope methods, and the
+    // try/catch emission all live in AsyncGeneratorMoveNextEmitter.Statements.TryCatch.cs — they
+    // share the unified exit-scope stack that routes non-local exits through enclosing finallys (#559).
 
     protected override void EmitBranchToLabel(Label target)
     {
@@ -274,317 +300,4 @@ public partial class AsyncGeneratorMoveNextEmitter
         else
             _il.Emit(OpCodes.Br, target);
     }
-
-    protected override void EmitTryCatch(Stmt.TryCatch t)
-    {
-        // Check if this try block contains any suspension points (yield or await)
-        bool hasSuspensionsInTry = ContainsSuspension(t.TryBlock);
-        bool hasSuspensionsInCatch = t.CatchBlock != null && ContainsSuspension(t.CatchBlock);
-        bool hasSuspensionsInFinally = t.FinallyBlock != null && ContainsSuspension(t.FinallyBlock);
-
-        if (hasSuspensionsInTry || hasSuspensionsInCatch || hasSuspensionsInFinally)
-        {
-            // Cannot use IL exception blocks when suspension points exist inside them
-            // because: (1) state switch can't jump into protected regions,
-            // (2) yield/return can't use 'ret' inside try blocks,
-            // (3) 'leave' from try/finally would trigger finally prematurely on yield.
-            // Use flag-based exception tracking instead.
-            EmitTryCatchWithSuspensions(t);
-        }
-        else
-        {
-            // No suspension points - safe to use IL exception blocks
-            EmitSimpleTryCatch(t);
-        }
-    }
-
-    private void EmitSimpleTryCatch(Stmt.TryCatch t)
-    {
-        _ctx!.ExceptionBlockDepth++;
-        _il.BeginExceptionBlock();
-
-        foreach (var stmt in t.TryBlock)
-            EmitStatement(stmt);
-
-        if (t.CatchBlock != null)
-        {
-            _il.BeginCatchBlock(typeof(Exception));
-
-            if (t.CatchParam != null)
-            {
-                var exLocal = _il.DeclareLocal(typeof(object));
-                _ctx!.Locals.RegisterLocal(t.CatchParam.Lexeme, exLocal);
-                _il.Emit(OpCodes.Call, _ctx.Runtime!.WrapException);
-                _il.Emit(OpCodes.Stloc, exLocal);
-            }
-            else
-            {
-                _il.Emit(OpCodes.Pop);
-            }
-
-            foreach (var stmt in t.CatchBlock)
-                EmitStatement(stmt);
-        }
-
-        if (t.FinallyBlock != null)
-        {
-            _il.BeginFinallyBlock();
-            foreach (var stmt in t.FinallyBlock)
-                EmitStatement(stmt);
-        }
-
-        _il.EndExceptionBlock();
-        _ctx!.ExceptionBlockDepth--;
-    }
-
-    private void EmitTryCatchWithSuspensions(Stmt.TryCatch t)
-    {
-        // Flag-based exception tracking: instead of IL exception blocks,
-        // wrap synchronous segments in mini try/catch blocks and track
-        // exceptions via a local variable.
-        var caughtExceptionLocal = _il.DeclareLocal(typeof(object));
-        var afterTryBodyLabel = _il.DefineLabel();
-        var afterTryCatchLabel = _il.DefineLabel();
-
-        // Initialize caught exception to null
-        _il.Emit(OpCodes.Ldnull);
-        _il.Emit(OpCodes.Stloc, caughtExceptionLocal);
-
-        // Set the return cleanup label so yields inside this try block
-        // can jump to afterTryBody when __returnRequested is set
-        var previousCleanupLabel = _returnCleanupLabel;
-        if (t.FinallyBlock != null)
-        {
-            _returnCleanupLabel = afterTryBodyLabel;
-        }
-
-        // Emit try body with segmented exception handling
-        EmitTryBodyWithSuspensions(t.TryBlock, caughtExceptionLocal, afterTryBodyLabel);
-
-        // Restore previous cleanup label
-        _returnCleanupLabel = previousCleanupLabel;
-
-        _il.MarkLabel(afterTryBodyLabel);
-
-        // Handle catch block
-        if (t.CatchBlock != null)
-        {
-            var skipCatchLabel = _il.DefineLabel();
-            _il.Emit(OpCodes.Ldloc, caughtExceptionLocal);
-            _il.Emit(OpCodes.Brfalse, skipCatchLabel);
-
-            // Store exception in catch param if needed
-            if (t.CatchParam != null)
-            {
-                var exLocal = _il.DeclareLocal(typeof(object));
-                _ctx!.Locals.RegisterLocal(t.CatchParam.Lexeme, exLocal);
-                _il.Emit(OpCodes.Ldloc, caughtExceptionLocal);
-                _il.Emit(OpCodes.Stloc, exLocal);
-            }
-
-            // Clear the exception since catch handles it
-            _il.Emit(OpCodes.Ldnull);
-            _il.Emit(OpCodes.Stloc, caughtExceptionLocal);
-
-            // Emit catch block statements
-            foreach (var stmt in t.CatchBlock)
-                EmitStatement(stmt);
-
-            _il.MarkLabel(skipCatchLabel);
-        }
-
-        // Handle finally block - always runs
-        if (t.FinallyBlock != null)
-        {
-            foreach (var stmt in t.FinallyBlock)
-                EmitStatement(stmt);
-
-            // After finally, if __returnRequested, complete the generator
-            var noReturnRequestedLabel = _il.DefineLabel();
-            _il.Emit(OpCodes.Ldarg_0);
-            _il.Emit(OpCodes.Ldfld, _builder.ReturnRequestedField);
-            _il.Emit(OpCodes.Brfalse, noReturnRequestedLabel);
-
-            // Return requested and finally has run - complete the generator
-            _il.Emit(OpCodes.Ldarg_0);
-            _il.Emit(OpCodes.Ldc_I4, -2);
-            _il.Emit(OpCodes.Stfld, _builder.StateField);
-            EmitReturnValueTaskBool(false);
-
-            _il.MarkLabel(noReturnRequestedLabel);
-
-            // After finally, rethrow if exception was not handled by catch
-            if (t.CatchBlock == null)
-            {
-                var noExceptionLabel = _il.DefineLabel();
-                _il.Emit(OpCodes.Ldloc, caughtExceptionLocal);
-                _il.Emit(OpCodes.Brfalse, noExceptionLabel);
-
-                // Rethrow the pending exception
-                _il.Emit(OpCodes.Ldloc, caughtExceptionLocal);
-                _il.Emit(OpCodes.Call, _ctx!.Runtime!.CreateException);
-                _il.Emit(OpCodes.Throw);
-
-                _il.MarkLabel(noExceptionLabel);
-            }
-        }
-
-        _il.MarkLabel(afterTryCatchLabel);
-    }
-
-    private void EmitTryBodyWithSuspensions(List<Stmt> tryBody, LocalBuilder caughtExceptionLocal, Label afterTryLabel)
-    {
-        // Walk through try body statements. Synchronous segments (no yield/await)
-        // are wrapped in mini try/catch blocks. Suspension-containing statements
-        // are emitted normally (outside any IL exception block) so the state switch
-        // can reach their resume labels.
-        List<Stmt> syncSegment = [];
-
-        foreach (var stmt in tryBody)
-        {
-            if (ContainsSuspensionInStmt(stmt))
-            {
-                // Emit accumulated sync statements in mini try/catch
-                if (syncSegment.Count > 0)
-                {
-                    EmitSyncSegmentInTry(syncSegment, caughtExceptionLocal);
-                    syncSegment.Clear();
-                }
-
-                // Check exception before continuing with suspension
-                _il.Emit(OpCodes.Ldloc, caughtExceptionLocal);
-                _il.Emit(OpCodes.Brtrue, afterTryLabel);
-
-                // Emit the suspension-containing statement normally
-                EmitStatement(stmt);
-            }
-            else
-            {
-                syncSegment.Add(stmt);
-            }
-        }
-
-        // Emit remaining sync statements
-        if (syncSegment.Count > 0)
-        {
-            EmitSyncSegmentInTry(syncSegment, caughtExceptionLocal);
-        }
-    }
-
-    private void EmitSyncSegmentInTry(List<Stmt> statements, LocalBuilder caughtExceptionLocal)
-    {
-        // Skip if exception already caught
-        var skipLabel = _il.DefineLabel();
-        _il.Emit(OpCodes.Ldloc, caughtExceptionLocal);
-        _il.Emit(OpCodes.Brtrue, skipLabel);
-
-        // Wrap sync statements in a mini try/catch
-        _il.BeginExceptionBlock();
-        foreach (var stmt in statements)
-            EmitStatement(stmt);
-
-        _il.BeginCatchBlock(typeof(Exception));
-        _il.Emit(OpCodes.Call, _ctx!.Runtime!.WrapException);
-        _il.Emit(OpCodes.Stloc, caughtExceptionLocal);
-
-        _il.EndExceptionBlock();
-
-        _il.MarkLabel(skipLabel);
-    }
-
-    #region Suspension Detection
-
-    private static bool ContainsSuspension(List<Stmt> statements)
-    {
-        foreach (var stmt in statements)
-        {
-            if (ContainsSuspensionInStmt(stmt))
-                return true;
-        }
-        return false;
-    }
-
-    private static bool ContainsSuspensionInStmt(Stmt stmt)
-    {
-        switch (stmt)
-        {
-            case Stmt.Expression e:
-                return ContainsSuspensionInExpr(e.Expr);
-            case Stmt.Var v:
-                return v.Initializer != null && ContainsSuspensionInExpr(v.Initializer);
-            case Stmt.Const c:
-                return ContainsSuspensionInExpr(c.Initializer);
-            case Stmt.Return r:
-                return r.Value != null && ContainsSuspensionInExpr(r.Value);
-            case Stmt.If i:
-                return ContainsSuspensionInExpr(i.Condition) ||
-                       ContainsSuspensionInStmt(i.ThenBranch) ||
-                       (i.ElseBranch != null && ContainsSuspensionInStmt(i.ElseBranch));
-            case Stmt.While w:
-                return ContainsSuspensionInExpr(w.Condition) || ContainsSuspensionInStmt(w.Body);
-            case Stmt.DoWhile dw:
-                return ContainsSuspensionInStmt(dw.Body) || ContainsSuspensionInExpr(dw.Condition);
-            case Stmt.For f:
-                return (f.Initializer != null && ContainsSuspensionInStmt(f.Initializer)) ||
-                       (f.Condition != null && ContainsSuspensionInExpr(f.Condition)) ||
-                       (f.Increment != null && ContainsSuspensionInExpr(f.Increment)) ||
-                       ContainsSuspensionInStmt(f.Body);
-            case Stmt.ForOf fo:
-                return ContainsSuspensionInExpr(fo.Iterable) || ContainsSuspensionInStmt(fo.Body);
-            case Stmt.ForIn fi:
-                return ContainsSuspensionInExpr(fi.Object) || ContainsSuspensionInStmt(fi.Body);
-            case Stmt.Block b:
-                return b.Statements != null && ContainsSuspension(b.Statements);
-            case Stmt.Sequence seq:
-                return ContainsSuspension(seq.Statements);
-            case Stmt.TryCatch t:
-                return ContainsSuspension(t.TryBlock) ||
-                       (t.CatchBlock != null && ContainsSuspension(t.CatchBlock)) ||
-                       (t.FinallyBlock != null && ContainsSuspension(t.FinallyBlock));
-            default:
-                return false;
-        }
-    }
-
-    private static bool ContainsSuspensionInExpr(Expr expr)
-    {
-        switch (expr)
-        {
-            case Expr.Yield:
-            case Expr.Await:
-                return true;
-            case Expr.Comma c:
-                return ContainsSuspensionInExpr(c.Left) || ContainsSuspensionInExpr(c.Right);
-            case Expr.Binary b:
-                return ContainsSuspensionInExpr(b.Left) || ContainsSuspensionInExpr(b.Right);
-            case Expr.Logical l:
-                return ContainsSuspensionInExpr(l.Left) || ContainsSuspensionInExpr(l.Right);
-            case Expr.Unary u:
-                return ContainsSuspensionInExpr(u.Right);
-            case Expr.Delete d:
-                return ContainsSuspensionInExpr(d.Operand);
-            case Expr.Grouping g:
-                return ContainsSuspensionInExpr(g.Expression);
-            case Expr.Call c:
-                if (ContainsSuspensionInExpr(c.Callee)) return true;
-                foreach (var arg in c.Arguments)
-                    if (ContainsSuspensionInExpr(arg)) return true;
-                return false;
-            case Expr.Assign a:
-                return ContainsSuspensionInExpr(a.Value);
-            case Expr.Ternary t:
-                return ContainsSuspensionInExpr(t.Condition) ||
-                       ContainsSuspensionInExpr(t.ThenBranch) ||
-                       ContainsSuspensionInExpr(t.ElseBranch);
-            case Expr.Get g:
-                return ContainsSuspensionInExpr(g.Object);
-            case Expr.Set s:
-                return ContainsSuspensionInExpr(s.Object) || ContainsSuspensionInExpr(s.Value);
-            default:
-                return false;
-        }
-    }
-
-    #endregion
-
 }

--- a/SharpTS.Tests/Compilation/EmitterSyncTests.cs
+++ b/SharpTS.Tests/Compilation/EmitterSyncTests.cs
@@ -129,6 +129,14 @@ public class EmitterSyncTests
             "EmitAwait",            // Core: suspend/resume state machine
             "EmitArrowFunction",    // Display class in async generator context
             "EmitSuper",            // This field indirection
+            // --- #559: non-local exits must run an enclosing flag-based finally first (async #500) ---
+            "EmitBreak",            // Route a break leaving a try through its finally(s)
+            "EmitContinue",         // Route a continue leaving a try through its finally(s)
+            "EmitThrow",            // Route a throw in a catch/finally body through the finally(s)
+            "EnterLoop",            // Loops share the unified _exitScopes stack with finally scopes
+            "ExitLoop",             // (so break/continue can find the finallys between them and the loop)
+            "get_CurrentLoop",      // Loop lookups read _exitScopes instead of the base loop stack
+            "FindLabeledLoop",      // Labeled loop lookups read _exitScopes
         },
     };
 

--- a/SharpTS.Tests/SharedTests/AsyncGeneratorTryFinallyTests.cs
+++ b/SharpTS.Tests/SharedTests/AsyncGeneratorTryFinallyTests.cs
@@ -1,0 +1,408 @@
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests;
+
+/// <summary>
+/// Regression tests for #559: a compiled <em>async</em> generator with a <c>yield</c>/<c>await</c>
+/// inside <c>try</c>/<c>catch</c>/<c>finally</c> previously mishandled non-local exits that cross the
+/// protected region. <c>break</c>/<c>continue</c> leaving the try emitted invalid IL
+/// (<c>InvalidProgramException</c> in <c>MoveNextAsync</c>), and <c>return</c> / a <c>throw</c> from a
+/// catch skipped the enclosing <c>finally</c>. This is the async analog of #500 (plain generator); the
+/// fix ports the same unified exit-scope + pending-action dispatch into
+/// <c>AsyncGeneratorMoveNextEmitter</c> so every non-local exit runs the enclosing <c>finally</c>(s)
+/// before transferring control. See <c>AsyncGeneratorMoveNextEmitter.Statements.TryCatch.cs</c>.
+///
+/// <para>
+/// COMPILED-ONLY. The interpreter eagerly drains an async generator's body: its internal side effects
+/// (a finally's <c>console.log</c>, a catch's logging) run before the consumer's <c>for await…of</c>
+/// body observes the yielded values, and a throwing async generator drops the consumer's processing of
+/// already-yielded values entirely. That ordering / value-delivery divergence is pre-existing and
+/// independent of try/finally control flow — it affects any async generator with observable internal
+/// effects — and is tracked separately (#564 ordering, #566 manual next() rejection). These tests
+/// therefore assert the compiled path,
+/// where #559 lives and where output matches Node. The IL-verification cases at the bottom — emitted
+/// IL must verify — are the heart of the fix.
+/// </para>
+/// </summary>
+public class AsyncGeneratorTryFinallyTests
+{
+    [Theory]
+    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    public void BreakOutOfTryFinally_RunsFinallyBeforeBreaking(ExecutionMode mode)
+    {
+        // The exact #559 repro: break leaving the try must run the finally first (was invalid IL).
+        var source = """
+            async function* g() {
+              while (true) {
+                try { yield 1; break; } finally { console.log("FIN"); }
+              }
+            }
+            async function main() { for await (const v of g()) console.log("v" + v); }
+            main();
+            """;
+
+        Assert.Equal("v1\nFIN\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    public void ContinueOutOfTryFinally_RunsFinallyThatIteration(ExecutionMode mode)
+    {
+        // `continue` from inside the try must run the finally before the next iteration, and the code
+        // after the continue must be skipped on that iteration only (was invalid IL).
+        var source = """
+            async function* g() {
+              for (let i = 0; i < 3; i++) {
+                try {
+                  yield i;
+                  if (i === 1) continue;
+                  console.log("after" + i);
+                } finally {
+                  console.log("fin" + i);
+                }
+              }
+            }
+            async function main() { for await (const v of g()) console.log("got" + v); }
+            main();
+            """;
+
+        Assert.Equal("got0\nafter0\nfin0\ngot1\nfin1\ngot2\nafter2\nfin2\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    public void ThrowFromCatch_RunsFinallyThenPropagates(ExecutionMode mode)
+    {
+        // The exact #559 repro: a throw inside the catch must still run the finally before the
+        // exception propagates out of the generator to the consumer (finally was skipped).
+        var source = """
+            async function* g() {
+              try { yield 1; throw "a"; } catch (e) { throw "b"; } finally { console.log("FIN"); }
+            }
+            async function main() {
+              try { for await (const v of g()) console.log("v" + v); } catch (e) { console.log("outer " + e); }
+            }
+            main();
+            """;
+
+        Assert.Equal("v1\nFIN\nouter b\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    public void ReturnFromCatch_RunsFinallyBeforeCompleting(ExecutionMode mode)
+    {
+        // A `return` from the catch body must run the finally; the yield after the try must not run.
+        var source = """
+            async function* g() {
+              try { yield 1; throw "x"; } catch (e) { return; } finally { console.log("FIN"); }
+              yield 99;
+            }
+            async function main() { for await (const v of g()) console.log("v" + v); }
+            main();
+            """;
+
+        Assert.Equal("v1\nFIN\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    public void ReturnInsideTryFinally_RunsFinallyBeforeCompleting(ExecutionMode mode)
+    {
+        // `return` inside the try must run the finally before the generator completes; the statement
+        // after the return must not execute (was invalid IL — the return's `ret` sat in a mini block).
+        var source = """
+            async function* g() {
+              try {
+                yield 1;
+                return;
+                yield 99;
+              } finally {
+                console.log("fin");
+              }
+            }
+            async function main() { for await (const v of g()) console.log("v" + v); }
+            main();
+            """;
+
+        Assert.Equal("v1\nfin\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    public void ReturnInsideNestedTryFinally_RunsAllEnclosingFinallys(ExecutionMode mode)
+    {
+        var source = """
+            async function* g() {
+              try {
+                try {
+                  yield 1;
+                  return;
+                } finally {
+                  console.log("inner");
+                }
+              } finally {
+                console.log("outer");
+              }
+              yield 99;
+            }
+            async function main() { for await (const v of g()) console.log("v" + v); }
+            main();
+            """;
+
+        Assert.Equal("v1\ninner\nouter\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    public void BreakThroughNestedFinallys_RunsInnerThenOuter(ExecutionMode mode)
+    {
+        // A break that leaves two enclosing trys runs both finallys, innermost first.
+        var source = """
+            async function* g() {
+              while (true) {
+                try {
+                  try { yield 1; break; } finally { console.log("inner"); }
+                } finally { console.log("outer"); }
+              }
+            }
+            async function main() { for await (const v of g()) console.log("v" + v); }
+            main();
+            """;
+
+        Assert.Equal("v1\ninner\nouter\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    public void LabeledBreakToOuterLoop_RunsInterveningFinally(ExecutionMode mode)
+    {
+        // A labeled break targeting the outer loop runs the finally of the inner loop's try.
+        var source = """
+            async function* g() {
+              outer: for (let i = 0; i < 3; i++) {
+                for (let j = 0; j < 3; j++) {
+                  try { yield i * 10 + j; if (j === 1) break outer; } finally { console.log("fin" + i + j); }
+                }
+              }
+            }
+            async function main() { for await (const v of g()) console.log("v" + v); }
+            main();
+            """;
+
+        Assert.Equal("v0\nfin00\nv1\nfin01\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    public void BreakToLoopBetweenTwoTrys_RunsOnlyInnerFinally(ExecutionMode mode)
+    {
+        // The break targets a loop that sits *between* two trys: only the finally inside that loop
+        // runs at the break; the outer finally runs once, later, when the generator completes.
+        var source = """
+            async function* g() {
+              try {
+                for (let i = 0; i < 3; i++) {
+                  try { yield i; if (i === 1) break; } finally { console.log("inner" + i); }
+                }
+                console.log("after-loop");
+              } finally { console.log("OUTER"); }
+            }
+            async function main() { for await (const v of g()) console.log("v" + v); }
+            main();
+            """;
+
+        Assert.Equal("v0\ninner0\nv1\ninner1\nafter-loop\nOUTER\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    public void BreakWithYieldingFinally_DrivesFinallyThenBreaks(ExecutionMode mode)
+    {
+        // The finally that runs on the break path itself yields; the break completes only after the
+        // finally's yields are driven, then control resumes after the loop.
+        var source = """
+            async function* g() {
+              while (true) {
+                try { yield 1; break; } finally { yield 2; }
+              }
+              yield 3;
+            }
+            async function main() { for await (const v of g()) console.log("v" + v); }
+            main();
+            """;
+
+        Assert.Equal("v1\nv2\nv3\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    public void ReturnInTry_WithYieldingFinally_CompletesAfterFinallyYields(ExecutionMode mode)
+    {
+        // The finally itself yields, suspending MoveNextAsync between the `return` and the completion.
+        // The pending-return state must survive that suspension (it lives in a field, not a local), so
+        // the generator completes after the finally rather than running `yield 99`.
+        var source = """
+            async function* g() {
+              try {
+                yield 1;
+                return;
+              } finally {
+                yield 2;
+              }
+              yield 99;
+            }
+            async function main() { for await (const v of g()) console.log("v" + v); }
+            main();
+            """;
+
+        Assert.Equal("v1\nv2\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    public void ThrowFromFinally_RunsEnclosingFinallyThenPropagates(ExecutionMode mode)
+    {
+        // A throw raised inside a finally body must still run the enclosing finally before it
+        // propagates to the consumer.
+        var source = """
+            async function* g() {
+              try {
+                try { yield 1; } finally { throw "boom"; }
+              } finally { console.log("OUTER"); }
+            }
+            async function main() {
+              try { for await (const v of g()) console.log("v" + v); } catch (e) { console.log("caught " + e); }
+            }
+            main();
+            """;
+
+        Assert.Equal("v1\nOUTER\ncaught boom\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    public void BreakOutOfInnerCatchlessTry_RunsOuterFinally(ExecutionMode mode)
+    {
+        // The break leaves an inner try/catch that has no finally, nested in an outer try-with-
+        // finally; the outer finally must still run on the way out.
+        var source = """
+            async function* g() {
+              while (true) {
+                try {
+                  try { yield 1; break; } catch (e) {}
+                } finally { console.log("OUTERFIN"); }
+              }
+            }
+            async function main() { for await (const v of g()) console.log("v" + v); }
+            main();
+            """;
+
+        Assert.Equal("v1\nOUTERFIN\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    public void YieldStarInTryFinally_DelegatesThenRunsFinally(ExecutionMode mode)
+    {
+        var source = """
+            async function* inner() { yield 2; yield 3; }
+            async function* g() {
+              try {
+                yield 1;
+                yield* inner();
+                yield 4;
+              } finally {
+                console.log("fin");
+              }
+            }
+            async function main() { for await (const v of g()) console.log("v" + v); }
+            main();
+            """;
+
+        Assert.Equal("v1\nv2\nv3\nv4\nfin\n", TestHarness.Run(source, mode));
+    }
+
+    // ---- await inside the protected region (async-generator-specific) ----
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    public void AwaitThenReturnInTryFinally_RunsFinally(ExecutionMode mode)
+    {
+        // An await suspension precedes the return inside the try; the finally must still run.
+        var source = """
+            async function* g() {
+              try { await Promise.resolve(0); yield 1; return; } finally { console.log("FIN"); }
+            }
+            async function main() { for await (const v of g()) console.log("v" + v); }
+            main();
+            """;
+
+        Assert.Equal("v1\nFIN\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    public void AwaitThenBreakOutOfTryFinally_RunsFinally(ExecutionMode mode)
+    {
+        var source = """
+            async function* g() {
+              while (true) {
+                try { const x = await Promise.resolve(5); yield x; break; } finally { console.log("FIN"); }
+              }
+            }
+            async function main() { for await (const v of g()) console.log("v" + v); }
+            main();
+            """;
+
+        Assert.Equal("v5\nFIN\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    public void AwaitThenContinueOutOfTryFinally_RunsFinallyEachIteration(ExecutionMode mode)
+    {
+        var source = """
+            async function* g() {
+              for (let i = 0; i < 2; i++) {
+                try { await Promise.resolve(0); yield i; continue; } finally { console.log("fin" + i); }
+              }
+            }
+            async function main() { for await (const v of g()) console.log("v" + v); }
+            main();
+            """;
+
+        Assert.Equal("v0\nfin0\nv1\nfin1\n", TestHarness.Run(source, mode));
+    }
+
+    // ---- IL-verification guards (the heart of #559: emitted IL must verify) ----
+
+    [Theory]
+    [InlineData("async function* g() { try { yield 1; yield 2; } finally { console.log('f'); } } async function main(){ for await (const v of g()) {} } main();")]
+    [InlineData("async function* g() { try { yield 1; throw 'x'; } catch (e) { console.log(e); } } async function main(){ for await (const v of g()) {} } main();")]
+    [InlineData("async function* g() { try { yield 1; } catch (e) {} finally { console.log('f'); } yield 2; } async function main(){ for await (const v of g()) {} } main();")]
+    [InlineData("async function* g() { for (let i=0;i<2;i++){ try { yield i; } finally { console.log(i); } } } async function main(){ for await (const v of g()) {} } main();")]
+    [InlineData("async function* g() { try { try { yield 1; } finally { console.log('a'); } } finally { console.log('b'); } } async function main(){ for await (const v of g()) {} } main();")]
+    [InlineData("async function* g() { try { yield 1; return; } finally { console.log('f'); } } async function main(){ for await (const v of g()) {} } main();")]
+    [InlineData("async function* g() { try { yield 1; } finally { yield 2; } } async function main(){ for await (const v of g()) {} } main();")]
+    [InlineData("async function* g() { while (true) { try { yield 1; break; } finally { console.log('f'); } } } async function main(){ for await (const v of g()) {} } main();")]
+    [InlineData("async function* inner(){ yield 2; } async function* g() { try { yield 1; yield* inner(); } finally { console.log('f'); } } async function main(){ for await (const v of g()) {} } main();")]
+    // #559 control-flow shapes: continue, throw-from-catch, return-from-catch, nested-finally break,
+    // labeled break, break to a loop sitting between two trys, and a yielding finally on the break path.
+    [InlineData("async function* g() { for (let i=0;i<2;i++){ try { yield i; continue; } finally { console.log('f'); } } } async function main(){ for await (const v of g()) {} } main();")]
+    [InlineData("async function* g() { try { yield 1; throw 'a'; } catch (e) { throw 'b'; } finally { console.log('f'); } } async function main(){ try { for await (const v of g()) {} } catch (e) {} } main();")]
+    [InlineData("async function* g() { try { yield 1; throw 'a'; } catch (e) { return; } finally { console.log('f'); } } async function main(){ for await (const v of g()) {} } main();")]
+    [InlineData("async function* g() { while (true) { try { try { yield 1; break; } finally { console.log('a'); } } finally { console.log('b'); } } } async function main(){ for await (const v of g()) {} } main();")]
+    [InlineData("async function* g() { outer: for(let i=0;i<2;i++){ for(let j=0;j<2;j++){ try { yield j; break outer; } finally { console.log('f'); } } } } async function main(){ for await (const v of g()) {} } main();")]
+    [InlineData("async function* g() { try { for(let i=0;i<2;i++){ try { yield i; break; } finally { console.log('a'); } } } finally { console.log('b'); } } async function main(){ for await (const v of g()) {} } main();")]
+    [InlineData("async function* g() { while (true) { try { yield 1; break; } finally { yield 2; } } } async function main(){ for await (const v of g()) {} } main();")]
+    // await suspensions crossing the protected region alongside the non-local exits.
+    [InlineData("async function* g() { try { await Promise.resolve(0); yield 1; return; } finally { console.log('f'); } } async function main(){ for await (const v of g()) {} } main();")]
+    [InlineData("async function* g() { while (true) { try { await Promise.resolve(0); yield 1; break; } finally { console.log('f'); } } } async function main(){ for await (const v of g()) {} } main();")]
+    public void AsyncGeneratorTryFinallyWithSuspension_EmitsVerifiableIL(string source)
+    {
+        var errors = TestHarness.CompileAndVerifyOnly(source);
+        Assert.Empty(errors);
+    }
+}


### PR DESCRIPTION
## Summary

Closes #559 — the async-generator analog of #500.

A compiled **async** generator with a `yield`/`await` inside `try`/`catch`/`finally` mishandled non-local exits that cross the protected region:

| Case | Before | Node |
|------|--------|------|
| `break` out of try/finally | `InvalidProgramException` in `MoveNextAsync` | `v1`, `FIN` |
| `continue` out of try/finally | `InvalidProgramException` | finally each iteration |
| `return` in try/finally | `InvalidProgramException` | `v1`, `FIN` |
| `throw` from catch | finally skipped | `v1`, `FIN`, `outer b` |

(The issue listed break/continue/throw; `return` in a try with a yield was also invalid IL — same root cause.)

## Root cause

`AsyncGeneratorMoveNextEmitter` treated only `yield`/`await` as "segment breakers", so `return`/`break`/`continue` were bundled into the synchronous mini-`try`/`catch` segments where their `ret`/`br` is illegal IL. And it had no machinery to route an in-body exit through an enclosing flag-based `finally` — only the external `generator.return()` path (`__returnRequested`) ran a finally.

## Fix

Port #500's design into the async emitter (new `AsyncGeneratorMoveNextEmitter.Statements.TryCatch.cs`, mirroring the plain generator's `GeneratorMoveNextEmitter.Statements.TryCatch.cs`):

- A unified `_exitScopes` stack of loop/finally scopes (overriding `EnterLoop`/`ExitLoop`/`CurrentLoop`/`FindLabeledLoop`).
- Escaping exits (`return`/`break`/`continue`) become segment breakers, emitted at the top level.
- Each non-local exit sets a `<>pendingExit` field and branches through the enclosing `finally`(s); after each finally a per-code dispatch chains to the next outer finally or runs the terminal action (complete / rethrow `<>pendingException` / jump to a loop label). Fields survive a yielding/awaiting finally across a `MoveNextAsync` re-entry.

Only two things differ from the plain generator: terminals return `ValueTask<bool>` (via `EmitReturnValueTaskBool`), and the routing **composes with** the pre-existing external `generator.return()` mechanism (independent flags: `__returnRequested` is checked before the in-body dispatch).

## Tests

`AsyncGeneratorTryFinallyTests` — 17 behavioral cases (break/continue/return/throw, nested finallys, labeled break, break-to-loop-between-trys, yielding finally, throw-from-finally, inner-catchless break, `yield*`, and `await`-in-try variants) plus 18 IL-verification cases. **Compiled-only**: the interpreter eagerly drains an async generator's body, so internal `finally`/`catch` side effects interleave out of Node order — a pre-existing divergence independent of try/finally, filed as #564 (ordering) and #566 (throwing `next()` rejection). Full suite green (11,894 pass; the lone failure was the known live-DNS network flake, passes on retry).

## Filed along the way

- #564 — interpreter eagerly drains async-generator bodies (side effects out of order vs `for await…of`).
- #566 — manual `it.next()` on a throwing async generator propagates unhandled instead of rejecting (both modes).
- #569 — compiled async generator loses the `catch` parameter when read after a suspension in the catch body (async analog of the plain-gen `StoreCaughtExceptionToParam` fix).