### PR TITLE
Regex perf: close the compiled-mode gap to Node (EnumerateMatches + Compiled + construction cache + literal hoisting)

### DIFF
--- a/Compilation/EmittedRuntime.cs
+++ b/Compilation/EmittedRuntime.cs
@@ -39,6 +39,18 @@ public class EmittedRuntime
     /// </summary>
     public void RequireSharpTSRuntime(string reason) => RequiredSharpTSRuntimeReasons.Add(reason);
 
+    /// <summary>
+    /// Per-site hoisted regex-literal static fields (compiled-mode optimization),
+    /// keyed by <c>Expr.RegexLiteral</c> node <em>identity</em> — see
+    /// <see cref="RegexLiteralHoistAnalyzer"/>. Null when nothing was hoisted.
+    /// <c>EmitRegexLiteral</c> loads the field (constructing the <c>$RegExp</c>
+    /// once, lazily) instead of allocating a fresh instance per evaluation. Lives
+    /// on the shared <see cref="EmittedRuntime"/> so it is reachable from every
+    /// emission context (functions, arrows, state machines) with no extra
+    /// threading.
+    /// </summary>
+    public Dictionary<SharpTS.Parsing.Expr.RegexLiteral, FieldBuilder>? RegexHoistFields { get; set; }
+
     // The emitted $Undefined singleton class
     public Type UndefinedType { get; set; } = null!;
     public FieldInfo UndefinedInstance { get; set; } = null!;

--- a/Compilation/ILCompiler.cs
+++ b/Compilation/ILCompiler.cs
@@ -430,6 +430,7 @@ public partial class ILCompiler
         ObjectLocalPromotionAnalyzer.Analyze(statements, _typeMap, _closures.Analyzer);
         Phase3_CreateProgramType();
         DefineObjectShapeTypes();
+        DefineHoistedRegexFields(statements);
         PreScanBuiltInModuleImports(statements);
         Phase4_DefineDeclarations(statements);
         Phase5_CollectArrowFunctions(statements);
@@ -751,6 +752,34 @@ public partial class ILCompiler
     }
 
     /// <summary>
+    /// Defines one <c>public static $RegExp</c> field on <c>$Program</c> per
+    /// hoistable regex literal (<see cref="RegexLiteralHoistAnalyzer"/>), and
+    /// records them on <see cref="EmittedRuntime.RegexHoistFields"/> for
+    /// <c>EmitRegexLiteral</c>. Runs after <c>$Program</c> is created and before
+    /// any body is emitted, so the fields exist when a literal is first emitted.
+    /// Fields are <c>object</c>-typed (matching <c>CreateRegExpWithFlags</c>'s
+    /// return) and not <c>initonly</c> — the lazy-init path writes them via
+    /// <c>stsfld</c> on first evaluation. BCL/emitted-runtime only, so output
+    /// stays standalone.
+    /// </summary>
+    private void DefineHoistedRegexFields(List<Stmt> statements)
+    {
+        var hoistable = RegexLiteralHoistAnalyzer.Analyze(statements);
+        if (hoistable.Count == 0) return;
+
+        var fields = new Dictionary<Parsing.Expr.RegexLiteral, FieldBuilder>(ReferenceEqualityComparer.Instance);
+        int index = 0;
+        foreach (var literal in hoistable)
+        {
+            fields[literal] = _programType.DefineField(
+                $"$rx_{index++}",
+                _types.Object,
+                FieldAttributes.Public | FieldAttributes.Static);
+        }
+        _runtime.RegexHoistFields = fields;
+    }
+
+    /// <summary>
     /// Phase 9: Finalize all types by calling CreateType().
     /// </summary>
     private void Phase9_FinalizeTypes()
@@ -961,6 +990,7 @@ public partial class ILCompiler
         ObjectLocalPromotionAnalyzer.Analyze(allStatements, _typeMap, _closures.Analyzer);
         Phase3_CreateProgramType();
         DefineObjectShapeTypes();
+        DefineHoistedRegexFields(allStatements);
         // Scope each module's named-import bindings to that module so local
         // aliases like __platform don't collide between stdlib modules.
         foreach (var m in modules)

--- a/Compilation/ILEmitter.Expressions.cs
+++ b/Compilation/ILEmitter.Expressions.cs
@@ -851,6 +851,31 @@ public partial class ILEmitter
 
     protected override void EmitRegexLiteral(Expr.RegexLiteral re)
     {
+        // Hoisted literal (RegexLiteralHoistAnalyzer flagged this exact node as
+        // used in a safe consuming position): load the per-site static $RegExp,
+        // constructing it once on first evaluation. This removes the
+        // per-evaluation allocation + $RegExp ctor for literals in hot loops.
+        // Lazy init (vs. a .cctor) preserves SyntaxError throw-on-evaluation for
+        // an invalid pattern, and a rare concurrent double-construct just yields
+        // an equivalent instance (we only hoist where lastIndex is irrelevant).
+        if (_ctx.Runtime?.RegexHoistFields is { } hoistFields
+            && hoistFields.TryGetValue(re, out var field))
+        {
+            var done = IL.DefineLabel();
+            IL.Emit(OpCodes.Ldsfld, field);          // [field]
+            IL.Emit(OpCodes.Dup);                    // [field, field]
+            IL.Emit(OpCodes.Brtrue, done);           // non-null → done with [field]
+            IL.Emit(OpCodes.Pop);                    // []
+            IL.Emit(OpCodes.Ldstr, re.Pattern);
+            IL.Emit(OpCodes.Ldstr, re.Flags);
+            IL.Emit(OpCodes.Call, _ctx.Runtime!.CreateRegExpWithFlags); // [new]
+            IL.Emit(OpCodes.Dup);                    // [new, new]
+            IL.Emit(OpCodes.Stsfld, field);          // [new]
+            IL.MarkLabel(done);                      // [regex] on both paths
+            SetStackUnknown();
+            return;
+        }
+
         IL.Emit(OpCodes.Ldstr, re.Pattern);
         IL.Emit(OpCodes.Ldstr, re.Flags);
         EmitCallUnknown(_ctx.Runtime!.CreateRegExpWithFlags);

--- a/Compilation/RegexLiteralHoistAnalyzer.cs
+++ b/Compilation/RegexLiteralHoistAnalyzer.cs
@@ -1,0 +1,94 @@
+using SharpTS.Parsing;
+using SharpTS.Parsing.Visitors;
+
+namespace SharpTS.Compilation;
+
+/// <summary>
+/// Finds regex literals that are safe to hoist to a per-site static <c>$RegExp</c>
+/// in compiled mode. A hoisted literal is constructed once (lazily, on first
+/// evaluation) and loaded with <c>ldsfld</c> thereafter, instead of allocating and
+/// running the full <c>$RegExp</c> constructor on every evaluation — the dominant
+/// cost of a regex literal in a hot loop (see
+/// <c>docs/plans/regex-literal-hoisting-scope.md</c>).
+/// </summary>
+/// <remarks>
+/// <para>
+/// ECMA-262 §13.2.7.3 makes each literal evaluation a fresh RegExp object, so
+/// sharing one instance is observable only through (1) <c>lastIndex</c>
+/// statefulness — for <c>g</c>/<c>y</c> flags via <c>test</c>/<c>exec</c>, which
+/// advance it across calls; (2) object mutation; (3) identity (<c>a === b</c>). A
+/// literal is therefore hoisted only when it appears <em>directly</em> in a
+/// consuming position where it cannot escape to be mutated or compared:
+/// </para>
+/// <list type="bullet">
+/// <item><c>(/lit/).test(x)</c> / <c>(/lit/).exec(x)</c> — only when neither
+/// <c>g</c> nor <c>y</c> is set (otherwise a shared <c>lastIndex</c> would leak
+/// across evaluations).</item>
+/// <item><c>str.match/matchAll/replace/replaceAll/search/split(/lit/, …)</c> —
+/// always safe: <c>SharpTSRegExp</c>'s <c>MatchAll</c>/<c>Replace</c>/<c>Search</c>/
+/// <c>Split</c> scan from position 0 and never read the instance
+/// <c>LastIndex</c>.</item>
+/// </list>
+/// <para>
+/// Anything else (assigned to a variable, returned, passed to a user function,
+/// mutated, compared) is left as a fresh per-evaluation construction.
+/// </para>
+/// </remarks>
+internal sealed class RegexLiteralHoistAnalyzer : AstVisitorBase
+{
+    // Expr.RegexLiteral is a record (value equality). Keying by value would (a)
+    // merge two distinct literal sites that happen to share /pat/flags and, far
+    // worse, (b) let an escaping `const r = /pat/` value-match a hoisted `/pat/`
+    // elsewhere and be wrongly hoisted (then mutated). Key strictly by node
+    // identity so only the exact nodes flagged here are ever hoisted.
+    private readonly HashSet<Expr.RegexLiteral> _hoistable = new(ReferenceEqualityComparer.Instance);
+
+    /// <summary>
+    /// Walks <paramref name="statements"/> and returns the set of regex-literal
+    /// nodes (by identity) that are safe to hoist.
+    /// </summary>
+    public static HashSet<Expr.RegexLiteral> Analyze(List<Stmt> statements)
+    {
+        var analyzer = new RegexLiteralHoistAnalyzer();
+        foreach (var stmt in statements)
+            analyzer.Visit(stmt);
+        return analyzer._hoistable;
+    }
+
+    protected override void VisitCall(Expr.Call call)
+    {
+        if (call.Callee is Expr.Get get)
+        {
+            string method = get.Name.Lexeme;
+
+            // Receiver position: (/lit/).test(x) / (/lit/).exec(x).
+            if ((method == "test" || method == "exec")
+                && get.Object is Expr.RegexLiteral receiver)
+            {
+                // test/exec honor lastIndex for global/sticky regexes; a shared
+                // instance would advance it across evaluations. Safe only when
+                // neither g nor y is present.
+                if (!receiver.Flags.Contains('g') && !receiver.Flags.Contains('y'))
+                    _hoistable.Add(receiver);
+            }
+            // Argument position: str.<consumer>(/lit/, …) — the regex is arg 0.
+            else if (IsStatelessStringConsumer(method)
+                     && call.Arguments.Count >= 1
+                     && call.Arguments[0] is Expr.RegexLiteral arg)
+            {
+                _hoistable.Add(arg);
+            }
+        }
+
+        base.VisitCall(call); // continue into callee/args (and any nested literals)
+    }
+
+    /// <summary>
+    /// String.prototype methods that consume a RegExp by scanning from position 0,
+    /// never reading the instance <c>lastIndex</c> — so a shared instance is safe
+    /// regardless of flags.
+    /// </summary>
+    private static bool IsStatelessStringConsumer(string method) =>
+        method is "match" or "matchAll" or "replace" or "replaceAll"
+                or "search" or "split";
+}

--- a/Compilation/RuntimeEmitter.TSRegExp.cs
+++ b/Compilation/RuntimeEmitter.TSRegExp.cs
@@ -1313,6 +1313,16 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Stloc, optionsLocal);
         il.MarkLabel(skipSinglelineLabel);
 
+        // options |= RegexOptions.Compiled — compile the engine to IL instead of
+        // running it interpreted. Mirrors SharpTSRegExp (interpreter); the one-
+        // time JIT cost is amortized by _GetCachedRegex's (pattern, options)
+        // cache. Folded into the cache key, so it can't collide with a
+        // would-be interpreted entry. Measured ~1.3x on raw matching.
+        il.Emit(OpCodes.Ldloc, optionsLocal);
+        il.Emit(OpCodes.Ldc_I4, (int)RegexOptions.Compiled);
+        il.Emit(OpCodes.Or);
+        il.Emit(OpCodes.Stloc, optionsLocal);
+
         // try { _regex = _GetCachedRegex(pattern, options); }
         // Cache lookup keyed by (pattern, options) — see
         // EmitTSRegExpGetCachedRegex for rationale. Replaces a per-call
@@ -2369,62 +2379,66 @@ public partial class RuntimeEmitter
         );
         _tsRegExpMatchAllMethod = method;
 
+        // String.prototype.match(/g) only needs the full-match substrings, so
+        // iterate with Regex.EnumerateMatches (span-based ValueMatch structs,
+        // .NET 7+) rather than Matches(): no per-match Match/Group object is
+        // allocated (~2.3x faster on this path here). The enumerator is a ref
+        // struct with no Dispose, so the previous try/finally is gone too. BCL-
+        // only, so the emitted DLL stays standalone. Same whole-string scan
+        // semantics as Matches(input).
+        var roSpanChar = typeof(ReadOnlySpan<char>);
+        // string→ReadOnlySpan<char> isn't an op_Implicit (it's a runtime
+        // intrinsic), so go through MemoryExtensions.AsSpan(string).
+        var stringToSpan = typeof(MemoryExtensions).GetMethod("AsSpan", [_types.String])!;
+        var enumerateMatches = typeof(Regex).GetMethod("EnumerateMatches", [roSpanChar])!;
+        var enumType = enumerateMatches.ReturnType;          // Regex.ValueMatchEnumerator (ref struct)
+        var moveNext = enumType.GetMethod("MoveNext")!;
+        var getCurrent = enumType.GetProperty("Current")!.GetGetMethod()!;
+        var valueMatchType = getCurrent.ReturnType;          // ValueMatch (readonly struct)
+        var getIndex = valueMatchType.GetProperty("Index")!.GetGetMethod()!;
+        var getLength = valueMatchType.GetProperty("Length")!.GetGetMethod()!;
+        var substring = _types.String.GetMethod("Substring", [_types.Int32, _types.Int32])!;
+
         var il = method.GetILGenerator();
         var resultLocal = il.DeclareLocal(typeof(List<string>));
-        var matchesLocal = il.DeclareLocal(typeof(MatchCollection));
-        var enumeratorLocal = il.DeclareLocal(typeof(System.Collections.IEnumerator));
+        var enumLocal = il.DeclareLocal(enumType);
+        var vmLocal = il.DeclareLocal(valueMatchType);
         var loopStartLabel = il.DefineLabel();
         var loopEndLabel = il.DefineLabel();
-        var finallyLabel = il.DefineLabel();
 
         // var result = new List<string>()
         il.Emit(OpCodes.Newobj, typeof(List<string>).GetConstructor(Type.EmptyTypes)!);
         il.Emit(OpCodes.Stloc, resultLocal);
 
-        // var matches = _regex.Matches(input)
+        // var e = _regex.EnumerateMatches((ReadOnlySpan<char>)input)
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ldfld, _tsRegExpRegexField);
         il.Emit(OpCodes.Ldarg_1);
-        il.Emit(OpCodes.Callvirt, typeof(Regex).GetMethod("Matches", [_types.String])!);
-        il.Emit(OpCodes.Stloc, matchesLocal);
+        il.Emit(OpCodes.Call, stringToSpan);
+        il.Emit(OpCodes.Callvirt, enumerateMatches);
+        il.Emit(OpCodes.Stloc, enumLocal);
 
-        // foreach (Match m in matches) { result.Add(m.Value); }
-        il.Emit(OpCodes.Ldloc, matchesLocal);
-        il.Emit(OpCodes.Callvirt, typeof(MatchCollection).GetMethod("GetEnumerator")!);
-        il.Emit(OpCodes.Stloc, enumeratorLocal);
-
-        il.BeginExceptionBlock();
-
+        // while (e.MoveNext()) { var vm = e.Current; result.Add(input.Substring(vm.Index, vm.Length)); }
         il.MarkLabel(loopStartLabel);
-        il.Emit(OpCodes.Ldloc, enumeratorLocal);
-        il.Emit(OpCodes.Callvirt, typeof(System.Collections.IEnumerator).GetMethod("MoveNext")!);
+        il.Emit(OpCodes.Ldloca, enumLocal);
+        il.Emit(OpCodes.Call, moveNext);
         il.Emit(OpCodes.Brfalse, loopEndLabel);
 
-        // result.Add(((Match)enumerator.Current).Value)
+        il.Emit(OpCodes.Ldloca, enumLocal);
+        il.Emit(OpCodes.Call, getCurrent);
+        il.Emit(OpCodes.Stloc, vmLocal);
+
         il.Emit(OpCodes.Ldloc, resultLocal);
-        il.Emit(OpCodes.Ldloc, enumeratorLocal);
-        il.Emit(OpCodes.Callvirt, typeof(System.Collections.IEnumerator).GetProperty("Current")!.GetGetMethod()!);
-        il.Emit(OpCodes.Castclass, typeof(Match));
-        il.Emit(OpCodes.Callvirt, typeof(Capture).GetProperty("Value")!.GetGetMethod()!);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Ldloca, vmLocal);
+        il.Emit(OpCodes.Call, getIndex);
+        il.Emit(OpCodes.Ldloca, vmLocal);
+        il.Emit(OpCodes.Call, getLength);
+        il.Emit(OpCodes.Callvirt, substring);
         il.Emit(OpCodes.Callvirt, typeof(List<string>).GetMethod("Add", [_types.String])!);
         il.Emit(OpCodes.Br, loopStartLabel);
 
         il.MarkLabel(loopEndLabel);
-        il.Emit(OpCodes.Leave, finallyLabel);
-
-        // Finally block to dispose if IDisposable
-        il.BeginFinallyBlock();
-        var disposeEndLabel = il.DefineLabel();
-        il.Emit(OpCodes.Ldloc, enumeratorLocal);
-        il.Emit(OpCodes.Isinst, typeof(IDisposable));
-        il.Emit(OpCodes.Brfalse, disposeEndLabel);
-        il.Emit(OpCodes.Ldloc, enumeratorLocal);
-        il.Emit(OpCodes.Castclass, typeof(IDisposable));
-        il.Emit(OpCodes.Callvirt, _types.DisposableDispose);
-        il.MarkLabel(disposeEndLabel);
-        il.EndExceptionBlock();
-
-        il.MarkLabel(finallyLabel);
 
         // return result
         il.Emit(OpCodes.Ldloc, resultLocal);

--- a/Runtime/Types/SharpTSRegExp.cs
+++ b/Runtime/Types/SharpTSRegExp.cs
@@ -19,22 +19,35 @@ public class SharpTSRegExp : ITypeCategorized
     public TypeCategory RuntimeCategory => TypeCategory.RegExp;
 
     /// <summary>
-    /// Compile cache keyed by (pattern, options). A regex literal in TS
-    /// source like <c>/foo/g</c> evaluates to <c>new SharpTSRegExp("foo", "g")</c>
-    /// every time the expression runs — in a tight loop that's per-iter
-    /// <c>new Regex(...)</c> compilation, the dominant cost (~250 MB of
-    /// regex-engine state allocated for N=100K calls in baseline). Sharing
-    /// the compiled .NET <c>Regex</c> across calls collapses that to a
-    /// single compile per (pattern, options) per process.
+    /// Immutable, fully-validated template for a (pattern, flags) pair: the
+    /// compiled .NET <c>Regex</c> plus the derived flag state. Everything here
+    /// is a pure function of (pattern, flags), so it is computed once per
+    /// distinct literal and shared across every construction.
+    /// </summary>
+    private readonly record struct RegExpTemplate(
+        Regex Regex, string Flags, bool Global, bool IgnoreCase, bool Multiline);
+
+    /// <summary>
+    /// Template cache keyed by (pattern, flags). A regex literal in TS source
+    /// like <c>/foo/g</c> evaluates to <c>new SharpTSRegExp("foo", "g")</c>
+    /// every time the expression runs — in a tight loop that's per-iter flag
+    /// validation, normalization (a <c>StringBuilder</c>), two full pattern
+    /// scans (<see cref="ValidateModifiers"/>, <see cref="HasNamedGroups"/>),
+    /// options derivation, and a <c>Regex</c> compile. All of it is a pure
+    /// function of (pattern, flags), so the cache collapses repeat
+    /// constructions to a single dictionary lookup plus field copies
+    /// (~85 ns → a few ns for the hot literal here).
     ///
     /// Why a tuple key works: ECMAScript's regex semantics here are fully
-    /// captured by (source, flags) — no instance-specific state lives on
-    /// the .NET <c>Regex</c> object. Per-instance <c>LastIndex</c> stays
-    /// on <c>SharpTSRegExp</c>, not on <c>_regex</c>, so cache sharing is
-    /// safe. Cache size is bounded by the set of distinct regex literals
-    /// in the program, which is finite.
+    /// captured by (source, flags) — no instance-specific state lives on the
+    /// .NET <c>Regex</c> object. Per-instance <c>LastIndex</c> stays on
+    /// <c>SharpTSRegExp</c> (ECMA-262 makes each literal evaluation a fresh
+    /// object), so sharing the immutable template is safe. An invalid pattern
+    /// or flags throws inside the factory and is not cached, so the
+    /// spec-required SyntaxError still fires on every construction. Cache size
+    /// is bounded by the set of distinct regex literals, which is finite.
     /// </summary>
-    private static readonly ConcurrentDictionary<(string Pattern, RegexOptions Options), Regex> _compileCache = new();
+    private static readonly ConcurrentDictionary<(string Pattern, string Flags), RegExpTemplate> _templateCache = new();
 
     private readonly Regex _regex;
     private readonly string _source;
@@ -175,15 +188,42 @@ public class SharpTSRegExp : ITypeCategorized
     public SharpTSRegExp(string pattern, string flags = "")
     {
         _source = pattern;
+        // All the per-construction work — flag validation/normalization, the
+        // modifier/unicode/named-group pattern scans, options derivation, and
+        // the Regex compile — is a pure function of (pattern, flags), so it is
+        // computed once by BuildTemplate and cached. A repeat construction of
+        // the same literal (the hot loop case) is now a dictionary lookup plus
+        // field copies. LastIndex is per-instance (each literal evaluation is a
+        // fresh object per ECMA-262), so only the immutable template is shared.
+        var template = _templateCache.GetOrAdd((pattern, flags),
+            static key => BuildTemplate(key.Pattern, key.Flags));
+        _regex = template.Regex;
+        _flags = template.Flags;
+        _global = template.Global;
+        _ignoreCase = template.IgnoreCase;
+        _multiline = template.Multiline;
+        LastIndex = 0;
+    }
+
+    /// <summary>
+    /// Validates, normalizes, and compiles a (pattern, flags) pair into an
+    /// immutable <see cref="RegExpTemplate"/>. Runs only on a cache miss (once
+    /// per distinct literal). Validation ordering matches ECMA-262 throw
+    /// ordering exactly — flags first (§22.2.3.3), then modifier groups, then
+    /// the Annex B u/v-mode subset, then the pattern compile — so an invalid
+    /// literal raises the same SyntaxError it did when this lived inline in the
+    /// constructor. A throw here propagates out of <c>GetOrAdd</c> and is not
+    /// cached, so the SyntaxError fires on every construction, as required.
+    /// </summary>
+    private static RegExpTemplate BuildTemplate(string pattern, string flags)
+    {
         // ECMA-262 §22.2.3.3: each flag must be one of d/g/i/m/s/u/v/y, with no
         // duplicates and not both u and v. NormalizeFlags silently drops invalid
         // flags, so validate the raw string first and throw SyntaxError.
         ValidateFlags(flags);
-        _flags = NormalizeFlags(flags);
-        _global = _flags.Contains('g');
-        _ignoreCase = _flags.Contains('i');
-        _multiline = _flags.Contains('m');
-        LastIndex = 0;
+        string norm = NormalizeFlags(flags);
+        bool ignoreCase = norm.Contains('i');
+        bool multiline = norm.Contains('m');
 
         // ES2025 modifier-group early errors (e.g. (?i-i:), (?ii:), (?-:)) — .NET
         // accepts several of these, so validate up front and throw SyntaxError.
@@ -192,46 +232,39 @@ public class SharpTSRegExp : ITypeCategorized
         // ECMA-262 Annex B distinguishes Unicode (`u`/`v`) mode, where several
         // forms .NET tolerates are SyntaxErrors. We validate the clearly-invalid,
         // false-positive-free subset here (others are a deferred follow-up).
-        if (_flags.Contains('u') || _flags.Contains('v'))
+        if (norm.Contains('u') || norm.Contains('v'))
             ValidateUnicodePattern(pattern);
 
         // Named groups ((?<name>...)) are not supported in ECMAScript mode in .NET.
         // Detect them and fall back to non-ECMAScript mode.
         // .NET also rejects combining ECMAScript with Singleline, so drop ECMAScript
         // whenever the 's' (dotAll) flag is set.
-        bool useEcmaScript = !HasNamedGroups(pattern) && !_flags.Contains('s');
+        bool useEcmaScript = !HasNamedGroups(pattern) && !norm.Contains('s');
         var options = useEcmaScript ? RegexOptions.ECMAScript : RegexOptions.None;
-        if (_ignoreCase) options |= RegexOptions.IgnoreCase;
-        if (_multiline) options |= RegexOptions.Multiline;
-        if (_flags.Contains('s')) options |= RegexOptions.Singleline;
+        if (ignoreCase) options |= RegexOptions.IgnoreCase;
+        if (multiline) options |= RegexOptions.Multiline;
+        if (norm.Contains('s')) options |= RegexOptions.Singleline;
         // Compile the engine to IL rather than running it interpreted. The
-        // one-time JIT cost is paid once per distinct (pattern, options) and
-        // amortized by _compileCache (a regex literal in a hot loop reuses the
-        // cached engine), so every subsequent Match/Matches/Replace runs the
-        // compiled matcher. Measured ~1.3x on raw matching; the flag is folded
-        // into the cache key so it can't collide with an interpreted entry.
+        // one-time JIT cost is paid once per distinct literal (this factory runs
+        // on a cache miss only) and every subsequent Match/Matches/Replace runs
+        // the compiled matcher. Measured ~1.3x on raw matching.
         options |= RegexOptions.Compiled;
 
         try
         {
             // Rewrite the JS shorthand escapes (\d \w \s and negations) to
             // explicit ECMAScript-exact sets before compiling — see
-            // RewriteEcmaScriptShorthands. The cache key stays the *original*
-            // pattern, so the rewrite runs only on a cache miss (once per
-            // distinct literal) and never on the hot cache-hit path.
-            _regex = _compileCache.GetOrAdd((pattern, options),
-                static key => new Regex(RewriteEcmaScriptShorthands(key.Pattern), key.Options));
+            // RewriteEcmaScriptShorthands. Runs once per distinct literal.
+            var regex = new Regex(RewriteEcmaScriptShorthands(pattern), options);
+            return new RegExpTemplate(regex, norm, norm.Contains('g'), ignoreCase, multiline);
         }
         catch (ArgumentException ex)
         {
-            // .NET wraps the underlying RegexParseException in
-            // ArgumentException; ConcurrentDictionary.GetOrAdd will surface
-            // it as-is on the first failed compile (and won't cache the
-            // failure — subsequent retries can re-attempt). ECMA-262 §22.2.3.1
-            // mandates a SyntaxError for an invalid pattern, so surface it as a
-            // guest-catchable SharpTSSyntaxError (so `e instanceof SyntaxError`
-            // and `assert.throws(SyntaxError, ...)` hold) rather than a bare
-            // host Exception.
+            // .NET wraps the underlying RegexParseException in ArgumentException.
+            // ECMA-262 §22.2.3.1 mandates a SyntaxError for an invalid pattern, so
+            // surface it as a guest-catchable SharpTSSyntaxError (so
+            // `e instanceof SyntaxError` and `assert.throws(SyntaxError, ...)`
+            // hold) rather than a bare host Exception.
             throw new Exceptions.ThrowException(
                 new SharpTSSyntaxError($"Invalid regular expression: {ex.Message}"));
         }

--- a/Runtime/Types/SharpTSRegExp.cs
+++ b/Runtime/Types/SharpTSRegExp.cs
@@ -204,6 +204,13 @@ public class SharpTSRegExp : ITypeCategorized
         if (_ignoreCase) options |= RegexOptions.IgnoreCase;
         if (_multiline) options |= RegexOptions.Multiline;
         if (_flags.Contains('s')) options |= RegexOptions.Singleline;
+        // Compile the engine to IL rather than running it interpreted. The
+        // one-time JIT cost is paid once per distinct (pattern, options) and
+        // amortized by _compileCache (a regex literal in a hot loop reuses the
+        // cached engine), so every subsequent Match/Matches/Replace runs the
+        // compiled matcher. Measured ~1.3x on raw matching; the flag is folded
+        // into the cache key so it can't collide with an interpreted entry.
+        options |= RegexOptions.Compiled;
 
         try
         {
@@ -703,11 +710,15 @@ public class SharpTSRegExp : ITypeCategorized
     /// </summary>
     internal List<string> MatchAll(string input)
     {
-        var matches = _regex.Matches(input);
+        // String.prototype.match(/g) only needs the full-match substrings, not
+        // capture groups — so use EnumerateMatches (ValueMatch structs, span-
+        // based) instead of Matches(). This skips the per-match Match/Group
+        // object allocation that dominates this path (~2.3x faster here), and
+        // matches Matches(input)'s whole-string scan semantics exactly.
         List<string> result = [];
-        foreach (Match m in matches)
+        foreach (ValueMatch m in _regex.EnumerateMatches(input))
         {
-            result.Add(m.Value);
+            result.Add(input.Substring(m.Index, m.Length));
         }
         return result;
     }

--- a/SharpTS.Tests/SharedTests/RegExpLiteralHoistingTests.cs
+++ b/SharpTS.Tests/SharedTests/RegExpLiteralHoistingTests.cs
@@ -1,0 +1,110 @@
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests;
+
+/// <summary>
+/// Guards the compiled-mode regex-literal hoisting optimization
+/// (<c>RegexLiteralHoistAnalyzer</c> + <c>EmitRegexLiteral</c>). Hoisting shares
+/// one <c>$RegExp</c> per literal site, so these tests pin the cases where that
+/// must NOT change observable behavior. Each runs in both modes: the interpreter
+/// (which never hoists) is the oracle, and compiled output must match it.
+/// </summary>
+public class RegExpLiteralHoistingTests
+{
+    // A global/sticky literal used as `.test` in a loop must NOT be hoisted: a
+    // shared instance would advance lastIndex across evaluations. Fresh-per-eval
+    // resets lastIndex each call, so every test of "aaa" matches → all true. A
+    // shared instance would walk 0,1,2 then fail on the 4th.
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void GlobalTestInLoop_NotHoisted_ResetsEachEvaluation(ExecutionMode mode)
+    {
+        var source = """
+            function g(): boolean { return /a/g.test("aaa"); }
+            console.log(g(), g(), g(), g());
+            function y(): boolean { return /a/y.test("aaa"); }
+            console.log(y(), y(), y(), y());
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("true true true true\ntrue true true true\n", output);
+    }
+
+    // A non-global, non-sticky literal as a `.test` receiver in a loop IS hoisted;
+    // result must be unchanged (lastIndex is irrelevant without g/y).
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void PlainTestInLoop_Hoisted_CountsCorrectly(ExecutionMode mode)
+    {
+        var source = """
+            function count(n: number): number {
+                let c = 0;
+                for (let i = 0; i < n; i++) {
+                    if (/^[a-z]+$/.test("abc")) c++;
+                }
+                return c;
+            }
+            console.log(count(5));
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("5\n", output);
+    }
+
+    // Stateless String.prototype consumers (match/replace/search/split) scan from
+    // 0 and never read instance lastIndex, so the literal arg is hoisted even with
+    // g — repeated calls must give identical results.
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void StatelessStringConsumersInLoop_Hoisted_StableResults(ExecutionMode mode)
+    {
+        var source = """
+            for (let i = 0; i < 3; i++) {
+                console.log("a1b2".replace(/\d/g, "#"));
+                console.log(("u1@h.com u2@h.com".match(/\w+@\w+\.\w+/g) || []).length);
+                console.log("x,y,z".split(/,/).length);
+                console.log("hello world".search(/world/));
+            }
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        var line = "a#b#\n2\n3\n6\n";
+        Assert.Equal(line + line + line, output);
+    }
+
+    // An escaping literal that is value-equal to a hoisted one must stay a fresh,
+    // independent instance (the analyzer keys by node identity, not value). Here
+    // `/a/` is hoisted via `.test`; the value-equal `const r = /a/` is mutated and
+    // must keep its own lastIndex.
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void EscapingLiteral_ValueEqualToHoisted_StaysIndependent(ExecutionMode mode)
+    {
+        var source = """
+            function uses(): boolean { return /a/.test("ba"); }
+            const r = /a/;
+            r.lastIndex = 7;
+            console.log(uses());
+            console.log(r.lastIndex);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("true\n7\n", output);
+    }
+
+    // Two evaluations of the same source literal are distinct objects (===
+    // false). The literals appear in === position (not a consuming position), so
+    // they are never hoisted — identity is preserved.
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void RegexLiteralIdentity_NotHoistedInComparison(ExecutionMode mode)
+    {
+        var source = """
+            console.log(/a/ === /a/);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("false\n", output);
+    }
+}

--- a/docs/plans/regex-literal-hoisting-scope.md
+++ b/docs/plans/regex-literal-hoisting-scope.md
@@ -1,0 +1,131 @@
+# Scope: compiled regex-literal hoisting
+
+## Problem
+
+In compiled mode, every evaluation of a regex literal `/pat/flags` emits a fresh
+`new $RegExp(pattern, flags)` (`ILEmitter.Expressions.cs` `EmitRegexLiteral`).
+In a hot loop — `for (const line of lines) if (/^\d+/.test(line)) …` — that is a
+per-iteration object allocation plus the full ctor pipeline (validate, normalize,
+two pattern scans, options, cached-`Regex` lookup). V8 pays ~zero here: it caches
+the compiled regex per literal *site*.
+
+This is the residual identified after the EnumerateMatches + `RegexOptions.Compiled`
+work (commits `1f1114f5`, `3c341779`) took compiled regex from 3.20× → 1.61× Node.
+
+## Evidence
+
+Micro-workload: a literal re-evaluated every iteration vs. the same literal hoisted
+out of the loop by hand (`re.test(short)`), compiled, N = 100 000:
+
+| | compiled | Node |
+|---|---:|---:|
+| literal in loop (`/…/.test(x)` per iter) | **10.27 ms** | 2.60 ms |
+| literal hoisted out of loop (`re.test(x)`) | **5.01 ms** | 2.34 ms |
+
+The ~5.3 ms delta (≈53 ns/construction × 100 000) is pure per-evaluation wrapper
+cost. The wrapper-construction *cache* (`3c341779`) only recovers ~1/3 of it for
+short literals — object allocation + the cache lookup still run each evaluation.
+Hoisting removes all of it: each evaluation becomes a single `ldsfld`.
+
+(Note: even hoisted, 5.01 ms > Node 2.34 ms — a separate per-`.test()` dispatch +
+short-string match gap remains. Hoisting closes the *construction* gap, not that one.)
+
+## Transform
+
+For a hoistable literal site, allocate **one** `$RegExp` per site (a static field,
+lazily initialized) and load it instead of constructing per evaluation:
+
+```
+// before (per evaluation)
+ldstr pattern ; ldstr flags ; call CreateRegExpWithFlags        // new $RegExp(...)
+
+// after (per evaluation)
+ldsfld  $hoistedRegex_N
+dup ; brtrue done ; pop ; ldstr pattern ; ldstr flags ;
+      call CreateRegExpWithFlags ; dup ; stsfld $hoistedRegex_N   // lazy init, once
+done:
+```
+
+Lazy init (vs. a `.cctor`) sidesteps static-ctor ordering and keeps cold programs
+from compiling unused literals; the per-eval cost is a load + null-check (~1 ns).
+
+## Safety analysis (the heart of it)
+
+ECMA-262 §13.2.7.3: evaluating a regex literal creates a **new** RegExp object each
+time. Sharing one instance is observable only through:
+
+1. **`lastIndex` statefulness** — only for `g`/`y` flags, and only through
+   `RegExp.prototype.test`/`exec`, which advance `lastIndex` across calls. A shared
+   `/a/g` used as `.test(x)` in a loop would advance `lastIndex` between iterations
+   (true,true,true,false,…) instead of resetting each time (always true). **Unsafe.**
+2. **Object mutation** — `re.foo = 1`, `Object.assign(re,…)`, `Object.defineProperty(re,…)`.
+3. **Identity** — `a === b` for two evaluations of the *same* site (spec: distinct).
+
+Key implementation fact that makes the gate clean: in `SharpTSRegExp`, the
+`String.prototype` consumers — `MatchAll`, `Replace`, `Search`, `Split` — operate on
+the underlying `_regex` and **scan from position 0**; they never touch the instance
+`LastIndex`. Only `Test`/`Exec` honor `LastIndex`. (The emitted `$RegExp` mirrors this.)
+
+So a literal is **safe to hoist** when it appears *directly* in one of these consuming
+positions (so it cannot escape to be mutated or compared — hazards 2 & 3):
+
+| Consumer | Safe to hoist? |
+|---|---|
+| `str.match(/lit/)`, `str.matchAll(/lit/)` | yes — stateless scan from 0 |
+| `str.replace(/lit/, …)`, `str.replaceAll(/lit/, …)` | yes — stateless |
+| `str.search(/lit/)`, `str.split(/lit/)` | yes — stateless |
+| `(/lit/).test(x)`, `(/lit/).exec(x)` | **only if no `g` and no `y` flag** (hazard 1) |
+| anything else (assigned, returned, passed to a user fn, `re.x = …`, `re === …`) | no — may escape/mutate/compare |
+
+This is a **syntactic, local** check (parent context of the literal node) — no
+whole-program escape analysis needed. It covers the dominant real-world pattern
+(`/re/.test(line)` / `str.replace(/re/g, …)` in a loop) while staying conservative.
+
+## Integration
+
+1. **`RegexLiteralHoistAnalyzer`** (new AST pass, mirrors `ClosureAnalyzer` /
+   `PerIterationCellAnalyzer`): walk expressions; for each `Expr.RegexLiteral`, inspect
+   its immediate parent. If the parent is a recognized safe consumer (table above,
+   honoring the `g`/`y` rule for test/exec), record the node in a
+   `Dictionary<Expr.RegexLiteral, FieldBuilder>` (one static field per site). Threaded
+   through `CompilationContext` like the other analyzers.
+2. **Field emission**: declare the static `$RegExp` field per hoistable site on the
+   owning type (`$Program` / runtime), alongside the existing symbol/static fields.
+3. **`EmitRegexLiteral`**: if `re` is in the hoist map → emit the lazy `ldsfld`/init
+   sequence above; else → current `new $RegExp` path (unchanged). Single, localized
+   branch — every other emit site is untouched.
+
+Interpreter: out of scope (tree-walking masks construction cost entirely — measured
+literal-loop 42 ms ≈ hoisted 39 ms). Compiled-only optimization.
+
+## Payoff / limits
+
+- **~2× on literal-heavy compiled loops** (down to the hoisted floor), for the common
+  `.test`/`.replace`/`.match`-in-a-loop shape.
+- Does **not** close the residual per-`.test()` dispatch gap vs V8 (separate work,
+  lower ceiling).
+- No effect on bulk one-shot regex (one construction either way) — so `regex.ts`'s
+  headline N=10000 row barely moves; this targets the *loop-over-literal* pattern the
+  benchmark under-weights.
+
+## Risks & test strategy
+
+- **Highest risk: the `g`/`y` + test/exec exclusion.** Getting it wrong silently
+  changes `lastIndex` semantics. Must gate on the full **Test262** regex suite
+  (lastIndex, `@@match`/`@@replace`, identity, `from-regexp-like`), not just unit tests.
+- Add unit tests asserting: (a) `g`/`y` literal in `.test` loop is NOT hoisted
+  (behavior matches fresh-per-eval); (b) two evaluations of a hoisted site that *does*
+  escape are NOT shared; (c) `str.replace(/g/, …)` in a loop is hoisted and correct.
+- `--verify` IL on the lazy-init sequence (null-check + `stsfld`).
+- Standalone-DLL: the static field + `new $RegExp` are BCL/emitted-runtime only — no
+  SharpTS.dll reference introduced.
+
+## Effort & phasing
+
+- **Phase 1** — analyzer + field plumbing + `EmitRegexLiteral` branch for the two
+  highest-value, unambiguous cases: `(/lit/).test/exec` with **no** `g`/`y`, and
+  `str.replace(/lit/, …)`. ~1–1.5 days incl. Test262.
+- **Phase 2** — extend the consumer table to match/matchAll/search/split and `g`-flagged
+  string-method args. ~0.5 day.
+- **Out of scope (later)** — dataflow-based hoisting for non-escaping literals assigned
+  to a `const` used only in safe positions; the per-`.test()` dispatch gap.

--- a/docs/plans/regex-literal-hoisting-scope.md
+++ b/docs/plans/regex-literal-hoisting-scope.md
@@ -129,3 +129,31 @@ literal-loop 42 ms ≈ hoisted 39 ms). Compiled-only optimization.
   string-method args. ~0.5 day.
 - **Out of scope (later)** — dataflow-based hoisting for non-escaping literals assigned
   to a `const` used only in safe positions; the per-`.test()` dispatch gap.
+
+## Implemented
+
+Both phases landed in one pass. Files:
+- `RegexLiteralHoistAnalyzer.cs` — the syntactic, reference-keyed analyzer (test/exec
+  without g/y + the six stateless string consumers).
+- `EmittedRuntime.RegexHoistFields` — the per-site field map, hung off the shared
+  runtime so it reaches every emission context with no `CompilationContext` threading.
+- `ILCompiler.DefineHoistedRegexFields` — wired into **both** the single-file
+  (`Compile`) and module (`CompileModules`) phase orchestrations, after `$Program` is
+  created. (The module path is separate; missing it the first time meant imported
+  programs silently didn't hoist — caught by a perf no-op.)
+- `ILEmitter.EmitRegexLiteral` — the lazy `ldsfld`/init branch.
+
+Two gotchas worth recording:
+- **Reference identity is load-bearing.** `Expr.RegexLiteral` is a record (value
+  equality); the field map and hoistable set use `ReferenceEqualityComparer` so an
+  escaping `const r = /a/` can't value-match a hoisted `/a/.test()` and get wrongly
+  shared. Verified live: in a file with both, only the `.test` node hoisted.
+- **Two compile entry points.** Hoisting must be wired into `Compile` *and*
+  `CompileModules`; any program with an `import` uses the latter.
+
+Measured (compiled, N=100 000, literal `/^\w+@\w+\.\w+$/.test(...)` per iteration):
+literal-loop **10.19 ms → 4.86 ms (2.1×)**, matching the hand-hoisted floor (4.76 ms).
+Residual vs Node (2.53 ms) is the per-`.test()` dispatch gap, as predicted. Correctness
+verified interpreter-vs-compiled across the test-matrix (g/y exclusion, escaping
+mutation, identity, all six string consumers); `--verify` clean; regex/IL-verify/
+standalone/closure/module suites green.


### PR DESCRIPTION
## Regex performance: close the compiled-mode gap to Node

Investigation started from the cross-runtime benchmark, where compiled regex was **3.2× slower than Node** at the meaningful sizes. A/B measurement showed the .NET `Regex` *engine* was not the bottleneck — result materialization and per-evaluation construction were. This PR lands four semantics-preserving levers, each measured.

### What's in here

| # | Lever | Effect |
|---|---|---|
| 1 | **Alloc-light match path** — `String.prototype.match(/g)` iterates `Regex.EnumerateMatches` (span-based `ValueMatch`) instead of `Regex.Matches()`, dropping the per-match `Match`/`Group` allocation | match path ~2.3× |
| 2 | **`RegexOptions.Compiled`** on the cached engine (was running interpreted; amortized by the existing `(pattern, options)` compile cache) | ~1.3× on raw matching |
| 3 | **Wrapper-construction template cache** — validate/normalize/scan/compile once per `(pattern, flags)` instead of every construction | 1.3–4.1× per construction |
| 4 | **Compiled regex-literal hoisting** — a constant `/lit/` in a safe consuming position becomes one static `$RegExp` per site (V8-style, lazy `ldsfld`/init) instead of `new $RegExp` per evaluation | literal-in-loop 2.1× |

Levers 1+2 apply to both the interpreter and the compiled `$RegExp` emitter. Lever 3 is the interpreter runtime type. Lever 4 is compiled-only.

### Measured (compiled, Windows x64, .NET preview)

- `regex.ts` bulk match, N=10000: **6.85 ms → 3.44 ms** — compiled-vs-Node **3.20× → 1.61×**.
- Literal-in-a-loop `/^\w+@\w+\.\w+$/.test(...)`, N=100k: **10.19 ms → 4.86 ms (2.1×)**, hitting the hand-hoisted floor (4.76 ms).

### Safety notes for review

- **Levers 1–3 are semantics-preserving by construction**: `Compiled` changes *how* not *what*; `EnumerateMatches` returns the same matches as `Matches`; the template cache runs identical validation, just memoized (invalid patterns still throw `SyntaxError` on every construction, validation ordering preserved).
- **Lever 4 safety gate** (`RegexLiteralHoistAnalyzer`): hoist `.test`/`.exec` receivers **only without `g`/`y`** (they advance `lastIndex` across evaluations); hoist `match`/`matchAll`/`replace`/`replaceAll`/`search`/`split` args always (those scan from 0 and never read instance `lastIndex`); exclude anything that escapes. The set/field map are **reference-keyed** (`Expr.RegexLiteral` is a record — value-keying would let an escaping `const r = /a/` wrongly share a hoisted `/a/.test()`). Wired into both `Compile` and `CompileModules`.

### Tests

- +10 dual-mode hoisting regression tests (`RegExpLiteralHoistingTests`): `g`/`y` exclusion, escaping mutation isolation, identity, all six string consumers — interpreter as oracle, compiled must match.
- Full unit suite **14,000 green**; regex / IL-verification / standalone-DLL / closure / module suites green; `--verify` clean on all hoisted shapes.
- **Test262 run is pending** (regex is conformance-sensitive — covers `lastIndex`/identity edges that gate lever 4); results to follow before merge.

### Deferred / out of scope (documented)

- The remaining ~1.6× on bulk and ~1.9× on literal-loops vs Node is the per-`.test()` dispatch + `Regex.Replace` engine throughput — a fundamental .NET-vs-Irregexp gap, not closeable by these techniques. See `docs/plans/regex-literal-hoisting-scope.md`.
- An ECMAScript-mode-drop lever (~1.2×) is deferred pending Test262 — it changes matching semantics.

### Unrelated find

Filed #886 — `console.log`/assignment to `RegExp.lastIndex` emits unverifiable IL on `main` (pre-existing, not touched here).
