### PR TITLE
Fix #471: interpreter member/index increment applies ToNumber, not a hard cast

### DIFF
--- a/Execution/Interpreter.Helpers.cs
+++ b/Execution/Interpreter.Helpers.cs
@@ -234,7 +234,10 @@ public partial class Interpreter
     /// <summary>Increments a variable l-value, returning the old or new value.</summary>
     private RuntimeValue IncrementVariable(Expr.Variable variable, double delta, bool returnOld)
     {
-        double current = _environment.Get(variable.Name).AsNumber();
+        // ECMA-262 13.4 (postfix)/13.5.7 (prefix): apply ToNumber to the operand's current
+        // value before adding ±1. A widened (`any`) variable can hold a non-number — a numeric
+        // string ("5"→5), undefined (→NaN), etc. — so coerce rather than asserting a boxed double.
+        double current = CoerceToNumber(_environment.Get(variable.Name));
         double newValue = current + delta;
         _environment.Assign(variable.Name, RuntimeValue.FromNumber(newValue));
         return RuntimeValue.FromNumber(returnOld ? current : newValue);
@@ -248,7 +251,10 @@ public partial class Interpreter
     {
         if (TryGetProperty(obj, name, out object? currentObj))
         {
-            double current = (double)currentObj!;
+            // ECMA-262 ToNumber on the member's current value (matches the variable path and
+            // compiled mode's ConvertToNumber): a non-numeric `any` member ("5"→5, undefined→NaN)
+            // follows JS semantics instead of throwing on a failed hard cast (#471).
+            double current = CoerceToNumber(currentObj);
             double newValue = current + delta;
             if (TrySetProperty(obj, name, newValue))
             {
@@ -267,7 +273,10 @@ public partial class Interpreter
     {
         if (TryGetIndex(obj, index, out object? currentObj))
         {
-            double current = (double)currentObj!;
+            // ECMA-262 ToNumber on the element's current value (see IncrementProperty): a
+            // non-numeric element in an `any[]` ("7"→7, undefined→NaN) follows JS semantics
+            // instead of throwing on a failed hard cast (#471).
+            double current = CoerceToNumber(currentObj);
             double newValue = current + delta;
             if (TrySetIndex(obj, index, newValue))
             {

--- a/SharpTS.Tests/SharedTests/MemberIncrementCoercionTests.cs
+++ b/SharpTS.Tests/SharedTests/MemberIncrementCoercionTests.cs
@@ -1,0 +1,95 @@
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests;
+
+/// <summary>
+/// Regression tests for #471: a prefix/postfix <c>++</c>/<c>--</c> on a member (<c>o.x</c>) or
+/// index (<c>arr[i]</c>) l-value whose current value is not already a number applies ECMA-262
+/// ToNumber — numeric strings parse (<c>"5"</c>→5), <c>undefined</c> becomes NaN — matching the
+/// variable path and compiled mode. The interpreter previously hard-cast the boxed value to
+/// <c>double</c>, throwing <c>InvalidCastException</c> on any non-number member/element (reachable
+/// when the static type is <c>any</c> or otherwise widened to carry a non-number).
+///
+/// Runs against both modes: compiled mode already coerced via <c>ConvertToNumber</c>, so each test
+/// doubles as an interpreter↔compiler parity check.
+/// </summary>
+public class MemberIncrementCoercionTests
+{
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void PostfixIncrement_NumericStringMember_ReturnsOldNumber_StoresIncremented(ExecutionMode mode)
+    {
+        // o.x = "5": (o.x++) is ToNumber("5") === 5; o.x becomes 6.
+        var source = """
+            const o: any = { x: "5" };
+            const old = o.x++;
+            console.log(old + "|" + o.x);
+            """;
+        Assert.Equal("5|6\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void PostfixIncrement_UndefinedMember_IsNaN(ExecutionMode mode)
+    {
+        // ToNumber(undefined) is NaN; NaN + 1 is NaN (no longer throws).
+        var source = """
+            const o: any = { x: undefined };
+            o.x++;
+            console.log(o.x);
+            """;
+        Assert.Equal("NaN\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void PrefixIncrement_NumericStringMember_ReturnsNewNumber(ExecutionMode mode)
+    {
+        var source = """
+            const o: any = { x: "5" };
+            const r = ++o.x;
+            console.log(r + "|" + o.x);
+            """;
+        Assert.Equal("6|6\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void PostfixDecrement_NumericStringMember_Coerces(ExecutionMode mode)
+    {
+        var source = """
+            const o: any = { x: "5" };
+            o.x--;
+            console.log(o.x);
+            """;
+        Assert.Equal("4\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void PostfixIncrement_NumericStringElement_Coerces(ExecutionMode mode)
+    {
+        // arr[i]++ has the identical divergence as o.x++.
+        var source = """
+            const a: any[] = ["7"];
+            const old = a[0]++;
+            console.log(old + "|" + a[0]);
+            """;
+        Assert.Equal("7|8\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void PostfixIncrement_NumericStringVariable_Coerces(ExecutionMode mode)
+    {
+        // The variable l-value path shared the same latent gap (it asserted a boxed double via
+        // RuntimeValue.AsNumber); #471 routes all three l-value kinds through ToNumber.
+        var source = """
+            let v: any = "3";
+            const old = v++;
+            console.log(old + "|" + v);
+            """;
+        Assert.Equal("3|4\n", TestHarness.Run(source, mode));
+    }
+}


### PR DESCRIPTION
Closes #471.

## Problem

In interpreter mode, `++`/`--` on a **member** (`o.x`) or **index** (`arr[i]`) l-value whose current value was not already a boxed `double` threw `InvalidCastException` instead of applying ECMA-262 ToNumber — diverging from compiled mode (which uses `ConvertToNumber`).

```ts
const o: any = { x: "5" };
o.x++;                 // interp: InvalidCastException;  compiled/Node: o.x === 6
```

## Fix

`IncrementProperty` / `IncrementIndex` now coerce the current value through the interpreter's existing `CoerceToNumber` (ECMA-262 ToNumber: `"5"`→5, `undefined`→NaN, etc.) instead of a hard `(double)` cast. `IncrementVariable` shared the identical latent gap — it asserted a boxed double via `RuntimeValue.AsNumber()`, which throws on a non-number `any` variable — so all three l-value kinds now coerce consistently. The async increment path uses the same shared helpers, so it is fixed too.

## Tests

`MemberIncrementCoercionTests` — postfix/prefix, increment/decrement, member/index/variable, numeric-string (`"5"`→6, returns old=5) and `undefined`→NaN. All cross-mode (compiled was already correct, so they double as parity checks). Full suite green (11931).