### PR TITLE
Perf #859: elide per-char box round-trip in promoted-string charCodeAt (strings → parity)

### DIFF
--- a/Compilation/ILEmitter.Properties.cs
+++ b/Compilation/ILEmitter.Properties.cs
@@ -1276,15 +1276,17 @@ public partial class ILEmitter
         IL.Emit(OpCodes.Ldloc, idxLocal);
         IL.Emit(OpCodes.Callvirt, getChars);
         IL.Emit(OpCodes.Conv_R8);
-        IL.Emit(OpCodes.Box, _ctx.Types.Double);
         IL.Emit(OpCodes.Br, end);
 
         IL.MarkLabel(oob);
         IL.Emit(OpCodes.Ldc_R8, double.NaN);
-        IL.Emit(OpCodes.Box, _ctx.Types.Double);
 
+        // #859: leave a raw float64 (both branches push double) instead of boxing. The result is
+        // typically consumed by a numeric op (`sum + s.charCodeAt(i)`), whose EnsureDouble is then a
+        // no-op; a boxed-object consumer re-boxes via EmitBoxIfNeeded (which checks StackType). This
+        // elides the per-char `box Double` (a heap allocation) plus the consumer's `ConvertToNumber`.
         IL.MarkLabel(end);
-        SetStackUnknown();
+        SetStackType(StackType.Double);
     }
 
     /// <summary>


### PR DESCRIPTION
Part of #856 (perf epic). The targeted, low-risk slice of #859 (dead box/unbox elision).

## Result

| strings @10k (warm) | Before | After | Node |
|---|---|---|---|
| compiled | ~0.20–0.29 ms (~2.4×) | **~0.12 ms (~parity)** | ~0.11 ms |

`stringWork`'s scan loop boxed the `charCodeAt` `double` result every character, then the `sum + …` consumer immediately unboxed it via `$Runtime::ConvertToNumber` — a dead round-trip whose `box Double` is a **heap allocation per character**. Eliminating it removed the dominant residual GC cost and brings strings to ≈Node.

## Change

`EmitPromotedStringCharCodeAt`: both branches (in-range `get_Chars` and OOB `NaN`) already push a raw `double`, so the merge is type-consistent without boxing. Drop the two `box Double`, set `StackType.Double`. The consumer's `EnsureDouble` then no-ops (it already gates on StackType), and any boxed-object consumer re-boxes once via `EmitBoxIfNeeded`.

## Why only this site

The map of the emitter (no IL-buffering layer exists → a general peephole-rewrite pass isn't feasible without refactoring) showed the clean dead round-trips are narrow:

- **General `charCodeAt`** (`StringMethods`): its fast path must converge at `doneLabel` with a dynamic-fallback branch returning a boxed `object` (`InvokeMethodValue`) — the box is **required** for the merge; removing it breaks IL verification.
- **count-primes array read**: `box Boolean → IsTruthy` merges the in-range value with the OOB `$Undefined` branch — structural, not dead.

Only the promoted `charCodeAt` is a self-contained typed path (both branches `double`, no fallback merge), so it's the safe site. Broader box/unbox elision (a `valueNeeded` discard flag) and loop-invariant `get_Length` hoisting are **deferred** — lower value now that the typed work removed most round-trips, higher risk.

## Validation

- `dotnet test`: 13999 passed, 0 real regressions (only a flaky `.NET`-interop test that passes in isolation + the documented stale Test262 baselines — `Array.isArray`/`proxy`, present in interpreter mode too).
- Existing `StringAccumulatorPromotionTests` cover the changed path in both modes (`Promoted_BuildThenScan_CharCodeSum` = the scan loop; `Promoted_CharCodeAt_OutOfRange_IsNaN` = the OOB→NaN branch).
- `--verify` passes; IL confirms the scan loop has no `box`/`ConvertToNumber`.