### PR TITLE
Fix #524: interpreter JSON.stringify unwraps boxed primitive wrappers

### DIFF
--- a/Runtime/BuiltIns/JSONBuiltIns.cs
+++ b/Runtime/BuiltIns/JSONBuiltIns.cs
@@ -209,6 +209,12 @@ public static class JSONBuiltIns
         var replacer = args.Length > 1 ? args[1].ToObject() : null;
         var space = args.Length > 2 ? args[2].ToObject() : null;
 
+        // ECMA-262 25.5.2.1 step 5: a boxed Number/String wrapper passed as `space`
+        // contributes its primitive value before the numeric/string indent rules below.
+        // (Compiled mode does the same — RuntimeEmitter.Json.StringifyFull.cs.)
+        if (TryUnwrapBoxedPrimitive(space, out var unwrappedSpace))
+            space = unwrappedSpace;
+
         // Handle space parameter: number = spaces, string = literal indent string
         string indentStr = "";
         switch (space)
@@ -262,6 +268,13 @@ public static class JSONBuiltIns
 
         // Check for toJSON() method before serializing
         value = CallToJsonIfExists(interp, value);
+
+        // ECMA-262 25.5.2.3 step 4: a boxed primitive wrapper (new Number/String/Boolean)
+        // serializes as its underlying primitive — not as an object exposing the internal
+        // __primitiveType/__primitiveValue marker slots. Applied after toJSON/replacer,
+        // before the type switch. (Compiled mode does the same — RuntimeEmitter.Json.Stringify.cs.)
+        if (TryUnwrapBoxedPrimitive(value, out var unwrappedPrimitive))
+            value = unwrappedPrimitive;
 
         switch (value)
         {
@@ -322,6 +335,32 @@ public static class JSONBuiltIns
                 return callable.Call(interp, []);
         }
         return value;
+    }
+
+    /// <summary>
+    /// ECMA-262 25.5.2.3 SerializeJSONProperty step 4: a boxed primitive wrapper —
+    /// <c>new Number()</c>/<c>new String()</c>/<c>new Boolean()</c>, modeled as a
+    /// <see cref="SharpTSObject"/> carrying <c>__primitiveType</c>/<c>__primitiveValue</c>
+    /// marker slots (see <see cref="BuiltInConstructorFactory"/>) — serializes as its
+    /// underlying primitive value, not as an object exposing those internal slots.
+    /// Returns <c>true</c> with the primitive in <paramref name="primitive"/> when
+    /// <paramref name="value"/> is such a wrapper. Gating on <c>__primitiveType</c> (which
+    /// only the boxed-primitive constructors set) keeps an ordinary user object that merely
+    /// happens to have a <c>__primitiveValue</c> field from being unwrapped — i.e. only the
+    /// objects with a genuine [[NumberData]]/[[StringData]]/[[BooleanData]] slot are unwrapped.
+    /// Compiled mode performs the equivalent unwrap (RuntimeEmitter.Json.Stringify*.cs).
+    /// </summary>
+    private static bool TryUnwrapBoxedPrimitive(object? value, out object? primitive)
+    {
+        if (value is SharpTSObject obj
+            && obj.GetProperty("__primitiveType") is string tag
+            && tag is "Number" or "String" or "Boolean")
+        {
+            primitive = obj.GetProperty("__primitiveValue");
+            return true;
+        }
+        primitive = null;
+        return false;
     }
 
     private static string FormatJsonNumber(double d)

--- a/SharpTS.Tests/SharedTests/JSONTests.cs
+++ b/SharpTS.Tests/SharedTests/JSONTests.cs
@@ -520,4 +520,83 @@ public class JSONTests
     }
 
     #endregion
+
+    #region JSON.stringify boxed primitive wrappers (#524)
+
+    // ECMA-262 25.5.2.3 step 4: a boxed primitive wrapper (new Number/String/Boolean) serializes
+    // as its underlying primitive, not as an object exposing the internal slots. The interpreter
+    // previously emitted the wrapper's __primitiveType/__primitiveValue marker fields; compiled
+    // mode was already correct, so these run in both modes as a parity check.
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void JSON_Stringify_BoxedPrimitives_TopLevel(ExecutionMode mode)
+    {
+        var source = """
+            console.log(JSON.stringify(new Number(5)));
+            console.log(JSON.stringify(new String("hi")));
+            console.log(JSON.stringify(new Boolean(true)));
+            """;
+        Assert.Equal("5\n\"hi\"\ntrue\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void JSON_Stringify_BoxedPrimitives_AsObjectProperties(ExecutionMode mode)
+    {
+        var source = """
+            console.log(JSON.stringify({ a: new Number(5), b: new String("x"), c: new Boolean(false) }));
+            """;
+        Assert.Equal("{\"a\":5,\"b\":\"x\",\"c\":false}\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void JSON_Stringify_BoxedPrimitives_AsArrayElements(ExecutionMode mode)
+    {
+        var source = """
+            console.log(JSON.stringify([new Number(1), new String("y"), new Boolean(false)]));
+            """;
+        Assert.Equal("[1,\"y\",false]\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void JSON_Stringify_BoxedNumber_AsSpace_Indents(ExecutionMode mode)
+    {
+        // ECMA-262 25.5.2.1 step 5: a boxed Number `space` contributes its primitive value (2 → 2
+        // spaces). A float is floored to an integer count by the existing space handling.
+        var source = """
+            console.log(JSON.stringify([7], null, new Number(2)));
+            """;
+        Assert.Equal("[\n  7\n]\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void JSON_Stringify_BoxedString_AsSpace_Indents(ExecutionMode mode)
+    {
+        // A boxed String `space` contributes its primitive value as the literal indent string.
+        var source = """
+            console.log(JSON.stringify({ k: 1 }, null, new String("--")));
+            """;
+        Assert.Equal("{\n--\"k\": 1\n}\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void JSON_Stringify_PlainObjectWithPrimitiveValueField_NotUnwrapped(ExecutionMode mode)
+    {
+        // An ordinary object that merely has a __primitiveValue field (but no __primitiveType) is
+        // NOT a boxed wrapper and must serialize verbatim — the interpreter gates the unwrap on
+        // __primitiveType, matching the sibling NumberPrototypeMethodWrapper et al. (and the spec's
+        // [[NumberData]]/[[StringData]]/[[BooleanData]] internal-slot semantics). Compiled mode
+        // unwraps on __primitiveValue alone, so it diverges here (too loose) — tracked by #565.
+        var source = """
+            console.log(JSON.stringify({ __primitiveValue: 7 }));
+            """;
+        Assert.Equal("{\"__primitiveValue\":7}\n", TestHarness.Run(source, mode));
+    }
+
+    #endregion
 }


### PR DESCRIPTION
Closes #524.

## Problem

In interpreter mode, `JSON.stringify` serialized a boxed primitive wrapper (`new Number/String/Boolean`, #360) as an object exposing its internal `__primitiveType`/`__primitiveValue` marker slots, instead of unwrapping it to the underlying primitive (ECMA-262 25.5.2.3 step 4). Compiled mode was already correct.

```ts
JSON.stringify(new Number(5));      // interp: {"__primitiveType":"Number","__primitiveValue":5}  →  now: 5
JSON.stringify(new Boolean(true));  // →  true
JSON.stringify([7], null, new Number(2));  // boxed Number as space →  indents by 2
```

## Fix

A small `TryUnwrapBoxedPrimitive` helper, applied in two places:
- `StringifyValue` — value position, after toJSON/replacer, before the type switch (spec step 4).
- `StringifyJson` — the `space` argument (spec 25.5.2.1 step 5).

Gating on `__primitiveType` ∈ {Number, String, Boolean} (as the sibling `NumberPrototypeMethodWrapper` et al. already do) keeps an ordinary object that merely has a stray `__primitiveValue` field from being unwrapped — i.e. only objects with a genuine `[[NumberData]]`/`[[StringData]]`/`[[BooleanData]]` slot are unwrapped.

## Tests

`JSONTests` — boxed primitives top-level / as object properties / as array elements; boxed Number & String as `space`; and a guard that a plain `{__primitiveValue}` object is **not** unwrapped (interpreter-only — see #565). Cross-mode otherwise (compiled already correct). Full suite green (11931).

## Test262

Pre-fix, all 8 `JSON/stringify` boxed-primitive tests were `Fail`; this flips exactly `value-boolean-object` and `space-number-float` to `Pass`, matching their already-committed `Pass` baseline lines — so the interpreted baseline needs no edit (the harness is green). The other 6 stay `Fail` (they assert custom `valueOf`/`toString` dispatch on the wrapper, a separate gap filed as #574).

## Follow-ups filed
- #565 — compiled mode's unwrap check is too loose (unwraps a plain `{__primitiveValue}`).
- #574 — boxed wrappers don't dispatch a user `valueOf`/`toString` in ToNumber/ToString.