### PR TITLE
Fix #746: nested namespace shadowing same-named top-level namespace throws in interpreter

### DIFF
--- a/Execution/Interpreter.Namespaces.cs
+++ b/Execution/Interpreter.Namespaces.cs
@@ -16,8 +16,11 @@ public partial class Interpreter
     {
         string name = ns.Name.Lexeme;
 
-        // Get or create namespace object
-        SharpTSNamespace? existingNs = _environment.GetNamespace(name);
+        // Get or create namespace object — check ONLY the current scope, not up the chain.
+        // GetNamespace walks up and would find a same-named outer namespace (e.g. top-level A
+        // when declaring O.A), incorrectly merging the nested namespace into the outer one and
+        // leaving the current scope without an "A" binding (#746).
+        SharpTSNamespace? existingNs = _environment.GetLocalNamespace(name);
         SharpTSNamespace nsObj;
 
         if (existingNs != null)

--- a/Runtime/RuntimeEnvironment.cs
+++ b/Runtime/RuntimeEnvironment.cs
@@ -155,6 +155,17 @@ public class RuntimeEnvironment : ScopeChain<RuntimeValue, RuntimeEnvironment>
     }
 
     /// <summary>
+    /// Gets a namespace by name from THIS scope only (no chain traversal).
+    /// Use when deciding whether to merge vs. create a new namespace declaration —
+    /// avoids treating a same-named namespace in an enclosing scope as a merge target (#746).
+    /// </summary>
+    public SharpTSNamespace? GetLocalNamespace(string name)
+    {
+        _namespaces.TryGetValue(name, out var ns);
+        return ns;
+    }
+
+    /// <summary>
     /// Defines a variable with a boxed value (legacy compatibility).
     /// Wraps the value in RuntimeValue.FromBoxed automatically.
     /// </summary>

--- a/SharpTS.Tests/SharedTests/NamespaceTests.cs
+++ b/SharpTS.Tests/SharedTests/NamespaceTests.cs
@@ -796,5 +796,25 @@ public class NamespaceTests
         Assert.Equal("2\n", TestHarness.Run(code, mode));
     }
 
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void NestedNamespace_ShadowsSameNamedTopLevelNamespace(ExecutionMode mode)
+    {
+        // Nested O.A shadows the top-level A for bare references from sibling O.B.
+        // The interpreter previously merged O.A's members into the global A and left
+        // namespaceEnvO without an "A" binding, so the pre-resolved distance-2 lookup
+        // returned Undefined → "Only instances and objects have properties" (#746).
+        var code = @"
+            namespace A { export function g() { return 100; } }
+            namespace O {
+              export namespace A { export function g() { return 5; } }
+              export namespace B { export function f() { return A.g(); } }
+            }
+            console.log(O.B.f());
+            console.log(A.g());
+        ";
+        Assert.Equal("5\n100\n", TestHarness.Run(code, mode));
+    }
+
     #endregion
 }


### PR DESCRIPTION
## Summary

- `GetLocalNamespace` added to `RuntimeEnvironment` — checks only the current scope's `_namespaces` dict (no chain traversal)
- `ExecuteNamespace` changed to use `GetLocalNamespace` instead of `GetNamespace` when deciding whether to merge a namespace declaration
- Test added: `NestedNamespace_ShadowsSameNamedTopLevelNamespace` (both modes)

## Root cause

`ExecuteNamespace` called `_environment.GetNamespace(name)`, which walks **up** the full scope chain. When a nested `O.A` was declared and the global scope already held a top-level `namespace A`, the chain-walk found the global `A` and entered the merge path — skipping the `else` branch that calls `_environment.DefineNamespace(name, nsObj)`.

As a result, `namespaceEnvO._values` never got an `"A"` entry. The `VariableResolver` had correctly pre-computed distance = 2 for the bare `A` reference inside `O.B.f` (pointing to O's scope), but `GetAt(2, "A")` returned `RuntimeValue.Undefined` because that slot was never written. The subsequent property access on `Undefined` threw:

```
Runtime Error: Only instances and objects have properties
```

The compiled path was already correct — `ResolveNamespaceField` keys namespace fields by their full dotted path (`"O.A"` vs `"A"`), so the collision never occurs there.

## Fix

`GetLocalNamespace` checks `_namespaces` on the current scope only. Using it in `ExecuteNamespace` ensures a nested `O.A` is always treated as a new binding in O's scope rather than a merge into the outer `A`. Declaration-merging at the same level is unaffected — `GetLocalNamespace` still finds a previously-defined namespace in the same scope.

## Test plan

- [ ] `NestedNamespace_ShadowsSameNamedTopLevelNamespace` passes in both interpreted and compiled mode (was failing with the runtime error above)
- [ ] All 101 `NamespaceTests` pass
- [ ] Full suite: 13421 passed, 0 failed