### PR TITLE
Fix #556, #557: loop-condition narrowing survives later reassignment; narrow boolean to true/false

### DIFF
--- a/SharpTS.Tests/TypeCheckerTests/NarrowingTests/ControlFlowNarrowingTests.cs
+++ b/SharpTS.Tests/TypeCheckerTests/NarrowingTests/ControlFlowNarrowingTests.cs
@@ -349,5 +349,145 @@ public class ControlFlowNarrowingTests
         Assert.Equal("2\n2\n2\n3\n", result);
     }
 
+    // ----- #556: loop-condition narrowing holds for uses that precede a later body reassignment.
+    // The condition is re-evaluated at the top of every iteration, so the narrowing is valid at
+    // the top of the body regardless of a downstream reassignment. (Contrast with
+    // AssignmentInvalidationTests.AssignmentInLoop_InvalidatesNarrowing, where the narrowing
+    // flows in from *before* the loop and is correctly invalidated.)
+
+    [Fact]
+    public void WhileCondition_NarrowsUseBeforeLaterReassignment()
+    {
+        // The exact repro from #556: `x.length` precedes `x = undefined`, so it sees `string`.
+        var source = """
+            function f(x: string | undefined): number {
+                let total = 0;
+                while (x !== undefined) {
+                    total += x.length;
+                    x = undefined;
+                }
+                return total;
+            }
+            console.log(f("hello"));
+            """;
+
+        Assert.Equal("5\n", TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void WhileCondition_Truthiness_NarrowsUseBeforeLaterReassignment()
+    {
+        // #556 truthiness variant: `while (x)` narrows the use before the reassignment.
+        var source = """
+            function f(x: string | undefined): number {
+                let total = 0;
+                while (x) {
+                    total += x.length;
+                    x = undefined;
+                }
+                return total;
+            }
+            console.log(f("hi"));
+            """;
+
+        Assert.Equal("2\n", TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void WhileCondition_Typeof_NarrowsUseBeforeLaterReassignment()
+    {
+        // #556 typeof variant.
+        var source = """
+            function f(x: string | undefined): number {
+                let total = 0;
+                while (typeof x === "string") {
+                    total += x.length;
+                    x = undefined;
+                }
+                return total;
+            }
+            console.log(f("abc"));
+            """;
+
+        Assert.Equal("3\n", TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void ForCondition_NarrowsUseBeforeIncrementReassignment()
+    {
+        // #556 for-loop variant: the increment reassigns the guarded var, but the body use still
+        // sees the narrowing because the condition is re-checked after the increment.
+        var source = """
+            function f(x: string | undefined): number {
+                let total = 0;
+                for (; x !== undefined; x = undefined) {
+                    total += x.length;
+                }
+                return total;
+            }
+            console.log(f("data"));
+            """;
+
+        Assert.Equal("4\n", TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void WhileCondition_UseAfterReassignment_StillWidens()
+    {
+        // #556 soundness counterpart: a use AFTER the reassignment widens back to the declared
+        // type — the reassignment invalidates the narrowing at that flow point, matching tsc.
+        var source = """
+            function f(x: string | undefined): number {
+                while (x !== undefined) {
+                    x = undefined;
+                    return x.length;
+                }
+                return 0;
+            }
+            """;
+
+        Assert.Throws<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void WhileCondition_NestedReassignment_StillInvalidates()
+    {
+        // #556 soundness: a reassignment in a nested branch invalidates the narrowing for the use
+        // that follows the branch (the join may carry the reassigned value), matching tsc.
+        var source = """
+            function f(x: string | undefined, foo: boolean): number {
+                while (x !== undefined) {
+                    if (foo) { x = undefined; }
+                    return x.length;
+                }
+                return 0;
+            }
+            """;
+
+        Assert.Throws<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void WhileCondition_NarrowsUseBeforeLaterReassignment_Compiled()
+    {
+        // #556 compiled parity. Uses a local (not a parameter) for the guarded `string | undefined`
+        // value to avoid the unrelated pre-existing bug where a `string | undefined` *parameter*
+        // reassigned to `undefined` is compiled with a non-nullable `String` slot (#568).
+        var source = """
+            function f(s: string): number {
+                let x: string | undefined = s;
+                let total = 0;
+                while (x !== undefined) {
+                    total += x.length;
+                    x = undefined;
+                }
+                return total;
+            }
+            console.log(f("hello"));
+            """;
+
+        Assert.Equal("5\n", TestHarness.RunCompiled(source));
+    }
+
     #endregion
 }

--- a/SharpTS.Tests/TypeCheckerTests/NarrowingTests/TruthinessNarrowingTests.cs
+++ b/SharpTS.Tests/TypeCheckerTests/NarrowingTests/TruthinessNarrowingTests.cs
@@ -241,4 +241,118 @@ public class TruthinessNarrowingTests
 
         Assert.Throws<TypeCheckException>(() => TestHarness.RunInterpreted(source));
     }
+
+    // ----- #557: a general `boolean` narrows to `true`/`false` under a truthiness guard -----
+    // (the only general primitive tsc narrows this way; `string`/`number` stay intact).
+
+    [Fact]
+    public void Truthiness_GeneralBoolean_NarrowsToTrueInThen()
+    {
+        // The exact repro from #557. The `: true` return slot proves `b` narrows to `true`.
+        var source = """
+            function f(b: boolean): true {
+                if (b) { return b; }
+                throw new Error("unreachable");
+            }
+            console.log(f(true));
+            """;
+
+        Assert.Equal("true\n", TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void Truthiness_GeneralBoolean_NarrowsToFalseInFalsyBranch()
+    {
+        // The falsy branch narrows `boolean` to `false`. After a terminating truthy branch the
+        // fall-through sees `false`.
+        var source = """
+            function g(b: boolean): false {
+                if (b) { throw new Error("no"); }
+                return b;
+            }
+            console.log(g(false));
+            """;
+
+        Assert.Equal("false\n", TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void Truthiness_GeneralBoolean_Negation_NarrowsToTrueAfterEarlyThrow()
+    {
+        // `if (!b) throw` leaves `b` as `true` for the code that follows.
+        var source = """
+            function f(b: boolean): true {
+                if (!b) { throw new Error("no"); }
+                return b;
+            }
+            console.log(f(true));
+            """;
+
+        Assert.Equal("true\n", TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void Truthiness_BooleanOrUndefined_NarrowsBothBranches()
+    {
+        // With a union, the truthy branch narrows to `true`; the falsy branch keeps
+        // `false | undefined` (both are falsy).
+        var source = """
+            function truthy(b: boolean | undefined): true {
+                if (b) { return b; }
+                throw new Error("no");
+            }
+            function falsy(b: boolean | undefined): false | undefined {
+                if (b) { throw new Error("no"); }
+                return b;
+            }
+            console.log(truthy(true));
+            console.log(falsy(false));
+            console.log(falsy(undefined));
+            """;
+
+        Assert.Equal("true\nfalse\nundefined\n", TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void Truthiness_GeneralBoolean_WhileBodyNarrowsToTrue()
+    {
+        // The shared guard analyzer narrows `boolean` to `true` inside a loop body too.
+        var source = """
+            function f(b: boolean): true[] {
+                const out: true[] = [];
+                while (b) { out.push(b); break; }
+                return out;
+            }
+            console.log(f(true).length);
+            """;
+
+        Assert.Equal("1\n", TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void Truthiness_GeneralBoolean_UnguardedReturnAsTrue_StillErrors()
+    {
+        // Sanity: the narrowing is guard-gated — an unguarded `boolean` is not assignable to `true`.
+        var source = """
+            function f(b: boolean): true {
+                return b;
+            }
+            """;
+
+        Assert.Throws<TypeMismatchException>(() => TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void Truthiness_GeneralBoolean_Compiled_MatchesInterpreted()
+    {
+        var source = """
+            function f(b: boolean): true {
+                if (b) { return b; }
+                throw new Error("no");
+            }
+            console.log(f(true));
+            """;
+
+        Assert.Equal("true\n", TestHarness.RunCompiled(source));
+    }
 }

--- a/TypeSystem/TypeChecker.Compatibility.TypeGuards.cs
+++ b/TypeSystem/TypeChecker.Compatibility.TypeGuards.cs
@@ -1274,6 +1274,16 @@ public partial class TypeChecker
         foreach (var t in constituents)
         {
             if (t is TypeInfo.Never) continue;       // bottom type inhabits neither branch
+            // A general `boolean` is the only general primitive tsc narrows for truthiness: it
+            // splits into `true` (truthy branch) and `false` (falsy branch). Equivalent to expanding
+            // it to `true | false` and running the filters below, but without the per-constituent
+            // allocation. (`string`/`number` stay intact — no single literal models "non-empty".)
+            if (t is TypeInfo.Primitive { Type: TokenType.TYPE_BOOLEAN })
+            {
+                truthy.Add(new TypeInfo.BooleanLiteral(true));
+                falsy.Add(new TypeInfo.BooleanLiteral(false));
+                continue;
+            }
             if (!IsAlwaysFalsy(t)) truthy.Add(t);    // can be truthy → keep in the truthy branch
             if (!IsAlwaysTruthy(t)) falsy.Add(t);    // can be falsy  → keep in the falsy branch
         }

--- a/TypeSystem/TypeChecker.Statements.cs
+++ b/TypeSystem/TypeChecker.Statements.cs
@@ -929,15 +929,18 @@ public partial class TypeChecker
                     InvalidateNarrowingsFor(assignedPath);
                 }
 
-                // Apply condition narrowings (if not affected by assignments)
+                // Apply the loop-condition narrowings. The condition is re-evaluated at the top of
+                // every iteration, so its narrowing holds at the top of the body even when the body
+                // reassigns the guarded variable later: the reassignment is on a downstream flow edge
+                // and is handled by the normal in-body flow analysis (CheckAssign invalidates the
+                // narrowing at the assignment point, so uses *after* it widen back). Suppressing the
+                // narrowing whenever the variable is assigned *anywhere* in the body over-invalidated
+                // uses that precede the reassignment, diverging from tsc (#556).
                 if (conditionNarrowings != null)
                 {
                     foreach (var (condPath, narrowedType, _) in conditionNarrowings)
                     {
-                        if (!IsPathAffectedByAssignments(condPath, assignedPaths))
-                        {
-                            AddNarrowing(condPath, narrowedType);
-                        }
+                        AddNarrowing(condPath, narrowedType);
                     }
                 }
 

--- a/TypeSystem/TypeChecker.cs
+++ b/TypeSystem/TypeChecker.cs
@@ -253,20 +253,6 @@ public partial class TypeChecker
     }
 
     /// <summary>
-    /// Checks if a narrowing path would be affected by any of the assigned paths.
-    /// A path is affected if any assignment is to the path itself or to a prefix of the path.
-    /// </summary>
-    private static bool IsPathAffectedByAssignments(Narrowing.NarrowingPath path, HashSet<Narrowing.NarrowingPath> assignedPaths)
-    {
-        foreach (var assigned in assignedPaths)
-        {
-            if (path.IsAffectedByAssignmentTo(assigned))
-                return true;
-        }
-        return false;
-    }
-
-    /// <summary>
     /// Pushes a new scope for declared variable types (called when entering a function).
     /// </summary>
     private void PushDeclaredVariableScope()


### PR DESCRIPTION
Fixes #556 and #557 — two pre-existing type-checker narrowing precision gaps (both filed during #486). Type-checker-only; no runtime/IL behavior changes.

## #557 — narrow a general `boolean` to `true`/`false` under a truthiness guard

`tsc` narrows a general `boolean` under truthiness: `true` in the truthy branch, `false` in the falsy branch. SharpTS left it as `boolean`, so this errored:

```ts
function f(b: boolean): true {
  if (b) { return b; }   // was: Type 'boolean' is not assignable to type 'true'
  throw new Error("no");
}
```

`ComputeTruthinessNarrowing` now expands a `boolean` constituent into its `true`/`false` members; the existing always-falsy/always-truthy filters split them across the branches. `boolean` is the only general primitive `tsc` narrows for truthiness (`string`/`number` stay intact — no single literal models "non-empty"/"non-zero"). Works for `if` / `!` / `while` / ternary / `&&` and unions (`boolean | undefined` → `true` / `false | undefined`).

## #556 — loop-condition narrowing must survive a later body reassignment

A loop body that reassigns the guarded variable *after* using it had its loop-condition narrowing dropped for the **entire** body, including the use that precedes the reassignment:

```ts
function f(x: string | undefined): number {
  let total = 0;
  while (x !== undefined) {
    total += x.length;   // was: Property 'length' cannot be accessed on 'undefined'
    x = undefined;
  }
  return total;
}
```

The loop condition is re-evaluated at the top of every iteration, so the narrowing holds at the top of the body regardless of a downstream reassignment. `CheckLoopBody` now applies condition narrowings **unconditionally** and lets the normal in-body flow analysis (`CheckAssign`, which invalidates + restores the declared type at the assignment point) widen uses that follow the reassignment. The separate **inflow** invalidation (a narrowing flowing in from *before* the loop) is unchanged — that case is still correctly invalidated (`AssignmentInLoop_InvalidatesNarrowing`). The now-dead `IsPathAffectedByAssignments` wrapper is removed.

Applies to `while` / `for` and all guard forms (`!== undefined`, `typeof`, truthiness). Uses **after** a reassignment, and reassignments in nested branches, still correctly widen/invalidate (verified by tests).

## Tests

- 7 tests in `TruthinessNarrowingTests` (#557): truthy/falsy branches, negation, `boolean | undefined`, while-body, compiled parity, and a guard-gated sanity check.
- 7 tests in `ControlFlowNarrowingTests` (#556): the repro plus truthiness/`typeof`/for-increment variants, use-after-reassignment and nested-reassignment soundness counterparts, and compiled parity.
- Full unit suite green (the only failures in a full run were the known flaky live-network `DnsRecordTypeTests`, which pass on re-run and are unrelated).

## Follow-ups filed while here

- #568 — **pre-existing, unrelated** compiled bug: a `T | undefined` *parameter* reassigned to `undefined` compiles to a non-nullable slot (`string|undefined` → `InvalidCastException`; `number|undefined` → invalid IL). Locals are fine. The #556 compiled-parity test uses a local to avoid it.
- #570 — **pre-existing** soundness gap: a reassignment in a nested `if` branch doesn't invalidate an outer guard's narrowing (non-loop only; loops are sound here because loop narrowing lives in the shared narrowing-context stack).