### PR TITLE
Fix #436, #439, #441: compiled await/value-type call emission in state machines (+ close #442)

### DIFF
--- a/Compilation/AsyncArrowMoveNextEmitter.Expressions.cs
+++ b/Compilation/AsyncArrowMoveNextEmitter.Expressions.cs
@@ -5,38 +5,16 @@ namespace SharpTS.Compilation;
 
 public partial class AsyncArrowMoveNextEmitter
 {
-    // EmitExpression dispatch is inherited from ExpressionEmitterBase
-
-    protected override void EmitLiteral(Expr.Literal lit)
-    {
-        if (lit.Value == null)
-        {
-            _il.Emit(OpCodes.Ldnull);
-            SetStackType(StackType.Null);
-        }
-        else if (lit.Value is double d)
-        {
-            _il.Emit(OpCodes.Ldc_R8, d);
-            _il.Emit(OpCodes.Box, typeof(double));
-            SetStackUnknown();
-        }
-        else if (lit.Value is string s)
-        {
-            _il.Emit(OpCodes.Ldstr, s);
-            SetStackType(StackType.String);
-        }
-        else if (lit.Value is bool b)
-        {
-            _il.Emit(b ? OpCodes.Ldc_I4_1 : OpCodes.Ldc_I4_0);
-            _il.Emit(OpCodes.Box, typeof(bool));
-            SetStackUnknown();
-        }
-        else
-        {
-            _il.Emit(OpCodes.Ldnull);
-            SetStackType(StackType.Null);
-        }
-    }
+    // EmitExpression dispatch is inherited from ExpressionEmitterBase.
+    // EmitLiteral is inherited from the base too: it leaves value-type literals (number/boolean)
+    // UNBOXED with a tracked StackType (Double/Boolean), the convention the shared expression
+    // framework — EnsureBoxed, EmitConversionForParameter — is built around. A previous override
+    // here eagerly boxed numbers/booleans and set StackType=Unknown; that desynced the literal
+    // fast-path in EmitConversionForParameter (which assumes an unboxed double for a `double`
+    // parameter), so a call to a function with a numeric parameter stored a boxed object into a
+    // double IL slot and failed IL verification (#441). The base storage paths here
+    // (EmitVarDeclaration, EmitReturn, …) already EnsureBoxed before storing, so no eager boxing
+    // is needed.
 
     protected override void EmitThis()
     {

--- a/Compilation/ExpressionEmitterBase.CallHelpers.cs
+++ b/Compilation/ExpressionEmitterBase.CallHelpers.cs
@@ -167,9 +167,19 @@ public abstract partial class ExpressionEmitterBase
                     }
 
                     // Store each converted arg to a temp for await-safety
-                    // (async emitters may yield during EmitExpression)
+                    // (async emitters may yield during EmitExpression).
+                    //
+                    // When a later argument can suspend (await/yield), spill each earlier argument
+                    // to a *registered, boxed* object local: a parameter-typed IL local does not
+                    // survive a deferred MoveNext re-entry (only state-machine fields do, #400), so
+                    // the earlier arg would read back as null and the typed reload also fails IL
+                    // verify (#436). Without a suspending argument — every call in the synchronous
+                    // ILEmitter, and await-free calls in async/generator bodies — keep the cheaper
+                    // parameter-typed locals (the JIT collapses the store/load and value-typed args
+                    // stay unboxed).
                     var targetParams = targetMethod.GetParameters();
-                    List<(LocalBuilder Local, Type ParamType)> callArgTemps = [];
+                    bool awaitSafe = AnyContainsSuspension(c.Arguments);
+                    List<(LocalBuilder Local, Type ParamType, bool Boxed)> callArgTemps = [];
 
                     for (int i = 0; i < c.Arguments.Count; i++)
                     {
@@ -177,9 +187,20 @@ public abstract partial class ExpressionEmitterBase
                         Type paramType = i < targetParams.Length ? targetParams[i].ParameterType : Types.Object;
                         if (arg is Expr.Spread spread)
                         {
+                            // A spread in a fixed-arity (non-rest) call is passed as one boxed value.
+                            if (awaitSafe)
+                            {
+                                callArgTemps.Add((SpillBoxed(spread.Expression), Types.Object, true));
+                                continue;
+                            }
                             EmitExpression(spread.Expression);
                             EnsureBoxed();
                             paramType = Types.Object;
+                        }
+                        else if (awaitSafe)
+                        {
+                            callArgTemps.Add((SpillConvertedArg(arg, paramType), paramType, true));
+                            continue;
                         }
                         else
                         {
@@ -191,7 +212,7 @@ public abstract partial class ExpressionEmitterBase
                         }
                         var temp = IL.DeclareLocal(paramType);
                         IL.Emit(OpCodes.Stloc, temp);
-                        callArgTemps.Add((temp, paramType));
+                        callArgTemps.Add((temp, paramType, false));
                     }
 
                     for (int i = c.Arguments.Count; i < paramCount; i++)
@@ -206,9 +227,11 @@ public abstract partial class ExpressionEmitterBase
                         {
                             EmitDefaultForType(pType);
                         }
+                        // Defaults are emitted after every real argument, so no suspension can
+                        // follow — a plain parameter-typed local is sufficient (Boxed = false).
                         var temp = IL.DeclareLocal(pType);
                         IL.Emit(OpCodes.Stloc, temp);
-                        callArgTemps.Add((temp, pType));
+                        callArgTemps.Add((temp, pType, false));
                     }
 
                     // If the callee's body references JS `arguments`, publish the raw
@@ -229,7 +252,9 @@ public abstract partial class ExpressionEmitterBase
                             IL.Emit(OpCodes.Dup);
                             IL.Emit(OpCodes.Ldc_I4, i);
                             IL.Emit(OpCodes.Ldloc, callArgTemps[i].Local);
-                            if (callArgTemps[i].ParamType.IsValueType)
+                            // Await-safe temps are already boxed objects; only parameter-typed
+                            // value-type temps need boxing for the object[] arguments array.
+                            if (!callArgTemps[i].Boxed && callArgTemps[i].ParamType.IsValueType)
                                 IL.Emit(OpCodes.Box, callArgTemps[i].ParamType);
                             IL.Emit(OpCodes.Stelem_Ref);
                         }
@@ -245,7 +270,13 @@ public abstract partial class ExpressionEmitterBase
                     // (#65, prerequisite for #64's zero-declared-param shape).
                     int loadCount = Math.Min(callArgTemps.Count, paramCount);
                     for (int i = 0; i < loadCount; i++)
+                    {
                         IL.Emit(OpCodes.Ldloc, callArgTemps[i].Local);
+                        // Await-safe temps hold a boxed object — coerce back to the declared
+                        // parameter slot (unbox value types / downcast reference types).
+                        if (callArgTemps[i].Boxed)
+                            EmitCoerceBoxedToType(callArgTemps[i].ParamType);
+                    }
                 }
 
                 IL.Emit(OpCodes.Call, targetMethod);
@@ -510,6 +541,90 @@ public abstract partial class ExpressionEmitterBase
     }
 
     /// <summary>
+    /// Emits <paramref name="arg"/>, converts it to <paramref name="paramType"/> (preserving
+    /// <see cref="EmitConversionForParameter"/>'s union/implicit-conversion semantics), then boxes
+    /// the result and spills it to a <em>registered</em> object local so a suspension (await/yield)
+    /// in a <em>later</em> argument persists it across the MoveNext re-entry (#400/#436/#439). Load
+    /// it back with <c>Ldloc</c> + <see cref="EmitCoerceBoxedToType"/>(paramType). Value types are
+    /// boxed explicitly (not via <c>EnsureBoxed</c>) because the conversion leaves them unboxed with
+    /// an untracked stack type after an <c>unbox.any</c>.
+    /// </summary>
+    private LocalBuilder SpillConvertedArg(Expr arg, Type paramType)
+    {
+        EmitExpression(arg);
+        EmitConversionForParameter(arg, paramType);
+        if (paramType.IsValueType)
+            IL.Emit(OpCodes.Box, paramType);
+        return _helpers.SpillStoreObject();
+    }
+
+    /// <summary>
+    /// True when evaluating any of <paramref name="exprs"/> can suspend the enclosing state machine
+    /// (contains an <c>await</c> or <c>yield</c>). Used to gate await-safe argument spilling: the
+    /// fast typed-local call path is only unsafe when a later argument can suspend, so non-suspending
+    /// calls (every call in the synchronous ILEmitter, and await-free calls in async/generator
+    /// bodies) keep their cheaper codegen (#436).
+    /// </summary>
+    protected static bool AnyContainsSuspension(IEnumerable<Expr> exprs)
+    {
+        foreach (var e in exprs)
+            if (ExprContainsSuspension(e))
+                return true;
+        return false;
+    }
+
+    /// <summary>
+    /// True when evaluating <paramref name="expr"/> can suspend the enclosing state machine. Only
+    /// <see cref="Expr.Await"/>/<see cref="Expr.Yield"/> suspend; this walks every composite that
+    /// can nest one. Nested function/arrow and class-expression bodies are NOT traversed — their
+    /// <c>await</c>/<c>yield</c> belong to their own state machine, not the one being emitted. New
+    /// expression containers must be added here (an unhandled type conservatively reports "no
+    /// suspension", which would re-expose the spill bug if it can actually nest one).
+    /// </summary>
+    protected static bool ExprContainsSuspension(Expr expr) => expr switch
+    {
+        Expr.Await or Expr.Yield => true,
+        Expr.Comma c => ExprContainsSuspension(c.Left) || ExprContainsSuspension(c.Right),
+        Expr.Binary b => ExprContainsSuspension(b.Left) || ExprContainsSuspension(b.Right),
+        Expr.Logical l => ExprContainsSuspension(l.Left) || ExprContainsSuspension(l.Right),
+        Expr.NullishCoalescing n => ExprContainsSuspension(n.Left) || ExprContainsSuspension(n.Right),
+        Expr.Ternary t => ExprContainsSuspension(t.Condition) || ExprContainsSuspension(t.ThenBranch) || ExprContainsSuspension(t.ElseBranch),
+        Expr.Grouping g => ExprContainsSuspension(g.Expression),
+        Expr.Unary u => ExprContainsSuspension(u.Right),
+        Expr.Delete d => ExprContainsSuspension(d.Operand),
+        Expr.Call call => ExprContainsSuspension(call.Callee) || AnyContainsSuspension(call.Arguments),
+        Expr.New nw => ExprContainsSuspension(nw.Callee) || AnyContainsSuspension(nw.Arguments),
+        Expr.CallPrivate cp => ExprContainsSuspension(cp.Object) || AnyContainsSuspension(cp.Arguments),
+        Expr.Get get => ExprContainsSuspension(get.Object),
+        Expr.GetPrivate gp => ExprContainsSuspension(gp.Object),
+        Expr.Set s => ExprContainsSuspension(s.Object) || ExprContainsSuspension(s.Value),
+        Expr.SetPrivate sp => ExprContainsSuspension(sp.Object) || ExprContainsSuspension(sp.Value),
+        Expr.GetIndex gi => ExprContainsSuspension(gi.Object) || ExprContainsSuspension(gi.Index),
+        Expr.SetIndex si => ExprContainsSuspension(si.Object) || ExprContainsSuspension(si.Index) || ExprContainsSuspension(si.Value),
+        Expr.Assign a => ExprContainsSuspension(a.Value),
+        Expr.CompoundAssign ca => ExprContainsSuspension(ca.Value),
+        Expr.CompoundSet cs => ExprContainsSuspension(cs.Object) || ExprContainsSuspension(cs.Value),
+        Expr.CompoundSetIndex csi => ExprContainsSuspension(csi.Object) || ExprContainsSuspension(csi.Index) || ExprContainsSuspension(csi.Value),
+        Expr.LogicalAssign la => ExprContainsSuspension(la.Value),
+        Expr.LogicalSet lst => ExprContainsSuspension(lst.Object) || ExprContainsSuspension(lst.Value),
+        Expr.LogicalSetIndex lsi => ExprContainsSuspension(lsi.Object) || ExprContainsSuspension(lsi.Index) || ExprContainsSuspension(lsi.Value),
+        Expr.PrefixIncrement pi => ExprContainsSuspension(pi.Operand),
+        Expr.PostfixIncrement pi => ExprContainsSuspension(pi.Operand),
+        Expr.ArrayLiteral al => AnyContainsSuspension(al.Elements),
+        Expr.ObjectLiteral ol => ol.Properties.Any(p =>
+            (p.Key is Expr.ComputedKey ck && ExprContainsSuspension(ck.Expression)) || ExprContainsSuspension(p.Value)),
+        Expr.TemplateLiteral tl => AnyContainsSuspension(tl.Expressions),
+        Expr.Spread sp => ExprContainsSuspension(sp.Expression),
+        Expr.TypeAssertion ta => ExprContainsSuspension(ta.Expression),
+        Expr.Satisfies sa => ExprContainsSuspension(sa.Expression),
+        Expr.NonNullAssertion nn => ExprContainsSuspension(nn.Expression),
+        Expr.DynamicImport di => ExprContainsSuspension(di.PathExpression),
+        // Leaves (Literal/Variable/This/Super/ImportMeta/RegexLiteral) and lambda/class
+        // boundaries (ArrowFunction/ClassExpr) cannot surface a suspension to the current frame.
+        _ => false
+    };
+
+    /// <summary>
     /// Emits the ExpandCallArgs call with Symbol.iterator and runtime type arguments.
     /// Expects args array and isSpread array on the stack.
     /// </summary>
@@ -561,13 +676,37 @@ public abstract partial class ExpressionEmitterBase
                 var staticMethodParams = callableMethod!.GetParameters();
                 var paramCount = staticMethodParams.Length;
 
-                for (int i = 0; i < c.Arguments.Count; i++)
+                // When a later argument can suspend, spill each argument to a registered, boxed
+                // object local first — emitting them directly onto the IL stack would leave the
+                // earlier args (and partial evaluation) stacked across the await/yield, which is
+                // invalid IL and loses values across the MoveNext re-entry (#439). Await-free calls
+                // (all of synchronous mode) keep the direct on-stack emission.
+                if (AnyContainsSuspension(c.Arguments))
                 {
-                    EmitExpression(c.Arguments[i]);
-                    if (i < staticMethodParams.Length)
-                        EmitConversionForParameter(c.Arguments[i], staticMethodParams[i].ParameterType);
-                    else
-                        EnsureBoxed();
+                    var argLocals = new LocalBuilder[c.Arguments.Count];
+                    for (int i = 0; i < c.Arguments.Count; i++)
+                    {
+                        Type pType = i < staticMethodParams.Length ? staticMethodParams[i].ParameterType : Types.Object;
+                        argLocals[i] = i < staticMethodParams.Length
+                            ? SpillConvertedArg(c.Arguments[i], pType)
+                            : SpillBoxed(c.Arguments[i]);
+                    }
+                    for (int i = 0; i < c.Arguments.Count; i++)
+                    {
+                        IL.Emit(OpCodes.Ldloc, argLocals[i]);
+                        EmitCoerceBoxedToType(i < staticMethodParams.Length ? staticMethodParams[i].ParameterType : Types.Object);
+                    }
+                }
+                else
+                {
+                    for (int i = 0; i < c.Arguments.Count; i++)
+                    {
+                        EmitExpression(c.Arguments[i]);
+                        if (i < staticMethodParams.Length)
+                            EmitConversionForParameter(c.Arguments[i], staticMethodParams[i].ParameterType);
+                        else
+                            EnsureBoxed();
+                    }
                 }
 
                 for (int i = c.Arguments.Count; i < paramCount; i++)
@@ -885,10 +1024,16 @@ public abstract partial class ExpressionEmitterBase
         if (c.Optional || c.Callee is not Expr.Get g || !HasOptionalLink(g))
             return false;
 
+        // When an argument can suspend, the receiver and resolved fn are live across that
+        // suspension, so spill them to *registered* locals (which persist to fields across the
+        // MoveNext re-entry, #400) and assemble the args array from pre-spilled locals rather than
+        // inline (#439). Synchronous mode never suspends, so SpillStoreObject is a plain local and
+        // the inline array build is kept.
+        bool awaitSafe = AnyContainsSuspension(c.Arguments);
+
         EmitExpression(g.Object);
         EnsureBoxed();
-        var recvLocal = IL.DeclareLocal(Types.Object);
-        IL.Emit(OpCodes.Stloc, recvLocal);
+        var recvLocal = _helpers.SpillStoreObject();
 
         var nullishLabel = IL.DefineLabel();
         var endLabel = IL.DefineLabel();
@@ -917,8 +1062,7 @@ public abstract partial class ExpressionEmitterBase
         IL.Emit(OpCodes.Ldloc, recvLocal);
         IL.Emit(OpCodes.Ldstr, g.Name.Lexeme);
         IL.Emit(OpCodes.Call, Ctx.Runtime!.GetProperty);
-        var fnLocal = IL.DeclareLocal(Types.Object);
-        IL.Emit(OpCodes.Stloc, fnLocal);
+        var fnLocal = _helpers.SpillStoreObject();
         IL.Emit(OpCodes.Ldloc, fnLocal);
         IL.Emit(OpCodes.Brfalse, nullishLabel);
         IL.Emit(OpCodes.Ldloc, fnLocal);
@@ -927,17 +1071,38 @@ public abstract partial class ExpressionEmitterBase
 
         // InvokeMethodValue(recv, fn, args) — args evaluated only on the
         // non-nullish path, per spec.
-        IL.Emit(OpCodes.Ldloc, recvLocal);
-        IL.Emit(OpCodes.Ldloc, fnLocal);
-        IL.Emit(OpCodes.Ldc_I4, c.Arguments.Count);
-        IL.Emit(OpCodes.Newarr, Types.Object);
-        for (int i = 0; i < c.Arguments.Count; i++)
+        if (awaitSafe)
         {
-            IL.Emit(OpCodes.Dup);
-            IL.Emit(OpCodes.Ldc_I4, i);
-            EmitExpression(c.Arguments[i]);
-            EnsureBoxed();
-            IL.Emit(OpCodes.Stelem_Ref);
+            // Spill args first so an await in a later arg doesn't suspend with the receiver, fn,
+            // and the partially-built array all stacked (invalid IL). Reached only on the
+            // non-nullish path, so args stay unevaluated when the chain short-circuits.
+            var argLocals = c.Arguments.Select(SpillBoxed).ToList();
+            IL.Emit(OpCodes.Ldloc, recvLocal);
+            IL.Emit(OpCodes.Ldloc, fnLocal);
+            IL.Emit(OpCodes.Ldc_I4, c.Arguments.Count);
+            IL.Emit(OpCodes.Newarr, Types.Object);
+            for (int i = 0; i < c.Arguments.Count; i++)
+            {
+                IL.Emit(OpCodes.Dup);
+                IL.Emit(OpCodes.Ldc_I4, i);
+                IL.Emit(OpCodes.Ldloc, argLocals[i]);
+                IL.Emit(OpCodes.Stelem_Ref);
+            }
+        }
+        else
+        {
+            IL.Emit(OpCodes.Ldloc, recvLocal);
+            IL.Emit(OpCodes.Ldloc, fnLocal);
+            IL.Emit(OpCodes.Ldc_I4, c.Arguments.Count);
+            IL.Emit(OpCodes.Newarr, Types.Object);
+            for (int i = 0; i < c.Arguments.Count; i++)
+            {
+                IL.Emit(OpCodes.Dup);
+                IL.Emit(OpCodes.Ldc_I4, i);
+                EmitExpression(c.Arguments[i]);
+                EnsureBoxed();
+                IL.Emit(OpCodes.Stelem_Ref);
+            }
         }
         IL.Emit(OpCodes.Call, Ctx.Runtime!.InvokeMethodValue);
         IL.Emit(OpCodes.Br, endLabel);
@@ -1102,31 +1267,47 @@ public abstract partial class ExpressionEmitterBase
         var methodParams = methodBuilder.GetParameters();
         int expectedParamCount = methodParams.Length;
 
-        List<LocalBuilder> argTemps = [];
-        foreach (var arg in arguments)
+        // Spill the receiver and every argument to object locals, then load from the locals. When
+        // any argument can suspend (await/yield), spill through SpillBoxed so the locals are
+        // *registered* and persist across the MoveNext re-entry — otherwise an await in a later
+        // argument loses the earlier values and crashes (#400/#439). The suspending path spills the
+        // receiver first (JS left-to-right: receiver before arguments); the non-suspending path
+        // keeps the prior args-then-receiver order so observable side-effect ordering is unchanged.
+        LocalBuilder recvLocal;
+        var argLocals = new LocalBuilder[arguments.Count];
+        if (AnyContainsSuspension(arguments))
         {
-            EmitExpression(arg);
+            recvLocal = SpillBoxed(receiver);
+            for (int i = 0; i < arguments.Count; i++)
+                argLocals[i] = SpillBoxed(arguments[i]);
+        }
+        else
+        {
+            for (int i = 0; i < arguments.Count; i++)
+            {
+                EmitExpression(arguments[i]);
+                EnsureBoxed();
+                var temp = IL.DeclareLocal(typeof(object));
+                IL.Emit(OpCodes.Stloc, temp);
+                argLocals[i] = temp;
+            }
+            EmitExpression(receiver);
             EnsureBoxed();
-            var temp = IL.DeclareLocal(typeof(object));
-            IL.Emit(OpCodes.Stloc, temp);
-            argTemps.Add(temp);
+            recvLocal = IL.DeclareLocal(typeof(object));
+            IL.Emit(OpCodes.Stloc, recvLocal);
         }
 
-        EmitExpression(receiver);
-        EnsureBoxed();
+        IL.Emit(OpCodes.Ldloc, recvLocal);
         IL.Emit(OpCodes.Castclass, castType);
-
-        for (int i = 0; i < argTemps.Count; i++)
+        // Coerce each boxed argument to its declared parameter slot: unbox value types AND downcast
+        // reference types. The previous unbox-only logic left a bare object on the stack for a typed
+        // reference parameter (e.g. `string`), which the JIT tolerated but `--verify` rejected with
+        // StackUnexpected (#439) — both the await and the plain call shapes.
+        for (int i = 0; i < argLocals.Length; i++)
         {
-            IL.Emit(OpCodes.Ldloc, argTemps[i]);
+            IL.Emit(OpCodes.Ldloc, argLocals[i]);
             if (i < methodParams.Length)
-            {
-                var targetType = methodParams[i].ParameterType;
-                if (targetType.IsValueType && targetType != typeof(object))
-                {
-                    IL.Emit(OpCodes.Unbox_Any, targetType);
-                }
-            }
+                EmitCoerceBoxedToType(methodParams[i].ParameterType);
         }
 
         for (int i = arguments.Count; i < expectedParamCount; i++)

--- a/SharpTS.Tests/Compilation/EmitterSyncTests.cs
+++ b/SharpTS.Tests/Compilation/EmitterSyncTests.cs
@@ -72,7 +72,10 @@ public class EmitterSyncTests
             "SharpTS.Compilation.Emitters.IEmitterContext.get_IL",           // IEmitterContext impl
             "SharpTS.Compilation.Emitters.IEmitterContext.SetStackUnknown", // IEmitterContext impl
             "SharpTS.Compilation.Emitters.IEmitterContext.SetStackType",   // IEmitterContext impl
-            "EmitLiteral",          // Literal optimization for capture context
+            // EmitLiteral is NO LONGER overridden (#441): the old override eagerly boxed numeric/
+            // boolean literals and set StackType=Unknown, which desynced EmitConversionForParameter's
+            // unboxed-double fast path and produced unverifiable IL for calls with numeric params.
+            // The base EmitLiteral (unboxed value types + tracked StackType) is now used.
             // --- Genuinely different behavior ---
             "EmitReturn",           // Async arrow return: store result + SetResult
             "EmitTryCatch",         // Await-aware exception handling

--- a/SharpTS.Tests/CompilerTests/ILVerificationTests.cs
+++ b/SharpTS.Tests/CompilerTests/ILVerificationTests.cs
@@ -386,6 +386,115 @@ public class ILVerificationTests
     }
 
     [Fact]
+    public void AwaitInFixedArityCallArg_PassesILVerification()
+    {
+        // #436: a fixed-arity (non-rest) call where an earlier argument precedes an await. The
+        // direct-call path spilled earlier args to parameter-typed IL locals; a typed local does
+        // not survive a deferred MoveNext re-entry and the spilled-then-reloaded value mismatched
+        // its declared slot under the verifier (StackUnexpected). Earlier args are now spilled to
+        // registered, boxed locals and coerced back to their declared slot (string / number).
+        var source = """
+            function concat2(x: string, y: string): string { return x + y; }
+            function add3(a: number, b: number, c: number): number { return a + b + c; }
+            async function m() {
+                console.log(concat2("A", await new Promise<string>(r => setTimeout(() => r("B"), 5))));
+                console.log(add3(1, await new Promise<number>(r => setTimeout(() => r(2), 5)), 3));
+            }
+            m();
+            """;
+
+        var errors = TestHarness.CompileAndVerifyOnly(source);
+
+        Assert.Empty(errors);
+    }
+
+    [Fact]
+    public void AwaitInMethodCallArg_PassesILVerification()
+    {
+        // #439: a method call (instance, static, optional-chain) with an await in an argument that
+        // follows an earlier argument. These dispatch paths left the receiver and earlier args on
+        // the IL stack (or in unregistered temps) across the suspension — StackUnexpected /
+        // PathStackDepth, plus a runtime crash. Receiver and args are now spilled to registered
+        // locals and each loaded argument is coerced to its declared parameter slot.
+        var source = """
+            class C {
+                m(a: string, b: string): string { return a + b; }
+                static s(a: string, b: string): string { return a + b; }
+            }
+            const o: any = { m(a: string, b: string): string { return a + b; } };
+            async function main() {
+                const c = new C();
+                console.log(c.m("A", await new Promise<string>(r => setTimeout(() => r("B"), 5))));
+                console.log(C.s("A", await new Promise<string>(r => setTimeout(() => r("B"), 5))));
+                console.log(o?.m("A", await new Promise<string>(r => setTimeout(() => r("B"), 5))));
+            }
+            main();
+            """;
+
+        var errors = TestHarness.CompileAndVerifyOnly(source);
+
+        Assert.Empty(errors);
+    }
+
+    [Fact]
+    public void AsyncArrowAwaitOfCall_PassesILVerification()
+    {
+        // #441: `await <functionCall>` inside an async arrow emitted invalid IL (StackUnexpected in
+        // the arrow's MoveNext) while the same shape in a regular async function verified. Root
+        // cause: the arrow's EmitLiteral override boxed numeric literals and set StackType=Unknown,
+        // desyncing EmitConversionForParameter's unboxed-double fast-path, so calling a function
+        // with a numeric parameter (e.g. defer's `ms`) stored a boxed object into a double IL slot.
+        // The arrow now inherits the base EmitLiteral (unboxed value types with a tracked StackType).
+        var source = """
+            function defer(v: any, ms: number): Promise<any> { return new Promise(r => setTimeout(() => r(v), ms)); }
+            const f = async () => { const x = await defer(1, 5); console.log(x); };
+            f();
+            """;
+
+        var errors = TestHarness.CompileAndVerifyOnly(source);
+
+        Assert.Empty(errors);
+    }
+
+    [Fact]
+    public void AsyncArrowCallWithNumericArgument_PassesILVerification()
+    {
+        // #441 root cause in isolation (no await): calling any function with a `number` parameter
+        // from inside an async arrow stored a boxed double into a double IL slot under the old
+        // eager-boxing EmitLiteral override.
+        var source = """
+            function inc(n: number): number { return n + 1; }
+            const f = async () => { console.log(inc(5)); };
+            f();
+            """;
+
+        var errors = TestHarness.CompileAndVerifyOnly(source);
+
+        Assert.Empty(errors);
+    }
+
+    [Fact]
+    public void NewPromiseInsideFunctionBody_PassesILVerification()
+    {
+        // #442 (already fixed by #393's non-async Promise<T> return-slot fix): `new Promise(executor)`
+        // inside a function/arrow body verifies. Guards the exact constructor-with-executor shape
+        // (closure/delegate construction + Promise newobj) that #393's `Promise.resolve(...)` tests
+        // did not cover. A non-async function returning Promise<T> previously mapped its return slot
+        // to Task<T> while the body produced the runtime $TSPromise (object) → StackUnexpected.
+        var source = """
+            function p(): Promise<number> { return new Promise<number>(r => r(1)); }
+            const q = (n: number): Promise<number> => new Promise<number>(r => setTimeout(() => r(n), 5));
+            const z = p();
+            const w = q(2);
+            console.log("made");
+            """;
+
+        var errors = TestHarness.CompileAndVerifyOnly(source);
+
+        Assert.Empty(errors);
+    }
+
+    [Fact]
     public void Closures_PassesILVerification()
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/AwaitDeferredSpillTests.cs
+++ b/SharpTS.Tests/SharedTests/AwaitDeferredSpillTests.cs
@@ -224,4 +224,84 @@ public class AwaitDeferredSpillTests
             """;
         Assert.Equal("concat: 6\n", TestHarness.Run(source, mode));
     }
+
+    // #436: a fixed-arity (non-rest) top-level function call where an earlier argument precedes a
+    // deferred await. The direct-call path spilled earlier args to *parameter-typed* IL locals,
+    // which do not survive a deferred MoveNext re-entry (only registered field-backed spills do),
+    // so the earlier arg read back as null (`nullB`) and the typed reload also failed IL verify.
+    // The earlier args are now spilled to registered, boxed locals and coerced back to their
+    // declared parameter slot (string / number / boolean) on load.
+    private const string FixedArityScaffold =
+        "function concat2(x: string, y: string): string { return x + y; }\n" +
+        "function add3(a: number, b: number, c: number): number { return a + b + c; }\n" +
+        "function pick(flag: boolean, a: string, b: string): string { return flag ? a : b; }\n";
+
+    private static string RunFns(string body, ExecutionMode mode)
+        => TestHarness.Run(Defer + FixedArityScaffold + "async function m() {\n" + body + "\n}\nm();\n", mode);
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void FixedArityCall_EarlierStringArgSurvivesDeferredAwait(ExecutionMode mode)
+    {
+        // The exact #436 repro shape: f("A", await ...) lost "A" → "nullB".
+        Assert.Equal("AB\n", RunFns("""console.log(concat2("A", await defer("B", 5)));""", mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void FixedArityCall_NumericArgsSurviveDeferredAwait(ExecutionMode mode)
+    {
+        // Numeric (double) parameters: earlier args boxed across the await, unboxed back on load.
+        Assert.Equal("6\n", RunFns("""console.log(add3(1, await defer(2, 5), 3));""", mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void FixedArityCall_TwoDeferredAwaitArgs(ExecutionMode mode)
+    {
+        Assert.Equal("12\n", RunFns("""console.log(add3(await defer(3, 5), 4, await defer(5, 5)));""", mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void FixedArityCall_BooleanArgBeforeDeferredAwait(ExecutionMode mode)
+    {
+        Assert.Equal("yes\n", RunFns("""console.log(pick(true, await defer("yes", 5), "no"));""", mode));
+    }
+
+    // #439: a method call (instance, static, optional-chain) where an earlier argument precedes a
+    // deferred await. These dispatch paths emitted the receiver and earlier args onto the IL stack
+    // (or into unregistered temps) across the suspension — invalid IL and a runtime crash. The
+    // receiver and arguments are now spilled to registered locals and coerced to their slots.
+    private const string MethodScaffold =
+        "class Calc {\n" +
+        "  join(a: string, b: string): string { return a + b; }\n" +
+        "  static mul(a: number, b: number): number { return a * b; }\n" +
+        "}\n";
+
+    private static string RunMethods(string body, ExecutionMode mode)
+        => TestHarness.Run(Defer + MethodScaffold + "async function m() {\n" + body + "\n}\nm();\n", mode);
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void InstanceMethodCall_EarlierArgSurvivesDeferredAwait(ExecutionMode mode)
+    {
+        Assert.Equal("AB\n", RunMethods("""const c = new Calc(); console.log(c.join("A", await defer("B", 5)));""", mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void StaticMethodCall_EarlierArgSurvivesDeferredAwait(ExecutionMode mode)
+    {
+        Assert.Equal("42\n", RunMethods("""console.log(Calc.mul(6, await defer(7, 5)));""", mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void OptionalChainMethodCall_EarlierArgSurvivesDeferredAwait(ExecutionMode mode)
+    {
+        Assert.Equal("AB\n", RunMethods(
+            """const o: any = { go(a: string, b: string): string { return a + b; } }; console.log(o?.go("A", await defer("B", 5)));""",
+            mode));
+    }
 }


### PR DESCRIPTION
Fixes three compiled-mode IL bugs in the shared call/await emission paths used by async/generator state machines, and closes a fourth that was already fixed. All four surfaced as `StackUnexpected`/`PathStackDepth` under `--verify` (with value loss or crashes at runtime); the interpreter was correct in every case. Full suite: **12259 passed, 0 failed**.

## #436 — fixed-arity free-function call `f(x, await deferred)`
The direct-call path spilled each earlier argument to a **parameter-typed** IL local. A typed local does not survive a deferred `MoveNext` re-entry (only state-machine fields do, #400), so `x` read back as `null` (`nullB`) and the typed reload also failed verification. Earlier args are now spilled to a **registered, boxed** object local (`SpillConvertedArg`) and coerced back to their declared slot on load — **only when a later argument can actually suspend** (`AnyContainsSuspension`), so the synchronous `ILEmitter` and await-free calls keep the cheaper unboxed typed-local path (no perf regression on the hot call path).

## #439 — method calls with an await after an earlier argument
Instance (`TryEmitDirectMethodCall`), static (`TryEmitGetCalleeViaBaseClass`), and optional-chain (`TryEmitOptionalChainMethodCall`) dispatch left the receiver/earlier args on the IL stack (or in unregistered temps) across the suspension. They now spill the receiver and arguments to registered locals and coerce each loaded arg to its declared parameter slot. `TryEmitDirectMethodCall` additionally now downcasts reference-typed parameters (`castclass`), fixing a **pre-existing** verify gap that also affected the no-await case (`c.m("A","B")` in an async body).

## #441 — `await <call>` (or any numeric-param call) inside an async arrow
`AsyncArrowMoveNextEmitter` overrode `EmitLiteral` to eagerly box number/boolean literals and set `StackType=Unknown`, desyncing `EmitConversionForParameter`'s unboxed-double fast path so a numeric argument stored a boxed object into a `double` IL slot. Removed the stale override (a leftover from before the "eliminate 5-way emitter sync" consolidation) so the arrow inherits the base `EmitLiteral` (unboxed value types + tracked `StackType`), matching every other emitter; updated the `EmitterSync` allowlist.

## #442 — `new Promise(executor)` inside a function body
**Already fixed** by #393 (PR #438): a non-async `Promise<T>` return slot mapped to `Task<T>` while the body returned the runtime `$TSPromise` (object). Confirmed via a revert experiment (reverting d0ceb9f9 reproduces `$Program.p: StackUnexpected`). The #414 branch that filed it predated #438 by ~14 min. Added a regression guard for the exact `new Promise(executor)` shape (#438's tests used `Promise.resolve`) and closed the issue.

## Tests
- `AwaitDeferredSpillTests`: #436 (fixed-arity; numeric/boolean params; two awaits) and #439 (instance/static/optional-chain) — behavior, both interpreter and compiler.
- `ILVerificationTests`: verify-only guards for #436, #439, #441, #442.

## Follow-ups filed
- #614 — await in an optional-chain **dispatchable-string-method** arg crashes at compile time (`EmitRuntimeStringMethod` is not await-aware). Pre-existing; confirmed via stash.
- #615 — an async **arrow** that nests another async-arrow expression fails to compile (`SelfBoxedField not set`). Pre-existing.

Closes #436, #439, #441, #442.
