### PR TITLE
Fix #886: compiled RegExp.lastIndex / process.exitCode assignment emits unverifiable IL

### DIFF
--- a/Compilation/ILEmitter.Properties.cs
+++ b/Compilation/ILEmitter.Properties.cs
@@ -557,12 +557,20 @@ public partial class ILEmitter
         if (s.Object is Expr.Variable processVar && processVar.Name.Lexeme == "process" && s.Name.Lexeme == "exitCode")
         {
             EmitExpression(s.Value);
-            EmitUnboxToDouble();
+            // #886: coerce to a native double only when the value isn't already one.
+            // An unconditional EmitUnboxToDouble() (Convert.ToDouble(object)) fails IL
+            // verification for native-double inputs (e.g. a numeric literal), which arrive
+            // unboxed with _stackType == Double.
+            EnsureDouble();
             IL.Emit(OpCodes.Conv_I4);
             IL.Emit(OpCodes.Dup); // Keep value for expression result
             IL.Emit(OpCodes.Call, _ctx.Types.GetPropertySetter(_ctx.Types.Environment, "ExitCode"));
             IL.Emit(OpCodes.Conv_R8); // Convert back to double for JS number
-            IL.Emit(OpCodes.Box, _ctx.Types.Double);
+            // #886: EmitBoxDouble boxes AND resets _stackType to Unknown. A raw
+            // IL.Emit(Box) leaves _stackType == Double stale over a boxed value, so a
+            // downstream consumer (e.g. the top-level await-drain wrapper) emits a second
+            // box and the IL fails verification.
+            EmitBoxDouble();
             return;
         }
 
@@ -655,9 +663,12 @@ public partial class ILEmitter
             var valueTemp = IL.DeclareLocal(_ctx.Types.Double);
             IL.Emit(OpCodes.Stloc, valueTemp);
             IL.Emit(OpCodes.Call, _ctx.Runtime!.RegExpSetLastIndex);
-            // Put value back on stack as boxed result
+            // Put value back on stack as boxed result. EmitBoxDouble boxes AND resets
+            // _stackType to Unknown (#886): a raw IL.Emit(Box) left _stackType == Double
+            // stale over a boxed value, so a downstream consumer re-boxed it and the
+            // emitted IL failed verification (StackUnexpected: ref 'float64' vs Double).
             IL.Emit(OpCodes.Ldloc, valueTemp);
-            IL.Emit(OpCodes.Box, _ctx.Types.Double);
+            EmitBoxDouble();
             return;
         }
 

--- a/Compilation/StateMachineEmitHelpers.cs
+++ b/Compilation/StateMachineEmitHelpers.cs
@@ -324,12 +324,23 @@ public class StateMachineEmitHelpers
         }
     }
 
+    // INVARIANT: after any value-producing emit, _stackType must describe the value actually
+    // on top of the IL stack. The EmitBox* helpers below box AND reset _stackType to Unknown
+    // so callers can't desync the two. Prefer them over a raw `IL.Emit(OpCodes.Box, ...)` for
+    // any box whose result is left on the stack as an expression/statement result: a raw box
+    // leaves _stackType stale (e.g. still Double over a boxed double), and a downstream
+    // _stackType-sensitive consumer — the top-level await-drain wrapper, EmitBoxIfNeeded,
+    // EnsureDouble, arithmetic — then emits a second box / native op and the IL fails
+    // verification (#886; see also #441 in AsyncArrowMoveNextEmitter.Expressions.cs).
+
+    /// <summary>Boxes a native double and resets _stackType to Unknown (maintains the invariant above).</summary>
     public void EmitBoxDouble()
     {
         _il.Emit(OpCodes.Box, _types.Double);
         SetStackUnknown();
     }
 
+    /// <summary>Boxes a native bool and resets _stackType to Unknown (maintains the invariant above).</summary>
     public void EmitBoxBool()
     {
         _il.Emit(OpCodes.Box, _types.Boolean);

--- a/SharpTS.Tests/CompilerTests/ILVerificationTests.cs
+++ b/SharpTS.Tests/CompilerTests/ILVerificationTests.cs
@@ -1667,4 +1667,111 @@ public class ILVerificationTests
         Assert.Equal("2\n3\n1\nok\nr\n3\n2\n", output);
         Assert.Equal(output, TestHarness.RunInterpreted(source));
     }
+
+    // #886: assigning to a built-in property whose setter ends by boxing the result and
+    // returning (RegExp.lastIndex, process.exitCode) left _stackType == Double stale over a
+    // boxed value. A downstream consumer (top-level await-drain wrapper, or arithmetic on the
+    // assignment result) then trusted the stale type and emitted a second box / native op,
+    // producing unverifiable IL (StackUnexpected: ref 'float64' vs Double). The setters now
+    // route the trailing box through EmitBoxDouble (box + SetStackUnknown).
+
+    [Fact]
+    public void RegExpLastIndexAssignment_TopLevel_PassesILVerification()
+    {
+        var source = """
+            const r = /a/;
+            r.lastIndex = 5;
+            console.log(r.lastIndex);
+            """;
+
+        var (errors, output) = TestHarness.CompileVerifyAndRun(source);
+
+        Assert.Empty(errors);
+        Assert.Equal("5\n", output);
+        Assert.Equal(output, TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void RegExpLastIndexAssignment_FromVariable_PassesILVerification()
+    {
+        var source = """
+            const r = /a/;
+            let n = 5;
+            r.lastIndex = n;
+            console.log(r.lastIndex);
+            """;
+
+        var (errors, output) = TestHarness.CompileVerifyAndRun(source);
+
+        Assert.Empty(errors);
+        Assert.Equal("5\n", output);
+        Assert.Equal(output, TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void RegExpLastIndexAssignment_FromCoercedString_PassesILVerification()
+    {
+        // The non-Double branch (box + Convert.ToDouble) must still verify: "1.9" coerces to
+        // 1.9, then RegExpSetLastIndex truncates to an int -> lastIndex == 1.
+        var source = """
+            const r = /a/;
+            r.lastIndex = "1.9" as any;
+            console.log(r.lastIndex);
+            """;
+
+        var (errors, output) = TestHarness.CompileVerifyAndRun(source);
+
+        Assert.Empty(errors);
+        Assert.Equal("1\n", output);
+        Assert.Equal(output, TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void RegExpLastIndexAssignment_UsedAsValue_PassesILVerification()
+    {
+        // The assignment result is consumed by arithmetic inside a function body. Before the fix
+        // this failed with ExpectedNumericType {Found=ref 'float64'} (native add on a boxed double).
+        var source = """
+            function f(): number {
+                const r = /a/;
+                let x = (r.lastIndex = 5) + 1;
+                return x;
+            }
+            console.log(f());
+            """;
+
+        var (errors, output) = TestHarness.CompileVerifyAndRun(source);
+
+        Assert.Empty(errors);
+        Assert.Equal("6\n", output);
+        Assert.Equal(output, TestHarness.RunInterpreted(source));
+    }
+
+    [Fact]
+    public void ProcessExitCodeAssignment_Literal_ProducesVerifiableIL()
+    {
+        // Uses CompileAndVerifyOnly (not ...AndRun) because setting a non-zero exit code would
+        // make the harness treat the process as failed. Before the fix this produced two errors:
+        // an unconditional Convert.ToDouble on a native double, plus the trailing double-box.
+        var source = """
+            process.exitCode = 5;
+            """;
+
+        var errors = TestHarness.CompileAndVerifyOnly(source);
+
+        Assert.Empty(errors);
+    }
+
+    [Fact]
+    public void ProcessExitCodeAssignment_FromVariable_ProducesVerifiableIL()
+    {
+        var source = """
+            let n = 3;
+            process.exitCode = n;
+            """;
+
+        var errors = TestHarness.CompileAndVerifyOnly(source);
+
+        Assert.Empty(errors);
+    }
 }

--- a/SharpTS.Tests/Infrastructure/TestHarness.cs
+++ b/SharpTS.Tests/Infrastructure/TestHarness.cs
@@ -289,6 +289,22 @@ public static class TestHarness
 
         // Skip the disk roundtrip — load the assembly straight from the in-memory PE bytes.
         var bytes = compiler.SaveToBytes();
+
+        // Systemic guardrail (#886): with SHARPTS_VERIFY_COMPILED=1, run ILVerify on every
+        // in-process compiled program so the whole compiled-mode suite becomes a provable check
+        // for IL-correctness regressions (stale _stackType, double-box, etc.). Opt-in because the
+        // suite may still contain pre-existing unverifiable-but-runnable programs that need triage
+        // before this can be enabled by default.
+        if (Environment.GetEnvironmentVariable("SHARPTS_VERIFY_COMPILED") == "1")
+        {
+            var verifyErrors = VerifyILBytes(bytes)
+                .Where(e => !e.Contains("Failed to load assembly"))
+                .ToList();
+            if (verifyErrors.Count > 0)
+                throw new InvalidOperationException(
+                    "IL verification failed for compiled program:\n  " + string.Join("\n  ", verifyErrors));
+        }
+
         var assembly = Assembly.Load(bytes);
         var programType = assembly.GetType("$Program")
             ?? throw new InvalidOperationException("Compiled assembly has no $Program type");
@@ -1129,6 +1145,17 @@ public static class TestHarness
     {
         using var verifier = new ILVerifier();
         using var stream = File.OpenRead(dllPath);
+        return verifier.Verify(stream);
+    }
+
+    /// <summary>
+    /// Verifies IL from in-memory PE bytes (no disk roundtrip). Used by the opt-in
+    /// suite-wide verification guardrail in <see cref="RunCompiledInProcess"/>.
+    /// </summary>
+    public static List<string> VerifyILBytes(byte[] bytes)
+    {
+        using var verifier = new ILVerifier();
+        using var stream = new MemoryStream(bytes);
         return verifier.Verify(stream);
     }
 


### PR DESCRIPTION
Closes #886.

## Root cause

Compiled `r.lastIndex = 5` emitted unverifiable IL (`StackUnexpected: ref 'float64' vs Double`). The reporter's hypothesis (the `if (_stackType != StackType.Double)` skip at `ILEmitter.Properties.cs:648`) was a **red herring** — that guard is correct.

I root-caused it by dumping the emitted IL of `$Program.Main`:

```
IL_0033: ldloc.0
IL_0034: box [Double]   // emitted by the setter branch (correct value, stale _stackType)
IL_0039: box [Double]   // BUG (offset 0x39 = 57): consumer re-boxes, trusting _stackType==Double
```

The RegExp `lastIndex` setter **and** the `process.exitCode` setter ended with a raw `IL.Emit(OpCodes.Box, Double); return;` **without** calling `SetStackUnknown()`. That left `_stackType == Double` stale over a *boxed* double. A downstream `_stackType`-sensitive consumer (the top-level await-drain wrapper, or arithmetic on the assignment result) then trusted the stale type and emitted a **second box** → bad IL. This is the same `_stackType`-desync class warned about in the #441 comment, and already guarded elsewhere via `SetStackUnknown()`.

### Trigger characterization (compiled + `--verify`)

| Repro | before | why |
|---|---|---|
| `r.lastIndex = 5` (top-level) | fails (off. 57) | await-drain wrapper re-boxes the stale-Double result |
| `r.lastIndex = n` (var) | fails | same |
| `(r.lastIndex = 5) + 1` (in fn) | fails — `ExpectedNumericType {ref 'float64'}` | native arithmetic on a boxed double |
| `r.lastIndex = 5` (in fn, discarded) | passes | stale type never consumed — *latent* |
| `process.exitCode = 5` | fails, **2 errors** | unconditional `Convert.ToDouble` on a native double + trailing double-box |

## Fix

- Route both setters' trailing box through `EmitBoxDouble()` (box **+** `SetStackUnknown()`) instead of a raw `IL.Emit(Box)`.
- `process.exitCode` also switched from unconditional `EmitUnboxToDouble()` to `EnsureDouble()` (the unconditional `Convert.ToDouble(object)` failed verification for native-double inputs — a mirror-image second error).
- Documented the invariant on the `EmitBox*` helpers: *after any value-producing emit, `_stackType` must match the real top-of-stack; use `EmitBox*` (not raw `IL.Emit(Box)`) for any result-leaving box.*

An audit (`grep "IL.Emit(OpCodes.Box"` = 139 hits) found only **two** `box → return` sites in the whole compiler — both fixed here. Every other box is immediately consumed, so its stack-type staleness is harmless.

## Tests

- 6 regression tests in `ILVerificationTests` (top-level, variable, coerced-string, used-as-value, `process.exitCode` ×2). The existing hoisting test ran `r.lastIndex` but **never through IL verification**, which is why this escaped.
- **Opt-in systemic guardrail**: `SHARPTS_VERIFY_COMPILED=1` runs ILVerify on every in-process compiled program, turning the whole compiled-mode suite into a provable IL check. Opt-in because it surfaces a large pre-existing backlog (47 tests) of the same bug class (unverifiable-but-runnable IL) — see below.

## Verification

- All 5 repro variants now pass `--verify` and match the interpreter (`5`/`6`; `process.exitCode=5` → exit code 5).
- `ILVerificationTests`: 77/77.
- Full suite: only known noise (load-flaky tests that pass in isolation + the stale Test262 baselines, which the compiler-only change cannot affect).

## Follow-up (not in this PR)

- **47-test pre-existing backlog** of the same bug class revealed by the guardrail: GlobalThis (16), Namespaces (9), `extends Error` (4), async super/await (4), PromiseSubclass, Proxy, Http, etc. Driving this to zero would let the guardrail be default-on.
- **Separate bug discovered**: regex *literals* (`/a/`) inside `async`/generator bodies are null/wrong in compiled mode (the `MoveNext` emitters don't override `EmitRegexLiteral`, bypassing the `ILEmitter.Expressions.cs:852` override); `new RegExp()` works. Passes `--verify` but fails at runtime.
- Long-term: unify the two stack-type models (`_stackType` scalar vs the dormant typed shadow stack in `ValidatedILBuilder`).