### PR TITLE
Differential harness Phase B: broaden corpus + Math/toExponential fixes

### DIFF
--- a/Runtime/BuiltIns/BuiltInTypeBuilder.cs
+++ b/Runtime/BuiltIns/BuiltInTypeBuilder.cs
@@ -176,6 +176,24 @@ public sealed class BuiltInStaticBuilder
     }
 
     /// <summary>
+    /// Registers a V2 variadic static method with an explicit ECMA-262 spec length
+    /// (the value visible as <c>fn.length</c>). Use when minArity differs from the spec
+    /// length — e.g. <c>Math.max</c> registered with <c>(0, int.MaxValue, 2, …)</c>:
+    /// minArity 0 (Math.max() is legal), spec length 2.
+    /// </summary>
+    public BuiltInStaticBuilder MethodV2(
+        string name,
+        int minArity,
+        int maxArity,
+        int specLength,
+        Func<Interpreter, RuntimeValue, ReadOnlySpan<RuntimeValue>, RuntimeValue> implementation)
+    {
+        _methods[name] = BuiltInMethod.CreateV2(name, minArity, maxArity, implementation)
+            .WithSpecLength(specLength);
+        return this;
+    }
+
+    /// <summary>
     /// Builds the static member lookup.
     /// </summary>
     public BuiltInStaticMemberLookup Build()

--- a/Runtime/BuiltIns/MathBuiltIns.cs
+++ b/Runtime/BuiltIns/MathBuiltIns.cs
@@ -37,6 +37,12 @@ public static class MathBuiltIns
                 RuntimeValue.FromNumber(Math.Log(args[0].AsNumber())))
             .MethodV2("exp", 1, (_, _, args) =>
                 RuntimeValue.FromNumber(Math.Exp(args[0].AsNumber())))
+            .MethodV2("cbrt", 1, (_, _, args) =>
+                RuntimeValue.FromNumber(Math.Cbrt(args[0].AsNumber())))
+            .MethodV2("log2", 1, (_, _, args) =>
+                RuntimeValue.FromNumber(Math.Log2(args[0].AsNumber())))
+            .MethodV2("log10", 1, (_, _, args) =>
+                RuntimeValue.FromNumber(Math.Log10(args[0].AsNumber())))
             .MethodV2("sign", 1, (_, _, args) =>
                 RuntimeValue.FromNumber(Math.Sign(args[0].AsNumber())))
             .MethodV2("trunc", 1, (_, _, args) =>
@@ -45,8 +51,11 @@ public static class MathBuiltIns
             .MethodV2("pow", 2, (_, _, args) =>
                 RuntimeValue.FromNumber(Math.Pow(args[0].AsNumber(), args[1].AsNumber())))
             // Variable arity methods
-            .MethodV2("min", 2, int.MaxValue, Min)
-            .MethodV2("max", 2, int.MaxValue, Max)
+            // min-arity 0 (Math.min()/max()/hypot() are legal -> Infinity / -Infinity / 0),
+            // spec length 2 (the .length property each exposes per ECMA-262).
+            .MethodV2("min", 0, int.MaxValue, 2, Min)
+            .MethodV2("max", 0, int.MaxValue, 2, Max)
+            .MethodV2("hypot", 0, int.MaxValue, 2, Hypot)
             // No argument methods
             .MethodV2("random", 0, (_, _, _) =>
                 RuntimeValue.FromNumber(_random.NextDouble()))
@@ -79,5 +88,17 @@ public static class MathBuiltIns
             if (val > max) max = val;
         }
         return RuntimeValue.FromNumber(max);
+    }
+
+    private static RuntimeValue Hypot(Interpreter _, RuntimeValue receiver, ReadOnlySpan<RuntimeValue> args)
+    {
+        // sqrt(sum of squares); IEEE handles the Infinity/NaN special cases.
+        double sum = 0;
+        for (int i = 0; i < args.Length; i++)
+        {
+            double v = args[i].AsNumber();
+            sum += v * v;
+        }
+        return RuntimeValue.FromNumber(Math.Sqrt(sum));
     }
 }

--- a/Runtime/BuiltIns/NumberBuiltIns.cs
+++ b/Runtime/BuiltIns/NumberBuiltIns.cs
@@ -142,6 +142,8 @@ public static class NumberBuiltIns
         var result = fractionDigits == -1
             ? value.ToString("e", CultureInfo.InvariantCulture)
             : value.ToString($"e{fractionDigits}", CultureInfo.InvariantCulture);
+        // .NET pads the exponent to 3 digits ("1.23e+003"); JS uses no leading zeros.
+        result = System.Text.RegularExpressions.Regex.Replace(result, @"e([+-])0+(?=\d)", "e$1");
         return RuntimeValue.FromString(result);
     }
 

--- a/SharpTS.Tests/SharedTests/DifferentialParityTests.cs
+++ b/SharpTS.Tests/SharedTests/DifferentialParityTests.cs
@@ -143,6 +143,52 @@ internal static class ParityCorpus
         // ---- collections ----
         ["map-set"] = "const m = new Map<string, number>([['a', 1], ['b', 2]]); const s = new Set([1, 2, 2, 3]); console.log(m.get('a'), m.size, s.size, [...s].join(','));",
         ["generator"] = "function* g() { yield 1; yield 2; yield 3; } console.log([...g()].join(','), [...g()].reduce((a, b) => a + b, 0));",
+
+        // ---- Phase B: broadened coverage ----
+        // Math
+        ["math-functions"] = "console.log(Math.max(1, 2, 3), Math.min(-1, -2), Math.pow(2, 8), Math.sqrt(144), Math.sign(-5), Math.cbrt(27));",
+        ["math-rounding"] = "console.log(Math.floor(-1.5), Math.ceil(-1.5), Math.round(-0.5), Math.round(2.5), Math.trunc(-4.7), Math.round(0.5));",
+        ["math-log-edge"] = "console.log(Math.log2(8), Math.log10(1000), Math.hypot(3, 4), Math.max(), Math.min(), Math.sqrt(-1));",
+        // Number methods / predicates
+        ["num-methods2"] = "console.log((3.14159).toFixed(2), (123.456).toPrecision(4), (1234.5).toExponential(2), (0.1).toFixed(5));",
+        ["num-predicates"] = "console.log(Number.isInteger(5), Number.isInteger(5.5), Number.isSafeInteger(9007199254740992), Number.isNaN(NaN), Number.isFinite(Infinity));",
+        // String
+        ["str-split2"] = "console.log('a,b,c,d'.split(',', 2).join('|'), 'abc'.split('').join('-'), 'a-b-c'.split('-').length, 'x'.repeat(3));",
+        ["str-charcodes"] = "console.log('hello'.charCodeAt(0), 'A'.codePointAt(0), String.fromCharCode(72, 73), 'hello'.lastIndexOf('l'));",
+        ["str-at-pad"] = "console.log('hello'.at(-1), 'hello'.at(0), '5'.padStart(3, '0'), '5'.padEnd(3, '-'), 'a'.localeCompare('b'));",
+        // Date (fixed epoch — deterministic, UTC)
+        ["date-fixed"] = "const d = new Date(0); console.log(d.toISOString(), d.getUTCFullYear(), new Date(Date.UTC(2020, 5, 15, 12, 0, 0)).toISOString());",
+        // Errors (caught)
+        ["error-typeerror"] = "try { (null as any).x; } catch (e) { console.log(e instanceof TypeError, (e as any).name); }",
+        ["error-custom"] = "class MyErr extends Error { constructor(m: string) { super(m); this.name = 'MyErr'; } } try { throw new MyErr('boom'); } catch (e) { console.log((e as any).name, (e as any).message, e instanceof Error); }",
+        ["error-range"] = "function f() { throw new RangeError('out'); } try { f(); } catch (e) { console.log((e as any).name, (e as any).message); }",
+        // Destructuring
+        ["destructure-nested"] = "const { a: { b }, c = 5 } = { a: { b: 1 } }; const [x, , z] = [10, 20, 30]; console.log(b, c, x, z);",
+        ["destructure-rest"] = "let p = 1, q = 2; [p, q] = [q, p]; const [first, ...rest] = [1, 2, 3, 4]; console.log(p, q, first, rest.join(','));",
+        // Optional chaining / logical assignment
+        ["optional-chain"] = "const o: any = { a: { b: 42 }, fn: () => 'F' }; console.log(o?.a?.b, o?.x?.y, o?.a?.['b'], o?.fn?.(), o?.nofn?.());",
+        ["nullish-assign"] = "let v: any = null; v ??= 'set'; let w: any = 0; w ||= 'or'; let u: any = 1; u &&= 'and'; console.log(v, w, u);",
+        // Symbol
+        ["symbol-basics"] = "const s = Symbol('desc'); console.log(typeof s, s.description, s === s, Symbol.for('x') === Symbol.for('x'), Symbol('a') === Symbol('a'));",
+        // Map / Set
+        ["map-iter"] = "const m = new Map<string, number>(); m.set('a', 1).set('b', 2); console.log([...m.keys()].join(','), [...m.values()].join(','), m.has('a'), m.delete('a'), m.size);",
+        ["set-ops"] = "const s = new Set<number>([1, 2, 3]); s.add(4); s.delete(2); console.log([...s].join(','), s.has(3), s.size);",
+        // BigInt is under-developed and divergent in BOTH modes — see KnownDivergences.
+        // instanceof
+        ["instanceof"] = "class A {} class B extends A {} const b = new B(); console.log(b instanceof A, b instanceof B, [] instanceof Array, b instanceof Object);",
+        // Accessors
+        ["accessors"] = "const o = { _x: 1, get x() { return this._x * 2; }, set x(v: number) { this._x = v; } }; o.x = 5; console.log(o.x, o._x);",
+        ["class-accessors"] = "class C { private _v = 0; get v() { return this._v; } set v(n: number) { this._v = n + 1; } } const c = new C(); c.v = 10; console.log(c.v);",
+        // Generators / iterators
+        ["gen-yield-star"] = "function* inner() { yield 1; yield 2; } function* outer() { yield* inner(); yield 3; } console.log([...outer()].join(','));",
+        ["gen-return"] = "function* g() { yield 1; return 99; yield 2; } const it = g(); console.log(it.next().value, it.next().value, it.next().done);",
+        ["custom-iterator"] = "const obj = { *[Symbol.iterator]() { yield 'a'; yield 'b'; } }; console.log([...obj].join(','), Array.from(obj).join('-'));",
+        // Arrays (more)
+        ["arr-flat2"] = "console.log([1, [2, [3, [4]]]].flat(2).join(','), [1, 2, 3].flatMap(x => [x, x * 10]).join(','), [1, 2, 3, 4].at(-1), Array(3).fill(0).join(','));",
+        ["arr-sort2"] = "console.log([10, 2, 1, 20].sort((a, b) => a - b).join(','), [10, 2, 1, 20].sort().join(','), ['b', 'a', 'c'].sort().join(''));",
+        ["arr-entries2"] = "console.log([...['x', 'y'].entries()].map(([i, v]) => i + v).join(','), [...['a', 'b'].keys()].join(','), [1, 2, 3].findLast(x => x < 3));",
+        // JSON (replacer array / undefined+null elision)
+        ["json-replacer"] = "console.log(JSON.stringify({ a: 1, b: 2, c: 3 }, ['a', 'c']), JSON.stringify({ x: undefined, y: null }));",
     };
 
     /// <summary>
@@ -153,8 +199,15 @@ internal static class ParityCorpus
     /// </summary>
     internal static readonly Dictionary<string, (string Source, string Note)> KnownDivergences = new()
     {
-        // (empty) The harness's first two findings — array->string coercion and Array.from
-        // on an array-like — were fixed and promoted into Snippets above (coerce-array-string,
-        // arr-from). Future divergences that can't be fixed immediately go here.
+        // BigInt is under-developed and buggy in BOTH modes (a dedicated effort, not a quick fix).
+        //   interp:   String(42n)="42n" (want "42"), Number(42n)=NaN (want 42), 10n==10 false (want true),
+        //             (123n).toString() throws.
+        //   compiled: typeof 10n="object" (want "bigint"), mixed 10n==10 crashes (Double->BigInteger cast).
+        ["bigint-basics"] = (
+            "console.log(typeof 10n, 10n + 20n, 2n ** 10n, 10n > 5n, 100n / 7n, (123n).toString());",
+            "BigInt: interp throws on (123n).toString(); compiled typeof 10n='object' (want 'bigint')."),
+        ["bigint-mixed"] = (
+            "console.log(10n === 10n, 10n == 10, String(42n), Number(42n), 5n * 5n);",
+            "BigInt: interp String(42n)='42n'/Number(42n)=NaN/10n==10 false; compiled crashes on 10n==10 (Double->BigInteger cast)."),
     };
 }

--- a/SharpTS.Tests/SharedTests/DifferentialParityTests.cs
+++ b/SharpTS.Tests/SharedTests/DifferentialParityTests.cs
@@ -189,6 +189,12 @@ internal static class ParityCorpus
         ["arr-entries2"] = "console.log([...['x', 'y'].entries()].map(([i, v]) => i + v).join(','), [...['a', 'b'].keys()].join(','), [1, 2, 3].findLast(x => x < 3));",
         // JSON (replacer array / undefined+null elision)
         ["json-replacer"] = "console.log(JSON.stringify({ a: 1, b: 2, c: 3 }, ['a', 'c']), JSON.stringify({ x: undefined, y: null }));",
+        // Regex (verbatim C# strings so the TS keeps its backslashes)
+        ["regex-basic"] = @"console.log(/\d+/.test('abc123'), 'a1b2c3'.match(/\d/g)?.join(','), 'hello world'.replace(/o/g, '0'), 'a-b-c'.split(/-/).join('|'));",
+        ["regex-groups"] = @"console.log('2020-01-15'.replace(/(\d+)-(\d+)-(\d+)/, '$3/$2/$1'), [...'a1b2'.matchAll(/(\w)(\d)/g)].map(m => m[1] + m[2]).join(','));",
+        // JSON parse/round-trip + specials (NaN/Infinity -> null, undefined elided)
+        ["json-parse"] = "console.log(JSON.parse('{\"a\":1,\"b\":[true,null,1.5]}').b.length, JSON.stringify(JSON.parse('[1,2,3]')));",
+        ["json-special"] = "console.log(JSON.stringify({ a: undefined, b: null, c: NaN, d: Infinity }), JSON.stringify([undefined, null, NaN]));",
     };
 
     /// <summary>
@@ -205,9 +211,9 @@ internal static class ParityCorpus
         //   compiled: typeof 10n="object" (want "bigint"), mixed 10n==10 crashes (Double->BigInteger cast).
         ["bigint-basics"] = (
             "console.log(typeof 10n, 10n + 20n, 2n ** 10n, 10n > 5n, 100n / 7n, (123n).toString());",
-            "BigInt: interp throws on (123n).toString(); compiled typeof 10n='object' (want 'bigint')."),
+            "BigInt (tracked #912): interp throws on (123n).toString(); compiled typeof 10n='object' (want 'bigint')."),
         ["bigint-mixed"] = (
             "console.log(10n === 10n, 10n == 10, String(42n), Number(42n), 5n * 5n);",
-            "BigInt: interp String(42n)='42n'/Number(42n)=NaN/10n==10 false; compiled crashes on 10n==10 (Double->BigInteger cast)."),
+            "BigInt (tracked #912): interp String(42n)='42n'/Number(42n)=NaN/10n==10 false; compiled crashes on 10n==10 (Double->BigInteger cast)."),
     };
 }


### PR DESCRIPTION
Phase B of the differential parity harness (#910): broadens the corpus and fixes the interpreter bugs the new snippets surfaced.

## Corpus
Adds ~30 snippets across Math, Number, Date, errors, destructuring, optional chaining, Symbol, Map/Set, generators, accessors, instanceof — bringing the green corpus to ~72 snippets.

## Bugs found & fixed (interp wrong, compiled correct)
1. `Math.cbrt` / `log2` / `log10` / `hypot` were missing in the interpreter (threw 'undefined is not a function'); added.
2. `Math.max()` / `min()` / `hypot()` with **0 args** threw (registered min-arity 2) though the handlers already cover the empty case. Registered min-arity 0 with spec length 2 (added a `specLength` overload to `BuiltInStaticBuilder` so `Math.max.length` stays 2).
3. `Number.prototype.toExponential` padded the exponent to 3 digits (.NET 'e2' -> '1.23e+003'); JS uses no leading zeros ('1.23e+3').

## Documented
**BigInt** is broken in *both* modes (interp String(42n)/Number(42n)/==/.toString(); compiled typeof/mixed-==-crash) — pinned as KnownDivergences pending a dedicated effort.

Full suite (minus LiveNetwork): 14108 passed, 0 failed.