### PR TITLE
feat(fs): mkdir semantics + accessSync mode + complete fs.constants (#979)

### DIFF
--- a/Compilation/RuntimeEmitter.FsSync.cs
+++ b/Compilation/RuntimeEmitter.FsSync.cs
@@ -797,6 +797,25 @@ public partial class RuntimeEmitter
         var pathLocal = il.DeclareLocal(_types.String);
         il.Emit(OpCodes.Stloc, pathLocal);
 
+        // mode = arg1 is a boxed double ? (int)(double)arg1 : 0. The async access
+        // path forwards an undefined mode, so unbox only when it really is a number.
+        var modeLocal = il.DeclareLocal(_types.Int32);
+        var modeNotDouble = il.DefineLabel();
+        var modeDone = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Isinst, _types.Double);
+        il.Emit(OpCodes.Dup);
+        il.Emit(OpCodes.Brfalse, modeNotDouble);
+        il.Emit(OpCodes.Unbox_Any, _types.Double);
+        il.Emit(OpCodes.Conv_I4);
+        il.Emit(OpCodes.Stloc, modeLocal);
+        il.Emit(OpCodes.Br, modeDone);
+        il.MarkLabel(modeNotDouble);
+        il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Stloc, modeLocal);
+        il.MarkLabel(modeDone);
+
         EmitWithFsErrorHandling(il, runtime, pathLocal, "access", afterTry =>
         {
             // Check if exists (File.Exists || Directory.Exists)
@@ -816,6 +835,32 @@ public partial class RuntimeEmitter
             il.Emit(OpCodes.Throw);
 
             il.MarkLabel(existsLabel);
+
+            // W_OK (mode & 2): a read-only file denies writes (best-effort, mirrors the
+            // interpreter's CheckAccess — surfaced as EACCES by the fs error wrapper).
+            var skipWok = il.DefineLabel();
+            il.Emit(OpCodes.Ldloc, modeLocal);
+            il.Emit(OpCodes.Ldc_I4_2);
+            il.Emit(OpCodes.And);
+            il.Emit(OpCodes.Brfalse, skipWok);
+
+            // Only files have a meaningful read-only attribute here.
+            il.Emit(OpCodes.Ldloc, pathLocal);
+            il.Emit(OpCodes.Call, _types.GetMethod(_types.File, "Exists", _types.String));
+            il.Emit(OpCodes.Brfalse, skipWok);
+
+            // (File.GetAttributes(path) & FileAttributes.ReadOnly) != 0
+            il.Emit(OpCodes.Ldloc, pathLocal);
+            il.Emit(OpCodes.Call, _types.GetMethod(_types.File, "GetAttributes", _types.String));
+            il.Emit(OpCodes.Ldc_I4_1); // FileAttributes.ReadOnly
+            il.Emit(OpCodes.And);
+            il.Emit(OpCodes.Brfalse, skipWok);
+
+            il.Emit(OpCodes.Ldstr, "permission denied");
+            il.Emit(OpCodes.Newobj, typeof(UnauthorizedAccessException).GetConstructor([_types.String])!);
+            il.Emit(OpCodes.Throw);
+
+            il.MarkLabel(skipWok);
             il.Emit(OpCodes.Leave, afterTry);
         });
         il.Emit(OpCodes.Ret);

--- a/Runtime/BuiltIns/Modules/Interpreter/FsAsyncHelpers.cs
+++ b/Runtime/BuiltIns/Modules/Interpreter/FsAsyncHelpers.cs
@@ -345,16 +345,11 @@ public static class FsAsyncHelpers
     /// <param name="mode">Optional mode specifying the accessibility checks (F_OK=0, R_OK=4, W_OK=2, X_OK=1).</param>
     public static async Task AccessAsync(string path, object? mode)
     {
-        await Task.Run(() =>
-        {
-            if (!File.Exists(path) && !Directory.Exists(path))
-            {
-                throw new FileNotFoundException("no such file or directory", path);
-            }
-
-            // For now, just check existence
-            // Full implementation would check actual permissions based on mode
-        });
+        var modeInt = mode is double d ? (int)d : 0;
+        // Shared with the sync path so callback/promise access enforce the same
+        // F_OK/W_OK semantics as accessSync (and the compiled async path, which
+        // calls the same FsAccessSync helper).
+        await Task.Run(() => FsModuleInterpreter.CheckAccess(path, modeInt));
     }
 
     /// <summary>

--- a/Runtime/BuiltIns/Modules/Interpreter/FsModuleInterpreter.cs
+++ b/Runtime/BuiltIns/Modules/Interpreter/FsModuleInterpreter.cs
@@ -397,16 +397,34 @@ public static class FsModuleInterpreter
     private static RuntimeValue AccessSync(Interp interpreter, RuntimeValue receiver, ReadOnlySpan<RuntimeValue> args)
     {
         var path = args[0].ToObject()?.ToString() ?? "";
+        var mode = args.Length >= 2 && args[1].ToObject() is double d ? (int)d : 0;
 
-        WrapFsOperation("access", path, () =>
-        {
-            if (!File.Exists(path) && !Directory.Exists(path))
-            {
-                throw new FileNotFoundException("no such file or directory", path);
-            }
-        });
+        WrapFsOperation("access", path, () => CheckAccess(path, mode));
 
         return RuntimeValue.Null;
+    }
+
+    /// <summary>
+    /// Enforces an fs.access mode against a path. F_OK requires existence (ENOENT
+    /// otherwise); W_OK requires the target to be writable — best-effort on Windows
+    /// (a read-only attribute denies writes, EACCES). R_OK/X_OK are treated as
+    /// granted when the path exists on the supported platforms. Shared by the sync
+    /// and async access implementations.
+    /// </summary>
+    internal static void CheckAccess(string path, int mode)
+    {
+        var isFile = File.Exists(path);
+        var isDir = Directory.Exists(path);
+        if (!isFile && !isDir)
+        {
+            throw new FileNotFoundException("no such file or directory", path);
+        }
+
+        // W_OK (2): writability. A read-only file can't be written (Windows + Unix).
+        if ((mode & 2) != 0 && isFile && File.GetAttributes(path).HasFlag(FileAttributes.ReadOnly))
+        {
+            throw new UnauthorizedAccessException($"permission denied, access '{path}'");
+        }
     }
 
     private static RuntimeValue LstatSync(Interp interpreter, RuntimeValue receiver, ReadOnlySpan<RuntimeValue> args)

--- a/SharpTS.Tests/SharedTests/BuiltInModules/FsModuleTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/FsModuleTests.cs
@@ -1377,4 +1377,102 @@ public class FsModuleTests
     }
 
     #endregion
+
+    #region Sync option semantics + constants (#979)
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Fs_MkdirSync_NonRecursive_ThrowsEexistAndEnoent(ExecutionMode mode)
+    {
+        var uid = Uid();
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = $$"""
+                import * as fs from 'fs';
+                import * as os from 'os';
+                const base = os.tmpdir() + '/mkd_{{uid}}';
+                fs.mkdirSync(base);
+                let a = 'none';
+                try { fs.mkdirSync(base); } catch (e: any) { a = e.code; }   // exists -> EEXIST
+                console.log(a);
+                let b = 'none';
+                try { fs.mkdirSync(base + '/x/y/z'); } catch (e: any) { b = e.code; }  // missing parent -> ENOENT
+                console.log(b);
+                """
+        };
+        Assert.Equal("EEXIST\nENOENT\n", TestHarness.RunModules(files, "main.ts", mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Fs_MkdirSync_Recursive_ReturnsFirstCreated(ExecutionMode mode)
+    {
+        var uid = Uid();
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = $$"""
+                import * as fs from 'fs';
+                import * as os from 'os';
+                const base = os.tmpdir() + '/mkr_{{uid}}';
+                fs.mkdirSync(base);
+                const created = fs.mkdirSync(base + '/p/q/r', { recursive: true });
+                console.log(typeof created === 'string' && created.endsWith('p'));   // first created = .../p
+                console.log(fs.mkdirSync(base + '/p/q/r', { recursive: true }) === undefined); // nothing new
+                console.log(fs.existsSync(base + '/p/q/r'));
+                """
+        };
+        Assert.Equal("true\ntrue\ntrue\n", TestHarness.RunModules(files, "main.ts", mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Fs_AccessSync_WriteOk_ThrowsOnReadOnly(ExecutionMode mode)
+    {
+        var path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"ro_{Uid()}.txt");
+        System.IO.File.WriteAllText(path, "x");
+        System.IO.File.SetAttributes(path, System.IO.FileAttributes.ReadOnly);
+        try
+        {
+            var jsPath = path.Replace("\\", "\\\\");
+            var files = new Dictionary<string, string>
+            {
+                ["main.ts"] = $$"""
+                    import * as fs from 'fs';
+                    let w = 'none';
+                    try { fs.accessSync('{{jsPath}}', fs.constants.W_OK); w = 'ok'; } catch (e: any) { w = e.code; }
+                    console.log(w);
+                    let r = 'none';
+                    try { fs.accessSync('{{jsPath}}', fs.constants.R_OK); r = 'ok'; } catch (e: any) { r = e.code; }
+                    console.log(r);
+                    """
+            };
+            Assert.Equal("EACCES\nok\n", TestHarness.RunModules(files, "main.ts", mode));
+        }
+        finally
+        {
+            System.IO.File.SetAttributes(path, System.IO.FileAttributes.Normal);
+            System.IO.File.Delete(path);
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Fs_Constants_AreComplete(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import * as fs from 'fs';
+                const c = fs.constants;
+                console.log([c.F_OK, c.R_OK, c.W_OK, c.X_OK].join(','));
+                console.log([c.S_IRUSR, c.S_IWUSR, c.S_IXUSR, c.S_IRWXU].join(','));
+                console.log([c.O_DIRECTORY, c.O_NOFOLLOW, c.O_SYNC, c.O_DSYNC, c.O_NONBLOCK].join(','));
+                console.log([c.UV_FS_SYMLINK_DIR, c.UV_FS_SYMLINK_JUNCTION].join(','));
+                """
+        };
+        Assert.Equal("0,4,2,1\n256,128,64,448\n65536,131072,1052672,4096,2048\n1,2\n",
+            TestHarness.RunModules(files, "main.ts", mode));
+    }
+
+    #endregion
 }

--- a/stdlib/node/fs.ts
+++ b/stdlib/node/fs.ts
@@ -59,8 +59,6 @@ import {
     watch as __watch,
     watchFile as __watchFile,
     unwatchFile as __unwatchFile,
-    // Constants
-    constants as __constants,
 } from 'primitive:fs';
 
 import {
@@ -140,9 +138,61 @@ export function appendFileSync(path: string, data: any, options?: any): void {
 export function unlinkSync(path: string): void { __unlinkSync(path); }
 
 /** Synchronously creates a directory. */
+// --- mkdir helpers (Node semantics live here in TS; the primitive only does the
+// raw, always-recursive directory create, so the facade handles recursive vs not,
+// EEXIST/ENOENT, and the recursive return value). ---
+
+/** Minimal parent-directory of a path, separator-agnostic (handles / and \\). */
+function __parentDir(p: string): string {
+    let end = p.length;
+    while (end > 1 && (p[end - 1] === '/' || p[end - 1] === '\\')) end--;
+    let i = end - 1;
+    while (i >= 0 && p[i] !== '/' && p[i] !== '\\') i--;
+    if (i < 0) return '';
+    if (i === 0) return p[0];
+    return p.slice(0, i);
+}
+
+const __errnoFor: any = { ENOENT: -2, EEXIST: -17, EACCES: -13 };
+
+/** Builds a Node-shaped fs error (code/errno/syscall/path) thrown from the facade. */
+function __fsError(code: string, message: string, syscall: string, path: string): any {
+    const err: any = new Error(code + ': ' + message + ', ' + syscall + " '" + path + "'");
+    err.code = code;
+    err.errno = __errnoFor[code] !== undefined ? __errnoFor[code] : -1;
+    err.syscall = syscall;
+    err.path = path;
+    return err;
+}
+
+/** Synchronously creates a directory. Honors `{ recursive }`: non-recursive throws
+ * EEXIST/ENOENT like Node; recursive returns the first directory created (or undefined). */
 export function mkdirSync(path: string, options?: any): any {
-    if (options === undefined) return __mkdirSync(path);
-    return __mkdirSync(path, options);
+    const recursive = typeof options === 'object' && options !== null && !!options.recursive;
+    if (recursive) {
+        let firstCreated: any = undefined;
+        if (!__existsSync(path)) {
+            let dir = path;
+            while (!__existsSync(dir)) {
+                firstCreated = dir;
+                const parent = __parentDir(dir);
+                if (!parent || parent === dir) break;
+                dir = parent;
+            }
+        }
+        __mkdirSync(path, options);
+        return firstCreated;
+    }
+    // Non-recursive: Node throws ENOENT if a parent is missing, EEXIST if it exists.
+    const parent = __parentDir(path);
+    if (parent && parent !== path && !__existsSync(parent)) {
+        throw __fsError('ENOENT', 'no such file or directory', 'mkdir', path);
+    }
+    if (__existsSync(path)) {
+        throw __fsError('EEXIST', 'file already exists', 'mkdir', path);
+    }
+    __mkdirSync(path);
+    return undefined;
 }
 
 /** Synchronously removes a directory. */
@@ -260,8 +310,33 @@ export function watchFile(filename: string, options: any, listener?: any): any {
 /** Stops watching a file previously registered with watchFile. */
 export function unwatchFile(filename: string, listener?: any): void { __unwatchFile(filename, listener); }
 
-/** File-system constants (access modes, open flags, copy flags, file-type bits). */
-export const constants: any = __constants;
+/**
+ * File-system constants (access modes, open flags, copy flags, file-type bits,
+ * permission bits, libuv flags). Defined here so `fs.constants` and
+ * `fs.promises.constants` share one complete table across both execution modes.
+ * Values follow the POSIX/Linux set SharpTS's openSync flag parsing expects.
+ */
+export const constants: any = {
+    // Access modes (accessSync)
+    F_OK: 0, R_OK: 4, W_OK: 2, X_OK: 1,
+    // Open flags (openSync)
+    O_RDONLY: 0, O_WRONLY: 1, O_RDWR: 2,
+    O_CREAT: 64, O_EXCL: 128, O_NOCTTY: 256, O_TRUNC: 512,
+    O_APPEND: 1024, O_NONBLOCK: 2048, O_DSYNC: 4096,
+    O_DIRECTORY: 65536, O_NOFOLLOW: 131072, O_NOATIME: 262144,
+    O_SYNC: 1052672,
+    // Copy flags (copyFile)
+    COPYFILE_EXCL: 1, COPYFILE_FICLONE: 2, COPYFILE_FICLONE_FORCE: 4,
+    // File-type bits (stat mode)
+    S_IFMT: 61440, S_IFREG: 32768, S_IFDIR: 16384, S_IFCHR: 8192,
+    S_IFBLK: 24576, S_IFIFO: 4096, S_IFLNK: 40960, S_IFSOCK: 49152,
+    // Permission bits (stat mode)
+    S_IRWXU: 448, S_IRUSR: 256, S_IWUSR: 128, S_IXUSR: 64,
+    S_IRWXG: 56, S_IRGRP: 32, S_IWGRP: 16, S_IXGRP: 8,
+    S_IRWXO: 7, S_IROTH: 4, S_IWOTH: 2, S_IXOTH: 1,
+    // libuv flags
+    UV_FS_O_FILEMAP: 0, UV_FS_SYMLINK_DIR: 1, UV_FS_SYMLINK_JUNCTION: 2,
+};
 
 // ===========================================================================
 // Callback-based async APIs — derived from the promise primitives.
@@ -412,7 +487,7 @@ export const promises = {
     symlink: (target: string, path: string, type?: any): Promise<void> => __pSymlink(target, path, type),
     link: (existingPath: string, newPath: string): Promise<void> => __pLink(existingPath, newPath),
     mkdtemp: (prefix: string): Promise<any> => __pMkdtemp(prefix),
-    constants: __constants,
+    constants,
 };
 
 // Node's `fs` module exposes its surface as both named exports and a default

--- a/stdlib/node/fs/promises.ts
+++ b/stdlib/node/fs/promises.ts
@@ -27,8 +27,9 @@ import {
     symlink as __symlink,
     link as __link,
     mkdtemp as __mkdtemp,
-    constants as __constants,
 } from 'primitive:fs/promises';
+// Node guarantees fs.promises.constants === fs.constants; share the one complete table.
+import { constants } from 'fs';
 
 /** Asynchronously reads the entire contents of a file. */
 export function readFile(path: string, options?: any): Promise<any> { return __readFile(path, options); }
@@ -93,8 +94,8 @@ export function link(existingPath: string, newPath: string): Promise<void> { ret
 /** Asynchronously creates a unique temporary directory. */
 export function mkdtemp(prefix: string): Promise<any> { return __mkdtemp(prefix); }
 
-/** File-system constants (access modes, open flags, copy flags, file-type bits). */
-export const constants: any = __constants;
+/** File-system constants — re-exported from 'fs' so both share one table. */
+export { constants };
 
 export default {
     readFile, writeFile, appendFile, stat, lstat, unlink, mkdir, rmdir, rm,


### PR DESCRIPTION
Part of #968. Stacked on #978.

mkdirSync EEXIST/ENOENT/recursive-return + complete `fs.constants` in the facade (both modes, no IL); accessSync W_OK→EACCES in the primitive. +4 dual-mode tests; full xUnit green.

Closes #979.