### PR TITLE
Fix #587: async function completing without a return value resolves with undefined

### DIFF
--- a/Compilation/AsyncArrowMoveNextEmitter.Statements.cs
+++ b/Compilation/AsyncArrowMoveNextEmitter.Statements.cs
@@ -6,9 +6,12 @@ public partial class AsyncArrowMoveNextEmitter
 {
     // Statement dispatch is now inherited from StatementEmitterBase
 
-    private void EmitReturnNull()
+    // Falling off the end of a block-bodied async arrow completes with `undefined`, not null
+    // (#587). Explicit returns are handled by EmitReturn; this is only the implicit-completion
+    // fall-through emitted after the body.
+    private void EmitImplicitReturnUndefined()
     {
-        _il.Emit(OpCodes.Ldnull);
+        _il.Emit(OpCodes.Ldsfld, _ctx!.Runtime!.UndefinedInstance);
         EmitSetResult();
         _il.Emit(OpCodes.Leave, _exitLabel);
     }

--- a/Compilation/AsyncArrowMoveNextEmitter.cs
+++ b/Compilation/AsyncArrowMoveNextEmitter.cs
@@ -158,8 +158,8 @@ public partial class AsyncArrowMoveNextEmitter : StatementEmitterBase, IEmitterC
             EmitStatement(stmt);
         }
 
-        // Default return null
-        EmitReturnNull();
+        // Implicit completion: a body that runs off the end resolves with `undefined`.
+        EmitImplicitReturnUndefined();
 
         // Catch block
         _il.BeginCatchBlock(_types.Exception);
@@ -226,7 +226,9 @@ public partial class AsyncArrowMoveNextEmitter : StatementEmitterBase, IEmitterC
         }
         else
         {
-            _il.Emit(OpCodes.Ldnull);
+            // Bare `return;` resolves the promise with `undefined`, not null (#587).
+            // A genuine `return null;` takes the branch above and still resolves with null.
+            _il.Emit(OpCodes.Ldsfld, _ctx!.Runtime!.UndefinedInstance);
         }
         EmitSetResult();
         _il.Emit(OpCodes.Leave, _exitLabel);

--- a/Compilation/AsyncMoveNextEmitter.Statements.ControlFlow.cs
+++ b/Compilation/AsyncMoveNextEmitter.Statements.ControlFlow.cs
@@ -15,6 +15,14 @@ public partial class AsyncMoveNextEmitter
             if (_returnValueLocal != null)
                 _il.Emit(OpCodes.Stloc, _returnValueLocal);
         }
+        else if (_returnValueLocal != null)
+        {
+            // Bare `return;` resolves the promise with `undefined`, not null (#587) — mirrors
+            // the generator GeneratorMoveNextEmitter.EmitReturn else. A genuine `return null;`
+            // takes the branch above and still resolves with null.
+            _il.Emit(OpCodes.Ldsfld, _ctx!.Runtime!.UndefinedInstance);
+            _il.Emit(OpCodes.Stloc, _returnValueLocal);
+        }
 
         // If we're inside a try with finally-with-awaits, set pending return flag
         // and jump to after-finally label (which will then complete the return)

--- a/Compilation/AsyncMoveNextEmitter.cs
+++ b/Compilation/AsyncMoveNextEmitter.cs
@@ -212,6 +212,16 @@ public partial class AsyncMoveNextEmitter : StatementEmitterBase, IEmitterContex
             EmitStatement(stmt);
         }
 
+        // Falling off the end of the body completes the async function with `undefined`,
+        // not null (#587) — the default-null _returnValueLocal would otherwise resolve the
+        // promise with null. Explicit `return` statements Leave straight to _setResultLabel
+        // and never reach this fall-through, so this only sets the implicit-completion value.
+        if (_returnValueLocal != null)
+        {
+            _il.Emit(OpCodes.Ldsfld, _ctx!.Runtime!.UndefinedInstance);
+            _il.Emit(OpCodes.Stloc, _returnValueLocal);
+        }
+
         // Jump to set result
         _il.Emit(OpCodes.Br, _setResultLabel);
 

--- a/Execution/Interpreter.Async.cs
+++ b/Execution/Interpreter.Async.cs
@@ -479,9 +479,10 @@ public partial class Interpreter
 
     internal async ValueTask<ExecutionResult> ExecuteReturnAsyncVT(Stmt.Return returnStmt)
     {
-        object? returnValue = null;
-        if (returnStmt.Value != null) returnValue = (await EvaluateAsync(returnStmt.Value)).ToObject();
-        return ExecutionResult.Return(returnValue);
+        // Bare `return;` completes with `undefined`, not null — see VisitReturn (#480).
+        if (returnStmt.Value == null)
+            return ExecutionResult.Return(RuntimeValue.Undefined);
+        return ExecutionResult.Return((await EvaluateAsync(returnStmt.Value)).ToObject());
     }
 
     internal async ValueTask<ExecutionResult> ExecutePrintAsyncVT(Stmt.Print printStmt)

--- a/Runtime/Types/SharpTSAsyncFunction.cs
+++ b/Runtime/Types/SharpTSAsyncFunction.cs
@@ -96,7 +96,11 @@ public class SharpTSAsyncFunction : ISharpTSAsyncCallable
             throw ThrowException.FromResult(result.Value.ToObject());
         }
 
-        return null;
+        // Falling off the end of the body completes the async function with `undefined`, not
+        // null (#587). A bare `return;` and `return <expr>` both take the ResultType.Return
+        // path above (ExecuteReturnAsyncVT maps a value-less return to the undefined sentinel),
+        // so `return null;` still resolves with null and `return;` with undefined.
+        return SharpTSUndefined.Instance;
     }
 
     public SharpTSAsyncFunction Bind(SharpTSInstance instance)
@@ -230,7 +234,10 @@ public class SharpTSAsyncArrowFunction : ISharpTSAsyncCallable
             }
         }
 
-        return null;
+        // A block-bodied async arrow that runs off the end completes with `undefined`, not null
+        // (#587). Bare/expression returns take the ResultType.Return path above; expression-
+        // bodied arrows always return their value above, so this is the off-the-end default.
+        return SharpTSUndefined.Instance;
     }
 
     public SharpTSAsyncArrowFunction Bind(object thisObject)

--- a/SharpTS.Tests/SharedTests/AsyncFunctionReturnValueTests.cs
+++ b/SharpTS.Tests/SharedTests/AsyncFunctionReturnValueTests.cs
@@ -1,0 +1,197 @@
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests;
+
+/// <summary>
+/// An async (non-generator) function that completes without an explicit <c>return &lt;expr&gt;</c>
+/// — a bare <c>return;</c> or falling off the end of the body — resolves its promise with
+/// <c>undefined</c>, per ECMA-262, not <c>null</c> (#587). A genuine <c>return null;</c> must
+/// still resolve with <c>null</c>. These run cross-mode (interpreter + compiled).
+/// </summary>
+public class AsyncFunctionReturnValueTests
+{
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AsyncFunction_BareReturn_ResolvesUndefined(ExecutionMode mode)
+    {
+        var source = """
+            async function f() { return; }
+            async function main() {
+                const v = await f();
+                console.log(typeof v);
+                console.log(v === undefined);
+            }
+            main();
+            """;
+
+        Assert.Equal("undefined\ntrue\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AsyncFunction_OffEnd_ResolvesUndefined(ExecutionMode mode)
+    {
+        var source = """
+            async function f() {}
+            async function main() {
+                const v = await f();
+                console.log(typeof v);
+                console.log(v === undefined);
+            }
+            main();
+            """;
+
+        Assert.Equal("undefined\ntrue\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AsyncArrow_BareReturn_ResolvesUndefined(ExecutionMode mode)
+    {
+        var source = """
+            const f = async () => { return; };
+            async function main() {
+                const v = await f();
+                console.log(typeof v);
+            }
+            main();
+            """;
+
+        Assert.Equal("undefined\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AsyncArrow_OffEnd_ResolvesUndefined(ExecutionMode mode)
+    {
+        var source = """
+            const f = async () => {};
+            async function main() {
+                const v = await f();
+                console.log(typeof v);
+            }
+            main();
+            """;
+
+        Assert.Equal("undefined\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AsyncFunction_ReturnNull_ResolvesNull(ExecutionMode mode)
+    {
+        // Care-case: an explicit `return null;` must keep resolving with null, not undefined.
+        // Null-ness is asserted via typeof/String/=== null (all correct cross-mode). We avoid
+        // `v === undefined` here because the compiled await-unwrap mis-compares an awaited null
+        // as `=== undefined` (pre-existing, tracked by #600) — orthogonal to this completion fix.
+        var source = """
+            async function f() { return null; }
+            async function main() {
+                const v = await f();
+                console.log(typeof v);
+                console.log(String(v));
+                console.log(v === null);
+            }
+            main();
+            """;
+
+        Assert.Equal("object\nnull\ntrue\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AsyncFunction_ReturnValue_Preserved(ExecutionMode mode)
+    {
+        var source = """
+            async function f() { return 42; }
+            async function main() {
+                const v = await f();
+                console.log(v);
+            }
+            main();
+            """;
+
+        Assert.Equal("42\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AsyncMethod_OffEnd_ResolvesUndefined(ExecutionMode mode)
+    {
+        var source = """
+            class C {
+                async m() { return; }
+                async mOff() {}
+                static async s() {}
+            }
+            async function main() {
+                const c = new C();
+                console.log(typeof (await c.m()));
+                console.log(typeof (await c.mOff()));
+                console.log(typeof (await C.s()));
+            }
+            main();
+            """;
+
+        Assert.Equal("undefined\nundefined\nundefined\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AsyncFunction_AwaitThenOffEnd_ResolvesUndefined(ExecutionMode mode)
+    {
+        // The implicit-completion value must be undefined even when the body suspends on an
+        // await first: the fall-through after the resumed body still completes with undefined.
+        var source = """
+            async function delay(): Promise<number> { return 1; }
+            async function f() { await delay(); }
+            async function main() {
+                const v = await f();
+                console.log(typeof v);
+            }
+            main();
+            """;
+
+        Assert.Equal("undefined\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AsyncFunction_BareReturnInTryWithAwaitFinally_ResolvesUndefined(ExecutionMode mode)
+    {
+        // A bare `return;` inside a try whose finally awaits routes through the pending-return
+        // path; the deferred completion must still resolve with undefined.
+        var source = """
+            async function delay(): Promise<number> { return 1; }
+            async function f() {
+                try { return; } finally { await delay(); }
+            }
+            async function main() {
+                const v = await f();
+                console.log(typeof v);
+            }
+            main();
+            """;
+
+        Assert.Equal("undefined\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AsyncFunction_AwaitOfUndefinedResolving_YieldsUndefined(ExecutionMode mode)
+    {
+        // Awaiting an async function that resolves with the implicit undefined must observe
+        // undefined at the await site, confirming the sentinel propagates through await.
+        var source = """
+            async function f() {}
+            async function main() {
+                const v = await f();
+                console.log(v === undefined ? "undefined" : "other");
+            }
+            main();
+            """;
+
+        Assert.Equal("undefined\n", TestHarness.Run(source, mode));
+    }
+}


### PR DESCRIPTION
## Summary

Closes #587. An async (non-generator) function that completes without an explicit `return <expr>` — a bare `return;` or falling off the end of the body — must resolve its promise with **`undefined`** (ECMA-262), not **`null`**. Several async-completion paths conflated the two by producing C# null. A genuine `return null;` must still resolve with `null`, and is preserved.

This is the async-function analog of #480 (interpreter completion) and #563 (compiled plain-function completion); both are on an unmerged branch, so this PR is **self-contained on origin/main** and fully fixes the async repro in both modes.

## Status (repro from the issue, all now ✓ in both modes)

| case | before (interp / compiled) | after |
|---|---|---|
| `async function f() { return; }` | undefined / **null** | undefined / undefined |
| `async function f() {}` (off-end) | **null** / **null** | undefined / undefined |
| `const f = async () => { return; }` | undefined / **null** | undefined / undefined |
| `const f = async () => {}` (off-end) | **null** / **null** | undefined / undefined |
| `async function f() { return null; }` | null / null | null / null (preserved) |

Also covers compiled async **instance/static methods** (same state-machine emitter).

## Changes

**Interpreter**
- `ExecuteReturnAsyncVT`: a value-less `return;` completes with the undefined sentinel. This is the async-path slice of #480, written **byte-identical** to that branch so the two merge cleanly regardless of order.
- `SharpTSAsyncFunction` / `SharpTSAsyncArrowFunction` `CallAsync`: the off-the-end default (body completes with no `ResultType.Return`) returns the undefined sentinel instead of null.

**Compiled** (`AsyncMoveNextEmitter`, `AsyncArrowMoveNextEmitter`)
- `EmitReturn`: a bare `return;` stores the `$Undefined` sentinel into the result slot (mirrors `GeneratorMoveNextEmitter.EmitReturn`'s else). `return null;` keeps null.
- Off-the-end fall-through stores `$Undefined` before completing, instead of leaving the result local at its default null. Explicit returns `Leave` straight to the result label and never reach the fall-through, so only the implicit-completion value is affected.

## Testing

- New cross-mode `AsyncFunctionReturnValueTests` (10 methods × 2 modes): bare-return, off-end, async arrow (both), async instance/static methods, await-then-off-end, and a bare `return;` inside a `try` whose `finally` awaits (the pending-return + awaiting-finally path), plus `return null;`/`return <value>;` care-cases.
- Full suite green: **12100 passed, 0 failed**. `--verify` IL verification passes.

## Follow-up filed

- **#600** — pre-existing compiled bug: awaiting a *null*-resolved promise yields a value that compares `=== undefined` as true, though `.then` receives it correctly. Out of scope here; the `return null;` care-case asserts null-ness via `typeof`/`String`/`=== null` to avoid that path.