### PR TITLE
Symbol/iterable method follow-ups: #757, #756, #761, #755 (sub-case 1)

### DIFF
--- a/Compilation/ILCompiler.AsyncGenerators.cs
+++ b/Compilation/ILCompiler.AsyncGenerators.cs
@@ -175,32 +175,37 @@ public partial class ILCompiler
     }
 
     /// <summary>
-    /// Emits the body of an instance async generator method using a state machine.
-    /// Called for class methods marked with both IsAsync and IsGenerator = true.
+    /// Emits the body of an async generator method using a state machine. Called for class methods
+    /// marked with both IsAsync and IsGenerator = true. A static async generator method (#761) has no
+    /// <c>this</c>/instance fields, so it is set up like a free function (isInstanceMethod: false,
+    /// static stub) — the async-generator analog of the static sync generator (#692).
     /// </summary>
-    private void EmitAsyncGeneratorMethodBody(MethodBuilder methodBuilder, Stmt.Function method, FieldInfo fieldsField)
+    private void EmitAsyncGeneratorMethodBody(MethodBuilder methodBuilder, Stmt.Function method, FieldInfo? fieldsField, bool isInstanceMethod = true)
     {
         // Analyze async generator function to determine yield/await points and hoisted variables
         var analysis = _asyncGenerators.Analyzer.Analyze(method);
 
-        // Build state machine type for instance method
+        // Build state machine type
         var smBuilder = new AsyncGeneratorStateMachineBuilder(_moduleBuilder, _types, _asyncGenerators.StateMachineCounter++);
         smBuilder.DefineStateMachine(
             $"{methodBuilder.DeclaringType!.Name}_{method.Name.Lexeme}",
             analysis,
-            isInstanceMethod: true,  // This is an instance method
+            isInstanceMethod: isInstanceMethod,
             runtime: _runtime
         );
 
         // Emit stub method body (creates state machine and returns it)
-        EmitAsyncGeneratorInstanceStubMethod(methodBuilder, smBuilder, method.Parameters);
+        if (isInstanceMethod)
+            EmitAsyncGeneratorInstanceStubMethod(methodBuilder, smBuilder, method.Parameters);
+        else
+            EmitAsyncGeneratorStaticStubMethod(methodBuilder, smBuilder, method.Parameters);
 
         // Create context for MoveNextAsync emission
         var il = smBuilder.MoveNextAsyncMethod.GetILGenerator();
         var ctx = new CompilationContext(il, _typeMapper, _functions.Builders, _classes.Builders, _namespaceFields, _namespaceVarFields, _types)
         {
             FieldsField = fieldsField,
-            IsInstanceMethod = true,
+            IsInstanceMethod = isInstanceMethod,
             ClosureAnalyzer = _closures.Analyzer,
             ArrowMethods = _closures.ArrowMethods,
             ConstArrowBindings = _closures.ConstArrowBindings,
@@ -291,6 +296,52 @@ public partial class ILCompiler
             {
                 il.Emit(OpCodes.Dup);  // Keep state machine reference on stack
                 il.Emit(OpCodes.Ldarg, i + 1);  // +1 because 'this' is at index 0
+
+                // Box value types since state machine fields are object-typed
+                if (i < paramTypes.Length && paramTypes[i].IsValueType)
+                {
+                    il.Emit(OpCodes.Box, paramTypes[i]);
+                }
+
+                il.Emit(OpCodes.Stfld, field);
+            }
+        }
+
+        // Return the state machine (which implements IAsyncEnumerable<object>)
+        il.Emit(OpCodes.Ret);
+    }
+
+    /// <summary>
+    /// Emits the stub that creates the async generator state machine for a STATIC method (#761): like
+    /// the instance stub but with no <c>this</c> and parameters starting at arg 0 (no receiver slot).
+    /// Value-type parameters are boxed into the object-typed state-machine fields. Mirrors the static
+    /// sync generator stub <see cref="EmitGeneratorStaticStubMethod"/>.
+    /// </summary>
+    private void EmitAsyncGeneratorStaticStubMethod(
+        MethodBuilder methodBuilder,
+        AsyncGeneratorStateMachineBuilder smBuilder,
+        List<Stmt.Parameter> parameters)
+    {
+        var il = methodBuilder.GetILGenerator();
+
+        // Create new instance of the state machine
+        il.Emit(OpCodes.Newobj, smBuilder.Constructor);
+
+        // Get the typed parameter types for the method (to box value types into object-typed fields).
+        string? className = methodBuilder.DeclaringType?.Name;
+        string methodName = methodBuilder.Name;
+        Type[] paramTypes = className != null
+            ? ParameterTypeResolver.ResolveMethodParameters(className, methodName, parameters, _typeMapper, _typeMap)
+            : parameters.Select(_ => typeof(object)).ToArray();
+
+        // Copy parameters to state machine fields (static methods start params at index 0).
+        for (int i = 0; i < parameters.Count; i++)
+        {
+            var field = smBuilder.GetVariableField(parameters[i].Name.Lexeme);
+            if (field != null)
+            {
+                il.Emit(OpCodes.Dup);  // Keep state machine reference on stack
+                il.Emit(OpCodes.Ldarg, i);  // No receiver slot — params start at arg 0
 
                 // Box value types since state machine fields are object-typed
                 if (i < paramTypes.Length && paramTypes[i].IsValueType)

--- a/Compilation/ILCompiler.Classes.Static.cs
+++ b/Compilation/ILCompiler.Classes.Static.cs
@@ -343,12 +343,21 @@ public partial class ILCompiler
 
         // Static generator methods (#692) use the generator state machine, set up like a free
         // function (no `this`). Checked before the plain-async branch so `static async *m()` isn't
-        // mis-emitted as a non-generator async method (its full support is tracked separately).
+        // mis-emitted as a non-generator async method.
         if (method.IsGenerator && !method.IsAsync)
         {
             var genTypeBuilder = _classes.Builders[className];
             var genMethodBuilder = _classes.StaticMethods[className][method.Name.Lexeme];
             EmitGeneratorMethodBody(genMethodBuilder, method, fieldsField: null, isInstanceMethod: false);
+            return;
+        }
+
+        // Static async generator methods (#761): the async-generator state machine, set up like a free
+        // function (no `this`). Must precede the plain-async branch since async generators set IsAsync too.
+        if (method.IsGenerator && method.IsAsync)
+        {
+            var agMethodBuilder = _classes.StaticMethods[className][method.Name.Lexeme];
+            EmitAsyncGeneratorMethodBody(agMethodBuilder, method, fieldsField: null, isInstanceMethod: false);
             return;
         }
 

--- a/Compilation/RuntimeEmitter.Objects.Index.cs
+++ b/Compilation/RuntimeEmitter.Objects.Index.cs
@@ -199,9 +199,12 @@ public partial class RuntimeEmitter
             il.MarkLabel(noSymGetterLabel);
         }
 
-        // #647: computed symbol-keyed method (`[Symbol.iterator]() {...}`). Reading the member
-        // returns the callable itself — the found MethodInfo, invoked later via InvokeMethodValue's
-        // MethodBase arm — unlike a getter (above), which is invoked here.
+        // #647/#755: computed symbol-keyed method (`[Symbol.iterator]() {...}`). Reading the member
+        // returns the callable itself, bound to the receiver as `new $TSFunction(obj, method)` — so a
+        // standalone `obj[Symbol.iterator]()` keeps `this` (#755). This mirrors how a string-keyed
+        // method read returns a receiver-bound callable; InvokeMethodValue's $TSFunction arm invokes it
+        // with the bound `this`. (for...of / spread / for await use GetIteratorFunction and pass the
+        // receiver themselves, so they are unaffected by this binding.)
         {
             var noSymMethodLabel = il.DefineLabel();
             var symMethodLocal = il.DeclareLocal(_types.Object);
@@ -211,7 +214,10 @@ public partial class RuntimeEmitter
             il.Emit(OpCodes.Stloc, symMethodLocal);
             il.Emit(OpCodes.Ldloc, symMethodLocal);
             il.Emit(OpCodes.Brfalse, noSymMethodLabel);
+            il.Emit(OpCodes.Ldarg_0);                       // receiver → $TSFunction target
             il.Emit(OpCodes.Ldloc, symMethodLocal);
+            il.Emit(OpCodes.Castclass, _types.MethodInfo);  // the registry stores a MethodInfo
+            il.Emit(OpCodes.Newobj, runtime.TSFunctionCtor);
             il.Emit(OpCodes.Ret);
             il.MarkLabel(noSymMethodLabel);
         }

--- a/Parsing/Parser.Expressions.cs
+++ b/Parsing/Parser.Expressions.cs
@@ -804,6 +804,46 @@ public partial class Parser
                         continue;
                     }
 
+                    // Method modifiers: generator `*` and/or `async` preceding the key, e.g.
+                    //   { *gen() {} }  { *[Symbol.iterator]() {} }  { async foo() {} }  { async *g() {} }
+                    // `async` is only a modifier when a property-name start or `*` follows it;
+                    // otherwise it is a property literally named `async` ({ async }, { async: v }, { async() {} }).
+                    bool isMethodAsync = false;
+                    if (Check(TokenType.ASYNC) && (IsPropertyNameStart(PeekNext().Type) || PeekNext().Type == TokenType.STAR))
+                    {
+                        Advance(); // consume 'async'
+                        isMethodAsync = true;
+                    }
+                    bool isMethodGenerator = Match(TokenType.STAR);
+
+                    if (isMethodAsync || isMethodGenerator)
+                    {
+                        // A modifier guarantees a method; parse its key (computed/string/number/identifier).
+                        Expr.PropertyKey methodKey;
+                        if (Match(TokenType.LEFT_BRACKET))
+                        {
+                            Expr keyExpr = Expression();
+                            Consume(TokenType.RIGHT_BRACKET, "Expect ']' after computed property key.");
+                            methodKey = new Expr.ComputedKey(keyExpr);
+                        }
+                        else if (Match(TokenType.STRING) || Match(TokenType.NUMBER))
+                        {
+                            methodKey = new Expr.LiteralKey(Previous());
+                        }
+                        else
+                        {
+                            Token methodName = ConsumePropertyName("Expect method name after method modifier.");
+                            methodKey = new Expr.IdentifierKey(methodName);
+                        }
+
+                        // Like the plain `{ foo() {} }` method-shorthand paths, object-literal methods
+                        // use the default Value kind; the generator/async semantics ride on the
+                        // ArrowFunction's IsGenerator/IsAsync flags.
+                        var methodExpr = ParseObjectMethodShorthand(isMethodAsync, isMethodGenerator);
+                        properties.Add(new Expr.Property(methodKey, methodExpr));
+                        continue;
+                    }
+
                     // Accessor shorthand: { get foo() {} }, { set foo(v) {} }.
                     // Disambiguate from a property literally named `get`/`set`:
                     //   { get }       shorthand            (next is `,` or `}`)
@@ -1035,7 +1075,7 @@ public partial class Parser
     /// values, and an optional <c>this:</c> parameter (TypeScript).
     /// Returns an ArrowFunction with <c>HasOwnThis=true</c>.
     /// </summary>
-    private Expr.ArrowFunction ParseObjectMethodShorthand()
+    private Expr.ArrowFunction ParseObjectMethodShorthand(bool isAsync = false, bool isGenerator = false)
     {
         Consume(TokenType.LEFT_PAREN, "Expect '(' in method shorthand.");
 
@@ -1145,7 +1185,9 @@ public partial class Parser
             ExpressionBody: null,
             BlockBody: body,
             ReturnType: returnType,
-            HasOwnThis: true);
+            HasOwnThis: true,
+            IsAsync: isAsync,
+            IsGenerator: isGenerator);
     }
 
     private Expr ParseTemplateLiteral()

--- a/SharpTS.Tests/ParserTests/ExpressionParsingTests.cs
+++ b/SharpTS.Tests/ParserTests/ExpressionParsingTests.cs
@@ -475,6 +475,81 @@ public class ExpressionParsingTests
     }
 
     [Fact]
+    public void ObjectLiteral_GeneratorMethodShorthand()
+    {
+        // `{ *gen() {} }` — a generator method (#757). Generator method bodies are lifted out of
+        // expression position by the GeneratorArrowLifter, so the parser+lift output is a hoisted
+        // generator Stmt.Function plus the object literal referencing it. Assert the generator was
+        // recognized (a generator function appears) and the property key survives.
+        var statements = Parse("({ *gen() { yield 1; } });");
+        Assert.Contains(statements, s => s is Stmt.Function { IsGenerator: true, IsAsync: false });
+        var obj = SingleObjectLiteral(statements);
+        var prop = Assert.Single(obj.Properties);
+        var ik = Assert.IsType<Expr.IdentifierKey>(prop.Key);
+        Assert.Equal("gen", ik.Name.Lexeme);
+    }
+
+    [Fact]
+    public void ObjectLiteral_GeneratorMethodWithComputedKey()
+    {
+        // `{ *[Symbol.iterator]() {} }` — the #757 repro form. The computed key is preserved on the
+        // object-literal property; the generator body lifts to a generator function.
+        var statements = Parse("({ *[Symbol.iterator]() { yield 1; } });");
+        Assert.Contains(statements, s => s is Stmt.Function { IsGenerator: true });
+        var obj = SingleObjectLiteral(statements);
+        var prop = Assert.Single(obj.Properties);
+        Assert.IsType<Expr.ComputedKey>(prop.Key);
+    }
+
+    [Fact]
+    public void ObjectLiteral_AsyncMethodShorthand()
+    {
+        // `{ async foo() {} }` — an async (non-generator) method. Async arrows are not lifted, so the
+        // property value is an async ArrowFunction in place.
+        var expr = ParseExpression("({ async foo() { return 1; } });");
+        var grouping = Assert.IsType<Expr.Grouping>(expr);
+        var obj = Assert.IsType<Expr.ObjectLiteral>(grouping.Expression);
+        var prop = Assert.Single(obj.Properties);
+        var arrow = Assert.IsType<Expr.ArrowFunction>(prop.Value);
+        Assert.True(arrow.IsAsync);
+        Assert.False(arrow.IsGenerator);
+    }
+
+    [Fact]
+    public void ObjectLiteral_AsyncGeneratorMethodShorthand()
+    {
+        // `{ async *gen() {} }` — an async generator method; lifts to an async generator function.
+        var statements = Parse("({ async *gen() { yield 1; } });");
+        Assert.Contains(statements, s => s is Stmt.Function { IsGenerator: true, IsAsync: true });
+        var obj = SingleObjectLiteral(statements);
+        Assert.Single(obj.Properties);
+    }
+
+    /// <summary>Finds the single object literal expression among parsed statements (it may be
+    /// accompanied by lifted generator function declarations).</summary>
+    private static Expr.ObjectLiteral SingleObjectLiteral(List<Stmt> statements)
+    {
+        var exprStmt = Assert.Single(statements.OfType<Stmt.Expression>());
+        var grouping = Assert.IsType<Expr.Grouping>(exprStmt.Expr);
+        return Assert.IsType<Expr.ObjectLiteral>(grouping.Expression);
+    }
+
+    [Fact]
+    public void ObjectLiteral_MethodNamedAsync_NotModifier()
+    {
+        // `{ async() {} }` — a method literally named `async`, not an async modifier.
+        var expr = ParseExpression("({ async() { return 1; } });");
+        var grouping = Assert.IsType<Expr.Grouping>(expr);
+        var obj = Assert.IsType<Expr.ObjectLiteral>(grouping.Expression);
+        var prop = Assert.Single(obj.Properties);
+        var ik = Assert.IsType<Expr.IdentifierKey>(prop.Key);
+        Assert.Equal("async", ik.Name.Lexeme);
+        var arrow = Assert.IsType<Expr.ArrowFunction>(prop.Value);
+        Assert.False(arrow.IsAsync);
+        Assert.False(arrow.IsGenerator);
+    }
+
+    [Fact]
     public void ObjectLiteral_GetAndSetAsShorthandProperties()
     {
         // `{ get, set }` must remain valid shorthand (not accessor).

--- a/SharpTS.Tests/SharedTests/ComputedSymbolMethodTests.cs
+++ b/SharpTS.Tests/SharedTests/ComputedSymbolMethodTests.cs
@@ -140,12 +140,11 @@ public class ComputedSymbolMethodTests
         Assert.Equal("2\n1\n2\n", TestHarness.Run(source, mode));
     }
 
-    // Compiled mode: reading a symbol method as a value (`obj[Symbol.iterator]`) returns the raw
-    // MethodInfo rather than a receiver-bound callable, so a standalone `obj[Symbol.iterator]()` call
-    // loses `this`. for...of / spread / for-await (which pass the receiver themselves) are unaffected
-    // and run in both back ends. Tracked as a follow-up.
+    // Reading a symbol method as a value (`obj[Symbol.iterator]`) returns a receiver-bound callable in
+    // both back ends, so a standalone `obj[Symbol.iterator]()` call keeps `this` (#755: compiled mode
+    // now binds the receiver as `new $TSFunction(obj, method)`, mirroring the string-keyed method read).
     [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void DirectSymbolMethodAccess_ReturnsCallable(ExecutionMode mode)
     {
         var source = """
@@ -155,6 +154,22 @@ public class ComputedSymbolMethodTests
             """;
 
         Assert.Equal("5\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void DirectSymbolMethodAccess_BindsThis(ExecutionMode mode)
+    {
+        // The returned callable must carry `this` — a standalone `obj[Symbol.iterator]()` reads
+        // `this.v` from the receiver (#755).
+        var source = """
+            class R { v = 9; *[Symbol.iterator]() { yield this.v; yield this.v + 1; } }
+            const it = (new R() as any)[Symbol.iterator]();
+            console.log(it.next().value);
+            console.log(it.next().value);
+            """;
+
+        Assert.Equal("9\n10\n", TestHarness.Run(source, mode));
     }
 
     // Compiled mode: class *expressions* go through a separate emit path that doesn't yet wire

--- a/SharpTS.Tests/SharedTests/ObjectFeatureTests.cs
+++ b/SharpTS.Tests/SharedTests/ObjectFeatureTests.cs
@@ -77,6 +77,75 @@ public class ObjectFeatureTests
         Assert.Equal("Hello, Alice\n", output);
     }
 
+    // Generator / async method shorthand in object literals (#757).
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Object_GeneratorMethodShorthand_Works(ExecutionMode mode)
+    {
+        // `{ *gen() {} }` — a named generator method.
+        var source = """
+            const o = { *gen() { yield 1; yield 2; yield 3; } };
+            for (const x of o.gen()) console.log(x);
+            """;
+
+        Assert.Equal("1\n2\n3\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Object_ComputedGeneratorMethod_IsIterable(ExecutionMode mode)
+    {
+        // #757 repro: `{ *[Symbol.iterator]() {} }` makes the object iterable.
+        var source = """
+            const o = { *[Symbol.iterator]() { yield 1; yield 2; } };
+            for (const x of o) console.log(x);
+            console.log([...o].length);
+            """;
+
+        Assert.Equal("1\n2\n2\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Object_AsyncMethodShorthand_Works(ExecutionMode mode)
+    {
+        // `{ async foo() {} }` — an async method returning a Promise.
+        var source = """
+            const o = { async foo(): Promise<number> { return 42; } };
+            o.foo().then(v => console.log(v));
+            """;
+
+        Assert.Equal("42\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Object_AsyncGeneratorComputedMethod_ForAwait_Works(ExecutionMode mode)
+    {
+        // `{ async *[Symbol.asyncIterator]() {} }` — async generator + computed key + for-await.
+        var source = """
+            const o = { async *[Symbol.asyncIterator]() { yield 10; yield 20; } };
+            async function main() { for await (const x of o) console.log(x); }
+            main();
+            """;
+
+        Assert.Equal("10\n20\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Object_MethodNamedAsync_NotTreatedAsModifier(ExecutionMode mode)
+    {
+        // `async` is only a method modifier when a property name / `*` follows it; here it is a
+        // method literally named `async`, and a property literally named `async`.
+        var source = """
+            const o = { async() { return 1; }, b: 2 };
+            console.log(o.async() + o.b);
+            """;
+
+        Assert.Equal("3\n", TestHarness.Run(source, mode));
+    }
+
     // Object Rest Pattern
     [Theory]
     [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]

--- a/SharpTS.Tests/SharedTests/StaticAsyncGeneratorMethodTests.cs
+++ b/SharpTS.Tests/SharedTests/StaticAsyncGeneratorMethodTests.cs
@@ -1,0 +1,87 @@
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests;
+
+/// <summary>
+/// Tests for static async generator methods — `class C { static async *gen() { yield … } }` (#761),
+/// the async-generator analog of the static sync generator (#692). The instance form already compiled;
+/// this pins the static form, whose async-generator state machine is set up like a free function (no
+/// `this`). Runs in both back ends.
+/// </summary>
+public class StaticAsyncGeneratorMethodTests
+{
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void StaticAsyncGenerator_SingleYields_Works(ExecutionMode mode)
+    {
+        var source = """
+            class C { static async *gen() { yield 1; yield 2; } }
+            async function main() { for await (const x of C.gen()) console.log(x); }
+            main();
+            """;
+
+        Assert.Equal("1\n2\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void StaticAsyncGenerator_WithParameterAndAwait_Works(ExecutionMode mode)
+    {
+        var source = """
+            class C {
+              static async *range(n: number) {
+                for (let i = 0; i < n; i++) { await Promise.resolve(); yield i * 10; }
+              }
+            }
+            async function main() { for await (const x of C.range(3)) console.log(x); }
+            main();
+            """;
+
+        Assert.Equal("0\n10\n20\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void StaticAsyncGenerator_ReadsStaticField_Works(ExecutionMode mode)
+    {
+        var source = """
+            class C {
+              static count = 3;
+              static async *fromField() { for (let i = 0; i < C.count; i++) yield i; }
+            }
+            async function main() { for await (const x of C.fromField()) console.log(x); }
+            main();
+            """;
+
+        Assert.Equal("0\n1\n2\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void StaticAsyncGenerator_ExplicitReturnType_Works(ExecutionMode mode)
+    {
+        // An explicit AsyncGenerator<T> return type doesn't change the lowering path.
+        var source = """
+            class C { static async *gen(): AsyncGenerator<number> { yield 5; yield 6; } }
+            async function main() { for await (const x of C.gen()) console.log(x); }
+            main();
+            """;
+
+        Assert.Equal("5\n6\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void InstanceAsyncGenerator_StillWorks(ExecutionMode mode)
+    {
+        // Regression guard: the instance form (the path #761 did not touch) keeps working.
+        var source = """
+            class C { async *gen() { yield 8; } }
+            async function main() { for await (const x of new C().gen()) console.log(x); }
+            main();
+            """;
+
+        Assert.Equal("8\n", TestHarness.Run(source, mode));
+    }
+}

--- a/SharpTS.Tests/TypeCheckerTests/ImplementsIterableProtocolTests.cs
+++ b/SharpTS.Tests/TypeCheckerTests/ImplementsIterableProtocolTests.cs
@@ -1,0 +1,175 @@
+using SharpTS.Tests.Infrastructure;
+using SharpTS.TypeSystem.Exceptions;
+using Xunit;
+
+namespace SharpTS.Tests.TypeCheckerTests;
+
+/// <summary>
+/// A class may list the built-in iterable-protocol interfaces (<c>Iterable&lt;T&gt;</c>,
+/// <c>AsyncIterable&lt;T&gt;</c>, <c>Iterator&lt;T&gt;</c>, …) in its <c>implements</c> clause (#756).
+/// These lib interfaces are not registered as named environment entries — they resolve only via the
+/// generic-type path — so the implements-clause lookup must fall back to a structural satisfaction
+/// check rather than reporting "is not an interface". Validation is type-checker-only, so these run
+/// interpreted (the type checker runs identically in both back ends).
+/// </summary>
+public class ImplementsIterableProtocolTests
+{
+    [Fact]
+    public void Class_ImplementsIterable_GeneratorMethod_Accepted()
+    {
+        // The #756 repro: a generator [Symbol.iterator] makes the class satisfy Iterable<number>.
+        var source = """
+            class Range implements Iterable<number> {
+              *[Symbol.iterator](): Iterator<number> { yield 1; yield 2; }
+            }
+            for (const x of new Range()) console.log(x);
+            """;
+
+        Assert.Equal("1\n2\n", TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void Class_ImplementsIterable_ObjectReturningIterator_Accepted()
+    {
+        // A non-generator [Symbol.iterator] returning a manual iterator object also satisfies it.
+        var source = """
+            class Range implements Iterable<number> {
+              [Symbol.iterator](): Iterator<number> {
+                let i = 0;
+                return { next() { return i < 2 ? { value: i++, done: false } : { value: 0, done: true }; } };
+              }
+            }
+            console.log([...new Range()].length);
+            """;
+
+        Assert.Equal("2\n", TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void Class_ImplementsIterable_NoTypeArgs_Accepted()
+    {
+        // `implements Iterable` with no type argument defaults to Iterable<any> (like tsc's Iterable<unknown>).
+        var source = """
+            class R implements Iterable<number> { *[Symbol.iterator]() { yield 7; } }
+            console.log([...new R()][0]);
+            """;
+
+        Assert.Equal("7\n", TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void Class_ImplementsAsyncIterable_Accepted()
+    {
+        // The async parallel: async *[Symbol.asyncIterator]() satisfies AsyncIterable<number>.
+        var source = """
+            class ARange implements AsyncIterable<number> {
+              async *[Symbol.asyncIterator]() { yield 10; yield 20; }
+            }
+            async function main() { for await (const x of new ARange()) console.log(x); }
+            main();
+            """;
+
+        Assert.Equal("10\n20\n", TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void Class_ImplementsIterableAndUserInterface_Accepted()
+    {
+        // A built-in protocol interface mixes with a user interface in the same implements clause.
+        var source = """
+            interface Named { name: string; }
+            class R implements Iterable<number>, Named {
+              name = "r";
+              *[Symbol.iterator]() { yield 1; }
+            }
+            console.log(new R().name);
+            """;
+
+        Assert.Equal("r\n", TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void ClassExpression_ImplementsIterable_Accepted()
+    {
+        // Class expressions resolve the implements clause through a separate path — also wired (#756).
+        var source = """
+            const C = class implements Iterable<number> { *[Symbol.iterator]() { yield 3; yield 4; } };
+            for (const x of new C()) console.log(x);
+            """;
+
+        Assert.Equal("3\n4\n", TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void Class_ImplementsIterable_NotIterable_Rejected()
+    {
+        // A class with no [Symbol.iterator] does not satisfy Iterable<number> (TS2420).
+        var source = """
+            class Bad implements Iterable<number> { x = 1; }
+            console.log(new Bad().x);
+            """;
+
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void Class_ImplementsAsyncIterable_NotAsyncIterable_Rejected()
+    {
+        var source = """
+            class Bad implements AsyncIterable<number> { x = 1; }
+            console.log(new Bad().x);
+            """;
+
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void Class_ImplementsIterable_SyncNotAsync_Rejected()
+    {
+        // A sync iterable is not an AsyncIterable — the structural async probe must reject it.
+        var source = """
+            class R implements AsyncIterable<number> { *[Symbol.iterator]() { yield 1; } }
+            console.log("x");
+            """;
+
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void Class_ImplementsIterable_ElementMismatch_Rejected()
+    {
+        // The element type is checked when known: yielding number does not satisfy Iterable<string>.
+        var source = """
+            class R implements Iterable<string> { *[Symbol.iterator](): Iterator<number> { yield 1; } }
+            console.log("x");
+            """;
+
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void Class_ImplementsNonInterface_StillRejected()
+    {
+        // Regression: a non-interface binding in implements position is still "is not an interface".
+        var source = """
+            const NotIface = 5;
+            class C implements NotIface {}
+            console.log("x");
+            """;
+
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void Class_ImplementsUserInterface_MissingMember_StillRejected()
+    {
+        // Regression: a user interface still validates member-by-member.
+        var source = """
+            interface Foo { bar(): number; }
+            class C implements Foo { baz() { return 1; } }
+            console.log("x");
+            """;
+
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+}

--- a/TypeSystem/TypeChecker.Expressions.cs
+++ b/TypeSystem/TypeChecker.Expressions.cs
@@ -2020,12 +2020,25 @@ public partial class TypeChecker
         // Validate interface implementations (skip for generic - validated at instantiation)
         if (classExpr.Interfaces != null && classTypeParams == null)
         {
-            foreach (var interfaceToken in classExpr.Interfaces)
+            for (int i = 0; i < classExpr.Interfaces.Count; i++)
             {
+                var interfaceToken = classExpr.Interfaces[i];
                 TypeInfo? itfTypeInfo = _environment.Get(interfaceToken.Lexeme);
-                if (itfTypeInfo is not TypeInfo.Interface interfaceType)
+                if (itfTypeInfo is TypeInfo.Interface interfaceType)
+                {
+                    ValidateInterfaceImplementation(classTypeForBody, interfaceType, className);
+                    continue;
+                }
+
+                // Built-in iterable-protocol interface (Iterable<T>, AsyncIterable<T>, …): structural
+                // satisfaction check, since it has no named environment entry to validate against. #756.
+                List<string>? typeArgs = classExpr.InterfaceTypeArgs != null && i < classExpr.InterfaceTypeArgs.Count
+                    ? classExpr.InterfaceTypeArgs[i]
+                    : null;
+                if (TryResolveIterableProtocolInterface(interfaceToken.Lexeme, typeArgs, out var protocolType))
+                    ValidateProtocolInterfaceImplementation(classTypeForBody, protocolType, interfaceToken.Lexeme, className);
+                else
                     throw new TypeCheckException($" '{interfaceToken.Lexeme}' is not an interface.", tsCode: "TS2304");
-                ValidateInterfaceImplementation(classTypeForBody, interfaceType, className);
             }
         }
 

--- a/TypeSystem/TypeChecker.Iterables.cs
+++ b/TypeSystem/TypeChecker.Iterables.cs
@@ -243,7 +243,7 @@ public partial class TypeChecker
     /// iterables are intentionally excluded (a sync iterable is not an async iterable). Returns false for
     /// non-async-iterable types (callers decide between an error and a fall-through to <c>any</c>).
     /// </summary>
-    private static bool TryGetAsyncIterableElementType(TypeInfo type, out TypeInfo elementType)
+    private bool TryGetAsyncIterableElementType(TypeInfo type, out TypeInfo elementType)
     {
         switch (type)
         {
@@ -251,9 +251,31 @@ public partial class TypeChecker
             case TypeInfo.AsyncIterator ait: elementType = ait.ElementType; return true;
             case TypeInfo.AsyncGenerator ag: elementType = ag.YieldType; return true;
             case TypeInfo.Any: elementType = new TypeInfo.Any(); return true;
-            default:
-                elementType = null!;
-                return false;
         }
+
+        // Structural async-iterable: an object/class exposing [Symbol.asyncIterator]() — modeled as the
+        // @@asyncIterator member; an object literal's symbol-keyed method lands in the symbol index
+        // signature, so both are probed. Mirrors the sync TryGetStructuralIterableElement, so a class
+        // declaring `async *[Symbol.asyncIterator]()` satisfies AsyncIterable<T> (#756). A sync-only
+        // iterable (no @@asyncIterator) falls through to rejection — a sync iterable is not async.
+        TypeInfo? factory = GetMemberType(type, "@@asyncIterator");
+        if (!IsCallableMember(factory) && type is TypeInfo.Record { SymbolIndexType: { } symIndex })
+            factory = symIndex;
+        if (IsCallableMember(factory))
+        {
+            TypeInfo? asyncIterator = GetCallableReturnType(factory);
+            if (asyncIterator is null) { elementType = new TypeInfo.Any(); return true; }
+            elementType = asyncIterator switch
+            {
+                TypeInfo.AsyncIterator it => it.ElementType,
+                TypeInfo.AsyncGenerator g => g.YieldType,
+                TypeInfo.AsyncIterable ib => ib.ElementType,
+                _ => new TypeInfo.Any(),   // structural next(): Promise<IteratorResult<T>> — keep permissive
+            };
+            return true;
+        }
+
+        elementType = null!;
+        return false;
     }
 }

--- a/TypeSystem/TypeChecker.Statements.Classes.cs
+++ b/TypeSystem/TypeChecker.Statements.Classes.cs
@@ -482,6 +482,14 @@ public partial class TypeChecker
                         substitutedMembers,
                         genericInterface.OptionalMembers);
                 }
+                else if (TryResolveIterableProtocolInterface(interfaceToken.Lexeme, typeArgs, out var protocolType))
+                {
+                    // Built-in iterable-protocol interface (Iterable<T>, AsyncIterable<T>, …): validate
+                    // the class satisfies it structurally — it has no named environment entry to validate
+                    // member-by-member. #756.
+                    ValidateProtocolInterfaceImplementation(classTypeForBody, protocolType, interfaceToken.Lexeme, classStmt.Name.Lexeme);
+                    continue;
+                }
                 else
                 {
                     throw new TypeCheckException($" '{interfaceToken.Lexeme}' is not an interface.", tsCode: "TS2304");

--- a/TypeSystem/TypeChecker.Validation.cs
+++ b/TypeSystem/TypeChecker.Validation.cs
@@ -65,6 +65,48 @@ public partial class TypeChecker
     }
 
     /// <summary>
+    /// The built-in iterable-protocol interfaces. Unlike user <c>interface</c>s, these are not
+    /// registered as named entries in the type environment — they resolve only via the generic-type
+    /// path (<see cref="ResolveGenericType"/>) — so the <c>implements</c>-clause interface lookup
+    /// misses them. They are nonetheless implementable (matching <c>tsc</c>:
+    /// <c>class C implements Iterable&lt;number&gt;</c>), validated structurally rather than member-by-member.
+    /// </summary>
+    private static readonly HashSet<string> IterableProtocolInterfaceNames =
+    [
+        "Iterable", "AsyncIterable",
+        "Iterator", "IterableIterator",
+        "AsyncIterator", "AsyncIterableIterator",
+    ];
+
+    /// <summary>
+    /// Resolves a built-in iterable-protocol interface named in an <c>implements</c> clause to its
+    /// <see cref="TypeInfo"/> (#756). Returns false for any other name, leaving the regular
+    /// "not an interface" handling in place. A missing type argument defaults to <c>any</c> so
+    /// <c>implements Iterable</c> (no args) is accepted like <c>tsc</c>'s <c>Iterable&lt;unknown&gt;</c>.
+    /// </summary>
+    private bool TryResolveIterableProtocolInterface(string name, List<string>? typeArgs, out TypeInfo protocolType)
+    {
+        protocolType = null!;
+        if (!IterableProtocolInterfaceNames.Contains(name)) return false;
+        var args = typeArgs is { Count: > 0 }
+            ? typeArgs.Select(ta => ToTypeInfo(ta)).ToList()
+            : [new TypeInfo.Any()];
+        protocolType = ResolveGenericType(name, args);
+        return true;
+    }
+
+    /// <summary>
+    /// Validates that <paramref name="classType"/> structurally satisfies a built-in iterable-protocol
+    /// interface listed in its <c>implements</c> clause (e.g. has a <c>[Symbol.iterator]()</c> yielding a
+    /// compatible element). Throws TS2420 when it does not. #756.
+    /// </summary>
+    private void ValidateProtocolInterfaceImplementation(TypeInfo.Class classType, TypeInfo protocolType, string protocolName, string className)
+    {
+        if (!IsCompatible(protocolType, new TypeInfo.Instance(classType)))
+            throw new TypeCheckException($" Class '{className}' incorrectly implements '{protocolName}'.", tsCode: "TS2420");
+    }
+
+    /// <summary>
     /// Validates that a class method signature is compatible with an interface method signature.
     /// For interface implementation, the class method must:
     /// 1. Accept at least as many required parameters as the interface method requires


### PR DESCRIPTION
Follow-ups to the computed symbol-keyed class method work in #764 (#592/#647/#692). **Stacked on #764** — review/merge that first; this targets its branch so the diff is only the changes below.

## #757 — object-literal generator computed methods (parser)
`{ *[Symbol.iterator]() { yield 1; } }` now parses. The object-literal property loop gained generator (`*`) and `async` method-modifier handling, threaded into `ParseObjectMethodShorthand` (sets the `ArrowFunction`'s `IsGenerator`/`IsAsync`). The existing runtime (generator-arrow lifter + async-arrow lowering) handles the rest, so `{ *gen() {} }`, `{ *[sym]() {} }`, `{ async foo() {} }` and `{ async *[Symbol.asyncIterator]() {} }` all work in **both** back ends (IL verified). `async` stays a property/method name when not followed by a property-name start or `*` (`{ async() {} }`, `{ async: v }`, `{ async }` preserved).

## #756 — `class C implements Iterable<T>` (type checker)
The built-in iterable-protocol interfaces (`Iterable`, `AsyncIterable`, `Iterator`, `IterableIterator`, `AsyncIterator`, `AsyncIterableIterator`) aren't named environment entries, so the `implements`-clause lookup reported "is not an interface". They are now resolved via the generic-type path and validated **structurally** (the class instance must satisfy the protocol), in both the class-declaration and class-expression paths. A missing type argument defaults to `any`. Also added the previously-missing **structural `@@asyncIterator` probe** to `TryGetAsyncIterableElementType`, so a class with `async *[Symbol.asyncIterator]()` satisfies `AsyncIterable<T>` (and a sync-only iterable correctly does **not**). User-interface validation and the "not an interface" error for non-interfaces are unchanged.

## #761 — compiled `static async *m()` (async-generator analog of #692)
`EmitAsyncGeneratorMethodBody` is generalized with an `isInstanceMethod` flag plus a static stub (`EmitAsyncGeneratorStaticStubMethod`, no `this`, params from arg 0, value-types boxed) — mirroring #692's static sync generator. `EmitStaticMethodBody` dispatches `static async *m()` there before the plain-async branch. IL verified.

## #755 — compiled symbol-method follow-ups (partial)
- **Sub-case 1 (reading a symbol method as a bound value) — FIXED.** The compiled bracket-get now returns the method receiver-bound as `new $TSFunction(obj, method)` (the same binding a string-keyed method read uses) instead of a raw `MethodInfo`, so `(new R() as any)[Symbol.iterator]()` keeps `this` rather than throwing `TargetException`. `for...of`/spread/`for await` use a separate path and are unaffected. Test flipped to `ExecutionModes.All` + new `DirectSymbolMethodAccess_BindsThis`.
- **Sub-case 2 (class expressions) — deferred.** Root cause is broader: compiled class *expressions* don't support generator methods at all (#765). The tracked test uses the `*[Symbol.iterator]()` form, so it can't pass until #765 lands. Stays `InterpretedOnly`.
- **Sub-case 3 (non-symbol computed keys) — deferred.** Needs a dynamically-named .NET method; unchanged. Stays `InterpretedOnly`.

## Issues filed for gaps found along the way
- #775 — generator function expression / object generator method loses dynamic `this` (both modes; pre-existing, surfaced by #757). The #757 tests intentionally avoid `this` in object generator methods.
- #776 — class-expression `async m()` infers a `void` return type, rejecting `return <value>` (both modes; class declarations are fine).
- #765 (pre-existing) is the blocker for #755 sub-case 2.

## Tests
New/updated: `ObjectFeatureTests` (object generator/async methods), `ExpressionParsingTests` (parser AST), `ImplementsIterableProtocolTests` (#756, 12 cases incl. negative/regression), `StaticAsyncGeneratorMethodTests` (#761), `ComputedSymbolMethodTests` (#755 sub-case 1 flipped to both modes + this-binding). Full `dotnet test SharpTS.sln` green.
