### PR TITLE
Fix #693: rewrite ECMAScript shorthand classes (\d \w \s) to JS-exact sets

### DIFF
--- a/Compilation/RuntimeEmitter.TSRegExp.cs
+++ b/Compilation/RuntimeEmitter.TSRegExp.cs
@@ -42,6 +42,8 @@ public partial class RuntimeEmitter
     private MethodBuilder _tsRegExpFindGroupCloseMethod = null!;
     private FieldBuilder _tsRegExpCompileCacheField = null!;
     private MethodBuilder _tsRegExpGetCachedRegexMethod = null!;
+    private MethodBuilder _tsRegExpRewriteShorthandsMethod = null!;
+    private MethodBuilder _tsRegExpExpandShorthandMethod = null!;
     private MethodBuilder _tsRegExpSetLastIndexStrictMethod = null!;
     private MethodBuilder _tsRegExpResolveLastIndexMethod = null!;
 
@@ -79,6 +81,11 @@ public partial class RuntimeEmitter
         _tsRegExpCompileCacheField = typeBuilder.DefineField(
             "_compileCache", cdType, FieldAttributes.Private | FieldAttributes.Static);
         EmitTSRegExpCompileCacheCctor(typeBuilder, cdType);
+        // JS→.NET shorthand rewrite (\d \w \s and negations) — emitted before
+        // _GetCachedRegex, whose cache-miss branch compiles the rewritten
+        // pattern. ExpandShorthand must precede the rewriter that calls it.
+        EmitTSRegExpExpandShorthand(typeBuilder);
+        EmitTSRegExpRewriteShorthands(typeBuilder);
         EmitTSRegExpGetCachedRegex(typeBuilder, cdType);
 
         // Helper method for normalizing flags
@@ -219,8 +226,12 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Callvirt, cdType.GetMethod("TryGetValue")!);
         il.Emit(OpCodes.Brtrue, hitLabel);
 
-        // var fresh = new Regex(pattern, options); _compileCache.TryAdd(key, fresh); return fresh
+        // var fresh = new Regex(RewriteEcmaScriptShorthands(pattern), options);
+        // _compileCache.TryAdd(key, fresh); return fresh
+        // The key (built above from the raw pattern) is unchanged, so the
+        // rewrite runs only on a cache miss — never on the hot cache-hit path.
         il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Call, _tsRegExpRewriteShorthandsMethod);
         il.Emit(OpCodes.Ldarg_1);
         il.Emit(OpCodes.Newobj, typeof(Regex).GetConstructor([_types.String, typeof(RegexOptions)])!);
         il.Emit(OpCodes.Stloc, freshLocal);
@@ -235,6 +246,176 @@ public partial class RuntimeEmitter
         il.MarkLabel(hitLabel);
         il.Emit(OpCodes.Ldloc, cachedLocal);
         il.Emit(OpCodes.Ret);
+    }
+
+    /// <summary>
+    /// Emits <c>static string ExpandShorthand(char esc, bool inClass)</c> — the
+    /// per-escape replacement table consumed by
+    /// <see cref="EmitTSRegExpRewriteShorthands"/>. Returns the explicit class
+    /// for a positive shorthand (<c>\d \w \s</c>, inside or outside a class) or
+    /// its bracketed/negated form (<c>\D \W \S</c>, outside a class only);
+    /// returns <c>null</c> for a non-shorthand letter or a negated shorthand
+    /// inside a class (both pass through unchanged). Mirrors
+    /// <c>SharpTSRegExp.ExpandShorthand</c> (interp).
+    /// </summary>
+    private void EmitTSRegExpExpandShorthand(TypeBuilder typeBuilder)
+    {
+        var method = typeBuilder.DefineMethod(
+            "ExpandShorthand", MethodAttributes.Private | MethodAttributes.Static,
+            _types.String, [_types.Char, _types.Boolean]);
+        _tsRegExpExpandShorthandMethod = method;
+        var il = method.GetILGenerator();
+
+        // The whitespace class inner is baked in straight from the interp
+        // constant, so both modes match the exact same set (one source of truth).
+        var ws = Runtime.Types.SharpTSRegExp.WhitespaceClassInner;
+
+        var ld = il.DefineLabel(); var lD = il.DefineLabel();
+        var lw = il.DefineLabel(); var lW = il.DefineLabel();
+        var ls = il.DefineLabel(); var lS = il.DefineLabel();
+
+        // switch (esc) { ... default: return null; }
+        void Dispatch(char ch, Label lbl)
+        {
+            il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Ldc_I4, (int)ch); il.Emit(OpCodes.Beq, lbl);
+        }
+        Dispatch('d', ld); Dispatch('D', lD); Dispatch('w', lw);
+        Dispatch('W', lW); Dispatch('s', ls); Dispatch('S', lS);
+        il.Emit(OpCodes.Ldnull); il.Emit(OpCodes.Ret);
+
+        // return inClass ? inside : outside  (inside == null → Ldnull)
+        void Case(Label lbl, string? inside, string outside)
+        {
+            il.MarkLabel(lbl);
+            var inLbl = il.DefineLabel();
+            il.Emit(OpCodes.Ldarg_1); il.Emit(OpCodes.Brtrue, inLbl);
+            il.Emit(OpCodes.Ldstr, outside); il.Emit(OpCodes.Ret);
+            il.MarkLabel(inLbl);
+            if (inside == null) il.Emit(OpCodes.Ldnull);
+            else il.Emit(OpCodes.Ldstr, inside);
+            il.Emit(OpCodes.Ret);
+        }
+        Case(ld, "0-9", "[0-9]");
+        Case(lD, null, "[^0-9]");
+        Case(lw, "A-Za-z0-9_", "[A-Za-z0-9_]");
+        Case(lW, null, "[^A-Za-z0-9_]");
+        Case(ls, ws, "[" + ws + "]");
+        Case(lS, null, "[^" + ws + "]");
+    }
+
+    /// <summary>
+    /// Emits <c>static string RewriteEcmaScriptShorthands(string pattern)</c> —
+    /// the compiled mirror of <c>SharpTSRegExp.RewriteEcmaScriptShorthands</c>.
+    /// Rewrites the JS shorthand escapes to explicit ECMAScript-exact sets so the
+    /// compiled .NET matcher follows JS semantics (sidesteps .NET's <c>\w</c>
+    /// U+0130 over-match and its narrow <c>\s</c>). Single forward pass tracking
+    /// <c>[…]</c> context and honoring backslash escapes; lazily allocates a
+    /// StringBuilder so a pattern with no rewritable shorthand returns the
+    /// original reference. Self-contained (BCL-only) — no SharpTS.dll reference.
+    /// </summary>
+    private void EmitTSRegExpRewriteShorthands(TypeBuilder typeBuilder)
+    {
+        var method = typeBuilder.DefineMethod(
+            "RewriteEcmaScriptShorthands", MethodAttributes.Private | MethodAttributes.Static,
+            _types.String, [_types.String]);
+        _tsRegExpRewriteShorthandsMethod = method;
+        var il = method.GetILGenerator();
+
+        var getLen = _types.String.GetProperty("Length")!.GetGetMethod()!;
+        var getChars = _types.String.GetMethod("get_Chars", [_types.Int32])!;
+        var sbCtorInt = _types.StringBuilder.GetConstructor([_types.Int32])!;
+        var sbAppendStr = _types.StringBuilder.GetMethod("Append", [_types.String])!;
+        var sbAppendChar = _types.StringBuilder.GetMethod("Append", [_types.Char])!;
+        var sbAppendSub = _types.StringBuilder.GetMethod("Append", [_types.String, _types.Int32, _types.Int32])!;
+        var sbToString = _types.StringBuilder.GetMethod("ToString", Type.EmptyTypes)!;
+
+        var sbLocal = il.DeclareLocal(_types.StringBuilder);
+        var inClassLocal = il.DeclareLocal(_types.Boolean);
+        var nLocal = il.DeclareLocal(_types.Int32);
+        var iLocal = il.DeclareLocal(_types.Int32);
+        var cLocal = il.DeclareLocal(_types.Char);
+        var nextLocal = il.DeclareLocal(_types.Char);
+        var replLocal = il.DeclareLocal(_types.String);
+
+        var loopCond = il.DefineLabel();
+        var normalChar = il.DefineLabel();
+        var replNull = il.DefineLabel();
+        var haveSb = il.DefineLabel();
+        var replNullAdvance = il.DefineLabel();
+        var chkClose = il.DefineLabel();
+        var appendC = il.DefineLabel();
+        var incr = il.DefineLabel();
+        var endLabel = il.DefineLabel();
+        var retSb = il.DefineLabel();
+
+        // sb = null; inClass = false; n = pattern.Length; i = 0
+        il.Emit(OpCodes.Ldnull); il.Emit(OpCodes.Stloc, sbLocal);
+        il.Emit(OpCodes.Ldc_I4_0); il.Emit(OpCodes.Stloc, inClassLocal);
+        il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Callvirt, getLen); il.Emit(OpCodes.Stloc, nLocal);
+        il.Emit(OpCodes.Ldc_I4_0); il.Emit(OpCodes.Stloc, iLocal);
+
+        il.MarkLabel(loopCond);
+        // if (i >= n) goto end
+        il.Emit(OpCodes.Ldloc, iLocal); il.Emit(OpCodes.Ldloc, nLocal); il.Emit(OpCodes.Bge, endLabel);
+        // c = pattern[i]
+        il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Ldloc, iLocal); il.Emit(OpCodes.Callvirt, getChars); il.Emit(OpCodes.Stloc, cLocal);
+        // if (c != '\\') goto normalChar
+        il.Emit(OpCodes.Ldloc, cLocal); il.Emit(OpCodes.Ldc_I4, (int)'\\'); il.Emit(OpCodes.Bne_Un, normalChar);
+        // if (i + 1 >= n) goto normalChar   (lone trailing backslash → literal)
+        il.Emit(OpCodes.Ldloc, iLocal); il.Emit(OpCodes.Ldc_I4_1); il.Emit(OpCodes.Add); il.Emit(OpCodes.Ldloc, nLocal); il.Emit(OpCodes.Bge, normalChar);
+
+        // --- escape branch ---
+        // next = pattern[i + 1]
+        il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Ldloc, iLocal); il.Emit(OpCodes.Ldc_I4_1); il.Emit(OpCodes.Add); il.Emit(OpCodes.Callvirt, getChars); il.Emit(OpCodes.Stloc, nextLocal);
+        // repl = ExpandShorthand(next, inClass)
+        il.Emit(OpCodes.Ldloc, nextLocal); il.Emit(OpCodes.Ldloc, inClassLocal); il.Emit(OpCodes.Call, _tsRegExpExpandShorthandMethod); il.Emit(OpCodes.Stloc, replLocal);
+        // if (repl == null) goto replNull
+        il.Emit(OpCodes.Ldloc, replLocal); il.Emit(OpCodes.Brfalse, replNull);
+        //   if (sb != null) goto haveSb
+        il.Emit(OpCodes.Ldloc, sbLocal); il.Emit(OpCodes.Brtrue, haveSb);
+        //     sb = new StringBuilder(n + 16); sb.Append(pattern, 0, i)
+        il.Emit(OpCodes.Ldloc, nLocal); il.Emit(OpCodes.Ldc_I4, 16); il.Emit(OpCodes.Add); il.Emit(OpCodes.Newobj, sbCtorInt); il.Emit(OpCodes.Stloc, sbLocal);
+        il.Emit(OpCodes.Ldloc, sbLocal); il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Ldc_I4_0); il.Emit(OpCodes.Ldloc, iLocal); il.Emit(OpCodes.Callvirt, sbAppendSub); il.Emit(OpCodes.Pop);
+        il.MarkLabel(haveSb);
+        //   sb.Append(repl)
+        il.Emit(OpCodes.Ldloc, sbLocal); il.Emit(OpCodes.Ldloc, replLocal); il.Emit(OpCodes.Callvirt, sbAppendStr); il.Emit(OpCodes.Pop);
+        //   i += 2; goto loopCond
+        il.Emit(OpCodes.Ldloc, iLocal); il.Emit(OpCodes.Ldc_I4_2); il.Emit(OpCodes.Add); il.Emit(OpCodes.Stloc, iLocal);
+        il.Emit(OpCodes.Br, loopCond);
+
+        il.MarkLabel(replNull);
+        //   if (sb == null) goto replNullAdvance   (nothing buffered yet)
+        il.Emit(OpCodes.Ldloc, sbLocal); il.Emit(OpCodes.Brfalse, replNullAdvance);
+        //   sb.Append('\\'); sb.Append(next)
+        il.Emit(OpCodes.Ldloc, sbLocal); il.Emit(OpCodes.Ldc_I4, (int)'\\'); il.Emit(OpCodes.Callvirt, sbAppendChar); il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Ldloc, sbLocal); il.Emit(OpCodes.Ldloc, nextLocal); il.Emit(OpCodes.Callvirt, sbAppendChar); il.Emit(OpCodes.Pop);
+        il.MarkLabel(replNullAdvance);
+        //   i += 2; goto loopCond
+        il.Emit(OpCodes.Ldloc, iLocal); il.Emit(OpCodes.Ldc_I4_2); il.Emit(OpCodes.Add); il.Emit(OpCodes.Stloc, iLocal);
+        il.Emit(OpCodes.Br, loopCond);
+
+        il.MarkLabel(normalChar);
+        // if (c == '[') inClass = true; else if (c == ']') inClass = false;
+        il.Emit(OpCodes.Ldloc, cLocal); il.Emit(OpCodes.Ldc_I4, (int)'['); il.Emit(OpCodes.Bne_Un, chkClose);
+        il.Emit(OpCodes.Ldc_I4_1); il.Emit(OpCodes.Stloc, inClassLocal); il.Emit(OpCodes.Br, appendC);
+        il.MarkLabel(chkClose);
+        il.Emit(OpCodes.Ldloc, cLocal); il.Emit(OpCodes.Ldc_I4, (int)']'); il.Emit(OpCodes.Bne_Un, appendC);
+        il.Emit(OpCodes.Ldc_I4_0); il.Emit(OpCodes.Stloc, inClassLocal);
+        il.MarkLabel(appendC);
+        // if (sb != null) sb.Append(c)
+        il.Emit(OpCodes.Ldloc, sbLocal); il.Emit(OpCodes.Brfalse, incr);
+        il.Emit(OpCodes.Ldloc, sbLocal); il.Emit(OpCodes.Ldloc, cLocal); il.Emit(OpCodes.Callvirt, sbAppendChar); il.Emit(OpCodes.Pop);
+        il.MarkLabel(incr);
+        // i += 1; goto loopCond
+        il.Emit(OpCodes.Ldloc, iLocal); il.Emit(OpCodes.Ldc_I4_1); il.Emit(OpCodes.Add); il.Emit(OpCodes.Stloc, iLocal);
+        il.Emit(OpCodes.Br, loopCond);
+
+        il.MarkLabel(endLabel);
+        // return sb == null ? pattern : sb.ToString()
+        il.Emit(OpCodes.Ldloc, sbLocal); il.Emit(OpCodes.Brtrue, retSb);
+        il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Ret);
+        il.MarkLabel(retSb);
+        il.Emit(OpCodes.Ldloc, sbLocal); il.Emit(OpCodes.Callvirt, sbToString); il.Emit(OpCodes.Ret);
     }
 
     private void EmitTSRegExpNormalizeFlags(TypeBuilder typeBuilder, EmittedRuntime runtime)

--- a/Runtime/Types/SharpTSRegExp.cs
+++ b/Runtime/Types/SharpTSRegExp.cs
@@ -207,8 +207,13 @@ public class SharpTSRegExp : ITypeCategorized
 
         try
         {
+            // Rewrite the JS shorthand escapes (\d \w \s and negations) to
+            // explicit ECMAScript-exact sets before compiling — see
+            // RewriteEcmaScriptShorthands. The cache key stays the *original*
+            // pattern, so the rewrite runs only on a cache miss (once per
+            // distinct literal) and never on the hot cache-hit path.
             _regex = _compileCache.GetOrAdd((pattern, options),
-                static key => new Regex(key.Pattern, key.Options));
+                static key => new Regex(RewriteEcmaScriptShorthands(key.Pattern), key.Options));
         }
         catch (ArgumentException ex)
         {
@@ -224,6 +229,93 @@ public class SharpTSRegExp : ITypeCategorized
                 new SharpTSSyntaxError($"Invalid regular expression: {ex.Message}"));
         }
     }
+
+    // ECMA-262 §22.2.2.10 WhiteSpace + LineTerminator — the exact set JS `\s`
+    // matches: [ \t\n\v\f\r] plus the Unicode space separators (Zs) and the
+    // line/paragraph separators. Written as the *inner* of a character class so
+    // it can be spliced into `[…]` (positive) or `[^…]` (negated). The emitted
+    // `$RegExp` mirror bakes this exact value in via Ldstr (RuntimeEmitter.TSRegExp.cs),
+    // so there is a single source of truth for the set.
+    internal const string WhitespaceClassInner =
+        @"\t\n\x0B\f\r\x20\xA0\u1680\u2000-\u200A\u2028\u2029\u202F\u205F\u3000\uFEFF";
+
+    /// <summary>
+    /// Rewrites the ECMAScript shorthand class escapes (<c>\d \D \w \W \s \S</c>)
+    /// to explicit character sets before the pattern is handed to .NET, so the
+    /// compiled matcher follows JS semantics rather than .NET's. This sidesteps
+    /// two divergences in <see cref="RegexOptions.ECMAScript"/> mode:
+    /// <list type="bullet">
+    /// <item>.NET's <c>\w</c> matches U+0130 (İ); JS's does not.</item>
+    /// <item>.NET's <c>\s</c> is just <c>[ \t\n\v\f\r]</c> — missing the Unicode
+    /// WhiteSpace/LineTerminator chars JS includes (U+00A0, U+1680,
+    /// U+2000–U+200A, U+2028, U+2029, U+202F, U+205F, U+3000, U+FEFF).</item>
+    /// </list>
+    /// In the non-ECMAScript fallback (named groups / <c>s</c> flag) the same
+    /// shorthands are Unicode-broad in .NET, so pinning them to the JS sets there
+    /// is also a fix, not a regression. The rewrite is context-aware: the
+    /// positive forms expand both inside and outside <c>[…]</c> classes; the
+    /// negated forms (<c>\D \W \S</c>) expand only *outside* a class — a negated
+    /// shorthand inside a class can't be expressed without engine-level class
+    /// nesting, so those pass through unchanged (tracked by #749). Backslash
+    /// escapes are respected, so <c>\\d</c>, <c>\cd</c>, backreferences, etc. are
+    /// left untouched. <c>iu</c>-mode case-folding edge cases (K U+212A, ſ U+017F
+    /// folding into <c>\w</c>) remain out of scope.
+    /// The RegExp's <c>source</c> keeps the original pattern; only the internal
+    /// matcher sees the rewrite.
+    /// </summary>
+    internal static string RewriteEcmaScriptShorthands(string pattern)
+    {
+        StringBuilder? sb = null;
+        bool inClass = false;
+        int n = pattern.Length;
+        for (int i = 0; i < n; i++)
+        {
+            char c = pattern[i];
+            if (c == '\\' && i + 1 < n)
+            {
+                char next = pattern[i + 1];
+                string? repl = ExpandShorthand(next, inClass);
+                if (repl != null)
+                {
+                    // Lazily allocate, back-filling the untouched prefix.
+                    if (sb == null)
+                    {
+                        sb = new StringBuilder(n + 16);
+                        sb.Append(pattern, 0, i);
+                    }
+                    sb.Append(repl);
+                }
+                else
+                {
+                    // Not a rewritable shorthand (or a negated form inside a
+                    // class) — copy the escape pair through verbatim.
+                    sb?.Append('\\').Append(next);
+                }
+                i++; // also consume the escaped char
+                continue;
+            }
+            if (c == '[') inClass = true;
+            else if (c == ']') inClass = false;
+            sb?.Append(c);
+        }
+        return sb == null ? pattern : sb.ToString();
+    }
+
+    /// <summary>
+    /// Returns the explicit replacement for a shorthand escape letter, or
+    /// <c>null</c> when the letter is not a shorthand or is a negated shorthand
+    /// inside a character class (which must pass through unchanged).
+    /// </summary>
+    private static string? ExpandShorthand(char esc, bool inClass) => esc switch
+    {
+        'd' => inClass ? "0-9" : "[0-9]",
+        'D' => inClass ? null : "[^0-9]",
+        'w' => inClass ? "A-Za-z0-9_" : "[A-Za-z0-9_]",
+        'W' => inClass ? null : "[^A-Za-z0-9_]",
+        's' => inClass ? WhitespaceClassInner : "[" + WhitespaceClassInner + "]",
+        'S' => inClass ? null : "[^" + WhitespaceClassInner + "]",
+        _ => null,
+    };
 
     /// <summary>
     /// ECMA-262 §22.2.3.3 flag validation: throws SyntaxError if a flag is not

--- a/SharpTS.Test262/baselines/compiled.txt
+++ b/SharpTS.Test262/baselines/compiled.txt
@@ -8119,13 +8119,13 @@ test/built-ins/RegExp/CharacterClassEscapes/character-class-digit-class-escape-n
 test/built-ins/RegExp/CharacterClassEscapes/character-class-digit-class-escape-positive-cases.js Pass
 test/built-ins/RegExp/CharacterClassEscapes/character-class-non-digit-class-escape-negative-cases.js Pass
 test/built-ins/RegExp/CharacterClassEscapes/character-class-non-digit-class-escape-positive-cases.js Pass
-test/built-ins/RegExp/CharacterClassEscapes/character-class-non-whitespace-class-escape-negative-cases.js Fail
+test/built-ins/RegExp/CharacterClassEscapes/character-class-non-whitespace-class-escape-negative-cases.js Pass
 test/built-ins/RegExp/CharacterClassEscapes/character-class-non-whitespace-class-escape-positive-cases.js Pass
 test/built-ins/RegExp/CharacterClassEscapes/character-class-non-word-class-escape-negative-cases.js Pass
-test/built-ins/RegExp/CharacterClassEscapes/character-class-non-word-class-escape-positive-cases.js Fail
+test/built-ins/RegExp/CharacterClassEscapes/character-class-non-word-class-escape-positive-cases.js Pass
 test/built-ins/RegExp/CharacterClassEscapes/character-class-whitespace-class-escape-negative-cases.js Pass
-test/built-ins/RegExp/CharacterClassEscapes/character-class-whitespace-class-escape-positive-cases.js Fail
-test/built-ins/RegExp/CharacterClassEscapes/character-class-word-class-escape-negative-cases.js Fail
+test/built-ins/RegExp/CharacterClassEscapes/character-class-whitespace-class-escape-positive-cases.js Pass
+test/built-ins/RegExp/CharacterClassEscapes/character-class-word-class-escape-negative-cases.js Pass
 test/built-ins/RegExp/CharacterClassEscapes/character-class-word-class-escape-positive-cases.js Pass
 test/built-ins/RegExp/S15.10.1_A1_T1.js Pass
 test/built-ins/RegExp/S15.10.1_A1_T10.js Pass
@@ -8503,7 +8503,7 @@ test/built-ins/RegExp/call_with_non_regexp_same_constructor.js Pass
 test/built-ins/RegExp/call_with_regexp_match_falsy.js Pass
 test/built-ins/RegExp/call_with_regexp_not_same_constructor.js Pass
 test/built-ins/RegExp/character-class-escape-non-whitespace-u180e.js Pass
-test/built-ins/RegExp/character-class-escape-non-whitespace.js Fail
+test/built-ins/RegExp/character-class-escape-non-whitespace.js Pass
 test/built-ins/RegExp/dotall/with-dotall-unicode.js Fail
 test/built-ins/RegExp/dotall/with-dotall.js Pass
 test/built-ins/RegExp/dotall/without-dotall-unicode.js Fail

--- a/SharpTS.Test262/baselines/interpreted.txt
+++ b/SharpTS.Test262/baselines/interpreted.txt
@@ -8119,13 +8119,13 @@ test/built-ins/RegExp/CharacterClassEscapes/character-class-digit-class-escape-n
 test/built-ins/RegExp/CharacterClassEscapes/character-class-digit-class-escape-positive-cases.js Pass
 test/built-ins/RegExp/CharacterClassEscapes/character-class-non-digit-class-escape-negative-cases.js Pass
 test/built-ins/RegExp/CharacterClassEscapes/character-class-non-digit-class-escape-positive-cases.js Pass
-test/built-ins/RegExp/CharacterClassEscapes/character-class-non-whitespace-class-escape-negative-cases.js Fail
+test/built-ins/RegExp/CharacterClassEscapes/character-class-non-whitespace-class-escape-negative-cases.js Pass
 test/built-ins/RegExp/CharacterClassEscapes/character-class-non-whitespace-class-escape-positive-cases.js Pass
 test/built-ins/RegExp/CharacterClassEscapes/character-class-non-word-class-escape-negative-cases.js Pass
-test/built-ins/RegExp/CharacterClassEscapes/character-class-non-word-class-escape-positive-cases.js Timeout
+test/built-ins/RegExp/CharacterClassEscapes/character-class-non-word-class-escape-positive-cases.js Pass
 test/built-ins/RegExp/CharacterClassEscapes/character-class-whitespace-class-escape-negative-cases.js Pass
-test/built-ins/RegExp/CharacterClassEscapes/character-class-whitespace-class-escape-positive-cases.js Fail
-test/built-ins/RegExp/CharacterClassEscapes/character-class-word-class-escape-negative-cases.js Timeout
+test/built-ins/RegExp/CharacterClassEscapes/character-class-whitespace-class-escape-positive-cases.js Pass
+test/built-ins/RegExp/CharacterClassEscapes/character-class-word-class-escape-negative-cases.js Pass
 test/built-ins/RegExp/CharacterClassEscapes/character-class-word-class-escape-positive-cases.js Pass
 test/built-ins/RegExp/S15.10.1_A1_T1.js Pass
 test/built-ins/RegExp/S15.10.1_A1_T10.js Pass
@@ -8503,7 +8503,7 @@ test/built-ins/RegExp/call_with_non_regexp_same_constructor.js Pass
 test/built-ins/RegExp/call_with_regexp_match_falsy.js Pass
 test/built-ins/RegExp/call_with_regexp_not_same_constructor.js Pass
 test/built-ins/RegExp/character-class-escape-non-whitespace-u180e.js Pass
-test/built-ins/RegExp/character-class-escape-non-whitespace.js Fail
+test/built-ins/RegExp/character-class-escape-non-whitespace.js Pass
 test/built-ins/RegExp/dotall/with-dotall-unicode.js Fail
 test/built-ins/RegExp/dotall/with-dotall.js Pass
 test/built-ins/RegExp/dotall/without-dotall-unicode.js Fail


### PR DESCRIPTION
Closes #693.

## Problem

SharpTS compiles JS regex patterns straight to `new Regex(pattern, RegexOptions.ECMAScript | …)`, but .NET's ECMAScript shorthands aren't byte-for-byte the JS sets:

- **`\w` over-matches U+0130** (`İ`): `/\w/.test("İ")` is `true` in .NET, `false` in JS.
- **`\s` is too narrow** — `[ \t\n\v\f\r]`, missing the Unicode WhiteSpace/LineTerminator chars JS includes (U+00A0, U+1680, U+2000–U+200A, U+2028, U+2029, U+202F, U+205F, U+3000, U+FEFF).

## Fix

A context-aware JS→.NET pattern rewrite (`RewriteEcmaScriptShorthands`) that replaces the shorthand escapes with explicit ECMAScript-exact sets **before** the pattern is handed to .NET:

- `\d`→`[0-9]`, `\w`→`[A-Za-z0-9_]`, `\s`→`[<WhiteSpace+LineTerminator>]` and the negations.
- Positive forms expand **inside and outside** `[…]`; negated forms (`\D \W \S`) expand only **outside** a class (a negated shorthand inside a class needs engine-level class nesting — deferred to #749).
- Backslash escapes are respected, so `\d`, `\cd`, backreferences, etc. pass through untouched.
- The rewrite also pins the shorthands in the non-ECMAScript fallback (named groups / `s` flag), where .NET's shorthands are otherwise Unicode-broad — a fix, not a regression.

### Where it hooks
Both modes apply the rewrite at the **single regex-compile chokepoint**, on the **cache-miss path only**, keyed by the original pattern — so `RegExp.source` stays the original text and the hot cache-hit path is untouched.

- Interpreter: `SharpTSRegExp.RewriteEcmaScriptShorthands` in the compile-cache factory.
- Compiled `$RegExp`: a hand-emitted **BCL-only IL mirror** called from `_GetCachedRegex`'s miss branch. The output DLL stays fully standalone (no `SharpTS.dll` reference; `--verify`/ILVerify passes). The whitespace set has **one source of truth** — the interpreter `const`, baked into the IL via `Ldstr`.

## Verification

- `/\w/.test("İ") === false` and `/\s/.test(" ") === true` in both modes ✓
- **Test262** (isolated via a clean origin/main-vs-branch scoped comparison, since the committed full-subset baseline is independently stale): **5 improvements per mode, 0 regressions**.
  - Compiled: all 4 target `RegExp/CharacterClassEscapes/` Fails → Pass.
  - Interpreter: the 2 Fails + 2 Timeouts all → Pass (explicit `[0-9]`/`[A-Za-z0-9_]` sets are faster than .NET's buggy ECMAScript path, resolving the timeouts).
  - Plus a bonus `RegExp/character-class-escape-non-whitespace.js` fix.
  - Baselines updated **surgically** (only the 10 lines this change flips) to avoid absorbing unrelated pre-existing drift.
- Full unit suite: **13021 passed, 0 failed**.

## Follow-up
- #749 — negated shorthand inside a `[…]` class (`[\W]`, `[\S]`) still diverges; needs engine-level class nesting. `iu`-mode case folding (K U+212A, ſ U+017F) also remains out of scope.

## Note for reviewers
The committed Test262 full-subset baseline was already stale vs `origin/main` (the suite isn't in CI) — a plain diff-mode run shows ~164 new passes / ~18 unrelated "regressions" in non-regex folders. This PR deliberately does **not** absorb that drift; the baseline change here is strictly the 10 regex lines this fix flips. A separate full baseline refresh is worth doing independently.