### PR TITLE
Fix #751, #753, #754: typed-array index IL-verify, string rest element, assignment destructuring

### DIFF
--- a/Compilation/CallHandlers/ArrayDestructureHandler.cs
+++ b/Compilation/CallHandlers/ArrayDestructureHandler.cs
@@ -8,13 +8,14 @@ namespace SharpTS.Compilation.CallHandlers;
 
 /// <summary>
 /// Handles the internal <c>__arrayDestructure</c> helper that normalizes an array binding-pattern
-/// source through the iterator protocol (#685). Index-addressable sources (arrays, tuples, strings)
-/// are emitted as-is — the desugared positional index access reads them directly and the type checker
+/// source through the iterator protocol (#685). Index-addressable sources (arrays, tuples) are
+/// emitted as-is — the desugared positional index access reads them directly and the type checker
 /// assigns them a matching pass-through type, so no runtime work is needed (preserves the fast path
-/// and tuple positional element types). Every other source is routed through the emitted
-/// <c>ArrayDestructureSource</c> runtime helper, which materializes non-indexable iterables
-/// (generators, Set, Map, <c>[Symbol.iterator]</c> objects) into an array and passes everything else
-/// through unchanged.
+/// and tuple positional element types). Every other source — including <b>strings</b> — is routed
+/// through the emitted <c>ArrayDestructureSource</c> runtime helper, which materializes non-indexable
+/// iterables (generators, Set, Map, strings, <c>[Symbol.iterator]</c> objects) into an array. Strings
+/// are deliberately not on the fast path so a rest element binds a fresh character array rather than
+/// the trailing substring (#753); non-rest character values are identical either way.
 /// </summary>
 public class ArrayDestructureHandler : ICallHandler
 {
@@ -52,6 +53,8 @@ public class ArrayDestructureHandler : ICallHandler
         return true;
     }
 
+    // Strings are intentionally excluded: they must materialize through ArrayDestructureSource so a
+    // rest element collects a fresh character array, not the trailing substring (#753).
     private static bool IsIndexAddressable(TypeInfo? type) =>
-        type is TypeInfo.Array or TypeInfo.Tuple or TypeInfo.String or TypeInfo.StringLiteral;
+        type is TypeInfo.Array or TypeInfo.Tuple;
 }

--- a/Compilation/ExpressionEmitterBase.cs
+++ b/Compilation/ExpressionEmitterBase.cs
@@ -170,6 +170,9 @@ public abstract partial class ExpressionEmitterBase : IEmitterContext
             case Expr.Comma c:
                 EmitComma(c);
                 break;
+            case Expr.DestructuringAssign da:
+                EmitDestructuringAssign(da);
+                break;
             case Expr.Literal lit:
                 EmitLiteral(lit);
                 break;
@@ -1992,6 +1995,16 @@ public abstract partial class ExpressionEmitterBase : IEmitterContext
         EmitExpression(c.Right);
         EnsureBoxed();
     }
+
+    /// <summary>
+    /// Emits an assignment-destructuring expression (#754) by running its lowered statements and then
+    /// leaving the result value on the stack. Overridden in <see cref="StatementEmitterBase"/> (the
+    /// concrete emitters' base), which has access to <c>EmitStatement</c>; declared here only so the
+    /// shared <see cref="EmitExpression"/> dispatch can reach it.
+    /// </summary>
+    protected virtual void EmitDestructuringAssign(Expr.DestructuringAssign da) =>
+        throw new NotSupportedException(
+            "DestructuringAssign requires statement emission; emit it from a StatementEmitterBase subclass.");
     #endregion
 
     #region Virtual Methods - Pass-through expressions

--- a/Compilation/ILEmitter.Properties.cs
+++ b/Compilation/ILEmitter.Properties.cs
@@ -746,7 +746,14 @@ public partial class ILEmitter
                     EmitExpressionAsDouble(gi.Index);
                     IL.Emit(OpCodes.Conv_I4);
                     IL.Emit(OpCodes.Callvirt, _ctx.Types.GetMethod(listType, "get_Item", _ctx.Types.Int32));
-                    SetStackType(h.Descriptor.StackType);
+                    // Box the unboxed element so this branch converges on `object` with the
+                    // $Array / List<object?> / fallback paths at endLabel. The typed List<T>
+                    // fast path otherwise leaves a native double/bool where the merge point — and
+                    // every consumer, which reads the clobbered StackType=Unknown — expects an
+                    // object ref. That ran only because the typed branch is dead for $Array-backed
+                    // values, but is unverifiable IL (#751).
+                    h.Descriptor.EmitBoxElement(IL, _ctx.Types);
+                    SetStackUnknown();
                     IL.Emit(OpCodes.Br, endLabel);
 
                     // Fallback: type didn't match at loop entry
@@ -787,7 +794,10 @@ public partial class ILEmitter
                 EmitExpressionAsDouble(gi.Index);
                 IL.Emit(OpCodes.Conv_I4);
                 IL.Emit(OpCodes.Callvirt, _ctx.Types.GetMethod(listType, "get_Item", _ctx.Types.Int32));
-                SetStackType(desc.StackType);
+                // Box so this branch converges on `object` with the sibling paths at endLabelNH
+                // (see the hoisted get path above for the full rationale, #751).
+                desc.EmitBoxElement(IL, _ctx.Types);
+                SetStackUnknown();
                 IL.Emit(OpCodes.Br, endLabelNH);
 
                 IL.MarkLabel(notTypedLabel);
@@ -898,7 +908,10 @@ public partial class ILEmitter
                 IL.Emit(OpCodes.Ldloc, typedValueLocal);
                 IL.Emit(OpCodes.Call, h.Descriptor.GetSetArrayElementMethod(_ctx.Runtime!));
                 IL.Emit(OpCodes.Ldloc, typedValueLocal);
-                SetStackType(h.Descriptor.StackType);
+                // Box the assigned value so this branch leaves `object` like the fallback path at
+                // endLabel (the assignment result is consumed via StackType=Unknown), #751.
+                h.Descriptor.EmitBoxElement(IL, _ctx.Types);
+                SetStackUnknown();
                 IL.Emit(OpCodes.Br, endLabel);
 
                 // Fallback: type didn't match at loop entry
@@ -970,7 +983,10 @@ public partial class ILEmitter
                 IL.Emit(OpCodes.Ldloc, typedValueLocalNH);
                 IL.Emit(OpCodes.Call, desc.GetSetArrayElementMethod(_ctx.Runtime!));
                 IL.Emit(OpCodes.Ldloc, typedValueLocalNH);
-                SetStackType(desc.StackType);
+                // Box so this branch converges on `object` with the sibling paths at endLabelNH
+                // (see the hoisted set path above for the full rationale, #751).
+                desc.EmitBoxElement(IL, _ctx.Types);
+                SetStackUnknown();
                 IL.Emit(OpCodes.Br, endLabelNH);
 
                 // Not typed list: box value and fall through to List<object?> path

--- a/Compilation/RuntimeEmitter.Objects.Iteration.cs
+++ b/Compilation/RuntimeEmitter.Objects.Iteration.cs
@@ -9,13 +9,17 @@ public partial class RuntimeEmitter
 {
     /// <summary>
     /// Emits ArrayDestructureSource: normalizes an array binding-pattern source through the
-    /// iterator protocol (#685). Index-addressable sources — strings and any
+    /// iterator protocol (#685). Index-addressable sources — any
     /// <see cref="System.Collections.IList"/> (arrays, <c>$Array</c>, typed lists) — pass through
     /// unchanged so the desugared positional index access reads them directly and stays consistent
     /// with the matching pass-through type the type checker assigned. Any other iterable (Set, Map,
-    /// generators, <c>[Symbol.iterator]</c> objects, <c>IEnumerable&lt;object&gt;</c>) is materialized
-    /// via <c>IterateToList</c> into a <c>List&lt;object&gt;</c> so positional access yields the
-    /// iterated elements. Non-iterable sources pass through, preserving the existing lenient behavior.
+    /// generators, strings, <c>[Symbol.iterator]</c> objects, <c>IEnumerable&lt;object&gt;</c>) is
+    /// materialized via <c>IterateToList</c> into a <c>List&lt;object&gt;</c> so positional access
+    /// yields the iterated elements. A <b>string</b> is deliberately not on the pass-through path: it
+    /// materializes to a fresh character array so a rest element binds an array rather than the trailing
+    /// substring (<c>const [a, ...rest] = "hi"</c>), matching ECMA-262 (#753) — non-rest character
+    /// values are identical either way. Non-iterable sources pass through, preserving the existing
+    /// lenient behavior.
     /// Signature: object ArrayDestructureSource(object value, $TSSymbol iteratorSymbol, Type runtimeType)
     /// </summary>
     private void EmitArrayDestructureSource(TypeBuilder typeBuilder, EmittedRuntime runtime)
@@ -33,13 +37,10 @@ public partial class RuntimeEmitter
 
         var passThroughLabel = il.DefineLabel();
 
-        // string → pass through (the source stays typed as string; index access reads chars).
-        il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Isinst, _types.String);
-        il.Emit(OpCodes.Brtrue, passThroughLabel);
-
         // IList (List<object>, $Array, typed lists) → pass through: already index-addressable, and
         // routing a typed list (List<double>/List<bool>) through IterateToList would re-box it.
+        // Note: a .NET string is NOT an IList, so it falls through to the IterateToList path below and
+        // is materialized into a character array (#753) — required so a rest element binds an array.
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Isinst, ilistType);
         il.Emit(OpCodes.Brtrue, passThroughLabel);

--- a/Compilation/RuntimeFeatureDetector.cs
+++ b/Compilation/RuntimeFeatureDetector.cs
@@ -824,6 +824,13 @@ public sealed class RuntimeFeatureDetector
                 VisitExpr(cm.Left);
                 VisitExpr(cm.Right);
                 break;
+            case Expr.DestructuringAssign da:
+                // Walk the lowered assignment statements so a feature inside the rhs/targets
+                // (e.g. eval/Proxy in the source expression) is still detected (#754).
+                foreach (var s in da.Assignments)
+                    VisitStmt(s);
+                VisitExpr(da.ResultValue);
+                break;
             case Expr.Grouping gr:
                 VisitExpr(gr.Expression);
                 break;

--- a/Compilation/StatementEmitterBase.cs
+++ b/Compilation/StatementEmitterBase.cs
@@ -191,6 +191,20 @@ public abstract class StatementEmitterBase : ExpressionEmitterBase
     #region Core Statement Dispatch
 
     /// <summary>
+    /// Emits an assignment-destructuring expression (#754): run the lowered assignment statements (temp
+    /// binding + per-target writes, all synthesized <see cref="Stmt.Var"/>/<see cref="Stmt.Expression"/>
+    /// with no control flow), then leave the result value (the original rhs) on the stack. Each statement
+    /// goes through the normal <see cref="EmitStatement"/> path, so the async/generator subclasses handle
+    /// an <c>await</c>/<c>yield</c> in the rhs without any extra plumbing.
+    /// </summary>
+    protected override void EmitDestructuringAssign(Expr.DestructuringAssign da)
+    {
+        foreach (var stmt in da.Assignments)
+            EmitStatement(stmt);
+        EmitExpression(da.ResultValue);
+    }
+
+    /// <summary>
     /// Dispatches statement emission to the appropriate handler method.
     /// </summary>
     public virtual void EmitStatement(Stmt stmt)

--- a/Execution/Interpreter.Expressions.cs
+++ b/Execution/Interpreter.Expressions.cs
@@ -47,6 +47,14 @@ public partial class Interpreter
     // All Evaluate* methods return RuntimeValue directly — no FromBoxed in dispatch.
 
     internal RuntimeValue VisitComma(Expr.Comma comma) { Evaluate(comma.Left); return EvaluateRV(comma.Right); }
+    internal RuntimeValue VisitDestructuringAssign(Expr.DestructuringAssign d)
+    {
+        // Run the lowered assignment statements (temp binding + per-target writes), then yield the
+        // original rhs the temp holds — an assignment expression evaluates to its right-hand side (#754).
+        foreach (var stmt in d.Assignments)
+            Execute(stmt);
+        return EvaluateRV(d.ResultValue);
+    }
     internal RuntimeValue VisitBinary(Expr.Binary binary) => EvaluateBinary(binary);
     internal RuntimeValue VisitLogical(Expr.Logical logical) => EvaluateLogical(logical);
     internal RuntimeValue VisitNullishCoalescing(Expr.NullishCoalescing nc) => EvaluateNullishCoalescing(nc);
@@ -115,6 +123,12 @@ public partial class Interpreter
         switch (expr)
         {
             case Expr.Comma comma: await EvaluateAsync(comma.Left); return await EvaluateAsync(comma.Right);
+            case Expr.DestructuringAssign d:
+                // Lowered statements may contain `await` in the rhs; run them on the async path, then
+                // yield the temp holding the original rhs (#754).
+                foreach (var stmt in d.Assignments)
+                    await ExecuteStatementAsync(stmt);
+                return await EvaluateAsync(d.ResultValue);
             case Expr.Binary binary: return await EvaluateBinaryAsync(binary);
             case Expr.Logical logical: return await EvaluateLogicalAsync(logical);
             case Expr.NullishCoalescing nc: return await EvaluateNullishCoalescingAsync(nc);

--- a/Execution/Interpreter.Statements.cs
+++ b/Execution/Interpreter.Statements.cs
@@ -945,15 +945,19 @@ public partial class Interpreter
     /// <summary>
     /// Normalizes an array binding-pattern source through the iterator protocol (#685). Array
     /// destructuring (<c>const [a, b] = src</c>) desugars to positional index access, which is only
-    /// correct for index-addressable sources. Arrays, strings, typed arrays and buffers pass through
-    /// unchanged (fast path); any other source is materialized into a <see cref="SharpTSArray"/> via
-    /// <see cref="GetIterableElements"/> — the same routine spread uses — so the index access reads
-    /// the iterated elements. A genuinely non-iterable source throws "is not iterable", matching JS;
-    /// the type checker already rejects those statically except behind <c>any</c>.
+    /// correct for index-addressable sources. Arrays, typed arrays and buffers pass through unchanged
+    /// (fast path); any other source — including <b>strings</b> — is materialized into a
+    /// <see cref="SharpTSArray"/> via <see cref="GetIterableElements"/> (the same routine spread uses)
+    /// so the index access reads the iterated elements. Strings are intentionally materialized (not on
+    /// the fast path) so a rest element binds a fresh array of characters rather than the trailing
+    /// substring (<c>const [a, ...rest] = "hi"</c> → <c>rest = ["i"]</c>), matching ECMA-262 (#753);
+    /// non-rest character values are identical either way. A genuinely non-iterable source throws "is
+    /// not iterable", matching JS; the type checker already rejects those statically except behind
+    /// <c>any</c>.
     /// </summary>
     internal object? NormalizeArrayDestructureSource(object? value)
     {
-        if (value is SharpTSArray or string or SharpTSTypedArray or SharpTSBuffer)
+        if (value is SharpTSArray or SharpTSTypedArray or SharpTSBuffer)
             return value;
 
         return new SharpTSArray(GetIterableElements(value).ToList());

--- a/Parsing/AST.cs
+++ b/Parsing/AST.cs
@@ -49,6 +49,7 @@ public abstract record Expr
     public static TResult Accept<TResult>(Expr expr, IExprVisitor<TResult> visitor) => expr switch
     {
         Comma e => visitor.VisitComma(e),
+        DestructuringAssign e => visitor.VisitDestructuringAssign(e),
         Binary e => visitor.VisitBinary(e),
         Logical e => visitor.VisitLogical(e),
         NullishCoalescing e => visitor.VisitNullishCoalescing(e),
@@ -98,6 +99,20 @@ public abstract record Expr
 
     /// <summary>Comma (sequence) expression: evaluates all sub-expressions left-to-right, returns the last value.</summary>
     public record Comma(Expr Left, Expr Right) : Expr;
+    /// <summary>
+    /// Destructuring assignment to existing l-values — <c>[a, b] = rhs</c> / <c>({a, b} = rhs)</c> (#754).
+    /// Unlike declaration destructuring (which binds new variables), the targets are existing
+    /// <see cref="Variable"/>/<see cref="Get"/>/<see cref="GetIndex"/> l-values. The parser lowers the
+    /// pattern (already parsed as an array/object literal) into <paramref name="Assignments"/> — a temp
+    /// declaration for the rhs, the per-target assignment statements (reusing the #685 iterator-protocol
+    /// normalization <c>__arrayDestructure</c> and <c>__objectRest</c>), and any nested temps — plus
+    /// <paramref name="ResultValue"/>, the temp holding the original rhs (an assignment expression
+    /// evaluates to its right-hand side, per ECMA-262). Every backend lowers it identically: run
+    /// <c>Assignments</c>, then yield <c>ResultValue</c>. <c>Assignments</c> contains only synthesized
+    /// <see cref="Stmt.Var"/> and <see cref="Stmt.Expression"/> statements (no control flow), so it is
+    /// safe in any expression position.
+    /// </summary>
+    public record DestructuringAssign(List<Stmt> Assignments, Expr ResultValue) : Expr;
     public record Binary(Expr Left, Token Operator, Expr Right) : Expr;
     public record Logical(Expr Left, Token Operator, Expr Right) : Expr;
     public record NullishCoalescing(Expr Left, Expr Right) : Expr;

--- a/Parsing/Parser.Destructuring.cs
+++ b/Parsing/Parser.Destructuring.cs
@@ -267,4 +267,164 @@ public partial class Parser
 
         return new Stmt.Sequence(statements);
     }
+
+    // ============== ASSIGNMENT DESTRUCTURING (#754) ==============
+    // `[a, b] = rhs` / `({a, b} = rhs)` assign to EXISTING l-values (not new bindings). The target has
+    // already been parsed as an array/object literal (the eager-parse cover grammar); here it is
+    // reinterpreted as a pattern and lowered into assignment statements that reuse the #685
+    // iterator-protocol normalization (`__arrayDestructure`) and `__objectRest`. The rhs is evaluated
+    // once into a temp and yielded as the expression's value (ECMA-262: an assignment evaluates to its
+    // right-hand side, the ORIGINAL rhs — not the normalized array).
+
+    /// <summary>True when an `=` target parsed as an array/object literal is an assignment-destructuring
+    /// pattern (#754) rather than an ordinary assignment target.</summary>
+    private static bool IsDestructuringAssignmentTarget(Expr target) =>
+        Unwrap(target) is Expr.ArrayLiteral or Expr.ObjectLiteral;
+
+    private static Expr Unwrap(Expr e) => e is Expr.Grouping g ? Unwrap(g.Expression) : e;
+
+    private Expr BuildDestructuringAssignment(Expr pattern, Expr value, int line)
+    {
+        var stmts = new List<Stmt>();
+        // _destN = rhs — evaluate the source exactly once; it is also the expression's result value.
+        Token rhsTemp = GenerateTempVar(line);
+        stmts.Add(new Stmt.Var(rhsTemp, null, value));
+        LowerAssignmentTarget(pattern, new Expr.Variable(rhsTemp), stmts, line);
+        return new Expr.DestructuringAssign(stmts, new Expr.Variable(rhsTemp));
+    }
+
+    private void LowerAssignmentTarget(Expr target, Expr source, List<Stmt> stmts, int line)
+    {
+        switch (Unwrap(target))
+        {
+            case Expr.ArrayLiteral arr: LowerArrayAssignmentTarget(arr, source, stmts, line); break;
+            case Expr.ObjectLiteral obj: LowerObjectAssignmentTarget(obj, source, stmts, line); break;
+            default: stmts.Add(new Stmt.Expression(MakeAssignmentExpr(target, source))); break;
+        }
+    }
+
+    private void LowerArrayAssignmentTarget(Expr.ArrayLiteral arr, Expr source, List<Stmt> stmts, int line)
+    {
+        // _srcN = __arrayDestructure(source) — normalize any iterable to an indexable array (#685).
+        Token srcTemp = GenerateTempVar(line);
+        stmts.Add(new Stmt.Var(srcTemp, null, MakeArrayDestructureCall(source, line)));
+        Expr src = new Expr.Variable(srcTemp);
+
+        for (int i = 0; i < arr.Elements.Count; i++)
+        {
+            if (arr.IsHole(i)) continue;
+            Expr element = Unwrap(arr.Elements[i]);
+
+            if (element is Expr.Spread spread)
+            {
+                // Rest: target = _srcN.slice(i). Must be the final element.
+                LowerAssignmentTarget(spread.Expression, MakeSliceCall(src, i, line), stmts, line);
+                break;
+            }
+
+            LowerElementWithDefault(element, new Expr.GetIndex(src, new Expr.Literal((double)i)), stmts, line);
+        }
+    }
+
+    private void LowerObjectAssignmentTarget(Expr.ObjectLiteral obj, Expr source, List<Stmt> stmts, int line)
+    {
+        // _srcN = source — object patterns read properties directly (no iterator normalization).
+        Token srcTemp = GenerateTempVar(line);
+        stmts.Add(new Stmt.Var(srcTemp, null, source));
+        Expr src = new Expr.Variable(srcTemp);
+        var usedKeys = new List<Expr>();
+
+        foreach (var prop in obj.Properties)
+        {
+            if (prop.IsSpread)
+            {
+                // Rest: target = __objectRest(_srcN, [usedKeys]). Must be last.
+                LowerAssignmentTarget(prop.Value, MakeObjectRestCall(src, usedKeys, line), stmts, line);
+                break;
+            }
+            if (prop.Kind is not Expr.ObjectPropertyKind.Value || prop.Key is null)
+                throw new Exception("Invalid assignment target.");  // getters/setters/methods aren't patterns
+
+            Expr access = MakePropertyAccess(src, prop.Key, usedKeys);
+            LowerElementWithDefault(prop.Value, access, stmts, line);
+        }
+    }
+
+    // Lowers one pattern element / property value to an assignment, peeling off a default (`= expr`)
+    // that the eager parser captured as an Assign (variable target) or Set/SetIndex/SetPrivate (member
+    // target). `?? default` applies the default when the read is null/undefined (matching the existing
+    // declaration desugaring; ECMA-262 is undefined-only — tracked separately).
+    private void LowerElementWithDefault(Expr element, Expr access, List<Stmt> stmts, int line)
+    {
+        switch (Unwrap(element))
+        {
+            case Expr.Assign def:
+                LowerAssignmentTarget(new Expr.Variable(def.Name),
+                    new Expr.NullishCoalescing(access, def.Value), stmts, line);
+                break;
+            case Expr.Set def:
+                LowerAssignmentTarget(new Expr.Get(def.Object, def.Name),
+                    new Expr.NullishCoalescing(access, def.Value), stmts, line);
+                break;
+            case Expr.SetIndex def:
+                LowerAssignmentTarget(new Expr.GetIndex(def.Object, def.Index),
+                    new Expr.NullishCoalescing(access, def.Value), stmts, line);
+                break;
+            case Expr.SetPrivate def:
+                LowerAssignmentTarget(new Expr.GetPrivate(def.Object, def.Name),
+                    new Expr.NullishCoalescing(access, def.Value), stmts, line);
+                break;
+            case Expr.DestructuringAssign:
+                // A nested pattern WITH a default (`[[a] = []]`, `{p: {x} = {}}`) was eagerly lowered,
+                // losing its raw target; recovering it needs cover-grammar reparsing. Rare — see #779.
+                throw new Exception("Nested destructuring with a default is not supported in assignment destructuring.");
+            default:
+                LowerAssignmentTarget(element, access, stmts, line);
+                break;
+        }
+    }
+
+    private static Expr MakeAssignmentExpr(Expr target, Expr value) => Unwrap(target) switch
+    {
+        Expr.Variable v => new Expr.Assign(v.Name, value),
+        Expr.Get g => new Expr.Set(g.Object, g.Name, value),
+        Expr.GetIndex gi => new Expr.SetIndex(gi.Object, gi.Index, value),
+        Expr.GetPrivate gp => new Expr.SetPrivate(gp.Object, gp.Name, value),
+        _ => throw new Exception("Invalid assignment target.")
+    };
+
+    private Expr MakePropertyAccess(Expr src, Expr.PropertyKey key, List<Expr> usedKeys)
+    {
+        switch (key)
+        {
+            case Expr.IdentifierKey ik:
+                usedKeys.Add(new Expr.Literal(ik.Name.Lexeme));
+                return new Expr.Get(src, ik.Name);
+            case Expr.LiteralKey lk:
+                string name = lk.Literal.Type == TokenType.STRING
+                    ? (string)lk.Literal.Literal!
+                    : lk.Literal.Literal!.ToString()!;
+                usedKeys.Add(new Expr.Literal(name));
+                return new Expr.GetIndex(src, new Expr.Literal(name));
+            case Expr.ComputedKey ck:
+                // A computed key is dynamic, so it cannot be added to the static rest-exclusion list
+                // (a `{[k]: v, ...rest}` pattern would over-include — a narrow, rare edge).
+                return new Expr.GetIndex(src, ck.Expression);
+            default:
+                throw new Exception("Invalid assignment target.");
+        }
+    }
+
+    private static Expr MakeArrayDestructureCall(Expr source, int line) => new Expr.Call(
+        new Expr.Variable(new Token(TokenType.IDENTIFIER, "__arrayDestructure", null, line)),
+        new Token(TokenType.RIGHT_PAREN, ")", null, line), null, [source]);
+
+    private static Expr MakeSliceCall(Expr src, int index, int line) => new Expr.Call(
+        new Expr.Get(src, new Token(TokenType.IDENTIFIER, "slice", null, line)),
+        new Token(TokenType.RIGHT_PAREN, ")", null, line), null, [new Expr.Literal((double)index)]);
+
+    private static Expr MakeObjectRestCall(Expr src, List<Expr> usedKeys, int line) => new Expr.Call(
+        new Expr.Variable(new Token(TokenType.IDENTIFIER, "__objectRest", null, line)),
+        new Token(TokenType.RIGHT_PAREN, ")", null, line), null,
+        [src, new Expr.ArrayLiteral(usedKeys)]);
 }

--- a/Parsing/Parser.Expressions.cs
+++ b/Parsing/Parser.Expressions.cs
@@ -62,7 +62,12 @@ public partial class Parser
 
         if (Match(TokenType.EQUAL))
         {
+            Token equals = Previous();
             Expr value = Assignment();
+            // Array/object literal on the left of `=` is assignment destructuring (#754): the targets
+            // are existing l-values, lowered to assignment statements reusing the #685 iterator path.
+            if (IsDestructuringAssignmentTarget(expr))
+                return BuildDestructuringAssignment(expr, value, equals.Line);
             return DispatchAssignmentTarget(expr, value, "Invalid assignment target.",
                 onVariable: (name, val) => new Expr.Assign(name, val),
                 onGet: (get, val) => new Expr.Set(get.Object, get.Name, val),

--- a/Parsing/Visitors/AstVisitorBase.cs
+++ b/Parsing/Visitors/AstVisitorBase.cs
@@ -26,6 +26,7 @@ public abstract class AstVisitorBase
         switch (expr)
         {
             case Expr.Comma e: VisitComma(e); break;
+            case Expr.DestructuringAssign e: VisitDestructuringAssign(e); break;
             case Expr.Binary e: VisitBinary(e); break;
             case Expr.Logical e: VisitLogical(e); break;
             case Expr.NullishCoalescing e: VisitNullishCoalescing(e); break;
@@ -129,6 +130,15 @@ public abstract class AstVisitorBase
     {
         Visit(expr.Left);
         Visit(expr.Right);
+    }
+
+    protected virtual void VisitDestructuringAssign(Expr.DestructuringAssign expr)
+    {
+        // The lowered assignment statements carry the rhs, per-target writes, and any nested temps;
+        // walking them (plus the result value) exposes every captured variable / declared temp.
+        foreach (var stmt in expr.Assignments)
+            Visit(stmt);
+        Visit(expr.ResultValue);
     }
 
     protected virtual void VisitBinary(Expr.Binary expr)

--- a/Parsing/Visitors/IExprVisitor.cs
+++ b/Parsing/Visitors/IExprVisitor.cs
@@ -13,6 +13,7 @@ namespace SharpTS.Parsing.Visitors;
 public interface IExprVisitor<out TResult>
 {
     TResult VisitComma(Expr.Comma expr);
+    TResult VisitDestructuringAssign(Expr.DestructuringAssign expr);
     TResult VisitBinary(Expr.Binary expr);
     TResult VisitLogical(Expr.Logical expr);
     TResult VisitNullishCoalescing(Expr.NullishCoalescing expr);

--- a/SharpTS.Tests/CompilerTests/ILVerificationTests.cs
+++ b/SharpTS.Tests/CompilerTests/ILVerificationTests.cs
@@ -1490,6 +1490,56 @@ public class ILVerificationTests
     // T (so storing the $Undefined sentinel threw InvalidCastException), or double? for a value T
     // (unverifiable IL). Such parameters must use an object slot, as locals already do. The body
     // reassigns the parameter to `undefined` and observes it, exercising both store and read.
+    // #751: indexing a typed-array (number[]/boolean[]) variable emitted an unverifiable merge — the
+    // typed List<T> fast path left a native double/bool on the stack where the sibling
+    // $Array/List<object>/fallback paths (and every consumer, which reads the clobbered
+    // StackType=Unknown) expected an object ref. It ran only because the typed branch is dead for an
+    // $Array-backed value. The fast path now boxes its result so every branch converges on object.
+    // Covers GET and SET, number and boolean, typed-backed (empty literal + push) and object-backed
+    // (non-empty literal) arrays, and the original spread/destructure-of-a-numeric-Set repro.
+    [Fact]
+    public void TypedArrayIndexReadAndWrite_PassesILVerification()
+    {
+        var source = """
+            const a: number[] = [1, 2, 3];
+            const x = a[0];
+            a[1] = 9;
+            const b: boolean[] = [true, false];
+            const y = b[0];
+            b[1] = true;
+            const c: number[] = [];
+            c.push(5);
+            let sum = 0;
+            for (let i = 0; i < 3; i++) sum += a[i];
+            console.log(x, a[1], y, b[1], c[0], sum);
+            """;
+
+        var (errors, output) = TestHarness.CompileVerifyAndRun(source);
+
+        Assert.Empty(errors);
+        Assert.Equal("1 9 true true 5 13\n", output);
+        Assert.Equal(output, TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void NumericSetSpreadAndDestructure_PassesILVerification()
+    {
+        // #751 original repro: materializing a numeric Set via spread, then index-reading the
+        // resulting number[], and array-destructuring a numeric Set (inherits the same path).
+        var source = """
+            const out = [...new Set<number>([1, 2, 3])];
+            console.log(out[0], out.length);
+            const [first, second] = new Set<number>([10, 20]);
+            console.log(first, second);
+            """;
+
+        var (errors, output) = TestHarness.CompileVerifyAndRun(source);
+
+        Assert.Empty(errors);
+        Assert.Equal("1 3\n10 20\n", output);
+        Assert.Equal(output, TestHarness.RunInterpreted(source));
+    }
+
     [Fact]
     public void UndefinedUnionParameterReassignment_PassesILVerification()
     {

--- a/SharpTS.Tests/ParsingTests/AstVisitorTests.cs
+++ b/SharpTS.Tests/ParsingTests/AstVisitorTests.cs
@@ -15,6 +15,7 @@ public class AstVisitorTests
     private class ExprTypeCollector : IExprVisitor<Type>
     {
         public Type VisitComma(Expr.Comma expr) => typeof(Expr.Comma);
+        public Type VisitDestructuringAssign(Expr.DestructuringAssign expr) => typeof(Expr.DestructuringAssign);
         public Type VisitBinary(Expr.Binary expr) => typeof(Expr.Binary);
         public Type VisitLogical(Expr.Logical expr) => typeof(Expr.Logical);
         public Type VisitNullishCoalescing(Expr.NullishCoalescing expr) => typeof(Expr.NullishCoalescing);

--- a/SharpTS.Tests/SharedTests/DestructuringTests.cs
+++ b/SharpTS.Tests/SharedTests/DestructuringTests.cs
@@ -339,4 +339,148 @@ public class DestructuringTests
     }
 
     #endregion
+
+    #region String Rest Element (#753)
+
+    // #753: a rest element over a STRING source must collect a fresh ARRAY of characters, not bind
+    // the trailing substring. Non-rest character bindings are identical either way.
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ArrayDestructuring_StringRest_BindsCharArray(ExecutionMode mode)
+    {
+        var source = """
+            const [a, ...rest] = "hello";
+            console.log(a);
+            console.log(Array.isArray(rest));
+            console.log(rest.length);
+            console.log(rest.join("-"));
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("h\ntrue\n4\ne-l-l-o\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ArrayDestructuring_StringNonRest_Unchanged(ExecutionMode mode)
+    {
+        var source = """
+            const [a, b, c = "Z"] = "hi";
+            console.log(a, b, c);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("h i Z\n", output);
+    }
+
+    #endregion
+
+    #region Assignment Destructuring (#754)
+
+    // #754: destructuring assignment to EXISTING l-values (no const/let), array and object patterns.
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AssignmentDestructuring_ArrayBasicAndSwap(ExecutionMode mode)
+    {
+        var source = """
+            let a = 0, b = 0;
+            [a, b] = [1, 2];
+            console.log(a, b);
+            [a, b] = [b, a];
+            console.log(a, b);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("1 2\n2 1\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AssignmentDestructuring_DefaultsHolesAndRest(ExecutionMode mode)
+    {
+        var source = """
+            let c = 0, d = 0;
+            [c, d = 9] = [5];
+            console.log(c, d);
+            let x, y;
+            [, x, , y] = [1, 2, 3, 4];
+            console.log(x, y);
+            let head: number, tail: number[];
+            [head, ...tail] = [1, 2, 3, 4];
+            console.log(head, Array.isArray(tail), tail.join(","));
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("5 9\n2 4\n1 true 2,3,4\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AssignmentDestructuring_MemberTargets(ExecutionMode mode)
+    {
+        var source = """
+            const o: any = {};
+            const arr: number[] = [0, 0];
+            [o.p, arr[1]] = [10, 20];
+            console.log(o.p, arr[1]);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("10 20\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AssignmentDestructuring_Object_RenameRestAndDefault(ExecutionMode mode)
+    {
+        var source = """
+            let pa: number, pb: number, rr: any;
+            ({ a: pa, b: pb, ...rr } = { a: 1, b: 2, z: 9 });
+            console.log(pa, pb, JSON.stringify(rr));
+            const src: any = { p: 3 };
+            let ox, oy;
+            ({ p: ox, q: oy = 4 } = src);
+            console.log(ox, oy);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("1 2 {\"z\":9}\n3 4\n", output);
+    }
+
+    // The right-hand side is normalized through the #685 iterator protocol, so a non-indexable
+    // iterable (Set) destructures by assignment just like a declaration.
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AssignmentDestructuring_IteratorSource(ExecutionMode mode)
+    {
+        var source = """
+            let s1, s2;
+            [s1, s2] = new Set<number>([11, 22]);
+            console.log(s1, s2);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("11 22\n", output);
+    }
+
+    // An assignment expression evaluates to its right-hand side (the ORIGINAL rhs, not the
+    // normalized array), so it composes in expression position and chains.
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AssignmentDestructuring_ExpressionPositionAndChained(ExecutionMode mode)
+    {
+        var source = """
+            let e1, e2;
+            const ret = ([e1, e2] = [100, 200]);
+            console.log(JSON.stringify(ret), e1, e2);
+            let a, b, c, d;
+            [a, b] = [c, d] = [1, 2];
+            console.log(a, b, c, d);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("[100,200] 100 200\n1 2 1 2\n", output);
+    }
+
+    #endregion
 }

--- a/TypeSystem/ControlFlow/LoopAssignmentAnalyzer.cs
+++ b/TypeSystem/ControlFlow/LoopAssignmentAnalyzer.cs
@@ -151,6 +151,14 @@ public static class LoopAssignmentAnalyzer
     {
         switch (expr)
         {
+            case Expr.DestructuringAssign destructuring:
+                // The destructured targets are written by the lowered assignment statements; collecting
+                // their paths keeps loop-narrowing invalidation sound for `[a, b] = ...` in a loop (#754).
+                foreach (var stmt in destructuring.Assignments)
+                    CollectAssignedPaths(stmt, paths);
+                CollectAssignedPathsFromExpr(destructuring.ResultValue, paths);
+                break;
+
             case Expr.Assign assign:
                 paths.Add(new NarrowingPath.Variable(assign.Name.Lexeme));
                 CollectAssignedPathsFromExpr(assign.Value, paths);

--- a/TypeSystem/ControlFlow/NarrowingPropagator.cs
+++ b/TypeSystem/ControlFlow/NarrowingPropagator.cs
@@ -175,6 +175,13 @@ public sealed class NarrowingPropagator
     {
         switch (expr)
         {
+            case Expr.DestructuringAssign destructuring:
+                // Process the lowered assignment statements so each destructured target invalidates its
+                // narrowing (`[a, b] = ...` reassigns a and b), then the result value (#754).
+                foreach (var stmt in destructuring.Assignments)
+                    context = ProcessStatementForNarrowing(stmt, context);
+                return ProcessExpressionForNarrowing(destructuring.ResultValue, context);
+
             case Expr.Assign assign:
                 var varPath = new NarrowingPath.Variable(assign.Name.Lexeme);
                 return context.Invalidate(varPath);

--- a/TypeSystem/TypeChecker.Expressions.cs
+++ b/TypeSystem/TypeChecker.Expressions.cs
@@ -144,6 +144,16 @@ public partial class TypeChecker
     // Comma (sequence) operator - evaluates all, returns type of last
     internal TypeInfo VisitComma(Expr.Comma expr) { CheckExpr(expr.Left); return CheckExpr(expr.Right); }
 
+    // Assignment destructuring (#754): check the lowered statements (which declare the rhs temp and
+    // validate each target write — e.g. assigning a number element to a `string` target raises TS2322),
+    // then report the result type as the rhs's, since the expression evaluates to its right-hand side.
+    internal TypeInfo VisitDestructuringAssign(Expr.DestructuringAssign expr)
+    {
+        foreach (var stmt in expr.Assignments)
+            CheckStmt(stmt);
+        return CheckExpr(expr.ResultValue);
+    }
+
     // Binary/logical operators (TypeChecker.Operators.cs)
     internal TypeInfo VisitBinary(Expr.Binary expr) => CheckBinary(expr);
     internal TypeInfo VisitLogical(Expr.Logical expr) => CheckLogical(expr);

--- a/TypeSystem/TypeChecker.Iterables.cs
+++ b/TypeSystem/TypeChecker.Iterables.cs
@@ -210,12 +210,15 @@ public partial class TypeChecker
     /// <summary>
     /// Computes the static type produced by the <c>__arrayDestructure</c> helper (#685), which
     /// normalizes an array binding-pattern source through the iterator protocol. Index-addressable
-    /// sources (arrays, tuples, strings, <c>any</c>) pass through with their precise type so the
-    /// desugared positional index access stays accurate — notably tuples keep their per-position
-    /// element types. Any other iterable (Set, Map, generators, <c>[Symbol.iterator]</c> objects)
-    /// becomes <c>Array&lt;element&gt;</c>, so the subsequent <c>_dest0[i]</c> reads the element type
-    /// instead of erroring. A non-iterable, non-indexable source is returned unchanged so the existing
-    /// index-access diagnostic still fires.
+    /// sources (arrays, tuples, <c>any</c>) pass through with their precise type so the desugared
+    /// positional index access stays accurate — notably tuples keep their per-position element types.
+    /// Any other iterable (Set, Map, generators, <c>[Symbol.iterator]</c> objects) becomes
+    /// <c>Array&lt;element&gt;</c>, so the subsequent <c>_dest0[i]</c> reads the element type instead of
+    /// erroring. A <b>string</b> is deliberately NOT passed through: it iterates to <c>string[]</c> so a
+    /// rest element binds a fresh array (<c>const [a, ...rest] = "hi"</c> → <c>rest: string[]</c>),
+    /// matching ECMA-262 instead of binding the trailing substring (#753); non-rest element types are
+    /// unchanged (<c>string</c> either way). A non-iterable, non-indexable source is returned unchanged
+    /// so the existing index-access diagnostic still fires.
     /// </summary>
     private TypeInfo NormalizeArrayDestructureSourceType(TypeInfo sourceType)
     {
@@ -223,8 +226,6 @@ public partial class TypeChecker
         {
             case TypeInfo.Array:
             case TypeInfo.Tuple:
-            case TypeInfo.String:
-            case TypeInfo.StringLiteral:
             case TypeInfo.Any:
                 return sourceType;
         }


### PR DESCRIPTION
Completes three issues from the #685 array-destructuring cluster.

## #754 — Array/object assignment destructuring (without declaration)

`[a, b] = rhs` and `({ a, b } = rhs)` (assigning to **existing** l-values) now parse and run in both interpreter and compiled mode.

- New `Expr.DestructuringAssign` carries the parser-lowered assignment statements (reusing the #685 `__arrayDestructure` iterator path and `__objectRest`) plus the **original** rhs as the result value. Every backend lowers it identically — run the statements, yield the result — so async/generator contexts work for free (each statement goes through the normal `EmitStatement`/`ExecuteStatementAsync` path).
- Supported: variables, member/index/private targets, leaf & member defaults, holes, rest (binds a real `Array`), nested patterns (no default), object shorthand/rename/rest/computed-key/string-key, iterator sources (Set/Map/generators), expression position, chaining (`[a,b]=[c,d]=x`), and `await` in the rhs.
- Spec semantics verified: the rhs is evaluated **once**, targets are written left-to-right after their receivers are evaluated, and the expression evaluates to the **original** rhs (`([a,b]="hi") === "hi"`).

## #753 — String rest element binds a substring instead of an array

`const [a, ...rest] = "hello"` now binds `rest = ["e","l","l","o"]` (a fresh `Array`), matching ECMA-262, instead of the substring `"ello"`. String is dropped from the index-addressable pass-through in the type checker, interpreter (`NormalizeArrayDestructureSource`), and compiled `ArrayDestructureSource`/handler, so it materializes through the iterator path. Non-rest character bindings are byte-for-byte unchanged.

## #751 — Numeric Set/Map spread/destructure fails `--verify`

Root cause was broader than the title: **every** typed-array (`number[]`/`boolean[]`) index read/write emitted IL that fails `ILVerify`. The typed `List<T>` fast path left a native `double`/`bool` on the stack where the sibling `$Array`/`List<object>`/fallback paths — and every consumer, which reads the clobbered `StackType=Unknown` — expected an `object` ref (`StackUnexpected {Found=Double, Expected=ref 'object'}`). It only ran because the typed branch is dead code for an `$Array`-backed value. The fast path now boxes its result at all four sites (`GetIndex`/`SetIndex` × hoisted/non-hoisted), converging every branch on `object`. The fix follows this codebase's established "box a typed value before a generic object slot" pattern (#279/#344/#367). Behavior- and performance-neutral: the unboxed value was never actually consumed unboxed (the consumer always required a boxed object). The numeric `Set`/`Map` spread/destructure repro inherits the fix.

## Tests

- `DestructuringTests`: string-rest (#753) and assignment-destructuring (#754) cases — basics, swap, defaults/holes/rest, member targets, object rename/rest/default, iterator source, expression position, chaining — all over both execution modes.
- `ILVerificationTests`: typed-array index read+write (number & boolean, typed- and object-backed) and the numeric-Set spread/destructure repro (#751), each asserting clean IL verification + interpreter parity.
- Full suite green (13206 passing; the lone intermittent failure is a pre-existing async-gen timing flake, reproduces clean on re-run and is outside the touched areas).

## Conformance

The TSConformance subset (`assignmentCompatibility` + `conditional`) is unrelated to destructuring/parsing. Test262 runs `.js` with type-checking off; the runtime/parser changes here were validated via the spec-semantics checks above and the both-mode unit tests rather than the heavy, uninitialized-submodule + stale-baseline Test262 isolation.

## Follow-ups filed

#779 (nested pattern *with* a default in assignment destructuring), #780 (`{a = 5}` object-shorthand-default parse), #781 (typed-array rest → `Array`, interpreter), #782 (`new Uint8Array([...])` crashes compiled — pre-existing), #783 (mixed nested array-literal tuple inference — pre-existing, affects declaration too), #784 (destructuring default applies on `null` via `??` instead of `undefined`-only — pre-existing).