### PR TITLE
Fix async generator completion/resume values, try-finally exits, and re-entrancy (#481, #540, #597, #542)

### DIFF
--- a/Compilation/AsyncGeneratorMoveNextEmitter.Expressions.cs
+++ b/Compilation/AsyncGeneratorMoveNextEmitter.Expressions.cs
@@ -79,8 +79,10 @@ public partial class AsyncGeneratorMoveNextEmitter
         _il.Emit(OpCodes.Ldc_I4_M1);
         _il.Emit(OpCodes.Stfld, _builder.StateField);
 
-        // 7. yield expression evaluates to undefined (null) when resumed
-        _il.Emit(OpCodes.Ldnull);
+        // 7. The resumed `yield` expression evaluates to `undefined` (e.g. `const r = yield 1` → r is
+        // undefined). Load the emitted `$Undefined` sentinel, not CLR null which would surface as JS
+        // `null` (#481, async analog of #443). next(v) forwarding a sent value is the separate gap #473.
+        _il.Emit(OpCodes.Ldsfld, _ctx!.Runtime!.UndefinedInstance);
         SetStackUnknown();
     }
 
@@ -255,8 +257,10 @@ public partial class AsyncGeneratorMoveNextEmitter
         _il.Emit(OpCodes.Ldnull);
         _il.Emit(OpCodes.Stfld, delegatedField);
 
-        // yield* evaluates to undefined
-        _il.Emit(OpCodes.Ldnull);
+        // yield* evaluates to undefined — load the `$Undefined` sentinel, not CLR null (#481). (A
+        // delegated iterator's own return value as the yield* result is a separate, deeper gap; this
+        // path drives via IAsyncEnumerator/IEnumerator, which carry no return value.)
+        _il.Emit(OpCodes.Ldsfld, _ctx!.Runtime!.UndefinedInstance);
         SetStackUnknown();
     }
 
@@ -323,7 +327,8 @@ public partial class AsyncGeneratorMoveNextEmitter
         _il.Emit(OpCodes.Ldnull);
         _il.Emit(OpCodes.Stfld, delegatedField);
 
-        _il.Emit(OpCodes.Ldnull);
+        // yield* evaluates to undefined — load the `$Undefined` sentinel, not CLR null (#481).
+        _il.Emit(OpCodes.Ldsfld, _ctx!.Runtime!.UndefinedInstance);
         SetStackUnknown();
     }
 
@@ -411,8 +416,8 @@ public partial class AsyncGeneratorMoveNextEmitter
         _il.Emit(OpCodes.Ldnull);
         _il.Emit(OpCodes.Stfld, delegatedField);
 
-        // yield* evaluates to undefined
-        _il.Emit(OpCodes.Ldnull);
+        // yield* evaluates to undefined — load the `$Undefined` sentinel, not CLR null (#481).
+        _il.Emit(OpCodes.Ldsfld, _ctx!.Runtime!.UndefinedInstance);
         SetStackUnknown();
     }
 

--- a/Compilation/AsyncGeneratorMoveNextEmitter.Statements.TryCatch.cs
+++ b/Compilation/AsyncGeneratorMoveNextEmitter.Statements.TryCatch.cs
@@ -89,6 +89,16 @@ public partial class AsyncGeneratorMoveNextEmitter
         _pendingExceptionField ??= _builder.StateMachineType.DefineField(
             "<>pendingException", typeof(object), FieldAttributes.Private);
 
+    // `<>pendingReturnValue` (object): the completion value of a `return` being routed through
+    // finally(s). A finally that yields overwrites `<>2__current` with its yielded value, so the
+    // return value is stashed here at the `return` and restored to Current by the return terminal,
+    // after the finally has run (#597, async analog of #555). Held across any suspension in those finallys.
+    private FieldBuilder? _pendingReturnValueField;
+
+    private FieldBuilder GetPendingReturnValueField() =>
+        _pendingReturnValueField ??= _builder.StateMachineType.DefineField(
+            "<>pendingReturnValue", typeof(object), FieldAttributes.Private);
+
     // ---- Loop-scope methods (override the base stack to use `_exitScopes`) -----------------------
 
     protected override void EnterLoop(Label breakLabel, Label continueLabel, string? labelName = null)
@@ -146,16 +156,17 @@ public partial class AsyncGeneratorMoveNextEmitter
         var loop = b.Label != null ? FindLabeledLoopScope(b.Label.Lexeme) : CurrentLoopScope();
         if (loop == null) return; // matches the base: a break with no resolvable target is a no-op
 
-        if (_protectedRegionDepth == 0)
+        var chain = FinallyFramesAbove(loop);
+        if (chain.Count > 0)
         {
-            var chain = FinallyFramesAbove(loop);
-            if (chain.Count > 0)
-            {
-                int code = loop.BreakCode ??= _nextExitCode++;
-                _exitTerminals.TryAdd(code, () => _il.Emit(OpCodes.Br, loop.BreakLabel));
-                RouteThroughFinallys(chain, code);
-                return;
-            }
+            // Flag-based finally(s) lie between the break and its loop; run them before jumping out.
+            // From inside a real IL block, `Leave` to the innermost flag cleanup (running the real,
+            // no-yield finally(s) on the way — a real try never encloses a flag try, so they are all
+            // innermore); otherwise branch there directly (#597, async analog of #554).
+            int code = loop.BreakCode ??= _nextExitCode++;
+            _exitTerminals.TryAdd(code, () => _il.Emit(OpCodes.Br, loop.BreakLabel));
+            RouteThroughFinallys(chain, code, _protectedRegionDepth > 0 ? OpCodes.Leave : OpCodes.Br);
+            return;
         }
 
         EmitBranchToLabel(loop.BreakLabel);
@@ -170,16 +181,15 @@ public partial class AsyncGeneratorMoveNextEmitter
         var loop = c.Label != null ? FindLabeledLoopScope(c.Label.Lexeme) : CurrentLoopScope();
         if (loop == null) return;
 
-        if (_protectedRegionDepth == 0)
+        var chain = FinallyFramesAbove(loop);
+        if (chain.Count > 0)
         {
-            var chain = FinallyFramesAbove(loop);
-            if (chain.Count > 0)
-            {
-                int code = loop.ContinueCode ??= _nextExitCode++;
-                _exitTerminals.TryAdd(code, () => _il.Emit(OpCodes.Br, loop.ContinueLabel));
-                RouteThroughFinallys(chain, code);
-                return;
-            }
+            // As in EmitBreak: run the intervening flag-based finally(s) first, `Leave`-ing out of any
+            // real IL block we are inside so its no-yield finally runs and the IL stays legal.
+            int code = loop.ContinueCode ??= _nextExitCode++;
+            _exitTerminals.TryAdd(code, () => _il.Emit(OpCodes.Br, loop.ContinueLabel));
+            RouteThroughFinallys(chain, code, _protectedRegionDepth > 0 ? OpCodes.Leave : OpCodes.Br);
+            return;
         }
 
         EmitBranchToLabel(loop.ContinueLabel);
@@ -206,7 +216,7 @@ public partial class AsyncGeneratorMoveNextEmitter
                 _il.Emit(OpCodes.Stfld, GetPendingExceptionField());
 
                 RegisterThrowTerminal();
-                RouteThroughFinallys(chain, ExitCodeThrow);
+                RouteThroughFinallys(chain, ExitCodeThrow, OpCodes.Br);
                 return;
             }
         }
@@ -245,7 +255,14 @@ public partial class AsyncGeneratorMoveNextEmitter
     /// the innermost finally. The caller must have prepared any value the terminal needs (e.g. the
     /// thrown value, or the Current/return state) beforehand.
     /// </summary>
-    private void RouteThroughFinallys(List<FinallyScope> chain, int code)
+    /// <param name="branch">
+    /// <c>Br</c> when the exit is at the top level, or <c>Leave</c> when it is emitted inside a real IL
+    /// exception block (EmitSimpleTryCatch) nested in the flag-based finally(s): the <c>Leave</c> exits
+    /// that block — running its no-yield finally — straight to the innermost flag cleanup label, then
+    /// the flag machinery runs the remaining (outer) finally(s). A real try never encloses a flag try,
+    /// so every real finally is innermore than every flag one and this ordering is correct (#597/#554).
+    /// </param>
+    private void RouteThroughFinallys(List<FinallyScope> chain, int code, OpCode branch)
     {
         for (int i = 0; i < chain.Count; i++)
         {
@@ -257,7 +274,7 @@ public partial class AsyncGeneratorMoveNextEmitter
         _il.Emit(OpCodes.Ldarg_0);
         _il.Emit(OpCodes.Ldc_I4, code);
         _il.Emit(OpCodes.Stfld, GetPendingExitField());
-        _il.Emit(OpCodes.Br, chain[0].CleanupLabel);
+        _il.Emit(branch, chain[0].CleanupLabel);
     }
 
     /// <summary>
@@ -296,6 +313,14 @@ public partial class AsyncGeneratorMoveNextEmitter
 
     private void RegisterReturnTerminal() => _exitTerminals.TryAdd(ExitCodeReturn, () =>
     {
+        // Restore the completion value into Current: a yielding finally between the `return` and this
+        // point overwrote Current with its yielded value, so re-load the value stashed at the `return`
+        // (#597, async analog of #555). With no yielding finally this is a no-op (Current is unchanged).
+        _il.Emit(OpCodes.Ldarg_0);
+        _il.Emit(OpCodes.Ldarg_0);
+        _il.Emit(OpCodes.Ldfld, GetPendingReturnValueField());
+        _il.Emit(OpCodes.Stfld, _builder.CurrentField);
+
         // The generator completes. State -2 is re-asserted here because a yielding finally between the
         // `return` and this point overwrote it with the finally's resume state.
         _il.Emit(OpCodes.Ldarg_0);

--- a/Compilation/AsyncGeneratorMoveNextEmitter.Statements.cs
+++ b/Compilation/AsyncGeneratorMoveNextEmitter.Statements.cs
@@ -13,8 +13,8 @@ public partial class AsyncGeneratorMoveNextEmitter
 
     protected override void EmitReturn(Stmt.Return r)
     {
-        // Async generator return - store the return value in Current (read as the completion value),
-        // then complete the state machine — unless an enclosing flag-based try/finally must run first.
+        // Async generator return — store the completion value in Current (read back as next().value when
+        // done), then complete the state machine, running any enclosing finally(s) first.
         if (r.Value != null)
         {
             // Evaluate fully before touching the frame: the value may itself contain a yield/await
@@ -28,26 +28,50 @@ public partial class AsyncGeneratorMoveNextEmitter
             _il.Emit(OpCodes.Ldloc, returnValueTemp);
             _il.Emit(OpCodes.Stfld, _builder.CurrentField);
         }
+        else
+        {
+            // Bare `return;` completes with `undefined`. Store the `$Undefined` sentinel into Current so
+            // the completion value is undefined, not the stale last-yielded value (#481/#540).
+            _il.Emit(OpCodes.Ldarg_0);
+            _il.Emit(OpCodes.Ldsfld, _ctx!.Runtime!.UndefinedInstance);
+            _il.Emit(OpCodes.Stfld, _builder.CurrentField);
+        }
 
-        // Set state to -2 (completed). The direct path below returns immediately; a routed return
-        // re-asserts this at its terminal, since a yielding finally would overwrite it.
+        // Set state to -2 (completed). The direct path below returns immediately; a routed or deferred
+        // return re-asserts this at its terminal / landing pad, since a yielding finally between here and
+        // there would overwrite it with the finally's resume state.
         _il.Emit(OpCodes.Ldarg_0);
         _il.Emit(OpCodes.Ldc_I4, -2);
         _il.Emit(OpCodes.Stfld, _builder.StateField);
 
-        // Inside a flag-based try/finally, the enclosing finally(s) must run before the generator
-        // actually completes. Route the return through them instead of returning directly (a `ret`
-        // here is also illegal — this return is emitted outside the protected segment, but a finally
-        // is emitted after it). See AsyncGeneratorMoveNextEmitter.Statements.TryCatch.cs.
-        if (_protectedRegionDepth == 0)
+        // A non-local `return` must run any enclosing flag-based finally(s) before the generator
+        // completes. See AsyncGeneratorMoveNextEmitter.Statements.TryCatch.cs.
+        var chain = ActiveFinallyFrames();
+        if (chain.Count > 0)
         {
-            var chain = ActiveFinallyFrames();
-            if (chain.Count > 0)
-            {
-                RegisterReturnTerminal();
-                RouteThroughFinallys(chain, ExitCodeReturn);
-                return;
-            }
+            // Stash the completion value: a finally that yields overwrites Current with its yielded
+            // value, and the return terminal restores it from here after the finally has run (#597,
+            // async analog of #555). From inside a real IL block the route uses `Leave` (running that
+            // block's no-yield finally) to reach the innermost flag cleanup label (#597/#554).
+            _il.Emit(OpCodes.Ldarg_0);
+            _il.Emit(OpCodes.Ldarg_0);
+            _il.Emit(OpCodes.Ldfld, _builder.CurrentField);
+            _il.Emit(OpCodes.Stfld, GetPendingReturnValueField());
+
+            RegisterReturnTerminal();
+            RouteThroughFinallys(chain, ExitCodeReturn, _protectedRegionDepth > 0 ? OpCodes.Leave : OpCodes.Br);
+            return;
+        }
+
+        if (_protectedRegionDepth > 0)
+        {
+            // Inside a real IL try/finally with no enclosing flag finally: completing directly (a
+            // `ret`/EmitReturnValueTaskBool) is illegal inside the protected region. Current/state are
+            // set above; `Leave` the deferred-return landing pad, which runs the enclosing no-yield
+            // finally(s) and returns false (#597, async analog of #554).
+            _deferredReturnUsed = true;
+            _il.Emit(OpCodes.Leave, _deferredReturnLabel);
+            return;
         }
 
         EmitReturnValueTaskBool(false);

--- a/Compilation/AsyncGeneratorMoveNextEmitter.cs
+++ b/Compilation/AsyncGeneratorMoveNextEmitter.cs
@@ -26,6 +26,14 @@ public partial class AsyncGeneratorMoveNextEmitter : StatementEmitterBase
     private readonly Dictionary<int, Label> _stateLabels = [];
     private Label _returnFalseLabel;
 
+    // Landing pad for a `return` emitted inside a real IL try/finally (EmitSimpleTryCatch) that has no
+    // enclosing flag-based finally (#597, async analog of #554). Such a return cannot complete the state
+    // machine directly (a `ret`/EmitReturnValueTaskBool is illegal inside a protected region), so it sets
+    // Current/state then `Leave`s here — running the enclosing no-yield finally(s) — to return false.
+    // Marked only when used; Current already holds the completion value, so it is not reset here.
+    private Label _deferredReturnLabel;
+    private bool _deferredReturnUsed;
+
     // Current suspension point being processed
     private int _currentSuspensionState = 0;
 
@@ -78,6 +86,7 @@ public partial class AsyncGeneratorMoveNextEmitter : StatementEmitterBase
             _stateLabels[suspensionPoint.StateNumber] = _il.DefineLabel();
         }
         _returnFalseLabel = _il.DefineLabel();
+        _deferredReturnLabel = _il.DefineLabel();
 
         // Check if generator is already completed (state == -2)
         _il.Emit(OpCodes.Ldarg_0);
@@ -94,18 +103,40 @@ public partial class AsyncGeneratorMoveNextEmitter : StatementEmitterBase
             EmitStatement(stmt);
         }
 
-        // Fall through after body completes - clear current value, mark as done and return false
-        // (Implicit return has value: null)
+        // Fall through after body completes — the generator ran off the end with no `return`.
+        // Per ECMA-262 its completion value is `undefined`, so reset Current to the `$Undefined`
+        // sentinel rather than CLR null: it currently still holds the last *yielded* value, which would
+        // otherwise surface as `next().value` after done, or as a delegating `yield*`'s completion value
+        // (#481, async analog of #443). An explicit `return X` takes the EmitReturn path and stores X.
         _il.Emit(OpCodes.Ldarg_0);
-        _il.Emit(OpCodes.Ldnull);
+        _il.Emit(OpCodes.Ldsfld, _ctx!.Runtime!.UndefinedInstance);
         _il.Emit(OpCodes.Stfld, _builder.CurrentField);
         _il.Emit(OpCodes.Ldarg_0);
         _il.Emit(OpCodes.Ldc_I4, -2);
         _il.Emit(OpCodes.Stfld, _builder.StateField);
         EmitReturnValueTaskBool(false);
 
-        // Return false label (generator completed)
+        // Deferred-return landing pad (#597, async analog of #554): a `return` inside a real IL
+        // try/finally `Leave`s here after its enclosing no-yield finally(s) have run. Current and state
+        // were already set at the `return`, so just return false. Marked only if such a return was emitted.
+        if (_deferredReturnUsed)
+        {
+            _il.MarkLabel(_deferredReturnLabel);
+            EmitReturnValueTaskBool(false);
+        }
+
+        // Return false label — re-entry on an already-completed generator (state == -2): next() called
+        // after the generator finished, or after return(v). Per ECMA-262 27.6.1.2 a completed async
+        // generator's next() always reports { value: undefined, done: true } — the completion value was
+        // already consumed by the call that finished it. Reset Current to the `$Undefined` sentinel so a
+        // stale value does not leak: an explicit `return X` left X in Current, and return(v) leaves the
+        // last *yielded* value there untouched — either of which the done-path read of Current in next()
+        // would otherwise re-surface (#540, async analog of #499). The first MoveNextAsync to complete
+        // takes the fall-through / EmitReturn path above (correct completion value), not this label.
         _il.MarkLabel(_returnFalseLabel);
+        _il.Emit(OpCodes.Ldarg_0);
+        _il.Emit(OpCodes.Ldsfld, _ctx!.Runtime!.UndefinedInstance);
+        _il.Emit(OpCodes.Stfld, _builder.CurrentField);
         EmitReturnValueTaskBool(false);
     }
 

--- a/Compilation/AsyncGeneratorStateMachineBuilder.cs
+++ b/Compilation/AsyncGeneratorStateMachineBuilder.cs
@@ -47,6 +47,11 @@ public class AsyncGeneratorStateMachineBuilder
     // Flag set by return() to trigger finally blocks during MoveNextAsync resume
     public FieldBuilder ReturnRequestedField { get; private set; } = null!;
 
+    // Re-entrancy flag: true only while next()/return() synchronously drives MoveNextAsync. A guest
+    // next()/return()/throw() observing it means the generator body is advancing itself; without the
+    // guard the synchronous drive recurses into MoveNextAsync until the stack overflows (#542).
+    public FieldBuilder ExecutingField { get; private set; } = null!;
+
     // Constructor
     public ConstructorBuilder Constructor { get; private set; } = null!;
 
@@ -133,6 +138,13 @@ public class AsyncGeneratorStateMachineBuilder
             "__returnRequested",
             _types.Boolean,
             FieldAttributes.Public
+        );
+
+        // Define the re-entrancy guard flag (#542); see EmitThrowIfExecutingAsync.
+        ExecutingField = _stateMachineType.DefineField(
+            "<>5__executing",
+            _types.Boolean,
+            FieldAttributes.Private
         );
 
         // Define delegated enumerator field for yield* expressions (typed as object to hold either sync or async enumerators)
@@ -364,29 +376,31 @@ public class AsyncGeneratorStateMachineBuilder
         var doneLabel = il.DefineLabel();
         var endLabel = il.DefineLabel();
 
-        // Call MoveNextAsync() and await it
-        // var moveNextTask = this.MoveNextAsync();
+        // Reject a re-entrant next() — the body advancing itself — before driving MoveNextAsync (#542).
+        EmitThrowIfExecutingAsync(il);
+
+        // Drive the body with the executing flag set so a re-entrant next()/return()/throw() from inside
+        // it hits the guard instead of recursing into MoveNextAsync (which overflowed the stack). The
+        // try/finally clears the flag on suspension/completion AND on an uncaught body throw (GetResult
+        // rethrowing) — a leaked flag would make later calls falsely report "already running".
+        var movedLocal = il.DeclareLocal(_types.Boolean);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Stfld, ExecutingField);
+        il.BeginExceptionBlock();
+
+        // Call MoveNextAsync(), convert ValueTask<bool> → Task<bool>, then block for the result.
+        // (This works for already-completed awaits — the common case; a pending await blocks the calling
+        // thread until the continuation drives MoveNextAsync to completion.)
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Call, MoveNextAsyncMethod);
-
-        // Convert ValueTask<bool> to Task<bool> via AsTask()
         var vtLocal = il.DeclareLocal(_types.ValueTaskOfBool);
         il.Emit(OpCodes.Stloc, vtLocal);
         il.Emit(OpCodes.Ldloca, vtLocal);
         var asTaskMethod = _types.GetMethodNoParams(_types.ValueTaskOfBool, "AsTask");
         il.Emit(OpCodes.Call, asTaskMethod);
-
-        // Now we have Task<bool> on stack
-        // We need to create a continuation that builds the result dictionary
-        // For simplicity, we'll use ContinueWith pattern
-
-        // Store Task<bool>
         var taskBoolLocal = il.DeclareLocal(_types.MakeGenericType(_types.TaskOpen, _types.Boolean));
         il.Emit(OpCodes.Stloc, taskBoolLocal);
-
-        // For a simpler initial implementation, we'll just get the result synchronously
-        // (This works for already-completed tasks which is the common case for generators)
-        // A full implementation would use async continuation
 
         // Get the result: task.GetAwaiter().GetResult()
         il.Emit(OpCodes.Ldloc, taskBoolLocal);
@@ -398,8 +412,16 @@ public class AsyncGeneratorStateMachineBuilder
         il.Emit(OpCodes.Ldloca, awaiterLocal);
         var getResultMethod = _types.GetMethodNoParams(awaiterType, "GetResult");
         il.Emit(OpCodes.Call, getResultMethod);
+        il.Emit(OpCodes.Stloc, movedLocal);
 
-        // Stack now has bool (true = has value, false = done)
+        il.BeginFinallyBlock();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Stfld, ExecutingField);
+        il.EndExceptionBlock();
+
+        // movedLocal: true = has value, false = done
+        il.Emit(OpCodes.Ldloc, movedLocal);
         il.Emit(OpCodes.Brfalse, doneLabel);
 
         // Not done: create { value: Current, done: false }
@@ -441,6 +463,9 @@ public class AsyncGeneratorStateMachineBuilder
     {
         var il = ReturnMethod.GetILGenerator();
 
+        // Reject a re-entrant return() before mutating state (#542; see EmitThrowIfExecutingAsync).
+        EmitThrowIfExecutingAsync(il);
+
         // If state >= 0 (suspended at a yield point), we need to trigger finally blocks
         // by setting __returnRequested and calling MoveNextAsync
         var simpleReturnLabel = il.DefineLabel();
@@ -458,6 +483,14 @@ public class AsyncGeneratorStateMachineBuilder
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ldarg_1);
         il.Emit(OpCodes.Stfld, CurrentField);
+
+        // Drive MoveNextAsync to run the finally blocks, with the executing flag set so a re-entrant
+        // call from inside a finally hits the guard (#542). The try/finally clears it even if a finally
+        // throws.
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Stfld, ExecutingField);
+        il.BeginExceptionBlock();
 
         // Call MoveNextAsync() to resume the generator and trigger finally blocks
         il.Emit(OpCodes.Ldarg_0);
@@ -479,6 +512,12 @@ public class AsyncGeneratorStateMachineBuilder
         il.Emit(OpCodes.Ldloca, awaiterLocal);
         il.Emit(OpCodes.Call, getResult);
         il.Emit(OpCodes.Pop); // Discard result
+
+        il.BeginFinallyBlock();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Stfld, ExecutingField);
+        il.EndExceptionBlock();
 
         il.MarkLabel(simpleReturnLabel);
 
@@ -509,6 +548,10 @@ public class AsyncGeneratorStateMachineBuilder
     {
         var il = ThrowMethod.GetILGenerator();
 
+        // Reject a re-entrant throw() before mutating state (#542). throw() does not itself drive
+        // MoveNextAsync, so it only needs the entry guard, not the executing flag.
+        EmitThrowIfExecutingAsync(il);
+
         // Set state to -2 (completed)
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ldc_I4, -2);
@@ -534,6 +577,35 @@ public class AsyncGeneratorStateMachineBuilder
         var fromExceptionMethod = typeof(Task).GetMethod("FromException", 1, [typeof(Exception)])!.MakeGenericMethod(_types.Object);
         il.Emit(OpCodes.Call, fromExceptionMethod);
         il.Emit(OpCodes.Ret);
+    }
+
+    /// <summary>
+    /// Emits, at the head of next()/return()/throw(), a guard that rejects a re-entrant call — the
+    /// generator body advancing itself — by returning a faulted Task&lt;object&gt; carrying a TypeError.
+    /// ECMA-262 §27.6.3 (AsyncGeneratorEnqueue) actually *queues* such a request, but this
+    /// synchronous-drive state machine (next() blocks on MoveNextAsync via GetResult) cannot queue
+    /// without deadlocking the only case re-entrancy is reachable in — the body awaiting its own
+    /// request. So it rejects rather than recurse into MoveNextAsync until the stack overflows (#542).
+    /// The error is wrapped via CreateException so the guest observes a catchable TypeError, and is
+    /// surfaced as a rejected promise (not a synchronous throw) since next() returns a Task. _runtime
+    /// is non-null here — DefineAsyncGeneratorMethods only runs when the runtime is present.
+    /// </summary>
+    private void EmitThrowIfExecutingAsync(ILGenerator il)
+    {
+        var okLabel = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, ExecutingField);
+        il.Emit(OpCodes.Brfalse, okLabel);
+
+        // return Task.FromException<object>(CreateException(new TypeError("...")));
+        il.Emit(OpCodes.Ldstr, "Async generator is already running");
+        il.Emit(OpCodes.Newobj, _runtime!.TSTypeErrorCtor);
+        il.Emit(OpCodes.Call, _runtime!.CreateException);
+        var fromException = typeof(Task).GetMethod("FromException", 1, [typeof(Exception)])!.MakeGenericMethod(_types.Object);
+        il.Emit(OpCodes.Call, fromException);
+        il.Emit(OpCodes.Ret);
+
+        il.MarkLabel(okLabel);
     }
 
     /// <summary>

--- a/Runtime/Types/SharpTSAsyncGenerator.cs
+++ b/Runtime/Types/SharpTSAsyncGenerator.cs
@@ -27,8 +27,14 @@ public class SharpTSAsyncGenerator : ITypeCategorized
 
     private List<object?>? _values = null;  // Collected yielded values (null = not yet executed)
     private int _index = 0;
-    private object? _returnValue = null;
+    // The generator's completion value. Defaults to undefined so a body that falls off the end (or a
+    // no-arg return) reports { value: undefined, done: true }, not C# null (#540).
+    private object? _returnValue = SharpTSUndefined.Instance;
     private bool _closed = false;
+    // Whether the one-time completion result has already been handed out. Once the body is drained
+    // (or the generator is closed), the completion value is reported exactly once; every later next()
+    // reports undefined (ECMA-262 §27.6.1.2 → CreateIterResultObject(undefined, true), #540).
+    private bool _completionDelivered = false;
 
     public SharpTSAsyncGenerator(Stmt.Function declaration, RuntimeEnvironment environment, Interpreter interpreter)
     {
@@ -43,10 +49,11 @@ public class SharpTSAsyncGenerator : ITypeCategorized
     /// </summary>
     public async Task<object?> Next()
     {
-        // If generator is closed, always return done
+        // A finished/disposed generator (closed via return()/throw()) reports undefined; its completion
+        // value was already delivered/consumed by that return()/throw() call (ECMA-262 §27.6.1.2, #540).
         if (_closed)
         {
-            return new SharpTSIteratorResult(_returnValue, done: true);
+            return new SharpTSIteratorResult(SharpTSUndefined.Instance, done: true);
         }
 
         // Execute the generator body on first call (async)
@@ -69,6 +76,14 @@ public class SharpTSAsyncGenerator : ITypeCategorized
             return new SharpTSIteratorResult(_values[_index++], done: false);
         }
 
+        // Body fully drained. Deliver the completion value once (the body's `return X`, or undefined
+        // when it ran off the end), then undefined on every later call — the stale completion / last
+        // yielded value must not replay forever (#540; mirrors the sync generator's done semantics).
+        if (_completionDelivered)
+        {
+            return new SharpTSIteratorResult(SharpTSUndefined.Instance, done: true);
+        }
+        _completionDelivered = true;
         return new SharpTSIteratorResult(_returnValue, done: true);
     }
 
@@ -77,8 +92,12 @@ public class SharpTSAsyncGenerator : ITypeCategorized
     /// </summary>
     public Task<object?> Return(object? value = null)
     {
+        // return(v) reports { value: v, done: true } (echoing the argument, per ECMA-262 §27.6.1.3) and
+        // closes the generator; a later next() then reports undefined via the `_closed` guard in Next()
+        // rather than replaying v (#540). _completionDelivered is set so the once-only accounting stays
+        // consistent even if the body had already run off the end before this return().
         _closed = true;
-        _returnValue = value;
+        _completionDelivered = true;
         return Task.FromResult<object?>(new SharpTSIteratorResult(value, done: true));
     }
 

--- a/SharpTS.Tests/SharedTests/AsyncGeneratorTests.cs
+++ b/SharpTS.Tests/SharedTests/AsyncGeneratorTests.cs
@@ -40,7 +40,8 @@ public class AsyncGeneratorTests
             """;
 
         var output = TestHarness.Run(source, mode);
-        Assert.Equal("1 false\n2 false\n3 false\nnull true\n", output);
+        // After the last yield, next() reports { value: undefined, done: true } — not null (#481/#540).
+        Assert.Equal("1 false\n2 false\n3 false\nundefined true\n", output);
     }
 
     [Theory]
@@ -139,7 +140,8 @@ public class AsyncGeneratorTests
             """;
 
         var output = TestHarness.Run(source, mode);
-        Assert.Equal("42 false\nnull true\n", output);
+        // The result after the single yield is { value: undefined, done: true } — not null (#481/#540).
+        Assert.Equal("42 false\nundefined true\n", output);
     }
 
     [Theory]
@@ -556,7 +558,7 @@ public class AsyncGeneratorTests
 
     [Theory]
     [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
-    public void AsyncGenerator_ImplicitReturn_ReturnsNull(ExecutionMode mode)
+    public void AsyncGenerator_ImplicitReturn_ReturnsUndefined(ExecutionMode mode)
     {
         var source = """
             async function* gen() {
@@ -574,7 +576,8 @@ public class AsyncGeneratorTests
             """;
 
         var output = TestHarness.Run(source, mode);
-        Assert.Equal("null true\n", output);
+        // A generator that runs off the end completes with `undefined`, not null (#481/#540).
+        Assert.Equal("undefined true\n", output);
     }
 
     [Theory]
@@ -953,6 +956,122 @@ public class AsyncGeneratorTests
 
         var output = TestHarness.Run(source, mode);
         Assert.Equal("6\n20\n", output);
+    }
+
+    #endregion
+
+    #region Completion / resume value semantics — #481, #540
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    public void AsyncGenerator_ResumedYield_EvaluatesToUndefined(ExecutionMode mode)
+    {
+        // The resumed `yield` expression evaluates to undefined (no value sent), not null (#481, the
+        // async analog of #443). Previously the compiled emitter loaded CLR null here.
+        //
+        // COMPILED-ONLY: #481 is a compiled-emitter bug. The interpreter eagerly drains the body and
+        // does not bind a variable whose initializer is a yield (`const r = yield 1`) at all — it
+        // throws "Undefined variable 'r'" — a separate pre-existing eager-drain gap, not what #481 fixes.
+        var source = """
+            async function* ag() { const r = yield 1; console.log("r=" + r); }
+            async function main() { for await (const v of ag()) {} }
+            main();
+            """;
+
+        Assert.Equal("r=undefined\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    public void AsyncGenerator_YieldStarCompletion_EvaluatesToUndefined(ExecutionMode mode)
+    {
+        // The completion value of `yield* inner()` (when the delegate has no explicit return value) is
+        // undefined, not null (#481). COMPILED-ONLY for the same eager-drain reason as the resumed-yield
+        // test: the interpreter does not bind `const x = yield* …`.
+        var source = """
+            async function* inner() { yield 2; yield 3; }
+            async function* g() { const x = yield* inner(); console.log("x=" + x); yield 4; }
+            async function main() { for await (const v of g()) console.log("v" + v); }
+            main();
+            """;
+
+        Assert.Equal("v2\nv3\nx=undefined\nv4\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AsyncGenerator_NextAfterDone_ReportsUndefinedNotStaleReturn(ExecutionMode mode)
+    {
+        // The return value is delivered exactly once; every later next() reports undefined, not the
+        // stale completion value replayed forever (#540, async analog of #499/#480).
+        var source = """
+            async function* ag() { yield 1; return 42; }
+            async function main() {
+                const it = ag();
+                console.log((await it.next()).value);
+                console.log((await it.next()).value);
+                console.log((await it.next()).value);
+                console.log((await it.next()).value);
+            }
+            main();
+            """;
+
+        Assert.Equal("1\n42\nundefined\nundefined\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AsyncGenerator_NextAfterReturn_ReportsUndefinedNotLastYielded(ExecutionMode mode)
+    {
+        // After return(v) delivers { value: v, done: true }, a later next() reports undefined — the
+        // last *yielded* value must not replay (#540).
+        var source = """
+            async function* ag() { yield 1; yield 2; }
+            async function main() {
+                const it = ag();
+                console.log((await it.next()).value);
+                console.log(JSON.stringify(await it.return(99)));
+                console.log((await it.next()).value);
+            }
+            main();
+            """;
+
+        Assert.Equal("1\n{\"value\":99,\"done\":true}\nundefined\n", TestHarness.Run(source, mode));
+    }
+
+    #endregion
+
+    #region Re-entrant next() — "already running" guard (#542)
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    public void AsyncGenerator_ReentrantNext_Compiled_RejectsInsteadOfStackOverflow(ExecutionMode mode)
+    {
+        // A compiled async generator whose body advances itself previously recursed into MoveNextAsync
+        // until the stack overflowed (RangeError: Maximum call stack size exceeded). ECMA-262 §27.6.3
+        // queues such a request, but under this synchronous drive a real queue would deadlock the only
+        // reachable re-entrancy case (the body awaiting its own request), so the guard rejects with a
+        // catchable TypeError instead of crashing (#542). Observed here via a `for await…of` consumer,
+        // whose next()-drive surfaces the rejection to the enclosing try/catch.
+        //
+        // COMPILED-ONLY: the interpreter eagerly drains the body, so its re-entrant next() returns a
+        // (non-conformant) done result rather than recursing — it never hit the stack overflow this
+        // guards against, and asserting that divergent eager-drain output here would not test #542.
+        var source = """
+            const h: any = {};
+            async function* g() { await h.it.next(); yield 1; }
+            h.it = g();
+            async function main() {
+              try {
+                for await (const v of h.it) { console.log("v" + v); }
+              } catch (e: any) {
+                console.log("caught: " + e.name + " " + e.message);
+              }
+            }
+            main();
+            """;
+
+        Assert.Equal("caught: TypeError Async generator is already running\n", TestHarness.Run(source, mode));
     }
 
     #endregion

--- a/SharpTS.Tests/SharedTests/AsyncGeneratorTryFinallyTests.cs
+++ b/SharpTS.Tests/SharedTests/AsyncGeneratorTryFinallyTests.cs
@@ -400,6 +400,94 @@ public class AsyncGeneratorTryFinallyTests
         Assert.Equal("v0\nfin0\nv1\nfin1\n", TestHarness.Run(source, mode));
     }
 
+    // ---- #597: return in a NO-yield try, and return value preserved across a yielding finally ----
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    public void ReturnInNoYieldTry_RunsFinally(ExecutionMode mode)
+    {
+        // #597(a): the `return` sits in a try whose body has NO suspension (a real IL try via
+        // EmitSimpleTryCatch). Previously the return completed the state machine directly inside the
+        // protected region — illegal IL (InvalidProgramException). It now Leaves a deferred-return
+        // landing pad that runs the no-yield finally first. The outer `yield 0` makes g a state machine.
+        var source = """
+            async function* g() { yield 0; try { return; } finally { console.log("f"); } }
+            async function main() { for await (const v of g()) console.log("v" + v); }
+            main();
+            """;
+
+        Assert.Equal("v0\nf\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    public void ReturnValueInTry_WithYieldingFinally_PreservesReturnValue(ExecutionMode mode)
+    {
+        // #597(b): when the finally yields, its yielded value must not clobber the return value in
+        // <>2__current. The return value (5) is stashed in <>pendingReturnValue at the `return` and
+        // restored to Current by the return terminal after the finally has run. Driven via next() so
+        // the exact { value, done } records are observable.
+        var source = """
+            async function* g() { try { return 5; } finally { yield 9; } }
+            async function main() {
+                const it = g();
+                console.log(JSON.stringify(await it.next()));
+                console.log(JSON.stringify(await it.next()));
+            }
+            main();
+            """;
+
+        Assert.Equal("{\"value\":9,\"done\":false}\n{\"value\":5,\"done\":true}\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    public void BreakOutOfNoYieldTry_NestedInYieldingTry_RunsOuterFinally(ExecutionMode mode)
+    {
+        // A break inside an inner NO-yield try (real IL) nested in an outer flag-based try-with-finally
+        // must still run the outer finally. Aligning the async EmitBreak/EmitContinue routing with the
+        // sync emitter (route through the flag finally with `Leave` even inside a real IL block) fixed
+        // this latent gap alongside #597; the old code Leave'd straight to the break label, skipping it.
+        var source = """
+            async function* g() {
+              while (true) {
+                try {
+                  yield 0;
+                  try { break; } catch (e) {}
+                } finally { console.log("OUTERFIN"); }
+              }
+            }
+            async function main() { for await (const v of g()) console.log("v" + v); }
+            main();
+            """;
+
+        Assert.Equal("v0\nOUTERFIN\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    public void ContinueOutOfNoYieldTry_NestedInYieldingTry_RunsOuterFinallyEachIteration(ExecutionMode mode)
+    {
+        // The continue sibling of the break case above: continue from an inner no-yield try nested in
+        // an outer flag-based try-with-finally runs the outer finally each iteration (and skips the
+        // statement after the continue).
+        var source = """
+            async function* g() {
+              for (let i = 0; i < 2; i++) {
+                try {
+                  yield i;
+                  try { continue; } catch (e) {}
+                  console.log("unreached");
+                } finally { console.log("fin" + i); }
+              }
+            }
+            async function main() { for await (const v of g()) console.log("v" + v); }
+            main();
+            """;
+
+        Assert.Equal("v0\nfin0\nv1\nfin1\n", TestHarness.Run(source, mode));
+    }
+
     // ---- IL-verification guards (the heart of #559: emitted IL must verify) ----
 
     [Theory]
@@ -426,6 +514,13 @@ public class AsyncGeneratorTryFinallyTests
     // await suspensions crossing the protected region alongside the non-local exits.
     [InlineData("async function* g() { try { await Promise.resolve(0); yield 1; return; } finally { console.log('f'); } } async function main(){ for await (const v of g()) {} } main();")]
     [InlineData("async function* g() { while (true) { try { await Promise.resolve(0); yield 1; break; } finally { console.log('f'); } } } async function main(){ for await (const v of g()) {} } main();")]
+    // #597: return in a NO-yield try (deferred-return landing pad), a value return preserved across a
+    // yielding finally, and break/continue from an inner no-yield try nested in an outer yielding try.
+    [InlineData("async function* g() { yield 0; try { return; } finally { console.log('f'); } } async function main(){ for await (const v of g()) {} } main();")]
+    [InlineData("async function* g() { yield 0; try { return 5; } finally { console.log('f'); } } async function main(){ for await (const v of g()) {} } main();")]
+    [InlineData("async function* g() { try { return 5; } finally { yield 9; } } async function main(){ for await (const v of g()) {} } main();")]
+    [InlineData("async function* g() { while (true) { try { yield 0; try { break; } catch (e) {} } finally { console.log('f'); } } } async function main(){ for await (const v of g()) {} } main();")]
+    [InlineData("async function* g() { for (let i=0;i<2;i++) { try { yield i; try { continue; } catch (e) {} } finally { console.log('f'); } } } async function main(){ for await (const v of g()) {} } main();")]
     public void AsyncGeneratorTryFinallyWithSuspension_EmitsVerifiableIL(string source)
     {
         var errors = TestHarness.CompileAndVerifyOnly(source);


### PR DESCRIPTION
Closes #481, #540, #597. Addresses #542 (eliminates the stack-overflow crash; full ECMA-262 request-queue semantics deferred — see rationale below).

Four related async-generator correctness fixes (compiled + interpreter). All centre on `AsyncGeneratorMoveNextEmitter` / `AsyncGeneratorStateMachineBuilder` and the interpreter's `SharpTSAsyncGenerator`.

## #481 — resumed `yield` / `yield*` completion / off-the-end → `undefined`, not `null` (compiled)
The emitter loaded CLR `null` where the JS value should be `undefined`. Now loads the emitted `$Undefined` sentinel (the async analog of the sync #443 fix) at:
- the resumed `yield` value (`const r = yield 1` → `r === undefined`),
- the `yield*` completion value (`const x = yield* g()`),
- the off-the-end completion value (a drained generator's `next().value`).

## #540 — `next()` after done replays the stale completion value (both modes)
Per ECMA-262 §27.6.1.2 a completed async generator's `next()` always reports `{ value: undefined, done: true }`; the completion value is delivered once.
- **Compiled:** reset `Current` to `$Undefined` at the `state == -2` re-entry label (async analog of #499).
- **Interpreter:** default the completion value to `undefined` and deliver it exactly once; `return()` echoes its argument then leaves the generator closed so a later `next()` reports `undefined` (async analog of #480).

## #597 — `return` in a no-yield try emits invalid IL + return value lost when finally yields (compiled)
Async analog of #554/#555:
- **(a)** a `return` inside a try whose body has no suspension previously completed the state machine directly inside the real IL protected region (illegal IL → `InvalidProgramException`). It now `Leave`s a deferred-return landing pad that runs the enclosing no-yield finally first.
- **(b)** `return <value>` is stashed in a `<>pendingReturnValue` field and restored to `Current` by the return terminal, so a yielding finally no longer clobbers it.
- Also aligns `EmitBreak`/`EmitContinue` routing with the sync emitter (`RouteThroughFinallys` now takes a `Leave`/`Br` choice), fixing a **latent gap**: a break/continue from a no-yield try nested inside a flag-based finally previously `Leave`d straight to the loop label, skipping that finally.

## #542 — re-entrant `next()` stack-overflows (compiled)
A compiled async generator whose body advances itself recursed into `MoveNextAsync` until the stack overflowed (`RangeError: Maximum call stack size exceeded`). An `<>5__executing` guard on `next()/return()/throw()` now rejects a re-entrant call with a catchable `TypeError("Async generator is already running")` instead.

**Why a guard and not the full ECMA-262 §27.6.3 request queue** (which the issue title asks for): the compiled `next()` drives `MoveNextAsync` **synchronously** (`…AsTask().GetAwaiter().GetResult()`). Under that synchronous drive the *only* reachable re-entrancy is the body calling back into itself — which deadlocks even under spec-correct queuing (the body awaits a request queued behind its own execution). A real queue here would convert the crash into a thread-block **hang**, strictly worse than a deterministic, catchable error. A truly-async `next()` (returning a pending promise rather than blocking) plus the queue is a larger rewrite and remains future work; this PR resolves the actual crash. The guard mirrors the proven compiled **sync**-generator guard from #521 (returning a faulted `Task` instead of throwing synchronously, since async `next()` returns a promise).

The re-entrant `TypeError` is observable from a `for await…of` consumer's `try/catch`; observing it from a `try { await it.next() } catch` inside the generator body is currently blocked by a separate pre-existing gap (filed #617).

## Tests
- `AsyncGeneratorTests`: resumed-yield / `yield*`-completion / next-after-done / next-after-return / re-entrancy (compiled). Updated three tests that asserted the old `null` completion value to `undefined`.
- `AsyncGeneratorTryFinallyTests`: return-in-no-yield-try, return-value-across-yielding-finally, break/continue-from-no-yield-try-nested-in-yielding-try, plus new IL-verification `InlineData` cases.
- Full unit suite: **12256 passed, 0 failed**. Test262 subset: **no baseline diff** (async generators aren't in the subset; changes are async-gen-specific). TypeScriptConformance unaffected (no type-checker changes).

## Follow-ups filed
- #617 — a rejected `await` inside a `try` in an async generator isn't caught by that try's `catch` (both modes).
- #618 — `return()`/`throw()` with no argument reports `null` instead of `undefined`.

Adjacent pre-existing issues confirmed but out of scope: #430 (for-await in an async **arrow**), #473 (async-gen `next(v)` resume value), #564 (interpreter eager-drain ordering), #566 (manual `next()` on a throwing gen propagates unhandled).