### PR TITLE
Fix #565: gate StringifyFull boxed-primitive unwrap on __primitiveType

### DIFF
--- a/Compilation/RuntimeEmitter.Json.StringifyFull.cs
+++ b/Compilation/RuntimeEmitter.Json.StringifyFull.cs
@@ -474,6 +474,17 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Isinst, _types.DictionaryStringObject);
         il.Emit(OpCodes.Brfalse, notBoxedPrimFull);
         il.MarkLabel(doBoxedUnwrapFull);
+        // #565: only a genuine boxed wrapper (carrying a string __primitiveType tag)
+        // is unwrapped — a plain object that merely has a __primitiveValue field must
+        // serialize as a normal object.
+        var boxedPrimTypeFull = il.DeclareLocal(_types.Object);
+        il.Emit(OpCodes.Ldloc, valueLocal);
+        il.Emit(OpCodes.Ldstr, "__primitiveType");
+        il.Emit(OpCodes.Call, runtime.GetProperty);
+        il.Emit(OpCodes.Stloc, boxedPrimTypeFull);
+        il.Emit(OpCodes.Ldloc, boxedPrimTypeFull);
+        il.Emit(OpCodes.Isinst, _types.String);
+        il.Emit(OpCodes.Brfalse, notBoxedPrimFull);
         var boxedPrimValFull = il.DeclareLocal(_types.Object);
         il.Emit(OpCodes.Ldloc, valueLocal);
         il.Emit(OpCodes.Ldstr, "__primitiveValue");

--- a/SharpTS.Tests/SharedTests/JSONTests.cs
+++ b/SharpTS.Tests/SharedTests/JSONTests.cs
@@ -584,18 +584,27 @@ public class JSONTests
     }
 
     [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void JSON_Stringify_PlainObjectWithPrimitiveValueField_NotUnwrapped(ExecutionMode mode)
     {
         // An ordinary object that merely has a __primitiveValue field (but no __primitiveType) is
-        // NOT a boxed wrapper and must serialize verbatim — the interpreter gates the unwrap on
-        // __primitiveType, matching the sibling NumberPrototypeMethodWrapper et al. (and the spec's
-        // [[NumberData]]/[[StringData]]/[[BooleanData]] internal-slot semantics). Compiled mode
-        // unwraps on __primitiveValue alone, so it diverges here (too loose) — tracked by #565.
+        // NOT a boxed wrapper and must serialize verbatim — the unwrap is gated on __primitiveType
+        // being a string, matching the spec's [[NumberData]]/[[StringData]]/[[BooleanData]] semantics.
         var source = """
             console.log(JSON.stringify({ __primitiveValue: 7 }));
             """;
         Assert.Equal("{\"__primitiveValue\":7}\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void JSON_Stringify_PlainObjectWithPrimitiveValueField_WithSpace_NotUnwrapped(ExecutionMode mode)
+    {
+        // Same as above but exercises the StringifyFull code path (replacer/space present).
+        var source = """
+            console.log(JSON.stringify({ __primitiveValue: 7 }, null, 2));
+            """;
+        Assert.Equal("{\n  \"__primitiveValue\": 7\n}\n", TestHarness.Run(source, mode));
     }
 
     #endregion


### PR DESCRIPTION
## Summary

- `RuntimeEmitter.Json.StringifyFull.cs`: add the missing `__primitiveType` string-tag guard before reading `__primitiveValue` in the boxed-primitive unwrap block. The simple stringify path (`Stringify.cs`) already had this guard; the full path (used when a replacer or space arg is supplied) was missed, causing any plain object with a `__primitiveValue` field to be incorrectly serialized as the field's value rather than as a normal object.
- `JSONTests.cs`: promote `JSON_Stringify_PlainObjectWithPrimitiveValueField_NotUnwrapped` from `InterpretedOnly` → `All` modes, and add `JSON_Stringify_PlainObjectWithPrimitiveValueField_WithSpace_NotUnwrapped` to explicitly cover the StringifyFull code path.

## Test plan

- [ ] `dotnet test --filter "JSON_Stringify_PlainObjectWithPrimitiveValueField"` — 4 pass (2 tests × 2 modes)
- [ ] `dotnet test --filter "JSON_Stringify_BoxedPrimitives"` — 6 pass (real boxed wrappers still unwrap correctly)
- [ ] `dotnet test` — full suite green