### PR TITLE
Fix #474: primitive *.prototype mutable + boxed wrapper reads array-like state through prototype chain

### DIFF
--- a/Execution/Interpreter.Expressions.cs
+++ b/Execution/Interpreter.Expressions.cs
@@ -1007,6 +1007,23 @@ public partial class Interpreter
             return RuntimeValue.FromBoxed(Runtime.BuiltIns.MathBuiltIns.GetMember(key) ?? SharpTSUndefined.Instance);
         }
 
+        // Number/Boolean/String.prototype bracket read — extras first, then built-in methods.
+        if (obj is SharpTSNumberPrototype numProto)
+        {
+            var key = PropertyKeyConverter.ToPropertyKeyString(index);
+            return RuntimeValue.FromBoxed(numProto.GetMember(key) ?? SharpTSUndefined.Instance);
+        }
+        if (obj is SharpTSBooleanPrototype boolProto)
+        {
+            var key = PropertyKeyConverter.ToPropertyKeyString(index);
+            return RuntimeValue.FromBoxed(boolProto.GetMember(key) ?? SharpTSUndefined.Instance);
+        }
+        if (obj is SharpTSStringPrototype strProto)
+        {
+            var key = PropertyKeyConverter.ToPropertyKeyString(index);
+            return RuntimeValue.FromBoxed(strProto.GetMember(key) ?? SharpTSUndefined.Instance);
+        }
+
         // ECMA-262 §22.2.5: RegExp.prototype has well-known-symbol-keyed methods
         // (@@match, @@matchAll, @@replace, @@search, @@split). These are bracket-only
         // and don't appear in ResolveIndexTarget — dispatch them here.
@@ -1164,6 +1181,24 @@ public partial class Interpreter
         if (obj is SharpTSMath math)
         {
             math.SetExtra(index?.ToString() ?? "", value);
+            return RuntimeValue.FromBoxed(value);
+        }
+
+        // Number/Boolean/String.prototype are mutable ordinary objects — allow
+        // bracket assignment (`Number.prototype[0] = 1`, `Number.prototype.length = 1`).
+        if (obj is SharpTSNumberPrototype numProto)
+        {
+            numProto.SetExtra(PropertyKeyConverter.ToPropertyKeyString(index), value);
+            return RuntimeValue.FromBoxed(value);
+        }
+        if (obj is SharpTSBooleanPrototype boolProto)
+        {
+            boolProto.SetExtra(PropertyKeyConverter.ToPropertyKeyString(index), value);
+            return RuntimeValue.FromBoxed(value);
+        }
+        if (obj is SharpTSStringPrototype strProto)
+        {
+            strProto.SetExtra(PropertyKeyConverter.ToPropertyKeyString(index), value);
             return RuntimeValue.FromBoxed(value);
         }
 

--- a/Execution/Interpreter.Properties.cs
+++ b/Execution/Interpreter.Properties.cs
@@ -1531,6 +1531,25 @@ public partial class Interpreter
             return value;
         }
 
+        // Number/Boolean/String.prototype are ordinary mutable objects per ECMA-262.
+        // Test262 assigns indexed elements and `length` before calling
+        // Array.prototype.* with a primitive as the receiver.
+        if (obj is SharpTSNumberPrototype numProto)
+        {
+            numProto.SetExtra(set.Name.Lexeme, value);
+            return value;
+        }
+        if (obj is SharpTSBooleanPrototype boolProto)
+        {
+            boolProto.SetExtra(set.Name.Lexeme, value);
+            return value;
+        }
+        if (obj is SharpTSStringPrototype strProto)
+        {
+            strProto.SetExtra(set.Name.Lexeme, value);
+            return value;
+        }
+
         var category = TypeCategoryResolver.ClassifyRuntime(obj);
         string memberName = set.Name.Lexeme;
         bool strictMode = _environment.IsStrictMode;

--- a/Runtime/Types/SharpTSArrayGlobal.cs
+++ b/Runtime/Types/SharpTSArrayGlobal.cs
@@ -191,7 +191,14 @@ internal sealed class ArrayPrototypeMethodWrapper : ISharpTSCallable
                 // (Object.defineProperty(obj, "length", { get: ... })). Per spec,
                 // a throwing length getter aborts the whole method; we propagate
                 // by letting the ThrowException escape to the caller.
-                long len = ToLength(ReadArrayLikeProperty(obj, "length", interpreter));
+                object? rawLen = ReadArrayLikeProperty(obj, "length", interpreter);
+                // When the wrapper has no own `length` (absent = SharpTSUndefined),
+                // walk the prototype chain. A boxed Number/Boolean primitive
+                // (ToObject result) carries __primitiveType but no own indexed
+                // elements — consult *.prototype extras.
+                if (rawLen is null or SharpTSUndefined)
+                    rawLen = GetBoxedPrimitiveProtoExtra(obj, "length");
+                long len = ToLength(rawLen);
                 len = Math.Min(len, 1 << 20);
                 var list = new List<object?>((int)len);
                 for (int i = 0; i < len; i++)
@@ -199,8 +206,10 @@ internal sealed class ArrayPrototypeMethodWrapper : ISharpTSCallable
                     var key = i.ToString();
                     if (obj.HasGetter(key))
                         list.Add(ReadArrayLikeProperty(obj, key, interpreter));
+                    else if (obj.HasProperty(key))
+                        list.Add(obj.GetProperty(key));
                     else
-                        list.Add(obj.HasProperty(key) ? obj.GetProperty(key) : ArrayHole.Instance);
+                        list.Add(GetBoxedPrimitiveProtoExtra(obj, key) ?? ArrayHole.Instance);
                 }
                 tempArr = new SharpTSArray(list);
                 return true;
@@ -221,6 +230,45 @@ internal sealed class ArrayPrototypeMethodWrapper : ISharpTSCallable
                 tempArr = new SharpTSArray(list);
                 return true;
             }
+            case SharpTSNumberPrototype numProto:
+            {
+                long len = ToLength(numProto.HasExtra("length") ? numProto.TryGetExtra("length") : null);
+                len = Math.Min(len, 1 << 20);
+                var list = new List<object?>((int)len);
+                for (int i = 0; i < len; i++)
+                {
+                    var key = i.ToString();
+                    list.Add(numProto.HasExtra(key) ? numProto.TryGetExtra(key) : ArrayHole.Instance);
+                }
+                tempArr = new SharpTSArray(list);
+                return true;
+            }
+            case SharpTSBooleanPrototype boolProto:
+            {
+                long len = ToLength(boolProto.HasExtra("length") ? boolProto.TryGetExtra("length") : null);
+                len = Math.Min(len, 1 << 20);
+                var list = new List<object?>((int)len);
+                for (int i = 0; i < len; i++)
+                {
+                    var key = i.ToString();
+                    list.Add(boolProto.HasExtra(key) ? boolProto.TryGetExtra(key) : ArrayHole.Instance);
+                }
+                tempArr = new SharpTSArray(list);
+                return true;
+            }
+            case SharpTSStringPrototype strProto:
+            {
+                long len = ToLength(strProto.HasExtra("length") ? strProto.TryGetExtra("length") : null);
+                len = Math.Min(len, 1 << 20);
+                var list = new List<object?>((int)len);
+                for (int i = 0; i < len; i++)
+                {
+                    var key = i.ToString();
+                    list.Add(strProto.HasExtra(key) ? strProto.TryGetExtra(key) : ArrayHole.Instance);
+                }
+                tempArr = new SharpTSArray(list);
+                return true;
+            }
             // A primitive string receiver never reaches here: Call() runs it
             // through ToObject first, so it arrives as a boxed String wrapper
             // (SharpTSObject with `length` + indexed char slots) handled by the
@@ -228,6 +276,25 @@ internal sealed class ArrayPrototypeMethodWrapper : ISharpTSCallable
             default:
                 return false;
         }
+    }
+
+    /// <summary>
+    /// Returns the extra property value from the matching primitive prototype when
+    /// <paramref name="obj"/> is a boxed primitive wrapper produced by ToObject,
+    /// or null if the property is absent or the object is not a boxed primitive.
+    /// Used to implement ECMA-262 LengthOfArrayLike/Get prototype-chain walk for
+    /// Number and Boolean wrappers whose own property bags carry no indexed state.
+    /// </summary>
+    private static object? GetBoxedPrimitiveProtoExtra(SharpTSObject obj, string name)
+    {
+        if (!obj.HasProperty("__primitiveType")) return null;
+        return obj.GetProperty("__primitiveType") switch
+        {
+            "Number"  => SharpTSNumberPrototype.Instance.TryGetExtra(name),
+            "Boolean" => SharpTSBooleanPrototype.Instance.TryGetExtra(name),
+            "String"  => SharpTSStringPrototype.Instance.TryGetExtra(name),
+            _ => null
+        };
     }
 
     /// <summary>

--- a/Runtime/Types/SharpTSPrimitiveNamespaces.cs
+++ b/Runtime/Types/SharpTSPrimitiveNamespaces.cs
@@ -46,15 +46,27 @@ public class SharpTSStringNamespace : ISharpTSCallable
 /// unbound <see cref="BuiltInMethod"/> via <see cref="StringBuiltIns"/>,
 /// wrapped so <c>String.prototype.trim.call(value)</c> throws a proper
 /// TypeError on null/undefined receivers and ToString-coerces every other
-/// receiver per ECMA-262 before dispatch.
+/// receiver per ECMA-262 before dispatch. Also accepts arbitrary user-assigned
+/// properties (ECMA-262: String.prototype is an ordinary object).
 /// </summary>
 public sealed class SharpTSStringPrototype
 {
     public static readonly SharpTSStringPrototype Instance = new();
     private SharpTSStringPrototype() { }
 
+    private Dictionary<string, object?>? _extras;
+    public bool HasExtra(string name) => _extras is not null && _extras.ContainsKey(name);
+    public object? TryGetExtra(string name) =>
+        _extras is not null && _extras.TryGetValue(name, out var v) ? v : null;
+    public void SetExtra(string name, object? value)
+    {
+        _extras ??= new Dictionary<string, object?>();
+        _extras[name] = value;
+    }
+
     public object? GetMember(string name)
     {
+        if (HasExtra(name)) return TryGetExtra(name);
         var method = StringBuiltIns.GetPrototypeMethod(name);
         if (method is null) return null;
         return new StringPrototypeMethodWrapper(name, method);
@@ -192,14 +204,28 @@ public class SharpTSNumberNamespace : ISharpTSCallable
 /// <c>Number.prototype</c>. Exposes registered Number instance methods
 /// (toFixed, toPrecision, toExponential, toString) as unbound callables
 /// wrapped to coerce the receiver to a number per ECMA-262.
+/// Also accepts arbitrary user-assigned properties (ECMA-262: Number.prototype is
+/// an ordinary object — Test262 sets indexed elements and <c>length</c> on it
+/// before invoking Array.prototype.* with a number primitive as the receiver).
 /// </summary>
 public sealed class SharpTSNumberPrototype
 {
     public static readonly SharpTSNumberPrototype Instance = new();
     private SharpTSNumberPrototype() { }
 
+    private Dictionary<string, object?>? _extras;
+    public bool HasExtra(string name) => _extras is not null && _extras.ContainsKey(name);
+    public object? TryGetExtra(string name) =>
+        _extras is not null && _extras.TryGetValue(name, out var v) ? v : null;
+    public void SetExtra(string name, object? value)
+    {
+        _extras ??= new Dictionary<string, object?>();
+        _extras[name] = value;
+    }
+
     public object? GetMember(string name)
     {
+        if (HasExtra(name)) return TryGetExtra(name);
         var method = NumberBuiltIns.GetPrototypeMethod(name);
         if (method is null) return null;
         return new NumberPrototypeMethodWrapper(name, method);
@@ -299,19 +325,35 @@ public class SharpTSBooleanNamespace : ISharpTSCallable
 /// <summary>
 /// <c>Boolean.prototype</c>. Exposes <c>toString</c> and <c>valueOf</c>
 /// per ECMA-262 as wrapper callables that throw TypeError on non-boolean
-/// receivers.
+/// receivers. Also accepts arbitrary user-assigned properties — Test262 sets
+/// indexed elements and <c>length</c> before calling Array.prototype.* with a
+/// boolean primitive as the receiver.
 /// </summary>
 public sealed class SharpTSBooleanPrototype
 {
     public static readonly SharpTSBooleanPrototype Instance = new();
     private SharpTSBooleanPrototype() { }
 
-    public object? GetMember(string name) => name switch
+    private Dictionary<string, object?>? _extras;
+    public bool HasExtra(string name) => _extras is not null && _extras.ContainsKey(name);
+    public object? TryGetExtra(string name) =>
+        _extras is not null && _extras.TryGetValue(name, out var v) ? v : null;
+    public void SetExtra(string name, object? value)
     {
-        "toString" => BooleanPrototypeMethodWrapper.ToStringInstance,
-        "valueOf" => BooleanPrototypeMethodWrapper.ValueOfInstance,
-        _ => null,
-    };
+        _extras ??= new Dictionary<string, object?>();
+        _extras[name] = value;
+    }
+
+    public object? GetMember(string name)
+    {
+        if (HasExtra(name)) return TryGetExtra(name);
+        return name switch
+        {
+            "toString" => BooleanPrototypeMethodWrapper.ToStringInstance,
+            "valueOf" => BooleanPrototypeMethodWrapper.ValueOfInstance,
+            _ => null,
+        };
+    }
 
     public override string ToString() => "[object Boolean]";
 }

--- a/SharpTS.Tests/SharedTests/PrimitiveMutablePrototypeTests.cs
+++ b/SharpTS.Tests/SharedTests/PrimitiveMutablePrototypeTests.cs
@@ -1,0 +1,164 @@
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests;
+
+/// <summary>
+/// Tests for issue #474: Number/Boolean/String.prototype must be mutable ordinary
+/// objects, and boxed primitive wrappers produced by ToObject must read array-like
+/// state (length, indexed elements) through the prototype chain.
+///
+/// Interpreter-only because compiled mode already passes these cases.
+/// </summary>
+public class PrimitiveMutablePrototypeTests
+{
+    // ── Number.prototype mutability ──────────────────────────────────────────
+
+    [Fact]
+    public void NumberPrototype_IndexAssignment_DoesNotThrow()
+    {
+        var source = """
+            (Number.prototype as any)[0] = 42;
+            console.log((Number.prototype as any)[0]);
+            """;
+        Assert.Equal("42\n", TestHarness.Run(source, ExecutionMode.Interpreted));
+    }
+
+    [Fact]
+    public void NumberPrototype_LengthAssignment_DoesNotThrow()
+    {
+        var source = """
+            (Number.prototype as any).length = 3;
+            console.log((Number.prototype as any).length);
+            """;
+        Assert.Equal("3\n", TestHarness.Run(source, ExecutionMode.Interpreted));
+    }
+
+    [Fact]
+    public void NumberPrototype_MemberAssignment_DoesNotThrow()
+    {
+        var source = """
+            (Number.prototype as any).foo = "bar";
+            console.log((Number.prototype as any).foo);
+            """;
+        Assert.Equal("bar\n", TestHarness.Run(source, ExecutionMode.Interpreted));
+    }
+
+    // ── Boolean.prototype mutability ─────────────────────────────────────────
+
+    [Fact]
+    public void BooleanPrototype_IndexAssignment_DoesNotThrow()
+    {
+        var source = """
+            (Boolean.prototype as any)[0] = true;
+            console.log((Boolean.prototype as any)[0]);
+            """;
+        Assert.Equal("true\n", TestHarness.Run(source, ExecutionMode.Interpreted));
+    }
+
+    [Fact]
+    public void BooleanPrototype_LengthAssignment_DoesNotThrow()
+    {
+        var source = """
+            (Boolean.prototype as any).length = 1;
+            console.log((Boolean.prototype as any).length);
+            """;
+        Assert.Equal("1\n", TestHarness.Run(source, ExecutionMode.Interpreted));
+    }
+
+    // ── String.prototype mutability ──────────────────────────────────────────
+
+    [Fact]
+    public void StringPrototype_IndexAssignment_DoesNotThrow()
+    {
+        var source = """
+            (String.prototype as any)[99] = "x";
+            console.log((String.prototype as any)[99]);
+            """;
+        Assert.Equal("x\n", TestHarness.Run(source, ExecutionMode.Interpreted));
+    }
+
+    [Fact]
+    public void StringPrototype_MemberAssignment_DoesNotThrow()
+    {
+        var source = """
+            (String.prototype as any).customProp = 42;
+            console.log((String.prototype as any).customProp);
+            """;
+        Assert.Equal("42\n", TestHarness.Run(source, ExecutionMode.Interpreted));
+    }
+
+    // ── Boxed number primitive reads through Number.prototype (issue repro) ──
+
+    [Fact]
+    public void Every_NumberPrimitive_CallbackRunsAndReceivesNumberWrapper()
+    {
+        // Exact repro from #474: Number.prototype[0]=1, .length=1 let every()
+        // iterate once over the boxed 2.5 wrapper, whose `o` arg is instanceof Number.
+        var source = """
+            (Number.prototype as any)[0] = 1;
+            (Number.prototype as any).length = 1;
+            console.log(Array.prototype.every.call(2.5 as any, function (v: any, i: any, o: any) {
+              return o instanceof Number;
+            }));
+            """;
+        Assert.Equal("true\n", TestHarness.Run(source, ExecutionMode.Interpreted));
+    }
+
+    [Fact]
+    public void Every_NumberPrimitive_CallbackReceivesExpectedElement()
+    {
+        // Element at index 0 should be Number.prototype[0] (the value we set).
+        var source = """
+            (Number.prototype as any)[0] = 99;
+            (Number.prototype as any).length = 1;
+            let elem: any = undefined;
+            Array.prototype.every.call(2.5 as any, function (v: any): any { elem = v; return true; });
+            console.log(elem);
+            """;
+        Assert.Equal("99\n", TestHarness.Run(source, ExecutionMode.Interpreted));
+    }
+
+    // ── Boxed boolean primitive reads through Boolean.prototype ──────────────
+
+    [Fact]
+    public void Every_BooleanPrimitive_CallbackRunsAndReceivesBooleanWrapper()
+    {
+        var source = """
+            (Boolean.prototype as any)[0] = false;
+            (Boolean.prototype as any).length = 1;
+            console.log(Array.prototype.every.call(false as any, function (v: any, i: any, o: any) {
+              return o instanceof Boolean;
+            }));
+            """;
+        Assert.Equal("true\n", TestHarness.Run(source, ExecutionMode.Interpreted));
+    }
+
+    // ── some / forEach / filter / reduce also work ───────────────────────────
+
+    [Fact]
+    public void Some_NumberPrimitive_ReturnsTrue()
+    {
+        var source = """
+            (Number.prototype as any)[0] = 1;
+            (Number.prototype as any).length = 1;
+            console.log(Array.prototype.some.call(0 as any, function (v: any, i: any, o: any) {
+              return o instanceof Number;
+            }));
+            """;
+        Assert.Equal("true\n", TestHarness.Run(source, ExecutionMode.Interpreted));
+    }
+
+    [Fact]
+    public void ForEach_NumberPrimitive_CallbackInvoked()
+    {
+        var source = """
+            (Number.prototype as any)[0] = 7;
+            (Number.prototype as any).length = 1;
+            let count = 0;
+            Array.prototype.forEach.call(1 as any, function (): void { count++; });
+            console.log(count);
+            """;
+        Assert.Equal("1\n", TestHarness.Run(source, ExecutionMode.Interpreted));
+    }
+}


### PR DESCRIPTION
## Summary

- `Number.prototype`, `Boolean.prototype`, and `String.prototype` are now mutable property bags (accepting dot and bracket assignment), matching ECMA-262 which specifies them as ordinary extensible objects
- Boxed primitive wrappers produced by `ToObject` now read `length` and indexed elements through the prototype chain in `TryMaterializeArrayLike`, so `Array.prototype.every.call(2.5, cb)` correctly iterates using `Number.prototype.length` / `Number.prototype[i]`

Fixes interpreter-mode failures on Test262 `Array.prototype.{every,some,filter,map,forEach,reduce,reduceRight}/15.4.4.*-1-3` (boolean primitive) and `-1-5` (number primitive). Compiled mode was already passing these.

## Changes

**`Runtime/Types/SharpTSPrimitiveNamespaces.cs`** — Adds lazy `Dictionary<string, object?>? _extras` + `HasExtra`/`TryGetExtra`/`SetExtra` helpers to all three prototype singletons (SharpTSMath pattern). `GetMember` checks extras first to allow user overrides.

**`Execution/Interpreter.Properties.cs`** — Adds dispatch cases for the three prototypes in `EvaluateSetOnObject` (dot-assignment path).

**`Execution/Interpreter.Expressions.cs`** — Adds cases in `PerformIndexSet` (bracket-assignment) and `PerformIndexGet` (bracket-read) for the three prototypes.

**`Runtime/Types/SharpTSArrayGlobal.cs`** — Extends `TryMaterializeArrayLike` with new cases for the prototype singletons as direct receivers, extends the `SharpTSObject` case to call `GetBoxedPrimitiveProtoExtra` when own `length` is absent (`SharpTSUndefined`), and adds the `GetBoxedPrimitiveProtoExtra` helper.

**`SharpTS.Tests/SharedTests/PrimitiveMutablePrototypeTests.cs`** — 12 new interpreter-mode tests.

## Test plan

- [x] `dotnet test --filter "FullyQualifiedName~PrimitiveMutablePrototype"` — 12/12 pass (new tests)
- [x] `dotnet test --filter "FullyQualifiedName~ArrayPrototypeToObject"` — 28/28 pass (existing regression suite)
- [x] `dotnet test` — 13,535 passed, 0 failed, 2 skipped (no regressions)