### PR TITLE
fix(check): union subtype reduction — numeric enum absorbed by `number` (#894)

### DIFF
--- a/SharpTS.Tests/TypeCheckerTests/EnumUnionIndexSignatureTests.cs
+++ b/SharpTS.Tests/TypeCheckerTests/EnumUnionIndexSignatureTests.cs
@@ -1,0 +1,103 @@
+using SharpTS.Diagnostics;
+using SharpTS.Parsing;
+using SharpTS.TypeSystem;
+using Xunit;
+
+namespace SharpTS.Tests.TypeCheckerTests;
+
+/// <summary>
+/// #894: a union property type is checked against a string index signature member-wise, but a
+/// numeric enum constituent absorbed by a sibling <c>number</c> (or string enum by <c>string</c>)
+/// must be dropped first — tsc reduces <c>e | number</c> to <c>number</c>, so it is assignable to a
+/// <em>different</em> numeric enum index (E2). enum→enum is nominal, so the un-reduced <c>e</c> arm
+/// would wrongly emit a spurious TS2411.
+///
+/// TS2411 is recorded (not thrown) since commit b2896eb8, so these assert on the diagnostic
+/// collection via <see cref="TypeChecker.CheckWithRecovery"/> rather than Assert.ThrowsAny.
+/// </summary>
+public class EnumUnionIndexSignatureTests
+{
+    private static IReadOnlyList<Diagnostic> Diagnostics(string source)
+    {
+        var tokens = new Lexer(source).ScanTokens();
+        var parseResult = new Parser(tokens).Parse();
+        Assert.True(parseResult.IsSuccess, "source should parse for a type-check test");
+        return new TypeChecker().CheckWithRecovery(parseResult.Statements).Diagnostics;
+    }
+
+    private static bool HasTs2411(IEnumerable<Diagnostic> diags) =>
+        diags.Any(d => d.TsCode == "TS2411");
+
+    [Fact]
+    public void NumericEnumUnionNumber_AgainstDifferentNumericEnumIndex_NoError()
+    {
+        // (e | number) reduces to number; number is assignable to the E2 index → no TS2411 (#894).
+        var source = """
+            enum e { e1, e2 }
+            enum E2 { A }
+            interface I14 {
+                [x: string]: E2;
+                foo2: e | number;
+            }
+            """;
+        Assert.DoesNotContain(Diagnostics(source), d => d.TsCode == "TS2411");
+    }
+
+    [Fact]
+    public void StringNumberUnion_AgainstNumericEnumIndex_StillErrors()
+    {
+        // No enum constituent → no reduction; string is not assignable to E2 → TS2411 stays.
+        var source = """
+            enum E2 { A }
+            interface I14 {
+                [x: string]: E2;
+                foo: string | number;
+            }
+            """;
+        Assert.True(HasTs2411(Diagnostics(source)));
+    }
+
+    [Fact]
+    public void BareEnum_AgainstDifferentEnumIndex_StillErrors()
+    {
+        // Bare enum (no union) is untouched by the reduction; enum→enum is nominal → TS2411 stays.
+        // Guards against regressing enumIsNotASubtypeOfAnythingButNumber.ts.
+        var source = """
+            enum E { A }
+            enum E2 { A }
+            interface I {
+                [x: string]: E2;
+                foo: E;
+            }
+            """;
+        Assert.True(HasTs2411(Diagnostics(source)));
+    }
+
+    [Fact]
+    public void NumericEnumUnionNumber_AgainstNumberIndex_NoError()
+    {
+        // Already correct before the fix; pin that it stays correct (e and number both → number).
+        var source = """
+            enum e { e1, e2 }
+            interface I2 {
+                [x: string]: number;
+                foo2: e | number;
+            }
+            """;
+        Assert.DoesNotContain(Diagnostics(source), d => d.TsCode == "TS2411");
+    }
+
+    [Fact]
+    public void NumericEnumUnionNumber_AgainstStringIndex_StillErrors()
+    {
+        // (e | number) reduces to number; number is not assignable to a string index → TS2411 stays.
+        var source = """
+            enum e { e1, e2 }
+            interface I3 {
+                [x: string]: string;
+                foo2: e | number;
+            }
+            """;
+        Assert.True(HasTs2411(Diagnostics(source)));
+    }
+}

--- a/SharpTS.TypeScriptConformance/baselines/interpreted.txt
+++ b/SharpTS.TypeScriptConformance/baselines/interpreted.txt
@@ -129,4 +129,4 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingW
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithStringIndexer3.ts Fail
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithStringIndexer4.ts Fail
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/undefinedIsSubtypeOfEverything.ts Pass
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/unionSubtypeIfEveryConstituentTypeIsSubtype.ts Fail
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/unionSubtypeIfEveryConstituentTypeIsSubtype.ts Pass

--- a/TypeSystem/TypeChecker.Compatibility.cs
+++ b/TypeSystem/TypeChecker.Compatibility.cs
@@ -374,6 +374,36 @@ public partial class TypeChecker
     };
 
     /// <summary>
+    /// tsc "Literal" union reduction, narrowed to the slice that changes an assignability verdict:
+    /// a bare enum constituent is absorbed by a primitive constituent it is a subtype of — numeric
+    /// enum by <c>number</c>, string enum by <c>string</c>, heterogeneous enum when both are present.
+    /// Drop the enum, keep the primitive. Needed because enum→enum is NOMINAL, so <c>(e | number)</c>
+    /// must relate to a target the way <c>number</c> does (e.g. assignable to a <em>different</em>
+    /// numeric enum E2 via numberAssignableToEnum), not member-wise — the <c>e</c> arm would otherwise
+    /// reject the whole union (#894). Literal-by-primitive absorption (<c>1</c> by <c>number</c>) is
+    /// intentionally omitted: real-literal subtyping is transitive, so it never changes an
+    /// assignability verdict, only the type's rendering. Returns the input list unchanged when nothing
+    /// is absorbed, so callers keep their cached <see cref="TypeInfo.Union.FlattenedTypes"/> instance.
+    /// </summary>
+    private static List<TypeInfo> ReduceEnumMembersAbsorbedByPrimitive(List<TypeInfo> members)
+    {
+        bool hasNumber = members.Any(m => m is TypeInfo.Primitive { Type: TokenType.TYPE_NUMBER });
+        bool hasString = members.Any(m => m is TypeInfo.String);
+        if (!hasNumber && !hasString) return members;
+
+        bool Absorbed(TypeInfo.Enum e) => e.Kind switch
+        {
+            EnumKind.Numeric => hasNumber,
+            EnumKind.String => hasString,
+            EnumKind.Heterogeneous => hasNumber && hasString,
+            _ => false
+        };
+
+        var reduced = members.Where(m => m is not TypeInfo.Enum en || !Absorbed(en)).ToList();
+        return reduced.Count == members.Count ? members : reduced; // never reduce to empty
+    }
+
+    /// <summary>
     /// Core type compatibility logic without caching.
     /// </summary>
     private bool IsCompatibleCore(TypeInfo expected, TypeInfo actual)
@@ -616,7 +646,8 @@ public partial class TypeChecker
         if (expected is TypeInfo.Union expectedUnion && actual is TypeInfo.Union actualUnion)
         {
             var expectedTypes = expectedUnion.FlattenedTypes;
-            var actualTypes = actualUnion.FlattenedTypes;
+            // Same enum-absorbed-by-primitive reduction as the union-as-actual branch below (#894).
+            var actualTypes = ReduceEnumMembersAbsorbedByPrimitive(actualUnion.FlattenedTypes);
             // Per source constituent: some-target-constituent first, then the discriminated
             // path (a constituent may relate only through its discriminant combinations).
             return actualTypes.All(actualType =>
@@ -633,10 +664,12 @@ public partial class TypeChecker
                 RelatedToDiscriminatedUnion(expUnion, actual);
         }
 
-        // Union as actual: all members must be compatible with expected
+        // Union as actual: all members must be compatible with expected. Drop enum members
+        // absorbed by a sibling primitive first (e | number → number): enum→enum is nominal, so
+        // the un-reduced `e` arm would wrongly reject `(e | number) → E2` (#894).
         if (actual is TypeInfo.Union actUnion)
         {
-            var actTypes = actUnion.FlattenedTypes;
+            var actTypes = ReduceEnumMembersAbsorbedByPrimitive(actUnion.FlattenedTypes);
             return actTypes.All(t => IsCompatible(expected, t));
         }
 


### PR DESCRIPTION
Closes #894.

## Problem

A property typed `e | number` (numeric enum `e`) checked against a *different* numeric-enum index signature `E2` emitted a spurious **TS2411**:

```ts
enum e { e1, e2 }
enum E2 { A }
interface I14 {
    [x: string]: E2;
    foo:  string | number;  // L99: tsc flags TS2411 — we agree
    foo2: e | number;        // L100: tsc does NOT flag — we WRONGLY did
}
```

The union-as-source assignability check requires *every* member assignable. `number → E2` succeeds (a numeric-enum index accepts widened `number`) but `e → E2` fails (enum→enum is **nominal**), so the whole union was rejected. tsc reduces `e | number` to just `number` at union construction, so it relates to `E2`.

## Fix

New `ReduceEnumMembersAbsorbedByPrimitive` in `TypeChecker.Compatibility.cs` — drops a bare enum constituent absorbed by a sibling primitive (numeric enum by `number`, string enum by `string`, heterogeneous by both); keep the primitive, drop the enum. Applied in the union-as-actual branch (the bug's path) and the both-union branch — **not** at union construction, which would perturb `ToString`/member-order/structural identity caches (the risk the issue flags, and the territory of the reverted "Bucket B" subtype-reduction work).

Two subtleties pinned by the implementation:
- **Only the enum case changes a verdict.** Enum→enum is non-transitive (`e <: number`, `number <: E2`, yet `e ⊀ E2`). Real-literal absorption (`1` by `number`) *is* transitive, so it's a no-op for assignability — deliberately omitted.
- **The reduction must be directional.** A numeric enum and `number` are *mutually* assignable, so a symmetric "drop the subtype" would drop both. We keep the primitive and drop the enum.

## Verification

- **Conformance (`SharpTS.TypeScriptConformance`): 0 regressions, 1 new pass** — `unionSubtypeIfEveryConstituentTypeIsSubtype.ts` Fail→Pass (Pass 109→110); `enumAssignability.ts` / `enumIsNotASubtypeOfAnythingButNumber.ts` stay Pass. Baseline regenerated (1-line diff).
- **+5 focused unit tests** (`EnumUnionIndexSignatureTests.cs`). These assert on the diagnostic collection via `CheckWithRecovery` because TS2411 is recorded, not thrown (since b2896eb8).
- **Full in-sln suite: 13981 passed.** The only 2 failures are the pre-existing `Test262Tests` baseline (object-spread parse drift) — confirmed unrelated by reproducing them identically with this change stashed.