### PR TITLE
Fix compiled generator void operator (#712) and nested-block let/const shadow leak (#711); verify #709

### DIFF
--- a/Compilation/ExpressionEmitterBase.cs
+++ b/Compilation/ExpressionEmitterBase.cs
@@ -2090,6 +2090,17 @@ public abstract partial class ExpressionEmitterBase : IEmitterContext
             case TokenType.TILDE:
                 _helpers.EmitUnaryBitwiseNot(() => EmitExpression(u.Right));
                 break;
+            case TokenType.VOID:
+                // void operator: evaluate the operand for its side effects, discard the
+                // result, and yield undefined. EmitExpression handles any nested
+                // yield/await suspension in the operand, so this works inside the
+                // generator/async state machines that inherit this base implementation.
+                EmitExpression(u.Right);
+                EnsureBoxed();
+                IL.Emit(OpCodes.Pop);
+                IL.Emit(OpCodes.Ldsfld, Ctx.Runtime!.UndefinedInstance);
+                SetStackUnknown();
+                break;
             default:
                 throw new NotImplementedException($"Unary operator {u.Operator.Type} not implemented");
         }

--- a/Compilation/GeneratorBlockScopeRenamer.cs
+++ b/Compilation/GeneratorBlockScopeRenamer.cs
@@ -1,0 +1,275 @@
+using SharpTS.Parsing;
+using SharpTS.Parsing.Visitors;
+
+namespace SharpTS.Compilation;
+
+/// <summary>
+/// Computes per-binding storage names for block-scoped (<c>let</c>/<c>const</c>) declarations inside a
+/// generator body that <em>shadow</em> an enclosing binding of the same name.
+/// </summary>
+/// <remarks>
+/// The generator state machine hoists every local that lives across a <c>yield</c> into a field keyed
+/// by its source name (see <see cref="HoistingManager"/>), and resolves non-hoisted locals through a
+/// flat, name-keyed local map. Both flatten lexical scope, so two block-scoped bindings that share a
+/// name collide on a single slot: an inner <c>{ const r = 0 }</c> clobbers an outer <c>const r</c>
+/// (#711). This pass walks the body with a scope stack and, for each inner <c>let</c>/<c>const</c> that
+/// shadows an enclosing binding, assigns a fresh source-illegal storage name. It records — by AST-node
+/// identity — the new name for the declaration and for every reference that lexically binds to it.
+/// <see cref="GeneratorStateAnalyzer"/> and <see cref="GeneratorMoveNextEmitter"/> consult the map so the
+/// hoist-vs-local decision and the field/local access become per-binding instead of per-name.
+///
+/// Restrictions that keep the rewrite sound:
+/// <list type="bullet">
+/// <item>Only <c>let</c>/<c>const</c> (<see cref="Stmt.Const"/>, <see cref="Stmt.Var"/> with
+/// <c>IsVar == false</c>) declarations are renamed. <c>for</c>/<c>for-of</c>/<c>for-in</c>/<c>catch</c>
+/// introduce scopes (so shadowing is detected accurately) but their loop-variable / catch-parameter
+/// bindings are left alone.</item>
+/// <item>A binding whose name is referenced by any nested closure (arrow/function/class) is left
+/// untouched: those names flow through the closure-capture machinery (keyed by name), which this pass
+/// does not rewrite, so renaming them would desync the capture (and the captured-name path shares the
+/// same field, so it is never a renamed binding).</item>
+/// </list>
+/// No AST node is mutated and none is created, so TypeMap / ClosureAnalyzer node identity is preserved.
+/// The walk is deterministic, so independent <see cref="GeneratorStateAnalyzer.Analyze"/> calls over the
+/// same function (field definition vs. body emission) produce identical maps.
+/// </remarks>
+internal sealed class GeneratorBlockScopeRenamer : AstVisitorBase
+{
+    // Keyed by AST-node reference (records use value equality, so reference identity is mandatory here).
+    private readonly Dictionary<object, string> _renames = new(ReferenceEqualityComparer.Instance);
+    // Scope stack of name -> storage-name (storage == name when the binding is not renamed).
+    private readonly List<Dictionary<string, string>> _scopes = [];
+    private readonly HashSet<string> _closureReferenced = [];
+    private int _counter;
+
+    /// <summary>
+    /// Returns the node→storage-name map for <paramref name="func"/>, empty when nothing shadows.
+    /// </summary>
+    public static IReadOnlyDictionary<object, string> Compute(Stmt.Function func)
+    {
+        var renamer = new GeneratorBlockScopeRenamer();
+        new ClosureReferenceCollector(renamer._closureReferenced).Run(func);
+
+        renamer.PushScope();
+        // The generator's own name is in scope inside the body (a named function expression can call
+        // itself by it); a nested-block let/const may shadow it, so seed it for shadow detection.
+        // Never renamed (it is not a hoisted local — it resolves to the function/method itself).
+        if (!string.IsNullOrEmpty(func.Name.Lexeme))
+            renamer.CurrentScope[func.Name.Lexeme] = func.Name.Lexeme;
+        // Parameters live in the function scope; an inner block let/const may shadow them. Never renamed.
+        foreach (var p in func.Parameters)
+            renamer.CurrentScope[p.Name.Lexeme] = p.Name.Lexeme;
+        if (func.Body != null)
+            foreach (var stmt in func.Body)
+                renamer.Visit(stmt);
+        renamer.PopScope();
+
+        return renamer._renames;
+    }
+
+    private Dictionary<string, string> CurrentScope => _scopes[^1];
+    private void PushScope() => _scopes.Add([]);
+    private void PopScope() => _scopes.RemoveAt(_scopes.Count - 1);
+
+    private bool ShadowsEnclosing(string name)
+    {
+        for (int i = _scopes.Count - 2; i >= 0; i--)
+            if (_scopes[i].ContainsKey(name)) return true;
+        return false;
+    }
+
+    private string? Resolve(string name)
+    {
+        for (int i = _scopes.Count - 1; i >= 0; i--)
+            if (_scopes[i].TryGetValue(name, out var storage)) return storage;
+        return null;
+    }
+
+    private void DeclareBlockScoped(object node, string name)
+    {
+        // Same-scope redeclaration is a TypeScript error; keep the first binding.
+        if (CurrentScope.ContainsKey(name)) return;
+
+        if (ShadowsEnclosing(name) && !_closureReferenced.Contains(name))
+        {
+            var storage = $"<{name}>__bs{_counter++}";
+            CurrentScope[name] = storage;
+            _renames[node] = storage;
+        }
+        else
+        {
+            CurrentScope[name] = name;
+        }
+    }
+
+    private void RecordRef(object node, string name)
+    {
+        var storage = Resolve(name);
+        if (storage != null && storage != name)
+            _renames[node] = storage;
+    }
+
+    #region Declarations
+
+    protected override void VisitConst(Stmt.Const stmt)
+    {
+        base.VisitConst(stmt);   // initializer is evaluated before the binding enters scope
+        DeclareBlockScoped(stmt, stmt.Name.Lexeme);
+    }
+
+    protected override void VisitVar(Stmt.Var stmt)
+    {
+        base.VisitVar(stmt);
+        if (stmt.IsVar)
+        {
+            // `var` is function-scoped: record it in the bottom scope so a later block-scoped
+            // let/const that shadows it is detected, but never rename it (one binding per name).
+            _scopes[0].TryAdd(stmt.Name.Lexeme, stmt.Name.Lexeme);
+        }
+        else
+        {
+            DeclareBlockScoped(stmt, stmt.Name.Lexeme);
+        }
+    }
+
+    #endregion
+
+    #region References
+
+    protected override void VisitVariable(Expr.Variable expr) => RecordRef(expr, expr.Name.Lexeme);
+
+    protected override void VisitAssign(Expr.Assign expr)
+    {
+        RecordRef(expr, expr.Name.Lexeme);
+        base.VisitAssign(expr);
+    }
+
+    protected override void VisitCompoundAssign(Expr.CompoundAssign expr)
+    {
+        RecordRef(expr, expr.Name.Lexeme);
+        base.VisitCompoundAssign(expr);
+    }
+
+    protected override void VisitLogicalAssign(Expr.LogicalAssign expr)
+    {
+        RecordRef(expr, expr.Name.Lexeme);
+        base.VisitLogicalAssign(expr);
+    }
+
+    // Increment/decrement record the operand Variable (via the default traversal → VisitVariable),
+    // matching how the emitter resolves it (it reads/writes through the operand variable node).
+
+    #endregion
+
+    #region Scope-introducing statements
+
+    protected override void VisitBlock(Stmt.Block stmt)
+    {
+        PushScope();
+        base.VisitBlock(stmt);
+        PopScope();
+    }
+
+    protected override void VisitFor(Stmt.For stmt)
+    {
+        // The for-statement owns a scope for any let/const declared in its initializer.
+        PushScope();
+        base.VisitFor(stmt);
+        PopScope();
+    }
+
+    protected override void VisitForOf(Stmt.ForOf stmt)
+    {
+        Visit(stmt.Iterable);   // iterable is evaluated in the enclosing scope
+        PushScope();
+        CurrentScope[stmt.Variable.Lexeme] = stmt.Variable.Lexeme;   // loop var: detected, not renamed
+        Visit(stmt.Body);
+        PopScope();
+    }
+
+    protected override void VisitForIn(Stmt.ForIn stmt)
+    {
+        Visit(stmt.Object);
+        PushScope();
+        CurrentScope[stmt.Variable.Lexeme] = stmt.Variable.Lexeme;
+        Visit(stmt.Body);
+        PopScope();
+    }
+
+    protected override void VisitSwitch(Stmt.Switch stmt)
+    {
+        Visit(stmt.Subject);
+        PushScope();   // all cases share one block scope (ECMA-262 14.12)
+        foreach (var c in stmt.Cases)
+        {
+            Visit(c.Value);
+            foreach (var s in c.Body) Visit(s);
+        }
+        if (stmt.DefaultBody != null)
+            foreach (var s in stmt.DefaultBody) Visit(s);
+        PopScope();
+    }
+
+    protected override void VisitTryCatch(Stmt.TryCatch stmt)
+    {
+        PushScope();
+        foreach (var s in stmt.TryBlock) Visit(s);
+        PopScope();
+
+        if (stmt.CatchBlock != null)
+        {
+            PushScope();
+            if (stmt.CatchParam != null)
+                CurrentScope[stmt.CatchParam.Lexeme] = stmt.CatchParam.Lexeme;   // catch param: detected, not renamed
+            foreach (var s in stmt.CatchBlock) Visit(s);
+            PopScope();
+        }
+
+        if (stmt.FinallyBlock != null)
+        {
+            PushScope();
+            foreach (var s in stmt.FinallyBlock) Visit(s);
+            PopScope();
+        }
+    }
+
+    #endregion
+
+    #region Opaque nodes (own scopes, not hoisted into this generator)
+
+    protected override void VisitArrowFunction(Expr.ArrowFunction expr) { }
+    protected override void VisitFunction(Stmt.Function stmt) { }
+    protected override void VisitClass(Stmt.Class stmt) { }
+    protected override void VisitClassExpr(Expr.ClassExpr expr) { }
+
+    #endregion
+
+    /// <summary>
+    /// Collects every variable name referenced anywhere inside a nested closure (arrow / function /
+    /// class) of the generator body. Names in this set are off-limits to renaming because the closure
+    /// capture machinery keys them by source name and this pass does not rewrite closure interiors.
+    /// </summary>
+    private sealed class ClosureReferenceCollector : AstVisitorBase
+    {
+        private readonly HashSet<string> _names;
+        private int _depth;
+
+        public ClosureReferenceCollector(HashSet<string> names) => _names = names;
+
+        public void Run(Stmt.Function func)
+        {
+            if (func.Body != null)
+                foreach (var s in func.Body) Visit(s);
+        }
+
+        protected override void VisitArrowFunction(Expr.ArrowFunction expr) { _depth++; base.VisitArrowFunction(expr); _depth--; }
+        protected override void VisitFunction(Stmt.Function stmt) { _depth++; base.VisitFunction(stmt); _depth--; }
+        protected override void VisitClass(Stmt.Class stmt) { _depth++; base.VisitClass(stmt); _depth--; }
+        protected override void VisitClassExpr(Expr.ClassExpr expr) { _depth++; base.VisitClassExpr(expr); _depth--; }
+
+        protected override void VisitVariable(Expr.Variable expr) { if (_depth > 0) _names.Add(expr.Name.Lexeme); }
+        protected override void VisitAssign(Expr.Assign expr) { if (_depth > 0) _names.Add(expr.Name.Lexeme); base.VisitAssign(expr); }
+        protected override void VisitCompoundAssign(Expr.CompoundAssign expr) { if (_depth > 0) _names.Add(expr.Name.Lexeme); base.VisitCompoundAssign(expr); }
+        protected override void VisitLogicalAssign(Expr.LogicalAssign expr) { if (_depth > 0) _names.Add(expr.Name.Lexeme); base.VisitLogicalAssign(expr); }
+    }
+}

--- a/Compilation/GeneratorMoveNextEmitter.Variables.cs
+++ b/Compilation/GeneratorMoveNextEmitter.Variables.cs
@@ -5,6 +5,12 @@ namespace SharpTS.Compilation;
 
 public partial class GeneratorMoveNextEmitter
 {
+    // Per-binding storage names for block-scoped let/const shadows (#711), shared with the analyzer
+    // via the analysis. Empty for the common no-shadow case.
+    private IReadOnlyDictionary<object, string> BlockScopeRenames => _analysis.BlockScopeRenames;
+
+    private static Token RenameToken(Token original, string lexeme) =>
+        new(original.Type, lexeme, original.Literal, original.Line, original.Start);
     // Expose the state machine's function display class field to the base arrow emitter so a
     // capturing arrow inside the generator body gets its $functionDC threaded in (#674).
     protected override FieldBuilder? GetFunctionDCField() => _builder.FunctionDCField;
@@ -42,6 +48,11 @@ public partial class GeneratorMoveNextEmitter
 
     protected override void EmitVariable(Expr.Variable v)
     {
+        // Resolve a shadowing block-scoped binding to its own storage before any DC routing (#711);
+        // a renamed binding is never a captured/DC name, so the DC check below correctly falls through.
+        if (BlockScopeRenames.TryGetValue(v, out var renamed))
+            v = v with { Name = RenameToken(v.Name, renamed) };
+
         if (TryGetFunctionDCField(v.Name.Lexeme, out var dcField))
         {
             _il.Emit(OpCodes.Ldarg_0);
@@ -56,6 +67,9 @@ public partial class GeneratorMoveNextEmitter
 
     protected override void EmitVarDeclaration(Stmt.Var v)
     {
+        if (BlockScopeRenames.TryGetValue(v, out var renamed))
+            v = v with { Name = RenameToken(v.Name, renamed) };
+
         if (TryGetFunctionDCField(v.Name.Lexeme, out var dcField))
         {
             if (v.Initializer != null)
@@ -76,6 +90,9 @@ public partial class GeneratorMoveNextEmitter
 
     protected override void EmitAssign(Expr.Assign a)
     {
+        if (BlockScopeRenames.TryGetValue(a, out var renamed))
+            a = a with { Name = RenameToken(a.Name, renamed) };
+
         if (TryGetFunctionDCField(a.Name.Lexeme, out var dcField))
         {
             EmitExpression(a.Value);
@@ -87,6 +104,47 @@ public partial class GeneratorMoveNextEmitter
         }
 
         base.EmitAssign(a);
+    }
+
+    // Const declarations, compound/logical assignment, and increment/decrement reach the variable
+    // through the operator node's name token (or the increment operand). Rewriting that token to the
+    // shadowing binding's storage name before delegating to the base routes both the read and the
+    // write to the right field/local (#711). A renamed binding is never a DC/captured name, so the
+    // base path (which re-enters EmitVariable / EmitStoreVariable) resolves it as a plain slot.
+
+    protected override void EmitConstDeclaration(Stmt.Const c)
+    {
+        if (BlockScopeRenames.TryGetValue(c, out var renamed))
+            c = c with { Name = RenameToken(c.Name, renamed) };
+        base.EmitConstDeclaration(c);
+    }
+
+    protected override void EmitCompoundAssign(Expr.CompoundAssign ca)
+    {
+        if (BlockScopeRenames.TryGetValue(ca, out var renamed))
+            ca = ca with { Name = RenameToken(ca.Name, renamed) };
+        base.EmitCompoundAssign(ca);
+    }
+
+    protected override void EmitLogicalAssign(Expr.LogicalAssign la)
+    {
+        if (BlockScopeRenames.TryGetValue(la, out var renamed))
+            la = la with { Name = RenameToken(la.Name, renamed) };
+        base.EmitLogicalAssign(la);
+    }
+
+    protected override void EmitPrefixIncrement(Expr.PrefixIncrement pi)
+    {
+        if (pi.Operand is Expr.Variable v && BlockScopeRenames.TryGetValue(v, out var renamed))
+            pi = pi with { Operand = v with { Name = RenameToken(v.Name, renamed) } };
+        base.EmitPrefixIncrement(pi);
+    }
+
+    protected override void EmitPostfixIncrement(Expr.PostfixIncrement poi)
+    {
+        if (poi.Operand is Expr.Variable v && BlockScopeRenames.TryGetValue(v, out var renamed))
+            poi = poi with { Operand = v with { Name = RenameToken(v.Name, renamed) } };
+        base.EmitPostfixIncrement(poi);
     }
 
     /// <summary>

--- a/Compilation/GeneratorStateAnalyzer.cs
+++ b/Compilation/GeneratorStateAnalyzer.cs
@@ -29,7 +29,11 @@ public class GeneratorStateAnalyzer : AstVisitorBase
         bool UsesThis,
         bool HasYieldStar,
         List<Stmt.ForOf> ForOfLoopsWithYield,  // for...of loops containing yields that need enumerator hoisting
-        List<Stmt.ForIn> ForInLoopsWithYield   // for...in loops containing yields that need key-list/index hoisting (#547)
+        List<Stmt.ForIn> ForInLoopsWithYield,  // for...in loops containing yields that need key-list/index hoisting (#547)
+        // Per-binding storage names for block-scoped let/const declarations that shadow an enclosing
+        // binding, keyed by declaration/reference AST node (see GeneratorBlockScopeRenamer, #711). The
+        // emitter consults the same map so each shadowing binding gets its own field/local.
+        IReadOnlyDictionary<object, string> BlockScopeRenames
     );
 
     // State during analysis
@@ -49,6 +53,9 @@ public class GeneratorStateAnalyzer : AstVisitorBase
     private bool _seenYield = false;
     private bool _usesThis = false;
     private bool _hasYieldStar = false;
+    // Block-scope shadow renames for this function (#711). Maps a declaration/reference AST node to
+    // the disambiguated storage name its binding uses; nodes absent from the map keep their lexeme.
+    private IReadOnlyDictionary<object, string> _renames = new Dictionary<object, string>();
 
     /// <summary>
     /// Analyzes a generator function to determine yield points and hoisted variables.
@@ -56,6 +63,10 @@ public class GeneratorStateAnalyzer : AstVisitorBase
     public GeneratorFunctionAnalysis Analyze(Stmt.Function func)
     {
         Reset();
+
+        // Disambiguate block-scoped let/const declarations that shadow an enclosing binding so the
+        // hoisting decision below is made per-binding rather than per-name (#711).
+        _renames = GeneratorBlockScopeRenamer.Compute(func);
 
         // Collect parameters as variables that need hoisting
         HashSet<string> parameters = [];
@@ -94,9 +105,17 @@ public class GeneratorStateAnalyzer : AstVisitorBase
             UsesThis: _usesThis,
             HasYieldStar: _hasYieldStar,
             ForOfLoopsWithYield: [.. _forOfLoopsWithYield],
-            ForInLoopsWithYield: [.. _forInLoopsWithYield]
+            ForInLoopsWithYield: [.. _forInLoopsWithYield],
+            BlockScopeRenames: _renames
         );
     }
+
+    /// <summary>
+    /// Translates a declaration/reference node's source lexeme to its disambiguated storage name
+    /// (#711), or returns the lexeme unchanged when the binding is not a renamed shadow.
+    /// </summary>
+    private string StorageName(object node, string lexeme) =>
+        _renames.TryGetValue(node, out var renamed) ? renamed : lexeme;
 
     private void Reset()
     {
@@ -145,17 +164,19 @@ public class GeneratorStateAnalyzer : AstVisitorBase
 
     protected override void VisitVar(Stmt.Var stmt)
     {
-        _declaredVariables.Add(stmt.Name.Lexeme);
+        var name = StorageName(stmt, stmt.Name.Lexeme);
+        _declaredVariables.Add(name);
         if (!_seenYield)
-            _variablesDeclaredBeforeYield.Add(stmt.Name.Lexeme);
+            _variablesDeclaredBeforeYield.Add(name);
         base.VisitVar(stmt);
     }
 
     protected override void VisitConst(Stmt.Const stmt)
     {
-        _declaredVariables.Add(stmt.Name.Lexeme);
+        var name = StorageName(stmt, stmt.Name.Lexeme);
+        _declaredVariables.Add(name);
         if (!_seenYield)
-            _variablesDeclaredBeforeYield.Add(stmt.Name.Lexeme);
+            _variablesDeclaredBeforeYield.Add(name);
         base.VisitConst(stmt);
     }
 
@@ -277,7 +298,7 @@ public class GeneratorStateAnalyzer : AstVisitorBase
 
     protected override void VisitVariable(Expr.Variable expr)
     {
-        var name = expr.Name.Lexeme;
+        var name = StorageName(expr, expr.Name.Lexeme);
 
         // Track variables used in any enclosing loop body (hoisted when the loop contains a yield).
         foreach (var scope in _loopStack)
@@ -290,22 +311,25 @@ public class GeneratorStateAnalyzer : AstVisitorBase
 
     protected override void VisitAssign(Expr.Assign expr)
     {
-        if (_seenYield && _declaredVariables.Contains(expr.Name.Lexeme))
-            _variablesUsedAfterYield.Add(expr.Name.Lexeme);
+        var name = StorageName(expr, expr.Name.Lexeme);
+        if (_seenYield && _declaredVariables.Contains(name))
+            _variablesUsedAfterYield.Add(name);
         base.VisitAssign(expr);
     }
 
     protected override void VisitCompoundAssign(Expr.CompoundAssign expr)
     {
-        if (_seenYield && _declaredVariables.Contains(expr.Name.Lexeme))
-            _variablesUsedAfterYield.Add(expr.Name.Lexeme);
+        var name = StorageName(expr, expr.Name.Lexeme);
+        if (_seenYield && _declaredVariables.Contains(name))
+            _variablesUsedAfterYield.Add(name);
         base.VisitCompoundAssign(expr);
     }
 
     protected override void VisitLogicalAssign(Expr.LogicalAssign expr)
     {
-        if (_seenYield && _declaredVariables.Contains(expr.Name.Lexeme))
-            _variablesUsedAfterYield.Add(expr.Name.Lexeme);
+        var name = StorageName(expr, expr.Name.Lexeme);
+        if (_seenYield && _declaredVariables.Contains(name))
+            _variablesUsedAfterYield.Add(name);
         base.VisitLogicalAssign(expr);
     }
 

--- a/SharpTS.Tests/Compilation/EmitterSyncTests.cs
+++ b/SharpTS.Tests/Compilation/EmitterSyncTests.cs
@@ -114,10 +114,18 @@ public class EmitterSyncTests
             // instance generator methods) so it fails fast instead of dropping the write.
             "EmitArrowFunction",
             // --- #674: closure mutation sharing (route captured-and-mutated locals through the DC) ---
-            "EmitVariable",         // Read a captured-and-mutated local through the function DC
-            "EmitAssign",           // Write a captured-and-mutated local through the function DC
+            "EmitVariable",         // Read a captured-and-mutated local through the function DC (+ #711 rename)
+            "EmitAssign",           // Write a captured-and-mutated local through the function DC (+ #711 rename)
             "EmitStoreVariable",    // Store side of compound/logical/increment through the function DC
-            "EmitVarDeclaration",   // Initialize a captured-and-mutated local into the function DC
+            "EmitVarDeclaration",   // Initialize a captured-and-mutated local into the function DC (+ #711 rename)
+            // --- #711: a nested-block let/const that shadows an enclosing binding is given its own
+            // storage name; these overrides retoken the operator node so the read/write land on the
+            // shadow's own field/local instead of the outer binding's hoisted field ---
+            "EmitConstDeclaration", // #711: route a shadowing const declaration to its own slot
+            "EmitCompoundAssign",   // #711: route a shadowing compound assignment to its own slot
+            "EmitLogicalAssign",    // #711: route a shadowing logical assignment to its own slot
+            "EmitPrefixIncrement",  // #711: route a shadowing prefix ++/-- to its own slot
+            "EmitPostfixIncrement", // #711: route a shadowing postfix ++/-- to its own slot
             // --- #500: non-local exits must run an enclosing flag-based finally first ---
             "EmitBreak",            // Route a break leaving a try through its finally(s)
             "EmitContinue",         // Route a continue leaving a try through its finally(s)

--- a/SharpTS.Tests/SharedTests/GeneratorTests.cs
+++ b/SharpTS.Tests/SharedTests/GeneratorTests.cs
@@ -1851,12 +1851,12 @@ public class GeneratorTests
     }
 
     [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void GeneratorExpression_NamedSelfReference_NestedBlockDoesNotShadow(ExecutionMode mode)
     {
         // A nested-block binding of the same name shadows only within that block, so the outer
-        // self-call still resolves to the function. Interpreted-only: compiled generators do not yet
-        // give a nested-block redeclaration its own slot, so the inner `rec` leaks (tracked by #711).
+        // self-call still resolves to the function. Compiled generators now give the nested-block
+        // redeclaration its own slot instead of leaking it onto the hoisted field (#711).
         var source = """
             const d = function* rec(n: number): Generator<number> {
               { const rec = 0; if (n < -100) yield rec; }
@@ -1866,6 +1866,189 @@ public class GeneratorTests
             """;
 
         Assert.Equal("[2, 1]\n", TestHarness.Run(source, mode));
+    }
+
+    #endregion
+
+    #region Block-scope shadowing in compiled generators (#711) and void operator (#712)
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Generator_NestedBlockConstShadow_DoesNotLeakToOuter(ExecutionMode mode)
+    {
+        // A const in a nested block that shadows an outer body-level const must get its own slot
+        // instead of clobbering the outer binding's hoisted state-machine field (#711).
+        var source = """
+            function* g(): Generator<number> {
+              const r = 100;
+              { const r = 0; if (false) yield r; }
+              yield r;
+            }
+            console.log([...g()]);
+            """;
+
+        Assert.Equal("[100]\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Generator_NestedBlockShadow_LiveAcrossYield_GetsOwnField(ExecutionMode mode)
+    {
+        // The inner shadow is itself read after a yield, so it must hoist to its OWN field, distinct
+        // from the outer binding's field — both must survive the suspension independently (#711).
+        var source = """
+            function* g(): Generator<number> {
+              const r = 100;
+              {
+                const r = 0;
+                yield r;
+                yield r + 1;
+              }
+              yield r;
+            }
+            console.log([...g()]);
+            """;
+
+        Assert.Equal("[0, 1, 100]\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Generator_NestedBlockLetShadow_ReassignedAcrossYield(ExecutionMode mode)
+    {
+        // A let shadow that is compound-assigned across yields keeps its own value, separate from
+        // the outer binding (#711).
+        var source = """
+            function* g(): Generator<number> {
+              let r = 7;
+              {
+                let r = 1;
+                r += 1;
+                yield r;
+                r += 10;
+                yield r;
+              }
+              yield r;
+            }
+            console.log([...g()]);
+            """;
+
+        Assert.Equal("[2, 12, 7]\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Generator_NestedBlockShadowsParameter(ExecutionMode mode)
+    {
+        // An inner block const may shadow a (hoisted) parameter without clobbering it (#711).
+        var source = """
+            function* g(r: number): Generator<number> {
+              { const r = 99; yield r; }
+              yield r;
+            }
+            console.log([...g(5)]);
+            """;
+
+        Assert.Equal("[99, 5]\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Generator_DeeplyNestedShadows_EachGetOwnSlot(ExecutionMode mode)
+    {
+        // Each nesting level that re-declares the name resolves to its own binding (#711).
+        var source = """
+            function* g(): Generator<number> {
+              const r = 1;
+              { const r = 2; { const r = 3; yield r; } yield r; }
+              yield r;
+            }
+            console.log([...g()]);
+            """;
+
+        Assert.Equal("[3, 2, 1]\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Generator_VoidOperator_InBody(ExecutionMode mode)
+    {
+        // `void expr` inside a compiled generator body must evaluate the operand for its side effects
+        // and yield undefined, rather than failing to compile (#712).
+        var source = """
+            function* g(): Generator<number> {
+              const r = 5;
+              void r;
+              yield r;
+            }
+            console.log([...g()]);
+            """;
+
+        Assert.Equal("[5]\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Generator_VoidOperator_WithYieldOperand_Suspends(ExecutionMode mode)
+    {
+        // `void (yield x)` must still suspend at the inner yield (the operand can suspend), then
+        // discard its result (#712).
+        var source = """
+            function* g(): Generator<number> {
+              void (yield 1);
+              yield 2;
+            }
+            console.log([...g()]);
+            """;
+
+        Assert.Equal("[1, 2]\n", TestHarness.Run(source, mode));
+    }
+
+    #endregion
+
+    #region Optional-chain string-method yield short-circuit parity (#709)
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Generator_OptionalChainStringMethod_OnNonString_ShortCircuitsBeforeYield(ExecutionMode mode)
+    {
+        // o?.substring(...) on a non-string object lacking the method short-circuits to undefined
+        // WITHOUT evaluating the yield argument, so the generator completes on the first next() in
+        // both modes (#709 — the generator manifestation of the #627 await parity).
+        var source = """
+            function* gen() {
+              const o: any = { foo: 1 };
+              const r = o?.substring((yield 1) as any, 4);
+              return r;
+            }
+            const g = gen();
+            const a = g.next();
+            const b = g.next(99);
+            console.log(a.value, a.done, b.value, b.done);
+            """;
+
+        Assert.Equal("undefined true undefined true\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Generator_OptionalChainStringMethod_OnString_RunsYield(ExecutionMode mode)
+    {
+        // On a genuine string receiver the method exists, so the yield argument DOES run and the
+        // generator suspends — the short-circuit must not over-trigger (#709).
+        var source = """
+            function* gen() {
+              const s: any = "hello";
+              const r = s?.substring((yield 1) as any, 4);
+              return r;
+            }
+            const g = gen();
+            const a = g.next();
+            const b = g.next(0);
+            console.log(a.value, a.done, b.value, b.done);
+            """;
+
+        Assert.Equal("1 false hell true\n", TestHarness.Run(source, mode));
     }
 
     #endregion


### PR DESCRIPTION
Fixes #712, fixes #711, closes #709.

## #712 — `void` operator in compiled state machines

The base `ExpressionEmitterBase.EmitUnary` (inherited by the generator, async, async-arrow, and async-generator MoveNext emitters) had no `VOID` case, so `void expr` inside any state-machine body threw `Unary operator VOID not implemented` at compile time — only the non-state-machine `ILEmitter` override handled it. One case added to the base evaluates the operand (so a nested `yield`/`await` still suspends) and yields `undefined`, fixing all four state machines.

```ts
function* g(): Generator<number> { const r = 5; void r; yield r; }
console.log([...g()]);   // was: compile error; now: [5]
```

## #711 — nested-block `let`/`const` shadow leak in compiled generators

A generator hoists every local that lives across a `yield` into a state-machine field keyed by **source name**, and resolves non-hoisted locals through a flat name-keyed map. Both flatten lexical scope, so an inner `{ const r = 0 }` that shadows an outer `const r` collided on a single slot and clobbered the outer binding (the interpreter scopes them correctly).

```ts
function* g(): Generator<number> {
  const r = 100;
  { const r = 0; if (false) yield r; }
  yield r;
}
console.log([...g()]);   // interp: [100]; compiled was: [0]; now: [100]
```

**Approach** — new `GeneratorBlockScopeRenamer` walks the body with a scope stack and assigns each shadowing `let`/`const` a fresh, source-illegal storage name (`<name>__bsN`), recorded by **AST-node reference identity**. `GeneratorStateAnalyzer` and `GeneratorMoveNextEmitter` consult the same map, so the hoist-vs-local decision and field/local access become per-binding instead of per-name — which also handles an inner shadow that is itself live across a yield (it hoists to its own field). No AST node is mutated or created, so `TypeMap`/`ClosureAnalyzer` node identity is preserved, and the deterministic walk makes the field-definition and body-emission analysis passes agree. Because the names become distinct, the existing field-first resolver needs no change.

A binding whose name is captured by a nested closure is deliberately left untouched (the capture machinery keys by source name) — see #767. `for`/`for-of`/`for-in`/`catch` introduce scopes for accurate shadow detection but their loop-var/catch-param bindings are not themselves renamed.

## #709 — optional-chain string-method `yield` short-circuit (already fixed)

Verified already resolved on `main` by ba9617b2 (#676/#701, which added the optional-chain short-circuit to the base `EmitGet` that the state-machine emitters use). `o?.substring((yield 1), 4)` on a non-string receiver now short-circuits before the yield in both modes, while a genuine string receiver still runs the yield. Locked in with regression tests.

## Tests

New shared (interpreted + compiled) regression tests in `GeneratorTests.cs` for all three issues, plus the existing named-self-reference nested-block test flipped from interpreted-only to both modes. Full unit suite green (13206); the `EmitterSyncTests` override allowlist was updated for the new per-binding generator overrides.

## Follow-ups filed

- #766 — compiled async functions & async generators have the same shadow leak (the renamer is reusable).
- #767 — generator shadow of a closure-captured name still leaks (out of scope here).
- #768 — interpreter async-generator: a nested-block `const` yielded before any `await` reads as `undefined`.