### PR TITLE
Fix #783: nested destructuring over a mixed (non-tuple) array literal

### DIFF
--- a/Parsing/AST.cs
+++ b/Parsing/AST.cs
@@ -404,7 +404,12 @@ public abstract record Stmt
     /// would otherwise default to <c>any</c> — suppressing TS2403 for a later <c>var z: number;</c>.
     /// The type checker infers the binding's declared type from this expression (widened, errors
     /// suppressed since they surface at the original site); the interpreter and IL compiler ignore it.</param>
-    public record Var(Token Name, string? TypeAnnotation, Expr? Initializer, bool HasDefiniteAssignmentAssertion = false, bool IsVar = false, TypeNode? TypeAnnotationNode = null, Expr? HoistTypeInferenceInitializer = null) : Stmt;
+    /// <param name="InitializerContext">A synthetic contextual type used ONLY to guide inference of the
+    /// initializer (not as the binding's declared type — it imposes no TS2322 compatibility check and the
+    /// inferred type is still kept). Set by the destructuring desugarer to carry the binding pattern's
+    /// shape so a mixed array literal source infers as a tuple instead of an array (#783). Erased at
+    /// runtime (interpreter and IL compiler ignore it).</param>
+    public record Var(Token Name, string? TypeAnnotation, Expr? Initializer, bool HasDefiniteAssignmentAssertion = false, bool IsVar = false, TypeNode? TypeAnnotationNode = null, Expr? HoistTypeInferenceInitializer = null, TypeNode? InitializerContext = null) : Stmt;
     /// <summary>
     /// Const variable declaration. Separate from Var for cleaner const-specific handling (e.g., unique symbol).
     /// Initializer is non-nullable since const always requires initialization.

--- a/Parsing/Parser.Destructuring.cs
+++ b/Parsing/Parser.Destructuring.cs
@@ -161,7 +161,10 @@ public partial class Parser
             null,
             [initializer]
         );
-        statements.Add(new Stmt.Var(temp, null, normalizedInit));
+        // Carry the pattern's shape as a contextual type so a mixed array-literal source (`[[7], 8]`)
+        // infers as a tuple instead of an array — otherwise `_dest[0]` is a non-indexable union and a
+        // nested pattern (`[m]`) fails to type-check (#783). Erased at runtime.
+        statements.Add(new Stmt.Var(temp, null, normalizedInit, InitializerContext: BuildArrayPatternShape(pattern)));
 
         int index = 0;
         foreach (var element in pattern.Elements)
@@ -278,6 +281,67 @@ public partial class Parser
         return new Stmt.Sequence(statements);
     }
 
+    // ============== CONTEXTUAL SHAPE FROM BINDING PATTERN (#783) ==============
+    // A mixed array literal (`[[7], 8]`) infers as the array `(number[] | number)[]` rather than the
+    // tuple `[number[], number]`, so the desugared positional read `_dest[0]` is a non-indexable union
+    // and a nested pattern (`[m]`) fails to type-check. tsc avoids this by using the binding pattern as a
+    // contextual type. These helpers reconstruct that shape as a synthetic `TupleTypeNode` attached to
+    // the source temp's `InitializerContext`: only positions whose binding is itself a nested array get a
+    // recursive tuple context; every other position gets `unknown`, which never triggers tuple inference
+    // (so uniform-nested literals like `[[1,2],[3,4]]` stay arrays, matching tsc). A trailing rest becomes
+    // a `...unknown[]` element so arity filtering still admits the literal.
+
+    private static TypeNode BuildArrayPatternShape(ArrayPattern pattern)
+    {
+        var elements = new List<TupleElementNode>(pattern.Elements.Count);
+        foreach (var element in pattern.Elements)
+        {
+            if (!element.IsHole && element.Pattern is RestPattern)
+            {
+                elements.Add(new TupleElementNode(null, UnknownArrayShape(pattern.Line), IsOptional: false, IsRest: true, pattern.Line));
+                break;
+            }
+            TypeNode shape = !element.IsHole && element.Pattern is ArrayPattern nested
+                ? BuildArrayPatternShape(nested)
+                : UnknownShape(pattern.Line);
+            elements.Add(new TupleElementNode(null, shape, IsOptional: false, IsRest: false, pattern.Line));
+        }
+        return new TupleTypeNode(elements, pattern.Line);
+    }
+
+    private static TypeNode BuildArrayLiteralShape(Expr.ArrayLiteral arr, int line)
+    {
+        var elements = new List<TupleElementNode>(arr.Elements.Count);
+        for (int i = 0; i < arr.Elements.Count; i++)
+        {
+            if (arr.IsHole(i))
+            {
+                elements.Add(new TupleElementNode(null, UnknownShape(line), IsOptional: false, IsRest: false, line));
+                continue;
+            }
+            Expr element = Unwrap(arr.Elements[i]);
+            if (element is Expr.Spread)
+            {
+                elements.Add(new TupleElementNode(null, UnknownArrayShape(line), IsOptional: false, IsRest: true, line));
+                break;
+            }
+            // A nested array target — directly (`[[m], n]`) or with a default that the eager parser
+            // captured as a DestructuringAssign carrying the raw target (`[[a] = []]`, #779).
+            Expr.ArrayLiteral? nested = element switch
+            {
+                Expr.ArrayLiteral lit => lit,
+                Expr.DestructuringAssign { RawTarget: { } raw } when Unwrap(raw) is Expr.ArrayLiteral rawLit => rawLit,
+                _ => null
+            };
+            TypeNode shape = nested != null ? BuildArrayLiteralShape(nested, line) : UnknownShape(line);
+            elements.Add(new TupleElementNode(null, shape, IsOptional: false, IsRest: false, line));
+        }
+        return new TupleTypeNode(elements, line);
+    }
+
+    private static TypeNode UnknownShape(int line) => new NamedTypeNode("unknown", null, line);
+    private static TypeNode UnknownArrayShape(int line) => new ArrayTypeNode(UnknownShape(line), line);
+
     // ============== ASSIGNMENT DESTRUCTURING (#754) ==============
     // `[a, b] = rhs` / `({a, b} = rhs)` assign to EXISTING l-values (not new bindings). The target has
     // already been parsed as an array/object literal (the eager-parse cover grammar); here it is
@@ -297,8 +361,11 @@ public partial class Parser
     {
         var stmts = new List<Stmt>();
         // _destN = rhs — evaluate the source exactly once; it is also the expression's result value.
+        // Carry the target pattern's shape as a contextual type so a mixed array-literal rhs infers as
+        // a tuple, not an array union — keeping nested targets (`[[m], n] = [[7], 8]`) indexable (#783).
         Token rhsTemp = GenerateTempVar(line);
-        stmts.Add(new Stmt.Var(rhsTemp, null, value));
+        TypeNode? rhsShape = Unwrap(pattern) is Expr.ArrayLiteral patternArr ? BuildArrayLiteralShape(patternArr, line) : null;
+        stmts.Add(new Stmt.Var(rhsTemp, null, value, InitializerContext: rhsShape));
         LowerAssignmentTarget(pattern, new Expr.Variable(rhsTemp), stmts, line);
         // Retain the raw (pattern, default) so this node can be re-lowered if it turns out to be a nested
         // element WITH a default (`[[a] = []]`) — see LowerElementWithDefault (#779).

--- a/SharpTS.Tests/SharedTests/DestructuringTests.cs
+++ b/SharpTS.Tests/SharedTests/DestructuringTests.cs
@@ -341,6 +341,105 @@ public class DestructuringTests
 
     #endregion
 
+    #region Nested over a mixed (non-tuple) array literal (#783)
+
+    // `[[7], 8]` infers as `(number[] | number)[]`; without contextual typing the desugared `src[0]`
+    // is a non-indexable union and the nested `[m]` pattern fails to type-check. The binding pattern's
+    // shape is threaded as a tuple context so the literal infers as `[number[], number]`.
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void NestedDestructuring_MixedArrayLiteral_Declaration(ExecutionMode mode)
+    {
+        var source = """
+            const [[m], n] = [[7], 8];
+            console.log(m);
+            console.log(n);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("7\n8\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void NestedDestructuring_MixedArrayLiteral_Assignment(ExecutionMode mode)
+    {
+        var source = """
+            let m = 0;
+            let n = 0;
+            [[m], n] = [[7], 8];
+            console.log(m);
+            console.log(n);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("7\n8\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void NestedDestructuring_MixedArrayLiteral_ExplicitTupleAnnotation(ExecutionMode mode)
+    {
+        var source = """
+            const [[m], n]: [number[], number] = [[7], 8];
+            console.log(m);
+            console.log(n);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("7\n8\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void NestedDestructuring_MixedArrayLiteral_DeepNesting(ExecutionMode mode)
+    {
+        var source = """
+            const [[[x]], y] = [[[1]], 2];
+            console.log(x);
+            console.log(y);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("1\n2\n", output);
+    }
+
+    // Bonus: a flat mixed literal source now infers element types positionally (matching tsc), so the
+    // element methods (`toFixed`/`toUpperCase`) type-check instead of reporting a spurious error.
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Destructuring_FlatMixedArrayLiteral_ElementTypesUsable(ExecutionMode mode)
+    {
+        var source = """
+            const [a, b] = [1, "two"];
+            console.log(a.toFixed(1));
+            console.log(b.toUpperCase());
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("1.0\nTWO\n", output);
+    }
+
+    // Regression guard: a UNIFORM nested literal must stay an array (`number[]`), NOT be over-tupled —
+    // `a.push(...)` would fail to type-check on a fixed-length tuple.
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void NestedDestructuring_UniformArrayLiteral_StaysArray(ExecutionMode mode)
+    {
+        var source = """
+            const [a, b] = [[1, 2], [3, 4]];
+            a.push(9);
+            console.log(a.length);
+            console.log(b[0]);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("3\n3\n", output);
+    }
+
+    #endregion
+
     #region String Rest Element (#753)
 
     // #753: a rest element over a STRING source must collect a fresh ARRAY of characters, not bind

--- a/TypeSystem/TypeChecker.Expressions.cs
+++ b/TypeSystem/TypeChecker.Expressions.cs
@@ -60,6 +60,15 @@ public partial class TypeChecker
                 _typeMap.Set(expr, tupleType);
                 return tupleType;
             }
+            // The destructuring desugarer wraps the source in `__arrayDestructure(src)` (#685). Re-thread
+            // the contextual shape to the wrapped source so a mixed array literal infers as a tuple, then
+            // normalize as the plain call branch does (#783).
+            case Expr.Call { Callee: Expr.Variable { Name.Lexeme: BuiltInNames.ArrayDestructure }, Arguments: [var src] }:
+            {
+                var sourceType = NormalizeArrayDestructureSourceType(CheckExprWithContext(src, contextualType));
+                _typeMap.Set(expr, sourceType);
+                return sourceType;
+            }
             default:
                 return CheckExpr(expr);
         }

--- a/TypeSystem/TypeChecker.Statements.cs
+++ b/TypeSystem/TypeChecker.Statements.cs
@@ -204,7 +204,11 @@ public partial class TypeChecker
                 }
                 else
                 {
-                    initializerType = CheckExprWithContext(initializer, declaredType);
+                    // An un-annotated synthetic temp may carry a contextual shape (the destructuring
+                    // binding pattern) used ONLY to guide inference — never as the binding's type and with
+                    // no compatibility check; the inferred result below is still what's kept (#783).
+                    TypeInfo? context = declaredType ?? ResolveAnnotation(null, stmt.InitializerContext);
+                    initializerType = CheckExprWithContext(initializer, context);
                 }
 
                 if (declaredType != null)


### PR DESCRIPTION
## Summary

`const [[m], n] = [[7], 8]` (and the assignment form `[[m2], n2] = [[7], 8]`, #754) was rejected by the type checker:

```
Type Error: Index type '0' is not valid for indexing all members of union type 'number[] | number'.
```

`[[7], 8]` infers as the array `(number[] | number)[]` instead of the tuple `[number[], number]`, so the destructuring desugarer's positional read `_dest[0]` is a non-indexable union and the nested `[m]` pattern fails to type-check. `tsc` avoids this by using the binding pattern as a contextual type to force tuple inference. SharpTS already had the machinery (`CheckExprWithContext` + `TryCheckArrayLiteralAsTuple`) — it was just never fed a context for destructuring sources.

## Approach (type-checker only, both modes)

Thread a synthetic **contextual shape** reconstructed from the binding pattern into the destructuring source check:

- **`Stmt.Var.InitializerContext`** — a *context-only* type that guides initializer inference but is **not** the binding's declared type (no TS2322 compatibility check, inferred type is still kept; erased at runtime).
- **`BuildArrayPatternShape` / `BuildArrayLiteralShape`** map nested-array positions to a recursive tuple and every other position (identifier/hole/nested-object) to `unknown`. Attached to the declaration temp and the #754 assignment RHS temp.
- **`VisitVar`** resolves the context for un-annotated temps; **`CheckExprWithContext`** re-threads it through the `__arrayDestructure` (#685) wrapper to the wrapped source.

### Why pattern-directed (not flat)

`unknown` leaf context never triggers tuple inference, so uniform-nested literals like `const [a, b] = [[1, 2], [3, 4]]` **stay** `number[]` (matching `tsc`; `a.push()` must still type-check). A prior flat-tuple attempt over-tupled uniform arrays and didn't fix the nested case.

**Bonus:** a flat mixed literal source now infers element types positionally — `const [a, b] = [1, "two"]` → `a: number`, `b: string` (previously a spurious error).

## Tests

+7 `DestructuringTests` (both interpreter and compiled modes): the headline declaration/assignment cases, explicit-tuple annotation, deep nesting, the flat-mixed bonus, and a regression guard that uniform-nested stays an array. Full suite green (**13,636 passed / 0 failed**).

Closes #783.