### PR TITLE
fix(compile): map union collection-element types to object (#954)

### DIFF
--- a/Compilation/TypeMapper.cs
+++ b/Compilation/TypeMapper.cs
@@ -306,7 +306,20 @@ public class TypeMapper
     private Type MapCollectionElementStrict(TypeInfo element)
     {
         Type mapped = MapTypeInfoStrict(element);
-        return _types.IsVoid(mapped) ? _types.Object : mapped;
+        if (_types.IsVoid(mapped))
+            return _types.Object;
+        // A generated Union_* struct as a List/Dictionary/HashSet element makes the closed
+        // generic a TypeBuilderInstantiation. Most reflection members on such a type throw
+        // NotSupportedException "Specified method is not supported." — e.g. ResolveReturnType's
+        // IsSubclassOf(Delegate) probe (ParameterTypeResolver.cs) fires before its
+        // IsDynamicRuntimeType→object fallback can collapse it. At runtime such a collection is a
+        // dynamic $Array/$Map/$Set of boxed objects — never an instance of the union struct — so
+        // object is the sound backing element type, matching the IsDynamicRuntimeType→object slot
+        // precedent. Covers both collection-member (number[]|number) and scalar-member
+        // (number|string) unions used as collection elements. (#954)
+        if (UnionTypeHelper.IsUnionType(mapped))
+            return _types.Object;
+        return mapped;
     }
 
     /// <summary>
@@ -347,6 +360,11 @@ public class TypeMapper
         Type innerType = MapTypeInfoStrict(promise.ValueType);
         if (_types.IsVoid(innerType))
             return _types.Task;
+        // Promise<number|string> would otherwise produce Task<Union_*> — a TypeBuilderInstantiation
+        // that throws on the same reflection probes as List<Union_*> (see MapCollectionElementStrict).
+        // Collapse the union inner to object so the closed generic stays a RuntimeType. (#954)
+        if (UnionTypeHelper.IsUnionType(innerType))
+            innerType = _types.Object;
         return _types.MakeGenericType(_types.TaskOpen, innerType);
     }
 

--- a/SharpTS.Tests/SharedTests/UnionArrayLiteralTests.cs
+++ b/SharpTS.Tests/SharedTests/UnionArrayLiteralTests.cs
@@ -1,0 +1,125 @@
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests;
+
+/// <summary>
+/// Regression tests for #954: a heterogeneous array literal whose inferred element
+/// type is a union (e.g. <c>[nn(), x]</c> → <c>(number[] | number)[]</c>) made the
+/// compiler map the array to <c>List&lt;Union_*&gt;</c>. A generated <c>Union_*</c> struct
+/// is a <c>TypeBuilder</c>, so the closed generic is a <c>TypeBuilderInstantiation</c>, and a
+/// reflection probe on it (<c>ResolveReturnType</c>'s <c>IsSubclassOf(Delegate)</c>) threw
+/// <c>NotSupportedException: "Specified method is not supported."</c> at emit time — compiled
+/// only; the interpreter was always fine. Fixed by collapsing union collection-elements (and
+/// <c>Promise&lt;union&gt;</c> inners) to <c>object</c> at the type-mapping choke points.
+/// Runs in both interpreter and compiled modes.
+/// </summary>
+public class UnionArrayLiteralTests
+{
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void IssueRepro_ArrowReturningArrayMixingFreeFnCallAndParam(ExecutionMode mode)
+    {
+        // Exact issue repro: array literal mixing a free-function call (number[]) and the
+        // arrow's own number parameter → element type number[] | number.
+        var source = """
+            function nn(): number[] { const a: number[] = []; a[0] = 1; return a; }
+            const f = (x: number) => [nn(), x];
+            console.log(f(1).length);
+            """;
+        Assert.Equal("2\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void MapCallback_ArrayMixingFreeFnCallAndParam(ExecutionMode mode)
+    {
+        var source = """
+            function nn(): number[] { const a: number[] = []; a[0] = 1; return a; }
+            console.log([1, 2].map(x => [nn(), x]).length);
+            """;
+        Assert.Equal("2\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void FlatMapCallback_ArrayMixingFreeFnCallAndParam(ExecutionMode mode)
+    {
+        var source = """
+            function nn(): number[] { const a: number[] = []; a[0] = 1; return a; }
+            console.log([1, 2].flatMap(x => [nn(), x]).length);
+            """;
+        Assert.Equal("4\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ScalarUnionArrayLiteral(ExecutionMode mode)
+    {
+        // No collection member, but number | string still generates a Union_* struct, so the
+        // array is List<Union_number_STRING> — the same TypeBuilderInstantiation hazard.
+        var source = """
+            const g = (x: number, y: string) => [x, y];
+            console.log(g(1, "a").length);
+            """;
+        Assert.Equal("2\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void PromiseUnionReturn(ExecutionMode mode)
+    {
+        // Promise<number | string> maps to Task<Union_*> — the analogous choke point.
+        var source = """
+            async function h(): Promise<number | string> { return 5; }
+            async function main() {
+                const v = await h();
+                console.log(typeof v);
+                console.log(v);
+            }
+            main();
+            """;
+        Assert.Equal("number\n5\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void MapWithUnionValueType(ExecutionMode mode)
+    {
+        // Map<string, number[] | number> exercises MapMapTypeStrict's value element via the
+        // same MapCollectionElementStrict choke point.
+        var source = """
+            function nn(): number[] { const a: number[] = []; a[0] = 1; return a; }
+            const m = new Map<string, number[] | number>();
+            m.set("k", nn());
+            m.set("j", 7);
+            console.log(m.size);
+            """;
+        Assert.Equal("2\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Control_HomogeneousNestedNumberArray(ExecutionMode mode)
+    {
+        // No union (number[][]) — must remain unaffected by the fix.
+        var source = """
+            function nn(): number[] { const a: number[] = []; a[0] = 1; return a; }
+            const f = (x: number) => [nn()];
+            console.log(f(1).length);
+            """;
+        Assert.Equal("1\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Control_HomogeneousNumberArray(ExecutionMode mode)
+    {
+        // No union (number[]) — must remain unaffected by the fix.
+        var source = """
+            const f = (x: number) => [x, x];
+            console.log(f(1).length);
+            """;
+        Assert.Equal("2\n", TestHarness.Run(source, mode));
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #954 — compiling an arrow returning an array literal that mixes an array-typed element and a scalar element (e.g. `const f = (x: number) => [nn(), x]` where `nn(): number[]`) crashed at emit time with `Error: Specified method is not supported.`. Compiled-only; the interpreter was always fine.

## Root cause

`[nn(), x]` infers element type `number[] | number` (a heterogeneous **union**). The compiler generates a `Union_*` discriminated-union **struct `TypeBuilder`**, then `MakeGenericType(List<>, Union_*)` produces a `TypeBuilderInstantiation` `List<Union_*>`. The throwing call is:

```
System.NotSupportedException: Specified method is not supported.
   at System.Reflection.Emit.TypeBuilderInstantiation.IsSubclassOf(Type c)
   at SharpTS.Compilation.ParameterTypeResolver.ResolveReturnType(...)  ParameterTypeResolver.cs:236
   at SharpTS.Compilation.ILCompiler.FinalizeArrowFunctionCollection()  ILCompiler.ArrowFunctions.cs:195
```

`IsSubclassOf(typeof(Delegate))` is unsupported on a `TypeBuilderInstantiation`, and it runs *before* `ResolveReturnType`'s own `IsDynamicRuntimeType -> object` fallback (line 277) can collapse the type.

A `Union_*` struct is **always** a `TypeBuilder`, so scalar-only union arrays like `(number | string)[]` crashed identically — the free-function call in the original repro was incidental.

## Fix

Two type-mapping choke points in `Compilation/TypeMapper.cs` so the `TypeBuilderInstantiation` is never produced:

- **`MapCollectionElementStrict`** — collapse a union-mapped element to `object` (next to the existing `void -> object`). Covers array/Map/Set elements; both collection-member (`number[] | number`) and scalar-member (`number | string`) unions.
- **`MapPromiseTypeStrict`** — collapse a union inner so `Promise<union>` maps to `Task<object>` instead of `Task<Union_*>`.

Sound because such collections are dynamic `$Array`/`$Map`/`$Set` of boxed objects at runtime, never instances of the union struct — `object` is the correct backing type, matching the existing `IsDynamicRuntimeType -> object` slot precedent. `MapUnionTypeStrict`/`GetOrCreateUnionType` are untouched, so direct union param/return/field slots are unaffected.

## Tests & verification

- New `SharpTS.Tests/SharedTests/UnionArrayLiteralTests.cs` — **16/16** (8 cases × interpreter + compiled): issue repro, `.map`, `.flatMap`, scalar union, `Promise<union>`, `Map<string, number[] | number>`, and homogeneous controls.
- Repro compiles, passes IL `--verify`, prints `2`.
- Full `dotnet test`: 14344 passed (one `LiveNetwork` DNS test failed transiently; passes in isolation).
- Test262 **compiled** baseline: 0 drift. TypeScript conformance: 31/31.