### PR TITLE
Fix #722: separate static/instance namespaces for methods and field access

### DIFF
--- a/SharpTS.Tests/SharedTests/ClassMethodNameTests.cs
+++ b/SharpTS.Tests/SharedTests/ClassMethodNameTests.cs
@@ -109,4 +109,57 @@ public class ClassMethodNameTests
     // by field openers. Methods named `get`/`set` are the practical case
     // that user code and stdlib hit (URLSearchParams etc.); fields with
     // these names are vanishingly rare.
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void StaticAndInstanceMethod_ShareName(ExecutionMode mode)
+    {
+        // Issue #722: static members live on the constructor, instance members
+        // on the prototype — same name is valid (tsc accepts it). The type
+        // checker must not flag this as duplicate implementations.
+        var source = """
+            class C {
+                run() { return "instance"; }
+                static run() { return "static"; }
+            }
+            console.log(C.run(), new C().run());
+            """;
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("static instance\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void StaticOverload_Coexists_WithInstanceMethod_SameName(ExecutionMode mode)
+    {
+        // Overload resolution must still run independently per namespace: an
+        // overloaded static `make` alongside a plain instance `make`.
+        var source = """
+            class C {
+                make(): string { return "instance"; }
+                static make(x: number): string;
+                static make(x: string): string;
+                static make(x: number | string): string { return "static:" + x; }
+            }
+            console.log(C.make(1), C.make("a"), new C().make());
+            """;
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("static:1 static:a instance\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ClassExpression_StaticAndInstanceMethod_ShareName(ExecutionMode mode)
+    {
+        // Same fix applies to class expressions (issue #722, site 3).
+        var source = """
+            const C = class {
+                run() { return "instance"; }
+                static run() { return "static"; }
+            };
+            console.log(C.run(), new C().run());
+            """;
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("static instance\n", output);
+    }
 }

--- a/SharpTS.Tests/SharedTests/StaticMethodAccessTests.cs
+++ b/SharpTS.Tests/SharedTests/StaticMethodAccessTests.cs
@@ -1,0 +1,202 @@
+using SharpTS.Tests.Infrastructure;
+using SharpTS.TypeSystem.Exceptions;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests;
+
+/// <summary>
+/// Tests that <c>private</c>/<c>protected</c> visibility is enforced for static
+/// methods accessed as <c>Class.method</c>, and that static and instance methods
+/// sharing a name keep independent access modifiers (issue #722). Static methods
+/// carry their own access map (StaticMethodAccess) distinct from instance methods,
+/// so a same-named pair no longer overwrite each other's visibility.
+/// Runs in both interpreter and compiled modes (type checking is shared).
+/// </summary>
+public class StaticMethodAccessTests
+{
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void PrivateStaticMethod_ExternalAccess_Errors(ExecutionMode mode)
+    {
+        var source = """
+            class C {
+                private static run() { return "static"; }
+            }
+            console.log(C.run());
+            """;
+        var ex = Assert.Throws<TypeCheckException>(() => TestHarness.Run(source, mode));
+        Assert.Contains("is private", ex.Message);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void PrivateStaticMethod_InternalAccess_Allowed(ExecutionMode mode)
+    {
+        var source = """
+            class C {
+                private static secret() { return "s"; }
+                static reveal() { return C.secret(); }
+            }
+            console.log(C.reveal());
+            """;
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("s\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ProtectedStaticMethod_FromSubclass_Allowed(ExecutionMode mode)
+    {
+        var source = """
+            class Base {
+                protected static make() { return "base"; }
+            }
+            class Sub extends Base {
+                static build() { return Sub.make(); }
+            }
+            console.log(Sub.build());
+            """;
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("base\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ProtectedStaticMethod_ExternalAccess_Errors(ExecutionMode mode)
+    {
+        var source = """
+            class Base {
+                protected static make() { return "base"; }
+            }
+            console.log(Base.make());
+            """;
+        var ex = Assert.Throws<TypeCheckException>(() => TestHarness.Run(source, mode));
+        Assert.Contains("is protected", ex.Message);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void PrivateInstanceMethod_NotMaskedByPublicStaticTwin(ExecutionMode mode)
+    {
+        // Issue #722 collision: a public `static run` must not overwrite the
+        // visibility of a same-named private instance `run`. External instance
+        // access must still be rejected as private.
+        var source = """
+            class C {
+                private run() { return "instance"; }
+                static run() { return "static"; }
+            }
+            console.log(new C().run());
+            """;
+        var ex = Assert.Throws<TypeCheckException>(() => TestHarness.Run(source, mode));
+        Assert.Contains("is private", ex.Message);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void PublicStaticTwin_StillAccessible_WhenInstanceTwinIsPrivate(ExecutionMode mode)
+    {
+        // The mirror of the above: the public static `run` remains accessible
+        // even though the same-named instance `run` is private.
+        var source = """
+            class C {
+                private run() { return "instance"; }
+                static run() { return "static"; }
+            }
+            console.log(C.run());
+            """;
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("static\n", output);
+    }
+
+    // --- Static fields (same StaticFieldAccess treatment as static methods) ---
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void PrivateStaticField_ExternalRead_Errors(ExecutionMode mode)
+    {
+        var source = """
+            class C {
+                private static x = 1;
+            }
+            console.log(C.x);
+            """;
+        var ex = Assert.Throws<TypeCheckException>(() => TestHarness.Run(source, mode));
+        Assert.Contains("is private", ex.Message);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void PrivateStaticField_ExternalAssignment_Errors(ExecutionMode mode)
+    {
+        var source = """
+            class C {
+                private static x = 1;
+            }
+            C.x = 5;
+            """;
+        var ex = Assert.Throws<TypeCheckException>(() => TestHarness.Run(source, mode));
+        Assert.Contains("is private", ex.Message);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void PrivateStaticField_InternalRead_Allowed(ExecutionMode mode)
+    {
+        var source = """
+            class C {
+                private static x = 1;
+                static read() { return C.x; }
+            }
+            console.log(C.read());
+            """;
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("1\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ProtectedStaticField_FromSubclass_Allowed(ExecutionMode mode)
+    {
+        var source = """
+            class Base { protected static x = 9; }
+            class Sub extends Base {
+                static read() { return Sub.x; }
+            }
+            console.log(Sub.read());
+            """;
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("9\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void PrivateInstanceField_NotMaskedByPublicStaticTwin(ExecutionMode mode)
+    {
+        // Field collision mirror of issue #722: a public `static x` must not
+        // overwrite the visibility of a same-named private instance `x`.
+        var source = """
+            class C {
+                private x = 1;
+                static x = 2;
+            }
+            console.log(new C().x);
+            """;
+        var ex = Assert.Throws<TypeCheckException>(() => TestHarness.Run(source, mode));
+        Assert.Contains("is private", ex.Message);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void PublicStaticField_ExternalRead_Allowed(ExecutionMode mode)
+    {
+        var source = """
+            class C {
+                static x = 7;
+            }
+            console.log(C.x);
+            """;
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("7\n", output);
+    }
+}

--- a/TypeSystem/ClassMetadataCore.cs
+++ b/TypeSystem/ClassMetadataCore.cs
@@ -30,7 +30,9 @@ public sealed record ClassMetadataCore(
     TypeInfo? StringIndexType = null,
     TypeInfo? NumberIndexType = null,
     TypeInfo? SymbolIndexType = null,
-    int DeclarationId = 0
+    int DeclarationId = 0,
+    FrozenDictionary<string, AccessModifier>? StaticMethodAccess = null,
+    FrozenDictionary<string, AccessModifier>? StaticFieldAccess = null
 )
 {
     /// <summary>True when the class declares any index signature.</summary>
@@ -60,4 +62,22 @@ public sealed record ClassMetadataCore(
     /// <summary>Static private method types with empty dictionary fallback.</summary>
     public FrozenDictionary<string, TypeInfo> StaticPrivateMethodTypes =>
         StaticPrivateMethods ?? FrozenDictionary<string, TypeInfo>.Empty;
+
+    /// <summary>
+    /// Access modifiers for static methods, keyed by name. Kept separate from
+    /// <see cref="MethodAccess"/> (instance methods) so a static and an instance
+    /// method sharing a name don't overwrite each other's visibility (issue #722).
+    /// Empty dictionary fallback.
+    /// </summary>
+    public FrozenDictionary<string, AccessModifier> StaticMethodAccessMap =>
+        StaticMethodAccess ?? FrozenDictionary<string, AccessModifier>.Empty;
+
+    /// <summary>
+    /// Access modifiers for static fields/properties, keyed by name. Kept separate
+    /// from <see cref="FieldAccess"/> (instance fields) so a static and an instance
+    /// field sharing a name don't overwrite each other's visibility (issue #722).
+    /// Empty dictionary fallback.
+    /// </summary>
+    public FrozenDictionary<string, AccessModifier> StaticFieldAccessMap =>
+        StaticFieldAccess ?? FrozenDictionary<string, AccessModifier>.Empty;
 }

--- a/TypeSystem/TypeChecker.Compatibility.Helpers.cs
+++ b/TypeSystem/TypeChecker.Compatibility.Helpers.cs
@@ -848,8 +848,14 @@ public partial class TypeChecker
     private static FrozenDictionary<string, AccessModifier>? GetMethodAccess(TypeInfo? classType) =>
         ClassInfoAccessor.Get(classType, c => c.MethodAccess, gc => gc.MethodAccess);
 
+    private static FrozenDictionary<string, AccessModifier>? GetStaticMethodAccess(TypeInfo? classType) =>
+        ClassInfoAccessor.Get(classType, c => c.StaticMethodAccess, gc => gc.StaticMethodAccess);
+
     private static FrozenDictionary<string, AccessModifier>? GetFieldAccess(TypeInfo? classType) =>
         ClassInfoAccessor.Get(classType, c => c.FieldAccess, gc => gc.FieldAccess);
+
+    private static FrozenDictionary<string, AccessModifier>? GetStaticFieldAccess(TypeInfo? classType) =>
+        ClassInfoAccessor.Get(classType, c => c.StaticFieldAccess, gc => gc.StaticFieldAccess);
 
     private static FrozenSet<string>? GetReadonlyFields(TypeInfo? classType) =>
         ClassInfoAccessor.Get(classType, c => c.ReadonlyFields, gc => gc.ReadonlyFields);

--- a/TypeSystem/TypeChecker.Expressions.cs
+++ b/TypeSystem/TypeChecker.Expressions.cs
@@ -1931,14 +1931,14 @@ public partial class TypeChecker
                     mutableClass.StaticMethods[memberName] = computedFunc;
                 else
                     mutableClass.Methods[memberName] = computedFunc;
-                mutableClass.MethodAccess[memberName] = method.Access;
+                (method.IsStatic ? mutableClass.StaticMethodAccess : mutableClass.MethodAccess)[memberName] = method.Access;
             }
 
             // Collect method signatures (computed-key methods handled above)
-            var methodGroups = classExpr.Methods.Where(m => m.ComputedKey == null).GroupBy(m => m.Name.Lexeme).ToList();
+            var methodGroups = classExpr.Methods.Where(m => m.ComputedKey == null).GroupBy(m => (m.IsStatic, Name: m.Name.Lexeme)).ToList();
             foreach (var group in methodGroups)
             {
-                string methodName = group.Key;
+                string methodName = group.Key.Name;
                 var methods = group.ToList();
 
                 var signatures = methods.Where(m => m.Body == null && !m.IsAbstract).ToList();
@@ -1966,7 +1966,7 @@ public partial class TypeChecker
                         mutableClass.StaticMethods[methodName] = overloadedFunc;
                     else
                         mutableClass.Methods[methodName] = overloadedFunc;
-                    mutableClass.MethodAccess[methodName] = implementation.Access;
+                    (implementation.IsStatic ? mutableClass.StaticMethodAccess : mutableClass.MethodAccess)[methodName] = implementation.Access;
                 }
                 else if (implementations.Count == 1)
                 {
@@ -1976,7 +1976,7 @@ public partial class TypeChecker
                         mutableClass.StaticMethods[methodName] = funcType;
                     else
                         mutableClass.Methods[methodName] = funcType;
-                    mutableClass.MethodAccess[methodName] = method.Access;
+                    (method.IsStatic ? mutableClass.StaticMethodAccess : mutableClass.MethodAccess)[methodName] = method.Access;
                 }
                 else if (implementations.Count > 1)
                 {
@@ -1997,7 +1997,7 @@ public partial class TypeChecker
                 else
                     mutableClass.FieldTypes[fieldName] = fieldType;
 
-                mutableClass.FieldAccess[fieldName] = field.Access;
+                (field.IsStatic ? mutableClass.StaticFieldAccess : mutableClass.FieldAccess)[fieldName] = field.Access;
                 if (field.IsReadonly)
                     mutableClass.ReadonlyFields.Add(fieldName);
             }

--- a/TypeSystem/TypeChecker.Properties.Helpers.cs
+++ b/TypeSystem/TypeChecker.Properties.Helpers.cs
@@ -116,15 +116,52 @@ public partial class TypeChecker
             var staticProps = GetStaticProperties(current);
             if (staticMethods != null && staticMethods.TryGetValue(memberName.Lexeme, out var staticMethodType))
             {
+                EnforceStaticMemberAccess(current, memberName);
                 return staticMethodType;
             }
             if (staticProps != null && staticProps.TryGetValue(memberName.Lexeme, out var staticPropType))
             {
+                EnforceStaticMemberAccess(current, memberName);
                 return staticPropType;
             }
             current = GetSuperclass(current);
         }
         return new TypeInfo.Any();
+    }
+
+    /// <summary>
+    /// Enforces <c>private</c>/<c>protected</c> visibility for a static member (method or
+    /// field/property) declared on <paramref name="declaringClass"/> when accessed as
+    /// <c>Class.member</c>. Static members carry their own access maps
+    /// (<see cref="ClassMetadataCore.StaticMethodAccessMap"/> /
+    /// <see cref="ClassMetadataCore.StaticFieldAccessMap"/>), distinct from instance members,
+    /// so a same-named static/instance pair don't clobber each other's visibility (issue #722).
+    /// No-op for public members or non-class types.
+    /// </summary>
+    private void EnforceStaticMemberAccess(TypeInfo declaringClass, Token memberName)
+    {
+        AccessModifier access;
+        var staticMethodAccess = GetStaticMethodAccess(declaringClass);
+        var staticFieldAccess = GetStaticFieldAccess(declaringClass);
+        if (staticMethodAccess != null && staticMethodAccess.TryGetValue(memberName.Lexeme, out var ma))
+            access = ma;
+        else if (staticFieldAccess != null && staticFieldAccess.TryGetValue(memberName.Lexeme, out var fa))
+            access = fa;
+        else
+            return;
+        if (access == AccessModifier.Public)
+            return;
+
+        var declName = GetClassName(declaringClass);
+        if (access == AccessModifier.Private && _currentClass?.Name != declName)
+        {
+            throw new TypeCheckException($" Property '{memberName.Lexeme}' is private and only accessible within class '{declName}'.", tsCode: "TS2341");
+        }
+        var declClass = AsClass(declaringClass);
+        if (access == AccessModifier.Protected && declClass != null && !IsSubclassOf(_currentClass, declClass))
+        {
+            throw new TypeCheckException($" Property '{memberName.Lexeme}' is protected and only accessible within class '{declName}' and its subclasses.", tsCode: "TS2445");
+        }
     }
 
     /// <summary>

--- a/TypeSystem/TypeChecker.Properties.cs
+++ b/TypeSystem/TypeChecker.Properties.cs
@@ -456,6 +456,7 @@ public partial class TypeChecker
                 var staticProps = GetStaticProperties(current);
                 if (staticProps != null && staticProps.TryGetValue(set.Name.Lexeme, out var staticPropType))
                 {
+                    EnforceStaticMemberAccess(current, set.Name);
                     TypeInfo valueType = CheckExpr(set.Value);
                     if (!IsCompatible(staticPropType, valueType))
                     {
@@ -811,10 +812,12 @@ public partial class TypeChecker
                 var staticProps = GetStaticProperties(current);
                 if (staticMethods != null && staticMethods.TryGetValue(memberName.Lexeme, out var staticMethodType))
                 {
+                    EnforceStaticMemberAccess(current, memberName);
                     return staticMethodType;
                 }
                 if (staticProps != null && staticProps.TryGetValue(memberName.Lexeme, out var staticPropType))
                 {
+                    EnforceStaticMemberAccess(current, memberName);
                     return staticPropType;
                 }
                 current = GetSuperclass(current);

--- a/TypeSystem/TypeChecker.Statements.Classes.cs
+++ b/TypeSystem/TypeChecker.Statements.Classes.cs
@@ -137,16 +137,16 @@ public partial class TypeChecker
                 mutableClass.StaticMethods[memberName] = funcType;
             else
                 mutableClass.Methods[memberName] = funcType;
-            mutableClass.MethodAccess[memberName] = method.Access;
+            (method.IsStatic ? mutableClass.StaticMethodAccess : mutableClass.MethodAccess)[memberName] = method.Access;
         }
 
         // First pass: collect signatures, grouping overloads
         // Group methods by name to detect overloads (computed-key methods handled above)
-        var methodGroups = classStmt.Methods.Where(m => m.ComputedKey == null).GroupBy(m => m.Name.Lexeme).ToList();
+        var methodGroups = classStmt.Methods.Where(m => m.ComputedKey == null).GroupBy(m => (m.IsStatic, Name: m.Name.Lexeme)).ToList();
 
         foreach (var group in methodGroups)
         {
-            string methodName = group.Key;
+            string methodName = group.Key.Name;
             var methods = group.ToList();
 
             // Separate overload signatures (null body) from implementations
@@ -169,7 +169,7 @@ public partial class TypeChecker
                 else
                     mutableClass.Methods[methodName] = funcType;
 
-                mutableClass.MethodAccess[methodName] = abstractMethod.Access;
+                (abstractMethod.IsStatic ? mutableClass.StaticMethodAccess : mutableClass.MethodAccess)[methodName] = abstractMethod.Access;
                 mutableClass.AbstractMethods.Add(methodName);
                 continue;
             }
@@ -206,7 +206,7 @@ public partial class TypeChecker
                 else
                     mutableClass.Methods[methodName] = overloadedFunc;
 
-                mutableClass.MethodAccess[methodName] = implementation.Access;
+                (implementation.IsStatic ? mutableClass.StaticMethodAccess : mutableClass.MethodAccess)[methodName] = implementation.Access;
             }
             else if (implementations.Count == 1)
             {
@@ -229,7 +229,7 @@ public partial class TypeChecker
                     else
                         mutableClass.Methods[methodName] = funcType;
 
-                    mutableClass.MethodAccess[methodName] = method.Access;
+                    (method.IsStatic ? mutableClass.StaticMethodAccess : mutableClass.MethodAccess)[methodName] = method.Access;
                 }
             }
             else if (implementations.Count > 1)
@@ -271,7 +271,7 @@ public partial class TypeChecker
             }
             if (!field.IsPrivate)
             {
-                mutableClass.FieldAccess[fieldName] = field.Access;
+                (field.IsStatic ? mutableClass.StaticFieldAccess : mutableClass.FieldAccess)[fieldName] = field.Access;
             }
             if (field.IsReadonly)
             {
@@ -1129,11 +1129,11 @@ public partial class TypeChecker
 
         // Collect method signatures (all methods in declare class are treated as signatures)
         // Constructor is included as a method named "constructor"
-        var methodGroups = classStmt.Methods.GroupBy(m => m.Name.Lexeme).ToList();
+        var methodGroups = classStmt.Methods.GroupBy(m => (m.IsStatic, Name: m.Name.Lexeme)).ToList();
 
         foreach (var group in methodGroups)
         {
-            string methodName = group.Key;
+            string methodName = group.Key.Name;
             var methods = group.ToList();
 
             if (methods.Count == 1)
@@ -1147,7 +1147,7 @@ public partial class TypeChecker
                 else
                     mutableClass.Methods[methodName] = funcType;
 
-                mutableClass.MethodAccess[methodName] = method.Access;
+                (method.IsStatic ? mutableClass.StaticMethodAccess : mutableClass.MethodAccess)[methodName] = method.Access;
             }
             else
             {
@@ -1160,7 +1160,7 @@ public partial class TypeChecker
                 else
                     mutableClass.Methods[methodName] = overloadedFunc;
 
-                mutableClass.MethodAccess[methodName] = methods[0].Access;
+                (methods[0].IsStatic ? mutableClass.StaticMethodAccess : mutableClass.MethodAccess)[methodName] = methods[0].Access;
             }
         }
 
@@ -1179,7 +1179,7 @@ public partial class TypeChecker
                 mutableClass.FieldTypes[field.Name.Lexeme] = fieldType;
             }
 
-            mutableClass.FieldAccess[field.Name.Lexeme] = field.Access;
+            (field.IsStatic ? mutableClass.StaticFieldAccess : mutableClass.FieldAccess)[field.Name.Lexeme] = field.Access;
             if (field.IsReadonly)
             {
                 mutableClass.ReadonlyFields.Add(field.Name.Lexeme);

--- a/TypeSystem/TypeInfo.cs
+++ b/TypeSystem/TypeInfo.cs
@@ -255,7 +255,9 @@ public abstract record TypeInfo
         public FrozenDictionary<string, TypeInfo> StaticMethods => Core.StaticMethods;
         public FrozenDictionary<string, TypeInfo> StaticProperties => Core.StaticProperties;
         public FrozenDictionary<string, AccessModifier> MethodAccess => Core.MethodAccess;
+        public FrozenDictionary<string, AccessModifier> StaticMethodAccess => Core.StaticMethodAccessMap;
         public FrozenDictionary<string, AccessModifier> FieldAccess => Core.FieldAccess;
+        public FrozenDictionary<string, AccessModifier> StaticFieldAccess => Core.StaticFieldAccessMap;
         public FrozenSet<string> ReadonlyFields => Core.ReadonlyFields;
         public FrozenDictionary<string, TypeInfo> Getters => Core.Getters;
         public FrozenDictionary<string, TypeInfo> Setters => Core.Setters;
@@ -315,7 +317,9 @@ public abstract record TypeInfo
         public Dictionary<string, TypeInfo> StaticMethods { get; } = [];
         public Dictionary<string, TypeInfo> StaticProperties { get; } = [];
         public Dictionary<string, AccessModifier> MethodAccess { get; } = [];
+        public Dictionary<string, AccessModifier> StaticMethodAccess { get; } = [];
         public Dictionary<string, AccessModifier> FieldAccess { get; } = [];
+        public Dictionary<string, AccessModifier> StaticFieldAccess { get; } = [];
         public HashSet<string> ReadonlyFields { get; } = [];
         public Dictionary<string, TypeInfo> Getters { get; } = [];
         public Dictionary<string, TypeInfo> Setters { get; } = [];
@@ -367,7 +371,9 @@ public abstract record TypeInfo
                 StringIndexType,
                 NumberIndexType,
                 SymbolIndexType,
-                DeclarationId);
+                DeclarationId,
+                StaticMethodAccess.Count > 0 ? StaticMethodAccess.ToFrozenDictionary() : null,
+                StaticFieldAccess.Count > 0 ? StaticFieldAccess.ToFrozenDictionary() : null);
             return _frozenCore;
         }
 
@@ -1349,7 +1355,9 @@ public abstract record TypeInfo
         public FrozenDictionary<string, TypeInfo> StaticMethods => Core.StaticMethods;
         public FrozenDictionary<string, TypeInfo> StaticProperties => Core.StaticProperties;
         public FrozenDictionary<string, AccessModifier> MethodAccess => Core.MethodAccess;
+        public FrozenDictionary<string, AccessModifier> StaticMethodAccess => Core.StaticMethodAccessMap;
         public FrozenDictionary<string, AccessModifier> FieldAccess => Core.FieldAccess;
+        public FrozenDictionary<string, AccessModifier> StaticFieldAccess => Core.StaticFieldAccessMap;
         public FrozenSet<string> ReadonlyFields => Core.ReadonlyFields;
         public FrozenDictionary<string, TypeInfo> Getters => Core.Getters;
         public FrozenDictionary<string, TypeInfo> Setters => Core.Setters;


### PR DESCRIPTION
## Summary

Fixes #722. The type checker rejected a class declaring a `static` method and an instance method with the **same name** (`Multiple implementations of method '<name>' without overload signatures`, TS2393). This is valid TypeScript — static members live on the constructor, instance members on the prototype, so they occupy separate namespaces.

Root cause: methods were grouped by bare name (`GroupBy(m => m.Name.Lexeme)`), collapsing a `static run` and an instance `run` into one group. Fixed by keying the grouping on `(IsStatic, name)` at all three collection sites (class statements, `declare class`, class expressions).

## Two additional access-modifier gaps fixed

While fixing the grouping, the same name-keyed collision was found in the access-modifier maps, and a separate enforcement gap surfaced:

1. **Collision** — `MethodAccess` / `FieldAccess` were single dictionaries keyed by bare name, shared by static + instance members. A same-named static/instance pair overwrote each other's visibility (declaration-order dependent), e.g. a public `static run` silently suppressed the privacy of a `private run` instance method.
2. **Missing enforcement** — `private static` / `protected static` methods and fields were **not enforced at all** on the static member-access path (`C.x` / `C.x = …`).

Fix: dedicated `StaticMethodAccess` and `StaticFieldAccess` maps (mirrored through `ClassMetadataCore`, `MutableClass`, `Class`, `GenericClass`), with static member writes routed to them and visibility enforced on static **read** and **assignment** via a shared `EnforceStaticMemberAccess` helper.

As a side benefit, instance nominal-branding and structural compatibility are no longer contaminated by static-member visibility (a `private static`-only class no longer falsely brands its instance type), matching `tsc`.

## Tests

- `ClassMethodNameTests`: static/instance same-name grouping, including an overloaded-static-alongside-instance case and a class-expression variant.
- `StaticMethodAccessTests` (new): private/protected static **method** and **field** enforcement on read and assignment, internal/subclass-allowed cases, the instance/static collision in both directions, and public-access sanity.
- All shared tests run in **both interpreter and compiled** modes.

Verification: `Class|Static|Access|Nominal|Compat|Assign|Field` suites pass (2106). Full suite shows only the pre-existing known-stale Test262 baselines and run-to-run Compiled-mode flakes (different tests each run, all passing in isolation) — none related to this change.

## Out of scope (noted for follow-up)

`readonly static` write protection (TS2540) is orthogonal to visibility and not addressed here.