### PR TITLE
Fix #505/#506/#510/#529/#530: inherited & built-in member visibility + generic-fn-type arrow constraint

### DIFF
--- a/Runtime/BuiltIns/BuiltInTypes.cs
+++ b/Runtime/BuiltIns/BuiltInTypes.cs
@@ -1170,13 +1170,56 @@ public static class BuiltInTypes
         "toArray", "forEach", "some", "every", "find",
     ];
 
+    // Apparent members of the remaining GetXxxMemberType-backed built-ins (#530, follow-up to #512):
+    // Error (and subclasses), Timeout, Buffer, EventEmitter, AbortController, AbortSignal. As with the
+    // lists above, every listed name must resolve through its GetXxxMemberType switch
+    // (BuiltInApparentMembersTests asserts this). Function is intentionally excluded — its members
+    // (.call/.apply/.bind and call signatures) depend on the function's own signature, so it does not
+    // fit this type-argument-independent name projection.
+
+    private static readonly string[] ErrorMemberNames = ["name", "message", "stack", "cause", "toString"];
+
+    // AggregateError additionally exposes `errors` (see GetErrorMemberType).
+    private static readonly string[] AggregateErrorMemberNames =
+        ["name", "message", "stack", "cause", "toString", "errors"];
+
+    private static readonly string[] TimeoutMemberNames = ["ref", "unref", "hasRef", "toString"];
+
+    private static readonly string[] BufferMemberNames =
+    [
+        "length", "toString", "slice", "copy", "compare", "equals", "fill", "write",
+        "readUInt8", "writeUInt8", "toJSON",
+        "readInt8", "readUInt16LE", "readUInt16BE", "readUInt32LE", "readUInt32BE",
+        "readInt16LE", "readInt16BE", "readInt32LE", "readInt32BE",
+        "readFloatLE", "readFloatBE", "readDoubleLE", "readDoubleBE",
+        "readBigInt64LE", "readBigInt64BE", "readBigUInt64LE", "readBigUInt64BE",
+        "writeInt8", "writeUInt16LE", "writeUInt16BE", "writeUInt32LE", "writeUInt32BE",
+        "writeInt16LE", "writeInt16BE", "writeInt32LE", "writeInt32BE",
+        "writeFloatLE", "writeFloatBE", "writeDoubleLE", "writeDoubleBE",
+        "writeBigInt64LE", "writeBigInt64BE", "writeBigUInt64LE", "writeBigUInt64BE",
+        "indexOf", "includes", "swap16", "swap32", "swap64",
+    ];
+
+    private static readonly string[] EventEmitterMemberNames =
+    [
+        "on", "addListener", "once", "off", "removeListener", "emit", "removeAllListeners",
+        "listeners", "rawListeners", "listenerCount", "eventNames",
+        "prependListener", "prependOnceListener", "setMaxListeners", "getMaxListeners",
+    ];
+
+    private static readonly string[] AbortControllerMemberNames = ["signal", "abort"];
+
+    private static readonly string[] AbortSignalMemberNames =
+        ["aborted", "reason", "onabort", "throwIfAborted", "addEventListener", "removeEventListener"];
+
     /// <summary>
     /// Resolves the type of a single instance member on a structurally-decomposable built-in object
-    /// type (Date/RegExp/Map/Set/Promise and the weak/iterator variants), or null when
-    /// <paramref name="type"/> is not such a type or the member is absent. Delegates to the same
-    /// per-type GetXxxMemberType resolvers that <c>value.member</c> reads use, so member access,
-    /// structural assignability, and conditional infer-matching agree on one model. The set of
-    /// handled types matches <see cref="GetInstanceMemberNames"/>.
+    /// type (Date/RegExp/Map/Set/Promise, the weak/iterator variants, and Error/Timeout/Buffer/
+    /// EventEmitter/AbortController/AbortSignal), or null when <paramref name="type"/> is not such a
+    /// type or the member is absent. Delegates to the same per-type GetXxxMemberType resolvers that
+    /// <c>value.member</c> reads use, so member access, structural assignability, and conditional
+    /// infer-matching agree on one model. The set of handled types matches
+    /// <see cref="GetInstanceMemberNames"/>.
     /// </summary>
     public static TypeInfo? GetInstanceMemberType(TypeInfo type, string name) => type switch
     {
@@ -1192,6 +1235,12 @@ public static class BuiltInTypes
         TypeInfo.Iterator it => GetIteratorMemberType(name, it.ElementType),
         TypeInfo.Generator g => GetIteratorMemberType(name, g.YieldType),
         TypeInfo.AsyncGenerator ag => GetIteratorMemberType(name, ag.YieldType),
+        TypeInfo.Error e => GetErrorMemberType(name, e.Name),
+        TypeInfo.Timeout => GetTimeoutMemberType(name),
+        TypeInfo.Buffer => GetBufferMemberType(name),
+        TypeInfo.EventEmitter => GetEventEmitterMemberType(name),
+        TypeInfo.AbortController => GetAbortControllerMemberType(name),
+        TypeInfo.AbortSignal => GetAbortSignalMemberType(name),
         _ => null
     };
 
@@ -1213,6 +1262,13 @@ public static class BuiltInTypes
         TypeInfo.FinalizationRegistry => FinalizationRegistryMemberNames,
         TypeInfo.Promise => PromiseMemberNames,
         TypeInfo.Iterator or TypeInfo.Generator or TypeInfo.AsyncGenerator => IteratorMemberNames,
+        TypeInfo.Error { Name: "AggregateError" } => AggregateErrorMemberNames,
+        TypeInfo.Error => ErrorMemberNames,
+        TypeInfo.Timeout => TimeoutMemberNames,
+        TypeInfo.Buffer => BufferMemberNames,
+        TypeInfo.EventEmitter => EventEmitterMemberNames,
+        TypeInfo.AbortController => AbortControllerMemberNames,
+        TypeInfo.AbortSignal => AbortSignalMemberNames,
         _ => null
     };
 

--- a/SharpTS.Tests/SharedTests/BuiltInStructuralTypeTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInStructuralTypeTests.cs
@@ -175,4 +175,78 @@ public class BuiltInStructuralTypeTests
             """;
         Assert.Equal("object\n", TestHarness.Run(source, mode));
     }
+
+    // ----- #530: the projection extended to Error (and the other GetXxxMemberType built-ins) -----
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void KeyOf_Error_AcceptsMemberName(ExecutionMode mode)
+    {
+        var source = """
+            const k: keyof Error = "message";
+            console.log(k);
+            """;
+        Assert.Equal("message\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void KeyOf_Error_RejectsNonMember(ExecutionMode mode)
+    {
+        var source = """
+            const k: keyof Error = "notAMember";
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Structural_Error_AssignableToMatchingShape(ExecutionMode mode)
+    {
+        // The verbatim repro from #530: an Error value satisfies a matching structural shape.
+        var source = """
+            const e = new Error("boom");
+            const o: { message: string } = e;
+            console.log(o.message);
+            """;
+        Assert.Equal("boom\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Structural_Error_MissingMember_Rejected(ExecutionMode mode)
+    {
+        var source = """
+            const e = new Error("boom");
+            const o: { notARealErrorMember: string } = e;
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.Run(source, mode));
+    }
+
+    // ----- #529: the weak-type check (TS2559) now sees a built-in source's members -----
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void WeakType_BuiltInSource_NoSharedMember_Rejected(ExecutionMode mode)
+    {
+        // tsc: TS2559 — Date has no properties in common with the all-optional target. Before #529 the
+        // built-in source contributed zero members, so the weak-type check was silently skipped.
+        var source = """
+            const o: { bogus?: number } = new Date();
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void WeakType_BuiltInSource_SharedMember_Accepted(ExecutionMode mode)
+    {
+        // The weak-type rule fires only when NOTHING is in common: a target sharing a member name with
+        // the Date source passes the weak check (and then ordinary structural assignability applies).
+        var source = """
+            const o: { getTime?: () => number } = new Date();
+            console.log(typeof o.getTime);
+            """;
+        Assert.Equal("function\n", TestHarness.Run(source, mode));
+    }
 }

--- a/SharpTS.Tests/TypeCheckerTests/BuiltInApparentMembersTests.cs
+++ b/SharpTS.Tests/TypeCheckerTests/BuiltInApparentMembersTests.cs
@@ -32,6 +32,14 @@ public class BuiltInApparentMembersTests
         yield return ["Iterator", new TypeInfo.Iterator(Any)];
         yield return ["Generator", new TypeInfo.Generator(Any)];
         yield return ["AsyncGenerator", new TypeInfo.AsyncGenerator(Any)];
+        // #530 follow-up: the remaining GetXxxMemberType-backed built-ins.
+        yield return ["Error", new TypeInfo.Error()];
+        yield return ["AggregateError", new TypeInfo.Error("AggregateError")];
+        yield return ["Timeout", new TypeInfo.Timeout()];
+        yield return ["Buffer", new TypeInfo.Buffer()];
+        yield return ["EventEmitter", new TypeInfo.EventEmitter()];
+        yield return ["AbortController", new TypeInfo.AbortController()];
+        yield return ["AbortSignal", new TypeInfo.AbortSignal()];
     }
 
     [Theory]
@@ -74,6 +82,17 @@ public class BuiltInApparentMembersTests
 
         Assert.Equal(iterator, generator);
         Assert.Equal(iterator, asyncGenerator);
+    }
+
+    [Fact]
+    public void AggregateErrorSurfacesErrorsMemberButPlainErrorDoesNot()
+    {
+        // GetErrorMemberType exposes `errors` only for AggregateError, so the apparent-member name
+        // list must be name-aware: AggregateError advertises it, a plain Error does not (#530).
+        Assert.Contains("errors", BuiltInTypes.GetInstanceMemberNames(new TypeInfo.Error("AggregateError"))!);
+        Assert.DoesNotContain("errors", BuiltInTypes.GetInstanceMemberNames(new TypeInfo.Error())!);
+        Assert.NotNull(BuiltInTypes.GetInstanceMemberType(new TypeInfo.Error("AggregateError"), "errors"));
+        Assert.Null(BuiltInTypes.GetInstanceMemberType(new TypeInfo.Error(), "errors"));
     }
 
     [Fact]

--- a/SharpTS.Tests/TypeCheckerTests/InheritedInferMatchTests.cs
+++ b/SharpTS.Tests/TypeCheckerTests/InheritedInferMatchTests.cs
@@ -15,9 +15,10 @@ namespace SharpTS.Tests.TypeCheckerTests;
 /// Each test pins the resolved conditional via an annotation: if <c>J&lt;C&gt;</c> resolves to the
 /// true branch (the inferred member type) the matching-typed assignment is accepted and the
 /// mismatched one throws; if it wrongly took the false branch (<c>"no"</c>) the expectations invert.
-/// Regular (non-<c>declare</c>) classes are used deliberately — <c>declare class</c> currently drops
-/// its <c>extends</c> clause entirely (a separate, broader bug tracked outside this fix), which would
-/// mask the member-source behavior under test here.
+///
+/// Most tests use regular (non-<c>declare</c>) classes, but <c>declare class</c> inheritance is now
+/// covered too: #505 fixed <c>declare class</c> dropping its <c>extends</c> clause, and #506 fixed the
+/// member collectors stopping at a generic-instantiation superclass (<c>extends Base&lt;number&gt;</c>).
 /// </summary>
 public class InheritedInferMatchTests
 {
@@ -256,14 +257,83 @@ public class InheritedInferMatchTests
     [Fact]
     public void DeclareClass_OwnMethod_Matches()
     {
-        // An OWN method on a `declare class` matches — own members are unaffected by the separate
-        // declare-class-superclass-drop bug (#505); only inheritance is. This is the exact repro
-        // form from #461 / PR #498.
+        // An OWN method on a `declare class` matches. This is the exact repro form from #461 / PR #498.
         var source = """
             declare class MyClass { toJSON(): "correct"; }
             type J<T> = T extends { toJSON(): infer R } ? R : "no";
             const z: J<MyClass> = "correct";
             """;
         TestHarness.RunInterpreted(source);
+    }
+
+    // ---- #506: generic-instantiation superclass (`class Sub extends Base<number>`) ----
+
+    [Fact]
+    public void GenericSuperclass_NonGenericSub_InheritedFieldInfers()
+    {
+        // Sub's superclass is Base<number> (an InstantiatedGeneric, not a bare Class). The member
+        // collectors must walk into it and substitute T:=number, so R binds to number. The verbatim
+        // repro #2 from #506.
+        var source = """
+            class Base<T> { value: T; constructor(v: T) { this.value = v; } }
+            class Sub extends Base<number> { extra(): void {} }
+            type J<T> = T extends { value: infer R } ? R : "no";
+            let x: J<Sub> = 123;
+            """;
+        TestHarness.RunInterpreted(source);
+    }
+
+    [Fact]
+    public void GenericSuperclass_NonGenericSub_WrongAssignment_IsTypeError()
+    {
+        var source = """
+            class Base<T> { value: T; constructor(v: T) { this.value = v; } }
+            class Sub extends Base<number> { extra(): void {} }
+            type J<T> = T extends { value: infer R } ? R : "no";
+            let x: J<Sub> = "nope";
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void GenericSuperclass_GenericSub_ComposesSubstitutionDownTheChain()
+    {
+        // class Sub<U> extends Base<U>, instantiated as Sub<string>: the substitution composes
+        // (U:=string, then Base's T:=U), so value resolves to string.
+        var source = """
+            class Base<T> { value: T; constructor(v: T) { this.value = v; } }
+            class Sub<U> extends Base<U> { constructor(v: U) { super(v); } }
+            type J<T> = T extends { value: infer R } ? R : "no";
+            let x: J<Sub<string>> = "ok";
+            """;
+        TestHarness.RunInterpreted(source);
+    }
+
+    // ---- #505: declare-class inheritance (the `extends` clause is no longer dropped) ----
+
+    [Fact]
+    public void DeclareClass_InheritedField_Matches()
+    {
+        // declare class Sub extends Base {} — val is inherited from Base. Before #505 the superclass
+        // was dropped, so val was invisible and J<Sub> wrongly took the false branch.
+        var source = """
+            declare class Base { val: "correct"; }
+            declare class Sub extends Base {}
+            type J<T> = T extends { val: infer R } ? R : "no";
+            const z: J<Sub> = "correct";
+            """;
+        TestHarness.RunInterpreted(source);
+    }
+
+    [Fact]
+    public void DeclareClass_InheritedField_WrongAssignment_IsTypeError()
+    {
+        var source = """
+            declare class Base { val: "correct"; }
+            declare class Sub extends Base {}
+            type J<T> = T extends { val: infer R } ? R : "no";
+            const z: J<Sub> = 42;
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
     }
 }

--- a/SharpTS.Tests/TypeCheckerTests/InheritedMemberResolutionTests.cs
+++ b/SharpTS.Tests/TypeCheckerTests/InheritedMemberResolutionTests.cs
@@ -1,0 +1,108 @@
+using SharpTS.Tests.Infrastructure;
+using SharpTS.TypeSystem.Exceptions;
+using Xunit;
+
+namespace SharpTS.Tests.TypeCheckerTests;
+
+/// <summary>
+/// Inherited members must be visible to structural assignability and to member-access type
+/// resolution, across two superclass shapes the shared member collectors
+/// (<c>CollectPublicInstanceMembers</c> / <c>CollectGenericClassMembers</c>) previously stopped at:
+/// <list type="bullet">
+///   <item>a <c>declare class</c>'s <c>extends</c> clause, which <c>CheckDeclareClass</c> dropped
+///   entirely (#505); and</item>
+///   <item>a generic-instantiation superclass <c>extends Base&lt;number&gt;</c> — an
+///   <c>InstantiatedGeneric</c>, not a bare <c>TypeInfo.Class</c>, so the collectors' <c>is
+///   TypeInfo.Class</c> walk exited at it without substituting the base's type arguments (#506).</item>
+/// </list>
+/// The conditional <c>infer</c>-matching side of both lives in <see cref="InheritedInferMatchTests"/>;
+/// this file covers the structural-assignability and member-access consumers of the same collectors.
+/// </summary>
+public class InheritedMemberResolutionTests
+{
+    // ---- #505: member access through a declare class's (previously dropped) extends clause ----
+
+    [Fact]
+    public void DeclareClass_InheritedMemberAccess_ResolvesDeclaredType()
+    {
+        // s.val is inherited from Base and typed "correct"; returning it as a number is TS2322. The
+        // verbatim repro from #505. Before the fix the superclass was dropped, val was not found, and
+        // the function type-checked with no error.
+        var source = """
+            declare class Base { val: "correct"; }
+            declare class Sub extends Base {}
+            function f(s: Sub): number { return s.val; }
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void DeclareClass_InheritedMemberAccess_AcceptsDeclaredType()
+    {
+        var source = """
+            declare class Base { val: "correct"; }
+            declare class Sub extends Base {}
+            function f(s: Sub): "correct" { return s.val; }
+            """;
+        TestHarness.RunInterpreted(source);
+    }
+
+    [Fact]
+    public void DeclareClass_NonClassSuperclass_StillRejected()
+    {
+        // The shared superclass resolver also runs for declare classes, so `extends` of a non-class
+        // remains an error (it is not silently dropped).
+        var source = """
+            type NotAClass = { x: number };
+            declare class Sub extends NotAClass {}
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+
+    // ---- #506: structural assignability through a generic-instantiation superclass ----
+
+    [Fact]
+    public void GenericSuperclass_InstanceAssignableToMatchingInterface()
+    {
+        // Sub inherits `value: number` from Base<number>; tsc accepts the assignment to HasNum. The
+        // verbatim repro #1 from #506 — fails before the fix (Sub's collected member set is empty).
+        var source = """
+            class Base<T> { value: T; constructor(v: T) { this.value = v; } }
+            class Sub extends Base<number> {}
+            interface HasNum { value: number; }
+            const h: HasNum = new Sub(5);
+            console.log(h.value);
+            """;
+        Assert.Equal("5\n", TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void GenericSuperclass_InheritedMemberSubstituted_WrongTargetRejected()
+    {
+        // Sub inherits `value: number`; the target wants string. This must stay rejected — guarding
+        // against a fix that folds the base's members in WITHOUT substituting (leaving `value: any`,
+        // which would wrongly satisfy `{ value: string }`).
+        var source = """
+            class Base<T> { value: T; constructor(v: T) { this.value = v; } }
+            class Sub extends Base<number> {}
+            interface HasStr { value: string; }
+            const h: HasStr = new Sub(5);
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void GenericSuperclass_GenericSub_ComposesSubstitution()
+    {
+        // class Sub<U> extends Base<U> instantiated as Sub<string>: the value member must resolve to
+        // string (U:=string composed into Base's T), so a string shape is assignable.
+        var source = """
+            class Base<T> { value: T; constructor(v: T) { this.value = v; } }
+            class Sub<U> extends Base<U> { constructor(v: U) { super(v); } }
+            interface HasStr { value: string; }
+            const h: HasStr = new Sub<string>("x");
+            console.log(h.value);
+            """;
+        Assert.Equal("x\n", TestHarness.RunInterpreted(source));
+    }
+}

--- a/SharpTS.Tests/TypeCheckerTests/StringTypeResolverArrowScanTests.cs
+++ b/SharpTS.Tests/TypeCheckerTests/StringTypeResolverArrowScanTests.cs
@@ -129,4 +129,45 @@ public class StringTypeResolverArrowScanTests
             """;
         TestHarness.RunInterpreted(source);
     }
+
+    // ---- TryParseGenericFunctionTypeInfo: arrow inside a type-parameter constraint/default (#510) ----
+    // A 7th scanner in the same family, with a different idiom (an early-break `--depth == 0` loop):
+    // the '>' of a `T extends () => number` constraint closed the type-parameter list early, so the
+    // remainder no longer parsed as `(...) => ...` and the whole type collapsed to `any` (a bare
+    // number was then wrongly accepted). FindTopLevelChar also had to skip the arrow's '=' so the
+    // constraint is not mis-split at `=>` into a phantom default.
+
+    [Fact]
+    public void GenericFunctionType_ArrowConstraint_RejectsNonFunction()
+    {
+        // F is a generic function type; 5 is not assignable to it. Before #510, F garbled to `any`
+        // and 5 was accepted.
+        var source = """
+            type F = <T extends () => number>(x: T) => T;
+            let bad: F = 5;
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void GenericFunctionType_ArrowConstraint_AcceptsGenericFunction()
+    {
+        var source = """
+            type F = <T extends () => number>(x: T) => T;
+            const ok: F = <T extends () => number>(x: T): T => x;
+            """;
+        TestHarness.RunInterpreted(source);
+    }
+
+    [Fact]
+    public void GenericFunctionType_ObjectConstraint_StillRejectsNonFunction()
+    {
+        // Control from #510: a non-arrow constraint already resolved to a proper generic function
+        // type, so 5 was correctly rejected. This must keep working.
+        var source = """
+            type G = <T extends { n: number }>(x: T) => T;
+            let bad: G = 5;
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
 }

--- a/TypeSystem/TypeChecker.Compatibility.Helpers.cs
+++ b/TypeSystem/TypeChecker.Compatibility.Helpers.cs
@@ -626,6 +626,17 @@ public partial class TypeChecker
                 foreach (var (name, type) in CollectPublicInstanceMembers(c))
                     yield return (name, type, false);
                 break;
+            default:
+                // Built-in object types (Date, RegExp, Map, …, Error, Buffer, …) model their members
+                // through the shared apparent-members projection, not a member dictionary. Surface them
+                // so the weak-type check (TS2559) sees a built-in source's properties (#529); a built-in
+                // sharing no member with an all-optional target is rejected, matching tsc. Built-in
+                // instance members are never optional.
+                if (BuiltInTypes.GetInstanceMemberNames(t) is { } builtInNames)
+                    foreach (var builtInName in builtInNames)
+                        yield return (builtInName,
+                            BuiltInTypes.GetInstanceMemberType(t, builtInName) ?? new TypeInfo.Any(), false);
+                break;
         }
     }
 
@@ -652,7 +663,7 @@ public partial class TypeChecker
     /// superclasses into a structural member map. Derived members shadow inherited ones.
     /// Used to check structural assignability against an unbranded target class.
     /// </summary>
-    private static Dictionary<string, TypeInfo> CollectPublicInstanceMembers(TypeInfo.Class cls)
+    private Dictionary<string, TypeInfo> CollectPublicInstanceMembers(TypeInfo.Class cls)
     {
         Dictionary<string, TypeInfo> members = [];
         TypeInfo? current = cls;
@@ -672,6 +683,13 @@ public partial class TypeChecker
                     members[name] = type;
             current = GetSuperclass(current);
         }
+        // A generic-instantiation superclass (`class Sub extends Base<number>`) is not a
+        // TypeInfo.Class, so the walk above stops at it. Fold in the generic base's members with its
+        // type arguments substituted; CollectGenericClassMembers recurses through the rest of the
+        // chain. Already-collected derived members shadow these. (#506)
+        if (current is TypeInfo.InstantiatedGeneric { GenericDefinition: TypeInfo.GenericClass baseGc } baseIg)
+            foreach (var (name, type) in CollectGenericClassMembers(baseGc, baseIg.TypeArguments))
+                members.TryAdd(name, type);
         return members;
     }
 
@@ -715,6 +733,15 @@ public partial class TypeChecker
         if (gc.Superclass is TypeInfo.Class sc)
             foreach (var (name, type) in CollectPublicInstanceMembers(sc))
                 members.TryAdd(name, type);
+        // A generic superclass (`class Sub<U> extends Base<U>`): compose substitutions down the chain
+        // by substituting this class's type arguments into the base's, then collect the base's
+        // members under the resulting instantiation (`Sub<number>` → `Base<number>`). (#506)
+        else if (gc.Superclass is TypeInfo.InstantiatedGeneric { GenericDefinition: TypeInfo.GenericClass baseGc } baseIg)
+        {
+            var baseArgs = baseIg.TypeArguments.Select(a => Substitute(a, subs)).ToList();
+            foreach (var (name, type) in CollectGenericClassMembers(baseGc, baseArgs))
+                members.TryAdd(name, type);
+        }
         return members;
     }
 

--- a/TypeSystem/TypeChecker.Compatibility.Structural.cs
+++ b/TypeSystem/TypeChecker.Compatibility.Structural.cs
@@ -193,35 +193,13 @@ public partial class TypeChecker
 
         if (type is TypeInfo.Instance instance)
         {
-            // Handle InstantiatedGeneric
-            if (instance.ClassType is TypeInfo.InstantiatedGeneric ig &&
-                ig.GenericDefinition is TypeInfo.GenericClass gc)
+            // A class instance — possibly a generic instantiation and/or extending a generic-class
+            // instantiation. Walk the hierarchy substituting each instantiation's type arguments so an
+            // own OR inherited generic member (e.g. `value: T` on `Base<number>`) surfaces with its
+            // instantiated type, matching member-access resolution (#506).
+            if (instance.ClassType is TypeInfo.InstantiatedGeneric or TypeInfo.Class)
             {
-                // Check fields first, then methods
-                if (gc.FieldTypes.TryGetValue(name, out var fieldType)) return fieldType;
-                if (gc.Methods.TryGetValue(name, out var methodType)) return methodType;
-                TypeInfo? current = gc.Superclass;
-                while (current != null)
-                {
-                    var fields = GetFieldTypes(current);
-                    if (fields != null && fields.TryGetValue(name, out var superField)) return superField;
-                    var methods = GetMethods(current);
-                    if (methods != null && methods.TryGetValue(name, out var superMethod)) return superMethod;
-                    current = GetSuperclass(current);
-                }
-            }
-            else if (instance.ClassType is TypeInfo.Class classType)
-            {
-                TypeInfo? current = classType;
-                while (current != null)
-                {
-                    // Check fields first, then methods
-                    var fields = GetFieldTypes(current);
-                    if (fields != null && fields.TryGetValue(name, out var fieldType)) return fieldType;
-                    var methods = GetMethods(current);
-                    if (methods != null && methods.TryGetValue(name, out var methodType)) return methodType;
-                    current = GetSuperclass(current);
-                }
+                return ResolveClassMemberTypeSubstituted(instance.ClassType, name);
             }
             // Handle MutableClass (during signature collection)
             else if (instance.ClassType is TypeInfo.MutableClass mutableClass)
@@ -243,6 +221,55 @@ public partial class TypeChecker
                     }
                 }
             }
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Resolves an instance member type by walking a class-like type (a <see cref="TypeInfo.Class"/> or
+    /// generic-class <see cref="TypeInfo.InstantiatedGeneric"/>) from most-derived to base, substituting
+    /// each generic instantiation's type arguments — composed down the chain — into the resolved member.
+    /// So <c>value: T</c> declared on <c>Base&lt;T&gt;</c> surfaces as <c>number</c> for an instance of
+    /// <c>class Sub extends Base&lt;number&gt;</c> (and for <c>new Box&lt;number&gt;()</c> directly),
+    /// keeping structural assignability and type guards consistent with member-access resolution (#506).
+    /// Fields shadow methods at the same level; derived levels shadow base ones. A non-generic level
+    /// performs no substitution (the accumulated map, if any, can only be a no-op on its members).
+    /// Returns null when the member is absent.
+    /// </summary>
+    private TypeInfo? ResolveClassMemberTypeSubstituted(TypeInfo? classLike, string name)
+    {
+        Dictionary<string, TypeInfo>? subs = null;
+        TypeInfo? current = classLike;
+        for (int guard = 0; current != null && guard < 256; guard++)
+        {
+            FrozenDictionary<string, TypeInfo>? fields;
+            FrozenDictionary<string, TypeInfo>? methods;
+            TypeInfo? next;
+            if (current is TypeInfo.InstantiatedGeneric { GenericDefinition: TypeInfo.GenericClass gc } ig)
+            {
+                // Re-express this instantiation's arguments in terms of the original instance (apply the
+                // substitution accumulated from derived levels), then map the generic def's parameters —
+                // e.g. `class Sub<U> extends Base<U>` instantiated Sub<number> composes U:=number into
+                // Base's T:=number.
+                var args = subs is null
+                    ? ig.TypeArguments
+                    : ig.TypeArguments.Select(a => Substitute(a, subs)).ToList();
+                subs = GenericClassSubs(gc, args);
+                fields = gc.FieldTypes;
+                methods = gc.Methods;
+                next = gc.Superclass;
+            }
+            else
+            {
+                fields = GetFieldTypes(current);
+                methods = GetMethods(current);
+                next = GetSuperclass(current);
+            }
+            if (fields is not null && fields.TryGetValue(name, out var fieldType))
+                return subs is null ? fieldType : Substitute(fieldType, subs);
+            if (methods is not null && methods.TryGetValue(name, out var methodType))
+                return subs is null ? methodType : Substitute(methodType, subs);
+            current = next;
         }
         return null;
     }

--- a/TypeSystem/TypeChecker.Statements.Classes.cs
+++ b/TypeSystem/TypeChecker.Statements.Classes.cs
@@ -22,61 +22,7 @@ public partial class TypeChecker
             return;
         }
 
-        TypeInfo? superclass = null;
-        if (classStmt.SuperclassExpr != null)
-        {
-            TypeInfo superType = CheckExpr(classStmt.SuperclassExpr);
-
-            // Handle generic class with type arguments: extends Box<number>
-            if (classStmt.SuperclassTypeArgs != null && classStmt.SuperclassTypeArgs.Count > 0)
-            {
-                if (superType is TypeInfo.GenericClass gc)
-                {
-                    // Convert type argument strings to TypeInfo
-                    var typeArgs = classStmt.SuperclassTypeArgs.Select(ToTypeInfo).ToList();
-                    // Instantiate the generic class with the type arguments
-                    superclass = InstantiateGenericClass(gc, typeArgs);
-                }
-                else if (superType is TypeInfo.Any)
-                {
-                    // Built-in generic globals (Promise<T>, Array<T>) resolve to
-                    // Any in value position; `extends Promise<T>` must not be
-                    // rejected as "non-generic" (#233). Validate the type args
-                    // resolve, then fall through to the Any placeholder below.
-                    foreach (var typeArg in classStmt.SuperclassTypeArgs)
-                        ToTypeInfo(typeArg);
-                }
-                else
-                {
-                    throw new TypeCheckException($"Cannot use type arguments with non-generic class '{Expr.GetSuperclassLeafName(classStmt.SuperclassExpr)}'", tsCode: "TS2315");
-                }
-            }
-            if (superclass == null)
-            {
-                if (superType is TypeInfo.Instance si && si.ClassType is TypeInfo.Class sic)
-                    superclass = sic;
-                else if (superType is TypeInfo.Class sc)
-                    superclass = sc;
-                else if (superType is TypeInfo.GenericClass gc2)
-                {
-                    // Generic class without type arguments - error
-                    throw new TypeCheckException($"Generic class '{gc2.Name}' requires type arguments", tsCode: "TS2314");
-                }
-                else if (superType is TypeInfo.Any)
-                {
-                    // Allow extending Any-typed globals (e.g. Error, TypeError,
-                    // Promise<T>, Array). Create a placeholder class so super()
-                    // calls and constructor validation type-check correctly
-                    // (accept any number of args).
-                    var placeholder = new TypeInfo.MutableClass(Expr.GetSuperclassLeafName(classStmt.SuperclassExpr)!);
-                    placeholder.Methods["constructor"] = new TypeInfo.Function(
-                        [new TypeInfo.Any()], new TypeInfo.Void(), RequiredParams: 0, HasRestParam: true);
-                    superclass = placeholder;
-                }
-                else
-                    throw new TypeCheckException("Superclass must be a class", tsCode: "TS2507");
-            }
-        }
+        TypeInfo? superclass = ResolveDeclaredSuperclass(classStmt);
 
         // Handle generic type parameters
         List<TypeInfo.TypeParameter>? classTypeParams = null;
@@ -866,6 +812,75 @@ public partial class TypeChecker
     }
 
     /// <summary>
+    /// Resolves a class declaration's <c>extends</c> clause to its superclass <see cref="TypeInfo"/>:
+    /// generic instantiation (<c>extends Box&lt;number&gt;</c>), a plain class/instance base, or an
+    /// Any-typed global base (e.g. <c>Error</c>) via a constructor placeholder. Returns <c>null</c>
+    /// when there is no <c>extends</c> clause. Shared by <see cref="CheckClassDeclaration"/> and
+    /// <see cref="CheckDeclareClass"/> so the two paths cannot drift and ambient
+    /// (<c>declare class</c>/<c>@DotNetType</c>) declarations inherit superclass members too (#505).
+    /// Resolved against the enclosing environment (the class's own type parameters are not in scope,
+    /// matching the regular path).
+    /// </summary>
+    private TypeInfo? ResolveDeclaredSuperclass(Stmt.Class classStmt)
+    {
+        if (classStmt.SuperclassExpr == null) return null;
+
+        TypeInfo superType = CheckExpr(classStmt.SuperclassExpr);
+        TypeInfo? superclass = null;
+
+        // Handle generic class with type arguments: extends Box<number>
+        if (classStmt.SuperclassTypeArgs != null && classStmt.SuperclassTypeArgs.Count > 0)
+        {
+            if (superType is TypeInfo.GenericClass gc)
+            {
+                // Convert type argument strings to TypeInfo
+                var typeArgs = classStmt.SuperclassTypeArgs.Select(ToTypeInfo).ToList();
+                // Instantiate the generic class with the type arguments
+                superclass = InstantiateGenericClass(gc, typeArgs);
+            }
+            else if (superType is TypeInfo.Any)
+            {
+                // Built-in generic globals (Promise<T>, Array<T>) resolve to
+                // Any in value position; `extends Promise<T>` must not be
+                // rejected as "non-generic" (#233). Validate the type args
+                // resolve, then fall through to the Any placeholder below.
+                foreach (var typeArg in classStmt.SuperclassTypeArgs)
+                    ToTypeInfo(typeArg);
+            }
+            else
+            {
+                throw new TypeCheckException($"Cannot use type arguments with non-generic class '{Expr.GetSuperclassLeafName(classStmt.SuperclassExpr)}'", tsCode: "TS2315");
+            }
+        }
+        if (superclass == null)
+        {
+            if (superType is TypeInfo.Instance si && si.ClassType is TypeInfo.Class sic)
+                superclass = sic;
+            else if (superType is TypeInfo.Class sc)
+                superclass = sc;
+            else if (superType is TypeInfo.GenericClass gc2)
+            {
+                // Generic class without type arguments - error
+                throw new TypeCheckException($"Generic class '{gc2.Name}' requires type arguments", tsCode: "TS2314");
+            }
+            else if (superType is TypeInfo.Any)
+            {
+                // Allow extending Any-typed globals (e.g. Error, TypeError,
+                // Promise<T>, Array). Create a placeholder class so super()
+                // calls and constructor validation type-check correctly
+                // (accept any number of args).
+                var placeholder = new TypeInfo.MutableClass(Expr.GetSuperclassLeafName(classStmt.SuperclassExpr)!);
+                placeholder.Methods["constructor"] = new TypeInfo.Function(
+                    [new TypeInfo.Any()], new TypeInfo.Void(), RequiredParams: 0, HasRestParam: true);
+                superclass = placeholder;
+            }
+            else
+                throw new TypeCheckException("Superclass must be a class", tsCode: "TS2507");
+        }
+        return superclass;
+    }
+
+    /// <summary>
     /// Type checks a declare class (ambient declaration).
     /// For declare classes, we only validate signatures without requiring implementations.
     /// Used for @DotNetType external type declarations.
@@ -874,6 +889,11 @@ public partial class TypeChecker
     {
         // Save reference to current environment for later registration
         TypeEnvironment parentEnv = _environment;
+
+        // Resolve the `extends` clause in the enclosing environment (before the class's own type
+        // parameters enter scope), so inherited members are visible to consumers of this ambient
+        // type (member access, structural assignability, conditional `infer`) — #505.
+        TypeInfo? superclass = ResolveDeclaredSuperclass(classStmt);
 
         // Handle generic type parameters
         TypeEnvironment classTypeEnv = new(_environment);
@@ -893,6 +913,7 @@ public partial class TypeChecker
         // The mutable class is populated during signature collection and frozen at the end.
         var mutableClass = new TypeInfo.MutableClass(classStmt.Name.Lexeme)
         {
+            Superclass = superclass,
             IsAbstract = classStmt.IsAbstract
         };
         classTypeEnv.Define(classStmt.Name.Lexeme, mutableClass);

--- a/TypeSystem/TypeChecker.TypeParsing.cs
+++ b/TypeSystem/TypeChecker.TypeParsing.cs
@@ -713,7 +713,9 @@ public partial class TypeChecker
         {
             char c = typeName[i];
             if (c == '<') depth++;
-            else if (c == '>' && --depth == 0) { close = i; break; }
+            // Skip the '>' of an arrow '=>' (e.g. a `T extends () => number` constraint), which would
+            // otherwise close the type-parameter list early and collapse the whole type to `any`.
+            else if (c == '>' && (i == 0 || typeName[i - 1] != '=') && --depth == 0) { close = i; break; }
         }
         if (close < 0) return false;
 
@@ -1653,7 +1655,9 @@ public partial class TypeChecker
             char c = str[i];
             if (c == '<' || c == '(' || c == '[' || c == '{') depth++;
             else if (c == ')' || c == ']' || c == '}' || (c == '>' && (i == 0 || str[i - 1] != '='))) depth--;  // Skip > in =>
-            else if (depth == 0 && c == target)
+            // When searching for a type-parameter default '=', skip the '=' of an arrow '=>' so a
+            // constraint/default like `T extends () => number` is not split at the arrow (#510).
+            else if (depth == 0 && c == target && !(target == '=' && i + 1 < str.Length && str[i + 1] == '>'))
             {
                 return i;
             }


### PR DESCRIPTION
Completes five type-system issues. Four concern members the checker failed to "see" on class/built-in sources; #510 is an independent string-resolver scanner fix. All verified together (full suite 12417 passing; TypeScript conformance — assignmentCompatibility + conditional — unchanged against baseline).

## #510 — generic function type with an arrow-typed type-parameter constraint garbled to `any`
`TryParseGenericFunctionTypeInfo`'s close-bracket scan (a 7th scanner in the `=>`-misscan family of #462, with a distinct early-break `--depth == 0` idiom) treated the `>` of `=>` inside a constraint/default as the list-closing bracket, collapsing the whole type to `any`. Applied the established `=>` guard; this newly reached `ParseTypeParamEntry`, exposing that `FindTopLevelChar(s, '=')` matched the arrow's `=` as a default separator — also guarded. `type F = <T extends () => number>(x: T) => T` now resolves with constraint `() => number`.

## #505 — `declare class` dropped its `extends` clause
`CheckDeclareClass` never resolved `SuperclassExpr`, so inherited members of ambient / `@DotNetType` classes were invisible everywhere. Extracted the regular path's superclass resolution into a shared `ResolveDeclaredSuperclass` helper, called from both `CheckClassDeclaration` and `CheckDeclareClass` so they can't drift.

## #506 — structural member resolution stopped at a generic-instantiation superclass
- `CollectPublicInstanceMembers` / `CollectGenericClassMembers` (infer-matching + class-target structural) exited the `is TypeInfo.Class` walk at an `extends Base<number>` base. They now fold in a generic base's members with its type arguments substituted, composing down the chain for `class Sub<U> extends Base<U>`.
- The compatibility `GetMemberType` (interface/record-target assignability, type guards) walked into such a base but returned the *unsubstituted* `T`. Its instance walk is now substitution-aware via a shared `ResolveClassMemberTypeSubstituted`, aligning structural assignability with member-access resolution. This also fixes the pre-existing case where a **direct** `new Box<number>()` was not assignable to `{ value: number }` (same root cause).

## #530 — extend the apparent-members projection to the remaining built-ins
Added Error (name-aware — AggregateError surfaces `errors`), Timeout, Buffer, EventEmitter, AbortController, AbortSignal to `BuiltInTypes.GetInstanceMemberType` / `GetInstanceMemberNames` (follow-up to #512), so they decompose for keyof, structural assignability, and infer-matching. Function is intentionally excluded (its members depend on the function's own signature). #528 (Error type-ref → `TypeInfo.Error`) has landed, so the Error caveat is resolved.

## #529 — weak-type check (TS2559) ignored built-in source members
`NamedMembersWithOptionality` enumerated members only for Record/Interface/Instance/Class, so a built-in source contributed zero members and the check was skipped (`const o: { bogus?: number } = new Date()` was wrongly accepted). Now surfaces built-in members via the same projection.

## Tests
- `StringTypeResolverArrowScanTests` — #510 (arrow constraint reject/accept + non-arrow control).
- `InheritedInferMatchTests` — #505/#506 infer-match (+ updated class doc); `InheritedMemberResolutionTests` (new) — #505/#506 structural assignability & member access.
- `BuiltInApparentMembersTests` — the six new built-ins added to the drift guard + AggregateError `errors` name-awareness.
- `BuiltInStructuralTypeTests` — #530 Error keyof/structural + #529 weak-type accept/reject.

## Notes
- A parallel gap remains in `CollectAllInstanceMembers` (branded-target member enumeration through a generic superclass); filed as a low-priority follow-up — it is near-unobservable because branded targets require same-origin sources.

Closes #505
Closes #506
Closes #510
Closes #529
Closes #530