### PR TITLE
perf(compile): hoist `as $Array` for escaping number[] (#927 step 1) — re-land

### DIFF
--- a/Compilation/Emitters/ArrayEmitter.cs
+++ b/Compilation/Emitters/ArrayEmitter.cs
@@ -454,36 +454,54 @@ public sealed class ArrayEmitter : ITypeEmitterStrategy
             if (hoisted.HasValue)
             {
                 var h = hoisted.Value;
-                var listType = h.Descriptor.GetListType(ctx.Types);
                 var fallbackLabel = il.DefineLabel();
                 var endLabel = il.DefineLabel();
 
                 il.Emit(OpCodes.Ldloc, h.TypedLocal);
                 il.Emit(OpCodes.Brfalse, fallbackLabel);
 
-                // $Arguments check: use _length, not Count, per ECMA-262 sloppy
-                // arguments. Only emits the runtime check when ArgumentsType is
-                // wired (production: always; tests may skip).
-                if (ctx.Runtime?.ArgumentsType != null && ctx.Runtime?.ArgumentsLengthField != null)
+                if (h.Descriptor.Kind == ArrayElementsKind.Double)
                 {
-                    var notArgsLengthLabel = il.DefineLabel();
+                    // Hoisted numeric $Array (#927 step 1): the typed local is a $Array (the preamble
+                    // hoists `isinst $Array`, not `isinst List<double>`), so read its authoritative length
+                    // via the $Array length getter — numeric-aware, maintained by SetDouble/PushDouble.
+                    // Calling List<float64>::Count here would read the EMPTY base list of a numeric $Array
+                    // and report 0, so a loop-condition `i < arr.length` never runs. A $Array is never the
+                    // arguments object, so no $Arguments check is needed on this arm.
                     il.Emit(OpCodes.Ldloc, h.TypedLocal);
-                    il.Emit(OpCodes.Isinst, ctx.Runtime!.ArgumentsType);
-                    il.Emit(OpCodes.Brfalse, notArgsLengthLabel);
-                    il.Emit(OpCodes.Ldloc, h.TypedLocal);
-                    il.Emit(OpCodes.Castclass, ctx.Runtime!.ArgumentsType);
-                    il.Emit(OpCodes.Ldfld, ctx.Runtime!.ArgumentsLengthField);
+                    il.Emit(OpCodes.Callvirt, ctx.Runtime!.TSArrayLongLengthGetter);
                     il.Emit(OpCodes.Conv_R8);
                     il.Emit(OpCodes.Box, ctx.Types.Double);
                     il.Emit(OpCodes.Br, endLabel);
-                    il.MarkLabel(notArgsLengthLabel);
                 }
+                else
+                {
+                    var listType = h.Descriptor.GetListType(ctx.Types);
 
-                il.Emit(OpCodes.Ldloc, h.TypedLocal);
-                il.Emit(OpCodes.Callvirt, ctx.Types.GetProperty(listType, "Count").GetGetMethod()!);
-                il.Emit(OpCodes.Conv_R8);
-                il.Emit(OpCodes.Box, ctx.Types.Double);
-                il.Emit(OpCodes.Br, endLabel);
+                    // $Arguments check: use _length, not Count, per ECMA-262 sloppy
+                    // arguments. Only emits the runtime check when ArgumentsType is
+                    // wired (production: always; tests may skip).
+                    if (ctx.Runtime?.ArgumentsType != null && ctx.Runtime?.ArgumentsLengthField != null)
+                    {
+                        var notArgsLengthLabel = il.DefineLabel();
+                        il.Emit(OpCodes.Ldloc, h.TypedLocal);
+                        il.Emit(OpCodes.Isinst, ctx.Runtime!.ArgumentsType);
+                        il.Emit(OpCodes.Brfalse, notArgsLengthLabel);
+                        il.Emit(OpCodes.Ldloc, h.TypedLocal);
+                        il.Emit(OpCodes.Castclass, ctx.Runtime!.ArgumentsType);
+                        il.Emit(OpCodes.Ldfld, ctx.Runtime!.ArgumentsLengthField);
+                        il.Emit(OpCodes.Conv_R8);
+                        il.Emit(OpCodes.Box, ctx.Types.Double);
+                        il.Emit(OpCodes.Br, endLabel);
+                        il.MarkLabel(notArgsLengthLabel);
+                    }
+
+                    il.Emit(OpCodes.Ldloc, h.TypedLocal);
+                    il.Emit(OpCodes.Callvirt, ctx.Types.GetProperty(listType, "Count").GetGetMethod()!);
+                    il.Emit(OpCodes.Conv_R8);
+                    il.Emit(OpCodes.Box, ctx.Types.Double);
+                    il.Emit(OpCodes.Br, endLabel);
+                }
 
                 il.MarkLabel(fallbackLabel);
                 emitter.EmitExpression(receiver);

--- a/Compilation/ILEmitter.Properties.cs
+++ b/Compilation/ILEmitter.Properties.cs
@@ -905,27 +905,49 @@ public partial class ILEmitter
                 if (hoisted.HasValue)
                 {
                     var h = hoisted.Value;
-                    var listType = h.Descriptor.GetListType(_ctx.Types);
                     var fallbackLabel = IL.DefineLabel();
                     var endLabel = IL.DefineLabel();
 
-                    IL.Emit(OpCodes.Ldloc, h.TypedLocal);
-                    IL.Emit(OpCodes.Brfalse, fallbackLabel);
+                    if (h.Descriptor.Kind == ArrayElementsKind.Double)
+                    {
+                        // Hoisted numeric $Array (escaping number[], #927 step 1): the loop-invariant
+                        // `isinst $Array` lives in the preamble, so per-access we only null-check the typed
+                        // local and call the numeric-aware Get(long) — it reads the unboxed double[] store
+                        // and returns a boxed double, with NO deopt (so the array stays numeric across
+                        // reads, keeping interleaved read/write on the fast path). The read-site unbox
+                        // (GetDouble) is deliberately NOT used here: it needs the type checker to resolve
+                        // arr[i] to number, else the raw double mis-feeds the generic Add path (#918).
+                        IL.Emit(OpCodes.Ldloc, h.TypedLocal);
+                        IL.Emit(OpCodes.Brfalse, fallbackLabel);
 
-                    // Fast path: typed local is valid
-                    IL.Emit(OpCodes.Ldloc, h.TypedLocal);
-                    EmitExpressionAsDouble(gi.Index);
-                    IL.Emit(OpCodes.Conv_I4);
-                    IL.Emit(OpCodes.Callvirt, _ctx.Types.GetMethod(listType, "get_Item", _ctx.Types.Int32));
-                    // Box the unboxed element so this branch converges on `object` with the
-                    // $Array / List<object?> / fallback paths at endLabel. The typed List<T>
-                    // fast path otherwise leaves a native double/bool where the merge point — and
-                    // every consumer, which reads the clobbered StackType=Unknown — expects an
-                    // object ref. That ran only because the typed branch is dead for $Array-backed
-                    // values, but is unverifiable IL (#751).
-                    h.Descriptor.EmitBoxElement(IL, _ctx.Types);
-                    SetStackUnknown();
-                    IL.Emit(OpCodes.Br, endLabel);
+                        IL.Emit(OpCodes.Ldloc, h.TypedLocal);
+                        EmitExpressionAsDouble(gi.Index);
+                        IL.Emit(OpCodes.Conv_I8);
+                        IL.Emit(OpCodes.Callvirt, _ctx.Runtime!.TSArrayGetLong);
+                        SetStackUnknown();
+                        IL.Emit(OpCodes.Br, endLabel);
+                    }
+                    else
+                    {
+                        var listType = h.Descriptor.GetListType(_ctx.Types);
+                        IL.Emit(OpCodes.Ldloc, h.TypedLocal);
+                        IL.Emit(OpCodes.Brfalse, fallbackLabel);
+
+                        // Fast path: typed local is valid
+                        IL.Emit(OpCodes.Ldloc, h.TypedLocal);
+                        EmitExpressionAsDouble(gi.Index);
+                        IL.Emit(OpCodes.Conv_I4);
+                        IL.Emit(OpCodes.Callvirt, _ctx.Types.GetMethod(listType, "get_Item", _ctx.Types.Int32));
+                        // Box the unboxed element so this branch converges on `object` with the
+                        // $Array / List<object?> / fallback paths at endLabel. The typed List<T>
+                        // fast path otherwise leaves a native double/bool where the merge point — and
+                        // every consumer, which reads the clobbered StackType=Unknown — expects an
+                        // object ref. That ran only because the typed branch is dead for $Array-backed
+                        // values, but is unverifiable IL (#751).
+                        h.Descriptor.EmitBoxElement(IL, _ctx.Types);
+                        SetStackUnknown();
+                        IL.Emit(OpCodes.Br, endLabel);
+                    }
 
                     // Fallback: type didn't match at loop entry
                     IL.MarkLabel(fallbackLabel);
@@ -1140,7 +1162,13 @@ public partial class ILEmitter
                 EmitExpressionAsDouble(si.Index);
                 IL.Emit(OpCodes.Conv_I4);
                 IL.Emit(OpCodes.Ldloc, typedValueLocal);
-                IL.Emit(OpCodes.Call, h.Descriptor.GetSetArrayElementMethod(_ctx.Runtime!));
+                if (h.Descriptor.Kind == ArrayElementsKind.Double)
+                    // Hoisted numeric $Array (#927 step 1): SetDouble stores the unboxed double straight
+                    // into the double[] store (mode-checked — a boxed $Array delegates to the boxed setter,
+                    // so this is behaviour-identical for both modes). h.TypedLocal is the hoisted $Array.
+                    IL.Emit(OpCodes.Callvirt, _ctx.Runtime!.TSArraySetDouble);
+                else
+                    IL.Emit(OpCodes.Call, h.Descriptor.GetSetArrayElementMethod(_ctx.Runtime!));
                 IL.Emit(OpCodes.Ldloc, typedValueLocal);
                 // Box the assigned value so this branch leaves `object` like the fallback path at
                 // endLabel (the assignment result is consumed via StackType=Unknown), #751.

--- a/Compilation/ILEmitter.Statements.cs
+++ b/Compilation/ILEmitter.Statements.cs
@@ -768,17 +768,26 @@ public partial class ILEmitter
 
         foreach (var (varName, desc) in candidates)
         {
-            var listType = desc.GetListType(_ctx.Types);
-            var typedLocal = IL.DeclareLocal(listType);
+            // Double-kind candidates that reach the hoist are escaping number[] whose runtime value is a
+            // $Array (numeric or boxed) — never a bare List<double> (promoted List<double> locals were
+            // filtered out above). Hoist the $Array cast so the loop-body index get/set route through the
+            // mode-checked Get(long)/SetDouble fast paths (straight into the unboxed double[] store)
+            // instead of isinst-ing List<double> → null → boxed SetIndex per write, which deopts the array
+            // to boxed and reintroduces the per-element boxing this project removed (#927 step 1). Bool/
+            // Object kinds keep their List<T> hoist ($Array : List<object?> covers Object directly).
+            var hoistType = desc.Kind == ArrayElementsKind.Double
+                ? _ctx.Runtime!.TSArrayType
+                : desc.GetListType(_ctx.Types);
+            var typedLocal = IL.DeclareLocal(hoistType);
 
-            // Load array variable, isinst to typed list, store in local
+            // Load array variable, isinst to the hoist type, store in local
             // If the variable holds a different type, typedLocal will be null
             // Use the local directly to avoid stack type tracking complications
             var arrLocal = _ctx.Locals.GetLocal(varName);
             if (arrLocal == null) continue; // Variable not found in locals — skip
             IL.Emit(OpCodes.Ldloc, arrLocal);
             // Array locals are always typed as object — no boxing needed
-            IL.Emit(OpCodes.Isinst, listType);
+            IL.Emit(OpCodes.Isinst, hoistType);
             IL.Emit(OpCodes.Stloc, typedLocal);
 
             cache[varName] = new HoistedArrayEntry(typedLocal, desc);


### PR DESCRIPTION
Re-lands **#927 step 1** on `main`. The original PR #950 was stacked on #949's branch and merged into that (already-merged) branch instead of `main`, so the hoist change never reached `main` — only the deopt fix (#949) did. This is the identical step-1 commit, cherry-picked cleanly onto current `main` (3 files; no overlap with the generator fix #948 that landed meanwhile).

## What it does (unchanged from #950)

Teaches the loop array-hoist to handle the unboxed numeric `$Array` (escaping `number[]`, #918). The preamble hoists `isinst $Array`, and the three hoist consumers route through the mode-checked fast paths: **GET** → `Get(long)`, **SET** → `SetDouble`, **LENGTH** → `$Array` length getter (not `List<float64>::Count`, which reads a numeric array's empty base list → 0).

Eliminates the per-write `isinst` that previously forced hoisted-loop index access onto the generic boxed `SetIndex` (which deopted the whole array to boxed). Escaping `number[]` index-write loop: **~3700 ms → ~310 ms (~12×)**, now ~1.2× of the `List<double>` local path.

## Verification

- Re-verified on current `main`: escape repro correct, `flat`/`flatMap` correct (deopt already in `main`), benchmark cliff gone.
- Full suite green (step 1 was 14315/0 combined with the deopt fix; re-running on current `main` — will confirm in a comment).

Closes the gap left by #950. Part of #927 (step 2 = `SetDouble` append tuning, step 3 = delete `List<double>` Double arm, still to come).