### PR TITLE
feat(fs): add rm/rmSync + cp/cpSync/promises.cp (#973)

### DIFF
--- a/SharpTS.Tests/SharedTests/BuiltInModules/FsModuleTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/FsModuleTests.cs
@@ -1586,4 +1586,63 @@ public class FsModuleTests
     }
 
     #endregion
+
+    #region rm / cp (#973)
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Fs_RmSync_RecursiveForceAndEisdir(ExecutionMode mode)
+    {
+        var uid = Uid();
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = $$"""
+                import * as fs from 'fs';
+                import * as os from 'os';
+                const root = os.tmpdir() + '/rm973_{{uid}}';
+                fs.mkdirSync(root + '/a/b', { recursive: true });
+                fs.writeFileSync(root + '/a/f.txt', 'x');
+                fs.rmSync(root, { recursive: true });
+                console.log(!fs.existsSync(root));                       // recursive remove
+                let f = 'threw'; try { fs.rmSync(root + '/nope', { force: true }); f = 'ok'; } catch (e) { }
+                console.log(f);                                          // force swallows ENOENT
+                fs.mkdirSync(root, { recursive: true });
+                let c = 'no'; try { fs.rmSync(root); } catch (e: any) { c = e.code; }
+                console.log(c);                                          // dir without recursive -> ERR_FS_EISDIR
+                fs.rmSync(root, { recursive: true });
+                """
+        };
+        Assert.Equal("true\nok\nERR_FS_EISDIR\n", TestHarness.RunModules(files, "main.ts", mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Fs_CpSync_RecursiveErrorOnExistAndFilter(ExecutionMode mode)
+    {
+        var uid = Uid();
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = $$"""
+                import * as fs from 'fs';
+                import * as os from 'os';
+                const root = os.tmpdir() + '/cp973_{{uid}}';
+                fs.rmSync(root, { recursive: true, force: true });
+                fs.mkdirSync(root + '/src/sub', { recursive: true });
+                fs.writeFileSync(root + '/src/x.txt', 'X');
+                fs.writeFileSync(root + '/src/sub/y.txt', 'Y');
+                fs.cpSync(root + '/src', root + '/dst', { recursive: true });
+                console.log(fs.readFileSync(root + '/dst/x.txt', 'utf8') === 'X' && fs.readFileSync(root + '/dst/sub/y.txt', 'utf8') === 'Y');
+                let n = 'no'; try { fs.cpSync(root + '/src', root + '/dst2'); } catch (e: any) { n = e.code; }
+                console.log(n);                                          // dir without recursive -> ERR_FS_EISDIR
+                let eoe = 'no'; try { fs.cpSync(root + '/src/x.txt', root + '/dst/x.txt', { errorOnExist: true, force: false }); } catch (e: any) { eoe = e.code; }
+                console.log(eoe);                                        // errorOnExist -> ERR_FS_CP_EEXIST
+                fs.cpSync(root + '/src', root + '/dst3', { recursive: true, filter: (s: string) => s.indexOf('sub') < 0 });
+                console.log(fs.existsSync(root + '/dst3/x.txt') && !fs.existsSync(root + '/dst3/sub'));
+                fs.rmSync(root, { recursive: true });
+                """
+        };
+        Assert.Equal("true\nERR_FS_EISDIR\nERR_FS_CP_EEXIST\ntrue\n", TestHarness.RunModules(files, "main.ts", mode));
+    }
+
+    #endregion
 }

--- a/stdlib/node/fs.ts
+++ b/stdlib/node/fs.ts
@@ -70,7 +70,6 @@ import {
     unlink as __pUnlink,
     mkdir as __pMkdir,
     rmdir as __pRmdir,
-    rm as __pRm,
     readdir as __pReaddir,
     rename as __pRename,
     copyFile as __pCopyFile,
@@ -136,6 +135,73 @@ export function appendFileSync(path: string, data: any, options?: any): void {
 
 /** Synchronously removes a file or symbolic link. */
 export function unlinkSync(path: string): void { __unlinkSync(path); }
+
+// --- rm / cp (Node 16.7+ recursive remove/copy). The recursion + option logic is
+// pure TS over the sync primitives; the async variants wrap the sync walk in a
+// Promise so sync and async behave identically. ---
+
+/** Joins a directory and a child name (forward slash; .NET accepts it on Windows). */
+function __joinPath(dir: string, name: string): string {
+    if (dir.length === 0) return name;
+    const last = dir[dir.length - 1];
+    return (last === '/' || last === '\\') ? dir + name : dir + '/' + name;
+}
+
+/** Runs a synchronous fs op inside a Promise so the callback/promise variants
+ * share the one implementation (resolves/rejects exactly as the sync op does). */
+function __promisifyVoid(fn: () => void): Promise<void> {
+    return new Promise<void>((resolve: any, reject: any) => {
+        try { fn(); resolve(undefined); } catch (e) { reject(e); }
+    });
+}
+
+/** Synchronously removes files and directories. `{ recursive }` removes a whole
+ * tree; `{ force }` makes a nonexistent path a no-op instead of throwing ENOENT. */
+export function rmSync(path: string, options?: any): void {
+    const recursive = !!(options && options.recursive);
+    const force = !!(options && options.force);
+    // `force` makes a missing path a no-op; otherwise Node throws ENOENT. Checking
+    // existence up front keeps this allocation-free of try/catch.
+    if (!existsSync(path)) {
+        if (force) return;
+        throw __fsError('ENOENT', 'no such file or directory', 'rm', path);
+    }
+    if (lstatSync(path).isDirectory()) {
+        if (!recursive) throw __fsError('ERR_FS_EISDIR', 'Path is a directory', 'rm', path);
+        rmdirSync(path, { recursive: true });
+    } else {
+        unlinkSync(path);
+    }
+}
+
+/** Synchronously copies `src` to `dest`, recursively when `{ recursive: true }`.
+ * Honors `force` (default true), `errorOnExist`, `dereference`, `preserveTimestamps`,
+ * and a synchronous `filter(src, dest)` predicate. */
+export function cpSync(src: string, dest: string, options?: any): void {
+    const opts = options || {};
+    if (opts.filter && !opts.filter(src, dest)) return;
+    const st: any = opts.dereference ? statSync(src) : lstatSync(src);
+    if (st.isDirectory()) {
+        if (!opts.recursive) {
+            throw __fsError('ERR_FS_EISDIR', 'Recursive option not enabled, cannot copy a directory', 'cp', src);
+        }
+        mkdirSync(dest, { recursive: true });
+        const names: any = readdirSync(src);
+        for (let i = 0; i < names.length; i++) {
+            cpSync(__joinPath(src, names[i]), __joinPath(dest, names[i]), options);
+        }
+    } else {
+        const force = opts.force !== false; // Node default is to overwrite.
+        if (existsSync(dest)) {
+            if (opts.errorOnExist) throw __fsError('ERR_FS_CP_EEXIST', 'File already exists', 'cp', dest);
+            if (!force) return;
+        }
+        const parent = __parentDir(dest);
+        if (parent && parent !== dest && !existsSync(parent)) mkdirSync(parent, { recursive: true });
+        copyFileSync(src, dest);
+        if (opts.preserveTimestamps) utimesSync(dest, st.atimeMs / 1000, st.mtimeMs / 1000);
+    }
+}
 
 /** Synchronously creates a directory. */
 // --- mkdir helpers (Node semantics live here in TS; the primitive only does the
@@ -486,6 +552,18 @@ export function unlink(path: string, callback: any): void {
     __cbVoid(__pUnlink(path), callback);
 }
 
+/** Asynchronously removes files and directories. */
+export function rm(path: string, options?: any, callback?: any): void {
+    if (typeof options === 'function') { callback = options; options = undefined; }
+    __cbVoid(__promisifyVoid(() => rmSync(path, options)), callback);
+}
+
+/** Asynchronously copies src to dest (recursively when `{ recursive: true }`). */
+export function cp(src: string, dest: string, options?: any, callback?: any): void {
+    if (typeof options === 'function') { callback = options; options = undefined; }
+    __cbVoid(__promisifyVoid(() => cpSync(src, dest, options)), callback);
+}
+
 /** Asynchronously creates a directory. */
 export function mkdir(path: string, options?: any, callback?: any): void {
     if (typeof options === 'function') { callback = options; options = undefined; }
@@ -587,7 +665,8 @@ export const promises = {
     unlink: (path: string): Promise<void> => __pUnlink(path),
     mkdir: (path: string, options?: any): Promise<any> => __pMkdir(path, options),
     rmdir: (path: string, options?: any): Promise<void> => __pRmdir(path, options),
-    rm: (path: string, options?: any): Promise<void> => __pRm(path, options),
+    rm: (path: string, options?: any): Promise<void> => __promisifyVoid(() => rmSync(path, options)),
+    cp: (src: string, dest: string, options?: any): Promise<void> => __promisifyVoid(() => cpSync(src, dest, options)),
     readdir: (path: string, options?: any): Promise<any> => __wantsFileTypes(options)
         ? (__readdirRecursive(options) ? __pReaddir(path, { recursive: true }) : __pReaddir(path)).then((n: any) => __makeDirents(path, n))
         : __pReaddir(path, options),
@@ -609,7 +688,7 @@ export const promises = {
 // export (the module object). Supports `import fs from 'fs'; fs.readFileSync(...)`.
 export default {
     existsSync, readFileSync, writeFileSync, appendFileSync,
-    unlinkSync, mkdirSync, rmdirSync, readdirSync,
+    unlinkSync, mkdirSync, rmdirSync, rmSync, cpSync, readdirSync,
     statSync, lstatSync, renameSync, copyFileSync, accessSync,
     chmodSync, chownSync, lchownSync, truncateSync,
     symlinkSync, readlinkSync, realpathSync, utimesSync,
@@ -619,7 +698,7 @@ export default {
     watch, watchFile, unwatchFile,
     constants,
     readFile, writeFile, appendFile, stat, lstat, unlink, mkdir, rmdir,
-    readdir, rename, copyFile, access, chmod, truncate, utimes,
+    rm, cp, readdir, rename, copyFile, access, chmod, truncate, utimes,
     readlink, realpath, symlink, link, mkdtemp,
     promises,
 };

--- a/stdlib/node/fs/promises.ts
+++ b/stdlib/node/fs/promises.ts
@@ -12,7 +12,6 @@ import {
     unlink as __unlink,
     mkdir as __mkdir,
     rmdir as __rmdir,
-    rm as __rm,
     rename as __rename,
     copyFile as __copyFile,
     access as __access,
@@ -54,7 +53,10 @@ export function mkdir(path: string, options?: any): Promise<any> { return __mkdi
 export function rmdir(path: string, options?: any): Promise<void> { return __rmdir(path, options); }
 
 /** Asynchronously removes files and directories (recursively when requested). */
-export function rm(path: string, options?: any): Promise<void> { return __rm(path, options); }
+export function rm(path: string, options?: any): Promise<void> { return __fsp.rm(path, options); }
+
+/** Asynchronously copies src to dest (recursively when `{ recursive: true }`). */
+export function cp(src: string, dest: string, options?: any): Promise<void> { return __fsp.cp(src, dest, options); }
 
 /** Asynchronously reads the contents of a directory. */
 export function readdir(path: string, options?: any): Promise<any> { return __fsp.readdir(path, options); }
@@ -96,7 +98,7 @@ export function mkdtemp(prefix: string): Promise<any> { return __mkdtemp(prefix)
 export { constants };
 
 export default {
-    readFile, writeFile, appendFile, stat, lstat, unlink, mkdir, rmdir, rm,
+    readFile, writeFile, appendFile, stat, lstat, unlink, mkdir, rmdir, rm, cp,
     readdir, rename, copyFile, access, chmod, truncate, utimes,
     readlink, realpath, symlink, link, mkdtemp, constants,
 };


### PR DESCRIPTION
Part of #968. Stacked on #984.

Recursive remove/copy as pure facade TS over the primitives (one impl, both modes): rm/rmSync (force/ERR_FS_EISDIR), cp/cpSync (force/errorOnExist→ERR_FS_CP_EEXIST/dereference/preserveTimestamps/filter), and the promise/callback forms. Byte-identical interp↔compiled.

Closes #973.