### PR TITLE
Fix #767: rename closure-captured block-scope shadows in compiled generators/async-gens

### DIFF
--- a/Compilation/AsyncArrowMoveNextEmitter.ArrowFunctions.cs
+++ b/Compilation/AsyncArrowMoveNextEmitter.ArrowFunctions.cs
@@ -71,7 +71,8 @@ public partial class AsyncArrowMoveNextEmitter
             if (_ctx.CellBindingLocals.TryGetValue(capturedVar, out var cellLocal))
                 _il.Emit(OpCodes.Ldloc, cellLocal);
             else
-                LoadVariableForCapture(capturedVar);
+                // #767: pivot a captured nested-block shadow to its renamed storage (identity otherwise).
+                LoadVariableForCapture(PivotCaptureSource(_analysis.BlockScopeCaptureRenames, af, capturedVar));
 
             _il.Emit(OpCodes.Stfld, field);
         }

--- a/Compilation/AsyncGeneratorMoveNextEmitter.Expressions.cs
+++ b/Compilation/AsyncGeneratorMoveNextEmitter.Expressions.cs
@@ -722,7 +722,10 @@ public partial class AsyncGeneratorMoveNextEmitter
                 continue;
             }
 
-            var hoistedField = _builder.GetVariableField(capturedVar);
+            // #767: pivot a captured nested-block shadow to its renamed storage (identity otherwise).
+            var sourceVar = PivotCaptureSource(_analysis.BlockScopeCaptureRenames, af, capturedVar);
+
+            var hoistedField = _builder.GetVariableField(sourceVar);
             if (hoistedField != null)
             {
                 _il.Emit(OpCodes.Ldarg_0);
@@ -733,7 +736,7 @@ public partial class AsyncGeneratorMoveNextEmitter
                 _il.Emit(OpCodes.Ldarg_0);
                 _il.Emit(OpCodes.Ldfld, _builder.ThisField);
             }
-            else if (_ctx.Locals.TryGetLocal(capturedVar, out var local))
+            else if (_ctx.Locals.TryGetLocal(sourceVar, out var local))
             {
                 _il.Emit(OpCodes.Ldloc, local);
             }

--- a/Compilation/AsyncGeneratorStateAnalyzer.cs
+++ b/Compilation/AsyncGeneratorStateAnalyzer.cs
@@ -56,7 +56,10 @@ public partial class AsyncGeneratorStateAnalyzer : AstVisitorBase
         List<Stmt.ForOf> ForOfLoopsWithSuspension,  // for...of loops containing yields/awaits that need enumerator hoisting
         // Per-binding storage names for block-scoped let/const declarations that shadow an enclosing
         // binding, keyed by declaration/reference AST node (see GeneratorBlockScopeRenamer, #766/#711).
-        IReadOnlyDictionary<object, string>? BlockScopeRenames = null
+        IReadOnlyDictionary<object, string>? BlockScopeRenames = null,
+        // Capturing-arrow node → (captured source name → renamed storage) (#767, async-gen analog).
+        // Pivots an inner arrow's captured field to a renamed shadow's storage. Null treated as empty.
+        IReadOnlyDictionary<object, IReadOnlyDictionary<string, string>>? BlockScopeCaptureRenames = null
     )
     {
         /// <summary>
@@ -110,6 +113,9 @@ public partial class AsyncGeneratorStateAnalyzer : AstVisitorBase
     // Block-scope shadow renames for this function (#766). Maps a declaration/reference AST node to the
     // disambiguated storage name its binding uses; nodes absent from the map keep their source lexeme.
     private IReadOnlyDictionary<object, string> _renames = new Dictionary<object, string>();
+    // Per-arrow capture-source pivot for renamed shadows captured by inner arrows (#767, async-gen analog).
+    private IReadOnlyDictionary<object, IReadOnlyDictionary<string, string>> _captureRenames =
+        new Dictionary<object, IReadOnlyDictionary<string, string>>();
 
     /// <summary>
     /// Translates a declaration/reference node's source lexeme to its disambiguated storage name (#766),
@@ -127,7 +133,9 @@ public partial class AsyncGeneratorStateAnalyzer : AstVisitorBase
 
         // Disambiguate block-scoped let/const declarations that shadow an enclosing binding so the
         // hoisting decision below is made per-binding rather than per-name (#766, async analog of #711).
-        _renames = GeneratorBlockScopeRenamer.Compute(func);
+        var renameResult = GeneratorBlockScopeRenamer.Compute(func);
+        _renames = renameResult.Renames;
+        _captureRenames = renameResult.CaptureRenames;
 
         // Collect parameters as variables that need hoisting
         HashSet<string> parameters = [];
@@ -166,7 +174,8 @@ public partial class AsyncGeneratorStateAnalyzer : AstVisitorBase
             HasTryCatch: _hasTryCatch,
             TryBlocks: tryBlocks,
             ForOfLoopsWithSuspension: [.. _forOfLoopsWithSuspension],
-            BlockScopeRenames: _renames
+            BlockScopeRenames: _renames,
+            BlockScopeCaptureRenames: _captureRenames
         );
     }
 

--- a/Compilation/AsyncMoveNextEmitter.ArrowFunctions.cs
+++ b/Compilation/AsyncMoveNextEmitter.ArrowFunctions.cs
@@ -111,7 +111,10 @@ public partial class AsyncMoveNextEmitter
                 continue;
             }
 
-            var hoistedField = _builder.GetVariableField(capturedVar);
+            // #767: pivot a captured nested-block shadow to its renamed storage (identity otherwise).
+            var sourceVar = PivotCaptureSource(_analysis.BlockScopeCaptureRenames, af, capturedVar);
+
+            var hoistedField = _builder.GetVariableField(sourceVar);
             if (hoistedField != null)
             {
                 _il.Emit(OpCodes.Ldarg_0);
@@ -122,7 +125,7 @@ public partial class AsyncMoveNextEmitter
                 _il.Emit(OpCodes.Ldarg_0);
                 _il.Emit(OpCodes.Ldfld, _builder.ThisField);
             }
-            else if (_ctx.Locals.TryGetLocal(capturedVar, out var local))
+            else if (_ctx.Locals.TryGetLocal(sourceVar, out var local))
             {
                 _il.Emit(OpCodes.Ldloc, local);
             }

--- a/Compilation/AsyncStateAnalyzer.cs
+++ b/Compilation/AsyncStateAnalyzer.cs
@@ -59,7 +59,10 @@ public partial class AsyncStateAnalyzer : AstVisitorBase
         // Per-binding storage names for block-scoped let/const declarations that shadow an enclosing
         // binding, keyed by declaration/reference AST node (see GeneratorBlockScopeRenamer, #766/#711).
         // Null for analyses built without the renamer (e.g. async arrows); treated as empty.
-        IReadOnlyDictionary<object, string>? BlockScopeRenames = null
+        IReadOnlyDictionary<object, string>? BlockScopeRenames = null,
+        // Capturing-arrow node → (captured source name → renamed storage) (#767, async analog). Pivots
+        // an inner arrow's captured field to a renamed shadow's storage. Null treated as empty.
+        IReadOnlyDictionary<object, IReadOnlyDictionary<string, string>>? BlockScopeCaptureRenames = null
     )
     {
         /// <summary>
@@ -104,6 +107,9 @@ public partial class AsyncStateAnalyzer : AstVisitorBase
     // Block-scope shadow renames for this function (#766). Maps a declaration/reference AST node to the
     // disambiguated storage name its binding uses; nodes absent from the map keep their source lexeme.
     private IReadOnlyDictionary<object, string> _renames = new Dictionary<object, string>();
+    // Per-arrow capture-source pivot for renamed shadows captured by inner arrows (#767, async analog).
+    private IReadOnlyDictionary<object, IReadOnlyDictionary<string, string>> _captureRenames =
+        new Dictionary<object, IReadOnlyDictionary<string, string>>();
 
     /// <summary>
     /// Translates a declaration/reference node's source lexeme to its disambiguated storage name (#766),
@@ -121,7 +127,12 @@ public partial class AsyncStateAnalyzer : AstVisitorBase
 
         // Disambiguate block-scoped let/const declarations that shadow an enclosing binding so the
         // hoisting decision below is made per-binding rather than per-name (#766, async analog of #711).
-        _renames = GeneratorBlockScopeRenamer.Compute(func);
+        // Async free functions lift every captured local (read or write) into a name-keyed function
+        // display class, so a read-only arrow capture cannot use the per-arrow snapshot pivot — keep
+        // such shadows off-limits (arrowReadCapturesShareStorage: true). #767.
+        var renameResult = GeneratorBlockScopeRenamer.Compute(func, arrowReadCapturesShareStorage: true);
+        _renames = renameResult.Renames;
+        _captureRenames = renameResult.CaptureRenames;
 
         // Collect parameters as variables that need hoisting
         HashSet<string> parameters = [];
@@ -160,7 +171,8 @@ public partial class AsyncStateAnalyzer : AstVisitorBase
             UsesThis: _usesThis,
             AsyncArrows: [.. _asyncArrows],
             TryBlocks: tryBlocks,
-            BlockScopeRenames: _renames
+            BlockScopeRenames: _renames,
+            BlockScopeCaptureRenames: _captureRenames
         );
     }
 

--- a/Compilation/ExpressionEmitterBase.cs
+++ b/Compilation/ExpressionEmitterBase.cs
@@ -1596,6 +1596,29 @@ public abstract partial class ExpressionEmitterBase : IEmitterContext
     /// shared GetHoistedVariableField / GetThisField hooks so a single implementation serves any
     /// emitter that uses the base <see cref="EmitArrowFunction"/>.
     /// </summary>
+    /// <summary>
+    /// Pivots the SOURCE name a capturing arrow reads its display-class field from (#767). When a
+    /// nested-block <c>let</c>/<c>const</c> that shadows an enclosing binding is renamed to its own
+    /// storage and an inner arrow captures it, the arrow's field must be populated from that storage,
+    /// not the outer same-named binding. The default is identity (no shadow); GeneratorMoveNextEmitter
+    /// overrides it. The async / async-generator / async-arrow emitters apply the same pivot inline via
+    /// <see cref="PivotCaptureSource"/> in their own capture-population loops.
+    /// </summary>
+    protected virtual string ResolveCaptureSourceName(Expr.ArrowFunction af, string capturedVar) => capturedVar;
+
+    /// <summary>
+    /// Looks up the renamed generator storage for <paramref name="capturedVar"/> as captured by
+    /// <paramref name="af"/> in <paramref name="captureRenames"/> (#767), or returns the name unchanged.
+    /// Shared by every state-machine capture-population path.
+    /// </summary>
+    protected static string PivotCaptureSource(
+        IReadOnlyDictionary<object, IReadOnlyDictionary<string, string>>? captureRenames,
+        Expr.ArrowFunction af, string capturedVar) =>
+        captureRenames != null
+        && captureRenames.TryGetValue(af, out var names)
+        && names.TryGetValue(capturedVar, out var storage)
+            ? storage : capturedVar;
+
     private void EmitCapturingArrowViaHooks(Expr.ArrowFunction af, MethodBuilder method, ConstructorBuilder displayCtor)
     {
         IL.Emit(OpCodes.Newobj, displayCtor);
@@ -1635,6 +1658,11 @@ public abstract partial class ExpressionEmitterBase : IEmitterContext
             {
                 IL.Emit(OpCodes.Dup);
 
+                // #767: a captured nested-block shadow was renamed to its own generator storage; source
+                // the field from that storage rather than the outer same-named binding. The arrow's own
+                // DC field (`field`) keeps the original name. Identity for non-shadow captures.
+                var sourceVar = ResolveCaptureSourceName(af, capturedVar);
+
                 // Per-iteration cell capture (#650): snapshot the StrongBox REFERENCE so the
                 // closure shares this iteration's cell (the cell local is repointed to a fresh
                 // box each iteration). Checked first; cell bindings are never hoisted fields.
@@ -1652,12 +1680,12 @@ public abstract partial class ExpressionEmitterBase : IEmitterContext
                     IL.Emit(OpCodes.Ldarg_0);
                     IL.Emit(OpCodes.Ldfld, thisField);
                 }
-                else if (GetHoistedVariableField(capturedVar) is FieldBuilder hoistedField)
+                else if (GetHoistedVariableField(sourceVar) is FieldBuilder hoistedField)
                 {
                     IL.Emit(OpCodes.Ldarg_0);
                     IL.Emit(OpCodes.Ldfld, hoistedField);
                 }
-                else if (Ctx.Locals.TryGetLocal(capturedVar, out var local))
+                else if (Ctx.Locals.TryGetLocal(sourceVar, out var local))
                 {
                     IL.Emit(OpCodes.Ldloc, local);
                 }

--- a/Compilation/GeneratorBlockScopeRenamer.cs
+++ b/Compilation/GeneratorBlockScopeRenamer.cs
@@ -4,6 +4,31 @@ using SharpTS.Parsing.Visitors;
 namespace SharpTS.Compilation;
 
 /// <summary>
+/// Result of <see cref="GeneratorBlockScopeRenamer.Compute(Stmt.Function)"/>: the per-binding storage
+/// renames for the state-machine body plus the per-arrow capture-source pivot (#767).
+/// </summary>
+/// <param name="Renames">
+/// Declaration/reference AST node → disambiguated storage name, for nodes in the STATE-MACHINE body
+/// (not inside a nested closure). Consumed by the analyzer (hoist decision) and the MoveNext emitter
+/// (retoken before field/local access). Empty when nothing shadows.
+/// </param>
+/// <param name="CaptureRenames">
+/// Capturing-arrow node → (captured source name → renamed generator storage). When an arrow lexically
+/// captures a shadowing block-scoped binding that <see cref="Renames"/> moved to its own storage, the
+/// arrow's display-class field must be sourced from that storage rather than the outer same-named
+/// binding. The capture-population step consults this map to pivot the SOURCE of the field (the arrow's
+/// own DC field keeps the original name). Empty unless a renamed shadow is closure-captured.
+/// </param>
+internal sealed record BlockScopeRenameResult(
+    IReadOnlyDictionary<object, string> Renames,
+    IReadOnlyDictionary<object, IReadOnlyDictionary<string, string>> CaptureRenames)
+{
+    public static readonly BlockScopeRenameResult Empty = new(
+        new Dictionary<object, string>(),
+        new Dictionary<object, IReadOnlyDictionary<string, string>>());
+}
+
+/// <summary>
 /// Computes per-binding storage names for block-scoped (<c>let</c>/<c>const</c>) declarations inside a
 /// suspension state-machine body that <em>shadow</em> an enclosing binding of the same name.
 /// </summary>
@@ -22,16 +47,24 @@ namespace SharpTS.Compilation;
 /// <see cref="GeneratorStateAnalyzer"/> and <see cref="GeneratorMoveNextEmitter"/> consult the map so the
 /// hoist-vs-local decision and the field/local access become per-binding instead of per-name.
 ///
+/// Closure interaction (#767): a shadowing binding that an inner <em>arrow</em> reads is still renamed,
+/// and the renamer additionally records, per capturing arrow, the source name → storage mapping so the
+/// capture-population step sources the arrow's field from the renamed generator storage rather than the
+/// outer same-named binding. The arrow's own display-class field keeps the original name (the arrow body
+/// is compiled in its own context and is never rewritten). Two shapes the capture pivot cannot honour
+/// stay OFF-LIMITS (left unrenamed, the conservative #711 behaviour): a binding <em>written</em> inside
+/// any closure (it flows through the name-keyed <c>$functionDC</c> path, #674/#725), and a binding read
+/// by a nested <em>non-arrow</em> function/class (it flows through the name-keyed lambda-lift path).
+///
 /// Restrictions that keep the rewrite sound:
 /// <list type="bullet">
 /// <item>Only <c>let</c>/<c>const</c> (<see cref="Stmt.Const"/>, <see cref="Stmt.Var"/> with
 /// <c>IsVar == false</c>) declarations are renamed. <c>for</c>/<c>for-of</c>/<c>for-in</c>/<c>catch</c>
 /// introduce scopes (so shadowing is detected accurately) but their loop-variable / catch-parameter
 /// bindings are left alone.</item>
-/// <item>A binding whose name is referenced by any nested closure (arrow/function/class) is left
-/// untouched: those names flow through the closure-capture machinery (keyed by name), which this pass
-/// does not rewrite, so renaming them would desync the capture (and the captured-name path shares the
-/// same field, so it is never a renamed binding).</item>
+/// <item>Declarations and references INSIDE a nested closure are never added to <see cref="Renames"/>
+/// — the closure compiles in its own context. The walk descends into arrows only to resolve which
+/// renamed generator binding each capture refers to (the <see cref="CaptureRenames"/> side-map).</item>
 /// </list>
 /// No AST node is mutated and none is created, so TypeMap / ClosureAnalyzer node identity is preserved.
 /// The walk is deterministic, so independent <see cref="GeneratorStateAnalyzer.Analyze"/> calls over the
@@ -41,31 +74,49 @@ internal sealed class GeneratorBlockScopeRenamer : AstVisitorBase
 {
     // Keyed by AST-node reference (records use value equality, so reference identity is mandatory here).
     private readonly Dictionary<object, string> _renames = new(ReferenceEqualityComparer.Instance);
+    // Capturing-arrow node → (captured source name → renamed generator storage). Reference-identity keyed.
+    private readonly Dictionary<object, Dictionary<string, string>> _captureSources = new(ReferenceEqualityComparer.Instance);
     // Scope stack of name -> storage-name (storage == name when the binding is not renamed).
     private readonly List<Dictionary<string, string>> _scopes = [];
-    private readonly HashSet<string> _closureReferenced = [];
+    // Names a closure makes off-limits to renaming (written in any closure, or read by a non-arrow
+    // function/class). See CaptureClassifier.
+    private readonly HashSet<string> _renameOffLimits = [];
     private int _counter;
+    // Depth of nested arrows currently being walked (0 == directly in the state-machine body).
+    private int _arrowDepth;
+    // The outermost arrow (directly in the state-machine body) currently being walked; captures of
+    // renamed generator bindings — at any nesting depth below it — are recorded against this arrow,
+    // because its display class is what the capture-population step populates.
+    private Expr.ArrowFunction? _currentTopArrow;
 
     /// <summary>
-    /// Returns the node→storage-name map for <paramref name="func"/>, empty when nothing shadows.
+    /// Returns the renames + capture-source pivot for <paramref name="func"/>; empty when nothing shadows.
     /// </summary>
-    public static IReadOnlyDictionary<object, string> Compute(Stmt.Function func) =>
-        Compute(func.Name.Lexeme, func.Parameters, func.Body);
+    /// <param name="arrowReadCapturesShareStorage">
+    /// When true, a binding merely READ by a nested arrow is also off-limits to renaming, because the
+    /// enclosing context lifts every captured local — read or write — into a name-keyed shared display
+    /// class (async free functions / async arrows: <c>ILCompiler.DefineFunctionDisplayClass</c>), so
+    /// renaming the body side would desync the closure's by-name read. Generators and async generators
+    /// pass false: they lift only captured-AND-mutated locals, so a read-only arrow capture flows through
+    /// the per-arrow snapshot path the capture pivot can redirect (#767).
+    /// </param>
+    public static BlockScopeRenameResult Compute(Stmt.Function func, bool arrowReadCapturesShareStorage = false) =>
+        Compute(func.Name.Lexeme, func.Parameters, func.Body, arrowReadCapturesShareStorage);
 
     /// <summary>
     /// Arrow-function overload (#766). Arrows have no self-name, and only a block body can hold
     /// block-scoped declarations (an expression-bodied arrow has none, so it has no shadows to rename).
     /// </summary>
-    public static IReadOnlyDictionary<object, string> Compute(Expr.ArrowFunction arrow) =>
-        Compute(selfName: null, arrow.Parameters, arrow.BlockBody);
+    public static BlockScopeRenameResult Compute(Expr.ArrowFunction arrow, bool arrowReadCapturesShareStorage = false) =>
+        Compute(selfName: null, arrow.Parameters, arrow.BlockBody, arrowReadCapturesShareStorage);
 
-    private static IReadOnlyDictionary<object, string> Compute(
-        string? selfName, List<Stmt.Parameter> parameters, List<Stmt>? body)
+    private static BlockScopeRenameResult Compute(
+        string? selfName, List<Stmt.Parameter> parameters, List<Stmt>? body, bool arrowReadCapturesShareStorage)
     {
         var renamer = new GeneratorBlockScopeRenamer();
-        if (body == null) return renamer._renames;   // expression-bodied arrow: nothing to rename
+        if (body == null) return BlockScopeRenameResult.Empty;   // expression-bodied arrow: nothing to rename
 
-        new ClosureReferenceCollector(renamer._closureReferenced).Run(body);
+        new CaptureClassifier(renamer._renameOffLimits, arrowReadCapturesShareStorage).Run(body);
 
         renamer.PushScope();
         // The callable's own name is in scope inside the body (a named function expression can call
@@ -80,7 +131,13 @@ internal sealed class GeneratorBlockScopeRenamer : AstVisitorBase
             renamer.Visit(stmt);
         renamer.PopScope();
 
-        return renamer._renames;
+        if (renamer._renames.Count == 0 && renamer._captureSources.Count == 0)
+            return BlockScopeRenameResult.Empty;
+
+        var captures = new Dictionary<object, IReadOnlyDictionary<string, string>>(ReferenceEqualityComparer.Instance);
+        foreach (var (arrow, names) in renamer._captureSources)
+            captures[arrow] = names;
+        return new BlockScopeRenameResult(renamer._renames, captures);
     }
 
     private Dictionary<string, string> CurrentScope => _scopes[^1];
@@ -101,12 +158,16 @@ internal sealed class GeneratorBlockScopeRenamer : AstVisitorBase
         return null;
     }
 
+    /// <summary>
+    /// Declares a state-machine-body block-scoped binding (only reached when <c>_arrowDepth == 0</c>),
+    /// renaming it to its own storage when it shadows an enclosing binding and is not off-limits.
+    /// </summary>
     private void DeclareBlockScoped(object node, string name)
     {
         // Same-scope redeclaration is a TypeScript error; keep the first binding.
         if (CurrentScope.ContainsKey(name)) return;
 
-        if (ShadowsEnclosing(name) && !_closureReferenced.Contains(name))
+        if (ShadowsEnclosing(name) && !_renameOffLimits.Contains(name))
         {
             var storage = $"<{name}>__bs{_counter++}";
             CurrentScope[name] = storage;
@@ -121,8 +182,23 @@ internal sealed class GeneratorBlockScopeRenamer : AstVisitorBase
     private void RecordRef(object node, string name)
     {
         var storage = Resolve(name);
-        if (storage != null && storage != name)
+        if (storage == null || storage == name) return;
+
+        if (_arrowDepth == 0)
+        {
+            // Reference in the state-machine body: retoken at emit so the read/write lands on the
+            // shadow's own field/local.
             _renames[node] = storage;
+        }
+        else if (_currentTopArrow != null)
+        {
+            // Reference inside a nested arrow that lexically binds to a renamed generator shadow:
+            // record the source pivot so the arrow's captured field is populated from that storage.
+            // The reference node itself is NOT renamed (the arrow body compiles in its own context).
+            if (!_captureSources.TryGetValue(_currentTopArrow, out var names))
+                _captureSources[_currentTopArrow] = names = [];
+            names[name] = storage;
+        }
     }
 
     #region Declarations
@@ -130,12 +206,22 @@ internal sealed class GeneratorBlockScopeRenamer : AstVisitorBase
     protected override void VisitConst(Stmt.Const stmt)
     {
         base.VisitConst(stmt);   // initializer is evaluated before the binding enters scope
+        if (_arrowDepth > 0)
+        {
+            CurrentScope.TryAdd(stmt.Name.Lexeme, stmt.Name.Lexeme);   // arrow-local: resolution only, never renamed
+            return;
+        }
         DeclareBlockScoped(stmt, stmt.Name.Lexeme);
     }
 
     protected override void VisitVar(Stmt.Var stmt)
     {
         base.VisitVar(stmt);
+        if (_arrowDepth > 0)
+        {
+            CurrentScope.TryAdd(stmt.Name.Lexeme, stmt.Name.Lexeme);   // arrow-local: resolution only, never renamed
+            return;
+        }
         if (stmt.IsVar)
         {
             // `var` is function-scoped: record it in the bottom scope so a later block-scoped
@@ -251,9 +337,31 @@ internal sealed class GeneratorBlockScopeRenamer : AstVisitorBase
 
     #endregion
 
-    #region Opaque nodes (own scopes, not hoisted into this generator)
+    #region Nested closures
 
-    protected override void VisitArrowFunction(Expr.ArrowFunction expr) { }
+    /// <summary>
+    /// Descends into a nested arrow with its own scope so a reference inside it that lexically binds to
+    /// a renamed generator shadow is recorded as a capture-source pivot (#767). Declarations inside the
+    /// arrow are the arrow's own bindings (resolution only, never renamed). The arrow's body compiles in
+    /// its own context, so no reference node inside it is added to <see cref="_renames"/>.
+    /// </summary>
+    protected override void VisitArrowFunction(Expr.ArrowFunction expr)
+    {
+        bool isTop = _arrowDepth == 0;
+        if (isTop) _currentTopArrow = expr;
+        _arrowDepth++;
+        PushScope();
+        foreach (var p in expr.Parameters)
+            CurrentScope[p.Name.Lexeme] = p.Name.Lexeme;   // arrow params shadow but are the arrow's own
+        base.VisitArrowFunction(expr);   // default traversal: param defaults + expression/block body
+        PopScope();
+        _arrowDepth--;
+        if (isTop) _currentTopArrow = null;
+    }
+
+    // Non-arrow functions and classes rebind/lift their captures through name-keyed machinery the
+    // capture pivot does not cover, so a binding they read is already OFF-LIMITS (CaptureClassifier).
+    // Their interiors contribute no renames or pivots; do not descend.
     protected override void VisitFunction(Stmt.Function stmt) { }
     protected override void VisitClass(Stmt.Class stmt) { }
     protected override void VisitClassExpr(Expr.ClassExpr expr) { }
@@ -261,30 +369,87 @@ internal sealed class GeneratorBlockScopeRenamer : AstVisitorBase
     #endregion
 
     /// <summary>
-    /// Collects every variable name referenced anywhere inside a nested closure (arrow / function /
-    /// class) of the generator body. Names in this set are off-limits to renaming because the closure
-    /// capture machinery keys them by source name and this pass does not rewrite closure interiors.
+    /// Classifies which names are off-limits to renaming because a nested closure flows them through
+    /// name-keyed machinery the capture pivot cannot honour: a name WRITTEN inside any closure (the
+    /// <c>$functionDC</c> shared-storage path, #674/#725) or a name READ inside a non-arrow function /
+    /// class (the lambda-lift path). A name only READ inside an arrow stays renameable — the renamer
+    /// pivots that arrow's capture source to the renamed storage (#767).
     /// </summary>
-    private sealed class ClosureReferenceCollector : AstVisitorBase
+    private sealed class CaptureClassifier : AstVisitorBase
     {
-        private readonly HashSet<string> _names;
-        private int _depth;
+        private readonly HashSet<string> _offLimits;
+        // True when even a read by an arrow shares name-keyed storage (async functions / arrows).
+        private readonly bool _arrowReadsOffLimits;
+        private int _closureDepth;   // inside any closure (arrow / function / class)
+        private int _nonArrowDepth;  // inside a function / class (not an arrow)
 
-        public ClosureReferenceCollector(HashSet<string> names) => _names = names;
+        public CaptureClassifier(HashSet<string> offLimits, bool arrowReadsOffLimits)
+        {
+            _offLimits = offLimits;
+            _arrowReadsOffLimits = arrowReadsOffLimits;
+        }
 
         public void Run(List<Stmt> body)
         {
             foreach (var s in body) Visit(s);
         }
 
-        protected override void VisitArrowFunction(Expr.ArrowFunction expr) { _depth++; base.VisitArrowFunction(expr); _depth--; }
-        protected override void VisitFunction(Stmt.Function stmt) { _depth++; base.VisitFunction(stmt); _depth--; }
-        protected override void VisitClass(Stmt.Class stmt) { _depth++; base.VisitClass(stmt); _depth--; }
-        protected override void VisitClassExpr(Expr.ClassExpr expr) { _depth++; base.VisitClassExpr(expr); _depth--; }
+        protected override void VisitArrowFunction(Expr.ArrowFunction expr)
+        {
+            _closureDepth++;
+            base.VisitArrowFunction(expr);
+            _closureDepth--;
+        }
 
-        protected override void VisitVariable(Expr.Variable expr) { if (_depth > 0) _names.Add(expr.Name.Lexeme); }
-        protected override void VisitAssign(Expr.Assign expr) { if (_depth > 0) _names.Add(expr.Name.Lexeme); base.VisitAssign(expr); }
-        protected override void VisitCompoundAssign(Expr.CompoundAssign expr) { if (_depth > 0) _names.Add(expr.Name.Lexeme); base.VisitCompoundAssign(expr); }
-        protected override void VisitLogicalAssign(Expr.LogicalAssign expr) { if (_depth > 0) _names.Add(expr.Name.Lexeme); base.VisitLogicalAssign(expr); }
+        protected override void VisitFunction(Stmt.Function stmt) { Enter(); base.VisitFunction(stmt); Exit(); }
+        protected override void VisitClass(Stmt.Class stmt) { Enter(); base.VisitClass(stmt); Exit(); }
+        protected override void VisitClassExpr(Expr.ClassExpr expr) { Enter(); base.VisitClassExpr(expr); Exit(); }
+
+        private void Enter() { _closureDepth++; _nonArrowDepth++; }
+        private void Exit() { _closureDepth--; _nonArrowDepth--; }
+
+        // Reads referenced by a non-arrow closure are off-limits (lambda-lift keys by name). Reads by an
+        // arrow are off-limits only when the enclosing context shares read captures by name (async).
+        protected override void VisitVariable(Expr.Variable expr)
+        {
+            if (_nonArrowDepth > 0 || (_arrowReadsOffLimits && _closureDepth > 0))
+                _offLimits.Add(expr.Name.Lexeme);
+        }
+
+        // Writes inside ANY closure are off-limits (captured-and-mutated → $functionDC, keyed by name).
+        protected override void VisitAssign(Expr.Assign expr)
+        {
+            MarkWrite(expr.Name.Lexeme);
+            base.VisitAssign(expr);
+        }
+
+        protected override void VisitCompoundAssign(Expr.CompoundAssign expr)
+        {
+            MarkWrite(expr.Name.Lexeme);
+            base.VisitCompoundAssign(expr);
+        }
+
+        protected override void VisitLogicalAssign(Expr.LogicalAssign expr)
+        {
+            MarkWrite(expr.Name.Lexeme);
+            base.VisitLogicalAssign(expr);
+        }
+
+        protected override void VisitPrefixIncrement(Expr.PrefixIncrement expr)
+        {
+            if (expr.Operand is Expr.Variable v) MarkWrite(v.Name.Lexeme);
+            base.VisitPrefixIncrement(expr);
+        }
+
+        protected override void VisitPostfixIncrement(Expr.PostfixIncrement expr)
+        {
+            if (expr.Operand is Expr.Variable v) MarkWrite(v.Name.Lexeme);
+            base.VisitPostfixIncrement(expr);
+        }
+
+        private void MarkWrite(string name)
+        {
+            if (_closureDepth > 0) _offLimits.Add(name);
+        }
     }
 }

--- a/Compilation/GeneratorMoveNextEmitter.Variables.cs
+++ b/Compilation/GeneratorMoveNextEmitter.Variables.cs
@@ -11,6 +11,12 @@ public partial class GeneratorMoveNextEmitter
 
     private static Token RenameToken(Token original, string lexeme) =>
         new(original.Type, lexeme, original.Literal, original.Line, original.Start);
+
+    // #767: a nested-block shadow captured (read-only) by an inner arrow is renamed to its own storage;
+    // pivot the arrow's capture SOURCE to that storage so it reads the shadow's value, not the outer
+    // same-named binding's hoisted field. The base EmitCapturingArrowViaHooks consults this.
+    protected override string ResolveCaptureSourceName(Expr.ArrowFunction af, string capturedVar) =>
+        PivotCaptureSource(_analysis.BlockScopeCaptureRenames, af, capturedVar);
     // Expose the state machine's function display class field to the base arrow emitter so a
     // capturing arrow inside the generator body gets its $functionDC threaded in (#674).
     protected override FieldBuilder? GetFunctionDCField() => _builder.FunctionDCField;

--- a/Compilation/GeneratorStateAnalyzer.cs
+++ b/Compilation/GeneratorStateAnalyzer.cs
@@ -33,7 +33,12 @@ public class GeneratorStateAnalyzer : AstVisitorBase
         // Per-binding storage names for block-scoped let/const declarations that shadow an enclosing
         // binding, keyed by declaration/reference AST node (see GeneratorBlockScopeRenamer, #711). The
         // emitter consults the same map so each shadowing binding gets its own field/local.
-        IReadOnlyDictionary<object, string> BlockScopeRenames
+        IReadOnlyDictionary<object, string> BlockScopeRenames,
+        // Capturing-arrow node → (captured source name → renamed generator storage) (#767). When a
+        // shadowing binding that was renamed above is captured by an inner arrow, the arrow's field is
+        // sourced from the renamed storage instead of the outer same-named binding. Empty in the common
+        // case; null is treated as empty by the emitter.
+        IReadOnlyDictionary<object, IReadOnlyDictionary<string, string>>? BlockScopeCaptureRenames = null
     );
 
     // State during analysis
@@ -56,6 +61,9 @@ public class GeneratorStateAnalyzer : AstVisitorBase
     // Block-scope shadow renames for this function (#711). Maps a declaration/reference AST node to
     // the disambiguated storage name its binding uses; nodes absent from the map keep their lexeme.
     private IReadOnlyDictionary<object, string> _renames = new Dictionary<object, string>();
+    // Per-arrow capture-source pivot for renamed shadows captured by inner arrows (#767).
+    private IReadOnlyDictionary<object, IReadOnlyDictionary<string, string>> _captureRenames =
+        new Dictionary<object, IReadOnlyDictionary<string, string>>();
 
     /// <summary>
     /// Analyzes a generator function to determine yield points and hoisted variables.
@@ -66,7 +74,9 @@ public class GeneratorStateAnalyzer : AstVisitorBase
 
         // Disambiguate block-scoped let/const declarations that shadow an enclosing binding so the
         // hoisting decision below is made per-binding rather than per-name (#711).
-        _renames = GeneratorBlockScopeRenamer.Compute(func);
+        var renameResult = GeneratorBlockScopeRenamer.Compute(func);
+        _renames = renameResult.Renames;
+        _captureRenames = renameResult.CaptureRenames;
 
         // Collect parameters as variables that need hoisting
         HashSet<string> parameters = [];
@@ -106,7 +116,8 @@ public class GeneratorStateAnalyzer : AstVisitorBase
             HasYieldStar: _hasYieldStar,
             ForOfLoopsWithYield: [.. _forOfLoopsWithYield],
             ForInLoopsWithYield: [.. _forInLoopsWithYield],
-            BlockScopeRenames: _renames
+            BlockScopeRenames: _renames,
+            BlockScopeCaptureRenames: _captureRenames
         );
     }
 

--- a/Compilation/ILCompiler.Async.cs
+++ b/Compilation/ILCompiler.Async.cs
@@ -281,19 +281,26 @@ public partial class ILCompiler
     // nested arrow is a separate AnalyzeAsyncArrow pass — the Expr.ArrowFunction walker case is a no-op,
     // so this field is never clobbered mid-walk). Mirrors the renamer wiring in the visitor analyzers.
     private IReadOnlyDictionary<object, string> _arrowBlockScopeRenames = new Dictionary<object, string>();
+    private IReadOnlyDictionary<object, IReadOnlyDictionary<string, string>> _arrowBlockScopeCaptureRenames =
+        new Dictionary<object, IReadOnlyDictionary<string, string>>();
 
     /// <summary>Storage name for an async-arrow declaration/reference node (#766), or the lexeme unchanged.</summary>
     private string ArrowStorageName(object node, string lexeme) =>
         _arrowBlockScopeRenames.TryGetValue(node, out var renamed) ? renamed : lexeme;
 
-    private (int AwaitCount, HashSet<string> HoistedLocals, IReadOnlyDictionary<object, string> Renames) AnalyzeAsyncArrow(Expr.ArrowFunction arrow)
+    private (int AwaitCount, HashSet<string> HoistedLocals, IReadOnlyDictionary<object, string> Renames,
+        IReadOnlyDictionary<object, IReadOnlyDictionary<string, string>> CaptureRenames) AnalyzeAsyncArrow(Expr.ArrowFunction arrow)
     {
         var awaitCount = 0;
         var seenAwait = false;
 
         // Disambiguate nested-block let/const shadows so the hoisting decision below is per-binding
         // rather than per-name (#766, async analog of #711).
-        _arrowBlockScopeRenames = GeneratorBlockScopeRenamer.Compute(arrow);
+        // An async arrow likewise shares its captures by name with inner closures, so keep read-only
+        // captured shadows off-limits (arrowReadCapturesShareStorage: true). #767.
+        var renameResult = GeneratorBlockScopeRenamer.Compute(arrow, arrowReadCapturesShareStorage: true);
+        _arrowBlockScopeRenames = renameResult.Renames;
+        _arrowBlockScopeCaptureRenames = renameResult.CaptureRenames;
 
         // Clear and reuse pooled HashSets
         _async.DeclaredVars.Clear();
@@ -332,7 +339,7 @@ public partial class ILCompiler
         foreach (var param in arrow.Parameters)
             hoistedLocals.Remove(param.Name.Lexeme);
 
-        return (awaitCount, hoistedLocals, _arrowBlockScopeRenames);
+        return (awaitCount, hoistedLocals, _arrowBlockScopeRenames, _arrowBlockScopeCaptureRenames);
     }
 
     private void AnalyzeArrowStmtForAwaits(Stmt stmt, ref int awaitCount, ref bool seenAwait,
@@ -710,7 +717,10 @@ public partial class ILCompiler
             [], // No nested async arrows handled yet
             // #766: carry the block-scope shadow renames so the arrow emitter routes a shadowing
             // nested-block let/const to its own storage instead of the outer binding's hoisted field.
-            BlockScopeRenames: arrowAnalysis.Renames
+            BlockScopeRenames: arrowAnalysis.Renames,
+            // #767: carry the capture-source pivot so a renamed shadow captured by a nested arrow is
+            // sourced from its own storage.
+            BlockScopeCaptureRenames: arrowAnalysis.CaptureRenames
         );
 
         // Create a new context for arrow MoveNext emission
@@ -1209,7 +1219,9 @@ public partial class ILCompiler
                 false, // UsesThis - standalone arrows don't have 'this' binding by default
                 [],    // No nested async arrows handled in this pass
                 // #766: carry the block-scope shadow renames into the standalone arrow emitter too.
-                BlockScopeRenames: arrowAnalysis.Renames
+                BlockScopeRenames: arrowAnalysis.Renames,
+                // #767: carry the capture-source pivot into the standalone arrow emitter too.
+                BlockScopeCaptureRenames: arrowAnalysis.CaptureRenames
             );
 
             // Determine if this arrow is inside a class (for private field access)

--- a/SharpTS.Tests/Compilation/EmitterSyncTests.cs
+++ b/SharpTS.Tests/Compilation/EmitterSyncTests.cs
@@ -120,6 +120,7 @@ public class EmitterSyncTests
             "GetThisField",
             "GetHoistedVariableField",
             "GetFunctionDCField",   // #674: exposes <>__functionDC so the base arrow emitter threads it in
+            "ResolveCaptureSourceName", // #767: pivot a captured nested-block shadow's source to its renamed storage
             // --- Genuinely different behavior ---
             "EmitReturn",           // Generator return: set state -2, return false
             "EmitTryCatch",         // Generator exception handling

--- a/SharpTS.Tests/SharedTests/AsyncBlockScopeShadowTests.cs
+++ b/SharpTS.Tests/SharedTests/AsyncBlockScopeShadowTests.cs
@@ -223,5 +223,73 @@ public class AsyncBlockScopeShadowTests
         Assert.Equal("5,9\n", TestHarness.Run(source, mode));
     }
 
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AsyncGenerator_NestedBlockShadow_CapturedByArrow_DoesNotLeak(ExecutionMode mode)
+    {
+        // An inner block const that shadows an outer binding AND is read by a nested arrow gets its own
+        // slot; the arrow reads the inner value while the outer keeps its own (#767, async-gen analog).
+        // Async generators lift only captured-AND-mutated locals into the function DC, so the read-only
+        // arrow capture flows through the per-arrow snapshot path the capture pivot redirects.
+        var source = """
+            async function* ag(): AsyncGenerator<number> {
+              const r = 100;
+              {
+                const r = 7;
+                const f = () => r;
+                await Promise.resolve(0);
+                yield f();
+              }
+              yield r;
+            }
+            async function main() {
+              const g = ag();
+              let x = await g.next();
+              let y = await g.next();
+              console.log(x.value + "," + y.value);
+            }
+            main();
+            """;
+
+        Assert.Equal("7,100\n", TestHarness.Run(source, mode));
+    }
+
+    #endregion
+
+    #region Known residual: async-function read-capture of a shadow shares name-keyed storage (#767)
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AsyncFunction_NestedBlockShadow_CapturedByArrow_Interpreted(ExecutionMode mode)
+    {
+        // Interpreter is correct in both directions and is the reference. Compiled async FUNCTIONS lift
+        // EVERY captured local (read or write) into a name-keyed function display class, so a read-only
+        // arrow capture of a renamed shadow cannot use the per-arrow snapshot pivot that fixes #767 for
+        // (async) generators. Such shadows are therefore kept OFF-LIMITS to renaming in async-function /
+        // async-arrow contexts (no regression from the prior #766 behaviour); a full fix needs the
+        // function DC itself to become rename-aware. This test pins the interpreter contract; the
+        // compiled async-function residual is tracked separately.
+        if (mode == ExecutionMode.Compiled) return;
+
+        var source = """
+            async function af(): Promise<string> {
+              const out: string[] = [];
+              const r = 100;
+              {
+                const r = 5;
+                const f = () => r;
+                await Promise.resolve(0);
+                out.push(String(f()));
+              }
+              out.push(String(r));
+              return out.join(",");
+            }
+            async function main() { console.log(await af()); }
+            main();
+            """;
+
+        Assert.Equal("5,100\n", TestHarness.Run(source, mode));
+    }
+
     #endregion
 }

--- a/SharpTS.Tests/SharedTests/GeneratorTests.cs
+++ b/SharpTS.Tests/SharedTests/GeneratorTests.cs
@@ -2221,6 +2221,74 @@ public class GeneratorTests
         Assert.Equal("[1, 2]\n", TestHarness.Run(source, mode));
     }
 
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Generator_NestedBlockShadow_CapturedByArrow_DoesNotLeak(ExecutionMode mode)
+    {
+        // An inner block const that shadows an outer body-level const AND is read by a nested arrow
+        // must get its own slot; the arrow reads the inner value while the outer binding keeps its own
+        // (#767, the residual closure-capture case left open by #711). Compiled previously yielded
+        // [5, 5] because the inner binding was left un-renamed to avoid desyncing the name-keyed capture.
+        var source = """
+            function* g(): Generator<number> {
+              const r = 100;
+              {
+                const r = 5;
+                const f = () => r;
+                yield f();
+              }
+              yield r;
+            }
+            console.log([...g()]);
+            """;
+
+        Assert.Equal("[5, 100]\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Generator_OuterBindingCapturedByArrow_StaysCorrect(ExecutionMode mode)
+    {
+        // The arrow captures the OUTER binding (declared before the shadowing block); the inner shadow
+        // is renamed but the capture must still resolve to the un-renamed outer storage (#767 soundness:
+        // pivoting only fires for captures that bind to a renamed shadow).
+        var source = """
+            function* g(): Generator<number> {
+              const r = 100;
+              const cap = () => r;
+              { const r = 5; yield r; }
+              yield cap();
+            }
+            console.log([...g()]);
+            """;
+
+        Assert.Equal("[5, 100]\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Generator_TwoArrows_CaptureInnerAndOuterShadows(ExecutionMode mode)
+    {
+        // Two arrows in distinct scopes each capture a different binding of the same name. Each arrow's
+        // captured field must be sourced from the binding it lexically refers to (#767, per-arrow pivot).
+        var source = """
+            function* g(): Generator<number> {
+              const r = 1;
+              const outer = () => r;
+              {
+                const r = 2;
+                const inner = () => r;
+                yield inner();
+                yield outer();
+              }
+              yield r;
+            }
+            console.log([...g()]);
+            """;
+
+        Assert.Equal("[2, 1, 1]\n", TestHarness.Run(source, mode));
+    }
+
     #endregion
 
     #region Optional-chain string-method yield short-circuit parity (#709)


### PR DESCRIPTION
Fixes #767 (for sync generators and async generators).

## Problem

A nested-block `let`/`const` that shadows an enclosing binding **and** is read by a nested arrow leaked the outer value in compiled state machines. The #711 renamer left any closure-referenced name un-renamed (the capture machinery is name-keyed), so the inner and outer binding collided on one slot:

```ts
function* g(): Generator<number> {
  const r = 100;
  { const r = 5; const f = () => r; yield f(); }
  yield r;
}
[...g()]  // compiled [5,5]  →  now [5,100]  (interpreter was always [5,100])
```

## Fix

`GeneratorBlockScopeRenamer` is now **scope-aware**: it descends into arrows to resolve which renamed generator binding each capture refers to, renames the inner shadow, and records a per-arrow **capture-source side-map** (`arrow → {capturedName → renamed storage}`). `Compute` returns a new `BlockScopeRenameResult` carrying both maps.

The state-machine capture-population paths source the arrow's field from the renamed storage while the arrow's own display-class field keeps the original name (the arrow body compiles in its own context and is never rewritten — no closure-interior nodes enter the rename map). The pivot seam is a base virtual `ResolveCaptureSourceName` + static `PivotCaptureSource` on `ExpressionEmitterBase`, used in `EmitCapturingArrowViaHooks`; `GeneratorMoveNextEmitter` overrides it (one EmitterSync allowlist entry) and the three async emitters apply `PivotCaptureSource` inline in their private capture loops (no overrides → no allowlist churn).

## Scope (important)

Only the **snapshot-path** modes are fixed: generators (#674) and async generators (#725) lift only *captured-and-mutated* locals into the function display class, so a read-only arrow capture flows through the per-arrow snapshot path the pivot can redirect.

**Async functions and async arrows** lift *every* captured local (read or write) into a **name-keyed** function display class, so a read-only capture there reads `functionDC.r` by name and bypasses the pivot. Those contexts pass `arrowReadCapturesShareStorage: true` to stay **conservative — identical to the prior #766 behaviour, no regression**. Filed as follow-ups:

- #837 — rename-aware async function DC (read captures)
- #838 — per-binding function DC for write-captured shadows (all modes; subsumes #837)

Both are low-priority / astronomically rare and have no TypeScript conformance impact (TSConformance is type-checker only; the interpreter already handles these). See the issues for details.

## Tests / verification

- Exact #767 repro correct in interpreter **and** `--compile --verify` (IL verification passes).
- +6 tests: generator capture / outer-binding / two-arrows (`GeneratorTests`); async-gen capture + async-fn interpreter contract (`AsyncBlockScopeShadowTests`).
- EmitterSync allowlist updated (`GeneratorMoveNextEmitter.ResolveCaptureSourceName`).
- Green: Generator 408, AsyncGenerator 129, Closure 74, Async fn/arrow 280, PerIteration/NumberLocalCapture/FunctionShadowing/GeneratorExpression 131, EmitterSync.