### PR TITLE
Fix #945: compiled generator expr capturing an enclosing generator's local

### DIFF
--- a/Compilation/ILCompiler.Generators.cs
+++ b/Compilation/ILCompiler.Generators.cs
@@ -106,10 +106,12 @@ public partial class ILCompiler
     }
 
     /// <summary>
-    /// Returns the generator's own locals/parameters that are both captured by an inner arrow and
-    /// written by one (the set that needs shared reference storage). Per-iteration <c>for (let…)</c>
-    /// bindings are excluded — each iteration owns its binding (#649), so closures must snapshot them
-    /// per iteration rather than share one function-DC cell.
+    /// Returns the generator's own locals/parameters that need shared reference storage in the function
+    /// display class: those both captured AND written by an inner arrow (#674), plus (#945) those a
+    /// HOISTED lambda-lifted nested generator forwards read-only — those must be read LIVE through the DC
+    /// rather than a stale by-value snapshot taken above the captured local's assignment. Per-iteration
+    /// <c>for (let…)</c> bindings are excluded — each iteration owns its binding (#649), so closures must
+    /// snapshot them per iteration rather than share one function-DC cell.
     /// </summary>
     private HashSet<string> ComputeMutatedCapturedGeneratorVars(Stmt.Function funcStmt)
     {
@@ -119,6 +121,17 @@ public partial class ILCompiler
 
         var result = new HashSet<string>(capturedLocals);
         result.IntersectWith(CollectGeneratorArrowCapturedWrites(funcStmt));
+
+        // #945: a read-only capture forwarded by a HOISTED lambda-lifted nested generator (the sync
+        // forwarding arrow NestedFunctionLifter marks IsLiftedForwarder) must also live in the DC, so the
+        // hoisted forwarder reads it live at call time. Marked forwarders only appear in free/module/
+        // nested-in-function generator bodies (class-method enclosers decline → unmarked), so generator
+        // METHODS are unaffected. Unioned BEFORE the empty-set short-circuit and the per-iteration
+        // exclusion below, which still strips any per-iteration loop binding a forwarder happens to read.
+        var forwardedReads = CollectLiftedForwarderCapturedReads(funcStmt);
+        forwardedReads.IntersectWith(capturedLocals);
+        result.UnionWith(forwardedReads);
+
         if (result.Count == 0)
             return [];
 
@@ -191,6 +204,28 @@ public partial class ILCompiler
             writes.UnionWith(arrowWrites);
         }
         return writes;
+    }
+
+    /// <summary>
+    /// Unions the captures of every lifted forwarding arrow (#945) lexically inside the generator body.
+    /// A forwarder is the sync, non-generator arrow <see cref="NestedFunctionLifter"/> substitutes for a
+    /// capturing nested generator when it hoists the binding into a generator encloser's body; it only
+    /// READS its forwarded captures, so it is invisible to the write-based
+    /// <see cref="CollectGeneratorArrowCapturedWrites"/>. The caller intersects the result with the
+    /// generator's own captured locals, so a forwarder nested in a deeper function contributes nothing.
+    /// </summary>
+    private HashSet<string> CollectLiftedForwarderCapturedReads(Stmt.Function funcStmt)
+    {
+        var collector = new ArrowCollector();
+        if (funcStmt.Body != null)
+            foreach (var stmt in funcStmt.Body)
+                collector.Visit(stmt);
+
+        var reads = new HashSet<string>();
+        foreach (var arrow in collector.Arrows)
+            if (arrow.IsLiftedForwarder)
+                reads.UnionWith(_closures.Analyzer.GetCaptures(arrow));
+        return reads;
     }
 
     /// <summary>Collects every arrow function in a subtree, descending into nested arrows.</summary>

--- a/Compilation/NestedFunctionLifter.cs
+++ b/Compilation/NestedFunctionLifter.cs
@@ -499,7 +499,7 @@ internal sealed class NestedFunctionLifter
         bool changed = false;
         foreach (var stmt in module)
         {
-            var rewritten = ProcessStmt(stmt, enclosingIsStateMachine: false, enclosingIsAsyncFunction: false);
+            var rewritten = ProcessStmt(stmt, enclosingIsStateMachine: false, enclosingIsAsyncFunction: false, enclosingIsGeneratorClassMethod: false);
             if (!ReferenceEquals(rewritten, stmt)) changed = true;
             result.Add(rewritten);
         }
@@ -511,7 +511,7 @@ internal sealed class NestedFunctionLifter
     /// the module top level under a fresh name and replaced, at the top of this list, by a
     /// <c>var &lt;name&gt; = &lt;freshName&gt;;</c> alias so references in this scope still resolve.
     /// </summary>
-    private List<Stmt> ProcessBody(List<Stmt> body, bool enclosingIsStateMachine, bool enclosingIsAsyncFunction)
+    private List<Stmt> ProcessBody(List<Stmt> body, bool enclosingIsStateMachine, bool enclosingIsAsyncFunction, bool enclosingIsGeneratorClassMethod)
     {
         List<Stmt>? result = null;
         List<Stmt>? aliases = null;
@@ -544,15 +544,23 @@ internal sealed class NestedFunctionLifter
                     // creates (it appends the lifted `function* __genArrow_N` at body END) resolves. The
                     // async-function case (#924) is the async analog of the plain-function #534 fix.
                     //
-                    // When the enclosing function is a GENERATOR (sync `function*` or `async function*`),
-                    // keep the binding in place: an instance generator method has no function display class
-                    // wired, so its forwarding arrow snapshots captures by value at creation, and hoisting
-                    // above the captured local's assignment would read a stale value. Leave those (the
-                    // existing #583 §1 decl-before-use behavior — currently a clean failure for the
-                    // generator-encloser analog of #924). Module-block/loop captures (#622) likewise stay
-                    // in place so each loop iteration rebuilds a fresh arrow over that iteration's binding.
+                    // When the enclosing function is a top-level / module-level / nested-in-plain-function
+                    // GENERATOR (sync `function*` or `async function*`), the binding is ALSO hoisted (#945):
+                    // such a generator wires a shared function display class (#674), and the forwarding
+                    // arrow — marked IsLiftedForwarder below — has its read-only forwarded captures routed
+                    // through that DC (see ComputeMutatedCapturedGeneratorVars), so it reads them live at
+                    // call time and the earlier hoisted creation position is harmless. The generator-
+                    // encloser case (#945) is the generator analog of the async-function #924 fix.
+                    //
+                    // When the enclosing function is a class GENERATOR METHOD (sync or async, static or
+                    // instance), keep the binding in place: a static generator method has no function
+                    // display class at all and an instance one wires it only for write-captures, so a
+                    // hoisted forwarding arrow would snapshot the captured local by value at creation and
+                    // read a stale value. Those decline cleanly (a clean failure, never a miscompile).
+                    // Module-block/loop captures (#622) likewise stay in place so each loop iteration
+                    // rebuilds a fresh arrow over that iteration's binding.
                     result ??= new List<Stmt>(body.GetRange(0, i));
-                    bool hoist = _hoistedForwards.Contains(f) && (!enclosingIsStateMachine || enclosingIsAsyncFunction);
+                    bool hoist = _hoistedForwards.Contains(f) && !enclosingIsGeneratorClassMethod;
                     var binding = LambdaLiftCandidate(f, forwarded, hoisted: hoist);
                     if (hoist)
                         (aliases ??= new List<Stmt>()).Add(binding);
@@ -562,7 +570,7 @@ internal sealed class NestedFunctionLifter
                 }
             }
 
-            var rewritten = ProcessStmt(stmt, enclosingIsStateMachine, enclosingIsAsyncFunction);
+            var rewritten = ProcessStmt(stmt, enclosingIsStateMachine, enclosingIsAsyncFunction, enclosingIsGeneratorClassMethod);
             if (result != null)
                 result.Add(rewritten);
             else if (!ReferenceEquals(rewritten, stmt))
@@ -584,7 +592,8 @@ internal sealed class NestedFunctionLifter
         var freshName = $"__nestedFn_{f.Name.Lexeme}_{_counter++}";
         var freshToken = new Token(TokenType.IDENTIFIER, freshName, null, f.Name.Line);
 
-        var liftedBody = ProcessBody(f.Body!, f.IsGenerator || f.IsAsync, f.IsAsync && !f.IsGenerator);
+        // The relocated function becomes a top-level declaration, so it is never a class method.
+        var liftedBody = ProcessBody(f.Body!, f.IsGenerator || f.IsAsync, f.IsAsync && !f.IsGenerator, enclosingIsGeneratorClassMethod: false);
 
         // Recursion: the relocated body still calls itself by the original name. Bind that name to
         // the fresh declaration with a self-alias at the top of the body.
@@ -623,8 +632,9 @@ internal sealed class NestedFunctionLifter
         var freshName = $"__nestedFn_{f.Name.Lexeme}_{_counter++}";
         var freshToken = new Token(TokenType.IDENTIFIER, freshName, null, f.Name.Line);
 
-        // Recurse first so nested candidates inside the relocated body are also handled.
-        var liftedBody = ProcessBody(f.Body!, f.IsGenerator || f.IsAsync, f.IsAsync && !f.IsGenerator);
+        // Recurse first so nested candidates inside the relocated body are also handled. The relocated
+        // function becomes a top-level declaration, so it is never a class method.
+        var liftedBody = ProcessBody(f.Body!, f.IsGenerator || f.IsAsync, f.IsAsync && !f.IsGenerator, enclosingIsGeneratorClassMethod: false);
 
         // Relocated declaration: captured bindings become leading (untyped) parameters, followed by
         // the original parameters. Body references to the captured names now resolve to these
@@ -661,7 +671,14 @@ internal sealed class NestedFunctionLifter
             ReturnType: null,
             HasOwnThis: false,
             IsAsync: false,
-            IsGenerator: false);
+            IsGenerator: false)
+        {
+            // #945: when this forwarder is HOISTED into a generator encloser's body, mark it so the
+            // generator function-DC pass routes its read-only forwarded captures through the shared
+            // display class (live read), not a stale by-value snapshot. Only hoisted forwarders are
+            // marked — class-method (declined) and module-block/loop (#622) forwarders stay unmarked.
+            IsLiftedForwarder = hoisted,
+        };
 
         // Function-scope capture (#534): a `var` the caller hoists to the body top, matching
         // function-declaration hoisting. Module-block/loop capture (#622): a block-scoped `let` left
@@ -669,72 +686,73 @@ internal sealed class NestedFunctionLifter
         return new Stmt.Var(f.Name, TypeAnnotation: null, Initializer: arrow, IsVar: hoisted);
     }
 
-    private Stmt ProcessStmt(Stmt stmt, bool enclosingIsStateMachine, bool enclosingIsAsyncFunction)
+    private Stmt ProcessStmt(Stmt stmt, bool enclosingIsStateMachine, bool enclosingIsAsyncFunction, bool enclosingIsGeneratorClassMethod)
     {
         switch (stmt)
         {
             case Stmt.Function f when f.Body != null:
             {
                 // Not lifted (not a safe candidate), but its body may contain nested candidates.
-                var nb = ProcessBody(f.Body, f.IsGenerator || f.IsAsync, f.IsAsync && !f.IsGenerator);
+                // A nested function declaration is never a class method, so the flag resets to false.
+                var nb = ProcessBody(f.Body, f.IsGenerator || f.IsAsync, f.IsAsync && !f.IsGenerator, enclosingIsGeneratorClassMethod: false);
                 return ReferenceEquals(nb, f.Body) ? f : f with { Body = nb };
             }
             case Stmt.Block b:
             {
-                var nb = ProcessBody(b.Statements, enclosingIsStateMachine, enclosingIsAsyncFunction);
+                var nb = ProcessBody(b.Statements, enclosingIsStateMachine, enclosingIsAsyncFunction, enclosingIsGeneratorClassMethod);
                 return ReferenceEquals(nb, b.Statements) ? b : new Stmt.Block(nb);
             }
             case Stmt.Sequence s:
             {
-                var nb = ProcessBody(s.Statements, enclosingIsStateMachine, enclosingIsAsyncFunction);
+                var nb = ProcessBody(s.Statements, enclosingIsStateMachine, enclosingIsAsyncFunction, enclosingIsGeneratorClassMethod);
                 return ReferenceEquals(nb, s.Statements) ? s : new Stmt.Sequence(nb);
             }
             case Stmt.If i:
             {
-                var nt = ProcessStmt(i.ThenBranch, enclosingIsStateMachine, enclosingIsAsyncFunction);
-                var ne = i.ElseBranch != null ? ProcessStmt(i.ElseBranch, enclosingIsStateMachine, enclosingIsAsyncFunction) : null;
+                var nt = ProcessStmt(i.ThenBranch, enclosingIsStateMachine, enclosingIsAsyncFunction, enclosingIsGeneratorClassMethod);
+                var ne = i.ElseBranch != null ? ProcessStmt(i.ElseBranch, enclosingIsStateMachine, enclosingIsAsyncFunction, enclosingIsGeneratorClassMethod) : null;
                 if (ReferenceEquals(nt, i.ThenBranch) && (i.ElseBranch == null || ReferenceEquals(ne, i.ElseBranch)))
                     return i;
                 return new Stmt.If(i.Condition, nt, ne);
             }
             case Stmt.While w:
             {
-                var nb = ProcessStmt(w.Body, enclosingIsStateMachine, enclosingIsAsyncFunction);
+                var nb = ProcessStmt(w.Body, enclosingIsStateMachine, enclosingIsAsyncFunction, enclosingIsGeneratorClassMethod);
                 return ReferenceEquals(nb, w.Body) ? w : new Stmt.While(w.Condition, nb);
             }
             case Stmt.DoWhile d:
             {
-                var nb = ProcessStmt(d.Body, enclosingIsStateMachine, enclosingIsAsyncFunction);
+                var nb = ProcessStmt(d.Body, enclosingIsStateMachine, enclosingIsAsyncFunction, enclosingIsGeneratorClassMethod);
                 return ReferenceEquals(nb, d.Body) ? d : new Stmt.DoWhile(nb, d.Condition);
             }
             case Stmt.For fo:
             {
-                var ni = fo.Initializer != null ? ProcessStmt(fo.Initializer, enclosingIsStateMachine, enclosingIsAsyncFunction) : null;
-                var nb = ProcessStmt(fo.Body, enclosingIsStateMachine, enclosingIsAsyncFunction);
+                var ni = fo.Initializer != null ? ProcessStmt(fo.Initializer, enclosingIsStateMachine, enclosingIsAsyncFunction, enclosingIsGeneratorClassMethod) : null;
+                var nb = ProcessStmt(fo.Body, enclosingIsStateMachine, enclosingIsAsyncFunction, enclosingIsGeneratorClassMethod);
                 if ((fo.Initializer == null || ReferenceEquals(ni, fo.Initializer)) && ReferenceEquals(nb, fo.Body))
                     return fo;
                 return new Stmt.For(ni, fo.Condition, fo.Increment, nb);
             }
             case Stmt.ForOf fof:
             {
-                var nb = ProcessStmt(fof.Body, enclosingIsStateMachine, enclosingIsAsyncFunction);
+                var nb = ProcessStmt(fof.Body, enclosingIsStateMachine, enclosingIsAsyncFunction, enclosingIsGeneratorClassMethod);
                 return ReferenceEquals(nb, fof.Body) ? fof : fof with { Body = nb };
             }
             case Stmt.ForIn fin:
             {
-                var nb = ProcessStmt(fin.Body, enclosingIsStateMachine, enclosingIsAsyncFunction);
+                var nb = ProcessStmt(fin.Body, enclosingIsStateMachine, enclosingIsAsyncFunction, enclosingIsGeneratorClassMethod);
                 return ReferenceEquals(nb, fin.Body) ? fin : fin with { Body = nb };
             }
             case Stmt.LabeledStatement l:
             {
-                var ni = ProcessStmt(l.Statement, enclosingIsStateMachine, enclosingIsAsyncFunction);
+                var ni = ProcessStmt(l.Statement, enclosingIsStateMachine, enclosingIsAsyncFunction, enclosingIsGeneratorClassMethod);
                 return ReferenceEquals(ni, l.Statement) ? l : new Stmt.LabeledStatement(l.Label, ni);
             }
             case Stmt.TryCatch t:
             {
-                var nt = ProcessBody(t.TryBlock, enclosingIsStateMachine, enclosingIsAsyncFunction);
-                var nc = t.CatchBlock != null ? ProcessBody(t.CatchBlock, enclosingIsStateMachine, enclosingIsAsyncFunction) : null;
-                var nfb = t.FinallyBlock != null ? ProcessBody(t.FinallyBlock, enclosingIsStateMachine, enclosingIsAsyncFunction) : null;
+                var nt = ProcessBody(t.TryBlock, enclosingIsStateMachine, enclosingIsAsyncFunction, enclosingIsGeneratorClassMethod);
+                var nc = t.CatchBlock != null ? ProcessBody(t.CatchBlock, enclosingIsStateMachine, enclosingIsAsyncFunction, enclosingIsGeneratorClassMethod) : null;
+                var nfb = t.FinallyBlock != null ? ProcessBody(t.FinallyBlock, enclosingIsStateMachine, enclosingIsAsyncFunction, enclosingIsGeneratorClassMethod) : null;
                 if (ReferenceEquals(nt, t.TryBlock)
                     && (t.CatchBlock == null || ReferenceEquals(nc, t.CatchBlock))
                     && (t.FinallyBlock == null || ReferenceEquals(nfb, t.FinallyBlock)))
@@ -747,14 +765,14 @@ internal sealed class NestedFunctionLifter
                 for (int i = 0; i < sw.Cases.Count; i++)
                 {
                     var c = sw.Cases[i];
-                    var nb = ProcessBody(c.Body, enclosingIsStateMachine, enclosingIsAsyncFunction);
+                    var nb = ProcessBody(c.Body, enclosingIsStateMachine, enclosingIsAsyncFunction, enclosingIsGeneratorClassMethod);
                     if (!ReferenceEquals(nb, c.Body))
                     {
                         newCases ??= new List<Stmt.SwitchCase>(sw.Cases);
                         newCases[i] = new Stmt.SwitchCase(c.Value, nb);
                     }
                 }
-                var newDefault = sw.DefaultBody != null ? ProcessBody(sw.DefaultBody, enclosingIsStateMachine, enclosingIsAsyncFunction) : null;
+                var newDefault = sw.DefaultBody != null ? ProcessBody(sw.DefaultBody, enclosingIsStateMachine, enclosingIsAsyncFunction, enclosingIsGeneratorClassMethod) : null;
                 bool defaultChanged = sw.DefaultBody != null && !ReferenceEquals(newDefault, sw.DefaultBody);
                 if (newCases == null && !defaultChanged) return sw;
                 return new Stmt.Switch(sw.Subject, newCases ?? sw.Cases, defaultChanged ? newDefault : sw.DefaultBody);
@@ -763,7 +781,7 @@ internal sealed class NestedFunctionLifter
                 return ProcessClass(cls);
             case Stmt.Export ex when ex.Declaration != null:
             {
-                var nd = ProcessStmt(ex.Declaration, enclosingIsStateMachine, enclosingIsAsyncFunction);
+                var nd = ProcessStmt(ex.Declaration, enclosingIsStateMachine, enclosingIsAsyncFunction, enclosingIsGeneratorClassMethod);
                 return ReferenceEquals(nd, ex.Declaration) ? ex : ex with { Declaration = nd };
             }
             // Stmt.Namespace is intentionally NOT traversed (#583 §3 lift barrier).
@@ -779,7 +797,10 @@ internal sealed class NestedFunctionLifter
         {
             var m = cls.Methods[i];
             if (m.Body == null) continue;
-            var nb = ProcessBody(m.Body, m.IsGenerator || m.IsAsync, m.IsAsync && !m.IsGenerator);
+            // #945: a class generator method (sync or async, static or instance) does NOT reliably wire
+            // a function display class for read-only captures, so a forwarding binding hoisted into its
+            // body would read a stale by-value snapshot. Flag it so the gate declines to hoist there.
+            var nb = ProcessBody(m.Body, m.IsGenerator || m.IsAsync, m.IsAsync && !m.IsGenerator, enclosingIsGeneratorClassMethod: m.IsGenerator);
             if (!ReferenceEquals(nb, m.Body))
             {
                 newMethods ??= new List<Stmt.Function>(cls.Methods);

--- a/Parsing/AST.cs
+++ b/Parsing/AST.cs
@@ -239,7 +239,14 @@ public abstract record Expr
     /// IsAsync indicates this is an async function that returns a Promise.
     /// IsGenerator indicates this is a generator function (function*) that can yield values.
     /// </summary>
-    public record ArrowFunction(Token? Name, List<TypeParam>? TypeParams, string? ThisType, List<Stmt.Parameter> Parameters, Expr? ExpressionBody, List<Stmt>? BlockBody, string? ReturnType, bool HasOwnThis = false, bool IsAsync = false, bool IsGenerator = false) : Expr;
+    public record ArrowFunction(Token? Name, List<TypeParam>? TypeParams, string? ThisType, List<Stmt.Parameter> Parameters, Expr? ExpressionBody, List<Stmt>? BlockBody, string? ReturnType, bool HasOwnThis = false, bool IsAsync = false, bool IsGenerator = false) : Expr
+    {
+        // #945: marks the sync forwarding arrow NestedFunctionLifter substitutes for a capturing nested
+        // generator that was hoisted into a generator encloser's body. Tells the generator function-DC
+        // pass (ComputeMutatedCapturedGeneratorVars) to route this arrow's read-only forwarded captures
+        // through the function display class so the hoisted arrow reads them live, not a stale snapshot.
+        public bool IsLiftedForwarder { get; init; }
+    }
     // Template literal
     public record TemplateLiteral(List<string> Strings, List<Expr> Expressions) : Expr;
     // Tagged template literal: tag`template ${expr}`

--- a/SharpTS.Tests/SharedTests/AsyncGeneratorTests.cs
+++ b/SharpTS.Tests/SharedTests/AsyncGeneratorTests.cs
@@ -1802,12 +1802,14 @@ public class AsyncGeneratorTests
         Assert.Equal("5,6\n", TestHarness.Run(source, mode));
     }
 
-    // Out of #924's scope: a generator EXPRESSION whose enclosing function is itself a GENERATOR (here an
-    // async generator). A forwarding arrow there would snapshot the generator's captures at creation, so
-    // the compiler keeps it nested. The interpreter handles the nested declaration natively.
+    // #945 (generator-encloser analog of #924): an async-generator EXPRESSION whose enclosing function is
+    // itself a top-level/module-level `async function*` now runs in BOTH modes. The lifted forwarding
+    // binding is hoisted to the generator body top, and its read-only forwarded capture (`y`) is routed
+    // through the generator's #674 function display class so the hoisted forwarder reads it LIVE — not a
+    // stale by-value snapshot. (Previously interpreter-only + a compiled-fails-cleanly guard.)
     [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
-    public void AsyncGeneratorExpression_CapturesAsyncGeneratorLocal_RunsInInterpreter(ExecutionMode mode)
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AsyncGeneratorExpression_CapturesAsyncGeneratorLocal(ExecutionMode mode)
     {
         var source = """
             async function* outer() {
@@ -1825,11 +1827,13 @@ public class AsyncGeneratorTests
         Assert.Equal("3,4\n", TestHarness.Run(source, mode));
     }
 
-    // The compiled generator-encloser case must FAIL CLEANLY — never miscompile to a wrong value. (The
-    // forward-reference form in a generator encloser stays unsupported; this pins that it does not
-    // silently produce a different result.)
+    // #945: directly pins the compiled fix for the async-generator encloser — the lifted
+    // `async function* __genArrow_N` is appended at the enclosing async-generator body's END, so its
+    // forwarding binding must be hoisted above the earlier `const g = …` reference AND its forwarded
+    // capture routed through the function DC. Before the fix this miscompiled to a runtime
+    // "object is not a function".
     [Fact]
-    public void AsyncGeneratorExpression_CapturesAsyncGeneratorLocal_CompiledFailsCleanly()
+    public void AsyncGeneratorExpression_CapturesAsyncGeneratorLocal_CompiledHoistsForwardReference()
     {
         var source = """
             async function* outer() {
@@ -1844,6 +1848,32 @@ public class AsyncGeneratorTests
             }
             main();
             """;
+        Assert.Equal("3,4\n", TestHarness.RunCompiled(source));
+    }
+
+    // #945 decline: a class GENERATOR METHOD encloser (here an async-generator instance method) stays
+    // unsupported in compiled mode — its state machine wires no function DC for read-only captures, so
+    // hoisting the forwarding binding would read a stale by-value snapshot. It must fail CLEANLY (compile
+    // error), never miscompile to a wrong value. The interpreter runs the nested declaration natively.
+    [Fact]
+    public void AsyncGeneratorExpression_CapturesAsyncGeneratorMethodLocal_CompiledDeclinesCleanly()
+    {
+        var source = """
+            class C {
+                async *m() {
+                    let y = 3;
+                    const g = async function* () { yield y; yield y + 1; };
+                    for await (const v of g()) yield v;
+                }
+            }
+            async function main() {
+                const out: number[] = [];
+                for await (const v of new C().m()) out.push(v);
+                console.log(out.join(","));
+            }
+            main();
+            """;
+        Assert.Equal("3,4\n", TestHarness.Run(source, ExecutionMode.Interpreted));
         string compiled;
         try { compiled = TestHarness.RunCompiled(source); }
         catch { compiled = "<compile-or-runtime-error>"; }

--- a/SharpTS.Tests/SharedTests/GeneratorTests.cs
+++ b/SharpTS.Tests/SharedTests/GeneratorTests.cs
@@ -1742,6 +1742,177 @@ public class GeneratorTests
 
     #endregion
 
+    #region Generator expression capturing an enclosing GENERATOR's local — issue #945
+
+    // #945 (generator-encloser analog of #534/#924): a generator expression closing over a local of an
+    // enclosing top-level/module-level (or nested-in-plain-function) `function*` now runs in BOTH modes.
+    // The lifted forwarding binding is hoisted to the generator body top and its read-only forwarded
+    // capture is routed through the generator's #674 function display class, so the hoisted forwarder
+    // reads it LIVE. Class generator-method enclosers (sync/async, static/instance) instead decline
+    // cleanly (a compile error, never a stale-value miscompile) — pinned below.
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void GeneratorExpression_ClosesOverGeneratorLocal(ExecutionMode mode)
+    {
+        // The exact repro from issue #945.
+        var source = """
+            function* outer() {
+              let y = 5;
+              const g = function*() { yield y; yield y + 1; };
+              yield* g();
+            }
+            console.log([...outer()]);
+            """;
+
+        Assert.Equal("[5, 6]\n", TestHarness.Run(source, mode));
+    }
+
+    [Fact]
+    public void GeneratorExpression_ClosesOverGeneratorLocal_CompiledHoistsForwardReference()
+    {
+        // Directly pins the #945 compile-path fix: before the fix the appended `function* __genArrow_N`'s
+        // forwarding binding was not hoisted for a generator encloser, miscompiling to a runtime
+        // "object is not a function".
+        var source = """
+            function* outer() {
+              let y = 5;
+              const g = function*() { yield y; };
+              yield* g();
+            }
+            console.log([...outer()]);
+            """;
+
+        Assert.Equal("[5]\n", TestHarness.RunCompiled(source));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void GeneratorExpression_ClosesOverGeneratorLocal_CapturesByReference(ExecutionMode mode)
+    {
+        // The forwarder reads the captured local LIVE through the shared function DC, so a write-capturing
+        // arrow that mutates `y` before iteration is observed (here 1 + 10 + 20 = 31) — pinning that the
+        // write-capture and the forwarder's read share one DC field.
+        var source = """
+            function* outer() {
+              let y = 1;
+              const g = function*() { yield y; };
+              [10, 20].forEach(n => { y += n; });
+              yield* g();
+            }
+            console.log([...outer()]);
+            """;
+
+        Assert.Equal("[31]\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void GeneratorExpression_ClosesOverGeneratorLocal_MultipleForwarders(ExecutionMode mode)
+    {
+        // Two generator expressions each capturing a distinct enclosing-generator local → two DC fields.
+        var source = """
+            function* outer() {
+              let a = 5;
+              let b = 100;
+              const g1 = function*() { yield a; };
+              const g2 = function*() { yield b; };
+              yield* g1();
+              yield* g2();
+            }
+            console.log([...outer()]);
+            """;
+
+        Assert.Equal("[5, 100]\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void GeneratorExpression_ClosesOverGeneratorLocal_NestedInPlainFunction(ExecutionMode mode)
+    {
+        // The enclosing generator is itself nested in a plain function. NestedFunctionLifter relocates it
+        // to module top level, where it wires a function DC — so the encloser is still hoist-safe.
+        var source = """
+            function host() {
+              function* outer() {
+                let y = 7;
+                const g = function*() { yield y; };
+                yield* g();
+              }
+              return [...outer()];
+            }
+            console.log(host());
+            """;
+
+        Assert.Equal("[7]\n", TestHarness.Run(source, mode));
+    }
+
+    [Fact]
+    public void GeneratorExpression_ClosesOverInstanceGeneratorMethodLocal_CompiledDeclinesCleanly()
+    {
+        // A class instance generator method encloser has no function DC wired for read-only captures, so
+        // the compiler keeps the binding in place and the body's `yield` fails cleanly ("Yield not
+        // supported in this context") — never a stale-value miscompile. Interpreter runs it natively.
+        var source = """
+            class C {
+              *m() {
+                let y = 5;
+                const g = function*() { yield y; };
+                yield* g();
+              }
+            }
+            console.log([...new C().m()]);
+            """;
+
+        Assert.Equal("[5]\n", TestHarness.Run(source, ExecutionMode.Interpreted));
+        var ex = Assert.Throws<CompileException>(() => TestHarness.RunCompiled(source));
+        Assert.Contains("Yield not supported", ex.Message);
+    }
+
+    [Fact]
+    public void GeneratorExpression_ClosesOverStaticGeneratorMethodLocal_CompiledDeclinesCleanly()
+    {
+        // A static generator method has no function DC at all; same clean decline as the instance case.
+        var source = """
+            class C {
+              static *m() {
+                let y = 7;
+                const g = function*() { yield y; };
+                yield* g();
+              }
+            }
+            console.log([...C.m()]);
+            """;
+
+        Assert.Equal("[7]\n", TestHarness.Run(source, ExecutionMode.Interpreted));
+        var ex = Assert.Throws<CompileException>(() => TestHarness.RunCompiled(source));
+        Assert.Contains("Yield not supported", ex.Message);
+    }
+
+    [Fact]
+    public void GeneratorExpression_NamedSelfRecursive_ClosesOverGeneratorLocal_CompiledNeverWrong()
+    {
+        // A NAMED self-recursive generator expression that also captures an enclosing local is declined by
+        // the lambda-lift (self-recursion can't be forwarded). The compiled path must be a clean error or
+        // the correct value — never a wrong value. (The interpreter's handling of this self-recursive form
+        // is a separate pre-existing limitation, so only the compiled "never wrong" guarantee is pinned.)
+        var source = """
+            function* outer() {
+              let n = 2;
+              const g = function* rec(k: number) { if (k > 0) { yield n; yield* rec(k - 1); } };
+              yield* g(2);
+            }
+            console.log([...outer()]);
+            """;
+
+        string compiled;
+        try { compiled = TestHarness.RunCompiled(source); }
+        catch { compiled = "<compile-or-runtime-error>"; }
+        Assert.True(compiled == "<compile-or-runtime-error>" || compiled == "[2, 2]\n", $"unexpected: {compiled}");
+    }
+
+    #endregion
+
     #region Generator function expression / object generator method dynamic `this` — issue #775
 
     [Theory]


### PR DESCRIPTION
Fixes #945 — the generator-encloser analog of #924/#534.

A generator function-expression (sync `function*` or `async function*`) that closes over a local of an enclosing **top-level / module-level / nested-in-plain-function generator** now compiles and runs correctly:

```ts
function* outer() {
  let y = 5;
  const g = function* () { yield y; };
  yield* g();                 // was: runtime "object is not a function"
}
console.log([...outer()]);    // now: [5]
```

## Scope clarification

The issue's interpreter claim turned out to be **stale** — the interpreter already handled both sync and async generator enclosers (sync `ExecuteBlock` always hoisted; #924 added the same to `ExecuteBlockAsync`). This was a **compiled-only** gap, so the change is entirely on the compile path. Per the issue's "fix both modes **or** decline cleanly" criteria, this is the full fix for top-level generators, keeping class generator-method enclosers a clean decline.

## How it works — two coordinated parts

Both are required (P1 alone → stale miscompile; P2 alone → never hoists):

- **P1 — gate** (`NestedFunctionLifter`): `GeneratorArrowLifter` appends a `function* __genArrow_N` declaration at the body END and `NestedFunctionLifter` lambda-lifts it, substituting a hoisted forwarding arrow. The hoist was previously declined for *any* generator encloser, so `const g = __genArrow_N` read an undefined binding. Now a new `enclosingIsGeneratorClassMethod` flag (true only for class generator methods — sync/async, static/instance) gates it: `hoist = _hoistedForwards.Contains(f) && !enclosingIsGeneratorClassMethod`. The hoisted forwarding arrow is marked `IsLiftedForwarder`.
- **P2 — DC inclusion** (`ILCompiler.Generators`): the forwarding arrow only *reads* the captured local, but the #674 generator function display class held only *mutated* captures — so a hoisted read-only capture would be a stale by-value snapshot taken above the captured local's assignment. `ComputeMutatedCapturedGeneratorVars` now also unions in the read-only captures of marked forwarders (new `CollectLiftedForwarderCapturedReads`), routing them through the DC so the hoisted arrow reads them **live**. All downstream field/load/store/threading infrastructure already exists for #674; the async-generator path shares the same compute method, so no emitter changes were needed.
- **Mark** (`AST.cs`): added a non-positional `IsLiftedForwarder` init member to `Expr.ArrowFunction` (defaults false; only set on the compile path, so the interpreter is unaffected).

Class generator-method enclosers (no function DC wired for read-only captures) continue to fail cleanly with "Yield not supported in this context" — never a silent stale-value miscompile.

## Tests

`GeneratorTests.cs` (new #945 region) and `AsyncGeneratorTests.cs` (converted the two #924 pins to all-modes success + added a method-decline guard):

- **Success (both modes):** sync `function*` encloser, async `function*` via `for await`, capture-by-reference (write-capture + forwarder read share one DC field → `[31]`), multiple forwarders, encloser generator nested in a plain function.
- **Clean decline:** instance generator method, static generator method, named self-recursive generator expression (compiled clean error or correct value, never wrong).

## Verification

- 16 new/converted #945 tests pass.
- Full suite: **14312 passed, 0 failed**.
- TypeScript conformance: **zero drift**.
- Test262: the CLR crash + `Number/prototype/toString` baseline drift are pre-existing **#882** — reproduced identically on a clean tree (changes stashed).

Refs #924, #534, #674.
