### PR TITLE
Perf #857: typed-string concat + non-escaping array-local List<T> slots

### DIFF
--- a/Compilation/ArrayLocalPromotionAnalyzer.cs
+++ b/Compilation/ArrayLocalPromotionAnalyzer.cs
@@ -1,0 +1,227 @@
+using SharpTS.Parsing;
+using SharpTS.Parsing.Visitors;
+using SharpTS.TypeSystem;
+
+namespace SharpTS.Compilation;
+
+/// <summary>
+/// Whole-program analysis that flags <c>number[]</c>/<c>boolean[]</c> local declarations which can be
+/// promoted from the default <c>object</c>/<c>$Array</c> slot to a concrete <c>List&lt;double&gt;</c>/
+/// <c>List&lt;bool&gt;</c> CLR slot with unboxed element access (#857 / #860). Results are written into the
+/// <see cref="TypeMap"/> via <see cref="TypeMap.MarkPromotableArrayLocal"/>; the IL emitter (EmitVar and
+/// the index/length/push fast paths) consults them.
+///
+/// <para>This is the deliberately-conservative first cut: a local is promoted only when it is provably
+/// non-escaping, so a bare <c>List&lt;T&gt;</c> (which is NOT a <c>$Array</c> and cannot represent holes,
+/// sparseness, or <c>$Array</c> identity) is never observed anywhere that needs those semantics. A
+/// candidate <c>x</c> qualifies iff ALL hold:</para>
+/// <list type="number">
+///   <item>declared <c>const</c>/<c>let</c> with an empty array-literal initializer (<c>[]</c>);</item>
+///   <item>every use resolves the array element type to <c>number</c> or <c>boolean</c>;</item>
+///   <item>the ONLY uses are <c>x[i]</c> read, <c>x[i] = v</c> write, <c>x.length</c>, and
+///         <c>x.push(...)</c> — any other appearance of the bare variable (argument pass, return, store,
+///         spread, <c>for…of</c>, <c>===</c>, reassignment, <c>delete x[i]</c>, <c>pop</c>/any other
+///         method or property) disqualifies it;</item>
+///   <item>the name is declared exactly once in the whole program (conservative guard against scope
+///         ambiguity / shadowing without full scope resolution);</item>
+///   <item>the name is not captured by any closure (a captured local is routed to an <c>object</c>
+///         display-class field, never a typed slot).</item>
+/// </list>
+///
+/// <para>The catch-all is <see cref="Visitor.VisitVariable"/>: any bare variable occurrence that was not
+/// consumed by a permitted-use override disqualifies the name. The permitted-use overrides deliberately do
+/// NOT recurse into the receiver variable, so only the safe shapes survive.</para>
+/// </summary>
+public static class ArrayLocalPromotionAnalyzer
+{
+    public static void Analyze(List<Stmt> program, TypeMap? typeMap, ClosureAnalyzer? closures)
+    {
+        if (typeMap == null) return;
+
+        var visitor = new Visitor(typeMap);
+        foreach (var stmt in program)
+            visitor.Visit(stmt);
+
+        foreach (var (name, nameToken) in visitor.Candidates)
+        {
+            if (visitor.Disqualified.Contains(name)) continue;
+            if (visitor.DeclCount.GetValueOrDefault(name) != 1) continue;
+            if (!visitor.ElementToken.TryGetValue(name, out var token)) continue; // no Double/Bool use seen
+            if (closures?.IsVariableCaptured(name) == true) continue;
+            typeMap.MarkPromotableArrayLocal(nameToken, token);
+        }
+    }
+
+    private sealed class Visitor(TypeMap typeMap) : AstVisitorBase
+    {
+        private readonly TypeMap _typeMap = typeMap;
+
+        /// <summary>name → candidate declaration's name token (empty-array-literal local).</summary>
+        public Dictionary<string, Token> Candidates { get; } = new();
+
+        /// <summary>How many times each name is declared anywhere (any kind of binding).</summary>
+        public Dictionary<string, int> DeclCount { get; } = new();
+
+        /// <summary>name → element primitive token (TYPE_NUMBER / TYPE_BOOLEAN), from its first typed use.</summary>
+        public Dictionary<string, TokenType> ElementToken { get; } = new();
+
+        /// <summary>Names with at least one disqualifying occurrence.</summary>
+        public HashSet<string> Disqualified { get; } = new();
+
+        protected override void VisitVar(Stmt.Var stmt) =>
+            HandleDeclaration(stmt.Name, stmt.Initializer);
+
+        protected override void VisitConst(Stmt.Const stmt) =>
+            HandleDeclaration(stmt.Name, stmt.Initializer);
+
+        private void HandleDeclaration(Token name, Expr? initializer)
+        {
+            var lexeme = name.Lexeme;
+            DeclCount[lexeme] = DeclCount.GetValueOrDefault(lexeme) + 1;
+
+            if (initializer is Expr.ArrayLiteral { Elements.Count: 0 } && !Candidates.ContainsKey(lexeme))
+                Candidates[lexeme] = name;
+
+            // Visit the initializer for completeness ([] has no sub-uses, but a
+            // non-candidate initializer may reference other arrays).
+            if (initializer != null)
+                Visit(initializer);
+        }
+
+        protected override void VisitGetIndex(Expr.GetIndex expr)
+        {
+            // `x[i]` read — permitted when receiver is a bare variable. Record the
+            // element kind and visit only the index (NOT the receiver variable).
+            if (expr.Object is Expr.Variable v && !expr.Optional)
+                NotePermittedReceiver(v);
+            else
+                Visit(expr.Object);
+            Visit(expr.Index);
+        }
+
+        protected override void VisitSetIndex(Expr.SetIndex expr)
+        {
+            // `x[i] = v` write — permitted receiver; visit index and value only.
+            if (expr.Object is Expr.Variable v)
+            {
+                NotePermittedReceiver(v);
+                // A written value whose static type admits the `undefined` sentinel
+                // (any/unknown/…) would be coerced to NaN/false by the typed setter,
+                // diverging from the general path that preserves it. Disqualify — the
+                // array analogue of the #367/#372 numeric-slot taint guard.
+                if (ValueAdmitsUndefinedSentinel(expr.Value))
+                    Disqualified.Add(v.Name.Lexeme);
+            }
+            else
+                Visit(expr.Object);
+            Visit(expr.Index);
+            Visit(expr.Value);
+        }
+
+        protected override void VisitGet(Expr.Get expr)
+        {
+            // `x.length` — permitted; skip the receiver variable. Any other
+            // property access on a bare variable falls through to VisitVariable
+            // (disqualifying), which is what we want.
+            if (expr.Name.Lexeme == "length" && expr.Object is Expr.Variable v && !expr.Optional)
+            {
+                NotePermittedReceiver(v);
+                return;
+            }
+            Visit(expr.Object);
+        }
+
+        protected override void VisitCall(Expr.Call expr)
+        {
+            // `x.push(args)` — permitted; visit the args but skip the receiver
+            // variable. Every other call shape recurses normally, so a receiver
+            // passed as an argument, or any non-push method, is caught. (pop is
+            // intentionally excluded from this first cut: its empty→undefined
+            // result can't sit in an unboxed typed slot.)
+            if (expr.Callee is Expr.Get { Object: Expr.Variable v, Optional: false } get
+                && get.Name.Lexeme == "push")
+            {
+                NotePermittedReceiver(v);
+                // Same undefined-sentinel guard as index writes: a pushed value that
+                // can be undefined would be coerced by the typed helper.
+                foreach (var arg in expr.Arguments)
+                {
+                    if (ValueAdmitsUndefinedSentinel(arg))
+                        Disqualified.Add(v.Name.Lexeme);
+                    Visit(arg);
+                }
+                return;
+            }
+            base.VisitCall(expr);
+        }
+
+        protected override void VisitAssign(Expr.Assign expr)
+        {
+            // `x = ...` rebinds the slot — disqualify. (Only the empty-literal
+            // initializer is supported; any later store could be a $Array or a
+            // value the typed slot can't hold.)
+            Disqualified.Add(expr.Name.Lexeme);
+            base.VisitAssign(expr);
+        }
+
+        protected override void VisitCompoundAssign(Expr.CompoundAssign expr)
+        {
+            Disqualified.Add(expr.Name.Lexeme);
+            base.VisitCompoundAssign(expr);
+        }
+
+        protected override void VisitDelete(Expr.Delete expr)
+        {
+            // `delete x[i]` creates a hole a List<T> cannot represent — disqualify
+            // the base variable of the deleted operand.
+            var target = expr.Operand;
+            while (true)
+            {
+                if (target is Expr.GetIndex gi) { target = gi.Object; continue; }
+                if (target is Expr.Get g) { target = g.Object; continue; }
+                break;
+            }
+            if (target is Expr.Variable v)
+                Disqualified.Add(v.Name.Lexeme);
+            base.VisitDelete(expr);
+        }
+
+        protected override void VisitVariable(Expr.Variable expr)
+        {
+            // Catch-all: any bare variable occurrence not consumed by a permitted-use
+            // override above is an escape (returned, passed, spread, compared, etc.).
+            Disqualified.Add(expr.Name.Lexeme);
+        }
+
+        private void NotePermittedReceiver(Expr.Variable v)
+        {
+            // Resolve the element kind from the receiver's static array type (as
+            // ArrayHoistAnalyzer does). Only Double/Bool arrays are promotable; an
+            // Object-kind array (string[]/union[]) disqualifies the name.
+            if (ElementToken.ContainsKey(v.Name.Lexeme)) return;
+            var desc = ArrayElements.Resolve(_typeMap.Get(v));
+            if (desc == null) return; // not statically an array here — leave undecided
+            if (desc.Kind == ArrayElementsKind.Object || desc.ElementTokenType is not { } tok)
+            {
+                Disqualified.Add(v.Name.Lexeme);
+                return;
+            }
+            ElementToken[v.Name.Lexeme] = tok;
+        }
+
+        /// <summary>
+        /// True if <paramref name="value"/>'s static type can carry the runtime <c>undefined</c>
+        /// sentinel (<c>any</c>/<c>unknown</c>/<c>undefined</c>, or a union containing one). Mirrors
+        /// the type checker's <c>TypeAdmitsUndefinedSentinel</c> — a value the typed element setter
+        /// would silently coerce to NaN/false instead of preserving as undefined.
+        /// </summary>
+        private bool ValueAdmitsUndefinedSentinel(Expr value) => Admits(_typeMap.Get(value));
+
+        private static bool Admits(TypeInfo? type) => type switch
+        {
+            TypeInfo.Any or TypeInfo.Unknown or TypeInfo.Undefined => true,
+            TypeInfo.Union u => u.Types.Any(Admits),
+            _ => false
+        };
+    }
+}

--- a/Compilation/CompilationContext.cs
+++ b/Compilation/CompilationContext.cs
@@ -253,6 +253,23 @@ public partial class CompilationContext
         return null;
     }
 
+    /// <summary>
+    /// If <paramref name="variableName"/> currently binds to a promoted typed-array local
+    /// (a slot whose CLR type is <c>List&lt;double&gt;</c>/<c>List&lt;bool&gt;</c>, declared by
+    /// the #857/#860 promotion path), returns its <see cref="LocalBuilder"/> and descriptor;
+    /// otherwise null. The slot's CLR type is the single source of truth, so this is
+    /// automatically scope-correct under shadowing and never misfires for a captured/object
+    /// local. No other code path declares a user local with a typed-list slot.
+    /// </summary>
+    public (LocalBuilder Local, ArrayElementsDescriptor Descriptor)? TryGetPromotedArrayLocal(string variableName)
+    {
+        if (!Locals.TryGetLocal(variableName, out var local)) return null;
+        var slotType = Locals.GetLocalType(variableName);
+        if (slotType == Types.ListOfDouble) return (local, ArrayElements.Double);
+        if (slotType == Types.ListOfBool) return (local, ArrayElements.Bool);
+        return null;
+    }
+
     // Exception block tracking for proper return handling
     public int ExceptionBlockDepth { get; set; } = 0;
     public LocalBuilder? ReturnValueLocal { get; set; }

--- a/Compilation/EmittedRuntime.cs
+++ b/Compilation/EmittedRuntime.cs
@@ -194,6 +194,8 @@ public class EmittedRuntime
     public MethodBuilder ArrayForEach { get; set; } = null!;
     public MethodBuilder ArrayForEachDirect { get; set; } = null!;
     public MethodBuilder ArrayPush { get; set; } = null!;
+    public MethodBuilder ArrayPushDouble { get; set; } = null!;
+    public MethodBuilder ArrayPushBool { get; set; } = null!;
     public MethodBuilder ArrayPushProto { get; set; } = null!;
     public MethodBuilder ArrayUnshiftProto { get; set; } = null!;
     public MethodBuilder ArrayFind { get; set; } = null!;

--- a/Compilation/ILCompiler.cs
+++ b/Compilation/ILCompiler.cs
@@ -424,6 +424,7 @@ public partial class ILCompiler
         Phase0_ExtractNamespace(statements);
         Phase1_EmitRuntimeTypes();
         Phase2_AnalyzeClosures(statements);
+        ArrayLocalPromotionAnalyzer.Analyze(statements, _typeMap, _closures.Analyzer);
         Phase3_CreateProgramType();
         PreScanBuiltInModuleImports(statements);
         Phase4_DefineDeclarations(statements);
@@ -904,6 +905,7 @@ public partial class ILCompiler
         ModulePhase0_ExtractNamespaces(modules);
         Phase1_EmitRuntimeTypes();
         Phase2_AnalyzeClosures(allStatements);
+        ArrayLocalPromotionAnalyzer.Analyze(allStatements, _typeMap, _closures.Analyzer);
         Phase3_CreateProgramType();
         // Scope each module's named-import bindings to that module so local
         // aliases like __platform don't collide between stdlib modules.

--- a/Compilation/ILEmitter.Calls.MethodDispatch.cs
+++ b/Compilation/ILEmitter.Calls.MethodDispatch.cs
@@ -14,6 +14,17 @@ public partial class ILEmitter
     {
         string methodName = methodGet.Name.Lexeme;
 
+        // Promoted typed-array local push (#857/#860): append unboxed elements directly to the
+        // bare List<T> via the typed helper — bypassing ArrayEmitter's $Array unwrap/copy and the
+        // per-element boxing. Handled here (not in ArrayEmitter) because EnsureDouble/EnsureBoolean
+        // live on the main emitter. Only fires when the receiver is a promoted local (typed slot).
+        if (methodName == "push" && !methodGet.Optional && methodGet.Object is Expr.Variable pushVar
+            && _ctx.TryGetPromotedArrayLocal(pushVar.Name.Lexeme) is { } pushProm)
+        {
+            EmitPromotedArrayPush(pushProm.Local, pushProm.Descriptor, arguments);
+            return;
+        }
+
         // Try direct dispatch for known class instance methods
         TypeSystem.TypeInfo? objType = _ctx.TypeMap?.Get(methodGet.Object);
         if (TryEmitDirectMethodCall(methodGet.Object, objType, methodName, arguments))

--- a/Compilation/ILEmitter.Operators.cs
+++ b/Compilation/ILEmitter.Operators.cs
@@ -44,6 +44,27 @@ public partial class ILEmitter
                     break;
                 }
 
+                // If both operands are statically string, emit a direct
+                // String.Concat(string, string) — skipping the dynamic
+                // $Runtime.Add type-dispatch + ToNumber/ToString probing every
+                // call. This is the 2-operand string concat the 3+-part chain
+                // optimizer (TryEmitStringConcatChain, MinPartsForOptimization=3)
+                // does not cover, e.g. `s = s + "ab"`. Both-string only: a
+                // non-string operand would need StringifyCoerce, whose
+                // string-hint ToPrimitive can diverge from `+`'s default-hint
+                // ToPrimitive for objects with differing valueOf/toString —
+                // those stay on the sound $Runtime.Add path.
+                if (IsStringPlusOperation(b))
+                {
+                    EmitExpression(b.Left);
+                    EnsureString();
+                    EmitExpression(b.Right);
+                    EnsureString();
+                    IL.Emit(OpCodes.Call, _ctx.Types.GetMethod(_ctx.Types.String, "Concat", _ctx.Types.String, _ctx.Types.String));
+                    SetStackType(StackType.String);
+                    break;
+                }
+
                 // Fallback: Use runtime Add() which handles string concat and mixed types
                 EmitExpression(b.Left);
                 EmitBoxIfNeeded(b.Left);
@@ -1733,6 +1754,18 @@ public partial class ILEmitter
         var rightType = _ctx.TypeMap.Get(b.Right);
 
         return IsNumericType(leftType) && IsNumericType(rightType);
+    }
+
+    private bool IsStringPlusOperation(Expr.Binary b)
+    {
+        // Both operands statically string — `+` is pure concatenation with no
+        // ToPrimitive ambiguity, so it can lower to String.Concat(string,string).
+        if (_ctx.TypeMap == null) return false;
+
+        var leftType = _ctx.TypeMap.Get(b.Left);
+        var rightType = _ctx.TypeMap.Get(b.Right);
+
+        return IsStringTypeInfo(leftType) && IsStringTypeInfo(rightType);
     }
 
     private bool IsStringComparison(Expr.Binary b)

--- a/Compilation/ILEmitter.Properties.cs
+++ b/Compilation/ILEmitter.Properties.cs
@@ -250,6 +250,18 @@ public partial class ILEmitter
                 return;
         }
 
+        // Promoted typed-array local `.length` (#857): direct List<T>.Count, no GetLength/isinst.
+        if (!g.Optional && g.Name.Lexeme == "length" && g.Object is Expr.Variable promVarLen
+            && _ctx.TryGetPromotedArrayLocal(promVarLen.Name.Lexeme) is { } promLen)
+        {
+            var listType = promLen.Descriptor.GetListType(_ctx.Types);
+            IL.Emit(OpCodes.Ldloc, promLen.Local);
+            IL.Emit(OpCodes.Callvirt, _ctx.Types.GetProperty(listType, "Count").GetGetMethod()!);
+            IL.Emit(OpCodes.Conv_R8);
+            SetStackType(StackType.Double);
+            return;
+        }
+
         // Try direct getter dispatch for known class instance types
         TypeInfo? objType = _ctx.TypeMap?.Get(g.Object);
         if (TryEmitDirectGetterCall(g.Object, objType, g.Name.Lexeme))
@@ -737,6 +749,47 @@ public partial class ILEmitter
             return;
         }
 
+        // Promoted typed-array local (#857): the slot IS a List<double>/List<bool>, so read
+        // directly with no isinst dispatch and no $Array indirection. An out-of-range read must
+        // yield `undefined` (JS semantics) — NOT throw, which a bare get_Item would, and which would
+        // regress arrays that were previously $Array-backed (e.g. boolean[]). List.get_Item also
+        // can't return the undefined sentinel from a value-type slot, so the result is boxed at the
+        // OOB/in-range merge (the #860 unboxed-element read is deferred — see plan B3). Even boxed,
+        // this still drops the per-access isinst ladder and the $Array virtual dispatch. The
+        // `(uint)i >= (uint)Count` compare folds the negative-index case into the OOB branch.
+        if (!gi.Optional && gi.Object is Expr.Variable promVarGet
+            && _ctx.TryGetPromotedArrayLocal(promVarGet.Name.Lexeme) is { } promGet)
+        {
+            var listType = promGet.Descriptor.GetListType(_ctx.Types);
+            var oobLabel = IL.DefineLabel();
+            var endLabel = IL.DefineLabel();
+
+            EmitExpressionAsDouble(gi.Index);
+            IL.Emit(OpCodes.Conv_I4);
+            var idxLocal = IL.DeclareLocal(_ctx.Types.Int32);
+            IL.Emit(OpCodes.Stloc, idxLocal);
+
+            IL.Emit(OpCodes.Ldloc, idxLocal);
+            IL.Emit(OpCodes.Ldloc, promGet.Local);
+            IL.Emit(OpCodes.Callvirt, _ctx.Types.GetProperty(listType, "Count").GetGetMethod()!);
+            IL.Emit(OpCodes.Bge_Un, oobLabel); // unsigned: i < 0 reads as huge, also branches to OOB
+
+            // In range: box(list[i]) so this branch converges on `object` with the OOB branch.
+            IL.Emit(OpCodes.Ldloc, promGet.Local);
+            IL.Emit(OpCodes.Ldloc, idxLocal);
+            IL.Emit(OpCodes.Callvirt, _ctx.Types.GetMethod(listType, "get_Item", _ctx.Types.Int32));
+            IL.Emit(OpCodes.Box, promGet.Descriptor.GetElementType(_ctx.Types));
+            IL.Emit(OpCodes.Br, endLabel);
+
+            // Out of range: undefined (matches the interpreter and the $Array path).
+            IL.MarkLabel(oobLabel);
+            IL.Emit(OpCodes.Ldsfld, _ctx.Runtime!.UndefinedInstance);
+
+            IL.MarkLabel(endLabel);
+            SetStackUnknown();
+            return;
+        }
+
         // Descriptor-driven fast path: when receiver is statically known to be an array,
         // emit direct List<T> access — skips runtime type dispatch,
         // index boxing, and Convert.ToInt32(object) overhead.
@@ -893,6 +946,30 @@ public partial class ILEmitter
             IL.Emit(OpCodes.Call, _ctx.Runtime!.GlobalThisSetProperty);
             IL.Emit(OpCodes.Ldloc, valueTemp); // expression result
             SetStackUnknown();
+            return;
+        }
+
+        // Promoted typed-array local (#857/#860): the slot IS a List<double>/List<bool>, so write
+        // directly via the typed auto-extend setter — no isinst dispatch, no value boxing. Value is
+        // evaluated before index, matching the hoisted path's ordering.
+        if (si.Object is Expr.Variable promVarSet
+            && _ctx.TryGetPromotedArrayLocal(promVarSet.Name.Lexeme) is { } promSet)
+        {
+            EmitExpression(si.Value);
+            if (promSet.Descriptor.Kind == ArrayElementsKind.Double) EnsureDouble();
+            else EnsureBoolean();
+            var valLocal = IL.DeclareLocal(promSet.Descriptor.GetElementType(_ctx.Types));
+            IL.Emit(OpCodes.Stloc, valLocal);
+
+            IL.Emit(OpCodes.Ldloc, promSet.Local);
+            EmitExpressionAsDouble(si.Index);
+            IL.Emit(OpCodes.Conv_I4);
+            IL.Emit(OpCodes.Ldloc, valLocal);
+            IL.Emit(OpCodes.Call, promSet.Descriptor.GetSetArrayElementMethod(_ctx.Runtime!));
+
+            // Assignment expression result: the (unboxed) assigned value.
+            IL.Emit(OpCodes.Ldloc, valLocal);
+            SetStackType(promSet.Descriptor.StackType);
             return;
         }
 
@@ -1063,6 +1140,42 @@ public partial class ILEmitter
         }
 
         IL.Emit(OpCodes.Ldloc, valueLocalGeneric);
+    }
+
+    /// <summary>
+    /// Emits <c>x.push(args)</c> for a promoted typed-array local (#857/#860): append each
+    /// (unboxed) argument directly to the bare <c>List&lt;T&gt;</c> via the typed
+    /// <c>ArrayPush{Double,Bool}</c> helper, leaving the final length (a JS number) as the
+    /// expression result. No <c>$Array</c> unwrap/copy and no per-element boxing.
+    /// </summary>
+    private void EmitPromotedArrayPush(LocalBuilder list, ArrayElementsDescriptor desc, List<Expr> arguments)
+    {
+        var pushMethod = desc.Kind == ArrayElementsKind.Double
+            ? _ctx.Runtime!.ArrayPushDouble
+            : _ctx.Runtime!.ArrayPushBool;
+
+        if (arguments.Count == 0)
+        {
+            // push() with no args returns the current length.
+            var listType = desc.GetListType(_ctx.Types);
+            IL.Emit(OpCodes.Ldloc, list);
+            IL.Emit(OpCodes.Callvirt, _ctx.Types.GetProperty(listType, "Count").GetGetMethod()!);
+            IL.Emit(OpCodes.Conv_R8);
+            SetStackType(StackType.Double);
+            return;
+        }
+
+        for (int i = 0; i < arguments.Count; i++)
+        {
+            IL.Emit(OpCodes.Ldloc, list);
+            EmitExpression(arguments[i]);
+            if (desc.Kind == ArrayElementsKind.Double) EnsureDouble();
+            else EnsureBoolean();
+            IL.Emit(OpCodes.Call, pushMethod);
+            if (i < arguments.Count - 1)
+                IL.Emit(OpCodes.Pop); // discard intermediate length; keep only the final one
+        }
+        SetStackType(StackType.Double);
     }
 
     /// <summary>

--- a/Compilation/ILEmitter.Statements.cs
+++ b/Compilation/ILEmitter.Statements.cs
@@ -161,6 +161,25 @@ public partial class ILEmitter
             return;
         }
 
+        // Typed-array-local promotion (#857/#860): a provably non-escaping number[]/boolean[]
+        // local with an empty-array-literal initializer gets a concrete List<double>/List<bool>
+        // slot, so index get/set, .length, and push/pop lower to direct typed ops with no
+        // element boxing or per-access isinst dispatch. Reached only AFTER the capture branches
+        // above, so a captured local (routed to an object display-class field) is never promoted —
+        // and the index/length/push fast paths key off the slot's CLR type via LocalsManager, so a
+        // captured name (which has no typed local) can never accidentally hit them.
+        if (_ctx.TypeMap != null && _ctx.TypeMap.IsPromotableArrayLocal(v.Name, out var promoElemTok))
+        {
+            var promoDesc = promoElemTok == TokenType.TYPE_NUMBER ? ArrayElements.Double : ArrayElements.Bool;
+            var promoListType = promoDesc.GetListType(_ctx.Types);
+            var promoLocal = _ctx.Locals.DeclareLocal(v.Name.Lexeme, promoListType);
+            // The initializer is guaranteed (by the analyzer) to be an empty array literal `[]`,
+            // so build the backing list directly instead of routing through CreateArray/$Array.
+            IL.Emit(OpCodes.Newobj, _ctx.Types.GetDefaultConstructor(promoListType));
+            IL.Emit(OpCodes.Stloc, promoLocal);
+            return;
+        }
+
         // Determine if this local can use unboxed double type
         Type localType = CanUseUnboxedLocal(v) ? _ctx.Types.Double : _ctx.Types.Object;
         var local = _ctx.Locals.DeclareLocal(v.Name.Lexeme, localType);
@@ -455,10 +474,12 @@ public partial class ILEmitter
         var candidates = ArrayHoistAnalyzer.AnalyzeFor(body, condition, increment, _ctx.TypeMap);
         if (candidates.Count == 0) return false;
 
-        // Exclude variables already hoisted by an outer loop
+        // Exclude variables already hoisted by an outer loop, and promoted typed-array
+        // locals (#857/#860) — their slot is already a concrete List<T>, so the index
+        // fast paths read it directly; hoisting would only emit a dead isinst + local.
         foreach (var name in candidates.Keys.ToList())
         {
-            if (_ctx.TryGetHoistedArray(name) != null)
+            if (_ctx.TryGetHoistedArray(name) != null || _ctx.TryGetPromotedArrayLocal(name) != null)
                 candidates.Remove(name);
         }
         if (candidates.Count == 0) return false;

--- a/Compilation/RuntimeEmitter.Arrays.Mutators.cs
+++ b/Compilation/RuntimeEmitter.Arrays.Mutators.cs
@@ -238,6 +238,35 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ret);
     }
 
+    // Typed push for promoted number[]/boolean[] locals (#857/#860): appends an
+    // unboxed double/bool to a bare List<T> and returns the new length. No frozen/
+    // sealed check — a promoted local is provably non-escaping and so can never be
+    // Object.freeze'd (that needs an argument-pass escape, which disqualifies promotion).
+    private void EmitArrayPushTyped(TypeBuilder typeBuilder, EmittedRuntime runtime, ArrayElementsDescriptor desc)
+    {
+        var listType = desc.GetListType(_types);
+        var elemType = desc.GetElementType(_types);
+        var method = typeBuilder.DefineMethod(
+            $"ArrayPush{desc.Kind}",
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.Double,
+            [listType, elemType]
+        );
+        if (desc.Kind == ArrayElementsKind.Double) runtime.ArrayPushDouble = method;
+        else runtime.ArrayPushBool = method;
+
+        var il = method.GetILGenerator();
+        // list.Add(value)
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Callvirt, listType.GetMethod("Add", [elemType])!);
+        // return (double)list.Count
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Callvirt, _types.GetProperty(listType, "Count").GetGetMethod()!);
+        il.Emit(OpCodes.Conv_R8);
+        il.Emit(OpCodes.Ret);
+    }
+
     private void EmitArrayPush(TypeBuilder typeBuilder, EmittedRuntime runtime)
     {
         var method = typeBuilder.DefineMethod(

--- a/Compilation/RuntimeEmitter.RuntimeClass.cs
+++ b/Compilation/RuntimeEmitter.RuntimeClass.cs
@@ -812,6 +812,8 @@ public partial class RuntimeEmitter
         EmitArrayForEach(typeBuilder, runtime);
         EmitArrayForEachDirect(typeBuilder, runtime);
         EmitArrayPush(typeBuilder, runtime);
+        EmitArrayPushTyped(typeBuilder, runtime, ArrayElements.Double);
+        EmitArrayPushTyped(typeBuilder, runtime, ArrayElements.Bool);
         EmitArrayPushProto(typeBuilder, runtime);
         EmitArrayFind(typeBuilder, runtime);
         EmitArrayFindDirect(typeBuilder, runtime);

--- a/SharpTS.Tests/SharedTests/ArrayLocalPromotionTests.cs
+++ b/SharpTS.Tests/SharedTests/ArrayLocalPromotionTests.cs
@@ -1,0 +1,247 @@
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests;
+
+/// <summary>
+/// Tests for the typed-array-local promotion optimization (#857/#860): a provably
+/// non-escaping number[]/boolean[] local with an empty-array-literal initializer is
+/// compiled to a concrete List&lt;double&gt;/List&lt;bool&gt; slot with unboxed element access.
+///
+/// These run against BOTH the interpreter and the compiler. The positive cases exercise
+/// the promoted fast paths; the escape cases must NOT be promoted (they fall back to the
+/// general $Array path) and must still produce correct results — i.e. interpreter/compiled
+/// parity must hold even when the array is passed, returned, spread, iterated, compared,
+/// or has holes. A wrong escape rule would surface here as a compiled-mode mismatch.
+/// </summary>
+public class ArrayLocalPromotionTests
+{
+    // ── Positive cases: promotable shapes ──────────────────────────────────
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Promoted_BoolSieve_CountsPrimes(ExecutionMode mode)
+    {
+        // The count-primes shape: const boolean[] built by push, then index read/write.
+        var source = """
+            function countPrimes(n: number): number {
+                if (n <= 2) return 0;
+                const isPrime: boolean[] = [];
+                for (let i: number = 0; i < n; i++) { isPrime.push(true); }
+                isPrime[0] = false;
+                isPrime[1] = false;
+                for (let i: number = 2; i * i < n; i++) {
+                    if (isPrime[i]) {
+                        for (let j: number = i * i; j < n; j = j + i) { isPrime[j] = false; }
+                    }
+                }
+                let count: number = 0;
+                for (let i: number = 0; i < n; i++) { if (isPrime[i]) count = count + 1; }
+                return count;
+            }
+            console.log(countPrimes(20));
+            """;
+
+        Assert.Equal("8\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Promoted_NumberArray_PushIndexLength(ExecutionMode mode)
+    {
+        var source = """
+            function build(): number {
+                const xs: number[] = [];
+                for (let i: number = 0; i < 5; i++) { xs.push(i * 2); }
+                xs[0] = 100;
+                let sum: number = 0;
+                for (let i: number = 0; i < xs.length; i++) { sum = sum + xs[i]; }
+                return sum;
+            }
+            console.log(build());
+            """;
+
+        // 100 + 2 + 4 + 6 + 8 = 120
+        Assert.Equal("120\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Promoted_IndexWrite_ReturnsAssignedValue(ExecutionMode mode)
+    {
+        // `arr[i] = v` is an expression whose value is the assigned RHS.
+        var source = """
+            function f(): number {
+                const xs: number[] = [];
+                xs.push(0);
+                const v: number = (xs[0] = 42);
+                return v + xs[0];
+            }
+            console.log(f());
+            """;
+
+        Assert.Equal("84\n", TestHarness.Run(source, mode));
+    }
+
+    // ── Escape cases: must fall back, must stay correct ────────────────────
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Escape_PassedToFunctionThatPushes(ExecutionMode mode)
+    {
+        // Passing the array as an argument escapes — a bare List<T> can't be mutated
+        // through the $Array-expecting callee, so this must NOT be promoted.
+        var source = """
+            function fill(a: number[]): void { a.push(1); a.push(2); a.push(3); }
+            function go(): number {
+                const xs: number[] = [];
+                fill(xs);
+                let sum: number = 0;
+                for (let i: number = 0; i < xs.length; i++) { sum = sum + xs[i]; }
+                return sum;
+            }
+            console.log(go());
+            """;
+
+        Assert.Equal("6\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Escape_Returned(ExecutionMode mode)
+    {
+        var source = """
+            function make(): number[] {
+                const xs: number[] = [];
+                xs.push(7);
+                xs.push(8);
+                return xs;
+            }
+            const r: number[] = make();
+            console.log(r.length);
+            console.log(r[1]);
+            """;
+
+        Assert.Equal("2\n8\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Escape_Spread(ExecutionMode mode)
+    {
+        var source = """
+            function f(): number {
+                const xs: number[] = [];
+                xs.push(1); xs.push(2); xs.push(3);
+                const ys: number[] = [...xs, 4];
+                let sum: number = 0;
+                for (let i: number = 0; i < ys.length; i++) { sum = sum + ys[i]; }
+                return sum;
+            }
+            console.log(f());
+            """;
+
+        Assert.Equal("10\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Escape_ForOf(ExecutionMode mode)
+    {
+        var source = """
+            function f(): number {
+                const xs: number[] = [];
+                xs.push(10); xs.push(20); xs.push(30);
+                let sum: number = 0;
+                for (const x of xs) { sum = sum + x; }
+                return sum;
+            }
+            console.log(f());
+            """;
+
+        Assert.Equal("60\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Escape_OtherMethod_Map(ExecutionMode mode)
+    {
+        // .map is not a permitted use → no promotion; result must still be correct.
+        var source = """
+            function f(): number {
+                const xs: number[] = [];
+                xs.push(1); xs.push(2); xs.push(3);
+                const doubled: number[] = xs.map((x: number): number => x * 2);
+                let sum: number = 0;
+                for (let i: number = 0; i < doubled.length; i++) { sum = sum + doubled[i]; }
+                return sum;
+            }
+            console.log(f());
+            """;
+
+        Assert.Equal("12\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Escape_OutOfRangeReadIsUndefined(ExecutionMode mode)
+    {
+        // A read past the end must yield undefined (JS semantics). Reading `xs[5]`
+        // anywhere is fine for a promoted array only if it stays in range; here the
+        // index expression escapes nothing, but an OOB read must match the interpreter.
+        // Because the array is also logged (escape), it is not promoted — but this pins
+        // the fallback semantics regardless.
+        var source = """
+            const xs: number[] = [];
+            xs.push(1);
+            console.log(xs);
+            console.log(xs[5]);
+            """;
+
+        Assert.Equal("[1]\nundefined\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Escape_AnyTypedElementWrite_NotPromoted(ExecutionMode mode)
+    {
+        // An `any`-typed element write disqualifies promotion (the typed setter would
+        // coerce a runtime undefined to NaN/false — the array analogue of the #367 taint
+        // guard). We assert interpreter/compiled parity only on a NUMBER-typed any value
+        // here, which both modes agree on; the guard's job is purely to keep codegen on
+        // the pre-existing general path, which the count-primes IL inspection confirms.
+        var source = """
+            function f(): number {
+                const xs: number[] = [];
+                xs.push(1);
+                const u: any = 41;
+                xs[1] = u;
+                return xs[0] + xs[1];
+            }
+            console.log(f());
+            """;
+
+        Assert.Equal("42\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Promoted_AutoExtendOnIndexWrite(ExecutionMode mode)
+    {
+        // Writing at index == length extends the array by one (auto-extend path).
+        var source = """
+            function f(): number {
+                const xs: number[] = [];
+                xs.push(1);
+                xs[1] = 2;
+                xs[2] = 3;
+                let sum: number = 0;
+                for (let i: number = 0; i < xs.length; i++) { sum = sum + xs[i]; }
+                return sum;
+            }
+            console.log(f());
+            """;
+
+        Assert.Equal("6\n", TestHarness.Run(source, mode));
+    }
+}

--- a/TypeSystem/TypeMap.cs
+++ b/TypeSystem/TypeMap.cs
@@ -20,6 +20,7 @@ public class TypeMap
     private readonly HashSet<Expr> _undefinedReachableReturns = new(ReferenceEqualityComparer.Instance);
     private readonly HashSet<object> _undefinedReachableNumericLocals = new(ReferenceEqualityComparer.Instance);
     private readonly HashSet<Stmt.Parameter> _undefinedReachableNumericParams = new(ReferenceEqualityComparer.Instance);
+    private readonly Dictionary<Token, TokenType> _promotableArrayLocals = new(ReferenceEqualityComparer.Instance);
 
     /// <summary>
     /// Associates an expression with its resolved type.
@@ -119,6 +120,29 @@ public class TypeMap
     /// </summary>
     public bool IsUndefinedReachableNumericParam(Stmt.Parameter param) =>
         _undefinedReachableNumericParams.Contains(param);
+
+    /// <summary>
+    /// Flags a <c>number[]</c>/<c>boolean[]</c>-typed local <c>const</c>/<c>let</c> declaration whose
+    /// initializer is an empty array literal and which is provably non-escaping (only used via
+    /// index get/set, <c>.length</c>, and <c>push</c>/<c>pop</c>). The compiler promotes such a local
+    /// to a concrete <c>List&lt;double&gt;</c>/<c>List&lt;bool&gt;</c> CLR slot with unboxed element access
+    /// (#857/#860), instead of the default <c>object</c>/<c>$Array</c> slot. <paramref name="elementToken"/>
+    /// is the element primitive token (<c>TYPE_NUMBER</c> or <c>TYPE_BOOLEAN</c>) so the compiler can pick the
+    /// backing list type without re-deriving it. Keyed by reference on the declaration's <em>name token</em>
+    /// (stable across both <c>Stmt.Var</c> and <c>Stmt.Const</c> — the latter is re-wrapped into a synthetic
+    /// <c>Stmt.Var</c> at emit time but reuses the same name <see cref="Token"/>). Purely a compiler hint —
+    /// set by the IL compiler's promotion analyzer, not by the type checker.
+    /// </summary>
+    public void MarkPromotableArrayLocal(Token nameToken, TokenType elementToken) =>
+        _promotableArrayLocals[nameToken] = elementToken;
+
+    /// <summary>
+    /// If the declaration with name token <paramref name="nameToken"/> was flagged by
+    /// <see cref="MarkPromotableArrayLocal"/>, returns true and sets <paramref name="elementToken"/> to the
+    /// element primitive token; otherwise false.
+    /// </summary>
+    public bool IsPromotableArrayLocal(Token nameToken, out TokenType elementToken) =>
+        _promotableArrayLocals.TryGetValue(nameToken, out elementToken);
 
     /// <summary>
     /// Gets the resolved type for an expression, or null if not found.


### PR DESCRIPTION
Part of #856 (perf epic), addressing #857 (statically-typed locals emitted as CLR `object`) and folding in #860 (typed array element access).

## What changed

**A1 — typed-string concatenation.** Static-string `s + e` lowers to `String.Concat(string, string)` instead of the dynamic `$Runtime.Add(object, object)` type-dispatch. Both operands must be statically `string` (a non-string operand would need `StringifyCoerce`, whose string-hint `ToPrimitive` can diverge from `+`'s default-hint `ToPrimitive` for objects with differing `valueOf`/`toString`). Covers the 2-operand case the 3+-part `StringConcatOptimizer` (`MinPartsForOptimization=3`) misses, e.g. `s = s + "ab"`.

**B (folds #860) — non-escaping array-local `List<T>` slots.** `number[]`/`boolean[]` locals initialized with `[]` that **provably never escape** are promoted from an `object`/`$Array` slot to a concrete `List<double>`/`List<bool>` slot: direct typed get/set, `push` via new emitted `ArrayPush{Double,Bool}` helpers, no per-element boxing, no per-access `isinst` ladder, no `$Array` allocation. A new function-scoped `ArrayLocalPromotionAnalyzer` enforces a conservative escape rule — any arg-pass, return, spread, `for…of`, `===`, `delete`, `.map`, reassignment, closure capture, or `any`/`undefined` write disqualifies (slot stays `object`, current behavior). count-primes' hot loops emit **zero `isinst` and zero boxing** and IL-verify clean.

Out-of-range reads on a promoted slot are bounds-checked to yield `undefined` (boxed at the merge) rather than throw — preserving interpreter/compiled parity and avoiding a regression for previously-`$Array`-backed arrays (e.g. `boolean[]`). This defers the #860 unboxed-element read.

The standalone-DLL constraint is preserved (new helpers are emitted runtime methods, not references into SharpTS.dll).

## Honest performance note

These deliver the IL #857/#860 specify (no boxing/isinst/`$Array`), which reduces allocation and helps **cold-start / tier-0**, but **warm steady-state on the current (post-overhaul, JIT-warmed) benchmark harness is flat**: count-primes@100k 2.32 vs 2.30 ms, strings@10k within noise.

The investigation found the epic's headline gaps (28×, 117×) reflect the **old cold methodology**. On .NET 10 warm: `s = s + x` accumulation is already **O(n)** (verified linear build-only scaling 25k→400k), and the JIT already optimizes the boxed/`$Array` path well. A StringBuilder accumulation optimization was prototyped and **discarded** for zero gain. The dominant remaining warm overhead is **reflective arrow dispatch (#858)** — recommended as the next target over the remaining boxing-focused children.

## Tests
- New `ArrayLocalPromotionTests` (positive shapes + escape-case fallbacks + auto-extend), interp/compiled parity.
- IL-verifies clean (`--verify`); OOB/gap-write parity battery passes.
- Full `dotnet test` green except the two known pre-existing stale/flaky Test262 baselines (`Interpreted`/`CompiledBaseline`, identical on `main`) and parallel-load flakiness (each passes in isolation).