### PR TITLE
Fix #850: await-safe argument spilling in compiled array fast-paths

### DIFF
--- a/Compilation/Emitters/ArrayEmitter.cs
+++ b/Compilation/Emitters/ArrayEmitter.cs
@@ -42,6 +42,28 @@ public sealed class ArrayEmitter : ITypeEmitterStrategy
             "slice" or "concat" or "map" or "filter" or "flat" or "flatMap"
             or "splice" or "toReversed" or "toSorted" or "toSpliced" or "with";
 
+        // #850: when an argument can suspend (await/yield), evaluating it while the receiver list sits
+        // on the IL evaluation stack produces invalid IL across a state-machine suspension
+        // (PathStackDepth — the stack differs between the "awaiter completed" and post-resume paths).
+        // Pre-spill the receiver and every argument into await-safe locals (registered so they survive
+        // the MoveNext re-entry; plain locals in the synchronous emitter, so non-async codegen is
+        // unchanged), then restore the list on the stack so each case below emits exactly as before but
+        // sources its arguments from the pre-spilled locals. Only the plain-argument methods are
+        // affected; the callback methods (map/filter/find/...) dispatch their arrow from the AST and
+        // never trigger this — an arrow body's await belongs to its own state machine.
+        LocalBuilder[]? argLocals = null;
+        if (arguments.Count > 0 && MethodTakesPlainArgs(methodName) && emitter.ArgsContainSuspension(arguments))
+        {
+            var listSafe = emitter.SpillStackToObjectLocal();      // [list] -> await-safe local
+            il.Emit(OpCodes.Ldloc, receiverLocal);                 // the original receiver must also
+            receiverLocal = emitter.SpillStackToObjectLocal();     // survive the suspension (returnsReceiver methods)
+            argLocals = new LocalBuilder[arguments.Count];
+            for (int i = 0; i < arguments.Count; i++)
+                argLocals[i] = emitter.SpillBoxedArg(arguments[i]);   // suspensions happen here, with a clear stack
+            il.Emit(OpCodes.Ldloc, listSafe);
+            il.Emit(OpCodes.Castclass, ctx.Types.ListOfObject);    // restore [list]
+        }
+
         switch (methodName)
         {
             case "pop":
@@ -56,16 +78,16 @@ public sealed class ArrayEmitter : ITypeEmitterStrategy
                 // JS `arr.unshift(a, b, c)` prepends all args in order: [a,b,c,...orig].
                 // ArrayUnshift(list, el) inserts one element at the start, so iterate
                 // in reverse to preserve the final order.
-                EmitVariadicListMutation(emitter, arguments, ctx.Runtime!.ArrayUnshift, reverse: true);
+                EmitVariadicListMutation(emitter, arguments, ctx.Runtime!.ArrayUnshift, reverse: true, argLocals);
                 break;
 
             case "push":
                 // JS `arr.push(a, b, c)` appends all args. Iterate forward.
-                EmitVariadicListMutation(emitter, arguments, ctx.Runtime!.ArrayPush, reverse: false);
+                EmitVariadicListMutation(emitter, arguments, ctx.Runtime!.ArrayPush, reverse: false, argLocals);
                 break;
 
             case "slice":
-                EmitArgsArray(emitter, arguments);
+                EmitArgsArray(emitter, arguments, argLocals);
                 il.Emit(OpCodes.Call, ctx.Runtime!.ArraySlice);
                 break;
 
@@ -172,24 +194,27 @@ public sealed class ArrayEmitter : ITypeEmitterStrategy
             }
 
             case "reduce":
-                if (TryEmitReduceDirectCall(emitter, arguments))
+                // The direct-call fast path re-evaluates the callback/initial-value from the AST, so
+                // skip it when arguments were pre-spilled for await-safety (#850) and use the
+                // argLocals-aware array path instead.
+                if (argLocals == null && TryEmitReduceDirectCall(emitter, arguments))
                     break;
-                EmitArgsArray(emitter, arguments);
+                EmitArgsArray(emitter, arguments, argLocals);
                 il.Emit(OpCodes.Call, ctx.Runtime!.ArrayReduce);
                 break;
 
             case "reduceRight":
-                EmitArgsArray(emitter, arguments);
+                EmitArgsArray(emitter, arguments, argLocals);
                 il.Emit(OpCodes.Call, ctx.Runtime!.ArrayReduceRight);
                 break;
 
             case "join":
-                EmitSingleArgOrNull(emitter, arguments);
+                EmitSingleArgOrNull(emitter, arguments, argLocals);
                 il.Emit(OpCodes.Call, ctx.Runtime!.ArrayJoin);
                 break;
 
             case "concat":
-                EmitArgsArray(emitter, arguments);
+                EmitArgsArray(emitter, arguments, argLocals);
                 il.Emit(OpCodes.Call, ctx.Runtime!.ArrayConcat);
                 break;
 
@@ -198,28 +223,35 @@ public sealed class ArrayEmitter : ITypeEmitterStrategy
                 break;
 
             case "flat":
-                EmitSingleArgOrNull(emitter, arguments);
+                EmitSingleArgOrNull(emitter, arguments, argLocals);
                 il.Emit(OpCodes.Call, ctx.Runtime!.ArrayFlat);
                 break;
 
             case "flatMap":
-                EmitSingleArgOrNull(emitter, arguments);
+                EmitSingleArgOrNull(emitter, arguments, argLocals);
                 il.Emit(OpCodes.Call, ctx.Runtime!.ArrayFlatMap);
                 break;
 
             case "includes":
-                EmitSingleArgOrNull(emitter, arguments);
+                EmitSingleArgOrNull(emitter, arguments, argLocals);
                 il.Emit(OpCodes.Call, ctx.Runtime!.ArrayIncludes);
                 break;
 
             case "indexOf":
             case "lastIndexOf":
                 // searchElement (arg 0) + optional fromIndex (arg 1).
-                EmitSingleArgOrNull(emitter, arguments);
+                EmitSingleArgOrNull(emitter, arguments, argLocals);
                 if (arguments.Count >= 2)
                 {
-                    emitter.EmitExpression(arguments[1]);
-                    emitter.EmitBoxIfNeeded(arguments[1]);
+                    if (argLocals != null)
+                    {
+                        il.Emit(OpCodes.Ldloc, argLocals[1]);
+                    }
+                    else
+                    {
+                        emitter.EmitExpression(arguments[1]);
+                        emitter.EmitBoxIfNeeded(arguments[1]);
+                    }
                 }
                 else
                 {
@@ -230,22 +262,22 @@ public sealed class ArrayEmitter : ITypeEmitterStrategy
                 break;
 
             case "sort":
-                EmitSingleArgOrNull(emitter, arguments);
+                EmitSingleArgOrNull(emitter, arguments, argLocals);
                 il.Emit(OpCodes.Call, ctx.Runtime!.ArraySort);
                 break;
 
             case "toSorted":
-                EmitSingleArgOrNull(emitter, arguments);
+                EmitSingleArgOrNull(emitter, arguments, argLocals);
                 il.Emit(OpCodes.Call, ctx.Runtime!.ArrayToSorted);
                 break;
 
             case "splice":
-                EmitArgsArray(emitter, arguments);
+                EmitArgsArray(emitter, arguments, argLocals);
                 il.Emit(OpCodes.Call, ctx.Runtime!.ArraySplice);
                 break;
 
             case "toSpliced":
-                EmitArgsArray(emitter, arguments);
+                EmitArgsArray(emitter, arguments, argLocals);
                 il.Emit(OpCodes.Call, ctx.Runtime!.ArrayToSpliced);
                 break;
 
@@ -277,22 +309,22 @@ public sealed class ArrayEmitter : ITypeEmitterStrategy
                 break;
 
             case "with":
-                EmitArgsArray(emitter, arguments);
+                EmitArgsArray(emitter, arguments, argLocals);
                 il.Emit(OpCodes.Call, ctx.Runtime!.ArrayWith);
                 break;
 
             case "at":
-                EmitSingleArgOrNull(emitter, arguments);
+                EmitSingleArgOrNull(emitter, arguments, argLocals);
                 il.Emit(OpCodes.Call, ctx.Runtime!.ArrayAt);
                 break;
 
             case "fill":
-                EmitArgsArray(emitter, arguments);
+                EmitArgsArray(emitter, arguments, argLocals);
                 il.Emit(OpCodes.Call, ctx.Runtime!.ArrayFill);
                 break;
 
             case "copyWithin":
-                EmitArgsArray(emitter, arguments);
+                EmitArgsArray(emitter, arguments, argLocals);
                 il.Emit(OpCodes.Call, ctx.Runtime!.ArrayCopyWithin);
                 break;
 
@@ -592,17 +624,40 @@ public sealed class ArrayEmitter : ITypeEmitterStrategy
     }
 
     /// <summary>
-    /// Emits a single argument or null if no arguments provided.
+    /// Array methods that evaluate plain-expression arguments (via <see cref="EmitVariadicListMutation"/>,
+    /// <see cref="EmitArgsArray"/>, <see cref="EmitSingleArgOrNull"/>, or inline) rather than dispatching
+    /// a callback arrow from the AST. Only these can hit the #850 stack-spill bug when an argument
+    /// contains <c>await</c>/<c>yield</c>, so only these get await-safe argument pre-spilling. The
+    /// callback methods (map/filter/forEach/find/findIndex/some/every/findLast/findLastIndex) are
+    /// excluded — their arrow argument is matched on the AST before evaluation, and a nested arrow's
+    /// <c>await</c> belongs to its own state machine (never reported by ArgsContainSuspension).
     /// </summary>
-    private static void EmitSingleArgOrNull(IEmitterContext emitter, List<Expr> arguments)
+    private static bool MethodTakesPlainArgs(string methodName) => methodName is
+        "push" or "unshift" or "slice" or "reduce" or "reduceRight" or "join" or "concat" or
+        "flat" or "flatMap" or "includes" or "indexOf" or "lastIndexOf" or "sort" or "toSorted" or
+        "splice" or "toSpliced" or "with" or "at" or "fill" or "copyWithin";
+
+    /// <summary>
+    /// Emits a single argument or null if no arguments provided. When <paramref name="argLocals"/> is
+    /// supplied (await-safe pre-spilled args, #850) the value is loaded from the local rather than
+    /// re-evaluated.
+    /// </summary>
+    private static void EmitSingleArgOrNull(IEmitterContext emitter, List<Expr> arguments, LocalBuilder[]? argLocals = null)
     {
         var ctx = emitter.Context;
         var il = ctx.IL;
 
         if (arguments.Count > 0)
         {
-            emitter.EmitExpression(arguments[0]);
-            emitter.EmitBoxIfNeeded(arguments[0]);
+            if (argLocals != null)
+            {
+                il.Emit(OpCodes.Ldloc, argLocals[0]);
+            }
+            else
+            {
+                emitter.EmitExpression(arguments[0]);
+                emitter.EmitBoxIfNeeded(arguments[0]);
+            }
         }
         else
         {
@@ -817,7 +872,13 @@ public sealed class ArrayEmitter : ITypeEmitterStrategy
     /// <summary>
     /// Emits all arguments as an object array.
     /// </summary>
-    private static void EmitArgsArray(IEmitterContext emitter, List<Expr> arguments)
+    /// <summary>
+    /// Builds an <c>object[]</c> of the (boxed) arguments on the stack. When <paramref name="argLocals"/>
+    /// is supplied (await-safe pre-spilled args, #850) each element is loaded from its local rather than
+    /// re-evaluated — needed because building the array inline would leave the receiver list (and the
+    /// partially built array) on the IL stack across a suspending argument.
+    /// </summary>
+    private static void EmitArgsArray(IEmitterContext emitter, List<Expr> arguments, LocalBuilder[]? argLocals = null)
     {
         var ctx = emitter.Context;
         var il = ctx.IL;
@@ -828,8 +889,15 @@ public sealed class ArrayEmitter : ITypeEmitterStrategy
         {
             il.Emit(OpCodes.Dup);
             il.Emit(OpCodes.Ldc_I4, i);
-            emitter.EmitExpression(arguments[i]);
-            emitter.EmitBoxIfNeeded(arguments[i]);
+            if (argLocals != null)
+            {
+                il.Emit(OpCodes.Ldloc, argLocals[i]);
+            }
+            else
+            {
+                emitter.EmitExpression(arguments[i]);
+                emitter.EmitBoxIfNeeded(arguments[i]);
+            }
             il.Emit(OpCodes.Stelem_Ref);
         }
     }
@@ -846,13 +914,15 @@ public sealed class ArrayEmitter : ITypeEmitterStrategy
     /// (needed for unshift so the final order matches JS: `unshift(a,b,c)` yields
     /// <c>[a,b,c,...orig]</c>).
     /// </summary>
-    private static void EmitVariadicListMutation(IEmitterContext emitter, List<Expr> arguments, System.Reflection.Emit.MethodBuilder runtimeMethod, bool reverse)
+    private static void EmitVariadicListMutation(IEmitterContext emitter, List<Expr> arguments, System.Reflection.Emit.MethodBuilder runtimeMethod, bool reverse, LocalBuilder[]? argLocals = null)
     {
         var ctx = emitter.Context;
         var il = ctx.IL;
 
         // Stash the list in a local so we can reuse it across iterations and then
-        // read its Count at the end.
+        // read its Count at the end. (When an argument suspends the list has already been
+        // moved to an await-safe local by the caller and the args pre-spilled into argLocals,
+        // so no suspension occurs in the loop below and this plain local never crosses one — #850.)
         var listLocal = il.DeclareLocal(ctx.Types.ListOfObject);
         il.Emit(OpCodes.Stloc, listLocal);
 
@@ -870,8 +940,15 @@ public sealed class ArrayEmitter : ITypeEmitterStrategy
         {
             int i = reverse ? arguments.Count - 1 - step : step;
             il.Emit(OpCodes.Ldloc, listLocal);
-            emitter.EmitExpression(arguments[i]);
-            emitter.EmitBoxIfNeeded(arguments[i]);
+            if (argLocals != null)
+            {
+                il.Emit(OpCodes.Ldloc, argLocals[i]);
+            }
+            else
+            {
+                emitter.EmitExpression(arguments[i]);
+                emitter.EmitBoxIfNeeded(arguments[i]);
+            }
             il.Emit(OpCodes.Call, runtimeMethod);
             il.Emit(OpCodes.Pop); // discard the per-element count return
         }

--- a/Compilation/Emitters/IEmitterContext.cs
+++ b/Compilation/Emitters/IEmitterContext.cs
@@ -87,6 +87,31 @@ public interface IEmitterContext
     void EmitOmittedArgument(Type slotType);
 
     /// <summary>
+    /// True when evaluating any of <paramref name="args"/> can suspend the enclosing state machine
+    /// (contains an <c>await</c>/<c>yield</c>). Type-emitter strategies use this to decide whether a
+    /// fast path must spill arguments before touching the receiver: leaving the receiver (or a partly
+    /// built array) on the IL stack across a suspension produces invalid IL (#850). Always false in the
+    /// synchronous emitter.
+    /// </summary>
+    bool ArgsContainSuspension(IReadOnlyList<Expr> args);
+
+    /// <summary>
+    /// Evaluates <paramref name="arg"/>, boxes it, and spills it into an await-safe object local (one
+    /// that persists across a MoveNext re-entry in state-machine emitters; a plain local in the
+    /// synchronous emitter). Use to pre-evaluate call arguments that can suspend so the suspension
+    /// happens with a clear stack. Stack: [] -&gt; [].
+    /// </summary>
+    LocalBuilder SpillBoxedArg(Expr arg);
+
+    /// <summary>
+    /// Pops the boxed object reference on top of the stack into an await-safe local (persisted across
+    /// a MoveNext re-entry in state-machine emitters; a plain local in the synchronous emitter) and
+    /// returns it. Use to move an already-evaluated receiver off the stack before spilling arguments
+    /// that can suspend. Stack: [value] -&gt; [].
+    /// </summary>
+    LocalBuilder SpillStackToObjectLocal();
+
+    /// <summary>
     /// Emits IL that constructs a delegate of the given type pointing at the
     /// arrow's compiled body. For non-capturing arrows: <c>new Func(null, ldftn staticMethod)</c>.
     /// For capturing arrows: allocate the display class instance, populate

--- a/Compilation/ExpressionEmitterBase.cs
+++ b/Compilation/ExpressionEmitterBase.cs
@@ -360,6 +360,14 @@ public abstract partial class ExpressionEmitterBase : IEmitterContext
         return _helpers.SpillStoreObject();
     }
 
+    // IEmitterContext spill seam (#850): exposes the await-safe spilling already used by the generic
+    // call path so type-emitter strategies (ArrayEmitter, etc.) can pre-spill arguments instead of
+    // evaluating them while the receiver sits on the IL stack. In the synchronous ILEmitter these
+    // resolve to plain locals, so non-async codegen is unchanged.
+    bool IEmitterContext.ArgsContainSuspension(IReadOnlyList<Expr> args) => AnyContainsSuspension(args);
+    LocalBuilder IEmitterContext.SpillBoxedArg(Expr arg) => SpillBoxed(arg);
+    LocalBuilder IEmitterContext.SpillStackToObjectLocal() => _helpers.SpillStoreObject();
+
     /// <summary>
     /// Emits a binary operator expression. Default boxes both operands and delegates to TryEmitBinaryOperator.
     /// ILEmitter overrides with stack-type-tracked fast paths.

--- a/SharpTS.Tests/SharedTests/ArrayMethodAwaitArgTests.cs
+++ b/SharpTS.Tests/SharedTests/ArrayMethodAwaitArgTests.cs
@@ -1,0 +1,262 @@
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests;
+
+/// <summary>
+/// An array method whose argument contains a nested `await` (e.g. `arr.push(String(await f()))`).
+/// In compiled mode the array fast-path emitters used to evaluate the argument while the receiver
+/// list (and, for the args-array methods, a partially built `object[]`) sat on the IL evaluation
+/// stack; across the state-machine suspension that produced invalid IL
+/// ("PathStackDepth - Stack depth differs depending on path", #850). The fix pre-spills the receiver
+/// and every argument into await-safe locals before the suspension. These tests pin every affected
+/// method (interp == compiled; compiled mode also IL-verifies on load).
+/// </summary>
+public class ArrayMethodAwaitArgTests
+{
+    // The exact #850 repro: an async arrow that WRITES a captured variable, awaited inside push().
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Push_AwaitedWriteCaptureArrow(ExecutionMode mode)
+    {
+        var source = """
+            async function af(): Promise<string> {
+              const out: string[] = [];
+              let r = 5;
+              const f = async () => { r = r + 1; return r; };
+              out.push(String(await f()));
+              out.push(String(r));
+              return out.join(",");
+            }
+            async function main() { console.log(await af()); }
+            main();
+            """;
+
+        Assert.Equal("6,6\n", TestHarness.Run(source, mode));
+    }
+
+    // Same shape but a READ-ONLY capture — confirms the bug was never about write-capture promotion.
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Push_AwaitedReadOnlyCaptureArrow(ExecutionMode mode)
+    {
+        var source = """
+            async function af(): Promise<string> {
+              const out: string[] = [];
+              let r = 5;
+              const f = async () => { return r + 1; };
+              out.push(String(await f()));
+              out.push(String(r));
+              return out.join(",");
+            }
+            async function main() { console.log(await af()); }
+            main();
+            """;
+
+        Assert.Equal("6,5\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Push_MultipleAwaitedArgs(ExecutionMode mode)
+    {
+        var source = """
+            async function n(x: number): Promise<number> { return x; }
+            async function main() {
+              const a: number[] = [];
+              a.push(await n(1), await n(2), await n(3));
+              console.log(a.join(","));
+            }
+            main();
+            """;
+
+        Assert.Equal("1,2,3\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Unshift_AwaitedArg(ExecutionMode mode)
+    {
+        var source = """
+            async function n(x: number): Promise<number> { return x; }
+            async function main() {
+              const a = [3, 4];
+              a.unshift(await n(1), await n(2));
+              console.log(a.join(","));
+            }
+            main();
+            """;
+
+        Assert.Equal("1,2,3,4\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Slice_AwaitedArgs(ExecutionMode mode)
+    {
+        var source = """
+            async function n(x: number): Promise<number> { return x; }
+            async function main() {
+              const a = [10, 20, 30, 40];
+              console.log(a.slice(await n(1), await n(3)).join(","));
+            }
+            main();
+            """;
+
+        Assert.Equal("20,30\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Splice_AwaitedArgs(ExecutionMode mode)
+    {
+        var source = """
+            async function n(x: number): Promise<number> { return x; }
+            async function main() {
+              const a = [10, 20, 30];
+              a.splice(await n(1), await n(1), await n(99));
+              console.log(a.join(","));
+            }
+            main();
+            """;
+
+        Assert.Equal("10,99,30\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Concat_AwaitedArg(ExecutionMode mode)
+    {
+        var source = """
+            async function n(x: number): Promise<number> { return x; }
+            async function main() {
+              const a = [1, 2];
+              console.log(a.concat([await n(3)]).join(","));
+            }
+            main();
+            """;
+
+        Assert.Equal("1,2,3\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Reduce_AwaitedInitialValue(ExecutionMode mode)
+    {
+        var source = """
+            async function n(x: number): Promise<number> { return x; }
+            async function main() {
+              const a = [1, 2, 3];
+              console.log(a.reduce((p, c) => p + c, await n(100)));
+            }
+            main();
+            """;
+
+        Assert.Equal("106\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void IndexOf_AwaitedArgs(ExecutionMode mode)
+    {
+        var source = """
+            async function n(x: number): Promise<number> { return x; }
+            async function main() {
+              const a = [5, 6, 7, 6];
+              console.log(a.indexOf(await n(6), await n(2)));
+            }
+            main();
+            """;
+
+        Assert.Equal("3\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Includes_AwaitedArg(ExecutionMode mode)
+    {
+        var source = """
+            async function n(x: number): Promise<number> { return x; }
+            async function main() {
+              const a = [1, 2, 3];
+              console.log(a.includes(await n(2)));
+            }
+            main();
+            """;
+
+        Assert.Equal("true\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Fill_AwaitedArgs(ExecutionMode mode)
+    {
+        var source = """
+            async function n(x: number): Promise<number> { return x; }
+            async function main() {
+              const a = [0, 0, 0, 0];
+              a.fill(await n(7), await n(1), await n(3));
+              console.log(a.join(","));
+            }
+            main();
+            """;
+
+        Assert.Equal("0,7,7,0\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void CopyWithin_AwaitedArgs(ExecutionMode mode)
+    {
+        var source = """
+            async function n(x: number): Promise<number> { return x; }
+            async function main() {
+              const a = [1, 2, 3, 4, 5];
+              a.copyWithin(await n(0), await n(3));
+              console.log(a.join(","));
+            }
+            main();
+            """;
+
+        Assert.Equal("4,5,3,4,5\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void At_AwaitedArg(ExecutionMode mode)
+    {
+        var source = """
+            async function n(x: number): Promise<number> { return x; }
+            async function main() {
+              const a = [11, 22, 33];
+              console.log(a.at(await n(-1)));
+            }
+            main();
+            """;
+
+        Assert.Equal("33\n", TestHarness.Run(source, mode));
+    }
+
+    // The original issue surfaced via a sync arrow capture plus an unrelated awaited call inside push
+    // (variant D) — also fixed, since the trigger is purely the nested await in the array argument.
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Push_SyncArrowCaptureWithUnrelatedAwait(ExecutionMode mode)
+    {
+        var source = """
+            async function g(): Promise<number> { return 0; }
+            async function af(): Promise<string> {
+              const out: string[] = [];
+              let r = 5;
+              const f = () => { r = r + 1; return r; };
+              out.push(String(f() + (await g())));
+              out.push(String(r));
+              return out.join(",");
+            }
+            async function main() { console.log(await af()); }
+            main();
+            """;
+
+        Assert.Equal("6,6\n", TestHarness.Run(source, mode));
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #850. In **compiled** mode, an array fast-path method whose argument contains an `await` emitted invalid IL:

```
[IL Error] <af>d__0.MoveNext: PathStackDepth {Offset=397} - Stack depth differs depending on path.
```

```ts
async function af(): Promise<string> {
  const out: string[] = [];
  let r = 5;
  const f = async () => { r = r + 1; return r; };
  out.push(String(await f()));   // <-- nested await in a push() argument
  out.push(String(r));
  return out.join(",");
}
```
Interpreted: `6,6`. Compiled: IL verification error.

## Root cause (issue mis-attributed)

The issue was filed against the async-arrow **write-capture promotion** path (`ComputeArrowWrittenCapturesToPromote`). Investigation (IL disassembly at the error offset + differential repros) disproved that:

| Variant | Compiled |
|---|---|
| write-capture arrow + `push(String(await f()))` | IL error |
| **read-only** capture, same shape | IL error |
| **sync** arrow capture + unrelated `await g()` in `push` | IL error |
| await spilled to a temp before `push` | clean |

The real trigger is purely **an `await` (suspension) nested as an argument to an array fast-path method**. `ArrayEmitter` leaves the unwrapped `List<object>` on the IL stack (`EmitGetListFromArrayOrList`) and then evaluates argument expressions inline (`EmitVariadicListMutation` for push/unshift; `EmitArgsArray` for slice/splice/concat/reduce/with/fill/copyWithin). The stranded list crosses the suspension → invalid IL. This is the same bug class the generic call path already solved via `AnyContainsSuspension`/`SpillBoxed` (#400/#413/#436/#439); the array fast paths never adopted it.

## Fix

- Expose an await-safe spill seam on `IEmitterContext` (`ArgsContainSuspension`, `SpillBoxedArg`, `SpillStackToObjectLocal`), implemented in `ExpressionEmitterBase` by delegating to the existing base helpers. In the synchronous emitter these resolve to plain locals — **no change to non-async codegen**.
- In `ArrayEmitter.TryEmitMethodCall`, when a plain-argument method has a suspending argument, pre-spill the receiver **and** every argument into await-safe locals before the suspension, then restore the list on the stack so each case emits exactly as before. The receiver is re-spilled too so `returnsReceiver` methods (`fill`/`copyWithin`) survive the MoveNext re-entry.
- Thread the pre-spilled `argLocals` through `EmitVariadicListMutation`/`EmitArgsArray`/`EmitSingleArgOrNull` and the inline `indexOf`/`lastIndexOf` arg; `reduce` skips its direct-call fast path when arguments were pre-spilled.

Callback methods (`map`/`filter`/`forEach`/`find`/...) are unaffected — an arrow argument's `await` belongs to its own state machine and never triggers the spill.

Covered methods: push, unshift, slice, splice, concat, reduce, reduceRight, join, flat, flatMap, includes, indexOf, lastIndexOf, sort, toSorted, with, at, fill, copyWithin.

## Tests / verification

- New `ArrayMethodAwaitArgTests` — 14 cases × interp+compiled (28), including the exact #850 repro (write-capture **and** read-only), the sync-arrow variant, and every affected method.
- The repro and each affected method IL-verify clean; interp == compiled output.
- Regression suites green: **Array 1096, Async 1224, Generator 1073**.

## Out of scope

The same "evaluate args while the receiver is stacked" pattern may exist in the string/Map/Set `ITypeEmitterStrategy` fast paths — a follow-up if a grep confirms it.