### PR TITLE
Fix #672: reject top-level / non-async `for await...of` in the type checker

### DIFF
--- a/SharpTS.Tests/SharedTests/AsyncGeneratorTests.cs
+++ b/SharpTS.Tests/SharedTests/AsyncGeneratorTests.cs
@@ -1,4 +1,5 @@
 using SharpTS.Tests.Infrastructure;
+using SharpTS.TypeSystem.Exceptions;
 using Xunit;
 
 namespace SharpTS.Tests.SharedTests;
@@ -327,6 +328,41 @@ public class AsyncGeneratorTests
 
         var output = TestHarness.Run(source, mode);
         Assert.Equal("first: 1\nfirst: 2\nsecond: 1\nsecond: 2\n", output);
+    }
+
+    // #672: a top-level `for await...of` drives the async-iterator protocol, which requires an async
+    // context. SharpTS does not support top-level await, so — like a top-level `await` expression —
+    // it must be rejected by the type checker rather than silently degrading to a synchronous
+    // `for...of` (which then throws a misleading 'not iterable' runtime error in both modes).
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ForAwaitOf_TopLevel_RejectedByTypeChecker(ExecutionMode mode)
+    {
+        var source = """
+            async function* g() { yield 1; yield 2; }
+            for await (const x of g()) console.log("top", x);
+            """;
+
+        var ex = Assert.Throws<TypeCheckException>(() => TestHarness.Run(source, mode));
+        Assert.Contains("'await' is only valid inside an async function.", ex.Message);
+    }
+
+    // #672: `for await...of` inside a non-async function is likewise an await outside an async
+    // context and must be rejected (TS conformance), not run as a synchronous `for...of`.
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ForAwaitOf_InNonAsyncFunction_RejectedByTypeChecker(ExecutionMode mode)
+    {
+        var source = """
+            async function* g() { yield 1; yield 2; }
+            function notAsync() {
+                for await (const x of g()) console.log(x);
+            }
+            notAsync();
+            """;
+
+        var ex = Assert.Throws<TypeCheckException>(() => TestHarness.Run(source, mode));
+        Assert.Contains("'await' is only valid inside an async function.", ex.Message);
     }
 
     #endregion

--- a/TypeSystem/TypeChecker.Statements.cs
+++ b/TypeSystem/TypeChecker.Statements.cs
@@ -825,6 +825,18 @@ public partial class TypeChecker
 
     internal VoidResult VisitForOf(Stmt.ForOf stmt)
     {
+        // `for await...of` drives the async-iterator protocol, so — like an `await` expression or
+        // `await using` — it is only valid inside an async function. SharpTS does not support
+        // top-level await, so a top-level (or otherwise non-async-context) `for await` is rejected
+        // here rather than silently degrading to a synchronous `for...of`, which would then fail at
+        // runtime with a misleading 'not iterable' error (#672). Mirrors CheckAwait / CheckUsingDeclaration.
+        if (stmt.IsAsync && !_inAsyncFunction)
+        {
+            throw new TypeCheckException(
+                "'await' is only valid inside an async function.",
+                stmt.Variable.Line, tsCode: "TS1308");
+        }
+
         TypeInfo iterableType = CheckExpr(stmt.Iterable);
 
         // Now that generator yield-type inference draws from the `yield` / `yield*` operands (#548), the


### PR DESCRIPTION
## What

A `for await...of` drives the async-iterator protocol and is only valid in an async context — exactly like an `await` expression or `await using`. The type checker flagged those two (`CheckAwait` / `CheckUsingDeclaration`) but never checked the `await` modifier on `Stmt.ForOf`, so a top-level `for await` (or one inside a plain function) slipped through type checking and was then executed as an ordinary synchronous `for...of`. Iterating an async generator that way failed at runtime in **both** modes with a misleading error:

| | Before |
|---|---|
| Interpreted | `Runtime Error: for...of requires an iterable (array, Map, Set, or iterator).` |
| Compiled | `System.Exception: Runtime Error: Value is not iterable...` at `$Runtime.IterateToList` |

## Fix

Reject it in `VisitForOf` with the same `'await' is only valid inside an async function.` diagnostic (`TS1308`) the await-expression and `await using` paths already emit. SharpTS does not support top-level await, so this is consistent with the existing up-front rejection of top-level `await` **expressions**, rather than silently degrading to a sync loop:

```
Type Error: 'await' is only valid inside an async function.
```

Now rejected up front in both modes (and also inside a non-async function, matching TS).

## Tests

Adds both-mode regression tests in `AsyncGeneratorTests`:
- `ForAwaitOf_TopLevel_RejectedByTypeChecker`
- `ForAwaitOf_InNonAsyncFunction_RejectedByTypeChecker`

Full suite green (12,838 passed). Conformance suites are unaffected by construction: Test262 runs with type-checking off for `.js` (and no runtime path changed), and the TypeScriptConformance subset covers only `assignmentCompatibility` / `conditional` — no `for await`.

## Note on #645

While picking up this branch I confirmed **#645** (compiled `for await` inside an async **arrow** throwing `InvalidCastException`) is already fixed on `main` (commit 2b7fc821) and its repro now passes in both modes — closing that issue separately.

Closes #672