### PR TITLE
Add labeled-continue async-generator regression test (closes #589)

### DIFF
--- a/SharpTS.Tests/SharedTests/AsyncGeneratorTryFinallyTests.cs
+++ b/SharpTS.Tests/SharedTests/AsyncGeneratorTryFinallyTests.cs
@@ -196,6 +196,30 @@ public class AsyncGeneratorTryFinallyTests
 
     [Theory]
     [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    public void LabeledContinueToOuterLoop_RunsInterveningFinally(ExecutionMode mode)
+    {
+        // The labeled-`continue` sibling of LabeledBreakToOuterLoop (#586/#589). `continue outer` must
+        // run the inner loop's finally and then advance the *outer* loop — skipping the rest of the
+        // inner loop — rather than continuing the inner loop. The same EnterLoop pending-label adoption
+        // (#586) that resolves the labeled break drives this path; without behavioral coverage the
+        // continue direction could regress silently (the labeled-break test alone would not catch it).
+        var source = """
+            async function* g() {
+              outer: for (let i = 0; i < 2; i++) {
+                for (let j = 0; j < 3; j++) {
+                  try { yield i * 10 + j; if (j === 0) continue outer; } finally { console.log("fin" + i + j); }
+                }
+              }
+            }
+            async function main() { for await (const v of g()) console.log("v" + v); }
+            main();
+            """;
+
+        Assert.Equal("v0\nfin00\nv10\nfin10\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
     public void BreakToLoopBetweenTwoTrys_RunsOnlyInnerFinally(ExecutionMode mode)
     {
         // The break targets a loop that sits *between* two trys: only the finally inside that loop
@@ -389,12 +413,14 @@ public class AsyncGeneratorTryFinallyTests
     [InlineData("async function* g() { while (true) { try { yield 1; break; } finally { console.log('f'); } } } async function main(){ for await (const v of g()) {} } main();")]
     [InlineData("async function* inner(){ yield 2; } async function* g() { try { yield 1; yield* inner(); } finally { console.log('f'); } } async function main(){ for await (const v of g()) {} } main();")]
     // #559 control-flow shapes: continue, throw-from-catch, return-from-catch, nested-finally break,
-    // labeled break, break to a loop sitting between two trys, and a yielding finally on the break path.
+    // labeled break, labeled continue (#586/#589), break to a loop sitting between two trys, and a
+    // yielding finally on the break path.
     [InlineData("async function* g() { for (let i=0;i<2;i++){ try { yield i; continue; } finally { console.log('f'); } } } async function main(){ for await (const v of g()) {} } main();")]
     [InlineData("async function* g() { try { yield 1; throw 'a'; } catch (e) { throw 'b'; } finally { console.log('f'); } } async function main(){ try { for await (const v of g()) {} } catch (e) {} } main();")]
     [InlineData("async function* g() { try { yield 1; throw 'a'; } catch (e) { return; } finally { console.log('f'); } } async function main(){ for await (const v of g()) {} } main();")]
     [InlineData("async function* g() { while (true) { try { try { yield 1; break; } finally { console.log('a'); } } finally { console.log('b'); } } } async function main(){ for await (const v of g()) {} } main();")]
     [InlineData("async function* g() { outer: for(let i=0;i<2;i++){ for(let j=0;j<2;j++){ try { yield j; break outer; } finally { console.log('f'); } } } } async function main(){ for await (const v of g()) {} } main();")]
+    [InlineData("async function* g() { outer: for(let i=0;i<2;i++){ for(let j=0;j<2;j++){ try { yield j; continue outer; } finally { console.log('f'); } } } } async function main(){ for await (const v of g()) {} } main();")]
     [InlineData("async function* g() { try { for(let i=0;i<2;i++){ try { yield i; break; } finally { console.log('a'); } } } finally { console.log('b'); } } async function main(){ for await (const v of g()) {} } main();")]
     [InlineData("async function* g() { while (true) { try { yield 1; break; } finally { yield 2; } } } async function main(){ for await (const v of g()) {} } main();")]
     // await suspensions crossing the protected region alongside the non-local exits.


### PR DESCRIPTION
## Summary

[#589](https://github.com/nickna/SharpTS/issues/589) reported that the committed test `AsyncGeneratorTryFinallyTests.LabeledBreakToOuterLoop_RunsInterveningFinally` fails on `main` in **compiled mode** — a labeled `break outer` from a nested loop inside an async generator is ignored and both loops run to completion.

**The bug was already fixed by #586 (`bf3c48dc`)**, which made the compiled async generator's `EnterLoop` override adopt the pending loop label set by an `outer:`-style labeled statement (`labelName ?? Ctx.TakePendingLoopLabel()`), matching the sync generator emitter. Issue #589 was filed against a working tree that predated that merge.

This PR does **not** change production code — it closes a regression-coverage gap.

## Verification of the attribution

- Reverting #586's one line reproduces #589's **exact** reported symptom: `v0, fin00, v1, fin01, v2, fin02, v10, fin10, v11, …` (the `break outer` is a no-op).
- Restoring #586 makes the test pass **deterministically** (3/3 isolated runs). The defect is IL-emit-time label resolution, not environment-sensitive (the issue's "environment-sensitive?" hedge was the predated checkout, not flakiness).

## The coverage gap this closes

#586's commit message claimed the fix was *"covered by the existing `LabeledBreakToOuterLoop_RunsInterveningFinally` (and the labeled-continue siblings)"* — but **no async-generator labeled-`continue` test actually existed**. Coverage before this PR:

| shape | break | continue |
|---|---|---|
| sync generator (`LabeledStatementTests`) | ✔ | ✔ |
| **async generator** (`AsyncGeneratorTryFinallyTests`) | ✔ | **✗ (missing)** |

The #586 `EnterLoop` fix drives **both** break and continue (shared `FindLabeledLoopScope`), but only break had behavioral coverage, so the continue direction could regress silently.

## Changes (test-only)

- **`LabeledContinueToOuterLoop_RunsInterveningFinally`** (behavioral, `CompiledOnly`): `continue outer` must run the inner loop's `finally`, then advance the *outer* loop (skipping the rest of the inner loop). Expected `v0, fin00, v10, fin10`.
- A matching **IL-verification** `InlineData` for the labeled-continue shape.

Both are confirmed **non-vacuous**: they fail without #586 and pass with it.

## Testing

- `AsyncGeneratorTryFinallyTests`: 37/37 pass (was 35; +1 behavioral, +1 IL-verify).
- `GeneratorTryFinallyTests`, `LabeledStatementTests`, `EmitterSyncTests` (override-drift meta-test): all green (156 total).

Closes #589.