### PR TITLE
Computed symbol-keyed class methods (#592, #647) + compiled static generators (#692)

### DIFF
--- a/Compilation/EmittedRuntime.cs
+++ b/Compilation/EmittedRuntime.cs
@@ -1686,13 +1686,19 @@ public class EmittedRuntime
     public MethodBuilder GlobalThisGetProperty { get; set; } = null!;
     public MethodBuilder GlobalThisSetProperty { get; set; } = null!;
 
-    // Symbol-keyed class accessor registry (#266). The field holds
-    // Dictionary<Type, Dictionary<object, object[]>>; each object[4] slot is
-    // {instanceGetter, instanceSetter, staticGetter, staticSetter} MethodInfos.
+    // Symbol-keyed class accessor registry (#266, #647). The field holds
+    // Dictionary<Type, Dictionary<object, object[]>>; each object[6] slot is
+    // {instanceGetter, instanceSetter, staticGetter, staticSetter, instanceMethod,
+    // staticMethod} MethodInfos. The method slots (#647) back computed symbol-keyed
+    // class methods (`[Symbol.iterator]() {…}`).
     public FieldBuilder SymbolAccessorRegistryField { get; set; } = null!;
     public MethodBuilder RegisterSymbolAccessor { get; set; } = null!;
     public MethodBuilder FindSymbolGetter { get; set; } = null!;
     public MethodBuilder FindSymbolSetter { get; set; } = null!;
+    // #647 computed symbol-keyed methods: register a method MethodInfo and look it up
+    // (base-chain walk), reusing the accessor registry's slot array with method slots.
+    public MethodBuilder RegisterSymbolMethod { get; set; } = null!;
+    public MethodBuilder FindSymbolMethod { get; set; } = null!;
     // #351 generic-class support helpers: map a (possibly generic) owner type to
     // its registry key (the open generic definition) and to a closed type usable
     // for cctor + reflective Invoke, and close an accessor MethodInfo declared on

--- a/Compilation/ILCompiler.Classes.Methods.cs
+++ b/Compilation/ILCompiler.Classes.Methods.cs
@@ -362,7 +362,7 @@ public partial class ILCompiler
         // EmitStaticMethodBody fills the new one, and the abandoned first MethodBuilder
         // shows up via reflection with no body — surface as BadImageFormatException at any
         // reflective Invoke. Tracked as #58.
-        foreach (var method in classStmt.Methods.Where(m => m.Body != null && m.IsStatic && m.Name.Lexeme != "constructor"))
+        foreach (var method in classStmt.Methods.Where(m => m.Body != null && m.IsStatic && m.Name.Lexeme != "constructor" && m.ComputedKey == null))
         {
             if (_classes.StaticMethods[qualifiedClassName].ContainsKey(method.Name.Lexeme))
                 continue;
@@ -387,8 +387,9 @@ public partial class ILCompiler
             _classes.StaticMethods[qualifiedClassName][method.Name.Lexeme] = methodBuilder;
         }
 
-        // Define instance methods (skip overload signatures with no body)
-        foreach (var method in classStmt.Methods.Where(m => m.Body != null))
+        // Define instance methods (skip overload signatures with no body, and computed
+        // symbol-keyed methods — handled by DefineSymbolMethods below).
+        foreach (var method in classStmt.Methods.Where(m => m.Body != null && m.ComputedKey == null))
         {
             if (method.IsStatic || method.Name.Lexeme == "constructor")
                 continue;
@@ -434,6 +435,11 @@ public partial class ILCompiler
             }
             preDefined[method.Name.Lexeme] = methodBuilder;
         }
+
+        // Define computed symbol-keyed methods ([Symbol.iterator]() {…}) under unique synthetic
+        // names so they flow through the normal method-body machinery (incl. generator/async state
+        // machines) and are dispatched via the runtime symbol-method registry (#647).
+        DefineSymbolMethods(typeBuilder, classStmt, qualifiedClassName);
 
         // Define accessors with PascalCase naming
         // Note: Explicit accessors keep object-typed signatures because their bodies
@@ -638,9 +644,10 @@ public partial class ILCompiler
             _classes.StaticMethods[qualifiedClassName] = [];
         }
 
-        // Define static methods first (so we can reference them in the static constructor)
-        // Skip overload signatures (no body)
-        foreach (var method in classStmt.Methods.Where(m => m.Body != null))
+        // Define static methods first (so we can reference them in the static constructor).
+        // Skip overload signatures (no body) and computed symbol-keyed methods (handled by
+        // DefineSymbolMethods / EmitSymbolMethods).
+        foreach (var method in classStmt.Methods.Where(m => m.Body != null && m.ComputedKey == null))
         {
             if (method.IsStatic && method.Name.Lexeme != "constructor")
             {
@@ -651,9 +658,10 @@ public partial class ILCompiler
         // Emit constructor
         EmitConstructor(typeBuilder, classStmt, fieldsField);
 
-        // Emit method bodies (skip overload signatures with no body)
+        // Emit method bodies (skip overload signatures with no body, and computed
+        // symbol-keyed methods — emitted by EmitSymbolMethods below).
         // This must happen BEFORE static constructor so static blocks can call static methods
-        foreach (var method in classStmt.Methods.Where(m => m.Body != null))
+        foreach (var method in classStmt.Methods.Where(m => m.Body != null && m.ComputedKey == null))
         {
             if (method.Name.Lexeme != "constructor")
             {
@@ -667,6 +675,10 @@ public partial class ILCompiler
                 }
             }
         }
+
+        // Emit computed symbol-keyed method bodies (#647). Before the static constructor so the
+        // registry registrations there can reference them.
+        EmitSymbolMethods(typeBuilder, qualifiedClassName, fieldsField);
 
         // Emit static constructor for static property initializers and static blocks
         // This is done AFTER method bodies so static blocks can call static methods
@@ -850,6 +862,93 @@ public partial class ILCompiler
             // correct defaults. (#588)
             EmitDefaultReturnValue(il, methodBuilder.ReturnType);
             il.Emit(OpCodes.Ret);
+        }
+    }
+
+    /// <summary>
+    /// Pre-defines a uniquely-named .NET method for each computed symbol-keyed class method
+    /// (<c>[Symbol.iterator]() {…}</c>, incl. the generator/async forms) so they flow through the
+    /// normal per-method emitters. Recorded in <see cref="ClassState.SymbolMethods"/> for body emission
+    /// (<see cref="EmitSymbolMethods"/>) and for runtime symbol-method registration in the class .cctor (#647).
+    /// </summary>
+    private void DefineSymbolMethods(TypeBuilder typeBuilder, Stmt.Class classStmt, string qualifiedClassName)
+    {
+        string className = typeBuilder.Name;
+        if (_classes.SymbolMethods.ContainsKey(className))
+            return;  // already defined (idempotent across multi-module pre-define/emit passes)
+
+        var computed = classStmt.Methods.Where(m => m.ComputedKey != null && m.Body != null).ToList();
+        if (computed.Count == 0)
+            return;
+
+        var list = new List<(Stmt.Function, Expr, MethodBuilder)>();
+        for (int i = 0; i < computed.Count; i++)
+        {
+            var method = computed[i];
+            // Unique, deterministic name: multiple computed methods must not collide, and the synthetic
+            // `<computed>` lexeme is not a dispatchable name.
+            string uniqueName = $"$symmethod_{i}";
+            var renamed = method with { Name = new Token(TokenType.IDENTIFIER, uniqueName, null, method.Name.Line) };
+
+            // Param types resolve from each parameter's annotation (the type map is keyed by the @@name,
+            // not the synthetic IL name) — fine: computed iterator methods are typically parameterless.
+            var paramTypes = ParameterTypeResolver.ResolveMethodParameters(
+                classStmt.Name.Lexeme, uniqueName, renamed.Parameters, _typeMapper, _typeMap);
+
+            // Async generator first (it sets both flags).
+            Type returnType = (method.IsAsync && method.IsGenerator) ? _types.IAsyncEnumerableOfObject :
+                              method.IsAsync ? _types.TaskOfObject :
+                              method.IsGenerator ? _types.IEnumerableOfObject :
+                              typeof(object);
+
+            // Non-virtual (like symbol accessors): the registry holds the exact MethodInfo and its
+            // base-chain walk handles inheritance, so virtual override dispatch isn't needed.
+            MethodAttributes attrs = MethodAttributes.Public | MethodAttributes.HideBySig;
+            if (method.IsStatic)
+                attrs |= MethodAttributes.Static;
+
+            var mb = typeBuilder.DefineMethod(uniqueName, attrs, returnType, paramTypes);
+
+            // Register under the unique name so EmitMethod/EmitStaticMethodBody resolve the pre-defined builder.
+            if (method.IsStatic)
+            {
+                _classes.StaticMethods[qualifiedClassName][uniqueName] = mb;
+            }
+            else
+            {
+                if (!_classes.InstanceMethods.TryGetValue(qualifiedClassName, out var im))
+                {
+                    im = [];
+                    _classes.InstanceMethods[qualifiedClassName] = im;
+                }
+                im[uniqueName] = mb;
+                if (!_classes.PreDefinedMethods.TryGetValue(className, out var pd))
+                {
+                    pd = [];
+                    _classes.PreDefinedMethods[className] = pd;
+                }
+                pd[uniqueName] = mb;
+            }
+
+            list.Add((renamed, method.ComputedKey!, mb));
+        }
+        _classes.SymbolMethods[className] = list;
+    }
+
+    /// <summary>
+    /// Emits the bodies of the computed symbol-keyed methods recorded by <see cref="DefineSymbolMethods"/>,
+    /// reusing the normal per-method emitters so the generator/async state machines compose.
+    /// </summary>
+    private void EmitSymbolMethods(TypeBuilder typeBuilder, string qualifiedClassName, FieldInfo fieldsField)
+    {
+        if (!_classes.SymbolMethods.TryGetValue(typeBuilder.Name, out var list))
+            return;
+        foreach (var (method, _key, _builder) in list)
+        {
+            if (method.IsStatic)
+                EmitStaticMethodBody(qualifiedClassName, method);
+            else
+                EmitMethod(typeBuilder, method, fieldsField);
         }
     }
 

--- a/Compilation/ILCompiler.Classes.Static.cs
+++ b/Compilation/ILCompiler.Classes.Static.cs
@@ -49,11 +49,12 @@ public partial class ILCompiler
         bool hasPrivateFieldStorage = _classes.PrivateFieldStorage.ContainsKey(qualifiedClassName);
         bool hasStaticPrivateFields = _classes.StaticPrivateFields.TryGetValue(qualifiedClassName, out var staticPrivateFields) && staticPrivateFields.Count > 0;
         bool hasStaticInitializers = classStmt.StaticInitializers != null && classStmt.StaticInitializers.Count > 0;
-        // Symbol-keyed computed accessors (#266) register in the .cctor.
+        // Symbol-keyed computed accessors (#266) and methods (#647) register in the .cctor.
         bool hasSymbolAccessors = _classes.SymbolAccessors.ContainsKey(typeBuilder.Name);
+        bool hasSymbolMethods = _classes.SymbolMethods.ContainsKey(typeBuilder.Name);
 
-        // Only emit if there are static fields with initializers, static lock fields, private field storage, static auto-accessors, static blocks, or symbol accessors
-        if (staticFieldsWithInit.Count == 0 && !hasStaticLockFields && !hasPrivateFieldStorage && !hasStaticPrivateFields && staticAutoAccessorsWithInit.Count == 0 && !hasStaticInitializers && !hasSymbolAccessors) return;
+        // Only emit if there are static fields with initializers, static lock fields, private field storage, static auto-accessors, static blocks, or symbol accessors/methods
+        if (staticFieldsWithInit.Count == 0 && !hasStaticLockFields && !hasPrivateFieldStorage && !hasStaticPrivateFields && staticAutoAccessorsWithInit.Count == 0 && !hasStaticInitializers && !hasSymbolAccessors && !hasSymbolMethods) return;
 
         var cctor = typeBuilder.DefineConstructor(
             MethodAttributes.Static | MethodAttributes.Private | MethodAttributes.SpecialName | MethodAttributes.RTSpecialName,
@@ -242,6 +243,7 @@ public partial class ILCompiler
         // Register symbol-keyed computed accessors (#266) in the runtime registry,
         // keyed by this class's Type so dynamic bracket get/set can dispatch them.
         EmitSymbolAccessorRegistrations(emitter, il, typeBuilder);
+        EmitSymbolMethodRegistrations(emitter, il, typeBuilder);
 
         il.Emit(OpCodes.Ret);
     }
@@ -287,6 +289,40 @@ public partial class ILCompiler
             il.Emit(accessor.IsStatic ? OpCodes.Ldc_I4_1 : OpCodes.Ldc_I4_0);
 
             il.Emit(OpCodes.Call, _runtime.RegisterSymbolAccessor);
+        }
+    }
+
+    /// <summary>
+    /// Emits <c>$Runtime.RegisterSymbolMethod(typeof(ThisClass), symbol, methodInfo, isStatic)</c>
+    /// for each computed symbol-keyed method recorded for this class (#647), mirroring
+    /// <see cref="EmitSymbolAccessorRegistrations"/>.
+    /// </summary>
+    private void EmitSymbolMethodRegistrations(ILEmitter emitter, ILGenerator il, TypeBuilder typeBuilder)
+    {
+        if (!_classes.SymbolMethods.TryGetValue(typeBuilder.Name, out var list))
+            return;
+
+        var getTypeFromHandle = _types.GetMethod(_types.Type, "GetTypeFromHandle", _types.RuntimeTypeHandle);
+        var getMethodFromHandle = _types.MethodBase.GetMethod(
+            "GetMethodFromHandle", [_types.RuntimeMethodHandle, _types.RuntimeTypeHandle])!;
+
+        foreach (var (method, key, builder) in list)
+        {
+            // owner: typeof(ThisClass)
+            il.Emit(OpCodes.Ldtoken, typeBuilder);
+            il.Emit(OpCodes.Call, getTypeFromHandle);
+
+            // symbol: evaluate the computed key expression (e.g. Symbol.iterator)
+            emitter.EmitExpression(key);
+            emitter.EmitBoxIfNeeded(key);
+
+            // method MethodInfo
+            EmitMethodInfoLiteral(il, builder, typeBuilder, getMethodFromHandle);
+
+            // isStatic
+            il.Emit(method.IsStatic ? OpCodes.Ldc_I4_1 : OpCodes.Ldc_I4_0);
+
+            il.Emit(OpCodes.Call, _runtime.RegisterSymbolMethod);
         }
     }
 

--- a/Compilation/ILCompiler.Classes.Static.cs
+++ b/Compilation/ILCompiler.Classes.Static.cs
@@ -336,6 +336,17 @@ public partial class ILCompiler
 
     private void EmitStaticMethodBody(string className, Stmt.Function method)
     {
+        // Static generator methods (#692) use the generator state machine, set up like a free
+        // function (no `this`). Checked before the plain-async branch so `static async *m()` isn't
+        // mis-emitted as a non-generator async method (its full support is tracked separately).
+        if (method.IsGenerator && !method.IsAsync)
+        {
+            var genTypeBuilder = _classes.Builders[className];
+            var genMethodBuilder = _classes.StaticMethods[className][method.Name.Lexeme];
+            EmitGeneratorMethodBody(genMethodBuilder, method, fieldsField: null, isInstanceMethod: false);
+            return;
+        }
+
         // Async static methods use state machine generation
         if (method.IsAsync)
         {

--- a/Compilation/ILCompiler.Generators.cs
+++ b/Compilation/ILCompiler.Generators.cs
@@ -333,29 +333,33 @@ public partial class ILCompiler
     /// Emits the body of an instance generator method using a state machine.
     /// Called for class methods marked with IsGenerator = true.
     /// </summary>
-    private void EmitGeneratorMethodBody(MethodBuilder methodBuilder, Stmt.Function method, FieldInfo fieldsField)
+    private void EmitGeneratorMethodBody(MethodBuilder methodBuilder, Stmt.Function method, FieldInfo? fieldsField, bool isInstanceMethod = true)
     {
         // Analyze generator function to determine yield points and hoisted variables
         var analysis = _generators.Analyzer.Analyze(method);
 
-        // Build state machine type for instance method
+        // Build state machine type. A static generator method (#692) has no `this`/instance fields,
+        // so it is set up like a free function (isInstanceMethod: false, static stub).
         var smBuilder = new GeneratorStateMachineBuilder(_moduleBuilder, _types, _generators.StateMachineCounter++);
         smBuilder.DefineStateMachine(
             $"{methodBuilder.DeclaringType!.Name}_{method.Name.Lexeme}",
             analysis,
-            isInstanceMethod: true,  // This is an instance method
+            isInstanceMethod: isInstanceMethod,
             runtime: _runtime
         );
 
         // Emit stub method body (creates state machine and returns it)
-        EmitGeneratorInstanceStubMethod(methodBuilder, smBuilder, method.Parameters);
+        if (isInstanceMethod)
+            EmitGeneratorInstanceStubMethod(methodBuilder, smBuilder, method.Parameters);
+        else
+            EmitGeneratorStaticStubMethod(methodBuilder, smBuilder, method.Parameters);
 
         // Create context for MoveNext emission
         var il = smBuilder.MoveNextMethod.GetILGenerator();
         var ctx = new CompilationContext(il, _typeMapper, _functions.Builders, _classes.Builders, _namespaceFields, _namespaceVarFields, _types)
         {
             FieldsField = fieldsField,
-            IsInstanceMethod = true,
+            IsInstanceMethod = isInstanceMethod,
             ClosureAnalyzer = _closures.Analyzer,
             ArrowMethods = _closures.ArrowMethods,
             ConstArrowBindings = _closures.ConstArrowBindings,
@@ -464,6 +468,50 @@ public partial class ILCompiler
         // Captured outer-scope variables are NOT copied into the state machine (#541): see the
         // free-function stub above. MoveNext reads/writes them live from their backing storage,
         // wired through the CompilationContext in EmitGeneratorMethodBody.
+
+        // Return the state machine (which implements IEnumerable<object>)
+        il.Emit(OpCodes.Ret);
+    }
+
+    /// <summary>
+    /// Emits the stub that creates the generator state machine for a STATIC method (#692): like the
+    /// instance stub but with no <c>this</c> and parameters starting at arg 0 (no receiver slot).
+    /// Value-type parameters are boxed into the object-typed state-machine fields.
+    /// </summary>
+    private void EmitGeneratorStaticStubMethod(
+        MethodBuilder methodBuilder,
+        GeneratorStateMachineBuilder smBuilder,
+        List<Stmt.Parameter> parameters)
+    {
+        var il = methodBuilder.GetILGenerator();
+
+        // Create new instance of the state machine
+        il.Emit(OpCodes.Newobj, smBuilder.Constructor);
+
+        string? className = methodBuilder.DeclaringType?.Name;
+        string methodName = methodBuilder.Name;
+        Type[] paramTypes = className != null
+            ? ParameterTypeResolver.ResolveMethodParameters(className, methodName, parameters, _typeMapper, _typeMap)
+            : parameters.Select(_ => typeof(object)).ToArray();
+
+        // Copy parameters to state machine fields (static methods start params at index 0).
+        for (int i = 0; i < parameters.Count; i++)
+        {
+            var field = smBuilder.GetVariableField(parameters[i].Name.Lexeme);
+            if (field != null)
+            {
+                il.Emit(OpCodes.Dup);  // Keep state machine reference on stack
+                il.Emit(OpCodes.Ldarg, i);
+
+                // Box value types since state machine fields are object-typed
+                if (i < paramTypes.Length && paramTypes[i].IsValueType)
+                {
+                    il.Emit(OpCodes.Box, paramTypes[i]);
+                }
+
+                il.Emit(OpCodes.Stfld, field);
+            }
+        }
 
         // Return the state machine (which implements IEnumerable<object>)
         il.Emit(OpCodes.Ret);

--- a/Compilation/ILCompiler.State.cs
+++ b/Compilation/ILCompiler.State.cs
@@ -55,6 +55,12 @@ public partial class ILCompiler
         // list of (accessor AST node, emitted getter/setter MethodBuilder). Used to
         // emit the bodies and to register them in the class .cctor.
         public Dictionary<string, List<(Parsing.Stmt.Accessor Accessor, MethodBuilder Method)>> SymbolAccessors { get; } = [];
+        // Symbol-keyed computed methods (#647): class name (typeBuilder.Name) -> list of
+        // (renamed method AST with a unique $symmethod_N name, computed key expression,
+        // emitted MethodBuilder). The renamed method flows through the normal method-body
+        // machinery (incl. generator/async state machines); the key drives the .cctor
+        // RegisterSymbolMethod call.
+        public Dictionary<string, List<(Parsing.Stmt.Function Method, Parsing.Expr Key, MethodBuilder Builder)>> SymbolMethods { get; } = [];
         public Dictionary<string, FieldBuilder> InstanceFieldsField { get; } = [];
         public Dictionary<string, GenericTypeParameterBuilder[]> GenericParams { get; } = [];
 

--- a/Compilation/RuntimeEmitter.Iterator.cs
+++ b/Compilation/RuntimeEmitter.Iterator.cs
@@ -285,10 +285,13 @@ public partial class RuntimeEmitter
         var returnNullLabel = il.DefineLabel();
         var tryGetValueLabel = il.DefineLabel();
         var returnLabel = il.DefineLabel();
+        var returnLabel2 = il.DefineLabel();   // registry-hit return (#647)
 
         // Locals
         var dictLocal = il.DeclareLocal(_types.DictionaryObjectObject);
         var valueLocal = il.DeclareLocal(_types.Object);
+
+        var tryRegistryLabel = il.DefineLabel();
 
         // if (obj == null) return null;
         il.Emit(OpCodes.Ldarg_0);
@@ -299,9 +302,9 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Call, runtime.GetSymbolDictMethod);
         il.Emit(OpCodes.Stloc, dictLocal);
 
-        // if (dict == null) return null;
+        // if (dict == null) goto tryRegistry;  (a class instance carries no per-object symbol dict)
         il.Emit(OpCodes.Ldloc, dictLocal);
-        il.Emit(OpCodes.Brfalse, returnNullLabel);
+        il.Emit(OpCodes.Brfalse, tryRegistryLabel);
 
         // if (dict.TryGetValue(symbol, out value)) return value;
         il.Emit(OpCodes.Ldloc, dictLocal);
@@ -311,14 +314,29 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Callvirt, tryGetValue);
         il.Emit(OpCodes.Brtrue, returnLabel);
 
+        // Per-object dict didn't have it — consult the symbol-method registry (#647): a computed
+        // [Symbol.iterator]()/[Symbol.asyncIterator]() declared on the class chain. The returned
+        // MethodInfo is invoked through InvokeMethodValue's MethodBase arm by the caller.
+        il.MarkLabel(tryRegistryLabel);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Call, runtime.FindSymbolMethod);
+        il.Emit(OpCodes.Dup);
+        il.Emit(OpCodes.Brtrue, returnLabel2);
+        il.Emit(OpCodes.Pop);
+
         // return null;
         il.MarkLabel(returnNullLabel);
         il.Emit(OpCodes.Ldnull);
         il.Emit(OpCodes.Ret);
 
-        // return value;
+        // return value;  (per-object dict hit)
         il.MarkLabel(returnLabel);
         il.Emit(OpCodes.Ldloc, valueLocal);
+        il.Emit(OpCodes.Ret);
+
+        // return registryMethod;  (registry hit — value already on stack)
+        il.MarkLabel(returnLabel2);
         il.Emit(OpCodes.Ret);
     }
 

--- a/Compilation/RuntimeEmitter.Objects.Index.cs
+++ b/Compilation/RuntimeEmitter.Objects.Index.cs
@@ -199,6 +199,23 @@ public partial class RuntimeEmitter
             il.MarkLabel(noSymGetterLabel);
         }
 
+        // #647: computed symbol-keyed method (`[Symbol.iterator]() {...}`). Reading the member
+        // returns the callable itself — the found MethodInfo, invoked later via InvokeMethodValue's
+        // MethodBase arm — unlike a getter (above), which is invoked here.
+        {
+            var noSymMethodLabel = il.DefineLabel();
+            var symMethodLocal = il.DeclareLocal(_types.Object);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Call, runtime.FindSymbolMethod);
+            il.Emit(OpCodes.Stloc, symMethodLocal);
+            il.Emit(OpCodes.Ldloc, symMethodLocal);
+            il.Emit(OpCodes.Brfalse, noSymMethodLabel);
+            il.Emit(OpCodes.Ldloc, symMethodLocal);
+            il.Emit(OpCodes.Ret);
+            il.MarkLabel(noSymMethodLabel);
+        }
+
         // Not found in user-set symbol dict — fall back to prototype-keyed
         // well-known-symbol dispatch. Currently only RegExp.prototype carries
         // symbol-keyed methods (@@match/@@matchAll/@@replace/@@search/@@split,

--- a/Compilation/RuntimeEmitter.Objects.Invocation.cs
+++ b/Compilation/RuntimeEmitter.Objects.Invocation.cs
@@ -576,6 +576,22 @@ public partial class RuntimeEmitter
         EmitThrowNotAFunction(il, runtime, () => il.Emit(OpCodes.Ldarg_1));
         il.MarkLabel(notNullLabel);
 
+        // A reflected MethodBase (a computed symbol-keyed method resolved from the symbol-method
+        // registry, #647) is invoked directly: function.Invoke(receiver, args). A static method
+        // ignores the receiver. This mirrors the symbol-accessor get/set paths, which invoke the
+        // found getter/setter MethodInfo the same way.
+        var notMethodBaseLabel = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Isinst, _types.MethodBase);
+        il.Emit(OpCodes.Brfalse, notMethodBaseLabel);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Castclass, _types.MethodBase);
+        il.Emit(OpCodes.Ldarg_0);  // receiver (this)
+        il.Emit(OpCodes.Ldarg_2);  // args
+        il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.MethodBase, "Invoke", _types.Object, _types.ObjectArray));
+        il.Emit(OpCodes.Ret);
+        il.MarkLabel(notMethodBaseLabel);
+
         // ECMA-262 §22.2.6: a RegExp object has no [[Call]] — calling one
         // (`/x/()`, `RegExp("a","g")()`) must throw TypeError. Checked early
         // so it doesn't fall into the dispatch chain.

--- a/Compilation/RuntimeEmitter.SymbolAccessors.cs
+++ b/Compilation/RuntimeEmitter.SymbolAccessors.cs
@@ -5,11 +5,14 @@ namespace SharpTS.Compilation;
 
 public partial class RuntimeEmitter
 {
-    // Slot layout inside each per-(Type,symbol) object[4].
+    // Slot layout inside each per-(Type,symbol) object[6].
     private const int SymGetterInstanceSlot = 0;
     private const int SymSetterInstanceSlot = 1;
     private const int SymGetterStaticSlot = 2;
     private const int SymSetterStaticSlot = 3;
+    private const int SymMethodInstanceSlot = 4;   // #647 computed instance method
+    private const int SymMethodStaticSlot = 5;     // #647 computed static method
+    private const int SymSlotCount = 6;
 
     private Type SymInnerDictType => _types.MakeGenericType(_types.DictionaryOpen, _types.Object, _types.ObjectArray);
     private Type SymOuterDictType => _types.MakeGenericType(_types.DictionaryOpen, _types.Type, SymInnerDictType);
@@ -40,6 +43,19 @@ public partial class RuntimeEmitter
 
         runtime.FindSymbolSetter = typeBuilder.DefineMethod(
             "FindSymbolSetterFor",
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.Object,
+            [_types.Object, _types.Object]);
+
+        // #647 computed symbol-keyed methods.
+        runtime.RegisterSymbolMethod = typeBuilder.DefineMethod(
+            "RegisterSymbolMethod",
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.Void,
+            [_types.Type, _types.Object, _types.Object, _types.Boolean]);
+
+        runtime.FindSymbolMethod = typeBuilder.DefineMethod(
+            "FindSymbolMethodFor",
             MethodAttributes.Public | MethodAttributes.Static,
             _types.Object,
             [_types.Object, _types.Object]);
@@ -87,11 +103,74 @@ public partial class RuntimeEmitter
         var getType = _types.GetMethod(_types.Object, "GetType");
 
         EmitRegisterSymbolAccessorBody(runtime, inner, outerTryGetValue, outerSetItem, innerTryGetValue, innerSetItem);
+        EmitRegisterSymbolMethodBody(runtime, inner, outerTryGetValue, outerSetItem, innerTryGetValue, innerSetItem);
         EmitSymbolGenericHelperBodies(runtime);
         EmitFindSymbolAccessorBody(runtime, runtime.FindSymbolGetter, field, inner,
             SymGetterInstanceSlot, SymGetterStaticSlot, outerTryGetValue, innerTryGetValue, getBaseType, getType);
         EmitFindSymbolAccessorBody(runtime, runtime.FindSymbolSetter, field, inner,
             SymSetterInstanceSlot, SymSetterStaticSlot, outerTryGetValue, innerTryGetValue, getBaseType, getType);
+        // #647: methods reuse the same base-chain walk, reading the method slots.
+        EmitFindSymbolAccessorBody(runtime, runtime.FindSymbolMethod, field, inner,
+            SymMethodInstanceSlot, SymMethodStaticSlot, outerTryGetValue, innerTryGetValue, getBaseType, getType);
+    }
+
+    /// <summary>
+    /// Emits <c>RegisterSymbolMethod(Type owner, object symbol, object method, bool isStatic)</c> (#647):
+    /// stores <paramref name="method"/> into the per-(owner,symbol) slot array's method slot (instance
+    /// slot 4 / static slot 5). Mirrors <see cref="EmitRegisterSymbolAccessorBody"/>'s get-or-create of
+    /// the inner dictionary and slot array (sized <see cref="SymSlotCount"/>).
+    /// </summary>
+    private void EmitRegisterSymbolMethodBody(
+        EmittedRuntime runtime, Type inner,
+        MethodInfo outerTryGetValue, MethodInfo outerSetItem,
+        MethodInfo innerTryGetValue, MethodInfo innerSetItem)
+    {
+        var il = runtime.RegisterSymbolMethod.GetILGenerator();
+        var field = runtime.SymbolAccessorRegistryField;
+        var innerLocal = il.DeclareLocal(inner);
+        var slotLocal = il.DeclareLocal(_types.ObjectArray);
+
+        // if (symbol == null) return;  (see RegisterSymbolAccessor — module-local Symbol keys, #282)
+        var symbolOkLabel = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Brtrue, symbolOkLabel);
+        il.Emit(OpCodes.Ret);
+        il.MarkLabel(symbolOkLabel);
+
+        // if (!_symbolAccessors.TryGetValue(owner, out inner)) { inner = new(); _symbolAccessors[owner] = inner; }
+        var haveInner = il.DefineLabel();
+        il.Emit(OpCodes.Ldsfld, field);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldloca, innerLocal);
+        il.Emit(OpCodes.Callvirt, outerTryGetValue);
+        il.Emit(OpCodes.Brtrue, haveInner);
+        il.Emit(OpCodes.Newobj, _types.GetDefaultConstructor(inner));
+        il.Emit(OpCodes.Stloc, innerLocal);
+        il.Emit(OpCodes.Ldsfld, field);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldloc, innerLocal);
+        il.Emit(OpCodes.Callvirt, outerSetItem);
+        il.MarkLabel(haveInner);
+
+        // if (!inner.TryGetValue(symbol, out slot)) { slot = new object[6]; inner[symbol] = slot; }
+        var haveSlot = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, innerLocal);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Ldloca, slotLocal);
+        il.Emit(OpCodes.Callvirt, innerTryGetValue);
+        il.Emit(OpCodes.Brtrue, haveSlot);
+        il.Emit(OpCodes.Ldc_I4, SymSlotCount);
+        il.Emit(OpCodes.Newarr, _types.Object);
+        il.Emit(OpCodes.Stloc, slotLocal);
+        il.Emit(OpCodes.Ldloc, innerLocal);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Ldloc, slotLocal);
+        il.Emit(OpCodes.Callvirt, innerSetItem);
+        il.MarkLabel(haveSlot);
+
+        // if (method != null) slot[isStatic ? 5 : 4] = method;  (isStatic is arg 3 here)
+        EmitStoreSlotIfPresent(il, slotLocal, argIndex: 2, staticSlot: SymMethodStaticSlot, instanceSlot: SymMethodInstanceSlot, isStaticArgIndex: 3);
+        il.Emit(OpCodes.Ret);
     }
 
     /// <summary>
@@ -269,14 +348,14 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Callvirt, outerSetItem);
         il.MarkLabel(haveInner);
 
-        // if (!inner.TryGetValue(symbol, out slot)) { slot = new object[4]; inner[symbol] = slot; }
+        // if (!inner.TryGetValue(symbol, out slot)) { slot = new object[6]; inner[symbol] = slot; }
         var haveSlot = il.DefineLabel();
         il.Emit(OpCodes.Ldloc, innerLocal);
         il.Emit(OpCodes.Ldarg_1);
         il.Emit(OpCodes.Ldloca, slotLocal);
         il.Emit(OpCodes.Callvirt, innerTryGetValue);
         il.Emit(OpCodes.Brtrue, haveSlot);
-        il.Emit(OpCodes.Ldc_I4_4);
+        il.Emit(OpCodes.Ldc_I4, SymSlotCount);
         il.Emit(OpCodes.Newarr, _types.Object);
         il.Emit(OpCodes.Stloc, slotLocal);
         il.Emit(OpCodes.Ldloc, innerLocal);
@@ -285,25 +364,25 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Callvirt, innerSetItem);
         il.MarkLabel(haveSlot);
 
-        // if (getter != null) slot[isStatic ? 2 : 0] = getter;
-        EmitStoreSlotIfPresent(il, slotLocal, argIndex: 2, staticSlot: SymGetterStaticSlot, instanceSlot: SymGetterInstanceSlot);
+        // if (getter != null) slot[isStatic ? 2 : 0] = getter;  (isStatic is arg 4 here)
+        EmitStoreSlotIfPresent(il, slotLocal, argIndex: 2, staticSlot: SymGetterStaticSlot, instanceSlot: SymGetterInstanceSlot, isStaticArgIndex: 4);
         // if (setter != null) slot[isStatic ? 3 : 1] = setter;
-        EmitStoreSlotIfPresent(il, slotLocal, argIndex: 3, staticSlot: SymSetterStaticSlot, instanceSlot: SymSetterInstanceSlot);
+        EmitStoreSlotIfPresent(il, slotLocal, argIndex: 3, staticSlot: SymSetterStaticSlot, instanceSlot: SymSetterInstanceSlot, isStaticArgIndex: 4);
 
         il.Emit(OpCodes.Ret);
     }
 
-    // if (argN != null) slot[isStatic ? staticSlot : instanceSlot] = argN;
-    private static void EmitStoreSlotIfPresent(ILGenerator il, LocalBuilder slotLocal, int argIndex, int staticSlot, int instanceSlot)
+    // if (argN != null) slot[arg(isStaticArgIndex) ? staticSlot : instanceSlot] = argN;
+    private static void EmitStoreSlotIfPresent(ILGenerator il, LocalBuilder slotLocal, int argIndex, int staticSlot, int instanceSlot, int isStaticArgIndex)
     {
         var skip = il.DefineLabel();
         il.Emit(OpCodes.Ldarg, argIndex);
         il.Emit(OpCodes.Brfalse, skip);
         il.Emit(OpCodes.Ldloc, slotLocal);
-        // index = isStatic(arg4) ? staticSlot : instanceSlot
+        // index = isStatic ? staticSlot : instanceSlot
         var useStatic = il.DefineLabel();
         var haveIdx = il.DefineLabel();
-        il.Emit(OpCodes.Ldarg, 4);
+        il.Emit(OpCodes.Ldarg, isStaticArgIndex);
         il.Emit(OpCodes.Brtrue, useStatic);
         il.Emit(OpCodes.Ldc_I4, instanceSlot);
         il.Emit(OpCodes.Br, haveIdx);

--- a/Execution/Interpreter.Async.cs
+++ b/Execution/Interpreter.Async.cs
@@ -183,8 +183,16 @@ public partial class Interpreter
         else if (iterable is SharpTSInstance inst)
         {
             var asyncIteratorFn = inst.GetBySymbol(SharpTSSymbol.AsyncIterator);
+            // Fall back to a declared symbol-keyed method on the class chain
+            // (`class C { async *[Symbol.asyncIterator]() {...} }`).
+            if (asyncIteratorFn == null && inst.GetClass().FindSymbolMethod(SharpTSSymbol.AsyncIterator) is { } symMethod)
+            {
+                asyncIteratorFn = SharpTSClass.BindMethod(symMethod, inst);
+            }
             if (asyncIteratorFn != null)
             {
+                if (asyncIteratorFn is SharpTSArrowFunction arrowFunc)
+                    asyncIteratorFn = arrowFunc.Bind(inst);
                 if (asyncIteratorFn is ISharpTSCallable callable)
                     return callable.Call(this, []);
             }

--- a/Execution/Interpreter.Expressions.cs
+++ b/Execution/Interpreter.Expressions.cs
@@ -979,6 +979,12 @@ public partial class Interpreter
     {
         object? own = instance.GetBySymbol(symbol);
         if (own != null) return own;
+        // Declared symbol-keyed method (`[Symbol.iterator]() {...}`) — returned bound, like a
+        // normal method read (`instance[Symbol.iterator]` yields the callable).
+        if (instance.GetClass().FindSymbolMethod(symbol) is { } method)
+        {
+            return SharpTSClass.BindMethod(method, instance);
+        }
         if (instance.GetClass().FindSymbolGetter(symbol) is { } getter)
         {
             return getter.Bind(instance).Call(this, []);
@@ -995,6 +1001,11 @@ public partial class Interpreter
         if (klass.FindStaticSymbolGetter(symbol) is { } getter)
         {
             return getter.BindStatic(klass).Call(this, []);
+        }
+        // Declared static symbol-keyed method (`static [Symbol.iterator]() {...}`) — bound to the class.
+        if (klass.FindStaticSymbolMethod(symbol) is { } method)
+        {
+            return SharpTSClass.BindStaticMethod(method, klass);
         }
         return klass.TryGetStaticBySymbol(symbol, out var value)
             ? value ?? SharpTSUndefined.Instance
@@ -1341,17 +1352,37 @@ public partial class Interpreter
                 }
             }
 
+            // Symbol-keyed computed methods (`[Symbol.iterator]() {...}`) attach to the class after construction.
+            List<(SharpTSSymbol Symbol, ISharpTSCallable Func, bool IsStatic)>? symbolMethods = null;
+
             // Process methods (skip overload signatures with no body)
             foreach (Stmt.Function method in classExpr.Methods.Where(m => m.Body != null))
             {
                 // Create the appropriate function type based on async/generator flags
                 ISharpTSCallable func;
-                if (method.IsAsync)
+                if (method.IsAsync && method.IsGenerator)
+                    func = new SharpTSAsyncGeneratorFunction(method, _environment);
+                else if (method.IsAsync)
                     func = new SharpTSAsyncFunction(method, _environment);
                 else if (method.IsGenerator)
                     func = new SharpTSGeneratorFunction(method, _environment);
                 else
                     func = new SharpTSFunction(method, _environment);
+
+                // Computed method keys (`[Symbol.iterator]()`) — symbol keys land in the symbol-method
+                // table; other keys fold to a string-named method (parallels the class-declaration path).
+                if (method.ComputedKey != null)
+                {
+                    object? key = Evaluate(method.ComputedKey);
+                    if (key is SharpTSSymbol symbolKey)
+                    {
+                        (symbolMethods ??= []).Add((symbolKey, func, method.IsStatic));
+                        continue;
+                    }
+                    string keyStr = PropertyKeyConverter.ToPropertyKeyString(key);
+                    (method.IsStatic ? staticMethods : methods)[keyStr] = func;
+                    continue;
+                }
 
                 if (method.IsStatic)
                 {
@@ -1459,6 +1490,14 @@ public partial class Interpreter
                 foreach (var (symbol, func, isStatic, isGetter) in symbolAccessors)
                 {
                     klass.AddSymbolAccessor(symbol, func, isStatic, isGetter);
+                }
+            }
+
+            if (symbolMethods != null)
+            {
+                foreach (var (symbol, func, isStatic) in symbolMethods)
+                {
+                    klass.AddSymbolMethod(symbol, func, isStatic);
                 }
             }
 

--- a/Execution/Interpreter.Statements.cs
+++ b/Execution/Interpreter.Statements.cs
@@ -790,6 +790,12 @@ public partial class Interpreter
         if (iterable is SharpTSInstance inst)
         {
             var iteratorFn = inst.GetBySymbol(SharpTSSymbol.Iterator);
+            // Fall back to a declared symbol-keyed method on the class chain
+            // (`class C { [Symbol.iterator]() {...} }`, including generator forms).
+            if (iteratorFn == null && inst.GetClass().FindSymbolMethod(SharpTSSymbol.Iterator) is { } symMethod)
+            {
+                iteratorFn = SharpTSClass.BindMethod(symMethod, inst);
+            }
             if (iteratorFn != null)
             {
                 // Bind 'this' to the instance if it's an arrow function
@@ -822,6 +828,16 @@ public partial class Interpreter
         else
         {
             throw new InterpreterException("[Symbol.iterator] must be a function.");
+        }
+
+        // A generator-valued [Symbol.iterator]() (`*[Symbol.iterator]() { yield ... }`) returns a
+        // generator object, which exposes iteration directly via IEnumerable rather than a queryable
+        // next() data property — delegate to it (the explicit next()-protocol objects are handled below).
+        if (iterator is IEnumerable<object?> directEnumerable and not SharpTSObject and not SharpTSInstance)
+        {
+            foreach (var item in directEnumerable)
+                yield return item;
+            yield break;
         }
 
         // Iterate using the iterator protocol

--- a/Execution/Interpreter.cs
+++ b/Execution/Interpreter.cs
@@ -2304,6 +2304,10 @@ public partial class Interpreter : IDisposable
             }
         }
 
+        // Symbol-keyed computed methods (`[Symbol.iterator]() {...}`) can't go into the string
+        // dictionaries; collected here and attached to the class after construction.
+        List<(SharpTSSymbol Symbol, ISharpTSCallable Func, bool IsStatic)>? symbolMethods = null;
+
         // Separate static and instance methods (skip overload signatures with no body)
         foreach (Stmt.Function method in classStmt.Methods.Where(m => m.Body != null))
         {
@@ -2317,6 +2321,22 @@ public partial class Interpreter : IDisposable
                 func = new SharpTSGeneratorFunction(method, _environment);
             else
                 func = new SharpTSFunction(method, _environment);
+
+            // Computed method keys (`[Symbol.iterator]()`, `[expr]()`) are evaluated at
+            // class-definition time, like computed field keys and accessors. Symbol keys land
+            // in the symbol-method table; other keys fold to a string-named method.
+            if (method.ComputedKey != null)
+            {
+                object? key = Evaluate(method.ComputedKey);
+                if (key is SharpTSSymbol symbolKey)
+                {
+                    (symbolMethods ??= []).Add((symbolKey, func, method.IsStatic));
+                    continue;
+                }
+                string keyStr = PropertyKeyConverter.ToPropertyKeyString(key);
+                (method.IsStatic ? staticMethods : methods)[keyStr] = func;
+                continue;
+            }
 
             if (method.IsPrivate)
             {
@@ -2507,6 +2527,14 @@ public partial class Interpreter : IDisposable
             foreach (var (symbol, func, isStatic, isGetter) in symbolAccessors)
             {
                 klass.AddSymbolAccessor(symbol, func, isStatic, isGetter);
+            }
+        }
+
+        if (symbolMethods != null)
+        {
+            foreach (var (symbol, func, isStatic) in symbolMethods)
+            {
+                klass.AddSymbolMethod(symbol, func, isStatic);
             }
         }
 

--- a/Parsing/AST.cs
+++ b/Parsing/AST.cs
@@ -381,8 +381,12 @@ public abstract record Stmt
     /// IsAsync indicates this is an async function that returns a Promise.
     /// IsGenerator indicates this is a generator function (function*) that can yield values.
     /// Decorators contains any @decorator annotations applied to this function/method.
+    /// ComputedKey is non-null for a computed symbol-keyed class method (e.g.
+    /// <c>[Symbol.iterator]() {}</c>); Name is then a synthetic <c>&lt;computed&gt;</c> token and the
+    /// key expression is evaluated at class-definition time (interpreter) / registered as a
+    /// symbol method (compiler).
     /// </summary>
-    public record Function(Token Name, List<TypeParam>? TypeParams, string? ThisType, List<Parameter> Parameters, List<Stmt>? Body, string? ReturnType, bool IsStatic = false, AccessModifier Access = AccessModifier.Public, bool IsAbstract = false, bool IsOverride = false, bool IsAsync = false, bool IsGenerator = false, List<Decorator>? Decorators = null, bool IsPrivate = false, bool IsDeclare = false) : Stmt;
+    public record Function(Token Name, List<TypeParam>? TypeParams, string? ThisType, List<Parameter> Parameters, List<Stmt>? Body, string? ReturnType, bool IsStatic = false, AccessModifier Access = AccessModifier.Public, bool IsAbstract = false, bool IsOverride = false, bool IsAsync = false, bool IsGenerator = false, List<Decorator>? Decorators = null, bool IsPrivate = false, bool IsDeclare = false, Expr? ComputedKey = null) : Stmt;
     public record Parameter(Token Name, string? Type, Expr? DefaultValue = null, bool IsRest = false, bool IsParameterProperty = false, AccessModifier? Access = null, bool IsReadonly = false, bool IsOptional = false, List<Decorator>? Decorators = null);
     /// <summary>
     /// Class field declaration. For computed property names (e.g., [Symbol("key")]: type),

--- a/Parsing/Parser.Classes.cs
+++ b/Parsing/Parser.Classes.cs
@@ -324,28 +324,8 @@ public partial class Parser
                     throw new Exception($"Parse Error at line {Peek().Line}: 'declare' modifier cannot be used with computed property names.");
                 }
 
-                Advance(); // consume '['
-                Expr computedKey = Expression();
-                Consume(TokenType.RIGHT_BRACKET, "Expect ']' after computed property name.");
-
-                // Create a synthetic token for the field name (for error reporting)
-                Token syntheticName = new Token(TokenType.IDENTIFIER, "<computed>", null, Previous().Line);
-
-                Consume(TokenType.COLON, "Expect ':' after computed property name.");
-                string typeAnnotation = ParseTypeAnnotation();
-                Expr? initializer = null;
-                if (Match(TokenType.EQUAL))
-                {
-                    initializer = Expression();
-                }
-
-                ConsumeSemicolon("Expect ';' after computed property field declaration.");
-                var field = new Stmt.Field(syntheticName, typeAnnotation, initializer, isStatic, access, isReadonly, IsOptional: false, HasDefiniteAssignmentAssertion: false, memberDecorators, IsPrivate: false, IsDeclare: false, ComputedKey: computedKey);
-                fields.Add(field);
-                if (isStatic)
-                {
-                    staticInitializers.Add(field);
-                }
+                // Computed-name method ([Symbol.iterator]() {}) or field ([expr]: T = v).
+                ParseComputedClassMember(isStatic, isMemberAsync, isMemberGenerator, isOverride, isReadonly, access, memberDecorators, methods, fields, staticInitializers);
             }
             else if ((Peek().Type == TokenType.IDENTIFIER || IsContextualKeyword(Peek().Type)
                       || Peek().Type == TokenType.STRING || Peek().Type == TokenType.NUMBER) &&
@@ -507,6 +487,58 @@ public partial class Parser
 
         Consume(TokenType.RIGHT_BRACE, "Expect '}' after class body.");
         return new Stmt.Class(name, typeParams, superclassExpr, superclassTypeArgs, methods, fields, accessors.Count > 0 ? accessors : null, autoAccessors.Count > 0 ? autoAccessors : null, interfaces, interfaceTypeArgs, isAbstract, classDecorators, isDeclare, staticInitializers.Count > 0 ? staticInitializers : null, indexSignatures.Count > 0 ? indexSignatures : null);
+    }
+
+    /// <summary>
+    /// Parses a computed-name class member positioned at the opening <c>[</c> — either a computed
+    /// symbol-keyed method (<c>[Symbol.iterator]() {}</c>, plus the generator <c>*[Symbol.iterator]()</c>
+    /// and async <c>async *[Symbol.asyncIterator]()</c> forms) or a computed-name field
+    /// (<c>[expr]: T = v</c>). Disambiguated by what follows the <c>]</c>: a <c>(</c> or <c>&lt;</c>
+    /// (generic) marks a method, otherwise a field. Index signatures must be ruled out by the caller first.
+    /// </summary>
+    private void ParseComputedClassMember(
+        bool isStatic, bool isMemberAsync, bool isMemberGenerator, bool isOverride, bool isReadonly,
+        AccessModifier access, List<Decorator>? memberDecorators,
+        List<Stmt.Function> methods, List<Stmt.Field> fields, List<Stmt> staticInitializers)
+    {
+        Advance(); // consume '['
+        Expr computedKey = Expression();
+        Consume(TokenType.RIGHT_BRACKET, "Expect ']' after computed property name.");
+
+        // Synthetic name token for error reporting; the real key lives in ComputedKey.
+        Token syntheticName = new Token(TokenType.IDENTIFIER, "<computed>", null, Previous().Line);
+
+        // A '(' or '<' after ']' marks a method ([Symbol.iterator]() {} / generic form);
+        // anything else is a computed-name field ([expr]: T = v).
+        if (Check(TokenType.LEFT_PAREN) || Check(TokenType.LESS))
+        {
+            var func = (Stmt.Function)FunctionDeclaration("method", isMemberAsync, isMemberGenerator, computedMethod: (syntheticName, computedKey));
+            func = func with { IsStatic = isStatic, Access = access, IsOverride = isOverride, Decorators = memberDecorators };
+            methods.Add(func);
+            return;
+        }
+
+        // Computed-name field. Generator/async are method-only markers.
+        if (isMemberGenerator)
+        {
+            throw new Exception($"Parse Error at line {syntheticName.Line}: Generator marker '*' can only be used with methods, not fields.");
+        }
+
+        Consume(TokenType.COLON, "Expect ':' after computed property name.");
+        string typeAnnotation = ParseTypeAnnotation();
+        Expr? initializer = null;
+        if (Match(TokenType.EQUAL))
+        {
+            initializer = Expression();
+        }
+
+        ConsumeSemicolon("Expect ';' after computed property field declaration.");
+        var field = new Stmt.Field(syntheticName, typeAnnotation, initializer, isStatic, access, isReadonly, IsOptional: false, HasDefiniteAssignmentAssertion: false, memberDecorators, IsPrivate: false, IsDeclare: false, ComputedKey: computedKey);
+        fields.Add(field);
+        if (isStatic)
+        {
+            staticInitializers.Add(field);
+        }
     }
 
     /// <summary>
@@ -869,6 +901,15 @@ public partial class Parser
                 {
                     staticInitializers.Add(field);
                 }
+            }
+            // Computed-name member: [Symbol.iterator]() {} (method) or [expr]: T = v (field).
+            else if (Check(TokenType.LEFT_BRACKET))
+            {
+                if (isMemberDeclare)
+                {
+                    throw new Exception($"Parse Error at line {Peek().Line}: 'declare' modifier cannot be used with computed property names.");
+                }
+                ParseComputedClassMember(isStatic, isMemberAsync, isMemberGenerator, isOverride: false, isReadonly, access, memberDecorators: null, methods, fields, staticInitializers);
             }
             else
             {

--- a/Parsing/Parser.Functions.cs
+++ b/Parsing/Parser.Functions.cs
@@ -2,10 +2,19 @@ namespace SharpTS.Parsing;
 
 public partial class Parser
 {
-    private Stmt FunctionDeclaration(string kind, bool isAsync = false, bool isGenerator = false, bool isDeclare = false)
+    private Stmt FunctionDeclaration(string kind, bool isAsync = false, bool isGenerator = false, bool isDeclare = false, (Token Name, Expr? ComputedKey)? computedMethod = null)
     {
         Token name;
-        if (kind == "constructor" && Match(TokenType.CONSTRUCTOR))
+        Expr? computedKey = null;
+        if (computedMethod is { } cm)
+        {
+            // Computed symbol-keyed class method ([Symbol.iterator]() {}): the caller already
+            // parsed [expr] and synthesized the <computed> name token; the key expression is
+            // carried on the resulting Stmt.Function for the interpreter/compiler to resolve.
+            name = cm.Name;
+            computedKey = cm.ComputedKey;
+        }
+        else if (kind == "constructor" && Match(TokenType.CONSTRUCTOR))
         {
             name = Previous();
         }
@@ -157,7 +166,7 @@ public partial class Parser
         if (Match(TokenType.SEMICOLON))
         {
             // Overload signature - no body, just declaration
-            return new Stmt.Function(name, typeParams, thisType, parameters, null, returnType, IsAsync: isAsync, IsGenerator: isGenerator, IsDeclare: isDeclare);
+            return new Stmt.Function(name, typeParams, thisType, parameters, null, returnType, IsAsync: isAsync, IsGenerator: isGenerator, IsDeclare: isDeclare, ComputedKey: computedKey);
         }
 
         // Save current strict mode state before parsing function body
@@ -220,7 +229,7 @@ public partial class Parser
         // declarations + assignments. Cheap no-op if no `var` keywords are present.
         body = VarHoister.Hoist(body);
 
-        return new Stmt.Function(name, typeParams, thisType, parameters, body, returnType, IsAsync: isAsync, IsGenerator: isGenerator);
+        return new Stmt.Function(name, typeParams, thisType, parameters, body, returnType, IsAsync: isAsync, IsGenerator: isGenerator, ComputedKey: computedKey);
     }
 
     /// <summary>

--- a/Runtime/Types/SharpTSClass.cs
+++ b/Runtime/Types/SharpTSClass.cs
@@ -147,6 +147,22 @@ public class SharpTSClass(
         };
     }
 
+    /// <summary>
+    /// Binds a static method to its class (so <c>this</c> is the class), handling sync,
+    /// async, generator and async-generator forms. Mirrors <see cref="BindMethod"/>.
+    /// </summary>
+    public static ISharpTSCallable BindStaticMethod(ISharpTSCallable method, SharpTSClass klass)
+    {
+        return method switch
+        {
+            SharpTSFunction func => func.BindStatic(klass),
+            SharpTSAsyncFunction asyncFunc => asyncFunc.BindStatic(klass),
+            SharpTSGeneratorFunction genFunc => genFunc.BindStatic(klass),
+            SharpTSAsyncGeneratorFunction asyncGenFunc => asyncGenFunc.BindStatic(klass),
+            _ => method
+        };
+    }
+
     protected void InitializeInstanceFields(Interpreter interpreter, SharpTSInstance instance)
     {
         // First initialize superclass fields
@@ -311,6 +327,27 @@ public class SharpTSClass(
 
     public SharpTSFunction? FindStaticSymbolSetter(SharpTSSymbol symbol)
         => _staticSymbolSetters?.GetValueOrDefault(symbol) ?? Superclass?.FindStaticSymbolSetter(symbol);
+
+    // Symbol-keyed declared methods (`[Symbol.iterator]() {...}`, the generator
+    // `*[Symbol.iterator]()` / async `async *[Symbol.asyncIterator]()` forms, and the
+    // static variants). Computed method keys are evaluated at class-definition time;
+    // symbol-valued keys land here, string-valued keys go into the regular method
+    // dictionaries. Stored as ISharpTSCallable so generator/async functions are held
+    // unboxed and bound via BindMethod. Lazy — most classes declare none.
+    private Dictionary<SharpTSSymbol, ISharpTSCallable>? _symbolMethods;
+    private Dictionary<SharpTSSymbol, ISharpTSCallable>? _staticSymbolMethods;
+
+    public void AddSymbolMethod(SharpTSSymbol symbol, ISharpTSCallable func, bool isStatic)
+    {
+        if (isStatic) (_staticSymbolMethods ??= [])[symbol] = func;
+        else (_symbolMethods ??= [])[symbol] = func;
+    }
+
+    public ISharpTSCallable? FindSymbolMethod(SharpTSSymbol symbol)
+        => _symbolMethods?.GetValueOrDefault(symbol) ?? Superclass?.FindSymbolMethod(symbol);
+
+    public ISharpTSCallable? FindStaticSymbolMethod(SharpTSSymbol symbol)
+        => _staticSymbolMethods?.GetValueOrDefault(symbol) ?? Superclass?.FindStaticSymbolMethod(symbol);
 
     public SharpTSFunction? FindGetter(string name)
     {

--- a/SharpTS.Tests/SharedTests/ComputedSymbolMethodTests.cs
+++ b/SharpTS.Tests/SharedTests/ComputedSymbolMethodTests.cs
@@ -1,0 +1,144 @@
+using SharpTS.Tests.Infrastructure;
+using SharpTS.TypeSystem.Exceptions;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests;
+
+/// <summary>
+/// Tests for computed symbol-keyed class methods — `class C { [Symbol.iterator]() {…} }`, the
+/// generator form `*[Symbol.iterator]()` and the async form `async *[Symbol.asyncIterator]()`
+/// (#592 parser/type-checker/interpreter; #647 compiled mode). Cases proven in both back ends use
+/// <see cref="ExecutionModes.All"/>; cases pending compiled support use
+/// <see cref="ExecutionModes.InterpretedOnly"/>.
+/// </summary>
+public class ComputedSymbolMethodTests
+{
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void ObjectReturningIterator_ForOf_Works(ExecutionMode mode)
+    {
+        var source = """
+            class Range {
+              [Symbol.iterator]() {
+                let i = 0;
+                return { next() { return i < 2 ? { value: i++, done: false } : { value: 0, done: true }; } };
+              }
+            }
+            for (const x of new Range()) console.log(x);
+            """;
+
+        Assert.Equal("0\n1\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void GeneratorIterator_ForOfAndSpread_Works(ExecutionMode mode)
+    {
+        var source = """
+            class Range { *[Symbol.iterator]() { yield 1; yield 2; } }
+            for (const x of new Range()) console.log(x);
+            console.log([...new Range()].length);
+            """;
+
+        Assert.Equal("1\n2\n2\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void GeneratorIterator_CapturesThis(ExecutionMode mode)
+    {
+        var source = """
+            class Range {
+              constructor(private start: number, private end: number) {}
+              *[Symbol.iterator](): Iterator<number> {
+                for (let i = this.start; i < this.end; i++) yield i;
+              }
+            }
+            let sum = 0;
+            for (const n of new Range(1, 5)) sum += n;
+            console.log(sum);
+            """;
+
+        Assert.Equal("10\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void GeneratorIterator_ElementTypeIsNumber(ExecutionMode mode)
+    {
+        // The spread must yield number[], not Iterator<number>[] — the factory's iterator
+        // return type must not be double-wrapped into Generator<Iterator<number>>.
+        var source = """
+            class Range { *[Symbol.iterator](): Iterator<number> { yield 1; yield 2; yield 3; } }
+            const arr: number[] = [...new Range()];
+            console.log(arr.length);
+            """;
+
+        Assert.Equal("3\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void NonSymbolComputedMethodKey_FoldsToNamedMethod(ExecutionMode mode)
+    {
+        var source = """
+            const KEY = "dyn";
+            class C { [KEY]() { return 42; } }
+            console.log((new C() as any).dyn());
+            """;
+
+        Assert.Equal("42\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void AsyncGeneratorIterator_ForAwait_Works(ExecutionMode mode)
+    {
+        var source = """
+            class ARange { async *[Symbol.asyncIterator]() { yield 10; yield 20; } }
+            async function main() {
+              for await (const x of new ARange()) console.log(x);
+            }
+            main();
+            """;
+
+        Assert.Equal("10\n20\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void DirectSymbolMethodAccess_ReturnsCallable(ExecutionMode mode)
+    {
+        var source = """
+            class R { *[Symbol.iterator]() { yield 5; } }
+            const it = (new R() as any)[Symbol.iterator]();
+            console.log(it.next().value);
+            """;
+
+        Assert.Equal("5\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void ClassExpression_ComputedSymbolMethod_Works(ExecutionMode mode)
+    {
+        var source = """
+            const Range = class { *[Symbol.iterator]() { yield 7; yield 8; } };
+            for (const x of new Range()) console.log(x);
+            """;
+
+        Assert.Equal("7\n8\n", TestHarness.Run(source, mode));
+    }
+
+    [Fact]
+    public void PlainClass_StillNotIterable_ReportsError()
+    {
+        // A class with no [Symbol.iterator] is still rejected as non-iterable (TS2488 / #593).
+        var source = """
+            class Plain { x = 1; }
+            for (const y of new Plain()) console.log(y);
+            """;
+
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+}

--- a/SharpTS.Tests/SharedTests/ComputedSymbolMethodTests.cs
+++ b/SharpTS.Tests/SharedTests/ComputedSymbolMethodTests.cs
@@ -14,7 +14,7 @@ namespace SharpTS.Tests.SharedTests;
 public class ComputedSymbolMethodTests
 {
     [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void ObjectReturningIterator_ForOf_Works(ExecutionMode mode)
     {
         var source = """
@@ -31,7 +31,7 @@ public class ComputedSymbolMethodTests
     }
 
     [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void GeneratorIterator_ForOfAndSpread_Works(ExecutionMode mode)
     {
         var source = """
@@ -44,7 +44,7 @@ public class ComputedSymbolMethodTests
     }
 
     [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void GeneratorIterator_CapturesThis(ExecutionMode mode)
     {
         var source = """
@@ -63,7 +63,7 @@ public class ComputedSymbolMethodTests
     }
 
     [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void GeneratorIterator_ElementTypeIsNumber(ExecutionMode mode)
     {
         // The spread must yield number[], not Iterator<number>[] — the factory's iterator
@@ -77,6 +77,9 @@ public class ComputedSymbolMethodTests
         Assert.Equal("3\n", TestHarness.Run(source, mode));
     }
 
+    // Compiled mode: a non-symbol computed key (`[KEY]()` with KEY a string) would need a
+    // dynamically-named .NET method; the symbol-method registry only backs symbol keys, and named
+    // access doesn't consult it. Interpreter-only; tracked as a follow-up.
     [Theory]
     [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
     public void NonSymbolComputedMethodKey_FoldsToNamedMethod(ExecutionMode mode)
@@ -91,7 +94,7 @@ public class ComputedSymbolMethodTests
     }
 
     [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void AsyncGeneratorIterator_ForAwait_Works(ExecutionMode mode)
     {
         var source = """
@@ -106,6 +109,42 @@ public class ComputedSymbolMethodTests
     }
 
     [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void GenericIterableClass_Works(ExecutionMode mode)
+    {
+        // Exercises the symbol registry's generic-class handling (registry keyed by the open
+        // definition; receiver/MethodInfo closed for invoke).
+        var source = """
+            class Box<T> {
+              constructor(private items: T[]) {}
+              *[Symbol.iterator](): Iterator<T> { for (const x of this.items) yield x; }
+            }
+            for (const n of new Box<number>([1, 2, 3])) console.log(n);
+            """;
+
+        Assert.Equal("1\n2\n3\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void InheritedComputedIterator_Works(ExecutionMode mode)
+    {
+        // A subclass inherits the base's [Symbol.iterator] via the registry's base-chain walk.
+        var source = """
+            class Base { *[Symbol.iterator]() { yield 1; yield 2; } }
+            class Derived extends Base {}
+            console.log([...new Derived()].length);
+            for (const x of new Derived()) console.log(x);
+            """;
+
+        Assert.Equal("2\n1\n2\n", TestHarness.Run(source, mode));
+    }
+
+    // Compiled mode: reading a symbol method as a value (`obj[Symbol.iterator]`) returns the raw
+    // MethodInfo rather than a receiver-bound callable, so a standalone `obj[Symbol.iterator]()` call
+    // loses `this`. for...of / spread / for-await (which pass the receiver themselves) are unaffected
+    // and run in both back ends. Tracked as a follow-up.
+    [Theory]
     [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
     public void DirectSymbolMethodAccess_ReturnsCallable(ExecutionMode mode)
     {
@@ -118,6 +157,8 @@ public class ComputedSymbolMethodTests
         Assert.Equal("5\n", TestHarness.Run(source, mode));
     }
 
+    // Compiled mode: class *expressions* go through a separate emit path that doesn't yet wire
+    // computed symbol-keyed methods (class declarations do). Tracked as a follow-up.
     [Theory]
     [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
     public void ClassExpression_ComputedSymbolMethod_Works(ExecutionMode mode)

--- a/SharpTS.Tests/SharedTests/StaticGeneratorMethodTests.cs
+++ b/SharpTS.Tests/SharedTests/StaticGeneratorMethodTests.cs
@@ -1,0 +1,78 @@
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests;
+
+/// <summary>
+/// Tests for static generator methods — `class C { static *gen() { yield … } }` (#692). The instance
+/// form already compiled; this pins the static form, whose state machine is set up like a free
+/// function (no `this`). Runs in both back ends.
+/// </summary>
+public class StaticGeneratorMethodTests
+{
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void StaticGenerator_SingleYield_Works(ExecutionMode mode)
+    {
+        var source = """
+            class C { static *gen() { yield 7; } }
+            console.log([...C.gen()][0]);
+            """;
+
+        Assert.Equal("7\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void StaticGenerator_WithParameter_Works(ExecutionMode mode)
+    {
+        var source = """
+            class C { static *range(n: number) { for (let i = 0; i < n; i++) yield i * 2; } }
+            console.log([...C.range(3)].join(","));
+            for (const x of C.range(2)) console.log(x);
+            """;
+
+        Assert.Equal("0,2,4\n0\n2\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void StaticGenerator_ReadsStaticField_Works(ExecutionMode mode)
+    {
+        var source = """
+            class C {
+              static count = 3;
+              static *fromField() { for (let i = 0; i < C.count; i++) yield i; }
+            }
+            console.log([...C.fromField()].join(","));
+            """;
+
+        Assert.Equal("0,1,2\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void StaticGenerator_ExplicitReturnType_Works(ExecutionMode mode)
+    {
+        // Per #692: an explicit Generator<T> return type doesn't change the lowering path.
+        var source = """
+            class C { static *gen(): Generator<number> { yield 1; yield 2; yield 3; } }
+            console.log([...C.gen()].length);
+            """;
+
+        Assert.Equal("3\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void InstanceGenerator_StillWorks(ExecutionMode mode)
+    {
+        // Regression guard: the instance form (the path #692 did not touch) keeps working.
+        var source = """
+            class C { *gen() { yield 7; } }
+            console.log([...new C().gen()][0]);
+            """;
+
+        Assert.Equal("7\n", TestHarness.Run(source, mode));
+    }
+}

--- a/TypeSystem/TypeChecker.Expressions.cs
+++ b/TypeSystem/TypeChecker.Expressions.cs
@@ -1830,8 +1830,28 @@ public partial class TypeChecker
                 return new TypeInfo.Function(paramTypes, returnType, requiredParams, hasRest, null, paramNames);
             }
 
-            // Collect method signatures
-            var methodGroups = classExpr.Methods.GroupBy(m => m.Name.Lexeme).ToList();
+            // Computed symbol-keyed methods (`[Symbol.iterator]() {...}`) are modeled under their
+            // canonical @@name (@@iterator, …) so structural iterability sees them (#592). They carry the
+            // synthetic `<computed>` name, so they're pulled out of the name-keyed overload grouping.
+            // An iterator factory's explicit return type is used as-is (not generator-wrapped), so the
+            // structural probe reads the right element type.
+            foreach (var method in classExpr.Methods.Where(m => m.ComputedKey != null && m.Body != null))
+            {
+                if (TryGetWellKnownSymbolMemberName(method.ComputedKey) is not { } memberName)
+                    continue;
+                var (cParamTypes, cRequired, cHasRest, cParamNames) = BuildFunctionSignature(
+                    method.Parameters, validateDefaults: true, contextName: $"method '{memberName}'");
+                TypeInfo factoryReturn = method.ReturnType != null ? ToTypeInfo(method.ReturnType) : new TypeInfo.Inferred();
+                var computedFunc = new TypeInfo.Function(cParamTypes, factoryReturn, cRequired, cHasRest, null, cParamNames);
+                if (method.IsStatic)
+                    mutableClass.StaticMethods[memberName] = computedFunc;
+                else
+                    mutableClass.Methods[memberName] = computedFunc;
+                mutableClass.MethodAccess[memberName] = method.Access;
+            }
+
+            // Collect method signatures (computed-key methods handled above)
+            var methodGroups = classExpr.Methods.Where(m => m.ComputedKey == null).GroupBy(m => m.Name.Lexeme).ToList();
             foreach (var group in methodGroups)
             {
                 string methodName = group.Key;
@@ -1995,9 +2015,31 @@ public partial class TypeChecker
                 else
                     methodEnv = new TypeEnvironment(_environment);
 
-                var declaredMethodType = method.IsStatic
-                    ? classTypeForBody.StaticMethods[method.Name.Lexeme]
-                    : classTypeForBody.Methods[method.Name.Lexeme];
+                TypeInfo declaredMethodType;
+                if (method.ComputedKey != null)
+                {
+                    // Computed methods carry the `<computed>` name; well-known ones are keyed by their
+                    // @@name, arbitrary ones aren't modeled — build a signature inline to bind params.
+                    string? memberName = TryGetWellKnownSymbolMemberName(method.ComputedKey);
+                    var computedDict = method.IsStatic ? classTypeForBody.StaticMethods : classTypeForBody.Methods;
+                    if (memberName != null && computedDict.TryGetValue(memberName, out var ct))
+                    {
+                        declaredMethodType = ct;
+                    }
+                    else
+                    {
+                        var (cpt, creq, chr, cpn) = BuildFunctionSignature(
+                            method.Parameters, validateDefaults: true, contextName: "computed method");
+                        TypeInfo cr = method.ReturnType != null ? ToTypeInfo(method.ReturnType) : new TypeInfo.Inferred();
+                        declaredMethodType = new TypeInfo.Function(cpt, cr, creq, chr, null, cpn);
+                    }
+                }
+                else
+                {
+                    declaredMethodType = method.IsStatic
+                        ? classTypeForBody.StaticMethods[method.Name.Lexeme]
+                        : classTypeForBody.Methods[method.Name.Lexeme];
+                }
 
                 TypeInfo.Function methodType = declaredMethodType switch
                 {

--- a/TypeSystem/TypeChecker.Statements.Classes.cs
+++ b/TypeSystem/TypeChecker.Statements.Classes.cs
@@ -10,6 +10,21 @@ namespace SharpTS.TypeSystem;
 /// </summary>
 public partial class TypeChecker
 {
+    /// <summary>
+    /// Maps a class computed method/accessor key expression to the canonical well-known-symbol member
+    /// name the type system uses (<c>Symbol.iterator</c> → <c>@@iterator</c>,
+    /// <c>Symbol.asyncIterator</c> → <c>@@asyncIterator</c>, …) — matching the <c>@@</c> convention the
+    /// parser already applies to symbol-keyed members in type/interface positions
+    /// (see <c>Parser.Types.cs</c>). Returns null for keys that aren't a static <c>Symbol.&lt;name&gt;</c>
+    /// access (an arbitrary computed key, e.g. <c>[myVar]()</c>, isn't modeled as a named member —
+    /// it parses and runs but carries no static member type, mirroring computed accessors).
+    /// </summary>
+    private static string? TryGetWellKnownSymbolMemberName(Expr? key) => key switch
+    {
+        Expr.Get { Object: Expr.Variable { Name.Lexeme: "Symbol" }, Name.Lexeme: var n } => "@@" + n,
+        _ => null
+    };
+
     private void CheckClassDeclaration(Stmt.Class classStmt)
     {
         // Check class decorators
@@ -99,9 +114,35 @@ public partial class TypeChecker
             return new TypeInfo.Function(paramTypes, returnType, requiredParams, hasRest, null, paramNames);
         }
 
+        // Computed symbol-keyed methods (`[Symbol.iterator]() {...}`) are modeled under their canonical
+        // well-known-symbol member name (@@iterator, @@asyncIterator, …) so structural iterability and
+        // member lookup see them (#592/#485). They carry the synthetic `<computed>` name, so they are
+        // pulled out of the name-keyed overload grouping below. Arbitrary computed keys (e.g. `[v]()`)
+        // aren't statically named members and are skipped (still parsed/checked, just untyped — like
+        // computed accessors).
+        foreach (var method in classStmt.Methods.Where(m => m.ComputedKey != null && m.Body != null))
+        {
+            if (TryGetWellKnownSymbolMemberName(method.ComputedKey) is not { } memberName)
+                continue;
+            // Build the factory signature WITHOUT the generator-return wrapping BuildMethodFuncType
+            // applies: a [Symbol.iterator]()/[Symbol.asyncIterator]() factory must return the iterator
+            // type itself (e.g. `Iterator<number>` — what for...of consumes and reads its element from),
+            // not Generator<Iterator<number>>. An un-annotated generator factory stays <inferred> here
+            // and is filled in by the inferred-return post-pass below as Generator<yieldType>.
+            var (cParamTypes, cRequired, cHasRest, cParamNames) = BuildFunctionSignature(
+                method.Parameters, validateDefaults: true, contextName: $"method '{memberName}'");
+            TypeInfo factoryReturn = method.ReturnType != null ? ToTypeInfo(method.ReturnType) : new TypeInfo.Inferred();
+            var funcType = new TypeInfo.Function(cParamTypes, factoryReturn, cRequired, cHasRest, null, cParamNames);
+            if (method.IsStatic)
+                mutableClass.StaticMethods[memberName] = funcType;
+            else
+                mutableClass.Methods[memberName] = funcType;
+            mutableClass.MethodAccess[memberName] = method.Access;
+        }
+
         // First pass: collect signatures, grouping overloads
-        // Group methods by name to detect overloads
-        var methodGroups = classStmt.Methods.GroupBy(m => m.Name.Lexeme).ToList();
+        // Group methods by name to detect overloads (computed-key methods handled above)
+        var methodGroups = classStmt.Methods.Where(m => m.ComputedKey == null).GroupBy(m => m.Name.Lexeme).ToList();
 
         foreach (var group in methodGroups)
         {
@@ -603,7 +644,27 @@ public partial class TypeChecker
                 // Get the method type (could be Function or OverloadedFunction)
                 // For ES2022 private methods, look in PrivateMethodTypes/StaticPrivateMethodTypes
                 TypeInfo declaredMethodType;
-                if (method.IsPrivate)
+                if (method.ComputedKey != null)
+                {
+                    // Computed symbol-keyed methods carry the `<computed>` name, so they aren't keyed
+                    // in the method dictionaries by a static name. Well-known ones are stored under their
+                    // @@name; reuse that type. An arbitrary computed key has no modeled member — build a
+                    // signature inline just to bind parameter types for the body check.
+                    string? memberName = TryGetWellKnownSymbolMemberName(method.ComputedKey);
+                    var computedDict = method.IsStatic ? classTypeForBody.StaticMethods : classTypeForBody.Methods;
+                    if (memberName != null && computedDict.TryGetValue(memberName, out var computedType))
+                    {
+                        declaredMethodType = computedType;
+                    }
+                    else
+                    {
+                        var (cParamTypes, cRequired, cHasRest, cParamNames) = BuildFunctionSignature(
+                            method.Parameters, validateDefaults: true, contextName: "computed method");
+                        TypeInfo cReturn = method.ReturnType != null ? ToTypeInfo(method.ReturnType) : new TypeInfo.Inferred();
+                        declaredMethodType = new TypeInfo.Function(cParamTypes, cReturn, cRequired, cHasRest, null, cParamNames);
+                    }
+                }
+                else if (method.IsPrivate)
                 {
                     declaredMethodType = method.IsStatic
                         ? classTypeForBody.StaticPrivateMethodTypes[method.Name.Lexeme]
@@ -707,22 +768,29 @@ public partial class TypeChecker
                         else if (method.IsAsync && inferredReturn is not TypeInfo.Void)
                             inferredReturn = new TypeInfo.Promise(inferredReturn);
 
-                        // Update the method type in the class
+                        // Update the method type in the class. Computed symbol-keyed methods are keyed
+                        // by their @@name (e.g. @@iterator), not the synthetic `<computed>` lexeme; an
+                        // arbitrary computed key (no well-known @@name) carries no static member to update.
                         var updatedMethodType = new TypeInfo.Function(methodType.ParamTypes, inferredReturn, methodType.RequiredParams, methodType.HasRestParam, methodType.ThisType, methodType.ParamNames);
-                        string mName = method.Name.Lexeme;
-                        if (method.IsPrivate)
+                        string? mName = method.ComputedKey != null
+                            ? TryGetWellKnownSymbolMemberName(method.ComputedKey)
+                            : method.Name.Lexeme;
+                        if (mName != null)
                         {
-                            if (method.IsStatic) mutableClass.StaticPrivateMethods[mName] = updatedMethodType;
-                            else mutableClass.PrivateMethods[mName] = updatedMethodType;
+                            if (method.IsPrivate)
+                            {
+                                if (method.IsStatic) mutableClass.StaticPrivateMethods[mName] = updatedMethodType;
+                                else mutableClass.PrivateMethods[mName] = updatedMethodType;
+                            }
+                            else
+                            {
+                                if (method.IsStatic) mutableClass.StaticMethods[mName] = updatedMethodType;
+                                else mutableClass.Methods[mName] = updatedMethodType;
+                            }
+                            // The frozen class call sites read still holds the <inferred> placeholder for
+                            // this method; flag a rebuild after the body pass (#658/#661).
+                            anyInferredMethodReturnResolved = true;
                         }
-                        else
-                        {
-                            if (method.IsStatic) mutableClass.StaticMethods[mName] = updatedMethodType;
-                            else mutableClass.Methods[mName] = updatedMethodType;
-                        }
-                        // The frozen class call sites read still holds the <inferred> placeholder for
-                        // this method; flag a rebuild after the body pass (#658/#661).
-                        anyInferredMethodReturnResolved = true;
                     }
                 }
                 finally


### PR DESCRIPTION
@
## Summary

Implements three related issues that together let user-defined iterable classes be written and run in **both** the interpreter and the IL compiler:

- **#592** — `class C { [Symbol.iterator]() {} }`, the generator `*[Symbol.iterator]()` and async `async *[Symbol.asyncIterator]()` forms now parse, type-check, and run in the interpreter (class declarations *and* class expressions).
- **#647** — the same feature in compiled mode.
- **#692** — compiled static generator methods (`static *m()`), which previously failed with *"Yield not supported in this context"*.

## What changed

### #592 — parser / type-checker / interpreter (`fc878262`)
- **Parser:** `Stmt.Function` gains `ComputedKey`; `FunctionDeclaration` accepts a pre-parsed computed key; a shared `ParseComputedClassMember` helper disambiguates a computed *method* (`(`/`<` after `]`) from a computed *field*, wired into both class-body loops.
- **Interpreter:** computed keys are evaluated at class-definition time — symbol keys register on the class (`SharpTSClass.AddSymbolMethod`/`FindSymbolMethod`, bound via the shared `BindMethod`/new `BindStaticMethod`), other keys fold to a string-named method. `instance[Symbol.x]`, sync `for...of` and `for await` resolve the symbol method off the class chain; a generator-valued factory iterates via its `IEnumerable`.
- **Type-checker:** a computed `[Symbol.iterator]()`/`[Symbol.asyncIterator]()` is modeled under its canonical `@@name` so structural iterability (#485) finds it (a plain class instance is still TS2488 non-iterable, #593). The iterator factorys explicit return type is used as-is (not generator-wrapped) so the element type reads correctly (`number`, not `Iterator<number>`).

### #647 — compiled mode (`da5da530`)
- Extends the existing `$Runtime` symbol-accessor registry: the per-`(Type, symbol)` slot array grows `object[4]` → `object[6]` with instance/static **method** slots; `RegisterSymbolMethod`/`FindSymbolMethodFor` reuse the proven base-chain walk (so generics and inheritance compose for free).
- Each computed method is emitted under a unique `$symmethod_N` name by flowing a renamed `Stmt.Function` through the normal per-method emitters — so the generator/async state machines compose unchanged — and registered in the class `.cctor`.
- Dispatch: `GetIteratorFunction` consults the registry after the per-object symbol-dict probe misses; the bracket-get returns the found method; and `InvokeMethodValue` gains a `MethodBase` arm so a resolved `MethodInfo` is invokable (mirroring the symbol-accessor get/set paths). All pure emitted IL on `$Runtime` — standalone DLLs stay standalone.

### #692 — compiled static generators (`173ea423`)
- `EmitStaticMethodBody` handled async but had no generator branch, so a static generator body was emitted as a plain sync method. `EmitGeneratorMethodBody` is generalized with an `isInstanceMethod` flag + a new `EmitGeneratorStaticStubMethod` (params from arg 0, no `this`, value-types boxed). The dispatch is gated `IsGenerator && !IsAsync` so `static async *m()` (its async-generator analog) still routes to the async path unchanged.

## Testing
- **13,008 unit tests pass** (full suite, re-run after each issue), including new `ComputedSymbolMethodTests` (18 cases: object-return/generator iterators, this-capture, element typing, generics, inheritance, for-await) and `StaticGeneratorMethodTests` (10 cases) covering both back ends.
- **Test262: no conformance regression** (`Failed: 0`, exit 0). The harness hard-fails on regression; guest programs run in isolated worker subprocesses.
- Independent review of the full diff found no correctness bugs.

## Scope / follow-ups
The core feature (for...of, spread, for-await over iterable classes — the issues examples) works in both modes. A few narrower cases remain interpreter-only and are filed as follow-ups, with their tests staged to flip to compiled as each lands:
- #755 — compiled: standalone `obj[Symbol.iterator]()` value access (unbound `MethodInfo`), class-*expression* computed methods, non-symbol (string) computed keys.
- #761 — compiled `static async *m()` (async-generator analog of #692).

Also filed while testing (pre-existing, independent): #756 (`class implements Iterable<T>` rejected), #757 (object-literal generator computed method parse failure).
@