### PR TITLE
Fix #343: --ref-asm BadImageFormatException constructing $TSFunction over a captured-var arrow

### DIFF
--- a/SharpTS.Tests/CompilerTests/ILVerificationTests.cs
+++ b/SharpTS.Tests/CompilerTests/ILVerificationTests.cs
@@ -945,9 +945,10 @@ public class ILVerificationTests
     // through a display class leaves a statically-object value against the slot,
     // which previously failed IL verification (StackUnexpected). No castclass is
     // safe here (it would crash on $Undefined), so the slot is dropped to object.
-    // Verified separately from run: reference-assembly compilation (used by
-    // CompileVerifyAndRun) trips a distinct, pre-existing $TSFunction.ctor reflection
-    // bug for this captured-var arrow shape — see #343.
+    // #343: reference-assembly compilation (used by CompileVerifyAndRun) used to trip
+    // a BadImageFormatException constructing $TSFunction over this captured-var arrow —
+    // root-caused to PEPacker emitting nil MethodDef ParamList row-pointers, fixed in
+    // NickNa.PEPacker 1.0.2. This now exercises the ref-asm runtime path end to end.
     [Fact]
     public void InferredStringReturn_CapturedVarArrow_PassesILVerification()
     {
@@ -962,10 +963,8 @@ public class ILVerificationTests
             console.log(outer());
             """;
 
-        var errors = TestHarness.CompileAndVerifyOnly(source);
+        var (errors, output) = TestHarness.CompileVerifyAndRun(source);
         Assert.Empty(errors);
-
-        var output = TestHarness.RunCompiled(source);
         Assert.Equal("ab\n", output);
     }
 

--- a/SharpTS.csproj
+++ b/SharpTS.csproj
@@ -76,7 +76,7 @@
   <ItemGroup>
     <PackageReference Include="MinVer" Version="6.0.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="NickNa.PEPacker" Version="1.0.1" />
+    <PackageReference Include="NickNa.PEPacker" Version="1.0.2" />
     <PackageReference Include="System.Reflection.MetadataLoadContext" Version="9.0.0" />
     <PackageReference Include="Microsoft.ILVerification" Version="10.0.0" />
     <PackageReference Include="NuGet.Packaging" Version="7.3.1" />


### PR DESCRIPTION
## Summary

Fixes #343. Compiling with `--ref-asm` and running the output DLL crashed with `System.BadImageFormatException: The parameters and the signature of the method don't match` from `GetParameters()` inside the emitted `$TSFunction` constructor, when wrapping a captured-var arrow (a top-level arrow whose nested arrows capture a sibling-mutated local).

## Root cause — in PEPacker, not SharpTS

The default (non-`--ref-asm`) compile runs the same program correctly, so SharpTS emits valid metadata. The `--ref-asm` path additionally runs PEPacker's `AssemblyReferenceRewriter`, which rebuilt the metadata with **nil `MethodDef.ParamList` row-pointers** for every method (it never pre-calculated `Param`-table rows, unlike `FieldList`/`MethodList` for TypeDefs). `MetadataBuilder` does not derive run-pointer columns, so the method→param linkage was wrong: a zero-arg method (e.g. a compiler-generated display-class `Invoke`) absorbed a later method's `Param` rows whose `SequenceNumber` exceeded its signature arity, and `GetParameters()` threw.

This single defect also produced the apparent "ref-asm strips parameter names" symptom worked around in #738 (the names were copied fine; the linkage was broken).

Fixed in **`NickNa.PEPacker` 1.0.2** (nickna/PE-Packer): a running `Param`-row counter assigns each method's `ParamList` correctly, plus a regression test.

## Changes here

- Bump `NickNa.PEPacker` `1.0.1` → `1.0.2`.
- Promote `ILVerificationTests.InferredStringReturn_CapturedVarArrow_PassesILVerification` from `CompileAndVerifyOnly` + `RunCompiled` to `CompileVerifyAndRun`, so the reference-assembly runtime path is now exercised end to end (it previously routed around this bug).

## Verification

- The issue repro compiled with `--ref-asm` now prints `ab` (was `BadImageFormatException`).
- 76 ref-asm / IL-verification tests pass locally, including the promoted test and the existing `RefAsm_*` suite.
- PEPacker's new `AssemblyReferenceRewriterParamTests` was validated by temporarily reverting the fix (test failed), then re-applying.

## Dependency note

Requires `NickNa.PEPacker` 1.0.2, published to NuGet via the nickna/PE-Packer `v1.0.2` tagged release. Allow a few minutes for NuGet indexing before CI restore.
