### PR TITLE
Fix #745: nested namespace member can reference its enclosing namespace by its own dotted name

### DIFF
--- a/SharpTS.Tests/SharedTests/NamespaceTests.cs
+++ b/SharpTS.Tests/SharedTests/NamespaceTests.cs
@@ -817,4 +817,84 @@ public class NamespaceTests
     }
 
     #endregion
+
+    #region Nested namespace reference to the enclosing namespace by its OWN dotted name (#745)
+
+    // Distinct from #665 (bare references to enclosing MEMBERS): here a nested member names the
+    // ENCLOSING namespace itself (or an ancestor) by its own dotted name. The checker previously
+    // rejected this ("Undefined variable 'O'") in both modes because CheckNamespace binds the
+    // namespace's own name only AFTER its body — including nested bodies — is fully checked.
+    // CheckNamespace now self-binds its own name into its body scope during the first pass.
+    // Scope note: only first-pass `types` members (nested namespaces, classes, etc.) resolve via
+    // the own dotted name; an enclosing function/var by the namespace's own name (`O.outerFunc()`)
+    // is not covered — its bare form works via #665.
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void NestedNamespace_ReferencesEnclosingNamespaceByOwnDottedName(ExecutionMode mode)
+    {
+        // The exact issue repro: O.B.f names O by its own name to reach O.A.g.
+        var code = @"
+            namespace O {
+                export namespace A { export function g() { return 5; } }
+                export namespace B { export function f() { return O.A.g(); } }
+            }
+            console.log(O.B.f());
+        ";
+        Assert.Equal("5\n", TestHarness.Run(code, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void DeeplyNested_ReferencesOutermostNamespaceByDottedName(ExecutionMode mode)
+    {
+        // A three-level-deep member names the outermost namespace by its own dotted name.
+        var code = @"
+            namespace Outer {
+                export namespace X { export function v() { return 9; } }
+                export namespace Mid {
+                    export namespace Inner {
+                        export function f() { return Outer.X.v(); }
+                    }
+                }
+            }
+            console.log(Outer.Mid.Inner.f());
+        ";
+        Assert.Equal("9\n", TestHarness.Run(code, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void NestedNamespace_BareAndOwnDottedNameCoexist(ExecutionMode mode)
+    {
+        // The same body uses both the bare sibling form (A.g(), #665) and the own dotted name
+        // (O.A.g(), #745) — both must resolve to the same member.
+        var code = @"
+            namespace O {
+                export namespace A { export function g() { return 5; } }
+                export namespace B { export function f() { return A.g() + O.A.g(); } }
+            }
+            console.log(O.B.f());
+        ";
+        Assert.Equal("10\n", TestHarness.Run(code, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void NestedNamespace_OwnDottedNameIsUnambiguousVsSameNamedTopLevel(ExecutionMode mode)
+    {
+        // A top-level A exists, but the dotted path O.A is unambiguous: it resolves the nested
+        // O.A (5), never the top-level A (100).
+        var code = @"
+            namespace A { export function g() { return 100; } }
+            namespace O {
+                export namespace A { export function g() { return 5; } }
+                export namespace B { export function f() { return O.A.g(); } }
+            }
+            console.log(O.B.f());
+        ";
+        Assert.Equal("5\n", TestHarness.Run(code, mode));
+    }
+
+    #endregion
 }

--- a/TypeSystem/TypeChecker.Namespaces.cs
+++ b/TypeSystem/TypeChecker.Namespaces.cs
@@ -79,6 +79,19 @@ public partial class TypeChecker
             foreach (var member in ns.Members)
             {
                 CollectNamespaceMemberType(member, types);
+                // Self-bind THIS namespace's own name into its own body scope from the members
+                // collected so far, so a later nested-namespace member body checked in this same
+                // pass can reference the enclosing namespace by its own dotted name (`O.A.g()`
+                // from inside O.B.f). Source order: `A` precedes `B` in the repro, so `A` is
+                // already in `types` when B's body is checked. DefineNamespace merges on repeat,
+                // so re-calling each iteration is safe. This binding lives only inside the
+                // namespace scope and is discarded at scope exit; the outer binding still happens
+                // after the body (below). Only first-pass `types` members (nested namespaces,
+                // classes, interfaces, enums, type aliases) resolve via the own dotted name —
+                // functions/vars enter `values` only in the second pass, so `O.outerFunc()` by the
+                // enclosing namespace's own name is not covered (the bare form works via #665). (#745)
+                _environment.DefineNamespace(name, new TypeInfo.Namespace(
+                    name, types.ToFrozenDictionary(), values.ToFrozenDictionary()));
             }
 
             // Second pass: fully type-check all members. In recovery mode, check each member


### PR DESCRIPTION
## Summary

Fixes #745. A function in a **nested** namespace could not reference its **enclosing** namespace by that namespace's own (dotted) name — rejected as `Type Error: Undefined variable '<enclosing>'` in **both** interpreter and compiled modes at check time. `tsc` accepts it (the enclosing namespace is in lexical scope). This is the type-checker analog of #665, which handled bare references to enclosing *members*; this issue is naming the enclosing *namespace itself*.

```ts
namespace O {
  export namespace A { export function g() { return 5; } }
  export namespace B { export function f() { return O.A.g(); } }  // names O by its own name
}
console.log(O.B.f());   // tsc: 5   before: Type Error: Undefined variable 'O'   now: 5 (both modes)
```

## Root cause

`TypeChecker.CheckNamespace` binds the namespace's own name into the enclosing scope only at the very **end** (`_environment.DefineNamespace(name, nsType)`), *after* the body — including nested namespaces and their member bodies — has already been type-checked during the first pass. So while `O.B.f`'s body is checked, `O` is not yet bound in any visible scope.

## Fix (type-checker only; fixes both modes)

In the first-pass loop, after each member is collected, self-bind the namespace's own name into its **own body scope** from the members collected so far. A nested member body checked later in the same pass then resolves the enclosing namespace by name via the scope chain.

- `DefineNamespace` merges on repeat, so re-binding each iteration is safe; it also writes `_values[name]` so `Get("O")` finds it.
- The binding lives only inside the namespace scope and is discarded at scope exit — **no member leak** (only the namespace *object* is bound; members are reached via dotted lookup). The outer binding still happens after the body.
- Compiled runtime already resolved bare `O` via `ResolveNamespaceField`'s `$ns_O` fallback, so the type-checker change alone fixes both modes.

## Known limitation (documented)

An enclosing **function/var** referenced by the namespace's *own dotted name* (`O.outerFunc()`) is still uncovered — those enter `values` only in the second pass. The bare form (`outerFunc()`) works via #665. Only first-pass `types` members (nested namespaces/classes/interfaces/enums/type-aliases) resolve via the own dotted name.

## Tests

4 new both-mode (`ExecutionModes.All`) tests in `SharedTests/NamespaceTests.cs`: exact repro, three-level nesting, bare+dotted coexistence (#665 regression guard), and unambiguous-vs-same-named-top-level.

## Verification

- Manual repro outputs `5` in both interpreter and compiled modes.
- Full suite: **13666 passed / 0 failed**.