### PR TITLE
Fix #662: structural [Symbol.asyncIterator] objects element-typed in for await...of

### DIFF
--- a/SharpTS.Tests/TypeCheckerTests/StructuralIterableTypingTests.cs
+++ b/SharpTS.Tests/TypeCheckerTests/StructuralIterableTypingTests.cs
@@ -549,4 +549,87 @@ public class StructuralIterableTypingTests
         var ex = Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
         Assert.Equal("TS2488", ex.Diagnostic.TsCode);
     }
+
+    // ---- Structural for await...of — [Symbol.asyncIterator] objects are element-typed (#662) ----
+
+    [Fact]
+    public void StructuralForAwaitOf_InterfaceAnnotated_ElementTyped()
+    {
+        // An interface declaring [Symbol.asyncIterator](): AsyncIterator<number> is async-iterable; the
+        // element type is number, so assigning the loop variable to string is TS2322.
+        var source = """
+            interface AsyncSrc { [Symbol.asyncIterator](): AsyncIterator<number>; }
+            async function run(x: AsyncSrc): Promise<void> {
+              for await (const v of x) { const s: string = v; }
+            }
+            """;
+        var ex = Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+        Assert.Equal("TS2322", ex.Diagnostic.TsCode);
+    }
+
+    [Fact]
+    public void StructuralForAwaitOf_ObjectLiteralWithAsyncGenFactory_ElementTyped()
+    {
+        // Object literal whose [Symbol.asyncIterator]() returns an AsyncGenerator<number>: the switch
+        // in TryGetStructuralAsyncIterableElement matches the AsyncGenerator record, yielding number.
+        var source = """
+            async function* agen(): AsyncGenerator<number> { yield 42; }
+            const obj = { [Symbol.asyncIterator]() { return agen(); } };
+            async function run(): Promise<void> {
+              for await (const v of obj) { const s: string = v; }
+            }
+            """;
+        var ex = Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+        Assert.Equal("TS2322", ex.Diagnostic.TsCode);
+    }
+
+    [Fact]
+    public void StructuralForAwaitOf_StructuralIteratorFactory_ElementTyped()
+    {
+        // Object literal whose [Symbol.asyncIterator]() returns a hand-written iterator
+        // ({ next(): Promise<IteratorResult<number>> }) — element type extracted via
+        // TryGetStructuralAsyncIteratorElement (Promise unwrap + value field).
+        var source = """
+            const obj = {
+              [Symbol.asyncIterator]() {
+                return {
+                  async next(): Promise<IteratorResult<number>> { return { value: 1, done: false }; }
+                };
+              }
+            };
+            async function run(): Promise<void> {
+              for await (const v of obj) { const s: string = v; }
+            }
+            """;
+        var ex = Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+        Assert.Equal("TS2322", ex.Diagnostic.TsCode);
+    }
+
+    [Fact]
+    public void StructuralForAwaitOf_CorrectElementType_Accepted()
+    {
+        // Same structural shape but the loop body uses the correct type — no error.
+        var source = """
+            async function* agen(): AsyncGenerator<number> { yield 42; }
+            const obj = { [Symbol.asyncIterator]() { return agen(); } };
+            async function run(): Promise<void> {
+              for await (const v of obj) { const n: number = v; }
+            }
+            """;
+        TestHarness.RunInterpreted(source);
+    }
+
+    [Fact]
+    public void ForAwaitOf_ObjectWithoutAsyncIterator_StaysLenient()
+    {
+        // An object without [Symbol.asyncIterator] does not resolve structurally, so the loop variable
+        // falls through to `any` — no error (async non-iterability is not yet diagnosed statically).
+        var source = """
+            const plain = { x: 1 };
+            async function run(): Promise<void> {
+              for await (const v of plain) { const s: string = v; }
+            }
+            """;
+        TestHarness.RunInterpreted(source);
+    }
 }

--- a/TypeSystem/TypeChecker.Iterables.cs
+++ b/TypeSystem/TypeChecker.Iterables.cs
@@ -72,6 +72,26 @@ public partial class TypeChecker
     };
 
     /// <summary>
+    /// Derives the element type of a structural ASYNC ITERATOR source — an object that exposes a callable
+    /// <c>next()</c> whose return type is <c>Promise&lt;IteratorResult&lt;T&gt;&gt;</c>. The async mirror of
+    /// <see cref="TryGetStructuralIteratorElement"/>: the Promise wrapping is resolved via
+    /// <see cref="ResolveAwaitedType"/> before reading <c>value</c>. Returns false when there is no callable
+    /// <c>next</c>.
+    /// </summary>
+    private bool TryGetStructuralAsyncIteratorElement(TypeInfo source, out TypeInfo elementType)
+    {
+        elementType = null!;
+        var nextMember = GetMemberType(source, "next");
+        if (!IsCallableMember(nextMember)) return false;
+
+        // next() on an async iterator returns Promise<IteratorResult<T>>; unwrap the Promise first.
+        TypeInfo? nextReturn = GetCallableReturnType(nextMember);
+        TypeInfo iterResult = nextReturn is null ? new TypeInfo.Any() : ResolveAwaitedType(nextReturn);
+        elementType = ExtractIteratorResultValue(iterResult);
+        return true;
+    }
+
+    /// <summary>
     /// Derives the element type of a structural ITERABLE source — an object exposing
     /// <c>[Symbol.iterator](): Iterator&lt;T&gt;</c>. In declared/interface types the method is the named
     /// member <c>@@iterator</c>; in object literals a symbol-keyed method lands in the symbol index
@@ -286,7 +306,10 @@ public partial class TypeChecker
             case TypeInfo.AsyncIterator ait: elementType = ait.ElementType; return true;
             case TypeInfo.AsyncGenerator ag: elementType = ag.YieldType; return true;
             case TypeInfo.AsyncIterable ai: elementType = ai.ElementType; return true;
-            default: elementType = new TypeInfo.Any(); return true;
+            default:
+                if (TryGetStructuralAsyncIteratorElement(iterator, out elementType)) return true;
+                elementType = new TypeInfo.Any();
+                return true;
         }
     }
 }

--- a/TypeSystem/TypeChecker.Statements.cs
+++ b/TypeSystem/TypeChecker.Statements.cs
@@ -855,14 +855,15 @@ public partial class TypeChecker
             TypeInfo.AsyncGenerator asyncGenType when stmt.IsAsync => asyncGenType.YieldType,
             TypeInfo.AsyncIterator asyncItType when stmt.IsAsync => asyncItType.ElementType,
             TypeInfo.AsyncIterable asyncIter when stmt.IsAsync => asyncIter.ElementType,
-            // A hand-written object exposing [Symbol.iterator] is iterable structurally (#485). Limited to
-            // sync `for...of`; structural async-iterable objects ([Symbol.asyncIterator]) are not yet
-            // element-typed (the dedicated async records above are — #483) and stay lenient below (#662).
+            // A hand-written object exposing [Symbol.asyncIterator] is async-iterable structurally (#662).
+            _ when stmt.IsAsync && TryGetStructuralAsyncIterableElement(iterableType, out var asyncStructuralElem) => asyncStructuralElem,
+            // A hand-written object exposing [Symbol.iterator] is iterable structurally (#485).
             _ when !stmt.IsAsync && TryGetStructuralIterableElement(iterableType, out var structuralElem) => structuralElem,
             // A structural object with no [Symbol.iterator] is an iterator-only or plain object, not an
             // Iterable — tsc rejects the loop with TS2488 rather than binding `any` (#550). Gated to types
             // SharpTS can prove non-iterable so it never rejects code tsc accepts (see the helper). Async
-            // sources stay lenient — structural async-iterable typing is a separate gap (#662).
+            // sources remain lenient (no TS2488 analog for async — async non-iterability is rarer and not
+            // yet diagnosed).
             _ when !stmt.IsAsync && IsProvablyNonIterableStructuralObject(iterableType) =>
                 throw new TypeCheckException(
                     $" Type '{iterableType}' must have a '[Symbol.iterator]()' method that returns an iterator.",


### PR DESCRIPTION
## Summary

Closes #662 — the async parallel of #485's structural-iterable work.

`TryGetStructuralAsyncIterableElement` already existed in `TypeChecker.Iterables.cs` and correctly
walked `@@asyncIterator` / the symbol index to find the factory, but `VisitForOf` never called it —
structural `for await...of` sources fell through to `any`.

Two changes:

- **`TypeChecker.Statements.cs`**: add `_ when stmt.IsAsync && TryGetStructuralAsyncIterableElement(...)` arm in the `VisitForOf` switch, directly after the three dedicated async-record arms.

- **`TypeChecker.Iterables.cs`**: add `TryGetStructuralAsyncIteratorElement` (async mirror of `TryGetStructuralIteratorElement`): finds `next()`, unwraps the `Promise<IteratorResult<T>>` via the existing `ResolveAwaitedType`, then reads `value` via `ExtractIteratorResultValue`. Called from `TryGetStructuralAsyncIterableElement`'s `default` arm so hand-written structural async iterators are element-typed rather than collapsing to `any`.

## Test plan

- `StructuralForAwaitOf_InterfaceAnnotated_ElementTyped` — interface with `[Symbol.asyncIterator](): AsyncIterator<number>` binds `number`; wrong-type use → TS2322
- `StructuralForAwaitOf_ObjectLiteralWithAsyncGenFactory_ElementTyped` — object literal whose factory returns `AsyncGenerator<number>` → element `number` via dedicated record arm; wrong-type use → TS2322
- `StructuralForAwaitOf_StructuralIteratorFactory_ElementTyped` — factory returns structural `{ next(): Promise<IteratorResult<number>> }` → element `number` via new `TryGetStructuralAsyncIteratorElement`; wrong-type use → TS2322
- `StructuralForAwaitOf_CorrectElementType_Accepted` — correct-type usage is accepted
- `ForAwaitOf_ObjectWithoutAsyncIterator_StaysLenient` — no `[Symbol.asyncIterator]` → `any`, no error

Full suite: 13 495 / 0 failed.