### PR TITLE
Remove dead LoadVariable method from AsyncArrowMoveNextEmitter

### DIFF
--- a/Compilation/AsyncArrowMoveNextEmitter.ArrowFunctions.cs
+++ b/Compilation/AsyncArrowMoveNextEmitter.ArrowFunctions.cs
@@ -66,7 +66,7 @@ public partial class AsyncArrowMoveNextEmitter
         {
             _il.Emit(OpCodes.Dup); // Keep display class instance on stack
 
-            // Load the captured variable using the same logic as LoadVariable
+            // Load the captured variable using the capture-population loader
             LoadVariableForCapture(capturedVar);
 
             _il.Emit(OpCodes.Stfld, field);

--- a/Compilation/AsyncArrowMoveNextEmitter.Variables.cs
+++ b/Compilation/AsyncArrowMoveNextEmitter.Variables.cs
@@ -140,89 +140,6 @@ public partial class AsyncArrowMoveNextEmitter
 
     protected override void EmitStoreVariable(string name) => StoreVariable(name);
 
-    private void LoadVariable(string name)
-    {
-        // Check if it's a parameter of this arrow
-        if (_builder.ParameterFields.TryGetValue(name, out var paramField))
-        {
-            _il.Emit(OpCodes.Ldarg_0);
-            _il.Emit(OpCodes.Ldfld, paramField);
-            SetStackUnknown();
-            return;
-        }
-
-        // Check if it's a hoisted local of this arrow
-        if (_builder.LocalFields.TryGetValue(name, out var localField))
-        {
-            _il.Emit(OpCodes.Ldarg_0);
-            _il.Emit(OpCodes.Ldfld, localField);
-            SetStackUnknown();
-            return;
-        }
-
-        // Check if it's captured from outer scope
-        if (_builder.IsCaptured(name) && _builder.CapturedFieldMap.TryGetValue(name, out var outerField))
-        {
-            // Load through outer reference
-            // Use Unbox (not Unbox_Any) to get a pointer to the boxed struct, then load field
-            _il.Emit(OpCodes.Ldarg_0);
-            _il.Emit(OpCodes.Ldfld, _builder.OuterStateMachineField!);
-
-            // Check if this is a transitive capture (needs extra indirection through parent's outer)
-            if (_builder.TransitiveCaptures.Contains(name) &&
-                _builder.ParentOuterStateMachineField != null &&
-                _builder.GrandparentStateMachineType != null)
-            {
-                // First unbox to parent, then load parent's outer reference
-                _il.Emit(OpCodes.Unbox, _builder.OuterStateMachineType!);
-                _il.Emit(OpCodes.Ldfld, _builder.ParentOuterStateMachineField);
-                _il.Emit(OpCodes.Unbox, _builder.GrandparentStateMachineType);
-            }
-            else
-            {
-                _il.Emit(OpCodes.Unbox, _builder.OuterStateMachineType!);
-            }
-
-            _il.Emit(OpCodes.Ldfld, outerField);
-            SetStackUnknown();
-            return;
-        }
-
-        // Check for non-hoisted local variable
-        if (_locals.TryGetValue(name, out var local))
-        {
-            _il.Emit(OpCodes.Ldloc, local);
-            SetStackUnknown();
-            return;
-        }
-
-        // Check if it's an imported value (from another module) - must check BEFORE Functions
-        // because cross-module function references need to go through the import field
-        if (_ctx?.TopLevelStaticVars?.TryGetValue(name, out var topLevelField) == true)
-        {
-            _il.Emit(OpCodes.Ldsfld, topLevelField);
-            SetStackUnknown();
-            return;
-        }
-
-        // Check if it's a global function
-        if (_ctx?.Functions.TryGetValue(_ctx.ResolveFunctionName(name), out var funcMethod) == true)
-        {
-            // Load function reference
-            _il.Emit(OpCodes.Ldnull);
-            _il.Emit(OpCodes.Ldtoken, funcMethod);
-            _il.Emit(OpCodes.Call, Types.MethodBaseGetMethodFromHandle);
-            _il.Emit(OpCodes.Castclass, typeof(MethodInfo));
-            _il.Emit(OpCodes.Newobj, _ctx.Runtime!.TSFunctionCtor);
-            SetStackUnknown();
-            return;
-        }
-
-        // Fallback: null
-        _il.Emit(OpCodes.Ldnull);
-        SetStackType(StackType.Null);
-    }
-
     private void StoreVariable(string name)
     {
         // A capture promoted into the enclosing function's display class (#625) is stored through
@@ -325,7 +242,7 @@ public partial class AsyncArrowMoveNextEmitter
 
     /// <summary>
     /// Loads a variable value for populating a capture in a non-async arrow's display class.
-    /// This is similar to LoadVariable but designed for capture population.
+    /// This is similar to the EmitVariable override but designed for capture population.
     /// </summary>
     private void LoadVariableForCapture(string name)
     {


### PR DESCRIPTION
## What

Deletes the unused `LoadVariable(string)` method from
`Compilation/AsyncArrowMoveNextEmitter.Variables.cs` and fixes the two
comments that referenced it by name.

## Why

A repo-wide search confirms `LoadVariable` had **no callers**. The only live
variable-load paths in this emitter are:

- the `EmitVariable` override (general expression loads), and
- `LoadVariableForCapture` (capture population, called from
  `AsyncArrowMoveNextEmitter.ArrowFunctions.cs`).

`LoadVariable` was a leftover near-duplicate of `EmitVariable`. It was also a
**latent copy of the bug fixed in #648 / PR #671**: like the pre-fix
`EmitVariable`, its `Ldnull` fallback never consulted the JS global constants
(`NaN`/`Infinity`/`undefined`). Had it ever been wired up, a bare
`NaN`/`Infinity` would again have compiled to a null load (e.g. `NaN === NaN`
degrading to `null === null` → `true`). Removing it eliminates that trap rather
than leaving a second code path that would need the same fix.

## Changes

- Remove the dead `LoadVariable` method (~82 lines).
- Update its two now-dangling doc/inline comment references to point at the
  live `EmitVariable` override / capture-population loader instead.

## Reviewer notes

- **No behavioral change** — the method was never reachable, so this is pure
  dead-code removal. Diff is net `+2 / -85`, confined to two files.
- The live `EmitVariable` override on current `main` already carries the
  #648/#671 fix (`TryEmitJsGlobalConstant`), so no functional gap is introduced.
- Verified: `dotnet build SharpTS.csproj --no-incremental` clean (0 warnings,
  0 errors); `dotnet test --filter FullyQualifiedName~AsyncNaNStrictEqualityTests`
  → **20/20 passing**.