### PR TITLE
Fix #554/#555: compiled generator non-local exits in try/finally

### DIFF
--- a/Compilation/GeneratorMoveNextEmitter.Statements.TryCatch.cs
+++ b/Compilation/GeneratorMoveNextEmitter.Statements.TryCatch.cs
@@ -86,6 +86,16 @@ public partial class GeneratorMoveNextEmitter
         _pendingExceptionField ??= _builder.StateMachineType.DefineField(
             "<>pendingException", typeof(object), FieldAttributes.Private);
 
+    // `<>pendingReturnValue` (object): the completion value of a `return` being routed through
+    // finally(s). A finally that yields overwrites `<>2__current` with its yielded value, so the
+    // return value is stashed here at the `return` and restored to Current by the return terminal,
+    // after the finally has run (#555). Held across any suspension in those finallys.
+    private FieldBuilder? _pendingReturnValueField;
+
+    private FieldBuilder GetPendingReturnValueField() =>
+        _pendingReturnValueField ??= _builder.StateMachineType.DefineField(
+            "<>pendingReturnValue", typeof(object), FieldAttributes.Private);
+
     // ---- Loop-scope methods (override the base stack to use `_exitScopes`) -----------------------
 
     protected override void EnterLoop(Label breakLabel, Label continueLabel, string? labelName = null)
@@ -139,16 +149,17 @@ public partial class GeneratorMoveNextEmitter
         var loop = b.Label != null ? FindLabeledLoopScope(b.Label.Lexeme) : CurrentLoopScope();
         if (loop == null) return; // matches the base: a break with no resolvable target is a no-op
 
-        if (_protectedRegionDepth == 0)
+        var chain = FinallyFramesAbove(loop);
+        if (chain.Count > 0)
         {
-            var chain = FinallyFramesAbove(loop);
-            if (chain.Count > 0)
-            {
-                int code = loop.BreakCode ??= _nextExitCode++;
-                _exitTerminals.TryAdd(code, () => _il.Emit(OpCodes.Br, loop.BreakLabel));
-                RouteThroughFinallys(chain, code);
-                return;
-            }
+            // Flag-based finally(s) lie between the break and its loop; run them before jumping out.
+            // From inside a real IL block, `Leave` to the innermost flag cleanup (running the real,
+            // no-yield finally(s) on the way — a real try never encloses a flag try, so they are all
+            // innermore); otherwise branch there directly.
+            int code = loop.BreakCode ??= _nextExitCode++;
+            _exitTerminals.TryAdd(code, () => _il.Emit(OpCodes.Br, loop.BreakLabel));
+            RouteThroughFinallys(chain, code, _protectedRegionDepth > 0 ? OpCodes.Leave : OpCodes.Br);
+            return;
         }
 
         EmitBranchToLabel(loop.BreakLabel);
@@ -163,16 +174,15 @@ public partial class GeneratorMoveNextEmitter
         var loop = c.Label != null ? FindLabeledLoopScope(c.Label.Lexeme) : CurrentLoopScope();
         if (loop == null) return;
 
-        if (_protectedRegionDepth == 0)
+        var chain = FinallyFramesAbove(loop);
+        if (chain.Count > 0)
         {
-            var chain = FinallyFramesAbove(loop);
-            if (chain.Count > 0)
-            {
-                int code = loop.ContinueCode ??= _nextExitCode++;
-                _exitTerminals.TryAdd(code, () => _il.Emit(OpCodes.Br, loop.ContinueLabel));
-                RouteThroughFinallys(chain, code);
-                return;
-            }
+            // As in EmitBreak: run the intervening flag-based finally(s) first, `Leave`-ing out of any
+            // real IL block we are inside so its no-yield finally runs and the IL stays legal.
+            int code = loop.ContinueCode ??= _nextExitCode++;
+            _exitTerminals.TryAdd(code, () => _il.Emit(OpCodes.Br, loop.ContinueLabel));
+            RouteThroughFinallys(chain, code, _protectedRegionDepth > 0 ? OpCodes.Leave : OpCodes.Br);
+            return;
         }
 
         EmitBranchToLabel(loop.ContinueLabel);
@@ -199,7 +209,7 @@ public partial class GeneratorMoveNextEmitter
                 _il.Emit(OpCodes.Stfld, GetPendingExceptionField());
 
                 RegisterThrowTerminal();
-                RouteThroughFinallys(chain, ExitCodeThrow);
+                RouteThroughFinallys(chain, ExitCodeThrow, OpCodes.Br);
                 return;
             }
         }
@@ -238,7 +248,14 @@ public partial class GeneratorMoveNextEmitter
     /// the innermost finally. The caller must have prepared any value the terminal needs (e.g. the
     /// thrown value, or the Current/return state) beforehand.
     /// </summary>
-    private void RouteThroughFinallys(List<FinallyScope> chain, int code)
+    /// <param name="branch">
+    /// <c>Br</c> when the exit is at the top level, or <c>Leave</c> when it is emitted inside a real IL
+    /// exception block (EmitSimpleTryCatch) nested in the flag-based finally(s): the <c>Leave</c> exits
+    /// that block — running its no-yield finally — straight to the innermost flag cleanup label, then
+    /// the flag machinery runs the remaining (outer) finally(s). A real try never encloses a flag try,
+    /// so every real finally is innermore than every flag one and this ordering is correct (#554).
+    /// </param>
+    private void RouteThroughFinallys(List<FinallyScope> chain, int code, OpCode branch)
     {
         for (int i = 0; i < chain.Count; i++)
         {
@@ -250,7 +267,7 @@ public partial class GeneratorMoveNextEmitter
         _il.Emit(OpCodes.Ldarg_0);
         _il.Emit(OpCodes.Ldc_I4, code);
         _il.Emit(OpCodes.Stfld, GetPendingExitField());
-        _il.Emit(OpCodes.Br, chain[0].CleanupLabel);
+        _il.Emit(branch, chain[0].CleanupLabel);
     }
 
     /// <summary>
@@ -289,6 +306,14 @@ public partial class GeneratorMoveNextEmitter
 
     private void RegisterReturnTerminal() => _exitTerminals.TryAdd(ExitCodeReturn, () =>
     {
+        // Restore the completion value into Current: a yielding finally between the `return` and this
+        // point overwrote Current with its yielded value, so re-load the value stashed at the `return`
+        // (#555). With no yielding finally this is a no-op (Current still holds the same value).
+        _il.Emit(OpCodes.Ldarg_0);
+        _il.Emit(OpCodes.Ldarg_0);
+        _il.Emit(OpCodes.Ldfld, GetPendingReturnValueField());
+        _il.Emit(OpCodes.Stfld, _builder.CurrentField);
+
         // The generator completes. State -2 is re-asserted here because a yielding finally between the
         // `return` and this point overwrote it with the finally's resume state.
         _il.Emit(OpCodes.Ldarg_0);
@@ -334,9 +359,15 @@ public partial class GeneratorMoveNextEmitter
     /// </summary>
     private void EmitSimpleTryCatch(Stmt.TryCatch t)
     {
-        // A real IL protected region is open: a routed `br`/`ret` out of it would be illegal, so
-        // exits emitted inside fall back to their per-path handling (see the exit overrides).
+        // A real IL protected region is open. A `br`/`ret` directly out of it is illegal, so a
+        // non-local exit crossing it must use `Leave` instead — which also runs this (no-yield)
+        // finally. _protectedRegionDepth tells the exit overrides a real block is open (so they pick
+        // `Leave` and, when also inside flag-based finally(s), route out via the innermost flag
+        // cleanup); ExceptionBlockDepth drives the Leave-vs-Br choice in EmitBranchToLabel. The latter
+        // is incremented only here (not in the flag path's sync segments) so internal branches inside
+        // a sync segment stay `Br` and do not illegally leave the mini try/catch.
         _protectedRegionDepth++;
+        _ctx!.ExceptionBlockDepth++;
         _il.BeginExceptionBlock();
 
         foreach (var stmt in t.TryBlock)
@@ -369,6 +400,7 @@ public partial class GeneratorMoveNextEmitter
         }
 
         _il.EndExceptionBlock();
+        _ctx!.ExceptionBlockDepth--;
         _protectedRegionDepth--;
     }
 

--- a/Compilation/GeneratorMoveNextEmitter.Statements.cs
+++ b/Compilation/GeneratorMoveNextEmitter.Statements.cs
@@ -44,29 +44,58 @@ public partial class GeneratorMoveNextEmitter
             _il.Emit(OpCodes.Stfld, _builder.CurrentField);
         }
 
-        // Generator return - set state to completed (the fast path below rets immediately; a routed
-        // return re-asserts this at its terminal, since a yielding finally would overwrite it).
+        // Generator return - set state to completed. The direct `ret` path below returns immediately;
+        // a routed or deferred return re-asserts this at its terminal / landing pad, since a yielding
+        // finally between here and there would overwrite it with the finally's resume state.
         _il.Emit(OpCodes.Ldarg_0);
         _il.Emit(OpCodes.Ldc_I4, -2);
         _il.Emit(OpCodes.Stfld, _builder.StateField);
 
-        // Inside a flag-based try/finally, the enclosing finally(s) must run before the generator
-        // actually completes. Route the return through them instead of `ret` (which is also illegal
-        // here — this return is emitted outside the protected segment, but a finally is emitted after
-        // it). See the exit-routing machinery in GeneratorMoveNextEmitter.Statements.TryCatch.cs.
-        if (_protectedRegionDepth == 0)
+        // A non-local `return` must run any enclosing finally(s) before the generator completes. See
+        // the exit-routing machinery in GeneratorMoveNextEmitter.Statements.TryCatch.cs.
+        var chain = ActiveFinallyFrames();
+        if (chain.Count > 0)
         {
-            var chain = ActiveFinallyFrames();
-            if (chain.Count > 0)
-            {
-                RegisterReturnTerminal();
-                RouteThroughFinallys(chain, ExitCodeReturn);
-                return;
-            }
+            // Flag-based finally(s) are open. Stash the completion value: a finally that yields
+            // overwrites Current with its yielded value, and the return terminal restores it from here
+            // after the finally has run (#555). From inside a real IL block the route uses `Leave`
+            // (running that block's no-yield finally) to reach the innermost flag cleanup label (#554).
+            _il.Emit(OpCodes.Ldarg_0);
+            _il.Emit(OpCodes.Ldarg_0);
+            _il.Emit(OpCodes.Ldfld, _builder.CurrentField);
+            _il.Emit(OpCodes.Stfld, GetPendingReturnValueField());
+
+            RegisterReturnTerminal();
+            RouteThroughFinallys(chain, ExitCodeReturn, _protectedRegionDepth > 0 ? OpCodes.Leave : OpCodes.Br);
+            return;
+        }
+
+        if (_protectedRegionDepth > 0)
+        {
+            // Inside a real IL try/finally with no enclosing flag finally: a bare `ret` here is illegal
+            // (it leaves a protected region). Current/state are set above; `Leave` the deferred-return
+            // landing pad, which runs the enclosing no-yield finally(s) and rets false (#554).
+            _deferredReturnUsed = true;
+            _il.Emit(OpCodes.Leave, _deferredReturnLabel);
+            return;
         }
 
         _il.Emit(OpCodes.Ldc_I4_0);
         _il.Emit(OpCodes.Ret);
+    }
+
+    /// <summary>
+    /// Branch out to <paramref name="target"/>. Inside a real IL exception block a `br` out is illegal,
+    /// so use `Leave` — which exits the block legally and runs its (no-yield) finally. ExceptionBlockDepth
+    /// counts only real blocks (EmitSimpleTryCatch), not the flag-based path's sync segments, so branches
+    /// internal to a sync segment stay `Br` and do not illegally leave the mini try/catch (#554).
+    /// </summary>
+    protected override void EmitBranchToLabel(Label target)
+    {
+        if (_ctx!.ExceptionBlockDepth > 0)
+            _il.Emit(OpCodes.Leave, target);
+        else
+            _il.Emit(OpCodes.Br, target);
     }
 
     // EmitTryCatch lives in GeneratorMoveNextEmitter.Statements.TryCatch.cs — it needs

--- a/Compilation/GeneratorMoveNextEmitter.cs
+++ b/Compilation/GeneratorMoveNextEmitter.cs
@@ -26,6 +26,13 @@ public partial class GeneratorMoveNextEmitter : StatementEmitterBase
     private readonly Dictionary<int, Label> _stateLabels = [];
     private Label _returnFalseLabel;
 
+    // Landing pad for a `return` emitted inside a real IL try/finally (EmitSimpleTryCatch) that has no
+    // enclosing flag-based finally (#554). Such a return cannot `ret` directly, so it sets Current/state
+    // then `Leave`s here — running the enclosing no-yield finally(s) — to perform the actual `ret false`.
+    // Marked only when used; Current already holds the completion value, so it is not reset here.
+    private Label _deferredReturnLabel;
+    private bool _deferredReturnUsed;
+
     // Current yield point being processed
     private int _currentYieldState = 0;
 
@@ -80,6 +87,7 @@ public partial class GeneratorMoveNextEmitter : StatementEmitterBase
             _stateLabels[yieldPoint.StateNumber] = _il.DefineLabel();
         }
         _returnFalseLabel = _il.DefineLabel();
+        _deferredReturnLabel = _il.DefineLabel();
 
         // Check if generator is already completed (state == -2)
         _il.Emit(OpCodes.Ldarg_0);
@@ -112,6 +120,16 @@ public partial class GeneratorMoveNextEmitter : StatementEmitterBase
         _il.Emit(OpCodes.Stfld, _builder.StateField);
         _il.Emit(OpCodes.Ldc_I4_0);
         _il.Emit(OpCodes.Ret);
+
+        // Deferred-return landing pad (#554): a `return` inside a real IL try/finally `Leave`s here
+        // after its enclosing no-yield finally(s) have run. Current and state were already set at the
+        // `return`, so just `ret false`. Marked only if such a return was emitted.
+        if (_deferredReturnUsed)
+        {
+            _il.MarkLabel(_deferredReturnLabel);
+            _il.Emit(OpCodes.Ldc_I4_0);
+            _il.Emit(OpCodes.Ret);
+        }
 
         // Return false label — re-entry on an already-completed generator (state == -2):
         // `gen.next()` called after the generator finished, or after `gen.return(v)`.

--- a/SharpTS.Tests/Compilation/EmitterSyncTests.cs
+++ b/SharpTS.Tests/Compilation/EmitterSyncTests.cs
@@ -110,6 +110,8 @@ public class EmitterSyncTests
             "ExitLoop",             // (so break/continue can find the finallys between them and the loop)
             "get_CurrentLoop",      // Loop lookups read _exitScopes instead of the base loop stack
             "FindLabeledLoop",      // Labeled loop lookups read _exitScopes
+            // --- #554: a non-local exit leaving a real IL try (no yield in it) must Leave, not Br ---
+            "EmitBranchToLabel",    // Leave instead of Br when inside a real IL exception block
         },
         [typeof(AsyncGeneratorMoveNextEmitter)] = new()
         {

--- a/SharpTS.Tests/SharedTests/GeneratorTryFinallyTests.cs
+++ b/SharpTS.Tests/SharedTests/GeneratorTryFinallyTests.cs
@@ -472,6 +472,133 @@ public class GeneratorTryFinallyTests
         Assert.Equal("0\nboom\n", TestHarness.Run(source, mode));
     }
 
+    // ---- #554: return/break/continue inside a NO-yield try (real IL exception block) ----
+    // When no yield crosses the protected region, EmitSimpleTryCatch opens a *real* IL exception
+    // block. A `return`/`break`/`continue` leaving it must therefore use `Leave` (which runs the
+    // finally) rather than an illegal `ret`/`br` — previously these crashed MoveNext with
+    // InvalidProgramException (return → ReturnFromTry, break/continue → BranchOutOfTry).
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void BareReturnInNoYieldTryFinally_RunsFinally(ExecutionMode mode)
+    {
+        // The exact #554 repro: a yield precedes the try, but the try itself contains no yield.
+        var source = """
+            function* g() { yield 0; try { return; } finally { console.log("f"); } }
+            for (const v of g()) console.log(v);
+            """;
+
+        Assert.Equal("0\nf\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ValueReturnInNoYieldTryFinally_RunsFinallyThenCompletesWithValue(ExecutionMode mode)
+    {
+        // The finally runs on the return path, and the returned value is the completion value.
+        var source = """
+            function* g() { yield 0; try { return 7; } finally { console.log("f"); } }
+            const it = g();
+            let r = it.next(); console.log(r.value + "/" + r.done);
+            r = it.next(); console.log(r.value + "/" + r.done);
+            r = it.next(); console.log(r.value + "/" + r.done);
+            """;
+
+        Assert.Equal("0/false\nf\n7/true\nundefined/true\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void BreakInNoYieldTryFinally_RunsFinallyBeforeBreaking(ExecutionMode mode)
+    {
+        // The second #554 repro: break leaves a no-yield try, running its finally first.
+        var source = """
+            function* g() { yield 0; while (true) { try { break; } finally { console.log("f"); } } }
+            for (const v of g()) console.log(v);
+            """;
+
+        Assert.Equal("0\nf\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ContinueInNoYieldTryFinally_RunsFinallyEachIteration(ExecutionMode mode)
+    {
+        // The yield sits outside the try, so the try (holding the continue) takes the real-IL path.
+        var source = """
+            function* g() {
+              for (let i = 0; i < 3; i++) {
+                yield i;
+                try { continue; } finally { console.log("f" + i); }
+              }
+            }
+            for (const v of g()) console.log("v" + v);
+            """;
+
+        Assert.Equal("v0\nf0\nv1\nf1\nv2\nf2\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ReturnInNoYieldTry_NestedInYieldingFinally_RunsAllThenKeepsValue(ExecutionMode mode)
+    {
+        // The inner try has no yield (real IL block); it is nested in an outer try whose finally
+        // yields (flag-based). The inner return must `Leave` the real block — running its no-yield
+        // finally — into the outer flag cleanup, drive the outer yielding finally, then complete with
+        // the returned value (a real try never encloses a flag try, so the finally ordering holds).
+        var source = """
+            function* g() {
+              try {
+                yield 1;
+                try { return 5; } finally { console.log("x"); }
+              } finally { yield 2; }
+            }
+            const it = g();
+            let r = it.next(); console.log(r.value + "/" + r.done);
+            r = it.next(); console.log(r.value + "/" + r.done);
+            r = it.next(); console.log(r.value + "/" + r.done);
+            """;
+
+        Assert.Equal("1/false\nx\n2/false\n5/true\n", TestHarness.Run(source, mode));
+    }
+
+    // ---- #555: a `return <value>` whose finally yields must keep its completion value ----
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ReturnValueWithYieldingFinally_RestoresCompletionValue(ExecutionMode mode)
+    {
+        // The exact #555 repro: the finally yields 9 (overwriting Current), but the final next() must
+        // still report the returned 5 — the value is stashed at the return and restored after the
+        // finally has run. (Compiled previously reported the yielded 9 as the completion value.)
+        var source = """
+            function* g() { try { return 5; } finally { yield 9; } }
+            const it = g();
+            let r = it.next(); console.log(r.value + "/" + r.done);
+            r = it.next(); console.log(r.value + "/" + r.done);
+            r = it.next(); console.log(r.value + "/" + r.done);
+            """;
+
+        Assert.Equal("9/false\n5/true\nundefined/true\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ReturnValueInYieldingTry_NonYieldingFinally_KeepsValue(ExecutionMode mode)
+    {
+        // Sibling of #555: the try yields (flag-based path) and returns a value; the finally does not
+        // yield. The completion value must be the returned 5, not the last yielded value.
+        var source = """
+            function* g() { try { yield 1; return 5; } finally { console.log("f"); } }
+            const it = g();
+            let r = it.next(); console.log(r.value + "/" + r.done);
+            r = it.next(); console.log(r.value + "/" + r.done);
+            r = it.next(); console.log(r.value + "/" + r.done);
+            """;
+
+        Assert.Equal("1/false\nf\n5/true\nundefined/true\n", TestHarness.Run(source, mode));
+    }
+
     // ---- IL-verification guards (the heart of #477: emitted IL must verify) ----
 
     [Theory]
@@ -493,6 +620,19 @@ public class GeneratorTryFinallyTests
     [InlineData("function* g() { outer: for(let i=0;i<2;i++){ for(let j=0;j<2;j++){ try { yield j; break outer; } finally { console.log('f'); } } } } for (const v of g()) {}")]
     [InlineData("function* g() { try { for(let i=0;i<2;i++){ try { yield i; break; } finally { console.log('a'); } } } finally { console.log('b'); } } for (const v of g()) {}")]
     [InlineData("function* g() { while (true) { try { yield 1; break; } finally { yield 2; } } } for (const v of g()) {}")]
+    // #554: return/break/continue inside a NO-yield try (real IL exception block) — must `Leave`, not
+    // `ret`/`br`. The yield lives elsewhere in the body so it is still a generator state machine.
+    [InlineData("function* g() { yield 0; try { return; } finally { console.log('f'); } } for (const v of g()) {}")]
+    [InlineData("function* g() { yield 0; try { return 7; } finally { console.log('f'); } } for (const v of g()) {}")]
+    [InlineData("function* g() { yield 0; while (true) { try { break; } finally { console.log('f'); } } } for (const v of g()) {}")]
+    [InlineData("function* g() { for (let i=0;i<2;i++){ yield i; try { continue; } finally { console.log('f'); } } } for (const v of g()) {}")]
+    [InlineData("function* g() { yield 0; try { return 3; } catch (e) {} } for (const v of g()) {}")]
+    [InlineData("function* g() { yield 0; try { try { return 1; } finally { console.log('a'); } } finally { console.log('b'); } } for (const v of g()) {}")]
+    // #554/#555: a no-yield (real IL) inner try nested in an outer yielding (flag-based) finally.
+    [InlineData("function* g() { try { yield 1; try { return 5; } finally { console.log('x'); } } finally { yield 2; } } for (const v of g()) {}")]
+    [InlineData("function* g() { while (true) { try { yield 1; try { break; } finally { console.log('x'); } } finally { yield 2; } } } for (const v of g()) {}")]
+    // #555: a `return <value>` whose finally yields.
+    [InlineData("function* g() { try { return 5; } finally { yield 9; } } for (const v of g()) {}")]
     public void GeneratorTryFinallyWithYield_EmitsVerifiableIL(string source)
     {
         var errors = TestHarness.CompileAndVerifyOnly(source);


### PR DESCRIPTION
Closes #554. Closes #555.

Both are follow-ups from the #500 compiled-generator try/finally work. Confirmed against the interpreter (correct in both) and via `--verify`.

## #554 — `return`/`break`/`continue` in a no-yield `try` emitted invalid IL

When no `yield` crosses a `try`/`catch`/`finally`, the generator emits a **real** IL exception block (`EmitSimpleTryCatch`). A non-local exit leaving it was emitted as `ret`/`br`, which is illegal out of a protected region → `InvalidProgramException`.

```ts
function* g(){ yield 0; try { return; } finally { console.log("f"); } }
for (const v of g()) console.log(v);   // was: InvalidProgramException; now: 0 / f
```

Fix:
- **break/continue** use `Leave` instead of `Br` inside a real IL block — a new `EmitBranchToLabel` override keyed on `ExceptionBlockDepth` (mirrors `AsyncGeneratorMoveNextEmitter`), and `EmitSimpleTryCatch` now tracks `ExceptionBlockDepth`. `ExceptionBlockDepth` is bumped only for real blocks (not the flag-path sync segments), so branches internal to a sync segment stay `Br`.
- **return** sets `Current`/state then `Leave`s a deferred-return landing pad that runs the enclosing no-yield finally(s) and performs the actual `ret false`.
- When such an exit is **nested inside outer flag-based (yielding) finally(s)**, it `Leave`s to the innermost flag cleanup label and the existing flag machinery runs the rest. This is correct because a real `try` can never enclose a flag `try` (enclosing a `yield` makes it flag-based), so every real finally is innermore than every flag finally — the `Leave`-then-route ordering always holds. `RouteThroughFinallys` gained a branch-opcode parameter (`Leave` vs `Br`) for this.

## #555 — `return <value>` lost when the finally yields

```ts
function* g(){ try { return 5; } finally { yield 9; } }
const it = g();
it.next();   // {value:9, done:false}
it.next();   // was {value:9,done:true}; now {value:5,done:true}
```

The return value lived in `<>2__current`, which the finally's `yield` overwrote. It is now stashed in a dedicated `<>pendingReturnValue` field at the `return` and restored to `Current` in the return terminal, after the finally has run — mirroring how the pending exit code/exception already survive a yielding finally (#500).

## Tests

`GeneratorTryFinallyTests` gains cross-mode (interp + compiled) behavioral tests and IL-verification guards for both bugs, plus the nested simple-inside-flag cases (inner real-IL try returning/breaking through an outer yielding finally, keeping the completion value). Registered the new `EmitBranchToLabel` override in `EmitterSyncTests`' override allowlist.

Full suite: green except 3 pre-existing/environmental reds unrelated to this change — #589 (async-gen labeled break, already tracked) and two live-network DNS smoke tests (empty output, no network in sandbox). Verified each is also red on the base.

## Follow-ups filed

- #597 — async-generator analog of both bugs (`AsyncGeneratorMoveNextEmitter`: `return` in a no-yield try is invalid IL; return value lost when the finally yields).
- #598 — `return`/`break`/`continue` lexically inside a no-yield `finally` block still emits invalid IL (`LeaveOutOfFinally`) — the finally-side analog; can't `Leave`/`ret`/`br` out of a .NET finally.
- #599 — an exception propagating through a *yielding* finally is lost (`caughtExceptionLocal` doesn't survive the suspension).
