### PR TITLE
Fix four interpreter-mode conformance bugs (#642, #603, #633, #446)

### DIFF
--- a/Execution/Interpreter.Async.cs
+++ b/Execution/Interpreter.Async.cs
@@ -414,18 +414,28 @@ public partial class Interpreter
         {
             if (forStmt.Initializer != null)
                 await ExecuteStatementAsync(forStmt.Initializer);
+            // ECMA-262 13.7.4 per-iteration bindings for `for (let/const …)`, so
+            // closures capture distinct values across iterations (#633). Mirrors
+            // the synchronous VisitFor path.
+            var perIterationNames = CollectPerIterationBindings(forStmt.Initializer);
+            if (perIterationNames != null)
+                CreatePerIterationEnvironment(loopEnv, perIterationNames);
             while (forStmt.Condition == null || IsTruthy(await EvaluateAsync(forStmt.Condition)))
             {
                 var result = await ExecuteStatementAsync(forStmt.Body);
                 if (result.Type == ExecutionResult.ResultType.Break && result.TargetLabel == null) break;
                 if (result.Type == ExecutionResult.ResultType.Continue && result.TargetLabel == null)
                 {
+                    if (perIterationNames != null)
+                        CreatePerIterationEnvironment(loopEnv, perIterationNames);
                     if (forStmt.Increment != null)
                         await EvaluateAsync(forStmt.Increment);
                     await Task.Yield();
                     continue;
                 }
                 if (result.IsAbrupt) return result;
+                if (perIterationNames != null)
+                    CreatePerIterationEnvironment(loopEnv, perIterationNames);
                 if (forStmt.Increment != null)
                     await EvaluateAsync(forStmt.Increment);
                 ProcessPendingCallbacks();
@@ -514,7 +524,12 @@ public partial class Interpreter
                 case OperatorDescriptor.Comparison:
                     return RuntimeValue.FromBoolean(EvaluateComparison(binary.Operator.Type, l, r));
                 case OperatorDescriptor.Equality eq:
-                    bool equal = l.Equals(r);
+                    // ECMA-262 7.2.16: NaN is never strictly equal to anything
+                    // (including itself). Use IEEE 754 `==` which returns false
+                    // for NaN comparisons; Double.Equals is .NET-specific and
+                    // treats NaN as equal to itself. Mirrors the sync fast path
+                    // in EvaluateBinary (Interpreter.Calls.cs).
+                    bool equal = l == r;
                     return RuntimeValue.FromBoolean(eq.IsNegated ? !equal : equal);
                 case OperatorDescriptor.Bitwise or OperatorDescriptor.BitwiseShift:
                     return RuntimeValue.FromNumber(EvaluateBitwise(binary.Operator.Type, (int)l, (int)r));

--- a/Execution/Interpreter.Properties.cs
+++ b/Execution/Interpreter.Properties.cs
@@ -91,10 +91,9 @@ public partial class Interpreter
             });
             var bound = userFn.BindThis(newThis);
             var result = bound.Call(this, fnArgs);
-            // JS spec: if constructor returns an object, use it; otherwise use the new `this`.
-            return result is SharpTSObject or SharpTSInstance or SharpTSArray
-                ? result
-                : newThis;
+            // JS spec: if the constructor returns an object (incl. a function), use
+            // it; otherwise use the new `this` (#446).
+            return IsConstructorReturnObject(result) ? result : newThis;
         }
 
         // Function expressions (named or anonymous) used as constructors:
@@ -124,9 +123,7 @@ public partial class Interpreter
             });
             var bound = userArrowFn.Bind(newThis);
             var result = bound.Call(this, arrowArgs);
-            return result is SharpTSObject or SharpTSInstance or SharpTSArray
-                ? result
-                : newThis;
+            return IsConstructorReturnObject(result) ? result : newThis;
         }
 
         // Prototype-method wrappers and Object.prototype unbound methods are
@@ -210,9 +207,7 @@ public partial class Interpreter
             });
             var bound = userFn.BindThis(newThis);
             var result = bound.Call(this, [.. args]);
-            return result is SharpTSObject or SharpTSInstance or SharpTSArray
-                or SharpTSRegExp or SharpTSDate or SharpTSMap or SharpTSSet
-                ? result : newThis;
+            return IsConstructorReturnObject(result) ? result : newThis;
         }
         if (callable is SharpTSArrowFunction arrowFn && arrowFn.HasOwnThis)
         {
@@ -228,9 +223,7 @@ public partial class Interpreter
             });
             var bound = arrowFn.Bind(newThis);
             var result = bound.Call(this, [.. args]);
-            return result is SharpTSObject or SharpTSInstance or SharpTSArray
-                or SharpTSRegExp or SharpTSDate or SharpTSMap or SharpTSSet
-                ? result : newThis;
+            return IsConstructorReturnObject(result) ? result : newThis;
         }
         // Built-in constructor (e.g. RegExp via SharpTSBuiltInConstructor).
         // BuiltInConstructorFactory handles the factory dispatch.
@@ -245,6 +238,28 @@ public partial class Interpreter
         }
         throw new InterpreterException("TypeError: Construct called on non-callable.");
     }
+
+    /// <summary>
+    /// ECMA-262 §10.2.2 [[Construct]]: when a constructor body returns a value,
+    /// <c>new</c> yields that value only if it is an <em>Object</em>; a primitive
+    /// return (number, string, boolean, symbol, bigint, null, undefined) is ignored
+    /// and the freshly-constructed <c>this</c> is used instead. Functions and arrays
+    /// are ordinary objects, so a returned function/arrow wins (#446) — matching
+    /// tsc/node and the compiled <c>NewOnFunction</c> path. Centralizes the decision
+    /// so every construct-return site stays consistent.
+    /// </summary>
+    private static bool IsConstructorReturnObject(object? result) => result switch
+    {
+        null => false,
+        SharpTSUndefined => false,
+        double => false,
+        bool => false,
+        string => false,
+        SharpTSSymbol => false,
+        SharpTSBigInt => false,
+        System.Numerics.BigInteger => false,
+        _ => true,
+    };
 
     private RuntimeValue EvaluateNew(Expr.New newExpr)
     {
@@ -315,10 +330,7 @@ public partial class Interpreter
             });
             var bound = userFn.BindThis(newThis);
             var result = bound.Call(this, fnArgs);
-            return RuntimeValue.FromBoxed(result is SharpTSObject or SharpTSInstance or SharpTSArray
-                or SharpTSRegExp or SharpTSDate or SharpTSMap or SharpTSSet
-                ? result
-                : newThis);
+            return RuntimeValue.FromBoxed(IsConstructorReturnObject(result) ? result : newThis);
         }
 
         // Function expressions used as constructors — same shape as
@@ -344,10 +356,7 @@ public partial class Interpreter
             });
             var bound = userArrowFn.Bind(newThis);
             var result = bound.Call(this, arrowArgs);
-            return RuntimeValue.FromBoxed(result is SharpTSObject or SharpTSInstance or SharpTSArray
-                or SharpTSRegExp or SharpTSDate or SharpTSMap or SharpTSSet
-                ? result
-                : newThis);
+            return RuntimeValue.FromBoxed(IsConstructorReturnObject(result) ? result : newThis);
         }
 
         // Prototype-method wrappers and Object.prototype unbound methods are

--- a/Execution/Interpreter.cs
+++ b/Execution/Interpreter.cs
@@ -2020,6 +2020,13 @@ public partial class Interpreter : IDisposable
             // Execute initializer once (defines loop variable in loopEnv)
             if (forStmt.Initializer != null)
                 Execute(forStmt.Initializer);
+            // ECMA-262 13.7.4: a `for (let/const …)` loop gives each iteration its
+            // own bindings for the loop variables, so closures created in different
+            // iterations capture distinct values (#633). `var`/expression
+            // initializers share a single binding and keep the no-copy fast path.
+            var perIterationNames = CollectPerIterationBindings(forStmt.Initializer);
+            if (perIterationNames != null)
+                CreatePerIterationEnvironment(loopEnv, perIterationNames);
             // Loop with proper continue handling - increment always runs
             while (forStmt.Condition == null || IsTruthy(Evaluate(forStmt.Condition)))
             {
@@ -2029,6 +2036,8 @@ public partial class Interpreter : IDisposable
                 // On continue (unlabeled or to this loop), execute increment then re-test
                 if (shouldContinue)
                 {
+                    if (perIterationNames != null)
+                        CreatePerIterationEnvironment(loopEnv, perIterationNames);
                     if (forStmt.Increment != null)
                         Evaluate(forStmt.Increment);
                     // Yield to allow timer callbacks and other threads to execute
@@ -2036,7 +2045,9 @@ public partial class Interpreter : IDisposable
                     continue;
                 }
                 if (abruptResult.HasValue) return abruptResult.Value;
-                // Normal completion: execute increment
+                // Normal completion: fresh per-iteration binding, then increment
+                if (perIterationNames != null)
+                    CreatePerIterationEnvironment(loopEnv, perIterationNames);
                 if (forStmt.Increment != null)
                     Evaluate(forStmt.Increment);
                 // Process any pending timer callbacks
@@ -2044,6 +2055,50 @@ public partial class Interpreter : IDisposable
             }
             return ExecutionResult.Success();
         }
+    }
+
+    /// <summary>
+    /// Returns the variable names a <c>for</c> initializer binds that require a
+    /// fresh binding per iteration (ECMA-262 13.7.4): <c>let</c>/<c>const</c>
+    /// declarations. Returns <c>null</c> for <c>var</c> or expression
+    /// initializers, which share a single binding across the whole loop.
+    /// </summary>
+    private static List<string>? CollectPerIterationBindings(Stmt? initializer)
+    {
+        switch (initializer)
+        {
+            // `let`/`const` in a for-initializer parse to Stmt.Var with IsVar=false.
+            case Stmt.Var v when !v.IsVar:
+                return [v.Name.Lexeme];
+            case Stmt.Const c:
+                return [c.Name.Lexeme];
+            // Multi-declarator initializers (`for (let i = 0, j = 10; …)`).
+            case Stmt.Sequence seq:
+                List<string>? names = null;
+                foreach (var s in seq.Statements)
+                {
+                    var sub = CollectPerIterationBindings(s);
+                    if (sub != null) (names ??= []).AddRange(sub);
+                }
+                return names;
+            default:
+                return null;
+        }
+    }
+
+    /// <summary>
+    /// ECMA-262 13.7.4.8 CreatePerIterationEnvironment: copies the current value
+    /// of each loop variable into a fresh environment that is a sibling of the
+    /// loop environment (same enclosing scope, so the resolver's static scope
+    /// distances stay valid) and makes it the active scope. Closures created in
+    /// the next iteration capture this distinct binding rather than a shared slot.
+    /// </summary>
+    private void CreatePerIterationEnvironment(RuntimeEnvironment loopEnv, List<string> names)
+    {
+        var iterationEnv = new RuntimeEnvironment(loopEnv.Enclosing);
+        foreach (var name in names)
+            iterationEnv.Define(name, _environment.GetAt(0, name));
+        _environment = iterationEnv;
     }
 
     internal ExecutionResult VisitForOf(Stmt.ForOf forOf) => ExecuteForOf(forOf);

--- a/Runtime/Types/SharpTSFunction.cs
+++ b/Runtime/Types/SharpTSFunction.cs
@@ -234,7 +234,11 @@ public class SharpTSFunction : ISharpTSCallable, ITypeCategorized
             throw ThrowException.FromResult(result.Value.ToObject());
         }
 
-        return null;
+        // A function that completes without an explicit `return <expr>` evaluates
+        // to JS `undefined`, not `null`. Return the sentinel (matching CallV2's
+        // RuntimeValue.Undefined) so getters/private methods invoked via this
+        // boxed path observe `undefined` for off-the-end completion (#603).
+        return SharpTSUndefined.Instance;
     }
 
     /// <summary>

--- a/SharpTS.Tests/SharedTests/AsyncNaNStrictEqualityTests.cs
+++ b/SharpTS.Tests/SharedTests/AsyncNaNStrictEqualityTests.cs
@@ -1,0 +1,149 @@
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests;
+
+/// <summary>
+/// Regression tests for #642: in the interpreter's async execution path, the number fast-path for
+/// equality used <c>Double.Equals</c> (which treats <c>NaN.Equals(NaN)</c> as true) instead of
+/// IEEE 754 <c>==</c>. So <c>NaN === NaN</c> inside an <c>async function</c> wrongly returned
+/// <c>true</c> (and <c>NaN !== NaN</c> wrongly returned <c>false</c>), while top-level code, sync
+/// functions, generators, and compiled mode were all correct (per ECMA-262 7.2.16 NaN is never
+/// equal to anything, including itself).
+///
+/// <para>The fix mirrors the synchronous fast path (<c>EvaluateBinary</c> in
+/// <c>Interpreter.Calls.cs</c>): <c>EvaluateBinaryAsync</c> now compares with <c>l == r</c>. These
+/// tests assert the corrected NaN behavior in every async/generator state-machine context and pin
+/// the already-correct contexts as cross-mode parity, plus guard that ordinary number equality is
+/// unaffected by the change.</para>
+/// </summary>
+public class AsyncNaNStrictEqualityTests
+{
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AsyncFunction_NaNStrictEquality(ExecutionMode mode)
+    {
+        // The exact repro from #642.
+        var source = """
+            async function main() {
+                console.log(NaN === NaN);
+                const x = NaN;
+                console.log(x === x);
+                console.log(NaN !== NaN);
+            }
+            main();
+            """;
+        Assert.Equal("false\nfalse\ntrue\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AsyncFunction_ComputedNaN_NotEqual(ExecutionMode mode)
+    {
+        // A NaN produced at runtime (not the literal) — exercises the same fast path.
+        var source = """
+            async function main() {
+                const n = Math.sqrt(-1);
+                console.log(n === n);
+                console.log(n !== n);
+            }
+            main();
+            """;
+        Assert.Equal("false\ntrue\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AsyncFunction_AfterAwait_NaNStillNotEqual(ExecutionMode mode)
+    {
+        // Equality evaluated after a suspension point still runs through the async fast path.
+        var source = """
+            async function main() {
+                await Promise.resolve(0);
+                console.log(NaN === NaN);
+            }
+            main();
+            """;
+        Assert.Equal("false\n", TestHarness.Run(source, mode));
+    }
+
+    // Interpreted-only: this issue (#642) is the interpreter async path. Compiled async ARROWS
+    // still evaluate NaN strict equality with loose/Double.Equals semantics (NaN === NaN → true) —
+    // a gap in #600's compiled coverage that does NOT affect compiled async *functions* or async
+    // *generators* (both correct). Tracked by #648.
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void AsyncArrow_NaNStrictEquality_Interpreted(ExecutionMode mode)
+    {
+        var source = """
+            const r = async () => {
+                console.log(NaN === NaN);
+                console.log(NaN !== NaN);
+            };
+            r();
+            """;
+        Assert.Equal("false\ntrue\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AsyncGenerator_NaNStrictEquality(ExecutionMode mode)
+    {
+        var source = """
+            async function* g() {
+                yield (NaN === NaN);
+                yield (NaN !== NaN);
+            }
+            async function main() {
+                for await (const x of g()) console.log(x);
+            }
+            main();
+            """;
+        Assert.Equal("false\ntrue\n", TestHarness.Run(source, mode));
+    }
+
+    // ---- Already-correct contexts: assert cross-mode parity so they don't regress ----
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void TopLevel_NaNStrictEquality(ExecutionMode mode)
+    {
+        var source = """
+            console.log(NaN === NaN);
+            console.log(NaN !== NaN);
+            """;
+        Assert.Equal("false\ntrue\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Generator_NaNStrictEquality(ExecutionMode mode)
+    {
+        var source = """
+            function* g() {
+                yield (NaN === NaN);
+                yield (NaN !== NaN);
+            }
+            for (const x of g()) console.log(x);
+            """;
+        Assert.Equal("false\ntrue\n", TestHarness.Run(source, mode));
+    }
+
+    // ---- Guard: ordinary number equality is unaffected by the Double.Equals -> == change ----
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AsyncFunction_OrdinaryNumberEquality_Unaffected(ExecutionMode mode)
+    {
+        var source = """
+            async function main() {
+                console.log(2 === 2);
+                console.log(2 === 3);
+                console.log(2 !== 3);
+                console.log(0 === -0);
+            }
+            main();
+            """;
+        Assert.Equal("true\nfalse\ntrue\ntrue\n", TestHarness.Run(source, mode));
+    }
+}

--- a/SharpTS.Tests/SharedTests/ConstructorReturnValueTests.cs
+++ b/SharpTS.Tests/SharedTests/ConstructorReturnValueTests.cs
@@ -1,0 +1,163 @@
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests;
+
+/// <summary>
+/// Regression tests for #446: per ECMA-262 §10.2.2 [[Construct]], when a constructor body returns
+/// an <i>Object</i>, that object becomes the result of <c>new</c>; a primitive return is ignored
+/// and the freshly-constructed <c>this</c> is used. Functions are ordinary objects, so a returned
+/// function/arrow must win.
+///
+/// <para>The interpreter's construct-return sites gated on
+/// <c>result is SharpTSObject or SharpTSInstance or SharpTSArray …</c>, which omitted callables —
+/// so a returned function fell through to <c>this</c> (and two of the sites even omitted
+/// Map/Date/RegExp). They now share a single <c>IsConstructorReturnObject</c> helper that returns
+/// the value for any non-primitive, matching tsc/node and the compiled <c>NewOnFunction</c> path.
+/// Compiled mode was already correct, so every case asserts cross-mode parity.</para>
+/// </summary>
+public class ConstructorReturnValueTests
+{
+    // ---- The issue repro: a constructor returning an arrow yields the arrow, not `this` ----
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ConstructorReturningArrow_YieldsArrow(ExecutionMode mode)
+    {
+        var source = """
+            function Make(this: any, v: string) {
+                this.v = v;
+                return () => "fn-result:" + v;
+            }
+            const f: any = new (Make as any)("X");
+            console.log(typeof f);
+            console.log(typeof f === "function" ? f() : "NOT CALLABLE");
+            """;
+        // f is the returned arrow: it's a function and is callable (it is NOT the constructed
+        // `this`, which would not be callable). (We avoid asserting `typeof f.v` here: reading a
+        // missing property off a function value returns null in compiled mode — an unrelated gap
+        // tracked by #651 — so it isn't a clean cross-mode signal for #446.)
+        Assert.Equal("function\nfn-result:X\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void FunctionExpressionConstructorReturningArrow_YieldsArrow(ExecutionMode mode)
+    {
+        // The function-expression construct path (SharpTSArrowFunction with HasOwnThis).
+        var source = """
+            const Make: any = function (this: any, v: string) {
+                this.v = v;
+                return () => "expr:" + v;
+            };
+            const g: any = new Make("Y");
+            console.log(typeof g);
+            console.log(g());
+            """;
+        Assert.Equal("function\nexpr:Y\n", TestHarness.Run(source, mode));
+    }
+
+    // ---- Other object return types win too ----
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ConstructorReturningObject_YieldsObject(ExecutionMode mode)
+    {
+        var source = """
+            function F(this: any) { this.a = 1; return { b: 2 }; }
+            const o: any = new (F as any)();
+            console.log(o.a, o.b);
+            """;
+        // The returned literal wins, so `a` (set on the discarded `this`) is undefined and `b` is 2.
+        Assert.Equal("undefined 2\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ConstructorReturningArray_YieldsArray(ExecutionMode mode)
+    {
+        var source = """
+            function F(this: any) { this.a = 1; return [9, 8]; }
+            const arr: any = new (F as any)();
+            console.log(Array.isArray(arr), arr[0], arr[1]);
+            """;
+        Assert.Equal("true 9 8\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ConstructorReturningClassInstance_YieldsInstance(ExecutionMode mode)
+    {
+        var source = """
+            class Other { tag = "other"; }
+            function F(this: any) { this.a = 1; return new Other(); }
+            const r: any = new (F as any)();
+            console.log(r.tag, r.a);
+            """;
+        Assert.Equal("other undefined\n", TestHarness.Run(source, mode));
+    }
+
+    // ---- Primitive returns are ignored: `this` wins ----
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ConstructorReturningNumber_YieldsThis(ExecutionMode mode)
+    {
+        var source = """
+            function F(this: any) { this.a = 1; return 42; }
+            const r: any = new (F as any)();
+            console.log(typeof r, r.a);
+            """;
+        Assert.Equal("object 1\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ConstructorReturningString_YieldsThis(ExecutionMode mode)
+    {
+        var source = """
+            function F(this: any) { this.a = 1; return "hi"; }
+            const r: any = new (F as any)();
+            console.log(typeof r, r.a);
+            """;
+        Assert.Equal("object 1\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ConstructorReturningBoolean_YieldsThis(ExecutionMode mode)
+    {
+        var source = """
+            function F(this: any) { this.a = 1; return true; }
+            const r: any = new (F as any)();
+            console.log(typeof r, r.a);
+            """;
+        Assert.Equal("object 1\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ConstructorReturningNull_YieldsThis(ExecutionMode mode)
+    {
+        var source = """
+            function F(this: any) { this.a = 1; return null; }
+            const r: any = new (F as any)();
+            console.log(typeof r, r.a);
+            """;
+        Assert.Equal("object 1\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ConstructorFallingOffEnd_YieldsThis(ExecutionMode mode)
+    {
+        // No return at all — `this` wins. (Interacts with #603: the boxed Call now returns the
+        // undefined sentinel off the end, which is still a primitive, so `this` is used.)
+        var source = """
+            function F(this: any) { this.a = 1; }
+            const r: any = new (F as any)();
+            console.log(typeof r, r.a);
+            """;
+        Assert.Equal("object 1\n", TestHarness.Run(source, mode));
+    }
+}

--- a/SharpTS.Tests/SharedTests/ForLoopPerIterationBindingTests.cs
+++ b/SharpTS.Tests/SharedTests/ForLoopPerIterationBindingTests.cs
@@ -1,0 +1,186 @@
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests;
+
+/// <summary>
+/// Regression tests for #633: each iteration of a <c>for (let/const …)</c> loop must get its own
+/// binding for the loop variable(s) (ECMA-262 13.7.4 CreatePerIterationEnvironment), so closures
+/// (and generators) created in different iterations capture distinct values.
+///
+/// <para>Before the fix the tree-walking interpreter reused a single environment slot for the loop
+/// variable across iterations, so a closure capturing the loop variable read its <i>final</i> value
+/// (e.g. <c>3,3,3</c> instead of <c>0,1,2</c>). Compiled mode (after the #431 box fix) already
+/// snapshots per iteration, so this was an interpreter-vs-compiler divergence as well as a
+/// conformance bug. The fix copies the loop variables into a fresh sibling environment per
+/// iteration in <c>VisitFor</c> / <c>ExecuteForAsyncVT</c>.</para>
+///
+/// <para><c>var</c> declarations and bare-expression initializers share a single binding (no
+/// per-iteration copy) — the negative cases below assert closures over those still read the final
+/// value, matching JS.</para>
+/// </summary>
+public class ForLoopPerIterationBindingTests
+{
+    // ---- Headline repro: arrow capturing the loop `let` ----
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ArrowCapturesLetLoopVar_PerIteration(ExecutionMode mode)
+    {
+        var source = """
+            const fns: any[] = [];
+            for (let k = 0; k < 3; k++) { fns.push(() => k); }
+            console.log(fns.map((f: any) => f()).join(","));
+            """;
+        Assert.Equal("0,1,2\n", TestHarness.Run(source, mode));
+    }
+
+    // The #622 headline repro: a generator created per iteration capturing the loop variable.
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void GeneratorCapturesLetLoopVar_PerIteration(ExecutionMode mode)
+    {
+        var source = """
+            const gens: any[] = [];
+            for (let k = 0; k < 3; k++) { function* g() { yield k; } gens.push(g()); }
+            console.log(gens.map((it: any) => it.next().value).join(","));
+            """;
+        Assert.Equal("0,1,2\n", TestHarness.Run(source, mode));
+    }
+
+    // ---- Multi-declarator: every declared name is per-iteration ----
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void MultiDeclarator_AllNamesPerIteration(ExecutionMode mode)
+    {
+        var source = """
+            const a: any[] = [];
+            for (let i = 0, j = 10; i < 3; i++, j++) { a.push(() => i + ":" + j); }
+            console.log(a.map((f: any) => f()).join(","));
+            """;
+        Assert.Equal("0:10,1:11,2:12\n", TestHarness.Run(source, mode));
+    }
+
+    // ---- continue keeps per-iteration semantics ----
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ContinuePath_StillPerIteration(ExecutionMode mode)
+    {
+        var source = """
+            const c: any[] = [];
+            for (let i = 0; i < 4; i++) { if (i === 2) continue; c.push(() => i); }
+            console.log(c.map((f: any) => f()).join(","));
+            """;
+        Assert.Equal("0,1,3\n", TestHarness.Run(source, mode));
+    }
+
+    // ---- Nested loops: inner closure captures both per-iteration bindings ----
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void NestedLoops_BothBindingsPerIteration(ExecutionMode mode)
+    {
+        var source = """
+            const d: any[] = [];
+            for (let i = 0; i < 2; i++) { for (let j = 0; j < 2; j++) { d.push(() => "" + i + j); } }
+            console.log(d.map((f: any) => f()).join(","));
+            """;
+        Assert.Equal("00,01,10,11\n", TestHarness.Run(source, mode));
+    }
+
+    // ---- Single-statement body (no block braces) ----
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void NoBraceBody_PerIteration(ExecutionMode mode)
+    {
+        var source = """
+            const fns: any[] = [];
+            for (let i = 0; i < 3; i++) fns.push(() => i);
+            console.log(fns.map((f: any) => f()).join(","));
+            """;
+        Assert.Equal("0,1,2\n", TestHarness.Run(source, mode));
+    }
+
+    // ---- Mutating the loop var inside the body is reflected in that iteration's capture ----
+    // i becomes i+10 at capture time, then i-10 before the iteration ends, so the per-iteration
+    // binding settles back to the loop value; the per-iteration copy then carries that forward.
+    // Interpreted-only: compiled mode snapshots the loop var at a different point and yields
+    // 10,11,12 here (a pre-existing per-iteration-snapshot timing gap, tracked by #650). The
+    // interpreter reads the live binding slot, matching node (0,1,2).
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void BodyMutatesLoopVar_CapturesLiveSlot(ExecutionMode mode)
+    {
+        var source = """
+            const g: any[] = [];
+            for (let i = 0; i < 3; i++) { i = i + 10; g.push(() => i); i = i - 10; }
+            console.log(g.map((f: any) => f()).join(","));
+            """;
+        Assert.Equal("0,1,2\n", TestHarness.Run(source, mode));
+    }
+
+    // ---- Negative: `var` is function-scoped — one shared binding, closures read the final value ----
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void VarLoopVar_SharedBinding_ReadsFinal(ExecutionMode mode)
+    {
+        var source = """
+            const fns: any[] = [];
+            for (var k = 0; k < 3; k++) { fns.push(() => k); }
+            console.log(fns.map((f: any) => f()).join(","));
+            """;
+        Assert.Equal("3,3,3\n", TestHarness.Run(source, mode));
+    }
+
+    // ---- Negative: a bare-expression initializer assigns an outer var — one shared binding ----
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ExpressionInitializer_OuterVar_ReadsFinal(ExecutionMode mode)
+    {
+        var source = """
+            let m = 0;
+            const fns: any[] = [];
+            for (m = 0; m < 3; m++) { fns.push(() => m); }
+            console.log(fns.map((f: any) => f()).join(","));
+            """;
+        Assert.Equal("3,3,3\n", TestHarness.Run(source, mode));
+    }
+
+    // ---- A fresh per-iteration const is unaffected (already correct in both modes) ----
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void InnerConstSnapshot_StillWorks(ExecutionMode mode)
+    {
+        var source = """
+            const fns: any[] = [];
+            for (let i = 0; i < 3; i++) { const v = i * 2; fns.push(() => v); }
+            console.log(fns.map((f: any) => f()).join(","));
+            """;
+        Assert.Equal("0,2,4\n", TestHarness.Run(source, mode));
+    }
+
+    // ---- Async function body exercises the ExecuteForAsyncVT per-iteration path ----
+    // Interpreted-only: compiled async-function state machines don't create per-iteration display
+    // classes for a `for (let …)`, so the capture reads the final value (3,3,3) — a pre-existing
+    // compiled gap (the #431 per-iteration box fix doesn't reach async bodies), tracked by #649.
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void AsyncFunctionBody_PerIteration(ExecutionMode mode)
+    {
+        var source = """
+            async function main() {
+                const fns: any[] = [];
+                for (let k = 0; k < 3; k++) { fns.push(() => k); }
+                console.log(fns.map((f: any) => f()).join(","));
+            }
+            main();
+            """;
+        Assert.Equal("0,1,2\n", TestHarness.Run(source, mode));
+    }
+}

--- a/SharpTS.Tests/SharedTests/MethodCompletionValueTests.cs
+++ b/SharpTS.Tests/SharedTests/MethodCompletionValueTests.cs
@@ -19,10 +19,10 @@ namespace SharpTS.Tests.SharedTests;
 /// goes through <c>EmitReturn</c> (untouched) and is asserted to be preserved.</para>
 ///
 /// <para>Public instance/static methods are invoked through the interpreter's boxing-free
-/// <c>CallV2</c> path, which is already spec-correct, so those cases assert cross-mode
-/// parity. Getters and private methods are invoked through the interpreter's legacy boxed
-/// <c>Call</c> path, which still returns <c>null</c> off the end (a separate, pre-existing
-/// gap tracked by #603); those cases are therefore compiled-only here.</para>
+/// <c>CallV2</c> path, which is already spec-correct. Getters and private methods are invoked
+/// through the interpreter's legacy boxed <c>Call</c> path; #603 fixed that path to return the
+/// <c>undefined</c> sentinel off the end as well (mirroring <c>CallV2</c>), so every case below
+/// now asserts cross-mode parity.</para>
 /// </summary>
 public class MethodCompletionValueTests
 {
@@ -186,14 +186,14 @@ public class MethodCompletionValueTests
         Assert.Equal("42,42\n", TestHarness.Run(source, mode));
     }
 
-    // ---- Compiled-only: getters & private methods ----
-    // The interpreter invokes these through the legacy boxed `Call`, which still returns
-    // null off the end (pre-existing gap #603). After #588 the compiled output is correct,
-    // so these assert the compiled behavior; the interpreter side is tracked by #603.
+    // ---- Getters & private methods (interpreter boxed `Call` path) ----
+    // The interpreter invokes these through the legacy boxed `Call`. #588 fixed the compiled
+    // epilogue; #603 fixed the interpreter's boxed `Call` to return the `undefined` sentinel
+    // off the end, so these now assert cross-mode parity (previously compiled-only).
 
     [Theory]
-    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
-    public void OffEndGetter_IsUndefined_Compiled(ExecutionMode mode)
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void OffEndGetter_IsUndefined(ExecutionMode mode)
     {
         var source = """
             class C { get gv() {} }
@@ -203,8 +203,8 @@ public class MethodCompletionValueTests
     }
 
     [Theory]
-    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
-    public void OffEndStaticGetter_IsUndefined_Compiled(ExecutionMode mode)
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void OffEndStaticGetter_IsUndefined(ExecutionMode mode)
     {
         var source = """
             class C { static get gv() {} }
@@ -214,8 +214,8 @@ public class MethodCompletionValueTests
     }
 
     [Theory]
-    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
-    public void GetterFallingOffEndAfterBranch_IsUndefined_Compiled(ExecutionMode mode)
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void GetterFallingOffEndAfterBranch_IsUndefined(ExecutionMode mode)
     {
         var source = """
             class C {
@@ -228,8 +228,8 @@ public class MethodCompletionValueTests
     }
 
     [Theory]
-    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
-    public void OffEndPrivateMethod_IsUndefined_Compiled(ExecutionMode mode)
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void OffEndPrivateMethod_IsUndefined(ExecutionMode mode)
     {
         var source = """
             class C {
@@ -242,8 +242,8 @@ public class MethodCompletionValueTests
     }
 
     [Theory]
-    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
-    public void OffEndPrivateStaticMethod_IsUndefined_Compiled(ExecutionMode mode)
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void OffEndPrivateStaticMethod_IsUndefined(ExecutionMode mode)
     {
         var source = """
             class C {
@@ -256,14 +256,57 @@ public class MethodCompletionValueTests
     }
 
     [Theory]
-    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
-    public void OffEndClassExpressionGetter_IsUndefined_Compiled(ExecutionMode mode)
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void OffEndClassExpressionGetter_IsUndefined(ExecutionMode mode)
     {
         var source = """
             const C = class { get ev() {} };
             console.log(typeof new C().ev);
             """;
         Assert.Equal("undefined\n", TestHarness.Run(source, mode));
+    }
+
+    // Off-the-end getter/private completion must be `undefined`, not CLR `null` — assert via
+    // arithmetic (undefined + 10 === NaN, but null + 10 === 10) so it can't pass by `typeof`
+    // coincidence. This is the #603 distinguisher on the interpreter's boxed `Call` path.
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void OffEndGetter_InArithmetic_IsNaN(ExecutionMode mode)
+    {
+        var source = """
+            class C { get gv() {} }
+            console.log((new C().gv as any) + 10);
+            """;
+        Assert.Equal("NaN\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void OffEndPrivateMethod_StrictlyEqualsUndefined(ExecutionMode mode)
+    {
+        var source = """
+            class C {
+                #secret() {}
+                call() { return this.#secret() === undefined; }
+            }
+            console.log(new C().call());
+            """;
+        Assert.Equal("true\n", TestHarness.Run(source, mode));
+    }
+
+    // Regression for #603: only the *off-the-end* completion becomes `undefined`. A getter with
+    // an explicit `return null` must still observe CLR `null` (boxed `Call` returns via the
+    // Return branch, untouched by the fix).
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void GetterExplicitReturnNull_StaysNull(ExecutionMode mode)
+    {
+        var source = """
+            class C { get gv() { return null; } }
+            console.log(typeof new C().gv);
+            console.log(new C().gv === null);
+            """;
+        Assert.Equal("object\ntrue\n", TestHarness.Run(source, mode));
     }
 
     // ---- @lock decorator: the deferred-return default ----

--- a/SharpTS.Tests/SharedTests/NumberLocalCaptureTests.cs
+++ b/SharpTS.Tests/SharedTests/NumberLocalCaptureTests.cs
@@ -38,16 +38,19 @@ public class NumberLocalCaptureTests
         Assert.Equal("6\n", TestHarness.Run(source, mode));
     }
 
-    [Fact]
-    public void NumberLoopLocal_CapturedByArrow_CompiledIsConformant()
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void NumberLoopVar_CapturedByArrow_IsPerIteration(ExecutionMode mode)
     {
-        // Compiled mode snapshots the loop variable per iteration, so capturing the `let` binding
-        // itself (not a fresh per-iteration const) is also conformant: 0,1,2.
+        // Capturing the `let` loop binding itself (not a fresh per-iteration const). Both modes
+        // give each iteration its own binding: compiled snapshots per iteration; the interpreter
+        // creates a per-iteration environment after #633. See ForLoopPerIterationBindingTests for
+        // the full per-iteration-binding suite.
         var source = """
             const fns: any[] = [];
             for (let k = 0; k < 3; k++) { fns.push(() => k); }
             console.log(fns.map((f: any) => f()).join(","));
             """;
-        Assert.Equal("0,1,2\n", TestHarness.RunCompiled(source));
+        Assert.Equal("0,1,2\n", TestHarness.Run(source, mode));
     }
 }


### PR DESCRIPTION
Fixes four **interpreter-only** divergences from tsc/node. In every case compiled mode was already correct, so these are conformance fixes and interpreter-vs-compiler parity fixes. Each fix is verified cross-mode and the affected previously-compiled-only tests are promoted to run in both modes.

## Fixes

### #642 — `NaN === NaN` returns `true` inside an `async` function
The async binary fast path (`EvaluateBinaryAsync`, `Interpreter.Async.cs`) compared two numbers with `Double.Equals`, which is .NET-specific and treats `NaN.Equals(NaN)` as `true`. It now uses IEEE 754 `==` (NaN-aware), byte-mirroring the synchronous `EvaluateBinary` fast path. (ECMA-262 7.2.16.)

### #603 — getter / private method falling off the end yields `null` not `undefined`
The boxed `SharpTSFunction.Call` returned CLR `null` for an off-the-end completion; it now returns the `undefined` sentinel, matching the boxing-free `CallV2`. Getters and private methods are invoked through this boxed path (public methods already use `CallV2`), so they were the observable cases. An explicit `return null` is unaffected (it flows through the Return branch). The previously compiled-only getter/private cases in `MethodCompletionValueTests` are promoted to cross-mode.

### #633 — closure capturing a `for (let/const …)` loop variable reads the final value
`VisitFor` / `ExecuteForAsyncVT` reused a single environment slot across iterations. They now create a fresh per-iteration binding (ECMA-262 13.7.4 `CreatePerIterationEnvironment`) as a **sibling** of the loop environment (same enclosing scope, so the resolver's static scope distances stay valid), copying the loop variables forward before each condition test and each increment. `var` and bare-expression initializers keep the single-binding fast path. New `ForLoopPerIterationBindingTests` plus a promoted `NumberLocalCaptureTests` case.

### #446 — `new F()` where `F` returns a function yields `this` instead of the function
The six construct-return sites in `Interpreter.Properties.cs` gated on a hand-listed set of object types that omitted callables (and two sites even omitted `Map`/`Date`/`RegExp`). They now share one `IsConstructorReturnObject` helper that returns the value for any non-primitive — matching §10.2.2 and the compiled `NewOnFunction` path.

## Testing
- Full xUnit suite: **12556 passed, 0 failed, 1 skipped**.
- Test262 default subset (interpreter + compiled): **7 passed, 0 failed** — no baseline shift.
- TypeScriptConformance is type-checker-only and untouched by these interpreter changes.

## Follow-ups filed (pre-existing compiled gaps surfaced by the cross-mode tests; out of scope here)
- #648 — compiled async **arrow** mishandles `NaN === NaN` (a #600 coverage gap; async functions/generators are correct).
- #649 — compiled `for (let)` capture inside an **async function** body reads the final value (the #431 per-iteration box fix doesn't reach async state machines).
- #650 — compiled `for (let)` capture diverges when the body mutates and restores the loop variable.
- #651 — compiled: reading a missing property off a function/arrow value yields `null` instead of `undefined`.

The assertions affected by these gaps are marked interpreted-only with tracking references.