### PR TITLE
Compiled closures: generator-arrow top-level capture, instance/async generator write-capture, async-arrow relay (#732 #724 #725 #716)

### DIFF
--- a/Compilation/AsyncGeneratorMoveNextEmitter.Expressions.cs
+++ b/Compilation/AsyncGeneratorMoveNextEmitter.Expressions.cs
@@ -672,6 +672,28 @@ public partial class AsyncGeneratorMoveNextEmitter
 
         _il.Emit(OpCodes.Newobj, displayCtor);
 
+        // Thread the entry-point display class into the arrow's $entryPointDC field so it reads
+        // captured TOP-LEVEL variables through shared storage (the async-generator analog of #732).
+        if (_ctx.ArrowEntryPointDCFields?.TryGetValue(af, out var entryPointDCField) == true &&
+            _ctx.EntryPointDisplayClassStaticField != null)
+        {
+            _il.Emit(OpCodes.Dup);
+            _il.Emit(OpCodes.Ldsfld, _ctx.EntryPointDisplayClassStaticField);
+            _il.Emit(OpCodes.Stfld, entryPointDCField);
+        }
+
+        // Thread the state machine's function display class into the arrow's $functionDC field so a
+        // write to a captured-and-mutated generator local reaches shared storage instead of a by-value
+        // snapshot — the case the compile-time guard previously rejected (#725).
+        if (_ctx.ArrowFunctionDCFields?.TryGetValue(af, out var functionDCField) == true &&
+            _builder.FunctionDCField != null)
+        {
+            _il.Emit(OpCodes.Dup);
+            _il.Emit(OpCodes.Ldarg_0);
+            _il.Emit(OpCodes.Ldfld, _builder.FunctionDCField);
+            _il.Emit(OpCodes.Stfld, functionDCField);
+        }
+
         if (_ctx.DisplayClassFields == null || !_ctx.DisplayClassFields.TryGetValue(af, out var fieldMap))
         {
             _il.Emit(OpCodes.Ldtoken, method);

--- a/Compilation/AsyncGeneratorMoveNextEmitter.Variables.cs
+++ b/Compilation/AsyncGeneratorMoveNextEmitter.Variables.cs
@@ -1,0 +1,107 @@
+using System.Reflection.Emit;
+using SharpTS.Parsing;
+
+namespace SharpTS.Compilation;
+
+public partial class AsyncGeneratorMoveNextEmitter
+{
+    // Expose the state machine's function display class field to the base arrow emitter so a
+    // capturing arrow inside the async generator body gets its $functionDC threaded in (#725).
+    protected override FieldBuilder? GetFunctionDCField() => _builder.FunctionDCField;
+
+    /// <summary>
+    /// Routes reads and writes of a captured-AND-mutated async-generator local/parameter through the
+    /// shared function display class (#725) so a write inside an arrow/callback and the generator body
+    /// observe the same storage. The async-generator state machine is a reference type, so the DC —
+    /// held by its <c>&lt;&gt;__functionDC</c> field — persists across awaits and yields and is the
+    /// single source of truth (the async generator never lifts these to async arrows, which it does not
+    /// support). Returns false (no DC routing) for variables that stay on the existing hoisted-field /
+    /// local snapshot path. Mirrors <see cref="GeneratorMoveNextEmitter"/>.
+    /// </summary>
+    private bool TryGetFunctionDCField(string name, out FieldBuilder dcField)
+    {
+        dcField = null!;
+        return _builder.FunctionDCField != null &&
+               _ctx?.CapturedFunctionLocals?.Contains(name) == true &&
+               _ctx.FunctionDisplayClassFields?.TryGetValue(name, out dcField!) == true;
+    }
+
+    /// <summary>
+    /// Stores the value currently on the stack into <c>this.&lt;&gt;__functionDC.dcField</c>,
+    /// consuming it. Caller is responsible for any duplicate it wants to keep as a result.
+    /// </summary>
+    private void StoreToDCField(FieldBuilder dcField)
+    {
+        var temp = _il.DeclareLocal(_types.Object);
+        _il.Emit(OpCodes.Stloc, temp);
+        _il.Emit(OpCodes.Ldarg_0);
+        _il.Emit(OpCodes.Ldfld, _builder.FunctionDCField!);
+        _il.Emit(OpCodes.Ldloc, temp);
+        _il.Emit(OpCodes.Stfld, dcField);
+    }
+
+    protected override void EmitVariable(Expr.Variable v)
+    {
+        if (TryGetFunctionDCField(v.Name.Lexeme, out var dcField))
+        {
+            _il.Emit(OpCodes.Ldarg_0);
+            _il.Emit(OpCodes.Ldfld, _builder.FunctionDCField!);
+            _il.Emit(OpCodes.Ldfld, dcField);
+            SetStackUnknown();
+            return;
+        }
+
+        base.EmitVariable(v);
+    }
+
+    protected override void EmitVarDeclaration(Stmt.Var v)
+    {
+        if (TryGetFunctionDCField(v.Name.Lexeme, out var dcField))
+        {
+            if (v.Initializer != null)
+            {
+                EmitExpression(v.Initializer);
+                EnsureBoxed();
+            }
+            else
+            {
+                _il.Emit(OpCodes.Ldsfld, _ctx!.Runtime!.UndefinedInstance);
+            }
+            StoreToDCField(dcField);
+            return;
+        }
+
+        base.EmitVarDeclaration(v);
+    }
+
+    protected override void EmitAssign(Expr.Assign a)
+    {
+        if (TryGetFunctionDCField(a.Name.Lexeme, out var dcField))
+        {
+            EmitExpression(a.Value);
+            EnsureBoxed();
+            _il.Emit(OpCodes.Dup); // keep a copy as the assignment expression's result
+            StoreToDCField(dcField);
+            SetStackUnknown();
+            return;
+        }
+
+        base.EmitAssign(a);
+    }
+
+    /// <summary>
+    /// Store side of compound assignment, logical assignment, and increment/decrement (the value
+    /// is already on the stack). Reads for those operators go through <see cref="EmitVariable"/>,
+    /// so routing the store here keeps both ends on the function DC.
+    /// </summary>
+    protected override void EmitStoreVariable(string name)
+    {
+        if (TryGetFunctionDCField(name, out var dcField))
+        {
+            StoreToDCField(dcField);
+            return;
+        }
+
+        base.EmitStoreVariable(name);
+    }
+}

--- a/Compilation/AsyncGeneratorStateMachineBuilder.cs
+++ b/Compilation/AsyncGeneratorStateMachineBuilder.cs
@@ -41,6 +41,12 @@ public class AsyncGeneratorStateMachineBuilder
     // 'this' field for instance async generator methods
     public FieldBuilder? ThisField { get; private set; }
 
+    // Function-level display class field for captured-and-mutated locals (#725). A sync arrow inside
+    // the async generator body that WRITES a variable captured from the generator scope shares storage
+    // with the generator through this reference-typed display class — the same mechanism the sync
+    // generator state machine uses (#674). Null when the async generator has no such write-capture.
+    public FieldBuilder? FunctionDCField { get; private set; }
+
     // Delegated async enumerator field for yield* expressions
     public FieldBuilder? DelegatedAsyncEnumeratorField { get; private set; }
 
@@ -748,6 +754,18 @@ public class AsyncGeneratorStateMachineBuilder
         var fromException = typeof(Task).GetMethod("FromException", 1, [typeof(Exception)])!.MakeGenericMethod(_types.Object);
         il.Emit(OpCodes.Call, fromException);
         il.Emit(OpCodes.Ret);
+    }
+
+    /// <summary>
+    /// Adds the field that holds the function display class instance for closure mutation
+    /// sharing (#725). Mirrors <see cref="GeneratorStateMachineBuilder.DefineFunctionDisplayClassField"/>.
+    /// </summary>
+    public void DefineFunctionDisplayClassField(Type dcType)
+    {
+        FunctionDCField = _stateMachineType.DefineField(
+            "<>__functionDC",
+            dcType,
+            FieldAttributes.Public);
     }
 
     /// <summary>

--- a/Compilation/ClosureAnalyzer.cs
+++ b/Compilation/ClosureAnalyzer.cs
@@ -276,7 +276,44 @@ public class ClosureAnalyzer : AstVisitorBase
                     _captureSources[_currentFunction] = sources;
                 }
                 sources[name] = definingFunc;
+
+                PropagateCaptureUpAsyncArrowChain(name, definingFunc);
             }
+        }
+    }
+
+    /// <summary>
+    /// A STANDALONE async arrow (one not nested in an async <em>function</em>) copies each captured
+    /// variable BY VALUE into its own state machine — there is no shared display class to relay it,
+    /// unlike sync arrows. So an INTERMEDIATE async arrow that does not itself reference
+    /// <paramref name="name"/> must still capture-and-forward it for a deeper nested arrow that does,
+    /// or the deeper arrow's capture array reads it as null (#716). This mirrors the up-the-chain
+    /// propagation <see cref="VisitThis"/> already does for <c>this</c>, but unions
+    /// <paramref name="name"/> onto enclosing ASYNC arrow frames only — sync arrows relay captures
+    /// through shared scope display classes and rely on per-arrow capture sets staying innermost-only,
+    /// so adding to them would perturb that machinery. Stops at the variable's defining scope (its
+    /// owner, which already has it as a local) and at the first non-async-arrow boundary (a sync arrow
+    /// or any function declaration), beyond which a different relay mechanism applies. Only invoked for
+    /// function-local captures (<paramref name="definingFunc"/> non-null); top-level variables reach an
+    /// arrow through the entry-point display class, not capture forwarding, so they are not propagated.
+    /// </summary>
+    private void PropagateCaptureUpAsyncArrowChain(string name, object definingFunc)
+    {
+        // _functionStack enumerates innermost-first; the top is _currentFunction (already recorded).
+        bool passedCurrent = false;
+        foreach (var frame in _functionStack)
+        {
+            if (!passedCurrent)
+            {
+                if (ReferenceEquals(frame, _currentFunction)) passedCurrent = true;
+                continue;
+            }
+            if (ReferenceEquals(frame, definingFunc))
+                break; // reached the owning scope — it holds `name` as a local
+            if (frame is not Expr.ArrowFunction { IsAsync: true } intermediateArrow)
+                break; // sync arrow / function boundary — different relay mechanism applies
+            if (_captures.TryGetValue(intermediateArrow, out var caps) && caps.Add(name))
+                _allCapturedVariables.Add(name);
         }
     }
 

--- a/Compilation/ExpressionEmitterBase.cs
+++ b/Compilation/ExpressionEmitterBase.cs
@@ -1574,6 +1574,21 @@ public abstract partial class ExpressionEmitterBase : IEmitterContext
     {
         IL.Emit(OpCodes.Newobj, displayCtor);
 
+        // Thread the entry-point display class into the arrow's $entryPointDC field so the arrow
+        // reads captured TOP-LEVEL (module-level) variables through shared storage. The generator
+        // body itself reads top-level vars live via the static entry-point DC field; an arrow
+        // nested in that body needs the same reference, or dereferencing the (null) $entryPointDC
+        // field throws a NullReferenceException when the arrow runs (#732). Mirrors the per-emitter
+        // override in AsyncMoveNextEmitter; the static field is the only entry-point DC source
+        // reachable from a generator MoveNext (no local, no parent-arrow DC field).
+        if (Ctx.ArrowEntryPointDCFields?.TryGetValue(af, out var entryPointDCField) == true &&
+            Ctx.EntryPointDisplayClassStaticField != null)
+        {
+            IL.Emit(OpCodes.Dup);
+            IL.Emit(OpCodes.Ldsfld, Ctx.EntryPointDisplayClassStaticField);
+            IL.Emit(OpCodes.Stfld, entryPointDCField);
+        }
+
         // Thread the enclosing state machine's function display class into the arrow's $functionDC
         // field so the arrow reads/writes captured-and-mutated locals through shared storage rather
         // than a by-value snapshot — the write case that was previously rejected (#674). The arrow's

--- a/Compilation/ILCompiler.AsyncGenerators.cs
+++ b/Compilation/ILCompiler.AsyncGenerators.cs
@@ -33,6 +33,13 @@ public partial class ILCompiler
         _asyncGenerators.StateMachines[qualifiedName] = smBuilder;
         _asyncGenerators.Functions[qualifiedName] = funcStmt;
 
+        // Record the AST node so PropagateFunctionDCRequirements can resolve arrows nested in this
+        // async generator back to its qualified name, and lift captured-and-mutated locals into a
+        // shared function display class so a sync arrow/callback that writes one reaches the generator
+        // instead of snapshotting it by value (#725). Mirrors DefineGeneratorFunction (#674).
+        _closures.FunctionAstNodes[qualifiedName] = funcStmt;
+        DefineAsyncGeneratorFunctionDisplayClass(funcStmt, qualifiedName, smBuilder);
+
         // Define the stub method that creates and returns the state machine.
         // A trailing rest parameter is typed List<object> so the indirect
         // ($TSFunction.Invoke) call path packs trailing args into it (#426).
@@ -58,6 +65,25 @@ public partial class ILCompiler
     }
 
     /// <summary>
+    /// Lifts an async generator's captured-AND-mutated locals into a function-level display class so a
+    /// sync arrow/callback inside the body that writes such a variable shares storage with the generator
+    /// instead of snapshotting it by value (#725). The async-generator state machine is a reference type,
+    /// so the DC field persists across awaits and yields. No-op when there is no write-capture, leaving
+    /// fully-standalone output unchanged. Mirrors <see cref="DefineGeneratorFunctionDisplayClass"/>.
+    /// </summary>
+    private void DefineAsyncGeneratorFunctionDisplayClass(
+        Stmt.Function funcStmt, string qualifiedName, AsyncGeneratorStateMachineBuilder smBuilder)
+    {
+        var mutatedCaptured = ComputeMutatedCapturedGeneratorVars(funcStmt);
+        if (mutatedCaptured.Count == 0)
+            return;
+
+        RegisterFunctionDisplayClass(qualifiedName, mutatedCaptured);
+        if (_closures.FunctionDisplayClasses.TryGetValue(qualifiedName, out var funcDC))
+            smBuilder.DefineFunctionDisplayClassField(funcDC);
+    }
+
+    /// <summary>
     /// Emits all async generator state machine bodies.
     /// Called after all functions have been defined.
     /// </summary>
@@ -78,10 +104,10 @@ public partial class ILCompiler
             var methodBuilder = _functions.Builders[funcName];
 
             // Emit the stub method body (creates and returns the state machine)
-            EmitAsyncGeneratorStubMethod(methodBuilder, smBuilder, funcStmt);
+            EmitAsyncGeneratorStubMethod(methodBuilder, smBuilder, funcStmt, funcName);
 
             // Emit the MoveNextAsync method body
-            EmitAsyncGeneratorMoveNextAsyncBody(smBuilder, funcStmt);
+            EmitAsyncGeneratorMoveNextAsyncBody(smBuilder, funcStmt, funcName);
 
             // Finalize the state machine type
             smBuilder.CreateType();
@@ -93,7 +119,7 @@ public partial class ILCompiler
     /// <summary>
     /// Emits the stub method that creates and initializes the async generator state machine.
     /// </summary>
-    private void EmitAsyncGeneratorStubMethod(MethodBuilder methodBuilder, AsyncGeneratorStateMachineBuilder smBuilder, Stmt.Function funcStmt)
+    private void EmitAsyncGeneratorStubMethod(MethodBuilder methodBuilder, AsyncGeneratorStateMachineBuilder smBuilder, Stmt.Function funcStmt, string qualifiedName)
     {
         var il = methodBuilder.GetILGenerator();
 
@@ -113,6 +139,11 @@ public partial class ILCompiler
             }
         }
 
+        // Instantiate the function display class (#725) and seed any captured-and-mutated parameter
+        // into it so a sync arrow that writes it shares the generator's storage. The stub params are
+        // object-typed (BuildStateMachineStubParamTypes), so no boxing is needed (paramTypes: null).
+        EmitGeneratorFunctionDCInit(il, smBuilder.FunctionDCField, funcStmt, qualifiedName, paramOffset: 0);
+
         // Return the state machine (which implements IAsyncEnumerable<object>)
         il.Emit(OpCodes.Ret);
     }
@@ -121,7 +152,7 @@ public partial class ILCompiler
     /// Emits the MoveNextAsync method body for an async generator state machine.
     /// Uses AsyncGeneratorMoveNextEmitter to handle full generator body with yield and await expressions.
     /// </summary>
-    private void EmitAsyncGeneratorMoveNextAsyncBody(AsyncGeneratorStateMachineBuilder smBuilder, Stmt.Function funcStmt)
+    private void EmitAsyncGeneratorMoveNextAsyncBody(AsyncGeneratorStateMachineBuilder smBuilder, Stmt.Function funcStmt, string qualifiedName)
     {
         var analysis = _asyncGenerators.Analyzer.Analyze(funcStmt);
 
@@ -166,8 +197,21 @@ public partial class ILCompiler
             EntryPointDisplayClassFields = BuildEntryPointDisplayClassFieldsForModule(_modules.CurrentPath),
             CapturedTopLevelVars = BuildCapturedTopLevelVarsForModule(_modules.CurrentPath),
             EntryPointDisplayClassStaticField = _closures.EntryPointDisplayClassStaticField,
+            // Per-arrow $entryPointDC field map so a capturing arrow nested in the async generator body
+            // gets the entry-point display class threaded in (#725 / async analog of #732).
+            ArrowEntryPointDCFields = _closures.ArrowEntryPointDCFields.Count > 0 ? _closures.ArrowEntryPointDCFields : null,
             TopLevelStaticVars = BuildTopLevelStaticVarsForModule(_modules.CurrentPath)
         };
+
+        // Route reads/writes of captured-and-mutated locals through the shared function display class
+        // (#725) and let capturing arrows thread it in. Only set when this async generator has a
+        // function DC; otherwise the existing by-value snapshot path is used unchanged.
+        if (_closures.FunctionDisplayClassFields.TryGetValue(qualifiedName, out var funcDCFields))
+        {
+            ctx.FunctionDisplayClassFields = funcDCFields;
+            ctx.CapturedFunctionLocals = [.. funcDCFields.Keys];
+            ctx.ArrowFunctionDCFields = _closures.ArrowFunctionDCFields.Count > 0 ? _closures.ArrowFunctionDCFields : null;
+        }
 
         // Use the new emitter for full async generator body emission
         var emitter = new AsyncGeneratorMoveNextEmitter(smBuilder, analysis, _types);
@@ -192,8 +236,16 @@ public partial class ILCompiler
             runtime: _runtime
         );
 
+        // #725: wire the function display class registered for this async generator method in
+        // DefineClass so a sync arrow that writes a captured method local shares storage with the
+        // generator. The field must be defined before the stub seeds captured params into it and
+        // before CreateType() finalizes the state machine.
+        string? methodDCKey = _asyncGeneratorMethodFunctionDCKeys.GetValueOrDefault(method);
+        if (methodDCKey != null && _closures.FunctionDisplayClasses.TryGetValue(methodDCKey, out var methodFuncDC))
+            smBuilder.DefineFunctionDisplayClassField(methodFuncDC);
+
         // Emit stub method body (creates state machine and returns it)
-        EmitAsyncGeneratorInstanceStubMethod(methodBuilder, smBuilder, method.Parameters);
+        EmitAsyncGeneratorInstanceStubMethod(methodBuilder, smBuilder, method, methodDCKey);
 
         // Create context for MoveNextAsync emission
         var il = smBuilder.MoveNextAsyncMethod.GetILGenerator();
@@ -241,8 +293,21 @@ public partial class ILCompiler
             EntryPointDisplayClassFields = BuildEntryPointDisplayClassFieldsForModule(_modules.CurrentPath),
             CapturedTopLevelVars = BuildCapturedTopLevelVarsForModule(_modules.CurrentPath),
             EntryPointDisplayClassStaticField = _closures.EntryPointDisplayClassStaticField,
+            // Per-arrow $entryPointDC field map so a capturing arrow nested in this instance async
+            // generator method's body gets the entry-point display class threaded in (#725).
+            ArrowEntryPointDCFields = _closures.ArrowEntryPointDCFields.Count > 0 ? _closures.ArrowEntryPointDCFields : null,
             TopLevelStaticVars = BuildTopLevelStaticVarsForModule(_modules.CurrentPath)
         };
+
+        // #725: route reads/writes of captured-and-mutated method locals through the shared function
+        // display class so the arrow's write and the generator body observe the same storage. Only set
+        // when this method has a function DC; otherwise the by-value snapshot path is used unchanged.
+        if (methodDCKey != null && _closures.FunctionDisplayClassFields.TryGetValue(methodDCKey, out var methodDCFields))
+        {
+            ctx.FunctionDisplayClassFields = methodDCFields;
+            ctx.CapturedFunctionLocals = [.. methodDCFields.Keys];
+            ctx.ArrowFunctionDCFields = _closures.ArrowFunctionDCFields.Count > 0 ? _closures.ArrowFunctionDCFields : null;
+        }
 
         // Emit MoveNextAsync body
         var moveNextEmitter = new AsyncGeneratorMoveNextEmitter(smBuilder, analysis, _types);
@@ -259,8 +324,10 @@ public partial class ILCompiler
     private void EmitAsyncGeneratorInstanceStubMethod(
         MethodBuilder methodBuilder,
         AsyncGeneratorStateMachineBuilder smBuilder,
-        List<Stmt.Parameter> parameters)
+        Stmt.Function method,
+        string? funcDCKey)
     {
+        var parameters = method.Parameters;
         var il = methodBuilder.GetILGenerator();
 
         // Create new instance of the state machine
@@ -301,6 +368,12 @@ public partial class ILCompiler
                 il.Emit(OpCodes.Stfld, field);
             }
         }
+
+        // #725: instantiate the function display class and seed any captured-and-mutated parameter
+        // into it (instance methods carry 'this' at arg 0, so user params start at arg 1). The stub
+        // params are typed, so value types are boxed before the store. No-op when no function DC.
+        if (funcDCKey != null)
+            EmitGeneratorFunctionDCInit(il, smBuilder.FunctionDCField, method, funcDCKey, paramOffset: 1, paramTypes);
 
         // Return the state machine (which implements IAsyncEnumerable<object>)
         il.Emit(OpCodes.Ret);

--- a/Compilation/ILCompiler.Classes.cs
+++ b/Compilation/ILCompiler.Classes.cs
@@ -70,6 +70,11 @@ public partial class ILCompiler
             return;
         }
 
+        // #724: register function display classes for instance generator methods whose arrows write a
+        // captured method local, before Phase 5's PropagateFunctionDCRequirements runs. Skipped for
+        // external (@DotNetType) classes, which return above without an emitted body.
+        RegisterGeneratorMethodFunctionDisplayClasses(classStmt, qualifiedClassName);
+
         // Set TypeAttributes.Abstract if the class is abstract
         TypeAttributes typeAttrs = TypeAttributes.Public | TypeAttributes.Class;
         if (classStmt.IsAbstract)

--- a/Compilation/ILCompiler.Generators.cs
+++ b/Compilation/ILCompiler.Generators.cs
@@ -11,6 +11,18 @@ namespace SharpTS.Compilation;
 /// </summary>
 public partial class ILCompiler
 {
+    // Maps an instance generator method's AST node to the function-display-class key registered for
+    // it during DefineClass (#724). EmitGeneratorMethodBody reads this to wire the state machine's
+    // function DC at emit time. Keyed by AST identity so the Phase-4 registration and the later
+    // Phase-7 emission agree without reconstructing a string from the emitted type name.
+    private readonly Dictionary<Stmt.Function, string> _generatorMethodFunctionDCKeys =
+        new(ReferenceEqualityComparer.Instance);
+
+    // The async-generator (`async *m()`) analogue of the above (#725), consumed by
+    // EmitAsyncGeneratorMethodBody. Kept separate so each emit path looks up only its own kind.
+    private readonly Dictionary<Stmt.Function, string> _asyncGeneratorMethodFunctionDCKeys =
+        new(ReferenceEqualityComparer.Instance);
+
     /// <summary>
     /// Defines a generator function and its state machine.
     /// </summary>
@@ -146,6 +158,39 @@ public partial class ILCompiler
     }
 
     /// <summary>
+    /// Phase-4 registration (called from <see cref="DefineClass"/>): for each SYNC instance generator
+    /// method whose body contains an arrow that WRITES a variable captured from the method scope,
+    /// registers a function-level display class — the instance-method analogue of the free-function
+    /// wiring <see cref="DefineGeneratorFunctionDisplayClass"/> does for <c>function*</c> declarations
+    /// (#724/#674). This must run before Phase 5 so <see cref="PropagateFunctionDCRequirements"/> can
+    /// resolve the nested arrow back to the method (via <c>FunctionAstNodes</c>) and route its write
+    /// through <c>$functionDC</c> instead of a by-value snapshot. <see cref="EmitGeneratorMethodBody"/>
+    /// later consumes the recorded key to wire the state machine's function DC. No-op for methods with
+    /// no such write-capture, leaving their state machines fully standalone. Covers both sync (#724)
+    /// and async (#725) instance generator methods; static and plain methods use other paths.
+    /// </summary>
+    private void RegisterGeneratorMethodFunctionDisplayClasses(Stmt.Class classStmt, string qualifiedClassName)
+    {
+        foreach (var method in classStmt.Methods)
+        {
+            if (method.Body == null || !method.IsGenerator || method.IsStatic)
+                continue;
+
+            var mutatedCaptured = ComputeMutatedCapturedGeneratorVars(method);
+            if (mutatedCaptured.Count == 0)
+                continue;
+
+            // Method names with bodies are unique within a class (overload signatures have no body),
+            // and the qualified class name disambiguates across modules/namespaces — so the "::" key is
+            // unique and disjoint from free-function registry keys (which never contain "::").
+            string key = $"{qualifiedClassName}::{method.Name.Lexeme}";
+            _closures.FunctionAstNodes[key] = method;
+            RegisterFunctionDisplayClass(key, mutatedCaptured);
+            (method.IsAsync ? _asyncGeneratorMethodFunctionDCKeys : _generatorMethodFunctionDCKeys)[method] = key;
+        }
+    }
+
+    /// <summary>
     /// Emits all generator state machine bodies.
     /// Called after all functions have been defined.
     /// </summary>
@@ -208,7 +253,7 @@ public partial class ILCompiler
         // Instantiate the function display class (#674) and seed any captured-and-mutated
         // parameters into it so an arrow that writes them shares the generator's storage. The
         // stub params are object-typed (BuildStateMachineStubParamTypes), so no boxing is needed.
-        EmitGeneratorFunctionDCInit(il, smBuilder, funcStmt, qualifiedName, paramOffset: 0);
+        EmitGeneratorFunctionDCInit(il, smBuilder.FunctionDCField, funcStmt, qualifiedName, paramOffset: 0);
 
         // Captured outer-scope variables are NOT copied into the state machine here. Doing so
         // snapshotted their value at creation time, so a later mutation of the outer variable
@@ -224,22 +269,25 @@ public partial class ILCompiler
     /// With the state machine instance on the stack, news up the function display class (#674),
     /// stores it into the state machine's <c>&lt;&gt;__functionDC</c> field, and copies any
     /// captured-and-mutated parameters into it. Leaves the state machine reference on the stack
-    /// (net stack effect zero). No-op when the generator has no function DC.
+    /// (net stack effect zero). No-op when the generator has no function DC. Takes the raw
+    /// <c>&lt;&gt;__functionDC</c> field so the sync (#674/#724) and async (#725) generator state
+    /// machine builders — which share no common interface — can both reuse it.
     /// </summary>
     private void EmitGeneratorFunctionDCInit(
         ILGenerator il,
-        GeneratorStateMachineBuilder smBuilder,
+        FieldBuilder? functionDCField,
         Stmt.Function funcStmt,
         string qualifiedName,
-        int paramOffset)
+        int paramOffset,
+        Type[]? paramTypes = null)
     {
-        if (smBuilder.FunctionDCField == null ||
+        if (functionDCField == null ||
             !_closures.FunctionDisplayClassCtors.TryGetValue(qualifiedName, out var dcCtor))
             return;
 
         il.Emit(OpCodes.Dup);                       // [sm, sm]
         il.Emit(OpCodes.Newobj, dcCtor);            // [sm, sm, dc]
-        il.Emit(OpCodes.Stfld, smBuilder.FunctionDCField); // [sm]
+        il.Emit(OpCodes.Stfld, functionDCField);    // [sm]
 
         if (!_closures.FunctionDisplayClassFields.TryGetValue(qualifiedName, out var dcFields))
             return;
@@ -250,8 +298,13 @@ public partial class ILCompiler
             if (!dcFields.TryGetValue(paramName, out var dcField))
                 continue;
             il.Emit(OpCodes.Dup);                   // [sm, sm]
-            il.Emit(OpCodes.Ldfld, smBuilder.FunctionDCField); // [sm, dc]
+            il.Emit(OpCodes.Ldfld, functionDCField); // [sm, dc]
             il.Emit(OpCodes.Ldarg, i + paramOffset);           // [sm, dc, arg]
+            // The DC field is object-typed; box a value-type parameter. Free-function stubs pass
+            // null here (their params are already object slots); instance-method stubs pass the
+            // resolved typed-parameter array so value types are boxed before the store (#724).
+            if (paramTypes != null && i < paramTypes.Length && paramTypes[i].IsValueType)
+                il.Emit(OpCodes.Box, paramTypes[i]);
             il.Emit(OpCodes.Stfld, dcField);        // [sm]
         }
     }
@@ -308,6 +361,10 @@ public partial class ILCompiler
             EntryPointDisplayClassFields = BuildEntryPointDisplayClassFieldsForModule(_modules.CurrentPath),
             CapturedTopLevelVars = BuildCapturedTopLevelVarsForModule(_modules.CurrentPath),
             EntryPointDisplayClassStaticField = _closures.EntryPointDisplayClassStaticField,
+            // Per-arrow $entryPointDC field map so a capturing arrow nested in the generator body
+            // gets the entry-point display class threaded in (#732). Without this the arrow's
+            // $entryPointDC stays null and reading a captured top-level var NREs.
+            ArrowEntryPointDCFields = _closures.ArrowEntryPointDCFields.Count > 0 ? _closures.ArrowEntryPointDCFields : null,
             TopLevelStaticVars = BuildTopLevelStaticVarsForModule(_modules.CurrentPath)
         };
 
@@ -347,8 +404,16 @@ public partial class ILCompiler
             runtime: _runtime
         );
 
+        // #724: wire the function display class registered for this method in DefineClass so an arrow
+        // that WRITES a captured method local shares storage with the generator (mirrors the free-
+        // function EmitGeneratorFunctionDCInit path). The field must be defined before the stub seeds
+        // captured params into it and before CreateType() finalizes the state machine.
+        string? methodDCKey = _generatorMethodFunctionDCKeys.GetValueOrDefault(method);
+        if (methodDCKey != null && _closures.FunctionDisplayClasses.TryGetValue(methodDCKey, out var methodFuncDC))
+            smBuilder.DefineFunctionDisplayClassField(methodFuncDC);
+
         // Emit stub method body (creates state machine and returns it)
-        EmitGeneratorInstanceStubMethod(methodBuilder, smBuilder, method.Parameters);
+        EmitGeneratorInstanceStubMethod(methodBuilder, smBuilder, method, methodDCKey);
 
         // Create context for MoveNext emission
         var il = smBuilder.MoveNextMethod.GetILGenerator();
@@ -397,8 +462,21 @@ public partial class ILCompiler
             EntryPointDisplayClassFields = BuildEntryPointDisplayClassFieldsForModule(_modules.CurrentPath),
             CapturedTopLevelVars = BuildCapturedTopLevelVarsForModule(_modules.CurrentPath),
             EntryPointDisplayClassStaticField = _closures.EntryPointDisplayClassStaticField,
+            // Per-arrow $entryPointDC field map so a capturing arrow nested in this instance
+            // generator method's body gets the entry-point display class threaded in (#732).
+            ArrowEntryPointDCFields = _closures.ArrowEntryPointDCFields.Count > 0 ? _closures.ArrowEntryPointDCFields : null,
             TopLevelStaticVars = BuildTopLevelStaticVarsForModule(_modules.CurrentPath)
         };
+
+        // #724: route reads/writes of captured-and-mutated method locals through the shared function
+        // display class so the arrow's write and the generator body observe the same storage. Only set
+        // when this method has a function DC; otherwise the by-value snapshot path is used unchanged.
+        if (methodDCKey != null && _closures.FunctionDisplayClassFields.TryGetValue(methodDCKey, out var methodDCFields))
+        {
+            ctx.FunctionDisplayClassFields = methodDCFields;
+            ctx.CapturedFunctionLocals = [.. methodDCFields.Keys];
+            ctx.ArrowFunctionDCFields = _closures.ArrowFunctionDCFields.Count > 0 ? _closures.ArrowFunctionDCFields : null;
+        }
 
         // Emit MoveNext body
         var moveNextEmitter = new GeneratorMoveNextEmitter(smBuilder, analysis, _types);
@@ -418,8 +496,10 @@ public partial class ILCompiler
     private void EmitGeneratorInstanceStubMethod(
         MethodBuilder methodBuilder,
         GeneratorStateMachineBuilder smBuilder,
-        List<Stmt.Parameter> parameters)
+        Stmt.Function method,
+        string? funcDCKey)
     {
+        var parameters = method.Parameters;
         var il = methodBuilder.GetILGenerator();
 
         // Create new instance of the state machine
@@ -460,6 +540,14 @@ public partial class ILCompiler
                 il.Emit(OpCodes.Stfld, field);
             }
         }
+
+        // #724: instantiate the function display class and seed any captured-and-mutated parameter
+        // into it so an arrow that writes that parameter shares the generator's storage. Instance
+        // methods carry 'this' at arg 0, so user params start at arg 1 (paramOffset: 1). The stub
+        // params are typed, so EmitGeneratorFunctionDCInit boxes value types before the store. No-op
+        // when the method has no function DC.
+        if (funcDCKey != null)
+            EmitGeneratorFunctionDCInit(il, smBuilder.FunctionDCField, method, funcDCKey, paramOffset: 1, paramTypes);
 
         // Captured outer-scope variables are NOT copied into the state machine (#541): see the
         // free-function stub above. MoveNext reads/writes them live from their backing storage,

--- a/SharpTS.Tests/Compilation/EmitterSyncTests.cs
+++ b/SharpTS.Tests/Compilation/EmitterSyncTests.cs
@@ -148,6 +148,12 @@ public class EmitterSyncTests
             "EmitAwait",            // Core: suspend/resume state machine
             "EmitArrowFunction",    // Display class in async generator context
             "EmitSuper",            // This field indirection
+            // --- #725: route a captured-and-mutated local through the function display class ---
+            "GetFunctionDCField",   // Exposes <>__functionDC so a capturing arrow threads it in
+            "EmitVariable",         // Read a captured-and-mutated local through the function DC
+            "EmitAssign",           // Write a captured-and-mutated local through the function DC
+            "EmitStoreVariable",    // Store side of compound/logical/increment through the function DC
+            "EmitVarDeclaration",   // Initialize a captured-and-mutated local into the function DC
             // --- #559: non-local exits must run an enclosing flag-based finally first (async #500) ---
             "EmitBreak",            // Route a break leaving a try through its finally(s)
             "EmitContinue",         // Route a continue leaving a try through its finally(s)

--- a/SharpTS.Tests/SharedTests/AsyncArrowNestedCaptureTests.cs
+++ b/SharpTS.Tests/SharedTests/AsyncArrowNestedCaptureTests.cs
@@ -168,8 +168,7 @@ public class AsyncArrowNestedCaptureTests
         // reads it directly) and then again by `h` nested inside g — so when building h's
         // capture array we must re-read `a` from g's capture field, not drop it to null.
         // (The "relay-only" shape where the intermediate arrow does NOT read the variable and
-        // captures it solely to forward to a deeper arrow is a separate capture-propagation
-        // gap, tracked in #716.)
+        // captures it solely to forward to a deeper arrow is exercised below — #716.)
         var source = """
             const f = async () => {
               const a = 7;
@@ -184,6 +183,93 @@ public class AsyncArrowNestedCaptureTests
             """;
 
         Assert.Equal("15\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void NestedAsyncArrow_RelayOnlyCaptureToDeeperArrow(ExecutionMode mode)
+    {
+        // #716: the intermediate arrow `g` does NOT itself read `a` — it captures it solely so the
+        // deeper nested `h` can. ClosureAnalyzer now propagates the capture up the standalone async
+        // arrow chain (onto async-arrow frames only), so g's state machine carries `a` and forwards
+        // it; previously g omitted `a`, h read it as null, and compiled mode printed 1 instead of 8.
+        var source = """
+            const f = async () => {
+              const a = 7;
+              const g = async () => {
+                const h = async () => a + 1;
+                return await h();
+              };
+              console.log(await g());
+            };
+            f();
+            """;
+
+        Assert.Equal("8\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void NestedAsyncArrow_RelayOnlyCaptureThroughTwoIntermediates(ExecutionMode mode)
+    {
+        // #716 across two relay-only intermediates: both `g` and `h` forward `a` to the deepest `k`.
+        var source = """
+            const f = async () => {
+              const a = 5;
+              const g = async () => {
+                const h = async () => {
+                  const k = async () => a * 2;
+                  return await k();
+                };
+                return await h();
+              };
+              console.log(await g());
+            };
+            f();
+            """;
+
+        Assert.Equal("10\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void NestedAsyncArrow_RelayOnlyMultipleCaptures(ExecutionMode mode)
+    {
+        // #716: more than one relay-only capture forwarded through the intermediate arrow.
+        var source = """
+            const f = async () => {
+              const a = 3; const b = 100;
+              const g = async () => {
+                const h = async () => a + b;
+                return await h();
+              };
+              console.log(await g());
+            };
+            f();
+            """;
+
+        Assert.Equal("103\n", TestHarness.Run(source, mode));
+    }
+
+    [Fact]
+    public void NestedAsyncArrow_RelayOnlyCaptureToDeeperArrow_PassesILVerification()
+    {
+        var source = """
+            const f = async () => {
+              const a = 7;
+              const g = async () => {
+                const h = async () => a + 1;
+                return await h();
+              };
+              console.log(await g());
+            };
+            f();
+            """;
+
+        var (errors, output) = TestHarness.CompileVerifyAndRun(source);
+
+        Assert.Empty(errors);
+        Assert.Equal("8\n", output);
     }
 
     [Fact]

--- a/SharpTS.Tests/SharedTests/GeneratorArrowBodyTests.cs
+++ b/SharpTS.Tests/SharedTests/GeneratorArrowBodyTests.cs
@@ -1,4 +1,3 @@
-using SharpTS.Diagnostics.Exceptions;
 using SharpTS.Tests.Infrastructure;
 using Xunit;
 
@@ -79,6 +78,71 @@ public class GeneratorArrowBodyTests
             """;
 
         Assert.Equal("101,102,103\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Generator_ArrowReadsCapturedTopLevelVar(ExecutionMode mode)
+    {
+        // #732: a TOP-LEVEL (module-level) variable captured by an arrow inside the generator body.
+        // The arrow reaches it through its $entryPointDC field, which the compiled generator MoveNext
+        // previously never populated → NullReferenceException when the arrow ran. Distinct from a
+        // captured generator LOCAL (snapshot path); top-level vars route through the entry-point DC.
+        var source = """
+            const base = 10;
+            function* g() {
+              yield [1, 2, 3].map(x => x + base).join(",");
+            }
+            console.log(g().next().value);
+            """;
+
+        Assert.Equal("11,12,13\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Generator_ArrowWritesCapturedTopLevelVar(ExecutionMode mode)
+    {
+        // #732 (write case): an arrow inside the generator body WRITES a captured top-level binding.
+        // Top-level captures route through $entryPointDC (not the arrow's snapshot field map), so the
+        // write reaches the module variable directly — no function display class involved.
+        var source = """
+            let outer = 0;
+            function* g() { [1, 2, 3].forEach(n => outer += n); yield outer; }
+            console.log(g().next().value);
+            console.log(outer);
+            """;
+
+        Assert.Equal("6\n6\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Generator_InstanceMethodArrowReadsCapturedTopLevelVar(ExecutionMode mode)
+    {
+        // #732 for an INSTANCE generator method — the separate EmitGeneratorMethodBody context also
+        // needed the per-arrow $entryPointDC field map wired in.
+        var source = """
+            const base = 10;
+            class C { *gen() { yield [1, 2, 3].map(x => x + base).join(","); } }
+            console.log(new C().gen().next().value);
+            """;
+
+        Assert.Equal("11,12,13\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Generator_InstanceMethodArrowWritesCapturedTopLevelVar(ExecutionMode mode)
+    {
+        // #732 instance-method write case.
+        var source = """
+            let outer = 0;
+            class C { *gen() { [1, 2, 3].forEach(n => outer += n); yield outer; } }
+            console.log(new C().gen().next().value);
+            """;
+
+        Assert.Equal("6\n", TestHarness.Run(source, mode));
     }
 
     [Theory]
@@ -242,13 +306,13 @@ public class GeneratorArrowBodyTests
         Assert.Equal("before:0|after:6\n", TestHarness.Run(source, mode));
     }
 
-    [Fact]
-    public void Generator_InstanceMethodWritesCapturedBinding_CompiledRejectsClearly()
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Generator_InstanceMethodWritesCapturedBinding(ExecutionMode mode)
     {
-        // An INSTANCE generator method's state machine is not yet wired with a function display
-        // class (#674 covers free `function*` declarations), so a write-to-captured-binding inside
-        // one must still FAIL FAST with a clear message rather than silently dropping the write.
-        // The interpreter handles it correctly.
+        // #724: an INSTANCE generator method whose arrow WRITES a captured method local. The method's
+        // state machine is now wired with a function display class (registered in DefineClass before
+        // PropagateFunctionDCRequirements), the instance-method analogue of #674's free-function path.
         var source = """
             class C {
               *gen() {
@@ -260,18 +324,81 @@ public class GeneratorArrowBodyTests
             console.log(new C().gen().next().value);
             """;
 
-        Assert.Equal("6\n", TestHarness.RunInterpreted(source));
-        var ex = Assert.Throws<CompileException>(() => TestHarness.RunCompiled(source));
-        Assert.Contains("captured from the generator scope", ex.Message);
+        Assert.Equal("6\n", TestHarness.Run(source, mode));
     }
 
-    [Fact]
-    public void AsyncGenerator_WritesCapturedBinding_CompiledRejectsClearly()
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Generator_InstanceMethodCallbackMutatesCapturedParameter(ExecutionMode mode)
     {
-        // The async-generator state machine has no function display class wired yet (#674 lifts the
-        // sync free-function generator case). Previously this SILENTLY dropped the write (compiled
-        // yielded 0 where the interpreter yields 6); it must now FAIL FAST with a clear message
-        // instead of miscompiling.
+        // #724: the mutated capture is a method PARAMETER (value-typed in the stub). The instance stub
+        // seeds it into the DC at arg offset 1 (this at 0), boxing the value type before the store.
+        var source = """
+            class C { *gen(acc: number) { [1, 2, 3].forEach(n => acc += n); yield acc; } }
+            console.log(new C().gen(100).next().value);
+            """;
+
+        Assert.Equal("106\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Generator_InstanceMethodMixesThisAndMutatedLocal(ExecutionMode mode)
+    {
+        // #724 + #435: the arrow reads `this` (via the state machine's ThisField) AND writes a captured
+        // local (via the function DC) in the same callback.
+        var source = """
+            class C {
+              base = 10;
+              *gen() { let s = 0; [1, 2, 3].forEach(n => s += n + this.base); yield s; }
+            }
+            console.log(new C().gen().next().value);
+            """;
+
+        Assert.Equal("36\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Generator_InstanceMethodCapturedWriteSurvivesAcrossYield(ExecutionMode mode)
+    {
+        // #724: the mutated capture is live across a yield — the DC lives on a state-machine field so
+        // it persists across the suspension.
+        var source = """
+            class C {
+              *gen() { let s = 0; yield "b:" + s; [1, 2, 3].forEach(n => s += n); yield "a:" + s; }
+            }
+            const it = new C().gen();
+            console.log(it.next().value + "|" + it.next().value);
+            """;
+
+        Assert.Equal("b:0|a:6\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Generator_TwoClassesSameMethodNameWriteCaptureIndependently(ExecutionMode mode)
+    {
+        // #724: two classes declaring a `*g()` with a write-capture must get DISTINCT function display
+        // classes — the registry key is qualified by class name, so they don't clobber each other.
+        var source = """
+            class A { *g() { let s = 0; [1, 2].forEach(n => s += n); yield s; } }
+            class B { *g() { let s = 100; [1, 2].forEach(n => s += n); yield s; } }
+            console.log(new A().g().next().value, new B().g().next().value);
+            """;
+
+        Assert.Equal("3 103\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AsyncGenerator_WritesCapturedBinding(ExecutionMode mode)
+    {
+        // #725: a sync arrow inside an ASYNC generator (`async function*`) body that WRITES a captured
+        // generator local. The async-generator state machine — a reference type — is now wired with a
+        // function display class (the async analogue of #674), so the write reaches shared storage and
+        // the generator yields 6. Previously the compiled path SILENTLY dropped the write (yielded 0),
+        // then (after #674) fail-fast; now it works.
         var source = """
             async function* g() {
               let sum = 0;
@@ -281,8 +408,78 @@ public class GeneratorArrowBodyTests
             (async () => { for await (const v of g()) console.log(v); })();
             """;
 
-        Assert.Equal("6\n", TestHarness.RunInterpreted(source));
-        var ex = Assert.Throws<CompileException>(() => TestHarness.RunCompiled(source));
-        Assert.Contains("captured from the generator scope", ex.Message);
+        Assert.Equal("6\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AsyncGenerator_CapturedWriteSurvivesAcrossAwait(ExecutionMode mode)
+    {
+        // #725: the mutated capture is live across an actual `await` suspension — the DC lives on the
+        // (reference-type) state machine, so it persists across the await like a hoisted local.
+        var source = """
+            async function* g() {
+              let sum = 0;
+              await Promise.resolve(1);
+              [1, 2, 3].forEach(n => sum += n);
+              yield sum;
+            }
+            (async () => { for await (const v of g()) console.log(v); })();
+            """;
+
+        Assert.Equal("6\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AsyncGenerator_MixedMutatedAndReadOnlyCaptures(ExecutionMode mode)
+    {
+        // #725: a read-only capture (`base`, by-value snapshot) and a mutated capture (`total`, function
+        // DC) coexist in the same callback — the snapshot/DC split mirrors the sync generator case.
+        var source = """
+            async function* g() {
+              const base = 10; let total = 0;
+              [1, 2, 3].forEach(n => total += n + base);
+              yield total;
+            }
+            (async () => { for await (const v of g()) console.log(v); })();
+            """;
+
+        Assert.Equal("36\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AsyncGenerator_InstanceMethodWritesCapturedBinding(ExecutionMode mode)
+    {
+        // #725: the async-generator INSTANCE method analogue — the function DC is registered in
+        // DefineClass (before Phase 5) and wired into the method's state machine at emit time.
+        var source = """
+            class C {
+              async *gen() {
+                let s = 0;
+                [1, 2, 3].forEach(n => s += n);
+                yield s;
+              }
+            }
+            (async () => { for await (const v of new C().gen()) console.log(v); })();
+            """;
+
+        Assert.Equal("6\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AsyncGenerator_ArrowReadsCapturedTopLevelVar(ExecutionMode mode)
+    {
+        // #725 also threads $entryPointDC into arrows nested in an async generator body (the async
+        // analogue of #732), so a captured TOP-LEVEL variable read works rather than NRE-ing.
+        var source = """
+            const base = 10;
+            async function* g() { yield [1, 2, 3].map(x => x + base).join(","); }
+            (async () => { for await (const v of g()) console.log(v); })();
+            """;
+
+        Assert.Equal("11,12,13\n", TestHarness.Run(source, mode));
     }
 }


### PR DESCRIPTION
Fixes #732, #724, #725, #716. Four compiled-mode closure bugs; the interpreter was already correct in every case. All build on the #674 function-display-class infrastructure.

## #732 — generator arrow capturing a TOP-LEVEL variable NRE'd
An arrow nested in a generator body reaches a captured module-level variable through its `$entryPointDC` display-class field, but the compiled generator `MoveNext` never populated it → `NullReferenceException` when the arrow ran (read **and** write captures).
- `ExpressionEmitterBase.EmitCapturingArrowViaHooks` (the generator MoveNext's only arrow path) now populates `$entryPointDC` from the static entry-point DC field, mirroring `AsyncMoveNextEmitter`.
- Both generator MoveNext contexts (`EmitGeneratorMoveNextBody`, `EmitGeneratorMethodBody`) now set `ArrowEntryPointDCFields`.

## #724 — instance generator method arrow that WRITES a captured local
Free `function*` got the #674 function-DC; instance `*m()` did not, so a write fail-fast'd. The function DC must be registered **before** Phase 5's `PropagateFunctionDCRequirements`, so registration happens in `DefineClass` (keyed `<Class>::<method>`, reusing the `::` convention from #682) and the state machine is wired at emit time (`EmitGeneratorMethodBody` + instance stub seeds captured params at `paramOffset: 1`, boxing value types).

## #725 — async generator (`async function*`) write-capture (full fix)
Previously silently miscompiled, then (after #674) fail-fast. Now fully wired, for both free functions and instance methods:
- `AsyncGeneratorStateMachineBuilder` gains `FunctionDCField` + `DefineFunctionDisplayClassField`.
- `DefineAsyncGeneratorFunction` registers the DC; the stub seeds captured params; the MoveNextAsync context routes reads/writes.
- New `AsyncGeneratorMoveNextEmitter.Variables.cs` mirrors the sync generator's DC routing; the async-gen arrow emitter now populates `$functionDC` and `$entryPointDC`.

The async-generator state machine is a reference type, so the DC survives across awaits and yields (verified with an `await` between the capture and the `yield`).

## #716 — standalone async arrow that relays a capture to a DEEPER nested arrow
A standalone async arrow copies captures **by value**, so an intermediate arrow that doesn't itself read a variable must still capture-and-forward it for a deeper arrow that does — otherwise the deeper arrow read it as null (printed `1` instead of `8`). `ClosureAnalyzer.ReferenceVariable` now propagates the capture up the async-arrow chain (onto async-arrow frames **only**, so the sync display-class machinery is untouched), mirroring how `VisitThis` propagates `this`.

## Notes
- `EmitGeneratorFunctionDCInit` was generalized to take the raw `<>__functionDC` `FieldBuilder` so the sync and async generator builders (no shared interface) reuse one helper.
- Programs with **no** write-capture emit no function DC and stay fully standalone (verified under `--standalone`).
- New emitter overrides registered in the `EmitterSyncTests` allowlist.

## Testing
- Full suite green: **13180 passed, 0 failed**.
- Added cross-mode (interp + compiled) regression tests for every case, plus `--verify` (ILVerify) coverage; the two prior fail-fast `[Fact]`s were converted to passing theories.
- Verified module (multi-file) mode and `--standalone` output.
- Filed #765 for a separate pre-existing gap encountered: generator methods in a class **expression** are unsupported in compiled mode (`Yield not supported in this context`), independent of these fixes.