### PR TITLE
feat(fs): migrate to primitive:fs + TypeScript facade (#969)

### DIFF
--- a/Compilation/Emitters/Modules/FsModuleEmitter.cs
+++ b/Compilation/Emitters/Modules/FsModuleEmitter.cs
@@ -10,7 +10,9 @@ namespace SharpTS.Compilation.Emitters.Modules;
 /// </summary>
 public sealed class FsModuleEmitter : IBuiltInModuleEmitter
 {
-    public string ModuleName => "fs";
+    // Registered under the primitive:fs key — the user-facing 'fs' specifier is
+    // served by stdlib/node/fs.ts, which imports from this primitive.
+    public string ModuleName => "primitive:fs";
 
     private static readonly string[] _exportedMembers =
     [

--- a/Compilation/Emitters/Modules/FsPromisesModuleEmitter.cs
+++ b/Compilation/Emitters/Modules/FsPromisesModuleEmitter.cs
@@ -10,7 +10,9 @@ namespace SharpTS.Compilation.Emitters.Modules;
 /// </summary>
 public sealed class FsPromisesModuleEmitter : IBuiltInModuleEmitter
 {
-    public string ModuleName => "fs/promises";
+    // Registered under the primitive:fs/promises key — the user-facing 'fs/promises'
+    // specifier is served by stdlib/node/fs/promises.ts, which imports from this primitive.
+    public string ModuleName => "primitive:fs/promises";
 
     private static readonly string[] _exportedMembers =
     [

--- a/Compilation/RuntimeEmitter.FsAsync.cs
+++ b/Compilation/RuntimeEmitter.FsAsync.cs
@@ -76,6 +76,16 @@ public partial class RuntimeEmitter
     /// Emits: Task&lt;object?&gt; FsReadFileAsync(object path, object? encoding)
     /// Calls FsReadFileSync and wraps result in Task.FromResult.
     /// </summary>
+    /// <remarks>
+    /// Deliberately synchronous-then-wrapped (not Task.Run). The #969 async proof
+    /// established that genuinely backgrounding this op (Task.Factory.StartNew) is
+    /// functionally correct and parity-clean, BUT the compiled $Promise(Task)
+    /// wrapper does not Ref the event loop for a still-pending task, so a
+    /// fire-and-forget callback/await can race program exit (flaky empty output).
+    /// Real backgrounding therefore needs event-loop ref-counting for adopted
+    /// Tasks — the interpreter's `refsEventLoopWhileInFlight` counterpart — which
+    /// is the core of #971. Until then this stays deterministic Task.FromResult.
+    /// </remarks>
     private void EmitFsReadFileAsync(TypeBuilder typeBuilder, EmittedRuntime runtime)
     {
         var method = typeBuilder.DefineMethod(

--- a/Modules/Stdlib/PrimitiveRegistry.cs
+++ b/Modules/Stdlib/PrimitiveRegistry.cs
@@ -29,6 +29,8 @@ public static class PrimitiveRegistry
         Prefix + "timers",
         Prefix + "timers/promises",
         Prefix + "readline",
+        Prefix + "fs",
+        Prefix + "fs/promises",
     };
 
     /// <summary>

--- a/Runtime/BuiltIns/Modules/BuiltInModuleRegistry.cs
+++ b/Runtime/BuiltIns/Modules/BuiltInModuleRegistry.cs
@@ -9,8 +9,8 @@ public static class BuiltInModuleRegistry
 {
     private static readonly HashSet<string> _builtInModules =
     [
-        "fs",
-        "fs/promises",
+        // "fs" — migrated to stdlib/node/fs.ts (embedded stdlib, wraps primitive:fs + primitive:fs/promises).
+        // "fs/promises" — migrated to stdlib/node/fs/promises.ts (embedded stdlib, wraps primitive:fs/promises).
         // "path" — migrated to stdlib/node/path.ts (embedded stdlib, uses primitive:process for cwd).
         // "os" — migrated to stdlib/node/os.ts (embedded stdlib, wraps primitive:os).
         // "querystring" — migrated to stdlib/node/querystring.ts (embedded stdlib).

--- a/Runtime/BuiltIns/Modules/Interpreter/BuiltInModuleValues.cs
+++ b/Runtime/BuiltIns/Modules/Interpreter/BuiltInModuleValues.cs
@@ -20,8 +20,10 @@ public static class BuiltInModuleValues
     {
         return moduleName switch
         {
-            "fs" => FsModuleInterpreter.GetExports(),
-            "fs/promises" => FsPromisesModuleInterpreter.GetExports(),
+            // "fs" — migrated to stdlib/node/fs.ts which imports from primitive:fs.
+            //   FsModuleInterpreter is reused by PrimitiveModuleValues; not routed here.
+            // "fs/promises" — migrated to stdlib/node/fs/promises.ts which imports from primitive:fs/promises.
+            //   FsPromisesModuleInterpreter is reused by PrimitiveModuleValues; not routed here.
             // "path" — migrated to stdlib/node/path.ts (pure-TS, uses primitive:process for cwd).
             // "os" — migrated to stdlib/node/os.ts which imports from primitive:os.
             //   OsModuleInterpreter is reused by PrimitiveModuleValues; not routed here.
@@ -65,8 +67,8 @@ public static class BuiltInModuleValues
     /// </summary>
     public static bool HasInterpreterSupport(string moduleName)
     {
-        return moduleName is "fs" or "fs/promises"
-            or "crypto" or "child_process" or "buffer"
+        return moduleName is
+            "crypto" or "child_process" or "buffer"
             or "zlib" or "stream" or "stream/promises" or "stream/web"
             or "http" or "worker_threads" or "dns" or "dns/promises" or "net" or "https" or "tls"
             or "dgram" or "cluster" or "vm";

--- a/Runtime/BuiltIns/Modules/Interpreter/FsModuleInterpreter.cs
+++ b/Runtime/BuiltIns/Modules/Interpreter/FsModuleInterpreter.cs
@@ -972,7 +972,13 @@ public static class FsModuleInterpreter
     /// <summary>
     /// Converts an exception to a Node.js-style error object for callbacks.
     /// </summary>
-    private static SharpTSObject CreateErrorObject(Exception ex, string syscall, string? path)
+    /// <remarks>
+    /// Shared with <see cref="FsPromisesModuleInterpreter"/>: the promise layer
+    /// rejects with this same guest object (wrapped in
+    /// <see cref="SharpTSPromiseRejectedException"/>) so the callback and promise
+    /// error paths deliver an identical <c>{ code, syscall, path, message }</c>.
+    /// </remarks>
+    internal static SharpTSObject CreateErrorObject(Exception ex, string syscall, string? path)
     {
         var code = ex is NodeError ne ? ne.Code : NodeErrorCodes.FromException(ex);
         var message = ex.Message;

--- a/Runtime/BuiltIns/Modules/Interpreter/FsPromisesModuleInterpreter.cs
+++ b/Runtime/BuiltIns/Modules/Interpreter/FsPromisesModuleInterpreter.cs
@@ -76,7 +76,7 @@ public static class FsPromisesModuleInterpreter
         }
         catch (Exception ex)
         {
-            throw CreateNodeError(ex, "open", path);
+            throw CreateRejection(ex, "open", path);
         }
     }
 
@@ -93,7 +93,7 @@ public static class FsPromisesModuleInterpreter
         }
         catch (Exception ex)
         {
-            throw CreateNodeError(ex, "open", path);
+            throw CreateRejection(ex, "open", path);
         }
     }
 
@@ -110,7 +110,7 @@ public static class FsPromisesModuleInterpreter
         }
         catch (Exception ex)
         {
-            throw CreateNodeError(ex, "open", path);
+            throw CreateRejection(ex, "open", path);
         }
     }
 
@@ -124,7 +124,7 @@ public static class FsPromisesModuleInterpreter
         }
         catch (Exception ex)
         {
-            throw CreateNodeError(ex, "stat", path);
+            throw CreateRejection(ex, "stat", path);
         }
     }
 
@@ -138,7 +138,7 @@ public static class FsPromisesModuleInterpreter
         }
         catch (Exception ex)
         {
-            throw CreateNodeError(ex, "lstat", path);
+            throw CreateRejection(ex, "lstat", path);
         }
     }
 
@@ -153,7 +153,7 @@ public static class FsPromisesModuleInterpreter
         }
         catch (Exception ex)
         {
-            throw CreateNodeError(ex, "unlink", path);
+            throw CreateRejection(ex, "unlink", path);
         }
     }
 
@@ -169,7 +169,7 @@ public static class FsPromisesModuleInterpreter
         }
         catch (Exception ex)
         {
-            throw CreateNodeError(ex, "mkdir", path);
+            throw CreateRejection(ex, "mkdir", path);
         }
     }
 
@@ -185,7 +185,7 @@ public static class FsPromisesModuleInterpreter
         }
         catch (Exception ex)
         {
-            throw CreateNodeError(ex, "rmdir", path);
+            throw CreateRejection(ex, "rmdir", path);
         }
     }
 
@@ -201,7 +201,7 @@ public static class FsPromisesModuleInterpreter
         }
         catch (Exception ex)
         {
-            throw CreateNodeError(ex, "rm", path);
+            throw CreateRejection(ex, "rm", path);
         }
     }
 
@@ -216,7 +216,7 @@ public static class FsPromisesModuleInterpreter
         }
         catch (Exception ex)
         {
-            throw CreateNodeError(ex, "readdir", path);
+            throw CreateRejection(ex, "readdir", path);
         }
     }
 
@@ -232,7 +232,7 @@ public static class FsPromisesModuleInterpreter
         }
         catch (Exception ex)
         {
-            throw CreateNodeError(ex, "rename", oldPath);
+            throw CreateRejection(ex, "rename", oldPath);
         }
     }
 
@@ -249,7 +249,7 @@ public static class FsPromisesModuleInterpreter
         }
         catch (Exception ex)
         {
-            throw CreateNodeError(ex, "copyfile", src);
+            throw CreateRejection(ex, "copyfile", src);
         }
     }
 
@@ -265,7 +265,7 @@ public static class FsPromisesModuleInterpreter
         }
         catch (Exception ex)
         {
-            throw CreateNodeError(ex, "access", path);
+            throw CreateRejection(ex, "access", path);
         }
     }
 
@@ -281,7 +281,7 @@ public static class FsPromisesModuleInterpreter
         }
         catch (Exception ex)
         {
-            throw CreateNodeError(ex, "chmod", path);
+            throw CreateRejection(ex, "chmod", path);
         }
     }
 
@@ -297,7 +297,7 @@ public static class FsPromisesModuleInterpreter
         }
         catch (Exception ex)
         {
-            throw CreateNodeError(ex, "truncate", path);
+            throw CreateRejection(ex, "truncate", path);
         }
     }
 
@@ -314,7 +314,7 @@ public static class FsPromisesModuleInterpreter
         }
         catch (Exception ex)
         {
-            throw CreateNodeError(ex, "utimes", path);
+            throw CreateRejection(ex, "utimes", path);
         }
     }
 
@@ -328,7 +328,7 @@ public static class FsPromisesModuleInterpreter
         }
         catch (Exception ex)
         {
-            throw CreateNodeError(ex, "readlink", path);
+            throw CreateRejection(ex, "readlink", path);
         }
     }
 
@@ -342,7 +342,7 @@ public static class FsPromisesModuleInterpreter
         }
         catch (Exception ex)
         {
-            throw CreateNodeError(ex, "realpath", path);
+            throw CreateRejection(ex, "realpath", path);
         }
     }
 
@@ -359,7 +359,7 @@ public static class FsPromisesModuleInterpreter
         }
         catch (Exception ex)
         {
-            throw CreateNodeError(ex, "symlink", path);
+            throw CreateRejection(ex, "symlink", path);
         }
     }
 
@@ -375,7 +375,7 @@ public static class FsPromisesModuleInterpreter
         }
         catch (Exception ex)
         {
-            throw CreateNodeError(ex, "link", newPath);
+            throw CreateRejection(ex, "link", newPath);
         }
     }
 
@@ -389,22 +389,27 @@ public static class FsPromisesModuleInterpreter
         }
         catch (Exception ex)
         {
-            throw CreateNodeError(ex, "mkdtemp", null);
+            throw CreateRejection(ex, "mkdtemp", null);
         }
     }
 
     /// <summary>
-    /// Creates a NodeError from an exception with proper error code.
+    /// Builds the rejection for a failed promise op. Rejects with a guest error
+    /// object (the same <c>{ code, syscall, path, message }</c> shape the callback
+    /// path delivers) wrapped in <see cref="SharpTSPromiseRejectedException"/> so
+    /// the interpreter's promise settling recognizes it as a guest rejection —
+    /// a raw <see cref="NodeError"/> fault would otherwise surface as a host error
+    /// and never reach <c>.then</c>/<c>.catch</c>/<c>await</c>.
     /// </summary>
-    private static NodeError CreateNodeError(Exception ex, string syscall, string? path)
+    private static SharpTSPromiseRejectedException CreateRejection(Exception ex, string syscall, string? path)
     {
-        if (ex is NodeError ne)
+        if (ex is SharpTSPromiseRejectedException rex)
         {
-            return ne;
+            return rex;
         }
 
-        var code = NodeErrorCodes.FromException(ex);
-        return new NodeError(code, ex.Message, syscall, path);
+        var error = FsModuleInterpreter.CreateErrorObject(ex, syscall, path);
+        return new SharpTSPromiseRejectedException(error);
     }
 }
 

--- a/Runtime/BuiltIns/Modules/Interpreter/PrimitiveModuleValues.cs
+++ b/Runtime/BuiltIns/Modules/Interpreter/PrimitiveModuleValues.cs
@@ -30,6 +30,8 @@ public static class PrimitiveModuleValues
             "timers" => TimersPrimitiveInterpreter.GetExports(),
             "timers/promises" => TimersPrimitiveInterpreter.GetPromisesExports(),
             "readline" => ReadlinePrimitiveInterpreter.GetExports(),
+            "fs" => FsModuleInterpreter.GetExports(),
+            "fs/promises" => FsPromisesModuleInterpreter.GetExports(),
             _ => throw new Exception($"Unknown primitive module: primitive:{primitiveName}")
         };
     }
@@ -40,6 +42,6 @@ public static class PrimitiveModuleValues
     public static bool HasInterpreterSupport(string primitiveName)
     {
         return primitiveName is "os" or "process" or "perf" or "tty" or "async_hooks"
-            or "timers" or "timers/promises" or "readline";
+            or "timers" or "timers/promises" or "readline" or "fs" or "fs/promises";
     }
 }

--- a/SharpTS.Tests/SharedTests/BuiltInModules/FsModuleTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/FsModuleTests.cs
@@ -1174,4 +1174,133 @@ public class FsModuleTests
     }
 
     #endregion
+
+    #region Callback-async parity (facade-derived; #969/#970)
+
+    // Before the primitive:fs migration the compiled emitter had no callback-async
+    // fs at all — `fs.readFile(path, cb)` did not compile. The TS facade now derives
+    // the callback forms from the promise primitives, so they run identically in
+    // both modes. These tests pin that parity.
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Fs_CallbackReadFile_ReturnsData(ExecutionMode mode)
+    {
+        var uid = Uid();
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = $$"""
+                import * as fs from 'fs';
+                import * as os from 'os';
+                const file = os.tmpdir() + '/cb_read_{{uid}}.txt';
+                fs.writeFileSync(file, 'callback-data');
+                fs.readFile(file, 'utf8', (err: any, data: any) => {
+                    console.log(err ? 'ERR' : ('DATA:' + data));
+                    fs.unlinkSync(file);
+                });
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("DATA:callback-data\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Fs_CallbackReadFile_NoEncoding_ReturnsBuffer(ExecutionMode mode)
+    {
+        var uid = Uid();
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = $$"""
+                import * as fs from 'fs';
+                import * as os from 'os';
+                const file = os.tmpdir() + '/cb_buf_{{uid}}.bin';
+                fs.writeFileSync(file, 'abc');
+                fs.readFile(file, (err: any, data: any) => {
+                    // No encoding => Buffer; toString() recovers the text.
+                    console.log(err ? 'ERR' : (data.length + ':' + data.toString()));
+                    fs.unlinkSync(file);
+                });
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("3:abc\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Fs_CallbackWriteFile_ThenReadBack(ExecutionMode mode)
+    {
+        var uid = Uid();
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = $$"""
+                import * as fs from 'fs';
+                import * as os from 'os';
+                const file = os.tmpdir() + '/cb_write_{{uid}}.txt';
+                fs.writeFile(file, 'written-via-cb', (err: any) => {
+                    if (err) { console.log('WRITE-ERR'); return; }
+                    console.log('READBACK:' + fs.readFileSync(file, 'utf8'));
+                    fs.unlinkSync(file);
+                });
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("READBACK:written-via-cb\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Fs_CallbackReadFile_MissingFile_PassesError(ExecutionMode mode)
+    {
+        var uid = Uid();
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = $$"""
+                import * as fs from 'fs';
+                import * as os from 'os';
+                const missing = os.tmpdir() + '/does_not_exist_{{uid}}.txt';
+                fs.readFile(missing, 'utf8', (err: any, data: any) => {
+                    console.log('ERR:' + (err ? 'yes' : 'no'));
+                });
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("ERR:yes\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Fs_PromisesReadFile_RoundTrips(ExecutionMode mode)
+    {
+        // fs.promises.write/readFile round-trips through await in both modes and
+        // must resolve byte-identically. (The interpreter backs these with real
+        // background I/O; the compiled path stays deterministic Task.FromResult
+        // until the #971 event-loop ref-counting lands.)
+        var uid = Uid();
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = $$"""
+                import { promises as fsp } from 'fs';
+                import * as os from 'os';
+                const file = os.tmpdir() + '/prom_{{uid}}.txt';
+                async function main() {
+                    await fsp.writeFile(file, 'promise-data');
+                    const data = await fsp.readFile(file, 'utf8');
+                    console.log('PROM:' + data);
+                    await fsp.unlink(file);
+                }
+                main();
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("PROM:promise-data\n", output);
+    }
+
+    #endregion
 }

--- a/TypeSystem/BuiltInModuleTypes.cs
+++ b/TypeSystem/BuiltInModuleTypes.cs
@@ -1013,8 +1013,10 @@ public static class BuiltInModuleTypes
             // "path" — migrated to stdlib/node/path.ts; types flow from the TS source.
             // "os" — migrated to stdlib/node/os.ts; types flow from the TS source.
             //   Primitive-layer types for primitive:os reuse GetOsModuleTypes via GetPrimitiveTypes.
-            "fs" => GetFsModuleTypes(),
-            "fs/promises" => GetFsPromisesModuleTypes(),
+            // "fs" — migrated to stdlib/node/fs.ts; types flow from the TS source.
+            //   Primitive-layer types for primitive:fs reuse GetFsModuleTypes via GetPrimitiveTypes.
+            // "fs/promises" — migrated to stdlib/node/fs/promises.ts; types flow from the TS source.
+            //   Primitive-layer types for primitive:fs/promises reuse GetFsPromisesModuleTypes via GetPrimitiveTypes.
             // "assert" — migrated to stdlib/node/assert.ts; types flow from the TS source.
             // "url" — migrated to stdlib/node/url.ts; types flow from the TS source.
             // "util" — migrated to stdlib/node/util.ts; types flow from the TS source.
@@ -1077,6 +1079,11 @@ public static class BuiltInModuleTypes
             // Readline's primitive surface is the full module surface — the TS
             // facade wraps the returned Interface and forwards calls dynamically.
             "readline" => GetReadlineModuleTypes(),
+            // Primitive fs types reuse the user-facing module type shapes — the
+            // primitive surface matches the Node surface; the TS facade re-exports
+            // the sync ops and derives the callback forms from primitive:fs/promises.
+            "fs" => GetFsModuleTypes(),
+            "fs/promises" => GetFsPromisesModuleTypes(),
             _ => null
         };
     }

--- a/stdlib/node/fs.ts
+++ b/stdlib/node/fs.ts
@@ -1,0 +1,429 @@
+// Node.js 'fs' module — SharpTS embedded stdlib implementation.
+// Target: Node.js 24.15.0. See https://nodejs.org/api/fs.html.
+//
+// Raw filesystem I/O stays in C# behind `primitive:fs` (sync ops, streams,
+// watchers, constants) and `primitive:fs/promises` (promise-based async I/O).
+// This file is the Node-shape facade:
+//   - sync APIs forward straight to `primitive:fs`;
+//   - the callback APIs (`fs.readFile(p, cb)`, …) are derived here in TS from
+//     the promise primitives, so BOTH execution modes (interpreter + compiled)
+//     get identical callback behaviour from one implementation — the compiled
+//     path previously had no callback fs at all;
+//   - `fs.promises` is assembled from the same promise primitives.
+// Divergence from Node semantics lives in the primitives, not here.
+
+import {
+    // Existence / read / write
+    existsSync as __existsSync,
+    readFileSync as __readFileSync,
+    writeFileSync as __writeFileSync,
+    appendFileSync as __appendFileSync,
+    // Delete
+    unlinkSync as __unlinkSync,
+    // Directories
+    mkdirSync as __mkdirSync,
+    rmdirSync as __rmdirSync,
+    readdirSync as __readdirSync,
+    // Metadata
+    statSync as __statSync,
+    lstatSync as __lstatSync,
+    // Move / copy
+    renameSync as __renameSync,
+    copyFileSync as __copyFileSync,
+    // Access / permissions
+    accessSync as __accessSync,
+    chmodSync as __chmodSync,
+    chownSync as __chownSync,
+    lchownSync as __lchownSync,
+    // Truncate / links / times
+    truncateSync as __truncateSync,
+    symlinkSync as __symlinkSync,
+    readlinkSync as __readlinkSync,
+    realpathSync as __realpathSync,
+    utimesSync as __utimesSync,
+    // File-descriptor APIs
+    openSync as __openSync,
+    closeSync as __closeSync,
+    readSync as __readSync,
+    writeSync as __writeSync,
+    fstatSync as __fstatSync,
+    ftruncateSync as __ftruncateSync,
+    // Directory utilities / hard links
+    mkdtempSync as __mkdtempSync,
+    opendirSync as __opendirSync,
+    linkSync as __linkSync,
+    // Stream factories
+    createReadStream as __createReadStream,
+    createWriteStream as __createWriteStream,
+    // Watch APIs
+    watch as __watch,
+    watchFile as __watchFile,
+    unwatchFile as __unwatchFile,
+    // Constants
+    constants as __constants,
+} from 'primitive:fs';
+
+import {
+    readFile as __pReadFile,
+    writeFile as __pWriteFile,
+    appendFile as __pAppendFile,
+    stat as __pStat,
+    lstat as __pLstat,
+    unlink as __pUnlink,
+    mkdir as __pMkdir,
+    rmdir as __pRmdir,
+    rm as __pRm,
+    readdir as __pReaddir,
+    rename as __pRename,
+    copyFile as __pCopyFile,
+    access as __pAccess,
+    chmod as __pChmod,
+    truncate as __pTruncate,
+    utimes as __pUtimes,
+    readlink as __pReadlink,
+    realpath as __pRealpath,
+    symlink as __pSymlink,
+    link as __pLink,
+    mkdtemp as __pMkdtemp,
+} from 'primitive:fs/promises';
+
+// ---------------------------------------------------------------------------
+// Callback derivation helpers.
+//
+// Node's callback APIs are `(err, data?) => void`. We forward to the promise
+// primitive and bridge its resolution/rejection back to the callback. The
+// primitive returns a real Promise in both modes (the compiled emitter wraps
+// its Task via WrapTaskAsPromise), so `.then` is a proven path here.
+// ---------------------------------------------------------------------------
+
+/** Bridge a value-producing promise to a Node `(err, data)` callback. */
+function __cbData(p: Promise<any>, callback: any): void {
+    p.then((value: any) => { callback(null, value); }, (err: any) => { callback(err); });
+}
+
+/** Bridge a void promise to a Node `(err)` callback. */
+function __cbVoid(p: Promise<any>, callback: any): void {
+    p.then(() => { callback(null); }, (err: any) => { callback(err); });
+}
+
+// ===========================================================================
+// Synchronous APIs — thin forwarders to primitive:fs.
+// ===========================================================================
+
+/** Synchronously tests whether the path exists. Returns false on error (never throws). */
+export function existsSync(path: string): boolean { return __existsSync(path); }
+
+// Optional trailing arguments are dispatched by arity rather than forwarded as
+// `undefined`: the primitives default by argument count, and forwarding an
+// explicit `undefined` would be numeric-converted (crash) or mis-read. Spread
+// can't be used — the compiled primitive emitter doesn't expand it (see process.ts).
+
+/** Synchronously reads a file. Returns a Buffer, or a string when an encoding is given. */
+export function readFileSync(path: string, options?: any): string | Buffer {
+    if (options === undefined) return __readFileSync(path);
+    return __readFileSync(path, options);
+}
+
+/** Synchronously writes data to a file, replacing the file if it already exists. */
+export function writeFileSync(path: string, data: any, options?: any): void { __writeFileSync(path, data); }
+
+/** Synchronously appends data to a file, creating the file if it does not yet exist. */
+export function appendFileSync(path: string, data: any, options?: any): void { __appendFileSync(path, data); }
+
+/** Synchronously removes a file or symbolic link. */
+export function unlinkSync(path: string): void { __unlinkSync(path); }
+
+/** Synchronously creates a directory. */
+export function mkdirSync(path: string, options?: any): any {
+    if (options === undefined) return __mkdirSync(path);
+    return __mkdirSync(path, options);
+}
+
+/** Synchronously removes a directory. */
+export function rmdirSync(path: string, options?: any): void {
+    if (options === undefined) { __rmdirSync(path); return; }
+    __rmdirSync(path, options);
+}
+
+/** Synchronously reads the contents of a directory. */
+export function readdirSync(path: string, options?: any): string[] {
+    if (options === undefined) return __readdirSync(path);
+    return __readdirSync(path, options);
+}
+
+/** Synchronously retrieves the Stats for the path. */
+export function statSync(path: string): any { return __statSync(path); }
+
+/** Synchronously retrieves the Stats for the path without following symbolic links. */
+export function lstatSync(path: string): any { return __lstatSync(path); }
+
+/** Synchronously renames (moves) a file or directory. */
+export function renameSync(oldPath: string, newPath: string): void { __renameSync(oldPath, newPath); }
+
+/** Synchronously copies a file. */
+export function copyFileSync(src: string, dest: string, mode?: number): void { __copyFileSync(src, dest); }
+
+/** Synchronously tests a user's permissions for the path; throws if the check fails. */
+export function accessSync(path: string, mode?: number): void {
+    if (mode === undefined) { __accessSync(path); return; }
+    __accessSync(path, mode);
+}
+
+/** Synchronously changes the permissions of a file. */
+export function chmodSync(path: string, mode: number): void { __chmodSync(path, mode); }
+
+/** Synchronously changes the owner and group of a file. */
+export function chownSync(path: string, uid: number, gid: number): void { __chownSync(path, uid, gid); }
+
+/** Synchronously changes the owner and group of a symbolic link. */
+export function lchownSync(path: string, uid: number, gid: number): void { __lchownSync(path, uid, gid); }
+
+/** Synchronously truncates a file to the given length. */
+export function truncateSync(path: string, len?: number): void {
+    if (len === undefined) { __truncateSync(path); return; }
+    __truncateSync(path, len);
+}
+
+/** Synchronously creates a symbolic link. */
+export function symlinkSync(target: string, path: string, type?: string): void {
+    if (type === undefined) { __symlinkSync(target, path); return; }
+    __symlinkSync(target, path, type);
+}
+
+/** Synchronously reads the value of a symbolic link. */
+export function readlinkSync(path: string): string { return __readlinkSync(path); }
+
+/** Synchronously computes the canonical pathname, resolving symbolic links. */
+export function realpathSync(path: string): string { return __realpathSync(path); }
+
+/** Synchronously changes the file-system timestamps of the path. */
+export function utimesSync(path: string, atime: number, mtime: number): void { __utimesSync(path, atime, mtime); }
+
+/** Synchronously opens a file and returns its file descriptor. */
+export function openSync(path: string, flags: any, mode?: number): number {
+    if (mode === undefined) return __openSync(path, flags);
+    return __openSync(path, flags, mode);
+}
+
+/** Synchronously closes a file descriptor. */
+export function closeSync(fd: number): void { __closeSync(fd); }
+
+/** Synchronously reads from a file descriptor into a buffer; returns the number of bytes read. */
+export function readSync(fd: number, buffer: Buffer, offset: number, length: number, position: any): number {
+    return __readSync(fd, buffer, offset, length, position);
+}
+
+/** Synchronously writes a buffer (or string) to a file descriptor; returns the number of bytes written. */
+export function writeSync(fd: number, buffer: any, offset?: number, length?: number, position?: any): number {
+    if (offset === undefined) return __writeSync(fd, buffer);
+    if (length === undefined) return __writeSync(fd, buffer, offset);
+    if (position === undefined) return __writeSync(fd, buffer, offset, length);
+    return __writeSync(fd, buffer, offset, length, position);
+}
+
+/** Synchronously retrieves the Stats for an open file descriptor. */
+export function fstatSync(fd: number): any { return __fstatSync(fd); }
+
+/** Synchronously truncates an open file descriptor to the given length. */
+export function ftruncateSync(fd: number, len?: number): void {
+    if (len === undefined) { __ftruncateSync(fd); return; }
+    __ftruncateSync(fd, len);
+}
+
+/** Synchronously creates a unique temporary directory and returns its path. */
+export function mkdtempSync(prefix: string): string { return __mkdtempSync(prefix); }
+
+/** Synchronously opens a directory and returns a Dir handle. */
+export function opendirSync(path: string): any { return __opendirSync(path); }
+
+/** Synchronously creates a hard link. */
+export function linkSync(existingPath: string, newPath: string): void { __linkSync(existingPath, newPath); }
+
+/** Returns a new ReadStream for the given path. */
+export function createReadStream(path: string, options?: any): any { return __createReadStream(path, options); }
+
+/** Returns a new WriteStream for the given path. */
+export function createWriteStream(path: string, options?: any): any { return __createWriteStream(path, options); }
+
+/** Watches for changes on a file or directory; returns an FSWatcher. */
+export function watch(filename: string, options?: any, listener?: any): any { return __watch(filename, options, listener); }
+
+/** Watches for changes on a file by polling its stats. */
+export function watchFile(filename: string, options: any, listener?: any): any { return __watchFile(filename, options, listener); }
+
+/** Stops watching a file previously registered with watchFile. */
+export function unwatchFile(filename: string, listener?: any): void { __unwatchFile(filename, listener); }
+
+/** File-system constants (access modes, open flags, copy flags, file-type bits). */
+export const constants: any = __constants;
+
+// ===========================================================================
+// Callback-based async APIs — derived from the promise primitives.
+// The trailing argument is the callback; an `options` argument may be omitted.
+// ===========================================================================
+
+/** Asynchronously reads the entire contents of a file. */
+export function readFile(path: string, options?: any, callback?: any): void {
+    if (typeof options === 'function') { callback = options; options = undefined; }
+    __cbData(__pReadFile(path, options), callback);
+}
+
+/** Asynchronously writes data to a file, replacing the file if it already exists. */
+export function writeFile(path: string, data: any, options?: any, callback?: any): void {
+    if (typeof options === 'function') { callback = options; options = undefined; }
+    __cbVoid(__pWriteFile(path, data, options), callback);
+}
+
+/** Asynchronously appends data to a file, creating the file if it does not yet exist. */
+export function appendFile(path: string, data: any, options?: any, callback?: any): void {
+    if (typeof options === 'function') { callback = options; options = undefined; }
+    __cbVoid(__pAppendFile(path, data, options), callback);
+}
+
+/** Asynchronously retrieves the Stats for the path. */
+export function stat(path: string, options?: any, callback?: any): void {
+    if (typeof options === 'function') { callback = options; options = undefined; }
+    __cbData(__pStat(path), callback);
+}
+
+/** Asynchronously retrieves the Stats for the path without following symbolic links. */
+export function lstat(path: string, options?: any, callback?: any): void {
+    if (typeof options === 'function') { callback = options; options = undefined; }
+    __cbData(__pLstat(path), callback);
+}
+
+/** Asynchronously removes a file or symbolic link. */
+export function unlink(path: string, callback: any): void {
+    __cbVoid(__pUnlink(path), callback);
+}
+
+/** Asynchronously creates a directory. */
+export function mkdir(path: string, options?: any, callback?: any): void {
+    if (typeof options === 'function') { callback = options; options = undefined; }
+    __cbData(__pMkdir(path, options), callback);
+}
+
+/** Asynchronously removes a directory. */
+export function rmdir(path: string, options?: any, callback?: any): void {
+    if (typeof options === 'function') { callback = options; options = undefined; }
+    __cbVoid(__pRmdir(path, options), callback);
+}
+
+/** Asynchronously reads the contents of a directory. */
+export function readdir(path: string, options?: any, callback?: any): void {
+    if (typeof options === 'function') { callback = options; options = undefined; }
+    __cbData(__pReaddir(path, options), callback);
+}
+
+/** Asynchronously renames (moves) a file or directory. */
+export function rename(oldPath: string, newPath: string, callback: any): void {
+    __cbVoid(__pRename(oldPath, newPath), callback);
+}
+
+/** Asynchronously copies a file. */
+export function copyFile(src: string, dest: string, mode?: any, callback?: any): void {
+    if (typeof mode === 'function') { callback = mode; mode = undefined; }
+    __cbVoid(__pCopyFile(src, dest, mode), callback);
+}
+
+/** Asynchronously tests a user's permissions for the path. */
+export function access(path: string, mode?: any, callback?: any): void {
+    if (typeof mode === 'function') { callback = mode; mode = undefined; }
+    __cbVoid(__pAccess(path, mode), callback);
+}
+
+/** Asynchronously changes the permissions of a file. */
+export function chmod(path: string, mode: number, callback: any): void {
+    __cbVoid(__pChmod(path, mode), callback);
+}
+
+/** Asynchronously truncates a file to the given length. */
+export function truncate(path: string, len?: any, callback?: any): void {
+    if (typeof len === 'function') { callback = len; len = undefined; }
+    __cbVoid(__pTruncate(path, len), callback);
+}
+
+/** Asynchronously changes the file-system timestamps of the path. */
+export function utimes(path: string, atime: number, mtime: number, callback: any): void {
+    __cbVoid(__pUtimes(path, atime, mtime), callback);
+}
+
+/** Asynchronously reads the value of a symbolic link. */
+export function readlink(path: string, options?: any, callback?: any): void {
+    if (typeof options === 'function') { callback = options; options = undefined; }
+    __cbData(__pReadlink(path), callback);
+}
+
+/** Asynchronously computes the canonical pathname, resolving symbolic links. */
+export function realpath(path: string, options?: any, callback?: any): void {
+    if (typeof options === 'function') { callback = options; options = undefined; }
+    __cbData(__pRealpath(path), callback);
+}
+
+/** Asynchronously creates a symbolic link. */
+export function symlink(target: string, path: string, type?: any, callback?: any): void {
+    if (typeof type === 'function') { callback = type; type = undefined; }
+    __cbVoid(__pSymlink(target, path, type), callback);
+}
+
+/** Asynchronously creates a hard link. */
+export function link(existingPath: string, newPath: string, callback: any): void {
+    __cbVoid(__pLink(existingPath, newPath), callback);
+}
+
+/** Asynchronously creates a unique temporary directory. */
+export function mkdtemp(prefix: string, options?: any, callback?: any): void {
+    if (typeof options === 'function') { callback = options; options = undefined; }
+    __cbData(__pMkdtemp(prefix), callback);
+}
+
+// ===========================================================================
+// fs.promises namespace — assembled from the promise primitives.
+// Each method is wrapped in an arrow so the call reaches the primitive at a
+// call-site (the emitter dispatches method calls, not method values).
+// ===========================================================================
+
+/** Promise-based file-system API (equivalent to `require('fs/promises')`). */
+export const promises = {
+    readFile: (path: string, options?: any): Promise<any> => __pReadFile(path, options),
+    writeFile: (path: string, data: any, options?: any): Promise<void> => __pWriteFile(path, data, options),
+    appendFile: (path: string, data: any, options?: any): Promise<void> => __pAppendFile(path, data, options),
+    stat: (path: string): Promise<any> => __pStat(path),
+    lstat: (path: string): Promise<any> => __pLstat(path),
+    unlink: (path: string): Promise<void> => __pUnlink(path),
+    mkdir: (path: string, options?: any): Promise<any> => __pMkdir(path, options),
+    rmdir: (path: string, options?: any): Promise<void> => __pRmdir(path, options),
+    rm: (path: string, options?: any): Promise<void> => __pRm(path, options),
+    readdir: (path: string, options?: any): Promise<any> => __pReaddir(path, options),
+    rename: (oldPath: string, newPath: string): Promise<void> => __pRename(oldPath, newPath),
+    copyFile: (src: string, dest: string, mode?: any): Promise<void> => __pCopyFile(src, dest, mode),
+    access: (path: string, mode?: any): Promise<void> => __pAccess(path, mode),
+    chmod: (path: string, mode: number): Promise<void> => __pChmod(path, mode),
+    truncate: (path: string, len?: any): Promise<void> => __pTruncate(path, len),
+    utimes: (path: string, atime: number, mtime: number): Promise<void> => __pUtimes(path, atime, mtime),
+    readlink: (path: string): Promise<any> => __pReadlink(path),
+    realpath: (path: string): Promise<any> => __pRealpath(path),
+    symlink: (target: string, path: string, type?: any): Promise<void> => __pSymlink(target, path, type),
+    link: (existingPath: string, newPath: string): Promise<void> => __pLink(existingPath, newPath),
+    mkdtemp: (prefix: string): Promise<any> => __pMkdtemp(prefix),
+    constants: __constants,
+};
+
+// Node's `fs` module exposes its surface as both named exports and a default
+// export (the module object). Supports `import fs from 'fs'; fs.readFileSync(...)`.
+export default {
+    existsSync, readFileSync, writeFileSync, appendFileSync,
+    unlinkSync, mkdirSync, rmdirSync, readdirSync,
+    statSync, lstatSync, renameSync, copyFileSync, accessSync,
+    chmodSync, chownSync, lchownSync, truncateSync,
+    symlinkSync, readlinkSync, realpathSync, utimesSync,
+    openSync, closeSync, readSync, writeSync, fstatSync, ftruncateSync,
+    mkdtempSync, opendirSync, linkSync,
+    createReadStream, createWriteStream,
+    watch, watchFile, unwatchFile,
+    constants,
+    readFile, writeFile, appendFile, stat, lstat, unlink, mkdir, rmdir,
+    readdir, rename, copyFile, access, chmod, truncate, utimes,
+    readlink, realpath, symlink, link, mkdtemp,
+    promises,
+};

--- a/stdlib/node/fs/promises.ts
+++ b/stdlib/node/fs/promises.ts
@@ -1,0 +1,103 @@
+// Node.js 'fs/promises' module — SharpTS embedded stdlib implementation.
+// Target: Node.js 24.15.0. See https://nodejs.org/api/fs.html#promises-api.
+//
+// Thin Node-shape facade over `primitive:fs/promises`. Each export forwards to
+// its matching promise primitive at a call-site (the compiled emitter dispatches
+// method calls, not method values). Divergence from Node lives in the primitive.
+
+import {
+    readFile as __readFile,
+    writeFile as __writeFile,
+    appendFile as __appendFile,
+    stat as __stat,
+    lstat as __lstat,
+    unlink as __unlink,
+    mkdir as __mkdir,
+    rmdir as __rmdir,
+    rm as __rm,
+    readdir as __readdir,
+    rename as __rename,
+    copyFile as __copyFile,
+    access as __access,
+    chmod as __chmod,
+    truncate as __truncate,
+    utimes as __utimes,
+    readlink as __readlink,
+    realpath as __realpath,
+    symlink as __symlink,
+    link as __link,
+    mkdtemp as __mkdtemp,
+    constants as __constants,
+} from 'primitive:fs/promises';
+
+/** Asynchronously reads the entire contents of a file. */
+export function readFile(path: string, options?: any): Promise<any> { return __readFile(path, options); }
+
+/** Asynchronously writes data to a file, replacing the file if it already exists. */
+export function writeFile(path: string, data: any, options?: any): Promise<void> { return __writeFile(path, data, options); }
+
+/** Asynchronously appends data to a file, creating the file if it does not yet exist. */
+export function appendFile(path: string, data: any, options?: any): Promise<void> { return __appendFile(path, data, options); }
+
+/** Asynchronously retrieves the Stats for the path. */
+export function stat(path: string): Promise<any> { return __stat(path); }
+
+/** Asynchronously retrieves the Stats for the path without following symbolic links. */
+export function lstat(path: string): Promise<any> { return __lstat(path); }
+
+/** Asynchronously removes a file or symbolic link. */
+export function unlink(path: string): Promise<void> { return __unlink(path); }
+
+/** Asynchronously creates a directory. */
+export function mkdir(path: string, options?: any): Promise<any> { return __mkdir(path, options); }
+
+/** Asynchronously removes a directory. */
+export function rmdir(path: string, options?: any): Promise<void> { return __rmdir(path, options); }
+
+/** Asynchronously removes files and directories (recursively when requested). */
+export function rm(path: string, options?: any): Promise<void> { return __rm(path, options); }
+
+/** Asynchronously reads the contents of a directory. */
+export function readdir(path: string, options?: any): Promise<any> { return __readdir(path, options); }
+
+/** Asynchronously renames (moves) a file or directory. */
+export function rename(oldPath: string, newPath: string): Promise<void> { return __rename(oldPath, newPath); }
+
+/** Asynchronously copies a file. */
+export function copyFile(src: string, dest: string, mode?: any): Promise<void> { return __copyFile(src, dest, mode); }
+
+/** Asynchronously tests a user's permissions for the path. */
+export function access(path: string, mode?: any): Promise<void> { return __access(path, mode); }
+
+/** Asynchronously changes the permissions of a file. */
+export function chmod(path: string, mode: number): Promise<void> { return __chmod(path, mode); }
+
+/** Asynchronously truncates a file to the given length. */
+export function truncate(path: string, len?: any): Promise<void> { return __truncate(path, len); }
+
+/** Asynchronously changes the file-system timestamps of the path. */
+export function utimes(path: string, atime: number, mtime: number): Promise<void> { return __utimes(path, atime, mtime); }
+
+/** Asynchronously reads the value of a symbolic link. */
+export function readlink(path: string): Promise<any> { return __readlink(path); }
+
+/** Asynchronously computes the canonical pathname, resolving symbolic links. */
+export function realpath(path: string): Promise<any> { return __realpath(path); }
+
+/** Asynchronously creates a symbolic link. */
+export function symlink(target: string, path: string, type?: any): Promise<void> { return __symlink(target, path, type); }
+
+/** Asynchronously creates a hard link. */
+export function link(existingPath: string, newPath: string): Promise<void> { return __link(existingPath, newPath); }
+
+/** Asynchronously creates a unique temporary directory. */
+export function mkdtemp(prefix: string): Promise<any> { return __mkdtemp(prefix); }
+
+/** File-system constants (access modes, open flags, copy flags, file-type bits). */
+export const constants: any = __constants;
+
+export default {
+    readFile, writeFile, appendFile, stat, lstat, unlink, mkdir, rmdir, rm,
+    readdir, rename, copyFile, access, chmod, truncate, utimes,
+    readlink, realpath, symlink, link, mkdtemp, constants,
+};


### PR DESCRIPTION
Part of the fs epic #968. Bottom of an 8-PR stack — review/merge bottom-up.

Flips `fs`/`fs/promises` from C# built-ins to TS facades over a `primitive:fs` seam (the os/process pattern). The C# impls are retained as the primitives; the facade re-exports the sync surface and derives callback APIs from the promise primitives — **structurally closing #970** (compiled had no callback fs before). Also fixes an exposed interp `fs/promises` rejection bug. Standalone preserved. Full xUnit green; TS conformance unchanged.

Closes #969.