### PR TITLE
Fix #588: compiled class method/accessor off-end completion yields undefined

### DIFF
--- a/Compilation/ILCompiler.Classes.Accessors.cs
+++ b/Compilation/ILCompiler.Classes.Accessors.cs
@@ -247,8 +247,11 @@ public partial class ILCompiler
         }
         else
         {
-            // Default return null
-            il.Emit(OpCodes.Ldnull);
+            // A getter that falls off the end completes with `undefined` (ECMA-262).
+            // Route through EmitDefaultReturnValue so the `object` slot materializes the
+            // `$Undefined` sentinel instead of CLR null. Setters also return `object`
+            // here (their value is discarded by callers), so this is correct for both. (#588)
+            EmitDefaultReturnValue(il, methodBuilder.ReturnType);
             il.Emit(OpCodes.Ret);
         }
     }

--- a/Compilation/ILCompiler.Classes.ClassExpressions.cs
+++ b/Compilation/ILCompiler.Classes.ClassExpressions.cs
@@ -837,7 +837,10 @@ public partial class ILCompiler
         }
         else
         {
-            il.Emit(OpCodes.Ldnull);
+            // Falling off the end completes with `undefined` (ECMA-262). Route through
+            // EmitDefaultReturnValue so an `object` slot materializes the `$Undefined`
+            // sentinel instead of CLR null. (#588)
+            EmitDefaultReturnValue(il, methodBuilder.ReturnType);
             il.Emit(OpCodes.Ret);
         }
     }
@@ -887,7 +890,10 @@ public partial class ILCompiler
         }
         else
         {
-            il.Emit(OpCodes.Ldnull);
+            // Falling off the end completes with `undefined` (ECMA-262). Route through
+            // EmitDefaultReturnValue so an `object` slot materializes the `$Undefined`
+            // sentinel instead of CLR null. (#588)
+            EmitDefaultReturnValue(il, methodBuilder.ReturnType);
             il.Emit(OpCodes.Ret);
         }
     }
@@ -932,7 +938,9 @@ public partial class ILCompiler
                 emitter.FinalizeReturns();
             else
             {
-                il.Emit(OpCodes.Ldnull);
+                // Falling off the end completes with `undefined` (ECMA-262); the slot is
+                // `object`, so emit the `$Undefined` sentinel instead of CLR null. (#588)
+                EmitDefaultReturnValue(il, methodBuilder.ReturnType);
                 il.Emit(OpCodes.Ret);
             }
         }
@@ -976,7 +984,10 @@ public partial class ILCompiler
         }
         else
         {
-            il.Emit(OpCodes.Ldnull);
+            // Falling off the end completes with `undefined` (ECMA-262). Route through
+            // EmitDefaultReturnValue so an `object` slot materializes the `$Undefined`
+            // sentinel instead of CLR null. (#588)
+            EmitDefaultReturnValue(il, methodBuilder.ReturnType);
             il.Emit(OpCodes.Ret);
         }
     }

--- a/Compilation/ILCompiler.Classes.Methods.cs
+++ b/Compilation/ILCompiler.Classes.Methods.cs
@@ -831,7 +831,12 @@ public partial class ILCompiler
         }
         else
         {
-            il.Emit(OpCodes.Ldnull);
+            // ECMA-262: a method that completes without an explicit `return <expr>`
+            // (here, falling off the end) has completion value `undefined`. Route
+            // through EmitDefaultReturnValue so an `object` slot materializes the
+            // `$Undefined` sentinel (not CLR null); typed/void slots keep their
+            // correct defaults. (#588)
+            EmitDefaultReturnValue(il, methodBuilder.ReturnType);
             il.Emit(OpCodes.Ret);
         }
     }
@@ -1092,9 +1097,11 @@ public partial class ILCompiler
         if (hasLock && prevReentrancyLocal != null && lockTakenLocal != null &&
             syncLockField != null && reentrancyField != null)
         {
-            // Store default return value if no explicit return was emitted
-            // ReturnValueLocal is guaranteed non-null here (set up earlier in hasLock block)
-            il.Emit(OpCodes.Ldnull);
+            // Store the implicit completion value if no explicit return was emitted.
+            // ReturnValueLocal is guaranteed non-null here (set up earlier in hasLock
+            // block) and is always typed `object`, so the default is the `$Undefined`
+            // sentinel — a method falling off the end completes with `undefined`. (#588)
+            EmitDefaultReturnValue(il, ctx.ReturnValueLocal!.LocalType);
             il.Emit(OpCodes.Stloc, ctx.ReturnValueLocal!);
             ctx.ILBuilder.Emit_Leave(ctx.ReturnLabel);
 
@@ -1136,8 +1143,10 @@ public partial class ILCompiler
         }
         else
         {
-            // Default return null
-            il.Emit(OpCodes.Ldnull);
+            // Falling off the end completes with `undefined` (ECMA-262). Route through
+            // EmitDefaultReturnValue so an `object` slot materializes the `$Undefined`
+            // sentinel instead of CLR null. (#588)
+            EmitDefaultReturnValue(il, methodBuilder.ReturnType);
             il.Emit(OpCodes.Ret);
         }
 

--- a/Compilation/ILCompiler.Classes.Static.cs
+++ b/Compilation/ILCompiler.Classes.Static.cs
@@ -443,9 +443,11 @@ public partial class ILCompiler
         if (hasLock && prevReentrancyLocal != null && lockTakenLocal != null &&
             staticSyncLockField != null && staticReentrancyField != null)
         {
-            // Store default return value if no explicit return was emitted
-            // ReturnValueLocal is guaranteed non-null here (set up earlier in hasLock block)
-            il.Emit(OpCodes.Ldnull);
+            // Store the implicit completion value if no explicit return was emitted.
+            // ReturnValueLocal is guaranteed non-null here (set up earlier in hasLock
+            // block) and is always typed `object`, so the default is the `$Undefined`
+            // sentinel — a method falling off the end completes with `undefined`. (#588)
+            EmitDefaultReturnValue(il, ctx.ReturnValueLocal!.LocalType);
             il.Emit(OpCodes.Stloc, ctx.ReturnValueLocal!);
             ctx.ILBuilder.Emit_Leave(ctx.ReturnLabel);
 
@@ -485,8 +487,10 @@ public partial class ILCompiler
         }
         else
         {
-            // Default return null
-            il.Emit(OpCodes.Ldnull);
+            // Falling off the end completes with `undefined` (ECMA-262). Route through
+            // EmitDefaultReturnValue so an `object` slot materializes the `$Undefined`
+            // sentinel instead of CLR null. (#588)
+            EmitDefaultReturnValue(il, methodBuilder.ReturnType);
             il.Emit(OpCodes.Ret);
         }
     }

--- a/SharpTS.Tests/SharedTests/MethodCompletionValueTests.cs
+++ b/SharpTS.Tests/SharedTests/MethodCompletionValueTests.cs
@@ -1,0 +1,315 @@
+using SharpTS.Parsing;
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests;
+
+/// <summary>
+/// Regression tests for #588: a compiled class method/accessor that completes by
+/// <b>falling off the end</b> of its body (no explicit <c>return &lt;expr&gt;</c>) must
+/// produce the JavaScript <c>undefined</c> sentinel, not CLR <c>null</c>.
+///
+/// <para>Before the fix the method epilogue hard-coded <c>ldnull</c> for the implicit
+/// completion value (so <c>typeof new C().inst()</c> was <c>"object"</c> instead of
+/// <c>"undefined"</c>). The fix routes every class method/accessor epilogue — instance,
+/// static, private, getter/setter, the <c>@lock</c> deferred-return default, and the
+/// class-<i>expression</i> equivalents — through <c>EmitDefaultReturnValue</c>, which
+/// materializes <c>$Undefined</c> for an <c>object</c> slot while preserving the correct
+/// default for typed/void slots. An explicit <c>return null</c> / <c>return &lt;value&gt;</c>
+/// goes through <c>EmitReturn</c> (untouched) and is asserted to be preserved.</para>
+///
+/// <para>Public instance/static methods are invoked through the interpreter's boxing-free
+/// <c>CallV2</c> path, which is already spec-correct, so those cases assert cross-mode
+/// parity. Getters and private methods are invoked through the interpreter's legacy boxed
+/// <c>Call</c> path, which still returns <c>null</c> off the end (a separate, pre-existing
+/// gap tracked by #603); those cases are therefore compiled-only here.</para>
+/// </summary>
+public class MethodCompletionValueTests
+{
+    // ---- Off-the-end instance / static methods (the issue's primary repro) ----
+    // The interpreter is already correct (CallV2), so these assert cross-mode parity.
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void OffEndInstanceMethod_IsUndefined(ExecutionMode mode)
+    {
+        var source = """
+            class C { inst() {} }
+            console.log(typeof new C().inst());
+            """;
+        Assert.Equal("undefined\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void OffEndStaticMethod_IsUndefined(ExecutionMode mode)
+    {
+        var source = """
+            class C { static stat() {} }
+            console.log(typeof C.stat());
+            """;
+        Assert.Equal("undefined\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void OffEndInstanceMethod_StrictlyEqualsUndefined(ExecutionMode mode)
+    {
+        var source = """
+            class C { inst() {} }
+            console.log(new C().inst() === undefined);
+            """;
+        Assert.Equal("true\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void OffEndInstanceMethod_InArithmetic_IsNaN(ExecutionMode mode)
+    {
+        // undefined + 10 === NaN, but null + 10 === 10 — this distinguishes the
+        // undefined sentinel from CLR null beyond the typeof check.
+        var source = """
+            class C { inst() {} }
+            console.log(new C().inst() + 10);
+            """;
+        Assert.Equal("NaN\n", TestHarness.Run(source, mode));
+    }
+
+    // A method that reaches the epilogue after a conditional branch (real body, still
+    // falls off the end on the taken path) — exercises the epilogue, not a bare return.
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void MethodFallingOffEndAfterBranch_IsUndefined(ExecutionMode mode)
+    {
+        var source = """
+            class C {
+                m(x: number) { if (x > 100) { return "big"; } }
+            }
+            console.log(typeof new C().m(1));
+            """;
+        Assert.Equal("undefined\n", TestHarness.Run(source, mode));
+    }
+
+    // ---- Class-expression methods (separate emit path) ----
+    // Interpreter invokes these via CallV2 too, so cross-mode parity holds.
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void OffEndClassExpressionInstanceMethod_IsUndefined(ExecutionMode mode)
+    {
+        var source = """
+            const C = class { ie() {} };
+            console.log(typeof new C().ie());
+            """;
+        Assert.Equal("undefined\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void OffEndClassExpressionStaticMethod_IsUndefined(ExecutionMode mode)
+    {
+        var source = """
+            const C = class { static se() {} };
+            console.log(typeof C.se());
+            """;
+        Assert.Equal("undefined\n", TestHarness.Run(source, mode));
+    }
+
+    // ---- Regression: explicit returns must NOT be rewritten to undefined ----
+    // These go through EmitReturn (untouched by the fix); asserts cross-mode parity.
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ExplicitReturnNull_StaysNull(ExecutionMode mode)
+    {
+        // `return null` is observably distinct from `undefined` — it must be preserved.
+        var source = """
+            class C { f() { return null; } }
+            console.log(typeof new C().f());
+            console.log(new C().f() === null);
+            """;
+        Assert.Equal("object\ntrue\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ExplicitReturnValue_IsPreserved(ExecutionMode mode)
+    {
+        var source = """
+            class C {
+                f() { return 5; }
+                g(): number { return 7; }
+                static s() { return "hi"; }
+            }
+            console.log(new C().f());
+            console.log(new C().g());
+            console.log(C.s());
+            """;
+        Assert.Equal("5\n7\nhi\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void BranchedExplicitReturns_StillWork(ExecutionMode mode)
+    {
+        var source = """
+            class C {
+                pick(x: number) {
+                    if (x > 0) { return "pos"; }
+                    return "nonpos";
+                }
+            }
+            const c = new C();
+            console.log(c.pick(1) + "," + c.pick(-1));
+            """;
+        Assert.Equal("pos,nonpos\n", TestHarness.Run(source, mode));
+    }
+
+    // ---- Regression: setter with an off-the-end body still applies its effect ----
+    // The setter's CLR return value is discarded; the assignment side effect and the
+    // value of the assignment expression (the RHS, per JS) must be unaffected.
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void SetterOffEnd_StillAppliesEffect(ExecutionMode mode)
+    {
+        var source = """
+            class C {
+                _v: number = 0;
+                set v(n: number) { this._v = n; }
+                get v(): number { return this._v; }
+            }
+            const c = new C();
+            const assigned = (c.v = 42);
+            console.log(c.v + "," + assigned);
+            """;
+        Assert.Equal("42,42\n", TestHarness.Run(source, mode));
+    }
+
+    // ---- Compiled-only: getters & private methods ----
+    // The interpreter invokes these through the legacy boxed `Call`, which still returns
+    // null off the end (pre-existing gap #603). After #588 the compiled output is correct,
+    // so these assert the compiled behavior; the interpreter side is tracked by #603.
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    public void OffEndGetter_IsUndefined_Compiled(ExecutionMode mode)
+    {
+        var source = """
+            class C { get gv() {} }
+            console.log(typeof new C().gv);
+            """;
+        Assert.Equal("undefined\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    public void OffEndStaticGetter_IsUndefined_Compiled(ExecutionMode mode)
+    {
+        var source = """
+            class C { static get gv() {} }
+            console.log(typeof C.gv);
+            """;
+        Assert.Equal("undefined\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    public void GetterFallingOffEndAfterBranch_IsUndefined_Compiled(ExecutionMode mode)
+    {
+        var source = """
+            class C {
+                _f: boolean = false;
+                get v() { if (this._f) { return 1; } }
+            }
+            console.log(typeof new C().v);
+            """;
+        Assert.Equal("undefined\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    public void OffEndPrivateMethod_IsUndefined_Compiled(ExecutionMode mode)
+    {
+        var source = """
+            class C {
+                #secret() {}
+                call() { return this.#secret(); }
+            }
+            console.log(typeof new C().call());
+            """;
+        Assert.Equal("undefined\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    public void OffEndPrivateStaticMethod_IsUndefined_Compiled(ExecutionMode mode)
+    {
+        var source = """
+            class C {
+                static #ssecret() {}
+                static call() { return C.#ssecret(); }
+            }
+            console.log(typeof C.call());
+            """;
+        Assert.Equal("undefined\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    public void OffEndClassExpressionGetter_IsUndefined_Compiled(ExecutionMode mode)
+    {
+        var source = """
+            const C = class { get ev() {} };
+            console.log(typeof new C().ev);
+            """;
+        Assert.Equal("undefined\n", TestHarness.Run(source, mode));
+    }
+
+    // ---- @lock decorator: the deferred-return default ----
+    // The @lock try/finally stores an implicit completion value into an object-typed
+    // local before running the unlock finally; that default was `ldnull` and is now the
+    // `$Undefined` sentinel. @lock is a compiled-mode code path (Stage3 decorators).
+
+    [Fact]
+    public void LockedInstanceMethodOffEnd_IsUndefined()
+    {
+        var source = """
+            class C {
+                @lock
+                run(): void {}
+            }
+            console.log(typeof new C().run());
+            """;
+        Assert.Equal("undefined\n", TestHarness.RunCompiled(source, DecoratorMode.Stage3));
+    }
+
+    [Fact]
+    public void LockedStaticMethodOffEnd_IsUndefined()
+    {
+        var source = """
+            class C {
+                @lock
+                static run(): void {}
+            }
+            console.log(typeof C.run());
+            """;
+        Assert.Equal("undefined\n", TestHarness.RunCompiled(source, DecoratorMode.Stage3));
+    }
+
+    [Fact]
+    public void LockedMethodWithExplicitReturn_IsPreserved()
+    {
+        // Regression: the @lock deferred-return must still surface an explicit value.
+        var source = """
+            class C {
+                total: number = 0;
+                @lock
+                add(n: number): number { this.total = this.total + n; return this.total; }
+            }
+            const c = new C();
+            console.log(c.add(5) + "," + c.add(10));
+            """;
+        Assert.Equal("5,15\n", TestHarness.RunCompiled(source, DecoratorMode.Stage3));
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #588. In **compiled mode**, a class instance/static method that falls **off the end** of its body (no explicit `return <expr>`) yielded CLR **`null`** instead of the JS **`undefined`** sentinel. Per ECMA-262 a function that returns no value completes with `undefined`. The interpreter is already correct for public methods (the boxing-free `CallV2` path).

The method/accessor epilogues hard-coded `ldnull` for the implicit off-the-end completion value. This routes every class method/accessor epilogue through `EmitDefaultReturnValue` — the same helper plain functions already use — which materializes `$Undefined` for an `object` slot, preserves `null` for typed reference slots, and emits the correct default for value/`void` slots.

## Repro

```ts
class C {
  inst() {}
  static stat() {}
}
const c = new C();
console.log("inst:" + typeof c.inst());  // node: undefined  (was: object)
console.log("stat:" + typeof C.stat());  // node: undefined  (was: object)
```

`--compile … --verify` passes.

## Sites fixed (10)

| File | Site |
|---|---|
| `ILCompiler.Classes.Methods.cs` | instance-method epilogue, `@lock` deferred-return default, private-method epilogue |
| `ILCompiler.Classes.Static.cs` | static-method epilogue, `@lock` deferred-return default |
| `ILCompiler.Classes.Accessors.cs` | getter/setter epilogue (instance + static) |
| `ILCompiler.Classes.ClassExpressions.cs` | instance-method, static-method, symbol-accessor, and accessor epilogues |

The `@lock` deferred-return local is always typed `object`, so it stores the `$Undefined` sentinel; the value-typed/void cases are handled by `EmitDefaultReturnValue`. The issue listed three approximate sites; the same bug (and identical fix) existed in the accessor and class-expression epilogues, so all were corrected for consistency.

## Not changed (correctly out of scope)

- **Explicit `return null` / `return <expr>`** flow through `EmitReturn` (untouched) and are preserved — covered by regression tests.
- **Bare `return;`** in a method goes through `EmitReturn`; that path is the compiled half of #563 and is unchanged here. (Note: #588's description assumed #563 had already landed; on `main` a bare `return;` in a method still yields `null`. This PR deliberately scopes to the off-the-end epilogue only.)
- **Async/generator methods** are unaffected (their completion is handled by the state machine).

## New gap filed

While fixing this I found that **off-the-end getters and private methods are still `null` in the interpreter** — they invoke through the legacy boxed `Call` (`SharpTSFunction.Call` returns `null` off the end, vs `CallV2` which correctly returns `undefined`). That path is shared retiring plumbing used pervasively for accessor invocation, so fixing it is a separate change with its own blast radius. Filed as #603. The getter/private-method tests here are therefore compiled-only.

## Tests

New `MethodCompletionValueTests` (31 cases):
- Cross-mode parity for off-end instance/static methods (incl. class expressions), `=== undefined`, and `undefined + 10 === NaN` discriminators.
- Compiled-only for getters, static getters, private (instance + static) methods, class-expression getters, and a getter that falls off the end after a branch.
- `@lock` instance/static off-end → `undefined`, plus a `@lock` explicit-return regression.
- Regressions: explicit `return null` stays `null`, explicit/typed returns preserved, branched returns work, setter side effect intact.

Full suite: **12110 passed**, 0 regressions (the one failure in the run was the known-flaky `Process_Uptime_IncreasesOverTime` timing test, which passes on retry).