### PR TITLE
Fix three build warnings via proper coding techniques

### DIFF
--- a/Compilation/RuntimeEmitter.Objects.Index.cs
+++ b/Compilation/RuntimeEmitter.Objects.Index.cs
@@ -240,8 +240,10 @@ public partial class RuntimeEmitter
             il.MarkLabel(notThisRcvLabel);
         }
         EmitProtoSymbolFallback(_types.ListOfObject, runtime.ArrayPrototypeField, runtime.ArrayPrototypePopulateMethod);
-        if (runtime.TSArrayType != null)
-            EmitProtoSymbolFallback(runtime.TSArrayType, runtime.ArrayPrototypeField, runtime.ArrayPrototypePopulateMethod);
+        // TSArrayType is non-null here by contract: the dispatch above (Isinst TSArrayType)
+        // already passed it to il.Emit, which throws on null. A redundant != null guard here
+        // would only poison nullable flow analysis for the unconditional casts further down.
+        EmitProtoSymbolFallback(runtime.TSArrayType, runtime.ArrayPrototypeField, runtime.ArrayPrototypePopulateMethod);
 
         // ECMA-262 §21.3.2.34 / §25.5.4: Math[@@toStringTag] = "Math",
         // JSON[@@toStringTag] = "JSON". Singletons aren't populated via a

--- a/SharpTS.Tests/TypeCheckerTests/BuiltInApparentMembersTests.cs
+++ b/SharpTS.Tests/TypeCheckerTests/BuiltInApparentMembersTests.cs
@@ -57,7 +57,9 @@ public class BuiltInApparentMembersTests
     {
         // The resolver must not over-match: a name that is not a real member resolves to null, so an
         // infer-match / structural check against it correctly fails.
-        Assert.Null(BuiltInTypes.GetInstanceMemberType(type, "definitelyNotARealMember"));
+        Assert.True(
+            BuiltInTypes.GetInstanceMemberType(type, "definitelyNotARealMember") is null,
+            $"{label} resolved a member type for the absent name 'definitelyNotARealMember' — the resolver over-matches.");
         Assert.DoesNotContain("definitelyNotARealMember", BuiltInTypes.GetInstanceMemberNames(type)!);
     }
 

--- a/TypeSystem/TypeChecker.Properties.Index.cs
+++ b/TypeSystem/TypeChecker.Properties.Index.cs
@@ -73,7 +73,8 @@ public partial class TypeChecker
                 }
                 return new TypeInfo.Any();
             }
-            return CheckGetIndexOnType(evaluated, indexType, getIndex);
+            return CheckGetIndexOnType(evaluated, indexType, getIndex)
+                ?? throw new TypeCheckException($" Index type '{indexType}' is not valid for indexing '{evaluated}'.", tsCode: "TS7053");
         }
 
         // Optional bracket access: strip null/undefined from object type


### PR DESCRIPTION
## Summary

Resolves the three build warnings emitted by `dotnet build` / `dotnet test`, each fixed at its root rather than suppressed.

| Warning | File | Fix |
|---------|------|-----|
| CS8603 (possible null return) | `TypeSystem/TypeChecker.Properties.Index.cs` | The conditional-type branch of `CheckGetIndex` returned the nullable `CheckGetIndexOnType` result directly, but the method returns non-nullable `TypeInfo`. Route the null case through the same `TS7053` the method already throws at its terminal fall-through. |
| CS8604 (possible null arg `cls`) | `Compilation/RuntimeEmitter.Objects.Index.cs` | Removed a redundant `if (runtime.TSArrayType != null)` guard. `TSArrayType` is non-null by contract — the dispatch `Isinst` at the top of the method already passes it to `il.Emit` (which throws on null), so reaching that point guarantees it is set. The stray guard only poisoned Roslyn nullable flow analysis for the unconditional `Castclass` further down. |
| xUnit1026 (unused param) | `SharpTS.Tests/TypeCheckerTests/BuiltInApparentMembersTests.cs` | The unused `label` Theory parameter is now used in a diagnostic assertion message, mirroring the sibling `EveryAdvertisedMemberNameResolves` test. |

## Why

- **CS8603**: previously a resolved conditional type that could not be indexed would leak `null` out of a non-nullable signature; it now surfaces a proper `TS7053` type error, consistent with the method's existing terminal behavior.
- **CS8604**: the `!= null` check was dead code and inconsistent with the method's own unconditional uses of `TSArrayType` (the dispatch at line 82, the cast at 463, the `Callvirt` at 465). Removing it both fixes the warning and restores clean flow tracking without changing emitted IL.
- **xUnit1026**: turns a bare `Assert.Null` into a labeled assertion that names the offending built-in type on failure.

## Testing

- Clean rebuild (`--no-incremental`): **0 warnings, 0 errors**.
- `BuiltInApparentMembersTests`: 28/28 passing.