### PR TITLE
perf(compile): fast paths for numeric and null/undefined equality

### DIFF
--- a/Compilation/ILEmitter.Operators.cs
+++ b/Compilation/ILEmitter.Operators.cs
@@ -194,6 +194,15 @@ public partial class ILEmitter
     /// </summary>
     private void EmitEqualityBinary(Expr.Binary b, bool isStrict, bool isNegated)
     {
+        // Fast path: comparison against the `null` or `undefined` literal. In compiled
+        // output JS null is CLR null and JS undefined is the $Undefined singleton, so
+        // the test is a direct reference check (ceq) rather than boxing the operand and
+        // dispatching Object.Equals/runtime.Equals — null guards are everywhere.
+        if (TryEmitNullishEqualityFastPath(b, isStrict, isNegated))
+        {
+            return;
+        }
+
         // Fast path: both operands statically numeric. JS number equality has no
         // coercion (=== and == agree when both sides are number), and IEEE `ceq`
         // matches the spec exactly — NaN is never equal (ceq → false, correct for
@@ -1886,6 +1895,78 @@ public partial class ILEmitter
         TypeSystem.TypeInfo.Union u => u.FlattenedTypes.All(IsNumericTypeInfo),
         _ => false
     };
+
+    /// <summary>
+    /// Fast path for <c>x === null</c> / <c>x === undefined</c> (and the loose and
+    /// negated forms) when exactly one operand is the statically-typed <c>null</c> or
+    /// <c>undefined</c> literal. In compiled output JS <c>null</c> is CLR null and JS
+    /// <c>undefined</c> is the <c>$Undefined</c> singleton, so the comparison is a
+    /// direct reference check (<c>ceq</c>) instead of boxing the value operand and
+    /// dispatching <c>Object.Equals</c>/<c>runtime.Equals</c>.
+    ///
+    /// <para>Strict <c>===</c> distinguishes null from undefined (reference identity);
+    /// loose <c>==</c> against either is the nullish test (null OR undefined). NaN is
+    /// never null/undefined, so a NaN value operand correctly compares unequal with no
+    /// special handling. When both sides are nullish-typed (e.g. <c>null === undefined</c>)
+    /// this returns false and the caller falls through to the existing boxed path.</para>
+    /// </summary>
+    private bool TryEmitNullishEqualityFastPath(Expr.Binary b, bool isStrict, bool isNegated)
+    {
+        if (_ctx.TypeMap == null) return false;
+
+        var leftType = _ctx.TypeMap.Get(b.Left);
+        var rightType = _ctx.TypeMap.Get(b.Right);
+        bool leftNullish = leftType is TypeSystem.TypeInfo.Null or TypeSystem.TypeInfo.Undefined;
+        bool rightNullish = rightType is TypeSystem.TypeInfo.Null or TypeSystem.TypeInfo.Undefined;
+
+        // Need exactly one side to be the literal; the other is the value being tested.
+        if (leftNullish == rightNullish) return false;
+
+        Expr valueExpr = leftNullish ? b.Right : b.Left;
+        var literalType = leftNullish ? leftType : rightType;
+
+        // Emit the value operand boxed (matches the boxed path's operand handling).
+        EmitExpression(valueExpr);
+        EmitBoxIfNeeded(valueExpr);
+
+        if (isStrict)
+        {
+            // x === null      -> reference-equal to CLR null
+            // x === undefined -> reference-equal to the $Undefined singleton
+            if (literalType is TypeSystem.TypeInfo.Null)
+            {
+                IL.Emit(OpCodes.Ldnull);
+            }
+            else
+            {
+                EmitUndefinedConstant();
+            }
+            IL.Emit(OpCodes.Ceq);
+        }
+        else
+        {
+            // Loose == / != against null or undefined is the nullish test: the value is
+            // CLR null OR the $Undefined singleton.
+            var valueLocal = IL.DeclareLocal(_ctx.Types.Object);
+            IL.Emit(OpCodes.Stloc, valueLocal);
+            IL.Emit(OpCodes.Ldloc, valueLocal);
+            IL.Emit(OpCodes.Ldnull);
+            IL.Emit(OpCodes.Ceq);
+            IL.Emit(OpCodes.Ldloc, valueLocal);
+            EmitUndefinedConstant();
+            IL.Emit(OpCodes.Ceq);
+            IL.Emit(OpCodes.Or);
+        }
+
+        if (isNegated)
+        {
+            IL.Emit(OpCodes.Ldc_I4_0);
+            IL.Emit(OpCodes.Ceq);
+        }
+
+        SetStackType(StackType.Boolean);
+        return true;
+    }
 
     private bool IsBigIntOperation(Expr.Binary b)
     {

--- a/Compilation/ILEmitter.Operators.cs
+++ b/Compilation/ILEmitter.Operators.cs
@@ -194,6 +194,27 @@ public partial class ILEmitter
     /// </summary>
     private void EmitEqualityBinary(Expr.Binary b, bool isStrict, bool isNegated)
     {
+        // Fast path: both operands statically numeric. JS number equality has no
+        // coercion (=== and == agree when both sides are number), and IEEE `ceq`
+        // matches the spec exactly — NaN is never equal (ceq → false, correct for
+        // `NaN === NaN`) and +0/-0 compare equal (ceq → true, correct for `===`).
+        // Mirrors the numeric relational fast path above; avoids boxing both
+        // operands and the boolean result plus an Object.Equals dispatch per
+        // comparison (the dominant per-iteration cost in comparison-heavy loops).
+        if (IsNumericComparison(b))
+        {
+            EmitExpressionAsDouble(b.Left);
+            EmitExpressionAsDouble(b.Right);
+            IL.Emit(OpCodes.Ceq);
+            if (isNegated)
+            {
+                IL.Emit(OpCodes.Ldc_I4_0);
+                IL.Emit(OpCodes.Ceq);
+            }
+            SetStackType(StackType.Boolean);
+            return;
+        }
+
         EmitExpression(b.Left);
         EmitBoxIfNeeded(b.Left);
         EmitExpression(b.Right);

--- a/SharpTS.Tests/SharedTests/NullishEqualityFastPathTests.cs
+++ b/SharpTS.Tests/SharedTests/NullishEqualityFastPathTests.cs
@@ -1,0 +1,142 @@
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests;
+
+/// <summary>
+/// Pins the compiled nullish-equality fast path in <c>ILEmitter.EmitEqualityBinary</c>: when exactly
+/// one operand is the statically-typed <c>null</c> or <c>undefined</c> literal, the comparison is a
+/// direct reference check rather than boxing the value operand and dispatching
+/// <c>Object.Equals</c>/<c>runtime.Equals</c>. In compiled output JS <c>null</c> is CLR null and JS
+/// <c>undefined</c> is the <c>$Undefined</c> singleton, so <c>x === null</c> is <c>ldnull; ceq</c>,
+/// <c>x === undefined</c> is a singleton reference compare, and loose <c>== null</c>/<c>== undefined</c>
+/// is the nullish test (null OR undefined).
+///
+/// <para>Strict <c>===</c> must keep <c>null</c> and <c>undefined</c> distinct; loose <c>==</c> must
+/// treat them as interchangeable; and <c>0</c>/<c>""</c>/<c>NaN</c>/objects must never be nullish.
+/// Values are produced at runtime so the constant folder can't pre-evaluate the comparison.</para>
+/// </summary>
+public class NullishEqualityFastPathTests
+{
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void StrictNull_DistinguishesUndefined(ExecutionMode mode)
+    {
+        var source = """
+            function probe(x: any): string {
+                return (x === null) + "," + (x !== null);
+            }
+            let n: any = null;
+            let u: any = undefined;
+            let o: any = { a: 1 };
+            console.log(probe(n));
+            console.log(probe(u));
+            console.log(probe(o));
+            """;
+        // null -> true,false ; undefined -> false,true ; object -> false,true
+        Assert.Equal("true,false\nfalse,true\nfalse,true\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void StrictUndefined_DistinguishesNull(ExecutionMode mode)
+    {
+        var source = """
+            function probe(x: any): string {
+                return (x === undefined) + "," + (x !== undefined);
+            }
+            let n: any = null;
+            let u: any = undefined;
+            console.log(probe(n));
+            console.log(probe(u));
+            console.log(probe(5));
+            """;
+        // null -> false,true ; undefined -> true,false ; 5 -> false,true
+        Assert.Equal("false,true\ntrue,false\nfalse,true\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void LooseNullish_NullAndUndefinedInterchangeable(ExecutionMode mode)
+    {
+        var source = """
+            function probe(x: any): string {
+                return (x == null) + "," + (x != null) + "," + (x == undefined);
+            }
+            let n: any = null;
+            let u: any = undefined;
+            console.log(probe(n));
+            console.log(probe(u));
+            console.log(probe(0));
+            console.log(probe(""));
+            console.log(probe({ }));
+            """;
+        // null/undefined -> true,false,true ; 0,"",{} are NOT nullish -> false,true,false
+        Assert.Equal(
+            "true,false,true\ntrue,false,true\nfalse,true,false\nfalse,true,false\nfalse,true,false\n",
+            TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void NaN_IsNotNullish(ExecutionMode mode)
+    {
+        // A NaN value operand must compare unequal to null/undefined (and the fast path
+        // needs no NaN special-casing because null/undefined are never NaN).
+        var source = """
+            const x: any = Math.sqrt(-1);
+            console.log(x === null, x === undefined, x == null);
+            """;
+        Assert.Equal("false false false\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void NullVsUndefinedLiterals(ExecutionMode mode)
+    {
+        // Both-literal comparisons (handled by the fall-through boxed path, not the fast
+        // path) must still be exactly right.
+        var source = """
+            console.log(null === null, undefined === undefined);
+            console.log(null === undefined, null !== undefined);
+            console.log(null == undefined, null != undefined);
+            """;
+        Assert.Equal("true true\nfalse true\ntrue false\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ReversedOperandOrder(ExecutionMode mode)
+    {
+        // The literal may be on either side.
+        var source = """
+            let o: any = { };
+            let n: any = null;
+            console.log(null === o, undefined === o, null == n);
+            """;
+        Assert.Equal("false false true\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void NullGuardedTreeTraversal(ExecutionMode mode)
+    {
+        // The binary-trees idiom: `node === null` driving recursion. Exercises the fast
+        // path on a real object-vs-null reference compare.
+        var source = """
+            type Node = { left: Node | null; right: Node | null };
+            function build(depth: number): Node {
+                if (depth <= 0) return { left: null, right: null };
+                return { left: build(depth - 1), right: build(depth - 1) };
+            }
+            function count(node: Node | null): number {
+                if (node === null) return 1;
+                return 1 + count(node.left) + count(node.right);
+            }
+            console.log(count(build(5)));
+            """;
+        // A perfect tree of depth d has 2^(d+1)-1 internal {left,right} nodes plus the
+        // null leaves counted by the base case: count = 2^(d+2)-1. For d=5 -> 127 nodes.
+        Assert.Equal("127\n", TestHarness.Run(source, mode));
+    }
+}

--- a/SharpTS.Tests/SharedTests/NumericEqualityFastPathTests.cs
+++ b/SharpTS.Tests/SharedTests/NumericEqualityFastPathTests.cs
@@ -1,0 +1,130 @@
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests;
+
+/// <summary>
+/// Pins the compiled numeric-equality fast path in <c>ILEmitter.EmitEqualityBinary</c>: when both
+/// operands are statically <c>number</c>, <c>===</c>/<c>!==</c>/<c>==</c>/<c>!=</c> emit a raw IEEE
+/// <c>ceq</c> on doubles instead of boxing both operands, dispatching <c>Object.Equals</c>, and
+/// boxing the boolean result. This mirrors the long-standing numeric relational fast path
+/// (<c>&lt;</c>/<c>&gt;</c>) directly above it and was the dominant per-iteration cost in
+/// comparison-heavy loops (e.g. the brainfuck benchmark's dispatch chain).
+///
+/// <para><c>ceq</c> matches ECMA-262 number equality exactly: NaN is never equal to anything
+/// including itself (ceq → false), and +0/-0 compare equal (ceq → true). The values below are
+/// produced at runtime (loops, arithmetic, parsing) so the constant folder cannot pre-evaluate the
+/// comparison — the emitted fast path is what actually runs.</para>
+/// </summary>
+public class NumericEqualityFastPathTests
+{
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void RuntimeNaN_NeverEqual(ExecutionMode mode)
+    {
+        // NaN from a runtime computation (not the literal) — must never equal itself.
+        var source = """
+            const n: number = Math.sqrt(-1);
+            const m: number = 0 / 0;
+            console.log(n === n);
+            console.log(n !== n);
+            console.log(n === m);
+            console.log(n != m);
+            """;
+        Assert.Equal("false\ntrue\nfalse\ntrue\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void RuntimeSignedZero_ComparesEqual(ExecutionMode mode)
+    {
+        // +0 === -0 is true per ===, even though Object.is would say false.
+        var source = """
+            const z: number = 0;
+            const neg: number = z * -1;
+            console.log(z === neg);
+            console.log(neg === 0);
+            console.log(z !== neg);
+            """;
+        Assert.Equal("true\ntrue\nfalse\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void RuntimeInfinity_Equality(ExecutionMode mode)
+    {
+        var source = """
+            const big: number = 1 / 0;
+            const negBig: number = -1 / 0;
+            console.log(big === big);
+            console.log(big === negBig);
+            console.log(big !== negBig);
+            """;
+        Assert.Equal("true\nfalse\ntrue\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void OrdinaryNumberEquality(ExecutionMode mode)
+    {
+        // Variables defeat constant folding; covers strict + loose + negated forms.
+        var source = """
+            let a: number = 2;
+            let b: number = 2;
+            let c: number = 3;
+            console.log(a === b);
+            console.log(a === c);
+            console.log(a !== c);
+            console.log(a !== b);
+            console.log(a == b);
+            console.log(a == c);
+            console.log(a != c);
+            """;
+        Assert.Equal("true\nfalse\ntrue\nfalse\ntrue\nfalse\ntrue\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void DispatchChain_LikeBrainfuck(ExecutionMode mode)
+    {
+        // The shape the fast path was built for: a tight loop whose control flow is driven by
+        // numeric === comparisons. Asserts the aggregate is correct, exercising every branch.
+        var source = """
+            function classify(n: number): number {
+                let total: number = 0;
+                for (let i: number = 0; i < n; i++) {
+                    const c: number = i % 5;
+                    if (c === 0) total = total + 1;
+                    else if (c === 1) total = total + 2;
+                    else if (c === 2) total = total + 3;
+                    else if (c === 3) total = total + 4;
+                    else if (c === 4) total = total + 5;
+                }
+                return total;
+            }
+            console.log(classify(100));
+            """;
+        // Each block of 5 contributes 1+2+3+4+5 = 15; 100/5 = 20 blocks -> 300.
+        Assert.Equal("300\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void CharCodeEquality(ExecutionMode mode)
+    {
+        // charCodeAt returns number; comparing it against numeric literals is the brainfuck idiom.
+        var source = """
+            const s: string = "AB+-";
+            let acc: number = 0;
+            for (let i: number = 0; i < s.length; i++) {
+                const c: number = s.charCodeAt(i);
+                if (c === 43) acc = acc + 100;      // '+'
+                else if (c === 45) acc = acc + 10;  // '-'
+                else acc = acc + 1;
+            }
+            console.log(acc);
+            """;
+        // 'A','B' -> +1 each (2), '+' -> +100, '-' -> +10  => 112.
+        Assert.Equal("112\n", TestHarness.Run(source, mode));
+    }
+}


### PR DESCRIPTION
## Summary

Two fast paths in compiled `EmitEqualityBinary`, eliminating boxing + `Object.Equals`/`runtime.Equals` dispatch from the two most common equality shapes. Both mirror the numeric *relational* fast path (`<` `>`) that already existed right next to them; neither changes semantics.

### 1. Numeric equality (`commit 1`)

`===` / `!==` / `==` / `!=` between two statically-`number` operands was boxing **both operands and the boolean result**, then dispatching `Object.Equals` — three heap allocations per comparison — while relational `<`/`>` already emitted raw `ceq`. Added the matching numeric branch (reusing the existing `IsNumericComparison` helper).

IEEE `ceq` is spec-correct for JS number equality: `NaN === NaN` → false ✓, `+0 === -0` → true ✓. Loose `==` between two numbers performs no coercion, so it collapses to the same compare. `bigint`/mixed fall through to the boxed path.

### 2. null / undefined equality (`commit 2`)

When exactly one operand is the statically-typed `null` or `undefined` literal, emit a direct reference check. In compiled output JS `null` is CLR null and JS `undefined` is the `$Undefined` singleton, so:

- `x === null` → `ldnull; ceq`
- `x === undefined` → `ldsfld $Undefined.Instance; ceq`
- `x == null` / `x == undefined` (loose) → nullish test (null **or** undefined)

Strict `===` keeps null and undefined distinct; loose `==` treats them interchangeably; `0`/`""`/`NaN`/objects are never nullish. NaN needs no special handling (null/undefined are never NaN, so a NaN operand compares unequal). Both-literal comparisons (`null === undefined`) fall through to the existing boxed path.

## Impact

Measured on the `benchmarks/` cross-runtime sweep (Windows, .NET 11 preview, Node v25):

| Workload | Before | After | vs Node |
|---|--:|--:|--:|
| brainfuck (5000) — numeric `===` dispatch loop | 184.7 ms | **71.2 ms** (2.6×) | 8.8× → **3.1×** |
| pure numeric `===` micro-loop | 31.3 ms | **5.94 ms** (5.3×) | now matches the `<` path |
| binary-trees traversal — `node === null` recursion | 7.61 ms | **6.09 ms** (1.25×) | 9.0× → 7.2× |
| loose `== null` / `=== undefined` guards | — | **~20% faster** | — |

The numeric path is the headline win; the null/undefined path is a smaller but broad improvement to null-guard-heavy code. (binary-trees overall is dominated by object *allocation*, a separate representation problem, so its end-to-end number moves little — the traversal sub-cost is what improves here.)

## Tests

`NumericEqualityFastPathTests` and `NullishEqualityFastPathTests` (both dual-mode, interpreter + compiled), using **runtime-computed** values so the constant folder can't pre-evaluate the comparison and mask the emitted path:

- numeric: runtime NaN / signed zero / Infinity, ordinary strict+loose+negated, dispatch chains, `charCodeAt` idiom
- nullish: strict null↔undefined distinction, loose interchangeability, `0`/`""`/`NaN`/object are not nullish, reversed operand order, both-literal comparisons, a null-guarded tree walk

Pre-existing `AsyncNaNStrictEqualityTests` and `StateMachineUndefinedEqualityTests` continue to pass.

## Scope

Only the synchronous `ILEmitter.EmitEqualityBinary` is touched. The async/generator state-machine equality path operates on already-boxed `object` stack operands with no `Expr`/`TypeMap` access — a different design no benchmark exercises — and is left unchanged (still correct, just boxed).

## Verification

- Full suite: **14,047 passed / 0 failed** (incl. 26 new dual-mode fast-path cases).
- Test262 (compiled `CompiledBaseline` gate): **passes — zero baseline drift** against the committed baseline (no regressions, no new passes). The interpreter equality path is untouched, so interpreted outcomes are unaffected.
