### PR TITLE
Fix async generator completion/return/throw values, manual-next rejection, and await-in-try catch (#540, #618, #566, #617)

### DIFF
--- a/Compilation/AsyncGeneratorMoveNextEmitter.Expressions.cs
+++ b/Compilation/AsyncGeneratorMoveNextEmitter.Expressions.cs
@@ -523,11 +523,33 @@ public partial class AsyncGeneratorMoveNextEmitter
         // 8. Continue point (if was already completed)
         _il.MarkLabel(continueLabel);
 
-        // 9. Get result: awaiter.GetResult()
-        _il.Emit(OpCodes.Ldarg_0);
-        _il.Emit(OpCodes.Ldflda, _builder.AwaiterField);
+        // 9. Get result: awaiter.GetResult(). A rejected awaited task throws here.
         var getResultMethod = _types.TaskAwaiterOfObject.GetMethod("GetResult")!;
-        _il.Emit(OpCodes.Call, getResultMethod);
+        if (_currentTryExceptionLocal != null)
+        {
+            // Inside a flag-based try: capture the rejection into the try's exception flag (as a sync
+            // segment would) and `Leave` to the try's catch/finally, rather than letting it escape
+            // MoveNextAsync unhandled (#617). The eval stack is empty here — the resume/continue labels
+            // are state-switch targets — so opening a protected region is legal.
+            var resultTemp = _il.DeclareLocal(typeof(object));
+            _il.BeginExceptionBlock();
+            _il.Emit(OpCodes.Ldarg_0);
+            _il.Emit(OpCodes.Ldflda, _builder.AwaiterField);
+            _il.Emit(OpCodes.Call, getResultMethod);
+            _il.Emit(OpCodes.Stloc, resultTemp);
+            _il.BeginCatchBlock(typeof(Exception));
+            _il.Emit(OpCodes.Call, _ctx!.Runtime!.WrapException);
+            _il.Emit(OpCodes.Stloc, _currentTryExceptionLocal);
+            _il.Emit(OpCodes.Leave, _currentTryCleanupLabel); // skip the rest of the try body → catch/finally
+            _il.EndExceptionBlock();
+            _il.Emit(OpCodes.Ldloc, resultTemp); // normal path: push the awaited value
+        }
+        else
+        {
+            _il.Emit(OpCodes.Ldarg_0);
+            _il.Emit(OpCodes.Ldflda, _builder.AwaiterField);
+            _il.Emit(OpCodes.Call, getResultMethod);
+        }
 
         // Result is now on stack
         SetStackUnknown();

--- a/Compilation/AsyncGeneratorMoveNextEmitter.Statements.TryCatch.cs
+++ b/Compilation/AsyncGeneratorMoveNextEmitter.Statements.TryCatch.cs
@@ -467,7 +467,16 @@ public partial class AsyncGeneratorMoveNextEmitter
         // Throws in the try body are captured by their sync segments, not routed.
         bool previousInHandler = _inHandlerBody;
         _inHandlerBody = false;
+        // Carry this try's capture target down to the suspension points emitted at the top level, so a
+        // rejected `await` inside the try routes its exception into the same flag + catch/finally
+        // instead of escaping MoveNextAsync (#617). Saved/restored for correct nesting.
+        var previousTryExceptionLocal = _currentTryExceptionLocal;
+        var previousTryCleanupLabel = _currentTryCleanupLabel;
+        _currentTryExceptionLocal = caughtExceptionLocal;
+        _currentTryCleanupLabel = afterTryBodyLabel;
         EmitTryBodyWithSuspensions(t.TryBlock, caughtExceptionLocal, afterTryBodyLabel);
+        _currentTryExceptionLocal = previousTryExceptionLocal;
+        _currentTryCleanupLabel = previousTryCleanupLabel;
         _inHandlerBody = previousInHandler;
 
         // Restore the enclosing try's cleanup label (its yields must route to it, not ours).
@@ -486,6 +495,7 @@ public partial class AsyncGeneratorMoveNextEmitter
             // Bind the captured value to the catch param, honouring a hoisted field when the param is
             // read across a suspension in the catch body (#569). Storing to a fresh local
             // unconditionally lost the value whenever the param was hoisted (reads resolve the field).
+            // This binding is also what lets a rejected await routed here (#617) surface its reason.
             if (t.CatchParam != null)
             {
                 _il.Emit(OpCodes.Ldloc, caughtExceptionLocal);

--- a/Compilation/AsyncGeneratorMoveNextEmitter.cs
+++ b/Compilation/AsyncGeneratorMoveNextEmitter.cs
@@ -41,6 +41,15 @@ public partial class AsyncGeneratorMoveNextEmitter : StatementEmitterBase
     // Set to the afterTryBody label of the enclosing try/finally block (if any).
     private Label? _returnCleanupLabel;
 
+    // While emitting a flag-based try BODY (EmitTryCatchWithSuspensions), these carry that try's
+    // exception-capture target down to suspension points, which are emitted at the top level —
+    // outside the sync segments' mini try/catch. A rejected `await` inside the try captures its
+    // exception into _currentTryExceptionLocal (exactly as a sync segment does) and `Leave`s to
+    // _currentTryCleanupLabel so the try's catch/finally run, instead of escaping MoveNextAsync
+    // unhandled (#617). Null when not inside such a try body (the common case → GetResult is plain).
+    private LocalBuilder? _currentTryExceptionLocal;
+    private Label _currentTryCleanupLabel;
+
     // Compilation context for access to functions, classes, etc.
     private CompilationContext? _ctx;
 

--- a/Compilation/AsyncGeneratorStateMachineBuilder.cs
+++ b/Compilation/AsyncGeneratorStateMachineBuilder.cs
@@ -380,14 +380,18 @@ public class AsyncGeneratorStateMachineBuilder
         EmitThrowIfExecutingAsync(il);
 
         // Drive the body with the executing flag set so a re-entrant next()/return()/throw() from inside
-        // it hits the guard instead of recursing into MoveNextAsync (which overflowed the stack). The
-        // try/finally clears the flag on suspension/completion AND on an uncaught body throw (GetResult
-        // rethrowing) — a leaked flag would make later calls falsely report "already running".
+        // it hits the guard instead of recursing into MoveNextAsync (which overflowed the stack). An
+        // outer try/finally clears the flag on suspension/completion AND on an uncaught body throw;
+        // an inner try/catch captures that throw into exLocal so next() returns a *rejected* Task
+        // rather than throwing synchronously out of the call — `await it.next()` must be catchable
+        // (ECMA-262 §27.6.1.2: next() returns a promise that rejects on an uncaught body throw) (#566).
         var movedLocal = il.DeclareLocal(_types.Boolean);
+        var exLocal = il.DeclareLocal(_types.Exception);
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ldc_I4_1);
         il.Emit(OpCodes.Stfld, ExecutingField);
-        il.BeginExceptionBlock();
+        il.BeginExceptionBlock();   // outer: finally clears the executing flag
+        il.BeginExceptionBlock();   // inner: catch captures a body throw into exLocal
 
         // Call MoveNextAsync(), convert ValueTask<bool> → Task<bool>, then block for the result.
         // (This works for already-completed awaits — the common case; a pending await blocks the calling
@@ -414,12 +418,28 @@ public class AsyncGeneratorStateMachineBuilder
         il.Emit(OpCodes.Call, getResultMethod);
         il.Emit(OpCodes.Stloc, movedLocal);
 
+        // inner catch: stash the exception. The outer finally still clears the flag; the conversion to
+        // a faulted Task happens after both blocks close, so the throw never escapes synchronously (#566).
+        il.BeginCatchBlock(_types.Exception);
+        il.Emit(OpCodes.Stloc, exLocal);
+        il.EndExceptionBlock();   // end inner try/catch
+
         il.BeginFinallyBlock();
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ldc_I4_0);
         il.Emit(OpCodes.Stfld, ExecutingField);
-        il.EndExceptionBlock();
+        il.EndExceptionBlock();   // end outer try/finally
 
+        // A body throw was captured → return Task.FromException<object>(ex), i.e. a rejected promise.
+        var buildResultLabel = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, exLocal);
+        il.Emit(OpCodes.Brfalse, buildResultLabel);
+        il.Emit(OpCodes.Ldloc, exLocal);
+        var fromExceptionNext = typeof(Task).GetMethod("FromException", 1, [typeof(Exception)])!.MakeGenericMethod(_types.Object);
+        il.Emit(OpCodes.Call, fromExceptionNext);
+        il.Emit(OpCodes.Ret);
+
+        il.MarkLabel(buildResultLabel);
         // movedLocal: true = has value, false = done
         il.Emit(OpCodes.Ldloc, movedLocal);
         il.Emit(OpCodes.Brfalse, doneLabel);

--- a/Compilation/Emitters/AsyncGeneratorEmitter.cs
+++ b/Compilation/Emitters/AsyncGeneratorEmitter.cs
@@ -39,7 +39,8 @@ public sealed class AsyncGeneratorEmitter : ITypeEmitterStrategy
                 emitter.EmitBoxIfNeeded(receiver);
                 // Cast to $IAsyncGenerator interface
                 il.Emit(OpCodes.Castclass, ctx.Runtime.AsyncGeneratorInterfaceType);
-                // Emit value argument (or null if not provided)
+                // Emit value argument; an omitted argument is undefined, not null, so return() reports
+                // { value: undefined } — an explicit return(null) still reports null (#618).
                 if (arguments.Count > 0)
                 {
                     emitter.EmitExpression(arguments[0]);
@@ -47,7 +48,7 @@ public sealed class AsyncGeneratorEmitter : ITypeEmitterStrategy
                 }
                 else
                 {
-                    il.Emit(OpCodes.Ldnull);
+                    il.Emit(OpCodes.Ldsfld, ctx.Runtime.UndefinedInstance);
                 }
                 // Call return(value) which returns Task<object>
                 il.Emit(OpCodes.Callvirt, ctx.Runtime.AsyncGeneratorReturnMethod);
@@ -59,7 +60,7 @@ public sealed class AsyncGeneratorEmitter : ITypeEmitterStrategy
                 emitter.EmitBoxIfNeeded(receiver);
                 // Cast to $IAsyncGenerator interface
                 il.Emit(OpCodes.Castclass, ctx.Runtime.AsyncGeneratorInterfaceType);
-                // Emit error argument (or null if not provided)
+                // Emit error argument; an omitted argument is the undefined sentinel, not null (#618).
                 if (arguments.Count > 0)
                 {
                     emitter.EmitExpression(arguments[0]);
@@ -67,7 +68,7 @@ public sealed class AsyncGeneratorEmitter : ITypeEmitterStrategy
                 }
                 else
                 {
-                    il.Emit(OpCodes.Ldnull);
+                    il.Emit(OpCodes.Ldsfld, ctx.Runtime.UndefinedInstance);
                 }
                 // Call throw(error) which returns Task<object>
                 il.Emit(OpCodes.Callvirt, ctx.Runtime.AsyncGeneratorThrowMethod);

--- a/Execution/Interpreter.Statements.cs
+++ b/Execution/Interpreter.Statements.cs
@@ -1063,7 +1063,7 @@ public partial class Interpreter
     /// </summary>
     /// <param name="ex">The host exception to translate.</param>
     /// <returns>The guest error value (ThrowException value, NodeError object, or message string).</returns>
-    private object? TranslateException(Exception ex)
+    internal object? TranslateException(Exception ex)
     {
         if (ex is ThrowException tex)
             return tex.Value;

--- a/Runtime/BuiltIns/AsyncGeneratorBuiltIns.cs
+++ b/Runtime/BuiltIns/AsyncGeneratorBuiltIns.cs
@@ -29,7 +29,9 @@ public static class AsyncGeneratorBuiltIns
             {
                 if (receiver is SharpTSAsyncGenerator gen)
                 {
-                    object? value = args.Count > 0 ? args[0] : null;
+                    // An omitted argument is undefined, not null — return() reports { value: undefined }
+                    // (ECMA-262 §27.6.1.3); an explicit return(null) still reports null (#618).
+                    object? value = args.Count > 0 ? args[0] : SharpTSUndefined.Instance;
                     return await gen.Return(value);
                 }
                 throw new Exception("Runtime Error: return() called on non-async-generator.");
@@ -38,7 +40,8 @@ public static class AsyncGeneratorBuiltIns
             {
                 if (receiver is SharpTSAsyncGenerator gen)
                 {
-                    object? error = args.Count > 0 ? args[0] : null;
+                    // An omitted argument is the undefined sentinel, not null (#618).
+                    object? error = args.Count > 0 ? args[0] : SharpTSUndefined.Instance;
                     return await gen.Throw(error);
                 }
                 throw new Exception("Runtime Error: throw() called on non-async-generator.");

--- a/Runtime/Types/SharpTSAsyncGenerator.cs
+++ b/Runtime/Types/SharpTSAsyncGenerator.cs
@@ -35,6 +35,11 @@ public class SharpTSAsyncGenerator : ITypeCategorized
     // (or the generator is closed), the completion value is reported exactly once; every later next()
     // reports undefined (ECMA-262 §27.6.1.2 → CreateIterResultObject(undefined, true), #540).
     private bool _completionDelivered = false;
+    // A throw (an uncaught guest `throw` or a rejected `await`) raised by the eagerly-drained body.
+    // The body runs to completion on the first next(), but the throw must be observed from the next()
+    // that follows the values yielded before it — so it is buffered here and rethrown by Next() once
+    // those values are exhausted, rejecting that call's promise (#566). Null when the body did not throw.
+    private Exception? _pendingException = null;
 
     public SharpTSAsyncGenerator(Stmt.Function declaration, RuntimeEnvironment environment, Interpreter interpreter)
     {
@@ -76,9 +81,21 @@ public class SharpTSAsyncGenerator : ITypeCategorized
             return new SharpTSIteratorResult(_values[_index++], done: false);
         }
 
-        // Body fully drained. Deliver the completion value once (the body's `return X`, or undefined
-        // when it ran off the end), then undefined on every later call — the stale completion / last
-        // yielded value must not replay forever (#540; mirrors the sync generator's done semantics).
+        // Body fully drained. If it threw after the values above, surface that now so this next()'s
+        // promise rejects — the throw is delivered after the preceding values, then the generator is
+        // done (#566). Reported exactly once.
+        if (_pendingException != null)
+        {
+            var ex = _pendingException;
+            _pendingException = null;
+            _closed = true;
+            _completionDelivered = true;
+            System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(ex).Throw();
+        }
+
+        // Deliver the completion value once (the body's `return X`, or undefined when it ran off the
+        // end), then undefined on every later call — the stale completion / last yielded value must
+        // not replay forever (#540; mirrors the sync generator's done semantics).
         if (_completionDelivered)
         {
             return new SharpTSIteratorResult(SharpTSUndefined.Instance, done: true);
@@ -98,6 +115,9 @@ public class SharpTSAsyncGenerator : ITypeCategorized
         // consistent even if the body had already run off the end before this return().
         _closed = true;
         _completionDelivered = true;
+        // return() closes the generator and wins over a not-yet-observed body throw: the code after
+        // the last yield never "runs" observably, so discard any buffered exception (#566).
+        _pendingException = null;
         return Task.FromResult<object?>(new SharpTSIteratorResult(value, done: true));
     }
 
@@ -138,10 +158,17 @@ public class SharpTSAsyncGenerator : ITypeCategorized
             }
             else if (result.Type == ExecutionResult.ResultType.Throw)
             {
-                // Propagate the original throw value through ThrowException —
-                // see SharpTSFunction.Call for the full rationale.
-                throw ThrowException.FromResult(result.Value.ToObject());
+                // Buffer rather than throw now: the body drains eagerly, so a throw after some yields
+                // must surface from the next() that follows those values, not the first one (#566).
+                // The original throw value is preserved through ThrowException (see SharpTSFunction.Call).
+                _pendingException = ThrowException.FromResult(result.Value.ToObject());
             }
+        }
+        catch (Exception ex) when (ex is not YieldException)
+        {
+            // A host exception escaped the body — a rejected `await`, or a `throw` surfaced as a C#
+            // exception. Buffer it so the post-drain next() rejects its promise with it (#566).
+            _pendingException = ex;
         }
         finally
         {
@@ -363,7 +390,9 @@ public class SharpTSAsyncGenerator : ITypeCategorized
                 return ExecutionResult.Success();
 
             case Stmt.Return returnStmt:
-                object? returnValue = null;
+                // A value-less `return;` (or running off the end) completes with undefined, not C#
+                // null; only an explicit `return null;` reports null (#540, mirrors the sync gen).
+                object? returnValue = SharpTSUndefined.Instance;
                 if (returnStmt.Value != null)
                 {
                     try
@@ -378,29 +407,53 @@ public class SharpTSAsyncGenerator : ITypeCategorized
                 return ExecutionResult.Return(returnValue);
 
             case Stmt.TryCatch tryCatch:
-                ExecutionResult tryResult = await ExecuteStatementsAsync(tryCatch.TryBlock);
-                if (tryResult.Type == ExecutionResult.ResultType.Throw)
+                ExecutionResult tryResult;
+                try
                 {
-                    if (tryCatch.CatchBlock != null && tryCatch.CatchParam != null)
+                    tryResult = await ExecuteStatementsAsync(tryCatch.TryBlock);
+                }
+                catch (Exception ex) when (ex is not YieldException)
+                {
+                    // A host exception escaped the try body — most often a rejected `await`
+                    // (SharpTSPromiseRejectedException) or a guest `throw` surfaced as a C#
+                    // exception. Convert it to a guest Throw so this try's catch/finally run (#617).
+                    tryResult = ExecutionResult.Throw(_interpreter.TranslateException(ex));
+                }
+
+                if (tryResult.Type == ExecutionResult.ResultType.Throw && tryCatch.CatchBlock != null)
+                {
+                    var catchEnv = new RuntimeEnvironment(_interpreter.Environment);
+                    // `catch {}` (no binding) is valid — only define the param when present, and bind
+                    // the unwrapped guest value rather than the boxed RuntimeValue struct.
+                    if (tryCatch.CatchParam != null)
+                        catchEnv.Define(tryCatch.CatchParam.Lexeme, tryResult.Value.ToObject());
+                    RuntimeEnvironment prevEnv = _interpreter.Environment;
+                    _interpreter.SetEnvironment(catchEnv);
+                    try
                     {
-                        var catchEnv = new RuntimeEnvironment(_interpreter.Environment);
-                        catchEnv.Define(tryCatch.CatchParam.Lexeme, tryResult.Value);
-                        RuntimeEnvironment prevEnv = _interpreter.Environment;
-                        _interpreter.SetEnvironment(catchEnv);
-                        try
-                        {
-                            tryResult = await ExecuteStatementsAsync(tryCatch.CatchBlock);
-                        }
-                        finally
-                        {
-                            _interpreter.SetEnvironment(prevEnv);
-                        }
+                        tryResult = await ExecuteStatementsAsync(tryCatch.CatchBlock);
+                    }
+                    catch (Exception ex) when (ex is not YieldException)
+                    {
+                        tryResult = ExecutionResult.Throw(_interpreter.TranslateException(ex));
+                    }
+                    finally
+                    {
+                        _interpreter.SetEnvironment(prevEnv);
                     }
                 }
 
                 if (tryCatch.FinallyBlock != null)
                 {
-                    var finallyResult = await ExecuteStatementsAsync(tryCatch.FinallyBlock);
+                    ExecutionResult finallyResult;
+                    try
+                    {
+                        finallyResult = await ExecuteStatementsAsync(tryCatch.FinallyBlock);
+                    }
+                    catch (Exception ex) when (ex is not YieldException)
+                    {
+                        finallyResult = ExecutionResult.Throw(_interpreter.TranslateException(ex));
+                    }
                     if (finallyResult.IsAbrupt) return finallyResult;
                 }
                 return tryResult;

--- a/SharpTS.Tests/SharedTests/AsyncGeneratorTests.cs
+++ b/SharpTS.Tests/SharedTests/AsyncGeneratorTests.cs
@@ -391,8 +391,10 @@ public class AsyncGeneratorTests
 
     [Theory]
     [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
-    public void AsyncGenerator_ReturnWithoutValue_ReturnsNull(ExecutionMode mode)
+    public void AsyncGenerator_ReturnWithoutValue_ReturnsUndefined(ExecutionMode mode)
     {
+        // ECMA-262 §27.6.1.3: AsyncGenerator.prototype.return(value) with value absent resolves to
+        // { value: undefined, done: true } — an omitted argument is undefined, not null (#618).
         var source = """
             async function* gen() {
                 yield 1;
@@ -410,7 +412,111 @@ public class AsyncGeneratorTests
             """;
 
         var output = TestHarness.Run(source, mode);
-        Assert.Equal("null true\n", output);
+        Assert.Equal("undefined true\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AsyncGenerator_ThrowWithoutValue_RejectsWithUndefined(ExecutionMode mode)
+    {
+        // throw() with no argument rejects with undefined, not null (#618).
+        var source = """
+            async function* gen() { yield 1; yield 2; }
+            async function main() {
+                const g = gen();
+                await g.next();
+                try { await g.throw(); } catch (e) { console.log("rejected " + e); }
+            }
+            main();
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("rejected undefined\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AsyncGenerator_BareReturn_CompletesWithUndefined(ExecutionMode mode)
+    {
+        // A value-less `return;` completes with undefined, not null; `return null;` still reports null (#540).
+        var source = """
+            async function* bare() { yield 1; return; }
+            async function* retNull() { yield 1; return null; }
+            async function main() {
+                const a = bare();
+                await a.next();
+                console.log("bare " + (await a.next()).value);
+                const b = retNull();
+                await b.next();
+                console.log("retNull " + (await b.next()).value);
+            }
+            main();
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("bare undefined\nretNull null\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AsyncGenerator_ManualNextOnThrowingGenerator_RejectsCatchably(ExecutionMode mode)
+    {
+        // A throwing async generator settles its final next() as a rejection (catchable via await),
+        // delivering the preceding yields first, rather than propagating unhandled (#566).
+        var source = """
+            async function* g() { yield 1; throw "b"; }
+            async function main() {
+                const it = g();
+                const r1 = await it.next();
+                let err = "none";
+                try { await it.next(); } catch (e) { err = "" + e; }
+                console.log(r1.value + " err=" + err);
+            }
+            main();
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("1 err=b\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AsyncGenerator_RejectedAwaitInTry_CaughtByOwnCatch(ExecutionMode mode)
+    {
+        // A rejected await inside a try in an async generator is caught by that try's catch, which
+        // binds the rejection reason; the generator then continues to its next yield (#617).
+        var source = """
+            async function* g() {
+                try { await Promise.reject("boom"); } catch (e: any) { console.log("caught " + e); }
+                yield 1;
+            }
+            async function main() { for await (const v of g()) console.log("v" + v); }
+            main();
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("caught boom\nv1\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AsyncGenerator_ThrowInTryAfterYield_CatchBindsValue(ExecutionMode mode)
+    {
+        // A throw in a flag-based try (one containing a yield) is caught and the catch parameter binds
+        // the thrown value, not null — the catch param is stored to its hoisted field (#617/#477 analog).
+        // The caught value is *yielded* (not logged) so the assertion is independent of the interpreter's
+        // eager-drain side-effect ordering (#564): yielded values keep their order in both modes.
+        var source = """
+            async function* g() {
+                try { yield 0; throw "x"; } catch (e: any) { yield "caught:" + e; }
+                yield 1;
+            }
+            async function main() { for await (const v of g()) console.log(v); }
+            main();
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("0\ncaught:x\n1\n", output);
     }
 
     #endregion


### PR DESCRIPTION
Closes #540, #618, #566, #617.

Four related async-generator correctness fixes (interpreter + compiled). Rebased onto current `main` (includes #630, which already fixed #569 — see note below).

## #540 — bare `return;` / off-end completion value (interpreter)
A value-less `return;` (or running off the end) now completes with `undefined`, not C# `null`; an explicit `return null;` still reports `null`. Fixed at the source in `SharpTSAsyncGenerator` (mirrors the sync generator). The compiled side and the next()-after-done replay were already correct.

## #618 — `return()`/`throw()` with no argument (both modes)
An omitted argument is `undefined`, not `null` (ECMA-262 §27.6.1.3). Interpreter: default the missing built-in arg to the undefined sentinel. Compiled: the call site pads an omitted argument with `$Undefined` instead of `ldnull`. `return(null)` / `throw(null)` still report `null`.

## #566 — manual `it.next()` on a throwing generator rejects catchably (both modes)
A throwing async generator now settles its final `next()` as a **rejection** (catchable via `await`), delivering the preceding yields first, instead of propagating unhandled.
- **Interpreter:** the eagerly-drained body's throw is buffered and rethrown from the `next()` that follows the already-yielded values (correct throw ordering; the deeper eager-drain side-effect ordering remains the separate #564).
- **Compiled:** `next()`'s synchronous `MoveNextAsync` drive gains an inner try/catch that returns `Task.FromException` instead of throwing synchronously out of the call.

## #617 — a rejected `await` inside a `try` is caught by that try's `catch` (both modes)
For synchronously-settled awaits (e.g. `await Promise.reject(x)`). Pending (`setTimeout`-style) awaits are blocked by the pre-existing **#631** hang, filed separately.
- **Interpreter:** the async-gen `try/catch` handler now catches host rejections (`SharpTSPromiseRejectedException` etc.) and converts them to a guest `Throw`, so the catch/finally run. Also fixes the catch param to bind the unwrapped guest value (was binding a boxed `RuntimeValue`) and honors `catch {}` without a binding.
- **Compiled:** an `await`'s `GetResult` inside a flag-based `try` captures a rejection into that try's exception flag and `Leave`s to its catch/finally (the eval stack is empty at the resume point, so opening a protected region is legal). This reuses the `StoreCaughtExceptionToParam` catch-binding that #630 added for #569, so the catch parameter receives the rejection reason.

### Note on #569
#569 (compiled async-gen catch param lost after a suspension) was fixed by #630, now on `main`. The compiled #617 fix depends on that same catch-binding (otherwise #617's repro would print `caught null`); after rebasing, this PR builds on #630's `StoreCaughtExceptionToParam` rather than duplicating it.

## Testing
- 6 new regression tests (both modes) in `AsyncGeneratorTests`; the `ReturnWithoutValue` test now asserts `undefined`.
- Full unit suite: green (see CI).
- Test262 subset: no baseline diff (interpreter + compiled).
- Emitted IL verified with `--compile … --verify` for the new try/catch and next() paths.

## Follow-ups filed
- **#631** — compiled async generator hangs on a not-yet-settled (genuinely-async) await (pre-existing; also gates #617's pending-await sub-case).
- **#632** — a `throw` from inside a `catch` body is not caught by an enclosing flag-based `try`/`catch` (pre-existing; sync + async).
