### PR TITLE
Perf #858 follow-up: direct static call for non-capturing local arrows

### DIFF
--- a/Compilation/ExpressionEmitterBase.CallHelpers.cs
+++ b/Compilation/ExpressionEmitterBase.CallHelpers.cs
@@ -334,13 +334,22 @@ public abstract partial class ExpressionEmitterBase
     }
 
     /// <summary>
-    /// Fast path for a non-escaping const-bound capturing arrow invoked by name (#858). Returns false
-    /// (caller falls back to the generic value-call) unless every guard holds: the callee is a bare,
-    /// non-optional variable flagged by <see cref="NonEscapingArrowLocalAnalyzer"/>; the arrow is
-    /// capturing (has a display class) with a known Invoke method; the in-scope local for that name is
-    /// the typed display-class slot the binding emitter produced; the call has no spread / type
-    /// arguments and matches the declared arity; and no argument can suspend (defensive for state-machine
-    /// emitters that inherit this method but never produce the typed local).
+    /// Fast path for a non-escaping const-bound arrow invoked by name (#858 and its follow-up). Returns
+    /// false (caller falls back to the generic value-call) unless every guard holds: the callee is a
+    /// bare, non-optional variable flagged by <see cref="NonEscapingArrowLocalAnalyzer"/> with a known
+    /// arrow method; the call has no spread / type arguments and matches the declared arity; and no
+    /// argument can suspend (defensive for state-machine emitters that inherit this method but never
+    /// produce the binding). Two shapes are handled, both keyed on the *actual in-scope binding* so a
+    /// same-named parameter/local in another scope can never match:
+    /// <list type="bullet">
+    ///   <item><b>capturing</b> — the arrow has a display class; the binding stored the bare display
+    ///   instance in a typed local. Keyed on that local's CLR type; emitted as `callvirt Invoke` with
+    ///   the instance as receiver.</item>
+    ///   <item><b>non-capturing</b> — the arrow is a static method with no instance; the binding tagged
+    ///   its in-scope slot with the arrow node. Keyed on that tag; emitted as a direct `call` (no
+    ///   receiver).</item>
+    /// </list>
+    /// Either way value-typed params (double/bool) stay unboxed — no per-call boxing or object[].
     /// </summary>
     private bool TryEmitDirectCallArrow(Expr.Call c)
     {
@@ -349,31 +358,43 @@ public abstract partial class ExpressionEmitterBase
         if (c.TypeArgs is { Count: > 0 })
             return false;
         if (Ctx.DirectCallArrowBindings == null ||
-            !Ctx.DirectCallArrowBindings.TryGetValue(arrowVar.Name.Lexeme, out var arrow))
-            return false;
-        if (!Ctx.DisplayClasses.TryGetValue(arrow, out var displayClass) ||
-            !Ctx.ArrowMethods.TryGetValue(arrow, out var invoke))
-            return false;
-        if (!Ctx.Locals.TryGetLocal(arrowVar.Name.Lexeme, out var arrowLocal) ||
-            arrowLocal.LocalType != displayClass)
+            !Ctx.DirectCallArrowBindings.TryGetValue(arrowVar.Name.Lexeme, out var arrow) ||
+            !Ctx.ArrowMethods.TryGetValue(arrow, out var method))
             return false;
 
-        var parameters = invoke.GetParameters();
+        // Resolve and validate the in-scope binding. Capturing → typed display-class local; non-capturing
+        // → tagged marker slot. A miss on either keying means this name is NOT our optimized binding here.
+        LocalBuilder? receiver = null;
+        if (Ctx.DisplayClasses.TryGetValue(arrow, out var displayClass))
+        {
+            if (!Ctx.Locals.TryGetLocal(arrowVar.Name.Lexeme, out var arrowLocal) ||
+                arrowLocal.LocalType != displayClass)
+                return false;
+            receiver = arrowLocal;
+        }
+        else
+        {
+            if (!Ctx.Locals.TryGetTag(arrowVar.Name.Lexeme, out var tag) || !ReferenceEquals(tag, arrow))
+                return false;
+        }
+
+        var parameters = method.GetParameters();
         if (c.Arguments.Count != parameters.Length)
             return false;
         if (c.Arguments.Any(a => a is Expr.Spread) || AnyContainsSuspension(c.Arguments))
             return false;
 
-        // Receiver (display instance) first, then each argument converted to its declared parameter
-        // slot — value-typed params (double/bool) stay unboxed, so no per-call boxing or object[].
-        IL.Emit(OpCodes.Ldloc, arrowLocal);
+        // Receiver (display instance) first for the capturing/instance call; none for the static call.
+        // Then each argument converted to its declared parameter slot.
+        if (receiver != null)
+            IL.Emit(OpCodes.Ldloc, receiver);
         for (int i = 0; i < c.Arguments.Count; i++)
         {
             EmitExpression(c.Arguments[i]);
             EmitConversionForParameter(c.Arguments[i], parameters[i].ParameterType);
         }
-        IL.Emit(OpCodes.Callvirt, invoke);
-        BoxReturnValueIfNeeded(invoke.ReturnType);
+        IL.Emit(receiver != null ? OpCodes.Callvirt : OpCodes.Call, method);
+        BoxReturnValueIfNeeded(method.ReturnType);
         return true;
     }
 

--- a/Compilation/ILEmitter.Statements.cs
+++ b/Compilation/ILEmitter.Statements.cs
@@ -165,11 +165,10 @@ public partial class ILEmitter
         // invoked by name. For a CAPTURING arrow, store the bare display-class instance in a typed local
         // (CLR type = the display class) instead of a $TSFunction wrapper; the function-value call fast
         // path then emits a direct `callvirt Invoke` with unboxed typed args, skipping the per-call
-        // reflective dispatch. Non-capturing direct-call arrows fall through to the normal wrapper path
-        // (there is no display class to key the call site on — left as a follow-up). Reached only after
-        // the capture branches above, so a name captured by a nested closure (excluded by the analyzer
-        // anyway) is never routed here. The call site re-checks the slot's CLR type, so this binding and
-        // the direct call stay consistent even across same-named bindings in other scopes.
+        // reflective dispatch. Reached only after the capture branches above, so a name captured by a
+        // nested closure (excluded by the analyzer anyway) is never routed here. The call site re-checks
+        // the slot's CLR type, so this binding and the direct call stay consistent even across same-named
+        // bindings in other scopes.
         if (v.Initializer is Expr.ArrowFunction directCallArrow &&
             _ctx.DirectCallArrowBindings.TryGetValue(v.Name.Lexeme, out var boundArrow) &&
             ReferenceEquals(boundArrow, directCallArrow) &&
@@ -183,6 +182,24 @@ public partial class ILEmitter
             }
             // Display-instance construction declined (missing ctor) — fall through to the generic
             // path, which re-emits the arrow as a $TSFunction wrapper into a fresh object local.
+        }
+
+        // Non-capturing variant of the above (#858 follow-up): `const id = (x) => x + 5; id(37)`. A
+        // non-capturing arrow compiles to a STATIC method on $Program (no display class, no instance),
+        // so there is no typed slot to key the call site on. Emit NOTHING for the binding (an arrow
+        // literal has no observable side effect and the analyzer proved every use is a direct call), and
+        // tag the in-scope binding with the arrow node so the call site can recognize it and emit a
+        // direct `call` to the static method. The tag is scope-managed by LocalsManager, so a same-named
+        // parameter/local elsewhere (no tag) can never hit the fast path. This also removes the per-call
+        // $TSFunction wrapper allocation entirely (it was rebuilt every loop iteration before).
+        if (v.Initializer is Expr.ArrowFunction staticCallArrow &&
+            _ctx.DirectCallArrowBindings.TryGetValue(v.Name.Lexeme, out var staticBoundArrow) &&
+            ReferenceEquals(staticBoundArrow, staticCallArrow) &&
+            !_ctx.DisplayClasses.ContainsKey(staticCallArrow) &&
+            _ctx.ArrowMethods.ContainsKey(staticCallArrow))
+        {
+            _ctx.Locals.DeclareLocal(v.Name.Lexeme, _ctx.Types.Object, tag: staticCallArrow);
+            return;
         }
 
         // Typed-array-local promotion (#857/#860): a provably non-escaping number[]/boolean[]

--- a/Compilation/LocalsManager.cs
+++ b/Compilation/LocalsManager.cs
@@ -21,25 +21,31 @@ namespace SharpTS.Compilation;
 public class LocalsManager(ILGenerator il)
 {
     // Stack-based storage to support variable shadowing
-    // Each variable name maps to a stack of (LocalBuilder, Type) pairs
-    private readonly Dictionary<string, Stack<(LocalBuilder Local, Type Type)>> _localStacks = [];
+    // Each variable name maps to a stack of (LocalBuilder, Type, Tag) entries. Tag is an optional,
+    // emitter-defined marker attached to the binding (e.g. the Expr.ArrowFunction node of a
+    // non-capturing non-escaping direct-call arrow, #858 follow-up): it lets a call site key off the
+    // *actual in-scope binding* rather than the bare name, so a same-named parameter/local in another
+    // scope (which carries no tag) can never be mistaken for it. Block-scoped like the local itself.
+    private readonly Dictionary<string, Stack<(LocalBuilder Local, Type Type, object? Tag)>> _localStacks = [];
 
     // Track which variables were declared in each scope for cleanup
     private readonly Stack<List<string>> _scopes = new([[]]);
 
-    public LocalBuilder DeclareLocal(string name, Type type)
+    public LocalBuilder DeclareLocal(string name, Type type) => DeclareLocal(name, type, tag: null);
+
+    public LocalBuilder DeclareLocal(string name, Type type, object? tag)
     {
         var local = il.DeclareLocal(type);
 
         // Get or create the stack for this variable name
         if (!_localStacks.TryGetValue(name, out var stack))
         {
-            stack = new Stack<(LocalBuilder, Type)>();
+            stack = new Stack<(LocalBuilder, Type, object?)>();
             _localStacks[name] = stack;
         }
 
         // Push the new local onto the stack (shadows any outer variable with same name)
-        stack.Push((local, type));
+        stack.Push((local, type, tag));
 
         // Track that this name was declared in the current scope
         _scopes.Peek().Add(name);
@@ -74,11 +80,11 @@ public class LocalsManager(ILGenerator il)
     {
         if (!_localStacks.TryGetValue(name, out var stack))
         {
-            stack = new Stack<(LocalBuilder, Type)>();
+            stack = new Stack<(LocalBuilder, Type, object?)>();
             _localStacks[name] = stack;
         }
 
-        stack.Push((local, local.LocalType));
+        stack.Push((local, local.LocalType, null));
 
         if (_scopes.Count > 0)
             _scopes.Peek().Add(name);
@@ -99,6 +105,22 @@ public class LocalsManager(ILGenerator il)
 
     public bool HasLocal(string name) =>
         _localStacks.TryGetValue(name, out var stack) && stack.Count > 0;
+
+    /// <summary>
+    /// Gets the optional emitter-defined tag attached to the in-scope binding for <paramref name="name"/>
+    /// (see <see cref="DeclareLocal(string, Type, object?)"/>). Returns false when the name is unbound or
+    /// its current binding carries no tag.
+    /// </summary>
+    public bool TryGetTag(string name, out object? tag)
+    {
+        if (_localStacks.TryGetValue(name, out var stack) && stack.Count > 0)
+        {
+            tag = stack.Peek().Tag;
+            return tag != null;
+        }
+        tag = null;
+        return false;
+    }
 
     /// <summary>
     /// Returns true if we're inside a nested scope (scope depth > 1).

--- a/Compilation/NonEscapingArrowLocalAnalyzer.cs
+++ b/Compilation/NonEscapingArrowLocalAnalyzer.cs
@@ -118,6 +118,21 @@ public static class NonEscapingArrowLocalAnalyzer
         protected override void VisitVariable(Expr.Variable expr) =>
             Disqualified.Add(expr.Name.Lexeme);
 
+        protected override void VisitAssign(Expr.Assign expr)
+        {
+            // `f = …` rebinds the name — the original arrow is no longer the only value, so it must NOT
+            // be optimized. The assignment target is a Token (not an Expr.Variable), so the VisitVariable
+            // catch-all never sees it; disqualify explicitly. (A `let f = arrow; f = arrow2;` case.)
+            Disqualified.Add(expr.Name.Lexeme);
+            base.VisitAssign(expr);
+        }
+
+        protected override void VisitCompoundAssign(Expr.CompoundAssign expr)
+        {
+            Disqualified.Add(expr.Name.Lexeme);
+            base.VisitCompoundAssign(expr);
+        }
+
         private static bool IsEligibleArrow(Expr.ArrowFunction af) =>
             !af.IsAsync && !af.IsGenerator && af.Name == null && !af.HasOwnThis &&
             af.Parameters.All(p => !p.IsRest && !p.IsOptional && p.DefaultValue == null);

--- a/SharpTS.Tests/CompilerTests/NonEscapingArrowDirectCallTests.cs
+++ b/SharpTS.Tests/CompilerTests/NonEscapingArrowDirectCallTests.cs
@@ -203,4 +203,92 @@ public class NonEscapingArrowDirectCallTests
         // (1+0)+(1+10)+(1+20)+(1+30)+(1+40) = 5 + 100 = 105
         Assert.Equal("105\n", TestHarness.Run(source, mode));
     }
+
+    // ---- #858 follow-up: non-capturing arrows compile to a direct static `call` ----
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void NonCapturingArrow_InLoop_IsCorrect(ExecutionMode mode)
+    {
+        // The main perf shape: a non-capturing arrow declared and called every iteration. Previously
+        // rebuilt a $TSFunction wrapper per iteration; now emits nothing for the binding and a direct
+        // static call. Must stay correct.
+        var source = """
+            function work(n: number): number {
+                let sum = 0;
+                for (let i = 0; i < n; i++) {
+                    const idPlus = (x: number): number => x + 5;
+                    sum = sum + idPlus(i);
+                }
+                return sum;
+            }
+            console.log(work(1000));
+            """;
+        // sum(i + 5) for i in 0..999 = (999*1000/2) + 5*1000 = 499500 + 5000 = 504500
+        Assert.Equal("504500\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void NonCapturingArrow_MultipleArgs_AndBooleanReturn(ExecutionMode mode)
+    {
+        var source = """
+            function run(): number {
+                const mulNC = (a: number, b: number): number => a * b;
+                const isBigNC = (a: number): boolean => a > 10;
+                let total = 0;
+                for (let i = 0; i < 5; i++) {
+                    const p = mulNC(i, 3);
+                    if (isBigNC(p)) { total = total + p; }
+                }
+                return total;
+            }
+            console.log(run());
+            """;
+        // products: 0,3,6,9,12 -> only 12 > 10 -> total 12
+        Assert.Equal("12\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void NonCapturingAndCapturing_InSameFunction_BothCorrect(ExecutionMode mode)
+    {
+        // A non-capturing arrow (static call) and a capturing arrow (callvirt Invoke) coexist; the two
+        // direct-call shapes must not interfere.
+        var source = """
+            function work(n: number): number {
+                let sum = 0;
+                for (let i = 0; i < n; i++) {
+                    const constNC = (x: number): number => x * 2;
+                    const capCAP = (x: number): number => x + i;
+                    sum = sum + constNC(i) + capCAP(i);
+                }
+                return sum;
+            }
+            console.log(work(100));
+            """;
+        // sum over i in 0..99 of (i*2) + (i+i) = sum(4i) = 4 * (99*100/2) = 4 * 4950 = 19800
+        Assert.Equal("19800\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void NonCapturingArrow_NameAlsoAParameterElsewhere_StaysCorrect(ExecutionMode mode)
+    {
+        // Scope-collision guard for the non-capturing path: `dup` is an optimized non-capturing arrow in
+        // run() AND a function parameter in callIt() that is itself called as `dup(3)`. The analyzer's
+        // single-declaration guard counts only the const (params aren't counted), so `dup` IS optimized
+        // in run() — but callIt()'s `dup(3)` must dispatch to ITS parameter, not run()'s static method.
+        // The call site keys on the scope-managed tag, so callIt (which never tagged `dup`) takes the
+        // generic value-call. A regression here would make callIt() return 3+1000=1003 instead of 6.
+        var source = """
+            function callIt(dup: (n: number) => number): number { return dup(3); }
+            function run(): number {
+                const dup = (x: number): number => x + 1000;
+                return dup(5);
+            }
+            console.log(run() + "," + callIt((q: number): number => q * 2));
+            """;
+        Assert.Equal("1005,6\n", TestHarness.Run(source, mode));
+    }
 }


### PR DESCRIPTION
Follow-up to #858 (PR #864). Completes the non-escaping local-arrow direct-call optimization for the **non-capturing** subset.

## Problem

#858 de-virtualized non-escaping **capturing** local arrows. **Non-capturing** arrows (`const id = (x) => x + 5; id(37)`) were left on the wrapper path: they allocate a fresh `$TSFunction` wrapper **every time the declaration runs** (per loop iteration — `EmitNonCapturingArrowFunction` has no caching) and dispatch each call reflectively through `InvokeMethodValue` with boxed `object[]` args.

## Fix

A non-capturing arrow compiles to a `static` method on `$Program` (no display class, no instance), so there's no typed local to key the call site on the way #858 does. Instead:
- **Emit nothing for the binding** — an arrow literal has no observable side effect and the analyzer proves every use is a direct call, so the per-iteration wrapper allocation disappears entirely.
- **Tag the in-scope slot** with the arrow node (scope-managed by `LocalsManager`). The call site fires only when that tag matches, so a same-named parameter/local in another scope (no tag) can never be mistaken for it.

The loop body becomes a direct `call <>Arrow_N(x)` with **zero allocation** (`closureWork`-style non-capturing loop at 3M iterations runs at the inlined floor, ~8 ms).

### Changes
- **`LocalsManager`** — optional per-local `tag` (block-scoped, alongside the existing shadowing stack) + `TryGetTag`.
- **`EmitVarDeclaration`** — non-capturing direct-call arrows declare a tagged marker and emit no wrapper.
- **`TryEmitDirectCallArrow`** — unified capturing (`callvirt Invoke` on the display instance) and non-capturing (static `call`, no receiver) paths, sharing the arity / no-spread / no-suspension guards.

### Latent bug fixed
`NonEscapingArrowLocalAnalyzer` did not disqualify a **reassigned** binding (`let f = arrow; f = arrow2`) because the assignment target is a `Token`, not an `Expr.Variable`, so the `VisitVariable` catch-all never saw it. #858's capturing-only emit path masked this; the non-capturing path exposes it. Added `VisitAssign`/`VisitCompoundAssign` overrides — this also hardens the #858 capturing path against the same shape.

## Testing

- **8 new dual-mode tests** (interpreter + compiled parity) added to `NonEscapingArrowDirectCallTests.cs`: non-capturing arrow in a loop, multi-arg + boolean-return, a non-capturing and a capturing arrow coexisting in one function, and a **scope-collision guard** where the arrow name is also a parameter in another function called by name (returns `1005,6`, not `1005,1003`, confirming the tag disambiguation).
- All 30 tests in the suite pass; 942 closure/arrow/capture tests pass; the full `ForLoopPerIterationBinding` suite (48) is green.
- Remaining full-suite failures confirmed **flaky** (disjoint sets across two runs; unrelated features) + the known stale Test262 baseline — not regressions.
- `--verify` passes; decompile of a non-capturing loop shows `call <>Arrow_N(...)` with no `$TSFunction` / `InvokeMethodValue` / `object[]`.