### PR TITLE
Fix #449: instanceof Symbol for bare symbols and Object(sym) wrappers

### DIFF
--- a/Compilation/RuntimeEmitter.CoreUtilities.cs
+++ b/Compilation/RuntimeEmitter.CoreUtilities.cs
@@ -3764,6 +3764,11 @@ public partial class RuntimeEmitter
         CheckBoxed(_types.Boolean, "Boolean");
         CheckBoxed(_types.Double,  "Number");
         CheckBoxed(_types.String,  "String");
+        // Symbol lowers to the $TSSymbol Type token, so a bare $TSSymbol would
+        // otherwise reach the IsAssignableFrom($TSSymbol, $TSSymbol) fallback and
+        // wrongly match. Terminal like the wrappers above: true iff `instance` is
+        // a boxed Symbol wrapper (`Object(sym)`), false for a bare symbol (#449).
+        CheckBoxed(runtime.TSSymbolType, "Symbol");
 
         // `x instanceof Promise`: the Promise identifier resolves to
         // typeof(Task<object?>), but $Promise instances (and #242 Promise

--- a/Execution/Interpreter.Calls.cs
+++ b/Execution/Interpreter.Calls.cs
@@ -779,6 +779,10 @@ public partial class Interpreter
                 // constructor) — brand-check the runtime instance type (#246).
                 "AbortSignal" => left is SharpTSAbortSignal,
                 "AbortController" => left is SharpTSAbortController,
+                // A boxed Symbol wrapper (`Object(sym)`) carries the __primitiveType
+                // marker; a bare SharpTSSymbol is not a SharpTSObject so stays false,
+                // per ECMA-262 OrdinaryHasInstance (#449).
+                "Symbol" => IsBoxedPrimitiveOfType(left, "Symbol"),
                 _ => false
             };
         }

--- a/Runtime/Types/SharpTSObjectNamespace.cs
+++ b/Runtime/Types/SharpTSObjectNamespace.cs
@@ -26,6 +26,15 @@ public class SharpTSObjectNamespace : ISharpTSCallable
         var value = arguments[0];
         if (value == null || value is SharpTSUndefined)
             return new SharpTSObject(new Dictionary<string, object?>());
+        // Symbol → boxed wrapper carrying the __primitiveType marker, matching the
+        // compiled NewBoxedPrimitive("Symbol", …) shape so `Object(sym) instanceof
+        // Symbol` is true (ECMA-262 §7.1.18 ToObject on a Symbol, #449).
+        if (value is SharpTSSymbol)
+            return new SharpTSObject(new Dictionary<string, object?>
+            {
+                ["__primitiveType"] = "Symbol",
+                ["__primitiveValue"] = value,
+            });
         // Primitives (string/number/bool) — wrap in a plain object holding the primitive.
         // Good enough for lodash's use case where the wrapper is iterated over, not read.
         // A fuller implementation would materialize String/Number/Boolean wrapper objects.

--- a/SharpTS.Tests/SharedTests/PrimitiveWrapperTests.cs
+++ b/SharpTS.Tests/SharedTests/PrimitiveWrapperTests.cs
@@ -117,6 +117,26 @@ public class PrimitiveWrapperTests
         Assert.Equal("false\n", output);
     }
 
+    // ── Symbol: bare not an instance, Object(sym) wrapper is (#449) ───────────
+    // Symbol has no `new` form, so its only boxed form is `Object(Symbol())`.
+    // A bare symbol primitive is NOT an instance; the boxed wrapper IS.
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Symbol_Bare_NotInstanceofSymbol(ExecutionMode mode)
+    {
+        var output = TestHarness.Run("console.log((Symbol('s') as any) instanceof Symbol);", mode);
+        Assert.Equal("false\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Symbol_Boxed_InstanceofSymbol(ExecutionMode mode)
+    {
+        var output = TestHarness.Run("console.log((Object(Symbol('s')) as any) instanceof Symbol);", mode);
+        Assert.Equal("true\n", output);
+    }
+
     // ── call form still coerces (no wrapper) ────────────────────────────────
 
     [Theory]


### PR DESCRIPTION
## Summary

Fixes #449 — two related `instanceof Symbol` defects (follow-up to #375/#360):

```ts
(Symbol('s') as any) instanceof Symbol;          // Node: false | was: interp false, compiled true  ❌
(Object(Symbol('s')) as any) instanceof Symbol;  // Node: true  | was: interp false, compiled false ❌
```

Per ECMA-262 `OrdinaryHasInstance`, a bare symbol primitive is never an instance of `Symbol`; only the boxed wrapper (`Object(Symbol())`) is. Symbol's twist vs Number/String/Boolean: it has no `new` form, so the only boxed form is `Object(sym)`.

## Changes

- **Compiled** (`RuntimeEmitter.CoreUtilities.cs`): add a terminal `CheckBoxed(runtime.TSSymbolType, "Symbol")` in `EmitInstanceOf`. `Symbol` lowers to the `$TSSymbol` Type token, so a bare `$TSSymbol` previously fell through to the `IsAssignableFrom($TSSymbol, $TSSymbol)` fallback (wrongly `true`); the terminal branch fixes that and matches the boxed wrapper. Fixes both compiled defects.
- **Interpreter** (`Interpreter.Calls.cs`): recognize the `Symbol` constructor in `EvaluateInstanceof`, routing to the existing `IsBoxedPrimitiveOfType(left, "Symbol")` helper.
- **Interpreter** (`SharpTSObjectNamespace.cs`): `Object(sym)` now produces a wrapper carrying `__primitiveType="Symbol"`, mirroring the compiled `NewBoxedPrimitive` shape so the marker check matches.

## Tests

Two dual-mode (`ExecutionModes.All` → interpreter + compiled) `[Theory]` cases in `PrimitiveWrapperTests`, one per repro line.

## Verification

- `dotnet build` — clean (0 warnings, 0 errors).
- Manual repro now prints `false` then `true` in **both** interpreter and compiled modes, matching Node.
- `PrimitiveWrapperTests` (66), all `Symbol` tests (206), and all `instanceof` tests (88) pass.

### Out of scope
`Object(string/number/bool)` boxing still uses the looser `{ valueOf: value }` shape in the interpreter (so e.g. `Object(5) instanceof Number` stays `false` in interp) — a separate pre-existing gap unrelated to #449.