### PR TITLE
Fix #480: bare `return;` completes generators (and functions) with undefined

### DIFF
--- a/Execution/Interpreter.Async.cs
+++ b/Execution/Interpreter.Async.cs
@@ -479,9 +479,10 @@ public partial class Interpreter
 
     internal async ValueTask<ExecutionResult> ExecuteReturnAsyncVT(Stmt.Return returnStmt)
     {
-        object? returnValue = null;
-        if (returnStmt.Value != null) returnValue = (await EvaluateAsync(returnStmt.Value)).ToObject();
-        return ExecutionResult.Return(returnValue);
+        // Bare `return;` completes with `undefined`, not null — see VisitReturn (#480).
+        if (returnStmt.Value == null)
+            return ExecutionResult.Return(RuntimeValue.Undefined);
+        return ExecutionResult.Return((await EvaluateAsync(returnStmt.Value)).ToObject());
     }
 
     internal async ValueTask<ExecutionResult> ExecutePrintAsyncVT(Stmt.Print printStmt)

--- a/Execution/Interpreter.cs
+++ b/Execution/Interpreter.cs
@@ -2523,9 +2523,14 @@ public partial class Interpreter : IDisposable
 
     internal ExecutionResult VisitReturn(Stmt.Return returnStmt)
     {
-        object? returnValue = null;
-        if (returnStmt.Value != null) returnValue = Evaluate(returnStmt.Value);
-        return ExecutionResult.Return(returnValue);
+        // A bare `return;` completes with `undefined` — distinct from `return null;`. Emitting the
+        // undefined sentinel here (rather than C# null, which represents JS null) is what makes a
+        // generator's completion value and a plain function's return value `undefined` instead of
+        // conflating them with null (#480). `return <expr>` preserves whatever the expression
+        // evaluates to, so an explicit `return null;` still yields null.
+        if (returnStmt.Value == null)
+            return ExecutionResult.Return(RuntimeValue.Undefined);
+        return ExecutionResult.Return(Evaluate(returnStmt.Value));
     }
 
     internal ExecutionResult VisitPrint(Stmt.Print printStmt)

--- a/SharpTS.Tests/SharedTests/FunctionReturnValueTests.cs
+++ b/SharpTS.Tests/SharedTests/FunctionReturnValueTests.cs
@@ -1,0 +1,72 @@
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests;
+
+/// <summary>
+/// Return-value semantics for plain (non-generator) functions: a function that completes
+/// without an explicit <c>return &lt;expr&gt;</c> — a bare <c>return;</c> or falling off the end —
+/// has return value <c>undefined</c>, distinct from <c>return null;</c> (which is null).
+///
+/// The interpreter is spec-correct in both cases: a bare <c>return;</c> produces the
+/// <c>undefined</c> sentinel at its source (<c>VisitReturn</c>) rather than C# null — the #480
+/// root-cause fix (which also corrected the generator completion value). Compiled mode still
+/// yields <c>null</c> for these implicit-completion cases (tracked by #563), so those two
+/// assertions are interpreter-only; the explicit <c>return null;</c> case agrees across modes.
+/// </summary>
+public class FunctionReturnValueTests
+{
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void BareReturn_IsUndefined(ExecutionMode mode)
+    {
+        // Bare `return;` is equivalent to `return undefined` (compiled half: #563).
+        var source = """
+            function f() { return; }
+            console.log(typeof f());
+            console.log(f() === undefined);
+            console.log(f() === null);
+            """;
+        Assert.Equal("undefined\ntrue\nfalse\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void OffEndCompletion_IsUndefined(ExecutionMode mode)
+    {
+        // Falling off the end of the body completes with undefined (compiled half: #563).
+        var source = """
+            function f() {}
+            console.log(typeof f());
+            console.log(f() === undefined);
+            """;
+        Assert.Equal("undefined\ntrue\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ReturnNull_IsNull(ExecutionMode mode)
+    {
+        // `return null;` is distinct from a bare `return;`: the value is JS null, not undefined.
+        var source = """
+            function f() { return null; }
+            console.log(typeof f());
+            console.log(f() === null);
+            """;
+        Assert.Equal("object\ntrue\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void AsyncFunction_BareReturn_ResolvesUndefined(ExecutionMode mode)
+    {
+        // The async return path (ExecuteReturnAsyncVT) got the same fix as the sync VisitReturn:
+        // a bare `return;` resolves the promise with undefined, not null (compiled half: #563).
+        // Async generators are a separate path and remain tracked by #540.
+        var source = """
+            async function f() { return; }
+            f().then(v => console.log(typeof v + ":" + (v === undefined)));
+            """;
+        Assert.Equal("undefined:true\n", TestHarness.Run(source, mode));
+    }
+}

--- a/SharpTS.Tests/SharedTests/GeneratorUndefinedValueTests.cs
+++ b/SharpTS.Tests/SharedTests/GeneratorUndefinedValueTests.cs
@@ -132,13 +132,16 @@ public class GeneratorUndefinedValueTests
         Assert.Equal("got:RET\n", TestHarness.Run(source, mode));
     }
 
-    // ---- Direct `.next().value` completion value ----
-    // These assert spec-correct behavior in COMPILED mode. The interpreter still reports `null`
-    // here (a separate, pre-existing gap tracked by #480), so they are compiled-only for now.
+    // ---- Direct `.next().value` completion value (#480) ----
+    // A generator that completes without an explicit `return <expr>` has completion value
+    // `undefined` (ECMA-262 27.5.1.x): both falling off the end and a bare `return;`. Both modes
+    // are now spec-correct — the interpreter previously reported `null` for the bare-`return;` case
+    // (#480), fixed by making a bare `return;` produce the `undefined` sentinel at its source
+    // (VisitReturn) rather than C# null, while preserving `return null;` as null (see below).
 
     [Theory]
-    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
-    public void OffEndCompletionValue_IsUndefined_Compiled(ExecutionMode mode)
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void OffEndCompletionValue_IsUndefined(ExecutionMode mode)
     {
         var source = """
             function* g() { yield 1; }
@@ -150,8 +153,8 @@ public class GeneratorUndefinedValueTests
     }
 
     [Theory]
-    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
-    public void BareReturnCompletionValue_IsUndefined_Compiled(ExecutionMode mode)
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void BareReturnCompletionValue_IsUndefined(ExecutionMode mode)
     {
         var source = """
             function* g() { yield 1; return; }
@@ -160,6 +163,21 @@ public class GeneratorUndefinedValueTests
             console.log("b:" + it.next().value);
             """;
         Assert.Equal("a:1\nb:undefined\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ReturnNullCompletionValue_IsNull(ExecutionMode mode)
+    {
+        // `return null;` is distinct from a bare `return;`: the completion value is JS null, not
+        // undefined. Guards against the #480 fix conflating "no return value" with "returned null".
+        var source = """
+            function* g() { yield 1; return null; }
+            const it = g();
+            console.log("a:" + it.next().value);
+            console.log("b:" + it.next().value);
+            """;
+        Assert.Equal("a:1\nb:null\n", TestHarness.Run(source, mode));
     }
 
     // ---- #499: `next()` on an already-completed generator yields undefined ----


### PR DESCRIPTION
Closes #480.

## Problem

A bare `return;` produced C# `null` (JS null) instead of the `undefined` sentinel, so an interpreter generator that completed via a value-less `return;` reported `{ value: null, done: true }` instead of `{ value: undefined, done: true }`:

```ts
function* g() { yield 1; return; }
const it = g();
it.next().value;   // 1
it.next().value;   // interp: null  →  now: undefined
```

The same root cause also made a **plain/async function**'s bare `return;` yield null rather than undefined (`function f(){ return; }; f() === undefined` was false).

Critically, the value-less `return;` is indistinguishable from `return null;` by the time it reaches the generator's completion handler (both are C# null there), so the fix must be at the source.

## Fix

`VisitReturn` / `ExecuteReturnAsyncVT` now emit the `undefined` sentinel for a value-less `return;`, while `return <expr>` is preserved verbatim — so `return null;` still yields null. The off-the-end and next-after-completion completion values were already correct in the interpreter.

## Tests

- `GeneratorUndefinedValueTests` — the two previously **compiled-only** completion-value tests (off-end, bare `return;`) are promoted to cross-mode; added a `return null;` → null guard.
- `FunctionReturnValueTests` (new) — bare `return;` / off-end → undefined, `return null;` → null, async-function bare `return;` → undefined. The implicit-completion cases are interpreter-only because compiled mode still returns null for them (filed #563).

Full suite green (11931).

## Scope / follow-ups
- #563 — compiled mode: a plain function completing without an explicit return value yields null instead of undefined (the compiled half).
- #540 — async **generators** (`SharpTSAsyncGenerator`) have the same bare-`return;`/off-end gap via their own `ExecuteStatementsAsync` handler; left to that issue to avoid overlapping its next-after-done replay work. Commented there with the exact root-cause lines.