### PR TITLE
Fix #923: compiled async-gen object method o.gen() threads dynamic `this`

### DIFF
--- a/Compilation/ExpressionEmitterBase.CallHelpers.cs
+++ b/Compilation/ExpressionEmitterBase.CallHelpers.cs
@@ -1153,11 +1153,44 @@ public abstract partial class ExpressionEmitterBase
     /// </summary>
     private void EmitFunctionValueCall(Expr.Call c)
     {
-        // Store callee in temp (await-safe)
-        EmitExpression(c.Callee);
-        EnsureBoxed();
-        var calleeLocal = IL.DeclareLocal(Types.Object);
-        IL.Emit(OpCodes.Stloc, calleeLocal);
+        LocalBuilder calleeLocal;
+
+        // #923: a direct method-style value-call `o.m(...)` must bind `this` to the receiver. The
+        // generic value-call below passes a null receiver (correct for a detached call like `f()`),
+        // which drops `this` — wrong for object-literal methods and the lifted generator /
+        // async-generator stubs that read `this` via the `_currentFunctionThis` thread-local
+        // InvokeWithThis sets (#775). The synchronous ILEmitter handles Expr.Get callees in its own
+        // EmitMethodCall, which threads the receiver; this base path is taken by the four
+        // state-machine emitters (async fn / async arrow / async gen / sync gen), so they need the
+        // same. Restrict to a non-optional Expr.Get whose receiver carries no TypeEmitter strategy —
+        // exactly the case EmitGet itself resolves through the plain dynamic GetProperty fallback
+        // (ExpressionEmitterBase.EmitGet) — so the resolved callee value is identical to today while
+        // the receiver is now preserved. Strategy-resolved callees, detached `f()` (Expr.Variable),
+        // and `arr[i]()` (Expr.Index) keep the null-receiver path below.
+        LocalBuilder? receiverLocal = null;
+        if (c.Callee is Expr.Get methodGet && !HasOptionalLink(methodGet) && !ReceiverHasGetStrategy(methodGet.Object))
+        {
+            // Evaluate the receiver once, spill it (a MoveNext re-entry from a suspending argument
+            // wipes plain IL locals, #400), enforce RequireObjectCoercible before the arguments'
+            // side effects fire (ECMA-262 §13.3.6.1, mirroring EmitMethodCall/EmitGet), then resolve
+            // the method off the same receiver and pass it through to InvokeMethodValue below.
+            EmitExpression(methodGet.Object);
+            EnsureBoxed();
+            receiverLocal = _helpers.SpillStoreObject();
+            EmitThrowIfReceiverUndefined(receiverLocal, methodGet.Name.Lexeme);
+            IL.Emit(OpCodes.Ldloc, receiverLocal);
+            IL.Emit(OpCodes.Ldstr, methodGet.Name.Lexeme);
+            IL.Emit(OpCodes.Call, Ctx.Runtime!.GetProperty);
+            calleeLocal = _helpers.SpillStoreObject();
+        }
+        else
+        {
+            // Store callee in temp (await-safe)
+            EmitExpression(c.Callee);
+            EnsureBoxed();
+            calleeLocal = IL.DeclareLocal(Types.Object);
+            IL.Emit(OpCodes.Stloc, calleeLocal);
+        }
 
         // Optional link in the callee chain (a?.[0](), (x?.f)()): a nullish
         // callee means the chain short-circuited — yield undefined instead of
@@ -1244,10 +1277,14 @@ public abstract partial class ExpressionEmitterBase
             EmitExpandCallArgs();
         }
 
-        // Call InvokeMethodValue(receiver=null, function, args)
+        // Call InvokeMethodValue(receiver, function, args). The receiver is the spilled `o` for a
+        // threaded `o.m()` (#923, above), else null for a detached call.
         var argsLocal = IL.DeclareLocal(Types.ObjectArray);
         IL.Emit(OpCodes.Stloc, argsLocal);
-        IL.Emit(OpCodes.Ldnull);
+        if (receiverLocal != null)
+            IL.Emit(OpCodes.Ldloc, receiverLocal);
+        else
+            IL.Emit(OpCodes.Ldnull);
         IL.Emit(OpCodes.Ldloc, calleeLocal);
         IL.Emit(OpCodes.Ldloc, argsLocal);
         IL.Emit(OpCodes.Call, Ctx.Runtime!.InvokeMethodValue);
@@ -1261,6 +1298,25 @@ public abstract partial class ExpressionEmitterBase
         }
 
         SetStackUnknown();
+    }
+
+    /// <summary>
+    /// True when reading <c>obj.&lt;member&gt;</c> would resolve through a <see cref="TypeEmitterRegistry"/>
+    /// strategy (a static-type property getter, e.g. <c>Math.PI</c>, or a type-first instance getter,
+    /// e.g. <c>AbortController.signal</c>) rather than the plain dynamic <c>GetProperty</c> fallback.
+    /// Mirrors the two strategy checks <see cref="EmitGet"/> performs before that fallback. The #923
+    /// receiver-threading in <see cref="EmitFunctionValueCall"/> only fires when this is false, so the
+    /// resolved callee value stays identical to today for strategy-backed receivers (which keep the
+    /// pre-existing null-receiver behavior) and only changes for genuinely dynamic receivers.
+    /// </summary>
+    private bool ReceiverHasGetStrategy(Expr obj)
+    {
+        if (Ctx.TypeEmitterRegistry == null)
+            return false;
+        if (obj is Expr.Variable v && Ctx.TypeEmitterRegistry.GetStaticStrategy(v.Name.Lexeme) != null)
+            return true;
+        var objType = Ctx.TypeMap?.Get(obj);
+        return objType != null && Ctx.TypeEmitterRegistry.GetStrategy(objType) != null;
     }
 
     /// <summary>

--- a/SharpTS.Tests/SharedTests/AsyncGeneratorTests.cs
+++ b/SharpTS.Tests/SharedTests/AsyncGeneratorTests.cs
@@ -45,13 +45,14 @@ public class AsyncGeneratorTests
         Assert.Equal("1 false\n2 false\n3 false\nundefined true\n", output);
     }
 
-    [Fact]
-    public void AsyncGenerator_ObjectMethod_ReadsThis_Interpreted()
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AsyncGenerator_ObjectMethod_ReadsThis(ExecutionMode mode)
     {
-        // #775: an object async-generator method reads instance state via `this`. Interpreter only:
-        // the compiled async-generator object-METHOD value-call (`o.gen()`) inside an async function does
-        // not yet thread the receiver into the state machine (a pre-existing async-codegen gap, tracked
-        // separately). The `.call`/`.apply` async path works in both modes — see the test below.
+        // #775/#923: an object async-generator method reads instance state via `this`. The value-call
+        // `o.gen()` inside an async function must thread the receiver into the state machine in both
+        // modes — #923 fixed the compiled gap (the call site dropped the receiver, so `<>4__this`
+        // captured the sloppy global instead of `o`).
         var source = """
             const o = { v: 7, async *gen() { yield this.v; yield this.v + 1; } };
             async function main() {
@@ -64,7 +65,49 @@ public class AsyncGeneratorTests
             main();
             """;
 
-        Assert.Equal("7\n8\n", TestHarness.Run(source, ExecutionMode.Interpreted));
+        Assert.Equal("7\n8\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ForAwaitOf_AsyncGeneratorObjectMethod_ReadsThis(ExecutionMode mode)
+    {
+        // #923: inline `for await (... of o.gen())` over an async-generator object method must thread
+        // `this` into the state machine. The for-await iterable is evaluated via the same call-site
+        // path as the bare value-call, so this exercises the second reported case (compiled mode
+        // previously hit null/NRE on `this.v`).
+        var source = """
+            const o = { v: 42, async *gen() { yield this.v; yield this.v + 1; } };
+            async function run() {
+                for await (const x of o.gen()) {
+                    console.log(x);
+                }
+            }
+            run();
+            """;
+
+        Assert.Equal("42\n43\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AsyncGeneratorFunctionExpression_AsObjectProperty_ReadsThis(ExecutionMode mode)
+    {
+        // #923: the other `HasOwnThis` lift shape — an `async function*` EXPRESSION assigned to an
+        // object property — must also bind `this` to the receiver when called as `o.gen()`.
+        var source = """
+            const o = { v: 5, gen: async function* () { yield this.v; yield this.v * 2; } };
+            async function main() {
+                const it = o.gen();
+                let r = await it.next();
+                console.log(r.value);
+                r = await it.next();
+                console.log(r.value);
+            }
+            main();
+            """;
+
+        Assert.Equal("5\n10\n", TestHarness.Run(source, mode));
     }
 
     [Theory]


### PR DESCRIPTION
Closes #923 (follow-up to #775).

## Problem

In **compiled mode**, an async-generator object method that reads `this` lost its receiver when invoked inside an async function — both as a bare value-call and as an inline `for await`:

```ts
const o = { v: 42, async *gen() { yield this.v; } };
async function run() {
  for await (const x of o.gen()) console.log(x);   // expected 42; was null / NRE
}
run();
```

The interpreter and the async `.call`/`.apply` paths already worked. #775 fixed sync generators and explicitly left this async case as a known codegen gap.

## Root cause

`o.gen()` is an `Expr.Call` with an `Expr.Get` callee. The synchronous `ILEmitter` routes `Expr.Get` callees to `EmitMethodCall`, which threads the receiver (`InvokeMethodValue(recv, GetProperty(recv, name), args)`). But the four state-machine emitters (`AsyncMoveNextEmitter`, `AsyncArrowMoveNextEmitter`, `AsyncGeneratorMoveNextEmitter`, `GeneratorMoveNextEmitter`) inherit the base `ExpressionEmitterBase.EmitFunctionValueCall`, whose `Expr.Get` fall-through passed a **null receiver**. `InvokeWithThis(null, …)` then set the `_currentFunctionThis` thread-local to the sloppy-global sentinel, so the #775 free-function async-gen stub snapshotted the wrong `this` into `<>4__this`.

The #775 stub-side capture was already correct — only the call site was missing the receiver. Both `for await` emitters evaluate their iterable through the same call path, so one call-site fix covers both reported cases. `ILEmitter` delegates only non-Get calls to `base.EmitCall`, so the base change is invisible to synchronous codegen — blast radius is exactly the four state-machine emitters.

## Fix

In `EmitFunctionValueCall`, for a non-optional `Expr.Get` callee whose receiver carries **no** `TypeEmitter` strategy (exactly the case `EmitGet` itself resolves through the plain dynamic `GetProperty` fallback): evaluate the receiver once, spill it await-safely (#400), enforce RequireObjectCoercible ordering, resolve the method off the same receiver, and thread it into `InvokeMethodValue` — mirroring `ILEmitter.EmitMethodCall`. The existing spread / await-spill block is reused unchanged (so `o.gen(...args)` works).

A `ReceiverHasGetStrategy` gate keeps strategy-backed receivers (String/Array/Map/etc.) on the exact prior path, so the strategy-bypass regression class is structurally impossible. Detached `f()` (`Expr.Variable`) and `arr[i]()` (`Expr.Index`) keep the null receiver — the latter is the same latent drop, left out of scope for #923.

## Tests

- Promoted the previously interpreted-only `AsyncGenerator_ObjectMethod_ReadsThis` to run in **both** modes.
- Added inline-`for await` and `async function*`-expression-as-property variants.
- `PlainGeneratorFunctionExpressionCall_ThisIsSloppyGlobal` (Expr.Variable callee → sloppy-global) still passes.

## Verification

- Issue repro compiled prints `42 / 43 / bare:42` (matches interpreted); **IL verification passes**.
- **Full suite: 14245 passed, 0 failed.**