### PR TITLE
Fix #668 #646 #640: optional/default parameter handling (type-checker + compiled)

### DIFF
--- a/Compilation/AsyncArrowMoveNextEmitter.cs
+++ b/Compilation/AsyncArrowMoveNextEmitter.cs
@@ -128,6 +128,9 @@ public partial class AsyncArrowMoveNextEmitter : StatementEmitterBase, IEmitterC
     /// Emits the complete MoveNext method body.
     /// </summary>
     public void EmitMoveNext(List<Stmt> body, CompilationContext ctx, Type returnType)
+        => EmitMoveNext(body, ctx, returnType, null);
+
+    public void EmitMoveNext(List<Stmt> body, CompilationContext ctx, Type returnType, List<Stmt.Parameter>? parameters)
     {
         // Note: _il is initialized in constructor via GetILGenerator()
         _ctx = ctx;
@@ -154,6 +157,16 @@ public partial class AsyncArrowMoveNextEmitter : StatementEmitterBase, IEmitterC
 
         // State dispatch switch
         EmitStateDispatch();
+
+        // Apply parameter defaults on initial entry (#646). Placed after the state-dispatch
+        // switch so a resume (state >= 0) jumps straight to its await label past this code; on
+        // initial entry (state -1) the switch falls through to here. Arrow parameter fields are
+        // always object-typed (AsyncArrowStateMachineBuilder), so the null / $Undefined check
+        // is valid — unlike the sync-arrow path, no slot widening is needed.
+        if (parameters != null)
+        {
+            EmitDefaultParameters(parameters);
+        }
 
         // Emit the body
         foreach (var stmt in body)
@@ -194,6 +207,56 @@ public partial class AsyncArrowMoveNextEmitter : StatementEmitterBase, IEmitterC
 
         // Default case - continue with normal execution
         _il.MarkLabel(defaultLabel);
+    }
+
+    /// <summary>
+    /// Applies parameter defaults at async-arrow entry (#646). For each parameter with a default
+    /// value, if its hoisted state-machine field holds null or the <c>$Undefined</c> sentinel, the
+    /// default expression is evaluated and stored. Mirrors the async-function path
+    /// (<see cref="AsyncMoveNextEmitter"/>); parameter fields are object-typed so the null /
+    /// <c>$Undefined</c> check is sound. Invoked only on initial entry (see EmitMoveNext placement),
+    /// so no defaults-applied guard field is required.
+    /// </summary>
+    private void EmitDefaultParameters(List<Stmt.Parameter> parameters)
+    {
+        foreach (var param in parameters)
+        {
+            if (param.DefaultValue == null) continue;
+
+            var field = _builder.GetVariableField(param.Name.Lexeme);
+            if (field == null) continue; // parameter not hoisted
+
+            var applyDefault = _il.DefineLabel();
+            var checkUndefined = _il.DefineLabel();
+            var skipDefault = _il.DefineLabel();
+
+            // Load the parameter field value.
+            _il.Emit(OpCodes.Ldarg_0);
+            _il.Emit(OpCodes.Ldfld, field);
+
+            // null -> apply default; otherwise test for the $Undefined sentinel.
+            _il.Emit(OpCodes.Dup);
+            _il.Emit(OpCodes.Brtrue, checkUndefined);
+            _il.Emit(OpCodes.Pop);
+            _il.Emit(OpCodes.Br, applyDefault);
+
+            _il.MarkLabel(checkUndefined);
+            _il.Emit(OpCodes.Isinst, _ctx!.Runtime!.UndefinedType);
+            _il.Emit(OpCodes.Brtrue, applyDefault);
+            _il.Emit(OpCodes.Br, skipDefault);
+
+            // field = <default>
+            _il.MarkLabel(applyDefault);
+            EmitExpression(param.DefaultValue);
+            EnsureBoxed();
+            var temp = _il.DeclareLocal(typeof(object));
+            _il.Emit(OpCodes.Stloc, temp);
+            _il.Emit(OpCodes.Ldarg_0);
+            _il.Emit(OpCodes.Ldloc, temp);
+            _il.Emit(OpCodes.Stfld, field);
+
+            _il.MarkLabel(skipDefault);
+        }
     }
 
     #region StatementEmitterBase Overrides

--- a/Compilation/EmittedRuntime.cs
+++ b/Compilation/EmittedRuntime.cs
@@ -265,6 +265,15 @@ public class EmittedRuntime
     public TypeBuilder CapturesArgumentsAttrType { get; set; } = null!;
     public ConstructorBuilder CapturesArgumentsAttrCtor { get; set; } = null!;
 
+    // Marker attribute applied to USER TypeScript function methods (declarations,
+    // arrows/function expressions, methods, async stubs). When the wrapped method
+    // carries it, $TSFunction.AdjustArgs pads omitted trailing arguments with the
+    // `undefined` sentinel ($Undefined.Instance) instead of CLR null, matching JS
+    // semantics and the direct-call path. Runtime built-ins stay unmarked and keep
+    // null padding (their bodies use null-checks for optional-arg absence). (#640)
+    public TypeBuilder PadUndefinedAttrType { get; set; } = null!;
+    public ConstructorBuilder PadUndefinedAttrCtor { get; set; } = null!;
+
     // String methods
     public MethodBuilder StringCharAt { get; set; } = null!;
     public MethodBuilder StringSubstring { get; set; } = null!;

--- a/Compilation/ILCompiler.ArrowFunctions.cs
+++ b/Compilation/ILCompiler.ArrowFunctions.cs
@@ -157,6 +157,11 @@ public partial class ILCompiler
             var resolvedParamTypes = ParameterTypeResolver.ResolveParameters(
                 arrow.Parameters, _typeMapper, null, _typeMap); // null funcType - use annotations only
 
+            // Arrows/function expressions get no OverloadGenerator forwarding, so a parameter
+            // default is applied by the runtime entry prologue, which needs an object slot to
+            // detect the missing/undefined argument (#646).
+            ParameterTypeResolver.WidenDefaultedParamsToObject(resolvedParamTypes, arrow.Parameters, _types.Object);
+
             // Store resolved types for use during arrow body emission
             _closures.ArrowParameterTypes[arrow] = resolvedParamTypes;
 
@@ -403,6 +408,10 @@ public partial class ILCompiler
                 _closures.DisplayClasses[arrow] = displayClass;
                 _closures.ArrowMethods[arrow] = invokeMethod;
             }
+
+            // User arrow / function-expression body: when invoked as a value, omitted trailing
+            // args must pad with the `undefined` sentinel (JS semantics), not CLR null. (#640)
+            MarkPadsUndefined(_closures.ArrowMethods[arrow]);
         }
     }
 

--- a/Compilation/ILCompiler.Async.cs
+++ b/Compilation/ILCompiler.Async.cs
@@ -170,6 +170,7 @@ public partial class ILCompiler
 
                 // Define the stub method that will be called to invoke the async arrow
                 arrowBuilder.DefineStubMethod(_programType);
+                MarkPadsUndefined(arrowBuilder.StubMethod); // #640
 
                 _async.ArrowBuilders[arrowInfo.Arrow] = arrowBuilder;
                 continue; // Already handled the full setup
@@ -185,6 +186,7 @@ public partial class ILCompiler
 
             // Define the stub method that will be called to invoke the async arrow
             arrowBuilder.DefineStubMethod(_programType);
+            MarkPadsUndefined(arrowBuilder.StubMethod); // #640
 
             _async.ArrowBuilders[arrowInfo.Arrow] = arrowBuilder;
         }
@@ -656,7 +658,7 @@ public partial class ILCompiler
             bodyStatements = [];
         }
 
-        arrowEmitter.EmitMoveNext(bodyStatements, ctx, _types.Object);
+        arrowEmitter.EmitMoveNext(bodyStatements, ctx, _types.Object, arrow.Parameters);
         ILLabelValidator.Validate(arrowBuilder.MoveNextMethod.GetILGenerator(),
             $"async arrow MoveNext");
     }
@@ -956,7 +958,7 @@ public partial class ILCompiler
                         false, // UsesThis
                         []     // AsyncArrows - handled separately via _async.ArrowBuilders
                     ), _types);
-                arrowEmitter.EmitMoveNext(bodyStatements, ctx, _types.Object);
+                arrowEmitter.EmitMoveNext(bodyStatements, ctx, _types.Object, arrow.Parameters);
                 ILLabelValidator.Validate(arrowBuilder.MoveNextMethod.GetILGenerator(),
                     $"async arrow MoveNext in {methodBuilder.DeclaringType?.Name}::{method.Name.Lexeme}");
             }
@@ -1009,6 +1011,7 @@ public partial class ILCompiler
 
             // Define the stub method
             arrowBuilder.DefineStubMethod(_programType);
+            MarkPadsUndefined(arrowBuilder.StubMethod); // #640
 
             // Store the builder
             _async.ArrowBuilders[arrow] = arrowBuilder;
@@ -1130,7 +1133,7 @@ public partial class ILCompiler
                 bodyStatements = [];
             }
 
-            arrowEmitter.EmitMoveNext(bodyStatements, ctx, _types.Object);
+            arrowEmitter.EmitMoveNext(bodyStatements, ctx, _types.Object, arrow.Parameters);
             ILLabelValidator.Validate(arrowBuilder.MoveNextMethod.GetILGenerator(),
                 $"standalone async arrow MoveNext");
 

--- a/Compilation/ILCompiler.Classes.Static.cs
+++ b/Compilation/ILCompiler.Classes.Static.cs
@@ -633,7 +633,7 @@ public partial class ILCompiler
                         false, // UsesThis
                         []     // AsyncArrows - handled separately via _async.ArrowBuilders
                     ), _types);
-                arrowEmitter.EmitMoveNext(bodyStatements, ctx, _types.Object);
+                arrowEmitter.EmitMoveNext(bodyStatements, ctx, _types.Object, arrow.Parameters);
             }
         }
 

--- a/Compilation/ILCompiler.Functions.cs
+++ b/Compilation/ILCompiler.Functions.cs
@@ -102,6 +102,10 @@ public partial class ILCompiler
 
         _functions.Builders[qualifiedFunctionName] = methodBuilder;
 
+        // User TS function: when invoked as a value, omitted trailing args must pad with the
+        // `undefined` sentinel (JS semantics), not CLR null. (#640)
+        MarkPadsUndefined(methodBuilder);
+
         // Flag eagerly (phase 3) so direct-call sites emitted in phase 7 can publish
         // caller args to the thread-static before OpCodes.Call. Uses the same scanner
         // the prologue consults, keeping the two sides in sync. Overload signatures
@@ -1410,6 +1414,20 @@ public partial class ILCompiler
                 emitter
             );
         }
+    }
+
+    /// <summary>
+    /// Marks a user TypeScript function method with the <c>$PadUndefined</c> attribute so that
+    /// <c>$TSFunction.AdjustArgs</c> pads omitted trailing arguments with the <c>undefined</c>
+    /// sentinel (JS semantics) when the function is invoked as a value (cross-module imports,
+    /// callbacks, <c>$TSFunction.Invoke</c>) — matching the direct-call path. Runtime built-ins
+    /// stay unmarked and keep CLR-null padding. No-op when the runtime attribute is unavailable. (#640)
+    /// </summary>
+    internal void MarkPadsUndefined(MethodBuilder method)
+    {
+        if (_runtime?.PadUndefinedAttrCtor != null)
+            method.SetCustomAttribute(
+                new System.Reflection.Emit.CustomAttributeBuilder(_runtime.PadUndefinedAttrCtor, []));
     }
 
     /// <summary>

--- a/Compilation/ILCompiler.InnerFunctions.cs
+++ b/Compilation/ILCompiler.InnerFunctions.cs
@@ -415,6 +415,10 @@ public partial class ILCompiler
                 _innerFunctionDisplayClasses[func] = displayClass;
                 _innerFunctionMethods[func] = invokeMethod;
             }
+
+            // User inner-function body: when invoked as a value, omitted trailing args must
+            // pad with the `undefined` sentinel (JS semantics), not CLR null. (#640)
+            MarkPadsUndefined(_innerFunctionMethods[func]);
         }
     }
 

--- a/Compilation/ParameterTypeResolver.cs
+++ b/Compilation/ParameterTypeResolver.cs
@@ -84,6 +84,28 @@ public static class ParameterTypeResolver
     }
 
     /// <summary>
+    /// Widens any parameter that has a <b>default value</b> to an <c>object</c> slot. Required for
+    /// function kinds that apply parameter defaults via the runtime entry prologue
+    /// (<see cref="ILEmitter.EmitDefaultParameters"/>) rather than via <see cref="OverloadGenerator"/>
+    /// lower-arity forwarding — i.e. arrow functions and function expressions, which get no overloads.
+    /// The prologue detects a missing/undefined argument by comparing the slot against null and the
+    /// <c>$Undefined</c> sentinel, and value-call padding (<c>$TSFunction.AdjustArgs</c>) fills omitted
+    /// slots with that sentinel. Only an <c>object</c> slot can hold it: a value-type slot can never be
+    /// null (and emits invalid <c>ldarg; brfalse</c> IL), and a typed reference slot (e.g. <c>string</c>)
+    /// coerces the sentinel to a real value (e.g. the string <c>"undefined"</c>) before the prologue can
+    /// observe it. Either way the default could never fire. Mirrors the optional-without-default widening
+    /// already applied in <see cref="ResolveParameters"/>. (#646)
+    /// </summary>
+    public static void WidenDefaultedParamsToObject(Type[] resolved, List<Stmt.Parameter> parameters, Type objectType)
+    {
+        for (int i = 0; i < parameters.Count && i < resolved.Length; i++)
+        {
+            if (parameters[i].DefaultValue != null && resolved[i] != objectType)
+                resolved[i] = objectType;
+        }
+    }
+
+    /// <summary>
     /// #372: widen a <c>number</c>/<c>boolean</c> parameter slot (unboxed <c>double</c>/<c>bool</c>) to
     /// <c>object</c> when the type checker flagged it as possibly holding the runtime <c>undefined</c>
     /// sentinel (a body reassignment of an <c>any</c>/<c>undefined</c> value, e.g.

--- a/Compilation/RuntimeEmitter.TSFunction.cs
+++ b/Compilation/RuntimeEmitter.TSFunction.cs
@@ -56,6 +56,33 @@ public partial class RuntimeEmitter
         typeBuilder.CreateType();
     }
 
+    /// <summary>
+    /// Emits a minimal marker attribute <c>$PadUndefined</c> (empty
+    /// <see cref="System.Attribute"/> subclass). Applied to user TypeScript function
+    /// methods (declarations, arrows/function expressions, methods, async stubs); read
+    /// back via <see cref="System.Reflection.MemberInfo.IsDefined(Type, bool)"/> at
+    /// <c>$TSFunction</c> construction to decide whether <c>AdjustArgs</c> pads omitted
+    /// trailing arguments with the <c>undefined</c> sentinel rather than CLR null (#640).
+    /// Lives in the output assembly so the compiled DLL stays standalone.
+    /// </summary>
+    private void EmitPadUndefinedAttribute(ModuleBuilder moduleBuilder, EmittedRuntime runtime)
+    {
+        var typeBuilder = moduleBuilder.DefineType(
+            "$PadUndefined",
+            TypeAttributes.Public | TypeAttributes.Sealed | TypeAttributes.BeforeFieldInit,
+            typeof(System.Attribute));
+        var ctor = typeBuilder.DefineConstructor(
+            MethodAttributes.Public, CallingConventions.Standard, Type.EmptyTypes);
+        var ctorIl = ctor.GetILGenerator();
+        ctorIl.Emit(OpCodes.Ldarg_0);
+        ctorIl.Emit(OpCodes.Call, typeof(System.Attribute).GetConstructor(
+            BindingFlags.Instance | BindingFlags.NonPublic, null, Type.EmptyTypes, null)!);
+        ctorIl.Emit(OpCodes.Ret);
+        runtime.PadUndefinedAttrCtor = ctor;
+        runtime.PadUndefinedAttrType = typeBuilder;
+        typeBuilder.CreateType();
+    }
+
     private void EmitTSFunctionClass(ModuleBuilder moduleBuilder, EmittedRuntime runtime)
     {
         // Define class: public sealed class $TSFunction
@@ -88,6 +115,16 @@ public partial class RuntimeEmitter
         // skip-index-box detection can read it without a method call.
         var capturesArgumentsField = typeBuilder.DefineField("_capturesArguments", _types.Boolean, FieldAttributes.Public);
         runtime.TSFunctionCapturesArgumentsField = capturesArgumentsField;
+        // Bitmask of parameter positions that AdjustArgs pads with the `undefined`
+        // sentinel (instead of CLR null) when the argument is omitted. Bit i is set iff
+        // the wrapped method carries the $PadUndefined marker (i.e. is a user TS function)
+        // AND parameter i has an `object` slot. Object slots can hold the sentinel, so
+        // `typeof`/`=== undefined`/default-firing all work; a typed slot (string/double)
+        // would coerce the sentinel to a real value before the entry prologue, so those
+        // stay null-padded and fire their default via the null check. Built-ins have an
+        // all-zero mask and keep pure null padding. Positions >= 32 are not tracked
+        // (such arity is never reached in practice) and pad null. (#640)
+        var padUndefinedMaskField = typeBuilder.DefineField("_padUndefinedMask", _types.Int32, FieldAttributes.Private);
         // Cached MethodInvoker. .NET 8+'s MethodInvoker.Create() pre-builds
         // the JIT'd dispatch stub for a method, then Invoke(...) calls it
         // directly — measured ~10× faster than MethodInfo.Invoke per call.
@@ -234,6 +271,8 @@ public partial class RuntimeEmitter
         EmitComputeExpectsThis(ctorIL, expectsThisField, methodArgIndex: 2);
         // this._capturesArguments = method.IsDefined($CapturesArguments)
         EmitComputeCapturesArguments(ctorIL, capturesArgumentsField, runtime, methodArgIndex: 2);
+        // this._padUndefinedMask = $PadUndefined ? (object-param bits) : 0
+        EmitComputePadUndefinedMask(ctorIL, padUndefinedMaskField, runtime, methodArgIndex: 2);
         // this._paramCount, _hasListRest, _hasArrayRest: cached by AdjustArgs.
         EmitComputeAdjustArgsCache(ctorIL, paramCountField, hasListRestField, hasArrayRestField, methodArgIndex: 2);
         EmitComputeNeedsArgConversion(ctorIL, needsArgConversionField, methodArgIndex: 2);
@@ -273,6 +312,7 @@ public partial class RuntimeEmitter
         // this._expectsThis = (method.GetParameters().Length > 0 && params[0].Name == "__this")
         EmitComputeExpectsThis(ctorCacheIL, expectsThisField, methodArgIndex: 2);
         EmitComputeCapturesArguments(ctorCacheIL, capturesArgumentsField, runtime, methodArgIndex: 2);
+        EmitComputePadUndefinedMask(ctorCacheIL, padUndefinedMaskField, runtime, methodArgIndex: 2);
         EmitComputeAdjustArgsCache(ctorCacheIL, paramCountField, hasListRestField, hasArrayRestField, methodArgIndex: 2);
         EmitComputeNeedsArgConversion(ctorCacheIL, needsArgConversionField, methodArgIndex: 2);
         // this._invoker = LookupOrAdd(_invokerCache, method)
@@ -356,7 +396,7 @@ public partial class RuntimeEmitter
         gmIL.Emit(OpCodes.Ret);
 
         // Helper method: private static object[] AdjustArgs(MethodInfo method, object[] args)
-        var adjustArgsMethod = EmitTSFunctionAdjustArgsHelper(typeBuilder, runtime, paramCountField, hasListRestField, hasArrayRestField);
+        var adjustArgsMethod = EmitTSFunctionAdjustArgsHelper(typeBuilder, runtime, paramCountField, hasListRestField, hasArrayRestField, padUndefinedMaskField);
 
         // Helper method: private static void ConvertArgsForUnionTypes(MethodInfo method, object[] args)
         var convertArgsMethod = EmitTSFunctionConvertArgsHelper(typeBuilder, runtime);
@@ -1286,6 +1326,91 @@ public partial class RuntimeEmitter
     }
 
     /// <summary>
+    /// Emits computation of <c>this._padUndefinedMask</c>. Zero unless the method carries the
+    /// <c>$PadUndefined</c> marker (i.e. is a user TS function), in which case bit <c>i</c> is set
+    /// for every parameter <c>i &lt; 32</c> whose slot is <c>object</c>. <c>AdjustArgs</c> pads only
+    /// those positions with the <c>undefined</c> sentinel; typed slots and built-ins keep null
+    /// padding. See <see cref="EmitPadUndefinedAttribute"/>. (#640)
+    /// </summary>
+    private void EmitComputePadUndefinedMask(ILGenerator il, FieldBuilder padUndefinedMaskField, EmittedRuntime runtime, int methodArgIndex)
+    {
+        var done = il.DefineLabel();
+
+        // if (!method.IsDefined($PadUndefined, false)) leave mask at its zero-init value.
+        il.Emit(OpCodes.Ldarg, methodArgIndex);
+        il.Emit(OpCodes.Ldtoken, runtime.PadUndefinedAttrType);
+        il.Emit(OpCodes.Call, _types.GetMethod(_types.Type, "GetTypeFromHandle", _types.RuntimeTypeHandle));
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.MethodInfo, "IsDefined", _types.Type, _types.Boolean));
+        il.Emit(OpCodes.Brfalse, done);
+
+        var paramsLocal = il.DeclareLocal(_types.MakeArrayType(_types.ParameterInfo));
+        var iLocal = il.DeclareLocal(_types.Int32);
+        var maskLocal = il.DeclareLocal(_types.Int32);
+        var nLocal = il.DeclareLocal(_types.Int32);
+
+        // ps = method.GetParameters(); n = ps.Length; mask = 0; i = 0;
+        il.Emit(OpCodes.Ldarg, methodArgIndex);
+        il.Emit(OpCodes.Callvirt, _types.MethodInfo.GetMethod("GetParameters")!);
+        il.Emit(OpCodes.Stloc, paramsLocal);
+        il.Emit(OpCodes.Ldloc, paramsLocal);
+        il.Emit(OpCodes.Ldlen);
+        il.Emit(OpCodes.Conv_I4);
+        il.Emit(OpCodes.Stloc, nLocal);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Stloc, maskLocal);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Stloc, iLocal);
+
+        var loopBody = il.DefineLabel();
+        var loopCond = il.DefineLabel();
+        var nextIter = il.DefineLabel();
+        var storeMask = il.DefineLabel();
+        il.Emit(OpCodes.Br, loopCond);
+
+        il.MarkLabel(loopBody);
+        // if (ps[i].ParameterType != typeof(object)) goto nextIter;
+        il.Emit(OpCodes.Ldloc, paramsLocal);
+        il.Emit(OpCodes.Ldloc, iLocal);
+        il.Emit(OpCodes.Ldelem_Ref);
+        il.Emit(OpCodes.Callvirt, _types.ParameterInfo.GetProperty("ParameterType")!.GetGetMethod()!);
+        il.Emit(OpCodes.Ldtoken, _types.Object);
+        il.Emit(OpCodes.Call, _types.Type.GetMethod("GetTypeFromHandle")!);
+        il.Emit(OpCodes.Call, _types.Type.GetMethod("op_Equality", [_types.Type, _types.Type])!);
+        il.Emit(OpCodes.Brfalse, nextIter);
+        // mask |= (1 << i);
+        il.Emit(OpCodes.Ldloc, maskLocal);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Ldloc, iLocal);
+        il.Emit(OpCodes.Shl);
+        il.Emit(OpCodes.Or);
+        il.Emit(OpCodes.Stloc, maskLocal);
+
+        il.MarkLabel(nextIter);
+        il.Emit(OpCodes.Ldloc, iLocal);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Stloc, iLocal);
+
+        il.MarkLabel(loopCond);
+        // while (i < n && i < 32)
+        il.Emit(OpCodes.Ldloc, iLocal);
+        il.Emit(OpCodes.Ldloc, nLocal);
+        il.Emit(OpCodes.Bge, storeMask);
+        il.Emit(OpCodes.Ldloc, iLocal);
+        il.Emit(OpCodes.Ldc_I4, 32);
+        il.Emit(OpCodes.Blt, loopBody);
+
+        il.MarkLabel(storeMask);
+        // this._padUndefinedMask = mask;
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldloc, maskLocal);
+        il.Emit(OpCodes.Stfld, padUndefinedMaskField);
+
+        il.MarkLabel(done);
+    }
+
+    /// <summary>
     /// Emits an instance helper method <c>$TSFunction.AdjustArgs(object[] args)</c>
     /// that adjusts argument arrays for rest parameters and padding/trimming
     /// using cached field reads (<c>_paramCount</c>, <c>_hasListRest</c>,
@@ -1293,7 +1418,8 @@ public partial class RuntimeEmitter
     /// + <c>ParameterType</c> reflection.
     /// </summary>
     private MethodBuilder EmitTSFunctionAdjustArgsHelper(TypeBuilder typeBuilder, EmittedRuntime runtime,
-        FieldBuilder paramCountField, FieldBuilder hasListRestField, FieldBuilder hasArrayRestField)
+        FieldBuilder paramCountField, FieldBuilder hasListRestField, FieldBuilder hasArrayRestField,
+        FieldBuilder padUndefinedMaskField)
     {
         // private object[] AdjustArgs(object[] args)
         // Instance method: arg0 = this, arg1 = args. paramCount and rest-shape
@@ -1518,13 +1644,59 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloc, argsLengthLocal);
         il.Emit(OpCodes.Call, _types.ArrayType.GetMethod("Copy", [_types.ArrayType, _types.ArrayType, _types.Int32])!);
 
-        // Missing args pad as null. NOT the $Undefined singleton: emitted
-        // built-ins broadly use null-checks for optional-arg absence (stream
-        // write/end callbacks, encodings, ...), so sentinel padding makes them
-        // treat the slot as a real argument. The one built-in that must
-        // distinguish absent (skip) from explicit JS null (throw) — value-form
-        // Object.create's props — gets a dedicated wrapper instead
-        // (ObjectCreateValueForm in RuntimeEmitter.Objects.Prototype.cs).
+        // Pad value for the missing trailing slots, per the cached _padUndefinedMask.
+        //
+        // A slot whose mask bit is set (user TS function + `object`-typed parameter) is filled
+        // with the `undefined` sentinel, matching JS semantics and the direct-call path — so
+        // `typeof`, `=== undefined`, and `=== null` answer correctly for an omitted optional
+        // parameter, and an object-slotted default-valued parameter's entry prologue fires.
+        //
+        // Every other slot is left as CLR null (the Newarr zero value). That covers built-ins
+        // (mask 0 — their bodies use null-checks for optional-arg absence: stream write/end
+        // callbacks, encodings, ...) and typed default-valued parameters of user functions
+        // (string/double slots can't hold the sentinel — it would coerce to a real value
+        // before the entry prologue, whereas null fires their default via the null check). The
+        // one built-in that must distinguish absent (skip) from explicit JS null (throw) —
+        // value-form Object.create's props — gets a dedicated wrapper instead
+        // (ObjectCreateValueForm in RuntimeEmitter.Objects.Prototype.cs). (#640)
+        var skipUndefinedPad = il.DefineLabel();
+        // if (_padUndefinedMask == 0) skip — fast path for built-ins and all-typed signatures.
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, padUndefinedMaskField);
+        il.Emit(OpCodes.Brfalse, skipUndefinedPad);
+        // for (int i = argsLength; i < paramCount; i++)
+        //     if (((_padUndefinedMask >> i) & 1) != 0) result[i] = $Undefined.Instance;
+        var padIdxLocal = il.DeclareLocal(_types.Int32);
+        var padLoopBody = il.DefineLabel();
+        var padLoopCond = il.DefineLabel();
+        var padSkipSlot = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, argsLengthLocal);
+        il.Emit(OpCodes.Stloc, padIdxLocal);
+        il.Emit(OpCodes.Br, padLoopCond);
+        il.MarkLabel(padLoopBody);
+        // if (((mask >> i) & 1) == 0) goto next;
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, padUndefinedMaskField);
+        il.Emit(OpCodes.Ldloc, padIdxLocal);
+        il.Emit(OpCodes.Shr_Un);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.And);
+        il.Emit(OpCodes.Brfalse, padSkipSlot);
+        il.Emit(OpCodes.Ldloc, resultLocal);
+        il.Emit(OpCodes.Ldloc, padIdxLocal);
+        il.Emit(OpCodes.Ldsfld, runtime.UndefinedInstance);
+        il.Emit(OpCodes.Stelem_Ref);
+        il.MarkLabel(padSkipSlot);
+        il.Emit(OpCodes.Ldloc, padIdxLocal);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Stloc, padIdxLocal);
+        il.MarkLabel(padLoopCond);
+        il.Emit(OpCodes.Ldloc, padIdxLocal);
+        il.Emit(OpCodes.Ldloc, paramCountLocal);
+        il.Emit(OpCodes.Blt, padLoopBody);
+        il.MarkLabel(skipUndefinedPad);
+
         il.Emit(OpCodes.Ldloc, resultLocal);
         il.Emit(OpCodes.Ret);
 

--- a/Compilation/RuntimeEmitter.cs
+++ b/Compilation/RuntimeEmitter.cs
@@ -62,6 +62,11 @@ public partial class RuntimeEmitter
         // ldtoken the type for the IsDefined read.
         EmitCapturesArgumentsAttribute(moduleBuilder, runtime);
 
+        // Marker attribute for "this is a user TS function; pad omitted args with the
+        // `undefined` sentinel". Defined+created before EmitTSFunctionClass so the ctor IL
+        // can ldtoken the type for the IsDefined read in AdjustArgs caching. (#640)
+        EmitPadUndefinedAttribute(moduleBuilder, runtime);
+
         // Emit TSFunction class first (other methods depend on it)
         EmitTSFunctionClass(moduleBuilder, runtime);
 

--- a/SharpTS.Tests/CompilerTests/ArrowFunctionDefaultParameterTests.cs
+++ b/SharpTS.Tests/CompilerTests/ArrowFunctionDefaultParameterTests.cs
@@ -1,0 +1,118 @@
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.CompilerTests;
+
+/// <summary>
+/// #646: in compiled mode, function expressions and arrow functions must honor parameter defaults
+/// for omitted arguments. They have no OverloadGenerator lower-arity forwarding, so a value-type
+/// default slot (e.g. <c>number</c>) previously emitted invalid <c>ldarg; brfalse</c> IL and left
+/// the parameter at its CLR zero value. The fix widens defaulted arrow/function-expression params
+/// to object so the runtime entry prologue applies the default; async arrows additionally now emit
+/// that prologue at all. These run in both modes to pin interpreter/compiler parity.
+/// </summary>
+public class ArrowFunctionDefaultParameterTests
+{
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void FunctionExpression_NumericDefault_OmittedArg(ExecutionMode mode)
+    {
+        var source = """
+            const f = function (x: number, y: number = 3) { return x + y; };
+            console.log(f(4));
+            """;
+        Assert.Equal("7\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Arrow_NumericDefault_OmittedArg(ExecutionMode mode)
+    {
+        var source = """
+            const f = (x: number, y: number = 3) => x + y;
+            console.log(f(4));
+            """;
+        Assert.Equal("7\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Arrow_NumericDefault_ArgPresent_DefaultNotApplied(ExecutionMode mode)
+    {
+        var source = """
+            const f = (x: number, y: number = 3) => x + y;
+            console.log(f(4, 10));
+            """;
+        Assert.Equal("14\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Arrow_BooleanDefault_OmittedArg(ExecutionMode mode)
+    {
+        var source = """
+            const h = (on: boolean = true) => on ? "Y" : "N";
+            console.log(h() + h(false));
+            """;
+        Assert.Equal("YN\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Arrow_StringDefault_OmittedArg(ExecutionMode mode)
+    {
+        var source = """
+            const s = (a: string, b: string = "B") => a + b;
+            console.log(s("A"));
+            """;
+        Assert.Equal("AB\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void CapturingArrow_NumericDefault_OmittedArg(ExecutionMode mode)
+    {
+        var source = """
+            const base = 100;
+            const cap = (n: number = 7) => base + n;
+            console.log(cap() + "," + cap(1));
+            """;
+        Assert.Equal("107,101\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AsyncArrow_NumericDefault_OmittedArg(ExecutionMode mode)
+    {
+        var source = """
+            const af = async (x: number, y: number = 3) => x + y;
+            af(4).then(v => console.log(v));
+            """;
+        Assert.Equal("7\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AsyncArrow_DefaultWithAwait_OmittedArg(ExecutionMode mode)
+    {
+        var source = """
+            const af = async (x: number, y: number = 9) => { await Promise.resolve(0); return x * y; };
+            af(2).then(v => console.log(v));
+            """;
+        Assert.Equal("18\n", TestHarness.Run(source, mode));
+    }
+
+    [Fact]
+    public void Arrow_ValueTypeDefault_ProducesVerifiableIL()
+    {
+        // Regression guard for the StackUnexpected IL error: a value-type defaulted arrow
+        // parameter must not emit `ldarg; brfalse` on a double slot. (Behavioral correctness
+        // is covered by the both-mode theory tests above via RunCompiled.)
+        var source = """
+            const f = function (x: number, y: number = 3) { return x + y; };
+            console.log(f(4));
+            """;
+        var errors = TestHarness.CompileAndVerifyOnly(source);
+        Assert.Empty(errors);
+    }
+}

--- a/SharpTS.Tests/CompilerTests/ValueCallUndefinedPaddingTests.cs
+++ b/SharpTS.Tests/CompilerTests/ValueCallUndefinedPaddingTests.cs
@@ -1,0 +1,98 @@
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.CompilerTests;
+
+/// <summary>
+/// #640: in compiled mode, invoking a user function as a value (cross-module imports, callbacks,
+/// <c>$TSFunction.Invoke</c>) must pad omitted trailing optional arguments with the <c>undefined</c>
+/// sentinel — not CLR null — so <c>typeof</c>, <c>=== undefined</c>, and <c>=== null</c> answer
+/// correctly. Runtime built-ins keep null padding (they use null-checks for optional-arg absence).
+/// Both modes are pinned for interpreter/compiler parity; the compiled path was the defective one.
+/// </summary>
+public class ValueCallUndefinedPaddingTests
+{
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void CrossModuleImport_OmittedOptionalArg_IsUndefined(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["helper.ts"] = """
+                export function h(x?: any): string { return typeof x; }
+                export function h2(x?: any): boolean { return x === undefined; }
+                export function h3(x?: any): boolean { return x === null; }
+                """,
+            ["main.ts"] = """
+                import { h, h2, h3 } from './helper';
+                console.log(h());
+                console.log(h2());
+                console.log(h3());
+                """,
+        };
+        Assert.Equal("undefined\ntrue\nfalse\n", TestHarness.RunModules(files, "main.ts", mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void FunctionDeclarationAsValue_OmittedOptionalArg_IsUndefined(ExecutionMode mode)
+    {
+        var source = """
+            function fdecl(x?: any): string { return typeof x; }
+            const r = fdecl;
+            console.log(r());
+            """;
+        Assert.Equal("undefined\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ArrowAsValue_OmittedOptionalArg_IsUndefined(ExecutionMode mode)
+    {
+        var source = """
+            const farrow = (x?: any): string => typeof x;
+            console.log(farrow());
+            """;
+        Assert.Equal("undefined\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Callback_OmittedOptionalArg_IsUndefined(ExecutionMode mode)
+    {
+        var source = """
+            function callIt(cb: (x?: any) => string): string { return cb(); }
+            console.log(callIt((x?: any) => typeof x));
+            """;
+        Assert.Equal("undefined\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void InnerFunctionAsValue_OmittedOptionalArg_IsUndefined(ExecutionMode mode)
+    {
+        var source = """
+            function outer(): string {
+              function inner(x?: any): string { return typeof x; }
+              const r = inner;
+              return r();
+            }
+            console.log(outer());
+            """;
+        Assert.Equal("undefined\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void BuiltInCallback_OmittedTrailingArg_StillNullPadded(ExecutionMode mode)
+    {
+        // Regression guard: built-in array callbacks pad missing trailing slots with null
+        // (not the sentinel). An arrow callback only declaring the element parameter must still
+        // work — and a `function` callback observing arity sees the standard 3 args.
+        var source = """
+            const doubled = [1, 2, 3].map(x => x * 2);
+            console.log(doubled.join(","));
+            """;
+        Assert.Equal("2,4,6\n", TestHarness.Run(source, mode));
+    }
+}

--- a/SharpTS.Tests/TypeCheckerTests/OptionalParamUndefinedArgTests.cs
+++ b/SharpTS.Tests/TypeCheckerTests/OptionalParamUndefinedArgTests.cs
@@ -1,0 +1,104 @@
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.TypeCheckerTests;
+
+/// <summary>
+/// #668: an optional (<c>x?: T</c>) or default-valued (<c>x: T = ...</c>) parameter accepts an
+/// explicit <c>undefined</c> argument at the call site (its call-site type is <c>T | undefined</c>);
+/// passing <c>undefined</c> to a default-valued parameter triggers the default. A genuinely required
+/// parameter must still reject <c>undefined</c>. Runs ahead of both interpreter and compiler.
+/// </summary>
+public class OptionalParamUndefinedArgTests
+{
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void OptionalParameter_AcceptsExplicitUndefined(ExecutionMode mode)
+    {
+        var source = """
+            function f(name?: string): string { return "Hi " + name; }
+            console.log(f(undefined));
+            """;
+        Assert.Equal("Hi undefined\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void DefaultParameter_AcceptsExplicitUndefined_FiresDefault(ExecutionMode mode)
+    {
+        var source = """
+            function g(n: string = "W"): string { return n; }
+            console.log(g(undefined));
+            """;
+        Assert.Equal("W\n", TestHarness.Run(source, mode));
+    }
+
+    [Fact]
+    public void DefaultSecondParameter_AcceptsExplicitUndefined()
+    {
+        // Interpreter-only: the #668 type-check fix (accept explicit `undefined`) is exercised in
+        // BOTH modes by the optional/string-default tests above. Passing `undefined` to a *value-type*
+        // default of a function declaration is correct here but yields NaN in compiled mode — a
+        // separate value-type-slot runtime gap tracked in #705.
+        var source = """
+            function p(a: string, b: number = 2): number { return a.length + b; }
+            console.log(p("x", undefined));
+            """;
+        Assert.Equal("3\n", TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void RequiredParameter_RejectsUndefined()
+    {
+        // Regression guard: a genuinely required parameter must still reject `undefined` (TS2345).
+        var source = """
+            function r(n: string): string { return n; }
+            console.log(r(undefined));
+            """;
+        var ex = Assert.ThrowsAny<Exception>(() => TestHarness.RunInterpreted(source));
+        Assert.Contains("Type Error", ex.Message);
+    }
+
+    [Fact]
+    public void OptionalParameter_AcceptsUnionWithUndefinedArgument()
+    {
+        // `string | undefined` value passed to an optional `string` parameter.
+        var source = """
+            function f(name?: string): string { return typeof name; }
+            const v: string | undefined = (Math.random() < 0 ? "x" : undefined);
+            console.log(f(v));
+            """;
+        // Type-checks (no TS2345); value is undefined at runtime.
+        Assert.Equal("undefined\n", TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void PrivateMethodDefaultParameter_AcceptsUndefined()
+    {
+        // Interpreter-only — see DefaultSecondParameter_AcceptsExplicitUndefined; value-type
+        // default in a method yields NaN in compiled mode (tracked in #705).
+        var source = """
+            class C {
+              #priv(a: string, b: number = 7): number { return a.length + b; }
+              go(): number { return this.#priv("x", undefined); }
+            }
+            console.log(new C().go());
+            """;
+        Assert.Equal("8\n", TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void ConstructorDefaultParameter_AcceptsUndefined()
+    {
+        // Interpreter-only — see DefaultSecondParameter_AcceptsExplicitUndefined; value-type
+        // default in a constructor yields NaN in compiled mode (tracked in #705).
+        var source = """
+            class D {
+              constructor(public name: string, public age: number = 99) {}
+            }
+            const d = new D("Bob", undefined);
+            console.log(d.name + ":" + d.age);
+            """;
+        Assert.Equal("Bob:99\n", TestHarness.RunInterpreted(source));
+    }
+}

--- a/TypeSystem/TypeChecker.Calls.cs
+++ b/TypeSystem/TypeChecker.Calls.cs
@@ -560,8 +560,10 @@ public partial class TypeChecker
                         }
                         if (paramIndex < regularParamCount)
                         {
-                            // Check against regular parameter
-                            if (!IsCompatible(funcType.ParamTypes[paramIndex], argType))
+                            // Check against regular parameter. An optional/default-valued parameter
+                            // (position >= MinArity) also accepts an explicit `undefined` (#668).
+                            bool optional = paramIndex >= funcType.MinArity;
+                            if (!IsArgumentCompatible(funcType.ParamTypes[paramIndex], argType, optional))
                             {
                                 throw new TypeCheckException($"Argument {argIndex + 1} expected type '{funcType.ParamTypes[paramIndex]}' but got '{argType}'.", tsCode: "TS2345");
                             }

--- a/TypeSystem/TypeChecker.Compatibility.cs
+++ b/TypeSystem/TypeChecker.Compatibility.cs
@@ -90,6 +90,24 @@ public partial class TypeChecker
     private const int MaxCompatibilityCheckDepth = 50;
 
     /// <summary>
+    /// Argument/parameter assignability that additionally honors parameter optionality.
+    /// An optional (<c>x?: T</c>) or default-valued (<c>x: T = …</c>) parameter has a call-site
+    /// type of <c>T | undefined</c> in TypeScript, so an explicit <c>undefined</c> (or a
+    /// <c>T | undefined</c> value) argument is accepted there — and, for a default-valued
+    /// parameter, triggers the default. Pass <paramref name="optional"/> = true only for a
+    /// non-rest parameter whose position is at or beyond the signature's <c>MinArity</c>; a
+    /// genuinely required parameter (optional = false) still rejects <c>undefined</c>. (#668)
+    /// </summary>
+    private bool IsArgumentCompatible(TypeInfo paramType, TypeInfo argType, bool optional)
+    {
+        if (IsCompatible(paramType, argType)) return true;
+        if (!optional) return false;
+        // Widen the declared type with `undefined`; the existing union-compatibility rules then
+        // accept an `undefined` / `T | undefined` argument without admitting any other mismatch.
+        return IsCompatible(new TypeInfo.Union([paramType, new TypeInfo.Undefined()]), argType);
+    }
+
+    /// <summary>
     /// Checks type compatibility with two-level memoization and co-inductive cycle detection.
     /// Level 1: Fast identity-based cache using reference equality (O(1) for same instances)
     /// Level 2: Structural equality cache for different instances with same structure

--- a/TypeSystem/TypeChecker.Properties.New.cs
+++ b/TypeSystem/TypeChecker.Properties.New.cs
@@ -759,7 +759,11 @@ public partial class TypeChecker
             for (int i = 0; i < newExpr.Arguments.Count; i++)
             {
                 TypeInfo argType = CheckExpr(newExpr.Arguments[i]);
-                if (!IsCompatible(paramTypes[i], argType))
+                // Optional/default constructor params accept an explicit `undefined` (#668);
+                // a rest parameter's elements are not optional in that sense.
+                bool optional = i >= ctorType.MinArity &&
+                                !(ctorType.HasRestParam && i >= paramTypes.Count - 1);
+                if (!IsArgumentCompatible(paramTypes[i], argType, optional))
                     throw new TypeCheckException($" Constructor argument {i + 1} expected type '{paramTypes[i]}' but got '{argType}'.", tsCode: "TS2345");
             }
         }

--- a/TypeSystem/TypeChecker.Properties.cs
+++ b/TypeSystem/TypeChecker.Properties.cs
@@ -1024,7 +1024,11 @@ public partial class TypeChecker
                 ? funcType.ParamTypes[i]
                 : funcType.ParamTypes[^1]; // Rest parameter type
 
-            if (!IsCompatible(paramType, argType))
+            // Optional/default params accept an explicit `undefined` (#668). A rest parameter's
+            // elements are not optional in that sense, so only widen for non-rest positions.
+            bool optional = i >= funcType.MinArity &&
+                            !(funcType.HasRestParam && i >= funcType.ParamTypes.Count - 1);
+            if (!IsArgumentCompatible(paramType, argType, optional))
             {
                 throw new TypeCheckException($" Argument {i + 1} to private method '{methodName}' has type '{argType}' but expected '{paramType}'.", tsCode: "TS2345");
             }


### PR DESCRIPTION
Completes #668, #646, and #640 — all optional/default-parameter handling, fixed in dependency order.

## #668 — type checker rejected explicit `undefined` for optional/default params
An optional (`x?: T`) or default-valued (`x: T = ...`) parameter now accepts an explicit `undefined` argument at the call site (its call-site type is `T | undefined`); passing `undefined` to a default-valued parameter triggers the default. `tsc` allows this; we emitted `TS2345`.

- New `IsArgumentCompatible(paramType, argType, optional)` helper in `TypeChecker.Compatibility.cs` — fast-path `IsCompatible`, else (when optional) retry against `T | undefined`.
- Applied at the regular-call (`TypeChecker.Calls.cs`), private-method (`TypeChecker.Properties.cs`), and constructor (`TypeChecker.Properties.New.cs`) argument-check sites. `optional = position >= MinArity` (both `?` and `= default` reduce `MinArity`).
- **Required** params still reject `undefined`; **rest-parameter** elements are *not* widened (matching `tsc`).

## #646 — compiled function expressions / arrow functions ignored defaults for omitted args
Two root causes:
1. A value-type default slot (`y: number = 3`) emitted invalid `ldarg; brfalse` IL (StackUnexpected) and the default never fired. Arrows/function-expressions get no `OverloadGenerator` lower-arity forwarding, so the runtime entry prologue is their only default mechanism — and it needs an `object` slot to detect a missing/undefined argument. `ParameterTypeResolver.WidenDefaultedParamsToObject` now widens **every** defaulted arrow/function-expression parameter to `object` (a typed reference slot like `string` coerces the sentinel to the literal `"undefined"` before the prologue, so widening value-types alone is insufficient).
2. `AsyncArrowMoveNextEmitter` never emitted the default prologue at all — it now does (placed after state dispatch so it runs only on initial entry), with `arrow.Parameters` threaded through its `EmitMoveNext` call sites.

## #640 — compiled value-calls padded omitted optional args with CLR `null`
Calling a user function as a value (cross-module imports, callbacks, `$TSFunction.Invoke`) now pads omitted trailing optional arguments with the `undefined` sentinel instead of CLR `null`, so `typeof` / `=== undefined` / `=== null` answer correctly and object-slotted defaults fire.

- A `$PadUndefined` marker attribute (mirroring the existing `$CapturesArguments`) tags user functions.
- `$TSFunction` caches a `_padUndefinedMask` at construction: bit `i` set iff the wrapped method is marked **and** parameter `i` has an `object` slot. `AdjustArgs` pads the sentinel only at masked positions.
- Typed default slots (string/double) and runtime built-ins keep `null` padding — built-ins null-check optional-arg absence, and a typed slot can't hold the sentinel (it would coerce before the prologue). This object-slot mask is what makes sentinel-vs-null correct and perf-neutral.
- Marker applied to function declarations, sync arrows (static + display-class), inner functions, and async-arrow stubs.

## Tests
New regression tests, both modes where applicable:
- `TypeCheckerTests/OptionalParamUndefinedArgTests.cs`
- `CompilerTests/ArrowFunctionDefaultParameterTests.cs` (incl. an IL-verification guard)
- `CompilerTests/ValueCallUndefinedPaddingTests.cs` (incl. a built-in null-padding guard)

Verification: full suite **12797 passed / 0 failed**; TypeScript conformance **31 / 0**; Test262 default subset showed **no bucket regressions** before hitting the pre-existing `0x80131506` host crash (a documented .NET host/JIT flake, unrelated to these changes).

## Follow-ups filed (out-of-scope gaps found along the way)
- #696 — parser can't parse an optional param in a private method (`#m(b?: T)`)
- #698 — a default value can't reference an earlier parameter (both modes)
- #703 — class methods invoked as values still null-pad (scattered method-define sites)
- #705 — value-type default + explicit/padded `undefined` → NaN in func-decl/method/ctor and the `--ref-asm` value-call (needs a broad value-type→object widening; deferred for perf/blast-radius)

## Reviewer notes
- The `--ref-asm` (reference-assembly emit) path makes `_types.Object != typeof(object)`; the widen helper takes the compilation's object type rather than hardcoding `typeof(object)`.
- An earlier cut padded `$Undefined` for *all* slots and regressed 24 tests (typed string-defaults coerced the sentinel) — the object-slot mask is the fix.