### PR TITLE
Fix #649: compiled for(let) closure captures the loop's final value in function bodies

### DIFF
--- a/Compilation/ClosureAnalyzer.cs
+++ b/Compilation/ClosureAnalyzer.cs
@@ -51,6 +51,23 @@ public class ClosureAnalyzer : AstVisitorBase
     // name-matching across unrelated scopes (which aliases shadowed names).
     private readonly Dictionary<object, Dictionary<string, object>> _captureSources = [];
 
+    // Maps function/arrow node → names it declares as `for (let/const …)` loop
+    // bindings. Each iteration of such a loop gets its OWN binding (ECMA-262
+    // 13.7.4 CreatePerIterationEnvironment), so a closure created in one iteration
+    // must capture a value distinct from other iterations. The shared function
+    // display class is a SINGLE instance per call, so routing a per-iteration loop
+    // binding through it makes every closure read the loop's final value (#649).
+    // Excluding these from the function DC keeps them as locals / state-machine
+    // fields that closures snapshot per iteration — matching the top-level case,
+    // which already stays correct for the same reason.
+    private readonly Dictionary<object, HashSet<string>> _functionLoopBindings = [];
+
+    // Names declared by a NON-loop binding in a function/arrow (params, plain
+    // `let`/`const`/`var`). Used to keep the per-iteration exclusion shadow-safe:
+    // a name that is also an ordinary captured-and-mutated local must keep its
+    // shared function-DC slot, so it is excluded from the loop-binding set.
+    private readonly Dictionary<object, HashSet<string>> _functionNonLoopDecls = [];
+
     // ============================================
     // Performance optimization: Inverse index
     // ============================================
@@ -94,6 +111,26 @@ public class ClosureAnalyzer : AstVisitorBase
     public bool HasCapturedLocals(object functionNode)
     {
         return _functionCapturedLocals.TryGetValue(functionNode, out var locals) && locals.Count > 0;
+    }
+
+    /// <summary>
+    /// Returns the names that <paramref name="functionNode"/> declares EXCLUSIVELY as
+    /// <c>for (let/const …)</c> loop bindings (never also as an ordinary local/param).
+    /// These must be kept out of the shared function display class so closures created
+    /// in different iterations capture distinct per-iteration values (ECMA-262 13.7.4;
+    /// #649). Callers intersect this with the captured-locals set.
+    /// </summary>
+    public HashSet<string> GetPerIterationLoopBindings(object functionNode)
+    {
+        if (!_functionLoopBindings.TryGetValue(functionNode, out var bindings) || bindings.Count == 0)
+            return [];
+        var result = new HashSet<string>(bindings);
+        // Shadow-safety: a name that is ALSO an ordinary declaration in this function
+        // keeps its shared slot (an ordinary captured-and-mutated local must stay in
+        // the function DC). Only purely-loop bindings are eligible for exclusion.
+        if (_functionNonLoopDecls.TryGetValue(functionNode, out var nonLoop))
+            result.ExceptWith(nonLoop);
+        return result;
     }
 
     /// <summary>
@@ -171,7 +208,22 @@ public class ClosureAnalyzer : AstVisitorBase
         // Track local variables for the current function
         if (_currentFunction != null && _localVars.TryGetValue(_currentFunction, out var locals))
             locals.Add(name);
+
+        // Record every NON-loop declaration so the per-iteration exclusion stays
+        // shadow-safe (see _functionNonLoopDecls). A for-let/const loop binding is
+        // declared with its name parked in _pendingLoopBindings, so it is skipped
+        // here and counts only as a loop binding.
+        if (_currentFunction != null && !_pendingLoopBindings.Contains(name))
+        {
+            if (!_functionNonLoopDecls.TryGetValue(_currentFunction, out var nonLoop))
+                _functionNonLoopDecls[_currentFunction] = nonLoop = [];
+            nonLoop.Add(name);
+        }
     }
+
+    // Loop-binding names currently being declared by a for-initializer, so
+    // DeclareVariable records them as loop bindings rather than ordinary locals.
+    private readonly HashSet<string> _pendingLoopBindings = [];
 
     private void ReferenceVariable(string name)
     {
@@ -357,13 +409,58 @@ public class ClosureAnalyzer : AstVisitorBase
         // For loops create a scope for the loop variable (e.g., let i in "for (let i = 0; ...)")
         EnterScope();
         if (stmt.Initializer != null)
-            Visit(stmt.Initializer);
+        {
+            // Record `for (let/const …)` loop bindings for the enclosing function so the
+            // per-iteration exclusion can keep them out of the shared function display
+            // class (#649). Parked in _pendingLoopBindings across the initializer visit
+            // so DeclareVariable classifies them as loop bindings, not ordinary locals.
+            var loopNames = CollectLoopBindingNames(stmt.Initializer);
+            if (loopNames != null && _currentFunction != null)
+            {
+                if (!_functionLoopBindings.TryGetValue(_currentFunction, out var bindings))
+                    _functionLoopBindings[_currentFunction] = bindings = [];
+                foreach (var n in loopNames) { bindings.Add(n); _pendingLoopBindings.Add(n); }
+                Visit(stmt.Initializer);
+                foreach (var n in loopNames) _pendingLoopBindings.Remove(n);
+            }
+            else
+            {
+                Visit(stmt.Initializer);
+            }
+        }
         if (stmt.Condition != null)
             Visit(stmt.Condition);
         if (stmt.Increment != null)
             Visit(stmt.Increment);
         Visit(stmt.Body);
         ExitScope();
+    }
+
+    /// <summary>
+    /// Returns the names a for-initializer binds per iteration (ECMA-262 13.7.4):
+    /// <c>let</c>/<c>const</c> declarations. Returns <c>null</c> for <c>var</c> or
+    /// expression initializers, which share one binding across the whole loop.
+    /// Mirrors <c>Interpreter.CollectPerIterationBindings</c>.
+    /// </summary>
+    private static List<string>? CollectLoopBindingNames(Stmt? initializer)
+    {
+        switch (initializer)
+        {
+            case Stmt.Var v when !v.IsVar:
+                return [v.Name.Lexeme];
+            case Stmt.Const c:
+                return [c.Name.Lexeme];
+            case Stmt.Sequence seq:
+                List<string>? names = null;
+                foreach (var s in seq.Statements)
+                {
+                    var sub = CollectLoopBindingNames(s);
+                    if (sub != null) (names ??= []).AddRange(sub);
+                }
+                return names;
+            default:
+                return null;
+        }
     }
 
     protected override void VisitTryCatch(Stmt.TryCatch stmt)

--- a/Compilation/ILCompiler.ArrowFunctions.cs
+++ b/Compilation/ILCompiler.ArrowFunctions.cs
@@ -899,6 +899,21 @@ public partial class ILCompiler
         if (capturedLocals.Count == 0)
             return;
 
+        // Per-iteration `for (let/const …)` loop bindings must NOT share this scope
+        // display class (a single instance per arrow/inner-function call): each
+        // iteration gets its own binding (ECMA-262 13.7.4), so a closure created in
+        // one iteration must capture a value distinct from other iterations. Keeping
+        // them out of the scope DC leaves them as locals that nested closures snapshot
+        // per iteration — mirroring the function-DC exclusion (#649).
+        var perIterationBindings = _closures.Analyzer.GetPerIterationLoopBindings(callable);
+        if (perIterationBindings.Count > 0)
+        {
+            capturedLocals = new HashSet<string>(capturedLocals);
+            capturedLocals.ExceptWith(perIterationBindings);
+            if (capturedLocals.Count == 0)
+                return;
+        }
+
         var displayClass = _moduleBuilder.DefineType(
             $"<>c__{nameSuffix}{_closures.DisplayClassCounter++}",
             TypeAttributes.Public | TypeAttributes.Sealed | TypeAttributes.BeforeFieldInit,
@@ -1268,7 +1283,11 @@ public partial class ILCompiler
             il.Emit(OpCodes.Stloc, arrowScopeDCLocal);
             ctx.ArrowScopeDisplayClassLocal = arrowScopeDCLocal;
             ctx.ArrowScopeDisplayClassFields = _closures.ArrowScopeDisplayClassFields[arrow];
-            ctx.CapturedArrowLocals = _closures.Analyzer.GetCapturedLocals(arrow);
+            // Derive from the DC's actual field map (not the raw analyzer set) so
+            // per-iteration loop bindings excluded by DefineScopeDisplayClass (#649)
+            // are also excluded here — keeping CapturedArrowLocals consistent with
+            // the fields the DC actually has.
+            ctx.CapturedArrowLocals = [.. _closures.ArrowScopeDisplayClassFields[arrow].Keys];
         }
 
         var emitter = new ILEmitter(ctx);

--- a/Compilation/ILCompiler.Functions.cs
+++ b/Compilation/ILCompiler.Functions.cs
@@ -224,6 +224,21 @@ public partial class ILCompiler
         if (capturedLocals.Count == 0)
             return;
 
+        // Per-iteration `for (let/const …)` loop bindings must NOT share the function
+        // display class (a single instance per call): each iteration gets its own
+        // binding (ECMA-262 13.7.4), so closures created in different iterations must
+        // capture distinct values. Keeping them out of the function DC leaves them as
+        // locals / state-machine fields that closures snapshot per iteration — matching
+        // the already-correct top-level case (#649).
+        var perIterationBindings = _closures.Analyzer.GetPerIterationLoopBindings(funcStmt);
+        if (perIterationBindings.Count > 0)
+        {
+            capturedLocals = new HashSet<string>(capturedLocals);
+            capturedLocals.ExceptWith(perIterationBindings);
+            if (capturedLocals.Count == 0)
+                return;
+        }
+
         // For async functions, exclude variables that are also captured by async arrows.
         // Those use the hoisted field mechanism and would conflict with the function DC.
         if (_closures.AsyncCapturedVarsExclusion.TryGetValue(qualifiedFunctionName, out var exclusions))
@@ -280,9 +295,15 @@ public partial class ILCompiler
         var methodBuilder = _functions.Builders[qualifiedFunctionName];
         var il = methodBuilder.GetILGenerator();
 
-        // Check if this function has captured locals that need a display class
+        // Check if this function has captured locals that need a display class.
+        // Derive the captured-local set from the display class's actual field map
+        // (not the raw analyzer set) so per-iteration loop bindings excluded by
+        // DefineFunctionDisplayClass (#649) are also excluded here — otherwise
+        // CapturedFunctionLocals would claim a loop var the DC has no field for.
         var hasFunctionDC = _closures.FunctionDisplayClasses.TryGetValue(qualifiedFunctionName, out var functionDCType);
-        var capturedLocals = hasFunctionDC ? _closures.Analyzer.GetCapturedLocals(funcStmt) : null;
+        var capturedLocals = hasFunctionDC && _closures.FunctionDisplayClassFields.TryGetValue(qualifiedFunctionName, out var hasFuncDCFields)
+            ? new HashSet<string>(hasFuncDCFields.Keys)
+            : null;
 
         // Build module-scoped top-level vars so this function only sees its own
         // module's bindings plus global imports. When emitting a namespace member body this

--- a/Compilation/ILCompiler.InnerFunctions.cs
+++ b/Compilation/ILCompiler.InnerFunctions.cs
@@ -594,7 +594,9 @@ public partial class ILCompiler
                 il.Emit(OpCodes.Stloc, ownScopeDCLocal);
                 ctx.ArrowScopeDisplayClassLocal = ownScopeDCLocal;
                 ctx.ArrowScopeDisplayClassFields = _closures.ArrowScopeDisplayClassFields[func];
-                ctx.CapturedArrowLocals = _closures.Analyzer.GetCapturedLocals(func);
+                // Derive from the DC's actual field map so per-iteration loop bindings
+                // excluded by DefineScopeDisplayClass (#649) are also excluded here.
+                ctx.CapturedArrowLocals = [.. _closures.ArrowScopeDisplayClassFields[func].Keys];
             }
 
             var emitter = new ILEmitter(ctx);

--- a/SharpTS.Tests/SharedTests/ForLoopPerIterationBindingTests.cs
+++ b/SharpTS.Tests/SharedTests/ForLoopPerIterationBindingTests.cs
@@ -107,9 +107,12 @@ public class ForLoopPerIterationBindingTests
     // ---- Mutating the loop var inside the body is reflected in that iteration's capture ----
     // i becomes i+10 at capture time, then i-10 before the iteration ends, so the per-iteration
     // binding settles back to the loop value; the per-iteration copy then carries that forward.
-    // Interpreted-only: compiled mode snapshots the loop var at a different point and yields
-    // 10,11,12 here (a pre-existing per-iteration-snapshot timing gap, tracked by #650). The
-    // interpreter reads the live binding slot, matching node (0,1,2).
+    // Interpreted-only: compiled mode SNAPSHOTS the loop var's value at closure-creation time
+    // (i+10 == 10/11/12) rather than reference-capturing the per-iteration binding (whose end-of-
+    // body value is 0/1/2). This snapshot-timing gap is uniform across compiled contexts (top
+    // level, sync/async function bodies) and is tracked by #650; a full fix needs a per-iteration
+    // binding cell that closures reference-capture. The interpreter reads the live binding slot,
+    // matching node (0,1,2).
     [Theory]
     [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
     public void BodyMutatesLoopVar_CapturesLiveSlot(ExecutionMode mode)
@@ -165,12 +168,30 @@ public class ForLoopPerIterationBindingTests
         Assert.Equal("0,2,4\n", TestHarness.Run(source, mode));
     }
 
-    // ---- Async function body exercises the ExecuteForAsyncVT per-iteration path ----
-    // Interpreted-only: compiled async-function state machines don't create per-iteration display
-    // classes for a `for (let …)`, so the capture reads the final value (3,3,3) — a pre-existing
-    // compiled gap (the #431 per-iteration box fix doesn't reach async bodies), tracked by #649.
+    // ---- Closures over a loop `let` inside a FUNCTION body are per-iteration in both modes (#649) ----
+    // Before #649 the compiler promoted a captured `for (let …)` loop variable to the function's
+    // single shared display class, so every closure read the loop's final value (3,3,3) inside any
+    // function body — sync OR async. (Top level already stayed correct because the loop variable
+    // remained a local that each closure snapshots.) The fix keeps these per-iteration loop bindings
+    // out of the function display class, so they are snapshotted per iteration like the top-level case.
+
     [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void SyncFunctionBody_PerIteration(ExecutionMode mode)
+    {
+        var source = """
+            function main(): string {
+                const fns: any[] = [];
+                for (let k = 0; k < 3; k++) { fns.push(() => k); }
+                return fns.map((f: any) => f()).join(",");
+            }
+            console.log(main());
+            """;
+        Assert.Equal("0,1,2\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void AsyncFunctionBody_PerIteration(ExecutionMode mode)
     {
         var source = """
@@ -182,5 +203,75 @@ public class ForLoopPerIterationBindingTests
             main();
             """;
         Assert.Equal("0,1,2\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ClassMethodBody_PerIteration(ExecutionMode mode)
+    {
+        var source = """
+            class C {
+                run(): string {
+                    const fns: any[] = [];
+                    for (let k = 0; k < 3; k++) { fns.push(() => k); }
+                    return fns.map((f: any) => f()).join(",");
+                }
+            }
+            console.log(new C().run());
+            """;
+        Assert.Equal("0,1,2\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ArrowBody_PerIteration(ExecutionMode mode)
+    {
+        var source = """
+            const outer = () => {
+                const fns: any[] = [];
+                for (let k = 0; k < 3; k++) { fns.push(() => k); }
+                return fns.map((f: any) => f()).join(",");
+            };
+            console.log(outer());
+            """;
+        Assert.Equal("0,1,2\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void InnerFunctionBody_PerIteration(ExecutionMode mode)
+    {
+        var source = """
+            function host(): string {
+                function inner(): string {
+                    const fns: any[] = [];
+                    for (let k = 0; k < 3; k++) { fns.push(() => k); }
+                    return fns.map((f: any) => f()).join(",");
+                }
+                return inner();
+            }
+            console.log(host());
+            """;
+        Assert.Equal("0,1,2\n", TestHarness.Run(source, mode));
+    }
+
+    // A function-scoped binding declared OUTSIDE the loop stays SHARED (one binding) even when a
+    // loop-body closure also captures the per-iteration loop variable: the per-iteration exclusion
+    // must apply only to the loop binding, not to ordinary captured locals. `outer` ends at 3 for
+    // every closure; `k` is per-iteration.
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void FunctionBody_OuterCapturedVarStaysShared(ExecutionMode mode)
+    {
+        var source = """
+            function f(): string {
+                let outer = 0;
+                const fns: any[] = [];
+                for (let k = 0; k < 3; k++) { fns.push(() => outer + ":" + k); outer++; }
+                return fns.map((g: any) => g()).join(",");
+            }
+            console.log(f());
+            """;
+        Assert.Equal("3:0,3:1,3:2\n", TestHarness.Run(source, mode));
     }
 }


### PR DESCRIPTION
## What

In **compiled** mode, a `for (let/const …)` loop variable captured by a closure is a per-iteration binding (ECMA-262 13.7.4 `CreatePerIterationEnvironment`): closures created in different iterations must capture distinct values. Top level already did this (the loop var stays a local each closure snapshots), but inside **any function-like body** the loop var was promoted to that body's **single shared display class**, so every closure read the loop's *final* value:

```ts
function main() {
  const fns: any[] = [];
  for (let k = 0; k < 3; k++) { fns.push(() => k); }
  return fns.map(f => f()).join(",");   // was 3,3,3 — should be 0,1,2
}
```

#649 reported this for **async** functions; it was actually **every** function body — sync function, async function, class method/constructor, arrow body, async arrow, and inner function.

## Fix

Keep purely-per-iteration `for (let/const …)` loop bindings **out of the shared display class** (function DC *and* arrow-scope DC), so they stay locals / state-machine fields that each closure snapshots per iteration — matching the already-correct top-level path. No new closure machinery; this reuses the existing snapshot capture.

- `ClosureAnalyzer` records each function/arrow's for-let/const loop bindings, plus the ordinary declarations (params/let/const/var) for **shadow-safety**: a name used both as a loop binding *and* an ordinary captured-and-mutated local keeps its shared slot.
- `DefineFunctionDisplayClass` and `DefineScopeDisplayClass` exclude the purely-loop bindings; `CapturedFunctionLocals` / `CapturedArrowLocals` are derived from the resulting field maps so they stay consistent with the fields that exist.

## Testing

- New cross-mode coverage in `ForLoopPerIterationBindingTests`: sync/async function, class method, arrow body, inner function, plus `FunctionBody_OuterCapturedVarStaysShared` (an outer captured-mutated local stays shared: `3:0,3:1,3:2`). Verified manually across top-level, class constructor, async arrow, and nested loops too.
- Full unit suite green (12,649; the only red was `Fork_WorkersShareHttpPort`, a pre-existing parallel-load network flake that passes in isolation). TypeScript conformance 31/31. Test262 behaves identically to baseline (its pre-existing host `0x80131506` abort reproduces unchanged on `origin/main`).

## Scope / follow-ups

- **Closes #649.**
- **#650** (mutate-and-restore: `for(let i){ i=i+10; g.push(()=>i); i=i-10 }` → `10,11,12` vs `0,1,2`) is **not** fixed here. After this PR that gap is *uniform* across all compiled contexts. A correct fix needs reference-capture (a per-iteration binding cell), which is a larger change with a boxing cost for captured counters — [analysis on #650](https://github.com/nickna/SharpTS/issues/650#issuecomment-4704913111). Interpreted-only regression test retained.
- Filed #669 for a pre-existing, orthogonal bug found while testing: compiled generator bodies miscompile arrow callbacks/closures (crash).