### PR TITLE
Differential interp<->compiled parity harness + 2 bug fixes it found

### DIFF
--- a/Execution/Interpreter.Operators.cs
+++ b/Execution/Interpreter.Operators.cs
@@ -484,6 +484,12 @@ public partial class Interpreter
     /// </summary>
     private object? ToPrimitive(object? value, PrimitiveHint hint)
     {
+        // Arrays have no own valueOf/toString and inherit Array.prototype.toString
+        // (= join(',')); OrdinaryToPrimitive resolves to it for every hint (valueOf
+        // returns the array, not a primitive, so it is skipped). e.g. `'' + [1,2,3]`
+        // -> "1,2,3" and `[1,2,3] == "1,2,3"` -> true. The console/debug ToString
+        // ("[1, 2, 3]") is intentionally NOT used here.
+        if (value is SharpTSArray arr) return ArrayBuiltIns.ToJsString(this, arr);
         if (value is not SharpTSObject obj) return value;
         bool isWrapper = TryGetBoxedPrimitiveValue(obj, out var primitiveValue);
         bool hasOwnValueOf = obj.HasProperty("valueOf");

--- a/Execution/Interpreter.Statements.cs
+++ b/Execution/Interpreter.Statements.cs
@@ -1054,6 +1054,44 @@ public partial class Interpreter
     }
 
     /// <summary>
+    /// True when <paramref name="value"/> is iterable via <see cref="GetIterableElements"/>
+    /// (a known iterable type or carrying a Symbol.iterator). Lets Array.from choose the
+    /// iterator protocol vs the array-like (length + indices) path without catching a throw.
+    /// </summary>
+    internal bool IsIterableSource(object? value) =>
+        value is SharpTSArray or SharpTSMap or SharpTSSet or SharpTSIterator or SharpTSGenerator
+            or string or List<object?> or IEnumerable<object?>
+        || TryGetSymbolIterator(value) != null;
+
+    /// <summary>
+    /// ECMA-262 array-like read (Array.from on a non-iterable): ToLength(Get(src,"length")),
+    /// then Get(src, 0..len-1). Missing indices yield undefined — so Array.from({length:3})
+    /// produces [undefined, undefined, undefined].
+    /// </summary>
+    internal List<object?> ReadArrayLikeElements(object? value)
+    {
+        long len = ToLength(GetArrayLikeProperty(value, "length"));
+        var result = new List<object?>(len > int.MaxValue ? int.MaxValue : (int)len);
+        for (long i = 0; i < len; i++)
+            result.Add(GetArrayLikeProperty(value, i.ToString(System.Globalization.CultureInfo.InvariantCulture)));
+        return result;
+    }
+
+    private static object? GetArrayLikeProperty(object? value, string key) => value switch
+    {
+        SharpTSObject obj => obj.GetProperty(key),
+        SharpTSInstance inst => inst.GetProperty(key),
+        _ => SharpTSUndefined.Instance,
+    };
+
+    private static long ToLength(object? value)
+    {
+        double n = Compilation.RuntimeTypes.ToNumber(value);
+        if (double.IsNaN(n) || n <= 0) return 0;
+        return (long)Math.Min(Math.Floor(n), 9007199254740991.0); // 2^53 - 1
+    }
+
+    /// <summary>
     /// Normalizes an array binding-pattern source through the iterator protocol (#685). Array
     /// destructuring (<c>const [a, b] = src</c>) desugars to positional index access, which is only
     /// correct for index-addressable sources. Plain arrays pass through unchanged (fast path). Typed

--- a/Runtime/BuiltIns/ArrayBuiltIns.cs
+++ b/Runtime/BuiltIns/ArrayBuiltIns.cs
@@ -36,6 +36,8 @@ public static class ArrayBuiltIns
             .MethodV2("indexOf", 1, 2, IndexOfV2)
             .MethodV2("lastIndexOf", 1, 2, LastIndexOfV2)
             .MethodV2("join", 0, 1, specLength: 1, JoinV2)
+            // Array.prototype.toString = join() with ","; distinct from the debug ToString().
+            .MethodV2("toString", 0, static (interp, arr, _) => RuntimeValue.FromString(ToJsString(interp, arr)))
             // Array.prototype.concat accepts any number of args (variadic).
             .MethodV2("concat", 0, int.MaxValue, specLength: 1, ConcatV2)
             .MethodV2("reverse", 0, ReverseV2)
@@ -503,6 +505,15 @@ public static class ArrayBuiltIns
         }
         return RuntimeValue.FromString(sb.ToString());
     }
+
+    /// <summary>
+    /// ECMA-262 23.1.3.36 Array.prototype.toString = join() with the default ","
+    /// separator — the string an array coerces to in string contexts (<c>+</c>,
+    /// template literals, <c>String()</c>), distinct from the console/debug
+    /// <see cref="SharpTSArray.ToString"/> format ("[1, 2, 3]").
+    /// </summary>
+    internal static string ToJsString(Interpreter interp, SharpTSArray arr)
+        => JoinV2(interp, arr, ReadOnlySpan<RuntimeValue>.Empty).AsString();
 
     /// <summary>
     /// Copies [0, length) of <paramref name="src"/> into <paramref name="dst"/>,

--- a/Runtime/BuiltIns/ArrayStaticBuiltIns.cs
+++ b/Runtime/BuiltIns/ArrayStaticBuiltIns.cs
@@ -37,7 +37,12 @@ public static class ArrayStaticBuiltIns
                     mapFn = mapFnCallable;
                 }
 
-                var elements = interpreter.GetIterableElements(iterable).ToList();
+                // ECMA-262 23.1.2.1: prefer the iterator protocol; a source without a usable
+                // iterator (e.g. an array-like { length: n }) is read via its length +
+                // indexed elements rather than throwing "not iterable".
+                var elements = interpreter.IsIterableSource(iterable)
+                    ? interpreter.GetIterableElements(iterable).ToList()
+                    : interpreter.ReadArrayLikeElements(iterable);
 
                 if (mapFn != null)
                 {

--- a/Runtime/Types/SharpTSPrimitiveNamespaces.cs
+++ b/Runtime/Types/SharpTSPrimitiveNamespaces.cs
@@ -23,7 +23,7 @@ public class SharpTSStringNamespace : ISharpTSCallable
         if (arg == null) return "null";
         if (arg is bool b) return b ? "true" : "false";
         if (arg is double d) return Compilation.RuntimeTypes.FormatNumber(d);
-        if (arg is SharpTSArray arr) return arr.ToString();
+        if (arg is SharpTSArray arr) return ArrayBuiltIns.ToJsString(interpreter, arr);
         // A boxed wrapper / plain object goes through ToString = ToPrimitive
         // (string hint) then stringify, honoring an own toString override and
         // unwrapping a bare wrapper to its primitive (#574). A raw Symbol is

--- a/SharpTS.Tests/SharedTests/DifferentialParityTests.cs
+++ b/SharpTS.Tests/SharedTests/DifferentialParityTests.cs
@@ -49,21 +49,19 @@ public class DifferentialParityTests
         catch (Exception ex) { return $"<<threw:{ex.GetType().Name}>>"; }
     }
 
-    public static IEnumerable<object[]> KnownDivergenceNames =>
-        ParityCorpus.KnownDivergences.Keys.OrderBy(k => k, StringComparer.Ordinal).Select(k => new object[] { k });
-
-    [Theory]
-    [MemberData(nameof(KnownDivergenceNames))]
-    public void KnownDivergence_StillDiverges(string name)
+    [Fact]
+    public void KnownDivergences_StillDiverge()
     {
-        // Real interp<->compiled bugs the harness surfaced, pinned so the green gate stays
-        // clean. When the underlying bug is fixed this test fails, prompting promotion of
-        // the snippet into the green corpus.
-        var (source, note) = ParityCorpus.KnownDivergences[name];
-        var interp = Capture(() => TestHarness.RunInterpreted(source));
-        var compiled = Capture(() => TestHarness.RunCompiled(source));
-        Assert.True(interp != compiled,
-            $"'{name}' no longer diverges — fix confirmed; move it into the green corpus. Note: {note}");
+        // Pins documented interp<->compiled bugs (currently none): when one is fixed this
+        // fails, prompting promotion of the snippet into the green corpus. Iterates rather
+        // than a [Theory] so an empty set is simply green.
+        foreach (var entry in ParityCorpus.KnownDivergences)
+        {
+            var interp = Capture(() => TestHarness.RunInterpreted(entry.Value.Source));
+            var compiled = Capture(() => TestHarness.RunCompiled(entry.Value.Source));
+            Assert.True(interp != compiled,
+                $"'{entry.Key}' no longer diverges — fix confirmed; move it into the green corpus. Note: {entry.Value.Note}");
+        }
     }
 }
 
@@ -99,6 +97,8 @@ internal static class ParityCorpus
         ["coerce-add"] = "console.log(1 + '2', '3' + 4, true + 1, null + 1, undefined + 1, 1 + null, 2 + true);",
         ["coerce-loose-eq"] = "console.log(0 == false, '' == false, '0' == 0, null == undefined, 1 == '1', 'true' == true);",
         ["coerce-truthy"] = "console.log(!!0, !!'', !!null, !!undefined, !!NaN, !!'x', !![], !!{}, !!0.0);",
+        // Array -> string coercion uses Array.prototype.toString (join), not the debug format.
+        ["coerce-array-string"] = "console.log('' + [1, 2, 3], String([4, 5]), `${[6, 7]}`, [8, 9].toString(), String([]), ['a', 'b'].join('-'));",
 
         // ---- strings ----
         ["str-methods"] = "console.log('Hello'.toUpperCase(), 'WORLD'.toLowerCase(), '  t  '.trim(), 'a,b,c'.split(',').length, 'abc'.charAt(1), 'abc'.indexOf('b'));",
@@ -117,6 +117,8 @@ internal static class ParityCorpus
         ["arr-mutate"] = "const a = [3, 1, 2]; a.sort(); a.push(4); console.log(a.join(','), a.reverse().join(','), a.length);",
         ["arr-query"] = "console.log([1, 2, 3].includes(2), [1, 2, 3].indexOf(3), [1, 2, 3].find(x => x > 1), [1, 2, 3].some(x => x > 2), [1, 2, 3].every(x => x > 0));",
         ["arr-spread"] = "console.log([...[1, 2], ...[3, 4]].join('-'), [1, 2, 3].slice(1).join(','));",
+        // Array.from over iterables AND array-likes ({length} / indexed).
+        ["arr-from"] = "console.log(Array.from({ length: 3 }, (_, i) => i).join(','), Array.from({ length: 2, 0: 'a', 1: 'b' }).join(','), Array.from('hi').join(','), Array.from(new Set([1, 1, 2])).join(','));",
 
         // ---- objects ----
         ["obj-keys"] = "const o = { a: 1, b: 2, c: 3 }; console.log(Object.keys(o).join(','), Object.values(o).join(','), Object.entries(o).length);",
@@ -151,11 +153,8 @@ internal static class ParityCorpus
     /// </summary>
     internal static readonly Dictionary<string, (string Source, string Note)> KnownDivergences = new()
     {
-        ["coerce-array-tostring"] = (
-            "console.log('' + [1, 2, 3]);",
-            "Array->string coercion: interp prints the console-inspect '[1, 2, 3]'; ECMA-262 says '1,2,3' via Array.prototype.toString (compiled is correct)."),
-        ["array-from-arraylike"] = (
-            "console.log(Array.from({ length: 3 }, (_, i) => i).join(','));",
-            "Array.from(arrayLike, mapFn): interp throws 'not iterable'; should use the array-like's .length -> '0,1,2' (compiled is correct)."),
+        // (empty) The harness's first two findings — array->string coercion and Array.from
+        // on an array-like — were fixed and promoted into Snippets above (coerce-array-string,
+        // arr-from). Future divergences that can't be fixed immediately go here.
     };
 }

--- a/SharpTS.Tests/SharedTests/DifferentialParityTests.cs
+++ b/SharpTS.Tests/SharedTests/DifferentialParityTests.cs
@@ -1,0 +1,161 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests;
+
+/// <summary>
+/// Differential (metamorphic) parity harness: runs each snippet through BOTH the
+/// interpreter and the compiler and asserts they produce identical output. The two
+/// modes are each other's oracle — no hand-authored expected value is needed, so this
+/// scales parity-checking far past the hand-written dual-mode tests (a snippet only
+/// gets a dual-mode test if someone both wrote it AND knew the right answer; that gap
+/// is exactly how e.g. console.log(0.1+0.2) diverged silently).
+///
+/// The corpus targets the historically divergence-prone areas (numbers, operators,
+/// coercion, strings, JSON, collections). It is a green regression GATE: every snippet
+/// here currently agrees across modes. Snippets the harness found to diverge are kept in
+/// <see cref="ParityCorpus.KnownDivergences"/> and pinned by
+/// <see cref="KnownDivergence_StillDiverges"/>, so the gate stays green while each
+/// divergence is tracked (and a fix trips the pin, prompting promotion to the corpus).
+/// </summary>
+public class DifferentialParityTests
+{
+    public static IEnumerable<object[]> CorpusNames =>
+        ParityCorpus.Snippets.Keys.OrderBy(k => k, StringComparer.Ordinal).Select(k => new object[] { k });
+
+    [Theory]
+    [MemberData(nameof(CorpusNames))]
+    public void InterpreterAndCompiledAgree(string name)
+    {
+        var source = ParityCorpus.Snippets[name];
+        var interp = Capture(() => TestHarness.RunInterpreted(source));
+        var compiled = Capture(() => TestHarness.RunCompiled(source));
+        Assert.True(interp == compiled,
+            $"interp/compiled divergence for '{name}':\n--- interpreted ---\n{interp}\n--- compiled ---\n{compiled}\n--- source ---\n{source}");
+    }
+
+    /// <summary>
+    /// Runs one mode and returns its stdout, or a normalized error marker if it threw.
+    /// Thrown errors are reduced to their CLR type so a snippet that crashes in one mode
+    /// shows up as a mismatch against the other mode's real output, without flaking on
+    /// the exact (mode-specific) error wording.
+    /// </summary>
+    private static string Capture(Func<string> run)
+    {
+        try { return run(); }
+        catch (Exception ex) { return $"<<threw:{ex.GetType().Name}>>"; }
+    }
+
+    public static IEnumerable<object[]> KnownDivergenceNames =>
+        ParityCorpus.KnownDivergences.Keys.OrderBy(k => k, StringComparer.Ordinal).Select(k => new object[] { k });
+
+    [Theory]
+    [MemberData(nameof(KnownDivergenceNames))]
+    public void KnownDivergence_StillDiverges(string name)
+    {
+        // Real interp<->compiled bugs the harness surfaced, pinned so the green gate stays
+        // clean. When the underlying bug is fixed this test fails, prompting promotion of
+        // the snippet into the green corpus.
+        var (source, note) = ParityCorpus.KnownDivergences[name];
+        var interp = Capture(() => TestHarness.RunInterpreted(source));
+        var compiled = Capture(() => TestHarness.RunCompiled(source));
+        Assert.True(interp != compiled,
+            $"'{name}' no longer diverges — fix confirmed; move it into the green corpus. Note: {note}");
+    }
+}
+
+/// <summary>
+/// The curated parity corpus. Each entry is (name -> TypeScript source) and must
+/// currently produce identical interpreter/compiled output. Add snippets freely; if a
+/// new one diverges, either fix the underlying bug or move it to KnownDivergences with a
+/// note. Snippets are intentionally small and deterministic and must terminate without an
+/// uncaught error (error-parity is a separate, later concern).
+/// </summary>
+internal static class ParityCorpus
+{
+    internal static readonly Dictionary<string, string> Snippets = new()
+    {
+        // ---- numbers / formatting ----
+        ["num-arithmetic"] = "console.log(1 + 2, 10 / 3, 2 ** 10, 7 % 3, -5 % 3, 0.1 + 0.2);",
+        ["num-special"] = "console.log(1 / 0, -1 / 0, 0 / 0, Math.sqrt(-1), -0, 1 / -0);",
+        ["num-thresholds"] = "console.log(1e20, 1e21, 1e-6, 1e-7, 123456789, 1234567890123456789);",
+        ["num-parse"] = "console.log(parseInt('42px'), parseFloat('3.14xyz'), Number('  12  '), Number(''), Number('x'));",
+        ["num-methods"] = "console.log((255).toString(16), (255).toString(2), (3.14159).toFixed(2), (1234.5678).toPrecision(6));",
+        ["num-int-ops"] = "console.log(Math.floor(3.7), Math.ceil(3.2), Math.round(2.5), Math.round(-2.5), Math.trunc(-3.7), Math.abs(-9));",
+
+        // ---- operators ----
+        ["op-comparison"] = "console.log(1 < 2, 'a' < 'b', 2 <= 2, 3 > 1, 'b' > 'a', 1 == 1, 1 === 1, NaN === NaN, NaN !== NaN);",
+        ["op-logical"] = "console.log(0 || 'x', 1 && 'y', null ?? 'z', '' || 'fb', 0 ?? 'no', false && 1, true || 1);",
+        ["op-bitwise"] = "console.log(5 & 3, 5 | 3, 5 ^ 3, ~5, 1 << 4, -8 >> 1, -8 >>> 28, 0xff & 0x0f);",
+        ["op-typeof"] = "console.log(typeof 1, typeof 's', typeof true, typeof undefined, typeof null, typeof {}, typeof [], typeof function(){});",
+        ["op-ternary-comma"] = "console.log(true ? 'a' : 'b', false ? 'a' : 'b', (1, 2, 3));",
+        ["op-increment"] = "let i = 5; console.log(i++, i, ++i, i--, i, --i);",
+
+        // ---- coercion ----
+        ["coerce-concat"] = "console.log('' + 1, '' + true, '' + null, '' + undefined, '' + 1.5);",
+        ["coerce-add"] = "console.log(1 + '2', '3' + 4, true + 1, null + 1, undefined + 1, 1 + null, 2 + true);",
+        ["coerce-loose-eq"] = "console.log(0 == false, '' == false, '0' == 0, null == undefined, 1 == '1', 'true' == true);",
+        ["coerce-truthy"] = "console.log(!!0, !!'', !!null, !!undefined, !!NaN, !!'x', !![], !!{}, !!0.0);",
+
+        // ---- strings ----
+        ["str-methods"] = "console.log('Hello'.toUpperCase(), 'WORLD'.toLowerCase(), '  t  '.trim(), 'a,b,c'.split(',').length, 'abc'.charAt(1), 'abc'.indexOf('b'));",
+        ["str-template"] = "const x = 5; console.log(`x=${x}, x*2=${x * 2}, ${x > 3 ? 'big' : 'small'}, ${[1, 2].join('+')}`);",
+        ["str-slice"] = "console.log('hello world'.slice(0, 5), 'hello'.substring(1, 3), 'abcdef'.substr(2, 2), 'x'.repeat(4), 'ab'.padStart(5, '0'));",
+        ["str-replace"] = "console.log('a-b-c'.replace('-', '+'), 'a-b-c'.replaceAll('-', '+'), 'Hello'.includes('ell'), 'Hello'.startsWith('He'), 'Hello'.endsWith('lo'));",
+
+        // ---- JSON ----
+        ["json-stringify"] = "console.log(JSON.stringify({ a: 1, b: [1, 2, 3], c: 'str', d: true, e: null }));",
+        ["json-numbers"] = "console.log(JSON.stringify({ a: 0.1 + 0.2, b: 1e21, c: 1e20, d: [NaN, Infinity] }));",
+        ["json-roundtrip"] = "console.log(JSON.stringify(JSON.parse('{\"x\":1.5,\"y\":[true,false],\"z\":\"hi\"}')));",
+        ["json-pretty"] = "console.log(JSON.stringify({ a: 1, b: { c: 2 } }, null, 2));",
+
+        // ---- arrays ----
+        ["arr-hof"] = "console.log([1, 2, 3].map(x => x * 2).join(','), [1, 2, 3, 4].filter(x => x % 2 === 0).join(','), [1, 2, 3].reduce((a, b) => a + b, 0));",
+        ["arr-mutate"] = "const a = [3, 1, 2]; a.sort(); a.push(4); console.log(a.join(','), a.reverse().join(','), a.length);",
+        ["arr-query"] = "console.log([1, 2, 3].includes(2), [1, 2, 3].indexOf(3), [1, 2, 3].find(x => x > 1), [1, 2, 3].some(x => x > 2), [1, 2, 3].every(x => x > 0));",
+        ["arr-spread"] = "console.log([...[1, 2], ...[3, 4]].join('-'), [1, 2, 3].slice(1).join(','));",
+
+        // ---- objects ----
+        ["obj-keys"] = "const o = { a: 1, b: 2, c: 3 }; console.log(Object.keys(o).join(','), Object.values(o).join(','), Object.entries(o).length);",
+        ["obj-spread"] = "const a = { x: 1, y: 2 }; const b = { ...a, z: 3 }; console.log(JSON.stringify(b), 'x' in b, b.hasOwnProperty('y'));",
+        ["obj-destructure"] = "const { p, q = 10, ...rest } = { p: 5, r: 1, s: 2 }; console.log(p, q, JSON.stringify(rest));",
+
+        // ---- control flow ----
+        ["ctrl-loops"] = "let s = 0; for (let i = 0; i < 5; i++) s += i; let t = ''; for (const c of 'abc') t += c.toUpperCase(); console.log(s, t);",
+        ["ctrl-switch"] = "function f(n: number) { switch (n) { case 1: return 'one'; case 2: return 'two'; default: return 'many'; } } console.log(f(1), f(2), f(9));",
+        ["ctrl-while"] = "let n = 10, steps = 0; while (n > 1) { n = n % 2 === 0 ? n / 2 : 3 * n + 1; steps++; } console.log(steps);",
+
+        // ---- functions / closures ----
+        ["fn-closure"] = "function counter() { let c = 0; return () => ++c; } const inc = counter(); console.log(inc(), inc(), inc());",
+        ["fn-default-rest"] = "function f(a: number, b = 10, ...rest: number[]) { return a + b + rest.length; } console.log(f(1), f(1, 2), f(1, 2, 3, 4));",
+        ["fn-recursion"] = "function fib(n: number): number { return n < 2 ? n : fib(n - 1) + fib(n - 2); } console.log(fib(10), fib(15));",
+
+        // ---- classes ----
+        ["class-basic"] = "class A { x: number; constructor(x: number) { this.x = x; } double() { return this.x * 2; } } const a = new A(5); console.log(a.x, a.double());",
+        ["class-inherit"] = "class Animal { speak() { return '...'; } } class Dog extends Animal { speak() { return 'woof: ' + super.speak(); } } console.log(new Dog().speak(), new Animal().speak());",
+        ["class-static"] = "class C { static count = 0; constructor() { C.count++; } } new C(); new C(); console.log(C.count);",
+
+        // ---- collections ----
+        ["map-set"] = "const m = new Map<string, number>([['a', 1], ['b', 2]]); const s = new Set([1, 2, 2, 3]); console.log(m.get('a'), m.size, s.size, [...s].join(','));",
+        ["generator"] = "function* g() { yield 1; yield 2; yield 3; } console.log([...g()].join(','), [...g()].reduce((a, b) => a + b, 0));",
+    };
+
+    /// <summary>
+    /// Snippets the harness found to DIVERGE — real interp↔compiled bugs, kept out of the
+    /// green gate and pinned by <c>DifferentialParityTests.KnownDivergence_StillDiverges</c>
+    /// so a future fix prompts promotion into <see cref="Snippets"/>. Each value is
+    /// (source, note) where the note records which mode is correct.
+    /// </summary>
+    internal static readonly Dictionary<string, (string Source, string Note)> KnownDivergences = new()
+    {
+        ["coerce-array-tostring"] = (
+            "console.log('' + [1, 2, 3]);",
+            "Array->string coercion: interp prints the console-inspect '[1, 2, 3]'; ECMA-262 says '1,2,3' via Array.prototype.toString (compiled is correct)."),
+        ["array-from-arraylike"] = (
+            "console.log(Array.from({ length: 3 }, (_, i) => i).join(','));",
+            "Array.from(arrayLike, mapFn): interp throws 'not iterable'; should use the array-like's .length -> '0,1,2' (compiled is correct)."),
+    };
+}


### PR DESCRIPTION
Stacked on #908 (the number formatter). Adds the **interp↔compiled differential parity harness** and the two interpreter bugs it immediately surfaced.

> Base is `wrk/number-formatter-parity` (#908) so the diff shows only the harness + fixes. Retarget to `main` (or rebase) once #908 merges.

## The harness — commit `8f37d1c0`

`SharpTS.Tests/SharedTests/DifferentialParityTests.cs` — a metamorphic parity gate that runs a curated corpus through **both** the interpreter and the compiler and asserts identical output, with **no hand-authored expected values**: the two modes are each other's oracle. This scales parity-checking far past the hand-written dual-mode tests, which only cover a snippet if someone both wrote it *and* knew the right answer — exactly the gap that hid bugs like `console.log(0.1 + 0.2)`.

- **44-snippet green corpus** across the divergence-prone areas (numbers, operators, coercion, strings, JSON, arrays, objects, control flow, closures, classes, collections) — a live regression gate; future drift in any of them fails CI.
- **`KnownDivergences`** pin mechanism: a found bug that can't be fixed immediately is pinned (asserted to *still* diverge), so when it's fixed the pin trips and prompts promoting the snippet into the green corpus.

## The 2 bugs it found, fixed — commit `07a93b47`

On its first run the harness surfaced two real divergences (both: interpreter wrong, compiled correct), neither covered by any existing dual-mode test:

1. **Array → string coercion** used the console/debug format `[1, 2, 3]` instead of `Array.prototype.toString` = `join(",")` → `1,2,3`. Root-fixed in `ToPrimitive` (arrays have no own `valueOf`/`toString` and inherit `join`), which corrects `+`, template literals, loose `==`, and relational coercion together. The probe also surfaced — and this fixes — `String([1,2,3])` and a completely **missing `Array.prototype.toString`** method (`[1,2,3].toString()` had thrown "undefined is not a function").
2. **`Array.from(arrayLike, mapFn)`** threw "not iterable" on `{length:n}`; now falls back to the ECMA array-like read (`ToLength(length)` + indexed elements) when the source has no iterator. Iterables (arrays/strings/Maps/Sets/`Symbol.iterator`) are unchanged.

Both findings (and the wider cluster) were promoted into the green corpus — the full discovery → fix → promote loop, demonstrated in one pass.

## Validation
- Harness: 44 corpus snippets green + the (now empty) `KnownDivergences` pin.
- Full suite (minus `LiveNetwork`): **14063 passed, 0 failed** — and no existing test had pinned the old buggy array output.
