### PR TITLE
Fix #747: serialize cluster tests to stop full-suite-load timeout flake

### DIFF
--- a/SharpTS.Tests/Infrastructure/ClusterTestsCollection.cs
+++ b/SharpTS.Tests/Infrastructure/ClusterTestsCollection.cs
@@ -1,0 +1,21 @@
+using Xunit;
+
+namespace SharpTS.Tests.Infrastructure;
+
+/// <summary>
+/// Defines the "ClusterTests" collection. Disables parallelization so cluster tests
+/// (which fork worker threads and bind real OS ports via ClusterSingleton) never run
+/// concurrently with the rest of the suite — prevents the CPU/port contention that times
+/// out fork+port-bind tests under full-suite parallel load (issue #747).
+/// </summary>
+/// <remarks>
+/// Without a matching CollectionDefinition, the <c>[Collection("ClusterTests")]</c> on
+/// <c>ClusterModuleTests</c> binds to an implicit, parallelizable collection: its tests run
+/// sequentially relative to each other (they share the <c>ClusterSingleton</c> global) but the
+/// whole collection still runs concurrently with every other collection. This definition makes
+/// xUnit schedule it in the non-parallel phase instead.
+/// </remarks>
+[CollectionDefinition("ClusterTests", DisableParallelization = true)]
+public class ClusterTestsCollection
+{
+}

--- a/SharpTS.Tests/Infrastructure/TestHarness.cs
+++ b/SharpTS.Tests/Infrastructure/TestHarness.cs
@@ -71,11 +71,11 @@ public static class TestHarness
     /// <param name="entryPoint">Path to the entry point module</param>
     /// <param name="mode">Execution mode (Interpreted or Compiled)</param>
     /// <returns>Captured console output</returns>
-    public static string RunModules(Dictionary<string, string> files, string entryPoint, ExecutionMode mode)
+    public static string RunModules(Dictionary<string, string> files, string entryPoint, ExecutionMode mode, TimeSpan? timeout = null)
     {
         return mode switch
         {
-            ExecutionMode.Interpreted => RunModulesInterpreted(files, entryPoint),
+            ExecutionMode.Interpreted => RunModulesInterpreted(files, entryPoint, timeout),
             ExecutionMode.Compiled => RunModulesCompiled(files, entryPoint),
             _ => throw new ArgumentOutOfRangeException(nameof(mode))
         };
@@ -654,13 +654,15 @@ public static class TestHarness
     /// <param name="files">Dictionary mapping file paths to source code</param>
     /// <param name="entryPoint">The entry point file path (e.g., "./main.ts")</param>
     /// <returns>Captured console output</returns>
-    public static string RunModulesInterpreted(Dictionary<string, string> files, string entryPoint)
+    public static string RunModulesInterpreted(Dictionary<string, string> files, string entryPoint, TimeSpan? timeout = null)
     {
+        var effectiveTimeout = timeout ?? DefaultTimeout;
+
         // Tests using __dirname / __filename / cluster.fork need files to exist on a real
         // disk path that the runtime can stat / spawn workers against; route those through
         // the disk-based path. Everything else uses the in-memory virtual file system.
         if (RequiresRealDisk(files.Values))
-            return RunModulesInterpretedOnDisk(files, entryPoint);
+            return RunModulesInterpretedOnDisk(files, entryPoint, effectiveTimeout);
 
         // Build an in-memory virtual file system instead of writing to %TEMP%. Concurrent
         // disk operations on Windows serialize through the kernel/AV — measured 1.4× speedup
@@ -686,11 +688,11 @@ public static class TestHarness
 
         try
         {
-            if (task.Wait(DefaultTimeout))
+            if (task.Wait(effectiveTimeout))
                 return task.Result;
 
             throw new TimeoutException(
-                $"Interpreted module execution exceeded {DefaultTimeout.TotalSeconds}s timeout.");
+                $"Interpreted module execution exceeded {effectiveTimeout.TotalSeconds}s timeout.");
         }
         catch (AggregateException ex)
         {
@@ -783,8 +785,10 @@ public static class TestHarness
     /// then runs the interpreter in-process. Used for tests that depend on real-disk paths
     /// (<c>__dirname</c>, <c>cluster.fork</c>) — see <see cref="RequiresRealDisk"/>.
     /// </summary>
-    private static string RunModulesInterpretedOnDisk(Dictionary<string, string> files, string entryPoint)
+    private static string RunModulesInterpretedOnDisk(Dictionary<string, string> files, string entryPoint, TimeSpan? timeout = null)
     {
+        var effectiveTimeout = timeout ?? DefaultTimeout;
+
         var tempDir = Path.Combine(Path.GetTempPath(), $"sharpts_module_test_{Guid.NewGuid()}");
         Directory.CreateDirectory(tempDir);
 
@@ -819,10 +823,10 @@ public static class TestHarness
 
             try
             {
-                if (task.Wait(DefaultTimeout))
+                if (task.Wait(effectiveTimeout))
                     return task.Result;
                 throw new TimeoutException(
-                    $"Interpreted module execution exceeded {DefaultTimeout.TotalSeconds}s timeout.");
+                    $"Interpreted module execution exceeded {effectiveTimeout.TotalSeconds}s timeout.");
             }
             catch (AggregateException ex) when (ex.InnerExceptions.Count == 1)
             {

--- a/SharpTS.Tests/SharedTests/BuiltInModules/ClusterModuleTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/ClusterModuleTests.cs
@@ -25,16 +25,49 @@ public class ClusterModuleTests : IDisposable
     }
 
     /// <summary>
-    /// Allocates a free TCP port by binding to port 0 and reading the assigned port.
-    /// The listener is stopped immediately, freeing the port for the test to use.
+    /// Fork+port tests spin up worker threads, bind a real OS port, and round-trip a request.
+    /// Under load that can take noticeably longer than a plain module run, so they use a higher
+    /// timeout than <see cref="TestHarness.DefaultTimeout"/> (issue #747).
+    /// </summary>
+    private static readonly TimeSpan PortTestTimeout = TimeSpan.FromSeconds(60);
+
+    /// <summary>
+    /// Allocates a free TCP loopback port for a cluster test to bind. Binds to port 0 to let the
+    /// OS assign a free port, then releases it so the guest interpreter can re-bind it. That
+    /// release→re-bind handoff has a TOCTOU window, so the candidate is verified bindable once
+    /// more before being returned, re-rolling if a racing test claimed it in between.
     /// </summary>
     private static int GetFreePort()
     {
-        var listener = new TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        int port = ((IPEndPoint)listener.LocalEndpoint).Port;
-        listener.Stop();
-        return port;
+        const int attempts = 5;
+        for (int i = 0; i < attempts; i++)
+        {
+            var listener = new TcpListener(IPAddress.Loopback, 0);
+            listener.Start();
+            int port = ((IPEndPoint)listener.LocalEndpoint).Port;
+            listener.Stop();
+
+            // Confirm the port is still free after the release; if a concurrent test grabbed it
+            // in the gap, re-roll rather than hand back a contended port.
+            try
+            {
+                var verify = new TcpListener(IPAddress.Loopback, port);
+                verify.Start();
+                verify.Stop();
+                return port;
+            }
+            catch (SocketException)
+            {
+                // Port taken between Stop() and the verify bind — try again.
+            }
+        }
+
+        // Fall back to a plain OS-assigned port if every verification raced (extremely unlikely).
+        var fallback = new TcpListener(IPAddress.Loopback, 0);
+        fallback.Start();
+        int fallbackPort = ((IPEndPoint)fallback.LocalEndpoint).Port;
+        fallback.Stop();
+        return fallbackPort;
     }
 
     #region Import and Basic Properties
@@ -434,7 +467,7 @@ public class ClusterModuleTests : IDisposable
                 """
         };
 
-        var output = TestHarness.RunModules(files, "main.ts", mode);
+        var output = TestHarness.RunModules(files, "main.ts", mode, PortTestTimeout);
         Assert.Contains("responses: 4", output);
     }
 
@@ -490,7 +523,7 @@ public class ClusterModuleTests : IDisposable
                 """
         };
 
-        var output = TestHarness.RunModules(files, "main.ts", mode);
+        var output = TestHarness.RunModules(files, "main.ts", mode, PortTestTimeout);
         Assert.Contains("after kill: worker-", output);
     }
 
@@ -538,7 +571,7 @@ public class ClusterModuleTests : IDisposable
                 """
         };
 
-        var output = TestHarness.RunModules(files, "main.ts", mode);
+        var output = TestHarness.RunModules(files, "main.ts", mode, PortTestTimeout);
         Assert.Contains("port was working", output);
         Assert.Contains("worker exited", output);
     }
@@ -591,7 +624,7 @@ public class ClusterModuleTests : IDisposable
                 """
         };
 
-        var output = TestHarness.RunModules(files, "main.ts", mode);
+        var output = TestHarness.RunModules(files, "main.ts", mode, PortTestTimeout);
         Assert.Contains("http response: worker-", output);
     }
 


### PR DESCRIPTION
## Summary

Fixes #747 — `ClusterModuleTests.Fork_WorkersShareHttpPort(Interpreted)` intermittently timed out (30s) during full `dotnet test` runs but passed reliably in isolation.

**Root cause:** `ClusterModuleTests` is annotated `[Collection("ClusterTests")]` but there was **no matching `[CollectionDefinition("ClusterTests")]`** in the test project. xUnit therefore treated it as an *implicit, parallelizable* collection: its tests ran sequentially relative to each other (they share the `ClusterSingleton` global), but the whole collection ran **concurrently with the rest of the suite** under `xunit.runner.json` (`parallelizeTestCollections: true`, `maxParallelThreads: 0`, `parallelAlgorithm: "aggressive"`). Under that load, two `cluster.fork()` workers binding a port + the primary's `fetch` round-trip exceeded the hard-coded 30s `TestHarness.DefaultTimeout`.

## Changes (test-infrastructure only)

1. **Serialize the collection (primary fix)** — new `SharpTS.Tests/Infrastructure/ClusterTestsCollection.cs` with `[CollectionDefinition("ClusterTests", DisableParallelization = true)]`, so xUnit schedules the cluster tests in its non-parallel phase. Mirrors the existing `TimerTestsCollection` / `DnsFakeServerEnvCollection` pattern.
2. **Harden `GetFreePort()`** — verifies the OS-assigned port is still bindable after release and re-rolls on the TOCTOU race instead of handing back a contended port.
3. **Configurable timeout** — threads an optional `TimeSpan? timeout` through `RunModules` → `RunModulesInterpreted` → `RunModulesInterpretedOnDisk` (defaults to `DefaultTimeout`); the four port-binding fork tests pass a 60s `PortTestTimeout` for headroom.

No production interpreter/compiler code is touched.

## Verification

- `dotnet build SharpTS.Tests` — Build succeeded.
- `dotnet test --filter "FullyQualifiedName~ClusterModuleTests"` — 21/21 passed on consecutive runs (incl. `Fork_WorkersShareHttpPort`).

The structural fix (serialized collection) only manifests under full-suite load, so CI's full run is the definitive check.