### PR TITLE
feat(fs): unify Stats/Dirent via one TS Stats class over statRaw (#977)

### DIFF
--- a/Compilation/EmittedRuntime.cs
+++ b/Compilation/EmittedRuntime.cs
@@ -1509,6 +1509,12 @@ public class EmittedRuntime
     public MethodBuilder FsReaddirSync { get; set; } = null!;
     public MethodBuilder FsStatSync { get; set; } = null!;
     public MethodBuilder FsLstatSync { get; set; } = null!;
+    // Raw stat records (#977) — the TS Stats class shapes these.
+    public MethodBuilder FsStatRaw { get; set; } = null!;
+    public MethodBuilder FsLstatRaw { get; set; } = null!;
+    public MethodBuilder FsFstatRaw { get; set; } = null!;
+    public MethodBuilder FsBuildStatRecord { get; set; } = null!;
+    public MethodBuilder FsStatTimeMs { get; set; } = null!;
     public MethodBuilder FsRenameSync { get; set; } = null!;
     public MethodBuilder FsCopyFileSync { get; set; } = null!;
     public MethodBuilder FsAccessSync { get; set; } = null!;

--- a/Compilation/Emitters/Modules/FsModuleEmitter.cs
+++ b/Compilation/Emitters/Modules/FsModuleEmitter.cs
@@ -18,7 +18,8 @@ public sealed class FsModuleEmitter : IBuiltInModuleEmitter
     [
         "existsSync", "readFileSync", "writeFileSync", "appendFileSync",
         "unlinkSync", "mkdirSync", "rmdirSync", "readdirSync",
-        "statSync", "lstatSync", "renameSync", "copyFileSync", "accessSync",
+        "statSync", "lstatSync", "statRaw", "lstatRaw", "fstatRaw",
+        "renameSync", "copyFileSync", "accessSync",
         "chmodSync", "chownSync", "lchownSync", "truncateSync",
         "symlinkSync", "readlinkSync", "realpathSync", "utimesSync",
         // File descriptor APIs
@@ -52,6 +53,9 @@ public sealed class FsModuleEmitter : IBuiltInModuleEmitter
             "readdirSync" => EmitReaddirSync(emitter, arguments),
             "statSync" => EmitStatSync(emitter, arguments),
             "lstatSync" => EmitLstatSync(emitter, arguments),
+            "statRaw" => EmitStatRawOp(emitter, arguments, emitter.Context.Runtime!.FsStatRaw),
+            "lstatRaw" => EmitStatRawOp(emitter, arguments, emitter.Context.Runtime!.FsLstatRaw),
+            "fstatRaw" => EmitStatRawOp(emitter, arguments, emitter.Context.Runtime!.FsFstatRaw),
             "renameSync" => EmitRenameSync(emitter, arguments),
             "copyFileSync" => EmitCopyFileSync(emitter, arguments),
             "accessSync" => EmitAccessSync(emitter, arguments),
@@ -368,6 +372,23 @@ public sealed class FsModuleEmitter : IBuiltInModuleEmitter
 
         // Call runtime helper: FsStatSync(object path) -> object (Stats-like object)
         il.Emit(OpCodes.Call, ctx.Runtime!.FsStatSync);
+        return true;
+    }
+
+    // statRaw/lstatRaw/fstatRaw (#977): emit the single arg (path or fd) and call
+    // the given raw-record helper, which returns the flat record the TS Stats shapes.
+    private static bool EmitStatRawOp(IEmitterContext emitter, List<Expr> arguments, System.Reflection.MethodInfo helper)
+    {
+        var ctx = emitter.Context;
+        var il = ctx.IL;
+        if (arguments.Count == 0)
+        {
+            il.Emit(OpCodes.Ldnull);
+            return true;
+        }
+        emitter.EmitExpression(arguments[0]);
+        emitter.EmitBoxIfNeeded(arguments[0]);
+        il.Emit(OpCodes.Call, helper);
         return true;
     }
 

--- a/Compilation/RuntimeEmitter.FsAsync.cs
+++ b/Compilation/RuntimeEmitter.FsAsync.cs
@@ -190,9 +190,9 @@ public partial class RuntimeEmitter
         var il = method.GetILGenerator();
         var (fromResult, resultTask, afterTry) = BeginFsAsyncTryCatch(il);
 
-        // Call FsStatSync(path)
+        // Call FsStatRaw(path) — return the raw record (#977); the TS Stats shapes it.
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Call, runtime.FsStatSync);
+        il.Emit(OpCodes.Call, runtime.FsStatRaw);
 
         // Wrap in Task.FromResult
         il.Emit(OpCodes.Call, fromResult);
@@ -218,9 +218,9 @@ public partial class RuntimeEmitter
         var il = method.GetILGenerator();
         var (fromResult, resultTask, afterTry) = BeginFsAsyncTryCatch(il);
 
-        // Call FsLstatSync(path)
+        // Call FsLstatRaw(path) — return the raw record (#977); the TS Stats shapes it.
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Call, runtime.FsLstatSync);
+        il.Emit(OpCodes.Call, runtime.FsLstatRaw);
 
         // Wrap in Task.FromResult
         il.Emit(OpCodes.Call, fromResult);

--- a/Compilation/RuntimeEmitter.FsHelpers.cs
+++ b/Compilation/RuntimeEmitter.FsHelpers.cs
@@ -58,6 +58,7 @@ public partial class RuntimeEmitter
         EmitFsReaddirSync(typeBuilder, runtime);
         EmitFsStatSync(typeBuilder, runtime);
         EmitFsLstatSync(typeBuilder, runtime);
+        EmitFsStatRawHelpers(typeBuilder, runtime); // #977: statRaw/lstatRaw/fstatRaw
         EmitFsRenameSync(typeBuilder, runtime);
         EmitFsCopyFileSync(typeBuilder, runtime);
         EmitFsAccessSync(typeBuilder, runtime);

--- a/Compilation/RuntimeEmitter.FsStatRaw.cs
+++ b/Compilation/RuntimeEmitter.FsStatRaw.cs
@@ -1,0 +1,351 @@
+using System.IO;
+using System.Reflection.Emit;
+
+namespace SharpTS.Compilation;
+
+public partial class RuntimeEmitter
+{
+    /// <summary>
+    /// Emits the raw stat record helpers (#977): FsStatTimeMs, FsBuildStatRecord,
+    /// and FsStatRaw/FsLstatRaw/FsFstatRaw. These return a flat numeric record that
+    /// the TS Stats class shapes — mirroring FsModuleInterpreter.BuildStatRecord so
+    /// interpreter and compiled Stats agree. BCL-only (standalone).
+    /// </summary>
+    private void EmitFsStatRawHelpers(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    {
+        EmitFsStatTimeMs(typeBuilder, runtime);
+        EmitFsBuildStatRecord(typeBuilder, runtime);
+        EmitFsStatRaw(typeBuilder, runtime);
+        EmitFsLstatRaw(typeBuilder, runtime);
+        EmitFsFstatRaw(typeBuilder, runtime);
+    }
+
+    /// <summary>double FsStatTimeMs(DateTime local) = unix-ms of local.ToUniversalTime().</summary>
+    private void EmitFsStatTimeMs(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    {
+        var method = typeBuilder.DefineMethod("FsStatTimeMs",
+            System.Reflection.MethodAttributes.Public | System.Reflection.MethodAttributes.Static,
+            _types.Double, [typeof(DateTime)]);
+        runtime.FsStatTimeMs = method;
+
+        var il = method.GetILGenerator();
+        var utc = il.DeclareLocal(typeof(DateTime));
+        il.Emit(OpCodes.Ldarga_S, (byte)0);
+        il.Emit(OpCodes.Call, typeof(DateTime).GetMethod("ToUniversalTime", Type.EmptyTypes)!);
+        il.Emit(OpCodes.Stloc, utc);
+        var dto = il.DeclareLocal(typeof(DateTimeOffset));
+        il.Emit(OpCodes.Ldloc, utc);
+        il.Emit(OpCodes.Newobj, typeof(DateTimeOffset).GetConstructor([typeof(DateTime)])!);
+        il.Emit(OpCodes.Stloc, dto);
+        il.Emit(OpCodes.Ldloca, dto);
+        il.Emit(OpCodes.Call, typeof(DateTimeOffset).GetMethod("ToUnixTimeMilliseconds", Type.EmptyTypes)!);
+        il.Emit(OpCodes.Conv_R8);
+        il.Emit(OpCodes.Ret);
+    }
+
+    /// <summary>
+    /// object FsBuildStatRecord(bool isDir, bool isSymlink, bool isReadOnly,
+    ///   double size, double atimeMs, double mtimeMs, double ctimeMs, double birthtimeMs)
+    /// </summary>
+    private void EmitFsBuildStatRecord(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    {
+        var method = typeBuilder.DefineMethod("FsBuildStatRecord",
+            System.Reflection.MethodAttributes.Public | System.Reflection.MethodAttributes.Static,
+            _types.Object,
+            [_types.Boolean, _types.Boolean, _types.Boolean, _types.Double, _types.Double, _types.Double, _types.Double, _types.Double]);
+        runtime.FsBuildStatRecord = method;
+
+        var il = method.GetILGenerator();
+
+        // typeBits = isSymlink ? 0xA000 : (isDir ? 0x4000 : 0x8000)
+        var typeBits = il.DeclareLocal(_types.Int32);
+        var symL = il.DefineLabel(); var dirL = il.DefineLabel(); var typeDone = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_1); il.Emit(OpCodes.Brtrue, symL);
+        il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Brtrue, dirL);
+        il.Emit(OpCodes.Ldc_I4, 0x8000); il.Emit(OpCodes.Br, typeDone);
+        il.MarkLabel(dirL); il.Emit(OpCodes.Ldc_I4, 0x4000); il.Emit(OpCodes.Br, typeDone);
+        il.MarkLabel(symL); il.Emit(OpCodes.Ldc_I4, 0xA000);
+        il.MarkLabel(typeDone); il.Emit(OpCodes.Stloc, typeBits);
+
+        // permBits = isDir ? 0x1FF : (isReadOnly ? 0x124 : 0x1B6)
+        var permBits = il.DeclareLocal(_types.Int32);
+        var permFile = il.DefineLabel(); var permRo = il.DefineLabel(); var permDone = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Brfalse, permFile);
+        il.Emit(OpCodes.Ldc_I4, 0x1FF); il.Emit(OpCodes.Br, permDone);
+        il.MarkLabel(permFile);
+        il.Emit(OpCodes.Ldarg_2); il.Emit(OpCodes.Brtrue, permRo);
+        il.Emit(OpCodes.Ldc_I4, 0x1B6); il.Emit(OpCodes.Br, permDone);
+        il.MarkLabel(permRo); il.Emit(OpCodes.Ldc_I4, 0x124);
+        il.MarkLabel(permDone); il.Emit(OpCodes.Stloc, permBits);
+
+        // mode = (double)(typeBits | permBits)
+        var modeL = il.DeclareLocal(_types.Double);
+        il.Emit(OpCodes.Ldloc, typeBits); il.Emit(OpCodes.Ldloc, permBits); il.Emit(OpCodes.Or);
+        il.Emit(OpCodes.Conv_R8); il.Emit(OpCodes.Stloc, modeL);
+
+        // blocks = Math.Floor((size + 511) / 512)
+        var blocksL = il.DeclareLocal(_types.Double);
+        il.Emit(OpCodes.Ldarg_3); il.Emit(OpCodes.Ldc_R8, 511.0); il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Ldc_R8, 512.0); il.Emit(OpCodes.Div);
+        il.Emit(OpCodes.Call, typeof(Math).GetMethod("Floor", [typeof(double)])!);
+        il.Emit(OpCodes.Stloc, blocksL);
+
+        var dictType = _types.DictionaryStringObject;
+        var dictCtor = _types.GetDefaultConstructor(dictType);
+        var addMethod = _types.GetMethod(dictType, "Add", _types.String, _types.Object);
+        il.Emit(OpCodes.Newobj, dictCtor);
+        var dict = il.DeclareLocal(dictType);
+        il.Emit(OpCodes.Stloc, dict);
+
+        void AddEntry(string key, Action loadDouble)
+        {
+            il.Emit(OpCodes.Ldloc, dict);
+            il.Emit(OpCodes.Ldstr, key);
+            loadDouble();
+            il.Emit(OpCodes.Box, _types.Double);
+            il.Emit(OpCodes.Call, addMethod);
+        }
+
+        AddEntry("mode", () => il.Emit(OpCodes.Ldloc, modeL));
+        AddEntry("size", () => il.Emit(OpCodes.Ldarg_3));
+        AddEntry("atimeMs", () => il.Emit(OpCodes.Ldarg_S, (byte)4));
+        AddEntry("mtimeMs", () => il.Emit(OpCodes.Ldarg_S, (byte)5));
+        AddEntry("ctimeMs", () => il.Emit(OpCodes.Ldarg_S, (byte)6));
+        AddEntry("birthtimeMs", () => il.Emit(OpCodes.Ldarg_S, (byte)7));
+        AddEntry("dev", () => il.Emit(OpCodes.Ldc_R8, 0.0));
+        AddEntry("ino", () => il.Emit(OpCodes.Ldc_R8, 0.0));
+        AddEntry("nlink", () => il.Emit(OpCodes.Ldc_R8, 1.0));
+        AddEntry("uid", () => il.Emit(OpCodes.Ldc_R8, 0.0));
+        AddEntry("gid", () => il.Emit(OpCodes.Ldc_R8, 0.0));
+        AddEntry("rdev", () => il.Emit(OpCodes.Ldc_R8, 0.0));
+        AddEntry("blksize", () => il.Emit(OpCodes.Ldc_R8, 4096.0));
+        AddEntry("blocks", () => il.Emit(OpCodes.Ldloc, blocksL));
+
+        il.Emit(OpCodes.Ldloc, dict);
+        il.Emit(OpCodes.Call, runtime.CreateObject);
+        il.Emit(OpCodes.Ret);
+    }
+
+    // Loads the four File.Get*Time timestamps (as unix-ms doubles) into the given
+    // locals, from the path local. Times work for files and directories alike.
+    private void EmitLoadStatTimes(ILGenerator il, EmittedRuntime runtime, LocalBuilder pathLocal,
+        LocalBuilder at, LocalBuilder mt, LocalBuilder ct)
+    {
+        il.Emit(OpCodes.Ldloc, pathLocal);
+        il.Emit(OpCodes.Call, _types.GetMethod(_types.File, "GetLastAccessTime", _types.String));
+        il.Emit(OpCodes.Call, runtime.FsStatTimeMs); il.Emit(OpCodes.Stloc, at);
+        il.Emit(OpCodes.Ldloc, pathLocal);
+        il.Emit(OpCodes.Call, _types.GetMethod(_types.File, "GetLastWriteTime", _types.String));
+        il.Emit(OpCodes.Call, runtime.FsStatTimeMs); il.Emit(OpCodes.Stloc, mt);
+        il.Emit(OpCodes.Ldloc, pathLocal);
+        il.Emit(OpCodes.Call, _types.GetMethod(_types.File, "GetCreationTime", _types.String));
+        il.Emit(OpCodes.Call, runtime.FsStatTimeMs); il.Emit(OpCodes.Stloc, ct);
+    }
+
+    /// <summary>object FsStatRaw(object path) — follows symlinks.</summary>
+    private void EmitFsStatRaw(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    {
+        var method = typeBuilder.DefineMethod("FsStatRaw",
+            System.Reflection.MethodAttributes.Public | System.Reflection.MethodAttributes.Static,
+            _types.Object, [_types.Object]);
+        runtime.FsStatRaw = method;
+
+        var il = method.GetILGenerator();
+        var resultLocal = il.DeclareLocal(_types.Object);
+        il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Call, runtime.Stringify);
+        var pathLocal = il.DeclareLocal(_types.String); il.Emit(OpCodes.Stloc, pathLocal);
+
+        EmitWithFsErrorHandling(il, runtime, pathLocal, "stat", afterTry =>
+        {
+            var isDirL = il.DeclareLocal(_types.Boolean);
+            il.Emit(OpCodes.Ldloc, pathLocal);
+            il.Emit(OpCodes.Call, _types.GetMethod(_types.Directory, "Exists", _types.String));
+            il.Emit(OpCodes.Stloc, isDirL);
+            var isFileL = il.DeclareLocal(_types.Boolean);
+            il.Emit(OpCodes.Ldloc, pathLocal);
+            il.Emit(OpCodes.Call, _types.GetMethod(_types.File, "Exists", _types.String));
+            il.Emit(OpCodes.Stloc, isFileL);
+
+            var existsL = il.DefineLabel();
+            il.Emit(OpCodes.Ldloc, isDirL); il.Emit(OpCodes.Brtrue, existsL);
+            il.Emit(OpCodes.Ldloc, isFileL); il.Emit(OpCodes.Brtrue, existsL);
+            il.Emit(OpCodes.Ldstr, "no such file or directory");
+            il.Emit(OpCodes.Ldloc, pathLocal);
+            il.Emit(OpCodes.Newobj, _types.GetConstructor(_types.FileNotFoundException, _types.String, _types.String));
+            il.Emit(OpCodes.Throw);
+            il.MarkLabel(existsL);
+
+            var sizeL = EmitStatSize(il, isFileL, pathLocal);
+            var roL = EmitStatReadOnly(il, isFileL, pathLocal);
+            var at = il.DeclareLocal(_types.Double);
+            var mt = il.DeclareLocal(_types.Double);
+            var ct = il.DeclareLocal(_types.Double);
+            EmitLoadStatTimes(il, runtime, pathLocal, at, mt, ct);
+
+            il.Emit(OpCodes.Ldloc, isDirL);
+            il.Emit(OpCodes.Ldc_I4_0);          // isSymlink = false (stat follows links)
+            il.Emit(OpCodes.Ldloc, roL);
+            il.Emit(OpCodes.Ldloc, sizeL);
+            il.Emit(OpCodes.Ldloc, at); il.Emit(OpCodes.Ldloc, mt);
+            il.Emit(OpCodes.Ldloc, ct); il.Emit(OpCodes.Ldloc, ct);
+            il.Emit(OpCodes.Call, runtime.FsBuildStatRecord);
+            il.Emit(OpCodes.Stloc, resultLocal);
+            il.Emit(OpCodes.Leave, afterTry);
+        });
+        il.Emit(OpCodes.Ldloc, resultLocal);
+        il.Emit(OpCodes.Ret);
+    }
+
+    /// <summary>object FsLstatRaw(object path) — does not follow symlinks.</summary>
+    private void EmitFsLstatRaw(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    {
+        var method = typeBuilder.DefineMethod("FsLstatRaw",
+            System.Reflection.MethodAttributes.Public | System.Reflection.MethodAttributes.Static,
+            _types.Object, [_types.Object]);
+        runtime.FsLstatRaw = method;
+
+        var il = method.GetILGenerator();
+        var resultLocal = il.DeclareLocal(_types.Object);
+        il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Call, runtime.Stringify);
+        var pathLocal = il.DeclareLocal(_types.String); il.Emit(OpCodes.Stloc, pathLocal);
+
+        EmitWithFsErrorHandling(il, runtime, pathLocal, "lstat", afterTry =>
+        {
+            var dirRawL = il.DeclareLocal(_types.Boolean);
+            il.Emit(OpCodes.Ldloc, pathLocal);
+            il.Emit(OpCodes.Call, _types.GetMethod(_types.Directory, "Exists", _types.String));
+            il.Emit(OpCodes.Stloc, dirRawL);
+            var isFileL = il.DeclareLocal(_types.Boolean);
+            il.Emit(OpCodes.Ldloc, pathLocal);
+            il.Emit(OpCodes.Call, _types.GetMethod(_types.File, "Exists", _types.String));
+            il.Emit(OpCodes.Stloc, isFileL);
+
+            var existsL = il.DefineLabel();
+            il.Emit(OpCodes.Ldloc, dirRawL); il.Emit(OpCodes.Brtrue, existsL);
+            il.Emit(OpCodes.Ldloc, isFileL); il.Emit(OpCodes.Brtrue, existsL);
+            il.Emit(OpCodes.Ldstr, "no such file or directory");
+            il.Emit(OpCodes.Ldloc, pathLocal);
+            il.Emit(OpCodes.Newobj, _types.GetConstructor(_types.FileNotFoundException, _types.String, _types.String));
+            il.Emit(OpCodes.Throw);
+            il.MarkLabel(existsL);
+
+            // isDir = dirRaw && !isFile
+            var isDirL = il.DeclareLocal(_types.Boolean);
+            il.Emit(OpCodes.Ldloc, dirRawL);
+            il.Emit(OpCodes.Ldloc, isFileL); il.Emit(OpCodes.Ldc_I4_0); il.Emit(OpCodes.Ceq);
+            il.Emit(OpCodes.And); il.Emit(OpCodes.Stloc, isDirL);
+
+            // isSymlink = (File.GetAttributes(path) & ReparsePoint) != 0
+            var symL = il.DeclareLocal(_types.Boolean);
+            il.Emit(OpCodes.Ldloc, pathLocal);
+            il.Emit(OpCodes.Call, _types.GetMethod(_types.File, "GetAttributes", _types.String));
+            il.Emit(OpCodes.Ldc_I4, (int)FileAttributes.ReparsePoint);
+            il.Emit(OpCodes.And); il.Emit(OpCodes.Ldc_I4_0); il.Emit(OpCodes.Cgt_Un);
+            il.Emit(OpCodes.Stloc, symL);
+
+            var sizeL = EmitStatSize(il, isFileL, pathLocal);
+            var roL = EmitStatReadOnly(il, isFileL, pathLocal);
+            var at = il.DeclareLocal(_types.Double);
+            var mt = il.DeclareLocal(_types.Double);
+            var ct = il.DeclareLocal(_types.Double);
+            EmitLoadStatTimes(il, runtime, pathLocal, at, mt, ct);
+
+            il.Emit(OpCodes.Ldloc, isDirL);
+            il.Emit(OpCodes.Ldloc, symL);
+            il.Emit(OpCodes.Ldloc, roL);
+            il.Emit(OpCodes.Ldloc, sizeL);
+            il.Emit(OpCodes.Ldloc, at); il.Emit(OpCodes.Ldloc, mt);
+            il.Emit(OpCodes.Ldloc, ct); il.Emit(OpCodes.Ldloc, ct);
+            il.Emit(OpCodes.Call, runtime.FsBuildStatRecord);
+            il.Emit(OpCodes.Stloc, resultLocal);
+            il.Emit(OpCodes.Leave, afterTry);
+        });
+        il.Emit(OpCodes.Ldloc, resultLocal);
+        il.Emit(OpCodes.Ret);
+    }
+
+    /// <summary>object FsFstatRaw(object fd).</summary>
+    private void EmitFsFstatRaw(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    {
+        var method = typeBuilder.DefineMethod("FsFstatRaw",
+            System.Reflection.MethodAttributes.Public | System.Reflection.MethodAttributes.Static,
+            _types.Object, [_types.Object]);
+        runtime.FsFstatRaw = method;
+
+        var il = method.GetILGenerator();
+        var resultLocal = il.DeclareLocal(_types.Object);
+
+        il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Call, runtime.ToNumber); il.Emit(OpCodes.Conv_I4);
+        var fdLocal = il.DeclareLocal(_types.Int32); il.Emit(OpCodes.Stloc, fdLocal);
+
+        il.Emit(OpCodes.Ldnull);
+        var pathLocal = il.DeclareLocal(_types.String); il.Emit(OpCodes.Stloc, pathLocal);
+
+        EmitWithFsErrorHandling(il, runtime, pathLocal, "fstat", afterTry =>
+        {
+            il.Emit(OpCodes.Ldsfld, runtime.FileDescriptorTableInstance);
+            il.Emit(OpCodes.Ldloc, fdLocal);
+            il.Emit(OpCodes.Callvirt, runtime.FileDescriptorTableGet);
+            var streamLocal = il.DeclareLocal(typeof(FileStream));
+            il.Emit(OpCodes.Stloc, streamLocal);
+
+            var sizeL = il.DeclareLocal(_types.Double);
+            il.Emit(OpCodes.Ldloc, streamLocal);
+            il.Emit(OpCodes.Callvirt, typeof(FileStream).GetProperty("Length")!.GetMethod!);
+            il.Emit(OpCodes.Conv_R8); il.Emit(OpCodes.Stloc, sizeL);
+
+            // path = stream.Name → for time recovery
+            il.Emit(OpCodes.Ldloc, streamLocal);
+            il.Emit(OpCodes.Callvirt, typeof(FileStream).GetProperty("Name")!.GetMethod!);
+            il.Emit(OpCodes.Stloc, pathLocal);
+
+            var at = il.DeclareLocal(_types.Double);
+            var mt = il.DeclareLocal(_types.Double);
+            var ct = il.DeclareLocal(_types.Double);
+            EmitLoadStatTimes(il, runtime, pathLocal, at, mt, ct);
+
+            il.Emit(OpCodes.Ldc_I4_0);    // isDir = false
+            il.Emit(OpCodes.Ldc_I4_0);    // isSymlink = false
+            il.Emit(OpCodes.Ldc_I4_0);    // isReadOnly = false
+            il.Emit(OpCodes.Ldloc, sizeL);
+            il.Emit(OpCodes.Ldloc, at); il.Emit(OpCodes.Ldloc, mt);
+            il.Emit(OpCodes.Ldloc, ct); il.Emit(OpCodes.Ldloc, ct);
+            il.Emit(OpCodes.Call, runtime.FsBuildStatRecord);
+            il.Emit(OpCodes.Stloc, resultLocal);
+            il.Emit(OpCodes.Leave, afterTry);
+        });
+        il.Emit(OpCodes.Ldloc, resultLocal);
+        il.Emit(OpCodes.Ret);
+    }
+
+    // size = isFile ? (double)new FileInfo(path).Length : 0
+    private LocalBuilder EmitStatSize(ILGenerator il, LocalBuilder isFileL, LocalBuilder pathLocal)
+    {
+        var sizeL = il.DeclareLocal(_types.Double);
+        var notFile = il.DefineLabel(); var done = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, isFileL); il.Emit(OpCodes.Brfalse, notFile);
+        il.Emit(OpCodes.Ldloc, pathLocal);
+        il.Emit(OpCodes.Newobj, _types.GetConstructor(_types.FileInfo, _types.String));
+        il.Emit(OpCodes.Callvirt, _types.GetProperty(_types.FileInfo, "Length").GetMethod!);
+        il.Emit(OpCodes.Conv_R8); il.Emit(OpCodes.Stloc, sizeL); il.Emit(OpCodes.Br, done);
+        il.MarkLabel(notFile); il.Emit(OpCodes.Ldc_R8, 0.0); il.Emit(OpCodes.Stloc, sizeL);
+        il.MarkLabel(done);
+        return sizeL;
+    }
+
+    // readOnly = isFile && (File.GetAttributes(path) & ReadOnly) != 0
+    private LocalBuilder EmitStatReadOnly(ILGenerator il, LocalBuilder isFileL, LocalBuilder pathLocal)
+    {
+        var roL = il.DeclareLocal(_types.Boolean);
+        var notFile = il.DefineLabel(); var done = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, isFileL); il.Emit(OpCodes.Brfalse, notFile);
+        il.Emit(OpCodes.Ldloc, pathLocal);
+        il.Emit(OpCodes.Call, _types.GetMethod(_types.File, "GetAttributes", _types.String));
+        il.Emit(OpCodes.Ldc_I4, (int)FileAttributes.ReadOnly);
+        il.Emit(OpCodes.And); il.Emit(OpCodes.Ldc_I4_0); il.Emit(OpCodes.Cgt_Un);
+        il.Emit(OpCodes.Stloc, roL); il.Emit(OpCodes.Br, done);
+        il.MarkLabel(notFile); il.Emit(OpCodes.Ldc_I4_0); il.Emit(OpCodes.Stloc, roL);
+        il.MarkLabel(done);
+        return roL;
+    }
+}

--- a/Runtime/BuiltIns/Modules/Interpreter/FsAsyncHelpers.cs
+++ b/Runtime/BuiltIns/Modules/Interpreter/FsAsyncHelpers.cs
@@ -70,41 +70,25 @@ public static class FsAsyncHelpers
     /// <returns>A Stats-like object with file information.</returns>
     public static async Task<SharpTSObject> StatAsync(string path)
     {
-        // Use Task.Run to offload the synchronous file info operations
+        // Returns the raw stat record (#977) — same shape/logic as the sync
+        // FsModuleInterpreter.StatRaw, so statSync and await stat agree by
+        // construction; the TS Stats class shapes it. stat follows symlinks.
         return await Task.Run(() =>
         {
             if (Directory.Exists(path))
             {
-                var dirInfo = new DirectoryInfo(path);
-                return CreateStatsObject(
-                    isDirectory: true,
-                    isFile: false,
-                    isSymbolicLink: dirInfo.Attributes.HasFlag(FileAttributes.ReparsePoint),
-                    size: 0,
-                    atime: dirInfo.LastAccessTime,
-                    mtime: dirInfo.LastWriteTime,
-                    ctime: dirInfo.CreationTime,
-                    birthtime: dirInfo.CreationTime
-                );
+                var di = new DirectoryInfo(path);
+                return FsModuleInterpreter.BuildStatRecord(true, false, false, 0.0,
+                    di.LastAccessTime, di.LastWriteTime, di.CreationTime, di.CreationTime);
             }
-            else if (File.Exists(path))
+            if (File.Exists(path))
             {
-                var fileInfo = new FileInfo(path);
-                return CreateStatsObject(
-                    isDirectory: false,
-                    isFile: true,
-                    isSymbolicLink: fileInfo.Attributes.HasFlag(FileAttributes.ReparsePoint),
-                    size: fileInfo.Length,
-                    atime: fileInfo.LastAccessTime,
-                    mtime: fileInfo.LastWriteTime,
-                    ctime: fileInfo.CreationTime,
-                    birthtime: fileInfo.CreationTime
-                );
+                var fi = new FileInfo(path);
+                bool ro = fi.Attributes.HasFlag(FileAttributes.ReadOnly);
+                return FsModuleInterpreter.BuildStatRecord(false, false, ro, fi.Length,
+                    fi.LastAccessTime, fi.LastWriteTime, fi.CreationTime, fi.CreationTime);
             }
-            else
-            {
-                throw new FileNotFoundException("no such file or directory", path);
-            }
+            throw new FileNotFoundException("no such file or directory", path);
         });
     }
 
@@ -238,7 +222,8 @@ public static class FsAsyncHelpers
             {
                 foreach (var entry in entries)
                 {
-                    list.Add(CreateDirent(entry));
+                    // Reuse the one canonical Dirent builder (#977) for sync/async parity.
+                    list.Add(FsModuleInterpreter.CreateDirent(entry, Path.GetDirectoryName(entry) ?? path));
                 }
             }
             else
@@ -257,35 +242,6 @@ public static class FsAsyncHelpers
             }
 
             return new SharpTSArray(list);
-        });
-    }
-
-    /// <summary>
-    /// Creates a Dirent-like object for readdir with withFileTypes option.
-    /// </summary>
-    private static SharpTSObject CreateDirent(string fullPath)
-    {
-        var name = Path.GetFileName(fullPath);
-        var isFile = File.Exists(fullPath);
-        var isDir = Directory.Exists(fullPath);
-        var isSymlink = false;
-
-        var fileInfo = new FileInfo(fullPath);
-        if (fileInfo.Exists || Directory.Exists(fullPath))
-        {
-            isSymlink = fileInfo.Attributes.HasFlag(FileAttributes.ReparsePoint);
-        }
-
-        return new SharpTSObject(new Dictionary<string, object?>
-        {
-            ["name"] = name,
-            ["isFile"] = BuiltInMethod.CreateV2("isFile", 0, 0, (_, _, _) => RuntimeValue.FromBoolean(isFile && !isDir)),
-            ["isDirectory"] = BuiltInMethod.CreateV2("isDirectory", 0, 0, (_, _, _) => RuntimeValue.FromBoolean(isDir)),
-            ["isSymbolicLink"] = BuiltInMethod.CreateV2("isSymbolicLink", 0, 0, (_, _, _) => RuntimeValue.FromBoolean(isSymlink)),
-            ["isBlockDevice"] = BuiltInMethod.CreateV2("isBlockDevice", 0, 0, (_, _, _) => RuntimeValue.False),
-            ["isCharacterDevice"] = BuiltInMethod.CreateV2("isCharacterDevice", 0, 0, (_, _, _) => RuntimeValue.False),
-            ["isFIFO"] = BuiltInMethod.CreateV2("isFIFO", 0, 0, (_, _, _) => RuntimeValue.False),
-            ["isSocket"] = BuiltInMethod.CreateV2("isSocket", 0, 0, (_, _, _) => RuntimeValue.False)
         });
     }
 
@@ -426,38 +382,16 @@ public static class FsAsyncHelpers
                 throw new FileNotFoundException("no such file or directory", path);
             }
 
-            bool isSymlink = false;
+            // Raw record matching the sync FsModuleInterpreter.LstatRaw (#977).
+            bool isSymlink = (fileInfo.Exists ? fileInfo.Attributes : dirInfo.Attributes).HasFlag(FileAttributes.ReparsePoint);
             bool isDir = dirInfo.Exists && !fileInfo.Exists;
-            long size = fileInfo.Exists ? fileInfo.Length : 0;
-            DateTime atime, mtime, ctime, birthtime;
+            double size = fileInfo.Exists ? fileInfo.Length : 0.0;
+            bool ro = fileInfo.Exists && fileInfo.Attributes.HasFlag(FileAttributes.ReadOnly);
+            DateTime atime = isDir ? dirInfo.LastAccessTime : fileInfo.LastAccessTime;
+            DateTime mtime = isDir ? dirInfo.LastWriteTime : fileInfo.LastWriteTime;
+            DateTime ctime = isDir ? dirInfo.CreationTime : fileInfo.CreationTime;
 
-            if (fileInfo.Exists)
-            {
-                isSymlink = fileInfo.Attributes.HasFlag(FileAttributes.ReparsePoint);
-                atime = fileInfo.LastAccessTime;
-                mtime = fileInfo.LastWriteTime;
-                ctime = fileInfo.CreationTime;
-                birthtime = fileInfo.CreationTime;
-            }
-            else
-            {
-                isSymlink = dirInfo.Attributes.HasFlag(FileAttributes.ReparsePoint);
-                atime = dirInfo.LastAccessTime;
-                mtime = dirInfo.LastWriteTime;
-                ctime = dirInfo.CreationTime;
-                birthtime = dirInfo.CreationTime;
-            }
-
-            return CreateStatsObject(
-                isDirectory: isDir,
-                isFile: fileInfo.Exists && !isDir,
-                isSymbolicLink: isSymlink,
-                size: size,
-                atime: atime,
-                mtime: mtime,
-                ctime: ctime,
-                birthtime: birthtime
-            );
+            return FsModuleInterpreter.BuildStatRecord(isDir, isSymlink, ro, size, atime, mtime, ctime, ctime);
         });
     }
 

--- a/Runtime/BuiltIns/Modules/Interpreter/FsModuleInterpreter.cs
+++ b/Runtime/BuiltIns/Modules/Interpreter/FsModuleInterpreter.cs
@@ -73,6 +73,10 @@ public static class FsModuleInterpreter
             ["readdirSync"] = BuiltInMethod.CreateV2("readdirSync", 1, 2, ReaddirSync),
             ["statSync"] = BuiltInMethod.CreateV2("statSync", 1, 1, StatSync),
             ["lstatSync"] = BuiltInMethod.CreateV2("lstatSync", 1, 1, LstatSync),
+            // Raw stat records (#977) — the TS Stats class shapes these.
+            ["statRaw"] = BuiltInMethod.CreateV2("statRaw", 1, 1, StatRaw),
+            ["lstatRaw"] = BuiltInMethod.CreateV2("lstatRaw", 1, 1, LstatRaw),
+            ["fstatRaw"] = BuiltInMethod.CreateV2("fstatRaw", 1, 1, FstatRaw),
             ["renameSync"] = BuiltInMethod.CreateV2("renameSync", 2, 2, RenameSync),
             ["copyFileSync"] = BuiltInMethod.CreateV2("copyFileSync", 2, 3, CopyFileSync),
             ["accessSync"] = BuiltInMethod.CreateV2("accessSync", 1, 2, AccessSync),
@@ -282,7 +286,7 @@ public static class FsModuleInterpreter
             {
                 foreach (var entry in entries)
                 {
-                    list.Add(CreateDirent(entry));
+                    list.Add(CreateDirent(entry, Path.GetDirectoryName(entry) ?? path));
                 }
             }
             else
@@ -308,30 +312,33 @@ public static class FsModuleInterpreter
     /// <summary>
     /// Creates a Dirent-like object for readdirSync({ withFileTypes: true }).
     /// </summary>
-    private static SharpTSObject CreateDirent(string fullPath)
+    internal static SharpTSObject CreateDirent(string fullPath, string parentPath)
     {
         var name = Path.GetFileName(fullPath);
         var isFile = File.Exists(fullPath);
         var isDir = Directory.Exists(fullPath);
         var isSymlink = false;
 
-        // Check for symbolic link
         var fileInfo = new FileInfo(fullPath);
-        if (fileInfo.Exists || Directory.Exists(fullPath))
+        if (fileInfo.Exists || isDir)
         {
             isSymlink = fileInfo.Attributes.HasFlag(FileAttributes.ReparsePoint);
         }
+        var fileOnly = isFile && !isDir;
 
+        // is*() are methods (Node Dirent), uniform across sync/async/compiled (#977).
         return new SharpTSObject(new Dictionary<string, object?>
         {
             ["name"] = name,
-            ["isFile"] = isFile && !isDir,
-            ["isDirectory"] = isDir,
-            ["isSymbolicLink"] = isSymlink,
-            ["isBlockDevice"] = false,
-            ["isCharacterDevice"] = false,
-            ["isFIFO"] = false,
-            ["isSocket"] = false,
+            ["parentPath"] = parentPath,
+            ["path"] = parentPath,
+            ["isFile"] = BuiltInMethod.CreateV2("isFile", 0, 0, (_, _, _) => RuntimeValue.FromBoolean(fileOnly)),
+            ["isDirectory"] = BuiltInMethod.CreateV2("isDirectory", 0, 0, (_, _, _) => RuntimeValue.FromBoolean(isDir)),
+            ["isSymbolicLink"] = BuiltInMethod.CreateV2("isSymbolicLink", 0, 0, (_, _, _) => RuntimeValue.FromBoolean(isSymlink)),
+            ["isBlockDevice"] = BuiltInMethod.CreateV2("isBlockDevice", 0, 0, (_, _, _) => RuntimeValue.False),
+            ["isCharacterDevice"] = BuiltInMethod.CreateV2("isCharacterDevice", 0, 0, (_, _, _) => RuntimeValue.False),
+            ["isFIFO"] = BuiltInMethod.CreateV2("isFIFO", 0, 0, (_, _, _) => RuntimeValue.False),
+            ["isSocket"] = BuiltInMethod.CreateV2("isSocket", 0, 0, (_, _, _) => RuntimeValue.False),
         });
     }
 
@@ -456,6 +463,107 @@ public static class FsModuleInterpreter
                 ["isSymbolicLink"] = BuiltInMethod.CreateV2("isSymbolicLink", 0, 0, (_, _, _) => RuntimeValue.FromBoolean(isSymlink)),
                 ["size"] = size
             });
+        }));
+    }
+
+    // ===== Stats raw record (#977) =====
+    // statRaw/lstatRaw/fstatRaw return a flat numeric record; the TS Stats class
+    // (stdlib/node/fs.ts) shapes it into the Node Stats object. The compiled twin
+    // ($Runtime.FsStatRaw/FsLstatRaw/FsFstatRaw) mirrors this logic byte-for-byte.
+
+    private static double StatTimeMs(DateTime dt) => new DateTimeOffset(dt.ToUniversalTime()).ToUnixTimeMilliseconds();
+
+    /// <summary>
+    /// Builds the flat numeric stat record. Perm bits are best-effort and
+    /// platform-uniform (dir 0o777; file 0o666, or 0o444 when read-only); the
+    /// device/inode/uid/gid fields are documented 0 fallbacks. Mirrored exactly by
+    /// the compiled emitter so interpreter and compiled Stats are byte-identical.
+    /// </summary>
+    internal static SharpTSObject BuildStatRecord(bool isDir, bool isSymlink, bool isReadOnly, double size,
+        DateTime atime, DateTime mtime, DateTime ctime, DateTime birthtime)
+    {
+        int typeBits = isSymlink ? 0xA000 : (isDir ? 0x4000 : 0x8000);
+        int permBits = isDir ? 0x1FF : (isReadOnly ? 0x124 : 0x1B6);
+        double mode = typeBits | permBits;
+        double blocks = Math.Floor((size + 511.0) / 512.0);
+        return new SharpTSObject(new Dictionary<string, object?>
+        {
+            ["mode"] = mode,
+            ["size"] = size,
+            ["atimeMs"] = StatTimeMs(atime),
+            ["mtimeMs"] = StatTimeMs(mtime),
+            ["ctimeMs"] = StatTimeMs(ctime),
+            ["birthtimeMs"] = StatTimeMs(birthtime),
+            ["dev"] = 0.0,
+            ["ino"] = 0.0,
+            ["nlink"] = 1.0,
+            ["uid"] = 0.0,
+            ["gid"] = 0.0,
+            ["rdev"] = 0.0,
+            ["blksize"] = 4096.0,
+            ["blocks"] = blocks,
+        });
+    }
+
+    private static RuntimeValue StatRaw(Interp interpreter, RuntimeValue receiver, ReadOnlySpan<RuntimeValue> args)
+    {
+        var path = args[0].ToObject()?.ToString() ?? "";
+        return RuntimeValue.FromBoxed(WrapFsOperation("stat", path, () =>
+        {
+            if (Directory.Exists(path))
+            {
+                var di = new DirectoryInfo(path);
+                return (object?)BuildStatRecord(true, false, false, 0.0,
+                    di.LastAccessTime, di.LastWriteTime, di.CreationTime, di.CreationTime);
+            }
+            if (File.Exists(path))
+            {
+                var fi = new FileInfo(path);
+                bool ro = fi.Attributes.HasFlag(FileAttributes.ReadOnly);
+                return BuildStatRecord(false, false, ro, fi.Length,
+                    fi.LastAccessTime, fi.LastWriteTime, fi.CreationTime, fi.CreationTime);
+            }
+            throw new FileNotFoundException("no such file or directory", path);
+        }));
+    }
+
+    private static RuntimeValue LstatRaw(Interp interpreter, RuntimeValue receiver, ReadOnlySpan<RuntimeValue> args)
+    {
+        var path = args[0].ToObject()?.ToString() ?? "";
+        return RuntimeValue.FromBoxed(WrapFsOperation("lstat", path, () =>
+        {
+            var fi = new FileInfo(path);
+            var di = new DirectoryInfo(path);
+            if (!fi.Exists && !di.Exists)
+            {
+                throw new FileNotFoundException("no such file or directory", path);
+            }
+            bool isSymlink = (fi.Exists ? fi.Attributes : di.Attributes).HasFlag(FileAttributes.ReparsePoint);
+            bool isDir = di.Exists && !fi.Exists;
+            double size = fi.Exists ? fi.Length : 0.0;
+            bool ro = fi.Exists && fi.Attributes.HasFlag(FileAttributes.ReadOnly);
+            DateTime at = isDir ? di.LastAccessTime : fi.LastAccessTime;
+            DateTime mt = isDir ? di.LastWriteTime : fi.LastWriteTime;
+            DateTime ct = isDir ? di.CreationTime : fi.CreationTime;
+            return (object?)BuildStatRecord(isDir, isSymlink, ro, size, at, mt, ct, ct);
+        }));
+    }
+
+    private static RuntimeValue FstatRaw(Interp interpreter, RuntimeValue receiver, ReadOnlySpan<RuntimeValue> args)
+    {
+        var fd = Convert.ToInt32(args[0].ToObject());
+        return RuntimeValue.FromBoxed(WrapFsOperation("fstat", null, () =>
+        {
+            var stream = _fdTable.Get(fd);
+            double size = stream.Length;
+            DateTime at = DateTime.UnixEpoch, mt = DateTime.UnixEpoch, ct = DateTime.UnixEpoch;
+            try
+            {
+                var fi = new FileInfo(stream.Name);
+                if (fi.Exists) { at = fi.LastAccessTime; mt = fi.LastWriteTime; ct = fi.CreationTime; }
+            }
+            catch { /* fd without a recoverable path → epoch fallback */ }
+            return (object?)BuildStatRecord(false, false, false, size, at, mt, ct, ct);
         }));
     }
 

--- a/SharpTS.Tests/SharedTests/BuiltInModules/FsModuleTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/FsModuleTests.cs
@@ -593,11 +593,11 @@ public class FsModuleTests
                     }
                 }
                 console.log(fileEntry !== null);
-                console.log(fileEntry.isFile === true);
-                console.log(fileEntry.isDirectory === false);
+                console.log(fileEntry.isFile() === true);
+                console.log(fileEntry.isDirectory() === false);
 
                 console.log(dirEntry !== null);
-                console.log(dirEntry.isDirectory === true);
+                console.log(dirEntry.isDirectory() === true);
 
                 // Cleanup
                 fs.unlinkSync(testDir + '/file.txt');
@@ -1472,6 +1472,94 @@ public class FsModuleTests
         };
         Assert.Equal("0,4,2,1\n256,128,64,448\n65536,131072,1052672,4096,2048\n1,2\n",
             TestHarness.RunModules(files, "main.ts", mode));
+    }
+
+    #endregion
+
+    #region Stats/Dirent unification (#977)
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Fs_Stat_SyncAndAsyncSameShapeAndPredicates(ExecutionMode mode)
+    {
+        var uid = Uid();
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = $$"""
+                import * as fs from 'fs';
+                import * as os from 'os';
+                const dir = os.tmpdir() + '/st977_{{uid}}';
+                fs.mkdirSync(dir);
+                const file = dir + '/f.txt';
+                fs.writeFileSync(file, 'hello');
+                async function main() {
+                    const s = fs.statSync(file);
+                    const a = await fs.promises.stat(file);
+                    console.log(s.isFile() === true && s.isDirectory() === false);
+                    console.log(s.size === 5 && a.size === 5);
+                    // sync and async produce the identical key set
+                    console.log(JSON.stringify(Object.keys(s).sort()) === JSON.stringify(Object.keys(a).sort()));
+                    console.log(fs.statSync(dir).isDirectory() === true);
+                    fs.unlinkSync(file);
+                    fs.rmdirSync(dir);
+                }
+                main();
+                """
+        };
+        Assert.Equal("true\ntrue\ntrue\ntrue\n", TestHarness.RunModules(files, "main.ts", mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Fs_Stat_BigIntOption(ExecutionMode mode)
+    {
+        var uid = Uid();
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = $$"""
+                import * as fs from 'fs';
+                import * as os from 'os';
+                const file = os.tmpdir() + '/big977_{{uid}}.txt';
+                fs.writeFileSync(file, 'x');
+                const s: any = fs.statSync(file, { bigint: true });
+                console.log(typeof s.size === 'bigint');
+                console.log(typeof s.atimeNs === 'bigint');
+                console.log(s.isFile() === true);
+                fs.unlinkSync(file);
+                """
+        };
+        Assert.Equal("true\ntrue\ntrue\n", TestHarness.RunModules(files, "main.ts", mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Fs_Dirent_ParentPathAndPredicates(ExecutionMode mode)
+    {
+        var uid = Uid();
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = $$"""
+                import * as fs from 'fs';
+                import * as os from 'os';
+                const dir = os.tmpdir() + '/de977_{{uid}}';
+                fs.mkdirSync(dir);
+                fs.writeFileSync(dir + '/f.txt', 'x');
+                fs.mkdirSync(dir + '/sub');
+                const ents: any = fs.readdirSync(dir, { withFileTypes: true });
+                let f: any = null, d: any = null;
+                for (let i = 0; i < ents.length; i++) {
+                    if (ents[i].name === 'f.txt') f = ents[i];
+                    if (ents[i].name === 'sub') d = ents[i];
+                }
+                console.log(f.isFile() === true && d.isDirectory() === true);
+                console.log(typeof f.parentPath === 'string' && f.parentPath.length > 0);
+                console.log(f.path === f.parentPath);
+                fs.unlinkSync(dir + '/f.txt');
+                fs.rmdirSync(dir + '/sub');
+                fs.rmdirSync(dir);
+                """
+        };
+        Assert.Equal("true\ntrue\ntrue\n", TestHarness.RunModules(files, "main.ts", mode));
     }
 
     #endregion

--- a/TypeSystem/BuiltInModuleTypes.cs
+++ b/TypeSystem/BuiltInModuleTypes.cs
@@ -173,6 +173,10 @@ public static class BuiltInModuleTypes
             // File info
             ["statSync"] = new TypeInfo.Function([stringType], statsType),
             ["lstatSync"] = new TypeInfo.Function([stringType], statsType),
+            // Raw stat records (#977) — the TS Stats class shapes these.
+            ["statRaw"] = new TypeInfo.Function([stringType], anyType),
+            ["lstatRaw"] = new TypeInfo.Function([stringType], anyType),
+            ["fstatRaw"] = new TypeInfo.Function([numberType], anyType),
 
             // File move/copy
             ["renameSync"] = new TypeInfo.Function(

--- a/stdlib/node/fs.ts
+++ b/stdlib/node/fs.ts
@@ -25,8 +25,8 @@ import {
     rmdirSync as __rmdirSync,
     readdirSync as __readdirSync,
     // Metadata
-    statSync as __statSync,
-    lstatSync as __lstatSync,
+    statRaw as __statRaw,
+    lstatRaw as __lstatRaw,
     // Move / copy
     renameSync as __renameSync,
     copyFileSync as __copyFileSync,
@@ -46,7 +46,7 @@ import {
     closeSync as __closeSync,
     readSync as __readSync,
     writeSync as __writeSync,
-    fstatSync as __fstatSync,
+    fstatRaw as __fstatRaw,
     ftruncateSync as __ftruncateSync,
     // Directory utilities / hard links
     mkdtempSync as __mkdtempSync,
@@ -202,16 +202,122 @@ export function rmdirSync(path: string, options?: any): void {
 }
 
 /** Synchronously reads the contents of a directory. */
-export function readdirSync(path: string, options?: any): string[] {
+export function readdirSync(path: string, options?: any): any {
+    if (__wantsFileTypes(options)) {
+        const names = __readdirRecursive(options) ? __readdirSync(path, { recursive: true }) : __readdirSync(path);
+        return __makeDirents(path, names);
+    }
     if (options === undefined) return __readdirSync(path);
     return __readdirSync(path, options);
 }
 
+// ===========================================================================
+// Stats (#977) — one canonical class built from primitive:fs's flat stat record,
+// so statSync / await stat / fstat all return the SAME shape and values. The
+// seven is*() predicates derive from the mode bits. `{ bigint: true }` stores the
+// numeric fields as BigInt and adds *Ns. Methods live on the prototype, so
+// Object.keys(stat) returns only the data fields (Node-faithful).
+// ===========================================================================
+const __S_IFMT = 0xf000, __S_IFREG = 0x8000, __S_IFDIR = 0x4000, __S_IFLNK = 0xa000,
+    __S_IFBLK = 0x6000, __S_IFCHR = 0x2000, __S_IFIFO = 0x1000, __S_IFSOCK = 0xc000;
+
+class Stats {
+    dev: any; ino: any; mode: any; nlink: any; uid: any; gid: any; rdev: any;
+    size: any; blksize: any; blocks: any;
+    atimeMs: any; mtimeMs: any; ctimeMs: any; birthtimeMs: any;
+    atime: any; mtime: any; ctime: any; birthtime: any;
+    constructor(r: any, big: boolean) {
+        const n = (x: number): any => big ? BigInt(Math.trunc(x)) : x;
+        this.dev = n(r.dev); this.ino = n(r.ino); this.mode = n(r.mode);
+        this.nlink = n(r.nlink); this.uid = n(r.uid); this.gid = n(r.gid); this.rdev = n(r.rdev);
+        this.size = n(r.size); this.blksize = n(r.blksize); this.blocks = n(r.blocks);
+        this.atimeMs = n(r.atimeMs); this.mtimeMs = n(r.mtimeMs);
+        this.ctimeMs = n(r.ctimeMs); this.birthtimeMs = n(r.birthtimeMs);
+        this.atime = new Date(r.atimeMs); this.mtime = new Date(r.mtimeMs);
+        this.ctime = new Date(r.ctimeMs); this.birthtime = new Date(r.birthtimeMs);
+        if (big) {
+            (this as any).atimeNs = BigInt(Math.trunc(r.atimeMs)) * 1000000n;
+            (this as any).mtimeNs = BigInt(Math.trunc(r.mtimeMs)) * 1000000n;
+            (this as any).ctimeNs = BigInt(Math.trunc(r.ctimeMs)) * 1000000n;
+            (this as any).birthtimeNs = BigInt(Math.trunc(r.birthtimeMs)) * 1000000n;
+        }
+    }
+    isFile(): boolean { return (Number(this.mode) & __S_IFMT) === __S_IFREG; }
+    isDirectory(): boolean { return (Number(this.mode) & __S_IFMT) === __S_IFDIR; }
+    isSymbolicLink(): boolean { return (Number(this.mode) & __S_IFMT) === __S_IFLNK; }
+    isBlockDevice(): boolean { return (Number(this.mode) & __S_IFMT) === __S_IFBLK; }
+    isCharacterDevice(): boolean { return (Number(this.mode) & __S_IFMT) === __S_IFCHR; }
+    isFIFO(): boolean { return (Number(this.mode) & __S_IFMT) === __S_IFIFO; }
+    isSocket(): boolean { return (Number(this.mode) & __S_IFMT) === __S_IFSOCK; }
+}
+
+/** Whether a stat options arg requests BigInt fields (`{ bigint: true }`). */
+function __statBig(options: any): boolean {
+    return typeof options === 'object' && options !== null && !!options.bigint;
+}
+
+/** Builds the canonical Stats object from a raw record. */
+function __makeStats(raw: any, big: boolean): Stats { return new Stats(raw, big); }
+
+// ===========================================================================
+// Dirent (#977) — one canonical class for readdir({ withFileTypes: true }) in
+// both modes. Built in TS from the entry's lstat mode, so the seven is*() are
+// methods (Node-shaped) and parentPath/path (Node 20+) are present everywhere.
+// ===========================================================================
+class Dirent {
+    name: string;
+    parentPath: string;
+    path: string;
+    mode: number;
+    constructor(name: string, parentPath: string, mode: number) {
+        this.name = name; this.parentPath = parentPath; this.path = parentPath; this.mode = mode;
+    }
+    isFile(): boolean { return (this.mode & __S_IFMT) === __S_IFREG; }
+    isDirectory(): boolean { return (this.mode & __S_IFMT) === __S_IFDIR; }
+    isSymbolicLink(): boolean { return (this.mode & __S_IFMT) === __S_IFLNK; }
+    isBlockDevice(): boolean { return (this.mode & __S_IFMT) === __S_IFBLK; }
+    isCharacterDevice(): boolean { return (this.mode & __S_IFMT) === __S_IFCHR; }
+    isFIFO(): boolean { return (this.mode & __S_IFMT) === __S_IFIFO; }
+    isSocket(): boolean { return (this.mode & __S_IFMT) === __S_IFSOCK; }
+}
+
+/** Last path segment (the entry's own name), separator-agnostic. */
+function __baseName(p: string): string {
+    let end = p.length;
+    while (end > 1 && (p[end - 1] === '/' || p[end - 1] === '\\')) end--;
+    let i = end - 1;
+    while (i >= 0 && p[i] !== '/' && p[i] !== '\\') i--;
+    return p.slice(i + 1, end);
+}
+
+/** Builds a Dirent for an entry `rel` (a name, or relative path under recursive). */
+function __makeDirent(base: string, rel: string): Dirent {
+    const full = base + '/' + rel;
+    let mode = 0;
+    try { mode = __lstatRaw(full).mode; } catch (e) { mode = 0; }
+    return new Dirent(__baseName(full), __parentDir(full), mode);
+}
+
+/** Whether a readdir options arg requested `{ withFileTypes: true }`. */
+function __wantsFileTypes(options: any): boolean {
+    return typeof options === 'object' && options !== null && !!options.withFileTypes;
+}
+
+/** Whether a readdir options arg requested `{ recursive: true }`. */
+function __readdirRecursive(options: any): boolean {
+    return typeof options === 'object' && options !== null && !!options.recursive;
+}
+
+/** Maps a raw name/relative-path listing to Dirent objects. */
+function __makeDirents(base: string, names: any): Dirent[] {
+    return names.map((rel: string) => __makeDirent(base, rel));
+}
+
 /** Synchronously retrieves the Stats for the path. */
-export function statSync(path: string): any { return __statSync(path); }
+export function statSync(path: string, options?: any): any { return __makeStats(__statRaw(path), __statBig(options)); }
 
 /** Synchronously retrieves the Stats for the path without following symbolic links. */
-export function lstatSync(path: string): any { return __lstatSync(path); }
+export function lstatSync(path: string, options?: any): any { return __makeStats(__lstatRaw(path), __statBig(options)); }
 
 /** Synchronously renames (moves) a file or directory. */
 export function renameSync(oldPath: string, newPath: string): void { __renameSync(oldPath, newPath); }
@@ -278,7 +384,7 @@ export function writeSync(fd: number, buffer: any, offset?: number, length?: num
 }
 
 /** Synchronously retrieves the Stats for an open file descriptor. */
-export function fstatSync(fd: number): any { return __fstatSync(fd); }
+export function fstatSync(fd: number, options?: any): any { return __makeStats(__fstatRaw(fd), __statBig(options)); }
 
 /** Synchronously truncates an open file descriptor to the given length. */
 export function ftruncateSync(fd: number, len?: number): void {
@@ -364,13 +470,15 @@ export function appendFile(path: string, data: any, options?: any, callback?: an
 /** Asynchronously retrieves the Stats for the path. */
 export function stat(path: string, options?: any, callback?: any): void {
     if (typeof options === 'function') { callback = options; options = undefined; }
-    __cbData(__pStat(path), callback);
+    const big = __statBig(options);
+    __pStat(path).then((r: any) => { callback(null, __makeStats(r, big)); }, (e: any) => { callback(e); });
 }
 
 /** Asynchronously retrieves the Stats for the path without following symbolic links. */
 export function lstat(path: string, options?: any, callback?: any): void {
     if (typeof options === 'function') { callback = options; options = undefined; }
-    __cbData(__pLstat(path), callback);
+    const big = __statBig(options);
+    __pLstat(path).then((r: any) => { callback(null, __makeStats(r, big)); }, (e: any) => { callback(e); });
 }
 
 /** Asynchronously removes a file or symbolic link. */
@@ -393,6 +501,11 @@ export function rmdir(path: string, options?: any, callback?: any): void {
 /** Asynchronously reads the contents of a directory. */
 export function readdir(path: string, options?: any, callback?: any): void {
     if (typeof options === 'function') { callback = options; options = undefined; }
+    if (__wantsFileTypes(options)) {
+        const names = __readdirRecursive(options) ? __pReaddir(path, { recursive: true }) : __pReaddir(path);
+        names.then((n: any) => { callback(null, __makeDirents(path, n)); }, (e: any) => { callback(e); });
+        return;
+    }
     __cbData(__pReaddir(path, options), callback);
 }
 
@@ -469,13 +582,15 @@ export const promises = {
     readFile: (path: string, options?: any): Promise<any> => __pReadFile(path, options),
     writeFile: (path: string, data: any, options?: any): Promise<void> => __pWriteFile(path, data, options),
     appendFile: (path: string, data: any, options?: any): Promise<void> => __pAppendFile(path, data, options),
-    stat: (path: string): Promise<any> => __pStat(path),
-    lstat: (path: string): Promise<any> => __pLstat(path),
+    stat: (path: string, options?: any): Promise<any> => __pStat(path).then((r: any) => __makeStats(r, __statBig(options))),
+    lstat: (path: string, options?: any): Promise<any> => __pLstat(path).then((r: any) => __makeStats(r, __statBig(options))),
     unlink: (path: string): Promise<void> => __pUnlink(path),
     mkdir: (path: string, options?: any): Promise<any> => __pMkdir(path, options),
     rmdir: (path: string, options?: any): Promise<void> => __pRmdir(path, options),
     rm: (path: string, options?: any): Promise<void> => __pRm(path, options),
-    readdir: (path: string, options?: any): Promise<any> => __pReaddir(path, options),
+    readdir: (path: string, options?: any): Promise<any> => __wantsFileTypes(options)
+        ? (__readdirRecursive(options) ? __pReaddir(path, { recursive: true }) : __pReaddir(path)).then((n: any) => __makeDirents(path, n))
+        : __pReaddir(path, options),
     rename: (oldPath: string, newPath: string): Promise<void> => __pRename(oldPath, newPath),
     copyFile: (src: string, dest: string, mode?: any): Promise<void> => __pCopyFile(src, dest, mode),
     access: (path: string, mode?: any): Promise<void> => __pAccess(path, mode),

--- a/stdlib/node/fs/promises.ts
+++ b/stdlib/node/fs/promises.ts
@@ -9,13 +9,10 @@ import {
     readFile as __readFile,
     writeFile as __writeFile,
     appendFile as __appendFile,
-    stat as __stat,
-    lstat as __lstat,
     unlink as __unlink,
     mkdir as __mkdir,
     rmdir as __rmdir,
     rm as __rm,
-    readdir as __readdir,
     rename as __rename,
     copyFile as __copyFile,
     access as __access,
@@ -28,8 +25,9 @@ import {
     link as __link,
     mkdtemp as __mkdtemp,
 } from 'primitive:fs/promises';
-// Node guarantees fs.promises.constants === fs.constants; share the one complete table.
-import { constants } from 'fs';
+// Node guarantees fs.promises.constants === fs.constants; share the one complete
+// table, and the Stats-shaping promise stat/lstat, from the fs facade.
+import { constants, promises as __fsp } from 'fs';
 
 /** Asynchronously reads the entire contents of a file. */
 export function readFile(path: string, options?: any): Promise<any> { return __readFile(path, options); }
@@ -41,10 +39,10 @@ export function writeFile(path: string, data: any, options?: any): Promise<void>
 export function appendFile(path: string, data: any, options?: any): Promise<void> { return __appendFile(path, data, options); }
 
 /** Asynchronously retrieves the Stats for the path. */
-export function stat(path: string): Promise<any> { return __stat(path); }
+export function stat(path: string, options?: any): Promise<any> { return __fsp.stat(path, options); }
 
 /** Asynchronously retrieves the Stats for the path without following symbolic links. */
-export function lstat(path: string): Promise<any> { return __lstat(path); }
+export function lstat(path: string, options?: any): Promise<any> { return __fsp.lstat(path, options); }
 
 /** Asynchronously removes a file or symbolic link. */
 export function unlink(path: string): Promise<void> { return __unlink(path); }
@@ -59,7 +57,7 @@ export function rmdir(path: string, options?: any): Promise<void> { return __rmd
 export function rm(path: string, options?: any): Promise<void> { return __rm(path, options); }
 
 /** Asynchronously reads the contents of a directory. */
-export function readdir(path: string, options?: any): Promise<any> { return __readdir(path, options); }
+export function readdir(path: string, options?: any): Promise<any> { return __fsp.readdir(path, options); }
 
 /** Asynchronously renames (moves) a file or directory. */
 export function rename(oldPath: string, newPath: string): Promise<void> { return __rename(oldPath, newPath); }


### PR DESCRIPTION
Part of #968. Stacked on #979.

New statRaw/lstatRaw/fstatRaw primitives return a flat numeric record; one TS `Stats` class shapes every stat path, so `statSync(p)` and `await stat(p)` are identical by construction (all is*() from mode, Date getters, `{bigint:true}`). Dirent gains parentPath/path. Byte-identical interp↔compiled; standalone preserved.

Closes #977.