### PR TITLE
Fix #635, #634, #467, #592: async fn expressions, generator-arrow lifter traversal, namespace const, computed symbol-keyed class methods

### DIFF
--- a/Compilation/ILCompiler.Classes.Methods.cs
+++ b/Compilation/ILCompiler.Classes.Methods.cs
@@ -278,6 +278,28 @@ public partial class ILCompiler
     /// Defines method signatures and registers them in _classes.InstanceMethods without emitting bodies.
     /// Also pre-defines the constructor so it's available for EmitNew in async contexts.
     /// </summary>
+    /// <summary>
+    /// Computed symbol-keyed methods (`[Symbol.iterator]() {}`, `*[Symbol.iterator]() {}`,
+    /// `async *[Symbol.asyncIterator]() {}`) are implemented in the parser, type checker, and
+    /// interpreter (#592) but the IL backend has no symbol-method dispatch yet (#647). Fail with a
+    /// clear compile error rather than emitting a method under the synthetic "&lt;computed&gt;" name that
+    /// nothing can dispatch — which would otherwise surface as a confusing "not iterable" at runtime.
+    /// Called from both class-method phases so every class-declaration compile path is covered.
+    /// </summary>
+    private static void ThrowIfComputedSymbolMethod(Stmt.Class classStmt)
+    {
+        foreach (var method in classStmt.Methods)
+        {
+            if (method.ComputedKey != null)
+            {
+                throw new Exception(
+                    "Compile Error: computed symbol-keyed class methods (e.g. `[Symbol.iterator]()`) are not yet " +
+                    "supported in compiled mode (issue #647); they are supported in the interpreter. " +
+                    $"Class '{classStmt.Name.Lexeme}'.");
+            }
+        }
+    }
+
     private void DefineClassMethodsOnly(Stmt.Class classStmt)
     {
         // Skip @DotNetType external type classes - they don't have TypeBuilders
@@ -352,6 +374,8 @@ public partial class ILCompiler
         {
             _classes.StaticMethods[qualifiedClassName] = [];
         }
+
+        ThrowIfComputedSymbolMethod(classStmt);
 
         // Pre-define static methods (so they're available during async MoveNext emission).
         // Per-method idempotency check: in multi-module compilation this method runs twice
@@ -631,6 +655,8 @@ public partial class ILCompiler
         if (!_classes.Builders.TryGetValue(qualifiedClassName, out var typeBuilder))
             return;  // Skip if no TypeBuilder exists for this class
         var fieldsField = _classes.InstanceFieldsField[qualifiedClassName];
+
+        ThrowIfComputedSymbolMethod(classStmt);
 
         // Initialize static methods dictionary for this class
         if (!_classes.StaticMethods.ContainsKey(qualifiedClassName))

--- a/Execution/Interpreter.Async.cs
+++ b/Execution/Interpreter.Async.cs
@@ -182,9 +182,14 @@ public partial class Interpreter
         }
         else if (iterable is SharpTSInstance inst)
         {
-            var asyncIteratorFn = inst.GetBySymbol(SharpTSSymbol.AsyncIterator);
-            if (asyncIteratorFn != null)
+            // Route through GetInstanceSymbolValue so a declared `[Symbol.asyncIterator]() {...}`
+            // method on the class chain is found (already bound to the instance), not just an
+            // own data property.
+            var asyncIteratorFn = GetInstanceSymbolValue(inst, SharpTSSymbol.AsyncIterator);
+            if (asyncIteratorFn != null && asyncIteratorFn is not SharpTSUndefined)
             {
+                if (asyncIteratorFn is SharpTSArrowFunction arrowFunc)
+                    asyncIteratorFn = arrowFunc.Bind(inst);
                 if (asyncIteratorFn is ISharpTSCallable callable)
                     return callable.Call(this, []);
             }

--- a/Execution/Interpreter.Expressions.cs
+++ b/Execution/Interpreter.Expressions.cs
@@ -983,6 +983,12 @@ public partial class Interpreter
         {
             return getter.Bind(instance).Call(this, []);
         }
+        // Symbol-keyed method (`[Symbol.iterator]() {...}`): return the method bound to the
+        // instance (not invoked), exactly like `instance.namedMethod` returns a bound method.
+        if (instance.GetClass().FindSymbolMethod(symbol) is { } method)
+        {
+            return SharpTSClass.BindMethod(method, instance);
+        }
         return SharpTSUndefined.Instance;
     }
 
@@ -995,6 +1001,13 @@ public partial class Interpreter
         if (klass.FindStaticSymbolGetter(symbol) is { } getter)
         {
             return getter.BindStatic(klass).Call(this, []);
+        }
+        // Static symbol-keyed method (`static [Symbol.hasInstance]() {...}`): return it bound
+        // to the class receiver where possible (SharpTSFunction); other callable kinds are
+        // returned as-is.
+        if (klass.FindStaticSymbolMethod(symbol) is { } method)
+        {
+            return method is SharpTSFunction f ? f.BindStatic(klass) : method;
         }
         return klass.TryGetStaticBySymbol(symbol, out var value)
             ? value ?? SharpTSUndefined.Instance

--- a/Execution/Interpreter.Namespaces.cs
+++ b/Execution/Interpreter.Namespaces.cs
@@ -93,6 +93,7 @@ public partial class Interpreter
                 Stmt.Function f => f.Name.Lexeme,
                 Stmt.Class c => c.Name.Lexeme,
                 Stmt.Var v => v.Name.Lexeme,
+                Stmt.Const ct => ct.Name.Lexeme,
                 Stmt.Enum e => e.Name.Lexeme,
                 Stmt.Namespace n => n.Name.Lexeme,
                 Stmt.Interface => null,  // Type-only, no runtime value
@@ -109,6 +110,7 @@ public partial class Interpreter
                     Stmt.Function f => f.Name,
                     Stmt.Class c => c.Name,
                     Stmt.Var v => v.Name,
+                    Stmt.Const ct => ct.Name,
                     Stmt.Enum e => e.Name,
                     Stmt.Namespace n => n.Name,
                     _ => null

--- a/Execution/Interpreter.Statements.cs
+++ b/Execution/Interpreter.Statements.cs
@@ -786,13 +786,15 @@ public partial class Interpreter
             }
         }
 
-        // Check for Symbol.iterator on SharpTSInstance
+        // Check for Symbol.iterator on SharpTSInstance. Routes through GetInstanceSymbolValue so a
+        // declared `[Symbol.iterator]() {...}` method on the class chain (not just an own data
+        // property) is found; that path returns the method already bound to the instance.
         if (iterable is SharpTSInstance inst)
         {
-            var iteratorFn = inst.GetBySymbol(SharpTSSymbol.Iterator);
-            if (iteratorFn != null)
+            var iteratorFn = GetInstanceSymbolValue(inst, SharpTSSymbol.Iterator);
+            if (iteratorFn != null && iteratorFn is not SharpTSUndefined)
             {
-                // Bind 'this' to the instance if it's an arrow function
+                // Bind 'this' to the instance if it's an arrow function (own data-property case)
                 if (iteratorFn is SharpTSArrowFunction arrowFunc)
                 {
                     iteratorFn = arrowFunc.Bind(inst);
@@ -822,6 +824,18 @@ public partial class Interpreter
         else
         {
             throw new InterpreterException("[Symbol.iterator] must be a function.");
+        }
+
+        // A generator-returning iterator method (`*[Symbol.iterator]() { yield ... }`) yields a
+        // SharpTSGenerator, which is itself directly enumerable and has no gettable `next` data
+        // property — enumerate it directly rather than via the property-based next() protocol below.
+        if (iterator is SharpTSGenerator genIterator)
+        {
+            foreach (var item in genIterator)
+            {
+                yield return item;
+            }
+            yield break;
         }
 
         // Iterate using the iterator protocol

--- a/Execution/Interpreter.cs
+++ b/Execution/Interpreter.cs
@@ -2222,6 +2222,10 @@ public partial class Interpreter : IDisposable
             }
         }
 
+        // Symbol-keyed computed methods (`[Symbol.iterator]() {...}`) can't go into the string
+        // method dictionaries; collected here and attached to the class after construction.
+        List<(SharpTSSymbol Symbol, ISharpTSCallable Func, bool IsStatic)>? symbolMethods = null;
+
         // Separate static and instance methods (skip overload signatures with no body)
         foreach (Stmt.Function method in classStmt.Methods.Where(m => m.Body != null))
         {
@@ -2235,6 +2239,23 @@ public partial class Interpreter : IDisposable
                 func = new SharpTSGeneratorFunction(method, _environment);
             else
                 func = new SharpTSFunction(method, _environment);
+
+            // Computed method names (`[Symbol.iterator]() {...}`) are evaluated at
+            // class-definition time, like computed accessor/field keys. Symbol-valued keys
+            // land in the class's symbol-method table; string/number keys fold into the
+            // regular method dictionaries.
+            if (method.ComputedKey != null)
+            {
+                object? key = Evaluate(method.ComputedKey);
+                if (key is SharpTSSymbol symbolKey)
+                {
+                    (symbolMethods ??= []).Add((symbolKey, func, method.IsStatic));
+                    continue;
+                }
+                string keyStr = PropertyKeyConverter.ToPropertyKeyString(key);
+                (method.IsStatic ? staticMethods : methods)[keyStr] = func;
+                continue;
+            }
 
             if (method.IsPrivate)
             {
@@ -2425,6 +2446,14 @@ public partial class Interpreter : IDisposable
             foreach (var (symbol, func, isStatic, isGetter) in symbolAccessors)
             {
                 klass.AddSymbolAccessor(symbol, func, isStatic, isGetter);
+            }
+        }
+
+        if (symbolMethods != null)
+        {
+            foreach (var (symbol, func, isStatic) in symbolMethods)
+            {
+                klass.AddSymbolMethod(symbol, func, isStatic);
             }
         }
 

--- a/Parsing/AST.cs
+++ b/Parsing/AST.cs
@@ -381,8 +381,10 @@ public abstract record Stmt
     /// IsAsync indicates this is an async function that returns a Promise.
     /// IsGenerator indicates this is a generator function (function*) that can yield values.
     /// Decorators contains any @decorator annotations applied to this function/method.
+    /// ComputedKey, when set, is the expression of a computed method name in a class body
+    /// (e.g. <c>[Symbol.iterator]() {}</c>); Name is then a synthetic <c>&lt;computed&gt;</c> token.
     /// </summary>
-    public record Function(Token Name, List<TypeParam>? TypeParams, string? ThisType, List<Parameter> Parameters, List<Stmt>? Body, string? ReturnType, bool IsStatic = false, AccessModifier Access = AccessModifier.Public, bool IsAbstract = false, bool IsOverride = false, bool IsAsync = false, bool IsGenerator = false, List<Decorator>? Decorators = null, bool IsPrivate = false, bool IsDeclare = false) : Stmt;
+    public record Function(Token Name, List<TypeParam>? TypeParams, string? ThisType, List<Parameter> Parameters, List<Stmt>? Body, string? ReturnType, bool IsStatic = false, AccessModifier Access = AccessModifier.Public, bool IsAbstract = false, bool IsOverride = false, bool IsAsync = false, bool IsGenerator = false, List<Decorator>? Decorators = null, bool IsPrivate = false, bool IsDeclare = false, Expr? ComputedKey = null) : Stmt;
     public record Parameter(Token Name, string? Type, Expr? DefaultValue = null, bool IsRest = false, bool IsParameterProperty = false, AccessModifier? Access = null, bool IsReadonly = false, bool IsOptional = false, List<Decorator>? Decorators = null);
     /// <summary>
     /// Class field declaration. For computed property names (e.g., [Symbol("key")]: type),

--- a/Parsing/GeneratorArrowLifter.cs
+++ b/Parsing/GeneratorArrowLifter.cs
@@ -111,6 +111,13 @@ internal sealed class GeneratorArrowLifter
             Stmt.Block b => RewriteBlock(b),
             Stmt.If i => RewriteIf(i),
             Stmt.While w => RewriteWhile(w),
+            Stmt.DoWhile dw => RewriteDoWhile(dw),
+            Stmt.For f => RewriteFor(f),
+            Stmt.ForOf fo => RewriteForOf(fo),
+            Stmt.ForIn fi => RewriteForIn(fi),
+            Stmt.TryCatch t => RewriteTryCatch(t),
+            Stmt.Switch sw => RewriteSwitch(sw),
+            Stmt.LabeledStatement l => RewriteLabeled(l),
             Stmt.Function f => RewriteFunction(f),
             _ => stmt,
         };
@@ -156,6 +163,85 @@ internal sealed class GeneratorArrowLifter
         var newBody = RewriteStmt(w.Body);
         if (ReferenceEquals(newCond, w.Condition) && ReferenceEquals(newBody, w.Body)) return w;
         return new Stmt.While(newCond, newBody);
+    }
+
+    private Stmt RewriteDoWhile(Stmt.DoWhile d)
+    {
+        var newBody = RewriteStmt(d.Body);
+        var newCond = RewriteExpr(d.Condition);
+        if (ReferenceEquals(newBody, d.Body) && ReferenceEquals(newCond, d.Condition)) return d;
+        return new Stmt.DoWhile(newBody, newCond);
+    }
+
+    private Stmt RewriteFor(Stmt.For f)
+    {
+        var newInit = f.Initializer is null ? null : RewriteStmt(f.Initializer);
+        var newCond = f.Condition is null ? null : RewriteExpr(f.Condition);
+        var newIncr = f.Increment is null ? null : RewriteExpr(f.Increment);
+        var newBody = RewriteStmt(f.Body);
+        if ((f.Initializer is null || ReferenceEquals(newInit, f.Initializer))
+            && (f.Condition is null || ReferenceEquals(newCond, f.Condition))
+            && (f.Increment is null || ReferenceEquals(newIncr, f.Increment))
+            && ReferenceEquals(newBody, f.Body))
+            return f;
+        return new Stmt.For(newInit, newCond, newIncr, newBody);
+    }
+
+    private Stmt RewriteForOf(Stmt.ForOf f)
+    {
+        var newIterable = RewriteExpr(f.Iterable);
+        var newBody = RewriteStmt(f.Body);
+        if (ReferenceEquals(newIterable, f.Iterable) && ReferenceEquals(newBody, f.Body)) return f;
+        return f with { Iterable = newIterable, Body = newBody };
+    }
+
+    private Stmt RewriteForIn(Stmt.ForIn f)
+    {
+        var newObject = RewriteExpr(f.Object);
+        var newBody = RewriteStmt(f.Body);
+        if (ReferenceEquals(newObject, f.Object) && ReferenceEquals(newBody, f.Body)) return f;
+        return f with { Object = newObject, Body = newBody };
+    }
+
+    private Stmt RewriteTryCatch(Stmt.TryCatch t)
+    {
+        var newTry = RewriteListIfChanged(t.TryBlock, RewriteStmt);
+        var newCatch = t.CatchBlock is null ? null : RewriteListIfChanged(t.CatchBlock, RewriteStmt);
+        var newFinally = t.FinallyBlock is null ? null : RewriteListIfChanged(t.FinallyBlock, RewriteStmt);
+        if (ReferenceEquals(newTry, t.TryBlock)
+            && (t.CatchBlock is null || ReferenceEquals(newCatch, t.CatchBlock))
+            && (t.FinallyBlock is null || ReferenceEquals(newFinally, t.FinallyBlock)))
+            return t;
+        return t with { TryBlock = newTry, CatchBlock = newCatch, FinallyBlock = newFinally };
+    }
+
+    private Stmt RewriteSwitch(Stmt.Switch s)
+    {
+        var newSubject = RewriteExpr(s.Subject);
+        List<Stmt.SwitchCase>? newCases = null;
+        for (int i = 0; i < s.Cases.Count; i++)
+        {
+            var c = s.Cases[i];
+            var newValue = RewriteExpr(c.Value);
+            var newBody = RewriteListIfChanged(c.Body, RewriteStmt);
+            if (!ReferenceEquals(newValue, c.Value) || !ReferenceEquals(newBody, c.Body))
+            {
+                newCases ??= new List<Stmt.SwitchCase>(s.Cases);
+                newCases[i] = new Stmt.SwitchCase(newValue, newBody);
+            }
+        }
+        var newDefault = s.DefaultBody is null ? null : RewriteListIfChanged(s.DefaultBody, RewriteStmt);
+        if (ReferenceEquals(newSubject, s.Subject)
+            && newCases is null
+            && (s.DefaultBody is null || ReferenceEquals(newDefault, s.DefaultBody)))
+            return s;
+        return new Stmt.Switch(newSubject, newCases ?? s.Cases, newDefault);
+    }
+
+    private Stmt RewriteLabeled(Stmt.LabeledStatement l)
+    {
+        var newStmt = RewriteStmt(l.Statement);
+        return ReferenceEquals(newStmt, l.Statement) ? l : new Stmt.LabeledStatement(l.Label, newStmt);
     }
 
     private Stmt RewriteFunction(Stmt.Function f)

--- a/Parsing/Parser.Classes.cs
+++ b/Parsing/Parser.Classes.cs
@@ -328,8 +328,25 @@ public partial class Parser
                 Expr computedKey = Expression();
                 Consume(TokenType.RIGHT_BRACKET, "Expect ']' after computed property name.");
 
-                // Create a synthetic token for the field name (for error reporting)
+                // Create a synthetic token for the field/method name (for error reporting)
                 Token syntheticName = new Token(TokenType.IDENTIFIER, "<computed>", null, Previous().Line);
+
+                // Computed METHOD: [expr](...) {...}, generic [expr]<T>(...) {...}, and the
+                // generator / async variants (*[expr]() / async [expr]()) — the `*` and `async`
+                // markers were already consumed above into isMemberGenerator / isMemberAsync.
+                // Stored as a Stmt.Function carrying ComputedKey (e.g. [Symbol.iterator]() {}).
+                if (Check(TokenType.LEFT_PAREN) || Check(TokenType.LESS))
+                {
+                    if (isMemberAbstract)
+                    {
+                        throw new Exception($"Parse Error at line {Peek().Line}: Computed method names are not supported on abstract methods.");
+                    }
+
+                    var computedMethod = (Stmt.Function)FunctionDeclaration("method", isMemberAsync, isMemberGenerator, preParsedName: syntheticName, computedKey: computedKey);
+                    computedMethod = computedMethod with { IsStatic = isStatic, Access = access, IsOverride = isOverride, Decorators = memberDecorators };
+                    methods.Add(computedMethod);
+                    continue;
+                }
 
                 Consume(TokenType.COLON, "Expect ':' after computed property name.");
                 string typeAnnotation = ParseTypeAnnotation();

--- a/Parsing/Parser.Expressions.cs
+++ b/Parsing/Parser.Expressions.cs
@@ -973,9 +973,17 @@ public partial class Parser
             return new Expr.ObjectLiteral(properties);
         }
 
-        // async arrow function: async () => {} or async (x) => x
+        // async function expression / async arrow function
         if (Match(TokenType.ASYNC))
         {
+            // async function expression: async function [name](params) { body }
+            // (and async generator function expression: async function* () { ... }).
+            // Mirrors the plain `function`/`function*` expression handling above.
+            if (Match(TokenType.FUNCTION))
+            {
+                return FunctionExpression(isAsync: true);
+            }
+
             if (Check(TokenType.LESS))
             {
                 Expr? genericArrow = TryParseGenericArrowFunction(isAsync: true);
@@ -1448,7 +1456,7 @@ public partial class Parser
     /// Supports optional name (for named function expressions), generator syntax (function*),
     /// this parameter, and type annotations.
     /// </summary>
-    private Expr FunctionExpression()
+    private Expr FunctionExpression(bool isAsync = false)
     {
         // Check for generator function: function* () { }
         bool isGenerator = Match(TokenType.STAR);
@@ -1585,6 +1593,7 @@ public partial class Parser
             BlockBody: body,
             ReturnType: returnType,
             HasOwnThis: true,
+            IsAsync: isAsync,
             IsGenerator: isGenerator
         );
     }

--- a/Parsing/Parser.Functions.cs
+++ b/Parsing/Parser.Functions.cs
@@ -2,10 +2,16 @@ namespace SharpTS.Parsing;
 
 public partial class Parser
 {
-    private Stmt FunctionDeclaration(string kind, bool isAsync = false, bool isGenerator = false, bool isDeclare = false)
+    private Stmt FunctionDeclaration(string kind, bool isAsync = false, bool isGenerator = false, bool isDeclare = false, Token? preParsedName = null, Expr? computedKey = null)
     {
         Token name;
-        if (kind == "constructor" && Match(TokenType.CONSTRUCTOR))
+        if (preParsedName is not null)
+        {
+            // Computed method name ([expr]() {}) — the key was already parsed by the caller,
+            // which passes a synthetic <computed> token and the key expression in computedKey.
+            name = preParsedName;
+        }
+        else if (kind == "constructor" && Match(TokenType.CONSTRUCTOR))
         {
             name = Previous();
         }
@@ -157,7 +163,7 @@ public partial class Parser
         if (Match(TokenType.SEMICOLON))
         {
             // Overload signature - no body, just declaration
-            return new Stmt.Function(name, typeParams, thisType, parameters, null, returnType, IsAsync: isAsync, IsGenerator: isGenerator, IsDeclare: isDeclare);
+            return new Stmt.Function(name, typeParams, thisType, parameters, null, returnType, IsAsync: isAsync, IsGenerator: isGenerator, IsDeclare: isDeclare, ComputedKey: computedKey);
         }
 
         // Save current strict mode state before parsing function body
@@ -220,7 +226,7 @@ public partial class Parser
         // declarations + assignments. Cheap no-op if no `var` keywords are present.
         body = VarHoister.Hoist(body);
 
-        return new Stmt.Function(name, typeParams, thisType, parameters, body, returnType, IsAsync: isAsync, IsGenerator: isGenerator);
+        return new Stmt.Function(name, typeParams, thisType, parameters, body, returnType, IsAsync: isAsync, IsGenerator: isGenerator, ComputedKey: computedKey);
     }
 
     /// <summary>

--- a/Parsing/Parser.Namespaces.cs
+++ b/Parsing/Parser.Namespaces.cs
@@ -113,7 +113,9 @@ public partial class Parser
             {
                 return WrapIfExported(EnumDeclaration(isConst: true), isExported);
             }
-            return WrapIfExported(VarDeclaration(), isExported);
+            // Parse as Stmt.Const (not mutable Stmt.Var) so const-ness is preserved:
+            // literal-type narrowing applies and reassignment is flagged (#467, sibling of #428).
+            return WrapIfExported(VarDeclaration(isConst: true), isExported);
         }
         if (Match(TokenType.ENUM))
         {

--- a/Runtime/Types/SharpTSClass.cs
+++ b/Runtime/Types/SharpTSClass.cs
@@ -312,6 +312,25 @@ public class SharpTSClass(
     public SharpTSFunction? FindStaticSymbolSetter(SharpTSSymbol symbol)
         => _staticSymbolSetters?.GetValueOrDefault(symbol) ?? Superclass?.FindStaticSymbolSetter(symbol);
 
+    // Symbol-keyed methods (`[Symbol.iterator]() {...}`, `*[Symbol.iterator]() {...}`,
+    // `async [Symbol.asyncIterator]() {...}`). Like symbol accessors, the computed key is
+    // evaluated at class-definition time; symbol-valued keys land here (string-valued keys
+    // go into the regular method dictionaries). Lazy — most classes declare none.
+    private Dictionary<SharpTSSymbol, ISharpTSCallable>? _symbolMethods;
+    private Dictionary<SharpTSSymbol, ISharpTSCallable>? _staticSymbolMethods;
+
+    public void AddSymbolMethod(SharpTSSymbol symbol, ISharpTSCallable func, bool isStatic)
+    {
+        if (isStatic) (_staticSymbolMethods ??= [])[symbol] = func;
+        else (_symbolMethods ??= [])[symbol] = func;
+    }
+
+    public ISharpTSCallable? FindSymbolMethod(SharpTSSymbol symbol)
+        => _symbolMethods?.GetValueOrDefault(symbol) ?? Superclass?.FindSymbolMethod(symbol);
+
+    public ISharpTSCallable? FindStaticSymbolMethod(SharpTSSymbol symbol)
+        => _staticSymbolMethods?.GetValueOrDefault(symbol) ?? Superclass?.FindStaticSymbolMethod(symbol);
+
     public SharpTSFunction? FindGetter(string name)
     {
         // Check cache first

--- a/SharpTS.Tests/SharedTests/AsyncFunctionExpressionTests.cs
+++ b/SharpTS.Tests/SharedTests/AsyncFunctionExpressionTests.cs
@@ -1,0 +1,122 @@
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests;
+
+/// <summary>
+/// Regression tests for #635: an <c>async function</c> expression in expression position
+/// (e.g. <c>const f = async function () {}</c>) must parse. Previously the parser only
+/// accepted an async <em>arrow</em> after <c>async</c> and demanded a <c>(</c>, so any
+/// <c>async function …</c> expression produced a parse error. Mirrors the existing
+/// <c>function</c> / <c>function*</c> expression handling. Runs against both modes.
+/// </summary>
+public class AsyncFunctionExpressionTests
+{
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AsyncFunctionExpression_Anonymous_ReturnsPromise(ExecutionMode mode)
+    {
+        // The exact repro from #635.
+        var source = """
+            const af = async function () { return 9; };
+            af().then((v: number) => console.log(v));
+            """;
+        Assert.Equal("9\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AsyncFunctionExpression_Named_Works(ExecutionMode mode)
+    {
+        var source = """
+            const af = async function compute() { return 42; };
+            af().then((v: number) => console.log(v));
+            """;
+        Assert.Equal("42\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AsyncFunctionExpression_WithAwaitBody_Works(ExecutionMode mode)
+    {
+        var source = """
+            const af = async function () {
+                const a = await Promise.resolve(10);
+                const b = await Promise.resolve(20);
+                return a + b;
+            };
+            af().then((v: number) => console.log(v));
+            """;
+        Assert.Equal("30\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AsyncFunctionExpression_ImmediatelyInvoked_Works(ExecutionMode mode)
+    {
+        var source = """
+            (async function () {
+                console.log("start");
+                const v = await Promise.resolve(5);
+                console.log(v);
+            })();
+            """;
+        Assert.Equal("start\n5\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AsyncFunctionExpression_WithExplicitParams_Works(ExecutionMode mode)
+    {
+        var source = """
+            const af = async function (x: number, y: number) { return x + y; };
+            af(4, 3).then((v: number) => console.log(v));
+            """;
+        Assert.Equal("7\n", TestHarness.Run(source, mode));
+    }
+
+    [Fact]
+    public void AsyncFunctionExpression_DefaultParameter_Applied_Interpreted()
+    {
+        // The async function expression honors a parameter default. Asserted interpreted-only
+        // because compiled function expressions / arrows currently drop omitted-arg defaults
+        // (pre-existing, not specific to async function expressions — tracked by #646).
+        var source = """
+            const af = async function (x: number, y: number = 3) { return x + y; };
+            af(4).then((v: number) => console.log(v));
+            """;
+        Assert.Equal("7\n", TestHarness.RunInterpreted(source));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AsyncArrow_StillParses_NoRegression(ExecutionMode mode)
+    {
+        // The async-arrow path the original code already handled must keep working.
+        var source = """
+            const af = async () => 9;
+            af().then((v: number) => console.log(v));
+            """;
+        Assert.Equal("9\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AsyncGeneratorFunctionExpression_Works(ExecutionMode mode)
+    {
+        // `async function* () {}` is also enabled by the fix (FunctionExpression handles the
+        // trailing `*`). Consumed by an async function declaration so it exercises the
+        // GeneratorArrowLifter path in compiled mode. (for-await inside an async ARROW is a
+        // separate, pre-existing compiled bug — see #645 — so it is deliberately not used here.)
+        var source = """
+            const ag = async function* () { yield 1; yield 2; yield 3; };
+            async function run() {
+                let sum = 0;
+                for await (const x of ag()) sum += x;
+                console.log(sum);
+            }
+            run();
+            """;
+        Assert.Equal("6\n", TestHarness.Run(source, mode));
+    }
+}

--- a/SharpTS.Tests/SharedTests/ComputedSymbolKeyedMethodTests.cs
+++ b/SharpTS.Tests/SharedTests/ComputedSymbolKeyedMethodTests.cs
@@ -1,0 +1,155 @@
+using SharpTS.Tests.Infrastructure;
+using SharpTS.TypeSystem.Exceptions;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests;
+
+/// <summary>
+/// Regression tests for #592: a class body can declare a computed symbol-keyed method, including the
+/// canonical iterable hook <c>[Symbol.iterator]()</c> (plus the generator <c>*[Symbol.iterator]()</c>
+/// and async <c>async *[Symbol.asyncIterator]()</c> forms). Previously the parser rejected the
+/// computed <c>[</c> form for methods, so a user-defined iterable class couldn't be written at all.
+///
+/// Runtime behavior is asserted interpreted-only: compiled-mode dispatch is a tracked follow-up
+/// (#647) for which the IL backend deliberately raises a clear compile error (see the bottom test).
+/// </summary>
+public class ComputedSymbolKeyedMethodTests
+{
+    // ---- Interpreter runtime ----
+
+    [Fact]
+    public void ComputedIterator_ObjectReturningForm_ForOf()
+    {
+        // The exact repro shape from #592.
+        var source = """
+            class Range {
+              [Symbol.iterator]() {
+                let i = 0;
+                return { next() { return i < 2 ? { value: i++, done: false } : { value: 0, done: true }; } };
+              }
+            }
+            for (const x of new Range()) console.log(x);
+            """;
+        Assert.Equal("0\n1\n", TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void ComputedIterator_GeneratorForm_ForOf()
+    {
+        var source = """
+            class GenRange { *[Symbol.iterator]() { yield 10; yield 20; } }
+            for (const x of new GenRange()) console.log(x);
+            """;
+        Assert.Equal("10\n20\n", TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void ComputedAsyncIterator_GeneratorForm_ForAwait()
+    {
+        var source = """
+            class AsyncRange { async *[Symbol.asyncIterator]() { yield 1; yield 2; } }
+            async function run() {
+              for await (const x of new AsyncRange()) console.log(x);
+            }
+            run();
+            """;
+        Assert.Equal("1\n2\n", TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void ComputedIterator_UsesThis()
+    {
+        var source = """
+            class Counter {
+              limit = 3;
+              *[Symbol.iterator]() { for (let i = 0; i < this.limit; i++) yield i; }
+            }
+            const out: number[] = [];
+            for (const x of new Counter()) out.push(x);
+            console.log(out.join(","));
+            """;
+        Assert.Equal("0,1,2\n", TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void ComputedStringKeyedMethod_FoldsIntoMethodTable()
+    {
+        // A string-literal computed key is a static name: `["greet"]()` is the method `greet`.
+        var source = """
+            class W { ["greet"]() { return "hi"; } }
+            console.log(new W().greet());
+            """;
+        Assert.Equal("hi\n", TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void ComputedIterator_SpreadAndArrayFrom()
+    {
+        var source = """
+            class R { *[Symbol.iterator]() { yield 1; yield 2; yield 3; } }
+            console.log([...new R()].join(","));
+            console.log(Array.from(new R()).length);
+            """;
+        Assert.Equal("1,2,3\n3\n", TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void ComputedIterator_InheritedFromSuperclass()
+    {
+        var source = """
+            class Base { *[Symbol.iterator]() { yield 7; yield 8; } }
+            class Derived extends Base {}
+            console.log([...new Derived()].join(","));
+            """;
+        Assert.Equal("7,8\n", TestHarness.RunInterpreted(source));
+    }
+
+    // ---- Type checker ----
+
+    [Fact]
+    public void ComputedMethod_Body_IsTypeChecked()
+    {
+        // A type error inside the computed method body must be reported.
+        Assert.ThrowsAny<TypeCheckException>(() =>
+            TestHarness.RunInterpreted("""
+                class C { [Symbol.iterator]() { const x: number = "bad"; return x; } }
+                new C();
+                """));
+    }
+
+    [Fact]
+    public void ComputedIterator_MakesClassStructurallyIterable()
+    {
+        // The `@@iterator` member registration lets the structural-iterable typing (#485) accept the
+        // class as a spread source — this would error ("must be an iterable type") before the fix.
+        TestHarness.RunInterpreted("""
+            class R { *[Symbol.iterator]() { yield 1; } }
+            const arr: number[] = [...new R()];
+            console.log(arr.length);
+            """);
+    }
+
+    [Fact]
+    public void TwoComputedMethods_NoSpuriousOverloadError()
+    {
+        // Two computed methods share the synthetic "<computed>" name internally; they must not be
+        // mistaken for duplicate overloads of one method.
+        TestHarness.RunInterpreted("""
+            class M {
+              [Symbol.iterator]() { return { next() { return { value: 0, done: true }; } }; }
+              [Symbol.asyncIterator]() { return null; }
+            }
+            console.log("ok");
+            """);
+    }
+
+    // ---- Compiled mode: tracked follow-up (#647) raises a clear compile error ----
+
+    [Fact]
+    public void ComputedMethod_Compiled_RaisesClearCompileError()
+    {
+        var ex = Assert.ThrowsAny<Exception>(() =>
+            TestHarness.RunCompiled("class R { [Symbol.iterator]() { return { next() { return { value: 0, done: true }; } }; } } new R();"));
+        Assert.Contains("computed symbol-keyed class methods", ex.Message);
+    }
+}

--- a/SharpTS.Tests/SharedTests/GeneratorExpressionStatementContextTests.cs
+++ b/SharpTS.Tests/SharedTests/GeneratorExpressionStatementContextTests.cs
@@ -1,0 +1,137 @@
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests;
+
+/// <summary>
+/// Regression tests for #634: <c>GeneratorArrowLifter.RewriteStmt</c> previously only recursed
+/// into a subset of statement kinds, so a generator function expression declared inside a
+/// <c>for</c> / <c>for-of</c> / <c>for-in</c> / <c>do-while</c> / <c>try</c> / <c>switch</c> /
+/// labeled statement was never lifted to a top-level declaration. Without the lift the type
+/// checker rejects its <c>yield</c> with "'yield' is only valid inside a generator function"
+/// (the generator-expression context is only established via the lift). These exercise each
+/// newly-traversed statement kind in both interpreted and compiled modes.
+/// </summary>
+public class GeneratorExpressionStatementContextTests
+{
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void GeneratorExpression_InForLoop_IsLifted(ExecutionMode mode)
+    {
+        // The exact repro from #634.
+        var source = """
+            for (let k = 0; k < 1; k++) {
+                const g = function* () { yield 99; };
+                console.log(g().next().value);
+            }
+            """;
+        Assert.Equal("99\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void GeneratorExpression_InForOf_IsLifted(ExecutionMode mode)
+    {
+        var source = """
+            for (const _ of [0]) {
+                const g = function* () { yield 1; };
+                console.log(g().next().value);
+            }
+            """;
+        Assert.Equal("1\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void GeneratorExpression_InForIn_IsLifted(ExecutionMode mode)
+    {
+        var source = """
+            for (const _k in { a: 1 }) {
+                const g = function* () { yield 2; };
+                console.log(g().next().value);
+            }
+            """;
+        Assert.Equal("2\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void GeneratorExpression_InDoWhile_IsLifted(ExecutionMode mode)
+    {
+        var source = """
+            let once = true;
+            do {
+                const g = function* () { yield 3; };
+                console.log(g().next().value);
+                once = false;
+            } while (once);
+            """;
+        Assert.Equal("3\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void GeneratorExpression_InTryCatchFinally_IsLifted(ExecutionMode mode)
+    {
+        var source = """
+            try {
+                const g = function* () { yield 4; };
+                console.log(g().next().value);
+            } finally {
+                const g = function* () { yield 5; };
+                console.log(g().next().value);
+            }
+            """;
+        Assert.Equal("4\n5\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void GeneratorExpression_InSwitchCase_IsLifted(ExecutionMode mode)
+    {
+        var source = """
+            switch (1) {
+                case 1: {
+                    const g = function* () { yield 6; };
+                    console.log(g().next().value);
+                    break;
+                }
+            }
+            """;
+        Assert.Equal("6\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void GeneratorExpression_InLabeledBlock_IsLifted(ExecutionMode mode)
+    {
+        var source = """
+            outer: {
+                const g = function* () { yield 7; };
+                console.log(g().next().value);
+            }
+            """;
+        Assert.Equal("7\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void GeneratorExpression_NestedInForInsideTry_IsLifted(ExecutionMode mode)
+    {
+        // Nested traversal: try → for → block. Each new arm must recurse so the inner
+        // generator expression still reaches the lifter. The body yields a constant
+        // (it does not close over the loop variable, which the lift would move out of
+        // scope — see the capture limitation tracked by #534).
+        var source = """
+            try {
+                for (let i = 0; i < 2; i++) {
+                    const g = function* () { yield 8; };
+                    console.log(g().next().value);
+                }
+            } catch (e) {
+                console.log("unreachable");
+            }
+            """;
+        Assert.Equal("8\n8\n", TestHarness.Run(source, mode));
+    }
+}

--- a/SharpTS.Tests/SharedTests/NamespaceConstNarrowingTests.cs
+++ b/SharpTS.Tests/SharedTests/NamespaceConstNarrowingTests.cs
@@ -1,0 +1,81 @@
+using SharpTS.Tests.Infrastructure;
+using SharpTS.TypeSystem.Exceptions;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests;
+
+/// <summary>
+/// Regression tests for #467 (sibling of #428): a namespace-scoped <c>const</c> / <c>export const</c>
+/// was parsed via <c>VarDeclaration()</c> with the default <c>isConst: false</c>, so it became a
+/// mutable <c>Stmt.Var</c> — losing const-ness (the literal type widened and reassignment went
+/// unflagged). The parser now passes <c>isConst: true</c>, and the type checker / interpreter grew
+/// dedicated <c>Stmt.Const</c> arms so the binding is still a visible namespace member.
+/// </summary>
+public class NamespaceConstNarrowingTests
+{
+    // --- Runtime: exported namespace consts are accessible with the right values (both modes) ---
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void NamespaceExportConst_IsAccessibleAtRuntime(ExecutionMode mode)
+    {
+        var source = """
+            namespace N { export const x = 5; export let y = 10; }
+            console.log(N.x);
+            console.log(N.y);
+            """;
+        Assert.Equal("5\n10\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void NamespaceExportConst_StringAndNumber_Runtime(ExecutionMode mode)
+    {
+        var source = """
+            namespace Cfg { export const name = "app"; export const version = 2; }
+            console.log(Cfg.name + " " + Cfg.version);
+            """;
+        Assert.Equal("app 2\n", TestHarness.Run(source, mode));
+    }
+
+    // --- Type checker: const-ness is preserved (literal narrowing + reassignment flagged) ---
+
+    [Fact]
+    public void NamespaceExportConst_HasLiteralType()
+    {
+        // `export const x = 5` gives `N.x` the literal type `5` (not the widened `number`),
+        // so assigning it to a `5`-typed binding type-checks. This failed before the fix.
+        TestHarness.RunInterpreted("""
+            namespace N { export const x = 5; }
+            const exact: 5 = N.x;
+            console.log(exact);
+            """);
+    }
+
+    [Fact]
+    public void NamespaceExportConst_LiteralType_RejectsWrongLiteral()
+    {
+        // `N.x` is `5`, not `number`, so it is not assignable to the unrelated literal `6`.
+        Assert.ThrowsAny<TypeCheckException>(() =>
+            TestHarness.RunInterpreted("""
+                namespace N { export const x = 5; }
+                const bad: 6 = N.x;
+                """));
+    }
+
+    [Fact]
+    public void NamespaceConst_ReassignmentInBody_IsFlagged()
+    {
+        // A namespace-scoped `const` is read-only; reassigning it in the body is an error.
+        Assert.ThrowsAny<TypeCheckException>(() =>
+            TestHarness.RunInterpreted("namespace N { export const x = 5; x = 6; }"));
+    }
+
+    [Fact]
+    public void NamespaceNonExportedConst_HasLiteralType()
+    {
+        // The parser change applies to non-exported consts too: `x` narrows to `5` and so is
+        // assignable to the `5`-typed `y` within the same namespace body.
+        TestHarness.RunInterpreted("namespace N { const x = 5; const y: 5 = x; }");
+    }
+}

--- a/TypeSystem/TypeChecker.Namespaces.cs
+++ b/TypeSystem/TypeChecker.Namespaces.cs
@@ -227,6 +227,19 @@ public partial class TypeChecker
                 }
                 break;
 
+            case Stmt.Const constStmt:
+                // Mirror the Stmt.Var arm. Type-checking the initializer narrows the literal
+                // type for `const` (e.g. `export const x = 5` gives `N.x` the type `5`), and we
+                // register the binding so `N.x` resolves as a namespace member (#467). Runtime
+                // visibility is still gated on `export` (see Interpreter.Namespaces.cs).
+                CheckStmt(constStmt);
+                var constType = _environment.Get(constStmt.Name.Lexeme);
+                if (constType != null)
+                {
+                    values[constStmt.Name.Lexeme] = constType;
+                }
+                break;
+
             case Stmt.Class:
             case Stmt.Namespace:
             case Stmt.Interface:

--- a/TypeSystem/TypeChecker.Statements.Classes.cs
+++ b/TypeSystem/TypeChecker.Statements.Classes.cs
@@ -9,6 +9,44 @@ namespace SharpTS.TypeSystem;
 /// </summary>
 public partial class TypeChecker
 {
+    /// <summary>
+    /// Maps a computed class-member key expression of the form <c>Symbol.iterator</c> (etc.) to its
+    /// canonical <c>@@</c>-prefixed member name (<c>@@iterator</c>), or null when the key is not a
+    /// recognized well-known symbol. Used to register computed symbol-keyed methods under a name the
+    /// rest of the type system (structural-iterable typing, member lookup) already understands.
+    /// </summary>
+    private static string? TryResolveWellKnownSymbolMemberName(Expr key)
+    {
+        if (key is Expr.Get { Object: Expr.Variable { Name.Lexeme: "Symbol" }, Name.Lexeme: var member }
+            && WellKnownSymbolTypes.TryGet(member) != null)
+        {
+            return "@@" + member;
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Builds the <see cref="TypeInfo.Function"/> for a computed-key method's body check. Mirrors the
+    /// local <c>BuildMethodFuncType</c> used during signature collection; used for computed methods,
+    /// which aren't registered under a static name (well-known ones are looked up by their <c>@@name</c>
+    /// instead). Defaults aren't re-validated here — that happens during signature collection.
+    /// </summary>
+    private TypeInfo.Function BuildComputedMethodFuncType(Stmt.Function method)
+    {
+        var (paramTypes, requiredParams, hasRest, paramNames) = BuildFunctionSignature(
+            method.Parameters, validateDefaults: false, contextName: "computed method");
+
+        TypeInfo returnType = method.ReturnType != null ? ToTypeInfo(method.ReturnType) : new TypeInfo.Inferred();
+        if (method.ReturnType != null && method.IsGenerator)
+        {
+            if (method.IsAsync && returnType is not TypeInfo.AsyncGenerator)
+                returnType = new TypeInfo.AsyncGenerator(returnType);
+            else if (!method.IsAsync && returnType is not TypeInfo.Generator)
+                returnType = new TypeInfo.Generator(returnType);
+        }
+        return new TypeInfo.Function(paramTypes, returnType, requiredParams, hasRest, null, paramNames);
+    }
+
     private void CheckClassDeclaration(Stmt.Class classStmt)
     {
         // Check class decorators
@@ -99,8 +137,10 @@ public partial class TypeChecker
         }
 
         // First pass: collect signatures, grouping overloads
-        // Group methods by name to detect overloads
-        var methodGroups = classStmt.Methods.GroupBy(m => m.Name.Lexeme).ToList();
+        // Group methods by name to detect overloads. Computed-key methods (`[Symbol.iterator]() {}`)
+        // all share the synthetic name "<computed>", so they are excluded here and registered
+        // separately below under their resolved well-known name (e.g. `@@iterator`).
+        var methodGroups = classStmt.Methods.Where(m => m.ComputedKey == null).GroupBy(m => m.Name.Lexeme).ToList();
 
         foreach (var group in methodGroups)
         {
@@ -193,6 +233,28 @@ public partial class TypeChecker
             else if (implementations.Count > 1)
             {
                 throw new TypeCheckException($" Multiple implementations of method '{methodName}' without overload signatures.", tsCode: "TS2393");
+            }
+        }
+
+        // Register computed-key methods whose key is a well-known symbol under their canonical
+        // `@@name` member (e.g. `[Symbol.iterator]() {}` → `@@iterator`). This lets the structural
+        // iterable typing (#485, see TryGetStructuralIterableElement) recognise a user-defined
+        // iterable class so `for...of`, spread, and `Array.from` over it type-check. Computed keys
+        // that aren't well-known symbols can't be modeled statically and are skipped here; their
+        // bodies are still type-checked in the body pass below.
+        foreach (var method in classStmt.Methods.Where(m => m.ComputedKey != null && m.Body != null))
+        {
+            string? canonical = TryResolveWellKnownSymbolMemberName(method.ComputedKey!);
+            if (canonical == null) continue;
+            var funcType = BuildMethodFuncType(method);
+            if (method.IsStatic)
+            {
+                mutableClass.StaticMethods[canonical] = funcType;
+            }
+            else
+            {
+                mutableClass.Methods[canonical] = funcType;
+                mutableClass.MethodAccess[canonical] = method.Access;
             }
         }
 
@@ -597,7 +659,18 @@ public partial class TypeChecker
                 // Get the method type (could be Function or OverloadedFunction)
                 // For ES2022 private methods, look in PrivateMethodTypes/StaticPrivateMethodTypes
                 TypeInfo declaredMethodType;
-                if (method.IsPrivate)
+                if (method.ComputedKey != null)
+                {
+                    // Computed-key methods (`[Symbol.iterator]() {}`) aren't registered under their
+                    // synthetic "<computed>" name. Well-known ones were registered under their
+                    // `@@name`; everything else is built on the fly for body checking.
+                    string? canonical = TryResolveWellKnownSymbolMemberName(method.ComputedKey);
+                    var computedTarget = method.IsStatic ? classTypeForBody.StaticMethods : classTypeForBody.Methods;
+                    declaredMethodType = canonical != null && computedTarget.TryGetValue(canonical, out var registered)
+                        ? registered
+                        : BuildComputedMethodFuncType(method);
+                }
+                else if (method.IsPrivate)
                 {
                     declaredMethodType = method.IsStatic
                         ? classTypeForBody.StaticPrivateMethodTypes[method.Name.Lexeme]


### PR DESCRIPTION
Completes four open issues — three full parser/type-checker/interpreter fixes and one new feature — each with regression tests.

## #635 — Parse `async function` expressions
After matching `async` in expression position the parser only attempted an async *arrow* and demanded `(`, so `const f = async function () {}` was a parse error. Now it checks for the `function` keyword first and parses an async function expression (including `async function*`) via `FunctionExpression`, mirroring the existing `function`/`function*` handling. Works in both interpreted and compiled mode.

## #634 — GeneratorArrowLifter statement traversal
`GeneratorArrowLifter.RewriteStmt` only recursed into a subset of statements, so a generator function expression declared inside `for` / `for-of` / `for-in` / `do-while` / `try` / `switch` / labeled statements was never lifted to a top-level declaration and its `yield` failed to type-check (`'yield' is only valid inside a generator function`). Added identity-preserving rewrite arms for those seven statement kinds, mirroring the scanner's traversal so the pre-scan and rewriter stay in sync. Works in both modes (8 constructs covered).

## #467 — namespace-scoped `const` / `export const` parsed as mutable (sibling of #428)
`NamespaceMember()` parsed `const` through `VarDeclaration()` with the default `isConst:false`, producing a mutable `Stmt.Var` — so const-ness was lost (the literal type widened and reassignment went unflagged). Now passes `isConst:true`, with dedicated `Stmt.Const` arms added to:
- `TypeChecker.Namespaces.cs` — registers the binding as a namespace member (so `N.x` resolves with its narrowed literal type)
- `Interpreter.Namespaces.cs` — two switches (member-name extraction + value-token lookup)

The compiler already handled `Stmt.Const`. After the fix, `namespace N { export const x = 5 }` gives `N.x` the type `5` and reassigning the const is flagged.

## #592 — class computed symbol-keyed methods (`[Symbol.iterator]()`)
A class body could not declare a computed-name method, so a user-defined iterable class couldn't be written at all. Implemented across the **parser, type checker, and interpreter** for the object-returning form, the generator form `*[Symbol.iterator]()`, and the async form `async *[Symbol.asyncIterator]()` (string-literal computed keys fold into the regular method table):

- **AST/parser:** `Stmt.Function` gains an optional `ComputedKey`; `FunctionDeclaration` accepts a pre-parsed name + key; the class-member parser routes `[expr](…)` to a method instead of forcing a field `:`.
- **Type checker:** well-known computed methods register under their canonical `@@name` (`@@iterator` / `@@asyncIterator`) so the structural-iterable typing from #485 recognises the class — `for…of`, spread, and `Array.from` over it now type-check. Computed-method bodies are still type-checked.
- **Interpreter:** new symbol-method table on `SharpTSClass` (with super-chain lookup); instance/class symbol-GET and the sync/async iterator-protocol paths resolve it; `EnumerateWithIteratorProtocol` handles a returned generator.

**Compiled mode** is intentionally scoped out: symbol-method IL dispatch is a sizeable change in the IL backend (new symbol-method registry + generator/async state-machine integration), tracked as **#647**. To avoid a confusing `Value is not iterable` runtime crash, the compiler now raises a **clear compile-time error** for computed-key class methods, pointing at #647.

## Tests
Four new regression suites (50 tests): `AsyncFunctionExpressionTests`, `GeneratorExpressionStatementContextTests`, `NamespaceConstNarrowingTests`, `ComputedSymbolKeyedMethodTests`.

## Verification
- **Full unit suite: 12515 passed, 0 failed.**
- **TypeScriptConformance: 31 / 0** (no baseline shift).
- **Test262:** a clean isolated-worker baseline run is in progress; the in-process fallback is dominated by the known issue#101 cross-test-pollution noise. Any baseline regeneration from the legitimate new-passes (e.g. `async function` expression tests now parsing) will be pushed as a follow-up commit to this PR.

## Issues filed along the way (pre-existing / out-of-scope, found while implementing)
- **#645** — compiled `for await` over an async generator inside an async *arrow* throws `InvalidCastException` (lowered as a sync for-of). Pre-existing; surfaced by #635.
- **#646** — compiled function expressions / arrow functions drop default parameter values for omitted args. Pre-existing.
- **#647** — compiled-mode support for #592's computed symbol-keyed methods (the tracked follow-up).