### PR TITLE
Perf #861: de-virtualize annotated-param array HOF callbacks

### DIFF
--- a/Compilation/ArrowBoxedAdapterEmitter.cs
+++ b/Compilation/ArrowBoxedAdapterEmitter.cs
@@ -47,7 +47,7 @@ internal sealed class ArrowBoxedAdapterEmitter
     // one containing its call site), so this per-context cache never double-defines;
     // the adapter NAME is derived from the arrow's globally-unique method name so it
     // stays collision-free across contexts that share the same $Program type.
-    private readonly Dictionary<(MethodBuilder, int), MethodBuilder> _cache = [];
+    private readonly Dictionary<(MethodBuilder, int, bool), MethodBuilder> _cache = [];
 
     /// <summary>
     /// Returns the boxed adapter for <paramref name="arrowMethod"/> bound to a delegate of
@@ -59,23 +59,28 @@ internal sealed class ArrowBoxedAdapterEmitter
     ///   <item>true (#861 L3): an INSTANCE adapter on the capturing arrow's display class, calling
     ///         <c>this.Invoke(...)</c>; the caller binds it to <c>(displayInstance, ldftn adapter)</c>.</item>
     /// </list>
+    /// <paramref name="boolReturn"/> (#861 L4): when the arrow returns <c>bool</c> and a
+    /// <c>Func&lt;object,bool&gt;</c> predicate helper is used, the adapter returns the unboxed
+    /// <c>bool</c> directly (no rebox) so the <c>*DirectBool</c> helper skips the box + IsTruthy.
     /// </summary>
-    public MethodBuilder GetOrEmit(TypeBuilder carrierType, MethodBuilder arrowMethod, int funcArity, bool instance)
+    public MethodBuilder GetOrEmit(TypeBuilder carrierType, MethodBuilder arrowMethod, int funcArity, bool instance, bool boolReturn)
     {
-        var key = (arrowMethod, funcArity);
+        var key = (arrowMethod, funcArity, boolReturn);
         if (_cache.TryGetValue(key, out var existing)) return existing;
 
         var objectType = typeof(object);
         var adapterParams = new Type[funcArity];
         for (int i = 0; i < funcArity; i++) adapterParams[i] = objectType;
+        var adapterReturnType = boolReturn ? typeof(bool) : objectType;
 
         // Name keyed off the arrow method's name ($Program-unique <>Arrow_N for static; "Invoke"
-        // for instance, where the per-arrow display class scopes it). Assembly-visible.
+        // for instance, where the per-arrow display class scopes it) plus the return-shape marker.
+        // Assembly-visible.
         var attrs = MethodAttributes.Assembly | (instance ? 0 : MethodAttributes.Static);
         var adapter = carrierType.DefineMethod(
-            $"{arrowMethod.Name}$box{funcArity}",
+            $"{arrowMethod.Name}${(boolReturn ? "bbox" : "box")}{funcArity}",
             attrs,
-            objectType,
+            adapterReturnType,
             adapterParams);
 
         var il = adapter.GetILGenerator();
@@ -96,8 +101,10 @@ internal sealed class ArrowBoxedAdapterEmitter
 
         il.Emit(instance ? OpCodes.Callvirt : OpCodes.Call, arrowMethod);
 
-        // Rebox the typed result back to object for the Func<object,…> contract.
-        DelegateAdapterEmitter.EmitBoxForTS(il, arrowMethod.ReturnType);
+        // bool-return: the arrow already returns bool (caller guarantees) — leave it unboxed for the
+        // Func<object,bool> contract. Otherwise rebox the typed result to object for Func<object,…>.
+        if (!boolReturn)
+            DelegateAdapterEmitter.EmitBoxForTS(il, arrowMethod.ReturnType);
         il.Emit(OpCodes.Ret);
 
         _cache[key] = adapter;

--- a/Compilation/ArrowBoxedAdapterEmitter.cs
+++ b/Compilation/ArrowBoxedAdapterEmitter.cs
@@ -1,0 +1,112 @@
+using System.Reflection;
+using System.Reflection.Emit;
+
+namespace SharpTS.Compilation;
+
+/// <summary>
+/// Emits per-arrow "boxed adapter" static methods that let an arrow with
+/// <b>annotated</b> parameters be dispatched by the array HOF direct-delegate
+/// fast path (#861).
+/// </summary>
+/// <remarks>
+/// <para>
+/// An annotated callback like <c>(x: number): number =&gt; x*2</c> compiles to a
+/// static method with the typed CLR signature <c>double(double)</c>, which cannot
+/// bind to the <c>Func&lt;object,object&gt;</c> that the emitted
+/// <c>Array*Direct</c> helpers expect. Without a bridge, such callbacks fall back
+/// to the reflective <c>$TSFunction</c>/<c>MethodInvoker</c> path (per-element
+/// dispatch + an <c>object[]</c> allocation), which is exactly the cost #861
+/// targets.
+/// </para>
+/// <para>
+/// The adapter is a static method <c>object Adapter(object[, object])</c> on
+/// <c>$Program</c> whose body unboxes/casts each boxed element into the arrow's
+/// typed parameter slot, <c>call</c>s the typed arrow method, then reboxes the
+/// result. It binds to <c>Func&lt;object,object&gt;</c> /
+/// <c>Func&lt;object,object,object&gt;</c> via <c>ldnull</c>+<c>ldftn</c>, so the
+/// unchanged <c>Array*Direct</c> helpers drive it with a direct delegate call.
+/// </para>
+/// <para>
+/// The unbox/box marshalling is shared with <see cref="DelegateAdapterEmitter"/>
+/// (<see cref="DelegateAdapterEmitter.EmitUnboxForReturn"/> coerces
+/// <c>object</c>→typed slot; <see cref="DelegateAdapterEmitter.EmitBoxForTS"/>
+/// reboxes the typed result), so the conversion matches the reflective
+/// <c>MethodInvoker</c> semantics for the no-arg-conversion regime (concrete
+/// <c>double</c>/<c>bool</c>/<c>string</c> params — unions/nullable already widen
+/// to <c>object</c> in <c>ParameterTypeResolver</c>, and the call site gates on
+/// that). Only emits a static adapter, so it carries no <c>SharpTS.dll</c>
+/// reference (standalone-DLL constraint preserved).
+/// </para>
+/// </remarks>
+internal sealed class ArrowBoxedAdapterEmitter
+{
+    // Keyed by (typed arrow method, adapter arity). Arity is the delegate's
+    // parameter count (1 for map/filter/forEach/find/…, 2 for reduce); the arrow
+    // itself may declare fewer params, in which case the extra adapter args are
+    // ignored. A given arrow node is emitted by exactly one CompilationContext (the
+    // one containing its call site), so this per-context cache never double-defines;
+    // the adapter NAME is derived from the arrow's globally-unique method name so it
+    // stays collision-free across contexts that share the same $Program type.
+    private readonly Dictionary<(MethodBuilder, int), MethodBuilder> _cache = [];
+
+    /// <summary>
+    /// Returns the boxed adapter for <paramref name="typedArrow"/> bound to a
+    /// delegate of <paramref name="funcArity"/> object parameters, emitting it on
+    /// <paramref name="programType"/> (the arrow's declaring <c>$Program</c> type)
+    /// on first request.
+    /// </summary>
+    public MethodBuilder GetOrEmit(TypeBuilder programType, MethodBuilder typedArrow, int funcArity)
+    {
+        var key = (typedArrow, funcArity);
+        if (_cache.TryGetValue(key, out var existing)) return existing;
+
+        var objectType = typeof(object);
+        var adapterParams = new Type[funcArity];
+        for (int i = 0; i < funcArity; i++) adapterParams[i] = objectType;
+
+        // Assembly-visible static, matching the arrow methods on $Program it calls
+        // into. Name keyed off the arrow's unique method name (e.g. <>Arrow_5) so
+        // two contexts emitting adapters onto the same $Program never collide.
+        var adapter = programType.DefineMethod(
+            $"{typedArrow.Name}$box{funcArity}",
+            MethodAttributes.Assembly | MethodAttributes.Static,
+            objectType,
+            adapterParams);
+
+        var il = adapter.GetILGenerator();
+        var arrowParams = typedArrow.GetParameters();
+
+        // Load only as many args as the arrow actually declares, coercing each
+        // boxed object into its typed parameter slot. A 0-/1-param arrow under a
+        // 2-arg delegate (or 1-arg delegate) simply ignores the surplus args.
+        for (int i = 0; i < arrowParams.Length; i++)
+        {
+            EmitLdarg(il, i);
+            DelegateAdapterEmitter.EmitUnboxForReturn(il, arrowParams[i].ParameterType);
+        }
+
+        il.Emit(OpCodes.Call, typedArrow);
+
+        // Rebox the typed result back to object for the Func<object,…> contract.
+        DelegateAdapterEmitter.EmitBoxForTS(il, typedArrow.ReturnType);
+        il.Emit(OpCodes.Ret);
+
+        _cache[key] = adapter;
+        return adapter;
+    }
+
+    private static void EmitLdarg(ILGenerator il, int index)
+    {
+        switch (index)
+        {
+            case 0: il.Emit(OpCodes.Ldarg_0); break;
+            case 1: il.Emit(OpCodes.Ldarg_1); break;
+            case 2: il.Emit(OpCodes.Ldarg_2); break;
+            case 3: il.Emit(OpCodes.Ldarg_3); break;
+            default:
+                if (index <= 255) il.Emit(OpCodes.Ldarg_S, (byte)index);
+                else il.Emit(OpCodes.Ldarg, index);
+                break;
+        }
+    }
+}

--- a/Compilation/ArrowBoxedAdapterEmitter.cs
+++ b/Compilation/ArrowBoxedAdapterEmitter.cs
@@ -50,45 +50,54 @@ internal sealed class ArrowBoxedAdapterEmitter
     private readonly Dictionary<(MethodBuilder, int), MethodBuilder> _cache = [];
 
     /// <summary>
-    /// Returns the boxed adapter for <paramref name="typedArrow"/> bound to a
-    /// delegate of <paramref name="funcArity"/> object parameters, emitting it on
-    /// <paramref name="programType"/> (the arrow's declaring <c>$Program</c> type)
-    /// on first request.
+    /// Returns the boxed adapter for <paramref name="arrowMethod"/> bound to a delegate of
+    /// <paramref name="funcArity"/> object parameters, emitting it on <paramref name="carrierType"/>
+    /// on first request. <paramref name="instance"/> selects the carrier shape:
+    /// <list type="bullet">
+    ///   <item>false (#861 L1): a STATIC adapter on <c>$Program</c> calling the non-capturing
+    ///         static arrow (<c>&lt;&gt;Arrow_N</c>).</item>
+    ///   <item>true (#861 L3): an INSTANCE adapter on the capturing arrow's display class, calling
+    ///         <c>this.Invoke(...)</c>; the caller binds it to <c>(displayInstance, ldftn adapter)</c>.</item>
+    /// </list>
     /// </summary>
-    public MethodBuilder GetOrEmit(TypeBuilder programType, MethodBuilder typedArrow, int funcArity)
+    public MethodBuilder GetOrEmit(TypeBuilder carrierType, MethodBuilder arrowMethod, int funcArity, bool instance)
     {
-        var key = (typedArrow, funcArity);
+        var key = (arrowMethod, funcArity);
         if (_cache.TryGetValue(key, out var existing)) return existing;
 
         var objectType = typeof(object);
         var adapterParams = new Type[funcArity];
         for (int i = 0; i < funcArity; i++) adapterParams[i] = objectType;
 
-        // Assembly-visible static, matching the arrow methods on $Program it calls
-        // into. Name keyed off the arrow's unique method name (e.g. <>Arrow_5) so
-        // two contexts emitting adapters onto the same $Program never collide.
-        var adapter = programType.DefineMethod(
-            $"{typedArrow.Name}$box{funcArity}",
-            MethodAttributes.Assembly | MethodAttributes.Static,
+        // Name keyed off the arrow method's name ($Program-unique <>Arrow_N for static; "Invoke"
+        // for instance, where the per-arrow display class scopes it). Assembly-visible.
+        var attrs = MethodAttributes.Assembly | (instance ? 0 : MethodAttributes.Static);
+        var adapter = carrierType.DefineMethod(
+            $"{arrowMethod.Name}$box{funcArity}",
+            attrs,
             objectType,
             adapterParams);
 
         var il = adapter.GetILGenerator();
-        var arrowParams = typedArrow.GetParameters();
+        var arrowParams = arrowMethod.GetParameters();
+        // For an instance adapter arg0 is `this` (pushed first as the Invoke receiver); the delegate
+        // args then start at arg1. A static adapter's delegate args start at arg0.
+        int argBase = instance ? 1 : 0;
+        if (instance)
+            il.Emit(OpCodes.Ldarg_0);
 
-        // Load only as many args as the arrow actually declares, coercing each
-        // boxed object into its typed parameter slot. A 0-/1-param arrow under a
-        // 2-arg delegate (or 1-arg delegate) simply ignores the surplus args.
+        // Load only as many args as the arrow actually declares, coercing each boxed object into its
+        // typed parameter slot. A 0-/1-param arrow under a wider delegate ignores the surplus args.
         for (int i = 0; i < arrowParams.Length; i++)
         {
-            EmitLdarg(il, i);
+            EmitLdarg(il, argBase + i);
             DelegateAdapterEmitter.EmitUnboxForReturn(il, arrowParams[i].ParameterType);
         }
 
-        il.Emit(OpCodes.Call, typedArrow);
+        il.Emit(instance ? OpCodes.Callvirt : OpCodes.Call, arrowMethod);
 
         // Rebox the typed result back to object for the Func<object,…> contract.
-        DelegateAdapterEmitter.EmitBoxForTS(il, typedArrow.ReturnType);
+        DelegateAdapterEmitter.EmitBoxForTS(il, arrowMethod.ReturnType);
         il.Emit(OpCodes.Ret);
 
         _cache[key] = adapter;

--- a/Compilation/CompilationContext.Closures.cs
+++ b/Compilation/CompilationContext.Closures.cs
@@ -16,6 +16,13 @@ public partial class CompilationContext
     // Arrow function methods (arrow node -> method info)
     public Dictionary<ArrowFunction, MethodBuilder> ArrowMethods { get; set; } = [];
 
+    // Boxed-callback adapters for annotated-param array HOF callbacks (#861).
+    // Lazily created (no constructor plumbing needed); emits per-arrow
+    // object(object[,object]) adapters on $Program so a typed arrow can bind to
+    // the Func<object,…> the Array*Direct helpers expect.
+    private ArrowBoxedAdapterEmitter? _arrowBoxedAdapters;
+    internal ArrowBoxedAdapterEmitter ArrowBoxedAdapters => _arrowBoxedAdapters ??= new ArrowBoxedAdapterEmitter();
+
     // Module-scope const → literal-arrow bindings. Iterator-helper fast paths
     // look up `Expr.Variable` callbacks here so `const sq = x => x*x; arr.map(sq)`
     // gets the same direct-delegate dispatch as the inline-arrow form.

--- a/Compilation/DelegateAdapterEmitter.cs
+++ b/Compilation/DelegateAdapterEmitter.cs
@@ -159,7 +159,13 @@ public class DelegateAdapterEmitter
     /// TS <c>number</c>, <c>bool</c> stays boxed bool, reference types pass through.
     /// Mirrors the interpreter's <c>DotNetMarshaller.WrapReturn</c> for the common primitives.
     /// </summary>
-    private void EmitBoxForTS(ILGenerator il, Type paramType)
+    /// <remarks>
+    /// <c>internal static</c> so the boxed-callback adapter emitter for array HOFs
+    /// (<see cref="ArrowBoxedAdapterEmitter"/>, #861) shares the exact same
+    /// box/unbox conventions — keeping <c>number</c>↔boxed-<c>double</c> etc.
+    /// consistent across every emitted marshalling site.
+    /// </remarks>
+    internal static void EmitBoxForTS(ILGenerator il, Type paramType)
     {
         if (!paramType.IsValueType)
         {
@@ -209,7 +215,13 @@ public class DelegateAdapterEmitter
     /// delegate's declared return type. void: pop. object: no-op. value types: unbox via
     /// boxed-double (matching <see cref="EmitBoxForTS"/>). Reference types: castclass.
     /// </summary>
-    private void EmitUnboxForReturn(ILGenerator il, Type returnType)
+    /// <remarks>
+    /// <c>internal static</c>: also used by <see cref="ArrowBoxedAdapterEmitter"/>
+    /// (#861) to coerce a boxed array element into an arrow's typed parameter slot
+    /// (the inverse role), so the unbox/cast matches the reflective
+    /// <c>MethodInvoker</c> path exactly.
+    /// </remarks>
+    internal static void EmitUnboxForReturn(ILGenerator il, Type returnType)
     {
         if (returnType == typeof(void))
         {

--- a/Compilation/Emitters/ArrayEmitter.cs
+++ b/Compilation/Emitters/ArrayEmitter.cs
@@ -13,46 +13,62 @@ public sealed class ArrayEmitter : ITypeEmitterStrategy
     /// Attempts to emit IL for a method call on an array receiver.
     /// </summary>
     public bool TryEmitMethodCall(IEmitterContext emitter, Expr receiver, string methodName, List<Expr> arguments)
+        => TryEmitMethodCall(emitter, receiver, methodName, arguments, leaveResultAsBareList: false);
+
+    /// <summary>
+    /// Core array-method emitter. <paramref name="leaveResultAsBareList"/> is set by the chained-stage
+    /// fast path (#861 L2): when this call's array result flows DIRECTLY into another array-method call,
+    /// the returnsNewArray <c>$Array</c> wrap is skipped so the bare <c>List&lt;object&gt;</c> feeds
+    /// straight into the next stage — eliminating the wrap-then-unwrap round-trip.
+    /// </summary>
+    private bool TryEmitMethodCall(IEmitterContext emitter, Expr receiver, string methodName, List<Expr> arguments, bool leaveResultAsBareList)
     {
         var ctx = emitter.Context;
         var il = ctx.IL;
 
-        // Emit the array object
-        emitter.EmitExpression(receiver);
-        emitter.EmitBoxIfNeeded(receiver);
-
-        // Handle both List<object> and $Array types
-        // For $Array, extract the Elements property.
-        // The returned local holds the ORIGINAL receiver, used below for
-        // identity-preserving methods (sort/reverse/fill/copyWithin) and to
-        // wrap "new array" method results back into $Array so downstream
-        // code sees a $Array whenever the input was one.
-        var receiverLocal = EmitGetListFromArrayOrList(il, ctx);
-
-        // Methods whose spec says "return this" — the caller expects the same
-        // reference the receiver started with. Since we unwrapped to a List,
-        // the runtime helper returns the inner List, not the $Array wrapper;
-        // to preserve `arr === arr.sort()` we stash the wrapper and push it
-        // back at the end.
+        // Methods whose spec says "return this" — the caller expects the same reference the receiver
+        // started with (sort/reverse/fill/copyWithin). Since we unwrap to a List, the helper returns the
+        // inner List, not the $Array wrapper; to preserve `arr === arr.sort()` we stash the wrapper and
+        // push it back at the end.
         bool returnsReceiver = methodName is "sort" or "reverse" or "fill" or "copyWithin";
-        // Methods whose spec says "return a new Array" — we want callers to
-        // continue seeing a $Array after them (not a bare List<object?>), so
-        // downstream array methods / runtime dispatch still match.
-        bool returnsNewArray = methodName is
-            "slice" or "concat" or "map" or "filter" or "flat" or "flatMap"
-            or "splice" or "toReversed" or "toSorted" or "toSpliced" or "with";
+        // Methods whose spec says "return a new Array" — callers should keep seeing a $Array after them
+        // (not a bare List<object?>), so downstream array methods / runtime dispatch still match.
+        bool returnsNewArray = IsReturnsNewArrayMethod(methodName);
 
         // #850: when an argument can suspend (await/yield), evaluating it while the receiver list sits
-        // on the IL evaluation stack produces invalid IL across a state-machine suspension
-        // (PathStackDepth — the stack differs between the "awaiter completed" and post-resume paths).
-        // Pre-spill the receiver and every argument into await-safe locals (registered so they survive
-        // the MoveNext re-entry; plain locals in the synchronous emitter, so non-async codegen is
-        // unchanged), then restore the list on the stack so each case below emits exactly as before but
-        // sources its arguments from the pre-spilled locals. Only the plain-argument methods are
-        // affected; the callback methods (map/filter/find/...) dispatch their arrow from the AST and
-        // never trigger this — an arrow body's await belongs to its own state machine.
+        // on the IL evaluation stack produces invalid IL across a state-machine suspension. Pre-spill the
+        // receiver + args into await-safe locals (callback methods never trigger this — an arrow body's
+        // await belongs to its own state machine).
+        bool plainArgSuspension = arguments.Count > 0 && MethodTakesPlainArgs(methodName)
+            && emitter.ArgsContainSuspension(arguments);
+
+        // The receiver local holds the ORIGINAL receiver, used by returnsReceiver methods and the
+        // suspension spill below; unused for the other methods.
+        LocalBuilder receiverLocal;
+
+        // #861 L2: if the receiver is itself an array-method call producing a fresh array via THIS
+        // emitter (e.g. the a.map(f) in a.map(f).filter(g)), emit it leaving a bare List<object> (its
+        // $Array wrap suppressed) and skip the unwrap here — killing the round-trip at the boundary. The
+        // intermediate array is anonymous (it can only be this one call's receiver), so dropping its
+        // $Array identity is unobservable. Disabled when the outer method needs the original receiver
+        // wrapper (returnsReceiver) or pre-spills suspending plain args (the chained receiver would sit
+        // on the stack across the suspension).
+        if (!returnsReceiver && !plainArgSuspension
+            && TryEmitChainedArrayReceiverAsBareList(emitter, receiver))
+        {
+            // Bare List<object> already on the stack; receiverLocal is never read in this path.
+            receiverLocal = il.DeclareLocal(ctx.Types.ListOfObject);
+        }
+        else
+        {
+            // General path: emit the array object and unwrap $Array → List<object>.
+            emitter.EmitExpression(receiver);
+            emitter.EmitBoxIfNeeded(receiver);
+            receiverLocal = EmitGetListFromArrayOrList(il, ctx);
+        }
+
         LocalBuilder[]? argLocals = null;
-        if (arguments.Count > 0 && MethodTakesPlainArgs(methodName) && emitter.ArgsContainSuspension(arguments))
+        if (plainArgSuspension)
         {
             var listSafe = emitter.SpillStackToObjectLocal();      // [list] -> await-safe local
             il.Emit(OpCodes.Ldloc, receiverLocal);                 // the original receiver must also
@@ -355,8 +371,38 @@ public sealed class ArrayEmitter : ITypeEmitterStrategy
                 return false;
         }
 
-        EmitPostCallAdjust(il, ctx, receiverLocal, returnsReceiver, returnsNewArray);
+        // #861 L2: when this result flows straight into a chained array call, skip the $Array wrap and
+        // leave the bare List<object> on the stack for the next stage.
+        if (!(leaveResultAsBareList && returnsNewArray))
+            EmitPostCallAdjust(il, ctx, receiverLocal, returnsReceiver, returnsNewArray);
         return true;
+    }
+
+    /// <summary>The methods whose spec result is a freshly-allocated array (kept as a $Array for callers).</summary>
+    private static bool IsReturnsNewArrayMethod(string methodName) => methodName is
+        "slice" or "concat" or "map" or "filter" or "flat" or "flatMap"
+        or "splice" or "toReversed" or "toSorted" or "toSpliced" or "with";
+
+    /// <summary>
+    /// #861 L2 chained-stage detection. If <paramref name="receiver"/> is a call to a fresh-array-
+    /// producing array method on an array receiver (the <c>a.map(f)</c> in <c>a.map(f).filter(g)</c>),
+    /// emit that inner call leaving a bare <c>List&lt;object&gt;</c> on the stack — its <c>$Array</c> wrap
+    /// suppressed — and return true. The intermediate array is anonymous (it can only be this one outer
+    /// call's receiver), so dropping its <c>$Array</c> identity is unobservable. Returns false (emitting
+    /// nothing) otherwise.
+    /// </summary>
+    private bool TryEmitChainedArrayReceiverAsBareList(IEmitterContext emitter, Expr receiver)
+    {
+        if (receiver is not Expr.Call { Optional: false, Callee: Expr.Get { Optional: false } innerGet } innerCall)
+            return false;
+        string innerMethod = innerGet.Name.Lexeme;
+        // Must be a returnsNewArray method handled by THIS emitter (so it leaves a List on the stack).
+        if (!IsReturnsNewArrayMethod(innerMethod)) return false;
+        // The inner call's receiver must statically be an array, so the inner call goes through this
+        // emitter's returnsNewArray path and the recursion leaves a List<object> (not some other value).
+        if (emitter.Context.TypeMap?.Get(innerGet.Object) is not SharpTS.TypeSystem.TypeInfo.Array)
+            return false;
+        return TryEmitMethodCall(emitter, innerGet.Object, innerMethod, innerCall.Arguments, leaveResultAsBareList: true);
     }
 
     /// <summary>

--- a/Compilation/Emitters/ArrayEmitter.cs
+++ b/Compilation/Emitters/ArrayEmitter.cs
@@ -877,13 +877,17 @@ public sealed class ArrayEmitter : ITypeEmitterStrategy
         // Typed-param adapter path (#861): an annotated callback compiles to a
         // typed static method (e.g. double(double)/bool(double)) that cannot bind
         // to Func<object, object> directly. Bind a per-arrow boxed adapter that
-        // marshals object↔typed around the arrow call, then drive the existing
-        // object-callback helper. The boxed bool predicate result is handled by
-        // the helper's own IsTruthy (so the boolHelper/Direct-bool variant is a
-        // later refinement, #861 L4).
-        if (!TryBindTypedArrowAdapter(emitter, af, staticMethod, funcArity: 1))
+        // marshals object↔typed around the arrow call, then drive the matching
+        // Array*Direct helper.
+        //
+        // #861 L4: when the predicate arrow returns `bool` and a Func<object, bool>
+        // helper variant exists (filter/find/findIndex/some/every), emit a
+        // bool-returning adapter and call that variant — skipping the per-element
+        // result box + IsTruthy the object helper would otherwise do.
+        bool wantBool = boolHelper != null && staticMethod.ReturnType == ctx.Types.Boolean;
+        if (!TryBindTypedArrowAdapter(emitter, af, staticMethod, funcArity: 1, boolReturn: wantBool))
             return false;
-        ctx.IL.Emit(OpCodes.Call, helperMethod);
+        ctx.IL.Emit(OpCodes.Call, wantBool ? boolHelper! : helperMethod);
         return true;
     }
 
@@ -898,7 +902,8 @@ public sealed class ArrayEmitter : ITypeEmitterStrategy
         IEmitterContext emitter,
         Expr.ArrowFunction af,
         System.Reflection.Emit.MethodBuilder arrowMethod,
-        int funcArity)
+        int funcArity,
+        bool boolReturn)
     {
         var ctx = emitter.Context;
 
@@ -910,9 +915,11 @@ public sealed class ArrayEmitter : ITypeEmitterStrategy
         foreach (var p in arrowMethod.GetParameters())
             if (!IsAdapterMarshallable(ctx, p.ParameterType)) return false;
 
-        Type funcType = funcArity == 2
-            ? typeof(Func<object, object, object>)
-            : typeof(Func<object, object>);
+        // boolReturn (#861 L4) binds Func<object, bool> for a bool-returning predicate so the
+        // *DirectBool helper consumes an unboxed bool. Only the 1-arg predicate helpers pass it.
+        Type funcType = boolReturn
+            ? typeof(Func<object, bool>)
+            : (funcArity == 2 ? typeof(Func<object, object, object>) : typeof(Func<object, object>));
         var funcCtor = funcType.GetConstructor([typeof(object), typeof(IntPtr)])!;
 
         if (ctx.DisplayClasses.TryGetValue(af, out var displayClass))
@@ -921,7 +928,7 @@ public sealed class ArrayEmitter : ITypeEmitterStrategy
             // Emit an INSTANCE adapter, build the display instance (capturing live locals), then bind
             // (displayInstance, ldftn adapter). The display instance is built fresh at the call site,
             // exactly as the reflective $TSFunction path does.
-            var adapter = ctx.ArrowBoxedAdapters.GetOrEmit(displayClass, arrowMethod, funcArity, instance: true);
+            var adapter = ctx.ArrowBoxedAdapters.GetOrEmit(displayClass, arrowMethod, funcArity, instance: true, boolReturn: boolReturn);
             if (!emitter.TryEmitCapturingArrowDisplayInstance(af))
                 return false;                                          // Stack: [displayInstance]
             ctx.IL.Emit(OpCodes.Ldftn, adapter);
@@ -933,7 +940,7 @@ public sealed class ArrayEmitter : ITypeEmitterStrategy
         // Using DeclaringType (rather than ctx.ProgramType, set only on the top-level context) lets the
         // adapter fire inside function/method bodies too. Bind (null, ldftn adapter).
         if (arrowMethod.DeclaringType is not TypeBuilder programType) return false;
-        var staticAdapter = ctx.ArrowBoxedAdapters.GetOrEmit(programType, arrowMethod, funcArity, instance: false);
+        var staticAdapter = ctx.ArrowBoxedAdapters.GetOrEmit(programType, arrowMethod, funcArity, instance: false, boolReturn: boolReturn);
         ctx.IL.Emit(OpCodes.Ldnull);
         ctx.IL.Emit(OpCodes.Ldftn, staticAdapter);
         ctx.IL.Emit(OpCodes.Newobj, funcCtor);
@@ -987,7 +994,7 @@ public sealed class ArrayEmitter : ITypeEmitterStrategy
         {
             // Annotated reducer (e.g. double(double,double)): bridge via a boxed
             // adapter object(object,object).
-            if (!TryBindTypedArrowAdapter(emitter, af, staticMethod, funcArity: 2))
+            if (!TryBindTypedArrowAdapter(emitter, af, staticMethod, funcArity: 2, boolReturn: false))
                 return false;
         }
         // Push initial value (boxed object).

--- a/Compilation/Emitters/ArrayEmitter.cs
+++ b/Compilation/Emitters/ArrayEmitter.cs
@@ -897,37 +897,45 @@ public sealed class ArrayEmitter : ITypeEmitterStrategy
     private static bool TryBindTypedArrowAdapter(
         IEmitterContext emitter,
         Expr.ArrowFunction af,
-        System.Reflection.Emit.MethodBuilder staticMethod,
+        System.Reflection.Emit.MethodBuilder arrowMethod,
         int funcArity)
     {
         var ctx = emitter.Context;
-        // Capturing arrows (display class) need an instance receiver — defer to the
-        // reflective path (#861 L3).
-        if (ctx.DisplayClasses.ContainsKey(af)) return false;
-        // The adapter is emitted onto the arrow's declaring $Program type. Using the
-        // arrow's DeclaringType (rather than ctx.ProgramType, which is only set on
-        // the module-top-level context) lets the adapter path fire inside function
-        // and method bodies too — the dominant case for the array-methods benchmark.
-        if (staticMethod.DeclaringType is not TypeBuilder programType) return false;
 
-        // Marshallable gate: stay in the reflective path's no-arg-conversion regime
-        // (concrete double/bool/string, or object) so the adapter's unbox/cast
-        // matches MethodInvoker semantics exactly. Union/nullable params already
-        // widen to object in ParameterTypeResolver, so a non-object slot here is a
-        // concrete value/reference type.
-        if (!IsAdapterMarshallable(ctx, staticMethod.ReturnType)) return false;
-        foreach (var sp in staticMethod.GetParameters())
-            if (!IsAdapterMarshallable(ctx, sp.ParameterType)) return false;
+        // Marshallable gate (shared): stay in the reflective path's no-arg-conversion regime
+        // (concrete double/bool/string, or object) so the adapter's unbox/cast matches MethodInvoker
+        // semantics exactly. Union/nullable params already widen to object in ParameterTypeResolver, so
+        // a non-object slot here is a concrete value/reference type.
+        if (!IsAdapterMarshallable(ctx, arrowMethod.ReturnType)) return false;
+        foreach (var p in arrowMethod.GetParameters())
+            if (!IsAdapterMarshallable(ctx, p.ParameterType)) return false;
 
-        var adapter = ctx.ArrowBoxedAdapters.GetOrEmit(programType, staticMethod, funcArity);
         Type funcType = funcArity == 2
             ? typeof(Func<object, object, object>)
             : typeof(Func<object, object>);
         var funcCtor = funcType.GetConstructor([typeof(object), typeof(IntPtr)])!;
 
-        // Non-capturing static adapter: target = null, ldftn the adapter.
+        if (ctx.DisplayClasses.TryGetValue(af, out var displayClass))
+        {
+            // #861 L3: capturing arrow — arrowMethod is the instance Invoke on the display class.
+            // Emit an INSTANCE adapter, build the display instance (capturing live locals), then bind
+            // (displayInstance, ldftn adapter). The display instance is built fresh at the call site,
+            // exactly as the reflective $TSFunction path does.
+            var adapter = ctx.ArrowBoxedAdapters.GetOrEmit(displayClass, arrowMethod, funcArity, instance: true);
+            if (!emitter.TryEmitCapturingArrowDisplayInstance(af))
+                return false;                                          // Stack: [displayInstance]
+            ctx.IL.Emit(OpCodes.Ldftn, adapter);
+            ctx.IL.Emit(OpCodes.Newobj, funcCtor);
+            return true;
+        }
+
+        // #861 L1: non-capturing arrow — arrowMethod is a static method on its declaring $Program type.
+        // Using DeclaringType (rather than ctx.ProgramType, set only on the top-level context) lets the
+        // adapter fire inside function/method bodies too. Bind (null, ldftn adapter).
+        if (arrowMethod.DeclaringType is not TypeBuilder programType) return false;
+        var staticAdapter = ctx.ArrowBoxedAdapters.GetOrEmit(programType, arrowMethod, funcArity, instance: false);
         ctx.IL.Emit(OpCodes.Ldnull);
-        ctx.IL.Emit(OpCodes.Ldftn, adapter);
+        ctx.IL.Emit(OpCodes.Ldftn, staticAdapter);
         ctx.IL.Emit(OpCodes.Newobj, funcCtor);
         return true;
     }

--- a/Compilation/Emitters/ArrayEmitter.cs
+++ b/Compilation/Emitters/ArrayEmitter.cs
@@ -781,43 +781,114 @@ public sealed class ArrayEmitter : ITypeEmitterStrategy
         if (af.Parameters.Count > 1) return false;
         foreach (var p in af.Parameters)
         {
-            if (p.Type != null) return false;
+            // Annotated params (p.Type != null) are now supported via a boxed
+            // adapter (#861) — see the typed-param path below. Rest/optional/
+            // defaulted params still bail (they need the reflective arg shape).
             if (p.IsRest || p.IsOptional) return false;
             if (p.DefaultValue != null) return false;
         }
         if (!ctx.ArrowMethods.TryGetValue(af, out var staticMethod)) return false;
 
-        // Static method's parameter types are guaranteed to be `object` by the
-        // AST-no-annotation check (ParameterTypeResolver falls back to object).
-        // Return type is the discriminator: type inference may yield `object`
-        // (any-typed bodies) or `bool` (predicate bodies like `v => v > 10`).
-        // The first uses Func<object, object>; the second uses Func<object, bool>
-        // where the helper variant exists. Phase B: capturing arrows now go
-        // through emitter.TryEmitArrowAsDelegate, which builds the display
-        // instance + binds the delegate to its Invoke method.
-        var ret = staticMethod.ReturnType;
-        System.Reflection.Emit.MethodBuilder chosenHelper;
-        Type funcType;
-        if (ret == ctx.Types.Object)
+        var sParams = staticMethod.GetParameters();
+        bool allParamsObject = true;
+        foreach (var sp in sParams)
+            if (sp.ParameterType != ctx.Types.Object) { allParamsObject = false; break; }
+
+        if (allParamsObject)
         {
-            chosenHelper = helperMethod;
-            funcType = typeof(Func<object, object>);
-        }
-        else if (ret == ctx.Types.Boolean && boolHelper != null)
-        {
-            chosenHelper = boolHelper;
-            funcType = typeof(Func<object, bool>);
-        }
-        else
-        {
-            return false;
+            // Untyped fast path (unchanged). The arrow's static method already has
+            // `object` parameter slots (unannotated params; ParameterTypeResolver
+            // falls back to object), so it binds directly to Func<object, …>. The
+            // return type is the discriminator: `object` (any-typed body) uses
+            // Func<object, object> + helperMethod; `bool` (predicate body like
+            // `v => v > 10`) uses Func<object, bool> + boolHelper where present.
+            // Capturing arrows go through emitter.TryEmitArrowAsDelegate, which
+            // builds the display instance + binds to its Invoke method.
+            var ret = staticMethod.ReturnType;
+            System.Reflection.Emit.MethodBuilder chosenHelper;
+            Type funcType;
+            if (ret == ctx.Types.Object)
+            {
+                chosenHelper = helperMethod;
+                funcType = typeof(Func<object, object>);
+            }
+            else if (ret == ctx.Types.Boolean && boolHelper != null)
+            {
+                chosenHelper = boolHelper;
+                funcType = typeof(Func<object, bool>);
+            }
+            else
+            {
+                return false;
+            }
+
+            if (!emitter.TryEmitArrowAsDelegate(af, funcType))
+                return false;
+            ctx.IL.Emit(OpCodes.Call, chosenHelper);
+            return true;
         }
 
-        if (!emitter.TryEmitArrowAsDelegate(af, funcType))
+        // Typed-param adapter path (#861): an annotated callback compiles to a
+        // typed static method (e.g. double(double)/bool(double)) that cannot bind
+        // to Func<object, object> directly. Bind a per-arrow boxed adapter that
+        // marshals object↔typed around the arrow call, then drive the existing
+        // object-callback helper. The boxed bool predicate result is handled by
+        // the helper's own IsTruthy (so the boolHelper/Direct-bool variant is a
+        // later refinement, #861 L4).
+        if (!TryBindTypedArrowAdapter(emitter, af, staticMethod, funcArity: 1))
             return false;
-        ctx.IL.Emit(OpCodes.Call, chosenHelper);
+        ctx.IL.Emit(OpCodes.Call, helperMethod);
         return true;
     }
+
+    /// <summary>
+    /// Binds a per-arrow boxed adapter (object(object[,object])) for an annotated,
+    /// non-capturing callback arrow to a Func&lt;object,…&gt; of
+    /// <paramref name="funcArity"/> parameters, leaving the delegate on the stack
+    /// for the caller to pass to an Array*Direct helper. Returns false (reflective
+    /// fallback) for capturing arrows or any non-marshallable param/return type.
+    /// </summary>
+    private static bool TryBindTypedArrowAdapter(
+        IEmitterContext emitter,
+        Expr.ArrowFunction af,
+        System.Reflection.Emit.MethodBuilder staticMethod,
+        int funcArity)
+    {
+        var ctx = emitter.Context;
+        // Capturing arrows (display class) need an instance receiver — defer to the
+        // reflective path (#861 L3).
+        if (ctx.DisplayClasses.ContainsKey(af)) return false;
+        // The adapter is emitted onto the arrow's declaring $Program type. Using the
+        // arrow's DeclaringType (rather than ctx.ProgramType, which is only set on
+        // the module-top-level context) lets the adapter path fire inside function
+        // and method bodies too — the dominant case for the array-methods benchmark.
+        if (staticMethod.DeclaringType is not TypeBuilder programType) return false;
+
+        // Marshallable gate: stay in the reflective path's no-arg-conversion regime
+        // (concrete double/bool/string, or object) so the adapter's unbox/cast
+        // matches MethodInvoker semantics exactly. Union/nullable params already
+        // widen to object in ParameterTypeResolver, so a non-object slot here is a
+        // concrete value/reference type.
+        if (!IsAdapterMarshallable(ctx, staticMethod.ReturnType)) return false;
+        foreach (var sp in staticMethod.GetParameters())
+            if (!IsAdapterMarshallable(ctx, sp.ParameterType)) return false;
+
+        var adapter = ctx.ArrowBoxedAdapters.GetOrEmit(programType, staticMethod, funcArity);
+        Type funcType = funcArity == 2
+            ? typeof(Func<object, object, object>)
+            : typeof(Func<object, object>);
+        var funcCtor = funcType.GetConstructor([typeof(object), typeof(IntPtr)])!;
+
+        // Non-capturing static adapter: target = null, ldftn the adapter.
+        ctx.IL.Emit(OpCodes.Ldnull);
+        ctx.IL.Emit(OpCodes.Ldftn, adapter);
+        ctx.IL.Emit(OpCodes.Newobj, funcCtor);
+        return true;
+    }
+
+    private static bool IsAdapterMarshallable(CompilationContext ctx, Type t)
+        => t == ctx.Types.Object || t == ctx.Types.Double
+        || t == ctx.Types.Boolean || t == ctx.Types.String;
 
     /// <summary>
     /// Reduce-specific fast path: the callback is binary
@@ -839,17 +910,32 @@ public sealed class ArrayEmitter : ITypeEmitterStrategy
         if (af.Parameters.Count != 2) return false;
         foreach (var p in af.Parameters)
         {
-            if (p.Type != null) return false;
+            // Annotated params now supported via a boxed adapter (#861).
             if (p.IsRest || p.IsOptional) return false;
             if (p.DefaultValue != null) return false;
         }
         if (!ctx.ArrowMethods.TryGetValue(af, out var staticMethod)) return false;
-        if (staticMethod.ReturnType != ctx.Types.Object) return false;
 
-        var func3 = typeof(Func<object, object, object>);
-        // Stack: [list]. Build delegate (capturing or non-capturing).
-        if (!emitter.TryEmitArrowAsDelegate(af, func3))
-            return false;
+        var sParams = staticMethod.GetParameters();
+        bool allObject = staticMethod.ReturnType == ctx.Types.Object;
+        if (allObject)
+            foreach (var sp in sParams)
+                if (sp.ParameterType != ctx.Types.Object) { allObject = false; break; }
+
+        // Stack: [list]. Build the (acc, element) => newAcc delegate.
+        if (allObject)
+        {
+            // Untyped fast path (unchanged): object(object,object) binds directly.
+            if (!emitter.TryEmitArrowAsDelegate(af, typeof(Func<object, object, object>)))
+                return false;
+        }
+        else
+        {
+            // Annotated reducer (e.g. double(double,double)): bridge via a boxed
+            // adapter object(object,object).
+            if (!TryBindTypedArrowAdapter(emitter, af, staticMethod, funcArity: 2))
+                return false;
+        }
         // Push initial value (boxed object).
         emitter.EmitExpression(arguments[1]);
         emitter.EmitBoxIfNeeded(arguments[1]);

--- a/Compilation/Emitters/IEmitterContext.cs
+++ b/Compilation/Emitters/IEmitterContext.cs
@@ -124,4 +124,13 @@ public interface IEmitterContext
     /// path when this returns false.
     /// </summary>
     bool TryEmitArrowAsDelegate(Expr.ArrowFunction af, Type delegateType);
+
+    /// <summary>
+    /// Builds the display-class instance for a capturing arrow (<c>new DisplayClass()</c>
+    /// + populate captured fields), leaving it on the stack. Used by the array-HOF boxed-
+    /// adapter fast path (#861 L3) to bind an instance adapter to <c>(displayInstance, ldftn
+    /// instanceAdapter)</c>. Returns false (without emitting) for unsupported emitters or when
+    /// the arrow has no registered display class.
+    /// </summary>
+    bool TryEmitCapturingArrowDisplayInstance(Expr.ArrowFunction af);
 }

--- a/Compilation/ExpressionEmitterBase.cs
+++ b/Compilation/ExpressionEmitterBase.cs
@@ -58,6 +58,15 @@ public abstract partial class ExpressionEmitterBase : IEmitterContext
     /// </summary>
     protected virtual bool TryEmitArrowAsDelegate(Expr.ArrowFunction af, Type delegateType) => false;
 
+    bool IEmitterContext.TryEmitCapturingArrowDisplayInstance(Expr.ArrowFunction af)
+        => TryEmitCapturingArrowDisplayInstance(af);
+
+    /// <summary>
+    /// Default: only <see cref="ILEmitter"/> can build a capturing arrow's display
+    /// instance (the display machinery lives there). Other contexts decline (#861 L3).
+    /// </summary>
+    protected virtual bool TryEmitCapturingArrowDisplayInstance(Expr.ArrowFunction af) => false;
+
     #endregion
 
     protected readonly StateMachineEmitHelpers _helpers;

--- a/Compilation/ILEmitter.Calls.Closures.cs
+++ b/Compilation/ILEmitter.Calls.Closures.cs
@@ -52,6 +52,21 @@ public partial class ILEmitter
         return true;
     }
 
+    /// <summary>
+    /// #861 L3: builds a capturing arrow's display-class instance on the stack so the array-HOF
+    /// boxed-adapter path can bind an instance adapter to it. Returns false if the arrow has no
+    /// registered display class / constructor.
+    /// </summary>
+    protected override bool TryEmitCapturingArrowDisplayInstance(Expr.ArrowFunction af)
+    {
+        if (!_ctx.DisplayClasses.TryGetValue(af, out var displayClass))
+            return false;
+        if (!EmitCapturingArrowDisplayInstance(af, displayClass))
+            return false;
+        SetStackUnknown();
+        return true;
+    }
+
     protected override void EmitArrowFunction(Expr.ArrowFunction af)
     {
         // Check if this is an async arrow function with a state machine

--- a/SharpTS.Tests/SharedTests/ArrayHofAnnotatedCallbackTests.cs
+++ b/SharpTS.Tests/SharedTests/ArrayHofAnnotatedCallbackTests.cs
@@ -1,0 +1,210 @@
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests;
+
+/// <summary>
+/// Tests for #861: array higher-order-function callbacks (map/filter/reduce/forEach/
+/// find/some/every) whose arrow has ANNOTATED parameters are de-virtualized in compiled
+/// mode. An annotated callback like <c>(x: number): number =&gt; x*2</c> compiles to a typed
+/// static method (<c>double(double)</c>) that cannot bind to the <c>Func&lt;object,object&gt;</c>
+/// the <c>Array*Direct</c> helpers expect; a per-arrow boxed adapter bridges it, so the
+/// per-element reflective <c>$TSFunction</c>/<c>MethodInvoker</c> dispatch is removed.
+///
+/// These run against BOTH the interpreter and the compiler. The point is interpreter/compiled
+/// parity: the adapter's unbox/box must match the reflective path exactly, and the cases that
+/// fall back (capturing arrows, multi-arg callbacks) must still produce correct results. A
+/// wrong adapter coercion or a mis-fired fast path surfaces here as a compiled-mode mismatch.
+/// </summary>
+public class ArrayHofAnnotatedCallbackTests
+{
+    // ── Adapter path: annotated callbacks inside a function (the benchmark shape) ──
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AnnotatedMap_Number(ExecutionMode mode)
+    {
+        var source = """
+            function f(): string {
+                const a: number[] = [1, 2, 3, 4, 5];
+                return a.map((x: number): number => x * 2).join(",");
+            }
+            console.log(f());
+            """;
+        Assert.Equal("2,4,6,8,10\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AnnotatedFilter_BooleanPredicate(ExecutionMode mode)
+    {
+        var source = """
+            function f(): string {
+                const a: number[] = [1, 2, 3, 4, 5, 6];
+                return a.filter((x: number): boolean => x % 2 === 0).join(",");
+            }
+            console.log(f());
+            """;
+        Assert.Equal("2,4,6\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AnnotatedReduce_TwoTypedParams(ExecutionMode mode)
+    {
+        var source = """
+            function f(): number {
+                const a: number[] = [1, 2, 3, 4, 5];
+                return a.reduce((acc: number, x: number): number => acc + x, 0);
+            }
+            console.log(f());
+            """;
+        Assert.Equal("15\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AnnotatedChain_MapFilterReduce(ExecutionMode mode)
+    {
+        // The array-methods benchmark shape: every callback param is annotated.
+        var source = """
+            function arrayMethodWork(n: number): number {
+                const arr: number[] = [];
+                for (let i: number = 0; i < n; i++) { arr.push(i); }
+                const doubled = arr.map((x: number): number => x * 2);
+                const evens = doubled.filter((x: number): boolean => x % 4 === 0);
+                return evens.reduce((acc: number, x: number): number => acc + x, 0);
+            }
+            console.log(arrayMethodWork(10));
+            """;
+        Assert.Equal("40\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AnnotatedPredicates_FindSomeEveryFindIndex(ExecutionMode mode)
+    {
+        var source = """
+            function f(): string {
+                const a: number[] = [1, 2, 3, 4, 5];
+                const found = a.find((x: number): boolean => x > 3);
+                const hasBig = a.some((x: number): boolean => x > 4);
+                const allPos = a.every((x: number): boolean => x > 0);
+                const idx = a.findIndex((x: number): boolean => x === 3);
+                return found + "," + hasBig + "," + allPos + "," + idx;
+            }
+            console.log(f());
+            """;
+        Assert.Equal("4,true,true,2\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AnnotatedForEach_Void(ExecutionMode mode)
+    {
+        var source = """
+            function f(): number {
+                const a: number[] = [1, 2, 3, 4];
+                let sum: number = 0;
+                a.forEach((x: number): void => { sum = sum + x; });
+                return sum;
+            }
+            console.log(f());
+            """;
+        Assert.Equal("10\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AnnotatedStringParam_MapsToLength(ExecutionMode mode)
+    {
+        var source = """
+            function f(): string {
+                const s: string[] = ["ab", "c", "defg"];
+                return s.map((w: string): number => w.length).join(",");
+            }
+            console.log(f());
+            """;
+        Assert.Equal("2,1,4\n", TestHarness.Run(source, mode));
+    }
+
+    // ── Coercion parity: non-integer / NaN elements must marshal identically ──
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AnnotatedMap_FloatAndNaN(ExecutionMode mode)
+    {
+        var source = """
+            function f(): string {
+                const b: number[] = [1.5, NaN, 3];
+                return b.map((x: number): number => x + 1).join(",");
+            }
+            console.log(f());
+            """;
+        Assert.Equal("2.5,NaN,4\n", TestHarness.Run(source, mode));
+    }
+
+    // ── Fallback cases: must NOT take the 1-arg adapter, must stay correct ──
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void MultiArgCallback_UsesIndex_FallsBack(ExecutionMode mode)
+    {
+        // 2-param map callback uses the index → arity guard keeps it on the reflective
+        // path; result must still be correct.
+        var source = """
+            function f(): string {
+                const a: number[] = [10, 20, 30];
+                return a.map((x: number, i: number): number => x + i).join(",");
+            }
+            console.log(f());
+            """;
+        Assert.Equal("10,21,32\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void CapturingAnnotatedArrow_FallsBack(ExecutionMode mode)
+    {
+        // Capturing arrow → adapter path is skipped (needs an instance receiver);
+        // reflective fallback must still produce the captured value correctly.
+        var source = """
+            function f(): string {
+                const a: number[] = [1, 2, 3];
+                const k: number = 10;
+                return a.map((x: number): number => x + k).join(",");
+            }
+            console.log(f());
+            """;
+        Assert.Equal("11,12,13\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void UntypedCallback_StillWorks(ExecutionMode mode)
+    {
+        // Unannotated callback keeps the pre-existing untyped direct/reflective path.
+        var source = """
+            function f(): string {
+                const a: number[] = [1, 2, 3, 4, 5];
+                return a.map(x => x + 1).join(",");
+            }
+            console.log(f());
+            """;
+        Assert.Equal("2,3,4,5,6\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ConstBoundAnnotatedCallback_Resolves(ExecutionMode mode)
+    {
+        // const-bound arrow callback resolves through ConstArrowBindings and takes the
+        // adapter path when annotated.
+        var source = """
+            const dbl = (x: number): number => x * 2;
+            const out = [3, 4, 5].map(dbl).join(",");
+            console.log(out);
+            """;
+        Assert.Equal("6,8,10\n", TestHarness.Run(source, mode));
+    }
+}

--- a/SharpTS.Tests/SharedTests/ArrayHofAnnotatedCallbackTests.cs
+++ b/SharpTS.Tests/SharedTests/ArrayHofAnnotatedCallbackTests.cs
@@ -218,6 +218,40 @@ public class ArrayHofAnnotatedCallbackTests
 
     [Theory]
     [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void CapturingBooleanPredicate_Filter(ExecutionMode mode)
+    {
+        // L3 (capturing instance adapter) + L4 (bool-returning adapter → *DirectBool): a captured
+        // threshold in a typed boolean predicate must still filter correctly.
+        var source = """
+            function f(): string {
+                const a: number[] = [1, 2, 3, 4, 5, 6];
+                const t: number = 3;
+                return a.filter((x: number): boolean => x > t).join(",");
+            }
+            console.log(f());
+            """;
+        Assert.Equal("4,5,6\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void BooleanPredicate_SomeEvery_ShortCircuit(ExecutionMode mode)
+    {
+        // L4 bool adapter under the short-circuiting some/every must agree with the reflective path.
+        var source = """
+            function f(): string {
+                const a: number[] = [2, 4, 6, 7, 8];
+                const someOdd = a.some((x: number): boolean => x % 2 === 1);
+                const allEven = a.every((x: number): boolean => x % 2 === 0);
+                return someOdd + "," + allEven;
+            }
+            console.log(f());
+            """;
+        Assert.Equal("true,false\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void CapturingAnnotatedArrow_Chained(ExecutionMode mode)
     {
         // Capturing arrows across a chained map().filter().reduce() (L1 capturing adapter + L2 round-trip).

--- a/SharpTS.Tests/SharedTests/ArrayHofAnnotatedCallbackTests.cs
+++ b/SharpTS.Tests/SharedTests/ArrayHofAnnotatedCallbackTests.cs
@@ -194,6 +194,71 @@ public class ArrayHofAnnotatedCallbackTests
         Assert.Equal("2,3,4,5,6\n", TestHarness.Run(source, mode));
     }
 
+    // ── #861 L2: chained-stage round-trip elimination ──
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ChainedMapFilter_AssignedToArrayVariable(ExecutionMode mode)
+    {
+        // The final stage's result is consumed as an array value, so its $Array wrap must be
+        // preserved (only the intermediate map result drops it). `.join` then works on it.
+        var source = """
+            function f(): string {
+                const a: number[] = [1, 2, 3, 4, 5];
+                const r = a.map((x: number): number => x * 2).filter((x: number): boolean => x > 4);
+                return r.join(",");
+            }
+            console.log(f());
+            """;
+        Assert.Equal("6,8,10\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ChainedMapFilter_LengthOnResult(ExecutionMode mode)
+    {
+        // .length on the chain result requires the final $Array wrap to survive.
+        var source = """
+            function f(): number {
+                const a: number[] = [1, 2, 3, 4, 5];
+                return a.map((x: number): number => x * 2).filter((x: number): boolean => x > 5).length;
+            }
+            console.log(f());
+            """;
+        Assert.Equal("3\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ChainedMapSlice_MixedCallbackAndPlainArgs(ExecutionMode mode)
+    {
+        // Inner map (callback) feeds outer slice (plain args) — the bare List must flow across the
+        // boundary and slice must consume it correctly.
+        var source = """
+            function f(): string {
+                const a: number[] = [1, 2, 3, 4, 5];
+                return a.map((x: number): number => x * 2).slice(1, 3).join(",");
+            }
+            console.log(f());
+            """;
+        Assert.Equal("4,6\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ChainedFilterMap_UntypedAndAnnotatedMixed(ExecutionMode mode)
+    {
+        // Inner filter is annotated, outer map is untyped — both stages chain through a bare List.
+        var source = """
+            function f(): string {
+                const a: number[] = [1, 2, 3, 4, 5, 6];
+                return a.filter((x: number): boolean => x % 2 === 0).map(x => x * 10).join(",");
+            }
+            console.log(f());
+            """;
+        Assert.Equal("20,40,60\n", TestHarness.Run(source, mode));
+    }
+
     [Theory]
     [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void ConstBoundAnnotatedCallback_Resolves(ExecutionMode mode)

--- a/SharpTS.Tests/SharedTests/ArrayHofAnnotatedCallbackTests.cs
+++ b/SharpTS.Tests/SharedTests/ArrayHofAnnotatedCallbackTests.cs
@@ -162,12 +162,14 @@ public class ArrayHofAnnotatedCallbackTests
         Assert.Equal("10,21,32\n", TestHarness.Run(source, mode));
     }
 
+    // ── #861 L3: capturing annotated arrows (instance adapter on the display class) ──
+
     [Theory]
     [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
-    public void CapturingAnnotatedArrow_FallsBack(ExecutionMode mode)
+    public void CapturingAnnotatedArrow_Map(ExecutionMode mode)
     {
-        // Capturing arrow → adapter path is skipped (needs an instance receiver);
-        // reflective fallback must still produce the captured value correctly.
+        // Capturing arrow → instance adapter on the display class (L3); the captured value must
+        // marshal correctly through the adapter.
         var source = """
             function f(): string {
                 const a: number[] = [1, 2, 3];
@@ -177,6 +179,59 @@ public class ArrayHofAnnotatedCallbackTests
             console.log(f());
             """;
         Assert.Equal("11,12,13\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void CapturingAnnotatedArrow_Reduce(ExecutionMode mode)
+    {
+        var source = """
+            function f(): number {
+                const a: number[] = [1, 2, 3, 4, 5];
+                const base: number = 100;
+                return a.reduce((acc: number, x: number): number => acc + x + base, 0);
+            }
+            console.log(f());
+            """;
+        Assert.Equal("515\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void CapturingAnnotatedArrow_PerIterationFreshCapture(ExecutionMode mode)
+    {
+        // The display instance must be built FRESH at each call so each closure captures the
+        // current loop variable, not a shared one.
+        var source = """
+            function f(): string {
+                const fns: number[] = [];
+                for (let i: number = 0; i < 3; i++) {
+                    const arr: number[] = [10, 20];
+                    fns.push(arr.map((x: number): number => x + i)[0]);
+                }
+                return fns.join(",");
+            }
+            console.log(f());
+            """;
+        Assert.Equal("10,11,12\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void CapturingAnnotatedArrow_Chained(ExecutionMode mode)
+    {
+        // Capturing arrows across a chained map().filter().reduce() (L1 capturing adapter + L2 round-trip).
+        var source = """
+            function f(): number {
+                const a: number[] = [1, 2, 3, 4, 5];
+                const m: number = 3;
+                return a.map((x: number): number => x * m)
+                        .filter((x: number): boolean => x > m)
+                        .reduce((s: number, x: number): number => s + x, 0);
+            }
+            console.log(f());
+            """;
+        Assert.Equal("42\n", TestHarness.Run(source, mode));
     }
 
     [Theory]


### PR DESCRIPTION
Part of #856 (perf epic), closes #861. The last reflective-dispatch hotspot in the epic — the same class of cost #858 won ~40× on, now for array higher-order-function callbacks.

## Problem

`arr.map`/`filter`/`reduce`/`forEach`/`find`/`some`/`every` already had a direct-delegate fast path (`TryEmitDirectDelegateCall` → `Array*Direct(List<object>, Func<object,…>)`, "#96 Phase A"), but it **bailed on annotated callback params** (`if (p.Type != null) return false`). An annotated arrow `(x: number): number => x*2` compiles to a typed static method `double(double)` that cannot bind to `Func<object,object>`, so idiomatic TypeScript (which annotates callback params — including the entire `array-methods` benchmark) fell back to the reflective `ArrayMap` + `$TSFunction`/`MethodInvoker` path: a `MethodInvoker.Invoke` + a 3-element `object[]` allocation + boxing **per element**.

## Fix (4 layers)

**L1 — boxed adapter (non-capturing).** A new `ArrowBoxedAdapterEmitter` emits a per-arrow `object(object[,object])` adapter that unboxes each boxed element into the arrow's typed slot, calls the typed arrow, and reboxes the result; it binds to the existing `Func<object,…>` and feeds the **unchanged** `Array*Direct` helpers. Marshalling reuses `DelegateAdapterEmitter.EmitUnboxForReturn`/`EmitBoxForTS` (now `internal static`), which matches the reflective `MethodInvoker` no-arg-conversion semantics exactly for concrete `double`/`bool`/`string` params (unions/nullable already widen to `object` in `ParameterTypeResolver`). The adapter is emitted onto the arrow's `staticMethod.DeclaringType` (not `ctx.ProgramType`, which is set only on the top-level context) so it fires **inside function/method bodies** too — the dominant benchmark case.

**L2 — chained-stage round-trip elimination.** `a.map(f).filter(g).reduce(h)` wrapped each intermediate result into a `$Array` only for the next stage to unwrap it. A recursive `leaveResultAsBareList` flag now lets the inner stage leave a bare `List<object>` and the outer skip the unwrap; the **final** stage still wraps when consumed as an array value (`.length`/assign/`===`). The intermediate is anonymous, so its `$Array` identity is unobservable. Disabled for `returnsReceiver` mutators (sort/reverse/fill/copyWithin) and the await-spill path.

**L3 — capturing annotated arrows.** A capturing arrow compiles to a typed *instance* `Invoke` on a display class. L3 emits the adapter as an **instance** method on that display class (`callvirt this.Invoke`) and binds `(displayInstance, ldftn adapter)`, building the display instance fresh at the call site via the existing machinery (exposed through `IEmitterContext.TryEmitCapturingArrowDisplayInstance`). Per-iteration fresh-binding is preserved (a loop over `arr.map(x => x + i)[0]` yields `10,11,12`, not a shared `i`).

**L4 — bool-returning adapter for typed predicates.** filter/find/findIndex/some/every with a typed `bool` predicate now bind `Func<object,bool>` + the existing `*DirectBool` helper, with the adapter returning the unboxed `bool` — dropping the per-element result box + `IsTruthy`.

## Performance (warm, .NET 10 Release, controlled same-session A/B)

| Workload | main | this PR | |
|---|---|---|---|
| array-methods chain (non-capturing, n=10k) | ~3.31 ms/call | ~1.4 ms/call | **~2.4×** |
| chain with a **capturing** callback | ~3.16 ms/call | ~1.10 ms/call | **~2.9×** |
| pure filter (L4 delta vs L3) | ~0.83 ms/call | ~0.79 ms/call | ~5% |

L2 is allocation/GC + cold-start (warm-flat on large-n, where per-element work dominates) — the chained `map().filter().reduce()` emits **zero** `newobj $Array`/`get_Elements` between stages (IL-verified). All outputs identical to `main`.

## Correctness / scope

Conservative and additive: anything outside the fast path (capturing/marshallable gates, multi-arg callbacks, rest/optional/default params, non-array receivers) falls back to the unchanged reflective path. The standalone-DLL constraint is preserved (adapters are emitted methods, no `SharpTS.dll` reference). `arr.map((x:number)...)` etc. — capturing or not — now emit a direct delegate call with no `$TSFunction`/`GetMethodFromHandle`/`object[]` per element.

## Tests

- **42 new dual-mode tests** (`ArrayHofAnnotatedCallbackTests`): annotated map/filter/reduce/forEach/find/some/every, string-param + NaN coercion parity, chained stages (final-wrap-preserved, `map→slice` boundary, mixed typed/untyped), capturing (map/reduce/chained + the per-iteration fresh-capture guard), bool predicates, and fallback cases (`any[]`, multi-arg, untyped).
- `--verify` clean on all shapes.
- Full `dotnet test` green except the two known pre-existing **stale/flaky** Test262 baselines: their only "regressions" are `Array/isArray` TypeCheckError/Proxy drift that **also appears in interpreter mode** (a compiled-only change cannot cause those), and the non-Test262 flaky failures pass in isolation with disjoint sets across runs. No HOF/callback/closure/predicate test changed status.