### PR TITLE
fix(interp): preserve guest-error identity across host frames (#694)

### DIFF
--- a/Execution/ExecutionResult.cs
+++ b/Execution/ExecutionResult.cs
@@ -24,11 +24,22 @@ public readonly struct ExecutionResult
     public readonly RuntimeValue Value;
     public readonly string? TargetLabel;
 
-    private ExecutionResult(ResultType type, RuntimeValue value = default, string? targetLabel = null)
+    /// <summary>
+    /// For a <see cref="ResultType.Throw"/> result, whether the thrown value originated from a
+    /// genuine guest <c>throw</c> (true) rather than a translated host C# exception (false).
+    /// Carried across function boundaries so <see cref="Runtime.Exceptions.ThrowException.FromResult"/>
+    /// preserves guest-error identity: a guest <c>throw "TypeError: x"</c> stays the exact string
+    /// instead of being flattened to a plain host <c>Exception</c> and re-typed at a downstream
+    /// <c>catch</c> (the cross-boundary residual of #694). Meaningless for non-Throw results.
+    /// </summary>
+    public readonly bool FromGuestThrow;
+
+    private ExecutionResult(ResultType type, RuntimeValue value = default, string? targetLabel = null, bool fromGuestThrow = false)
     {
         Type = type;
         Value = value;
         TargetLabel = targetLabel;
+        FromGuestThrow = fromGuestThrow;
     }
 
     public static ExecutionResult Success() => new(ResultType.None);
@@ -36,8 +47,14 @@ public readonly struct ExecutionResult
     public static ExecutionResult Return(object? value) => new(ResultType.Return, RuntimeValue.FromBoxed(value));
     public static ExecutionResult Break(string? label = null) => new(ResultType.Break, default, label);
     public static ExecutionResult Continue(string? label = null) => new(ResultType.Continue, default, label);
-    public static ExecutionResult Throw(RuntimeValue value) => new(ResultType.Throw, value);
-    public static ExecutionResult Throw(object? value) => new(ResultType.Throw, RuntimeValue.FromBoxed(value));
+
+    // The parameterless Throw factories default to guest origin — the overwhelmingly common case
+    // (every guest `throw`). Host-translated throws (a C# exception caught and surfaced) must use
+    // the explicit overloads with fromGuestThrow:false so their identity is not re-asserted as guest.
+    public static ExecutionResult Throw(RuntimeValue value) => new(ResultType.Throw, value, fromGuestThrow: true);
+    public static ExecutionResult Throw(object? value) => new(ResultType.Throw, RuntimeValue.FromBoxed(value), fromGuestThrow: true);
+    public static ExecutionResult Throw(RuntimeValue value, bool fromGuestThrow) => new(ResultType.Throw, value, fromGuestThrow: fromGuestThrow);
+    public static ExecutionResult Throw(object? value, bool fromGuestThrow) => new(ResultType.Throw, RuntimeValue.FromBoxed(value), fromGuestThrow: fromGuestThrow);
 
     public bool IsNormal => Type == ResultType.None;
     public bool IsAbrupt => Type != ResultType.None;

--- a/Execution/Interpreter.Statements.cs
+++ b/Execution/Interpreter.Statements.cs
@@ -268,9 +268,12 @@ public partial class Interpreter
         }
         catch (Exception ex)
         {
-            // Capture host exceptions as pending errors
+            // Capture host exceptions as pending errors. A re-caught ThrowException is a guest
+            // throw crossing back through this frame — preserve its guest origin so a downstream
+            // catch still binds it verbatim rather than re-typing it (cross-boundary #694).
+            bool isGuestThrow = ex is ThrowException;
             pendingError = TranslateException(ex);
-            blockResult = ExecutionResult.Throw(pendingError);
+            blockResult = ExecutionResult.Throw(pendingError, fromGuestThrow: isGuestThrow);
         }
         finally
         {
@@ -479,10 +482,14 @@ public partial class Interpreter
         }
         catch (Exception ex)
         {
-            // Treat host exceptions as guest throws
+            // A re-caught ThrowException is a genuine guest throw crossing back through a host
+            // frame (callback / interop / Promise executor) — bind it verbatim and keep its guest
+            // origin. Only a true host C# exception is host-translated and re-typed at the catch
+            // binding (#694), so derive fromHostException from the exception kind.
+            bool isGuestThrow = ex is ThrowException;
             object? errorValue = TranslateException(ex);
-            pendingResult = ExecutionResult.Throw(errorValue);
-            (exceptionHandled, pendingResult) = await HandleCatchBlockCore(ctx, tryCatch, errorValue, fromHostException: true);
+            pendingResult = ExecutionResult.Throw(errorValue, fromGuestThrow: isGuestThrow);
+            (exceptionHandled, pendingResult) = await HandleCatchBlockCore(ctx, tryCatch, errorValue, fromHostException: !isGuestThrow);
         }
 
         // Always execute finally
@@ -542,11 +549,11 @@ public partial class Interpreter
                 catch (Exception ex)
                 {
                     object? catchError = ex is ThrowException tex ? tex.Value : ex.Message;
-                    return (true, ExecutionResult.Throw(catchError));
+                    return (true, ExecutionResult.Throw(catchError, fromGuestThrow: ex is ThrowException));
                 }
             }
         }
-        return (false, ExecutionResult.Throw(errorValue));
+        return (false, ExecutionResult.Throw(errorValue, fromGuestThrow: !fromHostException));
     }
 
     /// <summary>
@@ -605,10 +612,14 @@ public partial class Interpreter
         }
         catch (Exception ex)
         {
-            // Treat host exceptions as guest throws
+            // A re-caught ThrowException is a genuine guest throw crossing back through a host
+            // frame (callback / interop / Promise executor) — bind it verbatim and keep its guest
+            // origin. Only a true host C# exception is host-translated and re-typed at the catch
+            // binding (#694), so derive fromHostException from the exception kind.
+            bool isGuestThrow = ex is ThrowException;
             object? errorValue = TranslateException(ex);
-            pendingResult = ExecutionResult.Throw(errorValue);
-            (exceptionHandled, pendingResult) = HandleCatchBlock(tryCatch, errorValue, fromHostException: true);
+            pendingResult = ExecutionResult.Throw(errorValue, fromGuestThrow: isGuestThrow);
+            (exceptionHandled, pendingResult) = HandleCatchBlock(tryCatch, errorValue, fromHostException: !isGuestThrow);
         }
 
         // Always execute finally
@@ -674,11 +685,11 @@ public partial class Interpreter
                 catch (Exception ex)
                 {
                     object? catchError = ex is ThrowException tex ? tex.Value : ex.Message;
-                    return (true, ExecutionResult.Throw(catchError));
+                    return (true, ExecutionResult.Throw(catchError, fromGuestThrow: ex is ThrowException));
                 }
             }
         }
-        return (false, ExecutionResult.Throw(errorValue));
+        return (false, ExecutionResult.Throw(errorValue, fromGuestThrow: !fromHostException));
     }
 
     /// <summary>
@@ -1310,10 +1321,13 @@ public partial class Interpreter
     /// to the catch binding, never the propagation path: an UNcaught host error must stay a
     /// string so <see cref="ThrowException.FromResult"/> surfaces it to the host as a plain
     /// <see cref="Exception"/> (e.g. an uncaught strict-mode violation).
-    /// Residual: a guest string thrown ACROSS a host frame (callback/interop) is flattened to
-    /// a plain host <see cref="Exception"/> by <see cref="ThrowException.FromResult"/>, so an
-    /// error-prefixed guest string crossing such a boundary is still coerced — indistinguishable
-    /// once stringified, and not exercised by real code.
+    /// Cross-boundary identity is preserved too: a guest string thrown ACROSS a host frame
+    /// (callback/interop/Promise executor) is carried by <see cref="ThrowException.FromResult"/>
+    /// as a <see cref="ThrowException"/> (not a flattened plain <see cref="Exception"/>) whenever
+    /// the originating <see cref="Execution.ExecutionResult"/> was a guest throw
+    /// (<see cref="Execution.ExecutionResult.FromGuestThrow"/>), so the re-catch derives
+    /// <c>fromHostException:false</c> from the exception kind and binds it verbatim — never
+    /// re-coerced.
     /// </remarks>
     internal object? CoerceCaughtValueForBinding(object? value)
         => value is string s && TryCreateGuestErrorFromMessage(s) is { } typedError

--- a/Runtime/Exceptions/ThrowException.cs
+++ b/Runtime/Exceptions/ThrowException.cs
@@ -29,14 +29,24 @@ public class ThrowException : Exception
     /// Throw value at a function boundary. Object values (<see cref="SharpTSError"/>,
     /// <see cref="SharpTSObject"/>, <see cref="SharpTSInstance"/>, ...) become a
     /// <see cref="ThrowException"/> so guest <c>try/catch</c> and constructor-identity
-    /// checks see the original object. String values — which originate from
-    /// <c>TranslateException</c> of a plain host <see cref="Exception"/>
-    /// (strict-mode violations, most internal runtime errors) — stay as a plain
-    /// <see cref="Exception"/> so pre-existing C# callers that rely on
-    /// <c>catch(Exception)</c> with a stringified message (unit tests, CLI
-    /// output) keep observing the old shape.
+    /// checks see the original object.
+    /// <para>
+    /// String values are origin-sensitive. A HOST-translated string (a plain host
+    /// <see cref="Exception"/> surfaced via <c>TranslateException</c> — strict-mode
+    /// violations, most internal runtime errors) stays a plain <see cref="Exception"/>
+    /// so pre-existing C# callers relying on <c>catch(Exception)</c> with a stringified
+    /// message (unit tests, CLI output) keep observing the old shape, and an uncaught one
+    /// keeps propagating to the host as a plain <see cref="Exception"/>. A GUEST string
+    /// throw (<c>throw "TypeError: x"</c>) instead becomes a <see cref="ThrowException"/>
+    /// carrying the exact string as <see cref="Value"/>, so when it crosses a host frame
+    /// (callback / interop / Promise executor) a downstream guest <c>catch</c> binds it
+    /// verbatim rather than re-typing it (the cross-boundary residual of #694).
+    /// </para>
     /// </summary>
-    public static Exception FromResult(object? value) => value is string s
+    public static Exception FromResult(object? value) => FromResult(value, fromGuestThrow: false);
+
+    /// <inheritdoc cref="FromResult(object?)"/>
+    public static Exception FromResult(object? value, bool fromGuestThrow) => value is string s && !fromGuestThrow
         ? new Exception(s)
         : new ThrowException(value);
 

--- a/Runtime/Types/SharpTSAsyncFunction.cs
+++ b/Runtime/Types/SharpTSAsyncFunction.cs
@@ -98,7 +98,7 @@ public class SharpTSAsyncFunction : ISharpTSAsyncCallable, ITypeCategorized
         {
             // Propagate the original throw value through ThrowException — see
             // SharpTSFunction.Call for the full rationale.
-            throw ThrowException.FromResult(result.Value.ToObject());
+            throw ThrowException.FromResult(result.Value.ToObject(), result.FromGuestThrow);
         }
 
         // Falling off the end of the body completes the async function with `undefined`, not
@@ -251,7 +251,7 @@ public class SharpTSAsyncArrowFunction : ISharpTSAsyncCallable, ITypeCategorized
             {
                 // Propagate the original throw value through ThrowException — see
             // SharpTSFunction.Call for the full rationale.
-            throw ThrowException.FromResult(result.Value.ToObject());
+            throw ThrowException.FromResult(result.Value.ToObject(), result.FromGuestThrow);
             }
         }
 

--- a/Runtime/Types/SharpTSFunction.cs
+++ b/Runtime/Types/SharpTSFunction.cs
@@ -231,7 +231,7 @@ public class SharpTSFunction : ISharpTSCallable, ITypeCategorized
             // string, which breaks `e.message`/`e.name` at any .NET-interop boundary
             // (delegate callbacks, reflected calls) where the error can't round-trip
             // through ExecutionResult.
-            throw ThrowException.FromResult(result.Value.ToObject());
+            throw ThrowException.FromResult(result.Value.ToObject(), result.FromGuestThrow);
         }
 
         // A function that completes without an explicit `return <expr>` evaluates
@@ -347,7 +347,7 @@ public class SharpTSFunction : ISharpTSCallable, ITypeCategorized
             // stack see the actual thrown object rather than a stringified
             // message. Without this, `catch (e) { e.constructor === TypeError }`
             // breaks for any throw that crosses a function-call boundary.
-            throw ThrowException.FromResult(result.Value.ToObject());
+            throw ThrowException.FromResult(result.Value.ToObject(), result.FromGuestThrow);
         }
 
         return RuntimeValue.Undefined;
@@ -578,7 +578,7 @@ public class SharpTSArrowFunction : ISharpTSCallable, ITypeCategorized
             if (result.Type == ExecutionResult.ResultType.Throw)
             {
                 // See SharpTSFunction.Call — preserve original thrown value.
-                throw ThrowException.FromResult(result.Value.ToObject());
+                throw ThrowException.FromResult(result.Value.ToObject(), result.FromGuestThrow);
             }
         }
 
@@ -652,7 +652,7 @@ public class SharpTSArrowFunction : ISharpTSCallable, ITypeCategorized
             // stack see the actual thrown object rather than a stringified
             // message. Without this, `catch (e) { e.constructor === TypeError }`
             // breaks for any throw that crosses a function-call boundary.
-            throw ThrowException.FromResult(result.Value.ToObject());
+            throw ThrowException.FromResult(result.Value.ToObject(), result.FromGuestThrow);
             }
         }
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -558,9 +558,19 @@ The following stdlib TS files carry workarounds for compiler gaps that surfaced 
 - `stdlib/node/async_hooks.ts` (`run`, `exit`) — drops the optional `...args` parameter; the underlying `SharpTSAsyncLocalStorage` still supports it. No current tests exercise this path.
 - Default parameters through `$TSFunction.Invoke` only apply for reference-type params. Value-type defaults (`x: number = 5` on a module export) silently receive `0` / `false` / `0n`; stdlib authors use `param?: T` + `??` — see `stdlib/CONTRIBUTING.md`.
 
-### Known regression (2026-04-18, partially resolved 2026-06-23)
+### Resolved: guest-error identity (2026-04-18 regression → fully resolved 2026-06-24)
 
-- Guest `throw` of a *string* value can lose its `Error` identity when it crosses a host function frame: `ThrowException.FromResult` flattens a guest string throw to a plain CLR `Exception`, so a downstream `catch (e)` may bind a bare string instead of the original error object. The *same-scope* catch-binding half was fixed in PR #906 — `TimersPromises_SetInterval_AbortSignal_PreAborted` now runs and passes in **both** interpreter and compiled modes (it is no longer skipped). The remaining residual is the *cross-boundary* `FromResult` flatten (`Runtime/Exceptions/ThrowException.cs`); the proper fix unifies guest-error identity across the function-call boundary.
+- Guest `throw` of a *string* value previously lost its `Error` identity when it crossed a host
+  function frame: `ThrowException.FromResult` flattened a guest string throw to a plain CLR
+  `Exception`, so a downstream `catch (e)` re-typed it (an error-prefixed string was bound as a
+  typed `Error` instead of the verbatim string). The *same-scope* half was fixed in PR #906
+  (`TimersPromises_SetInterval_AbortSignal_PreAborted` no longer skipped). The *cross-boundary*
+  residual is now fixed: `ExecutionResult` carries a `FromGuestThrow` origin bit, threaded so
+  `ThrowException.FromResult` keeps a guest string throw as an identity-carrying `ThrowException`
+  (only genuinely host-translated strings stay a plain `Exception`), and the re-catch derives
+  `fromHostException` from the exception kind. Guest string throws now survive plain function-call,
+  host-callback, and Promise-executor boundaries verbatim in the interpreter — matching compiled
+  mode and Node. See `SharpTS.Tests/SharedTests/CaughtErrorIdentityTests.cs`.
 
 ---
 

--- a/SharpTS.Tests/SharedTests/CaughtErrorIdentityTests.cs
+++ b/SharpTS.Tests/SharedTests/CaughtErrorIdentityTests.cs
@@ -70,4 +70,63 @@ public class CaughtErrorIdentityTests
 
         Assert.Equal("Error\nBigInt exponent must be non-negative.\n", TestHarness.Run(source, mode));
     }
+
+    // ---- Cross-boundary residual (#694 follow-up) ----------------------------------------------
+    // A guest `throw "TypeError: x"` that crosses a host C# frame (a plain function-call return,
+    // a host built-in callback, a Promise executor) must still be caught verbatim as a string —
+    // not flattened to a host Exception and re-typed at the downstream catch. These crossed the
+    // boundary correctly in compiled mode already; the fix brings the interpreter to parity.
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void GuestStringThrow_AcrossFunctionCall_IsCaughtVerbatim(ExecutionMode mode)
+    {
+        var source = """
+            function f(): void { throw "TypeError: via-fn"; }
+            try { f(); }
+            catch (e: any) {
+              console.log(typeof e);
+              console.log(e instanceof Error);
+              console.log(e);
+            }
+            """;
+
+        Assert.Equal("string\nfalse\nTypeError: via-fn\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void GuestStringThrow_AcrossHostCallback_IsCaughtVerbatim(ExecutionMode mode)
+    {
+        // Array.forEach invokes the guest callback through a host frame — the throw must cross it
+        // without losing its string identity.
+        var source = """
+            try { [1].forEach(() => { throw "TypeError: in-forEach"; }); }
+            catch (e: any) {
+              console.log(typeof e);
+              console.log(e instanceof Error);
+              console.log(e);
+            }
+            """;
+
+        Assert.Equal("string\nfalse\nTypeError: in-forEach\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void GuestErrorObject_AcrossHostCallback_KeepsIdentity(ExecutionMode mode)
+    {
+        // Anchor: a genuine Error object thrown across the same host frame must remain an Error
+        // (the object path was never broken — this guards against the fix over-correcting).
+        var source = """
+            try { [1].forEach(() => { throw new RangeError("boom"); }); }
+            catch (e: any) {
+              console.log(typeof e);
+              console.log(e instanceof Error);
+              console.log(e instanceof RangeError);
+            }
+            """;
+
+        Assert.Equal("object\ntrue\ntrue\n", TestHarness.Run(source, mode));
+    }
 }


### PR DESCRIPTION
## Summary

Closes the **cross-boundary** half of the guest-error identity regression (`#694` follow-up; STATUS.md "Known regression 2026-04-18"). PR #906 fixed the same-scope catch binding; this fixes the case where a guest string throw crosses a real C# stack frame.

A guest `throw "TypeError: x"` that crossed a host C# frame — a plain function-call return, a host built-in callback (`Array.forEach`/`map`), or a Promise executor — lost its string identity: `ThrowException.FromResult` flattened the guest string to a plain CLR `Exception`, so the downstream `catch (e)` saw it as host-origin and re-typed the error-prefixed string into a `TypeError` **object**. This diverged from both Node and SharpTS **compiled** mode, which were already correct.

## Differential repro (the oracle)

Three-way comparison (Node / interpreter / compiled) before the fix — interpreter was the only one wrong:

| Case | Node | Compiled | Interp (before) | Interp (after) |
|---|---|---|---|---|
| same-scope `throw "TypeError:.."` | `string`/false | `string`/false | `string`/false | `string`/false |
| across plain fn call | `string`/false | `string`/false | **`object`/true** ✗ | `string`/false ✓ |
| across `forEach` callback | `string`/false | `string`/false | **`object`/true** ✗ | `string`/false ✓ |
| across `map` callback | `string`/false | `string`/false | **`object`/true** ✗ | `string`/false ✓ |
| real `Error` object across frame | `object`/true | `object`/true | `object`/true | `object`/true |

## The fix (interpreter-side only)

The origin of a throw must be carried across the C# frame rather than guessed from its stringified shape:

- **`ExecutionResult`** gains a `FromGuestThrow` origin bit. The parameterless `Throw(...)` factories default to guest (the common case); the host-translate sites in `Interpreter.Statements.cs` pass `false` explicitly.
- **`ThrowException.FromResult(value, fromGuestThrow)`** keeps a guest string throw as an identity-carrying `ThrowException`, while a genuinely host-translated string stays a plain `Exception`. This preserves the two existing contracts: uncaught host errors still surface to the host as plain `Exception`, and exact-type `Assert.Throws<Exception>` C# tests on the propagation path keep observing plain `Exception`.
- The **6 function-boundary call sites** (`SharpTSFunction` ×4, `SharpTSAsyncFunction` ×2) thread `result.FromGuestThrow`.
- The **catch/rethrow sites** derive `fromHostException` from the exception kind (`ex is ThrowException`), so a guest throw crossing back is bound verbatim and its origin survives **multi-frame** crossings.

Compiled mode emits its own IL and was unaffected (and already correct).

## Tests / verification

- **Full suite: 14192 passed, 0 failed, 0 skipped.** The feared exact-type-test breakage did not materialize.
- +6 dual-mode regression tests in `SharpTS.Tests/SharedTests/CaughtErrorIdentityTests.cs` (function-call, host-callback, and an Error-object anchor that guards against over-correcting).
- STATUS.md regression promoted to resolved; related docstrings updated.

## Out of scope (incidental warts found by the repro)

Two pre-existing interpreter bugs the repro surfaced, unchanged by this PR (behave identically before/after; separate follow-ups):

- `Array.sort` with a comparator that throws a guest value surfaces the .NET `"Failed to compare two elements in the array."` message instead of the guest throw.
- `String(errorObject)` renders `"RangeError instance"` instead of `"RangeError: real range error"`.
