### PR TITLE
Fix #731: compiled String.fromCodePoint RangeError message includes the offending value

### DIFF
--- a/Compilation/RuntimeEmitter.Strings.cs
+++ b/Compilation/RuntimeEmitter.Strings.cs
@@ -1712,7 +1712,16 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Br, validLabel);
 
         il.MarkLabel(throwLabel);
-        il.Emit(OpCodes.Ldstr, "Invalid code point");
+        // Include the offending value for parity with the interpreter and
+        // tsc/V8 (e.g. "Invalid code point -1"). dLocal holds the ToNumber
+        // result; route it through ToJsString (ECMA ToString → JS number
+        // formatting) so NaN/fractional/out-of-range values print correctly.
+        // This sits only on the cold error path, so the box has no hot cost.
+        il.Emit(OpCodes.Ldstr, "Invalid code point ");
+        il.Emit(OpCodes.Ldloc, dLocal);
+        il.Emit(OpCodes.Box, _types.Double);
+        il.Emit(OpCodes.Call, runtime.ToJsString);
+        il.Emit(OpCodes.Call, _types.GetMethod(_types.String, "Concat", _types.String, _types.String));
         il.Emit(OpCodes.Newobj, runtime.TSRangeErrorCtor);
         il.Emit(OpCodes.Call, runtime.CreateException);
         il.Emit(OpCodes.Throw);

--- a/SharpTS.Tests/SharedTests/StringMethodTests.cs
+++ b/SharpTS.Tests/SharedTests/StringMethodTests.cs
@@ -651,6 +651,21 @@ public class StringMethodTests
 
     [Theory]
     [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void String_FromCodePoint_InvalidCodePoint_MessageIncludesValue(ExecutionMode mode)
+    {
+        // #731: the RangeError message must carry the offending code-point value
+        // for parity with the interpreter and tsc/V8 (compiled previously dropped it).
+        var source = """
+            try { String.fromCodePoint(-1); }
+            catch (e: any) { console.log(e.message); }
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("Invalid code point -1\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void String_FromCodePoint_BasicBMP(ExecutionMode mode)
     {
         var source = """


### PR DESCRIPTION
## Summary
Fixes #731. Compiled-mode `String.fromCodePoint` emitted a literal `"Invalid code point"` RangeError, dropping the offending code-point value and diverging from the interpreter and `tsc`/V8.

```ts
try { String.fromCodePoint(-1); } catch (e: any) { console.log(e.message); }
```
- **Before** — Interpreted: `Invalid code point -1` · Compiled: `Invalid code point`
- **After** — both modes: `Invalid code point -1`

Error identity (`e instanceof RangeError`, `e.name === "RangeError"`) was already correct in both modes after #694/#700; only the message text differed.

## Change
`Compilation/RuntimeEmitter.Strings.cs` `EmitStringFromCodePoint` throw block now concatenates `"Invalid code point "` with the offending value, formatting the already-computed `dLocal` double via `runtime.ToJsString` (ECMA ToString -> JS number formatting). The box + helper call sit only on the cold error path.

**Standalone-DLL constraint:** no new SharpTS-assembly dependency — `runtime.ToJsString` is a `$Runtime` MethodBuilder emitted into the output DLL (like the surrounding `ToNumber`/`CreateException`/`TSRangeErrorCtor` calls), and `String.Concat`/`Box` are pure BCL. Output stays standalone.

## Test
Added an `ExecutionModes.All` parity theory in `SharpTS.Tests/SharedTests/StringMethodTests.cs` asserting `String.fromCodePoint(-1)` yields `Invalid code point -1` in both modes. The existing tolerant identity test (`ErrorTests.BuiltInRangeError_CaughtAsRangeErrorInstance`) is unchanged.

## Verification
- `dotnet build` succeeded.
- `dotnet test --filter "FullyQualifiedName~String_FromCodePoint|FullyQualifiedName~BuiltInRangeError_CaughtAsRangeErrorInstance"` -> Passed: 16, Failed: 0 (covers both execution modes).