### PR TITLE
Complete namespace member nsvar resolution (#567) and live mutable exports (#623)

### DIFF
--- a/Compilation/ILCompiler.Async.cs
+++ b/Compilation/ILCompiler.Async.cs
@@ -464,12 +464,16 @@ public partial class ILCompiler
     private void EmitAsyncStateMachineBodies()
     {
         var savedPath = _modules.CurrentPath;
+        var savedNamespacePath = _currentNamespacePath;
         foreach (var (funcName, smBuilder) in _async.StateMachines)
         {
             if (_functionDefinitionModule.TryGetValue(funcName, out var fnModule))
             {
                 _modules.CurrentPath = NormalizeToEmissionPath(fnModule);
             }
+            // Restore the enclosing namespace (null for non-namespace functions) so the
+            // MoveNext body resolves namespace-level var/let/const by bare name (#567).
+            _currentNamespacePath = _functionDefinitionNamespace.GetValueOrDefault(funcName);
             var func = _async.Functions[funcName];
             var stubMethod = _functions.Builders[funcName];
             var analysis = _async.Analyzer.Analyze(func);
@@ -561,6 +565,7 @@ public partial class ILCompiler
             smBuilder.CreateType();
         }
         _modules.CurrentPath = savedPath;
+        _currentNamespacePath = savedNamespacePath;
 
         // Finalize nested async arrow state machine types. Standalone (top-level) arrows are
         // finalized in EmitTopLevelAsyncArrowBodies AFTER their MoveNext is emitted — creating

--- a/Compilation/ILCompiler.AsyncGenerators.cs
+++ b/Compilation/ILCompiler.AsyncGenerators.cs
@@ -64,12 +64,16 @@ public partial class ILCompiler
     private void EmitAsyncGeneratorStateMachineBodies()
     {
         var savedPath = _modules.CurrentPath;
+        var savedNamespacePath = _currentNamespacePath;
         foreach (var (funcName, smBuilder) in _asyncGenerators.StateMachines)
         {
             if (_functionDefinitionModule.TryGetValue(funcName, out var fnModule))
             {
                 _modules.CurrentPath = NormalizeToEmissionPath(fnModule);
             }
+            // Restore the enclosing namespace (null for non-namespace functions) so the
+            // MoveNext body resolves namespace-level var/let/const by bare name (#567).
+            _currentNamespacePath = _functionDefinitionNamespace.GetValueOrDefault(funcName);
             var funcStmt = _asyncGenerators.Functions[funcName];
             var methodBuilder = _functions.Builders[funcName];
 
@@ -83,6 +87,7 @@ public partial class ILCompiler
             smBuilder.CreateType();
         }
         _modules.CurrentPath = savedPath;
+        _currentNamespacePath = savedNamespacePath;
     }
 
     /// <summary>

--- a/Compilation/ILCompiler.Functions.cs
+++ b/Compilation/ILCompiler.Functions.cs
@@ -197,10 +197,18 @@ public partial class ILCompiler
     /// </summary>
     private void RegisterStateMachineFunctionModule(Stmt.Function funcStmt)
     {
+        string qualifiedName = GetDefinitionContext().GetQualifiedFunctionName(funcStmt.Name.Lexeme);
+
+        // A state-machine function declared in a namespace must resolve namespace-level
+        // var/let/const from its MoveNext body, which is emitted in a dedicated later phase
+        // after _currentNamespacePath is cleared. Record the namespace here (independent of
+        // module path, so single-file namespaces work) so that phase can restore it (#567).
+        if (_currentNamespacePath != null)
+            _functionDefinitionNamespace[qualifiedName] = _currentNamespacePath;
+
         if (_modules.CurrentPath == null)
             return;
 
-        string qualifiedName = GetDefinitionContext().GetQualifiedFunctionName(funcStmt.Name.Lexeme);
         _functionDefinitionModule[qualifiedName] = _modules.CurrentPath;
         _modules.FunctionToModule[funcStmt.Name.Lexeme] = _modules.CurrentPath;
     }
@@ -277,14 +285,11 @@ public partial class ILCompiler
         var capturedLocals = hasFunctionDC ? _closures.Analyzer.GetCapturedLocals(funcStmt) : null;
 
         // Build module-scoped top-level vars so this function only sees its own
-        // module's bindings plus global imports.
+        // module's bindings plus global imports. When emitting a namespace member body this
+        // also surfaces the enclosing namespace's var/let/const backing fields (#567) — the
+        // augmentation now lives in BuildTopLevelStaticVarsForModule so every emission site
+        // (state machines, class methods) gets it uniformly, not just this plain-function path.
         Dictionary<string, FieldBuilder>? topLevelVars = BuildTopLevelStaticVarsForModule(_modules.CurrentPath);
-
-        // A function declared inside a namespace must also resolve that namespace's
-        // var/let/const members by their bare names (#567). Surface their static backing
-        // fields through the same resolver path as module top-level vars.
-        if (_currentNamespacePath != null)
-            topLevelVars = BuildNamespaceScopedStaticVars(topLevelVars, _currentNamespacePath);
 
         var ctx = new CompilationContext(il, _typeMapper, _functions.Builders, _classes.Builders, _types)
         {

--- a/Compilation/ILCompiler.Generators.cs
+++ b/Compilation/ILCompiler.Generators.cs
@@ -65,12 +65,16 @@ public partial class ILCompiler
     private void EmitGeneratorStateMachineBodies()
     {
         var savedPath = _modules.CurrentPath;
+        var savedNamespacePath = _currentNamespacePath;
         foreach (var (funcName, smBuilder) in _generators.StateMachines)
         {
             if (_functionDefinitionModule.TryGetValue(funcName, out var fnModule))
             {
                 _modules.CurrentPath = NormalizeToEmissionPath(fnModule);
             }
+            // Restore the enclosing namespace (null for non-namespace functions) so the
+            // MoveNext body resolves namespace-level var/let/const by bare name (#567).
+            _currentNamespacePath = _functionDefinitionNamespace.GetValueOrDefault(funcName);
             var funcStmt = _generators.Functions[funcName];
             var methodBuilder = _functions.Builders[funcName];
 
@@ -84,6 +88,7 @@ public partial class ILCompiler
             smBuilder.CreateType();
         }
         _modules.CurrentPath = savedPath;
+        _currentNamespacePath = savedNamespacePath;
     }
 
     /// <summary>

--- a/Compilation/ILCompiler.Namespaces.cs
+++ b/Compilation/ILCompiler.Namespaces.cs
@@ -16,11 +16,25 @@ public partial class ILCompiler
     private readonly Dictionary<string, Dictionary<string, FieldBuilder>> _namespaceVarFields = [];
 
     /// <summary>
-    /// The namespace path whose member bodies are currently being emitted, or null when
-    /// not inside a namespace. Set by <see cref="EmitNamespaceMemberBodies"/> so a namespace
-    /// function body can surface its enclosing namespaces' var fields to its resolver (#567).
+    /// The namespace path whose members are currently being defined or emitted, or null when
+    /// not inside a namespace. Set by <see cref="DefineNamespaceFields"/> (define phase) and
+    /// <see cref="EmitNamespaceMemberBodies"/> (emit phase) so a namespace member body can
+    /// surface its enclosing namespaces' var fields to its resolver (#567). Read by
+    /// <see cref="BuildTopLevelStaticVarsForModule"/>, which augments the static-var view with
+    /// those fields whenever it is non-null.
     /// </summary>
     private string? _currentNamespacePath;
+
+    /// <summary>
+    /// Qualified state-machine function name -> enclosing namespace path, recorded at define
+    /// time for generators / async / async-generators declared in a namespace. Their MoveNext
+    /// bodies are emitted in dedicated later phases (<see cref="EmitGeneratorStateMachineBodies"/>
+    /// et al.) that iterate by qualified name, long after <see cref="_currentNamespacePath"/> has
+    /// been cleared — so those phases restore it from this map to keep namespace var resolution
+    /// working for state-machine members (#567). Plain sync functions and class methods don't
+    /// need this: they are emitted inline while <see cref="_currentNamespacePath"/> is still live.
+    /// </summary>
+    private readonly Dictionary<string, string> _functionDefinitionNamespace = [];
 
     /// <summary>
     /// Defines static fields for a namespace and its nested namespaces.
@@ -42,47 +56,60 @@ public partial class ILCompiler
             _namespaceFields[path] = field;
         }
 
-        // Define namespace members (functions, classes, enums, nested namespaces)
-        foreach (var member in ns.Members)
+        // Record the enclosing namespace during the define phase too: DefineFunction routes
+        // generators/async/async-generators through RegisterStateMachineFunctionModule, which
+        // captures _currentNamespacePath into _functionDefinitionNamespace so the later
+        // state-machine emission phases can restore it (#567). Saved/restored for nesting.
+        var savedNamespacePath = _currentNamespacePath;
+        _currentNamespacePath = path;
+        try
         {
-            var actualMember = member;
-            // Unwrap export
-            if (member is Stmt.Export { Declaration: not null } exp)
+            // Define namespace members (functions, classes, enums, nested namespaces)
+            foreach (var member in ns.Members)
             {
-                actualMember = exp.Declaration;
+                var actualMember = member;
+                // Unwrap export
+                if (member is Stmt.Export { Declaration: not null } exp)
+                {
+                    actualMember = exp.Declaration;
+                }
+
+                switch (actualMember)
+                {
+                    case Stmt.Namespace nested:
+                        DefineNamespaceFields(nested, path);
+                        break;
+
+                    case Stmt.Function funcStmt when funcStmt.Body != null:
+                        // Define functions inside namespace
+                        DefineFunction(funcStmt);
+                        break;
+
+                    case Stmt.Class classStmt:
+                        // Define classes inside namespace
+                        DefineClass(classStmt);
+                        break;
+
+                    case Stmt.Enum enumStmt:
+                        // Define enums inside namespace
+                        DefineEnum(enumStmt);
+                        break;
+
+                    // A namespace-level variable needs a static backing field so functions
+                    // declared in the namespace can resolve the bare name (#567).
+                    case Stmt.Var varStmt:
+                        DefineNamespaceVarField(path, varStmt.Name.Lexeme);
+                        break;
+
+                    case Stmt.Const constStmt:
+                        DefineNamespaceVarField(path, constStmt.Name.Lexeme);
+                        break;
+                }
             }
-
-            switch (actualMember)
-            {
-                case Stmt.Namespace nested:
-                    DefineNamespaceFields(nested, path);
-                    break;
-
-                case Stmt.Function funcStmt when funcStmt.Body != null:
-                    // Define functions inside namespace
-                    DefineFunction(funcStmt);
-                    break;
-
-                case Stmt.Class classStmt:
-                    // Define classes inside namespace
-                    DefineClass(classStmt);
-                    break;
-
-                case Stmt.Enum enumStmt:
-                    // Define enums inside namespace
-                    DefineEnum(enumStmt);
-                    break;
-
-                // A namespace-level variable needs a static backing field so functions
-                // declared in the namespace can resolve the bare name (#567).
-                case Stmt.Var varStmt:
-                    DefineNamespaceVarField(path, varStmt.Name.Lexeme);
-                    break;
-
-                case Stmt.Const constStmt:
-                    DefineNamespaceVarField(path, constStmt.Name.Lexeme);
-                    break;
-            }
+        }
+        finally
+        {
+            _currentNamespacePath = savedNamespacePath;
         }
     }
 

--- a/Compilation/ILCompiler.cs
+++ b/Compilation/ILCompiler.cs
@@ -1615,6 +1615,16 @@ public partial class ILCompiler
             result = new Dictionary<string, FieldBuilder>(_topLevelStaticVars);
         }
 
+        // A body emitted for a namespace member (function, generator, async, async-generator,
+        // class method/accessor/static) must also resolve its enclosing namespace's
+        // var/let/const members by bare name (#567). _currentNamespacePath is non-null only
+        // while EmitNamespaceMemberBodies is emitting such a body, so this augments exactly
+        // those emissions and nothing else. Centralizing here covers every emission site that
+        // routes through this helper (state machines, class methods) rather than just the plain
+        // function path.
+        if (_currentNamespacePath != null)
+            result = BuildNamespaceScopedStaticVars(result, _currentNamespacePath);
+
         return result;
     }
 

--- a/Compilation/ILEmitter.Properties.cs
+++ b/Compilation/ILEmitter.Properties.cs
@@ -15,6 +15,50 @@ namespace SharpTS.Compilation;
 /// </summary>
 public partial class ILEmitter
 {
+    /// <summary>
+    /// Emits a read of a namespace-level variable through its static backing field when
+    /// <paramref name="g"/> is <c>N.x</c> (or nested <c>N.M.x</c>) and <c>x</c> is a known
+    /// namespace var/let/const. This makes external access observe the live binding that member
+    /// functions mutate, rather than the snapshot stored in the namespace object at declaration
+    /// (#623). Returns false (leaving the normal property-get path) when the object is not a
+    /// namespace path or the member is not a namespace variable.
+    /// </summary>
+    private bool TryEmitNamespaceVarGet(Expr.Get g)
+    {
+        if (_ctx.NamespaceVarFields == null) return false;
+
+        string? nsPath = ResolveNamespacePathForGet(g.Object);
+        if (nsPath == null) return false;
+
+        if (_ctx.NamespaceVarFields.TryGetValue(nsPath, out var fields) &&
+            fields.TryGetValue(g.Name.Lexeme, out var field))
+        {
+            IL.Emit(OpCodes.Ldsfld, field);
+            SetStackUnknown();
+            return true;
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Resolves an expression to the dotted path of the namespace it denotes (e.g. <c>N</c> or
+    /// <c>N.M</c>), or null if it is not a reference to a known namespace. Used by
+    /// <see cref="TryEmitNamespaceVarGet"/> to locate a namespace var's backing field.
+    /// </summary>
+    private string? ResolveNamespacePathForGet(Expr obj)
+    {
+        switch (obj)
+        {
+            case Expr.Variable v when _ctx.NamespaceFields?.ContainsKey(v.Name.Lexeme) == true:
+                return v.Name.Lexeme;
+            case Expr.Get get when ResolveNamespacePathForGet(get.Object) is { } parent:
+                string candidate = $"{parent}.{get.Name.Lexeme}";
+                return _ctx.NamespaceFields?.ContainsKey(candidate) == true ? candidate : null;
+            default:
+                return null;
+        }
+    }
+
     protected override void EmitGet(Expr.Get g)
     {
         // CommonJS: `module.exports` reads → ldsfld $exports
@@ -126,6 +170,13 @@ public partial class ILEmitter
             }
             return;
         }
+
+        // External read of a namespace-level mutable variable must observe the live binding,
+        // not the declaration-time snapshot stored in the namespace object (#623). Redirect
+        // `N.x` (and nested `N.M.x`) to the var's static backing field — the same field member
+        // functions read and write (#567) — so a mutation made through a member function is
+        // visible here. Mirrors the interpreter's live-binding exposure.
+        if (TryEmitNamespaceVarGet(g)) return;
 
         // Handle static member access via 'this' in static context (static blocks, static methods)
         // In static blocks, 'this' refers to the class constructor, so this.property accesses static members

--- a/Execution/Interpreter.Namespaces.cs
+++ b/Execution/Interpreter.Namespaces.cs
@@ -118,6 +118,18 @@ public partial class Interpreter
                 {
                     object? value = _environment.Get(token).ToObject();
                     nsObj.Set(memberName, value);
+
+                    // An exported mutable variable is a live view of the namespace binding,
+                    // not a snapshot taken here: a member function that reassigns it must be
+                    // visible through external `N.x` access too (#623). Capture the namespace
+                    // scope so external reads resolve the current value. const/function/class/
+                    // enum members never reassign, so they keep the snapshot stored above.
+                    if (member is Stmt.Var)
+                    {
+                        var bindingEnv = _environment;
+                        var bindingToken = token;
+                        nsObj.SetLiveBinding(memberName, () => bindingEnv.Get(bindingToken).ToObject());
+                    }
                 }
                 else if (member is Stmt.ImportAlias ia)
                 {

--- a/Runtime/Types/SharpTSNamespace.cs
+++ b/Runtime/Types/SharpTSNamespace.cs
@@ -19,16 +19,39 @@ public class SharpTSNamespace : ITypeCategorized
     public string Name { get; }
     private readonly Dictionary<string, object?> _members = [];
 
+    /// <summary>
+    /// Live bindings for exported mutable namespace variables (#623). Per TS semantics, a
+    /// namespace's <c>export let</c>/<c>export var</c> is a live view of the binding its member
+    /// functions mutate — not a snapshot taken at declaration. When a name has a live binding,
+    /// <see cref="Get"/> resolves the current value through the getter instead of the
+    /// declaration-time value in <see cref="_members"/>. The <see cref="_members"/> entry is
+    /// still kept (the snapshot) so <see cref="HasMember"/>, <see cref="GetMemberNames"/>,
+    /// <see cref="Members"/>, and <see cref="Merge"/> continue to enumerate the member by name.
+    /// (<c>const</c> members never change, so their snapshot already equals the live value —
+    /// they get no live binding.) Lazily allocated; null when the namespace has none.
+    /// <para>
+    /// Interpreter-only and deliberately NOT mirrored into the emitted compiled
+    /// <c>$TSNamespace</c> (despite the class-level note): compiled mode achieves the same #623
+    /// liveness by redirecting external <c>N.x</c> reads to the var's static backing field at
+    /// IL-emit time (see <c>ILEmitter.TryEmitNamespaceVarGet</c>), so the compiled namespace
+    /// object never needs a live-binding layer.
+    /// </para>
+    /// </summary>
+    private Dictionary<string, Func<object?>>? _liveBindings;
+
     public SharpTSNamespace(string name)
     {
         Name = name;
     }
 
     /// <summary>
-    /// Gets a member value by name.
+    /// Gets a member value by name. An exported mutable variable with a live binding (#623)
+    /// resolves to its current value; all other members return their stored value.
     /// </summary>
     public object? Get(string name)
     {
+        if (_liveBindings != null && _liveBindings.TryGetValue(name, out var getter))
+            return getter();
         return _members.TryGetValue(name, out var value) ? value : null;
     }
 
@@ -38,6 +61,17 @@ public class SharpTSNamespace : ITypeCategorized
     public void Set(string name, object? value)
     {
         _members[name] = value;
+    }
+
+    /// <summary>
+    /// Registers a live binding for an exported mutable namespace variable so external
+    /// <c>N.x</c> reflects later mutations by member functions (#623). The caller is expected
+    /// to also record the declaration-time value via <see cref="Set"/> for enumeration/merging.
+    /// </summary>
+    public void SetLiveBinding(string name, Func<object?> getter)
+    {
+        _liveBindings ??= [];
+        _liveBindings[name] = getter;
     }
 
     /// <summary>
@@ -66,6 +100,15 @@ public class SharpTSNamespace : ITypeCategorized
         foreach (var (name, value) in other._members)
         {
             _members[name] = value;
+        }
+        // Carry over live bindings (#623) so a merged block's mutable exports stay live.
+        if (other._liveBindings != null)
+        {
+            _liveBindings ??= [];
+            foreach (var (name, getter) in other._liveBindings)
+            {
+                _liveBindings[name] = getter;
+            }
         }
     }
 

--- a/SharpTS.Tests/SharedTests/NamespaceTests.cs
+++ b/SharpTS.Tests/SharedTests/NamespaceTests.cs
@@ -79,6 +79,193 @@ public class NamespaceTests
         Assert.Equal("3\n", TestHarness.Run(code, mode));
     }
 
+    // The original #567 fix only reached the plain-function path. Generators, async
+    // functions, and class members emit their bodies through separate paths (state-machine
+    // MoveNext methods, class method/accessor/constructor emission) that built their
+    // top-level-static-var view without the namespace augmentation, so they could not
+    // resolve a namespace var by bare name — silently returning undefined (state machines)
+    // or throwing "Undefined variable" (class members). These pin each path.
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void NamespaceGenerator_ReadsNamespaceVar(ExecutionMode mode)
+    {
+        var code = @"
+            namespace N { const val = 4; export function* g() { yield val; } }
+            console.log(N.g().next().value);
+        ";
+        Assert.Equal("4\n", TestHarness.Run(code, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void NamespaceAsyncFunction_ReadsNamespaceVar(ExecutionMode mode)
+    {
+        var code = @"
+            namespace N { const val = 7; export async function a() { return val; } }
+            N.a().then(x => console.log(x));
+        ";
+        Assert.Equal("7\n", TestHarness.Run(code, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void NamespaceClassMethod_ReadsNamespaceVar(ExecutionMode mode)
+    {
+        var code = @"
+            namespace N { const val = 3; export class C { m() { return val; } } }
+            console.log(new N.C().m());
+        ";
+        Assert.Equal("3\n", TestHarness.Run(code, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void NamespaceClassStaticMethod_ReadsNamespaceVar(ExecutionMode mode)
+    {
+        var code = @"
+            namespace N { const val = 5; export class C { static m() { return val; } } }
+            console.log(N.C.m());
+        ";
+        Assert.Equal("5\n", TestHarness.Run(code, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void NamespaceClassAccessor_ReadsNamespaceVar(ExecutionMode mode)
+    {
+        var code = @"
+            namespace N { const val = 8; export class C { get x() { return val; } } }
+            console.log(new N.C().x);
+        ";
+        Assert.Equal("8\n", TestHarness.Run(code, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void NamespaceClassConstructor_ReadsNamespaceVar(ExecutionMode mode)
+    {
+        var code = @"
+            namespace N { const val = 6; export class C { y: number; constructor() { this.y = val; } } }
+            console.log(new N.C().y);
+        ";
+        Assert.Equal("6\n", TestHarness.Run(code, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void NestedNamespaceGenerator_ReadsOuterNamespaceVar(ExecutionMode mode)
+    {
+        var code = @"
+            namespace Out {
+                const a = 10;
+                export namespace In {
+                    const b = 5;
+                    export function* g() { yield a + b; }
+                }
+            }
+            console.log(Out.In.g().next().value);
+        ";
+        Assert.Equal("15\n", TestHarness.Run(code, mode));
+    }
+
+    #endregion
+
+    #region Mutable exported namespace variable is a live binding (#623)
+
+    // An exported `let`/`var` that a member function mutates must be a live view through
+    // external `N.x` access too, matching tsc/Node — not the snapshot taken at declaration.
+    // Interpreter: the namespace object exposes a live binding onto the namespace scope slot.
+    // Compiled: external `N.x` reads the var's static backing field (the one member functions
+    // write), instead of the namespace object's declaration-time member. const members never
+    // change, so their external value is unaffected.
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void MutableExportedLet_MutationVisibleViaExternalAccess(ExecutionMode mode)
+    {
+        var code = @"
+            namespace N {
+                export let count = 0;
+                export function inc() { count = count + 1; }
+                export function get() { return count; }
+            }
+            N.inc();
+            N.inc();
+            console.log(N.get());
+            console.log(N.count);
+        ";
+        Assert.Equal("2\n2\n", TestHarness.Run(code, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void MutableExportedVar_MutationVisibleViaExternalAccess(ExecutionMode mode)
+    {
+        var code = @"
+            namespace N {
+                export var count = 0;
+                export function inc() { count++; }
+            }
+            N.inc();
+            N.inc();
+            N.inc();
+            console.log(N.count);
+        ";
+        Assert.Equal("3\n", TestHarness.Run(code, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void MutableExportedLet_ExternalAccessReflectsEachMutation(ExecutionMode mode)
+    {
+        var code = @"
+            namespace N {
+                export let v = 1;
+                export function set(n: number) { v = n; }
+            }
+            console.log(N.v);
+            N.set(10);
+            console.log(N.v);
+            N.set(20);
+            console.log(N.v);
+        ";
+        Assert.Equal("1\n10\n20\n", TestHarness.Run(code, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ConstExportedMember_ExternalAccessUnaffected(ExecutionMode mode)
+    {
+        var code = @"
+            namespace N {
+                export const c = 5;
+                export function get() { return c; }
+            }
+            console.log(N.get());
+            console.log(N.c);
+        ";
+        Assert.Equal("5\n5\n", TestHarness.Run(code, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void NestedNamespace_MutableExport_LiveViaExternalAccess(ExecutionMode mode)
+    {
+        var code = @"
+            namespace N {
+                export namespace M {
+                    export let count = 0;
+                    export function inc() { count++; }
+                }
+            }
+            N.M.inc();
+            N.M.inc();
+            console.log(N.M.count);
+        ";
+        Assert.Equal("2\n", TestHarness.Run(code, mode));
+    }
+
     #endregion
 
     #region Basic Namespace Features (Both Modes)


### PR DESCRIPTION
Closes #567
Closes #623

## Summary

Completes two open namespace bugs, both in the interpreter and the IL compiler.

### #567 — namespace member bodies resolve namespace-level `var`/`let`/`const`

PR #624 fixed this for **plain functions** only. Generators, async functions, async
generators, and class methods/accessors/static members emit their bodies through other
paths that rebuilt the top-level-static-var view *without* the namespace augmentation —
so they silently returned `undefined` (state machines) or threw `Undefined variable`
(class members).

- The augmentation now lives in `BuildTopLevelStaticVarsForModule` (gated on
  `_currentNamespacePath`), so every emission site that routes through it — including
  `BuildClassMethodTopLevelStaticVarsForModule` — gets it uniformly.
- State-machine bodies are emitted in dedicated later phases that iterate by qualified
  name, after `_currentNamespacePath` is cleared. Each state-machine function's enclosing
  namespace is recorded at define time (`_functionDefinitionNamespace`) and restored in
  those phases.

### #623 — exported mutable namespace var is a live binding via `N.x`

Previously both modes returned the declaration-time snapshot after a member function
mutated the var. Now `N.x` (and nested `N.M.x`) is a live view, matching tsc/Node:

- **Interpreter:** the namespace object exposes a live binding onto the namespace scope
  slot for exported `var`/`let` (const keeps the snapshot — it never changes).
- **Compiled:** external `N.x` reads are redirected to the var's static backing field —
  the same field member functions write — via a new `EmitGet` fast path.

Both fixes are gated entirely behind `namespace` constructs, so non-namespace programs
are byte-for-byte unaffected.

## Tests

- 12 new namespace tests (each ×2 modes): #567 member-kind coverage (generator, async,
  class method/static/accessor/constructor, nested-namespace generator) and #623
  live-binding (`let`/`var` mutation visible externally, const unaffected, multi-mutation,
  nested namespace).
- **Full suite: 12581 pass / 0 fail.** TypeScriptConformance: **31/0** unchanged (no
  type-checker changes). Test262 has a pre-existing deterministic test-host crash in this
  environment (reproduces identically with and without these changes; 0 failures / 0
  baseline diff on completed tests — these changes are inert for the non-namespace corpus).

## Follow-ups filed (separate pre-existing gaps found while doing this)

- #656 — compiled: a namespace is not resolvable by bare name from a non-member function body (`ReferenceError 'N'`).
- #657 — compiled: namespace `var`/function members collide with module-level and sibling-namespace same-named bindings.
- #659 — compiled: arrow-function and async-generator namespace members are not callable via `N.member`.
- #660 — compiled: a nested function declaration inside a namespace member function throws `Undefined variable`.
- #661 — type checker: a class generator method without an explicit return type is treated as non-iterable (both modes).