### PR TITLE
fix: compiled Map keeps null and undefined as distinct keys (#960)

### DIFF
--- a/Compilation/RuntimeEmitter.Maps.cs
+++ b/Compilation/RuntimeEmitter.Maps.cs
@@ -24,7 +24,10 @@ public partial class RuntimeEmitter
     }
 
     /// <summary>
-    /// Emits NormalizeMapKey(key): converts null and $Undefined.Instance to _mapNullSentinel.
+    /// Emits NormalizeMapKey(key): converts a CLR null key to _mapNullSentinel so it can be
+    /// stored in a Dictionary (which forbids null keys). undefined ($Undefined.Instance) is
+    /// left untouched — it is a distinct singleton and a valid Dictionary key, so null and
+    /// undefined remain separate Map keys (matches JS and SharpTSMap; see issue #960).
     /// </summary>
     private void EmitNormalizeMapKey(TypeBuilder typeBuilder, EmittedRuntime runtime)
     {
@@ -38,16 +41,10 @@ public partial class RuntimeEmitter
 
         var il = method.GetILGenerator();
         var returnSentinelLabel = il.DefineLabel();
-        var returnKeyLabel = il.DefineLabel();
 
         // if (key == null) return _mapNullSentinel;
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Brfalse, returnSentinelLabel);
-
-        // if (key is $Undefined) return _mapNullSentinel;
-        il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Isinst, runtime.UndefinedType);
-        il.Emit(OpCodes.Brtrue, returnSentinelLabel);
 
         // return key;
         il.Emit(OpCodes.Ldarg_0);

--- a/Runtime/Types/SharpTSMap.cs
+++ b/Runtime/Types/SharpTSMap.cs
@@ -25,6 +25,13 @@ public class SharpTSMap : ITypeCategorized, IEnumerable<object?>
 
     private static object NormalizeKey(object? key) => key ?? NullSentinel;
 
+    /// <summary>
+    /// Reverses <see cref="NormalizeKey"/>: turns the internal null-sentinel back into a real
+    /// null so the sentinel never escapes the Map (keys(), entries(), forEach, for...of,
+    /// spread, console.log). undefined is stored as its own value, so it passes through.
+    /// </summary>
+    private static object? DenormalizeKey(object key) => ReferenceEquals(key, NullSentinel) ? null : key;
+
     private readonly Dictionary<object, object?> _map;
 
     public SharpTSMap()
@@ -133,12 +140,13 @@ public class SharpTSMap : ITypeCategorized, IEnumerable<object?>
     /// <summary>
     /// Exposes the internal dictionary for forEach implementation.
     /// </summary>
-    internal IEnumerable<KeyValuePair<object, object?>> InternalEntries => _map;
+    internal IEnumerable<(object? Key, object? Value)> InternalEntries =>
+        _map.Select(kvp => (DenormalizeKey(kvp.Key), kvp.Value));
 
     private IEnumerable<object?> EnumerateKeys()
     {
         foreach (var key in _map.Keys)
-            yield return key;
+            yield return DenormalizeKey(key);
     }
 
     private IEnumerable<object?> EnumerateValues()
@@ -150,7 +158,7 @@ public class SharpTSMap : ITypeCategorized, IEnumerable<object?>
     private IEnumerable<object?> EnumerateEntries()
     {
         foreach (var kvp in _map)
-            yield return new SharpTSArray([kvp.Key, kvp.Value]);
+            yield return new SharpTSArray([DenormalizeKey(kvp.Key), kvp.Value]);
     }
 
     /// <summary>
@@ -164,7 +172,7 @@ public class SharpTSMap : ITypeCategorized, IEnumerable<object?>
     public override string ToString()
     {
         var entries = _map.Select(kvp =>
-            $"{FormatValue(kvp.Key)} => {FormatValue(kvp.Value)}");
+            $"{FormatValue(DenormalizeKey(kvp.Key))} => {FormatValue(kvp.Value)}");
         return $"Map({_map.Count}) {{ {string.Join(", ", entries)} }}";
     }
 

--- a/Runtime/Types/StructuredClone.cs
+++ b/Runtime/Types/StructuredClone.cs
@@ -401,10 +401,9 @@ public static class StructuredClone
         {
             var clonedKey = CloneInternal(kvp.Key, cloned, transferred);
             var clonedValue = CloneInternal(kvp.Value, cloned, transferred);
-            if (clonedKey != null)
-            {
-                result.Set(clonedKey, clonedValue);
-            }
+            // A null key is valid in a JS Map (and SharpTSMap.Set normalizes it), so set
+            // unconditionally — guarding on non-null would silently drop a null key.
+            result.Set(clonedKey, clonedValue);
         }
 
         return result;

--- a/SharpTS.Tests/SharedTests/MapSetTests.cs
+++ b/SharpTS.Tests/SharedTests/MapSetTests.cs
@@ -117,6 +117,67 @@ public class MapSetTests
 
     #endregion
 
+    #region Map Null/Undefined Key Identity (issue #960)
+
+    // null and undefined are DISTINCT Map keys in JS (and the interpreter). Compiled mode
+    // previously collapsed both onto a single null-sentinel, so set(undefined) overwrote
+    // set(null) and size was undercounted. These run in both modes to pin parity.
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Map_NullAndUndefinedKeys_AreDistinct(ExecutionMode mode)
+    {
+        // Exact repro from issue #960.
+        var source = @"
+            const m = new Map();
+            m.set(null, 9);
+            m.set(undefined, 8);
+            console.log(m.size);
+            console.log(m.get(null));
+            console.log(m.get(undefined));
+        ";
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("2\n9\n8\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Map_NullAndUndefinedKeys_HasAndDeleteIndependently(ExecutionMode mode)
+    {
+        var source = @"
+            const m = new Map();
+            m.set(null, 1);
+            m.set(undefined, 2);
+            console.log(m.has(null));
+            console.log(m.has(undefined));
+            console.log(m.delete(null));
+            console.log(m.has(null));
+            console.log(m.has(undefined));
+            console.log(m.size);
+        ";
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("true\ntrue\ntrue\nfalse\ntrue\n1\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Map_NullAndUndefinedKeys_ConstructorAndIteration(ExecutionMode mode)
+    {
+        // Guards the entries-constructor (CreateMapFromEntries) and the
+        // denormalize-on-iteration path (#953 spread routes through the same code).
+        var source = @"
+            const m = new Map<any, string>([[null, 'a'], [undefined, 'b']]);
+            console.log(m.size);
+            m.forEach((v, k) => { console.log(k + '=' + v); });
+        ";
+        var output = TestHarness.Run(source, mode);
+        Assert.Contains("2\n", output);
+        Assert.Contains("null=a", output);
+        Assert.Contains("undefined=b", output);
+    }
+
+    #endregion
+
     #region Map Iteration
 
     [Theory]


### PR DESCRIPTION
Fixes #960.

## Problem
In **compiled** mode a `Map` treated `null` and `undefined` as the *same* key, so `set(undefined)` overwrote a prior `set(null)`, `size` was undercounted, and `get(null)` returned the `undefined`-keyed value. Real JS and the SharpTS interpreter treat them as distinct keys.

```ts
const m = new Map();
m.set(null, 9);
m.set(undefined, 8);
m.size;          // was 1, now 2
m.get(null);     // was 8, now 9
m.get(undefined);// 8
```

## Root cause
The hand-emitted IL for the standalone runtime's `NormalizeMapKey` (`Compilation/RuntimeEmitter.Maps.cs`) mapped **both** CLR `null` **and** `$Undefined.Instance` to the single shared `_mapNullSentinel`, so they hashed/compared identically and collided.

## Fix
Drop the `$Undefined`→sentinel branch in `EmitNormalizeMapKey`. `$Undefined` is a real singleton (private ctor, single static `Instance`, identity equality) and a valid `Dictionary` key under `$ReferenceEqualityComparer`, so it now stays its own key while only CLR `null` routes to the sentinel — matching the interpreter (`SharpTSMap`) and the already-correct `RuntimeTypes.Maps.cs` twin. `DenormalizeMapKey` and all call sites (`get`/`set`/`has`/`delete`, the entries-constructor, and the #953 spread path) are unchanged and now resolve uniformly.

## Bonus: interpreter parity bug found by the new iteration test
`SharpTSMap` normalized `null`→sentinel on store but **never reversed it** on iteration, so `keys()`/`entries()`/`forEach`/`for...of`/spread/`console.log` leaked the raw sentinel object for a `null` key (showed `System.Object`). Added `DenormalizeKey` and applied it at every exposure point (`EnumerateKeys`/`EnumerateEntries`/`InternalEntries`/`ToString`). The `StructuredClone` Map path then needed its non-null key guard removed so a `null` key is preserved rather than dropped.

## Out of scope (noted)
`RuntimeEmitter.Sets.cs` `EmitSetAdd` silently drops a CLR-`null` value — a separate compiled-Set bug, left for a follow-up.

## Tests / verification
- 3 dual-mode `MapSetTests` (exact #960 repro; `has`/`delete` independence; entries-constructor + iteration) — run in both interpreter and compiled modes.
- Full suite **14367 passed / 0 failed**.
- Compiled repro DLL output matches Node/interpreter; emitted IL passes `--verify`.