### PR TITLE
Fix #789: class-expression generator methods support arrow write-capture of a generator local

### DIFF
--- a/Compilation/ILCompiler.ArrowFunctions.cs
+++ b/Compilation/ILCompiler.ArrowFunctions.cs
@@ -103,6 +103,13 @@ public partial class ILCompiler
     /// </summary>
     private void FinalizeArrowFunctionCollection()
     {
+        // #789: register function display classes for class-EXPRESSION generator methods whose arrows
+        // write a captured method local. Class declarations do this in Phase 4 (DefineClass); class
+        // expressions are only collected during the Phase-5 arrow walk, so the registration is sequenced
+        // here — after every module has been walked (all class-expr names assigned) and before the
+        // PropagateFunctionDCRequirements pass below, which needs the function DC fields already present.
+        RegisterClassExpressionGeneratorMethodFunctionDisplayClasses();
+
         // Propagate function DC requirements through arrow nesting
         // If an inner arrow needs $functionDC, parent arrows also need it
         PropagateFunctionDCRequirements();
@@ -823,11 +830,14 @@ public partial class ILCompiler
                 // body, so clear the immediate-callable marker while walking them.
                 var prevCallableCE = _currentEnclosingCallable;
                 _currentEnclosingCallable = null;
-                // Also collect arrows inside class expression methods
+                // Also collect arrows inside class expression methods. Walk each method via
+                // CollectArrowsFromStmt(method) — not its body statements directly — so the Stmt.Function
+                // case records the method as `_currentEnclosingFunctionStmt`, the arrow→method mapping
+                // PropagateFunctionDCRequirements needs to route a generator method's write-capture through
+                // its function display class (#789). Mirrors the Stmt.Class declaration path above.
                 foreach (var method in ce.Methods)
                     if (method.Body != null)
-                        foreach (var s in method.Body)
-                            CollectArrowsFromStmt(s);
+                        CollectArrowsFromStmt(method);
                 // Collect arrows in field initializers
                 foreach (var field in ce.Fields)
                     if (field.Initializer != null)
@@ -840,6 +850,21 @@ public partial class ILCompiler
                 _currentEnclosingCallable = prevCallableCE;
                 break;
         }
+    }
+
+    /// <summary>
+    /// #789: registers function display classes for class-EXPRESSION generator methods that write a
+    /// captured method local, mirroring the Phase-4 registration class declarations get via
+    /// <see cref="RegisterGeneratorMethodFunctionDisplayClasses(Stmt.Class, string)"/>. Uses the generated
+    /// class-expr name (assigned by <see cref="CollectClassExpression"/>) as the qualified name; the key is
+    /// only required to be internally consistent because the DC-key dictionaries are AST-identity-keyed.
+    /// Must run before <see cref="PropagateFunctionDCRequirements"/>.
+    /// </summary>
+    private void RegisterClassExpressionGeneratorMethodFunctionDisplayClasses()
+    {
+        foreach (var classExpr in _classExprs.ToDefine)
+            if (_classExprs.Names.TryGetValue(classExpr, out var name))
+                RegisterGeneratorMethodFunctionDisplayClasses(classExpr.Methods, name);
     }
 
     /// <summary>

--- a/Compilation/ILCompiler.Generators.cs
+++ b/Compilation/ILCompiler.Generators.cs
@@ -169,9 +169,18 @@ public partial class ILCompiler
     /// no such write-capture, leaving their state machines fully standalone. Covers both sync (#724)
     /// and async (#725) instance generator methods; static and plain methods use other paths.
     /// </summary>
-    private void RegisterGeneratorMethodFunctionDisplayClasses(Stmt.Class classStmt, string qualifiedClassName)
+    private void RegisterGeneratorMethodFunctionDisplayClasses(Stmt.Class classStmt, string qualifiedClassName) =>
+        RegisterGeneratorMethodFunctionDisplayClasses(classStmt.Methods, qualifiedClassName);
+
+    /// <summary>
+    /// Shared core of <see cref="RegisterGeneratorMethodFunctionDisplayClasses(Stmt.Class, string)"/>, reused
+    /// for class EXPRESSIONS (#789). <c>Expr.ClassExpr.Methods</c> is the same <c>List&lt;Stmt.Function&gt;</c>
+    /// element type as <c>Stmt.Class.Methods</c>, so both class kinds register their generator-method function
+    /// display classes through this single pass.
+    /// </summary>
+    private void RegisterGeneratorMethodFunctionDisplayClasses(IReadOnlyList<Stmt.Function> methods, string qualifiedClassName)
     {
-        foreach (var method in classStmt.Methods)
+        foreach (var method in methods)
         {
             if (method.Body == null || !method.IsGenerator || method.IsStatic)
                 continue;

--- a/SharpTS.Tests/SharedTests/GeneratorArrowBodyTests.cs
+++ b/SharpTS.Tests/SharedTests/GeneratorArrowBodyTests.cs
@@ -541,4 +541,93 @@ public class GeneratorArrowBodyTests
 
         Assert.Equal("11\n", TestHarness.Run(source, mode));
     }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Generator_ClassExpressionMethodWritesCapturedBinding(ExecutionMode mode)
+    {
+        // #789: the class-EXPRESSION analogue of #724. Class expressions are only collected during the
+        // Phase-5 arrow walk, so their generator-method function display classes are registered in
+        // FinalizeArrowFunctionCollection (before PropagateFunctionDCRequirements) rather than DefineClass.
+        var source = """
+            const C = class {
+              *gen(arr: number[]) {
+                let sum = 0;
+                arr.forEach(n => sum += n);
+                yield sum;
+              }
+            };
+            console.log([...new C().gen([1, 2, 3])].join(","));
+            """;
+
+        Assert.Equal("6\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Generator_ClassExpressionMethodMutatesCapturedParameter(ExecutionMode mode)
+    {
+        // #789: the mutated capture is a method PARAMETER (value-typed in the stub) — class-expr analogue
+        // of the #724 parameter case.
+        var source = """
+            const C = class { *gen(acc: number) { [1, 2, 3].forEach(n => acc += n); yield acc; } };
+            console.log(new C().gen(100).next().value);
+            """;
+
+        Assert.Equal("106\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Generator_ClassExpressionMethodMixesThisAndMutatedLocal(ExecutionMode mode)
+    {
+        // #789: the arrow reads `this` (state machine ThisField) AND writes a captured local (function DC)
+        // in the same callback — class-expr analogue of the #724 this+local case.
+        var source = """
+            const C = class {
+              base = 10;
+              *gen() { let s = 0; [1, 2, 3].forEach(n => s += n + this.base); yield s; }
+            };
+            console.log(new C().gen().next().value);
+            """;
+
+        Assert.Equal("36\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Generator_ClassExpressionMethodCapturedWriteSurvivesAcrossYield(ExecutionMode mode)
+    {
+        // #789: the mutated capture is live across a yield — the DC lives on a state-machine field so it
+        // persists across the suspension (class-expr analogue of the #724 cross-yield case).
+        var source = """
+            const C = class {
+              *gen() { let s = 0; yield "b:" + s; [1, 2, 3].forEach(n => s += n); yield "a:" + s; }
+            };
+            const it = new C().gen();
+            console.log(it.next().value + "|" + it.next().value);
+            """;
+
+        Assert.Equal("b:0|a:6\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AsyncGenerator_ClassExpressionMethodWritesCapturedBinding(ExecutionMode mode)
+    {
+        // #789: the async-generator class-EXPRESSION analogue of #725 — the function DC is registered in
+        // FinalizeArrowFunctionCollection and wired into the method's (reference-type) state machine.
+        var source = """
+            const C = class {
+              async *gen() {
+                let s = 0;
+                [1, 2, 3].forEach(n => s += n);
+                yield s;
+              }
+            };
+            (async () => { for await (const v of new C().gen()) console.log(v); })();
+            """;
+
+        Assert.Equal("6\n", TestHarness.Run(source, mode));
+    }
 }


### PR DESCRIPTION
## Summary

Follow-up to #765. In compiled mode, an arrow/callback that **writes** a generator-scope local inside a class-**expression** generator method hit the safe `#674` fail-fast guard:

```ts
const C = class { *gen(arr: number[]) { let sum = 0; arr.forEach(n => sum += n); yield sum; } };
console.log([...new C().gen([1,2,3])].join(",")); // interp: 6; compiled (before): Compile Error
```

The interpreter always handled this; class **declarations** were fixed by #724 (sync) / #725 (async-gen). This ports the function-display-class (DC) wiring to class expressions.

## The fix needed two pieces (the issue named only the first)

1. **Registration** — extracted a shared `RegisterGeneratorMethodFunctionDisplayClasses(IReadOnlyList<Stmt.Function>, qualifiedName)` core (`Expr.ClassExpr.Methods` is the same `List<Stmt.Function>` as `Stmt.Class.Methods`). Class declarations register in Phase 4 (`DefineClass`); class-expr names are only assigned during the Phase-5 arrow walk, so registration is sequenced at the top of `FinalizeArrowFunctionCollection`, **before** `PropagateFunctionDCRequirements`.

2. **Hidden blocker (the real cause)** — the `Expr.ClassExpr` branch of `CollectArrowsFromStmt` walked method *bodies* directly, so `_currentEnclosingFunctionStmt` was never set to the method node → `PropagateFunctionDCRequirements` couldn't resolve the arrow back to its method's DC. Fixed by walking each method via `CollectArrowsFromStmt(method)`, mirroring the `Stmt.Class` declaration path.

No emit-side changes — `EmitGeneratorMethodBody` / `EmitAsyncGeneratorMethodBody` already consume the DC keys by AST identity (#765 routes class-expr generators through them). No new state-machine emitter overrides, so the `EmitterSyncTests` allowlist is untouched.

## Scope

Compiled-only; instance generator / async-generator methods (static stays fail-fast, matching the declaration path).

## Tests

Adds 5 class-expression cases to `GeneratorArrowBodyTests.cs` (sync / mutated-param / `this`+local / cross-yield / async-gen), mirroring the #724/#725 coverage. All run in both interpreter and compiled modes.

- New cases pass in both modes; issue repro outputs `6` interp + compiled (no Compile Error).
- All 1029 `Generator`-filtered tests green; ClassExpression / EmitterSync / ComputedSymbolMethod suites green.

Closes #789.