### PR TITLE
fix(compile): deopt numeric $Array in flat/flatMap (#918 completeness)

### DIFF
--- a/Compilation/RuntimeEmitter.Arrays.Mutators.cs
+++ b/Compilation/RuntimeEmitter.Arrays.Mutators.cs
@@ -682,6 +682,13 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.ListOfObject, "get_Item", _types.Int32));
         il.Emit(OpCodes.Stloc, itemLocal);
 
+        // number[] unboxing deopt: a numeric-mode $Array element masquerades as an EMPTY base
+        // List<object?> (it inherits List<object?> but its elements live unboxed in _numStore), so
+        // the `isinst List<object>` recursion below would flatten nothing. Materialize it first so its
+        // elements are visible. Self-guarded — a no-op for boxed/scalar items. (#918 deopt-completeness
+        // gap; exposed broadly once #927 keeps loop-built number[] numeric instead of deopting it.)
+        EmitDeoptIfNumericArray(il, runtime, () => il.Emit(OpCodes.Ldloc, itemLocal));
+
         // ECMA-262 23.1.3.12 FlattenIntoArray: skip holes (only kPresent
         // slots are flattened). Without this the hole sentinel would be
         // Add()'d directly into the result list.
@@ -817,6 +824,12 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloc, argsLocal); // args - second arg
         il.Emit(OpCodes.Call, runtime.InvokeValue);
         il.Emit(OpCodes.Stloc, callResultLocal);
+
+        // number[] unboxing deopt: a numeric-mode $Array callback result is an EMPTY base list
+        // (its elements live unboxed in _numStore), so the single-level flatten below would add
+        // nothing. Materialize it so its elements are visible. Self-guarded — a no-op for boxed/scalar
+        // results. (#918 deopt-completeness gap, same shape as ArrayFlatHelper above.)
+        EmitDeoptIfNumericArray(il, runtime, () => il.Emit(OpCodes.Ldloc, callResultLocal));
 
         // if (callResult is List<object> nestedList)
         var addDirectly = il.DefineLabel();


### PR DESCRIPTION
## What & why

`flat()` and `flatMap()` returned `[]` when a nested element / callback result was an unboxed numeric `$Array` (the `number[]` elements-kind from #918).

Both helpers test `item is List<object> nestedList` to decide whether to flatten. A numeric-mode `$Array` inherits `List<object?>` but keeps its elements in `_numStore` with an **empty** base list — so the `isinst` matched yet flattening produced nothing.

```ts
function nn(): number[] { const a: number[] = []; a[0] = 0.5; a[1] = 1.5; return a; }
[nn(), nn()].flat()            // compiled: []   node: [0.5,1.5,0.5,1.5]
[1,2].flatMap(() => nn())      // compiled: []   node: [0.5,1.5,0.5,1.5]
```

This is pre-existing on `main` for any numeric `number[]` (one built by index assignment). It is the same class of deopt-completeness gap #918 documented (its reviewer note: *"the differential repro battery vs Node is the real oracle, not the suite"* — no test serializes a still-numeric array, so the suite is green even when this is broken).

## Fix

Deopt the element (`ArrayFlatHelper`) / callback result (`ArrayFlatMap`) via the existing `EmitDeoptIfNumericArray` helper **before** the `isinst List<object>`, materializing `_numStore` into the base list first. Self-guarded — a no-op for boxed/scalar values. Same shape as the ~17 deopt sites #918 already installed (`ToJsString`/JSON/`Object.*`/spread/`Set`/`Map`/`structuredClone`/…). One file, 13 lines.

## Verification

- Byte-identical to Node across `flat` (incl. `flat(2)` and mixed `[arr, scalar, [arr]]` nesting, exercising the recursive deopt) and `flatMap`.
- Full xUnit suite **14315 / 0** (run alone).

## Why land first

The escaping-`number[]` hoist (#927 step 1) keeps loop-built `number[]` numeric instead of deopting it to boxed, which broadens exposure of this gap. Landing this first keeps that change regression-free; #927 step 1 stacks on top of this branch.

## Scope note

A `[...new Map(entryPairs)]`, `Math.max(...arr)`, and `[0].concat(...[arr])` divergence surfaced during the differential sweep, but each fails for **boxed** arrays too — they are separate, general pre-existing bugs (not numeric-array deopt gaps), filed separately and out of scope here.