### PR TITLE
Lower capturing module-block functions/generators/async (#622); box value-type captured locals (#431)

### DIFF
--- a/Compilation/ILEmitter.Calls.Closures.cs
+++ b/Compilation/ILEmitter.Calls.Closures.cs
@@ -468,6 +468,15 @@ public partial class ILEmitter
                 if (local != null)
                 {
                     IL.Emit(OpCodes.Ldloc, local);
+                    // The capture field is object-typed, so a value-type local (e.g. a
+                    // number stored in an unboxed `double` slot via CanUseUnboxedLocal)
+                    // must be boxed before Stfld. The captured-parameter path above
+                    // already does this; omitting it here left a float64 where the
+                    // verifier expects a reference, corrupting the stack (#431).
+                    if (local.LocalType.IsValueType)
+                    {
+                        IL.Emit(OpCodes.Box, local.LocalType);
+                    }
                 }
                 else
                 {

--- a/Compilation/NestedFunctionLifter.cs
+++ b/Compilation/NestedFunctionLifter.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using SharpTS.Parsing;
 
 namespace SharpTS.Compilation;
@@ -59,13 +60,18 @@ internal sealed class NestedFunctionLifter
 {
     private readonly ClosureAnalyzer _analyzer;
     private readonly HashSet<Stmt.Function> _safeCandidates;
+    private readonly Dictionary<Stmt.Function, List<string>> _lambdaForwards;
     private readonly List<Stmt.Function> _lifted = new();
     private int _counter;
 
-    private NestedFunctionLifter(ClosureAnalyzer analyzer, HashSet<Stmt.Function> safeCandidates)
+    private NestedFunctionLifter(
+        ClosureAnalyzer analyzer,
+        HashSet<Stmt.Function> safeCandidates,
+        Dictionary<Stmt.Function, List<string>> lambdaForwards)
     {
         _analyzer = analyzer;
         _safeCandidates = safeCandidates;
+        _lambdaForwards = lambdaForwards;
     }
 
     /// <summary>
@@ -92,26 +98,52 @@ internal sealed class NestedFunctionLifter
         var analyzer = new ClosureAnalyzer();
         analyzer.Analyze(module);
 
-        // A candidate is liftable when it captures nothing from an enclosing scope and its name does
-        // not collide with a top-level binding (which would hijack the injected alias).
+        // A candidate is liftable when it captures nothing from an enclosing FUNCTION scope.
         var reservedTopLevelNames = CollectTopLevelBindingNames(module);
         var safe = new HashSet<Stmt.Function>(ReferenceEqualityComparer.Instance);
+        // Module-block declarations that CAPTURE an enclosing block/loop binding are lambda-lifted:
+        // each captured binding becomes a leading parameter of the relocated top-level declaration,
+        // forwarded by an in-place arrow that closes over it (see LambdaLiftCandidate). Maps such a
+        // function to the ordered list of capture names to forward.
+        var lambdaForwards = new Dictionary<Stmt.Function, List<string>>(ReferenceEqualityComparer.Instance);
         foreach (var f in scan.Candidates)
         {
+            // A reference into an intermediate FUNCTION scope is a real closure capture (#583 §1)
+            // that neither plain relocation nor lambda-lifting can perform — leave it nested.
             if (!IsNonCapturing(analyzer, f)) continue;
-            if (reservedTopLevelNames.Contains(f.Name.Lexeme)) continue;
-            // A module-level-block candidate that captures a binding declared in an enclosing
-            // block/loop scope (e.g. a generator in a `for` reading the loop variable) cannot be
-            // lifted: that name does not exist at module top level, so the relocated body would
-            // read the wrong slot. Leaving it nested is a clean failure, never a miscompile (#605).
-            if (scan.ModuleBlockEnclosingBindings.TryGetValue(f, out var blockBindings) &&
-                CapturesAnyOf(analyzer, f, blockBindings))
+
+            bool isModuleBlock = scan.ModuleBlockEnclosingBindings.TryGetValue(f, out var blockBindings);
+
+            // A module-block candidate that captures an enclosing block/loop binding (e.g. a
+            // generator in a `for` reading the loop variable) can't move to module top level as-is —
+            // that name doesn't exist there. Lambda-lift it: the captured bindings become leading
+            // parameters of the relocated declaration, forwarded by an in-place arrow that closes
+            // over them. The compiler cannot emit a generator/async that captures locals, so this
+            // declaration-with-parameters form is the only route that handles all three function
+            // kinds uniformly (#622). The type checker has already rejected any reference to a
+            // captured binding before its declaration (or to the function before its own), so the
+            // arrow's snapshot of each capture at its in-place position is always well-defined.
+            if (isModuleBlock && CapturesAnyOf(analyzer, f, blockBindings!))
+            {
+                if (TryComputeLambdaForward(analyzer, f, blockBindings!, out var forwarded))
+                    lambdaForwards[f] = forwarded;
+                // Otherwise leave nested — a clean failure, never a miscompile.
                 continue;
+            }
+
+            // The injected alias for a MODULE-BLOCK candidate is a `var` that hoists to module
+            // scope, so a same-named top-level binding would collide with it — keep declining those.
+            // An INSIDE-FUNCTION candidate's alias is function-scoped and correctly shadows a
+            // same-named top-level function now that in-scope locals win that resolution (#607),
+            // so the name-collision guard is unnecessary there: without this relaxation a liftable
+            // nested generator/async whose name matched a top-level binding failed to compile with
+            // "Yield not supported in this context" instead of being lifted.
+            if (isModuleBlock && reservedTopLevelNames.Contains(f.Name.Lexeme)) continue;
             safe.Add(f);
         }
-        if (safe.Count == 0) return module;
+        if (safe.Count == 0 && lambdaForwards.Count == 0) return module;
 
-        var lifter = new NestedFunctionLifter(analyzer, safe);
+        var lifter = new NestedFunctionLifter(analyzer, safe, lambdaForwards);
         var rewritten = lifter.ProcessTopLevel(module);
         if (lifter._lifted.Count == 0) return module;
 
@@ -157,6 +189,81 @@ internal sealed class NestedFunctionLifter
             if (names.Contains(captured)) return true;
         }
         return false;
+    }
+
+    /// <summary>
+    /// Decides whether a module-block declaration that captures enclosing block/loop bindings can be
+    /// lambda-lifted, and if so produces the ordered list of capture names to forward as leading
+    /// parameters. Declines (returns false — the declaration stays nested, a clean failure) when the
+    /// forwarding arrow cannot faithfully reproduce the call:
+    /// <list type="bullet">
+    /// <item>rest or default parameters — forwarding them through the arrow miscompiles (spread call
+    /// args and expression-body arrow defaults are not yet reliable);</item>
+    /// <item>the body uses <c>this</c> or <c>arguments</c> — a plain top-level function reached
+    /// through an arrow has neither the original receiver nor the original argument list.</item>
+    /// </list>
+    /// The forwarded set is exactly the captured names that resolve to an enclosing block/loop
+    /// binding (a module top-level binding is reachable by the relocated function directly, so it is
+    /// not forwarded). The function's own name is included when it recurses, so the relocated body's
+    /// self-calls resolve to the forwarded arrow.
+    /// </summary>
+    private static bool TryComputeLambdaForward(
+        ClosureAnalyzer analyzer, Stmt.Function f, HashSet<string> blockBindings, out List<string> forwarded)
+    {
+        forwarded = [];
+
+        foreach (var p in f.Parameters)
+            if (p.IsRest || p.DefaultValue != null)
+                return false;
+
+        if (UsesThisOrArguments(f.Body))
+            return false;
+
+        // Ordinal sort gives a deterministic parameter order shared by the relocated declaration's
+        // leading parameters and the arrow's leading call arguments.
+        forwarded = analyzer.GetCaptures(f)
+            .Where(blockBindings.Contains)
+            .OrderBy(c => c, System.StringComparer.Ordinal)
+            .ToList();
+        return forwarded.Count > 0;
+    }
+
+    /// <summary>
+    /// True if any statement in <paramref name="body"/> reads <c>this</c> or <c>arguments</c>.
+    /// Deliberately over-approximates: it descends through nested function/arrow boundaries (which
+    /// rebind both), so a nested function's own <c>this</c> also trips it. A false positive only
+    /// declines a lambda-lift (a clean failure), never miscompiles.
+    /// </summary>
+    private static bool UsesThisOrArguments(List<Stmt>? body)
+    {
+        if (body == null) return false;
+        var scanner = new ThisArgumentsScanner();
+        foreach (var stmt in body)
+        {
+            scanner.Visit(stmt);
+            if (scanner.Found) return true;
+        }
+        return scanner.Found;
+    }
+
+    private sealed class ThisArgumentsScanner : Parsing.Visitors.AstVisitorBase
+    {
+        public bool Found { get; private set; }
+
+        protected override void VisitThis(Expr.This expr)
+        {
+            Found = true;
+            ShouldContinue = false;
+        }
+
+        protected override void VisitVariable(Expr.Variable expr)
+        {
+            if (expr.Name.Lexeme == "arguments")
+            {
+                Found = true;
+                ShouldContinue = false;
+            }
+        }
     }
 
     /// <summary>Accumulates the structural candidate scan results.</summary>
@@ -332,12 +439,27 @@ internal sealed class NestedFunctionLifter
         {
             var stmt = body[i];
 
-            if (stmt is Stmt.Function f && f.Body != null && _safeCandidates.Contains(f))
+            if (stmt is Stmt.Function f && f.Body != null)
             {
-                aliases ??= new List<Stmt>();
-                aliases.Add(LiftCandidate(f));
-                result ??= new List<Stmt>(body.GetRange(0, i));
-                continue; // drop the declaration from this body
+                if (_safeCandidates.Contains(f))
+                {
+                    // Non-capturing relocation: hoist a `var name = freshName;` alias to the top of
+                    // this body (function declarations hoist, so the alias must too).
+                    aliases ??= new List<Stmt>();
+                    aliases.Add(LiftCandidate(f));
+                    result ??= new List<Stmt>(body.GetRange(0, i));
+                    continue; // drop the declaration from this body
+                }
+                if (_lambdaForwards.TryGetValue(f, out var forwarded))
+                {
+                    // Capturing relocation: replace the declaration IN PLACE with a forwarding
+                    // arrow. In-place (not hoisted) so the arrow snapshots each captured binding
+                    // where they are all in scope and assigned — the type checker has already
+                    // guaranteed that ordering, rejecting any earlier reference.
+                    result ??= new List<Stmt>(body.GetRange(0, i));
+                    result.Add(LambdaLiftCandidate(f, forwarded));
+                    continue;
+                }
             }
 
             var rewritten = ProcessStmt(stmt, enclosingIsStateMachine);
@@ -380,6 +502,65 @@ internal sealed class NestedFunctionLifter
     /// <summary>Builds <c>var &lt;original&gt; = &lt;fresh&gt;;</c>.</summary>
     private static Stmt MakeAlias(Token original, Token fresh)
         => new Stmt.Var(original, TypeAnnotation: null, Initializer: new Expr.Variable(fresh), IsVar: true);
+
+    /// <summary>
+    /// Lambda-lifts a capturing module-block declaration: relocates it to a top-level declaration
+    /// whose leading parameters are the captured bindings (<paramref name="forwarded"/>), and returns
+    /// a block-scoped <c>let &lt;name&gt; = (&lt;params&gt;) =&gt; &lt;fresh&gt;(&lt;captures&gt;,
+    /// &lt;params&gt;);</c> arrow that stands in for it at its original position. The arrow closes over
+    /// the captured bindings and forwards them, so a generator/async relocated this way — which the
+    /// compiler cannot emit as a capturing closure directly — still observes its captures, and each
+    /// loop iteration builds a fresh arrow over that iteration's bindings (#622).
+    /// </summary>
+    private Stmt LambdaLiftCandidate(Stmt.Function f, List<string> forwarded)
+    {
+        var freshName = $"__nestedFn_{f.Name.Lexeme}_{_counter++}";
+        var freshToken = new Token(TokenType.IDENTIFIER, freshName, null, f.Name.Line);
+
+        // Recurse first so nested candidates inside the relocated body are also handled.
+        var liftedBody = ProcessBody(f.Body!, f.IsGenerator || f.IsAsync);
+
+        // Relocated declaration: captured bindings become leading (untyped) parameters, followed by
+        // the original parameters. Body references to the captured names now resolve to these
+        // parameters, so the body needs no renaming.
+        var liftedParams = new List<Stmt.Parameter>(forwarded.Count + f.Parameters.Count);
+        foreach (var name in forwarded)
+            liftedParams.Add(new Stmt.Parameter(new Token(TokenType.IDENTIFIER, name, null, f.Name.Line), Type: null));
+        foreach (var p in f.Parameters)
+            liftedParams.Add(p with { });
+        _lifted.Add(f with { Name = freshToken, Parameters = liftedParams, Body = liftedBody });
+
+        // Forwarding arrow: original parameters in, captured bindings + those parameters forwarded
+        // to the relocated declaration. Not a generator/async itself — it returns whatever the
+        // relocated declaration produces (the iterator for a generator, the promise for async).
+        var callArgs = new List<Expr>(forwarded.Count + f.Parameters.Count);
+        foreach (var name in forwarded)
+            callArgs.Add(new Expr.Variable(new Token(TokenType.IDENTIFIER, name, null, f.Name.Line)));
+        foreach (var p in f.Parameters)
+            callArgs.Add(new Expr.Variable(p.Name));
+
+        var call = new Expr.Call(
+            new Expr.Variable(freshToken),
+            new Token(TokenType.LEFT_PAREN, "(", null, f.Name.Line),
+            TypeArgs: null,
+            Arguments: callArgs);
+
+        var arrow = new Expr.ArrowFunction(
+            Name: null,
+            TypeParams: null,
+            ThisType: null,
+            Parameters: [.. f.Parameters.Select(p => p with { })],
+            ExpressionBody: call,
+            BlockBody: null,
+            ReturnType: null,
+            HasOwnThis: false,
+            IsAsync: false,
+            IsGenerator: false);
+
+        // Block-scoped `let`: doesn't leak past its block and is re-bound per loop iteration,
+        // matching block-scoped function-declaration semantics.
+        return new Stmt.Var(f.Name, TypeAnnotation: null, Initializer: arrow, IsVar: false);
+    }
 
     private Stmt ProcessStmt(Stmt stmt, bool enclosingIsStateMachine)
     {

--- a/SharpTS.Tests/SharedTests/NestedFunctionLiftingTests.cs
+++ b/SharpTS.Tests/SharedTests/NestedFunctionLiftingTests.cs
@@ -166,6 +166,22 @@ public class NestedFunctionLiftingTests
         Assert.Equal("[10] 20\n", TestHarness.Run(source, mode));
     }
 
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void NestedGenerator_NameCollidesWithTopLevelFunction_IsLifted(ExecutionMode mode)
+    {
+        // The nested generator `a3` shares a name with a top-level function. It is relocated under a
+        // fresh name and aliased by a function-local that correctly shadows the top-level `a3`
+        // (#607). Before the name-collision guard was relaxed, the lifter declined this and the
+        // nested generator failed to compile with "Yield not supported in this context".
+        var source = """
+            function a3(): number { return 1; }
+            function t3(): number { function* a3(): Generator<number> { yield 23; } return a3().next().value; }
+            console.log(a3(), t3());
+            """;
+        Assert.Equal("1 23\n", TestHarness.Run(source, mode));
+    }
+
     // ── Deep nesting ─────────────────────────────────────────────────────────────────────────────
 
     [Theory]
@@ -280,10 +296,77 @@ public class NestedFunctionLiftingTests
         Assert.Equal("yes\n", TestHarness.Run(source, mode));
     }
 
-    // ── Documented limitation #583 §1: capturing nested function-likes are NOT lifted ────────────
-    // The interpreter handles them via real closures; the compiler still cannot lower a nested
-    // state-machine function that captures an enclosing local (it stays nested and fails to compile,
-    // a clean failure — never a miscompile). This pins the interpreter behaviour.
+    // ── #622: capturing declarations inside a MODULE-LEVEL block/loop are lambda-lifted ──────────
+    // A function/generator/async declared in a module-level block that captures an enclosing
+    // block/loop binding is relocated to a top-level declaration whose leading parameters are the
+    // captured bindings, with an in-place arrow that closes over them and forwards them. This is the
+    // only route that lowers a capturing GENERATOR/ASYNC (the compiler cannot emit one as a capturing
+    // closure directly). Previously these threw "ReferenceError: Undefined variable" in compiled mode.
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void BlockFunction_CapturingBlockConst_IsCallable(ExecutionMode mode)
+    {
+        var source = """
+            { const base = 5; function add(n: number): number { return n + base; } console.log(add(1)); }
+            """;
+        Assert.Equal("6\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void BlockFunction_CapturingMultipleBlockBindings_IsCallable(ExecutionMode mode)
+    {
+        var source = """
+            { const a = 3; const b = 4; function sum(n: number): number { return a + b + n; } console.log(sum(5)); }
+            """;
+        Assert.Equal("12\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void BlockAsyncFunction_CapturingBlockConst_IsCallable(ExecutionMode mode)
+    {
+        var source = """
+            { const base = "y"; async function af(): Promise<string> { return base; } af().then((v: string) => console.log(v)); }
+            """;
+        Assert.Equal("y\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void RecursiveBlockGenerator_CapturingBlockConst_IsCallable(ExecutionMode mode)
+    {
+        // The function's own name is forwarded too, so the relocated body's self-calls resolve to
+        // the forwarding arrow.
+        var source = """
+            { const lim = 3; function* count(n: number): Generator<number> { yield n; if (n + 1 < lim) yield* count(n + 1); }
+              console.log([...count(0)].join(",")); }
+            """;
+        Assert.Equal("0,1,2\n", TestHarness.Run(source, mode));
+    }
+
+    // The headline #622 repro: a generator in a module-level for-loop capturing the loop variable.
+    // Compiled mode now lowers it conformantly — each iteration builds a fresh closure over that
+    // iteration's `let` binding, so the captured values are 0,1,2. (The interpreter still shares a
+    // single binding and yields 3,3,3 — a separate, pre-existing per-iteration `let` defect, #631-
+    // adjacent — so this is pinned for the compiler only.)
+    [Fact]
+    public void GeneratorCapturingModuleLevelLoopVar_IsLoweredConformantly()
+    {
+        var source = """
+            const gens: any[] = [];
+            for (let k = 0; k < 3; k++) { function* g() { yield k; } gens.push(g()); }
+            console.log(gens.map((it: any) => it.next().value).join(","));
+            """;
+        Assert.Equal("0,1,2\n", TestHarness.RunCompiled(source));
+    }
+
+    // ── Documented limitation #583 §1: capturing an enclosing FUNCTION scope is NOT lifted ───────
+    // Lambda-lifting forwards captured module-level block/loop bindings; a nested state-machine
+    // function that captures a local of an enclosing FUNCTION still cannot be lowered (it stays
+    // nested and fails to compile, a clean failure — never a miscompile). This pins the interpreter
+    // behaviour and asserts the compiler does not miscompile it.
 
     [Theory]
     [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
@@ -300,22 +383,19 @@ public class NestedFunctionLiftingTests
         Assert.Equal("10\n", TestHarness.Run(source, mode));
     }
 
-    // A generator declared inside a module-level loop that captures the loop variable must NOT be
-    // relocated: lifting it out of the loop would silently drop the capture. The compiler may decline
-    // to lower it (a clean failure), but it must never produce the miscompiled empty values.
+    // A block declaration that uses `this`/`arguments`, or has rest/default parameters, is declined
+    // by the lambda-lift (the forwarding arrow cannot faithfully reproduce the call). It must fail
+    // cleanly in compiled mode, never miscompile to a wrong value.
     [Fact]
-    public void GeneratorCapturingModuleLevelLoopVar_IsNotMiscompiled()
+    public void BlockFunction_WithRestParam_CapturingBlockConst_FailsCleanly()
     {
         var source = """
-            const gens: any[] = [];
-            for (let k = 0; k < 3; k++) { function* g() { yield k; } gens.push(g()); }
-            console.log(gens.map((it: any) => it.next().value).join(","));
+            { const b = 1; function f(...args: number[]): number { return b + args.length; } console.log(f(9, 9)); }
             """;
         string compiled;
         try { compiled = TestHarness.RunCompiled(source); }
         catch { compiled = "<compile-or-runtime-error>"; }
-        // The bug produced ",," (three lost captures). Anything but that wrong value is acceptable
-        // here — either a clean failure, or the correct interpreter result if lowering improves.
-        Assert.NotEqual(",,\n", compiled);
+        // The interpreter result is "3"; a clean failure is acceptable, a different (wrong) value is not.
+        Assert.True(compiled == "<compile-or-runtime-error>" || compiled == "3\n", $"unexpected: {compiled}");
     }
 }

--- a/SharpTS.Tests/SharedTests/NumberLocalCaptureTests.cs
+++ b/SharpTS.Tests/SharedTests/NumberLocalCaptureTests.cs
@@ -1,0 +1,53 @@
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests;
+
+/// <summary>
+/// Regression tests for #431: a value-type (number) local captured by a closure must be boxed
+/// before being stored into the closure's object-typed display-class field. The captured-local
+/// fallback in <c>ILEmitter.Calls.Closures.cs</c> (<c>EmitDisplayInstanceFieldPopulation</c>)
+/// loaded the unboxed <c>double</c> straight into the field, leaving a <c>float64</c> where the
+/// verifier expects a reference — invalid IL (<c>StackUnexpected</c>) that segfaulted / threw
+/// <c>AccessViolationException</c> at runtime. The captured-parameter path already boxed; the local
+/// path needed the same guard. Strings/objects (reference types) were unaffected, which is why the
+/// bug only surfaced for number-typed captures.
+/// </summary>
+public class NumberLocalCaptureTests
+{
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void NumberLoopLocal_CapturedByArrow(ExecutionMode mode)
+    {
+        // The #431 repro: a per-iteration number const captured by an arrow.
+        var source = """
+            const fns: any[] = [];
+            for (let i = 0; i < 3; i++) { const v = i; fns.push(() => v); }
+            console.log(fns.map((f: any) => f()).join(","));
+            """;
+        Assert.Equal("0,1,2\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void NumberBlockConst_CapturedByArrow(ExecutionMode mode)
+    {
+        var source = """
+            { const base = 5; const add = (n: number): number => n + base; console.log(add(1)); }
+            """;
+        Assert.Equal("6\n", TestHarness.Run(source, mode));
+    }
+
+    [Fact]
+    public void NumberLoopLocal_CapturedByArrow_CompiledIsConformant()
+    {
+        // Compiled mode snapshots the loop variable per iteration, so capturing the `let` binding
+        // itself (not a fresh per-iteration const) is also conformant: 0,1,2.
+        var source = """
+            const fns: any[] = [];
+            for (let k = 0; k < 3; k++) { fns.push(() => k); }
+            console.log(fns.map((f: any) => f()).join(","));
+            """;
+        Assert.Equal("0,1,2\n", TestHarness.RunCompiled(source));
+    }
+}


### PR DESCRIPTION
## Summary

Completes the compiled-mode scoping cluster #607 / #605 / #562 / #622. The first three were already fixed on `origin/main` (PR #624) and are **verified** here; this PR delivers the remaining work: lowering **capturing** module-block functions/generators/async (#622), fixing a value-type capture crash that blocked it (#431), and relaxing an obsolete lifter guard that completes the #607/#605 story.

## What changed

### #622 — capturing function/generator/async in a module-level block/loop is now lowered
Previously a `function` / `function*` / `async function` declared inside a module-level block or loop that **captured** an enclosing block/loop binding threw `ReferenceError: Undefined variable` in compiled mode (only the non-capturing half was handled). `NestedFunctionLifter` now **lambda-lifts** it:

- the captured bindings become **leading parameters** of a relocated top-level declaration, and
- the in-place declaration is replaced by a block-scoped arrow that **closes over those bindings and forwards them**.

This is the only route that lowers a capturing **generator/async** — the compiler can't emit one as a capturing closure, but it can emit a top-level state machine that takes the captures as parameters. It's also **conformant** for the loop case: each iteration builds a fresh closure, so

```ts
const gens: any[] = [];
for (let k = 0; k < 3; k++) { function* g() { yield k; } gens.push(g()); }
console.log(gens.map((it: any) => it.next().value).join(",")); // compiled: 0,1,2
```

The lift **declines cleanly** (stays nested → same clean failure as before, never a miscompile) for rest/default parameters or `this`/`arguments` usage. The type checker already enforces declaration-before-use, so the arrow's per-position snapshot of each capture is well-defined.

### #431 — value-type local captured by a closure emitted invalid IL (crash)
A number-typed local captured by a closure was stored into the closure's `object`-typed display-class field **without boxing**, leaving a `float64` where the verifier expects a reference → `StackUnexpected` / `AccessViolationException`. `EmitDisplayInstanceFieldPopulation` now boxes value-type locals in the captured-local fallback, mirroring the captured-parameter path. This also unblocked #622's number-typed `base = 5` repro and makes compiled loop-variable capture conformant.

### #607 / #605 — name-collision guard relaxed (cluster completion)
The lifter declined to relocate a nested generator/async whose name collided with a top-level binding — a pre-#607 workaround against the injected alias being hijacked. Now that an in-scope local correctly shadows a same-named module top-level function (#607, fixed in #624), the guard is unnecessary for inside-function candidates, which previously failed with **"Yield not supported in this context"**. The guard is kept for module-block candidates (whose injected `var` alias hoists to module scope).

## Verification
- Full unit suite: **12379 passed / 0 failed**
- Test262 (interp + compiled): **21 / 0**, baselines unchanged
- TypeScript conformance: **31 / 0**, baselines unchanged
- New tests: `NestedFunctionLiftingTests` (#622 plain/generator/async, multi-capture, self-recursion, name-collision, clean-decline) and `NumberLocalCaptureTests` (#431).

## Issues filed along the way (out of scope here)
- #633 — interpreter doesn't create per-iteration `let` bindings for captured loop variables (compiled mode now does; interpreter still reads the final value).
- #634 — `GeneratorArrowLifter` doesn't recurse into `for`/`for-of`/`for-in`/`do-while`/`try`/`switch`/labeled statements (generator function expression there fails to type-check).
- #635 — `async function` **expressions** don't parse.

Closes #622
Closes #431
