### PR TITLE
Fix #448: compiled pipeTo deadlock on push-style streams (cooperative pump)

### DIFF
--- a/Compilation/EmittedRuntime.cs
+++ b/Compilation/EmittedRuntime.cs
@@ -2812,6 +2812,18 @@ public class EmittedRuntime
     public MethodBuilder EventLoopRun { get; set; } = null!;
     public MethodBuilder EventLoopWake { get; set; } = null!;
     public MethodBuilder EventLoopWaitForTask { get; set; } = null!;
+
+    /// <summary>
+    /// <c>$EventLoop.PumpOnce()</c> — drives one cooperative tick of the loop
+    /// (drain queued continuations, fire due timers, 1ms idle sleep) and returns
+    /// <c>1</c> if work is still pending (a timer is due later, an active handle
+    /// is open, or the queue is non-empty) or <c>0</c> when idle/quiescent. Used
+    /// by the synchronous <c>$ReadableStream.PipeTo</c> pump to wait for a
+    /// push-style (event-loop-driven) read/write without blocking the loop (#448).
+    /// Signal-agnostic by design: the abort check lives in the pump, which (unlike
+    /// the early-emitted <c>$EventLoop</c>) can reference <c>AbortSignalGetAborted</c>.
+    /// </summary>
+    public MethodBuilder EventLoopPumpOnce { get; set; } = null!;
     public FieldBuilder EventLoopTimerProcessorField { get; set; } = null!;
 
     /// <summary>

--- a/Compilation/RuntimeEmitter.ReadableStream.cs
+++ b/Compilation/RuntimeEmitter.ReadableStream.cs
@@ -995,6 +995,10 @@ public partial class RuntimeEmitter
         var writeArgsLocal = il.DeclareLocal(_types.ObjectArray);
         var resultObjLocal = il.DeclareLocal(_types.Object);
         var reasonLocal = il.DeclareLocal(_types.Object);
+        // Scratch slot for the Task<object> the pump cooperatively waits on (read
+        // then write reuse it — read is fully consumed before the write). See
+        // EmitCooperativeAwaitTaskOrSignal (#448).
+        var coopTaskLocal = il.DeclareLocal(_types.TaskOfObject);
 
         // Extract opts.signal. Null opts, missing field, or $Undefined all
         // normalise to null so the per-iteration check can Brfalse cleanly.
@@ -1168,10 +1172,20 @@ public partial class RuntimeEmitter
 
         il.MarkLabel(signalOkLabel);
 
-        // Call this.Read() → Task<object>; sync-await
+        // Call this.Read() → Task<object>. For a sync-pull source the task is
+        // already completed and the cooperative wait returns immediately. For a
+        // push-style source the task parks on a pending TCS that only an
+        // event-loop callback (e.g. setTimeout → controller.enqueue) can settle,
+        // so we must drive the loop instead of blocking the main thread in
+        // GetResult() — otherwise the pump deadlocks (#448). On a mid-pipe abort
+        // the wait branches back to loopTop (the signal check runs teardown); on a
+        // never-settling read it gives up to donePathLabel (graceful close).
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Callvirt, readMethod);
-        EmitSyncAwaitTaskOfObject(il, awaiterLocal);
+        il.Emit(OpCodes.Stloc, coopTaskLocal);
+        EmitCooperativeAwaitTaskOrSignal(il, runtime, coopTaskLocal, signalLocal, loopTop, donePathLabel);
+        il.Emit(OpCodes.Ldloc, coopTaskLocal);
+        EmitSyncAwaitTaskOfObject(il, awaiterLocal); // completed → returns immediately
         il.Emit(OpCodes.Stloc, resultObjLocal);
 
         // Cast to Dictionary<string, object?>
@@ -1210,7 +1224,10 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloc, writeCallableLocal);      // callable
         il.Emit(OpCodes.Ldloc, writeArgsLocal);          // args
         il.Emit(OpCodes.Call, runtime.InvokeMethodValue);
-        EmitUnwrapResultToTask(il, runtime, awaiterLocal);
+        // Cooperative wait for the write too: a push-style WritableStream whose
+        // write() resolves later through the event loop would otherwise deadlock
+        // the sync pump the same way a push source read does (#448).
+        EmitCooperativeUnwrapResultToTask(il, runtime, awaiterLocal, signalLocal, coopTaskLocal, loopTop, donePathLabel);
 
         il.Emit(OpCodes.Br, loopTop);
 
@@ -1278,6 +1295,172 @@ public partial class RuntimeEmitter
         il.MarkLabel(notPromiseLabel);
 
         il.MarkLabel(doneLabel);
+    }
+
+    /// <summary>
+    /// Cooperative variant of <see cref="EmitUnwrapResultToTask"/> for the pump's
+    /// main-loop <c>writer.write()</c> await. Normalises the <c>object</c> result on
+    /// the stack to a <c>Task&lt;object&gt;</c> (direct task, <c>$Promise</c>, or
+    /// nothing), then drives the event loop via
+    /// <see cref="EmitCooperativeAwaitTaskOrSignal"/> instead of blocking — so a
+    /// push-style <c>WritableStream</c> whose <c>write()</c> settles through the loop
+    /// doesn't deadlock the pump (#448). On abort it branches to
+    /// <paramref name="abortLabel"/>; on a never-settling write to
+    /// <paramref name="quiesceLabel"/>.
+    /// </summary>
+    private void EmitCooperativeUnwrapResultToTask(
+        ILGenerator il, EmittedRuntime runtime, LocalBuilder awaiterLocal,
+        LocalBuilder signalLocal, LocalBuilder coopTaskLocal,
+        Label abortLabel, Label quiesceLabel)
+    {
+        // Stack: [object result]
+        var resultLocal = il.DeclareLocal(_types.Object);
+        il.Emit(OpCodes.Stloc, resultLocal);
+
+        var notTaskLabel = il.DefineLabel();
+        var notPromiseLabel = il.DefineLabel();
+        var haveTaskLabel = il.DefineLabel();
+        var doneLabel = il.DefineLabel();
+
+        // if (result is Task<object> t) { coopTask = t; goto haveTask }
+        il.Emit(OpCodes.Ldloc, resultLocal);
+        il.Emit(OpCodes.Isinst, _types.TaskOfObject);
+        il.Emit(OpCodes.Brfalse, notTaskLabel);
+        il.Emit(OpCodes.Ldloc, resultLocal);
+        il.Emit(OpCodes.Castclass, _types.TaskOfObject);
+        il.Emit(OpCodes.Stloc, coopTaskLocal);
+        il.Emit(OpCodes.Br, haveTaskLabel);
+
+        // else if (result is $Promise p) { coopTask = p.GetValueAsync(); goto haveTask }
+        il.MarkLabel(notTaskLabel);
+        il.Emit(OpCodes.Ldloc, resultLocal);
+        il.Emit(OpCodes.Isinst, runtime.TSPromiseType);
+        il.Emit(OpCodes.Brfalse, notPromiseLabel);
+        il.Emit(OpCodes.Ldloc, resultLocal);
+        il.Emit(OpCodes.Castclass, runtime.TSPromiseType);
+        il.Emit(OpCodes.Callvirt, runtime.TSPromiseGetValueAsync);
+        il.Emit(OpCodes.Stloc, coopTaskLocal);
+        il.Emit(OpCodes.Br, haveTaskLabel);
+
+        // else: nothing to await
+        il.MarkLabel(notPromiseLabel);
+        il.Emit(OpCodes.Br, doneLabel);
+
+        il.MarkLabel(haveTaskLabel);
+        EmitCooperativeAwaitTaskOrSignal(il, runtime, coopTaskLocal, signalLocal, abortLabel, quiesceLabel);
+        il.Emit(OpCodes.Ldloc, coopTaskLocal);
+        EmitSyncAwaitTaskOfObject(il, awaiterLocal); // completed → returns immediately
+        il.Emit(OpCodes.Pop);
+
+        il.MarkLabel(doneLabel);
+    }
+
+    /// <summary>
+    /// Emits a cooperative wait for the <c>Task&lt;object&gt;</c> already stored in
+    /// <paramref name="coopTaskLocal"/>: loops driving <c>$EventLoop.PumpOnce()</c>
+    /// (drain queue + fire timers + 1ms tick) until the task completes, the abort
+    /// signal fires, or the loop stays quiescent past the give-up window. This lets
+    /// a push-style read/write that only an event-loop callback can settle make
+    /// progress without the synchronous pump blocking the main thread (#448).
+    /// </summary>
+    /// <remarks>
+    /// On normal completion control falls through with the (now completed) task left
+    /// in <paramref name="coopTaskLocal"/> for the caller to <c>GetResult()</c>
+    /// immediately. On a mid-pipe abort it branches to <paramref name="abortLabel"/>
+    /// (the pump's loop top, whose signal check runs writer.abort + source.cancel
+    /// teardown). On a never-settling task it branches to
+    /// <paramref name="quiesceLabel"/> (the pump's done path → graceful close) after
+    /// a 250ms quiescence window, mirroring <c>$EventLoop.WaitForTask</c>'s backstop
+    /// so a producerless source can't hang the process. Stack on entry/exit (the
+    /// fall-through and both branch targets): empty. References only emitted
+    /// <c>$EventLoop</c>/<c>$Runtime</c> members, so the stream stays standalone.
+    /// </remarks>
+    private void EmitCooperativeAwaitTaskOrSignal(
+        ILGenerator il, EmittedRuntime runtime,
+        LocalBuilder coopTaskLocal, LocalBuilder signalLocal,
+        Label abortLabel, Label quiesceLabel)
+    {
+        // Continuous quiescent wall-clock time before concluding the task can never
+        // settle — same time-based backstop as $EventLoop.WaitForTask.
+        const long QuiescentMsBeforeGiveUp = 250;
+
+        var quiescentStartLocal = il.DeclareLocal(typeof(long));
+        var waitLoopTop = il.DefineLabel();
+        var notAbortedLabel = il.DefineLabel();
+        var notCompletedAfterPump = il.DefineLabel();
+        var busyResetLabel = il.DefineLabel();
+        var startStreakLabel = il.DefineLabel();
+        var completedLabel = il.DefineLabel();
+
+        var isCompletedGetter = typeof(Task).GetProperty("IsCompleted")!.GetGetMethod()!;
+        var tickCount64Getter = typeof(Environment).GetProperty("TickCount64")!.GetGetMethod()!;
+
+        // quiescentStart = -1
+        il.Emit(OpCodes.Ldc_I8, -1L);
+        il.Emit(OpCodes.Stloc, quiescentStartLocal);
+
+        il.MarkLabel(waitLoopTop);
+
+        // if (task.IsCompleted) goto completed
+        il.Emit(OpCodes.Ldloc, coopTaskLocal);
+        il.Emit(OpCodes.Callvirt, isCompletedGetter);
+        il.Emit(OpCodes.Brtrue, completedLabel);
+
+        // Abort check (isinst-guarded, same as the pump's loop-top check):
+        // if (signal != null && signal is Dictionary && AbortSignalGetAborted(signal)) goto abort
+        il.Emit(OpCodes.Ldloc, signalLocal);
+        il.Emit(OpCodes.Brfalse, notAbortedLabel);
+        il.Emit(OpCodes.Ldloc, signalLocal);
+        il.Emit(OpCodes.Isinst, _types.DictionaryStringObject);
+        il.Emit(OpCodes.Brfalse, notAbortedLabel);
+        il.Emit(OpCodes.Ldloc, signalLocal);
+        il.Emit(OpCodes.Call, runtime.AbortSignalGetAborted);
+        il.Emit(OpCodes.Brtrue, abortLabel);
+        il.MarkLabel(notAbortedLabel);
+
+        // busy = $EventLoop.GetInstance().PumpOnce()
+        il.Emit(OpCodes.Call, runtime.EventLoopGetInstance);
+        il.Emit(OpCodes.Callvirt, runtime.EventLoopPumpOnce);
+        // Stack: [busy]
+
+        // if (task.IsCompleted) { pop busy; goto completed }
+        il.Emit(OpCodes.Ldloc, coopTaskLocal);
+        il.Emit(OpCodes.Callvirt, isCompletedGetter);
+        il.Emit(OpCodes.Brfalse, notCompletedAfterPump);
+        il.Emit(OpCodes.Pop); // discard busy
+        il.Emit(OpCodes.Br, completedLabel);
+        il.MarkLabel(notCompletedAfterPump);
+        // Stack: [busy]
+
+        // if (busy != 0) { quiescentStart = -1; loop } — Brtrue consumes busy
+        il.Emit(OpCodes.Brtrue, busyResetLabel);
+
+        // idle: track the quiescent streak.
+        //   if (quiescentStart < 0) quiescentStart = TickCount64
+        //   else if (TickCount64 - quiescentStart >= grace) goto quiesce
+        il.Emit(OpCodes.Ldloc, quiescentStartLocal);
+        il.Emit(OpCodes.Ldc_I8, 0L);
+        il.Emit(OpCodes.Blt, startStreakLabel);
+        il.Emit(OpCodes.Call, tickCount64Getter);
+        il.Emit(OpCodes.Ldloc, quiescentStartLocal);
+        il.Emit(OpCodes.Sub);
+        il.Emit(OpCodes.Ldc_I8, QuiescentMsBeforeGiveUp);
+        il.Emit(OpCodes.Bge, quiesceLabel);
+        il.Emit(OpCodes.Br, waitLoopTop);
+
+        il.MarkLabel(startStreakLabel);
+        il.Emit(OpCodes.Call, tickCount64Getter);
+        il.Emit(OpCodes.Stloc, quiescentStartLocal);
+        il.Emit(OpCodes.Br, waitLoopTop);
+
+        // busy: reset the idle streak and loop
+        il.MarkLabel(busyResetLabel);
+        il.Emit(OpCodes.Ldc_I8, -1L);
+        il.Emit(OpCodes.Stloc, quiescentStartLocal);
+        il.Emit(OpCodes.Br, waitLoopTop);
+
+        // Completed: fall through with the task ready for an immediate sync-await.
+        il.MarkLabel(completedLabel);
     }
 
     /// <summary>

--- a/Compilation/RuntimeEmitter.TSEventLoop.cs
+++ b/Compilation/RuntimeEmitter.TSEventLoop.cs
@@ -102,6 +102,9 @@ public partial class RuntimeEmitter
         // WaitForTask(Task)
         EmitEventLoopWaitForTask(typeBuilder, runtime);
 
+        // PumpOnce() — single cooperative tick for the PipeTo pump (#448)
+        EmitEventLoopPumpOnce(typeBuilder, runtime);
+
         typeBuilder.CreateType();
 
         // Emit the SynchronizationContext that routes await continuations back to
@@ -620,5 +623,101 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldc_I4_1);
         il.Emit(OpCodes.Call, typeof(Thread).GetMethod("Sleep", [_types.Int32])!);
         il.Emit(OpCodes.Br, loopTop);
+    }
+
+    /// <summary>
+    /// Emits <c>$EventLoop.PumpOnce()</c> — one cooperative tick of the loop body
+    /// shared with <see cref="EmitEventLoopWaitForTask"/>, minus the task/quiescence
+    /// tracking: drain every queued continuation, fire due timers via
+    /// <c>_timerProcessor</c> (= <c>$Runtime.ProcessPendingTimers</c>, which also
+    /// flushes microtasks), then sleep 1ms. Returns <c>1</c> while work is still
+    /// pending (a timer is due later, an active handle is open, or the queue is
+    /// non-empty) and <c>0</c> once idle.
+    /// </summary>
+    /// <remarks>
+    /// The synchronous <c>$ReadableStream.PipeTo</c> pump calls this in a loop while
+    /// a push-style <c>Read()</c>/<c>Write()</c> task is still pending, so an
+    /// event-loop-driven producer (e.g. a <c>setTimeout</c> that calls
+    /// <c>controller.enqueue</c>) can run and settle the task — instead of the pump
+    /// blocking the main thread in <c>GetResult()</c> and starving the loop (#448).
+    /// Abort-signal and quiescence handling stay in the pump itself: <c>$EventLoop</c>
+    /// is emitted before <c>$Runtime</c>, so it cannot reference
+    /// <c>AbortSignalGetAborted</c>, whereas the later-emitted pump can. References
+    /// only this type's own fields plus the BCL, so the pure-IL stream stays
+    /// standalone (no SharpTS.dll dependency).
+    /// </remarks>
+    private void EmitEventLoopPumpOnce(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    {
+        var method = typeBuilder.DefineMethod(
+            "PumpOnce",
+            MethodAttributes.Public,
+            _types.Int32,
+            Type.EmptyTypes
+        );
+        runtime.EventLoopPumpOnce = method;
+
+        var il = method.GetILGenerator();
+        var waitMsLocal = il.DeclareLocal(_types.Int32);
+        var actionLocal = il.DeclareLocal(typeof(Action));
+
+        var drainTop = il.DefineLabel();
+        var drainEnd = il.DefineLabel();
+        var skipTimers = il.DefineLabel();
+        var busyLabel = il.DefineLabel();
+        var sleepLabel = il.DefineLabel();
+
+        // Drain queued callbacks on THIS (event-loop) thread — same rationale as
+        // WaitForTask: Posted await continuations / TCS resolutions live here and
+        // running them may settle the read/write the pump is waiting on.
+        il.MarkLabel(drainTop);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, _eventLoopQueueField);
+        il.Emit(OpCodes.Ldloca, actionLocal);
+        il.Emit(OpCodes.Callvirt, typeof(ConcurrentQueue<Action>).GetMethod("TryDequeue", [typeof(Action).MakeByRefType()])!);
+        il.Emit(OpCodes.Brfalse, drainEnd);
+        il.Emit(OpCodes.Ldloc, actionLocal);
+        il.Emit(OpCodes.Callvirt, typeof(Action).GetMethod("Invoke")!);
+        il.Emit(OpCodes.Br, drainTop);
+        il.MarkLabel(drainEnd);
+
+        // waitMs = -1; if (_timerProcessor != null) waitMs = _timerProcessor.Invoke();
+        // Invoke fires due timers (their callbacks may enqueue a chunk / settle the
+        // task) and returns ms until the next timer, or -1 when none are scheduled.
+        il.Emit(OpCodes.Ldc_I4_M1);
+        il.Emit(OpCodes.Stloc, waitMsLocal);
+        il.Emit(OpCodes.Ldsfld, _eventLoopTimerProcessorField);
+        il.Emit(OpCodes.Brfalse, skipTimers);
+        il.Emit(OpCodes.Ldsfld, _eventLoopTimerProcessorField);
+        il.Emit(OpCodes.Callvirt, typeof(Func<int>).GetMethod("Invoke")!);
+        il.Emit(OpCodes.Stloc, waitMsLocal);
+        il.MarkLabel(skipTimers);
+
+        // Sleep 1ms before reporting, matching WaitForTask's per-iteration tick so
+        // a tight pump loop doesn't spin the CPU.
+        il.MarkLabel(sleepLabel);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Call, typeof(Thread).GetMethod("Sleep", [_types.Int32])!);
+
+        // busy = waitMs >= 0 || _activeHandles > 0 || !_queue.IsEmpty
+        il.Emit(OpCodes.Ldloc, waitMsLocal);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Bge, busyLabel);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, _eventLoopActiveHandlesField);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Bgt, busyLabel);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, _eventLoopQueueField);
+        il.Emit(OpCodes.Callvirt, typeof(ConcurrentQueue<Action>).GetProperty("IsEmpty")!.GetGetMethod()!);
+        il.Emit(OpCodes.Brfalse, busyLabel);
+
+        // idle → return 0
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Ret);
+
+        // busy → return 1
+        il.MarkLabel(busyLabel);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Ret);
     }
 }

--- a/SharpTS.Tests/SharedTests/BuiltInModules/StreamsWebSemanticTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/StreamsWebSemanticTests.cs
@@ -778,6 +778,122 @@ public class StreamsWebSemanticTests
         Assert.DoesNotContain("pipe-completed-normally", output);
     }
 
+    /// <remarks>
+    /// #448 — push-style source piped with no signal. <c>start</c> captures the
+    /// controller; the only chunk is <c>enqueue</c>d (and the stream
+    /// <c>close</c>d) later from a <c>setTimeout</c> callback. The first
+    /// <c>this.Read()</c> inside the pump parks on a pending
+    /// <c>TaskCompletionSource</c> that only the timer can settle.
+    ///
+    /// <para>Before the fix the compiled pump sync-awaited that read with
+    /// <c>GetAwaiter().GetResult()</c> on the main thread, starving the loop: the
+    /// enqueue timer could never run, so the process hung. The fix makes the
+    /// read/write awaits cooperative — the pump drives <c>$EventLoop.PumpOnce()</c>
+    /// (drain queue + fire timers) while the task is pending (see
+    /// <c>RuntimeEmitter.EmitCooperativeAwaitTaskOrSignal</c> /
+    /// <c>EmitEventLoopPumpOnce</c>), so the timer fires, the read resolves, and
+    /// the chunk flows. The interpreter already handled this via its real async
+    /// pump (<c>WebStreamsHelpers.PipeTo</c>).</para>
+    /// </remarks>
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ReadableStream_PipeTo_PushSourceViaTimer(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                let ctrl: any;
+                const source = new ReadableStream({ start(c) { ctrl = c; } });
+                const dest = new WritableStream({ write(chunk) { console.log("wrote " + chunk); } });
+                setTimeout(() => { ctrl.enqueue("x"); ctrl.close(); }, 10);
+                async function run() {
+                    await source.pipeTo(dest);
+                    console.log("done");
+                }
+                run();
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("wrote x\ndone\n", output);
+    }
+
+    /// <remarks>
+    /// #448 residual gap — a signal-bearing pipe over a push source that never
+    /// produces, with a <b>delayed</b> abort (<c>setTimeout(() => ac.abort(),
+    /// 50)</c>). The #355 loop-top pump fires once before the abort is due, then
+    /// the parking read used to block the main thread forever. With the
+    /// cooperative wait the pump keeps driving the loop, the abort timer fires
+    /// mid-wait, the in-loop signal check observes it, and the pump branches back
+    /// to its loop top to run the abort/cancel/reject teardown. CompiledOnly: the
+    /// interpreter abort-pipe end-to-end assertion is load-flaky (see
+    /// <see cref="ReadableStream_PipeTo_AbortSignalCancelsSourceAndAbortsDest"/>),
+    /// whereas the compiled pump runs synchronously and is deterministic.
+    /// </remarks>
+    [Theory]
+    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    public void ReadableStream_PipeTo_PushSourceDelayedAbort_Compiled(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                const ac = new AbortController();
+                const source = new ReadableStream({ start(c) { /* never enqueues */ } });
+                const dest = new WritableStream({
+                    write(chunk) { /* accept everything */ },
+                    abort(reason) { console.log("dest-aborted"); }
+                });
+                setTimeout(() => ac.abort(), 50);
+                async function run() {
+                    try {
+                        await source.pipeTo(dest, { signal: ac.signal });
+                        console.log("pipe-completed-normally");
+                    } catch (e) {
+                        console.log("pipe-rejected");
+                    }
+                }
+                run();
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Contains("dest-aborted", output);
+        Assert.Contains("pipe-rejected", output);
+        Assert.DoesNotContain("pipe-completed-normally", output);
+    }
+
+    /// <remarks>
+    /// #448 write-side — a push-style destination whose <c>write()</c> settles
+    /// later through the event loop (here a microtask via
+    /// <c>Promise.resolve().then</c>). The pump's main-loop write await is
+    /// cooperative too (see <c>EmitCooperativeUnwrapResultToTask</c>), so a write
+    /// that can only resolve once the loop runs doesn't deadlock the synchronous
+    /// pump the way a push source read does. CompiledOnly: this is a compiled-pump
+    /// gap; the interpreter's async pump already awaits writes.
+    /// </remarks>
+    [Theory]
+    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    public void ReadableStream_PipeTo_PushStyleWrite_Compiled(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                const source = new ReadableStream({ start(c) { c.enqueue("a"); c.close(); } });
+                const dest = new WritableStream({
+                    write(chunk) { return Promise.resolve().then(() => { console.log("wrote " + chunk); }); }
+                });
+                async function run() {
+                    await source.pipeTo(dest);
+                    console.log("done");
+                }
+                run();
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("wrote a\ndone\n", output);
+    }
+
     /// <summary>
     /// Verifies that erroring a <c>$ReadableStream</c> that has a parked
     /// reader rejects the pending-reads queue via <c>TrySetException</c>.


### PR DESCRIPTION
Fixes #448.

## Problem
Compiled `$ReadableStream.PipeTo` runs a synchronous pump: each `this.Read()` / `writer.write()` is unwrapped with `GetAwaiter().GetResult()` on the main thread. For a **push-style** source — `start(c){ctrl=c}` whose chunks arrive later through the event loop (e.g. `setTimeout(() => ctrl.enqueue(...))`) — the first read parks on a pending `TaskCompletionSource` that only a loop callback can settle. The blocked main thread starves the loop, so the process hangs. The interpreter is fine because `WebStreamsHelpers.PipeTo` is a real `async` pump.

The #355 fix drove the loop once at the *top* of each iteration but left the read itself blocking, so a push source piped without a signal (this issue), and a signal-bearing pipe over a push source with a *delayed* abort, both still deadlocked.

## Fix (compiled-only)
Make the pump's read **and** write awaits cooperative:
- **`$EventLoop.PumpOnce()`** (`RuntimeEmitter.TSEventLoop.cs`, `EmitEventLoopPumpOnce`) — one cooperative tick: drain `_queue`, fire due timers via `_timerProcessor`, 1ms sleep; returns busy/idle. A trimmed copy of `WaitForTask`'s loop body.
- **`EmitCooperativeAwaitTaskOrSignal` / `EmitCooperativeUnwrapResultToTask`** (`RuntimeEmitter.ReadableStream.cs`) — loop `PumpOnce()` while the read/write task is pending: fall through on completion (immediate `GetResult`), branch to the pump's loop top on a mid-pipe abort (existing writer.abort + source.cancel teardown), or branch to the done path after a 250ms quiescence backstop (graceful close, mirroring `WaitForTask`'s give-up so a producerless source can't hang). Replaces the read sync-await and the main-loop write `EmitUnwrapResultToTask`; teardown/close awaits stay plain. Also closes the #355 residual signal+push+delayed-abort gap.

**Emission-ordering note:** `$EventLoop` is emitted and `CreateType()`'d before `$Runtime`, so it can't reference `AbortSignalGetAborted`. `PumpOnce` is therefore signal-agnostic and the abort/quiescence logic lives in the later-emitted pump (`$ReadableStream`, which already calls `AbortSignalGetAborted`). All references are to emitted `$EventLoop`/`$Runtime` members, so the stream stays standalone.

## Tests
`StreamsWebSemanticTests.cs`:
- `ReadableStream_PipeTo_PushSourceViaTimer` (`All`) — the issue's exact repro; parity with the interpreter.
- `ReadableStream_PipeTo_PushSourceDelayedAbort_Compiled` — the delayed-abort residual gap.
- `ReadableStream_PipeTo_PushStyleWrite_Compiled` — write that settles via the event loop.

## Verification
- Issue repro: compiled now prints `wrote x` / `done` and exits cleanly (stable over repeated runs).
- Web Streams suite (56) + event-loop/timer/parity suites (208) green.
- New emitted IL verifies clean. (The 6 pre-existing `--verify` field-visibility errors in `$WritableStreamDefaultController`/reader/writer are unrelated and untouched.)