### PR TITLE
Fix #925: make compiled $TSFunction.Invoke call ABI faithful for all function kinds

### DIFF
--- a/Compilation/ILCompiler.Async.cs
+++ b/Compilation/ILCompiler.Async.cs
@@ -43,6 +43,11 @@ public partial class ILCompiler
         _async.StateMachines[qualifiedFunctionName] = smBuilder;
         _async.Functions[qualifiedFunctionName] = funcStmt;
 
+        // #925: an async function used as a value (imported cross-module, stored, passed as a
+        // callback → $TSFunction.Invoke) must pad omitted trailing optional args with the `undefined`
+        // sentinel, not CLR null — matching plain functions, arrows, async arrows, and class methods.
+        MarkPadsUndefined(stubMethod);
+
         // Create function-level display class for captured locals (same as sync functions).
         // This enables closure mutation sharing between the async state machine and sync inner arrows.
         RegisterAsyncFunctionDisplayClass(funcStmt, qualifiedFunctionName, analysis);

--- a/Compilation/ILCompiler.AsyncGenerators.cs
+++ b/Compilation/ILCompiler.AsyncGenerators.cs
@@ -58,6 +58,11 @@ public partial class ILCompiler
 
         _functions.Builders[qualifiedName] = methodBuilder;
 
+        // #925: an async generator used as a value (imported cross-module, stored, passed as a
+        // callback → $TSFunction.Invoke) must pad omitted trailing optional args with the `undefined`
+        // sentinel, not CLR null — matching the other function kinds (see DefineGeneratorFunction).
+        MarkPadsUndefined(methodBuilder);
+
         // Track rest parameter info (keyed by the qualified name so ResolveFunctionName-based
         // call-site lookups in ExpressionEmitterBase find it).
         var restParam = funcStmt.Parameters.FirstOrDefault(p => p.IsRest);

--- a/Compilation/ILCompiler.Generators.cs
+++ b/Compilation/ILCompiler.Generators.cs
@@ -74,6 +74,13 @@ public partial class ILCompiler
 
         _functions.Builders[qualifiedName] = methodBuilder;
 
+        // #925: a generator function used as a value (imported cross-module, stored, passed as a
+        // callback → $TSFunction.Invoke) must pad omitted trailing optional args with the `undefined`
+        // sentinel, not CLR null — matching plain functions, arrows, and class methods. The stub's
+        // params are all `object` slots, so the sentinel flows into the state-machine fields and the
+        // MoveNext default prologue / `typeof` / `=== undefined` all answer correctly.
+        MarkPadsUndefined(methodBuilder);
+
         // Track rest parameter info (keyed by the qualified name so ResolveFunctionName-based
         // call-site lookups in ExpressionEmitterBase find it).
         var restParam = funcStmt.Parameters.FirstOrDefault(p => p.IsRest);

--- a/Compilation/ILEmitter.Helpers.cs
+++ b/Compilation/ILEmitter.Helpers.cs
@@ -96,8 +96,11 @@ public partial class ILEmitter
             if (param.DefaultValue == null) continue;
 
             // Skip value-type parameters when we know the resolved types: `ldarg; brtrue`
-            // is meaningless on a double/bool. OverloadGenerator covers these for direct
-            // calls. Known limitation for $TSFunction.Invoke callers.
+            // is meaningless on a double/bool, which can't hold the `$Undefined` sentinel.
+            // A *defaulted* param is widened to an `object` slot upstream (ParameterTypeResolver
+            // WidenDefaultedParamsToObject / WidenValueTypeDefaultedMethodParams), so it does NOT
+            // hit this guard — its default fires for direct AND $TSFunction.Invoke callers (#925).
+            // This only defends a genuinely value-typed slot that reached here without that widening.
             if (paramTypes != null && paramTypes[i].IsValueType) continue;
 
             int argIndex = i + argOffset;

--- a/Compilation/RuntimeEmitter.TSFunction.cs
+++ b/Compilation/RuntimeEmitter.TSFunction.cs
@@ -148,11 +148,14 @@ public partial class RuntimeEmitter
         // sentinel (instead of CLR null) when the argument is omitted. Bit i is set iff
         // the wrapped method carries the $PadUndefined marker (i.e. is a user TS function)
         // AND parameter i has an `object` slot. Object slots can hold the sentinel, so
-        // `typeof`/`=== undefined`/default-firing all work; a typed slot (string/double)
-        // would coerce the sentinel to a real value before the entry prologue, so those
-        // stay null-padded and fire their default via the null check. Built-ins have an
-        // all-zero mask and keep pure null padding. Positions >= 32 are not tracked
-        // (such arity is never reached in practice) and pad null. (#640)
+        // `typeof`/`=== undefined`/default-firing all work. An optional or *defaulted*
+        // param is widened to an `object` slot upstream (ParameterTypeResolver), so it
+        // lands here with its bit set and behaves correctly across the boundary (#925).
+        // A still-typed slot (string/double) is a genuinely *required* typed parameter —
+        // it can't coerce the sentinel, so it stays null-padded (an omitted required arg
+        // is a type error anyway). Built-ins have an all-zero mask and keep pure null
+        // padding (their bodies use null-checks for optional-arg absence). Positions >= 32
+        // are not tracked (such arity is never reached in practice) and pad null. (#640, #925)
         var padUndefinedMaskField = typeBuilder.DefineField("_padUndefinedMask", _types.Int32, FieldAttributes.Private);
         // Cached MethodInvoker. .NET 8+'s MethodInvoker.Create() pre-builds
         // the JIT'd dispatch stub for a method, then Invoke(...) calls it
@@ -1701,15 +1704,17 @@ public partial class RuntimeEmitter
         // with the `undefined` sentinel, matching JS semantics and the direct-call path — so
         // `typeof`, `=== undefined`, and `=== null` answer correctly for an omitted optional
         // parameter, and an object-slotted default-valued parameter's entry prologue fires.
+        // Optional and value-type-defaulted params are widened to `object` upstream
+        // (ParameterTypeResolver), so they get the sentinel here for every user-function kind —
+        // declarations, arrows, methods, and async/generator/async-generator functions (#925).
         //
         // Every other slot is left as CLR null (the Newarr zero value). That covers built-ins
         // (mask 0 — their bodies use null-checks for optional-arg absence: stream write/end
-        // callbacks, encodings, ...) and typed default-valued parameters of user functions
-        // (string/double slots can't hold the sentinel — it would coerce to a real value
-        // before the entry prologue, whereas null fires their default via the null check). The
+        // callbacks, encodings, ...) and genuinely value-typed *required* user params (a `double`
+        // can't hold the sentinel; an omitted required arg is a type error regardless). The
         // one built-in that must distinguish absent (skip) from explicit JS null (throw) —
         // value-form Object.create's props — gets a dedicated wrapper instead
-        // (ObjectCreateValueForm in RuntimeEmitter.Objects.Prototype.cs). (#640)
+        // (ObjectCreateValueForm in RuntimeEmitter.Objects.Prototype.cs). (#640, #925)
         var skipUndefinedPad = il.DefineLabel();
         // if (_padUndefinedMask == 0) skip — fast path for built-ins and all-typed signatures.
         il.Emit(OpCodes.Ldarg_0);

--- a/STATUS.md
+++ b/STATUS.md
@@ -556,7 +556,8 @@ The following stdlib TS files carry workarounds for compiler gaps that surfaced 
 
 - `stdlib/node/process.ts` (`nextTick`) and `stdlib/node/timers.ts` (`setTimeout`/`setInterval`/`setImmediate`) — arity-dispatch across 8 positional args because the built-in emitter doesn't expand `Expr.Spread` when forwarding to primitive methods. Payloads with >8 args are silently truncated.
 - `stdlib/node/async_hooks.ts` (`run`, `exit`) — drops the optional `...args` parameter; the underlying `SharpTSAsyncLocalStorage` still supports it. No current tests exercise this path.
-- Default parameters through `$TSFunction.Invoke` only apply for reference-type params. Value-type defaults (`x: number = 5` on a module export) silently receive `0` / `false` / `0n`; stdlib authors use `param?: T` + `??` — see `stdlib/CONTRIBUTING.md`.
+
+(Resolved #925: parameter defaults — reference **and** value type — and unset optional reference params now round-trip faithfully through `$TSFunction.Invoke`. The old `param?: T` + `??` and `!= null` authoring workarounds have been retired from `stdlib/CONTRIBUTING.md`.)
 
 ### Resolved: guest-error identity (2026-04-18 regression → fully resolved 2026-06-24)
 

--- a/SharpTS.Tests/CompilerTests/StandaloneDllTests.cs
+++ b/SharpTS.Tests/CompilerTests/StandaloneDllTests.cs
@@ -513,6 +513,42 @@ public class StandaloneDllTests
     }
 
     /// <summary>
+    /// #925 guardrail: an exported async function / generator used as an imported value pads omitted
+    /// optional args with the `undefined` sentinel (via the $PadUndefined attribute, which is defined
+    /// in the OUTPUT assembly) — so this must keep running with no SharpTS.dll on disk.
+    /// </summary>
+    [Fact]
+    public void Isolated_OptionalArgUndefinedPadding_ShouldExecuteWithoutSharpTsDll()
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["helper.ts"] = """
+                export async function h(x?: any): Promise<string> { return typeof x; }
+                export function* gen(x?: any): Generator<string> { yield typeof x; }
+                """,
+            ["main.ts"] = """
+                import { h, gen } from "./helper";
+                async function main() {
+                    console.log(await h());
+                    console.log(gen().next().value);
+                }
+                main();
+                """
+        };
+
+        var (tempDir, dllPath) = CompileStandaloneModule(files, "main.ts");
+        try
+        {
+            var output = ExecuteCompiledDllIsolated(dllPath, timeoutMs: 15000);
+            Assert.Equal("undefined\nundefined\n", output);
+        }
+        finally
+        {
+            CleanupTempDir(tempDir);
+        }
+    }
+
+    /// <summary>
     /// Phase 23 guardrail: Verifies crypto hash operations work standalone.
     /// </summary>
     [Fact]

--- a/SharpTS.Tests/CompilerTests/ValueCallUndefinedPaddingTests.cs
+++ b/SharpTS.Tests/CompilerTests/ValueCallUndefinedPaddingTests.cs
@@ -169,4 +169,82 @@ public class ValueCallUndefinedPaddingTests
             """;
         Assert.Equal("undefined\n", TestHarness.Run(source, mode));
     }
+
+    // #925: free-function declarations that compile to a state-machine stub — `async function`,
+    // `function*`, and `async function*` — were never marked $PadUndefined (only their class-method
+    // and async-arrow counterparts were), so an omitted optional reference arg padded CLR null
+    // instead of the sentinel on the value-call / cross-module boundary. `typeof`/`=== undefined`
+    // then answered "object"/false. Marking the stub fixes all three kinds.
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void CrossModuleImport_AsyncFunction_OmittedOptionalArg_IsUndefined(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["helper.ts"] = """
+                export async function h(x?: any): Promise<string> { return typeof x; }
+                export async function h2(x?: any): Promise<boolean> { return x === undefined; }
+                """,
+            ["main.ts"] = """
+                import { h, h2 } from './helper';
+                async function main() {
+                    console.log(await h());
+                    console.log(await h2());
+                }
+                main();
+                """,
+        };
+        Assert.Equal("undefined\ntrue\n", TestHarness.RunModules(files, "main.ts", mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void CrossModuleImport_Generator_OmittedOptionalArg_IsUndefined(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["helper.ts"] = """
+                export function* gen(x?: any): Generator<string> { yield typeof x; }
+                """,
+            ["main.ts"] = """
+                import { gen } from './helper';
+                console.log(gen().next().value);
+                """,
+        };
+        Assert.Equal("undefined\n", TestHarness.RunModules(files, "main.ts", mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void CrossModuleImport_AsyncGenerator_OmittedOptionalArg_IsUndefined(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["helper.ts"] = """
+                export async function* agen(x?: any): AsyncGenerator<string> { yield typeof x; }
+                """,
+            ["main.ts"] = """
+                import { agen } from './helper';
+                async function consume(): Promise<void> {
+                    for await (const v of agen()) console.log(v);
+                }
+                consume();
+                """,
+        };
+        Assert.Equal("undefined\n", TestHarness.RunModules(files, "main.ts", mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AsyncFunctionAsValue_OmittedOptionalArg_IsUndefined(ExecutionMode mode)
+    {
+        // Value-call (non-module) path for the async free-function stub.
+        var source = """
+            async function h(x?: any): Promise<string> { return typeof x; }
+            const r: any = h;
+            r().then((v: string) => console.log(v));
+            """;
+        Assert.Equal("undefined\n", TestHarness.Run(source, mode));
+    }
 }

--- a/SharpTS.Tests/SharedTests/DefaultParameterTests.cs
+++ b/SharpTS.Tests/SharedTests/DefaultParameterTests.cs
@@ -78,9 +78,11 @@ public class DefaultParameterTests
     [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void DefaultParam_NumericValue_DirectCall(ExecutionMode mode)
     {
-        // Numeric (value-type) defaults still work for direct same-module calls via
-        // OverloadGenerator. Module-imported callers with value-type defaults are a
-        // known limitation — the inline null-check pattern skips value types.
+        // Numeric (value-type) defaults work for direct same-module calls via OverloadGenerator,
+        // and — since #646/#705 — also through the $TSFunction.Invoke boundary: a value-type-
+        // defaulted param is widened to an `object` slot so the entry prologue can observe the
+        // `$Undefined` sentinel and fire the default. See the cross-module / value-call coverage
+        // in DefaultParam_NumericValue_*Boundary below (#925).
         var source = """
             function pad(width: number = 4): number {
                 return width * 2;
@@ -91,6 +93,85 @@ public class DefaultParameterTests
 
         var output = TestHarness.Run(source, mode);
         Assert.Equal("8\n14\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void DefaultParam_NumericValue_AppliedAcrossModuleImport(ExecutionMode mode)
+    {
+        // #925: a VALUE-TYPE default (`number`) on a module-exported function must fire through the
+        // cross-module $TSFunction.Invoke boundary when the arg is omitted — the param is widened to
+        // an `object` slot so the omitted arg pads `$Undefined` and the prologue applies the default.
+        // Previously documented (incorrectly, post-#705) as a known limitation that returned 0.
+        var files = new Dictionary<string, string>
+        {
+            ["lib.ts"] = """
+                export function pad(width: number = 4): number { return width * 2; }
+                """,
+            ["main.ts"] = """
+                import { pad } from './lib';
+                console.log(pad());
+                console.log(pad(7));
+                """
+        };
+        Assert.Equal("8\n14\n", TestHarness.RunModules(files, "main.ts", mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void DefaultParam_BooleanAndBigIntValue_AppliedAcrossModuleImport(ExecutionMode mode)
+    {
+        // #925: the value-type-default fix covers `boolean` and `bigint` defaults too, not just `number`.
+        var files = new Dictionary<string, string>
+        {
+            ["lib.ts"] = """
+                export function flag(on: boolean = true): boolean { return on; }
+                export function big(n: bigint = 7n): bigint { return n; }
+                """,
+            ["main.ts"] = """
+                import { flag, big } from './lib';
+                console.log(flag());
+                console.log(big());
+                """
+        };
+        Assert.Equal("true\n7n\n", TestHarness.RunModules(files, "main.ts", mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void DefaultParam_NumericValue_ValueCallBoundary(ExecutionMode mode)
+    {
+        // #925: same fix via the value-call path — a function stored in a value and called with the
+        // arg omitted routes through $TSFunction.Invoke and must still fire the value-type default.
+        var source = """
+            function pad(width: number = 4): number { return width * 2; }
+            const f: any = pad;
+            console.log(f());
+            console.log(f(7));
+            """;
+        Assert.Equal("8\n14\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void DefaultParam_NumericValue_AsyncFunction_AcrossModuleImport(ExecutionMode mode)
+    {
+        // #925: an exported ASYNC function with a value-type default fires it through the boundary.
+        var files = new Dictionary<string, string>
+        {
+            ["lib.ts"] = """
+                export async function pad(width: number = 4): Promise<number> { return width * 2; }
+                """,
+            ["main.ts"] = """
+                import { pad } from './lib';
+                async function main() {
+                    console.log(await pad());
+                    console.log(await pad(7));
+                }
+                main();
+                """
+        };
+        Assert.Equal("8\n14\n", TestHarness.RunModules(files, "main.ts", mode));
     }
 
     [Theory]

--- a/stdlib/CONTRIBUTING.md
+++ b/stdlib/CONTRIBUTING.md
@@ -66,58 +66,36 @@ Target Node.js 24.15.0. Match observable behavior including error codes
 (`ENOENT`, `EACCES`, etc.). Any deliberate divergence needs an explicit
 comment explaining why — no silent differences.
 
-### 6. Optional reference-type params: use `!= null`, not `!== undefined`
+### 6. Optional params and parameter defaults: write idiomatic TS
 
-When checking whether an optional parameter was passed, prefer loose
-null-equality (`!= null`) over the strict `undefined` check:
-
-```ts
-// Good — catches both undefined and null
-export function basename(p: string, ext?: string): string {
-    if (ext != null && ext.length > 0) { /* use ext */ }
-}
-
-// Bad — fails open in compiled mode when arg wasn't passed
-export function basename(p: string, ext?: string): string {
-    if (ext !== undefined && ext.length > 0) { /* NRE if ext is C# null */ }
-}
-```
-
-**Why:** compiled mode passes unset optional reference-type arguments
-through TSFunction.Invoke as C# `null`, not as SharpTS's `undefined`
-sentinel. The JS expression `null !== undefined` evaluates to `true`,
-so the strict check falls through to `.length` on null and NREs. Loose
-null equality (`x != null`) matches both values.
-
-This bit the `path.basename` migration on the `posix.basename(p)`
-(no-ext) overload before the rule was pinned here.
-
-### 7. Default parameter values: reference types only
-
-Reference-type default values (strings, objects, arrays) work correctly
-through module imports:
+Omitted optional parameters and parameter defaults round-trip faithfully
+through module imports — including the `$TSFunction.Invoke` value-call /
+cross-module path. Write the natural TypeScript; no boundary-specific
+workarounds are needed.
 
 ```ts
-// Fine — string default, works through module imports
+// Optional param: an omitted arg arrives as `undefined`, so `=== undefined`,
+// `typeof`, and `!= null` all answer correctly across module boundaries.
+export function basename(p: string, ext?: string): string {
+    if (ext !== undefined && ext.length > 0) { /* use ext */ }
+}
+
+// Defaults of any type fire when the arg is omitted — reference (string,
+// object, array) AND value type (number, boolean, bigint).
 export function parse(str: string, sep: string = '&', eq: string = '='): any { ... }
+export function pad(width: number = 4): number { return width * 2; }
 ```
 
-**Value-type defaults (numbers, booleans) are a known limitation through
-module imports.** The compiler's `$TSFunction.Invoke` path dispatches to
-the full-arity method with null-padded args; the inline null-check
-pattern used for reference types doesn't apply to value types (a `double`
-can't be null). If you need a numeric default in a module-exported
-function, use `param?: number` + `??` as a workaround:
+**Why this works:** value-type-defaulted params are widened to an `object`
+slot, and omitted optional args are padded with the `undefined` sentinel
+(not CLR null) for every user-function kind — declarations, arrows,
+methods, and async/generator/async-generator functions. The entry prologue
+fires the default when the slot holds `undefined`. (Previously, value-type
+defaults silently became `0`/`false` and unset optional ref params arrived
+as CLR null; both were fixed in #925 — this section retired the old
+`!= null` / `param?: T` + `??` workarounds.)
 
-```ts
-// Module-exported numeric defaults — use the ?? pattern:
-export function pad(width?: number): number {
-    const actualWidth = width ?? 4;
-    return actualWidth * 2;
-}
-```
-
-### 8. No SharpTS-specific APIs
+### 7. No SharpTS-specific APIs
 
 Shim code should be legal Node.js as far as syntax and semantics go.
 `console.log`, `JSON.*`, `Math.*`, `Array.*`, `Object.*`, standard globals

--- a/stdlib/node/timers/promises.ts
+++ b/stdlib/node/timers/promises.ts
@@ -11,25 +11,24 @@ import {
     setInterval as __setInterval,
 } from 'primitive:timers/promises';
 
-// `value` carries an explicit `= undefined` default (not just `?`) so the resolved value is the
-// `undefined` sentinel, not CLR null, when omitted. In compiled mode a missing optional argument
-// is padded to null (intentional, for built-in null-checks — see $TSFunction.AdjustArgs, tracked
-// in #640), and that null would otherwise flow through to the resolved promise; the default
-// expression re-establishes `undefined`, matching Node and the interpreter. (Surfaced by the
-// strict-=== fix in #600.)
+// `value` is a plain optional param: an omitted optional argument is padded with the `undefined`
+// sentinel (not CLR null) through the $TSFunction.Invoke boundary in compiled mode, so an unset
+// `value` resolves the promise with `undefined`, matching Node and the interpreter. This used to
+// require an explicit `= undefined` default to dodge null padding (#640/#600); #925 made the
+// boundary ABI-faithful, so the plain `?:` form is correct.
 
 /** Resolves with `value` after `delay` ms. Supports `options.signal` for AbortSignal. */
-export function setTimeout(delay?: number, value: any = undefined, options?: any): Promise<any> {
+export function setTimeout(delay?: number, value?: any, options?: any): Promise<any> {
     return __setTimeout(delay as any, value, options);
 }
 
 /** Resolves with `value` on the next event-loop tick. Supports `options.signal`. */
-export function setImmediate(value: any = undefined, options?: any): Promise<any> {
+export function setImmediate(value?: any, options?: any): Promise<any> {
     return __setImmediate(value, options);
 }
 
 /** Returns an AsyncIterable that yields `value` every `delay` ms. */
-export function setInterval(delay?: number, value: any = undefined, options?: any): AsyncIterable<any> {
+export function setInterval(delay?: number, value?: any, options?: any): AsyncIterable<any> {
     // NOTE: if the primitive throws synchronously (pre-aborted AbortSignal), the
     // interpreter currently converts the error to a string at the TS-function
     // boundary, losing Error identity. One test pins this behavior


### PR DESCRIPTION
Closes #925.

## Summary

The compiled call ABI (`$TSFunction.Invoke` → `AdjustArgs`) was flagged by the 2026-06 tech-debt audit as lossy in two ways for module-exported / value-called functions, papered over by `stdlib/CONTRIBUTING.md` §6–7:

1. value-type defaults (`x: number = 5`) silently become `0`/`false`/`0n` when omitted;
2. unset optional reference params arrive as CLR `null`, not the `$Undefined` sentinel.

Investigation showed the underlying mechanism (the `$PadUndefined` marker + `_padUndefinedMask` and `WidenDefaultedParamsToObject`, from the #640/#646/#705/#707/#723/#737 series) **already fixes both behaviors** for plain functions, arrows, and all class methods — the audit read stale docs. Value-type defaults round-trip correctly for every kind (defaulted params are widened to `object` slots and `EmitDefaultParameters` fires on null **or** the sentinel).

**The one genuine residual gap:** three free-function declaration stub kinds were never marked `$PadUndefined` — `DefineAsyncFunction`, `DefineGeneratorFunction`, `DefineAsyncGeneratorFunction` — so an omitted optional reference param on an exported `async function` / `function*` / `async function*` still padded CLR `null`, breaking `typeof` / `=== undefined` across the value-call / cross-module boundary. (Their value-type *defaults* still fired via the null path; only optional-ref observability was wrong.) Retiring §6 honestly *requires* closing this, otherwise the doc-guarded bug returns for async exports.

## Changes

- **Fix (3 lines):** mark the async / generator / async-generator stub builders with `MarkPadsUndefined`, mirroring the established pattern (`ILCompiler.Functions.cs:107`, the `// #640` async-arrow marks, and `ILCompiler.Classes.Methods.cs:1176`).
- **Retire workarounds:** rewrite `CONTRIBUTING.md` §6–7 (the `!= null` mandate and the value-type-default `?? ` workaround) into positive guidance; drop the value-type-default bullet from `STATUS.md`; simplify `timers/promises.ts` `value: any = undefined` → `value?: any`; update stale comments in `ILEmitter.Helpers.cs`, `RuntimeEmitter.TSFunction.cs`, and `DefaultParameterTests.cs`.
- **Tests (verification-first):** value-type defaults (number/boolean/bigint) across module import + value-call + async; optional-ref `=== undefined` for async/generator/async-gen free functions; a standalone-DLL guard. The async/gen optional-ref tests failed before the fix and pass after; the value-type-default tests passed already (confirming the docs were stale).

Out of scope (left tracked in STATUS.md): the unrelated arity-dispatch `Expr.Spread`-forwarding workarounds in `process.ts` / `timers.ts` / `async_hooks.ts`.

## Verification

- Full `dotnet test` green except a pre-existing `LiveNetwork` DNS smoke test (`DnsRecordTypeTests.LiveSmoke_ResolveNs_Promise`, Compiled) that fails identically on clean `origin/main` — environmental, unrelated.
- `SharpTS.Test262` (interpreter + compiled): baseline diff `Failed: 0` (the host crash at teardown is the documented pre-existing inert crash).