### PR TITLE
fix(interp): dispatch Error/instance toString in string coercion (#922)

### DIFF
--- a/Compilation/RuntimeEmitter.Arrays.Search.cs
+++ b/Compilation/RuntimeEmitter.Arrays.Search.cs
@@ -1283,7 +1283,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Br, setSepLabel);
         il.MarkLabel(hasSep);
         il.Emit(OpCodes.Ldarg_1);
-        il.Emit(OpCodes.Call, runtime.Stringify);
+        il.Emit(OpCodes.Call, runtime.ToJsString);
         il.MarkLabel(setSepLabel);
         il.Emit(OpCodes.Stloc, sepLocal);
 
@@ -1338,10 +1338,13 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Isinst, runtime.UndefinedType);
         il.Emit(OpCodes.Brtrue, skipAppend);
 
-        // sb.Append(Stringify(elem))
+        // sb.Append(ToJsString(elem)) — ECMA-262 23.1.3.16 step 7 ToString per element:
+        // a nested array joins recursively and an object / class instance (incl. Error)
+        // dispatches its toString, rather than the console/debug Stringify form
+        // ("[1, 2]" / "{ a: 1 }" / "ClassName") (#922 follow-up).
         il.Emit(OpCodes.Ldloc, sbLocal);
         il.Emit(OpCodes.Ldloc, elemLocal);
-        il.Emit(OpCodes.Call, runtime.Stringify);
+        il.Emit(OpCodes.Call, runtime.ToJsString);
         il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.StringBuilder, "Append", _types.String));
         il.Emit(OpCodes.Pop);
 

--- a/Compilation/RuntimeEmitter.CoreUtilities.cs
+++ b/Compilation/RuntimeEmitter.CoreUtilities.cs
@@ -1934,7 +1934,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Brtrue, skipAppend);
         il.Emit(OpCodes.Ldloc, sbJoinLocal);
         il.Emit(OpCodes.Ldloc, valLocalJ);
-        il.Emit(OpCodes.Call, runtime.Stringify);
+        il.Emit(OpCodes.Call, runtime.ToJsString);
         il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.StringBuilder, "Append", _types.String));
         il.Emit(OpCodes.Pop);
         il.MarkLabel(skipAppend);

--- a/Execution/Interpreter.Operators.cs
+++ b/Execution/Interpreter.Operators.cs
@@ -1007,6 +1007,10 @@ public partial class Interpreter
 
         if (obj is SharpTSInstance instance)
         {
+            if (TryStringifyInstanceToString(instance, out var instanceString))
+            {
+                return instanceString;
+            }
             return "[object " + instance.GetClass().Name + "]";
         }
 
@@ -1019,5 +1023,27 @@ public partial class Interpreter
         }
 
         return obj.ToString()!;
+    }
+
+    /// <summary>
+    /// String-coerces a class instance per ECMA-262 OrdinaryToPrimitive(hint "string"):
+    /// dispatch to its <c>toString</c> (an own-field shadow first, else
+    /// <c>Error.prototype.toString</c> or a user override resolved up the class chain) when
+    /// present. Returns false when no <c>toString</c> exists so callers keep the
+    /// "[object ClassName]" default for plain instances. Mirrors compiled mode's generic
+    /// property lookup + invoke (#922).
+    /// </summary>
+    private bool TryStringifyInstanceToString(SharpTSInstance instance, out string result)
+    {
+        result = "";
+        ISharpTSCallable? fn = instance.GetRawField("toString") as ISharpTSCallable;
+        if (fn is null && instance.GetClass().FindMethod("toString") is { } method)
+        {
+            fn = SharpTSClass.BindMethod(method, instance);
+        }
+        if (fn is null) return false;
+        var coerced = FunctionBuiltIns.CallWithThis(this, fn, instance, []);
+        result = coerced as string ?? Stringify(coerced);
+        return true;
     }
 }

--- a/Runtime/BuiltIns/ArrayBuiltIns.cs
+++ b/Runtime/BuiltIns/ArrayBuiltIns.cs
@@ -198,7 +198,7 @@ public static class ArrayBuiltIns
         else
         {
             // Default lexicographic sort (JavaScript behavior: numbers sorted as strings)
-            sorted = items.OrderBy(x => Stringify(x.Element), StringComparer.Ordinal)
+            sorted = items.OrderBy(x => CoerceToJsString(interp, x.Element), StringComparer.Ordinal)
                           .ThenBy(x => x.Index);
         }
 
@@ -480,7 +480,7 @@ public static class ArrayBuiltIns
         return Math.Truncate(d);
     }
 
-    private static RuntimeValue JoinV2(Interpreter _, SharpTSArray arr, ReadOnlySpan<RuntimeValue> args)
+    private static RuntimeValue JoinV2(Interpreter interp, SharpTSArray arr, ReadOnlySpan<RuntimeValue> args)
     {
         // ECMA-262 23.1.3.16: holes (and null/undefined values) render as empty
         // string. Separator defaults to "," when absent OR explicitly
@@ -490,7 +490,7 @@ public static class ArrayBuiltIns
         if (args.Length == 0 || args[0].ToObject() is SharpTSUndefined)
             separator = ",";
         else
-            separator = Stringify(args[0].ToObject());
+            separator = CoerceToJsString(interp, args[0].ToObject());
         int len = arr.Length;
         if (len == 0) return RuntimeValue.EmptyString;
         var sb = new System.Text.StringBuilder();
@@ -501,7 +501,7 @@ public static class ArrayBuiltIns
             if (!arr.HasIndex(i)) continue;
             var v = arr[i];
             if (v is null or SharpTSUndefined) continue;
-            sb.Append(Stringify(v));
+            sb.Append(CoerceToJsString(interp, v));
         }
         return RuntimeValue.FromString(sb.ToString());
     }
@@ -924,16 +924,17 @@ public static class ArrayBuiltIns
         return a.Equals(b);
     }
 
-    private static string Stringify(object? obj)
-    {
-        if (obj == null) return "null";
-        if (obj is double d)
-        {
-            return Compilation.RuntimeTypes.FormatNumber(d);
-        }
-        if (obj is bool b) return b ? "true" : "false";
-        return obj.ToString() ?? "null";
-    }
+    /// <summary>
+    /// ECMA-262 ToString of an array element / separator / default-sort key (used by
+    /// join, Array.prototype.toString and the default sort comparator). A nested array
+    /// renders via its own join (recursive, default ","); every other value — class
+    /// instances (incl. Errors, dispatching their <c>toString</c>), plain objects
+    /// ("[object Object]"), boxed wrappers (unwrapped) and primitives — goes through the
+    /// interpreter's ToString. Replaces a bare <c>obj.ToString()</c> that skipped
+    /// <c>toString</c> and leaked the console/debug array/object format (#922 follow-up).
+    /// </summary>
+    private static string CoerceToJsString(Interpreter interp, object? v)
+        => v is SharpTSArray a ? ToJsString(interp, a) : interp.ToStringForStringCall(v);
 
     #region Iterator Methods
 

--- a/Runtime/Types/SharpTSPrimitiveNamespaces.cs
+++ b/Runtime/Types/SharpTSPrimitiveNamespaces.cs
@@ -32,7 +32,10 @@ public class SharpTSStringNamespace : ISharpTSCallable
         // unwrapping a bare wrapper to its primitive (#574). A raw Symbol is
         // exempt from the ToString TypeError per §22.1.1.1 — fall through to its
         // descriptive string.
-        if (arg is SharpTSObject) return interpreter.ToStringForStringCall(arg);
+        // A class instance (incl. Error subtypes) dispatches to its own/prototype
+        // toString via ToStringForStringCall -> Stringify, matching compiled mode and
+        // Node (#922); without this an Error coerces to "ClassName instance".
+        if (arg is SharpTSObject or SharpTSInstance) return interpreter.ToStringForStringCall(arg);
         return arg.ToString() ?? "";
     }
 

--- a/SharpTS.Tests/SharedTests/ArrayIteratorTests.cs
+++ b/SharpTS.Tests/SharedTests/ArrayIteratorTests.cs
@@ -778,7 +778,17 @@ public class ArrayIteratorTests
             """;
 
         var output = TestHarness.Run(source, mode);
-        Assert.Equal("2\n[x, 10]; [y, 20]\n", output);
+        // Each spread Map entry is a tuple array; join ToString-coerces it via the
+        // nested array's own join (default ","), matching Node — "x,10", not the debug
+        // "[x, 10]" form (#922 follow-up; previously this asserted the pre-fix debug
+        // output in BOTH modes). The interpreter now matches Node. Compiled mode still
+        // shows the debug form here because Map-spread tuples are raw object[] (not a
+        // List-backed $Array), so $Runtime.ToJsString falls back to the debug join —
+        // a separate, pre-existing compiled gap tracked apart from this fix.
+        var expected = mode == ExecutionMode.Interpreted
+            ? "2\nx,10; y,20\n"
+            : "2\n[x, 10]; [y, 20]\n";
+        Assert.Equal(expected, output);
     }
 
     [Theory]

--- a/SharpTS.Tests/SharedTests/ArrayMethodTests.cs
+++ b/SharpTS.Tests/SharedTests/ArrayMethodTests.cs
@@ -363,6 +363,67 @@ public class ArrayMethodTests
 
     [Theory]
     [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Array_Join_NestedArrays_JoinRecursively(ExecutionMode mode)
+    {
+        // ECMA-262 23.1.3.16: each element is ToString-coerced, so a nested array
+        // renders via its own join (default ","), not the debug "[1, 2]" form
+        // (#922 follow-up). Also covers `"" + arr` / `${arr}` which share the path.
+        var source = """
+            console.log([[1, 2], [3]].join("-"));
+            console.log("" + [[1, 2], [3]]);
+            console.log(`${[[1, 2], [3]]}`);
+            """;
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("1,2-3\n1,2,3\n1,2,3\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Array_Join_PlainObject_UsesObjectObject(ExecutionMode mode)
+    {
+        // A plain object element ToString-coerces to "[object Object]" (its inherited
+        // Object.prototype.toString), not the console/debug "{ a: 1 }" form (#922 follow-up).
+        var source = """
+            console.log([{ a: 1 }, { b: 2 }].join(", "));
+            """;
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("[object Object], [object Object]\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Array_Join_ErrorElement_DispatchesToString(ExecutionMode mode)
+    {
+        // An Error element in a joined/coerced array dispatches Error.prototype.toString
+        // ("RangeError: boom"), not "RangeError instance" / "[object RangeError]" (#922
+        // follow-up). Was interpreter-only broken; compiled already correct — pins both.
+        var source = """
+            const e = new RangeError("boom");
+            console.log([e, "y"].join(", "));
+            console.log([e].toString());
+            console.log("" + [e]);
+            """;
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("RangeError: boom, y\nRangeError: boom\nRangeError: boom\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void Array_Join_UserToString_DispatchesToString(ExecutionMode mode)
+    {
+        // A user class with its own toString() is dispatched per element (#922
+        // follow-up). Interpreter-only: compiled mode has a separate, pre-existing
+        // gap where ToJsString returns the class name for non-Error instances.
+        var source = """
+            class Pt { x = 1; y = 2; toString() { return `(${this.x},${this.y})`; } }
+            console.log([new Pt(), new Pt()].join("|"));
+            """;
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("(1,2)|(1,2)\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void Array_Concat_ReturnsNewArray(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/ErrorTests.cs
+++ b/SharpTS.Tests/SharedTests/ErrorTests.cs
@@ -75,6 +75,59 @@ public class ErrorTests
 
     [Theory]
     [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Error_StringCoercion_InvokesToString(ExecutionMode mode)
+    {
+        // #922: String(e), "" + e and `${e}` must dispatch to Error.toString()
+        // (like e.toString() and Node), not fall back to a placeholder. Was
+        // interpreter-only broken ("RangeError instance" / "[object RangeError]");
+        // compiled was already correct — this pins both.
+        var source = @"
+            const e = new RangeError('real range error');
+            console.log(String(e));
+            console.log('' + e);
+            console.log(`${e}`);
+            console.log(e.toString());
+        ";
+        var output = TestHarness.Run(source, mode);
+        const string expected = "RangeError: real range error\n";
+        Assert.Equal(expected + expected + expected + expected, output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void Instance_StringCoercion_InvokesUserToString(ExecutionMode mode)
+    {
+        // #922 generalization: a user class with its own toString() is dispatched
+        // in every string-coercion form, matching Node. (Interpreter-only: compiled
+        // mode has a separate pre-existing quirk that yields the class name here.)
+        var source = @"
+            class Pt { x = 1; y = 2; toString() { return `(${this.x},${this.y})`; } }
+            const p = new Pt();
+            console.log(String(p));
+            console.log('' + p);
+            console.log(`${p}`);
+        ";
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("(1,2)\n(1,2)\n(1,2)\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void Instance_StringCoercion_NoToString_KeepsDefault(ExecutionMode mode)
+    {
+        // #922 fallback guard: a plain instance with no toString() keeps the
+        // interpreter's "[object ClassName]" default rather than throwing or
+        // dispatching a phantom method.
+        var source = @"
+            class Plain { x = 1; }
+            console.log('' + new Plain());
+        ";
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("[object Plain]\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void Error_HasStackProperty(ExecutionMode mode)
     {
         var source = @"


### PR DESCRIPTION
## Summary

Fixes #922. In the **interpreter**, string-coercing a class instance skipped its `toString()`:

| Expression | Before (interp) | After (interp + compiled + Node) |
|---|---|---|
| `String(e)` | `RangeError instance` | `RangeError: real range error` |
| `"" + e` | `[object RangeError]` | `RangeError: real range error` |
| `` `${e}` `` | `[object RangeError]` | `RangeError: real range error` |
| `e.toString()` | ✓ already correct | ✓ |

Two distinct paths skipped `toString` (hence the two different wrong outputs):
- `Stringify` (`Interpreter.Operators.cs`) hard-coded `"[object ClassName]"` for `SharpTSInstance` — served `"" + e` and `` `${e}` ``.
- `SharpTSStringNamespace.Call` routed only `SharpTSObject` through `ToStringForStringCall`; instances fell through to `SharpTSInstance.ToString()` (`"ClassName instance"`) — served `String(e)`.

Fix: a `TryStringifyInstanceToString` helper dispatches an instance's `toString` (own-field shadow first, else up the class chain via `FindMethod`/`BindMethod`), wired into `Stringify`; and `SharpTSInstance` now routes through `ToStringForStringCall`. Generalizes to any user class with a custom `toString`, matching compiled mode and Node.

## Follow-up (same root cause): array element coercion

`join` / `Array.prototype.toString` / `String(arr)` / `"" + arr` / `` `${arr}` `` used a debug stringifier that skipped `toString`, mis-rendered nested arrays, and inspect-formatted objects — in **both** modes:

| Case | Before (interp / compiled) | After (both) |
|---|---|---|
| `[err].join()` / `"" + [err]` | `Error instance` / `Error: m` | `Error: m` |
| `[[1,2],[3]].join("-")` | `[1, 2]-[3]` | `1,2-3` |
| `[{a:1}].join()` | `{ a: 1 }` | `[object Object]` |

- **Interpreter** (`ArrayBuiltIns`): new `CoerceToJsString` does ECMA ToString per element/separator/default-sort key (nested array → recursive join; instance/Error → `toString`; plain object → `[object Object]`; wrappers unwrapped).
- **Compiled** (`EmitArrayJoin`, `ToJsString` array branch): call `ToJsString` per element instead of the debug `Stringify` — the latter's comment already intended recursion.

## Tests
- New shared tests (`ArrayMethodTests`, `ErrorTests`): errors / nested arrays / plain objects across both modes; interpreted-only for user-class `toString`.
- Corrected `Spread_Map_CreatesArrayOfTuples`, which **asserted the pre-fix debug output** (`[x, 10]`) — now `x,10` to match Node, with a mode-dependent expectation documenting the compiled `object[]`-tuple gap below.
- Full suite green apart from the pre-existing stale **untracked** `SharpTS.Tests/Test262/` baseline (identical drift, no new regressions).

## Discovered, filed separately (pre-existing compiled-only gaps)
1. Compiled doesn't dispatch user-class (non-Error) `toString` in any string coercion (`String(new Pt())` → `"Pt"`). #922's "compiled is correct" only held because it tested `Error` (specially handled).
2. Compiled `object[]` (Map/Set/generator spread) tuples hit `ToJsString`'s debug fallback.