### PR TITLE
Fix #676 / #701: member read on null/undefined throws a guest TypeError

### DIFF
--- a/Compilation/ExpressionEmitterBase.CallHelpers.cs
+++ b/Compilation/ExpressionEmitterBase.CallHelpers.cs
@@ -440,6 +440,66 @@ public abstract partial class ExpressionEmitterBase
     }
 
     /// <summary>
+    /// ECMA-262 RequireObjectCoercible for a NON-optional member READ (<c>o.x</c>):
+    /// with the boxed receiver on top of the stack, throws a guest <c>TypeError</c>
+    /// ("Cannot read properties of undefined (reading '<paramref name="propertyName"/>')")
+    /// when it is <c>$Undefined</c>, leaving the receiver on the stack otherwise.
+    /// The read-expression analog of <see cref="EmitThrowIfReceiverUndefined"/> (the
+    /// method-call-callee guard) and the compiled counterpart of the interpreter's
+    /// guard — like the call-callee guard, a bare CLR <c>null</c> is left coercible
+    /// because compiled sloppy-mode <c>this</c> is represented as <c>null</c>
+    /// (= globalThis). Fixes #701, where <c>undefined.x</c> silently yielded
+    /// <c>undefined</c> instead of throwing. Callers MUST short-circuit the
+    /// optional-chain case (<c>o?.x</c>) before calling this.
+    /// </summary>
+    protected void EmitThrowIfUndefinedReceiverOnStack(string propertyName)
+    {
+        var okLabel = IL.DefineLabel();
+
+        IL.Emit(OpCodes.Dup);
+        IL.Emit(OpCodes.Isinst, Ctx.Runtime!.UndefinedType);
+        IL.Emit(OpCodes.Brfalse, okLabel);               // not $Undefined → ok
+
+        IL.Emit(OpCodes.Ldstr, $"Cannot read properties of undefined (reading '{propertyName}')");
+        IL.Emit(OpCodes.Newobj, Ctx.Runtime!.TSTypeErrorCtor);
+        IL.Emit(OpCodes.Call, Ctx.Runtime!.CreateException);
+        IL.Emit(OpCodes.Throw);
+
+        IL.MarkLabel(okLabel);
+    }
+
+    /// <summary>
+    /// Bracket-access (<c>o[k]</c>) counterpart of
+    /// <see cref="EmitThrowIfUndefinedReceiverOnStack"/>: throws a guest
+    /// <c>TypeError</c> when <paramref name="objLocal"/> holds <c>$Undefined</c>,
+    /// splicing the runtime key (<paramref name="keyLocal"/>, a boxed
+    /// <see cref="object"/>) into the message to match Node ("Cannot read
+    /// properties of undefined (reading '&lt;key&gt;')"). Leaves the stack
+    /// untouched. Callers MUST short-circuit the optional-chain case first. (#701)
+    /// </summary>
+    protected void EmitThrowIfUndefinedIndexReceiver(LocalBuilder objLocal, LocalBuilder keyLocal)
+    {
+        var okLabel = IL.DefineLabel();
+
+        IL.Emit(OpCodes.Ldloc, objLocal);
+        IL.Emit(OpCodes.Isinst, Ctx.Runtime!.UndefinedType);
+        IL.Emit(OpCodes.Brfalse, okLabel);               // not $Undefined → ok
+
+        // "Cannot read properties of undefined (reading '" + key + "')"
+        // Concat(object, object) is null-safe (a null key stringifies to "").
+        IL.Emit(OpCodes.Ldstr, "Cannot read properties of undefined (reading '");
+        IL.Emit(OpCodes.Ldloc, keyLocal);
+        IL.Emit(OpCodes.Call, Types.StringConcatObjectObject);
+        IL.Emit(OpCodes.Ldstr, "')");
+        IL.Emit(OpCodes.Call, Types.StringConcat2);
+        IL.Emit(OpCodes.Newobj, Ctx.Runtime!.TSTypeErrorCtor);
+        IL.Emit(OpCodes.Call, Ctx.Runtime!.CreateException);
+        IL.Emit(OpCodes.Throw);
+
+        IL.MarkLabel(okLabel);
+    }
+
+    /// <summary>
     /// Builds an <c>object[]</c> of the boxed call arguments on the stack. Stack: [] -&gt; [object[]].
     /// When <paramref name="argLocals"/> is non-null each element is loaded from those pre-spilled,
     /// already-boxed locals (await-safe: the arguments were evaluated and spilled by the caller, so

--- a/Compilation/ExpressionEmitterBase.cs
+++ b/Compilation/ExpressionEmitterBase.cs
@@ -503,6 +503,9 @@ public abstract partial class ExpressionEmitterBase : IEmitterContext
         else
         {
             var idxLocal = SpillBoxed(gi.Index);
+            // RequireObjectCoercible: `undefined[k]` throws a guest TypeError instead
+            // of silently yielding undefined (#701). Optional `o?.[k]` short-circuited above.
+            EmitThrowIfUndefinedIndexReceiver(objLocal, idxLocal);
             IL.Emit(OpCodes.Ldloc, objLocal);
             IL.Emit(OpCodes.Ldloc, idxLocal);
             IL.Emit(OpCodes.Call, Ctx.Runtime!.GetIndex);
@@ -2268,8 +2271,36 @@ public abstract partial class ExpressionEmitterBase : IEmitterContext
         // Dynamic property access fallback
         EmitExpression(g.Object);
         EnsureBoxed();
-        IL.Emit(OpCodes.Ldstr, g.Name.Lexeme);
-        IL.Emit(OpCodes.Call, Ctx.Runtime!.GetProperty);
+        if (g.Optional)
+        {
+            // `o?.x`: short-circuit to undefined when the base is nullish. This base
+            // emitter (used by the async/generator state-machine emitters) previously
+            // leaned on GetProperty's leniency for a nullish base; the explicit
+            // short-circuit is required now that the non-optional path throws on
+            // $Undefined below, and is otherwise behaviour-preserving.
+            var nullishLabel = IL.DefineLabel();
+            var endLabel = IL.DefineLabel();
+            IL.Emit(OpCodes.Dup);
+            IL.Emit(OpCodes.Brfalse, nullishLabel);          // CLR null → nullish
+            IL.Emit(OpCodes.Dup);
+            IL.Emit(OpCodes.Isinst, Ctx.Runtime!.UndefinedType);
+            IL.Emit(OpCodes.Brtrue, nullishLabel);           // $Undefined → nullish
+            IL.Emit(OpCodes.Ldstr, g.Name.Lexeme);
+            IL.Emit(OpCodes.Call, Ctx.Runtime!.GetProperty);
+            IL.Emit(OpCodes.Br, endLabel);
+            IL.MarkLabel(nullishLabel);
+            IL.Emit(OpCodes.Pop);
+            IL.Emit(OpCodes.Ldsfld, Ctx.Runtime!.UndefinedInstance);
+            IL.MarkLabel(endLabel);
+        }
+        else
+        {
+            // RequireObjectCoercible: a non-optional read on `undefined` throws a
+            // guest TypeError instead of silently yielding undefined (#701).
+            EmitThrowIfUndefinedReceiverOnStack(g.Name.Lexeme);
+            IL.Emit(OpCodes.Ldstr, g.Name.Lexeme);
+            IL.Emit(OpCodes.Call, Ctx.Runtime!.GetProperty);
+        }
         SetStackUnknown();
     }
 

--- a/Compilation/ILCompiler.Classes.HasFields.cs
+++ b/Compilation/ILCompiler.Classes.HasFields.cs
@@ -220,6 +220,33 @@ public partial class ILCompiler
         il.MarkLabel(skipLabel);
     }
 
+    /// <summary>
+    /// Emits the <c>instance.constructor</c> branch for a class's GetProperty body:
+    /// when the requested name is "constructor", returns the class itself,
+    /// represented — like a bare class identifier in value position
+    /// (see <see cref="ExpressionEmitterBase"/>'s class-token path) — as the
+    /// class's <see cref="System.Type"/>. This makes <c>x.constructor === MyClass</c>
+    /// and <c>x.constructor.staticMember</c> behave as in the interpreter (where an
+    /// instance's <c>constructor</c> resolves to its class). Without it, compiled
+    /// <c>instance.constructor</c> silently returned <c>undefined</c>; benign while
+    /// member reads were lenient, but #701 (a read on <c>undefined</c> now throws)
+    /// surfaced it (e.g. the <c>yaml</c> package reads <c>coll.constructor.tagName</c>).
+    /// Emitted after the own-field lookups so an own data property named
+    /// "constructor" still shadows it, matching JS.
+    /// </summary>
+    private void EmitConstructorPropertyBranch(ILGenerator il, Type classType)
+    {
+        var notCtorLabel = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Ldstr, "constructor");
+        il.Emit(OpCodes.Call, _types.GetMethod(_types.String, "op_Equality", _types.String, _types.String));
+        il.Emit(OpCodes.Brfalse, notCtorLabel);
+        il.Emit(OpCodes.Ldtoken, classType);
+        il.Emit(OpCodes.Call, _types.GetMethod(_types.Type, "GetTypeFromHandle", _types.RuntimeTypeHandle));
+        il.Emit(OpCodes.Ret);
+        il.MarkLabel(notCtorLabel);
+    }
+
     private void EmitGetPropertyBody(MethodBuilder method, string className, Stmt.Class classStmt, FieldInfo fieldsField)
     {
         var il = method.GetILGenerator();
@@ -274,6 +301,10 @@ public partial class ILCompiler
             EmitErrorPropertyFallback(il, "message", _runtime.ErrorGetMessage);
             EmitErrorPropertyFallback(il, "stack", _runtime.ErrorGetStack);
         }
+
+        // 2d. `instance.constructor` → the class (a System.Type value). See
+        // EmitConstructorPropertyBranch; after own fields so they can shadow it.
+        EmitConstructorPropertyBranch(il, _classes.Builders[className]);
 
         // 2c. Check instance getters (accessors with `get` keyword). JS semantics: reading
         // `obj.foo` where `foo` is a getter must INVOKE the getter and return its result.
@@ -595,6 +626,11 @@ public partial class ILCompiler
         // backing-field names are already handled (and returned) by section 1, so those entries
         // become dead branches here — matching the class-declaration registry's behavior.
         il.MarkLabel(tryMethodsLabel);
+
+        // 2d. `instance.constructor` → the class (a System.Type value). See
+        // EmitConstructorPropertyBranch; after own fields so they can shadow it.
+        EmitConstructorPropertyBranch(il, _classExprs.Builders[classExpr]);
+
         if (_classExprs.Getters.TryGetValue(classExpr, out var instanceGetters))
         {
             foreach (var (getterPascalName, getterMethod) in instanceGetters)

--- a/Compilation/ILEmitter.Properties.cs
+++ b/Compilation/ILEmitter.Properties.cs
@@ -320,6 +320,9 @@ public partial class ILEmitter
         }
         else
         {
+            // RequireObjectCoercible: a non-optional read on `undefined` throws a
+            // guest TypeError instead of silently yielding undefined (#701).
+            EmitThrowIfUndefinedReceiverOnStack(g.Name.Lexeme);
             IL.Emit(OpCodes.Ldstr, g.Name.Lexeme);
             IL.Emit(OpCodes.Call, _ctx.Runtime!.GetProperty);
         }
@@ -832,10 +835,15 @@ public partial class ILEmitter
             return;
         }
 
-        EmitExpression(gi.Object);
-        EmitBoxIfNeeded(gi.Object);
-        EmitExpression(gi.Index);
-        EmitBoxIfNeeded(gi.Index);
+        // Generic (non-array) dynamic bracket read. Spill both operands so the
+        // RequireObjectCoercible guard can inspect the receiver and splice the key
+        // into the TypeError message: `undefined[k]` throws instead of silently
+        // yielding undefined (#701). The optional `o?.[k]` case returned early above.
+        var idxRecvLocal = SpillBoxed(gi.Object);
+        var idxKeyLocal = SpillBoxed(gi.Index);
+        EmitThrowIfUndefinedIndexReceiver(idxRecvLocal, idxKeyLocal);
+        IL.Emit(OpCodes.Ldloc, idxRecvLocal);
+        IL.Emit(OpCodes.Ldloc, idxKeyLocal);
         IL.Emit(OpCodes.Call, _ctx.Runtime!.GetIndex);
     }
 

--- a/Compilation/TypeProvider.cs
+++ b/Compilation/TypeProvider.cs
@@ -533,6 +533,16 @@ public class TypeProvider
     public MethodInfo StringConcat2 =>
         _stringConcat2 ??= GetMethod(String, "Concat", String, String);
 
+    private MethodInfo? _stringConcatObjObj;
+
+    /// <summary>
+    /// Gets the string.Concat(object, object) method. Null-safe (a null arg
+    /// stringifies to ""); used to splice a runtime value into a diagnostic
+    /// message without risking an NRE on ToString.
+    /// </summary>
+    public MethodInfo StringConcatObjectObject =>
+        _stringConcatObjObj ??= GetMethod(String, "Concat", Object, Object);
+
     /// <summary>
     /// Gets the Math.Min(int, int) method.
     /// </summary>

--- a/Execution/Interpreter.Expressions.cs
+++ b/Execution/Interpreter.Expressions.cs
@@ -859,6 +859,31 @@ public partial class Interpreter
     /// </summary>
     private RuntimeValue PerformIndexGet(Expr objectExpr, object? obj, object? index)
     {
+        // ECMA-262 §13.3.3 RequireObjectCoercible: a bracket read on a nullish base
+        // throws a guest TypeError. The optional `?.[]` case is short-circuited by
+        // callers (EvaluateGetIndex/EvaluateGetIndexAsync) before reaching here, so
+        // any nullish receiver at this point is a non-optional access that must throw.
+        // Mirrors the dot-access guard in EvaluateGetOnObject (#676).
+        if (obj == null || obj is SharpTSUndefined)
+        {
+            // Format the key for the message WITHOUT invoking a guest toString:
+            // RequireObjectCoercible (this throw) runs before ToPropertyKey, so a
+            // throwing key.toString() must not pre-empt the TypeError. Primitive keys
+            // (the realistic case) format directly; the object-key fallback uses the
+            // host ToString, which does not dispatch the guest toString.
+            string key = index switch
+            {
+                null => "null",
+                SharpTSUndefined => "undefined",
+                SharpTSSymbol sym => sym.ToString(),
+                string s => s,
+                bool bk => bk ? "true" : "false",
+                double d => Stringify(d),
+                _ => index.ToString() ?? ""
+            };
+            ThrowCannotReadProperty(obj, key);
+        }
+
         // Proxy: intercept index access via get trap
         if (obj is SharpTSProxy proxy)
         {

--- a/Execution/Interpreter.Properties.cs
+++ b/Execution/Interpreter.Properties.cs
@@ -525,6 +525,16 @@ public partial class Interpreter
             return RuntimeValue.Undefined;
         }
 
+        // ECMA-262 §13.3.2.1 RequireObjectCoercible: a non-optional member read on
+        // a nullish base throws a guest TypeError ("Cannot read properties of
+        // <null|undefined> (reading '<key>')"), so a guest try/catch binds a real
+        // TypeError rather than a host "Runtime Error" string — matching Node, tsc
+        // and the compiled path (#676).
+        if (obj == null || obj is SharpTSUndefined)
+        {
+            ThrowCannotReadProperty(obj, get.Name.Lexeme);
+        }
+
         // Proxy interception - must be before any other dispatch
         if (obj is SharpTSProxy proxy)
         {
@@ -567,6 +577,24 @@ public partial class Interpreter
             // Fallback for remaining types (IDictionary, ISharpTSPropertyAccessor, unknown types)
             _ => RuntimeValue.FromBoxed(EvaluateGetOnFallback(obj, memberName))
         };
+    }
+
+    /// <summary>
+    /// ECMA-262 RequireObjectCoercible failure on a member read: throws a guest
+    /// <see cref="SharpTSTypeError"/> ("Cannot read properties of
+    /// &lt;null|undefined&gt; (reading '&lt;key&gt;')") wrapped in a
+    /// <see cref="ThrowException"/> so a guest <c>try/catch</c> binds a real
+    /// <c>TypeError</c> (with the correct name/message and
+    /// <c>instanceof TypeError</c>) rather than a host "Runtime Error" string.
+    /// Shared by the dot-access (<see cref="EvaluateGetOnObject"/>) and
+    /// bracket-access (<see cref="PerformIndexGet"/>) paths (#676).
+    /// </summary>
+    [System.Diagnostics.CodeAnalysis.DoesNotReturn]
+    private static void ThrowCannotReadProperty(object? nullishReceiver, string key)
+    {
+        string what = nullishReceiver is SharpTSUndefined ? "undefined" : "null";
+        throw new ThrowException(new SharpTSTypeError(
+            $"Cannot read properties of {what} (reading '{key}')"));
     }
 
     /// <summary>

--- a/SharpTS.Tests/SharedTests/InstanceConstructorTests.cs
+++ b/SharpTS.Tests/SharedTests/InstanceConstructorTests.cs
@@ -1,0 +1,85 @@
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests;
+
+/// <summary>
+/// An instance's <c>constructor</c> property resolves to its class in both modes.
+/// In compiled mode a class in value position is its <see cref="System.Type"/>, so
+/// <c>x.constructor</c> must return that same value: identity (<c>=== MyClass</c>),
+/// static-member reads (<c>x.constructor.staticProp</c>), and <c>.name</c> all work.
+///
+/// <para>Compiled mode previously returned <c>undefined</c> for <c>instance.constructor</c>.
+/// That was benign only while member reads were lenient; once #701 made a read on
+/// <c>undefined</c> throw, the gap surfaced (e.g. the <c>yaml</c> package reads
+/// <c>coll.constructor.tagName</c>). Fixed by emitting a <c>constructor</c> branch in
+/// each class's GetProperty body.</para>
+/// </summary>
+public class InstanceConstructorTests
+{
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void InstanceConstructor_IsTheClass(ExecutionMode mode)
+    {
+        var source = """
+            class Animal {}
+            const a = new Animal();
+            console.log(a.constructor === Animal);
+            """;
+        Assert.Equal("true\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void InstanceConstructor_Name(ExecutionMode mode)
+    {
+        var source = """
+            class Animal {}
+            const a = new Animal();
+            console.log((a.constructor as any).name);
+            """;
+        Assert.Equal("Animal\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void InstanceConstructor_ReadsStaticMember(ExecutionMode mode)
+    {
+        var source = """
+            class Animal { static kind = "mammal"; }
+            const a = new Animal();
+            console.log((a.constructor as any).kind);
+            """;
+        Assert.Equal("mammal\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void InstanceConstructor_SubclassResolvesToSubclass(ExecutionMode mode)
+    {
+        // The most-derived class is reported — each class's GetProperty returns its
+        // own Type, mirroring `(new Sub()).constructor === Sub` in JS.
+        var source = """
+            class Base {}
+            class Sub extends Base {}
+            const s = new Sub();
+            console.log(s.constructor === Sub, s.constructor === Base);
+            """;
+        Assert.Equal("true false\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void InstanceConstructor_OwnDataPropertyShadows(ExecutionMode mode)
+    {
+        // An own data property named `constructor` shadows the class (JS semantics):
+        // the own-field lookup runs before the constructor branch.
+        var source = """
+            class Animal {}
+            const a: any = new Animal();
+            a.constructor = "shadowed";
+            console.log(a.constructor);
+            """;
+        Assert.Equal("shadowed\n", TestHarness.Run(source, mode));
+    }
+}

--- a/SharpTS.Tests/SharedTests/NullishMemberAccessTests.cs
+++ b/SharpTS.Tests/SharedTests/NullishMemberAccessTests.cs
@@ -1,0 +1,197 @@
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests;
+
+/// <summary>
+/// ECMA-262 RequireObjectCoercible (§13.3.2 / §13.3.3): a non-optional member
+/// access on <c>undefined</c> or <c>null</c> must throw a guest <c>TypeError</c>
+/// ("Cannot read properties of &lt;undefined|null&gt; (reading '&lt;key&gt;')"),
+/// not silently yield <c>undefined</c> or surface a raw host "Runtime Error" string.
+///
+/// <para>#676 (interpreter): the property-access fallback threw a host
+/// <c>InterpreterException</c> that a guest <c>catch</c> bound as a plain string.</para>
+/// <para>#701 (compiled): the emitted property/index read silently evaluated to
+/// <c>undefined</c> instead of throwing.</para>
+///
+/// <para><b>Interpreter vs compiled on a genuine <c>null</c> receiver:</b> the
+/// interpreter represents JS <c>null</c> as CLR <c>null</c> (sloppy-mode <c>this</c>
+/// is a distinct globalThis object), so it can throw on both. Compiled mode
+/// represents sloppy-mode <c>this</c> as CLR <c>null</c> too, so — like the
+/// established method-call-callee guard — it only throws on the unambiguous
+/// <c>$Undefined</c> singleton and leaves CLR <c>null</c> coercible. The
+/// <c>null</c>-receiver cases below are therefore interpreter-only.</para>
+/// </summary>
+public class NullishMemberAccessTests
+{
+    // The guest harness prints the caught value's shape so we assert the guest
+    // sees a real TypeError (object + instanceof + name), plus the message.
+    private const string ProbeFull =
+        "catch (e: any) { console.log(typeof e, e instanceof TypeError, e.name, \"|\" + e.message); }";
+    private const string ProbeIdentity =
+        "catch (e: any) { console.log(typeof e, e instanceof TypeError, e.name); }";
+
+    // ----- undefined receiver: dot read (#676 / #701 core) -----
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void UndefinedDotRead_ThrowsTypeError(ExecutionMode mode)
+    {
+        var source = $$"""
+            const o: any = undefined;
+            try { const y = o.foo; console.log("NOTHROW " + y); }
+            {{ProbeFull}}
+            """;
+        Assert.Equal(
+            "object true TypeError |Cannot read properties of undefined (reading 'foo')\n",
+            TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void UndefinedBracketRead_StringKey_ThrowsTypeError(ExecutionMode mode)
+    {
+        var source = $$"""
+            const o: any = undefined;
+            try { const y = o["bar"]; console.log("NOTHROW " + y); }
+            {{ProbeFull}}
+            """;
+        Assert.Equal(
+            "object true TypeError |Cannot read properties of undefined (reading 'bar')\n",
+            TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void UndefinedBracketRead_NumericKey_ThrowsTypeError(ExecutionMode mode)
+    {
+        var source = $$"""
+            const o: any = undefined;
+            try { const y = o[0]; console.log("NOTHROW " + y); }
+            {{ProbeFull}}
+            """;
+        Assert.Equal(
+            "object true TypeError |Cannot read properties of undefined (reading '0')\n",
+            TestHarness.Run(source, mode));
+    }
+
+    // ----- undefined receiver: method call (the #676 repro shape) -----
+    // Identity-only: the interpreter routes the callee through the property read
+    // ("Cannot read properties of …"), while compiled mode reaches its method-call
+    // guard — both raise a real TypeError, which is what #676 was about.
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void UndefinedMethodCall_ThrowsTypeError(ExecutionMode mode)
+    {
+        var source = $$"""
+            const o: any = undefined;
+            try { o.foo(); console.log("NOTHROW"); }
+            {{ProbeIdentity}}
+            """;
+        Assert.Equal("object true TypeError\n", TestHarness.Run(source, mode));
+    }
+
+    // ----- null receiver (interpreter-only; see class remarks) -----
+
+    [Fact]
+    public void NullDotRead_ThrowsTypeError_Interpreted()
+    {
+        var source = $$"""
+            const o: any = null;
+            try { const y = o.foo; console.log("NOTHROW " + y); }
+            {{ProbeFull}}
+            """;
+        Assert.Equal(
+            "object true TypeError |Cannot read properties of null (reading 'foo')\n",
+            TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void NullBracketRead_ThrowsTypeError_Interpreted()
+    {
+        var source = $$"""
+            const o: any = null;
+            try { const y = o["bar"]; console.log("NOTHROW " + y); }
+            {{ProbeFull}}
+            """;
+        Assert.Equal(
+            "object true TypeError |Cannot read properties of null (reading 'bar')\n",
+            TestHarness.RunInterpreted(source));
+    }
+
+    // ----- async context exercises the base (state-machine) emitter for #701 -----
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void UndefinedDotRead_InsideAsync_ThrowsTypeError(ExecutionMode mode)
+    {
+        var source = $$"""
+            async function run(): Promise<void> {
+                const o: any = undefined;
+                try { const y = o.foo; console.log("NOTHROW " + y); }
+                {{ProbeFull}}
+            }
+            run();
+            """;
+        Assert.Equal(
+            "object true TypeError |Cannot read properties of undefined (reading 'foo')\n",
+            TestHarness.Run(source, mode));
+    }
+
+    // ----- regression: optional chaining still short-circuits (does NOT throw) -----
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void OptionalDotChain_OnUndefined_ReturnsUndefined(ExecutionMode mode)
+    {
+        var source = """
+            const o: any = undefined;
+            const y = o?.foo;
+            console.log(y === undefined ? "undefined-ok" : "WRONG:" + y);
+            """;
+        Assert.Equal("undefined-ok\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void OptionalBracketChain_OnUndefined_ReturnsUndefined(ExecutionMode mode)
+    {
+        var source = """
+            const o: any = undefined;
+            const y = o?.["bar"];
+            console.log(y === undefined ? "undefined-ok" : "WRONG:" + y);
+            """;
+        Assert.Equal("undefined-ok\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void OptionalDotChain_OnUndefined_InsideAsync_ReturnsUndefined(ExecutionMode mode)
+    {
+        // Exercises the base EmitGet optional short-circuit added for the
+        // async/generator state-machine emitters alongside the #701 guard.
+        var source = """
+            async function run(): Promise<void> {
+                const o: any = undefined;
+                const y = o?.foo;
+                console.log(y === undefined ? "undefined-ok" : "WRONG:" + y);
+            }
+            run();
+            """;
+        Assert.Equal("undefined-ok\n", TestHarness.Run(source, mode));
+    }
+
+    // ----- regression: real reads still work after the guard -----
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void DefinedReceiver_DotAndBracketRead_StillWork(ExecutionMode mode)
+    {
+        var source = """
+            const o: any = { foo: 42, "1": "one" };
+            console.log(o.foo, o["foo"], o[1]);
+            """;
+        Assert.Equal("42 42 one\n", TestHarness.Run(source, mode));
+    }
+}


### PR DESCRIPTION
Fixes #676. Fixes #701.

## What & why

A non-optional member **read** on a nullish receiver now throws a guest `TypeError` — `Cannot read properties of <null|undefined> (reading '<key>')` — instead of:

- a raw host `"Runtime Error"` string that a guest `catch` bound as `typeof e === "string"` (**#676**, interpreter), or
- silently evaluating to `undefined` (**#701**, compiled).

Covers **dot and bracket** reads in **sync and async/generator** contexts, matching Node/`tsc`.

### Interpreter (#676)
Guards at the top of `EvaluateGetOnObject` (dot) and `PerformIndexGet` (bracket), via a shared `ThrowCannotReadProperty` helper. Throws on **both** JS `null` and `undefined` — safe because the interpreter binds sloppy-mode `this` to `SharpTSGlobalThis.Instance` (strict → `SharpTSUndefined`), never CLR `null`. The bracket-key is formatted **without** invoking a guest `toString` (ECMA-262 runs RequireObjectCoercible before ToPropertyKey).

### Compiled (#701)
New `EmitThrowIfUndefinedReceiverOnStack` / `EmitThrowIfUndefinedIndexReceiver` guards wired into both the `ILEmitter` overrides and the **base** `EmitGet`/`EmitGetIndex` (used by the async/generator state-machine emitters). Throws on the `$Undefined` singleton only; a bare CLR `null` is left coercible because compiled sloppy `this` is represented as `null` (= globalThis) — the same deliberate constraint as the existing call-callee guard `EmitThrowIfReceiverUndefined`. Also adds the previously-missing optional-chain short-circuit to the base `EmitGet` (it had been relying on `GetProperty` leniency for nullish bases).

### Latent bug unmasked + fixed: compiled `instance.constructor`
Compiled `instance.constructor` returned `undefined` (the interpreter returns the class). This was benign only while member reads were lenient — once `undefined.<x>` started throwing, it surfaced as a real regression (the `yaml` package reads `coll.constructor.tagName`, which broke `Yaml_Compiled`). `instance.constructor` now returns `typeof(class)` — the same `System.Type` value a bare class identifier produces, so identity (`=== MyClass`), static reads (`.tagName`), and `.name` all work — via `EmitConstructorPropertyBranch` in both per-class `GetProperty` emitters, placed after the own-field lookup so an own `constructor` data property still shadows it (JS semantics).

## Tests
- `NullishMemberAccessTests` (20) — dot/bracket/method-call on `undefined` (both modes), `null` reads (interpreter), async-context reads, optional-chain regressions (incl. async), defined-receiver reads still work.
- `InstanceConstructorTests` (10) — identity, `.name`, static read, subclass resolution, own-property shadow (both modes).
- **Full suite: 12,956 passed / 0 failed / 0 skipped** (with npm on PATH, so the real-package smoke tests including `Yaml_Compiled` actually ran).

## Reviewer notes
- **Compiled throws on `undefined` only, not genuine `null`** — by design, because compiled sloppy `this` is indistinguishable from JS `null` at the read site (same call-guard precedent). The interpreter throws on both. Tracked in #735.
- **Follow-ups filed:** #733 (member **write** / compound-assign on nullish still throws a raw string; sync vs async diverge), #735 (compiled read on a genuine `null`).
- **Test262:** this is a runtime change, so it likely *adds* RequireObjectCoercible passes. The submodule isn't initialized and Test262 isn't part of PR CI (`ci.yml` runs only `dotnet test`), so the committed baseline refresh is left to a separate explicit conformance pass.