### PR TITLE
Fix compiled-mode scoping bugs #607, #562, #605, #567

### DIFF
--- a/Compilation/CompilationContext.cs
+++ b/Compilation/CompilationContext.cs
@@ -143,8 +143,32 @@ public partial class CompilationContext
     /// </summary>
     public bool IsStaticConstructorContext { get; set; }
 
+    /// <summary>
+    /// True only when emitting the module's top-level statements (entry-point Main,
+    /// module/script <c>$Initialize</c>). A <c>var</c>/<c>let</c>/<c>const</c> declared
+    /// here is a genuine module-level binding and is routed to its static field
+    /// (<see cref="TopLevelStaticVars"/>) or entry-point display-class field
+    /// (<see cref="CapturedTopLevelVars"/>) so all functions can read it.
+    /// <para>
+    /// Function/method/arrow bodies receive those same dictionaries for READ access
+    /// but set this flag to <c>false</c>: a same-named declaration inside a function
+    /// body is a function-local that must shadow the module binding, not overwrite its
+    /// storage. Without this gate a function-local <c>const x</c> whose name collides
+    /// with a module-level <c>x</c> silently writes through to the module slot and the
+    /// real local binding is never created (#562).
+    /// </para>
+    /// </summary>
+    public bool IsModuleTopLevel { get; set; }
+
     // Namespace support: namespace path -> static field
     public Dictionary<string, FieldBuilder>? NamespaceFields { get; set; }
+
+    // Namespace-level var/let/const backing fields: namespace path -> var name -> static field.
+    // A namespace member variable is stored in its namespace object (for external `N.x` access)
+    // AND in a static field so functions declared in the namespace can resolve the bare name —
+    // the namespace object is not visible inside the function bodies (#567). Mirrors how
+    // module top-level vars use TopLevelStaticVars.
+    public Dictionary<string, Dictionary<string, FieldBuilder>>? NamespaceVarFields { get; set; }
 
     // Top-level variables captured by async functions (stored as static fields)
     public Dictionary<string, FieldBuilder>? TopLevelStaticVars { get; set; }

--- a/Compilation/ExpressionEmitterBase.CallHelpers.cs
+++ b/Compilation/ExpressionEmitterBase.CallHelpers.cs
@@ -113,7 +113,34 @@ public abstract partial class ExpressionEmitterBase
             // Imported functions must go through TopLevelStaticVars (cross-module tokens don't work)
             bool isImportedFunction = Ctx.TopLevelStaticVars?.ContainsKey(funcVar.Name.Lexeme) == true;
 
-            if (!isImportedFunction && Ctx.Functions.TryGetValue(resolvedFuncName, out var methodBuilder))
+            // A more-local binding of the same name (parameter, local, captured var, or a
+            // hoisted nested function declaration) must shadow a module top-level function,
+            // matching JS lexical scoping and the interpreter (#607). The variable-read path
+            // (EmitVariable) already resolves the local binding before the top-level Functions
+            // branch; the direct-call path bypasses the resolver, so without this guard a call
+            // `h()` would silently hit the top-level `h` instead of the in-scope `h`. Defer to
+            // the inner-function direct call (below) or the function-value call (fallback),
+            // both of which honor the resolver's precedence.
+            bool shadowedByLocalBinding = Resolver.HasVariable(funcVar.Name.Lexeme);
+
+            // Exception: a same-module top-level function referenced from within a nested
+            // closure is materialized into a display-class capture field, so HasVariable
+            // reports it — but it is the function itself, not a shadowing binding. Routing it
+            // through the value-call path would drop the direct call's typed-parameter
+            // conversions (e.g. the `path` stdlib's `posix.join` method calls module helper
+            // `posixJoin(parts: string[])`, whose List<string> parameter a value call cannot
+            // satisfy from a List<object>). Keep the direct call unless a genuine parameter or
+            // local of the same name actually shadows it.
+            if (shadowedByLocalBinding &&
+                Ctx.Functions.ContainsKey(resolvedFuncName) &&
+                Ctx.CapturedFields?.ContainsKey(funcVar.Name.Lexeme) == true &&
+                !Ctx.TryGetParameter(funcVar.Name.Lexeme, out _) &&
+                !Ctx.Locals.HasLocal(funcVar.Name.Lexeme))
+            {
+                shadowedByLocalBinding = false;
+            }
+
+            if (!shadowedByLocalBinding && !isImportedFunction && Ctx.Functions.TryGetValue(resolvedFuncName, out var methodBuilder))
             {
                 MethodInfo targetMethod = methodBuilder;
 

--- a/Compilation/ILCompiler.Functions.cs
+++ b/Compilation/ILCompiler.Functions.cs
@@ -280,6 +280,12 @@ public partial class ILCompiler
         // module's bindings plus global imports.
         Dictionary<string, FieldBuilder>? topLevelVars = BuildTopLevelStaticVarsForModule(_modules.CurrentPath);
 
+        // A function declared inside a namespace must also resolve that namespace's
+        // var/let/const members by their bare names (#567). Surface their static backing
+        // fields through the same resolver path as module top-level vars.
+        if (_currentNamespacePath != null)
+            topLevelVars = BuildNamespaceScopedStaticVars(topLevelVars, _currentNamespacePath);
+
         var ctx = new CompilationContext(il, _typeMapper, _functions.Builders, _classes.Builders, _types)
         {
             ClosureAnalyzer = _closures.Analyzer,
@@ -950,6 +956,7 @@ public partial class ILCompiler
             EnumReverse = _enums.Reverse,
             EnumKinds = _enums.Kinds,
             NamespaceFields = _namespaceFields,
+            NamespaceVarFields = _namespaceVarFields,
             TopLevelStaticVars = BuildTopLevelStaticVarsForModule(_modules.CurrentPath),
             Runtime = _runtime,
             FunctionGenericParams = _functions.GenericParams,
@@ -984,7 +991,9 @@ public partial class ILCompiler
             ArrowEntryPointDCFields = _closures.ArrowEntryPointDCFields.Count > 0 ? _closures.ArrowEntryPointDCFields : null,
             EntryPointDisplayClassStaticField = _closures.EntryPointDisplayClassStaticField,
             // Program type for GetMethodFromHandle resolution
-            ProgramType = _programType
+            ProgramType = _programType,
+            // Top-level statements run here: var/let/const are module-level bindings (#562).
+            IsModuleTopLevel = true
         };
 
         // Create entry-point display class instance if there are captured top-level variables
@@ -1108,6 +1117,7 @@ public partial class ILCompiler
             EnumReverse = _enums.Reverse,
             EnumKinds = _enums.Kinds,
             NamespaceFields = _namespaceFields,
+            NamespaceVarFields = _namespaceVarFields,
             TopLevelStaticVars = BuildTopLevelStaticVarsForModule(_modules.CurrentPath),
             Runtime = _runtime,
             FunctionGenericParams = _functions.GenericParams,
@@ -1138,7 +1148,9 @@ public partial class ILCompiler
             EntryPointDisplayClassFields = BuildEntryPointDisplayClassFieldsForModule(_modules.CurrentPath),
             CapturedTopLevelVars = BuildCapturedTopLevelVarsForModule(_modules.CurrentPath),
             ArrowEntryPointDCFields = _closures.ArrowEntryPointDCFields.Count > 0 ? _closures.ArrowEntryPointDCFields : null,
-            EntryPointDisplayClassStaticField = _closures.EntryPointDisplayClassStaticField
+            EntryPointDisplayClassStaticField = _closures.EntryPointDisplayClassStaticField,
+            // Top-level statements run here: var/let/const are module-level bindings (#562).
+            IsModuleTopLevel = true
         };
 
         // Create entry-point display class instance if there are captured top-level variables

--- a/Compilation/ILCompiler.Modules.cs
+++ b/Compilation/ILCompiler.Modules.cs
@@ -713,6 +713,7 @@ public partial class ILCompiler
             EnumReverse = _enums.Reverse,
             EnumKinds = _enums.Kinds,
             NamespaceFields = _namespaceFields,
+            NamespaceVarFields = _namespaceVarFields,
             // Scope top-level static vars to the current module to prevent
             // cross-module name collisions (e.g. `const foo` in main.ts
             // shadowing `export function foo()` in lib.ts).
@@ -746,7 +747,10 @@ public partial class ILCompiler
             EntryPointDisplayClassFields = BuildEntryPointDisplayClassFieldsForModule(_modules.CurrentPath),
             CapturedTopLevelVars = BuildCapturedTopLevelVarsForModule(_modules.CurrentPath),
             ArrowEntryPointDCFields = _closures.ArrowEntryPointDCFields.Count > 0 ? _closures.ArrowEntryPointDCFields : null,
-            EntryPointDisplayClassStaticField = _closures.EntryPointDisplayClassStaticField
+            EntryPointDisplayClassStaticField = _closures.EntryPointDisplayClassStaticField,
+            // This context emits the module/script top-level statements, so var/let/const
+            // declarations here are genuine module-level bindings (#562).
+            IsModuleTopLevel = true
         };
     }
 

--- a/Compilation/ILCompiler.Namespaces.cs
+++ b/Compilation/ILCompiler.Namespaces.cs
@@ -10,6 +10,19 @@ namespace SharpTS.Compilation;
 public partial class ILCompiler
 {
     /// <summary>
+    /// Namespace-level var/let/const backing fields: namespace path -> var name -> static field.
+    /// See <see cref="CompilationContext.NamespaceVarFields"/> for the rationale (#567).
+    /// </summary>
+    private readonly Dictionary<string, Dictionary<string, FieldBuilder>> _namespaceVarFields = [];
+
+    /// <summary>
+    /// The namespace path whose member bodies are currently being emitted, or null when
+    /// not inside a namespace. Set by <see cref="EmitNamespaceMemberBodies"/> so a namespace
+    /// function body can surface its enclosing namespaces' var fields to its resolver (#567).
+    /// </summary>
+    private string? _currentNamespacePath;
+
+    /// <summary>
     /// Defines static fields for a namespace and its nested namespaces.
     /// Called during the definition phase to create module-level fields.
     /// </summary>
@@ -59,39 +72,111 @@ public partial class ILCompiler
                     // Define enums inside namespace
                     DefineEnum(enumStmt);
                     break;
+
+                // A namespace-level variable needs a static backing field so functions
+                // declared in the namespace can resolve the bare name (#567).
+                case Stmt.Var varStmt:
+                    DefineNamespaceVarField(path, varStmt.Name.Lexeme);
+                    break;
+
+                case Stmt.Const constStmt:
+                    DefineNamespaceVarField(path, constStmt.Name.Lexeme);
+                    break;
             }
         }
+    }
+
+    /// <summary>
+    /// Defines (once) the static backing field for a namespace-level variable.
+    /// </summary>
+    private void DefineNamespaceVarField(string nsPath, string varName)
+    {
+        if (!_namespaceVarFields.TryGetValue(nsPath, out var fields))
+        {
+            fields = [];
+            _namespaceVarFields[nsPath] = fields;
+        }
+        if (!fields.ContainsKey(varName))
+        {
+            fields[varName] = _programType.DefineField(
+                $"$nsvar_{nsPath.Replace(".", "_")}_{varName}",
+                _types.Object,
+                FieldAttributes.Public | FieldAttributes.Static);
+        }
+    }
+
+    /// <summary>
+    /// Returns module top-level static vars augmented with the static backing fields of every
+    /// namespace enclosing <paramref name="nsPath"/> (innermost wins). Used to make a namespace
+    /// function body resolve bare references to namespace-level variables (#567).
+    /// </summary>
+    private Dictionary<string, FieldBuilder>? BuildNamespaceScopedStaticVars(
+        Dictionary<string, FieldBuilder>? moduleVars, string nsPath)
+    {
+        var merged = moduleVars != null
+            ? new Dictionary<string, FieldBuilder>(moduleVars)
+            : [];
+
+        // Walk outermost → innermost ("N", then "N.M") so an inner namespace's binding
+        // shadows an outer one, and any namespace binding shadows a same-named module var.
+        string prefix = "";
+        foreach (var part in nsPath.Split('.'))
+        {
+            prefix = prefix.Length == 0 ? part : $"{prefix}.{part}";
+            if (_namespaceVarFields.TryGetValue(prefix, out var fields))
+            {
+                foreach (var (name, field) in fields)
+                    merged[name] = field;
+            }
+        }
+
+        return merged;
     }
 
     /// <summary>
     /// Emits method bodies for functions and classes inside a namespace.
     /// Called during Phase 7 (method body emission).
     /// </summary>
-    private void EmitNamespaceMemberBodies(Stmt.Namespace ns)
+    private void EmitNamespaceMemberBodies(Stmt.Namespace ns, string parentPath = "")
     {
-        foreach (var member in ns.Members)
+        string path = string.IsNullOrEmpty(parentPath)
+            ? ns.Name.Lexeme
+            : $"{parentPath}.{ns.Name.Lexeme}";
+
+        // Record the enclosing namespace so EmitFunctionBody can surface this namespace's
+        // var fields to the function's resolver (#567). Saved/restored to support nesting.
+        var savedNamespacePath = _currentNamespacePath;
+        _currentNamespacePath = path;
+        try
         {
-            var actualMember = member;
-            // Unwrap export
-            if (member is Stmt.Export { Declaration: not null } exp)
+            foreach (var member in ns.Members)
             {
-                actualMember = exp.Declaration;
+                var actualMember = member;
+                // Unwrap export
+                if (member is Stmt.Export { Declaration: not null } exp)
+                {
+                    actualMember = exp.Declaration;
+                }
+
+                switch (actualMember)
+                {
+                    case Stmt.Namespace nested:
+                        EmitNamespaceMemberBodies(nested, path);
+                        break;
+
+                    case Stmt.Function funcStmt when funcStmt.Body != null:
+                        EmitFunctionBody(funcStmt);
+                        break;
+
+                    case Stmt.Class classStmt:
+                        EmitClassMethods(classStmt);
+                        break;
+                }
             }
-
-            switch (actualMember)
-            {
-                case Stmt.Namespace nested:
-                    EmitNamespaceMemberBodies(nested);
-                    break;
-
-                case Stmt.Function funcStmt when funcStmt.Body != null:
-                    EmitFunctionBody(funcStmt);
-                    break;
-
-                case Stmt.Class classStmt:
-                    EmitClassMethods(classStmt);
-                    break;
-            }
+        }
+        finally
+        {
+            _currentNamespacePath = savedNamespacePath;
         }
     }
 

--- a/Compilation/ILEmitter.Namespaces.cs
+++ b/Compilation/ILEmitter.Namespaces.cs
@@ -80,15 +80,19 @@ public partial class ILEmitter
                 break;
 
             case Stmt.Var varStmt:
-                // Emit variable declaration
+                // Emit variable declaration (creates a local for same-namespace-init reads),
+                // publish to the namespace object (external `N.x`), and mirror into the static
+                // backing field so functions in the namespace can resolve the bare name (#567).
                 EmitStatement(varStmt);
                 StoreLocalInNamespaceField(nsField, memberName!);
+                StoreLocalInNamespaceStaticField(nsPath, memberName!);
                 break;
 
             case Stmt.Const constStmt:
-                // Emit const declaration
+                // Emit const declaration (see Stmt.Var above for the three storage targets).
                 EmitStatement(constStmt);
                 StoreLocalInNamespaceField(nsField, memberName!);
+                StoreLocalInNamespaceStaticField(nsPath, memberName!);
                 break;
 
             case Stmt.Class classStmt:
@@ -227,6 +231,33 @@ public partial class ILEmitter
                 IL.Emit(OpCodes.Box, memberLocal.LocalType);
             }
             IL.Emit(OpCodes.Call, _ctx.Runtime!.TSNamespaceSet);
+        }
+    }
+
+    /// <summary>
+    /// Mirrors a namespace-level variable's value from its emitted local into the namespace's
+    /// static backing field, so functions declared in the namespace resolve the bare name via
+    /// the standard top-level-static-var path (#567). No-op when no backing field was defined
+    /// (e.g. a non-variable member).
+    /// </summary>
+    private void StoreLocalInNamespaceStaticField(string nsPath, string memberName)
+    {
+        if (_ctx.NamespaceVarFields == null ||
+            !_ctx.NamespaceVarFields.TryGetValue(nsPath, out var fields) ||
+            !fields.TryGetValue(memberName, out var nsVarField))
+        {
+            return;
+        }
+
+        var memberLocal = _ctx.Locals.GetLocal(memberName);
+        if (memberLocal != null)
+        {
+            IL.Emit(OpCodes.Ldloc, memberLocal);
+            if (memberLocal.LocalType.IsValueType)
+            {
+                IL.Emit(OpCodes.Box, memberLocal.LocalType);
+            }
+            IL.Emit(OpCodes.Stsfld, nsVarField);
         }
     }
 }

--- a/Compilation/ILEmitter.Statements.cs
+++ b/Compilation/ILEmitter.Statements.cs
@@ -32,9 +32,15 @@ public partial class ILEmitter
 
     protected override void EmitVarDeclaration(Stmt.Var v)
     {
-        // If we're in a nested scope, always create a local variable to support shadowing.
-        // This allows inner scopes to declare variables with the same name as outer/top-level vars.
-        if (!_ctx.Locals.IsInNestedScope)
+        // Module-level storage (static field / entry-point display class) is only the right
+        // target when this declaration IS a module-level binding: we are emitting the module
+        // top-level statements (IsModuleTopLevel) and not inside a nested block. Inside a
+        // function body the same dictionaries are present for READ access, but a same-named
+        // declaration there is a function-local that must shadow — not overwrite — the module
+        // binding; falling into this block wrote a function-local through to the module slot
+        // and never created the real local, so captured reads saw null and the module var was
+        // clobbered (#562). A nested block at top level likewise shadows via a fresh local.
+        if (_ctx.IsModuleTopLevel && !_ctx.Locals.IsInNestedScope)
         {
             // Check if this is a captured top-level variable - use entry-point display class
             if (_ctx.CapturedTopLevelVars?.Contains(v.Name.Lexeme) == true &&

--- a/Compilation/NestedFunctionLifter.cs
+++ b/Compilation/NestedFunctionLifter.cs
@@ -75,11 +75,16 @@ internal sealed class NestedFunctionLifter
     /// </summary>
     public static List<Stmt> Lift(List<Stmt> module)
     {
-        // Cheap structural pre-scan: collect declarations whose SHAPE qualifies (case A/B), without
-        // running closure analysis. The overwhelmingly common module has none, so we return early.
-        var shapeCandidates = new List<Stmt.Function>();
-        CollectShapeCandidates(module, enclosingIsStateMachine: false, insideFunction: false, shapeCandidates);
-        if (shapeCandidates.Count == 0) return module;
+        // Cheap structural pre-scan: collect declarations whose SHAPE qualifies (case A/B, or a
+        // declaration inside a module-level block/loop), without running closure analysis. The
+        // overwhelmingly common module has none, so we return early. We iterate the module statements
+        // directly (not via CollectShapeCandidates) because module top-level declarations are NOT
+        // block/loop bindings — they stay reachable after a lift — so they must not seed the
+        // enclosing-binding set the capture guard checks against.
+        var scan = new ShapeScan();
+        foreach (var stmt in module)
+            CollectShapeCandidatesStmt(stmt, enclosingIsStateMachine: false, insideFunction: false, insideModuleBlock: false, enclosingBlockBindings: [], scan);
+        if (scan.Candidates.Count == 0) return module;
 
         // Capture analysis is needed to tell a safe (module/global) reference from an unsafe
         // enclosing-scope capture. Run our own pass on the original AST; the main pipeline
@@ -91,10 +96,17 @@ internal sealed class NestedFunctionLifter
         // not collide with a top-level binding (which would hijack the injected alias).
         var reservedTopLevelNames = CollectTopLevelBindingNames(module);
         var safe = new HashSet<Stmt.Function>(ReferenceEqualityComparer.Instance);
-        foreach (var f in shapeCandidates)
+        foreach (var f in scan.Candidates)
         {
             if (!IsNonCapturing(analyzer, f)) continue;
             if (reservedTopLevelNames.Contains(f.Name.Lexeme)) continue;
+            // A module-level-block candidate that captures a binding declared in an enclosing
+            // block/loop scope (e.g. a generator in a `for` reading the loop variable) cannot be
+            // lifted: that name does not exist at module top level, so the relocated body would
+            // read the wrong slot. Leaving it nested is a clean failure, never a miscompile (#605).
+            if (scan.ModuleBlockEnclosingBindings.TryGetValue(f, out var blockBindings) &&
+                CapturesAnyOf(analyzer, f, blockBindings))
+                continue;
             safe.Add(f);
         }
         if (safe.Count == 0) return module;
@@ -135,79 +147,156 @@ internal sealed class NestedFunctionLifter
         return true;
     }
 
-    #region Structural candidate collection (read-only, no closure analysis)
-
-    private static void CollectShapeCandidates(List<Stmt> body, bool enclosingIsStateMachine, bool insideFunction, List<Stmt.Function> output)
+    /// <summary>True if <paramref name="f"/> captures any name in <paramref name="names"/> (its own
+    /// name excluded — recursion is handled by the self-alias, not a captured binding).</summary>
+    private static bool CapturesAnyOf(ClosureAnalyzer analyzer, Stmt.Function f, HashSet<string> names)
     {
-        foreach (var stmt in body)
-            CollectShapeCandidatesStmt(stmt, enclosingIsStateMachine, insideFunction, output);
+        foreach (var captured in analyzer.GetCaptures(f))
+        {
+            if (captured == f.Name.Lexeme) continue;
+            if (names.Contains(captured)) return true;
+        }
+        return false;
     }
 
-    private static void CollectShapeCandidatesStmt(Stmt stmt, bool enclosingIsStateMachine, bool insideFunction, List<Stmt.Function> output)
+    /// <summary>Accumulates the structural candidate scan results.</summary>
+    private sealed class ShapeScan
+    {
+        public readonly List<Stmt.Function> Candidates = [];
+        /// <summary>For module-level-block candidates only: the block/loop-scoped binding names in
+        /// scope around the declaration. A candidate capturing any of these can't be lifted to
+        /// module scope (the names don't exist there).</summary>
+        public readonly Dictionary<Stmt.Function, HashSet<string>> ModuleBlockEnclosingBindings = new(ReferenceEqualityComparer.Instance);
+    }
+
+    #region Structural candidate collection (read-only, no closure analysis)
+
+    private static void CollectShapeCandidates(List<Stmt> body, bool enclosingIsStateMachine, bool insideFunction, bool insideModuleBlock, HashSet<string> enclosingBlockBindings, ShapeScan scan)
+    {
+        // A statement list opens a lexical scope: its own declarations are visible to nested
+        // functions, so add them to the enclosing-binding set used by the module-block capture
+        // guard. Only tracked at module level — inside a function the inner-function machinery
+        // resolves captures itself.
+        var bindings = !insideFunction ? WithBlockBindings(enclosingBlockBindings, body) : enclosingBlockBindings;
+        foreach (var stmt in body)
+            CollectShapeCandidatesStmt(stmt, enclosingIsStateMachine, insideFunction, insideModuleBlock, bindings, scan);
+    }
+
+    private static void CollectShapeCandidatesStmt(Stmt stmt, bool enclosingIsStateMachine, bool insideFunction, bool insideModuleBlock, HashSet<string> enclosingBlockBindings, ShapeScan scan)
     {
         switch (stmt)
         {
             case Stmt.Function f when f.Body != null:
-                // Only lift declarations nested INSIDE a function-like. A declaration that is only
-                // inside a module-level block/loop is left alone: the closure analyzer attributes
-                // block/loop-scoped captures to an enclosing function, but at module scope there is
-                // none, so such a capture looks (falsely) module-global. Lifting it out of its block
-                // would silently break the reference (e.g. a generator in a `for` capturing the loop
-                // variable). Inside a function those captures are tracked correctly and blocked.
+                // (1) A declaration nested INSIDE a function-like whose shape needs the top-level
+                // state-machine pipeline (gen/async, or a plain fn inside a state machine). Captures
+                // into the enclosing function are tracked correctly and blocked by IsNonCapturing.
                 if (insideFunction && IsCandidateShape(f, enclosingIsStateMachine))
-                    output.Add(f);
+                    scan.Candidates.Add(f);
+                // (2) Any function/generator/async declared directly inside a module-level block,
+                // loop, or `if` (no enclosing function): it is bound by neither the top-level
+                // definition pass (which doesn't recurse into blocks) nor the inner-function pass
+                // (which only fires inside a function), so a reference throws "Undefined variable"
+                // in compiled mode (#605). Record it with the block/loop bindings in scope so Lift
+                // can drop it if it captures one of them (a clean failure, never a miscompile).
+                else if (!insideFunction && insideModuleBlock)
+                {
+                    scan.Candidates.Add(f);
+                    scan.ModuleBlockEnclosingBindings[f] = enclosingBlockBindings;
+                }
                 // A nested function's own body establishes a fresh enclosing kind for its children.
-                CollectShapeCandidates(f.Body, f.IsGenerator || f.IsAsync, insideFunction: true, output);
+                CollectShapeCandidates(f.Body, f.IsGenerator || f.IsAsync, insideFunction: true, insideModuleBlock: false, enclosingBlockBindings, scan);
                 break;
             case Stmt.Block b:
-                CollectShapeCandidates(b.Statements, enclosingIsStateMachine, insideFunction, output);
+                CollectShapeCandidates(b.Statements, enclosingIsStateMachine, insideFunction, insideModuleBlock: !insideFunction, enclosingBlockBindings, scan);
                 break;
             case Stmt.Sequence s:
-                CollectShapeCandidates(s.Statements, enclosingIsStateMachine, insideFunction, output);
+                CollectShapeCandidates(s.Statements, enclosingIsStateMachine, insideFunction, insideModuleBlock, enclosingBlockBindings, scan);
                 break;
             case Stmt.If i:
-                CollectShapeCandidatesStmt(i.ThenBranch, enclosingIsStateMachine, insideFunction, output);
-                if (i.ElseBranch != null) CollectShapeCandidatesStmt(i.ElseBranch, enclosingIsStateMachine, insideFunction, output);
+                CollectShapeCandidatesStmt(i.ThenBranch, enclosingIsStateMachine, insideFunction, insideModuleBlock: !insideFunction, enclosingBlockBindings, scan);
+                if (i.ElseBranch != null) CollectShapeCandidatesStmt(i.ElseBranch, enclosingIsStateMachine, insideFunction, insideModuleBlock: !insideFunction, enclosingBlockBindings, scan);
                 break;
             case Stmt.While w:
-                CollectShapeCandidatesStmt(w.Body, enclosingIsStateMachine, insideFunction, output);
+                CollectShapeCandidatesStmt(w.Body, enclosingIsStateMachine, insideFunction, insideModuleBlock: !insideFunction, enclosingBlockBindings, scan);
                 break;
             case Stmt.DoWhile d:
-                CollectShapeCandidatesStmt(d.Body, enclosingIsStateMachine, insideFunction, output);
+                CollectShapeCandidatesStmt(d.Body, enclosingIsStateMachine, insideFunction, insideModuleBlock: !insideFunction, enclosingBlockBindings, scan);
                 break;
             case Stmt.For fo:
-                if (fo.Initializer != null) CollectShapeCandidatesStmt(fo.Initializer, enclosingIsStateMachine, insideFunction, output);
-                CollectShapeCandidatesStmt(fo.Body, enclosingIsStateMachine, insideFunction, output);
+                // The loop variable is scoped to the loop body — add it to the bindings so a body
+                // declaration that captures it (the #605 `for (let k…) { function* g(){ yield k } }`
+                // case) is recognized as capturing and left nested.
+                var forBindings = !insideFunction ? WithDeclaration(enclosingBlockBindings, fo.Initializer) : enclosingBlockBindings;
+                if (fo.Initializer != null) CollectShapeCandidatesStmt(fo.Initializer, enclosingIsStateMachine, insideFunction, insideModuleBlock, enclosingBlockBindings, scan);
+                CollectShapeCandidatesStmt(fo.Body, enclosingIsStateMachine, insideFunction, insideModuleBlock: !insideFunction, forBindings, scan);
                 break;
             case Stmt.ForOf fof:
-                CollectShapeCandidatesStmt(fof.Body, enclosingIsStateMachine, insideFunction, output);
+                var forOfBindings = !insideFunction ? WithName(enclosingBlockBindings, fof.Variable.Lexeme) : enclosingBlockBindings;
+                CollectShapeCandidatesStmt(fof.Body, enclosingIsStateMachine, insideFunction, insideModuleBlock: !insideFunction, forOfBindings, scan);
                 break;
             case Stmt.ForIn fin:
-                CollectShapeCandidatesStmt(fin.Body, enclosingIsStateMachine, insideFunction, output);
+                var forInBindings = !insideFunction ? WithName(enclosingBlockBindings, fin.Variable.Lexeme) : enclosingBlockBindings;
+                CollectShapeCandidatesStmt(fin.Body, enclosingIsStateMachine, insideFunction, insideModuleBlock: !insideFunction, forInBindings, scan);
                 break;
             case Stmt.LabeledStatement l:
-                CollectShapeCandidatesStmt(l.Statement, enclosingIsStateMachine, insideFunction, output);
+                CollectShapeCandidatesStmt(l.Statement, enclosingIsStateMachine, insideFunction, insideModuleBlock, enclosingBlockBindings, scan);
                 break;
             case Stmt.TryCatch t:
-                CollectShapeCandidates(t.TryBlock, enclosingIsStateMachine, insideFunction, output);
-                if (t.CatchBlock != null) CollectShapeCandidates(t.CatchBlock, enclosingIsStateMachine, insideFunction, output);
-                if (t.FinallyBlock != null) CollectShapeCandidates(t.FinallyBlock, enclosingIsStateMachine, insideFunction, output);
+                CollectShapeCandidates(t.TryBlock, enclosingIsStateMachine, insideFunction, insideModuleBlock: !insideFunction, enclosingBlockBindings, scan);
+                if (t.CatchBlock != null)
+                {
+                    var catchBindings = !insideFunction ? WithName(enclosingBlockBindings, t.CatchParam?.Lexeme) : enclosingBlockBindings;
+                    CollectShapeCandidates(t.CatchBlock, enclosingIsStateMachine, insideFunction, insideModuleBlock: !insideFunction, catchBindings, scan);
+                }
+                if (t.FinallyBlock != null) CollectShapeCandidates(t.FinallyBlock, enclosingIsStateMachine, insideFunction, insideModuleBlock: !insideFunction, enclosingBlockBindings, scan);
                 break;
             case Stmt.Switch sw:
-                foreach (var c in sw.Cases) CollectShapeCandidates(c.Body, enclosingIsStateMachine, insideFunction, output);
-                if (sw.DefaultBody != null) CollectShapeCandidates(sw.DefaultBody, enclosingIsStateMachine, insideFunction, output);
+                foreach (var c in sw.Cases) CollectShapeCandidates(c.Body, enclosingIsStateMachine, insideFunction, insideModuleBlock: !insideFunction, enclosingBlockBindings, scan);
+                if (sw.DefaultBody != null) CollectShapeCandidates(sw.DefaultBody, enclosingIsStateMachine, insideFunction, insideModuleBlock: !insideFunction, enclosingBlockBindings, scan);
                 break;
             case Stmt.Class cls:
                 // Method bodies are function-likes regardless of where the class sits.
                 foreach (var m in cls.Methods)
-                    if (m.Body != null) CollectShapeCandidates(m.Body, m.IsGenerator || m.IsAsync, insideFunction: true, output);
+                    if (m.Body != null) CollectShapeCandidates(m.Body, m.IsGenerator || m.IsAsync, insideFunction: true, insideModuleBlock: false, enclosingBlockBindings, scan);
                 break;
             case Stmt.Export ex when ex.Declaration != null:
-                CollectShapeCandidatesStmt(ex.Declaration, enclosingIsStateMachine, insideFunction, output);
+                CollectShapeCandidatesStmt(ex.Declaration, enclosingIsStateMachine, insideFunction, insideModuleBlock, enclosingBlockBindings, scan);
                 break;
             // Stmt.Namespace is intentionally NOT traversed (#583 §3 lift barrier).
         }
     }
+
+    /// <summary>Returns <paramref name="current"/> extended with the names declared directly in
+    /// <paramref name="blockStmts"/> (a new set only when something is added).</summary>
+    private static HashSet<string> WithBlockBindings(HashSet<string> current, List<Stmt> blockStmts)
+    {
+        HashSet<string>? added = null;
+        foreach (var s in blockStmts)
+        {
+            var name = DeclaredName(s);
+            if (name != null && !current.Contains(name))
+                (added ??= new HashSet<string>(current)).Add(name);
+        }
+        return added ?? current;
+    }
+
+    private static HashSet<string> WithDeclaration(HashSet<string> current, Stmt? decl)
+        => decl == null ? current : WithName(current, DeclaredName(decl));
+
+    private static HashSet<string> WithName(HashSet<string> current, string? name)
+        => name == null || current.Contains(name) ? current : new HashSet<string>(current) { name };
+
+    /// <summary>The single binding name a declaration statement introduces, or null.</summary>
+    private static string? DeclaredName(Stmt stmt) => stmt switch
+    {
+        Stmt.Function f => f.Name.Lexeme,
+        Stmt.Class c => c.Name.Lexeme,
+        Stmt.Var v => v.Name.Lexeme,
+        Stmt.Const co => co.Name.Lexeme,
+        Stmt.Enum e => e.Name.Lexeme,
+        Stmt.Export { Declaration: not null } ex => DeclaredName(ex.Declaration),
+        _ => null
+    };
 
     #endregion
 

--- a/SharpTS.Tests/SharedTests/FunctionShadowingCallTests.cs
+++ b/SharpTS.Tests/SharedTests/FunctionShadowingCallTests.cs
@@ -1,0 +1,85 @@
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests;
+
+/// <summary>
+/// Issue #607: in a call position, an in-scope local binding (parameter, <c>let</c>/<c>const</c>, or
+/// a nested <c>function</c> declaration) must shadow a module top-level function of the same name —
+/// matching JS lexical scoping and the interpreter. The compiler's direct-call dispatch consulted the
+/// top-level function table before the local resolver, so <c>h()</c> silently called the top-level
+/// <c>h</c> instead of the shadowing binding. The variable-READ path was already correct; only the
+/// call path was wrong. The fix defers the direct top-level call when the resolver has a closer
+/// binding (without disturbing a top-level function merely reached through a closure capture).
+/// </summary>
+public class FunctionShadowingCallTests
+{
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Parameter_ShadowsTopLevelFunction_InCall(ExecutionMode mode)
+    {
+        var source = """
+            function h(): number { return 1; }
+            function b(h: () => number): number { return h(); }
+            console.log(b(() => 20));
+            """;
+        Assert.Equal("20", TestHarness.Run(source, mode).Trim());
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void LocalConst_ShadowsTopLevelFunction_InCall(ExecutionMode mode)
+    {
+        var source = """
+            function h(): number { return 1; }
+            function b(): number { const h = () => 20; return h(); }
+            console.log(b());
+            """;
+        Assert.Equal("20", TestHarness.Run(source, mode).Trim());
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void NestedFunction_ShadowsTopLevelFunction_InCall(ExecutionMode mode)
+    {
+        var source = """
+            function h(): number { return 1; }
+            function b(): number { function h(): number { return 20; } return h(); }
+            console.log(b());
+            """;
+        Assert.Equal("20", TestHarness.Run(source, mode).Trim());
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void UnshadowedTopLevelFunction_StillCalledDirectly(ExecutionMode mode)
+    {
+        // Control: a function with no shadowing binding in scope must still reach the top-level h.
+        var source = """
+            function h(): number { return 1; }
+            function b(): number { function h(): number { return 20; } return h(); }
+            function callsTop(): number { return h(); }
+            console.log(b() + "," + callsTop());
+            """;
+        Assert.Equal("20,1", TestHarness.Run(source, mode).Trim());
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void LetParameter_ShadowsTopLevelFunction_InCall(ExecutionMode mode)
+    {
+        // A reassigned `let` still shadows the top-level function for the rest of the body; the call
+        // must observe the reassignment, not fall back to the top-level `compute`.
+        var source = """
+            function compute(): number { return 1; }
+            function run(): number {
+                let compute: () => number = () => 7;
+                const first = compute();
+                compute = () => 9;
+                return first + compute();
+            }
+            console.log(run());
+            """;
+        Assert.Equal("16", TestHarness.Run(source, mode).Trim());
+    }
+}

--- a/SharpTS.Tests/SharedTests/LexicalForwardReferenceTests.cs
+++ b/SharpTS.Tests/SharedTests/LexicalForwardReferenceTests.cs
@@ -99,14 +99,16 @@ public class LexicalForwardReferenceTests
         Assert.Equal("99", TestHarness.Run(source, mode).Trim());
     }
 
-    [Fact]
-    public void ShadowingConst_BindsToInnerDeclaration_Interpreted()
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ShadowingConst_BindsToInnerDeclaration(ExecutionMode mode)
     {
         // The inner `const x` shadows the outer one throughout `wrapper`, including in f's closure.
         // Hoisting the inner binding makes f resolve to it (value "shadow"), which is what runs.
-        // Interpreted-only: compiled mode mis-binds a captured *shadowing* block-scoped name to the
-        // wrong display-class slot (resolves to null) — a pre-existing defect, orthogonal to #533
-        // (it reproduces with f declared AFTER the inner const, i.e. no forward reference). See #562.
+        // #562: compiled mode previously routed a function-local declaration whose name collides with
+        // a module-level binding to the MODULE slot (a captured copy that f then read as null, and the
+        // module variable was clobbered). Fixed by gating module-level storage on the actual
+        // module-top-level emission context, so the inner binding gets its own display-class slot.
         var source = """
             const x = 99;
             function wrapper() {
@@ -117,7 +119,26 @@ public class LexicalForwardReferenceTests
             console.log(wrapper());
             """;
 
-        Assert.Equal("shadow", TestHarness.RunInterpreted(source).Trim());
+        Assert.Equal("shadow", TestHarness.Run(source, mode).Trim());
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ShadowingConst_DoesNotClobberOuterModuleBinding(ExecutionMode mode)
+    {
+        // The companion to #562: the function-local shadow must not write through to the module
+        // binding's storage. Before the fix the inner `const x` overwrote the module-level `x`.
+        var source = """
+            const x = "outer";
+            function wrapper() {
+                const x = "inner";
+                return x;
+            }
+            const inner = wrapper();
+            console.log(inner + " " + x);
+            """;
+
+        Assert.Equal("inner outer", TestHarness.Run(source, mode).Trim());
     }
 
     [Theory]
@@ -136,13 +157,15 @@ public class LexicalForwardReferenceTests
         Assert.Equal("true true", TestHarness.Run(source, mode).Trim());
     }
 
-    [Fact]
-    public void NamespaceMemberFunction_ReferencesLaterConst_Interpreted()
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void NamespaceMemberFunction_ReferencesLaterConst(ExecutionMode mode)
     {
-        // A namespace member function declared before a namespace-level const now type-checks the
-        // same way the in-order variant already did. Interpreted-only: compiled mode cannot resolve
-        // a namespace-level variable from a namespace member function at all (any order, var/let/const)
-        // — a pre-existing, orthogonal namespace-emission defect tracked in #567.
+        // A namespace member function declared before a namespace-level const type-checks the same way
+        // the in-order variant does. #567: compiled mode previously could not resolve a namespace-level
+        // variable from a namespace member function (any order, var/let/const) because the variable was
+        // only a runtime member of the namespace object, invisible to the function body. Fixed by also
+        // backing each namespace-level variable with a static field surfaced to the function's resolver.
         var source = """
             namespace N {
                 export function f() { return val; }
@@ -152,7 +175,7 @@ public class LexicalForwardReferenceTests
             console.log(N.result);
             """;
 
-        Assert.Equal("7", TestHarness.RunInterpreted(source).Trim());
+        Assert.Equal("7", TestHarness.Run(source, mode).Trim());
     }
 
     [Fact]

--- a/SharpTS.Tests/SharedTests/NamespaceTests.cs
+++ b/SharpTS.Tests/SharedTests/NamespaceTests.cs
@@ -10,6 +10,77 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class NamespaceTests
 {
+    #region Namespace-level variable access from member functions (#567)
+
+    // A function declared in a namespace must be able to read namespace-level var/let/const members.
+    // Compiled mode previously stored those only as runtime members of the namespace object, invisible
+    // to the member function body, throwing "Undefined variable". The fix also backs each with a static
+    // field surfaced to the function's resolver. These pin every variant from the issue.
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void NamespaceFunction_ReadsNamespaceConst(ExecutionMode mode)
+    {
+        var code = @"
+            namespace N { const val = 7; export function f() { return val; } export const result = f(); }
+            console.log(N.result);
+        ";
+        Assert.Equal("7\n", TestHarness.Run(code, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void NamespaceFunction_ReadsNamespaceLet(ExecutionMode mode)
+    {
+        var code = @"
+            namespace N { let val = 7; export function f() { return val; } export const r = f(); }
+            console.log(N.r);
+        ";
+        Assert.Equal("7\n", TestHarness.Run(code, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void NamespaceFunction_ReadsNamespaceVar(ExecutionMode mode)
+    {
+        var code = @"
+            namespace N { export var val = 7; export function f() { return val; } export const r = f(); }
+            console.log(N.r);
+        ";
+        Assert.Equal("7\n", TestHarness.Run(code, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void NamespaceFunction_ReadsExportedConst_AndExternalAccessStillWorks(ExecutionMode mode)
+    {
+        var code = @"
+            namespace N { export const val = 7; export function f() { return val; } export const r = f(); }
+            console.log(N.r + "","" + N.val);
+        ";
+        Assert.Equal("7,7\n", TestHarness.Run(code, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void NestedNamespaceFunction_ReadsOuterAndInnerVars(ExecutionMode mode)
+    {
+        var code = @"
+            namespace Out {
+                const a = 1;
+                export namespace In {
+                    const b = 2;
+                    export function g() { return a + b; }
+                    export const r = g();
+                }
+            }
+            console.log(Out.In.r);
+        ";
+        Assert.Equal("3\n", TestHarness.Run(code, mode));
+    }
+
+    #endregion
+
     #region Basic Namespace Features (Both Modes)
 
     [Theory]

--- a/SharpTS.Tests/SharedTests/NestedFunctionLiftingTests.cs
+++ b/SharpTS.Tests/SharedTests/NestedFunctionLiftingTests.cs
@@ -221,6 +221,65 @@ public class NestedFunctionLiftingTests
         Assert.Equal("function 1\n", TestHarness.Run(source, mode));
     }
 
+    // ── #605: function/generator declared inside a MODULE-LEVEL block/loop/if ────────────────────
+    // No enclosing function exists, so these are bound by neither the top-level definition pass nor
+    // the inner-function pass and previously threw "Undefined variable" in compiled mode. The lifter
+    // now relocates the non-capturing ones to the module top level.
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void PlainFunction_InTopLevelBlock_IsCallable(ExecutionMode mode)
+    {
+        var source = """
+            { function f() { return 1; } console.log(f()); }
+            """;
+        Assert.Equal("1\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Generator_InTopLevelBlock_IsCallable(ExecutionMode mode)
+    {
+        var source = """
+            { function* g() { yield 1; yield 2; } console.log([...g()].join(",")); }
+            """;
+        Assert.Equal("1,2\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void BlockFunction_ReferencingModuleBinding_IsCallable(ExecutionMode mode)
+    {
+        // A block function that references a module-level binding (not a block/loop-scoped one) is
+        // safe to lift — the reference still resolves after relocation. Guards the capture-guard from
+        // over-rejecting safe references (it must only block enclosing block/loop captures).
+        var source = """
+            const base = 10;
+            { function addBase(n: number): number { return n + base; } console.log(addBase(5)); }
+            """;
+        Assert.Equal("15\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void RecursiveBlockFunction_IsCallable(ExecutionMode mode)
+    {
+        var source = """
+            { function fact(n: number): number { return n <= 1 ? 1 : n * fact(n - 1); } console.log(fact(5)); }
+            """;
+        Assert.Equal("120\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Function_InTopLevelIfBlock_IsCallable(ExecutionMode mode)
+    {
+        var source = """
+            if (true) { function inIf(): string { return "yes"; } console.log(inIf()); }
+            """;
+        Assert.Equal("yes\n", TestHarness.Run(source, mode));
+    }
+
     // ── Documented limitation #583 §1: capturing nested function-likes are NOT lifted ────────────
     // The interpreter handles them via real closures; the compiler still cannot lower a nested
     // state-machine function that captures an enclosing local (it stays nested and fails to compile,


### PR DESCRIPTION
## Summary

Fixes four related **compiled-mode** scoping/resolution bugs. In every case the tree-walking interpreter was already correct and only the IL-compiled output diverged. The variable-**read** path was already correct in each; this PR fixes the corresponding emit/resolution paths.

| Issue | Symptom (compiled) | Fix |
|------|--------------------|-----|
| #607 | a call `h()` resolves to a module top-level function even when a parameter / local / nested-function `h` shadows it | call dispatch defers to the value/inner-function path when the resolver has a closer binding |
| #562 | a function-local `let`/`const` whose name collides with a module var resolves to `null` (and clobbers the module var) | gate module-level storage on a new `IsModuleTopLevel` context flag |
| #567 | a function in a `namespace` can't reference a namespace-level `var`/`let`/`const` (`ReferenceError`) | back each namespace var with a static field surfaced to member function bodies |
| #605 | a `function`/`function*` in a module-level block/loop is unbound (`ReferenceError`) | lift the non-capturing ones to module scope |

## Details

**#607** — the direct-call dispatch (`ExpressionEmitterBase.CallHelpers.cs`) consulted `Ctx.Functions` before the local resolver, so `h()` hit the top-level `h` even when a parameter, `const`/`let`, or nested `function` of the same name was in scope. It now defers to the value-call / inner-function path when `Resolver.HasVariable` reports a closer binding. A top-level function merely *reached through a closure capture* (e.g. the `path` stdlib's `posix.join` method calling module helper `posixJoin(parts: string[])`) is explicitly excluded, so its typed-parameter direct call is preserved.

**#562** — `EmitVarDeclaration` treated a function-body declaration like a module-level one whenever the scope depth was 1 (true for both module top level *and* a function body), routing a name that collides with a module binding into the module's static field / entry-point display class. The closure then read an unwritten captured slot (`null`) and the module variable was overwritten. A new `CompilationContext.IsModuleTopLevel` flag (set only for the entry-point and module/script-init contexts) gates that storage, so a function-body declaration always creates its own local / display-class slot.

**#567** — namespace-level variables were stored only as runtime members of the namespace object, invisible to the member function bodies (emitted as separate static methods). Each namespace variable now also gets a static backing field, mirrored at declaration and surfaced to member function bodies through the standard top-level-static-var resolver path. Nested namespaces resolve both inner and outer namespace vars.

**#605** — a declaration directly inside a module-level block/loop/`if` was collected by neither the top-level definition pass nor the inner-function pass. `NestedFunctionLifter` now lifts the non-capturing ones to the module top level. A declaration that captures an enclosing **block/loop** binding (e.g. a generator in a `for` over the loop variable) is declined by a capture guard — a clean failure, never a miscompile.

## Follow-ups filed

- #622 — compiled closure over a module-block binding (the capturing half of #605).
- #623 — namespace exported mutable var not reflected in external `N.x` (pre-existing, affects both modes).

## Testing

- Full suite: **12241 passed, 0 failed**.
- New/updated tests: `FunctionShadowingCallTests` (#607), `LexicalForwardReferenceTests` (#562/#567 promoted to both modes), `NamespaceTests` (#567 variants), `NestedFunctionLiftingTests` (#605 cases + capture guardrail).
- Test262 (21 pass / 0 fail) and TypeScriptConformance (31 pass / 0 fail) baselines unchanged.
