### PR TITLE
Fix #838: rename-aware $functionDC for write-captured block-scope shadows

### DIFF
--- a/Compilation/CompilationContext.Closures.cs
+++ b/Compilation/CompilationContext.Closures.cs
@@ -145,6 +145,29 @@ public partial class CompilationContext
     public FieldBuilder? CurrentArrowFunctionDCField { get; set; }
 
     /// <summary>
+    /// When inside an arrow body, maps a captured variable's source name to the renamed storage key of
+    /// its function-display-class field (#838). A nested-block <c>let</c>/<c>const</c> that shadows an
+    /// enclosing binding and is WRITTEN by this arrow is lifted into the shared <c>$functionDC</c> under a
+    /// disambiguated storage name (<c>&lt;r&gt;__bsN</c>), while the outer same-named binding keeps the
+    /// field <c>r</c>. Without this remap the arrow's <c>r</c> would resolve to the outer field and the
+    /// two bindings would collide. <see cref="LocalVariableResolver"/> maps the name through this table
+    /// before the <see cref="CapturedFunctionLocals"/> / <see cref="FunctionDisplayClassFields"/> lookup.
+    /// Null when the arrow captures no renamed write-shadow (the common case).
+    /// </summary>
+    public Dictionary<string, string>? CurrentArrowFunctionDCFieldRenames { get; set; }
+
+    /// <summary>
+    /// Maps a captured variable's source name to the key under which its function-display-class field is
+    /// registered (#838). In an arrow body this redirects a write-captured block-scope shadow to its
+    /// renamed storage (<c>&lt;r&gt;__bsN</c>) so reads and writes reach the shadow's field instead of the
+    /// outer same-named binding's. Returns <paramref name="name"/> unchanged when no remap applies (the
+    /// common case). Consulted by every function-DC load/store site — <see cref="LocalVariableResolver"/>
+    /// and the hand-rolled assignment / increment / declaration paths in <c>ILEmitter</c>.
+    /// </summary>
+    public string ResolveFunctionDCFieldName(string name) =>
+        CurrentArrowFunctionDCFieldRenames is { } m && m.TryGetValue(name, out var storage) ? storage : name;
+
+    /// <summary>
     /// For an async arrow's MoveNext: the <c>&lt;&gt;__functionDC</c> field on the enclosing async
     /// function's state machine. Combined with <see cref="FunctionDisplayClassFields"/>, it lets the
     /// arrow read/write captured locals that were promoted into the (reference-type) function display

--- a/Compilation/GeneratorBlockScopeRenamer.cs
+++ b/Compilation/GeneratorBlockScopeRenamer.cs
@@ -13,18 +13,30 @@ namespace SharpTS.Compilation;
 /// (retoken before field/local access). Empty when nothing shadows.
 /// </param>
 /// <param name="CaptureRenames">
-/// Capturing-arrow node → (captured source name → renamed generator storage). When an arrow lexically
-/// captures a shadowing block-scoped binding that <see cref="Renames"/> moved to its own storage, the
-/// arrow's display-class field must be sourced from that storage rather than the outer same-named
-/// binding. The capture-population step consults this map to pivot the SOURCE of the field (the arrow's
-/// own DC field keeps the original name). Empty unless a renamed shadow is closure-captured.
+/// Capturing-arrow node → (captured source name → renamed generator storage), for shadows an arrow only
+/// READS. When an arrow lexically captures a shadowing block-scoped binding that <see cref="Renames"/>
+/// moved to its own storage, the arrow's by-value display-class field must be sourced from that storage
+/// rather than the outer same-named binding. The capture-population step consults this map to pivot the
+/// SOURCE of the field (the arrow's own DC field keeps the original name). Empty unless a renamed
+/// read-only shadow is closure-captured.
+/// </param>
+/// <param name="WriteCaptureRenames">
+/// Capturing-arrow node → (captured source name → renamed generator storage), for shadows an arrow
+/// WRITES (so they are lifted into the shared, name-keyed function display class <c>$functionDC</c>,
+/// #674/#725). Unlike <see cref="CaptureRenames"/> (a by-value snapshot pivot), these drive the
+/// rename-aware DC: the DC field is registered under the renamed storage, and the arrow body's
+/// read/write of the capture is remapped to <c>$functionDC.&lt;name&gt;__bsN</c> instead of the outer
+/// same-named binding's field (#838). A shadow both read and written by the same arrow is recorded here
+/// (a write makes it DC-backed). Empty unless a renamed write-captured shadow exists.
 /// </param>
 internal sealed record BlockScopeRenameResult(
     IReadOnlyDictionary<object, string> Renames,
-    IReadOnlyDictionary<object, IReadOnlyDictionary<string, string>> CaptureRenames)
+    IReadOnlyDictionary<object, IReadOnlyDictionary<string, string>> CaptureRenames,
+    IReadOnlyDictionary<object, IReadOnlyDictionary<string, string>> WriteCaptureRenames)
 {
     public static readonly BlockScopeRenameResult Empty = new(
         new Dictionary<object, string>(),
+        new Dictionary<object, IReadOnlyDictionary<string, string>>(),
         new Dictionary<object, IReadOnlyDictionary<string, string>>());
 }
 
@@ -47,14 +59,17 @@ internal sealed record BlockScopeRenameResult(
 /// <see cref="GeneratorStateAnalyzer"/> and <see cref="GeneratorMoveNextEmitter"/> consult the map so the
 /// hoist-vs-local decision and the field/local access become per-binding instead of per-name.
 ///
-/// Closure interaction (#767): a shadowing binding that an inner <em>arrow</em> reads is still renamed,
-/// and the renamer additionally records, per capturing arrow, the source name → storage mapping so the
-/// capture-population step sources the arrow's field from the renamed generator storage rather than the
-/// outer same-named binding. The arrow's own display-class field keeps the original name (the arrow body
-/// is compiled in its own context and is never rewritten). Two shapes the capture pivot cannot honour
-/// stay OFF-LIMITS (left unrenamed, the conservative #711 behaviour): a binding <em>written</em> inside
-/// any closure (it flows through the name-keyed <c>$functionDC</c> path, #674/#725), and a binding read
-/// by a nested <em>non-arrow</em> function/class (it flows through the name-keyed lambda-lift path).
+/// Closure interaction (#767/#838): a shadowing binding that an inner <em>arrow</em> reads or writes is
+/// still renamed, and the renamer records, per capturing arrow, the source name → storage mapping. A
+/// READ-only capture is recorded in <see cref="BlockScopeRenameResult.CaptureRenames"/> so the
+/// capture-population step sources the arrow's by-value field from the renamed generator storage (#767);
+/// a WRITE capture is recorded in <see cref="BlockScopeRenameResult.WriteCaptureRenames"/> so the
+/// rename-aware <c>$functionDC</c> registers its shared field under the renamed storage and the arrow
+/// body's access is redirected there (#838). The arrow body is compiled in its own context and its
+/// reference nodes are never rewritten — only the source pivot is recorded. One shape the capture pivot
+/// still cannot honour stays OFF-LIMITS (left unrenamed, the conservative #711 behaviour): a binding read
+/// or written by a nested <em>non-arrow</em> function/class (it flows through the name-keyed lambda-lift
+/// path the pivot cannot redirect).
 ///
 /// Restrictions that keep the rewrite sound:
 /// <list type="bullet">
@@ -74,13 +89,20 @@ internal sealed class GeneratorBlockScopeRenamer : AstVisitorBase
 {
     // Keyed by AST-node reference (records use value equality, so reference identity is mandatory here).
     private readonly Dictionary<object, string> _renames = new(ReferenceEqualityComparer.Instance);
-    // Capturing-arrow node → (captured source name → renamed generator storage). Reference-identity keyed.
+    // Capturing-arrow node → (captured source name → renamed generator storage), for READ-only captures
+    // (by-value snapshot pivot). Reference-identity keyed.
     private readonly Dictionary<object, Dictionary<string, string>> _captureSources = new(ReferenceEqualityComparer.Instance);
+    // Capturing-arrow node → (captured source name → renamed generator storage), for WRITE captures
+    // (shared $functionDC, #838). Reference-identity keyed.
+    private readonly Dictionary<object, Dictionary<string, string>> _writeCaptureSources = new(ReferenceEqualityComparer.Instance);
     // Scope stack of name -> storage-name (storage == name when the binding is not renamed).
     private readonly List<Dictionary<string, string>> _scopes = [];
-    // Names a closure makes off-limits to renaming (written in any closure, or read by a non-arrow
-    // function/class). See CaptureClassifier.
+    // Names a closure makes off-limits to renaming: read by a non-arrow function/class, or written under a
+    // non-arrow function/class (both name-keyed lambda-lift paths the capture pivot cannot honour).
     private readonly HashSet<string> _renameOffLimits = [];
+    // Names WRITTEN inside an arrow only (no intervening non-arrow function/class): renameable and
+    // DC-backed — the arrow's accesses route to the shared $functionDC field (#674/#725/#838).
+    private readonly HashSet<string> _writeCaptured = [];
     private int _counter;
     // Depth of nested arrows currently being walked (0 == directly in the state-machine body).
     private int _arrowDepth;
@@ -116,7 +138,7 @@ internal sealed class GeneratorBlockScopeRenamer : AstVisitorBase
         var renamer = new GeneratorBlockScopeRenamer();
         if (body == null) return BlockScopeRenameResult.Empty;   // expression-bodied arrow: nothing to rename
 
-        new CaptureClassifier(renamer._renameOffLimits, arrowReadCapturesShareStorage).Run(body);
+        new CaptureClassifier(renamer._renameOffLimits, renamer._writeCaptured, arrowReadCapturesShareStorage).Run(body);
 
         renamer.PushScope();
         // The callable's own name is in scope inside the body (a named function expression can call
@@ -131,13 +153,16 @@ internal sealed class GeneratorBlockScopeRenamer : AstVisitorBase
             renamer.Visit(stmt);
         renamer.PopScope();
 
-        if (renamer._renames.Count == 0 && renamer._captureSources.Count == 0)
+        if (renamer._renames.Count == 0 && renamer._captureSources.Count == 0 && renamer._writeCaptureSources.Count == 0)
             return BlockScopeRenameResult.Empty;
 
         var captures = new Dictionary<object, IReadOnlyDictionary<string, string>>(ReferenceEqualityComparer.Instance);
         foreach (var (arrow, names) in renamer._captureSources)
             captures[arrow] = names;
-        return new BlockScopeRenameResult(renamer._renames, captures);
+        var writeCaptures = new Dictionary<object, IReadOnlyDictionary<string, string>>(ReferenceEqualityComparer.Instance);
+        foreach (var (arrow, names) in renamer._writeCaptureSources)
+            writeCaptures[arrow] = names;
+        return new BlockScopeRenameResult(renamer._renames, captures, writeCaptures);
     }
 
     private Dictionary<string, string> CurrentScope => _scopes[^1];
@@ -192,11 +217,14 @@ internal sealed class GeneratorBlockScopeRenamer : AstVisitorBase
         }
         else if (_currentTopArrow != null)
         {
-            // Reference inside a nested arrow that lexically binds to a renamed generator shadow:
-            // record the source pivot so the arrow's captured field is populated from that storage.
-            // The reference node itself is NOT renamed (the arrow body compiles in its own context).
-            if (!_captureSources.TryGetValue(_currentTopArrow, out var names))
-                _captureSources[_currentTopArrow] = names = [];
+            // Reference inside a nested arrow that lexically binds to a renamed generator shadow. The
+            // reference node itself is NOT renamed (the arrow body compiles in its own context); instead
+            // the source name → storage pivot is recorded so the emit phase can redirect it. A WRITE
+            // capture is DC-backed (the arrow shares $functionDC.<storage>, #838); a read-only capture is
+            // snapshot-backed (the arrow's by-value field is sourced from <storage>, #767).
+            var sink = _writeCaptured.Contains(name) ? _writeCaptureSources : _captureSources;
+            if (!sink.TryGetValue(_currentTopArrow, out var names))
+                sink[_currentTopArrow] = names = [];
             names[name] = storage;
         }
     }
@@ -369,23 +397,32 @@ internal sealed class GeneratorBlockScopeRenamer : AstVisitorBase
     #endregion
 
     /// <summary>
-    /// Classifies which names are off-limits to renaming because a nested closure flows them through
-    /// name-keyed machinery the capture pivot cannot honour: a name WRITTEN inside any closure (the
-    /// <c>$functionDC</c> shared-storage path, #674/#725) or a name READ inside a non-arrow function /
-    /// class (the lambda-lift path). A name only READ inside an arrow stays renameable — the renamer
-    /// pivots that arrow's capture source to the renamed storage (#767).
+    /// Classifies, for each name a nested closure flows through name-keyed machinery, whether it is
+    /// off-limits to renaming or renameable-but-DC-backed:
+    /// <list type="bullet">
+    /// <item>READ inside a non-arrow function / class, or WRITTEN under a non-arrow function / class →
+    /// OFF-LIMITS (the lambda-lift path keys by the original name, which the capture pivot cannot
+    /// redirect).</item>
+    /// <item>WRITTEN inside an arrow only (no intervening non-arrow function / class) → WRITE-CAPTURED:
+    /// renameable, with the arrow's accesses routed to the shared <c>$functionDC.&lt;storage&gt;</c>
+    /// (#674/#725/#838).</item>
+    /// <item>READ-only inside an arrow → renameable via the by-value snapshot pivot (#767).</item>
+    /// </list>
     /// </summary>
     private sealed class CaptureClassifier : AstVisitorBase
     {
         private readonly HashSet<string> _offLimits;
+        private readonly HashSet<string> _writeCaptured;
         // True when even a read by an arrow shares name-keyed storage (async functions / arrows).
         private readonly bool _arrowReadsOffLimits;
-        private int _closureDepth;   // inside any closure (arrow / function / class)
-        private int _nonArrowDepth;  // inside a function / class (not an arrow)
+        private int _closureDepth;     // inside any closure (arrow / function / class)
+        private int _nonArrowDepth;    // inside a function / class (not an arrow)
+        private int _asyncArrowDepth;  // inside an async arrow (its writes use the unwired promotion path)
 
-        public CaptureClassifier(HashSet<string> offLimits, bool arrowReadsOffLimits)
+        public CaptureClassifier(HashSet<string> offLimits, HashSet<string> writeCaptured, bool arrowReadsOffLimits)
         {
             _offLimits = offLimits;
+            _writeCaptured = writeCaptured;
             _arrowReadsOffLimits = arrowReadsOffLimits;
         }
 
@@ -397,7 +434,9 @@ internal sealed class GeneratorBlockScopeRenamer : AstVisitorBase
         protected override void VisitArrowFunction(Expr.ArrowFunction expr)
         {
             _closureDepth++;
+            if (expr.IsAsync) _asyncArrowDepth++;
             base.VisitArrowFunction(expr);
+            if (expr.IsAsync) _asyncArrowDepth--;
             _closureDepth--;
         }
 
@@ -447,9 +486,14 @@ internal sealed class GeneratorBlockScopeRenamer : AstVisitorBase
             base.VisitPostfixIncrement(expr);
         }
 
+        // A write under a non-arrow function / class flows through the name-keyed lambda-lift path, and a
+        // write inside an async arrow flows through the async-arrow promotion path (#625/#682) which is
+        // NOT rename-aware — both stay off-limits. A write inside a SYNC arrow only flows through the
+        // shared $functionDC, which the rename-aware DC redirects (#838), so it stays renameable.
         private void MarkWrite(string name)
         {
-            if (_closureDepth > 0) _offLimits.Add(name);
+            if (_nonArrowDepth > 0 || _asyncArrowDepth > 0) _offLimits.Add(name);
+            else if (_closureDepth > 0) _writeCaptured.Add(name);
         }
     }
 }

--- a/Compilation/ILCompiler.ArrowFunctions.cs
+++ b/Compilation/ILCompiler.ArrowFunctions.cs
@@ -1258,6 +1258,12 @@ public partial class ILCompiler
                     ctx.FunctionDisplayClassFields = funcDCFields;
                     ctx.CapturedFunctionLocals = [.. funcDCFields.Keys];
                 }
+
+                // #838: redirect this arrow's write-captured block-scope shadows to their renamed DC
+                // storage keys so they reach the shadow's field rather than the outer same-named binding.
+                ctx.CurrentArrowFunctionDCFieldRenames =
+                    _closures.ArrowFunctionDCFieldRenames.TryGetValue(arrow, out var dcFieldRenames)
+                        ? dcFieldRenames : null;
             }
 
             // Set the $arrowDC field if this arrow captures arrow-scope variables

--- a/Compilation/ILCompiler.Async.cs
+++ b/Compilation/ILCompiler.Async.cs
@@ -92,7 +92,12 @@ public partial class ILCompiler
                 _closures.AsyncCapturedVarsExclusion[qualifiedFunctionName] = readOnlyRenamedShadows;
         }
 
-        DefineFunctionDisplayClass(funcStmt, qualifiedFunctionName);
+        // #838: an async function body is retokenized by the block-scope renamer, so make its function DC
+        // rename-aware — a write-captured nested-block shadow gets its own renamed field instead of
+        // colliding with the outer same-named binding on a single name-keyed cell (matching the existing
+        // generator path). Recomputed here (deterministic, same flag the AsyncStateAnalyzer used).
+        var blockScopeRenames = GeneratorBlockScopeRenamer.Compute(funcStmt, arrowReadCapturesShareStorage: false);
+        DefineFunctionDisplayClass(funcStmt, qualifiedFunctionName, blockScopeRenames);
 
         // If a function DC was created, add a field on the state machine to hold it
         if (_closures.FunctionDisplayClasses.TryGetValue(qualifiedFunctionName, out var funcDC))

--- a/Compilation/ILCompiler.Functions.cs
+++ b/Compilation/ILCompiler.Functions.cs
@@ -221,7 +221,14 @@ public partial class ILCompiler
     /// Creates a display class for a function's captured local variables.
     /// This is needed when local variables are captured by inner arrow functions.
     /// </summary>
-    private void DefineFunctionDisplayClass(Stmt.Function funcStmt, string qualifiedFunctionName)
+    /// <param name="blockScopeRenames">
+    /// When non-null (state-machine contexts whose body is retokenized by <see cref="GeneratorBlockScopeRenamer"/>,
+    /// i.e. async functions), makes the DC rename-aware: a write-captured nested-block shadow is registered
+    /// under its renamed storage so it does not collide with the outer same-named binding (#838). Pass null
+    /// for plain sync functions (their bodies are not retokenized, so the DC must stay name-keyed).
+    /// </param>
+    private void DefineFunctionDisplayClass(Stmt.Function funcStmt, string qualifiedFunctionName,
+        BlockScopeRenameResult? blockScopeRenames = null)
     {
         // Check if this function has local variables that are captured by inner closures
         var capturedLocals = _closures.Analyzer.GetCapturedLocals(funcStmt);
@@ -251,6 +258,15 @@ public partial class ILCompiler
             capturedLocals.ExceptWith(exclusions);
             if (capturedLocals.Count == 0)
                 return;
+        }
+
+        // #838: in a retokenized state-machine body (async functions), split a write-captured nested-block
+        // shadow into its own renamed DC field and record the per-arrow remap for the arrow body resolver.
+        if (blockScopeRenames is { } renames && renames.WriteCaptureRenames.Count > 0)
+        {
+            var renameAware = new HashSet<string>(capturedLocals);
+            ApplyWriteCaptureRenames(renameAware, renames);
+            capturedLocals = renameAware;
         }
 
         RegisterFunctionDisplayClass(qualifiedFunctionName, capturedLocals);

--- a/Compilation/ILCompiler.Generators.cs
+++ b/Compilation/ILCompiler.Generators.cs
@@ -116,7 +116,45 @@ public partial class ILCompiler
         var perIteration = _closures.Analyzer.GetPerIterationLoopBindings(funcStmt);
         if (perIteration.Count > 0)
             result.ExceptWith(perIteration);
+        // #838: a write-captured nested-block shadow gets its own renamed DC field so it does not collide
+        // with the outer same-named binding on a single name-keyed cell.
+        ApplyWriteCaptureRenames(result, GeneratorBlockScopeRenamer.Compute(funcStmt));
         return result;
+    }
+
+    /// <summary>
+    /// Makes a name-keyed mutated-captured set rename-aware (#838). For every write-captured block-scope
+    /// shadow the renamer disambiguated (arrow → source name → renamed storage), adds the renamed storage
+    /// as its own display-class field (ADDITIVE — the original name stays so an un-renamed outer capture
+    /// of the same name keeps its own field) and records the per-arrow source → storage remap so the
+    /// arrow body's read/write of the capture is redirected to the renamed field at emit time. No-op when
+    /// nothing was write-captured-and-renamed (the common case), leaving the DC field set unchanged.
+    /// </summary>
+    private void ApplyWriteCaptureRenames(HashSet<string> mutatedCaptured, BlockScopeRenameResult renames)
+    {
+        if (renames.WriteCaptureRenames.Count == 0)
+            return;
+        foreach (var (arrowNode, names) in renames.WriteCaptureRenames)
+        {
+            if (arrowNode is not Expr.ArrowFunction arrow)
+                continue;
+            Dictionary<string, string>? perArrow = null;
+            foreach (var (name, storage) in names)
+            {
+                // Only lift names that are genuinely captured-and-mutated here; a renamed shadow whose
+                // outer name is not in the set was not a generator capture and needs no DC field.
+                if (!mutatedCaptured.Contains(name))
+                    continue;
+                mutatedCaptured.Add(storage);
+                (perArrow ??= [])[name] = storage;
+            }
+            if (perArrow == null)
+                continue;
+            if (_closures.ArrowFunctionDCFieldRenames.TryGetValue(arrow, out var existing))
+                foreach (var (k, v) in perArrow) existing[k] = v;
+            else
+                _closures.ArrowFunctionDCFieldRenames[arrow] = perArrow;
+        }
     }
 
     /// <summary>

--- a/Compilation/ILCompiler.State.cs
+++ b/Compilation/ILCompiler.State.cs
@@ -191,6 +191,11 @@ public partial class ILCompiler
         // Maps arrow functions to their $functionDC field (if they capture function-level vars)
         public Dictionary<Expr.ArrowFunction, FieldBuilder> ArrowFunctionDCFields { get; } = new(ReferenceEqualityComparer.Instance);
 
+        // Maps an arrow to (captured source name -> renamed $functionDC storage key) for write-captured
+        // block-scope shadows it lifts into the shared function DC under a disambiguated name (#838).
+        // Consumed when emitting the arrow body to set CompilationContext.CurrentArrowFunctionDCFieldRenames.
+        public Dictionary<Expr.ArrowFunction, Dictionary<string, string>> ArrowFunctionDCFieldRenames { get; } = new(ReferenceEqualityComparer.Instance);
+
         // Maps arrow functions to the function display class they need access to
         public Dictionary<Expr.ArrowFunction, string> ArrowFunctionDCSource { get; } = new(ReferenceEqualityComparer.Instance);
 

--- a/Compilation/ILEmitter.Expressions.cs
+++ b/Compilation/ILEmitter.Expressions.cs
@@ -338,9 +338,11 @@ public partial class ILEmitter
         }
 
         // 1. Function display class fields (captured function-local vars)
-        // Check this BEFORE regular locals to ensure we use the shared storage
-        if (_ctx.CapturedFunctionLocals?.Contains(a.Name.Lexeme) == true &&
-            _ctx.FunctionDisplayClassFields?.TryGetValue(a.Name.Lexeme, out var funcDCField) == true)
+        // Check this BEFORE regular locals to ensure we use the shared storage.
+        // #838: remap a write-captured block-scope shadow to its renamed DC storage key in an arrow body.
+        var assignDCName = _ctx.ResolveFunctionDCFieldName(a.Name.Lexeme);
+        if (_ctx.CapturedFunctionLocals?.Contains(assignDCName) == true &&
+            _ctx.FunctionDisplayClassFields?.TryGetValue(assignDCName, out var funcDCField) == true)
         {
             EmitBoxIfNeeded(a.Value);
             IL.Emit(OpCodes.Dup);

--- a/Compilation/ILEmitter.Operators.cs
+++ b/Compilation/ILEmitter.Operators.cs
@@ -846,9 +846,11 @@ public partial class ILEmitter
                 return;
             }
 
-            // Check function display class first (before regular locals)
-            if (_ctx.CapturedFunctionLocals?.Contains(v.Name.Lexeme) == true &&
-                _ctx.FunctionDisplayClassFields?.TryGetValue(v.Name.Lexeme, out var funcDCField) == true)
+            // Check function display class first (before regular locals).
+            // #838: remap a write-captured block-scope shadow to its renamed DC storage key in an arrow body.
+            var preIncDCName = _ctx.ResolveFunctionDCFieldName(v.Name.Lexeme);
+            if (_ctx.CapturedFunctionLocals?.Contains(preIncDCName) == true &&
+                _ctx.FunctionDisplayClassFields?.TryGetValue(preIncDCName, out var funcDCField) == true)
             {
                 // Store to function display class field (always boxed)
                 if (isTypedDouble)
@@ -1154,9 +1156,11 @@ public partial class ILEmitter
                 return;
             }
 
-            // Check function display class first (before regular locals)
-            if (_ctx.CapturedFunctionLocals?.Contains(v.Name.Lexeme) == true &&
-                _ctx.FunctionDisplayClassFields?.TryGetValue(v.Name.Lexeme, out var funcDCField) == true)
+            // Check function display class first (before regular locals).
+            // #838: remap a write-captured block-scope shadow to its renamed DC storage key in an arrow body.
+            var postIncDCName = _ctx.ResolveFunctionDCFieldName(v.Name.Lexeme);
+            if (_ctx.CapturedFunctionLocals?.Contains(postIncDCName) == true &&
+                _ctx.FunctionDisplayClassFields?.TryGetValue(postIncDCName, out var funcDCField) == true)
             {
                 // Store to function display class field (always boxed)
                 if (isTypedDouble)

--- a/Compilation/LocalVariableResolver.cs
+++ b/Compilation/LocalVariableResolver.cs
@@ -67,9 +67,15 @@ public class LocalVariableResolver : IVariableResolver
         }
 
         // 2. Function display class fields (captured function-local vars)
-        // Check this BEFORE regular locals to ensure we use the shared storage
-        if (_ctx.CapturedFunctionLocals?.Contains(name) == true &&
-            _ctx.FunctionDisplayClassFields?.TryGetValue(name, out var funcDCField) == true)
+        // Check this BEFORE regular locals to ensure we use the shared storage.
+        // #838: in an arrow body, a captured write-shadow's DC field is keyed by its renamed storage
+        // (<name>__bsN), not the bare name — remap before the lookup so the arrow's `name` reaches the
+        // shadow's field rather than the outer same-named binding's field.
+        var dcName = _ctx.CurrentArrowFunctionDCFieldRenames is { } funcDCRenames &&
+                     funcDCRenames.TryGetValue(name, out var renamedStorage)
+            ? renamedStorage : name;
+        if (_ctx.CapturedFunctionLocals?.Contains(dcName) == true &&
+            _ctx.FunctionDisplayClassFields?.TryGetValue(dcName, out var funcDCField) == true)
         {
             if (_ctx.FunctionDisplayClassLocal != null)
             {
@@ -264,9 +270,14 @@ public class LocalVariableResolver : IVariableResolver
         }
 
         // 1. Function display class fields (captured function-local vars)
-        // Check this BEFORE regular locals to ensure we use the shared storage
-        if (_ctx.CapturedFunctionLocals?.Contains(name) == true &&
-            _ctx.FunctionDisplayClassFields?.TryGetValue(name, out var funcDCField) == true)
+        // Check this BEFORE regular locals to ensure we use the shared storage.
+        // #838: remap a captured write-shadow's name to its renamed DC storage key in an arrow body
+        // (mirror of the load path), so the write lands on the shadow's field, not the outer binding's.
+        var dcName = _ctx.CurrentArrowFunctionDCFieldRenames is { } funcDCRenames &&
+                     funcDCRenames.TryGetValue(name, out var renamedStorage)
+            ? renamedStorage : name;
+        if (_ctx.CapturedFunctionLocals?.Contains(dcName) == true &&
+            _ctx.FunctionDisplayClassFields?.TryGetValue(dcName, out var funcDCField) == true)
         {
             var temp = _il.DeclareLocal(_types.Object);
             _il.Emit(OpCodes.Stloc, temp);

--- a/SharpTS.Tests/SharedTests/AsyncBlockScopeShadowTests.cs
+++ b/SharpTS.Tests/SharedTests/AsyncBlockScopeShadowTests.cs
@@ -348,4 +348,64 @@ public class AsyncBlockScopeShadowTests
     }
 
     #endregion
+
+    #region Write-capture of a shadow by an inner sync arrow (#838, write analog of #767)
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AsyncFunction_NestedBlockShadow_WriteCapturedByArrow(ExecutionMode mode)
+    {
+        // An inner block let that shadows an outer binding AND is WRITTEN by a nested sync arrow gets its
+        // own renamed shared $functionDC slot; the arrow's read/write land on the inner binding while the
+        // outer keeps its own (#838). Compiled previously collided on a single name-keyed DC field.
+        var source = """
+            async function af(): Promise<string> {
+              const out: string[] = [];
+              const r = 100;
+              {
+                let r = 5;
+                const f = () => { r = r + 1; return r; };
+                await Promise.resolve(0);
+                out.push(String(f()));
+                out.push(String(r));
+              }
+              out.push(String(r));
+              return out.join(",");
+            }
+            async function main() { console.log(await af()); }
+            main();
+            """;
+
+        Assert.Equal("6,6,100\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AsyncGenerator_NestedBlockShadow_WriteCapturedByArrow(ExecutionMode mode)
+    {
+        // Async-GENERATOR analog (#838): the write-captured shadow gets its own renamed DC field, shared
+        // between the generator body and the sync arrow, without colliding with the outer same-named const.
+        var source = """
+            async function* mut(): AsyncGenerator<number> {
+              const r = 100;
+              {
+                let r = 5;
+                const f = () => { r = r + 1; return r; };
+                yield f();
+                yield r;
+              }
+              yield r;
+            }
+            async function main() {
+              const out: number[] = [];
+              for await (const x of mut()) out.push(x);
+              console.log(out.join(","));
+            }
+            main();
+            """;
+
+        Assert.Equal("6,6,100\n", TestHarness.Run(source, mode));
+    }
+
+    #endregion
 }

--- a/SharpTS.Tests/SharedTests/GeneratorTests.cs
+++ b/SharpTS.Tests/SharedTests/GeneratorTests.cs
@@ -2289,6 +2289,93 @@ public class GeneratorTests
         Assert.Equal("[2, 1, 1]\n", TestHarness.Run(source, mode));
     }
 
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Generator_NestedBlockShadow_WriteCapturedByArrow_DoesNotLeak(ExecutionMode mode)
+    {
+        // An inner block let that shadows an outer body-level const AND is WRITTEN by a nested arrow must
+        // get its own shared function-DC slot; the arrow's read/write land on the inner binding while the
+        // outer keeps its own (#838, the write-capture residual left open by #767/#674). Compiled
+        // previously yielded 6,6,6 because the inner shadow was left un-renamed and collided with the
+        // outer binding on the single name-keyed $functionDC field.
+        var source = """
+            function* mut(): Generator<number> {
+              const r = 100;
+              {
+                let r = 5;
+                const f = () => { r = r + 1; return r; };
+                yield f();
+                yield r;
+              }
+              yield r;
+            }
+            console.log([...mut()].join(","));
+            """;
+
+        Assert.Equal("6,6,100\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Generator_NestedBlockShadow_WriteCapturedByArrow_IncrementForms(ExecutionMode mode)
+    {
+        // The arrow mutates the renamed write-shadow through ++ and += (distinct hand-rolled DC store
+        // sites from a plain assignment); all must target the shadow's renamed field, not the outer one (#838).
+        var source = """
+            function* mut(): Generator<number> {
+              const r = 100;
+              {
+                let r = 5;
+                const f = () => { r++; r += 2; return r; };
+                yield f();
+                yield r;
+              }
+              yield r;
+            }
+            console.log([...mut()].join(","));
+            """;
+
+        Assert.Equal("8,8,100\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Generator_TwoWriteShadows_CapturedByDistinctArrows(ExecutionMode mode)
+    {
+        // Two independent nested-block write-shadows, each written by its own arrow, must each get their
+        // own renamed DC field without cross-contamination, and the outer bindings stay untouched (#838).
+        var source = """
+            function* g(): Generator<number> {
+              const r = 100; const s = 200;
+              { let r = 5; const f = () => { r = r + 1; return r; }; yield f(); yield r; }
+              { let s = 9; const h = () => { s = s + 1; return s; }; yield h(); yield s; }
+              yield r; yield s;
+            }
+            console.log([...g()].join(","));
+            """;
+
+        Assert.Equal("6,6,10,10,100,200\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Generator_NonShadowWriteCapture_StillShared(ExecutionMode mode)
+    {
+        // Regression guard: the classic #674 write-capture WITHOUT shadowing must keep sharing the outer
+        // binding's storage (no rename, name-keyed DC) after the #838 rename-aware DC change.
+        var source = """
+            function* g(): Generator<number> {
+              let sum = 0;
+              const add = (n: number) => { sum += n; };
+              add(5); yield sum;
+              add(3); yield sum;
+            }
+            console.log([...g()].join(","));
+            """;
+
+        Assert.Equal("5,8\n", TestHarness.Run(source, mode));
+    }
+
     #endregion
 
     #region Optional-chain string-method yield short-circuit parity (#709)


### PR DESCRIPTION
## Summary

Fixes #838. A nested-block `let`/`const` that **shadows** an enclosing binding and is **written** by a nested sync arrow leaked in compiled mode across all suspension contexts (sync generator #674, async generator #725, async function). The captured-and-mutated local was lifted into the **name-keyed** function display class, so the inner shadow and the outer same-named binding collided on one `$functionDC` field — a **silent miscompile** (`6,6,6` compiled vs `6,6,100` interpreted).

```ts
function* mut(): Generator<number> {
  const r = 100;
  { let r = 5; const f = () => { r = r + 1; return r; }; yield f(); yield r; }
  yield r;
}
console.log([...mut()].join(",")); // was 6,6,6 compiled; now 6,6,100
```

## Approach (the issue's "Follow-up B" + fail-fast safety net)

Make the function DC **rename-aware / per-binding**:

- **Renamer** (`GeneratorBlockScopeRenamer`): write-captured shadows are no longer unconditionally off-limits. `CaptureClassifier` splits a write inside a **sync arrow** (renameable, DC-backed) from a write under a non-arrow function/class or an **async arrow** (still off-limits — those use name-keyed lambda-lift / the unwired async-arrow promotion path). New `WriteCaptureRenames` result map.
- **DC registration** is made **additive**: each renamed storage (`<r>__bs0`) becomes its own DC field while the original name stays for any un-renamed outer capture. Shared `ComputeMutatedCapturedGeneratorVars` covers sync + async generators; async functions go through `DefineFunctionDisplayClass` with a recomputed renamer. Plain sync functions stay name-keyed (their bodies aren't retokenized).
- **Arrow body resolution**: new `CurrentArrowFunctionDCFieldRenames` + `ResolveFunctionDCFieldName` remap the arrow's captured name to the renamed DC field key at every function-DC load/store site (`LocalVariableResolver` plus the hand-rolled assignment / pre+post increment paths in `ILEmitter`).

The body side is already retokenized by the #711 renames. The #674 fail-fast guard stays in place for any write that still lands on a by-value snapshot.

## Tests

Write-capture of a shadow across sync gen, async gen, async fn — plus increment forms (`r++`/`+=`), two distinct shadows captured by distinct arrows, and a non-shadow #674 regression guard. **Full suite 13760 green**; every new compiled case IL-verifies.

## Out of scope (pre-existing, filed separately)

Compiled **async-arrow** write-capture emits invalid IL **even without any shadow** (`async () => { r = r + 1 }` capturing an enclosing `r`) — the async-arrow promotion path is independently broken, unrelated to #838. Tracked in a separate issue.