### PR TITLE
Fix #526, #598, #599: compiled generator try/finally external completion, finally-body exits, exception survival

### DIFF
--- a/Compilation/GeneratorMoveNextEmitter.Expressions.Yield.cs
+++ b/Compilation/GeneratorMoveNextEmitter.Expressions.Yield.cs
@@ -56,6 +56,10 @@ public partial class GeneratorMoveNextEmitter
         // Restore spill temps from their fields on the resumed path.
         _helpers.RehydrateLiveSpillsAfterResume();
 
+        // 5a. An external return()/throw() on the suspended generator injects an abrupt completion
+        // here, running active try/finally(/catch) (#526). With nothing pending this falls through.
+        EmitResumeInjectionCheck();
+
         // 6. The yield expression evaluates to the value passed to next(v), which
         // next() stashed in SentField before driving MoveNext (ECMA-262 §27.5.3.3, #452).
         // A bare next()/for-of resume leaves it as the caller's sent value (undefined) — so
@@ -274,7 +278,19 @@ public partial class GeneratorMoveNextEmitter
         {
             driveViaGeneratorLabel = _il.DefineLabel();
             genDoneLabel = _il.DefineLabel();
+        }
 
+        // #526: an external return()/throw() injected while suspended at this yield* is forwarded
+        // into the delegate (ECMA-262 §14.4.14): return() runs the delegate's finally, then the outer
+        // returns (or, if the delegate's finally yields, the outer yields and stays delegating);
+        // throw() lets the delegate catch (then the outer continues past yield*) or, uncaught,
+        // re-raises here. Emits nothing that transfers control when no injection is pending.
+        EmitYieldStarResumeInjectionCheck(
+            delegatedField, generatorInterfaceType, genResultLocal, valueTemp,
+            yieldStarResultLocal, haveValueLabel, genDoneLabel, doneCleanupLabel);
+
+        if (generatorInterfaceType != null)
+        {
             _il.Emit(OpCodes.Ldarg_0);
             _il.Emit(OpCodes.Ldfld, delegatedField);
             _il.Emit(OpCodes.Isinst, generatorInterfaceType);
@@ -389,6 +405,159 @@ public partial class GeneratorMoveNextEmitter
         // yield* evaluates to the delegated iterator's return value (captured above).
         _il.Emit(OpCodes.Ldloc, yieldStarResultLocal);
         SetStackUnknown();
+    }
+
+    /// <summary>
+    /// At a <c>yield*</c> resume point, forwards an external return()/throw() injected on the outer
+    /// generator into the delegated iterator (ECMA-262 §14.4.14, #526). Only an <c>$IGenerator</c>
+    /// delegate carries return/throw; a plain iterable (array, string, Map/Set) has neither, so the
+    /// outer simply returns the value / re-raises the error after closing the delegate. Emits nothing
+    /// that transfers control when no injection is pending, so the normal per-element drive runs.
+    /// </summary>
+    private void EmitYieldStarResumeInjectionCheck(
+        FieldBuilder delegatedField,
+        Type? generatorInterfaceType,
+        LocalBuilder genResultLocal,
+        LocalBuilder valueTemp,
+        LocalBuilder yieldStarResultLocal,
+        Label haveValueLabel,
+        Label genDoneLabel,
+        Label doneCleanupLabel)
+    {
+        var kindField = _builder.InjectedKindField;
+        var valueField = _builder.InjectedValueField;
+        if (kindField == null || valueField == null) return;
+
+        void LoadInjectedValue()
+        {
+            _il.Emit(OpCodes.Ldarg_0);
+            _il.Emit(OpCodes.Ldfld, valueField);
+        }
+
+        // ---- return(v) forwarding ----
+        var afterReturn = _il.DefineLabel();
+        _il.Emit(OpCodes.Ldarg_0);
+        _il.Emit(OpCodes.Ldfld, kindField);
+        _il.Emit(OpCodes.Ldc_I4, GeneratorStateMachineBuilder.InjectKindReturn);
+        _il.Emit(OpCodes.Bne_Un, afterReturn);
+        ClearInjectedKind();
+
+        if (generatorInterfaceType != null)
+        {
+            var notGenReturn = _il.DefineLabel();
+            _il.Emit(OpCodes.Ldarg_0);
+            _il.Emit(OpCodes.Ldfld, delegatedField);
+            _il.Emit(OpCodes.Isinst, generatorInterfaceType);
+            _il.Emit(OpCodes.Brfalse, notGenReturn);
+
+            // result = delegate.return(injectedValue) — runs the delegate's finally(s).
+            _il.Emit(OpCodes.Ldarg_0);
+            _il.Emit(OpCodes.Ldfld, delegatedField);
+            _il.Emit(OpCodes.Castclass, generatorInterfaceType);
+            LoadInjectedValue();
+            _il.Emit(OpCodes.Callvirt, _ctx!.Runtime!.GeneratorReturnMethod);
+            _il.Emit(OpCodes.Stloc, genResultLocal);
+
+            // result.done → the outer returns result.value (§14.4.14 c.7); else the delegate's
+            // finally yielded, so the outer yields result.value and stays delegating.
+            var innerReturnNotDone = _il.DefineLabel();
+            _il.Emit(OpCodes.Ldloc, genResultLocal);
+            _il.Emit(OpCodes.Call, _ctx.Runtime.GetIteratorDone);
+            _il.Emit(OpCodes.Brfalse, innerReturnNotDone);
+            ClearDelegateField(delegatedField);
+            EmitRoutedReturn(() =>
+            {
+                _il.Emit(OpCodes.Ldloc, genResultLocal);
+                _il.Emit(OpCodes.Call, _ctx.Runtime.GetIteratorValue);
+            });
+
+            _il.MarkLabel(innerReturnNotDone);
+            _il.Emit(OpCodes.Ldloc, genResultLocal);
+            _il.Emit(OpCodes.Call, _ctx.Runtime.GetIteratorValue);
+            _il.Emit(OpCodes.Stloc, valueTemp);
+            _il.Emit(OpCodes.Br, haveValueLabel);
+
+            _il.MarkLabel(notGenReturn);
+        }
+
+        // Plain iterable: no return() to forward — close it and the outer returns the value.
+        ClearDelegateField(delegatedField);
+        EmitRoutedReturn(LoadInjectedValue);
+
+        _il.MarkLabel(afterReturn);
+
+        // ---- throw(e) forwarding ----
+        var afterThrow = _il.DefineLabel();
+        _il.Emit(OpCodes.Ldarg_0);
+        _il.Emit(OpCodes.Ldfld, kindField);
+        _il.Emit(OpCodes.Ldc_I4, GeneratorStateMachineBuilder.InjectKindThrow);
+        _il.Emit(OpCodes.Bne_Un, afterThrow);
+        ClearInjectedKind();
+
+        if (generatorInterfaceType != null)
+        {
+            var notGenThrow = _il.DefineLabel();
+            _il.Emit(OpCodes.Ldarg_0);
+            _il.Emit(OpCodes.Ldfld, delegatedField);
+            _il.Emit(OpCodes.Isinst, generatorInterfaceType);
+            _il.Emit(OpCodes.Brfalse, notGenThrow);
+
+            // Drive delegate.throw(injectedValue) in a mini try/catch so an inner rethrow (the
+            // delegate has no handler, §14.4.14 b.ii) is captured and re-raised at this point —
+            // running the outer's own catch/finally — rather than escaping MoveNext directly.
+            var caughtLocal = _il.DeclareLocal(typeof(object));
+            _il.Emit(OpCodes.Ldnull);
+            _il.Emit(OpCodes.Stloc, caughtLocal);
+            _il.BeginExceptionBlock();
+            _il.Emit(OpCodes.Ldarg_0);
+            _il.Emit(OpCodes.Ldfld, delegatedField);
+            _il.Emit(OpCodes.Castclass, generatorInterfaceType);
+            LoadInjectedValue();
+            _il.Emit(OpCodes.Callvirt, _ctx!.Runtime!.GeneratorThrowMethod);
+            _il.Emit(OpCodes.Stloc, genResultLocal);
+            _il.BeginCatchBlock(typeof(Exception));
+            _il.Emit(OpCodes.Call, _ctx.Runtime.WrapException);
+            _il.Emit(OpCodes.Stloc, caughtLocal);
+            _il.EndExceptionBlock();
+
+            // Inner rethrew → re-raise at this point (runs the outer's catch/finally).
+            var innerHandled = _il.DefineLabel();
+            _il.Emit(OpCodes.Ldloc, caughtLocal);
+            _il.Emit(OpCodes.Brfalse, innerHandled);
+            ClearDelegateField(delegatedField);
+            EmitRoutedThrow(() => _il.Emit(OpCodes.Ldloc, caughtLocal));
+
+            // Inner handled it: done → yield* value as a normal completion, the outer continues past
+            // yield* (§14.4.14 b.5); else the delegate yielded again, so the outer yields and stays.
+            _il.MarkLabel(innerHandled);
+            var innerThrowNotDone = _il.DefineLabel();
+            _il.Emit(OpCodes.Ldloc, genResultLocal);
+            _il.Emit(OpCodes.Call, _ctx.Runtime.GetIteratorDone);
+            _il.Emit(OpCodes.Brfalse, innerThrowNotDone);
+            _il.Emit(OpCodes.Br, genDoneLabel);
+
+            _il.MarkLabel(innerThrowNotDone);
+            _il.Emit(OpCodes.Ldloc, genResultLocal);
+            _il.Emit(OpCodes.Call, _ctx.Runtime.GetIteratorValue);
+            _il.Emit(OpCodes.Stloc, valueTemp);
+            _il.Emit(OpCodes.Br, haveValueLabel);
+
+            _il.MarkLabel(notGenThrow);
+        }
+
+        // Plain iterable: no throw() to forward — close it and re-raise the error at this point.
+        ClearDelegateField(delegatedField);
+        EmitRoutedThrow(LoadInjectedValue);
+
+        _il.MarkLabel(afterThrow);
+    }
+
+    /// <summary>Clears the delegated-enumerator field once a <c>yield*</c> delegation has ended.</summary>
+    private void ClearDelegateField(FieldBuilder delegatedField)
+    {
+        _il.Emit(OpCodes.Ldarg_0);
+        _il.Emit(OpCodes.Ldnull);
+        _il.Emit(OpCodes.Stfld, delegatedField);
     }
 
     private static System.Reflection.FieldInfo? _currentStackDepthField;

--- a/Compilation/GeneratorMoveNextEmitter.Statements.TryCatch.cs
+++ b/Compilation/GeneratorMoveNextEmitter.Statements.TryCatch.cs
@@ -359,7 +359,16 @@ public partial class GeneratorMoveNextEmitter
             || (t.CatchBlock != null && ContainsYield(t.CatchBlock))
             || (t.FinallyBlock != null && ContainsYield(t.FinallyBlock));
 
-        if (hasYields)
+        // A return/break/continue lexically inside the finally body can never be lowered with the
+        // real-IL path: none of `ret`/`br`/`Leave` may exit a .NET `finally` region, so it would emit
+        // invalid IL (LeaveOutOfFinally). Route the whole construct through the flag-based scheme even
+        // with no yield, so the finally is emitted as top-level statements and the exit is dispatched
+        // legally (#598, the finally-side analog of #554, which handles exits in the try/catch body).
+        // An exit targeting a loop *inside* the finally stays local and does not count as escaping.
+        bool finallyHasEscapingExit = t.FinallyBlock != null
+            && ContainsEscapingExit2(t.FinallyBlock, insideLoop: false, insideSwitch: false);
+
+        if (hasYields || finallyHasEscapingExit)
             EmitTryCatchWithYields(t);
         else
             EmitSimpleTryCatch(t);

--- a/Compilation/GeneratorMoveNextEmitter.Statements.TryCatch.cs
+++ b/Compilation/GeneratorMoveNextEmitter.Statements.TryCatch.cs
@@ -96,6 +96,18 @@ public partial class GeneratorMoveNextEmitter
         _pendingReturnValueField ??= _builder.StateMachineType.DefineField(
             "<>pendingReturnValue", typeof(object), FieldAttributes.Private);
 
+    // Per-construct fields holding a try-body exception across a *yielding* finally in a try/finally
+    // with no catch (#599). The exception is captured into an IL local during the try body, but that
+    // local resets when the yielding finally suspends MoveNext, so the post-finally rethrow would see
+    // null and silently drop it. Persisting to a field before the finally keeps it alive. Each
+    // qualifying construct gets its own field rather than sharing one: a nested persisting construct
+    // inside the finally body would otherwise clobber the outer's captured exception.
+    private int _caughtExceptionFieldCounter;
+
+    private FieldBuilder DefineCaughtExceptionField() =>
+        _builder.StateMachineType.DefineField(
+            $"<>caughtException{_caughtExceptionFieldCounter++}", typeof(object), FieldAttributes.Private);
+
     // ---- Loop-scope methods (override the base stack to use `_exitScopes`) -----------------------
 
     protected override void EnterLoop(Label breakLabel, Label continueLabel, string? labelName = null)
@@ -435,6 +447,28 @@ public partial class GeneratorMoveNextEmitter
         var caughtExceptionLocal = _il.DeclareLocal(typeof(object));
         var afterTryBodyLabel = _il.DefineLabel();
 
+        // #599: in a try/finally with no catch whose finally can yield, the captured try-body
+        // exception must survive the finally's suspension. The IL local resets on MoveNext re-entry,
+        // so persist it to a dedicated field before the finally and read that field in the
+        // post-finally rethrow. Allocated only for that shape; null means "use the local".
+        FieldBuilder? caughtExceptionField =
+            t.CatchBlock == null && t.FinallyBlock != null && ContainsYield(t.FinallyBlock)
+                ? DefineCaughtExceptionField()
+                : null;
+
+        void EmitLoadCaughtException()
+        {
+            if (caughtExceptionField != null)
+            {
+                _il.Emit(OpCodes.Ldarg_0);
+                _il.Emit(OpCodes.Ldfld, caughtExceptionField);
+            }
+            else
+            {
+                _il.Emit(OpCodes.Ldloc, caughtExceptionLocal);
+            }
+        }
+
         // No exception captured yet.
         _il.Emit(OpCodes.Ldnull);
         _il.Emit(OpCodes.Stloc, caughtExceptionLocal);
@@ -492,6 +526,15 @@ public partial class GeneratorMoveNextEmitter
         // Finally: always runs — on normal completion, after a caught exception, or on a routed exit.
         if (t.FinallyBlock != null)
         {
+            // #599: persist the captured exception (null on the normal/routed-exit paths) before the
+            // finally so a suspension inside it does not wipe the IL local out from under the rethrow.
+            if (caughtExceptionField != null)
+            {
+                _il.Emit(OpCodes.Ldarg_0);
+                _il.Emit(OpCodes.Ldloc, caughtExceptionLocal);
+                _il.Emit(OpCodes.Stfld, caughtExceptionField);
+            }
+
             _inHandlerBody = true;
             foreach (var stmt in t.FinallyBlock)
                 EmitStatement(stmt);
@@ -505,14 +548,14 @@ public partial class GeneratorMoveNextEmitter
         if (t.CatchBlock == null)
         {
             var noExceptionLabel = _il.DefineLabel();
-            _il.Emit(OpCodes.Ldloc, caughtExceptionLocal);
+            EmitLoadCaughtException();
             _il.Emit(OpCodes.Brfalse, noExceptionLabel);
 
             // Mark the generator done before the exception leaves MoveNext.
             _il.Emit(OpCodes.Ldarg_0);
             _il.Emit(OpCodes.Ldc_I4, -2);
             _il.Emit(OpCodes.Stfld, _builder.StateField);
-            _il.Emit(OpCodes.Ldloc, caughtExceptionLocal);
+            EmitLoadCaughtException();
             _il.Emit(OpCodes.Call, _ctx!.Runtime!.CreateException);
             _il.Emit(OpCodes.Throw);
 

--- a/Compilation/GeneratorMoveNextEmitter.Statements.TryCatch.cs
+++ b/Compilation/GeneratorMoveNextEmitter.Statements.TryCatch.cs
@@ -69,6 +69,14 @@ public partial class GeneratorMoveNextEmitter
     // be routed). Saved/restored around each region so nesting is handled correctly.
     private bool _inHandlerBody;
 
+    // The innermost flag-based try whose *body* is currently being emitted: its catch/finally entry
+    // (afterTryBodyLabel) and the local capturing a try-body exception. An external throw() injected
+    // at a yield in this body behaves as if the body threw there — it stores the error into this
+    // local and branches to the cleanup so the catch/finally run (#526). Saved/restored around the
+    // try-body emission, so it is null (or the enclosing try's) while emitting a catch/finally body,
+    // where `_inHandlerBody` instead routes an injected throw through the enclosing finally(s).
+    private (Label AfterTryBody, LocalBuilder CaughtException)? _tryBodyContext;
+
     // `<>pendingExit` (int): the code of an in-flight non-local exit, or 0 when none. A finally that
     // yields suspends MoveNext mid-routing, so this must be a field (a local would reset on re-entry).
     // Set once per exit and cleared by the terminal dispatch; defaults to 0 on a fresh state machine.
@@ -348,6 +356,132 @@ public partial class GeneratorMoveNextEmitter
         _il.Emit(OpCodes.Throw);
     });
 
+    // ---- External return()/throw() injection at a suspended yield (#526) -------------------------
+
+    /// <summary>
+    /// At a yield resume point, consult the injection fields a suspended generator's
+    /// return()/throw() set (#526) and, if one is pending, perform that abrupt completion here —
+    /// running active try/finally(/catch) — instead of resuming normally. Emits nothing that
+    /// transfers control when no injection is pending, so the caller's normal-resume code runs. A
+    /// no-op when the $IGenerator methods (hence the injection fields) were not emitted.
+    /// </summary>
+    private void EmitResumeInjectionCheck()
+    {
+        var kindField = _builder.InjectedKindField;
+        var valueField = _builder.InjectedValueField;
+        if (kindField == null || valueField == null) return;
+
+        void LoadInjectedValue()
+        {
+            _il.Emit(OpCodes.Ldarg_0);
+            _il.Emit(OpCodes.Ldfld, valueField);
+        }
+
+        // return(v): behaves as `return v` at this point (consume the kind first so a yielding
+        // finally that re-enters MoveNext does not re-inject).
+        var afterReturn = _il.DefineLabel();
+        _il.Emit(OpCodes.Ldarg_0);
+        _il.Emit(OpCodes.Ldfld, kindField);
+        _il.Emit(OpCodes.Ldc_I4, GeneratorStateMachineBuilder.InjectKindReturn);
+        _il.Emit(OpCodes.Bne_Un, afterReturn);
+        ClearInjectedKind();
+        EmitRoutedReturn(LoadInjectedValue);
+        _il.MarkLabel(afterReturn);
+
+        // throw(e): behaves as `throw e` at this point.
+        var afterThrow = _il.DefineLabel();
+        _il.Emit(OpCodes.Ldarg_0);
+        _il.Emit(OpCodes.Ldfld, kindField);
+        _il.Emit(OpCodes.Ldc_I4, GeneratorStateMachineBuilder.InjectKindThrow);
+        _il.Emit(OpCodes.Bne_Un, afterThrow);
+        ClearInjectedKind();
+        EmitRoutedThrow(LoadInjectedValue);
+        _il.MarkLabel(afterThrow);
+    }
+
+    private void ClearInjectedKind()
+    {
+        _il.Emit(OpCodes.Ldarg_0);
+        _il.Emit(OpCodes.Ldc_I4, GeneratorStateMachineBuilder.InjectKindNone);
+        _il.Emit(OpCodes.Stfld, _builder.InjectedKindField!);
+    }
+
+    /// <summary>
+    /// Emits an abrupt <c>return &lt;value&gt;</c> at a top-level resume point: store the value into
+    /// Current, mark the generator done, and route through any enclosing flag-based finally(s) so
+    /// they run before completion. <paramref name="loadValue"/> pushes the boxed completion value.
+    /// Mirrors <see cref="EmitReturn"/>'s chain logic, but the value is supplied (not evaluated from
+    /// an expression) and the resume point is always at the top level, so the route uses <c>Br</c>.
+    /// </summary>
+    private void EmitRoutedReturn(Action loadValue)
+    {
+        _il.Emit(OpCodes.Ldarg_0);
+        loadValue();
+        _il.Emit(OpCodes.Stfld, _builder.CurrentField);
+        _il.Emit(OpCodes.Ldarg_0);
+        _il.Emit(OpCodes.Ldc_I4, -2);
+        _il.Emit(OpCodes.Stfld, _builder.StateField);
+
+        var chain = ActiveFinallyFrames();
+        if (chain.Count > 0)
+        {
+            // Stash the completion value: a yielding finally overwrites Current; the return terminal
+            // restores it after the finally has run (#555).
+            _il.Emit(OpCodes.Ldarg_0);
+            _il.Emit(OpCodes.Ldarg_0);
+            _il.Emit(OpCodes.Ldfld, _builder.CurrentField);
+            _il.Emit(OpCodes.Stfld, GetPendingReturnValueField());
+
+            RegisterReturnTerminal();
+            RouteThroughFinallys(chain, ExitCodeReturn, OpCodes.Br);
+            return;
+        }
+
+        _il.Emit(OpCodes.Ldc_I4_0);
+        _il.Emit(OpCodes.Ret);
+    }
+
+    /// <summary>
+    /// Emits a <c>throw &lt;value&gt;</c> at a top-level resume point. Inside a try body it behaves
+    /// as if the body threw there (store into the try's caught-exception local and branch to its
+    /// cleanup, so the catch/finally run); inside a catch/finally body it routes through the
+    /// enclosing finally(s); with no enclosing try it propagates out of MoveNext. <paramref
+    /// name="loadValue"/> pushes the boxed guest error value.
+    /// </summary>
+    private void EmitRoutedThrow(Action loadValue)
+    {
+        if (!_inHandlerBody && _tryBodyContext is { } tryBody)
+        {
+            // In a try body: capture exactly like a try-body exception so the catch/finally at
+            // afterTryBodyLabel handle it. A catch-less yielding finally persists this local to a
+            // field before suspending, so it survives (#599).
+            loadValue();
+            _il.Emit(OpCodes.Stloc, tryBody.CaughtException);
+            _il.Emit(OpCodes.Br, tryBody.AfterTryBody);
+            return;
+        }
+
+        var chain = ActiveFinallyFrames();
+        if (chain.Count > 0)
+        {
+            // In a catch/finally body: run the enclosing finally(s), then rethrow at the terminal.
+            _il.Emit(OpCodes.Ldarg_0);
+            loadValue();
+            _il.Emit(OpCodes.Stfld, GetPendingExceptionField());
+            RegisterThrowTerminal();
+            RouteThroughFinallys(chain, ExitCodeThrow, OpCodes.Br);
+            return;
+        }
+
+        // No enclosing try: mark done and propagate out of MoveNext.
+        _il.Emit(OpCodes.Ldarg_0);
+        _il.Emit(OpCodes.Ldc_I4, -2);
+        _il.Emit(OpCodes.Stfld, _builder.StateField);
+        loadValue();
+        _il.Emit(OpCodes.Call, _ctx!.Runtime!.CreateException);
+        _il.Emit(OpCodes.Throw);
+    }
+
     /// <summary>
     /// Emits try/catch/finally. When a yield crosses the protected region, real IL exception
     /// blocks cannot be used (the state-dispatch switch can't branch into a protected region,
@@ -493,10 +627,15 @@ public partial class GeneratorMoveNextEmitter
             _exitScopes.Add(frame);
         }
 
-        // Throws in the try body are captured by their sync segments, not routed.
+        // Throws in the try body are captured by their sync segments, not routed. While emitting the
+        // body, expose this try as the injected-throw target so an external throw() at a yield here
+        // engages this try's catch/finally (#526).
         bool previousInHandler = _inHandlerBody;
+        var previousTryBody = _tryBodyContext;
         _inHandlerBody = false;
+        _tryBodyContext = (afterTryBodyLabel, caughtExceptionLocal);
         EmitTryBodyWithYields(t.TryBlock, caughtExceptionLocal, afterTryBodyLabel);
+        _tryBodyContext = previousTryBody;
         _inHandlerBody = previousInHandler;
 
         _il.MarkLabel(afterTryBodyLabel);

--- a/Compilation/GeneratorStateMachineBuilder.cs
+++ b/Compilation/GeneratorStateMachineBuilder.cs
@@ -36,6 +36,18 @@ public class GeneratorStateMachineBuilder
     // the $IGenerator methods are emitted (see DefineGeneratorMethods).
     public FieldBuilder? ExecutingField { get; private set; }
 
+    // An external return()/throw() on a *suspended* generator injects an abrupt completion at the
+    // yield point so active try/finally(/catch) run (ECMA-262 §27.5.3.4, #526). return()/throw() set
+    // these and drive MoveNext, which the yield-resume code consults: InjectKindReturn behaves as a
+    // `return InjectedValue`, InjectKindThrow as a `throw InjectedValue`, routed through the
+    // flag-based try machinery. Defined alongside the $IGenerator methods. Null kind = InjectKindNone.
+    public const int InjectKindNone = 0;
+    public const int InjectKindReturn = 1;
+    public const int InjectKindThrow = 2;
+
+    public FieldBuilder? InjectedKindField { get; private set; }
+    public FieldBuilder? InjectedValueField { get; private set; }
+
     // Hoisted variables (become struct fields) - delegated to HoistingManager.
     // Captured outer-scope variables are intentionally NOT hoisted: a generator reads them
     // live from their enclosing storage (entry-point display class / top-level static fields)
@@ -432,6 +444,12 @@ public class GeneratorStateMachineBuilder
             FieldAttributes.Private);
         ExecutingField = executingField;
 
+        // Injection state for external return()/throw() on a suspended generator (#526).
+        InjectedKindField = _stateMachineType.DefineField(
+            "<>6__injectedKind", _types.Int32, FieldAttributes.Private);
+        InjectedValueField = _stateMachineType.DefineField(
+            "<>6__injectedValue", _types.Object, FieldAttributes.Private);
+
         // next() method - wraps MoveNext/Current into iterator result
         // Using lowercase to match JavaScript API
         NextMethod = _stateMachineType.DefineMethod(
@@ -523,7 +541,18 @@ public class GeneratorStateMachineBuilder
         // Reject a re-entrant return() (ECMA-262 §27.5.3.3) before mutating state.
         EmitThrowIfExecuting(returnIL, executingField);
 
-        // Set state to -2 (completed)
+        // Suspended at a yield (state >= 0): inject a return so the body resumes there as an abrupt
+        // completion, running active finally(s), then settle from the resulting state (#526).
+        var returnNotSuspended = returnIL.DefineLabel();
+        returnIL.Emit(OpCodes.Ldarg_0);
+        returnIL.Emit(OpCodes.Ldfld, StateField);
+        returnIL.Emit(OpCodes.Ldc_I4_0);
+        returnIL.Emit(OpCodes.Blt, returnNotSuspended);
+        EmitInjectAndResume(returnIL, InjectKindReturn);
+
+        // Not started or already completed: close without running the body — its finally never runs
+        // (ECMA-262 §27.5.3.4) — and report { value: arg, done: true }.
+        returnIL.MarkLabel(returnNotSuspended);
         returnIL.Emit(OpCodes.Ldarg_0);
         returnIL.Emit(OpCodes.Ldc_I4, -2);
         returnIL.Emit(OpCodes.Stfld, StateField);
@@ -558,7 +587,18 @@ public class GeneratorStateMachineBuilder
         // takes precedence over injecting the caller's error into the running body.
         EmitThrowIfExecuting(throwIL, executingField);
 
-        // Set state to -2 (completed)
+        // Suspended at a yield (state >= 0): inject the error so the body resumes there as a throw,
+        // giving an enclosing catch/finally a chance to run (#526). If nothing handles it, MoveNext
+        // rethrows and the error propagates out of throw() — exactly the not-suspended behaviour below.
+        var throwNotSuspended = throwIL.DefineLabel();
+        throwIL.Emit(OpCodes.Ldarg_0);
+        throwIL.Emit(OpCodes.Ldfld, StateField);
+        throwIL.Emit(OpCodes.Ldc_I4_0);
+        throwIL.Emit(OpCodes.Blt, throwNotSuspended);
+        EmitInjectAndResume(throwIL, InjectKindThrow);
+
+        // Not started or already completed: close and throw without running the body.
+        throwIL.MarkLabel(throwNotSuspended);
         throwIL.Emit(OpCodes.Ldarg_0);
         throwIL.Emit(OpCodes.Ldc_I4, -2);
         throwIL.Emit(OpCodes.Stfld, StateField);
@@ -603,5 +643,57 @@ public class GeneratorStateMachineBuilder
         il.Emit(OpCodes.Call, _runtime!.CreateException);
         il.Emit(OpCodes.Throw);
         il.MarkLabel(okLabel);
+    }
+
+    /// <summary>
+    /// Emits the suspended-generator arm of return()/throw() (#526): stash the injected kind and the
+    /// argument (arg1), drive MoveNext under the executing guard (so the resumed body sees the
+    /// injection at its yield point and runs active finally/catch), then settle as
+    /// <c>{ value: Current, done: !moved }</c>. A finally that yields makes MoveNext return true, so
+    /// the abrupt completion is reported as a non-done yield and finished on a later call — mirroring
+    /// the interpreter. If MoveNext rethrows an uncaught injected throw, it propagates out unchanged.
+    /// Ends with <c>ret</c>; only called when <see cref="InjectedKindField"/> et al. are defined.
+    /// </summary>
+    private void EmitInjectAndResume(ILGenerator il, int injectKind)
+    {
+        // injectedValue = arg1; injectedKind = injectKind
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Stfld, InjectedValueField!);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldc_I4, injectKind);
+        il.Emit(OpCodes.Stfld, InjectedKindField!);
+
+        // executing = true; try { moved = MoveNext(); } finally { executing = false; }
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Stfld, ExecutingField!);
+        var movedLocal = il.DeclareLocal(_types.Boolean);
+        il.BeginExceptionBlock();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Call, MoveNextMethod);
+        il.Emit(OpCodes.Stloc, movedLocal);
+        il.BeginFinallyBlock();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Stfld, ExecutingField!);
+        il.EndExceptionBlock();
+
+        // return { value: Current, done: (moved ? false : true) }
+        var setItem = _types.GetMethod(_types.DictionaryStringObject, "set_Item", _types.String, _types.Object);
+        il.Emit(OpCodes.Newobj, _types.GetDefaultConstructor(_types.DictionaryStringObject));
+        il.Emit(OpCodes.Dup);
+        il.Emit(OpCodes.Ldstr, "value");
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, CurrentField);
+        il.Emit(OpCodes.Callvirt, setItem);
+        il.Emit(OpCodes.Dup);
+        il.Emit(OpCodes.Ldstr, "done");
+        il.Emit(OpCodes.Ldloc, movedLocal);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Ceq);   // !moved
+        il.Emit(OpCodes.Box, _types.Boolean);
+        il.Emit(OpCodes.Callvirt, setItem);
+        il.Emit(OpCodes.Ret);
     }
 }

--- a/Compilation/RuntimeEmitter.Objects.Invocation.cs
+++ b/Compilation/RuntimeEmitter.Objects.Invocation.cs
@@ -943,22 +943,29 @@ public partial class RuntimeEmitter
             // ((​$IGenerator)recv).next(args.Length > 0 ? args[0] : undefined)
             il.Emit(OpCodes.Ldarg_0);
             il.Emit(OpCodes.Castclass, runtime.GeneratorInterfaceType);
-            var sentArgLabel = il.DefineLabel();
-            var sentDoneLabel = il.DefineLabel();
-            il.Emit(OpCodes.Ldarg_2);
-            il.Emit(OpCodes.Ldlen);
-            il.Emit(OpCodes.Conv_I4);
-            il.Emit(OpCodes.Brtrue, sentArgLabel);
-            il.Emit(OpCodes.Ldsfld, runtime.UndefinedInstance);
-            il.Emit(OpCodes.Br, sentDoneLabel);
-            il.MarkLabel(sentArgLabel);
-            il.Emit(OpCodes.Ldarg_2);
-            il.Emit(OpCodes.Ldc_I4_0);
-            il.Emit(OpCodes.Ldelem_Ref);
-            il.MarkLabel(sentDoneLabel);
+            EmitArgZeroOrUndefined(il, runtime);
             il.Emit(OpCodes.Callvirt, runtime.GeneratorNextMethod);
             il.Emit(OpCodes.Ret);
             il.MarkLabel(notGeneratorNextLabel);
+
+            // return(v): forward to $IGenerator.return with the same undefined-default for a missing
+            // argument as next — a bare return() must inject `undefined`, not the null a missing
+            // reflected argument would pad (#526). User iterators with their own return() keep the
+            // GetProperty path below (they do not implement $IGenerator).
+            var notGeneratorReturnLabel = il.DefineLabel();
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Ldstr, "return");
+            il.Emit(OpCodes.Call, _types.StringOpEquality);
+            il.Emit(OpCodes.Brfalse, notGeneratorReturnLabel);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Isinst, runtime.GeneratorInterfaceType);
+            il.Emit(OpCodes.Brfalse, notGeneratorReturnLabel);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Castclass, runtime.GeneratorInterfaceType);
+            EmitArgZeroOrUndefined(il, runtime);
+            il.Emit(OpCodes.Callvirt, runtime.GeneratorReturnMethod);
+            il.Emit(OpCodes.Ret);
+            il.MarkLabel(notGeneratorReturnLabel);
         }
 
         // Resolve the JS-level member first. Generators and user-defined
@@ -1095,6 +1102,28 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Callvirt, setItem);
         il.Emit(OpCodes.Ldloc, resultLocal);
         il.Emit(OpCodes.Ret);
+    }
+
+    /// <summary>
+    /// Pushes <c>args.Length &gt; 0 ? args[0] : $Undefined</c> for the single-argument generator
+    /// protocol methods, so a bare <c>next()</c>/<c>return()</c> injects <c>undefined</c> rather than
+    /// the null a missing reflected argument would pad (#452/#526). Expects the args array in arg2.
+    /// </summary>
+    private void EmitArgZeroOrUndefined(ILGenerator il, EmittedRuntime runtime)
+    {
+        var hasArg = il.DefineLabel();
+        var done = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_2);
+        il.Emit(OpCodes.Ldlen);
+        il.Emit(OpCodes.Conv_I4);
+        il.Emit(OpCodes.Brtrue, hasArg);
+        il.Emit(OpCodes.Ldsfld, runtime.UndefinedInstance);
+        il.Emit(OpCodes.Br, done);
+        il.MarkLabel(hasArg);
+        il.Emit(OpCodes.Ldarg_2);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Ldelem_Ref);
+        il.MarkLabel(done);
     }
 
     private void EmitGetSuperMethod(TypeBuilder typeBuilder, EmittedRuntime runtime)

--- a/SharpTS.Tests/SharedTests/GeneratorTests.cs
+++ b/SharpTS.Tests/SharedTests/GeneratorTests.cs
@@ -685,11 +685,12 @@ public class GeneratorTests
 
     #region return()/throw() resume suspended generator (ECMA-262 §27.5.3.4) — issue #478
 
-    // These are interpreter-only: a try/finally combined with yield currently emits invalid
-    // IL in compiled mode (tracked in issue #477), so the compiled path can't be observed yet.
+    // Run in both modes: the interpreter implemented this in #478; the compiled analog (an external
+    // return()/throw() injecting an abrupt completion at the suspended yield, so active try/finally/
+    // catch run) landed in #526. They double as a cross-mode parity guard.
 
     [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void Generator_Return_RunsFinally_AndReportsValue(ExecutionMode mode)
     {
         // The repro from issue #478: return(v) on a suspended generator resumes it as an
@@ -718,7 +719,7 @@ public class GeneratorTests
     }
 
     [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void Generator_Throw_CaughtByTryCatch_Continues(ExecutionMode mode)
     {
         // throw(e) injects the error at the yield point; an enclosing catch handles it and
@@ -746,7 +747,7 @@ public class GeneratorTests
     }
 
     [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void Generator_Throw_RunsFinally_ThenPropagates(ExecutionMode mode)
     {
         // throw(e) with only a finally (no catch): the finally runs, then the error propagates
@@ -773,7 +774,7 @@ public class GeneratorTests
     }
 
     [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void Generator_Return_RunsNestedFinallyInnerToOuter(ExecutionMode mode)
     {
         var source = """
@@ -799,7 +800,7 @@ public class GeneratorTests
     }
 
     [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void Generator_Return_FinallyThatYields_DefersCompletion(ExecutionMode mode)
     {
         // A finally that yields suspends the pending return; the return value is delivered
@@ -825,7 +826,7 @@ public class GeneratorTests
     }
 
     [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void Generator_Return_FinallyReturnOverridesValue(ExecutionMode mode)
     {
         // A finally that returns its own value overrides the value passed to return().
@@ -848,7 +849,7 @@ public class GeneratorTests
     }
 
     [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void Generator_Return_FinallyThrowOverridesReturn(ExecutionMode mode)
     {
         // A finally that throws overrides the pending return with the thrown error.
@@ -874,7 +875,7 @@ public class GeneratorTests
     }
 
     [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void Generator_ReturnAndThrow_OnNotStarted_DoNotRunBody(ExecutionMode mode)
     {
         // return()/throw() on a generator that hasn't started close it without running the
@@ -903,7 +904,7 @@ public class GeneratorTests
     }
 
     [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void Generator_NextAfterCompletion_ReportsUndefined(ExecutionMode mode)
     {
         // Once a generator finishes, its completion value is delivered exactly once; further
@@ -926,7 +927,7 @@ public class GeneratorTests
     }
 
     [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void Generator_UncaughtThrowInBody_PropagatesToNext(ExecutionMode mode)
     {
         // An uncaught throw inside the body surfaces to the next() caller rather than being
@@ -950,7 +951,7 @@ public class GeneratorTests
     }
 
     [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void Generator_BareReturn_ReportsUndefinedValue(ExecutionMode mode)
     {
         // A no-argument return() resumes with undefined.
@@ -973,13 +974,12 @@ public class GeneratorTests
 
     #region yield* forwards return()/throw() to the delegated iterator (ECMA-262 §14.4.14) — issue #514
 
-    // Interpreter-only: these build on the return()/throw() resumption from #478 (above). In
-    // compiled mode, an external return()/throw() on a suspended generator does not inject the
-    // abrupt completion at all (finally/catch skipped) — the compiled analog of #478 — so the
-    // compiled EmitYieldStar likewise can't forward it. Both are tracked as issue #526.
+    // Run in both modes: the interpreter implemented yield* forwarding of return()/throw() in #514;
+    // the compiled EmitYieldStar gained the same forwarding (driving the delegate via return()/throw()
+    // instead of next()) once the compiled injection landed in #526.
 
     [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void YieldStar_Return_ForwardsToInnerFinally_ThenOuterReturns(ExecutionMode mode)
     {
         // The repro from #514: return(v) on the outer while suspended inside yield* must run the
@@ -1000,7 +1000,7 @@ public class GeneratorTests
     }
 
     [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void YieldStar_Throw_NoInnerCatch_RunsInnerFinally_ThenPropagates(ExecutionMode mode)
     {
         // throw(e) is forwarded to the delegate; with only a finally (no catch) the delegate's
@@ -1019,7 +1019,7 @@ public class GeneratorTests
     }
 
     [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void YieldStar_Throw_CaughtByInner_KeepsDelegating(ExecutionMode mode)
     {
         // The delegate catches the injected error and yields again; the outer stays in the
@@ -1039,7 +1039,7 @@ public class GeneratorTests
     }
 
     [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void YieldStar_Throw_CaughtByInnerThenReturns_OuterContinuesNormally(ExecutionMode mode)
     {
         // The delegate catches the error and returns: per §14.4.14 step b.5 the yield* evaluates
@@ -1063,7 +1063,7 @@ public class GeneratorTests
     }
 
     [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void YieldStar_Return_InnerFinallyYields_DefersCompletion(ExecutionMode mode)
     {
         // The delegate's finally itself yields: the outer suspends there (reporting the
@@ -1091,7 +1091,7 @@ public class GeneratorTests
     }
 
     [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void YieldStar_Return_InnerFinallyReturnOverridesValue(ExecutionMode mode)
     {
         // A finally in the delegate that returns its own value overrides the value passed to the
@@ -1111,7 +1111,7 @@ public class GeneratorTests
     }
 
     [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void YieldStar_Return_RunsInnerThenOuterFinally(ExecutionMode mode)
     {
         // When the outer also wraps the yield* in try/finally, the abrupt return runs the
@@ -1133,7 +1133,7 @@ public class GeneratorTests
     }
 
     [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void YieldStar_Nested_Return_ReachesInnermostFinally(ExecutionMode mode)
     {
         // Two levels of delegation (outer → middle → inner): return() must thread through both
@@ -1156,7 +1156,7 @@ public class GeneratorTests
     }
 
     [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void YieldStar_Nested_Throw_RunsAllFinallys_ThenPropagates(ExecutionMode mode)
     {
         // throw() through two levels of delegation with no catch anywhere: each finally runs
@@ -1178,7 +1178,7 @@ public class GeneratorTests
     }
 
     [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void YieldStar_Return_InnerWithoutFinally_TerminatesCleanly(ExecutionMode mode)
     {
         // return() forwarded to a delegate that has no finally: the delegate just closes, the
@@ -1197,7 +1197,7 @@ public class GeneratorTests
     }
 
     [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void YieldStar_Return_ForwardsIntoGeneratorExpressionDelegate(ExecutionMode mode)
     {
         // The delegate is a generator function EXPRESSION (a distinct runtime type from a
@@ -1217,7 +1217,7 @@ public class GeneratorTests
     }
 
     [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void YieldStar_Return_FromGeneratorExpressionOuter(ExecutionMode mode)
     {
         // The OUTER is a generator function expression delegating to a declaration; the suspend

--- a/SharpTS.Tests/SharedTests/GeneratorTryFinallyTests.cs
+++ b/SharpTS.Tests/SharedTests/GeneratorTryFinallyTests.cs
@@ -658,6 +658,113 @@ public class GeneratorTryFinallyTests
         Assert.Equal("{\"value\":1,\"done\":false}\ncaught:e\n", TestHarness.Run(source, mode));
     }
 
+    // ---- #598: return/break/continue lexically inside a no-yield finally body ----
+    // None of ret/br/Leave may exit a .NET finally region, so these constructs must take the
+    // flag-based path even with no yield (the finally-side analog of #554's try/catch-body fix).
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ReturnInsideNoYieldFinally_Completes(ExecutionMode mode)
+    {
+        // The exact #598 repro: a `return` inside a no-yield finally. The generator has a yield
+        // elsewhere so it is a state machine; the try/finally itself crosses no yield.
+        var source = """
+            function* g() { yield 0; try {} finally { return 5; } }
+            const it = g();
+            console.log(JSON.stringify(it.next()));
+            console.log(JSON.stringify(it.next()));
+            console.log(JSON.stringify(it.next()));
+            """;
+
+        Assert.Equal(
+            "{\"value\":0,\"done\":false}\n{\"value\":5,\"done\":true}\n{\"done\":true}\n",
+            TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void BreakInsideNoYieldFinally_ExitsLoop(ExecutionMode mode)
+    {
+        // #598's break repro: a `break` inside a no-yield finally exits the enclosing loop.
+        var source = """
+            function* g() { yield 0; while (true) { try {} finally { break; } } yield 1; }
+            for (const v of g()) console.log(v);
+            """;
+
+        Assert.Equal("0\n1\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ContinueInsideNoYieldFinally_SkipsRest(ExecutionMode mode)
+    {
+        var source = """
+            function* g() {
+              for (let i = 0; i < 3; i++) {
+                try {} finally { if (i === 1) continue; console.log("body" + i); }
+              }
+              yield 9;
+            }
+            for (const v of g()) console.log("y" + v);
+            """;
+
+        Assert.Equal("body0\nbody2\ny9\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ReturnInNoYieldFinally_OverridesPendingException(ExecutionMode mode)
+    {
+        // The try throws but the finally returns: per JS semantics the abrupt return overrides the
+        // exception (it is swallowed). The real-IL path could not express this at all (#598).
+        var source = """
+            function* g() { yield 0; try { throw "boom"; } finally { return 5; } }
+            const it = g();
+            console.log(JSON.stringify(it.next()));
+            console.log(JSON.stringify(it.next()));
+            """;
+
+        Assert.Equal(
+            "{\"value\":0,\"done\":false}\n{\"value\":5,\"done\":true}\n",
+            TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void LabeledBreakInsideNoYieldFinally_ExitsOuterLoop(ExecutionMode mode)
+    {
+        var source = """
+            function* g() {
+              yield 0;
+              outer: while (true) { while (true) { try {} finally { break outer; } } }
+              yield 1;
+            }
+            for (const v of g()) console.log(v);
+            """;
+
+        Assert.Equal("0\n1\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ReturnInNestedNoYieldFinally_RunsOuterFinally(ExecutionMode mode)
+    {
+        // A return in an inner finally must still run the enclosing finally before completing.
+        var source = """
+            function* g() {
+              yield 0;
+              try { try {} finally { return 1; } } finally { console.log("outer-fin"); }
+            }
+            const it = g();
+            console.log(JSON.stringify(it.next()));
+            console.log(JSON.stringify(it.next()));
+            """;
+
+        Assert.Equal(
+            "{\"value\":0,\"done\":false}\nouter-fin\n{\"value\":1,\"done\":true}\n",
+            TestHarness.Run(source, mode));
+    }
+
     // ---- IL-verification guards (the heart of #477: emitted IL must verify) ----
 
     [Theory]
@@ -696,6 +803,14 @@ public class GeneratorTryFinallyTests
     [InlineData("function* g() { try { yield 1; throw 'boom'; } finally { yield 2; } } try { for (const v of g()) {} } catch (e) {}")]
     [InlineData("function* g() { try { try { throw 'e1'; } catch (e) { throw 'e2'; } } finally { yield 7; } } try { for (const v of g()) {} } catch (e) {}")]
     [InlineData("function* g() { try { throw 'e'; } finally { try {} finally { yield 1; } } } try { for (const v of g()) {} } catch (e) {}")]
+    // #598: return/break/continue lexically inside a no-yield finally — must take the flag-based path
+    // (none of ret/br/Leave may exit a real .NET finally region → LeaveOutOfFinally otherwise).
+    [InlineData("function* g() { yield 0; try {} finally { return 5; } } for (const v of g()) {}")]
+    [InlineData("function* g() { yield 0; try { throw 'x'; } finally { return 5; } } try { for (const v of g()) {} } catch (e) {}")]
+    [InlineData("function* g() { yield 0; while (true) { try {} finally { break; } } yield 1; } for (const v of g()) {}")]
+    [InlineData("function* g() { for (let i=0;i<2;i++){ yield i; try {} finally { continue; } } } for (const v of g()) {}")]
+    [InlineData("function* g() { yield 0; outer: while(true){ while(true){ try {} finally { break outer; } } } } for (const v of g()) {}")]
+    [InlineData("function* g() { yield 0; try { try {} finally { return 1; } } finally { console.log('o'); } } for (const v of g()) {}")]
     public void GeneratorTryFinallyWithYield_EmitsVerifiableIL(string source)
     {
         var errors = TestHarness.CompileAndVerifyOnly(source);

--- a/SharpTS.Tests/SharedTests/GeneratorTryFinallyTests.cs
+++ b/SharpTS.Tests/SharedTests/GeneratorTryFinallyTests.cs
@@ -599,6 +599,65 @@ public class GeneratorTryFinallyTests
         Assert.Equal("1/false\nf\n5/true\nundefined/true\n", TestHarness.Run(source, mode));
     }
 
+    // ---- #599: an exception propagating through a YIELDING finally must not be lost ----
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void UncaughtThrow_ThroughYieldingFinally_StillPropagates(ExecutionMode mode)
+    {
+        // The exact #599 repro: the try throws after a yield, and the (catch-less) finally yields.
+        // The finally's suspension previously wiped the IL local holding the captured exception, so
+        // the post-finally rethrow saw null and the throw was swallowed. The exception must survive
+        // the suspension and surface to the consumer after the finally completes.
+        var source = """
+            function* g() { try { yield 1; throw "boom"; } finally { yield 2; } }
+            const it = g();
+            console.log(JSON.stringify(it.next()));
+            console.log(JSON.stringify(it.next()));
+            try { console.log(JSON.stringify(it.next())); } catch (e) { console.log("caught:" + e); }
+            """;
+
+        Assert.Equal(
+            "{\"value\":1,\"done\":false}\n{\"value\":2,\"done\":false}\ncaught:boom\n",
+            TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void RethrownFromInnerCatch_ThroughYieldingFinally_StillPropagates(ExecutionMode mode)
+    {
+        // #599's second shape: an inner try/catch (a sync segment of the outer try body) rethrows;
+        // the captured exception must survive the outer yielding finally and propagate.
+        var source = """
+            function* g() {
+              try { try { throw new Error("e1"); } catch (e) { throw new Error("e2"); } }
+              finally { yield 7; }
+            }
+            const it = g();
+            console.log(JSON.stringify(it.next()));
+            try { it.next(); } catch (e) { console.log("caught:" + e.message); }
+            """;
+
+        Assert.Equal("{\"value\":7,\"done\":false}\ncaught:e2\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void UncaughtThrow_ThroughNestedYieldingFinally_NotClobbered(ExecutionMode mode)
+    {
+        // A finally that yields and itself contains a (separate) try/finally that also yields. Each
+        // construct gets its own caught-exception field, so the inner construct's persistence cannot
+        // clobber the outer's captured exception — it must still rethrow after both finallys run.
+        var source = """
+            function* g() { try { throw "e"; } finally { try {} finally { yield 1; } } }
+            const it = g();
+            console.log(JSON.stringify(it.next()));
+            try { it.next(); } catch (e) { console.log("caught:" + e); }
+            """;
+
+        Assert.Equal("{\"value\":1,\"done\":false}\ncaught:e\n", TestHarness.Run(source, mode));
+    }
+
     // ---- IL-verification guards (the heart of #477: emitted IL must verify) ----
 
     [Theory]
@@ -633,6 +692,10 @@ public class GeneratorTryFinallyTests
     [InlineData("function* g() { while (true) { try { yield 1; try { break; } finally { console.log('x'); } } finally { yield 2; } } } for (const v of g()) {}")]
     // #555: a `return <value>` whose finally yields.
     [InlineData("function* g() { try { return 5; } finally { yield 9; } } for (const v of g()) {}")]
+    // #599: an exception crossing a yielding finally — the captured exception is persisted to a field.
+    [InlineData("function* g() { try { yield 1; throw 'boom'; } finally { yield 2; } } try { for (const v of g()) {} } catch (e) {}")]
+    [InlineData("function* g() { try { try { throw 'e1'; } catch (e) { throw 'e2'; } } finally { yield 7; } } try { for (const v of g()) {} } catch (e) {}")]
+    [InlineData("function* g() { try { throw 'e'; } finally { try {} finally { yield 1; } } } try { for (const v of g()) {} } catch (e) {}")]
     public void GeneratorTryFinallyWithYield_EmitsVerifiableIL(string source)
     {
         var errors = TestHarness.CompileAndVerifyOnly(source);

--- a/SharpTS.Tests/SharedTests/GeneratorTryFinallyTests.cs
+++ b/SharpTS.Tests/SharedTests/GeneratorTryFinallyTests.cs
@@ -811,6 +811,11 @@ public class GeneratorTryFinallyTests
     [InlineData("function* g() { for (let i=0;i<2;i++){ yield i; try {} finally { continue; } } } for (const v of g()) {}")]
     [InlineData("function* g() { yield 0; outer: while(true){ while(true){ try {} finally { break outer; } } } } for (const v of g()) {}")]
     [InlineData("function* g() { yield 0; try { try {} finally { return 1; } } finally { console.log('o'); } } for (const v of g()) {}")]
+    // #526: the external return()/throw() injection check is emitted at every yield resume, and the
+    // yield* forwarding check at every yield* resume — both must verify across these shapes.
+    [InlineData("function* inner(){ try { yield 1; } finally { console.log('x'); } } function* g(){ yield* inner(); } for (const v of g()) {}")]
+    [InlineData("function* inner(){ try { yield 1; } finally {} } function* mid(){ try { yield* inner(); } finally {} } function* g(){ yield* mid(); } for (const v of g()) {}")]
+    [InlineData("function* g(){ try { yield 1; } catch (e) { yield 2; } finally { yield 3; } } for (const v of g()) {}")]
     public void GeneratorTryFinallyWithYield_EmitsVerifiableIL(string source)
     {
         var errors = TestHarness.CompileAndVerifyOnly(source);


### PR DESCRIPTION
Fixes three related bugs in the **compiled** generator `try`/`finally` machinery. They are tightly coupled (same subsystem; #526 depends on #599), so they ship together as three reviewable commits.

## #599 — exception lost through a yielding `finally`
A try-body exception captured by the flag-based scheme lived in an IL local. When the `finally` yields, `MoveNext` suspends and the local resets on re-entry, so the post-`finally` rethrow saw `null` and the exception was silently dropped. Fix: persist it to a state-machine field before a `finally` that can yield (try/finally with no catch). Each qualifying construct gets its own field, so a nested persisting construct inside the `finally` body cannot clobber the outer's captured exception.

## #598 — `return`/`break`/`continue` inside a no-yield `finally` emitted invalid IL
None of `ret`/`br`/`Leave` may exit a .NET `finally` region (`LeaveOutOfFinally`). #554 handled exits in the try/catch body via `Leave`-routing, but an exit in the `finally` body had nowhere legal to go. Fix: when a try's `finally` contains an escaping exit, take the flag-based path even with no yield, so the `finally` is emitted as top-level statements and the exit dispatches legally. (Also makes a `finally`-`return` that overrides a pending try-body exception work — the real-IL path could not express it.)

## #526 — external `return()`/`throw()` on a suspended generator skipped `finally`/`catch`
The compiled analog of #478 (and a prerequisite for the compiled analog of #514). `gen.return(v)`/`throw(e)` settled/threw without resuming the body. Now the state machine carries an injected completion; when suspended, `return()`/`throw()` set it and drive `MoveNext`, which at the yield resume performs the abrupt completion in place — reusing the flag-based `finally` routing for a return, and capturing a thrown value like a try-body exception so the `catch`/`finally` run. `yield*` forwards the injection into the delegate per ECMA-262 §14.4.14 (running its `finally`/`catch`, threading through nested delegation). A bare `return()` now injects `undefined` rather than `null`.

The interpreter already implemented all of this (#478/#514); the 23 generator tests that were interpreter-only now run in **both** modes as a cross-mode parity guard, plus new IL-verification guards for the new shapes.

## Testing
- `GeneratorTests` + `GeneratorTryFinallyTests` (both modes) + `EmitterSyncTests` green.
- Every behavior validated against the interpreter (the oracle) and Node semantics; all emitted IL passes `--verify`.
- Full suite green: 12,294 passed, 0 failed, 0 skipped.

## Follow-up
Filed #619 — thrown `null`/`undefined` (and bare `it.throw()`) into a flag-based try skips the `catch`; pre-existing since #477, distinct root cause (the catch gate tests value-nullness), out of scope here.

Closes #526
Closes #598
Closes #599
