### PR TITLE
Fix compiled generator null/undefined throw into flag-based try/catch (#619) and async-gen catch-param hoisting (#569)

### DIFF
--- a/Compilation/AsyncGeneratorMoveNextEmitter.Statements.TryCatch.cs
+++ b/Compilation/AsyncGeneratorMoveNextEmitter.Statements.TryCatch.cs
@@ -384,10 +384,10 @@ public partial class AsyncGeneratorMoveNextEmitter
 
             if (t.CatchParam != null)
             {
-                var exLocal = _il.DeclareLocal(typeof(object));
-                _ctx!.Locals.RegisterLocal(t.CatchParam.Lexeme, exLocal);
-                _il.Emit(OpCodes.Call, _ctx.Runtime!.WrapException);
-                _il.Emit(OpCodes.Stloc, exLocal);
+                // Stack has the .NET exception; wrap to the TS value and bind to the catch param,
+                // honouring a hoisted field if the param is read across a suspension (#569).
+                _il.Emit(OpCodes.Call, _ctx!.Runtime!.WrapException);
+                StoreCaughtExceptionToParam(t.CatchParam.Lexeme);
             }
             else
             {
@@ -408,6 +408,26 @@ public partial class AsyncGeneratorMoveNextEmitter
         _il.EndExceptionBlock();
         _ctx!.ExceptionBlockDepth--;
         _protectedRegionDepth--;
+    }
+
+    /// <summary>
+    /// Binds the caught exception value (on the IL stack) to the catch parameter, honouring whether
+    /// the parameter was hoisted to a state-machine field (because it is read across a yield/await in
+    /// the catch body) or lives in an IL local. Storing to a fresh local unconditionally — the
+    /// previous behaviour — lost the value whenever the catch parameter was hoisted, because reads
+    /// resolve the field first (#569, async analog of GeneratorMoveNextEmitter.StoreCaughtExceptionToParam).
+    /// </summary>
+    private void StoreCaughtExceptionToParam(string name)
+    {
+        if (GetHoistedVariableField(name) == null)
+        {
+            // Not hoisted: register a local so the catch body's reads resolve to it.
+            var exLocal = _il.DeclareLocal(typeof(object));
+            _ctx!.Locals.RegisterLocal(name, exLocal);
+        }
+
+        // Resolver stores to the hoisted field if present, otherwise the registered local.
+        Resolver.TryStoreVariable(name);
     }
 
     /// <summary>
@@ -463,13 +483,13 @@ public partial class AsyncGeneratorMoveNextEmitter
             _il.Emit(OpCodes.Ldloc, caughtExceptionLocal);
             _il.Emit(OpCodes.Brfalse, skipCatchLabel);
 
-            // Store exception in catch param if needed
+            // Bind the captured value to the catch param, honouring a hoisted field when the param is
+            // read across a suspension in the catch body (#569). Storing to a fresh local
+            // unconditionally lost the value whenever the param was hoisted (reads resolve the field).
             if (t.CatchParam != null)
             {
-                var exLocal = _il.DeclareLocal(typeof(object));
-                _ctx!.Locals.RegisterLocal(t.CatchParam.Lexeme, exLocal);
                 _il.Emit(OpCodes.Ldloc, caughtExceptionLocal);
-                _il.Emit(OpCodes.Stloc, exLocal);
+                StoreCaughtExceptionToParam(t.CatchParam.Lexeme);
             }
 
             // Catch handles it; clear the flag so the post-finally rethrow below is skipped — and so a

--- a/Compilation/GeneratorMoveNextEmitter.Statements.TryCatch.cs
+++ b/Compilation/GeneratorMoveNextEmitter.Statements.TryCatch.cs
@@ -70,12 +70,14 @@ public partial class GeneratorMoveNextEmitter
     private bool _inHandlerBody;
 
     // The innermost flag-based try whose *body* is currently being emitted: its catch/finally entry
-    // (afterTryBodyLabel) and the local capturing a try-body exception. An external throw() injected
-    // at a yield in this body behaves as if the body threw there — it stores the error into this
-    // local and branches to the cleanup so the catch/finally run (#526). Saved/restored around the
-    // try-body emission, so it is null (or the enclosing try's) while emitting a catch/finally body,
-    // where `_inHandlerBody` instead routes an injected throw through the enclosing finally(s).
-    private (Label AfterTryBody, LocalBuilder CaughtException)? _tryBodyContext;
+    // (afterTryBodyLabel), the local capturing a try-body exception, and the boolean flag recording
+    // whether one was captured. An external throw() injected at a yield in this body behaves as if the
+    // body threw there — it stores the error into the local, sets the flag, and branches to the cleanup
+    // so the catch/finally run (#526). The flag (not the value's nullness) gates the catch so an
+    // injected throw(null)/throw(undefined) still engages it (#619). Saved/restored around the try-body
+    // emission, so it is null (or the enclosing try's) while emitting a catch/finally body, where
+    // `_inHandlerBody` instead routes an injected throw through the enclosing finally(s).
+    private (Label AfterTryBody, LocalBuilder CaughtException, LocalBuilder ExceptionPresent)? _tryBodyContext;
 
     // `<>pendingExit` (int): the code of an in-flight non-local exit, or 0 when none. A finally that
     // yields suspends MoveNext mid-routing, so this must be a field (a local would reset on re-entry).
@@ -115,6 +117,16 @@ public partial class GeneratorMoveNextEmitter
     private FieldBuilder DefineCaughtExceptionField() =>
         _builder.StateMachineType.DefineField(
             $"<>caughtException{_caughtExceptionFieldCounter++}", typeof(object), FieldAttributes.Private);
+
+    // Companion to `<>caughtException{n}`: the exception-present flag (#619) that must likewise survive
+    // a *yielding* finally in a catch-less try/finally. Gating the catch/rethrow on this boolean rather
+    // than the captured value's nullness is what lets a thrown null/undefined be caught (a null CLR ref
+    // would otherwise read as "no exception"). Own counter so each construct gets a distinct field.
+    private int _exceptionPresentFieldCounter;
+
+    private FieldBuilder DefineExceptionPresentField() =>
+        _builder.StateMachineType.DefineField(
+            $"<>exceptionPresent{_exceptionPresentFieldCounter++}", typeof(bool), FieldAttributes.Private);
 
     // ---- Loop-scope methods (override the base stack to use `_exitScopes`) -----------------------
 
@@ -454,9 +466,12 @@ public partial class GeneratorMoveNextEmitter
         {
             // In a try body: capture exactly like a try-body exception so the catch/finally at
             // afterTryBodyLabel handle it. A catch-less yielding finally persists this local to a
-            // field before suspending, so it survives (#599).
+            // field before suspending, so it survives (#599). Set the present flag (not the value's
+            // nullness) so an injected throw(null)/throw(undefined) still engages the catch (#619).
             loadValue();
             _il.Emit(OpCodes.Stloc, tryBody.CaughtException);
+            _il.Emit(OpCodes.Ldc_I4_1);
+            _il.Emit(OpCodes.Stloc, tryBody.ExceptionPresent);
             _il.Emit(OpCodes.Br, tryBody.AfterTryBody);
             return;
         }
@@ -588,16 +603,22 @@ public partial class GeneratorMoveNextEmitter
     private void EmitTryCatchWithYields(Stmt.TryCatch t)
     {
         var caughtExceptionLocal = _il.DeclareLocal(typeof(object));
+        // Whether the try body raised an exception, tracked separately from caughtExceptionLocal's
+        // nullness: a thrown null/undefined captures as a null CLR reference, which a value-nullness
+        // gate misreads as "no exception" — skipping the catch and dropping the post-finally rethrow
+        // (#619). This flag records presence regardless of the captured value.
+        var exceptionPresentLocal = _il.DeclareLocal(typeof(bool));
         var afterTryBodyLabel = _il.DefineLabel();
 
         // #599: in a try/finally with no catch whose finally can yield, the captured try-body
         // exception must survive the finally's suspension. The IL local resets on MoveNext re-entry,
         // so persist it to a dedicated field before the finally and read that field in the
-        // post-finally rethrow. Allocated only for that shape; null means "use the local".
-        FieldBuilder? caughtExceptionField =
-            t.CatchBlock == null && t.FinallyBlock != null && ContainsYield(t.FinallyBlock)
-                ? DefineCaughtExceptionField()
-                : null;
+        // post-finally rethrow. Allocated only for that shape; null means "use the local". The
+        // present flag needs the same persistence (read by the rethrow gate after the finally, #619).
+        bool persistAcrossYieldingFinally =
+            t.CatchBlock == null && t.FinallyBlock != null && ContainsYield(t.FinallyBlock);
+        FieldBuilder? caughtExceptionField = persistAcrossYieldingFinally ? DefineCaughtExceptionField() : null;
+        FieldBuilder? exceptionPresentField = persistAcrossYieldingFinally ? DefineExceptionPresentField() : null;
 
         void EmitLoadCaughtException()
         {
@@ -612,9 +633,24 @@ public partial class GeneratorMoveNextEmitter
             }
         }
 
+        void EmitLoadExceptionPresent()
+        {
+            if (exceptionPresentField != null)
+            {
+                _il.Emit(OpCodes.Ldarg_0);
+                _il.Emit(OpCodes.Ldfld, exceptionPresentField);
+            }
+            else
+            {
+                _il.Emit(OpCodes.Ldloc, exceptionPresentLocal);
+            }
+        }
+
         // No exception captured yet.
         _il.Emit(OpCodes.Ldnull);
         _il.Emit(OpCodes.Stloc, caughtExceptionLocal);
+        _il.Emit(OpCodes.Ldc_I4_0);
+        _il.Emit(OpCodes.Stloc, exceptionPresentLocal);
 
         // A non-local exit inside this try (or its catch) must run the finally before transferring
         // control, so register a finally scope whose cleanup is the catch/finally entry. On those exit
@@ -633,8 +669,8 @@ public partial class GeneratorMoveNextEmitter
         bool previousInHandler = _inHandlerBody;
         var previousTryBody = _tryBodyContext;
         _inHandlerBody = false;
-        _tryBodyContext = (afterTryBodyLabel, caughtExceptionLocal);
-        EmitTryBodyWithYields(t.TryBlock, caughtExceptionLocal, afterTryBodyLabel);
+        _tryBodyContext = (afterTryBodyLabel, caughtExceptionLocal, exceptionPresentLocal);
+        EmitTryBodyWithYields(t.TryBlock, caughtExceptionLocal, exceptionPresentLocal, afterTryBodyLabel);
         _tryBodyContext = previousTryBody;
         _inHandlerBody = previousInHandler;
 
@@ -644,8 +680,10 @@ public partial class GeneratorMoveNextEmitter
         // a non-local exit (including a throw) from the catch body runs this finally too.
         if (t.CatchBlock != null)
         {
+            // Gate on the present flag, not the value's nullness, so a caught null/undefined enters the
+            // catch (#619). In the with-catch shape no field is allocated, so the local is authoritative.
             var skipCatchLabel = _il.DefineLabel();
-            _il.Emit(OpCodes.Ldloc, caughtExceptionLocal);
+            _il.Emit(OpCodes.Ldloc, exceptionPresentLocal);
             _il.Emit(OpCodes.Brfalse, skipCatchLabel);
 
             if (t.CatchParam != null)
@@ -654,10 +692,11 @@ public partial class GeneratorMoveNextEmitter
                 StoreCaughtExceptionToParam(t.CatchParam.Lexeme);
             }
 
-            // Catch handles it; clear the flag so the post-finally rethrow below is skipped — and so a
-            // routed exit re-entering afterTryBodyLabel skips the catch rather than re-running it.
-            _il.Emit(OpCodes.Ldnull);
-            _il.Emit(OpCodes.Stloc, caughtExceptionLocal);
+            // Catch handles it; clear the present flag so the post-finally rethrow below is skipped —
+            // and so a routed exit re-entering afterTryBodyLabel skips the catch rather than re-running
+            // it. The flag (not the value) is the gate now, so clearing it is what matters (#619).
+            _il.Emit(OpCodes.Ldc_I4_0);
+            _il.Emit(OpCodes.Stloc, exceptionPresentLocal);
 
             _inHandlerBody = true;
             foreach (var stmt in t.CatchBlock)
@@ -681,6 +720,12 @@ public partial class GeneratorMoveNextEmitter
                 _il.Emit(OpCodes.Ldarg_0);
                 _il.Emit(OpCodes.Ldloc, caughtExceptionLocal);
                 _il.Emit(OpCodes.Stfld, caughtExceptionField);
+
+                // Persist the present flag alongside the value so the post-finally rethrow gate reads a
+                // live flag after a yielding finally (#619, same survival reason as the value, #599).
+                _il.Emit(OpCodes.Ldarg_0);
+                _il.Emit(OpCodes.Ldloc, exceptionPresentLocal);
+                _il.Emit(OpCodes.Stfld, exceptionPresentField!);
             }
 
             _inHandlerBody = true;
@@ -696,7 +741,7 @@ public partial class GeneratorMoveNextEmitter
         if (t.CatchBlock == null)
         {
             var noExceptionLabel = _il.DefineLabel();
-            EmitLoadCaughtException();
+            EmitLoadExceptionPresent();
             _il.Emit(OpCodes.Brfalse, noExceptionLabel);
 
             // Mark the generator done before the exception leaves MoveNext.
@@ -715,7 +760,7 @@ public partial class GeneratorMoveNextEmitter
     /// Walks the try body, wrapping runs of plain statements in mini IL try/catch blocks while
     /// emitting suspension points and non-local exits (return/break/continue) at the top level.
     /// </summary>
-    private void EmitTryBodyWithYields(List<Stmt> tryBody, LocalBuilder caughtExceptionLocal, Label afterTryLabel)
+    private void EmitTryBodyWithYields(List<Stmt> tryBody, LocalBuilder caughtExceptionLocal, LocalBuilder exceptionPresentLocal, Label afterTryLabel)
     {
         List<Stmt> syncSegment = [];
 
@@ -726,12 +771,13 @@ public partial class GeneratorMoveNextEmitter
                 // Flush the accumulated plain statements first.
                 if (syncSegment.Count > 0)
                 {
-                    EmitSyncSegmentInTry(syncSegment, caughtExceptionLocal);
+                    EmitSyncSegmentInTry(syncSegment, caughtExceptionLocal, exceptionPresentLocal);
                     syncSegment.Clear();
                 }
 
                 // If an earlier segment threw, skip the suspension/exit and head to catch/finally.
-                _il.Emit(OpCodes.Ldloc, caughtExceptionLocal);
+                // Gate on the present flag so a thrown null/undefined still short-circuits here (#619).
+                _il.Emit(OpCodes.Ldloc, exceptionPresentLocal);
                 _il.Emit(OpCodes.Brtrue, afterTryLabel);
 
                 // Emitted at the top level: a yield's `ret`/resume label and a return's `br` are
@@ -745,18 +791,19 @@ public partial class GeneratorMoveNextEmitter
         }
 
         if (syncSegment.Count > 0)
-            EmitSyncSegmentInTry(syncSegment, caughtExceptionLocal);
+            EmitSyncSegmentInTry(syncSegment, caughtExceptionLocal, exceptionPresentLocal);
     }
 
     /// <summary>
     /// Emits a run of plain (non-suspending, non-exiting) statements inside a real IL try/catch
     /// that records any thrown exception into <paramref name="caughtExceptionLocal"/>.
     /// </summary>
-    private void EmitSyncSegmentInTry(List<Stmt> statements, LocalBuilder caughtExceptionLocal)
+    private void EmitSyncSegmentInTry(List<Stmt> statements, LocalBuilder caughtExceptionLocal, LocalBuilder exceptionPresentLocal)
     {
-        // An earlier segment may already have thrown — don't run this one.
+        // An earlier segment may already have thrown — don't run this one. Gate on the present flag so
+        // a prior thrown null/undefined still suppresses this segment (#619).
         var skipLabel = _il.DefineLabel();
-        _il.Emit(OpCodes.Ldloc, caughtExceptionLocal);
+        _il.Emit(OpCodes.Ldloc, exceptionPresentLocal);
         _il.Emit(OpCodes.Brtrue, skipLabel);
 
         // A real IL protected region is open across the segment body (see _protectedRegionDepth).
@@ -768,6 +815,10 @@ public partial class GeneratorMoveNextEmitter
         _il.BeginCatchBlock(typeof(Exception));
         _il.Emit(OpCodes.Call, _ctx!.Runtime!.WrapException);
         _il.Emit(OpCodes.Stloc, caughtExceptionLocal);
+        // Record presence with the flag, not the value: a caught null/undefined would otherwise read
+        // as "no exception" at the gates above (#619).
+        _il.Emit(OpCodes.Ldc_I4_1);
+        _il.Emit(OpCodes.Stloc, exceptionPresentLocal);
         _il.EndExceptionBlock();
         _protectedRegionDepth--;
 

--- a/Compilation/ILEmitter.Calls.MethodDispatch.cs
+++ b/Compilation/ILEmitter.Calls.MethodDispatch.cs
@@ -142,16 +142,18 @@ public partial class ILEmitter
             return;
         }
 
-        // Iterator protocol (.next() / .return()) for any/unknown receivers.
+        // Iterator protocol (.next() / .return() / .throw()) for any/unknown receivers.
         // Array .values()/.keys()/.entries() return a bare IEnumerator<object>
         // that has no JS-shaped next/value/done members, so the generic
         // GetProperty+InvokeMethodValue fallback below would resolve `next` to
         // undefined and yield null. IteratorProtocolCall synthesizes the result
         // object for enumerator receivers and falls back to the normal dynamic
-        // dispatch for everything else (generators, user iterators). Typed
-        // iterators are already handled by the type-first dispatch above, so
-        // only any/unknown receivers reach here.
-        if (methodName is "next" or "return")
+        // dispatch for everything else (generators, user iterators). Routing
+        // `throw` here too gives a bare it.throw() the same undefined default as
+        // next/return for generator receivers (#619), instead of the null the
+        // generic path would pad. Typed iterators are already handled by the
+        // type-first dispatch above, so only any/unknown receivers reach here.
+        if (methodName is "next" or "return" or "throw")
         {
             EmitExpression(methodGet.Object);
             EmitBoxIfNeeded(methodGet.Object);

--- a/Compilation/RuntimeEmitter.Objects.Invocation.cs
+++ b/Compilation/RuntimeEmitter.Objects.Invocation.cs
@@ -966,6 +966,25 @@ public partial class RuntimeEmitter
             il.Emit(OpCodes.Callvirt, runtime.GeneratorReturnMethod);
             il.Emit(OpCodes.Ret);
             il.MarkLabel(notGeneratorReturnLabel);
+
+            // throw(e): forward to $IGenerator.throw with the same undefined-default for a missing
+            // argument as next/return — a bare throw() must inject `undefined`, not the null a missing
+            // reflected argument would pad (#619, counterpart of the bare-return() fix in #526). User
+            // iterators with their own throw() keep the GetProperty path below (no $IGenerator).
+            var notGeneratorThrowLabel = il.DefineLabel();
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Ldstr, "throw");
+            il.Emit(OpCodes.Call, _types.StringOpEquality);
+            il.Emit(OpCodes.Brfalse, notGeneratorThrowLabel);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Isinst, runtime.GeneratorInterfaceType);
+            il.Emit(OpCodes.Brfalse, notGeneratorThrowLabel);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Castclass, runtime.GeneratorInterfaceType);
+            EmitArgZeroOrUndefined(il, runtime);
+            il.Emit(OpCodes.Callvirt, runtime.GeneratorThrowMethod);
+            il.Emit(OpCodes.Ret);
+            il.MarkLabel(notGeneratorThrowLabel);
         }
 
         // Resolve the JS-level member first. Generators and user-defined
@@ -1013,6 +1032,23 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ret);
 
         il.MarkLabel(synthLabel);
+
+        // throw() on a bare BCL enumerator (no throw member) → TypeError, as in JS — `fn` is the
+        // null/undefined member here, so InvokeMethodValue throws "undefined is not a function". Without
+        // this guard the next()-synth below would wrongly advance the iterator. Only reachable for an
+        // any-typed array iterator; real generators take the $IGenerator throw branch above (#619).
+        var notThrowSynthLabel = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Ldstr, "throw");
+        il.Emit(OpCodes.Call, _types.StringOpEquality);
+        il.Emit(OpCodes.Brfalse, notThrowSynthLabel);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldloc, fn);
+        il.Emit(OpCodes.Ldarg_2);
+        il.Emit(OpCodes.Call, runtime.InvokeMethodValue);
+        il.Emit(OpCodes.Ret);
+        il.MarkLabel(notThrowSynthLabel);
+
         // result = new Dictionary<string, object>()
         il.Emit(OpCodes.Newobj, _types.GetConstructor(_types.DictionaryStringObject, _types.EmptyTypes));
         il.Emit(OpCodes.Stloc, resultLocal);

--- a/SharpTS.Tests/SharedTests/AsyncGeneratorTryFinallyTests.cs
+++ b/SharpTS.Tests/SharedTests/AsyncGeneratorTryFinallyTests.cs
@@ -488,6 +488,45 @@ public class AsyncGeneratorTryFinallyTests
         Assert.Equal("v0\nfin0\nv1\nfin1\n", TestHarness.Run(source, mode));
     }
 
+    // ---- #569: an async-generator catch parameter read after a suspension in the catch body ----
+    // The parameter is hoisted to a state-machine field because it lives across the suspension, but the
+    // catch binding stored it only to a fresh IL local, so the post-resume read resolved the unset field
+    // and came back null. The binding is now field-aware (mirrors the plain-generator fix in #477/#500).
+    // CompiledOnly: the interpreter eagerly drains the async generator body, so its internal logs
+    // interleave out of Node order (a separate concern, #564).
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    public void CatchParamAfterYieldInCatchBody_PreservesValue(ExecutionMode mode)
+    {
+        // The exact #569 repro: `e` is read after the `yield 0` inside the catch.
+        var source = """
+            async function* g() {
+              try { yield 1; throw "boom"; } catch (e) { yield 0; console.log("caught " + e); }
+            }
+            async function main() { for await (const v of g()) console.log("v" + v); }
+            main();
+            """;
+
+        Assert.Equal("v1\nv0\ncaught boom\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    public void CatchParamAfterAwaitInCatchBody_PreservesValue(ExecutionMode mode)
+    {
+        // The await sibling: `e` is read after an `await` suspension inside the catch.
+        var source = """
+            async function* g() {
+              try { yield 1; throw "boom"; } catch (e) { await Promise.resolve(0); console.log("caught " + e); yield 9; }
+            }
+            async function main() { for await (const v of g()) console.log("v" + v); }
+            main();
+            """;
+
+        Assert.Equal("v1\ncaught boom\nv9\n", TestHarness.Run(source, mode));
+    }
+
     // ---- IL-verification guards (the heart of #559: emitted IL must verify) ----
 
     [Theory]
@@ -521,6 +560,9 @@ public class AsyncGeneratorTryFinallyTests
     [InlineData("async function* g() { try { return 5; } finally { yield 9; } } async function main(){ for await (const v of g()) {} } main();")]
     [InlineData("async function* g() { while (true) { try { yield 0; try { break; } catch (e) {} } finally { console.log('f'); } } } async function main(){ for await (const v of g()) {} } main();")]
     [InlineData("async function* g() { for (let i=0;i<2;i++) { try { yield i; try { continue; } catch (e) {} } finally { console.log('f'); } } } async function main(){ for await (const v of g()) {} } main();")]
+    // #569: catch parameter read after a suspension (yield / await) in the catch body — hoisted-field binding.
+    [InlineData("async function* g() { try { yield 1; throw 'boom'; } catch (e) { yield 0; console.log(e); } } async function main(){ for await (const v of g()) {} } main();")]
+    [InlineData("async function* g() { try { yield 1; throw 'boom'; } catch (e) { await Promise.resolve(0); console.log(e); } } async function main(){ for await (const v of g()) {} } main();")]
     public void AsyncGeneratorTryFinallyWithSuspension_EmitsVerifiableIL(string source)
     {
         var errors = TestHarness.CompileAndVerifyOnly(source);

--- a/SharpTS.Tests/SharedTests/GeneratorTryFinallyTests.cs
+++ b/SharpTS.Tests/SharedTests/GeneratorTryFinallyTests.cs
@@ -765,6 +765,104 @@ public class GeneratorTryFinallyTests
             TestHarness.Run(source, mode));
     }
 
+    // ---- #619: throwing null/undefined into a flag-based try/catch must engage the catch ----
+    // The flag-based scheme inferred "was an exception thrown?" from the captured value's nullness, so
+    // a thrown null/undefined (a null CLR reference) read as "no exception" — skipping the catch and
+    // dropping the post-finally rethrow. A dedicated present flag now records presence independent of
+    // the value. (A `throw undefined` *literal* stringifies as "null" in compiled state-machine code —
+    // a separate, broader representation gap tracked elsewhere — so undefined cases assert via
+    // `=== undefined` rather than string form. `throw null` is fully correct.)
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ThrowNullIntoFlagBasedTryCatch_IsCaught(ExecutionMode mode)
+    {
+        // The exact #619 repro: throw null after a yield, caught in the same try's catch.
+        var source = """
+            function* g() { try { yield 1; throw null; } catch (e) { console.log("caught e=" + e); } }
+            for (const v of g()) console.log("v" + v);
+            """;
+
+        Assert.Equal("v1\ncaught e=null\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ThrowUndefinedIntoFlagBasedTryCatch_IsCaught(ExecutionMode mode)
+    {
+        // throw undefined likewise reaches the catch (was skipped). Asserted via `=== undefined`
+        // because the compiled stringification of the caught value is the separate representation gap.
+        var source = """
+            function* g() { try { yield 1; throw undefined; } catch (e) { console.log("isUndef=" + (e === undefined)); } }
+            for (const v of g()) console.log("v" + v);
+            """;
+
+        Assert.Equal("v1\nisUndef=true\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void FalsyNonNullThrowIntoFlagBasedTryCatch_StillCaught(ExecutionMode mode)
+    {
+        // Guard the boundary: a falsy-but-non-null thrown value (0 / "" / false box to non-null
+        // references) was already caught and must remain so under the present-flag scheme.
+        var source = """
+            function* g() { try { yield 1; throw 0; } catch (e) { console.log("caught e=" + e); } }
+            for (const v of g()) console.log("v" + v);
+            """;
+
+        Assert.Equal("v1\ncaught e=0\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ThrowNullIntoCatchlessTryFinally_RethrowsAfterFinally(ExecutionMode mode)
+    {
+        // The catch-less rethrow gate also used value-nullness; a thrown null was dropped instead of
+        // rethrown after the finally. It now propagates to the outer catch.
+        var source = """
+            function* g() { try { yield 1; throw null; } finally { console.log("fin"); } }
+            try { for (const v of g()) console.log("v" + v); } catch (e) { console.log("outer isNull=" + (e === null)); }
+            """;
+
+        Assert.Equal("v1\nfin\nouter isNull=true\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ThrowNullIntoCatchlessTry_WithYieldingFinally_RethrowsAfterFinally(ExecutionMode mode)
+    {
+        // The present flag must survive a yielding finally (persisted to a field, like the captured
+        // value in #599) so the post-finally rethrow still fires for a thrown null.
+        var source = """
+            function* g() { try { yield 1; throw null; } finally { yield 2; } }
+            const it = g();
+            console.log(JSON.stringify(it.next()));
+            console.log(JSON.stringify(it.next()));
+            try { it.next(); } catch (e) { console.log("isNull=" + (e === null)); }
+            """;
+
+        Assert.Equal(
+            "{\"value\":1,\"done\":false}\n{\"value\":2,\"done\":false}\nisNull=true\n",
+            TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void BareThrowOnSuspendedGenerator_InjectsUndefined(ExecutionMode mode)
+    {
+        // A bare it.throw() (no argument) injects `undefined` into the suspended yield and engages the
+        // catch — previously it padded `null` (and even then the value-nullness gate skipped the catch).
+        var source = """
+            function* g() { try { yield 1; } catch (e) { console.log("c:" + e); } }
+            const it = g();
+            it.next();
+            it.throw();
+            """;
+
+        Assert.Equal("c:undefined\n", TestHarness.Run(source, mode));
+    }
+
     // ---- IL-verification guards (the heart of #477: emitted IL must verify) ----
 
     [Theory]
@@ -816,6 +914,10 @@ public class GeneratorTryFinallyTests
     [InlineData("function* inner(){ try { yield 1; } finally { console.log('x'); } } function* g(){ yield* inner(); } for (const v of g()) {}")]
     [InlineData("function* inner(){ try { yield 1; } finally {} } function* mid(){ try { yield* inner(); } finally {} } function* g(){ yield* mid(); } for (const v of g()) {}")]
     [InlineData("function* g(){ try { yield 1; } catch (e) { yield 2; } finally { yield 3; } } for (const v of g()) {}")]
+    // #619: thrown null/undefined into a flag-based try — the present-flag gates must still verify.
+    [InlineData("function* g() { try { yield 1; throw null; } catch (e) { console.log(e); } } for (const v of g()) {}")]
+    [InlineData("function* g() { try { yield 1; throw undefined; } catch (e) { console.log(e); } } for (const v of g()) {}")]
+    [InlineData("function* g() { try { yield 1; throw null; } finally { yield 2; } } try { for (const v of g()) {} } catch (e) {}")]
     public void GeneratorTryFinallyWithYield_EmitsVerifiableIL(string source)
     {
         var errors = TestHarness.CompileAndVerifyOnly(source);


### PR DESCRIPTION
Closes #619, closes #569. (#597 was already fixed on `main` by #621 — closed separately; see note below.)

## #619 — throwing `null`/`undefined` into a flag-based generator `try`/`catch` skips the catch

The sync generator's flag-based try/catch (used when a `yield` crosses the protected region) tracked "was an exception thrown?" by the **nullness** of the captured-value local (`Brfalse` on an `object`). A thrown `null`/`undefined` captures as a null CLR reference, so the gate read it as "no exception" — the `catch` was skipped and the post-`finally` rethrow dropped it.

**Fix (Part A):** a dedicated `exceptionPresent` boolean records presence independent of the value — an IL local, persisted to a state-machine field when a catch-less `finally` yields (the same survival reason as the captured value in #599). All four gates now consult it: the catch gate, the catch-less rethrow gate, the per-segment skip in the try body, and the injected-`throw()` path. The captured value is still used verbatim to bind the catch parameter / rethrow.

```ts
function* g(){ try { yield 1; throw null; } catch(e){ console.log("caught e=" + e); } }
for (const v of g()) console.log("v" + v);
// before: v1            (catch skipped)
// after:  v1, caught e=null
```

**Fix (Part B):** a bare `it.throw()` (no argument) is now routed through `IteratorProtocolCall` so it injects the `undefined` **sentinel** for the missing argument (via `EmitArgZeroOrUndefined`) instead of the `null` a missing reflected argument pads — the counterpart of the bare-`return()` fix in #526. The bare-enumerator synth path is guarded so `.throw()` on a raw array iterator still raises a `TypeError`.

```ts
function* g(){ try { yield 1; } catch(e){ console.log("c:" + e); } }
const it = g(); it.next(); it.throw();
// before: (no output)   after: c:undefined
```

## #569 — async-generator catch parameter lost after a suspension in the catch body

A `catch (e)` parameter read after a `yield`/`await` inside the catch body is hoisted to a state-machine field, but the binding stored the caught value only into a fresh IL local — so the post-resume read resolved the unset field and came back `null`. Now bound field-aware at both catch sites via a new `StoreCaughtExceptionToParam`, mirroring the plain-generator fix from #477/#500.

```ts
async function* g(){ try { yield 1; throw "boom"; } catch(e){ yield 0; console.log("caught " + e); } }
async function main(){ for await (const v of g()) console.log("v" + v); }
main();
// before: v1, v0, caught null     after: v1, v0, caught boom
```

## #597 — already fixed

Both sub-bugs (return in a no-yield try → invalid IL; return value clobbered by a yielding finally) were fixed on `main` by #621 (merged as c42f90fe) and are covered by `AsyncGeneratorTryFinallyTests`. The issue stayed open only because #621 listed three numbers after a single auto-close keyword, which GitHub honours for the first number only. Verified on `main` and closed.

## Scope / follow-ups filed

- **#628** — async-generator analog of the #619 gate (same nullness pattern in `AsyncGeneratorMoveNextEmitter`). Kept separate, matching this repo's sync→async split precedent (#554/#555 → #597, #500 → #559).
- **#629** — compiled state machines emit the `undefined` *literal* as CLR `null` (`Ldnull`), so a `throw undefined` *literal* stringifies as `"null"` in async/generator code (also affects plain async functions). After this PR the `catch` runs (the #619 bug), but the caught value still renders `"null"`; that broader representation gap is tracked there. `throw null` and bare `it.throw()` are fully correct here.

## Testing

- New behavioural tests in `GeneratorTryFinallyTests` (both modes): throw `null`/`undefined`/`0` into a flag-based try/catch, catch-less rethrow (local + persisted-field-across-yielding-finally), and bare `it.throw()` → `undefined`. Plus IL-verify cases.
- New `CompiledOnly` tests in `AsyncGeneratorTryFinallyTests`: catch param after `yield`/`await` in the catch body, plus IL-verify cases.
- Full unit suite: **12,382 passed, 0 failed, 0 skipped**.
- `EmitterSyncTests` meta-test passes (the new helpers are not base overrides).
- Test262 (interpreter + compiled, baseline diff): **Failed: 0** (no conformance regression; the test-host teardown crash is the pre-existing flake).
- No type-checker changes → TypeScriptConformance unaffected.