### PR TITLE
Fix #610: restore build broken by #608×#609 semantic merge conflict

### DIFF
--- a/Compilation/ILCompiler.Generators.cs
+++ b/Compilation/ILCompiler.Generators.cs
@@ -12,68 +12,6 @@ namespace SharpTS.Compilation;
 public partial class ILCompiler
 {
     /// <summary>
-    /// Top-level (module-scope) function names, keyed by module path ("" for single-file).
-    /// A generator references a top-level function by treating its name as a captured outer variable
-    /// (it is not declared inside the generator). Generators wrongly materialise such captures as
-    /// state-machine fields that the kickoff never populates for functions — leaving them null, so a
-    /// value-use (<c>const h = helper; h()</c> / <c>yield helper</c>) reads null and throws "object
-    /// is not a function". Async/async-generator bodies don't create these fields and instead resolve
-    /// the name through the normal function-value path. Excluding such names from the generator's
-    /// captured fields lets its MoveNext resolver fall through to <c>TryEmitGlobalVariable</c>'s
-    /// function path too.
-    ///
-    /// <para>Keyed PER MODULE, not unioned: a name that is a top-level function in one module may be
-    /// a genuinely-captured binding (e.g. a module-level <c>const</c>, whose captured field IS
-    /// populated) in another. Excluding it there would strip a needed field. Only a name that is a
-    /// top-level function in the GENERATOR'S OWN module resolves correctly through the function-value
-    /// fallback, so only those are excluded.</para>
-    /// </summary>
-    private readonly Dictionary<string, HashSet<string>> _topLevelFunctionNamesByModule = new();
-
-    /// <summary>
-    /// Records the top-level function names in <paramref name="statements"/> under
-    /// <paramref name="moduleKey"/> (<c>""</c> for single-file). Called once per module after
-    /// nested-function lifting, so relocated functions (now top-level) are included.
-    /// </summary>
-    private void CollectTopLevelFunctionNames(IEnumerable<Stmt> statements, string moduleKey)
-    {
-        if (!_topLevelFunctionNamesByModule.TryGetValue(moduleKey, out var set))
-        {
-            set = new HashSet<string>();
-            _topLevelFunctionNamesByModule[moduleKey] = set;
-        }
-        foreach (var stmt in statements)
-        {
-            switch (stmt)
-            {
-                case Stmt.Function f when f.Body != null:
-                    set.Add(f.Name.Lexeme);
-                    break;
-                case Stmt.Export { Declaration: Stmt.Function ef } when ef.Body != null:
-                    set.Add(ef.Name.Lexeme);
-                    break;
-            }
-        }
-    }
-
-    /// <summary>
-    /// Returns <paramref name="analysis"/> with the current module's top-level function names removed
-    /// from its captured variables, so the generator state machine does not define (never-populated)
-    /// fields for them. See <see cref="_topLevelFunctionNamesByModule"/>.
-    /// </summary>
-    private GeneratorStateAnalyzer.GeneratorFunctionAnalysis ExcludeTopLevelFunctionsFromCaptures(
-        GeneratorStateAnalyzer.GeneratorFunctionAnalysis analysis)
-    {
-        if (!_topLevelFunctionNamesByModule.TryGetValue(_modules.CurrentPath ?? "", out var names)
-            || names.Count == 0)
-            return analysis;
-        if (!analysis.CapturedVariables.Overlaps(names)) return analysis;
-        var filtered = new HashSet<string>(analysis.CapturedVariables);
-        filtered.ExceptWith(names);
-        return analysis with { CapturedVariables = filtered };
-    }
-
-    /// <summary>
     /// Defines a generator function and its state machine.
     /// </summary>
     private void DefineGeneratorFunction(Stmt.Function funcStmt)
@@ -91,7 +29,7 @@ public partial class ILCompiler
 
         // Create the state machine builder
         var smBuilder = new GeneratorStateMachineBuilder(_moduleBuilder, _types, _generators.StateMachineCounter++);
-        smBuilder.DefineStateMachine(funcName, ExcludeTopLevelFunctionsFromCaptures(analysis), isInstanceMethod: false, runtime: _runtime);
+        smBuilder.DefineStateMachine(funcName, analysis, isInstanceMethod: false, runtime: _runtime);
 
         _generators.StateMachines[qualifiedName] = smBuilder;
         _generators.Functions[qualifiedName] = funcStmt;
@@ -259,7 +197,7 @@ public partial class ILCompiler
         var smBuilder = new GeneratorStateMachineBuilder(_moduleBuilder, _types, _generators.StateMachineCounter++);
         smBuilder.DefineStateMachine(
             $"{methodBuilder.DeclaringType!.Name}_{method.Name.Lexeme}",
-            ExcludeTopLevelFunctionsFromCaptures(analysis),
+            analysis,
             isInstanceMethod: true,  // This is an instance method
             runtime: _runtime
         );

--- a/Compilation/ILCompiler.cs
+++ b/Compilation/ILCompiler.cs
@@ -411,7 +411,6 @@ public partial class ILCompiler
         // to the module top level so the mature top-level state-machine pipeline can lower them
         // (#470, #501). Compile-path only — the interpreter handles nested declarations natively.
         statements = NestedFunctionLifter.Lift(statements);
-        CollectTopLevelFunctionNames(statements, _modules.CurrentPath ?? "");
 
         // Walk the AST to determine which runtime feature categories the program
         // actually needs, so Phase 1 can skip emitting unused helper types.
@@ -874,7 +873,7 @@ public partial class ILCompiler
         // Relocate non-capturing nested generator/async/state-machine-nested function declarations
         // to each module's top level (#470, #501). Compile-path only. The Statements property is
         // read-only but the underlying list is shared by reference across all phases, so mutate it
-        // in place. CollectTopLevelFunctionNames builds a cross-module union (over-inclusion is safe).
+        // in place.
         foreach (var m in modules)
         {
             var lifted = NestedFunctionLifter.Lift(m.Statements);
@@ -883,7 +882,6 @@ public partial class ILCompiler
                 m.Statements.Clear();
                 m.Statements.AddRange(lifted);
             }
-            CollectTopLevelFunctionNames(m.Statements, m.Path);
         }
 
         var allStatements = modules.SelectMany(m => m.Statements).ToList();


### PR DESCRIPTION
## Problem

`origin/main` at `2a5046de` **does not compile** (`error CS1061`/`CS0117` on `analysis.CapturedVariables` in `Compilation/ILCompiler.Generators.cs`). This blocks every build/test/PR. See #610.

## Root cause — semantic merge conflict between #608 and #609

Neither PR's diff textually conflicted, so both merged cleanly, but the combination is uncompilable:

- **#608** (nested-function lifter) added `ExcludeTopLevelFunctionsFromCaptures`, which reads `analysis.CapturedVariables`, plus the `CollectTopLevelFunctionNames` / `_topLevelFunctionNamesByModule` support chain. Purpose: stop a generator state machine from defining never-populated *fields* for top-level function names that appeared in the captured set.
- **#609** (#541) **removed** `CapturedVariables` from `GeneratorFunctionAnalysis` and stopped hoisting captured outer-scope variables into state-machine fields entirely — generators now read them **live** in `MoveNext`, mirroring the async-generator path.

`merge-base(#608, #609) == 019b320b` (#608's merge), and #609's branch (`3ba5789b`) was created *before* #608 merged, so it never saw the helper. The textual merge kept #608's helper while #609 deleted the field it depends on. Each PR's CI was green against a main that lacked the other change; the merge commit was never built.

## Fix

Remove the now-obsolete `ExcludeTopLevelFunctionsFromCaptures` and its dead `CollectTopLevelFunctionNames` / `_topLevelFunctionNamesByModule` chain (its only reader was the helper), plus the two call sites. `NestedFunctionLifter.Lift` — #608's actual fix — is untouched.

**No runtime behavior change.** The helper could no longer compile or run, so behavior is already governed entirely by #609's live-read design. The specific scenario #608's helper protected — a top-level function referenced as a value inside a generator (`const h = helper; yield h()`) — is now resolved through #609's live function-value path.

## Verification

- `dotnet build` — 0 errors (was 3).
- 86 tests pass across `GeneratorClosureCaptureTests`, `NestedFunctionLiftingTests`, `InnerFunctionScopeDisplayClassTests`, `CrossModuleNameCollisionTests`.
- Manual compiled + interpreted repro of the #608 value-ref case prints `42` / `42`.

Closes #610.
