### PR TITLE
fix(compiled): string-coerce Map-spread KVP tuples via join (#934)

### DIFF
--- a/Compilation/RuntimeEmitter.CoreUtilities.cs
+++ b/Compilation/RuntimeEmitter.CoreUtilities.cs
@@ -1955,6 +1955,65 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ret);
         il.MarkLabel(notListLabel);
 
+        // KeyValuePair<object, object> → treat as a 2-element [key, value] tuple for
+        // string coercion (ECMA-262 Array.prototype.toString ≡ join(",")). Map-spread
+        // tuples land here in compiled mode because IterateToList falls through to the
+        // IEnumerable path, yielding boxed KVP structs instead of List<object> pairs.
+        var notKvpLabel = il.DefineLabel();
+        var kvpType = _types.MakeGenericType(_types.KeyValuePairOpen, _types.Object, _types.Object);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Isinst, kvpType);
+        il.Emit(OpCodes.Brfalse, notKvpLabel);
+        var kvpLocal = il.DeclareLocal(kvpType);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Unbox_Any, kvpType);
+        il.Emit(OpCodes.Stloc, kvpLocal);
+        var sbKvpLocal = il.DeclareLocal(_types.StringBuilder);
+        il.Emit(OpCodes.Newobj, _types.GetConstructor(_types.StringBuilder, _types.EmptyTypes));
+        il.Emit(OpCodes.Stloc, sbKvpLocal);
+        // Key (index 0): skip if null/undefined, else recursive ToJsString
+        var keyLocal = il.DeclareLocal(_types.Object);
+        var skipKeyAppend = il.DefineLabel();
+        il.Emit(OpCodes.Ldloca, kvpLocal);
+        il.Emit(OpCodes.Call, _types.GetProperty(kvpType, "Key").GetGetMethod()!);
+        il.Emit(OpCodes.Stloc, keyLocal);
+        il.Emit(OpCodes.Ldloc, keyLocal);
+        il.Emit(OpCodes.Brfalse, skipKeyAppend);
+        il.Emit(OpCodes.Ldloc, keyLocal);
+        il.Emit(OpCodes.Isinst, runtime.UndefinedType);
+        il.Emit(OpCodes.Brtrue, skipKeyAppend);
+        il.Emit(OpCodes.Ldloc, sbKvpLocal);
+        il.Emit(OpCodes.Ldloc, keyLocal);
+        il.Emit(OpCodes.Call, runtime.ToJsString);
+        il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.StringBuilder, "Append", _types.String));
+        il.Emit(OpCodes.Pop);
+        il.MarkLabel(skipKeyAppend);
+        il.Emit(OpCodes.Ldloc, sbKvpLocal);
+        il.Emit(OpCodes.Ldstr, ",");
+        il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.StringBuilder, "Append", _types.String));
+        il.Emit(OpCodes.Pop);
+        // Value (index 1): skip if null/undefined, else recursive ToJsString
+        var valueLocal = il.DeclareLocal(_types.Object);
+        var skipValueAppend = il.DefineLabel();
+        il.Emit(OpCodes.Ldloca, kvpLocal);
+        il.Emit(OpCodes.Call, _types.GetProperty(kvpType, "Value").GetGetMethod()!);
+        il.Emit(OpCodes.Stloc, valueLocal);
+        il.Emit(OpCodes.Ldloc, valueLocal);
+        il.Emit(OpCodes.Brfalse, skipValueAppend);
+        il.Emit(OpCodes.Ldloc, valueLocal);
+        il.Emit(OpCodes.Isinst, runtime.UndefinedType);
+        il.Emit(OpCodes.Brtrue, skipValueAppend);
+        il.Emit(OpCodes.Ldloc, sbKvpLocal);
+        il.Emit(OpCodes.Ldloc, valueLocal);
+        il.Emit(OpCodes.Call, runtime.ToJsString);
+        il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.StringBuilder, "Append", _types.String));
+        il.Emit(OpCodes.Pop);
+        il.MarkLabel(skipValueAppend);
+        il.Emit(OpCodes.Ldloc, sbKvpLocal);
+        il.Emit(OpCodes.Callvirt, _types.GetMethodNoParams(_types.StringBuilder, "ToString"));
+        il.Emit(OpCodes.Ret);
+        il.MarkLabel(notKvpLabel);
+
         // Only attempt JS-toString invocation for Dictionary, $Object, or user
         // class instances ($IHasFields marker — #931). $Error/Map/Set/$TSFunction
         // don't implement $IHasFields, so they fall through to Stringify (Error

--- a/SharpTS.Tests/SharedTests/ArrayIteratorTests.cs
+++ b/SharpTS.Tests/SharedTests/ArrayIteratorTests.cs
@@ -778,17 +778,7 @@ public class ArrayIteratorTests
             """;
 
         var output = TestHarness.Run(source, mode);
-        // Each spread Map entry is a tuple array; join ToString-coerces it via the
-        // nested array's own join (default ","), matching Node — "x,10", not the debug
-        // "[x, 10]" form (#922 follow-up; previously this asserted the pre-fix debug
-        // output in BOTH modes). The interpreter now matches Node. Compiled mode still
-        // shows the debug form here because Map-spread tuples are raw object[] (not a
-        // List-backed $Array), so $Runtime.ToJsString falls back to the debug join —
-        // a separate, pre-existing compiled gap tracked apart from this fix.
-        var expected = mode == ExecutionMode.Interpreted
-            ? "2\nx,10; y,20\n"
-            : "2\n[x, 10]; [y, 20]\n";
-        Assert.Equal(expected, output);
+        Assert.Equal("2\nx,10; y,20\n", output);
     }
 
     [Theory]


### PR DESCRIPTION
## Summary

- In compiled mode, `[...m]` (Map spread) falls through `IterateToList` → IEnumerable path → boxed `KeyValuePair<object, object>` structs. `ToJsString` had no branch for KVPs so they hit `Stringify` → `KVP.ToString()` = `"[key, value]"` (wrong debug form).
- Add a `KeyValuePair<object, object>` branch to `EmitToJsString` (after `notListLabel`, before the Dictionary/TSObject checks), mirroring the existing `List<object>` join block: unbox the KVP, build `"key,value"` via StringBuilder, treating null/undefined as empty per ECMA-262 `Array.prototype.join`.
- Unify `Spread_Map_CreatesArrayOfTuples` test to a single expected value for both modes.

Closes #934.

## Test plan

- [ ] `Spread_Map_CreatesArrayOfTuples` passes for both Interpreted and Compiled (was mode-conditional before)
- [ ] All 102 `ArrayIterator` tests pass with no regressions
- [ ] Full test suite passes