### PR TITLE
Fix #549: structural objects accepted for AsyncGenerator<T> targets

### DIFF
--- a/SharpTS.Tests/TypeCheckerTests/StructuralIterableTypingTests.cs
+++ b/SharpTS.Tests/TypeCheckerTests/StructuralIterableTypingTests.cs
@@ -268,6 +268,46 @@ public class StructuralIterableTypingTests
         Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
     }
 
+    // ---- Structural objects can satisfy an AsyncGenerator<T> target (#549, async parallel of #485 gap 2) ----
+
+    [Fact]
+    public void StructuralAsyncIterableIterator_AssignableToAsyncGenerator_Accepted()
+    {
+        var source = """
+            const it = {
+              next(): Promise<IteratorResult<number>> { return Promise.resolve({ value: 1, done: false }); },
+              [Symbol.asyncIterator]() { return this; }
+            };
+            const g: AsyncGenerator<number> = it;
+            """;
+        TestHarness.RunInterpreted(source);
+    }
+
+    [Fact]
+    public void StructuralAsyncIterator_NotIterable_NotAssignableToAsyncGenerator_Rejected()
+    {
+        // A bare async iterator (no [Symbol.asyncIterator]) is not an AsyncIterableIterator, so it cannot be
+        // an AsyncGenerator.
+        var source = """
+            const it = { next(): Promise<IteratorResult<number>> { return Promise.resolve({ value: 1, done: false }); } };
+            const g: AsyncGenerator<number> = it;
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void StructuralAsyncGenerator_ElementMismatch_Rejected()
+    {
+        var source = """
+            const it = {
+              next(): Promise<IteratorResult<number>> { return Promise.resolve({ value: 1, done: false }); },
+              [Symbol.asyncIterator]() { return this; }
+            };
+            const g: AsyncGenerator<string> = it;
+            """;
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+
     // ---- Structural for...of / spread / yield* (#485 gap 3) ----
 
     [Fact]

--- a/TypeSystem/TypeChecker.Compatibility.cs
+++ b/TypeSystem/TypeChecker.Compatibility.cs
@@ -915,9 +915,20 @@ public partial class TypeChecker
                 TryGetStructuralIterableElement(actual, out _))
                 return IsCompatible(expGen.YieldType, genElem);
         }
-        if (expected is TypeInfo.AsyncGenerator expAsyncGen && actual is TypeInfo.AsyncGenerator actAsyncGen)
+        if (expected is TypeInfo.AsyncGenerator expAsyncGen)
         {
-            return IsCompatible(expAsyncGen.YieldType, actAsyncGen.YieldType);
+            if (actual is TypeInfo.AsyncGenerator actAsyncGen)
+                return IsCompatible(expAsyncGen.YieldType, actAsyncGen.YieldType);
+            // A structural object satisfies AsyncGenerator<T1> when it is at least an AsyncIterableIterator —
+            // it exposes BOTH the async iterator protocol (next returning Promise<IteratorResult<T>>) AND the
+            // async iterable protocol ([Symbol.asyncIterator]); its element comes from the Promise-unwrapped
+            // next().value and is checked against T1 (#549, async parallel of #485 / the sync Generator arm
+            // above). Requiring both protocols keeps a bare async `{ next() {…} }` — an AsyncIterator, handled
+            // by its own arm below — from passing. Dedicated AsyncIterator records are invisible to the
+            // structural lookup, so the asymmetric relations stay rejected.
+            if (TryGetStructuralAsyncIteratorElement(actual, out var asyncGenElem) &&
+                TryGetStructuralAsyncIterableElement(actual, out _))
+                return IsCompatible(expAsyncGen.YieldType, asyncGenElem);
         }
 
         // AsyncIterator<T1>/AsyncIterableIterator<T1> (#483, async parallel of the sync Iterator arm above):


### PR DESCRIPTION
## Summary

Async parallel of #485 gap 2. The sync `Generator<T>` compatibility arm already accepts a structural `IterableIterator`-shaped object (exposing `next()` **and** `[Symbol.iterator]()`), but the `AsyncGenerator<T>` arm only matched a same-kind `TypeInfo.AsyncGenerator` record — so a hand-written async iterator was wrongly rejected, though `tsc` types the async-generator protocol structurally:

```ts
const it = {
  next(): Promise<IteratorResult<number>> { return Promise.resolve({ value: 1, done: false }); },
  [Symbol.asyncIterator]() { return this; }
};
const g: AsyncGenerator<number> = it;   // was rejected; tsc accepts structurally
```

## Change

`TypeSystem/TypeChecker.Compatibility.cs` — split the `AsyncGenerator` arm to add a structural fallback mirroring the sync `Generator` arm. A structural object satisfies `AsyncGenerator<T1>` when it is at least an **AsyncIterableIterator** — exposing **both** the async iterator protocol (`next(): Promise<IteratorResult<T>>`) **and** the async iterable protocol (`[Symbol.asyncIterator]()`). Its element comes from the Promise-unwrapped `next().value` and is checked against `T1`. Requiring both protocols keeps a bare async `{ next() {…} }` (an `AsyncIterator`, handled by its own arm) from passing.

The `TryGetStructuralAsyncIteratorElement` / `TryGetStructuralAsyncIterableElement` helpers already existed (#483/#662) — only the wiring into the compatibility arm was missing.

## Tests

`SharpTS.Tests/TypeCheckerTests/StructuralIterableTypingTests.cs` — 3 new facts mirroring the sync `Generator<T>`-target block:
- structural AsyncIterableIterator → `AsyncGenerator<number>` accepted (the issue's example)
- bare async iterator (no `[Symbol.asyncIterator]`) → rejected (not an AsyncIterableIterator)
- element mismatch (`number` vs `AsyncGenerator<string>`) → rejected

## Verification

- `dotnet build` succeeds
- `StructuralIterableTypingTests`: 55/55 pass
- Full `TypeCheckerTests` suite: 1213/1213 pass (no regressions)
- The issue's exact snippet type-checks and runs end-to-end

Closes #549.
