### PR TITLE
feat(fs/buffer): binary/encoding I/O correctness + shared encoder (#978)

### DIFF
--- a/Compilation/EmittedRuntime.cs
+++ b/Compilation/EmittedRuntime.cs
@@ -1497,6 +1497,9 @@ public class EmittedRuntime
 
     // Fs module methods
     public MethodBuilder FsExistsSync { get; set; } = null!;
+    // Encoding helpers shared by fs read/write/append (BCL-only, standalone).
+    public MethodBuilder FsEncodingName { get; set; } = null!;
+    public MethodBuilder FsToBytes { get; set; } = null!;
     public MethodBuilder FsReadFileSync { get; set; } = null!;
     public MethodBuilder FsWriteFileSync { get; set; } = null!;
     public MethodBuilder FsAppendFileSync { get; set; } = null!;

--- a/Compilation/Emitters/Modules/FsModuleEmitter.cs
+++ b/Compilation/Emitters/Modules/FsModuleEmitter.cs
@@ -181,7 +181,18 @@ public sealed class FsModuleEmitter : IBuiltInModuleEmitter
         emitter.EmitExpression(arguments[1]);
         emitter.EmitBoxIfNeeded(arguments[1]);
 
-        // Call runtime helper: FsWriteFileSync(object path, object data)
+        // Emit encoding/options (null if not provided)
+        if (arguments.Count >= 3)
+        {
+            emitter.EmitExpression(arguments[2]);
+            emitter.EmitBoxIfNeeded(arguments[2]);
+        }
+        else
+        {
+            il.Emit(OpCodes.Ldnull);
+        }
+
+        // Call runtime helper: FsWriteFileSync(object path, object data, object? encoding)
         il.Emit(OpCodes.Call, ctx.Runtime!.FsWriteFileSync);
         il.Emit(OpCodes.Ldnull); // undefined return
         return true;
@@ -206,7 +217,18 @@ public sealed class FsModuleEmitter : IBuiltInModuleEmitter
         emitter.EmitExpression(arguments[1]);
         emitter.EmitBoxIfNeeded(arguments[1]);
 
-        // Call runtime helper: FsAppendFileSync(object path, object data)
+        // Emit encoding/options (null if not provided)
+        if (arguments.Count >= 3)
+        {
+            emitter.EmitExpression(arguments[2]);
+            emitter.EmitBoxIfNeeded(arguments[2]);
+        }
+        else
+        {
+            il.Emit(OpCodes.Ldnull);
+        }
+
+        // Call runtime helper: FsAppendFileSync(object path, object data, object? encoding)
         il.Emit(OpCodes.Call, ctx.Runtime!.FsAppendFileSync);
         il.Emit(OpCodes.Ldnull); // undefined return
         return true;

--- a/Compilation/RuntimeEmitter.FsAsync.cs
+++ b/Compilation/RuntimeEmitter.FsAsync.cs
@@ -128,9 +128,10 @@ public partial class RuntimeEmitter
         var il = method.GetILGenerator();
         var (fromResult, resultTask, afterTry) = BeginFsAsyncTryCatch(il);
 
-        // Call FsWriteFileSync(path, data) - ignores options for now
+        // Call FsWriteFileSync(path, data, options)
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Ldarg_2);
         il.Emit(OpCodes.Call, runtime.FsWriteFileSync);
 
         // Return Task.FromResult(null) for void operations
@@ -158,9 +159,10 @@ public partial class RuntimeEmitter
         var il = method.GetILGenerator();
         var (fromResult, resultTask, afterTry) = BeginFsAsyncTryCatch(il);
 
-        // Call FsAppendFileSync(path, data)
+        // Call FsAppendFileSync(path, data, options)
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Ldarg_2);
         il.Emit(OpCodes.Call, runtime.FsAppendFileSync);
 
         // Return Task.FromResult(null) for void operations

--- a/Compilation/RuntimeEmitter.FsHelpers.cs
+++ b/Compilation/RuntimeEmitter.FsHelpers.cs
@@ -44,6 +44,9 @@ public partial class RuntimeEmitter
         // Low-level helpers using reflection for standalone DLLs (must be first)
         EmitFsLowLevelHelpers(typeBuilder, runtime);
 
+        // Encoding helpers — must precede read/write/append which call them.
+        EmitFsEncodingHelpers(typeBuilder, runtime);
+
         EmitFsExistsSync(typeBuilder, runtime);
         EmitFsReadFileSync(typeBuilder, runtime);
         EmitFsWriteFileSync(typeBuilder, runtime);

--- a/Compilation/RuntimeEmitter.FsSync.cs
+++ b/Compilation/RuntimeEmitter.FsSync.cs
@@ -47,8 +47,95 @@ public partial class RuntimeEmitter
     }
 
     /// <summary>
+    /// Emits the BCL-only encoding helpers used by fs read/write/append. They mirror
+    /// the interpreter's FsModuleInterpreter.EncodingName + BufferEncoding.ToBytes and
+    /// reuse the (corrected) $Buffer encoder so fs encoding == Buffer encoding.
+    /// </summary>
+    private void EmitFsEncodingHelpers(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    {
+        // string FsEncodingName(object opt): null when none; the string itself, or
+        // opt.encoding when opt is an options object.
+        var nameMethod = typeBuilder.DefineMethod(
+            "FsEncodingName",
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.String,
+            [_types.Object]
+        );
+        runtime.FsEncodingName = nameMethod;
+        {
+            var il = nameMethod.GetILGenerator();
+            var retNull = il.DefineLabel();
+            var retIt = il.DefineLabel();
+            // if (opt == null) return null
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Brfalse, retNull);
+            // if (opt is string) return (string)opt
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Isinst, _types.String);
+            il.Emit(OpCodes.Dup);
+            il.Emit(OpCodes.Brtrue, retIt);
+            il.Emit(OpCodes.Pop);
+            // e = opt.encoding; return (e is string) ? e : null
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldstr, "encoding");
+            il.Emit(OpCodes.Call, runtime.GetProperty);
+            il.Emit(OpCodes.Isinst, _types.String);
+            il.Emit(OpCodes.Dup);
+            il.Emit(OpCodes.Brtrue, retIt);
+            il.Emit(OpCodes.Pop);
+            il.MarkLabel(retNull);
+            il.Emit(OpCodes.Ldnull);
+            il.Emit(OpCodes.Ret);
+            il.MarkLabel(retIt);
+            il.Emit(OpCodes.Ret);
+        }
+
+        // byte[] FsToBytes(object data, object encodingOpt): a Buffer contributes its
+        // bytes verbatim; a string is encoded via $Buffer.FromString (default utf8).
+        var byteArr = _types.MakeArrayType(_types.Byte);
+        var toBytesMethod = typeBuilder.DefineMethod(
+            "FsToBytes",
+            MethodAttributes.Public | MethodAttributes.Static,
+            byteArr,
+            [_types.Object, _types.Object]
+        );
+        runtime.FsToBytes = toBytesMethod;
+        {
+            var il = toBytesMethod.GetILGenerator();
+            var isBuf = il.DefineLabel();
+            var haveEnc = il.DefineLabel();
+            // buf = data as $Buffer
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Isinst, runtime.TSBufferType);
+            il.Emit(OpCodes.Dup);
+            il.Emit(OpCodes.Brtrue, isBuf);
+            il.Emit(OpCodes.Pop);
+            // string s = Stringify(data)
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Call, runtime.Stringify);
+            // string enc = FsEncodingName(encodingOpt) ?? "utf8"
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Call, runtime.FsEncodingName);
+            il.Emit(OpCodes.Dup);
+            il.Emit(OpCodes.Brtrue, haveEnc);
+            il.Emit(OpCodes.Pop);
+            il.Emit(OpCodes.Ldstr, "utf8");
+            il.MarkLabel(haveEnc);
+            // $Buffer.FromString(s, enc).GetData()
+            il.Emit(OpCodes.Call, runtime.TSBufferFromString);
+            il.Emit(OpCodes.Callvirt, runtime.TSBufferGetData);
+            il.Emit(OpCodes.Ret);
+            // ((TSBuffer)data).GetData()
+            il.MarkLabel(isBuf);
+            il.Emit(OpCodes.Callvirt, runtime.TSBufferGetData);
+            il.Emit(OpCodes.Ret);
+        }
+    }
+
+    /// <summary>
     /// Emits: public static object FsReadFileSync(object path, object? encoding)
-    /// Returns string if encoding specified, $Buffer otherwise.
+    /// Reads raw bytes; returns a $Buffer when no encoding, else decodes via the
+    /// $Buffer encoder (so every encoding matches the interpreter and Buffer).
     /// </summary>
     private void EmitFsReadFileSync(TypeBuilder typeBuilder, EmittedRuntime runtime)
     {
@@ -62,6 +149,8 @@ public partial class RuntimeEmitter
 
         var il = method.GetILGenerator();
         var resultLocal = il.DeclareLocal(_types.Object);
+        var bytesLocal = il.DeclareLocal(_types.MakeArrayType(_types.Byte));
+        var encLocal = il.DeclareLocal(_types.String);
 
         // Convert path to string
         il.Emit(OpCodes.Ldarg_0);
@@ -71,24 +160,32 @@ public partial class RuntimeEmitter
 
         EmitWithFsErrorHandling(il, runtime, pathLocal, "open", afterTry =>
         {
-            // Check if encoding is provided (not null)
-            var readBytesLabel = il.DefineLabel();
-            var afterReadLabel = il.DefineLabel();
-            il.Emit(OpCodes.Ldarg_1);
-            il.Emit(OpCodes.Brfalse, readBytesLabel);
-
-            // Read as text: File.ReadAllText(path)
+            // bytes = File.ReadAllBytes(path)
             il.Emit(OpCodes.Ldloc, pathLocal);
-            il.Emit(OpCodes.Call, _types.GetMethod(_types.File, "ReadAllText", _types.String));
+            il.Emit(OpCodes.Call, _types.GetMethod(_types.File, "ReadAllBytes", _types.String));
+            il.Emit(OpCodes.Stloc, bytesLocal);
+
+            // enc = FsEncodingName(encoding)
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Call, runtime.FsEncodingName);
+            il.Emit(OpCodes.Stloc, encLocal);
+
+            var asBufferLabel = il.DefineLabel();
+            var afterReadLabel = il.DefineLabel();
+            il.Emit(OpCodes.Ldloc, encLocal);
+            il.Emit(OpCodes.Brfalse, asBufferLabel);
+
+            // Decode: new $Buffer(bytes).ToEncodedString(enc)
+            il.Emit(OpCodes.Ldloc, bytesLocal);
+            il.Emit(OpCodes.Newobj, runtime.TSBufferCtor);
+            il.Emit(OpCodes.Ldloc, encLocal);
+            il.Emit(OpCodes.Callvirt, runtime.TSBufferToString);
             il.Emit(OpCodes.Stloc, resultLocal);
             il.Emit(OpCodes.Br, afterReadLabel);
 
-            // Read as bytes: File.ReadAllBytes(path) - wrap in $Buffer
-            il.MarkLabel(readBytesLabel);
-            il.Emit(OpCodes.Ldloc, pathLocal);
-            il.Emit(OpCodes.Call, _types.GetMethod(_types.File, "ReadAllBytes", _types.String));
-
-            // Create $Buffer from byte[]
+            // No encoding: wrap bytes in $Buffer
+            il.MarkLabel(asBufferLabel);
+            il.Emit(OpCodes.Ldloc, bytesLocal);
             il.Emit(OpCodes.Newobj, runtime.TSBufferCtor);
             il.Emit(OpCodes.Stloc, resultLocal);
 
@@ -100,7 +197,8 @@ public partial class RuntimeEmitter
     }
 
     /// <summary>
-    /// Emits: public static void FsWriteFileSync(object path, object data)
+    /// Emits: public static void FsWriteFileSync(object path, object data, object? encoding)
+    /// Writes raw bytes (Buffer verbatim, string encoded) — never ToString's a Buffer.
     /// </summary>
     private void EmitFsWriteFileSync(TypeBuilder typeBuilder, EmittedRuntime runtime)
     {
@@ -108,37 +206,38 @@ public partial class RuntimeEmitter
             "FsWriteFileSync",
             MethodAttributes.Public | MethodAttributes.Static,
             _types.Void,
-            [_types.Object, _types.Object]
+            [_types.Object, _types.Object, _types.Object]
         );
         runtime.FsWriteFileSync = method;
 
         var il = method.GetILGenerator();
 
-        // Convert path to string
+        // path = Stringify(arg0)
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Call, runtime.Stringify);
         var pathLocal = il.DeclareLocal(_types.String);
         il.Emit(OpCodes.Stloc, pathLocal);
 
-        // Convert data to string
+        // bytes = FsToBytes(data, encoding)
         il.Emit(OpCodes.Ldarg_1);
-        il.Emit(OpCodes.Call, runtime.Stringify);
-        var dataLocal = il.DeclareLocal(_types.String);
-        il.Emit(OpCodes.Stloc, dataLocal);
+        il.Emit(OpCodes.Ldarg_2);
+        il.Emit(OpCodes.Call, runtime.FsToBytes);
+        var bytesLocal = il.DeclareLocal(_types.MakeArrayType(_types.Byte));
+        il.Emit(OpCodes.Stloc, bytesLocal);
 
         EmitWithFsErrorHandling(il, runtime, pathLocal, "open", afterTry =>
         {
-            // File.WriteAllText(path, data)
+            // File.WriteAllBytes(path, bytes)
             il.Emit(OpCodes.Ldloc, pathLocal);
-            il.Emit(OpCodes.Ldloc, dataLocal);
-            il.Emit(OpCodes.Call, _types.GetMethod(_types.File, "WriteAllText", _types.String, _types.String));
+            il.Emit(OpCodes.Ldloc, bytesLocal);
+            il.Emit(OpCodes.Call, _types.GetMethod(_types.File, "WriteAllBytes", _types.String, _types.MakeArrayType(_types.Byte)));
             il.Emit(OpCodes.Leave, afterTry);
         });
         il.Emit(OpCodes.Ret);
     }
 
     /// <summary>
-    /// Emits: public static void FsAppendFileSync(object path, object data)
+    /// Emits: public static void FsAppendFileSync(object path, object data, object? encoding)
     /// </summary>
     private void EmitFsAppendFileSync(TypeBuilder typeBuilder, EmittedRuntime runtime)
     {
@@ -146,30 +245,31 @@ public partial class RuntimeEmitter
             "FsAppendFileSync",
             MethodAttributes.Public | MethodAttributes.Static,
             _types.Void,
-            [_types.Object, _types.Object]
+            [_types.Object, _types.Object, _types.Object]
         );
         runtime.FsAppendFileSync = method;
 
         var il = method.GetILGenerator();
 
-        // Convert path to string
+        // path = Stringify(arg0)
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Call, runtime.Stringify);
         var pathLocal = il.DeclareLocal(_types.String);
         il.Emit(OpCodes.Stloc, pathLocal);
 
-        // Convert data to string
+        // bytes = FsToBytes(data, encoding)
         il.Emit(OpCodes.Ldarg_1);
-        il.Emit(OpCodes.Call, runtime.Stringify);
-        var dataLocal = il.DeclareLocal(_types.String);
-        il.Emit(OpCodes.Stloc, dataLocal);
+        il.Emit(OpCodes.Ldarg_2);
+        il.Emit(OpCodes.Call, runtime.FsToBytes);
+        var bytesLocal = il.DeclareLocal(_types.MakeArrayType(_types.Byte));
+        il.Emit(OpCodes.Stloc, bytesLocal);
 
         EmitWithFsErrorHandling(il, runtime, pathLocal, "open", afterTry =>
         {
-            // File.AppendAllText(path, data)
+            // File.AppendAllBytes(path, bytes)
             il.Emit(OpCodes.Ldloc, pathLocal);
-            il.Emit(OpCodes.Ldloc, dataLocal);
-            il.Emit(OpCodes.Call, _types.GetMethod(_types.File, "AppendAllText", _types.String, _types.String));
+            il.Emit(OpCodes.Ldloc, bytesLocal);
+            il.Emit(OpCodes.Call, _types.GetMethod(_types.File, "AppendAllBytes", _types.String, _types.MakeArrayType(_types.Byte)));
             il.Emit(OpCodes.Leave, afterTry);
         });
         il.Emit(OpCodes.Ret);

--- a/Compilation/RuntimeEmitter.FsWrappers.cs
+++ b/Compilation/RuntimeEmitter.FsWrappers.cs
@@ -30,12 +30,14 @@ public partial class RuntimeEmitter
                 il.Emit(OpCodes.Call, runtime.FsReadFileSync);
             });
 
-        // writeFileSync(path, data) -> undefined
+        // writeFileSync(path, data) -> undefined (value-import fallback; encoding via
+        // the direct-dispatch path, so this fixed-arity wrapper passes null).
         EmitFsMethodWrapperSimple(typeBuilder, runtime, "writeFileSync", 2,
             il =>
             {
                 il.Emit(OpCodes.Ldarg_0);
                 il.Emit(OpCodes.Ldarg_1);
+                il.Emit(OpCodes.Ldnull);
                 il.Emit(OpCodes.Call, runtime.FsWriteFileSync);
                 il.Emit(OpCodes.Ldnull);
             });
@@ -46,6 +48,7 @@ public partial class RuntimeEmitter
             {
                 il.Emit(OpCodes.Ldarg_0);
                 il.Emit(OpCodes.Ldarg_1);
+                il.Emit(OpCodes.Ldnull);
                 il.Emit(OpCodes.Call, runtime.FsAppendFileSync);
                 il.Emit(OpCodes.Ldnull);
             });

--- a/Compilation/RuntimeEmitter.TSBufferInstance.cs
+++ b/Compilation/RuntimeEmitter.TSBufferInstance.cs
@@ -24,7 +24,10 @@ public partial class RuntimeEmitter
         var encodingLocal = il.DeclareLocal(_types.String);
         var utf8Label = il.DefineLabel();
         var asciiLabel = il.DefineLabel();
+        var latin1Label = il.DefineLabel();
+        var utf16leLabel = il.DefineLabel();
         var base64Label = il.DefineLabel();
+        var base64urlLabel = il.DefineLabel();
         var hexLabel = il.DefineLabel();
         var defaultLabel = il.DefineLabel();
 
@@ -45,11 +48,18 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Stloc, encodingLocal);
         il.MarkLabel(afterEncodingLabel);
 
-        // Check encodings
+        // Check encodings (must mirror Runtime/Types/BufferEncoding.Decode exactly).
         CheckStringEquals(il, encodingLocal, "utf8", utf8Label);
         CheckStringEquals(il, encodingLocal, "utf-8", utf8Label);
         CheckStringEquals(il, encodingLocal, "ascii", asciiLabel);
+        CheckStringEquals(il, encodingLocal, "latin1", latin1Label);
+        CheckStringEquals(il, encodingLocal, "binary", latin1Label);
+        CheckStringEquals(il, encodingLocal, "utf16le", utf16leLabel);
+        CheckStringEquals(il, encodingLocal, "utf-16le", utf16leLabel);
+        CheckStringEquals(il, encodingLocal, "ucs2", utf16leLabel);
+        CheckStringEquals(il, encodingLocal, "ucs-2", utf16leLabel);
         CheckStringEquals(il, encodingLocal, "base64", base64Label);
+        CheckStringEquals(il, encodingLocal, "base64url", base64urlLabel);
         CheckStringEquals(il, encodingLocal, "hex", hexLabel);
         il.Emit(OpCodes.Br, defaultLabel);
 
@@ -63,11 +73,31 @@ public partial class RuntimeEmitter
         EmitEncodingGetString(il, "ASCII");
         il.Emit(OpCodes.Ret);
 
+        // Latin1 / binary
+        il.MarkLabel(latin1Label);
+        EmitEncodingGetString(il, "Latin1");
+        il.Emit(OpCodes.Ret);
+
+        // UTF-16LE / ucs2
+        il.MarkLabel(utf16leLabel);
+        EmitEncodingGetString(il, "Unicode");
+        il.Emit(OpCodes.Ret);
+
         // Base64
         il.MarkLabel(base64Label);
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ldfld, _tsBufferDataField);
         il.Emit(OpCodes.Call, _types.ConvertToBase64String);
+        il.Emit(OpCodes.Ret);
+
+        // Base64url: standard base64 with -/_ alphabet and no padding.
+        il.MarkLabel(base64urlLabel);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, _tsBufferDataField);
+        il.Emit(OpCodes.Call, _types.ConvertToBase64String);
+        EmitStringReplace(il, "=", "");
+        EmitStringReplace(il, "+", "-");
+        EmitStringReplace(il, "/", "_");
         il.Emit(OpCodes.Ret);
 
         // Hex
@@ -82,6 +112,14 @@ public partial class RuntimeEmitter
         il.MarkLabel(defaultLabel);
         EmitEncodingGetString(il, "UTF8");
         il.Emit(OpCodes.Ret);
+    }
+
+    /// <summary>Emits <c>str = str.Replace(oldStr, newStr)</c> on the string atop the stack.</summary>
+    private void EmitStringReplace(ILGenerator il, string oldStr, string newStr)
+    {
+        il.Emit(OpCodes.Ldstr, oldStr);
+        il.Emit(OpCodes.Ldstr, newStr);
+        il.Emit(OpCodes.Callvirt, _types.String.GetMethod("Replace", [_types.String, _types.String])!);
     }
 
     private void EmitEncodingGetString(ILGenerator il, string encodingProperty)

--- a/Compilation/RuntimeEmitter.TSBufferStatic.cs
+++ b/Compilation/RuntimeEmitter.TSBufferStatic.cs
@@ -23,7 +23,10 @@ public partial class RuntimeEmitter
         var encodingLocal = il.DeclareLocal(_types.String);
         var utf8Label = il.DefineLabel();
         var asciiLabel = il.DefineLabel();
+        var latin1Label = il.DefineLabel();
+        var utf16leLabel = il.DefineLabel();
         var base64Label = il.DefineLabel();
+        var base64urlLabel = il.DefineLabel();
         var hexLabel = il.DefineLabel();
         var defaultLabel = il.DefineLabel();
 
@@ -32,11 +35,18 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Callvirt, _types.String.GetMethod("ToLowerInvariant")!);
         il.Emit(OpCodes.Stloc, encodingLocal);
 
-        // Check encodings
+        // Check encodings (must mirror Runtime/Types/BufferEncoding.Encode exactly).
         CheckStringEquals(il, encodingLocal, "utf8", utf8Label);
         CheckStringEquals(il, encodingLocal, "utf-8", utf8Label);
         CheckStringEquals(il, encodingLocal, "ascii", asciiLabel);
+        CheckStringEquals(il, encodingLocal, "latin1", latin1Label);
+        CheckStringEquals(il, encodingLocal, "binary", latin1Label);
+        CheckStringEquals(il, encodingLocal, "utf16le", utf16leLabel);
+        CheckStringEquals(il, encodingLocal, "utf-16le", utf16leLabel);
+        CheckStringEquals(il, encodingLocal, "ucs2", utf16leLabel);
+        CheckStringEquals(il, encodingLocal, "ucs-2", utf16leLabel);
         CheckStringEquals(il, encodingLocal, "base64", base64Label);
+        CheckStringEquals(il, encodingLocal, "base64url", base64urlLabel);
         CheckStringEquals(il, encodingLocal, "hex", hexLabel);
         il.Emit(OpCodes.Br, defaultLabel);
 
@@ -50,9 +60,26 @@ public partial class RuntimeEmitter
         EmitEncodingGetBytes(il, "ASCII", runtime.TSBufferCtor);
         il.Emit(OpCodes.Ret);
 
+        // Latin1 / binary
+        il.MarkLabel(latin1Label);
+        EmitEncodingGetBytes(il, "Latin1", runtime.TSBufferCtor);
+        il.Emit(OpCodes.Ret);
+
+        // UTF-16LE / ucs2
+        il.MarkLabel(utf16leLabel);
+        EmitEncodingGetBytes(il, "Unicode", runtime.TSBufferCtor);
+        il.Emit(OpCodes.Ret);
+
         // Base64
         il.MarkLabel(base64Label);
         il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Call, _types.ConvertFromBase64String);
+        il.Emit(OpCodes.Newobj, runtime.TSBufferCtor);
+        il.Emit(OpCodes.Ret);
+
+        // Base64url: map -/_ → +/ and re-pad to a multiple of 4, then decode.
+        il.MarkLabel(base64urlLabel);
+        EmitBase64UrlNormalize(il);
         il.Emit(OpCodes.Call, _types.ConvertFromBase64String);
         il.Emit(OpCodes.Newobj, runtime.TSBufferCtor);
         il.Emit(OpCodes.Ret);
@@ -68,6 +95,55 @@ public partial class RuntimeEmitter
         il.MarkLabel(defaultLabel);
         EmitEncodingGetBytes(il, "UTF8", runtime.TSBufferCtor);
         il.Emit(OpCodes.Ret);
+    }
+
+    /// <summary>
+    /// Emits: takes the input string (Ldarg_0) and leaves a standard-base64 string on
+    /// the stack — '-'→'+', '_'→'/', and re-padded with '=' to a multiple of 4 length.
+    /// Mirrors BufferEncoding.DecodeBase64's url-safe normalization.
+    /// </summary>
+    private void EmitBase64UrlNormalize(ILGenerator il)
+    {
+        var replace = _types.String.GetMethod("Replace", [_types.String, _types.String])!;
+        var concat = _types.String.GetMethod("Concat", [_types.String, _types.String])!;
+        var getLength = _types.String.GetProperty("Length")!.GetGetMethod()!;
+
+        var s = il.DeclareLocal(_types.String);
+        var rem = il.DeclareLocal(_types.Int32);
+
+        // s = arg0.Replace("-", "+").Replace("_", "/")
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldstr, "-"); il.Emit(OpCodes.Ldstr, "+"); il.Emit(OpCodes.Callvirt, replace);
+        il.Emit(OpCodes.Ldstr, "_"); il.Emit(OpCodes.Ldstr, "/"); il.Emit(OpCodes.Callvirt, replace);
+        il.Emit(OpCodes.Stloc, s);
+
+        // rem = s.Length % 4
+        il.Emit(OpCodes.Ldloc, s);
+        il.Emit(OpCodes.Callvirt, getLength);
+        il.Emit(OpCodes.Ldc_I4_4);
+        il.Emit(OpCodes.Rem);
+        il.Emit(OpCodes.Stloc, rem);
+
+        var pad1 = il.DefineLabel();
+        var done = il.DefineLabel();
+
+        // rem == 2 → s + "=="
+        il.Emit(OpCodes.Ldloc, rem); il.Emit(OpCodes.Ldc_I4_2); il.Emit(OpCodes.Bne_Un, pad1);
+        il.Emit(OpCodes.Ldloc, s); il.Emit(OpCodes.Ldstr, "=="); il.Emit(OpCodes.Call, concat);
+        il.Emit(OpCodes.Br, done);
+
+        // rem == 3 → s + "="
+        il.MarkLabel(pad1);
+        var noPad = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, rem); il.Emit(OpCodes.Ldc_I4_3); il.Emit(OpCodes.Bne_Un, noPad);
+        il.Emit(OpCodes.Ldloc, s); il.Emit(OpCodes.Ldstr, "="); il.Emit(OpCodes.Call, concat);
+        il.Emit(OpCodes.Br, done);
+
+        // rem == 0 (or 1) → s unchanged
+        il.MarkLabel(noPad);
+        il.Emit(OpCodes.Ldloc, s);
+
+        il.MarkLabel(done);
     }
 
     private void EmitEncodingGetBytes(ILGenerator il, string encodingProperty, ConstructorBuilder bufferCtor)

--- a/Runtime/BuiltIns/Modules/Interpreter/FsAsyncHelpers.cs
+++ b/Runtime/BuiltIns/Modules/Interpreter/FsAsyncHelpers.cs
@@ -29,17 +29,10 @@ public static class FsAsyncHelpers
     public static async Task<object?> ReadFileAsync(string path, object? encoding)
     {
         await InjectedTestLatency();
-        if (encoding != null)
-        {
-            // Return as string
-            return await File.ReadAllTextAsync(path);
-        }
-        else
-        {
-            // Return as Buffer
-            var bytes = await File.ReadAllBytesAsync(path);
-            return new SharpTSBuffer(bytes);
-        }
+        var encName = FsModuleInterpreter.EncodingName(encoding);
+        var bytes = await File.ReadAllBytesAsync(path);
+        // No encoding → Buffer; otherwise decode the raw bytes per the encoding.
+        return encName != null ? (object?)BufferEncoding.Decode(bytes, encName) : new SharpTSBuffer(bytes);
     }
 
     /// <summary>
@@ -51,15 +44,9 @@ public static class FsAsyncHelpers
     public static async Task WriteFileAsync(string path, object? data, object? options)
     {
         await InjectedTestLatency();
-        if (data is SharpTSBuffer buffer)
-        {
-            await File.WriteAllBytesAsync(path, buffer.Data);
-        }
-        else
-        {
-            var text = data?.ToString() ?? "";
-            await File.WriteAllTextAsync(path, text);
-        }
+        // Buffer/TypedArray data is written byte-exact; a string honors the encoding option.
+        var bytes = BufferEncoding.ToBytes(data, FsModuleInterpreter.EncodingName(options));
+        await File.WriteAllBytesAsync(path, bytes);
     }
 
     /// <summary>
@@ -70,8 +57,10 @@ public static class FsAsyncHelpers
     /// <param name="options">Optional options (encoding, mode, flag).</param>
     public static async Task AppendFileAsync(string path, object? data, object? options)
     {
-        var text = data?.ToString() ?? "";
-        await File.AppendAllTextAsync(path, text);
+        await InjectedTestLatency();
+        // Buffer/TypedArray data is appended byte-exact; a string honors the encoding option.
+        var bytes = BufferEncoding.ToBytes(data, FsModuleInterpreter.EncodingName(options));
+        await File.AppendAllBytesAsync(path, bytes);
     }
 
     /// <summary>

--- a/Runtime/BuiltIns/Modules/Interpreter/FsModuleInterpreter.cs
+++ b/Runtime/BuiltIns/Modules/Interpreter/FsModuleInterpreter.cs
@@ -178,40 +178,45 @@ public static class FsModuleInterpreter
         return RuntimeValue.FromBoolean(File.Exists(path) || Directory.Exists(path));
     }
 
+    /// <summary>
+    /// Extracts the encoding name from a string-or-options value (Node accepts both
+    /// <c>'utf8'</c> and <c>{ encoding: 'utf8' }</c>). Returns null when no encoding
+    /// is given — on read that means "return a Buffer".
+    /// </summary>
+    internal static string? EncodingName(object? options)
+    {
+        if (options is string s) return s;
+        if (options is SharpTSObject opts && opts.GetProperty("encoding") is string es) return es;
+        return null;
+    }
+
     private static RuntimeValue ReadFileSync(Interp interpreter, RuntimeValue receiver, ReadOnlySpan<RuntimeValue> args)
     {
         var path = args[0].ToObject()?.ToString() ?? "";
-        var encoding = args.Length >= 2 ? args[1].ToObject() : null;
+        var encoding = EncodingName(args.Length >= 2 ? args[1].ToObject() : null);
 
         return RuntimeValue.FromBoxed(WrapFsOperation("open", path, () =>
         {
-            if (encoding != null)
-            {
-                // Return as string
-                return (object?)File.ReadAllText(path);
-            }
-            else
-            {
-                // Return as Buffer
-                var bytes = File.ReadAllBytes(path);
-                return new SharpTSBuffer(bytes);
-            }
+            var bytes = File.ReadAllBytes(path);
+            // No encoding → Buffer; otherwise decode the raw bytes per the encoding.
+            return encoding != null ? (object?)BufferEncoding.Decode(bytes, encoding) : new SharpTSBuffer(bytes);
         }));
     }
 
     private static RuntimeValue WriteFileSync(Interp interpreter, RuntimeValue receiver, ReadOnlySpan<RuntimeValue> args)
     {
         var path = args[0].ToObject()?.ToString() ?? "";
-        var data = args[1].ToObject()?.ToString() ?? "";
-        WrapFsOperation("open", path, () => File.WriteAllText(path, data));
+        // Buffer/TypedArray data is written byte-exact; a string honors the encoding option.
+        var bytes = BufferEncoding.ToBytes(args[1].ToObject(), EncodingName(args.Length >= 3 ? args[2].ToObject() : null));
+        WrapFsOperation("open", path, () => File.WriteAllBytes(path, bytes));
         return RuntimeValue.Null;
     }
 
     private static RuntimeValue AppendFileSync(Interp interpreter, RuntimeValue receiver, ReadOnlySpan<RuntimeValue> args)
     {
         var path = args[0].ToObject()?.ToString() ?? "";
-        var data = args[1].ToObject()?.ToString() ?? "";
-        WrapFsOperation("open", path, () => File.AppendAllText(path, data));
+        var bytes = BufferEncoding.ToBytes(args[1].ToObject(), EncodingName(args.Length >= 3 ? args[2].ToObject() : null));
+        WrapFsOperation("open", path, () => File.AppendAllBytes(path, bytes));
         return RuntimeValue.Null;
     }
 

--- a/Runtime/Types/BufferEncoding.cs
+++ b/Runtime/Types/BufferEncoding.cs
@@ -1,0 +1,148 @@
+using System.Text;
+
+namespace SharpTS.Runtime.Types;
+
+/// <summary>
+/// The single source of truth for Node.js Buffer/string encoding conversions in
+/// interpreter mode. Both <see cref="SharpTSBuffer"/> and the <c>fs</c> module use
+/// this so a given encoding name behaves identically across Buffer and file I/O.
+/// </summary>
+/// <remarks>
+/// BCL-only by design. The compiled pipeline emits an IL twin
+/// (<c>$Runtime.BufferEncode</c>/<c>BufferDecode</c>) that MUST stay byte-for-byte
+/// equivalent to these tables so interpreter and compiled output agree.
+/// Supported names (Node 24): utf8/utf-8, ascii, latin1/binary, base64, base64url,
+/// hex, utf16le/ucs2/ucs-2/utf-16le.
+/// </remarks>
+public static class BufferEncoding
+{
+    /// <summary>Default encoding when none is supplied (Node uses utf8).</summary>
+    public const string Default = "utf8";
+
+    /// <summary>Encodes a string to bytes using the given Node encoding name.</summary>
+    public static byte[] Encode(string data, string? encoding)
+    {
+        switch (Normalize(encoding))
+        {
+            case "utf8": return Encoding.UTF8.GetBytes(data);
+            case "ascii": return Encoding.ASCII.GetBytes(data);
+            case "latin1": return Encoding.Latin1.GetBytes(data);
+            case "base64": return DecodeBase64(data, urlSafe: false);
+            case "base64url": return DecodeBase64(data, urlSafe: true);
+            case "hex": return HexToBytes(data);
+            case "utf16le": return Encoding.Unicode.GetBytes(data);
+            default: throw new ArgumentException($"Unknown encoding: {encoding}");
+        }
+    }
+
+    /// <summary>Decodes bytes to a string using the given Node encoding name.</summary>
+    public static string Decode(byte[] data, string? encoding)
+    {
+        switch (Normalize(encoding))
+        {
+            case "utf8": return Encoding.UTF8.GetString(data);
+            case "ascii": return Encoding.ASCII.GetString(data);
+            case "latin1": return Encoding.Latin1.GetString(data);
+            case "base64": return Convert.ToBase64String(data);
+            case "base64url": return Convert.ToBase64String(data)
+                .TrimEnd('=').Replace('+', '-').Replace('/', '_');
+            case "hex": return Convert.ToHexString(data).ToLowerInvariant();
+            case "utf16le": return Encoding.Unicode.GetString(data);
+            default: throw new ArgumentException($"Unknown encoding: {encoding}");
+        }
+    }
+
+    /// <summary>
+    /// Converts a write payload to raw bytes: a Buffer or TypedArray view contributes
+    /// its bytes verbatim (offset/length aware); a string is encoded with
+    /// <paramref name="encoding"/> (default utf8). This is what fs write/append and
+    /// stream writes use so binary data is persisted byte-exact (never ToString'd).
+    /// </summary>
+    public static byte[] ToBytes(object? data, string? encoding)
+    {
+        switch (data)
+        {
+            case SharpTSBuffer buf:
+                return buf.Data;
+            case SharpTSTypedArray ta:
+            {
+                var bytes = new byte[ta.ByteLength];
+                Array.Copy(ta.Buffer, ta.ByteOffset, bytes, 0, ta.ByteLength);
+                return bytes;
+            }
+            case string s:
+                return Encode(s, encoding);
+            default:
+                return Encode(data?.ToString() ?? "", encoding);
+        }
+    }
+
+    /// <summary>Whether the name is a Buffer encoding this helper supports.</summary>
+    public static bool IsSupported(string? encoding)
+    {
+        switch (Normalize(encoding))
+        {
+            case "utf8":
+            case "ascii":
+            case "latin1":
+            case "base64":
+            case "base64url":
+            case "hex":
+            case "utf16le":
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    /// <summary>Canonicalizes a Node encoding alias to its representative name.</summary>
+    private static string Normalize(string? encoding)
+    {
+        if (string.IsNullOrEmpty(encoding)) return "utf8";
+        return encoding.ToLowerInvariant() switch
+        {
+            "utf8" or "utf-8" => "utf8",
+            "ascii" => "ascii",
+            "latin1" or "binary" => "latin1",
+            "base64" => "base64",
+            "base64url" => "base64url",
+            "hex" => "hex",
+            "utf16le" or "utf-16le" or "ucs2" or "ucs-2" => "utf16le",
+            _ => encoding.ToLowerInvariant()
+        };
+    }
+
+    /// <summary>
+    /// Decodes a base64 (or base64url) string to bytes, tolerating missing padding
+    /// and the URL-safe alphabet (matching Node's lenient base64 decoder).
+    /// </summary>
+    private static byte[] DecodeBase64(string data, bool urlSafe)
+    {
+        // Node ignores whitespace and accepts both alphabets; normalize to standard.
+        var sb = new StringBuilder(data.Length);
+        foreach (var c in data)
+        {
+            if (char.IsWhiteSpace(c)) continue;
+            sb.Append(c switch { '-' => '+', '_' => '/', _ => c });
+        }
+        var s = sb.ToString();
+        switch (s.Length % 4)
+        {
+            case 2: s += "=="; break;
+            case 3: s += "="; break;
+        }
+        return Convert.FromBase64String(s);
+    }
+
+    /// <summary>Converts a hex string to bytes, padding an odd length like Node.</summary>
+    private static byte[] HexToBytes(string hex)
+    {
+        if (string.IsNullOrEmpty(hex)) return [];
+        hex = hex.Replace(" ", "").Replace("-", "");
+        if (hex.Length % 2 != 0) hex = "0" + hex;
+        var bytes = new byte[hex.Length / 2];
+        for (int i = 0; i < bytes.Length; i++)
+            bytes[i] = Convert.ToByte(hex.Substring(i * 2, 2), 16);
+        return bytes;
+    }
+}

--- a/Runtime/Types/SharpTSBuffer.cs
+++ b/Runtime/Types/SharpTSBuffer.cs
@@ -1152,62 +1152,11 @@ public class SharpTSBuffer : ITypeCategorized
 
     #region Encoding Helpers
 
-    /// <summary>
-    /// Encodes a string to bytes using the specified encoding.
-    /// </summary>
-    private static byte[] EncodeString(string data, string encoding)
-    {
-        return encoding.ToLowerInvariant() switch
-        {
-            "utf8" or "utf-8" => Encoding.UTF8.GetBytes(data),
-            "ascii" => Encoding.ASCII.GetBytes(data),
-            "base64" => Convert.FromBase64String(data),
-            "hex" => ConvertHexToBytes(data),
-            "latin1" or "binary" => Encoding.Latin1.GetBytes(data),
-            "ucs2" or "ucs-2" or "utf16le" or "utf-16le" => Encoding.Unicode.GetBytes(data),
-            _ => throw new ArgumentException($"Unknown encoding: {encoding}")
-        };
-    }
+    // Encoding conversions delegate to the shared BufferEncoding table so Buffer
+    // and fs agree on every encoding name (and the compiled IL twin stays in sync).
+    private static byte[] EncodeString(string data, string encoding) => BufferEncoding.Encode(data, encoding);
 
-    /// <summary>
-    /// Decodes bytes to string using the specified encoding.
-    /// </summary>
-    private static string DecodeBytes(byte[] data, string encoding)
-    {
-        return encoding.ToLowerInvariant() switch
-        {
-            "utf8" or "utf-8" => Encoding.UTF8.GetString(data),
-            "ascii" => Encoding.ASCII.GetString(data),
-            "base64" => Convert.ToBase64String(data),
-            "hex" => Convert.ToHexString(data).ToLowerInvariant(),
-            "latin1" or "binary" => Encoding.Latin1.GetString(data),
-            "ucs2" or "ucs-2" or "utf16le" or "utf-16le" => Encoding.Unicode.GetString(data),
-            _ => throw new ArgumentException($"Unknown encoding: {encoding}")
-        };
-    }
-
-    /// <summary>
-    /// Converts a hex string to byte array.
-    /// </summary>
-    private static byte[] ConvertHexToBytes(string hex)
-    {
-        if (string.IsNullOrEmpty(hex))
-            return [];
-
-        // Remove any spaces or hyphens
-        hex = hex.Replace(" ", "").Replace("-", "");
-
-        // Handle odd-length strings by padding
-        if (hex.Length % 2 != 0)
-            hex = "0" + hex;
-
-        var bytes = new byte[hex.Length / 2];
-        for (int i = 0; i < bytes.Length; i++)
-        {
-            bytes[i] = Convert.ToByte(hex.Substring(i * 2, 2), 16);
-        }
-        return bytes;
-    }
+    private static string DecodeBytes(byte[] data, string encoding) => BufferEncoding.Decode(data, encoding);
 
     #endregion
 }

--- a/SharpTS.Tests/SharedTests/BuiltInModules/FsModuleTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/FsModuleTests.cs
@@ -1303,4 +1303,78 @@ public class FsModuleTests
     }
 
     #endregion
+
+    #region Encoding / binary I/O correctness (#978)
+
+    // Identical asserts across ExecutionModes.All enforce interp==compiled parity.
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Fs_WriteReadBuffer_BinaryRoundTrip(ExecutionMode mode)
+    {
+        var uid = Uid();
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = $$"""
+                import * as fs from 'fs';
+                import * as os from 'os';
+                import { Buffer } from 'buffer';
+                const f = os.tmpdir() + '/bin_{{uid}}.bin';
+                const bin = Buffer.from([0, 255, 128, 10, 0, 200]);
+                fs.writeFileSync(f, bin);
+                const r = fs.readFileSync(f);
+                console.log(r.length === 6 && r[0] === 0 && r[1] === 255 && r[2] === 128 && r[5] === 200);
+                fs.unlinkSync(f);
+                """
+        };
+        Assert.Equal("true\n", TestHarness.RunModules(files, "main.ts", mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Fs_Encoding_HexAndBase64(ExecutionMode mode)
+    {
+        var uid = Uid();
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = $$"""
+                import * as fs from 'fs';
+                import * as os from 'os';
+                const f = os.tmpdir() + '/enc_{{uid}}.txt';
+                fs.writeFileSync(f, '48656c6c6f', 'hex');       // "Hello"
+                console.log(fs.readFileSync(f, 'utf8'));
+                console.log(fs.readFileSync(f, 'hex'));
+                fs.writeFileSync(f, 'SGk=', 'base64');           // "Hi"
+                console.log(fs.readFileSync(f, 'utf8'));
+                console.log(fs.readFileSync(f, 'base64url'));
+                fs.unlinkSync(f);
+                """
+        };
+        Assert.Equal("Hello\n48656c6c6f\nHi\nSGk\n", TestHarness.RunModules(files, "main.ts", mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Fs_Encoding_Latin1AndUtf16le(ExecutionMode mode)
+    {
+        var uid = Uid();
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = $$"""
+                import * as fs from 'fs';
+                import * as os from 'os';
+                import { Buffer } from 'buffer';
+                const f = os.tmpdir() + '/enc2_{{uid}}.txt';
+                fs.writeFileSync(f, Buffer.from([0xe9]));        // é (latin1)
+                console.log(fs.readFileSync(f, 'latin1'));
+                fs.writeFileSync(f, 'AB', 'utf16le');
+                console.log(fs.readFileSync(f, 'hex'));          // 41004200
+                console.log(fs.readFileSync(f, 'utf16le'));      // AB
+                fs.unlinkSync(f);
+                """
+        };
+        Assert.Equal("é\n41004200\nAB\n", TestHarness.RunModules(files, "main.ts", mode));
+    }
+
+    #endregion
 }

--- a/TypeSystem/BuiltInModuleTypes.cs
+++ b/TypeSystem/BuiltInModuleTypes.cs
@@ -135,14 +135,17 @@ public static class BuiltInModuleTypes
                 RequiredParams: 1
             ),
 
-            // Write operations - return void
+            // Write operations - return void. Data may be a string, Buffer, or
+            // TypedArray (any); the optional third arg carries the encoding/options.
             ["writeFileSync"] = new TypeInfo.Function(
-                [stringType, new TypeInfo.Union([stringType, new TypeInfo.Array(numberType)])],
-                voidType
+                [stringType, anyType, anyType],
+                voidType,
+                RequiredParams: 2
             ),
             ["appendFileSync"] = new TypeInfo.Function(
-                [stringType, stringType],
-                voidType
+                [stringType, anyType, anyType],
+                voidType,
+                RequiredParams: 2
             ),
 
             // File/directory deletion

--- a/stdlib/node/fs.ts
+++ b/stdlib/node/fs.ts
@@ -125,10 +125,16 @@ export function readFileSync(path: string, options?: any): string | Buffer {
 }
 
 /** Synchronously writes data to a file, replacing the file if it already exists. */
-export function writeFileSync(path: string, data: any, options?: any): void { __writeFileSync(path, data); }
+export function writeFileSync(path: string, data: any, options?: any): void {
+    if (options === undefined) { __writeFileSync(path, data); return; }
+    __writeFileSync(path, data, options);
+}
 
 /** Synchronously appends data to a file, creating the file if it does not yet exist. */
-export function appendFileSync(path: string, data: any, options?: any): void { __appendFileSync(path, data); }
+export function appendFileSync(path: string, data: any, options?: any): void {
+    if (options === undefined) { __appendFileSync(path, data); return; }
+    __appendFileSync(path, data, options);
+}
 
 /** Synchronously removes a file or symbolic link. */
 export function unlinkSync(path: string): void { __unlinkSync(path); }


### PR DESCRIPTION
Part of #968. Stacked on #969.

Fixes the `writeFileSync`/`appendFileSync` `.ToString()` Buffer-corruption bug and per-encoding read/write in both modes, via one BCL-only `BufferEncoding` shared by Buffer and fs. Also fixes adjacent Buffer encoder parity bugs (interp base64url; compiled latin1/utf16le/ucs2/base64url). Byte-identical interp↔compiled; standalone preserved.

Closes #978.