### PR TITLE
Adopt resolve-with-thenable on the event loop (fix async-ordering flake)

### DIFF
--- a/Execution/Interpreter.Expressions.cs
+++ b/Execution/Interpreter.Expressions.cs
@@ -311,15 +311,11 @@ public partial class Interpreter
         var resolve = new PromiseResolveCallback(v =>
         {
             // Flatten a promise resolution value the same way the executor
-            // resolve callback does, so `await` yields the eventual value.
+            // resolve callback does, so `await` yields the eventual value. Routed
+            // through the event loop (not the thread pool) so the loop can't exit
+            // before the adoption settles — see Interpreter.AdoptInnerPromise.
             if (v is SharpTSPromise inner)
-                inner.Task.ContinueWith(t =>
-                {
-                    if (t.IsFaulted)
-                        tcs.TrySetException(t.Exception!.InnerException ?? t.Exception);
-                    else
-                        tcs.TrySetResult(t.Result);
-                }, TaskScheduler.Default);
+                AdoptInnerPromise(inner.Task, tcs);
             else
                 tcs.TrySetResult(v);
         });

--- a/Execution/Interpreter.cs
+++ b/Execution/Interpreter.cs
@@ -746,6 +746,48 @@ public partial class Interpreter : IDisposable
     }
 
     /// <summary>
+    /// Adopts an inner promise's settled state into <paramref name="tcs"/> — the
+    /// <c>resolve(thenable)</c> / await-thenable flatten step where the resolution
+    /// value is itself a <see cref="Runtime.Types.SharpTSPromise"/>. The settle is
+    /// delivered as an event-loop callback so it (a) runs on the event-loop thread
+    /// and (b) is visible to the loop's exit check (<c>_callbackQueue</c>).
+    /// </summary>
+    /// <remarks>
+    /// The previous implementation used <c>innerTask.ContinueWith(…, TaskScheduler.Default)</c>,
+    /// which settled <paramref name="tcs"/> on a thread-pool thread with nothing on
+    /// the callback queue. When the inner task was already settled (e.g. resolving a
+    /// pending promise with an already-resolved one — Test262
+    /// <c>Promise/resolve-thenable-deferred</c>), the event loop could observe
+    /// "no active handles AND empty callback queue" and exit before the thread-pool
+    /// continuation settled the outer promise, so its <c>.then</c> reaction never
+    /// ran. Whether the loop won that race depended on scheduling, so the test
+    /// flipped Pass/Fail under machine load.
+    /// <para>
+    /// <see cref="TaskContinuationOptions.ExecuteSynchronously"/> means an
+    /// already-settled inner enqueues the settle callback inline (during
+    /// <c>resolve</c>, before the loop starts), so the loop never starts idle; a
+    /// never-settling inner enqueues nothing and the loop exits normally — matching
+    /// Node, where a pending adoption does not by itself keep the program alive.
+    /// Settling the outer task here synchronously posts any downstream <c>.then</c>
+    /// continuations onto this loop via the interpreter SynchronizationContext.
+    /// </para>
+    /// </remarks>
+    internal void AdoptInnerPromise(Task<object?> innerTask, TaskCompletionSource<object?> tcs)
+    {
+        innerTask.ContinueWith(
+            t => EnqueueCallback(() =>
+            {
+                if (t.IsFaulted)
+                    tcs.TrySetException(t.Exception!.InnerException ?? t.Exception);
+                else if (t.IsCanceled)
+                    tcs.TrySetCanceled();
+                else
+                    tcs.TrySetResult(t.Result);
+            }),
+            TaskContinuationOptions.ExecuteSynchronously);
+    }
+
+    /// <summary>
     /// Calculates the timeout until the next timer fires.
     /// Used by the event loop to efficiently wait without polling.
     /// </summary>

--- a/Runtime/Types/SharpTSPromiseClass.cs
+++ b/Runtime/Types/SharpTSPromiseClass.cs
@@ -181,16 +181,13 @@ public class SharpTSPromiseClass : SharpTSClass
                 settled = true;
             }
 
-            // Handle promise flattening - if value is a Promise, wait for it
+            // Handle promise flattening - if value is a Promise, adopt its settled
+            // state. Routed through the event loop (not the thread pool) so the loop
+            // can't exit before the adoption settles — see Interpreter.AdoptInnerPromise
+            // (fixes the resolve-with-thenable Pass/Fail flake under load).
             if (value is SharpTSPromise innerPromise)
             {
-                innerPromise.Task.ContinueWith(t =>
-                {
-                    if (t.IsFaulted)
-                        tcs.TrySetException(t.Exception!.InnerException ?? t.Exception);
-                    else
-                        tcs.TrySetResult(t.Result);
-                }, TaskScheduler.Default);
+                interpreter.AdoptInnerPromise(innerPromise.Task, tcs);
             }
             else
             {

--- a/SharpTS.Test262/baselines/interpreted.txt
+++ b/SharpTS.Test262/baselines/interpreted.txt
@@ -8058,7 +8058,7 @@ test/built-ins/Promise/resolve-poisoned-then-immed.js RuntimeError
 test/built-ins/Promise/resolve-prms-cstm-then-deferred.js RuntimeError
 test/built-ins/Promise/resolve-prms-cstm-then-immed.js RuntimeError
 test/built-ins/Promise/resolve-self.js Fail
-test/built-ins/Promise/resolve-thenable-deferred.js Fail
+test/built-ins/Promise/resolve-thenable-deferred.js Pass
 test/built-ins/Promise/resolve-thenable-immed.js Pass
 test/built-ins/Promise/resolve/S25.4.4.5_A1.1_T1.js Pass
 test/built-ins/Promise/resolve/S25.4.4.5_A2.1_T1.js Fail

--- a/SharpTS.Tests/SharedTests/PromiseMethodTests.cs
+++ b/SharpTS.Tests/SharedTests/PromiseMethodTests.cs
@@ -1143,5 +1143,61 @@ public class PromiseMethodTests
         Assert.Equal("true:raw\n", output);
     }
 
+    /// <summary>
+    /// Resolving a pending promise with another (already-settled) promise must
+    /// adopt the inner promise's value and still run the outer's <c>.then</c>
+    /// reaction (ECMA-262 resolve-with-thenable). The interpreter adopted the
+    /// inner promise on a thread-pool continuation, so the event loop could exit
+    /// before the adoption settled and the reaction was dropped — a load-sensitive
+    /// flake (Test262 Promise/resolve-thenable-deferred flipped Pass/Fail). The
+    /// adoption now runs as an event-loop callback, so the reaction always fires.
+    /// Interpreter-only — compiled mode emits its own event loop (it has the same
+    /// resolve-with-thenable gap, tracked separately).
+    /// </summary>
+    [Fact]
+    public void ResolveWithThenable_Deferred_RunsReactionWithInnerValue()
+    {
+        var mode = ExecutionMode.Interpreted;
+        var source = """
+            const value: any = { tag: "inner" };
+            let resolve: any;
+            const thenable = new Promise((r: any) => r(value));
+            const promise = new Promise((res: any) => { resolve = res; });
+            promise.then((v: any) => {
+                console.log(v === value ? "same" : "different");
+            }, () => {
+                console.log("rejected");
+            });
+            resolve(thenable);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("same\n", output);
+    }
+
+    /// <summary>
+    /// The await form of resolve-with-thenable: awaiting a promise that was
+    /// resolved with another promise yields the inner value (flattening through
+    /// the same event-loop adoption path). Interpreter-only (see above).
+    /// </summary>
+    [Fact]
+    public void ResolveWithThenable_Awaited_YieldsInnerValue()
+    {
+        var mode = ExecutionMode.Interpreted;
+        var source = """
+            async function main(): Promise<void> {
+                let resolve: any;
+                const inner = new Promise((r: any) => r(42));
+                const outer = new Promise((res: any) => { resolve = res; });
+                resolve(inner);
+                console.log(await outer);
+            }
+            main();
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("42\n", output);
+    }
+
     #endregion
 }


### PR DESCRIPTION
## Background

Follow-up to the interpreted-Test262 flake investigation. After PR #982 removed the orphan-thread amplifier, I profiled the residual flake: the suite is fast (11,303/11,385 tests <50ms, 0 genuine timeouts in isolation), and worker oversubscription alone never reproduces a flip — but under genuine full-machine CPU saturation (a 12-core burner), one test reproducibly flipped: **`Promise/resolve-thenable-deferred.js` (Fail→Pass)**. A Fail→Pass flip hard-fails the baseline gate ("new pass"), so this async-ordering non-determinism — not timeouts — is the residual run-to-run flake.

## Root cause

Resolving a promise with another promise — `resolve(thenable)`, or `await` of a promise that was resolved with a promise — adopted the inner promise via `innerTask.ContinueWith(..., TaskScheduler.Default)` (`SharpTSPromiseClass.RunExecutor` and `Interpreter.AdoptThenable`). That's a **thread-pool hop**: it settles the outer promise off the event-loop thread with nothing on the callback queue. When the inner promise is already settled (the "deferred" case: a pending promise resolved with an already-resolved one), the event loop can observe `!HasActiveHandles && _callbackQueue.Count == 0` and **exit before the adoption settles**, so the outer promise's `.then` reaction never runs. Whether the loop wins that race depends on scheduling, so the test flips Pass/Fail under load.

(The CLI happened to win the race consistently; the Test262 runner — which runs each test on a dedicated thread — lost it in isolation, which is why the test was "pinned Fail.")

## Fix (interpreter-only)

Route the adoption through the event loop via a new `Interpreter.AdoptInnerPromise`: deliver the settle as an event-loop callback using `TaskContinuationOptions.ExecuteSynchronously`. So:
- an **already-settled** inner enqueues the settle callback **inline** (during `resolve`, before the loop starts) → the loop never starts idle → deterministic;
- a **never-settling** inner enqueues nothing → the loop exits normally, matching Node (a pending adoption does not by itself keep the program alive);
- the settle always runs on the event-loop thread, and completing the outer promise synchronously posts its `.then` continuations back onto the loop.

Used by both the `new Promise` executor resolve and the `await`-thenable path. `SettleFromTask` (subclass capability adoption) already used `ExecuteSynchronously` and is unchanged.

## Validation
- `Promise/resolve-thenable-deferred.js`: **Fail → Pass**, deterministic with **and** under the 12-core burner (the condition that originally flipped it). Test262 interpreted baseline: **+1, 0 regressions**.
- Full xUnit suite **14412 / 0**.
- 2 new interpreter-only regression tests (`PromiseMethodTests.ResolveWithThenable_*`).

## Notes
- **Interpreter-only.** Compiled mode emits its own event loop and exhibits the same resolve-with-thenable gap (the new tests fail there) — a separate fix; the regression tests are scoped to the interpreter accordingly.
- Independent of PR #982 (different files); based on `main`.