### PR TITLE
Compiled namespace member fixes + namespace-scoped const (#467, #656, #657, #659, #660)

### DIFF
--- a/Compilation/CompilationContext.Functions.cs
+++ b/Compilation/CompilationContext.Functions.cs
@@ -44,10 +44,43 @@ public partial class CompilationContext
     public HashSet<string>? FunctionsCapturingArguments { get; set; }
 
     /// <summary>
+    /// Applies the namespace prefix to an already module-qualified function name. A namespace
+    /// member function lives in its own registry slot keyed by the namespace path, so two
+    /// namespaces declaring a same-named function (and a same-named module/global function) no
+    /// longer collide on the simple/module name (#657). Kept distinct from the namespace FIELD
+    /// name (<c>$ns_…</c>) and var-backing field (<c>$nsvar_…</c>) by its own <c>$nsfn_</c> prefix.
+    /// </summary>
+    private static string ApplyNamespacePrefix(string namespacePath, string baseName)
+        => $"$nsfn_{namespacePath.Replace('.', '_')}_{baseName}";
+
+    private string ModuleQualify(string simpleFunctionName)
+        => CurrentModulePath == null
+            ? simpleFunctionName
+            : $"$M_{SanitizeModuleName(Path.GetFileNameWithoutExtension(CurrentModulePath))}_{simpleFunctionName}";
+
+    /// <summary>
     /// Resolves a simple function name to its qualified name for lookup in the Functions dictionary.
     /// </summary>
     public string ResolveFunctionName(string simpleFunctionName)
     {
+        // Namespace-scoped resolution: a function declared in the current namespace (or an
+        // enclosing one) shadows a same-named module/global function. Walk innermost → outermost
+        // and return the first namespace-qualified key that actually exists, so a sibling/self
+        // call inside a namespace member body reaches its own namespace's function (#657). When
+        // none matches (the name is a plain module/global function), fall through.
+        if (CurrentNamespacePath != null)
+        {
+            string moduleBase = ModuleQualify(simpleFunctionName);
+            var parts = CurrentNamespacePath.Split('.');
+            for (int i = parts.Length; i >= 1; i--)
+            {
+                string nsPrefix = string.Join('.', parts.Take(i));
+                string key = ApplyNamespacePrefix(nsPrefix, moduleBase);
+                if (Functions.ContainsKey(key))
+                    return key;
+            }
+        }
+
         if (FunctionToModule != null && FunctionToModule.TryGetValue(simpleFunctionName, out var modulePath))
         {
             string sanitizedModule = SanitizeModuleName(Path.GetFileNameWithoutExtension(modulePath));
@@ -57,14 +90,16 @@ public partial class CompilationContext
     }
 
     /// <summary>
-    /// Gets the qualified function name for the current module context.
+    /// Gets the qualified function name for the current module + namespace context. Module
+    /// qualification (#418) keeps same-named functions in different modules distinct; namespace
+    /// qualification (#657) keeps same-named members of different namespaces distinct. Both are
+    /// gated: a plain top-level function in single-file compilation keeps its simple name.
     /// </summary>
     public string GetQualifiedFunctionName(string simpleFunctionName)
     {
-        if (CurrentModulePath == null)
-            return simpleFunctionName;
-
-        string sanitizedModule = SanitizeModuleName(Path.GetFileNameWithoutExtension(CurrentModulePath));
-        return $"$M_{sanitizedModule}_{simpleFunctionName}";
+        string baseName = ModuleQualify(simpleFunctionName);
+        return CurrentNamespacePath == null
+            ? baseName
+            : ApplyNamespacePrefix(CurrentNamespacePath, baseName);
     }
 }

--- a/Compilation/CompilationContext.cs
+++ b/Compilation/CompilationContext.cs
@@ -163,6 +163,17 @@ public partial class CompilationContext
     // Namespace support: namespace path -> static field
     public Dictionary<string, FieldBuilder>? NamespaceFields { get; set; }
 
+    /// <summary>
+    /// The dotted path (e.g. <c>N</c> or <c>N.M</c>) of the namespace whose member body this
+    /// context emits, or null outside any namespace. Threaded onto every namespace-member body
+    /// context so <see cref="GetQualifiedFunctionName"/> / <see cref="ResolveFunctionName"/>
+    /// namespace-qualify member functions — keeping <c>A.f</c> and <c>B.f</c> (and a top-level
+    /// <c>f</c>) in distinct registry slots instead of colliding (#657). Also set on the
+    /// namespace-emission context so member var initializers and sibling references resolve to
+    /// the namespace's own backing fields rather than same-named module bindings.
+    /// </summary>
+    public string? CurrentNamespacePath { get; set; }
+
     // Namespace-level var/let/const backing fields: namespace path -> var name -> static field.
     // A namespace member variable is stored in its namespace object (for external `N.x` access)
     // AND in a static field so functions declared in the namespace can resolve the bare name —
@@ -247,12 +258,22 @@ public partial class CompilationContext
         TypeMapper typeMapper,
         Dictionary<string, MethodBuilder> functions,
         Dictionary<string, TypeBuilder> classes,
+        Dictionary<string, FieldBuilder>? namespaceFields,
+        Dictionary<string, Dictionary<string, FieldBuilder>>? namespaceVarFields,
         TypeProvider? types = null)
     {
         IL = il;
         TypeMapper = typeMapper;
         Functions = functions;
         Classes = classes;
+        // Namespace registries are whole-compilation globals (like Functions/Classes), so they
+        // are threaded through the constructor — every emission context can resolve a bare
+        // namespace name and a namespace-var backing field, not just the subset that used to set
+        // these via object initializers. That subset gap was #656 (a non-member function body
+        // threw "Undefined variable 'N'"). The maps are shared references, populated during the
+        // define phase and observed live here.
+        NamespaceFields = namespaceFields;
+        NamespaceVarFields = namespaceVarFields;
         Types = types ?? TypeProvider.Runtime;
         Locals = new LocalsManager(il);
         ILBuilder = new ValidatedILBuilder(il, Types);

--- a/Compilation/ExpressionEmitterBase.cs
+++ b/Compilation/ExpressionEmitterBase.cs
@@ -2094,10 +2094,62 @@ public abstract partial class ExpressionEmitterBase : IEmitterContext
     /// Default implementation handles Symbol well-known properties, static field access,
     /// and falls back to dynamic property access via GetProperty.
     /// </summary>
+    /// <summary>
+    /// Emits a read of a namespace-level variable through its static backing field when
+    /// <paramref name="g"/> is <c>N.x</c> (or nested <c>N.M.x</c>) and <c>x</c> is a known
+    /// namespace var/let/const. This makes external access observe the live binding that member
+    /// functions mutate, rather than the snapshot stored in the namespace object at declaration
+    /// (#623). Returns false (leaving the normal property-get path) when the object is not a
+    /// namespace path or the member is not a namespace variable. Shared by ILEmitter and the
+    /// state-machine emitters so async/generator bodies see live bindings too (#656).
+    /// </summary>
+    protected bool TryEmitNamespaceVarGet(Expr.Get g)
+    {
+        if (Ctx.NamespaceVarFields == null) return false;
+
+        string? nsPath = ResolveNamespacePathForGet(g.Object);
+        if (nsPath == null) return false;
+
+        if (Ctx.NamespaceVarFields.TryGetValue(nsPath, out var fields) &&
+            fields.TryGetValue(g.Name.Lexeme, out var field))
+        {
+            IL.Emit(OpCodes.Ldsfld, field);
+            SetStackUnknown();
+            return true;
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Resolves an expression to the dotted path of the namespace it denotes (e.g. <c>N</c> or
+    /// <c>N.M</c>), or null if it is not a reference to a known namespace. Used by
+    /// <see cref="TryEmitNamespaceVarGet"/> to locate a namespace var's backing field.
+    /// </summary>
+    private string? ResolveNamespacePathForGet(Expr obj)
+    {
+        switch (obj)
+        {
+            case Expr.Variable v when Ctx.NamespaceFields?.ContainsKey(v.Name.Lexeme) == true:
+                return v.Name.Lexeme;
+            case Expr.Get get when ResolveNamespacePathForGet(get.Object) is { } parent:
+                string candidate = $"{parent}.{get.Name.Lexeme}";
+                return Ctx.NamespaceFields?.ContainsKey(candidate) == true ? candidate : null;
+            default:
+                return null;
+        }
+    }
+
     protected virtual void EmitGet(Expr.Get g)
     {
         // CommonJS: `module.exports` reads → ldsfld $exports.
         if (TryEmitCjsGet(g)) return;
+
+        // Namespace var live-binding redirect (#623): external `N.x` reads of a namespace
+        // var/let/const go to the var's static backing field — the same field member functions
+        // write — so external access observes the live binding, not the declaration-time
+        // snapshot. Lives here in the shared base (not just ILEmitter) so state-machine bodies
+        // (async/generator MoveNext emitters) observe live bindings too (#656).
+        if (TryEmitNamespaceVarGet(g)) return;
 
         if (TryEmitSymbolWellKnown(g)) return;
         if (TryEmitStaticFieldAccess(g)) return;

--- a/Compilation/ILCompiler.ArrowFunctions.cs
+++ b/Compilation/ILCompiler.ArrowFunctions.cs
@@ -559,6 +559,25 @@ public partial class ILCompiler
                 foreach (var binding in u.Bindings)
                     CollectArrowsFromExpr(binding.Initializer);
                 break;
+            case Stmt.Namespace ns:
+                // Recurse into namespace members so arrows and nested function declarations
+                // inside namespace member functions get collected. Without this the collection
+                // never enters namespace bodies, so a `function* `/arrow member's method is never
+                // registered (arrow `export const f = () => …` left non-callable, #659) and a
+                // nested `function inner(){}` inside a member function is never lifted, throwing
+                // "Undefined variable 'inner'" (#660). Setting _currentNamespacePath keeps the
+                // enclosing-function-name qualification symmetric with the define/emit phases
+                // (DefineNamespaceFields / EmitNamespaceMemberBodies). Members may be wrapped in
+                // Stmt.Export, which the Export arm unwraps. Depth is unchanged: a direct member
+                // function is a top-level (depth-0) function, exactly like a module-scoped one.
+                var savedNsPath = _currentNamespacePath;
+                _currentNamespacePath = string.IsNullOrEmpty(_currentNamespacePath)
+                    ? ns.Name.Lexeme
+                    : $"{_currentNamespacePath}.{ns.Name.Lexeme}";
+                foreach (var member in ns.Members)
+                    CollectArrowsFromStmt(member);
+                _currentNamespacePath = savedNsPath;
+                break;
             case Stmt.Export exp:
                 // Recurse into the wrapped declaration so arrows inside
                 // `export const X = () => …` or `export function …` get
@@ -1055,7 +1074,7 @@ public partial class ILCompiler
         _closures.ArrowReturnTypes.TryGetValue(arrow, out var arrowReturnType);
         arrowReturnType ??= _types.Object;
 
-        var ctx = new CompilationContext(il, _typeMapper, _functions.Builders, _classes.Builders, _types)
+        var ctx = new CompilationContext(il, _typeMapper, _functions.Builders, _classes.Builders, _namespaceFields, _namespaceVarFields, _types)
         {
             ClosureAnalyzer = _closures.Analyzer,
             ArrowMethods = _closures.ArrowMethods,
@@ -1079,6 +1098,7 @@ public partial class ILCompiler
             TopLevelStaticVars = BuildTopLevelStaticVarsForModule(_modules.CurrentPath),
             // Module support for multi-module compilation
             CurrentModulePath = _modules.CurrentPath,
+            CurrentNamespacePath = _currentNamespacePath,
             ClassToModule = _modules.ClassToModule,
             FunctionToModule = _modules.FunctionToModule,
             EnumToModule = _modules.EnumToModule,

--- a/Compilation/ILCompiler.Async.cs
+++ b/Compilation/ILCompiler.Async.cs
@@ -483,7 +483,7 @@ public partial class ILCompiler
 
             // Create context for MoveNext emission
             var il = smBuilder.MoveNextMethod.GetILGenerator();
-            var ctx = new CompilationContext(il, _typeMapper, _functions.Builders, _classes.Builders, _types)
+            var ctx = new CompilationContext(il, _typeMapper, _functions.Builders, _classes.Builders, _namespaceFields, _namespaceVarFields, _types)
             {
                 Runtime = _runtime,
                 ClosureAnalyzer = _closures.Analyzer,
@@ -495,7 +495,6 @@ public partial class ILCompiler
                 EnumMembers = _enums.Members,
                 EnumReverse = _enums.Reverse,
                 EnumKinds = _enums.Kinds,
-                NamespaceFields = _namespaceFields,
                 TopLevelStaticVars = BuildTopLevelStaticVarsForModule(_modules.CurrentPath),
                 FunctionRestParams = _functions.RestParams,
                 FunctionsCapturingArguments = _functions.CapturingArguments,
@@ -509,6 +508,7 @@ public partial class ILCompiler
                 AsyncArrowParentBuilders = _async.ArrowParentBuilders,
                 // Module support for multi-module compilation
                 CurrentModulePath = _modules.CurrentPath,
+                CurrentNamespacePath = _currentNamespacePath,
                 ModuleResolver = _modules.Resolver,
                 CommonJsExportFields = _modules.CommonJsExportFields,
                 CommonJsGetExportsMethods = _modules.CommonJsGetExportsMethods,
@@ -595,7 +595,7 @@ public partial class ILCompiler
         );
 
         // Create a new context for arrow MoveNext emission
-        var ctx = new CompilationContext(il, parentCtx.TypeMapper, parentCtx.Functions, parentCtx.Classes, parentCtx.Types)
+        var ctx = new CompilationContext(il, parentCtx.TypeMapper, parentCtx.Functions, parentCtx.Classes, parentCtx.NamespaceFields, parentCtx.NamespaceVarFields, parentCtx.Types)
         {
             Runtime = parentCtx.Runtime,
             ClosureAnalyzer = parentCtx.ClosureAnalyzer,
@@ -607,7 +607,6 @@ public partial class ILCompiler
             EnumMembers = parentCtx.EnumMembers,
             EnumReverse = parentCtx.EnumReverse,
             EnumKinds = parentCtx.EnumKinds,
-            NamespaceFields = parentCtx.NamespaceFields,
             TopLevelStaticVars = parentCtx.TopLevelStaticVars,
             FunctionRestParams = parentCtx.FunctionRestParams,
             FunctionGenericParams = parentCtx.FunctionGenericParams,
@@ -858,7 +857,7 @@ public partial class ILCompiler
 
         // Create context for MoveNext emission
         var il = smBuilder.MoveNextMethod.GetILGenerator();
-        var ctx = new CompilationContext(il, _typeMapper, _functions.Builders, _classes.Builders, _types)
+        var ctx = new CompilationContext(il, _typeMapper, _functions.Builders, _classes.Builders, _namespaceFields, _namespaceVarFields, _types)
         {
             FieldsField = fieldsField,
             IsInstanceMethod = true,
@@ -873,7 +872,6 @@ public partial class ILCompiler
             EnumMembers = _enums.Members,
             EnumReverse = _enums.Reverse,
             EnumKinds = _enums.Kinds,
-            NamespaceFields = _namespaceFields,
             TopLevelStaticVars = BuildTopLevelStaticVarsForModule(_modules.CurrentPath),
             Runtime = _runtime,
             FunctionGenericParams = _functions.GenericParams,
@@ -886,6 +884,7 @@ public partial class ILCompiler
             AsyncArrowParentBuilders = _async.ArrowParentBuilders,
             // Module support for multi-module compilation
             CurrentModulePath = _modules.CurrentPath,
+            CurrentNamespacePath = _currentNamespacePath,
             ClassToModule = _modules.ClassToModule,
             FunctionToModule = _modules.FunctionToModule,
             EnumToModule = _modules.EnumToModule,
@@ -1065,7 +1064,7 @@ public partial class ILCompiler
             }
 
             // Create context for MoveNext emission
-            var ctx = new CompilationContext(il, _typeMapper, _functions.Builders, _classes.Builders, _types)
+            var ctx = new CompilationContext(il, _typeMapper, _functions.Builders, _classes.Builders, _namespaceFields, _namespaceVarFields, _types)
             {
                 Runtime = _runtime,
                 ClosureAnalyzer = _closures.Analyzer,
@@ -1077,7 +1076,6 @@ public partial class ILCompiler
                 EnumMembers = _enums.Members,
                 EnumReverse = _enums.Reverse,
                 EnumKinds = _enums.Kinds,
-                NamespaceFields = _namespaceFields,
                 TopLevelStaticVars = BuildTopLevelStaticVarsForModule(_modules.CurrentPath),
                 FunctionRestParams = _functions.RestParams,
                 FunctionsCapturingArguments = _functions.CapturingArguments,
@@ -1090,6 +1088,7 @@ public partial class ILCompiler
                 AsyncArrowOuterBuilders = _async.ArrowOuterBuilders,
                 AsyncArrowParentBuilders = _async.ArrowParentBuilders,
                 CurrentModulePath = _modules.CurrentPath,
+                CurrentNamespacePath = _currentNamespacePath,
                 ClassToModule = _modules.ClassToModule,
                 FunctionToModule = _modules.FunctionToModule,
                 EnumToModule = _modules.EnumToModule,

--- a/Compilation/ILCompiler.AsyncGenerators.cs
+++ b/Compilation/ILCompiler.AsyncGenerators.cs
@@ -127,7 +127,7 @@ public partial class ILCompiler
 
         // Create a compilation context for the state machine
         var il = smBuilder.MoveNextAsyncMethod.GetILGenerator();
-        var ctx = new CompilationContext(il, _typeMapper, _functions.Builders, _classes.Builders, _types)
+        var ctx = new CompilationContext(il, _typeMapper, _functions.Builders, _classes.Builders, _namespaceFields, _namespaceVarFields, _types)
         {
             ClosureAnalyzer = _closures.Analyzer,
             ArrowMethods = _closures.ArrowMethods,
@@ -148,6 +148,7 @@ public partial class ILCompiler
             AsyncMethods = null,
             // Module support for multi-module compilation
             CurrentModulePath = _modules.CurrentPath,
+            CurrentNamespacePath = _currentNamespacePath,
             ClassToModule = _modules.ClassToModule,
             FunctionToModule = _modules.FunctionToModule,
             EnumToModule = _modules.EnumToModule,
@@ -196,7 +197,7 @@ public partial class ILCompiler
 
         // Create context for MoveNextAsync emission
         var il = smBuilder.MoveNextAsyncMethod.GetILGenerator();
-        var ctx = new CompilationContext(il, _typeMapper, _functions.Builders, _classes.Builders, _types)
+        var ctx = new CompilationContext(il, _typeMapper, _functions.Builders, _classes.Builders, _namespaceFields, _namespaceVarFields, _types)
         {
             FieldsField = fieldsField,
             IsInstanceMethod = true,
@@ -219,6 +220,7 @@ public partial class ILCompiler
             AsyncMethods = null,
             // Module support for multi-module compilation
             CurrentModulePath = _modules.CurrentPath,
+            CurrentNamespacePath = _currentNamespacePath,
             ClassToModule = _modules.ClassToModule,
             FunctionToModule = _modules.FunctionToModule,
             EnumToModule = _modules.EnumToModule,

--- a/Compilation/ILCompiler.Classes.Accessors.cs
+++ b/Compilation/ILCompiler.Classes.Accessors.cs
@@ -165,7 +165,7 @@ public partial class ILCompiler
         }
 
         var il = methodBuilder.GetILGenerator();
-        var ctx = new CompilationContext(il, _typeMapper, _functions.Builders, _classes.Builders, _types)
+        var ctx = new CompilationContext(il, _typeMapper, _functions.Builders, _classes.Builders, _namespaceFields, _namespaceVarFields, _types)
         {
             FieldsField = fieldsField,
             IsInstanceMethod = !accessor.IsStatic,
@@ -191,6 +191,7 @@ public partial class ILCompiler
             AsyncMethods = null,
             // Module support for multi-module compilation
             CurrentModulePath = _modules.CurrentPath,
+            CurrentNamespacePath = _currentNamespacePath,
             ClassToModule = _modules.ClassToModule,
             FunctionToModule = _modules.FunctionToModule,
             EnumToModule = _modules.EnumToModule,

--- a/Compilation/ILCompiler.Classes.ClassExpressions.cs
+++ b/Compilation/ILCompiler.Classes.ClassExpressions.cs
@@ -472,7 +472,7 @@ public partial class ILCompiler
     {
         string className = _classExprs.Names[classExpr];
 
-        return new CompilationContext(il, _typeMapper, _functions.Builders, _classes.Builders, _types)
+        return new CompilationContext(il, _typeMapper, _functions.Builders, _classes.Builders, _namespaceFields, _namespaceVarFields, _types)
         {
             FieldsField = fieldsField,
             ClosureAnalyzer = _closures.Analyzer,
@@ -493,6 +493,7 @@ public partial class ILCompiler
             TypeMap = _typeMap,
             DeadCode = _deadCodeInfo,
             CurrentModulePath = _modules.CurrentPath,
+            CurrentNamespacePath = _currentNamespacePath,
             ClassToModule = _modules.ClassToModule,
             FunctionToModule = _modules.FunctionToModule,
             EnumToModule = _modules.EnumToModule,

--- a/Compilation/ILCompiler.Classes.Constructors.cs
+++ b/Compilation/ILCompiler.Classes.Constructors.cs
@@ -45,7 +45,7 @@ public partial class ILCompiler
         }
 
         var il = ctorBuilder.GetILGenerator();
-        var ctx = new CompilationContext(il, _typeMapper, _functions.Builders, _classes.Builders, _types)
+        var ctx = new CompilationContext(il, _typeMapper, _functions.Builders, _classes.Builders, _namespaceFields, _namespaceVarFields, _types)
         {
             ClosureAnalyzer = _closures.Analyzer,
             ArrowMethods = _closures.ArrowMethods,
@@ -75,6 +75,7 @@ public partial class ILCompiler
             UnionGenerator = _unionGenerator,
             // Module support for multi-module compilation
             CurrentModulePath = _modules.CurrentPath,
+            CurrentNamespacePath = _currentNamespacePath,
             ClassToModule = _modules.ClassToModule,
             FunctionToModule = _modules.FunctionToModule,
             EnumToModule = _modules.EnumToModule,

--- a/Compilation/ILCompiler.Classes.Methods.cs
+++ b/Compilation/ILCompiler.Classes.Methods.cs
@@ -739,7 +739,7 @@ public partial class ILCompiler
         bool isStatic)
     {
         var il = methodBuilder.GetILGenerator();
-        var ctx = new CompilationContext(il, _typeMapper, _functions.Builders, _classes.Builders, _types)
+        var ctx = new CompilationContext(il, _typeMapper, _functions.Builders, _classes.Builders, _namespaceFields, _namespaceVarFields, _types)
         {
             FieldsField = isStatic ? null : fieldsField,
             IsInstanceMethod = !isStatic,
@@ -763,6 +763,7 @@ public partial class ILCompiler
             DeadCode = _deadCodeInfo,
             AsyncMethods = null,
             CurrentModulePath = _modules.CurrentPath,
+            CurrentNamespacePath = _currentNamespacePath,
             ClassToModule = _modules.ClassToModule,
             FunctionToModule = _modules.FunctionToModule,
             EnumToModule = _modules.EnumToModule,
@@ -923,7 +924,7 @@ public partial class ILCompiler
         bool hasLock = HasLockDecorator(method);
 
         var il = methodBuilder.GetILGenerator();
-        var ctx = new CompilationContext(il, _typeMapper, _functions.Builders, _classes.Builders, _types)
+        var ctx = new CompilationContext(il, _typeMapper, _functions.Builders, _classes.Builders, _namespaceFields, _namespaceVarFields, _types)
         {
             FieldsField = fieldsField,
             IsInstanceMethod = true,
@@ -950,6 +951,7 @@ public partial class ILCompiler
             AsyncArrowParentBuilders = _async.ArrowParentBuilders,
             // Module support for multi-module compilation
             CurrentModulePath = _modules.CurrentPath,
+            CurrentNamespacePath = _currentNamespacePath,
             ClassToModule = _modules.ClassToModule,
             FunctionToModule = _modules.FunctionToModule,
             EnumToModule = _modules.EnumToModule,

--- a/Compilation/ILCompiler.Classes.Static.cs
+++ b/Compilation/ILCompiler.Classes.Static.cs
@@ -62,7 +62,7 @@ public partial class ILCompiler
         );
 
         var il = cctor.GetILGenerator();
-        var ctx = new CompilationContext(il, _typeMapper, _functions.Builders, _classes.Builders, _types)
+        var ctx = new CompilationContext(il, _typeMapper, _functions.Builders, _classes.Builders, _namespaceFields, _namespaceVarFields, _types)
         {
             ClosureAnalyzer = _closures.Analyzer,
             ArrowMethods = _closures.ArrowMethods,
@@ -86,6 +86,7 @@ public partial class ILCompiler
             AsyncMethods = null,
             // Module support for multi-module compilation
             CurrentModulePath = _modules.CurrentPath,
+            CurrentNamespacePath = _currentNamespacePath,
             ClassToModule = _modules.ClassToModule,
             FunctionToModule = _modules.FunctionToModule,
             EnumToModule = _modules.EnumToModule,
@@ -313,7 +314,7 @@ public partial class ILCompiler
         bool hasLock = HasLockDecorator(method);
 
         var il = methodBuilder.GetILGenerator();
-        var ctx = new CompilationContext(il, _typeMapper, _functions.Builders, _classes.Builders, _types)
+        var ctx = new CompilationContext(il, _typeMapper, _functions.Builders, _classes.Builders, _namespaceFields, _namespaceVarFields, _types)
         {
             IsInstanceMethod = false,
             ClosureAnalyzer = _closures.Analyzer,
@@ -337,6 +338,7 @@ public partial class ILCompiler
             AsyncMethods = null,
             // Module support for multi-module compilation
             CurrentModulePath = _modules.CurrentPath,
+            CurrentNamespacePath = _currentNamespacePath,
             ClassToModule = _modules.ClassToModule,
             FunctionToModule = _modules.FunctionToModule,
             EnumToModule = _modules.EnumToModule,
@@ -542,7 +544,7 @@ public partial class ILCompiler
 
         // Create context for MoveNext emission
         var il = smBuilder.MoveNextMethod.GetILGenerator();
-        var ctx = new CompilationContext(il, _typeMapper, _functions.Builders, _classes.Builders, _types)
+        var ctx = new CompilationContext(il, _typeMapper, _functions.Builders, _classes.Builders, _namespaceFields, _namespaceVarFields, _types)
         {
             IsInstanceMethod = false,  // Static method!
             ClosureAnalyzer = _closures.Analyzer,
@@ -569,6 +571,7 @@ public partial class ILCompiler
             AsyncArrowParentBuilders = _async.ArrowParentBuilders,
             // Module support for multi-module compilation
             CurrentModulePath = _modules.CurrentPath,
+            CurrentNamespacePath = _currentNamespacePath,
             ClassToModule = _modules.ClassToModule,
             FunctionToModule = _modules.FunctionToModule,
             EnumToModule = _modules.EnumToModule,

--- a/Compilation/ILCompiler.Functions.cs
+++ b/Compilation/ILCompiler.Functions.cs
@@ -291,7 +291,7 @@ public partial class ILCompiler
         // (state machines, class methods) gets it uniformly, not just this plain-function path.
         Dictionary<string, FieldBuilder>? topLevelVars = BuildTopLevelStaticVarsForModule(_modules.CurrentPath);
 
-        var ctx = new CompilationContext(il, _typeMapper, _functions.Builders, _classes.Builders, _types)
+        var ctx = new CompilationContext(il, _typeMapper, _functions.Builders, _classes.Builders, _namespaceFields, _namespaceVarFields, _types)
         {
             ClosureAnalyzer = _closures.Analyzer,
             ArrowMethods = _closures.ArrowMethods,
@@ -315,6 +315,7 @@ public partial class ILCompiler
             TopLevelStaticVars = topLevelVars,
             // Module support for multi-module compilation
             CurrentModulePath = _modules.CurrentPath,
+            CurrentNamespacePath = _currentNamespacePath,
             ClassToModule = _modules.ClassToModule,
             FunctionToModule = _modules.FunctionToModule,
             EnumToModule = _modules.EnumToModule,
@@ -945,7 +946,7 @@ public partial class ILCompiler
 
         var il = mainMethod.GetILGenerator();
         EmitInstallEventLoopSyncContext(il);
-        var ctx = new CompilationContext(il, _typeMapper, _functions.Builders, _classes.Builders, _types)
+        var ctx = new CompilationContext(il, _typeMapper, _functions.Builders, _classes.Builders, _namespaceFields, _namespaceVarFields, _types)
         {
             ClosureAnalyzer = _closures.Analyzer,
             ArrowMethods = _closures.ArrowMethods,
@@ -960,8 +961,6 @@ public partial class ILCompiler
             EnumMembers = _enums.Members,
             EnumReverse = _enums.Reverse,
             EnumKinds = _enums.Kinds,
-            NamespaceFields = _namespaceFields,
-            NamespaceVarFields = _namespaceVarFields,
             TopLevelStaticVars = BuildTopLevelStaticVarsForModule(_modules.CurrentPath),
             Runtime = _runtime,
             FunctionGenericParams = _functions.GenericParams,
@@ -1106,7 +1105,7 @@ public partial class ILCompiler
 
         var il = mainMethod.GetILGenerator();
         EmitInstallEventLoopSyncContext(il);
-        var ctx = new CompilationContext(il, _typeMapper, _functions.Builders, _classes.Builders, _types)
+        var ctx = new CompilationContext(il, _typeMapper, _functions.Builders, _classes.Builders, _namespaceFields, _namespaceVarFields, _types)
         {
             ClosureAnalyzer = _closures.Analyzer,
             ArrowMethods = _closures.ArrowMethods,
@@ -1121,8 +1120,6 @@ public partial class ILCompiler
             EnumMembers = _enums.Members,
             EnumReverse = _enums.Reverse,
             EnumKinds = _enums.Kinds,
-            NamespaceFields = _namespaceFields,
-            NamespaceVarFields = _namespaceVarFields,
             TopLevelStaticVars = BuildTopLevelStaticVarsForModule(_modules.CurrentPath),
             Runtime = _runtime,
             FunctionGenericParams = _functions.GenericParams,
@@ -1373,7 +1370,7 @@ public partial class ILCompiler
             var il = overload.GetILGenerator();
 
             // Create a minimal context just for emitting default value expressions
-            var ctx = new CompilationContext(il, _typeMapper, _functions.Builders, _classes.Builders, _types)
+            var ctx = new CompilationContext(il, _typeMapper, _functions.Builders, _classes.Builders, _namespaceFields, _namespaceVarFields, _types)
             {
                 ClassRegistry = GetClassRegistry(),
                 Runtime = _runtime,

--- a/Compilation/ILCompiler.Generators.cs
+++ b/Compilation/ILCompiler.Generators.cs
@@ -137,7 +137,7 @@ public partial class ILCompiler
 
         // Create a compilation context for the state machine
         var il = smBuilder.MoveNextMethod.GetILGenerator();
-        var ctx = new CompilationContext(il, _typeMapper, _functions.Builders, _classes.Builders, _types)
+        var ctx = new CompilationContext(il, _typeMapper, _functions.Builders, _classes.Builders, _namespaceFields, _namespaceVarFields, _types)
         {
             ClosureAnalyzer = _closures.Analyzer,
             ArrowMethods = _closures.ArrowMethods,
@@ -158,6 +158,7 @@ public partial class ILCompiler
             AsyncMethods = null,
             // Module support for multi-module compilation
             CurrentModulePath = _modules.CurrentPath,
+            CurrentNamespacePath = _currentNamespacePath,
             ClassToModule = _modules.ClassToModule,
             FunctionToModule = _modules.FunctionToModule,
             EnumToModule = _modules.EnumToModule,
@@ -212,7 +213,7 @@ public partial class ILCompiler
 
         // Create context for MoveNext emission
         var il = smBuilder.MoveNextMethod.GetILGenerator();
-        var ctx = new CompilationContext(il, _typeMapper, _functions.Builders, _classes.Builders, _types)
+        var ctx = new CompilationContext(il, _typeMapper, _functions.Builders, _classes.Builders, _namespaceFields, _namespaceVarFields, _types)
         {
             FieldsField = fieldsField,
             IsInstanceMethod = true,
@@ -235,6 +236,7 @@ public partial class ILCompiler
             AsyncMethods = null,
             // Module support for multi-module compilation
             CurrentModulePath = _modules.CurrentPath,
+            CurrentNamespacePath = _currentNamespacePath,
             ClassToModule = _modules.ClassToModule,
             FunctionToModule = _modules.FunctionToModule,
             EnumToModule = _modules.EnumToModule,

--- a/Compilation/ILCompiler.InnerFunctions.cs
+++ b/Compilation/ILCompiler.InnerFunctions.cs
@@ -439,7 +439,7 @@ public partial class ILCompiler
             // Get resolved parameter types for this inner function
             _innerFunctionParamTypes.TryGetValue(func, out var innerParamTypes);
 
-            var ctx = new CompilationContext(il, _typeMapper, _functions.Builders, _classes.Builders, _types)
+            var ctx = new CompilationContext(il, _typeMapper, _functions.Builders, _classes.Builders, _namespaceFields, _namespaceVarFields, _types)
             {
                 ClosureAnalyzer = _closures.Analyzer,
                 ArrowMethods = _closures.ArrowMethods,
@@ -459,6 +459,7 @@ public partial class ILCompiler
                 DeadCode = _deadCodeInfo,
                 TopLevelStaticVars = BuildTopLevelStaticVarsForModule(_modules.CurrentPath),
                 CurrentModulePath = _modules.CurrentPath,
+                CurrentNamespacePath = _currentNamespacePath,
                 ClassToModule = _modules.ClassToModule,
                 FunctionToModule = _modules.FunctionToModule,
                 EnumToModule = _modules.EnumToModule,

--- a/Compilation/ILCompiler.Modules.cs
+++ b/Compilation/ILCompiler.Modules.cs
@@ -699,7 +699,7 @@ public partial class ILCompiler
     /// </summary>
     private CompilationContext CreateCompilationContext(ILGenerator il)
     {
-        return new CompilationContext(il, _typeMapper, _functions.Builders, _classes.Builders, _types)
+        return new CompilationContext(il, _typeMapper, _functions.Builders, _classes.Builders, _namespaceFields, _namespaceVarFields, _types)
         {
             ClosureAnalyzer = _closures.Analyzer,
             ArrowMethods = _closures.ArrowMethods,
@@ -712,8 +712,6 @@ public partial class ILCompiler
             EnumMembers = _enums.Members,
             EnumReverse = _enums.Reverse,
             EnumKinds = _enums.Kinds,
-            NamespaceFields = _namespaceFields,
-            NamespaceVarFields = _namespaceVarFields,
             // Scope top-level static vars to the current module to prevent
             // cross-module name collisions (e.g. `const foo` in main.ts
             // shadowing `export function foo()` in lib.ts).

--- a/Compilation/ILCompiler.Namespaces.cs
+++ b/Compilation/ILCompiler.Namespaces.cs
@@ -26,6 +26,16 @@ public partial class ILCompiler
     private string? _currentNamespacePath;
 
     /// <summary>
+    /// Namespace function import aliases (<c>import alias = Target.member</c> where the member is
+    /// a function), collected during the define phase as (consumer namespace path, alias stmt)
+    /// and resolved in <see cref="ResolveNamespaceImportAliasFunctions"/> after every namespace is
+    /// defined. Deferring lets the alias point at a sibling namespace's function declared later in
+    /// source. Once namespace member functions are namespace-qualified (#657) the alias can no
+    /// longer ride the simple-name registry, so it is explicitly aliased to the target's builder.
+    /// </summary>
+    private readonly List<(string ConsumerPath, Stmt.ImportAlias Alias)> _pendingNamespaceImportAliasFunctions = [];
+
+    /// <summary>
     /// Qualified state-machine function name -> enclosing namespace path, recorded at define
     /// time for generators / async / async-generators declared in a namespace. Their MoveNext
     /// bodies are emitted in dedicated later phases (<see cref="EmitGeneratorStateMachineBodies"/>
@@ -104,12 +114,58 @@ public partial class ILCompiler
                     case Stmt.Const constStmt:
                         DefineNamespaceVarField(path, constStmt.Name.Lexeme);
                         break;
+
+                    // Function import aliases are resolved after every namespace is defined so the
+                    // target (possibly in a sibling namespace declared later) is already in the
+                    // function registry. See _pendingNamespaceImportAliasFunctions (#657).
+                    case Stmt.ImportAlias importAlias:
+                        _pendingNamespaceImportAliasFunctions.Add((path, importAlias));
+                        break;
                 }
             }
         }
         finally
         {
             _currentNamespacePath = savedNamespacePath;
+        }
+    }
+
+    /// <summary>
+    /// Resolves namespace function import aliases collected during the define phase: for each
+    /// <c>import alias = Target.member</c> whose target is a namespace member function, aliases the
+    /// consumer namespace's qualified key to the target's <see cref="System.Reflection.Emit.MethodBuilder"/>
+    /// (plus its rest/overload metadata) so a call to <c>alias()</c> inside the consumer
+    /// namespace's bodies dispatches to the target. Runs after all namespaces are defined (#657).
+    /// </summary>
+    private void ResolveNamespaceImportAliasFunctions()
+    {
+        foreach (var (consumerPath, importAlias) in _pendingNamespaceImportAliasFunctions)
+        {
+            var qpath = importAlias.QualifiedPath;
+            if (qpath.Count < 2)
+                continue; // need at least Namespace.member to denote a namespace function
+
+            string targetNsPath = string.Join(".", qpath.Take(qpath.Count - 1).Select(t => t.Lexeme));
+            string targetMember = qpath[^1].Lexeme;
+
+            // Qualify the target member under the target namespace, and the alias name under the
+            // consumer namespace, reusing GetQualifiedFunctionName via the definition context.
+            var savedNs = _currentNamespacePath;
+            _currentNamespacePath = targetNsPath;
+            string targetKey = GetDefinitionContext().GetQualifiedFunctionName(targetMember);
+            _currentNamespacePath = consumerPath;
+            string aliasKey = GetDefinitionContext().GetQualifiedFunctionName(importAlias.AliasName.Lexeme);
+            _currentNamespacePath = savedNs;
+
+            if (_functions.Builders.TryGetValue(targetKey, out var targetBuilder)
+                && !_functions.Builders.ContainsKey(aliasKey))
+            {
+                _functions.Builders[aliasKey] = targetBuilder;
+                if (_functions.RestParams.TryGetValue(targetKey, out var rp))
+                    _functions.RestParams[aliasKey] = rp;
+                if (_functions.Overloads.TryGetValue(targetKey, out var ov))
+                    _functions.Overloads[aliasKey] = ov;
+            }
         }
     }
 

--- a/Compilation/ILCompiler.cs
+++ b/Compilation/ILCompiler.cs
@@ -329,7 +329,7 @@ public partial class ILCompiler
     /// </summary>
     private CompilationContext GetDefinitionContext()
     {
-        _definitionContext ??= new CompilationContext(null!, _typeMapper, _functions.Builders, _classes.Builders, _types)
+        _definitionContext ??= new CompilationContext(null!, _typeMapper, _functions.Builders, _classes.Builders, _namespaceFields, _namespaceVarFields, _types)
         {
             ClassToModule = _modules.ClassToModule,
             FunctionToModule = _modules.FunctionToModule,
@@ -338,6 +338,9 @@ public partial class ILCompiler
             // Note: ClassRegistry intentionally not set here - definition context uses raw dictionaries
         };
         _definitionContext.CurrentModulePath = _modules.CurrentPath;
+        // Keep the definition context's namespace in sync so GetQualifiedFunctionName produces
+        // namespace-qualified keys while a namespace's members are being defined/collected (#657).
+        _definitionContext.CurrentNamespacePath = _currentNamespacePath;
         _definitionContext.DotNetNamespace = _modules.CurrentDotNetNamespace;
         _definitionContext.IsStrictMode = _isStrictMode;
         return _definitionContext;
@@ -624,6 +627,10 @@ public partial class ILCompiler
         {
             DefineDeclarationFromStatement(stmt);
         }
+
+        // Alias namespace function import aliases to their targets now that every namespace
+        // member function is in the registry (#657).
+        ResolveNamespaceImportAliasFunctions();
 
         // Define static fields for top-level variables captured by async functions
         DefineTopLevelCapturedVariables(statements);
@@ -973,6 +980,10 @@ public partial class ILCompiler
         }
         _modules.CurrentPath = null;
         _modules.CurrentDotNetNamespace = null;
+
+        // Alias namespace function import aliases to their targets now that every namespace
+        // member function is in the registry (#657).
+        ResolveNamespaceImportAliasFunctions();
     }
 
     /// <summary>

--- a/Compilation/ILEmitter.Namespaces.cs
+++ b/Compilation/ILEmitter.Namespaces.cs
@@ -27,11 +27,59 @@ public partial class ILEmitter
             return;
         }
 
-        // Emit namespace members
-        foreach (var member in ns.Members)
+        // Emit members under namespace-scoped resolution (#657): set CurrentNamespacePath so
+        // member function lookups (ResolveFunctionName) resolve to namespace-qualified registry
+        // keys, and augment TopLevelStaticVars with the namespace's var backing fields so member
+        // var initializers and sibling references read/write the namespace's own field rather
+        // than a same-named module-level binding. Saved/restored to support nesting and the
+        // surrounding module scope.
+        var savedNsPath = _ctx.CurrentNamespacePath;
+        var savedTopLevel = _ctx.TopLevelStaticVars;
+        _ctx.CurrentNamespacePath = path;
+        _ctx.TopLevelStaticVars = BuildNamespaceScopedTopLevelVars(savedTopLevel, path);
+        try
         {
-            EmitNamespaceMember(member, nsField, path);
+            foreach (var member in ns.Members)
+            {
+                EmitNamespaceMember(member, nsField, path);
+            }
         }
+        finally
+        {
+            _ctx.CurrentNamespacePath = savedNsPath;
+            _ctx.TopLevelStaticVars = savedTopLevel;
+        }
+    }
+
+    /// <summary>
+    /// Returns <paramref name="moduleVars"/> augmented with the static var backing fields of
+    /// every namespace enclosing <paramref name="nsPath"/> (innermost wins). Used while emitting
+    /// a namespace's member initializers so a bare reference to a namespace var resolves to its
+    /// backing field, shadowing a same-named module binding (#657). Mirrors
+    /// <c>ILCompiler.BuildNamespaceScopedStaticVars</c>, which does the same for function bodies.
+    /// </summary>
+    private Dictionary<string, FieldBuilder>? BuildNamespaceScopedTopLevelVars(
+        Dictionary<string, FieldBuilder>? moduleVars, string nsPath)
+    {
+        if (_ctx.NamespaceVarFields == null)
+            return moduleVars;
+
+        var merged = moduleVars != null
+            ? new Dictionary<string, FieldBuilder>(moduleVars)
+            : [];
+
+        string prefix = "";
+        foreach (var part in nsPath.Split('.'))
+        {
+            prefix = prefix.Length == 0 ? part : $"{prefix}.{part}";
+            if (_ctx.NamespaceVarFields.TryGetValue(prefix, out var fields))
+            {
+                foreach (var (name, field) in fields)
+                    merged[name] = field;
+            }
+        }
+
+        return merged;
     }
 
     /// <summary>
@@ -80,19 +128,11 @@ public partial class ILEmitter
                 break;
 
             case Stmt.Var varStmt:
-                // Emit variable declaration (creates a local for same-namespace-init reads),
-                // publish to the namespace object (external `N.x`), and mirror into the static
-                // backing field so functions in the namespace can resolve the bare name (#567).
-                EmitStatement(varStmt);
-                StoreLocalInNamespaceField(nsField, memberName!);
-                StoreLocalInNamespaceStaticField(nsPath, memberName!);
+                EmitNamespaceMemberVar(nsField, nsPath, memberName!, varStmt.Initializer, varStmt.TypeAnnotation);
                 break;
 
             case Stmt.Const constStmt:
-                // Emit const declaration (see Stmt.Var above for the three storage targets).
-                EmitStatement(constStmt);
-                StoreLocalInNamespaceField(nsField, memberName!);
-                StoreLocalInNamespaceStaticField(nsPath, memberName!);
+                EmitNamespaceMemberVar(nsField, nsPath, memberName!, constStmt.Initializer, constStmt.TypeAnnotation);
                 break;
 
             case Stmt.Class classStmt:
@@ -235,29 +275,54 @@ public partial class ILEmitter
     }
 
     /// <summary>
-    /// Mirrors a namespace-level variable's value from its emitted local into the namespace's
-    /// static backing field, so functions declared in the namespace resolve the bare name via
-    /// the standard top-level-static-var path (#567). No-op when no backing field was defined
-    /// (e.g. a non-variable member).
+    /// Emits a namespace member variable (var/let/const). The initializer is evaluated once —
+    /// reads inside it resolve to namespace backing fields via the namespace-scoped
+    /// <see cref="CompilationContext.TopLevelStaticVars"/> augmentation set up in
+    /// <see cref="EmitNamespace"/> — then published to BOTH the static backing field
+    /// (<c>$nsvar_…</c>, which member functions resolve the bare name through, #567) and the
+    /// namespace object (external <c>N.x</c>). Crucially it does NOT route through the
+    /// module-top-level var path, so a namespace member whose name collides with a module-level
+    /// binding no longer clobbers that binding's slot (#657).
     /// </summary>
-    private void StoreLocalInNamespaceStaticField(string nsPath, string memberName)
+    private void EmitNamespaceMemberVar(FieldBuilder nsField, string nsPath, string memberName, Expr? initializer, string? typeAnnotation)
     {
-        if (_ctx.NamespaceVarFields == null ||
-            !_ctx.NamespaceVarFields.TryGetValue(nsPath, out var fields) ||
-            !fields.TryGetValue(memberName, out var nsVarField))
+        // Locate the backing field (DefineNamespaceVarField created one for every namespace var).
+        FieldBuilder? backingField = null;
+        if (_ctx.NamespaceVarFields != null &&
+            _ctx.NamespaceVarFields.TryGetValue(nsPath, out var fields))
         {
-            return;
+            fields.TryGetValue(memberName, out backingField);
         }
 
-        var memberLocal = _ctx.Locals.GetLocal(memberName);
-        if (memberLocal != null)
+        // Evaluate the initializer (or the type-driven / undefined default), boxed to object.
+        if (initializer != null)
         {
-            IL.Emit(OpCodes.Ldloc, memberLocal);
-            if (memberLocal.LocalType.IsValueType)
-            {
-                IL.Emit(OpCodes.Box, memberLocal.LocalType);
-            }
-            IL.Emit(OpCodes.Stsfld, nsVarField);
+            EmitExpression(initializer);
+            EmitBoxIfNeeded(initializer);
         }
+        else if (typeAnnotation == "number")
+        {
+            IL.Emit(OpCodes.Ldc_R8, 0.0);
+            IL.Emit(OpCodes.Box, _ctx.Types.Double);
+        }
+        else
+        {
+            IL.Emit(OpCodes.Ldsfld, _ctx.Runtime!.UndefinedInstance);
+        }
+
+        // Stash once, then publish to the backing field and the namespace object.
+        var valueLocal = IL.DeclareLocal(_ctx.Types.Object);
+        IL.Emit(OpCodes.Stloc, valueLocal);
+
+        if (backingField != null)
+        {
+            IL.Emit(OpCodes.Ldloc, valueLocal);
+            IL.Emit(OpCodes.Stsfld, backingField);
+        }
+
+        IL.Emit(OpCodes.Ldsfld, nsField);
+        IL.Emit(OpCodes.Ldstr, memberName);
+        IL.Emit(OpCodes.Ldloc, valueLocal);
+        IL.Emit(OpCodes.Call, _ctx.Runtime!.TSNamespaceSet);
     }
 }

--- a/Compilation/ILEmitter.Properties.cs
+++ b/Compilation/ILEmitter.Properties.cs
@@ -15,50 +15,6 @@ namespace SharpTS.Compilation;
 /// </summary>
 public partial class ILEmitter
 {
-    /// <summary>
-    /// Emits a read of a namespace-level variable through its static backing field when
-    /// <paramref name="g"/> is <c>N.x</c> (or nested <c>N.M.x</c>) and <c>x</c> is a known
-    /// namespace var/let/const. This makes external access observe the live binding that member
-    /// functions mutate, rather than the snapshot stored in the namespace object at declaration
-    /// (#623). Returns false (leaving the normal property-get path) when the object is not a
-    /// namespace path or the member is not a namespace variable.
-    /// </summary>
-    private bool TryEmitNamespaceVarGet(Expr.Get g)
-    {
-        if (_ctx.NamespaceVarFields == null) return false;
-
-        string? nsPath = ResolveNamespacePathForGet(g.Object);
-        if (nsPath == null) return false;
-
-        if (_ctx.NamespaceVarFields.TryGetValue(nsPath, out var fields) &&
-            fields.TryGetValue(g.Name.Lexeme, out var field))
-        {
-            IL.Emit(OpCodes.Ldsfld, field);
-            SetStackUnknown();
-            return true;
-        }
-        return false;
-    }
-
-    /// <summary>
-    /// Resolves an expression to the dotted path of the namespace it denotes (e.g. <c>N</c> or
-    /// <c>N.M</c>), or null if it is not a reference to a known namespace. Used by
-    /// <see cref="TryEmitNamespaceVarGet"/> to locate a namespace var's backing field.
-    /// </summary>
-    private string? ResolveNamespacePathForGet(Expr obj)
-    {
-        switch (obj)
-        {
-            case Expr.Variable v when _ctx.NamespaceFields?.ContainsKey(v.Name.Lexeme) == true:
-                return v.Name.Lexeme;
-            case Expr.Get get when ResolveNamespacePathForGet(get.Object) is { } parent:
-                string candidate = $"{parent}.{get.Name.Lexeme}";
-                return _ctx.NamespaceFields?.ContainsKey(candidate) == true ? candidate : null;
-            default:
-                return null;
-        }
-    }
-
     protected override void EmitGet(Expr.Get g)
     {
         // CommonJS: `module.exports` reads → ldsfld $exports

--- a/Execution/Interpreter.Namespaces.cs
+++ b/Execution/Interpreter.Namespaces.cs
@@ -93,6 +93,7 @@ public partial class Interpreter
                 Stmt.Function f => f.Name.Lexeme,
                 Stmt.Class c => c.Name.Lexeme,
                 Stmt.Var v => v.Name.Lexeme,
+                Stmt.Const ct => ct.Name.Lexeme,  // namespace-scoped const (#467)
                 Stmt.Enum e => e.Name.Lexeme,
                 Stmt.Namespace n => n.Name.Lexeme,
                 Stmt.Interface => null,  // Type-only, no runtime value
@@ -109,6 +110,7 @@ public partial class Interpreter
                     Stmt.Function f => f.Name,
                     Stmt.Class c => c.Name,
                     Stmt.Var v => v.Name,
+                    Stmt.Const ct => ct.Name,  // namespace-scoped const (#467)
                     Stmt.Enum e => e.Name,
                     Stmt.Namespace n => n.Name,
                     _ => null

--- a/Parsing/Parser.Namespaces.cs
+++ b/Parsing/Parser.Namespaces.cs
@@ -113,7 +113,10 @@ public partial class Parser
             {
                 return WrapIfExported(EnumDeclaration(isConst: true), isExported);
             }
-            return WrapIfExported(VarDeclaration(), isExported);
+            // A namespace-scoped `const` must parse as Stmt.Const (not the default mutable
+            // Stmt.Var) so const-ness — literal-type narrowing and reassignment checks — is
+            // preserved, mirroring the module-export path fixed in #428 (#467).
+            return WrapIfExported(VarDeclaration(isConst: true), isExported);
         }
         if (Match(TokenType.ENUM))
         {

--- a/SharpTS.Tests/SharedTests/NamespaceTests.cs
+++ b/SharpTS.Tests/SharedTests/NamespaceTests.cs
@@ -484,4 +484,201 @@ public class NamespaceTests
     }
 
     #endregion
+
+    #region Compiled namespace member fixes (#656, #657, #659, #660, #467)
+
+    // #656 — a namespace must be resolvable by its bare name from a NON-member function body.
+    // Compiled mode previously only carried the namespace static field on a subset of emission
+    // contexts, so a top-level function reading `N.c` threw "Undefined variable 'N'".
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Namespace_ResolvableByBareName_FromTopLevelFunction(ExecutionMode mode)
+    {
+        var code = @"
+            namespace N { export const c = 5; }
+            function f() { return N.c; }
+            console.log(f());
+        ";
+        Assert.Equal("5\n", TestHarness.Run(code, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Namespace_MemberCall_FromTopLevelFunction(ExecutionMode mode)
+    {
+        var code = @"
+            namespace N { export function ping() { return 9; } }
+            function f() { return N.ping(); }
+            console.log(f());
+        ";
+        Assert.Equal("9\n", TestHarness.Run(code, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Namespace_ExportedVar_IsLiveBinding_FromAsyncFunctionBody(ExecutionMode mode)
+    {
+        // The async function reads N.count AFTER two mutations; it must observe the live
+        // binding (2), not the declaration-time snapshot (0). The #623 redirect now lives in
+        // the shared ExpressionEmitterBase so state-machine bodies pick it up too (#656).
+        var code = @"
+            namespace N { export let count = 0; export function inc() { count++; } }
+            async function f() { return N.count; }
+            N.inc(); N.inc();
+            f().then(v => console.log(v));
+        ";
+        Assert.Equal("2\n", TestHarness.Run(code, mode));
+    }
+
+    // #657 — namespace var/function members must not collide with module-level or
+    // sibling-namespace bindings of the same name.
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void NamespaceVar_DoesNotClobber_ModuleVar(ExecutionMode mode)
+    {
+        var code = @"
+            const v = 100;
+            namespace N { const v = 5; export const w = v; }
+            console.log(v, N.w);
+        ";
+        Assert.Equal("100 5\n", TestHarness.Run(code, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void SiblingNamespaceFunctions_SameName_DoNotCollide(ExecutionMode mode)
+    {
+        var code = @"
+            namespace A { export function f() { return 1; } }
+            namespace B { export function f() { return 2; } }
+            console.log(A.f(), B.f());
+        ";
+        Assert.Equal("1 2\n", TestHarness.Run(code, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void NamespaceFunction_CallsNonExportedSibling(ExecutionMode mode)
+    {
+        var code = @"
+            namespace N { function helper() { return 41; } export function f() { return helper() + 1; } }
+            console.log(N.f());
+        ";
+        Assert.Equal("42\n", TestHarness.Run(code, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void NamespaceFunction_Recursive(ExecutionMode mode)
+    {
+        var code = @"
+            namespace N { export function fib(n: number): number { return n < 2 ? n : fib(n-1) + fib(n-2); } }
+            console.log(N.fib(10));
+        ";
+        Assert.Equal("55\n", TestHarness.Run(code, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void NamespaceFunction_FallsBackToTopLevelFunction(ExecutionMode mode)
+    {
+        var code = @"
+            function g() { return 9; }
+            namespace N { export function f() { return g(); } }
+            console.log(N.f());
+        ";
+        Assert.Equal("9\n", TestHarness.Run(code, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void NamespaceFunction_ShadowsTopLevelFunctionOfSameName(ExecutionMode mode)
+    {
+        // A namespace member function with the same simple name as a top-level function must
+        // stay distinct: N.f() is 5, the bare top-level f() is 100. A sibling reference inside
+        // the namespace resolves to the namespace's own helper, shadowing the top-level one.
+        var code = @"
+            function helper() { return 100; }
+            namespace N { function helper() { return 5; } export function f() { return helper(); } }
+            console.log(N.f(), helper());
+        ";
+        Assert.Equal("5 100\n", TestHarness.Run(code, mode));
+    }
+
+    // #659 — arrow-function and async-generator namespace members must be callable via N.member.
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ArrowFunctionNamespaceMember_IsCallable(ExecutionMode mode)
+    {
+        var code = @"
+            namespace N { export const f = () => 42; }
+            console.log(N.f());
+        ";
+        Assert.Equal("42\n", TestHarness.Run(code, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AsyncGeneratorNamespaceMember_IsCallableAndIterable(ExecutionMode mode)
+    {
+        // The async-generator member is callable and iterable via `for await` inside an async
+        // FUNCTION. (The same loop inside an async ARROW trips a separate, pre-existing async-
+        // arrow `for await` lowering bug tracked by #430/#645, independent of namespaces.)
+        var code = @"
+            namespace N { export async function* g() { yield 1; yield 2; } }
+            async function run() { for await (const x of N.g()) console.log(x); }
+            run();
+        ";
+        Assert.Equal("1\n2\n", TestHarness.Run(code, mode));
+    }
+
+    // #660 — a nested function declaration inside a namespace member function must be callable.
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void NestedFunctionDeclaration_InsideNamespaceMemberFunction(ExecutionMode mode)
+    {
+        var code = @"
+            namespace N {
+                export function f() {
+                    function inner() { return 1; }
+                    return inner();
+                }
+            }
+            console.log(N.f());
+        ";
+        Assert.Equal("1\n", TestHarness.Run(code, mode));
+    }
+
+    // #467 — a namespace-scoped `export const` parses as Stmt.Const, so it carries the narrowed
+    // literal type (and reassignment is rejected), matching tsc and the module-export fix #428.
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void NamespaceExportConst_HasLiteralType(ExecutionMode mode)
+    {
+        // Before #467 this raised TS2322 ("Type 'number' is not assignable to type '5'") because
+        // the namespace const was parsed as a mutable Stmt.Var and its type widened to number.
+        var code = @"
+            namespace N { export const x = 5; }
+            const exact: 5 = N.x;
+            console.log(exact);
+        ";
+        Assert.Equal("5\n", TestHarness.Run(code, mode));
+    }
+
+    [Fact]
+    public void NamespaceExportConst_ReassignmentIsRejected()
+    {
+        var code = @"
+            namespace N { export const x = 5; }
+            N.x = 6;
+        ";
+        Assert.ThrowsAny<Exception>(() => TestHarness.RunInterpreted(code));
+    }
+
+    #endregion
 }

--- a/TypeSystem/TypeChecker.Namespaces.cs
+++ b/TypeSystem/TypeChecker.Namespaces.cs
@@ -227,6 +227,20 @@ public partial class TypeChecker
                 }
                 break;
 
+            // A namespace-scoped `const` (since #467) registers its binding in the namespace's
+            // values exactly like `Stmt.Var`, but carries the narrowed literal type from const
+            // checking (e.g. `export const x = 5` ⇒ `N.x` has type `5`, matching tsc). Without
+            // this arm the const fell to `default` and was type-checked but never registered,
+            // so `N.x` was not a visible member.
+            case Stmt.Const constStmt:
+                CheckStmt(constStmt);
+                var constType = _environment.Get(constStmt.Name.Lexeme);
+                if (constType != null)
+                {
+                    values[constStmt.Name.Lexeme] = constType;
+                }
+                break;
+
             case Stmt.Class:
             case Stmt.Namespace:
             case Stmt.Interface:


### PR DESCRIPTION
Five namespace fixes — four compiled-mode follow-ups to #567/#623 plus the parser sibling of #428. Every change is gated behind namespace constructs, so namespace-free programs are unaffected (verified Test262-neutral below).

## Fixes

- **Fixes #467** — a namespace-scoped `const`/`export const` parsed as a mutable `Stmt.Var`, widening the literal type. `NamespaceMember()` now passes `VarDeclaration(isConst: true)`; the type-checker + interpreter gain `Stmt.Const` arms that register the binding (with the narrowed literal type, so `N.x` is `5`, matching tsc).
- **Fixes #656** — a namespace was unresolvable by bare name from a non-member function body (`ReferenceError 'N'`) because the `$ns_N` field map was set on only a subset of emission contexts. `NamespaceFields`/`NamespaceVarFields` are now threaded through the `CompilationContext` constructor, so every context carries them. The #623 namespace-var live-binding redirect moves into the shared `ExpressionEmitterBase.EmitGet`, so async/generator state-machine bodies observe live bindings too.
- **Fixes #657** — namespace var/function members collided with module-level and sibling-namespace bindings of the same name. Member functions get namespace-qualified registry keys (`$nsfn_<path>_<name>`); `ResolveFunctionName` walks namespace prefixes innermost→outermost (both gated on `CurrentNamespacePath`, so non-namespace resolution is byte-identical). Member var/const init routes to the namespace backing field only (no module-slot clobber). Function import aliases inside a namespace are re-aliased to their target builder in a deferred fixup.
- **Fixes #659** — `CollectArrowsFromStmt` now recurses into namespace members (it never did), so an `export const f = () => ...` member is materialized and callable. The async-generator member is likewise callable and iterable — its `for await` inside an async **function** works. ⚠️ The issue's async-**arrow** repro additionally trips a separate, pre-existing async-arrow `for await` lowering bug already tracked by #430/#645 (direct async generators fail there identically, no namespace involved).
- **Fixes #660** — a nested function declaration inside a namespace member function threw "Undefined variable"; the same `CollectArrowsFromStmt` namespace traversal now lifts those inner functions.

## Tests

14 namespace regression tests added to `NamespaceTests.cs`: bare-name resolution, live binding from async bodies, var/function collisions, sibling/recursion/fallback/shadow resolution, arrow + async-gen members, nested fn, const literal type + reassignment rejection.

## Verification

- Full suite **12658 pass / 0 fail**
- TypeScriptConformance **31 / 0** (no baseline shift)
- Test262 interpreted (18/186) and compiled (40/65) baseline drift is **byte-identical on clean origin/main** (`Pass=7905, Fail=1854` both) → pre-existing environmental flakiness (clean main itself crashes the testhost). Changes are Test262-neutral in both modes; **baselines untouched**.

## Follow-up filed

#665 — type checker: a nested namespace member cannot reference an outer namespace's member by bare name (pre-existing lexical-scope gap, both modes; out of scope here).