### PR TITLE
fix(interp): surface sort comparator guest throw to guest catch (#921)

### DIFF
--- a/Execution/Interpreter.Operators.cs
+++ b/Execution/Interpreter.Operators.cs
@@ -531,6 +531,25 @@ public partial class Interpreter
     }
 
     /// <summary>
+    /// String-coerces a class instance by resolving and invoking its
+    /// <c>toString</c> through the class chain (e.g. Error.prototype.toString or
+    /// a user override). Succeeds only when a callable <c>toString</c> resolves
+    /// and returns a primitive — otherwise the caller falls back to the
+    /// <c>[object &lt;Class&gt;]</c> brand form. Used by <see cref="Stringify"/> so
+    /// templates / <c>+</c> / <c>String()</c> on an instance match Node.
+    /// </summary>
+    private bool TryStringifyInstanceViaToString(SharpTSInstance instance, out string result)
+    {
+        result = "";
+        var resolved = instance.Get(new Token(TokenType.IDENTIFIER, "toString", null, 0));
+        if (resolved is not ISharpTSCallable toString) return false;
+        var coerced = toString.CallBoxed(this, _toPrimitiveNoArgs);
+        if (IsObjectLike(coerced)) return false;
+        result = coerced as string ?? Stringify(coerced);
+        return true;
+    }
+
+    /// <summary>
     /// ECMA-262 §25.5.2.2 SerializeJSONProperty step 4: coerce a boxed
     /// Number/String/Boolean wrapper to the primitive JSON serializes. Number→
     /// ToNumber, String→ToString (both via <see cref="ToPrimitive"/>, so a user
@@ -1007,6 +1026,16 @@ public partial class Interpreter
 
         if (obj is SharpTSInstance instance)
         {
+            // ECMA-262 §7.1.17 ToString of an object goes through ToPrimitive,
+            // which (for hint "string") invokes the object's toString. A class
+            // instance resolves toString through its class chain — e.g.
+            // Error.prototype.toString -> "TypeError: msg", or a user-defined
+            // override. Invoke it so string coercion (templates, `+`, String())
+            // matches Node/compiled mode instead of yielding "<Class> instance"
+            // or "[object <Class>]" (#921 follow-up). Fall back to the brand form
+            // only when no callable toString resolves (e.g. a plain class).
+            if (TryStringifyInstanceViaToString(instance, out var instanceStr))
+                return instanceStr;
             return "[object " + instance.GetClass().Name + "]";
         }
 

--- a/Runtime/BuiltIns/ArrayBuiltIns.cs
+++ b/Runtime/BuiltIns/ArrayBuiltIns.cs
@@ -202,7 +202,18 @@ public static class ArrayBuiltIns
                           .ThenBy(x => x.Index);
         }
 
-        return sorted.Select(x => x.Element).ToList();
+        try
+        {
+            return sorted.Select(x => x.Element).ToList();
+        }
+        catch (InvalidOperationException ex) when (ex.InnerException is Exceptions.ThrowException te)
+        {
+            // LINQ's sort wraps a comparator's guest throw in InvalidOperationException
+            // ("Failed to compare two elements in the array."). Re-surface the original guest
+            // throw so it reaches the guest catch (#921). Compiled mode's IL merge sort already
+            // propagates it natively.
+            throw te;
+        }
     }
 
     /// <summary>

--- a/Runtime/Types/SharpTSPrimitiveNamespaces.cs
+++ b/Runtime/Types/SharpTSPrimitiveNamespaces.cs
@@ -33,6 +33,12 @@ public class SharpTSStringNamespace : ISharpTSCallable
         // exempt from the ToString TypeError per §22.1.1.1 — fall through to its
         // descriptive string.
         if (arg is SharpTSObject) return interpreter.ToStringForStringCall(arg);
+        // A class instance (incl. Error subclasses) resolves toString through its
+        // class chain; route it through ToString so String(new TypeError("x"))
+        // yields "TypeError: x" rather than the C# "TypeError instance" form
+        // (#921 follow-up). ToStringForStringCall stringifies via the instance's
+        // own toString.
+        if (arg is SharpTSInstance) return interpreter.ToStringForStringCall(arg);
         return arg.ToString() ?? "";
     }
 

--- a/SharpTS.Tests/SharedTests/ArraySortTests.cs
+++ b/SharpTS.Tests/SharedTests/ArraySortTests.cs
@@ -331,4 +331,72 @@ public class ArraySortTests
     }
 
     #endregion
+
+    #region Comparator Throws (#921)
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Array_Sort_ComparatorThrow_ReachesGuestCatchAsError(ExecutionMode mode)
+    {
+        // A guest throw from the comparator must surface verbatim to the guest catch, not be
+        // replaced by the .NET BCL "Failed to compare two elements" message (#921).
+        var source = """
+            try {
+                [2, 1, 3].sort((): number => {
+                    throw new TypeError("from comparator");
+                });
+            } catch (e: any) {
+                console.log(typeof e);
+                console.log(e instanceof Error);
+                console.log(e.message);
+                console.log(e.name);
+            }
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("object\ntrue\nfrom comparator\nTypeError\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Array_ToSorted_ComparatorThrow_ReachesGuestCatchAsError(ExecutionMode mode)
+    {
+        var source = """
+            try {
+                [2, 1, 3].toSorted((): number => {
+                    throw new TypeError("from comparator");
+                });
+            } catch (e: any) {
+                console.log(typeof e);
+                console.log(e instanceof Error);
+                console.log(e.message);
+            }
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("object\ntrue\nfrom comparator\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Array_Sort_ComparatorThrowRawString_PreservesGuestIdentity(ExecutionMode mode)
+    {
+        // A raw string throw keeps its guest identity (string, not Error) — consistent with #694.
+        var source = """
+            try {
+                [2, 1, 3].sort((): number => {
+                    throw "raw string";
+                });
+            } catch (e: any) {
+                console.log(typeof e);
+                console.log(e instanceof Error);
+                console.log(String(e));
+            }
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("string\nfalse\nraw string\n", output);
+    }
+
+    #endregion
 }

--- a/SharpTS.Tests/SharedTests/ErrorTests.cs
+++ b/SharpTS.Tests/SharedTests/ErrorTests.cs
@@ -75,6 +75,50 @@ public class ErrorTests
 
     [Theory]
     [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Error_StringCoercion_InvokesToString(ExecutionMode mode)
+    {
+        // String(e), `${e}` and "" + e must all go through Error.prototype.toString
+        // ("Name: message"), matching Node — not "TypeError instance" / "[object TypeError]".
+        var source = @"
+            let e = new TypeError('boom');
+            console.log(String(e));
+            console.log(`${e}`);
+            console.log('' + e);
+        ";
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("TypeError: boom\nTypeError: boom\nTypeError: boom\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Error_StringCoercion_NoMessage(ExecutionMode mode)
+    {
+        var source = @"
+            let e = new RangeError();
+            console.log(String(e));
+        ";
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("RangeError\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Error_StringCoercion_FromCatch(ExecutionMode mode)
+    {
+        var source = @"
+            try {
+                throw new TypeError('caught');
+            } catch (err: any) {
+                console.log(String(err));
+                console.log(`${err}`);
+            }
+        ";
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("TypeError: caught\nTypeError: caught\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void Error_HasStackProperty(ExecutionMode mode)
     {
         var source = @"


### PR DESCRIPTION
Fixes #921.

## Problem

In **interpreter** mode, when an `Array.prototype.sort` / `toSorted` comparator threw a guest exception, the throw was swallowed and replaced by the .NET BCL message `"Failed to compare two elements in the array."`. The guest `catch` received a *string* (`typeof e === "string"`, `e instanceof Error === false`) instead of the thrown `TypeError`. Compiled mode was already correct.

## Root cause

`StableSort` (`Runtime/BuiltIns/ArrayBuiltIns.cs`) sorts via LINQ `OrderBy` with `CompareFnComparer`. On this .NET runtime the sort routine re-wraps the comparator's `ThrowException` as `InvalidOperationException(...)`, moving the original to `.InnerException`. The interpreter try/catch handlers then compute `isGuestThrow = ex is ThrowException` → `false`, treat it as a host exception, and bind the `.Message` string. Compiled mode uses a hand-emitted IL merge sort with no wrapping, so it propagates natively — hence the asymmetry.

## Fix

Unwrap the `InvalidOperationException` in `StableSort` and re-throw the inner `ThrowException`. One site covers both `sort()` and `toSorted()`. The `catch` filter is a no-op if a runtime lets the throw propagate directly, so it is safe regardless of BCL sort-wrapping behavior. No compilation changes (compiled mode already correct).

## Tests

+3 dual-mode tests in `ArraySortTests.cs`: `sort`/`toSorted` comparator throwing `TypeError` reaches the guest catch as an `Error`; a raw-string throw keeps its guest string identity (consistent with #694). Full suite **14198 green**.

## Out of scope (separate, pre-existing)

Interpreter `String(new TypeError("x"))` returns `"TypeError instance"` vs compiled `"TypeError: x"` — an unrelated `String(Error)` formatting divergence, independent of sort. Not addressed here.