### PR TITLE
Fix #650: compiled per-iteration loop-binding reference cells (sync + async/generators)

### DIFF
--- a/Compilation/AsyncArrowMoveNextEmitter.ArrowFunctions.cs
+++ b/Compilation/AsyncArrowMoveNextEmitter.ArrowFunctions.cs
@@ -66,8 +66,12 @@ public partial class AsyncArrowMoveNextEmitter
         {
             _il.Emit(OpCodes.Dup); // Keep display class instance on stack
 
-            // Load the captured variable using the capture-population loader
-            LoadVariableForCapture(capturedVar);
+            // Per-iteration cell capture (#650): snapshot the StrongBox REFERENCE, not its
+            // value (LoadVariableForCapture would deref the cell). The closure body derefs.
+            if (_ctx.CellBindingLocals.TryGetValue(capturedVar, out var cellLocal))
+                _il.Emit(OpCodes.Ldloc, cellLocal);
+            else
+                LoadVariableForCapture(capturedVar);
 
             _il.Emit(OpCodes.Stfld, field);
         }

--- a/Compilation/AsyncArrowMoveNextEmitter.cs
+++ b/Compilation/AsyncArrowMoveNextEmitter.cs
@@ -139,7 +139,8 @@ public partial class AsyncArrowMoveNextEmitter : StatementEmitterBase, IEmitterC
         if (ctx.Runtime != null) _helpers.SetRuntime(ctx.Runtime);
 
         // Create variable resolver for hoisted fields, locals, and captured variables
-        _resolver = new AsyncArrowVariableResolver(_il, _builder, _locals);
+        _resolver = new AsyncArrowVariableResolver(_il, _builder, _locals,
+            ctx.CellBindingLocals, ctx.Types.StrongBoxOfObjectValueField);
 
         // Create labels for each await state
         for (int i = 0; i < _analysis.AwaitPointCount; i++)

--- a/Compilation/AsyncArrowVariableResolver.cs
+++ b/Compilation/AsyncArrowVariableResolver.cs
@@ -21,6 +21,8 @@ public class AsyncArrowVariableResolver : IVariableResolver
     private readonly ILGenerator _il;
     private readonly AsyncArrowStateMachineBuilder _builder;
     private readonly Dictionary<string, LocalBuilder> _locals;
+    private readonly IReadOnlyDictionary<string, LocalBuilder>? _cellBindingLocals;
+    private readonly FieldInfo? _strongBoxValueField;
 
     /// <summary>
     /// Creates a new resolver for async arrow variable access.
@@ -28,19 +30,33 @@ public class AsyncArrowVariableResolver : IVariableResolver
     /// <param name="il">The IL generator for emitting instructions</param>
     /// <param name="builder">The async arrow state machine builder</param>
     /// <param name="locals">Dictionary of non-hoisted local variables</param>
+    /// <param name="cellBindingLocals">Per-iteration cell locals (#650), shared with the emitter; null disables cells.</param>
+    /// <param name="strongBoxValueField">The StrongBox&lt;object&gt;.Value field, for cell dereference.</param>
     public AsyncArrowVariableResolver(
         ILGenerator il,
         AsyncArrowStateMachineBuilder builder,
-        Dictionary<string, LocalBuilder> locals)
+        Dictionary<string, LocalBuilder> locals,
+        IReadOnlyDictionary<string, LocalBuilder>? cellBindingLocals = null,
+        FieldInfo? strongBoxValueField = null)
     {
         _il = il;
         _builder = builder;
         _locals = locals;
+        _cellBindingLocals = cellBindingLocals;
+        _strongBoxValueField = strongBoxValueField;
     }
 
     /// <inheritdoc />
     public StackType? TryLoadVariable(string name)
     {
+        // 0. Per-iteration loop-binding cell (#650): read through the StrongBox.
+        if (_cellBindingLocals != null && _cellBindingLocals.TryGetValue(name, out var loadCell))
+        {
+            _il.Emit(OpCodes.Ldloc, loadCell);
+            _il.Emit(OpCodes.Ldfld, _strongBoxValueField!);
+            return StackType.Unknown;
+        }
+
         // 1. Check if it's a parameter of this arrow
         if (_builder.ParameterFields.TryGetValue(name, out var paramField))
         {
@@ -81,6 +97,7 @@ public class AsyncArrowVariableResolver : IVariableResolver
     /// <inheritdoc />
     public bool HasVariable(string name)
     {
+        if (_cellBindingLocals != null && _cellBindingLocals.ContainsKey(name)) return true;
         if (_builder.ParameterFields.ContainsKey(name)) return true;
         if (_builder.LocalFields.ContainsKey(name)) return true;
         if (_builder.IsCaptured(name) && _builder.CapturedFieldMap.ContainsKey(name)) return true;
@@ -91,6 +108,17 @@ public class AsyncArrowVariableResolver : IVariableResolver
     /// <inheritdoc />
     public bool TryStoreVariable(string name)
     {
+        // 0. Per-iteration loop-binding cell (#650): write through the StrongBox.
+        if (_cellBindingLocals != null && _cellBindingLocals.TryGetValue(name, out var storeCell))
+        {
+            var cellTemp = _il.DeclareLocal(typeof(object));
+            _il.Emit(OpCodes.Stloc, cellTemp);
+            _il.Emit(OpCodes.Ldloc, storeCell);
+            _il.Emit(OpCodes.Ldloc, cellTemp);
+            _il.Emit(OpCodes.Stfld, _strongBoxValueField!);
+            return true;
+        }
+
         // 1. Check if it's a parameter of this arrow
         if (_builder.ParameterFields.TryGetValue(name, out var paramField))
         {

--- a/Compilation/AsyncGeneratorMoveNextEmitter.Expressions.cs
+++ b/Compilation/AsyncGeneratorMoveNextEmitter.Expressions.cs
@@ -709,6 +709,14 @@ public partial class AsyncGeneratorMoveNextEmitter
         {
             _il.Emit(OpCodes.Dup);
 
+            // Per-iteration cell capture (#650): snapshot the StrongBox REFERENCE.
+            if (_ctx.CellBindingLocals.TryGetValue(capturedVar, out var cellLocal))
+            {
+                _il.Emit(OpCodes.Ldloc, cellLocal);
+                _il.Emit(OpCodes.Stfld, field);
+                continue;
+            }
+
             var hoistedField = _builder.GetVariableField(capturedVar);
             if (hoistedField != null)
             {

--- a/Compilation/AsyncGeneratorMoveNextEmitter.cs
+++ b/Compilation/AsyncGeneratorMoveNextEmitter.cs
@@ -107,7 +107,9 @@ public partial class AsyncGeneratorMoveNextEmitter : StatementEmitterBase
             _il,
             _builder.GetVariableField,
             ctx.Locals,
-            _builder.ThisField);
+            _builder.ThisField,
+            ctx.CellBindingLocals,
+            ctx.Types.StrongBoxOfObjectValueField);
 
         // Define labels for each suspension resume point
         foreach (var suspensionPoint in _analysis.SuspensionPoints)

--- a/Compilation/AsyncMoveNextEmitter.ArrowFunctions.cs
+++ b/Compilation/AsyncMoveNextEmitter.ArrowFunctions.cs
@@ -103,6 +103,14 @@ public partial class AsyncMoveNextEmitter
         {
             _il.Emit(OpCodes.Dup);
 
+            // Per-iteration cell capture (#650): snapshot the StrongBox REFERENCE.
+            if (_ctx.CellBindingLocals.TryGetValue(capturedVar, out var cellLocal))
+            {
+                _il.Emit(OpCodes.Ldloc, cellLocal);
+                _il.Emit(OpCodes.Stfld, field);
+                continue;
+            }
+
             var hoistedField = _builder.GetVariableField(capturedVar);
             if (hoistedField != null)
             {

--- a/Compilation/AsyncMoveNextEmitter.cs
+++ b/Compilation/AsyncMoveNextEmitter.cs
@@ -163,7 +163,9 @@ public partial class AsyncMoveNextEmitter : StatementEmitterBase, IEmitterContex
             _il,
             _builder.GetVariableField,
             ctx.Locals,
-            _builder.ThisField);
+            _builder.ThisField,
+            ctx.CellBindingLocals,
+            ctx.Types.StrongBoxOfObjectValueField);
 
         // Declare exception local for catch block
         _exceptionLocal = _il.DeclareLocal(_types.Exception);

--- a/Compilation/ClosureAnalyzer.cs
+++ b/Compilation/ClosureAnalyzer.cs
@@ -75,6 +75,22 @@ public class ClosureAnalyzer : AstVisitorBase
     // O(1) lookup for whether any variable is captured (inverse of _captures)
     private readonly HashSet<string> _allCapturedVariables = [];
 
+    // Per-iteration reference-cell analysis (#650), run alongside capture analysis
+    // and reachable wherever this analyzer is threaded (via _ctx.ClosureAnalyzer).
+    private readonly PerIterationCellAnalyzer _cells = new();
+
+    /// <summary>
+    /// The <c>for (let/const …)</c> binding names in <paramref name="loop"/> that need
+    /// a per-iteration reference cell (#650); empty when none do.
+    /// </summary>
+    public HashSet<string> GetForLoopCells(Stmt.For loop) => _cells.GetForLoopCells(loop);
+
+    /// <summary>
+    /// The captured names in <paramref name="closure"/> that hold a per-iteration cell
+    /// (the closure body must dereference <c>StrongBox.Value</c>); empty when none do.
+    /// </summary>
+    public HashSet<string> GetClosureCellFields(object closure) => _cells.GetClosureCellFields(closure);
+
     /// <summary>
     /// Gets the captured variables for a given function/arrow AST node.
     /// </summary>
@@ -157,6 +173,10 @@ public class ClosureAnalyzer : AstVisitorBase
         foreach (var stmt in statements)
             Visit(stmt);
         _scopeStack.Pop();
+
+        // Per-iteration cell analysis (#650) is independent of capture-source state,
+        // so run it as its own pass over the same statements.
+        _cells.Analyze(statements);
     }
 
     /// <summary>

--- a/Compilation/CompilationContext.Closures.cs
+++ b/Compilation/CompilationContext.Closures.cs
@@ -235,6 +235,31 @@ public partial class CompilationContext
     public Dictionary<ArrowFunction, Dictionary<object, FieldBuilder>>? ArrowScopeDCExtraFieldsByArrow { get; set; }
 
     // ============================================
+    // Per-iteration loop-binding reference cells (#650)
+    // ============================================
+
+    /// <summary>
+    /// For a <c>for (let/const …)</c> binding that needs a per-iteration reference
+    /// cell, the local holding the CURRENT iteration's <c>StrongBox&lt;object&gt;</c>.
+    /// Populated by the for-loop emitter while emitting the loop body and increment,
+    /// and consulted FIRST by <see cref="LocalVariableResolver"/> so loop-body reads
+    /// and writes go through <c>StrongBox.Value</c> rather than the (now dead) plain
+    /// local. Scoped: the emitter removes the entry on loop exit. Empty outside a
+    /// cell-bearing loop body.
+    /// </summary>
+    public Dictionary<string, LocalBuilder> CellBindingLocals { get; } = [];
+
+    /// <summary>
+    /// When emitting a closure body, the captured field names that hold a
+    /// per-iteration cell (a <c>StrongBox&lt;object&gt;</c>) rather than a plain
+    /// value. The resolver loads the captured field, then reads <c>StrongBox.Value</c>
+    /// for these names (and writes through it). Set from
+    /// <see cref="PerIterationCellAnalyzer.ClosureCellFields"/> when the closure
+    /// body's emit context is established.
+    /// </summary>
+    public HashSet<string>? CellCapturedFieldNames { get; set; }
+
+    // ============================================
     // Inner Function Support
     // ============================================
 

--- a/Compilation/ExpressionEmitterBase.Operators.cs
+++ b/Compilation/ExpressionEmitterBase.Operators.cs
@@ -65,6 +65,19 @@ public abstract partial class ExpressionEmitterBase
     /// </remarks>
     protected virtual void EmitStoreVariable(string name)
     {
+        // Per-iteration loop-binding cell (#650): write through the StrongBox. This base
+        // helper (used by state-machine increments/compound/logical assignment) hand-rolls
+        // the store instead of routing through the resolver, so the cell case is handled here.
+        if (Ctx.CellBindingLocals.TryGetValue(name, out var cell))
+        {
+            var cellTemp = IL.DeclareLocal(typeof(object));
+            IL.Emit(OpCodes.Stloc, cellTemp);
+            IL.Emit(OpCodes.Ldloc, cell);
+            IL.Emit(OpCodes.Ldloc, cellTemp);
+            IL.Emit(OpCodes.Stfld, Ctx.Types.StrongBoxOfObjectValueField);
+            return;
+        }
+
         var field = GetHoistedVariableField(name);
         if (field != null)
         {

--- a/Compilation/ExpressionEmitterBase.cs
+++ b/Compilation/ExpressionEmitterBase.cs
@@ -1635,12 +1635,19 @@ public abstract partial class ExpressionEmitterBase : IEmitterContext
             {
                 IL.Emit(OpCodes.Dup);
 
+                // Per-iteration cell capture (#650): snapshot the StrongBox REFERENCE so the
+                // closure shares this iteration's cell (the cell local is repointed to a fresh
+                // box each iteration). Checked first; cell bindings are never hoisted fields.
+                if (Ctx.CellBindingLocals.TryGetValue(capturedVar, out var cellLocal))
+                {
+                    IL.Emit(OpCodes.Ldloc, cellLocal);
+                }
                 // `this` is checked before the hoisted-variable map: the generator's
                 // hoisting analyzer can mint a state-machine field keyed "this" that the
                 // stub never populates, so resolving it via the map would snapshot null
                 // (NRE when the arrow dereferences `this`). The real receiver lives in the
                 // builder's dedicated ThisField (set by the instance-method stub).
-                if (capturedVar == "this" && GetThisField() is FieldBuilder thisField)
+                else if (capturedVar == "this" && GetThisField() is FieldBuilder thisField)
                 {
                     IL.Emit(OpCodes.Ldarg_0);
                     IL.Emit(OpCodes.Ldfld, thisField);

--- a/Compilation/GeneratorMoveNextEmitter.cs
+++ b/Compilation/GeneratorMoveNextEmitter.cs
@@ -85,7 +85,9 @@ public partial class GeneratorMoveNextEmitter : StatementEmitterBase
             _il,
             _builder.GetVariableField,
             ctx.Locals,
-            _builder.ThisField);
+            _builder.ThisField,
+            ctx.CellBindingLocals,
+            ctx.Types.StrongBoxOfObjectValueField);
 
         // Define labels for each yield resume point
         foreach (var yieldPoint in _analysis.YieldPoints)

--- a/Compilation/ILCompiler.ArrowFunctions.cs
+++ b/Compilation/ILCompiler.ArrowFunctions.cs
@@ -1209,6 +1209,12 @@ public partial class ILCompiler
                 ctx.CapturedFields = [];
             }
 
+            // Per-iteration cell capture (#650): mark which captured fields hold a
+            // StrongBox so the body dereferences Value on read/write.
+            var arrowCellFields = _closures.Analyzer.GetClosureCellFields(arrow);
+            if (arrowCellFields.Count > 0)
+                ctx.CellCapturedFieldNames = arrowCellFields;
+
             // Set the $entryPointDC field if this arrow captures top-level variables
             if (_closures.ArrowEntryPointDCFields.TryGetValue(arrow, out var entryPointDCField))
             {

--- a/Compilation/ILEmitter.Calls.Closures.cs
+++ b/Compilation/ILEmitter.Calls.Closures.cs
@@ -362,6 +362,16 @@ public partial class ILEmitter
                 // parent arrow; class-method arg0 for the outermost).
                 _resolver.LoadThis();
             }
+            else if (_ctx.CellBindingLocals.TryGetValue(capturedVar, out var cellLocal))
+            {
+                // Per-iteration cell capture (#650): snapshot the StrongBox REFERENCE
+                // (not its value) so the closure shares this iteration's cell and
+                // observes end-of-iteration mutations. The cell local is repointed to a
+                // fresh box each iteration, so closures in distinct iterations capture
+                // distinct cells. The field stays object-typed; only the closure body
+                // dereferences Value (see LocalVariableResolver / CellCapturedFieldNames).
+                IL.Emit(OpCodes.Ldloc, cellLocal);
+            }
             else if (_ctx.TryGetParameter(capturedVar, out var argIndex))
             {
                 IL.Emit(OpCodes.Ldarg, argIndex);

--- a/Compilation/ILEmitter.Expressions.cs
+++ b/Compilation/ILEmitter.Expressions.cs
@@ -320,6 +320,23 @@ public partial class ILEmitter
 
         EmitExpression(a.Value);
 
+        // 0. Per-iteration loop-binding cell (#650): write through the StrongBox so the
+        //    mutation is visible to closures that captured this iteration's cell. Mirrors
+        //    LocalVariableResolver's cell store; this hand-rolled assignment path does not
+        //    route through TryStoreVariable, so the cell case must be handled here too.
+        if (_ctx.CellBindingLocals.TryGetValue(a.Name.Lexeme, out var assignCell))
+        {
+            EmitBoxIfNeeded(a.Value);
+            IL.Emit(OpCodes.Dup); // leave the assigned value on the stack (expression result)
+            var temp = IL.DeclareLocal(_ctx.Types.Object);
+            IL.Emit(OpCodes.Stloc, temp);
+            IL.Emit(OpCodes.Ldloc, assignCell);
+            IL.Emit(OpCodes.Ldloc, temp);
+            IL.Emit(OpCodes.Stfld, _ctx.Types.StrongBoxOfObjectValueField);
+            SetStackUnknown();
+            return;
+        }
+
         // 1. Function display class fields (captured function-local vars)
         // Check this BEFORE regular locals to ensure we use the shared storage
         if (_ctx.CapturedFunctionLocals?.Contains(a.Name.Lexeme) == true &&
@@ -489,9 +506,23 @@ public partial class ILEmitter
             // Store to field: need temp since value is on top of stack
             var temp = IL.DeclareLocal(_ctx.Types.Object);
             IL.Emit(OpCodes.Stloc, temp);
-            IL.Emit(OpCodes.Ldarg_0);  // Load display class instance
-            IL.Emit(OpCodes.Ldloc, temp);
-            IL.Emit(OpCodes.Stfld, field);
+            // Per-iteration cell capture (#650): the field holds a shared StrongBox —
+            // write through Value so the loop body and sibling closures see the update,
+            // rather than overwriting this closure's reference to the cell.
+            if (_ctx.CellCapturedFieldNames?.Contains(a.Name.Lexeme) == true)
+            {
+                IL.Emit(OpCodes.Ldarg_0);
+                IL.Emit(OpCodes.Ldfld, field);
+                IL.Emit(OpCodes.Castclass, _ctx.Types.StrongBoxOfObject);
+                IL.Emit(OpCodes.Ldloc, temp);
+                IL.Emit(OpCodes.Stfld, _ctx.Types.StrongBoxOfObjectValueField);
+            }
+            else
+            {
+                IL.Emit(OpCodes.Ldarg_0);  // Load display class instance
+                IL.Emit(OpCodes.Ldloc, temp);
+                IL.Emit(OpCodes.Stfld, field);
+            }
             SetStackUnknown();
         }
         else if (_ctx.CapturedTopLevelVars?.Contains(a.Name.Lexeme) == true &&

--- a/Compilation/ILEmitter.Operators.cs
+++ b/Compilation/ILEmitter.Operators.cs
@@ -821,6 +821,21 @@ public partial class ILEmitter
                 IL.Emit(OpCodes.Dup);
             }
 
+            // Per-iteration loop-binding cell (#650): write the new value through the
+            // StrongBox so closures that captured this iteration's cell observe it.
+            if (_ctx.CellBindingLocals.TryGetValue(v.Name.Lexeme, out var preCell))
+            {
+                if (isTypedDouble) IL.Emit(OpCodes.Box, _ctx.Types.Double);
+                var cellTemp = IL.DeclareLocal(_ctx.Types.Object);
+                IL.Emit(OpCodes.Stloc, cellTemp);
+                IL.Emit(OpCodes.Ldloc, preCell);
+                IL.Emit(OpCodes.Ldloc, cellTemp);
+                IL.Emit(OpCodes.Stfld, _ctx.Types.StrongBoxOfObjectValueField);
+                if (isTypedDouble) IL.Emit(OpCodes.Box, _ctx.Types.Double);
+                SetStackUnknown();
+                return;
+            }
+
             // Check function display class first (before regular locals)
             if (_ctx.CapturedFunctionLocals?.Contains(v.Name.Lexeme) == true &&
                 _ctx.FunctionDisplayClassFields?.TryGetValue(v.Name.Lexeme, out var funcDCField) == true)
@@ -950,9 +965,21 @@ public partial class ILEmitter
                 }
                 var temp = IL.DeclareLocal(_ctx.Types.Object);
                 IL.Emit(OpCodes.Stloc, temp);
-                IL.Emit(OpCodes.Ldarg_0); // display class instance
-                IL.Emit(OpCodes.Ldloc, temp);
-                IL.Emit(OpCodes.Stfld, capturedField);
+                // Per-iteration cell capture (#650): write through the shared StrongBox.
+                if (_ctx.CellCapturedFieldNames?.Contains(v.Name.Lexeme) == true)
+                {
+                    IL.Emit(OpCodes.Ldarg_0);
+                    IL.Emit(OpCodes.Ldfld, capturedField);
+                    IL.Emit(OpCodes.Castclass, _ctx.Types.StrongBoxOfObject);
+                    IL.Emit(OpCodes.Ldloc, temp);
+                    IL.Emit(OpCodes.Stfld, _ctx.Types.StrongBoxOfObjectValueField);
+                }
+                else
+                {
+                    IL.Emit(OpCodes.Ldarg_0); // display class instance
+                    IL.Emit(OpCodes.Ldloc, temp);
+                    IL.Emit(OpCodes.Stfld, capturedField);
+                }
             }
             else if (_ctx.TopLevelStaticVars?.TryGetValue(v.Name.Lexeme, out var topLevelField) == true)
             {
@@ -1102,6 +1129,21 @@ public partial class ILEmitter
                 IL.Emit(OpCodes.Box, _ctx.Types.Double);
             }
 
+            // Per-iteration loop-binding cell (#650): write the new value through the
+            // StrongBox; the original value (still on the stack below) is the postfix result.
+            if (_ctx.CellBindingLocals.TryGetValue(v.Name.Lexeme, out var postCell))
+            {
+                if (isTypedDouble) IL.Emit(OpCodes.Box, _ctx.Types.Double);
+                var cellTemp = IL.DeclareLocal(_ctx.Types.Object);
+                IL.Emit(OpCodes.Stloc, cellTemp);
+                IL.Emit(OpCodes.Ldloc, postCell);
+                IL.Emit(OpCodes.Ldloc, cellTemp);
+                IL.Emit(OpCodes.Stfld, _ctx.Types.StrongBoxOfObjectValueField);
+                IL.Emit(OpCodes.Box, _ctx.Types.Double); // box the original (result)
+                SetStackUnknown();
+                return;
+            }
+
             // Check function display class first (before regular locals)
             if (_ctx.CapturedFunctionLocals?.Contains(v.Name.Lexeme) == true &&
                 _ctx.FunctionDisplayClassFields?.TryGetValue(v.Name.Lexeme, out var funcDCField) == true)
@@ -1229,9 +1271,21 @@ public partial class ILEmitter
                 }
                 var temp = IL.DeclareLocal(_ctx.Types.Object);
                 IL.Emit(OpCodes.Stloc, temp);
-                IL.Emit(OpCodes.Ldarg_0); // display class instance
-                IL.Emit(OpCodes.Ldloc, temp);
-                IL.Emit(OpCodes.Stfld, capturedField);
+                // Per-iteration cell capture (#650): write through the shared StrongBox.
+                if (_ctx.CellCapturedFieldNames?.Contains(v.Name.Lexeme) == true)
+                {
+                    IL.Emit(OpCodes.Ldarg_0);
+                    IL.Emit(OpCodes.Ldfld, capturedField);
+                    IL.Emit(OpCodes.Castclass, _ctx.Types.StrongBoxOfObject);
+                    IL.Emit(OpCodes.Ldloc, temp);
+                    IL.Emit(OpCodes.Stfld, _ctx.Types.StrongBoxOfObjectValueField);
+                }
+                else
+                {
+                    IL.Emit(OpCodes.Ldarg_0); // display class instance
+                    IL.Emit(OpCodes.Ldloc, temp);
+                    IL.Emit(OpCodes.Stfld, capturedField);
+                }
             }
             else if (_ctx.TopLevelStaticVars?.TryGetValue(v.Name.Lexeme, out var topLevelField) == true)
             {

--- a/Compilation/ILEmitter.Statements.cs
+++ b/Compilation/ILEmitter.Statements.cs
@@ -376,55 +376,6 @@ public partial class ILEmitter
         }
     }
 
-    /// <summary>
-    /// For each per-iteration cell binding (#650), wraps the loop variable's initial
-    /// value (already stored in its plain local by the initializer) in a fresh
-    /// <c>StrongBox&lt;object&gt;</c>, stores the box in a dedicated local, and registers
-    /// it in <see cref="CompilationContext.CellBindingLocals"/> so subsequent
-    /// body/condition/increment access dereferences the cell. Returns the names set up.
-    /// </summary>
-    private List<(string Name, LocalBuilder? Prior)> EmitForLoopCellInit(IEnumerable<string> cellNames)
-    {
-        var active = new List<(string, LocalBuilder?)>();
-        foreach (var name in cellNames)
-        {
-            var local = _ctx.Locals.GetLocal(name);
-            if (local == null) continue; // defensive: binding has no local slot
-
-            IL.Emit(OpCodes.Ldloc, local);
-            if (local.LocalType.IsValueType)
-                IL.Emit(OpCodes.Box, local.LocalType);
-            IL.Emit(OpCodes.Newobj, _ctx.Types.StrongBoxOfObjectCtor);
-
-            var cellLocal = IL.DeclareLocal(_ctx.Types.StrongBoxOfObject);
-            IL.Emit(OpCodes.Stloc, cellLocal);
-            // Save any shadowed outer cell of the same name (nested same-named loops)
-            // so it is restored on loop exit rather than dropped.
-            _ctx.CellBindingLocals.TryGetValue(name, out var prior);
-            _ctx.CellBindingLocals[name] = cellLocal;
-            active.Add((name, prior));
-        }
-        return active;
-    }
-
-    /// <summary>
-    /// ECMA-262 13.7.4 CreatePerIterationEnvironment analog: allocates a fresh cell for
-    /// each binding, copying the current cell's value forward. Closures created in the
-    /// just-finished iteration keep their (old) cell; the loop's increment then operates
-    /// on the new cell.
-    /// </summary>
-    private void EmitForLoopCellCopyForward(List<(string Name, LocalBuilder? Prior)> activeCells)
-    {
-        foreach (var (name, _) in activeCells)
-        {
-            var cellLocal = _ctx.CellBindingLocals[name];
-            IL.Emit(OpCodes.Ldloc, cellLocal);
-            IL.Emit(OpCodes.Ldfld, _ctx.Types.StrongBoxOfObjectValueField);
-            IL.Emit(OpCodes.Newobj, _ctx.Types.StrongBoxOfObjectCtor);
-            IL.Emit(OpCodes.Stloc, cellLocal);
-        }
-    }
-
     protected override void EmitIf(Stmt.If i)
     {
         // Check for dead code elimination optimization

--- a/Compilation/ILEmitter.Statements.cs
+++ b/Compilation/ILEmitter.Statements.cs
@@ -305,6 +305,19 @@ public partial class ILEmitter
             if (f.Initializer != null)
                 EmitStatement(f.Initializer);
 
+            // Per-iteration reference cells (#650): for a loop binding that the body
+            // both mutates and a closure captures, wrap its initial value in a fresh
+            // StrongBox and route all body/condition/increment access through the cell
+            // (registered in CellBindingLocals). Closures capture the cell by reference,
+            // so they observe end-of-iteration mutations; the copy-forward below gives
+            // each iteration its own cell.
+            var cellNames = _ctx.ClosureAnalyzer?.GetForLoopCells(f);
+            List<(string Name, LocalBuilder? Prior)>? activeCells = null;
+            if (cellNames != null && cellNames.Count > 0)
+            {
+                activeCells = EmitForLoopCellInit(cellNames);
+            }
+
             // Array hoist preamble: emit isinst checks for loop-invariant arrays
             var hoisted = EmitArrayHoistPreamble(f.Body, f.Condition, f.Increment);
 
@@ -327,6 +340,13 @@ public partial class ILEmitter
             EmitStatement(f.Body);
 
             builder.MarkLabel(continueLabel);
+            // CreatePerIterationEnvironment analog: copy each cell's end-of-body value
+            // into a FRESH cell BEFORE the increment, so the closures created this
+            // iteration keep the value they observed and the increment acts on the
+            // next iteration's binding.
+            if (activeCells != null)
+                EmitForLoopCellCopyForward(activeCells);
+
             if (f.Increment != null)
             {
                 EmitExpression(f.Increment);
@@ -341,11 +361,67 @@ public partial class ILEmitter
             // Pop hoisted cache
             if (hoisted) _ctx.HoistedArrayCaches.Pop();
 
+            if (activeCells != null)
+                foreach (var (name, prior) in activeCells)
+                {
+                    if (prior != null) _ctx.CellBindingLocals[name] = prior;
+                    else _ctx.CellBindingLocals.Remove(name);
+                }
+
             _ctx.Locals.ExitScope();
         }
         finally
         {
             _optimizedLoopCounterName = null;
+        }
+    }
+
+    /// <summary>
+    /// For each per-iteration cell binding (#650), wraps the loop variable's initial
+    /// value (already stored in its plain local by the initializer) in a fresh
+    /// <c>StrongBox&lt;object&gt;</c>, stores the box in a dedicated local, and registers
+    /// it in <see cref="CompilationContext.CellBindingLocals"/> so subsequent
+    /// body/condition/increment access dereferences the cell. Returns the names set up.
+    /// </summary>
+    private List<(string Name, LocalBuilder? Prior)> EmitForLoopCellInit(IEnumerable<string> cellNames)
+    {
+        var active = new List<(string, LocalBuilder?)>();
+        foreach (var name in cellNames)
+        {
+            var local = _ctx.Locals.GetLocal(name);
+            if (local == null) continue; // defensive: binding has no local slot
+
+            IL.Emit(OpCodes.Ldloc, local);
+            if (local.LocalType.IsValueType)
+                IL.Emit(OpCodes.Box, local.LocalType);
+            IL.Emit(OpCodes.Newobj, _ctx.Types.StrongBoxOfObjectCtor);
+
+            var cellLocal = IL.DeclareLocal(_ctx.Types.StrongBoxOfObject);
+            IL.Emit(OpCodes.Stloc, cellLocal);
+            // Save any shadowed outer cell of the same name (nested same-named loops)
+            // so it is restored on loop exit rather than dropped.
+            _ctx.CellBindingLocals.TryGetValue(name, out var prior);
+            _ctx.CellBindingLocals[name] = cellLocal;
+            active.Add((name, prior));
+        }
+        return active;
+    }
+
+    /// <summary>
+    /// ECMA-262 13.7.4 CreatePerIterationEnvironment analog: allocates a fresh cell for
+    /// each binding, copying the current cell's value forward. Closures created in the
+    /// just-finished iteration keep their (old) cell; the loop's increment then operates
+    /// on the new cell.
+    /// </summary>
+    private void EmitForLoopCellCopyForward(List<(string Name, LocalBuilder? Prior)> activeCells)
+    {
+        foreach (var (name, _) in activeCells)
+        {
+            var cellLocal = _ctx.CellBindingLocals[name];
+            IL.Emit(OpCodes.Ldloc, cellLocal);
+            IL.Emit(OpCodes.Ldfld, _ctx.Types.StrongBoxOfObjectValueField);
+            IL.Emit(OpCodes.Newobj, _ctx.Types.StrongBoxOfObjectCtor);
+            IL.Emit(OpCodes.Stloc, cellLocal);
         }
     }
 

--- a/Compilation/LocalVariableResolver.cs
+++ b/Compilation/LocalVariableResolver.cs
@@ -37,6 +37,17 @@ public class LocalVariableResolver : IVariableResolver
     /// <inheritdoc />
     public StackType? TryLoadVariable(string name)
     {
+        // 0. Per-iteration loop-binding cell (#650): in the loop body / condition /
+        //    increment the binding is accessed through its StrongBox so closures that
+        //    captured the cell observe end-of-iteration mutations. Takes precedence
+        //    over the (now dead) plain local left by the initializer.
+        if (_ctx.CellBindingLocals.TryGetValue(name, out var loadCell))
+        {
+            _il.Emit(OpCodes.Ldloc, loadCell);
+            _il.Emit(OpCodes.Ldfld, _types.StrongBoxOfObjectValueField);
+            return StackType.Unknown;
+        }
+
         // 1. Parameters
         if (_ctx.TryGetParameter(name, out var argIndex))
         {
@@ -164,6 +175,15 @@ public class LocalVariableResolver : IVariableResolver
         {
             _il.Emit(OpCodes.Ldarg_0);
             _il.Emit(OpCodes.Ldfld, field);
+            // Per-iteration cell capture (#650): the field holds a StrongBox shared
+            // with the loop body; dereference Value to read the live binding.
+            if (_ctx.CellCapturedFieldNames?.Contains(name) == true)
+            {
+                // The field is object-typed but holds a StrongBox at runtime.
+                _il.Emit(OpCodes.Castclass, _types.StrongBoxOfObject);
+                _il.Emit(OpCodes.Ldfld, _types.StrongBoxOfObjectValueField);
+                return StackType.Unknown;
+            }
             return MapTypeToStackType(field.FieldType);
         }
 
@@ -211,6 +231,7 @@ public class LocalVariableResolver : IVariableResolver
     /// <inheritdoc />
     public bool HasVariable(string name)
     {
+        if (_ctx.CellBindingLocals.ContainsKey(name)) return true;
         if (_ctx.TryGetParameter(name, out _)) return true;
         if (_ctx.CapturedFunctionLocals?.Contains(name) == true &&
             _ctx.FunctionDisplayClassFields?.ContainsKey(name) == true) return true;
@@ -230,6 +251,18 @@ public class LocalVariableResolver : IVariableResolver
     /// <inheritdoc />
     public bool TryStoreVariable(string name)
     {
+        // 0. Per-iteration loop-binding cell (#650): write through the StrongBox so the
+        //    mutation is visible to closures that captured this iteration's cell.
+        if (_ctx.CellBindingLocals.TryGetValue(name, out var storeCell))
+        {
+            var cellTemp = _il.DeclareLocal(_types.Object);
+            _il.Emit(OpCodes.Stloc, cellTemp);
+            _il.Emit(OpCodes.Ldloc, storeCell);
+            _il.Emit(OpCodes.Ldloc, cellTemp);
+            _il.Emit(OpCodes.Stfld, _types.StrongBoxOfObjectValueField);
+            return true;
+        }
+
         // 1. Function display class fields (captured function-local vars)
         // Check this BEFORE regular locals to ensure we use the shared storage
         if (_ctx.CapturedFunctionLocals?.Contains(name) == true &&
@@ -380,6 +413,17 @@ public class LocalVariableResolver : IVariableResolver
             // This works for both value and reference type display classes
             var temp = _il.DeclareLocal(_types.Object);
             _il.Emit(OpCodes.Stloc, temp);
+            // Per-iteration cell capture (#650): the field holds a shared StrongBox —
+            // write through Value so the loop body and sibling closures see the update.
+            if (_ctx.CellCapturedFieldNames?.Contains(name) == true)
+            {
+                _il.Emit(OpCodes.Ldarg_0);
+                _il.Emit(OpCodes.Ldfld, field);
+                _il.Emit(OpCodes.Castclass, _types.StrongBoxOfObject);
+                _il.Emit(OpCodes.Ldloc, temp);
+                _il.Emit(OpCodes.Stfld, _types.StrongBoxOfObjectValueField);
+                return true;
+            }
             _il.Emit(OpCodes.Ldarg_0);
             _il.Emit(OpCodes.Ldloc, temp);
             _il.Emit(OpCodes.Stfld, field);

--- a/Compilation/PerIterationCellAnalyzer.cs
+++ b/Compilation/PerIterationCellAnalyzer.cs
@@ -1,0 +1,288 @@
+using SharpTS.Parsing;
+using SharpTS.Parsing.Visitors;
+
+namespace SharpTS.Compilation;
+
+/// <summary>
+/// Detects <c>for (let/const …)</c> loop bindings that need a per-iteration
+/// <b>reference cell</b> (the compiled analog of the interpreter's
+/// <c>CreatePerIterationEnvironment</c>; see ECMA-262 13.7.4 and issue #650).
+/// </summary>
+/// <remarks>
+/// The #649 fix keeps per-iteration loop bindings out of display classes so each
+/// closure snapshots a fresh value — correct for the common
+/// <c>for (let k …) { fns.push(() =&gt; k); }</c> case. It is NOT correct when the
+/// loop body <em>mutates</em> the binding after the closure is created
+/// (<c>{ i = i + 10; g.push(() =&gt; i); i = i - 10; }</c>): a value snapshot freezes
+/// the mid-body value (10/11/12) instead of the binding's end-of-body value
+/// (0/1/2). The fix is a per-iteration <see cref="System.Runtime.CompilerServices.StrongBox{T}"/>
+/// shared by the loop body and every capturing closure: closures hold the cell by
+/// reference, so they observe end-of-iteration mutations; a fresh cell is allocated
+/// (value copied forward) each iteration so distinct iterations stay distinct.
+///
+/// <para>A binding needs a cell iff it is (a per-iteration let/const binding) ∩
+/// (assigned in the loop <em>body</em>, not merely the <c>i++</c> update clause —
+/// these are separate AST subtrees, so the update clause is naturally excluded) ∩
+/// (captured by a closure). Bindings captured only at closure-creation but never
+/// body-mutated stay on the cheap value-snapshot path.</para>
+///
+/// <para><b>Phase 1 (sync) scope.</b> Only the sync <c>ILEmitter.EmitFor</c> path
+/// creates cells. To stay self-consistent — never letting a resolver dereference a
+/// field that was not populated with a cell — this analyzer marks a binding
+/// cell-eligible only when the loop and every capturing closure live in a fully
+/// synchronous context (no <c>async</c>/generator boundary between the loop and any
+/// capturer). Loops or captures that cross an async/generator boundary are left on
+/// the existing snapshot path (Phase 2 will extend cells through state machines).</para>
+/// </remarks>
+public sealed class PerIterationCellAnalyzer : AstVisitorBase
+{
+    private sealed class LoopFrame
+    {
+        public required Stmt.For Loop { get; init; }
+        public required HashSet<string> Bindings { get; init; }
+        public int AsyncDepthAtEntry { get; init; }
+        public int ClosureDepthAtEntry { get; init; }
+        public HashSet<string> Assigned { get; } = [];
+        public HashSet<string> CleanSyncCapture { get; } = [];
+        public HashSet<string> Ineligible { get; } = [];
+        public List<(object Closure, string Name)> Tentative { get; } = [];
+    }
+
+    // Stack of enclosing for-loop frames (innermost first), in source order.
+    private readonly Stack<LoopFrame> _loopFrames = new();
+
+    // Stack of enclosing closures (arrow / function declaration), innermost first.
+    private readonly Stack<object> _closureStack = new();
+
+    // Number of async/generator closures currently on the closure stack.
+    private int _asyncDepth;
+
+    /// <summary>For each cell-eligible for-loop, the binding names that get a cell.</summary>
+    public Dictionary<Stmt.For, HashSet<string>> ForLoopCells { get; } =
+        new(ReferenceEqualityComparer.Instance);
+
+    /// <summary>
+    /// For each closure node (arrow / inner function), the captured names that are
+    /// per-iteration cell bindings of an enclosing loop — the closure body must
+    /// dereference these (load the captured field, then read <c>StrongBox.Value</c>).
+    /// </summary>
+    public Dictionary<object, HashSet<string>> ClosureCellFields { get; } =
+        new(ReferenceEqualityComparer.Instance);
+
+    public void Analyze(List<Stmt> statements)
+    {
+        foreach (var stmt in statements)
+            Visit(stmt);
+    }
+
+    /// <summary>Cell bindings for a for-loop, or an empty set if none.</summary>
+    public HashSet<string> GetForLoopCells(Stmt.For loop) =>
+        ForLoopCells.TryGetValue(loop, out var cells) ? cells : [];
+
+    /// <summary>Cell-captured field names for a closure node, or an empty set if none.</summary>
+    public HashSet<string> GetClosureCellFields(object closure) =>
+        ClosureCellFields.TryGetValue(closure, out var names) ? names : [];
+
+    protected override void VisitFor(Stmt.For stmt)
+    {
+        // The increment clause is visited OUTSIDE the frame, so an `i++` update is
+        // not counted as a body mutation (matching ECMA-262: the per-iteration copy
+        // happens before the increment).
+        if (stmt.Initializer != null) Visit(stmt.Initializer);
+        if (stmt.Condition != null) Visit(stmt.Condition);
+        if (stmt.Increment != null) Visit(stmt.Increment);
+
+        var bindings = CollectLoopBindingNames(stmt.Initializer);
+        // Phase 1: only loops in a fully synchronous context get cells (the sync
+        // ILEmitter.EmitFor is the only emitter that allocates them). A loop nested
+        // in an async/generator callable is lowered by the state-machine EmitFor
+        // family, which ignores cells — tracking it would let a capturing sync
+        // closure dereference a field that was never populated with a cell.
+        if (bindings == null || bindings.Count == 0 || _asyncDepth > 0)
+        {
+            Visit(stmt.Body);
+            return;
+        }
+
+        var frame = new LoopFrame
+        {
+            Loop = stmt,
+            Bindings = [.. bindings],
+            AsyncDepthAtEntry = _asyncDepth,
+            ClosureDepthAtEntry = _closureStack.Count,
+        };
+        _loopFrames.Push(frame);
+        Visit(stmt.Body);
+        _loopFrames.Pop();
+
+        var cells = new HashSet<string>(frame.Bindings);
+        cells.IntersectWith(frame.Assigned);
+        cells.IntersectWith(frame.CleanSyncCapture);
+        cells.ExceptWith(frame.Ineligible);
+        if (cells.Count == 0) return;
+
+        ForLoopCells[stmt] = cells;
+        foreach (var (closure, name) in frame.Tentative)
+        {
+            if (!cells.Contains(name)) continue;
+            if (!ClosureCellFields.TryGetValue(closure, out var set))
+                ClosureCellFields[closure] = set = [];
+            set.Add(name);
+        }
+    }
+
+    /// <summary>
+    /// Mirrors <c>Interpreter.CollectPerIterationBindings</c> / <c>ClosureAnalyzer.CollectLoopBindingNames</c>:
+    /// <c>let</c>/<c>const</c> for-initializers bind per iteration; <c>var</c> and bare
+    /// expression initializers share one binding.
+    /// </summary>
+    private static List<string>? CollectLoopBindingNames(Stmt? initializer)
+    {
+        switch (initializer)
+        {
+            case Stmt.Var v when !v.IsVar:
+                return [v.Name.Lexeme];
+            case Stmt.Const c:
+                return [c.Name.Lexeme];
+            case Stmt.Sequence seq:
+                List<string>? names = null;
+                foreach (var s in seq.Statements)
+                {
+                    var sub = CollectLoopBindingNames(s);
+                    if (sub != null) (names ??= []).AddRange(sub);
+                }
+                return names;
+            default:
+                return null;
+        }
+    }
+
+    // ---- Reference / assignment recording ----
+
+    private void RecordReference(string name)
+    {
+        if (_closureStack.Count == 0) return; // not inside any closure → not a capture
+        foreach (var frame in _loopFrames)
+        {
+            if (!frame.Bindings.Contains(name)) continue;
+            // Innermost loop frame that declares this name owns it (shadowing).
+            // Captured iff referenced from inside a closure nested in THIS loop's
+            // body — i.e. a closure entered AFTER the frame was pushed (the loop's
+            // own enclosing function does not count).
+            if (_closureStack.Count <= frame.ClosureDepthAtEntry) return;
+            var innermost = _closureStack.Peek();
+            // Phase 1 wires only plain (sync, non-generator) ARROW capturers: their
+            // bodies use LocalVariableResolver, where we add the cell dereference. Inner
+            // function declarations have their own capture machinery (deferred), and any
+            // async/generator boundary is Phase 2 — those make the binding ineligible so
+            // it stays on the existing value-snapshot path (no resolver derefs a field
+            // that was never populated with a cell).
+            bool clean = _asyncDepth == frame.AsyncDepthAtEntry
+                && innermost is Expr.ArrowFunction { IsAsync: false, IsGenerator: false };
+            if (clean)
+            {
+                frame.CleanSyncCapture.Add(name);
+                frame.Tentative.Add((innermost, name));
+            }
+            else
+            {
+                // An async/generator boundary sits between the loop and the capturer;
+                // Phase 1 cannot wire a cell through it. Leave on the snapshot path.
+                frame.Ineligible.Add(name);
+            }
+            return;
+        }
+    }
+
+    private void RecordAssignment(string name)
+    {
+        foreach (var frame in _loopFrames)
+        {
+            if (!frame.Bindings.Contains(name)) continue;
+            frame.Assigned.Add(name);
+            return; // innermost owner
+        }
+    }
+
+    protected override void VisitVariable(Expr.Variable expr)
+    {
+        RecordReference(expr.Name.Lexeme);
+    }
+
+    protected override void VisitAssign(Expr.Assign expr)
+    {
+        RecordAssignment(expr.Name.Lexeme);
+        RecordReference(expr.Name.Lexeme);
+        base.VisitAssign(expr);
+    }
+
+    protected override void VisitCompoundAssign(Expr.CompoundAssign expr)
+    {
+        RecordAssignment(expr.Name.Lexeme);
+        RecordReference(expr.Name.Lexeme);
+        base.VisitCompoundAssign(expr);
+    }
+
+    protected override void VisitLogicalAssign(Expr.LogicalAssign expr)
+    {
+        RecordAssignment(expr.Name.Lexeme);
+        RecordReference(expr.Name.Lexeme);
+        base.VisitLogicalAssign(expr);
+    }
+
+    protected override void VisitPrefixIncrement(Expr.PrefixIncrement expr)
+    {
+        if (expr.Operand is Expr.Variable v)
+        {
+            RecordAssignment(v.Name.Lexeme);
+            RecordReference(v.Name.Lexeme);
+        }
+        base.VisitPrefixIncrement(expr);
+    }
+
+    protected override void VisitPostfixIncrement(Expr.PostfixIncrement expr)
+    {
+        if (expr.Operand is Expr.Variable v)
+        {
+            RecordAssignment(v.Name.Lexeme);
+            RecordReference(v.Name.Lexeme);
+        }
+        base.VisitPostfixIncrement(expr);
+    }
+
+    // ---- Closure scopes ----
+
+    protected override void VisitArrowFunction(Expr.ArrowFunction expr)
+    {
+        EnterClosure(expr, IsAsyncOrGen(expr));
+        base.VisitArrowFunction(expr);
+        ExitClosure(IsAsyncOrGen(expr));
+    }
+
+    protected override void VisitFunction(Stmt.Function stmt)
+    {
+        if (stmt.Body == null) { base.VisitFunction(stmt); return; }
+        EnterClosure(stmt, IsAsyncOrGen(stmt));
+        base.VisitFunction(stmt);
+        ExitClosure(IsAsyncOrGen(stmt));
+    }
+
+    private void EnterClosure(object node, bool asyncOrGen)
+    {
+        _closureStack.Push(node);
+        if (asyncOrGen) _asyncDepth++;
+    }
+
+    private void ExitClosure(bool asyncOrGen)
+    {
+        _closureStack.Pop();
+        if (asyncOrGen) _asyncDepth--;
+    }
+
+    private static bool IsAsyncOrGen(object node) => node switch
+    {
+        Expr.ArrowFunction a => a.IsAsync || a.IsGenerator,
+        Stmt.Function f => f.IsAsync || f.IsGenerator,
+        _ => false,
+    };
+}

--- a/Compilation/PerIterationCellAnalyzer.cs
+++ b/Compilation/PerIterationCellAnalyzer.cs
@@ -93,12 +93,26 @@ public sealed class PerIterationCellAnalyzer : AstVisitorBase
         if (stmt.Increment != null) Visit(stmt.Increment);
 
         var bindings = CollectLoopBindingNames(stmt.Initializer);
-        // Phase 1: only loops in a fully synchronous context get cells (the sync
-        // ILEmitter.EmitFor is the only emitter that allocates them). A loop nested
-        // in an async/generator callable is lowered by the state-machine EmitFor
-        // family, which ignores cells — tracking it would let a capturing sync
-        // closure dereference a field that was never populated with a cell.
-        if (bindings == null || bindings.Count == 0 || _asyncDepth > 0)
+        // The cell is an IL local in every emitter (sync ILEmitter.EmitFor and the
+        // state-machine base EmitFor). A cell-as-local is only valid when the whole
+        // loop runs within a single execution segment — i.e. the loop body has no
+        // DIRECT await/yield (suspension inside a nested closure is fine). A loop
+        // whose body itself suspends would span multiple MoveNext calls, where a
+        // local does not survive; those stay on the value-snapshot path (the cell
+        // would need to be a hoisted state-machine field — deferred). In a fully
+        // synchronous context there is never a direct suspension, so this is a no-op
+        // for Phase 1.
+        //
+        // Covered emitters: sync (ILEmitter), async functions (AsyncMoveNextEmitter),
+        // and generators (GeneratorMoveNextEmitter / base hooks). Async ARROWS and ASYNC
+        // GENERATORS are deferred: their closure-capture paths don't yet snapshot the cell
+        // reference, so creating a cell there would make a capturing closure dereference a
+        // non-cell value at runtime. Leaving those on the snapshot path keeps them correct-
+        // by-interpretation and crash-free.
+        var enclosingClosure = _closureStack.Count > 0 ? _closureStack.Peek() : null;
+        if (bindings == null || bindings.Count == 0
+            || HasDirectSuspension(stmt.Body)
+            || IsDeferredCellContext(enclosingClosure))
         {
             Visit(stmt.Body);
             return;
@@ -285,4 +299,42 @@ public sealed class PerIterationCellAnalyzer : AstVisitorBase
         Stmt.Function f => f.IsAsync || f.IsGenerator,
         _ => false,
     };
+
+    /// <summary>
+    /// True for state-machine contexts whose closure-capture path does not yet snapshot a
+    /// per-iteration cell by reference (#650 follow-up): async arrows and async generators.
+    /// Loops directly enclosed by one of these are left on the value-snapshot path.
+    /// </summary>
+    private static bool IsDeferredCellContext(object? closure) => closure switch
+    {
+        Expr.ArrowFunction { IsAsync: true } => true,
+        Stmt.Function { IsAsync: true, IsGenerator: true } => true,
+        _ => false,
+    };
+
+    /// <summary>
+    /// True if <paramref name="body"/> contains an <c>await</c> or <c>yield</c> that would
+    /// suspend the ENCLOSING state machine — i.e. not nested inside another closure. A loop
+    /// with such a suspension spans multiple MoveNext calls, so its per-iteration cell could
+    /// not live as a local; such loops are left on the snapshot path.
+    /// </summary>
+    private static bool HasDirectSuspension(Stmt body)
+    {
+        var v = new DirectSuspensionVisitor();
+        v.Visit(body);
+        return v.Found;
+    }
+
+    private sealed class DirectSuspensionVisitor : AstVisitorBase
+    {
+        public bool Found { get; private set; }
+
+        protected override void VisitAwait(Expr.Await expr) => Found = true;
+        protected override void VisitYield(Expr.Yield expr) => Found = true;
+
+        // Do not descend into nested closures: their await/yield suspends THEM, not the
+        // loop's enclosing state machine.
+        protected override void VisitArrowFunction(Expr.ArrowFunction expr) { }
+        protected override void VisitFunction(Stmt.Function stmt) { }
+    }
 }

--- a/Compilation/StateMachineVariableResolver.cs
+++ b/Compilation/StateMachineVariableResolver.cs
@@ -20,6 +20,8 @@ public class StateMachineVariableResolver : IVariableResolver
     private readonly Func<string, FieldInfo?> _getVariableField;
     private readonly LocalsManager _locals;
     private readonly FieldInfo? _thisField;
+    private readonly IReadOnlyDictionary<string, LocalBuilder>? _cellBindingLocals;
+    private readonly FieldInfo? _strongBoxValueField;
 
     /// <summary>
     /// Creates a new resolver for state machine variable access.
@@ -28,21 +30,36 @@ public class StateMachineVariableResolver : IVariableResolver
     /// <param name="getVariableField">Delegate to get hoisted field from state machine builder</param>
     /// <param name="locals">LocalsManager for non-hoisted locals</param>
     /// <param name="thisField">The <>4__this field, or null if not an instance method</param>
+    /// <param name="cellBindingLocals">Per-iteration cell locals (#650), shared with the emitter; null disables cells.</param>
+    /// <param name="strongBoxValueField">The StrongBox&lt;object&gt;.Value field, for cell dereference.</param>
     public StateMachineVariableResolver(
         ILGenerator il,
         Func<string, FieldInfo?> getVariableField,
         LocalsManager locals,
-        FieldInfo? thisField)
+        FieldInfo? thisField,
+        IReadOnlyDictionary<string, LocalBuilder>? cellBindingLocals = null,
+        FieldInfo? strongBoxValueField = null)
     {
         _il = il;
         _getVariableField = getVariableField;
         _locals = locals;
         _thisField = thisField;
+        _cellBindingLocals = cellBindingLocals;
+        _strongBoxValueField = strongBoxValueField;
     }
 
     /// <inheritdoc />
     public StackType? TryLoadVariable(string name)
     {
+        // 0. Per-iteration loop-binding cell (#650): read through the StrongBox so closures
+        //    that captured the cell observe end-of-iteration mutations.
+        if (_cellBindingLocals != null && _cellBindingLocals.TryGetValue(name, out var loadCell))
+        {
+            _il.Emit(OpCodes.Ldloc, loadCell);
+            _il.Emit(OpCodes.Ldfld, _strongBoxValueField!);
+            return StackType.Unknown;
+        }
+
         // 1. Check if hoisted to state machine field
         var field = _getVariableField(name);
         if (field != null)
@@ -65,6 +82,7 @@ public class StateMachineVariableResolver : IVariableResolver
     /// <inheritdoc />
     public bool HasVariable(string name)
     {
+        if (_cellBindingLocals != null && _cellBindingLocals.ContainsKey(name)) return true;
         if (_getVariableField(name) != null) return true;
         if (_locals.HasLocal(name)) return true;
         return false;
@@ -73,6 +91,17 @@ public class StateMachineVariableResolver : IVariableResolver
     /// <inheritdoc />
     public bool TryStoreVariable(string name)
     {
+        // 0. Per-iteration loop-binding cell (#650): write through the StrongBox.
+        if (_cellBindingLocals != null && _cellBindingLocals.TryGetValue(name, out var storeCell))
+        {
+            var cellTemp = _il.DeclareLocal(typeof(object));
+            _il.Emit(OpCodes.Stloc, cellTemp);
+            _il.Emit(OpCodes.Ldloc, storeCell);
+            _il.Emit(OpCodes.Ldloc, cellTemp);
+            _il.Emit(OpCodes.Stfld, _strongBoxValueField!);
+            return true;
+        }
+
         // 1. Check if hoisted to state machine field
         var field = _getVariableField(name);
         if (field != null)

--- a/Compilation/StatementEmitterBase.cs
+++ b/Compilation/StatementEmitterBase.cs
@@ -439,6 +439,16 @@ public abstract class StatementEmitterBase : ExpressionEmitterBase
         if (f.Initializer != null)
             EmitStatement(f.Initializer);
 
+        // Per-iteration reference cells (#650): see EmitForLoopCellInit. In a state-machine
+        // emitter the cell stays an IL local — valid because the analyzer only marks a loop
+        // when its body has no direct suspension point, so the whole loop runs within one
+        // MoveNext segment (the cell, a heap StrongBox, is captured by reference by closures
+        // and outlives the segment).
+        var cellNames = Ctx.ClosureAnalyzer?.GetForLoopCells(f);
+        List<(string Name, LocalBuilder? Prior)>? activeCells = null;
+        if (cellNames != null && cellNames.Count > 0)
+            activeCells = EmitForLoopCellInit(cellNames);
+
         var startLabel = IL.DefineLabel();
         var endLabel = IL.DefineLabel();
         var continueLabel = IL.DefineLabel();  // Points to increment
@@ -460,6 +470,8 @@ public abstract class StatementEmitterBase : ExpressionEmitterBase
 
         // Continue target: increment goes here
         IL.MarkLabel(continueLabel);
+        if (activeCells != null)
+            EmitForLoopCellCopyForward(activeCells);
         if (f.Increment != null)
         {
             EmitExpression(f.Increment);
@@ -471,8 +483,63 @@ public abstract class StatementEmitterBase : ExpressionEmitterBase
         IL.MarkLabel(endLabel);
         ExitLoop();
 
+        if (activeCells != null)
+            foreach (var (name, prior) in activeCells)
+            {
+                if (prior != null) Ctx.CellBindingLocals[name] = prior;
+                else Ctx.CellBindingLocals.Remove(name);
+            }
+
         // Exit loop scope
         Ctx.Locals.ExitScope();
+    }
+
+    /// <summary>
+    /// For each per-iteration cell binding (#650), wraps the loop variable's initial value
+    /// (already stored in its plain local by the initializer) in a fresh
+    /// <c>StrongBox&lt;object&gt;</c>, stores the box in a dedicated local, and registers it in
+    /// <see cref="CompilationContext.CellBindingLocals"/> so subsequent body/condition/increment
+    /// access (and any capturing closure) goes through the cell. Returns the names set up, each
+    /// paired with any shadowed outer cell to restore on loop exit (nested same-named loops).
+    /// Shared by the sync <see cref="ILEmitter"/> override and the state-machine emitters.
+    /// </summary>
+    protected List<(string Name, LocalBuilder? Prior)> EmitForLoopCellInit(IEnumerable<string> cellNames)
+    {
+        var active = new List<(string, LocalBuilder?)>();
+        foreach (var name in cellNames)
+        {
+            var local = Ctx.Locals.GetLocal(name);
+            if (local == null) continue; // defensive: binding has no local slot
+
+            IL.Emit(OpCodes.Ldloc, local);
+            if (local.LocalType.IsValueType)
+                IL.Emit(OpCodes.Box, local.LocalType);
+            IL.Emit(OpCodes.Newobj, Ctx.Types.StrongBoxOfObjectCtor);
+
+            var cellLocal = IL.DeclareLocal(Ctx.Types.StrongBoxOfObject);
+            IL.Emit(OpCodes.Stloc, cellLocal);
+            Ctx.CellBindingLocals.TryGetValue(name, out var prior);
+            Ctx.CellBindingLocals[name] = cellLocal;
+            active.Add((name, prior));
+        }
+        return active;
+    }
+
+    /// <summary>
+    /// ECMA-262 13.7.4 CreatePerIterationEnvironment analog: allocates a fresh cell for each
+    /// binding, copying the current cell's value forward. Closures created in the just-finished
+    /// iteration keep their (old) cell; the loop's increment then operates on the new cell.
+    /// </summary>
+    protected void EmitForLoopCellCopyForward(List<(string Name, LocalBuilder? Prior)> activeCells)
+    {
+        foreach (var (name, _) in activeCells)
+        {
+            var cellLocal = Ctx.CellBindingLocals[name];
+            IL.Emit(OpCodes.Ldloc, cellLocal);
+            IL.Emit(OpCodes.Ldfld, Ctx.Types.StrongBoxOfObjectValueField);
+            IL.Emit(OpCodes.Newobj, Ctx.Types.StrongBoxOfObjectCtor);
+            IL.Emit(OpCodes.Stloc, cellLocal);
+        }
     }
 
     /// <summary>

--- a/Compilation/TypeProvider.cs
+++ b/Compilation/TypeProvider.cs
@@ -200,6 +200,20 @@ public class TypeProvider
     public Type WeakReferenceOpen => Resolve("System.WeakReference`1");
     public Type WeakReferenceObject => MakeGenericType(WeakReferenceOpen, Object);
 
+    // Per-iteration loop-binding reference cell (#650). StrongBox<object> is a BCL
+    // type, so emitting it keeps compiled standalone DLLs free of a SharpTS.dll
+    // dependency. The body and every capturing closure share one StrongBox per
+    // iteration so closures observe end-of-iteration mutations of the loop variable.
+    public Type StrongBoxOpen => Resolve("System.Runtime.CompilerServices.StrongBox`1");
+    public Type StrongBoxOfObject => MakeGenericType(StrongBoxOpen, Object);
+
+    /// <summary>The <c>StrongBox&lt;object&gt;(object value)</c> constructor.</summary>
+    public ConstructorInfo StrongBoxOfObjectCtor =>
+        StrongBoxOfObject.GetConstructors().Single(c => c.GetParameters().Length == 1);
+
+    /// <summary>The public <c>StrongBox&lt;object&gt;.Value</c> field.</summary>
+    public FieldInfo StrongBoxOfObjectValueField => StrongBoxOfObject.GetField("Value")!;
+
     #endregion
 
     #region Tasks and Async

--- a/SharpTS.Tests/SharedTests/ForLoopPerIterationBindingTests.cs
+++ b/SharpTS.Tests/SharedTests/ForLoopPerIterationBindingTests.cs
@@ -107,20 +107,105 @@ public class ForLoopPerIterationBindingTests
     // ---- Mutating the loop var inside the body is reflected in that iteration's capture ----
     // i becomes i+10 at capture time, then i-10 before the iteration ends, so the per-iteration
     // binding settles back to the loop value; the per-iteration copy then carries that forward.
-    // Interpreted-only: compiled mode SNAPSHOTS the loop var's value at closure-creation time
-    // (i+10 == 10/11/12) rather than reference-capturing the per-iteration binding (whose end-of-
-    // body value is 0/1/2). This snapshot-timing gap is uniform across compiled contexts (top
-    // level, sync/async function bodies) and is tracked by #650; a full fix needs a per-iteration
-    // binding cell that closures reference-capture. The interpreter reads the live binding slot,
-    // matching node (0,1,2).
+    // Compiled mode (#650) now allocates a per-iteration StrongBox cell for a loop binding that
+    // the body BOTH mutates AND a closure captures, so closures reference-capture the live cell
+    // (end-of-body value 0/1/2) instead of snapshotting the mid-body value (10/11/12). The cheap
+    // value-snapshot path (#649) still serves the common non-mutating case.
     [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void BodyMutatesLoopVar_CapturesLiveSlot(ExecutionMode mode)
     {
         var source = """
             const g: any[] = [];
             for (let i = 0; i < 3; i++) { i = i + 10; g.push(() => i); i = i - 10; }
             console.log(g.map((f: any) => f()).join(","));
+            """;
+        Assert.Equal("0,1,2\n", TestHarness.Run(source, mode));
+    }
+
+    // Same mutate-and-restore pattern inside a SYNC function body (cell lives as a local
+    // in the function frame). Exercises the function-context EmitFor path.
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void BodyMutatesLoopVar_SyncFunctionBody(ExecutionMode mode)
+    {
+        var source = """
+            function main(): string {
+                const g: any[] = [];
+                for (let i = 0; i < 3; i++) { i = i + 10; g.push(() => i); i = i - 10; }
+                return g.map((f: any) => f()).join(",");
+            }
+            console.log(main());
+            """;
+        Assert.Equal("0,1,2\n", TestHarness.Run(source, mode));
+    }
+
+    // The cell is shared by reference, so a closure that WRITES the loop binding mutates that
+    // iteration's binding and a sibling reader observes it. Each iteration k: writer increments
+    // binding k (k → k+1), reader returns k+1. node: 1,2,3.
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void BodyMutatesLoopVar_ClosureWritesThrough(ExecutionMode mode)
+    {
+        var source = """
+            const readers: any[] = [];
+            const writers: any[] = [];
+            for (let i = 0; i < 3; i++) { readers.push(() => i); writers.push(() => { i = i + 1; }); }
+            writers.forEach((w: any) => w());
+            console.log(readers.map((f: any) => f()).join(","));
+            """;
+        Assert.Equal("1,2,3\n", TestHarness.Run(source, mode));
+    }
+
+    // Same as above but the writer uses `i++` (postfix increment in a closure), exercising
+    // the increment emitter's captured-cell write-through path.
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void BodyMutatesLoopVar_ClosureIncrementsThrough(ExecutionMode mode)
+    {
+        var source = """
+            const readers: any[] = [];
+            const writers: any[] = [];
+            for (let i = 0; i < 3; i++) { readers.push(() => i); writers.push(() => { i++; }); }
+            writers.forEach((w: any) => w());
+            console.log(readers.map((f: any) => f()).join(","));
+            """;
+        Assert.Equal("1,2,3\n", TestHarness.Run(source, mode));
+    }
+
+    // Nested loops where BOTH loop vars are mutate-and-restored and captured by the inner
+    // closure — each needs its own cell, copied forward independently.
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void NestedLoops_BothBindingsMutated(ExecutionMode mode)
+    {
+        var source = """
+            const d: any[] = [];
+            for (let i = 0; i < 2; i++) {
+                for (let j = 0; j < 2; j++) {
+                    i = i + 5; j = j + 5;
+                    d.push(() => "" + i + j);
+                    i = i - 5; j = j - 5;
+                }
+            }
+            console.log(d.map((f: any) => f()).join(","));
+            """;
+        Assert.Equal("00,01,10,11\n", TestHarness.Run(source, mode));
+    }
+
+    // Async/generator contexts keep the mutate-and-restore gap on the snapshot path until
+    // the state-machine cell rework (#650 Phase 2); interpreted-only for now.
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void BodyMutatesLoopVar_AsyncFunctionBody_InterpretedOnly(ExecutionMode mode)
+    {
+        var source = """
+            async function main() {
+                const g: any[] = [];
+                for (let i = 0; i < 3; i++) { i = i + 10; g.push(() => i); i = i - 10; }
+                console.log(g.map((f: any) => f()).join(","));
+            }
+            main();
             """;
         Assert.Equal("0,1,2\n", TestHarness.Run(source, mode));
     }

--- a/SharpTS.Tests/SharedTests/ForLoopPerIterationBindingTests.cs
+++ b/SharpTS.Tests/SharedTests/ForLoopPerIterationBindingTests.cs
@@ -193,11 +193,14 @@ public class ForLoopPerIterationBindingTests
         Assert.Equal("00,01,10,11\n", TestHarness.Run(source, mode));
     }
 
-    // Async/generator contexts keep the mutate-and-restore gap on the snapshot path until
-    // the state-machine cell rework (#650 Phase 2); interpreted-only for now.
+    // #650 Phase 2: the mutate-and-restore fix now works in state-machine contexts too
+    // (async function / generator / async generator), as long as the loop body has no
+    // direct await/yield — the per-iteration cell is an IL local that lives for the whole
+    // loop within one MoveNext segment. Loops whose body itself suspends remain on the
+    // snapshot path (cell-as-field is a further follow-up).
     [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
-    public void BodyMutatesLoopVar_AsyncFunctionBody_InterpretedOnly(ExecutionMode mode)
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void BodyMutatesLoopVar_AsyncFunctionBody(ExecutionMode mode)
     {
         var source = """
             async function main() {
@@ -206,6 +209,60 @@ public class ForLoopPerIterationBindingTests
                 console.log(g.map((f: any) => f()).join(","));
             }
             main();
+            """;
+        Assert.Equal("0,1,2\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void BodyMutatesLoopVar_GeneratorBody(ExecutionMode mode)
+    {
+        var source = """
+            function* gen() {
+                const g: any[] = [];
+                for (let i = 0; i < 3; i++) { i = i + 10; g.push(() => i); i = i - 10; }
+                yield g.map((f: any) => f()).join(",");
+            }
+            console.log(gen().next().value);
+            """;
+        Assert.Equal("0,1,2\n", TestHarness.Run(source, mode));
+    }
+
+    // Interpreted-only: the per-iteration cell wiring for async generators is in place, but
+    // consuming a COMPILED async generator via `for await…of` is a separate, pre-existing gap
+    // (it hangs even without the mutation), so this can't be exercised compiled yet.
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void BodyMutatesLoopVar_AsyncGeneratorBody(ExecutionMode mode)
+    {
+        var source = """
+            async function* agen() {
+                const g: any[] = [];
+                for (let i = 0; i < 3; i++) { i = i + 10; g.push(() => i); i = i - 10; }
+                yield g.map((f: any) => f()).join(",");
+            }
+            async function main() {
+                for await (const v of agen()) { console.log(v); }
+            }
+            main();
+            """;
+        Assert.Equal("0,1,2\n", TestHarness.Run(source, mode));
+    }
+
+    // Interpreted-only: async arrows are a deferred #650 context (their closure-capture path
+    // doesn't yet snapshot the per-iteration cell by reference), so the compiled path stays on
+    // the value-snapshot behavior. The interpreter is correct.
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void BodyMutatesLoopVar_AsyncArrowBody(ExecutionMode mode)
+    {
+        var source = """
+            const run = async () => {
+                const g: any[] = [];
+                for (let i = 0; i < 3; i++) { i = i + 10; g.push(() => i); i = i - 10; }
+                console.log(g.map((f: any) => f()).join(","));
+            };
+            run();
             """;
         Assert.Equal("0,1,2\n", TestHarness.Run(source, mode));
     }


### PR DESCRIPTION
## Summary

Fixes #650 — in **compiled** mode a closure capturing a `for (let …)` loop variable diverged from spec when the loop body mutated and then restored the loop variable in the same iteration (observed the closure-creation-time snapshot instead of the per-iteration binding's end-of-body value).

```ts
const g: any[] = [];
for (let i = 0; i < 3; i++) { i = i + 10; g.push(() => i); i = i - 10; }
console.log(g.map((f: any) => f()).join(","));
// node / interp: 0,1,2
// compiled (before): 10,11,12   (BUG)
// compiled (after):  0,1,2
```

## Approach

A per-iteration **`System.Runtime.CompilerServices.StrongBox<object>` cell** (a BCL type, so compiled standalone DLLs gain no `SharpTS.dll` dependency) — the compiled analog of the interpreter's `CreatePerIterationEnvironment`:

- the loop allocates a cell and routes body/condition/increment access through `cell.Value`;
- a **fresh cell is copied forward at the continue label, before the increment**, so closures created in iteration *N* keep *N*'s cell and the increment acts on *N+1*'s;
- capturing closures snapshot the cell **reference** (and dereference `.Value` in their body).

The cell is an **IL local** in every mode — valid because the fix is gated to loops whose body has no direct `await`/`yield`, so the whole loop runs in one execution segment and the heap `StrongBox` outlives it via the closures.

**Gating** (`PerIterationCellAnalyzer`, run by `ClosureAnalyzer`): a binding gets a cell only when it is per-iteration (`let`/`const`) ∩ assigned in the loop **body** (not the `i++` update clause) ∩ captured by a sync arrow ∩ the body has no direct suspension. The common non-mutating `() => k` case stays on the cheap value-snapshot path from #649.

## Scope

| Context | Compiled |
|---|---|
| Top level, sync functions/methods/arrows, inner functions | ✅ Phase 1 |
| Async functions, generators | ✅ Phase 2 |
| Async arrows, async generators | ⏸ deferred (interpreter-only) |
| Loop body itself `await`/`yield`s | ⏸ deferred (would need a hoisted state-machine field cell) |

Deferred contexts stay on the existing snapshot path (correct under interpretation, **crash-free** compiled — the analyzer's `IsDeferredCellContext` avoids creating a cell a capturer would mis-dereference). The deferred async-arrow / async-generator contexts (and the harder loop-body-suspends sub-case) are tracked in #817. Separately discovered: consuming a **compiled async generator via `for await…of` hangs even without this change** — a pre-existing gap, not addressed here.

## Tests

`SharpTS.Tests/SharedTests/ForLoopPerIterationBindingTests.cs`: `BodyMutatesLoopVar_*` flipped to run in both modes (top-level, sync function body, nested-both-mutated, closure write-through via `=` and `++`, async function, generator); async-arrow and async-generator mutate cases kept interpreted-only.

- All 46 tests in the file pass.
- Full suite green on Phase 1 (13,418 passed; the only failures were environmental File.Copy / subprocess-timeout flakes from running the whole in-process compiled suite at once — they pass in isolation).
- Bounded regression over generator/async closure + increment suites: 138 passed, 0 failed.

## Notable implementation gotchas (for reviewers)

- The captured display-class field is `object` but holds a `StrongBox`, so closure bodies `castclass StrongBox<object>` before `ldfld Value`.
- `ILEmitter` hand-rolls `EmitAssign` / pre+postfix increment (bypassing the resolver), and the state machines' base `EmitStoreVariable` likewise hand-rolls stores — each needed an explicit cell branch, or the loop's `i++` writes the dead plain local and the loop spins forever.

