### PR TITLE
Fix #696, complete #668: optional param (`x?: T`) in private/abstract methods

### DIFF
--- a/Compilation/AsyncMoveNextEmitter.Operators.cs
+++ b/Compilation/AsyncMoveNextEmitter.Operators.cs
@@ -293,6 +293,7 @@ public partial class AsyncMoveNextEmitter
             var argLocals = cp.Arguments.Select(SpillBoxed).ToList();
             foreach (var argLocal in argLocals)
                 _il.Emit(OpCodes.Ldloc, argLocal);
+            EmitPrivateCallUndefinedPadding(cp.Arguments.Count, staticMethod!.GetParameters().Length);
             _il.Emit(OpCodes.Call, staticMethod!);
             SetStackUnknown();
             return;
@@ -337,6 +338,7 @@ public partial class AsyncMoveNextEmitter
                 foreach (var argLocal in argLocals)
                     _il.Emit(OpCodes.Ldloc, argLocal);
 
+                EmitPrivateCallUndefinedPadding(cp.Arguments.Count, instanceMethod!.GetParameters().Length);
                 _il.Emit(OpCodes.Callvirt, instanceMethod!);
                 SetStackUnknown();
                 return;
@@ -355,6 +357,7 @@ public partial class AsyncMoveNextEmitter
                 foreach (var argLocal in argLocals)
                     _il.Emit(OpCodes.Ldloc, argLocal);
 
+                EmitPrivateCallUndefinedPadding(cp.Arguments.Count, instanceMethod!.GetParameters().Length);
                 _il.Emit(OpCodes.Callvirt, instanceMethod!);
                 SetStackUnknown();
                 return;

--- a/Compilation/ExpressionEmitterBase.cs
+++ b/Compilation/ExpressionEmitterBase.cs
@@ -873,6 +873,7 @@ public abstract partial class ExpressionEmitterBase : IEmitterContext
                 EmitExpression(arg);
                 EnsureBoxed();
             }
+            EmitPrivateCallUndefinedPadding(cp.Arguments.Count, staticMethod!.GetParameters().Length);
             IL.Emit(OpCodes.Call, staticMethod!);
             SetStackUnknown();
             return;
@@ -916,6 +917,7 @@ public abstract partial class ExpressionEmitterBase : IEmitterContext
                     EnsureBoxed();
                 }
 
+                EmitPrivateCallUndefinedPadding(cp.Arguments.Count, instanceMethod!.GetParameters().Length);
                 IL.Emit(OpCodes.Callvirt, instanceMethod!);
                 SetStackUnknown();
                 return;
@@ -934,6 +936,7 @@ public abstract partial class ExpressionEmitterBase : IEmitterContext
                     EnsureBoxed();
                 }
 
+                EmitPrivateCallUndefinedPadding(cp.Arguments.Count, instanceMethod!.GetParameters().Length);
                 IL.Emit(OpCodes.Callvirt, instanceMethod!);
                 SetStackUnknown();
                 return;
@@ -943,6 +946,22 @@ public abstract partial class ExpressionEmitterBase : IEmitterContext
         IL.Emit(OpCodes.Ldstr, $"Private method '#{methodName}' not found in class '{className}'");
         IL.Emit(OpCodes.Newobj, Types.ExceptionCtorString);
         IL.Emit(OpCodes.Throw);
+    }
+
+    /// <summary>
+    /// Pads the evaluation stack with <c>undefined</c> sentinels for any trailing parameters a
+    /// private method declares but the call omits. Private methods are emitted with a fixed,
+    /// all-<c>object</c> signature (see <c>ILCompiler.Classes.cs</c>), so a call supplying fewer
+    /// arguments than the method declares would otherwise leave <c>call</c>/<c>callvirt</c> short
+    /// of operands (StackUnderflow → <c>InvalidProgramException</c>). The padded slots read as
+    /// <c>undefined</c> in the body and fire any default-parameter prologue
+    /// (<see cref="ILEmitter.EmitDefaultParameters"/>). Mirrors the undefined-padding that
+    /// <c>$TSFunction.AdjustArgs</c> applies on the value-call path. (#696)
+    /// </summary>
+    protected void EmitPrivateCallUndefinedPadding(int argCount, int paramCount)
+    {
+        for (int i = argCount; i < paramCount; i++)
+            EmitUndefinedConstant();
     }
 
     /// <summary>

--- a/Compilation/ILCompiler.Classes.Methods.cs
+++ b/Compilation/ILCompiler.Classes.Methods.cs
@@ -816,6 +816,17 @@ public partial class ILCompiler
 
         var emitter = new ILEmitter(ctx);
 
+        // Apply parameter defaults at the top of the body. A defaulted (`x = ...`) or optional
+        // (`x?: T`) private-method parameter whose argument was omitted arrives as the `undefined`
+        // sentinel (call sites pad omitted trailing args — see EmitPrivateCallUndefinedPadding);
+        // this fires the default the same way function/public-method bodies do. Private methods are
+        // emitted with all-`object` parameter slots, so none are skipped for being value types. (#696)
+        emitter.EmitDefaultParameters(
+            method.Parameters,
+            isInstanceMethod: !isStatic,
+            hasOwnThis: false,
+            paramTypes: methodParams.Select(p => p.ParameterType).ToArray());
+
         // Emit method body
         if (method.Body != null)
         {

--- a/Compilation/ILEmitter.Properties.Private.cs
+++ b/Compilation/ILEmitter.Properties.Private.cs
@@ -236,6 +236,9 @@ public partial class ILEmitter
                     EmitBoxIfNeeded(arg);
                 }
 
+                // Pad omitted trailing arguments with `undefined` (fixed-arity method).
+                EmitPrivateCallUndefinedPadding(cp.Arguments.Count, staticMethod!.GetParameters().Length);
+
                 // Call static method
                 IL.Emit(OpCodes.Call, staticMethod!);
                 SetStackUnknown();
@@ -295,6 +298,9 @@ public partial class ILEmitter
                     EmitBoxIfNeeded(arg);
                 }
 
+                // Pad omitted trailing arguments with `undefined` (fixed-arity method).
+                EmitPrivateCallUndefinedPadding(cp.Arguments.Count, instanceMethod!.GetParameters().Length);
+
                 // Call instance method
                 IL.Emit(OpCodes.Callvirt, instanceMethod!);
                 SetStackUnknown();
@@ -316,6 +322,8 @@ public partial class ILEmitter
                     EmitBoxIfNeeded(arg);
                 }
 
+                // Pad omitted trailing arguments with `undefined` (fixed-arity method).
+                EmitPrivateCallUndefinedPadding(cp.Arguments.Count, instanceMethod!.GetParameters().Length);
                 IL.Emit(OpCodes.Callvirt, instanceMethod!);
                 SetStackUnknown();
                 return;
@@ -331,6 +339,7 @@ public partial class ILEmitter
                 EmitBoxIfNeeded(arg);
             }
 
+            EmitPrivateCallUndefinedPadding(cp.Arguments.Count, fallbackStaticMethod!.GetParameters().Length);
             IL.Emit(OpCodes.Call, fallbackStaticMethod!);
             SetStackUnknown();
             return;

--- a/Parsing/Parser.Functions.cs
+++ b/Parsing/Parser.Functions.cs
@@ -267,6 +267,11 @@ public partial class Parser
                 bool isRest = Match(TokenType.DOT_DOT_DOT);
 
                 Token paramName = ConsumeIdentifierName("Expect parameter name.");
+
+                // Check for optional parameter marker (?) — mirrors the main
+                // function-parameter parser so private/abstract methods accept `x?: T`.
+                bool isOptional = Match(TokenType.QUESTION);
+
                 string? paramType = null;
                 if (Match(TokenType.COLON))
                 {
@@ -279,7 +284,7 @@ public partial class Parser
                 {
                     defaultValue = Expression();
                 }
-                parameters.Add(new Stmt.Parameter(paramName, paramType, defaultValue, isRest));
+                parameters.Add(new Stmt.Parameter(paramName, paramType, defaultValue, isRest, IsOptional: isOptional));
 
                 // Rest parameter must be last
                 if (isRest && Check(TokenType.COMMA))

--- a/SharpTS.Tests/ParserTests/PrivateFieldParserTests.cs
+++ b/SharpTS.Tests/ParserTests/PrivateFieldParserTests.cs
@@ -133,6 +133,39 @@ public class PrivateFieldParserTests
         Assert.True(classStmt.Methods[0].IsStatic);
     }
 
+    [Fact]
+    public void PrivateMethod_OptionalParameter()
+    {
+        // #696: an optional parameter (`b?: T`) on a private method must parse, like it
+        // already does on public methods, free functions, and constructors. Before the fix
+        // the private-method parameter path (ParseMethodParameters) did not consume the `?`.
+        var source = """
+            class C {
+                #p(a: string, b?: number): string { return a; }
+            }
+            """;
+        var classStmt = ParseClass(source);
+        Assert.Single(classStmt.Methods);
+        Assert.True(classStmt.Methods[0].IsPrivate);
+        Assert.Equal(2, classStmt.Methods[0].Parameters.Count);
+        Assert.False(classStmt.Methods[0].Parameters[0].IsOptional);
+        Assert.True(classStmt.Methods[0].Parameters[1].IsOptional);
+    }
+
+    [Fact]
+    public void PrivateMethod_SoleOptionalParameter()
+    {
+        // The minimal #696 repro: a private method whose only parameter is optional.
+        var source = """
+            class C {
+                #p(b?: number): number { return 1; }
+            }
+            """;
+        var classStmt = ParseClass(source);
+        Assert.Single(classStmt.Methods);
+        Assert.True(classStmt.Methods[0].Parameters[0].IsOptional);
+    }
+
     #endregion
 
     #region Private Element Access Expressions

--- a/SharpTS.Tests/SharedTests/PrivateFieldTests.cs
+++ b/SharpTS.Tests/SharedTests/PrivateFieldTests.cs
@@ -256,6 +256,63 @@ public class PrivateFieldTests
         Assert.Equal("$42.00\n", output);
     }
 
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void PrivateMethod_MultipleOptionalParameters_PartialApplication(ExecutionMode mode)
+    {
+        // #696: several optional parameters, only some supplied. Omitted trailing arguments read
+        // as `undefined`. Compiled mode must pad the call so the fixed-arity method gets every slot.
+        var source = """
+            class C {
+                #combine(a?: number, b?: number, c?: number): number {
+                    return (a ?? 1) + (b ?? 2) + (c ?? 3);
+                }
+                go(): number { return this.#combine(10); }
+            }
+            console.log(new C().go());
+            """;
+        Assert.Equal("15\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void PrivateMethod_DefaultParameter_FiresWhenOmitted(ExecutionMode mode)
+    {
+        // #696: a defaulted private-method parameter fires its default when the argument is omitted,
+        // in compiled mode too. Before the fix the call StackUnderflowed (no padding) and the body
+        // had no default prologue, so this never produced the right value under compilation.
+        var source = """
+            class C {
+                #greet(name: string = "World"): string { return "Hi " + name; }
+                go(): string { return this.#greet(); }
+            }
+            console.log(new C().go());
+            """;
+        Assert.Equal("Hi World\n", TestHarness.Run(source, mode));
+    }
+
+    [Fact]
+    public void PrivateMethod_OptionalAndDefaultParameters_ProduceValidIL()
+    {
+        // #696 regression guard: calling a private method with fewer arguments than it declares
+        // must emit a balanced stack. Covers instance + static, optional + default, omitted +
+        // explicit-undefined — the exact shapes that previously emitted StackUnderflow IL.
+        var source = """
+            class C {
+                #opt(b?: number): number { return b ?? 1; }
+                #def(b: number = 7): number { return b; }
+                static #sopt(b?: string): string { return b ?? "S"; }
+                static #sdef(b: string = "D"): string { return b; }
+                run(): number { return this.#opt() + this.#def(undefined); }
+                static srun(): string { return C.#sopt() + C.#sdef(); }
+            }
+            console.log(new C().run());
+            console.log(C.srun());
+            """;
+        var errors = TestHarness.CompileAndVerifyOnly(source);
+        Assert.Empty(errors);
+    }
+
     #endregion
 
     #region Static Private Methods
@@ -280,6 +337,21 @@ public class PrivateFieldTests
 
         var output = TestHarness.Run(source, mode);
         Assert.Equal("20\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void StaticPrivateMethod_OptionalParameter_Omitted(ExecutionMode mode)
+    {
+        // #696: optional parameter on a *static* private method, invoked with no argument.
+        var source = """
+            class Utils {
+                static #label(text?: string): string { return text ?? "default"; }
+                static go(): string { return Utils.#label(); }
+            }
+            console.log(Utils.go());
+            """;
+        Assert.Equal("default\n", TestHarness.Run(source, mode));
     }
 
     [Theory]

--- a/SharpTS.Tests/TypeCheckerTests/OptionalParamUndefinedArgTests.cs
+++ b/SharpTS.Tests/TypeCheckerTests/OptionalParamUndefinedArgTests.cs
@@ -72,11 +72,14 @@ public class OptionalParamUndefinedArgTests
         Assert.Equal("undefined\n", TestHarness.RunInterpreted(source));
     }
 
-    [Fact]
-    public void PrivateMethodDefaultParameter_AcceptsUndefined()
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void PrivateMethodDefaultParameter_AcceptsUndefined(ExecutionMode mode)
     {
-        // Interpreter-only — see DefaultSecondParameter_AcceptsExplicitUndefined; value-type
-        // default in a method yields NaN in compiled mode (tracked in #705).
+        // #668 private-method argument-compatibility path. Runs in BOTH modes: unlike free
+        // functions / constructors (#705), compiled private methods emit every parameter as an
+        // `object` slot, so the value-type default is not stranded in a `double` slot — the
+        // call-site `undefined` padding + body default prologue added in #696 fire the default.
         var source = """
             class C {
               #priv(a: string, b: number = 7): number { return a.length + b; }
@@ -84,7 +87,40 @@ public class OptionalParamUndefinedArgTests
             }
             console.log(new C().go());
             """;
-        Assert.Equal("8\n", TestHarness.RunInterpreted(source));
+        Assert.Equal("8\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void PrivateMethodOptionalParameter_AcceptsExplicitUndefined(ExecutionMode mode)
+    {
+        // #668 path that #696 unblocked: an *optional* (`b?: T`) private-method parameter could
+        // not previously be parsed, so the original #668 work had to probe this path with a
+        // default param instead. An optional reference param accepts an explicit `undefined`.
+        var source = """
+            class C {
+              #priv(a: string, b?: string): string { return a + (b ?? "_"); }
+              go(): string { return this.#priv("x", undefined); }
+            }
+            console.log(new C().go());
+            """;
+        Assert.Equal("x_\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void PrivateMethodOptionalParameter_OmittedArgument(ExecutionMode mode)
+    {
+        // The minimal #696 scenario end-to-end: a private method with a sole optional parameter
+        // invoked with no argument. The omitted slot reads as `undefined` in both modes.
+        var source = """
+            class C {
+              #priv(b?: number): number { return b ?? 1; }
+              go(): number { return this.#priv(); }
+            }
+            console.log(new C().go());
+            """;
+        Assert.Equal("1\n", TestHarness.Run(source, mode));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Fixes **#696** and completes **#668**.

### #696 — parser
`ParseMethodParameters()` (the parameter parser used by **private** (`#m`) and **abstract** methods — distinct from the `FunctionDeclaration` path that public methods/functions use) never consumed the `?` optional marker. So *any* private or abstract method with an optional parameter failed to parse:

```ts
class C {
  #p(b?: number): number { return b ?? 1; }   // was: Parse Error: Expect ')' after parameters.
}
```

One-line fix mirroring the main function-parameter parser: read the `QUESTION` token and set `Parameter.IsOptional`.

### Compiled-mode gap exposed (and fixed) by the parser fix
Making it parse surfaced a **pre-existing** compiled-mode bug. Compiled private methods are emitted with a fixed, all-`object` signature, but:
- the three `EmitCallPrivate` copies emitted exactly `cp.Arguments.Count` arguments with no padding, and
- `EmitPrivateMethodBody` applied no default-value prologue.

So calling a private method with fewer arguments than it declares — an omitted optional, **or** the `#p(b = 7)` default-param workaround that already parsed before #696 — emitted a short stack (`StackUnderflow` → `InvalidProgramException`).

Fix:
- New shared helper `EmitPrivateCallUndefinedPadding(argCount, paramCount)` in `ExpressionEmitterBase` pads omitted trailing arguments with the `$Undefined` sentinel. Applied at all three `EmitCallPrivate` copies (sync `ILEmitter` override, `ExpressionEmitterBase` base, `AsyncMoveNextEmitter` async override) across every sub-branch (static / instance brand-check / instance no-brand / fallback-static).
- `EmitPrivateMethodBody` now calls `EmitDefaultParameters` before the body so a defaulted private-method parameter fires its default. Because private methods use all-`object` parameter slots (never value-type `double` slots), this makes value-type defaults work in **both** modes — unlike free functions / constructors, which stay interpreter-only (#705). The omitted slot reads as the `$Undefined` sentinel, so `typeof` / `=== undefined` / `=== null` answer correctly.

### #668 — completion
The optional-param private-method argument-compatibility path that #668 previously had to probe with a *default* param (optional params wouldn't parse) is now exercised directly. `PrivateMethodDefaultParameter_AcceptsUndefined` is upgraded to run in **both** modes, plus new optional-param coverage (explicit `undefined` + omitted).

## Tests
- Parser tests for `#m(x?: T)` (instance, multi-param, sole-optional).
- Both-modes execution: optional omitted, default-fires-on-omit, multiple optionals partial application, static private method, explicit `undefined`.
- An IL-verification regression guard pinning balanced stacks for the call-site padding (instance + static, optional + default).
- **Full suite green: 12,933 passed, 0 failed.** TSConformance subset (`typeRelationships/assignmentCompatibility`, `types/conditional`) confidently unaffected by a private/abstract-method parser change.

## Out of scope — filed #720
Async (`async #m`) and generator (`*#m`) private methods still emit invalid IL in compiled mode (`EmitPrivateMethodBody` emits their bodies linearly with no state machine, so `__private_p` returns bare `object` instead of `Task<object>`; `*#m` → "Yield not supported"). Pre-existing and independent of #696 (reproduces with required params); the interpreter handles both correctly.
