### PR TITLE
fix(compiled): string-coerce a class instance via its toString (#931/#933)

### DIFF
--- a/Compilation/RuntimeEmitter.CoreUtilities.cs
+++ b/Compilation/RuntimeEmitter.CoreUtilities.cs
@@ -1799,12 +1799,15 @@ public partial class RuntimeEmitter
         // A bigint coerces to its bare decimal form ("42"), not Stringify's "42n".
         EmitBigIntToStringReturn(il);
 
-        // An object-like value ($Object / Dictionary / List) coerces via
-        // ToJsString — the spec ToString → OrdinaryToPrimitive(string) protocol,
-        // which honors an own toString override and unwraps a boxed wrapper to
-        // its primitive (#574). Plain Stringify returns "[object Object]" for a
-        // wrapper, which is wrong for template literals / string concat. Primitive
-        // values stay on the cheap Stringify path.
+        // An object-like value ($Object / Dictionary / List / user class instance)
+        // coerces via ToJsString — the spec ToString → OrdinaryToPrimitive(string)
+        // protocol, which honors an own toString override and unwraps a boxed
+        // wrapper to its primitive (#574). Plain Stringify returns "[object Object]"
+        // for a wrapper and the bare "<Class> instance" CLR form for a user class
+        // instance, both wrong for template literals / string concat. A user class
+        // instance is identified by the $IHasFields marker — $Error/Map/Set/
+        // $TSFunction don't implement it, so they keep Stringify's path (#931).
+        // Primitive values stay on the cheap Stringify path.
         var objectLikeLabel = il.DefineLabel();
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Isinst, runtime.TSObjectType);
@@ -1814,6 +1817,9 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Brtrue, objectLikeLabel);
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Isinst, _types.ListOfObject);
+        il.Emit(OpCodes.Brtrue, objectLikeLabel);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Isinst, runtime.IHasFieldsInterface);
         il.Emit(OpCodes.Brtrue, objectLikeLabel);
 
         // return Stringify(value);  (primitives)
@@ -1949,13 +1955,21 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ret);
         il.MarkLabel(notListLabel);
 
-        // Only attempt JS-toString invocation for Dictionary or $Object receivers.
+        // Only attempt JS-toString invocation for Dictionary, $Object, or user
+        // class instances ($IHasFields marker — #931). $Error/Map/Set/$TSFunction
+        // don't implement $IHasFields, so they fall through to Stringify (Error
+        // keeps its overridden CLR ToString → "TypeError: x"). A user class
+        // instance resolves toString/valueOf through its generated GetProperty,
+        // yielding the user override or "[object Object]" when neither exists.
         var isObjectLikeLabel = il.DefineLabel();
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Isinst, _types.DictionaryStringObject);
         il.Emit(OpCodes.Brtrue, isObjectLikeLabel);
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Isinst, runtime.TSObjectType);
+        il.Emit(OpCodes.Brtrue, isObjectLikeLabel);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Isinst, runtime.IHasFieldsInterface);
         il.Emit(OpCodes.Brtrue, isObjectLikeLabel);
         il.Emit(OpCodes.Br, fallbackLabel);
 

--- a/Execution/Interpreter.Operators.cs
+++ b/Execution/Interpreter.Operators.cs
@@ -1032,11 +1032,12 @@ public partial class Interpreter
             // Error.prototype.toString -> "TypeError: msg", or a user-defined
             // override. Invoke it so string coercion (templates, `+`, String())
             // matches Node/compiled mode instead of yielding "<Class> instance"
-            // or "[object <Class>]" (#921/#922). Fall back to the brand form
-            // only when no callable toString resolves (e.g. a plain class).
+            // (#921/#922). Fall back to "[object Object]" only when no callable
+            // toString resolves (e.g. a plain class) — Node's Object.prototype.toString
+            // brand for an ordinary object, matching compiled mode (#931).
             if (TryStringifyInstanceViaToString(instance, out var instanceStr))
                 return instanceStr;
-            return "[object " + instance.GetClass().Name + "]";
+            return "[object Object]";
         }
 
         // ECMA-262 7.1.17 ToString(bigint) = bare numeric form ("42"). The "42n"

--- a/SharpTS.Tests/SharedTests/ArrayMethodTests.cs
+++ b/SharpTS.Tests/SharedTests/ArrayMethodTests.cs
@@ -408,12 +408,12 @@ public class ArrayMethodTests
     }
 
     [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void Array_Join_UserToString_DispatchesToString(ExecutionMode mode)
     {
         // A user class with its own toString() is dispatched per element (#922
-        // follow-up). Interpreter-only: compiled mode has a separate, pre-existing
-        // gap where ToJsString returns the class name for non-Error instances.
+        // follow-up). Compiled mode now dispatches it too — the prior gap where
+        // ToJsString returned the class name for non-Error instances is fixed (#931/#933).
         var source = """
             class Pt { x = 1; y = 2; toString() { return `(${this.x},${this.y})`; } }
             console.log([new Pt(), new Pt()].join("|"));

--- a/SharpTS.Tests/SharedTests/ClassToStringCoercionTests.cs
+++ b/SharpTS.Tests/SharedTests/ClassToStringCoercionTests.cs
@@ -1,0 +1,62 @@
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests;
+
+/// <summary>
+/// String coercion of a class instance must go through the instance's toString
+/// (resolved via its class chain), matching Node and the interpreter (#931).
+/// A plain class with no toString brands as "[object Object]"; a user toString
+/// override wins. Covers String(x), template literals, and "" + x in both modes.
+/// </summary>
+public class ClassToStringCoercionTests
+{
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void PlainClass_StringCoercion_BrandsAsObjectObject(ExecutionMode mode)
+    {
+        // No toString override → Object.prototype brand "[object Object]" (Node),
+        // not the bare class name / "<Class> instance" CLR form.
+        var source = @"
+            class Foo {}
+            let f: any = new Foo();
+            console.log(String(f));
+            console.log(`${f}`);
+            console.log('' + f);
+        ";
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("[object Object]\n[object Object]\n[object Object]\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void UserToString_StringCoercion_InvokesOverride(ExecutionMode mode)
+    {
+        var source = @"
+            class Bar { toString() { return 'bar!'; } }
+            let z: any = new Bar();
+            console.log(String(z));
+            console.log(`${z}`);
+            console.log('v=' + z);
+        ";
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("bar!\nbar!\nv=bar!\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void UserToString_ReturningNumber_CoercesToStringForm(ExecutionMode mode)
+    {
+        // toString returning a primitive number is a valid OrdinaryToPrimitive
+        // result; it stringifies to the number's natural form.
+        var source = @"
+            class Num { toString() { return 42; } }
+            let n: any = new Num();
+            console.log(String(n));
+            console.log(`${n}`);
+            console.log('' + n);
+        ";
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("42\n42\n42\n", output);
+    }
+}

--- a/SharpTS.Tests/SharedTests/ErrorTests.cs
+++ b/SharpTS.Tests/SharedTests/ErrorTests.cs
@@ -118,12 +118,12 @@ public class ErrorTests
     }
 
     [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void Instance_StringCoercion_InvokesUserToString(ExecutionMode mode)
     {
         // #922 generalization: a user class with its own toString() is dispatched
-        // in every string-coercion form, matching Node. (Interpreter-only: compiled
-        // mode has a separate pre-existing quirk that yields the class name — #933.)
+        // in every string-coercion form, matching Node. Compiled mode now dispatches
+        // it too (#931/#933) — pins both.
         var source = @"
             class Pt { x = 1; y = 2; toString() { return `(${this.x},${this.y})`; } }
             const p = new Pt();
@@ -136,18 +136,18 @@ public class ErrorTests
     }
 
     [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void Instance_StringCoercion_NoToString_KeepsDefault(ExecutionMode mode)
     {
-        // #922 fallback guard: a plain instance with no toString() keeps the
-        // interpreter's "[object ClassName]" default rather than throwing or
-        // dispatching a phantom method.
+        // A plain instance with no toString() brands as Node's ordinary-object
+        // "[object Object]" (Object.prototype.toString), not the class name — in
+        // both modes (#931). Was "[object Plain]" before compiled/interp parity.
         var source = @"
             class Plain { x = 1; }
             console.log('' + new Plain());
         ";
         var output = TestHarness.Run(source, mode);
-        Assert.Equal("[object Plain]\n", output);
+        Assert.Equal("[object Object]\n", output);
     }
 
     [Theory]


### PR DESCRIPTION
## Summary

Closes #931. Closes #933 (its compiled-mode duplicate). In **compiled** mode, string-coercing a class instance ignored the instance's `toString`: `String(x)`, `` `${x}` ``, `"" + x`, and `[x].join()` returned the bare class name (the generated type's CLR `ToString` → `"Foo instance"`) — ignoring a user `toString` override and yielding the class name instead of Node's `[object Object]` for a plain class. `Error` instances were already correct (their overridden CLR `ToString` produces `"Name: message"`).

| expression | Before (compiled) | After (both modes) / Node |
|---|---|---|
| `String(new Foo())` (no `toString`) | `Foo` | `[object Object]` |
| `` `${new Foo()}` `` / `"" + new Foo()` | `Foo` | `[object Object]` |
| `String(new Pt())` (user `toString`) | `Pt` | `(1,2)` |
| `[new Pt()].join(",")` | `Pt` | `(1,2)` |

## Root cause

Both `$Runtime.ToJsString` and `$Runtime.StringifyCoerce` gated the ECMA-262 `ToString → OrdinaryToPrimitive(string)` machinery (own `@@toPrimitive`, then `toString`, then `valueOf`, else `"[object Object]"`) to `Dictionary` / `$Object` receivers only. An emitted user-class instance is neither, so it fell through to the cheap `Stringify`, whose default case calls CLR `ToString`.

## Fix

- **Compiled** (`Compilation/RuntimeEmitter.CoreUtilities.cs`): admit user-class instances to the toString-resolving path via the **`$IHasFields`** marker — implemented by every emitted user class, but **not** by `$Error` / `Map` / `Set` / `$TSFunction`, so `Error` keeps its overridden-`ToString` path untouched. The existing `GetProperty("toString")` + `InvokeMethodValue` logic then dispatches a user override or falls back to `"[object Object]"`. `join()` is already routed through `ToJsString` per element (#922), so it's fixed by the same change.
- **Interpreter parity** (`Execution/Interpreter.Operators.cs`): a plain class instance with no `toString` now brands as `"[object Object]"` (Node's `Object.prototype.toString` for an ordinary object) instead of `"[object <Class>]"`, matching compiled mode. The #922 user-`toString` dispatch is unchanged.

This keeps the interpreter↔compiled parity invariant: both modes now produce identical, Node-matching output.

## Tests

- New dual-mode `ClassToStringCoercionTests` (plain class → `[object Object]`; user `toString` override; `toString` returning a number).
- Promoted the previously interpreter-only instance/join `toString` tests (`ErrorTests.Instance_StringCoercion_*`, `ArrayMethodTests.Array_Join_UserToString_DispatchesToString`) to **dual-mode**, and updated the plain-instance fallback expectation from `[object Plain]` to `[object Object]`.
- Full suite **14222 passed, 0 failed**; `DifferentialParityTests` / `ObjectToStringTag` / Test262-adjacent suites green.

## Verification

The #931 and #933 repros produce identical, Node-correct output in both interpreted and compiled modes (`(1,2) ...` for the `Pt` class; `[object Object] ...` for a plain `Foo`).

