### PR TITLE
Fix labeled `continue` to an outer `for` loop (#558)

### DIFF
--- a/Compilation/CompilationContext.cs
+++ b/Compilation/CompilationContext.cs
@@ -170,6 +170,26 @@ public partial class CompilationContext
     // Loop control labels (with optional label name for labeled statements)
     public Stack<(Label BreakLabel, Label ContinueLabel, string? LabelName)> LoopLabels { get; } = new();
 
+    /// <summary>
+    /// Label name awaiting attachment to the next loop's own break/continue targets.
+    /// Set by <c>EmitLabeledStatement</c> when the labeled statement is a loop, and consumed
+    /// by that loop's <c>EnterLoop</c> (here or in an emitter override). This lets
+    /// <c>continue &lt;label&gt;</c> branch to the loop's real continue point — a for-loop's
+    /// increment, a while's condition — instead of a point ahead of the loop's initializer,
+    /// which would re-run it forever (#558).
+    /// </summary>
+    public string? PendingLoopLabel { get; set; }
+
+    /// <summary>
+    /// Returns the pending labeled-loop name and clears it, so it attaches to exactly one loop.
+    /// </summary>
+    public string? TakePendingLoopLabel()
+    {
+        var label = PendingLoopLabel;
+        PendingLoopLabel = null;
+        return label;
+    }
+
     // Hoisted array type caches: stack of per-loop dictionaries mapping
     // variable name → (typed local, descriptor) for arrays whose isinst
     // check has been hoisted to the loop preamble.
@@ -275,7 +295,9 @@ public partial class CompilationContext
 
     public void EnterLoop(Label breakLabel, Label continueLabel, string? labelName = null)
     {
-        LoopLabels.Push((breakLabel, continueLabel, labelName));
+        // An unlabeled EnterLoop call adopts any label parked by an enclosing labeled
+        // statement, so the loop's own continue/break targets carry the label (#558).
+        LoopLabels.Push((breakLabel, continueLabel, labelName ?? TakePendingLoopLabel()));
     }
 
     public void ExitLoop()

--- a/Compilation/GeneratorMoveNextEmitter.Statements.TryCatch.cs
+++ b/Compilation/GeneratorMoveNextEmitter.Statements.TryCatch.cs
@@ -89,7 +89,7 @@ public partial class GeneratorMoveNextEmitter
     // ---- Loop-scope methods (override the base stack to use `_exitScopes`) -----------------------
 
     protected override void EnterLoop(Label breakLabel, Label continueLabel, string? labelName = null)
-        => _exitScopes.Add(new LoopScope { BreakLabel = breakLabel, ContinueLabel = continueLabel, LabelName = labelName });
+        => _exitScopes.Add(new LoopScope { BreakLabel = breakLabel, ContinueLabel = continueLabel, LabelName = labelName ?? Ctx.TakePendingLoopLabel() });
 
     protected override void ExitLoop()
     {

--- a/Compilation/ILEmitter.Statements.cs
+++ b/Compilation/ILEmitter.Statements.cs
@@ -481,6 +481,11 @@ public partial class ILEmitter
 
     protected override void EmitForOf(Stmt.ForOf f)
     {
+        // A for-of emits several alternative runtime paths (iterator protocol, index-based, …),
+        // each registering its own loop scope. Capture any labeled-loop name once up front and
+        // hand it to every path, so `continue`/`break <label>` resolve no matter which path runs
+        // at runtime (#558 — consuming it in only the first-emitted path left the others bare).
+        var labelName = _ctx.TakePendingLoopLabel();
         _ctx.Locals.EnterScope();
         var builder = _ctx.ILBuilder;
 
@@ -506,7 +511,7 @@ public partial class ILEmitter
             var genStartLabel = builder.DefineLabel("forof_gen_start");
             var genEndLabel = builder.DefineLabel("forof_gen_end");
             var genContinueLabel = builder.DefineLabel("forof_gen_continue");
-            _ctx.EnterLoop(genEndLabel, genContinueLabel);
+            _ctx.EnterLoop(genEndLabel, genContinueLabel, labelName);
             EmitForOfEnumerator(f, genStartLabel, genEndLabel, genContinueLabel);
             return;
         }
@@ -517,7 +522,7 @@ public partial class ILEmitter
             var iterStartLabel = builder.DefineLabel("forof_iter_start");
             var iterEndLabel = builder.DefineLabel("forof_iter_end");
             var iterContinueLabel = builder.DefineLabel("forof_iter_continue");
-            _ctx.EnterLoop(iterEndLabel, iterContinueLabel);
+            _ctx.EnterLoop(iterEndLabel, iterContinueLabel, labelName);
             EmitForOfNormalizedEnumerator(f, iterStartLabel, iterEndLabel, iterContinueLabel);
             return;
         }
@@ -537,7 +542,7 @@ public partial class ILEmitter
         var arrayDesc = ArrayElements.Resolve(iterableType);
         if (arrayDesc != null && arrayDesc.Kind == ArrayElementsKind.Object)
         {
-            EmitForOfArrayDirect(f, iterableLocal, arrayDesc);
+            EmitForOfArrayDirect(f, iterableLocal, arrayDesc, labelName);
             _ctx.Locals.ExitScope();
             return;
         }
@@ -561,7 +566,7 @@ public partial class ILEmitter
             var iterStartLabel = builder.DefineLabel("forof_iter_start");
             var iterEndLabel = builder.DefineLabel("forof_iter_end");
             var iterContinueLabel = builder.DefineLabel("forof_iter_continue");
-            _ctx.EnterLoop(iterEndLabel, iterContinueLabel);
+            _ctx.EnterLoop(iterEndLabel, iterContinueLabel, labelName);
 
             // Call the iterator function to get the iterator object
             // Use InvokeMethodValue to properly bind 'this' to the iterable object
@@ -632,7 +637,7 @@ public partial class ILEmitter
             var startLabel = builder.DefineLabel("forof_idx_start");
             var endLabel = builder.DefineLabel("forof_idx_end");
             var continueLabel = builder.DefineLabel("forof_idx_continue");
-            _ctx.EnterLoop(endLabel, continueLabel);
+            _ctx.EnterLoop(endLabel, continueLabel, labelName);
 
             // Create index variable
             var indexLocal = IL.DeclareLocal(_ctx.Types.Int32);
@@ -690,7 +695,7 @@ public partial class ILEmitter
     /// for Object kind, or routed to a fallback iterator-helper for
     /// typed kinds.
     /// </summary>
-    private void EmitForOfArrayDirect(Stmt.ForOf f, LocalBuilder iterableLocal, ArrayElementsDescriptor desc)
+    private void EmitForOfArrayDirect(Stmt.ForOf f, LocalBuilder iterableLocal, ArrayElementsDescriptor desc, string? labelName = null)
     {
         var builder = _ctx.ILBuilder;
         var listType = desc.GetListType(_ctx.Types);
@@ -760,7 +765,7 @@ public partial class ILEmitter
         // Loop entry: listLocal holds the list.
         builder.MarkLabel(loopHeadLabel);
 
-        _ctx.EnterLoop(endLabel, continueLabel);
+        _ctx.EnterLoop(endLabel, continueLabel, labelName);
 
         // var i = 0
         var indexLocal = IL.DeclareLocal(_ctx.Types.Int32);
@@ -1278,30 +1283,43 @@ public partial class ILEmitter
     protected override void EmitLabeledStatement(Stmt.LabeledStatement labeledStmt)
     {
         string labelName = labeledStmt.Label.Lexeme;
+
+        if (IsLabelableLoop(labeledStmt.Statement))
+        {
+            // Direct loop: park the label so the inner loop attaches it to its OWN break/continue
+            // targets (a for-loop's increment, a while's condition, …). Marking a continue label
+            // here — ahead of the for initializer — would re-run the initializer forever (#558).
+            _ctx.PendingLoopLabel = labelName;
+            try
+            {
+                EmitStatement(labeledStmt.Statement);
+            }
+            finally
+            {
+                // The loop's EnterLoop consumes the label; clear it if somehow it didn't.
+                _ctx.PendingLoopLabel = null;
+            }
+            return;
+        }
+
+        // Non-loop labeled statement (a block, etc.) or a chained label (a: b: loop) whose inner
+        // labeled statement owns the loop. Mark the continue target before the statement: harmless
+        // for a block, and for a chained while/for-of/for-in/do-while it re-enters at the loop
+        // head. (A chained label on a `for` re-runs its initializer — a pre-existing limitation,
+        // not regressed here; single-label `for` continue is fixed above.)
         var builder = _ctx.ILBuilder;
         var breakLabel = builder.DefineLabel($"labeled_{labelName}_break");
         var continueLabel = builder.DefineLabel($"labeled_{labelName}_continue");
-
-        // For labeled statements, we need to handle both loops and non-loop statements.
-        // For loops, the inner loop will use its own labels for unlabeled break/continue,
-        // but labeled break/continue should use the labels registered here.
-
-        // Mark continue label at the start (for labeled continue, restart from here)
         builder.MarkLabel(continueLabel);
-
         _ctx.EnterLoop(breakLabel, continueLabel, labelName);
         try
         {
-            // If this is directly a loop, the loop itself will handle its own unlabeled labels
-            // But for labeled break/continue, it will use the labeled entry we just pushed
             EmitStatement(labeledStmt.Statement);
         }
         finally
         {
             _ctx.ExitLoop();
         }
-
-        // Mark the break label (after the statement, for labeled break)
         builder.MarkLabel(breakLabel);
     }
 

--- a/Compilation/StatementEmitterBase.cs
+++ b/Compilation/StatementEmitterBase.cs
@@ -124,7 +124,7 @@ public abstract class StatementEmitterBase : ExpressionEmitterBase
     /// Default: pushes onto an internal stack. ILEmitter overrides to use CompilationContext.
     /// </summary>
     protected virtual void EnterLoop(Label breakLabel, Label continueLabel, string? labelName = null)
-        => _loopLabels.Push((breakLabel, continueLabel, labelName));
+        => _loopLabels.Push((breakLabel, continueLabel, labelName ?? Ctx.TakePendingLoopLabel()));
 
     /// <summary>
     /// Exits the current loop context.
@@ -631,21 +631,38 @@ public abstract class StatementEmitterBase : ExpressionEmitterBase
     /// </summary>
     protected virtual void EmitLabeledStatement(Stmt.LabeledStatement ls)
     {
+        if (IsLabelableLoop(ls.Statement))
+        {
+            // Direct loop: park the label so the loop attaches it to its OWN break/continue
+            // targets. A for registers continue at its increment, a while at its condition, etc.;
+            // marking a continue label here (ahead of the initializer) would re-run it (#558).
+            Ctx.PendingLoopLabel = ls.Label.Lexeme;
+            EmitStatement(ls.Statement);
+            // Defensive: the loop's EnterLoop consumes the label; clear it if somehow it didn't.
+            Ctx.PendingLoopLabel = null;
+            return;
+        }
+
+        // Non-loop labeled statement (a block, etc.) or a chained label (a: b: loop) whose inner
+        // labeled statement owns the loop. Mark the continue target before the statement: it is
+        // harmless for a block, and for a chained while/for-of/for-in/do-while it re-enters at the
+        // loop head. (A chained label on a `for` re-runs its initializer — a pre-existing
+        // limitation, not regressed here; single-label `for` continue is fixed above.)
         var breakLabel = IL.DefineLabel();
         var continueLabel = IL.DefineLabel();
-
-        // Mark continue label at the start
         IL.MarkLabel(continueLabel);
-
         EnterLoop(breakLabel, continueLabel, ls.Label.Lexeme);
-
         EmitStatement(ls.Statement);
-
         ExitLoop();
-
-        // Mark break label at the end
         IL.MarkLabel(breakLabel);
     }
+
+    /// <summary>
+    /// True when a labeled statement directly wraps an iteration statement, so the label
+    /// belongs on the loop's own break/continue targets rather than a wrapper.
+    /// </summary>
+    protected static bool IsLabelableLoop(Stmt stmt)
+        => stmt is Stmt.While or Stmt.DoWhile or Stmt.For or Stmt.ForOf or Stmt.ForIn;
 
     /// <summary>
     /// Emits a switch statement.

--- a/Execution/Interpreter.Statements.cs
+++ b/Execution/Interpreter.Statements.cs
@@ -293,51 +293,59 @@ public partial class Interpreter
     }
 
     /// <summary>
-    /// Executes a labeled statement, catching break/continue exceptions that target this label.
+    /// Executes a labeled statement, resolving break/continue that target this label.
     /// </summary>
     /// <param name="labeledStmt">The labeled statement AST node.</param>
     /// <remarks>
-    /// Labeled statements allow break and continue to target specific enclosing statements.
-    /// For loops, both break and continue are handled. For non-loop statements (blocks),
-    /// only break is valid. Labeled exceptions targeting this label are caught; others propagate.
+    /// When the label directly wraps an iteration statement, the label is handed to the loop so a
+    /// <c>continue &lt;label&gt;</c> runs the loop's own step (increment / re-test / advance) rather
+    /// than restarting it — restarting a <c>for</c> would re-run its initializer forever (#558).
+    /// Chained labels (<c>a: b: for …</c>) all attach to the same loop. For a non-loop labeled
+    /// statement (a block, etc.) only <c>break &lt;label&gt;</c> is meaningful.
     /// </remarks>
     private ExecutionResult ExecuteLabeledStatement(Stmt.LabeledStatement labeledStmt)
     {
-        string labelName = labeledStmt.Label.Lexeme;
-        bool isLoop = labeledStmt.Statement is Stmt.While
-                   or Stmt.DoWhile
-                   or Stmt.ForOf
-                   or Stmt.ForIn
-                   or Stmt.LabeledStatement; // Chained labels
+        // Flatten a chain of labels (a: b: stmt) down to the statement they wrap.
+        List<string> labels = [];
+        Stmt inner = labeledStmt;
+        while (inner is Stmt.LabeledStatement ls)
+        {
+            labels.Add(ls.Label.Lexeme);
+            inner = ls.Statement;
+        }
+
+        bool isLoop = inner is Stmt.While or Stmt.DoWhile or Stmt.For or Stmt.ForOf or Stmt.ForIn;
 
         if (isLoop)
         {
-            // For loops, labeled continue means restart the loop
-            while (true)
+            // Park the labels for the loop; it drains them at entry and handles a matching
+            // continue/break itself. Restore on the way out so an undrained label can't leak
+            // into a sibling loop (defensive — the loop normally consumes them all).
+            int baseCount = _pendingLoopLabels.Count;
+            _pendingLoopLabels.AddRange(labels);
+            ExecutionResult result;
+            try
             {
-                var result = Execute(labeledStmt.Statement);
-                if (result.Type == ExecutionResult.ResultType.Break && result.TargetLabel == labelName)
-                {
-                    return ExecutionResult.Success();
-                }
-                if (result.Type == ExecutionResult.ResultType.Continue && result.TargetLabel == labelName)
-                {
-                    continue;
-                }
-                if (result.IsAbrupt) return result;
-                return ExecutionResult.Success();
+                result = Execute(inner);
             }
-        }
-        else
-        {
-            // For non-loop statements, only handle break
-            var result = Execute(labeledStmt.Statement);
-            if (result.Type == ExecutionResult.ResultType.Break && result.TargetLabel == labelName)
+            finally
             {
-                return ExecutionResult.Success();
+                if (_pendingLoopLabels.Count > baseCount)
+                    _pendingLoopLabels.RemoveRange(baseCount, _pendingLoopLabels.Count - baseCount);
             }
+            // The loop absorbs continue/break for its labels; guard a matching break defensively.
+            if (result.Type == ExecutionResult.ResultType.Break &&
+                result.TargetLabel != null && labels.Contains(result.TargetLabel))
+                return ExecutionResult.Success();
             return result;
         }
+
+        // Non-loop labeled statement: only `break <label>` is meaningful.
+        var r = Execute(inner);
+        if (r.Type == ExecutionResult.ResultType.Break &&
+            r.TargetLabel != null && labels.Contains(r.TargetLabel))
+            return ExecutionResult.Success();
+        return r;
     }
 
     /// <summary>
@@ -687,13 +695,16 @@ public partial class Interpreter
     /// <seealso href="https://www.typescriptlang.org/docs/handbook/iterators-and-generators.html#forof-statements">TypeScript for...of</seealso>
     private ExecutionResult ExecuteForOf(Stmt.ForOf forOf)
     {
+        // Drain before evaluating the iterable so a labeled loop produced by the iterable
+        // expression (e.g. an IIFE) can't steal this loop's label.
+        var labels = TakePendingLoopLabels();
         object? iterable = Evaluate(forOf.Iterable);
 
         // First, check for Symbol.iterator protocol on objects/instances
         IEnumerable<object?>? customIterator = TryGetSymbolIterator(iterable);
         if (customIterator != null)
         {
-            return IterateWithBreakContinue(customIterator, forOf.Variable.Lexeme, forOf.Body);
+            return IterateWithBreakContinue(customIterator, forOf.Variable.Lexeme, forOf.Body, labels);
         }
 
         // Get elements based on iterable type
@@ -711,7 +722,7 @@ public partial class Interpreter
             _ => throw new InterpreterException("for...of requires an iterable (array, Map, Set, or iterator).")
         };
 
-        return IterateWithBreakContinue(elements, forOf.Variable.Lexeme, forOf.Body);
+        return IterateWithBreakContinue(elements, forOf.Variable.Lexeme, forOf.Body, labels);
     }
 
     /// <summary>
@@ -725,6 +736,7 @@ public partial class Interpreter
     /// <seealso href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...in">MDN for...in</seealso>
     private ExecutionResult ExecuteForIn(Stmt.ForIn forIn)
     {
+        var labels = TakePendingLoopLabels();
         object? obj = Evaluate(forIn.Object);
 
         IEnumerable<string> keys = obj switch
@@ -750,7 +762,7 @@ public partial class Interpreter
             _ => throw new InterpreterException("for...in requires an object.")
         };
 
-        return IterateWithBreakContinue(keys.Cast<object?>(), forIn.Variable.Lexeme, forIn.Body);
+        return IterateWithBreakContinue(keys.Cast<object?>(), forIn.Variable.Lexeme, forIn.Body, labels);
     }
 
     /// <summary>
@@ -933,7 +945,7 @@ public partial class Interpreter
     /// <summary>
     /// Iterates over elements with proper break/continue handling.
     /// </summary>
-    private ExecutionResult IterateWithBreakContinue(IEnumerable<object?> elements, string variableName, Stmt body)
+    private ExecutionResult IterateWithBreakContinue(IEnumerable<object?> elements, string variableName, Stmt body, IReadOnlyList<string>? labels = null)
     {
         foreach (var element in elements)
         {
@@ -943,7 +955,7 @@ public partial class Interpreter
             using (PushScope(loopEnv))
             {
                 var result = Execute(body);
-                var (shouldBreak, shouldContinue, abruptResult) = HandleLoopResult(result, null);
+                var (shouldBreak, shouldContinue, abruptResult) = HandleLoopResult(result, labels);
                 if (shouldBreak) return ExecutionResult.Success();
                 if (shouldContinue) continue;
                 if (abruptResult.HasValue) return abruptResult.Value;
@@ -961,12 +973,12 @@ public partial class Interpreter
     /// </summary>
     /// <param name="evaluateCondition">Function to evaluate the loop condition.</param>
     /// <param name="executeBody">Function to execute the loop body.</param>
-    /// <param name="label">Optional label for labeled break/continue support.</param>
+    /// <param name="labels">Labels wrapping this loop, for labeled break/continue support.</param>
     /// <returns>The execution result (Success or propagated abrupt completion).</returns>
     private ExecutionResult ExecuteWhileCore(
         Func<bool> evaluateCondition,
         Func<ExecutionResult> executeBody,
-        string? label = null)
+        IReadOnlyList<string>? labels = null)
     {
         while (evaluateCondition())
         {
@@ -976,7 +988,7 @@ public partial class Interpreter
                     new Runtime.Types.SharpTSError("Script execution timed out."));
 
             var result = executeBody();
-            var (shouldBreak, shouldContinue, abruptResult) = HandleLoopResult(result, label);
+            var (shouldBreak, shouldContinue, abruptResult) = HandleLoopResult(result, labels);
             if (shouldBreak) return ExecutionResult.Success();
             if (shouldContinue) continue;
             if (abruptResult.HasValue) return abruptResult.Value;
@@ -993,20 +1005,56 @@ public partial class Interpreter
     /// Processes ExecutionResult to determine break, continue, or propagation behavior.
     /// </summary>
     /// <param name="result">The execution result from the loop body.</param>
-    /// <param name="label">The label of the current loop (null for unlabeled loops).</param>
+    /// <param name="labels">
+    /// The labels that directly wrap this loop (empty/null for an unlabeled loop). A labeled
+    /// break/continue is handled here only when its target is one of these.
+    /// </param>
     /// <returns>A tuple indicating: (shouldBreak, shouldContinue, abruptResultToPropagate).</returns>
     private (bool shouldBreak, bool shouldContinue, ExecutionResult? abruptResult)
-        HandleLoopResult(ExecutionResult result, string? label)
+        HandleLoopResult(ExecutionResult result, IReadOnlyList<string>? labels)
     {
         if (result.Type == ExecutionResult.ResultType.Break &&
-            (result.TargetLabel == null || result.TargetLabel == label))
+            TargetsThisLoop(result.TargetLabel, labels))
             return (true, false, null);
         if (result.Type == ExecutionResult.ResultType.Continue &&
-            (result.TargetLabel == null || result.TargetLabel == label))
+            TargetsThisLoop(result.TargetLabel, labels))
             return (false, true, null);
         if (result.IsAbrupt)
             return (false, false, result);
         return (false, false, null);
+    }
+
+    /// <summary>
+    /// True when an unlabeled break/continue (targets the innermost loop) or a labeled one whose
+    /// target is among the labels wrapping this loop. A non-matching labeled target propagates.
+    /// </summary>
+    private static bool TargetsThisLoop(string? targetLabel, IReadOnlyList<string>? labels)
+    {
+        if (targetLabel == null) return true;
+        if (labels == null) return false;
+        for (int i = 0; i < labels.Count; i++)
+            if (labels[i] == targetLabel) return true;
+        return false;
+    }
+
+    /// <summary>
+    /// Labels parked by <see cref="ExecuteLabeledStatement"/> for the loop it directly wraps.
+    /// The loop drains these at entry via <see cref="TakePendingLoopLabels"/> and treats a
+    /// <c>continue</c>/<c>break</c> to any of them as targeting itself, running the loop's own
+    /// step (a for's increment, a while's re-test) instead of restarting it from scratch — which
+    /// for a <c>for</c> would re-run the initializer forever (#558).
+    /// </summary>
+    private readonly List<string> _pendingLoopLabels = new();
+
+    private static readonly string[] _noLoopLabels = [];
+
+    /// <summary>Returns the labels parked for the loop now being entered, and clears them.</summary>
+    private string[] TakePendingLoopLabels()
+    {
+        if (_pendingLoopLabels.Count == 0) return _noLoopLabels;
+        var labels = _pendingLoopLabels.ToArray();
+        _pendingLoopLabels.Clear();
+        return labels;
     }
 
     /// <summary>

--- a/Execution/Interpreter.cs
+++ b/Execution/Interpreter.cs
@@ -1982,17 +1982,22 @@ public partial class Interpreter : IDisposable
         return ExecutionResult.Success();
     }
 
-    internal ExecutionResult VisitWhile(Stmt.While whileStmt) =>
-        ExecuteWhileCore(
+    internal ExecutionResult VisitWhile(Stmt.While whileStmt)
+    {
+        var labels = TakePendingLoopLabels();
+        return ExecuteWhileCore(
             () => IsTruthy(Evaluate(whileStmt.Condition)),
-            () => Execute(whileStmt.Body));
+            () => Execute(whileStmt.Body),
+            labels);
+    }
 
     internal ExecutionResult VisitDoWhile(Stmt.DoWhile doWhileStmt)
     {
+        var labels = TakePendingLoopLabels();
         do
         {
             var result = Execute(doWhileStmt.Body);
-            var (shouldBreak, shouldContinue, abruptResult) = HandleLoopResult(result, null);
+            var (shouldBreak, shouldContinue, abruptResult) = HandleLoopResult(result, labels);
             if (shouldBreak) return ExecutionResult.Success();
             if (shouldContinue) continue;
             if (abruptResult.HasValue) return abruptResult.Value;
@@ -2004,6 +2009,9 @@ public partial class Interpreter : IDisposable
 
     internal ExecutionResult VisitFor(Stmt.For forStmt)
     {
+        // Drain labels parked by an enclosing labeled statement before running the initializer,
+        // so `continue <label>`/`break <label>` resolve to this loop (#558).
+        var labels = TakePendingLoopLabels();
         // Create scope for loop variables (ES6 let/const block scoping)
         // Variables declared with let/const in the initializer are scoped to the loop
         RuntimeEnvironment loopEnv = new(_environment);
@@ -2016,9 +2024,10 @@ public partial class Interpreter : IDisposable
             while (forStmt.Condition == null || IsTruthy(Evaluate(forStmt.Condition)))
             {
                 var result = Execute(forStmt.Body);
-                if (result.Type == ExecutionResult.ResultType.Break && result.TargetLabel == null) break;
-                // On continue, execute increment then continue the loop
-                if (result.Type == ExecutionResult.ResultType.Continue && result.TargetLabel == null)
+                var (shouldBreak, shouldContinue, abruptResult) = HandleLoopResult(result, labels);
+                if (shouldBreak) break;
+                // On continue (unlabeled or to this loop), execute increment then re-test
+                if (shouldContinue)
                 {
                     if (forStmt.Increment != null)
                         Evaluate(forStmt.Increment);
@@ -2026,7 +2035,7 @@ public partial class Interpreter : IDisposable
                     Thread.Sleep(0);
                     continue;
                 }
-                if (result.IsAbrupt) return result;
+                if (abruptResult.HasValue) return abruptResult.Value;
                 // Normal completion: execute increment
                 if (forStmt.Increment != null)
                     Evaluate(forStmt.Increment);

--- a/SharpTS.Tests/SharedTests/LabeledStatementTests.cs
+++ b/SharpTS.Tests/SharedTests/LabeledStatementTests.cs
@@ -184,6 +184,205 @@ public class LabeledStatementTests
 
     #endregion
 
+    #region Labeled `continue` to a for / iteration loop (issue #558)
+
+    // Before the fix, `continue <label>` targeting a labeled `for` branched ahead of the loop's
+    // initializer, re-running it forever (compiled hung; the interpreter treated `for` as a
+    // non-loop label and escaped). These pin the correct behavior: continue runs the loop's own
+    // step. Note the pre-existing suite only exercised labeled while/for-of/do-while continue.
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void LabeledFor_ContinueOuter_RunsIncrementNotInitializer(ExecutionMode mode)
+    {
+        // The exact #558 repro: continue to the outer `for` must advance i (not reset it).
+        var source = """
+            let result: string = "";
+            outer: for (let i = 0; i < 2; i++) {
+                for (let j = 0; j < 2; j++) {
+                    if (result !== "") { result = result + ","; }
+                    result = result + (i * 10 + j);
+                    if (j === 0) { continue outer; }
+                }
+            }
+            console.log(result);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("0,10\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void LabeledFor_ContinueSelf_SkipsIteration(ExecutionMode mode)
+    {
+        var source = """
+            let result: string = "";
+            lbl: for (let i = 0; i < 4; i++) {
+                if (i === 2) { continue lbl; }
+                result = result + i;
+            }
+            console.log(result);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("013\n", output);  // skips 2, but keeps advancing
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void LabeledFor_BreakOuter_ExitsBoth(ExecutionMode mode)
+    {
+        var source = """
+            let sum: number = 0;
+            outer: for (let i = 0; i < 3; i++) {
+                for (let j = 0; j < 3; j++) {
+                    if (i === 1 && j === 1) { break outer; }
+                    sum = sum + (i * 10 + j);
+                }
+            }
+            console.log(sum);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("13\n", output);  // 0+1+2 (i=0) + 10 (i=1,j=0), then break
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void LabeledForOf_ContinueOuter_SkipsRestOfInner(ExecutionMode mode)
+    {
+        var source = """
+            let result: string = "";
+            outer: for (const x of [1, 2, 3]) {
+                for (const y of [10, 20]) {
+                    result = result + (x + y) + ";";
+                    if (y === 10) { continue outer; }
+                }
+            }
+            console.log(result);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("11;12;13;\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void LabeledForIn_ContinueOuter_SkipsRestOfInner(ExecutionMode mode)
+    {
+        var source = """
+            let result: string = "";
+            const obj = { a: 1, b: 2 };
+            outer: for (const k1 in obj) {
+                for (const k2 in obj) {
+                    result = result + k1 + k2 + ";";
+                    continue outer;
+                }
+            }
+            console.log(result);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("aa;ba;\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void LabeledDoWhile_ContinueOuter_RetestsCondition(ExecutionMode mode)
+    {
+        var source = """
+            let result: string = "";
+            let i: number = 0;
+            outer: do {
+                i = i + 1;
+                let j: number = 0;
+                do {
+                    j = j + 1;
+                    if (j === 2) { continue outer; }
+                    result = result + (i * 10 + j) + ";";
+                } while (j < 3);
+            } while (i < 3);
+            console.log(result);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("11;21;31;\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Generator_LabeledContinueOuterFor_YieldsAcrossIterations(ExecutionMode mode)
+    {
+        // #558 generator repro: the yield suspends inside the inner loop; continue outer must
+        // advance the outer `for` rather than restart it (compiled looped forever on the first
+        // value before the fix).
+        var source = """
+            function* g() {
+                outer: for (let i = 0; i < 2; i++) {
+                    for (let j = 0; j < 2; j++) {
+                        yield i * 10 + j;
+                        if (j === 0) { continue outer; }
+                    }
+                }
+            }
+            let result: string = "";
+            for (const v of g()) { result = result + v + ";"; }
+            console.log(result);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("0;10;\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ChainedLabels_While_ContinueOuter(ExecutionMode mode)
+    {
+        // Both labels wrap the same while; `continue a` re-tests the outer condition.
+        var source = """
+            let sum: number = 0;
+            let i: number = 0;
+            a: b: while (i < 3) {
+                i = i + 1;
+                let j: number = 0;
+                while (j < 3) {
+                    j = j + 1;
+                    if (j === 2) { continue a; }
+                    sum = sum + (i * 10 + j);
+                }
+            }
+            console.log(sum);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("63\n", output);  // 11 + 21 + 31
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void ChainedLabels_For_ContinueOuter_Interpreted(ExecutionMode mode)
+    {
+        // A chain of labels on a `for` (a: b: for) — `continue p` must advance the outer for.
+        // The interpreter handles this; the compiled path is a known follow-up gap (it would
+        // re-run the for initializer), so this is interpreter-only.
+        var source = """
+            let sum: number = 0;
+            p: q: for (let x = 0; x < 3; x++) {
+                for (let y = 0; y < 3; y++) {
+                    if (y === 1) { continue p; }
+                    sum = sum + (x * 10 + y);
+                }
+            }
+            console.log(sum);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("30\n", output);  // 0 + 10 + 20
+    }
+
+    #endregion
+
     #region Labeled Block Tests
 
     [Theory]


### PR DESCRIPTION
Closes #558.

## Problem

A labeled `continue <label>` whose target is an outer `for` loop branched to a continue point placed **before** the loop's initializer, so the initializer re-ran and the loop never made progress — an infinite loop. Reproduced in **both** the interpreter and the compiler, independent of `try`/`finally` and generators.

```ts
const out: number[] = [];
outer: for (let i = 0; i < 2; i++) {
  for (let j = 0; j < 2; j++) {
    out.push(i * 10 + j);
    if (j === 0) continue outer;
  }
}
console.log(out.join(","));   // Node: 0,10 — SharpTS: hung (both modes)
```

The generator variant hung the same way (compiled looped forever on the first yielded value).

## Root cause

- `StatementEmitterBase.EmitLabeledStatement` and `ILEmitter.EmitLabeledStatement` marked the labeled continue target *before* emitting the loop. For a `for`, that sits ahead of the initializer.
- The interpreter's `ExecuteLabeledStatement` restarted the whole loop on a labeled continue (which re-runs a `for` initializer) and omitted `Stmt.For` from its loop-label set entirely.
- `AsyncMoveNextEmitter` already special-cased this; the base, the plain generator emitter, `ILEmitter`, and the interpreter did not.

## Fix

Make the loop own its label so a labeled `continue` lands on the loop's real continue point (a `for`'s increment, a `while`'s condition, an iterator's advance) — exactly like an unlabeled `continue`.

- **Compiled:** a labeled statement that directly wraps a loop parks the label on `CompilationContext.PendingLoopLabel`; the loop's own `EnterLoop` adopts it, so the loop's correctly-placed break/continue targets carry the label. `EmitForOf` emits several alternative runtime paths, so it captures the label once and hands it to every path (an early version regressed `break` on a typed-array for-of because only the first-emitted path was labeled — now fixed and covered by a test). Non-loop and chained-label statements keep the prior wrapper behavior. Covers `ILEmitter` and the sync generator emitter; the async emitter was already correct and is untouched.
- **Interpreter:** the wrapping label(s) are threaded into the loop executors, which resolve a matching labeled break/continue natively via `HandleLoopResult` instead of restarting the loop. Chained labels (`a: b: for`) all attach to the loop.

## Tests

Adds `LabeledStatementTests` cases (both interpreter and compiled) for labeled `continue`/`break` to an outer `for`/`for-of`/`for-in`/`do-while`, self-continue on a `for`, the generator repro, and chained labels. The existing suite only ever exercised labeled `while`/`for-of`/`do-while` continue — never a labeled `for` — which is why this went undetected.

## Verification

- Full unit suite: **11,890 passed**. The only 2 failures were the live-network `DnsRecordTypeTests.*ResolveNs*` smoke tests, which pass on re-run on both this branch and clean `main` (network timing, unrelated to control flow).
- Compiled IL for the labeled-loop cases passes `--verify`.
- Test262 / TypeScriptConformance: the TS-conformance suite is type-checker-only and the type checker is untouched; the Test262 subset doesn't cover labeled statements, and unlabeled loop codegen is byte-identical (the `labelName=null` path), so neither is affected.

## Known follow-up

A *chained* label on a `for` (`a: b: for ...; continue a`) is now handled by the interpreter but still hangs in compiled mode (the outer label of a chain falls back to the pre-existing wrapper placement). Filed as a separate issue; out of scope for #558 (single-label).