### PR TITLE
Fix #793: propagate class-expression inferred method return types to call sites

### DIFF
--- a/SharpTS.Tests/SharedTests/ClassExpressionTests.cs
+++ b/SharpTS.Tests/SharedTests/ClassExpressionTests.cs
@@ -511,4 +511,63 @@ public class ClassExpressionTests
     }
 
     #endregion
+
+    #region Inferred Method Return Propagation (#793)
+
+    // A class EXPRESSION's un-annotated method return must reach call sites, exactly as it does
+    // for a class declaration (#658/#661/#687). Before #793 the inferred generator return came
+    // back as Generator<Void>, so `for (const n of new C(...).gen()) sum += n` failed type-check
+    // with "Compound assignment requires numeric operands".
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ClassExpression_InferredGeneratorMethodReturn_ReachesCallSite(ExecutionMode mode)
+    {
+        var source = """
+            const Range = class {
+                constructor(public start: number, public end: number) {}
+                *gen() { for (let i = this.start; i < this.end; i++) yield i; }
+            };
+            let sum = 0;
+            for (const n of new Range(1, 5).gen()) sum += n;
+            console.log(sum);
+            """;
+
+        Assert.Equal("10\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ClassExpression_InferredPlainMethodReturn_ReachesCallSite(ExecutionMode mode)
+    {
+        var source = """
+            const Calc = class {
+                add(a: number, b: number) { return a + b; }
+            };
+            const x: number = new Calc().add(2, 3);
+            console.log(x * 2);
+            """;
+
+        Assert.Equal("10\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ClassExpression_InferredAsyncMethodReturn_ReachesCallSite(ExecutionMode mode)
+    {
+        var source = """
+            const Box = class {
+                async getAsync(n: number) { return n + 1; }
+            };
+            async function main() {
+                const v: number = await new Box().getAsync(4);
+                console.log(v * 2);
+            }
+            main();
+            """;
+
+        Assert.Equal("10\n", TestHarness.Run(source, mode));
+    }
+
+    #endregion
 }

--- a/TypeSystem/TypeChecker.Expressions.cs
+++ b/TypeSystem/TypeChecker.Expressions.cs
@@ -1893,10 +1893,13 @@ public partial class TypeChecker
 
                 TypeInfo returnType = method.ReturnType != null
                     ? ToTypeInfo(method.ReturnType)
-                    : new TypeInfo.Void();
+                    : new TypeInfo.Inferred();
 
-                // Wrap return type for generator/async generator methods
-                if (method.IsGenerator)
+                // Wrap return type for generator/async generator methods (skip when inferring).
+                // An un-annotated generator method stays a plain <inferred> placeholder so the
+                // inferred-return resolution pass below turns it into Generator<yieldType> (#793,
+                // mirroring CheckClassDeclaration).
+                if (method.ReturnType != null && method.IsGenerator)
                 {
                     if (method.IsAsync && returnType is not TypeInfo.AsyncGenerator)
                     {
@@ -2101,6 +2104,12 @@ public partial class TypeChecker
         _environment = classEnv;
         _currentClass = classTypeForBody is TypeInfo.Class c ? c : mutableClass.Freeze();
 
+        // Set when a method's inferred (un-annotated) return type is resolved during the body
+        // pass below. The class was frozen with <inferred> placeholders before this pass, so when
+        // this is true the frozen class is rebuilt and re-published afterwards (#793; mirrors the
+        // class-declaration path #658/#661).
+        bool anyInferredMethodReturnResolved = false;
+
         try
         {
             foreach (var method in classExpr.Methods.Where(m => m.Body != null))
@@ -2150,6 +2159,8 @@ public partial class TypeChecker
 
                 TypeEnvironment previousEnvFunc = _environment;
                 TypeInfo? previousReturnFunc = _currentFunctionReturnType;
+                var previousInferredFunc = _inferredReturnTypes;
+                var previousInferredYieldFunc = _inferredYieldTypes;
                 bool previousInStatic = _inStaticMethod;
                 bool previousInAsyncFunc = _inAsyncFunction;
                 bool previousInGeneratorFunc = _inGeneratorFunction;
@@ -2157,8 +2168,19 @@ public partial class TypeChecker
                 int previousSwitchDepthFunc = _switchDepth;
                 var previousActiveLabelsFunc = new Dictionary<string, bool>(_activeLabels);
 
+                bool inferringMethodReturn = methodType.ReturnType is TypeInfo.Inferred;
                 _environment = methodEnv;
-                _currentFunctionReturnType = methodType.ReturnType;
+                if (inferringMethodReturn)
+                {
+                    _inferredReturnTypes = new List<TypeInfo>();
+                    _currentFunctionReturnType = new TypeInfo.Inferred();
+                }
+                else
+                {
+                    _currentFunctionReturnType = methodType.ReturnType;
+                }
+                // Collect yield operand types only while inferring a generator method's type (#548).
+                _inferredYieldTypes = inferringMethodReturn && method.IsGenerator ? new List<TypeInfo>() : null;
                 _inStaticMethod = method.IsStatic;
                 _inAsyncFunction = method.IsAsync;
                 _inGeneratorFunction = method.IsGenerator;
@@ -2177,11 +2199,63 @@ public partial class TypeChecker
                         // that may hold the undefined sentinel.
                         MarkUndefinedReachableNumericSlots(method.Body, method.Parameters);
                     }
+
+                    // Resolve inferred method return type (#793; mirrors CheckClassDeclaration).
+                    if (inferringMethodReturn && method.Body != null)
+                    {
+                        var collected = _inferredReturnTypes!;
+                        _inferredReturnTypes = null;
+
+                        TypeInfo inferredReturn;
+                        if (collected.Count == 0)
+                        {
+                            inferredReturn = new TypeInfo.Void();
+                        }
+                        else
+                        {
+                            var distinct = collected.Distinct(TypeInfoEqualityComparer.Instance).ToList();
+                            inferredReturn = CollapseOrCreateUnion(distinct);
+                        }
+
+                        // A generator method's type argument is its YIELD type (#548), not the
+                        // `return`-derived inferredReturn; a non-generator async method wraps in Promise.
+                        // The resolved type is re-published below (anyInferredMethodReturnResolved), so
+                        // `new C().m()` reads the real Generator<…>/Promise<…> at the call site rather
+                        // than the `<inferred>` placeholder.
+                        if (method.IsGenerator)
+                            inferredReturn = BuildInferredGeneratorType(_inferredYieldTypes!, method.IsAsync);
+                        else if (method.IsAsync && inferredReturn is not TypeInfo.Void)
+                            inferredReturn = new TypeInfo.Promise(inferredReturn);
+
+                        // Update the method type in the class. Computed symbol-keyed methods are keyed
+                        // by their @@name (e.g. @@iterator); an arbitrary computed key (no well-known
+                        // @@name) carries no static member to update.
+                        var updatedMethodType = new TypeInfo.Function(methodType.ParamTypes, inferredReturn, methodType.RequiredParams, methodType.HasRestParam, methodType.ThisType, methodType.ParamNames);
+                        string? mName = method.ComputedKey != null
+                            ? TryGetWellKnownSymbolMemberName(method.ComputedKey)
+                            : method.Name.Lexeme;
+                        if (mName != null)
+                        {
+                            if (method.IsPrivate)
+                            {
+                                if (method.IsStatic) mutableClass.StaticPrivateMethods[mName] = updatedMethodType;
+                                else mutableClass.PrivateMethods[mName] = updatedMethodType;
+                            }
+                            else
+                            {
+                                if (method.IsStatic) mutableClass.StaticMethods[mName] = updatedMethodType;
+                                else mutableClass.Methods[mName] = updatedMethodType;
+                            }
+                            anyInferredMethodReturnResolved = true;
+                        }
+                    }
                 }
                 finally
                 {
                     _environment = previousEnvFunc;
                     _currentFunctionReturnType = previousReturnFunc;
+                    _inferredReturnTypes = previousInferredFunc;
+                    _inferredYieldTypes = previousInferredYieldFunc;
                     _inStaticMethod = previousInStatic;
                     _inAsyncFunction = previousInAsyncFunc;
                     _inGeneratorFunction = previousInGeneratorFunc;
@@ -2268,6 +2342,36 @@ public partial class TypeChecker
         {
             _environment = prevEnv;
             _currentClass = prevClass;
+        }
+
+        // Publish method return types inferred during the body pass. The class was frozen with
+        // <inferred> placeholders before the body could be checked, so the frozen Class the binding
+        // (`const C = class …`) and the TypeMap (read by the compiler) hold still carry the
+        // placeholder for every un-annotated method. Rebuild the frozen form from the now-resolved
+        // mutable state, re-register the TypeMap, and recompute the result type returned below.
+        // Unlike a class declaration, a class expression publishes nothing to the outer environment —
+        // its resolved type flows out solely through the return value and the TypeMap (#793).
+        if (anyInferredMethodReturnResolved)
+        {
+            mutableClass.ResetFrozenCache();
+            if (classTypeParams != null && classTypeParams.Count > 0)
+            {
+                var refrozenCore = mutableClass.Freeze();
+                _typeMap.SetClassType(className, refrozenCore);
+                _typeMap.SetClassExprType(classExpr, refrozenCore);
+                classExprResultType = mutableClass.FreezeGeneric(classTypeParams);
+            }
+            else
+            {
+                var refrozen = mutableClass.Freeze();
+                _typeMap.SetClassType(className, refrozen);
+                _typeMap.SetClassExprType(classExpr, refrozen);
+                classExprResultType = refrozen;
+            }
+            // Structural compatibility results cache on CacheKey() (carries the stable DeclarationId),
+            // so any comparison made against the placeholder during the body pass must not be reused.
+            _compatibilityCache = null;
+            _identityCompatibilityCache = null;
         }
 
         // Return the class type (not an instance). For a generic class expression this is the


### PR DESCRIPTION
@## Summary

An **inferred** (un-annotated) method return type on a class **expression** (`const C = class { *gen() {…} }`) was not propagated to call sites, so `new C().gen()` was typed too loosely (`Generator<Void>`). The same code on a class **declaration** type-checks fine — declarations got inferred-method-return propagation via #658/#661/#687, but class expressions were never included.

Closes #793.

### Repro (failed before, passes now — both back ends)

```ts
const Range = class {
  constructor(public start: number, public end: number) {}
  *gen() { for (let i = this.start; i < this.end; i++) yield i; }
};
let sum = 0;
for (const n of new Range(1, 5).gen()) sum += n;   // was: Type Error: Compound assignment requires numeric operands
console.log(sum);                                   // prints 10
```

## Root cause

`CheckClassExpression` (`TypeSystem/TypeChecker.Expressions.cs`) omitted three things `CheckClassDeclaration` does:

1. **Signature build** — defaulted un-annotated returns to `TypeInfo.Void` (not `Inferred`) and generator-wrapped unconditionally → an inferred `*gen()` froze as `Generator<Void>`, and inference never triggered (`methodType.ReturnType is TypeInfo.Inferred` was never true).
2. **Body-pass inference** — never set up `_inferredReturnTypes`/`_inferredYieldTypes`, so `return`/`yield` operands weren't collected or resolved.
3. **Post-body republish** — returned the pre-inference frozen type, so call sites kept reading the placeholder.

## Fix

All edits in `CheckClassExpression`, mirroring the class-declaration path:

- `BuildMethodFuncType` defaults un-annotated returns to `TypeInfo.Inferred` and only generator-wraps when **annotated**.
- The body-check loop initializes/saves/restores `_inferredReturnTypes`/`_inferredYieldTypes`, collects operands, and resolves the real `Generator<…>` / `Promise<…>` / union back into the mutable class (reusing `BuildInferredGeneratorType`, `CollapseOrCreateUnion`, `TypeInfoEqualityComparer.Instance`).
- After the body pass, refreeze and re-register the `TypeMap`, **recompute the returned `classExprResultType`** (a class expression publishes its type only through its return value + `TypeMap`, not the outer environment), and invalidate the compatibility caches.

Type-checker-only — codegen already runs class-expression generator methods correctly once typed (per #765). Generalizes beyond generators to any inferred method return (plain, async, generator, async-generator, computed well-known-symbol).

## Tests

Adds `ClassExpressionTests` cases (interpreter **and** compiler) for inferred generator, plain, and async method returns reaching numeric call sites.

## Verification

- Issue repro prints `10` in both `dotnet run -- file.ts` and `--compile` modes.
- `dotnet test --filter ClassExpressionTests` → 56 passed.
- Full suite green: **13,603 passed, 0 failed**.
- Type-checker-only ⇒ Test262/TSConformance baselines unaffected.