### PR TITLE
Test infra: de-flake MockHttpServer (readiness probe + port re-roll)

### DIFF
--- a/SharpTS.Tests/Infrastructure/MockHttpServer.cs
+++ b/SharpTS.Tests/Infrastructure/MockHttpServer.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Net.Http;
 using System.Text;
 using System.Text.Json;
 
@@ -229,38 +230,68 @@ public class MockHttpServer : IDisposable
     }
 
     /// <summary>
-    /// Starts the server with retry logic for port binding.
+    /// Starts the server. Each attempt binds the listener, launches the accept loop, then probes
+    /// the server with a real loopback request before returning. A bind exception OR a server that
+    /// binds but never answers (a port that was reserved but is unhealthy, or an accept loop that
+    /// hasn't begun serving) re-rolls the port and retries. This makes <see cref="Start"/> not
+    /// return until the server has actually responded, eliminating the accept-timing race and
+    /// catching silent bad binds that the old bind-exception-only retry missed.
     /// </summary>
     public void Start()
     {
-        const int maxRetries = 3;
-        Exception? lastException = null;
+        const int maxAttempts = 5;
+        Exception? lastError = null;
 
-        for (int retry = 0; retry < maxRetries; retry++)
+        for (int attempt = 0; attempt < maxAttempts; attempt++)
         {
             try
             {
                 _listener.Start();
-                break; // Success
             }
-            catch (HttpListenerException ex) when (retry < maxRetries - 1)
+            catch (HttpListenerException ex)
             {
-                lastException = ex;
-                // Port may have been taken - try a new one
-                ReleasePort(Port);
-                _listener.Close();
-                _listener = new HttpListener();
-                Port = FindAndReservePort();
-                _listener.Prefixes.Add(BaseUrl);
-                Thread.Sleep(10); // Small delay before retry
+                lastError = ex;
+                RebuildOnNewPort();
+                continue;
             }
+
+            StartAcceptLoop();
+
+            if (ProbeReady(TimeSpan.FromSeconds(2)))
+            {
+                return; // Server is bound AND answering requests.
+            }
+
+            // Bound but never became ready: tear this listener down (which makes the accept loop's
+            // GetContextAsync throw HttpListenerException and exit) and re-roll the port.
+            lastError = new InvalidOperationException($"MockHttpServer on port {Port} never became ready");
+            try { _listener.Stop(); } catch { /* ignore */ }
+            RebuildOnNewPort();
         }
 
-        if (!_listener.IsListening)
-        {
-            throw lastException ?? new InvalidOperationException("Failed to start listener");
-        }
+        throw lastError ?? new InvalidOperationException("Failed to start MockHttpServer");
+    }
 
+    /// <summary>
+    /// Releases the current port and rebuilds a fresh listener on a newly reserved port.
+    /// Used between failed start attempts (bind exception or failed readiness probe).
+    /// </summary>
+    private void RebuildOnNewPort()
+    {
+        ReleasePort(Port);
+        try { _listener.Close(); } catch { /* ignore */ }
+        _listener = new HttpListener();
+        Port = FindAndReservePort();
+        _listener.Prefixes.Add(BaseUrl);
+        Thread.Sleep(10); // Small delay before retry
+    }
+
+    /// <summary>
+    /// Launches the background accept loop for the current listener. The loop exits on cancellation
+    /// (<see cref="Dispose"/>) or when the listener is stopped (a failed start attempt).
+    /// </summary>
+    private void StartAcceptLoop()
+    {
         _listenerTask = Task.Run(async () =>
         {
             while (!_cts.Token.IsCancellationRequested)
@@ -281,6 +312,35 @@ public class MockHttpServer : IDisposable
                 }
             }
         }, _cts.Token);
+    }
+
+    /// <summary>
+    /// Probes the server with a real loopback HTTP request until it answers or the budget elapses.
+    /// Any completed HTTP response (even a 404 for the sentinel path) proves the accept loop is
+    /// serving, so this never depends on a specific route being registered, and it deliberately
+    /// avoids user routes (including the /slow delay route).
+    /// </summary>
+    private bool ProbeReady(TimeSpan budget)
+    {
+        using var client = new HttpClient { Timeout = TimeSpan.FromMilliseconds(400) };
+        var probeUrl = BaseUrl + "__ready__";
+        var deadline = DateTime.UtcNow + budget;
+
+        while (DateTime.UtcNow < deadline)
+        {
+            try
+            {
+                using var resp = client.GetAsync(probeUrl).GetAwaiter().GetResult();
+                return true; // Got an HTTP status back -> the server is serving.
+            }
+            catch
+            {
+                // Connection refused / reset / timeout: not ready yet.
+            }
+            Thread.Sleep(25);
+        }
+
+        return false;
     }
 
     private async Task HandleRequestAsync(HttpListenerContext context)


### PR DESCRIPTION
## Summary

PR #818 failed CI on **macos-latest only**, in one unrelated test: `FetchTests.Fetch_JsonBody(mode: Compiled)`, which asserted on an **empty output**. The cause is the test infrastructure, not the PR — `MockHttpServer` is a real `HttpListener` that guest TS reaches over a loopback HTTP round-trip, and `Start()` could return before the server was actually able to answer.

Two structural weaknesses:
1. **No readiness check.** `Start()` returned as soon as `_listener.Start()` bound, but the accept loop runs on a separate `Task`. Tests fire requests immediately — there's a window where the socket is "listening" but nothing is accepting.
2. **Port TOCTOU + silent bad bind.** `FindAvailablePort()` binds a `TcpListener` on port 0, reads the port, then **stops it**; `HttpListener` binds that port later. The old retry only caught a bind *exception* — a port that bound but is unhealthy passed `Start()` yet refused the first connection → empty response.

## Change

`SharpTS.Tests/Infrastructure/MockHttpServer.cs` only. `Start()` is restructured so each attempt **binds → launches the accept loop → probes** the server with a real request (any HTTP status, even a 404 for a sentinel path, counts as ready) before returning. A bind exception **or** a failed probe re-rolls the port and retries (up to 5 attempts). The probe deterministically closes the accept-timing window and converts silent bad binds into caught, retried failures, fixing all ~167 fetch test cases at the source.

Host strings are unchanged (`localhost` everywhere), so the currently-green Windows/Linux paths cannot regress. The macOS `/etc/hosts` CI workaround is orthogonal and left untouched.

## Test plan

- [x] `dotnet test --filter FetchTests|FetchCookieTests|FetchRedirectTests|HttpModuleTests|EventLoop` — 172/172 pass, no added startup latency
- [x] `dotnet test` (full suite) — 13,526 passed, 0 failed
- [ ] CI green on ubuntu / windows / macos (the real cross-platform proof)