### PR TITLE
fix(test262): stop in-process collectible-ALC churn crashing the testhost (#964)

### DIFF
--- a/SharpTS.Test262.Worker/Program.cs
+++ b/SharpTS.Test262.Worker/Program.cs
@@ -57,8 +57,8 @@ var skipFeatures = LoadSkipFeatures(skipFeaturesFile);
 // The trade-off — assemblies leak for the worker's lifetime — is bounded by
 // the working-set check below, which exits the worker cleanly when memory
 // crosses 1.5GB so the parent can spawn a fresh worker for the next batch.
-Test262Runner.UseNonCollectibleLoad = true;
-var runner = new Test262Runner(test262Root, TimeSpan.FromSeconds(timeoutSeconds), skipFeatures);
+var runner = new Test262Runner(
+    test262Root, TimeSpan.FromSeconds(timeoutSeconds), skipFeatures, useNonCollectibleLoad: true);
 
 // Memory ceiling for non-collectible mode. Each emitted assembly holds onto
 // metadata + JIT'd code in process memory permanently; left unchecked, a

--- a/SharpTS.Test262/SmokeTest.cs
+++ b/SharpTS.Test262/SmokeTest.cs
@@ -39,7 +39,7 @@ public class SmokeTest
             "built-ins", "Promise", "resolve", "arg-non-thenable.js");
         Assert.True(File.Exists(testPath));
 
-        var runner = new Test262Runner(root, TimeSpan.FromSeconds(15));
+        var runner = new Test262Runner(root, TimeSpan.FromSeconds(15), useNonCollectibleLoad: true);
         var result = runner.RunOne(testPath, mode);
         _output.WriteLine($"{mode} → {result.Outcome}");
         if (result.Message is not null) _output.WriteLine($"  message: {result.Message}");
@@ -107,7 +107,7 @@ public class SmokeTest
 
         foreach (var (label, src) in snippets)
         {
-            var runner = new Test262Runner(root, TimeSpan.FromSeconds(15));
+            var runner = new Test262Runner(root, TimeSpan.FromSeconds(15), useNonCollectibleLoad: true);
             runner.RunOne(prior, Test262ExecutionMode.Interpreted);
             var tmp = Path.GetTempFileName() + ".js";
             File.WriteAllText(tmp, src);
@@ -134,7 +134,7 @@ public class SmokeTest
         var src = "var re = /x/iy; re.constructor = function() {}; re.constructor[Symbol.species] = function() { return /[db]/y; }; var r = RegExp.prototype[Symbol.split].call(re, 'abcde'); console.log(r);";
         var tmp = Path.GetTempFileName() + ".js";
         File.WriteAllText(tmp, src);
-        var runner = new Test262Runner(root, TimeSpan.FromSeconds(15));
+        var runner = new Test262Runner(root, TimeSpan.FromSeconds(15), useNonCollectibleLoad: true);
         var result = runner.RunOne(tmp, Test262ExecutionMode.Interpreted);
         _output.WriteLine($"outcome: {result.Outcome}");
         if (result.Message is not null) _output.WriteLine($"message: {result.Message}");
@@ -154,7 +154,7 @@ public class SmokeTest
         if (root is null) return;
         var path = Path.Combine(Test262Paths.TestDir(root),
             "built-ins", "RegExp", "prototype", "Symbol.split", "species-ctor-species-get-err.js");
-        var runner = new Test262Runner(root, TimeSpan.FromSeconds(15));
+        var runner = new Test262Runner(root, TimeSpan.FromSeconds(15), useNonCollectibleLoad: true);
         var result = runner.RunOne(path, Test262ExecutionMode.Interpreted);
         _output.WriteLine($"{result.Outcome}: {result.Message}");
     }
@@ -172,7 +172,7 @@ public class SmokeTest
         };
         foreach (var path in paths)
         {
-            var runner = new Test262Runner(root, TimeSpan.FromSeconds(15));
+            var runner = new Test262Runner(root, TimeSpan.FromSeconds(15), useNonCollectibleLoad: true);
             var result = runner.RunOne(path, Test262ExecutionMode.Interpreted);
             _output.WriteLine($"{Path.GetFileName(path)} → {result.Outcome}: {result.Message}");
         }
@@ -194,7 +194,7 @@ public class SmokeTest
         };
         foreach (var p in paths)
         {
-            var runner = new Test262Runner(root, TimeSpan.FromSeconds(15));
+            var runner = new Test262Runner(root, TimeSpan.FromSeconds(15), useNonCollectibleLoad: true);
             var result = runner.RunOne(p, Test262ExecutionMode.Compiled);
             _output.WriteLine($"{Path.GetFileName(Path.GetDirectoryName(p))}/{Path.GetFileName(p)} → {result.Outcome}: {result.Message}");
         }
@@ -216,7 +216,7 @@ public class SmokeTest
         };
         foreach (var p in paths)
         {
-            var runner = new Test262Runner(root, TimeSpan.FromSeconds(15));
+            var runner = new Test262Runner(root, TimeSpan.FromSeconds(15), useNonCollectibleLoad: true);
             var result = runner.RunOne(p, Test262ExecutionMode.Compiled);
             _output.WriteLine($"{Path.GetFileName(Path.GetDirectoryName(p))}/{Path.GetFileName(p)} → {result.Outcome}: {result.Message}");
         }
@@ -237,7 +237,7 @@ public class SmokeTest
         };
         foreach (var p in paths)
         {
-            var runner = new Test262Runner(root, TimeSpan.FromSeconds(15));
+            var runner = new Test262Runner(root, TimeSpan.FromSeconds(15), useNonCollectibleLoad: true);
             var result = runner.RunOne(p, Test262ExecutionMode.Compiled);
             _output.WriteLine($"{Path.GetFileName(Path.GetDirectoryName(p))}/{Path.GetFileName(p)} → {result.Outcome}: {result.Message}");
         }
@@ -250,7 +250,7 @@ public class SmokeTest
         if (root is null) return;
         var path = Path.Combine(Test262Paths.TestDir(root),
             "built-ins", "RegExp", "prototype", "Symbol.replace", "coerce-global.js");
-        var runner = new Test262Runner(root, TimeSpan.FromSeconds(15));
+        var runner = new Test262Runner(root, TimeSpan.FromSeconds(15), useNonCollectibleLoad: true);
         var result = runner.RunOne(path, Test262ExecutionMode.Interpreted);
         _output.WriteLine($"{result.Outcome}: {result.Message}");
     }
@@ -264,7 +264,7 @@ public class SmokeTest
         foreach (var t in tests)
         {
             var path = Path.Combine(Test262Paths.TestDir(root), "built-ins", "RegExp", "prototype", "exec", t);
-            var runner = new Test262Runner(root, TimeSpan.FromSeconds(15));
+            var runner = new Test262Runner(root, TimeSpan.FromSeconds(15), useNonCollectibleLoad: true);
             var result = runner.RunOne(path, Test262ExecutionMode.Interpreted);
             _output.WriteLine($"{t} → {result.Outcome}: {result.Message}");
         }
@@ -338,7 +338,7 @@ public class SmokeTest
             "test/built-ins/Promise/allSettled/ctx-non-object.js",
             "test/built-ins/Promise/any/ctx-non-object.js",
         };
-        var runner = new Test262Runner(root, TimeSpan.FromSeconds(15));
+        var runner = new Test262Runner(root, TimeSpan.FromSeconds(15), useNonCollectibleLoad: true);
         int pass = 0, fail = 0;
         foreach (var t in tests)
         {
@@ -373,7 +373,7 @@ public class SmokeTest
             .Where(p => p.Contains("Object/getOwnPropertyDescriptor/"))
             .ToList();
         _output.WriteLine($"checking {allFails.Count} gOPD failing tests");
-        var runner = new Test262Runner(root, TimeSpan.FromSeconds(15));
+        var runner = new Test262Runner(root, TimeSpan.FromSeconds(15), useNonCollectibleLoad: true);
         int pass = 0, stillFail = 0;
         foreach (var rel in allFails)
         {
@@ -423,7 +423,7 @@ public class SmokeTest
         // Sample every 20th to keep this fast (~50-100 tests, ~30s).
         var sample = allPasses.Where((_, i) => i % 20 == 0).ToList();
         _output.WriteLine($"sampling {sample.Count} of {allPasses.Count} previously-passing tests");
-        var runner = new Test262Runner(root, TimeSpan.FromSeconds(15));
+        var runner = new Test262Runner(root, TimeSpan.FromSeconds(15), useNonCollectibleLoad: true);
         int pass = 0, fail = 0;
         var regressions = new List<string>();
         foreach (var rel in sample)
@@ -489,7 +489,7 @@ public class SmokeTest
             .ToList();
         _output.WriteLine($"checking {failing.Count} baseline-failing tests across touched clusters");
 
-        var runner = new Test262Runner(root, TimeSpan.FromSeconds(15));
+        var runner = new Test262Runner(root, TimeSpan.FromSeconds(15), useNonCollectibleLoad: true);
         int nowPass = 0, stillFail = 0;
         var newPassesByCluster = new Dictionary<string, int>();
         foreach (var rel in failing)
@@ -576,7 +576,7 @@ public class SmokeTest
         _output.WriteLine($"checking {failing.Count} baseline-failing tests");
         if (failing.Count == 0) return;
 
-        var runner = new Test262Runner(root, TimeSpan.FromSeconds(15));
+        var runner = new Test262Runner(root, TimeSpan.FromSeconds(15), useNonCollectibleLoad: true);
         int nowPass = 0, stillFail = 0;
         var byCluster = new Dictionary<string, int>();
         foreach (var rel in failing)
@@ -620,7 +620,7 @@ public class SmokeTest
             "test/built-ins/String/prototype/split/separator-null.js",
         };
         var sb = new System.Text.StringBuilder();
-        var runner = new Test262Runner(root, TimeSpan.FromSeconds(15));
+        var runner = new Test262Runner(root, TimeSpan.FromSeconds(15), useNonCollectibleLoad: true);
         foreach (var rel in probes)
         {
             var abs = Path.Combine(Test262Paths.TestDir(root), rel.Substring("test/".Length));
@@ -722,7 +722,7 @@ public class SmokeTest
         var files = Directory.EnumerateFiles(testDir, "*.js")
             .OrderBy(f => f, StringComparer.Ordinal)
             .ToList();
-        var runner = new Test262Runner(root, TimeSpan.FromSeconds(15));
+        var runner = new Test262Runner(root, TimeSpan.FromSeconds(15), useNonCollectibleLoad: true);
         var failures = new List<string>();
         foreach (var f in files)
         {
@@ -807,7 +807,7 @@ public class SmokeTest
         if (!File.Exists(testPath)) return;
 
         var skip = new HashSet<string>(StringComparer.Ordinal);
-        var runner = new Test262Runner(root, TimeSpan.FromSeconds(5), skip);
+        var runner = new Test262Runner(root, TimeSpan.FromSeconds(5), skip, useNonCollectibleLoad: true);
 
         // Warmup so JIT + filesystem caches are hot.
         for (int i = 0; i < 3; i++)
@@ -841,7 +841,12 @@ public class SmokeTest
     /// the steady-state compile + load + invoke path rather than outliers.
     /// Sequential single-threaded so phase ratios are clean (no contention).
     /// </summary>
-    [Fact]
+    // Diagnostic/profiling only. The "collectible ALC" arm intentionally drives
+    // the in-process collectible-ALC load → JIT → Unload churn that crashes the
+    // test host with a fatal CLR error (0x80131506) at volume — see issue #964.
+    // It is therefore skipped in normal runs; un-skip to profile the two load
+    // modes against each other in isolation.
+    [Fact(Skip = "diagnostic/profiling only — collectible-ALC arm crashes the host at volume (issue #964); un-skip to profile load modes")]
     public void Diagnostic_CompiledPhaseBreakdown()
     {
         var root = Test262Paths.TryFindRoot();
@@ -857,56 +862,54 @@ public class SmokeTest
             .ToList();
         _output.WriteLine($"profiling {paths.Count} tests from Math/");
 
-        var runner = new Test262Runner(root, TimeSpan.FromSeconds(15));
+        DumpRun("collectible ALC (current)", useNonCollectibleLoad: false);
+        DumpRun("non-collectible Assembly.Load (diagnostic)", useNonCollectibleLoad: true);
 
-        // Warm up (JIT, file caches, harness cache) so phase 1 isn't full of
-        // cold-start cost.
-        for (int i = 0; i < 3; i++)
-            runner.RunOne(paths[0], Test262ExecutionMode.Compiled);
-
-        DumpRun("collectible ALC (current)", false);
-        DumpRun("non-collectible Assembly.Load (diagnostic)", true);
-
-        void DumpRun(string label, bool nonCollectible)
+        void DumpRun(string label, bool useNonCollectibleLoad)
         {
-            Test262Runner.UseNonCollectibleLoad = nonCollectible;
-            try
-            {
-                CompiledPhaseStats.Reset();
-                var sw = System.Diagnostics.Stopwatch.StartNew();
-                foreach (var p in paths)
-                    runner.RunOne(p, Test262ExecutionMode.Compiled);
-                sw.Stop();
+            // The load mode is immutable per Test262Runner instance, so each arm
+            // builds its own runner rather than toggling a shared flag.
+            var runner = new Test262Runner(
+                root, TimeSpan.FromSeconds(15), useNonCollectibleLoad: useNonCollectibleLoad);
 
-                long total = CompiledPhaseStats.LexParseTicks
-                           + CompiledPhaseStats.TypeCheckTicks
-                           + CompiledPhaseStats.DeadCodeTicks
-                           + CompiledPhaseStats.ILCompileTicks
-                           + CompiledPhaseStats.SaveBytesTicks
-                           + CompiledPhaseStats.AlcLoadTicks
-                           + CompiledPhaseStats.InvokeTicks
-                           + CompiledPhaseStats.UnloadTicks
-                           + CompiledPhaseStats.PeriodicGcTicks;
-                long count = CompiledPhaseStats.Count;
-                if (count == 0) { _output.WriteLine($"--- {label}: no tests measured"); return; }
+            // Warm up (JIT, file caches, harness cache) so the measured pass
+            // isn't full of cold-start cost.
+            for (int i = 0; i < 3; i++)
+                runner.RunOne(paths[0], Test262ExecutionMode.Compiled);
 
-                _output.WriteLine($"--- {label} ---");
-                _output.WriteLine($"wall: {sw.Elapsed.TotalSeconds:F2} s   tests: {count}   wall/test: {sw.Elapsed.TotalMilliseconds / count:F2} ms");
-                _output.WriteLine($"  (total measured phase ticks: {CompiledPhaseStats.Ms(total):F1} ms)");
-                Row("LexParse",        CompiledPhaseStats.LexParseTicks, count, total);
-                Row("TypeCheck",       CompiledPhaseStats.TypeCheckTicks, count, total);
-                Row("DeadCode",        CompiledPhaseStats.DeadCodeTicks, count, total);
-                Row("ILCompile",       CompiledPhaseStats.ILCompileTicks, count, total);
-                Row("SaveBytes",       CompiledPhaseStats.SaveBytesTicks, count, total);
-                Row("AlcLoad",         CompiledPhaseStats.AlcLoadTicks, count, total);
-                Row("  AlcCtor",       CompiledPhaseStats.AlcCtorTicks, count, total);
-                Row("  AlcLoadStream", CompiledPhaseStats.AlcLoadFromStreamTicks, count, total);
-                Row("  AlcReflect",    CompiledPhaseStats.AlcReflectionTicks, count, total);
-                Row("Invoke",          CompiledPhaseStats.InvokeTicks, count, total);
-                Row("Unload",          CompiledPhaseStats.UnloadTicks, count, total);
-                Row("PeriodicGc",      CompiledPhaseStats.PeriodicGcTicks, count, total);
-            }
-            finally { Test262Runner.UseNonCollectibleLoad = false; }
+            CompiledPhaseStats.Reset();
+            var sw = System.Diagnostics.Stopwatch.StartNew();
+            foreach (var p in paths)
+                runner.RunOne(p, Test262ExecutionMode.Compiled);
+            sw.Stop();
+
+            long total = CompiledPhaseStats.LexParseTicks
+                       + CompiledPhaseStats.TypeCheckTicks
+                       + CompiledPhaseStats.DeadCodeTicks
+                       + CompiledPhaseStats.ILCompileTicks
+                       + CompiledPhaseStats.SaveBytesTicks
+                       + CompiledPhaseStats.AlcLoadTicks
+                       + CompiledPhaseStats.InvokeTicks
+                       + CompiledPhaseStats.UnloadTicks
+                       + CompiledPhaseStats.PeriodicGcTicks;
+            long count = CompiledPhaseStats.Count;
+            if (count == 0) { _output.WriteLine($"--- {label}: no tests measured"); return; }
+
+            _output.WriteLine($"--- {label} ---");
+            _output.WriteLine($"wall: {sw.Elapsed.TotalSeconds:F2} s   tests: {count}   wall/test: {sw.Elapsed.TotalMilliseconds / count:F2} ms");
+            _output.WriteLine($"  (total measured phase ticks: {CompiledPhaseStats.Ms(total):F1} ms)");
+            Row("LexParse",        CompiledPhaseStats.LexParseTicks, count, total);
+            Row("TypeCheck",       CompiledPhaseStats.TypeCheckTicks, count, total);
+            Row("DeadCode",        CompiledPhaseStats.DeadCodeTicks, count, total);
+            Row("ILCompile",       CompiledPhaseStats.ILCompileTicks, count, total);
+            Row("SaveBytes",       CompiledPhaseStats.SaveBytesTicks, count, total);
+            Row("AlcLoad",         CompiledPhaseStats.AlcLoadTicks, count, total);
+            Row("  AlcCtor",       CompiledPhaseStats.AlcCtorTicks, count, total);
+            Row("  AlcLoadStream", CompiledPhaseStats.AlcLoadFromStreamTicks, count, total);
+            Row("  AlcReflect",    CompiledPhaseStats.AlcReflectionTicks, count, total);
+            Row("Invoke",          CompiledPhaseStats.InvokeTicks, count, total);
+            Row("Unload",          CompiledPhaseStats.UnloadTicks, count, total);
+            Row("PeriodicGc",      CompiledPhaseStats.PeriodicGcTicks, count, total);
         }
 
         void Row(string name, long ticks, long count, long total)
@@ -936,7 +939,7 @@ public class SmokeTest
 
         Assert.True(File.Exists(testPath), $"Expected Test262 file at {testPath}");
 
-        var runner = new Test262Runner(root);
+        var runner = new Test262Runner(root, useNonCollectibleLoad: true);
         var result = runner.RunOne(testPath, mode);
 
         _output.WriteLine($"{mode} → {result.Outcome}");

--- a/SharpTS.Test262/Test262Runner.cs
+++ b/SharpTS.Test262/Test262Runner.cs
@@ -122,19 +122,40 @@ public sealed class Test262Runner
     /// the default (non-collectible) ALC via <see cref="Assembly.Load(byte[])"/>.
     /// Bypasses the collectibility load-time tax (~25% wall on the Math/200
     /// benchmark; LoadFromStream -15%, Invoke/JIT -71%) but leaks the assembly
-    /// for the lifetime of the process — only safe in a worker that restarts
-    /// before its working set exceeds a budget. The in-process fallback path
-    /// (when no worker DLL exists) leaves this off so dev runs don't OOM the
-    /// testhost. Diagnostic profiling code also flips it to compare modes.
+    /// for the lifetime of the process — only safe in a process that restarts
+    /// before its working set exceeds a budget, or that runs only a small,
+    /// bounded set of tests in-process.
+    /// <para>
+    /// It is also the only <em>stable</em> in-process mode: the collectible
+    /// path (false) loads + JIT-compiles + <c>Unload()</c>s a fresh ALC per
+    /// test, and that churn — under Server + Concurrent GC and the periodic
+    /// forced <c>GC.Collect()</c> — intermittently crashes the test host with
+    /// a fatal CLR error (<c>0x80131506</c>) inside the JIT/collectible-ALC
+    /// teardown path. See issue #964 and the .NET unloadability docs. The
+    /// persistent worker (<c>SharpTS.Test262.Worker</c>) and the in-process
+    /// SmokeTest diagnostics therefore set this to true; the in-process
+    /// baseline fallback (whole-subset, ~11k tests) leaves it off and relies
+    /// on collectible unload to avoid OOM (issue #109).
+    /// </para>
+    /// <para>
+    /// Per-instance (not a process-global static) so concurrently-running
+    /// xUnit collections — e.g. SmokeTest (non-collectible) and the baseline
+    /// in-process fallback (collectible) — can't clobber each other's mode.
+    /// </para>
     /// </summary>
-    public static bool UseNonCollectibleLoad = false;
+    public bool UseNonCollectibleLoad { get; }
 
-    public Test262Runner(string test262Root, TimeSpan? timeout = null, HashSet<string>? skipFeatures = null)
+    public Test262Runner(
+        string test262Root,
+        TimeSpan? timeout = null,
+        HashSet<string>? skipFeatures = null,
+        bool useNonCollectibleLoad = false)
     {
         _test262Root = test262Root;
         _assembler = new Test262HarnessAssembler(test262Root);
         _timeout = timeout ?? DefaultTimeout;
         _skipFeatures = skipFeatures ?? new HashSet<string>(StringComparer.Ordinal);
+        UseNonCollectibleLoad = useNonCollectibleLoad;
         EnsureConsoleProxyInstalled();
     }
 

--- a/SharpTS.Test262/Test262Tests.cs
+++ b/SharpTS.Test262/Test262Tests.cs
@@ -93,6 +93,12 @@ public abstract class Test262TestsBase
         else
         {
             _output.WriteLine($"[{mode}] worker DLL not found — falling back to in-process (build SharpTS.Test262.Worker for issue #109 batched mode)");
+            // Deliberately collectible (useNonCollectibleLoad: false, the default):
+            // this fallback can run the whole subset (~11k tests) in-process, so it
+            // relies on per-test ALC Unload to avoid OOM (issue #109). The crash-prone
+            // collectible path (issue #964) is the lesser evil here vs. a 28 GB testhost;
+            // build the worker to avoid both. SmokeTest, which runs only small curated
+            // lists, opts into the non-collectible path instead.
             var runner = new Test262Runner(test262Root, config.Timeout, skipFeatures);
             foreach (var (relPath, absPath) in files)
             {


### PR DESCRIPTION
## Summary

Fixes #964. The unfiltered `dotnet test SharpTS.Test262` crashed the test host with a fatal CLR error — `Internal CLR error. (0x80131506)` (`COR_E_EXECUTIONENGINE`) — **before the compiled differ ran**, so compiled-mode Test262 conformance couldn't be measured via the convenience run. `--filter ~CompiledBaseline` / `~InterpretedBaseline` completed, which made it look "combined-run-only."

## Root cause

The crash has **nothing to do with the compiled `CompiledBaseline` differ, #882, or codegen (#963)**. Both baselines run through the **subprocess worker pool**, which uses the non-collectible `Assembly.Load(byte[])` path and never `Unload()`s — a guest fault there is contained in a child process.

The **only in-process emitted-IL execution in the test host is `SmokeTest`**: its ~20 diagnostic facts each run compiled tests through a **collectible `AssemblyLoadContext`** (`load → JIT → Invoke → Unload()`), plus a periodic forced `GC.Collect()`, all under `ServerGarbageCollection` + `ConcurrentGarbageCollection`. That collectible-ALC teardown churn intermittently hits the fatal engine fault while JIT-compiling a collectible assembly's entry point.

**Proven by dump + isolation:**
- `--filter ~SmokeTest` **alone** (no baselines present) reproduces the identical crash at ~1m25s → the crash is **selection-based, not concurrency-based**.
- Dump faulting frame: `[PrestubMethodFrame] $Program.Main()` (JIT of a collectible assembly) on the `InvokeCompiledMain` `Task.Run` worker.
- `~CompiledBaseline` "completes" only because it **excludes** `SmokeTest`.

This is a **known .NET runtime fragility** around collectible-ALC unload under JIT + concurrent GC (cf. [dotnet/runtime#34838](https://github.com/dotnet/runtime/issues/34838), [#40547](https://github.com/dotnet/runtime/issues/40547), [#45285](https://github.com/dotnet/runtime/issues/45285); MS Learn unloadability docs note unload is "cooperative," the JIT can hold hidden refs, and R2R is ignored → everything JITs). It is **not a SharpTS logic bug** — the same emitted IL runs cleanly in the workers and in standalone DLLs.

## Fix

- `Test262Runner.cs`: `UseNonCollectibleLoad` changed from a racy mutable **process-global static** to an **immutable per-instance** property, set via a new optional ctor parameter (`useNonCollectibleLoad = false`). Per-instance so concurrently-running xUnit collections can't clobber each other's mode.
- `SmokeTest.cs`: all in-process runners opt into `useNonCollectibleLoad: true` (curated lists are small → per-process leak negligible). `Diagnostic_CompiledPhaseBreakdown` rewritten to build a per-mode runner and **skipped**, since its "collectible" arm intentionally drives the crash path.
- `Worker/Program.cs`: passes the flag via the ctor (behavior-identical — workers were already non-collectible).
- `Test262Tests.cs`: documents that the in-process baseline **fallback** (worker-not-found, ~11k tests) deliberately stays collectible to avoid the #109 28 GB OOM.

## Validation

| Run | Before | After |
|---|---|---|
| `--filter ~SmokeTest` | crash @ ~1m25s | **20 pass / 4 skip**, clean |
| Full unfiltered `dotnet test` | crash @ ~1m46s, differ never ran | **completes 3m17s**, no `0x80131506`, compiled differ runs `11384/11384` (`0 regressions, 8 new passes`) |

The remaining `Failed: 2` in the full run are the pre-existing **baseline-drift** assertions (interpreted 15 regressions / 49 new passes — timeout flakiness; compiled 8 new passes — the same 8 reported in #882's comment). That is separate `#882`-family staleness and is **out of scope** for this fix.