### PR TITLE
fix(compiled): Array.prototype.with out-of-bounds throws real RangeError (#916)

### DIFF
--- a/Compilation/RuntimeEmitter.Arrays.Mutators.cs
+++ b/Compilation/RuntimeEmitter.Arrays.Mutators.cs
@@ -1942,10 +1942,26 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Bge, throwRangeError);
         il.Emit(OpCodes.Br, validIndex);
 
-        // Throw RangeError
+        // Throw a real $RangeError (not a generic Exception) so guest `instanceof RangeError`
+        // and Test262's assert.throws(RangeError, ...) hold. The previous code threw a bare CLR
+        // Exception whose message merely began "RangeError:", so WrapException produced a generic
+        // $Error on catch. Wrap the $RangeError in a CLR Exception whose Data["__tsValue"] carries
+        // it (the inline-throw pattern from EmitArrayConstructor / ArrayFrom).
         il.MarkLabel(throwRangeError);
-        il.Emit(OpCodes.Ldstr, "RangeError: Invalid index for with()");
-        il.Emit(OpCodes.Newobj, _types.ExceptionCtorString);
+        var withErr = il.DeclareLocal(_types.Object);
+        var withEx = il.DeclareLocal(_types.Exception);
+        il.Emit(OpCodes.Ldstr, "Invalid index for with()");
+        il.Emit(OpCodes.Newobj, runtime.TSRangeErrorCtor);
+        il.Emit(OpCodes.Stloc, withErr);
+        il.Emit(OpCodes.Ldstr, "Invalid index for with()");
+        il.Emit(OpCodes.Newobj, _types.GetConstructor(_types.Exception, _types.String));
+        il.Emit(OpCodes.Stloc, withEx);
+        il.Emit(OpCodes.Ldloc, withEx);
+        il.Emit(OpCodes.Callvirt, _types.GetProperty(_types.Exception, "Data").GetGetMethod()!);
+        il.Emit(OpCodes.Ldstr, "__tsValue");
+        il.Emit(OpCodes.Ldloc, withErr);
+        il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.IDictionary, "set_Item"));
+        il.Emit(OpCodes.Ldloc, withEx);
         il.Emit(OpCodes.Throw);
 
         il.MarkLabel(validIndex);

--- a/SharpTS.Tests/SharedTests/ArrayMethodTests.cs
+++ b/SharpTS.Tests/SharedTests/ArrayMethodTests.cs
@@ -178,6 +178,31 @@ public class ArrayMethodTests
 
     [Theory]
     [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Array_With_OutOfBounds_ThrowsRangeError(ExecutionMode mode)
+    {
+        // Array.prototype.with must throw a real RangeError for out-of-bounds indices. Compiled
+        // mode previously threw a generic Error (a CLR Exception whose message merely began
+        // "RangeError:"), so Test262's assert.throws(RangeError, ...) — which checks
+        // `thrown.constructor === RangeError` — failed. Assert instanceof + constructor === plus
+        // valid in-range writes (positive and negative index).
+        var source = """
+            const a: number[] = [1, 2, 3];
+            function check(fn: () => any): string {
+                try { fn(); return "no-throw"; }
+                catch (e) { return (e instanceof RangeError) + "/" + ((e as any).constructor === RangeError); }
+            }
+            console.log(check(() => a.with(5, 9)));
+            console.log(check(() => a.with(-5, 9)));
+            console.log(a.with(1, 9).join(","));
+            console.log(a.with(-1, 9).join(","));
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("true/true\ntrue/true\n1,9,3\n1,2,9\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void Array_ReduceRight_WithoutInitialValue_UsesLastElement(ExecutionMode mode)
     {
         var source = """


### PR DESCRIPTION
## Bug
In **compiled** mode, `[1,2,3].with(5, 9)` (out-of-bounds index) threw a generic `$Error` instead of a `RangeError`. `EmitArrayWith` threw a bare CLR `Exception` whose message merely began `"RangeError:"`; `WrapException` doesn't parse that prefix, so on catch the guest saw a generic error. Both `e instanceof RangeError` and `e.constructor === RangeError` (the check Test262's `assert.throws` uses) were false. Interp was correct.

## Fix
Construct a real `$RangeError` (`runtime.TSRangeErrorCtor`) wrapped in a CLR `Exception` carrying it in `Data["__tsValue"]` — the inline-throw pattern already used by `EmitArrayConstructor`/`ArrayFrom`, so `WrapException` returns the typed error on catch.

## Verification
- Both modes now agree: `instanceof RangeError` = true **and** `constructor === RangeError` = true; valid in-range writes (positive/negative index) unaffected.
- **ILVerify-clean**; uses only the existing `$RangeError` runtime type (standalone-safe).
- Flips Test262 `Array/prototype/with/index-bigger-or-eq-than-length` + `.../index-smaller-than-minus-length` Fail→Pass in compiled (found via the interp↔compiled baseline diff in #916).
- Added dual-mode `Array_With_OutOfBounds_ThrowsRangeError` regression test.
- Full suite (minus LiveNetwork): **14165 passed, 0 failed**.

## Note
This generic-error-vs-typed-error pattern is **systematic** — ~22 more sites across 7 emitter files throw typed-prefixed messages as generic exceptions, likely the common root cause behind much of #916's compiled-regression set. Root-cause note + recommended helper extraction posted on #916. This PR is the template for that fix.