### PR TITLE
Fix #651: compiled missing property off a function/arrow yields undefined

### DIFF
--- a/Compilation/RuntimeEmitter.Functions.cs
+++ b/Compilation/RuntimeEmitter.Functions.cs
@@ -439,7 +439,11 @@ public partial class RuntimeEmitter
     /// </summary>
     private void EmitGetFunctionMethod(TypeBuilder typeBuilder, EmittedRuntime runtime)
     {
-        // GetFunctionMethod(object func, string methodName) -> object or null
+        // GetFunctionMethod(object func, string methodName) -> object
+        // Functions/arrows are ordinary objects: a missing property reads as JS
+        // `undefined`, not CLR null (#651). The miss path below returns the
+        // undefined sentinel so `typeof fn.absent === "undefined"` matches both
+        // the interpreter and plain compiled objects.
         var method = typeBuilder.DefineMethod(
             "GetFunctionMethod",
             MethodAttributes.Public | MethodAttributes.Static,
@@ -449,16 +453,17 @@ public partial class RuntimeEmitter
         runtime.GetFunctionMethod = method;
 
         var il = method.GetILGenerator();
-        var nullLabel = il.DefineLabel();
+        var missLabel = il.DefineLabel();
         var bindLabel = il.DefineLabel();
         var callLabel = il.DefineLabel();
         var applyLabel = il.DefineLabel();
         var lengthLabel = il.DefineLabel();
         var nameLabel = il.DefineLabel();
 
-        // if (func == null) return null
+        // if (func == null) treat as a miss (returns undefined) — defensive;
+        // callers only reach here after an Isinst confirms a function receiver.
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Brfalse, nullLabel);
+        il.Emit(OpCodes.Brfalse, missLabel);
 
         // Check for "bind"
         il.Emit(OpCodes.Ldarg_1);
@@ -581,7 +586,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Isinst, runtime.TSFunctionType);
         il.Emit(OpCodes.Dup);
         il.Emit(OpCodes.Stloc, tsfuncLocal);
-        il.Emit(OpCodes.Brfalse, nullLabel);
+        il.Emit(OpCodes.Brfalse, missLabel);
 
         // methodKey = tsfuncLocal.GetMethodInfo()  (public getter — avoids
         // field-access violation from accessing private _method across
@@ -771,12 +776,17 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloca, fpSlotLocal);
         il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.DictionaryStringObject, "TryGetValue",
             _types.String, _types.Object.MakeByRefType()));
-        il.Emit(OpCodes.Brfalse, nullLabel);
+        il.Emit(OpCodes.Brfalse, missLabel);
         il.Emit(OpCodes.Ldloc, fpSlotLocal);
         il.Emit(OpCodes.Ret);
 
-        il.MarkLabel(nullLabel);
-        il.Emit(OpCodes.Ldnull);
+        // Miss: a function/arrow has no such property. JS functions are
+        // ordinary objects, so an absent key reads as `undefined`, not null
+        // (#651). Reached for a generic missing property, `prototype` on a
+        // prototype-less callable (bound functions / built-in method wrappers),
+        // and the defensive null-func guard.
+        il.MarkLabel(missLabel);
+        il.Emit(OpCodes.Ldsfld, runtime.UndefinedInstance);
         il.Emit(OpCodes.Ret);
     }
 

--- a/SharpTS.Tests/SharedTests/ConstructorReturnValueTests.cs
+++ b/SharpTS.Tests/SharedTests/ConstructorReturnValueTests.cs
@@ -32,12 +32,14 @@ public class ConstructorReturnValueTests
             const f: any = new (Make as any)("X");
             console.log(typeof f);
             console.log(typeof f === "function" ? f() : "NOT CALLABLE");
+            console.log(typeof f.v);
             """;
         // f is the returned arrow: it's a function and is callable (it is NOT the constructed
-        // `this`, which would not be callable). (We avoid asserting `typeof f.v` here: reading a
-        // missing property off a function value returns null in compiled mode — an unrelated gap
-        // tracked by #651 — so it isn't a clean cross-mode signal for #446.)
-        Assert.Equal("function\nfn-result:X\n", TestHarness.Run(source, mode));
+        // `this`, which would not be callable). Reading the missing `v` off the arrow is now a
+        // clean cross-mode signal — `undefined` in both modes (functions are ordinary objects)
+        // since #651 fixed compiled-mode missing-property reads off function/arrow values. If f
+        // were the constructed `this`, `f.v` would be "X".
+        Assert.Equal("function\nfn-result:X\nundefined\n", TestHarness.Run(source, mode));
     }
 
     [Theory]

--- a/SharpTS.Tests/SharedTests/FunctionMissingPropertyTests.cs
+++ b/SharpTS.Tests/SharedTests/FunctionMissingPropertyTests.cs
@@ -1,0 +1,74 @@
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests;
+
+/// <summary>
+/// Reading a missing property off a function or arrow value yields JS
+/// <c>undefined</c>, not CLR null — functions are ordinary objects (#651).
+/// Plain objects were already correct in both modes; the gap was compiled-mode
+/// only, where the <c>$TSFunction</c>/<c>$BoundTSFunction</c> property path
+/// (<c>$Runtime.GetFunctionMethod</c>) fell through to null on a miss. The fix
+/// returns the <c>undefined</c> sentinel from that miss path, so
+/// <c>typeof fn.absent === "undefined"</c> matches the interpreter and Node.
+/// </summary>
+public class FunctionMissingPropertyTests
+{
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void MissingProperty_OffFunctionDeclaration_IsUndefined(ExecutionMode mode)
+    {
+        var source = """
+            function fn() {}
+            console.log(typeof (fn as any).missing);
+            console.log((fn as any).missing === undefined);
+            console.log((fn as any).missing === null);
+            """;
+        Assert.Equal("undefined\ntrue\nfalse\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void MissingProperty_OffArrow_IsUndefined(ExecutionMode mode)
+    {
+        var source = """
+            const arrow: any = () => 1;
+            console.log(typeof arrow.missing);
+            console.log(arrow.missing === undefined);
+            """;
+        Assert.Equal("undefined\ntrue\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void UserAssignedProperty_StillRoundTrips_MissIsUndefined(ExecutionMode mode)
+    {
+        // The miss path must not disturb genuine user-assigned properties:
+        // functions are objects, so `fn.x = v` writes/reads back, while an
+        // absent sibling key still reads undefined.
+        var source = """
+            function fn() {}
+            (fn as any).x = 42;
+            console.log((fn as any).x);
+            console.log(typeof (fn as any).y);
+            """;
+        Assert.Equal("42\nundefined\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void MissingProperty_OffConstructorReturnedArrow_IsUndefined(ExecutionMode mode)
+    {
+        // The discovery case from #651: a constructor returning an arrow yields
+        // the arrow (a function value); a missing property off it is undefined.
+        var source = """
+            function Make(this: any, v: string): any {
+                return () => "fn:" + v;
+            }
+            const f: any = new (Make as any)("X");
+            console.log(typeof f);
+            console.log(typeof f.someMissingProp);
+            """;
+        Assert.Equal("function\nundefined\n", TestHarness.Run(source, mode));
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #651 — in **compiled mode**, reading a missing property off a function or arrow value returned CLR `null` (so `typeof` was `"object"`) instead of JS `undefined`. Interpreter mode and plain objects were already correct.

Functions/arrows are ordinary objects, so an absent key must read as `undefined`. The `$TSFunction`/`$BoundTSFunction` property path (`$Runtime.GetFunctionMethod`) fell through to `ldnull` on a miss; this returns the `$Undefined` sentinel instead.

```ts
function fn() {}
const arrow: any = () => 1;
console.log(typeof (fn as any).missing); // was "object", now "undefined"
console.log(typeof arrow.missing);       // was "object", now "undefined"
```

## Notes

- Verified safe against all five `GetFunctionMethod` call sites — the three `prototype`-requesting sites (`new F()` linking, `instanceof`) only reach the helper for confirmed `$TSFunction` receivers, which take the auto-create path and never hit the miss label. The two property-dispatch sites and the bound-function fall-through simply return the result.
- Bonus: `boundFn.prototype` now correctly reads `undefined` (bound functions have no `prototype`).
- Renamed the internal `nullLabel` → `missLabel` since it now returns the sentinel, and updated the surrounding comments.

## Tests

- New `FunctionMissingPropertyTests` (both modes): missing prop off a function decl, off an arrow, user-assigned property round-trip + sibling miss, and the constructor-returned-arrow discovery case.
- Strengthened `ConstructorReturnValueTests.ConstructorReturningArrow_YieldsArrow` with the now-clean `typeof f.v` cross-mode signal (previously avoided due to this #651 gap).
- Full suite: **0 failed, 12639 passed, 0 skipped**.

## Context

This branch also investigated #640 (cross-module/value-call omitted optional args). That fix turned out to be cross-cutting (regressed 30 compiled tests via the compiled "absent arg = CLR null" model) and was reverted; analysis is documented in https://github.com/nickna/SharpTS/issues/640#issuecomment-4704418472.
