### PR TITLE
Fix #698: default parameter values can reference an earlier parameter

### DIFF
--- a/Compilation/ILCompiler.Functions.cs
+++ b/Compilation/ILCompiler.Functions.cs
@@ -1405,9 +1405,27 @@ public partial class ILCompiler
             };
             var emitter = new ILEmitter(ctx);
 
+            // Make the provided parameters resolvable so a default value that references an
+            // earlier parameter (e.g. `function f(a, b = a) {}`) emits `ldarg` instead of
+            // throwing "Undefined variable" at runtime. Static functions have no implicit
+            // `this`, so parameter i lives at arg index i. (#698)
+            var fullParams = fullMethod.GetParameters();
+            for (int i = 0; i < arity; i++)
+            {
+                Type paramType = i < fullParams.Length ? fullParams[i].ParameterType : _types.Object;
+                ctx.DefineParameter(funcStmt.Parameters[i].Name.Lexeme, i, paramType);
+            }
+
+            // Cascade: forward to the overload one arity higher (it fills the next default), or to
+            // the full implementation when this overload is one below full arity. Higher-arity
+            // overloads come earlier in the list, so the next arity up is overloads[overloadIndex-1].
+            // This lets a later default reference an earlier *defaulted* parameter — that parameter
+            // is a real argument of the target method rather than a transient stack value. (#698)
+            MethodInfo targetMethod = overloadIndex == 1 ? fullMethod : overloads[overloadIndex - 2];
+
             OverloadGenerator.EmitOverloadBody(
                 il,
-                fullMethod,
+                targetMethod,
                 funcStmt.Parameters,
                 arity,
                 isStatic: true,

--- a/Compilation/OverloadGenerator.cs
+++ b/Compilation/OverloadGenerator.cs
@@ -58,24 +58,33 @@ public static class OverloadGenerator
     }
 
     /// <summary>
-    /// Emits the forwarding body for an overload method.
-    /// Loads provided arguments, emits default values for missing arguments, then calls full method.
+    /// Emits the forwarding body for an overload method. Loads the provided arguments, supplies the
+    /// single next default value, then forwards to <paramref name="targetMethod"/> — the overload one
+    /// arity higher (or the full implementation when this overload is one arity below it).
     /// </summary>
+    /// <remarks>
+    /// Forwarding is <b>cascading</b>, not direct-to-full: an overload of arity <c>k</c> fills exactly
+    /// the default at index <c>k</c> and calls the arity-<c>k+1</c> method, which fills index <c>k+1</c>,
+    /// and so on. This keeps every parameter a real argument of the method that evaluates the next
+    /// default, so a default expression may reference any earlier parameter — including an earlier
+    /// <i>defaulted</i> one, e.g. <c>function f(a, b = 1, c = a + b) {}</c>. (#698)
+    /// </remarks>
     /// <param name="il">IL generator for the overload method</param>
-    /// <param name="fullMethod">The full method to call</param>
+    /// <param name="targetMethod">The next-higher-arity method to forward to (overload or full)</param>
     /// <param name="parameters">All parameters from AST (for default value expressions)</param>
     /// <param name="overloadArity">Number of parameters in this overload</param>
     /// <param name="isStatic">Whether this is a static method</param>
     /// <param name="emitter">ILEmitter for emitting default value expressions</param>
     public static void EmitOverloadBody(
         ILGenerator il,
-        MethodInfo fullMethod,
+        MethodInfo targetMethod,
         List<Stmt.Parameter> parameters,
         int overloadArity,
         bool isStatic,
         ILEmitter emitter)
     {
         int argOffset = isStatic ? 0 : 1;
+        var targetParams = targetMethod.GetParameters();
 
         // Load 'this' for instance methods
         if (!isStatic)
@@ -89,17 +98,21 @@ public static class OverloadGenerator
             il.Emit(OpCodes.Ldarg, i + argOffset);
         }
 
-        // Emit default values for missing arguments
-        for (int i = overloadArity; i < parameters.Count; i++)
+        // Supply the defaults this overload adds to reach the target method's arity. Under cascading
+        // forwarding that is the single parameter at index `overloadArity`, whose default may reference
+        // any earlier parameter (all are real arguments here, so they resolve to `ldarg`). (#698)
+        for (int i = overloadArity; i < targetParams.Length; i++)
         {
             var defaultExpr = parameters[i].DefaultValue;
-            var targetType = fullMethod.GetParameters()[i].ParameterType;
+            var targetType = targetParams[i].ParameterType;
 
             if (defaultExpr != null)
             {
                 emitter.EmitExpression(defaultExpr);
-                // Box if needed based on target type
-                EmitConversionIfNeeded(il, emitter, defaultExpr, targetType);
+                // Stack-aware conversion: adapts to whatever EmitExpression actually produced
+                // (an unboxed double/bool for an earlier-parameter reference, a boxed object for
+                // an `any` expression, etc.) so a default like `b = a` is not wrongly unboxed. (#698)
+                emitter.EmitConversionForParameter(defaultExpr, targetType);
             }
             else
             {
@@ -118,14 +131,14 @@ public static class OverloadGenerator
             }
         }
 
-        // Call the full method
+        // Forward to the next-higher-arity method (cascading).
         if (isStatic)
         {
-            il.Emit(OpCodes.Call, fullMethod);
+            il.Emit(OpCodes.Call, targetMethod);
         }
         else
         {
-            il.Emit(OpCodes.Callvirt, fullMethod);
+            il.Emit(OpCodes.Callvirt, targetMethod);
         }
 
         il.Emit(OpCodes.Ret);

--- a/SharpTS.Tests/SharedTests/DefaultParameterTests.cs
+++ b/SharpTS.Tests/SharedTests/DefaultParameterTests.cs
@@ -140,4 +140,120 @@ public class DefaultParameterTests
         var output = TestHarness.RunModules(files, "main.cjs", ExecutionMode.Compiled);
         Assert.Equal("-1\n", output);
     }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void DefaultParam_FunctionExpression_OmittedArg_AppliesDefault(ExecutionMode mode)
+    {
+        // #646: a function *expression* (or arrow) used to drop the default in compiled mode,
+        // leaving the parameter at its CLR zero value (0 for number). The Stmt.Function
+        // declaration path already worked; the Expr.ArrowFunction path did not.
+        var source = """
+            const f = function (x: number, y: number = 3) { return x + y; };
+            console.log(f(4));
+            console.log(f(4, 10));
+            """;
+        Assert.Equal("7\n14\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void DefaultParam_ArrowFunction_OmittedArg_AppliesDefault(ExecutionMode mode)
+    {
+        // #646
+        var source = """
+            const af = (x: number, y: number = 3) => x + y;
+            console.log(af(4));
+            console.log(af(4, 10));
+            """;
+        Assert.Equal("7\n14\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void DefaultParam_AsyncArrow_OmittedArg_AppliesDefault(ExecutionMode mode)
+    {
+        // #646 / #635: the async function-expression / async-arrow path inherits the same
+        // arrow default application.
+        var source = """
+            const af = async (x: number, y: number = 3) => x + y;
+            af(4).then(v => console.log(v));
+            """;
+        Assert.Equal("7\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void DefaultParam_ReferencesEarlierParam_Arrow(ExecutionMode mode)
+    {
+        // #698: a later default may reference any earlier parameter. The arrow / function-expression
+        // path used to reject this at type-check time with "Undefined variable 'a'".
+        var source = """
+            const g = (a: number, b: number = a * 2) => a + b;
+            console.log(g(5));
+            console.log(g(5, 1));
+            """;
+        Assert.Equal("15\n6\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void DefaultParam_ReferencesEarlierParam_FunctionDeclaration(ExecutionMode mode)
+    {
+        // #698: function-declaration earlier-param default. Compiled mode used to crash at runtime
+        // ("Undefined variable 'a'") inside the OverloadGenerator forwarding stub, which emitted the
+        // default expression without making the provided parameters resolvable.
+        var source = """
+            function f(a: number, b: number = a) { return a + b; }
+            console.log(f(5));
+            console.log(f(5, 1));
+            """;
+        Assert.Equal("10\n6\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void DefaultParam_ReferencesEarlierParam_StringValue(ExecutionMode mode)
+    {
+        // #698: reference-typed earlier-param default (exercises a different conversion path
+        // than the numeric/value-typed case).
+        var source = """
+            function f(a: string, b: string = a) { return a + b; }
+            console.log(f("x"));
+            console.log(f("x", "y"));
+            """;
+        Assert.Equal("xx\nxy\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void DefaultParam_ReferencesEarlierDefaultedParam_Chain(ExecutionMode mode)
+    {
+        // #698: a default may reference an earlier *defaulted* parameter, e.g. c = a + b where b is
+        // itself defaulted. Compiled mode resolves this via cascading overload forwarding — each
+        // overload fills exactly one default and forwards to the next-higher arity, so every prior
+        // parameter (provided or defaulted) is a real argument of the method evaluating the next default.
+        var source = """
+            function f(a: number, b: number = 1, c: number = a + b) { return a + b + c; }
+            console.log(f(5));
+            console.log(f(5, 2));
+            console.log(f(5, 2, 3));
+            """;
+        Assert.Equal("12\n14\n10\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void DefaultParam_ReferencesEarlierParam_Method(ExecutionMode mode)
+    {
+        // #698: a method default referencing an earlier parameter type-checks and evaluates correctly
+        // in the interpreter. (Compiled class methods ignore default parameter values entirely — a
+        // broader, separately tracked gap — so this is interpreter-only.)
+        var source = """
+            class C { m(a: number, b: number = a * 2) { return a + b; } }
+            console.log(new C().m(5));
+            console.log(new C().m(5, 1));
+            """;
+        Assert.Equal("15\n6\n", TestHarness.Run(source, mode));
+    }
 }

--- a/TypeSystem/TypeChecker.Expressions.cs
+++ b/TypeSystem/TypeChecker.Expressions.cs
@@ -1281,6 +1281,13 @@ public partial class TypeChecker
                 thisType = _pendingObjectThisType ?? new TypeInfo.Any();
             }
 
+            // A default value may reference any PRECEDING parameter (`(a, b = a * 2)`), so each
+            // parameter is progressively defined in a dedicated scope and later defaults are checked
+            // against it. Each parameter is defined AFTER its own default is checked, so a
+            // self-reference resolves to an outer binding or errors. Mirrors BuildFunctionSignature,
+            // which the function-declaration/method path already uses (#698).
+            var paramScope = new TypeEnvironment(_environment);
+
             // Build parameter types and check defaults
             for (int i = 0; i < arrow.Parameters.Count; i++)
             {
@@ -1307,13 +1314,18 @@ public partial class TypeChecker
                 // Rest parameters are not counted toward required params
                 if (param.IsRest)
                 {
+                    paramScope.Define(param.Name.Lexeme, paramType);
                     continue;
                 }
 
                 if (param.DefaultValue != null)
                 {
                     seenDefault = true;
-                    TypeInfo defaultType = CheckExpr(param.DefaultValue);
+                    TypeInfo defaultType;
+                    using (new EnvironmentScope(this, paramScope))
+                    {
+                        defaultType = CheckExpr(param.DefaultValue);
+                    }
                     if (!IsCompatible(paramType, defaultType))
                     {
                         throw new TypeCheckException($" Default value type '{defaultType}' is not assignable to parameter type '{paramType}'.", tsCode: "TS2322");
@@ -1331,6 +1343,8 @@ public partial class TypeChecker
                     }
                     requiredParams++;
                 }
+
+                paramScope.Define(param.Name.Lexeme, paramType);
             }
 
             // Determine return type (use expected type if available and no explicit annotation)


### PR DESCRIPTION
## What & why

Fixes #698 and adds regression coverage that locks in #646.

A later parameter's default value may reference any parameter to its left — `(a, b = a * 2)` — which TypeScript/JS allow. SharpTS rejected or mis-evaluated this in several places. The interpreter already evaluated it correctly (`ParameterBinder` binds each parameter before evaluating the next default); the gaps were in the type checker and the compiler.

### #698 — three fixes

1. **Type checker** (`TypeChecker.Expressions.cs` `CheckArrowFunction`)
   Arrow functions, function expressions, and object-method shorthand checked each default in a scope that did not yet contain the preceding parameters, so `(a, b = a) => …` failed type-checking with `Undefined variable 'a'`. It now checks each default against a progressively-populated parameter scope, exactly mirroring `BuildFunctionSignature` (the function-declaration / method path, which already worked). Each parameter is bound *after* its own default is checked, so a self-reference still resolves to an outer binding or errors — matching `tsc`.

2. **Compiled function overloads** (`OverloadGenerator` + `ILCompiler.Functions.cs` `EmitFunctionOverloads`)
   The lower-arity forwarding stub emitted the default expression in a synthetic context where the provided parameters were not registered, so `function f(a, b = a)` crashed at runtime with `Undefined variable`. The emit context now `DefineParameter`s the provided args, and the default→param-slot conversion is stack-aware (`EmitConversionForParameter`) so an earlier-parameter reference isn't wrongly unboxed.

3. **Compiled multi-default chains** (`f(a, b = 1, c = a + b)`)
   Overload forwarding is now **cascading**: each lower-arity overload fills exactly one default and forwards to the next-higher arity, instead of filling every default at once and calling the full method directly. This keeps every prior parameter — including an earlier *defaulted* one — a real argument of the method that evaluates the next default. (Single-default functions are unaffected: their one overload still forwards straight to the full method.)

### #646 — already fixed, now covered

Compiled arrow / function-expression defaults for omitted arguments were already fixed on `main` via `ParameterTypeResolver.WidenDefaultedParamsToObject`. Added both-mode regression tests so it stays fixed.

## Tests

`SharpTS.Tests/SharedTests/DefaultParameterTests.cs` — new cases run under both interpreter and compiled modes:
- #646: function-expression / arrow / async-arrow default for an omitted arg
- #698: earlier-param default for arrow, function declaration, string (reference-typed), and the defaulted-param chain
- #698 method case is interpreter-only (see below)

Full suite: **12,934 passed, 0 failed** (interpreter + compiled).

## Reviewer notes

- Filed #723: **compiled class methods (instance + static) ignore default parameter values entirely** — a broader, pre-existing gap discovered while doing this work. `EmitMethod` applies no defaults (neither the arrow-style widening nor `OverloadGenerator` overloads). The compiled-method earlier-param case is a strict subset of that and is blocked on it, so the method regression test here is interpreter-only. Fixing #723 needs care around virtual-dispatch / override-signature matching.
- `OverloadGenerator.EmitConstructorOverloadBody` remains unused dead scaffolding (constructors don't currently wire up arity overloads); left untouched to keep this change focused.
