### PR TITLE
perf(compile): native-int modulo for `counter % literal` (#928)

### DIFF
--- a/Compilation/ForLoopAnalyzer.cs
+++ b/Compilation/ForLoopAnalyzer.cs
@@ -30,6 +30,17 @@ public static class ForLoopAnalyzer
         Environment.GetEnvironmentVariable("SHARPTS_INT_LOOP_COUNTER") != "0";
 
     /// <summary>
+    /// #928: native int64 modulo for <c>counter % integerLiteral</c>. The integer loop
+    /// counter is already an <c>Int64</c> slot; emitting <c>i % 7</c> as an int64 <c>rem</c> (then
+    /// <c>conv.r8</c>) instead of an FP <c>fmod</c> on two doubles is bit-identical to JS truncated
+    /// remainder for every <c>|i| ≤ 2^53</c> — the same gate the counter representation already
+    /// accepts — and the <c>fmod</c> is the dominant per-iteration cost in write kernels (#928
+    /// measurement). On by default when the counter is on; kill with <c>SHARPTS_INT_MOD=0</c>.
+    /// </summary>
+    public static readonly bool IntegerModuloEnabled =
+        Environment.GetEnvironmentVariable("SHARPTS_INT_MOD") != "0";
+
+    /// <summary>
     /// Identifies a for-loop counter eligible for the native <c>Int64</c> representation, or null.
     /// Stricter than <see cref="Analyze"/>: requires an INTEGER-literal initializer, a pure
     /// <c>++</c>/<c>--</c> step, a numeric condition, no closure capture, and no reassignment or

--- a/Compilation/ILEmitter.Operators.cs
+++ b/Compilation/ILEmitter.Operators.cs
@@ -83,6 +83,14 @@ public partial class ILEmitter
                 break;
 
             case Arithmetic arith:
+                // #928: `counter % intLiteral` → native int64 rem instead of FP fmod (the dominant
+                // per-iteration write-kernel cost). Sound within the int-counter gate (truncated
+                // remainder matches JS for |i| ≤ 2^53). Falls through to the double path otherwise.
+                if (arith.Opcode == OpCodes.Rem && TryEmitIntegerCounterModulo(b))
+                {
+                    SetStackType(StackType.Double);
+                    break;
+                }
                 // Numeric arithmetic with direct IL opcodes
                 EmitExpressionAsDouble(b.Left);
                 EmitExpressionAsDouble(b.Right);
@@ -948,6 +956,60 @@ public partial class ILEmitter
         if (double.IsNaN(d) || double.IsInfinity(d) || d != Math.Truncate(d)) return false;
         value = (long)d;
         return true;
+    }
+
+    /// <summary>
+    /// #928: emits <c>counter % integerLiteral</c> as a native int64 <c>rem</c> followed by
+    /// <c>conv.r8</c>, replacing the per-iteration FP <c>fmod</c> (the dominant write-kernel cost).
+    /// The left operand must be an integer-counter expression (the counter, or counter ± int literal)
+    /// and the right a non-zero integer literal. C# <c>long %</c> and JS <c>%</c> are both truncated
+    /// (result takes the dividend's sign), so this is bit-identical to the double computation for every
+    /// <c>|dividend| ≤ 2^53</c> — the same range the int-counter representation already accepts. Divisor
+    /// 0 is left to the double path (<c>fmod(x,0)=NaN</c>), so no <c>DivideByZeroException</c> is risked.
+    /// Returns false (emitting nothing) when the shape does not qualify.
+    /// </summary>
+    private bool TryEmitIntegerCounterModulo(Expr.Binary b)
+    {
+        if (!ForLoopAnalyzer.IntegerModuloEnabled) return false;
+        if (!TryGetIntLiteralValue(b.Right, out long divisor) || divisor == 0) return false;
+        if (!TryEmitIntegerCounterValueI8(b.Left)) return false;
+        IL.Emit(OpCodes.Ldc_I8, divisor);
+        IL.Emit(OpCodes.Rem);
+        IL.Emit(OpCodes.Conv_R8);
+        return true;
+    }
+
+    /// <summary>
+    /// Emits an integer-counter expression as a native <c>Int64</c> (no <c>conv.r8</c>): the counter
+    /// <c>i</c>, or <c>i ± intLiteral</c> / <c>intLiteral + i</c>. Companion to
+    /// <see cref="TryEmitIntegerCounterIndexI4"/> but leaves the value as Int64 on the stack. Returns
+    /// false (emitting nothing) when the shape is not a recognized integer-counter expression.
+    /// </summary>
+    private bool TryEmitIntegerCounterValueI8(Expr e)
+    {
+        switch (e)
+        {
+            case Expr.Variable v when IsIntegerCounterLocal(v.Name.Lexeme):
+                IL.Emit(OpCodes.Ldloc, _ctx.Locals.GetLocal(v.Name.Lexeme)!);
+                return true;
+
+            case Expr.Binary { Operator.Type: TokenType.PLUS or TokenType.MINUS } bb
+                when bb.Left is Expr.Variable lv && IsIntegerCounterLocal(lv.Name.Lexeme)
+                     && TryGetIntLiteralValue(bb.Right, out long k):
+                IL.Emit(OpCodes.Ldloc, _ctx.Locals.GetLocal(lv.Name.Lexeme)!);
+                IL.Emit(OpCodes.Ldc_I8, k);
+                IL.Emit(bb.Operator.Type == TokenType.PLUS ? OpCodes.Add : OpCodes.Sub);
+                return true;
+
+            case Expr.Binary { Operator.Type: TokenType.PLUS } b2
+                when b2.Right is Expr.Variable rv && IsIntegerCounterLocal(rv.Name.Lexeme)
+                     && TryGetIntLiteralValue(b2.Left, out long k2):
+                IL.Emit(OpCodes.Ldc_I8, k2);
+                IL.Emit(OpCodes.Ldloc, _ctx.Locals.GetLocal(rv.Name.Lexeme)!);
+                IL.Emit(OpCodes.Add);
+                return true;
+        }
+        return false;
     }
 
     /// <summary>

--- a/SharpTS.Tests/SharedTests/ModuloParityTests.cs
+++ b/SharpTS.Tests/SharedTests/ModuloParityTests.cs
@@ -1,0 +1,130 @@
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests;
+
+/// <summary>
+/// Pins interpreter/compiled parity for the native-int modulo fast path (#928).
+///
+/// In compiled mode, <c>counter % integerLiteral</c> is emitted as a native int64 <c>rem</c>
+/// followed by <c>conv.r8</c> (<see cref="SharpTS.Compilation.ILEmitter"/>
+/// <c>TryEmitIntegerCounterModulo</c>) instead of an FP <c>fmod</c> on two doubles — the
+/// <c>fmod</c> is the dominant per-iteration cost in numeric write kernels. C# <c>long %</c> and
+/// JS <c>%</c> are both truncated (the result takes the dividend's sign), so the optimization is
+/// bit-identical to the double computation for every <c>|dividend| ≤ 2^53</c> — the same range the
+/// int-counter representation already accepts (<c>SHARPTS_INT_LOOP_COUNTER</c>). The interpreter
+/// never takes the fast path, so each theory below asserts both modes agree, and every expected
+/// value is ground-truthed against Node (= the JS spec).
+/// </summary>
+public class ModuloParityTests
+{
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AscendingCounter_BasicDivisor(ExecutionMode mode)
+    {
+        var source = """
+            let r: string = "";
+            for (let i: number = 0; i < 10; i++) { r += (i % 3) + ","; }
+            console.log(r);
+            """;
+        Assert.Equal("0,1,2,0,1,2,0,1,2,0,\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void CounterPlusMinusLiteral_Dividend(ExecutionMode mode)
+    {
+        // `(i + k) % m` and `(i - k) % m` — the counter±literal dividend shapes the fast path recognizes.
+        var source = """
+            let r: string = "";
+            for (let i: number = 0; i < 8; i++) { r += ((i + 1) % 4) + ":" + ((i - 2) % 5) + " "; }
+            console.log(r);
+            """;
+        Assert.Equal("1:-2 2:-1 3:0 0:1 1:2 2:3 3:4 0:0 \n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void DescendingCounter_NegativeDividend_AndNegativeDivisor(ExecutionMode mode)
+    {
+        // Truncated remainder: the result takes the dividend's sign; a negative divisor does not
+        // change the sign. C# and JS agree on both.
+        var source = """
+            let r: string = "";
+            for (let i: number = 3; i > -4; i--) { r += (i % 3) + "/" + (i % -3) + " "; }
+            console.log(r);
+            """;
+        Assert.Equal("0/0 2/2 1/1 0/0 -1/-1 -2/-2 0/0 \n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void DivisorOne_AlwaysZero(ExecutionMode mode)
+    {
+        var source = """
+            let r: string = "";
+            for (let i: number = 0; i < 5; i++) { r += (i % 1) + ","; }
+            console.log(r);
+            """;
+        Assert.Equal("0,0,0,0,0,\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void DivisorZero_FallsBackToNaN_DoesNotThrow(ExecutionMode mode)
+    {
+        // `i % 0` is NaN in JS (fmod(x, 0)). The fast path explicitly declines divisor 0 so it never
+        // emits an int64 `rem` (which would be a DivideByZeroException) — it routes to the double path.
+        var source = """
+            let r: string = "";
+            for (let i: number = 0; i < 3; i++) { r += (i % 0) + ","; }
+            console.log(r);
+            """;
+        Assert.Equal("NaN,NaN,NaN,\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void NonCounterDividend_FallsBackToDoublePath(ExecutionMode mode)
+    {
+        // `(i * 2) % 5` — the dividend is a multiply, not a recognized counter expression, so the
+        // fast path declines and the double path computes it. Must still be correct.
+        var source = """
+            let r: string = "";
+            for (let i: number = 0; i < 6; i++) { r += ((i * 2) % 5) + ","; }
+            console.log(r);
+            """;
+        Assert.Equal("0,2,4,1,3,0,\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ModuloInFloat64WriteKernel(ExecutionMode mode)
+    {
+        // The real kernel shape: a modulo embedded in a mixed-double store expression into a
+        // Float64Array, then summed. Exercises native-int modulo feeding a double store.
+        var source = """
+            const a: Float64Array = new Float64Array(20);
+            for (let i: number = 0; i < 20; i++) { a[i] = i * 1.5 + (i % 7); }
+            let s: number = 0;
+            for (let i: number = 0; i < 20; i++) { s = s + a[i]; }
+            console.log(s);
+            """;
+        Assert.Equal("342\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ModuloInInt32WriteKernel_ToInt32Truncation(ExecutionMode mode)
+    {
+        // Int32Array store path: the int64 modulo result feeds a store that ToInt32-truncates.
+        var source = """
+            const b: Int32Array = new Int32Array(15);
+            for (let i: number = 0; i < 15; i++) { b[i] = i * 3 - (i % 7); }
+            let r: string = "";
+            for (let i: number = 0; i < 15; i++) { r += b[i] + ","; }
+            console.log(r);
+            """;
+        Assert.Equal("0,2,4,6,8,10,12,21,23,25,27,29,31,33,42,\n", TestHarness.Run(source, mode));
+    }
+}


### PR DESCRIPTION
## What & why (#928)

Native-int **modulo** fast path for the compiled IL backend: `counter % integerLiteral` is emitted as a native int64 `rem` + `conv.r8` instead of an FP `fmod` on two doubles.

This came out of re-investigating #928. Split-isolation benchmarks overturned the issue's premise — the int32 gap is **not** element representation:

- SharpTS runs int and float typed arrays at the **same speed** (per-element `ToInt32`/`conv.r8` are negligible), and SharpTS's Float64 stencil-read is already at parity with Node (Node's int32 speed is just its Smi lane on integer data).
- The dominant per-iteration cost in numeric **write** kernels is the `i % k` **double `fmod`** — it nearly *doubles* any kernel containing it (`store64` 16.4 → `mod64` 32.6ms @1M; double *multiply* adds ~0).

`i` is already an int64 loop-counter slot and `k` is an integer literal, so `i % k` as int64 `rem` is **sound within the exact gate the int-counter already accepts** (C# `long %` ≡ JS `%` — both truncated, sign-of-dividend — for every `|i| ≤ 2^53`).

## Performance (A/B, only the compile-time gate differs; min ms @1M)

| Workload | off | on | speedup |
|---|---|---|---|
| typed-arrays (Float64) | 4.65 | **2.55** | **1.82×** — now beats Node (5.64) ~2.2×, ~1.2× off Bun |
| int32-kernel | 5.27 | **3.77** | **1.40×** |
| bare `s += i*3-(i%7)` | 29.3 | **14.8** | **1.99×** |
| kernels with no `%` (store/mul/accumulate) | — | unchanged | **1.0×** |

## Correctness & soundness

- **4-way byte-identical** (compiled-on / compiled-off / interpreter / Node) across an edge battery: negative dividend, negative divisor, `i±k` dividends, `%1`, descending counters, modulo embedded in a mixed-double kernel.
- New `SharpTS.Tests/SharedTests/ModuloParityTests.cs` — 8 cases × both modes (16 tests), every expected value ground-truthed against Node; includes the divisor-0 → NaN fallback (declined by the fast path, no `DivideByZeroException`) and the non-counter-dividend fallback.
- **Full suite 14192/0** green with the opt default-on. ILVerify-clean (covered by `ILVerificationTests`).
- **Test262** (interp + compiled): the default subset is **pre-existingly red on `main`** — the compiled host hits a fatal CLR error (`0x80131506`) that aborts the run *before* the compiled differ executes, and the interpreted baseline is stale/flaky (timeouts). This reproduces identically with the opt disabled (`SHARPTS_INT_MOD=0`): neither run reaches the `[Compiled]` differ, and the interpreted soft-change count even varies between two runs of the byte-identical interpreter (42 vs 19) — proving harness nondeterminism, not a regression from this change (which is compiled-only and cannot affect the interpreter). The subset also doesn't include the multiplicative/modulus operator folders, and Test262's modulus tests use constant operands that this loop-counter fast path never matches. So Test262 gives no signal here either way; the gate for this change is the dual-mode xUnit suite + parity tests + the 4-way differential above. The pre-existing crash is unrelated infra debt worth a separate issue.

## Scope / design

- Only `%` goes native. Multiply stays double (measured free); division `/` **must** stay double (JS `/` is true division, not integer division).
- Fires only when the left is a recognized integer-counter expression (`i`, `i±k`, `k+i`) and the right is a non-zero integer literal; everything else falls through to the existing double path.
- Gated by `SHARPTS_INT_MOD` (default-on kill-switch, mirroring `SHARPTS_INT_LOOP_COUNTER`).

## Interop

Safe by construction — the change operates on counter **values**, never the `byte[]` typed-array backing, so `ArrayBuffer`/`DataView`/`Atomics` and the `$Runtime`/`$Array` host types are untouched. Emitted IL is pure BCL opcodes (`ldloc`/`ldc.i8`/`rem`/`conv.r8`), so standalone DLLs gain no SharpTS.dll reference.
