### PR TITLE
Fix #782: compiled new XArray([...]) crashes with InvalidCastException

### DIFF
--- a/Compilation/RuntimeEmitter.Iterator.cs
+++ b/Compilation/RuntimeEmitter.Iterator.cs
@@ -396,6 +396,51 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ret);
         il.MarkLabel(notTSArrayLabel);
 
+        // 1b. Fast path for emitted $TypedArray — only present when program uses typed arrays.
+        if (runtime.TypedArrayBaseType != null)
+        {
+            var notTypedArrayLabel = il.DefineLabel();
+            var taLoopStartLabel = il.DefineLabel();
+            var taLoopDoneLabel = il.DefineLabel();
+            var taSrcLocal = il.DeclareLocal(_types.Object);
+            var taLenLocal = il.DeclareLocal(_types.Int32);
+            var taILocal = il.DeclareLocal(_types.Int32);
+
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Isinst, runtime.TypedArrayBaseType);
+            il.Emit(OpCodes.Brfalse, notTypedArrayLabel);
+
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Castclass, runtime.TypedArrayBaseType);
+            il.Emit(OpCodes.Stloc, taSrcLocal);
+            il.Emit(OpCodes.Ldloc, taSrcLocal);
+            il.Emit(OpCodes.Castclass, runtime.TypedArrayBaseType);
+            il.Emit(OpCodes.Callvirt, runtime.TypedArrayLengthGetter);
+            il.Emit(OpCodes.Stloc, taLenLocal);
+            il.Emit(OpCodes.Ldc_I4_0);
+            il.Emit(OpCodes.Stloc, taILocal);
+            il.MarkLabel(taLoopStartLabel);
+            il.Emit(OpCodes.Ldloc, taILocal);
+            il.Emit(OpCodes.Ldloc, taLenLocal);
+            il.Emit(OpCodes.Bge, taLoopDoneLabel);
+            il.Emit(OpCodes.Ldloc, resultLocal);
+            il.Emit(OpCodes.Ldloc, taSrcLocal);
+            il.Emit(OpCodes.Castclass, runtime.TypedArrayBaseType);
+            il.Emit(OpCodes.Ldloc, taILocal);
+            il.Emit(OpCodes.Callvirt, runtime.TypedArrayElementGet);
+            il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.ListOfObject, "Add", _types.Object));
+            il.Emit(OpCodes.Ldloc, taILocal);
+            il.Emit(OpCodes.Ldc_I4_1);
+            il.Emit(OpCodes.Add);
+            il.Emit(OpCodes.Stloc, taILocal);
+            il.Emit(OpCodes.Br, taLoopStartLabel);
+            il.MarkLabel(taLoopDoneLabel);
+            il.Emit(OpCodes.Ldloc, resultLocal);
+            il.Emit(OpCodes.Ret);
+
+            il.MarkLabel(notTypedArrayLabel);
+        }
+
         // 1. If obj is already List<object>, return it directly (fast path for arrays)
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Isinst, _types.ListOfObject);

--- a/Compilation/RuntimeEmitter.Worker.cs
+++ b/Compilation/RuntimeEmitter.Worker.cs
@@ -936,6 +936,8 @@ public partial class RuntimeEmitter
 
         var endLabel = il.DefineLabel();
         var isEmittedSharedArrayBufferLabel = il.DefineLabel();
+        var isTSArrayLabel = il.DefineLabel();
+        var isTypedArrayLabel = il.DefineLabel();
         var isNumberLabel = il.DefineLabel();
         var unsupportedTypeLabel = il.DefineLabel();
         var argNotNullLabel = il.DefineLabel();
@@ -971,7 +973,7 @@ public partial class RuntimeEmitter
         // Check if arg is $SharedArrayBuffer (emitted type)
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Isinst, runtime.SharedArrayBufferType);
-        il.Emit(OpCodes.Brfalse, isNumberLabel);
+        il.Emit(OpCodes.Brfalse, isTSArrayLabel);
 
         // It's $SharedArrayBuffer - use emitted buffer constructor
         il.Emit(OpCodes.Ldarg_0);  // buffer
@@ -981,6 +983,107 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloc, nullableIntLocal);  // length = null
         il.Emit(OpCodes.Newobj, bufferCtor);
         il.Emit(OpCodes.Br, endLabel);
+
+        // Check if arg is $Array (JS array literal like [1, 2, 3])
+        il.MarkLabel(isTSArrayLabel);
+        {
+            var loopStartLabel = il.DefineLabel();
+            var loopDoneLabel = il.DefineLabel();
+            var tsArrLocal = il.DeclareLocal(_types.Object);
+            var arrLengthLocal = il.DeclareLocal(_types.Int32);
+            var arrResultLocal = il.DeclareLocal(_types.Object);
+            var arrElemLocal = il.DeclareLocal(_types.Object);
+            var arrILocal = il.DeclareLocal(_types.Int32);
+
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Isinst, runtime.TSArrayType);
+            il.Emit(OpCodes.Brfalse, isTypedArrayLabel);
+
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Castclass, runtime.TSArrayType);
+            il.Emit(OpCodes.Stloc, tsArrLocal);
+            il.Emit(OpCodes.Ldloc, tsArrLocal);
+            il.Emit(OpCodes.Castclass, runtime.TSArrayType);
+            il.Emit(OpCodes.Callvirt, runtime.TSArrayLengthGetter);
+            il.Emit(OpCodes.Stloc, arrLengthLocal);
+            il.Emit(OpCodes.Ldloc, arrLengthLocal);
+            il.Emit(OpCodes.Newobj, lengthCtor);
+            il.Emit(OpCodes.Stloc, arrResultLocal);
+            il.Emit(OpCodes.Ldc_I4_0);
+            il.Emit(OpCodes.Stloc, arrILocal);
+            il.MarkLabel(loopStartLabel);
+            il.Emit(OpCodes.Ldloc, arrILocal);
+            il.Emit(OpCodes.Ldloc, arrLengthLocal);
+            il.Emit(OpCodes.Bge, loopDoneLabel);
+            il.Emit(OpCodes.Ldloc, tsArrLocal);
+            il.Emit(OpCodes.Ldloc, arrILocal);
+            il.Emit(OpCodes.Call, runtime.GetElement);
+            il.Emit(OpCodes.Stloc, arrElemLocal);
+            il.Emit(OpCodes.Ldloc, arrResultLocal);
+            il.Emit(OpCodes.Castclass, runtime.TypedArrayBaseType);
+            il.Emit(OpCodes.Ldloc, arrILocal);
+            il.Emit(OpCodes.Ldloc, arrElemLocal);
+            il.Emit(OpCodes.Callvirt, runtime.TypedArrayElementSet);
+            il.Emit(OpCodes.Ldloc, arrILocal);
+            il.Emit(OpCodes.Ldc_I4_1);
+            il.Emit(OpCodes.Add);
+            il.Emit(OpCodes.Stloc, arrILocal);
+            il.Emit(OpCodes.Br, loopStartLabel);
+            il.MarkLabel(loopDoneLabel);
+            il.Emit(OpCodes.Ldloc, arrResultLocal);
+            il.Emit(OpCodes.Br, endLabel);
+        }
+
+        // Check if arg is $TypedArray (copy constructor from another typed array)
+        il.MarkLabel(isTypedArrayLabel);
+        {
+            var loopStartLabel = il.DefineLabel();
+            var loopDoneLabel = il.DefineLabel();
+            var srcTALocal = il.DeclareLocal(_types.Object);
+            var taLengthLocal = il.DeclareLocal(_types.Int32);
+            var taResultLocal = il.DeclareLocal(_types.Object);
+            var taElemLocal = il.DeclareLocal(_types.Object);
+            var taILocal = il.DeclareLocal(_types.Int32);
+
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Isinst, runtime.TypedArrayBaseType);
+            il.Emit(OpCodes.Brfalse, isNumberLabel);
+
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Castclass, runtime.TypedArrayBaseType);
+            il.Emit(OpCodes.Stloc, srcTALocal);
+            il.Emit(OpCodes.Ldloc, srcTALocal);
+            il.Emit(OpCodes.Castclass, runtime.TypedArrayBaseType);
+            il.Emit(OpCodes.Callvirt, runtime.TypedArrayLengthGetter);
+            il.Emit(OpCodes.Stloc, taLengthLocal);
+            il.Emit(OpCodes.Ldloc, taLengthLocal);
+            il.Emit(OpCodes.Newobj, lengthCtor);
+            il.Emit(OpCodes.Stloc, taResultLocal);
+            il.Emit(OpCodes.Ldc_I4_0);
+            il.Emit(OpCodes.Stloc, taILocal);
+            il.MarkLabel(loopStartLabel);
+            il.Emit(OpCodes.Ldloc, taILocal);
+            il.Emit(OpCodes.Ldloc, taLengthLocal);
+            il.Emit(OpCodes.Bge, loopDoneLabel);
+            il.Emit(OpCodes.Ldloc, srcTALocal);
+            il.Emit(OpCodes.Castclass, runtime.TypedArrayBaseType);
+            il.Emit(OpCodes.Ldloc, taILocal);
+            il.Emit(OpCodes.Callvirt, runtime.TypedArrayElementGet);
+            il.Emit(OpCodes.Stloc, taElemLocal);
+            il.Emit(OpCodes.Ldloc, taResultLocal);
+            il.Emit(OpCodes.Castclass, runtime.TypedArrayBaseType);
+            il.Emit(OpCodes.Ldloc, taILocal);
+            il.Emit(OpCodes.Ldloc, taElemLocal);
+            il.Emit(OpCodes.Callvirt, runtime.TypedArrayElementSet);
+            il.Emit(OpCodes.Ldloc, taILocal);
+            il.Emit(OpCodes.Ldc_I4_1);
+            il.Emit(OpCodes.Add);
+            il.Emit(OpCodes.Stloc, taILocal);
+            il.Emit(OpCodes.Br, loopStartLabel);
+            il.MarkLabel(loopDoneLabel);
+            il.Emit(OpCodes.Ldloc, taResultLocal);
+            il.Emit(OpCodes.Br, endLabel);
+        }
 
         il.MarkLabel(isNumberLabel);
 

--- a/SharpTS.Tests/SharedTests/ArrayBufferTests.cs
+++ b/SharpTS.Tests/SharedTests/ArrayBufferTests.cs
@@ -301,6 +301,60 @@ public class ArrayBufferTests
 
     #endregion
 
+    #region TypedArray Array-literal Constructor Tests (#782)
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void TypedArray_FromArrayLiteral_CopiesElements(ExecutionMode mode)
+    {
+        var source = @"
+            const x = new Uint8Array([1, 2, 3]);
+            console.log(x[0], x[1], x[2], x.length);
+        ";
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("1 2 3 3\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void TypedArray_Int32_FromArrayLiteral_CopiesElements(ExecutionMode mode)
+    {
+        var source = @"
+            const y = new Int32Array([100, 200, -300]);
+            console.log(y[0], y[2], y.length);
+        ";
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("100 -300 3\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void TypedArray_CopyFromTypedArray(ExecutionMode mode)
+    {
+        var source = @"
+            const a = new Uint8Array([10, 20, 30]);
+            const b = new Uint8Array(a);
+            console.log(b[0], b[1], b[2]);
+        ";
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("10 20 30\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    public void TypedArray_Spread_ProducesArray(ExecutionMode mode)
+    {
+        var source = @"
+            const arr = new Uint8Array([5, 10, 15]);
+            const spread = [...arr];
+            console.log(spread[0], spread[1], spread[2]);
+        ";
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("5 10 15\n", output);
+    }
+
+    #endregion
+
     #region Mixed ArrayBuffer and SharedArrayBuffer Tests
 
     [Theory]

--- a/TypeSystem/TypeChecker.Expressions.cs
+++ b/TypeSystem/TypeChecker.Expressions.cs
@@ -366,6 +366,11 @@ public partial class TypeChecker
             case TypeInfo.Any:
                 elementType = new TypeInfo.Any();
                 return true;
+            case TypeInfo.TypedArray typed:
+                elementType = typed.ElementType.StartsWith("Big")
+                    ? (TypeInfo)new TypeInfo.BigInt()
+                    : new TypeInfo.Primitive(Parsing.TokenType.TYPE_NUMBER);
+                return true;
             default:
                 // A hand-written object exposing [Symbol.iterator] is spreadable structurally (#485).
                 return TryGetStructuralIterableElement(type, out elementType);


### PR DESCRIPTION
## Summary

- **`Compilation/RuntimeEmitter.Worker.cs`** (`EmitTypedArrayFromObjectHelper`): add `$Array` and `$TypedArray` copy-loop branches before the `Convert.ToDouble` fallback, mirroring the interpreter's element-by-element copy logic. Fixes the root crash.
- **`TypeSystem/TypeChecker.Expressions.cs`** (`TryGetSpreadElementType`): add a `TypeInfo.TypedArray` case so `[...new Uint8Array(...)]` no longer produces TS2488.
- **`Compilation/RuntimeEmitter.Iterator.cs`** (`EmitIterateToList`): add a `$TypedArray` fast-path (guarded on `runtime.TypedArrayBaseType != null`) so spread of typed arrays works at runtime in compiled mode.

## Test plan

- [ ] `new Uint8Array([1, 2, 3])` — both modes, elements and length correct
- [ ] `new Int32Array([100, 200, -300])` — both modes
- [ ] Typed array copy constructor `new Uint8Array(other)` — both modes
- [ ] `[...new Uint8Array([5, 10, 15])]` spread — compiled mode
- [ ] Full test suite: 13480 passed, 0 failed, 3 skipped (pre-existing DNS live-smoke)

Closes #782