### PR TITLE
Fix #796: defaulted object destructuring over a source lacking the property

### DIFF
--- a/Parsing/AST.cs
+++ b/Parsing/AST.cs
@@ -148,7 +148,12 @@ public abstract record Expr
         string? RedeclarationTypeAnnotation = null,
         TypeNode? RedeclarationTypeAnnotationNode = null) : Expr;
     public record Call(Expr Callee, Token Paren, List<string>? TypeArgs, List<Expr> Arguments, bool Optional = false) : Expr;
-    public record Get(Expr Object, Token Name, bool Optional = false) : Expr;
+    // Defaulted: this property read was synthesized by destructuring desugaring and is covered
+    // by a default (its own, or a default on an enclosing pattern). The type checker treats a
+    // missing property as `undefined` for such reads instead of reporting TS2339, since the
+    // wrapping `=== undefined ? default : read` ternary (or an enclosing default) supplies the
+    // value. A non-defaulted read stays strict (`const { a } = {}` is still an error). See #796.
+    public record Get(Expr Object, Token Name, bool Optional = false, bool Defaulted = false) : Expr;
     public record Set(Expr Object, Token Name, Expr Value) : Expr;
     /// <summary>Private field access: obj.#field</summary>
     public record GetPrivate(Expr Object, Token Name) : Expr;

--- a/Parsing/Parser.Destructuring.cs
+++ b/Parsing/Parser.Destructuring.cs
@@ -140,7 +140,11 @@ public partial class Parser
 
     // ============== DESUGARING METHODS ==============
 
-    private Stmt DesugarArrayPattern(ArrayPattern pattern, Expr initializer)
+    // underDefault: true when this pattern is reached through an enclosing default, so its
+    // property reads must tolerate a missing property (typed as `undefined`) rather than report
+    // TS2339. Array index reads are already OOB-tolerant in the checker, so the flag only needs
+    // to ride through to nested object patterns. #796
+    private Stmt DesugarArrayPattern(ArrayPattern pattern, Expr initializer, bool underDefault = false)
     {
         List<Stmt> statements = [];
 
@@ -199,11 +203,11 @@ public partial class Parser
             }
             else if (element.Pattern is ArrayPattern nestedArray)
             {
-                statements.Add(DesugarArrayPattern(nestedArray, accessExpr));
+                statements.Add(DesugarArrayPattern(nestedArray, accessExpr, underDefault));
             }
             else if (element.Pattern is ObjectPattern nestedObj)
             {
-                statements.Add(DesugarObjectPattern(nestedObj, accessExpr));
+                statements.Add(DesugarObjectPattern(nestedObj, accessExpr, underDefault));
             }
 
             index++;
@@ -212,7 +216,9 @@ public partial class Parser
         return new Stmt.Sequence(statements);
     }
 
-    private Stmt DesugarObjectPattern(ObjectPattern pattern, Expr initializer)
+    // underDefault: see DesugarArrayPattern. A property whose own value carries a default also
+    // makes its read (and any nested pattern beneath it) tolerant. #796
+    private Stmt DesugarObjectPattern(ObjectPattern pattern, Expr initializer, bool underDefault = false)
     {
         List<Stmt> statements = [];
         List<string> usedKeys = [];
@@ -242,8 +248,12 @@ public partial class Parser
 
             usedKeys.Add(prop.Key.Lexeme);
 
+            // This read is tolerant if an enclosing pattern is defaulted, or this property itself
+            // carries a default (its read may be missing on the source — the default covers it). #796
+            bool propDefaulted = underDefault || prop.DefaultValue != null;
+
             // Access expression: _dest0.key
-            Expr accessExpr = new Expr.Get(new Expr.Variable(temp), prop.Key);
+            Expr accessExpr = new Expr.Get(new Expr.Variable(temp), prop.Key, Defaulted: propDefaulted);
 
             if (prop.Value is IdentifierPattern id)
             {
@@ -257,11 +267,11 @@ public partial class Parser
             }
             else if (prop.Value is ArrayPattern nestedArray)
             {
-                statements.Add(DesugarArrayPattern(nestedArray, accessExpr));
+                statements.Add(DesugarArrayPattern(nestedArray, accessExpr, propDefaulted));
             }
             else if (prop.Value is ObjectPattern nestedObj)
             {
-                statements.Add(DesugarObjectPattern(nestedObj, accessExpr));
+                statements.Add(DesugarObjectPattern(nestedObj, accessExpr, propDefaulted));
             }
         }
 
@@ -295,17 +305,20 @@ public partial class Parser
         return new Expr.DestructuringAssign(stmts, new Expr.Variable(rhsTemp), RawTarget: pattern, RawDefault: value);
     }
 
-    private void LowerAssignmentTarget(Expr target, Expr source, List<Stmt> stmts, int line)
+    // underDefault: true when this target sits beneath an enclosing default (`{p: {x} = {}}`), so
+    // its property reads must tolerate a missing property (typed as `undefined`) rather than report
+    // TS2339. Threaded through to MakePropertyAccess; array index reads are already OOB-tolerant. #796
+    private void LowerAssignmentTarget(Expr target, Expr source, List<Stmt> stmts, int line, bool underDefault = false)
     {
         switch (Unwrap(target))
         {
-            case Expr.ArrayLiteral arr: LowerArrayAssignmentTarget(arr, source, stmts, line); break;
-            case Expr.ObjectLiteral obj: LowerObjectAssignmentTarget(obj, source, stmts, line); break;
+            case Expr.ArrayLiteral arr: LowerArrayAssignmentTarget(arr, source, stmts, line, underDefault); break;
+            case Expr.ObjectLiteral obj: LowerObjectAssignmentTarget(obj, source, stmts, line, underDefault); break;
             default: stmts.Add(new Stmt.Expression(MakeAssignmentExpr(target, source))); break;
         }
     }
 
-    private void LowerArrayAssignmentTarget(Expr.ArrayLiteral arr, Expr source, List<Stmt> stmts, int line)
+    private void LowerArrayAssignmentTarget(Expr.ArrayLiteral arr, Expr source, List<Stmt> stmts, int line, bool underDefault = false)
     {
         // _srcN = __arrayDestructure(source) — normalize any iterable to an indexable array (#685).
         Token srcTemp = GenerateTempVar(line);
@@ -320,15 +333,15 @@ public partial class Parser
             if (element is Expr.Spread spread)
             {
                 // Rest: target = _srcN.slice(i). Must be the final element.
-                LowerAssignmentTarget(spread.Expression, MakeSliceCall(src, i, line), stmts, line);
+                LowerAssignmentTarget(spread.Expression, MakeSliceCall(src, i, line), stmts, line, underDefault);
                 break;
             }
 
-            LowerElementWithDefault(element, new Expr.GetIndex(src, new Expr.Literal((double)i)), stmts, line);
+            LowerElementWithDefault(element, new Expr.GetIndex(src, new Expr.Literal((double)i)), stmts, line, underDefault);
         }
     }
 
-    private void LowerObjectAssignmentTarget(Expr.ObjectLiteral obj, Expr source, List<Stmt> stmts, int line)
+    private void LowerObjectAssignmentTarget(Expr.ObjectLiteral obj, Expr source, List<Stmt> stmts, int line, bool underDefault = false)
     {
         // _srcN = source — object patterns read properties directly (no iterator normalization).
         Token srcTemp = GenerateTempVar(line);
@@ -341,14 +354,14 @@ public partial class Parser
             if (prop.IsSpread)
             {
                 // Rest: target = __objectRest(_srcN, [usedKeys]). Must be last.
-                LowerAssignmentTarget(prop.Value, MakeObjectRestCall(src, usedKeys, line), stmts, line);
+                LowerAssignmentTarget(prop.Value, MakeObjectRestCall(src, usedKeys, line), stmts, line, underDefault);
                 break;
             }
             if (prop.Kind is not Expr.ObjectPropertyKind.Value || prop.Key is null)
                 throw new Exception("Invalid assignment target.");  // getters/setters/methods aren't patterns
 
-            Expr access = MakePropertyAccess(src, prop.Key, usedKeys);
-            LowerElementWithDefault(prop.Value, access, stmts, line);
+            Expr access = MakePropertyAccess(src, prop.Key, usedKeys, underDefault);
+            LowerElementWithDefault(prop.Value, access, stmts, line, underDefault);
         }
     }
 
@@ -356,35 +369,36 @@ public partial class Parser
     // that the eager parser captured as an Assign (variable target) or Set/SetIndex/SetPrivate (member
     // target). The default is applied only when the read is `undefined` (ECMA-262 AssignmentElement),
     // via the shared DefaultIfUndefined helper (#784).
-    private void LowerElementWithDefault(Expr element, Expr access, List<Stmt> stmts, int line)
+    private void LowerElementWithDefault(Expr element, Expr access, List<Stmt> stmts, int line, bool underDefault = false)
     {
         switch (Unwrap(element))
         {
             case Expr.Assign def:
                 LowerAssignmentTarget(new Expr.Variable(def.Name),
-                    DefaultIfUndefined(access, def.Value, stmts, line), stmts, line);
+                    DefaultIfUndefined(access, def.Value, stmts, line), stmts, line, underDefault);
                 break;
             case Expr.Set def:
                 LowerAssignmentTarget(new Expr.Get(def.Object, def.Name),
-                    DefaultIfUndefined(access, def.Value, stmts, line), stmts, line);
+                    DefaultIfUndefined(access, def.Value, stmts, line), stmts, line, underDefault);
                 break;
             case Expr.SetIndex def:
                 LowerAssignmentTarget(new Expr.GetIndex(def.Object, def.Index),
-                    DefaultIfUndefined(access, def.Value, stmts, line), stmts, line);
+                    DefaultIfUndefined(access, def.Value, stmts, line), stmts, line, underDefault);
                 break;
             case Expr.SetPrivate def:
                 LowerAssignmentTarget(new Expr.GetPrivate(def.Object, def.Name),
-                    DefaultIfUndefined(access, def.Value, stmts, line), stmts, line);
+                    DefaultIfUndefined(access, def.Value, stmts, line), stmts, line, underDefault);
                 break;
             case Expr.DestructuringAssign { RawTarget: { } rawTarget, RawDefault: { } rawDefault }:
                 // A nested pattern WITH a default (`[[a] = []]`, `{p: {x} = {}}`): the eager parser lowered
                 // the inner `[a] = []` to a DestructuringAssign but kept its raw (target, default), so
                 // re-lower the inner pattern against the defaulted access — discarding the inner node's
-                // pre-built statements, which bound against the wrong (inner-rhs) source (#779).
-                LowerAssignmentTarget(rawTarget, DefaultIfUndefined(access, rawDefault, stmts, line), stmts, line);
+                // pre-built statements, which bound against the wrong (inner-rhs) source (#779). The inner
+                // pattern sits beneath this default, so its reads must tolerate a missing property (#796).
+                LowerAssignmentTarget(rawTarget, DefaultIfUndefined(access, rawDefault, stmts, line), stmts, line, underDefault: true);
                 break;
             default:
-                LowerAssignmentTarget(element, access, stmts, line);
+                LowerAssignmentTarget(element, access, stmts, line, underDefault);
                 break;
         }
     }
@@ -396,6 +410,9 @@ public partial class Parser
     // Shared by both the declaration desugaring and the #754 assignment-destructuring lowering. #784
     private Expr DefaultIfUndefined(Expr access, Expr defaultValue, List<Stmt> stmts, int line)
     {
+        // The read is now covered by a default, so a missing property must type as `undefined`
+        // (the ternary below supplies the default) rather than reporting TS2339. #796
+        if (access is Expr.Get g && !g.Defaulted) access = g with { Defaulted = true };
         Token valueTemp = GenerateTempVar(line);
         stmts.Add(new Stmt.Var(valueTemp, null, access));
         Expr isUndefined = new Expr.Binary(
@@ -414,13 +431,13 @@ public partial class Parser
         _ => throw new Exception("Invalid assignment target.")
     };
 
-    private Expr MakePropertyAccess(Expr src, Expr.PropertyKey key, List<Expr> usedKeys)
+    private Expr MakePropertyAccess(Expr src, Expr.PropertyKey key, List<Expr> usedKeys, bool underDefault = false)
     {
         switch (key)
         {
             case Expr.IdentifierKey ik:
                 usedKeys.Add(new Expr.Literal(ik.Name.Lexeme));
-                return new Expr.Get(src, ik.Name);
+                return new Expr.Get(src, ik.Name, Defaulted: underDefault);
             case Expr.LiteralKey lk:
                 string name = lk.Literal.Type == TokenType.STRING
                     ? (string)lk.Literal.Literal!

--- a/SharpTS.Tests/SharedTests/DestructuringTests.cs
+++ b/SharpTS.Tests/SharedTests/DestructuringTests.cs
@@ -644,4 +644,84 @@ public class DestructuringTests
     }
 
     #endregion
+
+    #region Defaulted Read Over a Source Lacking the Property (#796)
+
+    // #796: a destructuring property read carrying a DEFAULT, over a source whose static type does
+    // not declare that property, must NOT report a spurious "Property does not exist" (TS2339) — the
+    // default makes the access safe (tsc accepts these). Covers the declaration form and the shipped
+    // #780/#754 assignment forms, with empty/closed object sources.
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Defaulted_OverEmptySource_Declaration(ExecutionMode mode)
+    {
+        var source = """
+            const { a = 5 } = {};
+            console.log(String(a));
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("5\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Defaulted_OverEmptySource_AssignmentShorthandAndRename(ExecutionMode mode)
+    {
+        var source = """
+            let b; ({ b = 5 } = {});
+            let x; ({ a: x = 5 } = {});
+            console.log(String(b), String(x));
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("5 5\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Defaulted_NestedPatternDefault_OverEmptyAndPresentSource(ExecutionMode mode)
+    {
+        // The inner default `{}` lacks `x`; the read must stay tolerant. With a present source the
+        // real value flows through; with an empty source the inner pattern reads undefined.
+        var source = """
+            let r; ({ p: { x: r } = {} } = { p: { x: 1 } });
+            let s; ({ p: { x: s } = {} } = {});
+            console.log(String(r), String(s));
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("1 undefined\n", output);
+    }
+
+    // #796: a source that DECLARES the property (even optional) still narrows the defaulted binding
+    // to the property type — the tolerance must not regress the well-typed case.
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Defaulted_OverDeclaredOptionalSource_StillWorks(ExecutionMode mode)
+    {
+        var source = """
+            const o: { a?: number } = {};
+            const { a = 5 } = o;
+            console.log(String(a));
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("5\n", output);
+    }
+
+    // #796 regression guard: a NON-defaulted read over a closed source must remain a TS2339 error,
+    // matching tsc (`const { a } = {}` is an error). The leniency applies only when a default exists.
+    [Fact]
+    public void NonDefaulted_OverEmptySource_IsTypeError()
+    {
+        var source = """
+            const { a } = {};
+            console.log(a);
+            """;
+
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+
+    #endregion
 }

--- a/TypeSystem/TypeChecker.Properties.cs
+++ b/TypeSystem/TypeChecker.Properties.cs
@@ -128,6 +128,29 @@ public partial class TypeChecker
         }
         objType = ResolveMappedTypeForAccess(objType);
 
+        // A property read synthesized by destructuring desugaring that is covered by a default
+        // (its own, or a default on an enclosing pattern) tolerates a missing property: type it as
+        // `undefined` instead of reporting TS2339, since the wrapping ternary / enclosing default
+        // supplies the value. A non-defaulted read stays strict (`const { a } = {}` still errors). #796
+        if (get.Defaulted)
+        {
+            try { return ResolveMemberType(get, objType); }
+            catch (TypeCheckException ex) when (ex.Diagnostic.TsCode == "TS2339")
+            {
+                return new TypeInfo.Undefined();
+            }
+        }
+
+        return ResolveMemberType(get, objType);
+    }
+
+    /// <summary>
+    /// Resolves the type of a property read on an already-evaluated receiver type, dispatching by
+    /// type category. Throws TS2339 when the member is absent. Shared by <see cref="CheckGet"/>'s
+    /// strict and (#796) defaulted-destructuring-tolerant paths.
+    /// </summary>
+    private TypeInfo ResolveMemberType(Expr.Get get, TypeInfo objType)
+    {
         var category = TypeCategoryResolver.Classify(objType);
         string memberName = get.Name.Lexeme;
 


### PR DESCRIPTION
## Summary

Object destructuring of a property that carries a **default**, over a source whose static type does not declare that property, reported a spurious `Property 'x' does not exist on type '...'` (TS2339) — even though the default makes the access safe. tsc accepts all of these:

```ts
const { a = 5 } = {};                       // decl, direct default
let b; ({ b = 5 } = {});                     // assignment, direct default (#780)
let x; ({ a: x = 5 } = {});                  // assignment, rename + default (#754)
({ p: { x } = {} } = { p: { x: 1 } });       // assignment, nested default (#779)
```

A source that *declares* the property (even optional) already worked: `const o: { a?: number } = {}; const { a = 5 } = o;` → `a === 5`.

## Root causes (two, both confirmed)

1. The desugared property read `_src.a` (`Expr.Get`) is type-checked strictly against the source's declared type; a closed record (`{}`) has no `a`, so `CheckGet` throws TS2339 *before* the wrapping `=== undefined ? default : read` ternary can absorb the `undefined`. Arrays were already OOB-tolerant (`__arrayDestructure` → `Array<T>`, index read returns the element type unconditionally); only the **object** property path errored.
2. For the nested example, `DefaultIfUndefined` builds the ternary `_t === undefined ? {} : _t`; `CheckTernary` returns `thenType` whenever either branch is compatible with the other, and `{x:number}` is assignable to `{}`, so it collapses to the empty `{}` — the inner `.x` read then throws.

## Fix

Type-checker-only, so both interpreter and compiled modes are fixed; **zero new runtime/emitter surface** (the runtime already returns `undefined` for a missing prop and the existing ternary applies the default).

- **`Parsing/AST.cs`** — add an optional `Defaulted` flag to `Expr.Get` (trailing record field, default `false` → no `Accept`/exhaustiveness churn; backends ignore it).
- **`Parsing/Parser.Destructuring.cs`** — `DefaultIfUndefined` flags the direct read (covers decl + assignment direct/rename at one chokepoint); an `underDefault` flag threads through nested-pattern desugaring (declaration + assignment paths) so reads beneath a default — the `{p:{x}={}}` form — are tolerant too. Literal/computed keys desugar to `Expr.GetIndex`, already tolerant.
- **`TypeSystem/TypeChecker.Properties.cs`** — extract the post-receiver dispatch into `ResolveMemberType`; in `CheckGet`, a `Defaulted` read treats a missing-property TS2339 as `undefined` instead of erroring. The receiver is still evaluated outside the guard so genuine receiver errors surface. A **non-defaulted** read stays strict (`const { a } = {}` is still an error), matching tsc.

**Deliberate trade-off:** a nested non-defaulted read under a default (`({ p: { x } = {} } = { p: {} })`, where the rhs genuinely lacks `x`) becomes permissive rather than erroring — acceptable since SharpTS has no binding-pattern contextual typing (the #783/#796 family); under-reporting beats spuriously rejecting valid code.

## Out of scope (pre-existing parser gap, not #796)

The declaration *binding* form of a nested-pattern-with-default — `const { q: { y } = {} } = {}` / `const [{ z = 3 } = {}] = []` — fails to **parse**. The issue's nested example is the assignment form, which works.

## Tests

Adds a `#796` region to `SharpTS.Tests/SharedTests/DestructuringTests.cs` (both interpreter and compiled): the four examples over empty/closed sources, the declared-optional-source narrowing case, and a regression guard asserting `const { a } = {}` (no default) still throws.

Full suite green: **13,559 passed, 0 failed**.

Closes #796.