### PR TITLE
Getter-aware iterator reads, IteratorClose, and timeout-safe iteration (interpreter)

### DIFF
--- a/Execution/Interpreter.Statements.cs
+++ b/Execution/Interpreter.Statements.cs
@@ -946,90 +946,182 @@ public partial class Interpreter
             yield break;
         }
 
-        // Iterate using the iterator protocol
-        while (true)
+        // Iterate using the iterator protocol. The surrounding try/finally
+        // implements ECMA-262 7.4.6 IteratorClose: when iteration is abandoned
+        // before the iterator reports done — a for-of break/throw, or a spread/
+        // Array.from element callback throwing (the C# enumerator is disposed on
+        // any early foreach/.ToList() exit) — invoke the iterator's return() so
+        // it can clean up. `iteratorDone` suppresses the close on normal
+        // exhaustion (a completed iterator must not be re-closed). yield is
+        // legal here because the try has only a finally, no catch.
+        bool iteratorDone = false;
+        try
         {
-            // Get the next() method
-            object? nextMethod = null;
-            if (iterator is SharpTSObject iterObj)
+            while (true)
             {
-                nextMethod = iterObj.GetProperty("next");
-            }
-            else if (iterator is SharpTSInstance iterInst)
-            {
-                nextMethod = iterInst.GetRawField("next");
+                // Honor the VM timeout token. A custom iterator whose next() never
+                // reports done — or whose done/value getters loop — would otherwise
+                // spin this thread forever, past the timeout. Under the Test262
+                // harness the timed-out test's worker thread is a background thread
+                // that keeps running after the runner returns Timeout, leaking a
+                // CPU-pegged orphan thread for the rest of the process's life. The
+                // accumulating orphans starve later tests and turn the interpreted
+                // baseline non-deterministic under load. Checking here unwinds the
+                // enumerator (it is consumed via .ToList()/foreach by spread,
+                // Array.from, yield*, etc.) so the thread actually exits.
+                if (_vmTimeoutToken.IsCancellationRequested)
+                    throw new ThrowException(new SharpTSError("Script execution timed out."));
+
+                // Get the next() method
+                object? nextMethod = null;
+                if (iterator is SharpTSObject iterObj)
+                {
+                    nextMethod = iterObj.GetProperty("next");
+                }
+                else if (iterator is SharpTSInstance iterInst)
+                {
+                    nextMethod = iterInst.GetRawField("next");
+                    if (nextMethod == null)
+                    {
+                        // Try getting a method from the class
+                        var tok = new Token(TokenType.IDENTIFIER, "next", null, 0);
+                        try { nextMethod = iterInst.Get(tok); } catch { }
+                    }
+                }
+
                 if (nextMethod == null)
                 {
-                    // Try getting a method from the class
-                    var tok = new Token(TokenType.IDENTIFIER, "next", null, 0);
-                    try { nextMethod = iterInst.Get(tok); } catch { }
+                    throw new InterpreterException("Iterator must have a next() method.");
                 }
-            }
 
-            if (nextMethod == null)
-            {
-                throw new InterpreterException("Iterator must have a next() method.");
-            }
-
-            // Bind next() to the iterator object so 'this' works correctly
-            if (nextMethod is SharpTSArrowFunction arrowFn)
-            {
-                nextMethod = arrowFn.Bind(iterator!);
-            }
-            else if (nextMethod is SharpTSFunction fn && iterator is SharpTSInstance inst)
-            {
-                nextMethod = fn.Bind(inst);
-            }
-
-            // Call next()
-            object? result;
-            if (nextMethod is ISharpTSCallable nextCallable)
-            {
-                result = nextCallable.Call(this, []);
-            }
-            else if (nextMethod is SharpTSFunction nextFn)
-            {
-                result = nextFn.Call(this, []);
-            }
-            else
-            {
-                throw new InterpreterException("Iterator.next must be a function.");
-            }
-
-            // Get done and value from result
-            bool done = false;
-            object? value = null;
-
-            if (result is SharpTSObject resultObj)
-            {
-                var doneVal = resultObj.GetProperty("done");
-                done = IsTruthy(doneVal);
-                value = resultObj.GetProperty("value");
-            }
-            else if (result is SharpTSInstance resultInst)
-            {
-                var doneTok = new Token(TokenType.IDENTIFIER, "done", null, 0);
-                var valueTok = new Token(TokenType.IDENTIFIER, "value", null, 0);
-                try
+                // Bind next() to the iterator object so 'this' works correctly
+                if (nextMethod is SharpTSArrowFunction arrowFn)
                 {
-                    done = IsTruthy(resultInst.Get(doneTok));
-                    value = resultInst.Get(valueTok);
+                    nextMethod = arrowFn.Bind(iterator!);
                 }
-                catch
+                else if (nextMethod is SharpTSFunction fn && iterator is SharpTSInstance inst)
                 {
-                    // Fall back to field access
-                    done = IsTruthy(resultInst.GetRawField("done"));
-                    value = resultInst.GetRawField("value");
+                    nextMethod = fn.Bind(inst);
                 }
-            }
 
-            if (done)
-            {
-                yield break;
-            }
+                // Call next()
+                object? result;
+                if (nextMethod is ISharpTSCallable nextCallable)
+                {
+                    result = nextCallable.Call(this, []);
+                }
+                else if (nextMethod is SharpTSFunction nextFn)
+                {
+                    result = nextFn.Call(this, []);
+                }
+                else
+                {
+                    throw new InterpreterException("Iterator.next must be a function.");
+                }
 
-            yield return value;
+                // Get done and value from result
+                bool done = false;
+                object? value = null;
+
+                if (result is SharpTSObject resultObj)
+                {
+                    // ECMA-262 7.4.5 IteratorComplete / 7.4.4 IteratorValue read
+                    // `done` then `value` via Get(), which invokes accessor getters
+                    // and walks the prototype chain. `resultObj.GetProperty` reads
+                    // only own data fields, so a result with a `get done()`/
+                    // `get value()` accessor (e.g. Test262's poisoned-iterator
+                    // tests: `Object.defineProperty(r, 'value', { get() { throw } })`)
+                    // never fired the getter — `done` stayed undefined/falsy and the
+                    // loop spun forever instead of surfacing the throw. Read `value`
+                    // only when not done, matching IteratorStep (don't invoke the
+                    // value getter once the iterator has completed).
+                    done = IsTruthy(EvaluateGetOnRecord(resultObj, "done"));
+                    value = done ? null : EvaluateGetOnRecord(resultObj, "value");
+                }
+                else if (result is SharpTSInstance resultInst)
+                {
+                    var doneTok = new Token(TokenType.IDENTIFIER, "done", null, 0);
+                    var valueTok = new Token(TokenType.IDENTIFIER, "value", null, 0);
+                    try
+                    {
+                        done = IsTruthy(resultInst.Get(doneTok));
+                        value = resultInst.Get(valueTok);
+                    }
+                    catch
+                    {
+                        // Fall back to field access
+                        done = IsTruthy(resultInst.GetRawField("done"));
+                        value = resultInst.GetRawField("value");
+                    }
+                }
+
+                if (done)
+                {
+                    iteratorDone = true;
+                    yield break;
+                }
+
+                yield return value;
+            }
         }
+        finally
+        {
+            // IteratorClose: only when the consumer abandoned us early (see above).
+            if (!iteratorDone)
+                TryCallIteratorReturn(iterator);
+        }
+    }
+
+    /// <summary>
+    /// ECMA-262 7.4.6 IteratorClose: invoke an iterator's <c>return()</c> method
+    /// when iteration is abandoned before the iterator reports done (a for-of
+    /// break/throw, or a spread / <c>Array.from(items, mapFn)</c> element callback
+    /// throwing). Best-effort: a missing/undefined <c>return</c> is a no-op, and any
+    /// abrupt completion from <c>return()</c> itself is swallowed — this runs inside
+    /// a <c>finally</c> during exception unwind, so letting <c>return()</c> throw
+    /// would mask the original completion (which is what the spec discards when the
+    /// triggering completion is itself a throw).
+    /// </summary>
+    private void TryCallIteratorReturn(object? iterator)
+    {
+        object? returnMethod = iterator switch
+        {
+            // Get(iterator, "return") — getter-aware, walks the prototype chain.
+            SharpTSObject iterObj => EvaluateGetOnRecord(iterObj, "return"),
+            SharpTSInstance iterInst => TryGetInstanceMember(iterInst, "return"),
+            _ => null,
+        };
+        if (returnMethod is null or SharpTSUndefined) return;
+
+        try
+        {
+            if (returnMethod is SharpTSArrowFunction arrowFn)
+                returnMethod = arrowFn.Bind(iterator!);
+            else if (returnMethod is SharpTSFunction fn && iterator is SharpTSInstance inst)
+                returnMethod = fn.Bind(inst);
+
+            // SharpTSFunction also implements ISharpTSCallable, so this covers both.
+            if (returnMethod is ISharpTSCallable callable)
+                callable.Call(this, []);
+        }
+        catch
+        {
+            // Swallow — see remarks. IteratorClose must not let return()'s failure
+            // replace the completion that triggered it.
+        }
+    }
+
+    /// <summary>
+    /// Reads a member from a class instance the way the iterator protocol does:
+    /// raw field first, then a declared method via the class chain (Get throws
+    /// when absent, so it is guarded). Returns null when the member is absent.
+    /// </summary>
+    private object? TryGetInstanceMember(SharpTSInstance instance, string name)
+    {
+        var field = instance.GetRawField(name);
+        if (field != null) return field;
+        var tok = new Token(TokenType.IDENTIFIER, name, null, 0);
+        try { return instance.Get(tok); } catch { return null; }
     }
 
     /// <summary>

--- a/Runtime/BuiltIns/ArrayStaticBuiltIns.cs
+++ b/Runtime/BuiltIns/ArrayStaticBuiltIns.cs
@@ -40,23 +40,39 @@ public static class ArrayStaticBuiltIns
                 // ECMA-262 23.1.2.1: prefer the iterator protocol; a source without a usable
                 // iterator (e.g. an array-like { length: n }) is read via its length +
                 // indexed elements rather than throwing "not iterable".
-                var elements = interpreter.IsIterableSource(iterable)
-                    ? interpreter.GetIterableElements(iterable).ToList()
-                    : interpreter.ReadArrayLikeElements(iterable);
+                bool isIterable = interpreter.IsIterableSource(iterable);
 
                 if (mapFn != null)
                 {
+                    // Apply mapfn DURING iteration, not after materializing the
+                    // whole source (ECMA-262 23.1.2.1 step 6.g: map each element as
+                    // it is produced). For an iterator this is observable two ways:
+                    // an infinite iterator whose mapfn throws on the first element
+                    // must surface that throw immediately (materialize-first would
+                    // spin forever); and the throw must trigger IteratorClose. The
+                    // lazy `foreach` here gives both — when mapfn throws, the C#
+                    // enumerator over GetIterableElements is disposed, which runs
+                    // EnumerateWithIteratorProtocol's finally → the iterator's
+                    // return(). Array-likes (ReadArrayLikeElements) have no iterator
+                    // to close, matching the spec.
                     var result = new List<object?>();
                     var callbackArgs = new List<object?>(2) { null, null };
-                    for (int i = 0; i < elements.Count; i++)
+                    var source = isIterable
+                        ? interpreter.GetIterableElements(iterable)
+                        : interpreter.ReadArrayLikeElements(iterable);
+                    int i = 0;
+                    foreach (var element in source)
                     {
-                        callbackArgs[0] = elements[i];
-                        callbackArgs[1] = (double)i;
+                        callbackArgs[0] = element;
+                        callbackArgs[1] = (double)i++;
                         result.Add(mapFn.Call(interpreter, callbackArgs));
                     }
                     return RuntimeValue.FromObject(new SharpTSArray(result));
                 }
 
+                var elements = isIterable
+                    ? interpreter.GetIterableElements(iterable).ToList()
+                    : interpreter.ReadArrayLikeElements(iterable);
                 return RuntimeValue.FromObject(new SharpTSArray(elements));
             }),
             "of" => BuiltInMethod.CreateV2("of", 0, int.MaxValue, static (_, _, args) =>

--- a/SharpTS.Test262/baselines/interpreted.txt
+++ b/SharpTS.Test262/baselines/interpreted.txt
@@ -52,7 +52,7 @@ test/built-ins/Array/from/calling-from-valid-1-onlyStrict.js Fail
 test/built-ins/Array/from/calling-from-valid-2.js RuntimeError
 test/built-ins/Array/from/elements-added-after.js Pass
 test/built-ins/Array/from/elements-deleted-after.js RuntimeError
-test/built-ins/Array/from/elements-updated-after.js Fail
+test/built-ins/Array/from/elements-updated-after.js Pass
 test/built-ins/Array/from/from-array.js Pass
 test/built-ins/Array/from/from-string.js Pass
 test/built-ins/Array/from/get-iter-method-err.js Fail
@@ -62,9 +62,9 @@ test/built-ins/Array/from/iter-adv-err.js Pass
 test/built-ins/Array/from/iter-cstm-ctor-err.js Fail
 test/built-ins/Array/from/iter-cstm-ctor.js Fail
 test/built-ins/Array/from/iter-get-iter-err.js Pass
-test/built-ins/Array/from/iter-get-iter-val-err.js Timeout
+test/built-ins/Array/from/iter-get-iter-val-err.js Pass
 test/built-ins/Array/from/iter-map-fn-args.js Pass
-test/built-ins/Array/from/iter-map-fn-err.js Timeout
+test/built-ins/Array/from/iter-map-fn-err.js Pass
 test/built-ins/Array/from/iter-map-fn-return.js Pass
 test/built-ins/Array/from/iter-map-fn-this-arg.js RuntimeError
 test/built-ins/Array/from/iter-map-fn-this-non-strict.js Pass
@@ -6279,7 +6279,7 @@ test/built-ins/Object/fromEntries/iterator-closed-for-throwing-entry-key-accesso
 test/built-ins/Object/fromEntries/iterator-closed-for-throwing-entry-key-tostring.js Fail
 test/built-ins/Object/fromEntries/iterator-closed-for-throwing-entry-value-accessor.js Fail
 test/built-ins/Object/fromEntries/iterator-not-closed-for-next-returning-non-object.js Fail
-test/built-ins/Object/fromEntries/iterator-not-closed-for-throwing-done-accessor.js Fail
+test/built-ins/Object/fromEntries/iterator-not-closed-for-throwing-done-accessor.js Pass
 test/built-ins/Object/fromEntries/iterator-not-closed-for-throwing-next.js Pass
 test/built-ins/Object/fromEntries/iterator-not-closed-for-uncallable-next.js Fail
 test/built-ins/Object/fromEntries/key-order.js Pass
@@ -11259,7 +11259,7 @@ test/language/expressions/call/spread-err-mult-err-iter-get-value.js Fail
 test/language/expressions/call/spread-err-mult-err-itr-get-call.js Pass
 test/language/expressions/call/spread-err-mult-err-itr-get-get.js Fail
 test/language/expressions/call/spread-err-mult-err-itr-step.js Pass
-test/language/expressions/call/spread-err-mult-err-itr-value.js Timeout
+test/language/expressions/call/spread-err-mult-err-itr-value.js Pass
 test/language/expressions/call/spread-err-mult-err-obj-unresolvable.js Fail
 test/language/expressions/call/spread-err-mult-err-unresolvable.js Fail
 test/language/expressions/call/spread-err-sngl-err-expr-throws.js Pass
@@ -11267,7 +11267,7 @@ test/language/expressions/call/spread-err-sngl-err-itr-get-call.js Pass
 test/language/expressions/call/spread-err-sngl-err-itr-get-get.js Fail
 test/language/expressions/call/spread-err-sngl-err-itr-get-value.js Fail
 test/language/expressions/call/spread-err-sngl-err-itr-step.js Pass
-test/language/expressions/call/spread-err-sngl-err-itr-value.js Timeout
+test/language/expressions/call/spread-err-sngl-err-itr-value.js Pass
 test/language/expressions/call/spread-err-sngl-err-obj-unresolvable.js Fail
 test/language/expressions/call/spread-err-sngl-err-unresolvable.js Fail
 test/language/expressions/call/spread-mult-empty.js Pass

--- a/SharpTS.Tests/SharedTests/IteratorProtocolTests.cs
+++ b/SharpTS.Tests/SharedTests/IteratorProtocolTests.cs
@@ -928,4 +928,105 @@ public class IteratorProtocolTests
     }
 
     #endregion
+
+    #region Iterator-result fields read via Get (accessor getters)
+
+    // Regression guard for the iterator-protocol fix in
+    // Interpreter.EnumerateWithIteratorProtocol. ECMA-262 7.4.4/7.4.5
+    // (IteratorValue/IteratorComplete) read the result's `value`/`done` through
+    // Get(), which invokes accessor getters and walks the prototype chain. The
+    // interpreter previously read them with a raw field accessor that skipped
+    // `_getters`, so a result defining `value`/`done` as an accessor behaved
+    // wrongly — and a *throwing* `value` getter (the shape in Test262's
+    // Array/from/iter-get-iter-val-err and call/spread-err-*-itr-value, where
+    // `done` is absent → falsy) made the loop spin forever (15s VM timeout),
+    // leaking a CPU-pegged orphan thread. The bounded Test262 baseline guards
+    // the throwing/non-terminating shapes (a unit-test reproduction of those
+    // would hang the suite if the fix regressed); this terminating case pins
+    // the same code path safely: a `value` accessor with a data-property `done`.
+    // Interpreter-only — compiled mode emits its own iterator IL.
+    [Fact]
+    public void CustomIterator_ValueDefinedAsAccessor_InvokesGetter()
+    {
+        var source = """
+            let i = 0;
+            const iterable: any = {
+                [Symbol.iterator]() {
+                    return {
+                        next() {
+                            i = i + 1;
+                            const r: any = { done: i > 3 };
+                            Object.defineProperty(r, "value", { get() { return i * 10; } });
+                            return r;
+                        }
+                    };
+                }
+            };
+            const out: string[] = [];
+            for (const x of iterable) { out.push(String(x)); }
+            console.log(out.join(","));
+            """;
+
+        // Pre-fix: the `value` accessor was never invoked → "undefined,undefined,undefined".
+        var output = TestHarness.Run(source, ExecutionMode.Interpreted);
+        Assert.Equal("10,20,30\n", output);
+    }
+
+    // IteratorClose (ECMA-262 7.4.6): for-of abandoned early (break) must invoke
+    // the iterator's return(). Uses an infinite iterator + break so it terminates
+    // either way (pre-fix it terminated but never closed → close=0).
+    // Interpreter-only — compiled mode emits its own iteration IL.
+    [Fact]
+    public void ForOf_BreakOverCustomIterator_CallsReturn()
+    {
+        var source = """
+            let closed = 0;
+            const iter: any = {
+                [Symbol.iterator]() {
+                    let i = 0;
+                    return {
+                        next() { i = i + 1; return { value: i, done: false }; },
+                        return() { closed = closed + 1; return {}; }
+                    };
+                }
+            };
+            for (const x of iter) { if (x >= 2) break; }
+            console.log("closed=" + closed);
+            """;
+
+        var output = TestHarness.Run(source, ExecutionMode.Interpreted);
+        Assert.Equal("closed=1\n", output);
+    }
+
+    // Array.from(items, mapFn): mapfn is applied DURING iteration, and a throwing
+    // mapfn triggers IteratorClose. Finite iterator so it terminates regardless of
+    // the fix (pre-fix the throw still surfaced after materializing, but return()
+    // was never called → close=0). Interpreter-only.
+    [Fact]
+    public void ArrayFrom_MapFnThrows_AppliedDuringIterationAndClosesIterator()
+    {
+        var source = """
+            let closed = 0;
+            let calls = 0;
+            const iterable: any = {
+                [Symbol.iterator]() {
+                    let i = 0;
+                    return {
+                        next() { i = i + 1; return i <= 3 ? { value: i, done: false } : { value: undefined, done: true }; },
+                        return() { closed = closed + 1; return {}; }
+                    };
+                }
+            };
+            let caught = "none";
+            try {
+                Array.from(iterable, (v: any) => { calls = calls + 1; if (v === 2) throw new Error("stop"); return v; });
+            } catch (e: any) { caught = e.message; }
+            console.log(caught + " calls=" + calls + " closed=" + closed);
+            """;
+
+        var output = TestHarness.Run(source, ExecutionMode.Interpreted);
+        Assert.Equal("stop calls=2 closed=1\n", output);
+    }
+
+    #endregion
 }


### PR DESCRIPTION
## Background

Started as an investigation into the long-\"unexplained\" interpreted Test262 baseline flake. **Finding: the baseline is fully deterministic in isolation** — 7 consecutive runs (default 6 workers + oversubscribed 24 workers on 12 cores) are byte-identical to each other and to the committed baseline. The per-realm work (#981) already removed the cross-worker state race; that was never this flake.

The flake is **load-induced timeout flips**: workers are long-lived subprocesses pulling from a shared queue (non-deterministic test→worker assignment), and under heavy concurrent machine load tests near the 15s timeout flip Pass↔Timeout depending on scheduling. The amplifier was a real interpreter bug (below): timed-out infinite-loop tests leaked CPU-pegged orphan threads that accumulated and starved later tests.

## Changes (interpreter-only — compiled mode emits its own iterator IL)

`Interpreter.EnumerateWithIteratorProtocol` had three gaps, all fixed here:

1. **Getter-aware `done`/`value` reads.** It read the iterator result's `done`/`value` via a raw field accessor that bypassed accessor getters (`_getters`). A result with a throwing `value`/`done` accessor (Test262 poisoned-iterator tests) never fired the getter, so `done` stayed falsy and the loop spun forever. Now reads via `Get()` (getter-aware, prototype-walking), reading `value` only when not done (ECMA-262 §7.4.4/§7.4.5).

2. **Timeout-safe iteration.** The `while(true)` never checked the VM timeout token, so a non-terminating iterator under the Test262 harness left a background (orphan) thread spinning at 100% CPU after the runner returned Timeout. The accumulating orphans were the flake amplifier. Now checks `_vmTimeoutToken` each step and unwinds the enumerator so the thread exits. (No-op in the CLI, where the token is non-cancellable.)

3. **IteratorClose (§7.4.6).** The loop is wrapped in `try/finally` so an abandoned iteration — `for-of` break/throw, or a spread / `Array.from` element callback throwing — invokes the iterator's `return()`. An `iteratorDone` flag suppresses the close on normal exhaustion. Generalizes to all iterator consumers (`for-of`, spread, `yield*`, destructuring).

`Array.from(items, mapFn)` (`ArrayStaticBuiltIns`) now applies `mapFn` **during** iteration (lazy `foreach`) instead of materializing the whole source via `.ToList()` first, so a throwing `mapFn` surfaces immediately (no infinite-iterator hang), triggers IteratorClose, and observes mid-iteration mutations (ECMA-262 §23.1.2.1 step 6.g).

## Results

Test262 interpreted baseline: **+6, 0 regressions**
- `Array/from/iter-get-iter-val-err.js`: Timeout → Pass
- `Array/from/iter-map-fn-err.js`: Timeout → Pass
- `call/spread-err-mult-err-itr-value.js`: Timeout → Pass
- `call/spread-err-sngl-err-itr-value.js`: Timeout → Pass
- `Object/fromEntries/iterator-not-closed-for-throwing-done-accessor.js`: Fail → Pass
- `Array/from/elements-updated-after.js`: Fail → Pass

Full xUnit suite **14410 / 0**. Added 3 interpreter-only iterator regression tests (all use finite/breakable iterators so they terminate regardless of the fix — no hang risk; the throwing/non-terminating shapes are guarded by the bounded Test262 baseline). Compiled baseline untouched.

## Notes / follow-ups
- The flake itself is load-sensitive and not fully eliminated by code (it's inherent to timeout + non-deterministic scheduling), but this removes its main self-inflicted amplifier (orphan threads).
- The large line count in `Interpreter.Statements.cs` is mostly re-indentation for the `try/finally`; the logic change is ~40 lines.