### PR TITLE
Fix #527, #528: keyof over index-signature built-ins; structured Error type references

### DIFF
--- a/Runtime/BuiltIns/BuiltInTypes.cs
+++ b/Runtime/BuiltIns/BuiltInTypes.cs
@@ -1209,4 +1209,43 @@ public static class BuiltInTypes
         TypeInfo.Iterator or TypeInfo.Generator or TypeInfo.AsyncGenerator => IteratorMemberNames,
         _ => null
     };
+
+    // ============ KEYOF NAMES FOR INDEX-SIGNATURE BUILT-INS: string, Array, Tuple (#527) ============
+    //
+    // Unlike the dedicated records above, these built-ins ALSO carry a numeric index signature, which
+    // keyof must surface as a `number` key. GetInstanceMemberNames deliberately excludes them (they are
+    // resolved structurally through GetStringMemberType / GetArrayMemberType, not the apparent-members
+    // model); the lists below supply just their NAMED members so keyof can emit those alongside the
+    // `number` index key (the index-key emission lives in TypeChecker's ExtractKeys). Each list mirrors
+    // its GetXxxMemberType switch — BuiltInApparentMembersTests asserts every listed name resolves there.
+
+    private static readonly string[] StringMemberNames =
+    [
+        "length", "charAt", "substring", "indexOf", "toUpperCase", "toLowerCase", "trim", "replace",
+        "split", "includes", "startsWith", "endsWith", "slice", "substr", "repeat", "padStart",
+        "padEnd", "charCodeAt", "codePointAt", "concat", "lastIndexOf", "trimStart", "trimEnd",
+        "replaceAll", "at", "normalize", "localeCompare", "toString", "match", "matchAll", "search",
+    ];
+
+    private static readonly string[] ArrayMemberNames =
+    [
+        "length", "push", "pop", "shift", "unshift", "slice", "map", "filter", "forEach", "find",
+        "findIndex", "some", "every", "reduce", "reduceRight", "includes", "indexOf", "lastIndexOf",
+        "join", "concat", "reverse", "flat", "flatMap", "sort", "toSorted", "splice", "toSpliced",
+        "findLast", "findLastIndex", "toReversed", "with", "at", "fill", "copyWithin", "entries",
+        "keys", "values", "toString", "toLocaleString",
+    ];
+
+    /// <summary>
+    /// Named members of the <c>string</c> primitive (its String.prototype members), for <c>keyof string</c>.
+    /// Mirrors <see cref="GetStringMemberType"/>; keyof emits the numeric index key separately.
+    /// </summary>
+    public static IReadOnlyList<string> StringApparentMemberNames => StringMemberNames;
+
+    /// <summary>
+    /// Named members shared by arrays and tuples (Array.prototype members plus <c>length</c>), for
+    /// <c>keyof T[]</c> and <c>keyof [a, b]</c>. Mirrors <see cref="GetArrayMemberType"/>; keyof emits the
+    /// numeric index key (and, for tuples, the literal element indices) separately.
+    /// </summary>
+    public static IReadOnlyList<string> ArrayApparentMemberNames => ArrayMemberNames;
 }

--- a/SharpTS.Tests/SharedTests/ErrorTypeReferenceTests.cs
+++ b/SharpTS.Tests/SharedTests/ErrorTypeReferenceTests.cs
@@ -1,0 +1,154 @@
+using SharpTS.Tests.Infrastructure;
+using SharpTS.TypeSystem.Exceptions;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests;
+
+/// <summary>
+/// Built-in Error type references (<c>Error</c>, <c>TypeError</c>, <c>RangeError</c>, …) used as
+/// annotations resolve to their structured <c>TypeInfo.Error</c> instead of degrading to <c>any</c>
+/// (#528). This types member access (<c>e.message: string</c>) and makes the error types participate
+/// in assignability — matching the value <c>new Error("x")</c>, which already produced TypeInfo.Error.
+/// Type resolution is type-check-time, so both execution modes exercise the same logic.
+/// </summary>
+public class ErrorTypeReferenceTests
+{
+    // ----- member access is typed (the core fix) -----
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ErrorAnnotation_MessageIsString(ExecutionMode mode)
+    {
+        var source = """
+            const e: Error = new Error("boom");
+            const m: string = e.message;
+            console.log(m);
+            """;
+        Assert.Equal("boom\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ErrorAnnotation_MessageNotAssignableToNumber(ExecutionMode mode)
+    {
+        // Before #528 `e.message` was `any`, so this was wrongly accepted; now it is a TS2322.
+        var source = """
+            const e: Error = new Error("boom");
+            const n: number = e.message;
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void TypeErrorAnnotation_IsAlsoStructured(ExecutionMode mode)
+    {
+        // The fix covers every built-in error subtype, not just `Error`.
+        var source = """
+            const e: TypeError = new TypeError("boom");
+            const n: number = e.message;
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ErrorAnnotation_UnknownMemberRejected(ExecutionMode mode)
+    {
+        var source = """
+            const e: Error = new Error("boom");
+            const x = e.notARealMember;
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.Run(source, mode));
+    }
+
+    // ----- assignability -----
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Error_AcceptsSpecificErrorSubtype(ExecutionMode mode)
+    {
+        // A specific error is assignable to the base Error target.
+        var source = """
+            const e: Error = new TypeError("boom");
+            console.log(e.message);
+            """;
+        Assert.Equal("boom\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void SiblingErrors_AreMutuallyAssignable(ExecutionMode mode)
+    {
+        // The built-in error subtypes add no members over Error (tsc models them as empty
+        // `interface TypeError extends Error {}`), so they are structurally identical and mutually
+        // assignable — assigning a TypeError to a RangeError-typed binding is accepted.
+        var source = """
+            const e: RangeError = new TypeError("boom");
+            console.log(e.message);
+            """;
+        Assert.Equal("boom\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Error_AssignableToMatchingStructuralShape(ExecutionMode mode)
+    {
+        // A built-in error structurally satisfies an object type spelling out its members.
+        var source = """
+            const o: { message: string; name: string } = new Error("boom");
+            console.log(o.message);
+            """;
+        Assert.Equal("boom\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void UserSubclassOfError_AssignableToError(ExecutionMode mode)
+    {
+        // `class X extends Error` is a nominal subtype of Error.
+        var source = """
+            class HttpError extends Error {
+                status = 500;
+            }
+            const e: Error = new HttpError("boom");
+            console.log(e.message);
+            """;
+        Assert.Equal("boom\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AggregateError_HasErrorsProperty(ExecutionMode mode)
+    {
+        var source = """
+            const ag: AggregateError = new AggregateError([new Error("a")], "agg");
+            console.log(ag.errors.length);
+            """;
+        Assert.Equal("1\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void PlainError_NotAssignableToAggregateError(ExecutionMode mode)
+    {
+        // AggregateError adds `errors`, which a plain Error lacks — so the reverse assignment fails.
+        var source = """
+            const ag: AggregateError = new Error("boom");
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ErrorParameter_TypesArgument(ExecutionMode mode)
+    {
+        var source = """
+            function describe(err: Error): string {
+                return err.name + ": " + err.message;
+            }
+            console.log(describe(new RangeError("oops")));
+            """;
+        Assert.Equal("RangeError: oops\n", TestHarness.Run(source, mode));
+    }
+}

--- a/SharpTS.Tests/SharedTests/KeyOfIndexSignatureBuiltInTests.cs
+++ b/SharpTS.Tests/SharedTests/KeyOfIndexSignatureBuiltInTests.cs
@@ -1,0 +1,149 @@
+using SharpTS.Tests.Infrastructure;
+using SharpTS.TypeSystem.Exceptions;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests;
+
+/// <summary>
+/// keyof over the index-signature-bearing built-ins — <c>string</c>, arrays, and tuples (#527,
+/// follow-up to #512). Unlike the dedicated records (Date/Map/…), these carry a numeric index
+/// signature, so <c>keyof</c> yields <c>number</c> together with their prototype member names
+/// (and, for tuples, the literal element indices), matching <c>tsc</c>. Before #527 they produced
+/// <c>never</c>, so every key assignment was wrongly rejected. keyof is type-check-time, so both
+/// execution modes exercise the same logic; running both also confirms the value executes after.
+/// </summary>
+public class KeyOfIndexSignatureBuiltInTests
+{
+    // ----- keyof string -----
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void KeyOf_String_AcceptsPropertyName(ExecutionMode mode)
+    {
+        var source = """
+            const k: keyof string = "length";
+            console.log(k);
+            """;
+        Assert.Equal("length\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void KeyOf_String_AcceptsMethodName(ExecutionMode mode)
+    {
+        var source = """
+            const k: keyof string = "charAt";
+            console.log(k);
+            """;
+        Assert.Equal("charAt\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void KeyOf_String_AcceptsNumberIndex(ExecutionMode mode)
+    {
+        // string carries a numeric index signature, so `number` is a valid key.
+        var source = """
+            const k: keyof string = 5;
+            console.log(k);
+            """;
+        Assert.Equal("5\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void KeyOf_String_RejectsNonMember(ExecutionMode mode)
+    {
+        var source = """
+            const k: keyof string = "notAMember";
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.Run(source, mode));
+    }
+
+    // ----- keyof T[] -----
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void KeyOf_Array_AcceptsMethodName(ExecutionMode mode)
+    {
+        var source = """
+            const k: keyof number[] = "push";
+            console.log(k);
+            """;
+        Assert.Equal("push\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void KeyOf_Array_AcceptsLengthAndNumberIndex(ExecutionMode mode)
+    {
+        var source = """
+            const a: keyof string[] = "length";
+            const b: keyof string[] = 0;
+            console.log(a, b);
+            """;
+        Assert.Equal("length 0\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void KeyOf_Array_RejectsNonMember(ExecutionMode mode)
+    {
+        var source = """
+            const k: keyof number[] = "nope";
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.Run(source, mode));
+    }
+
+    // ----- keyof [tuple] -----
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void KeyOf_Tuple_AcceptsLiteralIndex(ExecutionMode mode)
+    {
+        // A tuple is an Array subtype: keyof includes the literal element indices "0" | "1".
+        var source = """
+            const k: keyof [string, number] = "1";
+            console.log(k);
+            """;
+        Assert.Equal("1\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void KeyOf_Tuple_AcceptsArrayMemberAndNumberIndex(ExecutionMode mode)
+    {
+        var source = """
+            const a: keyof [string, number] = "length";
+            const b: keyof [string, number] = 0;
+            console.log(a, b);
+            """;
+        Assert.Equal("length 0\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void KeyOf_Tuple_RejectsOutOfRangeLiteralIndex(ExecutionMode mode)
+    {
+        // [a, b] has indices "0" and "1" only; "2" is not a literal key (and "2" is a string, so the
+        // numeric index signature does not cover it either).
+        var source = """
+            const k: keyof [string, number] = "2";
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.Run(source, mode));
+    }
+
+    // ----- keyof feeding a mapped type over an index-signature built-in -----
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void MappedType_OverKeyOfArray_TypeChecks(ExecutionMode mode)
+    {
+        var source = """
+            type Flags = { [K in keyof number[]]: boolean };
+            const f = {} as Flags;
+            console.log(typeof f);
+            """;
+        Assert.Equal("object\n", TestHarness.Run(source, mode));
+    }
+}

--- a/SharpTS.Tests/TypeCheckerTests/BuiltInApparentMembersTests.cs
+++ b/SharpTS.Tests/TypeCheckerTests/BuiltInApparentMembersTests.cs
@@ -77,11 +77,37 @@ public class BuiltInApparentMembersTests
     [Fact]
     public void NonDecomposableTypesReturnNull()
     {
-        // Types without a dedicated apparent-members model are not decomposable here; keyof/assignability
-        // handle them through their own paths (records, interfaces, classes, string/array index sigs).
+        // string/Array are NOT part of the dedicated apparent-members projection (it models the
+        // index-signature-free records); keyof handles them through their own ExtractKeys cases, which
+        // read the StringApparentMemberNames / ArrayApparentMemberNames lists guarded below (#527).
         Assert.Null(BuiltInTypes.GetInstanceMemberNames(new TypeInfo.String()));
         Assert.Null(BuiltInTypes.GetInstanceMemberNames(new TypeInfo.Array(Any)));
         Assert.Null(BuiltInTypes.GetInstanceMemberNames(Any));
         Assert.Null(BuiltInTypes.GetInstanceMemberType(new TypeInfo.String(), "length"));
+    }
+
+    /// <summary>
+    /// The keyof member-name lists for the index-signature built-ins (#527) must stay in sync with their
+    /// GetXxxMemberType resolvers: every advertised name must resolve, or <c>keyof string</c> /
+    /// <c>keyof T[]</c> would surface a key whose <c>T[K]</c> cannot be resolved.
+    /// </summary>
+    [Fact]
+    public void StringApparentMemberNames_AllResolve()
+    {
+        Assert.NotEmpty(BuiltInTypes.StringApparentMemberNames);
+        foreach (var name in BuiltInTypes.StringApparentMemberNames)
+            Assert.True(
+                BuiltInTypes.GetStringMemberType(name) is not null,
+                $"keyof string advertises member '{name}' but GetStringMemberType could not resolve it.");
+    }
+
+    [Fact]
+    public void ArrayApparentMemberNames_AllResolve()
+    {
+        Assert.NotEmpty(BuiltInTypes.ArrayApparentMemberNames);
+        foreach (var name in BuiltInTypes.ArrayApparentMemberNames)
+            Assert.True(
+                BuiltInTypes.GetArrayMemberType(name, Any) is not null,
+                $"keyof T[] advertises member '{name}' but GetArrayMemberType could not resolve it.");
     }
 }

--- a/TypeSystem/TypeChecker.Compatibility.Helpers.cs
+++ b/TypeSystem/TypeChecker.Compatibility.Helpers.cs
@@ -764,6 +764,25 @@ public partial class TypeChecker
     private static string? GetClassName(TypeInfo? classType) =>
         ClassInfoAccessor.Get(classType, c => c.Name, gc => gc.Name);
 
+    /// <summary>
+    /// True when an instance's class hierarchy includes a built-in Error type (Error, TypeError, …),
+    /// i.e. it was declared <c>class X extends Error</c>. Lets such a user subclass satisfy an
+    /// Error-typed target as a nominal subtype, now that <c>Error</c> resolves to TypeInfo.Error rather
+    /// than <c>any</c> (#528). The <c>extends Error</c> placeholder superclass is a MutableClass whose
+    /// Name is the error type's leaf name, so read that directly (ClassInfoAccessor skips MutableClass).
+    /// </summary>
+    private static bool ExtendsBuiltInError(TypeInfo.Instance instance)
+    {
+        TypeInfo? current = instance.ResolvedClassType;
+        for (int guard = 0; current != null && guard < 64; guard++)
+        {
+            string? name = current is TypeInfo.MutableClass mc ? mc.Name : GetClassName(current);
+            if (name != null && BuiltInNames.IsErrorTypeName(name)) return true;
+            current = GetSuperclass(current);
+        }
+        return false;
+    }
+
     private static FrozenDictionary<string, TypeInfo>? GetStaticMethods(TypeInfo? classType) =>
         ClassInfoAccessor.Get(classType, c => c.StaticMethods, gc => gc.StaticMethods);
 

--- a/TypeSystem/TypeChecker.Compatibility.Structural.cs
+++ b/TypeSystem/TypeChecker.Compatibility.Structural.cs
@@ -166,6 +166,15 @@ public partial class TypeChecker
             return BuiltInTypes.GetArrayMemberType(name, ComputeTupleElementUnion(tuple));
         }
 
+        // Handle dedicated Error types (Error, TypeError, …) - name/message/stack/cause and toString.
+        // Mirrors the String/Array/Tuple handling so a built-in error can structurally satisfy an
+        // object type like `{ message: string }` (#528). keyof Error still needs the apparent-members
+        // projection (#530); this is the structural-source-member half only.
+        if (type is TypeInfo.Error errType)
+        {
+            return BuiltInTypes.GetErrorMemberType(name, errType.Name);
+        }
+
         // Handle TypeParameter with constraint - delegate to constraint
         if (type is TypeInfo.TypeParameter tp && tp.Constraint != null)
         {

--- a/TypeSystem/TypeChecker.Compatibility.cs
+++ b/TypeSystem/TypeChecker.Compatibility.cs
@@ -797,6 +797,20 @@ public partial class TypeChecker
         if (expected is TypeInfo.Date && actual is TypeInfo.Date) return true;
         if (expected is TypeInfo.RegExp && actual is TypeInfo.RegExp) return true;
 
+        // Error-family compatibility (reachable since Error/TypeError/… stopped resolving to `any`,
+        // #528). Every built-in error shares the same structural shape (name/message/stack/cause), so
+        // any error satisfies a non-aggregate error target — tsc treats the empty `interface TypeError
+        // extends Error {}` declarations as mutually assignable. AggregateError additionally carries
+        // `errors`, so only an AggregateError satisfies an AggregateError target. A user class that
+        // extends a built-in error (class MyError extends Error) is a nominal subtype of it.
+        if (expected is TypeInfo.Error expErr)
+        {
+            if (actual is TypeInfo.Error actErr)
+                return expErr.Name != "AggregateError" || actErr.Name == "AggregateError";
+            if (expErr.Name != "AggregateError" && actual is TypeInfo.Instance errInst && ExtendsBuiltInError(errInst))
+                return true;
+        }
+
         // Promise type compatibility - Promise<A> is compatible with Promise<B> if A is compatible with B
         if (expected is TypeInfo.Promise expPromise && actual is TypeInfo.Promise actPromise)
         {

--- a/TypeSystem/TypeChecker.Generics.MappedTypes.cs
+++ b/TypeSystem/TypeChecker.Generics.MappedTypes.cs
@@ -84,6 +84,37 @@ public partial class TypeChecker
                 keys.AddRange(ExtractKeys(inst.ClassType));
                 break;
 
+            // Index-signature built-ins (string, Array, Tuple). Unlike the dedicated records handled
+            // by the GetInstanceMemberNames fallback below, these carry a numeric index signature that
+            // keyof must surface as a `number` key, alongside their prototype member names (#527).
+            case TypeInfo.String:
+                // keyof string = number | "length" | "charAt" | … (the index signature plus members).
+                keys.Add(new TypeInfo.Primitive(Parsing.TokenType.TYPE_NUMBER));
+                foreach (var name in Runtime.BuiltIns.BuiltInTypes.StringApparentMemberNames)
+                    keys.Add(new TypeInfo.StringLiteral(name));
+                break;
+
+            case TypeInfo.Array:
+                // keyof T[] = number | "length" | "push" | … (element type is irrelevant to the keys).
+                keys.Add(new TypeInfo.Primitive(Parsing.TokenType.TYPE_NUMBER));
+                foreach (var name in Runtime.BuiltIns.BuiltInTypes.ArrayApparentMemberNames)
+                    keys.Add(new TypeInfo.StringLiteral(name));
+                break;
+
+            case TypeInfo.Tuple tup:
+                // A tuple is an Array subtype, so keyof yields the literal element indices ("0" | "1" | …)
+                // on top of the array members and the `number` index signature — the same composition the
+                // tsc idiom `Exclude<keyof T, keyof any[]>` relies on to isolate just those indices (#527).
+                for (int i = 0; i < tup.Elements.Count; i++)
+                {
+                    if (tup.Elements[i].IsSpread) break; // positions after a variadic spread aren't fixed
+                    keys.Add(new TypeInfo.StringLiteral(i.ToString(System.Globalization.CultureInfo.InvariantCulture)));
+                }
+                keys.Add(new TypeInfo.Primitive(Parsing.TokenType.TYPE_NUMBER));
+                foreach (var name in Runtime.BuiltIns.BuiltInTypes.ArrayApparentMemberNames)
+                    keys.Add(new TypeInfo.StringLiteral(name));
+                break;
+
             case TypeInfo.InstantiatedGeneric ig:
                 // Expand the instantiated generic and extract from that
                 var expanded = ExpandInstantiatedGenericForKeyOf(ig);

--- a/TypeSystem/TypeChecker.TypeParsing.cs
+++ b/TypeSystem/TypeChecker.TypeParsing.cs
@@ -349,6 +349,11 @@ public partial class TypeChecker
         if (typeName == "String") return new TypeInfo.String();
         if (typeName == "Number") return new TypeInfo.Primitive(TokenType.TYPE_NUMBER);
         if (typeName == "Boolean") return new TypeInfo.Primitive(TokenType.TYPE_BOOLEAN);
+        // Built-in Error type references (Error, TypeError, RangeError, …) resolve to their structured
+        // TypeInfo.Error — like Date/RegExp above — instead of degrading to `any`. This types member
+        // access (`e.message: string`, so `const n: number = e.message` is a TS2322 error) and aligns
+        // the annotation with the value `new Error("x")`, which already produces TypeInfo.Error (#528).
+        if (Runtime.BuiltIns.BuiltInNames.IsErrorTypeName(typeName)) return new TypeInfo.Error(typeName);
 
         // A mapped-type parameter in scope (e.g. P in `{ [P in K]: DeepReadonly<T[P]> }`)
         // parses to a TypeParameter so the body builds deferred forms (IndexedAccess,


### PR DESCRIPTION
Two follow-ups to #512, both about how the type checker handles built-in types.

## #527 — `keyof string` / `keyof T[]` / `keyof [a, b]` yielded `never`

The index-signature-bearing built-ins were left out of #512, so `keyof` over them produced `never` and every key assignment was wrongly rejected:

```ts
const a: keyof string = "length";   // was: error (keyof string = never)
const b: keyof number[] = "push";   // was: error
const t: keyof [string, number] = "1"; // was: error
```

`ExtractKeys` now has `String` / `Array` / `Tuple` cases that surface the **numeric index signature** as a `number` key plus the prototype member names — and, for tuples, the literal element indices `"0" | "1" | …` (the composition `tsc`'s `Exclude<keyof T, keyof any[]>` idiom relies on). The member-name lists live in `BuiltInTypes` (`StringApparentMemberNames` / `ArrayApparentMemberNames`) and are pinned to their `GetXxxMemberType` resolvers by a drift test, matching the #512 pattern. This stays **keyof-only** — `string`/`Array` remain out of the apparent-members projection (the boundary `BuiltInApparentMembersTests` documents).

## #528 — `Error` / `TypeError` / … type references resolved to `any`

An `Error`-typed annotation degraded to `any`, so member access wasn't typed:

```ts
const e: Error = new Error("x");
const n: number = e.message;   // was: accepted (e.message: any); now: TS2322
```

The error type names now resolve to the structured `TypeInfo.Error` in `ToTypeInfoCore`, like `Date`/`RegExp` — aligning the annotation with the value `new Error("x")`, which already produced `TypeInfo.Error`. Making `Error` structured (rather than `any`) newly requires three compatibility paths, all reachable only now:

- **`Error` ↔ `Error`** — every built-in error shares one structural shape (`name`/`message`/`stack`/`cause`), so any error satisfies a non-aggregate `Error` target (tsc treats the empty `interface TypeError extends Error {}` declarations as mutually assignable). `AggregateError` adds `errors`, so only it satisfies an `AggregateError` target.
- **`class X extends Error`** is a nominal subtype of `Error` (`ExtendsBuiltInError`).
- **`GetMemberType`** resolves `Error` members, so an error structurally satisfies `{ message: string }` etc.

Precise `keyof Error` (currently `never`) and object-literal → `Error` structural assignment stay deferred to **#530** (the apparent-members projection for `Error`/`Buffer`/…), exactly as #528 scopes it: *"Until this is fixed, `Error` can't participate in the #512 structural-decomposition mechanism."*

## Tests / verification

- New `KeyOfIndexSignatureBuiltInTests` (11) and `ErrorTypeReferenceTests` (12), both modes via `ExecutionModes.All`; drift guards added to `BuiltInApparentMembersTests`.
- Full unit suite green (the only 2 failures were live-DNS network flakes that pass on retry).
- TypeScript conformance subset: **31/31**, no baseline shift.
- Test262: **0 failed**, both baselines pass. (The host-process abort seen locally reproduces on unmodified `main` — pre-existing, unrelated.)

Closes #527
Closes #528