### PR TITLE
Fix broken main: generator compiler references removed CapturedVariables (#608×#609)

### DIFF
--- a/Compilation/ILCompiler.Generators.cs
+++ b/Compilation/ILCompiler.Generators.cs
@@ -12,68 +12,6 @@ namespace SharpTS.Compilation;
 public partial class ILCompiler
 {
     /// <summary>
-    /// Top-level (module-scope) function names, keyed by module path ("" for single-file).
-    /// A generator references a top-level function by treating its name as a captured outer variable
-    /// (it is not declared inside the generator). Generators wrongly materialise such captures as
-    /// state-machine fields that the kickoff never populates for functions — leaving them null, so a
-    /// value-use (<c>const h = helper; h()</c> / <c>yield helper</c>) reads null and throws "object
-    /// is not a function". Async/async-generator bodies don't create these fields and instead resolve
-    /// the name through the normal function-value path. Excluding such names from the generator's
-    /// captured fields lets its MoveNext resolver fall through to <c>TryEmitGlobalVariable</c>'s
-    /// function path too.
-    ///
-    /// <para>Keyed PER MODULE, not unioned: a name that is a top-level function in one module may be
-    /// a genuinely-captured binding (e.g. a module-level <c>const</c>, whose captured field IS
-    /// populated) in another. Excluding it there would strip a needed field. Only a name that is a
-    /// top-level function in the GENERATOR'S OWN module resolves correctly through the function-value
-    /// fallback, so only those are excluded.</para>
-    /// </summary>
-    private readonly Dictionary<string, HashSet<string>> _topLevelFunctionNamesByModule = new();
-
-    /// <summary>
-    /// Records the top-level function names in <paramref name="statements"/> under
-    /// <paramref name="moduleKey"/> (<c>""</c> for single-file). Called once per module after
-    /// nested-function lifting, so relocated functions (now top-level) are included.
-    /// </summary>
-    private void CollectTopLevelFunctionNames(IEnumerable<Stmt> statements, string moduleKey)
-    {
-        if (!_topLevelFunctionNamesByModule.TryGetValue(moduleKey, out var set))
-        {
-            set = new HashSet<string>();
-            _topLevelFunctionNamesByModule[moduleKey] = set;
-        }
-        foreach (var stmt in statements)
-        {
-            switch (stmt)
-            {
-                case Stmt.Function f when f.Body != null:
-                    set.Add(f.Name.Lexeme);
-                    break;
-                case Stmt.Export { Declaration: Stmt.Function ef } when ef.Body != null:
-                    set.Add(ef.Name.Lexeme);
-                    break;
-            }
-        }
-    }
-
-    /// <summary>
-    /// Returns <paramref name="analysis"/> with the current module's top-level function names removed
-    /// from its captured variables, so the generator state machine does not define (never-populated)
-    /// fields for them. See <see cref="_topLevelFunctionNamesByModule"/>.
-    /// </summary>
-    private GeneratorStateAnalyzer.GeneratorFunctionAnalysis ExcludeTopLevelFunctionsFromCaptures(
-        GeneratorStateAnalyzer.GeneratorFunctionAnalysis analysis)
-    {
-        if (!_topLevelFunctionNamesByModule.TryGetValue(_modules.CurrentPath ?? "", out var names)
-            || names.Count == 0)
-            return analysis;
-        if (!analysis.CapturedVariables.Overlaps(names)) return analysis;
-        var filtered = new HashSet<string>(analysis.CapturedVariables);
-        filtered.ExceptWith(names);
-        return analysis with { CapturedVariables = filtered };
-    }
-
-    /// <summary>
     /// Defines a generator function and its state machine.
     /// </summary>
     private void DefineGeneratorFunction(Stmt.Function funcStmt)
@@ -91,7 +29,7 @@ public partial class ILCompiler
 
         // Create the state machine builder
         var smBuilder = new GeneratorStateMachineBuilder(_moduleBuilder, _types, _generators.StateMachineCounter++);
-        smBuilder.DefineStateMachine(funcName, ExcludeTopLevelFunctionsFromCaptures(analysis), isInstanceMethod: false, runtime: _runtime);
+        smBuilder.DefineStateMachine(funcName, analysis, isInstanceMethod: false, runtime: _runtime);
 
         _generators.StateMachines[qualifiedName] = smBuilder;
         _generators.Functions[qualifiedName] = funcStmt;
@@ -259,7 +197,7 @@ public partial class ILCompiler
         var smBuilder = new GeneratorStateMachineBuilder(_moduleBuilder, _types, _generators.StateMachineCounter++);
         smBuilder.DefineStateMachine(
             $"{methodBuilder.DeclaringType!.Name}_{method.Name.Lexeme}",
-            ExcludeTopLevelFunctionsFromCaptures(analysis),
+            analysis,
             isInstanceMethod: true,  // This is an instance method
             runtime: _runtime
         );

--- a/Compilation/ILCompiler.cs
+++ b/Compilation/ILCompiler.cs
@@ -411,7 +411,6 @@ public partial class ILCompiler
         // to the module top level so the mature top-level state-machine pipeline can lower them
         // (#470, #501). Compile-path only — the interpreter handles nested declarations natively.
         statements = NestedFunctionLifter.Lift(statements);
-        CollectTopLevelFunctionNames(statements, _modules.CurrentPath ?? "");
 
         // Walk the AST to determine which runtime feature categories the program
         // actually needs, so Phase 1 can skip emitting unused helper types.
@@ -874,7 +873,7 @@ public partial class ILCompiler
         // Relocate non-capturing nested generator/async/state-machine-nested function declarations
         // to each module's top level (#470, #501). Compile-path only. The Statements property is
         // read-only but the underlying list is shared by reference across all phases, so mutate it
-        // in place. CollectTopLevelFunctionNames builds a cross-module union (over-inclusion is safe).
+        // in place.
         foreach (var m in modules)
         {
             var lifted = NestedFunctionLifter.Lift(m.Statements);
@@ -883,7 +882,6 @@ public partial class ILCompiler
                 m.Statements.Clear();
                 m.Statements.AddRange(lifted);
             }
-            CollectTopLevelFunctionNames(m.Statements, m.Path);
         }
 
         var allStatements = modules.SelectMany(m => m.Statements).ToList();


### PR DESCRIPTION
## Problem

`main` (2a5046de) **does not compile**:

```
Compilation/ILCompiler.Generators.cs(70,23): error CS1061:
  'GeneratorStateAnalyzer.GeneratorFunctionAnalysis' does not contain a
  definition for 'CapturedVariables'
```

This blocks every branch and PR, not just the one where it surfaced.

## Root cause — a semantic merge conflict git didn't flag

Two PRs touched the same area in **different files**, so the merge had no textual conflict:

- **#608** (`ef5329c3`, *Fix #470/#501: lift non-capturing nested generators*) added `ExcludeTopLevelFunctionsFromCaptures()`, which reads `analysis.CapturedVariables`. Written against a record that still had that member.
- **#609** (`3ba5789b`, *Fix #541: generators capture closure variables by reference*) **removed `CapturedVariables`** from `GeneratorFunctionAnalysis`, switching generators to read captured outer variables live-by-reference (`CapturedTopLevelVars` / `TopLevelStaticVars`), mirroring async generators.

#608 merged first (`019b320b`), then #609 (`2a5046de`) removed the member #608's new code depends on → broken `main`.

## Fix

Under #541's model the state machine no longer materializes per-variable fields from `analysis.CapturedVariables`, so the whole exclusion chain is **dead code** — its only consumer fed `DefineStateMachine`, which no longer reads captured variables:

- `_topLevelFunctionNamesByModule` (field)
- `CollectTopLevelFunctionNames()` (populator, called from 2 sites in `ILCompiler.cs`)
- `ExcludeTopLevelFunctionsFromCaptures()` (consumer)

Removed the chain and pass `analysis` straight through. The *"object is not a function"* case #608 guarded against can no longer occur (no analysis-driven captured fields exist) and is now handled by #541's unified live-reference path. The #470/#501 fix itself — the `NestedFunctionLifter` — is untouched.

Net: **3 insertions, 67 deletions**, 2 files.

## Verification

- Build clean (0 errors).
- **1703 targeted tests pass**: `NestedFunctionLifting` (#470/#501), all `Generator`/`AsyncGenerator`/`Yield`, `Closure`/`Capture`, `ILVerification`.