### PR TITLE
Fix #541: compiled generators capture closure variables by reference

### DIFF
--- a/Compilation/ExpressionEmitterBase.cs
+++ b/Compilation/ExpressionEmitterBase.cs
@@ -1539,6 +1539,24 @@ public abstract partial class ExpressionEmitterBase : IEmitterContext
             return true;
         }
 
+        // A captured top-level variable (a real let/const/var binding closed over by this
+        // body) must be resolved BEFORE Functions: a variable binding in scope shadows a
+        // same-named top-level function from another module. The EntryPointDisplayClassFields
+        // guard means only genuine variable bindings stored on the display class match here;
+        // function references aren't in that map and correctly fall through to Functions below.
+        // Without this ordering, a generator capturing e.g. `const composeDoc = require(...)`
+        // whose name collides with a cross-module `composeDoc` function resolved to the
+        // function and threw "object is not a function" (#541).
+        if (Ctx.CapturedTopLevelVars?.Contains(name) == true &&
+            Ctx.EntryPointDisplayClassFields?.TryGetValue(name, out var capturedEntryField) == true &&
+            Ctx.EntryPointDisplayClassStaticField != null)
+        {
+            IL.Emit(OpCodes.Ldsfld, Ctx.EntryPointDisplayClassStaticField);
+            IL.Emit(OpCodes.Ldfld, capturedEntryField);
+            SetStackUnknown();
+            return true;
+        }
+
         if (Ctx.Functions.TryGetValue(Ctx.ResolveFunctionName(name), out var funcMethod))
         {
             // Stage 6r: route through GetOrCreate (MethodInfo-keyed instance cache)
@@ -1573,16 +1591,6 @@ public abstract partial class ExpressionEmitterBase : IEmitterContext
         if (Ctx.NamespaceFields?.TryGetValue(name, out var nsField) == true)
         {
             IL.Emit(OpCodes.Ldsfld, nsField);
-            SetStackUnknown();
-            return true;
-        }
-
-        if (Ctx.CapturedTopLevelVars?.Contains(name) == true &&
-            Ctx.EntryPointDisplayClassFields?.TryGetValue(name, out var entryPointField) == true &&
-            Ctx.EntryPointDisplayClassStaticField != null)
-        {
-            IL.Emit(OpCodes.Ldsfld, Ctx.EntryPointDisplayClassStaticField);
-            IL.Emit(OpCodes.Ldfld, entryPointField);
             SetStackUnknown();
             return true;
         }

--- a/Compilation/GeneratorStateAnalyzer.cs
+++ b/Compilation/GeneratorStateAnalyzer.cs
@@ -28,7 +28,6 @@ public class GeneratorStateAnalyzer : AstVisitorBase
         HashSet<string> HoistedParameters,
         bool UsesThis,
         bool HasYieldStar,
-        HashSet<string> CapturedVariables,  // Variables from outer scopes that need to be captured
         List<Stmt.ForOf> ForOfLoopsWithYield  // for...of loops containing yields that need enumerator hoisting
     );
 
@@ -37,7 +36,6 @@ public class GeneratorStateAnalyzer : AstVisitorBase
     private readonly HashSet<string> _declaredVariables = [];
     private readonly HashSet<string> _variablesUsedAfterYield = [];
     private readonly HashSet<string> _variablesDeclaredBeforeYield = [];
-    private readonly HashSet<string> _capturedVariables = [];  // Variables from outer scopes
     private readonly List<Stmt.ForOf> _forOfLoopsWithYield = [];  // for...of loops containing yields (enumerator hoisting)
     // Loop bodies currently being analyzed (innermost on top). A loop whose body contains a
     // yield re-executes after the yield resumes, so every local used anywhere in it is live
@@ -93,7 +91,6 @@ public class GeneratorStateAnalyzer : AstVisitorBase
             HoistedParameters: parameters,
             UsesThis: _usesThis,
             HasYieldStar: _hasYieldStar,
-            CapturedVariables: [.. _capturedVariables],
             ForOfLoopsWithYield: [.. _forOfLoopsWithYield]
         );
     }
@@ -104,7 +101,6 @@ public class GeneratorStateAnalyzer : AstVisitorBase
         _declaredVariables.Clear();
         _variablesUsedAfterYield.Clear();
         _variablesDeclaredBeforeYield.Clear();
-        _capturedVariables.Clear();
         _forOfLoopsWithYield.Clear();
         _loopStack.Clear();
         _yieldCounter = 0;
@@ -273,12 +269,6 @@ public class GeneratorStateAnalyzer : AstVisitorBase
     protected override void VisitVariable(Expr.Variable expr)
     {
         var name = expr.Name.Lexeme;
-
-        // Detect outer scope capture - variable not declared in this function
-        if (!_declaredVariables.Contains(name))
-        {
-            _capturedVariables.Add(name);
-        }
 
         // Track variables used in any enclosing loop body (hoisted when the loop contains a yield).
         foreach (var scope in _loopStack)

--- a/Compilation/GeneratorStateMachineBuilder.cs
+++ b/Compilation/GeneratorStateMachineBuilder.cs
@@ -30,10 +30,12 @@ public class GeneratorStateMachineBuilder
     // §27.5.3.3 — `yield expr` evaluates to the argument of the resuming next).
     public FieldBuilder SentField { get; private set; } = null!;
 
-    // Hoisted variables (become struct fields) - delegated to HoistingManager
+    // Hoisted variables (become struct fields) - delegated to HoistingManager.
+    // Captured outer-scope variables are intentionally NOT hoisted: a generator reads them
+    // live from their enclosing storage (entry-point display class / top-level static fields)
+    // in MoveNext, mirroring JS closure semantics and the async-generator path (#541).
     public Dictionary<string, FieldBuilder> HoistedParameters => _hoisting.HoistedParameters;
     public Dictionary<string, FieldBuilder> HoistedLocals => _hoisting.HoistedLocals;
-    public Dictionary<string, FieldBuilder> CapturedVariables => _hoisting.CapturedVariables;
 
     // 'this' field for instance generator methods
     public FieldBuilder? ThisField { get; private set; }
@@ -131,11 +133,14 @@ public class GeneratorStateMachineBuilder
         DefineCurrentField();
         DefineSentField();
 
-        // Define hoisted variables using HoistingManager
+        // Define hoisted variables using HoistingManager.
+        // Captured outer-scope variables are deliberately not hoisted into state-machine
+        // fields: doing so snapshotted their value at generator-creation time, diverging
+        // from JS closure semantics (#541). They are instead read live from their enclosing
+        // storage in MoveNext, the same way the async-generator path already works.
         _hoisting = new HoistingManager(_stateMachineType, _types.Object);
         _hoisting.DefineHoistedParameters(analysis.HoistedParameters);
         _hoisting.DefineHoistedLocals(analysis.HoistedLocals);
-        _hoisting.DefineHoistedCapturedVariables(analysis.CapturedVariables);
         _hoisting.DefineHoistedEnumerators(analysis.ForOfLoopsWithYield, _types.IEnumerator);
 
         // Define 'this' field for instance methods that use 'this'

--- a/Compilation/HoistingManager.cs
+++ b/Compilation/HoistingManager.cs
@@ -27,12 +27,6 @@ public class HoistingManager
     public Dictionary<string, FieldBuilder> HoistedLocals { get; } = [];
 
     /// <summary>
-    /// Variables captured from outer scopes (closures) that need to be copied into
-    /// the state machine.
-    /// </summary>
-    public Dictionary<string, FieldBuilder> CapturedVariables { get; } = [];
-
-    /// <summary>
     /// Enumerators for for...of loops that contain yield statements.
     /// These must be hoisted because the enumerator state persists across yield boundaries.
     /// </summary>
@@ -69,22 +63,9 @@ public class HoistingManager
     }
 
     /// <summary>
-    /// Defines fields for captured outer scope variables.
-    /// Field names use a special prefix to distinguish from local hoisting.
-    /// </summary>
-    public void DefineHoistedCapturedVariables(IEnumerable<string> names)
-    {
-        foreach (var name in names)
-        {
-            // Use <>5__ prefix following C# compiler convention for captured variables
-            var field = _typeBuilder.DefineField($"<>5__{name}", _objectType, FieldAttributes.Public);
-            CapturedVariables[name] = field;
-        }
-    }
-
-    /// <summary>
     /// Gets the field for a hoisted variable, or null if not hoisted.
-    /// Checks parameters, locals, and captured variables.
+    /// Checks parameters and locals. Captured outer-scope variables are deliberately not
+    /// hoisted — state machines read them live from their enclosing storage (#541).
     /// </summary>
     public FieldBuilder? GetVariableField(string name)
     {
@@ -92,27 +73,14 @@ public class HoistingManager
             return paramField;
         if (HoistedLocals.TryGetValue(name, out var localField))
             return localField;
-        if (CapturedVariables.TryGetValue(name, out var capturedField))
-            return capturedField;
         return null;
     }
-
-    /// <summary>
-    /// Gets the field for a captured variable specifically, or null if not captured.
-    /// </summary>
-    public FieldBuilder? GetCapturedVariableField(string name) =>
-        CapturedVariables.TryGetValue(name, out var field) ? field : null;
 
     /// <summary>
     /// Checks if a variable is hoisted.
     /// </summary>
     public bool IsHoisted(string name) =>
-        HoistedParameters.ContainsKey(name) || HoistedLocals.ContainsKey(name) || CapturedVariables.ContainsKey(name);
-
-    /// <summary>
-    /// Checks if a variable is captured from an outer scope.
-    /// </summary>
-    public bool IsCaptured(string name) => CapturedVariables.ContainsKey(name);
+        HoistedParameters.ContainsKey(name) || HoistedLocals.ContainsKey(name);
 
     /// <summary>
     /// Defines fields for hoisted enumerators from for...of loops containing yields.

--- a/Compilation/ILCompiler.Generators.cs
+++ b/Compilation/ILCompiler.Generators.cs
@@ -73,10 +73,9 @@ public partial class ILCompiler
             }
             var funcStmt = _generators.Functions[funcName];
             var methodBuilder = _functions.Builders[funcName];
-            var analysis = _generators.Analyzer.Analyze(funcStmt);
 
             // Emit the stub method body (creates and returns the state machine)
-            EmitGeneratorStubMethod(methodBuilder, smBuilder, funcStmt, analysis);
+            EmitGeneratorStubMethod(methodBuilder, smBuilder, funcStmt);
 
             // Emit the MoveNext method body
             EmitGeneratorMoveNextBody(smBuilder, funcStmt);
@@ -93,8 +92,7 @@ public partial class ILCompiler
     private void EmitGeneratorStubMethod(
         MethodBuilder methodBuilder,
         GeneratorStateMachineBuilder smBuilder,
-        Stmt.Function funcStmt,
-        GeneratorStateAnalyzer.GeneratorFunctionAnalysis analysis)
+        Stmt.Function funcStmt)
     {
         var il = methodBuilder.GetILGenerator();
 
@@ -114,38 +112,11 @@ public partial class ILCompiler
             }
         }
 
-        // Copy captured outer scope variables to state machine fields
-        var moduleCapturedVars = BuildCapturedTopLevelVarsForModule(_modules.CurrentPath);
-        var moduleEntryPointFields = BuildEntryPointDisplayClassFieldsForModule(_modules.CurrentPath);
-        foreach (var capturedVar in analysis.CapturedVariables)
-        {
-            var capturedField = smBuilder.CapturedVariables.GetValueOrDefault(capturedVar);
-            if (capturedField == null) continue;
-
-            // Try to load from entry-point display class (captured top-level variables)
-            if (moduleCapturedVars?.Contains(capturedVar) == true &&
-                moduleEntryPointFields?.TryGetValue(capturedVar, out var entryPointField) == true)
-            {
-                il.Emit(OpCodes.Dup);  // Keep state machine reference on stack
-                if (_closures.EntryPointDisplayClassStaticField != null)
-                {
-                    il.Emit(OpCodes.Ldsfld, _closures.EntryPointDisplayClassStaticField);
-                    il.Emit(OpCodes.Ldfld, entryPointField);
-                }
-                else
-                {
-                    il.Emit(OpCodes.Ldnull);
-                }
-                il.Emit(OpCodes.Stfld, capturedField);
-            }
-            // Try to load from top-level static vars (non-captured module-level variables)
-            else if (_topLevelStaticVars.TryGetValue(capturedVar, out var staticField))
-            {
-                il.Emit(OpCodes.Dup);  // Keep state machine reference on stack
-                il.Emit(OpCodes.Ldsfld, staticField);
-                il.Emit(OpCodes.Stfld, capturedField);
-            }
-        }
+        // Captured outer-scope variables are NOT copied into the state machine here. Doing so
+        // snapshotted their value at creation time, so a later mutation of the outer variable
+        // was invisible to the running body (#541). MoveNext instead reads/writes them live
+        // from their enclosing storage (top-level statics / entry-point display class), which
+        // requires the corresponding fields to be set on the MoveNext CompilationContext below.
 
         // Return the state machine (which implements IEnumerable<object>)
         il.Emit(OpCodes.Ret);
@@ -195,7 +166,14 @@ public partial class ILCompiler
             // Check for function-level "use strict" directive
             IsStrictMode = _isStrictMode || CheckForUseStrict(funcStmt.Body),
             // Registry services
-            ClassRegistry = GetClassRegistry()
+            ClassRegistry = GetClassRegistry(),
+            // Captured outer variables are read live (by reference) rather than snapshotted (#541).
+            // These mirror the async-generator MoveNext context so reads/writes of top-level
+            // variables go straight to their backing storage instead of a stale state-machine field.
+            EntryPointDisplayClassFields = BuildEntryPointDisplayClassFieldsForModule(_modules.CurrentPath),
+            CapturedTopLevelVars = BuildCapturedTopLevelVarsForModule(_modules.CurrentPath),
+            EntryPointDisplayClassStaticField = _closures.EntryPointDisplayClassStaticField,
+            TopLevelStaticVars = BuildTopLevelStaticVarsForModule(_modules.CurrentPath)
         };
 
         // Use the new emitter for full generator body emission
@@ -225,7 +203,7 @@ public partial class ILCompiler
         );
 
         // Emit stub method body (creates state machine and returns it)
-        EmitGeneratorInstanceStubMethod(methodBuilder, smBuilder, method.Parameters, analysis);
+        EmitGeneratorInstanceStubMethod(methodBuilder, smBuilder, method.Parameters);
 
         // Create context for MoveNext emission
         var il = smBuilder.MoveNextMethod.GetILGenerator();
@@ -268,10 +246,12 @@ public partial class ILCompiler
             CurrentClassBuilder = methodBuilder.DeclaringType as TypeBuilder,
             // Registry services
             ClassRegistry = GetClassRegistry(),
-            // Entry-point display class for captured top-level variables
+            // Captured outer variables are read live (by reference), not snapshotted (#541).
+            // TopLevelStaticVars covers module-level vars that aren't in the entry-point display class.
             EntryPointDisplayClassFields = BuildEntryPointDisplayClassFieldsForModule(_modules.CurrentPath),
             CapturedTopLevelVars = BuildCapturedTopLevelVarsForModule(_modules.CurrentPath),
-            EntryPointDisplayClassStaticField = _closures.EntryPointDisplayClassStaticField
+            EntryPointDisplayClassStaticField = _closures.EntryPointDisplayClassStaticField,
+            TopLevelStaticVars = BuildTopLevelStaticVarsForModule(_modules.CurrentPath)
         };
 
         // Emit MoveNext body
@@ -292,8 +272,7 @@ public partial class ILCompiler
     private void EmitGeneratorInstanceStubMethod(
         MethodBuilder methodBuilder,
         GeneratorStateMachineBuilder smBuilder,
-        List<Stmt.Parameter> parameters,
-        GeneratorStateAnalyzer.GeneratorFunctionAnalysis analysis)
+        List<Stmt.Parameter> parameters)
     {
         var il = methodBuilder.GetILGenerator();
 
@@ -336,38 +315,9 @@ public partial class ILCompiler
             }
         }
 
-        // Copy captured outer scope variables to state machine fields
-        var moduleCapturedVars = BuildCapturedTopLevelVarsForModule(_modules.CurrentPath);
-        var moduleEntryPointFields = BuildEntryPointDisplayClassFieldsForModule(_modules.CurrentPath);
-        foreach (var capturedVar in analysis.CapturedVariables)
-        {
-            var capturedField = smBuilder.CapturedVariables.GetValueOrDefault(capturedVar);
-            if (capturedField == null) continue;
-
-            // Try to load from entry-point display class (captured top-level variables)
-            if (moduleCapturedVars?.Contains(capturedVar) == true &&
-                moduleEntryPointFields?.TryGetValue(capturedVar, out var entryPointField) == true)
-            {
-                il.Emit(OpCodes.Dup);  // Keep state machine reference on stack
-                if (_closures.EntryPointDisplayClassStaticField != null)
-                {
-                    il.Emit(OpCodes.Ldsfld, _closures.EntryPointDisplayClassStaticField);
-                    il.Emit(OpCodes.Ldfld, entryPointField);
-                }
-                else
-                {
-                    il.Emit(OpCodes.Ldnull);
-                }
-                il.Emit(OpCodes.Stfld, capturedField);
-            }
-            // Try to load from top-level static vars (non-captured module-level variables)
-            else if (_topLevelStaticVars.TryGetValue(capturedVar, out var staticField))
-            {
-                il.Emit(OpCodes.Dup);  // Keep state machine reference on stack
-                il.Emit(OpCodes.Ldsfld, staticField);
-                il.Emit(OpCodes.Stfld, capturedField);
-            }
-        }
+        // Captured outer-scope variables are NOT copied into the state machine (#541): see the
+        // free-function stub above. MoveNext reads/writes them live from their backing storage,
+        // wired through the CompilationContext in EmitGeneratorMethodBody.
 
         // Return the state machine (which implements IEnumerable<object>)
         il.Emit(OpCodes.Ret);

--- a/SharpTS.Tests/IntegrationTests/CliCommonJsCompiledTests.cs
+++ b/SharpTS.Tests/IntegrationTests/CliCommonJsCompiledTests.cs
@@ -139,6 +139,43 @@ public class CliCommonJsCompiledTests
         Assert.Contains("86400000", output);
     }
 
+    /// <summary>
+    /// Regression for #541: a generator method that captures a <c>require()</c>'d import
+    /// whose binding name collides with a same-named top-level function in ANOTHER module
+    /// must resolve to the import, not the cross-module function. This is the yaml
+    /// composer shape (<c>const composeDoc = require('./compose-doc.js')</c> referenced as
+    /// <c>composeDoc.composeDoc(...)</c> inside <c>*next()</c>).
+    ///
+    /// <para>The captured variable is dropped from the per-module static-var map (captured
+    /// vars live on the entry-point display class), so the generator's live read fell through
+    /// to the global Functions registry and picked up the wrong module's function, throwing
+    /// "object is not a function". A captured variable binding must shadow a cross-module
+    /// function of the same name.</para>
+    /// </summary>
+    [Fact]
+    public void Compiled_Generator_CapturedImportShadowsCrossModuleFunction()
+    {
+        using var tempDir = CliTestHelper.CreateTempDirectory();
+        tempDir.CreateFile("compose-doc.cjs", """
+            function composeDoc(opts, token) { return { v: token }; }
+            module.exports = { composeDoc };
+            """);
+        var entry = tempDir.CreateFile("composer.cjs", """
+            const composeDoc = require("./compose-doc.cjs");
+            class Composer {
+              *next(token) { yield composeDoc.composeDoc(this.opts, token).v; }
+              *compose(tokens) { for (const t of tokens) yield* this.next(t); }
+            }
+            const out = [];
+            for (const v of new Composer().compose([1, 2, 3])) out.push(v);
+            console.log(out.join(","));
+            """);
+
+        var (exit, output) = CompileAndRun(tempDir, entry);
+        Assert.Equal(0, exit);
+        Assert.Contains("1,2,3", output);
+    }
+
     [Fact]
     public void Compiled_CjsFile_CircularRequire_PartialExportsVisible()
     {

--- a/SharpTS.Tests/SharedTests/GeneratorClosureCaptureTests.cs
+++ b/SharpTS.Tests/SharedTests/GeneratorClosureCaptureTests.cs
@@ -1,0 +1,174 @@
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests;
+
+/// <summary>
+/// Generators must capture outer (closure) variables BY REFERENCE — reading their live value
+/// when the body runs — not snapshot the value at generator-creation time. The compiled path
+/// previously copied captured top-level variables into state-machine fields when the stub ran,
+/// diverging from the interpreter and from JS closure semantics (#541).
+/// </summary>
+public class GeneratorClosureCaptureTests
+{
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Generator_CapturesOuterLetByReference_NotSnapshot(ExecutionMode mode)
+    {
+        // The canonical #541 repro: x is mutated after the generator is created but before
+        // the body runs, so next() must observe the new value (42), not the creation-time one.
+        var source = """
+            let x: any = 1;
+            function* g() { yield x; }
+            const it = g();
+            x = 42;
+            console.log(it.next().value);
+            """;
+
+        Assert.Equal("42\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Generator_SelfReferenceResolvesLive(ExecutionMode mode)
+    {
+        // The shape from #521: the generator's own binding is assigned the generator instance
+        // after creation; the body must see the live binding ("generator"), not undefined.
+        var source = """
+            let it: any;
+            function* g() { yield (it === undefined ? "undefined" : "generator"); }
+            it = g();
+            console.log(it.next().value);
+            """;
+
+        Assert.Equal("generator\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Generator_MutationBetweenYieldsIsVisible(ExecutionMode mode)
+    {
+        var source = """
+            let x: any = 10;
+            function* g() { yield x; yield x; }
+            const it = g();
+            const a = it.next().value;
+            x = 20;
+            const b = it.next().value;
+            console.log(a, b);
+            """;
+
+        Assert.Equal("10 20\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Generator_WriteToCapturedVarPropagatesToOuterScope(ExecutionMode mode)
+    {
+        // A write to a captured variable from inside the generator body must update the
+        // enclosing binding (by reference), not a private copy.
+        var source = """
+            let x: any = 1;
+            function* g() { x = 100; yield x; }
+            const it = g();
+            it.next();
+            console.log(x);
+            """;
+
+        Assert.Equal("100\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Generator_IncrementAndCompoundOnCapturedVar(ExecutionMode mode)
+    {
+        var source = """
+            let x: any = 1;
+            function* g() { x++; yield x; x += 10; yield x; }
+            const it = g();
+            const a = it.next().value;
+            const b = it.next().value;
+            console.log(a, b, x);
+            """;
+
+        Assert.Equal("2 12 12\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Generator_InstanceMethodCapturesOuterByReference(ExecutionMode mode)
+    {
+        var source = """
+            let x: any = 1;
+            class K { *g() { yield x; } }
+            const it = new K().g();
+            x = 55;
+            console.log(it.next().value);
+            """;
+
+        Assert.Equal("55\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Generator_CapturedVarInLoopBodyReadLive(ExecutionMode mode)
+    {
+        // Combines by-reference capture with the loop-body hoisting path (#497).
+        var source = """
+            let base_: any = 100;
+            function* g() { for (let i = 0; i < 3; i++) yield base_ + i; }
+            const it = g();
+            base_ = 200;
+            console.log(it.next().value, it.next().value, it.next().value);
+            """;
+
+        Assert.Equal("200 201 202\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Generator_YieldStarDelegateSeesCapturedMutation(ExecutionMode mode)
+    {
+        var source = """
+            let x: any = 1;
+            function* inner() { yield x; yield x; }
+            function* g() { yield* inner(); }
+            const it = g();
+            x = 9;
+            console.log(it.next().value, it.next().value);
+            """;
+
+        Assert.Equal("9 9\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Generator_MultipleInstancesShareCapturedVar(ExecutionMode mode)
+    {
+        var source = """
+            let x: any = 1;
+            function* g() { yield x; }
+            const a = g();
+            const b = g();
+            x = 7;
+            console.log(a.next().value, b.next().value);
+            """;
+
+        Assert.Equal("7 7\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Generator_ReferencesTopLevelFunctionAsValue(ExecutionMode mode)
+    {
+        // Referencing a top-level function as a value inside a generator previously read a
+        // never-populated capture field and threw at runtime in compiled mode.
+        var source = """
+            function helper() { return "H"; }
+            function* g() { const f: any = helper; yield f(); }
+            console.log(g().next().value);
+            """;
+
+        Assert.Equal("H\n", TestHarness.Run(source, mode));
+    }
+}


### PR DESCRIPTION
## Summary

Compiled generators snapshotted the **values** of captured outer (closure) variables into state-machine fields when the generator was created, so a later mutation of the outer variable was invisible to the running body — diverging from the interpreter and from JS closure semantics (#541).

```ts
let x: any = 1;
function* g() { yield x; }
const it = g();   // generator created while x === 1
x = 42;           // mutated after creation, before the body runs
console.log(it.next().value);   // interp: 42   compiled (before): 1
```

## Fix

The **async-generator** path already read captured variables live; this makes regular generators match it.

- **Stop hoisting/snapshotting** captured variables into state-machine fields (`GeneratorStateMachineBuilder`, `GeneratorStateAnalyzer`, and both generator stub emitters in `ILCompiler.Generators`).
- **Wire the live-resolution context** (`TopLevelStaticVars` / `CapturedTopLevelVars` / `EntryPointDisplayClass*`) onto both generator `MoveNext` contexts (free-function and instance-method; the instance-method context was missing `TopLevelStaticVars`), so reads **and** writes resolve live against the enclosing storage.

### Latent resolution-order bug exposed (and fixed)

Removing the snapshot surfaced a bug in the shared `ExpressionEmitterBase.TryEmitGlobalVariable`: it checked `Functions` **before** `CapturedTopLevelVars`. A captured top-level variable whose name collides with a same-named **cross-module** function (e.g. CJS `const composeDoc = require('./compose-doc')` referenced as `composeDoc.composeDoc(...)`) resolved to the *function*, throwing `TypeError: object is not a function`. This broke the `Yaml_Compiled` smoke test. A variable binding in scope must shadow a cross-module function, so the captured-top-level-var arm now runs first (its `EntryPointDisplayClassFields` guard keeps genuine function references falling through correctly).

This also **closes #581** (top-level function referenced as a value inside a generator threw "object is not a function").

### Cleanup

Removed the now-dead capture-hoisting feature from `HoistingManager` and the dead `analysis` parameters/locals left behind.

## Tests

- New `GeneratorClosureCaptureTests` (both interpreter + compiled): by-reference reads, self-reference (#521 shape), mutation between yields, write-back to outer scope, increment/compound, instance-method generators, loop-body captures (with #497 hoisting), `yield*` delegation, shared instances, and top-level-function-as-value.
- New compiled CJS collision regression mirroring the yaml composer shape.
- **Full suite: 12101 passed, 0 failed** (+21 new). **Test262: 0 conformance regressions.**

## Related issues filed (pre-existing, unrelated gaps found along the way)

- #605 — top-level block-scoped `function`/`function*` declarations (loop body / `{}`) aren't bound in compiled mode.
- #606 — a non-capturing generator nested in a *regular* function fails to compile ("Yield not supported in this context").

Closes #541. Closes #581.