### PR TITLE
Fix #570, #639, #468, #594 (narrowing soundness, branded-target collector, module diagnostics, readonly union index)

### DIFF
--- a/SharpTS.Tests/TypeCheckerTests/InheritedMemberResolutionTests.cs
+++ b/SharpTS.Tests/TypeCheckerTests/InheritedMemberResolutionTests.cs
@@ -105,4 +105,53 @@ public class InheritedMemberResolutionTests
             """;
         Assert.Equal("x\n", TestHarness.RunInterpreted(source));
     }
+
+    // ---- #639: the BRANDED-target collector (CollectAllInstanceMembers) also walks a
+    //            generic-instantiation superclass. A target class branded by a private/protected
+    //            member is matched over ALL its members; the inherited generic-base members must be
+    //            in that required set (with the base's type arguments substituted), so a same-origin
+    //            source whose inherited members have incompatible instantiated types is rejected. ----
+
+    [Fact]
+    public void BrandedTarget_GenericBase_SiblingInstantiationSource_Rejected()
+    {
+        // Source and Target share the protected `brand` from Base (same declaration → they pass the
+        // nominal accessibility gate), and have identical OWN members (`ownField: number`). They differ
+        // only in the base instantiation: Target extends Base<number>, Source extends Base<string>.
+        // The inherited `brand`/`baseField` resolve to number on Target but string on Source, so Source
+        // is not assignable to Target — but only once the inherited generic-base members are part of
+        // Target's required set. Before #639 that set omitted them and the assignment was accepted.
+        var source = """
+            class Base<T> {
+                protected brand: T;
+                baseField: T;
+                constructor(v: T) { this.brand = v; this.baseField = v; }
+            }
+            class Target extends Base<number> { ownField: number = 0; }
+            class Source extends Base<string> { ownField: number = 0; constructor() { super("x"); } }
+            const t: Target = new Source();
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void BrandedTarget_GenericBase_MatchingInstantiationSource_Accepted()
+    {
+        // Non-vacuity companion: a source extending the SAME instantiation (Base<number>) inherits
+        // number-typed brand/baseField, matching the target, so the assignment is accepted. This
+        // differs from the rejected case ONLY in the base's type argument, proving the inherited
+        // generic-base members are what the check now consults.
+        var source = """
+            class Base<T> {
+                protected brand: T;
+                baseField: T;
+                constructor(v: T) { this.brand = v; this.baseField = v; }
+            }
+            class Target extends Base<number> { ownField: number = 0; }
+            class Match extends Base<number> { ownField: number = 0; constructor() { super(1); } }
+            const t: Target = new Match();
+            console.log("ok");
+            """;
+        Assert.Equal("ok\n", TestHarness.RunInterpreted(source));
+    }
 }

--- a/SharpTS.Tests/TypeCheckerTests/ModuleDiagnosticAttributionTests.cs
+++ b/SharpTS.Tests/TypeCheckerTests/ModuleDiagnosticAttributionTests.cs
@@ -1,0 +1,67 @@
+using SharpTS.Diagnostics;
+using SharpTS.Modules;
+using SharpTS.TypeSystem;
+using Xunit;
+
+namespace SharpTS.Tests.TypeCheckerTests;
+
+/// <summary>
+/// A type error in a module-mode file (one containing <c>import</c>/<c>export</c>) must be reported
+/// ONCE and with a source location, matching script mode (#468). Two prior defects made module mode
+/// worse than script mode:
+/// <list type="bullet">
+///   <item>The preparatory export-collection pass (<c>CollectModuleExports</c>) fully type-checked
+///   every statement and recorded its errors, then the authoritative second pass recorded them
+///   again — so each error appeared twice.</item>
+///   <item><c>CheckModules</c> never set the <c>_currentStatementLine</c> fallback that the script
+///   path uses, so an error whose throw-site carries no line rendered with no location at all.</item>
+/// </list>
+/// These drive <see cref="TypeChecker.CheckModules"/> through the in-memory resolver and assert on
+/// the collected diagnostics directly (the CLI just prints <c>GetDiagnostics()</c>).
+/// </summary>
+public class ModuleDiagnosticAttributionTests
+{
+    private static IReadOnlyList<Diagnostic> CheckModule(string entry, string source)
+    {
+        var baseDir = Path.Combine(Path.GetTempPath(), $"sharpts_moddiag_{Guid.NewGuid():N}");
+        var entryPath = Path.GetFullPath(Path.Combine(baseDir, entry));
+        var virtualFiles = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            [entryPath] = source,
+        };
+
+        var resolver = new ModuleResolver(entryPath, virtualFiles);
+        var entryModule = resolver.LoadModule(entryPath);
+        var allModules = resolver.GetModulesInOrder(entryModule);
+
+        var checker = new TypeChecker();
+        checker.CheckModules(allModules, resolver);
+        return checker.GetDiagnostics();
+    }
+
+    [Fact]
+    public void ExportModule_LocalTypeError_ReportedOnceWithLocation()
+    {
+        // The verbatim #468 repro: an `export` routes the file through module mode.
+        var diags = CheckModule("main.ts", "export let z: number = 5;\nz = \"hello\";\n");
+
+        var errors = diags.Where(d => d.Severity == DiagnosticSeverity.Error).ToList();
+        Assert.Single(errors);
+        Assert.NotNull(errors[0].Location);
+        Assert.Equal(2, errors[0].Line);
+    }
+
+    [Fact]
+    public void ImportModule_LocalTypeError_ReportedOnceWithLocation()
+    {
+        // An `import` also routes through module mode; a plain local error reproduces the same defects.
+        var diags = CheckModule(
+            "main.ts",
+            "import { readFileSync } from \"fs\";\nlet q: number = 5;\nq = \"hello\";\n");
+
+        var errors = diags.Where(d => d.Severity == DiagnosticSeverity.Error).ToList();
+        Assert.Single(errors);
+        Assert.NotNull(errors[0].Location);
+        Assert.Equal(3, errors[0].Line);
+    }
+}

--- a/SharpTS.Tests/TypeCheckerTests/NarrowingTests/NestedReassignmentNarrowingTests.cs
+++ b/SharpTS.Tests/TypeCheckerTests/NarrowingTests/NestedReassignmentNarrowingTests.cs
@@ -1,0 +1,130 @@
+using SharpTS.Tests.Infrastructure;
+using SharpTS.TypeSystem.Exceptions;
+using Xunit;
+
+namespace SharpTS.Tests.TypeCheckerTests.NarrowingTests;
+
+/// <summary>
+/// A reassignment that takes a variable OUT of its <c>if</c>-guard narrowing must widen that
+/// narrowing for later statements, even when the reassignment is in a nested branch (#570). The gap:
+/// <c>if</c>-guard variable narrowing is applied by redefining the variable in the guard's child
+/// <see cref="SharpTS.TypeSystem.TypeEnvironment"/>; a reassignment inside a further-nested block ran
+/// against a deeper env that is discarded at the join, so the outer narrowing wrongly survived and
+/// SharpTS accepted code <c>tsc</c> rejects.
+///
+/// The fix gates invalidation on whether the assigned value escapes the current narrowing — so a
+/// reassignment that STAYS within the narrowing keeps it (matching <c>tsc</c>, and incidentally
+/// fixing the symmetric loop case where a reassign-to-narrow used to over-widen a still-valid
+/// loop-condition narrowing).
+/// </summary>
+public class NestedReassignmentNarrowingTests
+{
+    // ---- #570: nested-branch reassignment OUT of the narrowing widens the outer guard ----
+
+    [Fact]
+    public void IfGuard_NestedUnguardedReassignToExcluded_WidensNarrowing()
+    {
+        // The verbatim #570 repro. `x` is narrowed to string by the guard; the nested `if (foo)`
+        // reassigns it to undefined, so at `return x.length` it is `string | undefined` again.
+        var source = """
+            function g(x: string | undefined, foo: boolean): number {
+                if (x !== undefined) {
+                    if (foo) { x = undefined; }
+                    return x.length;
+                }
+                return 0;
+            }
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void IfGuard_NestedGuardedReassignToExcluded_WidensNarrowing()
+    {
+        // Sibling shape: the reassignment sits inside a nested guard on a DIFFERENT variable. The
+        // outer narrowing of `x` must still widen at the join.
+        var source = """
+            function g(x: string | undefined, y: string | undefined): number {
+                if (x !== undefined) {
+                    if (y !== undefined) { x = undefined; }
+                    return x.length;
+                }
+                return 0;
+            }
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void IfGuard_NestedReassignWithinNarrowing_KeepsNarrowing()
+    {
+        // No regression: reassigning to a value the guard still admits (a string) keeps `x` narrowed
+        // to string, so `x.length` is fine — matching tsc, which narrows `x` to the assigned type.
+        var source = """
+            function g(x: string | undefined, cond: boolean): number {
+                if (x !== undefined) {
+                    if (cond) { x = "other"; }
+                    return x.length;
+                }
+                return 0;
+            }
+            console.log(g("hello", true));
+            """;
+        Assert.Equal("5\n", TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void IfGuard_DirectReassignToExcluded_StillWidens()
+    {
+        // The same-scope case was already handled; guard against a fix that only patched the nested
+        // path and broke the direct one.
+        var source = """
+            function g(x: string | undefined): number {
+                if (x !== undefined) {
+                    x = undefined;
+                    return x.length;
+                }
+                return 0;
+            }
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+
+    // ---- the symmetric loop case: reassign-to-narrow keeps the loop-condition narrowing ----
+
+    [Fact]
+    public void LoopGuard_NestedReassignWithinNarrowing_KeepsNarrowing()
+    {
+        // The loop-condition narrowing re-holds each iteration; a body reassignment that stays within
+        // it must not widen subsequent uses. Before the gated invalidation this over-widened and the
+        // `x.length` was wrongly rejected.
+        var source = """
+            function h(x: string | undefined, cond: boolean): number {
+                while (x !== undefined) {
+                    if (cond) { x = "other"; }
+                    return x.length;
+                }
+                return 0;
+            }
+            console.log(h("hi", false));
+            """;
+        Assert.Equal("2\n", TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void LoopGuard_NestedReassignToExcluded_StillWidens()
+    {
+        // The soundness direction stays intact for loops: a reassignment to undefined widens, so the
+        // post-reassignment `x.length` is rejected.
+        var source = """
+            function h(x: string | undefined, cond: boolean): number {
+                while (x !== undefined) {
+                    if (cond) { x = undefined; }
+                    return x.length;
+                }
+                return 0;
+            }
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+}

--- a/SharpTS.Tests/TypeCheckerTests/ReadonlyIndexWriteTests.cs
+++ b/SharpTS.Tests/TypeCheckerTests/ReadonlyIndexWriteTests.cs
@@ -66,9 +66,39 @@ public class ReadonlyIndexWriteTests
         AssertTsCode("TS2542", "const a: readonly number[] = [1]; a[\"0\"] = 5;");
     }
 
-    // Note: readonly arrays reached through a *union* (`readonly number[] | number[]`) are a separate,
-    // pre-existing gap — the union collapses the readonly and mutable members during construction — and
-    // are tracked in their own follow-up rather than here, to keep this change scoped to direct writes.
+    // ---- readonly arrays/tuples reached through a *union* reject index writes (#594) ----
+
+    [Fact]
+    public void ReadonlyOrMutableArrayUnion_IndexWrite_RejectedTS2542()
+    {
+        // `readonly number[] | number[]` must keep BOTH members distinct (the string resolver used to
+        // mis-parse it as `readonly (number[] | number[])`, dropping the readonly member). With both
+        // present, the write is invalid for the readonly member, so the whole union write is TS2542.
+        AssertTsCode("TS2542", "function f(u: readonly number[] | number[]): void { u[0] = 1; }");
+    }
+
+    [Fact]
+    public void MutableOrReadonlyArrayUnion_IndexWrite_RejectedTS2542()
+    {
+        // Order-independent: the readonly member rejects the write regardless of its position.
+        AssertTsCode("TS2542", "function f(u: number[] | readonly number[]): void { u[0] = 1; }");
+    }
+
+    [Fact]
+    public void ReadonlyOrMutableTupleUnion_IndexWrite_RejectedTS2542()
+    {
+        // The union-distribution helper previously did not handle tuples at all; a readonly tuple
+        // member now rejects the write too.
+        AssertTsCode("TS2542", "function f(u: readonly [number, number] | [number, number]): void { u[0] = 1; }");
+    }
+
+    [Fact]
+    public void MutableArrayTupleUnion_IndexWrite_Accepted()
+    {
+        // A union of mutable members (array + tuple), where the write is valid for every member,
+        // still accepts — the new tuple/readonly guards must not over-reject writable members.
+        TestHarness.RunInterpreted("function f(u: number[] | [number, number]): void { u[0] = 1; }\nf([1, 2]);");
+    }
 
     // ---- mutable receivers and reads stay accepted (no over-rejection) ----
 

--- a/TypeSystem/TypeChecker.Compatibility.Helpers.cs
+++ b/TypeSystem/TypeChecker.Compatibility.Helpers.cs
@@ -362,7 +362,7 @@ public partial class TypeChecker
     /// provided by the source; accessibility itself is enforced separately by
     /// <see cref="MembersAccessibilityCompatible"/>.
     /// </summary>
-    private static Dictionary<string, TypeInfo> CollectAllInstanceMembers(TypeInfo.Class cls)
+    private Dictionary<string, TypeInfo> CollectAllInstanceMembers(TypeInfo.Class cls)
     {
         Dictionary<string, TypeInfo> members = [];
         TypeInfo? current = cls;
@@ -375,6 +375,14 @@ public partial class TypeChecker
             foreach (var (name, type) in core.Getters) members.TryAdd(name, type);
             current = GetSuperclass(current);
         }
+        // A generic-instantiation superclass (`class Sub extends Base<number>`) is not a
+        // TypeInfo.Class, so the walk above stops at it. Fold in the generic base's members —
+        // including private/protected — with its type arguments substituted, mirroring the public
+        // collector (CollectPublicInstanceMembers, #506) but in all-members mode (#639). Derived
+        // members already collected shadow these.
+        if (current is TypeInfo.InstantiatedGeneric { GenericDefinition: TypeInfo.GenericClass baseGc } baseIg)
+            foreach (var (name, type) in CollectGenericClassMembers(baseGc, baseIg.TypeArguments, includeNonPublic: true))
+                members.TryAdd(name, type);
         return members;
     }
 
@@ -712,26 +720,28 @@ public partial class TypeChecker
     }
 
     /// <summary>
-    /// Collects the public instance members of a generic class with its type arguments substituted
+    /// Collects the instance members of a generic class with its type arguments substituted
     /// (e.g. a field <c>item: T</c> on <c>A&lt;Base&gt;</c> becomes <c>item: Base</c>). Inherited members from a
-    /// non-generic superclass are included verbatim.
+    /// superclass are included with substitutions composed down the chain. By default only public
+    /// members are collected; <paramref name="includeNonPublic"/> additionally includes
+    /// TypeScript private/protected members (the all-members mode used for a branded target, #639).
     /// </summary>
-    private Dictionary<string, TypeInfo> CollectGenericClassMembers(TypeInfo.GenericClass gc, List<TypeInfo> args)
+    private Dictionary<string, TypeInfo> CollectGenericClassMembers(TypeInfo.GenericClass gc, List<TypeInfo> args, bool includeNonPublic = false)
     {
         var subs = GenericClassSubs(gc, args);
         Dictionary<string, TypeInfo> members = [];
         var core = gc.Core;
         foreach (var (name, type) in core.FieldTypes)
-            if (IsPublicMember(core.FieldAccess, name) && !members.ContainsKey(name))
+            if ((includeNonPublic || IsPublicMember(core.FieldAccess, name)) && !members.ContainsKey(name))
                 members[name] = Substitute(type, subs);
         foreach (var (name, type) in core.Methods)
-            if (name != "constructor" && IsPublicMember(core.MethodAccess, name) && !members.ContainsKey(name))
+            if (name != "constructor" && (includeNonPublic || IsPublicMember(core.MethodAccess, name)) && !members.ContainsKey(name))
                 members[name] = Substitute(type, subs);
         foreach (var (name, type) in core.Getters)
             if (!members.ContainsKey(name))
                 members[name] = Substitute(type, subs);
         if (gc.Superclass is TypeInfo.Class sc)
-            foreach (var (name, type) in CollectPublicInstanceMembers(sc))
+            foreach (var (name, type) in (includeNonPublic ? CollectAllInstanceMembers(sc) : CollectPublicInstanceMembers(sc)))
                 members.TryAdd(name, type);
         // A generic superclass (`class Sub<U> extends Base<U>`): compose substitutions down the chain
         // by substituting this class's type arguments into the base's, then collect the base's
@@ -739,7 +749,7 @@ public partial class TypeChecker
         else if (gc.Superclass is TypeInfo.InstantiatedGeneric { GenericDefinition: TypeInfo.GenericClass baseGc } baseIg)
         {
             var baseArgs = baseIg.TypeArguments.Select(a => Substitute(a, subs)).ToList();
-            foreach (var (name, type) in CollectGenericClassMembers(baseGc, baseArgs))
+            foreach (var (name, type) in CollectGenericClassMembers(baseGc, baseArgs, includeNonPublic))
                 members.TryAdd(name, type);
         }
         return members;

--- a/TypeSystem/TypeChecker.Expressions.cs
+++ b/TypeSystem/TypeChecker.Expressions.cs
@@ -1542,9 +1542,28 @@ public partial class TypeChecker
             throw new TypeCheckException($" Cannot assign type '{valueType}' to variable '{assign.Name.Lexeme}' of type '{declaredType}'.", tsCode: AssignmentDiagnosticCode(declaredType, valueType));
         }
 
-        // Invalidate any narrowings affected by this assignment
+        // A reassignment widens the variable's OWN narrowing only when the assigned value falls
+        // OUTSIDE it: tsc keeps `x` narrowed after `x = stillNarrowValue` (a value the guard still
+        // admits) but widens it after a value the guard excluded. The variable's PROPERTY narrowings,
+        // however, describe the now-replaced value and are always stale, so they are dropped either
+        // way. (#570 — and incidentally the loop over-invalidation where a reassign-to-narrow widened
+        // a still-valid loop-condition narrowing.)
         var assignedPath = new Narrowing.NarrowingPath.Variable(assign.Name.Lexeme);
-        InvalidateNarrowingsFor(assignedPath);
+        var currentNarrowedType = GetNarrowing(assignedPath) ?? _environment.Get(assign.Name.Lexeme) ?? declaredType;
+        if (IsCompatible(currentNarrowedType, valueType))
+        {
+            InvalidatePropertyNarrowingsFor(assignedPath);
+        }
+        else
+        {
+            // The value escapes the narrowing: drop the variable's own (context-stack) narrowing and
+            // its descendants, AND widen any enclosing lexical narrowing the context stack can't reach.
+            // `if`-guard variable narrowing lives in a child TypeEnvironment that a nested block's own
+            // env shadows-then-discards, so without WidenEnclosingNarrowing a reassignment inside a
+            // nested branch leaves the outer guard's narrowing in place for later statements (#570).
+            InvalidateNarrowingsFor(assignedPath);
+            WidenEnclosingNarrowing(assign.Name.Lexeme, declaredType);
+        }
 
         // Also restore the declared type in the environment to undo any variable narrowing
         // that was applied via TypeEnvironment.Define() in control flow statements.

--- a/TypeSystem/TypeChecker.Properties.Index.cs
+++ b/TypeSystem/TypeChecker.Properties.Index.cs
@@ -697,7 +697,11 @@ public partial class TypeChecker
 
     /// <summary>
     /// Checks index assignment on a given type (used for delegating from Union types).
-    /// Returns the value type if assignment is valid, null otherwise.
+    /// Returns the value type if assignment is valid, null when the index is structurally invalid
+    /// for the type (the union caller turns null into TS7053). A write to a <b>readonly</b> array or
+    /// tuple member throws TS2542 directly — mirroring the direct-write guard in
+    /// <see cref="CheckSetIndex"/> — so a readonly member of a surviving union makes the whole
+    /// index write TS2542 (#594).
     /// </summary>
     private TypeInfo? CheckSetIndexOnType(TypeInfo objType, TypeInfo indexType, TypeInfo valueType, Expr.SetIndex setIndex)
     {
@@ -732,8 +736,32 @@ public partial class TypeChecker
         // Handle number index
         if (IsNumber(indexType) || indexType is TypeInfo.NumberLiteral)
         {
+            // Tuple member (the main CheckSetIndex path handles tuples; this helper previously did
+            // not, so a union with a tuple member rejected every numeric write). A readonly tuple
+            // rejects the write (TS2542); otherwise the value must match the addressed element. (#594)
+            if (objType is TypeInfo.Tuple tupleType)
+            {
+                if (tupleType.IsReadonly)
+                    throw new TypeCheckException($" Index signature in type '{objType}' only permits reading.", tsCode: "TS2542");
+                if (setIndex.Index is Expr.Literal { Value: double tIdx })
+                {
+                    int i = (int)tIdx;
+                    if (i >= 0 && i < tupleType.ElementTypes.Count)
+                        return IsCompatible(tupleType.ElementTypes[i], valueType) ? valueType : null;
+                    if (tupleType.RestElementType != null && i >= tupleType.ElementTypes.Count)
+                        return IsCompatible(tupleType.RestElementType, valueType) ? valueType : null;
+                    return null; // out of bounds for this constituent
+                }
+                var allTypes = tupleType.ElementTypes.ToList();
+                if (tupleType.RestElementType != null) allTypes.Add(tupleType.RestElementType);
+                return allTypes.All(t => IsCompatible(t, valueType)) ? valueType : null;
+            }
             if (objType is TypeInfo.Array arrayType)
             {
+                // A readonly array member permits reading only — reject the write with TS2542,
+                // mirroring the direct-write guard in CheckSetIndex (#594).
+                if (arrayType.IsReadonly)
+                    throw new TypeCheckException($" Index signature in type '{objType}' only permits reading.", tsCode: "TS2542");
                 // Same out-of-range carve-out as CheckSetIndex above.
                 if (!IsArrayIndexInRange(setIndex.Index))
                     return valueType;

--- a/TypeSystem/TypeChecker.TypeParsing.cs
+++ b/TypeSystem/TypeChecker.TypeParsing.cs
@@ -40,8 +40,14 @@ public partial class TypeChecker
     private TypeInfo ToTypeInfoCore(string typeName)
     {
         // `readonly` array/tuple modifier (preserved by ParseTypeAnnotation): mark the underlying
-        // array/tuple readonly. Other inner types ignore the modifier.
-        if (typeName.StartsWith("readonly ", StringComparison.Ordinal))
+        // array/tuple readonly. Other inner types ignore the modifier. The modifier binds tighter
+        // than `|`/`&`, so it applies only to the array/tuple that immediately follows it: skip this
+        // branch when the remainder still carries a top-level union/intersection operator
+        // (`readonly number[] | number[]` is `(readonly number[]) | number[]`, NOT
+        // `readonly (number[] | number[])`) and let the union/intersection split below own it — each
+        // part then re-enters here and marks its own array/tuple readonly (#594).
+        if (typeName.StartsWith("readonly ", StringComparison.Ordinal)
+            && !HasTopLevelUnionOrIntersection(typeName.AsSpan()))
         {
             var inner = ToTypeInfo(typeName["readonly ".Length..].Trim());
             return inner switch
@@ -385,6 +391,26 @@ public partial class TypeChecker
         }
 
         return new TypeInfo.Any();
+    }
+
+    /// <summary>
+    /// True when <paramref name="typeName"/> contains a top-level (depth-0) union <c>|</c> or
+    /// intersection <c>&amp;</c> separator — i.e. it splits into more than one union/intersection
+    /// part. Allocation-free; mirrors the depth/`=&gt;` handling of <see cref="SplitUnionParts"/>.
+    /// </summary>
+    private static bool HasTopLevelUnionOrIntersection(ReadOnlySpan<char> typeName)
+    {
+        int depth = 0;
+        for (int i = 0; i < typeName.Length; i++)
+        {
+            char c = typeName[i];
+            if (c == '(' || c == '<' || c == '[' || c == '{') depth++;
+            else if (c == ')' || c == ']' || c == '}') depth--;
+            else if (c == '>' && (i == 0 || typeName[i - 1] != '=')) depth--;  // Skip > in =>
+            else if ((c == '|' || c == '&') && depth == 0 && i > 0 && typeName[i - 1] == ' ')
+                return true;
+        }
+        return false;
     }
 
     private List<string> SplitUnionParts(ReadOnlySpan<char> typeName)

--- a/TypeSystem/TypeChecker.cs
+++ b/TypeSystem/TypeChecker.cs
@@ -253,6 +253,44 @@ public partial class TypeChecker
     }
 
     /// <summary>
+    /// Invalidates only the property/element narrowings rooted at <paramref name="basePath"/> (paths
+    /// strictly deeper than it), leaving the base path's OWN narrowing intact. Used when a variable is
+    /// reassigned to a value that stays within its narrowing: the variable itself is still narrowed,
+    /// but its old property narrowings describe a now-replaced value, so they are dropped (#570).
+    /// </summary>
+    private void InvalidatePropertyNarrowingsFor(Narrowing.NarrowingPath basePath)
+    {
+        if (_narrowingContextStack.Count > 0)
+        {
+            var current = _narrowingContextStack.Pop();
+            _narrowingContextStack.Push(current.InvalidatePropertiesOf(basePath));
+        }
+    }
+
+    /// <summary>
+    /// Resets any active lexical (<see cref="TypeEnvironment"/>) narrowing of <paramref name="name"/>
+    /// in the ENCLOSING scope that holds it back to <paramref name="declaredType"/>. <c>if</c>-guard
+    /// variable narrowing is applied by redefining the variable in the guard's child environment; when
+    /// a reassignment that escapes the narrowing happens inside a further-nested block, that block's
+    /// environment is discarded at the join, so the outer guard narrowing would otherwise survive into
+    /// later statements (the #570 soundness gap). Widening the guard's environment closes that gap.
+    /// The reassignment's own (current) scope is widened separately by the caller's
+    /// <c>_environment.Define</c>; this walks strictly OUTWARD to the nearest enclosing scope that
+    /// rebound the name, which for an outer guard is its narrowing override.
+    /// </summary>
+    private void WidenEnclosingNarrowing(string name, TypeInfo declaredType)
+    {
+        for (TypeEnvironment? env = _environment.Enclosing; env != null; env = env.Enclosing)
+        {
+            if (env.IsDefinedLocally(name))
+            {
+                env.Define(name, declaredType);
+                return;
+            }
+        }
+    }
+
+    /// <summary>
     /// Pushes a new scope for declared variable types (called when entering a function).
     /// </summary>
     private void PushDeclaredVariableScope()
@@ -1149,6 +1187,10 @@ public partial class TypeChecker
                     // Check all statements with error recovery
                     foreach (var stmt in module.Statements)
                     {
+                        // Fallback line for diagnostics whose throw-site doesn't carry one, mirroring
+                        // the script path (CheckWithRecovery). Without it, module-mode errors render
+                        // with no location (#468).
+                        _currentStatementLine = TryGetStmtLine(stmt);
                         try
                         {
                             CheckStmt(stmt);
@@ -1197,6 +1239,10 @@ public partial class TypeChecker
                     // Third pass: check all statements with error recovery
                     foreach (var stmt in module.Statements)
                     {
+                        // Fallback line for diagnostics whose throw-site doesn't carry one, mirroring
+                        // the script path (CheckWithRecovery). Without it, module-mode errors render
+                        // with no location (#468).
+                        _currentStatementLine = TryGetStmtLine(stmt);
                         try
                         {
                             CheckStmt(stmt);
@@ -1214,6 +1260,7 @@ public partial class TypeChecker
 
         _currentModule = null;
         _filePath = null;
+        _currentStatementLine = null;
         return _typeMap;
     }
 
@@ -1297,52 +1344,65 @@ public partial class TypeChecker
             // Hoist let/const declarations (pre-define as any for forward reference support — #533)
             HoistLexicalDeclarations(module.Statements);
 
-            // Then, process all declarations to populate the environment
-            foreach (var stmt in module.Statements)
+            // Then, process all declarations to populate the environment. This is a PREPARATORY
+            // pass: it registers declaration/export types so forward references and exports resolve.
+            // The authoritative body type-check (with source-location attribution) runs in
+            // CheckModules' second pass, which re-checks every statement — so suppress diagnostics
+            // here to avoid reporting each error twice, once in this pass and once in the second
+            // (#468). The per-statement catch still lets collection continue past a faulty statement.
+            _suppressDiagnostics++;
+            try
             {
-                try
+                foreach (var stmt in module.Statements)
                 {
-                    // Skip imports - already bound above
-                    if (stmt is Stmt.Import)
+                    try
                     {
-                        continue;
-                    }
+                        // Skip imports - already bound above
+                        if (stmt is Stmt.Import)
+                        {
+                            continue;
+                        }
 
-                    // For exports, process the underlying declaration
-                    if (stmt is Stmt.Export export)
-                    {
-                        if (export.ExportAssignment != null)
+                        // For exports, process the underlying declaration
+                        if (stmt is Stmt.Export export)
                         {
-                            // CommonJS-style export = value
-                            var type = CheckExpr(export.ExportAssignment);
-                            module.HasExportAssignment = true;
-                            module.ExportAssignmentType = type;
+                            if (export.ExportAssignment != null)
+                            {
+                                // CommonJS-style export = value
+                                var type = CheckExpr(export.ExportAssignment);
+                                module.HasExportAssignment = true;
+                                module.ExportAssignmentType = type;
+                            }
+                            else if (export.Declaration != null)
+                            {
+                                CheckStmt(export.Declaration);
+                            }
+                            else if (export.DefaultExpr != null)
+                            {
+                                var type = CheckExpr(export.DefaultExpr);
+                                module.DefaultExportType = type;
+                            }
+                            else if (export.NamedExports != null && export.FromModulePath == null)
+                            {
+                                // Named exports like `export { x, y }` need the declarations to be processed first
+                                // They'll be resolved in the second pass
+                            }
                         }
-                        else if (export.Declaration != null)
+                        else
                         {
-                            CheckStmt(export.Declaration);
-                        }
-                        else if (export.DefaultExpr != null)
-                        {
-                            var type = CheckExpr(export.DefaultExpr);
-                            module.DefaultExportType = type;
-                        }
-                        else if (export.NamedExports != null && export.FromModulePath == null)
-                        {
-                            // Named exports like `export { x, y }` need the declarations to be processed first
-                            // They'll be resolved in the second pass
+                            // Regular declarations
+                            CheckStmt(stmt);
                         }
                     }
-                    else
+                    catch (TypeCheckException ex)
                     {
-                        // Regular declarations
-                        CheckStmt(stmt);
+                        RecordTypeError(ex);
                     }
                 }
-                catch (TypeCheckException ex)
-                {
-                    RecordTypeError(ex);
-                }
+            }
+            finally
+            {
+                _suppressDiagnostics--;
             }
 
         // Now collect exports


### PR DESCRIPTION
Closes #570, #639, #468, #594.

Four independent, well-scoped fixes (type-checker + CLI module diagnostics). Each ships with regression-covered tests.

## #570 — nested-branch reassignment doesn't invalidate the outer `if` narrowing (soundness gap)
`if`-guard variable narrowing is applied by redefining the variable in the guard's child `TypeEnvironment`. A reassignment inside a *nested* branch runs against a deeper env that is discarded at the join, so the outer guard's narrowing wrongly survived — SharpTS accepted `x.length` where tsc errors:
```ts
function g(x: string | undefined, foo: boolean): number {
  if (x !== undefined) {
    if (foo) { x = undefined; }
    return x.length;   // was accepted; now correctly rejected
  }
  return 0;
}
```
`CheckAssign` now **gates** invalidation on whether the assigned value escapes the current narrowing: a reassign that stays within it keeps the narrowing (matching tsc — `x = "still a string"`), while a reassign that escapes it widens — invalidating the context narrowing *and* resetting the enclosing guard environment the context stack can't reach. Property narrowings of the variable are always dropped (the value is replaced). This also fixes the symmetric loop case where a reassign-to-narrow used to over-widen a still-valid loop-condition narrowing (a false positive). Bounded to `CheckAssign` — `LookupVariable` and the compound/index paths are untouched.

## #639 — `CollectAllInstanceMembers` didn't walk a generic-instantiation superclass
Follow-up to #506. The branded-target (private/protected) collector stopped at an `extends Base<number>` superclass, omitting its inherited members from the required set (a permissive structural gap). It now folds in the generic base with type arguments substituted, including private/protected members; `CollectGenericClassMembers` gains an all-members mode so all three collectors stay consistent.

## #468 — module-mode type errors double-reported and missing line/column
The preparatory export-collection pass fully type-checked every statement and recorded its errors, then the authoritative second pass recorded them again; and `CheckModules` never set the `_currentStatementLine` fallback the script path uses. Module errors now render **once, with `file:line:col`**, matching script mode.

## #594 — readonly index write through a union not rejected; union collapses `readonly T[] | T[]`
The string type resolver mis-parsed `readonly number[] | number[]` as `readonly (number[] | number[])` (the `readonly` prefix was stripped before the union split), dropping the readonly member. `readonly` now binds tighter than `|`/`&`, so the union keeps both members distinct. `CheckSetIndexOnType` (the union-distribution path) gains the `IsReadonly` → TS2542 guard for arrays and a tuple arm, so a readonly member of a surviving union makes the whole index write TS2542.

## Follow-ups filed
- #653 — variable reassignment doesn't narrow to the RHS type (over-strict; tsc accepts). Symmetric precision gap deliberately left out of #570.
- #654 — #570 residual: nested guards on the *same* variable can leave a stale outer narrowing. The principled context-stack-with-join refactor would close it.

## Verification
- Full unit suite: **12502 passed, 0 failed**, 1 skipped (env-dependent DNS live test).
- TypeScript conformance: **31 passed, 0 failed**.
- Test262: **0 baseline regressions** (the host-process crash is the pre-existing flakiness documented in prior work; type-checker changes can't affect runtime execution).