### PR TITLE
Fix #775: generator fn-expr / object generator method dynamic `this`

### DIFF
--- a/Compilation/AsyncGeneratorStateMachineBuilder.cs
+++ b/Compilation/AsyncGeneratorStateMachineBuilder.cs
@@ -104,11 +104,15 @@ public class AsyncGeneratorStateMachineBuilder
     /// <summary>
     /// Defines the complete state machine class type with all fields and method stubs.
     /// </summary>
+    /// <param name="hasDynamicThis">True for a free-function async-generator stub that binds its own
+    /// dynamic receiver (#775): it captures the active thread-local <c>this</c> into <c>&lt;&gt;4__this</c>
+    /// at creation time even though it is a static stub.</param>
     public void DefineStateMachine(
         string methodName,
         AsyncGeneratorStateAnalyzer.AsyncGeneratorFunctionAnalysis analysis,
         bool isInstanceMethod = false,
-        EmittedRuntime? runtime = null)
+        EmittedRuntime? runtime = null,
+        bool hasDynamicThis = false)
     {
         _runtime = runtime;
 
@@ -148,8 +152,10 @@ public class AsyncGeneratorStateMachineBuilder
         // Define hoisted enumerators for for...of loops containing suspensions (yield/await)
         _hoisting.DefineHoistedEnumerators(analysis.ForOfLoopsWithSuspension, _types.IEnumerator);
 
-        // Define 'this' field for instance methods that use 'this'
-        if (isInstanceMethod && analysis.UsesThis)
+        // Define 'this' field for instance methods that use 'this', and for a free-function async
+        // generator stub that binds its own dynamic receiver (#775 — a `HasOwnThis` async generator
+        // expression / object method, captured from the thread-local receiver at creation time).
+        if ((isInstanceMethod || hasDynamicThis) && analysis.UsesThis)
         {
             ThisField = _stateMachineType.DefineField(
                 "<>4__this",

--- a/Compilation/GeneratorStateMachineBuilder.cs
+++ b/Compilation/GeneratorStateMachineBuilder.cs
@@ -122,12 +122,17 @@ public class GeneratorStateMachineBuilder
     /// <param name="methodName">Name of the generator method (used in type name)</param>
     /// <param name="analysis">Analysis results from GeneratorStateAnalyzer</param>
     /// <param name="isInstanceMethod">True if this is an instance method (needs 'this' hoisting)</param>
+    /// <param name="hasDynamicThis">True for a free-function stub lifted from a <c>HasOwnThis</c> generator
+    /// expression / object generator method (#775): it carries its own dynamic receiver in a leading
+    /// <c>__this</c> stub argument rather than an IL instance <c>this</c>, so it still needs the
+    /// <c>&lt;&gt;4__this</c> field even though it is a static stub.</param>
     /// <param name="runtime">Optional runtime reference for $IGenerator interface</param>
     public void DefineStateMachine(
         string methodName,
         GeneratorStateAnalyzer.GeneratorFunctionAnalysis analysis,
         bool isInstanceMethod = false,
-        EmittedRuntime? runtime = null)
+        EmittedRuntime? runtime = null,
+        bool hasDynamicThis = false)
     {
         _runtime = runtime;
 
@@ -169,8 +174,10 @@ public class GeneratorStateMachineBuilder
         _hoisting.DefineHoistedEnumerators(analysis.ForOfLoopsWithYield, _types.IEnumerator);
         _hoisting.DefineHoistedForInState(analysis.ForInLoopsWithYield, _types.ListOfObject, _types.Int32);
 
-        // Define 'this' field for instance methods that use 'this'
-        if (isInstanceMethod && analysis.UsesThis)
+        // Define 'this' field for instance methods that use 'this', and for a free-function generator
+        // stub that binds its own dynamic receiver (#775 — a `HasOwnThis` generator expression / object
+        // generator method, threaded in via a leading `__this` stub argument).
+        if ((isInstanceMethod || hasDynamicThis) && analysis.UsesThis)
         {
             ThisField = _stateMachineType.DefineField(
                 "<>4__this",

--- a/Compilation/ILCompiler.AsyncGenerators.cs
+++ b/Compilation/ILCompiler.AsyncGenerators.cs
@@ -26,9 +26,14 @@ public partial class ILCompiler
         // Analyze the async generator function for yield/await points and hoisted variables
         var analysis = _asyncGenerators.Analyzer.Analyze(funcStmt);
 
+        // #775: a free-function async generator binds its own dynamic `this`; when its body uses `this`
+        // the stub captures the active dynamic receiver into <>4__this at creation time (see
+        // EmitGeneratorStubMethod for the sync rationale).
+        bool hasDynamicThis = analysis.UsesThis;
+
         // Create the state machine builder
         var smBuilder = new AsyncGeneratorStateMachineBuilder(_moduleBuilder, _types, _asyncGenerators.StateMachineCounter++);
-        smBuilder.DefineStateMachine(funcName, analysis, isInstanceMethod: false, runtime: _runtime);
+        smBuilder.DefineStateMachine(funcName, analysis, isInstanceMethod: false, runtime: _runtime, hasDynamicThis: hasDynamicThis);
 
         _asyncGenerators.StateMachines[qualifiedName] = smBuilder;
         _asyncGenerators.Functions[qualifiedName] = funcStmt;
@@ -125,6 +130,24 @@ public partial class ILCompiler
 
         // Create new instance of the state machine using the constructor builder
         il.Emit(OpCodes.Newobj, smBuilder.Constructor);
+
+        // #775: capture the active dynamic `this` into <>4__this (see EmitGeneratorStubMethod for the
+        // full rationale — the thread-local receiver is gone by the time MoveNextAsync runs lazily).
+        if (smBuilder.ThisField != null && _runtime?.CurrentFunctionThisField != null)
+        {
+            il.Emit(OpCodes.Dup);
+            il.Emit(OpCodes.Ldsfld, _runtime.CurrentFunctionThisField);
+            if (_runtime.GlobalThisSingletonField != null)
+            {
+                var thisNotNull = il.DefineLabel();
+                il.Emit(OpCodes.Dup);
+                il.Emit(OpCodes.Brtrue, thisNotNull);
+                il.Emit(OpCodes.Pop);
+                il.Emit(OpCodes.Ldsfld, _runtime.GlobalThisSingletonField);
+                il.MarkLabel(thisNotNull);
+            }
+            il.Emit(OpCodes.Stfld, smBuilder.ThisField);
+        }
 
         // Copy parameters to state machine fields
         for (int i = 0; i < funcStmt.Parameters.Count; i++)

--- a/Compilation/ILCompiler.Generators.cs
+++ b/Compilation/ILCompiler.Generators.cs
@@ -39,9 +39,18 @@ public partial class ILCompiler
         // Analyze the generator function for yield points and hoisted variables
         var analysis = _generators.Analyzer.Analyze(funcStmt);
 
+        // #775: a free-function generator binds its own dynamic `this` (it is a `function*`, never an
+        // arrow). When its body uses `this`, the stub captures the active dynamic receiver — the
+        // thread-local `$TSFunction._currentFunctionThis`, set by InvokeWithThis for an `o.gen()` /
+        // `.call(recv)` value-call — into the state machine's <>4__this field at creation time, since
+        // the thread-local is gone by the time MoveNext runs lazily. A plain direct `g()` call leaves it
+        // at the globalThis sentinel (sloppy `this`). This mirrors how a non-generator `function(){ this.x }`
+        // declaration threads `this`, so direct calls keep their signature (no synthetic `__this` param).
+        bool hasDynamicThis = analysis.UsesThis;
+
         // Create the state machine builder
         var smBuilder = new GeneratorStateMachineBuilder(_moduleBuilder, _types, _generators.StateMachineCounter++);
-        smBuilder.DefineStateMachine(funcName, analysis, isInstanceMethod: false, runtime: _runtime);
+        smBuilder.DefineStateMachine(funcName, analysis, isInstanceMethod: false, runtime: _runtime, hasDynamicThis: hasDynamicThis);
 
         _generators.StateMachines[qualifiedName] = smBuilder;
         _generators.Functions[qualifiedName] = funcStmt;
@@ -245,6 +254,27 @@ public partial class ILCompiler
 
         // Create new instance of the state machine using the constructor builder
         il.Emit(OpCodes.Newobj, smBuilder.Constructor);
+
+        // #775: capture the active dynamic `this` into the state machine's <>4__this field. The stub
+        // runs eagerly (when the generator is created), while MoveNext runs lazily — by then the
+        // thread-local receiver is gone, so it must be snapshotted here. The receiver is the thread-local
+        // `$TSFunction._currentFunctionThis` (set by InvokeWithThis for an `o.gen()` / `.call(recv)`
+        // value-call), coerced null → globalThis sentinel to match LocalVariableResolver.LoadThis.
+        if (smBuilder.ThisField != null && _runtime?.CurrentFunctionThisField != null)
+        {
+            il.Emit(OpCodes.Dup);       // Keep state machine reference on stack
+            il.Emit(OpCodes.Ldsfld, _runtime.CurrentFunctionThisField);
+            if (_runtime.GlobalThisSingletonField != null)
+            {
+                var thisNotNull = il.DefineLabel();
+                il.Emit(OpCodes.Dup);
+                il.Emit(OpCodes.Brtrue, thisNotNull);
+                il.Emit(OpCodes.Pop);
+                il.Emit(OpCodes.Ldsfld, _runtime.GlobalThisSingletonField);
+                il.MarkLabel(thisNotNull);
+            }
+            il.Emit(OpCodes.Stfld, smBuilder.ThisField);
+        }
 
         // Copy parameters to state machine fields
         for (int i = 0; i < funcStmt.Parameters.Count; i++)

--- a/Compilation/NestedFunctionLifter.cs
+++ b/Compilation/NestedFunctionLifter.cs
@@ -246,7 +246,7 @@ internal sealed class NestedFunctionLifter
             if (p.IsRest || p.DefaultValue != null)
                 return false;
 
-        if (UsesThisOrArguments(f.Body))
+        if (DeclinesForThisOrArguments(f))
             return false;
 
         // Ordinal sort gives a deterministic parameter order shared by the relocated declaration's
@@ -276,7 +276,7 @@ internal sealed class NestedFunctionLifter
             if (p.IsRest || p.DefaultValue != null)
                 return false;
 
-        if (UsesThisOrArguments(f.Body))
+        if (DeclinesForThisOrArguments(f))
             return false;
 
         // Self-recursion can't be lambda-lifted here: the relocated body's self-calls must resolve to the
@@ -295,15 +295,28 @@ internal sealed class NestedFunctionLifter
     }
 
     /// <summary>
-    /// True if any statement in <paramref name="body"/> reads <c>this</c> or <c>arguments</c>.
-    /// Deliberately over-approximates: it descends through nested function/arrow boundaries (which
-    /// rebind both), so a nested function's own <c>this</c> also trips it. A false positive only
-    /// declines a lambda-lift (a clean failure), never miscompiles.
+    /// Whether a candidate must be declined because its body reads <c>this</c> or <c>arguments</c> that
+    /// a plain top-level function reached through a forwarding arrow could not supply. A non-generator
+    /// declines on either. A GENERATOR declines only on <c>arguments</c> (#775): a <c>function*</c>
+    /// expression binds its own dynamic <c>this</c>, and the compiled free-function generator stub
+    /// threads that receiver in via the thread-local <c>$TSFunction._currentFunctionThis</c> (captured
+    /// into <c>&lt;&gt;4__this</c> at creation), so a <c>this</c>-using generator body lambda-lifts fine.
     /// </summary>
-    private static bool UsesThisOrArguments(List<Stmt>? body)
+    private static bool DeclinesForThisOrArguments(Stmt.Function f) =>
+        f.IsGenerator ? UsesThisOrArguments(f.Body, includeThis: false)
+                      : UsesThisOrArguments(f.Body, includeThis: true);
+
+    /// <summary>
+    /// True if any statement in <paramref name="body"/> reads <c>arguments</c> (and, when
+    /// <paramref name="includeThis"/> is set, <c>this</c>). Deliberately over-approximates: it descends
+    /// through nested function/arrow boundaries (which rebind both), so a nested function's own
+    /// <c>this</c>/<c>arguments</c> also trips it. A false positive only declines a lambda-lift (a clean
+    /// failure), never miscompiles.
+    /// </summary>
+    private static bool UsesThisOrArguments(List<Stmt>? body, bool includeThis = true)
     {
         if (body == null) return false;
-        var scanner = new ThisArgumentsScanner();
+        var scanner = new ThisArgumentsScanner(includeThis);
         foreach (var stmt in body)
         {
             scanner.Visit(stmt);
@@ -312,12 +325,13 @@ internal sealed class NestedFunctionLifter
         return scanner.Found;
     }
 
-    private sealed class ThisArgumentsScanner : Parsing.Visitors.AstVisitorBase
+    private sealed class ThisArgumentsScanner(bool includeThis) : Parsing.Visitors.AstVisitorBase
     {
         public bool Found { get; private set; }
 
         protected override void VisitThis(Expr.This expr)
         {
+            if (!includeThis) return;
             Found = true;
             ShouldContinue = false;
         }

--- a/Execution/Interpreter.Properties.cs
+++ b/Execution/Interpreter.Properties.cs
@@ -1014,6 +1014,27 @@ public partial class Interpreter
     }
 
     /// <summary>
+    /// Binds the dynamic receiver when a method-bearing value is read off an object literal as
+    /// <c>obj.method</c>. Covers ordinary function-expression / object-method shorthand
+    /// (<see cref="SharpTSArrowFunction"/> with <c>HasOwnThis</c>) and — for #775 — generator function
+    /// expressions / object generator methods in both their lifted declaration form
+    /// (<see cref="SharpTSGeneratorFunction"/> / <see cref="SharpTSAsyncGeneratorFunction"/> with
+    /// <c>HasDynamicThis</c>) and their in-place expression form
+    /// (<see cref="SharpTSArrowGeneratorFunction"/> / <see cref="SharpTSAsyncArrowGeneratorFunction"/> with
+    /// <c>HasOwnThis</c>, left in place when they close over a block-scoped binding). Returns null when the
+    /// value is not a receiver-bound method (caller returns it unchanged).
+    /// </summary>
+    private static ISharpTSCallable? TryBindReceiverForMethodAccess(object? value, object receiver) => value switch
+    {
+        SharpTSArrowFunction af when af.HasOwnThis => af.Bind(receiver),
+        SharpTSArrowGeneratorFunction sag when sag.HasOwnThis => sag.Bind(receiver),
+        SharpTSAsyncArrowGeneratorFunction saag when saag.HasOwnThis => saag.Bind(receiver),
+        SharpTSGeneratorFunction gf when gf.HasDynamicThis => gf.BindToReceiver(receiver),
+        SharpTSAsyncGeneratorFunction agf when agf.HasDynamicThis => agf.BindToReceiver(receiver),
+        _ => null,
+    };
+
+    /// <summary>
     /// Evaluates property access on a record/object literal, walking the __proto__
     /// chain when the property is not an own property. JS spec: property access
     /// traverses the prototype chain until a match or null is reached.
@@ -1033,11 +1054,10 @@ public partial class Interpreter
         if (simpleObj.HasProperty(memberName))
         {
             var value = simpleObj.GetProperty(memberName);
-            // Bind 'this' for function expressions and object method shorthand (HasOwnThis=true)
-            if (value is SharpTSArrowFunction arrowFunc && arrowFunc.HasOwnThis)
-            {
-                return arrowFunc.Bind(simpleObj);
-            }
+            // Bind 'this' for function expressions and object method shorthand (HasOwnThis=true),
+            // including generator / async-generator methods (#775).
+            if (TryBindReceiverForMethodAccess(value, simpleObj) is { } boundMethod)
+                return boundMethod;
             return value;
         }
 
@@ -1057,10 +1077,8 @@ public partial class Interpreter
             if (proto.HasProperty(memberName))
             {
                 var value = proto.GetProperty(memberName);
-                if (value is SharpTSArrowFunction arrowFunc && arrowFunc.HasOwnThis)
-                {
-                    return arrowFunc.Bind(simpleObj);
-                }
+                if (TryBindReceiverForMethodAccess(value, simpleObj) is { } boundMethod)
+                    return boundMethod;
                 return value;
             }
             object? next = proto.HasProperty("__proto__") ? proto.GetProperty("__proto__") : null;
@@ -1109,10 +1127,8 @@ public partial class Interpreter
         if (simpleObj.HasProperty(memberName))
         {
             var value = simpleObj.GetProperty(memberName);
-            if (value is SharpTSArrowFunction arrowFunc && arrowFunc.HasOwnThis)
-            {
-                return RuntimeValue.FromObject(arrowFunc.Bind(simpleObj));
-            }
+            if (TryBindReceiverForMethodAccess(value, simpleObj) is { } boundMethod)
+                return RuntimeValue.FromObject(boundMethod);
             return RuntimeValue.FromBoxed(value);
         }
 
@@ -1134,10 +1150,8 @@ public partial class Interpreter
                 if (proto.HasProperty(memberName))
                 {
                     var value = proto.GetProperty(memberName);
-                    if (value is SharpTSArrowFunction arrowFunc && arrowFunc.HasOwnThis)
-                    {
-                        return RuntimeValue.FromObject(arrowFunc.Bind(simpleObj));
-                    }
+                    if (TryBindReceiverForMethodAccess(value, simpleObj) is { } boundMethod)
+                        return RuntimeValue.FromObject(boundMethod);
                     return RuntimeValue.FromBoxed(value);
                 }
                 object? next = proto.HasProperty("__proto__") ? proto.GetProperty("__proto__") : null;

--- a/Execution/Interpreter.Statements.cs
+++ b/Execution/Interpreter.Statements.cs
@@ -860,10 +860,11 @@ public partial class Interpreter
             var iteratorFn = obj.GetBySymbol(SharpTSSymbol.Iterator);
             if (iteratorFn != null)
             {
-                // Bind 'this' to the object if it's an arrow function
-                if (iteratorFn is SharpTSArrowFunction arrowFunc)
+                // Bind 'this' to the object for a function expression / object method shorthand,
+                // including generator forms (`[Symbol.iterator]: function*(){ this... }`, #775).
+                if (TryBindReceiverForMethodAccess(iteratorFn, obj) is { } boundIteratorFn)
                 {
-                    iteratorFn = arrowFunc.Bind(obj);
+                    iteratorFn = boundIteratorFn;
                 }
                 return EnumerateWithIteratorProtocol(iteratorFn);
             }
@@ -881,10 +882,11 @@ public partial class Interpreter
             }
             if (iteratorFn != null)
             {
-                // Bind 'this' to the instance if it's an arrow function
-                if (iteratorFn is SharpTSArrowFunction arrowFunc)
+                // Bind 'this' to the instance for a function expression / object method shorthand,
+                // including generator forms (#775).
+                if (TryBindReceiverForMethodAccess(iteratorFn, inst) is { } boundIteratorFn)
                 {
-                    iteratorFn = arrowFunc.Bind(inst);
+                    iteratorFn = boundIteratorFn;
                 }
                 return EnumerateWithIteratorProtocol(iteratorFn);
             }

--- a/Parsing/AST.cs
+++ b/Parsing/AST.cs
@@ -425,8 +425,14 @@ public abstract record Stmt
     /// <c>[Symbol.iterator]() {}</c>); Name is then a synthetic <c>&lt;computed&gt;</c> token and the
     /// key expression is evaluated at class-definition time (interpreter) / registered as a
     /// symbol method (compiler).
+    /// HasDynamicThis is set ONLY on a synthetic generator declaration lifted from a
+    /// <c>HasOwnThis</c> generator function expression / object generator method
+    /// (<see cref="SharpTS.Parsing.GeneratorArrowLifter"/>). It means "this stub binds its own
+    /// dynamic receiver": the compiler threads a leading <c>__this</c> argument into the generator
+    /// state machine's <c>&lt;&gt;4__this</c> field, and the interpreter binds the call receiver
+    /// (defaulting to <c>undefined</c>) so <c>this</c> inside the body resolves (#775).
     /// </summary>
-    public record Function(Token Name, List<TypeParam>? TypeParams, string? ThisType, List<Parameter> Parameters, List<Stmt>? Body, string? ReturnType, bool IsStatic = false, AccessModifier Access = AccessModifier.Public, bool IsAbstract = false, bool IsOverride = false, bool IsAsync = false, bool IsGenerator = false, List<Decorator>? Decorators = null, bool IsPrivate = false, bool IsDeclare = false, Expr? ComputedKey = null) : Stmt;
+    public record Function(Token Name, List<TypeParam>? TypeParams, string? ThisType, List<Parameter> Parameters, List<Stmt>? Body, string? ReturnType, bool IsStatic = false, AccessModifier Access = AccessModifier.Public, bool IsAbstract = false, bool IsOverride = false, bool IsAsync = false, bool IsGenerator = false, List<Decorator>? Decorators = null, bool IsPrivate = false, bool IsDeclare = false, Expr? ComputedKey = null, bool HasDynamicThis = false) : Stmt;
     public record Parameter(Token Name, string? Type, Expr? DefaultValue = null, bool IsRest = false, bool IsParameterProperty = false, AccessModifier? Access = null, bool IsReadonly = false, bool IsOptional = false, List<Decorator>? Decorators = null);
     /// <summary>
     /// Class field declaration. For computed property names (e.g., [Symbol("key")]: type),

--- a/Parsing/GeneratorArrowLifter.cs
+++ b/Parsing/GeneratorArrowLifter.cs
@@ -817,7 +817,11 @@ internal sealed class GeneratorArrowLifter
             Body: rewrittenBody,
             ReturnType: af.ReturnType,
             IsAsync: af.IsAsync,
-            IsGenerator: true);
+            IsGenerator: true,
+            // #775: a HasOwnThis generator expression / object generator method binds its own
+            // dynamic receiver. Carry that need onto the lifted declaration so both back ends can
+            // thread the call receiver into the generator body's `this`.
+            HasDynamicThis: af.HasOwnThis);
 
         // Lift into the nearest enclosing function if the body closes over one of the enclosing
         // functions' locals (#534); otherwise to the module body (#522). Lifting into the enclosing

--- a/Runtime/BuiltIns/FunctionBuiltIns.cs
+++ b/Runtime/BuiltIns/FunctionBuiltIns.cs
@@ -198,6 +198,16 @@ public static class FunctionBuiltIns
                 : asyncFn.Call(interp, args);
         }
 
+        // Generator / async-generator function values (declarations and `function*` expressions) have
+        // their own dynamic `this`; .call/.apply rebind the receiver (#775). A null thisArg leaves the
+        // body's `this` defaulting to undefined (the wrapper's own Call handles that).
+        if (callable is SharpTSGeneratorFunction or SharpTSAsyncGeneratorFunction
+            or SharpTSArrowGeneratorFunction or SharpTSAsyncArrowGeneratorFunction)
+        {
+            var target = thisArg != null ? ((IReceiverBindable)callable).BindToReceiver(thisArg) : callable;
+            return target.Call(interp, args);
+        }
+
         // Array.prototype methods rebind their receiver via BindTo so that
         // Array.prototype.push.apply(target, items) pushes onto `target`.
         if (callable is SharpTSArrayUnboundMethod unbound)
@@ -341,6 +351,13 @@ public class BoundFunction : ISharpTSCallable
                 return ((ISharpTSCallable)asyncFn.BindThisValue(_thisArg)).CallV2(interpreter, combined);
             }
 
+            // Generator / async-generator function values rebind their dynamic `this` (#775).
+            if (_target is SharpTSGeneratorFunction or SharpTSAsyncGeneratorFunction
+                or SharpTSArrowGeneratorFunction or SharpTSAsyncArrowGeneratorFunction)
+            {
+                return ((IReceiverBindable)_target).BindToReceiver(_thisArg).CallV2(interpreter, combined);
+            }
+
             // Mirror the legacy Call path for BuiltInMethod (issue #101): the
             // V2 path is hit by JS-level invocation of a BoundFunction wrapping
             // a BuiltInMethod target (e.g. Function.prototype.call.bind(...)).
@@ -389,6 +406,13 @@ public class BoundFunction : ISharpTSCallable
             if (_target is SharpTSAsyncFunction asyncFn)
             {
                 return asyncFn.BindThisValue(_thisArg).Call(interpreter, combinedArgs);
+            }
+
+            // Generator / async-generator function values rebind their dynamic `this` (#775).
+            if (_target is SharpTSGeneratorFunction or SharpTSAsyncGeneratorFunction
+                or SharpTSArrowGeneratorFunction or SharpTSAsyncArrowGeneratorFunction)
+            {
+                return ((IReceiverBindable)_target).BindToReceiver(_thisArg).Call(interpreter, combinedArgs);
             }
 
             // Built-in methods read their receiver from the bound `_receiver`

--- a/Runtime/Types/SharpTSAsyncGeneratorFunction.cs
+++ b/Runtime/Types/SharpTSAsyncGeneratorFunction.cs
@@ -13,16 +13,31 @@ namespace SharpTS.Runtime.Types;
 /// </remarks>
 /// <seealso cref="SharpTSAsyncGenerator"/>
 /// <seealso cref="SharpTSGeneratorFunction"/>
-public class SharpTSAsyncGeneratorFunction : ISharpTSCallable
+public class SharpTSAsyncGeneratorFunction : ISharpTSCallable, IReceiverBindable
 {
     private readonly Stmt.Function _declaration;
     private readonly RuntimeEnvironment _closure;
     private readonly int _arity;
+    /// <summary>A dynamic receiver was bound, so <see cref="Call"/> binds <c>this</c> to
+    /// <see cref="_boundThis"/> rather than defaulting it to undefined.</summary>
+    private readonly bool _thisBound;
+    private readonly object? _boundThis;
+    private readonly SharpTSClass? _boundSuper;
 
-    public SharpTSAsyncGeneratorFunction(Stmt.Function declaration, RuntimeEnvironment closure)
+    /// <summary>
+    /// True when this is an async generator declaration lifted from a <c>HasOwnThis</c> async generator
+    /// expression / object method (#775). Binds its own dynamic <c>this</c>.
+    /// </summary>
+    public bool HasDynamicThis => _declaration.HasDynamicThis;
+
+    public SharpTSAsyncGeneratorFunction(Stmt.Function declaration, RuntimeEnvironment closure,
+        bool thisBound = false, object? boundThis = null, SharpTSClass? boundSuper = null)
     {
         _declaration = declaration;
         _closure = closure;
+        _thisBound = thisBound;
+        _boundThis = boundThis;
+        _boundSuper = boundSuper;
         _arity = declaration.Parameters?.Count ?? 0;
     }
 
@@ -32,6 +47,20 @@ public class SharpTSAsyncGeneratorFunction : ISharpTSCallable
     {
         // Create a new environment for this generator invocation
         RuntimeEnvironment environment = new(_closure);
+
+        // #775: an async generator expression / object method binds its own dynamic `this`. The bound
+        // receiver (or globalThis for a plain call) is defined in the generator's OWN body environment,
+        // NOT a parent scope, so a captured enclosing-function local keeps its lexical scope distance.
+        if (_thisBound)
+        {
+            environment.Define("this", _boundThis);
+            if (_boundSuper != null)
+                environment.Define("super", _boundSuper);
+        }
+        else if (_declaration.HasDynamicThis)
+        {
+            environment.Define("this", SharpTSGlobalThis.Instance); // sloppy-mode `this` = globalThis (#775)
+        }
 
         // Bind parameters to arguments
         ParameterBinder.Bind(_declaration.Parameters ?? [], arguments, environment, interpreter);
@@ -45,20 +74,14 @@ public class SharpTSAsyncGeneratorFunction : ISharpTSCallable
     /// Creates a bound version with 'this' set for method calls.
     /// </summary>
     public SharpTSAsyncGeneratorFunction Bind(SharpTSInstance instance)
-    {
-        RuntimeEnvironment boundEnv = new(_closure);
-        boundEnv.Define("this", instance);
-        return new SharpTSAsyncGeneratorFunction(_declaration, boundEnv);
-    }
+        => new(_declaration, _closure, thisBound: true, boundThis: instance);
+
+    /// <summary>Binds an arbitrary receiver (object async generator method / <c>.call</c> / <c>.apply</c>) (#775).</summary>
+    public ISharpTSCallable BindToReceiver(object receiver)
+        => new SharpTSAsyncGeneratorFunction(_declaration, _closure, thisBound: true, boundThis: receiver);
 
     public SharpTSAsyncGeneratorFunction BindStatic(SharpTSClass klass)
-    {
-        RuntimeEnvironment boundEnv = new(_closure);
-        boundEnv.Define("this", klass);
-        if (klass.Superclass != null)
-            boundEnv.Define("super", klass.Superclass);
-        return new SharpTSAsyncGeneratorFunction(_declaration, boundEnv);
-    }
+        => new(_declaration, _closure, thisBound: true, boundThis: klass, boundSuper: klass.Superclass);
 
     public override string ToString() => $"[async function* {_declaration.Name?.Lexeme ?? "anonymous"}]";
 }
@@ -76,11 +99,15 @@ public class SharpTSAsyncGeneratorFunction : ISharpTSCallable
 /// </remarks>
 /// <seealso cref="SharpTSAsyncGenerator"/>
 /// <seealso cref="SharpTSArrowGeneratorFunction"/>
-public class SharpTSAsyncArrowGeneratorFunction : ISharpTSCallable
+public class SharpTSAsyncArrowGeneratorFunction : ISharpTSCallable, IReceiverBindable
 {
     private readonly Expr.ArrowFunction _declaration;
     private readonly RuntimeEnvironment _closure;
     private readonly int _arity;
+    /// <summary>A dynamic receiver was bound (via <see cref="Bind"/>), so <see cref="Call"/> binds
+    /// <c>this</c> to <see cref="_boundThis"/> rather than defaulting it to undefined.</summary>
+    private readonly bool _thisBound;
+    private readonly object? _boundThis;
 
     /// <summary>
     /// Whether this has its own <c>this</c> binding (a <c>function*</c> expression) rather than
@@ -88,11 +115,13 @@ public class SharpTSAsyncArrowGeneratorFunction : ISharpTSCallable
     /// </summary>
     public bool HasOwnThis { get; }
 
-    public SharpTSAsyncArrowGeneratorFunction(Expr.ArrowFunction declaration, RuntimeEnvironment closure, bool hasOwnThis = false)
+    public SharpTSAsyncArrowGeneratorFunction(Expr.ArrowFunction declaration, RuntimeEnvironment closure, bool hasOwnThis = false, bool thisBound = false, object? boundThis = null)
     {
         _declaration = declaration;
         _closure = closure;
         HasOwnThis = hasOwnThis;
+        _thisBound = thisBound;
+        _boundThis = boundThis;
         _arity = declaration.Parameters.Count(p => p.DefaultValue == null && !p.IsRest && !p.IsOptional);
     }
 
@@ -107,6 +136,12 @@ public class SharpTSAsyncArrowGeneratorFunction : ISharpTSCallable
         {
             environment.Define(_declaration.Name.Lexeme, this);
         }
+        // #775: a `function*` expression binds its own dynamic `this`; the bound receiver (or globalThis for
+        // a plain call) is defined in the generator's OWN body environment, NOT a parent scope.
+        if (_thisBound)
+            environment.Define("this", _boundThis);
+        else if (HasOwnThis)
+            environment.Define("this", SharpTSGlobalThis.Instance); // sloppy-mode `this` = globalThis (#775)
         ParameterBinder.Bind(_declaration.Parameters, arguments, environment, interpreter);
 
         // Generator expressions always have a block body (the parser never produces an
@@ -116,11 +151,10 @@ public class SharpTSAsyncArrowGeneratorFunction : ISharpTSCallable
 
     /// <summary>Binds <c>this</c>. Only applicable for function expressions with HasOwnThis=true.</summary>
     public SharpTSAsyncArrowGeneratorFunction Bind(object thisObject)
-    {
-        RuntimeEnvironment boundEnv = new(_closure);
-        boundEnv.Define("this", thisObject);
-        return new SharpTSAsyncArrowGeneratorFunction(_declaration, boundEnv, hasOwnThis: true);
-    }
+        => new(_declaration, _closure, hasOwnThis: true, thisBound: true, boundThis: thisObject);
+
+    /// <summary>Receiver-binding entry point for the method-call / <c>.call</c> / <c>.apply</c> path (#775).</summary>
+    public ISharpTSCallable BindToReceiver(object receiver) => Bind(receiver);
 
     public override string ToString() => $"[async function* {_declaration.Name?.Lexeme ?? "anonymous"}]";
 }

--- a/Runtime/Types/SharpTSGeneratorFunction.cs
+++ b/Runtime/Types/SharpTSGeneratorFunction.cs
@@ -14,16 +14,33 @@ namespace SharpTS.Runtime.Types;
 /// </remarks>
 /// <seealso cref="SharpTSGenerator"/>
 /// <seealso cref="SharpTSFunction"/>
-public class SharpTSGeneratorFunction : ISharpTSCallable
+public class SharpTSGeneratorFunction : ISharpTSCallable, IReceiverBindable
 {
     private readonly Stmt.Function _declaration;
     private readonly RuntimeEnvironment _closure;
     private readonly int _arity;
+    /// <summary>A dynamic receiver was bound (via <see cref="BindToReceiver"/>), so <see cref="Call"/>
+    /// binds <c>this</c> to <see cref="_boundThis"/> rather than defaulting it to undefined.</summary>
+    private readonly bool _thisBound;
+    private readonly object? _boundThis;
+    private readonly SharpTSClass? _boundSuper;
 
-    public SharpTSGeneratorFunction(Stmt.Function declaration, RuntimeEnvironment closure)
+    /// <summary>
+    /// True when this is a generator declaration lifted from a <c>HasOwnThis</c> generator expression /
+    /// object generator method (#775). Such a generator binds its own dynamic <c>this</c>: when invoked
+    /// as a method the receiver is bound (<see cref="BindToReceiver"/>), and a plain call defaults
+    /// <c>this</c> to <c>undefined</c> rather than leaving it unbound.
+    /// </summary>
+    public bool HasDynamicThis => _declaration.HasDynamicThis;
+
+    public SharpTSGeneratorFunction(Stmt.Function declaration, RuntimeEnvironment closure,
+        bool thisBound = false, object? boundThis = null, SharpTSClass? boundSuper = null)
     {
         _declaration = declaration;
         _closure = closure;
+        _thisBound = thisBound;
+        _boundThis = boundThis;
+        _boundSuper = boundSuper;
         _arity = declaration.Parameters.Count(p => p.DefaultValue == null && !p.IsRest && !p.IsOptional);
     }
 
@@ -36,6 +53,21 @@ public class SharpTSGeneratorFunction : ISharpTSCallable
     {
         // Create environment and bind parameters (like a regular function)
         RuntimeEnvironment environment = new(_closure);
+        // #775: a generator expression / object generator method binds its own dynamic `this`. The bound
+        // receiver (or globalThis for a plain call) is defined in the generator's OWN body environment —
+        // NOT a new parent scope inserted above the closure — so a captured enclosing-function local keeps
+        // its lexical scope distance and still resolves. A plain call defaults `this` to undefined
+        // (strict-mode function-expression semantics) rather than leaving it unbound.
+        if (_thisBound)
+        {
+            environment.Define("this", _boundThis);
+            if (_boundSuper != null)
+                environment.Define("super", _boundSuper);
+        }
+        else if (_declaration.HasDynamicThis)
+        {
+            environment.Define("this", SharpTSGlobalThis.Instance); // sloppy-mode `this` = globalThis (#775)
+        }
         ParameterBinder.Bind(_declaration.Parameters, arguments, environment, interpreter);
 
         // Return a generator that will execute the body lazily
@@ -46,20 +78,17 @@ public class SharpTSGeneratorFunction : ISharpTSCallable
     /// Creates a bound version with 'this' set for method calls.
     /// </summary>
     public SharpTSGeneratorFunction Bind(SharpTSInstance instance)
-    {
-        RuntimeEnvironment boundEnv = new(_closure);
-        boundEnv.Define("this", instance);
-        return new SharpTSGeneratorFunction(_declaration, boundEnv);
-    }
+        => new(_declaration, _closure, thisBound: true, boundThis: instance);
+
+    /// <summary>
+    /// Binds an arbitrary receiver (object-literal generator method / <c>.call</c> / <c>.apply</c>),
+    /// not just a <see cref="SharpTSInstance"/> (#775).
+    /// </summary>
+    public ISharpTSCallable BindToReceiver(object receiver)
+        => new SharpTSGeneratorFunction(_declaration, _closure, thisBound: true, boundThis: receiver);
 
     public SharpTSGeneratorFunction BindStatic(SharpTSClass klass)
-    {
-        RuntimeEnvironment boundEnv = new(_closure);
-        boundEnv.Define("this", klass);
-        if (klass.Superclass != null)
-            boundEnv.Define("super", klass.Superclass);
-        return new SharpTSGeneratorFunction(_declaration, boundEnv);
-    }
+        => new(_declaration, _closure, thisBound: true, boundThis: klass, boundSuper: klass.Superclass);
 
     public override string ToString() => $"<generator fn {_declaration.Name.Lexeme}>";
 }
@@ -71,11 +100,15 @@ public class SharpTSGeneratorFunction : ISharpTSCallable
 /// Similar to <see cref="SharpTSGeneratorFunction"/> but wraps an <see cref="Expr.ArrowFunction"/>
 /// with IsGenerator=true instead of a <see cref="Stmt.Function"/>.
 /// </remarks>
-public class SharpTSArrowGeneratorFunction : ISharpTSCallable
+public class SharpTSArrowGeneratorFunction : ISharpTSCallable, IReceiverBindable
 {
     private readonly Expr.ArrowFunction _declaration;
     private readonly RuntimeEnvironment _closure;
     private readonly int _arity;
+    /// <summary>A dynamic receiver was bound (via <see cref="Bind"/>), so <see cref="Call"/> binds
+    /// <c>this</c> to <see cref="_boundThis"/> rather than defaulting it to undefined.</summary>
+    private readonly bool _thisBound;
+    private readonly object? _boundThis;
 
     /// <summary>
     /// Indicates whether this function has its own 'this' binding (function expressions)
@@ -83,11 +116,13 @@ public class SharpTSArrowGeneratorFunction : ISharpTSCallable
     /// </summary>
     public bool HasOwnThis { get; }
 
-    public SharpTSArrowGeneratorFunction(Expr.ArrowFunction declaration, RuntimeEnvironment closure, bool hasOwnThis = false)
+    public SharpTSArrowGeneratorFunction(Expr.ArrowFunction declaration, RuntimeEnvironment closure, bool hasOwnThis = false, bool thisBound = false, object? boundThis = null)
     {
         _declaration = declaration;
         _closure = closure;
         HasOwnThis = hasOwnThis;
+        _thisBound = thisBound;
+        _boundThis = boundThis;
         _arity = declaration.Parameters.Count(p => p.DefaultValue == null && !p.IsRest && !p.IsOptional);
     }
 
@@ -104,6 +139,13 @@ public class SharpTSArrowGeneratorFunction : ISharpTSCallable
         {
             environment.Define(_declaration.Name.Lexeme, this);
         }
+        // #775: a `function*` expression binds its own dynamic `this`. The bound receiver (or undefined
+        // for a plain call) is defined in the generator's OWN body environment, NOT a parent scope, so a
+        // captured enclosing-scope binding keeps its lexical scope distance.
+        if (_thisBound)
+            environment.Define("this", _boundThis);
+        else if (HasOwnThis)
+            environment.Define("this", SharpTSGlobalThis.Instance); // sloppy-mode `this` = globalThis (#775)
         ParameterBinder.Bind(_declaration.Parameters, arguments, environment, interpreter);
 
         // A generator function expression drives the same SharpTSGenerator as a declaration — only the
@@ -118,11 +160,10 @@ public class SharpTSArrowGeneratorFunction : ISharpTSCallable
     /// Binds 'this' to the given object. Only applicable for function expressions with HasOwnThis=true.
     /// </summary>
     public SharpTSArrowGeneratorFunction Bind(object thisObject)
-    {
-        RuntimeEnvironment boundEnv = new(_closure);
-        boundEnv.Define("this", thisObject);
-        return new SharpTSArrowGeneratorFunction(_declaration, boundEnv, hasOwnThis: true);
-    }
+        => new(_declaration, _closure, hasOwnThis: true, thisBound: true, boundThis: thisObject);
+
+    /// <summary>Receiver-binding entry point for the method-call / <c>.call</c> / <c>.apply</c> path (#775).</summary>
+    public ISharpTSCallable BindToReceiver(object receiver) => Bind(receiver);
 
     public override string ToString()
     {

--- a/SharpTS.Tests/SharedTests/AsyncGeneratorTests.cs
+++ b/SharpTS.Tests/SharedTests/AsyncGeneratorTests.cs
@@ -45,6 +45,48 @@ public class AsyncGeneratorTests
         Assert.Equal("1 false\n2 false\n3 false\nundefined true\n", output);
     }
 
+    [Fact]
+    public void AsyncGenerator_ObjectMethod_ReadsThis_Interpreted()
+    {
+        // #775: an object async-generator method reads instance state via `this`. Interpreter only:
+        // the compiled async-generator object-METHOD value-call (`o.gen()`) inside an async function does
+        // not yet thread the receiver into the state machine (a pre-existing async-codegen gap, tracked
+        // separately). The `.call`/`.apply` async path works in both modes — see the test below.
+        var source = """
+            const o = { v: 7, async *gen() { yield this.v; yield this.v + 1; } };
+            async function main() {
+                const it = o.gen();
+                let r = await it.next();
+                console.log(r.value);
+                r = await it.next();
+                console.log(r.value);
+            }
+            main();
+            """;
+
+        Assert.Equal("7\n8\n", TestHarness.Run(source, ExecutionMode.Interpreted));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AsyncGeneratorFunctionExpression_DotCallBindsThis(ExecutionMode mode)
+    {
+        // #775: an `async function*` expression bound via `.call` reads `this`.
+        var source = """
+            async function* g() { yield this.x; yield this.x + 1; }
+            async function main() {
+                const it = (g as any).call({ x: 9 });
+                let r = await it.next();
+                console.log(r.value);
+                r = await it.next();
+                console.log(r.value);
+            }
+            main();
+            """;
+
+        Assert.Equal("9\n10\n", TestHarness.Run(source, mode));
+    }
+
     [Theory]
     [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void AsyncGenerator_EmptyGenerator_ReturnsDoneImmediately(ExecutionMode mode)

--- a/SharpTS.Tests/SharedTests/GeneratorTests.cs
+++ b/SharpTS.Tests/SharedTests/GeneratorTests.cs
@@ -1703,11 +1703,13 @@ public class GeneratorTests
         Assert.Contains("Yield not supported", ex.Message);
     }
 
-    [Fact]
-    public void GeneratorExpression_ClosesOverLocal_UsingThis_CompiledFailsCleanly()
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void GeneratorExpression_ClosesOverLocal_UsingThis_ThreadsDynamicThis(ExecutionMode mode)
     {
-        // A body using `this` cannot be reached through the forwarding arrow (it has no receiver), so
-        // the lambda-lift declines and the generator stays nested.
+        // #775: a generator function expression that closes over an enclosing-function local AND uses
+        // `this` lambda-lifts and threads its own dynamic `this`. Called plainly (`g()`), `this` is the
+        // sloppy-mode receiver (globalThis), so the body simply yields two values — length 2.
         var source = """
             function outer(this: any) {
               let y = 5;
@@ -1717,8 +1719,112 @@ public class GeneratorTests
             console.log(outer.call({}));
             """;
 
-        var ex = Assert.Throws<CompileException>(() => TestHarness.RunCompiled(source));
-        Assert.Contains("Yield not supported", ex.Message);
+        Assert.Equal("2\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void GeneratorExpression_ClosesOverLocal_UsingThis_DotCallBindsReceiver(ExecutionMode mode)
+    {
+        // #775: the generator captures an enclosing-function local (`mult`) AND reads `this` via a bound
+        // receiver (`.call`). Both the captured local and the dynamic receiver must resolve.
+        var source = """
+            function outer() {
+              let mult = 3;
+              const g = function*() { yield this.base * mult; yield this.base + mult; };
+              return [...(g as any).call({ base: 10 })];
+            }
+            console.log(outer().join(","));
+            """;
+
+        Assert.Equal("30,13\n", TestHarness.Run(source, mode));
+    }
+
+    #endregion
+
+    #region Generator function expression / object generator method dynamic `this` — issue #775
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ObjectGeneratorMethod_ReadsThis(ExecutionMode mode)
+    {
+        // The canonical case from the issue: an object generator method reads instance state via `this`.
+        var source = """
+            const o = { v: 5, *gen() { yield this.v; yield this.v + 1; } };
+            for (const x of o.gen()) console.log(x);
+            """;
+
+        Assert.Equal("5\n6\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void GeneratorFunctionExpression_DotCallBindsThis(ExecutionMode mode)
+    {
+        var source = """
+            function* g() { yield this.x; }
+            const o = { x: 9 };
+            for (const v of (g as any).call(o)) console.log(v);
+            """;
+
+        Assert.Equal("9\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void GeneratorFunctionExpression_AssignedAsMethod_BindsThis(ExecutionMode mode)
+    {
+        var source = """
+            const o: any = { v: 42 };
+            o.gen = function*() { yield this.v; };
+            console.log([...o.gen()].join(","));
+            """;
+
+        Assert.Equal("42\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ObjectSymbolIteratorGenerator_ReadsThis(ExecutionMode mode)
+    {
+        // The canonical MDN iterator pattern: a `[Symbol.iterator]` generator reading `this`.
+        var source = """
+            const o = {
+              vals: [10, 20],
+              [Symbol.iterator]: function*() { for (const v of this.vals) yield v; }
+            };
+            for (const x of o) console.log(x);
+            """;
+
+        Assert.Equal("10\n20\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void NamedGeneratorFunctionExpression_ReadsThis(ExecutionMode mode)
+    {
+        var source = """
+            const o: any = { base: 100 };
+            o.gen = function* gen() { yield this.base; yield this.base + 1; };
+            console.log([...o.gen()].join(","));
+            """;
+
+        Assert.Equal("100,101\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void PlainGeneratorFunctionExpressionCall_ThisIsSloppyGlobal(ExecutionMode mode)
+    {
+        // A `function*` expression called plainly (no receiver) binds `this` to the sloppy-mode global
+        // (consistent with a non-generator function expression), not an unbound-variable error. Both
+        // back ends model sloppy `this` as a globalThis object → typeof is "object".
+        var source = """
+            const g = function*() { yield typeof this; };
+            console.log([...g()].join(","));
+            """;
+
+        Assert.Equal("object\n", TestHarness.Run(source, mode));
     }
 
     #endregion


### PR DESCRIPTION
Fixes #775.

## Problem
A generator **function expression** (`function*(){}`) or **object-literal generator method** (`{ *gen(){ yield this.v } }`) lost its dynamic `this` in both back ends:
- **Interpreter:** `Runtime Error: Undefined variable 'this'.`
- **Compiled:** `System.NullReferenceException` inside the lifted `<__genArrow_N>` state machine.

Both forms are modeled as a `HasOwnThis` generator `Expr.ArrowFunction` and lifted by `GeneratorArrowLifter` to a free `Stmt.Function`, which drops the method receiver. Class generator methods (real instance methods) were unaffected.

## Approach
Lift-carry: a new `Stmt.Function.HasDynamicThis` flag is threaded through the lift.

- **Compiler:** the free-function generator stub captures the thread-local `$TSFunction._currentFunctionThis` (set by `InvokeWithThis` for an `o.gen()` / `.call(recv)` value-call) into the state machine's `<>4__this` field at creation time, coerced null → globalThis. This mirrors how a non-generator `function(){ this.x }` threads `this`, so direct `g()` calls keep their signature (no synthetic `__this` param) and `.call` on plain `function*` **declarations** works too. Applied to sync and async generators.
- **Interpreter:** the four generator wrappers implement `IReceiverBindable`; the receiver is bound at property access, for-of `[Symbol.iterator]`, and `.call`/`.apply`/`.bind` via a shared helper. `this` is defined in the generator's **own body environment** (not a new parent scope) so a captured enclosing-function local keeps its lexical scope distance. Unbound plain calls bind `this` to the sloppy-mode global, matching the compiler and regular function expressions.
- **`NestedFunctionLifter`:** a generator body using `this` can now lambda-lift (the enclosing-local + `this` case); only `arguments` still declines.

## Verification
- Full suite **13750 passed / 0 failed**
- All compiled repros **IL-verify**
- **+21 tests** (object generator methods, `function*` expressions, `.call`, `Symbol.iterator`, named gen exprs, enclosing-local + `this`, async via `.call`)

## Known follow-up (pre-existing async-codegen, not a regression)
Compiled async-generator object-**method** value-call `o.gen()` *inside an async function*, and inline `for await (… of o.gen())`, don't yet thread the receiver. The async `.call`/`.apply` path and the interpreter work.