### PR TITLE
Fix #774: run the finally on break/continue/return out of a compiled async try-with-awaits

### DIFF
--- a/Compilation/AsyncMoveNextEmitter.Statements.ControlFlow.cs
+++ b/Compilation/AsyncMoveNextEmitter.Statements.ControlFlow.cs
@@ -24,14 +24,22 @@ public partial class AsyncMoveNextEmitter
             _il.Emit(OpCodes.Stloc, _returnValueLocal);
         }
 
-        // If we're inside a try with finally-with-awaits, set pending return flag
-        // and jump to after-finally label (which will then complete the return)
-        if (_pendingReturnFlagLocal != null && _afterFinallyLabel != null)
+        // If a flag-based finally lies between this return and the function boundary, run it (and any
+        // outer ones) before completing: stash the return value in a state-machine field (an await in
+        // the finally would lose the IL local across the suspension), then route through the finally(s).
+        // The return terminal restores the value into _returnValueLocal and leaves to SetResult (#774).
+        var chain = ActiveFinallyFrames();
+        if (chain.Count > 0)
         {
-            _il.Emit(OpCodes.Ldc_I4_1);
-            _il.Emit(OpCodes.Stloc, _pendingReturnFlagLocal);
-            // Use Leave to exit the protected region to the after-finally label
-            _il.Emit(OpCodes.Leave, _afterFinallyLabel.Value);
+            if (_returnValueLocal != null)
+            {
+                _il.Emit(OpCodes.Ldarg_0);
+                _il.Emit(OpCodes.Ldloc, _returnValueLocal);
+                _il.Emit(OpCodes.Stfld, GetPendingReturnValueField());
+            }
+
+            RegisterReturnTerminal();
+            RouteThroughFinallys(chain, ExitCodeReturn, _ctx!.ExceptionBlockDepth > 0 ? OpCodes.Leave : OpCodes.Br);
             return;
         }
 

--- a/Compilation/AsyncMoveNextEmitter.Statements.ExitRouting.cs
+++ b/Compilation/AsyncMoveNextEmitter.Statements.ExitRouting.cs
@@ -1,0 +1,279 @@
+using System.Reflection;
+using System.Reflection.Emit;
+using SharpTS.Parsing;
+
+namespace SharpTS.Compilation;
+
+public partial class AsyncMoveNextEmitter
+{
+    // ---- Unified exit-scope stack (#774, the async-function analog of #500/#559) ----------------
+    //
+    // A non-local exit (return / break / continue) that crosses a flag-based try/finally must run the
+    // enclosing finally(s) before transferring control. Because a finally can itself await, the routing
+    // state has to survive a MoveNext re-entry, so it lives in state-machine fields rather than IL
+    // locals.
+    //
+    // This mirrors the async generator's routing (AsyncGeneratorMoveNextEmitter.Statements.TryCatch.cs,
+    // itself the async analog of GeneratorMoveNextEmitter), pared down for the plain async function:
+    //   * there are no yields and no external generator.return(), so there is no <>pendingReturnValue
+    //     vs Current juggling and no __returnRequested mechanism;
+    //   * a `throw` in a try body is already captured by the existing flag-based exception path
+    //     (caughtExceptionLocal, which runs the finally before rethrowing), so throw routing is NOT
+    //     ported — only return/break/continue need the finally machinery here.
+    //
+    // The Leave-vs-Br choice keys off CompilationContext.ExceptionBlockDepth (the count of real IL
+    // exception blocks opened by EmitSimpleTryCatch around the current point), exactly as the existing
+    // EmitBranchToLabel does — escaping break/continue/return are pulled out as segment breakers and
+    // emitted at the top level (depth 0 → Br), while one nested inside a no-await simple try leaves it
+    // via Leave, running that real finally on the way to the innermost flag cleanup.
+
+    private interface IExitScope;
+
+    /// <summary>A loop (or switch / labeled statement) that <c>break</c>/<c>continue</c> can target.</summary>
+    private sealed class LoopScope : IExitScope
+    {
+        public required Label BreakLabel;
+        public required Label ContinueLabel;
+        public IReadOnlyList<string> LabelNames = CompilationContext.NoLabels;
+
+        // Lazily assigned the first time a break/continue to this loop must run an intervening
+        // finally; identifies that exit in the `<>pendingExit` field. Unset while the loop's
+        // break/continue need no finally routing (the common case → a direct branch).
+        public int? BreakCode;
+        public int? ContinueCode;
+    }
+
+    /// <summary>A flag-based <c>try</c> that has a <c>finally</c>; its finally runs on any exit that crosses it.</summary>
+    private sealed class FinallyScope : IExitScope
+    {
+        public required Label CleanupLabel;
+
+        // code → where control goes after this finally for that pending exit: a chain to the next
+        // outer finally's cleanup label, or null meaning "this finally is terminal for the exit".
+        public readonly Dictionary<int, Label?> Dispatch = [];
+    }
+
+    // Innermost-last stack of loop and finally scopes currently open at the emission point. Replaces
+    // the base class's `_loopLabels` (the loop-scope methods below are overridden to use this) so loops
+    // and finallys share one ordering — needed to know which finallys lie between a break and its loop.
+    private readonly List<IExitScope> _exitScopes = [];
+
+    private const int ExitCodeReturn = 1;
+    private int _nextExitCode = 2; // break/continue codes are allocated from here (no throw routing here)
+
+    // code → emits the terminal action for that code (invoked when a finally is terminal for it).
+    private readonly Dictionary<int, Action> _exitTerminals = [];
+
+    // `<>pendingExit` (int): the code of an in-flight non-local exit, or 0 when none. A finally that
+    // awaits suspends MoveNext mid-routing, so this must be a field (a local would reset on re-entry).
+    // Set once per exit and cleared by the terminal dispatch; defaults to 0 on a fresh state machine.
+    private FieldBuilder? _pendingExitField;
+
+    private FieldBuilder GetPendingExitField() =>
+        _pendingExitField ??= _builder.StateMachineType.DefineField(
+            "<>pendingExit", typeof(int), FieldAttributes.Private);
+
+    // `<>pendingReturnValue` (object): the completion value of a `return` being routed through
+    // finally(s). `_returnValueLocal` is an IL local, so a finally that awaits would lose it across the
+    // suspension; the value is stashed here at the `return` and restored to `_returnValueLocal` by the
+    // return terminal, after the finally has run. Held across any suspension in those finallys.
+    private FieldBuilder? _pendingReturnValueField;
+
+    private FieldBuilder GetPendingReturnValueField() =>
+        _pendingReturnValueField ??= _builder.StateMachineType.DefineField(
+            "<>pendingReturnValue", typeof(object), FieldAttributes.Private);
+
+    // ---- Loop-scope methods (override the base stack to use `_exitScopes`) -----------------------
+
+    protected override void EnterLoop(Label breakLabel, Label continueLabel, string? labelName = null)
+        // Adopt any pending labels (`outer: for (...)`, or a chain `a: b: for`) just like the base
+        // EnterLoop does, so a labeled `break`/`continue` can resolve this loop as its target.
+        => _exitScopes.Add(new LoopScope { BreakLabel = breakLabel, ContinueLabel = continueLabel, LabelNames = labelName != null ? new[] { labelName } : Ctx.TakePendingLoopLabels() });
+
+    protected override void ExitLoop()
+    {
+        // Well-nested: any try opened inside the loop body has already been closed, so the top of the
+        // stack is this loop's LoopScope.
+        _exitScopes.RemoveAt(_exitScopes.Count - 1);
+    }
+
+    protected override (Label BreakLabel, Label ContinueLabel, IReadOnlyList<string> LabelNames)? CurrentLoop
+    {
+        get
+        {
+            var loop = CurrentLoopScope();
+            return loop == null ? null : (loop.BreakLabel, loop.ContinueLabel, loop.LabelNames);
+        }
+    }
+
+    protected override (Label BreakLabel, Label ContinueLabel, IReadOnlyList<string> LabelNames)? FindLabeledLoop(string labelName)
+    {
+        var loop = FindLabeledLoopScope(labelName);
+        return loop == null ? null : (loop.BreakLabel, loop.ContinueLabel, loop.LabelNames);
+    }
+
+    private LoopScope? CurrentLoopScope()
+    {
+        for (int i = _exitScopes.Count - 1; i >= 0; i--)
+            if (_exitScopes[i] is LoopScope ls)
+                return ls;
+        return null;
+    }
+
+    private LoopScope? FindLabeledLoopScope(string labelName)
+    {
+        for (int i = _exitScopes.Count - 1; i >= 0; i--)
+            if (_exitScopes[i] is LoopScope ls && ls.LabelNames.Contains(labelName))
+                return ls;
+        return null;
+    }
+
+    // ---- Non-local exit overrides ---------------------------------------------------------------
+
+    /// <summary>
+    /// A <c>break</c> must run any finally between it and the target loop before jumping out.
+    /// </summary>
+    protected override void EmitBreak(Stmt.Break b)
+    {
+        var loop = b.Label != null ? FindLabeledLoopScope(b.Label.Lexeme) : CurrentLoopScope();
+        if (loop == null) return; // matches the base: a break with no resolvable target is a no-op
+
+        var chain = FinallyFramesAbove(loop);
+        if (chain.Count > 0)
+        {
+            // Flag-based finally(s) lie between the break and its loop; run them before jumping out.
+            int code = loop.BreakCode ??= _nextExitCode++;
+            _exitTerminals.TryAdd(code, () => _il.Emit(OpCodes.Br, loop.BreakLabel));
+            RouteThroughFinallys(chain, code, _ctx!.ExceptionBlockDepth > 0 ? OpCodes.Leave : OpCodes.Br);
+            return;
+        }
+
+        EmitBranchToLabel(loop.BreakLabel);
+    }
+
+    /// <summary>
+    /// A <c>continue</c> must run any finally between it and the target loop before jumping to the
+    /// loop's continue point.
+    /// </summary>
+    protected override void EmitContinue(Stmt.Continue c)
+    {
+        var loop = c.Label != null ? FindLabeledLoopScope(c.Label.Lexeme) : CurrentLoopScope();
+        if (loop == null) return;
+
+        var chain = FinallyFramesAbove(loop);
+        if (chain.Count > 0)
+        {
+            int code = loop.ContinueCode ??= _nextExitCode++;
+            _exitTerminals.TryAdd(code, () => _il.Emit(OpCodes.Br, loop.ContinueLabel));
+            RouteThroughFinallys(chain, code, _ctx!.ExceptionBlockDepth > 0 ? OpCodes.Leave : OpCodes.Br);
+            return;
+        }
+
+        EmitBranchToLabel(loop.ContinueLabel);
+    }
+
+    // ---- Routing helpers ------------------------------------------------------------------------
+
+    /// <summary>All open finally scopes, innermost first.</summary>
+    private List<FinallyScope> ActiveFinallyFrames()
+    {
+        var result = new List<FinallyScope>();
+        for (int i = _exitScopes.Count - 1; i >= 0; i--)
+            if (_exitScopes[i] is FinallyScope fs)
+                result.Add(fs);
+        return result;
+    }
+
+    /// <summary>The finally scopes between the current point and <paramref name="target"/>, innermost first.</summary>
+    private List<FinallyScope> FinallyFramesAbove(LoopScope target)
+    {
+        var result = new List<FinallyScope>();
+        for (int i = _exitScopes.Count - 1; i >= 0; i--)
+        {
+            if (ReferenceEquals(_exitScopes[i], target)) break;
+            if (_exitScopes[i] is FinallyScope fs)
+                result.Add(fs);
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Records <paramref name="code"/>'s per-frame routing across <paramref name="chain"/> (each frame
+    /// chains to the next, the outermost is terminal), then sets the pending-exit field and branches to
+    /// the innermost finally. The caller must have prepared any value the terminal needs (e.g. the
+    /// return value) beforehand.
+    /// </summary>
+    /// <param name="branch">
+    /// <c>Br</c> when the exit is at the top level, or <c>Leave</c> when it is emitted inside a real IL
+    /// exception block (EmitSimpleTryCatch) nested in the flag-based finally(s): the <c>Leave</c> exits
+    /// that block — running its no-await finally — straight to the innermost flag cleanup label, then
+    /// the flag machinery runs the remaining (outer) finally(s). A real try never encloses a flag try,
+    /// so every real finally is innermore than every flag one and this ordering is correct.
+    /// </param>
+    private void RouteThroughFinallys(List<FinallyScope> chain, int code, OpCode branch)
+    {
+        for (int i = 0; i < chain.Count; i++)
+        {
+            // The last frame in the chain is terminal for this code (null); the rest chain outward.
+            Label? next = i < chain.Count - 1 ? chain[i + 1].CleanupLabel : null;
+            chain[i].Dispatch[code] = next; // idempotent: the same code always routes a frame the same way
+        }
+
+        _il.Emit(OpCodes.Ldarg_0);
+        _il.Emit(OpCodes.Ldc_I4, code);
+        _il.Emit(OpCodes.Stfld, GetPendingExitField());
+        _il.Emit(branch, chain[0].CleanupLabel);
+    }
+
+    /// <summary>
+    /// Emitted after a finally body: for each pending-exit code that routes through this frame, either
+    /// chain to the next outer finally or, if terminal here, clear the pending field and run the
+    /// terminal action. A pending value of 0 (none) and codes not handled here fall through unchanged.
+    /// </summary>
+    private void EmitFinallyDispatch(FinallyScope frame)
+    {
+        foreach (var (code, next) in frame.Dispatch)
+        {
+            var skip = _il.DefineLabel();
+            _il.Emit(OpCodes.Ldarg_0);
+            _il.Emit(OpCodes.Ldfld, GetPendingExitField());
+            _il.Emit(OpCodes.Ldc_I4, code);
+            _il.Emit(OpCodes.Bne_Un, skip);
+
+            if (next.HasValue)
+            {
+                // Not terminal here — keep the pending code and run the next outer finally.
+                _il.Emit(OpCodes.Br, next.Value);
+            }
+            else
+            {
+                // Terminal: the exit has run every finally it needed to. Clear the flag first so a
+                // break/continue resumes with clean state.
+                _il.Emit(OpCodes.Ldarg_0);
+                _il.Emit(OpCodes.Ldc_I4_0);
+                _il.Emit(OpCodes.Stfld, GetPendingExitField());
+                _exitTerminals[code]();
+            }
+
+            _il.MarkLabel(skip);
+        }
+    }
+
+    /// <summary>
+    /// The terminal for a routed <c>return</c>: a finally that awaited between the <c>return</c> and
+    /// here ran on a separate MoveNext invocation, so the return value (stashed in
+    /// <c>&lt;&gt;pendingReturnValue</c> at the <c>return</c>) is restored into <c>_returnValueLocal</c>
+    /// before leaving to the SetResult epilogue.
+    /// </summary>
+    private void RegisterReturnTerminal() => _exitTerminals.TryAdd(ExitCodeReturn, () =>
+    {
+        if (_returnValueLocal != null)
+        {
+            _il.Emit(OpCodes.Ldarg_0);
+            _il.Emit(OpCodes.Ldfld, GetPendingReturnValueField());
+            _il.Emit(OpCodes.Stloc, _returnValueLocal);
+        }
+
+        _il.Emit(OpCodes.Leave, _setResultLabel);
+    });
+}

--- a/Compilation/AsyncMoveNextEmitter.Statements.TryCatch.cs
+++ b/Compilation/AsyncMoveNextEmitter.Statements.TryCatch.cs
@@ -94,25 +94,18 @@ public partial class AsyncMoveNextEmitter
         _il.Emit(OpCodes.Ldnull);
         _il.Emit(OpCodes.Stloc, caughtExceptionLocal);
 
-        // If there are awaits in finally, set up pending return tracking
-        // This allows return statements inside try to defer to after finally runs
-        LocalBuilder? pendingReturnLocal = null;
-        Label? afterFinallyLabel = null;
-        var previousPendingReturnLocal = _pendingReturnFlagLocal;
-        var previousAfterFinallyLabel = _afterFinallyLabel;
-
-        if (hasAwaitsInFinally && t.FinallyBlock != null)
+        // A finally must run on every path that leaves the try — including a non-local break / continue
+        // / return that crosses it. Push a FinallyScope before emitting the try body so those exits
+        // (emitted at the top level by EmitTryBodyWithAwaits / EmitReturn) route through it before
+        // transferring control; the cleanup label is the finally's entry. The frame stays open across
+        // the catch too, so an exit from the catch body runs this finally as well (#774).
+        FinallyScope? frame = null;
+        Label cleanupLabel = default;
+        if (t.FinallyBlock != null)
         {
-            pendingReturnLocal = _il.DeclareLocal(typeof(bool));
-            afterFinallyLabel = _il.DefineLabel();
-
-            // Initialize pending return flag to false
-            _il.Emit(OpCodes.Ldc_I4_0);
-            _il.Emit(OpCodes.Stloc, pendingReturnLocal);
-
-            // Set context for return statements to use
-            _pendingReturnFlagLocal = pendingReturnLocal;
-            _afterFinallyLabel = afterFinallyLabel;
+            cleanupLabel = _il.DefineLabel();
+            frame = new FinallyScope { CleanupLabel = cleanupLabel };
+            _exitScopes.Add(frame);
         }
 
         if (hasAwaitsInTry)
@@ -123,7 +116,10 @@ public partial class AsyncMoveNextEmitter
         else if (hasAwaitsInFinally)
         {
             // No awaits in try but awaits in finally - need to capture exception from try
-            // so we can run the finally with awaits before rethrowing
+            // so we can run the finally with awaits before rethrowing. The try body runs inside a real
+            // IL exception block, so a non-local exit crossing it must Leave, not Br — bump
+            // ExceptionBlockDepth so EmitBranchToLabel / the routing pick Leave to the cleanup (#774).
+            _ctx!.ExceptionBlockDepth++;
             _il.BeginExceptionBlock();
             foreach (var stmt in t.TryBlock)
                 EmitStatement(stmt);
@@ -134,10 +130,13 @@ public partial class AsyncMoveNextEmitter
             _il.Emit(OpCodes.Stloc, caughtExceptionLocal);
 
             _il.EndExceptionBlock();
+            _ctx!.ExceptionBlockDepth--;
         }
         else
         {
-            // No awaits in try or finally - use normal try block
+            // No awaits in try or finally - use normal try block. Same real-IL-block reasoning as above:
+            // bump ExceptionBlockDepth so a non-local exit crossing this try Leaves to the cleanup (#774).
+            _ctx!.ExceptionBlockDepth++;
             _il.BeginExceptionBlock();
             foreach (var stmt in t.TryBlock)
                 EmitStatement(stmt);
@@ -149,7 +148,14 @@ public partial class AsyncMoveNextEmitter
                 _il.Emit(OpCodes.Stloc, caughtExceptionLocal);
             }
             _il.EndExceptionBlock();
+            _ctx!.ExceptionBlockDepth--;
         }
+
+        // Cleanup entry: normal completion falls here, and a routed non-local exit branches here. The
+        // catch is gated on caughtExceptionLocal below, which is null on every exit path, so those
+        // paths skip the catch and flow straight into the finally (#774).
+        if (frame != null)
+            _il.MarkLabel(cleanupLabel);
 
         // Check if we need to run catch block
         if (t.CatchBlock != null)
@@ -196,13 +202,14 @@ public partial class AsyncMoveNextEmitter
             _il.MarkLabel(skipCatchLabel);
         }
 
+        // The finally itself is outside its own scope: an exit within the finally body runs the
+        // *enclosing* finallys, not this one. Pop before emitting the body (#774).
+        if (frame != null)
+            _exitScopes.RemoveAt(_exitScopes.Count - 1);
+
         // Finally block - must always execute
         if (t.FinallyBlock != null)
         {
-            // Mark label for return statements inside try to jump to finally
-            if (afterFinallyLabel != null)
-                _il.MarkLabel(afterFinallyLabel.Value);
-
             if (hasAwaitsInFinally)
             {
                 // Finally with awaits - need special handling
@@ -216,6 +223,11 @@ public partial class AsyncMoveNextEmitter
                 foreach (var stmt in t.FinallyBlock)
                     EmitStatement(stmt);
             }
+
+            // Dispatch any pending non-local exit (return / break / continue) that routed through this
+            // finally: run the terminal action, or chain to the next outer finally (#774). On a normal
+            // or exception path <>pendingExit is 0 and this falls through unchanged.
+            EmitFinallyDispatch(frame!);
 
             // After finally, check if we need to rethrow a pending exception
             // (but only if there was no catch block that handled it)
@@ -232,24 +244,7 @@ public partial class AsyncMoveNextEmitter
 
                 _il.MarkLabel(noExceptionLabel);
             }
-
-            // After finally, check if there was a pending return
-            if (pendingReturnLocal != null)
-            {
-                var noPendingReturnLabel = _il.DefineLabel();
-                _il.Emit(OpCodes.Ldloc, pendingReturnLocal);
-                _il.Emit(OpCodes.Brfalse, noPendingReturnLabel);
-
-                // Pending return - jump to set result
-                _il.Emit(OpCodes.Leave, _setResultLabel);
-
-                _il.MarkLabel(noPendingReturnLabel);
-            }
         }
-
-        // Restore previous context
-        _pendingReturnFlagLocal = previousPendingReturnLocal;
-        _afterFinallyLabel = previousAfterFinallyLabel;
 
         _il.MarkLabel(afterTryCatchLabel);
     }

--- a/Compilation/AsyncMoveNextEmitter.cs
+++ b/Compilation/AsyncMoveNextEmitter.cs
@@ -116,10 +116,6 @@ public partial class AsyncMoveNextEmitter : StatementEmitterBase, IEmitterContex
     private LocalBuilder? _currentTryCatchExceptionLocal = null;
     private Label? _currentTryCatchSkipLabel = null;
 
-    // For return inside try with finally-with-awaits: track pending return
-    private LocalBuilder? _pendingReturnFlagLocal = null;
-    private Label? _afterFinallyLabel = null;
-
     // @lock decorator support for async methods
     private Label _lockResumeLabel;  // Resume point after lock acquisition await
 

--- a/SharpTS.Tests/Compilation/EmitterSyncTests.cs
+++ b/SharpTS.Tests/Compilation/EmitterSyncTests.cs
@@ -70,6 +70,13 @@ public class EmitterSyncTests
             "EmitLogicalAssign",    // #766: route a shadowing logical assignment to its own slot
             "EmitPrefixIncrement",  // #766: route a shadowing prefix ++/-- to its own slot
             "EmitPostfixIncrement", // #766: route a shadowing postfix ++/-- to its own slot
+            // --- #774: non-local exits must run an enclosing flag-based finally first (async-fn #500/#559) ---
+            "EmitBreak",            // Route a break leaving a try-with-awaits through its finally(s)
+            "EmitContinue",         // Route a continue leaving a try-with-awaits through its finally(s)
+            "EnterLoop",            // Loops share the unified _exitScopes stack with finally scopes
+            "ExitLoop",             // (so break/continue can find the finallys between them and the loop)
+            "get_CurrentLoop",      // Loop lookups read _exitScopes instead of the base loop stack
+            "FindLabeledLoop",      // Labeled loop lookups read _exitScopes
         },
         [typeof(AsyncArrowMoveNextEmitter)] = new()
         {

--- a/SharpTS.Tests/SharedTests/AsyncFinallyTests.cs
+++ b/SharpTS.Tests/SharedTests/AsyncFinallyTests.cs
@@ -298,4 +298,204 @@ public class AsyncFinallyTests
         var output = TestHarness.Run(source, mode);
         Assert.Equal("try op\ncatch op\ncaught: error\nfinally op\ndone\n", output);
     }
+
+    // --- #774: a non-local exit (break/continue/return) leaving a try whose body awaits must still
+    // run the try's finally. Previously the compiled state machine jumped straight to the loop label,
+    // skipping the (now flag-based) finally. ---
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Finally_ContinueOutOfTryWithAwait_RunsFinally(ExecutionMode mode)
+    {
+        // The issue repro: `continue` crosses the finally on iteration i==1.
+        var source = """
+            function delay(v: number): Promise<number> { return new Promise(r => r(v)); }
+            async function main(): Promise<void> {
+                let log = "";
+                for (let i = 0; i < 3; i++) {
+                    try {
+                        const x = await delay(i);
+                        if (x === 1) continue;
+                        log += "b" + x;
+                    } finally {
+                        log += "f" + i;
+                    }
+                }
+                console.log(log);
+            }
+            main();
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("b0f0f1b2f2\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Finally_BreakOutOfTryWithAwait_RunsFinally(ExecutionMode mode)
+    {
+        var source = """
+            function delay(v: number): Promise<number> { return new Promise(r => r(v)); }
+            async function main(): Promise<void> {
+                let log = "";
+                for (let i = 0; i < 3; i++) {
+                    try {
+                        const x = await delay(i);
+                        if (x === 1) break;
+                        log += "b" + x;
+                    } finally {
+                        log += "f" + i;
+                    }
+                }
+                console.log(log);
+            }
+            main();
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("b0f0f1\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Finally_ContinueOutOfTryWithAwait_AwaitingFinally_RunsFinally(ExecutionMode mode)
+    {
+        // The finally itself awaits — previously dropped entirely on the continue.
+        var source = """
+            function delay(v: number): Promise<number> { return new Promise(r => r(v)); }
+            async function main(): Promise<void> {
+                let log = "";
+                for (let i = 0; i < 3; i++) {
+                    try {
+                        const x = await delay(i);
+                        if (x === 1) continue;
+                        log += "b" + x;
+                    } finally {
+                        await delay(0);
+                        log += "f" + i;
+                    }
+                }
+                console.log(log);
+            }
+            main();
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("b0f0f1b2f2\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Finally_ReturnOutOfTryWithAwait_NoAwaitFinally_RunsFinally(ExecutionMode mode)
+    {
+        // The `return` half: a no-await finally was previously only run when the finally itself awaited.
+        // The finally logs (observable side effect) and the returned value is delivered afterwards.
+        var source = """
+            function delay(v: number): Promise<number> { return new Promise(r => r(v)); }
+            async function compute(): Promise<string> {
+                try {
+                    const x = await delay(5);
+                    if (x === 5) return "ret" + x;
+                    return "z";
+                } finally {
+                    console.log("finally ran");
+                }
+            }
+            async function main(): Promise<void> {
+                const r = await compute();
+                console.log(r);
+            }
+            main();
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("finally ran\nret5\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Finally_BreakOutOfNestedTriesWithAwait_RunsBothFinallysInnermostFirst(ExecutionMode mode)
+    {
+        var source = """
+            function delay(v: number): Promise<number> { return new Promise(r => r(v)); }
+            async function main(): Promise<void> {
+                let log = "";
+                for (let i = 0; i < 2; i++) {
+                    try {
+                        try {
+                            const x = await delay(i);
+                            if (x === 0) continue;
+                            log += "b" + x;
+                        } finally {
+                            log += "i" + i;
+                        }
+                    } finally {
+                        log += "o" + i;
+                    }
+                }
+                console.log(log);
+            }
+            main();
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("i0o0b1i1o1\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Finally_LabeledBreakOutOfTryWithAwait_RunsFinally(ExecutionMode mode)
+    {
+        var source = """
+            function delay(v: number): Promise<number> { return new Promise(r => r(v)); }
+            async function main(): Promise<void> {
+                let log = "";
+                outer: for (let i = 0; i < 2; i++) {
+                    for (let j = 0; j < 2; j++) {
+                        try {
+                            const x = await delay(j);
+                            if (x === 1) break outer;
+                            log += i + "" + j;
+                        } finally {
+                            log += "f";
+                        }
+                    }
+                }
+                console.log(log);
+            }
+            main();
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("00ff\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Finally_BreakTargetingLoopInsideTryWithAwait_DoesNotRunFinally(ExecutionMode mode)
+    {
+        // Regression: a break whose target loop is *inside* the try crosses no finally, so the finally
+        // must run only once (on normal completion of the try), not on the inner break.
+        var source = """
+            function delay(v: number): Promise<number> { return new Promise(r => r(v)); }
+            async function main(): Promise<void> {
+                let log = "";
+                try {
+                    for (let i = 0; i < 3; i++) {
+                        const x = await delay(i);
+                        if (x === 1) break;
+                        log += "b" + x;
+                    }
+                    log += "t";
+                } finally {
+                    log += "f";
+                }
+                console.log(log);
+            }
+            main();
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("b0tf\n", output);
+    }
 }


### PR DESCRIPTION
Fixes #774.

## Problem
In **compiled mode**, a `break`/`continue` (or a `return` whose `finally` does not itself await) leaving a `try` whose body **awaits** transferred control to the loop/return without running the try's `finally`. The interpreter was already correct. This is the `finally`-execution analog of #727 (which fixed the invalid-IL half — the jump became a legal `Br`, but that legal jump still bypassed the flag-based finally).

```ts
function delay(v: number): Promise<number> { return new Promise(r => r(v)); }
async function main() {
  let log = "";
  for (let i = 0; i < 3; i++) {
    try {
      const x = await delay(i);
      if (x === 1) continue;   // crosses the finally
      log += "b" + x;
    } finally { log += "f" + i; }
  }
  console.log(log);            // interp: b0f0f1b2f2   compiled (before): b0f0b2f2  (f1 missing)
}
main();
```

## Root cause / approach
There are three sibling state-machine emitters extending `StatementEmitterBase`. `GeneratorMoveNextEmitter` (#500/#559) and `AsyncGeneratorMoveNextEmitter` (#597/#632) both already carry full non-local-exit finally-routing; `AsyncMoveNextEmitter` was the **only one missing it** (it had only a partial `return`-when-finally-awaits flag). So this is a proven port of that machinery, using the async-generator emitter as the closest template.

- **New partial** `Compilation/AsyncMoveNextEmitter.Statements.ExitRouting.cs`: a unified `_exitScopes` stack of loop + flag-based-finally scopes, per-exit codes held in a suspension-surviving `<>pendingExit` field (a finally can await, so it must be a field, not an IL local), `RouteThroughFinallys` + `EmitFinallyDispatch`, loop-scope overrides, `EmitBreak`/`EmitContinue`, and a return terminal that restores the value from `<>pendingReturnValue` before leaving to `SetResult`.
- `EmitReturn` now routes through `ActiveFinallyFrames()`, unifying the previously-partial `return` handling with break/continue; the old `_pendingReturnFlagLocal`/`_afterFinallyLabel` mechanism is removed.
- `EmitTryCatchWithAwaits` pushes a `FinallyScope` before the try body (cleanup label = finally entry) and calls `EmitFinallyDispatch` after the finally body.
- The two real-IL-block branches (await-only-in-finally / await-only-in-catch) now bump `ExceptionBlockDepth` so a crossing exit `Leave`s to the cleanup label instead of emitting an illegal `Br` out of the protected region.

Branch-op choice keys off `ExceptionBlockDepth` (`Leave` inside a real IL block, else `Br`), matching the existing `EmitBranchToLabel` convention. **Throw routing is intentionally not ported** — a thrown exception already runs the finally via the existing `caughtExceptionLocal` capture-then-rethrow path.

## Scope
Pre-existing, compiled-only (interpreter unchanged). Break/continue/return only.

## Tests
+8 `AsyncFinallyTests` (All modes — interpreter and compiled assert identical output): continue/break crossing the finally, finally-that-awaits, `return` with a no-await finally, nested tries (both finallys, innermost-first), labeled `break outer`, and a regression for a break targeting a loop *inside* the try (no finally crossed). EmitterSync allowlist updated for the new overrides.

Full suite green (**13702 passed, 0 failed**); IL verification passes on the repros.