### PR TITLE
Fix #674: generator-body arrows can write a captured variable (function display class)

### DIFF
--- a/Compilation/AsyncGeneratorMoveNextEmitter.Expressions.cs
+++ b/Compilation/AsyncGeneratorMoveNextEmitter.Expressions.cs
@@ -592,6 +592,12 @@ public partial class AsyncGeneratorMoveNextEmitter
             return;
         }
 
+        // The async-generator state machine has no function display class wired yet (#674 lifts the
+        // sync free-function generator case; the async-generator path is tracked separately), so an
+        // arrow that WRITES a captured generator local would snapshot it by value and silently drop
+        // the write. Fail fast with a clear message instead of miscompiling to a wrong result.
+        CapturedWriteAnalysis.ThrowIfCapturedWriteWouldBeLost(af, _ctx?.DisplayClassFields);
+
         // Get the method for this arrow function (pre-compiled)
         if (_ctx!.ArrowMethods == null || !_ctx.ArrowMethods.TryGetValue(af, out var method))
         {

--- a/Compilation/CapturedWriteAnalysis.cs
+++ b/Compilation/CapturedWriteAnalysis.cs
@@ -1,3 +1,5 @@
+using System.Reflection.Emit;
+using SharpTS.Diagnostics.Exceptions;
 using SharpTS.Parsing;
 using SharpTS.Parsing.Visitors;
 
@@ -13,6 +15,43 @@ namespace SharpTS.Compilation;
 /// </summary>
 internal static class CapturedWriteAnalysis
 {
+    /// <summary>
+    /// Fails fast (clear <see cref="CompileException"/>) when a sync arrow inside a generator body
+    /// writes a variable that the arrow captured BY VALUE into its own display class — a write that
+    /// would be silently lost because it lands on the private snapshot rather than the generator's
+    /// own storage (#674). Shared by the sync and async generator MoveNext emitters so they stay in
+    /// step. No-op when:
+    /// <list type="bullet">
+    /// <item>the arrow is async (its writes go through a different capture path);</item>
+    /// <item>the arrow captures nothing by value; or</item>
+    /// <item>the written captures were lifted into a shared function display class — those are
+    /// routed through <c>$functionDC</c> and so are absent from the by-value snapshot field map,
+    /// meaning the write already reaches shared storage (the sync free-function generator case).</item>
+    /// </list>
+    /// </summary>
+    public static void ThrowIfCapturedWriteWouldBeLost(
+        Expr.ArrowFunction arrow,
+        Dictionary<Expr.ArrowFunction, Dictionary<string, FieldBuilder>>? displayClassFields)
+    {
+        if (arrow.IsAsync ||
+            displayClassFields == null ||
+            !displayClassFields.TryGetValue(arrow, out var captureFields) ||
+            captureFields.Count == 0)
+            return;
+
+        var written = CollectImmediateWrites(arrow);
+        written.IntersectWith(captureFields.Keys);
+        if (written.Count == 0)
+            return;
+
+        var names = string.Join(", ", written.OrderBy(n => n, StringComparer.Ordinal));
+        throw new CompileException(
+            $"Compiled mode does not yet support an arrow/callback inside a generator (function*) " +
+            $"body that writes to a variable captured from the generator scope ({names}). The write " +
+            $"would be lost. Rewrite the mutation outside the callback (e.g. a for…of loop), or run " +
+            $"in interpreted mode. (#674)");
+    }
+
     /// <summary>
     /// Returns the names assigned within <paramref name="arrow"/>'s own scope.
     /// </summary>

--- a/Compilation/ExpressionEmitterBase.cs
+++ b/Compilation/ExpressionEmitterBase.cs
@@ -73,6 +73,15 @@ public abstract partial class ExpressionEmitterBase : IEmitterContext
     /// </summary>
     protected virtual FieldBuilder? GetHoistedVariableField(string name) => null;
 
+    /// <summary>
+    /// Gets the state machine's function display class field (<c>&lt;&gt;__functionDC</c>), or
+    /// null if this emitter has no function-level display class. Override in a state-machine
+    /// emitter whose generator/async function lifts captured-and-mutated locals into a shared
+    /// display class, so <see cref="EmitCapturingArrowViaHooks"/> can thread that reference into
+    /// an arrow's <c>$functionDC</c> field and the arrow's writes reach shared storage (#674).
+    /// </summary>
+    protected virtual FieldBuilder? GetFunctionDCField() => null;
+
     protected ExpressionEmitterBase(StateMachineEmitHelpers helpers)
     {
         _helpers = helpers;
@@ -1542,6 +1551,20 @@ public abstract partial class ExpressionEmitterBase : IEmitterContext
     private void EmitCapturingArrowViaHooks(Expr.ArrowFunction af, MethodBuilder method, ConstructorBuilder displayCtor)
     {
         IL.Emit(OpCodes.Newobj, displayCtor);
+
+        // Thread the enclosing state machine's function display class into the arrow's $functionDC
+        // field so the arrow reads/writes captured-and-mutated locals through shared storage rather
+        // than a by-value snapshot — the write case that was previously rejected (#674). The arrow's
+        // own snapshot fields (populated below) deliberately omit these vars (see the function-DC
+        // skip in CollectAndDefineArrowFunctions), so the two paths don't both materialize them.
+        if (Ctx.ArrowFunctionDCFields?.TryGetValue(af, out var arrowFunctionDCField) == true &&
+            GetFunctionDCField() is FieldBuilder stateMachineFunctionDC)
+        {
+            IL.Emit(OpCodes.Dup);
+            IL.Emit(OpCodes.Ldarg_0);
+            IL.Emit(OpCodes.Ldfld, stateMachineFunctionDC);
+            IL.Emit(OpCodes.Stfld, arrowFunctionDCField);
+        }
 
         if (Ctx.DisplayClassFields?.TryGetValue(af, out var fieldMap) == true)
         {

--- a/Compilation/GeneratorMoveNextEmitter.ArrowFunctions.cs
+++ b/Compilation/GeneratorMoveNextEmitter.ArrowFunctions.cs
@@ -1,4 +1,3 @@
-using SharpTS.Diagnostics.Exceptions;
 using SharpTS.Parsing;
 
 namespace SharpTS.Compilation;
@@ -8,36 +7,20 @@ public partial class GeneratorMoveNextEmitter
     /// <summary>
     /// Arrow emission inside a generator <c>MoveNext</c>. Delegates the actual emission to the
     /// base <see cref="ExpressionEmitterBase.EmitArrowFunction"/> (which instantiates the display
-    /// class for capturing arrows via the GetThisField / GetHoistedVariableField hooks), but first
-    /// rejects the one shape the generator path cannot yet honour: an arrow that <em>writes</em> to
-    /// a variable it captures from the enclosing generator scope.
+    /// class for capturing arrows via the GetThisField / GetHoistedVariableField / GetFunctionDCField
+    /// hooks), but first rejects any residual shape the generator path cannot yet honour: an arrow
+    /// that <em>writes</em> to a captured variable that was NOT lifted into a shared function display
+    /// class.
     /// </summary>
     protected override void EmitArrowFunction(Expr.ArrowFunction af)
     {
-        // Capturing arrows snapshot their captures BY VALUE into the arrow's display class. That is
-        // correct for read-only captures (the common `yield arr.map(x => x + base)` case), but if the
-        // arrow assigns to a captured variable, the write lands on the private snapshot and never
-        // reaches the generator's own storage — the mutation is silently lost. Honouring it needs a
-        // shared function-level display class threaded through the generator state machine (as plain
-        // and async functions already have, but generators do not — see #674). Fail fast with a clear
-        // message rather than miscompiling `arr.forEach(n => sum += n)` to a wrong result.
-        if (!af.IsAsync &&
-            _ctx?.DisplayClassFields != null &&
-            _ctx.DisplayClassFields.TryGetValue(af, out var captureFields) &&
-            captureFields.Count > 0)
-        {
-            var written = CapturedWriteAnalysis.CollectImmediateWrites(af);
-            written.IntersectWith(captureFields.Keys);
-            if (written.Count > 0)
-            {
-                var names = string.Join(", ", written.OrderBy(n => n, System.StringComparer.Ordinal));
-                throw new CompileException(
-                    $"Compiled mode does not yet support an arrow/callback inside a generator (function*) " +
-                    $"body that writes to a variable captured from the generator scope ({names}). The write " +
-                    $"would be lost. Rewrite the mutation outside the callback (e.g. a for…of loop), or run " +
-                    $"in interpreted mode. (#674)");
-            }
-        }
+        // A captured-AND-mutated variable backed by the generator's function display class (#674) is
+        // routed through `$functionDC` and so is intentionally absent from the arrow's own by-value
+        // snapshot fields — its write reaches shared storage and this guard does not fire. What
+        // remains is the still-unsupported subset: a write to a captured variable that is only ever
+        // snapshotted by value (e.g. inside an instance generator method, whose state machine has no
+        // function DC wired). Fail fast there rather than miscompiling `arr.forEach(n => sum += n)`.
+        CapturedWriteAnalysis.ThrowIfCapturedWriteWouldBeLost(af, _ctx?.DisplayClassFields);
 
         base.EmitArrowFunction(af);
     }

--- a/Compilation/GeneratorMoveNextEmitter.Variables.cs
+++ b/Compilation/GeneratorMoveNextEmitter.Variables.cs
@@ -1,0 +1,107 @@
+using System.Reflection.Emit;
+using SharpTS.Parsing;
+
+namespace SharpTS.Compilation;
+
+public partial class GeneratorMoveNextEmitter
+{
+    // Expose the state machine's function display class field to the base arrow emitter so a
+    // capturing arrow inside the generator body gets its $functionDC threaded in (#674).
+    protected override FieldBuilder? GetFunctionDCField() => _builder.FunctionDCField;
+
+    /// <summary>
+    /// Routes reads and writes of a captured-AND-mutated generator local/parameter through the
+    /// shared function display class (#674) so a write inside an arrow/callback and the generator
+    /// body observe the same storage. Unlike the async path there is no parallel hoisted-field
+    /// write: a sync generator has no async arrows reading the boxed state machine, and the DC —
+    /// held by the <c>&lt;&gt;__functionDC</c> state-machine field — already survives across yields,
+    /// so it is the single source of truth. Returns false (no DC routing) for variables that stay
+    /// on the existing by-value snapshot / hoisted-field path.
+    /// </summary>
+    private bool TryGetFunctionDCField(string name, out FieldBuilder dcField)
+    {
+        dcField = null!;
+        return _builder.FunctionDCField != null &&
+               _ctx?.CapturedFunctionLocals?.Contains(name) == true &&
+               _ctx.FunctionDisplayClassFields?.TryGetValue(name, out dcField!) == true;
+    }
+
+    /// <summary>
+    /// Stores the value currently on the stack into <c>this.&lt;&gt;__functionDC.dcField</c>,
+    /// consuming it. Caller is responsible for any duplicate it wants to keep as a result.
+    /// </summary>
+    private void StoreToDCField(FieldBuilder dcField)
+    {
+        var temp = _il.DeclareLocal(_types.Object);
+        _il.Emit(OpCodes.Stloc, temp);
+        _il.Emit(OpCodes.Ldarg_0);
+        _il.Emit(OpCodes.Ldfld, _builder.FunctionDCField!);
+        _il.Emit(OpCodes.Ldloc, temp);
+        _il.Emit(OpCodes.Stfld, dcField);
+    }
+
+    protected override void EmitVariable(Expr.Variable v)
+    {
+        if (TryGetFunctionDCField(v.Name.Lexeme, out var dcField))
+        {
+            _il.Emit(OpCodes.Ldarg_0);
+            _il.Emit(OpCodes.Ldfld, _builder.FunctionDCField!);
+            _il.Emit(OpCodes.Ldfld, dcField);
+            SetStackUnknown();
+            return;
+        }
+
+        base.EmitVariable(v);
+    }
+
+    protected override void EmitVarDeclaration(Stmt.Var v)
+    {
+        if (TryGetFunctionDCField(v.Name.Lexeme, out var dcField))
+        {
+            if (v.Initializer != null)
+            {
+                EmitExpression(v.Initializer);
+                EnsureBoxed();
+            }
+            else
+            {
+                _il.Emit(OpCodes.Ldsfld, _ctx!.Runtime!.UndefinedInstance);
+            }
+            StoreToDCField(dcField);
+            return;
+        }
+
+        base.EmitVarDeclaration(v);
+    }
+
+    protected override void EmitAssign(Expr.Assign a)
+    {
+        if (TryGetFunctionDCField(a.Name.Lexeme, out var dcField))
+        {
+            EmitExpression(a.Value);
+            EnsureBoxed();
+            _il.Emit(OpCodes.Dup); // keep a copy as the assignment expression's result
+            StoreToDCField(dcField);
+            SetStackUnknown();
+            return;
+        }
+
+        base.EmitAssign(a);
+    }
+
+    /// <summary>
+    /// Store side of compound assignment, logical assignment, and increment/decrement (the value
+    /// is already on the stack). Reads for those operators go through <see cref="EmitVariable"/>,
+    /// so routing the store here keeps both ends on the function DC.
+    /// </summary>
+    protected override void EmitStoreVariable(string name)
+    {
+        if (TryGetFunctionDCField(name, out var dcField))
+        {
+            StoreToDCField(dcField);
+            return;
+        }
+
+        base.EmitStoreVariable(name);
+    }
+}

--- a/Compilation/GeneratorStateMachineBuilder.cs
+++ b/Compilation/GeneratorStateMachineBuilder.cs
@@ -58,6 +58,13 @@ public class GeneratorStateMachineBuilder
     // 'this' field for instance generator methods
     public FieldBuilder? ThisField { get; private set; }
 
+    // Function-level display class field for captured-and-mutated locals (#674).
+    // An arrow inside the generator body that WRITES a variable captured from the
+    // generator scope shares storage with the generator through this reference-typed
+    // display class (mirrors AsyncStateMachineBuilder.FunctionDCField). Null when the
+    // generator has no such write-capture.
+    public FieldBuilder? FunctionDCField { get; private set; }
+
     // Delegated enumerator field for yield* expressions
     public FieldBuilder? DelegatedEnumeratorField { get; private set; }
 
@@ -399,6 +406,18 @@ public class GeneratorStateMachineBuilder
 
         var nonGenericInterfaceMethod = _types.GetMethodNoParams(_types.IEnumerable, "GetEnumerator");
         _stateMachineType.DefineMethodOverride(NonGenericGetEnumeratorMethod, nonGenericInterfaceMethod);
+    }
+
+    /// <summary>
+    /// Adds the field that holds the function display class instance for closure mutation
+    /// sharing (#674). Mirrors <see cref="AsyncStateMachineBuilder.DefineFunctionDisplayClassField"/>.
+    /// </summary>
+    public void DefineFunctionDisplayClassField(Type dcType)
+    {
+        FunctionDCField = _stateMachineType.DefineField(
+            "<>__functionDC",
+            dcType,
+            FieldAttributes.Public);
     }
 
     /// <summary>

--- a/Compilation/ILCompiler.Functions.cs
+++ b/Compilation/ILCompiler.Functions.cs
@@ -253,6 +253,17 @@ public partial class ILCompiler
                 return;
         }
 
+        RegisterFunctionDisplayClass(qualifiedFunctionName, capturedLocals);
+    }
+
+    /// <summary>
+    /// Creates and registers a function-level display class holding one <c>object</c> field per
+    /// named captured variable. Shared by the sync/async path (<see cref="DefineFunctionDisplayClass"/>,
+    /// which lifts all captured locals) and the generator path (which lifts only captured-AND-mutated
+    /// locals, #674). The caller is responsible for the membership decision; this only builds the type.
+    /// </summary>
+    private void RegisterFunctionDisplayClass(string qualifiedFunctionName, IEnumerable<string> capturedLocals)
+    {
         // Create display class type
         var displayClass = _moduleBuilder.DefineType(
             $"<>c__FuncDisplayClass_{qualifiedFunctionName.Replace(".", "_")}_{_closures.DisplayClassCounter++}",

--- a/Compilation/ILCompiler.Generators.cs
+++ b/Compilation/ILCompiler.Generators.cs
@@ -34,6 +34,12 @@ public partial class ILCompiler
         _generators.StateMachines[qualifiedName] = smBuilder;
         _generators.Functions[qualifiedName] = funcStmt;
 
+        // Record the AST node so PropagateFunctionDCRequirements can resolve arrows nested in this
+        // generator back to its qualified name, and lift captured-and-mutated locals into a shared
+        // function display class so a write inside an arrow/callback reaches the generator (#674).
+        _closures.FunctionAstNodes[qualifiedName] = funcStmt;
+        DefineGeneratorFunctionDisplayClass(funcStmt, qualifiedName, smBuilder);
+
         // Define the stub method that creates and returns the state machine.
         // A trailing rest parameter is typed List<object> so the indirect
         // ($TSFunction.Invoke) call path packs trailing args into it (#426).
@@ -59,6 +65,87 @@ public partial class ILCompiler
     }
 
     /// <summary>
+    /// Lifts a generator's captured-AND-mutated locals into a function-level display class so an
+    /// arrow/callback inside the generator body that writes such a variable shares storage with the
+    /// generator instead of snapshotting it by value (#674). Read-only captures keep the existing
+    /// by-value snapshot path. Mirrors the sync/async function-DC wiring, restricted to the write
+    /// case the generator state machine could not previously honour. No-op when the generator has no
+    /// write-captures (the common case), leaving fully-standalone output unchanged.
+    /// </summary>
+    private void DefineGeneratorFunctionDisplayClass(
+        Stmt.Function funcStmt, string qualifiedName, GeneratorStateMachineBuilder smBuilder)
+    {
+        var mutatedCaptured = ComputeMutatedCapturedGeneratorVars(funcStmt);
+        if (mutatedCaptured.Count == 0)
+            return;
+
+        RegisterFunctionDisplayClass(qualifiedName, mutatedCaptured);
+        if (_closures.FunctionDisplayClasses.TryGetValue(qualifiedName, out var funcDC))
+            smBuilder.DefineFunctionDisplayClassField(funcDC);
+    }
+
+    /// <summary>
+    /// Returns the generator's own locals/parameters that are both captured by an inner arrow and
+    /// written by one (the set that needs shared reference storage). Per-iteration <c>for (let…)</c>
+    /// bindings are excluded — each iteration owns its binding (#649), so closures must snapshot them
+    /// per iteration rather than share one function-DC cell.
+    /// </summary>
+    private HashSet<string> ComputeMutatedCapturedGeneratorVars(Stmt.Function funcStmt)
+    {
+        var capturedLocals = _closures.Analyzer.GetCapturedLocals(funcStmt);
+        if (capturedLocals.Count == 0)
+            return [];
+
+        var result = new HashSet<string>(capturedLocals);
+        result.IntersectWith(CollectGeneratorArrowCapturedWrites(funcStmt));
+        if (result.Count == 0)
+            return [];
+
+        var perIteration = _closures.Analyzer.GetPerIterationLoopBindings(funcStmt);
+        if (perIteration.Count > 0)
+            result.ExceptWith(perIteration);
+        return result;
+    }
+
+    /// <summary>
+    /// Unions, over every arrow lexically inside the generator body (nested arrows included), the
+    /// names the arrow assigns within its own scope that it also captures from an enclosing scope.
+    /// Intersected by the caller with the generator's own captured locals to identify mutated
+    /// generator captures.
+    /// </summary>
+    private HashSet<string> CollectGeneratorArrowCapturedWrites(Stmt.Function funcStmt)
+    {
+        var collector = new ArrowCollector();
+        if (funcStmt.Body != null)
+            foreach (var stmt in funcStmt.Body)
+                collector.Visit(stmt);
+
+        var writes = new HashSet<string>();
+        foreach (var arrow in collector.Arrows)
+        {
+            // Only sync arrows share the generator's function DC — async arrows capture through
+            // their own boxed state machine, the same scope the compile-time guard covers (#674).
+            if (arrow.IsAsync)
+                continue;
+            var arrowWrites = CapturedWriteAnalysis.CollectImmediateWrites(arrow);
+            arrowWrites.IntersectWith(_closures.Analyzer.GetCaptures(arrow));
+            writes.UnionWith(arrowWrites);
+        }
+        return writes;
+    }
+
+    /// <summary>Collects every arrow function in a subtree, descending into nested arrows.</summary>
+    private sealed class ArrowCollector : Parsing.Visitors.AstVisitorBase
+    {
+        public readonly List<Expr.ArrowFunction> Arrows = [];
+        protected override void VisitArrowFunction(Expr.ArrowFunction expr)
+        {
+            Arrows.Add(expr);
+            base.VisitArrowFunction(expr); // descend to find nested arrows
+        }
+    }
+
+    /// <summary>
     /// Emits all generator state machine bodies.
     /// Called after all functions have been defined.
     /// </summary>
@@ -79,10 +166,10 @@ public partial class ILCompiler
             var methodBuilder = _functions.Builders[funcName];
 
             // Emit the stub method body (creates and returns the state machine)
-            EmitGeneratorStubMethod(methodBuilder, smBuilder, funcStmt);
+            EmitGeneratorStubMethod(methodBuilder, smBuilder, funcStmt, funcName);
 
             // Emit the MoveNext method body
-            EmitGeneratorMoveNextBody(smBuilder, funcStmt);
+            EmitGeneratorMoveNextBody(smBuilder, funcStmt, funcName);
 
             // Finalize the state machine type
             smBuilder.CreateType();
@@ -97,7 +184,8 @@ public partial class ILCompiler
     private void EmitGeneratorStubMethod(
         MethodBuilder methodBuilder,
         GeneratorStateMachineBuilder smBuilder,
-        Stmt.Function funcStmt)
+        Stmt.Function funcStmt,
+        string qualifiedName)
     {
         var il = methodBuilder.GetILGenerator();
 
@@ -117,6 +205,11 @@ public partial class ILCompiler
             }
         }
 
+        // Instantiate the function display class (#674) and seed any captured-and-mutated
+        // parameters into it so an arrow that writes them shares the generator's storage. The
+        // stub params are object-typed (BuildStateMachineStubParamTypes), so no boxing is needed.
+        EmitGeneratorFunctionDCInit(il, smBuilder, funcStmt, qualifiedName, paramOffset: 0);
+
         // Captured outer-scope variables are NOT copied into the state machine here. Doing so
         // snapshotted their value at creation time, so a later mutation of the outer variable
         // was invisible to the running body (#541). MoveNext instead reads/writes them live
@@ -128,10 +221,46 @@ public partial class ILCompiler
     }
 
     /// <summary>
+    /// With the state machine instance on the stack, news up the function display class (#674),
+    /// stores it into the state machine's <c>&lt;&gt;__functionDC</c> field, and copies any
+    /// captured-and-mutated parameters into it. Leaves the state machine reference on the stack
+    /// (net stack effect zero). No-op when the generator has no function DC.
+    /// </summary>
+    private void EmitGeneratorFunctionDCInit(
+        ILGenerator il,
+        GeneratorStateMachineBuilder smBuilder,
+        Stmt.Function funcStmt,
+        string qualifiedName,
+        int paramOffset)
+    {
+        if (smBuilder.FunctionDCField == null ||
+            !_closures.FunctionDisplayClassCtors.TryGetValue(qualifiedName, out var dcCtor))
+            return;
+
+        il.Emit(OpCodes.Dup);                       // [sm, sm]
+        il.Emit(OpCodes.Newobj, dcCtor);            // [sm, sm, dc]
+        il.Emit(OpCodes.Stfld, smBuilder.FunctionDCField); // [sm]
+
+        if (!_closures.FunctionDisplayClassFields.TryGetValue(qualifiedName, out var dcFields))
+            return;
+
+        for (int i = 0; i < funcStmt.Parameters.Count; i++)
+        {
+            var paramName = funcStmt.Parameters[i].Name.Lexeme;
+            if (!dcFields.TryGetValue(paramName, out var dcField))
+                continue;
+            il.Emit(OpCodes.Dup);                   // [sm, sm]
+            il.Emit(OpCodes.Ldfld, smBuilder.FunctionDCField); // [sm, dc]
+            il.Emit(OpCodes.Ldarg, i + paramOffset);           // [sm, dc, arg]
+            il.Emit(OpCodes.Stfld, dcField);        // [sm]
+        }
+    }
+
+    /// <summary>
     /// Emits the MoveNext method body for a generator state machine.
     /// Uses GeneratorMoveNextEmitter to handle full generator body with yield expressions.
     /// </summary>
-    private void EmitGeneratorMoveNextBody(GeneratorStateMachineBuilder smBuilder, Stmt.Function funcStmt)
+    private void EmitGeneratorMoveNextBody(GeneratorStateMachineBuilder smBuilder, Stmt.Function funcStmt, string qualifiedName)
     {
         var analysis = _generators.Analyzer.Analyze(funcStmt);
 
@@ -181,6 +310,16 @@ public partial class ILCompiler
             EntryPointDisplayClassStaticField = _closures.EntryPointDisplayClassStaticField,
             TopLevelStaticVars = BuildTopLevelStaticVarsForModule(_modules.CurrentPath)
         };
+
+        // Route reads/writes of captured-and-mutated locals through the shared function display
+        // class (#674) and let capturing arrows thread it in. Only set when this generator has a
+        // function DC; otherwise the existing by-value snapshot path is used unchanged.
+        if (_closures.FunctionDisplayClassFields.TryGetValue(qualifiedName, out var funcDCFields))
+        {
+            ctx.FunctionDisplayClassFields = funcDCFields;
+            ctx.CapturedFunctionLocals = [.. funcDCFields.Keys];
+            ctx.ArrowFunctionDCFields = _closures.ArrowFunctionDCFields.Count > 0 ? _closures.ArrowFunctionDCFields : null;
+        }
 
         // Use the new emitter for full generator body emission
         var emitter = new GeneratorMoveNextEmitter(smBuilder, analysis, _types);

--- a/SharpTS.Tests/Compilation/EmitterSyncTests.cs
+++ b/SharpTS.Tests/Compilation/EmitterSyncTests.cs
@@ -100,6 +100,7 @@ public class EmitterSyncTests
             "get_Resolver",
             "GetThisField",
             "GetHoistedVariableField",
+            "GetFunctionDCField",   // #674: exposes <>__functionDC so the base arrow emitter threads it in
             // --- Genuinely different behavior ---
             "EmitReturn",           // Generator return: set state -2, return false
             "EmitTryCatch",         // Generator exception handling
@@ -108,10 +109,15 @@ public class EmitterSyncTests
             "EmitYield",            // Core: yield value + suspend
             "EmitSuper",            // This field indirection
             "EmitDynamicImport",    // Dynamic import fallback
-            // #674: reject (with a clear error) an arrow that writes a variable captured from the
-            // generator scope — the generator SM has no function display class to share storage, so
-            // a by-value snapshot would silently drop the write. Read-only captures delegate to base.
+            // #674: a captured-AND-mutated generator local is lifted into a shared function display
+            // class; EmitArrowFunction still rejects the residual not-yet-DC-backed write case (e.g.
+            // instance generator methods) so it fails fast instead of dropping the write.
             "EmitArrowFunction",
+            // --- #674: closure mutation sharing (route captured-and-mutated locals through the DC) ---
+            "EmitVariable",         // Read a captured-and-mutated local through the function DC
+            "EmitAssign",           // Write a captured-and-mutated local through the function DC
+            "EmitStoreVariable",    // Store side of compound/logical/increment through the function DC
+            "EmitVarDeclaration",   // Initialize a captured-and-mutated local into the function DC
             // --- #500: non-local exits must run an enclosing flag-based finally first ---
             "EmitBreak",            // Route a break leaving a try through its finally(s)
             "EmitContinue",         // Route a continue leaving a try through its finally(s)

--- a/SharpTS.Tests/SharedTests/GeneratorArrowBodyTests.cs
+++ b/SharpTS.Tests/SharedTests/GeneratorArrowBodyTests.cs
@@ -116,10 +116,13 @@ public class GeneratorArrowBodyTests
         Assert.Equal("2,4,6\n", TestHarness.Run(source, mode));
     }
 
-    [Fact]
-    public void Generator_ForEachWritesCapturedBinding_InterpretedIsCorrect()
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Generator_ForEachWritesCapturedBinding(ExecutionMode mode)
     {
-        // The interpreter handles the write-to-captured-binding case correctly.
+        // #674: an arrow that WRITES a captured generator local. The mutation must reach the
+        // generator's own storage — a shared function-level display class threaded through the
+        // generator state machine in compiled mode (the interpreter has always been correct).
         var source = """
             function* g() {
               const a = [1, 2, 3]; let s = "";
@@ -129,24 +132,156 @@ public class GeneratorArrowBodyTests
             console.log(g().next().value);
             """;
 
-        Assert.Equal("123\n", TestHarness.RunInterpreted(source));
+        Assert.Equal("123\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Generator_CallbackAccumulatesIntoCapturedNumber(ExecutionMode mode)
+    {
+        // #674, numeric accumulator — the canonical `reduce`-by-side-effect shape.
+        var source = """
+            function* g() {
+              let sum = 0;
+              [1, 2, 3].forEach(n => sum += n);
+              yield sum;
+            }
+            console.log(g().next().value);
+            """;
+
+        Assert.Equal("6\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Generator_MultipleMutatedCaptures(ExecutionMode mode)
+    {
+        // #674: two distinct captured locals mutated by one callback — each gets its own DC field.
+        var source = """
+            function* g() {
+              let sum = 0; let product = 1;
+              [1, 2, 3, 4].forEach(n => { sum += n; product *= n; });
+              yield `${sum},${product}`;
+            }
+            console.log(g().next().value);
+            """;
+
+        Assert.Equal("10,24\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Generator_CallbackMutatesCapturedParameter(ExecutionMode mode)
+    {
+        // #674: the mutated capture is a generator PARAMETER — the stub seeds it into the DC.
+        var source = """
+            function* g(acc: number) {
+              [1, 2, 3].forEach(n => acc += n);
+              yield acc;
+            }
+            console.log(g(100).next().value);
+            """;
+
+        Assert.Equal("106\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Generator_NestedCallbackWritesCaptureThroughToGenerator(ExecutionMode mode)
+    {
+        // #674 (the case the compile-time guard could not see): a NESTED arrow writes a variable
+        // captured all the way through to the generator scope. The DC threads through both arrows.
+        var source = """
+            function* g() {
+              let sum = 0;
+              [[1, 2], [3, 4]].forEach(row => row.forEach(m => sum += m));
+              yield sum;
+            }
+            console.log(g().next().value);
+            """;
+
+        Assert.Equal("10\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Generator_MutatedAndReadOnlyCapturesMixed(ExecutionMode mode)
+    {
+        // #674: a read-only capture (`base`, by-value snapshot) and a mutated capture (`total`,
+        // function DC) coexist in the same callback.
+        var source = """
+            function* g() {
+              const base = 10; let total = 0;
+              [1, 2, 3].forEach(n => total += n + base);
+              yield total;
+            }
+            console.log(g().next().value);
+            """;
+
+        Assert.Equal("36\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Generator_CapturedWriteSurvivesAcrossYield(ExecutionMode mode)
+    {
+        // #674: the mutated capture is also live across a yield. The DC lives on a state-machine
+        // field, so it persists across the suspension just like a hoisted local.
+        var source = """
+            function* g() {
+              let s = 0;
+              yield "before:" + s;
+              [1, 2, 3].forEach(n => s += n);
+              yield "after:" + s;
+            }
+            const it = g();
+            let out = it.next().value + "|" + it.next().value;
+            console.log(out);
+            """;
+
+        Assert.Equal("before:0|after:6\n", TestHarness.Run(source, mode));
     }
 
     [Fact]
-    public void Generator_ForEachWritesCapturedBinding_CompiledRejectsClearly()
+    public void Generator_InstanceMethodWritesCapturedBinding_CompiledRejectsClearly()
     {
-        // Compiled mode cannot yet share storage for a mutated capture (would need a function-level
-        // display class threaded through the generator state machine, #674). Until then it must
-        // FAIL FAST with a clear message rather than silently dropping the write.
+        // An INSTANCE generator method's state machine is not yet wired with a function display
+        // class (#674 covers free `function*` declarations), so a write-to-captured-binding inside
+        // one must still FAIL FAST with a clear message rather than silently dropping the write.
+        // The interpreter handles it correctly.
         var source = """
-            function* g() {
-              const a = [1, 2, 3]; let s = "";
-              a.forEach(n => s += n);
-              yield s;
+            class C {
+              *gen() {
+                let s = 0;
+                [1, 2, 3].forEach(n => s += n);
+                yield s;
+              }
             }
-            console.log(g().next().value);
+            console.log(new C().gen().next().value);
             """;
 
+        Assert.Equal("6\n", TestHarness.RunInterpreted(source));
+        var ex = Assert.Throws<CompileException>(() => TestHarness.RunCompiled(source));
+        Assert.Contains("captured from the generator scope", ex.Message);
+    }
+
+    [Fact]
+    public void AsyncGenerator_WritesCapturedBinding_CompiledRejectsClearly()
+    {
+        // The async-generator state machine has no function display class wired yet (#674 lifts the
+        // sync free-function generator case). Previously this SILENTLY dropped the write (compiled
+        // yielded 0 where the interpreter yields 6); it must now FAIL FAST with a clear message
+        // instead of miscompiling.
+        var source = """
+            async function* g() {
+              let sum = 0;
+              [1, 2, 3].forEach(n => sum += n);
+              yield sum;
+            }
+            (async () => { for await (const v of g()) console.log(v); })();
+            """;
+
+        Assert.Equal("6\n", TestHarness.RunInterpreted(source));
         var ex = Assert.Throws<CompileException>(() => TestHarness.RunCompiled(source));
         Assert.Contains("captured from the generator scope", ex.Message);
     }


### PR DESCRIPTION
## What

Compiled mode: an arrow/callback inside a **sync free-function generator** body that **writes** a variable captured from the generator scope now shares storage with the generator through a function-level display class, rather than snapshotting it by value and silently dropping the write.

```ts
function* g() { let s = 0; [1, 2, 3].forEach(n => s += n); yield s; }
console.log(g().next().value);   // interp: 6 — compiled was a fail-fast error, now 6
```

Also **verifies and closes #669** (arrows as array-method callbacks / capturing closures inside compiled generator bodies — fixed by #699, now confirmed with the repros + cross-mode tests).

## How

Mirrors the existing sync/async function-DC wiring, restricted to the write case the generator state machine could not previously honour:

- `GeneratorStateMachineBuilder` gains a `<>__functionDC` field.
- `DefineGeneratorFunction` lifts the **captured-AND-mutated** generator locals/params into a shared display class. Read-only captures keep the existing by-value snapshot path; per-iteration `for (let…)` bindings stay per-iteration (#649). The generic `PropagateFunctionDCRequirements` plumbing then routes arrows through `$functionDC` automatically — generators are treated like sync functions there since they aren’t in `_async.StateMachines`.
- The generator stub instantiates the DC and seeds captured params; `MoveNext` reads/writes those vars through `this.<>__functionDC.field` (`GeneratorMoveNextEmitter.Variables.cs`).
- New `ExpressionEmitterBase.GetFunctionDCField()` hook lets the shared capturing-arrow emitter thread the DC into the arrow’s `$functionDC` field.
- `RegisterFunctionDisplayClass` extracted from `DefineFunctionDisplayClass` (shared builder).

The compile-time guard **self-narrows**: a DC-backed write is absent from the arrow’s snapshot fields, so it no longer fires; it still fail-fasts the not-yet-wired cases. It was extracted to a shared helper and **also applied to the async-generator emitter**, which previously **silently miscompiled** the write case (yielded `0` vs `6`) — now a clear error instead of a wrong answer.

## Scope / follow-ups

This PR covers **sync free-function generators** (the issue’s repros). Filed for the remaining, separate paths:
- #724 — instance generator methods (`*m()`), a different stub/context path.
- #725 — full async-generator DC fix (this PR only adds the fail-fast guard there).
- #732 — pre-existing NRE (unrelated to this work): an arrow inside a generator that captures a **top-level** variable crashes because `$entryPointDC` is never populated on the base generator-arrow path (affects read-only captures too).

## Verification

- Emitted IL passes `--verify` (ILVerify) for every new case; compiled output stays fully standalone (no SharpTS.dll dependency, no new soft-dependency).
- Cross-mode tests added in `GeneratorArrowBodyTests` (multiple / parameter / nested-arrow / mixed read+write / write-across-yield) plus fail-fast tests for instance methods and async generators. `EmitterSyncTests` allowlist updated.
- **Full suite green: 12,900 passed, 0 failed.**
- Test262/TSConformance: change is inert outside the new generator path; targeted corpus search found no generator+arrow+write tests, so the baselines are unaffected.

Closes #669.