### PR TITLE
Fix #790: override-arity bridge for derived overrides adding trailing optional params

### DIFF
--- a/Compilation/ILCompiler.Classes.Methods.cs
+++ b/Compilation/ILCompiler.Classes.Methods.cs
@@ -676,6 +676,11 @@ public partial class ILCompiler
             }
         }
 
+        // #790: emit override-arity bridges so a base-typed call reaches a derived override that
+        // adds trailing optional/default params (whose wider CLR arity would otherwise take a new
+        // vtable slot instead of overriding the base).
+        EmitOverrideArityBridges(typeBuilder, classStmt, qualifiedClassName);
+
         // Emit computed symbol-keyed method bodies (#647). Before the static constructor so the
         // registry registrations there can reference them.
         EmitSymbolMethods(typeBuilder, qualifiedClassName, fieldsField);
@@ -699,6 +704,132 @@ public partial class ILCompiler
 
         // Emit ES2022 private method bodies
         EmitPrivateMethodBodies(typeBuilder, classStmt, fieldsField, qualifiedClassName);
+    }
+
+    /// <summary>
+    /// #790: For a derived instance method that overrides a base method by adding trailing
+    /// optional/default parameters, the override's CLR arity differs from the base (e.g.
+    /// <c>Derived.m(double, object)</c> vs <c>Base.m(double)</c>), so it takes a NEW vtable slot
+    /// instead of overriding — and a base-typed call (<c>(b: Base).m(3)</c>) dispatches to the base
+    /// method, never reaching the override. (The same-<i>arity</i> case is handled by
+    /// <see cref="ParameterTypeResolver"/>'s hierarchy-consistent widening, #705/#723/#787.)
+    ///
+    /// This emits, for each shorter ancestor signature of the method, a synthetic <c>virtual</c>
+    /// (non-newslot, so it auto-overrides) bridge matching that ancestor's exact CLR signature,
+    /// forwarding to the derived full method with the missing trailing params filled by the
+    /// <c>$Undefined</c>/null sentinel. The full method's existing default prologue then fires the
+    /// defaults in order — identical to what a direct call site does via <c>EmitOmittedArgument</c>,
+    /// so a default may reference an earlier param (#698). Forwarding via <c>callvirt</c> means a
+    /// base-/mid-typed call lands on the most-derived implementation in deeper chains.
+    ///
+    /// Scoped to sync (return type <c>object</c>) instance methods: an async/generator ancestor has
+    /// a different return type, so a CLR override is impossible.
+    /// </summary>
+    private void EmitOverrideArityBridges(TypeBuilder typeBuilder, Stmt.Class classStmt, string qualifiedClassName)
+    {
+        if (!_classes.InstanceMethods.TryGetValue(qualifiedClassName, out var ownMethods))
+            return;
+
+        foreach (var method in classStmt.Methods.Where(m =>
+                     m.Body != null && !m.IsStatic && !m.IsPrivate && !m.IsAbstract &&
+                     !m.IsAsync && !m.IsGenerator && m.ComputedKey == null &&
+                     m.Name.Lexeme != "constructor"))
+        {
+            string name = method.Name.Lexeme;
+            if (!ownMethods.TryGetValue(name, out var fullBuilder))
+                continue;
+
+            var fullParams = fullBuilder.GetParameters();
+            int fullArity = fullParams.Length;
+            if (fullArity == 0)
+                continue; // cannot add trailing params below arity 0
+
+            // Collect the distinct shorter ancestor CLR signatures (one bridge per arity, nearest
+            // ancestor wins). Each distinct ancestor arity is a separate vtable slot to override.
+            var byArity = new Dictionary<int, Type[]>();
+            string? current = _classes.Superclass.GetValueOrDefault(qualifiedClassName);
+            var visited = new HashSet<string>(StringComparer.Ordinal);
+            while (current != null && visited.Add(current))
+            {
+                if (_classes.InstanceMethods.TryGetValue(current, out var ancMethods) &&
+                    ancMethods.TryGetValue(name, out var ancBuilder))
+                {
+                    var ancParams = ancBuilder.GetParameters();
+                    int ancArity = ancParams.Length;
+                    // Only a strictly-shorter, object-returning (sync) ancestor signature whose
+                    // shared prefix matches ours can be bridged: the bridge must equal the ancestor
+                    // slot's signature to bind, and forward those args into our full method.
+                    if (ancArity < fullArity && !byArity.ContainsKey(ancArity) &&
+                        ancBuilder.ReturnType == typeof(object) &&
+                        PrefixTypesMatch(ancParams, fullParams, ancArity))
+                    {
+                        byArity[ancArity] = ancParams.Select(p => p.ParameterType).ToArray();
+                    }
+                }
+                current = _classes.Superclass.GetValueOrDefault(current);
+            }
+
+            foreach (var (bridgeArity, bridgeSig) in byArity)
+            {
+                var bridge = typeBuilder.DefineMethod(
+                    name,
+                    MethodAttributes.Public | MethodAttributes.Virtual,
+                    typeof(object),
+                    bridgeSig);
+
+                var il = bridge.GetILGenerator();
+                il.Emit(OpCodes.Ldarg_0);                       // this
+                for (int i = 0; i < bridgeArity; i++)
+                    il.Emit(OpCodes.Ldarg, i + 1);              // forward provided args
+                for (int i = bridgeArity; i < fullArity; i++)
+                    EmitOmittedBridgeArgument(il, fullParams[i].ParameterType);
+                il.Emit(OpCodes.Callvirt, fullBuilder);         // dispatch to most-derived full method
+                il.Emit(OpCodes.Ret);
+            }
+        }
+    }
+
+    /// <summary>True when the first <paramref name="count"/> parameter types of two signatures are
+    /// identical — a precondition for the override bridge to forward args without conversion.</summary>
+    private static bool PrefixTypesMatch(ParameterInfo[] a, ParameterInfo[] b, int count)
+    {
+        for (int i = 0; i < count; i++)
+            if (a[i].ParameterType != b[i].ParameterType)
+                return false;
+        return true;
+    }
+
+    /// <summary>
+    /// Emits the omitted-argument sentinel for a trailing slot the bridge does not receive, mirroring
+    /// <c>EmitOmittedArgument</c>: an <c>object</c> slot (every widened optional/defaulted param) gets
+    /// the emitted runtime's <c>$Undefined</c> sentinel — which fires the default prologue and is
+    /// observable through <c>typeof</c>/<c>=== undefined</c>; a value-type slot gets its CLR default;
+    /// a not-widened reference-typed default (e.g. <c>string</c>) gets <c>null</c>, on which the
+    /// prologue still fires. Standalone-safe: references the emitted <c>UndefinedInstance</c> field,
+    /// not SharpTS.dll.
+    /// </summary>
+    private void EmitOmittedBridgeArgument(System.Reflection.Emit.ILGenerator il, Type slotType)
+    {
+        if (slotType == typeof(object))
+        {
+            if (_runtime != null)
+                il.Emit(OpCodes.Ldsfld, _runtime.UndefinedInstance);
+            else
+                il.Emit(OpCodes.Ldnull);
+        }
+        else if (slotType == typeof(double)) { il.Emit(OpCodes.Ldc_R8, 0.0); }
+        else if (slotType == typeof(int)) { il.Emit(OpCodes.Ldc_I4_0); }
+        else if (slotType == typeof(bool)) { il.Emit(OpCodes.Ldc_I4_0); }
+        else if (slotType == typeof(float)) { il.Emit(OpCodes.Ldc_R4, 0.0f); }
+        else if (slotType == typeof(long)) { il.Emit(OpCodes.Ldc_I8, 0L); }
+        else if (slotType.IsValueType)
+        {
+            var local = il.DeclareLocal(slotType);
+            il.Emit(OpCodes.Ldloca, local);
+            il.Emit(OpCodes.Initobj, slotType);
+            il.Emit(OpCodes.Ldloc, local);
+        }
+        else { il.Emit(OpCodes.Ldnull); }
     }
 
     /// <summary>

--- a/SharpTS.Tests/CompilerTests/ClassMethodDefaultParameterTests.cs
+++ b/SharpTS.Tests/CompilerTests/ClassMethodDefaultParameterTests.cs
@@ -246,6 +246,95 @@ public class ClassMethodDefaultParameterTests
         Assert.Equal("D:D\n", TestHarness.Run(source, mode));
     }
 
+    // ---- Different-arity override: derived adds trailing optional/default params (#790) ----
+    // A base-typed call must reach the derived override even though its wider CLR arity would
+    // otherwise take a new vtable slot. Fixed by emitting a base-arity override bridge.
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Override_DerivedAddsValueTypeDefault_BaseTypedDispatchesToDerived(ExecutionMode mode)
+    {
+        var source = """
+            class Base { m(x: number): number { return x; } }
+            class Derived extends Base { m(x: number, y: number = 100): number { return x + y; } }
+            const b: Base = new Derived();
+            console.log(b.m(3));
+            """;
+        Assert.Equal("103\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Override_DerivedAddsReferenceTypeDefault_BaseTypedDispatchesToDerived(ExecutionMode mode)
+    {
+        // Reference-type added default proves the gap is dispatch, not default-firing.
+        var source = """
+            class B2 { g(x: number): string { return "x" + x; } }
+            class D2 extends B2 { g(x: number, s: string = "Z"): string { return "x" + x + s; } }
+            const b2: B2 = new D2();
+            console.log(b2.g(3));
+            """;
+        Assert.Equal("x3Z\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Override_DerivedAddsNoDefaultOptional_BaseTypedDispatchesToDerived(ExecutionMode mode)
+    {
+        // Added optional with no default: the derived runs with the param undefined.
+        var source = """
+            class Base { m(x: number): string { return "B:" + x; } }
+            class Derived extends Base { m(x: number, y?: number): string { return "D:" + x + ":" + (y === undefined ? "u" : y); } }
+            const b: Base = new Derived();
+            console.log(b.m(3));
+            """;
+        Assert.Equal("D:3:u\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Override_DerivedAddsMultipleDefaults_BaseTypedDispatchesToDerived(ExecutionMode mode)
+    {
+        var source = """
+            class P { f(a: number): string { return "P:" + a; } }
+            class Q extends P { f(a: number, b: number = 7, c: string = "z"): string { return "Q:" + a + ":" + b + ":" + c; } }
+            const p: P = new Q();
+            console.log(p.f(1));
+            """;
+        Assert.Equal("Q:1:7:z\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Override_ThreeLevelChain_BaseAndMidTypedReachMostDerived(ExecutionMode mode)
+    {
+        // Each level adds an arity; both a base-typed and a mid-typed call must land on L2.
+        var source = """
+            class L0 { m(x: number): string { return "L0:" + x; } }
+            class L1 extends L0 { m(x: number, y: number = 1): string { return "L1:" + x + ":" + y; } }
+            class L2 extends L1 { m(x: number, y: number = 1, z: number = 2): string { return "L2:" + x + ":" + y + ":" + z; } }
+            const asL0: L0 = new L2();
+            const asL1: L1 = new L2();
+            console.log(asL0.m(3));
+            console.log(asL1.m(3));
+            """;
+        Assert.Equal("L2:3:1:2\nL2:3:1:2\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Override_DerivedAddsDefault_DirectCallStillWorks(ExecutionMode mode)
+    {
+        // Regression: the direct (derived-typed) call path is unaffected by the bridge.
+        var source = """
+            class Base { m(x: number): number { return x; } }
+            class Derived extends Base { m(x: number, y: number = 100): number { return x + y; } }
+            const d = new Derived();
+            console.log(d.m(3));
+            """;
+        Assert.Equal("103\n", TestHarness.Run(source, mode));
+    }
+
     // ---- Value-type defaults on (virtual) instance & static methods (#723/#737) ----
 
     [Theory]


### PR DESCRIPTION
## Summary

In **compiled** mode, when a derived class overrides a base method by **adding trailing optional / default parameters** (a valid TypeScript override), a call through a **base-typed reference** dispatched to the **base** method instead of the override — the derived body never ran. The interpreter was already correct.

```ts
class Base { m(x: number): number { return x; } }
class Derived extends Base { m(x: number, y: number = 100): number { return x + y; } }
const b: Base = new Derived();
console.log(b.m(3));   // interp: 103   compiled (before): 3   compiled (after): 103
```

**Root cause.** Instance methods are emitted `virtual` (no `newslot`), so the CLR treats a derived method as an override only when name **and signature** match. `Derived.m(x, y=100)` has CLR arity 2 (`(double, object)` after #737 widening) while `Base.m(x)` has arity 1 — different signature, so the derived method silently takes a **new vtable slot**. A statically-`Base`-typed call resolves to `Base.m(double)` and `callvirt`s that slot. The same-*arity* case was already handled by `ParameterTypeResolver`'s hierarchy-consistent widening (#705/#723/#787); this PR closes the remaining different-arity slice.

## Fix

New `EmitOverrideArityBridges` in `Compilation/ILCompiler.Classes.Methods.cs`, called from `EmitClassMethods` after the instance-method body loop. For each sync (`returnType == object`) instance method, it walks the ancestry (`_classes.Superclass`) and, for each distinct **shorter ancestor signature** whose prefix CLR types match, emits a `virtual` (non-`newslot`, so it auto-overrides) **bridge** matching the ancestor's exact signature. The bridge forwards `this` + the provided args, pads the added params with the `$Undefined`/null sentinel (`EmitOmittedBridgeArgument`), then `callvirt`s the derived **full** method.

- The full method's **existing default prologue** fires the defaults in order — identical to a direct call site, so a default may reference an earlier param (#698).
- `callvirt` forwarding means base-/mid-typed calls reach the **most-derived** implementation in N-level chains (gathering ancestor full-method arities suffices and composes).
- **Standalone-safe**: the sentinel references the emitted `UndefinedInstance` field, not `SharpTS.dll`.

### Scope
Sync-over-sync instance methods. Out of scope (different-return-type or different machinery — candidates for follow-ups): async/generator overrides that add arity, class-*expression* methods, private methods.

## Tests

Six new `[Theory]`-over-`ExecutionModes.All` cases in `ClassMethodDefaultParameterTests.cs` (interp stays the oracle): value-type added default, reference-type added default, added no-default optional, multiple added defaults, 3-level chain (base- and mid-typed both reach the most-derived), and a direct-call regression guard.

## Verification

- Issue repro cases A/B/C + chain + optional + multi-default: compiled now matches interp exactly; `--compile … --verify` passes.
- `ClassMethodDefaultParameterTests` 72/72; `ILVerificationTests` 71/71 (emitted IL valid).
- No regressions: `OverrideKeywordTests`, `ClassTests` (183), `SyncAsyncEquivalenceTests` (124), `AbstractClassTests`, `StaticMembersTests`, `GenericsTests`, `PromiseSubclassTests`, `ThisParameterTests`, `InheritedMemberResolutionTests`.

Closes #790.