### PR TITLE
Fix #776: compiled class-expression async method emits real async state machine

### DIFF
--- a/Compilation/ILCompiler.Classes.ClassExpressions.cs
+++ b/Compilation/ILCompiler.Classes.ClassExpressions.cs
@@ -836,10 +836,13 @@ public partial class ILCompiler
             return;
         }
 
-        // Handle async methods via state machine
+        // Async (non-generator) methods route through the same async state-machine emitter as
+        // class declarations (#776), mirroring the async-generator line above. The earlier stub
+        // emitted the body synchronously and returned Task.FromResult(null), so `return <value>`
+        // produced a raw value (breaking `.then`) and an `await` in the body emitted invalid IL.
         if (method.IsAsync)
         {
-            EmitClassExpressionAsyncMethod(classExpr, typeBuilder, method, methodBuilder, fieldsField);
+            EmitAsyncMethodBody(methodBuilder, method, fieldsField);
             return;
         }
 
@@ -909,9 +912,14 @@ public partial class ILCompiler
             return;
         }
 
+        // Async (non-generator) static methods route through the shared async state-machine
+        // emitter (#776), mirroring the static async-generator line above. EmitAsyncMethodBody
+        // takes the methodBuilder directly (deriving SM name/lock fields from its DeclaringType),
+        // so it works for the class-expression builder — unlike the declaration's
+        // EmitStaticAsyncMethodBody, which re-resolves from the declaration registry.
         if (method.IsAsync)
         {
-            EmitClassExpressionStaticAsyncMethod(classExpr, typeBuilder, method, methodBuilder);
+            EmitAsyncMethodBody(methodBuilder, method, fieldsField: null, isInstanceMethod: false);
             return;
         }
 
@@ -1120,101 +1128,6 @@ public partial class ILCompiler
             // sentinel instead of CLR null. (#588)
             EmitDefaultReturnValue(il, methodBuilder.ReturnType);
             il.Emit(OpCodes.Ret);
-        }
-    }
-
-    /// <summary>
-    /// Emits an async instance method for a class expression using state machine.
-    /// </summary>
-    private void EmitClassExpressionAsyncMethod(
-        Expr.ClassExpr classExpr,
-        TypeBuilder typeBuilder,
-        Stmt.Function method,
-        MethodBuilder methodBuilder,
-        FieldInfo fieldsField)
-    {
-        // For now, emit a simple wrapper that runs synchronously and returns Task.FromResult
-        // Full state machine support can be added later if needed
-        var il = methodBuilder.GetILGenerator();
-        var ctx = CreateClassExpressionContext(il, classExpr, typeBuilder, fieldsField);
-        ctx.IsInstanceMethod = true;
-
-        // Define parameters with typed parameter types from method signature
-        var methodParams = methodBuilder.GetParameters();
-        for (int i = 0; i < method.Parameters.Count; i++)
-        {
-            Type? paramType = i < methodParams.Length ? methodParams[i].ParameterType : null;
-            ctx.DefineParameter(method.Parameters[i].Name.Lexeme, i + 1, paramType);
-        }
-
-        var emitter = new ILEmitter(ctx);
-        emitter.EmitDefaultParameters(method.Parameters, true);
-
-        // Emit body statements
-        if (method.Body != null)
-        {
-            foreach (var stmt in method.Body)
-            {
-                emitter.EmitStatement(stmt);
-            }
-        }
-
-        // Return Task.FromResult(null)
-        if (!emitter.HasDeferredReturns)
-        {
-            il.Emit(OpCodes.Ldnull);
-            il.Emit(OpCodes.Call, typeof(Task).GetMethod("FromResult")!.MakeGenericMethod(typeof(object)));
-            il.Emit(OpCodes.Ret);
-        }
-        else
-        {
-            emitter.FinalizeReturns();
-        }
-    }
-
-    /// <summary>
-    /// Emits an async static method for a class expression.
-    /// </summary>
-    private void EmitClassExpressionStaticAsyncMethod(
-        Expr.ClassExpr classExpr,
-        TypeBuilder typeBuilder,
-        Stmt.Function method,
-        MethodBuilder methodBuilder)
-    {
-        var il = methodBuilder.GetILGenerator();
-        var ctx = CreateClassExpressionContext(il, classExpr, typeBuilder, null);
-        ctx.IsInstanceMethod = false;
-
-        // Define parameters with typed parameter types from method signature
-        var methodParams = methodBuilder.GetParameters();
-        for (int i = 0; i < method.Parameters.Count; i++)
-        {
-            Type? paramType = i < methodParams.Length ? methodParams[i].ParameterType : null;
-            ctx.DefineParameter(method.Parameters[i].Name.Lexeme, i, paramType);
-        }
-
-        var emitter = new ILEmitter(ctx);
-        emitter.EmitDefaultParameters(method.Parameters, false);
-
-        // Emit body statements
-        if (method.Body != null)
-        {
-            foreach (var stmt in method.Body)
-            {
-                emitter.EmitStatement(stmt);
-            }
-        }
-
-        // Return Task.FromResult(null)
-        if (!emitter.HasDeferredReturns)
-        {
-            il.Emit(OpCodes.Ldnull);
-            il.Emit(OpCodes.Call, typeof(Task).GetMethod("FromResult")!.MakeGenericMethod(typeof(object)));
-            il.Emit(OpCodes.Ret);
-        }
-        else
-        {
-            emitter.FinalizeReturns();
         }
     }
 }

--- a/SharpTS.Tests/SharedTests/ClassExpressionTests.cs
+++ b/SharpTS.Tests/SharedTests/ClassExpressionTests.cs
@@ -510,6 +510,52 @@ public class ClassExpressionTests
         Assert.Equal("5\n6\n", TestHarness.Run(source, mode));
     }
 
+    // #776: a class-EXPRESSION async (non-generator) method must compile to a real async state
+    // machine returning a Promise. The compiled path previously emitted a synchronous stub that
+    // returned the raw value, so `.then` threw (Double is not a Task) and an `await` in the body
+    // emitted invalid IL. The interpreter and type-checker (#793) already handled these.
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ClassExpression_AsyncMethod_ThenReceivesValue(ExecutionMode mode)
+    {
+        var source = """
+            const C = class { async m() { return 5; } };
+            (new C().m() as Promise<number>).then(v => console.log(v));
+            """;
+
+        Assert.Equal("5\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ClassExpression_StaticAsyncMethod_ThenReceivesValue(ExecutionMode mode)
+    {
+        var source = """
+            const C = class { static async m() { return 7; } };
+            (C.m() as Promise<number>).then(v => console.log(v));
+            """;
+
+        Assert.Equal("7\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ClassExpression_AsyncMethod_AwaitsAndReadsInstanceField(ExecutionMode mode)
+    {
+        // A real suspension point (await) plus a `this` field read proves the state machine and
+        // fieldsField wiring, not just a value passthrough.
+        var source = """
+            const C = class {
+                v = 10;
+                async m(n: number) { const x = await Promise.resolve(n); return x + this.v; }
+            };
+            async function main() { console.log(await new C().m(5)); }
+            main();
+            """;
+
+        Assert.Equal("15\n", TestHarness.Run(source, mode));
+    }
+
     #endregion
 
     #region Inferred Method Return Propagation (#793)


### PR DESCRIPTION
## Problem

A compiled class-**expression** async (non-generator) method returning a value returned a raw value instead of a Promise, so `.then()` threw:

```ts
const C = class { async m() { return 5; } };
(new C().m() as Promise<number>).then(v => console.log(v));
// interp → 5 ; compiled → InvalidCastException: Double is not Task`1
```

`await new C().m()` happened to work (await tolerates a plain value), which masked the bug — `.then` is the discriminating repro.

The type-checker inference half was already fixed by #793; this is the remaining **compiled codegen** gap.

## Root cause

`Compilation/ILCompiler.Classes.ClassExpressions.cs` routed async (non-generator) class-expression methods to two stub emitters (`EmitClassExpressionAsyncMethod` / `EmitClassExpressionStaticAsyncMethod`) carrying the comment *"For now, emit a simple wrapper... Full state machine support can be added later"*. They emitted the body inline, so `return 5` left a raw double on the stack (and an `await` in the body emitted invalid IL). Async **generators** in class expressions already worked — they route through the shared `EmitAsyncGeneratorMethodBody` (#765/#778) — plain async was simply missed in that same routing.

## Fix

Route instance and static async class-expression methods through the shared `EmitAsyncMethodBody` state-machine emitter the class-**declaration** path already uses, mirroring the async-generator line directly above each site. `EmitAsyncMethodBody` takes the `methodBuilder` directly and derives the state-machine name / lock fields / `this`+field access from its `DeclaringType`, so it works for the class-expression builder. Deleted the two now-unused stub emitters. No type-checker, interpreter, or signature changes needed (return type was already `Task<object>`).

## Verification

- Compiled repros now correct: `.then` instance → `5`, `.then` static → `7`, `await`+`this.field` → `15` (all previously threw `InvalidCastException`).
- IL verification passes.
- +6 tests (3 theories × interp/compiled) in `SharpTS.Tests/SharedTests/ClassExpressionTests.cs`.
- Full suite: **13754 passed, 0 failed**.

Closes #776.