### PR TITLE
Fix #792: defaulted generator/async-gen parameter captured by a nested arrow ignores its default

### DIFF
--- a/Compilation/AsyncGeneratorMoveNextEmitter.cs
+++ b/Compilation/AsyncGeneratorMoveNextEmitter.cs
@@ -224,6 +224,16 @@ public partial class AsyncGeneratorMoveNextEmitter : StatementEmitterBase
             _il.Emit(OpCodes.Ldloc, temp);
             _il.Emit(OpCodes.Stfld, field);
 
+            // A captured-and-mutated parameter's live storage is the function display-class field,
+            // not the state-machine field the body no longer reads. Mirror the default into the DC
+            // field so a nested arrow observes the default rather than the omitted-arg $Undefined
+            // sentinel (#792). Non-captured params return false here and keep the SM-field-only path.
+            if (TryGetFunctionDCField(param.Name.Lexeme, out var dcField))
+            {
+                _il.Emit(OpCodes.Ldloc, temp);
+                StoreToDCField(dcField);
+            }
+
             _il.MarkLabel(skipDefault);
         }
     }

--- a/Compilation/GeneratorMoveNextEmitter.cs
+++ b/Compilation/GeneratorMoveNextEmitter.cs
@@ -213,6 +213,16 @@ public partial class GeneratorMoveNextEmitter : StatementEmitterBase
             _il.Emit(OpCodes.Ldloc, temp);
             _il.Emit(OpCodes.Stfld, field);
 
+            // A captured-and-mutated parameter's live storage is the function display-class field,
+            // not the state-machine field the body no longer reads. Mirror the default into the DC
+            // field so a nested arrow observes the default rather than the omitted-arg $Undefined
+            // sentinel (#792). Non-captured params return false here and keep the SM-field-only path.
+            if (TryGetFunctionDCField(param.Name.Lexeme, out var dcField))
+            {
+                _il.Emit(OpCodes.Ldloc, temp);
+                StoreToDCField(dcField);
+            }
+
             _il.MarkLabel(skipDefault);
         }
     }

--- a/SharpTS.Tests/SharedTests/GeneratorArrowBodyTests.cs
+++ b/SharpTS.Tests/SharedTests/GeneratorArrowBodyTests.cs
@@ -482,4 +482,63 @@ public class GeneratorArrowBodyTests
 
         Assert.Equal("11,12,13\n", TestHarness.Run(source, mode));
     }
+
+    // #792: a defaulted parameter that is ALSO captured-and-mutated by a nested arrow. The default
+    // prologue (#737) wrote the default to the state-machine field, but a captured parameter's live
+    // storage is the function DC field (#674/#724/#725) — so an omitted argument left the arrow
+    // reading the $Undefined sentinel (NaN for value defaults, the missing string for ref defaults).
+    // Only the omitted-arg path was broken; supplying the argument always worked.
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Generator_DefaultedParamCapturedByArrow_OmittedUsesDefault(ExecutionMode mode)
+    {
+        // value-type default, captured by a forEach arrow — free-function generator.
+        var source = """
+            function* g(acc: number = 5): Generator<number> { [1, 2, 3].forEach(n => acc += n); yield acc; }
+            console.log([...g()][0]);
+            """;
+
+        Assert.Equal("11\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Generator_DefaultedParamCapturedByArrow_SuppliedWins(ExecutionMode mode)
+    {
+        // Regression guard: a supplied argument must beat the default on the captured path too.
+        var source = """
+            function* g(acc: number = 5): Generator<number> { [1, 2, 3].forEach(n => acc += n); yield acc; }
+            console.log([...g(100)][0]);
+            """;
+
+        Assert.Equal("106\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Generator_RefDefaultedParamCapturedByArrow_InstanceMethod(ExecutionMode mode)
+    {
+        // reference-type (string) default, captured — instance generator method.
+        var source = """
+            class C { *gen(s: string = "x"): Generator<string> { [1, 2, 3].forEach(n => s += n); yield s; } }
+            console.log([...new C().gen()][0]);
+            console.log([...new C().gen("Y")][0]);
+            """;
+
+        Assert.Equal("x123\nY123\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AsyncGenerator_DefaultedParamCapturedByArrow_OmittedUsesDefault(ExecutionMode mode)
+    {
+        // value-type default, captured — async generator.
+        var source = """
+            async function* ag(acc: number = 5) { [1, 2, 3].forEach(n => acc += n); yield acc; }
+            (async () => { for await (const v of ag()) console.log(v); })();
+            """;
+
+        Assert.Equal("11\n", TestHarness.Run(source, mode));
+    }
 }


### PR DESCRIPTION
Fixes #792.

## Problem

In **compiled** mode, when a generator or async-generator parameter has a **default value** *and* is **captured-and-mutated by a nested arrow/closure**, an **omitted** argument did not get its default — the `$Undefined` sentinel (or null) leaked into the closure's storage. The interpreter was correct, and supplying the argument explicitly always worked.

| case | interp | compiled (before) |
|------|--------|-------------------|
| `g()` value default, free-func generator | 11 | **NaN** |
| `new C().gen()` ref default, instance generator | x123 | **6** |
| `ag()` value default, async generator | 11 | **NaN** |

## Root cause

A captured-and-mutated generator parameter's **live storage** is the function display-class (DC) field (#674/#724/#725) — the body and nested arrow both read/write it. The default-parameter prologue (#737), `EmitDefaultParameters`, runs on initial `MoveNext` entry and wrote the evaluated default **only to the state-machine field**. For a captured parameter the body never reads that field, so the default never reached the DC field the closure observes.

The undefined-check side was already fine (it reads the state-machine field, which the stub seeds with the real incoming arg); only the **write** side targeted the wrong storage.

## Fix

In both `EmitDefaultParameters` prologues (`Compilation/GeneratorMoveNextEmitter.cs` and `Compilation/AsyncGeneratorMoveNextEmitter.cs`), after storing the default to the state-machine field, also mirror it into the DC field when the parameter is captured, reusing the existing `TryGetFunctionDCField` / `StoreToDCField` helpers. Non-captured params and supplied-argument paths are byte-for-byte unchanged.

No changes needed to the stub seeding (`EmitGeneratorFunctionDCInit`) — that was already correct; the gap was purely in the MoveNext default prologue.

## Tests

Adds parity tests (run in both interpreter and compiled modes) to `SharpTS.Tests/SharedTests/GeneratorArrowBodyTests.cs` covering free-function and instance generators, async generators, value- and reference-type defaults, and a supplied-argument regression guard.

## Verification

- All repro cases now match the interpreter in compiled mode (`11`, `x123`, `11`); supplied-arg variants and the non-captured `*h(b=5)` baseline still correct.
- `dotnet test --filter "FullyQualifiedName~Generator|FullyQualifiedName~DefaultParameter"` → 1137 passed.
- Full suite green except 5 pre-existing flaky Test262 baseline diffs on the unrelated `new X(...spread)` path (confirmed present without this change).