### PR TITLE
Fix #743: track module-level variables in the declared-type stack

### DIFF
--- a/SharpTS.Tests/TypeCheckerTests/NarrowingTests/VariableAssignmentFlowNarrowingTests.cs
+++ b/SharpTS.Tests/TypeCheckerTests/NarrowingTests/VariableAssignmentFlowNarrowingTests.cs
@@ -13,8 +13,10 @@ namespace SharpTS.Tests.TypeCheckerTests.NarrowingTests;
 ///
 /// The narrowed type is the declared union filtered to the members the RHS can be
 /// (<c>NarrowToDeclaredSlot</c>), so literal members survive and the declared type is the fallback
-/// when nothing narrows. Only function-local/parameter variables are narrowed — module-level
-/// variables are not tracked in the declared-type stack, so they stay at the declared type.
+/// when nothing narrows. Both function-local/parameter and module/top-level variables are tracked in
+/// the declared-type stack (#743 pushes a module frame in <c>Check</c>/<c>CheckWithRecovery</c>), so
+/// post-write narrowing applies at module scope too — assignments are still checked against the
+/// declared type, not the narrowed one.
 /// </summary>
 public class VariableAssignmentFlowNarrowingTests
 {
@@ -184,6 +186,53 @@ public class VariableAssignmentFlowNarrowingTests
                     x.toFixed(2);
                 }
             }
+            """;
+
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void ModuleScope_GuardThenReassignToOtherMember_Allowed()
+    {
+        // #743 Bug 1: at module scope `g = 42` was checked against the guard-narrowed `string` instead
+        // of the declared `string | number`, producing a spurious "Cannot assign" error. tsc accepts
+        // this — the assignment is checked against the DECLARED type. The same code in a function
+        // already worked because function locals were tracked in the declared-type stack.
+        var source = """
+            let g: string | number = "s";
+            if (typeof g === "string") {
+                g = 42;
+            }
+            console.log(g);
+            """;
+
+        Assert.Equal("42\n", TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void ModuleScope_WriteThenRead_NarrowsToRhsType()
+    {
+        // #743 Bug 2: post-write narrowing (#653) is gated on tracked variables, so module-level
+        // `x = "hi"` previously left `x` at `string | null` and `x.length` reported a false
+        // "possibly null". With the module declared-type frame, the write narrows `x` to string.
+        var source = """
+            let x: string | null = null;
+            x = "hi";
+            console.log(x.length);
+            """;
+
+        Assert.Equal("2\n", TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void ModuleScope_AssignOutsideDeclaredType_StillRejected()
+    {
+        // Regression guard: tracking module vars must not weaken assignment checking. An assignment
+        // outside the declared type is still rejected (checked against the declared type, which is now
+        // correctly recorded rather than read back from a narrowed binding).
+        var source = """
+            let n: number = 1;
+            n = "s";
             """;
 
         Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));

--- a/TypeSystem/TypeChecker.cs
+++ b/TypeSystem/TypeChecker.cs
@@ -865,6 +865,13 @@ public partial class TypeChecker
         _compatibilityCheckDepth = 0;
         _narrowingContextStack.Clear();
 
+        // Module/top-level declarations live in their own declared-type frame so that
+        // GetDeclaredType / IsDeclaredTypeTracked treat them like function locals (#743).
+        // Clear first: the checker is reused across REPL lines and may retain frames from a
+        // prior check (function frames are normally popped, but be defensive on early-exit).
+        _declaredVariableTypesStack.Clear();
+        PushDeclaredVariableScope();
+
         // Pre-define built-ins
         _environment.Define("console", new TypeInfo.Any());
         _environment.Define("Reflect", new TypeInfo.Any());
@@ -908,6 +915,13 @@ public partial class TypeChecker
         _ts2741Reported = null;
         _compatibilityCheckDepth = 0;
         _narrowingContextStack.Clear();
+
+        // Module/top-level declarations live in their own declared-type frame so that
+        // GetDeclaredType / IsDeclaredTypeTracked treat them like function locals (#743).
+        // Clear first: the checker is reused across REPL lines and may retain frames from a
+        // prior check (function frames are normally popped, but be defensive on early-exit).
+        _declaredVariableTypesStack.Clear();
+        PushDeclaredVariableScope();
 
         // Pre-define built-ins
         _environment.Define("console", new TypeInfo.Any());


### PR DESCRIPTION
## Context

The `TypeChecker`'s `_declaredVariableTypesStack` (which lets assignments be checked against a variable's **declared** type rather than its currently **narrowed** type) was only ever pushed at **function entry**. Module/top-level `let`/`const`/`var` declarations were therefore never recorded, so `GetDeclaredType` fell back to `_environment.Get(name)` — the *narrowed* type — for them.

This produced two `tsc`-divergent bugs at module scope (both already work correctly inside a function):

- **Bug 1 — false positive on guard + reassign:**
  ```ts
  let g: string | number = "s";
  if (typeof g === "string") {
    g = 42;            // tsc: ok (g's DECLARED type is string | number)
  }                    // SharpTS: error "Cannot assign type '42' ... of type 'string'"
  ```
- **Bug 2 — #653 post-write narrowing doesn't apply at module scope:** the #653 narrowing is gated on **tracked** variables (`IsDeclaredTypeTracked`), so `let x: string | null; x = "hi"; x.length` still reported a false "possibly null".

## Fix

Push a single **module-level declared-type frame** at the start of `Check` and `CheckWithRecovery` (clear-then-push, so the REPL's persistent checker rebuilds it per check). The existing `RecordDeclaredType` calls in `CheckVar` now land in it, so `GetDeclaredType`/`IsDeclaredTypeTracked` treat module vars like function locals — fixing both bugs. The `_environment.Get` fallback is preserved for genuinely-untracked names (built-in globals, hoist placeholders). 14 lines, no structural change.

## Tests

Added 3 module-scope cases to `VariableAssignmentFlowNarrowingTests` (Bug 1, Bug 2, and a regression guard that an out-of-union assignment is still rejected), plus a doc-comment update.

## Verification

- Type-checker tests: **1216 pass** (+3 new)
- Full suite: **13,600 pass, 0 fail** (a transient flake on one run cleared on re-run of the identical build — a known non-deterministic test, not this change)
- TypeScript conformance: **31 pass**, no baseline movement (Test262 unaffected — type-checking off there)
- Build clean, 0 warnings

Closes #743