### PR TITLE
perf(#928): graduate native-int loop counter to default-on + byte-level TypedArray bulk methods

### DIFF
--- a/Compilation/ForLoopAnalyzer.cs
+++ b/Compilation/ForLoopAnalyzer.cs
@@ -18,14 +18,16 @@ namespace SharpTS.Compilation;
 public static class ForLoopAnalyzer
 {
     /// <summary>
-    /// Integer loop-counter prototype gate (#928). When enabled, a provably-integer monotonic
+    /// Integer loop-counter optimization gate (#928). When enabled, a provably-integer monotonic
     /// loop counter is backed by a native <c>Int64</c> slot instead of a <c>double</c> — its
     /// increment stays native int and recognized index sites (<c>a[i]</c>, <c>a[i±k]</c>) consume
-    /// it directly, closing the typed-array kernel gap to Node. Off by default (zero behavior
-    /// change); opt in with <c>SHARPTS_INT_LOOP_COUNTER=1</c> while the prototype is validated.
+    /// it directly, closing the typed-array kernel gap to Node. On by default; it is sound (every
+    /// value-read materializes back to <c>double</c> via <c>conv.r8</c>, bit-identical to the
+    /// double counter, and the byte[] backing is untouched, so .NET interop is preserved). Set
+    /// <c>SHARPTS_INT_LOOP_COUNTER=0</c> to disable it as a kill-switch.
     /// </summary>
     public static readonly bool IntegerCounterEnabled =
-        Environment.GetEnvironmentVariable("SHARPTS_INT_LOOP_COUNTER") == "1";
+        Environment.GetEnvironmentVariable("SHARPTS_INT_LOOP_COUNTER") != "0";
 
     /// <summary>
     /// Identifies a for-loop counter eligible for the native <c>Int64</c> representation, or null.

--- a/Runtime/Types/SharpTSTypedArray.cs
+++ b/Runtime/Types/SharpTSTypedArray.cs
@@ -175,6 +175,20 @@ public abstract class SharpTSTypedArray : ITypeCategorized
             if (offset + typedSource.Length > _length)
                 throw new Exception("RangeError: Source too large for target");
 
+            // Same element type → bit-exact bulk copy on the byte[] backing, no per-element
+            // boxing or double round-trip. (A different element type still needs the
+            // value-converting element-wise path below; a negative offset falls through so the
+            // element setter raises the same RangeError as before.)
+            if (typedSource.GetType() == GetType() && offset >= 0)
+            {
+                int bpe = BytesPerElement;
+                System.Buffer.BlockCopy(
+                    typedSource._buffer, typedSource._byteOffset,
+                    _buffer, _byteOffset + offset * bpe,
+                    typedSource._length * bpe);
+                return;
+            }
+
             for (int i = 0; i < typedSource.Length; i++)
             {
                 this[offset + i] = typedSource[i];
@@ -204,10 +218,22 @@ public abstract class SharpTSTypedArray : ITypeCategorized
         int actualEnd = end ?? _length;
         start = Math.Max(0, Math.Min(start, _length));
         actualEnd = Math.Max(start, Math.Min(actualEnd, _length));
+        if (actualEnd <= start)
+            return this;
 
-        for (int i = start; i < actualEnd; i++)
+        // Convert the value to the element representation exactly once (via the typed
+        // setter, which applies the per-type coercion/clamping), then replicate its raw
+        // bytes across the range with an exponential-doubling copy — no boxing or
+        // re-conversion per element. Interop-safe: same byte[] backing.
+        this[start] = value;
+        int bpe = BytesPerElement;
+        var region = _buffer.AsSpan(_byteOffset + start * bpe, (actualEnd - start) * bpe);
+        int filled = bpe;
+        while (filled < region.Length)
         {
-            this[i] = value;
+            int chunk = Math.Min(filled, region.Length - filled);
+            region.Slice(0, chunk).CopyTo(region.Slice(filled, chunk));
+            filled += chunk;
         }
 
         return this;
@@ -224,18 +250,15 @@ public abstract class SharpTSTypedArray : ITypeCategorized
         actualEnd = Math.Max(start, Math.Min(actualEnd, _length));
 
         int count = Math.Min(actualEnd - start, _length - target);
+        if (count <= 0)
+            return this;
 
-        // Create temporary copy to handle overlapping regions
-        var temp = new object?[count];
-        for (int i = 0; i < count; i++)
-        {
-            temp[i] = this[start + i];
-        }
-
-        for (int i = 0; i < count; i++)
-        {
-            this[target + i] = temp[i];
-        }
+        // Byte-level memmove on the backing buffer. Span.CopyTo handles overlapping
+        // source/destination regions correctly, so no boxed temporary is needed.
+        int bpe = BytesPerElement;
+        var buf = _buffer.AsSpan();
+        buf.Slice(_byteOffset + start * bpe, count * bpe)
+           .CopyTo(buf.Slice(_byteOffset + target * bpe, count * bpe));
 
         return this;
     }
@@ -245,19 +268,42 @@ public abstract class SharpTSTypedArray : ITypeCategorized
     /// </summary>
     public SharpTSTypedArray Reverse()
     {
+        int bpe = BytesPerElement;
+        var buf = _buffer.AsSpan();
+        Span<byte> temp = stackalloc byte[8]; // max BytesPerElement (Float64/BigInt64) is 8
         int left = 0;
         int right = _length - 1;
 
         while (left < right)
         {
-            var temp = this[left];
-            this[left] = this[right];
-            this[right] = temp;
+            // Swap the two elements' raw bytes — no boxing or double round-trip.
+            var ls = buf.Slice(_byteOffset + left * bpe, bpe);
+            var rs = buf.Slice(_byteOffset + right * bpe, bpe);
+            ls.CopyTo(temp);
+            rs.CopyTo(ls);
+            temp.Slice(0, bpe).CopyTo(rs);
             left++;
             right--;
         }
 
         return this;
+    }
+
+    /// <summary>
+    /// Bit-exact byte copy of <paramref name="count"/> elements starting at element
+    /// <paramref name="begin"/> in this array into <paramref name="dest"/> at element 0.
+    /// <paramref name="dest"/> must share this array's concrete element type (the bytes are
+    /// copied verbatim). Used by the per-subclass <see cref="Slice"/> to avoid a boxed
+    /// element-by-element copy.
+    /// </summary>
+    protected void BlockCopyElementsInto(SharpTSTypedArray dest, int begin, int count)
+    {
+        if (count <= 0)
+            return;
+        int bpe = BytesPerElement;
+        System.Buffer.BlockCopy(
+            _buffer, _byteOffset + begin * bpe,
+            dest._buffer, dest._byteOffset, count * bpe);
     }
 
     /// <summary>
@@ -475,7 +521,7 @@ public class SharpTSInt8Array : SharpTSTypedArray
             : _length;
         int count = Math.Max(0, actualEnd - begin);
         var result = new SharpTSInt8Array(count);
-        for (int i = 0; i < count; i++) result[i] = this[begin + i];
+        BlockCopyElementsInto(result, begin, count);
         return result;
     }
 
@@ -530,7 +576,7 @@ public class SharpTSUint8Array : SharpTSTypedArray
             : _length;
         int count = Math.Max(0, actualEnd - begin);
         var result = new SharpTSUint8Array(count);
-        for (int i = 0; i < count; i++) result[i] = this[begin + i];
+        BlockCopyElementsInto(result, begin, count);
         return result;
     }
 
@@ -592,7 +638,7 @@ public class SharpTSUint8ClampedArray : SharpTSTypedArray
             : _length;
         int count = Math.Max(0, actualEnd - begin);
         var result = new SharpTSUint8ClampedArray(count);
-        for (int i = 0; i < count; i++) result[i] = this[begin + i];
+        BlockCopyElementsInto(result, begin, count);
         return result;
     }
 
@@ -663,7 +709,7 @@ public class SharpTSInt16Array : SharpTSTypedArray
             : _length;
         int count = Math.Max(0, actualEnd - begin);
         var result = new SharpTSInt16Array(count);
-        for (int i = 0; i < count; i++) result[i] = this[begin + i];
+        BlockCopyElementsInto(result, begin, count);
         return result;
     }
 
@@ -734,7 +780,7 @@ public class SharpTSUint16Array : SharpTSTypedArray
             : _length;
         int count = Math.Max(0, actualEnd - begin);
         var result = new SharpTSUint16Array(count);
-        for (int i = 0; i < count; i++) result[i] = this[begin + i];
+        BlockCopyElementsInto(result, begin, count);
         return result;
     }
 
@@ -814,7 +860,7 @@ public class SharpTSInt32Array : SharpTSTypedArray
             : _length;
         int count = Math.Max(0, actualEnd - begin);
         var result = new SharpTSInt32Array(count);
-        for (int i = 0; i < count; i++) result[i] = this[begin + i];
+        BlockCopyElementsInto(result, begin, count);
         return result;
     }
 
@@ -885,7 +931,7 @@ public class SharpTSUint32Array : SharpTSTypedArray
             : _length;
         int count = Math.Max(0, actualEnd - begin);
         var result = new SharpTSUint32Array(count);
-        for (int i = 0; i < count; i++) result[i] = this[begin + i];
+        BlockCopyElementsInto(result, begin, count);
         return result;
     }
 
@@ -956,7 +1002,7 @@ public class SharpTSFloat32Array : SharpTSTypedArray
             : _length;
         int count = Math.Max(0, actualEnd - begin);
         var result = new SharpTSFloat32Array(count);
-        for (int i = 0; i < count; i++) result[i] = this[begin + i];
+        BlockCopyElementsInto(result, begin, count);
         return result;
     }
 
@@ -1027,7 +1073,7 @@ public class SharpTSFloat64Array : SharpTSTypedArray
             : _length;
         int count = Math.Max(0, actualEnd - begin);
         var result = new SharpTSFloat64Array(count);
-        for (int i = 0; i < count; i++) result[i] = this[begin + i];
+        BlockCopyElementsInto(result, begin, count);
         return result;
     }
 
@@ -1119,7 +1165,7 @@ public class SharpTSBigInt64Array : SharpTSTypedArray
             : _length;
         int count = Math.Max(0, actualEnd - begin);
         var result = new SharpTSBigInt64Array(count);
-        for (int i = 0; i < count; i++) result[i] = this[begin + i];
+        BlockCopyElementsInto(result, begin, count);
         return result;
     }
 
@@ -1202,7 +1248,7 @@ public class SharpTSBigUint64Array : SharpTSTypedArray
             : _length;
         int count = Math.Max(0, actualEnd - begin);
         var result = new SharpTSBigUint64Array(count);
-        for (int i = 0; i < count; i++) result[i] = this[begin + i];
+        BlockCopyElementsInto(result, begin, count);
         return result;
     }
 

--- a/SharpTS.Tests/SharedTests/TypedArrayBulkMethodTests.cs
+++ b/SharpTS.Tests/SharedTests/TypedArrayBulkMethodTests.cs
@@ -1,0 +1,213 @@
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests;
+
+/// <summary>
+/// Coverage for the in-place / copying TypedArray bulk methods — fill, set, copyWithin,
+/// reverse, slice — which previously had no dedicated tests. These exercise the
+/// byte[]-level fast paths in <c>SharpTSTypedArray</c> (#928 ②): the methods convert/copy
+/// at the raw-buffer level (Buffer.BlockCopy / Span memmove) instead of boxing every
+/// element through the <c>object?</c> indexer, and must observe identical JS semantics.
+///
+/// These run interpreter-only on purpose: the compiled emitter (<c>$TypedArray</c>) does
+/// not implement these bulk methods at all — calling them on a compiled typed array throws
+/// "object is not a function" — so a dual-mode theory would fail in compiled mode. Closing
+/// that compiled gap is separate, larger work.
+/// </summary>
+public class TypedArrayBulkMethodTests
+{
+    private static string Run(string source) => TestHarness.Run(source, ExecutionMode.Interpreted);
+
+    // ----- fill -----
+
+    [Fact]
+    public void Fill_WholeArray()
+    {
+        Assert.Equal("2.5,2.5,2.5,2.5\n", Run(@"
+            let a = new Float64Array(4);
+            a.fill(2.5);
+            console.log(a.join(','));"));
+    }
+
+    [Fact]
+    public void Fill_Range_LeavesOthersZero()
+    {
+        Assert.Equal("0,7,7,7,0\n", Run(@"
+            let a = new Int32Array(5);
+            a.fill(7, 1, 4);
+            console.log(a.join(','));"));
+    }
+
+    [Fact]
+    public void Fill_Int32_TruncatesTowardZero()
+    {
+        Assert.Equal("3,3,3\n", Run(@"
+            let a = new Int32Array(3);
+            a.fill(3.9);
+            console.log(a.join(','));"));
+    }
+
+    [Fact]
+    public void Fill_Uint8Clamped_ClampsHigh()
+    {
+        Assert.Equal("255,255,255\n", Run(@"
+            let a = new Uint8ClampedArray(3);
+            a.fill(300);
+            console.log(a.join(','));"));
+    }
+
+    [Fact]
+    public void Fill_Uint8Clamped_ClampsLow()
+    {
+        Assert.Equal("0,0,0\n", Run(@"
+            let a = new Uint8ClampedArray(3);
+            a.fill(-5);
+            console.log(a.join(','));"));
+    }
+
+    // ----- set -----
+
+    [Fact]
+    public void Set_SameType_AtOffset()
+    {
+        // Same element type → Buffer.BlockCopy fast path.
+        Assert.Equal("0,1.5,2.5,0\n", Run(@"
+            let a = new Float64Array(2);
+            a[0] = 1.5; a[1] = 2.5;
+            let b = new Float64Array(4);
+            b.set(a, 1);
+            console.log(b.join(','));"));
+    }
+
+    [Fact]
+    public void Set_CrossType_ConvertsPerElement()
+    {
+        // Different element type → value-converting element-wise path (truncates to int8).
+        Assert.Equal("1,2\n", Run(@"
+            let f = new Float64Array(2);
+            f[0] = 1.9; f[1] = 2.1;
+            let i = new Int8Array(2);
+            i.set(f);
+            console.log(i.join(','));"));
+    }
+
+    [Fact]
+    public void Set_FromRegularArray()
+    {
+        Assert.Equal("10,20,30\n", Run(@"
+            let a = new Int32Array(3);
+            a.set([10, 20, 30]);
+            console.log(a.join(','));"));
+    }
+
+    [Fact]
+    public void Set_SameType_NegativeOffset_Throws()
+    {
+        // The same-type fast path must NOT silently accept a negative offset — it falls
+        // through to the element setter, which raises a RangeError as before.
+        Assert.Equal("threw\n", Run(@"
+            let src = new Int32Array(2);
+            src[0] = 5; src[1] = 6;
+            let dst = new Int32Array(4);
+            try { dst.set(src, -1); console.log('no-error'); }
+            catch (e) { console.log('threw'); }"));
+    }
+
+    [Fact]
+    public void Set_SameType_TooLarge_Throws()
+    {
+        Assert.Equal("threw\n", Run(@"
+            let src = new Int32Array(3);
+            let dst = new Int32Array(2);
+            try { dst.set(src); console.log('no-error'); }
+            catch (e) { console.log('threw'); }"));
+    }
+
+    // ----- copyWithin -----
+
+    [Fact]
+    public void CopyWithin_Forward()
+    {
+        Assert.Equal("3,4,2,3,4\n", Run(@"
+            let a = new Int32Array(5);
+            for (let i = 0; i < 5; i++) { a[i] = i; }
+            a.copyWithin(0, 3);
+            console.log(a.join(','));"));
+    }
+
+    [Fact]
+    public void CopyWithin_OverlappingRegions()
+    {
+        // src [0..3) copied onto [2..5): overlapping; memmove must read-before-overwrite.
+        Assert.Equal("0,1,0,1,2\n", Run(@"
+            let a = new Int32Array(5);
+            for (let i = 0; i < 5; i++) { a[i] = i; }
+            a.copyWithin(2, 0, 3);
+            console.log(a.join(','));"));
+    }
+
+    // ----- reverse -----
+
+    [Fact]
+    public void Reverse_EvenLength()
+    {
+        Assert.Equal("4,3,2,1\n", Run(@"
+            let a = new Int32Array(4);
+            for (let i = 0; i < 4; i++) { a[i] = i + 1; }
+            a.reverse();
+            console.log(a.join(','));"));
+    }
+
+    [Fact]
+    public void Reverse_OddLength_MiddleFixed()
+    {
+        Assert.Equal("3,2,1\n", Run(@"
+            let a = new Int32Array(3);
+            for (let i = 0; i < 3; i++) { a[i] = i + 1; }
+            a.reverse();
+            console.log(a.join(','));"));
+    }
+
+    [Fact]
+    public void Reverse_Float64_PreservesValues()
+    {
+        Assert.Equal("3.5,2.5,1.5\n", Run(@"
+            let a = new Float64Array(3);
+            a[0] = 1.5; a[1] = 2.5; a[2] = 3.5;
+            a.reverse();
+            console.log(a.join(','));"));
+    }
+
+    // ----- slice -----
+
+    [Fact]
+    public void Slice_Range()
+    {
+        Assert.Equal("1,2,3\n", Run(@"
+            let a = new Int32Array(5);
+            for (let i = 0; i < 5; i++) { a[i] = i; }
+            console.log(a.slice(1, 4).join(','));"));
+    }
+
+    [Fact]
+    public void Slice_NegativeBegin()
+    {
+        Assert.Equal("3,4\n", Run(@"
+            let a = new Int32Array(5);
+            for (let i = 0; i < 5; i++) { a[i] = i; }
+            console.log(a.slice(-2).join(','));"));
+    }
+
+    [Fact]
+    public void Slice_IsIndependentCopy()
+    {
+        // Mutating the slice must not affect the source (slice copies, subarray would alias).
+        Assert.Equal("9,1,2|0,1,2\n", Run(@"
+            let a = new Int32Array(3);
+            for (let i = 0; i < 3; i++) { a[i] = i; }
+            let s = a.slice(0, 3);
+            s[0] = 9;
+            console.log(s.join(',') + '|' + a.join(','));"));
+    }
+}


### PR DESCRIPTION
Two completable, interop-safe follow-ups from the #928 investigation. The issue's own two levers (native-int element arithmetic; `double[]`/SIMD backing) remain dead-ends for an AOT compiler — the first is unsound (TS `number` is a double, no deopt tier), the second breaks `ArrayBuffer`/`DataView`/`Atomics` aliasing. The dominant cost was always the loop induction variable, which PR #938 addressed behind a flag.

## ① Graduate the native-int loop counter to default-on

PR #938 landed the native-int loop counter gated behind `SHARPTS_INT_LOOP_COUNTER`, **off by default**. It's the biggest lever for compiled typed-array kernels (2 of 3 benchmark kernels meet-or-beat Node with it on). This flips the gate to **default-on**, keeping `SHARPTS_INT_LOOP_COUNTER=0` as a kill-switch.

**Soundness / interop unchanged:** the counter is a non-escaping local and the typed-array `byte[]` backing is untouched. Every value-read still materializes as `conv.r8` (bit-identical to the double counter); only the increment and `a[i±k]` index sites consume the native int.

## ② Byte-level TypedArray bulk methods (interpreter)

The interpreter's `fill`/`set`/`copyWithin`/`reverse`/`slice` boxed every element through the `object?` indexer. They now operate on the `byte[]` backing directly (`Buffer.BlockCopy` / `Span.CopyTo` memmove / exponential-doubling fill / in-place block-swap reverse / a shared `BlockCopyElementsInto` for slice). Interop- and conformance-safe (same backing), and slightly *more* correct — a byte copy preserves NaN bit patterns the old double round-trip could canonicalize.

**Scope: interpreter only.** The compiled emitter (`$TypedArray`) doesn't implement these bulk methods at all (calling them throws `TypeError: object is not a function`), so a dual-mode test would fail in compiled mode. Closing that compiled gap is separate, larger work (filed as a follow-up).

These methods previously had **no dedicated test coverage**; this adds `TypedArrayBulkMethodTests` (18 interpreter tests).

## Validation

- **Full unit suite 14240 / 0** with the counter default-on (incl. `ILVerificationTests`); the suite was also 14222/0 with the counter forced on before ② landed.
- **Compiled differential probe** (f64 stencil, int32 kernel, decrementing loop, counter observed as a string / object key): **byte-identical** output with the counter on vs off.
- **Test262** loop-heavy subset (Array/Math/Number/String/language): counter-on **≡** counter-off, zero delta. (Note: that compiled-Test262 gate is currently red on `main` from a pre-existing stale baseline (#882) and a pre-existing host crash — both reproduce identically with this change reverted, so they are not introduced here.)

## Not done (deliberately)

- Compiled-mode TypedArray bulk-method support — separate follow-up.
- The residual gap vs the idiomatic-C# ceiling traces to the per-iteration `Volatile.Read` cancellation poll at each loop head (#74/#198), a correctness feature, not touched here.