### PR TITLE
Fix #771: guard async-generator re-entrant next() after a pending await

### DIFF
--- a/Execution/Interpreter.Async.cs
+++ b/Execution/Interpreter.Async.cs
@@ -39,6 +39,12 @@ public partial class Interpreter
         // must resume with its own generator (and scope) restored, even if interleaved event-loop work
         // ran another generator in the meantime (#752).
         var savedGen = CurrentAsyncGenerator;
+        // While suspended at this await the body is off the call stack, so a request issued during the
+        // gap is a legit concurrent next(), not re-entrancy. Clear the active generator's running guard
+        // and re-set it on resume (success or rejection — a body unwinding a rejected await is still
+        // synchronously on the stack), so a re-entrant next() after a genuinely-pending await is still
+        // caught (#771). No-op when no async generator is active.
+        savedGen?.MarkBodySuspended();
         try
         {
             return await task;
@@ -47,6 +53,7 @@ public partial class Interpreter
         {
             _environment = saved;
             CurrentAsyncGenerator = savedGen;
+            savedGen?.MarkBodyResumed();
         }
     }
 

--- a/Runtime/Types/SharpTSAsyncGenerator.cs
+++ b/Runtime/Types/SharpTSAsyncGenerator.cs
@@ -77,10 +77,30 @@ public class SharpTSAsyncGenerator : ITypeCategorized
     // Set while the body is SuspendedYield: completed by the resuming request to wake the body.
     private TaskCompletionSource<Request>? _pendingResume;
 
-    // True only while the body runs its initial synchronous segment (between the first next() and the
-    // first suspension). A next/return/throw observing this is the body advancing itself synchronously
-    // (re-entrancy), which a real queue can't serve here without deadlocking the body it blocks (#542).
+    // True whenever the body is synchronously on the call stack — between a resume (start, await
+    // completion, or yield resume) and its next suspension/completion. A next/return/throw observing
+    // this is the body advancing itself synchronously (re-entrancy), which a real queue can't serve
+    // here without deadlocking the body it blocks (#542, #771). Cleared at every suspend point (await
+    // via AwaitPreservingEnvironment, yield via SuspendAtYieldAsync) and on completion (CompleteBody),
+    // re-set on each resume. Safe to toggle unconditionally: the interpreter is single-threaded, so an
+    // external request can only fire while the body is suspended (flag false) — the spurious-true
+    // windows are uninterruptible synchronous segments.
     private bool _running;
+
+    /// <summary>
+    /// Marks the body as suspended (off the call stack) at an await. Called by
+    /// <see cref="Interpreter.AwaitPreservingEnvironment"/> — the chokepoint every guest await routes
+    /// through — just before it suspends, so a concurrent request issued during a genuine async gap is
+    /// queued rather than misread as re-entrancy (#771).
+    /// </summary>
+    internal void MarkBodySuspended() => _running = false;
+
+    /// <summary>
+    /// Marks the body as resumed (back synchronously on the call stack) after an await. Paired with
+    /// <see cref="MarkBodySuspended"/>; runs on both the resolved and rejected resume paths (a body
+    /// unwinding a rejected await is still synchronously on the stack).
+    /// </summary>
+    internal void MarkBodyResumed() => _running = true;
 
     public SharpTSAsyncGenerator(List<Stmt> body, RuntimeEnvironment environment, Interpreter interpreter)
     {
@@ -258,7 +278,12 @@ public class SharpTSAsyncGenerator : ITypeCategorized
         _state = State.SuspendedYield;
         req.Completion.SetResult(new SharpTSIteratorResult(value, done: false));
 
+        // The body is now off the stack until a request resumes it, so a request arriving in this
+        // window is a normal resume (or a legit concurrent next), not re-entrancy — clear the guard
+        // and re-set it once the body is back on the stack (#771).
+        _running = false;
         Request next = await TakeNextRequestAsync();
+        _running = true;
 
         _interpreter.SetEnvironment(genEnv);
         _interpreter.CurrentAsyncGenerator = this;
@@ -362,6 +387,10 @@ public class SharpTSAsyncGenerator : ITypeCategorized
     private void CompleteBody(object? completionValue, Exception? pendingException)
     {
         _state = State.Completed;
+        // The body's final segment ran synchronously after an await/yield resume that set _running;
+        // clear it so a post-completion next()/return()/throw() settles normally rather than being
+        // rejected as re-entrancy (#771).
+        _running = false;
         Request? req = _currentRequest;
         _currentRequest = null;
         if (req != null)

--- a/SharpTS.Tests/SharedTests/AsyncGeneratorTests.cs
+++ b/SharpTS.Tests/SharedTests/AsyncGeneratorTests.cs
@@ -1209,6 +1209,36 @@ public class AsyncGeneratorTests
         Assert.Equal("caught: TypeError Async generator is already running\n", TestHarness.Run(source, mode));
     }
 
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void AsyncGenerator_ReentrantNext_AfterPendingAwait_Rejects(ExecutionMode mode)
+    {
+        // Re-entrancy issued *after* a genuinely-pending (setTimeout-backed) await — once the body has
+        // suspended and resumed, the guard used to be back to false and the self-advancing next() was
+        // silently enqueued behind the body that awaits it, stalling the chain with no output. The
+        // running guard now tracks "body synchronously on the stack" across await/yield resume spans
+        // (toggled at the AwaitPreservingEnvironment chokepoint), so this rejects with the same
+        // catchable TypeError as the synchronous-prefix form above (#771). Interpreter-only: compiled
+        // mode still stalls this pathological self-referential pattern (as does Node), recorded as a
+        // follow-up tail of #542.
+        var source = """
+            const h: any = {};
+            function later(): Promise<number> { return new Promise(res => setTimeout(() => res(0), 5)); }
+            async function* g() { await later(); await h.it.next(); yield 1; }
+            h.it = g();
+            async function main() {
+              try {
+                for await (const v of h.it) { console.log("v" + v); }
+              } catch (e: any) {
+                console.log("caught: " + e.name + " " + e.message);
+              }
+            }
+            main();
+            """;
+
+        Assert.Equal("caught: TypeError Async generator is already running\n", TestHarness.Run(source, mode));
+    }
+
     #endregion
 
     #region Genuinely-async awaits and request queuing (#631 / #542)


### PR DESCRIPTION
## Summary

Fixes #771. The interpreter's lazy async-generator coroutine guarded re-entrancy (the body advancing itself via `next()`/`return()`/`throw()`) only across the body's **initial synchronous segment**. A re-entrant `next()` issued **after the body suspended at a genuinely-pending await** (state back to `Executing`, guard back to false) was not detected — it was enqueued behind the very body awaiting it, so the request chain silently stalled (no output, process still exits 0).

This extends the guard so re-entrancy after a real async gap rejects with the same catchable `TypeError: Async generator is already running` as the already-handled synchronous-prefix form.

## Approach

Redefine `_running` from "true only during the initial synchronous segment" to "true whenever the body frame is synchronously on the call stack" (between a resume and its next suspension/completion), and maintain that invariant at every suspend/resume chokepoint:

- **`AwaitPreservingEnvironment`** (`Execution/Interpreter.Async.cs`) — the single chokepoint every guest await routes through — clears the active generator's guard before suspending and re-sets it on resume (in `finally`, so a rejected-await unwind is covered too).
- **`SuspendAtYieldAsync`** (`Runtime/Types/SharpTSAsyncGenerator.cs`) — clears/re-sets the guard around the yield suspension so a clean resume at a yield isn't misread as re-entrancy.
- **`CompleteBody`** — forces the guard false on completion so a post-completion `next()`/`return()`/`throw()` settles normally (the one new failure mode the change could otherwise introduce).

Toggling is safe to do unconditionally: the interpreter is single-threaded, so an external request can only fire while the body is suspended (guard already false); the spurious-true windows are uninterruptible synchronous segments.

## Scope

Interpreter-only. Compiled mode still stalls this pathological self-referential pattern (as does Node) — recorded as a follow-up tail of #542. The new test is `InterpretedOnly`.

## Testing

- New test `AsyncGenerator_ReentrantNext_AfterPendingAwait_Rejects`.
- Repro now prints `caught: TypeError Async generator is already running` (previously no output).
- `dotnet build` clean; `~AsyncGeneratorTests` 129/129 pass; broader `~Async` slice 1181/1181 pass (no regression from the shared `AwaitPreservingEnvironment` change).