### PR TITLE
Fix #735, #733: property access on null throws TypeError (compiled + interpreted)

### DIFF
--- a/Compilation/ExpressionEmitterBase.CallHelpers.cs
+++ b/Compilation/ExpressionEmitterBase.CallHelpers.cs
@@ -411,27 +411,57 @@ public abstract partial class ExpressionEmitterBase
     }
 
     /// <summary>
+    /// True for compile-time null-placeholder globals — globals that emit CLR
+    /// <c>null</c> and rely on special-cased property access (currently just
+    /// <c>process</c>, see <c>EmitVariable</c>'s <c>process</c> branch). An
+    /// uncovered property on such a placeholder yields <c>null</c>/<c>undefined</c>
+    /// via <c>GetProperty</c>'s null branch rather than a <c>TypeError</c>, because
+    /// the receiver is a stand-in for a host object whose full reification isn't
+    /// emitted — not a runtime JS <c>null</c>. Exempting it preserves the
+    /// pre-#735/#733 behavior for <c>process.X</c> reads/writes the dedicated
+    /// emitters don't cover (#735/#733).
+    /// </summary>
+    protected static bool IsNullPlaceholderGlobal(Expr receiver) =>
+        receiver is Expr.Variable v && v.Name.Lexeme == "process";
+
+    /// <summary>
     /// Emits a guard that throws <c>TypeError</c> when <paramref name="objLocal"/>
-    /// holds <c>$Undefined</c> — the RequireObjectCoercible step a member-access
-    /// callee performs before its arguments are evaluated. Missing-property reads
+    /// holds <c>$Undefined</c> or CLR <c>null</c> — the RequireObjectCoercible step a
+    /// member-access callee performs before its arguments are evaluated. Missing-property reads
     /// (e.g. <c>o.bar</c> where <c>bar</c> is absent) yield <c>$Undefined</c>, so
     /// this catches <c>o.bar.gar(sideEffect())</c> before the side effect runs.
     ///
-    /// Deliberately does NOT reject a bare CLR <c>null</c>: compiled sloppy-mode
-    /// <c>this</c> is represented as <c>null</c> (spec says it is globalThis, which
-    /// is coercible), so <c>this.method(sideEffect())</c> must keep evaluating its
-    /// arguments. Symbols/primitives are coercible too. A genuine <c>null.x()</c>
-    /// still throws — just deferred to InvokeMethodValue, as before this guard.
+    /// Compiled sloppy-mode <c>this</c> is no longer represented as bare CLR <c>null</c>:
+    /// it resolves to the globalThis sentinel (see <see cref="LocalVariableResolver.LoadThis"/>
+    /// and <c>InvokeWithThis</c>), so a CLR <c>null</c> receiver here is an unambiguous
+    /// genuine JS <c>null</c> and is rejected with the "Cannot read properties of null"
+    /// message (#735). Symbols/primitives are coercible and pass through.
     /// </summary>
-    protected void EmitThrowIfReceiverUndefined(LocalBuilder objLocal, string methodName)
+    protected void EmitThrowIfReceiverUndefined(LocalBuilder objLocal, string methodName, bool isWrite = false)
     {
+        var action = isWrite ? "set" : "read";
+        var actionIng = isWrite ? "setting" : "reading";
+        var undefinedLabel = IL.DefineLabel();
+        var nullLabel = IL.DefineLabel();
         var okLabel = IL.DefineLabel();
 
         IL.Emit(OpCodes.Ldloc, objLocal);
         IL.Emit(OpCodes.Isinst, Ctx.Runtime!.UndefinedType);
-        IL.Emit(OpCodes.Brfalse, okLabel);               // not $Undefined → ok
+        IL.Emit(OpCodes.Brtrue, undefinedLabel);          // $Undefined → throw "undefined"
 
-        IL.Emit(OpCodes.Ldstr, $"Cannot read properties of undefined (reading '{methodName}')");
+        IL.Emit(OpCodes.Ldloc, objLocal);
+        IL.Emit(OpCodes.Brfalse, nullLabel);              // CLR null → throw "null"
+
+        IL.Emit(OpCodes.Br, okLabel);
+
+        IL.MarkLabel(undefinedLabel);
+        IL.Emit(OpCodes.Ldstr, $"Cannot {action} properties of undefined ({actionIng} '{methodName}')");
+        IL.Emit(OpCodes.Newobj, Ctx.Runtime!.TSTypeErrorCtor);
+        IL.Emit(OpCodes.Call, Ctx.Runtime!.CreateException);
+        IL.Emit(OpCodes.Throw);
+
+        IL.MarkLabel(nullLabel);
+        IL.Emit(OpCodes.Ldstr, $"Cannot {action} properties of null ({actionIng} '{methodName}')");
         IL.Emit(OpCodes.Newobj, Ctx.Runtime!.TSTypeErrorCtor);
         IL.Emit(OpCodes.Call, Ctx.Runtime!.CreateException);
         IL.Emit(OpCodes.Throw);
@@ -442,25 +472,41 @@ public abstract partial class ExpressionEmitterBase
     /// <summary>
     /// ECMA-262 RequireObjectCoercible for a NON-optional member READ (<c>o.x</c>):
     /// with the boxed receiver on top of the stack, throws a guest <c>TypeError</c>
-    /// ("Cannot read properties of undefined (reading '<paramref name="propertyName"/>')")
-    /// when it is <c>$Undefined</c>, leaving the receiver on the stack otherwise.
-    /// The read-expression analog of <see cref="EmitThrowIfReceiverUndefined"/> (the
-    /// method-call-callee guard) and the compiled counterpart of the interpreter's
-    /// guard — like the call-callee guard, a bare CLR <c>null</c> is left coercible
-    /// because compiled sloppy-mode <c>this</c> is represented as <c>null</c>
-    /// (= globalThis). Fixes #701, where <c>undefined.x</c> silently yielded
-    /// <c>undefined</c> instead of throwing. Callers MUST short-circuit the
-    /// optional-chain case (<c>o?.x</c>) before calling this.
+    /// when it is <c>$Undefined</c> or CLR <c>null</c>, leaving the receiver on the
+    /// stack otherwise. The message distinguishes the two ("Cannot read properties of
+    /// undefined|null (reading '<paramref name="propertyName"/>')"). The read-expression
+    /// analog of <see cref="EmitThrowIfReceiverUndefined"/> (the method-call-callee guard)
+    /// and the compiled counterpart of the interpreter's guard. Compiled sloppy-mode
+    /// <c>this</c> now resolves to the globalThis sentinel instead of CLR <c>null</c>,
+    /// so a null receiver here is an unambiguous genuine JS <c>null</c> (#735). Fixes
+    /// #701 (undefined) and #735 (null). Callers MUST short-circuit the optional-chain
+    /// case (<c>o?.x</c>) before calling this.
     /// </summary>
     protected void EmitThrowIfUndefinedReceiverOnStack(string propertyName)
     {
+        var undefinedLabel = IL.DefineLabel();
+        var nullLabel = IL.DefineLabel();
         var okLabel = IL.DefineLabel();
 
         IL.Emit(OpCodes.Dup);
         IL.Emit(OpCodes.Isinst, Ctx.Runtime!.UndefinedType);
-        IL.Emit(OpCodes.Brfalse, okLabel);               // not $Undefined → ok
+        IL.Emit(OpCodes.Brtrue, undefinedLabel);          // $Undefined → throw "undefined"
 
+        IL.Emit(OpCodes.Dup);
+        IL.Emit(OpCodes.Brfalse, nullLabel);              // CLR null → throw "null"
+
+        IL.Emit(OpCodes.Br, okLabel);
+
+        IL.MarkLabel(undefinedLabel);
+        IL.Emit(OpCodes.Pop);                             // discard receiver
         IL.Emit(OpCodes.Ldstr, $"Cannot read properties of undefined (reading '{propertyName}')");
+        IL.Emit(OpCodes.Newobj, Ctx.Runtime!.TSTypeErrorCtor);
+        IL.Emit(OpCodes.Call, Ctx.Runtime!.CreateException);
+        IL.Emit(OpCodes.Throw);
+
+        IL.MarkLabel(nullLabel);
+        IL.Emit(OpCodes.Pop);                             // discard receiver
+        IL.Emit(OpCodes.Ldstr, $"Cannot read properties of null (reading '{propertyName}')");
         IL.Emit(OpCodes.Newobj, Ctx.Runtime!.TSTypeErrorCtor);
         IL.Emit(OpCodes.Call, Ctx.Runtime!.CreateException);
         IL.Emit(OpCodes.Throw);
@@ -471,23 +517,47 @@ public abstract partial class ExpressionEmitterBase
     /// <summary>
     /// Bracket-access (<c>o[k]</c>) counterpart of
     /// <see cref="EmitThrowIfUndefinedReceiverOnStack"/>: throws a guest
-    /// <c>TypeError</c> when <paramref name="objLocal"/> holds <c>$Undefined</c>,
-    /// splicing the runtime key (<paramref name="keyLocal"/>, a boxed
-    /// <see cref="object"/>) into the message to match Node ("Cannot read
-    /// properties of undefined (reading '&lt;key&gt;')"). Leaves the stack
-    /// untouched. Callers MUST short-circuit the optional-chain case first. (#701)
+    /// <c>TypeError</c> when <paramref name="objLocal"/> holds <c>$Undefined</c> or
+    /// CLR <c>null</c>, splicing the runtime key (<paramref name="keyLocal"/>, a boxed
+    /// <see cref="object"/>) into the message to match Node ("Cannot read properties of
+    /// undefined|null (reading '&lt;key&gt;')"). Leaves the stack untouched. Callers MUST
+    /// short-circuit the optional-chain case first. (#701 undefined / #735 null)
     /// </summary>
-    protected void EmitThrowIfUndefinedIndexReceiver(LocalBuilder objLocal, LocalBuilder keyLocal)
+    protected void EmitThrowIfUndefinedIndexReceiver(LocalBuilder objLocal, LocalBuilder keyLocal, bool isWrite = false)
     {
+        var prefixUndef = isWrite
+            ? "Cannot set properties of undefined (setting '"
+            : "Cannot read properties of undefined (reading '";
+        var prefixNull = isWrite
+            ? "Cannot set properties of null (setting '"
+            : "Cannot read properties of null (reading '";
+        var undefinedLabel = IL.DefineLabel();
+        var nullLabel = IL.DefineLabel();
         var okLabel = IL.DefineLabel();
 
         IL.Emit(OpCodes.Ldloc, objLocal);
         IL.Emit(OpCodes.Isinst, Ctx.Runtime!.UndefinedType);
-        IL.Emit(OpCodes.Brfalse, okLabel);               // not $Undefined → ok
+        IL.Emit(OpCodes.Brtrue, undefinedLabel);          // $Undefined → throw "undefined"
 
-        // "Cannot read properties of undefined (reading '" + key + "')"
-        // Concat(object, object) is null-safe (a null key stringifies to "").
-        IL.Emit(OpCodes.Ldstr, "Cannot read properties of undefined (reading '");
+        IL.Emit(OpCodes.Ldloc, objLocal);
+        IL.Emit(OpCodes.Brfalse, nullLabel);              // CLR null → throw "null"
+
+        IL.Emit(OpCodes.Br, okLabel);
+
+        // "<prefix>" + key + "')" — Concat(object, object) is null-safe
+        // (a null key stringifies to "").
+        IL.MarkLabel(undefinedLabel);
+        IL.Emit(OpCodes.Ldstr, prefixUndef);
+        IL.Emit(OpCodes.Ldloc, keyLocal);
+        IL.Emit(OpCodes.Call, Types.StringConcatObjectObject);
+        IL.Emit(OpCodes.Ldstr, "')");
+        IL.Emit(OpCodes.Call, Types.StringConcat2);
+        IL.Emit(OpCodes.Newobj, Ctx.Runtime!.TSTypeErrorCtor);
+        IL.Emit(OpCodes.Call, Ctx.Runtime!.CreateException);
+        IL.Emit(OpCodes.Throw);
+
+        IL.MarkLabel(nullLabel);
+        IL.Emit(OpCodes.Ldstr, prefixNull);
         IL.Emit(OpCodes.Ldloc, keyLocal);
         IL.Emit(OpCodes.Call, Types.StringConcatObjectObject);
         IL.Emit(OpCodes.Ldstr, "')");

--- a/Compilation/ExpressionEmitterBase.cs
+++ b/Compilation/ExpressionEmitterBase.cs
@@ -516,8 +516,11 @@ public abstract partial class ExpressionEmitterBase : IEmitterContext
         {
             var idxLocal = SpillBoxed(gi.Index);
             // RequireObjectCoercible: `undefined[k]` throws a guest TypeError instead
-            // of silently yielding undefined (#701). Optional `o?.[k]` short-circuited above.
-            EmitThrowIfUndefinedIndexReceiver(objLocal, idxLocal);
+            // of silently yielding undefined (#701), and `null[k]` too now that sloppy
+            // `this` is the globalThis sentinel (#735). Optional `o?.[k]` short-circuited
+            // above. Null-placeholder globals (e.g. `process`) are exempt.
+            if (!IsNullPlaceholderGlobal(gi.Object))
+                EmitThrowIfUndefinedIndexReceiver(objLocal, idxLocal);
             IL.Emit(OpCodes.Ldloc, objLocal);
             IL.Emit(OpCodes.Ldloc, idxLocal);
             IL.Emit(OpCodes.Call, Ctx.Runtime!.GetIndex);
@@ -554,6 +557,12 @@ public abstract partial class ExpressionEmitterBase : IEmitterContext
         var objLocal = SpillBoxed(si.Object);
         var idxLocal = SpillBoxed(si.Index);
 
+        // RequireObjectCoercible (PutValue): a null/undefined base throws a guest
+        // TypeError ("Cannot set properties of undefined|null (setting '<key>')")
+        // instead of silently no-op'ing (#733). Null-placeholder globals are exempt.
+        if (!IsNullPlaceholderGlobal(si.Object))
+            EmitThrowIfUndefinedIndexReceiver(objLocal, idxLocal, isWrite: true);
+
         IL.Emit(OpCodes.Ldloc, objLocal);
         IL.Emit(OpCodes.Ldloc, idxLocal);
         IL.Emit(OpCodes.Ldloc, valueLocal);
@@ -564,8 +573,11 @@ public abstract partial class ExpressionEmitterBase : IEmitterContext
     }
 
     /// <summary>
-    /// Emits 'this' expression. Default uses GetThisField() hook — loads from field if non-null, else null.
-    /// ILEmitter overrides (Resolver.LoadThis). AsyncArrowMoveNextEmitter overrides (outer state machine capture).
+    /// Emits 'this' expression. Default uses GetThisField() hook — loads from field if non-null,
+    /// otherwise resolves to the globalThis sentinel (sloppy-mode `this` = globalThis) when an
+    /// emitted runtime is available, so that value-position JS null stays distinct from a sloppy
+    /// `this` receiver (#735/#733). ILEmitter overrides (Resolver.LoadThis). AsyncArrowMoveNextEmitter
+    /// overrides (outer state machine capture).
     /// </summary>
     protected virtual void EmitThis()
     {
@@ -574,6 +586,11 @@ public abstract partial class ExpressionEmitterBase : IEmitterContext
         {
             IL.Emit(OpCodes.Ldarg_0);
             IL.Emit(OpCodes.Ldfld, thisField);
+            SetStackUnknown();
+        }
+        else if (Ctx.Runtime?.GlobalThisSingletonField != null)
+        {
+            IL.Emit(OpCodes.Ldsfld, Ctx.Runtime.GlobalThisSingletonField);
             SetStackUnknown();
         }
         else
@@ -701,6 +718,12 @@ public abstract partial class ExpressionEmitterBase : IEmitterContext
         // Spill operands so an await inside Value doesn't suspend with the object on the stack.
         var objLocal = SpillBoxed(s.Object);
         var valueLocal = SpillBoxed(s.Value);
+
+        // RequireObjectCoercible (PutValue): a null/undefined base throws a guest
+        // TypeError ("Cannot set properties of undefined|null (setting 'X')") (#733).
+        // Null-placeholder globals (e.g. `process`) are exempt.
+        if (!IsNullPlaceholderGlobal(s.Object))
+            EmitThrowIfReceiverUndefined(objLocal, s.Name.Lexeme, isWrite: true);
 
         IL.Emit(OpCodes.Ldloc, objLocal);
         IL.Emit(OpCodes.Ldstr, s.Name.Lexeme);
@@ -2380,8 +2403,11 @@ public abstract partial class ExpressionEmitterBase : IEmitterContext
         else
         {
             // RequireObjectCoercible: a non-optional read on `undefined` throws a
-            // guest TypeError instead of silently yielding undefined (#701).
-            EmitThrowIfUndefinedReceiverOnStack(g.Name.Lexeme);
+            // guest TypeError instead of silently yielding undefined (#701), and on
+            // a genuine value-null now that sloppy `this` is the globalThis sentinel
+            // (#735). Null-placeholder globals (e.g. `process`) are exempt.
+            if (!IsNullPlaceholderGlobal(g.Object))
+                EmitThrowIfUndefinedReceiverOnStack(g.Name.Lexeme);
             IL.Emit(OpCodes.Ldstr, g.Name.Lexeme);
             IL.Emit(OpCodes.Call, Ctx.Runtime!.GetProperty);
         }

--- a/Compilation/ILEmitter.Properties.cs
+++ b/Compilation/ILEmitter.Properties.cs
@@ -321,8 +321,12 @@ public partial class ILEmitter
         else
         {
             // RequireObjectCoercible: a non-optional read on `undefined` throws a
-            // guest TypeError instead of silently yielding undefined (#701).
-            EmitThrowIfUndefinedReceiverOnStack(g.Name.Lexeme);
+            // guest TypeError instead of silently yielding undefined (#701). Also
+            // rejects a genuine value-null (#735) now that sloppy `this` resolves to
+            // the globalThis sentinel. Null-placeholder globals (e.g. `process`)
+            // are exempt — uncovered properties there yield undefined, not a throw.
+            if (!IsNullPlaceholderGlobal(g.Object))
+                EmitThrowIfUndefinedReceiverOnStack(g.Name.Lexeme);
             IL.Emit(OpCodes.Ldstr, g.Name.Lexeme);
             IL.Emit(OpCodes.Call, _ctx.Runtime!.GetProperty);
         }
@@ -606,20 +610,33 @@ public partial class ILEmitter
             return;
         }
 
-        // Build stack for SetProperty(obj, name, value) or SetPropertyStrict(obj, name, value, strictMode)
+        // Build stack for SetProperty(obj, name, value) or SetPropertyStrict(obj, name, value, strictMode).
+        // The LHS base is evaluated and recorded before the RHS (ECMA-262 §13.15 — the
+        // reference's base is captured during LeftHandSideExpression eval), and the RHS
+        // value is captured into a local so the coercibility guard below runs AFTER its
+        // side effects (PutValue follows RHS evaluation).
         EmitExpression(s.Object);
         EmitBoxIfNeeded(s.Object);
-        IL.Emit(OpCodes.Ldstr, s.Name.Lexeme);
+        var setRecvLocal = IL.DeclareLocal(_ctx.Types.Object);
+        IL.Emit(OpCodes.Stloc, setRecvLocal);
+
         EmitExpression(s.Value);
         EmitBoxIfNeeded(s.Value);
+        var setResultLocal = IL.DeclareLocal(_ctx.Types.Object);
+        IL.Emit(OpCodes.Stloc, setResultLocal);
 
-        // Stack: [obj, name, value]
-        // Dup value for expression result, then store it
-        IL.Emit(OpCodes.Dup);
-        var resultTemp = IL.DeclareLocal(_ctx.Types.Object);
-        IL.Emit(OpCodes.Stloc, resultTemp);
+        // RequireObjectCoercible (PutValue): a null/undefined base throws a guest
+        // TypeError ("Cannot set properties of undefined|null (setting 'X')") instead
+        // of silently no-op'ing. Compiled sloppy `this` is the globalThis sentinel, so
+        // `this.x = v` in a loose function still routes to GlobalThisSetProperty. (#733)
+        // Null-placeholder globals (e.g. `process`) are exempt.
+        if (!IsNullPlaceholderGlobal(s.Object))
+            EmitThrowIfReceiverUndefined(setRecvLocal, s.Name.Lexeme, isWrite: true);
 
         // Stack: [obj, name, value] - call SetProperty or SetPropertyStrict
+        IL.Emit(OpCodes.Ldloc, setRecvLocal);
+        IL.Emit(OpCodes.Ldstr, s.Name.Lexeme);
+        IL.Emit(OpCodes.Ldloc, setResultLocal);
         if (_ctx.IsStrictMode)
         {
             IL.Emit(OpCodes.Ldc_I4_1); // true for strict mode
@@ -631,7 +648,7 @@ public partial class ILEmitter
         }
 
         // Put result back on stack
-        IL.Emit(OpCodes.Ldloc, resultTemp);
+        IL.Emit(OpCodes.Ldloc, setResultLocal);
     }
 
     protected override void EmitGetIndex(Expr.GetIndex gi)
@@ -848,10 +865,13 @@ public partial class ILEmitter
         // Generic (non-array) dynamic bracket read. Spill both operands so the
         // RequireObjectCoercible guard can inspect the receiver and splice the key
         // into the TypeError message: `undefined[k]` throws instead of silently
-        // yielding undefined (#701). The optional `o?.[k]` case returned early above.
+        // yielding undefined (#701), and `null[k]` too now that sloppy `this` is the
+        // globalThis sentinel (#735). The optional `o?.[k]` case returned early above.
+        // Null-placeholder globals (e.g. `process`) are exempt.
         var idxRecvLocal = SpillBoxed(gi.Object);
         var idxKeyLocal = SpillBoxed(gi.Index);
-        EmitThrowIfUndefinedIndexReceiver(idxRecvLocal, idxKeyLocal);
+        if (!IsNullPlaceholderGlobal(gi.Object))
+            EmitThrowIfUndefinedIndexReceiver(idxRecvLocal, idxKeyLocal);
         IL.Emit(OpCodes.Ldloc, idxRecvLocal);
         IL.Emit(OpCodes.Ldloc, idxKeyLocal);
         IL.Emit(OpCodes.Call, _ctx.Runtime!.GetIndex);
@@ -1014,8 +1034,22 @@ public partial class ILEmitter
 
         EmitExpression(si.Object);
         EmitBoxIfNeeded(si.Object);
+        var objLocalGeneric = IL.DeclareLocal(_ctx.Types.Object);
+        IL.Emit(OpCodes.Stloc, objLocalGeneric);
+
         EmitExpression(si.Index);
         EmitBoxIfNeeded(si.Index);
+        var idxLocalGeneric = IL.DeclareLocal(_ctx.Types.Object);
+        IL.Emit(OpCodes.Stloc, idxLocalGeneric);
+
+        // RequireObjectCoercible (PutValue): a null/undefined base throws a guest
+        // TypeError ("Cannot set properties of undefined|null (setting 'X')") (#733).
+        // Null-placeholder globals (e.g. `process`) are exempt.
+        if (!IsNullPlaceholderGlobal(si.Object))
+            EmitThrowIfUndefinedIndexReceiver(objLocalGeneric, idxLocalGeneric, isWrite: true);
+
+        IL.Emit(OpCodes.Ldloc, objLocalGeneric);
+        IL.Emit(OpCodes.Ldloc, idxLocalGeneric);
         IL.Emit(OpCodes.Ldloc, valueLocalGeneric);
 
         if (_ctx.IsStrictMode)
@@ -1090,9 +1124,15 @@ public partial class ILEmitter
 
         // Fallback: generic dispatch
         IL.MarkLabel(fallbackLabel);
+        var idxFallbackLocal = SpillBoxed(si.Index);
+        // RequireObjectCoercible (PutValue): a null/undefined base throws a guest
+        // TypeError. Reached when a statically-typed receiver is null/undefined at
+        // runtime (typed miss) — its value/index side effects have already run. (#733)
+        // Null-placeholder globals (e.g. `process`) are exempt.
+        if (!IsNullPlaceholderGlobal(si.Object))
+            EmitThrowIfUndefinedIndexReceiver(objLocal, idxFallbackLocal, isWrite: true);
         IL.Emit(OpCodes.Ldloc, objLocal);
-        EmitExpression(si.Index);
-        EmitBoxIfNeeded(si.Index);
+        IL.Emit(OpCodes.Ldloc, idxFallbackLocal);
         IL.Emit(OpCodes.Ldloc, valueLocal);
         if (_ctx.IsStrictMode)
         {

--- a/Compilation/LocalVariableResolver.cs
+++ b/Compilation/LocalVariableResolver.cs
@@ -469,15 +469,32 @@ public class LocalVariableResolver : IVariableResolver
 
         // 5. Thread-local `this` set by $Runtime.NewOnFunction (or other call paths
         //    that prep a thisArg for a method whose signature has no __this param).
-        //    Falls back to null when no such this is active — matches the JS sloppy-
-        //    mode default (undefined-ish) for bare function calls.
+        //    Falls back to the globalThis sentinel when no such this is active: the
+        //    sentinel denotes sloppy-mode `this` (= globalThis) so that a subsequent
+        //    `this.x` read routes through GlobalThisGetProperty and — crucially for
+        //    #735/#733 — value-position JS null stays distinct from a sloppy `this`.
         if (_ctx.Runtime?.CurrentFunctionThisField != null)
         {
             _il.Emit(OpCodes.Ldsfld, _ctx.Runtime.CurrentFunctionThisField);
+            var thisNotNull = _il.DefineLabel();
+            _il.Emit(OpCodes.Dup);
+            _il.Emit(OpCodes.Brtrue, thisNotNull);
+            _il.Emit(OpCodes.Pop);
+            _il.Emit(OpCodes.Ldsfld, _ctx.Runtime.GlobalThisSingletonField);
+            _il.MarkLabel(thisNotNull);
             return;
         }
 
-        // 6. Static context without an emitted runtime (reference-assembly mode etc.)
+        // 6. Static context with an emitted runtime: top-level / entry point with no
+        //    active this binding. Resolve to the globalThis sentinel (sloppy `this`)
+        //    so `this.x` works and value-null remains distinguishable. Reference-
+        //    assembly mode (no runtime) falls back to bare null as before.
+        if (_ctx.Runtime != null)
+        {
+            _il.Emit(OpCodes.Ldsfld, _ctx.Runtime.GlobalThisSingletonField);
+            return;
+        }
+
         _il.Emit(OpCodes.Ldnull);
     }
 

--- a/Compilation/RuntimeEmitter.RuntimeClass.cs
+++ b/Compilation/RuntimeEmitter.RuntimeClass.cs
@@ -99,11 +99,11 @@ public partial class RuntimeEmitter
         // globalThis/global sentinel (#271) — a plain object whose identity lets
         // the dynamic property paths recognize a value-position globalThis and
         // route reads/writes through GlobalThisGetProperty/GlobalThisSetProperty.
-        var globalThisSingletonField = typeBuilder.DefineField(
-            "_globalThisSingleton",
-            _types.Object,
-            FieldAttributes.Public | FieldAttributes.Static);
-        runtime.GlobalThisSingletonField = globalThisSingletonField;
+        // The field itself is forward-declared in DefineRuntimeClassPhase1 (so
+        // $TSFunction.InvokeWithThis, emitted before this method, can coerce a
+        // null sloppy-this thisArg to it — #735/#733). Only the .cctor init below
+        // runs here; re-DefineField would throw a duplicate.
+        var globalThisSingletonField = runtime.GlobalThisSingletonField;
 
         // Boolean / Number / String prototype singletons. Test262 patterns like
         //   Boolean.prototype[0] = true; Boolean.prototype.length = 1;

--- a/Compilation/RuntimeEmitter.RuntimeClassPhase1.cs
+++ b/Compilation/RuntimeEmitter.RuntimeClassPhase1.cs
@@ -156,5 +156,15 @@ public partial class RuntimeEmitter
             "_regexpPrototype",
             _types.DictionaryStringObject,
             FieldAttributes.Public | FieldAttributes.Static);
+
+        // Forward-declare the globalThis/global sentinel field (#271). $TSFunction's
+        // InvokeWithThis (emitted in EmitTSFunctionClass, BEFORE EmitRuntimeClass)
+        // coerces a null sloppy-this thisArg to this sentinel, so the field must
+        // exist now. EmitRuntimeClass initialises it in the .cctor (new object());
+        // EmitRuntimeClass MUST skip its own DefineField when this is already set.
+        runtime.GlobalThisSingletonField = typeBuilder.DefineField(
+            "_globalThisSingleton",
+            _types.Object,
+            FieldAttributes.Public | FieldAttributes.Static);
     }
 }

--- a/Compilation/RuntimeEmitter.TSFunction.cs
+++ b/Compilation/RuntimeEmitter.TSFunction.cs
@@ -610,7 +610,20 @@ public partial class RuntimeEmitter
         iwt.Emit(OpCodes.Ldsfld, currentThisField);
         iwt.Emit(OpCodes.Stloc, prevThisIWT);
 
+        // Coerce a null thisArg to the globalThis sentinel before storing: compiled
+        // mode uses CLR null to denote sloppy-mode `this` (= globalThis), but #735/#733
+        // rely on value-position JS null being unambiguous so the property-access guards
+        // can throw TypeError on `null.x` / `null.x = v`. Substituting the sentinel here
+        // means the thread-local never holds a "sloppy-this" null; a genuine JS null
+        // thisArg never reaches this path (callers pass $Undefined or a real object).
+        // Mirrors the interpreter binding sloppy `this` to SharpTSGlobalThis.Instance.
+        var thisArgNotNullIWT = iwt.DefineLabel();
         iwt.Emit(OpCodes.Ldarg_1);
+        iwt.Emit(OpCodes.Dup);
+        iwt.Emit(OpCodes.Brtrue, thisArgNotNullIWT);
+        iwt.Emit(OpCodes.Pop);
+        iwt.Emit(OpCodes.Ldsfld, runtime.GlobalThisSingletonField);
+        iwt.MarkLabel(thisArgNotNullIWT);
         iwt.Emit(OpCodes.Stsfld, currentThisField);
 
         iwt.BeginExceptionBlock();
@@ -848,7 +861,7 @@ public partial class RuntimeEmitter
         // Store in cache (even if null, but ConcurrentDictionary doesn't allow null values if we used that, but here we can just skip if null)
         // Actually, if null, we shouldn't cache null if we use TryGetValue. 
         // Let's simplify: if field is found, cache it. If not found, we don't cache (or cache a dummy? no need to overcomplicate).
-        
+
         var fieldNullLabel = bindThisIL.DefineLabel();
         bindThisIL.Emit(OpCodes.Ldloc, thisFieldLocal);
         bindThisIL.Emit(OpCodes.Brfalse, fieldNullLabel);

--- a/Execution/Interpreter.Expressions.cs
+++ b/Execution/Interpreter.Expressions.cs
@@ -1117,6 +1117,15 @@ public partial class Interpreter
     {
         bool strictMode = _environment.IsStrictMode;
 
+        // ECMA-262 PutValue: RequireObjectCoercible throws a guest TypeError on a
+        // null/undefined base before any setter dispatch (#733). Operands (obj,
+        // index, value) are already evaluated by EvaluateSetIndex, so RHS side
+        // effects have run — matching PutValue-after-RHS ordering.
+        if (obj == null || obj is SharpTSUndefined)
+        {
+            ThrowCannotSetProperty(obj, index?.ToString() ?? "");
+        }
+
         // Proxy: intercept index assignment via set trap
         if (obj is SharpTSProxy proxy)
         {

--- a/Execution/Interpreter.Properties.cs
+++ b/Execution/Interpreter.Properties.cs
@@ -161,10 +161,10 @@ public partial class Interpreter
 
         if (klass is not SharpTSClass sharpClass)
         {
-             // ECMA-262: invoking `new X` on a non-constructor surfaces as
-             // TypeError. Routed through ThrowException so guest code sees a
-             // real TypeError instance for `assert.throws(TypeError, ...)`.
-             throw new ThrowException(new SharpTSTypeError("X is not a constructor"));
+            // ECMA-262: invoking `new X` on a non-constructor surfaces as
+            // TypeError. Routed through ThrowException so guest code sees a
+            // real TypeError instance for `assert.throws(TypeError, ...)`.
+            throw new ThrowException(new SharpTSTypeError("X is not a constructor"));
         }
 
         // Runtime check for abstract class instantiation (backup to type checker)
@@ -400,10 +400,10 @@ public partial class Interpreter
 
         if (klass is not SharpTSClass sharpClass)
         {
-             // ECMA-262: invoking `new X` on a non-constructor surfaces as
-             // TypeError. Routed through ThrowException so guest code sees a
-             // real TypeError instance for `assert.throws(TypeError, ...)`.
-             throw new ThrowException(new SharpTSTypeError("X is not a constructor"));
+            // ECMA-262: invoking `new X` on a non-constructor surfaces as
+            // TypeError. Routed through ThrowException so guest code sees a
+            // real TypeError instance for `assert.throws(TypeError, ...)`.
+            throw new ThrowException(new SharpTSTypeError("X is not a constructor"));
         }
 
         // Runtime check for abstract class instantiation (backup to type checker)
@@ -595,6 +595,22 @@ public partial class Interpreter
         string what = nullishReceiver is SharpTSUndefined ? "undefined" : "null";
         throw new ThrowException(new SharpTSTypeError(
             $"Cannot read properties of {what} (reading '{key}')"));
+    }
+
+    /// <summary>
+    /// ECMA-262 PutValue RequireObjectCoercible failure on a member write: throws
+    /// a guest <see cref="SharpTSTypeError"/> ("Cannot set properties of
+    /// &lt;null|undefined&gt; (setting '&lt;key&gt;')") wrapped in a
+    /// <see cref="ThrowException"/> so a guest <c>try/catch</c> binds a real
+    /// <c>TypeError</c>. Write-path counterpart of <see cref="ThrowCannotReadProperty"/>
+    /// (#733). Mirrors Node: <c>null.x = 1</c> throws even in sloppy mode.
+    /// </summary>
+    [System.Diagnostics.CodeAnalysis.DoesNotReturn]
+    private static void ThrowCannotSetProperty(object? nullishReceiver, string key)
+    {
+        string what = nullishReceiver is SharpTSUndefined ? "undefined" : "null";
+        throw new ThrowException(new SharpTSTypeError(
+            $"Cannot set properties of {what} (setting '{key}')"));
     }
 
     /// <summary>
@@ -1355,6 +1371,15 @@ public partial class Interpreter
     /// </summary>
     private object? EvaluateSetOnObject(Expr.Set set, object? obj, object? value)
     {
+        // ECMA-262 PutValue: RequireObjectCoercible throws a guest TypeError on a
+        // null/undefined base before any setter dispatch (#733). The RHS value is
+        // already evaluated by EvaluateSet, matching the spec's PutValue-after-RHS
+        // ordering, so side effects in the RHS have run by this point.
+        if (obj == null || obj is SharpTSUndefined)
+        {
+            ThrowCannotSetProperty(obj, set.Name.Lexeme);
+        }
+
         // Proxy interception - must be before any other dispatch
         if (obj is SharpTSProxy proxy)
         {

--- a/SharpTS.Tests/SharedTests/NullishMemberAccessTests.cs
+++ b/SharpTS.Tests/SharedTests/NullishMemberAccessTests.cs
@@ -4,23 +4,25 @@ using Xunit;
 namespace SharpTS.Tests.SharedTests;
 
 /// <summary>
-/// ECMA-262 RequireObjectCoercible (§13.3.2 / §13.3.3): a non-optional member
-/// access on <c>undefined</c> or <c>null</c> must throw a guest <c>TypeError</c>
-/// ("Cannot read properties of &lt;undefined|null&gt; (reading '&lt;key&gt;')"),
-/// not silently yield <c>undefined</c> or surface a raw host "Runtime Error" string.
+/// ECMA-262 RequireObjectCoercible (§13.3.2 / §13.3.3) and PutValue (§13.15.5):
+/// a non-optional member access on <c>undefined</c> or <c>null</c> must throw a
+/// guest <c>TypeError</c> ("Cannot read|set properties of &lt;undefined|null&gt;
+/// (reading|setting '&lt;key&gt;')"), not silently yield <c>undefined</c>,
+/// silently no-op, or surface a raw host "Runtime Error" string.
 ///
-/// <para>#676 (interpreter): the property-access fallback threw a host
+/// <para>#676 (interpreter reads): the property-access fallback threw a host
 /// <c>InterpreterException</c> that a guest <c>catch</c> bound as a plain string.</para>
-/// <para>#701 (compiled): the emitted property/index read silently evaluated to
-/// <c>undefined</c> instead of throwing.</para>
-///
-/// <para><b>Interpreter vs compiled on a genuine <c>null</c> receiver:</b> the
-/// interpreter represents JS <c>null</c> as CLR <c>null</c> (sloppy-mode <c>this</c>
-/// is a distinct globalThis object), so it can throw on both. Compiled mode
-/// represents sloppy-mode <c>this</c> as CLR <c>null</c> too, so — like the
-/// established method-call-callee guard — it only throws on the unambiguous
-/// <c>$Undefined</c> singleton and leaves CLR <c>null</c> coercible. The
-/// <c>null</c>-receiver cases below are therefore interpreter-only.</para>
+/// <para>#701 (compiled reads on <c>undefined</c>): the emitted property/index read
+/// silently evaluated to <c>undefined</c> instead of throwing.</para>
+/// <para>#735 (compiled reads on a genuine <c>null</c>): compiled mode represented
+/// sloppy-mode <c>this</c> as CLR <c>null</c>, so the guards could not reject a
+/// value-position <c>null</c> without breaking <c>this.x</c>. Compiled sloppy
+/// <c>this</c> now resolves to the globalThis sentinel, so <c>null</c> is unambiguous
+/// and reads on it throw — matching the interpreter on both <c>null</c> and
+/// <c>undefined</c>.</para>
+/// <para>#733 (writes on <c>null</c>/<c>undefined</c>): both the interpreter (which
+/// threw a host <c>InterpreterException</c>) and the compiler (which silently
+/// no-op'd) now throw a guest <c>TypeError</c> via PutValue's RequireObjectCoercible.</para>
 /// </summary>
 public class NullishMemberAccessTests
 {
@@ -75,10 +77,37 @@ public class NullishMemberAccessTests
             TestHarness.Run(source, mode));
     }
 
-    // ----- undefined receiver: method call (the #676 repro shape) -----
-    // Identity-only: the interpreter routes the callee through the property read
-    // ("Cannot read properties of …"), while compiled mode reaches its method-call
-    // guard — both raise a real TypeError, which is what #676 was about.
+    // ----- null receiver: dot + bracket read (#735) -----
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void NullDotRead_ThrowsTypeError(ExecutionMode mode)
+    {
+        var source = $$"""
+            const o: any = null;
+            try { const y = o.foo; console.log("NOTHROW " + y); }
+            {{ProbeFull}}
+            """;
+        Assert.Equal(
+            "object true TypeError |Cannot read properties of null (reading 'foo')\n",
+            TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void NullBracketRead_ThrowsTypeError(ExecutionMode mode)
+    {
+        var source = $$"""
+            const o: any = null;
+            try { const y = o["bar"]; console.log("NOTHROW " + y); }
+            {{ProbeFull}}
+            """;
+        Assert.Equal(
+            "object true TypeError |Cannot read properties of null (reading 'bar')\n",
+            TestHarness.Run(source, mode));
+    }
+
+    // ----- null/undefined receiver: method call (the #676 repro shape) -----
 
     [Theory]
     [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
@@ -92,35 +121,77 @@ public class NullishMemberAccessTests
         Assert.Equal("object true TypeError\n", TestHarness.Run(source, mode));
     }
 
-    // ----- null receiver (interpreter-only; see class remarks) -----
-
-    [Fact]
-    public void NullDotRead_ThrowsTypeError_Interpreted()
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void NullMethodCall_ThrowsTypeError(ExecutionMode mode)
     {
         var source = $$"""
             const o: any = null;
-            try { const y = o.foo; console.log("NOTHROW " + y); }
+            try { o.foo(); console.log("NOTHROW"); }
+            {{ProbeIdentity}}
+            """;
+        Assert.Equal("object true TypeError\n", TestHarness.Run(source, mode));
+    }
+
+    // ----- writes on null/undefined (#733) -----
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void UndefinedDotWrite_ThrowsTypeError(ExecutionMode mode)
+    {
+        var source = $$"""
+            const o: any = undefined;
+            try { o.foo = 1; console.log("NOTHROW"); }
             {{ProbeFull}}
             """;
         Assert.Equal(
-            "object true TypeError |Cannot read properties of null (reading 'foo')\n",
-            TestHarness.RunInterpreted(source));
+            "object true TypeError |Cannot set properties of undefined (setting 'foo')\n",
+            TestHarness.Run(source, mode));
     }
 
-    [Fact]
-    public void NullBracketRead_ThrowsTypeError_Interpreted()
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void NullDotWrite_ThrowsTypeError(ExecutionMode mode)
     {
         var source = $$"""
             const o: any = null;
-            try { const y = o["bar"]; console.log("NOTHROW " + y); }
+            try { o.foo = 1; console.log("NOTHROW"); }
             {{ProbeFull}}
             """;
         Assert.Equal(
-            "object true TypeError |Cannot read properties of null (reading 'bar')\n",
-            TestHarness.RunInterpreted(source));
+            "object true TypeError |Cannot set properties of null (setting 'foo')\n",
+            TestHarness.Run(source, mode));
     }
 
-    // ----- async context exercises the base (state-machine) emitter for #701 -----
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void NullBracketWrite_ThrowsTypeError(ExecutionMode mode)
+    {
+        var source = $$"""
+            const o: any = null;
+            try { o["bar"] = 1; console.log("NOTHROW"); }
+            {{ProbeFull}}
+            """;
+        Assert.Equal(
+            "object true TypeError |Cannot set properties of null (setting 'bar')\n",
+            TestHarness.Run(source, mode));
+    }
+
+    // PutValue follows RHS evaluation: the RHS side effect must run before the throw.
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void NullWrite_RHS_SideEffect_Runs_BeforeThrow(ExecutionMode mode)
+    {
+        var source = """
+            const o: any = null;
+            let ran = false;
+            try { o.foo = (ran = true, 1); }
+            catch (e: any) { console.log("threw ran=" + ran); }
+            """;
+        Assert.Equal("threw ran=true\n", TestHarness.Run(source, mode));
+    }
+
+    // ----- async context exercises the base (state-machine) emitter -----
 
     [Theory]
     [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
@@ -137,6 +208,67 @@ public class NullishMemberAccessTests
         Assert.Equal(
             "object true TypeError |Cannot read properties of undefined (reading 'foo')\n",
             TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void NullDotRead_InsideAsync_ThrowsTypeError(ExecutionMode mode)
+    {
+        var source = $$"""
+            async function run(): Promise<void> {
+                const o: any = null;
+                try { const y = o.foo; console.log("NOTHROW " + y); }
+                {{ProbeFull}}
+            }
+            run();
+            """;
+        Assert.Equal(
+            "object true TypeError |Cannot read properties of null (reading 'foo')\n",
+            TestHarness.Run(source, mode));
+    }
+
+    // ----- sloppy-mode `this` must stay coercible (regression for the #735 fix) -----
+    // Compiled sloppy `this` now resolves to the globalThis sentinel (mirroring the
+    // interpreter's SharpTSGlobalThis.Instance binding), so `this.x` must NOT trip
+    // the new null/undefined guard, and writes via `this.x = v` round-trip through
+    // the global object.
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void SloppyThis_Read_DoesNotThrow(ExecutionMode mode)
+    {
+        var source = """
+            function probe(): any { return this.missing; }
+            console.log(probe() === undefined ? "ok-undefined" : "WRONG:" + probe());
+            """;
+        Assert.Equal("ok-undefined\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void SloppyThis_Write_RoutesToGlobalThis(ExecutionMode mode)
+    {
+        var source = """
+            function setViaThis(): void { (this as any).__sloppyProbe735 = 42; }
+            setViaThis();
+            console.log((globalThis as any).__sloppyProbe735);
+            """;
+        Assert.Equal("42\n", TestHarness.Run(source, mode));
+    }
+
+    // The async state-machine emitter resolves `this` via the base EmitThis path
+    // (LoadThis → globalThis sentinel), so a sloppy `this.x` read inside async
+    // must not trip the new null guard. Interpreter-only limitation: top-level
+    // bare async calls don't bind `this` there (pre-existing, tracked separately),
+    // so this is compiled-only.
+    [Fact]
+    public void SloppyThis_Read_InsideAsync_DoesNotThrow_Compiled()
+    {
+        var source = """
+            async function probe(): Promise<any> { return (this as any).missing; }
+            probe().then((v: any) => console.log(v === undefined ? "ok-undefined" : "WRONG:" + v));
+            """;
+        Assert.Equal("ok-undefined\n", TestHarness.RunCompiled(source));
     }
 
     // ----- regression: optional chaining still short-circuits (does NOT throw) -----
@@ -160,6 +292,18 @@ public class NullishMemberAccessTests
         var source = """
             const o: any = undefined;
             const y = o?.["bar"];
+            console.log(y === undefined ? "undefined-ok" : "WRONG:" + y);
+            """;
+        Assert.Equal("undefined-ok\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void OptionalDotChain_OnNull_ReturnsUndefined(ExecutionMode mode)
+    {
+        var source = """
+            const o: any = null;
+            const y = o?.foo;
             console.log(y === undefined ? "undefined-ok" : "WRONG:" + y);
             """;
         Assert.Equal("undefined-ok\n", TestHarness.Run(source, mode));
@@ -193,5 +337,17 @@ public class NullishMemberAccessTests
             console.log(o.foo, o["foo"], o[1]);
             """;
         Assert.Equal("42 42 one\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void DefinedReceiver_DotWrite_StillWorks(ExecutionMode mode)
+    {
+        var source = """
+            const o: any = { foo: 1 };
+            o.foo = 99;
+            console.log(o.foo);
+            """;
+        Assert.Equal("99\n", TestHarness.Run(source, mode));
     }
 }


### PR DESCRIPTION
## Summary

Closes #735 (compiled property *read* on a genuine `null`) and #733 (writes on `null`/`undefined`).

A compiled non-optional member read on a genuine JS `null` (not the `` singleton) silently yielded `undefined`/`null` instead of throwing `TypeError`. The #701 guards deliberately spared CLR `null` because compiled sloppy-mode `this` was represented as bare `null` (= globalThis), so a blanket "throw on null" would have broken `this.x` inside loose functions. The write path (`null.x = v`) silently no-op'd in compiled mode and threw a host `InterpreterException` (not a guest `TypeError`) in the interpreter.

## Fix

Compiled sloppy-mode `this` now resolves to the existing **globalThis sentinel** — mirroring the interpreter's `SharpTSGlobalThis.Instance` binding — so value-`null` is unambiguous from a sloppy `this`:

- `RuntimeEmitter.TSFunction.cs` — `InvokeWithThis` coerces a null `thisArg` → sentinel.
- `LocalVariableResolver.cs` — `LoadThis` thread-local + static-context fallbacks resolve to the sentinel.
- `ExpressionEmitterBase.cs` — base `EmitThis` loads the sentinel.
- `RuntimeEmitter.RuntimeClassPhase1.cs` / `RuntimeEmitter.RuntimeClass.cs` — `GlobalThisSingletonField` forward-declared in Phase 1 so it exists before `EmitTSFunctionClass` runs.

With `null` unambiguous, the guards now reject **both** `undefined` and `null`:

- Three read guards (dot, bracket, method-call callee) extended in `ExpressionEmitterBase.CallHelpers.cs` (added `isWrite` flag → "Cannot set … (setting 'X')" message).
- New PutValue guards wired into `EmitSet`/`EmitSetIndex` (override + base).
- Interpreter write paths (`EvaluateSetOnObject`, `PerformIndexSet`) now throw a guest `TypeError` via a new `ThrowCannotSetProperty` helper (was a host `InterpreterException`).
- The `process` placeholder global is exempted via `IsNullPlaceholderGlobal` so uncovered `process.X` keeps yielding undefined rather than throwing.

## Behavior (verified end-to-end)

| Source | Interpreted | Compiled (before) | Compiled (after) |
|---|---|---|---|
| `null.foo`        | ❌ TypeError | ✅ `undefined` (bug) | ❌ TypeError ✓ |
| `null[\x\]`     | ❌ TypeError | ✅ `undefined` (bug) | ❌ TypeError ✓ |
| `null.foo = 1`    | ❌ host error | ✅ silent no-op (bug) | ❌ TypeError ✓ |
| `undefined.foo`   | ❌ TypeError | ❌ TypeError (#701) | ❌ TypeError |
| `this.x` (sloppy) | ✅ globalThis | ✅ `undefined` | ✅ globalThis (routes via `GlobalThisGetProperty`) |

Messages match Node: `Cannot read|set properties of <undefined|null> (reading|setting 'X')`. RHS side effects run before the write-path throw (ECMA-262 PutValue ordering).

## Tests

`SharpTS.Tests/SharedTests/NullishMemberAccessTests.cs` expanded: promoted the null-receiver read tests from interpreted-only `[Fact]` to `[Theory]` across both modes; added null/undefined write tests, method-call-on-null, RHS-side-effect ordering, and sloppy-`this` read/write regression tests.

## Test notes

- All 43 `NullishMemberAccessTests` + 791 member-access tests pass.
- The Test262 baseline tests are **pre-existing red** on `main` (unrelated drift from other recent commits — verified identical with these changes stashed). This change additionally flips the `this-is-null/undefined-throws.js` + abrupt-`this` test262 families from RuntimeError → Pass in the interpreter; the baseline should be refreshed separately to avoid conflating with the unrelated drift.
- A handful of compiled-mode tests are flaky under parallel execution (pre-existing on `main` — different tests each run); all pass in isolation.

## Risks

- Compiled mode still doesn't track strict-vs-sloppy for the `this` *value*; strict bare-call `this` becomes the sentinel instead of `null` (still a deviation from `undefined`, but coercible so `this.x` doesn't spuriously throw). Out of scope for this fix.
- `--standalone` builds unaffected (sentinel is a plain `object()`, no new SharpTS.dll hard reference).