### PR TITLE
Fix #574: boxed wrappers honor own valueOf/toString in ToNumber/ToString (+ string coercion)

### DIFF
--- a/Compilation/RuntimeEmitter.BoxedPrimitives.cs
+++ b/Compilation/RuntimeEmitter.BoxedPrimitives.cs
@@ -368,15 +368,25 @@ public partial class RuntimeEmitter
     /// <c>OrdinaryToPrimitive(hint)</c> → <c>valueOf()</c>. This is the cheap
     /// shortcut the spec endorses for boxed primitives specifically.
     /// </summary>
-    private void EmitUnwrapIfBoxed(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    /// <summary>
+    /// Defines the <c>UnwrapIfBoxed</c> MethodBuilder shell (no body). Emitted
+    /// early — before <c>Add</c>/<c>Stringify</c>/<c>Equals</c>, which reference
+    /// its token — while the body (<see cref="EmitUnwrapIfBoxedBody"/>) is filled
+    /// later, once <c>GetProperty</c>/<c>InvokeMethodValue</c>/<c>HasOwnPropertyHelper</c>
+    /// (which it calls for the #574 own-conversion dispatch) have been emitted.
+    /// </summary>
+    private void DeclareUnwrapIfBoxed(TypeBuilder typeBuilder, EmittedRuntime runtime)
     {
-        var method = typeBuilder.DefineMethod(
+        runtime.UnwrapIfBoxedMethod = typeBuilder.DefineMethod(
             "UnwrapIfBoxed",
             MethodAttributes.Public | MethodAttributes.Static,
             _types.Object,
             [_types.Object]);
-        runtime.UnwrapIfBoxedMethod = method;
+    }
 
+    private void EmitUnwrapIfBoxedBody(EmittedRuntime runtime)
+    {
+        var method = (MethodBuilder)runtime.UnwrapIfBoxedMethod;
         var il = method.GetILGenerator();
         var passThruLabel = il.DefineLabel();
 
@@ -387,7 +397,8 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Isinst, runtime.TSObjectType);
         il.Emit(OpCodes.Brfalse, passThruLabel);
 
-        // Must have __primitiveType marker (else it's a plain $Object).
+        // Must have __primitiveType marker (else it's a plain $Object — passed
+        // through unchanged so == / + treat it as an ordinary object).
         var typeMarkerLocal = il.DeclareLocal(_types.Object);
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Castclass, runtime.TSObjectType);
@@ -398,7 +409,54 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Isinst, _types.String);
         il.Emit(OpCodes.Brfalse, passThruLabel);
 
-        // Read __primitiveValue and return it.
+        // #574: ECMA-262 7.1.1 ToPrimitive (default/number hint, used by == and +):
+        // OrdinaryToPrimitive tries valueOf first. An OWN valueOf override wins;
+        // otherwise the *inherited* valueOf — which for a boxed wrapper just yields
+        // its [[PrimitiveValue]] — already returns a primitive, so toString is never
+        // consulted. Hence: own valueOf (if any) → else __primitiveValue. An
+        // inherited prototype valueOf is NOT own (HasOwnPropertyHelper does not walk
+        // the prototype), so an un-overridden wrapper falls through to the slot read
+        // below, preserving prior behavior.
+        var emptyArgs = il.DeclareLocal(_types.ObjectArray);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Newarr, _types.Object);
+        il.Emit(OpCodes.Stloc, emptyArgs);
+
+        var afterValueOf = il.DefineLabel();
+        // if (!HasOwnPropertyHelper(arg, "valueOf")) goto afterValueOf
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldstr, "valueOf");
+        il.Emit(OpCodes.Call, runtime.HasOwnPropertyHelperMethod);
+        il.Emit(OpCodes.Brfalse, afterValueOf);
+        // fn = GetProperty(arg, "valueOf"); skip if missing
+        var fnLocal = il.DeclareLocal(_types.Object);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldstr, "valueOf");
+        il.Emit(OpCodes.Call, runtime.GetProperty);
+        il.Emit(OpCodes.Stloc, fnLocal);
+        il.Emit(OpCodes.Ldloc, fnLocal);
+        il.Emit(OpCodes.Brfalse, afterValueOf);
+        // res = InvokeMethodValue(arg, fn, emptyArgs) — a throwing override
+        // propagates naturally.
+        var resLocal = il.DeclareLocal(_types.Object);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldloc, fnLocal);
+        il.Emit(OpCodes.Ldloc, emptyArgs);
+        il.Emit(OpCodes.Call, runtime.InvokeMethodValue);
+        il.Emit(OpCodes.Stloc, resLocal);
+        // An object result is not a primitive → fall back to the slot.
+        il.Emit(OpCodes.Ldloc, resLocal);
+        il.Emit(OpCodes.Isinst, runtime.TSObjectType);
+        il.Emit(OpCodes.Brtrue, afterValueOf);
+        il.Emit(OpCodes.Ldloc, resLocal);
+        il.Emit(OpCodes.Isinst, _types.DictionaryStringObject);
+        il.Emit(OpCodes.Brtrue, afterValueOf);
+        // Primitive (incl. null/undefined/string/number/bool) → return it.
+        il.Emit(OpCodes.Ldloc, resLocal);
+        il.Emit(OpCodes.Ret);
+        il.MarkLabel(afterValueOf);
+
+        // Fallback: the wrapper's [[PrimitiveValue]] (≡ inherited valueOf).
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Castclass, runtime.TSObjectType);
         il.Emit(OpCodes.Ldstr, "__primitiveValue");

--- a/Compilation/RuntimeEmitter.CoreUtilities.cs
+++ b/Compilation/RuntimeEmitter.CoreUtilities.cs
@@ -1885,9 +1885,32 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Throw);
         il.MarkLabel(notSymbolLabel);
 
-        // return Stringify(value);
+        // An object-like value ($Object / Dictionary / List) coerces via
+        // ToJsString — the spec ToString → OrdinaryToPrimitive(string) protocol,
+        // which honors an own toString override and unwraps a boxed wrapper to
+        // its primitive (#574). Plain Stringify returns "[object Object]" for a
+        // wrapper, which is wrong for template literals / string concat. Primitive
+        // values stay on the cheap Stringify path.
+        var objectLikeLabel = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Isinst, runtime.TSObjectType);
+        il.Emit(OpCodes.Brtrue, objectLikeLabel);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Isinst, _types.DictionaryStringObject);
+        il.Emit(OpCodes.Brtrue, objectLikeLabel);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Isinst, _types.ListOfObject);
+        il.Emit(OpCodes.Brtrue, objectLikeLabel);
+
+        // return Stringify(value);  (primitives)
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Call, runtime.Stringify);
+        il.Emit(OpCodes.Ret);
+
+        // return ToJsString(value);  (object-like)
+        il.MarkLabel(objectLikeLabel);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Call, runtime.ToJsString);
         il.Emit(OpCodes.Ret);
     }
 

--- a/Compilation/RuntimeEmitter.CoreUtilities.cs
+++ b/Compilation/RuntimeEmitter.CoreUtilities.cs
@@ -2025,6 +2025,16 @@ public partial class RuntimeEmitter
         // natural string repr (`new Object(true).valueOf()` gives wrapper, not true).
         var primValLocal = il.DeclareLocal(_types.Object);
         var notBoxedLabel = il.DefineLabel();
+        // #574: an own (instance) toString override must win over the boxed
+        // __primitiveValue fast-path — ECMA-262 OrdinaryToPrimitive(O, "string")
+        // calls the own toString first. When the wrapper carries an own toString,
+        // defer to the OrdinaryToPrimitive section below (which invokes it). An
+        // inherited prototype toString is NOT own, so un-overridden wrappers still
+        // take the fast-path. (HasOwnPropertyHelper does not walk the prototype.)
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldstr, "toString");
+        il.Emit(OpCodes.Call, runtime.HasOwnPropertyHelperMethod);
+        il.Emit(OpCodes.Brtrue, notBoxedLabel);
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ldstr, "__primitiveValue");
         il.Emit(OpCodes.Call, runtime.GetProperty);

--- a/Compilation/RuntimeEmitter.Json.Stringify.cs
+++ b/Compilation/RuntimeEmitter.Json.Stringify.cs
@@ -415,42 +415,7 @@ public partial class RuntimeEmitter
         // primitive — without this, JSON.stringify(new Boolean(true)) returns
         // the marker dict instead of "true". Check both $Object and Dictionary
         // since either may be the receiver shape.
-        var notBoxedPrim = il.DefineLabel();
-        var checkBoxedDict = il.DefineLabel();
-        var doBoxedUnwrap = il.DefineLabel();
-        il.Emit(OpCodes.Ldloc, valueLocal);
-        il.Emit(OpCodes.Isinst, runtime.TSObjectType);
-        il.Emit(OpCodes.Brtrue, doBoxedUnwrap);
-        il.Emit(OpCodes.Ldloc, valueLocal);
-        il.Emit(OpCodes.Isinst, _types.DictionaryStringObject);
-        il.Emit(OpCodes.Brfalse, notBoxedPrim);
-        il.MarkLabel(doBoxedUnwrap);
-        // #565: only a genuine boxed wrapper (carrying a string __primitiveType tag)
-        // is unwrapped — an ordinary object that merely has a __primitiveValue field
-        // must serialize as a normal object, matching the interpreter and
-        // RuntimeEmitter.Json.StringifyFull.cs.
-        var boxedPrimType = il.DeclareLocal(_types.Object);
-        il.Emit(OpCodes.Ldloc, valueLocal);
-        il.Emit(OpCodes.Ldstr, "__primitiveType");
-        il.Emit(OpCodes.Call, runtime.GetProperty);
-        il.Emit(OpCodes.Stloc, boxedPrimType);
-        il.Emit(OpCodes.Ldloc, boxedPrimType);
-        il.Emit(OpCodes.Isinst, _types.String);
-        il.Emit(OpCodes.Brfalse, notBoxedPrim);
-        var boxedPrimVal = il.DeclareLocal(_types.Object);
-        il.Emit(OpCodes.Ldloc, valueLocal);
-        il.Emit(OpCodes.Ldstr, "__primitiveValue");
-        il.Emit(OpCodes.Call, runtime.GetProperty);
-        il.Emit(OpCodes.Stloc, boxedPrimVal);
-        il.Emit(OpCodes.Ldloc, boxedPrimVal);
-        il.Emit(OpCodes.Brfalse, notBoxedPrim);
-        il.Emit(OpCodes.Ldloc, boxedPrimVal);
-        il.Emit(OpCodes.Isinst, runtime.UndefinedType);
-        il.Emit(OpCodes.Brtrue, notBoxedPrim);
-        // Replace value with the unwrapped primitive and continue.
-        il.Emit(OpCodes.Ldloc, boxedPrimVal);
-        il.Emit(OpCodes.Stloc, valueLocal);
-        il.MarkLabel(notBoxedPrim);
+        EmitBoxedPrimitiveJsonCoerce(il, valueLocal, runtime);
 
         // Proxy materialization (#92): if value is SharpTSProxy, dispatch its
         // [[OwnPropertyKeys]] / [[Get]] traps and substitute a Dictionary so the
@@ -1062,6 +1027,82 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloc, sbLocal);
         il.Emit(OpCodes.Callvirt, _types.GetMethodNoParams(_types.Object, "ToString"));
         il.Emit(OpCodes.Ret);
+    }
+
+    /// <summary>
+    /// ECMA-262 §25.5.2.3 step 4 / §25.5.2.1 step 5: coerce a boxed
+    /// Number/String/Boolean wrapper held in <paramref name="valueLocal"/> to the
+    /// primitive JSON serializes. Number → <c>$Runtime.ToNumber</c>, String →
+    /// <c>$Runtime.ToJsString</c> (both run ECMA-262 ToPrimitive, honoring an own
+    /// <c>valueOf</c>/<c>toString</c> override — #574), Boolean → its
+    /// <c>__primitiveValue</c> (no coercion per spec). A non-wrapper value is left
+    /// unchanged. #565: only an object carrying a string <c>__primitiveType</c> tag
+    /// is treated as a wrapper. Mirrors
+    /// <c>Interpreter.TryCoerceBoxedPrimitiveForJson</c>; used by both the simple and
+    /// full (replacer/space) stringify helpers, and for a boxed Number/String
+    /// <c>space</c> argument.
+    /// </summary>
+    private void EmitBoxedPrimitiveJsonCoerce(ILGenerator il, LocalBuilder valueLocal, EmittedRuntime runtime)
+    {
+        var notBoxed = il.DefineLabel();
+        var doUnwrap = il.DefineLabel();
+        var done = il.DefineLabel();
+
+        // Only an $Object / Dictionary shape can be a wrapper.
+        il.Emit(OpCodes.Ldloc, valueLocal);
+        il.Emit(OpCodes.Isinst, runtime.TSObjectType);
+        il.Emit(OpCodes.Brtrue, doUnwrap);
+        il.Emit(OpCodes.Ldloc, valueLocal);
+        il.Emit(OpCodes.Isinst, _types.DictionaryStringObject);
+        il.Emit(OpCodes.Brfalse, notBoxed);
+        il.MarkLabel(doUnwrap);
+
+        // tag = (string)GetProperty("__primitiveType"); must be a string (#565).
+        var tag = il.DeclareLocal(_types.String);
+        il.Emit(OpCodes.Ldloc, valueLocal);
+        il.Emit(OpCodes.Ldstr, "__primitiveType");
+        il.Emit(OpCodes.Call, runtime.GetProperty);
+        il.Emit(OpCodes.Isinst, _types.String);
+        il.Emit(OpCodes.Stloc, tag);
+        il.Emit(OpCodes.Ldloc, tag);
+        il.Emit(OpCodes.Brfalse, notBoxed);
+
+        var strEq = _types.GetMethod(_types.String, "op_Equality", _types.String, _types.String);
+        var numberCase = il.DefineLabel();
+        var booleanCase = il.DefineLabel();
+
+        il.Emit(OpCodes.Ldloc, tag);
+        il.Emit(OpCodes.Ldstr, "Number");
+        il.Emit(OpCodes.Call, strEq);
+        il.Emit(OpCodes.Brtrue, numberCase);
+        il.Emit(OpCodes.Ldloc, tag);
+        il.Emit(OpCodes.Ldstr, "Boolean");
+        il.Emit(OpCodes.Call, strEq);
+        il.Emit(OpCodes.Brtrue, booleanCase);
+
+        // String tag → ToString (string-hint ToPrimitive → toString first).
+        il.Emit(OpCodes.Ldloc, valueLocal);
+        il.Emit(OpCodes.Call, runtime.ToJsString);
+        il.Emit(OpCodes.Stloc, valueLocal);
+        il.Emit(OpCodes.Br, done);
+
+        // Number tag → ToNumber (number-hint ToPrimitive → valueOf first).
+        il.MarkLabel(numberCase);
+        il.Emit(OpCodes.Ldloc, valueLocal);
+        il.Emit(OpCodes.Call, runtime.ToNumber);
+        il.Emit(OpCodes.Box, _types.Double);
+        il.Emit(OpCodes.Stloc, valueLocal);
+        il.Emit(OpCodes.Br, done);
+
+        // Boolean tag → [[BooleanData]] directly (no coercion per ECMA-262).
+        il.MarkLabel(booleanCase);
+        il.Emit(OpCodes.Ldloc, valueLocal);
+        il.Emit(OpCodes.Ldstr, "__primitiveValue");
+        il.Emit(OpCodes.Call, runtime.GetProperty);
+        il.Emit(OpCodes.Stloc, valueLocal);
+
+        il.MarkLabel(notBoxed);
+        il.MarkLabel(done);
     }
 
 }

--- a/Compilation/RuntimeEmitter.Json.StringifyFull.cs
+++ b/Compilation/RuntimeEmitter.Json.StringifyFull.cs
@@ -47,61 +47,14 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldstr, "");
         il.Emit(OpCodes.Stloc, indentStrLocal);
 
-        // Stage 6s: ECMA-262 25.5.2 unbox Number/String wrappers before space typecheck.
-        // `JSON.stringify(obj, null, new Number(5))` should treat the wrapper as a
-        // primitive number per spec step 4 (`If space has a [[NumberData]] internal slot`).
-        // Boxed wrappers in compiled mode are $Object instances with `__primitiveType`
-        // and `__primitiveValue` marker fields (see RuntimeEmitter.BoxedPrimitives.cs).
+        // ECMA-262 25.5.2.1 step 5: a boxed Number/String wrapper `space` contributes
+        // its primitive (Number → ToNumber, String → ToString) before the numeric/
+        // string indent rules below — honoring an own valueOf/toString override (#574).
+        // See EmitBoxedPrimitiveJsonCoerce (RuntimeEmitter.Json.Stringify.cs).
         var spaceLocal = il.DeclareLocal(_types.Object);
         il.Emit(OpCodes.Ldarg_2);
         il.Emit(OpCodes.Stloc, spaceLocal);
-
-        // If space is $Object with __primitiveType == "Number"|"String", unbox.
-        var notWrapperLabel = il.DefineLabel();
-        il.Emit(OpCodes.Ldloc, spaceLocal);
-        il.Emit(OpCodes.Isinst, runtime.TSObjectType);
-        il.Emit(OpCodes.Brfalse, notWrapperLabel);
-        // GetProperty(space, "__primitiveType") - check for "Number" or "String"
-        il.Emit(OpCodes.Ldloc, spaceLocal);
-        il.Emit(OpCodes.Ldstr, "__primitiveType");
-        il.Emit(OpCodes.Call, runtime.GetProperty);
-        var typeTagLocal = il.DeclareLocal(_types.Object);
-        il.Emit(OpCodes.Stloc, typeTagLocal);
-        // if typeTag is null/undefined, skip
-        il.Emit(OpCodes.Ldloc, typeTagLocal);
-        il.Emit(OpCodes.Brfalse, notWrapperLabel);
-        il.Emit(OpCodes.Ldloc, typeTagLocal);
-        il.Emit(OpCodes.Isinst, _types.String);
-        il.Emit(OpCodes.Brfalse, notWrapperLabel);
-        // If type tag is "Number" or "String", replace space with primitive value.
-        var isNumberTagLabel = il.DefineLabel();
-        var isStringTagLabel = il.DefineLabel();
-        il.Emit(OpCodes.Ldloc, typeTagLocal);
-        il.Emit(OpCodes.Castclass, _types.String);
-        il.Emit(OpCodes.Ldstr, "Number");
-        il.Emit(OpCodes.Call, _types.GetMethod(_types.String, "op_Equality", _types.String, _types.String));
-        il.Emit(OpCodes.Brtrue, isNumberTagLabel);
-        il.Emit(OpCodes.Ldloc, typeTagLocal);
-        il.Emit(OpCodes.Castclass, _types.String);
-        il.Emit(OpCodes.Ldstr, "String");
-        il.Emit(OpCodes.Call, _types.GetMethod(_types.String, "op_Equality", _types.String, _types.String));
-        il.Emit(OpCodes.Brtrue, isStringTagLabel);
-        il.Emit(OpCodes.Br, notWrapperLabel);
-
-        il.MarkLabel(isNumberTagLabel);
-        il.Emit(OpCodes.Ldloc, spaceLocal);
-        il.Emit(OpCodes.Ldstr, "__primitiveValue");
-        il.Emit(OpCodes.Call, runtime.GetProperty);
-        il.Emit(OpCodes.Stloc, spaceLocal);
-        il.Emit(OpCodes.Br, notWrapperLabel);
-
-        il.MarkLabel(isStringTagLabel);
-        il.Emit(OpCodes.Ldloc, spaceLocal);
-        il.Emit(OpCodes.Ldstr, "__primitiveValue");
-        il.Emit(OpCodes.Call, runtime.GetProperty);
-        il.Emit(OpCodes.Stloc, spaceLocal);
-
-        il.MarkLabel(notWrapperLabel);
+        EmitBoxedPrimitiveJsonCoerce(il, spaceLocal, runtime);
 
         // if (space == null) goto spaceDoneLabel
         il.Emit(OpCodes.Ldloc, spaceLocal);
@@ -297,9 +250,12 @@ public partial class RuntimeEmitter
 
     /// <summary>
     /// Emits code to convert List&lt;object?&gt; to HashSet&lt;string&gt;. Per ECMA-262
-    /// 25.5.2.1 step 4.b: strings pass through; numbers ToString-coerce; other
-    /// types are dropped. (Number/String wrapper objects per spec also coerce —
-    /// not handled here because compiled mode doesn't expose those wrappers.)
+    /// 25.5.2.1 step 4.b: strings pass through; numbers ToString-coerce; a boxed
+    /// <c>new String</c>/<c>new Number</c> wrapper (object with a [[StringData]]/
+    /// [[NumberData]] slot) ToString-coerces too — honoring an own toString/valueOf
+    /// override (#574, via <c>$Runtime.ToJsString</c>'s string-hint ToPrimitive);
+    /// other types are dropped. Mirrors
+    /// <c>Interpreter.TryCoerceReplacerArrayKey</c>.
     /// </summary>
     private void EmitConvertListToHashSet(ILGenerator il, LocalBuilder allowedKeysLocal, EmittedRuntime runtime)
     {
@@ -312,6 +268,7 @@ public partial class RuntimeEmitter
         var skipLabel = il.DefineLabel();
         var addLabel = il.DefineLabel();
         var keyLocal = il.DeclareLocal(_types.String);
+        var tagLocal = il.DeclareLocal(_types.String);
 
         // Cast replacer to List<object?>
         il.Emit(OpCodes.Ldarg_1);
@@ -350,11 +307,47 @@ public partial class RuntimeEmitter
         il.MarkLabel(notStringLabel);
 
         // if (elem is double) keyLocal = $Runtime.Stringify(elem)
+        var notDoubleLabel = il.DefineLabel();
         il.Emit(OpCodes.Ldloc, elemLocal);
         il.Emit(OpCodes.Isinst, _types.Double);
-        il.Emit(OpCodes.Brfalse, skipLabel);
+        il.Emit(OpCodes.Brfalse, notDoubleLabel);
         il.Emit(OpCodes.Ldloc, elemLocal);
         il.Emit(OpCodes.Call, runtime.Stringify);
+        il.Emit(OpCodes.Stloc, keyLocal);
+        il.Emit(OpCodes.Br, addLabel);
+
+        // else if elem is a boxed String/Number wrapper → ToString (#574).
+        // Only an $Object / Dictionary carrying a "Number"/"String" __primitiveType
+        // tag is a wrapper; any other object element is dropped per spec.
+        il.MarkLabel(notDoubleLabel);
+        var checkTagLabel = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, elemLocal);
+        il.Emit(OpCodes.Isinst, runtime.TSObjectType);
+        il.Emit(OpCodes.Brtrue, checkTagLabel);
+        il.Emit(OpCodes.Ldloc, elemLocal);
+        il.Emit(OpCodes.Isinst, _types.DictionaryStringObject);
+        il.Emit(OpCodes.Brfalse, skipLabel);
+        il.MarkLabel(checkTagLabel);
+        il.Emit(OpCodes.Ldloc, elemLocal);
+        il.Emit(OpCodes.Ldstr, "__primitiveType");
+        il.Emit(OpCodes.Call, runtime.GetProperty);
+        il.Emit(OpCodes.Isinst, _types.String);
+        il.Emit(OpCodes.Stloc, tagLocal);
+        il.Emit(OpCodes.Ldloc, tagLocal);
+        il.Emit(OpCodes.Brfalse, skipLabel);
+        var strEq = _types.GetMethod(_types.String, "op_Equality", _types.String, _types.String);
+        var wrapperKeyLabel = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, tagLocal);
+        il.Emit(OpCodes.Ldstr, "Number");
+        il.Emit(OpCodes.Call, strEq);
+        il.Emit(OpCodes.Brtrue, wrapperKeyLabel);
+        il.Emit(OpCodes.Ldloc, tagLocal);
+        il.Emit(OpCodes.Ldstr, "String");
+        il.Emit(OpCodes.Call, strEq);
+        il.Emit(OpCodes.Brfalse, skipLabel);
+        il.MarkLabel(wrapperKeyLabel);
+        il.Emit(OpCodes.Ldloc, elemLocal);
+        il.Emit(OpCodes.Call, runtime.ToJsString);
         il.Emit(OpCodes.Stloc, keyLocal);
 
         il.MarkLabel(addLabel);
@@ -463,41 +456,10 @@ public partial class RuntimeEmitter
         // ECMA-262 25.5.2.3 step 9: skip callable values (return undefined).
         EmitFunctionSkipCheck(il, valueLocal, runtime);
 
-        // Boxed-primitive unwrap (ECMA-262 25.5.2.3 step 4.a-c). Mirrors the same
-        // logic in EmitJsonStringifyHelper. See that method for the rationale.
-        var notBoxedPrimFull = il.DefineLabel();
-        var doBoxedUnwrapFull = il.DefineLabel();
-        il.Emit(OpCodes.Ldloc, valueLocal);
-        il.Emit(OpCodes.Isinst, runtime.TSObjectType);
-        il.Emit(OpCodes.Brtrue, doBoxedUnwrapFull);
-        il.Emit(OpCodes.Ldloc, valueLocal);
-        il.Emit(OpCodes.Isinst, _types.DictionaryStringObject);
-        il.Emit(OpCodes.Brfalse, notBoxedPrimFull);
-        il.MarkLabel(doBoxedUnwrapFull);
-        // #565: only a genuine boxed wrapper (carrying a string __primitiveType tag)
-        // is unwrapped — a plain object that merely has a __primitiveValue field must
-        // serialize as a normal object.
-        var boxedPrimTypeFull = il.DeclareLocal(_types.Object);
-        il.Emit(OpCodes.Ldloc, valueLocal);
-        il.Emit(OpCodes.Ldstr, "__primitiveType");
-        il.Emit(OpCodes.Call, runtime.GetProperty);
-        il.Emit(OpCodes.Stloc, boxedPrimTypeFull);
-        il.Emit(OpCodes.Ldloc, boxedPrimTypeFull);
-        il.Emit(OpCodes.Isinst, _types.String);
-        il.Emit(OpCodes.Brfalse, notBoxedPrimFull);
-        var boxedPrimValFull = il.DeclareLocal(_types.Object);
-        il.Emit(OpCodes.Ldloc, valueLocal);
-        il.Emit(OpCodes.Ldstr, "__primitiveValue");
-        il.Emit(OpCodes.Call, runtime.GetProperty);
-        il.Emit(OpCodes.Stloc, boxedPrimValFull);
-        il.Emit(OpCodes.Ldloc, boxedPrimValFull);
-        il.Emit(OpCodes.Brfalse, notBoxedPrimFull);
-        il.Emit(OpCodes.Ldloc, boxedPrimValFull);
-        il.Emit(OpCodes.Isinst, runtime.UndefinedType);
-        il.Emit(OpCodes.Brtrue, notBoxedPrimFull);
-        il.Emit(OpCodes.Ldloc, boxedPrimValFull);
-        il.Emit(OpCodes.Stloc, valueLocal);
-        il.MarkLabel(notBoxedPrimFull);
+        // Boxed-primitive unwrap (ECMA-262 25.5.2.3 step 4.a-c), honoring an own
+        // valueOf/toString override (#574). See EmitBoxedPrimitiveJsonCoerce
+        // (RuntimeEmitter.Json.Stringify.cs) for the rationale.
+        EmitBoxedPrimitiveJsonCoerce(il, valueLocal, runtime);
 
         // Proxy materialization (#92): if value is SharpTSProxy, dispatch its
         // [[OwnPropertyKeys]] / [[Get]] traps and substitute a Dictionary so the

--- a/Compilation/RuntimeEmitter.RuntimeClass.cs
+++ b/Compilation/RuntimeEmitter.RuntimeClass.cs
@@ -519,12 +519,13 @@ public partial class RuntimeEmitter
         // Emit all methods - these are now in partial class files
         // Core utilities
 
-        // UnwrapIfBoxed must be emitted before Add/Equals/Stringify so those
-        // helpers can ToPrimitive boxed-primitive wrappers before the type-
-        // based dispatch ($Object → __primitiveValue per ECMA-262 §7.2.14
-        // and §13.10.1). Depends only on TSObjectType + TSObjectGetProperty,
-        // both already populated in EmitTSObjectClass (very early).
-        EmitUnwrapIfBoxed(typeBuilder, runtime);
+        // UnwrapIfBoxed's MethodBuilder must exist before Add/Equals/Stringify
+        // so those helpers can reference its token to ToPrimitive boxed-primitive
+        // wrappers before the type-based dispatch ($Object → __primitiveValue per
+        // ECMA-262 §7.2.14 and §13.10.1). Its BODY is filled later
+        // (EmitUnwrapIfBoxedBody, after EmitGetProperty) because the #574 own-
+        // conversion dispatch calls GetProperty/InvokeMethodValue/HasOwnPropertyHelper.
+        DeclareUnwrapIfBoxed(typeBuilder, runtime);
 
         EmitStringify(typeBuilder, runtime);
         // EmitStringRaw is moved later in this method (after ToJsString/
@@ -669,6 +670,10 @@ public partial class RuntimeEmitter
         // String/Number/Boolean populate shells already defined above
         // (before cctor) so the cctor can call them eagerly.
         EmitGetProperty(typeBuilder, runtime);
+        // Fill UnwrapIfBoxed's body now that GetProperty / InvokeMethodValue /
+        // HasOwnPropertyHelper are all emitted — its #574 own-conversion dispatch
+        // (own valueOf/toString before __primitiveValue) calls them.
+        EmitUnwrapIfBoxedBody(runtime);
         // Dynamic iterator-protocol bridge — must come after GetProperty +
         // InvokeMethodValue since its non-enumerator fallback calls both.
         EmitIteratorProtocolCall(typeBuilder, runtime);

--- a/Execution/Interpreter.Operators.cs
+++ b/Execution/Interpreter.Operators.cs
@@ -452,9 +452,18 @@ public partial class Interpreter
 
         string first = hint == PrimitiveHint.String ? "toString" : "valueOf";
         string second = hint == PrimitiveHint.String ? "valueOf" : "toString";
+        // An own override of the hint-preferred conversion always wins.
         if (TryCallOwnConversion(obj, first, out var r1)) return r1;
+        // For a boxed wrapper, the *inherited* preferred conversion
+        // (Number/String/Boolean.prototype.toString|valueOf) returns the
+        // [[PrimitiveValue]] and short-circuits before the second method is
+        // tried — so an own override of the *other* method must not leak into a
+        // string→valueOf or number→toString coercion (#574). Use the primitive
+        // directly. A plain object (no internal slot) keeps the two-step
+        // OrdinaryToPrimitive fallback.
+        if (isWrapper) return primitiveValue;
         if (TryCallOwnConversion(obj, second, out var r2)) return r2;
-        return isWrapper ? primitiveValue : value;
+        return value;
     }
 
     /// <summary>
@@ -504,6 +513,17 @@ public partial class Interpreter
                 return false;
         }
     }
+
+    /// <summary>
+    /// ECMA-262 ToString abstract operation for an object argument, used by the
+    /// <c>String(value)</c> call form: ToPrimitive(value, "string") then the
+    /// string form — so an own <c>toString</c> override on a boxed wrapper is
+    /// honored and a bare wrapper yields its primitive's natural string
+    /// (#574 / boxed-wrapper string coercion). Primitives pass straight to
+    /// <see cref="Stringify"/>.
+    /// </summary>
+    internal string ToStringForStringCall(object? value)
+        => Stringify(value is SharpTSObject ? ToPrimitive(value, PrimitiveHint.String) : value);
 
     /// <summary>
     /// ECMA-262 §25.5.2.1 step 4.b: coerce a replacer-array element to a

--- a/Execution/Interpreter.Operators.cs
+++ b/Execution/Interpreter.Operators.cs
@@ -506,6 +506,36 @@ public partial class Interpreter
     }
 
     /// <summary>
+    /// ECMA-262 §25.5.2.1 step 4.b: coerce a replacer-array element to a
+    /// PropertyList key. A String stays as-is; a Number coerces via ToString;
+    /// an Object carrying a [[StringData]]/[[NumberData]] slot (a boxed
+    /// <c>new String</c>/<c>new Number</c> wrapper) coerces via ToString too —
+    /// honoring an own <c>toString</c>/<c>valueOf</c> override (#574, string hint
+    /// so <c>toString</c> is tried first). Any other element is ignored (returns
+    /// false). The interpreter and compiled JSON.stringify build their allowed-key
+    /// set through this rule.
+    /// </summary>
+    internal bool TryCoerceReplacerArrayKey(object? value, out string key)
+    {
+        key = "";
+        switch (value)
+        {
+            case string s:
+                key = s;
+                return true;
+            case double d:
+                key = Stringify(d);
+                return true;
+            case SharpTSObject obj when obj.GetProperty("__primitiveType") is "String" or "Number":
+                var sp = ToPrimitive(obj, PrimitiveHint.String);
+                key = sp as string ?? Stringify(sp);
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    /// <summary>
     /// Evaluates the delete operator.
     /// </summary>
     /// <param name="delete">The delete expression AST node.</param>

--- a/Runtime/BuiltIns/JSONBuiltIns.cs
+++ b/Runtime/BuiltIns/JSONBuiltIns.cs
@@ -234,9 +234,16 @@ public static class JSONBuiltIns
 
         if (replacerArray != null)
         {
-            allowedKeys = replacerArray
-                .OfType<string>()
-                .ToHashSet();
+            // ECMA-262 25.5.2.1 step 4.b: build PropertyList from the replacer
+            // array. A String element is used as-is; a Number or a boxed
+            // String/Number wrapper is coerced via ToString (honoring an own
+            // toString/valueOf — #574); any other element is ignored.
+            allowedKeys = new HashSet<string>();
+            foreach (var element in replacerArray)
+            {
+                if (interp.TryCoerceReplacerArrayKey(element, out var coercedKey))
+                    allowedKeys.Add(coercedKey);
+            }
         }
 
         var sb = new StringBuilder();

--- a/Runtime/Types/SharpTSPrimitiveNamespaces.cs
+++ b/Runtime/Types/SharpTSPrimitiveNamespaces.cs
@@ -23,6 +23,12 @@ public class SharpTSStringNamespace : ISharpTSCallable
         if (arg == null) return "null";
         if (arg is bool b) return b ? "true" : "false";
         if (arg is SharpTSArray arr) return arr.ToString();
+        // A boxed wrapper / plain object goes through ToString = ToPrimitive
+        // (string hint) then stringify, honoring an own toString override and
+        // unwrapping a bare wrapper to its primitive (#574). A raw Symbol is
+        // exempt from the ToString TypeError per §22.1.1.1 — fall through to its
+        // descriptive string.
+        if (arg is SharpTSObject) return interpreter.ToStringForStringCall(arg);
         return arg.ToString() ?? "";
     }
 

--- a/SharpTS.Tests/SharedTests/JSONTests.cs
+++ b/SharpTS.Tests/SharedTests/JSONTests.cs
@@ -608,4 +608,129 @@ public class JSONTests
     }
 
     #endregion
+
+    #region JSON.stringify boxed wrapper valueOf/toString dispatch (#574)
+
+    // ECMA-262 25.5.2.3 step 4 / 25.5.2.1 steps 4.b & 5: a boxed wrapper coerces via
+    // ToNumber/ToString, which go through OrdinaryToPrimitive and so honor a user-
+    // overridden own valueOf/toString — not the raw [[PrimitiveValue]] slot.
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void JSON_Stringify_BoxedNumber_Value_HonorsValueOfOverride(ExecutionMode mode)
+    {
+        // value-number-object.js: a replacer returns a new Number whose own valueOf
+        // is overridden; ToNumber must call it (toString must NOT be reached).
+        var source = """
+            const replacer = function (_key: any, value: any): any {
+              if (value === "str") {
+                const num: any = new Number(42);
+                num.toString = function () { throw new Error("should not be called"); };
+                num.valueOf = function () { return 2; };
+                return num;
+              }
+              return value;
+            };
+            console.log(JSON.stringify(["str"], replacer));
+            """;
+        Assert.Equal("[2]\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void JSON_Stringify_BoxedString_Value_HonorsToStringOverride(ExecutionMode mode)
+    {
+        // value-string-object.js: a String wrapper with an own toString override
+        // serializes via that override (string-hint ToPrimitive → toString first).
+        var source = """
+            const s: any = new String("ignored");
+            s.toString = function () { return "OVERRIDE"; };
+            console.log(JSON.stringify(s));
+            """;
+        Assert.Equal("\"OVERRIDE\"\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void JSON_Stringify_BoxedNumber_Space_HonorsValueOfOverride(ExecutionMode mode)
+    {
+        // space-number-object.js: space = new Number(1) with valueOf → 3 indents by 3.
+        var source = """
+            const num: any = new Number(1);
+            num.toString = function () { throw new Error("should not be called"); };
+            num.valueOf = function () { return 3; };
+            console.log(JSON.stringify({ k: 1 }, null, num));
+            """;
+        Assert.Equal("{\n   \"k\": 1\n}\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void JSON_Stringify_BoxedString_Space_HonorsToStringOverride(ExecutionMode mode)
+    {
+        // space-string-object.js: space = new String with toString override is the indent.
+        var source = """
+            const s: any = new String("ignored");
+            s.toString = function () { return ">>"; };
+            console.log(JSON.stringify({ k: 1 }, null, s));
+            """;
+        Assert.Equal("{\n>>\"k\": 1\n}\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void JSON_Stringify_ReplacerArray_BoxedNumber_UsesToString(ExecutionMode mode)
+    {
+        // replacer-array-number-object.js: a Number wrapper in the replacer array is a
+        // PropertyList key via ToString — its own toString (not valueOf) is used.
+        var source = """
+            const num: any = new Number(10);
+            num.toString = function () { return "toString"; };
+            num.valueOf = function () { throw new Error("should not be called"); };
+            const value: any = { 10: 1, toString: 2, valueOf: 3 };
+            console.log(JSON.stringify(value, [num]));
+            """;
+        Assert.Equal("{\"toString\":2}\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void JSON_Stringify_ReplacerArray_BoxedString_UsedAsKey(ExecutionMode mode)
+    {
+        // replacer-array-string-object.js: a String wrapper element selects that key.
+        var source = """
+            const key: any = new String("z");
+            console.log(JSON.stringify({ z: 1, y: 2 }, [key]));
+            """;
+        Assert.Equal("{\"z\":1}\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void JSON_Stringify_ReplacerArray_PlainNumber_CoercedToKey(ExecutionMode mode)
+    {
+        // ECMA-262 25.5.2.1 step 4.b: a plain Number element coerces to its ToString key.
+        var source = """
+            console.log(JSON.stringify({ a: 1, "2": 2, c: 3 }, ["a", 2, "c"]));
+            """;
+        Assert.Equal("{\"a\":1,\"2\":2,\"c\":3}\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void JSON_Stringify_BoxedNumber_AbruptValueOf_Propagates(ExecutionMode mode)
+    {
+        // value-number-object.js abrupt case: a throwing valueOf/toString must propagate.
+        var source = """
+            let threw = false;
+            const num: any = new Number(3.14);
+            num.toString = function () { throw new Error("boom"); };
+            num.valueOf = function () { throw new Error("boom"); };
+            try { JSON.stringify({ key: num }); } catch (e) { threw = true; }
+            console.log(threw);
+            """;
+        Assert.Equal("true\n", TestHarness.Run(source, mode));
+    }
+
+    #endregion
 }

--- a/SharpTS.Tests/SharedTests/PrimitiveWrapperTests.cs
+++ b/SharpTS.Tests/SharedTests/PrimitiveWrapperTests.cs
@@ -223,4 +223,88 @@ public class PrimitiveWrapperTests
             """;
         Assert.Equal("true\nfalse\n", TestHarness.Run(source, mode));
     }
+
+    // ── string coercion of wrappers: template literals & String() ────────────
+    // ECMA-262 7.1.1 (string hint): toString first. A bare wrapper yields its
+    // primitive's natural string; an own valueOf override does NOT affect a
+    // string coercion; an own toString override does. Interpreter and compiled
+    // must agree (the divergence these tests pin down).
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Number_Wrapper_TemplateLiteral_UsesPrimitive(ExecutionMode mode)
+    {
+        Assert.Equal("v:1\n", TestHarness.Run("const n: any = new Number(1); console.log(`v:${n}`);", mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Number_Wrapper_TemplateLiteral_IgnoresValueOfOverride(ExecutionMode mode)
+    {
+        // String hint resolves toString first (inherited → primitive), so a
+        // valueOf override is never consulted: `${n}` is "1", not "9".
+        var source = """
+            const n: any = new Number(1);
+            n.valueOf = function () { return 9; };
+            console.log(`v:${n}`);
+            """;
+        Assert.Equal("v:1\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Number_Wrapper_TemplateLiteral_HonorsToStringOverride(ExecutionMode mode)
+    {
+        var source = """
+            const n: any = new Number(1);
+            n.toString = function () { return "NUM"; };
+            console.log(`v:${n}`);
+            """;
+        Assert.Equal("v:NUM\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void String_Wrapper_TemplateLiteral_UsesPrimitive(ExecutionMode mode)
+    {
+        Assert.Equal("v:x\n", TestHarness.Run("const s: any = new String(\"x\"); console.log(`v:${s}`);", mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void String_CallForm_CoercesBoxedNumber(ExecutionMode mode)
+    {
+        Assert.Equal("1\n", TestHarness.Run("console.log(String(new Number(1)));", mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void String_CallForm_BoxedNumber_IgnoresValueOfOverride(ExecutionMode mode)
+    {
+        var source = """
+            const n: any = new Number(1);
+            n.valueOf = function () { return 9; };
+            console.log(String(n));
+            """;
+        Assert.Equal("1\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void String_CallForm_BoxedString_HonorsToStringOverride(ExecutionMode mode)
+    {
+        var source = """
+            const s: any = new String("x");
+            s.toString = function () { return "STR"; };
+            console.log(String(s));
+            """;
+        Assert.Equal("STR\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void String_CallForm_CoercesBoxedBoolean(ExecutionMode mode)
+    {
+        Assert.Equal("true\n", TestHarness.Run("console.log(String(new Boolean(true)));", mode));
+    }
 }

--- a/SharpTS.Tests/SharedTests/PrimitiveWrapperTests.cs
+++ b/SharpTS.Tests/SharedTests/PrimitiveWrapperTests.cs
@@ -194,4 +194,33 @@ public class PrimitiveWrapperTests
         var output = TestHarness.Run("console.log((new Boolean(true) as any).toString());", mode);
         Assert.Equal("true\n", output);
     }
+
+    // ── valueOf override honored in general ToPrimitive (#574) ───────────────
+    // ECMA-262 7.1.1: `+` and `==` ToPrimitive (default hint) an object operand,
+    // which calls an own valueOf override before reading the wrapper's slot.
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Number_ValueOfOverride_HonoredInAddition(ExecutionMode mode)
+    {
+        var source = """
+            const n: any = new Number(1);
+            n.valueOf = function () { return 9; };
+            console.log(n + 1);
+            """;
+        Assert.Equal("10\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Number_ValueOfOverride_HonoredInLooseEquality(ExecutionMode mode)
+    {
+        var source = """
+            const n: any = new Number(1);
+            n.valueOf = function () { return 9; };
+            console.log(n == 9);
+            console.log(n == 1);
+            """;
+        Assert.Equal("true\nfalse\n", TestHarness.Run(source, mode));
+    }
 }


### PR DESCRIPTION
Closes #574.

A boxed primitive wrapper (`new Number(x)` / `new String(x)` / `new Boolean(x)`) must coerce via **OrdinaryToPrimitive**, which invokes the object's own `valueOf`/`toString` before falling back to the internal `[[PrimitiveValue]]` slot. Several paths read `__primitiveValue` directly, ignoring a user override:

```ts
const n = new Number(8.5);
n.valueOf = function () { return 2; };
JSON.stringify([n]);   // Node: [2]   SharpTS (was): [8.5]
```

This PR fixes that across both execution modes (interpreter + compiled), in two commits.

## Commit 1 — `Fix #574` (ToNumber/ToString of wrappers)
- **Interpreter:** `JSON.stringify` replacer arrays dropped boxed/numeric keys (`.OfType<string>()`). Added `TryCoerceReplacerArrayKey` (ECMA-262 25.5.2.1 step 4.b): string as-is, number→ToString, boxed String/Number wrapper→ToString (honoring an own `toString`/`valueOf`).
- **Compiled:** new shared `EmitBoxedPrimitiveJsonCoerce` dispatches on `__primitiveType` (Number→`ToNumber`, String→`ToJsString` — both run OrdinaryToPrimitive — Boolean→slot); routed the JSON value, space, and replacer-array paths through it.
- **Compiled:** `ToJsString`'s boxed fast-path now defers to OrdinaryToPrimitive when the wrapper has an own `toString` (via `HasOwnPropertyHelper`, which doesn't walk the prototype).
- **Compiled:** `UnwrapIfBoxed` (backs `==` and `+`) now honors an own `valueOf` override before the slot fallback (split into Declare/EmitBody so the body can call `GetProperty`/`InvokeMethodValue`/`HasOwnPropertyHelper`).

## Commit 2 — string coercion in template literals & `String()`
Follow-up closing a pre-existing, mode-divergent gap surfaced while fixing #574 (the string-coercion sites didn't run wrappers through a spec-correct `ToString → OrdinaryToPrimitive(string)`):
- **Compiled:** `StringifyCoerce` (template interpolation + string concat) routed object-like values through `Stringify` (→ `[object Object]` for wrappers); now routes them through `ToJsString`.
- **Interpreter:** `ToPrimitive` for a wrapper now returns the primitive after an absent own hint-preferred conversion, rather than leaking an own override of the *other* method — fixing `` `${n}` `` (string hint no longer uses a `valueOf` override) and `"x"+n` (number hint no longer uses a `toString` override), and bringing the interpreter to parity with the compiled `==`/`+` path.
- **Interpreter:** `String(obj)` now coerces via the string-hint ToString instead of returning the wrapper's marker object; `String(Symbol)` keeps its descriptive-string exemption.

Resulting string-coercion matrix is spec-correct and **identical** in both modes:

| | Spec | After (both modes) |
|---|---|---|
| `` `${new Number(1)}` `` | `1` | `1` |
| `` `${n}` `` with `valueOf→9` | `1` | `1` |
| `String(new Number(1))` | `1` | `1` |
| own `toString` override | honored | honored |

## Tests
- Dual-mode (`[Theory]` + `ExecutionModes.All`) tests in `JSONTests.cs` (value/space/replacer overrides, abrupt throwing `valueOf`/`toString` propagation) and `PrimitiveWrapperTests.cs` (general `==`/`+` + template/`String()` parity).
- Full suite: **13,581 pass**. The only failures are the 2 pre-existing Test262 baseline-drift tests (untracked, stale harness — verified identical drift on the pre-PR tree, all Array.isArray/Proxy, unrelated) and a few compiled tests flaky under parallel execution that pass in isolation.

## Out of scope
None remaining for boxed-wrapper coercion — the template-literal/`String()` divergence noted during review is fixed in commit 2.