### PR TITLE
Fix #817: per-iteration cells for async arrows & async generators

### DIFF
--- a/Compilation/AsyncArrowMoveNextEmitter.Variables.cs
+++ b/Compilation/AsyncArrowMoveNextEmitter.Variables.cs
@@ -112,6 +112,18 @@ public partial class AsyncArrowMoveNextEmitter
         EnsureBoxed();
         _il.Emit(OpCodes.Dup);
 
+        // Per-iteration loop-binding cell (#650/#817): write through the StrongBox.
+        if (_ctx != null && _ctx.CellBindingLocals.TryGetValue(name, out var assignCell))
+        {
+            var cellTmp = _il.DeclareLocal(_types.Object);
+            _il.Emit(OpCodes.Stloc, cellTmp);
+            _il.Emit(OpCodes.Ldloc, assignCell);
+            _il.Emit(OpCodes.Ldloc, cellTmp);
+            _il.Emit(OpCodes.Stfld, _types.StrongBoxOfObjectValueField);
+            SetStackUnknown();
+            return;
+        }
+
         // A capture promoted into the enclosing function's display class (#625) is written through
         // `outer.functionDC.field = value` (the DC is a reference type, so the store is verifiable),
         // not by mutating the boxed value-type state machine in place. Checked first.
@@ -158,6 +170,17 @@ public partial class AsyncArrowMoveNextEmitter
 
     private void StoreVariable(string name)
     {
+        // Per-iteration loop-binding cell (#650/#817): write through the StrongBox.
+        if (_ctx != null && _ctx.CellBindingLocals.TryGetValue(name, out var cell))
+        {
+            var t = _il.DeclareLocal(_types.Object);
+            _il.Emit(OpCodes.Stloc, t);
+            _il.Emit(OpCodes.Ldloc, cell);
+            _il.Emit(OpCodes.Ldloc, t);
+            _il.Emit(OpCodes.Stfld, _types.StrongBoxOfObjectValueField);
+            return;
+        }
+
         // A capture promoted into the enclosing function's display class (#625) is stored through
         // `outer.functionDC.field`. Checked first so it wins over any (now-unused) hoisted SM field.
         if (TryGetOuterFunctionDCField(name, out var dcStoreField))

--- a/Compilation/PerIterationCellAnalyzer.cs
+++ b/Compilation/PerIterationCellAnalyzer.cs
@@ -103,16 +103,10 @@ public sealed class PerIterationCellAnalyzer : AstVisitorBase
         // synchronous context there is never a direct suspension, so this is a no-op
         // for Phase 1.
         //
-        // Covered emitters: sync (ILEmitter), async functions (AsyncMoveNextEmitter),
-        // and generators (GeneratorMoveNextEmitter / base hooks). Async ARROWS and ASYNC
-        // GENERATORS are deferred: their closure-capture paths don't yet snapshot the cell
-        // reference, so creating a cell there would make a capturing closure dereference a
-        // non-cell value at runtime. Leaving those on the snapshot path keeps them correct-
-        // by-interpretation and crash-free.
-        var enclosingClosure = _closureStack.Count > 0 ? _closureStack.Peek() : null;
-        if (bindings == null || bindings.Count == 0
-            || HasDirectSuspension(stmt.Body)
-            || IsDeferredCellContext(enclosingClosure))
+        // Covered emitters: sync (ILEmitter), async functions, generators, async arrows, and
+        // async generators — all read/write the cell through their resolver / base store helper
+        // and snapshot the cell reference in their closure-capture path.
+        if (bindings == null || bindings.Count == 0 || HasDirectSuspension(stmt.Body))
         {
             Visit(stmt.Body);
             return;
@@ -297,18 +291,6 @@ public sealed class PerIterationCellAnalyzer : AstVisitorBase
     {
         Expr.ArrowFunction a => a.IsAsync || a.IsGenerator,
         Stmt.Function f => f.IsAsync || f.IsGenerator,
-        _ => false,
-    };
-
-    /// <summary>
-    /// True for state-machine contexts whose closure-capture path does not yet snapshot a
-    /// per-iteration cell by reference (#650 follow-up): async arrows and async generators.
-    /// Loops directly enclosed by one of these are left on the value-snapshot path.
-    /// </summary>
-    private static bool IsDeferredCellContext(object? closure) => closure switch
-    {
-        Expr.ArrowFunction { IsAsync: true } => true,
-        Stmt.Function { IsAsync: true, IsGenerator: true } => true,
         _ => false,
     };
 

--- a/Compilation/StatementEmitterBase.cs
+++ b/Compilation/StatementEmitterBase.cs
@@ -508,12 +508,15 @@ public abstract class StatementEmitterBase : ExpressionEmitterBase
         var active = new List<(string, LocalBuilder?)>();
         foreach (var name in cellNames)
         {
-            var local = Ctx.Locals.GetLocal(name);
-            if (local == null) continue; // defensive: binding has no local slot
-
-            IL.Emit(OpCodes.Ldloc, local);
-            if (local.LocalType.IsValueType)
-                IL.Emit(OpCodes.Box, local.LocalType);
+            // Load the binding's initial value through the resolver so this works whether the
+            // loop variable lives as an IL local (sync / async fn / generator) or a hoisted
+            // state-machine field (async arrow). The cell is not registered yet, so the
+            // resolver reads the underlying storage rather than recursing.
+            if (!Resolver.HasVariable(name)) continue; // defensive: binding has no slot
+            var st = Resolver.TryLoadVariable(name);
+            if (st == null) continue;
+            SetStackType(st.Value);
+            EnsureBoxed(); // box double/bool to object for StrongBox<object>
             IL.Emit(OpCodes.Newobj, Ctx.Types.StrongBoxOfObjectCtor);
 
             var cellLocal = IL.DeclareLocal(Ctx.Types.StrongBoxOfObject);

--- a/SharpTS.Tests/SharedTests/ForLoopPerIterationBindingTests.cs
+++ b/SharpTS.Tests/SharedTests/ForLoopPerIterationBindingTests.cs
@@ -193,10 +193,10 @@ public class ForLoopPerIterationBindingTests
         Assert.Equal("00,01,10,11\n", TestHarness.Run(source, mode));
     }
 
-    // #650 Phase 2: the mutate-and-restore fix now works in state-machine contexts too
-    // (async function / generator / async generator), as long as the loop body has no
-    // direct await/yield — the per-iteration cell is an IL local that lives for the whole
-    // loop within one MoveNext segment. Loops whose body itself suspends remain on the
+    // #650 Phase 2 / #817: the mutate-and-restore fix works in all state-machine contexts
+    // (async function / generator / async generator / async arrow), as long as the loop body
+    // has no direct await/yield — the per-iteration cell is an IL local that lives for the
+    // whole loop within one MoveNext segment. Loops whose body itself suspends remain on the
     // snapshot path (cell-as-field is a further follow-up).
     [Theory]
     [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
@@ -228,11 +228,10 @@ public class ForLoopPerIterationBindingTests
         Assert.Equal("0,1,2\n", TestHarness.Run(source, mode));
     }
 
-    // Interpreted-only: the per-iteration cell wiring for async generators is in place, but
-    // consuming a COMPILED async generator via `for await…of` is a separate, pre-existing gap
-    // (it hangs even without the mutation), so this can't be exercised compiled yet.
+    // Async generator: consumed via `.next()` (a compiled async generator consumed through
+    // `for await…of` is a separate pre-existing gap that hangs even without the mutation).
     [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void BodyMutatesLoopVar_AsyncGeneratorBody(ExecutionMode mode)
     {
         var source = """
@@ -242,18 +241,17 @@ public class ForLoopPerIterationBindingTests
                 yield g.map((f: any) => f()).join(",");
             }
             async function main() {
-                for await (const v of agen()) { console.log(v); }
+                const it: any = agen();
+                const r = await it.next();
+                console.log(r.value);
             }
             main();
             """;
         Assert.Equal("0,1,2\n", TestHarness.Run(source, mode));
     }
 
-    // Interpreted-only: async arrows are a deferred #650 context (their closure-capture path
-    // doesn't yet snapshot the per-iteration cell by reference), so the compiled path stays on
-    // the value-snapshot behavior. The interpreter is correct.
     [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void BodyMutatesLoopVar_AsyncArrowBody(ExecutionMode mode)
     {
         var source = """


### PR DESCRIPTION
## Summary

Closes #817 — completes the contexts deferred by #650/#816. Compiled **async arrows** and **async generators** now reference-capture a per-iteration `StrongBox` cell for the mutate-and-restore pattern, matching the interpreter (ECMA-262 13.7.4).

```ts
const run = async () => {
  const g: any[] = [];
  for (let i = 0; i < 3; i++) { i = i + 10; g.push(() => i); i = i - 10; }
  console.log(g.map((f: any) => f()).join(","));
};
run();
// before: crash / hang compiled · after: 0,1,2
```

> **Stacked on #816** (`wrk/per-iteration-cells-650`). Review/merge that first; this PR's base will retarget to `main` once it lands.

## What was blocking these two contexts

Same cell-as-IL-local model as the already-shipped state-machine contexts (valid because the gate still requires no direct `await`/`yield` in the loop body, so the loop runs within one `MoveNext` segment). Two concrete gaps remained:

1. **`StatementEmitterBase.EmitForLoopCellInit`** read the loop variable's initial value via `Ctx.Locals.GetLocal`, which returns null when the loop variable is a **hoisted state-machine field** (async arrows hoist it). No cell was created, but the capturer still dereferenced one → `InvalidCastException`. Now reads through the **resolver**, which handles locals *and* hoisted fields (a no-op change for the sync/async-fn/generator paths).

2. **`AsyncArrowMoveNextEmitter`**'s own `StoreVariable` / `EmitAssign` overrides bypass the base cell-aware store, so the loop's `i++` wrote the hoisted field while the condition read the cell → infinite loop. Both now write through the cell.

Async generators already routed through the cell-aware base store/resolver and the arrow-capture cell branch from #816 — they only needed the analyzer's deferral removed. `PerIterationCellAnalyzer.IsDeferredCellContext` is now gone; every emitter handles cells.

## Still deferred (unchanged)

- Loops whose body **itself** `await`/`yield`s (gated by `HasDirectSuspension`) — would need a hoisted state-machine field cell.
- Consuming a **compiled async generator via `for await…of`** hangs (pre-existing, unrelated) — so the async-generator test consumes via `.next()`.

## Tests

`BodyMutatesLoopVar_AsyncArrowBody` and `BodyMutatesLoopVar_AsyncGeneratorBody` flipped to run in both modes. All 48 in `ForLoopPerIterationBindingTests` pass; bounded regression over generator/async-arrow closure + increment suites (242 tests) green.
