### PR TITLE
Generator yield-type inference + async-iterator type refs + Generator arity (#548, #532, #487, #483)

### DIFF
--- a/Compilation/TypeMapper.cs
+++ b/Compilation/TypeMapper.cs
@@ -277,22 +277,36 @@ public class TypeMapper
 
     private Type MapArrayTypeStrict(TypeInfo.Array arr)
     {
-        Type elementType = MapTypeInfoStrict(arr.ElementType);
+        Type elementType = MapCollectionElementStrict(arr.ElementType);
         // Use List<T> for typed arrays
         return _types.MakeGenericType(_types.ListOpen, elementType);
     }
 
     private Type MapMapTypeStrict(TypeInfo.Map map)
     {
-        Type keyType = MapTypeInfoStrict(map.KeyType);
-        Type valueType = MapTypeInfoStrict(map.ValueType);
+        Type keyType = MapCollectionElementStrict(map.KeyType);
+        Type valueType = MapCollectionElementStrict(map.ValueType);
         return _types.MakeGenericType(_types.DictionaryOpen, keyType, valueType);
     }
 
     private Type MapSetTypeStrict(TypeInfo.Set set)
     {
-        Type elementType = MapTypeInfoStrict(set.ElementType);
+        Type elementType = MapCollectionElementStrict(set.ElementType);
         return _types.MakeGenericType(_types.HashSetOpen, elementType);
+    }
+
+    /// <summary>
+    /// Maps a collection element/key/value type for a strict <c>List&lt;T&gt;</c> / <c>Dictionary&lt;,&gt;</c>
+    /// / <c>HashSet&lt;T&gt;</c> slot, substituting <c>object</c> when the element maps to <c>System.Void</c>.
+    /// A <c>never</c>/<c>void</c> element (e.g. an empty generator's <c>never</c> yield type spread into an
+    /// array — <c>function* g() {}</c> then <c>[...g()]</c>) would otherwise make <c>MakeGenericType</c>
+    /// throw "System.Void may not be used as a type argument", and such a collection is an empty dynamic
+    /// <c>$Array</c>/<c>TSMap</c>/<c>TSSet</c> carried as <c>object</c> at runtime regardless (#548).
+    /// </summary>
+    private Type MapCollectionElementStrict(TypeInfo element)
+    {
+        Type mapped = MapTypeInfoStrict(element);
+        return _types.IsVoid(mapped) ? _types.Object : mapped;
     }
 
     /// <summary>

--- a/SharpTS.Tests/TypeCheckerTests/AsyncIteratorTypeReferenceTests.cs
+++ b/SharpTS.Tests/TypeCheckerTests/AsyncIteratorTypeReferenceTests.cs
@@ -1,0 +1,233 @@
+using SharpTS.Tests.Infrastructure;
+using SharpTS.TypeSystem.Exceptions;
+using Xunit;
+
+namespace SharpTS.Tests.TypeCheckerTests;
+
+/// <summary>
+/// The async iterator-protocol type references — <c>AsyncIterator&lt;T&gt;</c> /
+/// <c>AsyncIterableIterator&lt;T&gt;</c> (=&gt; <c>TypeInfo.AsyncIterator</c>) and
+/// <c>AsyncIterable&lt;T&gt;</c> (=&gt; <c>TypeInfo.AsyncIterable</c>) — now resolve from a type REFERENCE
+/// instead of degrading to <c>any</c> (#483, the async parallel of the sync work in #456/#485). Also pins
+/// the <c>Generator</c>/<c>AsyncGenerator</c> arity accepting the lib's optional <c>TReturn</c>/<c>TNext</c>
+/// (#487).
+/// </summary>
+public class AsyncIteratorTypeReferenceTests
+{
+    // ---- #483: async iterator references are strongly typed (no longer `any`) ----
+
+    [Fact]
+    public void AsyncIterableIterator_FakeMemberRejected()
+    {
+        // The issue's headline example: `it` is now AsyncIterator<number>, not `any`, so an unknown member
+        // is a type error instead of silently passing (it failed only at runtime before). A parameter is
+        // used so the type comes purely from the annotation.
+        var source = """
+            function f(it: AsyncIterableIterator<number>): void { it.totallyFakeMethod(); }
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void AsyncIterator_AltSpelling_FakeMemberRejected()
+    {
+        var source = """
+            function f(it: AsyncIterator<number>): void { it.nope(); }
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void AsyncIterable_FakeMemberRejected()
+    {
+        var source = """
+            function f(it: AsyncIterable<number>): void { it.nope(); }
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void AsyncIterableIterator_RealMemberResolves()
+    {
+        // next() is a genuine member of the iterator protocol and must resolve on the strongly-typed value.
+        var source = """
+            function f(it: AsyncIterableIterator<number>): void { it.next(); }
+            """;
+        TestHarness.RunInterpreted(source);
+    }
+
+    // ---- AsyncGenerator <-> async iterator direction (an AsyncGenerator IS an AsyncIterableIterator) ----
+
+    [Fact]
+    public void AsyncGenerator_AssignableToAsyncIterableIterator_Accepted()
+    {
+        var source = """
+            async function* agen(): AsyncGenerator<number> { yield 1; }
+            let it: AsyncIterableIterator<number> = agen();
+            """;
+        TestHarness.RunInterpreted(source);
+    }
+
+    [Fact]
+    public void AsyncGenerator_AssignableToAsyncIterator_Accepted()
+    {
+        var source = """
+            async function* agen(): AsyncGenerator<number> { yield 1; }
+            let it: AsyncIterator<number> = agen();
+            """;
+        TestHarness.RunInterpreted(source);
+    }
+
+    [Fact]
+    public void AsyncGenerator_AssignableToAsyncIterable_Accepted()
+    {
+        var source = """
+            async function* agen(): AsyncGenerator<number> { yield 1; }
+            let ai: AsyncIterable<number> = agen();
+            """;
+        TestHarness.RunInterpreted(source);
+    }
+
+    [Fact]
+    public void AsyncIterableIterator_SelfAssignment_Accepted()
+    {
+        var source = """
+            function f(a: AsyncIterableIterator<number>): AsyncIterableIterator<number> { return a; }
+            """;
+        TestHarness.RunInterpreted(source);
+    }
+
+    [Fact]
+    public void AsyncIterable_NotAssignableToAsyncIterator_Rejected()
+    {
+        // Asymmetric: an AsyncIterable exposes only [Symbol.asyncIterator], not next(), so it is not an
+        // AsyncIterator (mirrors the sync Iterable ↛ Iterator relation).
+        var source = """
+            function f(a: AsyncIterable<number>): AsyncIterableIterator<number> { return a; }
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void AsyncIterator_NotAssignableToSyncIterator_Rejected()
+    {
+        // The sync and async hierarchies are distinct: an AsyncGenerator is not a sync IterableIterator.
+        var source = """
+            async function* agen(): AsyncGenerator<number> { yield 1; }
+            function f(): IterableIterator<number> { return agen(); }
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void AsyncIterableIterator_ElementMismatch_Rejected()
+    {
+        var source = """
+            function f(it: AsyncIterableIterator<number>): AsyncIterableIterator<string> { return it; }
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void AsyncIterator_ThreeTypeArgs_LibSpelling_Accepted()
+    {
+        // lib.d.ts is AsyncIterator<T, TReturn = any, TNext = any>; SharpTS keeps only the element type but
+        // must accept (and drop) the optional TReturn/TNext.
+        var source = """
+            async function* agen(): AsyncGenerator<number> { yield 1; }
+            let it: AsyncIterator<number, void, undefined> = agen();
+            """;
+        TestHarness.RunInterpreted(source);
+    }
+
+    [Fact]
+    public void AsyncIterator_TooManyTypeArgs_Rejected()
+    {
+        var source = """
+            function f(it: AsyncIterator<number, void, undefined, string>): void {}
+            """;
+        var ex = Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+        Assert.Equal("TS2707", ex.Diagnostic.TsCode);
+    }
+
+    // ---- conditional-type `infer` extraction (DecomposeBuiltInContainer) ----
+
+    [Fact]
+    public void ConditionalInfer_FromAsyncIterableIterator_CorrectBranchAccepted()
+    {
+        var source = """
+            type ElemOf<T> = T extends AsyncIterableIterator<infer V> ? V : "none";
+            let x: ElemOf<AsyncIterableIterator<number>> = 5;
+            """;
+        TestHarness.RunInterpreted(source);
+    }
+
+    [Fact]
+    public void ConditionalInfer_FromAsyncIterableIterator_BindsElement()
+    {
+        var source = """
+            type ElemOf<T> = T extends AsyncIterableIterator<infer V> ? V : "none";
+            function f(): ElemOf<AsyncIterableIterator<number>> { return "hello"; }
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void ConditionalInfer_FromAsyncIterable_BindsElement()
+    {
+        var source = """
+            type ElemOf<T> = T extends AsyncIterable<infer V> ? V : never;
+            let x: ElemOf<AsyncIterable<number>> = 5;
+            """;
+        TestHarness.RunInterpreted(source);
+    }
+
+    // ---- #487: Generator/AsyncGenerator accept the lib's optional TReturn/TNext (arity 1–3) ----
+
+    [Fact]
+    public void Generator_ThreeTypeArgs_LibSpelling_Accepted()
+    {
+        // lib.d.ts is Generator<T, TReturn = any, TNext = unknown>; the extra two args are accepted and
+        // dropped (only the yield type is modeled). Previously rejected with "requires exactly 1" (#487).
+        var source = """
+            function* gen(): Generator<number, void, unknown> { yield 1; }
+            let g: Generator<number> = gen();
+            """;
+        TestHarness.RunInterpreted(source);
+    }
+
+    [Fact]
+    public void Generator_TwoTypeArgs_Accepted()
+    {
+        var source = """
+            function* gen(): Generator<number, void> { yield 1; }
+            """;
+        TestHarness.RunInterpreted(source);
+    }
+
+    [Fact]
+    public void Generator_TooManyTypeArgs_Rejected()
+    {
+        var source = "function* gen(): Generator<number, void, unknown, string> { yield 1; }";
+        var ex = Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+        Assert.Equal("TS2707", ex.Diagnostic.TsCode);
+    }
+
+    [Fact]
+    public void AsyncGenerator_ThreeTypeArgs_LibSpelling_Accepted()
+    {
+        var source = """
+            async function* agen(): AsyncGenerator<number, void, unknown> { yield 1; }
+            let g: AsyncGenerator<number> = agen();
+            """;
+        TestHarness.RunInterpreted(source);
+    }
+
+    [Fact]
+    public void AsyncGenerator_TooManyTypeArgs_Rejected()
+    {
+        var source = "async function* agen(): AsyncGenerator<number, void, unknown, string> { yield 1; }";
+        var ex = Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+        Assert.Equal("TS2707", ex.Diagnostic.TsCode);
+    }
+}

--- a/SharpTS.Tests/TypeCheckerTests/DedicatedContainerTypeReferenceTests.cs
+++ b/SharpTS.Tests/TypeCheckerTests/DedicatedContainerTypeReferenceTests.cs
@@ -82,9 +82,11 @@ public class DedicatedContainerTypeReferenceTests
     [Fact]
     public void Iterator_TooManyTypeArgs_Rejected()
     {
+        // The lib signature defaults TReturn/TNext, so an over-arity reference is the range error TS2707
+        // ("requires between …"), the code tsc uses for a defaulted range — not the exact-count TS2314 (#487).
         var source = "let it: Iterator<number, void, undefined, string> = [1].values();";
         var ex = Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
-        Assert.Equal("TS2314", ex.Diagnostic.TsCode);
+        Assert.Equal("TS2707", ex.Diagnostic.TsCode);
     }
 
     // ---- Generator <-> Iterator direction (a sync Generator IS an IterableIterator) ----

--- a/SharpTS.Tests/TypeCheckerTests/GeneratorYieldInferenceTests.cs
+++ b/SharpTS.Tests/TypeCheckerTests/GeneratorYieldInferenceTests.cs
@@ -1,0 +1,173 @@
+using SharpTS.Tests.Infrastructure;
+using SharpTS.TypeSystem.Exceptions;
+using Xunit;
+
+namespace SharpTS.Tests.TypeCheckerTests;
+
+/// <summary>
+/// A generator function with no explicit <c>Generator&lt;T&gt;</c> return annotation now infers its yield
+/// type from the operand types of its <c>yield</c> / <c>yield*</c> expressions, instead of reusing the
+/// (usually empty → <c>void</c>) inferred RETURN type (#548). Once the yield type is real, <c>for...of</c>
+/// binds it directly rather than degrading to <c>any</c>, and a nested generator no longer compiles to an
+/// invalid <c>IEnumerator&lt;System.Void&gt;</c> (#532).
+/// </summary>
+public class GeneratorYieldInferenceTests
+{
+    // ---- #548: yield type derived from yield / yield* operands (was always void) ----
+
+    [Fact]
+    public void Generator_InfersYieldType_FromYieldExpressions()
+    {
+        // The headline #548 example: g() infers Generator<number> (was Generator<void>), so the spread is
+        // number[] and reading an element as number type-checks.
+        var source = """
+            function* g() { yield 1; yield 2; }
+            const arr: number[] = [...g()];
+            const n: number = arr[0];
+            """;
+        TestHarness.RunInterpreted(source);
+    }
+
+    [Fact]
+    public void Generator_InferredYield_IsNotVoid_WrongConsumerRejected()
+    {
+        // The inferred element is number, so assigning it to string is a genuine TS2322 — previously the
+        // element was void and the error named the wrong type.
+        var source = """
+            function* g() { yield 1; }
+            const s: string = [...g()][0];
+            """;
+        var ex = Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+        Assert.Equal("TS2322", ex.Diagnostic.TsCode);
+    }
+
+    [Fact]
+    public void Generator_ForOf_BindsInferredYieldType()
+    {
+        // VisitForOf now extracts Generator.YieldType (it deliberately did not before, because a
+        // delegating-only generator inferred a void yield — now fixed).
+        var source = """
+            function* g() { yield 1; yield 2; }
+            for (const x of g()) { const n: number = x; }
+            """;
+        TestHarness.RunInterpreted(source);
+    }
+
+    [Fact]
+    public void Generator_ForOf_WrongElementUse_Rejected()
+    {
+        var source = """
+            function* g() { yield 1; }
+            for (const x of g()) { const s: string = x; }
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void Generator_YieldStar_ContributesDelegatedElementType()
+    {
+        // yield* over an iterable contributes the delegate's element type to the enclosing yield type.
+        var source = """
+            function* g() { yield* [1, 2, 3]; }
+            const arr: number[] = [...g()];
+            """;
+        TestHarness.RunInterpreted(source);
+    }
+
+    [Fact]
+    public void Generator_YieldStar_ElementMismatch_Rejected()
+    {
+        var source = """
+            function* g() { yield* [1, 2, 3]; }
+            const arr: string[] = [...g()];
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void Generator_MixedYields_UnionsYieldType()
+    {
+        var source = """
+            function* g() { yield 1; yield "a"; }
+            const arr: (number | string)[] = [...g()];
+            """;
+        TestHarness.RunInterpreted(source);
+    }
+
+    [Fact]
+    public void Generator_ReturnValue_DoesNotBecomeYieldType()
+    {
+        // The `return` value is the (discarded) TReturn, not the yield type: a generator that only yields
+        // numbers but returns a string still infers Generator<number>, so the string return must not make
+        // the elements assignable to string.
+        var source = """
+            function* g() { yield 1; return "done"; }
+            const s: string = [...g()][0];
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Generator_InferredYield_IteratesInBothModes(ExecutionMode mode)
+    {
+        // Type-level change must not perturb interpretation or IL codegen.
+        var source = """
+            function* g() { yield 10; yield 20; yield 30; }
+            let sum = 0;
+            for (const x of g()) { sum += x; }
+            console.log(sum);
+            """;
+        Assert.Equal("60\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Generator_EmptyYieldsNever_RunsInBothModes(ExecutionMode mode)
+    {
+        // An empty generator infers Generator<never>; spreading it yields an empty array. The never element
+        // (which maps to System.Void) must fall back to an object collection slot rather than crashing IL
+        // emission with "System.Void may not be used as a type argument".
+        var source = """
+            function outer() { function* g() {} return [...g()]; }
+            console.log(outer().length);
+            """;
+        Assert.Equal("0\n", TestHarness.Run(source, mode));
+    }
+
+    // ---- #532: nested generator declaration infers its yield type (compiled no longer System.Void) ----
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void NestedGenerator_InfersYieldType_RunsInBothModes(ExecutionMode mode)
+    {
+        // The nested generator's yield type is inferred (number), so the outer function returns number[]
+        // and the compiled path no longer emits an invalid IEnumerator<System.Void> (#532).
+        var source = """
+            function outer() {
+              function* g() { yield 42; }
+              return [...g()];
+            }
+            console.log(outer()[0]);
+            """;
+        Assert.Equal("42\n", TestHarness.Run(source, mode));
+    }
+
+    [Fact]
+    public void NestedGenerator_InferredYield_SatisfiesAnnotatedReturn()
+    {
+        var source = """
+            function outer(): number[] {
+              function* g() { yield 42; }
+              return [...g()];
+            }
+            """;
+        TestHarness.RunInterpreted(source);
+    }
+
+    // NOTE: generator METHODS with an inferred return type now also compute Generator<yieldType> rather
+    // than Generator<void> (the same fix in CheckClassBody), but the result is not yet observable at a call
+    // site: `new C().values()` resolves an inferred method's return to the unresolved `<inferred>`
+    // placeholder regardless of generator-ness — a pre-existing method-return-inference propagation gap
+    // (#658). A test here would exercise that unrelated bug, so it is intentionally omitted.
+}

--- a/SharpTS.Tests/TypeCheckerTests/StructuralIterableTypingTests.cs
+++ b/SharpTS.Tests/TypeCheckerTests/StructuralIterableTypingTests.cs
@@ -75,7 +75,8 @@ public class StructuralIterableTypingTests
     {
         var source = "let r: IteratorResult<number, string, boolean> = { value: 1 };";
         var ex = Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
-        Assert.Equal("TS2314", ex.Diagnostic.TsCode);
+        // Defaulted-arity range (TReturn defaults) → TS2707, the code tsc uses for a range (#487).
+        Assert.Equal("TS2707", ex.Diagnostic.TsCode);
     }
 
     // ---- Iterable<T> reference is element-typed (#485 gap 4) and relates structurally ----
@@ -164,7 +165,8 @@ public class StructuralIterableTypingTests
     {
         var source = "let a: Iterable<number, void, undefined, string> = [1];";
         var ex = Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
-        Assert.Equal("TS2314", ex.Diagnostic.TsCode);
+        // Defaulted-arity range (newer lib Iterable<T, TReturn, TNext>) → TS2707 (#487).
+        Assert.Equal("TS2707", ex.Diagnostic.TsCode);
     }
 
     [Fact]

--- a/TypeSystem/TypeCategoryResolver.cs
+++ b/TypeSystem/TypeCategoryResolver.cs
@@ -46,6 +46,7 @@ public static class TypeCategoryResolver
         TypeInfo.Generator => TypeCategory.Generator,
         TypeInfo.AsyncGenerator => TypeCategory.AsyncGenerator,
         TypeInfo.AsyncIterable => TypeCategory.AsyncGenerator,
+        TypeInfo.AsyncIterator => TypeCategory.AsyncGenerator,
 
         // User-defined types
         TypeInfo.Class or TypeInfo.GenericClass or TypeInfo.MutableClass => TypeCategory.Class,

--- a/TypeSystem/TypeChecker.Compatibility.cs
+++ b/TypeSystem/TypeChecker.Compatibility.cs
@@ -902,6 +902,35 @@ public partial class TypeChecker
             return IsCompatible(expAsyncGen.YieldType, actAsyncGen.YieldType);
         }
 
+        // AsyncIterator<T1>/AsyncIterableIterator<T1> (#483, async parallel of the sync Iterator arm above):
+        // an AsyncIterator source (self) and an AsyncGenerator (which structurally IS an AsyncIterator)
+        // satisfy it when the element types relate, so a strict `let it: AsyncIterableIterator<number> =
+        // agen()` does not regress. An AsyncIterable (only `[Symbol.asyncIterator]`, no `next`) is NOT an
+        // AsyncIterator and falls through to rejection — the async mirror of Iterable ↛ Iterator.
+        if (expected is TypeInfo.AsyncIterator expAsyncIter)
+        {
+            TypeInfo? asyncIterSrcElem = actual switch
+            {
+                TypeInfo.AsyncIterator a => a.ElementType,
+                TypeInfo.AsyncGenerator g => g.YieldType,
+                _ => null
+            };
+            if (asyncIterSrcElem is not null)
+                return IsCompatible(expAsyncIter.ElementType, asyncIterSrcElem);
+            // Not async-iterator-shaped: fall through to the remaining (ultimately rejecting) rules.
+        }
+
+        // AsyncIterable<T1> (#483, async parallel of the sync Iterable arm below): the dedicated async
+        // records — AsyncIterable (self), the AsyncIterator record (= AsyncIterableIterator, which IS an
+        // AsyncIterable) and AsyncGenerator — satisfy it when their element types relate. A sync iterable
+        // is NOT an AsyncIterable and falls through to rejection.
+        if (expected is TypeInfo.AsyncIterable expAsyncIterable)
+        {
+            if (TryGetAsyncIterableElementType(actual, out var asyncIterableSrcElem))
+                return IsCompatible(expAsyncIterable.ElementType, asyncIterableSrcElem);
+            // Not async-iterable: fall through to the remaining (ultimately rejecting) rules.
+        }
+
         // Iterable<T1> (#485): a sync-iterable source satisfies it when its element type relates to T1 —
         // arrays, sets, maps ([K, V]), strings, the dedicated iterator/generator records, and structural
         // objects exposing [Symbol.iterator]. Covariant in the element, like the other container records.

--- a/TypeSystem/TypeChecker.Expressions.cs
+++ b/TypeSystem/TypeChecker.Expressions.cs
@@ -268,13 +268,21 @@ public partial class TypeChecker
             if (yieldExpr.IsDelegating)
             {
                 // yield* requires an iterable (array, generator, etc.)
-                return GetIterableElementType(valueType);
+                TypeInfo delegatedElement = GetIterableElementType(valueType);
+                // The delegated iterable's element type flows into the enclosing generator's yield type
+                // (#548): `function* g() { yield* [1, 2]; }` yields `number`, so it must infer
+                // Generator<number>, not Generator<void>. Collected only while that type is being inferred.
+                _inferredYieldTypes?.Add(delegatedElement);
+                return delegatedElement;
             }
 
+            _inferredYieldTypes?.Add(valueType);
             return valueType;
         }
 
-        // Bare yield returns undefined (void type for simplicity)
+        // Bare `yield` yields `undefined`; it contributes `undefined` to the inferred yield type (#548).
+        _inferredYieldTypes?.Add(new TypeInfo.Undefined());
+        // The yield EXPRESSION still evaluates to the (modeled) void type for an operand-less yield.
         return new TypeInfo.Void();
     }
 

--- a/TypeSystem/TypeChecker.Generics.Conditional.cs
+++ b/TypeSystem/TypeChecker.Generics.Conditional.cs
@@ -954,6 +954,8 @@ public partial class TypeChecker
         TypeInfo.AsyncGenerator g => [g.YieldType],
         TypeInfo.Iterator it => [it.ElementType],
         TypeInfo.Iterable ib => [ib.ElementType],
+        TypeInfo.AsyncIterator ait => [ait.ElementType],
+        TypeInfo.AsyncIterable aib => [aib.ElementType],
         TypeInfo.WeakRef wr => [wr.TargetType],
         TypeInfo.FinalizationRegistry fr => [fr.TargetType],
         _ => null

--- a/TypeSystem/TypeChecker.Generics.cs
+++ b/TypeSystem/TypeChecker.Generics.cs
@@ -112,19 +112,24 @@ public partial class TypeChecker
             }
             result = new TypeInfo.Promise(valueType);
         }
+        // The lib signatures are Generator<T = unknown, TReturn = any, TNext = unknown> and
+        // AsyncGenerator<T = unknown, TReturn = any, TNext = unknown> — TReturn/TNext are defaulted, so a
+        // reference may carry 1–3 arguments. SharpTS models only the yield type (T), so the extra two are
+        // accepted and dropped, exactly like the Iterator arm below. Out-of-range is TS2707 (the code tsc
+        // uses for a defaulted-arity range), not the exact-count TS2314 (#487).
         else if (baseName == "Generator")
         {
-            if (typeArgs.Count != 1)
+            if (typeArgs.Count is < 1 or > 3)
             {
-                throw new TypeCheckException($" Generator requires exactly 1 type argument, got {typeArgs.Count}.", tsCode: "TS2314");
+                throw new TypeCheckException($" Generator requires between 1 and 3 type arguments, got {typeArgs.Count}.", tsCode: "TS2707");
             }
             result = new TypeInfo.Generator(typeArgs[0]);
         }
         else if (baseName == "AsyncGenerator")
         {
-            if (typeArgs.Count != 1)
+            if (typeArgs.Count is < 1 or > 3)
             {
-                throw new TypeCheckException($" AsyncGenerator requires exactly 1 type argument, got {typeArgs.Count}.", tsCode: "TS2314");
+                throw new TypeCheckException($" AsyncGenerator requires between 1 and 3 type arguments, got {typeArgs.Count}.", tsCode: "TS2707");
             }
             result = new TypeInfo.AsyncGenerator(typeArgs[0]);
         }
@@ -165,18 +170,36 @@ public partial class TypeChecker
         else if (baseName is "Iterator" or "IterableIterator")
         {
             if (typeArgs.Count is < 1 or > 3)
-                throw new TypeCheckException($" {baseName} requires between 1 and 3 type arguments, got {typeArgs.Count}.", tsCode: "TS2314");
+                throw new TypeCheckException($" {baseName} requires between 1 and 3 type arguments, got {typeArgs.Count}.", tsCode: "TS2707");
             result = new TypeInfo.Iterator(typeArgs[0]);
+        }
+        // The async iterator-protocol references mirror their sync counterparts (#483, async parallel of
+        // #456): AsyncIterator<T> / AsyncIterableIterator<T> collapse onto the dedicated AsyncIterator
+        // record (as Iterator/IterableIterator collapse onto Iterator), and AsyncIterable<T> resolves to
+        // the AsyncIterable record — all previously degraded to `any`. The lib signatures default
+        // TReturn/TNext (AsyncIterator<T, TReturn = any, TNext = any>), so 1–3 arguments are accepted and
+        // only the element type is kept; out-of-range is TS2707.
+        else if (baseName is "AsyncIterator" or "AsyncIterableIterator")
+        {
+            if (typeArgs.Count is < 1 or > 3)
+                throw new TypeCheckException($" {baseName} requires between 1 and 3 type arguments, got {typeArgs.Count}.", tsCode: "TS2707");
+            result = new TypeInfo.AsyncIterator(typeArgs[0]);
+        }
+        else if (baseName == "AsyncIterable")
+        {
+            if (typeArgs.Count is < 1 or > 3)
+                throw new TypeCheckException($" AsyncIterable requires between 1 and 3 type arguments, got {typeArgs.Count}.", tsCode: "TS2707");
+            result = new TypeInfo.AsyncIterable(typeArgs[0]);
         }
         // Iterable<T> references resolve to the dedicated Iterable record so the annotation is element-typed
         // (for...of/spread/yield* and assignment) rather than degrading to `any` (#485). The newer lib
         // signature is Iterable<T, TReturn = void, TNext = undefined> — only the element type is modeled, so
-        // 1–3 arguments are accepted and the rest are dropped, mirroring the Iterator arm above. The async
-        // parallel (AsyncIterable/AsyncIterableIterator references) is tracked separately in #483.
+        // 1–3 arguments are accepted and the rest are dropped, mirroring the Iterator arm above. (The async
+        // parallel — AsyncIterable/AsyncIterator/AsyncIterableIterator — is handled by the arms above, #483.)
         else if (baseName == "Iterable")
         {
             if (typeArgs.Count is < 1 or > 3)
-                throw new TypeCheckException($" Iterable requires between 1 and 3 type arguments, got {typeArgs.Count}.", tsCode: "TS2314");
+                throw new TypeCheckException($" Iterable requires between 1 and 3 type arguments, got {typeArgs.Count}.", tsCode: "TS2707");
             result = new TypeInfo.Iterable(typeArgs[0]);
         }
         // IteratorResult<T, TReturn = any> and its IteratorYieldResult/IteratorReturnResult arms are
@@ -187,7 +210,7 @@ public partial class TypeChecker
         else if (baseName == "IteratorResult")
         {
             if (typeArgs.Count is < 1 or > 2)
-                throw new TypeCheckException($" IteratorResult requires 1 or 2 type arguments, got {typeArgs.Count}.", tsCode: "TS2314");
+                throw new TypeCheckException($" IteratorResult requires 1 or 2 type arguments, got {typeArgs.Count}.", tsCode: "TS2707");
             result = BuildIteratorResultType(typeArgs[0]);
         }
         else if (baseName is "IteratorYieldResult" or "IteratorReturnResult")

--- a/TypeSystem/TypeChecker.Iterables.cs
+++ b/TypeSystem/TypeChecker.Iterables.cs
@@ -166,4 +166,26 @@ public partial class TypeChecker
                 return false;
         }
     }
+
+    /// <summary>
+    /// The element type of any async-iterable source — the dedicated <see cref="TypeInfo.AsyncIterable"/>,
+    /// <see cref="TypeInfo.AsyncIterator"/> (= AsyncIterableIterator) and <see cref="TypeInfo.AsyncGenerator"/>
+    /// records. Drives the <c>AsyncIterable&lt;T&gt;</c> assignment target and the async arm of
+    /// <c>for await...of</c> (#483). The async mirror of <see cref="TryGetIterableElementType"/>; sync
+    /// iterables are intentionally excluded (a sync iterable is not an async iterable). Returns false for
+    /// non-async-iterable types (callers decide between an error and a fall-through to <c>any</c>).
+    /// </summary>
+    private static bool TryGetAsyncIterableElementType(TypeInfo type, out TypeInfo elementType)
+    {
+        switch (type)
+        {
+            case TypeInfo.AsyncIterable ai: elementType = ai.ElementType; return true;
+            case TypeInfo.AsyncIterator ait: elementType = ait.ElementType; return true;
+            case TypeInfo.AsyncGenerator ag: elementType = ag.YieldType; return true;
+            case TypeInfo.Any: elementType = new TypeInfo.Any(); return true;
+            default:
+                elementType = null!;
+                return false;
+        }
+    }
 }

--- a/TypeSystem/TypeChecker.Properties.Helpers.cs
+++ b/TypeSystem/TypeChecker.Properties.Helpers.cs
@@ -59,6 +59,8 @@ public partial class TypeChecker
                 BuiltInTypes.GetIteratorMemberType(memberName, asyncGen.YieldType),
             TypeCategory.AsyncGenerator when objType is TypeInfo.AsyncIterable asyncIter =>
                 BuiltInTypes.GetIteratorMemberType(memberName, asyncIter.ElementType),
+            TypeCategory.AsyncGenerator when objType is TypeInfo.AsyncIterator asyncIt =>
+                BuiltInTypes.GetIteratorMemberType(memberName, asyncIt.ElementType),
             TypeCategory.Promise when objType is TypeInfo.Promise promise =>
                 BuiltInTypes.GetPromiseMemberType(memberName, promise.ValueType),
             TypeCategory.EventEmitter =>

--- a/TypeSystem/TypeChecker.Statements.Classes.cs
+++ b/TypeSystem/TypeChecker.Statements.Classes.cs
@@ -628,6 +628,7 @@ public partial class TypeChecker
                 TypeEnvironment previousEnvFunc = _environment;
                 TypeInfo? previousReturnFunc = _currentFunctionReturnType;
                 var previousInferredFunc = _inferredReturnTypes;
+                var previousInferredYieldFunc = _inferredYieldTypes;
                 bool previousInStatic = _inStaticMethod;
                 bool previousInAsyncFunc = _inAsyncFunction;
                 bool previousInGeneratorFunc = _inGeneratorFunction;
@@ -646,6 +647,8 @@ public partial class TypeChecker
                 {
                     _currentFunctionReturnType = methodType.ReturnType;
                 }
+                // Collect yield operand types only while inferring a generator method's type (#548).
+                _inferredYieldTypes = inferringMethodReturn && method.IsGenerator ? new List<TypeInfo>() : null;
                 _inStaticMethod = method.IsStatic;
                 _inAsyncFunction = method.IsAsync;
                 _inGeneratorFunction = method.IsGenerator;
@@ -687,15 +690,16 @@ public partial class TypeChecker
                             inferredReturn = CollapseOrCreateUnion(distinct);
                         }
 
-                        if (method.IsAsync && inferredReturn is not TypeInfo.Void)
-                            inferredReturn = new TypeInfo.Promise(inferredReturn);
+                        // A generator method's type argument is its YIELD type (#548), not the
+                        // `return`-derived inferredReturn; a non-generator async method wraps in Promise.
+                        // (The inferred result is not yet observable at a call site — `new C().m()` reads an
+                        // inferred method return as `<inferred>` regardless of generator-ness, a separate
+                        // method-return-inference propagation gap, #658 — but computing it correctly here
+                        // keeps the method path consistent with the function path for when that is fixed.)
                         if (method.IsGenerator)
-                        {
-                            if (method.IsAsync)
-                                inferredReturn = new TypeInfo.AsyncGenerator(inferredReturn);
-                            else
-                                inferredReturn = new TypeInfo.Generator(inferredReturn);
-                        }
+                            inferredReturn = BuildInferredGeneratorType(_inferredYieldTypes!, method.IsAsync);
+                        else if (method.IsAsync && inferredReturn is not TypeInfo.Void)
+                            inferredReturn = new TypeInfo.Promise(inferredReturn);
 
                         // Update the method type in the class
                         var updatedMethodType = new TypeInfo.Function(methodType.ParamTypes, inferredReturn, methodType.RequiredParams, methodType.HasRestParam, methodType.ThisType, methodType.ParamNames);
@@ -718,6 +722,7 @@ public partial class TypeChecker
                     _environment = previousEnvFunc;
                     _currentFunctionReturnType = previousReturnFunc;
                     _inferredReturnTypes = previousInferredFunc;
+                    _inferredYieldTypes = previousInferredYieldFunc;
                     _inStaticMethod = previousInStatic;
                     _inAsyncFunction = previousInAsyncFunc;
                     _inGeneratorFunction = previousInGeneratorFunc;

--- a/TypeSystem/TypeChecker.Statements.Functions.cs
+++ b/TypeSystem/TypeChecker.Statements.Functions.cs
@@ -664,6 +664,7 @@ public partial class TypeChecker
         bool previousRecoveryMode = _recoveryMode;
 
         var previousInferredReturnTypes = _inferredReturnTypes;
+        var previousInferredYieldTypes = _inferredYieldTypes;
 
         _environment = funcEnv;
         if (inferringReturnType)
@@ -675,6 +676,9 @@ public partial class TypeChecker
         {
             _currentFunctionReturnType = returnType;
         }
+        // Collect yield operand types only while inferring a generator's type (#548). Set to null otherwise
+        // so a nested explicitly-typed generator's yields cannot leak into an enclosing inferred one.
+        _inferredYieldTypes = inferringReturnType && funcStmt.IsGenerator ? new List<TypeInfo>() : null;
         _currentFunctionThisType = thisType;
         _inAsyncFunction = funcStmt.IsAsync;
         _inGeneratorFunction = funcStmt.IsGenerator;
@@ -755,16 +759,13 @@ public partial class TypeChecker
                     inferredReturn = CollapseOrCreateUnion(distinct);
                 }
 
-                // Apply async/generator wrapping
-                if (funcStmt.IsAsync && inferredReturn is not TypeInfo.Void)
-                    inferredReturn = new TypeInfo.Promise(inferredReturn);
+                // Apply async/generator wrapping. A generator's type argument is its YIELD type (collected
+                // above), not the `return`-derived inferredReturn (#548); a non-generator async function
+                // wraps its return type in a Promise.
                 if (funcStmt.IsGenerator)
-                {
-                    if (funcStmt.IsAsync)
-                        inferredReturn = new TypeInfo.AsyncGenerator(inferredReturn);
-                    else
-                        inferredReturn = new TypeInfo.Generator(inferredReturn);
-                }
+                    inferredReturn = BuildInferredGeneratorType(_inferredYieldTypes!, funcStmt.IsAsync);
+                else if (funcStmt.IsAsync && inferredReturn is not TypeInfo.Void)
+                    inferredReturn = new TypeInfo.Promise(inferredReturn);
 
                 returnType = inferredReturn;
 
@@ -818,6 +819,7 @@ public partial class TypeChecker
             _environment = previousEnv;
             _currentFunctionReturnType = previousReturn;
             _inferredReturnTypes = previousInferredReturnTypes;
+            _inferredYieldTypes = previousInferredYieldTypes;
             _currentFunctionThisType = previousThisType;
             _inAsyncFunction = previousInAsync;
             _inGeneratorFunction = previousInGenerator;
@@ -832,6 +834,30 @@ public partial class TypeChecker
                 _suppressDiagnostics--;
             }
         }
+    }
+
+    /// <summary>
+    /// Builds the inferred type of a generator function from the operand types of its <c>yield</c> /
+    /// <c>yield*</c> expressions (collected in <see cref="_inferredYieldTypes"/> during body checking),
+    /// wrapped in <see cref="TypeInfo.Generator"/> or <see cref="TypeInfo.AsyncGenerator"/>. The type
+    /// argument is the YIELD type, not the function's <c>return</c> value (#548 — previously the inferred
+    /// return type was reused, so a generator with no <c>return</c> always inferred <c>void</c>). A
+    /// generator that yields nothing infers <c>never</c>, matching tsc's <c>Generator&lt;never, …&gt;</c>.
+    /// </summary>
+    private TypeInfo BuildInferredGeneratorType(IReadOnlyList<TypeInfo> collectedYields, bool isAsync)
+    {
+        TypeInfo yieldType;
+        if (collectedYields.Count == 0)
+        {
+            yieldType = new TypeInfo.Never();
+        }
+        else
+        {
+            var distinct = collectedYields.Distinct(TypeInfoEqualityComparer.Instance).ToList();
+            yieldType = CollapseOrCreateUnion(distinct);
+        }
+
+        return isAsync ? new TypeInfo.AsyncGenerator(yieldType) : new TypeInfo.Generator(yieldType);
     }
 
     /// <summary>

--- a/TypeSystem/TypeChecker.Statements.cs
+++ b/TypeSystem/TypeChecker.Statements.cs
@@ -827,10 +827,11 @@ public partial class TypeChecker
     {
         TypeInfo iterableType = CheckExpr(stmt.Iterable);
 
-        // For `for await...of`, an AsyncIterable<T> yields T.
-        // (Generator/AsyncGenerator yield types are intentionally NOT extracted here — generator yield-type
-        // inference does not yet account for `yield*` delegation, so a delegating-only generator infers a
-        // `void` yield; binding `any` preserves that flexibility. Tracked separately.)
+        // Now that generator yield-type inference draws from the `yield` / `yield*` operands (#548), the
+        // Generator/AsyncGenerator yield type is real (a delegating-only generator infers its delegate's
+        // element type, not `void`), so `for...of` can bind it directly instead of falling to `any`. A sync
+        // generator is also a valid `for await...of` source (each yield is awaited), so its arm is unguarded;
+        // the async-only records bind only under `for await`.
         TypeInfo elementType = iterableType switch
         {
             TypeInfo.Array arr => arr.ElementType,
@@ -838,14 +839,18 @@ public partial class TypeChecker
             TypeInfo.Set setType => setType.ElementType,
             TypeInfo.Iterator iterType => iterType.ElementType,
             TypeInfo.Iterable iterableElem => iterableElem.ElementType,
+            TypeInfo.Generator genType => genType.YieldType,
+            TypeInfo.AsyncGenerator asyncGenType when stmt.IsAsync => asyncGenType.YieldType,
+            TypeInfo.AsyncIterator asyncItType when stmt.IsAsync => asyncItType.ElementType,
             TypeInfo.AsyncIterable asyncIter when stmt.IsAsync => asyncIter.ElementType,
             // A hand-written object exposing [Symbol.iterator] is iterable structurally (#485). Limited to
-            // sync `for...of`; the async iterable protocol resolution is tracked separately (#483).
+            // sync `for...of`; structural async-iterable objects ([Symbol.asyncIterator]) are not yet
+            // element-typed (the dedicated async records above are — #483) and stay lenient below (#662).
             _ when !stmt.IsAsync && TryGetStructuralIterableElement(iterableType, out var structuralElem) => structuralElem,
             // A structural object with no [Symbol.iterator] is an iterator-only or plain object, not an
             // Iterable — tsc rejects the loop with TS2488 rather than binding `any` (#550). Gated to types
             // SharpTS can prove non-iterable so it never rejects code tsc accepts (see the helper). Async
-            // sources stay lenient — the async-iterable protocol is resolved separately (#483).
+            // sources stay lenient — structural async-iterable typing is a separate gap (#662).
             _ when !stmt.IsAsync && IsProvablyNonIterableStructuralObject(iterableType) =>
                 throw new TypeCheckException(
                     $" Type '{iterableType}' must have a '[Symbol.iterator]()' method that returns an iterator.",

--- a/TypeSystem/TypeChecker.TypeNodes.cs
+++ b/TypeSystem/TypeChecker.TypeNodes.cs
@@ -503,6 +503,7 @@ public partial class TypeChecker
         "Array" or "ReadonlyArray" or "Promise" or "Generator" or "AsyncGenerator" or
         "Map" or "Set" or "WeakMap" or "WeakSet" or
         "Iterator" or "IterableIterator" or "Iterable" or
+        "AsyncIterator" or "AsyncIterableIterator" or "AsyncIterable" or
         "IteratorResult" or "IteratorYieldResult" or "IteratorReturnResult" or
         "WeakRef" or "FinalizationRegistry" or
         "Partial" or "Required" or "Readonly" or "Record" or "Pick" or "Omit" or

--- a/TypeSystem/TypeChecker.cs
+++ b/TypeSystem/TypeChecker.cs
@@ -117,6 +117,11 @@ public partial class TypeChecker
     private TypeInfo? _currentFunctionReturnType = null;
     // When non-null, VisitReturn collects return expression types here instead of validating (for inference)
     private List<TypeInfo>? _inferredReturnTypes = null;
+    // When non-null (set only while inferring a generator's return type), CheckYield collects the operand
+    // types of `yield` / `yield*` here. A generator's inferred type argument is the union of these YIELD
+    // types, NOT the function's `return` value — `return` is the (discarded) TReturn (#548). Distinct from
+    // _inferredReturnTypes so a generator with `return x` still type-checks x without polluting the yield type.
+    private List<TypeInfo>? _inferredYieldTypes = null;
     private TypeInfo.Class? _currentClass = null;
     private bool _inStaticMethod = false;
     private bool _inStaticBlock = false;

--- a/TypeSystem/TypeInfo.cs
+++ b/TypeSystem/TypeInfo.cs
@@ -1126,6 +1126,18 @@ public abstract record TypeInfo
     }
 
     /// <summary>
+    /// Represents the async iterator-protocol type — an object exposing <c>next(): Promise&lt;IteratorResult&lt;T&gt;&gt;</c>.
+    /// <c>AsyncIterator&lt;T&gt;</c> and <c>AsyncIterableIterator&lt;T&gt;</c> both collapse onto this record,
+    /// exactly as the sync <see cref="Iterator"/> record carries both <c>Iterator&lt;T&gt;</c> and
+    /// <c>IterableIterator&lt;T&gt;</c>. Kept distinct from <see cref="AsyncIterable"/> (which only exposes
+    /// <c>[Symbol.asyncIterator]</c>) so the two annotations are not interchangeable (#483).
+    /// </summary>
+    public record AsyncIterator(TypeInfo ElementType) : TypeInfo
+    {
+        public override string ToString() => $"AsyncIterableIterator<{ElementType}>";
+    }
+
+    /// <summary>
     /// Represents the sync Iterable&lt;T&gt; type — an object exposing <c>[Symbol.iterator](): Iterator&lt;T&gt;</c>.
     /// This is the supertype of arrays, sets, maps, strings, generators and the dedicated iterator record;
     /// it is what <c>for...of</c>, spread and <c>yield*</c> consume. Modeled nominally (parallel to


### PR DESCRIPTION
Resolves #548, #532, #487, #483 — a cohesive set of generator/iterator type-system fixes.

## #548 + #532 — generator yield-type inference (same root bug)
A generator's inferred type argument was taken from its `return` expressions (collected in `_inferredReturnTypes`; usually none → `void`), not its `yield`/`yield*` operands — so every un-annotated generator inferred `Generator<void>`.

- New `_inferredYieldTypes` collector (mirrors `_inferredReturnTypes`; set up only while inferring a generator's type, save/restored at the function-declaration and class-method sites).
- `CheckYield` contributes the operand type for `yield x`, the delegated element type for `yield* x`, and `undefined` for bare `yield`.
- `BuildInferredGeneratorType` unions the collected yields (empty → `never`, matching `tsc`) and wraps in `Generator`/`AsyncGenerator`.
- With a real yield type, `VisitForOf` now binds the `Generator`/`AsyncGenerator`/`AsyncIterator` element type directly instead of falling to `any` (the arms were previously omitted *because* of this bug).
- **#532**: the nested-generator compiled crash (`The type 'System.Void' may not be used as a type argument`) is fixed at the root — `outer()` returning `[...g()]` is now `number[]`, not `void[]`. An empty generator's `never[]` exercised the same latent `MakeGenericType(void)` crash, so the strict collection mappers (`MapCollectionElementStrict`) fall back to `object` for `never`/`void` elements.

```ts
function* g() { yield 1; yield 2; }
const arr = [...g()];          // was void[], now number[]
function outer() { function* g() { yield 42; } return [...g()]; }  // compiled: was System.Void crash, now [42]
```

## #487 — Generator/AsyncGenerator arity
`Generator<T, TReturn = any, TNext = unknown>` (the lib spelling) was rejected — arity was fixed at 1. Now accepts 1–3 args (keeps the yield type, drops the rest). Out-of-range uses **TS2707** (`tsc`'s code for a defaulted-arity range); the sibling protocol range-arms (`Iterator`/`IterableIterator`/`Iterable`/`IteratorResult`) are migrated from `TS2314` to `TS2707` for consistency.

## #483 — AsyncIterator / AsyncIterableIterator / AsyncIterable references
These degraded to `any` (so bogus members weren't flagged). New `TypeInfo.AsyncIterator` record (mirrors the sync `Iterator`/`Iterable` split; `AsyncIterator`/`AsyncIterableIterator` collapse onto it, kept distinct from `AsyncIterable`). Wired through `ResolveGenericType`, `IsBuiltInGenericName`, `DecomposeBuiltInContainer`, `TypeCategoryResolver`, member lookup, compatibility (new `TryGetAsyncIterableElementType`; `AsyncGenerator` assignable to all three), and `for await...of`.

```ts
async function* agen(): AsyncGenerator<number> { yield 1; }
let it: AsyncIterableIterator<number> = agen();
it.totallyFakeMethod();   // now a type error (was silently any)
```

## Tests & verification
- New: `GeneratorYieldInferenceTests`, `AsyncIteratorTypeReferenceTests`; updated 3 existing assertions to TS2707.
- **Full suite: 12593 passed / 0 failed.** **TypeScriptConformance: 31/0** (no baseline shift). **Test262**: the host process crashes early in this environment — reproduced identically on clean `origin/main`, so it is pre-existing and unrelated to this change.

## Follow-ups filed
- #658 — inferred class **method** return types leak `<inferred>`/`any` at call sites (pre-existing, all methods; the generator-method half of this fix is forward-correct but unobservable until #658).
- #662 — structural async-iterable objects (`[Symbol.asyncIterator]`) are not element-typed in `for await...of` (async parallel of #485).