### PR TITLE
fix(compiled): res.writeHead applies headers (was a no-op TODO)

### DIFF
--- a/Compilation/RuntimeEmitter.TSHttpServer.cs
+++ b/Compilation/RuntimeEmitter.TSHttpServer.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Net;
 using System.Reflection;
 using System.Reflection.Emit;
@@ -365,11 +366,12 @@ public partial class RuntimeEmitter
         ctorIL.Emit(OpCodes.Stfld, _httpResponseBodyBufferField);
         ctorIL.Emit(OpCodes.Ret);
 
-        // Methods
-        EmitHttpResponseWriteHead(typeBuilder, runtime, httpListenerResponseType);
+        // Methods. SetHeader is emitted before WriteHead so WriteHead can call it to apply
+        // the optional headers object.
+        var setHeaderMethod = EmitHttpResponseSetHeader(typeBuilder, runtime, httpListenerResponseType);
+        EmitHttpResponseWriteHead(typeBuilder, runtime, httpListenerResponseType, setHeaderMethod);
         EmitHttpResponseWrite(typeBuilder, runtime);
         EmitHttpResponseEnd(typeBuilder, runtime, httpListenerResponseType);
-        EmitHttpResponseSetHeader(typeBuilder, runtime, httpListenerResponseType);
         EmitHttpResponseHasHeader(typeBuilder, runtime, httpListenerResponseType);
         EmitHttpResponseGetHeader(typeBuilder, runtime, httpListenerResponseType);
         EmitHttpResponseGetHeaderNames(typeBuilder, runtime, httpListenerResponseType);
@@ -485,7 +487,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ret);
     }
 
-    private void EmitHttpResponseWriteHead(TypeBuilder typeBuilder, EmittedRuntime runtime, Type httpListenerResponseType)
+    private void EmitHttpResponseWriteHead(TypeBuilder typeBuilder, EmittedRuntime runtime, Type httpListenerResponseType, MethodBuilder setHeaderMethod)
     {
         // public object WriteHead(double statusCode, object? headers)
         var method = typeBuilder.DefineMethod(
@@ -504,7 +506,65 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Conv_I4);
         il.Emit(OpCodes.Callvirt, httpListenerResponseType.GetProperty("StatusCode")!.GetSetMethod()!);
 
-        // TODO: Handle headers from arg2 if Dictionary
+        // Apply the optional headers object. A compiled object literal (e.g. { 'Content-Type': ... })
+        // is a bare Dictionary<string, object?>; for each entry call this.SetHeader(key,
+        // value?.ToString() ?? "") which handles the Content-Type restricted-header special case.
+        // (Previously a no-op TODO, so compiled writeHead silently dropped all headers.)
+        var dictType = typeof(Dictionary<string, object?>);
+        var enumType = typeof(Dictionary<string, object?>.Enumerator);
+        var kvpType = typeof(KeyValuePair<string, object?>);
+        var headersDict = il.DeclareLocal(dictType);
+        var dictEnum = il.DeclareLocal(enumType);
+        var kvLocal = il.DeclareLocal(kvpType);
+        var skipHeaders = il.DefineLabel();
+
+        // if ((headersDict = arg2 as Dictionary<string, object?>) == null) goto skipHeaders;
+        il.Emit(OpCodes.Ldarg_2);
+        il.Emit(OpCodes.Isinst, dictType);
+        il.Emit(OpCodes.Dup);
+        il.Emit(OpCodes.Stloc, headersDict);
+        il.Emit(OpCodes.Brfalse, skipHeaders);
+
+        // var e = headersDict.GetEnumerator();
+        il.Emit(OpCodes.Ldloc, headersDict);
+        il.Emit(OpCodes.Callvirt, dictType.GetMethod("GetEnumerator", Type.EmptyTypes)!);
+        il.Emit(OpCodes.Stloc, dictEnum);
+
+        var loopCond = il.DefineLabel();
+        var loopBody = il.DefineLabel();
+        il.Emit(OpCodes.Br, loopCond);
+
+        il.MarkLabel(loopBody);
+        // var kv = e.Current;
+        il.Emit(OpCodes.Ldloca, dictEnum);
+        il.Emit(OpCodes.Call, enumType.GetProperty("Current")!.GetGetMethod()!);
+        il.Emit(OpCodes.Stloc, kvLocal);
+
+        // this.SetHeader(kv.Key, kv.Value?.ToString() ?? "")
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldloca, kvLocal);
+        il.Emit(OpCodes.Call, kvpType.GetProperty("Key")!.GetGetMethod()!);
+        il.Emit(OpCodes.Ldloca, kvLocal);
+        il.Emit(OpCodes.Call, kvpType.GetProperty("Value")!.GetGetMethod()!);
+        var valNotNull = il.DefineLabel();
+        var valDone = il.DefineLabel();
+        il.Emit(OpCodes.Dup);
+        il.Emit(OpCodes.Brtrue, valNotNull);
+        il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Ldstr, "");
+        il.Emit(OpCodes.Br, valDone);
+        il.MarkLabel(valNotNull);
+        il.Emit(OpCodes.Callvirt, _types.Object.GetMethod("ToString", Type.EmptyTypes)!);
+        il.MarkLabel(valDone);
+        il.Emit(OpCodes.Callvirt, setHeaderMethod);
+        il.Emit(OpCodes.Pop); // SetHeader returns this
+
+        il.MarkLabel(loopCond);
+        il.Emit(OpCodes.Ldloca, dictEnum);
+        il.Emit(OpCodes.Call, enumType.GetMethod("MoveNext", Type.EmptyTypes)!);
+        il.Emit(OpCodes.Brtrue, loopBody);
+
+        il.MarkLabel(skipHeaders);
 
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ret);
@@ -650,7 +710,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ret);
     }
 
-    private void EmitHttpResponseSetHeader(TypeBuilder typeBuilder, EmittedRuntime runtime, Type httpListenerResponseType)
+    private MethodBuilder EmitHttpResponseSetHeader(TypeBuilder typeBuilder, EmittedRuntime runtime, Type httpListenerResponseType)
     {
         // public object SetHeader(string name, string value)
         var method = typeBuilder.DefineMethod(
@@ -690,6 +750,8 @@ public partial class RuntimeEmitter
 
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ret);
+
+        return method;
     }
 
     private void EmitHttpResponseHasHeader(TypeBuilder typeBuilder, EmittedRuntime runtime, Type httpListenerResponseType)

--- a/SharpTS.Tests/SharedTests/HttpEventTests.cs
+++ b/SharpTS.Tests/SharedTests/HttpEventTests.cs
@@ -66,7 +66,9 @@ public class HttpEventTests
             ["./main.ts"] = $$"""
                 import * as http from 'http';
                 const server = http.createServer((req, res) => {
-                    res.writeHead(200, { 'Content-Type': 'text/plain' });
+                    res.writeHead(200, { 'Content-Type': 'text/plain', 'X-Custom': 'abc' });
+                    console.log('ctype=' + res.getHeader('Content-Type'));
+                    console.log('xcustom=' + res.getHeader('X-Custom'));
                     res.end('OK');
                     server.close();
                 });
@@ -78,6 +80,11 @@ public class HttpEventTests
         };
         var output = TestHarness.RunModules(files, "./main.ts", mode);
         Assert.Contains("server started", output);
+        // writeHead's headers object must actually be applied. Compiled mode previously dropped
+        // it entirely (the emitted WriteHead had a no-op TODO), so assert both the restricted
+        // Content-Type and a custom header round-trip via getHeader.
+        Assert.Contains("ctype=text/plain", output);
+        Assert.Contains("xcustom=abc", output);
     }
 
     [Theory]


### PR DESCRIPTION
## Bug
In **compiled** mode, `res.writeHead(statusCode, headers)` silently dropped every header. The emitted `$HttpResponse.WriteHead` set the status code and then hit a literal `// TODO: Handle headers from arg2 if Dictionary` — it never applied the headers object. The interpreter (`SharpTSHttpResponse`) was unaffected, so this was a pure interp↔compiled divergence.

## Fix
A compiled object literal is a bare `Dictionary<string, object?>`, so `WriteHead` now iterates it and calls the already-emitted `SetHeader(key, value?.ToString() ?? "")` for each entry — reusing `SetHeader`'s Content-Type restricted-header special case (Content-Type → `HttpListenerResponse.ContentType`, others → `Headers.Set`). `SetHeader` is now emitted before `WriteHead` and returns its `MethodBuilder` so `WriteHead` can call it.

## Verification
- **ILVerify-clean**; emitted IL uses only BCL types (`Dictionary`/`KeyValuePair` enumerator) — **no `SharpTS.dll` dependency**, standalone-DLL guard tests pass.
- Both Content-Type and a custom header round-trip in compiled (`ctype=text/plain`, `xcustom=abc`); interp agrees.
- Strengthened `HttpServerResponseWriteHead` — it previously only asserted `"server started"` (which is why this bug went unnoticed) — to assert the headers actually apply, in **both** modes.
- Full suite (minus LiveNetwork): **14163 passed, 0 failed**.