### PR TITLE
Fix un-buildable main: ParameterInfo[]/Type[] mismatch in generator instance stubs (re-enables #723/#737/#738/#739)

### DIFF
--- a/Compilation/ILCompiler.AsyncGenerators.cs
+++ b/Compilation/ILCompiler.AsyncGenerators.cs
@@ -371,9 +371,12 @@ public partial class ILCompiler
 
         // #725: instantiate the function display class and seed any captured-and-mutated parameter
         // into it (instance methods carry 'this' at arg 0, so user params start at arg 1). The stub
-        // params are typed, so value types are boxed before the store. No-op when no function DC.
+        // params are typed, so value types are boxed before the store. No-op when no function DC. Pass
+        // the CLR boxing types from the method's ACTUAL IL signature (same source as the field-seeding
+        // loop above), so widened/all-object slots are not spuriously boxed.
         if (funcDCKey != null)
-            EmitGeneratorFunctionDCInit(il, smBuilder.FunctionDCField, method, funcDCKey, paramOffset: 1, paramTypes);
+            EmitGeneratorFunctionDCInit(il, smBuilder.FunctionDCField, method, funcDCKey, paramOffset: 1,
+                paramTypes.Select(p => p.ParameterType).ToArray());
 
         // Return the state machine (which implements IAsyncEnumerable<object>)
         il.Emit(OpCodes.Ret);

--- a/Compilation/ILCompiler.Generators.cs
+++ b/Compilation/ILCompiler.Generators.cs
@@ -552,9 +552,12 @@ public partial class ILCompiler
         // into it so an arrow that writes that parameter shares the generator's storage. Instance
         // methods carry 'this' at arg 0, so user params start at arg 1 (paramOffset: 1). The stub
         // params are typed, so EmitGeneratorFunctionDCInit boxes value types before the store. No-op
-        // when the method has no function DC.
+        // when the method has no function DC. Pass the CLR boxing types from the method's ACTUAL IL
+        // signature (same source as the field-seeding loop above), so widened/all-object slots are not
+        // spuriously boxed.
         if (funcDCKey != null)
-            EmitGeneratorFunctionDCInit(il, smBuilder.FunctionDCField, method, funcDCKey, paramOffset: 1, paramTypes);
+            EmitGeneratorFunctionDCInit(il, smBuilder.FunctionDCField, method, funcDCKey, paramOffset: 1,
+                paramTypes.Select(p => p.ParameterType).ToArray());
 
         // Captured outer-scope variables are NOT copied into the state machine (#541): see the
         // free-function stub above. MoveNext reads/writes them live from their backing storage,


### PR DESCRIPTION
## What this fixes

`origin/main` currently **does not compile**:

```
Compilation/ILCompiler.AsyncGenerators.cs(376,107): error CS1503: Argument 6: cannot convert from 'System.Reflection.ParameterInfo[]' to 'System.Type[]?'
Compilation/ILCompiler.Generators.cs(557,107): error CS1503: Argument 6: cannot convert from 'System.Reflection.ParameterInfo[]' to 'System.Type[]?'
```

This is a **semantic merge conflict** between two independently-correct PRs that were merged without being rebased onto each other:

- **#769** (`e64f3adb`, compiled closures #724/#725) added `EmitGeneratorFunctionDCInit(…, Type[]? paramTypes)` and called it from the generator / async-generator **instance** stub methods, passing their `paramTypes` local (then a `Type[]`).
- **#786** (`b95b6945`, "Fix #720: async/generator private methods emit invalid IL") changed that same `paramTypes` local from the AST-resolved `Type[]` to `methodBuilder.GetParameters()` (a `ParameterInfo[]`) — deliberately, so boxing is decided from the method's **actual IL signature** (a private method's params are all `object` slots; boxing an AST-resolved `double` into an `object` slot is a `StackUnexpected`).

Each compiled in isolation; together a `ParameterInfo[]` flows into a `Type[]?` parameter → CS1503. (Neither side is #787 — that is simply what surfaced this when I went to verify it.)

## The fix

Convert at the two call sites with `.Select(p => p.ParameterType).ToArray()` — the dominant idiom in this codebase for `GetParameters()` → `Type[]` (`ILCompiler.Classes.Methods.cs:1250`, `Static.cs:438`, `Constructors.cs:363`). This preserves #720's "box from the actual IL signature" intent: for a private/all-object or #737-widened-to-`object` slot, `ParameterType` is `object`, so `IsValueType` is false and nothing is spuriously boxed — exactly matching the field-seeding loop directly above each call.

```diff
-            EmitGeneratorFunctionDCInit(il, smBuilder.FunctionDCField, method, funcDCKey, paramOffset: 1, paramTypes);
+            EmitGeneratorFunctionDCInit(il, smBuilder.FunctionDCField, method, funcDCKey, paramOffset: 1,
+                paramTypes.Select(p => p.ParameterType).ToArray());
```

(I considered widening the helper to `ParameterInfo[]?` instead, but it genuinely operates on `Type` — it boxes with the element and checks `.IsValueType` — and two of its four callers pass `null`; the call-site conversion is the smaller, more idiomatic change.)

## Why this matters / relation to #723 #737 #738 #739

The compiled default/optional-parameter cluster (#705/#723/#737/#738/#739) was implemented and merged in #787, but the later merge above left `main` un-buildable, so those features could not actually run. With the build repaired I verified all four issues' repros, compiled output matching the interpreter:

- **#723** instance/static method defaults — `new C().m(5)`→`7`, `C.st(5)`→`7`, string default→`xz` ✓
- **#737** value-type defaults on instance/static + generator methods, incl. the same-arity override-safety case ✓
- **#738** `--compile --ref-asm` value-call no longer shifts args (`f(4)`→`7`) ✓
- **#739** omitted optional reads `undefined` (`typeof`→`"undefined"`) ✓

Existing coverage `Generator_InstanceMethodCallbackMutatesCapturedParameter` — an instance generator method whose arrow mutates a captured **value-type** parameter, the exact path repaired here — exercises the boxing branch and passes. Full unit suite green (13352 passed, 0 failed, 1 skipped).

## Follow-ups filed (pre-existing gaps surfaced while verifying)

- **#790** — a base-typed call to a derived override that *adds* trailing optional params dispatches to the base method (a different-arity override is not a CLR vtable override). Affects value- and reference-type defaults and no-default optionals; distinct from the same-arity override group #787 handles.
- **#792** — a defaulted generator/async-generator parameter that is *also* captured by a nested arrow ignores its default on omitted args (the default prologue writes the state-machine field, but a captured param's live storage is the function-DC field). Intersection of #737 and #724/#725; reproduces for free-function generators too, so independent of this build fix.

No new tests added: the break is compile-time (caught by any build) and its runtime path is already covered; the two follow-ups are failing cases tracked as issues.

Fixes #723, #737, #738, #739.
