### PR TITLE
Fix #694, #700: caught host/built-in errors surface as real Error instances

### DIFF
--- a/Compilation/RuntimeEmitter.Objects.Exceptions.cs
+++ b/Compilation/RuntimeEmitter.Objects.Exceptions.cs
@@ -162,21 +162,16 @@ public partial class RuntimeEmitter
         // Return the dictionary
         il.Emit(OpCodes.Ret);
 
-        // Standard fallback: wrap standard .NET exceptions as Dictionary
+        // Standard fallback: a host-originated .NET exception (no guest __tsValue,
+        // not a rejected promise, no Node metadata). Wrap as a real $Error so guest
+        // `catch` sees a proper Error instance — `e instanceof Error` is true and
+        // `e.name` is "Error" rather than the .NET type name. Previously this returned
+        // a plain { message, name=<.NET type> } dictionary. (#700)
+        // return new $Error(ex.Message)
         il.MarkLabel(standardFallbackLabel);
-        // return new Dictionary<string, object> { ["message"] = ex.Message, ["name"] = ex.GetType().Name }
-        il.Emit(OpCodes.Newobj, _types.GetDefaultConstructor(_types.DictionaryStringObject));
-        il.Emit(OpCodes.Dup);
-        il.Emit(OpCodes.Ldstr, "message");
         il.Emit(OpCodes.Ldloc, exLocal);
         il.Emit(OpCodes.Callvirt, _types.GetProperty(_types.Exception, "Message").GetGetMethod()!);
-        il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.DictionaryStringObject, "set_Item"));
-        il.Emit(OpCodes.Dup);
-        il.Emit(OpCodes.Ldstr, "name");
-        il.Emit(OpCodes.Ldloc, exLocal);
-        il.Emit(OpCodes.Callvirt, _types.GetMethodNoParams(_types.Object, "GetType"));
-        il.Emit(OpCodes.Callvirt, _types.GetProperty(_types.Type, "Name").GetGetMethod()!);
-        il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.DictionaryStringObject, "set_Item"));
+        il.Emit(OpCodes.Newobj, runtime.TSErrorCtorMessage);
         il.Emit(OpCodes.Ret);
     }
 

--- a/Compilation/RuntimeTypes.Exceptions.cs
+++ b/Compilation/RuntimeTypes.Exceptions.cs
@@ -1,3 +1,5 @@
+using SharpTS.Runtime.Types;
+
 namespace SharpTS.Compilation;
 
 public static partial class RuntimeTypes
@@ -20,11 +22,11 @@ public static partial class RuntimeTypes
             if (reason != null) return reason;
         }
 
-        return new Dictionary<string, object?>
-        {
-            ["message"] = ex.Message,
-            ["name"] = ex.GetType().Name
-        };
+        // Wrap a host-originated exception as a real Error so guest `catch` sees a
+        // proper Error instance (`e instanceof Error`, `e.name === "Error"`) rather than
+        // a bare { message, name=<.NET type> } object. Mirrors the emitted
+        // $Runtime.WrapException standard fallback. (#700)
+        return new SharpTSError(ex.Message);
     }
 
     #endregion

--- a/Execution/Interpreter.Statements.cs
+++ b/Execution/Interpreter.Statements.cs
@@ -517,7 +517,7 @@ public partial class Interpreter
             RuntimeEnvironment catchEnv = new(_environment);
             if (tryCatch.CatchParam != null)
             {
-                catchEnv.Define(tryCatch.CatchParam.Lexeme, errorValue);
+                catchEnv.Define(tryCatch.CatchParam.Lexeme, CoerceCaughtValueForBinding(errorValue));
             }
 
             using (PushScope(catchEnv))
@@ -637,7 +637,7 @@ public partial class Interpreter
             RuntimeEnvironment catchEnv = new(_environment);
             if (tryCatch.CatchParam != null)
             {
-                catchEnv.Define(tryCatch.CatchParam.Lexeme, errorValue);
+                catchEnv.Define(tryCatch.CatchParam.Lexeme, CoerceCaughtValueForBinding(errorValue));
             }
 
             using (PushScope(catchEnv))
@@ -1085,7 +1085,74 @@ public partial class Interpreter
                 ["errno"] = nodeError.Errno.HasValue ? (double)nodeError.Errno.Value : null
             });
 
+        // Host exceptions surface as their raw message string. Built-ins signal JS errors
+        // via `throw new Exception("RangeError: ...")`, but the typed-error synthesis is
+        // deferred to CoerceCaughtValueForBinding — applied only when a value is bound to a
+        // guest `catch` parameter (#694). Doing it here instead would also convert errors
+        // on the *propagation* path, where ThrowException.FromResult relies on host errors
+        // staying strings so an uncaught strict-mode/internal error keeps propagating to the
+        // host as a plain Exception rather than becoming a top-level-swallowed guest throw.
         return ex.Message;
+    }
+
+    /// <summary>
+    /// Known JS error-name prefixes that built-ins prepend to host <see cref="Exception"/>
+    /// messages (e.g. "RangeError: ..."). Used by <see cref="CoerceCaughtValueForBinding"/>
+    /// to reconstruct a typed guest error when one is caught (#694). AggregateError is
+    /// intentionally excluded — it requires an errors array, not a bare message.
+    /// </summary>
+    private static readonly (string Prefix, string Name)[] JsErrorMessagePrefixes =
+    {
+        ("TypeError: ", "TypeError"),
+        ("RangeError: ", "RangeError"),
+        ("ReferenceError: ", "ReferenceError"),
+        ("SyntaxError: ", "SyntaxError"),
+        ("EvalError: ", "EvalError"),
+        ("URIError: ", "URIError"),
+    };
+
+    /// <summary>
+    /// Coerces a value about to be bound to a guest <c>catch</c> parameter (#694).
+    /// Built-ins signal JS errors as host exceptions whose message carries a
+    /// "&lt;Name&gt;Error: " prefix; <see cref="TranslateException"/> surfaces these as the
+    /// raw message string. When guest code catches one, present it as the matching typed
+    /// Error so <c>instanceof</c>, <c>.name</c>, and <c>.message</c> hold — parity with
+    /// compiled mode, which throws a real <c>$RangeError</c>/<c>$TypeError</c>/etc.
+    /// Non-prefixed strings and non-string values pass through unchanged, so
+    /// <c>throw "msg"</c> and <c>throw new Error()</c> keep their exact caught value.
+    /// </summary>
+    /// <remarks>
+    /// Applied only at the catch binding, never on the propagation path: an UNcaught
+    /// host error must stay a string so <see cref="ThrowException.FromResult"/> lets it
+    /// surface to the host as a plain <see cref="Exception"/> (e.g. an uncaught strict-mode
+    /// violation), rather than a top-level-swallowed guest throw.
+    /// Known limitation: a guest <c>throw "RangeError: ..."</c> — a bare string that
+    /// happens to match a runtime error-message shape — is also coerced to a typed Error.
+    /// This is indistinguishable from a host error once stringified and is not exercised by
+    /// any real code (nobody throws an error-prefixed string instead of <c>new RangeError</c>).
+    /// </remarks>
+    internal object? CoerceCaughtValueForBinding(object? value)
+        => value is string s && TryCreateGuestErrorFromMessage(s) is { } typedError
+            ? typedError
+            : value;
+
+    /// <summary>
+    /// If <paramref name="message"/> begins with a known JS error-name prefix
+    /// (e.g. "RangeError: "), returns the matching guest <see cref="SharpTSError"/>
+    /// carrying the remainder as its message; otherwise returns <c>null</c> (#694).
+    /// </summary>
+    private static SharpTSError? TryCreateGuestErrorFromMessage(string? message)
+    {
+        if (message is null) return null;
+        foreach (var (prefix, name) in JsErrorMessagePrefixes)
+        {
+            if (message.StartsWith(prefix, StringComparison.Ordinal))
+            {
+                var detail = message.Substring(prefix.Length);
+                return ErrorBuiltIns.CreateError(name, new List<object?> { detail });
+            }
+        }
+        return null;
     }
 
     /// <summary>

--- a/Runtime/Types/SharpTSAsyncGenerator.cs
+++ b/Runtime/Types/SharpTSAsyncGenerator.cs
@@ -426,7 +426,8 @@ public class SharpTSAsyncGenerator : ITypeCategorized
                     // `catch {}` (no binding) is valid — only define the param when present, and bind
                     // the unwrapped guest value rather than the boxed RuntimeValue struct.
                     if (tryCatch.CatchParam != null)
-                        catchEnv.Define(tryCatch.CatchParam.Lexeme, tryResult.Value.ToObject());
+                        catchEnv.Define(tryCatch.CatchParam.Lexeme,
+                            _interpreter.CoerceCaughtValueForBinding(tryResult.Value.ToObject()));
                     RuntimeEnvironment prevEnv = _interpreter.Environment;
                     _interpreter.SetEnvironment(catchEnv);
                     try

--- a/SharpTS.Tests/SharedTests/ErrorTests.cs
+++ b/SharpTS.Tests/SharedTests/ErrorTests.cs
@@ -581,4 +581,100 @@ public class ErrorTests
     }
 
     #endregion
+
+    #region Built-in error parity (#694)
+
+    /// <summary>
+    /// Regression for #694: built-ins signal JS errors with
+    /// <c>throw new Exception("RangeError: ...")</c>. The interpreter previously bound the
+    /// bare message string as the caught value (<c>typeof e === "string"</c>,
+    /// <c>e instanceof RangeError === false</c>, <c>e.name === undefined</c>); it now
+    /// synthesizes a real <c>RangeError</c>, matching compiled mode which throws a real
+    /// <c>$RangeError</c>. Asserted identical in both modes.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void BuiltInRangeError_CaughtAsRangeErrorInstance(ExecutionMode mode)
+    {
+        var source = @"
+            try {
+                String.fromCodePoint(-1);
+            } catch (e: any) {
+                console.log(typeof e);
+                console.log(e instanceof RangeError);
+                console.log(e instanceof Error);
+                console.log(e.name);
+                console.log(typeof e.message === 'string' && e.message.length > 0);
+            }
+        ";
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("object\ntrue\ntrue\nRangeError\ntrue\n", output);
+    }
+
+    /// <summary>
+    /// Regression for #694 covering a second error type: an empty-array <c>reduce</c> with
+    /// no initial value throws <c>"TypeError: ..."</c> from the built-in. The caught value
+    /// must be a real <c>TypeError</c> in both modes.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void BuiltInTypeError_CaughtAsTypeErrorInstance(ExecutionMode mode)
+    {
+        var source = @"
+            try {
+                ([] as number[]).reduce((a, b) => a + b);
+            } catch (e: any) {
+                console.log(typeof e);
+                console.log(e instanceof TypeError);
+                console.log(e instanceof Error);
+                console.log(e.name);
+                console.log(typeof e.message === 'string' && e.message.length > 0);
+            }
+        ";
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("object\ntrue\ntrue\nTypeError\ntrue\n", output);
+    }
+
+    /// <summary>
+    /// Regression for #694: a built-in error thrown inside a CALLED function — so it crosses
+    /// a function boundary where <c>ThrowException.FromResult</c> stringifies it — is still
+    /// caught as the typed Error by an outer <c>try</c>. Guards the catch-binding coercion
+    /// against the host-error string round-trip across the boundary.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void BuiltInError_AcrossFunctionBoundary_CaughtAsTypedError(ExecutionMode mode)
+    {
+        var source = @"
+            function boom() { String.fromCodePoint(-1); }
+            try {
+                boom();
+            } catch (e: any) {
+                console.log(e instanceof RangeError);
+                console.log(e.name);
+            }
+        ";
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("true\nRangeError\n", output);
+    }
+
+    /// <summary>
+    /// Regression guard for #694: a guest <c>throw</c> of a real error object keeps its exact
+    /// identity when caught (the catch-binding coercion only touches prefixed strings), and a
+    /// guest <c>throw</c> of a plain string stays a string.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void GuestThrows_PreserveValueIdentity(ExecutionMode mode)
+    {
+        var source = @"
+            const original = new RangeError('mine');
+            try { throw original; } catch (e: any) { console.log(e === original, e instanceof RangeError); }
+            try { throw 'plain string'; } catch (e: any) { console.log(typeof e, e); }
+        ";
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("true true\nstring plain string\n", output);
+    }
+
+    #endregion
 }

--- a/SharpTS.Tests/SharedTests/WorkerThreadsTests.cs
+++ b/SharpTS.Tests/SharedTests/WorkerThreadsTests.cs
@@ -993,18 +993,19 @@ public class WorkerThreadsTests
     #region Worker construction failure surfaces as an Error (#464)
 
     /// <summary>
-    /// Regression for #464: when the <c>Worker</c> constructor fails (here an
+    /// Regression for #464 and #700: when the <c>Worker</c> constructor fails (here an
     /// uncloneable <c>workerData</c> containing a function), the value caught by guest
-    /// <c>try/catch</c> must be an object carrying the reason in <c>.message</c> — not
-    /// the bare message string the interpreter previously bound (<c>typeof e</c> was
-    /// "string", <c>e.message</c> undefined). Both modes now expose <c>.message</c>;
-    /// interpreter mode additionally surfaces a real <c>Error</c> (asserted below).
+    /// <c>try/catch</c> must be a real <c>Error</c> carrying the reason in <c>.message</c>
+    /// — not the bare message string the interpreter previously bound (<c>typeof e</c>
+    /// was "string", <c>e.message</c> undefined), and not the plain
+    /// <c>{ message, name }</c> object (with <c>name</c> = the .NET type) that compiled
+    /// mode previously produced.
     /// </summary>
     /// <remarks>
-    /// Compiled mode currently yields a plain object with <c>message</c> rather than a
-    /// real <c>Error</c> instance (a separate, general compiled-mode gap in how caught
-    /// host exceptions are wrapped — filed separately), so <c>instanceof Error</c> is
-    /// only asserted for the interpreter, which #464 targets.
+    /// #700 fixed the compiled-mode <c>WrapException</c> catch-boundary path to return a
+    /// real <c>$Error</c>, so <c>e instanceof Error</c> and <c>e.name === "Error"</c> now
+    /// hold in BOTH modes (previously asserted only for the interpreter, which #464
+    /// targeted).
     /// </remarks>
     [Theory]
     [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
@@ -1025,6 +1026,7 @@ public class WorkerThreadsTests
                     console.log("typeof=" + typeof e);
                     console.log("hasMessage=" + (e && typeof e.message === "string" && e.message.length > 0));
                     console.log("isError=" + (e instanceof Error));
+                    console.log("name=" + e.name);
                 }
                 """
         };
@@ -1034,8 +1036,10 @@ public class WorkerThreadsTests
         Assert.Contains("hasMessage=true", output);
         Assert.DoesNotContain("constructed-without-error", output);
         Assert.DoesNotContain("worker-should-not-start", output);
-        if (mode == ExecutionMode.Interpreted)
-            Assert.Contains("isError=true", output);
+        // #700: a real Error in both modes — instanceof Error holds and name is "Error"
+        // (not the .NET exception type name).
+        Assert.Contains("isError=true", output);
+        Assert.Contains("name=Error", output);
     }
 
     #endregion


### PR DESCRIPTION
Resolves #694 and #700 — two sides of the same parity gap: a host-originated exception caught by guest `try/catch` should be a real `Error`, not a bare string (interpreter) or a `{ message, name }` dictionary (compiled).

## #694 — interpreter
Built-ins signal JS errors with `throw new Exception("RangeError: ...")`. `Interpreter.TranslateException` surfaces these as the raw message **string**, so guest `catch (e)` bound `e` to a string:

```ts
try { String.fromCodePoint(-1); }
catch (e) {
  e instanceof RangeError   // was: false   → now: true
  e.name                    // was: undefined → now: "RangeError"
}
```

A new `CoerceCaughtValueForBinding` reconstructs the matching typed `SharpTSError` (via `ErrorBuiltIns.CreateError`) **at the catch-parameter binding** — sync `HandleCatchBlock`, async `HandleCatchBlockCore`, and `SharpTSAsyncGenerator`. `instanceof` / `.name` / `.message` now hold, matching compiled mode.

**Why at the binding and not in `TranslateException`:** host errors must stay strings on the *propagation* path. `ThrowException.FromResult` turns a string into a plain host `Exception` (rethrown to the host/CLI when uncaught) versus an object into a guest-catchable `ThrowException` (swallowed at the top level). Synthesizing the typed error earlier flips **uncaught** strict-mode violations from "rethrown" to "swallowed" (caught the hard way — it regressed `StrictModeTests`). Coercing only at the binding leaves uncaught propagation intact, preserves guest `throw new Error()` identity, and keeps guest `throw "msg"` a string.

## #700 — compiled
The emitted `$Runtime.WrapException` standard fallback returned a plain `{ message, name = <.NET type> }` dictionary for caught host exceptions (e.g. a `Worker` constructor failure), so `e instanceof Error` was `false` and `e.name` was `"Exception"`. It now returns a real `$Error(ex.Message)` (name `"Error"`), preserving the existing `__tsValue` / `PromiseRejectedException.Reason` / `__nodeError` fast-paths. `$Error` is emitted into the output assembly, so standalone DLLs stay dependency-free. The static `RuntimeTypes.WrapException` mirror was updated to match.

## Tests
- New `ErrorTests`: caught `RangeError`/`TypeError` (direct **and** across a function boundary, which exercises the `FromResult` string round-trip), plus guest-throw identity preservation.
- `Worker_UncloneableWorkerData_RejectsWithErrorObjectNotString` now asserts a real `Error` (`instanceof`, `name === "Error"`) in **both** modes.
- Full suite green: **12941 passed, 0 failed**. Emitted IL verifies clean.

## Notes
- Filed #731 for an unrelated gap found along the way: compiled `String.fromCodePoint(-1)` omits the offending code-point value from its `RangeError` message (`"Invalid code point"` vs interpreted `"Invalid code point -1"`). The #694 tests deliberately don't assert exact message text to tolerate it.
- Known pathological edge (documented in code): a guest `throw "RangeError: ..."` *string* — one that exactly matches a runtime error-message shape — is also coerced. It's indistinguishable from a host error once stringified and isn't exercised by any real code.
- Conformance suites aren't run in CI; this runtime change can only *add* Test262 interpreter passes (`assert.throws`), so no PR-CI impact (baseline update only on a local run).