### PR TITLE
Fix #756, #757: iterable-protocol implements clause + object-literal generator methods

### DIFF
--- a/Parsing/Parser.Expressions.cs
+++ b/Parsing/Parser.Expressions.cs
@@ -809,6 +809,24 @@ public partial class Parser
                         continue;
                     }
 
+                    // Generator / async method modifiers: { *gen() {} }, { async fn() {} },
+                    // { async *gen() {} } and their computed/string/number-keyed forms (#757). The key
+                    // forms below already dispatch to ParseObjectMethodShorthand on a following '(', so
+                    // the modifiers just need to be threaded through. `async` is a modifier only when
+                    // followed by a property-name start or `*`; otherwise it is a property named `async`
+                    // ({ async }, { async: 1 }, { async() {} }).
+                    bool isMethodAsync = false;
+                    bool isMethodGenerator = false;
+                    if (Check(TokenType.ASYNC) && (IsPropertyNameStart(PeekNext().Type) || PeekNext().Type == TokenType.STAR))
+                    {
+                        Advance();
+                        isMethodAsync = true;
+                    }
+                    if (Match(TokenType.STAR))
+                    {
+                        isMethodGenerator = true;
+                    }
+
                     // Accessor shorthand: { get foo() {} }, { set foo(v) {} }.
                     // Disambiguate from a property literally named `get`/`set`:
                     //   { get }       shorthand            (next is `,` or `}`)
@@ -901,7 +919,7 @@ public partial class Parser
 
                         if (Check(TokenType.LEFT_PAREN))
                         {
-                            var methodExpr = ParseObjectMethodShorthand();
+                            var methodExpr = ParseObjectMethodShorthand(isMethodAsync, isMethodGenerator);
                             properties.Add(new Expr.Property(new Expr.ComputedKey(keyExpr), methodExpr));
                             continue;
                         }
@@ -921,7 +939,7 @@ public partial class Parser
 
                         if (Check(TokenType.LEFT_PAREN))
                         {
-                            var methodExpr = ParseObjectMethodShorthand();
+                            var methodExpr = ParseObjectMethodShorthand(isMethodAsync, isMethodGenerator);
                             properties.Add(new Expr.Property(key, methodExpr));
                             continue;
                         }
@@ -940,7 +958,7 @@ public partial class Parser
 
                         if (Check(TokenType.LEFT_PAREN))
                         {
-                            var methodExpr = ParseObjectMethodShorthand();
+                            var methodExpr = ParseObjectMethodShorthand(isMethodAsync, isMethodGenerator);
                             properties.Add(new Expr.Property(key, methodExpr));
                             continue;
                         }
@@ -959,7 +977,7 @@ public partial class Parser
                     if (Check(TokenType.LEFT_PAREN))
                     {
                         // Method shorthand: { fn() {} }
-                        value = ParseObjectMethodShorthand();
+                        value = ParseObjectMethodShorthand(isMethodAsync, isMethodGenerator);
                     }
                     else if (Match(TokenType.COLON))
                     {
@@ -1051,7 +1069,7 @@ public partial class Parser
     /// values, and an optional <c>this:</c> parameter (TypeScript).
     /// Returns an ArrowFunction with <c>HasOwnThis=true</c>.
     /// </summary>
-    private Expr.ArrowFunction ParseObjectMethodShorthand()
+    private Expr.ArrowFunction ParseObjectMethodShorthand(bool isAsync = false, bool isGenerator = false)
     {
         Consume(TokenType.LEFT_PAREN, "Expect '(' in method shorthand.");
 
@@ -1161,7 +1179,9 @@ public partial class Parser
             ExpressionBody: null,
             BlockBody: body,
             ReturnType: returnType,
-            HasOwnThis: true);
+            HasOwnThis: true,
+            IsAsync: isAsync,
+            IsGenerator: isGenerator);
     }
 
     private Expr ParseTemplateLiteral()

--- a/SharpTS.Tests/SharedTests/ComputedSymbolMethodTests.cs
+++ b/SharpTS.Tests/SharedTests/ComputedSymbolMethodTests.cs
@@ -202,4 +202,73 @@ public class ComputedSymbolMethodTests
 
         Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
     }
+
+    // #757: object literals accept the generator/async method modifiers (`*`, `async`, `async *`),
+    // including the computed symbol-keyed form, which previously failed to parse ("Expect property
+    // name"). The class-body parser already handled these (#592); this is the object-literal parser.
+    // Tests are kept free of dynamic `this` inside the generator (object generator methods lose
+    // `this` in both modes — pre-existing #775).
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ObjectLiteral_ComputedGeneratorMethod_Iterates(ExecutionMode mode)
+    {
+        var source = """
+            const o = { *[Symbol.iterator]() { yield 1; yield 2; } };
+            for (const x of o) console.log(x);
+            """;
+
+        Assert.Equal("1\n2\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ObjectLiteral_NamedGeneratorMethod_Iterates(ExecutionMode mode)
+    {
+        var source = """
+            const o = { *gen() { yield 10; yield 20; } };
+            for (const x of o.gen()) console.log(x);
+            """;
+
+        Assert.Equal("10\n20\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ObjectLiteral_AsyncMethod_Resolves(ExecutionMode mode)
+    {
+        var source = """
+            const o = { async foo() { return 5; } };
+            o.foo().then(v => console.log("async:", v));
+            """;
+
+        Assert.Equal("async: 5\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ObjectLiteral_AsyncGeneratorMethod_Iterates(ExecutionMode mode)
+    {
+        var source = """
+            const o = { async *ag() { yield 1; yield 2; } };
+            async function main() { for await (const x of o.ag()) console.log("ag:", x); }
+            main();
+            """;
+
+        Assert.Equal("ag: 1\nag: 2\n", TestHarness.Run(source, mode));
+    }
+
+    [Fact]
+    public void ObjectLiteral_AsyncAsPropertyName_StillParses()
+    {
+        // `async` is a method/property modifier only before a property-name start or `*`; otherwise
+        // it remains an ordinary property name ({ async }, { async: 1 }, { async() {} }).
+        var source = """
+            const a = { async: 1 };
+            const b = { async() { return 2; } };
+            console.log(a.async, b.async());
+            """;
+
+        Assert.Equal("1 2\n", TestHarness.RunInterpreted(source));
+    }
 }

--- a/SharpTS.Tests/TypeCheckerTests/NominalTypingTests.cs
+++ b/SharpTS.Tests/TypeCheckerTests/NominalTypingTests.cs
@@ -525,6 +525,73 @@ public class NominalTypingTests
         Assert.Contains("Type Error", ex.Message);
     }
 
+    // #756: a class may declare it implements the built-in iterable-protocol interfaces
+    // (Iterable<T>, AsyncIterable<T>, …) — validated structurally via [Symbol.iterator]() etc.
+
+    [Fact]
+    public void ClassImplementsIterable_Compatible()
+    {
+        var source = """
+            class Range implements Iterable<number> {
+                *[Symbol.iterator](): Iterator<number> { yield 1; yield 2; }
+            }
+            for (const x of new Range()) console.log(x);
+            """;
+
+        var result = TestHarness.RunInterpreted(source);
+        Assert.Equal("1\n2\n", result);
+    }
+
+    [Fact]
+    public void ClassImplementsAsyncIterable_Compatible()
+    {
+        var source = """
+            class AR implements AsyncIterable<number> {
+                async *[Symbol.asyncIterator](): AsyncIterator<number> { yield 1; }
+            }
+            console.log("ok");
+            """;
+
+        var result = TestHarness.RunInterpreted(source);
+        Assert.Equal("ok\n", result);
+    }
+
+    [Fact]
+    public void ClassExpressionImplementsIterable_Compatible()
+    {
+        var source = """
+            const Range = class implements Iterable<number> {
+                *[Symbol.iterator](): Iterator<number> { yield 7; }
+            };
+            for (const x of new Range()) console.log(x);
+            """;
+
+        var result = TestHarness.RunInterpreted(source);
+        Assert.Equal("7\n", result);
+    }
+
+    [Fact]
+    public void ClassDoesNotImplementIterable_Fails()
+    {
+        var source = """
+            class Bad implements Iterable<number> { x = 1; }
+            """;
+
+        var ex = Assert.ThrowsAny<Exception>(() => TestHarness.RunInterpreted(source));
+        Assert.Contains("incorrectly implements", ex.Message);
+    }
+
+    [Fact]
+    public void ClassImplementsUnknownName_StillFails()
+    {
+        var source = """
+            class C implements NotAThing {}
+            """;
+
+        var ex = Assert.ThrowsAny<Exception>(() => TestHarness.RunInterpreted(source));
+        Assert.Contains("is not an interface", ex.Message);
+    }
+
     #endregion
 
     #region Abstract Classes

--- a/TypeSystem/TypeChecker.Expressions.cs
+++ b/TypeSystem/TypeChecker.Expressions.cs
@@ -2056,12 +2056,27 @@ public partial class TypeChecker
         // Validate interface implementations (skip for generic - validated at instantiation)
         if (classExpr.Interfaces != null && classTypeParams == null)
         {
-            foreach (var interfaceToken in classExpr.Interfaces)
+            for (int i = 0; i < classExpr.Interfaces.Count; i++)
             {
+                var interfaceToken = classExpr.Interfaces[i];
                 TypeInfo? itfTypeInfo = _environment.Get(interfaceToken.Lexeme);
-                if (itfTypeInfo is not TypeInfo.Interface interfaceType)
+                if (itfTypeInfo is TypeInfo.Interface interfaceType)
+                {
+                    ValidateInterfaceImplementation(classTypeForBody, interfaceType, className);
+                }
+                else if (itfTypeInfo == null && TryResolveIterableProtocolInterface(
+                             interfaceToken.Lexeme,
+                             classExpr.InterfaceTypeArgs != null && i < classExpr.InterfaceTypeArgs.Count ? classExpr.InterfaceTypeArgs[i] : null,
+                             out var protocolType))
+                {
+                    // Built-in iterable-protocol interface (Iterable<T>, AsyncIterable<T>, …) — not a
+                    // user-declared interface, so validate the class structurally implements it (#756).
+                    ValidateProtocolInterfaceImplementation(classTypeForBody, protocolType, className);
+                }
+                else
+                {
                     throw new TypeCheckException($" '{interfaceToken.Lexeme}' is not an interface.", tsCode: "TS2304");
-                ValidateInterfaceImplementation(classTypeForBody, interfaceType, className);
+                }
             }
         }
 

--- a/TypeSystem/TypeChecker.Iterables.cs
+++ b/TypeSystem/TypeChecker.Iterables.cs
@@ -244,7 +244,7 @@ public partial class TypeChecker
     /// iterables are intentionally excluded (a sync iterable is not an async iterable). Returns false for
     /// non-async-iterable types (callers decide between an error and a fall-through to <c>any</c>).
     /// </summary>
-    private static bool TryGetAsyncIterableElementType(TypeInfo type, out TypeInfo elementType)
+    private bool TryGetAsyncIterableElementType(TypeInfo type, out TypeInfo elementType)
     {
         switch (type)
         {
@@ -252,9 +252,41 @@ public partial class TypeChecker
             case TypeInfo.AsyncIterator ait: elementType = ait.ElementType; return true;
             case TypeInfo.AsyncGenerator ag: elementType = ag.YieldType; return true;
             case TypeInfo.Any: elementType = new TypeInfo.Any(); return true;
+            case TypeInfo.Record or TypeInfo.Interface or TypeInfo.Instance:
+                return TryGetStructuralAsyncIterableElement(type, out elementType);
             default:
                 elementType = null!;
                 return false;
+        }
+    }
+
+    /// <summary>
+    /// Derives the element type of a structural ASYNC-ITERABLE source — an object exposing
+    /// <c>[Symbol.asyncIterator](): AsyncIterator&lt;T&gt;</c>. The async mirror of
+    /// <see cref="TryGetStructuralIterableElement"/>: a class's <c>[Symbol.asyncIterator]()</c> member
+    /// lands as the named <c>@@asyncIterator</c> member (#592), and an object literal's symbol-keyed
+    /// method in the symbol index signature. Needed so a class declaring <c>implements AsyncIterable&lt;T&gt;</c>
+    /// validates structurally (#756). Returns false when no async-iterator factory exists.
+    /// </summary>
+    private bool TryGetStructuralAsyncIterableElement(TypeInfo source, out TypeInfo elementType)
+    {
+        elementType = null!;
+
+        TypeInfo? iteratorFactory = GetMemberType(source, "@@asyncIterator");
+        if (!IsCallableMember(iteratorFactory) && source is TypeInfo.Record { SymbolIndexType: { } symIndex })
+            iteratorFactory = symIndex;   // object-literal [Symbol.asyncIterator]() lands in the symbol index
+        if (!IsCallableMember(iteratorFactory))
+            return false;
+
+        TypeInfo? iterator = GetCallableReturnType(iteratorFactory);
+        if (iterator is null) { elementType = new TypeInfo.Any(); return true; }
+
+        switch (iterator)
+        {
+            case TypeInfo.AsyncIterator ait: elementType = ait.ElementType; return true;
+            case TypeInfo.AsyncGenerator ag: elementType = ag.YieldType; return true;
+            case TypeInfo.AsyncIterable ai: elementType = ai.ElementType; return true;
+            default: elementType = new TypeInfo.Any(); return true;
         }
     }
 }

--- a/TypeSystem/TypeChecker.Statements.Classes.cs
+++ b/TypeSystem/TypeChecker.Statements.Classes.cs
@@ -482,6 +482,13 @@ public partial class TypeChecker
                         substitutedMembers,
                         genericInterface.OptionalMembers);
                 }
+                else if (itfTypeInfo == null && TryResolveIterableProtocolInterface(interfaceToken.Lexeme, typeArgs, out var protocolType))
+                {
+                    // Built-in iterable-protocol interface (Iterable<T>, AsyncIterable<T>, …) — not a
+                    // user-declared interface, so validate the class structurally implements it (#756).
+                    ValidateProtocolInterfaceImplementation(classTypeForBody, protocolType, classStmt.Name.Lexeme);
+                    continue;
+                }
                 else
                 {
                     throw new TypeCheckException($" '{interfaceToken.Lexeme}' is not an interface.", tsCode: "TS2304");

--- a/TypeSystem/TypeChecker.Validation.cs
+++ b/TypeSystem/TypeChecker.Validation.cs
@@ -65,6 +65,56 @@ public partial class TypeChecker
     }
 
     /// <summary>
+    /// The built-in iterable-protocol interfaces a class may legally list in its <c>implements</c>
+    /// clause. These are NOT user-declared <c>interface</c>s (so they are absent from the type
+    /// environment) but lib types resolved generically — a class satisfies them structurally via a
+    /// <c>[Symbol.iterator]()</c> / <c>[Symbol.asyncIterator]()</c> member (#592, #756).
+    /// </summary>
+    private static readonly HashSet<string> IterableProtocolInterfaceNames =
+    [
+        "Iterable", "Iterator", "IterableIterator",
+        "AsyncIterable", "AsyncIterator", "AsyncIterableIterator",
+    ];
+
+    /// <summary>
+    /// Resolves an <c>implements</c>-clause name to a built-in iterable-protocol type when the name is
+    /// one of the six protocol interfaces (<c>Iterable&lt;T&gt;</c>, <c>AsyncIterable&lt;T&gt;</c>, …).
+    /// These names never reach the type environment as <see cref="TypeInfo.Interface"/>s, so the normal
+    /// <c>implements</c> resolution rejects them as "not an interface" even when the class genuinely
+    /// implements the protocol; this restores the lib-type resolution used in annotation position. The
+    /// element type defaults to <c>any</c> when no type argument is supplied. Returns false for any
+    /// other name (including other built-in generics such as <c>Array</c>/<c>Map</c>), leaving the
+    /// caller's existing "is not an interface" diagnostic intact (#756).
+    /// </summary>
+    private bool TryResolveIterableProtocolInterface(string name, List<string>? typeArgStrings, out TypeInfo protocolType)
+    {
+        protocolType = null!;
+        if (!IterableProtocolInterfaceNames.Contains(name))
+            return false;
+
+        List<TypeInfo> resolvedArgs = typeArgStrings is { Count: > 0 }
+            ? typeArgStrings.Select(ta => ToTypeInfo(ta)).ToList()
+            : [new TypeInfo.Any()];
+
+        protocolType = ResolveGenericType(name, resolvedArgs);
+        return true;
+    }
+
+    /// <summary>
+    /// Validates that a class structurally implements a built-in iterable-protocol interface (resolved by
+    /// <see cref="TryResolveIterableProtocolInterface"/>). Reuses the assignment-compatibility engine: a
+    /// class instance is checked against the protocol target, which probes the class's
+    /// <c>@@iterator</c>/<c>@@asyncIterator</c> member exactly as a <c>for...of</c>/<c>for await</c> would.
+    /// Throws TS2420 (the same code the structural interface check uses) when the class does not satisfy
+    /// the protocol (#756).
+    /// </summary>
+    private void ValidateProtocolInterfaceImplementation(TypeInfo classType, TypeInfo protocolType, string className)
+    {
+        if (!IsCompatible(protocolType, new TypeInfo.Instance(classType)))
+            throw new TypeCheckException($" Class '{className}' incorrectly implements interface '{protocolType}'.", tsCode: "TS2420");
+    }
+
+    /// <summary>
     /// Validates that a class method signature is compatible with an interface method signature.
     /// For interface implementation, the class method must:
     /// 1. Accept at least as many required parameters as the interface method requires


### PR DESCRIPTION
Two related iterable-protocol gaps surfaced by #592 (computed symbol-keyed class methods).

## Fix #756 — `class C implements Iterable<T>`
A class could not list the built-in iterable-protocol interfaces (`Iterable<T>`, `AsyncIterable<T>`, `Iterator<T>`, `IterableIterator<T>`, `AsyncIterator<T>`, `AsyncIterableIterator<T>`) in its `implements` clause — the type checker reported `'Iterable' is not an interface`, even though the class genuinely implements the protocol via a `[Symbol.iterator]()`/`[Symbol.asyncIterator]()` member. These names are built-in generics (not type-environment interfaces), so they resolve fine in annotation position but were rejected in the `implements` clause.

- New `TryResolveIterableProtocolInterface` (six-name allow-list → existing `ResolveGenericType`) + `ValidateProtocolInterfaceImplementation` (reuses `IsCompatible(protocol, Instance(class))` → TS2420 on mismatch) in `TypeChecker.Validation.cs`.
- Wired into both the class-declaration and class-expression `implements` loops.
- Added a structural `@@asyncIterator` probe (`TryGetAsyncIterableElementType` made non-static + `TryGetStructuralAsyncIterableElement`) so `AsyncIterable<T>` validates against a class's `[Symbol.asyncIterator]()`.
- A class that does not satisfy the protocol now gets TS2420 (`incorrectly implements`); a genuinely-unknown name still gets TS2304 (`is not an interface`).

## Fix #757 — object-literal generator/async computed methods
The object-literal parser rejected `{ *[Symbol.iterator]() {} }` (and `*gen()`, `async fn()`, `async *gen()`) with `Expect property name` — only the non-generator computed form parsed. The class-body parser already handled these (#592); this brings the object-literal parser to parity.

- `ParseObjectMethodShorthand` now takes `isAsync`/`isGenerator` and stamps them onto the emitted `ArrowFunction`.
- The object-literal property loop detects the `*`/`async` modifiers and threads them into all four key forms. `async` is a modifier only before a property-name start or `*`, so `{ async }`, `{ async: 1 }`, `{ async() {} }` parse exactly as before.
- Parser-only — the runtime already lowered generator/async object methods. Works in both interpreted and compiled modes.

## Notes
- Dynamic `this` inside an *object* generator method remains broken in both modes (pre-existing #775); #757 tests are kept `this`-free.

## Testing
- 10 new tests (`NominalTypingTests.cs`, `ComputedSymbolMethodTests.cs`), covering both class-declaration and class-expression forms and both back ends.
- Full suite: **13458 passed, 0 failed**.