### PR TITLE
feat(fs): async chown/lchown + callback fd ops (#974)

### DIFF
--- a/SharpTS.Tests/SharedTests/BuiltInModules/FsModuleTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/FsModuleTests.cs
@@ -1657,6 +1657,75 @@ public class FsModuleTests
 
     #endregion
 
+    #region async chown + callback fd ops (#974)
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Fs_CallbackFdOps_OpenReadWriteFstatClose(ExecutionMode mode)
+    {
+        var uid = Uid();
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = $$"""
+                import * as fs from 'fs';
+                import * as os from 'os';
+                import { Buffer } from 'buffer';
+                function p<T>(fn: (cb: any) => void): Promise<T> {
+                    return new Promise<T>((res: any, rej: any) => { fn((e: any, v: any) => e ? rej(e) : res(v)); });
+                }
+                async function main() {
+                    const f = os.tmpdir() + '/fd974_{{uid}}.txt';
+                    fs.writeFileSync(f, 'HELLO WORLD');
+                    const fd: any = await p((cb) => fs.open(f, 'r', cb));
+                    const buf = Buffer.alloc(5);
+                    const n: any = await new Promise((res: any, rej: any) => fs.read(fd, buf, 0, 5, 6, (e: any, c: any) => e ? rej(e) : res(c)));
+                    console.log(n + ':' + buf.toString('utf8'));        // 5:WORLD (position 6)
+                    const st: any = await p((cb) => fs.fstat(fd, cb));
+                    console.log(st.size + ':' + st.isFile());           // 11:true
+                    await new Promise((res: any, rej: any) => fs.close(fd, (e: any) => e ? rej(e) : res(0)));
+                    const fw: any = await p((cb) => fs.open(f, 'w', cb));
+                    const wn: any = await new Promise((res: any, rej: any) => fs.write(fw, Buffer.from('XY'), 0, 2, 0, (e: any, c: any) => e ? rej(e) : res(c)));
+                    await new Promise((res: any, rej: any) => fs.ftruncate(fw, 2, (e: any) => e ? rej(e) : res(0)));
+                    await new Promise((res: any, rej: any) => fs.close(fw, (e: any) => e ? rej(e) : res(0)));
+                    console.log(wn + ':' + fs.readFileSync(f, 'utf8')); // 2:XY
+                    fs.unlinkSync(f);
+                }
+                main();
+                """
+        };
+        Assert.Equal("5:WORLD\n11:true\n2:XY\n", TestHarness.RunModules(files, "main.ts", mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Fs_CallbackFd_BadFd_And_Chown_Invoke(ExecutionMode mode)
+    {
+        var uid = Uid();
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = $$"""
+                import * as fs from 'fs';
+                import * as os from 'os';
+                async function main() {
+                    const f = os.tmpdir() + '/fd974b_{{uid}}.txt';
+                    fs.writeFileSync(f, 'x');
+                    // Bad fd surfaces an error with a code to the callback (the exact code
+                    // differs by mode for a stale fd — a pre-existing primitive divergence).
+                    const hasCode: any = await new Promise((res: any) => fs.fstat(999999, (e: any) => res(!!(e && typeof e.code === 'string' && e.code.length > 0))));
+                    console.log('badfd:' + hasCode);
+                    // chown's callback is invoked (platform/no-op behavior aside).
+                    const called: any = await new Promise((res: any) => fs.chown(f, 0, 0, () => res(true)));
+                    console.log('chown:' + called);
+                    fs.unlinkSync(f);
+                }
+                main();
+                """
+        };
+        Assert.Equal("badfd:true\nchown:true\n", TestHarness.RunModules(files, "main.ts", mode));
+    }
+
+    #endregion
+
     #region rm / cp (#973)
 
     [Theory]

--- a/stdlib/node/fs.ts
+++ b/stdlib/node/fs.ts
@@ -154,6 +154,13 @@ function __promisifyVoid(fn: () => void): Promise<void> {
     });
 }
 
+/** Like __promisifyVoid but resolves with the sync op's return value. */
+function __promisifyValue(fn: () => any): Promise<any> {
+    return new Promise<any>((resolve: any, reject: any) => {
+        try { resolve(fn()); } catch (e) { reject(e); }
+    });
+}
+
 /** Synchronously removes files and directories. `{ recursive }` removes a whole
  * tree; `{ force }` makes a nonexistent path a no-op instead of throwing ENOENT. */
 export function rmSync(path: string, options?: any): void {
@@ -725,6 +732,64 @@ export function mkdtemp(prefix: string, options?: any, callback?: any): void {
     __cbData(__pMkdtemp(prefix), callback);
 }
 
+// --- async chown/lchown + callback file-descriptor ops (#974). Thin TS wrappers
+// over the *Sync primitives; the Promise wrap defers the callback off the caller's
+// synchronous frame and carries err.code (e.g. EBADF) through to the callback. ---
+
+/** Asynchronously changes the owner and group of a file. */
+export function chown(path: string, uid: number, gid: number, callback: any): void {
+    __cbVoid(__promisifyVoid(() => chownSync(path, uid, gid)), callback);
+}
+
+/** Asynchronously changes the owner and group of a symbolic link. */
+export function lchown(path: string, uid: number, gid: number, callback: any): void {
+    __cbVoid(__promisifyVoid(() => lchownSync(path, uid, gid)), callback);
+}
+
+/** Asynchronously opens a file; callback receives (err, fd). */
+export function open(path: string, flags?: any, mode?: any, callback?: any): void {
+    if (typeof flags === 'function') { callback = flags; flags = 'r'; mode = undefined; }
+    else if (typeof mode === 'function') { callback = mode; mode = undefined; }
+    __cbData(__promisifyValue(() => mode === undefined ? openSync(path, flags) : openSync(path, flags, mode)), callback);
+}
+
+/** Asynchronously closes a file descriptor; callback receives (err). */
+export function close(fd: number, callback: any): void {
+    __cbVoid(__promisifyVoid(() => closeSync(fd)), callback);
+}
+
+/** Asynchronously reads from a file descriptor; callback receives (err, bytesRead, buffer). */
+export function read(fd: number, buffer: any, offset: number, length: number, position: any, callback: any): void {
+    __promisifyValue(() => readSync(fd, buffer, offset, length, position)).then(
+        (n: any) => { callback(null, n, buffer); },
+        (e: any) => { callback(e, 0, buffer); }
+    );
+}
+
+/** Asynchronously writes to a file descriptor; callback receives (err, bytesWritten, buffer). */
+export function write(fd: number, buffer: any, offset?: any, length?: any, position?: any, callback?: any): void {
+    let cb = callback;
+    if (typeof offset === 'function') { cb = offset; offset = undefined; length = undefined; position = undefined; }
+    else if (typeof length === 'function') { cb = length; length = undefined; position = undefined; }
+    else if (typeof position === 'function') { cb = position; position = undefined; }
+    __promisifyValue(() => writeSync(fd, buffer, offset, length, position)).then(
+        (n: any) => { cb(null, n, buffer); },
+        (e: any) => { cb(e, 0, buffer); }
+    );
+}
+
+/** Asynchronously retrieves the Stats for an open fd; callback receives (err, stats). */
+export function fstat(fd: number, options?: any, callback?: any): void {
+    if (typeof options === 'function') { callback = options; options = undefined; }
+    __cbData(__promisifyValue(() => fstatSync(fd)), callback);
+}
+
+/** Asynchronously truncates an open fd to a length; callback receives (err). */
+export function ftruncate(fd: number, len?: any, callback?: any): void {
+    if (typeof len === 'function') { callback = len; len = undefined; }
+    __cbVoid(__promisifyVoid(() => ftruncateSync(fd, len)), callback);
+}
+
 // ===========================================================================
 // fs.promises namespace — assembled from the promise primitives.
 // Each method is wrapped in an arrow so the call reaches the primitive at a
@@ -750,6 +815,8 @@ export const promises = {
     copyFile: (src: string, dest: string, mode?: any): Promise<void> => __pCopyFile(src, dest, mode),
     access: (path: string, mode?: any): Promise<void> => __pAccess(path, mode),
     chmod: (path: string, mode: number): Promise<void> => __pChmod(path, mode),
+    chown: (path: string, uid: number, gid: number): Promise<void> => __promisifyVoid(() => chownSync(path, uid, gid)),
+    lchown: (path: string, uid: number, gid: number): Promise<void> => __promisifyVoid(() => lchownSync(path, uid, gid)),
     truncate: (path: string, len?: any): Promise<void> => __pTruncate(path, len),
     utimes: (path: string, atime: number, mtime: number): Promise<void> => __pUtimes(path, atime, mtime),
     readlink: (path: string): Promise<any> => __pReadlink(path),
@@ -778,5 +845,6 @@ export default {
     readFile, writeFile, appendFile, stat, lstat, unlink, mkdir, rmdir,
     rm, cp, readdir, rename, copyFile, access, chmod, truncate, utimes,
     readlink, realpath, symlink, link, mkdtemp,
+    chown, lchown, open, close, read, write, fstat, ftruncate,
     promises,
 };

--- a/stdlib/node/fs/promises.ts
+++ b/stdlib/node/fs/promises.ts
@@ -73,6 +73,12 @@ export function access(path: string, mode?: any): Promise<void> { return __acces
 /** Asynchronously changes the permissions of a file. */
 export function chmod(path: string, mode: number): Promise<void> { return __chmod(path, mode); }
 
+/** Asynchronously changes the owner and group of a file. */
+export function chown(path: string, uid: number, gid: number): Promise<void> { return __fsp.chown(path, uid, gid); }
+
+/** Asynchronously changes the owner and group of a symbolic link. */
+export function lchown(path: string, uid: number, gid: number): Promise<void> { return __fsp.lchown(path, uid, gid); }
+
 /** Asynchronously truncates a file to the given length. */
 export function truncate(path: string, len?: any): Promise<void> { return __truncate(path, len); }
 
@@ -105,6 +111,6 @@ export { constants };
 
 export default {
     readFile, writeFile, appendFile, stat, lstat, unlink, mkdir, rmdir, rm, cp,
-    readdir, rename, copyFile, access, chmod, truncate, utimes,
+    readdir, rename, copyFile, access, chmod, chown, lchown, truncate, utimes,
     readlink, realpath, symlink, link, mkdtemp, opendir, watch, constants,
 };


### PR DESCRIPTION
Part of #968. Top of the stack (stacked on #975).

Callback open/read/write/close/fstat/ftruncate + chown/lchown (callback + promise), thin TS wrappers over the *Sync primitives sharing the callback/promise plumbing. Happy-path fd round trips byte-identical both modes.

Pre-existing compiled fd-op error-code divergence (EINVAL vs EBADF/ENOSYS) filed as #986.

Closes #974.