### PR TITLE
Fix compiled chained-label for-loop hang (#580) and optional-chain string-method await over-eval (#627)

### DIFF
--- a/Compilation/AsyncGeneratorMoveNextEmitter.Statements.TryCatch.cs
+++ b/Compilation/AsyncGeneratorMoveNextEmitter.Statements.TryCatch.cs
@@ -28,7 +28,7 @@ public partial class AsyncGeneratorMoveNextEmitter
     {
         public required Label BreakLabel;
         public required Label ContinueLabel;
-        public string? LabelName;
+        public IReadOnlyList<string> LabelNames = CompilationContext.NoLabels;
 
         // Lazily assigned the first time a break/continue to this loop must run an intervening
         // finally; identifies that exit in the `<>pendingExit` field. Unset while the loop's
@@ -102,11 +102,11 @@ public partial class AsyncGeneratorMoveNextEmitter
     // ---- Loop-scope methods (override the base stack to use `_exitScopes`) -----------------------
 
     protected override void EnterLoop(Label breakLabel, Label continueLabel, string? labelName = null)
-        // Adopt a pending label (`outer: for (...)`) just like the sync generator emitter does, so a
-        // labeled `break`/`continue` can resolve this loop as its target. Without the fallback the
-        // LoopScope registers with LabelName == null and FindLabeledLoopScope never matches, making a
-        // labeled break/continue a silent no-op — the loop keeps iterating (#586).
-        => _exitScopes.Add(new LoopScope { BreakLabel = breakLabel, ContinueLabel = continueLabel, LabelName = labelName ?? Ctx.TakePendingLoopLabel() });
+        // Adopt any pending labels (`outer: for (...)`, or a chain `a: b: for`) just like the sync
+        // generator emitter does, so a labeled `break`/`continue` can resolve this loop as its target.
+        // Without the fallback the LoopScope registers with no labels and FindLabeledLoopScope never
+        // matches, making a labeled break/continue a silent no-op — the loop keeps iterating (#586).
+        => _exitScopes.Add(new LoopScope { BreakLabel = breakLabel, ContinueLabel = continueLabel, LabelNames = labelName != null ? new[] { labelName } : Ctx.TakePendingLoopLabels() });
 
     protected override void ExitLoop()
     {
@@ -115,19 +115,19 @@ public partial class AsyncGeneratorMoveNextEmitter
         _exitScopes.RemoveAt(_exitScopes.Count - 1);
     }
 
-    protected override (Label BreakLabel, Label ContinueLabel, string? LabelName)? CurrentLoop
+    protected override (Label BreakLabel, Label ContinueLabel, IReadOnlyList<string> LabelNames)? CurrentLoop
     {
         get
         {
             var loop = CurrentLoopScope();
-            return loop == null ? null : (loop.BreakLabel, loop.ContinueLabel, loop.LabelName);
+            return loop == null ? null : (loop.BreakLabel, loop.ContinueLabel, loop.LabelNames);
         }
     }
 
-    protected override (Label BreakLabel, Label ContinueLabel, string? LabelName)? FindLabeledLoop(string labelName)
+    protected override (Label BreakLabel, Label ContinueLabel, IReadOnlyList<string> LabelNames)? FindLabeledLoop(string labelName)
     {
         var loop = FindLabeledLoopScope(labelName);
-        return loop == null ? null : (loop.BreakLabel, loop.ContinueLabel, loop.LabelName);
+        return loop == null ? null : (loop.BreakLabel, loop.ContinueLabel, loop.LabelNames);
     }
 
     private LoopScope? CurrentLoopScope()
@@ -141,7 +141,7 @@ public partial class AsyncGeneratorMoveNextEmitter
     private LoopScope? FindLabeledLoopScope(string labelName)
     {
         for (int i = _exitScopes.Count - 1; i >= 0; i--)
-            if (_exitScopes[i] is LoopScope ls && ls.LabelName == labelName)
+            if (_exitScopes[i] is LoopScope ls && ls.LabelNames.Contains(labelName))
                 return ls;
         return null;
     }

--- a/Compilation/CompilationContext.cs
+++ b/Compilation/CompilationContext.cs
@@ -202,27 +202,36 @@ public partial class CompilationContext
     // Loop and Exception Block Control
     // ============================================
 
-    // Loop control labels (with optional label name for labeled statements)
-    public Stack<(Label BreakLabel, Label ContinueLabel, string? LabelName)> LoopLabels { get; } = new();
+    // Loop control labels. LabelNames carries every label a labeled break/continue can target —
+    // usually zero or one, but a chain like `a: b: for` hands the loop both, so `continue a` and
+    // `continue b` resolve to the same loop. Empty (NoLabels) for an unlabeled loop.
+    public Stack<(Label BreakLabel, Label ContinueLabel, IReadOnlyList<string> LabelNames)> LoopLabels { get; } = new();
+
+    /// <summary>Shared empty label set for unlabeled loops (avoids per-loop allocation).</summary>
+    public static readonly IReadOnlyList<string> NoLabels = [];
+
+    // Labels parked by EmitLabeledStatement for the loop a chain of them directly wraps. The loop
+    // drains them all at entry via TakePendingLoopLabels and treats a continue/break to any of them
+    // as targeting itself, running the loop's own step (a for's increment, a while's re-test) rather
+    // than restarting it — restarting a `for` would re-run its initializer forever (#558/#580).
+    private readonly List<string> _pendingLoopLabels = [];
+
+    /// <summary>Parks a label for the next loop to adopt. A chain parks several before the loop.</summary>
+    public void AddPendingLoopLabel(string label) => _pendingLoopLabels.Add(label);
+
+    /// <summary>Discards any parked labels the next loop didn't drain (defensive cleanup).</summary>
+    public void ClearPendingLoopLabels() => _pendingLoopLabels.Clear();
 
     /// <summary>
-    /// Label name awaiting attachment to the next loop's own break/continue targets.
-    /// Set by <c>EmitLabeledStatement</c> when the labeled statement is a loop, and consumed
-    /// by that loop's <c>EnterLoop</c> (here or in an emitter override). This lets
-    /// <c>continue &lt;label&gt;</c> branch to the loop's real continue point — a for-loop's
-    /// increment, a while's condition — instead of a point ahead of the loop's initializer,
-    /// which would re-run it forever (#558).
+    /// Returns the labels parked for the loop now being entered, and clears them, so they attach to
+    /// exactly one loop.
     /// </summary>
-    public string? PendingLoopLabel { get; set; }
-
-    /// <summary>
-    /// Returns the pending labeled-loop name and clears it, so it attaches to exactly one loop.
-    /// </summary>
-    public string? TakePendingLoopLabel()
+    public IReadOnlyList<string> TakePendingLoopLabels()
     {
-        var label = PendingLoopLabel;
-        PendingLoopLabel = null;
-        return label;
+        if (_pendingLoopLabels.Count == 0) return NoLabels;
+        var labels = _pendingLoopLabels.ToArray();
+        _pendingLoopLabels.Clear();
+        return labels;
     }
 
     // Hoisted array type caches: stack of per-loop dictionaries mapping
@@ -340,27 +349,38 @@ public partial class CompilationContext
 
     public void EnterLoop(Label breakLabel, Label continueLabel, string? labelName = null)
     {
-        // An unlabeled EnterLoop call adopts any label parked by an enclosing labeled
-        // statement, so the loop's own continue/break targets carry the label (#558).
-        LoopLabels.Push((breakLabel, continueLabel, labelName ?? TakePendingLoopLabel()));
+        // An explicit label names this loop alone; otherwise the loop adopts whatever an enclosing
+        // labeled statement parked — a chain hands it several — so its own continue/break targets
+        // carry every label (#558/#580).
+        var labels = labelName != null ? new[] { labelName } : TakePendingLoopLabels();
+        LoopLabels.Push((breakLabel, continueLabel, labels));
     }
+
+    /// <summary>
+    /// Enters a loop carrying a pre-collected set of label names. Used where the labels are drained
+    /// once up front and handed to each of several alternative runtime paths (e.g. for-of's iterator
+    /// / index-based variants), so every path's break/continue targets resolve no matter which one
+    /// runs at runtime (#558).
+    /// </summary>
+    public void EnterLoop(Label breakLabel, Label continueLabel, IReadOnlyList<string> labelNames)
+        => LoopLabels.Push((breakLabel, continueLabel, labelNames));
 
     public void ExitLoop()
     {
         LoopLabels.Pop();
     }
 
-    public (Label BreakLabel, Label ContinueLabel, string? LabelName)? CurrentLoop =>
+    public (Label BreakLabel, Label ContinueLabel, IReadOnlyList<string> LabelNames)? CurrentLoop =>
         LoopLabels.Count > 0 ? LoopLabels.Peek() : null;
 
     /// <summary>
-    /// Find a loop label by name (for labeled break/continue).
+    /// Find a loop scope that carries the given label name (for labeled break/continue).
     /// </summary>
-    public (Label BreakLabel, Label ContinueLabel, string? LabelName)? FindLabeledLoop(string labelName)
+    public (Label BreakLabel, Label ContinueLabel, IReadOnlyList<string> LabelNames)? FindLabeledLoop(string labelName)
     {
         foreach (var entry in LoopLabels)
         {
-            if (entry.LabelName == labelName)
+            if (entry.LabelNames.Contains(labelName))
                 return entry;
         }
         return null;

--- a/Compilation/ExpressionEmitterBase.CallHelpers.cs
+++ b/Compilation/ExpressionEmitterBase.CallHelpers.cs
@@ -1097,34 +1097,107 @@ public abstract partial class ExpressionEmitterBase
         IL.Emit(OpCodes.Isinst, Ctx.Runtime!.UndefinedType);
         IL.Emit(OpCodes.Brtrue, nullishLabel);
 
-        // Pre-spilled, already-boxed argument locals shared by the string fast path and the generic
-        // path below. Stays null unless an argument can suspend.
-        LocalBuilder[]? argLocals = null;
+        bool stringMethod = IsRuntimeDispatchableStringMethod(g.Name.Lexeme);
 
-        // GetProperty can't resolve most string prototype methods (see
-        // EmitDynamicMethodCallPreservingThis) — keep its string fast path.
-        if (IsRuntimeDispatchableStringMethod(g.Name.Lexeme))
+        if (stringMethod && awaitSafe)
         {
-            // The string fast path and the generic path below both contain the arguments and are
-            // mutually exclusive at runtime. When an argument can suspend, spill the arguments once
-            // here — before the string-vs-generic split — so each await/yield is emitted exactly
-            // once; emitting them in both branches would desync the await-state counter (#614). The
-            // spill is reached only on the non-nullish receiver path, so the arguments stay
-            // unevaluated when the chain short-circuits.
+            // A string-named method with a suspending argument needs the args resolved *after* the
+            // short-circuit decision yet emitted exactly once. Handled in its own block (#614/#627).
+            EmitOptionalChainStringMethodAwaitSafe(c, g, recvLocal, nullishLabel, endLabel);
+        }
+        else
+        {
+            // Pre-spilled, already-boxed argument locals shared by the string fast path and the
+            // generic path below. Stays null unless an argument can suspend.
+            LocalBuilder[]? argLocals = null;
+
+            // GetProperty can't resolve most string prototype methods (see
+            // EmitDynamicMethodCallPreservingThis) — keep its string fast path. Without a suspending
+            // argument the args are emitted inline; the two paths are mutually exclusive at runtime,
+            // and with no await/yield, duplicating the (side-effect-free-to-the-counter) arg IL in
+            // both is harmless. The generic branch's fn-nullish check below still short-circuits
+            // before its inline args run, so a missing method never evaluates the args.
+            if (stringMethod)
+            {
+                var notStringLabel = IL.DefineLabel();
+                IL.Emit(OpCodes.Ldloc, recvLocal);
+                IL.Emit(OpCodes.Isinst, Types.String);
+                IL.Emit(OpCodes.Brfalse, notStringLabel);
+                EmitRuntimeStringMethod(recvLocal, g.Name.Lexeme, c.Arguments, argLocals);
+                IL.Emit(OpCodes.Br, endLabel);
+                IL.MarkLabel(notStringLabel);
+            }
+
+            // fn = GetProperty(recv, name); nullish fn short-circuits to undefined,
+            // matching the interpreter's HasOptionalInChain rule.
+            IL.Emit(OpCodes.Ldloc, recvLocal);
+            IL.Emit(OpCodes.Ldstr, g.Name.Lexeme);
+            IL.Emit(OpCodes.Call, Ctx.Runtime!.GetProperty);
+            var fnLocal = _helpers.SpillStoreObject();
+            IL.Emit(OpCodes.Ldloc, fnLocal);
+            IL.Emit(OpCodes.Brfalse, nullishLabel);
+            IL.Emit(OpCodes.Ldloc, fnLocal);
+            IL.Emit(OpCodes.Isinst, Ctx.Runtime!.UndefinedType);
+            IL.Emit(OpCodes.Brtrue, nullishLabel);
+
+            // InvokeMethodValue(recv, fn, args) — args evaluated only on the non-nullish path, per
+            // spec. For a non-string method spill the args here, after the method lookup, so an await
+            // in a later arg doesn't suspend with the receiver, fn, and the partially-built array all
+            // stacked (#439); this preserves the lookup-before-args evaluation order.
             if (awaitSafe)
                 argLocals = c.Arguments.Select(SpillBoxed).ToArray();
-
-            var notStringLabel = IL.DefineLabel();
             IL.Emit(OpCodes.Ldloc, recvLocal);
-            IL.Emit(OpCodes.Isinst, Types.String);
-            IL.Emit(OpCodes.Brfalse, notStringLabel);
-            EmitRuntimeStringMethod(recvLocal, g.Name.Lexeme, c.Arguments, argLocals);
+            IL.Emit(OpCodes.Ldloc, fnLocal);
+            EmitBoxedArgsArray(c.Arguments, argLocals);
+            IL.Emit(OpCodes.Call, Ctx.Runtime!.InvokeMethodValue);
             IL.Emit(OpCodes.Br, endLabel);
-            IL.MarkLabel(notStringLabel);
         }
 
-        // fn = GetProperty(recv, name); nullish fn short-circuits to undefined,
-        // matching the interpreter's HasOptionalInChain rule.
+        IL.MarkLabel(nullishLabel);
+        IL.Emit(OpCodes.Ldsfld, Ctx.Runtime!.UndefinedInstance);
+
+        IL.MarkLabel(endLabel);
+        SetStackUnknown();
+        return true;
+    }
+
+    /// <summary>
+    /// Emits the optional-chain dispatch for a string-named method (<c>substring</c>, <c>charAt</c>,
+    /// …) when an argument can suspend (<c>await</c>/<c>yield</c>). Two constraints collide here:
+    /// <list type="bullet">
+    /// <item>The string fast path (<see cref="EmitRuntimeStringMethod"/>, no method-existence check —
+    /// the method always exists on a real string) and the generic <c>GetProperty</c>+
+    /// <c>InvokeMethodValue</c> path are mutually exclusive at runtime, but the suspending argument
+    /// must be emitted <em>exactly once</em>; emitting it in both branches desyncs the await-state
+    /// counter and crashes the compiler (#614).</item>
+    /// <item>When the receiver is a non-string object that lacks the method, the chain short-circuits
+    /// to <c>undefined</c> and the argument must stay <em>unevaluated</em> — matching the interpreter,
+    /// which short-circuits before evaluating arguments (#627).</item>
+    /// </list>
+    /// So the dispatch is decided and the generic fn null-checked <em>before</em> any argument runs
+    /// (short-circuiting straight to <paramref name="nullishLabel"/> when the method is missing), then
+    /// the argument(s) are evaluated once in a shared block both live dispatches reach. The receiver
+    /// kind is re-tested with <c>isinst string</c> after the evaluation rather than stashed in a flag,
+    /// because <paramref name="recvLocal"/> persists across the suspension but a plain bool local would
+    /// reset on MoveNext re-entry.
+    ///
+    /// Note: like the rest of <see cref="TryEmitOptionalChainMethodCall"/> this keeps SharpTS's
+    /// pre-existing <c>HasOptionalInChain</c> quirk — a missing method on a non-nullish receiver yields
+    /// <c>undefined</c> rather than throwing <c>TypeError</c> (ECMA-262 would evaluate the args and
+    /// throw). Both modes share that quirk; this only realigns <em>when</em> the args run.
+    /// </summary>
+    private void EmitOptionalChainStringMethodAwaitSafe(Expr.Call c, Expr.Get g, LocalBuilder recvLocal, Label nullishLabel, Label endLabel)
+    {
+        var evalArgsLabel = IL.DefineLabel();
+        var genericDispatchLabel = IL.DefineLabel();
+
+        // String receiver → the method exists, so skip the lookup and go straight to arg eval.
+        IL.Emit(OpCodes.Ldloc, recvLocal);
+        IL.Emit(OpCodes.Isinst, Types.String);
+        IL.Emit(OpCodes.Brtrue, evalArgsLabel);
+
+        // Non-string receiver: resolve the method generically; a nullish fn short-circuits to
+        // undefined WITHOUT evaluating the argument (the parity fix — #627).
         IL.Emit(OpCodes.Ldloc, recvLocal);
         IL.Emit(OpCodes.Ldstr, g.Name.Lexeme);
         IL.Emit(OpCodes.Call, Ctx.Runtime!.GetProperty);
@@ -1135,25 +1208,25 @@ public abstract partial class ExpressionEmitterBase
         IL.Emit(OpCodes.Isinst, Ctx.Runtime!.UndefinedType);
         IL.Emit(OpCodes.Brtrue, nullishLabel);
 
-        // InvokeMethodValue(recv, fn, args) — args evaluated only on the non-nullish path, per spec.
-        // For a non-string method (or when the string path didn't pre-spill) spill the args here,
-        // after the method lookup, so an await in a later arg doesn't suspend with the receiver, fn,
-        // and the partially-built array all stacked (#439); this preserves the lookup-before-args
-        // evaluation order. String methods reuse the locals pre-spilled above.
-        if (awaitSafe && argLocals == null)
-            argLocals = c.Arguments.Select(SpillBoxed).ToArray();
+        // Shared block both live dispatches reach: evaluate the suspending argument(s) exactly once.
+        IL.MarkLabel(evalArgsLabel);
+        var argLocals = c.Arguments.Select(SpillBoxed).ToArray();
+
+        // Re-test the receiver kind (recvLocal survives the suspension) to pick the dispatch.
+        IL.Emit(OpCodes.Ldloc, recvLocal);
+        IL.Emit(OpCodes.Isinst, Types.String);
+        IL.Emit(OpCodes.Brfalse, genericDispatchLabel);
+        EmitRuntimeStringMethod(recvLocal, g.Name.Lexeme, c.Arguments, argLocals);
+        IL.Emit(OpCodes.Br, endLabel);
+
+        // Non-string receiver with a real method: InvokeMethodValue(recv, fn, args). fnLocal was
+        // stored on the non-string path above (the only way to reach this dispatch at runtime).
+        IL.MarkLabel(genericDispatchLabel);
         IL.Emit(OpCodes.Ldloc, recvLocal);
         IL.Emit(OpCodes.Ldloc, fnLocal);
         EmitBoxedArgsArray(c.Arguments, argLocals);
         IL.Emit(OpCodes.Call, Ctx.Runtime!.InvokeMethodValue);
         IL.Emit(OpCodes.Br, endLabel);
-
-        IL.MarkLabel(nullishLabel);
-        IL.Emit(OpCodes.Ldsfld, Ctx.Runtime!.UndefinedInstance);
-
-        IL.MarkLabel(endLabel);
-        SetStackUnknown();
-        return true;
     }
 
     /// <summary>

--- a/Compilation/GeneratorMoveNextEmitter.Statements.TryCatch.cs
+++ b/Compilation/GeneratorMoveNextEmitter.Statements.TryCatch.cs
@@ -28,7 +28,7 @@ public partial class GeneratorMoveNextEmitter
     {
         public required Label BreakLabel;
         public required Label ContinueLabel;
-        public string? LabelName;
+        public IReadOnlyList<string> LabelNames = CompilationContext.NoLabels;
 
         // Lazily assigned the first time a break/continue to this loop must run an intervening
         // finally; identifies that exit in the `<>pendingExit` field. Unset while the loop's
@@ -133,7 +133,7 @@ public partial class GeneratorMoveNextEmitter
     // ---- Loop-scope methods (override the base stack to use `_exitScopes`) -----------------------
 
     protected override void EnterLoop(Label breakLabel, Label continueLabel, string? labelName = null)
-        => _exitScopes.Add(new LoopScope { BreakLabel = breakLabel, ContinueLabel = continueLabel, LabelName = labelName ?? Ctx.TakePendingLoopLabel() });
+        => _exitScopes.Add(new LoopScope { BreakLabel = breakLabel, ContinueLabel = continueLabel, LabelNames = labelName != null ? new[] { labelName } : Ctx.TakePendingLoopLabels() });
 
     protected override void ExitLoop()
     {
@@ -142,19 +142,19 @@ public partial class GeneratorMoveNextEmitter
         _exitScopes.RemoveAt(_exitScopes.Count - 1);
     }
 
-    protected override (Label BreakLabel, Label ContinueLabel, string? LabelName)? CurrentLoop
+    protected override (Label BreakLabel, Label ContinueLabel, IReadOnlyList<string> LabelNames)? CurrentLoop
     {
         get
         {
             var loop = CurrentLoopScope();
-            return loop == null ? null : (loop.BreakLabel, loop.ContinueLabel, loop.LabelName);
+            return loop == null ? null : (loop.BreakLabel, loop.ContinueLabel, loop.LabelNames);
         }
     }
 
-    protected override (Label BreakLabel, Label ContinueLabel, string? LabelName)? FindLabeledLoop(string labelName)
+    protected override (Label BreakLabel, Label ContinueLabel, IReadOnlyList<string> LabelNames)? FindLabeledLoop(string labelName)
     {
         var loop = FindLabeledLoopScope(labelName);
-        return loop == null ? null : (loop.BreakLabel, loop.ContinueLabel, loop.LabelName);
+        return loop == null ? null : (loop.BreakLabel, loop.ContinueLabel, loop.LabelNames);
     }
 
     private LoopScope? CurrentLoopScope()
@@ -168,7 +168,7 @@ public partial class GeneratorMoveNextEmitter
     private LoopScope? FindLabeledLoopScope(string labelName)
     {
         for (int i = _exitScopes.Count - 1; i >= 0; i--)
-            if (_exitScopes[i] is LoopScope ls && ls.LabelName == labelName)
+            if (_exitScopes[i] is LoopScope ls && ls.LabelNames.Contains(labelName))
                 return ls;
         return null;
     }

--- a/Compilation/ILEmitter.Statements.cs
+++ b/Compilation/ILEmitter.Statements.cs
@@ -488,10 +488,10 @@ public partial class ILEmitter
     protected override void EmitForOf(Stmt.ForOf f)
     {
         // A for-of emits several alternative runtime paths (iterator protocol, index-based, …),
-        // each registering its own loop scope. Capture any labeled-loop name once up front and
-        // hand it to every path, so `continue`/`break <label>` resolve no matter which path runs
-        // at runtime (#558 — consuming it in only the first-emitted path left the others bare).
-        var labelName = _ctx.TakePendingLoopLabel();
+        // each registering its own loop scope. Capture any labeled-loop names once up front and
+        // hand them to every path, so `continue`/`break <label>` resolve no matter which path runs
+        // at runtime (#558 — consuming them in only the first-emitted path left the others bare).
+        var labelNames = _ctx.TakePendingLoopLabels();
         _ctx.Locals.EnterScope();
         var builder = _ctx.ILBuilder;
 
@@ -517,7 +517,7 @@ public partial class ILEmitter
             var genStartLabel = builder.DefineLabel("forof_gen_start");
             var genEndLabel = builder.DefineLabel("forof_gen_end");
             var genContinueLabel = builder.DefineLabel("forof_gen_continue");
-            _ctx.EnterLoop(genEndLabel, genContinueLabel, labelName);
+            _ctx.EnterLoop(genEndLabel, genContinueLabel, labelNames);
             EmitForOfEnumerator(f, genStartLabel, genEndLabel, genContinueLabel);
             return;
         }
@@ -528,7 +528,7 @@ public partial class ILEmitter
             var iterStartLabel = builder.DefineLabel("forof_iter_start");
             var iterEndLabel = builder.DefineLabel("forof_iter_end");
             var iterContinueLabel = builder.DefineLabel("forof_iter_continue");
-            _ctx.EnterLoop(iterEndLabel, iterContinueLabel, labelName);
+            _ctx.EnterLoop(iterEndLabel, iterContinueLabel, labelNames);
             EmitForOfNormalizedEnumerator(f, iterStartLabel, iterEndLabel, iterContinueLabel);
             return;
         }
@@ -548,7 +548,7 @@ public partial class ILEmitter
         var arrayDesc = ArrayElements.Resolve(iterableType);
         if (arrayDesc != null && arrayDesc.Kind == ArrayElementsKind.Object)
         {
-            EmitForOfArrayDirect(f, iterableLocal, arrayDesc, labelName);
+            EmitForOfArrayDirect(f, iterableLocal, arrayDesc, labelNames);
             _ctx.Locals.ExitScope();
             return;
         }
@@ -572,7 +572,7 @@ public partial class ILEmitter
             var iterStartLabel = builder.DefineLabel("forof_iter_start");
             var iterEndLabel = builder.DefineLabel("forof_iter_end");
             var iterContinueLabel = builder.DefineLabel("forof_iter_continue");
-            _ctx.EnterLoop(iterEndLabel, iterContinueLabel, labelName);
+            _ctx.EnterLoop(iterEndLabel, iterContinueLabel, labelNames);
 
             // Call the iterator function to get the iterator object
             // Use InvokeMethodValue to properly bind 'this' to the iterable object
@@ -643,7 +643,7 @@ public partial class ILEmitter
             var startLabel = builder.DefineLabel("forof_idx_start");
             var endLabel = builder.DefineLabel("forof_idx_end");
             var continueLabel = builder.DefineLabel("forof_idx_continue");
-            _ctx.EnterLoop(endLabel, continueLabel, labelName);
+            _ctx.EnterLoop(endLabel, continueLabel, labelNames);
 
             // Create index variable
             var indexLocal = IL.DeclareLocal(_ctx.Types.Int32);
@@ -701,7 +701,7 @@ public partial class ILEmitter
     /// for Object kind, or routed to a fallback iterator-helper for
     /// typed kinds.
     /// </summary>
-    private void EmitForOfArrayDirect(Stmt.ForOf f, LocalBuilder iterableLocal, ArrayElementsDescriptor desc, string? labelName = null)
+    private void EmitForOfArrayDirect(Stmt.ForOf f, LocalBuilder iterableLocal, ArrayElementsDescriptor desc, IReadOnlyList<string>? labelNames = null)
     {
         var builder = _ctx.ILBuilder;
         var listType = desc.GetListType(_ctx.Types);
@@ -771,7 +771,7 @@ public partial class ILEmitter
         // Loop entry: listLocal holds the list.
         builder.MarkLabel(loopHeadLabel);
 
-        _ctx.EnterLoop(endLabel, continueLabel, labelName);
+        _ctx.EnterLoop(endLabel, continueLabel, labelNames ?? CompilationContext.NoLabels);
 
         // var i = 0
         var indexLocal = IL.DeclareLocal(_ctx.Types.Int32);
@@ -1299,31 +1299,33 @@ public partial class ILEmitter
 
     protected override void EmitLabeledStatement(Stmt.LabeledStatement labeledStmt)
     {
-        string labelName = labeledStmt.Label.Lexeme;
+        // Look through a chain of labels (a: b: …) to whatever they ultimately wrap.
+        var inner = UnwrapLabelChain(labeledStmt, out var chainLabels);
 
-        if (IsLabelableLoop(labeledStmt.Statement))
+        if (IsLabelableLoop(inner))
         {
-            // Direct loop: park the label so the inner loop attaches it to its OWN break/continue
-            // targets (a for-loop's increment, a while's condition, …). Marking a continue label
-            // here — ahead of the for initializer — would re-run the initializer forever (#558).
-            _ctx.PendingLoopLabel = labelName;
+            // Direct (or chained) loop: park EVERY label in the chain so the inner loop attaches them
+            // all to its OWN break/continue targets (a for-loop's increment, a while's condition, …).
+            // Marking a continue label here — ahead of a for's initializer — would re-run it forever,
+            // and the outer label of a chain used to fall into exactly that path (#558/#580).
+            foreach (var label in chainLabels)
+                _ctx.AddPendingLoopLabel(label);
             try
             {
-                EmitStatement(labeledStmt.Statement);
+                EmitStatement(inner);
             }
             finally
             {
-                // The loop's EnterLoop consumes the label; clear it if somehow it didn't.
-                _ctx.PendingLoopLabel = null;
+                // The loop's EnterLoop drains the parked labels; clear any it somehow didn't.
+                _ctx.ClearPendingLoopLabels();
             }
             return;
         }
 
-        // Non-loop labeled statement (a block, etc.) or a chained label (a: b: loop) whose inner
-        // labeled statement owns the loop. Mark the continue target before the statement: harmless
-        // for a block, and for a chained while/for-of/for-in/do-while it re-enters at the loop
-        // head. (A chained label on a `for` re-runs its initializer — a pre-existing limitation,
-        // not regressed here; single-label `for` continue is fixed above.)
+        // Non-loop labeled statement (a block, etc.). Mark the continue target before the statement
+        // (harmless for a block) and keep one wrapper scope per label by recursing through the chain;
+        // only `break <label>` is meaningful here.
+        string labelName = labeledStmt.Label.Lexeme;
         var builder = _ctx.ILBuilder;
         var breakLabel = builder.DefineLabel($"labeled_{labelName}_break");
         var continueLabel = builder.DefineLabel($"labeled_{labelName}_continue");

--- a/Compilation/ILEmitter.cs
+++ b/Compilation/ILEmitter.cs
@@ -105,10 +105,10 @@ public partial class ILEmitter : StatementEmitterBase, IEmitterContext
     protected override void ExitLoop()
         => _ctx.ExitLoop();
 
-    protected override (Label BreakLabel, Label ContinueLabel, string? LabelName)? CurrentLoop
+    protected override (Label BreakLabel, Label ContinueLabel, IReadOnlyList<string> LabelNames)? CurrentLoop
         => _ctx.CurrentLoop;
 
-    protected override (Label BreakLabel, Label ContinueLabel, string? LabelName)? FindLabeledLoop(string labelName)
+    protected override (Label BreakLabel, Label ContinueLabel, IReadOnlyList<string> LabelNames)? FindLabeledLoop(string labelName)
         => _ctx.FindLabeledLoop(labelName);
 
     #endregion

--- a/Compilation/StatementEmitterBase.cs
+++ b/Compilation/StatementEmitterBase.cs
@@ -117,14 +117,14 @@ public abstract class StatementEmitterBase : ExpressionEmitterBase
 
     #region Virtual Methods - Loop Label Management (default: stack-based)
 
-    protected readonly Stack<(Label BreakLabel, Label ContinueLabel, string? LabelName)> _loopLabels = new();
+    protected readonly Stack<(Label BreakLabel, Label ContinueLabel, IReadOnlyList<string> LabelNames)> _loopLabels = new();
 
     /// <summary>
     /// Registers a loop context for break/continue resolution.
     /// Default: pushes onto an internal stack. ILEmitter overrides to use CompilationContext.
     /// </summary>
     protected virtual void EnterLoop(Label breakLabel, Label continueLabel, string? labelName = null)
-        => _loopLabels.Push((breakLabel, continueLabel, labelName ?? Ctx.TakePendingLoopLabel()));
+        => _loopLabels.Push((breakLabel, continueLabel, labelName != null ? new[] { labelName } : Ctx.TakePendingLoopLabels()));
 
     /// <summary>
     /// Exits the current loop context.
@@ -135,16 +135,16 @@ public abstract class StatementEmitterBase : ExpressionEmitterBase
     /// <summary>
     /// Gets the current innermost loop context, or null if not in a loop.
     /// </summary>
-    protected virtual (Label BreakLabel, Label ContinueLabel, string? LabelName)? CurrentLoop
+    protected virtual (Label BreakLabel, Label ContinueLabel, IReadOnlyList<string> LabelNames)? CurrentLoop
         => _loopLabels.Count > 0 ? _loopLabels.Peek() : null;
 
     /// <summary>
-    /// Finds a loop context by label name.
+    /// Finds a loop context that carries the given label name.
     /// </summary>
-    protected virtual (Label BreakLabel, Label ContinueLabel, string? LabelName)? FindLabeledLoop(string labelName)
+    protected virtual (Label BreakLabel, Label ContinueLabel, IReadOnlyList<string> LabelNames)? FindLabeledLoop(string labelName)
     {
         foreach (var loop in _loopLabels)
-            if (loop.LabelName == labelName)
+            if (loop.LabelNames.Contains(labelName))
                 return loop;
         return null;
     }
@@ -941,23 +941,33 @@ public abstract class StatementEmitterBase : ExpressionEmitterBase
     /// </summary>
     protected virtual void EmitLabeledStatement(Stmt.LabeledStatement ls)
     {
-        if (IsLabelableLoop(ls.Statement))
+        // Look through a chain of labels (a: b: …) to whatever they ultimately wrap.
+        var inner = UnwrapLabelChain(ls, out var chainLabels);
+
+        if (IsLabelableLoop(inner))
         {
-            // Direct loop: park the label so the loop attaches it to its OWN break/continue
-            // targets. A for registers continue at its increment, a while at its condition, etc.;
-            // marking a continue label here (ahead of the initializer) would re-run it (#558).
-            Ctx.PendingLoopLabel = ls.Label.Lexeme;
-            EmitStatement(ls.Statement);
-            // Defensive: the loop's EnterLoop consumes the label; clear it if somehow it didn't.
-            Ctx.PendingLoopLabel = null;
+            // Direct (or chained) loop: park EVERY label in the chain so the loop attaches them all
+            // to its OWN break/continue targets. A for registers continue at its increment, a while
+            // at its condition, etc.; marking a continue label here (ahead of a for's initializer)
+            // would re-run it forever — and the outer label of a chain used to fall into exactly
+            // that path (#558/#580).
+            foreach (var label in chainLabels)
+                Ctx.AddPendingLoopLabel(label);
+            try
+            {
+                EmitStatement(inner);
+            }
+            finally
+            {
+                // The loop's EnterLoop drains the parked labels; clear any it somehow didn't.
+                Ctx.ClearPendingLoopLabels();
+            }
             return;
         }
 
-        // Non-loop labeled statement (a block, etc.) or a chained label (a: b: loop) whose inner
-        // labeled statement owns the loop. Mark the continue target before the statement: it is
-        // harmless for a block, and for a chained while/for-of/for-in/do-while it re-enters at the
-        // loop head. (A chained label on a `for` re-runs its initializer — a pre-existing
-        // limitation, not regressed here; single-label `for` continue is fixed above.)
+        // Non-loop labeled statement (a block, etc.). Mark the continue target before the statement
+        // (harmless for a block) and keep one wrapper scope per label by recursing through the chain;
+        // only `break <label>` is meaningful here.
         var breakLabel = IL.DefineLabel();
         var continueLabel = IL.DefineLabel();
         IL.MarkLabel(continueLabel);
@@ -965,6 +975,22 @@ public abstract class StatementEmitterBase : ExpressionEmitterBase
         EmitStatement(ls.Statement);
         ExitLoop();
         IL.MarkLabel(breakLabel);
+    }
+
+    /// <summary>
+    /// Follows a chain of nested labeled statements (<c>a: b: stmt</c>) to the statement they wrap,
+    /// collecting every label name along the way.
+    /// </summary>
+    protected static Stmt UnwrapLabelChain(Stmt.LabeledStatement ls, out List<string> labels)
+    {
+        labels = [];
+        Stmt inner = ls;
+        while (inner is Stmt.LabeledStatement l)
+        {
+            labels.Add(l.Label.Lexeme);
+            inner = l.Statement;
+        }
+        return inner;
     }
 
     /// <summary>

--- a/SharpTS.Tests/SharedTests/AwaitDeferredSpillTests.cs
+++ b/SharpTS.Tests/SharedTests/AwaitDeferredSpillTests.cs
@@ -362,4 +362,55 @@ public class AwaitDeferredSpillTests
     {
         Assert.Equal("undefined\n", Run("""const n: any = null; console.log(n?.substring(await defer(1, 5), 4));""", mode));
     }
+
+    // #627: an optional-chain call to a dispatchable-string-method NAME (substring/charAt/…) on a
+    // non-string object that LACKS the method, with a deferred-await argument. The chain
+    // short-circuits to undefined; the interpreter does so before evaluating the argument, but the
+    // compiled await-safe path used to spill the arg before the string-vs-generic split, so the
+    // await ran anyway. Both modes must now leave the argument unevaluated (parity). The result is
+    // undefined in both either way — only the side effect differs.
+    // Observes whether an optional-chain call's awaited argument runs. `ran` and the synchronous
+    // flag-setter `mark()` live at top level (compiled mode supports neither a nested function nor a
+    // nested async function inside the async body); the awaited arg folds in `mark()` so its side
+    // effect fires iff the argument is evaluated. If the chain short-circuits first, `ran` stays false.
+    private static string RunOptionalChainObserve(string receiverDecl, string call, ExecutionMode mode)
+        => TestHarness.Run(
+            Defer +
+            "let ran = false;\n" +
+            "function mark(): number { ran = true; return 1; }\n" +
+            receiverDecl + "\n" +
+            "async function m() { const r = " + call + "; console.log(\"r=\" + r + \" ran=\" + ran); }\n" +
+            "m();\n",
+            mode);
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void OptionalChainStringMethod_MissingOnNonStringReceiver_DoesNotEvaluateAwaitArg(ExecutionMode mode)
+    {
+        // The #627 repro: substring on a non-string object that lacks it. Both modes short-circuit to
+        // undefined WITHOUT running the awaited arg (compiled used to spill it before the split).
+        Assert.Equal("r=undefined ran=false\n", RunOptionalChainObserve(
+            "const o: any = { foo: 1 };", "o?.substring(mark() + (await defer(0, 5)), 4)", mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void OptionalChainNonStringMethod_MissingOnReceiver_DoesNotEvaluateAwaitArg(ExecutionMode mode)
+    {
+        // The non-dispatchable-name sibling (slice) was already consistent — it never had a string
+        // fast path, so its arg spill already happened after the fn-nullish short-circuit. Pinned so
+        // the two stay aligned.
+        Assert.Equal("r=undefined ran=false\n", RunOptionalChainObserve(
+            "const o: any = { foo: 1 };", "o?.slice(mark() + (await defer(0, 5)), 4)", mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void OptionalChainStringMethod_StringReceiver_EvaluatesAwaitArg(ExecutionMode mode)
+    {
+        // A string receiver DOES have the method, so the argument must evaluate (side effect runs) and
+        // the real result comes back — the deferred-await arg still survives the suspension.
+        Assert.Equal("r=ell ran=true\n", RunOptionalChainObserve(
+            "const s: any = \"hello\";", "s?.substring(mark() + (await defer(0, 5)), 4)", mode));
+    }
 }

--- a/SharpTS.Tests/SharedTests/LabeledStatementTests.cs
+++ b/SharpTS.Tests/SharedTests/LabeledStatementTests.cs
@@ -360,12 +360,13 @@ public class LabeledStatementTests
     }
 
     [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
-    public void ChainedLabels_For_ContinueOuter_Interpreted(ExecutionMode mode)
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ChainedLabels_For_ContinueOuter(ExecutionMode mode)
     {
-        // A chain of labels on a `for` (a: b: for) — `continue p` must advance the outer for.
-        // The interpreter handles this; the compiled path is a known follow-up gap (it would
-        // re-run the for initializer), so this is interpreter-only.
+        // A chain of labels on a `for` (p: q: for) — `continue p` to the OUTER label of the chain
+        // must advance the for's own increment, not restart it. The compiled path used to re-run the
+        // for initializer (an infinite loop), since only the innermost label was handed to the loop
+        // and the outer one fell into the legacy "mark continue before the loop" path (#580).
         var source = """
             let sum: number = 0;
             p: q: for (let x = 0; x < 3; x++) {
@@ -379,6 +380,87 @@ public class LabeledStatementTests
 
         var output = TestHarness.Run(source, mode);
         Assert.Equal("30\n", output);  // 0 + 10 + 20
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ChainedLabels_For_ContinueInner(ExecutionMode mode)
+    {
+        // `continue q` to the INNER label of the chain targets the same for — same result as the
+        // outer-label case, since both labels wrap that one loop.
+        var source = """
+            let sum: number = 0;
+            p: q: for (let x = 0; x < 3; x++) {
+                for (let y = 0; y < 3; y++) {
+                    if (y === 1) { continue q; }
+                    sum = sum + (x * 10 + y);
+                }
+            }
+            console.log(sum);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("30\n", output);  // 0 + 10 + 20
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ChainedLabels_For_BreakOuter(ExecutionMode mode)
+    {
+        // `break a` to the outer label of a chain on a `for` exits the loop entirely.
+        var source = """
+            let s: string = "";
+            a: b: for (let x = 0; x < 3; x++) {
+                for (let y = 0; y < 3; y++) {
+                    if (x === 1 && y === 1) { break a; }
+                    s = s + x + "" + y + ";";
+                }
+            }
+            console.log(s);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("00;01;02;10;\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ChainedLabels_For_TripleChain_ContinueOutermost(ExecutionMode mode)
+    {
+        // Three labels on one `for`; `continue a` to the outermost resolves to the loop's increment.
+        var source = """
+            let sum: number = 0;
+            a: b: c: for (let x = 0; x < 3; x++) {
+                for (let y = 0; y < 3; y++) {
+                    if (y === 1) { continue a; }
+                    sum = sum + (x * 10 + y);
+                }
+            }
+            console.log(sum);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("30\n", output);  // 0 + 10 + 20
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ChainedLabels_ForOf_ContinueOuter(ExecutionMode mode)
+    {
+        // A chain on a `for-of`; `continue m` to the outer label advances the outer iterator.
+        var source = """
+            let s: string = "";
+            m: n: for (const x of [0, 1, 2]) {
+                for (const y of [0, 1, 2]) {
+                    if (y === 1) { continue m; }
+                    s = s + x + "" + y + ";";
+                }
+            }
+            console.log(s);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("00;10;20;\n", output);
     }
 
     #endregion


### PR DESCRIPTION
Fixes two compiled-mode parity bugs and documents a third as a deliberate deferral.

## #580 — chained label on a `for` re-ran the initializer on `continue <outerLabel>` (compiled hang)

`a: b: for (…)` with `continue` to the **outer** label of the chain hung in compiled mode: only the innermost label was handed to the loop, so the outer one fell into the legacy "mark continue target before the loop" path, ahead of the `for` initializer, which then re-ran forever. The interpreter already handled it.

**Fix:** a compiled loop scope now carries a *set* of label names (`IReadOnlyList<string> LabelNames`) instead of a single `string?`. `EmitLabeledStatement` flattens the label chain (new `UnwrapLabelChain` helper) and, when it bottoms out in a loop, parks **every** label via a pending list that the loop drains at `EnterLoop` — mirroring the interpreter's `_pendingLoopLabels`. `FindLabeledLoop` matches by membership. Threaded through `CompilationContext`, `StatementEmitterBase`, `ILEmitter`, and the sync/async generator emitters (for-of uses a drain-early-pass-many `IReadOnlyList<string>` `EnterLoop` overload; while/do-while/for-in adopt via the pending default).

**Tests:** converted the interpreter-only `ChainedLabels_For_ContinueOuter` to both-modes and added continue-inner, break-outer, triple-chain, and for-of-chain (all both-modes).

## #627 — optional-chain string-method over-evaluated an awaited argument (compiled)

For `o?.substring(await x, n)` where `o` is a non-string object lacking `substring`, the compiled await-safe path spilled the argument **before** the `isinst string` split (the #614 emit-once position), so the `await` ran even though the chain short-circuits to `undefined`. The interpreter short-circuits without evaluating the argument.

**Fix:** a dedicated await-safe helper (`EmitOptionalChainStringMethodAwaitSafe`) resolves the dispatch and null-checks the generic fn **before** evaluating the argument (short-circuiting first), then evaluates it once in a shared block both live dispatches reach — re-testing `isinst string` after the spill (the receiver local survives the suspension; a plain bool flag would reset on MoveNext re-entry). Preserves the #614 emit-once invariant and the pre-existing `HasOptionalInChain` quirk (returns `undefined` rather than throwing — that's shared by both modes). The non-await path keeps the baseline, which already short-circuits before its inline args.

**Tests:** new `RunOptionalChainObserve` helper (top-level flag-setter folded into the awaited arg — compiled supports neither a nested function nor a nested async function inside the async body) covering missing-on-non-string (`ran=false`), the `slice` sibling (`ran=false`), and a string receiver (`ran=true`).

## #650 — for(let) mutate-and-restore capture — assessed and deferred (no code change)

`for (let i …) { i=i+10; g.push(()=>i); i=i-10 }` yields `10,11,12` compiled vs `0,1,2` interp/node. Compiled snapshots the loop var at closure-creation time; the spec wants the per-iteration binding's end-of-body value. The correct fix is per-iteration **reference-capture cells** (the compiled analog of `CreatePerIterationEnvironment`) — a 5-area rework across all three variable resolvers + the for-loop emitters + closure capture + the analyzer, and it reintroduces boxing. Disproportionate and regression-prone for this exotic, low-priority edge, so it stays deferred (with an actionable design note added to the issue). The interpreted-only regression test is retained.

## Follow-up issues filed

- #704 — the async state-machine's separate labeled-loop subsystem has the same chained-label bug (wrong value, not a hang); out of scope for the sync #580 fix.
- #709 — `yield`-arg to an optional-chain string-method on a non-string object in a *generator* still diverges (astronomically rare; the non-string-method sibling is fine).

## Testing

Full suite green except `ClusterModuleTests.Fork_WorkersShareHttpPort`, a known pre-existing flake (HTTP-port race under parallel load, unrelated to these changes) that passes in isolation.
