### PR TITLE
Fix #480, #489, #563: function & generator implicit completion value is undefined, not null

### DIFF
--- a/Compilation/ExpressionEmitterBase.CallHelpers.cs
+++ b/Compilation/ExpressionEmitterBase.CallHelpers.cs
@@ -1677,8 +1677,12 @@ public abstract partial class ExpressionEmitterBase
     {
         if (returnType == typeof(void))
         {
-            IL.Emit(OpCodes.Ldnull);
-            SetStackUnknown();
+            // A void-returning method used in a value context yields `undefined` (ECMA-262),
+            // not C# null (= JS null): a TS `void` function still produces `undefined` when its
+            // result is read — e.g. an off-the-end function compiled to a void slot. The helper
+            // pushes the $Undefined sentinel (with a null fallback for standalone) and sets the
+            // stack type to Unknown. #563
+            EmitUndefinedConstant();
         }
         else if (Types.IsDouble(returnType))
         {

--- a/Compilation/ILEmitter.Helpers.cs
+++ b/Compilation/ILEmitter.Helpers.cs
@@ -36,9 +36,10 @@ public partial class ILEmitter
     {
         if (returnType == typeof(void))
         {
-            // Void returns don't leave a value on the stack
-            IL.Emit(OpCodes.Ldnull);
-            SetStackUnknown();
+            // A void-returning method used in a value context yields `undefined`, not C# null
+            // (= JS null) — mirrors BoxReturnValueIfNeeded in ExpressionEmitterBase. The helper
+            // pushes the $Undefined sentinel (null fallback for standalone) and sets stack type. #563
+            EmitUndefinedConstant();
         }
         else if (_ctx.Types.IsDouble(returnType))
         {

--- a/Compilation/ILEmitter.Statements.cs
+++ b/Compilation/ILEmitter.Statements.cs
@@ -1211,8 +1211,19 @@ public partial class ILEmitter
             {
                 // Void functions: no value on stack; ret takes nothing.
             }
-            else if (returnType == _ctx.Types.Object || !returnType.IsValueType)
+            else if (returnType == _ctx.Types.Object)
             {
+                // ECMA-262: a bare `return;` completes with undefined, not null. Emit the
+                // $Undefined sentinel for untyped object returns — mirrors EmitDefaultReturnValue
+                // (the off-the-end path) and the interpreter's VisitReturn — so a plain function
+                // returning no value is `undefined`. `return null;` (the r.Value != null branch
+                // above) still yields null. #563
+                EmitUndefinedConstant();
+            }
+            else if (!returnType.IsValueType)
+            {
+                // Specific reference-typed returns keep their null default (matches
+                // EmitDefaultReturnValue): the checker treats an explicit `T | null` return as null.
                 IL.Emit(OpCodes.Ldnull);
             }
             else if (_ctx.Types.IsDouble(returnType))

--- a/Execution/Interpreter.Async.cs
+++ b/Execution/Interpreter.Async.cs
@@ -479,9 +479,10 @@ public partial class Interpreter
 
     internal async ValueTask<ExecutionResult> ExecuteReturnAsyncVT(Stmt.Return returnStmt)
     {
-        object? returnValue = null;
-        if (returnStmt.Value != null) returnValue = (await EvaluateAsync(returnStmt.Value)).ToObject();
-        return ExecutionResult.Return(returnValue);
+        // Bare `return;` completes with `undefined`, not null — see VisitReturn (#480).
+        if (returnStmt.Value == null)
+            return ExecutionResult.Return(RuntimeValue.Undefined);
+        return ExecutionResult.Return((await EvaluateAsync(returnStmt.Value)).ToObject());
     }
 
     internal async ValueTask<ExecutionResult> ExecutePrintAsyncVT(Stmt.Print printStmt)

--- a/Execution/Interpreter.cs
+++ b/Execution/Interpreter.cs
@@ -2532,9 +2532,14 @@ public partial class Interpreter : IDisposable
 
     internal ExecutionResult VisitReturn(Stmt.Return returnStmt)
     {
-        object? returnValue = null;
-        if (returnStmt.Value != null) returnValue = Evaluate(returnStmt.Value);
-        return ExecutionResult.Return(returnValue);
+        // A bare `return;` completes with `undefined` — distinct from `return null;`. Emitting the
+        // undefined sentinel here (rather than C# null, which represents JS null) is what makes a
+        // generator's completion value and a plain function's return value `undefined` instead of
+        // conflating them with null (#480). `return <expr>` preserves whatever the expression
+        // evaluates to, so an explicit `return null;` still yields null.
+        if (returnStmt.Value == null)
+            return ExecutionResult.Return(RuntimeValue.Undefined);
+        return ExecutionResult.Return(Evaluate(returnStmt.Value));
     }
 
     internal ExecutionResult VisitPrint(Stmt.Print printStmt)

--- a/SharpTS.Tests/SharedTests/FunctionReturnValueTests.cs
+++ b/SharpTS.Tests/SharedTests/FunctionReturnValueTests.cs
@@ -1,0 +1,96 @@
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests;
+
+/// <summary>
+/// Return-value semantics for plain (non-generator) functions and arrows: a function that
+/// completes without an explicit <c>return &lt;expr&gt;</c> — a bare <c>return;</c> or falling off
+/// the end — has return value <c>undefined</c>, distinct from <c>return null;</c> (which is null).
+///
+/// Both modes are spec-correct for synchronous functions/arrows:
+/// <list type="bullet">
+/// <item>Interpreter: a bare <c>return;</c> produces the <c>undefined</c> sentinel at its source
+/// (<c>VisitReturn</c>) rather than C# null — the #480 root-cause fix.</item>
+/// <item>Compiled: a bare <c>return;</c> into an object slot emits the <c>$Undefined</c> sentinel
+/// (<c>ILEmitter.EmitReturn</c>), and an off-the-end body compiled to a <c>void</c> slot is
+/// materialized as <c>undefined</c> at the call site (<c>BoxReturnValueIfNeeded</c>) — the #563 fix.</item>
+/// </list>
+///
+/// Async (non-generator) functions are a separate path: the interpreter is correct for a bare
+/// <c>return;</c> (<c>ExecuteReturnAsyncVT</c>, #480) but the compiled async state machine and the
+/// off-the-end completion still yield <c>null</c>, tracked by #587. Async generators are #540.
+/// </summary>
+public class FunctionReturnValueTests
+{
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void BareReturn_IsUndefined(ExecutionMode mode)
+    {
+        // Bare `return;` is equivalent to `return undefined` — undefined, not null.
+        var source = """
+            function f() { return; }
+            console.log(typeof f());
+            console.log(f() === undefined);
+            console.log(f() === null);
+            """;
+        Assert.Equal("undefined\ntrue\nfalse\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void OffEndCompletion_IsUndefined(ExecutionMode mode)
+    {
+        // Falling off the end of the body completes with undefined. In compiled mode such a
+        // body is emitted into a `void` slot, so this also covers the call-site materialization
+        // of a void return as undefined (#563).
+        var source = """
+            function f() {}
+            console.log(typeof f());
+            console.log(f() === undefined);
+            """;
+        Assert.Equal("undefined\ntrue\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ArrowBareReturn_IsUndefined(ExecutionMode mode)
+    {
+        // A block-bodied arrow shares the same return emission as a function declaration, so a
+        // bare `return;` is undefined in both modes too.
+        var source = """
+            const f = () => { return; };
+            console.log(typeof f());
+            console.log(f() === undefined);
+            """;
+        Assert.Equal("undefined\ntrue\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ReturnNull_IsNull(ExecutionMode mode)
+    {
+        // `return null;` is distinct from a bare `return;`: the value is JS null, not undefined.
+        var source = """
+            function f() { return null; }
+            console.log(typeof f());
+            console.log(f() === null);
+            """;
+        Assert.Equal("object\ntrue\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void AsyncFunction_BareReturn_ResolvesUndefined(ExecutionMode mode)
+    {
+        // The async return path (ExecuteReturnAsyncVT) got the same fix as the sync VisitReturn:
+        // a bare `return;` resolves the promise with undefined, not null. The compiled async state
+        // machine (and async off-the-end completion in both modes) still yields null — tracked by
+        // #587 — so this is interpreter-only. Async generators are a separate path tracked by #540.
+        var source = """
+            async function f() { return; }
+            f().then(v => console.log(typeof v + ":" + (v === undefined)));
+            """;
+        Assert.Equal("undefined:true\n", TestHarness.Run(source, mode));
+    }
+}

--- a/SharpTS.Tests/SharedTests/GeneratorUndefinedValueTests.cs
+++ b/SharpTS.Tests/SharedTests/GeneratorUndefinedValueTests.cs
@@ -132,13 +132,16 @@ public class GeneratorUndefinedValueTests
         Assert.Equal("got:RET\n", TestHarness.Run(source, mode));
     }
 
-    // ---- Direct `.next().value` completion value ----
-    // These assert spec-correct behavior in COMPILED mode. The interpreter still reports `null`
-    // here (a separate, pre-existing gap tracked by #480), so they are compiled-only for now.
+    // ---- Direct `.next().value` completion value (#480) ----
+    // A generator that completes without an explicit `return <expr>` has completion value
+    // `undefined` (ECMA-262 27.5.1.x): both falling off the end and a bare `return;`. Both modes
+    // are now spec-correct — the interpreter previously reported `null` for the bare-`return;` case
+    // (#480), fixed by making a bare `return;` produce the `undefined` sentinel at its source
+    // (VisitReturn) rather than C# null, while preserving `return null;` as null (see below).
 
     [Theory]
-    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
-    public void OffEndCompletionValue_IsUndefined_Compiled(ExecutionMode mode)
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void OffEndCompletionValue_IsUndefined(ExecutionMode mode)
     {
         var source = """
             function* g() { yield 1; }
@@ -150,8 +153,8 @@ public class GeneratorUndefinedValueTests
     }
 
     [Theory]
-    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
-    public void BareReturnCompletionValue_IsUndefined_Compiled(ExecutionMode mode)
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void BareReturnCompletionValue_IsUndefined(ExecutionMode mode)
     {
         var source = """
             function* g() { yield 1; return; }
@@ -160,6 +163,24 @@ public class GeneratorUndefinedValueTests
             console.log("b:" + it.next().value);
             """;
         Assert.Equal("a:1\nb:undefined\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ReturnNullCompletionValue_IsNull(ExecutionMode mode)
+    {
+        // `return null;` is distinct from a bare `return;`: the completion value is JS null, not
+        // undefined. Guards two things cross-mode: the interpreter #480 fix must not conflate "no
+        // return value" with "returned null", and the compiled generator return path must preserve
+        // null (#489 — compiled `return null` previously produced an undefined completion value;
+        // fixed by reading the stored CurrentField on the done path rather than emitting null).
+        var source = """
+            function* g() { yield 1; return null; }
+            const it = g();
+            console.log("a:" + it.next().value);
+            console.log("b:" + it.next().value);
+            """;
+        Assert.Equal("a:1\nb:null\n", TestHarness.Run(source, mode));
     }
 
     // ---- #499: `next()` on an already-completed generator yields undefined ----


### PR DESCRIPTION
Closes #480, #489, #563. Supersedes #577 (which fixed the #480 interpreter half only; this PR carries that fix forward and adds the compiled halves).

## Theme

A function or generator that completes **without an explicit `return <expr>`** — a bare `return;` or falling off the end — has completion value **`undefined`**, distinct from `return null;` (which is **`null`**). Several paths conflated the two by producing C# `null` (= JS `null`). This unifies the behaviour across interpreter + compiled and across plain functions, arrows, and generators.

| case | before (interp / compiled) | after (interp / compiled) |
|---|---|---|
| generator bare `return;` / off-end | `null`* / `undefined` | `undefined` / `undefined` |
| generator `return null;` | `null` / `null` | `null` / `null` |
| function/arrow bare `return;` | `null` / `null` | `undefined` / `undefined` |
| function/arrow off-the-end | `undefined` / `null` | `undefined` / `undefined` |
| function `return null;` | `null` / `null` | `null` / `null` |

\* the interpreter generator off-end was already `undefined`; only the bare-`return;` case was `null`.

## Changes

**Interpreter — #480.** `VisitReturn` (`Execution/Interpreter.cs`) and `ExecuteReturnAsyncVT` (`Execution/Interpreter.Async.cs`) emit the `undefined` sentinel for a value-less `return;` at the source. Because a bare `return;` and `return null;` are indistinguishable once reduced to a runtime value, the fix must live where `returnStmt.Value == null` is still visible. `return <expr>` is preserved verbatim, so `return null;` stays `null`. This corrects the generator completion value **and** the plain/async function return value in one place.

**Compiled plain functions & block-bodied arrows — #563.**
- `ILEmitter.EmitReturn` (`Compilation/ILEmitter.Statements.cs`): a bare `return;` into an `object` slot now emits `$Undefined` instead of `ldnull`, mirroring `EmitDefaultReturnValue` (the off-the-end path) and the interpreter. A specifically-typed reference slot keeps its `null` default.
- `BoxReturnValueIfNeeded` (`Compilation/ExpressionEmitterBase.CallHelpers.cs` + the `ILEmitter` override): a `void`-returning method used in a value context now yields `undefined`. A no-return function is compiled to a `void` slot, so this is the off-the-end half.

**Compiled generator `return null` — #489.** Already spec-correct on `main` (the `next()` done-path reads the stored `CurrentField` rather than emitting `null` — commit `2f7a3c27`). This PR adds the missing cross-mode regression guard so it can't silently regress.

## Testing

- New `FunctionReturnValueTests` (plain / arrow / async) and the promoted `GeneratorUndefinedValueTests` completion cases assert cross-mode behaviour where compiled is now fixed.
- Full xUnit suite green **except** one pre-existing, unrelated failure — `AsyncGeneratorTryFinallyTests.LabeledBreakToOuterLoop_RunsInterveningFinally(Compiled)` — which reproduces with the tree reverted to `origin/main` (filed #589).
- Test262 subset: no baseline change. IL verification passes on all compiled repros.

## Out-of-scope follow-ups filed

Same theme, distinct surfaces, left out to keep this PR focused (and the async ones out of the fragile async state machine):
- **#587** — async (non-generator) function completion: `null` in compiled mode, and off-the-end in both modes.
- **#588** — compiled class instance/static method falling off the end yields `null`.
- **#589** — pre-existing compiled async-generator labeled-`break` failure (red committed test on `main`).
