### PR TITLE
feat(fs/promises): add opendir (+ Dir) and watch async-iterator (#975)

### DIFF
--- a/SharpTS.Tests/SharedTests/BuiltInModules/FsModuleTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/FsModuleTests.cs
@@ -1587,6 +1587,76 @@ public class FsModuleTests
 
     #endregion
 
+    #region promises.opendir + watch (#975)
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Fs_PromisesOpendir_AsyncIteratesEntries(ExecutionMode mode)
+    {
+        var uid = Uid();
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = $$"""
+                import * as fs from 'fs';
+                import * as os from 'os';
+                async function main() {
+                    const d = os.tmpdir() + '/opendir_{{uid}}';
+                    fs.rmSync(d, { recursive: true, force: true });
+                    fs.mkdirSync(d, { recursive: true });
+                    fs.writeFileSync(d + '/a.txt', '1');
+                    fs.writeFileSync(d + '/b.txt', '2');
+                    fs.mkdirSync(d + '/sub');
+                    const dir = await fs.promises.opendir(d);
+                    let count = 0; let sawDir = false;
+                    for await (const ent of dir) { count++; if (ent.isDirectory()) sawDir = true; }
+                    console.log('count:' + count + ' sawDir:' + sawDir);
+                    fs.rmSync(d, { recursive: true, force: true });
+                }
+                main();
+                """
+        };
+        Assert.Equal("count:3 sawDir:true\n", TestHarness.RunModules(files, "main.ts", mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Fs_PromisesWatch_AsyncIteratorTerminatesOnAbort(ExecutionMode mode)
+    {
+        // Real FSWatcher event timing is non-deterministic (and flaky under load), so
+        // this pins the iterator + AbortSignal-termination contract deterministically:
+        // aborting then pulling yields done, and a pre-aborted signal ends a for-await
+        // immediately. (Live change-event observation is covered by manual/e2e checks;
+        // the compiled parked-abort limitation is tracked in #985.)
+        var uid = Uid();
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = $$"""
+                import * as fs from 'fs';
+                import * as os from 'os';
+                async function main() {
+                    const d = os.tmpdir() + '/watch_{{uid}}';
+                    fs.rmSync(d, { recursive: true, force: true });
+                    fs.mkdirSync(d, { recursive: true });
+                    const ac = new AbortController();
+                    const it: any = fs.promises.watch(d, { signal: ac.signal });
+                    ac.abort();
+                    const r = await it.next();
+                    console.log('done:' + r.done);
+                    const ac2 = new AbortController();
+                    ac2.abort();
+                    let count = 0;
+                    for await (const ev of fs.promises.watch(d, { signal: ac2.signal })) { count++; }
+                    console.log('count:' + count);
+                    fs.rmSync(d, { recursive: true, force: true });
+                }
+                main();
+                """
+        };
+        Assert.Equal("done:true\ncount:0\n", TestHarness.RunModules(files, "main.ts", mode));
+    }
+
+    #endregion
+
     #region rm / cp (#973)
 
     [Theory]

--- a/stdlib/node/fs.ts
+++ b/stdlib/node/fs.ts
@@ -50,7 +50,6 @@ import {
     ftruncateSync as __ftruncateSync,
     // Directory utilities / hard links
     mkdtempSync as __mkdtempSync,
-    opendirSync as __opendirSync,
     linkSync as __linkSync,
     // Stream factories
     createReadStream as __createReadStream,
@@ -462,7 +461,84 @@ export function ftruncateSync(fd: number, len?: number): void {
 export function mkdtempSync(prefix: string): string { return __mkdtempSync(prefix); }
 
 /** Synchronously opens a directory and returns a Dir handle. */
-export function opendirSync(path: string): any { return __opendirSync(path); }
+// A Dir handle: sync + async iterable over a snapshot of the directory's Dirents.
+// Node reads lazily; reading the whole listing up front is simple and correct for
+// typical sizes. read()/readSync()/iteration share one cursor (as in Node).
+function __makeDir(path: string, entries: any[]): any {
+    let i = 0;
+    return {
+        path,
+        readSync(): any { return i < entries.length ? entries[i++] : null; },
+        read(): Promise<any> { return Promise.resolve(i < entries.length ? entries[i++] : null); },
+        closeSync(): void { i = entries.length; },
+        close(): Promise<void> { i = entries.length; return Promise.resolve(); },
+        [Symbol.asyncIterator](): any {
+            return {
+                next(): any {
+                    const e = i < entries.length ? entries[i++] : null;
+                    return Promise.resolve(e !== null ? { value: e, done: false } : { value: undefined, done: true });
+                }
+            };
+        }
+    };
+}
+
+/** Synchronously opens a directory and returns a Dir handle (sync + async iterable). */
+export function opendirSync(path: string, options?: any): any {
+    return __makeDir(path, readdirSync(path, { withFileTypes: true } as any));
+}
+
+// --- promises.watch: bridge the FSWatcher's 'change' event stream into a
+// pull-based async iterator. Events arriving between pulls are queued; a pull
+// with no pending event parks a resolver until the next event. An AbortSignal
+// (or iterator return()) closes the watcher and ends iteration cleanly so the
+// event loop can drain. ---
+function __watchAsync(filename: string, options?: any): any {
+    const opts = options || {};
+    const signal = opts.signal;
+    const watcher: any = __watch(filename, opts);
+    const queue: any[] = [];
+    const resolvers: any[] = [];
+    let done = false;
+
+    const finish = () => {
+        if (done) return;
+        done = true;
+        try { watcher.close(); } catch (e) { }
+        while (resolvers.length) { resolvers.shift()({ value: undefined, done: true }); }
+    };
+
+    watcher.on('change', (eventType: any, fname: any) => {
+        if (done) return;
+        const ev = { eventType, filename: fname };
+        if (resolvers.length) { resolvers.shift()({ value: ev, done: false }); }
+        else { queue.push(ev); }
+    });
+    watcher.on('error', () => { finish(); });
+
+    if (signal) {
+        if (signal.aborted) {
+            finish();
+        } else {
+            // Immediate termination when the AbortSignal fires while the iterator is
+            // parked. In compiled mode AbortSignal's listener API is not callable from
+            // stdlib code (the call throws), so this is ignored there — abort is then
+            // observed by the `signal.aborted` check in next() on the following pull.
+            try { signal.addEventListener('abort', finish); } catch (e) { }
+        }
+    }
+
+    return {
+        [Symbol.asyncIterator]() { return this; },
+        next(): any {
+            if (signal && signal.aborted) finish();
+            if (queue.length) return Promise.resolve({ value: queue.shift(), done: false });
+            if (done) return Promise.resolve({ value: undefined, done: true });
+            return new Promise((resolve: any) => { resolvers.push(resolve); });
+        },
+        return(): any { finish(); return Promise.resolve({ value: undefined, done: true }); }
+    };
+}
 
 /** Synchronously creates a hard link. */
 export function linkSync(existingPath: string, newPath: string): void { __linkSync(existingPath, newPath); }
@@ -681,6 +757,8 @@ export const promises = {
     symlink: (target: string, path: string, type?: any): Promise<void> => __pSymlink(target, path, type),
     link: (existingPath: string, newPath: string): Promise<void> => __pLink(existingPath, newPath),
     mkdtemp: (prefix: string): Promise<any> => __pMkdtemp(prefix),
+    opendir: (path: string, options?: any): Promise<any> => Promise.resolve(opendirSync(path, options)),
+    watch: (filename: string, options?: any): any => __watchAsync(filename, options),
     constants,
 };
 

--- a/stdlib/node/fs/promises.ts
+++ b/stdlib/node/fs/promises.ts
@@ -94,11 +94,17 @@ export function link(existingPath: string, newPath: string): Promise<void> { ret
 /** Asynchronously creates a unique temporary directory. */
 export function mkdtemp(prefix: string): Promise<any> { return __mkdtemp(prefix); }
 
+/** Asynchronously opens a directory; returns a Dir handle (async iterable). */
+export function opendir(path: string, options?: any): Promise<any> { return __fsp.opendir(path, options); }
+
+/** Returns an async iterator of `{ eventType, filename }` change events for a path. */
+export function watch(filename: string, options?: any): any { return __fsp.watch(filename, options); }
+
 /** File-system constants — re-exported from 'fs' so both share one table. */
 export { constants };
 
 export default {
     readFile, writeFile, appendFile, stat, lstat, unlink, mkdir, rmdir, rm, cp,
     readdir, rename, copyFile, access, chmod, truncate, utimes,
-    readlink, realpath, symlink, link, mkdtemp, constants,
+    readlink, realpath, symlink, link, mkdtemp, opendir, watch, constants,
 };


### PR DESCRIPTION
Part of #968. Stacked on #973.

opendir/Dir (sync+async iterable) and promises.watch (pull-based async-iterator bridge over FSWatcher with backpressure + AbortSignal/return termination), pure facade TS. Both modes.

Known limitation filed as #985: compiled AbortSignal has no working abort callback, so a parked compiled watch iterator observes abort only on the next pull. The watch test is deterministic (FSWatcher event timing is flaky under load).

Closes #975.