### PR TITLE
Fix #697, #688: compiled async-gen for-await + yield* suspend on genuinely-async sources

### DIFF
--- a/Compilation/AsyncGeneratorMoveNextEmitter.Expressions.cs
+++ b/Compilation/AsyncGeneratorMoveNextEmitter.Expressions.cs
@@ -45,11 +45,18 @@ public partial class AsyncGeneratorMoveNextEmitter
         _il.Emit(OpCodes.Ldc_I4, stateNumber);
         _il.Emit(OpCodes.Stfld, _builder.StateField);
 
+        // Mirror live spill temps to fields before the yield suspends (a value spilled before this yield
+        // and used after it would otherwise be lost across the MoveNextAsync re-entry — #400 analog).
+        _helpers.PersistLiveSpillsBeforeSuspend();
+
         // 4. Return ValueTask<bool>(true) - has value
         EmitReturnValueTaskBool(true);
 
         // 5. Mark the resume label (jumped to from state switch)
         _il.MarkLabel(resumeLabel);
+
+        // Restore spill temps from their fields on the resumed path (reached only via the state switch).
+        _helpers.RehydrateLiveSpillsAfterResume();
 
         // 5a. Check __returnRequested flag (set by generator.return())
         // If true, jump to the enclosing finally cleanup path or complete the generator
@@ -123,6 +130,13 @@ public partial class AsyncGeneratorMoveNextEmitter
 
         var iterableTemp = _il.DeclareLocal(typeof(object));
         _il.Emit(OpCodes.Stloc, iterableTemp);
+
+        // Reserve the suspension state for the delegated iterator's next() await (consumed by the async
+        // arm below, #688). Allocated AFTER the value expression so any awaits inside it take earlier
+        // states — matching AsyncGeneratorStateAnalyzer.VisitYield, which records this synthetic await
+        // point after visiting the yield value. Unused by the sync arm, but its resume label is always
+        // marked (the async arm is always emitted), so the state switch stays valid either way.
+        int awaitState = _currentSuspensionState++;
 
         // Check if it's IAsyncEnumerator<object> (async generators implement this)
         _il.Emit(OpCodes.Ldloc, iterableTemp);
@@ -205,45 +219,38 @@ public partial class AsyncGeneratorMoveNextEmitter
         _il.Emit(OpCodes.Br, endLabel);
 
         // === Async loop ===
+        // Drive the delegated async iterator via its $IAsyncGenerator.next() — a Task<object> holding the
+        // { value, done } iterator result — and SUSPEND the enclosing async generator on it, rather than
+        // blocking on a synchronous ValueTask GetResult (which deadlocks a genuinely-async delegate the
+        // same way next() did before #631). next() maps directly onto the async-gen await mechanism; the
+        // reserved `awaitState` backs that suspension. Everything that reaches this arm
+        // (Isinst IAsyncEnumerator<object> succeeded) is an emitted async generator, which implements
+        // $IAsyncGenerator (#688).
         var asyncLoopEnd = _il.DefineLabel();
         _il.MarkLabel(asyncLoopLabel);
 
-        // Call MoveNextAsync
+        // result = await delegated.next()  — leaves the { value, done } dict on the stack
         _il.Emit(OpCodes.Ldarg_0);
         _il.Emit(OpCodes.Ldfld, delegatedField);
-        _il.Emit(OpCodes.Castclass, _types.IAsyncEnumeratorOfObject);
-        var moveNextAsync = _types.GetMethodNoParams(_types.IAsyncEnumeratorOfObject, "MoveNextAsync");
-        _il.Emit(OpCodes.Callvirt, moveNextAsync);
+        _il.Emit(OpCodes.Castclass, _ctx!.Runtime!.AsyncGeneratorInterfaceType);
+        _il.Emit(OpCodes.Callvirt, _ctx.Runtime.AsyncGeneratorNextMethod);
+        SetStackUnknown();
+        EmitAwaitFromValueOnStack(awaitState);
+        var asyncResultLocal = _il.DeclareLocal(typeof(object));
+        _il.Emit(OpCodes.Stloc, asyncResultLocal);
 
-        // Get result synchronously (simplified - full impl would suspend here)
-        var valueTaskLocal = _il.DeclareLocal(_types.ValueTaskOfBool);
-        _il.Emit(OpCodes.Stloc, valueTaskLocal);
-        _il.Emit(OpCodes.Ldloca, valueTaskLocal);
-        var getAwaiter = _types.GetMethodNoParams(_types.ValueTaskOfBool, "GetAwaiter");
-        _il.Emit(OpCodes.Call, getAwaiter);
-        var awaiterLocal = _il.DeclareLocal(_types.ValueTaskAwaiterOfBool);
-        _il.Emit(OpCodes.Stloc, awaiterLocal);
-        _il.Emit(OpCodes.Ldloca, awaiterLocal);
-        var getResult = _types.GetMethodNoParams(_types.ValueTaskAwaiterOfBool, "GetResult");
-        _il.Emit(OpCodes.Call, getResult);
+        // if (result.done) the delegation is finished.
+        _il.Emit(OpCodes.Ldloc, asyncResultLocal);
+        _il.Emit(OpCodes.Call, _ctx.Runtime.GetIteratorDone);
+        _il.Emit(OpCodes.Brtrue, asyncLoopEnd);
 
-        _il.Emit(OpCodes.Brfalse, asyncLoopEnd);
-
-        // Get Current
+        // <>2__current = result.value
         _il.Emit(OpCodes.Ldarg_0);
-        _il.Emit(OpCodes.Ldfld, delegatedField);
-        _il.Emit(OpCodes.Castclass, _types.IAsyncEnumeratorOfObject);
-        var currentGetter = _types.GetPropertyGetter(_types.IAsyncEnumeratorOfObject, "Current");
-        _il.Emit(OpCodes.Callvirt, currentGetter);
-
-        // Store in current field
-        var asyncValueTemp = _il.DeclareLocal(typeof(object));
-        _il.Emit(OpCodes.Stloc, asyncValueTemp);
-        _il.Emit(OpCodes.Ldarg_0);
-        _il.Emit(OpCodes.Ldloc, asyncValueTemp);
+        _il.Emit(OpCodes.Ldloc, asyncResultLocal);
+        _il.Emit(OpCodes.Call, _ctx.Runtime.GetIteratorValue);
         _il.Emit(OpCodes.Stfld, _builder.CurrentField);
 
-        // Set state and return
+        // Re-yield the delegated value to our own consumer: suspend at the re-yield state and return true.
         _il.Emit(OpCodes.Ldarg_0);
         _il.Emit(OpCodes.Ldc_I4, stateNumber);
         _il.Emit(OpCodes.Stfld, _builder.StateField);
@@ -428,12 +435,31 @@ public partial class AsyncGeneratorMoveNextEmitter
     protected override void EmitAwait(Expr.Await a)
     {
         int stateNumber = _currentSuspensionState++;
-        var resumeLabel = _stateLabels[stateNumber];
-        var continueLabel = _il.DefineLabel();
 
         // 1. Emit the awaited expression (should produce Task<object> or $Promise or any value)
         EmitExpression(a.Expression);
         EnsureBoxed();
+
+        // 2+. Coerce to Task<object>, suspend the async generator until it settles, and leave the
+        // awaited result on the stack.
+        EmitAwaitFromValueOnStack(stateNumber);
+    }
+
+    /// <summary>
+    /// Emits the await of a value already on the evaluation stack (boxed): coerces it to
+    /// <c>Task&lt;object&gt;</c> (unwrapping $Promise / adopting thenables / wrapping plain values),
+    /// suspends the async-generator state machine until it settles (via
+    /// <see cref="EmitAwaitSuspensionReturn"/> and the emitted AsyncGeneratorAwaitContinue), then leaves
+    /// the awaited result on the stack. Shared by <see cref="EmitAwait"/>, the <c>for await…of</c> loop's
+    /// implicit next()/return() awaits (#697), and <c>yield*</c> delegation's next() await (#688);
+    /// <paramref name="stateNumber"/> is the reserved suspension state for this await. The shared
+    /// AwaiterField/AwaitedTaskField are safe to reuse because the state machine only ever has one
+    /// suspension in flight at a time.
+    /// </summary>
+    internal void EmitAwaitFromValueOnStack(int stateNumber)
+    {
+        var resumeLabel = _stateLabels[stateNumber];
+        var continueLabel = _il.DefineLabel();
 
         // 2. Convert to Task<object> - handle $Promise, Task<object>, or non-Task values
         // If it's a $Promise, extract its Task property
@@ -507,6 +533,11 @@ public partial class AsyncGeneratorMoveNextEmitter
         _il.Emit(OpCodes.Ldc_I4, stateNumber);
         _il.Emit(OpCodes.Stfld, _builder.StateField);
 
+        // Mirror live spill temps to fields before the state machine suspends: IL locals do not survive
+        // the MoveNextAsync re-entry, so a value spilled before this await and used after it would be lost
+        // (#400 analog). Suspending path only. (#688/#697 exercise this via `param + (await …)` bodies.)
+        _helpers.PersistLiveSpillsBeforeSuspend();
+
         // For async generators, we need to return a ValueTask<bool> that will complete when the await completes
         // The simplest approach: wrap the continuing task
         // Create a continuation that resumes MoveNextAsync
@@ -519,6 +550,10 @@ public partial class AsyncGeneratorMoveNextEmitter
         _il.Emit(OpCodes.Ldarg_0);
         _il.Emit(OpCodes.Ldc_I4_M1);
         _il.Emit(OpCodes.Stfld, _builder.StateField);
+
+        // Restore spill temps from their fields — only on the resumed path; the synchronously-completed
+        // path (continueLabel below) never persisted and keeps its locals.
+        _helpers.RehydrateLiveSpillsAfterResume();
 
         // 8. Continue point (if was already completed)
         _il.MarkLabel(continueLabel);

--- a/Compilation/AsyncGeneratorMoveNextEmitter.Statements.TryCatch.cs
+++ b/Compilation/AsyncGeneratorMoveNextEmitter.Statements.TryCatch.cs
@@ -780,7 +780,12 @@ public partial class AsyncGeneratorMoveNextEmitter
                        (f.Increment != null && ContainsSuspensionInExpr(f.Increment)) ||
                        ContainsSuspensionInStmt(f.Body);
             case Stmt.ForOf fo:
-                return ContainsSuspensionInExpr(fo.Iterable) || ContainsSuspensionInStmt(fo.Body);
+                // `for await…of` now suspends on its implicit next()/return() awaits (#697), so it
+                // contains a suspension even when neither the iterable nor the body has an explicit
+                // yield/await. Treating it otherwise would put a `for await` inside a try on the real-IL
+                // try path, where its resume labels become illegal BranchIntoTry targets (the async-gen
+                // analog of the #631 ContainsAwait pitfall).
+                return fo.IsAsync || ContainsSuspensionInExpr(fo.Iterable) || ContainsSuspensionInStmt(fo.Body);
             case Stmt.ForIn fi:
                 return ContainsSuspensionInExpr(fi.Object) || ContainsSuspensionInStmt(fi.Body);
             case Stmt.Block b:

--- a/Compilation/AsyncGeneratorMoveNextEmitter.Statements.cs
+++ b/Compilation/AsyncGeneratorMoveNextEmitter.Statements.cs
@@ -6,6 +6,9 @@ namespace SharpTS.Compilation;
 
 public partial class AsyncGeneratorMoveNextEmitter
 {
+    // Per-method counter giving each for await…of loop a unique hoisted iterator field name (#697).
+    private int _forAwaitCounter;
+
     // EmitStatement: inherited from StatementEmitterBase (handles all statement types
     // including Using, DeclareModule, DeclareGlobal that were previously missing here)
 
@@ -168,107 +171,80 @@ public partial class AsyncGeneratorMoveNextEmitter
         ExitLoop();
     }
 
-    // Overrides the shared StatementEmitterBase.EmitForAwaitOf: an async generator that
-    // consumes another async iterable needs its own error-propagation handling (the
-    // try/catch around GetResult below) and a strict done check, so it keeps a specialized
-    // lowering rather than the shared one used by async functions/arrows (#430/#645).
+    /// <summary>
+    /// Async-generator override of the shared <see cref="StatementEmitterBase.EmitForAwaitOf"/>: a
+    /// <c>for await…of</c> inside an async generator drives an async iterator and SUSPENDS the enclosing
+    /// async-generator state machine on each <c>iterator.next()</c>/<c>iterator.return()</c> await,
+    /// instead of blocking on a synchronous <c>GetResult</c>. Blocking deadlocks a genuinely-async source
+    /// (a not-yet-settled await inside the iterator needs the very event-loop thread the block holds) —
+    /// the async-generator sibling of the async-function deadlock fixed in #631 (this is #697). The
+    /// analyzer reserved two suspension states (next + return) in
+    /// <c>AsyncGeneratorStateAnalyzer.VisitForOf</c>, consumed here in the same order.
+    /// </summary>
+    /// <remarks>
+    /// Scope matches the prior override: the iterator is driven through the <c>$IAsyncGenerator</c>
+    /// interface — the only async-iterator shape reachable as a CLR <c>IAsyncEnumerator&lt;object&gt;</c>
+    /// in compiled mode (custom <c>Symbol.asyncIterator</c> sources are guest objects, which this position
+    /// did not accept before either — a separate, pre-existing gap). <c>next()</c> returns a
+    /// <c>Task&lt;object&gt;</c> ({ value, done }) that maps directly onto the async-gen await mechanism
+    /// (<see cref="EmitAwaitFromValueOnStack"/>), so rejected steps propagate / reach an enclosing try
+    /// exactly as a normal <c>await</c> does.
+    /// </remarks>
     protected override void EmitForAwaitOf(Stmt.ForOf f)
     {
-        // for await...of iterates over async iterables
-        // We use the $IAsyncGenerator.next() method which returns Task<object>
-        // The result is a dictionary with { value, done } properties
-
         string varName = f.Variable.Lexeme;
         var varField = _builder.GetVariableField(varName);
+        var asyncGenInterface = _ctx!.Runtime!.AsyncGeneratorInterfaceType;
 
-        // Emit the async iterable expression
+        // The iterator must survive the per-iteration suspensions (a MoveNextAsync re-entry wipes IL
+        // locals — and the loop body itself may yield/await), so store it in a state-machine field,
+        // unique per loop. The type is still open here (CreateType runs after MoveNextAsync), so defining
+        // a field now is valid.
+        int loopId = _forAwaitCounter++;
+        var iteratorField = _builder.StateMachineType.DefineField(
+            $"<>7__aiter{loopId}", _types.Object, FieldAttributes.Private);
+
+        // Evaluate the async iterable and store it as the iterator (the async generator IS its own
+        // iterator). Casting to $IAsyncGenerator validates the shape, matching the prior override.
         EmitExpression(f.Iterable);
         EnsureBoxed();
-
-        // Cast to $IAsyncGenerator interface
-        var asyncGenInterface = _ctx!.Runtime!.AsyncGeneratorInterfaceType;
         _il.Emit(OpCodes.Castclass, asyncGenInterface);
+        var iterTemp = _il.DeclareLocal(asyncGenInterface);
+        _il.Emit(OpCodes.Stloc, iterTemp);
+        _il.Emit(OpCodes.Ldarg_0);
+        _il.Emit(OpCodes.Ldloc, iterTemp);
+        _il.Emit(OpCodes.Stfld, iteratorField);
 
-        // Store the async generator in a local
-        var asyncGenLocal = _il.DeclareLocal(asyncGenInterface);
-        _il.Emit(OpCodes.Stloc, asyncGenLocal);
+        int nextState = _currentSuspensionState++;   // iterator.next() await (reused each iteration)
 
         var startLabel = _il.DefineLabel();
         var endLabel = _il.DefineLabel();
         var cleanupLabel = _il.DefineLabel();
         var continueLabel = _il.DefineLabel();
 
-        // Break goes to cleanup (calls generator.return()), not directly to end
+        // break → cleanup (await iterator.return()); natural done → endLabel (no return() per spec).
         EnterLoop(cleanupLabel, continueLabel);
 
         _il.MarkLabel(startLabel);
 
-        // Call next() which returns Task<object>
-        _il.Emit(OpCodes.Ldloc, asyncGenLocal);
-        _il.Emit(OpCodes.Callvirt, _ctx.Runtime.AsyncGeneratorNextMethod);
-
-        // Await the Task<object> - get result synchronously for now
-        // (full async continuation would require state machine suspension)
-        var taskLocal = _il.DeclareLocal(_types.TaskOfObject);
-        _il.Emit(OpCodes.Stloc, taskLocal);
-        _il.Emit(OpCodes.Ldloc, taskLocal);
-        var getAwaiter = _types.GetMethodNoParams(_types.TaskOfObject, "GetAwaiter");
-        _il.Emit(OpCodes.Call, getAwaiter);
-        var awaiterLocal = _il.DeclareLocal(_types.TaskAwaiterOfObject);
-        _il.Emit(OpCodes.Stloc, awaiterLocal);
-
-        // Result local for storing the result
+        // result = await iterator.next()  — suspends if next() is not yet settled.
+        _il.Emit(OpCodes.Ldarg_0);
+        _il.Emit(OpCodes.Ldfld, iteratorField);
+        _il.Emit(OpCodes.Castclass, asyncGenInterface);
+        _il.Emit(OpCodes.Callvirt, _ctx.Runtime.AsyncGeneratorNextMethod);  // Task<object>
+        SetStackUnknown();
+        EmitAwaitFromValueOnStack(nextState);
         var resultLocal = _il.DeclareLocal(_types.Object);
-        var getResultSuccessLabel = _il.DefineLabel();
-
-        // Wrap GetResult() in try-catch for proper error propagation from rejected promises
-        _il.BeginExceptionBlock();
-
-        _il.Emit(OpCodes.Ldloca, awaiterLocal);
-        var getResult = _types.GetMethodNoParams(_types.TaskAwaiterOfObject, "GetResult");
-        _il.Emit(OpCodes.Call, getResult);
-        _il.Emit(OpCodes.Stloc, resultLocal);
-        _il.Emit(OpCodes.Leave, getResultSuccessLabel);
-
-        _il.BeginCatchBlock(typeof(Exception));
-        // Re-throw wrapped exception for proper propagation
-        _il.Emit(OpCodes.Call, _ctx.Runtime.WrapException);
-        _il.Emit(OpCodes.Call, _ctx.Runtime.CreateException);
-        _il.Emit(OpCodes.Throw);
-        _il.EndExceptionBlock();
-
-        _il.MarkLabel(getResultSuccessLabel);
-
-        // Result is a Dictionary<string, object> with { value, done }
         _il.Emit(OpCodes.Stloc, resultLocal);
 
-        // Check if done: GetProperty(result, "done")
-        // IMPORTANT: Use strict boolean check, not IsTruthy - IsTruthy treats 0 as falsy
-        // which would incorrectly end the loop when yielding zero
+        // if (result.done) exit without calling return().
         _il.Emit(OpCodes.Ldloc, resultLocal);
-        _il.Emit(OpCodes.Ldstr, "done");
-        _il.Emit(OpCodes.Call, _ctx.Runtime.GetProperty);
+        _il.Emit(OpCodes.Call, _ctx.Runtime.GetIteratorDone);
+        _il.Emit(OpCodes.Brtrue, endLabel);
 
-        // Check if it's a boxed bool true (strict check)
-        var notDoneLabel = _il.DefineLabel();
-        _il.Emit(OpCodes.Isinst, typeof(bool));
-        _il.Emit(OpCodes.Brfalse, notDoneLabel);  // Not a bool - continue loop
-
-        // It's a bool - unbox and check if true
+        // loopVar = result.value
         _il.Emit(OpCodes.Ldloc, resultLocal);
-        _il.Emit(OpCodes.Ldstr, "done");
-        _il.Emit(OpCodes.Call, _ctx.Runtime.GetProperty);
-        _il.Emit(OpCodes.Unbox_Any, typeof(bool));
-        _il.Emit(OpCodes.Brtrue, endLabel);  // done === true -> exit loop (no cleanup needed)
-
-        _il.MarkLabel(notDoneLabel);
-
-        // Get value: GetProperty(result, "value")
-        _il.Emit(OpCodes.Ldloc, resultLocal);
-        _il.Emit(OpCodes.Ldstr, "value");
-        _il.Emit(OpCodes.Call, _ctx.Runtime.GetProperty);
-
-        // Assign to loop variable
+        _il.Emit(OpCodes.Call, _ctx.Runtime.GetIteratorValue);
         if (varField != null)
         {
             var valueTemp = _il.DeclareLocal(_types.Object);
@@ -289,22 +265,17 @@ public partial class AsyncGeneratorMoveNextEmitter
         _il.MarkLabel(continueLabel);
         _il.Emit(OpCodes.Br, startLabel);
 
-        // Cleanup on break: call generator.return(null) to trigger finally blocks
+        // Cleanup on break: await iterator.return() (runs the iterator's finally blocks), discard result.
+        int returnState = _currentSuspensionState++;   // allocated after the body, matching the analyzer
         _il.MarkLabel(cleanupLabel);
-        _il.Emit(OpCodes.Ldloc, asyncGenLocal);
+        _il.Emit(OpCodes.Ldarg_0);
+        _il.Emit(OpCodes.Ldfld, iteratorField);
+        _il.Emit(OpCodes.Castclass, asyncGenInterface);
         _il.Emit(OpCodes.Ldnull);
-        _il.Emit(OpCodes.Callvirt, _ctx.Runtime.AsyncGeneratorReturnMethod);
-        // Await the Task<object> result and discard it
-        var cleanupTaskLocal = _il.DeclareLocal(_types.TaskOfObject);
-        _il.Emit(OpCodes.Stloc, cleanupTaskLocal);
-        _il.Emit(OpCodes.Ldloc, cleanupTaskLocal);
-        _il.Emit(OpCodes.Call, getAwaiter);
-        var cleanupAwaiterLocal = _il.DeclareLocal(_types.TaskAwaiterOfObject);
-        _il.Emit(OpCodes.Stloc, cleanupAwaiterLocal);
-        _il.Emit(OpCodes.Ldloca, cleanupAwaiterLocal);
-        _il.Emit(OpCodes.Call, getResult);
+        _il.Emit(OpCodes.Callvirt, _ctx.Runtime.AsyncGeneratorReturnMethod);  // Task<object>
+        SetStackUnknown();
+        EmitAwaitFromValueOnStack(returnState);
         _il.Emit(OpCodes.Pop);
-        _il.Emit(OpCodes.Br, endLabel);
 
         _il.MarkLabel(endLabel);
         ExitLoop();

--- a/Compilation/AsyncGeneratorMoveNextEmitter.cs
+++ b/Compilation/AsyncGeneratorMoveNextEmitter.cs
@@ -74,6 +74,12 @@ public partial class AsyncGeneratorMoveNextEmitter : StatementEmitterBase
         _analysis = analysis;
         _il = builder.MoveNextAsyncMethod.GetILGenerator();
         _types = types;
+        // A value spilled before an await/yield and used after it (e.g. the `p` in `p + (await x)`)
+        // must survive the MoveNextAsync re-entry in a state-machine field, not a transient IL local —
+        // the async-generator analog of #400. This was the only state-machine emitter that lacked the
+        // wiring (the other three enable it), so such a value was silently lost across a suspension.
+        _helpers.EnablePersistentSpills(name => _builder.StateMachineType.DefineField(
+            name, _types.Object, FieldAttributes.Private));
     }
 
     // DeclareLoopVariable and EmitStoreLoopVariable are handled by StatementEmitterBase

--- a/Compilation/AsyncGeneratorStateAnalyzer.Expressions.cs
+++ b/Compilation/AsyncGeneratorStateAnalyzer.Expressions.cs
@@ -32,7 +32,18 @@ public partial class AsyncGeneratorStateAnalyzer
         _seenSuspension = true;
 
         if (expr.IsDelegating)
+        {
             _hasYieldStar = true;
+
+            // `yield* iterable` over a genuinely-async iterator awaits the delegated iterator's next()
+            // each turn before re-yielding. Reserve a suspension state for that await — emitted (and
+            // consumed) AFTER the yield's own re-yield state and after the value expression, matching
+            // EmitYieldStarWithTypeCheck's allocation in the async arm (#688). It is reserved
+            // unconditionally for every delegating yield: sync-vs-async delegation is a runtime type
+            // check, and the async arm (which marks this state's resume label) is always emitted, so the
+            // state stays consistent whether or not the sync arm is taken at runtime.
+            RecordSyntheticAwaitPoint();
+        }
 
         // Track suspension in try block
         RecordSuspensionInTryBlock();

--- a/Compilation/AsyncGeneratorStateAnalyzer.Statements.cs
+++ b/Compilation/AsyncGeneratorStateAnalyzer.Statements.cs
@@ -31,7 +31,24 @@ public partial class AsyncGeneratorStateAnalyzer
         // Track for...of loops to detect suspensions inside them
         _forOfStack.Push(stmt);
         _variablesUsedInLoopBody[stmt] = [];
-        base.VisitForOf(stmt);
+
+        if (stmt.IsAsync)
+        {
+            // `for await…of` suspends the async generator on the iterator protocol: it awaits
+            // iterator.next() each iteration and iterator.return() on early exit. Reserve a suspension
+            // state for each, in emission order (iterable, next, body, return) — consumed in the same
+            // order by EmitForAwaitOf in AsyncGeneratorMoveNextEmitter.Statements.cs (#697). Mirrors
+            // AsyncStateAnalyzer.VisitForOf for async functions (#631).
+            Visit(stmt.Iterable);
+            RecordSyntheticAwaitPoint();   // iterator.next() — awaited at the loop head
+            Visit(stmt.Body);
+            RecordSyntheticAwaitPoint();   // iterator.return() — awaited in the break cleanup
+        }
+        else
+        {
+            base.VisitForOf(stmt);
+        }
+
         _forOfStack.Pop();
 
         // If this loop contains a suspension, all variables used in its body need hoisting

--- a/Compilation/AsyncGeneratorStateAnalyzer.cs
+++ b/Compilation/AsyncGeneratorStateAnalyzer.cs
@@ -201,6 +201,41 @@ public partial class AsyncGeneratorStateAnalyzer : AstVisitorBase
         _tryBlockSuspensionFlags.Clear();
     }
 
+    /// <summary>
+    /// Reserves a synthetic await suspension point — one that has no <see cref="Expr.Await"/> node in the
+    /// source. These back the implicit awaits of <c>for await…of</c> (the iterator's next()/return(), #697)
+    /// and of <c>yield*</c> delegation to a genuinely-async iterator (the delegated iterator's next(), #688).
+    /// The emitter consumes them, in the same traversal order, via <c>EmitAwaitFromValueOnStack</c>; this
+    /// mirrors <c>AsyncStateAnalyzer.VisitForOf</c>'s <c>RecordAwaitPoint(null)</c> for async functions (#631).
+    /// <see cref="SuspensionPoint.Expression"/> is left null and is never dereferenced — only
+    /// <see cref="SuspensionPoint.StateNumber"/> is read (to define the resume label in MoveNextAsync).
+    /// </summary>
+    private void RecordSyntheticAwaitPoint()
+    {
+        var liveVars = new HashSet<string>(_declaredVariables);
+        _suspensionPoints.Add(new SuspensionPoint(
+            _stateCounter++,
+            SuspensionType.Await,
+            Expression: null,
+            liveVars,
+            IsDelegatingYield: false,
+            TryBlockDepth: _currentTryBlockDepth,
+            EnclosingTryId: _currentTryBlockId
+        ));
+        _seenSuspension = true;
+
+        // Track suspension in try block (a for-await/delegating-yield inside a try makes that try suspend).
+        RecordSuspensionInTryBlock();
+
+        // Any for...of loop currently on the stack now contains a suspension and needs enumerator/variable
+        // hoisting (its body re-executes across the suspension).
+        foreach (var forOf in _forOfStack)
+        {
+            if (!_forOfLoopsWithSuspension.Contains(forOf))
+                _forOfLoopsWithSuspension.Add(forOf);
+        }
+    }
+
     private void RecordSuspensionInTryBlock()
     {
         if (_currentTryBlockId.HasValue && _currentTryRegion != TryRegion.None)

--- a/SharpTS.Tests/SharedTests/AsyncGeneratorTests.cs
+++ b/SharpTS.Tests/SharedTests/AsyncGeneratorTests.cs
@@ -1274,5 +1274,129 @@ public class AsyncGeneratorTests
         Assert.Equal("1 false 2 false\n", TestHarness.Run(source, mode));
     }
 
+    [Theory]
+    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    public void AsyncGenerator_ForAwaitOf_OverPendingAsyncGenerator_SuspendsNotBlocks(ExecutionMode mode)
+    {
+        // A `for await…of` INSIDE an async generator, consuming a genuinely-async (setTimeout-backed)
+        // source, must suspend on the inner iterator's next() instead of blocking on a synchronous
+        // GetResult — the latter deadlocked/crashed this stream-transform shape in compiled mode (#697,
+        // the async-generator sibling of #631). Compiled-only: the interpreter has a separate "cannot
+        // iterate" gap for `for await` over an async generator (its eager-drain model), tracked apart.
+        var source = """
+            function later(n: number): Promise<number> {
+                return new Promise(res => setTimeout(() => res(n), 5));
+            }
+            async function* src() { yield await later(1); yield await later(2); }
+            async function* transform() { for await (const x of src()) yield x * 10; }
+            async function main() {
+                for await (const v of transform()) console.log("v" + v);
+            }
+            main();
+            """;
+
+        Assert.Equal("v10\nv20\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    public void AsyncGenerator_ForAwaitOf_BreakAwaitsReturn(ExecutionMode mode)
+    {
+        // Breaking out of a `for await…of` inside an async generator must await the inner iterator's
+        // return() (the suspension-based cleanup path) and stop consuming — here only the first
+        // transformed value is produced before the break (#697). Compiled-only (interp for-await-in-
+        // async-generator gap).
+        var source = """
+            function later(n: number): Promise<number> {
+                return new Promise(res => setTimeout(() => res(n), 5));
+            }
+            async function* src() { yield await later(1); yield await later(2); yield await later(3); }
+            async function* transform() {
+                for await (const x of src()) { if (x === 2) break; yield x * 10; }
+            }
+            async function main() {
+                for await (const v of transform()) console.log("v" + v);
+                console.log("end");
+            }
+            main();
+            """;
+
+        Assert.Equal("v10\nend\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    public void AsyncGenerator_ForAwaitOf_InsideTryFinally_RunsFinally(ExecutionMode mode)
+    {
+        // A `for await…of` inside a try in an async generator now suspends, so it must take the
+        // flag-based try path: its resume labels would be illegal BranchIntoTry targets on the real-IL
+        // try path (the async-gen analog of the #631 ContainsAwait pitfall). The finally still runs after
+        // the loop drains. Compiled-only (interp for-await-in-async-generator gap).
+        var source = """
+            function later(n: number): Promise<number> {
+                return new Promise(res => setTimeout(() => res(n), 5));
+            }
+            async function* src() { yield await later(1); yield await later(2); }
+            async function* transform() {
+                try { for await (const x of src()) yield x * 10; }
+                finally { console.log("finally"); }
+            }
+            async function main() {
+                for await (const v of transform()) console.log("v" + v);
+            }
+            main();
+            """;
+
+        Assert.Equal("v10\nv20\nfinally\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AsyncGenerator_YieldStar_DelegatesToPendingAsyncGenerator(ExecutionMode mode)
+    {
+        // yield* delegating to a genuinely-async (setTimeout-backed) async generator must drive the
+        // delegate via its next() and suspend, not block on a synchronous MoveNextAsync GetResult — which
+        // produced no output at all in compiled mode (#688, sibling of #631). The delegate's
+        // `p + (await …)` body also exercises the live-spill-across-await persistence the async-generator
+        // emitter previously lacked (the #400 analog), so the parameter prefix survives the suspension.
+        var source = """
+            function later(n: number): Promise<number> {
+                return new Promise(res => setTimeout(() => res(n), 5));
+            }
+            async function* inner(p: string) { yield p + (await later(1)); yield p + (await later(2)); }
+            async function* outer() { yield* inner("a"); }
+            async function main() {
+                for await (const v of outer()) console.log(v);
+                console.log("done");
+            }
+            main();
+            """;
+
+        Assert.Equal("a1\na2\ndone\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AsyncGenerator_ValueLiveAcrossAwait_IsPreserved(ExecutionMode mode)
+    {
+        // A value live on the IL evaluation stack across an await inside an async generator — here the
+        // parameter `p`, the left operand of `p + (await …)` — must be spilled to a state-machine field
+        // and restored on resume (the async-generator analog of #400). The async-gen emitter previously
+        // never enabled persistent spills, so `p` was wiped by the MoveNextAsync re-entry and the result
+        // was "1"/"2" instead of "a1"/"a2".
+        var source = """
+            function later(n: number): Promise<number> {
+                return new Promise(res => setTimeout(() => res(n), 5));
+            }
+            async function* g(p: string) { yield p + (await later(1)); yield p + (await later(2)); }
+            async function main() {
+                for await (const v of g("a")) console.log(v);
+            }
+            main();
+            """;
+
+        Assert.Equal("a1\na2\n", TestHarness.Run(source, mode));
+    }
+
     #endregion
 }


### PR DESCRIPTION
## Summary

Fixes the two remaining compiled-mode async-generator paths that drove a **genuinely-async** inner iterator with a synchronous `GetResult`, deadlocking the event-loop thread the continuation needs — the siblings of #631. Both now **suspend** via the async-generator await mechanism.

| | before (compiled) | after |
|---|---|---|
| **#697** `for await…of` inside an async generator | `InvalidProgramException` | suspends ✓ |
| **#688** `yield*` to a genuinely-async async iterator | no output | suspends ✓ |

```ts
function later(n: number): Promise<number> { return new Promise(res => setTimeout(() => res(n), 5)); }

// #697
async function* src() { yield await later(1); yield await later(2); }
async function* transform() { for await (const x of src()) yield x * 10; }   // v10, v20

// #688
async function* inner(p: string) { yield p + (await later(1)); yield p + (await later(2)); }
async function* outer() { yield* inner("a"); }                                // a1, a2
```

## What changed

- **`EmitForAwaitOf`** (#697) drives `$IAsyncGenerator.next()`/`return()` (both `Task<object>`) and suspends on each via the extracted **`EmitAwaitFromValueOnStack`** instead of blocking. The iterator is persisted in a per-loop state-machine field (`<>7__aiter{N}`) so it survives the body's own yield/await suspensions — the old code used an IL local (wiped on re-entry) and crashed.
- **`EmitYieldStarWithTypeCheck`** async arm (#688) drives the delegate via `$IAsyncGenerator.next()` and suspends, instead of a synchronous `MoveNextAsync().GetResult()`. Everything reaching that arm is an emitted async generator (the only CLR `IAsyncEnumerator<object>` in compiled mode), which implements `$IAsyncGenerator`.
- **`AsyncGeneratorStateAnalyzer`** reserves the synthetic await states — 2 per `for await` (next + return), 1 per delegating `yield` — via the new `RecordSyntheticAwaitPoint`, in the same order the emitter consumes them (mirrors `AsyncStateAnalyzer.VisitForOf`'s `RecordAwaitPoint(null)`).
- **`ContainsSuspensionInStmt(ForOf)`** now treats `IsAsync` as a suspension, so a `for await` inside a try takes the flag-based path — the async-gen analog of the #631 `ContainsAwait` pitfall (otherwise its resume labels become illegal `BranchIntoTry` targets).

## Also: #400 analog (live-spill persistence)

The async-generator emitter was the **only** state-machine emitter that never enabled persistent spills, so a value live on the eval stack across a suspension — e.g. the `p` in `yield p + (await later(1))` — was a plain IL local wiped by the `MoveNextAsync` re-entry (yielding `1` instead of `a1`). #688's own repro hits this. Fixed by wiring up `EnablePersistentSpills` + persist/rehydrate in `EmitAwaitFromValueOnStack` and `EmitYield`, exactly like the three sibling emitters (`ClearLiveSpills` was already shared via `StatementEmitterBase`).

## Tests

Adds `AsyncGeneratorTests` for both fixes (genuinely-async **and** settled sources, `break`→`return()` cleanup, `for await` inside `try/finally`) and the spill fix. `for await`-inside-async-generator cases are compiled-only (the interpreter has a separate eager-drain gap, filed as #717).

- Full unit suite: **12841 passed, 0 failed**.
- Test262 / TypeScriptConformance unaffected: async-generator tests are skip-listed in Test262 (`async-iteration` + `async` flag), and TS-conformance is type-checker-only while this change is emitter-only.

## Follow-up filed
- #717 — interpreter: `for await…of` **inside** an async generator throws "Cannot iterate over non-iterable value" (the interp side of #697; works inside an async function).

Closes #697. Closes #688.
