### PR TITLE
Fix #703 #705: compiled default/optional parameter handling for class members

### DIFF
--- a/Compilation/ILCompiler.ArrowFunctions.cs
+++ b/Compilation/ILCompiler.ArrowFunctions.cs
@@ -152,15 +152,12 @@ public partial class ILCompiler
                 continue;
             }
 
-            // Resolve typed parameters from annotations (optimization for numeric parameters)
-            // Rest parameters always use List<object> to enable detection at invoke time
+            // Resolve typed parameters from annotations (optimization for numeric parameters).
+            // Rest parameters always use List<object> to enable detection at invoke time.
+            // ResolveParameters widens defaulted params to an object slot (#646/#705) so the
+            // runtime entry prologue can detect the missing/undefined argument and fire the default.
             var resolvedParamTypes = ParameterTypeResolver.ResolveParameters(
                 arrow.Parameters, _typeMapper, null, _typeMap); // null funcType - use annotations only
-
-            // Arrows/function expressions get no OverloadGenerator forwarding, so a parameter
-            // default is applied by the runtime entry prologue, which needs an object slot to
-            // detect the missing/undefined argument (#646).
-            ParameterTypeResolver.WidenDefaultedParamsToObject(resolvedParamTypes, arrow.Parameters, _types.Object);
 
             // Store resolved types for use during arrow body emission
             _closures.ArrowParameterTypes[arrow] = resolvedParamTypes;

--- a/Compilation/ILCompiler.Classes.ClassExpressions.cs
+++ b/Compilation/ILCompiler.Classes.ClassExpressions.cs
@@ -802,6 +802,10 @@ public partial class ILCompiler
         if (!_classExprs.InstanceMethods[classExpr].TryGetValue(method.Name.Lexeme, out var methodBuilder))
             return;
 
+        // #703: class-expression instance method invoked as a value pads omitted optional
+        // args with the `undefined` sentinel on the value-call path (covers sync + async).
+        MarkPadsUndefined(methodBuilder);
+
         // Handle async methods via state machine
         if (method.IsAsync)
         {
@@ -853,6 +857,10 @@ public partial class ILCompiler
     {
         if (!_classExprs.StaticMethods[classExpr].TryGetValue(method.Name.Lexeme, out var methodBuilder))
             return;
+
+        // #703: class-expression static method invoked as a value pads omitted optional
+        // args with the `undefined` sentinel on the value-call path (covers sync + async).
+        MarkPadsUndefined(methodBuilder);
 
         var typeBuilder = _classExprs.Builders[classExpr];
 

--- a/Compilation/ILCompiler.Classes.Constructors.cs
+++ b/Compilation/ILCompiler.Classes.Constructors.cs
@@ -353,7 +353,15 @@ public partial class ILCompiler
 
             var emitter = new ILEmitter(ctx);
 
-            // No runtime default parameter checks needed - overloads handle this
+            // Apply parameter defaults before the body. Constructors get no OverloadGenerator
+            // forwarding, so without this a defaulted constructor argument that is omitted or
+            // explicit `undefined` would never fire its default. This must run before the body
+            // because parameter-property assignments (`this.x = x`, prepended to the body by the
+            // parser) and any default expression referencing the param read the defaulted value.
+            // Value-type-defaulted params are widened to object by ParameterTypeResolver so the
+            // prologue can observe the `$Undefined` sentinel. (#705)
+            var ctorDefaultParamTypes = ctorBuilder.GetParameters().Select(p => p.ParameterType).ToArray();
+            emitter.EmitDefaultParameters(constructor.Parameters, isInstanceMethod: true, paramTypes: ctorDefaultParamTypes);
 
             if (constructor.Body != null)
             {

--- a/Compilation/ILCompiler.Classes.Methods.cs
+++ b/Compilation/ILCompiler.Classes.Methods.cs
@@ -738,6 +738,10 @@ public partial class ILCompiler
         string qualifiedClassName,
         bool isStatic)
     {
+        // #703: a private method referenced as a value (e.g. `this.#m` passed as a callback)
+        // pads omitted optional args with the `undefined` sentinel on the value-call path.
+        MarkPadsUndefined(methodBuilder);
+
         var il = methodBuilder.GetILGenerator();
         var ctx = new CompilationContext(il, _typeMapper, _functions.Builders, _classes.Builders, _namespaceFields, _namespaceVarFields, _types)
         {
@@ -816,6 +820,13 @@ public partial class ILCompiler
 
         var emitter = new ILEmitter(ctx);
 
+        // Apply parameter defaults (omitted or explicit `undefined` fires the default). Private
+        // methods get neither OverloadGenerator forwarding nor (previously) this prologue, so
+        // defaults never fired. Their params are already object-typed, so the prologue can
+        // observe the `$Undefined` sentinel directly. (#705)
+        var privateDefaultParamTypes = methodBuilder.GetParameters().Select(p => p.ParameterType).ToArray();
+        emitter.EmitDefaultParameters(method.Parameters, isInstanceMethod: !isStatic, paramTypes: privateDefaultParamTypes);
+
         // Emit method body
         if (method.Body != null)
         {
@@ -885,6 +896,13 @@ public partial class ILCompiler
             }
             classMethods[method.Name.Lexeme] = methodBuilder;
         }
+
+        // #703: a user class method invoked as a value (extracted, `.bind()`-ed, or passed
+        // as a callback → `$TSFunction.Invoke`) must pad omitted trailing optional args with
+        // the `undefined` sentinel, matching the direct-call path. Marking is safe for direct
+        // calls — it only affects the value-call padding mask. Covers sync/async/generator
+        // instance methods (they all share this builder before the kind-specific branch).
+        MarkPadsUndefined(methodBuilder);
 
         // Apply method-level decorators as .NET attributes
         if (_decoratorMode != DecoratorMode.None)
@@ -1085,6 +1103,14 @@ public partial class ILCompiler
                 .ToArray();
             EmitArgumentsLocalPrologueForInstanceMethod(il, ctx, method.Parameters, resolvedParamTypes);
         }
+
+        // Apply parameter defaults (JS: a default fires when the argument is missing or
+        // explicit `undefined`). Class declarations historically skipped this entirely, so
+        // defaults never fired in compiled mode (omit → null/0, explicit undefined → NaN/cast
+        // error). ParameterTypeResolver widens value-type-defaulted params to an object slot
+        // so the prologue can observe the `$Undefined` sentinel and fire the default. (#705)
+        var defaultParamTypes = methodBuilder.GetParameters().Select(p => p.ParameterType).ToArray();
+        emitter.EmitDefaultParameters(method.Parameters, isInstanceMethod: true, paramTypes: defaultParamTypes);
 
         // Abstract methods have no body to emit
         if (method.Body != null)

--- a/Compilation/ILCompiler.Classes.Static.cs
+++ b/Compilation/ILCompiler.Classes.Static.cs
@@ -300,6 +300,11 @@ public partial class ILCompiler
 
     private void EmitStaticMethodBody(string className, Stmt.Function method)
     {
+        // #703: a static method invoked as a value pads omitted optional args with the
+        // `undefined` sentinel on the value-call path. Mark before the async branch so it
+        // covers both sync and async static methods (same builder).
+        MarkPadsUndefined(_classes.StaticMethods[className][method.Name.Lexeme]);
+
         // Async static methods use state machine generation
         if (method.IsAsync)
         {
@@ -378,7 +383,13 @@ public partial class ILCompiler
 
         var emitter = new ILEmitter(ctx);
 
-        // No runtime default parameter checks needed - overloads handle this
+        // Apply parameter defaults. Static methods get no OverloadGenerator forwarding (only
+        // free functions do), so without this a defaulted argument that is omitted or explicit
+        // `undefined` would never fire its default (omit → null/0, undefined → NaN/cast error).
+        // Value-type-defaulted params are widened to an object slot by ParameterTypeResolver so
+        // the prologue can observe the `$Undefined` sentinel. (#705)
+        var staticDefaultParamTypes = methodBuilder.GetParameters().Select(p => p.ParameterType).ToArray();
+        emitter.EmitDefaultParameters(method.Parameters, isInstanceMethod: false, paramTypes: staticDefaultParamTypes);
 
         // Variables for @lock decorator support
         LocalBuilder? prevReentrancyLocal = null;

--- a/Compilation/ILEmitter.Properties.Private.cs
+++ b/Compilation/ILEmitter.Properties.Private.cs
@@ -206,6 +206,33 @@ public partial class ILEmitter
     }
 
     /// <summary>
+    /// Emits the arguments for a private method call (boxing each), then pads any omitted
+    /// trailing parameters with the <c>$Undefined</c> sentinel. Private methods get neither
+    /// OverloadGenerator forwarding nor call-site padding elsewhere, so without this an
+    /// under-applied call — e.g. <c>this.#m(x)</c> to <c>#m(x, y = 1)</c> — pushes too few stack
+    /// slots (InvalidProgramException) and the body's default-parameter prologue never sees the
+    /// missing argument. Padding with the sentinel (not null) also makes an omitted optional
+    /// parameter read as <c>undefined</c>. Over-application is left untouched. (#705)
+    /// </summary>
+    private void EmitPrivateCallArgsPadded(System.Reflection.MethodInfo method, IReadOnlyList<Expr> args)
+    {
+        foreach (var arg in args)
+        {
+            EmitExpression(arg);
+            EmitBoxIfNeeded(arg);
+        }
+
+        int paramCount = method.GetParameters().Length;
+        for (int i = args.Count; i < paramCount; i++)
+        {
+            if (_ctx.Runtime?.UndefinedInstance != null)
+                IL.Emit(OpCodes.Ldsfld, _ctx.Runtime.UndefinedInstance);
+            else
+                IL.Emit(OpCodes.Ldnull);
+        }
+    }
+
+    /// <summary>
     /// Emits IL for ES2022 private method call (obj.#method()).
     /// </summary>
     protected override void EmitCallPrivate(Expr.CallPrivate cp)
@@ -229,12 +256,7 @@ public partial class ILEmitter
         {
             if (_ctx.ClassRegistry!.TryGetStaticPrivateMethod(className, methodName, out var staticMethod))
             {
-                // Emit arguments
-                foreach (var arg in cp.Arguments)
-                {
-                    EmitExpression(arg);
-                    EmitBoxIfNeeded(arg);
-                }
+                EmitPrivateCallArgsPadded(staticMethod!, cp.Arguments);
 
                 // Call static method
                 IL.Emit(OpCodes.Call, staticMethod!);
@@ -288,12 +310,7 @@ public partial class ILEmitter
                     IL.Emit(OpCodes.Castclass, _ctx.CurrentClassBuilder);
                 }
 
-                // Emit arguments
-                foreach (var arg in cp.Arguments)
-                {
-                    EmitExpression(arg);
-                    EmitBoxIfNeeded(arg);
-                }
+                EmitPrivateCallArgsPadded(instanceMethod!, cp.Arguments);
 
                 // Call instance method
                 IL.Emit(OpCodes.Callvirt, instanceMethod!);
@@ -310,11 +327,7 @@ public partial class ILEmitter
                     IL.Emit(OpCodes.Castclass, _ctx.CurrentClassBuilder);
                 }
 
-                foreach (var arg in cp.Arguments)
-                {
-                    EmitExpression(arg);
-                    EmitBoxIfNeeded(arg);
-                }
+                EmitPrivateCallArgsPadded(instanceMethod!, cp.Arguments);
 
                 IL.Emit(OpCodes.Callvirt, instanceMethod!);
                 SetStackUnknown();
@@ -325,11 +338,7 @@ public partial class ILEmitter
         // Fallback: check for static private method
         if (_ctx.ClassRegistry!.TryGetStaticPrivateMethod(className, methodName, out var fallbackStaticMethod))
         {
-            foreach (var arg in cp.Arguments)
-            {
-                EmitExpression(arg);
-                EmitBoxIfNeeded(arg);
-            }
+            EmitPrivateCallArgsPadded(fallbackStaticMethod!, cp.Arguments);
 
             IL.Emit(OpCodes.Call, fallbackStaticMethod!);
             SetStackUnknown();

--- a/Compilation/ParameterTypeResolver.cs
+++ b/Compilation/ParameterTypeResolver.cs
@@ -31,7 +31,9 @@ public static class ParameterTypeResolver
         if (funcType == null || funcType.ParamTypes.Count != parameters.Count)
         {
             // Fallback: try to resolve from parameter type annotations
-            return parameters.Select(p => WidenIfUndefinedReachableParam(ResolveParameterType(p, typeMapper), p, typeMap)).ToArray();
+            var fallback = parameters.Select(p => WidenIfUndefinedReachableParam(ResolveParameterType(p, typeMapper), p, typeMap)).ToArray();
+            WidenDefaultedParamsToObject(fallback, parameters, typeof(object));
+            return fallback;
         }
 
         // Map each parameter type, but use 'object' for:
@@ -41,7 +43,7 @@ public static class ParameterTypeResolver
         //    `List<object>` when packing trailing args; using a typed list like
         //    `List<string>` for `...parts: string[]` breaks the dispatch path
         //    (method gets invoked without rest packing, trailing args are dropped).
-        return funcType.ParamTypes
+        var resolved = funcType.ParamTypes
             .Select((pt, i) =>
             {
                 var mappedType = typeMapper.MapTypeInfoStrict(pt);
@@ -81,26 +83,34 @@ public static class ParameterTypeResolver
                     WidenIfUndefinedReachableParam(mappedType, parameters[i], typeMap), pt, typeMapper);
             })
             .ToArray();
+
+        WidenDefaultedParamsToObject(resolved, parameters, typeof(object));
+        return resolved;
     }
 
     /// <summary>
     /// Widens any parameter that has a <b>default value</b> to an <c>object</c> slot. Required for
-    /// function kinds that apply parameter defaults via the runtime entry prologue
-    /// (<see cref="ILEmitter.EmitDefaultParameters"/>) rather than via <see cref="OverloadGenerator"/>
-    /// lower-arity forwarding — i.e. arrow functions and function expressions, which get no overloads.
-    /// The prologue detects a missing/undefined argument by comparing the slot against null and the
-    /// <c>$Undefined</c> sentinel, and value-call padding (<c>$TSFunction.AdjustArgs</c>) fills omitted
-    /// slots with that sentinel. Only an <c>object</c> slot can hold it: a value-type slot can never be
-    /// null (and emits invalid <c>ldarg; brfalse</c> IL), and a typed reference slot (e.g. <c>string</c>)
-    /// coerces the sentinel to a real value (e.g. the string <c>"undefined"</c>) before the prologue can
-    /// observe it. Either way the default could never fire. Mirrors the optional-without-default widening
-    /// already applied in <see cref="ResolveParameters"/>. (#646)
+    /// every function kind that applies parameter defaults via the runtime entry prologue
+    /// (<see cref="ILEmitter.EmitDefaultParameters"/>): arrow functions and function expressions
+    /// (which get no overloads), and — since #705 — function declarations, class methods, and
+    /// constructors. The prologue detects a missing/undefined argument by comparing the slot against
+    /// null and the <c>$Undefined</c> sentinel, and value-call padding (<c>$TSFunction.AdjustArgs</c>)
+    /// fills omitted slots with that sentinel. Only an <c>object</c> slot can hold it: a value-type
+    /// slot can never be null (and emits invalid <c>ldarg; brfalse</c> IL — so the prologue skips it
+    /// and the default never fires), and a typed reference slot (e.g. <c>string</c>) coerces the
+    /// sentinel to a real value (the string <c>"undefined"</c>) before the prologue can observe it.
+    /// Either way the default could never fire. Applied centrally in <see cref="ResolveParameters"/>,
+    /// <see cref="ResolveMethodParameters"/>, and <see cref="ResolveConstructorParameters"/> so the
+    /// define-time and emit-time signatures always agree. (#646, #705)
     /// </summary>
     public static void WidenDefaultedParamsToObject(Type[] resolved, List<Stmt.Parameter> parameters, Type objectType)
     {
         for (int i = 0; i < parameters.Count && i < resolved.Length; i++)
         {
-            if (parameters[i].DefaultValue != null && resolved[i] != objectType)
+            // A rest parameter is never "omitted" (it collects zero-or-more trailing args into a
+            // List<object>) and its `= ` form is illegal TS, but guard anyway so a future change
+            // can't turn the rest marker List<object> into a plain object slot and break dispatch.
+            if (parameters[i].DefaultValue != null && !parameters[i].IsRest && resolved[i] != objectType)
                 resolved[i] = objectType;
         }
     }
@@ -300,6 +310,17 @@ public static class ParameterTypeResolver
     /// <summary>
     /// Resolves parameter types for a class method.
     /// </summary>
+    /// <remarks>
+    /// Deliberately does NOT widen value-type-defaulted params to <c>object</c> (unlike free
+    /// functions and constructors, which do). Instance methods are <b>virtual</b>: changing a
+    /// defaulted param's slot from <c>double</c>/<c>bool</c> to <c>object</c> would change the CLR
+    /// signature and break override matching against a base method that declares the same param
+    /// without a default (the derived override silently lands in a new vtable slot, so a
+    /// base-typed call dispatches to the base method). Reference-type defaults still fire via the
+    /// entry prologue without any slot change (a reference slot already holds null). Firing
+    /// value-type method defaults override-safely needs hierarchy-consistent widening or bridge
+    /// methods — tracked as #737.
+    /// </remarks>
     public static Type[] ResolveMethodParameters(
         string className,
         string methodName,
@@ -406,9 +427,21 @@ public static class ParameterTypeResolver
     }
 
     /// <summary>
-    /// Resolves constructor parameter types for a class.
+    /// Resolves constructor parameter types for a class, widening value-type-defaulted params to
+    /// <c>object</c> so the entry prologue can fire their defaults (#705).
     /// </summary>
     public static Type[] ResolveConstructorParameters(
+        string className,
+        List<Stmt.Parameter> parameters,
+        TypeMapper typeMapper,
+        TypeMap? typeMap)
+    {
+        var resolved = ResolveConstructorParametersCore(className, parameters, typeMapper, typeMap);
+        WidenDefaultedParamsToObject(resolved, parameters, typeof(object));
+        return resolved;
+    }
+
+    private static Type[] ResolveConstructorParametersCore(
         string className,
         List<Stmt.Parameter> parameters,
         TypeMapper typeMapper,

--- a/SharpTS.Tests/CompilerTests/ClassMethodDefaultParameterTests.cs
+++ b/SharpTS.Tests/CompilerTests/ClassMethodDefaultParameterTests.cs
@@ -1,0 +1,263 @@
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.CompilerTests;
+
+/// <summary>
+/// #705: in compiled mode, default parameters on class-declaration members were never applied —
+/// the body emitters skipped the runtime entry prologue entirely, and value-type-defaulted params
+/// kept an unboxed slot that cannot hold the <c>undefined</c> sentinel. This pins the fixes for the
+/// <b>non-virtual</b> members from the issue's repros — constructors, private methods, and free
+/// functions — whose value-type defaults are now widened to an object slot so an omitted or explicit
+/// <c>undefined</c> argument fires the default (omit → default, explicit undefined → default, present
+/// → used). Reference-type defaults on (virtual) instance / static methods also fire now, override-safely
+/// (no slot change). Value-type defaults on virtual instance/static methods remain a tracked follow-up
+/// (widening their slot would break override matching), and are intentionally not asserted here.
+/// All run in both modes to pin interpreter/compiler parity.
+/// </summary>
+public class ClassMethodDefaultParameterTests
+{
+    // ---- Constructors (parameter properties, value-type + reference) -------
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Constructor_ParameterProperty_NumericDefault_Omitted(ExecutionMode mode)
+    {
+        var source = """
+            class D { constructor(public name: string, public age: number = 99) {} }
+            console.log(new D("Bob").age);
+            """;
+        Assert.Equal("99\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Constructor_ParameterProperty_NumericDefault_ExplicitUndefined(ExecutionMode mode)
+    {
+        var source = """
+            class D { constructor(public name: string, public age: number = 99) {} }
+            console.log(new D("Bob", undefined).age);
+            """;
+        Assert.Equal("99\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Constructor_ParameterProperty_NumericDefault_Present(ExecutionMode mode)
+    {
+        var source = """
+            class D { constructor(public name: string, public age: number = 99) {} }
+            console.log(new D("Bob", 7).age);
+            """;
+        Assert.Equal("7\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Constructor_StringDefault_OmittedArg(ExecutionMode mode)
+    {
+        var source = """
+            class D { constructor(public name: string = "anon") {} }
+            console.log(new D().name);
+            """;
+        Assert.Equal("anon\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Constructor_BooleanDefault_ExplicitUndefined(ExecutionMode mode)
+    {
+        var source = """
+            class D { active: boolean; constructor(on: boolean = true) { this.active = on; } }
+            console.log(new D(undefined).active);
+            console.log(new D(false).active);
+            """;
+        Assert.Equal("true\nfalse\n", TestHarness.Run(source, mode));
+    }
+
+    // ---- Private methods (instance + static, value-type + reference) -------
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void PrivateMethod_NumericDefault_OmittedArg(ExecutionMode mode)
+    {
+        var source = """
+            class C {
+              #add(a: number, b: number = 10): number { return a + b; }
+              run(): number { return this.#add(5); }
+            }
+            console.log(new C().run());
+            """;
+        Assert.Equal("15\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void PrivateMethod_NumericDefault_ExplicitUndefined(ExecutionMode mode)
+    {
+        var source = """
+            class C {
+              #add(a: number, b: number = 10): number { return a + b; }
+              run(): number { return this.#add(5, undefined); }
+            }
+            console.log(new C().run());
+            """;
+        Assert.Equal("15\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void PrivateMethod_MultipleDefaults_AllOmitted(ExecutionMode mode)
+    {
+        var source = """
+            class C {
+              #sum(a: number = 1, b: number = 2, c: number = 3): number { return a + b + c; }
+              run(): number { return this.#sum(); }
+            }
+            console.log(new C().run());
+            """;
+        Assert.Equal("6\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void PrivateMethod_PartialApplication_RemainingDefaults(ExecutionMode mode)
+    {
+        var source = """
+            class C {
+              #sum(a: number, b: number = 2, c: number = 3): number { return a + b + c; }
+              run(): number { return this.#sum(10); }
+            }
+            console.log(new C().run());
+            """;
+        Assert.Equal("15\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void StaticPrivateMethod_NumericDefault_OmittedArg(ExecutionMode mode)
+    {
+        var source = """
+            class C {
+              static #add(a: number, b: number = 10): number { return a + b; }
+              static run(): number { return C.#add(5); }
+            }
+            console.log(C.run());
+            """;
+        Assert.Equal("15\n", TestHarness.Run(source, mode));
+    }
+
+    // ---- Free functions (value-type default + explicit undefined, #705 (a)) ----
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void FreeFunction_NumericDefault_ExplicitUndefined(ExecutionMode mode)
+    {
+        var source = """
+            function p(a: string, b: number = 2): number { return a.length + b; }
+            console.log(p("x", undefined));
+            """;
+        Assert.Equal("3\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void FreeFunction_NumericDefault_OmittedArg(ExecutionMode mode)
+    {
+        var source = """
+            function p(a: string, b: number = 2): number { return a.length + b; }
+            console.log(p("x"));
+            """;
+        Assert.Equal("3\n", TestHarness.Run(source, mode));
+    }
+
+    // ---- Reference-type defaults on (virtual) instance & static methods ----
+    // These fire without changing the slot type, so override matching is preserved.
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void InstanceMethod_StringDefault_OmittedArg(ExecutionMode mode)
+    {
+        var source = """
+            class C { greet(name: string = "World"): string { return "Hi " + name; } }
+            console.log(new C().greet());
+            console.log(new C().greet("Bob"));
+            """;
+        Assert.Equal("Hi World\nHi Bob\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void StaticMethod_StringDefault_OmittedArg(ExecutionMode mode)
+    {
+        var source = """
+            class C { static greet(name: string = "World"): string { return "Hi " + name; } }
+            console.log(C.greet());
+            """;
+        Assert.Equal("Hi World\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void InstanceMethod_ArgPresent_DefaultNotApplied(ExecutionMode mode)
+    {
+        // Argument present: no default-firing needed; value-type slot stays fast and correct.
+        var source = """
+            class C { add(a: number, b: number = 10): number { return a + b; } }
+            console.log(new C().add(5, 20));
+            """;
+        Assert.Equal("25\n", TestHarness.Run(source, mode));
+    }
+
+    // ---- Override safety: widening must NOT change a virtual method's signature ----
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Override_DerivedAddsDefault_StillOverrides(ExecutionMode mode)
+    {
+        // Regression guard: a derived override that adds a default to a value-type param the base
+        // declares as required must still override (a base-typed call dispatches to the derived
+        // method). Widening the derived param to object would silently break this. (#705)
+        var source = """
+            class B { m(x: number): number { return x; } }
+            class D extends B { m(x: number = 5): number { return x * 2; } }
+            const b: B = new D();
+            console.log(b.m(3));
+            """;
+        Assert.Equal("6\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Override_BothDefault_DispatchesToDerived(ExecutionMode mode)
+    {
+        var source = """
+            class B { greet(n: string = "B"): string { return "B:" + n; } }
+            class D extends B { greet(n: string = "D"): string { return "D:" + n; } }
+            const b: B = new D();
+            console.log(b.greet());
+            """;
+        Assert.Equal("D:D\n", TestHarness.Run(source, mode));
+    }
+
+    // ---- IL verification guard ---------------------------------------------
+
+    [Fact]
+    public void NonVirtualValueTypeDefaults_ProduceVerifiableIL()
+    {
+        // Widening defaulted value-type params to object (free fn / private / ctor) and padding
+        // private calls must emit verifiable IL — no `ldarg; brfalse` on a double/bool slot, no
+        // unbalanced private-call stack.
+        var source = """
+            class C {
+              #p(a: number, b: number = 7): number { return a + b; }
+              run(): number { return this.#p(1); }
+            }
+            class D { constructor(public age: number = 99) {} }
+            function f(x: number, y: number = 3): number { return x + y; }
+            console.log(new C().run() + new D().age + f(1));
+            """;
+        var errors = TestHarness.CompileAndVerifyOnly(source);
+        Assert.Empty(errors);
+    }
+}

--- a/SharpTS.Tests/CompilerTests/ValueCallUndefinedPaddingTests.cs
+++ b/SharpTS.Tests/CompilerTests/ValueCallUndefinedPaddingTests.cs
@@ -95,4 +95,78 @@ public class ValueCallUndefinedPaddingTests
             """;
         Assert.Equal("2,4,6\n", TestHarness.Run(source, mode));
     }
+
+    // #703: class methods invoked as values (extracted, `.bind()`-ed, passed as callbacks →
+    // `$TSFunction.Invoke`) must also pad omitted trailing optional args with the `undefined`
+    // sentinel, matching function declarations/arrows. Marking is applied to every user
+    // class-method builder kind (instance, static, private, class-expression).
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void InstanceMethodBound_OmittedOptionalArg_IsUndefined(ExecutionMode mode)
+    {
+        var source = """
+            class C { m(x?: any): string { return typeof x; } }
+            const inst = new C();
+            const mval = inst.m.bind(inst);
+            console.log(mval());
+            """;
+        Assert.Equal("undefined\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void InstanceMethodAsValue_OmittedOptionalArg_StrictEquality(ExecutionMode mode)
+    {
+        var source = """
+            class C {
+              isUndef(x?: any): boolean { return x === undefined; }
+              isNull(x?: any): boolean { return x === null; }
+            }
+            const c = new C();
+            const u = c.isUndef.bind(c);
+            const n = c.isNull.bind(c);
+            console.log(u());
+            console.log(n());
+            """;
+        Assert.Equal("true\nfalse\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void StaticMethodAsValue_OmittedOptionalArg_IsUndefined(ExecutionMode mode)
+    {
+        var source = """
+            class C { static m(x?: any): string { return typeof x; } }
+            const f = C.m;
+            console.log(f());
+            """;
+        Assert.Equal("undefined\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ClassExpressionMethodAsValue_OmittedOptionalArg_IsUndefined(ExecutionMode mode)
+    {
+        var source = """
+            const C = class { m(x?: any): string { return typeof x; } };
+            const c = new C();
+            const mval = c.m.bind(c);
+            console.log(mval());
+            """;
+        Assert.Equal("undefined\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void InstanceMethodAsCallback_OmittedOptionalArg_IsUndefined(ExecutionMode mode)
+    {
+        var source = """
+            class C { m(x?: any): string { return typeof x; } }
+            function invoke(cb: () => string): string { return cb(); }
+            const c = new C();
+            console.log(invoke(c.m.bind(c)));
+            """;
+        Assert.Equal("undefined\n", TestHarness.Run(source, mode));
+    }
 }


### PR DESCRIPTION
## What & why

In **compiled** mode, default and optional parameters on class members were mishandled. Re-measuring baselines showed the problem was broader than the issues stated: class-declaration methods and constructors **never ran the default-parameter prologue at all**, so a default silently dropped even when the argument was merely *omitted* (`greet(n = "World")` → `"Hi null"`; `b: number = 10` → `0`), and an explicit/padded `undefined` reaching a value-type slot threw `InvalidCastException` / produced `NaN`. Class *expressions* already worked (they use all-`object` slots); declarations did not.

This PR resolves the value-call padding follow-up (#703) and the default-parameter handling (#705), and adds coverage confirming #640 (already fixed on `main`).

## Changes

**#703 — class methods invoked as values pad omitted optionals with `undefined`**
- Apply the existing `$PadUndefined` marker (`MarkPadsUndefined`) at the 5 class-method body-emission sites: instance, static, private, and class-expression (instance + static) methods. When such a method is invoked as a value (extracted, `.bind()`-ed, or passed as a callback → `$TSFunction.Invoke`), an omitted trailing optional now pads with the `undefined` sentinel instead of CLR `null`, matching the direct-call path. Accessors are skipped (getters take 0 params, setters exactly 1 required → mask is always empty).

**#705 — apply parameter defaults for class-declaration members**
- **Free functions & constructors** (non-virtual): widen value-type-defaulted params to an `object` slot (centralized in `ParameterTypeResolver.ResolveParameters` / `ResolveConstructorParameters`) so the entry prologue can observe the `$Undefined` sentinel; emit the prologue in the constructor body *before* parameter-property assignments.
- **Private methods**: emit the prologue (params are already `object`-typed) and pad omitted trailing args at the call site — under-application previously emitted too few stack slots (`InvalidProgramException`). New helper `EmitPrivateCallArgsPadded` pads with `$Undefined` across all 4 private-call sites.
- **Instance & static methods**: emit the prologue, which fires **reference-type** defaults override-safely.

## Key design decision (avoiding a polymorphism regression)

Value-type defaults on **virtual instance methods** are deliberately **not** widened. Widening changes a method's CLR signature (`m(double)` → `m(object)`), so a derived override that adds a default to a param the base declares as required silently lands in a *new* vtable slot — a base-typed call (`(b: Base).m(3)`) then dispatches to the base method. The full test suite stayed green even with that bug (no existing test exercised the pattern), but it's a real conformance break, so widening is scoped to non-virtual members only. This also preserves instance methods' unboxed value-type fast path. Regression guards (`Override_DerivedAddsDefault_StillOverrides`, `Override_BothDefault_DispatchesToDerived`) pin the behavior.

## Follow-ups filed

- #737 — value-type defaults on virtual instance/static methods (needs override-safe widening: hierarchy-consistent or bridge methods) + generator-method defaults (their state-machine emitter lacks the prologue).
- #738 — #705 case (b): `--ref-asm` value-call ignores a value-type default (pre-existing, independent of this work).
- #739 — direct call to an instance/static method/constructor pads an omitted optional-no-default param with `null` not `undefined` (the direct-call analogue of #640/#703).
- Confirmed the `(a, b = a * 2)` overload crash is the already-filed #698, not a regression here.

## Validation

- Full unit suite: **12964 passed, 0 failed**.
- IL `--verify` passes on a feature-rich program (overrides, private value-type defaults, static/ctor defaults, value-call).
- Standalone-DLL + IL-verification tests (97) pass — the private-call padding uses the emitted `$Undefined` field, so the standalone-DLL constraint is preserved.
- New tests: `ClassMethodDefaultParameterTests` (constructors / private / free-fn value-type defaults, instance/static reference defaults, override-safety guards, IL-verify guard) and additions to `ValueCallUndefinedPaddingTests` (#703).

## Performance

Only **defaulted/optional** params are affected; non-defaulted hot-path params are unchanged. Boxing is added only for *defaulted value-type* params on free functions and constructors (bounded); instance-method value-type slots are intentionally left unboxed.