### PR TITLE
Fix #791: compiled non-symbol (string/number) computed class method keys

### DIFF
--- a/Compilation/ILCompiler.Classes.HasFields.cs
+++ b/Compilation/ILCompiler.Classes.HasFields.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
 using SharpTS.Parsing;
@@ -363,6 +364,11 @@ public partial class ILCompiler
                 if (methodName == "constructor")
                     continue;
 
+                // #791: synthetic computed-method bodies ($symmethod_N) are not user-dispatchable
+                // by their internal name — they resolve via the registry fallback below.
+                if (methodName.StartsWith("$symmethod_", System.StringComparison.Ordinal))
+                    continue;
+
                 var nextLabel = il.DefineLabel();
 
                 // if (name == "methodName") return new $TSFunction(this, methodBuilder);
@@ -397,6 +403,32 @@ public partial class ILCompiler
 
                 il.MarkLabel(nextLabel);
             }
+        }
+
+        // 3b. #791: non-symbol (string/number) computed method keys. Their bodies are emitted as
+        // $symmethod_N and registered in the symbol-method registry under the property-key string
+        // (RegisterSymbolMethod), but named/string-index access (obj.dyn, obj["dyn"]) funnels here
+        // rather than through the symbol-key branch, so consult the registry as a fallback. Gated on
+        // this class declaring a computed method to keep the common no-computed-method path untouched.
+        // FindSymbolMethod walks the receiver's base chain, so an inherited key still resolves once
+        // base-fallthrough reaches the declaring class's GetProperty.
+        if (classStmt.Methods.Any(m => m.ComputedKey != null && m.Body != null))
+        {
+            var noStrMethodLabel = il.DefineLabel();
+            var strMethodLocal = il.DeclareLocal(_types.Object);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Call, _runtime.FindSymbolMethod);
+            il.Emit(OpCodes.Stloc, strMethodLocal);
+            il.Emit(OpCodes.Ldloc, strMethodLocal);
+            il.Emit(OpCodes.Brfalse, noStrMethodLabel);
+            // return new $TSFunction(this, (MethodInfo)mi)  — receiver-bound, mirroring the symbol path.
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldloc, strMethodLocal);
+            il.Emit(OpCodes.Castclass, _types.MethodInfo);
+            il.Emit(OpCodes.Newobj, _runtime.TSFunctionCtor);
+            il.Emit(OpCodes.Ret);
+            il.MarkLabel(noStrMethodLabel);
         }
 
         // 4. Not found on this class — delegate to the base class's GetProperty
@@ -674,6 +706,11 @@ public partial class ILCompiler
             {
                 // Skip constructor
                 if (methodName == "constructor")
+                    continue;
+
+                // #791: synthetic computed-method bodies ($symmethod_N) are not user-dispatchable
+                // by their internal name — they resolve via the registry fallback below.
+                if (methodName.StartsWith("$symmethod_", System.StringComparison.Ordinal))
                     continue;
 
                 var nextLabel = il.DefineLabel();

--- a/Compilation/RuntimeEmitter.SymbolAccessors.cs
+++ b/Compilation/RuntimeEmitter.SymbolAccessors.cs
@@ -137,6 +137,20 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ret);
         il.MarkLabel(symbolOkLabel);
 
+        // #791: a non-symbol computed method key (string/number, e.g. `["dyn"]()` / `[1]()`) is
+        // registered here too. Normalize it to its property-key string so it matches the form the
+        // lookup side produces (a named access uses the literal string; an index access uses
+        // ToJsString(key)); a numeric key would otherwise store as a boxed double and never match.
+        // Symbols pass through unchanged so symbol-keyed methods/accessors still share their slot.
+        var keyNormalizedLabel = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Call, runtime.IsSymbolMethod);
+        il.Emit(OpCodes.Brtrue, keyNormalizedLabel);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Call, runtime.ToJsString);
+        il.Emit(OpCodes.Starg_S, (byte)1);
+        il.MarkLabel(keyNormalizedLabel);
+
         // if (!_symbolAccessors.TryGetValue(owner, out inner)) { inner = new(); _symbolAccessors[owner] = inner; }
         var haveInner = il.DefineLabel();
         il.Emit(OpCodes.Ldsfld, field);

--- a/SharpTS.Tests/SharedTests/ComputedSymbolMethodTests.cs
+++ b/SharpTS.Tests/SharedTests/ComputedSymbolMethodTests.cs
@@ -77,11 +77,11 @@ public class ComputedSymbolMethodTests
         Assert.Equal("3\n", TestHarness.Run(source, mode));
     }
 
-    // Compiled mode: a non-symbol computed key (`[KEY]()` with KEY a string) would need a
-    // dynamically-named .NET method; the symbol-method registry only backs symbol keys, and named
-    // access doesn't consult it. Interpreter-only; tracked as a follow-up in #791.
+    // #791: non-symbol computed keys (string/number) fold to a string-named method. Bodies emit as
+    // synthetic $symmethod_N and register in the symbol-method registry under the property-key string;
+    // named/string-index access consults the registry as a fallback in $IHasFields.GetProperty.
     [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void NonSymbolComputedMethodKey_FoldsToNamedMethod(ExecutionMode mode)
     {
         var source = """
@@ -91,6 +91,64 @@ public class ComputedSymbolMethodTests
             """;
 
         Assert.Equal("42\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void StringLiteralComputedMethodKey_BothAccessForms(ExecutionMode mode)
+    {
+        // Literal key, accessed both by name and by string index.
+        var source = """
+            class C { ["dyn"]() { return 42; } }
+            const c = new C() as any;
+            console.log(c.dyn());
+            console.log(c["dyn"]());
+            """;
+
+        Assert.Equal("42\n42\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void MutableLocalComputedMethodKey_FoldsToNamedMethod(ExecutionMode mode)
+    {
+        // Fully dynamic form: the key is a mutable local, unknowable at compile time.
+        var source = """
+            let k = "dyn";
+            class C { [k]() { return 42; } }
+            console.log((new C() as any).dyn());
+            """;
+
+        Assert.Equal("42\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void NumericComputedMethodKey_FoldsToStringKey(ExecutionMode mode)
+    {
+        // A numeric key folds to its property-key string ("1"), reachable via either index form.
+        var source = """
+            class C { [1]() { return 7; } }
+            const c = new C() as any;
+            console.log(c[1]());
+            console.log(c["1"]());
+            """;
+
+        Assert.Equal("7\n7\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void InheritedComputedMethodKey_ResolvesOnSubclass(ExecutionMode mode)
+    {
+        // A computed key declared on the base resolves through the subclass via the base-chain walk.
+        var source = """
+            class Base { ["inh"]() { return 99; } }
+            class Derived extends Base {}
+            console.log((new Derived() as any).inh());
+            """;
+
+        Assert.Equal("99\n", TestHarness.Run(source, mode));
     }
 
     [Theory]


### PR DESCRIPTION
Fixes #791.

## Problem

In **compiled** mode, a class method declared with a non-symbol computed key (string or number) was not callable:

```ts
class C { ["dyn"]() { return 42; } }
console.log((new C() as any).dyn());   // interp: 42   compiled: TypeError: undefined is not a function
```

The interpreter already handled all three forms (literal `["dyn"]`, `const KEY`, mutable `let k`). This was sub-case 3 of #755; the symbol-keyed cases (#647) were already fixed.

## Root cause

The fix turned out far smaller than the issue's "why it's hard" suggested. The symbol-method machinery filters on `ComputedKey != null` — i.e. it already processes **all** computed methods, not just symbol-keyed ones:

- **Body emission** — already done: `DefineSymbolMethods`/`EmitSymbolMethods` emit a synthetic `$symmethod_N` body for string-keyed methods too.
- **Registration** — already done: `EmitSymbolMethodRegistrations` registers each computed key in the `object`-keyed symbol-method registry in the class `.cctor`.
- **Lookup** — *missing*: the registry was only consulted on the symbol-key access branch. Named/string-index access (`obj.dyn`, `obj["dyn"]`) funnels through `$IHasFields.GetProperty`, which never queried it → returned `undefined` → `TypeError`.

## Changes

- **`Compilation/ILCompiler.Classes.HasFields.cs`** — `EmitGetPropertyBody`: registry fallback (`FindSymbolMethod(this, name)` → `new $TSFunction(this, mi)`) before the base fall-through, **gated** on the class declaring a computed method so the common no-computed-method hot path is untouched. One insertion covers both `obj.dyn` and `obj["dyn"]` (both funnel through `GetProperty`); inheritance resolves via the registry's base-chain walk. Also skips synthetic `$symmethod_N` names in the named-method dispatch loop.
- **`Compilation/RuntimeEmitter.SymbolAccessors.cs`** — `EmitRegisterSymbolMethodBody`: normalize non-symbol keys via `ToJsString` so numeric keys (`[1]`) match the property-key string produced at lookup; symbols pass through unchanged.
- **Tests** — `NonSymbolComputedMethodKey_FoldsToNamedMethod` now runs in both modes; added compiled coverage for literal / mutable-local / numeric keys, both access forms, and inheritance.

No type-checker or interpreter changes were needed (both already handled these forms). Static computed keys and class-expression computed keys remain out of scope (different access paths).

## Verification

- Manual smoke test of all forms (literal, `const`, `let`, numeric, index access, inheritance) — compiled output now matches the interpreter.
- 40/40 in `ComputedSymbolMethodTests`; 384/384 across class/symbol/computed-related tests.
- Full-suite failures investigated and confirmed **not** regressions: the 3 built-in-module ones (crypto/os/uri) produce empty output only under parallel load and pass in isolation both before and after the change; the 2 Test262 baseline failures show `spread`/`new`-expression diffs unrelated to this feature (and that baseline is known stale/flaky).
