### PR TITLE
Fix #681: support .call/.apply/.bind on async functions

### DIFF
--- a/Compilation/AsyncArrowMoveNextEmitter.Expressions.cs
+++ b/Compilation/AsyncArrowMoveNextEmitter.Expressions.cs
@@ -18,6 +18,17 @@ public partial class AsyncArrowMoveNextEmitter
 
     protected override void EmitThis()
     {
+        // Standalone async function expression: `this` is bound dynamically at
+        // call time (fn.call/apply/bind) and snapshotted into OwnThisField by the
+        // stub — read it rather than a lexical capture.
+        if (_builder.IsStandalone && _builder.Arrow.HasOwnThis && _builder.OwnThisField != null)
+        {
+            _il.Emit(OpCodes.Ldarg_0);
+            _il.Emit(OpCodes.Ldfld, _builder.OwnThisField);
+            SetStackUnknown();
+            return;
+        }
+
         // Load 'this' from outer state machine if captured
         if (_builder.Captures.Contains("this"))
         {

--- a/Compilation/AsyncArrowStateMachineBuilder.cs
+++ b/Compilation/AsyncArrowStateMachineBuilder.cs
@@ -37,6 +37,12 @@ public class AsyncArrowStateMachineBuilder
     // Self-boxed field for sharing this state machine with nested async arrows
     public FieldBuilder? SelfBoxedField { get; private set; }
 
+    // Dynamic `this` field for a standalone async FUNCTION EXPRESSION (HasOwnThis).
+    // Unlike a true arrow (lexical this), its `this` is bound at call time via
+    // fn.call/apply/bind, so it lives in its own field populated by the stub from
+    // the thread-local — not in a lexical capture field. Null for true arrows.
+    public FieldBuilder? OwnThisField { get; private set; }
+
     // Core state machine fields
     public FieldBuilder StateField { get; private set; } = null!;
     public FieldBuilder BuilderField { get; private set; } = null!;
@@ -279,6 +285,18 @@ public class AsyncArrowStateMachineBuilder
             LocalFields[localName] = field;
         }
 
+        // Async function expressions bind `this` dynamically at call time, so give
+        // them a dedicated field the stub fills from the thread-local receiver
+        // (see DefineStubMethod). True arrows capture `this` lexically instead.
+        if (Arrow.HasOwnThis)
+        {
+            OwnThisField = _stateMachineType.DefineField(
+                "<>4__this",
+                _types.Object,
+                FieldAttributes.Public
+            );
+        }
+
         // Define capture fields for variables from the enclosing (non-async) function
         // These will be passed to the stub method and stored in the state machine
         foreach (var captureName in Captures)
@@ -316,7 +334,7 @@ public class AsyncArrowStateMachineBuilder
     /// The stub takes (outer state machine boxed, params...) and returns Task&lt;object&gt;.
     /// For standalone arrows, there's no outer SM parameter but captures are passed.
     /// </summary>
-    public void DefineStubMethod(TypeBuilder programType)
+    public void DefineStubMethod(TypeBuilder programType, EmittedRuntime? runtime = null)
     {
         // Build parameter types list
         var paramTypes = new List<Type>();
@@ -388,6 +406,28 @@ public class AsyncArrowStateMachineBuilder
                 il.Emit(OpCodes.Stfld, captureField);
             }
             paramOffset = 1; // Skip the single capture-array arg when copying params
+        }
+
+        // Async function expressions (HasOwnThis) have a DYNAMIC `this` bound at
+        // call time — `fn.call(receiver)`, `fn.apply(...)`, `fn.bind(...)` — not a
+        // lexically-captured one. $TSFunction.InvokeWithThis stashes that receiver
+        // in the thread-local `_currentFunctionThis` before dispatching here, so
+        // snapshot it into the dedicated OwnThisField. Snapshotting at stub entry
+        // (synchronously, before any await) is what makes it survive state-machine
+        // suspension/resume on another thread. A null thread-local means a plain
+        // call → sloppy `this` (globalThis sentinel), matching
+        // LocalVariableResolver.LoadThis.
+        if (IsStandalone && Arrow.HasOwnThis && runtime != null && OwnThisField != null)
+        {
+            il.Emit(OpCodes.Ldloca, smLocal);
+            il.Emit(OpCodes.Ldsfld, runtime.CurrentFunctionThisField);
+            var thisNotNull = il.DefineLabel();
+            il.Emit(OpCodes.Dup);
+            il.Emit(OpCodes.Brtrue, thisNotNull);
+            il.Emit(OpCodes.Pop);
+            il.Emit(OpCodes.Ldsfld, runtime.GlobalThisSingletonField);
+            il.MarkLabel(thisNotNull);
+            il.Emit(OpCodes.Stfld, OwnThisField);
         }
 
         // Copy parameters to state machine fields (in order!)

--- a/Compilation/ILCompiler.Async.cs
+++ b/Compilation/ILCompiler.Async.cs
@@ -249,7 +249,7 @@ public partial class ILCompiler
                     hasNestedChildren);
 
                 // Define the stub method that will be called to invoke the async arrow
-                arrowBuilder.DefineStubMethod(_programType);
+                arrowBuilder.DefineStubMethod(_programType, _runtime);
                 MarkPadsUndefined(arrowBuilder.StubMethod); // #640
 
                 _async.ArrowBuilders[arrowInfo.Arrow] = arrowBuilder;
@@ -265,7 +265,7 @@ public partial class ILCompiler
                 hasNestedAsyncArrows: hasNestedChildren);
 
             // Define the stub method that will be called to invoke the async arrow
-            arrowBuilder.DefineStubMethod(_programType);
+            arrowBuilder.DefineStubMethod(_programType, _runtime);
             MarkPadsUndefined(arrowBuilder.StubMethod); // #640
 
             _async.ArrowBuilders[arrowInfo.Arrow] = arrowBuilder;
@@ -1148,7 +1148,7 @@ public partial class ILCompiler
                 arrowAnalysis.HoistedLocals);
 
             // Define the stub method
-            arrowBuilder.DefineStubMethod(_programType);
+            arrowBuilder.DefineStubMethod(_programType, _runtime);
             MarkPadsUndefined(arrowBuilder.StubMethod); // #640
 
             // Store the builder

--- a/Runtime/BuiltIns/FunctionBuiltIns.cs
+++ b/Runtime/BuiltIns/FunctionBuiltIns.cs
@@ -182,6 +182,22 @@ public static class FunctionBuiltIns
             return bound.Call(interp, args);
         }
 
+        // Async function expressions / async arrows with their own 'this' rebind
+        // the receiver; true async arrows ignore thisArg (lexical this). A null
+        // thisArg leaves the captured 'this' unchanged (mirrors the sync path).
+        if (callable is SharpTSAsyncArrowFunction asyncArrow)
+        {
+            if (asyncArrow.HasOwnThis && thisArg != null)
+                return asyncArrow.Bind(thisArg).Call(interp, args);
+            return asyncArrow.Call(interp, args);
+        }
+        if (callable is SharpTSAsyncFunction asyncFn)
+        {
+            return thisArg != null
+                ? asyncFn.BindThisValue(thisArg).Call(interp, args)
+                : asyncFn.Call(interp, args);
+        }
+
         // Array.prototype methods rebind their receiver via BindTo so that
         // Array.prototype.push.apply(target, items) pushes onto `target`.
         if (callable is SharpTSArrayUnboundMethod unbound)
@@ -313,6 +329,18 @@ public class BoundFunction : ISharpTSCallable
                 return boundArrow.CallV2(interpreter, combined);
             }
 
+            // Async function expressions (HasOwnThis) and async function
+            // declarations rebind 'this'; true async arrows capture lexically
+            // and fall through to the unbound target call below.
+            if (_target is SharpTSAsyncArrowFunction asyncArrow && asyncArrow.HasOwnThis)
+            {
+                return ((ISharpTSCallable)asyncArrow.Bind(_thisArg)).CallV2(interpreter, combined);
+            }
+            if (_target is SharpTSAsyncFunction asyncFn)
+            {
+                return ((ISharpTSCallable)asyncFn.BindThisValue(_thisArg)).CallV2(interpreter, combined);
+            }
+
             // Mirror the legacy Call path for BuiltInMethod (issue #101): the
             // V2 path is hit by JS-level invocation of a BoundFunction wrapping
             // a BuiltInMethod target (e.g. Function.prototype.call.bind(...)).
@@ -349,6 +377,18 @@ public class BoundFunction : ISharpTSCallable
             {
                 var boundArrow = arrow.Bind(_thisArg);
                 return boundArrow.Call(interpreter, combinedArgs);
+            }
+
+            // Async function expressions (HasOwnThis) and async function
+            // declarations rebind 'this'; true async arrows capture lexically
+            // and fall through to the unbound target call below.
+            if (_target is SharpTSAsyncArrowFunction asyncArrow && asyncArrow.HasOwnThis)
+            {
+                return asyncArrow.Bind(_thisArg).Call(interpreter, combinedArgs);
+            }
+            if (_target is SharpTSAsyncFunction asyncFn)
+            {
+                return asyncFn.BindThisValue(_thisArg).Call(interpreter, combinedArgs);
             }
 
             // Built-in methods read their receiver from the bound `_receiver`

--- a/Runtime/Types/SharpTSAsyncFunction.cs
+++ b/Runtime/Types/SharpTSAsyncFunction.cs
@@ -2,6 +2,7 @@ using SharpTS.Parsing;
 using SharpTS.Runtime;
 using SharpTS.Runtime.Exceptions;
 using SharpTS.Execution;
+using SharpTS.TypeSystem;
 
 namespace SharpTS.Runtime.Types;
 
@@ -28,8 +29,12 @@ public interface ISharpTSAsyncCallable : ISharpTSCallable
 /// The synchronous Call method returns a <see cref="SharpTSPromise"/> immediately,
 /// while CallAsync executes the function body asynchronously.
 /// </remarks>
-public class SharpTSAsyncFunction : ISharpTSAsyncCallable
+public class SharpTSAsyncFunction : ISharpTSAsyncCallable, ITypeCategorized
 {
+    // JS async functions are functions — categorize as Function so member
+    // access routes through FunctionBuiltIns (call/apply/bind/length/name).
+    public TypeCategory RuntimeCategory => TypeCategory.Function;
+
     private readonly Stmt.Function _declaration;
     private readonly RuntimeEnvironment _closure;
     private readonly int _arity;
@@ -123,6 +128,18 @@ public class SharpTSAsyncFunction : ISharpTSAsyncCallable
         return new SharpTSAsyncFunction(_declaration, environment);
     }
 
+    /// <summary>
+    /// Rebinds <c>this</c> to an arbitrary value for <c>fn.call/apply/bind</c>.
+    /// Unlike <see cref="Bind(SharpTSInstance)"/> (used for method binding), the
+    /// receiver here may be any runtime value (a plain object, dictionary, etc.).
+    /// </summary>
+    public SharpTSAsyncFunction BindThisValue(object? thisObject)
+    {
+        RuntimeEnvironment environment = new(_closure);
+        environment.Define("this", thisObject);
+        return new SharpTSAsyncFunction(_declaration, environment);
+    }
+
     public SharpTSAsyncFunction BindStatic(SharpTSClass klass)
     {
         RuntimeEnvironment environment = new(_closure);
@@ -144,8 +161,12 @@ public class SharpTSAsyncFunction : ISharpTSAsyncCallable
 /// For arrow functions (<c>HasOwnThis=false</c>), <c>this</c> is captured from the enclosing scope.
 /// For async function expressions (<c>HasOwnThis=true</c>), <c>this</c> is bound at call time.
 /// </remarks>
-public class SharpTSAsyncArrowFunction : ISharpTSAsyncCallable
+public class SharpTSAsyncArrowFunction : ISharpTSAsyncCallable, ITypeCategorized
 {
+    // JS async arrows / async function expressions are functions — categorize
+    // as Function so member access routes through FunctionBuiltIns.
+    public TypeCategory RuntimeCategory => TypeCategory.Function;
+
     private readonly Expr.ArrowFunction _declaration;
     private readonly RuntimeEnvironment _closure;
     private readonly int _arity;

--- a/SharpTS.Tests/SharedTests/AsyncCallApplyBindTests.cs
+++ b/SharpTS.Tests/SharedTests/AsyncCallApplyBindTests.cs
@@ -1,0 +1,103 @@
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests;
+
+/// <summary>
+/// Regression tests for issue #681: <c>Function.prototype.call</c> / <c>.apply</c> /
+/// <c>.bind</c> on async functions (async arrows, async function expressions, async
+/// function declarations).
+/// </summary>
+/// <remarks>
+/// Two defects were fixed:
+/// (A) Interpreter — async callables didn't classify as <c>TypeCategory.Function</c>, so
+///     member access never reached <c>FunctionBuiltIns</c> and <c>aarrow.call(...)</c> threw
+///     "undefined is not a function". Fixed by implementing <c>ITypeCategorized</c> on
+///     <c>SharpTSAsyncFunction</c>/<c>SharpTSAsyncArrowFunction</c> plus async this-binding
+///     branches in <c>InvokeWithThis</c>/<c>BoundFunction</c>.
+/// (B) Compiled — a standalone async function expression (HasOwnThis) dropped the supplied
+///     <c>this</c>: it had no field for a dynamically-bound receiver. Fixed by adding
+///     <c>OwnThisField</c> to the async-arrow state machine, snapshotting the thread-local
+///     <c>_currentFunctionThis</c> into it at stub entry, and reading it from <c>EmitThis</c>.
+/// </remarks>
+public class AsyncCallApplyBindTests
+{
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AsyncArrow_Call_PassesArguments(ExecutionMode mode)
+    {
+        // The headline repro from the issue: used to throw "undefined is not a function".
+        var source = """
+            const aarrow = async (x: number) => x + 1;
+            aarrow.call(null, 5).then((r: number) => console.log(r));
+            """;
+
+        Assert.Equal("6\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AsyncFunctionExpression_Call_BindsThis(ExecutionMode mode)
+    {
+        var source = """
+            const af = async function (this: any) { return this.x; };
+            af.call({ x: 42 }).then((r: number) => console.log(r));
+            """;
+
+        Assert.Equal("42\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AsyncFunctionExpression_Apply_BindsThis(ExecutionMode mode)
+    {
+        var source = """
+            const af = async function (this: any) { return this.x; };
+            af.apply({ x: 7 }, []).then((r: number) => console.log(r));
+            """;
+
+        Assert.Equal("7\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AsyncFunctionExpression_Bind_BindsThis(ExecutionMode mode)
+    {
+        var source = """
+            const af = async function (this: any) { return this.x; };
+            const b = af.bind({ x: 9 });
+            b().then((r: number) => console.log(r));
+            """;
+
+        Assert.Equal("9\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AsyncArrow_Bind_IgnoresThisAppliesPartialArgs(ExecutionMode mode)
+    {
+        // True async arrows ignore the bound `this` (lexical) but still honor partial args.
+        var source = """
+            const add = async (a: number, b: number) => a + b;
+            add.bind(null, 10)(5).then((r: number) => console.log(r));
+            """;
+
+        Assert.Equal("15\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AsyncFunctionExpression_CallBindsThis_AcrossAwait(ExecutionMode mode)
+    {
+        // The bound `this` must survive a state-machine suspension/resume.
+        var source = """
+            const af = async function (this: any, n: number) {
+                await Promise.resolve(0);
+                return this.x + n;
+            };
+            af.call({ x: 100 }, 5).then((r: number) => console.log(r));
+            """;
+
+        Assert.Equal("105\n", TestHarness.Run(source, mode));
+    }
+}


### PR DESCRIPTION
## Summary

Resolves #681. `Function.prototype.call`/`apply`/`bind` did not work on async functions:

- **Interpreter:** threw `TypeError: undefined is not a function` — the methods weren't found on the async-function runtime value.
- **Compiled:** the call resolved but the supplied `this` was silently dropped.

Both are fixed, in interpreter **and** compiled modes.

## Root causes

**Interpreter.** `SharpTSAsyncFunction`/`SharpTSAsyncArrowFunction` didn't implement `ITypeCategorized`, so they classified as `TypeCategory.Unknown`; member access never reached `FunctionBuiltIns.GetMember` and returned `undefined`. Additionally, `InvokeWithThis`/`BoundFunction` had no async branch, so an async function expression's `this` wasn't rebound.

**Compiled.** A standalone async function expression (`HasOwnThis`) compiles to the async-arrow state machine, which had no field for a dynamically-bound `this` — `EmitThis` emitted `null`.

## Changes

- **`Runtime/Types/SharpTSAsyncFunction.cs`** — both async classes implement `ITypeCategorized` → `TypeCategory.Function`; added `BindThisValue(object?)` for arbitrary receivers.
- **`Runtime/BuiltIns/FunctionBuiltIns.cs`** — async this-binding branches in `InvokeWithThis` and `BoundFunction.Call`/`CallV2` (function expressions rebind `this`; true arrows ignore it).
- **`Compilation/AsyncArrowStateMachineBuilder.cs`** — added `OwnThisField`, populated at stub entry from the thread-local `_currentFunctionThis` (snapshotted synchronously before any `await`, so it survives state-machine suspension).
- **`Compilation/AsyncArrowMoveNextEmitter.Expressions.cs`** — `EmitThis` reads `OwnThisField` for standalone function expressions.
- **`Compilation/ILCompiler.Async.cs`** — threaded `_runtime` into the `DefineStubMethod` call sites.

## Tests

New `SharpTS.Tests/SharedTests/AsyncCallApplyBindTests.cs` — 6 cases × both execution modes, including an across-`await` case proving the bound `this` survives suspension.

## Verification

- Issue repro: all cases pass in interpreter and compiled modes.
- 237 async/arrow/function/bound tests pass.
- Full suite: the only failures are pre-existing and unrelated (Test262 baseline drift reproduces identically on clean `main`; the few compiled-mode failures pass in isolation — known .NET 10 tier-0 JIT/order flakiness).
