### PR TITLE
Fix #678, #679: generator expressions capturing block-scoped bindings; named self-reference

### DIFF
--- a/Parsing/GeneratorArrowLifter.cs
+++ b/Parsing/GeneratorArrowLifter.cs
@@ -61,6 +61,92 @@ internal sealed class GeneratorArrowLifter
         public List<Stmt.Function> Lifted { get; } = new();
     }
 
+    /// <summary>
+    /// Stack of block-scoped binding-name sets currently in scope along the traversal path: loop
+    /// variables, catch parameters, and <c>let</c>/<c>const</c>/<c>class</c>/block-level <c>function</c>
+    /// declarations inside a nested block, switch body, or try/catch/finally block. A generator function
+    /// expression that closes over one of these CANNOT be lifted out — the module body and every
+    /// enclosing function body sit outside the block where the binding lives, so the lift would unbind
+    /// the reference. Such a generator is left in place as an expression instead (#678): the interpreter
+    /// runs generator expressions natively (<c>SharpTSArrowGeneratorFunction</c>) and the type checker
+    /// establishes the generator context directly (<c>CheckArrowFunction</c>). The compiler has no
+    /// generator-expression IL path; it reports a clear "Yield not supported in this context" error for
+    /// the capturing case — the same outcome as #534's enclosing-function-local capture.
+    /// </summary>
+    private readonly List<HashSet<string>> _blockScopes = new();
+
+    /// <summary>Shared read-only sentinel for blocks that introduce no block-scoped bindings (avoids a
+    /// per-block allocation; never mutated after creation).</summary>
+    private static readonly HashSet<string> EmptyScope = new(StringComparer.Ordinal);
+
+    private void PushBlockScope(HashSet<string> names) => _blockScopes.Add(names);
+    private void PopBlockScope() => _blockScopes.RemoveAt(_blockScopes.Count - 1);
+
+    private static HashSet<string> SingletonScope(string name) => new(StringComparer.Ordinal) { name };
+
+    /// <summary>
+    /// Collects the block-scoped binding names declared directly in a statement list (a block body):
+    /// <c>let</c>/<c>const</c>/<c>class</c> and block-level <c>function</c> declarations. <c>var</c> is
+    /// excluded (function-scoped, and already hoisted to the function top by the parse-time
+    /// <c>VarHoister</c>), as are bindings nested in deeper blocks. Returns the shared empty sentinel
+    /// when the block declares nothing block-scoped.
+    /// </summary>
+    private static HashSet<string> CollectBlockBindings(List<Stmt> statements)
+    {
+        HashSet<string>? names = null;
+        foreach (var stmt in statements)
+        {
+            string? n = stmt switch
+            {
+                Stmt.Var v when !v.IsVar => v.Name.Lexeme,   // `let` (var is function-scoped + pre-hoisted)
+                Stmt.Const c => c.Name.Lexeme,
+                Stmt.Function f => f.Name.Lexeme,
+                Stmt.Class cl => cl.Name.Lexeme,
+                _ => null,
+            };
+            if (n is not null) (names ??= new HashSet<string>(StringComparer.Ordinal)).Add(n);
+        }
+        return names ?? EmptyScope;
+    }
+
+    /// <summary>Collects the block-scoped names declared by a <c>for(;;)</c> initializer (the loop
+    /// variables of <c>for (let i = 0, j = 0; …)</c>). A <c>var</c> initializer is function-scoped, so
+    /// it contributes nothing.</summary>
+    private static HashSet<string> CollectForInitBindings(Stmt? init) => init switch
+    {
+        Stmt.Sequence seq => CollectBlockBindings(seq.Statements),
+        Stmt.Var v when !v.IsVar => SingletonScope(v.Name.Lexeme),
+        Stmt.Const c => SingletonScope(c.Name.Lexeme),
+        _ => EmptyScope,
+    };
+
+    /// <summary>The body of a <c>switch</c> is a single lexical scope shared by every case, so its
+    /// block-scoped bindings are the union of all case and default body declarations.</summary>
+    private static HashSet<string> CollectSwitchBindings(Stmt.Switch sw)
+    {
+        HashSet<string>? names = null;
+        void Merge(HashSet<string> from)
+        {
+            if (from.Count == 0) return;
+            (names ??= new HashSet<string>(StringComparer.Ordinal)).UnionWith(from);
+        }
+        foreach (var c in sw.Cases) Merge(CollectBlockBindings(c.Body));
+        if (sw.DefaultBody is not null) Merge(CollectBlockBindings(sw.DefaultBody));
+        return names ?? EmptyScope;
+    }
+
+    /// <summary>True when the generator arrow references a free variable bound in an enclosing BLOCK
+    /// scope (loop variable, catch parameter, or nested-block let/const/class/function). Lifting it out
+    /// would move the reference outside that block, so the generator must stay an expression (#678).</summary>
+    private bool CapturesBlockScopedBinding(HashSet<string> freeVars)
+    {
+        if (freeVars.Count == 0) return false;
+        foreach (var scope in _blockScopes)
+            foreach (var name in freeVars)
+                if (scope.Contains(name)) return true;
+        return false;
+    }
+
     public static List<Stmt> Lift(List<Stmt> body)
     {
         // Cheap pre-scan: if there are no generator function expressions anywhere, return the
@@ -153,8 +239,13 @@ internal sealed class GeneratorArrowLifter
 
     private Stmt RewriteBlock(Stmt.Block b)
     {
-        var rewritten = RewriteListIfChanged(b.Statements, RewriteStmt);
-        return ReferenceEquals(rewritten, b.Statements) ? b : new Stmt.Block(rewritten);
+        PushBlockScope(CollectBlockBindings(b.Statements));
+        try
+        {
+            var rewritten = RewriteListIfChanged(b.Statements, RewriteStmt);
+            return ReferenceEquals(rewritten, b.Statements) ? b : new Stmt.Block(rewritten);
+        }
+        finally { PopBlockScope(); }
     }
 
     private Stmt RewriteSequence(Stmt.Sequence sq)
@@ -193,10 +284,20 @@ internal sealed class GeneratorArrowLifter
 
     private Stmt RewriteFor(Stmt.For f)
     {
+        // The initializer is rewritten BEFORE the loop variables enter scope (a `for (let i = …)`
+        // initializer is in i's TDZ); the condition, increment, and body see them as block-scoped.
         var newInit = f.Initializer is null ? null : RewriteStmt(f.Initializer);
-        var newCond = f.Condition is null ? null : RewriteExpr(f.Condition);
-        var newIncr = f.Increment is null ? null : RewriteExpr(f.Increment);
-        var newBody = RewriteStmt(f.Body);
+        Expr? newCond;
+        Expr? newIncr;
+        Stmt newBody;
+        PushBlockScope(CollectForInitBindings(f.Initializer));
+        try
+        {
+            newCond = f.Condition is null ? null : RewriteExpr(f.Condition);
+            newIncr = f.Increment is null ? null : RewriteExpr(f.Increment);
+            newBody = RewriteStmt(f.Body);
+        }
+        finally { PopBlockScope(); }
         if ((f.Initializer is null || ReferenceEquals(newInit, f.Initializer))
             && (f.Condition is null || ReferenceEquals(newCond, f.Condition))
             && (f.Increment is null || ReferenceEquals(newIncr, f.Increment))
@@ -207,8 +308,13 @@ internal sealed class GeneratorArrowLifter
 
     private Stmt RewriteForOf(Stmt.ForOf fo)
     {
+        // The iterable is evaluated before the loop variable is bound, so it is rewritten outside the
+        // loop-variable scope; the body sees the loop variable as block-scoped (#678).
         var newIter = RewriteExpr(fo.Iterable);
-        var newBody = RewriteStmt(fo.Body);
+        Stmt newBody;
+        PushBlockScope(SingletonScope(fo.Variable.Lexeme));
+        try { newBody = RewriteStmt(fo.Body); }
+        finally { PopBlockScope(); }
         if (ReferenceEquals(newIter, fo.Iterable) && ReferenceEquals(newBody, fo.Body)) return fo;
         return fo with { Iterable = newIter, Body = newBody };
     }
@@ -216,7 +322,10 @@ internal sealed class GeneratorArrowLifter
     private Stmt RewriteForIn(Stmt.ForIn fi)
     {
         var newObj = RewriteExpr(fi.Object);
-        var newBody = RewriteStmt(fi.Body);
+        Stmt newBody;
+        PushBlockScope(SingletonScope(fi.Variable.Lexeme));
+        try { newBody = RewriteStmt(fi.Body); }
+        finally { PopBlockScope(); }
         if (ReferenceEquals(newObj, fi.Object) && ReferenceEquals(newBody, fi.Body)) return fi;
         return fi with { Object = newObj, Body = newBody };
     }
@@ -229,20 +338,27 @@ internal sealed class GeneratorArrowLifter
 
     private Stmt RewriteSwitch(Stmt.Switch sw)
     {
+        // The subject is evaluated outside the switch block; every case shares one lexical scope (#678).
         var newSubject = RewriteExpr(sw.Subject);
         List<Stmt.SwitchCase>? newCases = null;
-        for (int i = 0; i < sw.Cases.Count; i++)
+        List<Stmt>? newDefault;
+        PushBlockScope(CollectSwitchBindings(sw));
+        try
         {
-            var c = sw.Cases[i];
-            var newValue = RewriteExpr(c.Value);
-            var newBody = RewriteListIfChanged(c.Body, RewriteStmt);
-            if (!ReferenceEquals(newValue, c.Value) || !ReferenceEquals(newBody, c.Body))
+            for (int i = 0; i < sw.Cases.Count; i++)
             {
-                newCases ??= new List<Stmt.SwitchCase>(sw.Cases);
-                newCases[i] = new Stmt.SwitchCase(newValue, newBody);
+                var c = sw.Cases[i];
+                var newValue = RewriteExpr(c.Value);
+                var newBody = RewriteListIfChanged(c.Body, RewriteStmt);
+                if (!ReferenceEquals(newValue, c.Value) || !ReferenceEquals(newBody, c.Body))
+                {
+                    newCases ??= new List<Stmt.SwitchCase>(sw.Cases);
+                    newCases[i] = new Stmt.SwitchCase(newValue, newBody);
+                }
             }
+            newDefault = sw.DefaultBody is null ? null : RewriteListIfChanged(sw.DefaultBody, RewriteStmt);
         }
-        var newDefault = sw.DefaultBody is null ? null : RewriteListIfChanged(sw.DefaultBody, RewriteStmt);
+        finally { PopBlockScope(); }
         if (ReferenceEquals(newSubject, sw.Subject) && newCases is null
             && (sw.DefaultBody is null || ReferenceEquals(newDefault, sw.DefaultBody)))
             return sw;
@@ -251,14 +367,42 @@ internal sealed class GeneratorArrowLifter
 
     private Stmt RewriteTryCatch(Stmt.TryCatch tc)
     {
-        var newTry = RewriteListIfChanged(tc.TryBlock, RewriteStmt);
-        var newCatch = tc.CatchBlock is null ? null : RewriteListIfChanged(tc.CatchBlock, RewriteStmt);
-        var newFinally = tc.FinallyBlock is null ? null : RewriteListIfChanged(tc.FinallyBlock, RewriteStmt);
+        // The try/catch/finally blocks are each their own lexical scope; the catch block additionally
+        // binds the catch parameter (#678).
+        var newTry = RewriteBlockScoped(tc.TryBlock);
+
+        List<Stmt>? newCatch;
+        if (tc.CatchBlock is null)
+        {
+            newCatch = null;
+        }
+        else
+        {
+            var catchBindings = CollectBlockBindings(tc.CatchBlock);
+            HashSet<string> catchScope =
+                tc.CatchParam is null ? catchBindings
+                : catchBindings.Count == 0 ? SingletonScope(tc.CatchParam.Lexeme)
+                : new HashSet<string>(catchBindings, StringComparer.Ordinal) { tc.CatchParam.Lexeme };
+            PushBlockScope(catchScope);
+            try { newCatch = RewriteListIfChanged(tc.CatchBlock, RewriteStmt); }
+            finally { PopBlockScope(); }
+        }
+
+        var newFinally = tc.FinallyBlock is null ? null : RewriteBlockScoped(tc.FinallyBlock);
         if (ReferenceEquals(newTry, tc.TryBlock)
             && (tc.CatchBlock is null || ReferenceEquals(newCatch, tc.CatchBlock))
             && (tc.FinallyBlock is null || ReferenceEquals(newFinally, tc.FinallyBlock)))
             return tc;
         return tc with { TryBlock = newTry, CatchBlock = newCatch, FinallyBlock = newFinally };
+    }
+
+    /// <summary>Rewrites a statement list that forms its own block scope (a try/catch/finally block),
+    /// pushing the block's block-scoped bindings for the #678 capture analysis.</summary>
+    private List<Stmt> RewriteBlockScoped(List<Stmt> statements)
+    {
+        PushBlockScope(CollectBlockBindings(statements));
+        try { return RewriteListIfChanged(statements, RewriteStmt); }
+        finally { PopBlockScope(); }
     }
 
     private Stmt RewriteFunction(Stmt.Function f)
@@ -614,6 +758,29 @@ internal sealed class GeneratorArrowLifter
 
     private Expr LiftGeneratorArrow(Expr.ArrowFunction af)
     {
+        var freeVars = FreeVariableCollector.Collect(af);
+
+        // #678: a generator expression that closes over a block-scoped binding (loop variable, catch
+        // parameter, or a let/const/class declared in a nested block) cannot be lifted — the module
+        // body and every enclosing function body sit outside that block, so the lift would unbind the
+        // reference. Leave it in place as a generator EXPRESSION: the interpreter runs generator
+        // expressions natively and the type checker establishes the generator context directly. The
+        // body is still rewritten so any nested generator expressions inside it are handled, and its
+        // own name (if any) stays bound natively — no #679 self-binding rewrite is needed in place.
+        //
+        // ASYNC generator expressions are excluded: the interpreter's native arrow path does not yet
+        // build an async generator instance (EvaluateArrowFunction treats an async arrow as a plain
+        // async function), so an in-place async generator would be mishandled. They keep their prior
+        // lift behavior — a block-capturing async generator still reports "Undefined variable" (#734).
+        if (!af.IsAsync && CapturesBlockScopedBinding(freeVars))
+        {
+            var inPlaceBody = RewriteFunctionBody(af.Parameters, af.BlockBody!, selfName: af.Name?.Lexeme);
+            var inPlaceParams = RewriteParameters(af.Parameters);
+            return ReferenceEquals(inPlaceBody, af.BlockBody) && ReferenceEquals(inPlaceParams, af.Parameters)
+                ? af
+                : af with { BlockBody = inPlaceBody, Parameters = inPlaceParams };
+        }
+
         var name = $"__genArrow_{_counter++}";
         var nameToken = new Token(TokenType.IDENTIFIER, name, null, af.Parameters.FirstOrDefault()?.Name.Line ?? 1);
 
@@ -621,6 +788,21 @@ internal sealed class GeneratorArrowLifter
         // own function scope, so run it through the frame machinery too.
         var rewrittenBody = RewriteFunctionBody(af.Parameters, af.BlockBody!, selfName: af.Name?.Lexeme);
         var rewrittenParams = RewriteParameters(af.Parameters);
+
+        // #679: a NAMED generator function expression can reference itself by name for recursion
+        // (`const g = function* gen(n) { ... yield* gen(n - 1); }`). The lift renames the declaration to
+        // the synthetic __genArrow_N and discards af.Name, so without help the self-reference is unbound.
+        // Inject `const <name> = __genArrow_N;` at the top of the lifted body so the name resolves to the
+        // generator inside its own body (the lifted declaration hoists, so it is in scope there). Skipped
+        // when the name is shadowed by a parameter or a body-level declaration — there the inner binding
+        // wins (named-function-expression scoping), and injecting a const would be a duplicate declaration.
+        if (af.Name is not null && !IsSelfNameShadowed(af))
+        {
+            var selfBinding = new Stmt.Const(af.Name, TypeAnnotation: null, Initializer: new Expr.Variable(nameToken));
+            var withSelfBinding = new List<Stmt>(rewrittenBody.Count + 1) { selfBinding };
+            withSelfBinding.AddRange(rewrittenBody);
+            rewrittenBody = withSelfBinding;
+        }
 
         var funcStmt = new Stmt.Function(
             Name: nameToken,
@@ -638,7 +820,7 @@ internal sealed class GeneratorArrowLifter
         // over-approximates the BOUND set, so a free-variable name is only attributed to an
         // enclosing local when it truly escapes the generator body — never a false positive that
         // would relocate a module-closing generator into a function (which the compiler can't lower).
-        if (_frames.Count > 0 && ClosesOverEnclosingLocal(af))
+        if (_frames.Count > 0 && ClosesOverEnclosingLocal(freeVars))
         {
             _frames[^1].Lifted.Add(funcStmt);
         }
@@ -651,12 +833,25 @@ internal sealed class GeneratorArrowLifter
     }
 
     /// <summary>
+    /// True when a named function expression's own name is shadowed by a parameter or a body-level
+    /// var/let/const/function/class declaration. In that case the inner binding — not the function
+    /// itself — is what the name refers to inside the body (named-function-expression scoping), so the
+    /// #679 self-binding must NOT be injected (it would be a duplicate declaration). Nested-block
+    /// bindings do not shadow at the body level, so they are intentionally excluded.
+    /// </summary>
+    private static bool IsSelfNameShadowed(Expr.ArrowFunction af)
+    {
+        if (af.Name is null) return false;
+        var bodyBindings = LocalBindingCollector.Collect(af.Parameters, af.BlockBody!, selfName: null);
+        return bodyBindings.Contains(af.Name.Lexeme);
+    }
+
+    /// <summary>
     /// True when the generator arrow references a free variable that is bound as a local by one of
     /// the enclosing function scopes (so the lift must stay inside that scope, #534).
     /// </summary>
-    private bool ClosesOverEnclosingLocal(Expr.ArrowFunction af)
+    private bool ClosesOverEnclosingLocal(HashSet<string> freeVars)
     {
-        var freeVars = FreeVariableCollector.Collect(af);
         if (freeVars.Count == 0) return false;
         foreach (var frame in _frames)
         {

--- a/Runtime/Types/SharpTSGenerator.cs
+++ b/Runtime/Types/SharpTSGenerator.cs
@@ -44,18 +44,21 @@ internal readonly record struct GeneratorResume(GeneratorResumeKind Kind, object
 /// Runtime object representing an active generator instance.
 /// </summary>
 /// <remarks>
-/// Created by <see cref="SharpTSGeneratorFunction"/> when called.
-/// Uses thread-based coroutines for lazy evaluation — the generator body runs on a
-/// background thread and suspends at each yield point via synchronization primitives.
-/// This correctly handles infinite generators and lazy iteration.
+/// Created by <see cref="SharpTSGeneratorFunction"/> (generator declarations) and
+/// <see cref="SharpTSArrowGeneratorFunction"/> (generator function expressions) when called — both
+/// drive the same body-statement list, so a single generator type serves both. Uses thread-based
+/// coroutines for lazy evaluation — the generator body runs on a background thread and suspends at
+/// each yield point via synchronization primitives. This correctly handles infinite generators and
+/// lazy iteration.
 /// </remarks>
 /// <seealso cref="SharpTSGeneratorFunction"/>
+/// <seealso cref="SharpTSArrowGeneratorFunction"/>
 /// <seealso cref="SharpTSIteratorResult"/>
 public class SharpTSGenerator : IEnumerable<object?>, IDisposable, ITypeCategorized
 {
     /// <inheritdoc />
     public TypeCategory RuntimeCategory => TypeCategory.Generator;
-    private readonly Stmt.Function _declaration;
+    private readonly List<Stmt> _body;
     private readonly RuntimeEnvironment _environment;
     private readonly Interpreter _interpreter;
 
@@ -92,9 +95,9 @@ public class SharpTSGenerator : IEnumerable<object?>, IDisposable, ITypeCategori
     private RuntimeEnvironment? _callerEnv;
     private Func<object?, bool, object?>? _callerYieldCallback;
 
-    public SharpTSGenerator(Stmt.Function declaration, RuntimeEnvironment environment, Interpreter interpreter)
+    public SharpTSGenerator(List<Stmt> body, RuntimeEnvironment environment, Interpreter interpreter)
     {
-        _declaration = declaration;
+        _body = body;
         _environment = environment;
         _interpreter = interpreter;
     }
@@ -264,10 +267,10 @@ public class SharpTSGenerator : IEnumerable<object?>, IDisposable, ITypeCategori
 
         try
         {
-            if (_declaration.Body == null || _declaration.Body.Count == 0)
+            if (_body.Count == 0)
                 return;
 
-            var result = _interpreter.ExecuteBlock(_declaration.Body, _environment);
+            var result = _interpreter.ExecuteBlock(_body, _environment);
             if (result.Type == ExecutionResult.ResultType.Return)
             {
                 _returnValue = result.Value.ToObject();
@@ -329,8 +332,6 @@ public class SharpTSGenerator : IEnumerable<object?>, IDisposable, ITypeCategori
         {
             case SharpTSGenerator gen:
                 return DelegateToGenerator(gen.Next, gen.Return, gen.Throw, suspend, isClosed);
-            case SharpTSArrowGenerator agen:
-                return DelegateToGenerator(agen.Next, agen.Return, agen.Throw, suspend, isClosed);
             default:
                 // Non-generator iterables (arrays, Maps, custom iterator objects) are
                 // driven lazily via GetIterableElements, which calls next() without an
@@ -465,278 +466,6 @@ public class SharpTSGenerator : IEnumerable<object?>, IDisposable, ITypeCategori
         _closed = true;
         if (_state == State.Suspended)
             _callerReady.Set();
-        _callerReady.Dispose();
-        _workerReady.Dispose();
-        GC.SuppressFinalize(this);
-    }
-}
-
-/// <summary>
-/// Runtime object representing an active generator instance created from a function expression.
-/// </summary>
-/// <remarks>
-/// Similar to <see cref="SharpTSGenerator"/> but created from <see cref="Expr.ArrowFunction"/>
-/// with IsGenerator=true instead of <see cref="Stmt.Function"/>.
-/// Uses thread-based coroutines for lazy evaluation.
-/// </remarks>
-public class SharpTSArrowGenerator : IEnumerable<object?>, IDisposable
-{
-    private readonly Expr.ArrowFunction _declaration;
-    private readonly RuntimeEnvironment _environment;
-    private readonly Interpreter _interpreter;
-
-    // Coroutine synchronization
-    private Thread? _workerThread;
-    private readonly ManualResetEventSlim _callerReady = new(false);
-    private readonly ManualResetEventSlim _workerReady = new(false);
-
-    // State
-    private enum State { NotStarted, Suspended, Running, Completed }
-    private State _state = State.NotStarted;
-    private object? _yieldedValue;
-    // The generator's completion value. Defaults to undefined so a body that falls off the
-    // end (or a no-arg return()) reports { value: undefined, done: true }, not C# null.
-    private object? _returnValue = SharpTSUndefined.Instance;
-    // The value passed to the resuming next(v); becomes the result of the suspended
-    // yield (ECMA-262 §27.5.3.3). Defaults to undefined for implicit resumes.
-    private object? _sentValue = SharpTSUndefined.Instance;
-
-    // How the suspended yield is resumed (ECMA-262 §27.5.3.4): a plain next(v), or a
-    // return(v)/throw(e) that injects an abrupt completion so active try/finally blocks run.
-    private GeneratorResumeKind _resumeKind = GeneratorResumeKind.Next;
-    // Value carried by an abrupt resume: the return value for Return, the error for Throw.
-    private object? _injectedValue;
-
-    private bool _closed;
-    private Exception? _workerException;
-
-    private RuntimeEnvironment? _callerEnv;
-    private Func<object?, bool, object?>? _callerYieldCallback;
-
-    public SharpTSArrowGenerator(Expr.ArrowFunction declaration, RuntimeEnvironment environment, Interpreter interpreter)
-    {
-        _declaration = declaration;
-        _environment = environment;
-        _interpreter = interpreter;
-    }
-
-    /// <summary>
-    /// Rejects a re-entrant resume with a <c>TypeError</c> (ECMA-262 §27.5.3.3). See
-    /// <see cref="SharpTSGenerator.ThrowIfExecuting"/> — observing <see cref="State.Running"/>
-    /// from a guest call means the body is advancing itself, which would otherwise deadlock (#515).
-    /// </summary>
-    private void ThrowIfExecuting()
-    {
-        if (_state == State.Running)
-            throw new ThrowException(new SharpTSTypeError("Generator is already running"));
-    }
-
-    public SharpTSIteratorResult Next() => Next(SharpTSUndefined.Instance);
-
-    /// <summary>
-    /// Advances the generator, resuming the suspended <c>yield</c> with
-    /// <paramref name="sentValue"/> (ECMA-262 §27.5.3.3). Ignored on the first call.
-    /// </summary>
-    public SharpTSIteratorResult Next(object? sentValue)
-    {
-        ThrowIfExecuting();
-
-        // A finished/disposed generator delivers undefined; the completion value is reported
-        // only once, when the body finishes (ECMA-262 §27.5.3.3).
-        if (_closed || _state == State.Completed)
-            return new SharpTSIteratorResult(SharpTSUndefined.Instance, done: true);
-
-        _callerEnv = _interpreter.Environment;
-
-        if (_state == State.NotStarted)
-        {
-            _state = State.Running;
-            _workerThread = new Thread(RunBody) { IsBackground = true, Name = "ArrowGenerator" };
-            _workerThread.Start();
-        }
-        else
-        {
-            _resumeKind = GeneratorResumeKind.Next;
-            _sentValue = sentValue;
-            _state = State.Running;
-            _callerReady.Set();
-        }
-
-        return AwaitWorker();
-    }
-
-    /// <summary>
-    /// Resumes a suspended generator with a <c>return</c> abrupt completion, running active
-    /// <c>try</c>/<c>finally</c> blocks (ECMA-262 §27.5.3.4). See <see cref="SharpTSGenerator.Return"/>.
-    /// </summary>
-    public SharpTSIteratorResult Return(object? value = null)
-    {
-        ThrowIfExecuting();
-
-        if (_state == State.NotStarted)
-        {
-            _state = State.Completed;
-            return new SharpTSIteratorResult(value, done: true);
-        }
-
-        if (_closed || _state == State.Completed)
-            return new SharpTSIteratorResult(value, done: true);
-
-        _callerEnv = _interpreter.Environment;
-        _resumeKind = GeneratorResumeKind.Return;
-        _injectedValue = value;
-        _state = State.Running;
-        _callerReady.Set();
-
-        return AwaitWorker();
-    }
-
-    /// <summary>
-    /// Resumes a suspended generator with a <c>throw</c> abrupt completion, running active
-    /// <c>catch</c>/<c>finally</c> blocks (ECMA-262 §27.5.3.4). See <see cref="SharpTSGenerator.Throw"/>.
-    /// </summary>
-    public SharpTSIteratorResult Throw(object? error = null)
-    {
-        ThrowIfExecuting();
-
-        if (_state == State.NotStarted || _closed || _state == State.Completed)
-        {
-            _state = State.Completed;
-            throw ThrowException.FromResult(error);
-        }
-
-        _callerEnv = _interpreter.Environment;
-        _resumeKind = GeneratorResumeKind.Throw;
-        _injectedValue = error;
-        _state = State.Running;
-        _callerReady.Set();
-
-        return AwaitWorker();
-    }
-
-    /// <summary>
-    /// Blocks until the worker yields again or completes, rethrowing a worker exception or
-    /// building the iterator result. Shared by next/return/throw.
-    /// </summary>
-    private SharpTSIteratorResult AwaitWorker()
-    {
-        _workerReady.Wait();
-        _workerReady.Reset();
-
-        if (_workerException != null)
-        {
-            var ex = _workerException;
-            _workerException = null;
-            _state = State.Completed;
-            ExceptionDispatchInfo.Capture(ex).Throw();
-        }
-
-        if (_state == State.Completed)
-            return new SharpTSIteratorResult(_returnValue, done: true);
-
-        return new SharpTSIteratorResult(_yieldedValue, done: false);
-    }
-
-    private void RunBody()
-    {
-        RuntimeEnvironment previousEnv = _interpreter.Environment;
-        _interpreter.SetEnvironment(_environment);
-
-        _callerYieldCallback = _interpreter.YieldCallback;
-        _interpreter.YieldCallback = HandleYieldCallback;
-
-        try
-        {
-            if (_declaration.ExpressionBody != null)
-            {
-                _returnValue = _interpreter.Evaluate(_declaration.ExpressionBody);
-            }
-            else if (_declaration.BlockBody != null && _declaration.BlockBody.Count > 0)
-            {
-                var result = _interpreter.ExecuteBlock(_declaration.BlockBody, _environment);
-                if (result.Type == ExecutionResult.ResultType.Return)
-                {
-                    _returnValue = result.Value.ToObject();
-                }
-                else if (result.Type == ExecutionResult.ResultType.Throw)
-                {
-                    // An uncaught guest throw — from the body or an unhandled throw(e)
-                    // injection — propagates to the resuming next()/throw() caller.
-                    _workerException = ThrowException.FromResult(result.Value.ToObject());
-                }
-            }
-        }
-        catch (Exception ex) when (ex is not ThreadInterruptedException)
-        {
-            _workerException = ex;
-        }
-        finally
-        {
-            _interpreter.YieldCallback = _callerYieldCallback;
-            _interpreter.SetEnvironment(previousEnv);
-            _state = State.Completed;
-            _workerReady.Set();
-        }
-    }
-
-    private object? HandleYieldCallback(object? value, bool isDelegating)
-    {
-        if (isDelegating)
-        {
-            return SharpTSGenerator.DelegateYieldStar(_interpreter, value, v => SuspendCore(v), () => _closed);
-        }
-        // A plain `yield`: realize an abrupt resume (return/throw) as the control-flow exception
-        // that unwinds the outer body's own try/finally blocks (ECMA-262 §27.5.3.4).
-        return SuspendCore(value).Realize();
-    }
-
-    private GeneratorResume SuspendCore(object? value)
-    {
-        _yieldedValue = value;
-        _state = State.Suspended;
-
-        // Save generator state, restore caller state
-        var generatorEnv = _interpreter.Environment;
-        _interpreter.SetEnvironment(_callerEnv!);
-        _interpreter.YieldCallback = _callerYieldCallback;
-
-        _workerReady.Set();
-        _callerReady.Wait();
-        _callerReady.Reset();
-
-        // Save caller state (may have changed), restore generator state
-        _callerEnv = _interpreter.Environment;
-        _callerYieldCallback = _interpreter.YieldCallback;
-        _interpreter.SetEnvironment(generatorEnv);
-        _interpreter.YieldCallback = HandleYieldCallback;
-
-        // Read the resume completion requested by next(v)/return(v)/throw(e). Consume the
-        // resume kind so a later non-setting wake (e.g. Dispose) resumes normally.
-        var kind = _resumeKind;
-        var injected = _injectedValue;
-        _resumeKind = GeneratorResumeKind.Next;
-        _injectedValue = null;
-        return new GeneratorResume(kind, kind == GeneratorResumeKind.Next ? _sentValue : injected);
-    }
-
-    public IEnumerator<object?> GetEnumerator()
-    {
-        while (true)
-        {
-            var result = Next();
-            if (result.Done) yield break;
-            yield return result.Value;
-        }
-    }
-
-    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
-
-    public override string ToString() => "[object Generator]";
-
-    public void Dispose()
-    {
-        _closed = true;
-        if (_state == State.Suspended) _callerReady.Set();
         _callerReady.Dispose();
         _workerReady.Dispose();
         GC.SuppressFinalize(this);

--- a/Runtime/Types/SharpTSGeneratorFunction.cs
+++ b/Runtime/Types/SharpTSGeneratorFunction.cs
@@ -39,7 +39,7 @@ public class SharpTSGeneratorFunction : ISharpTSCallable
         ParameterBinder.Bind(_declaration.Parameters, arguments, environment, interpreter);
 
         // Return a generator that will execute the body lazily
-        return new SharpTSGenerator(_declaration, environment, interpreter);
+        return new SharpTSGenerator(_declaration.Body ?? [], environment, interpreter);
     }
 
     /// <summary>
@@ -106,7 +106,12 @@ public class SharpTSArrowGeneratorFunction : ISharpTSCallable
         }
         ParameterBinder.Bind(_declaration.Parameters, arguments, environment, interpreter);
 
-        return new SharpTSArrowGenerator(_declaration, environment, interpreter);
+        // A generator function expression drives the same SharpTSGenerator as a declaration — only the
+        // block body and the captured environment differ. Generator expressions always have a block
+        // body (the parser never produces an expression-bodied generator). This native path runs the
+        // generator expressions the GeneratorArrowLifter leaves in place because they close over a
+        // block-scoped binding (#678); all others are lifted to declarations.
+        return new SharpTSGenerator(_declaration.BlockBody ?? [], environment, interpreter);
     }
 
     /// <summary>

--- a/SharpTS.Tests/SharedTests/GeneratorTests.cs
+++ b/SharpTS.Tests/SharedTests/GeneratorTests.cs
@@ -1,3 +1,4 @@
+using SharpTS.Diagnostics.Exceptions;
 using SharpTS.Tests.Infrastructure;
 using Xunit;
 
@@ -1427,8 +1428,8 @@ public class GeneratorTests
     public void GeneratorExpression_InsideForOf(ExecutionMode mode)
     {
         // The generator yields a constant (not the loop variable): #634 is about the lifter reaching
-        // the for-of body, not closure capture. Capturing the block-scoped loop variable is a
-        // separate, unsupported case (the lift would move the body outside the loop's scope).
+        // the for-of body, not closure capture. Capturing the block-scoped loop variable is handled
+        // separately (#678) — see the "closes over a block-scoped binding" region below.
         var source = """
             for (const n of [10, 20]) {
               const g = function* () { yield 1; };
@@ -1602,6 +1603,273 @@ public class GeneratorTests
 
     #endregion
 
+    #region Generator function EXPRESSION closing over a BLOCK-scoped binding — issue #678
+
+    // A generator expression that closes over a block-scoped binding (a for/for-of/for-in loop
+    // variable, a catch parameter, or a let/const declared in a nested block or switch body) cannot be
+    // lifted to a top-level declaration — the lift target sits outside that block, so the captured name
+    // would be out of scope. The GeneratorArrowLifter leaves it in place as an expression; the
+    // interpreter runs it natively (SharpTSGenerator) and the type checker establishes the generator
+    // context directly. These run interpreted-only: the compiler has no generator-expression IL path
+    // for a capturing generator and reports a clear "Yield not supported in this context" error (the
+    // same as #534's enclosing-function-local capture; asserted by the *_CompiledRejectsClearly test).
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void GeneratorExpression_CapturesForOfLoopVariable(ExecutionMode mode)
+    {
+        // The exact repro from issue #678.
+        var source = """
+            for (const n of [10, 20]) {
+              const g = function* () { yield n; };
+              console.log(g().next().value);
+            }
+            """;
+
+        Assert.Equal("10\n20\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void GeneratorExpression_CapturesNestedBlockLet(ExecutionMode mode)
+    {
+        // The second repro from issue #678: a let in a nested block within a function.
+        var source = """
+            function outer() {
+              {
+                let y = 5;
+                const g = function* () { yield y; };
+                return [...g()];
+              }
+            }
+            console.log(outer());
+            """;
+
+        Assert.Equal("[5]\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void GeneratorExpression_CapturesForLetLoopVariable(ExecutionMode mode)
+    {
+        var source = """
+            for (let k = 1; k <= 2; k++) {
+              const g = function* () { yield k * 10; };
+              console.log(g().next().value);
+            }
+            """;
+
+        Assert.Equal("10\n20\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void GeneratorExpression_CapturesForInKey(ExecutionMode mode)
+    {
+        var source = """
+            const obj = { a: 1, b: 2 };
+            for (const key in obj) {
+              const g = function* () { yield key; };
+              console.log(g().next().value);
+            }
+            """;
+
+        Assert.Equal("a\nb\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void GeneratorExpression_CapturesCatchParameter(ExecutionMode mode)
+    {
+        var source = """
+            try {
+              throw "boom";
+            } catch (e) {
+              const g = function* () { yield e; };
+              console.log(g().next().value);
+            }
+            """;
+
+        Assert.Equal("boom\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void GeneratorExpression_CapturesSwitchCaseBinding(ExecutionMode mode)
+    {
+        var source = """
+            switch (1) {
+              case 1: {
+                const local = 99;
+                const g = function* () { yield local; };
+                console.log(g().next().value);
+                break;
+              }
+            }
+            """;
+
+        Assert.Equal("99\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void GeneratorExpression_LoopVariableCapturedPerIteration(ExecutionMode mode)
+    {
+        // Each iteration's for-of binding is distinct, so a generator created in one iteration captures
+        // that iteration's value — not the last one. Confirms the in-place generator closes over the
+        // per-iteration binding (it is not hoisted to a single shared slot).
+        var source = """
+            const gens: (() => Generator<number>)[] = [];
+            for (const n of [1, 2, 3]) {
+              gens.push(function* () { yield n; });
+            }
+            console.log(gens.map(g => g().next().value).join(","));
+            """;
+
+        Assert.Equal("1,2,3\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void GeneratorExpression_CapturesBlockScopedAndModuleScoped(ExecutionMode mode)
+    {
+        // A capture mixing a block-scoped loop variable with a module-scoped const still works: the
+        // presence of a block-scoped capture keeps the generator in place, and the module binding
+        // remains visible via the closure.
+        var source = """
+            const factor = 100;
+            for (const n of [2]) {
+              const g = function* () { yield n * factor; };
+              console.log(g().next().value);
+            }
+            """;
+
+        Assert.Equal("200\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void GeneratorExpression_NamedSelfRecursionCapturingLoopVariable(ExecutionMode mode)
+    {
+        // #678 + #679 together: a NAMED generator expression that both closes over a loop variable and
+        // recurses by its own name. The in-place native path binds the self-name in the call scope.
+        var source = """
+            for (const base of [10]) {
+              const g = function* count(n: number): Generator<number> {
+                if (n > 0) { yield base + n; yield* count(n - 1); }
+              };
+              console.log([...g(2)].join(","));
+            }
+            """;
+
+        Assert.Equal("12,11\n", TestHarness.Run(source, mode));
+    }
+
+    [Fact]
+    public void GeneratorExpression_BlockScopedCapture_CompiledRejectsClearly()
+    {
+        // The compiler has no generator-expression IL path for a generator that closes over a
+        // block-scoped binding (it cannot be lifted, and nested-generator lowering is incomplete,
+        // #501). It must FAIL FAST with a clear message rather than crash or silently misbehave —
+        // matching #534's enclosing-function-local capture.
+        var source = """
+            for (const n of [1, 2]) {
+              const g = function* () { yield n; };
+              console.log(g().next().value);
+            }
+            """;
+
+        var ex = Assert.Throws<CompileException>(() => TestHarness.RunCompiled(source));
+        Assert.Contains("Yield not supported", ex.Message);
+    }
+
+    #endregion
+
+    #region Named generator function EXPRESSION self-reference — issue #679
+
+    // A NAMED generator function expression can call itself by its own name for recursion. The
+    // GeneratorArrowLifter renames the lifted declaration to the synthetic __genArrow_N and discards
+    // the original name, so it injects `const <name> = __genArrow_N;` at the top of the body to keep
+    // the self-reference bound (skipped when a parameter or body-level binding shadows the name).
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void GeneratorExpression_NamedSelfRecursion(ExecutionMode mode)
+    {
+        // The exact repro from issue #679.
+        var source = """
+            const g = function* countdown(n: number): Generator<number> {
+              if (n > 0) { yield n; yield* countdown(n - 1); }
+            };
+            console.log([...g(3)]);
+            """;
+
+        Assert.Equal("[3, 2, 1]\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void GeneratorExpression_NamedSelfRecursion_ClosesOverModuleConst(ExecutionMode mode)
+    {
+        // Self-reference plus a capture of a module-scope binding: both must resolve.
+        var source = """
+            const step = 1;
+            const g = function* down(n: number): Generator<number> {
+              if (n > 0) { yield n; yield* down(n - step); }
+            };
+            console.log([...g(3)]);
+            """;
+
+        Assert.Equal("[3, 2, 1]\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void GeneratorExpression_NamedSelfReference_ParameterShadowsName(ExecutionMode mode)
+    {
+        // A parameter named the same as the function expression shadows the self-name (the self-binding
+        // must NOT be injected): `foo` refers to the parameter inside the body.
+        var source = """
+            const a = function* foo(foo: number) { yield foo; yield foo + 1; };
+            console.log([...a(10)]);
+            """;
+
+        Assert.Equal("[10, 11]\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void GeneratorExpression_NamedSelfReference_BodyLetShadowsName(ExecutionMode mode)
+    {
+        // A body-level `let` of the same name shadows the self-name (no self-binding injected).
+        var source = """
+            const b = function* bar() { let bar = 7; yield bar; };
+            console.log([...b()]);
+            """;
+
+        Assert.Equal("[7]\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void GeneratorExpression_NamedSelfReference_NestedBlockDoesNotShadow(ExecutionMode mode)
+    {
+        // A nested-block binding of the same name shadows only within that block, so the outer
+        // self-call still resolves to the function. Interpreted-only: compiled generators do not yet
+        // give a nested-block redeclaration its own slot, so the inner `rec` leaks (tracked by #711).
+        var source = """
+            const d = function* rec(n: number): Generator<number> {
+              { const rec = 0; if (n < -100) yield rec; }
+              if (n > 0) { yield n; yield* rec(n - 1); }
+            };
+            console.log([...d(2)]);
+            """;
+
+        Assert.Equal("[2, 1]\n", TestHarness.Run(source, mode));
+    }
+
+    #endregion
+
     #region Re-entrant next()/return()/throw() — "already running" (ECMA-262 §27.5.3.3) — issues #515, #521
 
     // ECMA-262 §27.5.3.3 (GeneratorValidate): calling next/return/throw on a generator whose state
@@ -1732,19 +2000,22 @@ public class GeneratorTests
     [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
     public void GeneratorExpression_ReentrantNext_ThrowsTypeError(ExecutionMode mode)
     {
-        // A generator function *expression* uses a distinct runtime class (SharpTSArrowGenerator);
-        // its guard is exercised here. `var` (not `let`) sidesteps an unrelated type-checker scoping
-        // bug for generator function expressions that close over block-scoped variables.
+        // A generator function *expression* that closes over a block-scoped binding stays in place and
+        // runs natively (it is NOT lifted to a declaration, #678); it produces a SharpTSGenerator like
+        // any other generator, so the re-entrancy guard (ECMA-262 §27.5.3.3) applies. The `let it`
+        // capture forces the in-place native path.
         var source = """
-            var it: any;
-            const g = function*() {
-                try { it.next(); }
-                catch (e: any) { console.log("expr ->", e.message); }
-                yield 7;
-            };
-            it = g();
-            const r = it.next();
-            console.log(r.value, r.done);
+            {
+                let it: any;
+                const g = function*() {
+                    try { it.next(); }
+                    catch (e: any) { console.log("expr ->", e.message); }
+                    yield 7;
+                };
+                it = g();
+                const r = it.next();
+                console.log(r.value, r.done);
+            }
             """;
 
         var output = TestHarness.Run(source, mode);

--- a/TypeSystem/TypeChecker.Expressions.cs
+++ b/TypeSystem/TypeChecker.Expressions.cs
@@ -1379,6 +1379,8 @@ public partial class TypeChecker
         var previousInferredArrow = _inferredReturnTypes;
         TypeInfo? previousThisType = _currentFunctionThisType;
         bool previousInAsync = _inAsyncFunction;
+        bool previousInGenerator = _inGeneratorFunction;
+        var previousInferredYieldTypes = _inferredYieldTypes;
         int previousLoopDepth = _loopDepth;
         int previousSwitchDepth = _switchDepth;
         var previousActiveLabels = new Dictionary<string, bool>(_activeLabels);
@@ -1396,6 +1398,15 @@ public partial class TypeChecker
         }
         _currentFunctionThisType = thisType;
         _inAsyncFunction = arrow.IsAsync;
+        // A generator function EXPRESSION establishes its own generator context so `yield` is valid in
+        // its body and its element type is inferred from the yields. Reached only for generator arrows
+        // the GeneratorArrowLifter intentionally leaves in place — i.e. those closing over a block-scoped
+        // binding (#678); all other generator expressions are lifted to declarations before type-check.
+        _inGeneratorFunction = arrow.IsGenerator;
+        // Collect yield operand types only while inferring a generator's type (mirrors the declaration
+        // path, #548). Null otherwise so a nested explicitly-typed generator's yields cannot leak into an
+        // enclosing inferred one.
+        _inferredYieldTypes = inferringArrowReturn && arrow.IsGenerator ? new List<TypeInfo>() : null;
         _loopDepth = 0;
         _switchDepth = 0;
         _activeLabels.Clear();
@@ -1462,7 +1473,13 @@ public partial class TypeChecker
                     var collected = _inferredReturnTypes!;
                     _inferredReturnTypes = null;
 
-                    if (collected.Count == 0)
+                    if (arrow.IsGenerator)
+                    {
+                        // A generator's element type is its YIELD type (#548), not the return-derived
+                        // type; build Generator<Y> (or AsyncGenerator<Y> for an async generator).
+                        returnType = BuildInferredGeneratorType(_inferredYieldTypes!, arrow.IsAsync);
+                    }
+                    else if (collected.Count == 0)
                     {
                         returnType = new TypeInfo.Void();
                     }
@@ -1472,7 +1489,7 @@ public partial class TypeChecker
                         returnType = CollapseOrCreateUnion(distinct);
                     }
 
-                    if (arrow.IsAsync && returnType is not TypeInfo.Void)
+                    if (arrow.IsAsync && !arrow.IsGenerator && returnType is not TypeInfo.Void)
                         returnType = new TypeInfo.Promise(returnType);
                 }
             }
@@ -1484,6 +1501,8 @@ public partial class TypeChecker
             _inferredReturnTypes = previousInferredArrow;
             _currentFunctionThisType = previousThisType;
             _inAsyncFunction = previousInAsync;
+            _inGeneratorFunction = previousInGenerator;
+            _inferredYieldTypes = previousInferredYieldTypes;
             _loopDepth = previousLoopDepth;
             _switchDepth = previousSwitchDepth;
             _activeLabels.Clear();


### PR DESCRIPTION
## Summary

Completes #634, #678, and #679 (generator function *expressions* — `function*() {}` — handled by `GeneratorArrowLifter`).

- **#634** (lifter traversal into for/for-of/for-in/do-while/try/switch/labeled bodies) was already fixed by `15b396c6`; verified by the existing per-statement-kind tests and **closed** separately.
- **#679** — a *named* generator expression (`const g = function* gen() { ... yield* gen(n-1); }`) lost its self-reference because the lift renamed it to `__genArrow_N` and discarded the name. Now injects `const <name> = __genArrow_N;` at the top of the lifted body (skipped when a parameter or body-level declaration shadows the name).
- **#678** — a generator expression closing over a **block-scoped** binding (loop variable, catch parameter, or a `let`/`const`/`class` in a nested block / switch body) cannot be lifted out of that block. The lifter now tracks block scopes and leaves such **sync** generators in place as expressions; `TypeChecker.CheckArrowFunction` establishes the generator context (mirroring the declaration path), and the interpreter runs them natively.

## Notable change: `SharpTSArrowGenerator` consolidation

The interpreter already had a native generator-expression runtime (`SharpTSArrowGenerator`), but it was effectively dead code (everything was lifted) and incompletely integrated — it never implemented `ITypeCategorized`, and the generator built-ins only recognized `SharpTSGenerator`, so `.next()` property access failed (`Only instances and objects have properties`) even though spread worked. Rather than patch the duplication, `SharpTSGenerator` is refactored to take the body statement list (all it ever used), both generator-function classes now produce it, and `SharpTSArrowGenerator` is deleted (~270 lines removed).

## Scope / follow-ups

- The compiler has no generator-expression IL path for a capturing generator, so it reports a clear `Yield not supported in this context` error — consistent with #534/#501 (asserted by a fail-fast test).
- **Async** generator expressions keep their prior lift behavior (the interpreter's native arrow path doesn't yet build an async generator instance); a block-capturing async generator is tracked by #734.
- `CheckArrowFunction` now also correctly rejects `yield` in a non-generator arrow nested inside a generator (previously the enclosing generator context leaked in).

Found and filed along the way: #711 (compiled generator nested-block `const`/`let` shadow leak), #712 (`void` operator unimplemented in compiled generator bodies), #734 (async generator expression block-capture).

## Testing

- 19 new regression tests (10 for #678, 9 for #679) + a compiled fail-fast assertion, in `GeneratorTests.cs`.
- Full suite: **12,853 passed, 0 failed, 0 skipped**.
- TypeScript conformance: 31 passed. Test262: verified conformance-neutral (interpreted baseline drift is pre-existing and identical with/without this change).

Closes #678
Closes #679