### PR TITLE
Fix #503: forward next(v) to non-generator custom iterators in yield*

### DIFF
--- a/Compilation/EmittedRuntime.cs
+++ b/Compilation/EmittedRuntime.cs
@@ -1389,11 +1389,13 @@ public class EmittedRuntime
     public ConstructorBuilder IteratorWrapperCtor { get; set; } = null!;
 
     // Iterator protocol helper methods
-    public MethodBuilder GetIteratorFunction { get; set; } = null!;  // Returns iterator function or null
-    public MethodBuilder InvokeIteratorNext { get; set; } = null!;   // Calls next() on iterator
-    public MethodBuilder GetIteratorDone { get; set; } = null!;      // Extracts done from result
-    public MethodBuilder GetIteratorValue { get; set; } = null!;     // Extracts value from result
-    public MethodBuilder IterateToList { get; set; } = null!;        // Converts any iterable to List<object>
+    public MethodBuilder GetIteratorFunction { get; set; } = null!;              // Returns iterator function or null
+    public MethodBuilder InvokeIteratorNext { get; set; } = null!;              // Calls next() on iterator (no sent value)
+    public MethodBuilder InvokeIteratorNextWithSent { get; set; } = null!;      // Calls next(sent) forwarding resume value (#503)
+    public MethodBuilder GetIteratorDone { get; set; } = null!;                 // Extracts done from result
+    public MethodBuilder GetIteratorValue { get; set; } = null!;                // Extracts value from result
+    public MethodBuilder IterateToList { get; set; } = null!;                   // Converts any iterable to List<object>
+    public MethodBuilder IteratorWrapperMoveNextWithSent { get; set; } = null!; // $IteratorWrapper.MoveNextWithSent(sent) (#503)
 
     // Generator interface ($IGenerator extends IEnumerator<object> with Return/Throw)
     public TypeBuilder GeneratorInterfaceType { get; set; } = null!;

--- a/Compilation/GeneratorMoveNextEmitter.Expressions.Yield.cs
+++ b/Compilation/GeneratorMoveNextEmitter.Expressions.Yield.cs
@@ -262,12 +262,14 @@ public partial class GeneratorMoveNextEmitter
         // before the setup above, so the field already holds the live value (#400/#414).
         _helpers.RehydrateLiveSpillsAfterResume();
 
-        // Drive the delegate one step. Two paths converge on a single value via valueTemp:
+        // Drive the delegate one step. Three paths converge on a single value via valueTemp:
         //   - $IGenerator (a delegated SharpTS generator): call next(this.SentField) so the
         //     outer's resume value reaches the inner's suspended yield (#476). The result is
         //     a { value, done } record.
-        //   - IEnumerator (arrays, $IteratorWrapper, etc.): MoveNext()/Current, which carry
-        //     no resume slot — the sent value is irrelevant to those iterators.
+        //   - $IteratorWrapper (custom iterator objects with [Symbol.iterator]): call
+        //     MoveNextWithSent(this.SentField) to forward the sent value to next(v) (#503).
+        //   - Plain IEnumerator (arrays, Maps, Sets, etc.): MoveNext()/Current with no
+        //     resume slot — the sent value is irrelevant to those iterators.
         var valueTemp = _il.DeclareLocal(typeof(object));
         var genResultLocal = _il.DeclareLocal(typeof(object));
         var yieldStarResultLocal = _il.DeclareLocal(typeof(object));
@@ -279,6 +281,11 @@ public partial class GeneratorMoveNextEmitter
             driveViaGeneratorLabel = _il.DefineLabel();
             genDoneLabel = _il.DefineLabel();
         }
+        var iteratorWrapperType = _ctx?.Runtime?.IteratorWrapperType;
+        var moveNextWithSent = _ctx?.Runtime?.IteratorWrapperMoveNextWithSent;
+        Label plainEnumeratorLabel = default;
+        if (iteratorWrapperType != null && moveNextWithSent != null)
+            plainEnumeratorLabel = _il.DefineLabel();
 
         // #526: an external return()/throw() injected while suspended at this yield* is forwarded
         // into the delegate (ECMA-262 §14.4.14): return() runs the delegate's finally, then the outer
@@ -297,7 +304,32 @@ public partial class GeneratorMoveNextEmitter
             _il.Emit(OpCodes.Brtrue, driveViaGeneratorLabel);
         }
 
-        // IEnumerator path: advance, then read Current into valueTemp.
+        // $IteratorWrapper path: call MoveNextWithSent(SentField) so the outer's resume value
+        // is forwarded as the argument to the custom iterator's next(v) (ECMA-262 §14.4.14, #503).
+        if (iteratorWrapperType != null && moveNextWithSent != null)
+        {
+            _il.Emit(OpCodes.Ldarg_0);
+            _il.Emit(OpCodes.Ldfld, delegatedField);
+            _il.Emit(OpCodes.Isinst, iteratorWrapperType);
+            _il.Emit(OpCodes.Brfalse, plainEnumeratorLabel);
+
+            _il.Emit(OpCodes.Ldarg_0);
+            _il.Emit(OpCodes.Ldfld, delegatedField);
+            _il.Emit(OpCodes.Castclass, iteratorWrapperType);
+            _il.Emit(OpCodes.Ldarg_0);
+            _il.Emit(OpCodes.Ldfld, _builder.SentField);
+            _il.Emit(OpCodes.Call, moveNextWithSent);
+            _il.Emit(OpCodes.Brfalse, loopEnd);
+            _il.Emit(OpCodes.Ldarg_0);
+            _il.Emit(OpCodes.Ldfld, delegatedField);
+            _il.Emit(OpCodes.Callvirt, current);
+            _il.Emit(OpCodes.Stloc, valueTemp);
+            _il.Emit(OpCodes.Br, haveValueLabel);
+
+            _il.MarkLabel(plainEnumeratorLabel);
+        }
+
+        // Plain IEnumerator path (arrays, Maps, Sets, etc.): advance, then read Current into valueTemp.
         _il.Emit(OpCodes.Ldarg_0);
         _il.Emit(OpCodes.Ldfld, delegatedField);
         _il.Emit(OpCodes.Callvirt, moveNext);

--- a/Compilation/RuntimeEmitter.Iterator.cs
+++ b/Compilation/RuntimeEmitter.Iterator.cs
@@ -124,6 +124,43 @@ public partial class RuntimeEmitter
         moveNextIl.Emit(OpCodes.Ldc_I4_1);
         moveNextIl.Emit(OpCodes.Ret);
 
+        // Method: bool MoveNextWithSent(object? sent) — forwards sent value to next(v) (#503).
+        // Called by the yield* drive loop instead of MoveNext() when the delegate is a
+        // $IteratorWrapper so the outer generator's resume value reaches the iterator's next(v).
+        var moveNextWithSent = typeBuilder.DefineMethod(
+            "MoveNextWithSent",
+            MethodAttributes.Public | MethodAttributes.HideBySig,
+            _types.Boolean,
+            [_types.Object]
+        );
+        runtime.IteratorWrapperMoveNextWithSent = moveNextWithSent;
+        var mwsIl = moveNextWithSent.GetILGenerator();
+
+        var mwsResultLocal = mwsIl.DeclareLocal(_types.Object);
+
+        // var result = InvokeIteratorNextWithSent(_iterator, sent);
+        mwsIl.Emit(OpCodes.Ldarg_0);
+        mwsIl.Emit(OpCodes.Ldfld, iteratorField);
+        mwsIl.Emit(OpCodes.Ldarg_1);               // sent value
+        mwsIl.Emit(OpCodes.Call, runtime.InvokeIteratorNextWithSent);
+        mwsIl.Emit(OpCodes.Stloc, mwsResultLocal);
+
+        mwsIl.Emit(OpCodes.Ldloc, mwsResultLocal);
+        mwsIl.Emit(OpCodes.Call, runtime.GetIteratorDone);
+
+        var mwsNotDoneLabel = mwsIl.DefineLabel();
+        mwsIl.Emit(OpCodes.Brfalse, mwsNotDoneLabel);
+        mwsIl.Emit(OpCodes.Ldc_I4_0);
+        mwsIl.Emit(OpCodes.Ret);
+
+        mwsIl.MarkLabel(mwsNotDoneLabel);
+        mwsIl.Emit(OpCodes.Ldarg_0);
+        mwsIl.Emit(OpCodes.Ldloc, mwsResultLocal);
+        mwsIl.Emit(OpCodes.Call, runtime.GetIteratorValue);
+        mwsIl.Emit(OpCodes.Stfld, currentField);
+        mwsIl.Emit(OpCodes.Ldc_I4_1);
+        mwsIl.Emit(OpCodes.Ret);
+
         // Method: void Reset() - throws NotSupportedException
         var reset = typeBuilder.DefineMethod(
             "Reset",
@@ -162,6 +199,7 @@ public partial class RuntimeEmitter
         EmitGetIteratorDone(typeBuilder, runtime);
         EmitGetIteratorValue(typeBuilder, runtime);
         EmitInvokeIteratorNext(typeBuilder, runtime);
+        EmitInvokeIteratorNextWithSent(typeBuilder, runtime);
         EmitGetIteratorFunction(typeBuilder, runtime);
     }
 
@@ -256,6 +294,59 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloc, nextMethodLocal);    // nextMethod
         il.Emit(OpCodes.Ldc_I4_0);
         il.Emit(OpCodes.Newarr, _types.Object);     // empty args array
+        il.Emit(OpCodes.Call, runtime.InvokeMethodValue);
+        il.Emit(OpCodes.Ret);
+
+        // Throw error if next is null
+        il.MarkLabel(throwLabel);
+        il.Emit(OpCodes.Ldstr, "Runtime Error: Iterator must have a next() method.");
+        il.Emit(OpCodes.Newobj, _types.ExceptionCtorString);
+        il.Emit(OpCodes.Throw);
+    }
+
+    /// <summary>
+    /// Emits InvokeIteratorNextWithSent: gets the 'next' method from iterator and calls it with
+    /// a sent value argument, forwarding the outer generator's resume value (ECMA-262 §14.4.14, #503).
+    /// Signature: object InvokeIteratorNextWithSent(object iterator, object sent)
+    /// </summary>
+    private void EmitInvokeIteratorNextWithSent(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    {
+        var method = typeBuilder.DefineMethod(
+            "InvokeIteratorNextWithSent",
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.Object,
+            [_types.Object, _types.Object]  // iterator, sent
+        );
+        runtime.InvokeIteratorNextWithSent = method;
+
+        var il = method.GetILGenerator();
+        var throwLabel = il.DefineLabel();
+        var nextMethodLocal = il.DeclareLocal(_types.Object);
+        var argsLocal = il.DeclareLocal(_types.Object.MakeArrayType());
+
+        // Get "next" property from iterator
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldstr, "next");
+        il.Emit(OpCodes.Call, runtime.GetProperty);
+        il.Emit(OpCodes.Stloc, nextMethodLocal);
+
+        // Check if null
+        il.Emit(OpCodes.Ldloc, nextMethodLocal);
+        il.Emit(OpCodes.Brfalse, throwLabel);
+
+        // Build args array: new object[] { sent }
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Newarr, _types.Object);
+        il.Emit(OpCodes.Stloc, argsLocal);
+        il.Emit(OpCodes.Ldloc, argsLocal);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Ldarg_1);               // sent value
+        il.Emit(OpCodes.Stelem_Ref);
+
+        // Call InvokeMethodValue(iterator, nextMethod, args) to properly bind 'this'
+        il.Emit(OpCodes.Ldarg_0);               // iterator (receiver/"this")
+        il.Emit(OpCodes.Ldloc, nextMethodLocal);
+        il.Emit(OpCodes.Ldloc, argsLocal);
         il.Emit(OpCodes.Call, runtime.InvokeMethodValue);
         il.Emit(OpCodes.Ret);
 

--- a/Execution/Interpreter.Statements.cs
+++ b/Execution/Interpreter.Statements.cs
@@ -768,6 +768,87 @@ public partial class Interpreter
     }
 
     /// <summary>
+    /// Extracts the raw iterator object and its bound <c>next</c> callable from a custom iterable
+    /// (one that carries <c>[Symbol.iterator]</c>). Used by <c>yield*</c> delegation to drive the
+    /// iterator manually so the outer generator's resume value can be forwarded as the argument to
+    /// <c>next(v)</c> (ECMA-262 §14.4.14, #503).
+    /// </summary>
+    /// <returns>
+    /// <c>true</c> when a custom iterator was found; <c>false</c> for built-in iterables (arrays,
+    /// strings, Maps, Sets) that have no <c>[Symbol.iterator]</c> in the runtime.
+    /// </returns>
+    internal bool TryGetCustomIteratorProtocol(
+        object? iterable,
+        out object? iteratorObj,
+        out ISharpTSCallable? nextFn)
+    {
+        iteratorObj = null;
+        nextFn = null;
+
+        object? iteratorFn = null;
+        object? thisForBind = null;
+
+        if (iterable is SharpTSObject obj)
+        {
+            iteratorFn = obj.GetBySymbol(SharpTSSymbol.Iterator);
+            thisForBind = obj;
+        }
+        else if (iterable is SharpTSInstance inst)
+        {
+            iteratorFn = inst.GetBySymbol(SharpTSSymbol.Iterator);
+            if (iteratorFn == null && inst.GetClass().FindSymbolMethod(SharpTSSymbol.Iterator) is { } sym)
+                iteratorFn = SharpTSClass.BindMethod(sym, inst);
+            thisForBind = inst;
+        }
+
+        if (iteratorFn == null) return false;
+
+        // Bind 'this' and call to get the iterator object.
+        if (iteratorFn is SharpTSArrowFunction arrowFn && thisForBind != null)
+            iteratorFn = arrowFn.Bind(thisForBind);
+
+        object? iterator = iteratorFn is ISharpTSCallable callableIter
+            ? callableIter.Call(this, [])
+            : iteratorFn is SharpTSFunction fn
+                ? fn.Call(this, [])
+                : null;
+
+        if (iterator == null) return false;
+
+        // A generator returned by [Symbol.iterator]() is driven directly (it doesn't
+        // expose a data-property next()); let the caller fall through to GetIterableElements.
+        if (iterator is IEnumerable<object?> and not SharpTSObject and not SharpTSInstance)
+            return false;
+
+        // Extract and bind the 'next' method from the iterator object.
+        object? nextMethod = null;
+        if (iterator is SharpTSObject iterObj)
+        {
+            nextMethod = iterObj.GetProperty("next");
+        }
+        else if (iterator is SharpTSInstance iterInst)
+        {
+            nextMethod = iterInst.GetRawField("next");
+            if (nextMethod == null)
+            {
+                var tok = new Token(TokenType.IDENTIFIER, "next", null, 0);
+                try { nextMethod = iterInst.Get(tok); } catch { }
+            }
+        }
+
+        if (nextMethod is SharpTSArrowFunction arrow)
+            nextMethod = arrow.Bind(iterator);
+        else if (nextMethod is SharpTSFunction nfn && iterator is SharpTSInstance nInst)
+            nextMethod = nfn.Bind(nInst);
+
+        if (nextMethod is not ISharpTSCallable callable) return false;
+
+        iteratorObj = iterator;
+        nextFn = callable;
+        return true;
+    }
+
+    /// <summary>
     /// Attempts to get an iterator from an object using the Symbol.iterator protocol.
     /// </summary>
     /// <returns>An enumerable of values if the object has a Symbol.iterator, null otherwise.</returns>

--- a/Runtime/Types/SharpTSAsyncGenerator.cs
+++ b/Runtime/Types/SharpTSAsyncGenerator.cs
@@ -319,8 +319,32 @@ public class SharpTSAsyncGenerator : ITypeCategorized
             }
         }
 
-        // Sync iterable (array, Map, Set, string, custom iterator): iterate lazily, suspending the outer
-        // for each element. An abrupt resume realizes the control-flow exception to unwind the outer.
+        // Custom iterator objects (those with [Symbol.iterator] and a next(v) that
+        // consumes its argument) are driven manually so the outer's resume value is
+        // forwarded as the argument to next(v) (ECMA-262 §14.4.14, #503).
+        if (_interpreter.TryGetCustomIteratorProtocol(iterable, out var iterObj, out var nextFn))
+        {
+            object? sentValue = SharpTSUndefined.Instance;
+            while (true)
+            {
+                var result = nextFn!.Call(_interpreter, [sentValue]);
+                (bool done, object? innerValue) = ReadIteratorResult(result);
+                if (done) return innerValue ?? SharpTSUndefined.Instance;
+                GeneratorResume resume = await SuspendAtYieldAsync(innerValue);
+                switch (resume.Kind)
+                {
+                    case GeneratorResumeKind.Return:
+                    case GeneratorResumeKind.Throw:
+                        resume.Realize();
+                        return null; // unreachable
+                    default:
+                        sentValue = resume.Value;
+                        break;
+                }
+            }
+        }
+
+        // Built-in iterables (arrays, strings, Maps, Sets): next() ignores resume value.
         foreach (object? element in _interpreter.GetIterableElements(iterable))
         {
             GeneratorResume resume = await SuspendAtYieldAsync(element);

--- a/Runtime/Types/SharpTSGenerator.cs
+++ b/Runtime/Types/SharpTSGenerator.cs
@@ -333,18 +333,81 @@ public class SharpTSGenerator : IEnumerable<object?>, IDisposable, ITypeCategori
             case SharpTSGenerator gen:
                 return DelegateToGenerator(gen.Next, gen.Return, gen.Throw, suspend, isClosed);
             default:
-                // Non-generator iterables (arrays, Maps, custom iterator objects) are
-                // driven lazily via GetIterableElements, which calls next() without an
-                // argument. Built-in iterators ignore the resume value; an abrupt resume
-                // (return/throw) is realized here to unwind the outer body. Forwarding the
-                // sent value or the abrupt completion into a custom iterator's
-                // next(v)/return/throw is a separate gap (tracked in #476 notes, #516).
+                // Custom iterator objects (those with [Symbol.iterator] and a next(v) that
+                // consumes its argument) are driven manually so the outer generator's resume
+                // value is forwarded as the argument to next(v) (ECMA-262 §14.4.14, #503).
+                if (interpreter.TryGetCustomIteratorProtocol(iterable, out var iterObj, out var nextFn))
+                    return DelegateToCustomIterator(interpreter, iterObj, nextFn!, suspend, isClosed);
+
+                // Built-in iterables (arrays, strings, Maps, Sets) and generator-valued
+                // [Symbol.iterator]() results: next() ignores the resume value, so driving
+                // lazily via GetIterableElements is correct. Abrupt resumes (return/throw)
+                // are realized here to unwind the outer body.
                 foreach (var element in interpreter.GetIterableElements(iterable))
                 {
                     if (isClosed()) return null;
                     suspend(element).Realize();
                 }
                 return null;
+        }
+    }
+
+    /// <summary>
+    /// Drives a custom (non-generator) iterator object manually, forwarding the outer generator's
+    /// resume value into its <c>next(v)</c> on each turn (ECMA-262 §14.4.14, #503).
+    /// Abrupt completions (<c>return</c>/<c>throw</c>) are realized as the appropriate
+    /// control-flow exception and unwind through the outer body unchanged.
+    /// </summary>
+    private static object? DelegateToCustomIterator(
+        Interpreter interpreter,
+        object? iteratorObj,
+        ISharpTSCallable nextFn,
+        Func<object?, GeneratorResume> suspend,
+        Func<bool> isClosed)
+    {
+        object? sentValue = SharpTSUndefined.Instance;
+        while (true)
+        {
+            if (isClosed()) return null;
+
+            var result = nextFn.Call(interpreter, [sentValue]);
+
+            bool done = false;
+            object? value = null;
+            if (result is SharpTSObject resultObj)
+            {
+                done = RuntimeTypes.IsTruthy(resultObj.GetProperty("done"));
+                value = resultObj.GetProperty("value");
+            }
+            else if (result is SharpTSInstance resultInst)
+            {
+                var doneTok = new Token(TokenType.IDENTIFIER, "done", null, 0);
+                var valueTok = new Token(TokenType.IDENTIFIER, "value", null, 0);
+                try
+                {
+                    done = RuntimeTypes.IsTruthy(resultInst.Get(doneTok));
+                    value = resultInst.Get(valueTok);
+                }
+                catch
+                {
+                    done = RuntimeTypes.IsTruthy(resultInst.GetRawField("done"));
+                    value = resultInst.GetRawField("value");
+                }
+            }
+
+            if (done) return value ?? SharpTSUndefined.Instance;
+
+            var received = suspend(value);
+            switch (received.Kind)
+            {
+                case GeneratorResumeKind.Return:
+                case GeneratorResumeKind.Throw:
+                    received.Realize();
+                    return null; // unreachable
+                default:
+                    sentValue = received.Value;
+                    break;
+            }
         }
     }
 

--- a/SharpTS.Tests/SharedTests/GeneratorTests.cs
+++ b/SharpTS.Tests/SharedTests/GeneratorTests.cs
@@ -253,6 +253,63 @@ public class GeneratorTests
         Assert.Equal("R:15\n", output);
     }
 
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Generator_YieldStar_CustomIterator_ForwardsNextSentValue(ExecutionMode mode)
+    {
+        // ECMA-262 §14.4.14: the value passed to the outer's next(v) must be forwarded
+        // to a non-generator custom iterator's next(v) as well (issue #503).
+        var source = """
+            function makeEcho() {
+              let started = false;
+              return {
+                [Symbol.iterator]() { return this; },
+                next(v: any) {
+                  const out = started ? `got:${v}` : "start";
+                  started = true;
+                  return { value: out, done: false };
+                },
+              };
+            }
+            function* outer() { yield* makeEcho() as any; }
+            const it = outer();
+            console.log(it.next().value);
+            console.log(it.next(42).value);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("start\ngot:42\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Generator_YieldStar_CustomIterator_ForwardsMultipleSentValues(ExecutionMode mode)
+    {
+        // Each successive next(v) on the outer must be forwarded to the custom iterator's next(v).
+        var source = """
+            function makeEcho() {
+              let started = false;
+              return {
+                [Symbol.iterator]() { return this; },
+                next(v: any) {
+                  const out = started ? `got:${v}` : "start";
+                  started = true;
+                  return { value: out, done: false };
+                },
+              };
+            }
+            function* outer() { yield* makeEcho() as any; }
+            const it = outer();
+            console.log(it.next().value);
+            console.log(it.next(1).value);
+            console.log(it.next(2).value);
+            console.log(it.next(3).value);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("start\ngot:1\ngot:2\ngot:3\n", output);
+    }
+
     #endregion
 
     #region Control Flow


### PR DESCRIPTION
## Summary

ECMA-262 §14.4.14 requires the outer generator's resume value to be forwarded to *any* delegated iterator's `next(v)` — including plain (non-generator) iterator objects whose `next` consumes its argument. #476 fixed this for SharpTS generator delegates; this PR completes the fix for custom iterator objects.

**Before:** `it.next(42).value` → `"got:undefined"` (interpreter) / `"got:null"` (compiled)  
**After:** `it.next(42).value` → `"got:42"` in both modes, matching Node.js

## Changes

- **Interpreter** (`Execution/Interpreter.Statements.cs`, `Runtime/Types/SharpTSGenerator.cs`): Added `TryGetCustomIteratorProtocol` to extract the iterator and bound `next` callable from objects with `[Symbol.iterator]`. `DelegateYieldStar` now drives these manually via a new `DelegateToCustomIterator` helper that calls `next(sentValue)` each turn, forwarding whatever the outer received. Same fix in `SharpTSAsyncGenerator.DelegateYieldStarAsync`.

- **Compiled** (`Compilation/RuntimeEmitter.Iterator.cs`, `EmittedRuntime.cs`, `GeneratorMoveNextEmitter.Expressions.Yield.cs`): Added `InvokeIteratorNextWithSent(iterator, sent)` runtime method and `MoveNextWithSent(sent)` on `$IteratorWrapper`. The `yield*` drive loop now detects `$IteratorWrapper` via `isinst` and calls `MoveNextWithSent(SentField)` instead of plain `MoveNext()`. Also eliminates the CLR `null`-vs-`undefined` divergence noted in the issue.

- Built-in iterables (arrays, Maps, Sets, strings) are unaffected — they go through the plain `IEnumerator` path where the sent value is irrelevant.

## Test plan

- [ ] `Generator_YieldStar_CustomIterator_ForwardsNextSentValue` — exact repro from the issue (`makeEcho()` pattern), both modes
- [ ] `Generator_YieldStar_CustomIterator_ForwardsMultipleSentValues` — multiple successive sent values, both modes
- [ ] Full `yield*` regression suite (92 tests) — all pass
- [ ] Full test suite (13,460 tests) — 0 failures