### PR TITLE
Fix #684 (multi-capture): pack standalone async-arrow captures into one object[]

### DIFF
--- a/Compilation/AsyncArrowMoveNextEmitter.ArrowFunctions.cs
+++ b/Compilation/AsyncArrowMoveNextEmitter.ArrowFunctions.cs
@@ -111,13 +111,12 @@ public partial class AsyncArrowMoveNextEmitter
         // stub's arg0, clobbering the first real parameter. (#615)
         if (nestedBuilder.IsStandalone)
         {
-            // A capturing standalone nested arrow's stub takes its single captured value as a leading
-            // argument. $TSFunction's "static method with target" mechanism prepends the target before
-            // the call args, so we pass the capture AS the target, read from THIS (enclosing) arrow's
-            // frame. Mirrors the module-level standalone path in ILEmitter.EmitAsyncArrowFunction.
-            // Before #641 every capturing standalone nested arrow threw "not yet supported"; now the
-            // single read-only capture (the #641 repros) is supported, and the two harder shapes below
-            // fail loudly rather than miscompiling.
+            // A capturing standalone nested arrow's stub takes every captured value packed into a
+            // single object[]. $TSFunction's "static method with target" mechanism prepends the
+            // target before the call args, so we pass that object[] AS the target, each element read
+            // from THIS (enclosing) arrow's frame. Mirrors the module-level standalone path in
+            // ILEmitter.EmitAsyncArrowFunction. #641 enabled the single read-only capture; #684
+            // generalized it to any number of read-only captures via the shared object[] slot.
             var captureOrder = nestedBuilder.StandaloneCaptureFields.Keys
                 .OrderBy(k => k, System.StringComparer.Ordinal).ToList();
 
@@ -125,7 +124,8 @@ public partial class AsyncArrowMoveNextEmitter
             {
                 // A standalone arrow captures BY VALUE (the values are copied into its own state
                 // machine). A write to a capture therefore cannot propagate back to the enclosing
-                // binding, so reject it instead of silently dropping the write (#684).
+                // binding, so reject it instead of silently dropping the write (#684/#682). The
+                // verifiable shared-cell fix is the same class as #625/#673 and tracked there.
                 var written = CapturedWriteAnalysis.CollectImmediateWrites(af);
                 written.IntersectWith(captureOrder);
                 if (written.Count > 0)
@@ -133,27 +133,23 @@ public partial class AsyncArrowMoveNextEmitter
                     throw new CompileException(
                         "A nested async arrow inside a top-level async arrow that WRITES a captured " +
                         $"variable ({string.Join(", ", written.OrderBy(n => n, System.StringComparer.Ordinal))}) " +
-                        "is not yet supported in compiled mode (#684): the standalone arrow captures by " +
-                        "value, so the write would be lost. Hoist it to a named async function, or run " +
+                        "is not yet supported in compiled mode (#684/#682): the standalone arrow captures " +
+                        "by value, so the write would be lost. Hoist it to a named async function, or run " +
                         "in interpreted mode.");
                 }
 
-                // Multiple captures would need to ride in $TSFunction's single prepended target slot
-                // (an object[]), but the standalone stub expects each capture as a separate arg — a
-                // mismatch also broken for module-level standalone async arrows (#684).
-                if (captureOrder.Count > 1)
+                // Pack all captures into the single object[] target slot, in the same ordinal order
+                // the stub unpacks them.
+                _il.Emit(OpCodes.Ldc_I4, captureOrder.Count);
+                _il.Emit(OpCodes.Newarr, _types.Object);
+                for (int i = 0; i < captureOrder.Count; i++)
                 {
-                    throw new CompileException(
-                        "A nested async arrow inside a top-level async arrow that captures more than " +
-                        "one variable is not yet supported in compiled mode (#684); reduce it to a " +
-                        "single capture, hoist it to a named async function, or run in interpreted mode.");
+                    _il.Emit(OpCodes.Dup);
+                    _il.Emit(OpCodes.Ldc_I4, i);
+                    LoadVariableForCapture(captureOrder[i]);
+                    EnsureBoxed();
+                    _il.Emit(OpCodes.Stelem_Ref);
                 }
-            }
-
-            if (captureOrder.Count == 1)
-            {
-                LoadVariableForCapture(captureOrder[0]);
-                EnsureBoxed();
             }
             else
             {

--- a/Compilation/AsyncArrowMoveNextEmitter.Variables.cs
+++ b/Compilation/AsyncArrowMoveNextEmitter.Variables.cs
@@ -297,6 +297,18 @@ public partial class AsyncArrowMoveNextEmitter
             return;
         }
 
+        // Transitive standalone capture: a variable THIS (enclosing) standalone arrow itself
+        // captured (stored in its own state-machine field) and a nested standalone arrow now
+        // re-captures. Without this the value would fall through to null one level too deep.
+        // Checked after the arrow's own params/locals so a same-named local still shadows it.
+        if (_builder.StandaloneCaptureFields.TryGetValue(name, out var enclosingCaptureField))
+        {
+            _il.Emit(OpCodes.Ldarg_0);
+            _il.Emit(OpCodes.Ldfld, enclosingCaptureField);
+            SetStackUnknown();
+            return;
+        }
+
         // Handle 'this' capture - in async arrows, 'this' is captured from outer scope
         if (name == "this" && _builder.IsCaptured("this") && _builder.CapturedFieldMap.TryGetValue("this", out var thisField))
         {

--- a/Compilation/AsyncArrowStateMachineBuilder.cs
+++ b/Compilation/AsyncArrowStateMachineBuilder.cs
@@ -327,16 +327,19 @@ public class AsyncArrowStateMachineBuilder
             paramTypes.Add(_types.Object); // Outer SM
         }
 
-        // For standalone arrows with captures, add capture parameters first
-        // Order: [captures...], [arrow params...]
-        // Ordinal ordering must match the call sites (ILEmitter / AsyncArrowMoveNextEmitter).
+        // For standalone arrows with captures, a SINGLE leading object arg carries ALL captured
+        // values packed into an object[] (passed by the call site as the $TSFunction "target").
+        // $TSFunction prepends its target as one leading argument, so one slot must hold every
+        // capture regardless of count — the stub unpacks the array into its fields below. Using
+        // one slot for any capture count is what makes multi-capture work (#684); a per-capture
+        // arg only ever lined up when there was exactly one (#641).
+        // Ordinal ordering must match the call sites (ILEmitter / AsyncArrowMoveNextEmitter) and
+        // the unpack loop below.
         var captureOrder = StandaloneCaptureFields.Keys.OrderBy(k => k, System.StringComparer.Ordinal).ToList();
-        if (IsStandalone)
+        bool hasStandaloneCaptures = IsStandalone && captureOrder.Count > 0;
+        if (hasStandaloneCaptures)
         {
-            foreach (var _ in captureOrder)
-            {
-                paramTypes.Add(_types.Object); // Captured values
-            }
+            paramTypes.Add(_types.Object); // object[] of captured values (the single target slot)
         }
 
         // Add arrow parameters
@@ -369,18 +372,22 @@ public class AsyncArrowStateMachineBuilder
             paramOffset = 1; // Skip outer SM arg when copying params
         }
 
-        // For standalone arrows with captures, copy captured values to state machine fields
-        if (IsStandalone && captureOrder.Count > 0)
+        // For standalone arrows with captures, unpack the leading object[] (arg0) into the
+        // state-machine capture fields: sm.<>captured_x = ((object[])arg0)[i]. The ordinal
+        // capture order matches DefineStateMachineStandalone and the call sites.
+        if (hasStandaloneCaptures)
         {
             for (int i = 0; i < captureOrder.Count; i++)
             {
-                var captureName = captureOrder[i];
-                var captureField = StandaloneCaptureFields[captureName];
+                var captureField = StandaloneCaptureFields[captureOrder[i]];
                 il.Emit(OpCodes.Ldloca, smLocal);
-                il.Emit(OpCodes.Ldarg, i);
+                il.Emit(OpCodes.Ldarg_0);
+                il.Emit(OpCodes.Castclass, _types.ObjectArray);
+                il.Emit(OpCodes.Ldc_I4, i);
+                il.Emit(OpCodes.Ldelem_Ref);
                 il.Emit(OpCodes.Stfld, captureField);
             }
-            paramOffset = captureOrder.Count; // Skip capture args when copying params
+            paramOffset = 1; // Skip the single capture-array arg when copying params
         }
 
         // Copy parameters to state machine fields (in order!)

--- a/Compilation/ILEmitter.Calls.Closures.cs
+++ b/Compilation/ILEmitter.Calls.Closures.cs
@@ -93,51 +93,32 @@ public partial class ILEmitter
         var stubMethod = arrowBuilder.StubMethod;
 
         // For standalone async arrows with captures, TSFunction's "static method with target"
-        // mechanism prepends the target to the args, so captures get passed as leading args.
+        // mechanism prepends the single target to the args. Pack EVERY captured value into one
+        // object[] and pass it as that target; the stub unpacks each into its own field. One
+        // array slot for any capture count is what makes multi-capture work — the old per-capture
+        // arg layout only lined up at exactly one capture (#641/#684).
         if (arrowBuilder.IsStandalone && arrowBuilder.StandaloneCaptureFields.Count > 0)
         {
             // Ordinal ordering must match the stub's capture-unpacking order (AsyncArrowStateMachineBuilder).
             var captureOrder = arrowBuilder.StandaloneCaptureFields.Keys.OrderBy(k => k, System.StringComparer.Ordinal).ToList();
 
-            if (captureOrder.Count == 1)
+            IL.Emit(OpCodes.Ldc_I4, captureOrder.Count);
+            IL.Emit(OpCodes.Newarr, _ctx.Types.Object);
+            for (int i = 0; i < captureOrder.Count; i++)
             {
-                // Single capture: use TSFunction target prepend mechanism.
-                // TSFunction.Invoke detects static method + non-null target and prepends target as arg0.
-                var captureName = captureOrder[0];
+                IL.Emit(OpCodes.Dup);
+                IL.Emit(OpCodes.Ldc_I4, i);
+                var captureName = captureOrder[i];
                 if (captureName == "this")
                 {
-                    // Load 'this' (arg0 in instance methods)
                     IL.Emit(OpCodes.Ldarg_0);
                 }
                 else
                 {
-                    // Load the captured variable
                     EmitVariable(new Expr.Variable(new Parsing.Token(Parsing.TokenType.IDENTIFIER, captureName, null, 0)));
                     EnsureBoxed();
                 }
-            }
-            else
-            {
-                // Multiple captures: pack into an object[] and use as target.
-                // The stub's paramOffset handles unpacking from arg0.
-                IL.Emit(OpCodes.Ldc_I4, captureOrder.Count);
-                IL.Emit(OpCodes.Newarr, _ctx.Types.Object);
-                for (int i = 0; i < captureOrder.Count; i++)
-                {
-                    IL.Emit(OpCodes.Dup);
-                    IL.Emit(OpCodes.Ldc_I4, i);
-                    var captureName = captureOrder[i];
-                    if (captureName == "this")
-                    {
-                        IL.Emit(OpCodes.Ldarg_0);
-                    }
-                    else
-                    {
-                        EmitVariable(new Expr.Variable(new Parsing.Token(Parsing.TokenType.IDENTIFIER, captureName, null, 0)));
-                        EnsureBoxed();
-                    }
-                    IL.Emit(OpCodes.Stelem_Ref);
-                }
+                IL.Emit(OpCodes.Stelem_Ref);
             }
         }
         else

--- a/SharpTS.Tests/SharedTests/AsyncArrowNestedCaptureTests.cs
+++ b/SharpTS.Tests/SharedTests/AsyncArrowNestedCaptureTests.cs
@@ -7,10 +7,11 @@ namespace SharpTS.Tests.SharedTests;
 /// <summary>
 /// An async arrow nested directly inside a TOP-LEVEL (standalone) async arrow that captures a
 /// variable from the enclosing arrow's scope. Compiled mode registers the inner arrow as its own
-/// standalone state machine; #641 wires the single read-only capture through the stub's leading
-/// capture argument (read from the enclosing frame, copied into the inner state machine). Harder
-/// shapes — writing a capture, or capturing more than one variable — are rejected with a clear
-/// compile error rather than miscompiled (#684).
+/// standalone state machine; #641 wired the single read-only capture and #684 the multi-capture
+/// case: every captured value rides in a single <c>object[]</c> passed as the $TSFunction target
+/// slot, which the stub unpacks into the inner state machine's capture fields. Writing a capture
+/// is still rejected with a clear compile error rather than miscompiled (#684/#682): a standalone
+/// arrow captures by value, so the write could not propagate back.
 /// </summary>
 public class AsyncArrowNestedCaptureTests
 {
@@ -69,7 +70,7 @@ public class AsyncArrowNestedCaptureTests
     public void NestedAsyncArrow_WritesCapture_RejectedInCompiledMode()
     {
         // Standalone arrows capture by value, so a write cannot propagate back. Compiled mode must
-        // reject this rather than silently dropping the write (#684); the interpreter is correct.
+        // reject this rather than silently dropping the write (#684/#682); the interpreter is correct.
         var source = """
             const f = async () => {
               let n = 1;
@@ -84,8 +85,109 @@ public class AsyncArrowNestedCaptureTests
         Assert.Throws<CompileException>(() => TestHarness.RunCompiled(source));
     }
 
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void NestedAsyncArrow_MultipleCaptures(ExecutionMode mode)
+    {
+        // Three captures from the enclosing top-level async arrow ride together in the
+        // single object[] target slot (#684); the stub unpacks each into its own field.
+        var source = """
+            const f = async () => {
+              const a = 10, b = 20, c = 30;
+              const inner = async () => a + b + c;
+              console.log(await inner());
+            };
+            f();
+            """;
+
+        Assert.Equal("60\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void NestedAsyncArrow_MultipleCaptures_MixedWithOwnParameter(ExecutionMode mode)
+    {
+        // Captures are unpacked from the object[] target before the arrow's own parameter,
+        // so capture/param ordering in the stub must stay distinct.
+        var source = """
+            const f = async () => {
+              const a = 1, b = 2;
+              const inner = async (k: number) => a + b + k;
+              console.log(await inner(100));
+            };
+            f();
+            """;
+
+        Assert.Equal("103\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void NestedAsyncArrow_MultipleCapturesOfEnclosingParameters(ExecutionMode mode)
+    {
+        // Captures resolve through the enclosing arrow's ParameterFields (not LocalFields),
+        // a distinct LoadVariableForCapture branch; both ride the object[] target slot.
+        var source = """
+            const f = async (p: number, q: number) => {
+              const inner = async () => p + q;
+              console.log(await inner());
+            };
+            f(5, 37);
+            """;
+
+        Assert.Equal("42\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void StandaloneAsyncArrow_MultipleCapturesFromEnclosingFunction(ExecutionMode mode)
+    {
+        // A standalone async arrow (no enclosing async state machine — here the enclosing
+        // scope is a plain function) capturing multiple of that function's locals was
+        // independently broken (#684 note): ILEmitter packed an object[] target but the
+        // stub read each capture from a separate arg. Now both agree on the single
+        // object[] slot. (Top-level `const` captures resolve to static/entry-point fields,
+        // not standalone captures, so a plain function is what exercises this path.)
+        var source = """
+            function outer() {
+              const a = 10, b = 20, c = 30;
+              const inner = async () => a + b + c;
+              inner().then(x => console.log(x));
+            }
+            outer();
+            """;
+
+        Assert.Equal("60\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void NestedAsyncArrow_TransitiveCaptureThroughStandaloneArrow(ExecutionMode mode)
+    {
+        // `a` is captured by `g` (a standalone capture on g's own state machine, because g
+        // reads it directly) and then again by `h` nested inside g — so when building h's
+        // capture array we must re-read `a` from g's capture field, not drop it to null.
+        // (The "relay-only" shape where the intermediate arrow does NOT read the variable and
+        // captures it solely to forward to a deeper arrow is a separate capture-propagation
+        // gap, tracked in #716.)
+        var source = """
+            const f = async () => {
+              const a = 7;
+              const g = async () => {
+                const seen = a;
+                const h = async () => a + 1;
+                return seen + await h();
+              };
+              console.log(await g());
+            };
+            f();
+            """;
+
+        Assert.Equal("15\n", TestHarness.Run(source, mode));
+    }
+
     [Fact]
-    public void NestedAsyncArrow_MultipleCaptures_RejectedInCompiledMode()
+    public void NestedAsyncArrow_MultipleCaptures_PassesILVerification()
     {
         var source = """
             const f = async () => {
@@ -96,7 +198,30 @@ public class AsyncArrowNestedCaptureTests
             f();
             """;
 
-        Assert.Equal("60\n", TestHarness.RunInterpreted(source));
-        Assert.Throws<CompileException>(() => TestHarness.RunCompiled(source));
+        var (errors, output) = TestHarness.CompileVerifyAndRun(source);
+
+        Assert.Empty(errors);
+        Assert.Equal("60\n", output);
+    }
+
+    [Fact]
+    public void StandaloneAsyncArrow_SingleCaptureFromFunction_PassesILVerification()
+    {
+        // Exercises the module-level (ILEmitter) standalone-capture path with exactly one
+        // capture, which now also rides the single object[] target slot (previously a raw
+        // value). Guards against a regression in the unified single/multi capture passing.
+        var source = """
+            function outer() {
+              const base = 41;
+              const inner = async () => base + 1;
+              inner().then(x => console.log(x));
+            }
+            outer();
+            """;
+
+        var (errors, output) = TestHarness.CompileVerifyAndRun(source);
+
+        Assert.Empty(errors);
+        Assert.Equal("42\n", output);
     }
 }


### PR DESCRIPTION
## What

Implements the **multi-capture** half of #684 for standalone async arrows, and verifies/closes #641.

A standalone async arrow's stub previously took one `object` argument **per** captured variable. That layout only lined up at exactly one capture (#641); with two or more it miscompiled — the module-level path threw `InvalidCastException`, and the nested-in-top-level-async-arrow path was guarded off with a compile error.

This unifies everything onto a single `object[]` carried in `$TSFunction`'s prepended "target" slot:

- **`AsyncArrowStateMachineBuilder.DefineStubMethod`** — the stub now takes one leading `object` arg, `Castclass`es it to `object[]`, and unpacks each capture (`Ldelem_Ref`) into its `<>captured_x` field.
- **`ILEmitter.EmitAsyncArrowFunction`** (module-level / inside a plain function) and **`AsyncArrowMoveNextEmitter.EmitNestedAsyncArrow`** (nested in a top-level async arrow) — both call sites always pack the `object[]`, in matching `StringComparer.Ordinal` order. The old single-vs-multi branch is gone.
- **`AsyncArrowMoveNextEmitter.LoadVariableForCapture`** — now also reads the enclosing arrow's `StandaloneCaptureFields`, so an intermediate standalone arrow that itself reads a captured var forwards it to a deeper nested arrow.

## Why

#684 documented that multi-capture was broken both at module level (a packed `object[]` target the stub never unpacked) and in the nested case (guarded off). One `object[]` slot works for any capture count, so single- and multi-capture now share one code path instead of diverging.

## Scope / what's deferred

- **Write-back** (a standalone arrow that *writes* a capture) stays guarded with a clear compile error. It needs the captured var promoted to a shared reference cell — the **same root cause as #682** (a top-level async arrow / async method has no function display class to route the write through; the current `unbox`+`stfld` is unverifiable). Deferred to #682 rather than duplicating that machinery here. #684 stays open for this half.
- Filed **#716** for a separate, pre-existing capture-*propagation* gap surfaced while testing: an intermediate arrow that captures a var *only to forward it* to a deeper arrow (without reading it) drops it to `null`, because `ClosureAnalyzer.ReferenceVariable` records captures on the innermost function only (unlike `VisitThis`).

## Tests

New coverage in `SharpTS.Tests/SharedTests/AsyncArrowNestedCaptureTests.cs` (both modes unless noted):

- `NestedAsyncArrow_MultipleCaptures`
- `NestedAsyncArrow_MultipleCaptures_MixedWithOwnParameter`
- `NestedAsyncArrow_MultipleCapturesOfEnclosingParameters`
- `NestedAsyncArrow_TransitiveCaptureThroughStandaloneArrow`
- `StandaloneAsyncArrow_MultipleCapturesFromEnclosingFunction`
- `StandaloneAsyncArrow_SingleCaptureFromFunction_PassesILVerification`
- `NestedAsyncArrow_MultipleCaptures_PassesILVerification`
- The write-back case remains `Assert.Throws<CompileException>`.

## Verification

- **Full `SharpTS.Tests` suite: 12842 passed, 0 failed.** All IL-verification tests pass.
- The Test262 host crash (`0x80131506`) is **pre-existing and flaky** — confirmed it reproduces identically on clean `origin/main` (aborts at different points across runs), so it is not a regression from this change.

## Reviewer notes

- Ordinal capture ordering must stay in sync across three places: the stub unpack loop and both call sites. All three use `StringComparer.Ordinal`.
- The single-capture path now allocates a 1-element `object[]` (previously passed the raw boxed value). This is on arrow-value creation, not a hot path — negligible.

Closes #641.