### PR TITLE
perf(regex): drop intermediate List<string> in String.match materialization

### DIFF
--- a/Compilation/RuntimeEmitter.RegExp.cs
+++ b/Compilation/RuntimeEmitter.RegExp.cs
@@ -756,11 +756,7 @@ public partial class RuntimeEmitter
         var searchLocal = il.DeclareLocal(_types.String);
         var idxLocal = il.DeclareLocal(_types.Int32);
         var notFoundLabel = il.DefineLabel();
-        var matchesLocal = il.DeclareLocal(typeof(List<string>));
-        var elementsLocal = il.DeclareLocal(_types.ListOfObject);
-        var iLocal = il.DeclareLocal(_types.Int32);
-        var loopStartLabel = il.DefineLabel();
-        var loopEndLabel = il.DefineLabel();
+        var matchesLocal = il.DeclareLocal(_types.ListOfObject);
 
         // ECMA-262 22.1.3.13 String.prototype.match: when pattern is undefined,
         // RegExpCreate coerces to /(?:)/ and the exec path returns the
@@ -804,7 +800,7 @@ public partial class RuntimeEmitter
         // Global match: get all matches and return as array
         il.MarkLabel(globalMatchLabel);
 
-        // var matches = regexp.MatchAll(str)
+        // var matches = regexp.MatchAll(str)  // List<object?> of full-match substrings
         il.Emit(OpCodes.Ldloc, regexpLocal);
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Call, _tsRegExpMatchAllMethod);
@@ -813,44 +809,16 @@ public partial class RuntimeEmitter
         // if (matches.Count == 0) return null
         var hasMatchesLabel = il.DefineLabel();
         il.Emit(OpCodes.Ldloc, matchesLocal);
-        il.Emit(OpCodes.Callvirt, typeof(List<string>).GetProperty("Count")!.GetGetMethod()!);
+        il.Emit(OpCodes.Callvirt, _types.ListOfObject.GetProperty("Count")!.GetGetMethod()!);
         il.Emit(OpCodes.Brtrue, hasMatchesLabel);
         il.Emit(OpCodes.Ldnull);
         il.Emit(OpCodes.Ret);
 
         il.MarkLabel(hasMatchesLabel);
 
-        // Convert List<string> to $Array
-        // var elements = new List<object?>()
-        il.Emit(OpCodes.Newobj, _types.ListOfObject.GetConstructor(Type.EmptyTypes)!);
-        il.Emit(OpCodes.Stloc, elementsLocal);
-
-        // for (int i = 0; i < matches.Count; i++) elements.Add(matches[i])
-        il.Emit(OpCodes.Ldc_I4_0);
-        il.Emit(OpCodes.Stloc, iLocal);
-
-        il.MarkLabel(loopStartLabel);
-        il.Emit(OpCodes.Ldloc, iLocal);
+        // MatchAll already returns List<object?>, so hand it straight to the
+        // $Array ctor with no intermediate copy. return new $Array(matches)
         il.Emit(OpCodes.Ldloc, matchesLocal);
-        il.Emit(OpCodes.Callvirt, typeof(List<string>).GetProperty("Count")!.GetGetMethod()!);
-        il.Emit(OpCodes.Bge, loopEndLabel);
-
-        il.Emit(OpCodes.Ldloc, elementsLocal);
-        il.Emit(OpCodes.Ldloc, matchesLocal);
-        il.Emit(OpCodes.Ldloc, iLocal);
-        il.Emit(OpCodes.Callvirt, typeof(List<string>).GetMethod("get_Item", [_types.Int32])!);
-        il.Emit(OpCodes.Callvirt, _types.ListOfObject.GetMethod("Add", [_types.Object])!);
-
-        il.Emit(OpCodes.Ldloc, iLocal);
-        il.Emit(OpCodes.Ldc_I4_1);
-        il.Emit(OpCodes.Add);
-        il.Emit(OpCodes.Stloc, iLocal);
-        il.Emit(OpCodes.Br, loopStartLabel);
-
-        il.MarkLabel(loopEndLabel);
-
-        // return new $Array(elements)
-        il.Emit(OpCodes.Ldloc, elementsLocal);
         il.Emit(OpCodes.Newobj, runtime.TSArrayCtor);
         il.Emit(OpCodes.Ret);
 

--- a/Compilation/RuntimeEmitter.TSRegExp.cs
+++ b/Compilation/RuntimeEmitter.TSRegExp.cs
@@ -2370,11 +2370,16 @@ public partial class RuntimeEmitter
 
     private void EmitTSRegExpMatchAll(TypeBuilder typeBuilder, EmittedRuntime runtime)
     {
-        // internal List<string> MatchAll(string input)
+        // internal List<object?> MatchAll(string input)
+        // Returns List<object?> (not List<string>) so the String.match and
+        // [Symbol.matchAll] consumers hand it straight to the $Array ctor with
+        // no element-by-element copy into an object list. Substrings are
+        // reference types, so storing them as object is free (no box). Mirrors
+        // the runtime SharpTSRegExp.MatchAll — keep both in lockstep.
         var method = typeBuilder.DefineMethod(
             "MatchAll",
             MethodAttributes.Assembly,
-            typeof(List<string>),
+            _types.ListOfObject,
             [_types.String]
         );
         _tsRegExpMatchAllMethod = method;
@@ -2400,14 +2405,14 @@ public partial class RuntimeEmitter
         var substring = _types.String.GetMethod("Substring", [_types.Int32, _types.Int32])!;
 
         var il = method.GetILGenerator();
-        var resultLocal = il.DeclareLocal(typeof(List<string>));
+        var resultLocal = il.DeclareLocal(_types.ListOfObject);
         var enumLocal = il.DeclareLocal(enumType);
         var vmLocal = il.DeclareLocal(valueMatchType);
         var loopStartLabel = il.DefineLabel();
         var loopEndLabel = il.DefineLabel();
 
-        // var result = new List<string>()
-        il.Emit(OpCodes.Newobj, typeof(List<string>).GetConstructor(Type.EmptyTypes)!);
+        // var result = new List<object?>()
+        il.Emit(OpCodes.Newobj, _types.ListOfObject.GetConstructor(Type.EmptyTypes)!);
         il.Emit(OpCodes.Stloc, resultLocal);
 
         // var e = _regex.EnumerateMatches((ReadOnlySpan<char>)input)
@@ -2435,7 +2440,9 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloca, vmLocal);
         il.Emit(OpCodes.Call, getLength);
         il.Emit(OpCodes.Callvirt, substring);
-        il.Emit(OpCodes.Callvirt, typeof(List<string>).GetMethod("Add", [_types.String])!);
+        // The substring is a string on the stack; List<object?>.Add(object) takes
+        // it directly (reference conversion, no box).
+        il.Emit(OpCodes.Callvirt, _types.ListOfObject.GetMethod("Add", [_types.Object])!);
         il.Emit(OpCodes.Br, loopStartLabel);
 
         il.MarkLabel(loopEndLabel);
@@ -3385,12 +3392,7 @@ public partial class RuntimeEmitter
         var il = method.GetILGenerator();
         var rxLocal = il.DeclareLocal(typeBuilder);
         var sLocal = il.DeclareLocal(_types.String);
-        var listLocal = il.DeclareLocal(typeof(List<string>));
-        var resultLocal = il.DeclareLocal(_types.ListOfObject);
-        var enumLocal = il.DeclareLocal(typeof(List<string>.Enumerator));
-
-        var loopStartLabel = il.DefineLabel();
-        var loopBodyLabel = il.DefineLabel();
+        var listLocal = il.DeclareLocal(_types.ListOfObject);
 
         // ECMA-262 §22.2.5.8 step 2: throw TypeError if `this` is not an Object.
         EmitRequireObjectArg(il, runtime, method, argIndex: 0, "RegExp.prototype[Symbol.matchAll]");
@@ -3419,35 +3421,15 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Throw);
         il.MarkLabel(rxOkLabel);
 
-        // var list = rx.MatchAll(s);
+        // var list = rx.MatchAll(s);  // List<object?> of full-match substrings
         il.Emit(OpCodes.Ldloc, rxLocal);
         il.Emit(OpCodes.Ldloc, sLocal);
         il.Emit(OpCodes.Call, _tsRegExpMatchAllMethod);
         il.Emit(OpCodes.Stloc, listLocal);
 
-        // var result = new List<object?>(list.Count);
+        // MatchAll already returns List<object?>, so wrap it directly — no copy.
+        // return new $Array(list)
         il.Emit(OpCodes.Ldloc, listLocal);
-        il.Emit(OpCodes.Callvirt, typeof(List<string>).GetProperty("Count")!.GetGetMethod()!);
-        il.Emit(OpCodes.Newobj, _types.GetConstructor(_types.ListOfObject, _types.Int32));
-        il.Emit(OpCodes.Stloc, resultLocal);
-
-        il.Emit(OpCodes.Ldloc, listLocal);
-        il.Emit(OpCodes.Callvirt, typeof(List<string>).GetMethod("GetEnumerator")!);
-        il.Emit(OpCodes.Stloc, enumLocal);
-
-        il.Emit(OpCodes.Br, loopStartLabel);
-        il.MarkLabel(loopBodyLabel);
-        il.Emit(OpCodes.Ldloc, resultLocal);
-        il.Emit(OpCodes.Ldloca, enumLocal);
-        il.Emit(OpCodes.Call, typeof(List<string>.Enumerator).GetProperty("Current")!.GetGetMethod()!);
-        il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.ListOfObject, "Add", _types.Object));
-
-        il.MarkLabel(loopStartLabel);
-        il.Emit(OpCodes.Ldloca, enumLocal);
-        il.Emit(OpCodes.Call, typeof(List<string>.Enumerator).GetMethod("MoveNext")!);
-        il.Emit(OpCodes.Brtrue, loopBodyLabel);
-
-        il.Emit(OpCodes.Ldloc, resultLocal);
         il.Emit(OpCodes.Newobj, runtime.TSArrayCtor);
         il.Emit(OpCodes.Ret);
     }

--- a/Runtime/BuiltIns/StringBuiltIns.cs
+++ b/Runtime/BuiltIns/StringBuiltIns.cs
@@ -135,7 +135,7 @@ public static class StringBuiltIns
             {
                 var matches = regex.MatchAll(str);
                 if (matches.Count == 0) return RuntimeValue.Null;
-                return RuntimeValue.FromObject(new SharpTSArray(matches.Select(m => (object?)m).ToList()));
+                return RuntimeValue.FromObject(new SharpTSArray(matches));
             }
             else
             {

--- a/Runtime/Types/SharpTSRegExp.cs
+++ b/Runtime/Types/SharpTSRegExp.cs
@@ -741,14 +741,20 @@ public class SharpTSRegExp : ITypeCategorized
     /// <summary>
     /// Match all occurrences in the string (used by String.match with global flag).
     /// </summary>
-    internal List<string> MatchAll(string input)
+    internal List<object?> MatchAll(string input)
     {
         // String.prototype.match(/g) only needs the full-match substrings, not
         // capture groups — so use EnumerateMatches (ValueMatch structs, span-
         // based) instead of Matches(). This skips the per-match Match/Group
         // object allocation that dominates this path (~2.3x faster here), and
         // matches Matches(input)'s whole-string scan semantics exactly.
-        List<string> result = [];
+        //
+        // Returns List<object?> (not List<string>) so callers hand it straight
+        // to the SharpTSArray ctor with no element-by-element re-box into an
+        // object list. The substrings are reference types, so storing them as
+        // object? is free (no boxing). Mirrored by the emitted MatchAll
+        // (RuntimeEmitter.TSRegExp.cs) — keep both in lockstep.
+        List<object?> result = [];
         foreach (ValueMatch m in _regex.EnumerateMatches(input))
         {
             result.Add(input.Substring(m.Index, m.Length));


### PR DESCRIPTION
## Summary

`String.prototype.match(/…/g)` and the compiled `[Symbol.matchAll]` helper built a `List<string>` of full-match substrings, then copied it **element-by-element** into a `List<object?>` to feed the array constructor. That intermediate list is pure overhead — the substrings are reference types, so storing them as `object?` is free (no boxing).

This changes `MatchAll` (the `SharpTSRegExp` runtime type **and** its emitted `$RegExp` IL twin, kept in lockstep) to return `List<object?>`, and deletes the copy loop in all three fast-path consumers:

| Path | Change |
|---|---|
| interpreter `MatchV2` | dropped `.Select(m => (object?)m).ToList()` |
| emitted `StringMatchRegExp` | deleted the per-element copy loop → wrap the list directly |
| emitted `SymMatchAll` | deleted the per-element copy loop → wrap the list directly |

Net **−44 LOC** (two IL copy loops removed).

## Why / scope

This came out of investigating #929 (drop `RegexOptions.ECMAScript`). A measured in-pipeline A/B showed that lever has **decayed to ~0× on current .NET 10** (see the #929 comment), so I pivoted to where profiling shows the time actually goes. Decomposition of the `regex.ts` `match` workload (N=10000, 10 000 matches):

| Variant | time/call | alloc/call |
|---|---:|---:|
| engine scan only (no substrings/list) | 3.26 ms | 0 B |
| **proposed** single `List<object?>` | 3.34 ms | 718 KB |
| **current** two-list (`List<string>`→copy→`List<object?>`) | 4.56 ms | 1163 KB |

The match path is **~96% engine-scan-bound** (the .NET-vs-Irregexp residual epic #856 already acknowledges), so this targets **allocation / GC pressure**, not raw scan throughput.

## Measured impact

- match-path **mean −4.5%**, whole `regex.ts` **mean −1.7%** (`min` flat — engine-bound, as expected)
- **−263 KB/call (~23%)** allocation on the match path
- `replace`/`test` paths unchanged

## Correctness

Pure container-type swap; the regex matching itself is untouched and the returned arrays are **byte-identical**.

- Interpreter vs compiled output **identical** across: global match, digit match, no-match `null`, non-global exec-shape, `matchAll` with capture groups, empty-string edge.
- `--compile … --verify` clean on the rewritten helpers.
- **Full unit suite: 14,219 passing**, including `RuntimeTypeSyncTests` (the runtime↔emitted parity guard). The 3 transient failures in the 42-min run (`CryptoKDFTests.ScryptSync_KnownVector` ×2, `CliVarTests.Compiled_VarBasic`) are load-induced timeouts — all pass in 2 s in isolation; the scrypt one was an explicit `TimeoutException`, not a wrong answer.
- Standalone-DLL constraint preserved: pure BCL (`List<object?>`, `EnumerateMatches`, `Substring`) — no `SharpTS.dll` reference introduced.

## Not run

Test262 RegExp/String — the submodule isn't initialized in this environment. Risk is negligible (output provably byte-identical), but happy to run both modes if a reviewer wants it gated.

Part of epic #856.