### PR TITLE
Fix #801: read a descriptor object's INHERITED fields through its prototype

### DIFF
--- a/Compilation/RuntimeEmitter.Objects.Descriptors.cs
+++ b/Compilation/RuntimeEmitter.Objects.Descriptors.cs
@@ -341,22 +341,113 @@ public partial class RuntimeEmitter
         var synthDictTryGetValue = _types.GetMethod(_types.DictionaryStringObject, "TryGetValue", _types.String, _types.Object.MakeByRefType());
 
         // For each well-known descriptor field, GetProperty(descriptor, field).
-        // If result is non-null and not $Undefined, add to synthDict. Treats
-        // "undefined" as "field absent" UNLESS the field is explicit in the
-        // input Dict (the overlay pass below handles that).
+        // GetProperty walks the prototype chain and invokes getters. A defined
+        // result is stashed directly. When Get yields undefined we additionally
+        // probe for an INHERITED accessor (getter OR setter) via the prototype-
+        // walking __lookupGetter__/__lookupSetter__ helpers: a setter-only
+        // inherited `value` (or any field) IS specified per §6.2.5.5 HasProperty
+        // even though Get reads undefined (#801), so we stash $Undefined for it.
+        // Treats "undefined with no accessor" as "field absent" UNLESS the field
+        // is an explicit own key on the input Dict (the overlay pass handles that).
+        //
+        // Branches to `target` when `local` holds a defined value (non-null and
+        // not $Undefined); otherwise falls through.
+        void EmitBranchIfDefined(LocalBuilder local, Label target)
+        {
+            var notDefined = il.DefineLabel();
+            il.Emit(OpCodes.Ldloc, local);
+            il.Emit(OpCodes.Brfalse, notDefined);
+            il.Emit(OpCodes.Ldloc, local);
+            il.Emit(OpCodes.Isinst, runtime.UndefinedType);
+            il.Emit(OpCodes.Brtrue, notDefined);
+            il.Emit(OpCodes.Br, target);
+            il.MarkLabel(notDefined);
+        }
+
+        // Walks the descriptor's prototype chain via the PDS (the compiled
+        // prototype link) and branches to `target` if any level has a PDS
+        // accessor descriptor (getter OR setter) for `field`. Detects an
+        // inherited setter-only `value` whose Get yields undefined (#801). Uses
+        // only PDS primitives, which are emitted before this method.
+        var getterGet = runtime.CompiledPropertyDescriptorGetter.GetGetMethod()!;
+        var setterGet = runtime.CompiledPropertyDescriptorSetter.GetGetMethod()!;
+        void EmitBranchIfAccessorOnChain(string field, Label target)
+        {
+            var curLocal = il.DeclareLocal(_types.Object);
+            var pdescLocal = il.DeclareLocal(runtime.CompiledPropertyDescriptorType);
+            var depthLocal = il.DeclareLocal(_types.Int32);
+            var loopLabel = il.DefineLabel();
+            var notFoundLabel = il.DefineLabel();
+            var noPdescLabel = il.DefineLabel();
+
+            il.Emit(OpCodes.Ldarg_2);
+            il.Emit(OpCodes.Stloc, curLocal);
+            il.Emit(OpCodes.Ldc_I4_0);
+            il.Emit(OpCodes.Stloc, depthLocal);
+
+            il.MarkLabel(loopLabel);
+            // cur == null → not found
+            il.Emit(OpCodes.Ldloc, curLocal);
+            il.Emit(OpCodes.Brfalse, notFoundLabel);
+            // depth guard (cycle safety)
+            il.Emit(OpCodes.Ldloc, depthLocal);
+            il.Emit(OpCodes.Ldc_I4, 64);
+            il.Emit(OpCodes.Bge, notFoundLabel);
+            il.Emit(OpCodes.Ldloc, depthLocal);
+            il.Emit(OpCodes.Ldc_I4_1);
+            il.Emit(OpCodes.Add);
+            il.Emit(OpCodes.Stloc, depthLocal);
+            // pdesc = PDSGetPropertyDescriptor(cur, field)
+            il.Emit(OpCodes.Ldloc, curLocal);
+            il.Emit(OpCodes.Ldstr, field);
+            il.Emit(OpCodes.Call, runtime.PDSGetPropertyDescriptor);
+            il.Emit(OpCodes.Stloc, pdescLocal);
+            il.Emit(OpCodes.Ldloc, pdescLocal);
+            il.Emit(OpCodes.Brfalse, noPdescLabel);
+            // pdesc.Getter != null → accessor present
+            il.Emit(OpCodes.Ldloc, pdescLocal);
+            il.Emit(OpCodes.Callvirt, getterGet);
+            il.Emit(OpCodes.Brtrue, target);
+            // pdesc.Setter != null → accessor present
+            il.Emit(OpCodes.Ldloc, pdescLocal);
+            il.Emit(OpCodes.Callvirt, setterGet);
+            il.Emit(OpCodes.Brtrue, target);
+            il.MarkLabel(noPdescLabel);
+            // cur = PDSGetPrototype(cur)
+            il.Emit(OpCodes.Ldloc, curLocal);
+            il.Emit(OpCodes.Call, runtime.PDSGetPrototype);
+            il.Emit(OpCodes.Stloc, curLocal);
+            il.Emit(OpCodes.Br, loopLabel);
+
+            il.MarkLabel(notFoundLabel);
+        }
+
         void EmitGetAndStash(string field)
         {
+            var stashLabel = il.DefineLabel();
             var skipLabel = il.DefineLabel();
             var fieldValLocal = il.DeclareLocal(_types.Object);
+
+            // fieldVal = GetProperty(descriptor, field)
             il.Emit(OpCodes.Ldarg_2);
             il.Emit(OpCodes.Ldstr, field);
             il.Emit(OpCodes.Call, runtime.GetProperty);
             il.Emit(OpCodes.Stloc, fieldValLocal);
+            // Defined value → stash it.
+            EmitBranchIfDefined(fieldValLocal, stashLabel);
+            // Undefined Get result: still present if an own/inherited accessor exists.
+            EmitBranchIfAccessorOnChain(field, stashLabel);
+            il.Emit(OpCodes.Br, skipLabel);
+
+            // stash: synthDict[field] = fieldVal, normalizing null → $Undefined so
+            // an accessor-only (setter-only) field records a present undefined value.
+            il.MarkLabel(stashLabel);
+            var haveValLabel = il.DefineLabel();
             il.Emit(OpCodes.Ldloc, fieldValLocal);
-            il.Emit(OpCodes.Brfalse, skipLabel);
-            il.Emit(OpCodes.Ldloc, fieldValLocal);
-            il.Emit(OpCodes.Isinst, runtime.UndefinedType);
-            il.Emit(OpCodes.Brtrue, skipLabel);
+            il.Emit(OpCodes.Brtrue, haveValLabel);
+            il.Emit(OpCodes.Ldsfld, runtime.UndefinedInstance);
+            il.Emit(OpCodes.Stloc, fieldValLocal);
+            il.MarkLabel(haveValLabel);
             il.Emit(OpCodes.Ldloc, synthDictLocal);
             il.Emit(OpCodes.Ldstr, field);
             il.Emit(OpCodes.Ldloc, fieldValLocal);

--- a/Execution/Interpreter.Properties.cs
+++ b/Execution/Interpreter.Properties.cs
@@ -514,6 +514,85 @@ public partial class Interpreter
     }
 
     /// <summary>
+    /// ECMA-262 §7.3.11 HasProperty(O, P): true when <paramref name="obj"/> or
+    /// anything on its prototype chain has an own data field OR an accessor
+    /// (getter or setter) named <paramref name="name"/>. Unlike the type-specific
+    /// own-only checks, this walks the prototype chain and — crucially for
+    /// §6.2.5.5 ToPropertyDescriptor (#801) — counts a setter-only accessor as
+    /// present even though <see cref="GetProperty"/> would read <c>undefined</c>
+    /// for it. Used to distinguish an omitted descriptor field from one explicitly
+    /// set to undefined.
+    /// </summary>
+    internal bool HasProperty(object? obj, string name)
+    {
+        for (int depth = 0; depth < 64 && obj is not (null or SharpTSUndefined); depth++)
+        {
+            if (obj is SharpTSObject so)
+            {
+                // SharpTSObject.HasProperty covers own fields + getters; add setters
+                // so a setter-only accessor registers as present.
+                if (so.HasProperty(name) || so.HasSetter(name)) return true;
+                obj = so.HasProperty("__proto__") ? so.GetProperty("__proto__") : null;
+                continue;
+            }
+            // Non-record receivers (instances, built-ins like RegExp, boxed
+            // primitives): defer to Get semantics over the full chain from here.
+            // A defined result means present; this misses only a setter-only
+            // accessor whose Get yields undefined, which does not arise for these
+            // receiver kinds in practice.
+            return GetProperty(obj, name) is not (null or SharpTSUndefined);
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Reads a descriptor field with ECMA-262 §7.3.2 Get semantics AND correct
+    /// presence (§7.3.11 HasProperty), used by ToPropertyDescriptor (#801).
+    /// Walks the prototype chain and stops at the first level that owns the
+    /// property: an own getter is invoked; an own SETTER-only accessor is present
+    /// with value undefined (and shadows any inherited getter — the case plain
+    /// <see cref="GetProperty"/> misses); an own data field returns its value.
+    /// Returns true when the field is present (so an explicit <c>value: undefined</c>
+    /// or a setter-only <c>value</c> is distinguished from an omitted field).
+    /// </summary>
+    internal bool TryGetDescriptorField(object? obj, string name, out object? value)
+    {
+        value = null;
+        for (int depth = 0; depth < 64 && obj is not (null or SharpTSUndefined); depth++)
+        {
+            if (obj is SharpTSObject so)
+            {
+                var getter = so.GetGetter(name);
+                if (getter != null)
+                {
+                    value = BindAccessorToObject(getter, so).Call(this, []);
+                    return true;
+                }
+                if (so.HasSetter(name))
+                {
+                    value = SharpTSUndefined.Instance; // setter-only accessor shadows inherited getter
+                    return true;
+                }
+                if (so.Fields.ContainsKey(name))
+                {
+                    value = so.GetProperty(name);
+                    return true;
+                }
+                obj = so.HasProperty("__proto__") ? so.GetProperty("__proto__") : null;
+                continue;
+            }
+            // Non-record receivers: fall back to HasProperty/Get from this level up.
+            if (HasProperty(obj, name))
+            {
+                value = GetProperty(obj, name);
+                return true;
+            }
+            return false;
+        }
+        return false;
+    }
+
+    /// <summary>
     /// Core property access logic, shared between sync and async evaluation.
     /// Uses TypeCategoryResolver for unified type dispatch.
     /// </summary>
@@ -731,6 +810,27 @@ public partial class Interpreter
         var member = BuiltInRegistry.Instance.GetMemberByCategory(category, obj, memberName);
         if (member != null)
             return RuntimeValue.FromBoxed(BindBuiltInMember(member, obj));
+
+        // RegExp instances inherit user-set properties from the realm
+        // RegExp.prototype (built-in prototype mutability, #801/#474-adjacent).
+        // Own properties/accessors and built-in members were already resolved
+        // above; this final fallback reaches user assignments such as
+        // `RegExp.prototype.enumerable = true` and user-defined prototype getters,
+        // so they are visible on `new RegExp()` (and on descriptor reads, which
+        // route through this same path). Built-in prototype accessors/methods are
+        // handled earlier, so they take precedence and are never shadowed here.
+        if (obj is SharpTSRegExp)
+        {
+            var rxProto = GetRegExpPrototype();
+            var rxProtoGetter = rxProto.GetGetter(memberName);
+            if (rxProtoGetter != null)
+            {
+                var bound = rxProtoGetter is SharpTSFunction rxFn ? rxFn.BindThis(obj) : rxProtoGetter;
+                return RuntimeValue.FromBoxed(bound.Call(this, []));
+            }
+            if (rxProto.Fields.ContainsKey(memberName))
+                return RuntimeValue.FromBoxed(rxProto.GetProperty(memberName));
+        }
 
         return RuntimeValue.Undefined;
     }

--- a/Runtime/BuiltIns/ObjectBuiltIns.cs
+++ b/Runtime/BuiltIns/ObjectBuiltIns.cs
@@ -480,6 +480,10 @@ public static class ObjectBuiltIns
         // attributes. Correct flags are required for the delete configurability
         // check in SharpTSObject.
         ApplyBooleanAttributes(descriptor, descriptorArg, interpreter);
+        // §6.2.5.5 also reads value/get/set through the prototype chain (honoring
+        // accessors); FromAnyObject only saw own fields. Re-derive them prototype-aware
+        // and record presence so omitted-vs-undefined is preserved downstream (#801).
+        ApplyValueAndAccessors(descriptor, descriptorArg, interpreter);
 
         // Handle Symbol-keyed property definition — route through Symbol storage.
         // Per ECMA-262 §10.1.6 / §6.2.5.6, a descriptor that omits `value` (only
@@ -491,7 +495,7 @@ public static class ObjectBuiltIns
         // this path against RegExp.prototype[Symbol.split].
         if (args[1] is SharpTSSymbol symKey)
         {
-            bool descriptorHasValue = DescriptorHasValueOrAccessor(descriptorArg);
+            bool descriptorHasValue = descriptor.HasValue;
             bool isAccessor = descriptor.Get != null || descriptor.Set != null;
             switch (target)
             {
@@ -553,7 +557,7 @@ public static class ObjectBuiltIns
                 {
                     fn.DefineAccessor(propertyKey, descriptor.Get, descriptor.Set);
                 }
-                else if (DescriptorHasValueOrAccessor(descriptorArg))
+                else if (descriptor.HasValue)
                 {
                     fn.SetProperty(propertyKey, descriptor.Value);
                 }
@@ -576,7 +580,7 @@ public static class ObjectBuiltIns
                 {
                     rx.DefineAccessor(propertyKey, descriptor.Get, descriptor.Set);
                 }
-                else if (DescriptorHasValueOrAccessor(descriptorArg))
+                else if (descriptor.HasValue)
                 {
                     rx.SetProperty(propertyKey, descriptor.Value);
                 }
@@ -594,7 +598,7 @@ public static class ObjectBuiltIns
                 {
                     promise.DefineAccessor(propertyKey, descriptor.Get, descriptor.Set);
                 }
-                else if (DescriptorHasValueOrAccessor(descriptorArg))
+                else if (descriptor.HasValue)
                 {
                     promise.SetOwnProperty(propertyKey, descriptor.Value);
                 }
@@ -610,41 +614,6 @@ public static class ObjectBuiltIns
         }
 
         return target;
-    }
-
-    /// <summary>
-    /// Returns true if the descriptor object explicitly contains a `value`,
-    /// `get`, or `set` key — i.e. it is a data or accessor descriptor, not an
-    /// attribute-only descriptor. ECMA-262 §6.2.5.6 distinguishes "field
-    /// absent" (preserve existing) from "field present" (overwrite). The
-    /// flattened SharpTSPropertyDescriptor record loses that distinction, so
-    /// we re-derive it from the source descriptor object's own keys.
-    /// </summary>
-    private static bool DescriptorHasValueOrAccessor(object descriptorArg)
-    {
-        switch (descriptorArg)
-        {
-            case SharpTSObject so:
-                return so.HasProperty("value") || so.HasProperty("get") || so.HasProperty("set");
-            case Dictionary<string, object?> d:
-                return d.ContainsKey("value") || d.ContainsKey("get") || d.ContainsKey("set");
-            case System.Collections.IDictionary id:
-                return id.Contains("value") || id.Contains("get") || id.Contains("set");
-            default:
-                // Compiled $Object: probe via reflection on HasProperty(string).
-                var t = descriptorArg.GetType();
-                var has = t.GetMethod("HasProperty",
-                    System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance,
-                    null, [typeof(string)], null);
-                if (has != null)
-                {
-                    bool Has(string n) => has.Invoke(descriptorArg, [n]) is bool b && b;
-                    return Has("value") || Has("get") || Has("set");
-                }
-                // Conservative fallback: assume value-bearing so we don't
-                // silently drop user descriptors on unknown types.
-                return true;
-        }
     }
 
     /// <summary>
@@ -1564,6 +1533,39 @@ public static class ObjectBuiltIns
     }
 
     /// <summary>
+    /// ECMA-262 §6.2.5.5 ToPropertyDescriptor reads <c>value</c>/<c>get</c>/<c>set</c>
+    /// with HasProperty/Get semantics — walking the descriptor object's prototype
+    /// chain and honoring accessors. <see cref="SharpTSPropertyDescriptor.FromAnyObject"/>
+    /// only sees own fields, so re-derive these prototype-aware with interpreter access
+    /// and record presence on the descriptor (#801). An inherited setter-only
+    /// <c>value</c> counts as a data descriptor whose value reads <c>undefined</c>,
+    /// which <see cref="Interpreter.HasProperty"/> detects even though Get yields
+    /// undefined for it.
+    /// </summary>
+    private static void ApplyValueAndAccessors(SharpTSPropertyDescriptor descriptor, object? descObj, Interpreter interpreter)
+    {
+        if (descObj is null) return;
+        // TryGetDescriptorField applies Get semantics with correct presence AND
+        // own-accessor shadowing (an own setter-only `value` shadows an inherited
+        // getter, yielding undefined) — plain Get would walk past it (#801).
+        if (interpreter.TryGetDescriptorField(descObj, "value", out var v))
+        {
+            descriptor.Value = v;
+            descriptor.HasValue = true;
+        }
+        if (interpreter.TryGetDescriptorField(descObj, "get", out var g))
+        {
+            descriptor.HasGet = true;
+            descriptor.Get = g as ISharpTSCallable;
+        }
+        if (interpreter.TryGetDescriptorField(descObj, "set", out var s))
+        {
+            descriptor.HasSet = true;
+            descriptor.Set = s as ISharpTSCallable;
+        }
+    }
+
+    /// <summary>
     /// ECMA-262 §10.1.6.3 ValidateAndApplyPropertyDescriptor: when redefining an
     /// EXISTING own property, attributes the descriptor omits are preserved from
     /// the current property rather than reset to false (<see cref="SharpTSPropertyDescriptor"/>
@@ -1592,9 +1594,14 @@ public static class ObjectBuiltIns
         if (!DescriptorSpecifies(descObj, "configurable", interpreter)) descriptor.Configurable = existing.Configurable;
     }
 
-    /// <summary>True when the source descriptor object explicitly provides <paramref name="attr"/>.</summary>
+    /// <summary>
+    /// True when the source descriptor object provides <paramref name="attr"/> —
+    /// own or inherited, including setter-only accessors (ECMA-262 §7.3.11
+    /// HasProperty semantics), so an inherited attribute is treated as specified
+    /// rather than preserved (#801).
+    /// </summary>
     private static bool DescriptorSpecifies(object? descObj, string attr, Interpreter interpreter)
-        => interpreter.GetProperty(descObj, attr) is not (null or SharpTSUndefined);
+        => interpreter.HasProperty(descObj, attr);
 
     /// <summary>
     /// Runtime helper for Object.create called from compiled code.

--- a/Runtime/Types/SharpTSObject.cs
+++ b/Runtime/Types/SharpTSObject.cs
@@ -476,7 +476,7 @@ public class SharpTSObject(Dictionary<string, object?> fields) : ISharpTSPropert
                 // Cannot change attributes on non-configurable property
                 return false;
             }
-            if (!existingFlags.Writable && descriptor.Value != null)
+            if (!existingFlags.Writable && descriptor.HasValue)
             {
                 // Cannot change value of non-writable, non-configurable property
                 var currentValue = _fields.TryGetValue(name, out var v) ? v : null;
@@ -506,29 +506,38 @@ public class SharpTSObject(Dictionary<string, object?> fields) : ISharpTSPropert
             descriptor.Configurable
         );
 
+        // ECMA-262 §10.1.6.3 classification. SharpTSObject represents an accessor
+        // property only via a concrete getter/setter, so we take the accessor branch
+        // when the descriptor supplies a real getter/setter, when it refines an
+        // existing accessor (e.g. a `set`-only descriptor over one), or on an
+        // attribute-only redefine of an existing accessor — which must KEEP the
+        // accessor rather than convert it to a data property (#801, test 15.2.3.6-4-*).
+        // A descriptor whose only accessor field is undefined (`{get: undefined}`)
+        // on a fresh property falls through to a data property with value undefined,
+        // matching the observable result (hasOwnProperty true, value undefined).
+        bool descHasRealAccessor = descriptor.Get != null || descriptor.Set != null;
+        bool descSpecifiesAccessor = descriptor.HasGet || descriptor.HasSet;
+        bool existingIsAccessor = HasGetter(name) || HasSetter(name);
+
         // Apply the descriptor
-        if (descriptor.Get != null || descriptor.Set != null)
+        if (descHasRealAccessor
+            || (descSpecifiesAccessor && existingIsAccessor)
+            || (!descSpecifiesAccessor && !descriptor.HasValue && existingIsAccessor))
         {
             // Accessor property - remove any data property value
             _fields.Remove(name);
 
-            if (descriptor.Get != null)
-            {
-                DefineGetter(name, descriptor.Get);
-            }
-            else
-            {
-                _getters?.Remove(name);
-            }
+            // Install a concrete getter/setter; clear it only when the descriptor
+            // EXPLICITLY specifies the half as undefined (HasGet/HasSet with a null
+            // callable); otherwise (omitted) preserve the existing one. The non-null
+            // check comes first so internally-built descriptors that set Get/Set
+            // directly without the Has* flags (e.g. RegExp.prototype's accessor
+            // slots) still register their getter.
+            if (descriptor.Get != null) DefineGetter(name, descriptor.Get);
+            else if (descriptor.HasGet) _getters?.Remove(name);
 
-            if (descriptor.Set != null)
-            {
-                DefineSetter(name, descriptor.Set);
-            }
-            else
-            {
-                _setters?.Remove(name);
-            }
+            if (descriptor.Set != null) DefineSetter(name, descriptor.Set);
+            else if (descriptor.HasSet) _setters?.Remove(name);
         }
         else
         {
@@ -536,10 +545,21 @@ public class SharpTSObject(Dictionary<string, object?> fields) : ISharpTSPropert
             _getters?.Remove(name);
             _setters?.Remove(name);
 
-            // Only set value if provided in descriptor
-            if (descriptor.Value != null || !hasExisting)
+            // Only set value when the descriptor actually specifies `value`; an
+            // attribute-only redefine of an existing data property preserves its
+            // current value (ECMA-262 §10.1.6.3). Gating on HasValue rather than
+            // `Value != null` avoids wiping the value to the undefined sentinel when
+            // `value` was omitted (#801).
+            if (descriptor.HasValue)
             {
                 _fields[name] = descriptor.Value;
+            }
+            else if (!hasExisting)
+            {
+                // A brand-new data property whose descriptor omits `value` defaults
+                // to undefined per spec — store the sentinel (not C# null, which
+                // would read back as typeof "object").
+                _fields[name] = SharpTSUndefined.Instance;
             }
         }
 

--- a/Runtime/Types/SharpTSPropertyDescriptor.cs
+++ b/Runtime/Types/SharpTSPropertyDescriptor.cs
@@ -30,6 +30,22 @@ public class SharpTSPropertyDescriptor
     /// <summary>Whether the property can be deleted or changed.</summary>
     public bool Configurable { get; set; } = false;
 
+    /// <summary>
+    /// Presence flags distinguishing "field omitted" from "field present and
+    /// null/undefined". ECMA-262 §6.2.5.6 treats an absent descriptor field
+    /// differently from one explicitly set to undefined (e.g. an attribute-only
+    /// redefine preserves the existing value, whereas <c>{ value: undefined }</c>
+    /// overwrites it). The flattened Value/Get/Set/bool fields lose that
+    /// distinction; these flags record whether each field was actually specified
+    /// by the source descriptor object. See #801.
+    /// </summary>
+    public bool HasValue { get; set; }
+    public bool HasGet { get; set; }
+    public bool HasSet { get; set; }
+    public bool HasWritable { get; set; }
+    public bool HasEnumerable { get; set; }
+    public bool HasConfigurable { get; set; }
+
     public SharpTSPropertyDescriptor() { }
 
     public SharpTSPropertyDescriptor(
@@ -46,6 +62,15 @@ public class SharpTSPropertyDescriptor
         Writable = writable;
         Enumerable = enumerable;
         Configurable = configurable;
+        // Explicitly-constructed descriptors (ForMethod/ForGetter/…) are full
+        // descriptors: record which fields were supplied so the value-write gate in
+        // SharpTSObject.DefineProperty treats them as specified rather than omitted (#801).
+        HasValue = value != null;
+        HasGet = getter != null;
+        HasSet = setter != null;
+        HasWritable = true;
+        HasEnumerable = true;
+        HasConfigurable = true;
     }
 
     /// <summary>
@@ -84,40 +109,51 @@ public class SharpTSPropertyDescriptor
     {
         var descriptor = new SharpTSPropertyDescriptor();
 
-        var value = obj.GetProperty("value");
-        if (value != null)
+        // Own-only fast path. Presence is detected via HasProperty/HasSetter so an
+        // explicit `value: undefined` (or a setter-only `value` accessor) is recorded
+        // as specified rather than dropped, distinguishing "omitted" from "undefined"
+        // (#801). The interpreter-aware pass in ObjectBuiltIns re-derives these
+        // prototype-aware (walking the chain + ToBoolean) and overrides as needed.
+        if (obj.HasProperty("value") || obj.HasSetter("value"))
         {
-            descriptor.Value = value;
+            descriptor.Value = obj.GetProperty("value");
+            descriptor.HasValue = true;
         }
 
-        var getter = obj.GetProperty("get");
-        if (getter is ISharpTSCallable getterFn)
+        if (obj.HasProperty("get") || obj.HasSetter("get"))
         {
-            descriptor.Get = getterFn;
+            descriptor.HasGet = true;
+            if (obj.GetProperty("get") is ISharpTSCallable getterFn)
+            {
+                descriptor.Get = getterFn;
+            }
         }
 
-        var setter = obj.GetProperty("set");
-        if (setter is ISharpTSCallable setterFn)
+        if (obj.HasProperty("set") || obj.HasSetter("set"))
         {
-            descriptor.Set = setterFn;
+            descriptor.HasSet = true;
+            if (obj.GetProperty("set") is ISharpTSCallable setterFn)
+            {
+                descriptor.Set = setterFn;
+            }
         }
 
-        var writable = obj.GetProperty("writable");
-        if (writable is bool w)
+        if (obj.HasProperty("writable"))
         {
-            descriptor.Writable = w;
+            descriptor.HasWritable = true;
+            if (obj.GetProperty("writable") is bool w) descriptor.Writable = w;
         }
 
-        var enumerable = obj.GetProperty("enumerable");
-        if (enumerable is bool e)
+        if (obj.HasProperty("enumerable"))
         {
-            descriptor.Enumerable = e;
+            descriptor.HasEnumerable = true;
+            if (obj.GetProperty("enumerable") is bool e) descriptor.Enumerable = e;
         }
 
-        var configurable = obj.GetProperty("configurable");
-        if (configurable is bool c)
+        if (obj.HasProperty("configurable"))
         {
-            descriptor.Configurable = c;
+            descriptor.HasConfigurable = true;
+            if (obj.GetProperty("configurable") is bool c) descriptor.Configurable = c;
         }
 
         return descriptor;
@@ -157,40 +193,47 @@ public class SharpTSPropertyDescriptor
         {
             object? GetProp(string name) => getPropertyMethod.Invoke(obj, [name]);
 
-            var value = GetProp("value");
-            if (value != null)
+            // Probe presence via HasProperty(string) when the type exposes it, so an
+            // explicit `value: undefined` is distinguished from an omitted value (#801).
+            var hasPropertyMethod = type.GetMethod("HasProperty",
+                System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance,
+                null, [typeof(string)], null);
+            bool HasProp(string name) => hasPropertyMethod?.Invoke(obj, [name]) is bool b && b;
+
+            if (HasProp("value"))
             {
-                descriptor.Value = value;
+                descriptor.Value = GetProp("value");
+                descriptor.HasValue = true;
             }
 
-            var getter = GetProp("get");
-            if (getter is ISharpTSCallable getterFn)
+            if (HasProp("get"))
             {
-                descriptor.Get = getterFn;
+                descriptor.HasGet = true;
+                if (GetProp("get") is ISharpTSCallable getterFn) descriptor.Get = getterFn;
             }
 
-            var setter = GetProp("set");
-            if (setter is ISharpTSCallable setterFn)
+            if (HasProp("set"))
             {
-                descriptor.Set = setterFn;
+                descriptor.HasSet = true;
+                if (GetProp("set") is ISharpTSCallable setterFn) descriptor.Set = setterFn;
             }
 
-            var writable = GetProp("writable");
-            if (writable is bool w)
+            if (HasProp("writable"))
             {
-                descriptor.Writable = w;
+                descriptor.HasWritable = true;
+                if (GetProp("writable") is bool w) descriptor.Writable = w;
             }
 
-            var enumerable = GetProp("enumerable");
-            if (enumerable is bool e)
+            if (HasProp("enumerable"))
             {
-                descriptor.Enumerable = e;
+                descriptor.HasEnumerable = true;
+                if (GetProp("enumerable") is bool e) descriptor.Enumerable = e;
             }
 
-            var configurable = GetProp("configurable");
-            if (configurable is bool c)
+            if (HasProp("configurable"))
             {
-                descriptor.Configurable = c;
+                descriptor.HasConfigurable = true;
+                if (GetProp("configurable") is bool c) descriptor.Configurable = c;
             }
         }
 
@@ -207,31 +250,37 @@ public class SharpTSPropertyDescriptor
         if (dict.TryGetValue("value", out var value))
         {
             descriptor.Value = value;
+            descriptor.HasValue = true;
         }
 
-        if (dict.TryGetValue("get", out var getter) && getter is ISharpTSCallable getterFn)
+        if (dict.TryGetValue("get", out var getter))
         {
-            descriptor.Get = getterFn;
+            descriptor.HasGet = true;
+            if (getter is ISharpTSCallable getterFn) descriptor.Get = getterFn;
         }
 
-        if (dict.TryGetValue("set", out var setter) && setter is ISharpTSCallable setterFn)
+        if (dict.TryGetValue("set", out var setter))
         {
-            descriptor.Set = setterFn;
+            descriptor.HasSet = true;
+            if (setter is ISharpTSCallable setterFn) descriptor.Set = setterFn;
         }
 
-        if (dict.TryGetValue("writable", out var writable) && writable is bool w)
+        if (dict.TryGetValue("writable", out var writable))
         {
-            descriptor.Writable = w;
+            descriptor.HasWritable = true;
+            if (writable is bool w) descriptor.Writable = w;
         }
 
-        if (dict.TryGetValue("enumerable", out var enumerable) && enumerable is bool e)
+        if (dict.TryGetValue("enumerable", out var enumerable))
         {
-            descriptor.Enumerable = e;
+            descriptor.HasEnumerable = true;
+            if (enumerable is bool e) descriptor.Enumerable = e;
         }
 
-        if (dict.TryGetValue("configurable", out var configurable) && configurable is bool c)
+        if (dict.TryGetValue("configurable", out var configurable))
         {
-            descriptor.Configurable = c;
+            descriptor.HasConfigurable = true;
+            if (configurable is bool c) descriptor.Configurable = c;
         }
 
         return descriptor;
@@ -247,31 +296,37 @@ public class SharpTSPropertyDescriptor
         if (dict.Contains("value"))
         {
             descriptor.Value = dict["value"];
+            descriptor.HasValue = true;
         }
 
-        if (dict.Contains("get") && dict["get"] is ISharpTSCallable getterFn)
+        if (dict.Contains("get"))
         {
-            descriptor.Get = getterFn;
+            descriptor.HasGet = true;
+            if (dict["get"] is ISharpTSCallable getterFn) descriptor.Get = getterFn;
         }
 
-        if (dict.Contains("set") && dict["set"] is ISharpTSCallable setterFn)
+        if (dict.Contains("set"))
         {
-            descriptor.Set = setterFn;
+            descriptor.HasSet = true;
+            if (dict["set"] is ISharpTSCallable setterFn) descriptor.Set = setterFn;
         }
 
-        if (dict.Contains("writable") && dict["writable"] is bool w)
+        if (dict.Contains("writable"))
         {
-            descriptor.Writable = w;
+            descriptor.HasWritable = true;
+            if (dict["writable"] is bool w) descriptor.Writable = w;
         }
 
-        if (dict.Contains("enumerable") && dict["enumerable"] is bool e)
+        if (dict.Contains("enumerable"))
         {
-            descriptor.Enumerable = e;
+            descriptor.HasEnumerable = true;
+            if (dict["enumerable"] is bool e) descriptor.Enumerable = e;
         }
 
-        if (dict.Contains("configurable") && dict["configurable"] is bool c)
+        if (dict.Contains("configurable"))
         {
-            descriptor.Configurable = c;
+            descriptor.HasConfigurable = true;
+            if (dict["configurable"] is bool c) descriptor.Configurable = c;
         }
 
         return descriptor;

--- a/SharpTS.Tests/SharedTests/ObjectFeatureTests.cs
+++ b/SharpTS.Tests/SharedTests/ObjectFeatureTests.cs
@@ -2293,6 +2293,83 @@ public class ObjectFeatureTests
         Assert.Equal("10\n10\n", output);
     }
 
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Object_DefineProperty_ReadsInheritedValueViaSetterOnlyAccessor(ExecutionMode mode)
+    {
+        // #801: ECMA-262 §6.2.5.5 ToPropertyDescriptor reads `value` via HasProperty/Get,
+        // walking the prototype chain. A descriptor whose `value` is an INHERITED
+        // setter-only accessor IS a data descriptor with value === undefined, so the
+        // target property must be overwritten to undefined (not preserved).
+        var source = """
+            const proto: any = {};
+            Object.defineProperty(proto, "value", { set() {} });
+            const Ctor: any = function () {};
+            Ctor.prototype = proto;
+            const child: any = new Ctor();
+            const o: any = { property: 120 };
+            Object.defineProperty(o, "property", child);
+            console.log(typeof o.property);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("undefined\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Object_DefineProperty_AttributeOnlyRedefinePreservesValue(ExecutionMode mode)
+    {
+        // #801: an attribute-only descriptor (no `value` key) must preserve the existing
+        // value rather than wiping it to the undefined sentinel.
+        var source = """
+            const o: any = { a: 42 };
+            Object.defineProperty(o, "a", { writable: false });
+            console.log(o.a);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("42\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void Object_DefineProperty_ReadsInheritedEnumerableFromRegExpPrototype(ExecutionMode mode)
+    {
+        // #801: a descriptor's INHERITED `enumerable` (here via a user-set
+        // RegExp.prototype property) must be read through the prototype chain. RegExp
+        // instances expose user-set prototype properties (built-in prototype mutability).
+        // Interpreter-only: compiled $RegExp prototype mutability is tracked separately.
+        var source = """
+            (RegExp.prototype as any).enumerable = true;
+            const regObj: any = new RegExp();
+            const obj: any = {};
+            Object.defineProperty(obj, "property", regObj);
+            let seen = false;
+            for (const p in obj) if (p === "property") seen = true;
+            console.log(seen);
+            console.log((regObj as any).enumerable);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("true\ntrue\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void Object_RegExp_InheritsUserSetPrototypeProperty(ExecutionMode mode)
+    {
+        // #801/#474-adjacent: a plain user property set on RegExp.prototype is visible
+        // on RegExp instances via the prototype chain.
+        var source = """
+            (RegExp.prototype as any).foo = 1;
+            console.log((new RegExp() as any).foo);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("1\n", output);
+    }
+
     // ========================
     // Object.defineProperties
     // ========================


### PR DESCRIPTION
## Summary

`Object.defineProperty` / `ToPropertyDescriptor` (ECMA-262 §6.2.5.5) reads each descriptor field (`value`, `get`, `set`, `writable`, `enumerable`, `configurable`) with `HasProperty`/`Get` semantics — walking the descriptor object's **prototype chain** and honoring accessors. SharpTS read them **own-only**, so an inherited field was silently missed. This was the gap behind the committed Test262 baseline regression `Object/defineProperty/15.2.3.6-3-40-1` (left by #475), plus a related `value` undefined-sentinel bug that wiped existing values.

Fixes #801.

## What changed

- **`SharpTSPropertyDescriptor`** — adds `HasValue`/`HasGet`/`HasSet`/`HasWritable`/`HasEnumerable`/`HasConfigurable` presence flags, set in every `From*` factory, so "field omitted" is distinguished from "field present and `undefined`".
- **Interpreter** — adds prototype-walking, accessor-aware `HasProperty` and `TryGetDescriptorField` (Get semantics with correct own-setter-only shadowing of an inherited getter).
- **`ObjectBuiltIns.DefineProperty`** — `ApplyValueAndAccessors` re-derives `value`/`get`/`set` prototype-aware; presence checks use the new flags (drops own-only `DescriptorHasValueOrAccessor`).
- **`SharpTSObject.DefineProperty`** — value write gated on `HasValue` (fixes the undefined-sentinel wipe); a brand-new value-less data property defaults to `undefined`; an attribute-only redefine of an **accessor** preserves it instead of destroying it; getters/setters install on non-null and clear only on an explicit `undefined` half.
- **RegExp instance reads** consult the realm `RegExp.prototype` for user-set inherited properties (built-in prototype mutability) — clears `15.2.3.6-3-40-1`.
- **Compiled IL** (`RuntimeEmitter.Objects.Descriptors`) — descriptor-field reads detect presence via an inline `$PropertyDescriptorStore` prototype walk, so an inherited setter-only `value` is honored (`15.2.3.6-3-138` now passes compiled too).
- **Tests** — 6 new `ObjectFeatureTests` cases (both execution modes where applicable).

## Verification

- **13,448 unit tests pass, 0 failures.**
- Both issue repros pass interpreted; repro #2 + value-preservation also pass **compiled**.
- Directly verified descriptor edge cases (accessor preservation on redefine, accessor-with-`undefined`-get/set, `RegExp.prototype` gOPD, Math/RegExp descriptors, RegExp `Symbol.match/replace`). Caught & fixed one self-introduced regression (RegExp.prototype accessor gOPD) via a stash-and-compare against clean `main`.

> Note: the standalone `SharpTS.Test262` baseline is stale and the harness is flaky in this tree (verified against clean `main`), so it was not regenerated. Compiled-mode RegExp **instance** prototype mutability (repro #1 compiled, ≈ #474) is left as a follow-up — a pre-existing gap, not a #475 regression.
