### PR TITLE
Fix #434: condition-at-top loop in EmitGetListFromArrayOrList fixes BackwardBranch IL error

### DIFF
--- a/Compilation/Emitters/ArrayEmitter.cs
+++ b/Compilation/Emitters/ArrayEmitter.cs
@@ -542,7 +542,10 @@ public sealed class ArrayEmitter : ITypeEmitterStrategy
         il.Emit(OpCodes.Callvirt, ctx.Runtime.TSArrayElementsGetter);
         il.Emit(OpCodes.Br, endLabel);
 
-        // Typed list path: convert IList to List<object?> via boxing loop
+        // Typed list path: convert IList to List<object?> via boxing loop.
+        // Loop uses condition-at-top so the backward-branch target (loopStart) is
+        // reachable from forward flow, keeping the IL verifiable even when the
+        // caller's evaluation stack is non-empty (e.g. left side of a + expr).
         il.MarkLabel(typedListLabel);
         var ilistLocal = il.DeclareLocal(ilistType);
         il.Emit(OpCodes.Ldloc, objLocal);
@@ -558,10 +561,13 @@ public sealed class ArrayEmitter : ITypeEmitterStrategy
         var idxLocal = il.DeclareLocal(ctx.Types.Int32);
         il.Emit(OpCodes.Ldc_I4_0);
         il.Emit(OpCodes.Stloc, idxLocal);
-        var loopCheck = il.DefineLabel();
-        var loopBody = il.DefineLabel();
-        il.Emit(OpCodes.Br, loopCheck);
-        il.MarkLabel(loopBody);
+        var loopStart = il.DefineLabel(); // condition at top — reachable via fall-through from init
+        var loopEnd   = il.DefineLabel();
+        il.MarkLabel(loopStart);
+        il.Emit(OpCodes.Ldloc, idxLocal);
+        il.Emit(OpCodes.Ldloc, ilistLocal);
+        il.Emit(OpCodes.Callvirt, typeof(System.Collections.ICollection).GetProperty("Count")!.GetGetMethod()!);
+        il.Emit(OpCodes.Bge, loopEnd); // exit if i >= count
         il.Emit(OpCodes.Ldloc, resultLocal);
         il.Emit(OpCodes.Ldloc, ilistLocal);
         il.Emit(OpCodes.Ldloc, idxLocal);
@@ -571,11 +577,8 @@ public sealed class ArrayEmitter : ITypeEmitterStrategy
         il.Emit(OpCodes.Ldc_I4_1);
         il.Emit(OpCodes.Add);
         il.Emit(OpCodes.Stloc, idxLocal);
-        il.MarkLabel(loopCheck);
-        il.Emit(OpCodes.Ldloc, idxLocal);
-        il.Emit(OpCodes.Ldloc, ilistLocal);
-        il.Emit(OpCodes.Callvirt, typeof(System.Collections.ICollection).GetProperty("Count")!.GetGetMethod()!);
-        il.Emit(OpCodes.Blt, loopBody);
+        il.Emit(OpCodes.Br, loopStart); // backward branch to a forward-reachable label
+        il.MarkLabel(loopEnd);
         il.Emit(OpCodes.Ldloc, resultLocal);
         il.Emit(OpCodes.Br, endLabel);
 

--- a/SharpTS.Tests/CompilerTests/ILVerificationTests.cs
+++ b/SharpTS.Tests/CompilerTests/ILVerificationTests.cs
@@ -1556,4 +1556,24 @@ public class ILVerificationTests
         Assert.Equal("undefined\nundefined\n", output);
         Assert.Equal(output, TestHarness.RunInterpreted(source));
     }
+
+    [Fact]
+    public void RestParam_StringConcatWithJoinCall_PassesILVerification()
+    {
+        // Issue #434: "p" + rest.join(",") caused BackwardBranch IL error because
+        // EmitGetListFromArrayOrList's typed-list conversion loop used a
+        // jump-to-condition pattern that placed the backward-branch target in dead
+        // code, making the stack height indeterminate when "p" was already on the
+        // evaluation stack.
+        var source = """
+            function h(...rest: any[]): string { return "p" + rest.join(","); }
+            console.log(h("a", "b"));
+            """;
+
+        var (errors, output) = TestHarness.CompileVerifyAndRun(source);
+
+        Assert.Empty(errors);
+        Assert.Equal("pa,b\n", output);
+        Assert.Equal(output, TestHarness.RunInterpreted(source));
+    }
 }


### PR DESCRIPTION
## Summary

- `EmitGetListFromArrayOrList` (`Compilation/Emitters/ArrayEmitter.cs`) converts typed arrays (`List<double>`, etc.) to `List<object?>` via an inline IL loop. That loop used a **jump-to-condition** pattern — `Br loopCheck` followed immediately by `loopBody:` — placing the backward-branch target in dead code from the ECMA-335 verifier's forward scan.
- When this code was emitted with items already on the evaluation stack (e.g. `"p"` from the left side of `"p" + rest.join(",")`) the verifier could not deterministically establish the stack height at `loopBody:`, producing `BackwardBranch - Stack height at all points must be determinable in a single forward scan of IL`.
- Fix: switch to **condition-at-top** (`loopStart:` → `Bge loopEnd` → body → `Br loopStart`), the same pattern used by `EmitArrayJoin`. `loopStart:` is now reachable via fall-through from the `i = 0` initializer, so the verifier establishes its height before seeing the backward branch.

## Test plan

- [x] New `ILVerificationTests.RestParam_StringConcatWithJoinCall_PassesILVerification` — compiles and verifies the exact repro from the issue, asserts no IL errors and correct output (`pa,b`)
- [x] All 13 482 existing tests pass (`dotnet test`)