### PR TITLE
fix(compiled): route async throw-await + unify suspension walkers (#914)

### DIFF
--- a/Compilation/AsyncFunctionMoveNextEmitter.TryCatch.cs
+++ b/Compilation/AsyncFunctionMoveNextEmitter.TryCatch.cs
@@ -5,6 +5,102 @@ namespace SharpTS.Compilation;
 
 public abstract partial class AsyncFunctionMoveNextEmitter
 {
+    // ---- Suspending-throw routing in a flag-based try body (#914) -------------------------------
+    // `throw <expr-with-await>` in a try body is a segment-breaker: it is emitted at the top level,
+    // outside the sync-segment mini try/catch that captures ordinary throws (EmitSegmentInTry). A raw
+    // CLR throw there escapes the guest try and faults the Task instead of reaching `catch`. We route it
+    // into the active flag-based try exactly as a captured await-rejection is (EmitAwaitGetResult /
+    // EmitGuardedSyncSegment): store the value into the try's exception local and branch to its catch
+    // dispatch, running any finally(s) strictly inside the try first. A non-suspending throw is captured
+    // by its mini try/catch and never reaches here; a handler-body throw is handled by the existing
+    // nested-catch wrap — both run with _throwRoutingGuardDepth > 0.
+
+    // Count of real-IL guest exception blocks open around the current emission point (the sync-segment
+    // mini try/catch, the nested-catch wrap, the no-await / simple try blocks, and the for-await guarded
+    // sync segment). While > 0 a real-IL handler already owns any throw, so routing must defer. This is
+    // deliberately independent of CompilationContext.ExceptionBlockDepth — which the async functions key
+    // the break/continue Leave-vs-Br choice off (#727) and which the segment/wrap sites do not bump — and
+    // of the base ProtectedRegionDepth. Protected so the for-await loop emitter (a subclass partial) can
+    // bump it around its own guarded sync segment.
+    protected int _throwRoutingGuardDepth;
+
+    // _exitScopes.Count captured at the start of the flag-based try body whose exception local is
+    // _currentTryCatchExceptionLocal; selects the finally(s) strictly inside that try for a routed throw.
+    private int _currentTryCatchScopeDepth;
+
+    // <>pendingException (object): holds a routed throw value across an intervening finally that itself
+    // suspends, until the routing terminal moves it into the try's exception local.
+    private FieldBuilder? _pendingExceptionField;
+    private FieldBuilder GetPendingExceptionField() =>
+        _pendingExceptionField ??= DefineStateMachineField("<>pendingException", typeof(object));
+
+    protected override void EmitThrow(Stmt.Throw t)
+    {
+        // Only a top-level throw inside a flag-based try body reaches here un-guarded; route it to that
+        // try's catch. Everything else (guarded throws, handler-body throws, throws with no enclosing
+        // flag-based try) falls through to the base raw throw, which the relevant real-IL handler or the
+        // outer MoveNext catch (→ Task fault) already handles.
+        if (_currentTryCatchExceptionLocal != null && _currentTryCatchSkipLabel != null
+            && _throwRoutingGuardDepth == 0)
+        {
+            RouteThrowIntoCurrentTry(() => { EmitExpression(t.Value); EnsureBoxed(); });
+            return;
+        }
+
+        base.EmitThrow(t);
+    }
+
+    /// <summary>
+    /// Routes a guest throw escaping the top level of a flag-based try body into that try: stores the
+    /// value into its exception local and branches to its catch dispatch (<see
+    /// cref="_currentTryCatchSkipLabel"/>, which is null-gated on the local so no separate present flag is
+    /// needed). Any finally(s) strictly inside the try run first; because such a finally can await, the
+    /// value is held in <c>&lt;&gt;pendingException</c> across them and moved into the exception local by
+    /// the routing terminal (#914, the async-function analog of the generators' throw routing).
+    /// </summary>
+    private void RouteThrowIntoCurrentTry(Action loadValue)
+    {
+        var exLocal = _currentTryCatchExceptionLocal!;
+        var skip = _currentTryCatchSkipLabel!.Value;
+        var chain = FinallyFramesInside(_currentTryCatchScopeDepth);
+        if (chain.Count == 0)
+        {
+            loadValue();
+            IL.Emit(OpCodes.Stloc, exLocal);
+            IL.Emit(OpCodes.Br, skip);
+            return;
+        }
+
+        // Intervening finally(s) may await, so hold the value in a field across them; the routing terminal
+        // moves it into the try's exception local and branches to its catch dispatch.
+        IL.Emit(OpCodes.Ldarg_0);
+        loadValue();
+        IL.Emit(OpCodes.Stfld, GetPendingExceptionField());
+        int code = _nextExitCode++;
+        _exitTerminals[code] = () =>
+        {
+            IL.Emit(OpCodes.Ldarg_0);
+            IL.Emit(OpCodes.Ldfld, GetPendingExceptionField());
+            IL.Emit(OpCodes.Stloc, exLocal);
+            IL.Emit(OpCodes.Br, skip);
+        };
+        RouteThroughFinallys(chain, code, OpCodes.Br);
+    }
+
+    /// <summary>
+    /// The finally scopes strictly inside the flag-based try whose body began at <paramref
+    /// name="scopeDepth"/> (= <c>_exitScopes.Count</c> there), innermost first. Excludes the try's own
+    /// finally (just below scopeDepth, run by the normal catch→finally flow) and everything outside it.
+    /// </summary>
+    private List<FinallyScope> FinallyFramesInside(int scopeDepth)
+    {
+        var result = new List<FinallyScope>();
+        for (int i = _exitScopes.Count - 1; i >= scopeDepth; i--)
+            if (_exitScopes[i] is FinallyScope fs)
+                result.Add(fs);
+        return result;
+    }
+
     protected override void EmitTryCatch(Stmt.TryCatch t)
     {
         // Check if this try block contains any await points
@@ -33,6 +129,7 @@ public abstract partial class AsyncFunctionMoveNextEmitter
         // segments), so a break targeting a loop nested inside the try stays a legal in-region `Br`
         // while an escaping break/continue leaves via `Leave` (#727).
         Ctx.ExceptionBlockDepth++;
+        _throwRoutingGuardDepth++;
         IL.BeginExceptionBlock();
 
         // Emit try block statements
@@ -75,6 +172,7 @@ public abstract partial class AsyncFunctionMoveNextEmitter
 
         IL.EndExceptionBlock();
         Ctx.ExceptionBlockDepth--;
+        _throwRoutingGuardDepth--;
     }
 
     private void EmitTryCatchWithAwaits(Stmt.TryCatch t, bool hasAwaitsInTry, bool hasAwaitsInCatch, bool hasAwaitsInFinally)
@@ -119,6 +217,7 @@ public abstract partial class AsyncFunctionMoveNextEmitter
             // IL exception block, so a non-local exit crossing it must Leave, not Br — bump
             // ExceptionBlockDepth so EmitBranchToLabel / the routing pick Leave to the cleanup (#774).
             Ctx.ExceptionBlockDepth++;
+            _throwRoutingGuardDepth++;
             IL.BeginExceptionBlock();
             foreach (var stmt in t.TryBlock)
                 EmitStatement(stmt);
@@ -130,12 +229,14 @@ public abstract partial class AsyncFunctionMoveNextEmitter
 
             IL.EndExceptionBlock();
             Ctx.ExceptionBlockDepth--;
+            _throwRoutingGuardDepth--;
         }
         else
         {
             // No awaits in try or finally - use normal try block. Same real-IL-block reasoning as above:
             // bump ExceptionBlockDepth so a non-local exit crossing this try Leaves to the cleanup (#774).
             Ctx.ExceptionBlockDepth++;
+            _throwRoutingGuardDepth++;
             IL.BeginExceptionBlock();
             foreach (var stmt in t.TryBlock)
                 EmitStatement(stmt);
@@ -148,6 +249,7 @@ public abstract partial class AsyncFunctionMoveNextEmitter
             }
             IL.EndExceptionBlock();
             Ctx.ExceptionBlockDepth--;
+            _throwRoutingGuardDepth--;
         }
 
         // Cleanup entry: normal completion falls here, and a routed non-local exit branches here. The
@@ -184,8 +286,10 @@ public abstract partial class AsyncFunctionMoveNextEmitter
                 // We're nested inside another try-with-awaits
                 // Wrap catch block in try/catch to propagate exceptions outward
                 IL.BeginExceptionBlock();
+                _throwRoutingGuardDepth++;
                 foreach (var stmt in t.CatchBlock)
                     EmitStatement(stmt);
+                _throwRoutingGuardDepth--;
                 IL.BeginCatchBlock(typeof(Exception));
                 IL.Emit(OpCodes.Call, Ctx.Runtime!.WrapException);
                 IL.Emit(OpCodes.Stloc, outerExceptionLocal);
@@ -274,9 +378,13 @@ public abstract partial class AsyncFunctionMoveNextEmitter
         // Set context for await exception handling
         var previousExceptionLocal = _currentTryCatchExceptionLocal;
         var previousSkipLabel = _currentTryCatchSkipLabel;
+        var previousScopeDepth = _currentTryCatchScopeDepth;
         var afterTryLabel = IL.DefineLabel();
         _currentTryCatchExceptionLocal = caughtExceptionLocal;
         _currentTryCatchSkipLabel = afterTryLabel;
+        // Finally(s) pushed after this point are strictly inside this try; a routed throw runs them
+        // before reaching its catch (the try's own finally, pushed just before the body, is excluded).
+        _currentTryCatchScopeDepth = _exitScopes.Count;
 
         List<Stmt> syncSegment = [];
 
@@ -332,13 +440,16 @@ public abstract partial class AsyncFunctionMoveNextEmitter
         // try with no exit target).
         _currentTryCatchExceptionLocal = previousExceptionLocal;
         _currentTryCatchSkipLabel = previousSkipLabel;
+        _currentTryCatchScopeDepth = previousScopeDepth;
     }
 
     private void EmitSegmentInTry(List<Stmt> statements, LocalBuilder caughtExceptionLocal)
     {
         IL.BeginExceptionBlock();
+        _throwRoutingGuardDepth++;
         foreach (var stmt in statements)
             EmitStatement(stmt);
+        _throwRoutingGuardDepth--;
 
         IL.BeginCatchBlock(typeof(Exception));
         IL.Emit(OpCodes.Call, Ctx.Runtime!.WrapException);
@@ -419,49 +530,12 @@ public abstract partial class AsyncFunctionMoveNextEmitter
         }
     }
 
-    protected bool ContainsAwaitInExpr(Expr expr)
-    {
-        switch (expr)
-        {
-            case Expr.Await:
-                return true;
-            case Expr.Comma c:
-                return ContainsAwaitInExpr(c.Left) || ContainsAwaitInExpr(c.Right);
-            case Expr.Binary b:
-                return ContainsAwaitInExpr(b.Left) || ContainsAwaitInExpr(b.Right);
-            case Expr.Logical l:
-                return ContainsAwaitInExpr(l.Left) || ContainsAwaitInExpr(l.Right);
-            case Expr.Unary u:
-                return ContainsAwaitInExpr(u.Right);
-            case Expr.Delete d:
-                return ContainsAwaitInExpr(d.Operand);
-            case Expr.Grouping g:
-                return ContainsAwaitInExpr(g.Expression);
-            case Expr.Call c:
-                if (ContainsAwaitInExpr(c.Callee)) return true;
-                foreach (var arg in c.Arguments)
-                    if (ContainsAwaitInExpr(arg)) return true;
-                return false;
-            case Expr.Assign a:
-                return ContainsAwaitInExpr(a.Value);
-            case Expr.Ternary t:
-                return ContainsAwaitInExpr(t.Condition) ||
-                       ContainsAwaitInExpr(t.ThenBranch) ||
-                       ContainsAwaitInExpr(t.ElseBranch);
-            case Expr.Get g:
-                return ContainsAwaitInExpr(g.Object);
-            case Expr.Set s:
-                return ContainsAwaitInExpr(s.Object) || ContainsAwaitInExpr(s.Value);
-            // Parity with ContainsYieldInExpr: `a[i] += await f()`, `a[await i()]`,
-            // and `a[i] = await f()` inside a try must report suspension (#850).
-            case Expr.CompoundAssign ca:
-                return ContainsAwaitInExpr(ca.Value);
-            case Expr.GetIndex gi:
-                return ContainsAwaitInExpr(gi.Object) || ContainsAwaitInExpr(gi.Index);
-            case Expr.SetIndex si:
-                return ContainsAwaitInExpr(si.Object) || ContainsAwaitInExpr(si.Index) || ContainsAwaitInExpr(si.Value);
-            default:
-                return false;
-        }
-    }
+    // Delegates to the canonical, exhaustive suspension walker shared by every state-machine emitter
+    // (ExpressionEmitterBase.ExprContainsSuspension). The previous hand-maintained switch had drifted
+    // and was missing CompoundSetIndex/CompoundSet/LogicalAssign/LogicalSet/LogicalSetIndex plus await
+    // nested in array/object/template literals and new(...) — so e.g. `a[i] += await f()` inside a try
+    // under-reported suspension and took the real-IL try path (an illegal BranchIntoTry resume label →
+    // InvalidProgramException) (#914). An async function never contains `yield`, so the helper's Yield
+    // arm is vacuously inapplicable here.
+    protected bool ContainsAwaitInExpr(Expr expr) => ExprContainsSuspension(expr);
 }

--- a/Compilation/AsyncGeneratorMoveNextEmitter.Statements.TryCatch.cs
+++ b/Compilation/AsyncGeneratorMoveNextEmitter.Statements.TryCatch.cs
@@ -687,50 +687,13 @@ public partial class AsyncGeneratorMoveNextEmitter
         }
     }
 
-    private static bool ContainsSuspensionInExpr(Expr expr)
-    {
-        switch (expr)
-        {
-            case Expr.Yield:
-            case Expr.Await:
-                return true;
-            case Expr.Comma c:
-                return ContainsSuspensionInExpr(c.Left) || ContainsSuspensionInExpr(c.Right);
-            case Expr.Binary b:
-                return ContainsSuspensionInExpr(b.Left) || ContainsSuspensionInExpr(b.Right);
-            case Expr.Logical l:
-                return ContainsSuspensionInExpr(l.Left) || ContainsSuspensionInExpr(l.Right);
-            case Expr.Unary u:
-                return ContainsSuspensionInExpr(u.Right);
-            case Expr.Delete d:
-                return ContainsSuspensionInExpr(d.Operand);
-            case Expr.Grouping g:
-                return ContainsSuspensionInExpr(g.Expression);
-            case Expr.Call c:
-                if (ContainsSuspensionInExpr(c.Callee)) return true;
-                foreach (var arg in c.Arguments)
-                    if (ContainsSuspensionInExpr(arg)) return true;
-                return false;
-            case Expr.Assign a:
-                return ContainsSuspensionInExpr(a.Value);
-            case Expr.CompoundAssign ca:
-                return ContainsSuspensionInExpr(ca.Value);
-            case Expr.Ternary t:
-                return ContainsSuspensionInExpr(t.Condition) ||
-                       ContainsSuspensionInExpr(t.ThenBranch) ||
-                       ContainsSuspensionInExpr(t.ElseBranch);
-            case Expr.Get g:
-                return ContainsSuspensionInExpr(g.Object);
-            case Expr.Set s:
-                return ContainsSuspensionInExpr(s.Object) || ContainsSuspensionInExpr(s.Value);
-            case Expr.GetIndex gi:
-                return ContainsSuspensionInExpr(gi.Object) || ContainsSuspensionInExpr(gi.Index);
-            case Expr.SetIndex si:
-                return ContainsSuspensionInExpr(si.Object) || ContainsSuspensionInExpr(si.Index) || ContainsSuspensionInExpr(si.Value);
-            default:
-                return false;
-        }
-    }
+    // Delegates to the canonical, exhaustive suspension walker shared by every state-machine emitter
+    // (ExpressionEmitterBase.ExprContainsSuspension). The previous hand-maintained switch had drifted
+    // and was missing CompoundSetIndex/CompoundSet/LogicalAssign/LogicalSet/LogicalSetIndex plus
+    // await/yield nested in array/object/template literals and new(...) — the same under-reporting that
+    // produced an illegal BranchIntoTry resume label for those forms inside a try (#914). An async
+    // generator suspends on both `await` and `yield`, which the helper covers exactly.
+    private static bool ContainsSuspensionInExpr(Expr expr) => ExprContainsSuspension(expr);
 
     // ContainsEscapingExit / ContainsEscapingExit2 are shared across the suspension-aware emitters and
     // live in StatementEmitterBase (the generator, async-generator, and async-function emitters all

--- a/Compilation/AsyncMoveNextEmitter.Statements.Loops.cs
+++ b/Compilation/AsyncMoveNextEmitter.Statements.Loops.cs
@@ -287,7 +287,11 @@ public partial class AsyncMoveNextEmitter
         }
         var exLocal = _currentTryCatchExceptionLocal;
         _il.BeginExceptionBlock();
+        // This real-IL try already captures a throw from the span into the enclosing flag-based catch, so
+        // the #914 throw routing must defer to it (a routed `br` out of this region would be illegal IL).
+        _throwRoutingGuardDepth++;
         emit();
+        _throwRoutingGuardDepth--;
         _il.BeginCatchBlock(typeof(Exception));
         _il.Emit(OpCodes.Call, _ctx!.Runtime!.WrapException);
         _il.Emit(OpCodes.Stloc, exLocal);

--- a/Compilation/GeneratorMoveNextEmitter.Statements.TryCatch.cs
+++ b/Compilation/GeneratorMoveNextEmitter.Statements.TryCatch.cs
@@ -824,49 +824,13 @@ public partial class GeneratorMoveNextEmitter
         }
     }
 
-    private static bool ContainsYieldInExpr(Expr expr)
-    {
-        switch (expr)
-        {
-            case Expr.Yield:
-                return true;
-            case Expr.Comma c:
-                return ContainsYieldInExpr(c.Left) || ContainsYieldInExpr(c.Right);
-            case Expr.Binary b:
-                return ContainsYieldInExpr(b.Left) || ContainsYieldInExpr(b.Right);
-            case Expr.Logical l:
-                return ContainsYieldInExpr(l.Left) || ContainsYieldInExpr(l.Right);
-            case Expr.Unary u:
-                return ContainsYieldInExpr(u.Right);
-            case Expr.Delete d:
-                return ContainsYieldInExpr(d.Operand);
-            case Expr.Grouping g:
-                return ContainsYieldInExpr(g.Expression);
-            case Expr.Call c:
-                if (ContainsYieldInExpr(c.Callee)) return true;
-                foreach (var arg in c.Arguments)
-                    if (ContainsYieldInExpr(arg)) return true;
-                return false;
-            case Expr.Assign a:
-                return ContainsYieldInExpr(a.Value);
-            case Expr.CompoundAssign ca:
-                return ContainsYieldInExpr(ca.Value);
-            case Expr.Ternary t:
-                return ContainsYieldInExpr(t.Condition)
-                    || ContainsYieldInExpr(t.ThenBranch)
-                    || ContainsYieldInExpr(t.ElseBranch);
-            case Expr.Get g:
-                return ContainsYieldInExpr(g.Object);
-            case Expr.Set s:
-                return ContainsYieldInExpr(s.Object) || ContainsYieldInExpr(s.Value);
-            case Expr.GetIndex gi:
-                return ContainsYieldInExpr(gi.Object) || ContainsYieldInExpr(gi.Index);
-            case Expr.SetIndex si:
-                return ContainsYieldInExpr(si.Object) || ContainsYieldInExpr(si.Index) || ContainsYieldInExpr(si.Value);
-            default:
-                return false;
-        }
-    }
+    // Delegates to the canonical, exhaustive suspension walker shared by every state-machine emitter
+    // (ExpressionEmitterBase.ExprContainsSuspension). The previous hand-maintained switch had drifted
+    // and was missing CompoundSetIndex/CompoundSet/LogicalAssign/LogicalSet/LogicalSetIndex plus yield
+    // nested in array/object/template literals and new(...) — the same under-reporting that produced an
+    // illegal BranchIntoTry resume label for those forms inside a try (#914). A plain generator never
+    // contains `await`, so the helper's Await arm is vacuously inapplicable here.
+    private static bool ContainsYieldInExpr(Expr expr) => ExprContainsSuspension(expr);
 
     // ContainsEscapingExit / ContainsEscapingExit2 are shared across the suspension-aware emitters and
     // live in StatementEmitterBase (the generator, async-generator, and async-function emitters all

--- a/SharpTS.Tests/Compilation/EmitterSyncTests.cs
+++ b/SharpTS.Tests/Compilation/EmitterSyncTests.cs
@@ -49,6 +49,9 @@ public class EmitterSyncTests
             // --- #774: await-aware exception handling + async-function completion ---
             "EmitReturn",           // Async return: route through finally(s), then complete the task
             "EmitTryCatch",         // Await-aware (flag-based) exception handling
+            // --- #914: a suspending `throw await f()` in a try body is emitted at the flag-based top
+            //     level (outside any mini try/catch), so route it into the active try's catch ---
+            "EmitThrow",            // Route a top-level throw in a flag-based try body to its catch
         },
         [typeof(AsyncMoveNextEmitter)] = new()
         {

--- a/SharpTS.Tests/SharedTests/AsyncTrySuspensionWalkerTests.cs
+++ b/SharpTS.Tests/SharedTests/AsyncTrySuspensionWalkerTests.cs
@@ -47,13 +47,12 @@ public class AsyncTrySuspensionWalkerTests
         Assert.Equal("case: 1\ndone\n", TestHarness.Run(source, mode));
     }
 
-    // Interpreter-only: in COMPILED mode `throw await f()` inside a try does not route
-    // to the guest catch (the awaited value escapes as a host exception). That is a
-    // deeper bug in AsyncFunctionMoveNextEmitter's flag-based throw emission, not the
-    // suspension walker (which now correctly classifies this as suspending). Tracked as
-    // follow-up; pinned here in the mode that is correct.
+    // `throw await f()` inside a try is a segment-breaker emitted at the top level (outside the
+    // sync-segment mini try/catch), so before #914 the compiled raw throw escaped the guest try and
+    // faulted the Task. Fixed by AsyncFunctionMoveNextEmitter.EmitThrow routing a top-level throw into
+    // the active flag-based try's exception local (running any intervening finally first).
     [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void AsyncTry_AwaitInsideThrow(ExecutionMode mode)
     {
         var source = """
@@ -89,12 +88,13 @@ public class AsyncTrySuspensionWalkerTests
         Assert.Equal("hi\n", TestHarness.Run(source, mode));
     }
 
-    // Interpreter-only: in COMPILED mode `arr[i] += await f()` inside a try strands the
-    // indexed receiver across the suspension (#850-class). The suspension walker now
-    // classifies it correctly; the remaining gap is in the flag-based async state-machine
-    // emission. Tracked as follow-up; pinned here in the mode that is correct.
+    // `arr[i] += await f()` parses to Expr.CompoundSetIndex, which the async-function
+    // suspension walker did not descend into — so the try under-reported suspension and
+    // took the real-IL lowering (illegal BranchIntoTry resume → InvalidProgramException).
+    // Fixed in #914 by delegating the walker to the canonical ExprContainsSuspension
+    // (the CompoundSetIndex emission already spilled the receiver/index correctly).
     [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void AsyncTry_AwaitInCompoundIndexedAssign(ExecutionMode mode)
     {
         // arr[0] += await ... exercises CompoundAssign + GetIndex + SetIndex.
@@ -156,5 +156,135 @@ public class AsyncTrySuspensionWalkerTests
             main();
             """;
         Assert.Equal("labeled: 7\n", TestHarness.Run(source, mode));
+    }
+
+    // The walker arms below were all absent before #914 (only CompoundAssign/GetIndex/SetIndex
+    // had been added). Each puts an await inside a composite the walker must descend into, within
+    // a try; under-reporting any of them would re-expose the BranchIntoTry resume failure.
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AsyncTry_AwaitInCompoundMemberAssign(ExecutionMode mode)
+    {
+        // obj.x += await ... is Expr.CompoundSet.
+        var source = """
+            async function inc(): Promise<number> { return 5; }
+            async function main(): Promise<void> {
+                const obj = { x: 10 };
+                try {
+                    obj.x += await inc();
+                    console.log("x: " + obj.x);
+                } catch (e) {
+                    console.log("caught");
+                }
+            }
+            main();
+            """;
+        Assert.Equal("x: 15\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AsyncTry_AwaitInLogicalIndexedAssign(ExecutionMode mode)
+    {
+        // arr[0] ||= await ... is Expr.LogicalSetIndex; arr[0] is falsy so the RHS await runs.
+        var source = """
+            async function inc(): Promise<number> { return 5; }
+            async function main(): Promise<void> {
+                const arr = [0];
+                try {
+                    arr[0] ||= await inc();
+                    console.log("arr0: " + arr[0]);
+                } catch (e) {
+                    console.log("caught");
+                }
+            }
+            main();
+            """;
+        Assert.Equal("arr0: 5\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AsyncTry_AwaitInArrayLiteral(ExecutionMode mode)
+    {
+        // [await ...] is Expr.ArrayLiteral with a suspending element.
+        var source = """
+            async function val(): Promise<number> { return 3; }
+            async function main(): Promise<void> {
+                try {
+                    const a = [await val(), 9];
+                    console.log("a: " + a[0] + "," + a[1]);
+                } catch (e) {
+                    console.log("caught");
+                }
+            }
+            main();
+            """;
+        Assert.Equal("a: 3,9\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AsyncTry_AwaitInTemplateLiteral(ExecutionMode mode)
+    {
+        // `v=${await ...}` is Expr.TemplateLiteral with a suspending interpolation.
+        var source = """
+            async function val(): Promise<number> { return 4; }
+            async function main(): Promise<void> {
+                try {
+                    const s = `v=${await val()}`;
+                    console.log(s);
+                } catch (e) {
+                    console.log("caught");
+                }
+            }
+            main();
+            """;
+        Assert.Equal("v=4\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AsyncTry_ThrowAwait_RunsOwnFinallyThenCatch(ExecutionMode mode)
+    {
+        // The routed throw lands in this try's catch and its own finally still runs after (#914).
+        var source = """
+            async function makeErr(): Promise<string> { return "boom"; }
+            async function main(): Promise<void> {
+                try {
+                    throw await makeErr();
+                } catch (e) {
+                    console.log("caught: " + e);
+                } finally {
+                    console.log("finally");
+                }
+            }
+            main();
+            """;
+        Assert.Equal("caught: boom\nfinally\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AsyncTry_ThrowAwait_NestedInIf_RoutesToCatch(ExecutionMode mode)
+    {
+        // The `if` is the segment-breaker (its branch contains the await); the throw is emitted while
+        // descending into it, still at the try-body top level — routing must fire there too.
+        var source = """
+            async function makeErr(): Promise<string> { return "deep"; }
+            async function main(): Promise<void> {
+                try {
+                    if (1 < 2) {
+                        throw await makeErr();
+                    }
+                    console.log("unreached");
+                } catch (e) {
+                    console.log("caught: " + e);
+                }
+            }
+            main();
+            """;
+        Assert.Equal("caught: deep\n", TestHarness.Run(source, mode));
     }
 }


### PR DESCRIPTION
Fixes #914.

Two `await`-inside-`try` constructs were mis-compiled in the async state machine. **The interpreter was correct in both; these were compiled-mode-only.** Both pinned interpreter-only acceptance tests are flipped to `ExecutionModes.All`.

## Bug #1 — `throw await f()` inside a try escaped the guest catch
A suspending `throw` is emitted as a flag-based **segment-breaker at the top level**, outside the sync-segment mini try/catch, so the base raw CLR throw bypassed the guest handler and faulted the Task.

`AsyncFunctionMoveNextEmitter` now overrides `EmitThrow` to route a top-level throw in a flag-based try body into that try's exception local (the same store-into-local + `Br`-to-skip idiom as the await-rejection capture), running any **strictly-inside finally** first via `FinallyFramesInside` + `RouteThroughFinallys`. The discriminator is a new `_throwRoutingGuardDepth` that counts the emitter's real-IL **guest** exception blocks (mini try/catch segments, the nested-catch wrap, no-await/simple trys, and the for-await guarded sync segment) — deliberately separate from `Ctx.ExceptionBlockDepth` (which drives the break/continue Leave-vs-Br choice, #727) and the base `ProtectedRegionDepth`, and excluding the outer MoveNext backstop. That separation is exactly why **handler-body throws and for-await-cleanup throws are not regressed** (the naive direct-branch attempt in the issue regressed 6 tests there).

## Bug #2 — `arr[i] += await f()` inside a try emitted invalid IL
`arr[i] += …` parses to `Expr.CompoundSetIndex`, which the async-function suspension walker did **not** descend into (nor `CompoundSet` / `LogicalAssign` / `LogicalSet` / `LogicalSetIndex`, nor `await` inside array/object/template literals & `new()`). The try under-reported suspension and took the real-IL lowering, whose await-resume label became an illegal `BranchIntoTry` target → `InvalidProgramException`.

Per maintainer direction, the three drifted per-emitter walkers — `ContainsAwaitInExpr`, `ContainsYieldInExpr`, `ContainsSuspensionInExpr` — now delegate to the canonical, exhaustive `ExprContainsSuspension`, closing the whole family in every state-machine emitter. The `CompoundSetIndex` emission already spilled the receiver/index correctly.

## Verification
- **Acceptance:** `AsyncTry_AwaitInsideThrow` and `AsyncTry_AwaitInCompoundIndexedAssign` now pass in **both** modes.
- **Regression gate:** the 6 tests the naive attempt broke — `AsyncTryCatch_NestedTryCatch`, `AsyncTryCatch_InnerCatchRethrows`, 4× `AsyncIterator_ThrowInForAwaitBody*` — all green.
- **Full async + generator suites:** zero regressions.
- **+6 new dual-mode tests** for the walker family (`obj.x += await`, `arr[i] ||= await`, `[await f()]`, `` `${await f()}` ``) and throw-routing edge cases (own-finally-runs, throw-nested-in-`if`).
- **Full suite: 14186 passed, 0 failed.** `EmitterSync` override-allowlist, StandaloneDll, and ILVerify guards all clean (the routing IL is BCL-only / standalone / verifiable).