### PR TITLE
fix(compiled): implement TypedArray bulk methods (#940)

### DIFF
--- a/Compilation/EmittedRuntime.cs
+++ b/Compilation/EmittedRuntime.cs
@@ -1633,6 +1633,29 @@ public class EmittedRuntime
     public Dictionary<string, MethodBuilder> TypedArrayGetUnboxedByElement { get; } = new();
     public Dictionary<string, MethodBuilder> TypedArraySetUnboxedByElement { get; } = new();
 
+    // Bulk instance methods on the $TypedArray base type (#940), mirroring the interpreter's
+    // GetMember surface. Stored so $BoundTypedArrayMethod.Invoke can callvirt them. All BCL-only
+    // (no SharpTS.dll reference) so standalone DLLs stay standalone.
+    public MethodBuilder TypedArrayFill { get; set; } = null!;
+    public MethodBuilder TypedArrayCopyWithin { get; set; } = null!;
+    public MethodBuilder TypedArrayReverse { get; set; } = null!;
+    public MethodBuilder TypedArraySetFrom { get; set; } = null!;
+    public MethodBuilder TypedArraySlice { get; set; } = null!;
+    public MethodBuilder TypedArraySubarray { get; set; } = null!;
+    public MethodBuilder TypedArrayIndexOf { get; set; } = null!;
+    public MethodBuilder TypedArrayLastIndexOf { get; set; } = null!;
+    public MethodBuilder TypedArrayIncludes { get; set; } = null!;
+    public MethodBuilder TypedArrayJoin { get; set; } = null!;
+    public MethodBuilder TypedArrayToStringJoin { get; set; } = null!;
+
+    // $BoundTypedArrayMethod (#940): pure-IL wrapper returned by GetTypedArrayMember for a
+    // bulk-method name, dispatched through InvokeMethodValue/InvokeValue (mirrors $BoundArrayMethod).
+    public TypeBuilder BoundTypedArrayMethodType { get; set; } = null!;
+    public FieldBuilder BoundTypedArrayMethodArrayField { get; set; } = null!;
+    public FieldBuilder BoundTypedArrayMethodNameField { get; set; } = null!;
+    public ConstructorBuilder BoundTypedArrayMethodCtor { get; set; } = null!;
+    public MethodBuilder BoundTypedArrayMethodInvoke { get; set; } = null!;
+
     /// <summary>Concrete emitted $XArray type for a numeric element prefix, or null (BigInt/unknown).</summary>
     public Type? GetTypedArrayType(string elementType) => elementType switch
     {

--- a/Compilation/RuntimeEmitter.Objects.Invocation.cs
+++ b/Compilation/RuntimeEmitter.Objects.Invocation.cs
@@ -234,6 +234,16 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Isinst, runtime.BoundArrayMethodType);
         il.Emit(OpCodes.Brtrue, boundArrayMethodLabel);
 
+        // $BoundTypedArrayMethod (#940) — value-position call (`const f = a.fill; f(x)`).
+        Label boundTypedArrayMethodLabel = default;
+        if (_features.HasAnyTypedArray)
+        {
+            boundTypedArrayMethodLabel = il.DefineLabel();
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Isinst, runtime.BoundTypedArrayMethodType);
+            il.Emit(OpCodes.Brtrue, boundTypedArrayMethodLabel);
+        }
+
         var boundMapMethodLabel = il.DefineLabel();
         if (_features.UsesMap)
         {
@@ -502,6 +512,16 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldarg_1);
         il.Emit(OpCodes.Callvirt, runtime.BoundArrayMethodInvoke);
         il.Emit(OpCodes.Ret);
+
+        if (_features.HasAnyTypedArray)
+        {
+            il.MarkLabel(boundTypedArrayMethodLabel);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Castclass, runtime.BoundTypedArrayMethodType);
+            il.Emit(OpCodes.Ldarg_1);  // args
+            il.Emit(OpCodes.Callvirt, runtime.BoundTypedArrayMethodInvoke);
+            il.Emit(OpCodes.Ret);
+        }
 
         if (_features.UsesMap)
         {
@@ -813,6 +833,22 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ret);
 
         il.MarkLabel(notBoundAnyFunctionLabel);
+
+        // $BoundTypedArrayMethod (#940) — wraps a typed-array bulk method bound to its receiver.
+        // The receiver is already captured in the wrapper, so arg0 is ignored (like $MethodCallable).
+        if (_features.HasAnyTypedArray)
+        {
+            var notBoundTypedArrayMethodLabel = il.DefineLabel();
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Isinst, runtime.BoundTypedArrayMethodType);
+            il.Emit(OpCodes.Brfalse, notBoundTypedArrayMethodLabel);
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Castclass, runtime.BoundTypedArrayMethodType);
+            il.Emit(OpCodes.Ldarg_2);  // args
+            il.Emit(OpCodes.Callvirt, runtime.BoundTypedArrayMethodInvoke);
+            il.Emit(OpCodes.Ret);
+            il.MarkLabel(notBoundTypedArrayMethodLabel);
+        }
 
         // Handle $MethodCallable (wraps BuiltInMethod from GetMember)
         var notMethodCallableLabel = il.DefineLabel();

--- a/Compilation/RuntimeEmitter.TSBoundTypedArrayMethod.cs
+++ b/Compilation/RuntimeEmitter.TSBoundTypedArrayMethod.cs
@@ -1,0 +1,277 @@
+using System;
+using System.Reflection;
+using System.Reflection.Emit;
+
+namespace SharpTS.Compilation;
+
+public partial class RuntimeEmitter
+{
+    // $BoundTypedArrayMethod (#940): the callable returned by GetTypedArrayMember for a typed-array
+    // bulk-method name. Stores (receiver, methodName); its Invoke(object[]) coerces args and
+    // dispatches to the matching $TypedArray base method. Mirrors $BoundArrayMethod (the array
+    // analog) and is dispatched through InvokeMethodValue / InvokeValue. Two-phase like the array
+    // wrapper: the type/ctor/Invoke signature is defined before EmitRuntimeClass (so the invocation
+    // helpers and GetTypedArrayMember can reference it); the Invoke body is finalized afterward.
+
+    /// <summary>Phase 1: define $BoundTypedArrayMethod, its fields, ctor, and Invoke signature.</summary>
+    internal void EmitBoundTypedArrayMethodTypeDefinition(ModuleBuilder moduleBuilder, EmittedRuntime runtime)
+    {
+        var typeBuilder = moduleBuilder.DefineType(
+            "$BoundTypedArrayMethod",
+            TypeAttributes.Public | TypeAttributes.Sealed | TypeAttributes.BeforeFieldInit,
+            _types.Object
+        );
+        runtime.BoundTypedArrayMethodType = typeBuilder;
+
+        var arrayField = typeBuilder.DefineField("_array", runtime.TypedArrayBaseType, FieldAttributes.Assembly);
+        var nameField = typeBuilder.DefineField("_methodName", _types.String, FieldAttributes.Assembly);
+        runtime.BoundTypedArrayMethodArrayField = arrayField;
+        runtime.BoundTypedArrayMethodNameField = nameField;
+
+        var ctor = typeBuilder.DefineConstructor(
+            MethodAttributes.Public, CallingConventions.Standard,
+            [runtime.TypedArrayBaseType, _types.String]);
+        runtime.BoundTypedArrayMethodCtor = ctor;
+        var cil = ctor.GetILGenerator();
+        cil.Emit(OpCodes.Ldarg_0);
+        cil.Emit(OpCodes.Call, _types.GetDefaultConstructor(_types.Object));
+        cil.Emit(OpCodes.Ldarg_0); cil.Emit(OpCodes.Ldarg_1); cil.Emit(OpCodes.Stfld, arrayField);
+        cil.Emit(OpCodes.Ldarg_0); cil.Emit(OpCodes.Ldarg_2); cil.Emit(OpCodes.Stfld, nameField);
+        cil.Emit(OpCodes.Ret);
+
+        // Body emitted in Phase 2; signature now so InvokeValue/InvokeMethodValue can reference it.
+        var invoke = typeBuilder.DefineMethod(
+            "Invoke", MethodAttributes.Public, _types.Object, [_types.ObjectArray]);
+        runtime.BoundTypedArrayMethodInvoke = invoke;
+    }
+
+    /// <summary>Phase 2: emit Invoke body and create the type. Must run after EmitRuntimeClass
+    /// (uses GetElement / TSArrayLengthGetter) and after the base bulk methods are defined.</summary>
+    internal void EmitBoundTypedArrayMethodFinalize(EmittedRuntime runtime)
+    {
+        var typeBuilder = runtime.BoundTypedArrayMethodType;
+        var arrayField = runtime.BoundTypedArrayMethodArrayField;
+        var nameField = runtime.BoundTypedArrayMethodNameField;
+        var il = runtime.BoundTypedArrayMethodInvoke.GetILGenerator();
+
+        var stringEquals = _types.GetMethod(_types.String, "op_Equality", _types.String, _types.String);
+        var objToString = _types.GetMethodNoParams(_types.Object, "ToString");
+        var exCtor = _types.GetConstructor(_types.Exception, _types.String);
+
+        // Locals reused across the set arm.
+        var sourceLoc = il.DeclareLocal(_types.Object);
+        var offsetLoc = il.DeclareLocal(_types.Int32);
+        var lenLoc = il.DeclareLocal(_types.Int32);
+        var iLoc = il.DeclareLocal(_types.Int32);
+        var vLoc = il.DeclareLocal(_types.Object);
+
+        void LoadArray()
+        {
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, arrayField);
+        }
+        void LoadLength()
+        {
+            LoadArray();
+            il.Emit(OpCodes.Callvirt, runtime.TypedArrayLengthGetter);
+        }
+        // args[index] coerced to int (truncate toward zero), or loadDefault() when absent/non-number.
+        void EmitArgAsInt(int index, Action loadDefault)
+        {
+            var useDefault = il.DefineLabel();
+            var done = il.DefineLabel();
+            il.Emit(OpCodes.Ldarg_1); il.Emit(OpCodes.Ldlen); il.Emit(OpCodes.Conv_I4);
+            il.Emit(OpCodes.Ldc_I4, index); il.Emit(OpCodes.Ble, useDefault);
+            il.Emit(OpCodes.Ldarg_1); il.Emit(OpCodes.Ldc_I4, index); il.Emit(OpCodes.Ldelem_Ref);
+            il.Emit(OpCodes.Isinst, _types.Double); il.Emit(OpCodes.Brfalse, useDefault);
+            il.Emit(OpCodes.Ldarg_1); il.Emit(OpCodes.Ldc_I4, index); il.Emit(OpCodes.Ldelem_Ref);
+            il.Emit(OpCodes.Unbox_Any, _types.Double); il.Emit(OpCodes.Conv_I4);
+            il.Emit(OpCodes.Br, done);
+            il.MarkLabel(useDefault); loadDefault();
+            il.MarkLabel(done);
+        }
+        void EmitArgZeroOrNull(int index)
+        {
+            var useNull = il.DefineLabel();
+            var done = il.DefineLabel();
+            il.Emit(OpCodes.Ldarg_1); il.Emit(OpCodes.Ldlen); il.Emit(OpCodes.Conv_I4);
+            il.Emit(OpCodes.Ldc_I4, index); il.Emit(OpCodes.Ble, useNull);
+            il.Emit(OpCodes.Ldarg_1); il.Emit(OpCodes.Ldc_I4, index); il.Emit(OpCodes.Ldelem_Ref);
+            il.Emit(OpCodes.Br, done);
+            il.MarkLabel(useNull); il.Emit(OpCodes.Ldnull);
+            il.MarkLabel(done);
+        }
+
+        // Dispatch chain on _methodName.
+        var lFill = il.DefineLabel();
+        var lCopyWithin = il.DefineLabel();
+        var lReverse = il.DefineLabel();
+        var lSet = il.DefineLabel();
+        var lSlice = il.DefineLabel();
+        var lSubarray = il.DefineLabel();
+        var lIndexOf = il.DefineLabel();
+        var lLastIndexOf = il.DefineLabel();
+        var lIncludes = il.DefineLabel();
+        var lJoin = il.DefineLabel();
+        var lToString = il.DefineLabel();
+
+        void Dispatch(string name, Label target)
+        {
+            il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Ldfld, nameField);
+            il.Emit(OpCodes.Ldstr, name);
+            il.Emit(OpCodes.Call, stringEquals);
+            il.Emit(OpCodes.Brtrue, target);
+        }
+        Dispatch("fill", lFill);
+        Dispatch("copyWithin", lCopyWithin);
+        Dispatch("reverse", lReverse);
+        Dispatch("set", lSet);
+        Dispatch("slice", lSlice);
+        Dispatch("subarray", lSubarray);
+        Dispatch("indexOf", lIndexOf);
+        Dispatch("lastIndexOf", lLastIndexOf);
+        Dispatch("includes", lIncludes);
+        Dispatch("join", lJoin);
+        Dispatch("toString", lToString);
+        // Unknown — return null (should not happen; GetTypedArrayMember only binds known names).
+        il.Emit(OpCodes.Ldnull);
+        il.Emit(OpCodes.Ret);
+
+        // fill(value, start=0, end=length)
+        il.MarkLabel(lFill);
+        LoadArray();
+        EmitArgZeroOrNull(0);
+        EmitArgAsInt(1, () => il.Emit(OpCodes.Ldc_I4_0));
+        EmitArgAsInt(2, LoadLength);
+        il.Emit(OpCodes.Callvirt, runtime.TypedArrayFill);
+        il.Emit(OpCodes.Ret);
+
+        // copyWithin(target=0, start=0, end=length)
+        il.MarkLabel(lCopyWithin);
+        LoadArray();
+        EmitArgAsInt(0, () => il.Emit(OpCodes.Ldc_I4_0));
+        EmitArgAsInt(1, () => il.Emit(OpCodes.Ldc_I4_0));
+        EmitArgAsInt(2, LoadLength);
+        il.Emit(OpCodes.Callvirt, runtime.TypedArrayCopyWithin);
+        il.Emit(OpCodes.Ret);
+
+        // reverse()
+        il.MarkLabel(lReverse);
+        LoadArray();
+        il.Emit(OpCodes.Callvirt, runtime.TypedArrayReverse);
+        il.Emit(OpCodes.Ret);
+
+        // set(source, offset=0)
+        il.MarkLabel(lSet);
+        EmitArgZeroOrNull(0); il.Emit(OpCodes.Stloc, sourceLoc);
+        EmitArgAsInt(1, () => il.Emit(OpCodes.Ldc_I4_0)); il.Emit(OpCodes.Stloc, offsetLoc);
+        // if (source is $TypedArray) -> base SetFrom handles range-check + fast/element-wise copy
+        var notTyped = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, sourceLoc); il.Emit(OpCodes.Isinst, runtime.TypedArrayBaseType); il.Emit(OpCodes.Brfalse, notTyped);
+        LoadArray();
+        il.Emit(OpCodes.Ldloc, sourceLoc); il.Emit(OpCodes.Ldloc, offsetLoc);
+        il.Emit(OpCodes.Callvirt, runtime.TypedArraySetFrom);
+        il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Ldnull); il.Emit(OpCodes.Ret);
+        // else if (source is $Array) -> element-wise via GetElement (coerced by the element setter)
+        il.MarkLabel(notTyped);
+        var notArray = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, sourceLoc); il.Emit(OpCodes.Isinst, runtime.TSArrayType); il.Emit(OpCodes.Brfalse, notArray);
+        il.Emit(OpCodes.Ldloc, sourceLoc); il.Emit(OpCodes.Castclass, runtime.TSArrayType);
+        il.Emit(OpCodes.Callvirt, runtime.TSArrayLengthGetter); il.Emit(OpCodes.Stloc, lenLoc);
+        // if (offset + len > _array.Length) throw RangeError
+        var okRange = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, offsetLoc); il.Emit(OpCodes.Ldloc, lenLoc); il.Emit(OpCodes.Add);
+        LoadLength();
+        il.Emit(OpCodes.Ble, okRange);
+        il.Emit(OpCodes.Ldstr, "RangeError: Source too large for target");
+        il.Emit(OpCodes.Newobj, exCtor); il.Emit(OpCodes.Throw);
+        il.MarkLabel(okRange);
+        il.Emit(OpCodes.Ldc_I4_0); il.Emit(OpCodes.Stloc, iLoc);
+        var setLoopCond = il.DefineLabel();
+        var setLoopBody = il.DefineLabel();
+        il.Emit(OpCodes.Br, setLoopCond);
+        il.MarkLabel(setLoopBody);
+        LoadArray();
+        il.Emit(OpCodes.Ldloc, offsetLoc); il.Emit(OpCodes.Ldloc, iLoc); il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Ldloc, sourceLoc); il.Emit(OpCodes.Ldloc, iLoc); il.Emit(OpCodes.Call, runtime.GetElement);
+        il.Emit(OpCodes.Callvirt, runtime.TypedArrayElementSet);
+        il.Emit(OpCodes.Ldloc, iLoc); il.Emit(OpCodes.Ldc_I4_1); il.Emit(OpCodes.Add); il.Emit(OpCodes.Stloc, iLoc);
+        il.MarkLabel(setLoopCond);
+        il.Emit(OpCodes.Ldloc, iLoc); il.Emit(OpCodes.Ldloc, lenLoc); il.Emit(OpCodes.Blt, setLoopBody);
+        il.Emit(OpCodes.Ldnull); il.Emit(OpCodes.Ret);
+        // else throw TypeError
+        il.MarkLabel(notArray);
+        il.Emit(OpCodes.Ldstr, "TypeError: Invalid source type for TypedArray.set");
+        il.Emit(OpCodes.Newobj, exCtor); il.Emit(OpCodes.Throw);
+
+        // slice(begin=0, end=length)
+        il.MarkLabel(lSlice);
+        LoadArray();
+        EmitArgAsInt(0, () => il.Emit(OpCodes.Ldc_I4_0));
+        EmitArgAsInt(1, LoadLength);
+        il.Emit(OpCodes.Callvirt, runtime.TypedArraySlice);
+        il.Emit(OpCodes.Ret);
+
+        // subarray(begin=0, end=length)
+        il.MarkLabel(lSubarray);
+        LoadArray();
+        EmitArgAsInt(0, () => il.Emit(OpCodes.Ldc_I4_0));
+        EmitArgAsInt(1, LoadLength);
+        il.Emit(OpCodes.Callvirt, runtime.TypedArraySubarray);
+        il.Emit(OpCodes.Ret);
+
+        // indexOf(value, fromIndex=0) -> double
+        il.MarkLabel(lIndexOf);
+        LoadArray();
+        EmitArgZeroOrNull(0);
+        EmitArgAsInt(1, () => il.Emit(OpCodes.Ldc_I4_0));
+        il.Emit(OpCodes.Callvirt, runtime.TypedArrayIndexOf);
+        il.Emit(OpCodes.Box, _types.Double);
+        il.Emit(OpCodes.Ret);
+
+        // lastIndexOf(value, fromIndex=length-1) -> double
+        il.MarkLabel(lLastIndexOf);
+        LoadArray();
+        EmitArgZeroOrNull(0);
+        EmitArgAsInt(1, () => { LoadLength(); il.Emit(OpCodes.Ldc_I4_1); il.Emit(OpCodes.Sub); });
+        il.Emit(OpCodes.Callvirt, runtime.TypedArrayLastIndexOf);
+        il.Emit(OpCodes.Box, _types.Double);
+        il.Emit(OpCodes.Ret);
+
+        // includes(value, fromIndex=0) -> bool
+        il.MarkLabel(lIncludes);
+        LoadArray();
+        EmitArgZeroOrNull(0);
+        EmitArgAsInt(1, () => il.Emit(OpCodes.Ldc_I4_0));
+        il.Emit(OpCodes.Callvirt, runtime.TypedArrayIncludes);
+        il.Emit(OpCodes.Box, _types.Boolean);
+        il.Emit(OpCodes.Ret);
+
+        // join(separator=",")
+        il.MarkLabel(lJoin);
+        LoadArray();
+        {
+            var useDefault = il.DefineLabel();
+            var doneSep = il.DefineLabel();
+            il.Emit(OpCodes.Ldarg_1); il.Emit(OpCodes.Ldlen); il.Emit(OpCodes.Conv_I4);
+            il.Emit(OpCodes.Ldc_I4_0); il.Emit(OpCodes.Ble, useDefault);
+            il.Emit(OpCodes.Ldarg_1); il.Emit(OpCodes.Ldc_I4_0); il.Emit(OpCodes.Ldelem_Ref); il.Emit(OpCodes.Stloc, vLoc);
+            il.Emit(OpCodes.Ldloc, vLoc); il.Emit(OpCodes.Brfalse, useDefault);
+            il.Emit(OpCodes.Ldloc, vLoc); il.Emit(OpCodes.Isinst, runtime.UndefinedType); il.Emit(OpCodes.Brtrue, useDefault);
+            il.Emit(OpCodes.Ldloc, vLoc); il.Emit(OpCodes.Callvirt, objToString); il.Emit(OpCodes.Br, doneSep);
+            il.MarkLabel(useDefault); il.Emit(OpCodes.Ldstr, ",");
+            il.MarkLabel(doneSep);
+        }
+        il.Emit(OpCodes.Callvirt, runtime.TypedArrayJoin);
+        il.Emit(OpCodes.Ret);
+
+        // toString()
+        il.MarkLabel(lToString);
+        LoadArray();
+        il.Emit(OpCodes.Callvirt, runtime.TypedArrayToStringJoin);
+        il.Emit(OpCodes.Ret);
+
+        typeBuilder.CreateType();
+    }
+}

--- a/Compilation/RuntimeEmitter.TSTypedArray.BulkMethods.cs
+++ b/Compilation/RuntimeEmitter.TSTypedArray.BulkMethods.cs
@@ -1,0 +1,625 @@
+using System.Reflection;
+using System.Reflection.Emit;
+
+namespace SharpTS.Compilation;
+
+public partial class RuntimeEmitter
+{
+    // TypedArray bulk instance methods (#940), emitted on the abstract $TypedArray base type so
+    // every concrete $XArray inherits them. They mirror the interpreter's GetMember surface in
+    // Runtime/Types/SharpTSTypedArray.cs (Fill 216, Set 171, CopyWithin 245, Reverse 269,
+    // Slice/Subarray per-subclass, IndexOf 312, LastIndexOf 328, Includes 345, Join/toString
+    // 451-470, ElementEquals 363) — including the same clamping/coercion, so interpreter and
+    // compiled output match byte-for-byte. Everything here is BCL-only (Buffer.BlockCopy,
+    // Array.Copy, Math.Min/Max, string.Join, double.IsNaN, object.Equals) plus the base type's
+    // own fields/abstractions, so the emitted token never references SharpTS.dll — standalone
+    // DLLs stay standalone. The element-converting paths go through the virtual Get/Set so each
+    // concrete type's per-element coercion/clamping applies.
+    private void EmitTypedArrayBulkMethods(TypeBuilder t, EmittedRuntime runtime)
+    {
+        var minI = typeof(Math).GetMethod("Min", [_types.Int32, _types.Int32])!;
+        var maxI = typeof(Math).GetMethod("Max", [_types.Int32, _types.Int32])!;
+        var blockCopy = typeof(System.Buffer).GetMethod(
+            "BlockCopy", [typeof(Array), _types.Int32, typeof(Array), _types.Int32, _types.Int32])!;
+        var arrayCopy = typeof(Array).GetMethod(
+            "Copy", [typeof(Array), _types.Int32, typeof(Array), _types.Int32, _types.Int32])!;
+        var objToString = _types.GetMethodNoParams(_types.Object, "ToString");
+
+        var elementEquals = EmitTaElementEquals(t);
+
+        EmitTypedArrayFill(t, runtime, minI, maxI, blockCopy);
+        EmitTypedArrayCopyWithin(t, runtime, minI, arrayCopy);
+        EmitTypedArrayReverse(t, runtime);
+        EmitTypedArraySetFrom(t, runtime, blockCopy);
+        EmitTypedArrayIndexOf(t, runtime, maxI, elementEquals);
+        EmitTypedArrayLastIndexOf(t, runtime, minI, elementEquals);
+        EmitTypedArrayIncludes(t, runtime);
+        EmitTypedArrayJoin(t, runtime, objToString);
+        EmitTypedArrayToStringJoin(t, runtime);
+        EmitTypedArraySlice(t, runtime, minI, maxI, blockCopy);
+        EmitTypedArraySubarray(t, runtime, minI, maxI);
+    }
+
+    /// <summary>
+    /// Loads typed-array arg <paramref name="argIndex"/> (an int element index), applies JS
+    /// relative-index clamping against <c>_length</c> (`v &lt; 0 ? Max(_length+v,0) : Min(v,_length)`,
+    /// matching slice/subarray in the interpreter), and stores into <paramref name="dest"/>.
+    /// </summary>
+    private void EmitRelativeClampToLocal(ILGenerator il, int argIndex, LocalBuilder dest, MethodInfo minI, MethodInfo maxI)
+    {
+        var negLabel = il.DefineLabel();
+        var doneLabel = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg, argIndex);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Blt, negLabel);
+        // v >= 0: Min(v, _length)
+        il.Emit(OpCodes.Ldarg, argIndex);
+        il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Ldfld, _typedArrayLengthField!);
+        il.Emit(OpCodes.Call, minI);
+        il.Emit(OpCodes.Br, doneLabel);
+        il.MarkLabel(negLabel);
+        // v < 0: Max(_length + v, 0)
+        il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Ldfld, _typedArrayLengthField!);
+        il.Emit(OpCodes.Ldarg, argIndex);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Call, maxI);
+        il.MarkLabel(doneLabel);
+        il.Emit(OpCodes.Stloc, dest);
+    }
+
+    // object Fill(object value, int start, int end) — clamp start/end into [0,_length] (no
+    // negative wraparound, matching the interpreter), coerce the value once via the virtual Set,
+    // then byte-replicate it across the range with an exponential-doubling BlockCopy. Returns this.
+    private void EmitTypedArrayFill(TypeBuilder t, EmittedRuntime runtime, MethodInfo minI, MethodInfo maxI, MethodInfo blockCopy)
+    {
+        var m = t.DefineMethod("Fill", MethodAttributes.Public | MethodAttributes.HideBySig,
+            runtime.TypedArrayBaseType, [_types.Object, _types.Int32, _types.Int32]);
+        runtime.TypedArrayFill = m;
+        var il = m.GetILGenerator();
+        var startLoc = il.DeclareLocal(_types.Int32);
+        var endLoc = il.DeclareLocal(_types.Int32);
+        var bpeLoc = il.DeclareLocal(_types.Int32);
+        var baseOffLoc = il.DeclareLocal(_types.Int32);
+        var totalLoc = il.DeclareLocal(_types.Int32);
+        var filledLoc = il.DeclareLocal(_types.Int32);
+        var chunkLoc = il.DeclareLocal(_types.Int32);
+
+        // start = Max(0, Min(start, _length))
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Ldarg_2);
+        il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Ldfld, _typedArrayLengthField!);
+        il.Emit(OpCodes.Call, minI);
+        il.Emit(OpCodes.Call, maxI);
+        il.Emit(OpCodes.Stloc, startLoc);
+        // end = Max(start, Min(end, _length))
+        il.Emit(OpCodes.Ldloc, startLoc);
+        il.Emit(OpCodes.Ldarg_3);
+        il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Ldfld, _typedArrayLengthField!);
+        il.Emit(OpCodes.Call, minI);
+        il.Emit(OpCodes.Call, maxI);
+        il.Emit(OpCodes.Stloc, endLoc);
+
+        // if (end <= start) return this
+        var doFill = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, endLoc);
+        il.Emit(OpCodes.Ldloc, startLoc);
+        il.Emit(OpCodes.Bgt, doFill);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ret);
+        il.MarkLabel(doFill);
+
+        // this.Set(start, value)  (coerce once)
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldloc, startLoc);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Callvirt, runtime.TypedArrayElementSet);
+
+        // bpe = BytesPerElement
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Callvirt, _typedArrayBytesPerElementGetter!);
+        il.Emit(OpCodes.Stloc, bpeLoc);
+        // baseOff = _byteOffset + start*bpe
+        il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Ldfld, _typedArrayByteOffsetField!);
+        il.Emit(OpCodes.Ldloc, startLoc); il.Emit(OpCodes.Ldloc, bpeLoc); il.Emit(OpCodes.Mul);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Stloc, baseOffLoc);
+        // total = (end - start) * bpe
+        il.Emit(OpCodes.Ldloc, endLoc); il.Emit(OpCodes.Ldloc, startLoc); il.Emit(OpCodes.Sub);
+        il.Emit(OpCodes.Ldloc, bpeLoc); il.Emit(OpCodes.Mul);
+        il.Emit(OpCodes.Stloc, totalLoc);
+        // filled = bpe
+        il.Emit(OpCodes.Ldloc, bpeLoc);
+        il.Emit(OpCodes.Stloc, filledLoc);
+
+        // while (filled < total) { chunk = Min(filled, total-filled);
+        //   Buffer.BlockCopy(_buffer, baseOff, _buffer, baseOff+filled, chunk); filled += chunk; }
+        var loopCond = il.DefineLabel();
+        var loopBody = il.DefineLabel();
+        il.Emit(OpCodes.Br, loopCond);
+        il.MarkLabel(loopBody);
+        il.Emit(OpCodes.Ldloc, filledLoc);
+        il.Emit(OpCodes.Ldloc, totalLoc); il.Emit(OpCodes.Ldloc, filledLoc); il.Emit(OpCodes.Sub);
+        il.Emit(OpCodes.Call, minI);
+        il.Emit(OpCodes.Stloc, chunkLoc);
+        il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Ldfld, _typedArrayBufferField!);
+        il.Emit(OpCodes.Ldloc, baseOffLoc);
+        il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Ldfld, _typedArrayBufferField!);
+        il.Emit(OpCodes.Ldloc, baseOffLoc); il.Emit(OpCodes.Ldloc, filledLoc); il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Ldloc, chunkLoc);
+        il.Emit(OpCodes.Call, blockCopy);
+        il.Emit(OpCodes.Ldloc, filledLoc); il.Emit(OpCodes.Ldloc, chunkLoc); il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Stloc, filledLoc);
+        il.MarkLabel(loopCond);
+        il.Emit(OpCodes.Ldloc, filledLoc);
+        il.Emit(OpCodes.Ldloc, totalLoc);
+        il.Emit(OpCodes.Blt, loopBody);
+
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ret);
+    }
+
+    // object CopyWithin(int target, int start, int end) — clamp, compute count, memmove on the
+    // backing buffer with Array.Copy (overlap-safe, matching the interpreter's Span.CopyTo).
+    private void EmitTypedArrayCopyWithin(TypeBuilder t, EmittedRuntime runtime, MethodInfo minI, MethodInfo arrayCopy)
+    {
+        var maxI = typeof(Math).GetMethod("Max", [_types.Int32, _types.Int32])!;
+        var m = t.DefineMethod("CopyWithin", MethodAttributes.Public | MethodAttributes.HideBySig,
+            runtime.TypedArrayBaseType, [_types.Int32, _types.Int32, _types.Int32]);
+        runtime.TypedArrayCopyWithin = m;
+        var il = m.GetILGenerator();
+        var targetLoc = il.DeclareLocal(_types.Int32);
+        var startLoc = il.DeclareLocal(_types.Int32);
+        var endLoc = il.DeclareLocal(_types.Int32);
+        var countLoc = il.DeclareLocal(_types.Int32);
+        var bpeLoc = il.DeclareLocal(_types.Int32);
+
+        // target = Max(0, Min(target, _length))
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Ldarg_1); il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Ldfld, _typedArrayLengthField!);
+        il.Emit(OpCodes.Call, minI); il.Emit(OpCodes.Call, maxI);
+        il.Emit(OpCodes.Stloc, targetLoc);
+        // start = Max(0, Min(start, _length))
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Ldarg_2); il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Ldfld, _typedArrayLengthField!);
+        il.Emit(OpCodes.Call, minI); il.Emit(OpCodes.Call, maxI);
+        il.Emit(OpCodes.Stloc, startLoc);
+        // end = Max(start, Min(end, _length))
+        il.Emit(OpCodes.Ldloc, startLoc);
+        il.Emit(OpCodes.Ldarg_3); il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Ldfld, _typedArrayLengthField!);
+        il.Emit(OpCodes.Call, minI); il.Emit(OpCodes.Call, maxI);
+        il.Emit(OpCodes.Stloc, endLoc);
+        // count = Min(end - start, _length - target)
+        il.Emit(OpCodes.Ldloc, endLoc); il.Emit(OpCodes.Ldloc, startLoc); il.Emit(OpCodes.Sub);
+        il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Ldfld, _typedArrayLengthField!); il.Emit(OpCodes.Ldloc, targetLoc); il.Emit(OpCodes.Sub);
+        il.Emit(OpCodes.Call, minI);
+        il.Emit(OpCodes.Stloc, countLoc);
+
+        // if (count <= 0) return this
+        var doCopy = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, countLoc);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Bgt, doCopy);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ret);
+        il.MarkLabel(doCopy);
+
+        // bpe = BytesPerElement
+        il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Callvirt, _typedArrayBytesPerElementGetter!);
+        il.Emit(OpCodes.Stloc, bpeLoc);
+        // Array.Copy(_buffer, _byteOffset+start*bpe, _buffer, _byteOffset+target*bpe, count*bpe)
+        il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Ldfld, _typedArrayBufferField!);
+        il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Ldfld, _typedArrayByteOffsetField!);
+        il.Emit(OpCodes.Ldloc, startLoc); il.Emit(OpCodes.Ldloc, bpeLoc); il.Emit(OpCodes.Mul); il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Ldfld, _typedArrayBufferField!);
+        il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Ldfld, _typedArrayByteOffsetField!);
+        il.Emit(OpCodes.Ldloc, targetLoc); il.Emit(OpCodes.Ldloc, bpeLoc); il.Emit(OpCodes.Mul); il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Ldloc, countLoc); il.Emit(OpCodes.Ldloc, bpeLoc); il.Emit(OpCodes.Mul);
+        il.Emit(OpCodes.Call, arrayCopy);
+
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ret);
+    }
+
+    // object Reverse() — two-pointer element-wise swap via the virtual Get/Set. Returns this.
+    private void EmitTypedArrayReverse(TypeBuilder t, EmittedRuntime runtime)
+    {
+        var m = t.DefineMethod("Reverse", MethodAttributes.Public | MethodAttributes.HideBySig,
+            runtime.TypedArrayBaseType, Type.EmptyTypes);
+        runtime.TypedArrayReverse = m;
+        var il = m.GetILGenerator();
+        var leftLoc = il.DeclareLocal(_types.Int32);
+        var rightLoc = il.DeclareLocal(_types.Int32);
+        var tmpLoc = il.DeclareLocal(_types.Object);
+
+        il.Emit(OpCodes.Ldc_I4_0); il.Emit(OpCodes.Stloc, leftLoc);
+        il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Ldfld, _typedArrayLengthField!); il.Emit(OpCodes.Ldc_I4_1); il.Emit(OpCodes.Sub);
+        il.Emit(OpCodes.Stloc, rightLoc);
+
+        var loopCond = il.DefineLabel();
+        var loopBody = il.DefineLabel();
+        il.Emit(OpCodes.Br, loopCond);
+        il.MarkLabel(loopBody);
+        // tmp = Get(left)
+        il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Ldloc, leftLoc); il.Emit(OpCodes.Callvirt, runtime.TypedArrayElementGet);
+        il.Emit(OpCodes.Stloc, tmpLoc);
+        // Set(left, Get(right))
+        il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Ldloc, leftLoc);
+        il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Ldloc, rightLoc); il.Emit(OpCodes.Callvirt, runtime.TypedArrayElementGet);
+        il.Emit(OpCodes.Callvirt, runtime.TypedArrayElementSet);
+        // Set(right, tmp)
+        il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Ldloc, rightLoc); il.Emit(OpCodes.Ldloc, tmpLoc);
+        il.Emit(OpCodes.Callvirt, runtime.TypedArrayElementSet);
+        // left++; right--
+        il.Emit(OpCodes.Ldloc, leftLoc); il.Emit(OpCodes.Ldc_I4_1); il.Emit(OpCodes.Add); il.Emit(OpCodes.Stloc, leftLoc);
+        il.Emit(OpCodes.Ldloc, rightLoc); il.Emit(OpCodes.Ldc_I4_1); il.Emit(OpCodes.Sub); il.Emit(OpCodes.Stloc, rightLoc);
+        il.MarkLabel(loopCond);
+        il.Emit(OpCodes.Ldloc, leftLoc);
+        il.Emit(OpCodes.Ldloc, rightLoc);
+        il.Emit(OpCodes.Blt, loopBody);
+
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ret);
+    }
+
+    // object SetFrom(object source, int offset) — source is always another $TypedArray (the
+    // wrapper routes array-likes itself). Range-checks (throws guest-catchable RangeError),
+    // same-concrete-type → Buffer.BlockCopy fast path (offset >= 0), else element-wise via Get/Set
+    // (the negative-offset case falls here and the element setter raises its own bounds error,
+    // matching the interpreter). Returns null (interpreter's set returns null).
+    private void EmitTypedArraySetFrom(TypeBuilder t, EmittedRuntime runtime, MethodInfo blockCopy)
+    {
+        var getType = _types.GetMethodNoParams(_types.Object, "GetType");
+        var m = t.DefineMethod("SetFrom", MethodAttributes.Public | MethodAttributes.HideBySig,
+            _types.Object, [_types.Object, _types.Int32]);
+        runtime.TypedArraySetFrom = m;
+        var il = m.GetILGenerator();
+        var tsLoc = il.DeclareLocal(runtime.TypedArrayBaseType);
+        var srcLenLoc = il.DeclareLocal(_types.Int32);
+        var bpeLoc = il.DeclareLocal(_types.Int32);
+        var iLoc = il.DeclareLocal(_types.Int32);
+
+        // ts = ($TypedArray)source
+        il.Emit(OpCodes.Ldarg_1); il.Emit(OpCodes.Castclass, runtime.TypedArrayBaseType);
+        il.Emit(OpCodes.Stloc, tsLoc);
+        // srcLen = ts._length
+        il.Emit(OpCodes.Ldloc, tsLoc); il.Emit(OpCodes.Ldfld, _typedArrayLengthField!);
+        il.Emit(OpCodes.Stloc, srcLenLoc);
+
+        // if (offset + srcLen > _length) throw RangeError
+        var okRange = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_2); il.Emit(OpCodes.Ldloc, srcLenLoc); il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Ldfld, _typedArrayLengthField!);
+        il.Emit(OpCodes.Ble, okRange);
+        il.Emit(OpCodes.Ldstr, "RangeError: Source too large for target");
+        il.Emit(OpCodes.Newobj, _types.GetConstructor(_types.Exception, _types.String));
+        il.Emit(OpCodes.Throw);
+        il.MarkLabel(okRange);
+
+        // fast path: ts.GetType() == this.GetType() && offset >= 0
+        var elementWise = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, tsLoc); il.Emit(OpCodes.Callvirt, getType);
+        il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Callvirt, getType);
+        il.Emit(OpCodes.Bne_Un, elementWise);
+        il.Emit(OpCodes.Ldarg_2); il.Emit(OpCodes.Ldc_I4_0); il.Emit(OpCodes.Blt, elementWise);
+        // bpe = BytesPerElement
+        il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Callvirt, _typedArrayBytesPerElementGetter!);
+        il.Emit(OpCodes.Stloc, bpeLoc);
+        // Buffer.BlockCopy(ts._buffer, ts._byteOffset, _buffer, _byteOffset + offset*bpe, srcLen*bpe)
+        il.Emit(OpCodes.Ldloc, tsLoc); il.Emit(OpCodes.Ldfld, _typedArrayBufferField!);
+        il.Emit(OpCodes.Ldloc, tsLoc); il.Emit(OpCodes.Ldfld, _typedArrayByteOffsetField!);
+        il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Ldfld, _typedArrayBufferField!);
+        il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Ldfld, _typedArrayByteOffsetField!);
+        il.Emit(OpCodes.Ldarg_2); il.Emit(OpCodes.Ldloc, bpeLoc); il.Emit(OpCodes.Mul); il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Ldloc, srcLenLoc); il.Emit(OpCodes.Ldloc, bpeLoc); il.Emit(OpCodes.Mul);
+        il.Emit(OpCodes.Call, blockCopy);
+        il.Emit(OpCodes.Ldnull);
+        il.Emit(OpCodes.Ret);
+
+        // element-wise: for (i=0;i<srcLen;i++) this.Set(offset+i, ts.Get(i))
+        il.MarkLabel(elementWise);
+        il.Emit(OpCodes.Ldc_I4_0); il.Emit(OpCodes.Stloc, iLoc);
+        var loopCond = il.DefineLabel();
+        var loopBody = il.DefineLabel();
+        il.Emit(OpCodes.Br, loopCond);
+        il.MarkLabel(loopBody);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldarg_2); il.Emit(OpCodes.Ldloc, iLoc); il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Ldloc, tsLoc); il.Emit(OpCodes.Ldloc, iLoc); il.Emit(OpCodes.Callvirt, runtime.TypedArrayElementGet);
+        il.Emit(OpCodes.Callvirt, runtime.TypedArrayElementSet);
+        il.Emit(OpCodes.Ldloc, iLoc); il.Emit(OpCodes.Ldc_I4_1); il.Emit(OpCodes.Add); il.Emit(OpCodes.Stloc, iLoc);
+        il.MarkLabel(loopCond);
+        il.Emit(OpCodes.Ldloc, iLoc);
+        il.Emit(OpCodes.Ldloc, srcLenLoc);
+        il.Emit(OpCodes.Blt, loopBody);
+        il.Emit(OpCodes.Ldnull);
+        il.Emit(OpCodes.Ret);
+    }
+
+    // double IndexOf(object value, int fromIndex) — forward linear scan; -1 if not found.
+    private void EmitTypedArrayIndexOf(TypeBuilder t, EmittedRuntime runtime, MethodInfo maxI, MethodInfo elementEquals)
+    {
+        var m = t.DefineMethod("IndexOf", MethodAttributes.Public | MethodAttributes.HideBySig,
+            _types.Double, [_types.Object, _types.Int32]);
+        runtime.TypedArrayIndexOf = m;
+        var il = m.GetILGenerator();
+        var iLoc = il.DeclareLocal(_types.Int32);
+
+        // i = Max(0, fromIndex)
+        il.Emit(OpCodes.Ldc_I4_0); il.Emit(OpCodes.Ldarg_2); il.Emit(OpCodes.Call, maxI);
+        il.Emit(OpCodes.Stloc, iLoc);
+
+        var loopCond = il.DefineLabel();
+        var loopBody = il.DefineLabel();
+        var next = il.DefineLabel();
+        il.Emit(OpCodes.Br, loopCond);
+        il.MarkLabel(loopBody);
+        il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Ldloc, iLoc); il.Emit(OpCodes.Callvirt, runtime.TypedArrayElementGet);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Call, elementEquals);
+        il.Emit(OpCodes.Brfalse, next);
+        il.Emit(OpCodes.Ldloc, iLoc); il.Emit(OpCodes.Conv_R8); il.Emit(OpCodes.Ret);
+        il.MarkLabel(next);
+        il.Emit(OpCodes.Ldloc, iLoc); il.Emit(OpCodes.Ldc_I4_1); il.Emit(OpCodes.Add); il.Emit(OpCodes.Stloc, iLoc);
+        il.MarkLabel(loopCond);
+        il.Emit(OpCodes.Ldloc, iLoc);
+        il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Ldfld, _typedArrayLengthField!);
+        il.Emit(OpCodes.Blt, loopBody);
+
+        il.Emit(OpCodes.Ldc_R8, -1.0);
+        il.Emit(OpCodes.Ret);
+    }
+
+    // double LastIndexOf(object value, int fromIndex) — backward scan from Min(fromIndex,_length-1).
+    private void EmitTypedArrayLastIndexOf(TypeBuilder t, EmittedRuntime runtime, MethodInfo minI, MethodInfo elementEquals)
+    {
+        var m = t.DefineMethod("LastIndexOf", MethodAttributes.Public | MethodAttributes.HideBySig,
+            _types.Double, [_types.Object, _types.Int32]);
+        runtime.TypedArrayLastIndexOf = m;
+        var il = m.GetILGenerator();
+        var iLoc = il.DeclareLocal(_types.Int32);
+
+        // i = Min(fromIndex, _length - 1)
+        il.Emit(OpCodes.Ldarg_2);
+        il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Ldfld, _typedArrayLengthField!); il.Emit(OpCodes.Ldc_I4_1); il.Emit(OpCodes.Sub);
+        il.Emit(OpCodes.Call, minI);
+        il.Emit(OpCodes.Stloc, iLoc);
+
+        var loopCond = il.DefineLabel();
+        var loopBody = il.DefineLabel();
+        var next = il.DefineLabel();
+        il.Emit(OpCodes.Br, loopCond);
+        il.MarkLabel(loopBody);
+        il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Ldloc, iLoc); il.Emit(OpCodes.Callvirt, runtime.TypedArrayElementGet);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Call, elementEquals);
+        il.Emit(OpCodes.Brfalse, next);
+        il.Emit(OpCodes.Ldloc, iLoc); il.Emit(OpCodes.Conv_R8); il.Emit(OpCodes.Ret);
+        il.MarkLabel(next);
+        il.Emit(OpCodes.Ldloc, iLoc); il.Emit(OpCodes.Ldc_I4_1); il.Emit(OpCodes.Sub); il.Emit(OpCodes.Stloc, iLoc);
+        il.MarkLabel(loopCond);
+        il.Emit(OpCodes.Ldloc, iLoc);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Bge, loopBody);
+
+        il.Emit(OpCodes.Ldc_R8, -1.0);
+        il.Emit(OpCodes.Ret);
+    }
+
+    // bool Includes(object value, int fromIndex) — IndexOf(...) >= 0.
+    private void EmitTypedArrayIncludes(TypeBuilder t, EmittedRuntime runtime)
+    {
+        var m = t.DefineMethod("Includes", MethodAttributes.Public | MethodAttributes.HideBySig,
+            _types.Boolean, [_types.Object, _types.Int32]);
+        runtime.TypedArrayIncludes = m;
+        var il = m.GetILGenerator();
+        il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Ldarg_1); il.Emit(OpCodes.Ldarg_2);
+        il.Emit(OpCodes.Callvirt, runtime.TypedArrayIndexOf);
+        // result >= 0  ==  !(result < 0)
+        il.Emit(OpCodes.Ldc_R8, 0.0);
+        il.Emit(OpCodes.Clt);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Ceq);
+        il.Emit(OpCodes.Ret);
+    }
+
+    // string Join(string sep) — boxed-element ToString() joined by sep (matches interpreter).
+    private void EmitTypedArrayJoin(TypeBuilder t, EmittedRuntime runtime, MethodInfo objToString)
+    {
+        var stringJoin = typeof(string).GetMethod("Join", [_types.String, typeof(string[])])!;
+        var m = t.DefineMethod("Join", MethodAttributes.Public | MethodAttributes.HideBySig,
+            _types.String, [_types.String]);
+        runtime.TypedArrayJoin = m;
+        var il = m.GetILGenerator();
+        var nLoc = il.DeclareLocal(_types.Int32);
+        var partsLoc = il.DeclareLocal(typeof(string[]));
+        var iLoc = il.DeclareLocal(_types.Int32);
+        var elLoc = il.DeclareLocal(_types.Object);
+
+        il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Ldfld, _typedArrayLengthField!); il.Emit(OpCodes.Stloc, nLoc);
+        il.Emit(OpCodes.Ldloc, nLoc); il.Emit(OpCodes.Newarr, _types.String); il.Emit(OpCodes.Stloc, partsLoc);
+        il.Emit(OpCodes.Ldc_I4_0); il.Emit(OpCodes.Stloc, iLoc);
+
+        var loopCond = il.DefineLabel();
+        var loopBody = il.DefineLabel();
+        var notNull = il.DefineLabel();
+        var store = il.DefineLabel();
+        il.Emit(OpCodes.Br, loopCond);
+        il.MarkLabel(loopBody);
+        il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Ldloc, iLoc); il.Emit(OpCodes.Callvirt, runtime.TypedArrayElementGet);
+        il.Emit(OpCodes.Stloc, elLoc);
+        il.Emit(OpCodes.Ldloc, partsLoc); il.Emit(OpCodes.Ldloc, iLoc);
+        il.Emit(OpCodes.Ldloc, elLoc); il.Emit(OpCodes.Dup); il.Emit(OpCodes.Brtrue, notNull);
+        il.Emit(OpCodes.Pop); il.Emit(OpCodes.Ldstr, ""); il.Emit(OpCodes.Br, store);
+        il.MarkLabel(notNull);
+        il.Emit(OpCodes.Callvirt, objToString);
+        il.MarkLabel(store);
+        il.Emit(OpCodes.Stelem_Ref);
+        il.Emit(OpCodes.Ldloc, iLoc); il.Emit(OpCodes.Ldc_I4_1); il.Emit(OpCodes.Add); il.Emit(OpCodes.Stloc, iLoc);
+        il.MarkLabel(loopCond);
+        il.Emit(OpCodes.Ldloc, iLoc); il.Emit(OpCodes.Ldloc, nLoc); il.Emit(OpCodes.Blt, loopBody);
+
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Ldloc, partsLoc);
+        il.Emit(OpCodes.Call, stringJoin);
+        il.Emit(OpCodes.Ret);
+    }
+
+    // string ToStringJoin() — toString() == Join(",").
+    private void EmitTypedArrayToStringJoin(TypeBuilder t, EmittedRuntime runtime)
+    {
+        var m = t.DefineMethod("ToStringJoin", MethodAttributes.Public | MethodAttributes.HideBySig,
+            _types.String, Type.EmptyTypes);
+        runtime.TypedArrayToStringJoin = m;
+        var il = m.GetILGenerator();
+        il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Ldstr, ","); il.Emit(OpCodes.Callvirt, runtime.TypedArrayJoin);
+        il.Emit(OpCodes.Ret);
+    }
+
+    // $TypedArray Slice(int begin, int end) — fresh same-kind array containing the copied range.
+    private void EmitTypedArraySlice(TypeBuilder t, EmittedRuntime runtime, MethodInfo minI, MethodInfo maxI, MethodInfo blockCopy)
+    {
+        var m = t.DefineMethod("Slice", MethodAttributes.Public | MethodAttributes.HideBySig,
+            runtime.TypedArrayBaseType, [_types.Int32, _types.Int32]);
+        runtime.TypedArraySlice = m;
+        var il = m.GetILGenerator();
+        var beginLoc = il.DeclareLocal(_types.Int32);
+        var endLoc = il.DeclareLocal(_types.Int32);
+        var countLoc = il.DeclareLocal(_types.Int32);
+        var destLoc = il.DeclareLocal(runtime.TypedArrayBaseType);
+        var bpeLoc = il.DeclareLocal(_types.Int32);
+
+        EmitRelativeClampToLocal(il, 1, beginLoc, minI, maxI);
+        EmitRelativeClampToLocal(il, 2, endLoc, minI, maxI);
+        // count = Max(0, end - begin)
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Ldloc, endLoc); il.Emit(OpCodes.Ldloc, beginLoc); il.Emit(OpCodes.Sub);
+        il.Emit(OpCodes.Call, maxI);
+        il.Emit(OpCodes.Stloc, countLoc);
+        // dest = CreateOfLength(count)
+        il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Ldloc, countLoc); il.Emit(OpCodes.Callvirt, _typedArrayCreateOfLength!);
+        il.Emit(OpCodes.Stloc, destLoc);
+
+        // if (count > 0) BlockCopy(_buffer, _byteOffset+begin*bpe, dest._buffer, dest._byteOffset, count*bpe)
+        var skip = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, countLoc); il.Emit(OpCodes.Ldc_I4_0); il.Emit(OpCodes.Ble, skip);
+        il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Callvirt, _typedArrayBytesPerElementGetter!); il.Emit(OpCodes.Stloc, bpeLoc);
+        il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Ldfld, _typedArrayBufferField!);
+        il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Ldfld, _typedArrayByteOffsetField!);
+        il.Emit(OpCodes.Ldloc, beginLoc); il.Emit(OpCodes.Ldloc, bpeLoc); il.Emit(OpCodes.Mul); il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Ldloc, destLoc); il.Emit(OpCodes.Ldfld, _typedArrayBufferField!);
+        il.Emit(OpCodes.Ldloc, destLoc); il.Emit(OpCodes.Ldfld, _typedArrayByteOffsetField!);
+        il.Emit(OpCodes.Ldloc, countLoc); il.Emit(OpCodes.Ldloc, bpeLoc); il.Emit(OpCodes.Mul);
+        il.Emit(OpCodes.Call, blockCopy);
+        il.MarkLabel(skip);
+
+        il.Emit(OpCodes.Ldloc, destLoc);
+        il.Emit(OpCodes.Ret);
+    }
+
+    // $TypedArray Subarray(int begin, int end) — view sharing the backing buffer.
+    private void EmitTypedArraySubarray(TypeBuilder t, EmittedRuntime runtime, MethodInfo minI, MethodInfo maxI)
+    {
+        var m = t.DefineMethod("Subarray", MethodAttributes.Public | MethodAttributes.HideBySig,
+            runtime.TypedArrayBaseType, [_types.Int32, _types.Int32]);
+        runtime.TypedArraySubarray = m;
+        var il = m.GetILGenerator();
+        var beginLoc = il.DeclareLocal(_types.Int32);
+        var endLoc = il.DeclareLocal(_types.Int32);
+        var countLoc = il.DeclareLocal(_types.Int32);
+        var bpeLoc = il.DeclareLocal(_types.Int32);
+
+        EmitRelativeClampToLocal(il, 1, beginLoc, minI, maxI);
+        EmitRelativeClampToLocal(il, 2, endLoc, minI, maxI);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Ldloc, endLoc); il.Emit(OpCodes.Ldloc, beginLoc); il.Emit(OpCodes.Sub);
+        il.Emit(OpCodes.Call, maxI);
+        il.Emit(OpCodes.Stloc, countLoc);
+        il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Callvirt, _typedArrayBytesPerElementGetter!); il.Emit(OpCodes.Stloc, bpeLoc);
+        // return CreateView(_byteOffset + begin*bpe, count)
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Ldfld, _typedArrayByteOffsetField!);
+        il.Emit(OpCodes.Ldloc, beginLoc); il.Emit(OpCodes.Ldloc, bpeLoc); il.Emit(OpCodes.Mul); il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Ldloc, countLoc);
+        il.Emit(OpCodes.Callvirt, _typedArrayCreateView!);
+        il.Emit(OpCodes.Ret);
+    }
+
+    // static bool TaElementEquals(object a, object b) — replicates SharpTSTypedArray.ElementEquals:
+    // NaN-aware double compare (NaN equals NaN, used by includes' SameValueZero), else object.Equals.
+    private MethodBuilder EmitTaElementEquals(TypeBuilder t)
+    {
+        var objEquals = typeof(object).GetMethod("Equals", [_types.Object, _types.Object])!;
+        var isNaN = typeof(double).GetMethod("IsNaN", [_types.Double])!;
+        var m = t.DefineMethod("TaElementEquals",
+            MethodAttributes.Private | MethodAttributes.Static | MethodAttributes.HideBySig,
+            _types.Boolean, [_types.Object, _types.Object]);
+        var il = m.GetILGenerator();
+        var daLoc = il.DeclareLocal(_types.Double);
+        var dbLoc = il.DeclareLocal(_types.Double);
+        var notBoth = il.DefineLabel();
+        var checkNaN = il.DefineLabel();
+        var retFalse = il.DefineLabel();
+
+        il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Isinst, _types.Double); il.Emit(OpCodes.Brfalse, notBoth);
+        il.Emit(OpCodes.Ldarg_1); il.Emit(OpCodes.Isinst, _types.Double); il.Emit(OpCodes.Brfalse, notBoth);
+        il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Unbox_Any, _types.Double); il.Emit(OpCodes.Stloc, daLoc);
+        il.Emit(OpCodes.Ldarg_1); il.Emit(OpCodes.Unbox_Any, _types.Double); il.Emit(OpCodes.Stloc, dbLoc);
+        // if (da == db) return true
+        il.Emit(OpCodes.Ldloc, daLoc); il.Emit(OpCodes.Ldloc, dbLoc); il.Emit(OpCodes.Ceq); il.Emit(OpCodes.Brfalse, checkNaN);
+        il.Emit(OpCodes.Ldc_I4_1); il.Emit(OpCodes.Ret);
+        // return IsNaN(da) && IsNaN(db)
+        il.MarkLabel(checkNaN);
+        il.Emit(OpCodes.Ldloc, daLoc); il.Emit(OpCodes.Call, isNaN); il.Emit(OpCodes.Brfalse, retFalse);
+        il.Emit(OpCodes.Ldloc, dbLoc); il.Emit(OpCodes.Call, isNaN); il.Emit(OpCodes.Ret);
+        il.MarkLabel(retFalse);
+        il.Emit(OpCodes.Ldc_I4_0); il.Emit(OpCodes.Ret);
+        // return object.Equals(a, b)
+        il.MarkLabel(notBoth);
+        il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Ldarg_1); il.Emit(OpCodes.Call, objEquals); il.Emit(OpCodes.Ret);
+
+        return m;
+    }
+
+    // Per-concrete buffer-sharing ctor + CreateOfLength/CreateView overrides backing the base
+    // Slice/Subarray (#940). Emitted inside EmitConcreteTypedArrayType, before CreateType.
+    private void EmitTypedArrayFactoryMembers(TypeBuilder t, EmittedRuntime runtime, ConstructorBuilder lengthCtor)
+    {
+        // public $XArray(byte[] buffer, int byteOffset, int length, object arrayBuffer) : base(...)
+        var viewCtor = t.DefineConstructor(
+            MethodAttributes.Public, CallingConventions.Standard,
+            [typeof(byte[]), _types.Int32, _types.Int32, _types.Object]);
+        var cil = viewCtor.GetILGenerator();
+        cil.Emit(OpCodes.Ldarg_0);
+        cil.Emit(OpCodes.Ldarg_1);
+        cil.Emit(OpCodes.Ldarg_2);
+        cil.Emit(OpCodes.Ldarg_3);
+        cil.Emit(OpCodes.Ldarg, 4);
+        cil.Emit(OpCodes.Call, runtime.TypedArrayBaseCtor);
+        cil.Emit(OpCodes.Ret);
+
+        // protected override $TypedArray CreateOfLength(int length) => new $XArray(length)
+        var col = t.DefineMethod("CreateOfLength",
+            MethodAttributes.Family | MethodAttributes.Virtual | MethodAttributes.HideBySig,
+            runtime.TypedArrayBaseType, [_types.Int32]);
+        var colIl = col.GetILGenerator();
+        colIl.Emit(OpCodes.Ldarg_1);
+        colIl.Emit(OpCodes.Newobj, lengthCtor);
+        colIl.Emit(OpCodes.Ret);
+        t.DefineMethodOverride(col, _typedArrayCreateOfLength!);
+
+        // protected override $TypedArray CreateView(int byteOffset, int length)
+        //   => new $XArray(_buffer, byteOffset, length, _arrayBuffer)
+        var cv = t.DefineMethod("CreateView",
+            MethodAttributes.Family | MethodAttributes.Virtual | MethodAttributes.HideBySig,
+            runtime.TypedArrayBaseType, [_types.Int32, _types.Int32]);
+        var cvIl = cv.GetILGenerator();
+        cvIl.Emit(OpCodes.Ldarg_0); cvIl.Emit(OpCodes.Ldfld, _typedArrayBufferField!);
+        cvIl.Emit(OpCodes.Ldarg_1);
+        cvIl.Emit(OpCodes.Ldarg_2);
+        cvIl.Emit(OpCodes.Ldarg_0); cvIl.Emit(OpCodes.Ldfld, _typedArrayArrayBufferField!);
+        cvIl.Emit(OpCodes.Newobj, viewCtor);
+        cvIl.Emit(OpCodes.Ret);
+        t.DefineMethodOverride(cv, _typedArrayCreateView!);
+    }
+}

--- a/Compilation/RuntimeEmitter.TSTypedArray.cs
+++ b/Compilation/RuntimeEmitter.TSTypedArray.cs
@@ -12,6 +12,10 @@ public partial class RuntimeEmitter
     private FieldBuilder? _typedArrayLengthField;
     private FieldBuilder? _typedArrayArrayBufferField;
     private MethodBuilder? _typedArrayBytesPerElementGetter;
+    // Abstract per-concrete factories used by the base Slice/Subarray (#940): create a fresh
+    // same-kind array (slice copies) / a view sharing the backing buffer (subarray aliases).
+    private MethodBuilder? _typedArrayCreateOfLength;
+    private MethodBuilder? _typedArrayCreateView;
 
     /// <summary>
     /// Emits all TypedArray types for standalone DLLs.
@@ -115,6 +119,27 @@ public partial class RuntimeEmitter
         getBufferIl.Emit(OpCodes.Ldarg_0);
         getBufferIl.Emit(OpCodes.Ldfld, _typedArrayBufferField);
         getBufferIl.Emit(OpCodes.Ret);
+
+        // Abstract factories overridden by each concrete type — let the base-class Slice
+        // (fresh same-kind copy) and Subarray (buffer-sharing view) build the right concrete
+        // type without the base needing to know the concrete constructors (#940).
+        _typedArrayCreateOfLength = _typedArrayBaseType.DefineMethod(
+            "CreateOfLength",
+            MethodAttributes.Family | MethodAttributes.Abstract | MethodAttributes.Virtual | MethodAttributes.HideBySig,
+            _typedArrayBaseType,
+            [_types.Int32]
+        );
+        _typedArrayCreateView = _typedArrayBaseType.DefineMethod(
+            "CreateView",
+            MethodAttributes.Family | MethodAttributes.Abstract | MethodAttributes.Virtual | MethodAttributes.HideBySig,
+            _typedArrayBaseType,
+            [_types.Int32, _types.Int32]
+        );
+
+        // Bulk instance methods (fill/copyWithin/reverse/set/slice/subarray/indexOf/…) mirroring
+        // the interpreter's GetMember surface. Emitted here, before CreateType, so they live on
+        // the base type. BCL-only — standalone-safe.
+        EmitTypedArrayBulkMethods(_typedArrayBaseType, runtime);
     }
 
     private MethodBuilder EmitTypedArrayAbstractProperty(TypeBuilder typeBuilder, string name, Type returnType)
@@ -249,6 +274,10 @@ public partial class RuntimeEmitter
             var elementType = name.EndsWith("Array") ? name[..^5] : name;
             EmitUnboxedNumericAccessors(typeBuilder, runtime, elementType, bytesPerElement, signed, isFloat);
         }
+
+        // Buffer-sharing ctor + CreateOfLength/CreateView overrides backing the base
+        // Slice/Subarray (#940).
+        EmitTypedArrayFactoryMembers(typeBuilder, runtime, lengthCtor);
 
         // Finalize type
         typeBuilder.CreateType();

--- a/Compilation/RuntimeEmitter.Worker.cs
+++ b/Compilation/RuntimeEmitter.Worker.cs
@@ -807,6 +807,8 @@ public partial class RuntimeEmitter
         var checkByteOffsetLabel = il.DefineLabel();
         var checkBufferLabel = il.DefineLabel();
         var checkBytesPerElementLabel = il.DefineLabel();
+        var checkMethodsLabel = il.DefineLabel();
+        var buildWrapperLabel = il.DefineLabel();
         var returnNullLabel = il.DefineLabel();
 
         // Check if object is an emitted $TypedArray
@@ -877,7 +879,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldarg_1);
         il.Emit(OpCodes.Ldstr, "BYTES_PER_ELEMENT");
         il.Emit(OpCodes.Call, _types.GetMethod(_types.String, "op_Equality", _types.String, _types.String));
-        il.Emit(OpCodes.Brfalse, returnNullLabel);
+        il.Emit(OpCodes.Brfalse, checkMethodsLabel);
 
         // Return BYTES_PER_ELEMENT (call abstract BytesPerElement property)
         il.Emit(OpCodes.Ldarg_0);
@@ -885,6 +887,29 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Callvirt, typedArrayBytesPerElementGetter);
         il.Emit(OpCodes.Conv_R8);
         il.Emit(OpCodes.Box, _types.Double);
+        il.Emit(OpCodes.Br, endLabel);
+
+        // Bulk-method names (#940): return a $BoundTypedArrayMethod bound to (this, name); it is
+        // dispatched through InvokeMethodValue/InvokeValue. Mirrors the interpreter's GetMember.
+        il.MarkLabel(checkMethodsLabel);
+        foreach (var methodName in new[]
+                 {
+                     "fill", "set", "copyWithin", "reverse", "slice", "subarray",
+                     "indexOf", "lastIndexOf", "includes", "join", "toString"
+                 })
+        {
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Ldstr, methodName);
+            il.Emit(OpCodes.Call, _types.GetMethod(_types.String, "op_Equality", _types.String, _types.String));
+            il.Emit(OpCodes.Brtrue, buildWrapperLabel);
+        }
+        il.Emit(OpCodes.Br, returnNullLabel);
+
+        il.MarkLabel(buildWrapperLabel);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Castclass, runtime.TypedArrayBaseType);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Newobj, runtime.BoundTypedArrayMethodCtor);
         il.Emit(OpCodes.Br, endLabel);
 
         il.MarkLabel(returnNullLabel);

--- a/Compilation/RuntimeEmitter.cs
+++ b/Compilation/RuntimeEmitter.cs
@@ -243,6 +243,10 @@ public partial class RuntimeEmitter
             EmitSharedArrayBufferType(moduleBuilder, runtime);
             EmitDataViewType(moduleBuilder, runtime);
             EmitTypedArrayTypes(moduleBuilder, runtime);
+            // $BoundTypedArrayMethod Phase 1 (#940): callable wrapper for typed-array bulk methods.
+            // Needs $TypedArray defined (above); must precede EmitRuntimeClass, whose invocation
+            // helpers and GetTypedArrayMember reference its type/ctor/Invoke.
+            EmitBoundTypedArrayMethodTypeDefinition(moduleBuilder, runtime);
         }
 
         // Emit stream classes for standalone stream support
@@ -442,6 +446,11 @@ public partial class RuntimeEmitter
         // Finalize $BoundArrayMethod with Invoke method (Phase 2)
         // Must come after EmitRuntimeClass (needs array methods defined)
         EmitBoundArrayMethodFinalize(runtime);
+
+        // Finalize $BoundTypedArrayMethod (#940) Phase 2 — Invoke dispatches to the base
+        // typed-array bulk methods and uses GetElement/TSArrayLengthGetter (defined in EmitRuntimeClass).
+        if (features.HasAnyTypedArray)
+            EmitBoundTypedArrayMethodFinalize(runtime);
 
         // Finalize $BoundMapMethod / $BoundSetMethod with Invoke method (Phase 2)
         // Must come after EmitRuntimeClass (needs Map*/Set* runtime methods defined).

--- a/SharpTS.Tests/SharedTests/TypedArrayBulkMethodTests.cs
+++ b/SharpTS.Tests/SharedTests/TypedArrayBulkMethodTests.cs
@@ -5,71 +5,76 @@ namespace SharpTS.Tests.SharedTests;
 
 /// <summary>
 /// Coverage for the in-place / copying TypedArray bulk methods — fill, set, copyWithin,
-/// reverse, slice — which previously had no dedicated tests. These exercise the
+/// reverse, slice, subarray, indexOf, lastIndexOf, includes, join, toString. These exercise the
 /// byte[]-level fast paths in <c>SharpTSTypedArray</c> (#928 ②): the methods convert/copy
 /// at the raw-buffer level (Buffer.BlockCopy / Span memmove) instead of boxing every
 /// element through the <c>object?</c> indexer, and must observe identical JS semantics.
 ///
-/// These run interpreter-only on purpose: the compiled emitter (<c>$TypedArray</c>) does
-/// not implement these bulk methods at all — calling them on a compiled typed array throws
-/// "object is not a function" — so a dual-mode theory would fail in compiled mode. Closing
-/// that compiled gap is separate, larger work.
+/// Run in BOTH modes (#940): the compiled emitter now emits these methods on the pure-IL
+/// <c>$TypedArray</c> types and dispatches them through a <c>$BoundTypedArrayMethod</c> wrapper,
+/// mirroring the interpreter — so interpreter and compiled output must match.
 /// </summary>
 public class TypedArrayBulkMethodTests
 {
-    private static string Run(string source) => TestHarness.Run(source, ExecutionMode.Interpreted);
+    private static string Run(string source, ExecutionMode mode) => TestHarness.Run(source, mode);
 
     // ----- fill -----
 
-    [Fact]
-    public void Fill_WholeArray()
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Fill_WholeArray(ExecutionMode mode)
     {
         Assert.Equal("2.5,2.5,2.5,2.5\n", Run(@"
             let a = new Float64Array(4);
             a.fill(2.5);
-            console.log(a.join(','));"));
+            console.log(a.join(','));", mode));
     }
 
-    [Fact]
-    public void Fill_Range_LeavesOthersZero()
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Fill_Range_LeavesOthersZero(ExecutionMode mode)
     {
         Assert.Equal("0,7,7,7,0\n", Run(@"
             let a = new Int32Array(5);
             a.fill(7, 1, 4);
-            console.log(a.join(','));"));
+            console.log(a.join(','));", mode));
     }
 
-    [Fact]
-    public void Fill_Int32_TruncatesTowardZero()
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Fill_Int32_TruncatesTowardZero(ExecutionMode mode)
     {
         Assert.Equal("3,3,3\n", Run(@"
             let a = new Int32Array(3);
             a.fill(3.9);
-            console.log(a.join(','));"));
+            console.log(a.join(','));", mode));
     }
 
-    [Fact]
-    public void Fill_Uint8Clamped_ClampsHigh()
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Fill_Uint8Clamped_ClampsHigh(ExecutionMode mode)
     {
         Assert.Equal("255,255,255\n", Run(@"
             let a = new Uint8ClampedArray(3);
             a.fill(300);
-            console.log(a.join(','));"));
+            console.log(a.join(','));", mode));
     }
 
-    [Fact]
-    public void Fill_Uint8Clamped_ClampsLow()
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Fill_Uint8Clamped_ClampsLow(ExecutionMode mode)
     {
         Assert.Equal("0,0,0\n", Run(@"
             let a = new Uint8ClampedArray(3);
             a.fill(-5);
-            console.log(a.join(','));"));
+            console.log(a.join(','));", mode));
     }
 
     // ----- set -----
 
-    [Fact]
-    public void Set_SameType_AtOffset()
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Set_SameType_AtOffset(ExecutionMode mode)
     {
         // Same element type → Buffer.BlockCopy fast path.
         Assert.Equal("0,1.5,2.5,0\n", Run(@"
@@ -77,11 +82,12 @@ public class TypedArrayBulkMethodTests
             a[0] = 1.5; a[1] = 2.5;
             let b = new Float64Array(4);
             b.set(a, 1);
-            console.log(b.join(','));"));
+            console.log(b.join(','));", mode));
     }
 
-    [Fact]
-    public void Set_CrossType_ConvertsPerElement()
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Set_CrossType_ConvertsPerElement(ExecutionMode mode)
     {
         // Different element type → value-converting element-wise path (truncates to int8).
         Assert.Equal("1,2\n", Run(@"
@@ -89,20 +95,22 @@ public class TypedArrayBulkMethodTests
             f[0] = 1.9; f[1] = 2.1;
             let i = new Int8Array(2);
             i.set(f);
-            console.log(i.join(','));"));
+            console.log(i.join(','));", mode));
     }
 
-    [Fact]
-    public void Set_FromRegularArray()
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Set_FromRegularArray(ExecutionMode mode)
     {
         Assert.Equal("10,20,30\n", Run(@"
             let a = new Int32Array(3);
             a.set([10, 20, 30]);
-            console.log(a.join(','));"));
+            console.log(a.join(','));", mode));
     }
 
-    [Fact]
-    public void Set_SameType_NegativeOffset_Throws()
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Set_SameType_NegativeOffset_Throws(ExecutionMode mode)
     {
         // The same-type fast path must NOT silently accept a negative offset — it falls
         // through to the element setter, which raises a RangeError as before.
@@ -111,96 +119,105 @@ public class TypedArrayBulkMethodTests
             src[0] = 5; src[1] = 6;
             let dst = new Int32Array(4);
             try { dst.set(src, -1); console.log('no-error'); }
-            catch (e) { console.log('threw'); }"));
+            catch (e) { console.log('threw'); }", mode));
     }
 
-    [Fact]
-    public void Set_SameType_TooLarge_Throws()
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Set_SameType_TooLarge_Throws(ExecutionMode mode)
     {
         Assert.Equal("threw\n", Run(@"
             let src = new Int32Array(3);
             let dst = new Int32Array(2);
             try { dst.set(src); console.log('no-error'); }
-            catch (e) { console.log('threw'); }"));
+            catch (e) { console.log('threw'); }", mode));
     }
 
     // ----- copyWithin -----
 
-    [Fact]
-    public void CopyWithin_Forward()
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void CopyWithin_Forward(ExecutionMode mode)
     {
         Assert.Equal("3,4,2,3,4\n", Run(@"
             let a = new Int32Array(5);
             for (let i = 0; i < 5; i++) { a[i] = i; }
             a.copyWithin(0, 3);
-            console.log(a.join(','));"));
+            console.log(a.join(','));", mode));
     }
 
-    [Fact]
-    public void CopyWithin_OverlappingRegions()
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void CopyWithin_OverlappingRegions(ExecutionMode mode)
     {
         // src [0..3) copied onto [2..5): overlapping; memmove must read-before-overwrite.
         Assert.Equal("0,1,0,1,2\n", Run(@"
             let a = new Int32Array(5);
             for (let i = 0; i < 5; i++) { a[i] = i; }
             a.copyWithin(2, 0, 3);
-            console.log(a.join(','));"));
+            console.log(a.join(','));", mode));
     }
 
     // ----- reverse -----
 
-    [Fact]
-    public void Reverse_EvenLength()
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Reverse_EvenLength(ExecutionMode mode)
     {
         Assert.Equal("4,3,2,1\n", Run(@"
             let a = new Int32Array(4);
             for (let i = 0; i < 4; i++) { a[i] = i + 1; }
             a.reverse();
-            console.log(a.join(','));"));
+            console.log(a.join(','));", mode));
     }
 
-    [Fact]
-    public void Reverse_OddLength_MiddleFixed()
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Reverse_OddLength_MiddleFixed(ExecutionMode mode)
     {
         Assert.Equal("3,2,1\n", Run(@"
             let a = new Int32Array(3);
             for (let i = 0; i < 3; i++) { a[i] = i + 1; }
             a.reverse();
-            console.log(a.join(','));"));
+            console.log(a.join(','));", mode));
     }
 
-    [Fact]
-    public void Reverse_Float64_PreservesValues()
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Reverse_Float64_PreservesValues(ExecutionMode mode)
     {
         Assert.Equal("3.5,2.5,1.5\n", Run(@"
             let a = new Float64Array(3);
             a[0] = 1.5; a[1] = 2.5; a[2] = 3.5;
             a.reverse();
-            console.log(a.join(','));"));
+            console.log(a.join(','));", mode));
     }
 
     // ----- slice -----
 
-    [Fact]
-    public void Slice_Range()
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Slice_Range(ExecutionMode mode)
     {
         Assert.Equal("1,2,3\n", Run(@"
             let a = new Int32Array(5);
             for (let i = 0; i < 5; i++) { a[i] = i; }
-            console.log(a.slice(1, 4).join(','));"));
+            console.log(a.slice(1, 4).join(','));", mode));
     }
 
-    [Fact]
-    public void Slice_NegativeBegin()
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Slice_NegativeBegin(ExecutionMode mode)
     {
         Assert.Equal("3,4\n", Run(@"
             let a = new Int32Array(5);
             for (let i = 0; i < 5; i++) { a[i] = i; }
-            console.log(a.slice(-2).join(','));"));
+            console.log(a.slice(-2).join(','));", mode));
     }
 
-    [Fact]
-    public void Slice_IsIndependentCopy()
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Slice_IsIndependentCopy(ExecutionMode mode)
     {
         // Mutating the slice must not affect the source (slice copies, subarray would alias).
         Assert.Equal("9,1,2|0,1,2\n", Run(@"
@@ -208,6 +225,97 @@ public class TypedArrayBulkMethodTests
             for (let i = 0; i < 3; i++) { a[i] = i; }
             let s = a.slice(0, 3);
             s[0] = 9;
-            console.log(s.join(',') + '|' + a.join(','));"));
+            console.log(s.join(',') + '|' + a.join(','));", mode));
+    }
+
+    // ----- subarray -----
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Subarray_AliasesBackingBuffer(ExecutionMode mode)
+    {
+        // subarray returns a VIEW over the same buffer: mutating it is visible in the parent.
+        Assert.Equal("0,9,2|9,2\n", Run(@"
+            let a = new Int32Array(3);
+            for (let i = 0; i < 3; i++) { a[i] = i; }
+            let s = a.subarray(1, 3);
+            s[0] = 9;
+            console.log(a.join(',') + '|' + s.join(','));", mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Subarray_NegativeBegin(ExecutionMode mode)
+    {
+        Assert.Equal("3,4\n", Run(@"
+            let a = new Int32Array(5);
+            for (let i = 0; i < 5; i++) { a[i] = i; }
+            console.log(a.subarray(-2).join(','));", mode));
+    }
+
+    // ----- indexOf / lastIndexOf / includes -----
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void IndexOf_FoundMissingAndFromIndex(ExecutionMode mode)
+    {
+        // found=1, missing=-1, and fromIndex skips earlier matches.
+        Assert.Equal("1,-1,-1\n", Run(@"
+            let a = new Int32Array(3);
+            a[0] = 5; a[1] = 6; a[2] = 7;
+            console.log(a.indexOf(6) + ',' + a.indexOf(42) + ',' + a.indexOf(5, 1));", mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void LastIndexOf_ScansBackward(ExecutionMode mode)
+    {
+        Assert.Equal("2,1,-1\n", Run(@"
+            let a = new Int32Array(3);
+            a[0] = 1; a[1] = 2; a[2] = 1;
+            console.log(a.lastIndexOf(1) + ',' + a.lastIndexOf(2) + ',' + a.lastIndexOf(9));", mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Includes_TrueAndFalse(ExecutionMode mode)
+    {
+        Assert.Equal("true,false\n", Run(@"
+            let a = new Int32Array(3);
+            a[0] = 1; a[1] = 2; a[2] = 1;
+            console.log(a.includes(2) + ',' + a.includes(9));", mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Includes_NaN_SameValueZero(ExecutionMode mode)
+    {
+        // includes uses SameValueZero, so NaN matches NaN (unlike indexOf strict equality).
+        Assert.Equal("true\n", Run(@"
+            let a = new Float64Array(2);
+            a.fill(NaN);
+            console.log(a.includes(NaN));", mode));
+    }
+
+    // ----- join / toString -----
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Join_CustomAndDefaultSeparator(ExecutionMode mode)
+    {
+        Assert.Equal("1-2-3 1,2,3\n", Run(@"
+            let a = new Uint8Array(3);
+            a[0] = 1; a[1] = 2; a[2] = 3;
+            console.log(a.join('-') + ' ' + a.join());", mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ToString_CommaSeparated(ExecutionMode mode)
+    {
+        Assert.Equal("1,2,3\n", Run(@"
+            let a = new Uint8Array(3);
+            a[0] = 1; a[1] = 2; a[2] = 3;
+            console.log(a.toString());", mode));
     }
 }


### PR DESCRIPTION
Closes #940.

## Problem

Calling any TypedArray bulk method on a **compiled** typed array threw at runtime:

```
TypeError: object is not a function
   at $Runtime.InvokeMethodValue(...)
```

This affected `fill`, `set`, `copyWithin`, `reverse`, `slice`, `subarray`, `indexOf`, `lastIndexOf`, `includes`, `join`, and `toString` in both in-process compiled mode and standalone `--compile` DLLs. The emitted `$TypedArray` only exposed the element accessors (`Get`/`Set`/`GetUnboxed`/`SetUnboxed`) and property getters (`length`/`byteLength`/`byteOffset`/`buffer`/`BYTES_PER_ELEMENT`); the dynamic `GetTypedArrayMember` helper returned `null` for every method name, so the subsequent `InvokeMethodValue` saw a null callee and threw. The interpreter implemented all of these.

## Fix

All BCL-only — the emitted token never references `SharpTS.dll`, so standalone DLLs stay standalone.

- **`RuntimeEmitter.TSTypedArray.BulkMethods.cs` (new):** emits the 11 bulk methods on the abstract `$TypedArray` base type, mirroring the interpreter's clamping/coercion exactly (so interpreter and compiled output match byte-for-byte). Hot paths reuse the `byte[]` backing: exponential-doubling `Buffer.BlockCopy` for `fill`, overlap-safe `Array.Copy` for `copyWithin`, and the same-type `Buffer.BlockCopy` fast path for `set`. `slice`/`subarray` use two per-concrete virtual factories (`CreateOfLength` / `CreateView`) plus a buffer-sharing ctor so the base methods can build the right concrete type (`slice` copies, `subarray` aliases).
- **`RuntimeEmitter.TSBoundTypedArrayMethod.cs` (new):** a `$BoundTypedArrayMethod` callable wrapper (mirrors `$BoundArrayMethod`, two-phase) that binds `(receiver, methodName)`; its `Invoke` coerces args and dispatches to the base methods. The rare array-literal `set` source is handled here via `GetElement`.
- **Wiring:** `GetTypedArrayMember` now returns the wrapper for the 11 method names; dispatch arms added to `InvokeMethodValue` + `InvokeValue`; Phase 1/2 wired in `RuntimeEmitter.cs`; field handles added to `EmittedRuntime.cs`. Everything new is gated behind `HasAnyTypedArray`, so programs that don't use typed arrays emit identical IL to before.
- **Tests:** `TypedArrayBulkMethodTests` promoted from interpreter-only to dual-mode (`ExecutionModes.All`), plus new cases for the previously-untested `subarray` (aliasing view), `indexOf`/`lastIndexOf`/`includes` (incl. NaN SameValueZero), `join`, and `toString`.

## Verification

- `dotnet build` — clean, 0 warnings.
- Issue repro in **interpreter**, **in-process compiled**, and **standalone `--compile`** produce identical output; the standalone DLL has no `SharpTS.dll` co-located. Throw cases (negative offset, too-large source) are caught by guest `try/catch` in both modes.
- `TypedArrayBulkMethodTests`: **52/52 pass** (26 methods x 2 modes).
- Full `dotnet test`: **14272 pass** (the only 2 failures were a live-DNS network smoke test and a CLI 30s-subprocess-timeout under full-suite load; both pass in isolation and are unrelated).
- Test262 subset: **Failed: 0** (no baseline drift). TypeScriptConformance untouched (no type-checker changes).