### PR TITLE
fix: expand spread args to Math.max/min/hypot (#951)

### DIFF
--- a/Compilation/Emitters/IEmitterContext.cs
+++ b/Compilation/Emitters/IEmitterContext.cs
@@ -68,6 +68,14 @@ public interface IEmitterContext
     void EmitFetchCall(List<Expr> arguments);
 
     /// <summary>
+    /// Evaluates <paramref name="args"/> and leaves a single <c>object[]</c> on the IL stack with
+    /// any <see cref="Expr.Spread"/> arguments flattened in place (numeric <c>$Array</c> + arbitrary
+    /// iterables). Use when a type-emitter strategy needs the full, spread-expanded argument list as
+    /// a runtime array — e.g. the variadic <c>Math.max/min/hypot</c> adapters (#951).
+    /// </summary>
+    void EmitArgsArrayWithSpread(IReadOnlyList<Expr> args);
+
+    /// <summary>
     /// Emits conversion from the current stack value to the target parameter type.
     /// Handles boxing for object, unboxing for value types, union types, and pass-through.
     /// </summary>

--- a/Compilation/Emitters/MathStaticEmitter.cs
+++ b/Compilation/Emitters/MathStaticEmitter.cs
@@ -28,6 +28,20 @@ public sealed class MathStaticEmitter : IStaticTypeEmitterStrategy
         // Handle variadic min/max (JavaScript allows any number of arguments)
         if (methodName is "min" or "max")
         {
+            // Spread args (\`Math.max(...arr)\`) have a runtime-unknown count, so the
+            // inline per-arg loop below can't expand them. Route to the variadic
+            // \`object[]\`-taking adapter, feeding a spread-expanded args array — the
+            // adapter applies ToNumber per element with the same empty→∓∞ / NaN
+            // short-circuit semantics as the inline path (#951).
+            if (arguments.Any(a => a is Expr.Spread))
+            {
+                emitter.EmitArgsArrayWithSpread(arguments);
+                il.Emit(OpCodes.Call, methodName == "min"
+                    ? ctx.Runtime!.MathMinAdapter
+                    : ctx.Runtime!.MathMaxAdapter);
+                return true;
+            }
+
             var minMaxMethod = methodName == "min"
                 ? ctx.Types.GetMethod(ctx.Types.Math, "Min", ctx.Types.Double, ctx.Types.Double)
                 : ctx.Types.GetMethod(ctx.Types.Math, "Max", ctx.Types.Double, ctx.Types.Double);
@@ -65,6 +79,19 @@ public sealed class MathStaticEmitter : IStaticTypeEmitterStrategy
             emitter.EmitExpression(arguments[0]);
             emitter.EnsureBoxed();
             il.Emit(OpCodes.Call, ctx.Runtime!.MathSumPrecise);
+            return true;
+        }
+
+        // Variadic hypot with spread args (\`Math.hypot(...arr)\`) has a runtime-
+        // unknown count, so the inline local-stash path below can't expand it.
+        // Route to the \`object[]\`-taking adapter with a spread-expanded args
+        // array (it applies ToNumber + the Infinity-first / NaN-propagating
+        // sqrt(Σx²)). Must run BEFORE the general ToNumber loop, which would
+        // otherwise emit ToNumber(array) → NaN for the spread element (#951).
+        if (methodName == "hypot" && arguments.Any(a => a is Expr.Spread))
+        {
+            emitter.EmitArgsArrayWithSpread(arguments);
+            il.Emit(OpCodes.Call, ctx.Runtime!.MathHypotAdapter);
             return true;
         }
 

--- a/Compilation/ExpressionEmitterBase.CallHelpers.cs
+++ b/Compilation/ExpressionEmitterBase.CallHelpers.cs
@@ -933,6 +933,70 @@ public abstract partial class ExpressionEmitterBase
     }
 
     /// <summary>
+    /// Evaluates <paramref name="args"/> and leaves a single <c>object[]</c> on the IL stack with
+    /// any <see cref="Expr.Spread"/> arguments flattened in place (via the emitted-runtime
+    /// <c>ExpandCallArgs</c>, which understands numeric <c>$Array</c> + arbitrary iterables). Each
+    /// argument is evaluated and boxed into a temp local <em>before</em> any array is built, so an
+    /// <c>await</c>/<c>yield</c> in a later argument never strands a partly-built array on the stack
+    /// (#413). Shared by <see cref="EmitFunctionValueCall"/> and the variadic <c>Math.*</c> emitter
+    /// so <c>Math.max(...arr)</c> expands spreads identically to <c>f(...arr)</c> (#951).
+    /// </summary>
+    public void EmitArgsArrayWithSpread(IReadOnlyList<Expr> args)
+    {
+        // Evaluate all arguments into temps first (await-safe for async emitters)
+        List<LocalBuilder> argTemps = [];
+        List<bool> isSpread = [];
+        foreach (var arg in args)
+        {
+            if (arg is Expr.Spread spread)
+            {
+                EmitExpression(spread.Expression);
+                EnsureBoxed();
+                isSpread.Add(true);
+            }
+            else
+            {
+                EmitExpression(arg);
+                EnsureBoxed();
+                isSpread.Add(false);
+            }
+            var temp = IL.DeclareLocal(Types.Object);
+            IL.Emit(OpCodes.Stloc, temp);
+            argTemps.Add(temp);
+        }
+
+        // Build args array from temps (both paths leave object[] on the stack).
+        IL.Emit(OpCodes.Ldc_I4, argTemps.Count);
+        IL.Emit(OpCodes.Newarr, Types.Object);
+        for (int i = 0; i < argTemps.Count; i++)
+        {
+            IL.Emit(OpCodes.Dup);
+            IL.Emit(OpCodes.Ldc_I4, i);
+            IL.Emit(OpCodes.Ldloc, argTemps[i]);
+            IL.Emit(OpCodes.Stelem_Ref);
+        }
+
+        if (!isSpread.Any(s => s))
+            return;
+
+        // Spread case: build the isSpread bool array and flatten via ExpandCallArgs.
+        IL.Emit(OpCodes.Ldc_I4, argTemps.Count);
+        IL.Emit(OpCodes.Newarr, Types.Boolean);
+        for (int i = 0; i < argTemps.Count; i++)
+        {
+            if (isSpread[i])
+            {
+                IL.Emit(OpCodes.Dup);
+                IL.Emit(OpCodes.Ldc_I4, i);
+                IL.Emit(OpCodes.Ldc_I4_1);
+                IL.Emit(OpCodes.Stelem_I1);
+            }
+        }
+
+        EmitExpandCallArgs();
+    }
+
+    /// <summary>
     /// Tries to handle an Expr.Get callee via shared dispatch patterns:
     /// module.promises, class statics, Promise.then/catch/finally, type-first dispatch,
     /// fallback string/array methods, ambiguous methods.
@@ -1209,73 +1273,8 @@ public abstract partial class ExpressionEmitterBase
             IL.Emit(OpCodes.Brtrue, optChainNullishLabel.Value);
         }
 
-        // Evaluate all arguments into temps first (await-safe for async emitters)
-        List<LocalBuilder> argTemps = [];
-        List<bool> isSpread = [];
-        foreach (var arg in c.Arguments)
-        {
-            if (arg is Expr.Spread spread)
-            {
-                EmitExpression(spread.Expression);
-                EnsureBoxed();
-                isSpread.Add(true);
-            }
-            else
-            {
-                EmitExpression(arg);
-                EnsureBoxed();
-                isSpread.Add(false);
-            }
-            var temp = IL.DeclareLocal(Types.Object);
-            IL.Emit(OpCodes.Stloc, temp);
-            argTemps.Add(temp);
-        }
-
-        bool hasSpreads = isSpread.Any(s => s);
-
-        if (!hasSpreads)
-        {
-            // Simple case: build args array from temps
-            IL.Emit(OpCodes.Ldc_I4, argTemps.Count);
-            IL.Emit(OpCodes.Newarr, Types.Object);
-            for (int i = 0; i < argTemps.Count; i++)
-            {
-                IL.Emit(OpCodes.Dup);
-                IL.Emit(OpCodes.Ldc_I4, i);
-                IL.Emit(OpCodes.Ldloc, argTemps[i]);
-                IL.Emit(OpCodes.Stelem_Ref);
-            }
-        }
-        else
-        {
-            // Spread case: build args array from temps
-            IL.Emit(OpCodes.Ldc_I4, argTemps.Count);
-            IL.Emit(OpCodes.Newarr, Types.Object);
-            for (int i = 0; i < argTemps.Count; i++)
-            {
-                IL.Emit(OpCodes.Dup);
-                IL.Emit(OpCodes.Ldc_I4, i);
-                IL.Emit(OpCodes.Ldloc, argTemps[i]);
-                IL.Emit(OpCodes.Stelem_Ref);
-            }
-
-            // Build isSpread bool array
-            IL.Emit(OpCodes.Ldc_I4, argTemps.Count);
-            IL.Emit(OpCodes.Newarr, Types.Boolean);
-            for (int i = 0; i < argTemps.Count; i++)
-            {
-                if (isSpread[i])
-                {
-                    IL.Emit(OpCodes.Dup);
-                    IL.Emit(OpCodes.Ldc_I4, i);
-                    IL.Emit(OpCodes.Ldc_I4_1);
-                    IL.Emit(OpCodes.Stelem_I1);
-                }
-            }
-
-            // ExpandCallArgs
-            EmitExpandCallArgs();
-        }
+        // Evaluate the arguments and leave a (spread-expanded) object[] on the stack.
+        EmitArgsArrayWithSpread(c.Arguments);
 
         // Call InvokeMethodValue(receiver, function, args). The receiver is the spilled `o` for a
         // threaded `o.m()` (#923, above), else null for a detached call.

--- a/Compilation/RuntimeEmitter.MathAdapters.cs
+++ b/Compilation/RuntimeEmitter.MathAdapters.cs
@@ -188,6 +188,38 @@ public partial class RuntimeEmitter
         var iLocal = il.DeclareLocal(_types.Int32);
         var argLocal = il.DeclareLocal(_types.Double);
 
+        // ECMA-262 21.3.2.16: the Infinity check fires BEFORE NaN, so
+        // Math.hypot(NaN, Infinity) === Infinity (not NaN). First pass: if any
+        // ToNumber(arg) is ±Infinity, return +Infinity. Mirrors the inline
+        // MathStaticEmitter hypot path so value-form / spread hypot agree (#951).
+        var infLoopStart = il.DefineLabel();
+        var infLoopEnd = il.DefineLabel();
+        var notInfArg = il.DefineLabel();
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Stloc, iLocal);
+        il.MarkLabel(infLoopStart);
+        il.Emit(OpCodes.Ldloc, iLocal);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldlen);
+        il.Emit(OpCodes.Conv_I4);
+        il.Emit(OpCodes.Bge, infLoopEnd);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldloc, iLocal);
+        il.Emit(OpCodes.Ldelem_Ref);
+        il.Emit(OpCodes.Call, runtime.ToNumber);
+        il.Emit(OpCodes.Call, _types.GetMethod(_types.Double, "IsInfinity", _types.Double));
+        il.Emit(OpCodes.Brfalse, notInfArg);
+        il.Emit(OpCodes.Ldc_R8, double.PositiveInfinity);
+        il.Emit(OpCodes.Box, _types.Double);
+        il.Emit(OpCodes.Ret);
+        il.MarkLabel(notInfArg);
+        il.Emit(OpCodes.Ldloc, iLocal);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Stloc, iLocal);
+        il.Emit(OpCodes.Br, infLoopStart);
+        il.MarkLabel(infLoopEnd);
+
         // sum = 0; i = 0
         il.Emit(OpCodes.Ldc_R8, 0.0);
         il.Emit(OpCodes.Stloc, sumLocal);

--- a/Execution/Interpreter.Calls.cs
+++ b/Execution/Interpreter.Calls.cs
@@ -7,6 +7,7 @@ using SharpTS.Runtime.Types;
 using SharpTS.TypeSystem;
 using System.Buffers;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 namespace SharpTS.Execution;
 
@@ -24,6 +25,54 @@ public partial class Interpreter
         ISharpTSCallable method,
         IReadOnlyList<Expr> arguments)
     {
+        // Spread args have a runtime-unknown count; expand them into a flat list
+        // before dispatch so they don't leak through as a single Object-kind arg
+        // (matches the sync CallBuiltInSync path, #951). A span can't cross an
+        // await, so all arguments are evaluated into the list first.
+        if (HasSpreadArgs(arguments))
+        {
+            if (method is BuiltInMethod bmSpread && bmSpread.HasV2Implementation)
+            {
+                var expanded = new List<RuntimeValue>(arguments.Count);
+                foreach (var arg in arguments)
+                {
+                    if (arg is Expr.Spread spread)
+                    {
+                        var spreadValue = (await ctx.EvaluateExprAsync(spread.Expression)).ToObject();
+                        foreach (var el in GetIterableElements(spreadValue))
+                            expanded.Add(RuntimeValue.FromBoxed(el));
+                    }
+                    else
+                    {
+                        expanded.Add(await ctx.EvaluateExprAsync(arg));
+                    }
+                }
+                return bmSpread.CallV2(this, CollectionsMarshal.AsSpan(expanded)).ToObject();
+            }
+
+            var spreadList = ArgumentListPool.Rent();
+            try
+            {
+                foreach (var arg in arguments)
+                {
+                    if (arg is Expr.Spread spread)
+                    {
+                        var spreadValue = (await ctx.EvaluateExprAsync(spread.Expression)).ToObject();
+                        spreadList.AddRange(GetIterableElements(spreadValue));
+                    }
+                    else
+                    {
+                        spreadList.Add((await ctx.EvaluateExprAsync(arg)).ToObject());
+                    }
+                }
+                return method.Call(this, spreadList);
+            }
+            finally
+            {
+                ArgumentListPool.Return(spreadList);
+            }
+        }
+
         // V2 fast path: use RuntimeValue span instead of List<object?>
         if (method is BuiltInMethod bm && bm.HasV2Implementation)
         {
@@ -226,6 +275,49 @@ public partial class Interpreter
     /// </summary>
     private RuntimeValue CallBuiltInSync(ISharpTSCallable method, IReadOnlyList<Expr> arguments)
     {
+        // Spread args (\`Math.max(...arr)\`) have a runtime-unknown count, so the
+        // ArrayPool-by-arity fast path can't hold them. Expand into a flat list
+        // (the same GetIterableElements expansion the user-function boxed path
+        // uses) before dispatching — otherwise the spread array leaks through as
+        // a single Object-kind arg and Math.max's AsNumber() throws (#951).
+        if (HasSpreadArgs(arguments))
+        {
+            if (method is BuiltInMethod bmSpread && bmSpread.HasV2Implementation)
+            {
+                var expanded = new List<RuntimeValue>(arguments.Count);
+                foreach (var arg in arguments)
+                {
+                    if (arg is Expr.Spread spread)
+                    {
+                        foreach (var el in GetIterableElements(Evaluate(spread.Expression)))
+                            expanded.Add(RuntimeValue.FromBoxed(el));
+                    }
+                    else
+                    {
+                        expanded.Add(EvaluateRV(arg));
+                    }
+                }
+                return bmSpread.CallV2(this, CollectionsMarshal.AsSpan(expanded));
+            }
+
+            var spreadList = ArgumentListPool.Rent();
+            try
+            {
+                foreach (var arg in arguments)
+                {
+                    if (arg is Expr.Spread spread)
+                        spreadList.AddRange(GetIterableElements(Evaluate(spread.Expression)));
+                    else
+                        spreadList.Add(Evaluate(arg));
+                }
+                return RuntimeValue.FromBoxed(method.Call(this, spreadList));
+            }
+            finally
+            {
+                ArgumentListPool.Return(spreadList);
+            }
+        }
+
         // V2 fast path — no boxing at all
         if (method is BuiltInMethod bm && bm.HasV2Implementation)
         {

--- a/Runtime/BuiltIns/MathBuiltIns.cs
+++ b/Runtime/BuiltIns/MathBuiltIns.cs
@@ -72,6 +72,10 @@ public static class MathBuiltIns
         for (int i = 0; i < args.Length; i++)
         {
             double val = args[i].AsNumber();
+            // ECMA-262 21.3.2.25: any NaN argument makes the result NaN (a plain
+            // `val < min` comparison would silently skip NaN and return a finite
+            // value instead).
+            if (double.IsNaN(val)) return RuntimeValue.FromNumber(double.NaN);
             if (val < min) min = val;
         }
         return RuntimeValue.FromNumber(min);
@@ -85,6 +89,8 @@ public static class MathBuiltIns
         for (int i = 0; i < args.Length; i++)
         {
             double val = args[i].AsNumber();
+            // ECMA-262 21.3.2.24: any NaN argument makes the result NaN.
+            if (double.IsNaN(val)) return RuntimeValue.FromNumber(double.NaN);
             if (val > max) max = val;
         }
         return RuntimeValue.FromNumber(max);
@@ -92,7 +98,16 @@ public static class MathBuiltIns
 
     private static RuntimeValue Hypot(Interpreter _, RuntimeValue receiver, ReadOnlySpan<RuntimeValue> args)
     {
-        // sqrt(sum of squares); IEEE handles the Infinity/NaN special cases.
+        // ECMA-262 21.3.2.16: the Infinity check fires BEFORE NaN, so
+        // Math.hypot(NaN, Infinity) === Infinity (not NaN). The naive
+        // sqrt(Σx²) below would propagate the NaN instead.
+        for (int i = 0; i < args.Length; i++)
+        {
+            if (double.IsInfinity(args[i].AsNumber()))
+                return RuntimeValue.FromNumber(double.PositiveInfinity);
+        }
+
+        // sqrt(sum of squares); any remaining NaN propagates through Sqrt.
         double sum = 0;
         for (int i = 0; i < args.Length; i++)
         {

--- a/SharpTS.Tests/SharedTests/MathSpreadArgumentTests.cs
+++ b/SharpTS.Tests/SharedTests/MathSpreadArgumentTests.cs
@@ -1,0 +1,107 @@
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests;
+
+/// <summary>
+/// Regression for #951: in compiled mode the variadic <c>Math.max</c>,
+/// <c>Math.min</c>, and <c>Math.hypot</c> emitters iterated their arguments and
+/// emitted each via <c>EmitExpression</c>, but a spread argument (<c>...arr</c>)
+/// is an <c>Expr.Spread</c> whose emit just produces the inner array — so
+/// <c>Math.max(...arr)</c> fed the array object to <c>ToNumber</c> and returned
+/// <c>NaN</c>. The fix routes spread calls through the variadic <c>object[]</c>
+/// adapters with a spread-expanded argument array (the same expansion the
+/// generic <c>f(...arr)</c> call site uses).
+/// </summary>
+public class MathSpreadArgumentTests
+{
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Math_Max_Min_Hypot_BasicSpread(ExecutionMode mode)
+    {
+        var source = @"
+            console.log(Math.max(...[1, 2, 3]));
+            console.log(Math.min(...[1, 2, 3]));
+            console.log(Math.hypot(...[3, 4]));
+        ";
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("3\n1\n5\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Math_Spread_MixedWithRegularArgs(ExecutionMode mode)
+    {
+        var source = @"
+            console.log(Math.max(1, ...[5, 2], 4));
+            console.log(Math.hypot(...[3, 4], 12));
+            console.log(Math.min(...[3], ...[1, 9]));
+        ";
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("5\n13\n1\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Math_Spread_EmptyArray(ExecutionMode mode)
+    {
+        // Spreading an empty array yields the no-argument result: max → -Infinity,
+        // min → Infinity, hypot → 0.
+        var source = @"
+            console.log(Math.max(...[]));
+            console.log(Math.min(...[]));
+            console.log(Math.hypot(...[]));
+        ";
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("-Infinity\nInfinity\n0\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Math_Spread_BoxedAnyArray(ExecutionMode mode)
+    {
+        // A spread of an `any[]` (boxed-element representation) must expand the
+        // same as an inline numeric array literal.
+        var source = @"
+            const arr: any[] = [10, 20, 5];
+            console.log(Math.max(...arr));
+            console.log(Math.min(...arr));
+        ";
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("20\n5\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Math_Spread_NaNAndInfinitySemantics(ExecutionMode mode)
+    {
+        // max/min short-circuit to NaN on any NaN; hypot's Infinity check fires
+        // BEFORE its NaN check (ECMA-262 21.3.2.16), so a mix returns Infinity.
+        var source = @"
+            console.log(Math.max(...[1, NaN, 3]));
+            console.log(Math.min(...[1, NaN, 3]));
+            console.log(Math.hypot(...[NaN, Infinity]));
+        ";
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("NaN\nNaN\nInfinity\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Math_Spread_InsideAsyncFunction(ExecutionMode mode)
+    {
+        // Exercises the async built-in call path (CallBuiltInWithPooledArgs /
+        // the async MoveNext emitter): a spread whose element list is produced by
+        // an awaited value must still expand correctly.
+        var source = @"
+            async function f() {
+                const arr = [3, 1, 4, 1, 5];
+                console.log(Math.max(...arr));
+                console.log(Math.max(...[await Promise.resolve(10)], 2));
+            }
+            f();
+        ";
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("5\n10\n", output);
+    }
+}


### PR DESCRIPTION
Closes #951.

## Problem

In **compiled** mode, `Math.max(...arr)` / `Math.min(...arr)` / `Math.hypot(...arr)` returned `NaN`. The variadic Math emitters iterated `arguments` and emitted each via `EmitExpression`, but a spread argument `...arr` is an `Expr.Spread` whose emit just yields the inner **array object** — so `ToNumber(array)` → `NaN`.

While fixing it, differential-vs-Node testing showed the bug was **broader than the issue described** (the "compiled-only; interpreter unaffected" note was wrong): the interpreter also failed, and there were two adjacent `Math.*` spec bugs.

## Changes

**Compiled (the reported bug)**
- `MathStaticEmitter` — `min`/`max`/`hypot` detect spread args and route to the variadic `object[]` adapters with a spread-expanded argument array. The hypot guard runs *before* the general `ToNumber` loop so it doesn't corrupt the stack.
- `ExpressionEmitterBase.CallHelpers` — extracted the existing `f(...arr)` arg-array-with-spread logic into a reusable `EmitArgsArrayWithSpread` (exposed on `IEmitterContext`), keeping the working generic-call path as the single source of truth.
- `RuntimeEmitter.MathAdapters` — added the ECMA-262 21.3.2.16 Infinity-first check to the hypot adapter so value-form (`const h = Math.hypot`) and spread paths agree.

**Interpreter (also affected)**
- `Interpreter.Calls` — the built-in static call path (`CallBuiltInSync` + async `CallBuiltInWithPooledArgs`) never expanded spreads, leaking the array through as a single `Object`-kind arg so `AsNumber()` threw. Both now expand spreads into a flat arg list before dispatch.
- `MathBuiltIns` — pre-existing bugs surfaced by testing: `Math.max/min(1, NaN, 3)` returned `1`/`3` (now `NaN`); `Math.hypot(NaN, Infinity)` returned `NaN` (now `Infinity`).

**Tests**
- `MathSpreadArgumentTests` — basic / mixed / empty / boxed `any[]` / NaN-Infinity / async spreads, run in **both** interpreter and compiled modes (interpreter as the Node-matching oracle).

## Verification

- The issue repro + edge cases produce Node-identical output in both modes.
- Full suite: **14338 passing**. The only failures are the 2 in-sln `Test262` baseline tests (untracked local scaffolding with a stale baseline — fails identically on clean `main`) and one load-flaky unit test (differs each run, passes in isolation; the known .NET 10 tier-0 QuickJit issue).