### PR TITLE
perf(compiled): gated native-int loop counter + typed-array receiver hoist (#928)

### DIFF
--- a/Compilation/CompilationContext.cs
+++ b/Compilation/CompilationContext.cs
@@ -64,6 +64,12 @@ public partial class CompilationContext
     /// </summary>
     public TypeProvider Types { get; }
 
+    // Integer loop-counter prototype (#928, gated by SHARPTS_INT_LOOP_COUNTER): names of locals
+    // currently backed by a native Int64 slot because they are provably-integer monotonic loop
+    // counters. Reads convert to double on load; the increment and recognized index sites consume
+    // the int directly. Populated/cleared per loop scope by EmitFor/EmitVarStatement.
+    public HashSet<string> IntegerCounterLocals { get; } = new();
+
     // Emitted runtime types and methods (for standalone DLLs)
     public EmittedRuntime? Runtime { get; set; }
 

--- a/Compilation/CompilationContext.cs
+++ b/Compilation/CompilationContext.cs
@@ -30,6 +30,14 @@ public enum StackType
 public record struct HoistedArrayEntry(LocalBuilder TypedLocal, ArrayElementsDescriptor Descriptor);
 
 /// <summary>
+/// Entry in the hoisted typed-array cache (#928): a loop-invariant variable statically typed as a
+/// numeric TypedArray, cast to its concrete <c>$XArray</c> type ONCE before the loop. The element
+/// index fast paths load <see cref="TypedLocal"/> directly instead of re-emitting
+/// <c>ldloc; castclass $XArray</c> on every access.
+/// </summary>
+public record struct HoistedTypedArrayEntry(LocalBuilder TypedLocal, Type XArrayType, string ElementType);
+
+/// <summary>
 /// Holds compilation state passed between ILCompiler and ILEmitter.
 /// </summary>
 /// <remarks>
@@ -252,6 +260,26 @@ public partial class CompilationContext
     public HoistedArrayEntry? TryGetHoistedArray(string variableName)
     {
         foreach (var cache in HoistedArrayCaches)
+        {
+            if (cache.TryGetValue(variableName, out var entry))
+                return entry;
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Hoisted typed-array receiver caches (#928), innermost loop scope on top. Parallel to
+    /// <see cref="HoistedArrayCaches"/> but for numeric TypedArray receivers cast to their concrete
+    /// <c>$XArray</c> type once per loop.
+    /// </summary>
+    public Stack<Dictionary<string, HoistedTypedArrayEntry>> HoistedTypedArrayCaches { get; } = new();
+
+    /// <summary>
+    /// Looks up a hoisted typed-array receiver for the given variable name, innermost loop scope first.
+    /// </summary>
+    public HoistedTypedArrayEntry? TryGetHoistedTypedArray(string variableName)
+    {
+        foreach (var cache in HoistedTypedArrayCaches)
         {
             if (cache.TryGetValue(variableName, out var entry))
                 return entry;

--- a/Compilation/ForLoopAnalyzer.cs
+++ b/Compilation/ForLoopAnalyzer.cs
@@ -18,6 +18,80 @@ namespace SharpTS.Compilation;
 public static class ForLoopAnalyzer
 {
     /// <summary>
+    /// Integer loop-counter prototype gate (#928). When enabled, a provably-integer monotonic
+    /// loop counter is backed by a native <c>Int64</c> slot instead of a <c>double</c> — its
+    /// increment stays native int and recognized index sites (<c>a[i]</c>, <c>a[i±k]</c>) consume
+    /// it directly, closing the typed-array kernel gap to Node. Off by default (zero behavior
+    /// change); opt in with <c>SHARPTS_INT_LOOP_COUNTER=1</c> while the prototype is validated.
+    /// </summary>
+    public static readonly bool IntegerCounterEnabled =
+        Environment.GetEnvironmentVariable("SHARPTS_INT_LOOP_COUNTER") == "1";
+
+    /// <summary>
+    /// Identifies a for-loop counter eligible for the native <c>Int64</c> representation, or null.
+    /// Stricter than <see cref="Analyze"/>: requires an INTEGER-literal initializer, a pure
+    /// <c>++</c>/<c>--</c> step, a numeric condition, no closure capture, and no reassignment or
+    /// re-declaration of the counter anywhere in the body (so it only ever changes by ±1). Unlike
+    /// <see cref="Analyze"/> it does NOT bail on an explicit <c>: number</c> annotation — the common
+    /// real-world / benchmark form <c>for (let i: number = 0; i &lt; n; i++)</c> must qualify.
+    ///
+    /// Soundness: TS <c>number</c> is a double, but an integer counter stepping by ±1 stays exactly
+    /// representable as both <c>long</c> and <c>double</c> for any loop that terminates in finite
+    /// time (≤ 2^53), so reads materialized as <c>conv.r8</c> are bit-identical to today's double
+    /// counter. Values only ever observed as doubles; no native-int arithmetic is exposed.
+    /// </summary>
+    public static string? AnalyzeIntegerCounter(Stmt.For forLoop, ClosureAnalyzer? closureAnalyzer)
+    {
+        if (forLoop.Initializer is not Stmt.Var varDecl)
+            return null;
+
+        string varName = varDecl.Name.Lexeme;
+
+        // Initializer must be an INTEGER literal (0, 1, -1, …).
+        if (!TryGetNumericLiteral(varDecl.Initializer, out double initialValue))
+            return null;
+        if (double.IsNaN(initialValue) || double.IsInfinity(initialValue)
+            || initialValue != Math.Truncate(initialValue))
+            return null;
+
+        // Step must be exactly ++ or -- on the counter (prototype scope: no += / i = i + k yet).
+        if (forLoop.Increment is not (Expr.PostfixIncrement or Expr.PrefixIncrement)
+            || !IsSimpleIncDecOf(forLoop.Increment, varName))
+            return null;
+
+        // Must not be captured by a closure (a captured counter needs the boxed/cell representation).
+        if (closureAnalyzer != null && closureAnalyzer.IsVariableCaptured(varName))
+            return null;
+        if (ContainsPotentialCapture(forLoop.Body, varName))
+            return null;
+
+        // Condition must use the counter in numeric comparisons.
+        if (forLoop.Condition != null && !IsNumericComparison(forLoop.Condition, varName))
+            return null;
+
+        // The counter must change ONLY via the increment clause: bail if the body reassigns,
+        // compound-assigns, ++/-- s, or re-declares it (e.g. a shadowing nested loop counter).
+        if (CounterMutatedInBody(forLoop.Body, varName))
+            return null;
+
+        return varName;
+    }
+
+    private static bool IsSimpleIncDecOf(Expr increment, string varName) => increment switch
+    {
+        Expr.PostfixIncrement pi => IsVariableReference(pi.Operand, varName),
+        Expr.PrefixIncrement pri => IsVariableReference(pri.Operand, varName),
+        _ => false
+    };
+
+    private static bool CounterMutatedInBody(Stmt body, string varName)
+    {
+        var v = new CounterMutationVisitor(varName);
+        v.Visit(body);
+        return v.Mutated;
+    }
+
+    /// <summary>
     /// Result of analyzing a for loop for unboxed counter optimization.
     /// </summary>
     public readonly struct AnalysisResult
@@ -275,6 +349,51 @@ public static class ForLoopAnalyzer
                 HasPotentialCapture = true;
             }
             base.VisitAssign(expr);
+        }
+    }
+
+    /// <summary>
+    /// Flags any mutation of the named counter inside a loop body: assignment, compound-assignment,
+    /// ++/--, or re-declaration (a shadowing nested-loop counter of the same name). Used by
+    /// <see cref="AnalyzeIntegerCounter"/> to guarantee the counter only ever changes by the
+    /// loop's ±1 increment clause, so the native Int64 representation can never observe a
+    /// non-integer or out-of-step value.
+    /// </summary>
+    private class CounterMutationVisitor : Parsing.Visitors.AstVisitorBase
+    {
+        private readonly string _varName;
+        public bool Mutated { get; private set; }
+
+        public CounterMutationVisitor(string varName) => _varName = varName;
+
+        protected override void VisitAssign(Expr.Assign expr)
+        {
+            if (expr.Name.Lexeme == _varName) Mutated = true;
+            base.VisitAssign(expr);
+        }
+
+        protected override void VisitCompoundAssign(Expr.CompoundAssign expr)
+        {
+            if (expr.Name.Lexeme == _varName) Mutated = true;
+            base.VisitCompoundAssign(expr);
+        }
+
+        protected override void VisitPrefixIncrement(Expr.PrefixIncrement expr)
+        {
+            if (IsVariableReference(expr.Operand, _varName)) Mutated = true;
+            base.VisitPrefixIncrement(expr);
+        }
+
+        protected override void VisitPostfixIncrement(Expr.PostfixIncrement expr)
+        {
+            if (IsVariableReference(expr.Operand, _varName)) Mutated = true;
+            base.VisitPostfixIncrement(expr);
+        }
+
+        protected override void VisitVar(Stmt.Var stmt)
+        {
+            if (stmt.Name.Lexeme == _varName) Mutated = true;
+            base.VisitVar(stmt);
         }
     }
 }

--- a/Compilation/ForLoopAnalyzer.cs
+++ b/Compilation/ForLoopAnalyzer.cs
@@ -59,19 +59,30 @@ public static class ForLoopAnalyzer
             || !IsSimpleIncDecOf(forLoop.Increment, varName))
             return null;
 
-        // Must not be captured by a closure (a captured counter needs the boxed/cell representation).
-        if (closureAnalyzer != null && closureAnalyzer.IsVariableCaptured(varName))
+        // Must not be captured by a closure (a captured counter needs the boxed/cell representation,
+        // not a native Int64 slot). A `let`/`const` counter is block-scoped to the loop, so any
+        // capturing closure is lexically inside the body / condition / increment — detect that
+        // PRECISELY. The global, name-keyed ClosureAnalyzer.IsVariableCaptured bails whenever ANY
+        // closure anywhere in the whole bundled program captures a same-named variable, which
+        // silently disabled this optimization across multi-module programs (the #928 coverage gap).
+        // A `var` counter is function-scoped and may be captured AFTER the loop, where the precise
+        // scan can't see it, so keep the conservative global check for that (uncommon) case.
+        if (varDecl.IsVar && closureAnalyzer != null && closureAnalyzer.IsVariableCaptured(varName))
             return null;
-        if (ContainsPotentialCapture(forLoop.Body, varName))
+        if (ContainsPotentialCapture(forLoop.Body, varName)
+            || (forLoop.Condition != null && ContainsPotentialCaptureExpr(forLoop.Condition, varName))
+            || (forLoop.Increment != null && ContainsPotentialCaptureExpr(forLoop.Increment, varName)))
             return null;
 
         // Condition must use the counter in numeric comparisons.
         if (forLoop.Condition != null && !IsNumericComparison(forLoop.Condition, varName))
             return null;
 
-        // The counter must change ONLY via the increment clause: bail if the body reassigns,
-        // compound-assigns, ++/-- s, or re-declares it (e.g. a shadowing nested loop counter).
-        if (CounterMutatedInBody(forLoop.Body, varName))
+        // The counter must change ONLY via the ++/-- increment clause: bail if the body or
+        // condition reassigns, compound-assigns, ++/-- s, or re-declares it (a shadowing nested
+        // counter). The increment clause itself is the validated ++/-- step, so it is not scanned.
+        if (CounterMutatedInBody(forLoop.Body, varName)
+            || (forLoop.Condition != null && CounterMutatedInExpr(forLoop.Condition, varName)))
             return null;
 
         return varName;
@@ -89,6 +100,20 @@ public static class ForLoopAnalyzer
         var v = new CounterMutationVisitor(varName);
         v.Visit(body);
         return v.Mutated;
+    }
+
+    private static bool CounterMutatedInExpr(Expr expr, string varName)
+    {
+        var v = new CounterMutationVisitor(varName);
+        v.VisitExpr(expr);
+        return v.Mutated;
+    }
+
+    private static bool ContainsPotentialCaptureExpr(Expr expr, string varName)
+    {
+        var v = new CaptureCheckVisitor(varName);
+        v.VisitExpr(expr);
+        return v.HasPotentialCapture;
     }
 
     /// <summary>
@@ -316,6 +341,8 @@ public static class ForLoopAnalyzer
             _varName = varName;
         }
 
+        public void VisitExpr(Expr expr) => Visit(expr);
+
         protected override void VisitArrowFunction(Expr.ArrowFunction expr)
         {
             // Enter a function scope and check for references
@@ -365,6 +392,8 @@ public static class ForLoopAnalyzer
         public bool Mutated { get; private set; }
 
         public CounterMutationVisitor(string varName) => _varName = varName;
+
+        public void VisitExpr(Expr expr) => Visit(expr);
 
         protected override void VisitAssign(Expr.Assign expr)
         {

--- a/Compilation/ILEmitter.Operators.cs
+++ b/Compilation/ILEmitter.Operators.cs
@@ -866,10 +866,112 @@ public partial class ILEmitter
         SetStackUnknown();
     }
 
+    // ===== Integer loop-counter prototype (#928) — gated by SHARPTS_INT_LOOP_COUNTER =====
+
+    /// <summary>True iff <paramref name="name"/> is a loop counter currently backed by a native Int64 slot.</summary>
+    private bool IsIntegerCounterLocal(string name)
+        => _ctx.IntegerCounterLocals.Contains(name)
+           && _ctx.Locals.GetLocalType(name) == _ctx.Types.Int64;
+
+    /// <summary>
+    /// Pushes a typed-array/array index as a native int32. When the index is an integer-counter
+    /// expression (the counter, or counter ± integer literal), emits it in native int — skipping the
+    /// <c>EmitExpressionAsDouble + Conv_I4</c> round trip and the double induction-variable tax that
+    /// dominates typed-array kernels (#928). Produces the identical int32 for the in-range values a
+    /// ±1 loop counter takes, so this is a pure representation choice. Falls back otherwise.
+    /// </summary>
+    private void EmitIndexAsInt32(Expr index)
+    {
+        if (TryEmitIntegerCounterIndexI4(index)) return;
+        EmitExpressionAsDouble(index);
+        IL.Emit(OpCodes.Conv_I4);
+    }
+
+    private bool TryEmitIntegerCounterIndexI4(Expr index)
+    {
+        switch (index)
+        {
+            // a[i]
+            case Expr.Variable v when IsIntegerCounterLocal(v.Name.Lexeme):
+                IL.Emit(OpCodes.Ldloc, _ctx.Locals.GetLocal(v.Name.Lexeme)!);
+                IL.Emit(OpCodes.Conv_I4);
+                return true;
+
+            // a[i + k] / a[i - k]  (counter left, integer literal right)
+            case Expr.Binary { Operator.Type: TokenType.PLUS or TokenType.MINUS } b
+                when b.Left is Expr.Variable lv && IsIntegerCounterLocal(lv.Name.Lexeme)
+                     && TryGetIntLiteralValue(b.Right, out long k):
+                IL.Emit(OpCodes.Ldloc, _ctx.Locals.GetLocal(lv.Name.Lexeme)!);
+                IL.Emit(OpCodes.Ldc_I8, k);
+                IL.Emit(b.Operator.Type == TokenType.PLUS ? OpCodes.Add : OpCodes.Sub);
+                IL.Emit(OpCodes.Conv_I4);
+                return true;
+
+            // a[k + i]  (commutative addition, counter right)
+            case Expr.Binary { Operator.Type: TokenType.PLUS } b2
+                when b2.Right is Expr.Variable rv && IsIntegerCounterLocal(rv.Name.Lexeme)
+                     && TryGetIntLiteralValue(b2.Left, out long k2):
+                IL.Emit(OpCodes.Ldloc, _ctx.Locals.GetLocal(rv.Name.Lexeme)!);
+                IL.Emit(OpCodes.Ldc_I8, k2);
+                IL.Emit(OpCodes.Add);
+                IL.Emit(OpCodes.Conv_I4);
+                return true;
+        }
+        return false;
+    }
+
+    private static bool TryGetIntLiteralValue(Expr e, out long value)
+    {
+        value = 0;
+        double d;
+        if (e is Expr.Literal { Value: double lit }) d = lit;
+        else if (e is Expr.Unary { Operator.Type: TokenType.MINUS, Right: Expr.Literal { Value: double neg } }) d = -neg;
+        else return false;
+        if (double.IsNaN(d) || double.IsInfinity(d) || d != Math.Truncate(d)) return false;
+        value = (long)d;
+        return true;
+    }
+
+    /// <summary>
+    /// Native int64 increment for an integer-counter local: <c>i++</c>/<c>i--</c> (postfix) or
+    /// <c>++i</c>/<c>--i</c> (prefix). Mutates the slot in place and leaves the postfix-old /
+    /// prefix-new value as a double (the numeric expression result). The counter is provably
+    /// non-captured (analyzer), so the cell / display-class write-backs of the general path are
+    /// unnecessary here.
+    /// </summary>
+    private void EmitIntegerCounterIncrement(string name, bool isPlus, bool postfix)
+    {
+        var local = _ctx.Locals.GetLocal(name)!;
+        IL.Emit(OpCodes.Ldloc, local);
+        if (postfix)
+        {
+            IL.Emit(OpCodes.Dup);                            // old, old
+            IL.Emit(OpCodes.Ldc_I8, 1L);
+            IL.Emit(isPlus ? OpCodes.Add : OpCodes.Sub);     // old, new
+            IL.Emit(OpCodes.Stloc, local);                   // old
+        }
+        else
+        {
+            IL.Emit(OpCodes.Ldc_I8, 1L);
+            IL.Emit(isPlus ? OpCodes.Add : OpCodes.Sub);     // new
+            IL.Emit(OpCodes.Dup);                            // new, new
+            IL.Emit(OpCodes.Stloc, local);                   // new
+        }
+        IL.Emit(OpCodes.Conv_R8);
+        SetStackType(StackType.Double);
+    }
+
     protected override void EmitPrefixIncrement(Expr.PrefixIncrement pi)
     {
         if (pi.Operand is Expr.Variable v)
         {
+            // Integer loop-counter prototype (#928): native int64 increment, no double/box round trip.
+            if (IsIntegerCounterLocal(v.Name.Lexeme))
+            {
+                EmitIntegerCounterIncrement(v.Name.Lexeme, isPlus: pi.Operator.Type == TokenType.PLUS_PLUS, postfix: false);
+                return;
+            }
+
             // Check if this is a typed double local
             var localType = _ctx.Locals.GetLocalType(v.Name.Lexeme);
             bool isTypedDouble = localType != null && _ctx.Types.IsDouble(localType);
@@ -1185,6 +1287,13 @@ public partial class ILEmitter
     {
         if (pi.Operand is Expr.Variable v)
         {
+            // Integer loop-counter prototype (#928): native int64 increment, no double/box round trip.
+            if (IsIntegerCounterLocal(v.Name.Lexeme))
+            {
+                EmitIntegerCounterIncrement(v.Name.Lexeme, isPlus: pi.Operator.Type == TokenType.PLUS_PLUS, postfix: true);
+                return;
+            }
+
             // Check if this is a typed double local
             var localType = _ctx.Locals.GetLocalType(v.Name.Lexeme);
             bool isTypedDouble = localType != null && _ctx.Types.IsDouble(localType);
@@ -1694,9 +1803,8 @@ public partial class ILEmitter
             var recvLocal = IL.DeclareLocal(ctaType);
             IL.Emit(OpCodes.Stloc, recvLocal);
 
-            // idx = (int)i
-            EmitExpressionAsDouble(csi.Index);
-            IL.Emit(OpCodes.Conv_I4);
+            // idx = (int)i  (native-int fast path when the index is an integer loop counter, #928)
+            EmitIndexAsInt32(csi.Index);
             var idxLocal = IL.DeclareLocal(_ctx.Types.Int32);
             IL.Emit(OpCodes.Stloc, idxLocal);
 

--- a/Compilation/ILEmitter.Operators.cs
+++ b/Compilation/ILEmitter.Operators.cs
@@ -887,6 +887,24 @@ public partial class ILEmitter
         IL.Emit(OpCodes.Conv_I4);
     }
 
+    /// <summary>
+    /// Emits a typed-array receiver onto the stack as its concrete <c>$XArray</c> type: the hoisted
+    /// loop-invariant local when one is available (#928 — cast once per loop), otherwise the
+    /// per-access <c>ldloc; EnsureBoxed; castclass</c>. Eliminating the per-access cast is what,
+    /// together with the native-int counter, closes the typed-array read-stencil gap.
+    /// </summary>
+    private void EmitTypedArrayReceiver(Expr receiver, Type xArrayType)
+    {
+        if (receiver is Expr.Variable rv && _ctx.TryGetHoistedTypedArray(rv.Name.Lexeme) is { } h)
+        {
+            IL.Emit(OpCodes.Ldloc, h.TypedLocal);
+            return;
+        }
+        EmitExpression(receiver);
+        EnsureBoxed();
+        IL.Emit(OpCodes.Castclass, xArrayType);
+    }
+
     private bool TryEmitIntegerCounterIndexI4(Expr index)
     {
         switch (index)
@@ -1796,12 +1814,21 @@ public partial class ILEmitter
             && _ctx.TypeMap?.Get(csi.Value) is TypeInfo.Primitive { Type: TokenType.TYPE_NUMBER } or TypeInfo.NumberLiteral
             && IsArithmeticOrBitwiseCompound(csi.Operator.Type))
         {
-            // recv = (TAType)a  — side-effect-free variable, loaded once
-            EmitExpression(csi.Object);
-            EnsureBoxed();
-            IL.Emit(OpCodes.Castclass, ctaType);
-            var recvLocal = IL.DeclareLocal(ctaType);
-            IL.Emit(OpCodes.Stloc, recvLocal);
+            // recv = (TAType)a  — side-effect-free variable, loaded once. Reuse the loop-hoisted
+            // typed local directly when available (#928), else cast once into a fresh recvLocal.
+            LocalBuilder recvLocal;
+            if (csi.Object is Expr.Variable cv && _ctx.TryGetHoistedTypedArray(cv.Name.Lexeme) is { } choist)
+            {
+                recvLocal = choist.TypedLocal;
+            }
+            else
+            {
+                EmitExpression(csi.Object);
+                EnsureBoxed();
+                IL.Emit(OpCodes.Castclass, ctaType);
+                recvLocal = IL.DeclareLocal(ctaType);
+                IL.Emit(OpCodes.Stloc, recvLocal);
+            }
 
             // idx = (int)i  (native-int fast path when the index is an integer loop counter, #928)
             EmitIndexAsInt32(csi.Index);

--- a/Compilation/ILEmitter.Properties.cs
+++ b/Compilation/ILEmitter.Properties.cs
@@ -883,8 +883,8 @@ public partial class ILEmitter
             EmitExpression(gi.Object);
             EnsureBoxed();
             IL.Emit(OpCodes.Castclass, gtaType);
-            EmitExpressionAsDouble(gi.Index);
-            IL.Emit(OpCodes.Conv_I4);
+            // Native-int fast path when the index is an integer loop counter (#928).
+            EmitIndexAsInt32(gi.Index);
             // Non-virtual call to the sealed-type accessor → the JIT inlines it (AggressiveInlining)
             // so the receiver's _buffer load and the element bounds check can hoist out of loops.
             IL.Emit(OpCodes.Call, taGetU);
@@ -1088,8 +1088,8 @@ public partial class ILEmitter
             && _ctx.Runtime!.TypedArraySetUnboxedByElement.TryGetValue(sta.ElementType, out var taSetU)
             && _ctx.TypeMap?.Get(si.Value) is TypeInfo.Primitive { Type: TokenType.TYPE_NUMBER } or TypeInfo.NumberLiteral)
         {
-            EmitExpressionAsDouble(si.Index);
-            IL.Emit(OpCodes.Conv_I4);
+            // Native-int fast path when the index is an integer loop counter (#928).
+            EmitIndexAsInt32(si.Index);
             var idxLocal = IL.DeclareLocal(_ctx.Types.Int32);
             IL.Emit(OpCodes.Stloc, idxLocal);
 

--- a/Compilation/ILEmitter.Properties.cs
+++ b/Compilation/ILEmitter.Properties.cs
@@ -880,9 +880,8 @@ public partial class ILEmitter
             && _ctx.Runtime!.GetTypedArrayType(gta.ElementType) is { } gtaType
             && _ctx.Runtime!.TypedArrayGetUnboxedByElement.TryGetValue(gta.ElementType, out var taGetU))
         {
-            EmitExpression(gi.Object);
-            EnsureBoxed();
-            IL.Emit(OpCodes.Castclass, gtaType);
+            // Receiver: hoisted loop-invariant cast when available, else per-access cast (#928).
+            EmitTypedArrayReceiver(gi.Object, gtaType);
             // Native-int fast path when the index is an integer loop counter (#928).
             EmitIndexAsInt32(gi.Index);
             // Non-virtual call to the sealed-type accessor → the JIT inlines it (AggressiveInlining)
@@ -1098,9 +1097,8 @@ public partial class ILEmitter
             var valLocal = IL.DeclareLocal(_ctx.Types.Double);
             IL.Emit(OpCodes.Stloc, valLocal);
 
-            EmitExpression(si.Object);
-            EnsureBoxed();
-            IL.Emit(OpCodes.Castclass, staType);
+            // Receiver: hoisted loop-invariant cast when available, else per-access cast (#928).
+            EmitTypedArrayReceiver(si.Object, staType);
             IL.Emit(OpCodes.Ldloc, idxLocal);
             IL.Emit(OpCodes.Ldloc, valLocal);
             // Non-virtual call to the sealed-type accessor → the JIT inlines it (AggressiveInlining).

--- a/Compilation/ILEmitter.Statements.cs
+++ b/Compilation/ILEmitter.Statements.cs
@@ -608,6 +608,8 @@ public partial class ILEmitter
 
             // Array hoist preamble: emit isinst checks for loop-invariant arrays
             var hoisted = EmitArrayHoistPreamble(f.Body, f.Condition, f.Increment);
+            // Typed-array receiver hoist (#928): cast loop-invariant numeric TypedArray receivers once.
+            var taHoisted = EmitTypedArrayHoistPreamble(f.Body, f.Condition, f.Increment);
 
             var builder = _ctx.ILBuilder;
             var startLabel = builder.DefineLabel("for_start");
@@ -648,6 +650,7 @@ public partial class ILEmitter
 
             // Pop hoisted cache
             if (hoisted) _ctx.HoistedArrayCaches.Pop();
+            if (taHoisted) _ctx.HoistedTypedArrayCaches.Pop();
 
             if (activeCells != null)
                 foreach (var (name, prior) in activeCells)
@@ -718,6 +721,8 @@ public partial class ILEmitter
     {
         // Array hoist preamble before loop
         var hoisted = EmitArrayHoistPreamble(w.Body, w.Condition, increment: null);
+        // Typed-array receiver hoist (#928): cast loop-invariant numeric TypedArray receivers once.
+        var taHoisted = EmitTypedArrayHoistPreamble(w.Body, w.Condition, increment: null);
 
         var builder = _ctx.ILBuilder;
         var startLabel = builder.DefineLabel("while_start");
@@ -737,6 +742,7 @@ public partial class ILEmitter
         _ctx.ExitLoop();
 
         if (hoisted) _ctx.HoistedArrayCaches.Pop();
+        if (taHoisted) _ctx.HoistedTypedArrayCaches.Pop();
     }
 
     /// <summary>
@@ -779,6 +785,51 @@ public partial class ILEmitter
         }
 
         _ctx.HoistedArrayCaches.Push(cache);
+        return true;
+    }
+
+    /// <summary>
+    /// Typed-array receiver hoist (#928): for each loop-invariant variable statically typed as a
+    /// numeric TypedArray and used as an index receiver, cast it to its concrete <c>$XArray</c> type
+    /// ONCE before the loop into a typed local. The element index fast paths then load that local
+    /// instead of re-emitting <c>ldloc; castclass $XArray</c> on every access — which, combined with
+    /// the native-int counter, is what closes the typed-array kernel gap. Returns true if anything
+    /// was hoisted (caller must pop the cache). Gated on the same flag as the int-counter prototype
+    /// so the two ship together.
+    /// </summary>
+    private bool EmitTypedArrayHoistPreamble(Stmt body, Expr? condition, Expr? increment)
+    {
+        if (!ForLoopAnalyzer.IntegerCounterEnabled || _ctx.Runtime == null) return false;
+
+        var candidates = TypedArrayHoistAnalyzer.AnalyzeFor(body, condition, increment, _ctx.TypeMap);
+        if (candidates.Count == 0) return false;
+
+        Dictionary<string, HoistedTypedArrayEntry>? cache = null;
+        foreach (var (varName, elementType) in candidates)
+        {
+            // Skip variables already hoisted by an outer loop.
+            if (_ctx.TryGetHoistedTypedArray(varName) != null) continue;
+            // Only numeric typed arrays with unboxed accessors take the fast path (BigInt /
+            // Uint8Clamped fall through to boxed GetIndex, so a hoisted local would be dead).
+            if (_ctx.Runtime.GetTypedArrayType(elementType) is not { } xArrayType) continue;
+            if (!_ctx.Runtime.TypedArrayGetUnboxedByElement.ContainsKey(elementType)) continue;
+
+            var arrLocal = _ctx.Locals.GetLocal(varName);
+            if (arrLocal == null) continue; // captured / not a plain local — leave to the per-access path
+
+            // castclass (not isinst) mirrors the per-access fast path exactly: the static type is
+            // TypedArray, so a correctly-typed value never throws; null casts to null as before.
+            var typedLocal = IL.DeclareLocal(xArrayType);
+            IL.Emit(OpCodes.Ldloc, arrLocal);
+            IL.Emit(OpCodes.Castclass, xArrayType);
+            IL.Emit(OpCodes.Stloc, typedLocal);
+
+            cache ??= new Dictionary<string, HoistedTypedArrayEntry>();
+            cache[varName] = new HoistedTypedArrayEntry(typedLocal, xArrayType, elementType);
+        }
+
+        if (cache == null) return false;
+        _ctx.HoistedTypedArrayCaches.Push(cache);
         return true;
     }
 

--- a/Compilation/ILEmitter.Statements.cs
+++ b/Compilation/ILEmitter.Statements.cs
@@ -306,6 +306,21 @@ public partial class ILEmitter
             return;
         }
 
+        // Integer loop-counter prototype (#928): the analyzer-identified counter gets a native
+        // Int64 slot initialized from its integer literal. Reads materialize a double (resolver),
+        // the increment stays native int, and recognized index sites (a[i], a[i±k]) consume the
+        // int directly. The analyzer guarantees the counter is non-captured, non-reassigned, and
+        // integer-initialized, so this early return safely bypasses the capture/array paths below.
+        if (_integerLoopCounterName == v.Name.Lexeme
+            && TryGetIntegerCounterInit(v.Initializer, out long counterInit))
+        {
+            var intLocal = _ctx.Locals.DeclareLocal(v.Name.Lexeme, _ctx.Types.Int64);
+            _ctx.IntegerCounterLocals.Add(v.Name.Lexeme);
+            IL.Emit(OpCodes.Ldc_I8, counterInit);
+            IL.Emit(OpCodes.Stloc, intLocal);
+            return;
+        }
+
         // Determine if this local can use unboxed double type
         Type localType = CanUseUnboxedLocal(v) ? _ctx.Types.Double : _ctx.Types.Object;
         var local = _ctx.Locals.DeclareLocal(v.Name.Lexeme, localType);
@@ -415,6 +430,13 @@ public partial class ILEmitter
     private string? _optimizedLoopCounterName;
 
     /// <summary>
+    /// Integer loop-counter prototype (#928): name of the for-loop counter to back with a native
+    /// Int64 slot for the current loop, or null. Consulted by EmitVarStatement at the counter's
+    /// declaration. Gated by <see cref="ForLoopAnalyzer.IntegerCounterEnabled"/>.
+    /// </summary>
+    private string? _integerLoopCounterName;
+
+    /// <summary>
     /// Check whether a local variable can use an unboxed double (float64) IL type
     /// instead of the default object. Eligible when:
     ///   1. It is an optimized for-loop counter, OR
@@ -470,6 +492,28 @@ public partial class ILEmitter
     private static bool IsNumericType(TypeSystem.TypeInfo? type) =>
         type is TypeSystem.TypeInfo.Primitive { Type: TokenType.TYPE_NUMBER }
             or TypeSystem.TypeInfo.NumberLiteral;
+
+    /// <summary>
+    /// Integer loop-counter prototype (#928): extracts an integer-literal initializer (incl. unary
+    /// minus, e.g. <c>let i = -1</c>) as a <c>long</c>. Mirrors <c>ForLoopAnalyzer</c>'s eligibility
+    /// check; returns false for non-integer or non-literal initializers (defensive — the analyzer
+    /// already required an integer literal before the counter name reaches here).
+    /// </summary>
+    private static bool TryGetIntegerCounterInit(Expr? initializer, out long value)
+    {
+        value = 0;
+        double d;
+        if (initializer is Expr.Literal { Value: double lit })
+            d = lit;
+        else if (initializer is Expr.Unary { Operator.Type: TokenType.MINUS, Right: Expr.Literal { Value: double neg } })
+            d = -neg;
+        else
+            return false;
+        if (double.IsNaN(d) || double.IsInfinity(d) || d != Math.Truncate(d))
+            return false;
+        value = (long)d;
+        return true;
+    }
 
     /// <summary>
     /// Numeric-mode array creation (number[] unboxing project): a statically-typed
@@ -529,6 +573,15 @@ public partial class ILEmitter
 
         if (analysis.CanUseUnboxedCounter && analysis.VariableName != null)
             _optimizedLoopCounterName = analysis.VariableName;
+
+        // Integer loop-counter prototype (#928): when gated on, back a provably-integer monotonic
+        // counter with a native Int64 slot. Save/restore the field so nested loops don't clobber it.
+        var savedIntCounterName = _integerLoopCounterName;
+        string? activeIntCounter = ForLoopAnalyzer.IntegerCounterEnabled
+            ? ForLoopAnalyzer.AnalyzeIntegerCounter(f, _ctx.ClosureAnalyzer)
+            : null;
+        if (activeIntCounter != null)
+            _integerLoopCounterName = activeIntCounter;
 
         try
         {
@@ -608,6 +661,11 @@ public partial class ILEmitter
         finally
         {
             _optimizedLoopCounterName = null;
+            // The counter's Int64 slot/membership is loop-scoped: drop it so any later same-named
+            // local in an enclosing scope is not mistaken for an integer counter.
+            if (activeIntCounter != null)
+                _ctx.IntegerCounterLocals.Remove(activeIntCounter);
+            _integerLoopCounterName = savedIntCounterName;
         }
     }
 

--- a/Compilation/LocalVariableResolver.cs
+++ b/Compilation/LocalVariableResolver.cs
@@ -173,6 +173,15 @@ public class LocalVariableResolver : IVariableResolver
         {
             var localType = _ctx.Locals.GetLocalType(name);
             _il.Emit(OpCodes.Ldloc, local);
+            // Integer loop-counter prototype (#928): a counter backed by a native Int64 slot reads
+            // back as a double everywhere it is observed as a value (condition compares, arithmetic,
+            // boxing, calls) — exact for any terminating loop (≤ 2^53). The increment and recognized
+            // index sites bypass this generic load with their own native-int IL.
+            if (localType == _types.Int64 && _ctx.IntegerCounterLocals.Contains(name))
+            {
+                _il.Emit(OpCodes.Conv_R8);
+                return StackType.Double;
+            }
             return MapTypeToStackType(localType);
         }
 

--- a/Compilation/TypedArrayHoistAnalyzer.cs
+++ b/Compilation/TypedArrayHoistAnalyzer.cs
@@ -1,0 +1,95 @@
+using SharpTS.Parsing;
+using SharpTS.Parsing.Visitors;
+using SharpTS.TypeSystem;
+
+namespace SharpTS.Compilation;
+
+/// <summary>
+/// Analyzes a loop for numeric TypedArray variables whose <c>castclass $XArray</c> can be hoisted
+/// out of the loop (#928). A variable qualifies when it is the receiver of an index get / set /
+/// compound-set, is statically typed as a <see cref="TypeInfo.TypedArray"/>, and is not reassigned
+/// or re-declared anywhere in the loop (so the cast stays valid for every iteration).
+///
+/// Returns <c>varName → element-type name</c> (e.g. <c>"Int32"</c>); the emit site resolves the
+/// concrete <c>$XArray</c> type and skips element types without unboxed accessors (BigInt /
+/// Uint8Clamped), whose index sites do not take the unboxed fast path. Mirrors
+/// <see cref="ArrayHoistAnalyzer"/>, which performs the equivalent hoist for ordinary arrays.
+/// </summary>
+public static class TypedArrayHoistAnalyzer
+{
+    public static Dictionary<string, string> AnalyzeFor(
+        Stmt body, Expr? condition, Expr? increment, TypeMap? typeMap)
+    {
+        if (typeMap == null) return new();
+
+        var visitor = new TypedArrayAccessVisitor(typeMap);
+        visitor.Visit(body);
+        if (condition != null) visitor.VisitExpr(condition);
+        if (increment != null) visitor.VisitExpr(increment);
+
+        foreach (var reassigned in visitor.Reassigned)
+            visitor.Candidates.Remove(reassigned);
+
+        return visitor.Candidates;
+    }
+
+    private sealed class TypedArrayAccessVisitor : AstVisitorBase
+    {
+        private readonly TypeMap _typeMap;
+
+        /// <summary>Variable name → TypedArray element-type name (e.g. "Int32").</summary>
+        public Dictionary<string, string> Candidates { get; } = new();
+
+        /// <summary>Variables reassigned/re-declared within the loop (disqualified).</summary>
+        public HashSet<string> Reassigned { get; } = new();
+
+        public TypedArrayAccessVisitor(TypeMap typeMap) => _typeMap = typeMap;
+
+        public void VisitExpr(Expr expr) => Visit(expr);
+
+        protected override void VisitGetIndex(Expr.GetIndex expr)
+        {
+            TryRegister(expr.Object);
+            base.VisitGetIndex(expr);
+        }
+
+        protected override void VisitSetIndex(Expr.SetIndex expr)
+        {
+            TryRegister(expr.Object);
+            base.VisitSetIndex(expr);
+        }
+
+        protected override void VisitCompoundSetIndex(Expr.CompoundSetIndex expr)
+        {
+            TryRegister(expr.Object);
+            base.VisitCompoundSetIndex(expr);
+        }
+
+        protected override void VisitAssign(Expr.Assign expr)
+        {
+            Reassigned.Add(expr.Name.Lexeme);
+            base.VisitAssign(expr);
+        }
+
+        protected override void VisitCompoundAssign(Expr.CompoundAssign expr)
+        {
+            Reassigned.Add(expr.Name.Lexeme);
+            base.VisitCompoundAssign(expr);
+        }
+
+        protected override void VisitVar(Stmt.Var stmt)
+        {
+            // Variable shadowing — treat as reassignment, matching ArrayHoistAnalyzer.
+            Reassigned.Add(stmt.Name.Lexeme);
+            base.VisitVar(stmt);
+        }
+
+        private void TryRegister(Expr receiver)
+        {
+            if (receiver is not Expr.Variable v) return;
+            if (Candidates.ContainsKey(v.Name.Lexeme)) return;
+            if (_typeMap.Get(receiver) is TypeInfo.TypedArray ta)
+                Candidates[v.Name.Lexeme] = ta.ElementType;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up to the #928 investigation. The key finding: **the dominant cost in compiled typed-array kernels is the `double` loop induction variable + double index arithmetic, not the typed-array element representation** that both of #928's proposed levers (native-int element arithmetic, `double[]`/SIMD backing) target.

A controlled experiment (idiomatic C#, mirroring the kernels) isolated it: with a `double` loop counter the int32 stencil runs ~6.7ms; with a native `int` counter and the *same* byte[] representation it runs ~2.6ms — matching Node. The representation was never the bottleneck.

This PR prototypes the lever that actually moves the needle — a **native-integer loop counter** — plus the two co-optimizations needed to realize it. **Everything is gated behind `SHARPTS_INT_LOOP_COUNTER=1` and off by default** (zero behavior change to normal builds) while it's validated.

## What's in here (3 logical changes, 2 commits)

1. **Native-int loop counter.** A provably-integer monotonic for-loop counter is backed by a native `Int64` slot instead of a `double`. The increment stays native int and recognized index sites (`a[i]`, `a[i±k]`) consume it directly — eliminating the double induction-variable + per-access `Conv_I4` tax.
   - **Soundness:** TS `number` is a double, but an integer counter stepping by ±1 stays exactly representable as both `long` and `double` for any loop that terminates in finite time (≤ 2^53). Reads materialize as `conv.r8` everywhere the counter is observed as a value (condition compares, arithmetic, boxing, calls), so they're bit-identical to today's double counter; only the increment and index sites use native int.
   - The analyzer requires an integer-literal init, a pure `++`/`--` step, a numeric condition, no closure capture, and no reassignment/re-declaration of the counter in the body or condition.

2. **Typed-array receiver hoist.** The element read fast path was re-emitting `ldloc a; EnsureBoxed; castclass $XArray` on *every* access (3× per stencil iteration). New `TypedArrayHoistAnalyzer` + `EmitTypedArrayHoistPreamble` cast a loop-invariant numeric-TypedArray receiver to its concrete `$XArray` **once** before the loop (mirroring the existing ordinary-array hoist); the read/write/compound index sites load that hoisted local. `castclass` (not `isinst`) keeps semantics identical to the per-access path.

3. **Multi-module coverage fix.** `ClosureAnalyzer.IsVariableCaptured` is a global, name-keyed set across the whole bundled program, so any closure anywhere capturing a same-named variable disqualified *every* counter with that name in *every* module — silently disabling the optimization for imported-module kernels. A `let`/`const` for-counter is block-scoped, so any capturing closure is lexically inside the loop; we now detect that precisely and keep the global check only for `var` counters.

## Results (1M elements, min ms, flag on vs off)

| kernel | off | on | vs Node | vs Bun |
|---|---|---|---|---|
| typed-arrays.ts (imported f64 stencil) | ~6.35 | **~4.63 (1.37×)** | **beats** (6.03) | 2.1× behind (2.16) |
| accumulate (f64 `+=`) | ~8.08 | **~5.10 (1.58×)** | **beats** (7.59) | 1.6× behind (3.21) |
| int32-kernel | ~7.26 | **~5.48 (1.33×)** | 2.4× behind (2.31) | 2.3× behind (2.35) |

Two of three kernels now meet-or-exceed Node. The int32 residual vs Node is V8/JSC's native-int (Smi) speculative lane, which an AOT compiler can't replicate without a deopt tier — established as out of scope in the #928 investigation.

## Validation

- **Correctness:** flag-on output byte-identical to flag-off and to Node across a probe covering stencils, decrementing loops, the counter observed as a value, regular-array indexing, and nested loops.
- **Tests:** 3305 array/number/loop/typed-array/closure tests pass with the flag **on**; the default (flag-off) path is unaffected.
- **ILVerify:** clean.

## Not done (deliberately)

- The flag is **off by default**. Graduating it to default-on needs a full-suite + Test262 (interp + compiled) run first.
- A residual ~2× to the idiomatic-C# ceiling (common to both element types, so not int-specific) remains — likely the per-iteration cancellation check + accessor-call shape. Tried marking the `$TypedArray` fields `initonly`; no measurable benefit, reverted. This is headroom, not a competitive gap (f64/accum already beat Node).

Refs #928.