### PR TITLE
Fix #689, #690: interpreter async-generator environment leak

### DIFF
--- a/Execution/Interpreter.Async.cs
+++ b/Execution/Interpreter.Async.cs
@@ -197,6 +197,14 @@ public partial class Interpreter
     /// </summary>
     private async Task<ExecutionResult> IterateAsyncIterator(object asyncIterator, Stmt.ForOf forOf)
     {
+        // The loop body must run in the for-await statement's own lexical scope, regardless of how the
+        // iterator's next() mutates the interpreter's ambient environment. The eager-drain async generator
+        // transiently repoints that environment at its own closure while draining, and a body shape whose
+        // await is nested in a delegated expression can leave it repointed across the suspension; without
+        // re-asserting the loop scope here, the body (and code after the loop) would resolve outer bindings
+        // against the wrong scope — "Undefined variable" (#689). Capturing once and restoring after each
+        // next() also hardens for-await against any custom async iterator with environment side effects.
+        RuntimeEnvironment hostEnv = _environment;
         while (true)
         {
             // Call iterator.next()
@@ -207,6 +215,9 @@ public partial class Interpreter
                 nextResult = await AwaitPreservingEnvironment(promise.Task);
             else if (nextResult is Task<object?> task)
                 nextResult = await AwaitPreservingEnvironment(task);
+
+            // Re-assert the loop's lexical scope (see above) before consuming the result or running the body.
+            _environment = hostEnv;
 
             // Check if the result is an iterator result object
             bool done = false;

--- a/Runtime/Types/SharpTSAsyncGenerator.cs
+++ b/Runtime/Types/SharpTSAsyncGenerator.cs
@@ -26,6 +26,13 @@ public class SharpTSAsyncGenerator : ITypeCategorized
     private readonly Interpreter _interpreter;
 
     private List<object?>? _values = null;  // Collected yielded values (null = not yet executed)
+    // The single eager body drain, shared by every next() caller. Started by the first next() and
+    // awaited by all subsequent calls so overlapping requests are serviced in call order (ECMA-262
+    // §27.6.3 services the async-generator request queue FIFO) rather than racing the half-populated
+    // _values list. _values alone can't gate this: it is set to an empty list at drain start, so a
+    // second next() issued before the first settles would see it non-null and wrongly report completion
+    // before any value was collected (#690).
+    private Task? _drainTask = null;
     private int _index = 0;
     // The generator's completion value. Defaults to undefined so a body that falls off the end (or a
     // no-arg return) reports { value: undefined, done: true }, not C# null (#540).
@@ -40,6 +47,17 @@ public class SharpTSAsyncGenerator : ITypeCategorized
     // that follows the values yielded before it — so it is buffered here and rethrown by Next() once
     // those values are exhausted, rejecting that call's promise (#566). Null when the body did not throw.
     private Exception? _pendingException = null;
+
+    // The interpreter's ambient environment captured when the eager body drain begins — i.e. the scope
+    // active in the caller that triggered the first next(). The drain temporarily repoints the shared
+    // interpreter environment at the generator's own closure (_environment); because the body suspends
+    // at `await` points while that closure is installed, control can return to the caller — or to
+    // interleaved event-loop work — with the generator's closure still in place. Every guest-suspending
+    // await restores this caller environment before suspending and re-asserts the generator's
+    // environment on resume, so the generator never leaks its closure into the ambient environment
+    // (otherwise an outer binding read after the generator is driven resolves against the wrong scope:
+    // "Undefined variable" in a for-await body (#689), or a member access on the wrong value (#690)).
+    private RuntimeEnvironment? _callerEnv;
 
     public SharpTSAsyncGenerator(Stmt.Function declaration, RuntimeEnvironment environment, Interpreter interpreter)
     {
@@ -61,11 +79,12 @@ public class SharpTSAsyncGenerator : ITypeCategorized
             return new SharpTSIteratorResult(SharpTSUndefined.Instance, done: true);
         }
 
-        // Execute the generator body on first call (async)
-        if (_values == null)
-        {
-            await ExecuteBodyAsync();
-        }
+        // Execute the generator body on the first call; serialize concurrent/overlapping next() calls by
+        // awaiting the same drain task. A second next() issued before the first settles must wait for the
+        // shared drain and then hand out the next collected value in call order — not race ahead and read
+        // the not-yet-populated _values list as completion (#690).
+        _drainTask ??= ExecuteBodyAsync();
+        await _drainTask;
 
         // Defensive check: ExecuteBodyAsync should always initialize _values,
         // but verify to provide a clear error message if something goes wrong.
@@ -145,8 +164,11 @@ public class SharpTSAsyncGenerator : ITypeCategorized
             return;
         }
 
-        // Save and set the interpreter environment
+        // Save and set the interpreter environment. _callerEnv is the scope the drain must restore
+        // whenever it suspends at an await, so the shared interpreter environment is never left pointing
+        // at this generator's closure while control is elsewhere (#689, #690).
         RuntimeEnvironment previousEnv = _interpreter.Environment;
+        _callerEnv = previousEnv;
         _interpreter.SetEnvironment(_environment);
 
         try
@@ -173,6 +195,30 @@ public class SharpTSAsyncGenerator : ITypeCategorized
         finally
         {
             _interpreter.SetEnvironment(previousEnv);
+        }
+    }
+
+    /// <summary>
+    /// Awaits a host task at a point where the eager body drain suspends, keeping the interpreter's
+    /// shared ambient environment consistent across the suspension. The drain runs with that environment
+    /// repointed at this generator's closure; this restores the caller's environment (<see cref="_callerEnv"/>)
+    /// before suspending — so control returning to the caller, or interleaved event-loop work, sees the
+    /// correct scope — and re-asserts the generator's environment on resume so the drain continues in the
+    /// right scope. Without it, an outer binding read after the generator is driven resolves against the
+    /// wrong scope: "Undefined variable" in a for-await body (#689) or a member access on the wrong value
+    /// (#690). Mirrors the caller-state save/restore the synchronous generator performs at each yield.
+    /// </summary>
+    private async Task<object?> AwaitDetached(Task<object?> task)
+    {
+        RuntimeEnvironment generatorEnv = _interpreter.Environment;
+        _interpreter.SetEnvironment(_callerEnv ?? generatorEnv);
+        try
+        {
+            return await task;
+        }
+        finally
+        {
+            _interpreter.SetEnvironment(generatorEnv);
         }
     }
 
@@ -482,14 +528,15 @@ public class SharpTSAsyncGenerator : ITypeCategorized
         {
             // Recursively evaluate the inner expression (may contain await)
             var value = await EvaluateAsync(awaitExpr.Expression);
-            // Handle SharpTSPromise (wraps Task<object?>)
+            // Handle SharpTSPromise (wraps Task<object?>). Await through AwaitDetached so the suspension
+            // does not leak this generator's closure into the shared interpreter environment (#689, #690).
             if (value is SharpTSPromise promise)
             {
-                return await promise.Task;
+                return await AwaitDetached(promise.Task);
             }
             if (value is Task<object?> task)
             {
-                return await task;
+                return await AwaitDetached(task);
             }
             return value;
         }
@@ -524,7 +571,7 @@ public class SharpTSAsyncGenerator : ITypeCategorized
             {
                 while (true)
                 {
-                    var result = await asyncGen.Next();
+                    var result = await AwaitDetached(asyncGen.Next());
                     if (result is SharpTSIteratorResult ir)
                     {
                         if (ir.Done) break;
@@ -547,11 +594,12 @@ public class SharpTSAsyncGenerator : ITypeCategorized
         }
         else
         {
-            // If yielding a promise, await it first
+            // If yielding a promise, await it first (through AwaitDetached so the suspension does not
+            // leak this generator's closure into the shared interpreter environment — #689, #690).
             var value = yield.Value;
             if (value is Task<object?> task)
             {
-                value = await task;
+                value = await AwaitDetached(task);
             }
             _values!.Add(value);
         }

--- a/SharpTS.Tests/SharedTests/AsyncGeneratorTests.cs
+++ b/SharpTS.Tests/SharedTests/AsyncGeneratorTests.cs
@@ -1242,11 +1242,15 @@ public class AsyncGeneratorTests
     }
 
     [Theory]
-    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void AsyncGenerator_PendingAwait_DirectNext_ResolvesInOrder(ExecutionMode mode)
     {
-        // Driving a pending-await async generator by awaiting next() directly (compiled mode; the
-        // interpreter eagerly drains the body, a separate non-conformant model). #631.
+        // Driving a pending-await async generator by awaiting next() directly. #631 (compiled). Now also
+        // covered in the interpreter: a second `await it.next()` previously read `it` against a scope the
+        // generator's eager drain had corrupted ("Only instances and objects have properties"); the drain
+        // now restores the caller's environment across each suspension (#690), so sequential next() calls
+        // resolve in order. The eager-drain model still collects values eagerly, but the observable result
+        // matches the spec for this finite, no-sent-value case.
         var source = """
             function later(n: number): Promise<number> {
                 return new Promise(res => setTimeout(() => res(n), 5));
@@ -1288,12 +1292,15 @@ public class AsyncGeneratorTests
     }
 
     [Theory]
-    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void AsyncGenerator_ConcurrentNext_QueuesInOrder(ExecutionMode mode)
     {
         // Two next() calls issued before the first settles must be serviced FIFO (ECMA-262 §27.6.3
-        // AsyncGeneratorQueue), modeled as a task chain — not rejected as "already running" (#542).
-        // Compiled-only: the interpreter's eager-drain async generator can't service concurrent next().
+        // AsyncGeneratorQueue): compiled mode models it as a task chain (#542); the interpreter serializes
+        // every caller on one shared body drain, then hands out collected values in call order, so a
+        // second next() can no longer race ahead and read the not-yet-populated values list as completion
+        // (#690). Previously the interpreter threw "Only instances and objects have properties" here (the
+        // env-leak symptom) and could not service concurrent next() at all.
         var source = """
             function later(n: number): Promise<number> {
                 return new Promise(res => setTimeout(() => res(n), 5));
@@ -1308,6 +1315,59 @@ public class AsyncGeneratorTests
             """;
 
         Assert.Equal("1 false 2 false\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AsyncGenerator_ForAwaitBody_WritesOuterBinding(ExecutionMode mode)
+    {
+        // #689: a `let`/`const` declared before a `for await…of` over a (genuinely-async) async generator
+        // must remain visible inside the loop body. The interpreter's eager drain repointed the shared
+        // environment at the generator's closure and held it across the body's awaits, so the loop body
+        // resolved `out` against the wrong scope and threw "Undefined variable 'out'". The drain now
+        // restores the caller's environment across each suspension, so the body reaches the enclosing
+        // scope in both modes.
+        var source = """
+            function later(n: number): Promise<number> {
+                return new Promise(res => setTimeout(() => res(n), 5));
+            }
+            async function* g() { yield await later(1); yield await later(2); }
+            async function main() {
+                let out = "";
+                for await (const v of g()) out += v;
+                console.log(out);
+            }
+            main();
+            """;
+
+        Assert.Equal("12\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AsyncGenerator_DirectNext_PreservesCallerScope(ExecutionMode mode)
+    {
+        // #690 (env-leak symptom): after the first `await it.next()` drives the generator's eager drain,
+        // bindings declared before it (here `it` itself and the outer `tag`) must still resolve in the
+        // caller's scope. Previously a second `it.next()` read `it` against the leaked generator closure
+        // and threw "Only instances and objects have properties", and an outer local read back as
+        // undefined. The drain now restores the caller's environment across each await suspension.
+        var source = """
+            function later(n: number): Promise<number> {
+                return new Promise(res => setTimeout(() => res(n), 5));
+            }
+            async function* g() { yield await later(1); yield await later(2); }
+            async function main() {
+                let tag = "T";
+                const it = g();
+                const a = await it.next();
+                const b = await it.next();
+                console.log(tag + " " + a.value + " " + b.value);
+            }
+            main();
+            """;
+
+        Assert.Equal("T 1 2\n", TestHarness.Run(source, mode));
     }
 
     [Theory]

--- a/SharpTS.Tests/SharedTests/AsyncGeneratorTests.cs
+++ b/SharpTS.Tests/SharedTests/AsyncGeneratorTests.cs
@@ -1371,6 +1371,33 @@ public class AsyncGeneratorTests
     }
 
     [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AsyncGenerator_ForAwaitBody_OuterBinding_SurvivesNestedAwaitBody(ExecutionMode mode)
+    {
+        // #689 hardening: a generator body whose await is nested inside a delegated expression
+        // (`yield dbl(await later(n))`) suspends through the interpreter's general async-expression path,
+        // not the generator's own await chokepoint, so the generator alone can't keep its closure from
+        // leaking for that shape. The for-await driver re-asserts the loop's lexical scope after each
+        // next(), so the loop body still reaches the outer `out` binding regardless of the body shape.
+        // (Direct `await it.next()` of such a body is the narrower residual tracked in #752.)
+        var source = """
+            function later(n: number): Promise<number> {
+                return new Promise(res => setTimeout(() => res(n), 5));
+            }
+            function dbl(n: number): number { return n * 2; }
+            async function* g() { yield dbl(await later(1)); yield dbl(await later(2)); }
+            async function main() {
+                let out = "";
+                for await (const v of g()) out += v;
+                console.log(out);
+            }
+            main();
+            """;
+
+        Assert.Equal("24\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
     [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
     public void AsyncGenerator_ForAwaitOf_OverPendingAsyncGenerator_SuspendsNotBlocks(ExecutionMode mode)
     {


### PR DESCRIPTION
## Summary

Fixes #689 and #690 — two interpreter-only async-generator bugs that turned out to share **one root cause**.

The interpreter's eager-drain `SharpTSAsyncGenerator` repointed the shared `_interpreter.Environment` at the generator's own closure in `ExecuteBodyAsync` and **held it across the body's `await` suspensions** (restoring only in the post-drain `finally`). So when control returned to the caller, variable resolution ran against the generator's closure instead of the caller's scope:

- **#689** — `let out = ""; for await (const v of g()) out += v;` threw `Runtime Error: Undefined variable 'out'` (the loop body resolved `out` against the wrong scope).
- **#690** — the second `it.next()` resolved `it` against the leaked closure → `Runtime Error: Only instances and objects have properties`. This bit even two **sequential** `await it.next()` calls, not only the concurrent `Promise.all([it.next(), it.next()])` form in the issue.

Compiled mode was already correct for both.

## What changed

**`Runtime/Types/SharpTSAsyncGenerator.cs`**
- Capture the caller's environment (`_callerEnv`) when the drain begins.
- New `AwaitDetached` helper restores `_callerEnv` before suspending at a guest-promise await and re-asserts the generator's environment on resume — so the generator never leaves its closure installed while control is elsewhere. Applied at the generator's await chokepoints (`Expr.Await`, and `HandleYieldAsync` for yield-of-promise / `yield*`-to-async-generator). This mirrors the discipline the synchronous `SharpTSGenerator` already uses (caller-state save/restore at each yield).
- Serialize concurrent `next()` on a single shared `_drainTask` (`_drainTask ??= ExecuteBodyAsync(); await _drainTask;`). The old `if (_values == null)` gate let a second concurrent call see `_values` already set to an empty list (it is created at drain start) and wrongly report completion before any value was collected. All callers now await the same drain and hand out collected values in call order (FIFO, per ECMA-262 §27.6.3).

**`Execution/Interpreter.Async.cs`**
- `IterateAsyncIterator` re-asserts the `for await` statement's lexical scope after each `next()`. The loop body must run in the loop's own scope regardless of how the iterator's `next()` mutated the ambient environment. This makes the for-await path robust for **every** generator body shape — including bodies whose `await` is nested in a delegated expression (`yield dbl(await x())`), which suspend through the interpreter's general async path rather than the generator's own chokepoint — and also hardens for-await against any custom async iterator with environment side effects.

## Tests

- Added 3 All-mode regression tests in `AsyncGeneratorTests.cs` (for-await body writing an outer binding; sequential `next()` preserving caller scope; for-await over a nested-await body).
- **Promoted 2 previously `CompiledOnly` tests to All-mode** — `AsyncGenerator_ConcurrentNext_QueuesInOrder` and `AsyncGenerator_PendingAwait_DirectNext_ResolvesInOrder` — which crashed in the interpreter before this fix and now pass (a conformance gain). Their comments are updated to explain the new interpreter behavior.
- Full suite green (**13026 passing**). The single failure in the full run was `ClusterModuleTests.Fork_WorkersShareHttpPort` — an unrelated HTTP-port/worker-fork timeout under parallel load that passes in isolation (filed #747).

## Reviewer notes / scope

- The change is confined to the interpreter's async-generator runtime and the for-await driver. Compiled mode is untouched.
- I deliberately did **not** attempt the full thread-based lazy async-generator rewrite. The codebase treats the eager-drain model as an accepted limitation (many `CompiledOnly` tests document it), so this targeted env-leak fix matches the issues without the risk of a large rewrite.
- Out-of-scope residuals encountered and filed:
  - #752 — narrow residual: direct `await it.next()` of a body whose `await` is nested in a delegated expression still leaks (cannot be contained from the generator side; the for-await consumption of that shape is fixed here).
  - #717 (pre-existing) — `for await` *inside* an async generator throws "Cannot iterate over non-iterable value".
  - #747 — the flaky cluster test noted above.
