### PR TITLE
Share storage for sync inner-arrow write-captures in async methods/arrows (follow-up to #838)

### DIFF
--- a/Compilation/AsyncArrowMoveNextEmitter.ArrowFunctions.cs
+++ b/Compilation/AsyncArrowMoveNextEmitter.ArrowFunctions.cs
@@ -49,6 +49,18 @@ public partial class AsyncArrowMoveNextEmitter
         // Create display class instance
         _il.Emit(OpCodes.Newobj, displayCtor);
 
+        // Follow-up to #838: if this sync arrow routes a captured write through THIS async arrow's own
+        // function DC, share the reference: dc.$functionDC = this.<>__functionDC. The arrow body then
+        // reads/writes that local through $functionDC (verifiable) instead of a by-value snapshot.
+        if (_ctx.ArrowFunctionDCFields?.TryGetValue(af, out var functionDCField) == true &&
+            _builder.FunctionDCField != null)
+        {
+            _il.Emit(OpCodes.Dup);
+            _il.Emit(OpCodes.Ldarg_0);
+            _il.Emit(OpCodes.Ldfld, _builder.FunctionDCField);
+            _il.Emit(OpCodes.Stfld, functionDCField);
+        }
+
         // Get captured variables field mapping
         if (_ctx.DisplayClassFields == null || !_ctx.DisplayClassFields.TryGetValue(af, out var fieldMap))
         {

--- a/Compilation/AsyncArrowMoveNextEmitter.Variables.cs
+++ b/Compilation/AsyncArrowMoveNextEmitter.Variables.cs
@@ -35,6 +35,16 @@ public partial class AsyncArrowMoveNextEmitter
             return;
         }
 
+        // Follow-up to #838: a local of THIS async arrow that a nested sync arrow writes lives in the
+        // arrow's own function DC (reference type), so read it through `this.<>__functionDC.field`.
+        if (TryGetOwnFunctionDCField(name, out var ownReadField))
+        {
+            EmitLoadOwnFunctionDC();
+            _il.Emit(OpCodes.Ldfld, ownReadField);
+            SetStackUnknown();
+            return;
+        }
+
         // Try resolver first (params, locals, hoisted, captured)
         var stackType = _resolver!.TryLoadVariable(name);
         if (stackType != null)
@@ -138,6 +148,18 @@ public partial class AsyncArrowMoveNextEmitter
             return;
         }
 
+        // Follow-up to #838: write a DC-resident local through `this.<>__functionDC.field = value`.
+        if (TryGetOwnFunctionDCField(name, out var ownAssignField))
+        {
+            var temp = _il.DeclareLocal(_types.Object);
+            _il.Emit(OpCodes.Stloc, temp);     // consume the duplicated value
+            EmitLoadOwnFunctionDC();
+            _il.Emit(OpCodes.Ldloc, temp);
+            _il.Emit(OpCodes.Stfld, ownAssignField);
+            SetStackUnknown();                 // remaining copy is the assignment's value
+            return;
+        }
+
         // Check if it's a captured top-level variable in entry-point display class
         if (_ctx?.CapturedTopLevelVars?.Contains(name) == true &&
             _ctx.EntryPointDisplayClassFields?.TryGetValue(name, out var entryPointField) == true &&
@@ -190,6 +212,19 @@ public partial class AsyncArrowMoveNextEmitter
             EmitLoadOuterFunctionDC();
             _il.Emit(OpCodes.Ldloc, temp);
             _il.Emit(OpCodes.Stfld, dcStoreField);
+            return;
+        }
+
+        // Follow-up to #838: store a DC-resident local through `this.<>__functionDC.field` (covers the
+        // body's own `let r = …` declaration, which routes through EmitStoreVariable). Checked first so it
+        // wins over any (now-unused) hoisted SM field.
+        if (TryGetOwnFunctionDCField(name, out var ownStoreField))
+        {
+            var temp = _il.DeclareLocal(_types.Object);
+            _il.Emit(OpCodes.Stloc, temp);
+            EmitLoadOwnFunctionDC();
+            _il.Emit(OpCodes.Ldloc, temp);
+            _il.Emit(OpCodes.Stfld, ownStoreField);
             return;
         }
 
@@ -392,6 +427,23 @@ public partial class AsyncArrowMoveNextEmitter
         _il.Emit(OpCodes.Ldfld, _builder.OuterStateMachineField!);
         _il.Emit(OpCodes.Unbox, _builder.OuterStateMachineType!);
         _il.Emit(OpCodes.Ldfld, _ctx!.OuterFunctionDCField!);
+    }
+
+    // Follow-up to #838: this arrow's OWN function display class (a reference type held on its state
+    // machine), shared with a nested sync arrow that writes one of the arrow's locals. The field map is
+    // on the builder so it never collides with the OuterFunctionDCField relay above.
+    private bool TryGetOwnFunctionDCField(string name, out FieldBuilder dcField)
+    {
+        dcField = null!;
+        return _builder.FunctionDCField != null
+            && _builder.FunctionDCFieldMap.TryGetValue(name, out dcField!);
+    }
+
+    // Pushes `this.<>__functionDC` (a class reference); the caller's ldfld/stfld on it is verifiable.
+    private void EmitLoadOwnFunctionDC()
+    {
+        _il.Emit(OpCodes.Ldarg_0);
+        _il.Emit(OpCodes.Ldfld, _builder.FunctionDCField!);
     }
 
     // Const declarations, compound/logical assignment, and increment/decrement reach the variable

--- a/Compilation/AsyncArrowMoveNextEmitter.cs
+++ b/Compilation/AsyncArrowMoveNextEmitter.cs
@@ -159,6 +159,21 @@ public partial class AsyncArrowMoveNextEmitter : StatementEmitterBase, IEmitterC
         // State dispatch switch
         EmitStateDispatch();
 
+        // Follow-up to #838: instantiate this arrow's own function display class once, so a nested sync
+        // arrow that writes one of the arrow's locals shares the reference cell. Null-guarded: a resume
+        // re-enters MoveNext but the field is already set, so it is created exactly once on initial entry.
+        if (_builder.FunctionDCField != null && _builder.FunctionDCCtor != null)
+        {
+            var dcAlreadySet = _il.DefineLabel();
+            _il.Emit(OpCodes.Ldarg_0);
+            _il.Emit(OpCodes.Ldfld, _builder.FunctionDCField);
+            _il.Emit(OpCodes.Brtrue, dcAlreadySet);
+            _il.Emit(OpCodes.Ldarg_0);
+            _il.Emit(OpCodes.Newobj, _builder.FunctionDCCtor);
+            _il.Emit(OpCodes.Stfld, _builder.FunctionDCField);
+            _il.MarkLabel(dcAlreadySet);
+        }
+
         // Apply parameter defaults on initial entry (#646). Placed after the state-dispatch
         // switch so a resume (state >= 0) jumps straight to its await label past this code; on
         // initial entry (state -1) the switch falls through to here. Arrow parameter fields are

--- a/Compilation/AsyncArrowStateMachineBuilder.cs
+++ b/Compilation/AsyncArrowStateMachineBuilder.cs
@@ -73,6 +73,17 @@ public class AsyncArrowStateMachineBuilder
     // The captures this arrow needs from outer scope
     public HashSet<string> Captures { get; }
 
+    // Follow-up to #838: the <>__functionDC field holding this async arrow's own reference-type function
+    // display class, shared with a nested SYNC arrow that writes one of the arrow's captured locals. Null
+    // unless RegisterAsyncArrowFunctionDisplayClasses registered a DC for this arrow. The ctor is stored so
+    // the stub can instantiate it once on entry.
+    public FieldBuilder? FunctionDCField { get; private set; }
+    public ConstructorBuilder? FunctionDCCtor { get; private set; }
+    // The DC's (storage name → field) map, so this arrow's own MoveNext routes a DC-resident local's
+    // read/write through `this.<>__functionDC.field`. Kept on the builder rather than the context so it
+    // never collides with the OuterFunctionDCField relay's use of ctx.FunctionDisplayClassFields.
+    public Dictionary<string, FieldBuilder> FunctionDCFieldMap { get; } = [];
+
     // Methods
     public MethodBuilder MoveNextMethod { get; private set; } = null!;
     public MethodBuilder SetStateMachineMethod { get; private set; } = null!;
@@ -330,6 +341,22 @@ public class AsyncArrowStateMachineBuilder
     }
 
     /// <summary>
+    /// Follow-up to #838: adds the <c>&lt;&gt;__functionDC</c> field that holds this async arrow's own
+    /// reference-type function display class (shared with a nested sync arrow that writes one of the
+    /// arrow's captured locals). Must be called after <see cref="DefineStateMachine"/> /
+    /// <see cref="DefineStateMachineStandalone"/> (the state-machine type must exist) and before
+    /// <c>CreateType</c>. The stub instantiates it once on entry; the ctor is stored here for that.
+    /// </summary>
+    public void DefineFunctionDisplayClassField(Type dcType, ConstructorBuilder dcCtor,
+        IReadOnlyDictionary<string, FieldBuilder> dcFields)
+    {
+        FunctionDCField = _stateMachineType.DefineField("<>__functionDC", dcType, FieldAttributes.Public);
+        FunctionDCCtor = dcCtor;
+        foreach (var (name, field) in dcFields)
+            FunctionDCFieldMap[name] = field;
+    }
+
+    /// <summary>
     /// Defines and emits the stub method that creates the state machine when the arrow is invoked.
     /// The stub takes (outer state machine boxed, params...) and returns Task&lt;object&gt;.
     /// For standalone arrows, there's no outer SM parameter but captures are passed.
@@ -439,6 +466,10 @@ public class AsyncArrowStateMachineBuilder
             il.Emit(OpCodes.Ldarg, i + paramOffset);
             il.Emit(OpCodes.Stfld, paramField);
         }
+
+        // (Follow-up to #838: this arrow's own function DC is instantiated in the MoveNext prologue, not
+        // here — the DC field is attached only in Phase 5/6, after this stub is defined in Phase 4 for a
+        // nested arrow. The prologue null-guards so it runs exactly once on initial entry.)
 
         // sm.<>t__builder = AsyncTaskMethodBuilder<object>.Create();
         il.Emit(OpCodes.Ldloca, smLocal);

--- a/Compilation/ILCompiler.ArrowFunctions.cs
+++ b/Compilation/ILCompiler.ArrowFunctions.cs
@@ -39,7 +39,13 @@ public partial class ILCompiler
     // name qualification isn't available here. The AST node is stable; we
     // resolve it to the qualified name at propagate time via FunctionAstNodes.
     private readonly Dictionary<Expr.ArrowFunction, Stmt.Function> _arrowEnclosingFunction = new(ReferenceEqualityComparer.Instance);
+    // Follow-up to #838: the nearest enclosing ASYNC ARROW of each collected arrow. An async arrow plays
+    // the role of a "function" scope for a nested sync arrow that captures-and-writes one of its locals:
+    // PropagateFunctionDCRequirements resolves the sync arrow's DC source to the async arrow's display
+    // class. Separate from _arrowEnclosingFunction because the enclosing scope is an Expr.ArrowFunction.
+    private readonly Dictionary<Expr.ArrowFunction, Expr.ArrowFunction> _arrowEnclosingAsyncArrow = new(ReferenceEqualityComparer.Instance);
     private Stmt.Function? _currentEnclosingFunctionStmt;
+    private Expr.ArrowFunction? _currentEnclosingAsyncArrow;
     private Expr.ArrowFunction? _currentParentArrow;
     private string? _currentCollectClassName;
     // The IMMEDIATELY enclosing callable (Expr.ArrowFunction or Stmt.Function) during
@@ -109,6 +115,11 @@ public partial class ILCompiler
         // here — after every module has been walked (all class-expr names assigned) and before the
         // PropagateFunctionDCRequirements pass below, which needs the function DC fields already present.
         RegisterClassExpressionGeneratorMethodFunctionDisplayClasses();
+
+        // Follow-up to #838: register a function display class for each async arrow whose own local is
+        // captured-and-written by a nested SYNC arrow, before PropagateFunctionDCRequirements (which
+        // resolves those sync arrows to the async arrow's DC).
+        RegisterAsyncArrowFunctionDisplayClasses();
 
         // Propagate function DC requirements through arrow nesting
         // If an inner arrow needs $functionDC, parent arrows also need it
@@ -463,6 +474,11 @@ public partial class ILCompiler
                     var previousEnclosing = _currentEnclosingFunctionName;
                     var previousEnclosingStmt = _currentEnclosingFunctionStmt;
                     var previousCallable = _currentEnclosingCallable;
+                    // A nested function declaration is a lambda-lift boundary: an arrow inside it captures
+                    // from the function, not the enclosing async arrow. Clear the async-arrow cursor so a
+                    // deeper arrow is not mis-attributed to the async arrow's function DC (#838 follow-up).
+                    var previousEnclosingAsyncArrowFn = _currentEnclosingAsyncArrow;
+                    _currentEnclosingAsyncArrow = null;
                     if (_functionNestingDepth == 0)
                     {
                         // Top-level function: use its qualified name as enclosing context
@@ -479,6 +495,7 @@ public partial class ILCompiler
                     _currentEnclosingFunctionName = previousEnclosing;
                     _currentEnclosingFunctionStmt = previousEnclosingStmt;
                     _currentEnclosingCallable = previousCallable;
+                    _currentEnclosingAsyncArrow = previousEnclosingAsyncArrowFn;
                 }
                 foreach (var p in f.Parameters)
                     if (p.DefaultValue != null)
@@ -649,13 +666,24 @@ public partial class ILCompiler
                     _arrowEnclosingFunction[af] = _currentEnclosingFunctionStmt;
                 }
 
+                // Follow-up to #838: record the nearest enclosing async arrow so a nested sync arrow can
+                // resolve a write-capture to that async arrow's function DC. Recorded for descendants of
+                // an async arrow (the async arrow itself maps to its own outer async arrow, if any).
+                if (_currentEnclosingAsyncArrow != null)
+                {
+                    _arrowEnclosingAsyncArrow[af] = _currentEnclosingAsyncArrow;
+                }
+
                 // Track parent arrow for function DC propagation
                 _arrowParent[af] = _currentParentArrow;
                 _arrowEnclosingCallable[af] = _currentEnclosingCallable;
                 var previousParent = _currentParentArrow;
                 var previousCallable = _currentEnclosingCallable;
+                var previousEnclosingAsyncArrow = _currentEnclosingAsyncArrow;
                 _currentParentArrow = af;
                 _currentEnclosingCallable = af;
+                if (af.IsAsync)
+                    _currentEnclosingAsyncArrow = af;
 
                 // Entering an arrow body is the same as entering a function body for the
                 // purpose of "inner function declaration" classification: `function X() {}`
@@ -676,6 +704,7 @@ public partial class ILCompiler
 
                 _currentParentArrow = previousParent;
                 _currentEnclosingCallable = previousCallable;
+                _currentEnclosingAsyncArrow = previousEnclosingAsyncArrow;
                 break;
             case Expr.Binary b:
                 CollectArrowsFromExpr(b.Left);
@@ -864,7 +893,77 @@ public partial class ILCompiler
     {
         foreach (var classExpr in _classExprs.ToDefine)
             if (_classExprs.Names.TryGetValue(classExpr, out var name))
+            {
                 RegisterGeneratorMethodFunctionDisplayClasses(classExpr.Methods, name);
+                RegisterAsyncMethodFunctionDisplayClasses(classExpr.Methods, name);
+            }
+    }
+
+    private int _asyncArrowDCCounter;
+
+    /// <summary>
+    /// Follow-up to #838: registers a function display class for each async arrow whose OWN local is
+    /// captured-and-written by a nested SYNC arrow, so that write shares verifiable reference storage on
+    /// the async arrow's state machine (the async-arrow analogue of free async functions / async methods).
+    /// Runs in Phase 5 before <see cref="PropagateFunctionDCRequirements"/>, which resolves the nested sync
+    /// arrow's DC source to this DC via <see cref="ClosureCompilationState.AsyncArrowDCKeys"/>. No-op for
+    /// async arrows with no such write-capture (the common case).
+    /// </summary>
+    private void RegisterAsyncArrowFunctionDisplayClasses()
+    {
+        foreach (var (arrow, _) in _collectedArrows)
+        {
+            if (!arrow.IsAsync) continue;
+
+            var members = ComputeAsyncArrowSyncWriteCaptures(arrow);
+            if (members.Count == 0) continue;
+
+            string key = $"$asyncArrow${_asyncArrowDCCounter++}";
+
+            // #838 (additive): expands `members` with renamed storage keys for write-captured shadows AND
+            // records ArrowFunctionDCFieldRenames[nestedSyncArrow] so the sync arrow's body resolves the
+            // renamed field generically (main's CurrentArrowFunctionDCFieldRenames path).
+            ApplyWriteCaptureRenames(members, GeneratorBlockScopeRenamer.Compute(arrow));
+
+            RegisterFunctionDisplayClass(key, members);
+            if (_closures.FunctionDisplayClasses.ContainsKey(key))
+                _closures.AsyncArrowDCKeys[arrow] = key;
+        }
+    }
+
+    /// <summary>
+    /// The async arrow's OWN locals (captured by an inner closure) that a nested SYNC arrow WRITES — the
+    /// member set of the async arrow's function display class. Mirrors the generator path: per nested sync
+    /// arrow, the names it assigns AND captures; intersected with the async arrow's captured locals so only
+    /// its own bindings are lifted (transitive captures stay on their existing path). Parameters and
+    /// per-iteration loop bindings (#649) are excluded.
+    /// </summary>
+    private HashSet<string> ComputeAsyncArrowSyncWriteCaptures(Expr.ArrowFunction asyncArrow)
+    {
+        var capturedLocals = _closures.Analyzer.GetCapturedLocals(asyncArrow);
+        if (capturedLocals.Count == 0) return [];
+
+        var writes = new HashSet<string>();
+        foreach (var (arrow, _) in _collectedArrows)
+        {
+            if (arrow.IsAsync) continue;   // only SYNC arrows share through the async arrow's function DC
+            if (!_arrowEnclosingAsyncArrow.TryGetValue(arrow, out var encl) || !ReferenceEquals(encl, asyncArrow))
+                continue;
+            var w = CapturedWriteAnalysis.CollectImmediateWrites(arrow);
+            w.IntersectWith(_closures.Analyzer.GetCaptures(arrow));
+            writes.UnionWith(w);
+        }
+        if (writes.Count == 0) return [];
+
+        var result = new HashSet<string>(capturedLocals);
+        result.IntersectWith(writes);
+        // Parameters stay on their hoisted fields (the stub seeds only the DC's locals); a
+        // captured-written async-arrow PARAMETER stays on the existing path (rare; out of scope here).
+        foreach (var p in asyncArrow.Parameters)
+            result.Remove(p.Name.Lexeme);
+        var perIteration = _closures.Analyzer.GetPerIterationLoopBindings(asyncArrow);
+        if (perIteration.Count > 0) result.ExceptWith(perIteration);
+        return result;
     }
 
     /// <summary>
@@ -911,17 +1010,28 @@ public partial class ILCompiler
 
         foreach (var (arrow, captures) in _collectedArrows)
         {
-            if (!_arrowEnclosingFunction.TryGetValue(arrow, out var enclosingStmt))
-                continue;
-            var enclosingFuncName = ResolveQualifiedName(enclosingStmt);
-            if (enclosingFuncName == null)
-                continue;
-            if (!_closures.FunctionDisplayClassFields.TryGetValue(enclosingFuncName, out var funcDCFields))
-                continue;
-            if (captures.Any(c => funcDCFields.ContainsKey(c)))
+            // (1) Enclosing Stmt.Function's display class (free functions / methods). Membership is by
+            // plain ContainsKey: #838 renames are ADDITIVE (ApplyWriteCaptureRenames keeps the source
+            // name AND adds the renamed storage key), so a write-captured shadow's source name is present.
+            if (_arrowEnclosingFunction.TryGetValue(arrow, out var enclosingStmt) &&
+                ResolveQualifiedName(enclosingStmt) is string enclosingFuncName &&
+                _closures.FunctionDisplayClassFields.TryGetValue(enclosingFuncName, out var funcDCFields) &&
+                captures.Any(funcDCFields.ContainsKey))
             {
                 _arrowsNeedingFunctionDC.Add(arrow);
                 _closures.ArrowFunctionDCSource[arrow] = enclosingFuncName;
+                continue;
+            }
+
+            // (2) Follow-up to #838: enclosing ASYNC ARROW's display class — a sync arrow that
+            // captures-and-writes one of the async arrow's own locals routes through that DC.
+            if (_arrowEnclosingAsyncArrow.TryGetValue(arrow, out var enclAsyncArrow) &&
+                _closures.AsyncArrowDCKeys.TryGetValue(enclAsyncArrow, out var asyncKey) &&
+                _closures.FunctionDisplayClassFields.TryGetValue(asyncKey, out var asyncDCFields) &&
+                captures.Any(asyncDCFields.ContainsKey))
+            {
+                _arrowsNeedingFunctionDC.Add(arrow);
+                _closures.ArrowFunctionDCSource[arrow] = asyncKey;
             }
         }
 
@@ -934,6 +1044,14 @@ public partial class ILCompiler
             {
                 if (_arrowParent.TryGetValue(arrow, out var parent) && parent != null)
                 {
+                    // Follow-up to #838: stop at the async arrow that OWNS the DC the child sources from —
+                    // it reaches its own DC via `this.<>__functionDC`, not a threaded $functionDC field, so
+                    // it must not be marked as needing one passed in.
+                    if (_closures.AsyncArrowDCKeys.TryGetValue(parent, out var parentOwnKey) &&
+                        _closures.ArrowFunctionDCSource.TryGetValue(arrow, out var childSrc) &&
+                        parentOwnKey == childSrc)
+                        continue;
+
                     if (!_arrowsNeedingFunctionDC.Contains(parent))
                     {
                         _arrowsNeedingFunctionDC.Add(parent);

--- a/Compilation/ILCompiler.Async.cs
+++ b/Compilation/ILCompiler.Async.cs
@@ -45,8 +45,33 @@ public partial class ILCompiler
 
         // Create function-level display class for captured locals (same as sync functions).
         // This enables closure mutation sharing between the async state machine and sync inner arrows.
-        // Variables also captured by async arrows are excluded since they use the hoisted field mechanism.
-        _closures.FunctionAstNodes[qualifiedFunctionName] = funcStmt;
+        RegisterAsyncFunctionDisplayClass(funcStmt, qualifiedFunctionName, analysis);
+
+        // If a function DC was created, add a field on the state machine to hold it
+        if (_closures.FunctionDisplayClasses.TryGetValue(qualifiedFunctionName, out var funcDC))
+        {
+            smBuilder.DefineFunctionDisplayClassField(funcDC);
+        }
+
+        // Build state machines for any async arrows found in this function
+        DefineAsyncArrowStateMachines(analysis.AsyncArrows, smBuilder);
+    }
+
+    /// <summary>
+    /// Registers the function-level display class ($functionDC) for an async free function OR async
+    /// method, keyed by <paramref name="key"/>. Lifts the captured locals a nested SYNC arrow shares —
+    /// minus the ones an async arrow captures (those use the boxed-outer hoisted-field path), keeping the
+    /// direct-child async-arrow WRITES that #625 promotes for verifiable mutation. Excludes read-only
+    /// renamed shadows from the name-keyed DC (#837) and makes the DC rename-aware for write-captured
+    /// shadows (#838) via <c>DefineFunctionDisplayClass</c> → <c>ApplyWriteCaptureRenames</c>. Records the
+    /// AST node so the arrow-collection (<see cref="PropagateFunctionDCRequirements"/>) can resolve a
+    /// nested sync arrow's enclosing scope back to this DC. Does NOT attach the state-machine field — the
+    /// caller does that once its <c>smBuilder</c> exists (free functions inline; methods in phase 7).
+    /// </summary>
+    private void RegisterAsyncFunctionDisplayClass(
+        Stmt.Function funcStmt, string key, AsyncStateAnalyzer.AsyncFunctionAnalysis analysis)
+    {
+        _closures.FunctionAstNodes[key] = funcStmt;
 
         // Collect variables captured by async arrows. By default these can't use the function DC —
         // they're read through the boxed outer state machine in the arrow's MoveNext.
@@ -69,7 +94,7 @@ public partial class ILCompiler
 
         // Filter out (still-)async-captured vars before creating the DC
         if (asyncCapturedVars.Count > 0)
-            _closures.AsyncCapturedVarsExclusion[qualifiedFunctionName] = asyncCapturedVars;
+            _closures.AsyncCapturedVarsExclusion[key] = asyncCapturedVars;
 
         // #837: a nested-block let/const that shadows an enclosing binding and is merely READ by an
         // inner arrow is now renamed (#767), recording a capture-source pivot. Keep its SOURCE name out
@@ -86,27 +111,58 @@ public partial class ILCompiler
         readOnlyRenamedShadows.ExceptWith(promotedToFunctionDC);
         if (readOnlyRenamedShadows.Count > 0)
         {
-            if (_closures.AsyncCapturedVarsExclusion.TryGetValue(qualifiedFunctionName, out var existing))
+            if (_closures.AsyncCapturedVarsExclusion.TryGetValue(key, out var existing))
                 existing.UnionWith(readOnlyRenamedShadows);
             else
-                _closures.AsyncCapturedVarsExclusion[qualifiedFunctionName] = readOnlyRenamedShadows;
+                _closures.AsyncCapturedVarsExclusion[key] = readOnlyRenamedShadows;
         }
 
-        // #838: an async function body is retokenized by the block-scope renamer, so make its function DC
+        // #838: an async body is retokenized by the block-scope renamer, so make its function DC
         // rename-aware — a write-captured nested-block shadow gets its own renamed field instead of
         // colliding with the outer same-named binding on a single name-keyed cell (matching the existing
         // generator path). Recomputed here (deterministic, same flag the AsyncStateAnalyzer used).
         var blockScopeRenames = GeneratorBlockScopeRenamer.Compute(funcStmt, arrowReadCapturesShareStorage: false);
-        DefineFunctionDisplayClass(funcStmt, qualifiedFunctionName, blockScopeRenames);
+        DefineFunctionDisplayClass(funcStmt, key, blockScopeRenames);
+    }
 
-        // If a function DC was created, add a field on the state machine to hold it
-        if (_closures.FunctionDisplayClasses.TryGetValue(qualifiedFunctionName, out var funcDC))
+    // Maps an async METHOD's AST node to the function-display-class key registered for it in Phase 4
+    // (RegisterAsyncMethodFunctionDisplayClasses). The phase-7 emit (SetupAsyncMethodFunctionDC) reads
+    // this to attach/wire the state machine's function DC without reconstructing a key string. Keyed by
+    // AST identity so phase-4 registration and phase-7 emission agree. Mirrors the generator-method map.
+    private readonly Dictionary<Stmt.Function, string> _asyncMethodFunctionDCKeys =
+        new(ReferenceEqualityComparer.Instance);
+
+    /// <summary>
+    /// Phase-4 registration (called from <see cref="DefineClass"/> / the class-expression analog) of the
+    /// function display class for each async (non-generator) method whose nested SYNC arrow shares a
+    /// captured method local — the async-method analogue of
+    /// <c>RegisterGeneratorMethodFunctionDisplayClasses</c>. Must run before phase-5
+    /// <see cref="PropagateFunctionDCRequirements"/> so a nested sync arrow can resolve its enclosing
+    /// method back to this DC (via <c>FunctionAstNodes</c>) and route its write through <c>$functionDC</c>
+    /// instead of a by-value snapshot. <see cref="SetupAsyncMethodFunctionDC"/> later reads the recorded
+    /// key to attach/wire the state machine's DC. No-op for methods with no such capture.
+    /// </summary>
+    private void RegisterAsyncMethodFunctionDisplayClasses(IReadOnlyList<Stmt.Function> methods, string qualifiedClassName)
+    {
+        foreach (var method in methods)
         {
-            smBuilder.DefineFunctionDisplayClassField(funcDC);
-        }
+            if (method.Body == null || method.IsGenerator || !method.IsAsync)
+                continue;
 
-        // Build state machines for any async arrows found in this function
-        DefineAsyncArrowStateMachines(analysis.AsyncArrows, smBuilder);
+            // Match the key shape SetupAsyncMethodFunctionDC used (instance "::", static "::static::"),
+            // qualified by class name so modules/overloads don't collide. The key is stored and later
+            // retrieved by AST identity, so it is never reconstructed from the emitted type name.
+            string infix = method.IsStatic ? "::static::" : "::";
+            string key = $"{qualifiedClassName}{infix}{method.Name.Lexeme}";
+
+            var analysis = _async.Analyzer.Analyze(method);
+            RegisterAsyncFunctionDisplayClass(method, key, analysis);
+
+            // Only track the key when a DC was actually created (captured locals to share); otherwise the
+            // method stays fully standalone and phase-7 leaves it alone (methodDCKey null).
+            if (_closures.FunctionDisplayClasses.ContainsKey(key))
+                _asyncMethodFunctionDCKeys[method] = key;
+        }
     }
 
     /// <summary>
@@ -148,33 +204,54 @@ public partial class ILCompiler
     /// from free-function registry keys (which never contain "::"). Returns <paramref name="dcKey"/> so
     /// the caller can thread it to <see cref="EmitAsyncStubMethod"/> and <see cref="WireAsyncMethodFunctionDC"/>.
     /// </summary>
-    private string SetupAsyncMethodFunctionDC(AsyncStateMachineBuilder smBuilder, string dcKey,
-        AsyncStateAnalyzer.AsyncFunctionAnalysis analysis)
+    private string? SetupAsyncMethodFunctionDC(AsyncStateMachineBuilder smBuilder, Stmt.Function method)
     {
-        var promoted = ComputeArrowWrittenCapturesToPromote(analysis.AsyncArrows);
-        if (promoted.Count > 0)
-        {
-            RegisterFunctionDisplayClass(dcKey, promoted);
-            if (_closures.FunctionDisplayClasses.TryGetValue(dcKey, out var dc))
-                smBuilder.DefineFunctionDisplayClassField(dc);
-        }
+        // The method's whole function DC (sync-arrow shares + #625 promoted async-arrow writes + #838
+        // renamed shadows) is built in Phase 4 (RegisterAsyncMethodFunctionDisplayClasses); here we only
+        // ATTACH the already-registered DC's field to the state machine. Null when the method shares no
+        // captured local (fully standalone), leaving its state machine unchanged.
+        if (!_asyncMethodFunctionDCKeys.TryGetValue(method, out var dcKey))
+            return null;
+        if (_closures.FunctionDisplayClasses.TryGetValue(dcKey, out var dc))
+            smBuilder.DefineFunctionDisplayClassField(dc);
         return dcKey;
     }
 
     /// <summary>
     /// #682: wires <paramref name="ctx"/> so the async method body (AsyncMoveNextEmitter) reads/writes
-    /// the promoted captures via <c>this.functionDC.field</c> and a nested async arrow
+    /// the DC captures via <c>this.functionDC.field</c> and a nested async arrow
     /// (AsyncArrowMoveNextEmitter, sharing this ctx) reaches them via <c>outer.functionDC.field</c>.
-    /// No-op when nothing was promoted (no DC field on the state machine).
+    /// No-op when the method has no function DC (null key / no DC field on the state machine).
     /// </summary>
-    private void WireAsyncMethodFunctionDC(CompilationContext ctx, AsyncStateMachineBuilder smBuilder, string dcKey)
+    private void WireAsyncMethodFunctionDC(CompilationContext ctx, AsyncStateMachineBuilder smBuilder, string? dcKey)
     {
-        if (smBuilder.FunctionDCField != null &&
+        if (dcKey != null && smBuilder.FunctionDCField != null &&
             _closures.FunctionDisplayClassFields.TryGetValue(dcKey, out var dcFields))
         {
             ctx.FunctionDisplayClassFields = dcFields;
             ctx.CapturedFunctionLocals = new HashSet<string>(dcFields.Keys);
             ctx.OuterFunctionDCField = smBuilder.FunctionDCField;
+            // Let the MoveNext populate a nested sync arrow's $functionDC from this method's DC
+            // (AsyncMoveNextEmitter.EmitArrowFunction), so the sync arrow shares the DC reference.
+            ctx.ArrowFunctionDCFields = _closures.ArrowFunctionDCFields.Count > 0 ? _closures.ArrowFunctionDCFields : null;
+        }
+    }
+
+    /// <summary>
+    /// Follow-up to #838: attaches the function display class registered for <paramref name="arrow"/> (an
+    /// async arrow with a nested sync-arrow write-capture) to its state-machine builder, so a nested sync
+    /// arrow shares the reference (the MoveNext prologue instantiates it). No-op when no DC was registered.
+    /// Called in Phase 6 (before EmitAsyncArrowMoveNext) — not Phase 4 — because the async-arrow DC is
+    /// registered in Phase 5 (RegisterAsyncArrowFunctionDisplayClasses), after the arrow's stub is built.
+    /// </summary>
+    private void AttachAsyncArrowFunctionDC(AsyncArrowStateMachineBuilder builder, Expr.ArrowFunction arrow)
+    {
+        if (_closures.AsyncArrowDCKeys.TryGetValue(arrow, out var key) &&
+            _closures.FunctionDisplayClasses.TryGetValue(key, out var dc) &&
+            _closures.FunctionDisplayClassCtors.TryGetValue(key, out var ctor) &&
+            _closures.FunctionDisplayClassFields.TryGetValue(key, out var dcFields))
+        {
+            builder.DefineFunctionDisplayClassField(dc, ctor, dcFields);
         }
     }
 
@@ -708,6 +785,9 @@ public partial class ILCompiler
             {
                 if (_async.ArrowBuilders.TryGetValue(arrowInfo.Arrow, out var arrowBuilder))
                 {
+                    // Follow-up to #838: attach this nested arrow's function DC (registered in Phase 5)
+                    // before its MoveNext is emitted (the prologue instantiates it) and before CreateType.
+                    AttachAsyncArrowFunctionDC(arrowBuilder, arrowInfo.Arrow);
                     EmitAsyncArrowMoveNext(arrowBuilder, arrowInfo.Arrow, ctx);
                 }
             }
@@ -797,6 +877,9 @@ public partial class ILCompiler
             // actually placed in its DC are listed here, so a name present means "route via DC".
             FunctionDisplayClassFields = parentCtx.FunctionDisplayClassFields,
             OuterFunctionDCField = parentCtx.OuterFunctionDCField,
+            // Follow-up to #838: lets this nested async arrow's MoveNext populate a nested sync arrow's
+            // $functionDC from this arrow's OWN DC (EmitCapturingArrowInAsyncArrow).
+            ArrowFunctionDCFields = _closures.ArrowFunctionDCFields.Count > 0 ? _closures.ArrowFunctionDCFields : null,
         };
 
         // Create arrow-specific emitter
@@ -999,13 +1082,11 @@ public partial class ILCompiler
             hasLock: hasLock
         );
 
-        // #682: a direct-child async arrow that WRITES a captured method-local must mutate it through
-        // a reference-type function display class, not the boxed value-type state machine (unverifiable
-        // unbox → readonly pointer). Async methods have no function-DC by default; wire one. The
-        // "::static::" infix keeps a static method's key distinct from an instance member of the same name.
-        string dcInfix = isInstanceMethod ? "::" : "::static::";
-        string methodDCKey = SetupAsyncMethodFunctionDC(
-            smBuilder, $"{methodBuilder.DeclaringType!.Name}{dcInfix}{methodBuilder.Name}", analysis);
+        // #682/#follow-up: attach the method's function display class (registered in Phase 4) to the
+        // state machine so a direct-child async arrow's write AND a nested sync arrow's write/read share
+        // verifiable reference storage instead of the boxed value-type state machine. Null when nothing
+        // is shared.
+        string? methodDCKey = SetupAsyncMethodFunctionDC(smBuilder, method);
 
         // Build state machines for any async arrows found in this method
         DefineAsyncArrowStateMachines(analysis.AsyncArrows, smBuilder);
@@ -1124,6 +1205,8 @@ public partial class ILCompiler
         {
             if (_async.ArrowBuilders.TryGetValue(arrowInfo.Arrow, out var arrowBuilder))
             {
+                // Follow-up to #838: attach this nested arrow's function DC before MoveNext + CreateType.
+                AttachAsyncArrowFunctionDC(arrowBuilder, arrowInfo.Arrow);
                 EmitAsyncArrowMoveNext(arrowBuilder, arrowInfo.Arrow, ctx);
             }
         }
@@ -1228,6 +1311,10 @@ public partial class ILCompiler
                 continue;
             }
 
+            // Follow-up to #838: attach this standalone arrow's function DC (registered in Phase 5)
+            // before its MoveNext is emitted (the prologue instantiates it) and before CreateType.
+            AttachAsyncArrowFunctionDC(arrowBuilder, arrow);
+
             if (_arrowToModule.TryGetValue(arrow, out var arrowModule))
             {
                 _modules.CurrentPath = NormalizeToEmissionPath(arrowModule);
@@ -1310,7 +1397,10 @@ public partial class ILCompiler
                 EntryPointDisplayClassFields = BuildEntryPointDisplayClassFieldsForModule(_modules.CurrentPath),
                 CapturedTopLevelVars = BuildCapturedTopLevelVarsForModule(_modules.CurrentPath),
                 ArrowEntryPointDCFields = _closures.ArrowEntryPointDCFields.Count > 0 ? _closures.ArrowEntryPointDCFields : null,
-                EntryPointDisplayClassStaticField = _closures.EntryPointDisplayClassStaticField
+                EntryPointDisplayClassStaticField = _closures.EntryPointDisplayClassStaticField,
+                // Follow-up to #838: lets this standalone async arrow's MoveNext populate a nested sync
+                // arrow's $functionDC from this arrow's OWN DC (EmitCapturingArrowInAsyncArrow).
+                ArrowFunctionDCFields = _closures.ArrowFunctionDCFields.Count > 0 ? _closures.ArrowFunctionDCFields : null
             };
 
             // Create arrow-specific emitter

--- a/Compilation/ILCompiler.Classes.Static.cs
+++ b/Compilation/ILCompiler.Classes.Static.cs
@@ -586,11 +586,10 @@ public partial class ILCompiler
             hasLock: hasLock
         );
 
-        // #682: wire a function display class for captures a direct-child async arrow writes (same as
-        // instance methods). The "::static::" infix keeps the key distinct from an instance method of
-        // the same class+name (statics and instance members share a name space in TS).
-        string methodDCKey = SetupAsyncMethodFunctionDC(
-            smBuilder, $"{className}::static::{method.Name.Lexeme}", analysis);
+        // #682/#follow-up: attach the static method's function display class (registered in Phase 4) to
+        // the state machine — shares verifiable reference storage for both async-arrow and nested
+        // sync-arrow captured writes. Null when nothing is shared.
+        string? methodDCKey = SetupAsyncMethodFunctionDC(smBuilder, method);
 
         // Build state machines for any async arrows found in this method
         DefineAsyncArrowStateMachines(analysis.AsyncArrows, smBuilder);

--- a/Compilation/ILCompiler.Classes.cs
+++ b/Compilation/ILCompiler.Classes.cs
@@ -75,6 +75,10 @@ public partial class ILCompiler
         // external (@DotNetType) classes, which return above without an emitted body.
         RegisterGeneratorMethodFunctionDisplayClasses(classStmt, qualifiedClassName);
 
+        // Same, for async (non-generator) methods whose nested sync arrow writes a captured method local,
+        // before Phase 5's PropagateFunctionDCRequirements runs.
+        RegisterAsyncMethodFunctionDisplayClasses(classStmt.Methods, qualifiedClassName);
+
         // Set TypeAttributes.Abstract if the class is abstract
         TypeAttributes typeAttrs = TypeAttributes.Public | TypeAttributes.Class;
         if (classStmt.IsAbstract)

--- a/Compilation/ILCompiler.State.cs
+++ b/Compilation/ILCompiler.State.cs
@@ -199,6 +199,13 @@ public partial class ILCompiler
         // Maps arrow functions to the function display class they need access to
         public Dictionary<Expr.ArrowFunction, string> ArrowFunctionDCSource { get; } = new(ReferenceEqualityComparer.Instance);
 
+        // Follow-up to #838: maps an ASYNC ARROW to the synthetic function-display-class key registered
+        // for it — its own locals that a nested sync arrow captures-and-writes are lifted into a
+        // reference-type DC on the async arrow's state machine, letting the async arrow play the role of a
+        // "function" scope for nested sync arrows. Key shape "$asyncArrow$N" is disjoint from real
+        // function keys. Registered in RegisterAsyncArrowFunctionDisplayClasses (Phase 5, pre-propagate).
+        public Dictionary<Expr.ArrowFunction, string> AsyncArrowDCKeys { get; } = new(ReferenceEqualityComparer.Instance);
+
         // ============================================
         // Scope display classes (for callable-local vars captured by nested closures).
         // Keys are the OWNING callable's AST node: Expr.ArrowFunction, or Stmt.Function

--- a/SharpTS.Tests/SharedTests/AsyncArrowSyncWriteCaptureTests.cs
+++ b/SharpTS.Tests/SharedTests/AsyncArrowSyncWriteCaptureTests.cs
@@ -1,0 +1,143 @@
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests;
+
+/// <summary>
+/// A SYNC arrow nested in an ASYNC ARROW that WRITES a variable captured from the async arrow's scope
+/// must share storage with the arrow body (live capture), not snapshot it by value. Compiled mode used
+/// to drop the write: async arrows never built a function display class, so a nested sync arrow's write
+/// went to a by-value snapshot field (interpreted 6,6 vs compiled 6,5). The fix gives the async arrow its
+/// own reference-type function DC on its state machine (instantiated once in the MoveNext prologue) that
+/// the nested sync arrow shares via <c>$functionDC</c>. The interpreter has always been correct.
+/// </summary>
+public class AsyncArrowSyncWriteCaptureTests
+{
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void StandaloneAsyncArrow_SyncArrowWritesCapturedLocal(ExecutionMode mode)
+    {
+        var source = """
+            const af = async (): Promise<string> => {
+              let r = 5;
+              const f = () => { r = r + 1; return r; };
+              await Promise.resolve(0);
+              return f() + "," + r;
+            };
+            async function main() { console.log(await af()); }
+            main();
+            """;
+
+        Assert.Equal("6,6\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void NestedAsyncArrow_SyncArrowWritesCapturedLocal(ExecutionMode mode)
+    {
+        // The async arrow is itself nested inside an async function — it still needs its OWN function DC
+        // for its OWN local; the enclosing function's DC / outer relay is a separate concern.
+        var source = """
+            async function outer(): Promise<string> {
+              const af = async (): Promise<string> => {
+                let r = 5;
+                const f = () => { r = r + 1; return r; };
+                await Promise.resolve(0);
+                return f() + "," + r;
+              };
+              return await af();
+            }
+            async function main() { console.log(await outer()); }
+            main();
+            """;
+
+        Assert.Equal("6,6\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void StandaloneAsyncArrow_CompoundAssignCapturedLocal(ExecutionMode mode)
+    {
+        var source = """
+            const af = async (): Promise<string> => {
+              let r = 5;
+              const f = () => { r += 1; r++; return r; };
+              await Promise.resolve(0);
+              return f() + "," + r;
+            };
+            async function main() { console.log(await af()); }
+            main();
+            """;
+
+        Assert.Equal("7,7\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void StandaloneAsyncArrow_WriteCapturedBlockScopeShadow_DoesNotLeak(ExecutionMode mode)
+    {
+        // Combines this fix with #838: the written capture is a nested-block shadow of an outer binding;
+        // the inner shadow's DC field must not collide with the outer same-named binding.
+        var source = """
+            const af = async (): Promise<string> => {
+              const out: string[] = [];
+              const r = 100;
+              {
+                let r = 5;
+                const f = () => { r = r + 1; return r; };
+                await Promise.resolve(0);
+                out.push(String(f()));
+                out.push(String(r));
+              }
+              out.push(String(r));
+              return out.join(",");
+            };
+            async function main() { console.log(await af()); }
+            main();
+            """;
+
+        Assert.Equal("6,6,100\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void StandaloneAsyncArrow_TwoArrowsWriteDistinctCapturedLocals(ExecutionMode mode)
+    {
+        var source = """
+            const af = async (): Promise<string> => {
+              let a = 1;
+              let b = 10;
+              const f = () => { a = a + 1; return a; };
+              const g = () => { b = b + 1; return b; };
+              await Promise.resolve(0);
+              return f() + "," + g() + "," + a + "," + b;
+            };
+            async function main() { console.log(await af()); }
+            main();
+            """;
+
+        Assert.Equal("2,11,2,11\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void StandaloneAsyncArrow_CapturedWriteSurvivesAcrossAwait(ExecutionMode mode)
+    {
+        // The mutation straddles an await — the DC lives on the (reference-held) state machine field, so
+        // it persists across the suspension like a hoisted local.
+        var source = """
+            const af = async (): Promise<number> => {
+              let n = 0;
+              const inc = () => { n = n + 1; };
+              inc();
+              await Promise.resolve(0);
+              inc();
+              return n;
+            };
+            async function main() { console.log(await af()); }
+            main();
+            """;
+
+        Assert.Equal("2\n", TestHarness.Run(source, mode));
+    }
+}

--- a/SharpTS.Tests/SharedTests/AsyncMethodNestedCaptureTests.cs
+++ b/SharpTS.Tests/SharedTests/AsyncMethodNestedCaptureTests.cs
@@ -1,0 +1,151 @@
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests;
+
+/// <summary>
+/// A SYNC arrow nested in an ASYNC METHOD that WRITES a variable captured from the method scope must
+/// share storage with the method body (live capture), not snapshot it by value. Compiled mode used to
+/// drop the write: async methods only lifted direct-child ASYNC-arrow writes into the function display
+/// class (#682) and never registered the method in <c>FunctionAstNodes</c>, so a nested sync arrow could
+/// not resolve the method's DC and fell back to a by-value snapshot field (interpreted 6,6 vs compiled
+/// 6,5). The fix registers the method's function DC in Phase 4 (mirroring generator methods / free async
+/// functions) lifting the shared captured locals. The interpreter has always been correct.
+/// </summary>
+public class AsyncMethodNestedCaptureTests
+{
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AsyncInstanceMethod_SyncArrowWritesCapturedLocal(ExecutionMode mode)
+    {
+        var source = """
+            class C {
+              async m(): Promise<string> {
+                let r = 5;
+                const f = () => { r = r + 1; return r; };
+                await Promise.resolve(0);
+                return f() + "," + r;
+              }
+            }
+            async function main() { console.log(await new C().m()); }
+            main();
+            """;
+
+        Assert.Equal("6,6\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AsyncStaticMethod_SyncArrowWritesCapturedLocal(ExecutionMode mode)
+    {
+        var source = """
+            class C {
+              static async m(): Promise<string> {
+                let r = 5;
+                const f = () => { r = r + 1; return r; };
+                await Promise.resolve(0);
+                return f() + "," + r;
+              }
+            }
+            async function main() { console.log(await C.m()); }
+            main();
+            """;
+
+        Assert.Equal("6,6\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AsyncMethod_SyncArrowCompoundAssignCapturedLocal(ExecutionMode mode)
+    {
+        // `+=` and `++` go through distinct emitter paths than plain `=` — both must route to the DC.
+        var source = """
+            class C {
+              async m(): Promise<string> {
+                let r = 5;
+                const f = () => { r += 1; r++; return r; };
+                await Promise.resolve(0);
+                return f() + "," + r;
+              }
+            }
+            async function main() { console.log(await new C().m()); }
+            main();
+            """;
+
+        Assert.Equal("7,7\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AsyncMethod_TwoArrowsWriteDistinctCapturedLocals(ExecutionMode mode)
+    {
+        // Two independent captured locals, each written by its own arrow, must not cross-contaminate.
+        var source = """
+            class C {
+              async m(): Promise<string> {
+                let a = 1;
+                let b = 10;
+                const f = () => { a = a + 1; return a; };
+                const g = () => { b = b + 1; return b; };
+                await Promise.resolve(0);
+                return f() + "," + g() + "," + a + "," + b;
+              }
+            }
+            async function main() { console.log(await new C().m()); }
+            main();
+            """;
+
+        Assert.Equal("2,11,2,11\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AsyncMethod_WriteCapturedBlockScopeShadow_DoesNotLeak(ExecutionMode mode)
+    {
+        // Combines this fix with #838: the written capture is a nested-block shadow of an outer binding;
+        // the inner shadow's DC field must not collide with the outer same-named binding.
+        var source = """
+            class C {
+              async m(): Promise<string> {
+                const out: string[] = [];
+                const r = 100;
+                {
+                  let r = 5;
+                  const f = () => { r = r + 1; return r; };
+                  await Promise.resolve(0);
+                  out.push(String(f()));
+                  out.push(String(r));
+                }
+                out.push(String(r));
+                return out.join(",");
+              }
+            }
+            async function main() { console.log(await new C().m()); }
+            main();
+            """;
+
+        Assert.Equal("6,6,100\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AsyncMethod_AsyncArrowWriteCaptureStillWorks(ExecutionMode mode)
+    {
+        // Regression guard for #682: a direct-child ASYNC arrow writing a captured method local still
+        // shares storage through the (now Phase-4-registered) function DC.
+        var source = """
+            class C {
+              async m(): Promise<number> {
+                let sum = 0;
+                const f = async () => { sum += 5; };
+                await f();
+                return sum;
+              }
+            }
+            async function main() { console.log(await new C().m()); }
+            main();
+            """;
+
+        Assert.Equal("5\n", TestHarness.Run(source, mode));
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up to **#838** (already merged to `main` via #849). Rebased onto main — this PR is now **follow-up-only** (one commit); the bundled #838 work was dropped in favour of main's merged implementation, and this builds on main's `ApplyWriteCaptureRenames` / `ArrowFunctionDCFieldRenames` machinery.

A **sync** arrow nested inside an **async method** or an **async arrow** that *writes* a variable captured from the enclosing scope silently dropped the write in compiled mode (snapshot by value): neither context built a reference-type function display class (`$functionDC`) the inner arrow could share.

```ts
class C { async m(){ let r=5; const f=()=>{r=r+1;return r;}; await Promise.resolve(0); return f()+","+r; } }
const af  = async () => { let r=5; const f=()=>{r=r+1;return r;}; await Promise.resolve(0); return f()+","+r; };
// interpreted: 6,6   was compiled: 6,5
```

Free async functions and generator methods already work via their function DC; this wires the two missing contexts the same way.

## Changes
- **Async methods (instance + static):** extract `RegisterAsyncFunctionDisplayClass` from `DefineAsyncFunction`; add Phase-4 `RegisterAsyncMethodFunctionDisplayClasses` (mirrors the generator-method path) registering the method DC + `FunctionAstNodes[key]=method` before arrow collection. `SetupAsyncMethodFunctionDC` looks up the pre-registered key and attaches the SM field; `WireAsyncMethodFunctionDC` threads `ArrowFunctionDCFields` so the MoveNext populates a nested sync arrow's `$functionDC`.
- **Async arrows (standalone + nested):** new `_arrowEnclosingAsyncArrow` scope map so a nested sync arrow resolves to the async arrow as its "function" scope; `RegisterAsyncArrowFunctionDisplayClasses` (Phase 5, pre-propagate) registers a `$asyncArrow$N` DC via `ApplyWriteCaptureRenames`; `AsyncArrowStateMachineBuilder` gains a `<>__functionDC` field instantiated once (null-guarded) in the MoveNext prologue; the body routes own-DC reads/writes through `this.<>__functionDC` and populates the nested sync arrow's `$functionDC`. `PropagateFunctionDCRequirements` gets an async-arrow branch + owner guard.

## Notes
- Pure IL-emit change; type-checker / Test262 (interpreter) untouched. The #682 async-arrow write relay is preserved.
- **Remaining residual:** an async-arrow captured-and-written **parameter** is still snapshot (params excluded from the async-arrow DC) — astronomically rare, tracked.

## Tests
- `AsyncMethodNestedCaptureTests` + `AsyncArrowSyncWriteCaptureTests` (instance/static methods, standalone/nested arrows, compound-assign, two-distinct-vars, cross-await, #838 shadow combos) — 24 cases.
- Full `dotnet test` green except the pre-existing stale/flaky Test262 baselines and known JIT-flaky compiled tests. `--verify` green on all four repros (interpreter == compiled).
