### PR TITLE
Fix #837: compiled async function/arrow read-capture of a block-scope shadow

### DIFF
--- a/Compilation/AsyncStateAnalyzer.cs
+++ b/Compilation/AsyncStateAnalyzer.cs
@@ -127,10 +127,11 @@ public partial class AsyncStateAnalyzer : AstVisitorBase
 
         // Disambiguate block-scoped let/const declarations that shadow an enclosing binding so the
         // hoisting decision below is made per-binding rather than per-name (#766, async analog of #711).
-        // Async free functions lift every captured local (read or write) into a name-keyed function
-        // display class, so a read-only arrow capture cannot use the per-arrow snapshot pivot — keep
-        // such shadows off-limits (arrowReadCapturesShareStorage: true). #767.
-        var renameResult = GeneratorBlockScopeRenamer.Compute(func, arrowReadCapturesShareStorage: true);
+        // A shadow merely READ by a nested arrow is renamed and a capture-source pivot recorded (#767):
+        // DefineAsyncFunction excludes such read-only-captured renamed shadows from the name-keyed
+        // function display class so the arrow's read flows through the per-arrow snapshot path the pivot
+        // redirects, instead of colliding with the outer same-named binding on one DC field (#837).
+        var renameResult = GeneratorBlockScopeRenamer.Compute(func, arrowReadCapturesShareStorage: false);
         _renames = renameResult.Renames;
         _captureRenames = renameResult.CaptureRenames;
 

--- a/Compilation/ILCompiler.Async.cs
+++ b/Compilation/ILCompiler.Async.cs
@@ -71,6 +71,27 @@ public partial class ILCompiler
         if (asyncCapturedVars.Count > 0)
             _closures.AsyncCapturedVarsExclusion[qualifiedFunctionName] = asyncCapturedVars;
 
+        // #837: a nested-block let/const that shadows an enclosing binding and is merely READ by an
+        // inner arrow is now renamed (#767), recording a capture-source pivot. Keep its SOURCE name out
+        // of the name-keyed function DC so the arrow body's read resolves to the arrow's own pivot-aware
+        // snapshot field instead of the shared `$functionDC.<name>` (the resolver prefers the function DC
+        // over the per-arrow field, so the name colliding there is what leaks the outer value). The keys
+        // of BlockScopeCaptureRenames are exactly those read-only-captured renamed shadows (names written
+        // inside any closure are off-limits and never appear). Gate on the promoted-written set so a
+        // same-named mutated capture stays in the DC for verifiable mutation (#625).
+        var readOnlyRenamedShadows = new HashSet<string>();
+        if (analysis.BlockScopeCaptureRenames != null)
+            foreach (var perArrow in analysis.BlockScopeCaptureRenames.Values)
+                readOnlyRenamedShadows.UnionWith(perArrow.Keys);
+        readOnlyRenamedShadows.ExceptWith(promotedToFunctionDC);
+        if (readOnlyRenamedShadows.Count > 0)
+        {
+            if (_closures.AsyncCapturedVarsExclusion.TryGetValue(qualifiedFunctionName, out var existing))
+                existing.UnionWith(readOnlyRenamedShadows);
+            else
+                _closures.AsyncCapturedVarsExclusion[qualifiedFunctionName] = readOnlyRenamedShadows;
+        }
+
         DefineFunctionDisplayClass(funcStmt, qualifiedFunctionName);
 
         // If a function DC was created, add a field on the state machine to hold it
@@ -296,9 +317,11 @@ public partial class ILCompiler
 
         // Disambiguate nested-block let/const shadows so the hoisting decision below is per-binding
         // rather than per-name (#766, async analog of #711).
-        // An async arrow likewise shares its captures by name with inner closures, so keep read-only
-        // captured shadows off-limits (arrowReadCapturesShareStorage: true). #767.
-        var renameResult = GeneratorBlockScopeRenamer.Compute(arrow, arrowReadCapturesShareStorage: true);
+        // A shadow merely READ by a nested arrow is renamed and a capture-source pivot recorded (#767):
+        // an async arrow does not lift read-only captures into a name-keyed function display class (only
+        // promoted WRITTEN captures, #682/#625), so the inner arrow's read flows through the per-arrow
+        // snapshot path the pivot redirects — no DC exclusion is needed here, unlike async functions (#837).
+        var renameResult = GeneratorBlockScopeRenamer.Compute(arrow, arrowReadCapturesShareStorage: false);
         _arrowBlockScopeRenames = renameResult.Renames;
         _arrowBlockScopeCaptureRenames = renameResult.CaptureRenames;
 

--- a/SharpTS.Tests/SharedTests/AsyncBlockScopeShadowTests.cs
+++ b/SharpTS.Tests/SharedTests/AsyncBlockScopeShadowTests.cs
@@ -256,21 +256,18 @@ public class AsyncBlockScopeShadowTests
 
     #endregion
 
-    #region Known residual: async-function read-capture of a shadow shares name-keyed storage (#767)
+    #region Read-capture of a shadow by an inner arrow (#837, async analog of #767)
 
     [Theory]
     [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
-    public void AsyncFunction_NestedBlockShadow_CapturedByArrow_Interpreted(ExecutionMode mode)
+    public void AsyncFunction_NestedBlockShadow_CapturedByArrow(ExecutionMode mode)
     {
-        // Interpreter is correct in both directions and is the reference. Compiled async FUNCTIONS lift
-        // EVERY captured local (read or write) into a name-keyed function display class, so a read-only
-        // arrow capture of a renamed shadow cannot use the per-arrow snapshot pivot that fixes #767 for
-        // (async) generators. Such shadows are therefore kept OFF-LIMITS to renaming in async-function /
-        // async-arrow contexts (no regression from the prior #766 behaviour); a full fix needs the
-        // function DC itself to become rename-aware. This test pins the interpreter contract; the
-        // compiled async-function residual is tracked separately.
-        if (mode == ExecutionMode.Compiled) return;
-
+        // An inner block const that shadows an outer binding AND is read by a nested arrow gets its own
+        // slot; the arrow reads the inner value while the outer keeps its own (#837). Compiled async
+        // FUNCTIONS used to lift every captured local into a name-keyed function display class, so a
+        // read-only arrow capture of the shadow collided with the outer binding on one DC field (leaked
+        // 5,5). The fix renames the shadow (#767 pivot) and excludes it from the function DC so the
+        // arrow's read flows through the per-arrow snapshot path the pivot redirects.
         var source = """
             async function af(): Promise<string> {
               const out: string[] = [];
@@ -289,6 +286,65 @@ public class AsyncBlockScopeShadowTests
             """;
 
         Assert.Equal("5,100\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AsyncArrow_NestedBlockShadow_CapturedByArrow(ExecutionMode mode)
+    {
+        // Async-ARROW analog of the above (#837): the shadow read by an inner arrow gets its own slot.
+        var source = """
+            const af = async (): Promise<string> => {
+              const out: string[] = [];
+              const r = 100;
+              {
+                const r = 5;
+                const f = () => r;
+                await Promise.resolve(0);
+                out.push(String(f()));
+              }
+              out.push(String(r));
+              return out.join(",");
+            };
+            async function main() { console.log(await af()); }
+            main();
+            """;
+
+        Assert.Equal("5,100\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AsyncFunction_TwoShadowsReadCapturedByDistinctArrows(ExecutionMode mode)
+    {
+        // Two independent nested-block shadows, each read by its own arrow, must each get their own slot
+        // without cross-contamination (#837). Confirms the exclusion handles more than one renamed shadow.
+        var source = """
+            async function af(): Promise<string> {
+              const out: string[] = [];
+              const r = 100;
+              const s = 200;
+              {
+                const r = 5;
+                const f = () => r;
+                await Promise.resolve(0);
+                out.push(String(f()));
+              }
+              {
+                const s = 9;
+                const g = () => s;
+                await Promise.resolve(0);
+                out.push(String(g()));
+              }
+              out.push(String(r));
+              out.push(String(s));
+              return out.join(",");
+            }
+            async function main() { console.log(await af()); }
+            main();
+            """;
+
+        Assert.Equal("5,9,100,200\n", TestHarness.Run(source, mode));
     }
 
     #endregion


### PR DESCRIPTION
Closes #837.

## Problem

In **compiled** async functions/arrows, a nested-block `let`/`const` that shadows an enclosing binding and is **read by a nested arrow** leaked the outer value (the documented residual of #767):

```ts
async function af(): Promise<string> {
  const out: string[] = [];
  const r = 100;
  { const r = 5; const f = () => r; await Promise.resolve(0); out.push(String(f())); }
  out.push(String(r));
  return out.join(",");
}
```
Interpreted → `5,100` (correct). Compiled → `5,5` (wrong).

## Root cause

Async free functions lift **every** captured local into a **name-keyed** function display class (DC). `LocalVariableResolver` resolves the `$functionDC.<name>` field **before** the arrow's own pivot-aware snapshot field, so inner and outer same-named bindings collide on one DC slot. #767 fixed this for (async) generators (which lift only captured-and-mutated locals) but kept async functions/arrows conservative via `arrowReadCapturesShareStorage: true`.

## Fix (issue's Follow-up A)

- Flip `arrowReadCapturesShareStorage` to `false` for async functions and async arrows, so a read-only-captured shadow is **renamed** and a capture-source pivot recorded (the per-arrow snapshot path is already pivot-aware — `AsyncMoveNextEmitter.ArrowFunctions.cs`).
- In `DefineAsyncFunction`, **exclude** those read-only renamed shadows from the function DC, gated on the promoted-written set (`ComputeArrowWrittenCapturesToPromote`) so a same-named **mutated** capture stays in the DC for verifiable mutation (#625). The arrow's read then falls to the per-arrow snapshot field, which pivots to the renamed storage.
- Async arrows need only the flag flip — they never lift read-only captures into a name-keyed function DC (only promoted written captures, #682/#625).

Analyzer/registration-side only; **no new IL emitted**. Generators/async-gens are untouched (already pass `false`).

## Tests (`AsyncBlockScopeShadowTests`)

- Un-skipped the previously compiled-skipped contract test (now `AsyncFunction_NestedBlockShadow_CapturedByArrow`, runs both modes → `5,100`).
- Added an async-arrow analog and a two-distinct-shadows test.

## Verification

- `AsyncBlockScopeShadowTests`: **26/26 pass**.
- Generator/Async/Closure regression: **1956/1956 pass**.
- Full suite: only the pre-existing flaky Test262 `new`+spread baseline entries fail — confirmed identical on the clean base (`origin/main`), unrelated to this change.

## Out of scope (unchanged, not a regression)

A shadow **written** inside any closure stays off-limits to renaming (collapses inner/outer, e.g. `5,6`) — the documented #767 restriction. The exclusion gate is consequently a defensive no-op for that case.