### PR TITLE
fix: expand spread args to compiled Array.prototype.concat (#952)

### DIFF
--- a/Compilation/Emitters/ArrayEmitter.cs
+++ b/Compilation/Emitters/ArrayEmitter.cs
@@ -35,12 +35,19 @@ public sealed class ArrayEmitter : ITypeEmitterStrategy
         // (not a bare List<object?>), so downstream array methods / runtime dispatch still match.
         bool returnsNewArray = IsReturnsNewArrayMethod(methodName);
 
+        // #952: `concat(...spread)` must expand the spread BEFORE concat (which only flattens one level
+        // per *argument*). The spread path below routes through EmitArgsArrayWithSpread, which is itself
+        // await-safe (it evaluates each arg into a temp with a clear stack), so it must NOT also go through
+        // the #850 pre-spill — that would double-evaluate the args.
+        bool concatSpread = methodName == "concat" && arguments.Any(a => a is Expr.Spread);
+
         // #850: when an argument can suspend (await/yield), evaluating it while the receiver list sits
         // on the IL evaluation stack produces invalid IL across a state-machine suspension. Pre-spill the
         // receiver + args into await-safe locals (callback methods never trigger this — an arrow body's
         // await belongs to its own state machine).
         bool plainArgSuspension = arguments.Count > 0 && MethodTakesPlainArgs(methodName)
-            && emitter.ArgsContainSuspension(arguments);
+            && emitter.ArgsContainSuspension(arguments)
+            && !concatSpread;
 
         // The receiver local holds the ORIGINAL receiver, used by returnsReceiver methods and the
         // suspension spill below; unused for the other methods.
@@ -230,7 +237,25 @@ public sealed class ArrayEmitter : ITypeEmitterStrategy
                 break;
 
             case "concat":
-                EmitArgsArray(emitter, arguments, argLocals);
+                if (concatSpread)
+                {
+                    // #952: the receiver [list] is on the stack. Spread args must be flattened
+                    // BEFORE concat (concat itself only flattens one level per argument). Stash the
+                    // list, build the spread-expanded args array await-safely (EmitArgsArrayWithSpread
+                    // evaluates into temps with a clear stack — the spread expr may contain await),
+                    // then reload [list] under [items] so ArrayConcat sees (list, items).
+                    var concatListTmp = il.DeclareLocal(ctx.Types.ListOfObject);
+                    il.Emit(OpCodes.Stloc, concatListTmp);
+                    emitter.EmitArgsArrayWithSpread(arguments);
+                    var concatItemsTmp = il.DeclareLocal(ctx.Types.ObjectArray);
+                    il.Emit(OpCodes.Stloc, concatItemsTmp);
+                    il.Emit(OpCodes.Ldloc, concatListTmp);
+                    il.Emit(OpCodes.Ldloc, concatItemsTmp);
+                }
+                else
+                {
+                    EmitArgsArray(emitter, arguments, argLocals);
+                }
                 il.Emit(OpCodes.Call, ctx.Runtime!.ArrayConcat);
                 break;
 

--- a/Compilation/ExpressionEmitterBase.CallHelpers.cs
+++ b/Compilation/ExpressionEmitterBase.CallHelpers.cs
@@ -2149,14 +2149,9 @@ public abstract partial class ExpressionEmitterBase
             case "concat":
                 // ECMA-262: concat(...items) is variadic. Pass args as object[]
                 // so each argument spreads (Array/List) or appends individually.
-                IL.Emit(OpCodes.Ldc_I4, arguments.Count);
-                IL.Emit(OpCodes.Newarr, Ctx.Types.Object);
-                for (int i = 0; i < arguments.Count; i++)
-                {
-                    IL.Emit(OpCodes.Dup); IL.Emit(OpCodes.Ldc_I4, i);
-                    EmitExpression(arguments[i]); EnsureBoxed();
-                    IL.Emit(OpCodes.Stelem_Ref);
-                }
+                // A `...spread` arg is flattened first (#952) so concat sees the
+                // expanded elements, not the source array as one nested item.
+                EmitArgsArrayWithSpread(arguments);
                 IL.Emit(OpCodes.Call, Ctx.Runtime!.ArrayConcat);
                 break;
         }

--- a/Compilation/ILEmitter.Calls.AmbiguousDispatch.cs
+++ b/Compilation/ILEmitter.Calls.AmbiguousDispatch.cs
@@ -309,17 +309,9 @@ public partial class ILEmitter
                 break;
 
             case "concat":
-                // ECMA-262: concat(...items) is variadic. Pass args as object[].
-                IL.Emit(OpCodes.Ldc_I4, arguments.Count);
-                IL.Emit(OpCodes.Newarr, _ctx.Types.Object);
-                for (int i = 0; i < arguments.Count; i++)
-                {
-                    IL.Emit(OpCodes.Dup);
-                    IL.Emit(OpCodes.Ldc_I4, i);
-                    EmitExpression(arguments[i]);
-                    EmitBoxIfNeeded(arguments[i]);
-                    IL.Emit(OpCodes.Stelem_Ref);
-                }
+                // ECMA-262: concat(...items) is variadic. Pass args as object[], with any
+                // `...spread` flattened first (#952) so concat appends/spreads each element.
+                EmitArgsArrayWithSpread(arguments);
                 IL.Emit(OpCodes.Call, _ctx.Runtime!.ArrayConcat);
                 break;
 

--- a/Compilation/ILEmitter.Calls.cs
+++ b/Compilation/ILEmitter.Calls.cs
@@ -597,17 +597,11 @@ public partial class ILEmitter
                 }
                 break;
             case "argsArray":
-                // Push the method args as an object[].
-                IL.Emit(OpCodes.Ldc_I4, methodArgs.Count);
-                IL.Emit(OpCodes.Newarr, _ctx.Types.Object);
-                for (int i = 0; i < methodArgs.Count; i++)
-                {
-                    IL.Emit(OpCodes.Dup);
-                    IL.Emit(OpCodes.Ldc_I4, i);
-                    EmitExpression(methodArgs[i]);
-                    EmitBoxIfNeeded(methodArgs[i]);
-                    IL.Emit(OpCodes.Stelem_Ref);
-                }
+                // Push the method args as an object[], flattening any `...spread` arg in
+                // place (#952) — identical to the old inline loop when no spread is present,
+                // so concat/reduce/slice/toSpliced/with via Array.prototype.X.call all expand
+                // spreads the way the generic call path does.
+                EmitArgsArrayWithSpread(methodArgs);
                 break;
             case "noArg":
                 // Helper takes only the materialized list — no extra args

--- a/SharpTS.Tests/SharedTests/ArrayConcatSpreadTests.cs
+++ b/SharpTS.Tests/SharedTests/ArrayConcatSpreadTests.cs
@@ -1,0 +1,126 @@
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests;
+
+/// <summary>
+/// Regression for #952: in compiled mode the array-method emitters built
+/// <c>concat</c>'s argument array by emitting each AST arg via
+/// <c>EmitExpression</c>, but a spread argument (<c>...arr</c>) is an
+/// <c>Expr.Spread</c> whose emit just yields the inner array — so
+/// <c>[0].concat(...[[1, 2]])</c> reached the runtime <c>ArrayConcat</c> as a
+/// single nested item and produced <c>[0,[1,2]]</c> instead of <c>[0,1,2]</c>.
+/// The fix routes <c>concat</c>'s args through <c>EmitArgsArrayWithSpread</c>
+/// (the same spread expansion the generic <c>f(...arr)</c> call site uses), so
+/// the spread is flattened before <c>concat</c> applies its per-argument
+/// one-level flatten. The interpreter already expanded spreads correctly, so
+/// each case is asserted against Node-identical output in BOTH modes.
+/// </summary>
+public class ArrayConcatSpreadTests
+{
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Concat_SpreadOfArrayOfArrays_FlattensOneLevel(ExecutionMode mode)
+    {
+        // The issue repro: ...[[1, 2]] spreads into concat([1, 2]), which then
+        // flattens that one level → [0, 1, 2].
+        var source = @"
+            console.log(JSON.stringify([0].concat(...[[1, 2]])));
+        ";
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("[0,1,2]\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Concat_SpreadOfFlatArray_AppendsElements(ExecutionMode mode)
+    {
+        // ...[1, 2] spreads into concat(1, 2); neither arg is an array, so each
+        // is appended individually.
+        var source = @"
+            console.log(JSON.stringify([0].concat(...[1, 2])));
+        ";
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("[0,1,2]\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Concat_SpreadOfMultipleArrays_FlattensEach(ExecutionMode mode)
+    {
+        // ...[[1,2],[3]] spreads into concat([1,2], [3]) → each flattened once.
+        var source = @"
+            console.log(JSON.stringify([0].concat(...[[1, 2], [3]])));
+        ";
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("[0,1,2,3]\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Concat_MixedSpreadAndPlainArgs(ExecutionMode mode)
+    {
+        // concat(2, ...[[3, 4]], 5) → append 2, flatten [3,4], append 5.
+        var source = @"
+            console.log(JSON.stringify([1].concat(2, ...[[3, 4]], 5)));
+        ";
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("[1,2,3,4,5]\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Concat_SpreadOfBoxedStringArrays(ExecutionMode mode)
+    {
+        // The bug is not numeric-specific — boxed (string) element arrays spread
+        // the same way.
+        var source = @"
+            console.log(JSON.stringify([""a""].concat(...[[""b"", ""c""]])));
+        ";
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("[\"a\",\"b\",\"c\"]\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Concat_SpreadOfVariable(ExecutionMode mode)
+    {
+        // Spread source as a named variable (not an inline literal) routes
+        // through the same expansion.
+        var source = @"
+            const x = [[1, 2]];
+            console.log(JSON.stringify([0].concat(...x)));
+        ";
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("[0,1,2]\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Concat_SpreadOfEmptyArray_NoOp(ExecutionMode mode)
+    {
+        // Spreading an empty array contributes no arguments.
+        var source = @"
+            console.log(JSON.stringify([0].concat(...[])));
+        ";
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("[0]\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Concat_SpreadInsideAsyncFunction(ExecutionMode mode)
+    {
+        // Exercises the async emitter: the spread element list is produced by an
+        // awaited value. EmitArgsArrayWithSpread evaluates args into temps with a
+        // clear stack, so the await-suspending spread still expands correctly.
+        var source = @"
+            async function f() {
+                console.log(JSON.stringify([0].concat(...await Promise.resolve([[1, 2]]))));
+            }
+            f();
+        ";
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("[0,1,2]\n", output);
+    }
+}


### PR DESCRIPTION
Closes #952.

## Problem

In **compiled** mode, a spread argument to `Array.prototype.concat` was not flattened:

```ts
console.log(JSON.stringify([0].concat(...[[1, 2]])));
// compiled: [0,[1,2]]   node: [0,1,2]
```

The array-method emitters built `concat`'s argument array by emitting each AST arg via `EmitExpression`, but a spread `...arr` is an `Expr.Spread` whose emit yields the inner **array object** — so the spread element reached the runtime `ArrayConcat(list, object?[] items)` as a single nested item, and concat's per-argument one-level flatten left it nested. `[0].concat(b)` (no spread) was always correct; it failed for boxed (non-numeric) arrays too.

The interpreter already expanded spreads correctly (`EvaluateCall` → `GetIterableElements`), so this was **compiled-only**, exactly as the issue stated.

Same family as the `Math.max(...arr)` → `NaN` gap (#951, PR #957), which introduced the helper this fix reuses.

## Changes

Route `concat`'s args through the existing `EmitArgsArrayWithSpread` helper (on `IEmitterContext`, added in #957) at **every** compiled dispatch path that emits `Array.prototype.concat`, so the spread is flattened **before** concat applies its per-argument flatten. The helper is **identical to the old inline loop when no spread is present**, so non-spread concat IL is unchanged → no regression.

- **`Compilation/Emitters/ArrayEmitter.cs`** — primary `arr.concat(...)` path (statically-typed array). Stash the receiver list, build the spread-expanded args array await-safely (the helper evaluates each arg into a temp with a clear stack, so the spread may contain `await`), then reload `list` under `items`. Excluded from the #850 plain-arg pre-spill (`!concatSpread`) to avoid double-evaluating the args.
- **`Compilation/ILEmitter.Calls.AmbiguousDispatch.cs`** and **`Compilation/ExpressionEmitterBase.CallHelpers.cs`** — the two runtime-typed (string-or-list / `any`) dispatch paths for `x.concat(...)`.
- **`Compilation/ILEmitter.Calls.cs`** — the shared `argsArray` case (`Array.prototype.X.call`), which also closes the same spread gap for `reduce`/`slice`/`toSpliced`/`with` via `.call`.

## Tests

`SharpTS.Tests/SharedTests/ArrayConcatSpreadTests.cs` (new) — the issue repro plus flat-array / multi-array / mixed spread+plain / boxed-string / variable-source / empty / **async** spreads, run in **both** interpreter (the Node-matching oracle) and compiled modes.

## Verification

- New tests: 16/16 green (8 cases × 2 modes); adjacent array/spread tests 156/156.
- Full suite: **14383 passed, 0 failed**.
- The exact repro produces Node-identical output in both modes via the CLI.