### PR TITLE
Fix #614: emit await args once before the string-method dispatch split

### DIFF
--- a/Compilation/ExpressionEmitterBase.CallHelpers.cs
+++ b/Compilation/ExpressionEmitterBase.CallHelpers.cs
@@ -339,8 +339,9 @@ public abstract partial class ExpressionEmitterBase
     {
         EmitExpression(obj);
         EnsureBoxed();
-        var objLocal = IL.DeclareLocal(Types.Object);
-        IL.Emit(OpCodes.Stloc, objLocal);
+        // SpillStoreObject (not a plain local) so the receiver survives a MoveNext re-entry when a
+        // later argument suspends (#400/#614); in the synchronous emitter it is just a plain local.
+        var objLocal = _helpers.SpillStoreObject();
 
         // Fast path: if receiver is a string at runtime, dispatch to the string-strategy path
         // directly. GetProperty(str, methodName) returns null for everything except "length",
@@ -349,17 +350,25 @@ public abstract partial class ExpressionEmitterBase
         // receiver is a string.
         if (IsRuntimeDispatchableStringMethod(methodName))
         {
+            // The string fast path and the generic GetProperty path both contain the arguments and
+            // are mutually exclusive at runtime. When an argument can suspend, spill the arguments
+            // once here so each `await`/`yield` is emitted exactly once — emitting them in both
+            // branches would emit the suspension twice and desync the await-state counter (#614).
+            LocalBuilder[]? argLocals = AnyContainsSuspension(arguments)
+                ? arguments.Select(SpillBoxed).ToArray()
+                : null;
+
             var notStringLabel = IL.DefineLabel();
             var endLabel = IL.DefineLabel();
             IL.Emit(OpCodes.Ldloc, objLocal);
             IL.Emit(OpCodes.Isinst, Types.String);
             IL.Emit(OpCodes.Brfalse, notStringLabel);
 
-            EmitRuntimeStringMethod(objLocal, methodName, arguments);
+            EmitRuntimeStringMethod(objLocal, methodName, arguments, argLocals);
             IL.Emit(OpCodes.Br, endLabel);
 
             IL.MarkLabel(notStringLabel);
-            EmitGetPropertyAndInvoke(objLocal, methodName, arguments);
+            EmitGetPropertyAndInvoke(objLocal, methodName, arguments, argLocals);
             IL.MarkLabel(endLabel);
             SetStackUnknown();
             return;
@@ -369,23 +378,53 @@ public abstract partial class ExpressionEmitterBase
         SetStackUnknown();
     }
 
-    private void EmitGetPropertyAndInvoke(LocalBuilder objLocal, string methodName, List<Expr> arguments)
+    private void EmitGetPropertyAndInvoke(LocalBuilder objLocal, string methodName, List<Expr> arguments, LocalBuilder[]? argLocals = null)
     {
-        IL.Emit(OpCodes.Ldloc, objLocal);                // receiver for Invoke
-        IL.Emit(OpCodes.Ldloc, objLocal);                // receiver for GetProperty
+        // Resolve the method first (property lookup precedes argument evaluation, per spec) and
+        // store it, so the receiver and resolved fn aren't left on the IL stack while arguments are
+        // evaluated — a later argument can suspend (await/yield), which requires a clear stack.
+        IL.Emit(OpCodes.Ldloc, objLocal);
         IL.Emit(OpCodes.Ldstr, methodName);
         IL.Emit(OpCodes.Call, Ctx.Runtime!.GetProperty); // → fn
+        var fnLocal = _helpers.SpillStoreObject();
+
+        // When the caller hasn't pre-spilled the arguments and one can suspend, spill them now
+        // (after the lookup) so the suspension happens with a clear stack (#614/#413).
+        argLocals ??= AnyContainsSuspension(arguments)
+            ? arguments.Select(SpillBoxed).ToArray()
+            : null;
+
+        IL.Emit(OpCodes.Ldloc, objLocal);                // receiver for InvokeMethodValue
+        IL.Emit(OpCodes.Ldloc, fnLocal);                 // resolved fn
+        EmitBoxedArgsArray(arguments, argLocals);
+        IL.Emit(OpCodes.Call, Ctx.Runtime!.InvokeMethodValue);
+    }
+
+    /// <summary>
+    /// Builds an <c>object[]</c> of the boxed call arguments on the stack. Stack: [] -&gt; [object[]].
+    /// When <paramref name="argLocals"/> is non-null each element is loaded from those pre-spilled,
+    /// already-boxed locals (await-safe: the arguments were evaluated and spilled by the caller, so
+    /// no suspension is re-emitted here); otherwise each argument expression is emitted inline.
+    /// </summary>
+    private void EmitBoxedArgsArray(List<Expr> arguments, LocalBuilder[]? argLocals)
+    {
         IL.Emit(OpCodes.Ldc_I4, arguments.Count);
         IL.Emit(OpCodes.Newarr, Types.Object);
         for (int i = 0; i < arguments.Count; i++)
         {
             IL.Emit(OpCodes.Dup);
             IL.Emit(OpCodes.Ldc_I4, i);
-            EmitExpression(arguments[i]);
-            EnsureBoxed();
+            if (argLocals != null)
+            {
+                IL.Emit(OpCodes.Ldloc, argLocals[i]);
+            }
+            else
+            {
+                EmitExpression(arguments[i]);
+                EnsureBoxed();
+            }
             IL.Emit(OpCodes.Stelem_Ref);
         }
-        IL.Emit(OpCodes.Call, Ctx.Runtime!.InvokeMethodValue);
     }
 
     private static bool IsRuntimeDispatchableStringMethod(string methodName) => methodName is
@@ -393,7 +432,12 @@ public abstract partial class ExpressionEmitterBase
         or "trim" or "trimStart" or "trimEnd" or "startsWith" or "endsWith"
         or "repeat" or "padStart" or "padEnd" or "at";
 
-    private void EmitRuntimeStringMethod(LocalBuilder objLocal, string methodName, List<Expr> arguments)
+    /// <param name="argLocals">
+    /// Pre-spilled, already-boxed argument locals to read from instead of re-emitting the argument
+    /// expressions. The caller passes these when an argument can suspend so the <c>await</c>/<c>yield</c>
+    /// is emitted exactly once (#614); null means emit the arguments inline.
+    /// </param>
+    private void EmitRuntimeStringMethod(LocalBuilder objLocal, string methodName, List<Expr> arguments, LocalBuilder[]? argLocals = null)
     {
         // Stack entry: (nothing — objLocal is the receiver). Push the string, then args, then call.
         IL.Emit(OpCodes.Ldloc, objLocal);
@@ -403,30 +447,12 @@ public abstract partial class ExpressionEmitterBase
         {
             case "substring":
                 // StringSubstring takes (string, object[]): pack args into object[].
-                IL.Emit(OpCodes.Ldc_I4, arguments.Count);
-                IL.Emit(OpCodes.Newarr, Types.Object);
-                for (int i = 0; i < arguments.Count; i++)
-                {
-                    IL.Emit(OpCodes.Dup);
-                    IL.Emit(OpCodes.Ldc_I4, i);
-                    EmitExpression(arguments[i]);
-                    EnsureBoxed();
-                    IL.Emit(OpCodes.Stelem_Ref);
-                }
+                EmitBoxedArgsArray(arguments, argLocals);
                 IL.Emit(OpCodes.Call, Ctx.Runtime!.StringSubstring);
                 break;
 
             case "substr":
-                IL.Emit(OpCodes.Ldc_I4, arguments.Count);
-                IL.Emit(OpCodes.Newarr, Types.Object);
-                for (int i = 0; i < arguments.Count; i++)
-                {
-                    IL.Emit(OpCodes.Dup);
-                    IL.Emit(OpCodes.Ldc_I4, i);
-                    EmitExpression(arguments[i]);
-                    EnsureBoxed();
-                    IL.Emit(OpCodes.Stelem_Ref);
-                }
+                EmitBoxedArgsArray(arguments, argLocals);
                 IL.Emit(OpCodes.Call, Ctx.Runtime!.StringSubstr);
                 break;
 
@@ -446,7 +472,7 @@ public abstract partial class ExpressionEmitterBase
                 // Other known methods: fall back to GetProperty+Invoke; the caller still
                 // returns a value, just not via the direct runtime method.
                 IL.Emit(OpCodes.Pop); // pop the cast-to-string receiver we pushed
-                EmitGetPropertyAndInvoke(objLocal, methodName, arguments);
+                EmitGetPropertyAndInvoke(objLocal, methodName, arguments, argLocals);
                 break;
         }
     }
@@ -1071,15 +1097,28 @@ public abstract partial class ExpressionEmitterBase
         IL.Emit(OpCodes.Isinst, Ctx.Runtime!.UndefinedType);
         IL.Emit(OpCodes.Brtrue, nullishLabel);
 
+        // Pre-spilled, already-boxed argument locals shared by the string fast path and the generic
+        // path below. Stays null unless an argument can suspend.
+        LocalBuilder[]? argLocals = null;
+
         // GetProperty can't resolve most string prototype methods (see
         // EmitDynamicMethodCallPreservingThis) — keep its string fast path.
         if (IsRuntimeDispatchableStringMethod(g.Name.Lexeme))
         {
+            // The string fast path and the generic path below both contain the arguments and are
+            // mutually exclusive at runtime. When an argument can suspend, spill the arguments once
+            // here — before the string-vs-generic split — so each await/yield is emitted exactly
+            // once; emitting them in both branches would desync the await-state counter (#614). The
+            // spill is reached only on the non-nullish receiver path, so the arguments stay
+            // unevaluated when the chain short-circuits.
+            if (awaitSafe)
+                argLocals = c.Arguments.Select(SpillBoxed).ToArray();
+
             var notStringLabel = IL.DefineLabel();
             IL.Emit(OpCodes.Ldloc, recvLocal);
             IL.Emit(OpCodes.Isinst, Types.String);
             IL.Emit(OpCodes.Brfalse, notStringLabel);
-            EmitRuntimeStringMethod(recvLocal, g.Name.Lexeme, c.Arguments);
+            EmitRuntimeStringMethod(recvLocal, g.Name.Lexeme, c.Arguments, argLocals);
             IL.Emit(OpCodes.Br, endLabel);
             IL.MarkLabel(notStringLabel);
         }
@@ -1096,41 +1135,16 @@ public abstract partial class ExpressionEmitterBase
         IL.Emit(OpCodes.Isinst, Ctx.Runtime!.UndefinedType);
         IL.Emit(OpCodes.Brtrue, nullishLabel);
 
-        // InvokeMethodValue(recv, fn, args) — args evaluated only on the
-        // non-nullish path, per spec.
-        if (awaitSafe)
-        {
-            // Spill args first so an await in a later arg doesn't suspend with the receiver, fn,
-            // and the partially-built array all stacked (invalid IL). Reached only on the
-            // non-nullish path, so args stay unevaluated when the chain short-circuits.
-            var argLocals = c.Arguments.Select(SpillBoxed).ToList();
-            IL.Emit(OpCodes.Ldloc, recvLocal);
-            IL.Emit(OpCodes.Ldloc, fnLocal);
-            IL.Emit(OpCodes.Ldc_I4, c.Arguments.Count);
-            IL.Emit(OpCodes.Newarr, Types.Object);
-            for (int i = 0; i < c.Arguments.Count; i++)
-            {
-                IL.Emit(OpCodes.Dup);
-                IL.Emit(OpCodes.Ldc_I4, i);
-                IL.Emit(OpCodes.Ldloc, argLocals[i]);
-                IL.Emit(OpCodes.Stelem_Ref);
-            }
-        }
-        else
-        {
-            IL.Emit(OpCodes.Ldloc, recvLocal);
-            IL.Emit(OpCodes.Ldloc, fnLocal);
-            IL.Emit(OpCodes.Ldc_I4, c.Arguments.Count);
-            IL.Emit(OpCodes.Newarr, Types.Object);
-            for (int i = 0; i < c.Arguments.Count; i++)
-            {
-                IL.Emit(OpCodes.Dup);
-                IL.Emit(OpCodes.Ldc_I4, i);
-                EmitExpression(c.Arguments[i]);
-                EnsureBoxed();
-                IL.Emit(OpCodes.Stelem_Ref);
-            }
-        }
+        // InvokeMethodValue(recv, fn, args) — args evaluated only on the non-nullish path, per spec.
+        // For a non-string method (or when the string path didn't pre-spill) spill the args here,
+        // after the method lookup, so an await in a later arg doesn't suspend with the receiver, fn,
+        // and the partially-built array all stacked (#439); this preserves the lookup-before-args
+        // evaluation order. String methods reuse the locals pre-spilled above.
+        if (awaitSafe && argLocals == null)
+            argLocals = c.Arguments.Select(SpillBoxed).ToArray();
+        IL.Emit(OpCodes.Ldloc, recvLocal);
+        IL.Emit(OpCodes.Ldloc, fnLocal);
+        EmitBoxedArgsArray(c.Arguments, argLocals);
         IL.Emit(OpCodes.Call, Ctx.Runtime!.InvokeMethodValue);
         IL.Emit(OpCodes.Br, endLabel);
 

--- a/SharpTS.Tests/CompilerTests/ILVerificationTests.cs
+++ b/SharpTS.Tests/CompilerTests/ILVerificationTests.cs
@@ -437,6 +437,32 @@ public class ILVerificationTests
     }
 
     [Fact]
+    public void AwaitInDispatchableStringMethodArg_PassesILVerification()
+    {
+        // #614: an await in an argument of a call to a runtime-dispatchable string method
+        // (substring/substr/charAt/…) on an any-typed receiver. The string fast path and the generic
+        // GetProperty path are mutually exclusive at runtime but both contained the arguments at emit
+        // time, so each await was emitted twice — desyncing the await-state counter and crashing the
+        // compiler ("key 'N' was not present in the dictionary"). Covers the optional-chain branch
+        // (direct switch case + default fallback) and the non-optional dynamic-dispatch sibling.
+        var source = """
+            const s: any = "hello";
+            const o: any = { substring(a: number, b: number): string { return "" + a + b; } };
+            async function main() {
+                console.log(s?.substring(await new Promise<number>(r => setTimeout(() => r(1), 5)), 4));
+                console.log(s?.charAt(await new Promise<number>(r => setTimeout(() => r(1), 5))));
+                console.log(s.substring(await new Promise<number>(r => setTimeout(() => r(1), 5)), 4));
+                console.log(o?.substring(await new Promise<number>(r => setTimeout(() => r(2), 5)), 7));
+            }
+            main();
+            """;
+
+        var errors = TestHarness.CompileAndVerifyOnly(source);
+
+        Assert.Empty(errors);
+    }
+
+    [Fact]
     public void AsyncArrowAwaitOfCall_PassesILVerification()
     {
         // #441: `await <functionCall>` inside an async arrow emitted invalid IL (StackUnexpected in

--- a/SharpTS.Tests/SharedTests/AwaitDeferredSpillTests.cs
+++ b/SharpTS.Tests/SharedTests/AwaitDeferredSpillTests.cs
@@ -304,4 +304,62 @@ public class AwaitDeferredSpillTests
             """const o: any = { go(a: string, b: string): string { return a + b; } }; console.log(o?.go("A", await defer("B", 5)));""",
             mode));
     }
+
+    // #614: an await in an argument of a call to a *runtime-dispatchable string method*
+    // (substring/substr/charAt/…) on an any-typed receiver. The string fast path
+    // (EmitRuntimeStringMethod) and the generic GetProperty path are mutually exclusive at runtime
+    // but both contained the arguments at emit time, so each await was emitted twice — desyncing the
+    // await-state counter and crashing the compiler with "The given key 'N' was not present in the
+    // dictionary." The arguments are now spilled once before the string-vs-generic split.
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void OptionalChainStringMethod_DeferredAwaitArg(ExecutionMode mode)
+    {
+        // The exact #614 repro shape: substring (a direct runtime string method) on `any?.`.
+        Assert.Equal("ell\n", Run("""const s: any = "hello"; console.log(s?.substring(await defer(1, 5), 4));""", mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void OptionalChainStringMethod_TwoDeferredAwaits(ExecutionMode mode)
+    {
+        Assert.Equal("hel\n", Run("""const s: any = "hello"; console.log(s?.substring(await defer(0, 5), await defer(3, 5)));""", mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void OptionalChainStringMethod_DefaultCasePath_DeferredAwaitArg(ExecutionMode mode)
+    {
+        // charAt is dispatchable but not one of the direct switch cases, so it routes through the
+        // default → GetProperty+Invoke fallback, which must also read the pre-spilled args.
+        Assert.Equal("e\n", Run("""const s: any = "hello"; console.log(s?.charAt(await defer(1, 5)));""", mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void DynamicDispatchStringMethod_DeferredAwaitArg(ExecutionMode mode)
+    {
+        // Non-optional dynamic dispatch (EmitDynamicMethodCallPreservingThis) has the same
+        // dual-emission shape and was the latent sibling gap called out in #614.
+        Assert.Equal("ell\n", Run("""const s: any = "hello"; console.log(s.substring(await defer(1, 5), 4));""", mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void OptionalChainStringMethod_NonStringReceiverWithOwnMethod_DeferredAwaitArg(ExecutionMode mode)
+    {
+        // Receiver is not a string at runtime, so the generic (non-string) branch runs, reading the
+        // same pre-spilled args — the user's own `substring` is invoked, not the string built-in.
+        Assert.Equal("OBJ:2,7\n", Run(
+            """const o: any = { substring(a: number, b: number): string { return "OBJ:" + a + "," + b; } }; console.log(o?.substring(await defer(2, 5), 7));""",
+            mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void OptionalChainStringMethod_NullishReceiverShortCircuits(ExecutionMode mode)
+    {
+        Assert.Equal("undefined\n", Run("""const n: any = null; console.log(n?.substring(await defer(1, 5), 4));""", mode));
+    }
 }


### PR DESCRIPTION
## Summary

Fixes **#614**: in compiled mode, an `await` (or `yield`) in an argument of a call to a **runtime-dispatchable string method** (`substring`, `substr`, `charAt`, …) on an `any`-typed receiver crashed the **compiler** with `Error: The given key '1' was not present in the dictionary.` The interpreter was always correct.

### Root cause

These calls emit two mutually-exclusive paths selected at runtime by `isinst string`: the direct string fast path (`EmitRuntimeStringMethod`) and the generic `GetProperty`+`InvokeMethodValue` path. **Both contained the call arguments at emit time**, so a single AST `await` was emitted **twice**. `EmitAwait` assigns state numbers with a sequential counter (`_currentAwaitState++`) and looks up `_stateLabels[stateNumber]`; the analyzer registers exactly one label per AST await. The second emission advanced the counter to a state that was never registered → `KeyNotFoundException` at compile time.

This is the path #439’s fix did not cover (the issue is the *dispatchable-string* fast path specifically); `s?.slice(await …)` already worked because `slice` isn’t dispatchable and only the generic path emits its args.

### Fix

Spill each argument to an await-safe local **exactly once, before the string-vs-generic branch**, and have both branches read those locals. `SpillStoreObject`-registered spills survive the `MoveNext` re-entry (#400), and emitting the args once keeps the analyzer/emitter await counters in sync.

- **`TryEmitOptionalChainMethodCall`** — for dispatchable-string methods, pre-spill before the branch. Non-string methods keep the #439 spill-after-lookup order (**byte-identical IL**), so evaluation order is unchanged on that path.
- **`EmitDynamicMethodCallPreservingThis`** (non-optional dynamic dispatch, e.g. CJS-imported receivers) — same dual-emission gap, fixed the same way; the receiver now spills via `SpillStoreObject` so it survives an await in a later arg. This was the latent sibling gap noted in #614.
- **`EmitGetPropertyAndInvoke`** — made await-safe on its own: resolves the method to a local first (lookup precedes arg evaluation, per spec), then spills args off a clear stack.
- New **`EmitBoxedArgsArray`** helper centralises the boxed `object[]` build (inline or from pre-spilled locals), replacing five copies of the loop.

### Tests

- `AwaitDeferredSpillTests` — behavior in **both** modes: optional-chain `substring` (the repro), two awaits, the `charAt` default-case fallback, non-optional dynamic dispatch, a non-string receiver with its own `substring`, and nullish-receiver short-circuit.
- `ILVerificationTests` — verify-only guard covering the optional-chain (direct + default) and dynamic-dispatch shapes.
- Manually verified parity (interpreter == compiled, `--verify` clean) for async functions, async arrows, and **generators** (`yield` in the arg).

**Full suite: 12376 passed, 0 failed.**

## Note on #439 / #441

This branch was opened to also complete **#439** and **#441**, but both are **already fixed in `main`** by the merged PR #616 (they simply never auto-closed). Verified each repro: interpreter, `--compile --verify`, and the compiled run all pass. Closing those issues separately with evidence; no code here is needed for them.

## Follow-up filed

- **#625** — pre-existing, unrelated: an async **arrow** that *writes* to a captured variable fails IL verify (`StackUnexpected`). Reads and non-async arrows are fine. Discovered while probing evaluation order; independent of this path.

Closes #614.