### PR TITLE
Compiled perf: typed arrays, JSON.parse, charCodeAt + shaped-objects design

### DIFF
--- a/Compilation/EmittedRuntime.cs
+++ b/Compilation/EmittedRuntime.cs
@@ -1605,6 +1605,29 @@ public class EmittedRuntime
     public MethodBuilder Float64ArrayGetUnboxed { get; set; } = null!;
     public MethodBuilder Float64ArraySetUnboxed { get; set; } = null!;
 
+    // Unboxed numeric typed-array element accessors (#3) — `double GetUnboxed(int)` /
+    // `void SetUnboxed(int, double)` on each concrete numeric $XArray, keyed by element-type
+    // prefix ("Int32", "Float64", …). Bypass the boxed Get/Set + GetIndex dispatch and the
+    // per-element double box on BOTH read and write. BigInt + Uint8Clamped are absent (they
+    // fall back to the boxed path).
+    public Dictionary<string, MethodBuilder> TypedArrayGetUnboxedByElement { get; } = new();
+    public Dictionary<string, MethodBuilder> TypedArraySetUnboxedByElement { get; } = new();
+
+    /// <summary>Concrete emitted $XArray type for a numeric element prefix, or null (BigInt/unknown).</summary>
+    public Type? GetTypedArrayType(string elementType) => elementType switch
+    {
+        "Int8" => Int8ArrayType,
+        "Uint8" => Uint8ArrayType,
+        "Uint8Clamped" => Uint8ClampedArrayType,
+        "Int16" => Int16ArrayType,
+        "Uint16" => Uint16ArrayType,
+        "Int32" => Int32ArrayType,
+        "Uint32" => Uint32ArrayType,
+        "Float32" => Float32ArrayType,
+        "Float64" => Float64ArrayType,
+        _ => null
+    };
+
     // Concrete TypedArray types (pure-IL for standalone DLLs)
     public TypeBuilder Int8ArrayType { get; set; } = null!;
     public ConstructorBuilder Int8ArrayLengthCtor { get; set; } = null!;

--- a/Compilation/ILEmitter.Calls.MethodDispatch.cs
+++ b/Compilation/ILEmitter.Calls.MethodDispatch.cs
@@ -35,6 +35,26 @@ public partial class ILEmitter
             return;
         }
 
+        // Statically-typed string receiver charCodeAt (lexer / interpreter hot path, e.g. brainfuck's
+        // `program.charCodeAt(ip)`): the receiver is known to be a CLR string, so call StringCharCodeAt
+        // directly with the index passed UNBOXED via EmitExpressionAsDouble (proper ToNumber, no
+        // box→ToNumber round-trip) and leave the result as a raw double (SetStackType) instead of boxing.
+        // The common numeric consumer (`=== 43`, `sum + …`) then pays no box/unbox; a boxed consumer
+        // re-boxes lazily via EmitBoxIfNeeded. Mirrors the #859 promoted-accumulator path for plain
+        // strings; the any-typed receiver still routes through the boxed EmitStringOnlyMethodCall path.
+        if (methodName == "charCodeAt" && !methodGet.Optional && arguments.Count <= 1
+            && _ctx.TypeMap?.Get(methodGet.Object) is TypeSystem.TypeInfo.String)
+        {
+            EmitExpression(methodGet.Object);
+            EmitBoxIfNeeded(methodGet.Object);
+            IL.Emit(OpCodes.Castclass, _ctx.Types.String);
+            if (arguments.Count > 0) EmitExpressionAsDouble(arguments[0]);
+            else IL.Emit(OpCodes.Ldc_R8, 0.0);
+            IL.Emit(OpCodes.Call, _ctx.Runtime!.StringCharCodeAt);
+            SetStackType(StackType.Double);
+            return;
+        }
+
         // Promoted number[] local reduce (#861 typed-HOF pipeline): `arr.reduce((a,x)=>…, init)` over a
         // List<double> with a non-capturing double(double,double) reducer → bind the arrow's typed static
         // method DIRECTLY to Func<double,double,double> (no boxed adapter) and drive ArrayReduceDouble —

--- a/Compilation/ILEmitter.Operators.cs
+++ b/Compilation/ILEmitter.Operators.cs
@@ -1635,6 +1635,54 @@ public partial class ILEmitter
         // 2. Apply operation
         // 3. Store back
 
+        // Numeric typed-array compound-assign fast path (#3): `a[i] OP= v` where `a` is a statically-
+        // typed numeric typed array and `v` is statically a number. Reads via GetUnboxed → double,
+        // applies the op in native double/int space (the same helper the boxed path uses), writes via
+        // SetUnboxed — no GetIndex/Add/SetIndex dispatch and no per-element boxing. Other receivers,
+        // operators, RHS types (BigInt/Uint8Clamped have no accessor) fall through to the boxed path.
+        if (csi.Object is Expr.Variable
+            && _ctx.TypeMap?.Get(csi.Object) is TypeInfo.TypedArray cta
+            && _ctx.Runtime!.GetTypedArrayType(cta.ElementType) is { } ctaType
+            && _ctx.Runtime!.TypedArrayGetUnboxedByElement.TryGetValue(cta.ElementType, out var ctaGet)
+            && _ctx.Runtime!.TypedArraySetUnboxedByElement.TryGetValue(cta.ElementType, out var ctaSet)
+            && _ctx.TypeMap?.Get(csi.Value) is TypeInfo.Primitive { Type: TokenType.TYPE_NUMBER } or TypeInfo.NumberLiteral
+            && IsArithmeticOrBitwiseCompound(csi.Operator.Type))
+        {
+            // recv = (TAType)a  — side-effect-free variable, loaded once
+            EmitExpression(csi.Object);
+            EnsureBoxed();
+            IL.Emit(OpCodes.Castclass, ctaType);
+            var recvLocal = IL.DeclareLocal(ctaType);
+            IL.Emit(OpCodes.Stloc, recvLocal);
+
+            // idx = (int)i
+            EmitExpressionAsDouble(csi.Index);
+            IL.Emit(OpCodes.Conv_I4);
+            var idxLocal = IL.DeclareLocal(_ctx.Types.Int32);
+            IL.Emit(OpCodes.Stloc, idxLocal);
+
+            // cur = recv.GetUnboxed(idx)  → double
+            IL.Emit(OpCodes.Ldloc, recvLocal);
+            IL.Emit(OpCodes.Ldloc, idxLocal);
+            IL.Emit(OpCodes.Call, ctaGet);
+
+            // result = cur OP v  (double)
+            EmitCompoundArithmeticDoubleOnStack(csi.Operator.Type, csi.Value);
+            var resLocal = IL.DeclareLocal(_ctx.Types.Double);
+            IL.Emit(OpCodes.Stloc, resLocal);
+
+            // recv.SetUnboxed(idx, result)
+            IL.Emit(OpCodes.Ldloc, recvLocal);
+            IL.Emit(OpCodes.Ldloc, idxLocal);
+            IL.Emit(OpCodes.Ldloc, resLocal);
+            IL.Emit(OpCodes.Call, ctaSet);
+
+            // The compound-assignment expression evaluates to the stored numeric result.
+            IL.Emit(OpCodes.Ldloc, resLocal);
+            SetStackType(StackType.Double);
+            return;
+        }
+
         // Spill receiver and index once so the read-guard and the write reuse them
         // (also avoids re-evaluating side-effecting subexpressions twice).
         EmitExpression(csi.Object);
@@ -1677,9 +1725,6 @@ public partial class ILEmitter
     private void EmitCompoundOperation(TokenType opType, Expr value)
     {
         // Stack has current value (object). Apply the operation.
-        bool isBitwise = opType is TokenType.AMPERSAND_EQUAL or TokenType.PIPE_EQUAL
-            or TokenType.CARET_EQUAL or TokenType.LESS_LESS_EQUAL or TokenType.GREATER_GREATER_EQUAL;
-
         if (opType == TokenType.PLUS_EQUAL && IsStringExpression(value))
         {
             // String concatenation - we know right side is a string at compile time.
@@ -1703,8 +1748,27 @@ public partial class ILEmitter
             return;
         }
 
-        // Convert current value to number
+        // Convert current value to number, apply the op in double/int space, re-box.
         EmitUnboxToDouble();
+        EmitCompoundArithmeticDoubleOnStack(opType, value);
+        IL.Emit(OpCodes.Box, _ctx.Types.Double);
+    }
+
+    // The compound operators handled by the numeric path (arithmetic + bitwise) — i.e. those that
+    // the typed-array compound fast path can compute in native double/int space.
+    private static bool IsArithmeticOrBitwiseCompound(TokenType op) => op is
+        TokenType.PLUS_EQUAL or TokenType.MINUS_EQUAL or TokenType.STAR_EQUAL or
+        TokenType.SLASH_EQUAL or TokenType.PERCENT_EQUAL or TokenType.AMPERSAND_EQUAL or
+        TokenType.PIPE_EQUAL or TokenType.CARET_EQUAL or TokenType.LESS_LESS_EQUAL or
+        TokenType.GREATER_GREATER_EQUAL;
+
+    // Stack in: [cur (double)]. Applies `cur OP value` in native double space (JS bitwise ops route
+    // through int32) and leaves the numeric result as a double. Shared by the boxed compound path
+    // and the typed-array compound fast path so the two always agree on semantics.
+    private void EmitCompoundArithmeticDoubleOnStack(TokenType opType, Expr value)
+    {
+        bool isBitwise = opType is TokenType.AMPERSAND_EQUAL or TokenType.PIPE_EQUAL
+            or TokenType.CARET_EQUAL or TokenType.LESS_LESS_EQUAL or TokenType.GREATER_GREATER_EQUAL;
 
         if (isBitwise)
         {
@@ -1719,44 +1783,22 @@ public partial class ILEmitter
 
         switch (opType)
         {
-            case TokenType.PLUS_EQUAL:
-                IL.Emit(OpCodes.Add);
-                break;
-            case TokenType.MINUS_EQUAL:
-                IL.Emit(OpCodes.Sub);
-                break;
-            case TokenType.STAR_EQUAL:
-                IL.Emit(OpCodes.Mul);
-                break;
-            case TokenType.SLASH_EQUAL:
-                IL.Emit(OpCodes.Div);
-                break;
-            case TokenType.PERCENT_EQUAL:
-                IL.Emit(OpCodes.Rem);
-                break;
-            case TokenType.AMPERSAND_EQUAL:
-                IL.Emit(OpCodes.And);
-                break;
-            case TokenType.PIPE_EQUAL:
-                IL.Emit(OpCodes.Or);
-                break;
-            case TokenType.CARET_EQUAL:
-                IL.Emit(OpCodes.Xor);
-                break;
-            case TokenType.LESS_LESS_EQUAL:
-                IL.Emit(OpCodes.Shl);
-                break;
-            case TokenType.GREATER_GREATER_EQUAL:
-                IL.Emit(OpCodes.Shr);
-                break;
+            case TokenType.PLUS_EQUAL: IL.Emit(OpCodes.Add); break;
+            case TokenType.MINUS_EQUAL: IL.Emit(OpCodes.Sub); break;
+            case TokenType.STAR_EQUAL: IL.Emit(OpCodes.Mul); break;
+            case TokenType.SLASH_EQUAL: IL.Emit(OpCodes.Div); break;
+            case TokenType.PERCENT_EQUAL: IL.Emit(OpCodes.Rem); break;
+            case TokenType.AMPERSAND_EQUAL: IL.Emit(OpCodes.And); break;
+            case TokenType.PIPE_EQUAL: IL.Emit(OpCodes.Or); break;
+            case TokenType.CARET_EQUAL: IL.Emit(OpCodes.Xor); break;
+            case TokenType.LESS_LESS_EQUAL: IL.Emit(OpCodes.Shl); break;
+            case TokenType.GREATER_GREATER_EQUAL: IL.Emit(OpCodes.Shr); break;
         }
 
         if (isBitwise)
         {
             IL.Emit(OpCodes.Conv_R8);
         }
-
-        IL.Emit(OpCodes.Box, _ctx.Types.Double);
     }
 
     private bool IsNumericPlusOperation(Expr.Binary b)

--- a/Compilation/ILEmitter.Properties.cs
+++ b/Compilation/ILEmitter.Properties.cs
@@ -858,21 +858,25 @@ public partial class ILEmitter
             return;
         }
 
-        // Float64Array fast path (#878): when the receiver is a variable statically typed
-        // Float64Array, read the element UNBOXED via $Float64Array.GetUnboxed → native double
-        // on the stack. Eliminates the Runtime.GetIndex dispatch, the GetTypedArrayElement
-        // isinst/castclass, the virtual Get, and the per-element box. Out-of-range access
-        // faults via BitConverter exactly as the boxed path does today (OOB semantics
-        // unchanged). Receiver is a side-effect-free variable, so it is loaded once.
+        // Numeric typed-array fast path (#3, generalizing #878 past Float64): when the receiver is
+        // a variable statically typed as a numeric typed array, read the element UNBOXED via
+        // $XArray.GetUnboxed → native double on the stack. Eliminates the Runtime.GetIndex dispatch,
+        // the GetTypedArrayElement isinst/castclass, the virtual Get, and the per-element box. BigInt
+        // and Uint8Clamped have no entry → fall through to the boxed path. Out-of-range access faults
+        // exactly as the boxed path does today. Receiver is side-effect-free, so it is loaded once.
         if (!gi.Optional && gi.Object is Expr.Variable
-            && _ctx.TypeMap?.Get(gi.Object) is TypeInfo.TypedArray { ElementType: "Float64" })
+            && _ctx.TypeMap?.Get(gi.Object) is TypeInfo.TypedArray gta
+            && _ctx.Runtime!.GetTypedArrayType(gta.ElementType) is { } gtaType
+            && _ctx.Runtime!.TypedArrayGetUnboxedByElement.TryGetValue(gta.ElementType, out var taGetU))
         {
             EmitExpression(gi.Object);
             EnsureBoxed();
-            IL.Emit(OpCodes.Castclass, _ctx.Runtime!.Float64ArrayType);
+            IL.Emit(OpCodes.Castclass, gtaType);
             EmitExpressionAsDouble(gi.Index);
             IL.Emit(OpCodes.Conv_I4);
-            IL.Emit(OpCodes.Callvirt, _ctx.Runtime!.Float64ArrayGetUnboxed);
+            // Non-virtual call to the sealed-type accessor → the JIT inlines it (AggressiveInlining)
+            // so the receiver's _buffer load and the element bounds check can hoist out of loops.
+            IL.Emit(OpCodes.Call, taGetU);
             SetStackType(StackType.Double);
             return;
         }
@@ -1060,15 +1064,18 @@ public partial class ILEmitter
             return;
         }
 
-        // Float64Array fast path (#878): variable statically typed Float64Array with a
-        // statically-numeric RHS — write the element UNBOXED via $Float64Array.SetUnboxed.
-        // Eliminates the Runtime.SetIndex dispatch, the isinst, the value box, and the
-        // Convert.ToDouble coercion. A non-numeric RHS falls through to the boxed path,
-        // which performs JS ToNumber coercion. OOB faults exactly as the boxed path does.
+        // Numeric typed-array fast path (#3, generalizing #878 past Float64): variable statically
+        // typed as a numeric typed array with a statically-numeric RHS — write the element UNBOXED
+        // via $XArray.SetUnboxed. Eliminates the Runtime.SetIndex dispatch, the isinst, the value
+        // box, and the Convert.ToDouble coercion; the double→element narrowing lives in SetUnboxed
+        // and matches the boxed Set. A non-numeric RHS (or BigInt/Uint8Clamped) falls through to the
+        // boxed path, which performs JS ToNumber coercion. OOB faults exactly as the boxed path does.
         // Evaluate index then value (the receiver var is side-effect-free).
         if (si.Object is Expr.Variable
-            && _ctx.TypeMap?.Get(si.Object) is TypeInfo.TypedArray { ElementType: "Float64" }
-            && _ctx.TypeMap?.Get(si.Value) is TypeInfo.Primitive { Type: TokenType.TYPE_NUMBER })
+            && _ctx.TypeMap?.Get(si.Object) is TypeInfo.TypedArray sta
+            && _ctx.Runtime!.GetTypedArrayType(sta.ElementType) is { } staType
+            && _ctx.Runtime!.TypedArraySetUnboxedByElement.TryGetValue(sta.ElementType, out var taSetU)
+            && _ctx.TypeMap?.Get(si.Value) is TypeInfo.Primitive { Type: TokenType.TYPE_NUMBER } or TypeInfo.NumberLiteral)
         {
             EmitExpressionAsDouble(si.Index);
             IL.Emit(OpCodes.Conv_I4);
@@ -1082,12 +1089,13 @@ public partial class ILEmitter
 
             EmitExpression(si.Object);
             EnsureBoxed();
-            IL.Emit(OpCodes.Castclass, _ctx.Runtime!.Float64ArrayType);
+            IL.Emit(OpCodes.Castclass, staType);
             IL.Emit(OpCodes.Ldloc, idxLocal);
             IL.Emit(OpCodes.Ldloc, valLocal);
-            IL.Emit(OpCodes.Callvirt, _ctx.Runtime!.Float64ArraySetUnboxed);
+            // Non-virtual call to the sealed-type accessor → the JIT inlines it (AggressiveInlining).
+            IL.Emit(OpCodes.Call, taSetU);
 
-            // Assignment expression result: the (unboxed) assigned value.
+            // Assignment expression result: the (unboxed) assigned value (the RHS, JS semantics).
             IL.Emit(OpCodes.Ldloc, valLocal);
             SetStackType(StackType.Double);
             return;

--- a/Compilation/RuntimeEmitter.Arrays.Mutators.cs
+++ b/Compilation/RuntimeEmitter.Arrays.Mutators.cs
@@ -1058,6 +1058,13 @@ public partial class RuntimeEmitter
         var midLocal = il.DeclareLocal(_types.Int32);
         var hiLocal = il.DeclareLocal(_types.Int32);
         var kLocal = il.DeclareLocal(_types.Int32);
+        // Comparator-argument buffer, allocated ONCE below and reused for every comparison.
+        // The merge loop previously did `new object[2]` per compared pair — Θ(n log n)
+        // throwaway arrays, the dominant cost (and GC-variance source) of compiled sort on
+        // large inputs. The guest comparator only ever sees its two parameters, never this
+        // backing array, so reusing it across all comparisons is safe (the interpreter's
+        // CompareFnComparer reuses its arg list for the same reason).
+        var argsLocal = il.DeclareLocal(_types.ObjectArray);
 
         // n = defined.Count
         il.Emit(OpCodes.Ldloc, definedLocal);
@@ -1074,6 +1081,11 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloc, nLocal);
         il.Emit(OpCodes.Newarr, _types.Object);
         il.Emit(OpCodes.Stloc, dstLocal);
+
+        // argsBuf = new object[2] — allocated once here; reused for every comparator call.
+        il.Emit(OpCodes.Ldc_I4_2);
+        il.Emit(OpCodes.Newarr, _types.Object);
+        il.Emit(OpCodes.Stloc, argsLocal);
 
         var widthCond = il.DefineLabel();
         var widthBody = il.DefineLabel();
@@ -1189,23 +1201,20 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Br, checkCompareResult);
 
         il.MarkLabel(hasCompareFn);
-        // result = InvokeValue(compareFn, new object[] { src[i], src[j] })
-        il.Emit(OpCodes.Ldc_I4_2);
-        il.Emit(OpCodes.Newarr, _types.Object);
-        il.Emit(OpCodes.Dup);
+        // result = InvokeValue(compareFn, argsBuf) with argsBuf[0]=src[i], argsBuf[1]=src[j].
+        // argsBuf is the single hoisted object[2] declared above — no per-comparison allocation.
+        il.Emit(OpCodes.Ldloc, argsLocal);
         il.Emit(OpCodes.Ldc_I4_0);
         il.Emit(OpCodes.Ldloc, srcLocal);
         il.Emit(OpCodes.Ldloc, iLocal);
         il.Emit(OpCodes.Ldelem_Ref);
         il.Emit(OpCodes.Stelem_Ref);
-        il.Emit(OpCodes.Dup);
+        il.Emit(OpCodes.Ldloc, argsLocal);
         il.Emit(OpCodes.Ldc_I4_1);
         il.Emit(OpCodes.Ldloc, srcLocal);
         il.Emit(OpCodes.Ldloc, jLocal);
         il.Emit(OpCodes.Ldelem_Ref);
         il.Emit(OpCodes.Stelem_Ref);
-        var argsLocal = il.DeclareLocal(_types.ObjectArray);
-        il.Emit(OpCodes.Stloc, argsLocal);
         il.Emit(OpCodes.Ldarg_1);
         il.Emit(OpCodes.Ldloc, argsLocal);
         il.Emit(OpCodes.Call, runtime.InvokeValue);

--- a/Compilation/RuntimeEmitter.Json.Parse.cs
+++ b/Compilation/RuntimeEmitter.Json.Parse.cs
@@ -78,6 +78,7 @@ public partial class RuntimeEmitter
     private MethodBuilder EmitJsonParseStaticHelper(TypeBuilder typeBuilder)
     {
         var validateControlChars = EmitJsonValidateControlChars(typeBuilder);
+        var parseValue = EmitParseValueFromReaderHelper(typeBuilder);
 
         var method = typeBuilder.DefineMethod(
             "ParseJsonValue",
@@ -88,55 +89,81 @@ public partial class RuntimeEmitter
 
         var il = method.GetILGenerator();
 
-        // Simple implementation: just call ToString and return
-        // This won't properly parse, but at least we can test the infrastructure
+        // One-pass parse: transcode the text to UTF-8 and walk it with a
+        // System.Text.Json.Utf8JsonReader straight into our runtime graph
+        // (Dictionary<string,object?> / List<object?> / boxed double|bool|string|null),
+        // instead of building a throwaway JsonDocument DOM and then re-walking it.
+        // Skipping the intermediate DOM removes a full second pass over the data and
+        // its allocations. Utf8JsonReader and Encoding live in the BCL, so the emitted
+        // token references System.Text.Json / System.Private.CoreLib, never SharpTS.dll
+        // — standalone DLLs stay standalone. The token decoders (GetString/GetDouble)
+        // are the SAME engine JsonDocument used, so the produced values are identical.
+        var readerType = typeof(System.Text.Json.Utf8JsonReader);
         var strLocal = il.DeclareLocal(_types.String);
+        var bytesLocal = il.DeclareLocal(typeof(byte[]));
+        var optionsLocal = il.DeclareLocal(typeof(System.Text.Json.JsonReaderOptions));
+        var readerLocal = il.DeclareLocal(readerType);
+        var resultLocal = il.DeclareLocal(_types.Object);
         var notNullLabel = il.DefineLabel();
+        var gotTokenLabel = il.DefineLabel();
+        var okEndLabel = il.DefineLabel();
 
+        // if (arg == null) return null;
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Brfalse_S, notNullLabel);
+
+        // str = arg.ToString();
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Callvirt, _types.GetMethodNoParams(_types.Object, "ToString"));
         il.Emit(OpCodes.Stloc, strLocal);
 
-        // ECMA-262 25.5.1 JSON grammar: control chars (U+0000–U+001F except
-        // \t \n \r as whitespace) are forbidden — both inside string literals
-        // (must be escaped as \u00XX) and in the JSON structural body.
-        // System.Text.Json.JsonDocument is lenient about some of these, so
-        // pre-validate and throw before Parse runs. The throw converts to
-        // SyntaxError via the outer catch in EmitJsonParse.
+        // ECMA-262 25.5.1: control chars (U+0000–U+001F except \t \n \r whitespace) are
+        // forbidden in the JSON grammar. Kept as an explicit pre-pass so behavior is
+        // identical to before; the throw converts to SyntaxError via EmitJsonParse's catch.
         il.Emit(OpCodes.Ldloc, strLocal);
         il.Emit(OpCodes.Call, validateControlChars);
 
-        // Parse using JsonDocument - keep typeof() for System.Text.Json types
-        var parseMethod = typeof(System.Text.Json.JsonDocument).GetMethod("Parse",
-            [typeof(string), typeof(System.Text.Json.JsonDocumentOptions)])!;
-        var optionsLocal = il.DeclareLocal(typeof(System.Text.Json.JsonDocumentOptions));
+        // bytes = Encoding.UTF8.GetBytes(str)
+        il.Emit(OpCodes.Call, typeof(System.Text.Encoding).GetProperty("UTF8")!.GetGetMethod()!);
         il.Emit(OpCodes.Ldloc, strLocal);
+        il.Emit(OpCodes.Callvirt, typeof(System.Text.Encoding).GetMethod("GetBytes", [typeof(string)])!);
+        il.Emit(OpCodes.Stloc, bytesLocal);
+
+        // reader = new Utf8JsonReader((ReadOnlySpan<byte>)bytes, default)
         il.Emit(OpCodes.Ldloca, optionsLocal);
-        il.Emit(OpCodes.Initobj, typeof(System.Text.Json.JsonDocumentOptions));
+        il.Emit(OpCodes.Initobj, typeof(System.Text.Json.JsonReaderOptions));
+        il.Emit(OpCodes.Ldloca, readerLocal);
+        il.Emit(OpCodes.Ldloc, bytesLocal);
+        il.Emit(OpCodes.Call, typeof(ReadOnlySpan<byte>).GetMethod("op_Implicit", [typeof(byte[])])!);
         il.Emit(OpCodes.Ldloc, optionsLocal);
-        il.Emit(OpCodes.Call, parseMethod);
+        il.Emit(OpCodes.Call, readerType.GetConstructor(
+            [typeof(ReadOnlySpan<byte>), typeof(System.Text.Json.JsonReaderOptions)])!);
 
-        // Get RootElement
-        var docLocal = il.DeclareLocal(typeof(System.Text.Json.JsonDocument));
-        il.Emit(OpCodes.Stloc, docLocal);
-        il.Emit(OpCodes.Ldloc, docLocal);
-        il.Emit(OpCodes.Callvirt, typeof(System.Text.Json.JsonDocument).GetProperty("RootElement")!.GetGetMethod()!);
+        // if (!reader.Read()) throw  — empty input is not a valid JSON document.
+        il.Emit(OpCodes.Ldloca, readerLocal);
+        il.Emit(OpCodes.Call, readerType.GetMethod("Read", Type.EmptyTypes)!);
+        il.Emit(OpCodes.Brtrue, gotTokenLabel);
+        il.Emit(OpCodes.Ldstr, "Unexpected end of JSON input");
+        il.Emit(OpCodes.Newobj, _types.GetConstructor(_types.Exception, _types.String));
+        il.Emit(OpCodes.Throw);
 
-        // Store element first before calling Clone (Clone is an instance method on struct)
-        var elemLocal = il.DeclareLocal(typeof(System.Text.Json.JsonElement));
-        il.Emit(OpCodes.Stloc, elemLocal);
+        il.MarkLabel(gotTokenLabel);
+        // result = ParseValueFromReader(ref reader)
+        il.Emit(OpCodes.Ldloca, readerLocal);
+        il.Emit(OpCodes.Call, parseValue);
+        il.Emit(OpCodes.Stloc, resultLocal);
 
-        // Clone the element to avoid disposal issues (need address for struct instance method)
-        il.Emit(OpCodes.Ldloca, elemLocal);
-        il.Emit(OpCodes.Call, typeof(System.Text.Json.JsonElement).GetMethod("Clone")!);
+        // A single JSON document must hold exactly one value: any non-whitespace
+        // trailing token is a SyntaxError (matches JsonDocument.Parse).
+        il.Emit(OpCodes.Ldloca, readerLocal);
+        il.Emit(OpCodes.Call, readerType.GetMethod("Read", Type.EmptyTypes)!);
+        il.Emit(OpCodes.Brfalse, okEndLabel);
+        il.Emit(OpCodes.Ldstr, "Unexpected non-whitespace character after JSON");
+        il.Emit(OpCodes.Newobj, _types.GetConstructor(_types.Exception, _types.String));
+        il.Emit(OpCodes.Throw);
 
-        // Store cloned element and convert it
-        var clonedLocal = il.DeclareLocal(typeof(System.Text.Json.JsonElement));
-        il.Emit(OpCodes.Stloc, clonedLocal);
-        il.Emit(OpCodes.Ldloca, clonedLocal);
-        il.Emit(OpCodes.Call, EmitConvertJsonElementHelper(typeBuilder));
+        il.MarkLabel(okEndLabel);
+        il.Emit(OpCodes.Ldloc, resultLocal);
         il.Emit(OpCodes.Ret);
 
         il.MarkLabel(notNullLabel);
@@ -293,163 +320,171 @@ public partial class RuntimeEmitter
         return method;
     }
 
-    private MethodBuilder EmitConvertJsonElementHelper(TypeBuilder typeBuilder)
+    /// <summary>
+    /// Emits <c>object? ParseValueFromReader(ref Utf8JsonReader reader)</c>: a recursive
+    /// descent that consumes the value at the reader's current position and returns the
+    /// runtime graph node for it — <c>Dictionary&lt;string,object?&gt;</c> for objects,
+    /// <c>List&lt;object?&gt;</c> for arrays, a boxed double / bool, a string, or null.
+    /// On entry the reader is positioned ON the value's first token; on return it is
+    /// positioned on the value's last token (the matching End for containers), so the
+    /// caller's next <c>Read()</c> advances past it. Mirrors the value kinds the old
+    /// JsonDocument walker produced, so the resulting graph (consumed by the reviver and
+    /// everything downstream) is byte-for-byte the same.
+    /// </summary>
+    private MethodBuilder EmitParseValueFromReaderHelper(TypeBuilder typeBuilder)
     {
-        // Convert JsonElement to appropriate runtime type
+        var readerType = typeof(System.Text.Json.Utf8JsonReader);
+        var readMethod = readerType.GetMethod("Read", Type.EmptyTypes)!;
+        var tokenTypeGetter = readerType.GetProperty("TokenType")!.GetGetMethod()!;
+        var getStringMethod = readerType.GetMethod("GetString", Type.EmptyTypes)!;
+        var getDoubleMethod = readerType.GetMethod("GetDouble", Type.EmptyTypes)!;
+
         var method = typeBuilder.DefineMethod(
-            "ConvertJsonElement",
+            "ParseValueFromReader",
             MethodAttributes.Private | MethodAttributes.Static,
             _types.Object,
-            [typeof(System.Text.Json.JsonElement).MakeByRefType()] // byref for struct
+            [readerType.MakeByRefType()]
         );
 
         var il = method.GetILGenerator();
 
-        var resultDictLocal = il.DeclareLocal(_types.DictionaryStringObject);
-        var resultListLocal = il.DeclareLocal(_types.ListOfObject);
-        var propEnumLocal = il.DeclareLocal(typeof(System.Text.Json.JsonElement.ObjectEnumerator));
-        var arrEnumLocal = il.DeclareLocal(typeof(System.Text.Json.JsonElement.ArrayEnumerator));
-        var propLocal = il.DeclareLocal(typeof(System.Text.Json.JsonProperty));
-        var elemLocal = il.DeclareLocal(typeof(System.Text.Json.JsonElement));
+        var dictLocal = il.DeclareLocal(_types.DictionaryStringObject);
+        var listLocal = il.DeclareLocal(_types.ListOfObject);
+        var nameLocal = il.DeclareLocal(_types.String);
 
-        var undefinedLabel = il.DefineLabel();
         var objectLabel = il.DefineLabel();
         var arrayLabel = il.DefineLabel();
         var stringLabel = il.DefineLabel();
         var numberLabel = il.DefineLabel();
-        var trueLiteralLabel = il.DefineLabel();
-        var falseLiteralLabel = il.DefineLabel();
+        var trueLabel = il.DefineLabel();
+        var falseLabel = il.DefineLabel();
         var nullLabel = il.DefineLabel();
-        var objLoopStart = il.DefineLabel();
-        var objLoopEnd = il.DefineLabel();
-        var arrLoopStart = il.DefineLabel();
-        var arrLoopEnd = il.DefineLabel();
 
-        // switch on element.ValueKind
+        // switch (reader.TokenType) — same dup/Beq ladder shape as the old DOM walker.
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Call, typeof(System.Text.Json.JsonElement).GetProperty("ValueKind")!.GetGetMethod()!);
+        il.Emit(OpCodes.Call, tokenTypeGetter);
 
-        // Check each value kind
         il.Emit(OpCodes.Dup);
-        il.Emit(OpCodes.Ldc_I4, (int)System.Text.Json.JsonValueKind.Object);
+        il.Emit(OpCodes.Ldc_I4, (int)System.Text.Json.JsonTokenType.StartObject);
         il.Emit(OpCodes.Beq, objectLabel);
 
         il.Emit(OpCodes.Dup);
-        il.Emit(OpCodes.Ldc_I4, (int)System.Text.Json.JsonValueKind.Array);
+        il.Emit(OpCodes.Ldc_I4, (int)System.Text.Json.JsonTokenType.StartArray);
         il.Emit(OpCodes.Beq, arrayLabel);
 
         il.Emit(OpCodes.Dup);
-        il.Emit(OpCodes.Ldc_I4, (int)System.Text.Json.JsonValueKind.String);
+        il.Emit(OpCodes.Ldc_I4, (int)System.Text.Json.JsonTokenType.String);
         il.Emit(OpCodes.Beq, stringLabel);
 
         il.Emit(OpCodes.Dup);
-        il.Emit(OpCodes.Ldc_I4, (int)System.Text.Json.JsonValueKind.Number);
+        il.Emit(OpCodes.Ldc_I4, (int)System.Text.Json.JsonTokenType.Number);
         il.Emit(OpCodes.Beq, numberLabel);
 
         il.Emit(OpCodes.Dup);
-        il.Emit(OpCodes.Ldc_I4, (int)System.Text.Json.JsonValueKind.True);
-        il.Emit(OpCodes.Beq, trueLiteralLabel);
+        il.Emit(OpCodes.Ldc_I4, (int)System.Text.Json.JsonTokenType.True);
+        il.Emit(OpCodes.Beq, trueLabel);
 
         il.Emit(OpCodes.Dup);
-        il.Emit(OpCodes.Ldc_I4, (int)System.Text.Json.JsonValueKind.False);
-        il.Emit(OpCodes.Beq, falseLiteralLabel);
+        il.Emit(OpCodes.Ldc_I4, (int)System.Text.Json.JsonTokenType.False);
+        il.Emit(OpCodes.Beq, falseLabel);
 
-        il.Emit(OpCodes.Pop); // pop the valueKind we've been checking
+        il.Emit(OpCodes.Pop); // None / Null / anything else → null
         il.Emit(OpCodes.Br, nullLabel);
 
-        // Object
+        // --- Object: { (PropertyName value)* } ---
         il.MarkLabel(objectLabel);
-        il.Emit(OpCodes.Pop); // pop valueKind
+        il.Emit(OpCodes.Pop); // pop tokenType
         il.Emit(OpCodes.Newobj, _types.GetDefaultConstructor(_types.DictionaryStringObject));
-        il.Emit(OpCodes.Stloc, resultDictLocal);
+        il.Emit(OpCodes.Stloc, dictLocal);
 
+        var objLoop = il.DefineLabel();
+        var objEnd = il.DefineLabel();
+        il.MarkLabel(objLoop);
+        // Read() → PropertyName or EndObject (throws on malformed/incomplete input).
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Call, typeof(System.Text.Json.JsonElement).GetMethod("EnumerateObject")!);
-        il.Emit(OpCodes.Stloc, propEnumLocal);
-
-        il.MarkLabel(objLoopStart);
-        il.Emit(OpCodes.Ldloca, propEnumLocal);
-        il.Emit(OpCodes.Call, typeof(System.Text.Json.JsonElement.ObjectEnumerator).GetMethod("MoveNext")!);
-        il.Emit(OpCodes.Brfalse, objLoopEnd);
-
-        il.Emit(OpCodes.Ldloca, propEnumLocal);
-        il.Emit(OpCodes.Call, typeof(System.Text.Json.JsonElement.ObjectEnumerator).GetProperty("Current")!.GetGetMethod()!);
-        il.Emit(OpCodes.Stloc, propLocal);
-
-        // dict[name] = ConvertJsonElement(ref value)
-        il.Emit(OpCodes.Ldloc, resultDictLocal);
-        il.Emit(OpCodes.Ldloca, propLocal);
-        il.Emit(OpCodes.Call, typeof(System.Text.Json.JsonProperty).GetProperty("Name")!.GetGetMethod()!);
-        il.Emit(OpCodes.Ldloca, propLocal);
-        il.Emit(OpCodes.Call, typeof(System.Text.Json.JsonProperty).GetProperty("Value")!.GetGetMethod()!);
-        il.Emit(OpCodes.Stloc, elemLocal);
-        il.Emit(OpCodes.Ldloca, elemLocal);
+        il.Emit(OpCodes.Call, readMethod);
+        il.Emit(OpCodes.Brfalse, objEnd);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Call, tokenTypeGetter);
+        il.Emit(OpCodes.Ldc_I4, (int)System.Text.Json.JsonTokenType.EndObject);
+        il.Emit(OpCodes.Beq, objEnd);
+        // name = reader.GetString() (current token is the property name)
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Call, getStringMethod);
+        il.Emit(OpCodes.Stloc, nameLocal);
+        // reader.Read() → the value's first token
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Call, readMethod);
+        il.Emit(OpCodes.Pop);
+        // dict[name] = ParseValueFromReader(ref reader)
+        il.Emit(OpCodes.Ldloc, dictLocal);
+        il.Emit(OpCodes.Ldloc, nameLocal);
+        il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Call, method); // recursive
         il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.DictionaryStringObject, "set_Item", [_types.String, _types.Object]));
-        il.Emit(OpCodes.Br, objLoopStart);
+        il.Emit(OpCodes.Br, objLoop);
 
-        il.MarkLabel(objLoopEnd);
-        il.Emit(OpCodes.Ldloc, resultDictLocal);
+        il.MarkLabel(objEnd);
+        il.Emit(OpCodes.Ldloc, dictLocal);
         il.Emit(OpCodes.Ret);
 
-        // Array
+        // --- Array: [ value* ] ---
         il.MarkLabel(arrayLabel);
-        il.Emit(OpCodes.Pop); // pop valueKind
+        il.Emit(OpCodes.Pop); // pop tokenType
         il.Emit(OpCodes.Newobj, _types.GetDefaultConstructor(_types.ListOfObject));
-        il.Emit(OpCodes.Stloc, resultListLocal);
+        il.Emit(OpCodes.Stloc, listLocal);
 
+        var arrLoop = il.DefineLabel();
+        var arrEnd = il.DefineLabel();
+        il.MarkLabel(arrLoop);
+        // Read() → the element's first token or EndArray.
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Call, typeof(System.Text.Json.JsonElement).GetMethod("EnumerateArray")!);
-        il.Emit(OpCodes.Stloc, arrEnumLocal);
-
-        il.MarkLabel(arrLoopStart);
-        il.Emit(OpCodes.Ldloca, arrEnumLocal);
-        il.Emit(OpCodes.Call, typeof(System.Text.Json.JsonElement.ArrayEnumerator).GetMethod("MoveNext")!);
-        il.Emit(OpCodes.Brfalse, arrLoopEnd);
-
-        il.Emit(OpCodes.Ldloc, resultListLocal);
-        il.Emit(OpCodes.Ldloca, arrEnumLocal);
-        il.Emit(OpCodes.Call, typeof(System.Text.Json.JsonElement.ArrayEnumerator).GetProperty("Current")!.GetGetMethod()!);
-        il.Emit(OpCodes.Stloc, elemLocal);
-        il.Emit(OpCodes.Ldloca, elemLocal);
+        il.Emit(OpCodes.Call, readMethod);
+        il.Emit(OpCodes.Brfalse, arrEnd);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Call, tokenTypeGetter);
+        il.Emit(OpCodes.Ldc_I4, (int)System.Text.Json.JsonTokenType.EndArray);
+        il.Emit(OpCodes.Beq, arrEnd);
+        // list.Add(ParseValueFromReader(ref reader))
+        il.Emit(OpCodes.Ldloc, listLocal);
+        il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Call, method); // recursive
         il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.ListOfObject, "Add", [_types.Object]));
-        il.Emit(OpCodes.Br, arrLoopStart);
+        il.Emit(OpCodes.Br, arrLoop);
 
-        il.MarkLabel(arrLoopEnd);
-        il.Emit(OpCodes.Ldloc, resultListLocal);
+        il.MarkLabel(arrEnd);
+        il.Emit(OpCodes.Ldloc, listLocal);
         il.Emit(OpCodes.Ret);
 
-        // String
+        // --- String ---
         il.MarkLabel(stringLabel);
-        il.Emit(OpCodes.Pop); // pop valueKind
+        il.Emit(OpCodes.Pop);
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Call, typeof(System.Text.Json.JsonElement).GetMethod("GetString")!);
+        il.Emit(OpCodes.Call, getStringMethod);
         il.Emit(OpCodes.Ret);
 
-        // Number
+        // --- Number → boxed double ---
         il.MarkLabel(numberLabel);
-        il.Emit(OpCodes.Pop); // pop valueKind
+        il.Emit(OpCodes.Pop);
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Call, typeof(System.Text.Json.JsonElement).GetMethod("GetDouble")!);
+        il.Emit(OpCodes.Call, getDoubleMethod);
         il.Emit(OpCodes.Box, _types.Double);
         il.Emit(OpCodes.Ret);
 
-        // True
-        il.MarkLabel(trueLiteralLabel);
-        il.Emit(OpCodes.Pop); // pop valueKind
+        // --- True / False → boxed bool ---
+        il.MarkLabel(trueLabel);
+        il.Emit(OpCodes.Pop);
         il.Emit(OpCodes.Ldc_I4_1);
         il.Emit(OpCodes.Box, _types.Boolean);
         il.Emit(OpCodes.Ret);
 
-        // False
-        il.MarkLabel(falseLiteralLabel);
-        il.Emit(OpCodes.Pop); // pop valueKind
+        il.MarkLabel(falseLabel);
+        il.Emit(OpCodes.Pop);
         il.Emit(OpCodes.Ldc_I4_0);
         il.Emit(OpCodes.Box, _types.Boolean);
         il.Emit(OpCodes.Ret);
 
-        // Null/Undefined
+        // --- Null / None / unhandled ---
         il.MarkLabel(nullLabel);
         il.Emit(OpCodes.Ldnull);
         il.Emit(OpCodes.Ret);

--- a/Compilation/RuntimeEmitter.TSTypedArray.cs
+++ b/Compilation/RuntimeEmitter.TSTypedArray.cs
@@ -241,6 +241,15 @@ public partial class RuntimeEmitter
         // Indexer: public object this[int index] { get; set; }
         EmitTypedArrayIndexer(typeBuilder, runtime, bytesPerElement, signed, clamped, isFloat, isBigInt);
 
+        // Unboxed numeric element accessors (#3): GetUnboxed/SetUnboxed return/accept a native
+        // double, for the compiled fast path (ILEmitter binds them at statically-typed sites).
+        // Skip BigInt (bigint, not number) and Uint8Clamped (keeps the boxed clamp/round path).
+        if (!isBigInt && !clamped)
+        {
+            var elementType = name.EndsWith("Array") ? name[..^5] : name;
+            EmitUnboxedNumericAccessors(typeBuilder, runtime, elementType, bytesPerElement, signed, isFloat);
+        }
+
         // Finalize type
         typeBuilder.CreateType();
     }
@@ -629,47 +638,37 @@ public partial class RuntimeEmitter
         }
         else if (bytesPerElement == 2)
         {
-            var bytesLocal = setIl.DeclareLocal(typeof(byte[]));
+            // Unsafe.WriteUnaligned(ref _buffer[byteIdx], (short|ushort)(int)Convert.ToDouble(value));
+            setIl.Emit(OpCodes.Ldarg_0);
+            setIl.Emit(OpCodes.Ldfld, _typedArrayBufferField!);
+            setIl.Emit(OpCodes.Ldloc, setIndexLocal);
+            setIl.Emit(OpCodes.Ldelema, typeof(byte));
             setIl.Emit(OpCodes.Ldarg_2);
             setIl.Emit(OpCodes.Call, typeof(Convert).GetMethod("ToDouble", [typeof(object)])!);
             setIl.Emit(OpCodes.Conv_I4);
             if (signed)
+            {
                 setIl.Emit(OpCodes.Conv_I2);
+                setIl.Emit(OpCodes.Call, UnsafeWriteUnaligned(typeof(short)));
+            }
             else
+            {
                 setIl.Emit(OpCodes.Conv_U2);
-            if (signed)
-                setIl.Emit(OpCodes.Call, typeof(BitConverter).GetMethod("GetBytes", [typeof(short)])!);
-            else
-                setIl.Emit(OpCodes.Call, typeof(BitConverter).GetMethod("GetBytes", [typeof(ushort)])!);
-            setIl.Emit(OpCodes.Stloc, bytesLocal);
-
-            // Copy bytes to buffer
-            setIl.Emit(OpCodes.Ldarg_0);
-            setIl.Emit(OpCodes.Ldfld, _typedArrayBufferField!);
-            setIl.Emit(OpCodes.Ldloc, setIndexLocal);
-            setIl.Emit(OpCodes.Ldloc, bytesLocal);
-            setIl.Emit(OpCodes.Ldc_I4_0);
-            setIl.Emit(OpCodes.Ldelem_U1);
-            setIl.Emit(OpCodes.Stelem_I1);
-
-            setIl.Emit(OpCodes.Ldarg_0);
-            setIl.Emit(OpCodes.Ldfld, _typedArrayBufferField!);
-            setIl.Emit(OpCodes.Ldloc, setIndexLocal);
-            setIl.Emit(OpCodes.Ldc_I4_1);
-            setIl.Emit(OpCodes.Add);
-            setIl.Emit(OpCodes.Ldloc, bytesLocal);
-            setIl.Emit(OpCodes.Ldc_I4_1);
-            setIl.Emit(OpCodes.Ldelem_U1);
-            setIl.Emit(OpCodes.Stelem_I1);
+                setIl.Emit(OpCodes.Call, UnsafeWriteUnaligned(typeof(ushort)));
+            }
         }
         else if (bytesPerElement == 4)
         {
-            var bytesLocal = setIl.DeclareLocal(typeof(byte[]));
+            setIl.Emit(OpCodes.Ldarg_0);
+            setIl.Emit(OpCodes.Ldfld, _typedArrayBufferField!);
+            setIl.Emit(OpCodes.Ldloc, setIndexLocal);
+            setIl.Emit(OpCodes.Ldelema, typeof(byte));
             if (isFloat)
             {
+                // Unsafe.WriteUnaligned(ref _buffer[byteIdx], Convert.ToSingle(value));
                 setIl.Emit(OpCodes.Ldarg_2);
                 setIl.Emit(OpCodes.Call, typeof(Convert).GetMethod("ToSingle", [typeof(object)])!);
-                setIl.Emit(OpCodes.Call, typeof(BitConverter).GetMethod("GetBytes", [typeof(float)])!);
+                setIl.Emit(OpCodes.Call, UnsafeWriteUnaligned(typeof(float)));
             }
             else
             {
@@ -678,81 +677,66 @@ public partial class RuntimeEmitter
                 if (signed)
                 {
                     setIl.Emit(OpCodes.Conv_I4);
-                    setIl.Emit(OpCodes.Call, typeof(BitConverter).GetMethod("GetBytes", [typeof(int)])!);
+                    setIl.Emit(OpCodes.Call, UnsafeWriteUnaligned(typeof(int)));
                 }
                 else
                 {
                     setIl.Emit(OpCodes.Conv_U4);
-                    setIl.Emit(OpCodes.Call, typeof(BitConverter).GetMethod("GetBytes", [typeof(uint)])!);
+                    setIl.Emit(OpCodes.Call, UnsafeWriteUnaligned(typeof(uint)));
                 }
             }
-            setIl.Emit(OpCodes.Stloc, bytesLocal);
-
-            // Use Array.Copy for 4 bytes
-            setIl.Emit(OpCodes.Ldloc, bytesLocal);
-            setIl.Emit(OpCodes.Ldc_I4_0);
-            setIl.Emit(OpCodes.Ldarg_0);
-            setIl.Emit(OpCodes.Ldfld, _typedArrayBufferField!);
-            setIl.Emit(OpCodes.Ldloc, setIndexLocal);
-            setIl.Emit(OpCodes.Ldc_I4_4);
-            setIl.Emit(OpCodes.Call, typeof(Array).GetMethod("Copy", [typeof(Array), typeof(int), typeof(Array), typeof(int), typeof(int)])!);
         }
         else if (bytesPerElement == 8)
         {
-            var bytesLocal = setIl.DeclareLocal(typeof(byte[]));
+            setIl.Emit(OpCodes.Ldarg_0);
+            setIl.Emit(OpCodes.Ldfld, _typedArrayBufferField!);
+            setIl.Emit(OpCodes.Ldloc, setIndexLocal);
+            setIl.Emit(OpCodes.Ldelema, typeof(byte));
             if (isFloat)
             {
+                // Unsafe.WriteUnaligned(ref _buffer[byteIdx], Convert.ToDouble(value));
                 setIl.Emit(OpCodes.Ldarg_2);
                 setIl.Emit(OpCodes.Call, typeof(Convert).GetMethod("ToDouble", [typeof(object)])!);
-                setIl.Emit(OpCodes.Call, typeof(BitConverter).GetMethod("GetBytes", [typeof(double)])!);
+                setIl.Emit(OpCodes.Call, UnsafeWriteUnaligned(typeof(double)));
             }
             else if (isBigInt)
             {
-                // For BigInt, need to convert from BigInteger to long/ulong
+                // For BigInt, convert from BigInteger to long/ulong (preserves prior ToInt64 form).
                 setIl.Emit(OpCodes.Ldarg_2);
                 setIl.Emit(OpCodes.Call, typeof(Convert).GetMethod("ToInt64", [typeof(object)])!);
                 if (signed)
-                    setIl.Emit(OpCodes.Call, typeof(BitConverter).GetMethod("GetBytes", [typeof(long)])!);
+                    setIl.Emit(OpCodes.Call, UnsafeWriteUnaligned(typeof(long)));
                 else
-                    setIl.Emit(OpCodes.Call, typeof(BitConverter).GetMethod("GetBytes", [typeof(ulong)])!);
+                    setIl.Emit(OpCodes.Call, UnsafeWriteUnaligned(typeof(ulong)));
             }
             else
             {
                 setIl.Emit(OpCodes.Ldarg_2);
                 setIl.Emit(OpCodes.Call, typeof(Convert).GetMethod("ToDouble", [typeof(object)])!);
                 setIl.Emit(OpCodes.Conv_I8);
-                setIl.Emit(OpCodes.Call, typeof(BitConverter).GetMethod("GetBytes", [typeof(long)])!);
+                setIl.Emit(OpCodes.Call, UnsafeWriteUnaligned(typeof(long)));
             }
-            setIl.Emit(OpCodes.Stloc, bytesLocal);
-
-            // Use Array.Copy for 8 bytes
-            setIl.Emit(OpCodes.Ldloc, bytesLocal);
-            setIl.Emit(OpCodes.Ldc_I4_0);
-            setIl.Emit(OpCodes.Ldarg_0);
-            setIl.Emit(OpCodes.Ldfld, _typedArrayBufferField!);
-            setIl.Emit(OpCodes.Ldloc, setIndexLocal);
-            setIl.Emit(OpCodes.Ldc_I4_8);
-            setIl.Emit(OpCodes.Call, typeof(Array).GetMethod("Copy", [typeof(Array), typeof(int), typeof(Array), typeof(int), typeof(int)])!);
         }
 
         setIl.Emit(OpCodes.Ret);
         typeBuilder.DefineMethodOverride(setter, runtime.TypedArrayElementSet);
-
-        // Unboxed double accessors for Float64Array (#878). These mirror the byte
-        // logic of the boxed Get/Set above but take/return a native `double` — no
-        // Box, no Convert.ToDouble coercion. The IL emitter binds them directly at
-        // statically-known Float64Array index sites, eliminating the GetIndex/SetIndex
-        // dispatch, the isinst ladder, and the per-element box. Like Get/Set, they do
-        // NOT bounds-check: out-of-range access faults via BitConverter/Array.Copy,
-        // exactly as the boxed path does today (OOB semantics unchanged).
-        if (bytesPerElement == 8 && isFloat)
-        {
-            EmitFloat64UnboxedAccessors(typeBuilder, runtime);
-        }
     }
 
-    // double GetUnboxed(int index) / void SetUnboxed(int index, double value) on $Float64Array.
-    private void EmitFloat64UnboxedAccessors(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    // double GetUnboxed(int index) / void SetUnboxed(int index, double value) on each concrete
+    // numeric $XArray (#3, generalizing the Float64-only #878 path). They mirror the byte logic
+    // of the boxed Get/Set above but take/return a native `double` — no Box, no Convert.ToDouble
+    // coercion — reinterpreting over the byte[] backing store via Unsafe.Read/WriteUnaligned (no
+    // per-element allocation). The IL emitter binds them at statically-typed typed-array index
+    // sites, eliminating the GetIndex/SetIndex dispatch, the isinst ladder, and the per-element
+    // box on BOTH read and write. AggressiveInlining + a non-virtual `call` let the JIT fold them
+    // into the caller's loop and hoist the _buffer load / bounds check. The single ldelema
+    // bounds-checks the first byte; a correctly-sized buffer (length a multiple of bytesPerElement,
+    // byteOffset aligned) guarantees the rest are in range, so OOB faults exactly as the boxed
+    // path does today (semantics unchanged). The double→element narrowing matches the boxed Set's
+    // conv opcodes so the fast path and the boxed fallback always agree.
+    private void EmitUnboxedNumericAccessors(
+        TypeBuilder typeBuilder, EmittedRuntime runtime, string elementType,
+        int bytesPerElement, bool signed, bool isFloat)
     {
         var getU = typeBuilder.DefineMethod(
             "GetUnboxed",
@@ -760,19 +744,12 @@ public partial class RuntimeEmitter
             _types.Double,
             [_types.Int32]
         );
+        getU.SetImplementationFlags(MethodImplAttributes.AggressiveInlining);
         var gil = getU.GetILGenerator();
-        // return BitConverter.ToDouble(_buffer, _byteOffset + index * 8);
-        gil.Emit(OpCodes.Ldarg_0);
-        gil.Emit(OpCodes.Ldfld, _typedArrayBufferField!);
-        gil.Emit(OpCodes.Ldarg_0);
-        gil.Emit(OpCodes.Ldfld, _typedArrayByteOffsetField!);
-        gil.Emit(OpCodes.Ldarg_1);
-        gil.Emit(OpCodes.Ldc_I4_8);
-        gil.Emit(OpCodes.Mul);
-        gil.Emit(OpCodes.Add);
-        gil.Emit(OpCodes.Call, typeof(BitConverter).GetMethod("ToDouble", [typeof(byte[]), typeof(int)])!);
+        EmitElementRef(gil, bytesPerElement);
+        EmitReadElementAsDouble(gil, bytesPerElement, signed, isFloat);
         gil.Emit(OpCodes.Ret);
-        runtime.Float64ArrayGetUnboxed = getU;
+        runtime.TypedArrayGetUnboxedByElement[elementType] = getU;
 
         var setU = typeBuilder.DefineMethod(
             "SetUnboxed",
@@ -780,26 +757,127 @@ public partial class RuntimeEmitter
             _types.Void,
             [_types.Int32, _types.Double]
         );
+        setU.SetImplementationFlags(MethodImplAttributes.AggressiveInlining);
         var sil = setU.GetILGenerator();
-        var bytesLocal = sil.DeclareLocal(typeof(byte[]));
-        // var bytes = BitConverter.GetBytes(value);
-        sil.Emit(OpCodes.Ldarg_2);
-        sil.Emit(OpCodes.Call, typeof(BitConverter).GetMethod("GetBytes", [typeof(double)])!);
-        sil.Emit(OpCodes.Stloc, bytesLocal);
-        // Array.Copy(bytes, 0, _buffer, _byteOffset + index * 8, 8);
-        sil.Emit(OpCodes.Ldloc, bytesLocal);
-        sil.Emit(OpCodes.Ldc_I4_0);
-        sil.Emit(OpCodes.Ldarg_0);
-        sil.Emit(OpCodes.Ldfld, _typedArrayBufferField!);
-        sil.Emit(OpCodes.Ldarg_0);
-        sil.Emit(OpCodes.Ldfld, _typedArrayByteOffsetField!);
-        sil.Emit(OpCodes.Ldarg_1);
-        sil.Emit(OpCodes.Ldc_I4_8);
-        sil.Emit(OpCodes.Mul);
-        sil.Emit(OpCodes.Add);
-        sil.Emit(OpCodes.Ldc_I4_8);
-        sil.Emit(OpCodes.Call, typeof(Array).GetMethod("Copy", [typeof(Array), typeof(int), typeof(Array), typeof(int), typeof(int)])!);
+        EmitElementRef(sil, bytesPerElement);   // ref byte destination
+        sil.Emit(OpCodes.Ldarg_2);              // double value
+        EmitNarrowDoubleAndWrite(sil, bytesPerElement, signed, isFloat);
         sil.Emit(OpCodes.Ret);
-        runtime.Float64ArraySetUnboxed = setU;
+        runtime.TypedArraySetUnboxedByElement[elementType] = setU;
+
+        // Keep the Float64-specific handles populated for any direct references.
+        if (elementType == "Float64")
+        {
+            runtime.Float64ArrayGetUnboxed = getU;
+            runtime.Float64ArraySetUnboxed = setU;
+        }
+    }
+
+    // Pushes `ref byte` at _buffer[_byteOffset + index * bytesPerElement] (this=arg0, index=arg1).
+    private void EmitElementRef(ILGenerator il, int bytesPerElement)
+    {
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, _typedArrayBufferField!);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, _typedArrayByteOffsetField!);
+        il.Emit(OpCodes.Ldarg_1);
+        if (bytesPerElement != 1)
+        {
+            il.Emit(OpCodes.Ldc_I4, bytesPerElement);
+            il.Emit(OpCodes.Mul);
+        }
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Ldelema, typeof(byte));
+    }
+
+    // Stack in: [ref byte]. Stack out: [double]. Reads the element and widens to double.
+    private static void EmitReadElementAsDouble(ILGenerator il, int bytesPerElement, bool signed, bool isFloat)
+    {
+        if (bytesPerElement == 1)
+        {
+            il.Emit(OpCodes.Call, UnsafeReadUnaligned(signed ? typeof(sbyte) : typeof(byte)));
+            il.Emit(OpCodes.Conv_R8);
+        }
+        else if (bytesPerElement == 2)
+        {
+            il.Emit(OpCodes.Call, UnsafeReadUnaligned(signed ? typeof(short) : typeof(ushort)));
+            il.Emit(OpCodes.Conv_R8);
+        }
+        else if (bytesPerElement == 4 && isFloat)
+        {
+            il.Emit(OpCodes.Call, UnsafeReadUnaligned(typeof(float)));
+            il.Emit(OpCodes.Conv_R8);
+        }
+        else if (bytesPerElement == 4 && signed)
+        {
+            il.Emit(OpCodes.Call, UnsafeReadUnaligned(typeof(int)));
+            il.Emit(OpCodes.Conv_R8);
+        }
+        else if (bytesPerElement == 4)
+        {
+            il.Emit(OpCodes.Call, UnsafeReadUnaligned(typeof(uint)));
+            il.Emit(OpCodes.Conv_U8);  // zero-extend uint32 → int64 so the double is 0..4294967295
+            il.Emit(OpCodes.Conv_R8);
+        }
+        else // bytesPerElement == 8 && isFloat (Float64)
+        {
+            il.Emit(OpCodes.Call, UnsafeReadUnaligned(typeof(double)));
+        }
+    }
+
+    // Stack in: [ref byte, double value]. Narrows the double to the element type and stores it.
+    // Conv opcodes mirror the boxed Set so the fast path and boxed fallback agree exactly.
+    private static void EmitNarrowDoubleAndWrite(ILGenerator il, int bytesPerElement, bool signed, bool isFloat)
+    {
+        if (bytesPerElement == 1)
+        {
+            il.Emit(OpCodes.Conv_I4);
+            if (signed) { il.Emit(OpCodes.Conv_I1); il.Emit(OpCodes.Call, UnsafeWriteUnaligned(typeof(sbyte))); }
+            else { il.Emit(OpCodes.Conv_U1); il.Emit(OpCodes.Call, UnsafeWriteUnaligned(typeof(byte))); }
+        }
+        else if (bytesPerElement == 2)
+        {
+            il.Emit(OpCodes.Conv_I4);
+            if (signed) { il.Emit(OpCodes.Conv_I2); il.Emit(OpCodes.Call, UnsafeWriteUnaligned(typeof(short))); }
+            else { il.Emit(OpCodes.Conv_U2); il.Emit(OpCodes.Call, UnsafeWriteUnaligned(typeof(ushort))); }
+        }
+        else if (bytesPerElement == 4 && isFloat)
+        {
+            il.Emit(OpCodes.Conv_R4);
+            il.Emit(OpCodes.Call, UnsafeWriteUnaligned(typeof(float)));
+        }
+        else if (bytesPerElement == 4 && signed)
+        {
+            il.Emit(OpCodes.Conv_I4);
+            il.Emit(OpCodes.Call, UnsafeWriteUnaligned(typeof(int)));
+        }
+        else if (bytesPerElement == 4)
+        {
+            il.Emit(OpCodes.Conv_U4);
+            il.Emit(OpCodes.Call, UnsafeWriteUnaligned(typeof(uint)));
+        }
+        else // bytesPerElement == 8 && isFloat (Float64)
+        {
+            il.Emit(OpCodes.Call, UnsafeWriteUnaligned(typeof(double)));
+        }
+    }
+
+    // Reflects the `ref byte` overloads of Unsafe.Read/WriteUnaligned (not the `void*` ones)
+    // and instantiates them for the element type. Unsafe lives in System.Private.CoreLib (BCL),
+    // so the emitted token references the BCL, never SharpTS.dll — standalone DLLs stay standalone.
+    private static MethodInfo UnsafeWriteUnaligned(Type elementType)
+    {
+        var methods = typeof(System.Runtime.CompilerServices.Unsafe).GetMethods();
+        var open = Array.Find(methods, m => m.Name == "WriteUnaligned"
+            && m.GetParameters()[0].ParameterType == typeof(byte).MakeByRefType())!;
+        return open.MakeGenericMethod(elementType);
+    }
+
+    private static MethodInfo UnsafeReadUnaligned(Type elementType)
+    {
+        var methods = typeof(System.Runtime.CompilerServices.Unsafe).GetMethods();
+        var open = Array.Find(methods, m => m.Name == "ReadUnaligned"
+            && m.GetParameters()[0].ParameterType == typeof(byte).MakeByRefType())!;
+        return open.MakeGenericMethod(elementType);
     }
 }

--- a/Execution/Interpreter.Operators.cs
+++ b/Execution/Interpreter.Operators.cs
@@ -92,6 +92,20 @@ public partial class Interpreter
             return newValue;
         }
 
+        // Typed-array element compound assignment (e.g. `a[i] += 1` on an Int32Array). Read the
+        // element (a boxed double, or BigInteger for BigInt arrays), apply the op, narrow back via
+        // the typed-array setter. The compiled side has a dedicated unboxed fast path; this keeps the
+        // interpreter consistent (previously it threw "not supported on this type").
+        if (obj is SharpTSTypedArray typedArray && index is double typedIdx)
+        {
+            int ti = (int)typedIdx;
+            RuntimeValue addValue = EvaluateRV(compound.Value);
+            RuntimeValue newValue = ApplyCompoundOperatorRV(
+                compound.Operator.Type, RuntimeValue.FromBoxed(typedArray[ti]), addValue);
+            typedArray[ti] = newValue.ToObject();
+            return newValue;
+        }
+
         throw new InterpreterException("Compound index assignment not supported on this type.");
     }
 

--- a/Runtime/BuiltIns/ArrayBuiltIns.cs
+++ b/Runtime/BuiltIns/ArrayBuiltIns.cs
@@ -219,6 +219,11 @@ public static class ArrayBuiltIns
         {
             _compareArgs[0] = x.Element;
             _compareArgs[1] = y.Element;
+            // NOTE: deliberately stays on the legacy boxed Call rather than CallV2. For the
+            // common trivial comparator (`(a,b)=>a-b`), eagerly converting both boxed args to
+            // RuntimeValue here (FromBoxed) costs more than this near-free reference copy and
+            // measured ~13% SLOWER on a 100k interpreter sort — the boxed Call lets the
+            // comparator body unbox lazily. Revisit only with a non-boxing comparator path.
             var result = _fn.Call(_interp, _compareArgs);
             if (result is double d && !double.IsNaN(d) && d != 0)
                 return d < 0 ? -1 : 1;

--- a/Runtime/Types/SharpTSTypedArray.cs
+++ b/Runtime/Types/SharpTSTypedArray.cs
@@ -637,9 +637,7 @@ public class SharpTSInt16Array : SharpTSTypedArray
         set
         {
             int byteIdx = GetByteIndex(index);
-            var bytes = BitConverter.GetBytes((short)Convert.ToDouble(value));
-            _buffer[byteIdx] = bytes[0];
-            _buffer[byteIdx + 1] = bytes[1];
+            Unsafe.WriteUnaligned(ref _buffer[byteIdx], (short)Convert.ToDouble(value));
         }
     }
 
@@ -710,9 +708,7 @@ public class SharpTSUint16Array : SharpTSTypedArray
         set
         {
             int byteIdx = GetByteIndex(index);
-            var bytes = BitConverter.GetBytes((ushort)Convert.ToDouble(value));
-            _buffer[byteIdx] = bytes[0];
-            _buffer[byteIdx + 1] = bytes[1];
+            Unsafe.WriteUnaligned(ref _buffer[byteIdx], (ushort)Convert.ToDouble(value));
         }
     }
 
@@ -783,8 +779,7 @@ public class SharpTSInt32Array : SharpTSTypedArray
         set
         {
             int byteIdx = GetByteIndex(index);
-            var bytes = BitConverter.GetBytes((int)Convert.ToDouble(value));
-            Array.Copy(bytes, 0, _buffer, byteIdx, 4);
+            Unsafe.WriteUnaligned(ref _buffer[byteIdx], (int)Convert.ToDouble(value));
         }
     }
 
@@ -864,8 +859,7 @@ public class SharpTSUint32Array : SharpTSTypedArray
         set
         {
             int byteIdx = GetByteIndex(index);
-            var bytes = BitConverter.GetBytes((uint)Convert.ToDouble(value));
-            Array.Copy(bytes, 0, _buffer, byteIdx, 4);
+            Unsafe.WriteUnaligned(ref _buffer[byteIdx], (uint)Convert.ToDouble(value));
         }
     }
 
@@ -936,8 +930,7 @@ public class SharpTSFloat32Array : SharpTSTypedArray
         set
         {
             int byteIdx = GetByteIndex(index);
-            var bytes = BitConverter.GetBytes((float)Convert.ToDouble(value));
-            Array.Copy(bytes, 0, _buffer, byteIdx, 4);
+            Unsafe.WriteUnaligned(ref _buffer[byteIdx], (float)Convert.ToDouble(value));
         }
     }
 
@@ -1008,8 +1001,7 @@ public class SharpTSFloat64Array : SharpTSTypedArray
         set
         {
             int byteIdx = GetByteIndex(index);
-            var bytes = BitConverter.GetBytes(Convert.ToDouble(value));
-            Array.Copy(bytes, 0, _buffer, byteIdx, 8);
+            Unsafe.WriteUnaligned(ref _buffer[byteIdx], Convert.ToDouble(value));
         }
     }
 
@@ -1086,8 +1078,7 @@ public class SharpTSBigInt64Array : SharpTSTypedArray
                 double d => (long)d,
                 _ => Convert.ToInt64(value)
             };
-            var bytes = BitConverter.GetBytes(val);
-            Array.Copy(bytes, 0, _buffer, byteIdx, 8);
+            Unsafe.WriteUnaligned(ref _buffer[byteIdx], val);
         }
     }
 
@@ -1179,8 +1170,7 @@ public class SharpTSBigUint64Array : SharpTSTypedArray
                 double d => (ulong)d,
                 _ => Convert.ToUInt64(value)
             };
-            var bytes = BitConverter.GetBytes(val);
-            Array.Copy(bytes, 0, _buffer, byteIdx, 8);
+            Unsafe.WriteUnaligned(ref _buffer[byteIdx], val);
         }
     }
 

--- a/TypeSystem/TypeChecker.Compatibility.cs
+++ b/TypeSystem/TypeChecker.Compatibility.cs
@@ -815,6 +815,12 @@ public partial class TypeChecker
         if (expected is TypeInfo.Date && actual is TypeInfo.Date) return true;
         if (expected is TypeInfo.RegExp && actual is TypeInfo.RegExp) return true;
 
+        // Typed-array identity (reachable since `Int32Array`/`Float64Array`/… annotations stopped
+        // resolving to `any`). Each typed array is its own nominal type: assignable only from the
+        // same element kind (Int32Array ← Int32Array, not ← Float64Array), matching tsc.
+        if (expected is TypeInfo.TypedArray expTa && actual is TypeInfo.TypedArray actTa)
+            return expTa.ElementType == actTa.ElementType;
+
         // Error-family compatibility (reachable since Error/TypeError/… stopped resolving to `any`,
         // #528). Every built-in error shares the same structural shape (name/message/stack/cause), so
         // any error satisfies a non-aggregate error target — tsc treats the empty `interface TypeError

--- a/TypeSystem/TypeChecker.TypeParsing.cs
+++ b/TypeSystem/TypeChecker.TypeParsing.cs
@@ -355,6 +355,19 @@ public partial class TypeChecker
         if (typeName == "String") return new TypeInfo.String();
         if (typeName == "Number") return new TypeInfo.Primitive(TokenType.TYPE_NUMBER);
         if (typeName == "Boolean") return new TypeInfo.Primitive(TokenType.TYPE_BOOLEAN);
+        // Typed-array names in annotation position (`Int32Array`, `Float64Array`, …) resolve to
+        // TypeInfo.TypedArray — the SAME type `new Int32Array(...)` produces — so element access on an
+        // annotated typed array is typed `number` and the compiled unboxed fast paths fire. Without
+        // this they fell through to `any`, leaving every annotated typed array (the common case, and
+        // every benchmark/real program) on the boxed GetIndex/SetIndex path. The element prefix is the
+        // name minus "Array"; BigInt64/BigUint64 carry bigint elements (the compiled side keeps those
+        // on the boxed path).
+        if (typeName is "Int8Array" or "Uint8Array" or "Uint8ClampedArray"
+            or "Int16Array" or "Uint16Array" or "Int32Array" or "Uint32Array"
+            or "Float32Array" or "Float64Array" or "BigInt64Array" or "BigUint64Array")
+        {
+            return new TypeInfo.TypedArray(typeName[..^"Array".Length]);
+        }
         // Built-in Error type references (Error, TypeError, RangeError, …) resolve to their structured
         // TypeInfo.Error — like Date/RegExp above — instead of degrading to `any`. This types member
         // access (`e.message: string`, so `const n: number = e.message` is a TS2322 error) and aligns

--- a/benchmarks/scripts/int-arrays.ts
+++ b/benchmarks/scripts/int-arrays.ts
@@ -1,0 +1,50 @@
+import { bench } from "./lib/bench.ts";
+
+// Companion to typed-arrays.ts, targeting the paths typed-arrays.ts does NOT
+// exercise: a NON-Float64 typed array (Int32Array) and in-place compound
+// assignment. Before the unboxed fast path was extended past Float64, both
+// boxed a double per element — int32 reads/writes through GetIndex/SetIndex, and
+// `a[i] += …` through GetIndex/Add/SetIndex (2-3 boxes per element).
+
+// Int32Array numeric kernel: fill + 3-point stencil sweep. Mirrors
+// typedArrayKernel but on a 4-byte signed integer element type, so it measures
+// the unboxed Get/Set fast path for a non-Float64 typed array.
+function int32Kernel(n: number): number {
+    const a: Int32Array = new Int32Array(n);
+    for (let i: number = 0; i < n; i++) {
+        a[i] = i * 3 - (i % 7);
+    }
+    let sum: number = 0;
+    for (let i: number = 1; i < n - 1; i++) {
+        sum = sum + (a[i - 1] - 2 * a[i] + a[i + 1]);
+    }
+    return sum;
+}
+
+// In-place accumulation on a Float64Array via compound assignment `a[i] += …`.
+// Four accumulation passes dominate the single fill, so this measures the
+// compound-index-assign path, not allocation.
+function accumulate(n: number): number {
+    const a: Float64Array = new Float64Array(n);
+    for (let i: number = 0; i < n; i++) {
+        a[i] = i;
+    }
+    for (let pass: number = 0; pass < 4; pass++) {
+        for (let i: number = 0; i < n; i++) {
+            a[i] += i * 0.5;
+        }
+    }
+    let sum: number = 0;
+    for (let i: number = 0; i < n; i++) {
+        sum = sum + a[i];
+    }
+    return sum;
+}
+
+const params: number[] = [1000, 100000, 1000000];
+for (let p: number = 0; p < params.length; p++) {
+    bench("int32-kernel", params[p], () => int32Kernel(params[p]));
+}
+for (let p: number = 0; p < params.length; p++) {
+    bench("accumulate", params[p], () => accumulate(params[p]));
+}

--- a/docs/plans/shaped-objects-representation.md
+++ b/docs/plans/shaped-objects-representation.md
@@ -227,13 +227,29 @@ access, cannot realize the win from the representation alone. So:
   that this hits 2.2× in real emitted IL, integrates with stack-typing, and stays
   standalone. That is the next de-risk.
 
+## Prototype 2 (compiled IC) — concrete implementation plan
+
+This is the decisive de-risk. Scouted integration points:
+
+| Piece | Where | Change |
+|-------|-------|--------|
+| `$Object` storage | `RuntimeEmitter.TSObject.cs:34` (`_fields: Dictionary`) | add `_shape: object` + `_slots: object[]` fields (keep `_fields` initially as the deopt/dictionary-mode fallback) |
+| Object-literal construction | the literal emitter that builds the `Dictionary` then `newobj $Object` | emit a **pre-sized** shaped object: the compiler knows the literal's keys, so intern the terminal `$Shape` once (static field) and fill `_slots[0..k]` directly — **no runtime SlotOf/transition** |
+| Property read fast path | `ILEmitter.Properties.cs:687` (`TypeInfo.Record` branch; **must stay behind the #862 promoted-struct path at :23**) | emit the IC: `if (o._shape == site.shape) push o._slots[site.slot]; else SlowGet(o, "k", ref site)` with `site.shape`/`site.slot` as **per-site static fields** (the regex-literal-hoisting pattern) |
+| `$Shape` type | new emitted type | `SlotOf(string)→int` + `Add(string)→$Shape` (interned transition tree). **Only invoked on construction-of-non-literal-shapes, dynamic adds, and IC misses** — never on the IC hot path, so its IL cost is off the critical path |
+| Deopt | `delete`, dynamic string keys, megamorphic | flip to `_fields` dictionary mode; ICs miss → slow path → equals today |
+
+**Critical simplification:** the IC *hit* path is just `ldfld _shape; ceq; brtrue; ldfld _slots; ldc slot; ldelem.ref` — trivial IL, no Shape logic. All the Shape machinery (SlotOf/transitions) sits on construction + miss. For object **literals** (the common case) even construction skips it, because the compiler emits the interned terminal shape directly.
+
+**First milestone (one path, measurable):** statically-`Record`-typed escaping object, read `o.field` in a loop (binary-trees-style). Wire `$Object` shaped fields + literal construction + the read IC for this path only; confirm the **2.2×** holds in emitted IL and `ILVerify` is clean, *before* touching `Object.*`/for-in/spread/delete/proxies. Land it together with the interpreter `ShapedFieldStore` as one net win.
+
+**Open risk to watch:** `$Object` must stay standalone — `$Shape` and the IC are pure emitted IL + BCL (`object[]`, `Dictionary` for `SlotOf`), no SharpTS.dll ref. The per-site cache is a static field on the emitting type, exactly like hoisted regex literals.
+
 ## Recommendation
 
-Phase 1 is the expensive, risky foundation; Phase 2 (ICs) is where the measured
-2.2× lands — and Prototype 1 shows the representation alone does nothing without
-them. **Next: prototype the *compiled* IC on a single path** (e.g. a
-statically-typed escaping object's `.field`, binary-trees-style) end to end —
-emit a shaped `$Object`, cache `(shape, slot)` per site, and confirm the 2.2×
-holds in emitted IL before committing to the full both-modes rollout. The
-interpreter `ShapedFieldStore` is perf-neutral on its own, so it should land
-*together with* the compiled ICs (as one net win), not before.
+Phase 1 is the foundation; Phase 2 (ICs) is where the measured 2.2× lands — and
+Prototype 1 proved the representation alone does nothing without them. Execute
+**Prototype 2's first milestone** above (one `Record.field` read path, end to
+end in emitted IL) as the next focused session; ship it together with the
+interpreter `ShapedFieldStore` so the combined change is a net win, never a
+perf-neutral complexity increase.

--- a/docs/plans/shaped-objects-representation.md
+++ b/docs/plans/shaped-objects-representation.md
@@ -1,0 +1,203 @@
+# Plan: Hidden-class ("shape") representation for dynamic objects
+
+Status: **design + de-risking spike complete; not yet started.** This is the
+high-leverage representation project identified by the post-typed-array perf
+session (see `MEMORY` / `project_compiled_perf_sort_json`).
+
+## Goal
+
+Give dynamic objects a V8-style **hidden class** ("shape" / "map") + **inline
+cache** representation so that property access is a slot-index load behind a
+cheap shape check instead of a `Dictionary<string,object?>` hash probe, and so
+that objects sharing a structure share their layout. Targets the compiled mode
+first (the competitive gap), interpreter second.
+
+### Why (measured)
+
+Every remaining big compiled-vs-Node gap bottoms out in the **same** cost — the
+boxed `Dictionary`-per-object + boxed-`double`-per-number representation:
+
+| Benchmark | compiled vs Node | dominated by |
+|-----------|-----------------:|--------------|
+| `json` parse | ~6–8× | building `Dictionary`/`List`/boxed graph |
+| `json` stringify | ~5× | walking that graph |
+| `binary-trees` | 6–26× | `node.left`/`node.right` dictionary lookups |
+| property-heavy code | — | every `o.x` is a hash probe + box |
+
+`#857`/`#858`/`#862` already promote **non-escaping** object literals to
+compile-time value-type shape structs (`$Shape_N`), so `objectWork`
+(`{x,y}; o.x+o.y`, never escapes) is already fast. This plan covers the
+**escaping / dynamic** objects those optimizations cannot touch:
+`JSON.parse` output, `binary-trees` nodes, objects returned from functions or
+stored in collections.
+
+## De-risking spike (results)
+
+A standalone harness (`scratchpad/shapespike`) built 1,000,000 escaping objects
+of shape `{id:number, name:string, value:number}`, stored them, then read the
+numeric `value` field hot. `min` over repeats, Release, workstation GC:
+
+### Property read — the inline-cache payoff
+
+| representation | read 1M | vs Dictionary | vs class ceiling |
+|----------------|--------:|--------------:|-----------------:|
+| A `Dictionary<string,object?>` (today) | 11.8ms | 1.0× | 7.0× |
+| B shape + boxed slots + monomorphic IC | 5.3ms | **2.2×** | 3.1× |
+| C shape + **unboxed** numeric slots + IC | 4.5ms | **2.6×** | 2.7× |
+| B-poly: 2 shapes, 1-entry IC thrashing | 7.9ms | **1.5×** | — |
+| D idiomatic C# class field (ceiling) | 1.7ms | 7.0× | 1.0× |
+
+### Construction — the JSON.parse payoff
+
+| representation | build 1M | alloc | vs Dictionary |
+|----------------|---------:|------:|--------------:|
+| A `Dictionary` (today) | 170ms | 259MB | 1.0× |
+| B shape, grow-per-slot (naive) | 239ms | 198MB | 0.7× (slower!) |
+| **B2 shape + boxed, pre-sized** | 104ms | 130MB | **1.6×, ½ alloc** |
+| **C2 shape + unboxed, pre-sized** | 80ms | 114MB | **2.1×, 44% alloc** |
+| D idiomatic class (ceiling) | 27ms | 46MB | 6.3× |
+
+### What the spike proved
+
+1. **Inline caches deliver ~2.2× on reads** (2.6× with unboxed numeric slots).
+   This validates Phase 2 — the IC is worth building.
+2. **Pre-sizing the slot array is mandatory.** Growing one slot at a time (3
+   `Array.Copy`s/object) makes shaped construction *slower* than `Dictionary`.
+   With the shape known up front (compiled literal, or a parse that buffers a
+   record then allocates the terminal shape once), construction is **1.6–2.1×
+   faster and roughly halves allocation**.
+3. **Shapes never regress below today's `Dictionary`.** Even a pathological
+   polymorphic site where a 1-entry IC misses on *every* access is 1.5× faster
+   than `Dictionary` (7.9 vs 11.8ms); megamorphic objects fall back to
+   dictionary mode and merely *equal* today. **The risk is correctness, not a
+   perf cliff.**
+4. Shapes do **not** reach the idiomatic-class ceiling (still ~2.7–3.1× off) —
+   the IC branch + array bounds check + indirection remain. They close most,
+   not all, of the gap. Node doesn't reach it either; this is competitive.
+
+## Current representation (what changes)
+
+| Concern | Interpreter | Compiled |
+|---------|-------------|----------|
+| Object backing | `SharpTSObject._fields : Dictionary<string,object?>` (`Runtime/Types/SharpTSObject.cs:19`) | emitted `$Object` over a `Dictionary` (`Compilation/RuntimeEmitter.TSObject.cs`) |
+| Read / write | `GetProperty`/`SetProperty` (`SharpTSObject.cs:111,147`) | `EmitGet`/`EmitSet` (`Compilation/ILEmitter.Properties.cs`) |
+| Getters/setters/descriptors | side `_getters`/`_setters`/`_descriptors` dicts (`SharpTSObject.cs:21-23`) | `PropertyDescriptorStore` (PDS) |
+| Symbols, prototype, frozen/sealed | `_symbolFields`, `Prototype`, `IsFrozen`/`IsSealed`/`IsExtensible` | mirrored on `$Object` |
+
+Numbers are stored boxed (`object?` slot / `RuntimeValue`→boxed at the boundary).
+
+## Design
+
+### Shape (immutable, interned)
+
+```
+sealed class Shape {
+    string[]                 Names;          // ordered own property names (insertion order)
+    Dictionary<string,int>   SlotOf;         // name -> slot index
+    Dictionary<string,Shape> Transitions;    // "add name" -> resulting shape (shared)
+    // Phase 4: per-slot kind (Num|Ref) + sub-index into typed backing arrays
+    static readonly Shape Root;              // empty
+}
+```
+
+A transition tree means every `{id,name,value}` literal/parse, after the first,
+walks cached `Add` edges and lands on the **same terminal `Shape`** — so the
+shape is allocated once per distinct structure, not once per object, and an IC
+keyed on shape identity (`ReferenceEquals`) is monomorphic across all of them.
+
+### ShapedObject
+
+```
+sealed class ShapedObject {
+    Shape    Shape;
+    object?[] Slots;                 // Phase 1-2
+    // Phase 4: double[] Nums; object?[] Refs;  (segregated typed storage)
+    Dictionary<string,object?>? Overflow;  // dictionary-mode fallback (null in fast path)
+}
+```
+
+Insertion-order, descriptors, getters/setters, symbols, prototype, frozen state:
+property **order** comes from `Shape.Names`; the rare side concerns
+(descriptors, accessors, symbols) stay in lazily-allocated side tables exactly
+as today — the shape only governs the plain data slots.
+
+### Inline caches (compiled `o.x` sites) — where the speed is
+
+Each property site gets a per-site cache (static fields, like the regex-literal
+hoisting pattern in `regex-literal-hoisting-scope.md`):
+
+```
+// o.x  -->
+if (o.Shape == site.CachedShape) value = o.Slots[site.CachedSlot];   // fast
+else                             value = SlowGet(o, "x", ref site);  // fill cache / deopt
+```
+
+- **Monomorphic** (1 shape): the common case; ~2.2× the spike measured.
+- **Polymorphic** (cache 2–4 shapes, linear check): still beats Dictionary.
+- **Megamorphic** (>N shapes): stop caching, dictionary-mode lookup ≈ today.
+
+### Deopt to dictionary mode
+
+`delete`, non-string/integer-index keys, runaway property counts, `Object.assign`
+of disjoint shapes, etc. flip a `ShapedObject` to `Overflow` dictionary mode
+(shape becomes a sentinel; ICs miss and route to the slow path). This is the
+correctness safety net that guarantees "never worse than today."
+
+## Phasing (each independently shippable, gated by test262 + TS-conformance)
+
+| Phase | Scope | Expected | Risk |
+|-------|-------|---------:|------|
+| **1** | `Shape` + `ShapedObject` as the dynamic-object backing. Interpreter first (easier to validate every `Object.*` path), then compiled `$Object`. Slot-index access, **no ICs yet**, **pre-sized construction for literals**. Dictionary-mode deopt in place. | Construction 1.6× + ½ alloc; reads ~flat without ICs | **High** — central type, every property path |
+| **2** | Inline caches at compiled `o.x` / `o.x=` sites (mono→poly→mega). | **Reads ~2.2×** (binary-trees, property-heavy) | Med-high |
+| **3** | `JSON.parse` builds shaped objects directly (buffer record → terminal shape → pre-sized slots); object literals emit shaped objects; stringify walks slots. | json parse ~1.6×, stringify, binary-trees | Med |
+| **4** *(optional)* | Segregated **unboxed numeric slots** (`double[] Nums` + `object?[] Refs`). | +read 1.18×, +construction 1.3×, less alloc | **High** (typed slot bookkeeping; deopt on type change) |
+
+## Integration points (the reason this is multi-week, not a weekend)
+
+Every path that reads/writes/enumerates object properties must understand shapes
+**or** route through a shape-aware accessor, in **both** modes:
+
+- `EvaluateGet`/`EvaluateSet` (interp), `EmitGet`/`EmitSet` (compiled)
+- `PropertyDescriptorStore`, `Object.defineProperty`/`getOwnPropertyDescriptor`
+- `Object.keys`/`values`/`entries`/`assign`/`freeze`/`seal`/`getOwnPropertyNames`
+- `for-in`, spread `{...o}`, object destructuring, `delete`, `in`
+- getters/setters, `Symbol`-keyed properties, the prototype chain walk
+- Proxies (must NOT be shaped — they dispatch through traps)
+- Reviver walk (`RuntimeEmitter.Json.ParseReviver.cs`) — already graph-based, fine
+
+**Invariant to preserve at every step:** ECMA-262 own-property **insertion
+order** (integer-index keys ascending first, then string keys in insertion
+order). `Shape.Names` must encode exactly this.
+
+## Risks & mitigations
+
+- **Conformance regressions** — property order, descriptor flags, accessor
+  semantics, freeze/seal, `in`/`hasOwnProperty`. *Mitigation:* phase behind both
+  conformance suites; keep dictionary-mode as a behavior-identical fallback; land
+  interpreter first (cheaper to validate, no IL) and diff against it.
+- **Standalone-DLL constraint** — shapes/IC sites are emitted IL + BCL types
+  only; per-site caches are static fields (proven pattern). No new SharpTS.dll
+  refs.
+- **Perf cliff from polymorphism** — spike shows even thrashing mono-IC beats
+  Dictionary; poly-IC (2–4 entries) recovers; megamorphic equals today.
+- **Phase 4 type instability** — a slot that changes number↔ref must transition
+  shape (or deopt). Keep Phase 4 optional and last.
+
+## Open questions
+
+1. IC storage in compiled IL: per-site static `(Shape, int)` fields vs a small
+   per-site struct. (Lean: two static fields, mirroring regex-literal hoisting.)
+2. Poly-IC width before megamorphic (V8 uses 4). Start at 4.
+3. Should the interpreter get ICs too, or only the denser representation? (Spike
+   suggests interp benefits mostly from the representation; ICs are a compiled
+   win. Likely: representation both modes, ICs compiled-only.)
+4. JSON.parse shape-building: buffer a whole record before allocating (clean
+   pre-size) vs transition-walk with end-of-object resize. (Lean: buffer.)
+
+## Recommendation
+
+Phase 1 is the expensive, risky foundation; Phase 2 is where the measured 2.2×
+lands. **Do not start Phase 1 cold** — the spike has de-risked the *payoff*; next
+de-risk the *cost* by prototyping the compiled IC on a single path
+(`binary-trees`-style `node.left`) end to end before the full both-modes
+rollout.

--- a/docs/plans/shaped-objects-representation.md
+++ b/docs/plans/shaped-objects-representation.md
@@ -194,10 +194,46 @@ order). `Shape.Names` must encode exactly this.
 4. JSON.parse shape-building: buffer a whole record before allocating (clean
    pre-size) vs transition-walk with end-of-object resize. (Lean: buffer.)
 
+## Prototype 1 (interpreter) — results
+
+A first interpreter prototype (`Runtime/Types/ShapedFieldStore.cs`) replaced the
+`Dictionary<string,object?>` backing of `SharpTSObject` with an interned-shape +
+slot-array store (`IReadOnlyDictionary` drop-in; delete → dictionary-mode deopt).
+What it established:
+
+- **Integration is viable.** After one fix it passes the object-semantics suite
+  (1,363 object/destructure/spread/freeze/for-in tests + 84 worker tests).
+- **The one real integration cost found:** `SharpTSObject(Dictionary)`'s *aliasing
+  contract*. `StructuredClone.CloneObject` constructed the object with an empty
+  dict and then **mutated that dict after construction**, relying on the object
+  aliasing it. A shaped store copies at construction, so those writes were lost
+  (clone came back empty → `cloned.nested` undefined → "Cannot set properties of
+  undefined"). Fixed by writing through `SetProperty`. Only **1 of 159**
+  `new SharpTSObject(...)` sites relied on this — the friction is small but real,
+  and Phase 1 must audit for it.
+- **Shapes are perf-NEUTRAL in the interpreter** (paired object-read bench: ~1100ms
+  both). Two reasons: the tree-walk dominates per-access cost, and a shaped read
+  *still* does a name→slot dictionary lookup (`ObjectShape.SlotOf`) + an array
+  index — no cheaper than a direct `Dictionary` probe **without an inline cache**.
+
+**Conclusion: the 2.2× payoff is entirely inline-cache-bound**, and ICs are a
+*compiled* call-site mechanism (cache `(shape, slot)` in per-site static fields,
+skip `SlotOf` on the hot path). The interpreter, which resolves by name every
+access, cannot realize the win from the representation alone. So:
+
+- The interpreter prototype **de-risked integration/correctness** (cheap, no IL).
+- The standalone spike **de-risked the IC payoff** (2.2×, in C#).
+- **Still unproven end-to-end: the *compiled* shaped-`$Object` + emitted IC** —
+  that this hits 2.2× in real emitted IL, integrates with stack-typing, and stays
+  standalone. That is the next de-risk.
+
 ## Recommendation
 
-Phase 1 is the expensive, risky foundation; Phase 2 is where the measured 2.2×
-lands. **Do not start Phase 1 cold** — the spike has de-risked the *payoff*; next
-de-risk the *cost* by prototyping the compiled IC on a single path
-(`binary-trees`-style `node.left`) end to end before the full both-modes
-rollout.
+Phase 1 is the expensive, risky foundation; Phase 2 (ICs) is where the measured
+2.2× lands — and Prototype 1 shows the representation alone does nothing without
+them. **Next: prototype the *compiled* IC on a single path** (e.g. a
+statically-typed escaping object's `.field`, binary-trees-style) end to end —
+emit a shaped `$Object`, cache `(shape, slot)` per site, and confirm the 2.2×
+holds in emitted IL before committing to the full both-modes rollout. The
+interpreter `ShapedFieldStore` is perf-neutral on its own, so it should land
+*together with* the compiled ICs (as one net win), not before.

--- a/docs/plans/shaped-objects-representation.md
+++ b/docs/plans/shaped-objects-representation.md
@@ -227,9 +227,51 @@ access, cannot realize the win from the representation alone. So:
   that this hits 2.2× in real emitted IL, integrates with stack-typing, and stays
   standalone. That is the next de-risk.
 
-## Prototype 2 (compiled IC) — concrete implementation plan
+## Prototype 2 (compiled IC) — SCOUTING FINDING that reshapes the milestone
 
-This is the decisive de-risk. Scouted integration points:
+**Plain compiled objects are NOT `$Object` — they are a bare `Dictionary<string,object?>`.**
+`ILEmitter.Properties.Literals.cs:117-148`: an object literal with no spread /
+computed key / accessor emits `new Dictionary(); set_Item…` directly (only
+accessor-bearing literals become `$Object`). The `TypeInfo.Record` read/write
+fast paths (`ILEmitter.Properties.cs:687`, `EmitTypedRecordPropertyGet/Set`) do
+`Castclass Dictionary; TryGetValue / set_Item`. So:
+
+- There is **no `$Object` instance to add `_shape`/`_slots` to** for the common
+  case — the original milestone's premise was wrong.
+- The bare `Dictionary` is shared by **construction and every consumer**
+  (spread/`MergeIntoObject`, `Object.keys`, for-in, `StructuredClone`'s
+  `Dictionary` arm, the Record get/set fast paths). Swapping it for a bespoke
+  shaped struct would touch all of them — a full representation swap, no slice.
+
+**Revised contained approach — `$ShapedDict : Dictionary<string,object?>`.**
+Subclass the Dictionary instead of replacing it:
+
+```
+class $ShapedDict : Dictionary<string,object?> {
+    string[] _shape;     // interned per construction site (static field)
+    object?[] _slots;    // values, slot i == _shape[i]
+}
+```
+
+- **Every existing consumer is oblivious** — `$ShapedDict` *is* a `Dictionary`,
+  so `Castclass Dictionary`, `TryGetValue`, `Keys`, spread, clone, for-in all
+  keep working unchanged. Zero blast radius outside the two touch points below.
+- **Construction** (Record-typed, all-data-prop literals only): emit
+  `new $ShapedDict(internedNames)` and fill *both* the base dictionary entry and
+  `_slots[i]` per property (double-write; double storage — acceptable for a
+  measurement prototype; Phase 1 proper drops the dict for shaped-only).
+- **Read IC** at `EmitTypedRecordPropertyGet`: `isinst $ShapedDict`; if it is one
+  and `sd._shape == site.cachedShape` → `sd._slots[site.cachedSlot]`; else the
+  existing `TryGetValue`. Per-site `static string[] cachedShape; static int slot`.
+  On miss, `slot = Array.IndexOf(sd._shape, name)` (BCL, standalone-safe).
+
+This makes the **in-pipeline IC measurement contained and reversible**: only the
+new type, the Record-literal construction, and the Record get fast path change;
+everything else is untouched because the object is still a `Dictionary`. If the
+IC shows the spike's 2.2× on a read-hot loop (build-once/read-many), the approach
+is validated and Phase 1 proper can drop the double storage.
+
+### Original integration points (still valid for Phase 1 proper)
 
 | Piece | Where | Change |
 |-------|-------|--------|


### PR DESCRIPTION
Compiled-mode performance work plus the design + de-risking for the next big lever. Each commit is independently verified; everything is gated on the relevant test suites (no regressions; full suite 13,928 passed / 0 failed).

## Performance wins

| Commit | Win | Result (compiled vs Node) |
|---|---|---|
| Typed-array all-numeric unboxed | element read/write/compound unboxed for every numeric typed array (was Float64-only **and dormant for annotated code** — the type-checker unlock makes `: Int32Array` resolve to a real type) | **8–24× faster**; Float64/compound now ~1.1× Node, Int32 ~3.1× |
| JSON.parse one-pass `Utf8JsonReader` | parse straight into the runtime graph; drop the throwaway `JsonDocument` DOM + its re-walk | parse **~210→170ms (~19%)** |
| charCodeAt unboxed | statically-string receiver: unboxed index + raw-double result (was 2 heap boxes/call) | **~7×; now faster than Node** — helps every lexer/tokenizer/scanner |
| sort arg-buffer hoist | reuse one `object[2]` across merge comparisons instead of one per comparison | small (~2–3%) + variance/GC; honest — the gap is un-inlinable boxed comparator dispatch, not allocation |

## Shapes (hidden-class) representation — design + de-risk (no production code yet)

`docs/plans/shaped-objects-representation.md` plus findings:
- **Spike** (de-risks the payoff): inline-cache property reads **2.2×** the current `Dictionary` (2.6× with unboxed slots); pre-sized shaped construction **1.6–2.1×** at ~half the allocation; even a thrashing polymorphic IC stays **1.5×** ahead — **never a perf cliff**.
- **Interpreter prototype** (de-risks integration, full suite green): the representation drops into `SharpTSObject` cleanly; the one integration cost is the `SharpTSObject(Dictionary)` aliasing contract (1 of 159 sites). **Key finding: shapes are perf-neutral without an inline cache** — the 2.2× is IC-bound, and ICs are a compiled call-site mechanism. So the interp store is held back to land *with* the compiled ICs.

## Landscape (for reviewers)

Remaining compiled-vs-Node gaps fall into: (1) **boundary box/unbox** (typed-array, charCodeAt — the clean wins here), (2) **boxed object/array storage** (json residual, stringify 5×, binary-trees, `number[]` ~9×) → the shapes/representation project, (3) **capped** (sort dispatch, SIMD stencil).

## Verification
- Full test suite: 13,928 passed, 0 failed, 16 skipped.
- Per-area: typed-array, JSON (185), String (944), ILVerify (81) all green; emitted IL verifies.
- Each win measured byte-identical to Node across edge cases (number forms, escapes, NaN/out-of-range, reviver, malformed→SyntaxError, boxed consumers).