### PR TITLE
Fix #648: NaN/Infinity globals compiled to null inside a compiled async arrow

### DIFF
--- a/Compilation/AsyncArrowMoveNextEmitter.Variables.cs
+++ b/Compilation/AsyncArrowMoveNextEmitter.Variables.cs
@@ -18,6 +18,13 @@ public partial class AsyncArrowMoveNextEmitter
             return;
         }
 
+        // JavaScript global constants (NaN/Infinity/undefined). The base EmitVariable reaches
+        // these through TryEmitGlobalVariable, but this override reimplements resolution and so
+        // must check them explicitly — otherwise a bare NaN/Infinity compiled to a null load,
+        // e.g. `NaN === NaN` degraded to `null === null` → true (#648). Checked after the
+        // resolver so a same-named local/param/capture still shadows the global.
+        if (TryEmitJsGlobalConstant(name)) return;
+
         // Check if it's an imported value (from another module) - must check BEFORE Functions
         // because cross-module function references need to go through the import field
         if (_ctx?.TopLevelStaticVars?.TryGetValue(name, out var topLevelField) == true)

--- a/Compilation/ExpressionEmitterBase.cs
+++ b/Compilation/ExpressionEmitterBase.cs
@@ -1526,18 +1526,36 @@ public abstract partial class ExpressionEmitterBase : IEmitterContext
     #region Global Variable Resolution Helpers
 
     /// <summary>
+    /// Emits the JavaScript global constants that are not real bindings: <c>NaN</c>,
+    /// <c>Infinity</c>, and <c>undefined</c>. Every variable-emission path must consult this
+    /// before falling back to a null load — otherwise a bare <c>NaN</c>/<c>Infinity</c>
+    /// reference compiles to a null load, so e.g. <c>NaN === NaN</c> silently degrades to
+    /// <c>null === null</c> → <c>true</c> (that was the #648 async-arrow gap). Callers must run
+    /// their local/parameter/capture resolver first so a same-named user binding still shadows
+    /// the global, matching ECMA-262 lexical lookup.
+    /// </summary>
+    /// <returns><c>true</c> if <paramref name="name"/> is a global constant and was emitted.</returns>
+    protected bool TryEmitJsGlobalConstant(string name)
+    {
+        switch (name)
+        {
+            case "NaN": EmitDoubleConstant(double.NaN); return true;
+            case "Infinity": EmitDoubleConstant(double.PositiveInfinity); return true;
+            case "undefined": EmitUndefinedConstant(); return true;
+            default: return false;
+        }
+    }
+
+    /// <summary>
     /// Tries to emit a global variable load (after resolver fails).
     /// Checks TopLevelStaticVars → Functions → NamespaceFields → CapturedTopLevelVars.
     /// </summary>
     protected virtual bool TryEmitGlobalVariable(string name)
     {
-        // JavaScript global constants — must be checked before user-defined variables
-        // ILEmitter.EmitVariable handles these too, but state machine emitters
-        // (Async/Generator/AsyncGenerator MoveNextEmitter, AsyncArrowMoveNextEmitter)
-        // inherit from this base class and need them here.
-        if (name == "NaN") { EmitDoubleConstant(double.NaN); return true; }
-        if (name == "Infinity") { EmitDoubleConstant(double.PositiveInfinity); return true; }
-        if (name == "undefined") { EmitUndefinedConstant(); return true; }
+        // JavaScript global constants — must be checked before user-defined variables. State
+        // machine emitters (Async/Generator/AsyncGenerator MoveNextEmitter) reach this via the
+        // base EmitVariable; ILEmitter and AsyncArrowMoveNextEmitter call the helper directly.
+        if (TryEmitJsGlobalConstant(name)) return true;
 
         if (Ctx.TopLevelStaticVars?.TryGetValue(name, out var topLevelField) == true)
         {

--- a/Compilation/ILEmitter.Expressions.cs
+++ b/Compilation/ILEmitter.Expressions.cs
@@ -130,24 +130,8 @@ public partial class ILEmitter
             return;
         }
 
-        // JavaScript global constants
-        if (name == "NaN")
-        {
-            EmitDoubleConstant(double.NaN);
-            return;
-        }
-
-        if (name == "Infinity")
-        {
-            EmitDoubleConstant(double.PositiveInfinity);
-            return;
-        }
-
-        if (name == "undefined")
-        {
-            EmitUndefinedConstant();
-            return;
-        }
+        // JavaScript global constants (NaN/Infinity/undefined)
+        if (TryEmitJsGlobalConstant(name)) return;
 
         // Global fetch function - use cached TSFunction for reference equality with globalThis.fetch
         if (name == "fetch")

--- a/SharpTS.Tests/SharedTests/AsyncNaNStrictEqualityTests.cs
+++ b/SharpTS.Tests/SharedTests/AsyncNaNStrictEqualityTests.cs
@@ -16,6 +16,15 @@ namespace SharpTS.Tests.SharedTests;
 /// tests assert the corrected NaN behavior in every async/generator state-machine context and pin
 /// the already-correct contexts as cross-mode parity, plus guard that ordinary number equality is
 /// unaffected by the change.</para>
+///
+/// <para>Also covers #648, the compiled-mode analog. There the equality machinery was already
+/// NaN-aware; the real defect was narrower and broader at once: <c>AsyncArrowMoveNextEmitter</c>
+/// reimplements variable resolution and never consulted the JS global constants, so a bare
+/// <c>NaN</c>/<c>Infinity</c> inside a compiled <c>async</c> arrow compiled to a <c>null</c> load.
+/// <c>NaN === NaN</c> therefore degraded to <c>null === null</c> → <c>true</c>, and any other use
+/// (value, <c>typeof</c>, arithmetic) was equally wrong. The fix routes that emitter through the
+/// shared <c>TryEmitJsGlobalConstant</c> helper, so the <see cref="AsyncArrow_NaNStrictEquality"/>
+/// and <see cref="AsyncArrow_GlobalConstantsResolve"/> cases below now run cross-mode.</para>
 /// </summary>
 public class AsyncNaNStrictEqualityTests
 {
@@ -67,14 +76,14 @@ public class AsyncNaNStrictEqualityTests
         Assert.Equal("false\n", TestHarness.Run(source, mode));
     }
 
-    // Interpreted-only: this issue (#642) is the interpreter async path. Compiled async ARROWS
-    // still evaluate NaN strict equality with loose/Double.Equals semantics (NaN === NaN → true) —
-    // a gap in #600's compiled coverage that does NOT affect compiled async *functions* or async
-    // *generators* (both correct). Tracked by #648.
+    // #648: previously interpreted-only because a bare NaN/Infinity inside a compiled async arrow
+    // resolved to null (NaN === NaN → null === null → true). Now cross-mode after the
+    // AsyncArrowMoveNextEmitter global-constant fix.
     [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
-    public void AsyncArrow_NaNStrictEquality_Interpreted(ExecutionMode mode)
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AsyncArrow_NaNStrictEquality(ExecutionMode mode)
     {
+        // The exact repro from #648.
         var source = """
             const r = async () => {
                 console.log(NaN === NaN);
@@ -83,6 +92,49 @@ public class AsyncNaNStrictEqualityTests
             r();
             """;
         Assert.Equal("false\ntrue\n", TestHarness.Run(source, mode));
+    }
+
+    // #648 root cause (broader than the equality symptom): the JS global constants NaN/Infinity
+    // must resolve to real values inside a compiled async arrow, not a null load. A param named
+    // `NaN` must still shadow the global (resolver runs before the constant check), matching
+    // ECMA-262 lexical lookup.
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AsyncArrow_GlobalConstantsResolve(ExecutionMode mode)
+    {
+        var source = """
+            const r = async () => {
+                console.log(NaN);
+                console.log(typeof NaN);
+                console.log(Infinity);
+                console.log(-Infinity);
+                console.log(NaN + 1);
+                console.log(Number.isNaN(NaN));
+                console.log(Infinity > 1e308);
+            };
+            r();
+            const shadow = async (NaN: any) => NaN === NaN;
+            shadow(5).then((v: boolean) => console.log(v));
+            """;
+        Assert.Equal("NaN\nnumber\nInfinity\n-Infinity\nNaN\ntrue\ntrue\ntrue\n", TestHarness.Run(source, mode));
+    }
+
+    // After an await the arrow body runs from a resumed state-machine label; the global constants
+    // must still resolve there too (the suspend/resume path is where #648's null load was most
+    // surprising).
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AsyncArrow_AfterAwait_NaNStillNotEqual(ExecutionMode mode)
+    {
+        var source = """
+            const r = async () => {
+                await Promise.resolve(0);
+                console.log(NaN === NaN);
+                console.log(NaN);
+            };
+            r();
+            """;
+        Assert.Equal("false\nNaN\n", TestHarness.Run(source, mode));
     }
 
     [Theory]


### PR DESCRIPTION
Fixes #648.

## Summary

The reported symptom — `NaN === NaN` returning `true` inside a **compiled `async` arrow** — is real, but the root cause is **not** the issue's hypothesis (a `Double.Equals` equality fast path). The state-machine equality IL is already NaN-aware; the operands were simply `null`.

`AsyncArrowMoveNextEmitter.EmitVariable` overrides the base variable resolution with its own chain — resolver → `TopLevelStaticVars` → `Functions` → `CapturedTopLevelVars` → **`ldnull` fallback** — and never consulted the JavaScript global constants that the base `TryEmitGlobalVariable` checks first. So a bare `NaN`/`Infinity` inside a compiled async arrow compiled to a **null load**:

| expression (in a compiled `async () => {}`) | before | after |
|---|---|---|
| `NaN === NaN` | `true` ❌ | `false` ✅ |
| `NaN` (value) | `null` ❌ | `NaN` ✅ |
| `typeof NaN` | `"object"` ❌ | `"number"` ✅ |
| `Infinity` / `-Infinity` | `null` / `0` ❌ | `Infinity` / `-Infinity` ✅ |
| `NaN + 1` | `1` ❌ | `NaN` ✅ |
| `Number.isNaN(NaN)` | `false` ❌ | `true` ✅ |

So the defect was both **narrower** (it's variable resolution, not equality) and **broader** (every use of the constant, not just `===`) than the issue described. Async **functions** and async **generators** were unaffected — they reach the base resolution; only async **arrows** override `EmitVariable`.

## Fix

Extract the `NaN`/`Infinity`/`undefined` emission — previously duplicated in `ILEmitter.EmitVariable` and `ExpressionEmitterBase.TryEmitGlobalVariable` — into a shared `ExpressionEmitterBase.TryEmitJsGlobalConstant`, and call it from the async-arrow `EmitVariable` **after** the local/param/capture resolver, so a same-named binding (e.g. `async (NaN) => …`) still shadows the global per ECMA-262 lexical lookup. Net effect is a small reduction in duplication: the three real variable-emission paths now share one definition of the JS global constants.

## Tests

- Promotes the async-arrow NaN strict-equality test to **cross-mode** (was interpreted-only, pinned to #648).
- Adds `AsyncArrow_GlobalConstantsResolve` (value / `typeof` / arithmetic / `Number.isNaN` / param-shadowing) and `AsyncArrow_AfterAwait_NaNStillNotEqual` (resumed-state-machine path).
- Full xUnit suite: **12643 passing** (1 unrelated pre-existing flaky cluster HTTP-port timeout in *interpreted* mode — passes in isolation; this change is compile-time only).
- Test262: **no baseline drift**. (The compiled corpus hits a pre-existing testhost memory-pressure crash documented in `SmokeTest.cs`; I confirmed it reproduces identically on clean `main`, so it is unrelated to this change.)

## Note on #642

The interpreter analog (#642, `NaN === NaN` inside an `async function`) was already fixed on `main` by 1052b6e8; verified still green cross-mode. No code change here.
