### PR TITLE
feat(compile): unboxed number[] elements-kind for the compiled $Array

### DIFF
--- a/Compilation/EmittedRuntime.cs
+++ b/Compilation/EmittedRuntime.cs
@@ -1381,6 +1381,9 @@ public class EmittedRuntime
     // statically-number[] array-creation sites so escaping number[] arrays start
     // unboxed. No-op on a non-empty / sparse array (stays boxed).
     public MethodBuilder TSArrayMarkNumeric { get; set; } = null!;
+    // Sets $Array._isNonExtensible so the unboxed PushDouble fast path refuses to append; called by
+    // Object.seal / Object.preventExtensions (which otherwise only register the array externally).
+    public MethodBuilder TSArrayMarkNonExtensible { get; set; } = null!;
 
     // $IHasFields interface - for unified property access on user classes and $Object
     // Note: These use MethodInfo instead of MethodBuilder because we need the actual

--- a/Compilation/EmittedRuntime.cs
+++ b/Compilation/EmittedRuntime.cs
@@ -1377,6 +1377,10 @@ public class EmittedRuntime
     public MethodBuilder TSArraySetDouble { get; set; } = null!;
     public MethodBuilder TSArrayPushDouble { get; set; } = null!;
     public MethodBuilder TSArrayEnsureBoxed { get; set; } = null!;
+    // Flips an empty $Array into numeric (unboxed double[]) mode — emitted at
+    // statically-number[] array-creation sites so escaping number[] arrays start
+    // unboxed. No-op on a non-empty / sparse array (stays boxed).
+    public MethodBuilder TSArrayMarkNumeric { get; set; } = null!;
 
     // $IHasFields interface - for unified property access on user classes and $Object
     // Note: These use MethodInfo instead of MethodBuilder because we need the actual

--- a/Compilation/EmittedRuntime.cs
+++ b/Compilation/EmittedRuntime.cs
@@ -1370,6 +1370,14 @@ public class EmittedRuntime
     public MethodBuilder TSArraySetLength { get; set; } = null!;
     public MethodBuilder TSArrayDeleteAt { get; set; } = null!;
 
+    // Unboxed packed-double elements-kind accessors (number[] unboxing project).
+    // GetDouble/SetDouble/PushDouble are the fast paths the compiler emits at
+    // statically-number[] sites; EnsureBoxed is the deopt (numeric -> boxed).
+    public MethodBuilder TSArrayGetDouble { get; set; } = null!;
+    public MethodBuilder TSArraySetDouble { get; set; } = null!;
+    public MethodBuilder TSArrayPushDouble { get; set; } = null!;
+    public MethodBuilder TSArrayEnsureBoxed { get; set; } = null!;
+
     // $IHasFields interface - for unified property access on user classes and $Object
     // Note: These use MethodInfo instead of MethodBuilder because we need the actual
     // methods from the created interface type (after CreateType() is called)

--- a/Compilation/Emitters/ArrayEmitter.cs
+++ b/Compilation/Emitters/ArrayEmitter.cs
@@ -586,6 +586,22 @@ public sealed class ArrayEmitter : ITypeEmitterStrategy
         var objLocal = il.DeclareLocal(ctx.Types.Object);
         il.Emit(OpCodes.Stloc, objLocal);
 
+        // Deopt: if this is a numeric-mode $Array, materialize its unboxed
+        // double store into the base List<object?> first. The `isinst
+        // List<object?>` check below matches $Array (it inherits List<object?>)
+        // and would otherwise read the empty base list. EnsureBoxed is a no-op
+        // for boxed-mode arrays.
+        var deoptDone = il.DefineLabel();
+        var arrLocal = il.DeclareLocal(ctx.Runtime!.TSArrayType);
+        il.Emit(OpCodes.Ldloc, objLocal);
+        il.Emit(OpCodes.Isinst, ctx.Runtime.TSArrayType);
+        il.Emit(OpCodes.Stloc, arrLocal);
+        il.Emit(OpCodes.Ldloc, arrLocal);
+        il.Emit(OpCodes.Brfalse, deoptDone);
+        il.Emit(OpCodes.Ldloc, arrLocal);
+        il.Emit(OpCodes.Callvirt, ctx.Runtime.TSArrayEnsureBoxed);
+        il.MarkLabel(deoptDone);
+
         var isListLabel = il.DefineLabel();
         var endLabel = il.DefineLabel();
 

--- a/Compilation/ILCompiler.Classes.Constructors.cs
+++ b/Compilation/ILCompiler.Classes.Constructors.cs
@@ -296,8 +296,13 @@ public partial class ILCompiler
                     il.Emit(OpCodes.Ldarg_0);
                     il.Emit(OpCodes.Ldfld, fieldsField);
                     il.Emit(OpCodes.Ldstr, fieldName);
-                    initEmitter.EmitExpression(field.Initializer!);
-                    initEmitter.EmitBoxIfNeeded(field.Initializer!);
+                    // number[] unboxing: an `arr: number[] = []` field is created as a numeric $Array
+                    // (escaping by nature — a field is aliasable), so `this.arr[i]=v` writes unboxed.
+                    if (!initEmitter.TryEmitNumericEmptyArrayInit(field.TypeAnnotation, field.Initializer))
+                    {
+                        initEmitter.EmitExpression(field.Initializer!);
+                        initEmitter.EmitBoxIfNeeded(field.Initializer!);
+                    }
                     il.Emit(OpCodes.Callvirt, _types.DictionaryStringObjectSetItem);
                 }
             }

--- a/Compilation/ILEmitter.Calls.MethodDispatch.cs
+++ b/Compilation/ILEmitter.Calls.MethodDispatch.cs
@@ -25,6 +25,26 @@ public partial class ILEmitter
             return;
         }
 
+        // Escaping number[] push (number[] unboxing): the receiver is a statically `number[]`
+        // expression that is NOT a promoted local — so its runtime value is a $Array (numeric or boxed,
+        // never List<double>: the promoted-local branch above + the escape analyzer guarantee that).
+        // Append each UNBOXED double via $Array.PushDouble (mode-checked: a numeric array appends into its
+        // double[] store with no boxing and STAYS numeric; a boxed array delegates to the boxed Set). The
+        // generic ArrayEmitter path would instead unwrap the array (EmitGetListFromArrayOrList), deopting a
+        // numeric receiver before the append. Gated so numeric == boxed: every arg must be statically
+        // `number` (EmitExpressionAsDouble coerces; an any/undefined-admitting arg would store a coerced
+        // double where the boxed path preserves the value/undefined sentinel). Sync-only path (ILEmitter):
+        // a push arg cannot contain await/yield here, so the $Array ref on the stack during arg evaluation
+        // never strands across a suspension (cf. the promoted-local push, which likewise has no guard).
+        // push() with no args falls through to the generic path.
+        if (methodName == "push" && !methodGet.Optional && arguments.Count > 0
+            && ArrayElements.Resolve(_ctx.TypeMap?.Get(methodGet.Object)) is { Kind: ArrayElementsKind.Double }
+            && arguments.All(a => IsNumericType(_ctx.TypeMap?.Get(a))))
+        {
+            EmitEscapingNumberArrayPush(methodGet.Object, arguments);
+            return;
+        }
+
         // Promoted string-accumulator charCodeAt (#857): read the StringBuilder's UTF-16 code unit
         // directly via its [int] indexer (== JS charCodeAt); out-of-range yields NaN (JS semantics).
         // Must intercept before the string-method path, which would emit the slot as a string receiver.

--- a/Compilation/ILEmitter.Properties.cs
+++ b/Compilation/ILEmitter.Properties.cs
@@ -1225,8 +1225,33 @@ public partial class ILEmitter
                 SetStackUnknown();
                 IL.Emit(OpCodes.Br, endLabelNH);
 
-                // Not typed list: box value and fall through to List<object?> path
                 IL.MarkLabel(notTypedLabel);
+
+                // $Array numeric fast path (number[] unboxing): SetDouble takes the
+                // UNBOXED double, so a numeric-mode $Array stores it straight into
+                // its double[] with no allocation (the write side of the 73x gap).
+                // SetDouble is mode-checked — a boxed $Array delegates to Set, so
+                // this is behaviour-identical until numeric creation is wired.
+                if (desc.Kind == ArrayElementsKind.Double)
+                {
+                    IL.Emit(OpCodes.Ldloc, objLocal);
+                    IL.Emit(OpCodes.Isinst, _ctx.Runtime!.TSArrayType);
+                    var notTSArraySet = IL.DefineLabel();
+                    IL.Emit(OpCodes.Brfalse, notTSArraySet);
+                    IL.Emit(OpCodes.Ldloc, objLocal);
+                    IL.Emit(OpCodes.Castclass, _ctx.Runtime!.TSArrayType);
+                    EmitExpressionAsDouble(si.Index);
+                    IL.Emit(OpCodes.Conv_I4);
+                    IL.Emit(OpCodes.Ldloc, typedValueLocalNH);
+                    IL.Emit(OpCodes.Callvirt, _ctx.Runtime!.TSArraySetDouble);
+                    IL.Emit(OpCodes.Ldloc, typedValueLocalNH);
+                    desc.EmitBoxElement(IL, _ctx.Types);
+                    SetStackUnknown();
+                    IL.Emit(OpCodes.Br, endLabelNH);
+                    IL.MarkLabel(notTSArraySet);
+                }
+
+                // Not typed list: box value and fall through to List<object?> path
                 IL.Emit(OpCodes.Ldloc, objLocal);
                 IL.Emit(OpCodes.Ldloc, typedValueLocalNH);
                 IL.Emit(OpCodes.Box, desc.GetElementType(_ctx.Types));

--- a/Compilation/ILEmitter.Properties.cs
+++ b/Compilation/ILEmitter.Properties.cs
@@ -1343,6 +1343,38 @@ public partial class ILEmitter
     }
 
     /// <summary>
+    /// Emits <c>x.push(args)</c> for an ESCAPING <c>number[]</c> whose runtime value is a <c>$Array</c>
+    /// (number[] unboxing project): append each (unboxed) <c>double</c> argument via the mode-checked
+    /// <c>$Array.PushDouble</c>, then leave the new length (a JS number) as the result. A numeric-mode
+    /// receiver appends straight into its <c>double[]</c> store with no boxing and stays numeric (unlike
+    /// the generic dispatcher, which unwraps the array and deopts it); a boxed receiver has PushDouble
+    /// delegate to the boxed append, so this is behaviour-identical for both. Caller gates on a statically
+    /// <c>number[]</c> receiver with statically <c>number</c> arguments (see EmitMethodCall).
+    /// </summary>
+    private void EmitEscapingNumberArrayPush(Expr receiver, List<Expr> arguments)
+    {
+        EmitExpression(receiver);
+        EmitBoxIfNeeded(receiver);
+        IL.Emit(OpCodes.Castclass, _ctx.Runtime!.TSArrayType);
+        var arrLocal = IL.DeclareLocal(_ctx.Runtime!.TSArrayType);
+        IL.Emit(OpCodes.Stloc, arrLocal);
+
+        for (int i = 0; i < arguments.Count; i++)
+        {
+            IL.Emit(OpCodes.Ldloc, arrLocal);
+            EmitExpressionAsDouble(arguments[i]);
+            IL.Emit(OpCodes.Callvirt, _ctx.Runtime!.TSArrayPushDouble);
+        }
+
+        // push() returns the new length. _length is authoritative in both modes
+        // (PushDouble maintains it numeric; SyncLength reconciles it boxed).
+        IL.Emit(OpCodes.Ldloc, arrLocal);
+        IL.Emit(OpCodes.Callvirt, _ctx.Runtime!.TSArrayLongLengthGetter);
+        IL.Emit(OpCodes.Conv_R8);
+        SetStackType(StackType.Double);
+    }
+
+    /// <summary>
     /// Emits <c>s.charCodeAt(i)</c> for a promoted string-accumulator (StringBuilder slot): reads the
     /// UTF-16 code unit directly via the <c>this[int]</c> indexer (identical to JS charCodeAt), with an
     /// out-of-range (incl. negative, via unsigned compare) result of NaN. Leaves a boxed double, matching

--- a/Compilation/ILEmitter.Statements.cs
+++ b/Compilation/ILEmitter.Statements.cs
@@ -87,8 +87,11 @@ public partial class ILEmitter
             {
                 if (v.Initializer != null)
                 {
-                    EmitExpression(v.Initializer);
-                    EmitBoxIfNeeded(v.Initializer);
+                    if (!TryEmitNumericEmptyArrayInit(v))
+                    {
+                        EmitExpression(v.Initializer);
+                        EmitBoxIfNeeded(v.Initializer);
+                    }
                     IL.Emit(OpCodes.Stsfld, staticField);
                 }
                 else if (v.TypeAnnotation == "number")
@@ -462,6 +465,47 @@ public partial class ILEmitter
     private static bool IsNumericType(TypeSystem.TypeInfo? type) =>
         type is TypeSystem.TypeInfo.Primitive { Type: TokenType.TYPE_NUMBER }
             or TypeSystem.TypeInfo.NumberLiteral;
+
+    /// <summary>
+    /// Numeric-mode array creation (number[] unboxing project): a statically-typed
+    /// <c>number[]</c> declaration initialized with an empty array literal (<c>[]</c>)
+    /// is created as a NUMERIC <c>$Array</c> (unboxed <c>double[]</c> elements-kind)
+    /// instead of a boxed one. Escaping <c>number[]</c> arrays (params/fields/
+    /// module-level) live on the <c>$Array</c> path — the win is that their index
+    /// writes go straight into an unboxed <c>double[]</c> via the <c>SetDouble</c>
+    /// fast path, with no per-element boxing. Non-escaping <c>number[]</c> locals are
+    /// promoted to <c>List&lt;double&gt;</c> upstream (the IsPromotableArrayLocal
+    /// branch) and return before reaching the storage sites that consult this.
+    ///
+    /// <para>Returns true and leaves a numeric (empty) <c>$Array</c> on the stack
+    /// (as <c>object</c>) when applicable; the caller stores it. Returns false
+    /// otherwise — the caller emits the initializer normally. Any operation the
+    /// numeric fast paths don't cover deopts the array back to boxed on first
+    /// touch, so this is purely a representation choice, never a semantic one.</para>
+    /// </summary>
+    private bool TryEmitNumericEmptyArrayInit(Stmt.Var v)
+    {
+        if (v.TypeAnnotation != "number[]") return false;
+        if (v.Initializer is not Expr.ArrayLiteral { Elements.Count: 0 }) return false;
+        EmitNumericEmptyArray();
+        return true;
+    }
+
+    /// <summary>
+    /// Emits an empty numeric <c>$Array</c> onto the stack: <c>$Runtime.CreateArray(new
+    /// object[0])</c> (a fresh empty <c>$Array</c>) followed by <c>MarkNumeric()</c>,
+    /// which flips it into unboxed <c>double[]</c> mode. Leaves the <c>$Array</c>
+    /// reference on the stack.
+    /// </summary>
+    private void EmitNumericEmptyArray()
+    {
+        IL.Emit(OpCodes.Ldc_I4_0);
+        IL.Emit(OpCodes.Newarr, _ctx.Types.Object);
+        IL.Emit(OpCodes.Call, _ctx.Runtime!.CreateArray);            // [$Array] (empty)
+        IL.Emit(OpCodes.Dup);                                        // [$Array, $Array]
+        IL.Emit(OpCodes.Callvirt, _ctx.Runtime!.TSArrayMarkNumeric); // [$Array]
+        SetStackUnknown();
+    }
 
     /// <summary>
     /// Emits a for loop with unboxed counter and array hoist optimizations.

--- a/Compilation/ILEmitter.Statements.cs
+++ b/Compilation/ILEmitter.Statements.cs
@@ -87,11 +87,16 @@ public partial class ILEmitter
             {
                 if (v.Initializer != null)
                 {
-                    if (!TryEmitNumericEmptyArrayInit(v))
-                    {
-                        EmitExpression(v.Initializer);
-                        EmitBoxIfNeeded(v.Initializer);
-                    }
+                    // NOTE (number[] unboxing): live numeric-$Array creation is intentionally NOT wired
+                    // here yet. A numeric $Array keeps its elements in an unboxed double[] with an EMPTY
+                    // base List<object>, but generic-consumption runtime helpers — string coercion
+                    // (ToJsString), JSON (Stringify/StringifyFull) and console (ConsoleLog) — read that base
+                    // list directly via `is List<object>` and would observe an empty array. Until every such
+                    // boundary deopts (the "harden deopt completeness" sweep), escaping number[] stays boxed
+                    // = sound. The $Array machinery (MarkNumeric, SetDouble/PushDouble, the $BoundArrayMethod
+                    // deopt) is in place and correct; flipping creation on is gated on that sweep.
+                    EmitExpression(v.Initializer);
+                    EmitBoxIfNeeded(v.Initializer);
                     IL.Emit(OpCodes.Stsfld, staticField);
                 }
                 else if (v.TypeAnnotation == "number")

--- a/Compilation/ILEmitter.Statements.cs
+++ b/Compilation/ILEmitter.Statements.cs
@@ -325,17 +325,22 @@ public partial class ILEmitter
             _ctx.SelfCaptureVarName = v.Name.Lexeme;
             _ctx.SelfCaptureWriteBacks = [];
 
-            EmitExpression(v.Initializer);
+            // number[] unboxing: a non-promoted (escaping) `number[]` local with an empty-array
+            // initializer is created as a NUMERIC $Array; otherwise emit the initializer normally.
+            if (!TryEmitNumericEmptyArrayInit(v))
+            {
+                EmitExpression(v.Initializer);
 
-            if (_ctx.Types.IsDouble(localType))
-            {
-                // Ensure we have an unboxed double on stack
-                EnsureDouble();
-            }
-            else
-            {
-                // Ensure we have a boxed object on stack
-                EmitBoxIfNeeded(v.Initializer);
+                if (_ctx.Types.IsDouble(localType))
+                {
+                    // Ensure we have an unboxed double on stack
+                    EnsureDouble();
+                }
+                else
+                {
+                    // Ensure we have a boxed object on stack
+                    EmitBoxIfNeeded(v.Initializer);
+                }
             }
             IL.Emit(OpCodes.Stloc, local);
 

--- a/Compilation/ILEmitter.Statements.cs
+++ b/Compilation/ILEmitter.Statements.cs
@@ -87,16 +87,11 @@ public partial class ILEmitter
             {
                 if (v.Initializer != null)
                 {
-                    // NOTE (number[] unboxing): live numeric-$Array creation is intentionally NOT wired
-                    // here yet. A numeric $Array keeps its elements in an unboxed double[] with an EMPTY
-                    // base List<object>, but generic-consumption runtime helpers — string coercion
-                    // (ToJsString), JSON (Stringify/StringifyFull) and console (ConsoleLog) — read that base
-                    // list directly via `is List<object>` and would observe an empty array. Until every such
-                    // boundary deopts (the "harden deopt completeness" sweep), escaping number[] stays boxed
-                    // = sound. The $Array machinery (MarkNumeric, SetDouble/PushDouble, the $BoundArrayMethod
-                    // deopt) is in place and correct; flipping creation on is gated on that sweep.
-                    EmitExpression(v.Initializer);
-                    EmitBoxIfNeeded(v.Initializer);
+                    if (!TryEmitNumericEmptyArrayInit(v))
+                    {
+                        EmitExpression(v.Initializer);
+                        EmitBoxIfNeeded(v.Initializer);
+                    }
                     IL.Emit(OpCodes.Stsfld, staticField);
                 }
                 else if (v.TypeAnnotation == "number")

--- a/Compilation/ILEmitter.Statements.cs
+++ b/Compilation/ILEmitter.Statements.cs
@@ -489,9 +489,16 @@ public partial class ILEmitter
     /// touch, so this is purely a representation choice, never a semantic one.</para>
     /// </summary>
     private bool TryEmitNumericEmptyArrayInit(Stmt.Var v)
+        => TryEmitNumericEmptyArrayInit(v.TypeAnnotation, v.Initializer);
+
+    /// <summary>
+    /// Component overload of <see cref="TryEmitNumericEmptyArrayInit(Stmt.Var)"/> so class
+    /// field initializers (<c>arr: number[] = []</c>) can reuse the same numeric-creation hook.
+    /// </summary>
+    internal bool TryEmitNumericEmptyArrayInit(string? typeAnnotation, Expr? initializer)
     {
-        if (v.TypeAnnotation != "number[]") return false;
-        if (v.Initializer is not Expr.ArrayLiteral { Elements.Count: 0 }) return false;
+        if (typeAnnotation != "number[]") return false;
+        if (initializer is not Expr.ArrayLiteral { Elements.Count: 0 }) return false;
         EmitNumericEmptyArray();
         return true;
     }

--- a/Compilation/RuntimeEmitter.Arrays.cs
+++ b/Compilation/RuntimeEmitter.Arrays.cs
@@ -1339,6 +1339,28 @@ public partial class RuntimeEmitter
 
         var il = invokeBuilder.GetILGenerator();
 
+        // Numeric-array deopt (number[] unboxing): _list may be a numeric-mode
+        // $Array whose elements live unboxed in its double[] store, with an EMPTY
+        // base List<object?>. Every array method below operates on that base list
+        // directly, so a numeric receiver would read/mutate the wrong (empty)
+        // storage and silently corrupt — this is the one dynamic-dispatch boundary
+        // the static-call deopt sites don't cover (`(arr as any).push(x)` etc.).
+        // EnsureBoxed materializes the unboxed store back into the base list and
+        // self-guards (no-op unless actually numeric), so boxed arrays and plain
+        // List<object?> receivers pay only a single isinst on this cold path.
+        {
+            var notNumeric = il.DefineLabel();
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, listField);
+            il.Emit(OpCodes.Isinst, runtime.TSArrayType);
+            il.Emit(OpCodes.Brfalse, notNumeric);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, listField);
+            il.Emit(OpCodes.Castclass, runtime.TSArrayType);
+            il.Emit(OpCodes.Callvirt, runtime.TSArrayEnsureBoxed);
+            il.MarkLabel(notNumeric);
+        }
+
         // Switch on _methodName to dispatch to appropriate runtime method. Each case
         // must leave exactly one `object` value on the stack before branching to
         // endLabel. The fall-through path emits `ldnull` + `ret`.

--- a/Compilation/RuntimeEmitter.Arrays.cs
+++ b/Compilation/RuntimeEmitter.Arrays.cs
@@ -267,6 +267,8 @@ public partial class RuntimeEmitter
         runtime.GetKeys = method;
 
         var il = method.GetILGenerator();
+        // number[] unboxing: materialize a numeric-mode $Array before enumerating it as an object.
+        EmitDeoptArgIfNumericArray(il, runtime, 0);
         var dictType = _types.DictionaryStringObject;
         var listType = _types.ListOfObject;
 
@@ -1110,6 +1112,9 @@ public partial class RuntimeEmitter
 
         var il = method.GetILGenerator();
         var listLabel = il.DefineLabel();
+
+        // number[] unboxing: f(...arr) spread copies the base list, so materialize a numeric $Array first.
+        EmitDeoptArgIfNumericArray(il, runtime, 0);
 
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Isinst, _types.ListOfObject);

--- a/Compilation/RuntimeEmitter.ConsoleHelpers.cs
+++ b/Compilation/RuntimeEmitter.ConsoleHelpers.cs
@@ -688,6 +688,9 @@ public partial class RuntimeEmitter
         var notEmptyLabel = il.DefineLabel();
         var endLabel = il.DefineLabel();
 
+        // number[] unboxing: materialize a numeric-mode $Array before reading its base list as a table.
+        EmitDeoptArgIfNumericArray(il, runtime, 0);
+
         // var list = (List<object>)data
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Castclass, _types.ListOfObject);

--- a/Compilation/RuntimeEmitter.CoreUtilities.cs
+++ b/Compilation/RuntimeEmitter.CoreUtilities.cs
@@ -22,6 +22,9 @@ public partial class RuntimeEmitter
         var listLabel = il.DefineLabel();
         var endLabel = il.DefineLabel();
 
+        // number[] unboxing: materialize a numeric-mode $Array before the `is List<object>` branch reads it.
+        EmitDeoptArgIfNumericArray(il, runtime, 0);
+
         // if (value == null) return "null"
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Brfalse, nullLabel);
@@ -706,6 +709,9 @@ public partial class RuntimeEmitter
 
         var il = method.GetILGenerator();
         var noFormatLabel = il.DefineLabel();
+
+        // number[] unboxing: materialize a numeric-mode $Array before any array-formatting reads its base list.
+        EmitDeoptArgIfNumericArray(il, runtime, 0);
 
         // Check if arg is a string with format specifiers
         il.Emit(OpCodes.Ldarg_0);
@@ -1926,6 +1932,10 @@ public partial class RuntimeEmitter
         var method = (MethodBuilder)runtime.ToJsString;
         var il = method.GetILGenerator();
         var fallbackLabel = il.DefineLabel();
+
+        // number[] unboxing: the `is List<object>` array branch below joins the base
+        // list directly, so a numeric-mode $Array (empty base list) must materialize first.
+        EmitDeoptArgIfNumericArray(il, runtime, 0);
 
         // null / undefined → handled by Stringify ("null" / "undefined")
         il.Emit(OpCodes.Ldarg_0);

--- a/Compilation/RuntimeEmitter.Json.Stringify.cs
+++ b/Compilation/RuntimeEmitter.Json.Stringify.cs
@@ -801,6 +801,8 @@ public partial class RuntimeEmitter
         var loopStart = il.DefineLabel();
         var loopEnd = il.DefineLabel();
 
+        // number[] unboxing: materialize a numeric-mode $Array before reading its base list.
+        EmitDeoptIfNumericArray(il, runtime, () => il.Emit(OpCodes.Ldloc, valueLocal));
         il.Emit(OpCodes.Ldloc, valueLocal);
         il.Emit(OpCodes.Castclass, _types.ListOfObject);
         il.Emit(OpCodes.Stloc, arrLocal);

--- a/Compilation/RuntimeEmitter.Json.StringifyFull.cs
+++ b/Compilation/RuntimeEmitter.Json.StringifyFull.cs
@@ -270,6 +270,9 @@ public partial class RuntimeEmitter
         var keyLocal = il.DeclareLocal(_types.String);
         var tagLocal = il.DeclareLocal(_types.String);
 
+        // number[] unboxing: materialize a numeric-mode $Array replacer before reading its base list.
+        EmitDeoptArgIfNumericArray(il, runtime, 1);
+
         // Cast replacer to List<object?>
         il.Emit(OpCodes.Ldarg_1);
         il.Emit(OpCodes.Castclass, _types.ListOfObject);
@@ -579,6 +582,9 @@ public partial class RuntimeEmitter
         var closeLocal = il.DeclareLocal(_types.String);
         var elemLocal = il.DeclareLocal(_types.Object);
         var strResultLocal = il.DeclareLocal(_types.String);
+
+        // number[] unboxing: materialize a numeric-mode $Array before reading its base list.
+        EmitDeoptIfNumericArray(il, runtime, () => il.Emit(OpCodes.Ldloc, valueLocal));
 
         var loopStart = il.DefineLabel();
         var loopEnd = il.DefineLabel();

--- a/Compilation/RuntimeEmitter.Maps.cs
+++ b/Compilation/RuntimeEmitter.Maps.cs
@@ -144,6 +144,9 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Newobj, ctorWithComparer);
         il.Emit(OpCodes.Stloc, mapLocal);
 
+        // number[] unboxing: materialize a numeric-mode $Array entries source before reading its base list.
+        EmitDeoptArgIfNumericArray(il, runtime, 0);
+
         // if (entries is not List<object?> list) return map;
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Isinst, _types.ListOfObject);

--- a/Compilation/RuntimeEmitter.Objects.Comparison.cs
+++ b/Compilation/RuntimeEmitter.Objects.Comparison.cs
@@ -382,6 +382,8 @@ public partial class RuntimeEmitter
         // entirely, missing both the assign and the spec-mandated TypeError
         // when target is a String exotic (test262 assignment-to-readonly...).
         var notListSrcLabel = il.DefineLabel();
+        // number[] unboxing: materialize a numeric-mode $Array source before reading its base list.
+        EmitDeoptIfNumericArray(il, runtime, () => il.Emit(OpCodes.Ldloc, sourceLocal));
         il.Emit(OpCodes.Ldloc, sourceLocal);
         il.Emit(OpCodes.Isinst, listType);
         il.Emit(OpCodes.Brfalse, notListSrcLabel);

--- a/Compilation/RuntimeEmitter.Objects.Extensibility.cs
+++ b/Compilation/RuntimeEmitter.Objects.Extensibility.cs
@@ -148,6 +148,18 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Callvirt, runtime.TSObjectSeal);
         il.MarkLabel(notTSObjectSealLabel);
 
+        // number[] unboxing: mark a $Array non-extensible so the unboxed PushDouble fast path refuses to
+        // append (Object.seal otherwise only registers the array in the external collections the boxed
+        // ArrayPush consults, which PushDouble can't reach).
+        var notTSArraySealLabel = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Isinst, runtime.TSArrayType);
+        il.Emit(OpCodes.Brfalse, notTSArraySealLabel);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Castclass, runtime.TSArrayType);
+        il.Emit(OpCodes.Callvirt, runtime.TSArrayMarkNonExtensible);
+        il.MarkLabel(notTSArraySealLabel);
+
         // Call $PropertyDescriptorStore.Seal(obj) - fully standalone, no reflection
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Call, runtime.PDSSeal);

--- a/Compilation/RuntimeEmitter.Objects.Iteration.cs
+++ b/Compilation/RuntimeEmitter.Objects.Iteration.cs
@@ -240,6 +240,8 @@ public partial class RuntimeEmitter
         runtime.GetValues = method;
 
         var il = method.GetILGenerator();
+        // number[] unboxing: materialize a numeric-mode $Array before enumerating it as an object.
+        EmitDeoptArgIfNumericArray(il, runtime, 0);
         var dictType = _types.DictionaryStringObject;
         var listType = _types.ListOfObject;
         var kvpType = _types.KeyValuePairStringObject;
@@ -732,6 +734,8 @@ public partial class RuntimeEmitter
         runtime.GetEntries = method;
 
         var il = method.GetILGenerator();
+        // number[] unboxing: materialize a numeric-mode $Array before enumerating it as an object.
+        EmitDeoptArgIfNumericArray(il, runtime, 0);
         var dictType = _types.DictionaryStringObject;
         var listType = _types.ListOfObject;
         var kvpType = _types.KeyValuePairStringObject;

--- a/Compilation/RuntimeEmitter.Objects.Prototype.cs
+++ b/Compilation/RuntimeEmitter.Objects.Prototype.cs
@@ -254,6 +254,18 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Callvirt, runtime.TSObjectPreventExtensions);
         il.MarkLabel(notTSObjectLabel);
 
+        // number[] unboxing: mark a $Array non-extensible so the unboxed PushDouble fast path refuses to
+        // append (preventExtensions otherwise only records the array in external collections PushDouble
+        // can't reach).
+        var notTSArrayPxLabel = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Isinst, runtime.TSArrayType);
+        il.Emit(OpCodes.Brfalse, notTSArrayPxLabel);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Castclass, runtime.TSArrayType);
+        il.Emit(OpCodes.Callvirt, runtime.TSArrayMarkNonExtensible);
+        il.MarkLabel(notTSArrayPxLabel);
+
         // Call $PropertyDescriptorStore.PreventExtensions(obj) - fully standalone, no reflection
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Call, runtime.PDSPreventExtensions);

--- a/Compilation/RuntimeEmitter.Sets.cs
+++ b/Compilation/RuntimeEmitter.Sets.cs
@@ -81,6 +81,9 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Newobj, ctorWithComparer);
         il.Emit(OpCodes.Stloc, setLocal);
 
+        // number[] unboxing: materialize a numeric-mode $Array before reading its base list.
+        EmitDeoptArgIfNumericArray(il, runtime, 0);
+
         // if (values is not List<object?> list) return set;
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Isinst, _types.ListOfObject);

--- a/Compilation/RuntimeEmitter.TSArray.cs
+++ b/Compilation/RuntimeEmitter.TSArray.cs
@@ -261,6 +261,9 @@ public partial class RuntimeEmitter
         var pushDouble = typeBuilder.DefineMethod("PushDouble",
             MethodAttributes.Public | MethodAttributes.HideBySig, _types.Void, [_types.Double]);
         runtime.TSArrayPushDouble = pushDouble;
+        var markNumeric = typeBuilder.DefineMethod("MarkNumeric",
+            MethodAttributes.Public | MethodAttributes.HideBySig, _types.Void, System.Type.EmptyTypes);
+        runtime.TSArrayMarkNumeric = markNumeric;
 
         // ── void EnsureBoxed() ── numeric -> boxed: box each _numStore[i] into
         // the (empty) base list, then clear the numeric mode.
@@ -440,6 +443,32 @@ public partial class RuntimeEmitter
             il.MarkLabel(haveIndex);
             il.Emit(OpCodes.Ldarg_1);                       // value
             il.Emit(OpCodes.Call, setDouble);
+            il.Emit(OpCodes.Ret);
+        }
+
+        // ── void MarkNumeric() ── flip an EMPTY dense array into numeric mode.
+        // The compiler emits this at statically-number[] creation sites (e.g.
+        // `const a: number[] = []`) so escaping number[] arrays start unboxed.
+        // Guarded so it is a safe no-op on anything that isn't an empty dense
+        // array (already numeric, sparse, or holding elements) — those stay
+        // boxed and correct (non-empty element-move is a later phase). The
+        // invariant "numeric ⟹ base list empty" therefore holds by construction.
+        {
+            var il = markNumeric.GetILGenerator();
+            var done = il.DefineLabel();
+            il.Emit(OpCodes.Ldarg_0);                       // if (_isNumeric) return;
+            il.Emit(OpCodes.Ldfld, _tsArrayIsNumericField);
+            il.Emit(OpCodes.Brtrue, done);
+            il.Emit(OpCodes.Ldarg_0);                       // if (_sparse != null) return;
+            il.Emit(OpCodes.Ldfld, _tsArraySparseField);
+            il.Emit(OpCodes.Brtrue, done);
+            il.Emit(OpCodes.Ldarg_0);                       // if (this.Count != 0) return;
+            il.Emit(OpCodes.Callvirt, _tsArrayListCountGetter!);
+            il.Emit(OpCodes.Brtrue, done);
+            il.Emit(OpCodes.Ldarg_0);                       // _isNumeric = true;
+            il.Emit(OpCodes.Ldc_I4_1);
+            il.Emit(OpCodes.Stfld, _tsArrayIsNumericField);
+            il.MarkLabel(done);
             il.Emit(OpCodes.Ret);
         }
     }

--- a/Compilation/RuntimeEmitter.TSArray.cs
+++ b/Compilation/RuntimeEmitter.TSArray.cs
@@ -66,6 +66,11 @@ public partial class RuntimeEmitter
     private MethodInfo? _tsArrayListGetItem;
     private MethodInfo? _tsArrayListSetItem;
 
+    // The deopt method (numeric -> boxed). Defined early in EmitTSArrayClass so
+    // the base-list methods emitted below can call it via EmitTSArrayDeoptGuard;
+    // its body is emitted later in EmitTSArrayNumericAccessors.
+    private MethodBuilder _tsArrayEnsureBoxedMethod = null!;
+
     private void InitTSArrayMethodCache()
     {
         _tsArraySparseTryGetValue = _tsArraySparseType.GetMethod("TryGetValue", [_types.UInt32, _types.Object.MakeByRefType()])!;
@@ -129,6 +134,14 @@ public partial class RuntimeEmitter
         _tsArrayNumStoreField = typeBuilder.DefineField("_numStore", _types.DoubleArray, FieldAttributes.Private);
         _tsArrayNumCountField = typeBuilder.DefineField("_numCount", _types.Int32, FieldAttributes.Private);
         _tsArrayIsNumericField = typeBuilder.DefineField("_isNumeric", _types.Boolean, FieldAttributes.Private);
+
+        // Define the deopt method up front (body emitted in
+        // EmitTSArrayNumericAccessors) so the base-list methods below can guard
+        // themselves with EmitTSArrayDeoptGuard — any boxed-representation access
+        // on a numeric-mode array first materializes the unboxed store.
+        _tsArrayEnsureBoxedMethod = typeBuilder.DefineMethod("EnsureBoxed",
+            MethodAttributes.Public | MethodAttributes.HideBySig, _types.Void, System.Type.EmptyTypes);
+        runtime.TSArrayEnsureBoxed = _tsArrayEnsureBoxedMethod;
 
         EmitTSArrayConstructor(typeBuilder, runtime);
 
@@ -201,6 +214,27 @@ public partial class RuntimeEmitter
     }
 
     /// <summary>
+    /// Prepends a deopt guard to a base-list method body: <c>if (_isNumeric)
+    /// this.EnsureBoxed();</c>. Any method that reads/writes the inherited
+    /// <c>List&lt;object?&gt;</c>, <c>_sparse</c>, or reconciles <c>_length</c>
+    /// against base <c>Count</c> must call this first — in numeric mode the base
+    /// list is empty and those operations would corrupt. Costs one field load +
+    /// branch in the common boxed case (mode off); only numeric arrays pay the
+    /// materialization. Idempotent (EnsureBoxed self-guards), so redundant
+    /// guards across delegating methods are harmless.
+    /// </summary>
+    private void EmitTSArrayDeoptGuard(ILGenerator il)
+    {
+        var skip = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, _tsArrayIsNumericField);
+        il.Emit(OpCodes.Brfalse, skip);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Call, _tsArrayEnsureBoxedMethod);
+        il.MarkLabel(skip);
+    }
+
+    /// <summary>
     /// Emits the unboxed packed-double accessors on <c>$Array</c>:
     /// <c>GetDouble</c>/<c>SetDouble</c>/<c>PushDouble</c> (the fast paths the
     /// compiler will emit at statically-<c>number[]</c> sites) and
@@ -215,10 +249,9 @@ public partial class RuntimeEmitter
     {
         var arrayResize = typeof(System.Array).GetMethod("Resize")!.MakeGenericMethod(_types.Double);
 
-        // Define all four first so the bodies can reference one another.
-        var ensureBoxed = typeBuilder.DefineMethod("EnsureBoxed",
-            MethodAttributes.Public | MethodAttributes.HideBySig, _types.Void, System.Type.EmptyTypes);
-        runtime.TSArrayEnsureBoxed = ensureBoxed;
+        // EnsureBoxed's builder was defined early (so base-list methods can guard
+        // on it); we only emit its body here. The other three are defined now.
+        var ensureBoxed = _tsArrayEnsureBoxedMethod;
         var getDouble = typeBuilder.DefineMethod("GetDouble",
             MethodAttributes.Public | MethodAttributes.HideBySig, _types.Double, [_types.Int32]);
         runtime.TSArrayGetDouble = getDouble;
@@ -626,6 +659,7 @@ public partial class RuntimeEmitter
         runtime.TSArrayFreeze = method;
 
         var il = method.GetILGenerator();
+        EmitTSArrayDeoptGuard(il);
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ldc_I4_1);
         il.Emit(OpCodes.Stfld, _tsArrayIsFrozenField);
@@ -643,6 +677,7 @@ public partial class RuntimeEmitter
         runtime.TSArraySeal = method;
 
         var il = method.GetILGenerator();
+        EmitTSArrayDeoptGuard(il);
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ldc_I4_1);
         il.Emit(OpCodes.Stfld, _tsArrayIsSealedField);
@@ -655,6 +690,7 @@ public partial class RuntimeEmitter
         runtime.TSArrayGet = method;
 
         var il = method.GetILGenerator();
+        EmitTSArrayDeoptGuard(il);
         var throwLabel = il.DefineLabel();
 
         il.Emit(OpCodes.Ldarg_1);
@@ -683,6 +719,7 @@ public partial class RuntimeEmitter
         runtime.TSArraySet = method;
 
         var il = method.GetILGenerator();
+        EmitTSArrayDeoptGuard(il);
         var frozenLabel = il.DefineLabel();
         var throwLabel = il.DefineLabel();
 
@@ -721,6 +758,7 @@ public partial class RuntimeEmitter
         runtime.TSArraySetStrict = method;
 
         var il = method.GetILGenerator();
+        EmitTSArrayDeoptGuard(il);
         var notFrozenLabel = il.DefineLabel();
         var frozenReturnLabel = il.DefineLabel();
         var throwBoundsLabel = il.DefineLabel();
@@ -776,6 +814,7 @@ public partial class RuntimeEmitter
     {
         var method = typeBuilder.DefineMethod("SyncLength", MethodAttributes.Private, _types.Void, Type.EmptyTypes);
         var il = method.GetILGenerator();
+        EmitTSArrayDeoptGuard(il);
         var doneLabel = il.DefineLabel();
 
         // if (_sparse != null) return;
@@ -805,6 +844,7 @@ public partial class RuntimeEmitter
         var method = typeBuilder.DefineMethod("MaterializeDense", MethodAttributes.Private, _types.Void, Type.EmptyTypes);
 
         var il = method.GetILGenerator();
+        EmitTSArrayDeoptGuard(il);
         var sparseBranch = il.DefineLabel();
         var throwRangeLabel = il.DefineLabel();
         var loopHead = il.DefineLabel();
@@ -886,6 +926,7 @@ public partial class RuntimeEmitter
         var method = typeBuilder.DefineMethod("TryCollapseSparse", MethodAttributes.Private, _types.Void, Type.EmptyTypes);
 
         var il = method.GetILGenerator();
+        EmitTSArrayDeoptGuard(il);
         var collapseLabel = il.DefineLabel();
         var doneLabel = il.DefineLabel();
 
@@ -929,6 +970,7 @@ public partial class RuntimeEmitter
         var method = typeBuilder.DefineMethod("GetCore", MethodAttributes.Private, _types.Object, [_types.Int64]);
 
         var il = method.GetILGenerator();
+        EmitTSArrayDeoptGuard(il);
         var sparsePathLabel = il.DefineLabel();
         var returnHoleLabel = il.DefineLabel();
         var lookupLabel = il.DefineLabel();
@@ -985,6 +1027,7 @@ public partial class RuntimeEmitter
             [_types.Int64, _types.Object]);
 
         var il = method.GetILGenerator();
+        EmitTSArrayDeoptGuard(il);
         var sparseLabel = il.DefineLabel();
         var denseLabel = il.DefineLabel();
 
@@ -1030,6 +1073,7 @@ public partial class RuntimeEmitter
             [_types.Int64, _types.Object]);
 
         var il = method.GetILGenerator();
+        EmitTSArrayDeoptGuard(il);
         var denseEntryLabel = il.DefineLabel();
         var sparseWriteReturn = il.DefineLabel();
         var skipLenUpdate = il.DefineLabel();
@@ -1175,6 +1219,7 @@ public partial class RuntimeEmitter
         runtime.TSArrayHasIndex = method;
 
         var il = method.GetILGenerator();
+        EmitTSArrayDeoptGuard(il);
         var returnFalseLabel = il.DefineLabel();
         var sparseBranchLabel = il.DefineLabel();
         var checkDenseHoleLabel = il.DefineLabel();
@@ -1245,6 +1290,7 @@ public partial class RuntimeEmitter
         runtime.TSArrayGetRaw = method;
 
         var il = method.GetILGenerator();
+        EmitTSArrayDeoptGuard(il);
         var oobLabel = il.DefineLabel();
 
         il.Emit(OpCodes.Ldarg_0);
@@ -1282,6 +1328,7 @@ public partial class RuntimeEmitter
         runtime.TSArrayGetLong = method;
 
         var il = method.GetILGenerator();
+        EmitTSArrayDeoptGuard(il);
         var oobLabel = il.DefineLabel();
         var notHoleLabel = il.DefineLabel();
 
@@ -1334,6 +1381,7 @@ public partial class RuntimeEmitter
         runtime.TSArraySetLong = method;
 
         var il = method.GetILGenerator();
+        EmitTSArrayDeoptGuard(il);
         var frozenReturnLabel = il.DefineLabel();
         var negThrowLabel = il.DefineLabel();
         var maxThrowLabel = il.DefineLabel();
@@ -1386,6 +1434,7 @@ public partial class RuntimeEmitter
         runtime.TSArraySetStrictLong = method;
 
         var il = method.GetILGenerator();
+        EmitTSArrayDeoptGuard(il);
         var notFrozenLabel = il.DefineLabel();
         var frozenReturnLabel = il.DefineLabel();
         var negThrowLabel = il.DefineLabel();
@@ -1441,6 +1490,7 @@ public partial class RuntimeEmitter
         runtime.TSArraySetLength = method;
 
         var il = method.GetILGenerator();
+        EmitTSArrayDeoptGuard(il);
         var negThrowLabel = il.DefineLabel();
         var tooBigThrowLabel = il.DefineLabel();
         var notFrozenLabel = il.DefineLabel();
@@ -1710,6 +1760,7 @@ public partial class RuntimeEmitter
         runtime.TSArrayDeleteAt = method;
 
         var il = method.GetILGenerator();
+        EmitTSArrayDeoptGuard(il);
         var retLabel = il.DefineLabel();
         var denseDeleteLabel = il.DefineLabel();
         var sparseDeleteCheckLabel = il.DefineLabel();
@@ -1780,6 +1831,7 @@ public partial class RuntimeEmitter
         runtime.TSArrayToString = method;
 
         var il = method.GetILGenerator();
+        EmitTSArrayDeoptGuard(il);
 
         // ToString renders _dense elements joined by comma — matches pre-refactor
         // behavior exactly. Hole-aware join lives in the array built-ins (M5).

--- a/Compilation/RuntimeEmitter.TSArray.cs
+++ b/Compilation/RuntimeEmitter.TSArray.cs
@@ -27,6 +27,11 @@ public partial class RuntimeEmitter
     private FieldBuilder _tsArrayLengthField = null!;
     private FieldBuilder _tsArrayIsFrozenField = null!;
     private FieldBuilder _tsArrayIsSealedField = null!;
+    // Set true by Object.seal / Object.preventExtensions on a $Array (those runtime helpers don't touch
+    // the instance _isFrozen/_isSealed, only the external _sealedObjects/_nonExtensibleObjects collections
+    // that the boxed ArrayPush consults). The unboxed PushDouble fast path can't reach those collections,
+    // so it checks this cheap instance flag to refuse appending to a non-extensible array.
+    private FieldBuilder _tsArrayNonExtensibleField = null!;
 
     // ── Unboxed "packed-double" elements-kind (project: number[] unboxing) ────
     // When _isNumeric is true the dense prefix [0, _numCount) lives unboxed in
@@ -124,6 +129,7 @@ public partial class RuntimeEmitter
         _tsArrayLengthField = typeBuilder.DefineField("_length", _types.Int64, FieldAttributes.Private);
         _tsArrayIsFrozenField = typeBuilder.DefineField("_isFrozen", _types.Boolean, FieldAttributes.Private);
         _tsArrayIsSealedField = typeBuilder.DefineField("_isSealed", _types.Boolean, FieldAttributes.Private);
+        _tsArrayNonExtensibleField = typeBuilder.DefineField("_isNonExtensible", _types.Boolean, FieldAttributes.Private);
         // _tsArrayDenseField retired; every previous read-of-_dense is replaced
         // by a no-op (receiver is already the List via inheritance).
 
@@ -292,6 +298,9 @@ public partial class RuntimeEmitter
         var markNumeric = typeBuilder.DefineMethod("MarkNumeric",
             MethodAttributes.Public | MethodAttributes.HideBySig, _types.Void, System.Type.EmptyTypes);
         runtime.TSArrayMarkNumeric = markNumeric;
+        var markNonExtensible = typeBuilder.DefineMethod("MarkNonExtensible",
+            MethodAttributes.Public | MethodAttributes.HideBySig, _types.Void, System.Type.EmptyTypes);
+        runtime.TSArrayMarkNonExtensible = markNonExtensible;
 
         // ── void EnsureBoxed() ── numeric -> boxed: box each _numStore[i] into
         // the (empty) base list, then clear the numeric mode.
@@ -458,6 +467,19 @@ public partial class RuntimeEmitter
             var il = pushDouble.GetILGenerator();
             var useNum = il.DefineLabel();
             var haveIndex = il.DefineLabel();
+            var blockedReturn = il.DefineLabel();
+
+            // Non-extensible (frozen / sealed / preventExtensions) → push is a no-op, matching the boxed
+            // ArrayPush (which consults the external _frozenObjects/_sealedObjects/_nonExtensibleObjects
+            // collections this unboxed path can't reach). _isFrozen is set by $Array.Freeze();
+            // _isNonExtensible by Object.seal / Object.preventExtensions via MarkNonExtensible.
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, _tsArrayIsFrozenField);
+            il.Emit(OpCodes.Brtrue, blockedReturn);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, _tsArrayNonExtensibleField);
+            il.Emit(OpCodes.Brtrue, blockedReturn);
+
             il.Emit(OpCodes.Ldarg_0);                       // SetDouble receiver
             il.Emit(OpCodes.Ldarg_0);
             il.Emit(OpCodes.Ldfld, _tsArrayIsNumericField);
@@ -471,6 +493,9 @@ public partial class RuntimeEmitter
             il.MarkLabel(haveIndex);
             il.Emit(OpCodes.Ldarg_1);                       // value
             il.Emit(OpCodes.Call, setDouble);
+            il.Emit(OpCodes.Ret);
+
+            il.MarkLabel(blockedReturn);                    // non-extensible: leave length unchanged
             il.Emit(OpCodes.Ret);
         }
 
@@ -497,6 +522,17 @@ public partial class RuntimeEmitter
             il.Emit(OpCodes.Ldc_I4_1);
             il.Emit(OpCodes.Stfld, _tsArrayIsNumericField);
             il.MarkLabel(done);
+            il.Emit(OpCodes.Ret);
+        }
+
+        // ── void MarkNonExtensible() ── set _isNonExtensible so the unboxed PushDouble fast path refuses
+        // to append; called by Object.seal / Object.preventExtensions on a $Array (Object.freeze already
+        // sets _isFrozen via $Array.Freeze()). No deopt — the array may stay numeric and simply stop growing.
+        {
+            var il = markNonExtensible.GetILGenerator();
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldc_I4_1);
+            il.Emit(OpCodes.Stfld, _tsArrayNonExtensibleField);
             il.Emit(OpCodes.Ret);
         }
     }

--- a/Compilation/RuntimeEmitter.TSArray.cs
+++ b/Compilation/RuntimeEmitter.TSArray.cs
@@ -235,6 +235,34 @@ public partial class RuntimeEmitter
     }
 
     /// <summary>
+    /// Emits, into ANY runtime helper (not just <c>$Array</c>'s own methods), a
+    /// deopt of a numeric-mode <c>$Array</c> that the helper is about to read AS a
+    /// base <c>List&lt;object?&gt;</c> directly — the generic-consumption sites that
+    /// bypass <c>$Array</c>'s guarded methods because <c>$Array : List&lt;object?&gt;</c>
+    /// (string coercion / JSON / <c>Object.*</c> / call-spread / …). <paramref name="loadValue"/>
+    /// pushes the candidate value; this emits <c>if (v is $Array a) a.EnsureBoxed();</c>
+    /// (value re-loaded for the cast, so it leaves the stack exactly as found).
+    /// <c>EnsureBoxed</c> self-guards (no-op unless actually numeric) and materializes
+    /// <c>_numStore</c> back into the base list, so the subsequent <c>is List&lt;object&gt;</c>
+    /// read sees the elements. Costs one isinst on the cold generic-consumption path.
+    /// </summary>
+    private void EmitDeoptIfNumericArray(ILGenerator il, EmittedRuntime runtime, Action loadValue)
+    {
+        var skip = il.DefineLabel();
+        loadValue();
+        il.Emit(OpCodes.Isinst, runtime.TSArrayType);
+        il.Emit(OpCodes.Brfalse, skip);
+        loadValue();
+        il.Emit(OpCodes.Castclass, runtime.TSArrayType);
+        il.Emit(OpCodes.Callvirt, runtime.TSArrayEnsureBoxed);
+        il.MarkLabel(skip);
+    }
+
+    /// <summary>Convenience: <see cref="EmitDeoptIfNumericArray"/> for a method argument by index.</summary>
+    private void EmitDeoptArgIfNumericArray(ILGenerator il, EmittedRuntime runtime, int argIndex)
+        => EmitDeoptIfNumericArray(il, runtime, () => il.Emit(OpCodes.Ldarg, checked((short)argIndex)));
+
+    /// <summary>
     /// Emits the unboxed packed-double accessors on <c>$Array</c>:
     /// <c>GetDouble</c>/<c>SetDouble</c>/<c>PushDouble</c> (the fast paths the
     /// compiler will emit at statically-<c>number[]</c> sites) and

--- a/Compilation/RuntimeEmitter.TSArray.cs
+++ b/Compilation/RuntimeEmitter.TSArray.cs
@@ -817,8 +817,21 @@ public partial class RuntimeEmitter
     {
         var method = typeBuilder.DefineMethod("SyncLength", MethodAttributes.Private, _types.Void, Type.EmptyTypes);
         var il = method.GetILGenerator();
-        EmitTSArrayDeoptGuard(il);
         var doneLabel = il.DefineLabel();
+
+        // Numeric-aware (number[] unboxing): in numeric mode _length is the
+        // authoritative length (maintained by SetDouble/PushDouble) and the
+        // inherited base list is empty, so there is nothing to reconcile.
+        // Critically we must NOT deopt here — doing so would materialize the
+        // unboxed store on every `arr.length` read, defeating the win. Callers
+        // that genuinely touch the base list (GetLong/SetLong/HasIndex/GetRaw/
+        // SetLength/DeleteAt) carry their own EmitTSArrayDeoptGuard, which fires
+        // before they call SyncLength; by then mode is boxed and the reconcile
+        // below runs normally. The only callers reaching here still-numeric are
+        // the Length / LongLength getters, which read the authoritative _length.
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, _tsArrayIsNumericField);
+        il.Emit(OpCodes.Brtrue, doneLabel);
 
         // if (_sparse != null) return;
         il.Emit(OpCodes.Ldarg_0);

--- a/Compilation/RuntimeEmitter.TSArray.cs
+++ b/Compilation/RuntimeEmitter.TSArray.cs
@@ -28,6 +28,31 @@ public partial class RuntimeEmitter
     private FieldBuilder _tsArrayIsFrozenField = null!;
     private FieldBuilder _tsArrayIsSealedField = null!;
 
+    // ── Unboxed "packed-double" elements-kind (project: number[] unboxing) ────
+    // When _isNumeric is true the dense prefix [0, _numCount) lives unboxed in
+    // _numStore (a double[] grown geometrically), NOT in the inherited
+    // List<object?> base (which is empty in numeric mode). Holes are the
+    // reserved HoleNanBits pattern; genuine NaN is canonicalized on write so it
+    // never collides. A non-double write (or any base-List consumer) triggers
+    // EnsureBoxed, which materializes _numStore back into the base list and
+    // clears _isNumeric (deopt). All three default to the boxed mode
+    // (_isNumeric=false, _numStore=null, _numCount=0) so an unmodified program
+    // behaves exactly as before until creation/fast-path emission is wired.
+    private FieldBuilder _tsArrayNumStoreField = null!;
+    private FieldBuilder _tsArrayNumCountField = null!;
+    private FieldBuilder _tsArrayIsNumericField = null!;
+
+    /// <summary>
+    /// Reserved IEEE-754 bit pattern marking a HOLE in <c>_numStore</c>. A
+    /// quiet NaN distinct from the canonical JS NaN (<c>0x7FF8000000000000</c>),
+    /// so a genuine <c>NaN</c> element (canonicalized to the standard bits on
+    /// write) is never mistaken for a hole. Matches V8's hole-NaN choice.
+    /// </summary>
+    private const long HoleNanBits = unchecked((long)0xFFF7FFFFFFFFFFFFUL);
+
+    /// <summary>Canonical JS NaN bits — what a genuine NaN element is stored as.</summary>
+    private const long CanonicalNanBits = unchecked((long)0x7FF8000000000000UL);
+
     // Cached generic type for the sparse dictionary backing.
     private Type _tsArraySparseType = null!;
 
@@ -96,6 +121,14 @@ public partial class RuntimeEmitter
         _tsArrayIsSealedField = typeBuilder.DefineField("_isSealed", _types.Boolean, FieldAttributes.Private);
         // _tsArrayDenseField retired; every previous read-of-_dense is replaced
         // by a no-op (receiver is already the List via inheritance).
+
+        // Unboxed packed-double elements-kind (number[] unboxing project). All
+        // default to boxed mode; nothing reads them until creation/fast-path
+        // emission is wired in a later phase, so this is a zero-behavior-change
+        // addition (CLR zero-inits: _isNumeric=false, _numStore=null, _numCount=0).
+        _tsArrayNumStoreField = typeBuilder.DefineField("_numStore", _types.DoubleArray, FieldAttributes.Private);
+        _tsArrayNumCountField = typeBuilder.DefineField("_numCount", _types.Int32, FieldAttributes.Private);
+        _tsArrayIsNumericField = typeBuilder.DefineField("_isNumeric", _types.Boolean, FieldAttributes.Private);
 
         EmitTSArrayConstructor(typeBuilder, runtime);
 

--- a/Compilation/RuntimeEmitter.TSArray.cs
+++ b/Compilation/RuntimeEmitter.TSArray.cs
@@ -563,6 +563,9 @@ public partial class RuntimeEmitter
         runtime.TSArrayElementsGetter = getter;
 
         var il = getter.GetILGenerator();
+        // Elements hands out the inherited List<object?> directly; a numeric-mode
+        // array's base list is empty, so materialize first.
+        EmitTSArrayDeoptGuard(il);
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ret);
 

--- a/Compilation/RuntimeEmitter.TSArray.cs
+++ b/Compilation/RuntimeEmitter.TSArray.cs
@@ -1437,9 +1437,31 @@ public partial class RuntimeEmitter
         runtime.TSArrayGetLong = method;
 
         var il = method.GetILGenerator();
-        EmitTSArrayDeoptGuard(il);
         var oobLabel = il.DefineLabel();
         var notHoleLabel = il.DefineLabel();
+        var notNumeric = il.DefineLabel();
+
+        // Numeric-aware read (number[] unboxing): in numeric mode the elements live unboxed in _numStore;
+        // read directly + box the double, OOB → undefined, and crucially do NOT deopt — so a numeric array
+        // stays numeric across index reads, keeping interleaved read/write on the fast path. _numCount is
+        // authoritative; the unsigned compare also rejects negative indices. (Numeric mode is dense, so no
+        // hole check is needed here — gap writes deopt before they can punch a hole.)
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, _tsArrayIsNumericField);
+        il.Emit(OpCodes.Brfalse, notNumeric);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, _tsArrayNumCountField);
+        il.Emit(OpCodes.Conv_I8);
+        il.Emit(OpCodes.Bge_Un, oobLabel);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, _tsArrayNumStoreField);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Conv_I4);
+        il.Emit(OpCodes.Ldelem_R8);
+        il.Emit(OpCodes.Box, _types.Double);
+        il.Emit(OpCodes.Ret);
+        il.MarkLabel(notNumeric);
 
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Call, syncLength);

--- a/Compilation/RuntimeEmitter.TSArray.cs
+++ b/Compilation/RuntimeEmitter.TSArray.cs
@@ -191,7 +191,224 @@ public partial class RuntimeEmitter
         // IList<object?> impl is inherited from List<object?> — no explicit
         // bridges needed (was the old composition-based approach).
 
+        // Unboxed packed-double accessors (number[] unboxing project). Emitted
+        // after SetLong (SetDouble delegates the boxed/gap paths to it). Mode is
+        // never entered until creation/fast-path emission is wired, so these are
+        // dead-but-valid IL today.
+        EmitTSArrayNumericAccessors(typeBuilder, runtime);
+
         typeBuilder.CreateType();
+    }
+
+    /// <summary>
+    /// Emits the unboxed packed-double accessors on <c>$Array</c>:
+    /// <c>GetDouble</c>/<c>SetDouble</c>/<c>PushDouble</c> (the fast paths the
+    /// compiler will emit at statically-<c>number[]</c> sites) and
+    /// <c>EnsureBoxed</c> (the deopt that materializes the <c>double[]</c> store
+    /// back into the boxed base list). Numeric mode is dense-only for now: a
+    /// gap-creating write (<c>index &gt; _numCount</c>) deopts via EnsureBoxed
+    /// rather than punching a NaN-sentinel hole (that holey-fast upgrade is a
+    /// later phase). Until creation/fast-path emission is wired these are
+    /// emitted-but-uncalled — valid IL, zero behavior change.
+    /// </summary>
+    private void EmitTSArrayNumericAccessors(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    {
+        var arrayResize = typeof(System.Array).GetMethod("Resize")!.MakeGenericMethod(_types.Double);
+
+        // Define all four first so the bodies can reference one another.
+        var ensureBoxed = typeBuilder.DefineMethod("EnsureBoxed",
+            MethodAttributes.Public | MethodAttributes.HideBySig, _types.Void, System.Type.EmptyTypes);
+        runtime.TSArrayEnsureBoxed = ensureBoxed;
+        var getDouble = typeBuilder.DefineMethod("GetDouble",
+            MethodAttributes.Public | MethodAttributes.HideBySig, _types.Double, [_types.Int32]);
+        runtime.TSArrayGetDouble = getDouble;
+        var setDouble = typeBuilder.DefineMethod("SetDouble",
+            MethodAttributes.Public | MethodAttributes.HideBySig, _types.Void, [_types.Int32, _types.Double]);
+        runtime.TSArraySetDouble = setDouble;
+        var pushDouble = typeBuilder.DefineMethod("PushDouble",
+            MethodAttributes.Public | MethodAttributes.HideBySig, _types.Void, [_types.Double]);
+        runtime.TSArrayPushDouble = pushDouble;
+
+        // ── void EnsureBoxed() ── numeric -> boxed: box each _numStore[i] into
+        // the (empty) base list, then clear the numeric mode.
+        {
+            var il = ensureBoxed.GetILGenerator();
+            var done = il.DefineLabel();
+            var loop = il.DefineLabel();
+            var loopCheck = il.DefineLabel();
+            var i = il.DeclareLocal(_types.Int32);
+
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, _tsArrayIsNumericField);
+            il.Emit(OpCodes.Brfalse, done);
+
+            il.Emit(OpCodes.Ldc_I4_0);
+            il.Emit(OpCodes.Stloc, i);
+            il.Emit(OpCodes.Br, loopCheck);
+            il.MarkLabel(loop);
+            il.Emit(OpCodes.Ldarg_0);                       // Add receiver (this : List)
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, _tsArrayNumStoreField);
+            il.Emit(OpCodes.Ldloc, i);
+            il.Emit(OpCodes.Ldelem_R8);
+            il.Emit(OpCodes.Box, _types.Double);
+            il.Emit(OpCodes.Callvirt, _tsArrayListAdd!);
+            il.Emit(OpCodes.Ldloc, i);
+            il.Emit(OpCodes.Ldc_I4_1);
+            il.Emit(OpCodes.Add);
+            il.Emit(OpCodes.Stloc, i);
+            il.MarkLabel(loopCheck);
+            il.Emit(OpCodes.Ldloc, i);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, _tsArrayNumCountField);
+            il.Emit(OpCodes.Blt, loop);
+
+            il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Ldc_I4_0); il.Emit(OpCodes.Stfld, _tsArrayIsNumericField);
+            il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Ldnull); il.Emit(OpCodes.Stfld, _tsArrayNumStoreField);
+            il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Ldc_I4_0); il.Emit(OpCodes.Stfld, _tsArrayNumCountField);
+
+            il.MarkLabel(done);
+            il.Emit(OpCodes.Ret);
+        }
+
+        // ── double GetDouble(int index) ──
+        {
+            var il = getDouble.GetILGenerator();
+            var boxed = il.DefineLabel();
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, _tsArrayIsNumericField);
+            il.Emit(OpCodes.Brfalse, boxed);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, _tsArrayNumStoreField);
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Ldelem_R8);
+            il.Emit(OpCodes.Ret);
+            il.MarkLabel(boxed);                            // (double) base[index]
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Callvirt, _tsArrayListGetItem!);
+            il.Emit(OpCodes.Unbox_Any, _types.Double);
+            il.Emit(OpCodes.Ret);
+        }
+
+        // ── void SetDouble(int index, double value) ──
+        {
+            var il = setDouble.GetILGenerator();
+            var notNumeric = il.DefineLabel();
+            var notOverwrite = il.DefineLabel();
+            var gap = il.DefineLabel();
+            var hasStore = il.DefineLabel();
+            var doStore = il.DefineLabel();
+
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, _tsArrayIsNumericField);
+            il.Emit(OpCodes.Brfalse, notNumeric);
+
+            // overwrite in range: if (index < _numCount) { _numStore[index] = value; return; }
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, _tsArrayNumCountField);
+            il.Emit(OpCodes.Bge, notOverwrite);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, _tsArrayNumStoreField);
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Ldarg_2);
+            il.Emit(OpCodes.Stelem_R8);
+            il.Emit(OpCodes.Ret);
+
+            il.MarkLabel(notOverwrite);
+            // gap write (index > _numCount): deopt then boxed set
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, _tsArrayNumCountField);
+            il.Emit(OpCodes.Bgt, gap);
+
+            // append at _numCount: ensure capacity
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, _tsArrayNumStoreField);
+            il.Emit(OpCodes.Brtrue, hasStore);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldc_I4_4);
+            il.Emit(OpCodes.Newarr, _types.Double);
+            il.Emit(OpCodes.Stfld, _tsArrayNumStoreField);
+            il.Emit(OpCodes.Br, doStore);
+            il.MarkLabel(hasStore);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, _tsArrayNumCountField);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, _tsArrayNumStoreField);
+            il.Emit(OpCodes.Ldlen);
+            il.Emit(OpCodes.Conv_I4);
+            il.Emit(OpCodes.Bne_Un, doStore);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldflda, _tsArrayNumStoreField);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, _tsArrayNumCountField);
+            il.Emit(OpCodes.Ldc_I4_2);
+            il.Emit(OpCodes.Mul);
+            il.Emit(OpCodes.Call, arrayResize);
+
+            il.MarkLabel(doStore);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, _tsArrayNumStoreField);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, _tsArrayNumCountField);
+            il.Emit(OpCodes.Ldarg_2);
+            il.Emit(OpCodes.Stelem_R8);
+            il.Emit(OpCodes.Ldarg_0);                       // _numCount++
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, _tsArrayNumCountField);
+            il.Emit(OpCodes.Ldc_I4_1);
+            il.Emit(OpCodes.Add);
+            il.Emit(OpCodes.Stfld, _tsArrayNumCountField);
+            il.Emit(OpCodes.Ldarg_0);                       // _length = (long)_numCount
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, _tsArrayNumCountField);
+            il.Emit(OpCodes.Conv_I8);
+            il.Emit(OpCodes.Stfld, _tsArrayLengthField);
+            il.Emit(OpCodes.Ret);
+
+            il.MarkLabel(gap);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Call, ensureBoxed);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Conv_I8);
+            il.Emit(OpCodes.Ldarg_2);
+            il.Emit(OpCodes.Box, _types.Double);
+            il.Emit(OpCodes.Call, runtime.TSArraySetLong);
+            il.Emit(OpCodes.Ret);
+
+            il.MarkLabel(notNumeric);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Conv_I8);
+            il.Emit(OpCodes.Ldarg_2);
+            il.Emit(OpCodes.Box, _types.Double);
+            il.Emit(OpCodes.Call, runtime.TSArraySetLong);
+            il.Emit(OpCodes.Ret);
+        }
+
+        // ── void PushDouble(double value) ── append at the current length.
+        {
+            var il = pushDouble.GetILGenerator();
+            var useNum = il.DefineLabel();
+            var haveIndex = il.DefineLabel();
+            il.Emit(OpCodes.Ldarg_0);                       // SetDouble receiver
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, _tsArrayIsNumericField);
+            il.Emit(OpCodes.Brtrue, useNum);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Callvirt, _tsArrayListCountGetter!);
+            il.Emit(OpCodes.Br, haveIndex);
+            il.MarkLabel(useNum);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, _tsArrayNumCountField);
+            il.MarkLabel(haveIndex);
+            il.Emit(OpCodes.Ldarg_1);                       // value
+            il.Emit(OpCodes.Call, setDouble);
+            il.Emit(OpCodes.Ret);
+        }
     }
 
     private void EmitTSArrayConstructor(TypeBuilder typeBuilder, EmittedRuntime runtime)

--- a/Compilation/RuntimeEmitter.Worker.cs
+++ b/Compilation/RuntimeEmitter.Worker.cs
@@ -1503,6 +1503,8 @@ public partial class RuntimeEmitter
 
         // List<object> deep clone.
         coreIl.MarkLabel(checkList);
+        // number[] unboxing: materialize a numeric-mode $Array before deep-cloning its base list.
+        EmitDeoptArgIfNumericArray(coreIl, runtime, 0);
         coreIl.Emit(OpCodes.Ldarg_0);
         coreIl.Emit(OpCodes.Isinst, _types.ListOfObject);
         coreIl.Emit(OpCodes.Stloc, sourceListLocal);

--- a/benchmarks/scripts/num-arrays.ts
+++ b/benchmarks/scripts/num-arrays.ts
@@ -1,0 +1,51 @@
+import { bench } from "./lib/bench.ts";
+
+// Plain `number[]` (NOT a typed array — see int-arrays.ts / typed-arrays.ts for
+// those). Each array ESCAPES (it is passed to a helper / is module-level), so it
+// is the numeric-$Array "PACKED_DOUBLE" elements-kind, not a non-escaping
+// List<double> local. This is the param/field/module-level write pattern that
+// boxed a double per element write before the unboxed elements-kind — measured at
+// ~73x Node, the gap this targets. A non-escaping local would instead promote to
+// List<double> and is covered implicitly elsewhere.
+
+// Index-write: build by index through a helper (so the array escapes), then a
+// read pass for a checksum. The dominant cost is the per-element write.
+function fillIndex(a: number[], n: number): void {
+    for (let i: number = 0; i < n; i++) {
+        a[i] = i * 3;
+    }
+}
+function numWrite(n: number): number {
+    const a: number[] = [];
+    fillIndex(a, n);
+    let sum: number = 0;
+    for (let i: number = 0; i < n; i++) {
+        sum = sum + a[i];
+    }
+    return sum;
+}
+
+// Push-built: append n elements through a helper, then a read pass. Measures the
+// growth + append path rather than fixed-index stores.
+function fillPush(a: number[], n: number): void {
+    for (let i: number = 0; i < n; i++) {
+        a.push(i * 3);
+    }
+}
+function numPush(n: number): number {
+    const a: number[] = [];
+    fillPush(a, n);
+    let sum: number = 0;
+    for (let i: number = 0; i < n; i++) {
+        sum = sum + a[i];
+    }
+    return sum;
+}
+
+const params: number[] = [1000, 100000, 1000000];
+for (let p: number = 0; p < params.length; p++) {
+    bench("num-write", params[p], () => numWrite(params[p]));
+}
+for (let p: number = 0; p < params.length; p++) {
+    bench("num-push", params[p], () => numPush(params[p]));
+}

--- a/docs/design/number-array-unboxing.md
+++ b/docs/design/number-array-unboxing.md
@@ -1,0 +1,53 @@
+# Design: closing the `number[]` boxing gap (Option A)
+
+## The gap (measured)
+Compiled `number[]` at params/fields boxes a `double` per element WRITE → ~73–80x slower than Node for write-heavy code; ~14x for read-heavy. Promoted-LOCAL `number[]` (unboxed `List<double>`) is only ~3.5x Node. The tax is the boxing at the boundary.
+
+## Representation landscape (confirmed in code)
+- **Interpreter:** `Runtime/Types/SharpTSArray.cs` — composition over `Deque<object?>` + sparse `Dictionary`, holes, length, freeze.
+- **Compiled:** emitted `$Array` (`RuntimeEmitter.TSArray.cs`) — **inherits `List<object?>`** (the base list IS the dense store). ~48 IL emitter sites do `isinst List<object?>` to mean "is an array". Must stay in sync with `SharpTSArray`.
+- **Promoted locals:** raw `List<double>`/`List<bool>` — a *separate* type, only for `number[]`/`boolean[]` locals the `ArrayLocalPromotionAnalyzer` proves never escape (not passed, returned, stored, aliased, captured, or used by any method beyond push/map/filter/reduce).
+
+## The two candidate architectures
+
+### A. `List<double>` end-to-end (extend promotion across boundaries + coerce at the `any` boundary)
+Make `number[]` compile to `List<double>` for params/fields/returns too; insert `List<double>↔$Array` conversions wherever a `number[]` meets a non-`number[]` static type.
+- **Reuses** existing unboxed machinery (`SetArrayElementDouble`, `ArrayMapDouble`, the descriptor).
+- **FATAL FLAW — unsound for aliased arrays.** Arrays are mutable *reference* types. A boundary coercion `List<double> → $Array` **copies** (different CLR object), so:
+  ```ts
+  const a: number[] = []; const b: any = a; b.push(1); a.length // must be 1
+  ```
+  breaks — `b` becomes a *copied* `$Array`, mutations don't reflect in `a`. The existing promoted-LOCAL path is sound *only because* the analyzer forbids exactly these escapes; params/fields are inherently aliasable, so the forbiddance can't extend. **A cannot be made sound** without whole-program alias analysis (infeasible). ❌
+
+### B. Elements-kind on `$Array` (V8 PACKED_DOUBLE_ELEMENTS), identity-preserving
+Keep ONE `$Array` object (identity preserved — aliasing works); give it an internal **unboxed double storage mode** + a deopt-to-boxed transition on any non-double write. Compiler emits unboxed `GetDouble`/`SetDouble`/`PushDouble` at statically-`number[]` sites (local/param/field/return uniformly, since they're all `$Array`).
+- **Sound** — object identity preserved, so aliasing across `number[]`/`any` is correct; deopt handles unsound casts (`any → number[]`).
+- **This is the only sound general design.** ✅
+- **BLOCKER — the inheritance.** `$Array : List<object?>` ⇒ the element store *is* a `List<object?>`; you cannot put unboxed doubles in it. Options:
+  - **B1: shadow `List<double>` field**, base `List<object?>` unused in double-mode. Requires **every** element access to funnel through mode-aware `$Array` methods — but the inheritance was chosen *specifically so* the ~48 emitter sites + built-ins can use the base `List<object?>` API **directly**. Must audit + reroute all direct base-list access. Large.
+  - **B2: break the inheritance** (compose instead) — then fix all ~48 `isinst List<object?>` sites + everything using the base API. Larger.
+
+## Verdict
+- The **sound** way to close the gap generally is **B** (identity-preserving elements-kind).
+- B is a **foundational, multi-week, high-regression-risk** change to the single most-used runtime type, fighting the deliberate `$Array : List<object?>` inheritance, duplicated across interp + emitted-IL (+ standalone), with deopt-correctness obligations across the entire array-mutator + built-in surface, gated by 14k tests + Test262 at every step.
+- **A is unsound** (breaks array aliasing) and must be rejected for the general case.
+
+## Phasing for B (if pursued)
+1. Audit: does every `$Array` element access (the ~48 sites + all built-ins) go through `$Array` methods, or hit the base `List<object?>` API directly? (Determines B1 feasibility / size.)
+2. Add double-store + mode flag + central mode-aware Get/SetCore + deopt to emitted `$Array` (and `SharpTSArray` twin); ZERO behavior change (mode never entered yet). Gate.
+3. `number[]`-typed array creation enters double-mode. Gate.
+4. Emit `Get/SetDouble`/`PushDouble` at `number[]` sites. Re-benchmark. Gate.
+5. Extend built-ins to operate on the double store directly; `boolean[]`.
+
+## Phase-1 audit result (2026-06-23)
+- Element access does NOT funnel through `$Array` methods: `SetArrayElement(List<object?>, i, v)` and ~62 `Arrays.*` built-in helpers operate on the base `List<object?>` API directly (`list[i]`, `.Add`, `.Count`). Base API is non-virtual → not interceptable.
+- BUT access is centralized through typed helpers the compiler picks by static descriptor (`SetArrayElement` vs `SetArrayElementDouble`, `EmitSetArrayElementFor`). The compiler knows `number[]` statically at the emit site → the hook.
+- Design = deopt-at-compiler-boundaries, not reroute-every-site:
+  - Hot ops (index get/set, push, length): ~6–8 double-aware fast-path emit sites.
+  - Cold built-ins + `number[]→any/object` widening: compiler emits one-time deopt (materialize `double[]`→boxed base list, flip mode). ~55 cold built-in bodies + ~48 runtime isinst sites UNCHANGED (only see boxed arrays).
+- Only the EMITTED `$Array` needs changing; interp `SharpTSArray` parity is observable-only (stays boxed). Single-representation change.
+- Backing store = raw `double[] + count`, geometric growth, direct/Unsafe access (per Nick's instinct; ceiling ~1.1x Node vs List<double> ~4x). Growth reallocs `$Array._store`; object identity preserved → aliasing sound.
+- Core risk = deopt-completeness (every compiler boundary to base-list consumers must deopt; bounded by type-checker coercion points; miss one = silent corruption). Gated by Test262 + suite per phase.
+
+## Sound contained alternative (not general, but real)
+Extend `ArrayLocalPromotionAnalyzer` to promote MORE *local* `number[]` (it's sound for locals — no aliasing). Today it disqualifies on `pop`/`shift`/`forEach`/`for-of`/compound-assign/most methods. Broadening these captures more local hot loops with **low risk, no representation change** — but does NOT touch the param/field 73x case.


### PR DESCRIPTION
## What & why

Compiled `number[]` at params/fields/module-level boxed a `double` per element **write** — ~73× slower than Node for write-heavy code (a `double` heap-boxed into the `$Array`'s `List<object>` per `a[i]=v`). This PR gives the emitted `$Array` a V8-style **PACKED_DOUBLE elements-kind**: when an escaping `number[]` is created, its elements live in an unboxed `double[]` (`_numStore`) with the inherited `List<object>` left empty, so index writes/reads and `push` stay fully unboxed.

The original 73× param/field write-boxing gap is closed.

## Measured (this machine; numeric ≡ Node correctness on all)

**Synthetic micro-repros** (isolate the element op; numeric vs the old boxed `$Array`):

| Workload | boxed `$Array` | numeric `$Array` | vs Node |
|---|---|---|---|
| index write (`for a[i]=i`), 1M × 20 | ~2120 ms | **~91 ms (~23×)** | ~2.2× |
| push (`for a.push(i)`), 20M into one array | ~1320 ms | **~127 ms (~10×)** | **faster than Node** (~164 ms) |
| interleaved write+read (`a[i]=i; s+=a[i]`), 1M × 20 | ~2200 ms (read deopted) | **~290 ms (~7×)** | ~5.5× |

**In-suite benchmark** — `benchmarks/scripts/num-arrays.ts`, **added in this PR** so the win is verifiable in CI (escaping `number[]`, 1M, median ms):

| Case | compiled | Node | Bun | vs Node |
|---|---|---|---|---|
| num-write (index fill + read pass) | 25.1 | 9.7 | 5.0 | ~2.6× |
| num-push (append + read pass) | 19.7 | 9.8 | 4.8 | ~2.0× |

≈2.0–2.6× Node, down from ~73× before the elements-kind. The residual is the box-per-read in the checksum pass (the read-site `GetDouble` refinement noted below) plus per-call allocation — the pure write is ~2.2× (top table).

**No regression on the existing suite** (`run-benchmarks.ps1`): compiled is *faster than Node* on array-methods (1.57 vs 2.69 ms) and fibonacci (30 vs 75 ms), ~par on count-primes. The weak cases (sort = boxed comparator dispatch; typed-array kernels) are pre-existing and unrelated to `number[]` boxing.

## How it works

- **Representation.** `$Array` (which inherits `List<object>`) gains `_numStore: double[]` + `_numCount: int` + `_isNumeric: bool`. In numeric mode the base list is empty and elements live unboxed in `_numStore` (raw `double[]`, geometric growth). Identity-preserving — the array stays one object, so aliasing across `number[]`/`any` is sound (the `List<double>` end-to-end alternative was rejected as unsound: a boundary coercion would *copy* and break aliasing).
- **Fast paths.** The compiler emits `SetDouble`/`GetDouble`/`PushDouble` (mode-checked) at statically-`number[]` sites: numeric → straight into `_numStore`; boxed → delegates to the existing boxed path. Index reads (`Get`) and `.length` are numeric-aware (read `_numStore`/`_length`, no deopt) so interleaved read/write stays on the fast path.
- **Deopt to boxed.** Any operation the fast paths don't cover materializes `_numStore` back into the base list (`EnsureBoxed`) and clears `_isNumeric` — correctness-preserving, one-way, on first touch. Creation is wired for module-level, function-local, and class-field escaping `number[]`.

## Soundness — and the most important reviewer note

A numeric `$Array` masquerades as an **empty** `List<object>` (it inherits `List<object>` but the base list is empty in numeric mode). Any runtime helper that does `is List<object>` and reads the base list directly would observe an empty array → silent corruption. This PR deopts every such reachable consumer (`ToJsString`/`Stringify`, JSON `Stringify*`, `ConsoleLog`/table, `Object.keys/values/entries`/`ObjectAssign`, call-spread `SpreadArray`, `new Set`/`new Map`, `structuredClone`), found by an audit of the emitted runtime **cross-checked against a 60+ case differential repro battery vs Node**.

> ⚠️ **The 14021-test xUnit suite is GREEN even when serialization corruption is present** — no test serializes a *still-numeric* module-level `number[]`, and Test262's JS is untyped so it never creates one. **The differential repro battery vs Node is the real oracle for this change, not the suite.** Please keep this in mind when reasoning about the deopt-completeness surface.

## Scope: two representations, unify deferred (on purpose)

This ships the **escaping** case (params/fields/module-level — the actual 73× problem). Non-escaping `number[]` locals keep their existing `List<double>` promotion. Collapsing to a single representation (deleting `List<double>`) was scoped and **intentionally deferred**: measurement shows numeric `$Array` is ~15% faster than `List<double>` for reused/steady-state arrays but ~1.5× *slower* for fresh-per-call append-heavy locals (`List<double>` is a tuned path — loop-hoisted cast + BCL `List.Add`). Deleting `List<double>` would regress that pattern until the numeric append path is optimized (hoist-for-`$Array` + `Unsafe`). The plan is documented; not in this PR.

## Known-latent / not-yet-covered creation paths (all sound — just boxed, not numeric)

- **Class fields:** numeric creation is correct and emits `SetDouble`, but `this.arr[i]=v` throughput is dominated by the per-iteration **field access** (`_extras` dict lookup), not array boxing — the object-shape/hidden-class concern (separate issue), so the field win is latent.
- **Captured module-level `number[]`:** a module-level array referenced by a closure routes to the display-class path, which the creation hook doesn't cover yet, so it stays boxed (correct, just not unboxed). Rare; function-local and uncaptured module-level arrays are numeric.
- **Read-site unbox:** index *reads* return a boxed `double` (`GetDouble`-at-read-site was prototyped and reverted — it needs the type checker to resolve `arr[i]` to `number`); this is the residual on read-heavy loops.

Module-level and function-local write/push wins are real and unaffected.

## Testing

- Full xUnit suite **14021 / 0** green at every commit; IL verification clean.
- Differential repro battery (string/template/`String()`, JSON incl. nested + array-of-arrays, `Object.*`, spread-into-call, `new Set`/`Map`, `structuredClone`, typed-array-from, `flat`/`flatMap`/`reverse`/`sort`/`at`/`includes`/`findLast`/`Promise.all`, for-of, destructuring, object-field + Map-value aliasing, dynamic `any` methods, `.call`/`.apply`) — all numeric ≡ boxed ≡ Node.
- Standalone-DLL guard green (the new runtime is pure-BCL: `double[]`/`Array.Resize`/`Unsafe`).

## Commit-history note

`30fc5453` ("disable") → `a23af32f` ("re-enable") is honest history: live numeric creation surfaced the serialization deopt gap, so creation was disabled while the complete generic-consumption deopt was built, then re-enabled. Kept as-is for the diagnostic trail; happy to squash if linear history is preferred.

## CI caveats (pre-existing, not from this change)

- macOS CI may go red on a flaky 10-min test-step timeout (#198) — re-run.
- Test262 isn't in the solution (invoked explicitly); its compiled in-process run crashes the host and its interp baseline has pre-existing drift. This change is compiler-only — the interpreter is untouched and no baselines are modified.
