### PR TITLE
feat(fs): land remaining fs-epic children onto main (#978, #979, #977, #984, #973, #975, #974)

### DIFF
--- a/Compilation/EmittedRuntime.cs
+++ b/Compilation/EmittedRuntime.cs
@@ -1509,6 +1509,12 @@ public class EmittedRuntime
     public MethodBuilder FsReaddirSync { get; set; } = null!;
     public MethodBuilder FsStatSync { get; set; } = null!;
     public MethodBuilder FsLstatSync { get; set; } = null!;
+    // Raw stat records (#977) — the TS Stats class shapes these.
+    public MethodBuilder FsStatRaw { get; set; } = null!;
+    public MethodBuilder FsLstatRaw { get; set; } = null!;
+    public MethodBuilder FsFstatRaw { get; set; } = null!;
+    public MethodBuilder FsBuildStatRecord { get; set; } = null!;
+    public MethodBuilder FsStatTimeMs { get; set; } = null!;
     public MethodBuilder FsRenameSync { get; set; } = null!;
     public MethodBuilder FsCopyFileSync { get; set; } = null!;
     public MethodBuilder FsAccessSync { get; set; } = null!;

--- a/Compilation/EmittedRuntime.cs
+++ b/Compilation/EmittedRuntime.cs
@@ -1497,6 +1497,9 @@ public class EmittedRuntime
 
     // Fs module methods
     public MethodBuilder FsExistsSync { get; set; } = null!;
+    // Encoding helpers shared by fs read/write/append (BCL-only, standalone).
+    public MethodBuilder FsEncodingName { get; set; } = null!;
+    public MethodBuilder FsToBytes { get; set; } = null!;
     public MethodBuilder FsReadFileSync { get; set; } = null!;
     public MethodBuilder FsWriteFileSync { get; set; } = null!;
     public MethodBuilder FsAppendFileSync { get; set; } = null!;

--- a/Compilation/Emitters/Modules/FsModuleEmitter.cs
+++ b/Compilation/Emitters/Modules/FsModuleEmitter.cs
@@ -181,7 +181,18 @@ public sealed class FsModuleEmitter : IBuiltInModuleEmitter
         emitter.EmitExpression(arguments[1]);
         emitter.EmitBoxIfNeeded(arguments[1]);
 
-        // Call runtime helper: FsWriteFileSync(object path, object data)
+        // Emit encoding/options (null if not provided)
+        if (arguments.Count >= 3)
+        {
+            emitter.EmitExpression(arguments[2]);
+            emitter.EmitBoxIfNeeded(arguments[2]);
+        }
+        else
+        {
+            il.Emit(OpCodes.Ldnull);
+        }
+
+        // Call runtime helper: FsWriteFileSync(object path, object data, object? encoding)
         il.Emit(OpCodes.Call, ctx.Runtime!.FsWriteFileSync);
         il.Emit(OpCodes.Ldnull); // undefined return
         return true;
@@ -206,7 +217,18 @@ public sealed class FsModuleEmitter : IBuiltInModuleEmitter
         emitter.EmitExpression(arguments[1]);
         emitter.EmitBoxIfNeeded(arguments[1]);
 
-        // Call runtime helper: FsAppendFileSync(object path, object data)
+        // Emit encoding/options (null if not provided)
+        if (arguments.Count >= 3)
+        {
+            emitter.EmitExpression(arguments[2]);
+            emitter.EmitBoxIfNeeded(arguments[2]);
+        }
+        else
+        {
+            il.Emit(OpCodes.Ldnull);
+        }
+
+        // Call runtime helper: FsAppendFileSync(object path, object data, object? encoding)
         il.Emit(OpCodes.Call, ctx.Runtime!.FsAppendFileSync);
         il.Emit(OpCodes.Ldnull); // undefined return
         return true;

--- a/Compilation/Emitters/Modules/FsModuleEmitter.cs
+++ b/Compilation/Emitters/Modules/FsModuleEmitter.cs
@@ -18,7 +18,8 @@ public sealed class FsModuleEmitter : IBuiltInModuleEmitter
     [
         "existsSync", "readFileSync", "writeFileSync", "appendFileSync",
         "unlinkSync", "mkdirSync", "rmdirSync", "readdirSync",
-        "statSync", "lstatSync", "renameSync", "copyFileSync", "accessSync",
+        "statSync", "lstatSync", "statRaw", "lstatRaw", "fstatRaw",
+        "renameSync", "copyFileSync", "accessSync",
         "chmodSync", "chownSync", "lchownSync", "truncateSync",
         "symlinkSync", "readlinkSync", "realpathSync", "utimesSync",
         // File descriptor APIs
@@ -52,6 +53,9 @@ public sealed class FsModuleEmitter : IBuiltInModuleEmitter
             "readdirSync" => EmitReaddirSync(emitter, arguments),
             "statSync" => EmitStatSync(emitter, arguments),
             "lstatSync" => EmitLstatSync(emitter, arguments),
+            "statRaw" => EmitStatRawOp(emitter, arguments, emitter.Context.Runtime!.FsStatRaw),
+            "lstatRaw" => EmitStatRawOp(emitter, arguments, emitter.Context.Runtime!.FsLstatRaw),
+            "fstatRaw" => EmitStatRawOp(emitter, arguments, emitter.Context.Runtime!.FsFstatRaw),
             "renameSync" => EmitRenameSync(emitter, arguments),
             "copyFileSync" => EmitCopyFileSync(emitter, arguments),
             "accessSync" => EmitAccessSync(emitter, arguments),
@@ -368,6 +372,23 @@ public sealed class FsModuleEmitter : IBuiltInModuleEmitter
 
         // Call runtime helper: FsStatSync(object path) -> object (Stats-like object)
         il.Emit(OpCodes.Call, ctx.Runtime!.FsStatSync);
+        return true;
+    }
+
+    // statRaw/lstatRaw/fstatRaw (#977): emit the single arg (path or fd) and call
+    // the given raw-record helper, which returns the flat record the TS Stats shapes.
+    private static bool EmitStatRawOp(IEmitterContext emitter, List<Expr> arguments, System.Reflection.MethodInfo helper)
+    {
+        var ctx = emitter.Context;
+        var il = ctx.IL;
+        if (arguments.Count == 0)
+        {
+            il.Emit(OpCodes.Ldnull);
+            return true;
+        }
+        emitter.EmitExpression(arguments[0]);
+        emitter.EmitBoxIfNeeded(arguments[0]);
+        il.Emit(OpCodes.Call, helper);
         return true;
     }
 

--- a/Compilation/RuntimeEmitter.FsAsync.cs
+++ b/Compilation/RuntimeEmitter.FsAsync.cs
@@ -128,9 +128,10 @@ public partial class RuntimeEmitter
         var il = method.GetILGenerator();
         var (fromResult, resultTask, afterTry) = BeginFsAsyncTryCatch(il);
 
-        // Call FsWriteFileSync(path, data) - ignores options for now
+        // Call FsWriteFileSync(path, data, options)
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Ldarg_2);
         il.Emit(OpCodes.Call, runtime.FsWriteFileSync);
 
         // Return Task.FromResult(null) for void operations
@@ -158,9 +159,10 @@ public partial class RuntimeEmitter
         var il = method.GetILGenerator();
         var (fromResult, resultTask, afterTry) = BeginFsAsyncTryCatch(il);
 
-        // Call FsAppendFileSync(path, data)
+        // Call FsAppendFileSync(path, data, options)
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Ldarg_2);
         il.Emit(OpCodes.Call, runtime.FsAppendFileSync);
 
         // Return Task.FromResult(null) for void operations

--- a/Compilation/RuntimeEmitter.FsAsync.cs
+++ b/Compilation/RuntimeEmitter.FsAsync.cs
@@ -190,9 +190,9 @@ public partial class RuntimeEmitter
         var il = method.GetILGenerator();
         var (fromResult, resultTask, afterTry) = BeginFsAsyncTryCatch(il);
 
-        // Call FsStatSync(path)
+        // Call FsStatRaw(path) — return the raw record (#977); the TS Stats shapes it.
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Call, runtime.FsStatSync);
+        il.Emit(OpCodes.Call, runtime.FsStatRaw);
 
         // Wrap in Task.FromResult
         il.Emit(OpCodes.Call, fromResult);
@@ -218,9 +218,9 @@ public partial class RuntimeEmitter
         var il = method.GetILGenerator();
         var (fromResult, resultTask, afterTry) = BeginFsAsyncTryCatch(il);
 
-        // Call FsLstatSync(path)
+        // Call FsLstatRaw(path) — return the raw record (#977); the TS Stats shapes it.
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Call, runtime.FsLstatSync);
+        il.Emit(OpCodes.Call, runtime.FsLstatRaw);
 
         // Wrap in Task.FromResult
         il.Emit(OpCodes.Call, fromResult);

--- a/Compilation/RuntimeEmitter.FsDirUtils.cs
+++ b/Compilation/RuntimeEmitter.FsDirUtils.cs
@@ -36,41 +36,31 @@ public partial class RuntimeEmitter
 
         EmitWithFsErrorHandling(il, runtime, pathLocal, "mkdtemp", afterTry =>
         {
-            // Path.GetTempPath()
-            il.Emit(OpCodes.Call, _types.GetMethod(_types.Path, "GetTempPath"));
-
-            // Path.GetRandomFileName()
+            // random = Path.GetRandomFileName().Replace(".", "")
             il.Emit(OpCodes.Call, _types.GetMethod(_types.Path, "GetRandomFileName"));
-
-            // Remove the dot from the random filename
             il.Emit(OpCodes.Ldstr, ".");
             il.Emit(OpCodes.Ldstr, "");
             il.Emit(OpCodes.Callvirt, _types.String.GetMethod("Replace", [typeof(string), typeof(string)])!);
+            var randomLocal = il.DeclareLocal(_types.String);
+            il.Emit(OpCodes.Stloc, randomLocal);
 
-            // Combine prefix + randomFileName
+            // suffix = prefix + random  (Node appends the random suffix to the prefix)
             il.Emit(OpCodes.Ldloc, prefixLocal);
-            var tempFileNameLocal = il.DeclareLocal(_types.String);
-            il.Emit(OpCodes.Stloc, tempFileNameLocal);
-
-            // string.Concat(tempPath, prefix + randomFileName)
-            var tempPathLocal = il.DeclareLocal(_types.String);
-            // We need to re-emit GetTempPath
-            il.Emit(OpCodes.Call, _types.GetMethod(_types.Path, "GetTempPath"));
-            il.Emit(OpCodes.Stloc, tempPathLocal);
-
-            il.Emit(OpCodes.Ldloc, prefixLocal);
-            il.Emit(OpCodes.Ldloc, tempFileNameLocal);
+            il.Emit(OpCodes.Ldloc, randomLocal);
             il.Emit(OpCodes.Call, _types.String.GetMethod("Concat", [typeof(string), typeof(string)])!);
             var suffixLocal = il.DeclareLocal(_types.String);
             il.Emit(OpCodes.Stloc, suffixLocal);
 
-            // Path.Combine(tempPath, prefix + random)
-            il.Emit(OpCodes.Ldloc, tempPathLocal);
+            // result = Path.Combine(Path.GetTempPath(), suffix). Path.Combine returns
+            // `suffix` verbatim when it is rooted, so an absolute prefix (the canonical
+            // mkdtempSync(path.join(os.tmpdir(),'foo-'))) is NOT doubled — matches the
+            // interpreter and Node. A bare relative prefix lands under the temp dir.
+            il.Emit(OpCodes.Call, _types.GetMethod(_types.Path, "GetTempPath"));
             il.Emit(OpCodes.Ldloc, suffixLocal);
             il.Emit(OpCodes.Call, _types.GetMethod(_types.Path, "Combine", _types.String, _types.String));
             il.Emit(OpCodes.Stloc, resultLocal);
 
-            // Directory.CreateDirectory
+            // Directory.CreateDirectory(result)
             il.Emit(OpCodes.Ldloc, resultLocal);
             il.Emit(OpCodes.Call, _types.GetMethod(_types.Directory, "CreateDirectory", _types.String));
             il.Emit(OpCodes.Pop);

--- a/Compilation/RuntimeEmitter.FsHelpers.cs
+++ b/Compilation/RuntimeEmitter.FsHelpers.cs
@@ -44,6 +44,9 @@ public partial class RuntimeEmitter
         // Low-level helpers using reflection for standalone DLLs (must be first)
         EmitFsLowLevelHelpers(typeBuilder, runtime);
 
+        // Encoding helpers — must precede read/write/append which call them.
+        EmitFsEncodingHelpers(typeBuilder, runtime);
+
         EmitFsExistsSync(typeBuilder, runtime);
         EmitFsReadFileSync(typeBuilder, runtime);
         EmitFsWriteFileSync(typeBuilder, runtime);

--- a/Compilation/RuntimeEmitter.FsHelpers.cs
+++ b/Compilation/RuntimeEmitter.FsHelpers.cs
@@ -58,6 +58,7 @@ public partial class RuntimeEmitter
         EmitFsReaddirSync(typeBuilder, runtime);
         EmitFsStatSync(typeBuilder, runtime);
         EmitFsLstatSync(typeBuilder, runtime);
+        EmitFsStatRawHelpers(typeBuilder, runtime); // #977: statRaw/lstatRaw/fstatRaw
         EmitFsRenameSync(typeBuilder, runtime);
         EmitFsCopyFileSync(typeBuilder, runtime);
         EmitFsAccessSync(typeBuilder, runtime);

--- a/Compilation/RuntimeEmitter.FsStatRaw.cs
+++ b/Compilation/RuntimeEmitter.FsStatRaw.cs
@@ -1,0 +1,351 @@
+using System.IO;
+using System.Reflection.Emit;
+
+namespace SharpTS.Compilation;
+
+public partial class RuntimeEmitter
+{
+    /// <summary>
+    /// Emits the raw stat record helpers (#977): FsStatTimeMs, FsBuildStatRecord,
+    /// and FsStatRaw/FsLstatRaw/FsFstatRaw. These return a flat numeric record that
+    /// the TS Stats class shapes — mirroring FsModuleInterpreter.BuildStatRecord so
+    /// interpreter and compiled Stats agree. BCL-only (standalone).
+    /// </summary>
+    private void EmitFsStatRawHelpers(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    {
+        EmitFsStatTimeMs(typeBuilder, runtime);
+        EmitFsBuildStatRecord(typeBuilder, runtime);
+        EmitFsStatRaw(typeBuilder, runtime);
+        EmitFsLstatRaw(typeBuilder, runtime);
+        EmitFsFstatRaw(typeBuilder, runtime);
+    }
+
+    /// <summary>double FsStatTimeMs(DateTime local) = unix-ms of local.ToUniversalTime().</summary>
+    private void EmitFsStatTimeMs(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    {
+        var method = typeBuilder.DefineMethod("FsStatTimeMs",
+            System.Reflection.MethodAttributes.Public | System.Reflection.MethodAttributes.Static,
+            _types.Double, [typeof(DateTime)]);
+        runtime.FsStatTimeMs = method;
+
+        var il = method.GetILGenerator();
+        var utc = il.DeclareLocal(typeof(DateTime));
+        il.Emit(OpCodes.Ldarga_S, (byte)0);
+        il.Emit(OpCodes.Call, typeof(DateTime).GetMethod("ToUniversalTime", Type.EmptyTypes)!);
+        il.Emit(OpCodes.Stloc, utc);
+        var dto = il.DeclareLocal(typeof(DateTimeOffset));
+        il.Emit(OpCodes.Ldloc, utc);
+        il.Emit(OpCodes.Newobj, typeof(DateTimeOffset).GetConstructor([typeof(DateTime)])!);
+        il.Emit(OpCodes.Stloc, dto);
+        il.Emit(OpCodes.Ldloca, dto);
+        il.Emit(OpCodes.Call, typeof(DateTimeOffset).GetMethod("ToUnixTimeMilliseconds", Type.EmptyTypes)!);
+        il.Emit(OpCodes.Conv_R8);
+        il.Emit(OpCodes.Ret);
+    }
+
+    /// <summary>
+    /// object FsBuildStatRecord(bool isDir, bool isSymlink, bool isReadOnly,
+    ///   double size, double atimeMs, double mtimeMs, double ctimeMs, double birthtimeMs)
+    /// </summary>
+    private void EmitFsBuildStatRecord(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    {
+        var method = typeBuilder.DefineMethod("FsBuildStatRecord",
+            System.Reflection.MethodAttributes.Public | System.Reflection.MethodAttributes.Static,
+            _types.Object,
+            [_types.Boolean, _types.Boolean, _types.Boolean, _types.Double, _types.Double, _types.Double, _types.Double, _types.Double]);
+        runtime.FsBuildStatRecord = method;
+
+        var il = method.GetILGenerator();
+
+        // typeBits = isSymlink ? 0xA000 : (isDir ? 0x4000 : 0x8000)
+        var typeBits = il.DeclareLocal(_types.Int32);
+        var symL = il.DefineLabel(); var dirL = il.DefineLabel(); var typeDone = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_1); il.Emit(OpCodes.Brtrue, symL);
+        il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Brtrue, dirL);
+        il.Emit(OpCodes.Ldc_I4, 0x8000); il.Emit(OpCodes.Br, typeDone);
+        il.MarkLabel(dirL); il.Emit(OpCodes.Ldc_I4, 0x4000); il.Emit(OpCodes.Br, typeDone);
+        il.MarkLabel(symL); il.Emit(OpCodes.Ldc_I4, 0xA000);
+        il.MarkLabel(typeDone); il.Emit(OpCodes.Stloc, typeBits);
+
+        // permBits = isDir ? 0x1FF : (isReadOnly ? 0x124 : 0x1B6)
+        var permBits = il.DeclareLocal(_types.Int32);
+        var permFile = il.DefineLabel(); var permRo = il.DefineLabel(); var permDone = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Brfalse, permFile);
+        il.Emit(OpCodes.Ldc_I4, 0x1FF); il.Emit(OpCodes.Br, permDone);
+        il.MarkLabel(permFile);
+        il.Emit(OpCodes.Ldarg_2); il.Emit(OpCodes.Brtrue, permRo);
+        il.Emit(OpCodes.Ldc_I4, 0x1B6); il.Emit(OpCodes.Br, permDone);
+        il.MarkLabel(permRo); il.Emit(OpCodes.Ldc_I4, 0x124);
+        il.MarkLabel(permDone); il.Emit(OpCodes.Stloc, permBits);
+
+        // mode = (double)(typeBits | permBits)
+        var modeL = il.DeclareLocal(_types.Double);
+        il.Emit(OpCodes.Ldloc, typeBits); il.Emit(OpCodes.Ldloc, permBits); il.Emit(OpCodes.Or);
+        il.Emit(OpCodes.Conv_R8); il.Emit(OpCodes.Stloc, modeL);
+
+        // blocks = Math.Floor((size + 511) / 512)
+        var blocksL = il.DeclareLocal(_types.Double);
+        il.Emit(OpCodes.Ldarg_3); il.Emit(OpCodes.Ldc_R8, 511.0); il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Ldc_R8, 512.0); il.Emit(OpCodes.Div);
+        il.Emit(OpCodes.Call, typeof(Math).GetMethod("Floor", [typeof(double)])!);
+        il.Emit(OpCodes.Stloc, blocksL);
+
+        var dictType = _types.DictionaryStringObject;
+        var dictCtor = _types.GetDefaultConstructor(dictType);
+        var addMethod = _types.GetMethod(dictType, "Add", _types.String, _types.Object);
+        il.Emit(OpCodes.Newobj, dictCtor);
+        var dict = il.DeclareLocal(dictType);
+        il.Emit(OpCodes.Stloc, dict);
+
+        void AddEntry(string key, Action loadDouble)
+        {
+            il.Emit(OpCodes.Ldloc, dict);
+            il.Emit(OpCodes.Ldstr, key);
+            loadDouble();
+            il.Emit(OpCodes.Box, _types.Double);
+            il.Emit(OpCodes.Call, addMethod);
+        }
+
+        AddEntry("mode", () => il.Emit(OpCodes.Ldloc, modeL));
+        AddEntry("size", () => il.Emit(OpCodes.Ldarg_3));
+        AddEntry("atimeMs", () => il.Emit(OpCodes.Ldarg_S, (byte)4));
+        AddEntry("mtimeMs", () => il.Emit(OpCodes.Ldarg_S, (byte)5));
+        AddEntry("ctimeMs", () => il.Emit(OpCodes.Ldarg_S, (byte)6));
+        AddEntry("birthtimeMs", () => il.Emit(OpCodes.Ldarg_S, (byte)7));
+        AddEntry("dev", () => il.Emit(OpCodes.Ldc_R8, 0.0));
+        AddEntry("ino", () => il.Emit(OpCodes.Ldc_R8, 0.0));
+        AddEntry("nlink", () => il.Emit(OpCodes.Ldc_R8, 1.0));
+        AddEntry("uid", () => il.Emit(OpCodes.Ldc_R8, 0.0));
+        AddEntry("gid", () => il.Emit(OpCodes.Ldc_R8, 0.0));
+        AddEntry("rdev", () => il.Emit(OpCodes.Ldc_R8, 0.0));
+        AddEntry("blksize", () => il.Emit(OpCodes.Ldc_R8, 4096.0));
+        AddEntry("blocks", () => il.Emit(OpCodes.Ldloc, blocksL));
+
+        il.Emit(OpCodes.Ldloc, dict);
+        il.Emit(OpCodes.Call, runtime.CreateObject);
+        il.Emit(OpCodes.Ret);
+    }
+
+    // Loads the four File.Get*Time timestamps (as unix-ms doubles) into the given
+    // locals, from the path local. Times work for files and directories alike.
+    private void EmitLoadStatTimes(ILGenerator il, EmittedRuntime runtime, LocalBuilder pathLocal,
+        LocalBuilder at, LocalBuilder mt, LocalBuilder ct)
+    {
+        il.Emit(OpCodes.Ldloc, pathLocal);
+        il.Emit(OpCodes.Call, _types.GetMethod(_types.File, "GetLastAccessTime", _types.String));
+        il.Emit(OpCodes.Call, runtime.FsStatTimeMs); il.Emit(OpCodes.Stloc, at);
+        il.Emit(OpCodes.Ldloc, pathLocal);
+        il.Emit(OpCodes.Call, _types.GetMethod(_types.File, "GetLastWriteTime", _types.String));
+        il.Emit(OpCodes.Call, runtime.FsStatTimeMs); il.Emit(OpCodes.Stloc, mt);
+        il.Emit(OpCodes.Ldloc, pathLocal);
+        il.Emit(OpCodes.Call, _types.GetMethod(_types.File, "GetCreationTime", _types.String));
+        il.Emit(OpCodes.Call, runtime.FsStatTimeMs); il.Emit(OpCodes.Stloc, ct);
+    }
+
+    /// <summary>object FsStatRaw(object path) — follows symlinks.</summary>
+    private void EmitFsStatRaw(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    {
+        var method = typeBuilder.DefineMethod("FsStatRaw",
+            System.Reflection.MethodAttributes.Public | System.Reflection.MethodAttributes.Static,
+            _types.Object, [_types.Object]);
+        runtime.FsStatRaw = method;
+
+        var il = method.GetILGenerator();
+        var resultLocal = il.DeclareLocal(_types.Object);
+        il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Call, runtime.Stringify);
+        var pathLocal = il.DeclareLocal(_types.String); il.Emit(OpCodes.Stloc, pathLocal);
+
+        EmitWithFsErrorHandling(il, runtime, pathLocal, "stat", afterTry =>
+        {
+            var isDirL = il.DeclareLocal(_types.Boolean);
+            il.Emit(OpCodes.Ldloc, pathLocal);
+            il.Emit(OpCodes.Call, _types.GetMethod(_types.Directory, "Exists", _types.String));
+            il.Emit(OpCodes.Stloc, isDirL);
+            var isFileL = il.DeclareLocal(_types.Boolean);
+            il.Emit(OpCodes.Ldloc, pathLocal);
+            il.Emit(OpCodes.Call, _types.GetMethod(_types.File, "Exists", _types.String));
+            il.Emit(OpCodes.Stloc, isFileL);
+
+            var existsL = il.DefineLabel();
+            il.Emit(OpCodes.Ldloc, isDirL); il.Emit(OpCodes.Brtrue, existsL);
+            il.Emit(OpCodes.Ldloc, isFileL); il.Emit(OpCodes.Brtrue, existsL);
+            il.Emit(OpCodes.Ldstr, "no such file or directory");
+            il.Emit(OpCodes.Ldloc, pathLocal);
+            il.Emit(OpCodes.Newobj, _types.GetConstructor(_types.FileNotFoundException, _types.String, _types.String));
+            il.Emit(OpCodes.Throw);
+            il.MarkLabel(existsL);
+
+            var sizeL = EmitStatSize(il, isFileL, pathLocal);
+            var roL = EmitStatReadOnly(il, isFileL, pathLocal);
+            var at = il.DeclareLocal(_types.Double);
+            var mt = il.DeclareLocal(_types.Double);
+            var ct = il.DeclareLocal(_types.Double);
+            EmitLoadStatTimes(il, runtime, pathLocal, at, mt, ct);
+
+            il.Emit(OpCodes.Ldloc, isDirL);
+            il.Emit(OpCodes.Ldc_I4_0);          // isSymlink = false (stat follows links)
+            il.Emit(OpCodes.Ldloc, roL);
+            il.Emit(OpCodes.Ldloc, sizeL);
+            il.Emit(OpCodes.Ldloc, at); il.Emit(OpCodes.Ldloc, mt);
+            il.Emit(OpCodes.Ldloc, ct); il.Emit(OpCodes.Ldloc, ct);
+            il.Emit(OpCodes.Call, runtime.FsBuildStatRecord);
+            il.Emit(OpCodes.Stloc, resultLocal);
+            il.Emit(OpCodes.Leave, afterTry);
+        });
+        il.Emit(OpCodes.Ldloc, resultLocal);
+        il.Emit(OpCodes.Ret);
+    }
+
+    /// <summary>object FsLstatRaw(object path) — does not follow symlinks.</summary>
+    private void EmitFsLstatRaw(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    {
+        var method = typeBuilder.DefineMethod("FsLstatRaw",
+            System.Reflection.MethodAttributes.Public | System.Reflection.MethodAttributes.Static,
+            _types.Object, [_types.Object]);
+        runtime.FsLstatRaw = method;
+
+        var il = method.GetILGenerator();
+        var resultLocal = il.DeclareLocal(_types.Object);
+        il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Call, runtime.Stringify);
+        var pathLocal = il.DeclareLocal(_types.String); il.Emit(OpCodes.Stloc, pathLocal);
+
+        EmitWithFsErrorHandling(il, runtime, pathLocal, "lstat", afterTry =>
+        {
+            var dirRawL = il.DeclareLocal(_types.Boolean);
+            il.Emit(OpCodes.Ldloc, pathLocal);
+            il.Emit(OpCodes.Call, _types.GetMethod(_types.Directory, "Exists", _types.String));
+            il.Emit(OpCodes.Stloc, dirRawL);
+            var isFileL = il.DeclareLocal(_types.Boolean);
+            il.Emit(OpCodes.Ldloc, pathLocal);
+            il.Emit(OpCodes.Call, _types.GetMethod(_types.File, "Exists", _types.String));
+            il.Emit(OpCodes.Stloc, isFileL);
+
+            var existsL = il.DefineLabel();
+            il.Emit(OpCodes.Ldloc, dirRawL); il.Emit(OpCodes.Brtrue, existsL);
+            il.Emit(OpCodes.Ldloc, isFileL); il.Emit(OpCodes.Brtrue, existsL);
+            il.Emit(OpCodes.Ldstr, "no such file or directory");
+            il.Emit(OpCodes.Ldloc, pathLocal);
+            il.Emit(OpCodes.Newobj, _types.GetConstructor(_types.FileNotFoundException, _types.String, _types.String));
+            il.Emit(OpCodes.Throw);
+            il.MarkLabel(existsL);
+
+            // isDir = dirRaw && !isFile
+            var isDirL = il.DeclareLocal(_types.Boolean);
+            il.Emit(OpCodes.Ldloc, dirRawL);
+            il.Emit(OpCodes.Ldloc, isFileL); il.Emit(OpCodes.Ldc_I4_0); il.Emit(OpCodes.Ceq);
+            il.Emit(OpCodes.And); il.Emit(OpCodes.Stloc, isDirL);
+
+            // isSymlink = (File.GetAttributes(path) & ReparsePoint) != 0
+            var symL = il.DeclareLocal(_types.Boolean);
+            il.Emit(OpCodes.Ldloc, pathLocal);
+            il.Emit(OpCodes.Call, _types.GetMethod(_types.File, "GetAttributes", _types.String));
+            il.Emit(OpCodes.Ldc_I4, (int)FileAttributes.ReparsePoint);
+            il.Emit(OpCodes.And); il.Emit(OpCodes.Ldc_I4_0); il.Emit(OpCodes.Cgt_Un);
+            il.Emit(OpCodes.Stloc, symL);
+
+            var sizeL = EmitStatSize(il, isFileL, pathLocal);
+            var roL = EmitStatReadOnly(il, isFileL, pathLocal);
+            var at = il.DeclareLocal(_types.Double);
+            var mt = il.DeclareLocal(_types.Double);
+            var ct = il.DeclareLocal(_types.Double);
+            EmitLoadStatTimes(il, runtime, pathLocal, at, mt, ct);
+
+            il.Emit(OpCodes.Ldloc, isDirL);
+            il.Emit(OpCodes.Ldloc, symL);
+            il.Emit(OpCodes.Ldloc, roL);
+            il.Emit(OpCodes.Ldloc, sizeL);
+            il.Emit(OpCodes.Ldloc, at); il.Emit(OpCodes.Ldloc, mt);
+            il.Emit(OpCodes.Ldloc, ct); il.Emit(OpCodes.Ldloc, ct);
+            il.Emit(OpCodes.Call, runtime.FsBuildStatRecord);
+            il.Emit(OpCodes.Stloc, resultLocal);
+            il.Emit(OpCodes.Leave, afterTry);
+        });
+        il.Emit(OpCodes.Ldloc, resultLocal);
+        il.Emit(OpCodes.Ret);
+    }
+
+    /// <summary>object FsFstatRaw(object fd).</summary>
+    private void EmitFsFstatRaw(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    {
+        var method = typeBuilder.DefineMethod("FsFstatRaw",
+            System.Reflection.MethodAttributes.Public | System.Reflection.MethodAttributes.Static,
+            _types.Object, [_types.Object]);
+        runtime.FsFstatRaw = method;
+
+        var il = method.GetILGenerator();
+        var resultLocal = il.DeclareLocal(_types.Object);
+
+        il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Call, runtime.ToNumber); il.Emit(OpCodes.Conv_I4);
+        var fdLocal = il.DeclareLocal(_types.Int32); il.Emit(OpCodes.Stloc, fdLocal);
+
+        il.Emit(OpCodes.Ldnull);
+        var pathLocal = il.DeclareLocal(_types.String); il.Emit(OpCodes.Stloc, pathLocal);
+
+        EmitWithFsErrorHandling(il, runtime, pathLocal, "fstat", afterTry =>
+        {
+            il.Emit(OpCodes.Ldsfld, runtime.FileDescriptorTableInstance);
+            il.Emit(OpCodes.Ldloc, fdLocal);
+            il.Emit(OpCodes.Callvirt, runtime.FileDescriptorTableGet);
+            var streamLocal = il.DeclareLocal(typeof(FileStream));
+            il.Emit(OpCodes.Stloc, streamLocal);
+
+            var sizeL = il.DeclareLocal(_types.Double);
+            il.Emit(OpCodes.Ldloc, streamLocal);
+            il.Emit(OpCodes.Callvirt, typeof(FileStream).GetProperty("Length")!.GetMethod!);
+            il.Emit(OpCodes.Conv_R8); il.Emit(OpCodes.Stloc, sizeL);
+
+            // path = stream.Name → for time recovery
+            il.Emit(OpCodes.Ldloc, streamLocal);
+            il.Emit(OpCodes.Callvirt, typeof(FileStream).GetProperty("Name")!.GetMethod!);
+            il.Emit(OpCodes.Stloc, pathLocal);
+
+            var at = il.DeclareLocal(_types.Double);
+            var mt = il.DeclareLocal(_types.Double);
+            var ct = il.DeclareLocal(_types.Double);
+            EmitLoadStatTimes(il, runtime, pathLocal, at, mt, ct);
+
+            il.Emit(OpCodes.Ldc_I4_0);    // isDir = false
+            il.Emit(OpCodes.Ldc_I4_0);    // isSymlink = false
+            il.Emit(OpCodes.Ldc_I4_0);    // isReadOnly = false
+            il.Emit(OpCodes.Ldloc, sizeL);
+            il.Emit(OpCodes.Ldloc, at); il.Emit(OpCodes.Ldloc, mt);
+            il.Emit(OpCodes.Ldloc, ct); il.Emit(OpCodes.Ldloc, ct);
+            il.Emit(OpCodes.Call, runtime.FsBuildStatRecord);
+            il.Emit(OpCodes.Stloc, resultLocal);
+            il.Emit(OpCodes.Leave, afterTry);
+        });
+        il.Emit(OpCodes.Ldloc, resultLocal);
+        il.Emit(OpCodes.Ret);
+    }
+
+    // size = isFile ? (double)new FileInfo(path).Length : 0
+    private LocalBuilder EmitStatSize(ILGenerator il, LocalBuilder isFileL, LocalBuilder pathLocal)
+    {
+        var sizeL = il.DeclareLocal(_types.Double);
+        var notFile = il.DefineLabel(); var done = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, isFileL); il.Emit(OpCodes.Brfalse, notFile);
+        il.Emit(OpCodes.Ldloc, pathLocal);
+        il.Emit(OpCodes.Newobj, _types.GetConstructor(_types.FileInfo, _types.String));
+        il.Emit(OpCodes.Callvirt, _types.GetProperty(_types.FileInfo, "Length").GetMethod!);
+        il.Emit(OpCodes.Conv_R8); il.Emit(OpCodes.Stloc, sizeL); il.Emit(OpCodes.Br, done);
+        il.MarkLabel(notFile); il.Emit(OpCodes.Ldc_R8, 0.0); il.Emit(OpCodes.Stloc, sizeL);
+        il.MarkLabel(done);
+        return sizeL;
+    }
+
+    // readOnly = isFile && (File.GetAttributes(path) & ReadOnly) != 0
+    private LocalBuilder EmitStatReadOnly(ILGenerator il, LocalBuilder isFileL, LocalBuilder pathLocal)
+    {
+        var roL = il.DeclareLocal(_types.Boolean);
+        var notFile = il.DefineLabel(); var done = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, isFileL); il.Emit(OpCodes.Brfalse, notFile);
+        il.Emit(OpCodes.Ldloc, pathLocal);
+        il.Emit(OpCodes.Call, _types.GetMethod(_types.File, "GetAttributes", _types.String));
+        il.Emit(OpCodes.Ldc_I4, (int)FileAttributes.ReadOnly);
+        il.Emit(OpCodes.And); il.Emit(OpCodes.Ldc_I4_0); il.Emit(OpCodes.Cgt_Un);
+        il.Emit(OpCodes.Stloc, roL); il.Emit(OpCodes.Br, done);
+        il.MarkLabel(notFile); il.Emit(OpCodes.Ldc_I4_0); il.Emit(OpCodes.Stloc, roL);
+        il.MarkLabel(done);
+        return roL;
+    }
+}

--- a/Compilation/RuntimeEmitter.FsSync.cs
+++ b/Compilation/RuntimeEmitter.FsSync.cs
@@ -47,8 +47,95 @@ public partial class RuntimeEmitter
     }
 
     /// <summary>
+    /// Emits the BCL-only encoding helpers used by fs read/write/append. They mirror
+    /// the interpreter's FsModuleInterpreter.EncodingName + BufferEncoding.ToBytes and
+    /// reuse the (corrected) $Buffer encoder so fs encoding == Buffer encoding.
+    /// </summary>
+    private void EmitFsEncodingHelpers(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    {
+        // string FsEncodingName(object opt): null when none; the string itself, or
+        // opt.encoding when opt is an options object.
+        var nameMethod = typeBuilder.DefineMethod(
+            "FsEncodingName",
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.String,
+            [_types.Object]
+        );
+        runtime.FsEncodingName = nameMethod;
+        {
+            var il = nameMethod.GetILGenerator();
+            var retNull = il.DefineLabel();
+            var retIt = il.DefineLabel();
+            // if (opt == null) return null
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Brfalse, retNull);
+            // if (opt is string) return (string)opt
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Isinst, _types.String);
+            il.Emit(OpCodes.Dup);
+            il.Emit(OpCodes.Brtrue, retIt);
+            il.Emit(OpCodes.Pop);
+            // e = opt.encoding; return (e is string) ? e : null
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldstr, "encoding");
+            il.Emit(OpCodes.Call, runtime.GetProperty);
+            il.Emit(OpCodes.Isinst, _types.String);
+            il.Emit(OpCodes.Dup);
+            il.Emit(OpCodes.Brtrue, retIt);
+            il.Emit(OpCodes.Pop);
+            il.MarkLabel(retNull);
+            il.Emit(OpCodes.Ldnull);
+            il.Emit(OpCodes.Ret);
+            il.MarkLabel(retIt);
+            il.Emit(OpCodes.Ret);
+        }
+
+        // byte[] FsToBytes(object data, object encodingOpt): a Buffer contributes its
+        // bytes verbatim; a string is encoded via $Buffer.FromString (default utf8).
+        var byteArr = _types.MakeArrayType(_types.Byte);
+        var toBytesMethod = typeBuilder.DefineMethod(
+            "FsToBytes",
+            MethodAttributes.Public | MethodAttributes.Static,
+            byteArr,
+            [_types.Object, _types.Object]
+        );
+        runtime.FsToBytes = toBytesMethod;
+        {
+            var il = toBytesMethod.GetILGenerator();
+            var isBuf = il.DefineLabel();
+            var haveEnc = il.DefineLabel();
+            // buf = data as $Buffer
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Isinst, runtime.TSBufferType);
+            il.Emit(OpCodes.Dup);
+            il.Emit(OpCodes.Brtrue, isBuf);
+            il.Emit(OpCodes.Pop);
+            // string s = Stringify(data)
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Call, runtime.Stringify);
+            // string enc = FsEncodingName(encodingOpt) ?? "utf8"
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Call, runtime.FsEncodingName);
+            il.Emit(OpCodes.Dup);
+            il.Emit(OpCodes.Brtrue, haveEnc);
+            il.Emit(OpCodes.Pop);
+            il.Emit(OpCodes.Ldstr, "utf8");
+            il.MarkLabel(haveEnc);
+            // $Buffer.FromString(s, enc).GetData()
+            il.Emit(OpCodes.Call, runtime.TSBufferFromString);
+            il.Emit(OpCodes.Callvirt, runtime.TSBufferGetData);
+            il.Emit(OpCodes.Ret);
+            // ((TSBuffer)data).GetData()
+            il.MarkLabel(isBuf);
+            il.Emit(OpCodes.Callvirt, runtime.TSBufferGetData);
+            il.Emit(OpCodes.Ret);
+        }
+    }
+
+    /// <summary>
     /// Emits: public static object FsReadFileSync(object path, object? encoding)
-    /// Returns string if encoding specified, $Buffer otherwise.
+    /// Reads raw bytes; returns a $Buffer when no encoding, else decodes via the
+    /// $Buffer encoder (so every encoding matches the interpreter and Buffer).
     /// </summary>
     private void EmitFsReadFileSync(TypeBuilder typeBuilder, EmittedRuntime runtime)
     {
@@ -62,6 +149,8 @@ public partial class RuntimeEmitter
 
         var il = method.GetILGenerator();
         var resultLocal = il.DeclareLocal(_types.Object);
+        var bytesLocal = il.DeclareLocal(_types.MakeArrayType(_types.Byte));
+        var encLocal = il.DeclareLocal(_types.String);
 
         // Convert path to string
         il.Emit(OpCodes.Ldarg_0);
@@ -71,24 +160,32 @@ public partial class RuntimeEmitter
 
         EmitWithFsErrorHandling(il, runtime, pathLocal, "open", afterTry =>
         {
-            // Check if encoding is provided (not null)
-            var readBytesLabel = il.DefineLabel();
-            var afterReadLabel = il.DefineLabel();
-            il.Emit(OpCodes.Ldarg_1);
-            il.Emit(OpCodes.Brfalse, readBytesLabel);
-
-            // Read as text: File.ReadAllText(path)
+            // bytes = File.ReadAllBytes(path)
             il.Emit(OpCodes.Ldloc, pathLocal);
-            il.Emit(OpCodes.Call, _types.GetMethod(_types.File, "ReadAllText", _types.String));
+            il.Emit(OpCodes.Call, _types.GetMethod(_types.File, "ReadAllBytes", _types.String));
+            il.Emit(OpCodes.Stloc, bytesLocal);
+
+            // enc = FsEncodingName(encoding)
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Call, runtime.FsEncodingName);
+            il.Emit(OpCodes.Stloc, encLocal);
+
+            var asBufferLabel = il.DefineLabel();
+            var afterReadLabel = il.DefineLabel();
+            il.Emit(OpCodes.Ldloc, encLocal);
+            il.Emit(OpCodes.Brfalse, asBufferLabel);
+
+            // Decode: new $Buffer(bytes).ToEncodedString(enc)
+            il.Emit(OpCodes.Ldloc, bytesLocal);
+            il.Emit(OpCodes.Newobj, runtime.TSBufferCtor);
+            il.Emit(OpCodes.Ldloc, encLocal);
+            il.Emit(OpCodes.Callvirt, runtime.TSBufferToString);
             il.Emit(OpCodes.Stloc, resultLocal);
             il.Emit(OpCodes.Br, afterReadLabel);
 
-            // Read as bytes: File.ReadAllBytes(path) - wrap in $Buffer
-            il.MarkLabel(readBytesLabel);
-            il.Emit(OpCodes.Ldloc, pathLocal);
-            il.Emit(OpCodes.Call, _types.GetMethod(_types.File, "ReadAllBytes", _types.String));
-
-            // Create $Buffer from byte[]
+            // No encoding: wrap bytes in $Buffer
+            il.MarkLabel(asBufferLabel);
+            il.Emit(OpCodes.Ldloc, bytesLocal);
             il.Emit(OpCodes.Newobj, runtime.TSBufferCtor);
             il.Emit(OpCodes.Stloc, resultLocal);
 
@@ -100,7 +197,8 @@ public partial class RuntimeEmitter
     }
 
     /// <summary>
-    /// Emits: public static void FsWriteFileSync(object path, object data)
+    /// Emits: public static void FsWriteFileSync(object path, object data, object? encoding)
+    /// Writes raw bytes (Buffer verbatim, string encoded) — never ToString's a Buffer.
     /// </summary>
     private void EmitFsWriteFileSync(TypeBuilder typeBuilder, EmittedRuntime runtime)
     {
@@ -108,37 +206,38 @@ public partial class RuntimeEmitter
             "FsWriteFileSync",
             MethodAttributes.Public | MethodAttributes.Static,
             _types.Void,
-            [_types.Object, _types.Object]
+            [_types.Object, _types.Object, _types.Object]
         );
         runtime.FsWriteFileSync = method;
 
         var il = method.GetILGenerator();
 
-        // Convert path to string
+        // path = Stringify(arg0)
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Call, runtime.Stringify);
         var pathLocal = il.DeclareLocal(_types.String);
         il.Emit(OpCodes.Stloc, pathLocal);
 
-        // Convert data to string
+        // bytes = FsToBytes(data, encoding)
         il.Emit(OpCodes.Ldarg_1);
-        il.Emit(OpCodes.Call, runtime.Stringify);
-        var dataLocal = il.DeclareLocal(_types.String);
-        il.Emit(OpCodes.Stloc, dataLocal);
+        il.Emit(OpCodes.Ldarg_2);
+        il.Emit(OpCodes.Call, runtime.FsToBytes);
+        var bytesLocal = il.DeclareLocal(_types.MakeArrayType(_types.Byte));
+        il.Emit(OpCodes.Stloc, bytesLocal);
 
         EmitWithFsErrorHandling(il, runtime, pathLocal, "open", afterTry =>
         {
-            // File.WriteAllText(path, data)
+            // File.WriteAllBytes(path, bytes)
             il.Emit(OpCodes.Ldloc, pathLocal);
-            il.Emit(OpCodes.Ldloc, dataLocal);
-            il.Emit(OpCodes.Call, _types.GetMethod(_types.File, "WriteAllText", _types.String, _types.String));
+            il.Emit(OpCodes.Ldloc, bytesLocal);
+            il.Emit(OpCodes.Call, _types.GetMethod(_types.File, "WriteAllBytes", _types.String, _types.MakeArrayType(_types.Byte)));
             il.Emit(OpCodes.Leave, afterTry);
         });
         il.Emit(OpCodes.Ret);
     }
 
     /// <summary>
-    /// Emits: public static void FsAppendFileSync(object path, object data)
+    /// Emits: public static void FsAppendFileSync(object path, object data, object? encoding)
     /// </summary>
     private void EmitFsAppendFileSync(TypeBuilder typeBuilder, EmittedRuntime runtime)
     {
@@ -146,30 +245,31 @@ public partial class RuntimeEmitter
             "FsAppendFileSync",
             MethodAttributes.Public | MethodAttributes.Static,
             _types.Void,
-            [_types.Object, _types.Object]
+            [_types.Object, _types.Object, _types.Object]
         );
         runtime.FsAppendFileSync = method;
 
         var il = method.GetILGenerator();
 
-        // Convert path to string
+        // path = Stringify(arg0)
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Call, runtime.Stringify);
         var pathLocal = il.DeclareLocal(_types.String);
         il.Emit(OpCodes.Stloc, pathLocal);
 
-        // Convert data to string
+        // bytes = FsToBytes(data, encoding)
         il.Emit(OpCodes.Ldarg_1);
-        il.Emit(OpCodes.Call, runtime.Stringify);
-        var dataLocal = il.DeclareLocal(_types.String);
-        il.Emit(OpCodes.Stloc, dataLocal);
+        il.Emit(OpCodes.Ldarg_2);
+        il.Emit(OpCodes.Call, runtime.FsToBytes);
+        var bytesLocal = il.DeclareLocal(_types.MakeArrayType(_types.Byte));
+        il.Emit(OpCodes.Stloc, bytesLocal);
 
         EmitWithFsErrorHandling(il, runtime, pathLocal, "open", afterTry =>
         {
-            // File.AppendAllText(path, data)
+            // File.AppendAllBytes(path, bytes)
             il.Emit(OpCodes.Ldloc, pathLocal);
-            il.Emit(OpCodes.Ldloc, dataLocal);
-            il.Emit(OpCodes.Call, _types.GetMethod(_types.File, "AppendAllText", _types.String, _types.String));
+            il.Emit(OpCodes.Ldloc, bytesLocal);
+            il.Emit(OpCodes.Call, _types.GetMethod(_types.File, "AppendAllBytes", _types.String, _types.MakeArrayType(_types.Byte)));
             il.Emit(OpCodes.Leave, afterTry);
         });
         il.Emit(OpCodes.Ret);

--- a/Compilation/RuntimeEmitter.FsSync.cs
+++ b/Compilation/RuntimeEmitter.FsSync.cs
@@ -797,6 +797,25 @@ public partial class RuntimeEmitter
         var pathLocal = il.DeclareLocal(_types.String);
         il.Emit(OpCodes.Stloc, pathLocal);
 
+        // mode = arg1 is a boxed double ? (int)(double)arg1 : 0. The async access
+        // path forwards an undefined mode, so unbox only when it really is a number.
+        var modeLocal = il.DeclareLocal(_types.Int32);
+        var modeNotDouble = il.DefineLabel();
+        var modeDone = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Isinst, _types.Double);
+        il.Emit(OpCodes.Dup);
+        il.Emit(OpCodes.Brfalse, modeNotDouble);
+        il.Emit(OpCodes.Unbox_Any, _types.Double);
+        il.Emit(OpCodes.Conv_I4);
+        il.Emit(OpCodes.Stloc, modeLocal);
+        il.Emit(OpCodes.Br, modeDone);
+        il.MarkLabel(modeNotDouble);
+        il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Stloc, modeLocal);
+        il.MarkLabel(modeDone);
+
         EmitWithFsErrorHandling(il, runtime, pathLocal, "access", afterTry =>
         {
             // Check if exists (File.Exists || Directory.Exists)
@@ -816,6 +835,32 @@ public partial class RuntimeEmitter
             il.Emit(OpCodes.Throw);
 
             il.MarkLabel(existsLabel);
+
+            // W_OK (mode & 2): a read-only file denies writes (best-effort, mirrors the
+            // interpreter's CheckAccess — surfaced as EACCES by the fs error wrapper).
+            var skipWok = il.DefineLabel();
+            il.Emit(OpCodes.Ldloc, modeLocal);
+            il.Emit(OpCodes.Ldc_I4_2);
+            il.Emit(OpCodes.And);
+            il.Emit(OpCodes.Brfalse, skipWok);
+
+            // Only files have a meaningful read-only attribute here.
+            il.Emit(OpCodes.Ldloc, pathLocal);
+            il.Emit(OpCodes.Call, _types.GetMethod(_types.File, "Exists", _types.String));
+            il.Emit(OpCodes.Brfalse, skipWok);
+
+            // (File.GetAttributes(path) & FileAttributes.ReadOnly) != 0
+            il.Emit(OpCodes.Ldloc, pathLocal);
+            il.Emit(OpCodes.Call, _types.GetMethod(_types.File, "GetAttributes", _types.String));
+            il.Emit(OpCodes.Ldc_I4_1); // FileAttributes.ReadOnly
+            il.Emit(OpCodes.And);
+            il.Emit(OpCodes.Brfalse, skipWok);
+
+            il.Emit(OpCodes.Ldstr, "permission denied");
+            il.Emit(OpCodes.Newobj, typeof(UnauthorizedAccessException).GetConstructor([_types.String])!);
+            il.Emit(OpCodes.Throw);
+
+            il.MarkLabel(skipWok);
             il.Emit(OpCodes.Leave, afterTry);
         });
         il.Emit(OpCodes.Ret);

--- a/Compilation/RuntimeEmitter.FsWrappers.cs
+++ b/Compilation/RuntimeEmitter.FsWrappers.cs
@@ -30,12 +30,14 @@ public partial class RuntimeEmitter
                 il.Emit(OpCodes.Call, runtime.FsReadFileSync);
             });
 
-        // writeFileSync(path, data) -> undefined
+        // writeFileSync(path, data) -> undefined (value-import fallback; encoding via
+        // the direct-dispatch path, so this fixed-arity wrapper passes null).
         EmitFsMethodWrapperSimple(typeBuilder, runtime, "writeFileSync", 2,
             il =>
             {
                 il.Emit(OpCodes.Ldarg_0);
                 il.Emit(OpCodes.Ldarg_1);
+                il.Emit(OpCodes.Ldnull);
                 il.Emit(OpCodes.Call, runtime.FsWriteFileSync);
                 il.Emit(OpCodes.Ldnull);
             });
@@ -46,6 +48,7 @@ public partial class RuntimeEmitter
             {
                 il.Emit(OpCodes.Ldarg_0);
                 il.Emit(OpCodes.Ldarg_1);
+                il.Emit(OpCodes.Ldnull);
                 il.Emit(OpCodes.Call, runtime.FsAppendFileSync);
                 il.Emit(OpCodes.Ldnull);
             });

--- a/Compilation/RuntimeEmitter.TSBufferInstance.cs
+++ b/Compilation/RuntimeEmitter.TSBufferInstance.cs
@@ -24,7 +24,10 @@ public partial class RuntimeEmitter
         var encodingLocal = il.DeclareLocal(_types.String);
         var utf8Label = il.DefineLabel();
         var asciiLabel = il.DefineLabel();
+        var latin1Label = il.DefineLabel();
+        var utf16leLabel = il.DefineLabel();
         var base64Label = il.DefineLabel();
+        var base64urlLabel = il.DefineLabel();
         var hexLabel = il.DefineLabel();
         var defaultLabel = il.DefineLabel();
 
@@ -45,11 +48,18 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Stloc, encodingLocal);
         il.MarkLabel(afterEncodingLabel);
 
-        // Check encodings
+        // Check encodings (must mirror Runtime/Types/BufferEncoding.Decode exactly).
         CheckStringEquals(il, encodingLocal, "utf8", utf8Label);
         CheckStringEquals(il, encodingLocal, "utf-8", utf8Label);
         CheckStringEquals(il, encodingLocal, "ascii", asciiLabel);
+        CheckStringEquals(il, encodingLocal, "latin1", latin1Label);
+        CheckStringEquals(il, encodingLocal, "binary", latin1Label);
+        CheckStringEquals(il, encodingLocal, "utf16le", utf16leLabel);
+        CheckStringEquals(il, encodingLocal, "utf-16le", utf16leLabel);
+        CheckStringEquals(il, encodingLocal, "ucs2", utf16leLabel);
+        CheckStringEquals(il, encodingLocal, "ucs-2", utf16leLabel);
         CheckStringEquals(il, encodingLocal, "base64", base64Label);
+        CheckStringEquals(il, encodingLocal, "base64url", base64urlLabel);
         CheckStringEquals(il, encodingLocal, "hex", hexLabel);
         il.Emit(OpCodes.Br, defaultLabel);
 
@@ -63,11 +73,31 @@ public partial class RuntimeEmitter
         EmitEncodingGetString(il, "ASCII");
         il.Emit(OpCodes.Ret);
 
+        // Latin1 / binary
+        il.MarkLabel(latin1Label);
+        EmitEncodingGetString(il, "Latin1");
+        il.Emit(OpCodes.Ret);
+
+        // UTF-16LE / ucs2
+        il.MarkLabel(utf16leLabel);
+        EmitEncodingGetString(il, "Unicode");
+        il.Emit(OpCodes.Ret);
+
         // Base64
         il.MarkLabel(base64Label);
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ldfld, _tsBufferDataField);
         il.Emit(OpCodes.Call, _types.ConvertToBase64String);
+        il.Emit(OpCodes.Ret);
+
+        // Base64url: standard base64 with -/_ alphabet and no padding.
+        il.MarkLabel(base64urlLabel);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, _tsBufferDataField);
+        il.Emit(OpCodes.Call, _types.ConvertToBase64String);
+        EmitStringReplace(il, "=", "");
+        EmitStringReplace(il, "+", "-");
+        EmitStringReplace(il, "/", "_");
         il.Emit(OpCodes.Ret);
 
         // Hex
@@ -82,6 +112,14 @@ public partial class RuntimeEmitter
         il.MarkLabel(defaultLabel);
         EmitEncodingGetString(il, "UTF8");
         il.Emit(OpCodes.Ret);
+    }
+
+    /// <summary>Emits <c>str = str.Replace(oldStr, newStr)</c> on the string atop the stack.</summary>
+    private void EmitStringReplace(ILGenerator il, string oldStr, string newStr)
+    {
+        il.Emit(OpCodes.Ldstr, oldStr);
+        il.Emit(OpCodes.Ldstr, newStr);
+        il.Emit(OpCodes.Callvirt, _types.String.GetMethod("Replace", [_types.String, _types.String])!);
     }
 
     private void EmitEncodingGetString(ILGenerator il, string encodingProperty)

--- a/Compilation/RuntimeEmitter.TSBufferStatic.cs
+++ b/Compilation/RuntimeEmitter.TSBufferStatic.cs
@@ -23,7 +23,10 @@ public partial class RuntimeEmitter
         var encodingLocal = il.DeclareLocal(_types.String);
         var utf8Label = il.DefineLabel();
         var asciiLabel = il.DefineLabel();
+        var latin1Label = il.DefineLabel();
+        var utf16leLabel = il.DefineLabel();
         var base64Label = il.DefineLabel();
+        var base64urlLabel = il.DefineLabel();
         var hexLabel = il.DefineLabel();
         var defaultLabel = il.DefineLabel();
 
@@ -32,11 +35,18 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Callvirt, _types.String.GetMethod("ToLowerInvariant")!);
         il.Emit(OpCodes.Stloc, encodingLocal);
 
-        // Check encodings
+        // Check encodings (must mirror Runtime/Types/BufferEncoding.Encode exactly).
         CheckStringEquals(il, encodingLocal, "utf8", utf8Label);
         CheckStringEquals(il, encodingLocal, "utf-8", utf8Label);
         CheckStringEquals(il, encodingLocal, "ascii", asciiLabel);
+        CheckStringEquals(il, encodingLocal, "latin1", latin1Label);
+        CheckStringEquals(il, encodingLocal, "binary", latin1Label);
+        CheckStringEquals(il, encodingLocal, "utf16le", utf16leLabel);
+        CheckStringEquals(il, encodingLocal, "utf-16le", utf16leLabel);
+        CheckStringEquals(il, encodingLocal, "ucs2", utf16leLabel);
+        CheckStringEquals(il, encodingLocal, "ucs-2", utf16leLabel);
         CheckStringEquals(il, encodingLocal, "base64", base64Label);
+        CheckStringEquals(il, encodingLocal, "base64url", base64urlLabel);
         CheckStringEquals(il, encodingLocal, "hex", hexLabel);
         il.Emit(OpCodes.Br, defaultLabel);
 
@@ -50,9 +60,26 @@ public partial class RuntimeEmitter
         EmitEncodingGetBytes(il, "ASCII", runtime.TSBufferCtor);
         il.Emit(OpCodes.Ret);
 
+        // Latin1 / binary
+        il.MarkLabel(latin1Label);
+        EmitEncodingGetBytes(il, "Latin1", runtime.TSBufferCtor);
+        il.Emit(OpCodes.Ret);
+
+        // UTF-16LE / ucs2
+        il.MarkLabel(utf16leLabel);
+        EmitEncodingGetBytes(il, "Unicode", runtime.TSBufferCtor);
+        il.Emit(OpCodes.Ret);
+
         // Base64
         il.MarkLabel(base64Label);
         il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Call, _types.ConvertFromBase64String);
+        il.Emit(OpCodes.Newobj, runtime.TSBufferCtor);
+        il.Emit(OpCodes.Ret);
+
+        // Base64url: map -/_ → +/ and re-pad to a multiple of 4, then decode.
+        il.MarkLabel(base64urlLabel);
+        EmitBase64UrlNormalize(il);
         il.Emit(OpCodes.Call, _types.ConvertFromBase64String);
         il.Emit(OpCodes.Newobj, runtime.TSBufferCtor);
         il.Emit(OpCodes.Ret);
@@ -68,6 +95,55 @@ public partial class RuntimeEmitter
         il.MarkLabel(defaultLabel);
         EmitEncodingGetBytes(il, "UTF8", runtime.TSBufferCtor);
         il.Emit(OpCodes.Ret);
+    }
+
+    /// <summary>
+    /// Emits: takes the input string (Ldarg_0) and leaves a standard-base64 string on
+    /// the stack — '-'→'+', '_'→'/', and re-padded with '=' to a multiple of 4 length.
+    /// Mirrors BufferEncoding.DecodeBase64's url-safe normalization.
+    /// </summary>
+    private void EmitBase64UrlNormalize(ILGenerator il)
+    {
+        var replace = _types.String.GetMethod("Replace", [_types.String, _types.String])!;
+        var concat = _types.String.GetMethod("Concat", [_types.String, _types.String])!;
+        var getLength = _types.String.GetProperty("Length")!.GetGetMethod()!;
+
+        var s = il.DeclareLocal(_types.String);
+        var rem = il.DeclareLocal(_types.Int32);
+
+        // s = arg0.Replace("-", "+").Replace("_", "/")
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldstr, "-"); il.Emit(OpCodes.Ldstr, "+"); il.Emit(OpCodes.Callvirt, replace);
+        il.Emit(OpCodes.Ldstr, "_"); il.Emit(OpCodes.Ldstr, "/"); il.Emit(OpCodes.Callvirt, replace);
+        il.Emit(OpCodes.Stloc, s);
+
+        // rem = s.Length % 4
+        il.Emit(OpCodes.Ldloc, s);
+        il.Emit(OpCodes.Callvirt, getLength);
+        il.Emit(OpCodes.Ldc_I4_4);
+        il.Emit(OpCodes.Rem);
+        il.Emit(OpCodes.Stloc, rem);
+
+        var pad1 = il.DefineLabel();
+        var done = il.DefineLabel();
+
+        // rem == 2 → s + "=="
+        il.Emit(OpCodes.Ldloc, rem); il.Emit(OpCodes.Ldc_I4_2); il.Emit(OpCodes.Bne_Un, pad1);
+        il.Emit(OpCodes.Ldloc, s); il.Emit(OpCodes.Ldstr, "=="); il.Emit(OpCodes.Call, concat);
+        il.Emit(OpCodes.Br, done);
+
+        // rem == 3 → s + "="
+        il.MarkLabel(pad1);
+        var noPad = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, rem); il.Emit(OpCodes.Ldc_I4_3); il.Emit(OpCodes.Bne_Un, noPad);
+        il.Emit(OpCodes.Ldloc, s); il.Emit(OpCodes.Ldstr, "="); il.Emit(OpCodes.Call, concat);
+        il.Emit(OpCodes.Br, done);
+
+        // rem == 0 (or 1) → s unchanged
+        il.MarkLabel(noPad);
+        il.Emit(OpCodes.Ldloc, s);
+
+        il.MarkLabel(done);
     }
 
     private void EmitEncodingGetBytes(ILGenerator il, string encodingProperty, ConstructorBuilder bufferCtor)

--- a/Runtime/BuiltIns/Modules/Interpreter/FsAsyncHelpers.cs
+++ b/Runtime/BuiltIns/Modules/Interpreter/FsAsyncHelpers.cs
@@ -70,41 +70,25 @@ public static class FsAsyncHelpers
     /// <returns>A Stats-like object with file information.</returns>
     public static async Task<SharpTSObject> StatAsync(string path)
     {
-        // Use Task.Run to offload the synchronous file info operations
+        // Returns the raw stat record (#977) — same shape/logic as the sync
+        // FsModuleInterpreter.StatRaw, so statSync and await stat agree by
+        // construction; the TS Stats class shapes it. stat follows symlinks.
         return await Task.Run(() =>
         {
             if (Directory.Exists(path))
             {
-                var dirInfo = new DirectoryInfo(path);
-                return CreateStatsObject(
-                    isDirectory: true,
-                    isFile: false,
-                    isSymbolicLink: dirInfo.Attributes.HasFlag(FileAttributes.ReparsePoint),
-                    size: 0,
-                    atime: dirInfo.LastAccessTime,
-                    mtime: dirInfo.LastWriteTime,
-                    ctime: dirInfo.CreationTime,
-                    birthtime: dirInfo.CreationTime
-                );
+                var di = new DirectoryInfo(path);
+                return FsModuleInterpreter.BuildStatRecord(true, false, false, 0.0,
+                    di.LastAccessTime, di.LastWriteTime, di.CreationTime, di.CreationTime);
             }
-            else if (File.Exists(path))
+            if (File.Exists(path))
             {
-                var fileInfo = new FileInfo(path);
-                return CreateStatsObject(
-                    isDirectory: false,
-                    isFile: true,
-                    isSymbolicLink: fileInfo.Attributes.HasFlag(FileAttributes.ReparsePoint),
-                    size: fileInfo.Length,
-                    atime: fileInfo.LastAccessTime,
-                    mtime: fileInfo.LastWriteTime,
-                    ctime: fileInfo.CreationTime,
-                    birthtime: fileInfo.CreationTime
-                );
+                var fi = new FileInfo(path);
+                bool ro = fi.Attributes.HasFlag(FileAttributes.ReadOnly);
+                return FsModuleInterpreter.BuildStatRecord(false, false, ro, fi.Length,
+                    fi.LastAccessTime, fi.LastWriteTime, fi.CreationTime, fi.CreationTime);
             }
-            else
-            {
-                throw new FileNotFoundException("no such file or directory", path);
-            }
+            throw new FileNotFoundException("no such file or directory", path);
         });
     }
 
@@ -238,7 +222,8 @@ public static class FsAsyncHelpers
             {
                 foreach (var entry in entries)
                 {
-                    list.Add(CreateDirent(entry));
+                    // Reuse the one canonical Dirent builder (#977) for sync/async parity.
+                    list.Add(FsModuleInterpreter.CreateDirent(entry, Path.GetDirectoryName(entry) ?? path));
                 }
             }
             else
@@ -257,35 +242,6 @@ public static class FsAsyncHelpers
             }
 
             return new SharpTSArray(list);
-        });
-    }
-
-    /// <summary>
-    /// Creates a Dirent-like object for readdir with withFileTypes option.
-    /// </summary>
-    private static SharpTSObject CreateDirent(string fullPath)
-    {
-        var name = Path.GetFileName(fullPath);
-        var isFile = File.Exists(fullPath);
-        var isDir = Directory.Exists(fullPath);
-        var isSymlink = false;
-
-        var fileInfo = new FileInfo(fullPath);
-        if (fileInfo.Exists || Directory.Exists(fullPath))
-        {
-            isSymlink = fileInfo.Attributes.HasFlag(FileAttributes.ReparsePoint);
-        }
-
-        return new SharpTSObject(new Dictionary<string, object?>
-        {
-            ["name"] = name,
-            ["isFile"] = BuiltInMethod.CreateV2("isFile", 0, 0, (_, _, _) => RuntimeValue.FromBoolean(isFile && !isDir)),
-            ["isDirectory"] = BuiltInMethod.CreateV2("isDirectory", 0, 0, (_, _, _) => RuntimeValue.FromBoolean(isDir)),
-            ["isSymbolicLink"] = BuiltInMethod.CreateV2("isSymbolicLink", 0, 0, (_, _, _) => RuntimeValue.FromBoolean(isSymlink)),
-            ["isBlockDevice"] = BuiltInMethod.CreateV2("isBlockDevice", 0, 0, (_, _, _) => RuntimeValue.False),
-            ["isCharacterDevice"] = BuiltInMethod.CreateV2("isCharacterDevice", 0, 0, (_, _, _) => RuntimeValue.False),
-            ["isFIFO"] = BuiltInMethod.CreateV2("isFIFO", 0, 0, (_, _, _) => RuntimeValue.False),
-            ["isSocket"] = BuiltInMethod.CreateV2("isSocket", 0, 0, (_, _, _) => RuntimeValue.False)
         });
     }
 
@@ -426,38 +382,16 @@ public static class FsAsyncHelpers
                 throw new FileNotFoundException("no such file or directory", path);
             }
 
-            bool isSymlink = false;
+            // Raw record matching the sync FsModuleInterpreter.LstatRaw (#977).
+            bool isSymlink = (fileInfo.Exists ? fileInfo.Attributes : dirInfo.Attributes).HasFlag(FileAttributes.ReparsePoint);
             bool isDir = dirInfo.Exists && !fileInfo.Exists;
-            long size = fileInfo.Exists ? fileInfo.Length : 0;
-            DateTime atime, mtime, ctime, birthtime;
+            double size = fileInfo.Exists ? fileInfo.Length : 0.0;
+            bool ro = fileInfo.Exists && fileInfo.Attributes.HasFlag(FileAttributes.ReadOnly);
+            DateTime atime = isDir ? dirInfo.LastAccessTime : fileInfo.LastAccessTime;
+            DateTime mtime = isDir ? dirInfo.LastWriteTime : fileInfo.LastWriteTime;
+            DateTime ctime = isDir ? dirInfo.CreationTime : fileInfo.CreationTime;
 
-            if (fileInfo.Exists)
-            {
-                isSymlink = fileInfo.Attributes.HasFlag(FileAttributes.ReparsePoint);
-                atime = fileInfo.LastAccessTime;
-                mtime = fileInfo.LastWriteTime;
-                ctime = fileInfo.CreationTime;
-                birthtime = fileInfo.CreationTime;
-            }
-            else
-            {
-                isSymlink = dirInfo.Attributes.HasFlag(FileAttributes.ReparsePoint);
-                atime = dirInfo.LastAccessTime;
-                mtime = dirInfo.LastWriteTime;
-                ctime = dirInfo.CreationTime;
-                birthtime = dirInfo.CreationTime;
-            }
-
-            return CreateStatsObject(
-                isDirectory: isDir,
-                isFile: fileInfo.Exists && !isDir,
-                isSymbolicLink: isSymlink,
-                size: size,
-                atime: atime,
-                mtime: mtime,
-                ctime: ctime,
-                birthtime: birthtime
-            );
+            return FsModuleInterpreter.BuildStatRecord(isDir, isSymlink, ro, size, atime, mtime, ctime, ctime);
         });
     }
 

--- a/Runtime/BuiltIns/Modules/Interpreter/FsAsyncHelpers.cs
+++ b/Runtime/BuiltIns/Modules/Interpreter/FsAsyncHelpers.cs
@@ -29,17 +29,10 @@ public static class FsAsyncHelpers
     public static async Task<object?> ReadFileAsync(string path, object? encoding)
     {
         await InjectedTestLatency();
-        if (encoding != null)
-        {
-            // Return as string
-            return await File.ReadAllTextAsync(path);
-        }
-        else
-        {
-            // Return as Buffer
-            var bytes = await File.ReadAllBytesAsync(path);
-            return new SharpTSBuffer(bytes);
-        }
+        var encName = FsModuleInterpreter.EncodingName(encoding);
+        var bytes = await File.ReadAllBytesAsync(path);
+        // No encoding → Buffer; otherwise decode the raw bytes per the encoding.
+        return encName != null ? (object?)BufferEncoding.Decode(bytes, encName) : new SharpTSBuffer(bytes);
     }
 
     /// <summary>
@@ -51,15 +44,9 @@ public static class FsAsyncHelpers
     public static async Task WriteFileAsync(string path, object? data, object? options)
     {
         await InjectedTestLatency();
-        if (data is SharpTSBuffer buffer)
-        {
-            await File.WriteAllBytesAsync(path, buffer.Data);
-        }
-        else
-        {
-            var text = data?.ToString() ?? "";
-            await File.WriteAllTextAsync(path, text);
-        }
+        // Buffer/TypedArray data is written byte-exact; a string honors the encoding option.
+        var bytes = BufferEncoding.ToBytes(data, FsModuleInterpreter.EncodingName(options));
+        await File.WriteAllBytesAsync(path, bytes);
     }
 
     /// <summary>
@@ -70,8 +57,10 @@ public static class FsAsyncHelpers
     /// <param name="options">Optional options (encoding, mode, flag).</param>
     public static async Task AppendFileAsync(string path, object? data, object? options)
     {
-        var text = data?.ToString() ?? "";
-        await File.AppendAllTextAsync(path, text);
+        await InjectedTestLatency();
+        // Buffer/TypedArray data is appended byte-exact; a string honors the encoding option.
+        var bytes = BufferEncoding.ToBytes(data, FsModuleInterpreter.EncodingName(options));
+        await File.AppendAllBytesAsync(path, bytes);
     }
 
     /// <summary>

--- a/Runtime/BuiltIns/Modules/Interpreter/FsAsyncHelpers.cs
+++ b/Runtime/BuiltIns/Modules/Interpreter/FsAsyncHelpers.cs
@@ -345,16 +345,11 @@ public static class FsAsyncHelpers
     /// <param name="mode">Optional mode specifying the accessibility checks (F_OK=0, R_OK=4, W_OK=2, X_OK=1).</param>
     public static async Task AccessAsync(string path, object? mode)
     {
-        await Task.Run(() =>
-        {
-            if (!File.Exists(path) && !Directory.Exists(path))
-            {
-                throw new FileNotFoundException("no such file or directory", path);
-            }
-
-            // For now, just check existence
-            // Full implementation would check actual permissions based on mode
-        });
+        var modeInt = mode is double d ? (int)d : 0;
+        // Shared with the sync path so callback/promise access enforce the same
+        // F_OK/W_OK semantics as accessSync (and the compiled async path, which
+        // calls the same FsAccessSync helper).
+        await Task.Run(() => FsModuleInterpreter.CheckAccess(path, modeInt));
     }
 
     /// <summary>

--- a/Runtime/BuiltIns/Modules/Interpreter/FsModuleInterpreter.cs
+++ b/Runtime/BuiltIns/Modules/Interpreter/FsModuleInterpreter.cs
@@ -178,40 +178,45 @@ public static class FsModuleInterpreter
         return RuntimeValue.FromBoolean(File.Exists(path) || Directory.Exists(path));
     }
 
+    /// <summary>
+    /// Extracts the encoding name from a string-or-options value (Node accepts both
+    /// <c>'utf8'</c> and <c>{ encoding: 'utf8' }</c>). Returns null when no encoding
+    /// is given — on read that means "return a Buffer".
+    /// </summary>
+    internal static string? EncodingName(object? options)
+    {
+        if (options is string s) return s;
+        if (options is SharpTSObject opts && opts.GetProperty("encoding") is string es) return es;
+        return null;
+    }
+
     private static RuntimeValue ReadFileSync(Interp interpreter, RuntimeValue receiver, ReadOnlySpan<RuntimeValue> args)
     {
         var path = args[0].ToObject()?.ToString() ?? "";
-        var encoding = args.Length >= 2 ? args[1].ToObject() : null;
+        var encoding = EncodingName(args.Length >= 2 ? args[1].ToObject() : null);
 
         return RuntimeValue.FromBoxed(WrapFsOperation("open", path, () =>
         {
-            if (encoding != null)
-            {
-                // Return as string
-                return (object?)File.ReadAllText(path);
-            }
-            else
-            {
-                // Return as Buffer
-                var bytes = File.ReadAllBytes(path);
-                return new SharpTSBuffer(bytes);
-            }
+            var bytes = File.ReadAllBytes(path);
+            // No encoding → Buffer; otherwise decode the raw bytes per the encoding.
+            return encoding != null ? (object?)BufferEncoding.Decode(bytes, encoding) : new SharpTSBuffer(bytes);
         }));
     }
 
     private static RuntimeValue WriteFileSync(Interp interpreter, RuntimeValue receiver, ReadOnlySpan<RuntimeValue> args)
     {
         var path = args[0].ToObject()?.ToString() ?? "";
-        var data = args[1].ToObject()?.ToString() ?? "";
-        WrapFsOperation("open", path, () => File.WriteAllText(path, data));
+        // Buffer/TypedArray data is written byte-exact; a string honors the encoding option.
+        var bytes = BufferEncoding.ToBytes(args[1].ToObject(), EncodingName(args.Length >= 3 ? args[2].ToObject() : null));
+        WrapFsOperation("open", path, () => File.WriteAllBytes(path, bytes));
         return RuntimeValue.Null;
     }
 
     private static RuntimeValue AppendFileSync(Interp interpreter, RuntimeValue receiver, ReadOnlySpan<RuntimeValue> args)
     {
         var path = args[0].ToObject()?.ToString() ?? "";
-        var data = args[1].ToObject()?.ToString() ?? "";
-        WrapFsOperation("open", path, () => File.AppendAllText(path, data));
+        var bytes = BufferEncoding.ToBytes(args[1].ToObject(), EncodingName(args.Length >= 3 ? args[2].ToObject() : null));
+        WrapFsOperation("open", path, () => File.AppendAllBytes(path, bytes));
         return RuntimeValue.Null;
     }
 

--- a/Runtime/BuiltIns/Modules/Interpreter/FsModuleInterpreter.cs
+++ b/Runtime/BuiltIns/Modules/Interpreter/FsModuleInterpreter.cs
@@ -73,6 +73,10 @@ public static class FsModuleInterpreter
             ["readdirSync"] = BuiltInMethod.CreateV2("readdirSync", 1, 2, ReaddirSync),
             ["statSync"] = BuiltInMethod.CreateV2("statSync", 1, 1, StatSync),
             ["lstatSync"] = BuiltInMethod.CreateV2("lstatSync", 1, 1, LstatSync),
+            // Raw stat records (#977) — the TS Stats class shapes these.
+            ["statRaw"] = BuiltInMethod.CreateV2("statRaw", 1, 1, StatRaw),
+            ["lstatRaw"] = BuiltInMethod.CreateV2("lstatRaw", 1, 1, LstatRaw),
+            ["fstatRaw"] = BuiltInMethod.CreateV2("fstatRaw", 1, 1, FstatRaw),
             ["renameSync"] = BuiltInMethod.CreateV2("renameSync", 2, 2, RenameSync),
             ["copyFileSync"] = BuiltInMethod.CreateV2("copyFileSync", 2, 3, CopyFileSync),
             ["accessSync"] = BuiltInMethod.CreateV2("accessSync", 1, 2, AccessSync),
@@ -282,7 +286,7 @@ public static class FsModuleInterpreter
             {
                 foreach (var entry in entries)
                 {
-                    list.Add(CreateDirent(entry));
+                    list.Add(CreateDirent(entry, Path.GetDirectoryName(entry) ?? path));
                 }
             }
             else
@@ -308,30 +312,33 @@ public static class FsModuleInterpreter
     /// <summary>
     /// Creates a Dirent-like object for readdirSync({ withFileTypes: true }).
     /// </summary>
-    private static SharpTSObject CreateDirent(string fullPath)
+    internal static SharpTSObject CreateDirent(string fullPath, string parentPath)
     {
         var name = Path.GetFileName(fullPath);
         var isFile = File.Exists(fullPath);
         var isDir = Directory.Exists(fullPath);
         var isSymlink = false;
 
-        // Check for symbolic link
         var fileInfo = new FileInfo(fullPath);
-        if (fileInfo.Exists || Directory.Exists(fullPath))
+        if (fileInfo.Exists || isDir)
         {
             isSymlink = fileInfo.Attributes.HasFlag(FileAttributes.ReparsePoint);
         }
+        var fileOnly = isFile && !isDir;
 
+        // is*() are methods (Node Dirent), uniform across sync/async/compiled (#977).
         return new SharpTSObject(new Dictionary<string, object?>
         {
             ["name"] = name,
-            ["isFile"] = isFile && !isDir,
-            ["isDirectory"] = isDir,
-            ["isSymbolicLink"] = isSymlink,
-            ["isBlockDevice"] = false,
-            ["isCharacterDevice"] = false,
-            ["isFIFO"] = false,
-            ["isSocket"] = false,
+            ["parentPath"] = parentPath,
+            ["path"] = parentPath,
+            ["isFile"] = BuiltInMethod.CreateV2("isFile", 0, 0, (_, _, _) => RuntimeValue.FromBoolean(fileOnly)),
+            ["isDirectory"] = BuiltInMethod.CreateV2("isDirectory", 0, 0, (_, _, _) => RuntimeValue.FromBoolean(isDir)),
+            ["isSymbolicLink"] = BuiltInMethod.CreateV2("isSymbolicLink", 0, 0, (_, _, _) => RuntimeValue.FromBoolean(isSymlink)),
+            ["isBlockDevice"] = BuiltInMethod.CreateV2("isBlockDevice", 0, 0, (_, _, _) => RuntimeValue.False),
+            ["isCharacterDevice"] = BuiltInMethod.CreateV2("isCharacterDevice", 0, 0, (_, _, _) => RuntimeValue.False),
+            ["isFIFO"] = BuiltInMethod.CreateV2("isFIFO", 0, 0, (_, _, _) => RuntimeValue.False),
+            ["isSocket"] = BuiltInMethod.CreateV2("isSocket", 0, 0, (_, _, _) => RuntimeValue.False),
         });
     }
 
@@ -456,6 +463,107 @@ public static class FsModuleInterpreter
                 ["isSymbolicLink"] = BuiltInMethod.CreateV2("isSymbolicLink", 0, 0, (_, _, _) => RuntimeValue.FromBoolean(isSymlink)),
                 ["size"] = size
             });
+        }));
+    }
+
+    // ===== Stats raw record (#977) =====
+    // statRaw/lstatRaw/fstatRaw return a flat numeric record; the TS Stats class
+    // (stdlib/node/fs.ts) shapes it into the Node Stats object. The compiled twin
+    // ($Runtime.FsStatRaw/FsLstatRaw/FsFstatRaw) mirrors this logic byte-for-byte.
+
+    private static double StatTimeMs(DateTime dt) => new DateTimeOffset(dt.ToUniversalTime()).ToUnixTimeMilliseconds();
+
+    /// <summary>
+    /// Builds the flat numeric stat record. Perm bits are best-effort and
+    /// platform-uniform (dir 0o777; file 0o666, or 0o444 when read-only); the
+    /// device/inode/uid/gid fields are documented 0 fallbacks. Mirrored exactly by
+    /// the compiled emitter so interpreter and compiled Stats are byte-identical.
+    /// </summary>
+    internal static SharpTSObject BuildStatRecord(bool isDir, bool isSymlink, bool isReadOnly, double size,
+        DateTime atime, DateTime mtime, DateTime ctime, DateTime birthtime)
+    {
+        int typeBits = isSymlink ? 0xA000 : (isDir ? 0x4000 : 0x8000);
+        int permBits = isDir ? 0x1FF : (isReadOnly ? 0x124 : 0x1B6);
+        double mode = typeBits | permBits;
+        double blocks = Math.Floor((size + 511.0) / 512.0);
+        return new SharpTSObject(new Dictionary<string, object?>
+        {
+            ["mode"] = mode,
+            ["size"] = size,
+            ["atimeMs"] = StatTimeMs(atime),
+            ["mtimeMs"] = StatTimeMs(mtime),
+            ["ctimeMs"] = StatTimeMs(ctime),
+            ["birthtimeMs"] = StatTimeMs(birthtime),
+            ["dev"] = 0.0,
+            ["ino"] = 0.0,
+            ["nlink"] = 1.0,
+            ["uid"] = 0.0,
+            ["gid"] = 0.0,
+            ["rdev"] = 0.0,
+            ["blksize"] = 4096.0,
+            ["blocks"] = blocks,
+        });
+    }
+
+    private static RuntimeValue StatRaw(Interp interpreter, RuntimeValue receiver, ReadOnlySpan<RuntimeValue> args)
+    {
+        var path = args[0].ToObject()?.ToString() ?? "";
+        return RuntimeValue.FromBoxed(WrapFsOperation("stat", path, () =>
+        {
+            if (Directory.Exists(path))
+            {
+                var di = new DirectoryInfo(path);
+                return (object?)BuildStatRecord(true, false, false, 0.0,
+                    di.LastAccessTime, di.LastWriteTime, di.CreationTime, di.CreationTime);
+            }
+            if (File.Exists(path))
+            {
+                var fi = new FileInfo(path);
+                bool ro = fi.Attributes.HasFlag(FileAttributes.ReadOnly);
+                return BuildStatRecord(false, false, ro, fi.Length,
+                    fi.LastAccessTime, fi.LastWriteTime, fi.CreationTime, fi.CreationTime);
+            }
+            throw new FileNotFoundException("no such file or directory", path);
+        }));
+    }
+
+    private static RuntimeValue LstatRaw(Interp interpreter, RuntimeValue receiver, ReadOnlySpan<RuntimeValue> args)
+    {
+        var path = args[0].ToObject()?.ToString() ?? "";
+        return RuntimeValue.FromBoxed(WrapFsOperation("lstat", path, () =>
+        {
+            var fi = new FileInfo(path);
+            var di = new DirectoryInfo(path);
+            if (!fi.Exists && !di.Exists)
+            {
+                throw new FileNotFoundException("no such file or directory", path);
+            }
+            bool isSymlink = (fi.Exists ? fi.Attributes : di.Attributes).HasFlag(FileAttributes.ReparsePoint);
+            bool isDir = di.Exists && !fi.Exists;
+            double size = fi.Exists ? fi.Length : 0.0;
+            bool ro = fi.Exists && fi.Attributes.HasFlag(FileAttributes.ReadOnly);
+            DateTime at = isDir ? di.LastAccessTime : fi.LastAccessTime;
+            DateTime mt = isDir ? di.LastWriteTime : fi.LastWriteTime;
+            DateTime ct = isDir ? di.CreationTime : fi.CreationTime;
+            return (object?)BuildStatRecord(isDir, isSymlink, ro, size, at, mt, ct, ct);
+        }));
+    }
+
+    private static RuntimeValue FstatRaw(Interp interpreter, RuntimeValue receiver, ReadOnlySpan<RuntimeValue> args)
+    {
+        var fd = Convert.ToInt32(args[0].ToObject());
+        return RuntimeValue.FromBoxed(WrapFsOperation("fstat", null, () =>
+        {
+            var stream = _fdTable.Get(fd);
+            double size = stream.Length;
+            DateTime at = DateTime.UnixEpoch, mt = DateTime.UnixEpoch, ct = DateTime.UnixEpoch;
+            try
+            {
+                var fi = new FileInfo(stream.Name);
+                if (fi.Exists) { at = fi.LastAccessTime; mt = fi.LastWriteTime; ct = fi.CreationTime; }
+            }
+            catch { /* fd without a recoverable path → epoch fallback */ }
+            return (object?)BuildStatRecord(false, false, false, size, at, mt, ct, ct);
         }));
     }
 

--- a/Runtime/BuiltIns/Modules/Interpreter/FsModuleInterpreter.cs
+++ b/Runtime/BuiltIns/Modules/Interpreter/FsModuleInterpreter.cs
@@ -397,16 +397,34 @@ public static class FsModuleInterpreter
     private static RuntimeValue AccessSync(Interp interpreter, RuntimeValue receiver, ReadOnlySpan<RuntimeValue> args)
     {
         var path = args[0].ToObject()?.ToString() ?? "";
+        var mode = args.Length >= 2 && args[1].ToObject() is double d ? (int)d : 0;
 
-        WrapFsOperation("access", path, () =>
-        {
-            if (!File.Exists(path) && !Directory.Exists(path))
-            {
-                throw new FileNotFoundException("no such file or directory", path);
-            }
-        });
+        WrapFsOperation("access", path, () => CheckAccess(path, mode));
 
         return RuntimeValue.Null;
+    }
+
+    /// <summary>
+    /// Enforces an fs.access mode against a path. F_OK requires existence (ENOENT
+    /// otherwise); W_OK requires the target to be writable — best-effort on Windows
+    /// (a read-only attribute denies writes, EACCES). R_OK/X_OK are treated as
+    /// granted when the path exists on the supported platforms. Shared by the sync
+    /// and async access implementations.
+    /// </summary>
+    internal static void CheckAccess(string path, int mode)
+    {
+        var isFile = File.Exists(path);
+        var isDir = Directory.Exists(path);
+        if (!isFile && !isDir)
+        {
+            throw new FileNotFoundException("no such file or directory", path);
+        }
+
+        // W_OK (2): writability. A read-only file can't be written (Windows + Unix).
+        if ((mode & 2) != 0 && isFile && File.GetAttributes(path).HasFlag(FileAttributes.ReadOnly))
+        {
+            throw new UnauthorizedAccessException($"permission denied, access '{path}'");
+        }
     }
 
     private static RuntimeValue LstatSync(Interp interpreter, RuntimeValue receiver, ReadOnlySpan<RuntimeValue> args)

--- a/Runtime/Types/BufferEncoding.cs
+++ b/Runtime/Types/BufferEncoding.cs
@@ -1,0 +1,148 @@
+using System.Text;
+
+namespace SharpTS.Runtime.Types;
+
+/// <summary>
+/// The single source of truth for Node.js Buffer/string encoding conversions in
+/// interpreter mode. Both <see cref="SharpTSBuffer"/> and the <c>fs</c> module use
+/// this so a given encoding name behaves identically across Buffer and file I/O.
+/// </summary>
+/// <remarks>
+/// BCL-only by design. The compiled pipeline emits an IL twin
+/// (<c>$Runtime.BufferEncode</c>/<c>BufferDecode</c>) that MUST stay byte-for-byte
+/// equivalent to these tables so interpreter and compiled output agree.
+/// Supported names (Node 24): utf8/utf-8, ascii, latin1/binary, base64, base64url,
+/// hex, utf16le/ucs2/ucs-2/utf-16le.
+/// </remarks>
+public static class BufferEncoding
+{
+    /// <summary>Default encoding when none is supplied (Node uses utf8).</summary>
+    public const string Default = "utf8";
+
+    /// <summary>Encodes a string to bytes using the given Node encoding name.</summary>
+    public static byte[] Encode(string data, string? encoding)
+    {
+        switch (Normalize(encoding))
+        {
+            case "utf8": return Encoding.UTF8.GetBytes(data);
+            case "ascii": return Encoding.ASCII.GetBytes(data);
+            case "latin1": return Encoding.Latin1.GetBytes(data);
+            case "base64": return DecodeBase64(data, urlSafe: false);
+            case "base64url": return DecodeBase64(data, urlSafe: true);
+            case "hex": return HexToBytes(data);
+            case "utf16le": return Encoding.Unicode.GetBytes(data);
+            default: throw new ArgumentException($"Unknown encoding: {encoding}");
+        }
+    }
+
+    /// <summary>Decodes bytes to a string using the given Node encoding name.</summary>
+    public static string Decode(byte[] data, string? encoding)
+    {
+        switch (Normalize(encoding))
+        {
+            case "utf8": return Encoding.UTF8.GetString(data);
+            case "ascii": return Encoding.ASCII.GetString(data);
+            case "latin1": return Encoding.Latin1.GetString(data);
+            case "base64": return Convert.ToBase64String(data);
+            case "base64url": return Convert.ToBase64String(data)
+                .TrimEnd('=').Replace('+', '-').Replace('/', '_');
+            case "hex": return Convert.ToHexString(data).ToLowerInvariant();
+            case "utf16le": return Encoding.Unicode.GetString(data);
+            default: throw new ArgumentException($"Unknown encoding: {encoding}");
+        }
+    }
+
+    /// <summary>
+    /// Converts a write payload to raw bytes: a Buffer or TypedArray view contributes
+    /// its bytes verbatim (offset/length aware); a string is encoded with
+    /// <paramref name="encoding"/> (default utf8). This is what fs write/append and
+    /// stream writes use so binary data is persisted byte-exact (never ToString'd).
+    /// </summary>
+    public static byte[] ToBytes(object? data, string? encoding)
+    {
+        switch (data)
+        {
+            case SharpTSBuffer buf:
+                return buf.Data;
+            case SharpTSTypedArray ta:
+            {
+                var bytes = new byte[ta.ByteLength];
+                Array.Copy(ta.Buffer, ta.ByteOffset, bytes, 0, ta.ByteLength);
+                return bytes;
+            }
+            case string s:
+                return Encode(s, encoding);
+            default:
+                return Encode(data?.ToString() ?? "", encoding);
+        }
+    }
+
+    /// <summary>Whether the name is a Buffer encoding this helper supports.</summary>
+    public static bool IsSupported(string? encoding)
+    {
+        switch (Normalize(encoding))
+        {
+            case "utf8":
+            case "ascii":
+            case "latin1":
+            case "base64":
+            case "base64url":
+            case "hex":
+            case "utf16le":
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    /// <summary>Canonicalizes a Node encoding alias to its representative name.</summary>
+    private static string Normalize(string? encoding)
+    {
+        if (string.IsNullOrEmpty(encoding)) return "utf8";
+        return encoding.ToLowerInvariant() switch
+        {
+            "utf8" or "utf-8" => "utf8",
+            "ascii" => "ascii",
+            "latin1" or "binary" => "latin1",
+            "base64" => "base64",
+            "base64url" => "base64url",
+            "hex" => "hex",
+            "utf16le" or "utf-16le" or "ucs2" or "ucs-2" => "utf16le",
+            _ => encoding.ToLowerInvariant()
+        };
+    }
+
+    /// <summary>
+    /// Decodes a base64 (or base64url) string to bytes, tolerating missing padding
+    /// and the URL-safe alphabet (matching Node's lenient base64 decoder).
+    /// </summary>
+    private static byte[] DecodeBase64(string data, bool urlSafe)
+    {
+        // Node ignores whitespace and accepts both alphabets; normalize to standard.
+        var sb = new StringBuilder(data.Length);
+        foreach (var c in data)
+        {
+            if (char.IsWhiteSpace(c)) continue;
+            sb.Append(c switch { '-' => '+', '_' => '/', _ => c });
+        }
+        var s = sb.ToString();
+        switch (s.Length % 4)
+        {
+            case 2: s += "=="; break;
+            case 3: s += "="; break;
+        }
+        return Convert.FromBase64String(s);
+    }
+
+    /// <summary>Converts a hex string to bytes, padding an odd length like Node.</summary>
+    private static byte[] HexToBytes(string hex)
+    {
+        if (string.IsNullOrEmpty(hex)) return [];
+        hex = hex.Replace(" ", "").Replace("-", "");
+        if (hex.Length % 2 != 0) hex = "0" + hex;
+        var bytes = new byte[hex.Length / 2];
+        for (int i = 0; i < bytes.Length; i++)
+            bytes[i] = Convert.ToByte(hex.Substring(i * 2, 2), 16);
+        return bytes;
+    }
+}

--- a/Runtime/Types/SharpTSBuffer.cs
+++ b/Runtime/Types/SharpTSBuffer.cs
@@ -1152,62 +1152,11 @@ public class SharpTSBuffer : ITypeCategorized
 
     #region Encoding Helpers
 
-    /// <summary>
-    /// Encodes a string to bytes using the specified encoding.
-    /// </summary>
-    private static byte[] EncodeString(string data, string encoding)
-    {
-        return encoding.ToLowerInvariant() switch
-        {
-            "utf8" or "utf-8" => Encoding.UTF8.GetBytes(data),
-            "ascii" => Encoding.ASCII.GetBytes(data),
-            "base64" => Convert.FromBase64String(data),
-            "hex" => ConvertHexToBytes(data),
-            "latin1" or "binary" => Encoding.Latin1.GetBytes(data),
-            "ucs2" or "ucs-2" or "utf16le" or "utf-16le" => Encoding.Unicode.GetBytes(data),
-            _ => throw new ArgumentException($"Unknown encoding: {encoding}")
-        };
-    }
+    // Encoding conversions delegate to the shared BufferEncoding table so Buffer
+    // and fs agree on every encoding name (and the compiled IL twin stays in sync).
+    private static byte[] EncodeString(string data, string encoding) => BufferEncoding.Encode(data, encoding);
 
-    /// <summary>
-    /// Decodes bytes to string using the specified encoding.
-    /// </summary>
-    private static string DecodeBytes(byte[] data, string encoding)
-    {
-        return encoding.ToLowerInvariant() switch
-        {
-            "utf8" or "utf-8" => Encoding.UTF8.GetString(data),
-            "ascii" => Encoding.ASCII.GetString(data),
-            "base64" => Convert.ToBase64String(data),
-            "hex" => Convert.ToHexString(data).ToLowerInvariant(),
-            "latin1" or "binary" => Encoding.Latin1.GetString(data),
-            "ucs2" or "ucs-2" or "utf16le" or "utf-16le" => Encoding.Unicode.GetString(data),
-            _ => throw new ArgumentException($"Unknown encoding: {encoding}")
-        };
-    }
-
-    /// <summary>
-    /// Converts a hex string to byte array.
-    /// </summary>
-    private static byte[] ConvertHexToBytes(string hex)
-    {
-        if (string.IsNullOrEmpty(hex))
-            return [];
-
-        // Remove any spaces or hyphens
-        hex = hex.Replace(" ", "").Replace("-", "");
-
-        // Handle odd-length strings by padding
-        if (hex.Length % 2 != 0)
-            hex = "0" + hex;
-
-        var bytes = new byte[hex.Length / 2];
-        for (int i = 0; i < bytes.Length; i++)
-        {
-            bytes[i] = Convert.ToByte(hex.Substring(i * 2, 2), 16);
-        }
-        return bytes;
-    }
+    private static string DecodeBytes(byte[] data, string encoding) => BufferEncoding.Decode(data, encoding);
 
     #endregion
 }

--- a/SharpTS.Tests/SharedTests/BuiltInModules/FsModuleTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/FsModuleTests.cs
@@ -1377,4 +1377,102 @@ public class FsModuleTests
     }
 
     #endregion
+
+    #region Sync option semantics + constants (#979)
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Fs_MkdirSync_NonRecursive_ThrowsEexistAndEnoent(ExecutionMode mode)
+    {
+        var uid = Uid();
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = $$"""
+                import * as fs from 'fs';
+                import * as os from 'os';
+                const base = os.tmpdir() + '/mkd_{{uid}}';
+                fs.mkdirSync(base);
+                let a = 'none';
+                try { fs.mkdirSync(base); } catch (e: any) { a = e.code; }   // exists -> EEXIST
+                console.log(a);
+                let b = 'none';
+                try { fs.mkdirSync(base + '/x/y/z'); } catch (e: any) { b = e.code; }  // missing parent -> ENOENT
+                console.log(b);
+                """
+        };
+        Assert.Equal("EEXIST\nENOENT\n", TestHarness.RunModules(files, "main.ts", mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Fs_MkdirSync_Recursive_ReturnsFirstCreated(ExecutionMode mode)
+    {
+        var uid = Uid();
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = $$"""
+                import * as fs from 'fs';
+                import * as os from 'os';
+                const base = os.tmpdir() + '/mkr_{{uid}}';
+                fs.mkdirSync(base);
+                const created = fs.mkdirSync(base + '/p/q/r', { recursive: true });
+                console.log(typeof created === 'string' && created.endsWith('p'));   // first created = .../p
+                console.log(fs.mkdirSync(base + '/p/q/r', { recursive: true }) === undefined); // nothing new
+                console.log(fs.existsSync(base + '/p/q/r'));
+                """
+        };
+        Assert.Equal("true\ntrue\ntrue\n", TestHarness.RunModules(files, "main.ts", mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Fs_AccessSync_WriteOk_ThrowsOnReadOnly(ExecutionMode mode)
+    {
+        var path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"ro_{Uid()}.txt");
+        System.IO.File.WriteAllText(path, "x");
+        System.IO.File.SetAttributes(path, System.IO.FileAttributes.ReadOnly);
+        try
+        {
+            var jsPath = path.Replace("\\", "\\\\");
+            var files = new Dictionary<string, string>
+            {
+                ["main.ts"] = $$"""
+                    import * as fs from 'fs';
+                    let w = 'none';
+                    try { fs.accessSync('{{jsPath}}', fs.constants.W_OK); w = 'ok'; } catch (e: any) { w = e.code; }
+                    console.log(w);
+                    let r = 'none';
+                    try { fs.accessSync('{{jsPath}}', fs.constants.R_OK); r = 'ok'; } catch (e: any) { r = e.code; }
+                    console.log(r);
+                    """
+            };
+            Assert.Equal("EACCES\nok\n", TestHarness.RunModules(files, "main.ts", mode));
+        }
+        finally
+        {
+            System.IO.File.SetAttributes(path, System.IO.FileAttributes.Normal);
+            System.IO.File.Delete(path);
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Fs_Constants_AreComplete(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import * as fs from 'fs';
+                const c = fs.constants;
+                console.log([c.F_OK, c.R_OK, c.W_OK, c.X_OK].join(','));
+                console.log([c.S_IRUSR, c.S_IWUSR, c.S_IXUSR, c.S_IRWXU].join(','));
+                console.log([c.O_DIRECTORY, c.O_NOFOLLOW, c.O_SYNC, c.O_DSYNC, c.O_NONBLOCK].join(','));
+                console.log([c.UV_FS_SYMLINK_DIR, c.UV_FS_SYMLINK_JUNCTION].join(','));
+                """
+        };
+        Assert.Equal("0,4,2,1\n256,128,64,448\n65536,131072,1052672,4096,2048\n1,2\n",
+            TestHarness.RunModules(files, "main.ts", mode));
+    }
+
+    #endregion
 }

--- a/SharpTS.Tests/SharedTests/BuiltInModules/FsModuleTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/FsModuleTests.cs
@@ -1657,6 +1657,75 @@ public class FsModuleTests
 
     #endregion
 
+    #region async chown + callback fd ops (#974)
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Fs_CallbackFdOps_OpenReadWriteFstatClose(ExecutionMode mode)
+    {
+        var uid = Uid();
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = $$"""
+                import * as fs from 'fs';
+                import * as os from 'os';
+                import { Buffer } from 'buffer';
+                function p<T>(fn: (cb: any) => void): Promise<T> {
+                    return new Promise<T>((res: any, rej: any) => { fn((e: any, v: any) => e ? rej(e) : res(v)); });
+                }
+                async function main() {
+                    const f = os.tmpdir() + '/fd974_{{uid}}.txt';
+                    fs.writeFileSync(f, 'HELLO WORLD');
+                    const fd: any = await p((cb) => fs.open(f, 'r', cb));
+                    const buf = Buffer.alloc(5);
+                    const n: any = await new Promise((res: any, rej: any) => fs.read(fd, buf, 0, 5, 6, (e: any, c: any) => e ? rej(e) : res(c)));
+                    console.log(n + ':' + buf.toString('utf8'));        // 5:WORLD (position 6)
+                    const st: any = await p((cb) => fs.fstat(fd, cb));
+                    console.log(st.size + ':' + st.isFile());           // 11:true
+                    await new Promise((res: any, rej: any) => fs.close(fd, (e: any) => e ? rej(e) : res(0)));
+                    const fw: any = await p((cb) => fs.open(f, 'w', cb));
+                    const wn: any = await new Promise((res: any, rej: any) => fs.write(fw, Buffer.from('XY'), 0, 2, 0, (e: any, c: any) => e ? rej(e) : res(c)));
+                    await new Promise((res: any, rej: any) => fs.ftruncate(fw, 2, (e: any) => e ? rej(e) : res(0)));
+                    await new Promise((res: any, rej: any) => fs.close(fw, (e: any) => e ? rej(e) : res(0)));
+                    console.log(wn + ':' + fs.readFileSync(f, 'utf8')); // 2:XY
+                    fs.unlinkSync(f);
+                }
+                main();
+                """
+        };
+        Assert.Equal("5:WORLD\n11:true\n2:XY\n", TestHarness.RunModules(files, "main.ts", mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Fs_CallbackFd_BadFd_And_Chown_Invoke(ExecutionMode mode)
+    {
+        var uid = Uid();
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = $$"""
+                import * as fs from 'fs';
+                import * as os from 'os';
+                async function main() {
+                    const f = os.tmpdir() + '/fd974b_{{uid}}.txt';
+                    fs.writeFileSync(f, 'x');
+                    // Bad fd surfaces an error with a code to the callback (the exact code
+                    // differs by mode for a stale fd — a pre-existing primitive divergence).
+                    const hasCode: any = await new Promise((res: any) => fs.fstat(999999, (e: any) => res(!!(e && typeof e.code === 'string' && e.code.length > 0))));
+                    console.log('badfd:' + hasCode);
+                    // chown's callback is invoked (platform/no-op behavior aside).
+                    const called: any = await new Promise((res: any) => fs.chown(f, 0, 0, () => res(true)));
+                    console.log('chown:' + called);
+                    fs.unlinkSync(f);
+                }
+                main();
+                """
+        };
+        Assert.Equal("badfd:true\nchown:true\n", TestHarness.RunModules(files, "main.ts", mode));
+    }
+
+    #endregion
+
     #region rm / cp (#973)
 
     [Theory]

--- a/SharpTS.Tests/SharedTests/BuiltInModules/FsModuleTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/FsModuleTests.cs
@@ -593,11 +593,11 @@ public class FsModuleTests
                     }
                 }
                 console.log(fileEntry !== null);
-                console.log(fileEntry.isFile === true);
-                console.log(fileEntry.isDirectory === false);
+                console.log(fileEntry.isFile() === true);
+                console.log(fileEntry.isDirectory() === false);
 
                 console.log(dirEntry !== null);
-                console.log(dirEntry.isDirectory === true);
+                console.log(dirEntry.isDirectory() === true);
 
                 // Cleanup
                 fs.unlinkSync(testDir + '/file.txt');
@@ -1472,6 +1472,94 @@ public class FsModuleTests
         };
         Assert.Equal("0,4,2,1\n256,128,64,448\n65536,131072,1052672,4096,2048\n1,2\n",
             TestHarness.RunModules(files, "main.ts", mode));
+    }
+
+    #endregion
+
+    #region Stats/Dirent unification (#977)
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Fs_Stat_SyncAndAsyncSameShapeAndPredicates(ExecutionMode mode)
+    {
+        var uid = Uid();
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = $$"""
+                import * as fs from 'fs';
+                import * as os from 'os';
+                const dir = os.tmpdir() + '/st977_{{uid}}';
+                fs.mkdirSync(dir);
+                const file = dir + '/f.txt';
+                fs.writeFileSync(file, 'hello');
+                async function main() {
+                    const s = fs.statSync(file);
+                    const a = await fs.promises.stat(file);
+                    console.log(s.isFile() === true && s.isDirectory() === false);
+                    console.log(s.size === 5 && a.size === 5);
+                    // sync and async produce the identical key set
+                    console.log(JSON.stringify(Object.keys(s).sort()) === JSON.stringify(Object.keys(a).sort()));
+                    console.log(fs.statSync(dir).isDirectory() === true);
+                    fs.unlinkSync(file);
+                    fs.rmdirSync(dir);
+                }
+                main();
+                """
+        };
+        Assert.Equal("true\ntrue\ntrue\ntrue\n", TestHarness.RunModules(files, "main.ts", mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Fs_Stat_BigIntOption(ExecutionMode mode)
+    {
+        var uid = Uid();
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = $$"""
+                import * as fs from 'fs';
+                import * as os from 'os';
+                const file = os.tmpdir() + '/big977_{{uid}}.txt';
+                fs.writeFileSync(file, 'x');
+                const s: any = fs.statSync(file, { bigint: true });
+                console.log(typeof s.size === 'bigint');
+                console.log(typeof s.atimeNs === 'bigint');
+                console.log(s.isFile() === true);
+                fs.unlinkSync(file);
+                """
+        };
+        Assert.Equal("true\ntrue\ntrue\n", TestHarness.RunModules(files, "main.ts", mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Fs_Dirent_ParentPathAndPredicates(ExecutionMode mode)
+    {
+        var uid = Uid();
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = $$"""
+                import * as fs from 'fs';
+                import * as os from 'os';
+                const dir = os.tmpdir() + '/de977_{{uid}}';
+                fs.mkdirSync(dir);
+                fs.writeFileSync(dir + '/f.txt', 'x');
+                fs.mkdirSync(dir + '/sub');
+                const ents: any = fs.readdirSync(dir, { withFileTypes: true });
+                let f: any = null, d: any = null;
+                for (let i = 0; i < ents.length; i++) {
+                    if (ents[i].name === 'f.txt') f = ents[i];
+                    if (ents[i].name === 'sub') d = ents[i];
+                }
+                console.log(f.isFile() === true && d.isDirectory() === true);
+                console.log(typeof f.parentPath === 'string' && f.parentPath.length > 0);
+                console.log(f.path === f.parentPath);
+                fs.unlinkSync(dir + '/f.txt');
+                fs.rmdirSync(dir + '/sub');
+                fs.rmdirSync(dir);
+                """
+        };
+        Assert.Equal("true\ntrue\ntrue\n", TestHarness.RunModules(files, "main.ts", mode));
     }
 
     #endregion

--- a/SharpTS.Tests/SharedTests/BuiltInModules/FsModuleTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/FsModuleTests.cs
@@ -1587,6 +1587,76 @@ public class FsModuleTests
 
     #endregion
 
+    #region promises.opendir + watch (#975)
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Fs_PromisesOpendir_AsyncIteratesEntries(ExecutionMode mode)
+    {
+        var uid = Uid();
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = $$"""
+                import * as fs from 'fs';
+                import * as os from 'os';
+                async function main() {
+                    const d = os.tmpdir() + '/opendir_{{uid}}';
+                    fs.rmSync(d, { recursive: true, force: true });
+                    fs.mkdirSync(d, { recursive: true });
+                    fs.writeFileSync(d + '/a.txt', '1');
+                    fs.writeFileSync(d + '/b.txt', '2');
+                    fs.mkdirSync(d + '/sub');
+                    const dir = await fs.promises.opendir(d);
+                    let count = 0; let sawDir = false;
+                    for await (const ent of dir) { count++; if (ent.isDirectory()) sawDir = true; }
+                    console.log('count:' + count + ' sawDir:' + sawDir);
+                    fs.rmSync(d, { recursive: true, force: true });
+                }
+                main();
+                """
+        };
+        Assert.Equal("count:3 sawDir:true\n", TestHarness.RunModules(files, "main.ts", mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Fs_PromisesWatch_AsyncIteratorTerminatesOnAbort(ExecutionMode mode)
+    {
+        // Real FSWatcher event timing is non-deterministic (and flaky under load), so
+        // this pins the iterator + AbortSignal-termination contract deterministically:
+        // aborting then pulling yields done, and a pre-aborted signal ends a for-await
+        // immediately. (Live change-event observation is covered by manual/e2e checks;
+        // the compiled parked-abort limitation is tracked in #985.)
+        var uid = Uid();
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = $$"""
+                import * as fs from 'fs';
+                import * as os from 'os';
+                async function main() {
+                    const d = os.tmpdir() + '/watch_{{uid}}';
+                    fs.rmSync(d, { recursive: true, force: true });
+                    fs.mkdirSync(d, { recursive: true });
+                    const ac = new AbortController();
+                    const it: any = fs.promises.watch(d, { signal: ac.signal });
+                    ac.abort();
+                    const r = await it.next();
+                    console.log('done:' + r.done);
+                    const ac2 = new AbortController();
+                    ac2.abort();
+                    let count = 0;
+                    for await (const ev of fs.promises.watch(d, { signal: ac2.signal })) { count++; }
+                    console.log('count:' + count);
+                    fs.rmSync(d, { recursive: true, force: true });
+                }
+                main();
+                """
+        };
+        Assert.Equal("done:true\ncount:0\n", TestHarness.RunModules(files, "main.ts", mode));
+    }
+
+    #endregion
+
     #region rm / cp (#973)
 
     [Theory]

--- a/SharpTS.Tests/SharedTests/BuiltInModules/FsModuleTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/FsModuleTests.cs
@@ -1563,4 +1563,27 @@ public class FsModuleTests
     }
 
     #endregion
+
+    #region mkdtemp absolute prefix (#984)
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Fs_MkdtempSync_AbsolutePrefix_NotDoubled(ExecutionMode mode)
+    {
+        // Canonical usage mkdtempSync(path.join(os.tmpdir(), 'foo-')) — the compiled
+        // twin used to double the prefix and throw. It must now create '…/mkdt_XXXXXX'.
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import * as fs from 'fs';
+                import * as os from 'os';
+                const d = fs.mkdtempSync(os.tmpdir() + '/mkdt_');
+                console.log(fs.existsSync(d) && d.split('mkdt_').length === 2 && d.startsWith(os.tmpdir()));
+                fs.rmdirSync(d);
+                """
+        };
+        Assert.Equal("true\n", TestHarness.RunModules(files, "main.ts", mode));
+    }
+
+    #endregion
 }

--- a/SharpTS.Tests/SharedTests/BuiltInModules/FsModuleTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/FsModuleTests.cs
@@ -1586,4 +1586,63 @@ public class FsModuleTests
     }
 
     #endregion
+
+    #region rm / cp (#973)
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Fs_RmSync_RecursiveForceAndEisdir(ExecutionMode mode)
+    {
+        var uid = Uid();
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = $$"""
+                import * as fs from 'fs';
+                import * as os from 'os';
+                const root = os.tmpdir() + '/rm973_{{uid}}';
+                fs.mkdirSync(root + '/a/b', { recursive: true });
+                fs.writeFileSync(root + '/a/f.txt', 'x');
+                fs.rmSync(root, { recursive: true });
+                console.log(!fs.existsSync(root));                       // recursive remove
+                let f = 'threw'; try { fs.rmSync(root + '/nope', { force: true }); f = 'ok'; } catch (e) { }
+                console.log(f);                                          // force swallows ENOENT
+                fs.mkdirSync(root, { recursive: true });
+                let c = 'no'; try { fs.rmSync(root); } catch (e: any) { c = e.code; }
+                console.log(c);                                          // dir without recursive -> ERR_FS_EISDIR
+                fs.rmSync(root, { recursive: true });
+                """
+        };
+        Assert.Equal("true\nok\nERR_FS_EISDIR\n", TestHarness.RunModules(files, "main.ts", mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Fs_CpSync_RecursiveErrorOnExistAndFilter(ExecutionMode mode)
+    {
+        var uid = Uid();
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = $$"""
+                import * as fs from 'fs';
+                import * as os from 'os';
+                const root = os.tmpdir() + '/cp973_{{uid}}';
+                fs.rmSync(root, { recursive: true, force: true });
+                fs.mkdirSync(root + '/src/sub', { recursive: true });
+                fs.writeFileSync(root + '/src/x.txt', 'X');
+                fs.writeFileSync(root + '/src/sub/y.txt', 'Y');
+                fs.cpSync(root + '/src', root + '/dst', { recursive: true });
+                console.log(fs.readFileSync(root + '/dst/x.txt', 'utf8') === 'X' && fs.readFileSync(root + '/dst/sub/y.txt', 'utf8') === 'Y');
+                let n = 'no'; try { fs.cpSync(root + '/src', root + '/dst2'); } catch (e: any) { n = e.code; }
+                console.log(n);                                          // dir without recursive -> ERR_FS_EISDIR
+                let eoe = 'no'; try { fs.cpSync(root + '/src/x.txt', root + '/dst/x.txt', { errorOnExist: true, force: false }); } catch (e: any) { eoe = e.code; }
+                console.log(eoe);                                        // errorOnExist -> ERR_FS_CP_EEXIST
+                fs.cpSync(root + '/src', root + '/dst3', { recursive: true, filter: (s: string) => s.indexOf('sub') < 0 });
+                console.log(fs.existsSync(root + '/dst3/x.txt') && !fs.existsSync(root + '/dst3/sub'));
+                fs.rmSync(root, { recursive: true });
+                """
+        };
+        Assert.Equal("true\nERR_FS_EISDIR\nERR_FS_CP_EEXIST\ntrue\n", TestHarness.RunModules(files, "main.ts", mode));
+    }
+
+    #endregion
 }

--- a/SharpTS.Tests/SharedTests/BuiltInModules/FsModuleTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/FsModuleTests.cs
@@ -1303,4 +1303,78 @@ public class FsModuleTests
     }
 
     #endregion
+
+    #region Encoding / binary I/O correctness (#978)
+
+    // Identical asserts across ExecutionModes.All enforce interp==compiled parity.
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Fs_WriteReadBuffer_BinaryRoundTrip(ExecutionMode mode)
+    {
+        var uid = Uid();
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = $$"""
+                import * as fs from 'fs';
+                import * as os from 'os';
+                import { Buffer } from 'buffer';
+                const f = os.tmpdir() + '/bin_{{uid}}.bin';
+                const bin = Buffer.from([0, 255, 128, 10, 0, 200]);
+                fs.writeFileSync(f, bin);
+                const r = fs.readFileSync(f);
+                console.log(r.length === 6 && r[0] === 0 && r[1] === 255 && r[2] === 128 && r[5] === 200);
+                fs.unlinkSync(f);
+                """
+        };
+        Assert.Equal("true\n", TestHarness.RunModules(files, "main.ts", mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Fs_Encoding_HexAndBase64(ExecutionMode mode)
+    {
+        var uid = Uid();
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = $$"""
+                import * as fs from 'fs';
+                import * as os from 'os';
+                const f = os.tmpdir() + '/enc_{{uid}}.txt';
+                fs.writeFileSync(f, '48656c6c6f', 'hex');       // "Hello"
+                console.log(fs.readFileSync(f, 'utf8'));
+                console.log(fs.readFileSync(f, 'hex'));
+                fs.writeFileSync(f, 'SGk=', 'base64');           // "Hi"
+                console.log(fs.readFileSync(f, 'utf8'));
+                console.log(fs.readFileSync(f, 'base64url'));
+                fs.unlinkSync(f);
+                """
+        };
+        Assert.Equal("Hello\n48656c6c6f\nHi\nSGk\n", TestHarness.RunModules(files, "main.ts", mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Fs_Encoding_Latin1AndUtf16le(ExecutionMode mode)
+    {
+        var uid = Uid();
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = $$"""
+                import * as fs from 'fs';
+                import * as os from 'os';
+                import { Buffer } from 'buffer';
+                const f = os.tmpdir() + '/enc2_{{uid}}.txt';
+                fs.writeFileSync(f, Buffer.from([0xe9]));        // é (latin1)
+                console.log(fs.readFileSync(f, 'latin1'));
+                fs.writeFileSync(f, 'AB', 'utf16le');
+                console.log(fs.readFileSync(f, 'hex'));          // 41004200
+                console.log(fs.readFileSync(f, 'utf16le'));      // AB
+                fs.unlinkSync(f);
+                """
+        };
+        Assert.Equal("é\n41004200\nAB\n", TestHarness.RunModules(files, "main.ts", mode));
+    }
+
+    #endregion
 }

--- a/TypeSystem/BuiltInModuleTypes.cs
+++ b/TypeSystem/BuiltInModuleTypes.cs
@@ -135,14 +135,17 @@ public static class BuiltInModuleTypes
                 RequiredParams: 1
             ),
 
-            // Write operations - return void
+            // Write operations - return void. Data may be a string, Buffer, or
+            // TypedArray (any); the optional third arg carries the encoding/options.
             ["writeFileSync"] = new TypeInfo.Function(
-                [stringType, new TypeInfo.Union([stringType, new TypeInfo.Array(numberType)])],
-                voidType
+                [stringType, anyType, anyType],
+                voidType,
+                RequiredParams: 2
             ),
             ["appendFileSync"] = new TypeInfo.Function(
-                [stringType, stringType],
-                voidType
+                [stringType, anyType, anyType],
+                voidType,
+                RequiredParams: 2
             ),
 
             // File/directory deletion

--- a/TypeSystem/BuiltInModuleTypes.cs
+++ b/TypeSystem/BuiltInModuleTypes.cs
@@ -173,6 +173,10 @@ public static class BuiltInModuleTypes
             // File info
             ["statSync"] = new TypeInfo.Function([stringType], statsType),
             ["lstatSync"] = new TypeInfo.Function([stringType], statsType),
+            // Raw stat records (#977) — the TS Stats class shapes these.
+            ["statRaw"] = new TypeInfo.Function([stringType], anyType),
+            ["lstatRaw"] = new TypeInfo.Function([stringType], anyType),
+            ["fstatRaw"] = new TypeInfo.Function([numberType], anyType),
 
             // File move/copy
             ["renameSync"] = new TypeInfo.Function(

--- a/stdlib/node/fs.ts
+++ b/stdlib/node/fs.ts
@@ -59,8 +59,6 @@ import {
     watch as __watch,
     watchFile as __watchFile,
     unwatchFile as __unwatchFile,
-    // Constants
-    constants as __constants,
 } from 'primitive:fs';
 
 import {
@@ -140,9 +138,61 @@ export function appendFileSync(path: string, data: any, options?: any): void {
 export function unlinkSync(path: string): void { __unlinkSync(path); }
 
 /** Synchronously creates a directory. */
+// --- mkdir helpers (Node semantics live here in TS; the primitive only does the
+// raw, always-recursive directory create, so the facade handles recursive vs not,
+// EEXIST/ENOENT, and the recursive return value). ---
+
+/** Minimal parent-directory of a path, separator-agnostic (handles / and \\). */
+function __parentDir(p: string): string {
+    let end = p.length;
+    while (end > 1 && (p[end - 1] === '/' || p[end - 1] === '\\')) end--;
+    let i = end - 1;
+    while (i >= 0 && p[i] !== '/' && p[i] !== '\\') i--;
+    if (i < 0) return '';
+    if (i === 0) return p[0];
+    return p.slice(0, i);
+}
+
+const __errnoFor: any = { ENOENT: -2, EEXIST: -17, EACCES: -13 };
+
+/** Builds a Node-shaped fs error (code/errno/syscall/path) thrown from the facade. */
+function __fsError(code: string, message: string, syscall: string, path: string): any {
+    const err: any = new Error(code + ': ' + message + ', ' + syscall + " '" + path + "'");
+    err.code = code;
+    err.errno = __errnoFor[code] !== undefined ? __errnoFor[code] : -1;
+    err.syscall = syscall;
+    err.path = path;
+    return err;
+}
+
+/** Synchronously creates a directory. Honors `{ recursive }`: non-recursive throws
+ * EEXIST/ENOENT like Node; recursive returns the first directory created (or undefined). */
 export function mkdirSync(path: string, options?: any): any {
-    if (options === undefined) return __mkdirSync(path);
-    return __mkdirSync(path, options);
+    const recursive = typeof options === 'object' && options !== null && !!options.recursive;
+    if (recursive) {
+        let firstCreated: any = undefined;
+        if (!__existsSync(path)) {
+            let dir = path;
+            while (!__existsSync(dir)) {
+                firstCreated = dir;
+                const parent = __parentDir(dir);
+                if (!parent || parent === dir) break;
+                dir = parent;
+            }
+        }
+        __mkdirSync(path, options);
+        return firstCreated;
+    }
+    // Non-recursive: Node throws ENOENT if a parent is missing, EEXIST if it exists.
+    const parent = __parentDir(path);
+    if (parent && parent !== path && !__existsSync(parent)) {
+        throw __fsError('ENOENT', 'no such file or directory', 'mkdir', path);
+    }
+    if (__existsSync(path)) {
+        throw __fsError('EEXIST', 'file already exists', 'mkdir', path);
+    }
+    __mkdirSync(path);
+    return undefined;
 }
 
 /** Synchronously removes a directory. */
@@ -260,8 +310,33 @@ export function watchFile(filename: string, options: any, listener?: any): any {
 /** Stops watching a file previously registered with watchFile. */
 export function unwatchFile(filename: string, listener?: any): void { __unwatchFile(filename, listener); }
 
-/** File-system constants (access modes, open flags, copy flags, file-type bits). */
-export const constants: any = __constants;
+/**
+ * File-system constants (access modes, open flags, copy flags, file-type bits,
+ * permission bits, libuv flags). Defined here so `fs.constants` and
+ * `fs.promises.constants` share one complete table across both execution modes.
+ * Values follow the POSIX/Linux set SharpTS's openSync flag parsing expects.
+ */
+export const constants: any = {
+    // Access modes (accessSync)
+    F_OK: 0, R_OK: 4, W_OK: 2, X_OK: 1,
+    // Open flags (openSync)
+    O_RDONLY: 0, O_WRONLY: 1, O_RDWR: 2,
+    O_CREAT: 64, O_EXCL: 128, O_NOCTTY: 256, O_TRUNC: 512,
+    O_APPEND: 1024, O_NONBLOCK: 2048, O_DSYNC: 4096,
+    O_DIRECTORY: 65536, O_NOFOLLOW: 131072, O_NOATIME: 262144,
+    O_SYNC: 1052672,
+    // Copy flags (copyFile)
+    COPYFILE_EXCL: 1, COPYFILE_FICLONE: 2, COPYFILE_FICLONE_FORCE: 4,
+    // File-type bits (stat mode)
+    S_IFMT: 61440, S_IFREG: 32768, S_IFDIR: 16384, S_IFCHR: 8192,
+    S_IFBLK: 24576, S_IFIFO: 4096, S_IFLNK: 40960, S_IFSOCK: 49152,
+    // Permission bits (stat mode)
+    S_IRWXU: 448, S_IRUSR: 256, S_IWUSR: 128, S_IXUSR: 64,
+    S_IRWXG: 56, S_IRGRP: 32, S_IWGRP: 16, S_IXGRP: 8,
+    S_IRWXO: 7, S_IROTH: 4, S_IWOTH: 2, S_IXOTH: 1,
+    // libuv flags
+    UV_FS_O_FILEMAP: 0, UV_FS_SYMLINK_DIR: 1, UV_FS_SYMLINK_JUNCTION: 2,
+};
 
 // ===========================================================================
 // Callback-based async APIs — derived from the promise primitives.
@@ -412,7 +487,7 @@ export const promises = {
     symlink: (target: string, path: string, type?: any): Promise<void> => __pSymlink(target, path, type),
     link: (existingPath: string, newPath: string): Promise<void> => __pLink(existingPath, newPath),
     mkdtemp: (prefix: string): Promise<any> => __pMkdtemp(prefix),
-    constants: __constants,
+    constants,
 };
 
 // Node's `fs` module exposes its surface as both named exports and a default

--- a/stdlib/node/fs.ts
+++ b/stdlib/node/fs.ts
@@ -50,7 +50,6 @@ import {
     ftruncateSync as __ftruncateSync,
     // Directory utilities / hard links
     mkdtempSync as __mkdtempSync,
-    opendirSync as __opendirSync,
     linkSync as __linkSync,
     // Stream factories
     createReadStream as __createReadStream,
@@ -462,7 +461,84 @@ export function ftruncateSync(fd: number, len?: number): void {
 export function mkdtempSync(prefix: string): string { return __mkdtempSync(prefix); }
 
 /** Synchronously opens a directory and returns a Dir handle. */
-export function opendirSync(path: string): any { return __opendirSync(path); }
+// A Dir handle: sync + async iterable over a snapshot of the directory's Dirents.
+// Node reads lazily; reading the whole listing up front is simple and correct for
+// typical sizes. read()/readSync()/iteration share one cursor (as in Node).
+function __makeDir(path: string, entries: any[]): any {
+    let i = 0;
+    return {
+        path,
+        readSync(): any { return i < entries.length ? entries[i++] : null; },
+        read(): Promise<any> { return Promise.resolve(i < entries.length ? entries[i++] : null); },
+        closeSync(): void { i = entries.length; },
+        close(): Promise<void> { i = entries.length; return Promise.resolve(); },
+        [Symbol.asyncIterator](): any {
+            return {
+                next(): any {
+                    const e = i < entries.length ? entries[i++] : null;
+                    return Promise.resolve(e !== null ? { value: e, done: false } : { value: undefined, done: true });
+                }
+            };
+        }
+    };
+}
+
+/** Synchronously opens a directory and returns a Dir handle (sync + async iterable). */
+export function opendirSync(path: string, options?: any): any {
+    return __makeDir(path, readdirSync(path, { withFileTypes: true } as any));
+}
+
+// --- promises.watch: bridge the FSWatcher's 'change' event stream into a
+// pull-based async iterator. Events arriving between pulls are queued; a pull
+// with no pending event parks a resolver until the next event. An AbortSignal
+// (or iterator return()) closes the watcher and ends iteration cleanly so the
+// event loop can drain. ---
+function __watchAsync(filename: string, options?: any): any {
+    const opts = options || {};
+    const signal = opts.signal;
+    const watcher: any = __watch(filename, opts);
+    const queue: any[] = [];
+    const resolvers: any[] = [];
+    let done = false;
+
+    const finish = () => {
+        if (done) return;
+        done = true;
+        try { watcher.close(); } catch (e) { }
+        while (resolvers.length) { resolvers.shift()({ value: undefined, done: true }); }
+    };
+
+    watcher.on('change', (eventType: any, fname: any) => {
+        if (done) return;
+        const ev = { eventType, filename: fname };
+        if (resolvers.length) { resolvers.shift()({ value: ev, done: false }); }
+        else { queue.push(ev); }
+    });
+    watcher.on('error', () => { finish(); });
+
+    if (signal) {
+        if (signal.aborted) {
+            finish();
+        } else {
+            // Immediate termination when the AbortSignal fires while the iterator is
+            // parked. In compiled mode AbortSignal's listener API is not callable from
+            // stdlib code (the call throws), so this is ignored there — abort is then
+            // observed by the `signal.aborted` check in next() on the following pull.
+            try { signal.addEventListener('abort', finish); } catch (e) { }
+        }
+    }
+
+    return {
+        [Symbol.asyncIterator]() { return this; },
+        next(): any {
+            if (signal && signal.aborted) finish();
+            if (queue.length) return Promise.resolve({ value: queue.shift(), done: false });
+            if (done) return Promise.resolve({ value: undefined, done: true });
+            return new Promise((resolve: any) => { resolvers.push(resolve); });
+        },
+        return(): any { finish(); return Promise.resolve({ value: undefined, done: true }); }
+    };
+}
 
 /** Synchronously creates a hard link. */
 export function linkSync(existingPath: string, newPath: string): void { __linkSync(existingPath, newPath); }
@@ -681,6 +757,8 @@ export const promises = {
     symlink: (target: string, path: string, type?: any): Promise<void> => __pSymlink(target, path, type),
     link: (existingPath: string, newPath: string): Promise<void> => __pLink(existingPath, newPath),
     mkdtemp: (prefix: string): Promise<any> => __pMkdtemp(prefix),
+    opendir: (path: string, options?: any): Promise<any> => Promise.resolve(opendirSync(path, options)),
+    watch: (filename: string, options?: any): any => __watchAsync(filename, options),
     constants,
 };
 

--- a/stdlib/node/fs.ts
+++ b/stdlib/node/fs.ts
@@ -125,10 +125,16 @@ export function readFileSync(path: string, options?: any): string | Buffer {
 }
 
 /** Synchronously writes data to a file, replacing the file if it already exists. */
-export function writeFileSync(path: string, data: any, options?: any): void { __writeFileSync(path, data); }
+export function writeFileSync(path: string, data: any, options?: any): void {
+    if (options === undefined) { __writeFileSync(path, data); return; }
+    __writeFileSync(path, data, options);
+}
 
 /** Synchronously appends data to a file, creating the file if it does not yet exist. */
-export function appendFileSync(path: string, data: any, options?: any): void { __appendFileSync(path, data); }
+export function appendFileSync(path: string, data: any, options?: any): void {
+    if (options === undefined) { __appendFileSync(path, data); return; }
+    __appendFileSync(path, data, options);
+}
 
 /** Synchronously removes a file or symbolic link. */
 export function unlinkSync(path: string): void { __unlinkSync(path); }

--- a/stdlib/node/fs.ts
+++ b/stdlib/node/fs.ts
@@ -70,7 +70,6 @@ import {
     unlink as __pUnlink,
     mkdir as __pMkdir,
     rmdir as __pRmdir,
-    rm as __pRm,
     readdir as __pReaddir,
     rename as __pRename,
     copyFile as __pCopyFile,
@@ -136,6 +135,73 @@ export function appendFileSync(path: string, data: any, options?: any): void {
 
 /** Synchronously removes a file or symbolic link. */
 export function unlinkSync(path: string): void { __unlinkSync(path); }
+
+// --- rm / cp (Node 16.7+ recursive remove/copy). The recursion + option logic is
+// pure TS over the sync primitives; the async variants wrap the sync walk in a
+// Promise so sync and async behave identically. ---
+
+/** Joins a directory and a child name (forward slash; .NET accepts it on Windows). */
+function __joinPath(dir: string, name: string): string {
+    if (dir.length === 0) return name;
+    const last = dir[dir.length - 1];
+    return (last === '/' || last === '\\') ? dir + name : dir + '/' + name;
+}
+
+/** Runs a synchronous fs op inside a Promise so the callback/promise variants
+ * share the one implementation (resolves/rejects exactly as the sync op does). */
+function __promisifyVoid(fn: () => void): Promise<void> {
+    return new Promise<void>((resolve: any, reject: any) => {
+        try { fn(); resolve(undefined); } catch (e) { reject(e); }
+    });
+}
+
+/** Synchronously removes files and directories. `{ recursive }` removes a whole
+ * tree; `{ force }` makes a nonexistent path a no-op instead of throwing ENOENT. */
+export function rmSync(path: string, options?: any): void {
+    const recursive = !!(options && options.recursive);
+    const force = !!(options && options.force);
+    // `force` makes a missing path a no-op; otherwise Node throws ENOENT. Checking
+    // existence up front keeps this allocation-free of try/catch.
+    if (!existsSync(path)) {
+        if (force) return;
+        throw __fsError('ENOENT', 'no such file or directory', 'rm', path);
+    }
+    if (lstatSync(path).isDirectory()) {
+        if (!recursive) throw __fsError('ERR_FS_EISDIR', 'Path is a directory', 'rm', path);
+        rmdirSync(path, { recursive: true });
+    } else {
+        unlinkSync(path);
+    }
+}
+
+/** Synchronously copies `src` to `dest`, recursively when `{ recursive: true }`.
+ * Honors `force` (default true), `errorOnExist`, `dereference`, `preserveTimestamps`,
+ * and a synchronous `filter(src, dest)` predicate. */
+export function cpSync(src: string, dest: string, options?: any): void {
+    const opts = options || {};
+    if (opts.filter && !opts.filter(src, dest)) return;
+    const st: any = opts.dereference ? statSync(src) : lstatSync(src);
+    if (st.isDirectory()) {
+        if (!opts.recursive) {
+            throw __fsError('ERR_FS_EISDIR', 'Recursive option not enabled, cannot copy a directory', 'cp', src);
+        }
+        mkdirSync(dest, { recursive: true });
+        const names: any = readdirSync(src);
+        for (let i = 0; i < names.length; i++) {
+            cpSync(__joinPath(src, names[i]), __joinPath(dest, names[i]), options);
+        }
+    } else {
+        const force = opts.force !== false; // Node default is to overwrite.
+        if (existsSync(dest)) {
+            if (opts.errorOnExist) throw __fsError('ERR_FS_CP_EEXIST', 'File already exists', 'cp', dest);
+            if (!force) return;
+        }
+        const parent = __parentDir(dest);
+        if (parent && parent !== dest && !existsSync(parent)) mkdirSync(parent, { recursive: true });
+        copyFileSync(src, dest);
+        if (opts.preserveTimestamps) utimesSync(dest, st.atimeMs / 1000, st.mtimeMs / 1000);
+    }
+}
 
 /** Synchronously creates a directory. */
 // --- mkdir helpers (Node semantics live here in TS; the primitive only does the
@@ -486,6 +552,18 @@ export function unlink(path: string, callback: any): void {
     __cbVoid(__pUnlink(path), callback);
 }
 
+/** Asynchronously removes files and directories. */
+export function rm(path: string, options?: any, callback?: any): void {
+    if (typeof options === 'function') { callback = options; options = undefined; }
+    __cbVoid(__promisifyVoid(() => rmSync(path, options)), callback);
+}
+
+/** Asynchronously copies src to dest (recursively when `{ recursive: true }`). */
+export function cp(src: string, dest: string, options?: any, callback?: any): void {
+    if (typeof options === 'function') { callback = options; options = undefined; }
+    __cbVoid(__promisifyVoid(() => cpSync(src, dest, options)), callback);
+}
+
 /** Asynchronously creates a directory. */
 export function mkdir(path: string, options?: any, callback?: any): void {
     if (typeof options === 'function') { callback = options; options = undefined; }
@@ -587,7 +665,8 @@ export const promises = {
     unlink: (path: string): Promise<void> => __pUnlink(path),
     mkdir: (path: string, options?: any): Promise<any> => __pMkdir(path, options),
     rmdir: (path: string, options?: any): Promise<void> => __pRmdir(path, options),
-    rm: (path: string, options?: any): Promise<void> => __pRm(path, options),
+    rm: (path: string, options?: any): Promise<void> => __promisifyVoid(() => rmSync(path, options)),
+    cp: (src: string, dest: string, options?: any): Promise<void> => __promisifyVoid(() => cpSync(src, dest, options)),
     readdir: (path: string, options?: any): Promise<any> => __wantsFileTypes(options)
         ? (__readdirRecursive(options) ? __pReaddir(path, { recursive: true }) : __pReaddir(path)).then((n: any) => __makeDirents(path, n))
         : __pReaddir(path, options),
@@ -609,7 +688,7 @@ export const promises = {
 // export (the module object). Supports `import fs from 'fs'; fs.readFileSync(...)`.
 export default {
     existsSync, readFileSync, writeFileSync, appendFileSync,
-    unlinkSync, mkdirSync, rmdirSync, readdirSync,
+    unlinkSync, mkdirSync, rmdirSync, rmSync, cpSync, readdirSync,
     statSync, lstatSync, renameSync, copyFileSync, accessSync,
     chmodSync, chownSync, lchownSync, truncateSync,
     symlinkSync, readlinkSync, realpathSync, utimesSync,
@@ -619,7 +698,7 @@ export default {
     watch, watchFile, unwatchFile,
     constants,
     readFile, writeFile, appendFile, stat, lstat, unlink, mkdir, rmdir,
-    readdir, rename, copyFile, access, chmod, truncate, utimes,
+    rm, cp, readdir, rename, copyFile, access, chmod, truncate, utimes,
     readlink, realpath, symlink, link, mkdtemp,
     promises,
 };

--- a/stdlib/node/fs.ts
+++ b/stdlib/node/fs.ts
@@ -25,8 +25,8 @@ import {
     rmdirSync as __rmdirSync,
     readdirSync as __readdirSync,
     // Metadata
-    statSync as __statSync,
-    lstatSync as __lstatSync,
+    statRaw as __statRaw,
+    lstatRaw as __lstatRaw,
     // Move / copy
     renameSync as __renameSync,
     copyFileSync as __copyFileSync,
@@ -46,7 +46,7 @@ import {
     closeSync as __closeSync,
     readSync as __readSync,
     writeSync as __writeSync,
-    fstatSync as __fstatSync,
+    fstatRaw as __fstatRaw,
     ftruncateSync as __ftruncateSync,
     // Directory utilities / hard links
     mkdtempSync as __mkdtempSync,
@@ -202,16 +202,122 @@ export function rmdirSync(path: string, options?: any): void {
 }
 
 /** Synchronously reads the contents of a directory. */
-export function readdirSync(path: string, options?: any): string[] {
+export function readdirSync(path: string, options?: any): any {
+    if (__wantsFileTypes(options)) {
+        const names = __readdirRecursive(options) ? __readdirSync(path, { recursive: true }) : __readdirSync(path);
+        return __makeDirents(path, names);
+    }
     if (options === undefined) return __readdirSync(path);
     return __readdirSync(path, options);
 }
 
+// ===========================================================================
+// Stats (#977) — one canonical class built from primitive:fs's flat stat record,
+// so statSync / await stat / fstat all return the SAME shape and values. The
+// seven is*() predicates derive from the mode bits. `{ bigint: true }` stores the
+// numeric fields as BigInt and adds *Ns. Methods live on the prototype, so
+// Object.keys(stat) returns only the data fields (Node-faithful).
+// ===========================================================================
+const __S_IFMT = 0xf000, __S_IFREG = 0x8000, __S_IFDIR = 0x4000, __S_IFLNK = 0xa000,
+    __S_IFBLK = 0x6000, __S_IFCHR = 0x2000, __S_IFIFO = 0x1000, __S_IFSOCK = 0xc000;
+
+class Stats {
+    dev: any; ino: any; mode: any; nlink: any; uid: any; gid: any; rdev: any;
+    size: any; blksize: any; blocks: any;
+    atimeMs: any; mtimeMs: any; ctimeMs: any; birthtimeMs: any;
+    atime: any; mtime: any; ctime: any; birthtime: any;
+    constructor(r: any, big: boolean) {
+        const n = (x: number): any => big ? BigInt(Math.trunc(x)) : x;
+        this.dev = n(r.dev); this.ino = n(r.ino); this.mode = n(r.mode);
+        this.nlink = n(r.nlink); this.uid = n(r.uid); this.gid = n(r.gid); this.rdev = n(r.rdev);
+        this.size = n(r.size); this.blksize = n(r.blksize); this.blocks = n(r.blocks);
+        this.atimeMs = n(r.atimeMs); this.mtimeMs = n(r.mtimeMs);
+        this.ctimeMs = n(r.ctimeMs); this.birthtimeMs = n(r.birthtimeMs);
+        this.atime = new Date(r.atimeMs); this.mtime = new Date(r.mtimeMs);
+        this.ctime = new Date(r.ctimeMs); this.birthtime = new Date(r.birthtimeMs);
+        if (big) {
+            (this as any).atimeNs = BigInt(Math.trunc(r.atimeMs)) * 1000000n;
+            (this as any).mtimeNs = BigInt(Math.trunc(r.mtimeMs)) * 1000000n;
+            (this as any).ctimeNs = BigInt(Math.trunc(r.ctimeMs)) * 1000000n;
+            (this as any).birthtimeNs = BigInt(Math.trunc(r.birthtimeMs)) * 1000000n;
+        }
+    }
+    isFile(): boolean { return (Number(this.mode) & __S_IFMT) === __S_IFREG; }
+    isDirectory(): boolean { return (Number(this.mode) & __S_IFMT) === __S_IFDIR; }
+    isSymbolicLink(): boolean { return (Number(this.mode) & __S_IFMT) === __S_IFLNK; }
+    isBlockDevice(): boolean { return (Number(this.mode) & __S_IFMT) === __S_IFBLK; }
+    isCharacterDevice(): boolean { return (Number(this.mode) & __S_IFMT) === __S_IFCHR; }
+    isFIFO(): boolean { return (Number(this.mode) & __S_IFMT) === __S_IFIFO; }
+    isSocket(): boolean { return (Number(this.mode) & __S_IFMT) === __S_IFSOCK; }
+}
+
+/** Whether a stat options arg requests BigInt fields (`{ bigint: true }`). */
+function __statBig(options: any): boolean {
+    return typeof options === 'object' && options !== null && !!options.bigint;
+}
+
+/** Builds the canonical Stats object from a raw record. */
+function __makeStats(raw: any, big: boolean): Stats { return new Stats(raw, big); }
+
+// ===========================================================================
+// Dirent (#977) — one canonical class for readdir({ withFileTypes: true }) in
+// both modes. Built in TS from the entry's lstat mode, so the seven is*() are
+// methods (Node-shaped) and parentPath/path (Node 20+) are present everywhere.
+// ===========================================================================
+class Dirent {
+    name: string;
+    parentPath: string;
+    path: string;
+    mode: number;
+    constructor(name: string, parentPath: string, mode: number) {
+        this.name = name; this.parentPath = parentPath; this.path = parentPath; this.mode = mode;
+    }
+    isFile(): boolean { return (this.mode & __S_IFMT) === __S_IFREG; }
+    isDirectory(): boolean { return (this.mode & __S_IFMT) === __S_IFDIR; }
+    isSymbolicLink(): boolean { return (this.mode & __S_IFMT) === __S_IFLNK; }
+    isBlockDevice(): boolean { return (this.mode & __S_IFMT) === __S_IFBLK; }
+    isCharacterDevice(): boolean { return (this.mode & __S_IFMT) === __S_IFCHR; }
+    isFIFO(): boolean { return (this.mode & __S_IFMT) === __S_IFIFO; }
+    isSocket(): boolean { return (this.mode & __S_IFMT) === __S_IFSOCK; }
+}
+
+/** Last path segment (the entry's own name), separator-agnostic. */
+function __baseName(p: string): string {
+    let end = p.length;
+    while (end > 1 && (p[end - 1] === '/' || p[end - 1] === '\\')) end--;
+    let i = end - 1;
+    while (i >= 0 && p[i] !== '/' && p[i] !== '\\') i--;
+    return p.slice(i + 1, end);
+}
+
+/** Builds a Dirent for an entry `rel` (a name, or relative path under recursive). */
+function __makeDirent(base: string, rel: string): Dirent {
+    const full = base + '/' + rel;
+    let mode = 0;
+    try { mode = __lstatRaw(full).mode; } catch (e) { mode = 0; }
+    return new Dirent(__baseName(full), __parentDir(full), mode);
+}
+
+/** Whether a readdir options arg requested `{ withFileTypes: true }`. */
+function __wantsFileTypes(options: any): boolean {
+    return typeof options === 'object' && options !== null && !!options.withFileTypes;
+}
+
+/** Whether a readdir options arg requested `{ recursive: true }`. */
+function __readdirRecursive(options: any): boolean {
+    return typeof options === 'object' && options !== null && !!options.recursive;
+}
+
+/** Maps a raw name/relative-path listing to Dirent objects. */
+function __makeDirents(base: string, names: any): Dirent[] {
+    return names.map((rel: string) => __makeDirent(base, rel));
+}
+
 /** Synchronously retrieves the Stats for the path. */
-export function statSync(path: string): any { return __statSync(path); }
+export function statSync(path: string, options?: any): any { return __makeStats(__statRaw(path), __statBig(options)); }
 
 /** Synchronously retrieves the Stats for the path without following symbolic links. */
-export function lstatSync(path: string): any { return __lstatSync(path); }
+export function lstatSync(path: string, options?: any): any { return __makeStats(__lstatRaw(path), __statBig(options)); }
 
 /** Synchronously renames (moves) a file or directory. */
 export function renameSync(oldPath: string, newPath: string): void { __renameSync(oldPath, newPath); }
@@ -278,7 +384,7 @@ export function writeSync(fd: number, buffer: any, offset?: number, length?: num
 }
 
 /** Synchronously retrieves the Stats for an open file descriptor. */
-export function fstatSync(fd: number): any { return __fstatSync(fd); }
+export function fstatSync(fd: number, options?: any): any { return __makeStats(__fstatRaw(fd), __statBig(options)); }
 
 /** Synchronously truncates an open file descriptor to the given length. */
 export function ftruncateSync(fd: number, len?: number): void {
@@ -364,13 +470,15 @@ export function appendFile(path: string, data: any, options?: any, callback?: an
 /** Asynchronously retrieves the Stats for the path. */
 export function stat(path: string, options?: any, callback?: any): void {
     if (typeof options === 'function') { callback = options; options = undefined; }
-    __cbData(__pStat(path), callback);
+    const big = __statBig(options);
+    __pStat(path).then((r: any) => { callback(null, __makeStats(r, big)); }, (e: any) => { callback(e); });
 }
 
 /** Asynchronously retrieves the Stats for the path without following symbolic links. */
 export function lstat(path: string, options?: any, callback?: any): void {
     if (typeof options === 'function') { callback = options; options = undefined; }
-    __cbData(__pLstat(path), callback);
+    const big = __statBig(options);
+    __pLstat(path).then((r: any) => { callback(null, __makeStats(r, big)); }, (e: any) => { callback(e); });
 }
 
 /** Asynchronously removes a file or symbolic link. */
@@ -393,6 +501,11 @@ export function rmdir(path: string, options?: any, callback?: any): void {
 /** Asynchronously reads the contents of a directory. */
 export function readdir(path: string, options?: any, callback?: any): void {
     if (typeof options === 'function') { callback = options; options = undefined; }
+    if (__wantsFileTypes(options)) {
+        const names = __readdirRecursive(options) ? __pReaddir(path, { recursive: true }) : __pReaddir(path);
+        names.then((n: any) => { callback(null, __makeDirents(path, n)); }, (e: any) => { callback(e); });
+        return;
+    }
     __cbData(__pReaddir(path, options), callback);
 }
 
@@ -469,13 +582,15 @@ export const promises = {
     readFile: (path: string, options?: any): Promise<any> => __pReadFile(path, options),
     writeFile: (path: string, data: any, options?: any): Promise<void> => __pWriteFile(path, data, options),
     appendFile: (path: string, data: any, options?: any): Promise<void> => __pAppendFile(path, data, options),
-    stat: (path: string): Promise<any> => __pStat(path),
-    lstat: (path: string): Promise<any> => __pLstat(path),
+    stat: (path: string, options?: any): Promise<any> => __pStat(path).then((r: any) => __makeStats(r, __statBig(options))),
+    lstat: (path: string, options?: any): Promise<any> => __pLstat(path).then((r: any) => __makeStats(r, __statBig(options))),
     unlink: (path: string): Promise<void> => __pUnlink(path),
     mkdir: (path: string, options?: any): Promise<any> => __pMkdir(path, options),
     rmdir: (path: string, options?: any): Promise<void> => __pRmdir(path, options),
     rm: (path: string, options?: any): Promise<void> => __pRm(path, options),
-    readdir: (path: string, options?: any): Promise<any> => __pReaddir(path, options),
+    readdir: (path: string, options?: any): Promise<any> => __wantsFileTypes(options)
+        ? (__readdirRecursive(options) ? __pReaddir(path, { recursive: true }) : __pReaddir(path)).then((n: any) => __makeDirents(path, n))
+        : __pReaddir(path, options),
     rename: (oldPath: string, newPath: string): Promise<void> => __pRename(oldPath, newPath),
     copyFile: (src: string, dest: string, mode?: any): Promise<void> => __pCopyFile(src, dest, mode),
     access: (path: string, mode?: any): Promise<void> => __pAccess(path, mode),

--- a/stdlib/node/fs.ts
+++ b/stdlib/node/fs.ts
@@ -154,6 +154,13 @@ function __promisifyVoid(fn: () => void): Promise<void> {
     });
 }
 
+/** Like __promisifyVoid but resolves with the sync op's return value. */
+function __promisifyValue(fn: () => any): Promise<any> {
+    return new Promise<any>((resolve: any, reject: any) => {
+        try { resolve(fn()); } catch (e) { reject(e); }
+    });
+}
+
 /** Synchronously removes files and directories. `{ recursive }` removes a whole
  * tree; `{ force }` makes a nonexistent path a no-op instead of throwing ENOENT. */
 export function rmSync(path: string, options?: any): void {
@@ -725,6 +732,64 @@ export function mkdtemp(prefix: string, options?: any, callback?: any): void {
     __cbData(__pMkdtemp(prefix), callback);
 }
 
+// --- async chown/lchown + callback file-descriptor ops (#974). Thin TS wrappers
+// over the *Sync primitives; the Promise wrap defers the callback off the caller's
+// synchronous frame and carries err.code (e.g. EBADF) through to the callback. ---
+
+/** Asynchronously changes the owner and group of a file. */
+export function chown(path: string, uid: number, gid: number, callback: any): void {
+    __cbVoid(__promisifyVoid(() => chownSync(path, uid, gid)), callback);
+}
+
+/** Asynchronously changes the owner and group of a symbolic link. */
+export function lchown(path: string, uid: number, gid: number, callback: any): void {
+    __cbVoid(__promisifyVoid(() => lchownSync(path, uid, gid)), callback);
+}
+
+/** Asynchronously opens a file; callback receives (err, fd). */
+export function open(path: string, flags?: any, mode?: any, callback?: any): void {
+    if (typeof flags === 'function') { callback = flags; flags = 'r'; mode = undefined; }
+    else if (typeof mode === 'function') { callback = mode; mode = undefined; }
+    __cbData(__promisifyValue(() => mode === undefined ? openSync(path, flags) : openSync(path, flags, mode)), callback);
+}
+
+/** Asynchronously closes a file descriptor; callback receives (err). */
+export function close(fd: number, callback: any): void {
+    __cbVoid(__promisifyVoid(() => closeSync(fd)), callback);
+}
+
+/** Asynchronously reads from a file descriptor; callback receives (err, bytesRead, buffer). */
+export function read(fd: number, buffer: any, offset: number, length: number, position: any, callback: any): void {
+    __promisifyValue(() => readSync(fd, buffer, offset, length, position)).then(
+        (n: any) => { callback(null, n, buffer); },
+        (e: any) => { callback(e, 0, buffer); }
+    );
+}
+
+/** Asynchronously writes to a file descriptor; callback receives (err, bytesWritten, buffer). */
+export function write(fd: number, buffer: any, offset?: any, length?: any, position?: any, callback?: any): void {
+    let cb = callback;
+    if (typeof offset === 'function') { cb = offset; offset = undefined; length = undefined; position = undefined; }
+    else if (typeof length === 'function') { cb = length; length = undefined; position = undefined; }
+    else if (typeof position === 'function') { cb = position; position = undefined; }
+    __promisifyValue(() => writeSync(fd, buffer, offset, length, position)).then(
+        (n: any) => { cb(null, n, buffer); },
+        (e: any) => { cb(e, 0, buffer); }
+    );
+}
+
+/** Asynchronously retrieves the Stats for an open fd; callback receives (err, stats). */
+export function fstat(fd: number, options?: any, callback?: any): void {
+    if (typeof options === 'function') { callback = options; options = undefined; }
+    __cbData(__promisifyValue(() => fstatSync(fd)), callback);
+}
+
+/** Asynchronously truncates an open fd to a length; callback receives (err). */
+export function ftruncate(fd: number, len?: any, callback?: any): void {
+    if (typeof len === 'function') { callback = len; len = undefined; }
+    __cbVoid(__promisifyVoid(() => ftruncateSync(fd, len)), callback);
+}
+
 // ===========================================================================
 // fs.promises namespace — assembled from the promise primitives.
 // Each method is wrapped in an arrow so the call reaches the primitive at a
@@ -750,6 +815,8 @@ export const promises = {
     copyFile: (src: string, dest: string, mode?: any): Promise<void> => __pCopyFile(src, dest, mode),
     access: (path: string, mode?: any): Promise<void> => __pAccess(path, mode),
     chmod: (path: string, mode: number): Promise<void> => __pChmod(path, mode),
+    chown: (path: string, uid: number, gid: number): Promise<void> => __promisifyVoid(() => chownSync(path, uid, gid)),
+    lchown: (path: string, uid: number, gid: number): Promise<void> => __promisifyVoid(() => lchownSync(path, uid, gid)),
     truncate: (path: string, len?: any): Promise<void> => __pTruncate(path, len),
     utimes: (path: string, atime: number, mtime: number): Promise<void> => __pUtimes(path, atime, mtime),
     readlink: (path: string): Promise<any> => __pReadlink(path),
@@ -778,5 +845,6 @@ export default {
     readFile, writeFile, appendFile, stat, lstat, unlink, mkdir, rmdir,
     rm, cp, readdir, rename, copyFile, access, chmod, truncate, utimes,
     readlink, realpath, symlink, link, mkdtemp,
+    chown, lchown, open, close, read, write, fstat, ftruncate,
     promises,
 };

--- a/stdlib/node/fs/promises.ts
+++ b/stdlib/node/fs/promises.ts
@@ -94,11 +94,17 @@ export function link(existingPath: string, newPath: string): Promise<void> { ret
 /** Asynchronously creates a unique temporary directory. */
 export function mkdtemp(prefix: string): Promise<any> { return __mkdtemp(prefix); }
 
+/** Asynchronously opens a directory; returns a Dir handle (async iterable). */
+export function opendir(path: string, options?: any): Promise<any> { return __fsp.opendir(path, options); }
+
+/** Returns an async iterator of `{ eventType, filename }` change events for a path. */
+export function watch(filename: string, options?: any): any { return __fsp.watch(filename, options); }
+
 /** File-system constants — re-exported from 'fs' so both share one table. */
 export { constants };
 
 export default {
     readFile, writeFile, appendFile, stat, lstat, unlink, mkdir, rmdir, rm, cp,
     readdir, rename, copyFile, access, chmod, truncate, utimes,
-    readlink, realpath, symlink, link, mkdtemp, constants,
+    readlink, realpath, symlink, link, mkdtemp, opendir, watch, constants,
 };

--- a/stdlib/node/fs/promises.ts
+++ b/stdlib/node/fs/promises.ts
@@ -73,6 +73,12 @@ export function access(path: string, mode?: any): Promise<void> { return __acces
 /** Asynchronously changes the permissions of a file. */
 export function chmod(path: string, mode: number): Promise<void> { return __chmod(path, mode); }
 
+/** Asynchronously changes the owner and group of a file. */
+export function chown(path: string, uid: number, gid: number): Promise<void> { return __fsp.chown(path, uid, gid); }
+
+/** Asynchronously changes the owner and group of a symbolic link. */
+export function lchown(path: string, uid: number, gid: number): Promise<void> { return __fsp.lchown(path, uid, gid); }
+
 /** Asynchronously truncates a file to the given length. */
 export function truncate(path: string, len?: any): Promise<void> { return __truncate(path, len); }
 
@@ -105,6 +111,6 @@ export { constants };
 
 export default {
     readFile, writeFile, appendFile, stat, lstat, unlink, mkdir, rmdir, rm, cp,
-    readdir, rename, copyFile, access, chmod, truncate, utimes,
+    readdir, rename, copyFile, access, chmod, chown, lchown, truncate, utimes,
     readlink, realpath, symlink, link, mkdtemp, opendir, watch, constants,
 };

--- a/stdlib/node/fs/promises.ts
+++ b/stdlib/node/fs/promises.ts
@@ -9,13 +9,10 @@ import {
     readFile as __readFile,
     writeFile as __writeFile,
     appendFile as __appendFile,
-    stat as __stat,
-    lstat as __lstat,
     unlink as __unlink,
     mkdir as __mkdir,
     rmdir as __rmdir,
     rm as __rm,
-    readdir as __readdir,
     rename as __rename,
     copyFile as __copyFile,
     access as __access,
@@ -28,8 +25,9 @@ import {
     link as __link,
     mkdtemp as __mkdtemp,
 } from 'primitive:fs/promises';
-// Node guarantees fs.promises.constants === fs.constants; share the one complete table.
-import { constants } from 'fs';
+// Node guarantees fs.promises.constants === fs.constants; share the one complete
+// table, and the Stats-shaping promise stat/lstat, from the fs facade.
+import { constants, promises as __fsp } from 'fs';
 
 /** Asynchronously reads the entire contents of a file. */
 export function readFile(path: string, options?: any): Promise<any> { return __readFile(path, options); }
@@ -41,10 +39,10 @@ export function writeFile(path: string, data: any, options?: any): Promise<void>
 export function appendFile(path: string, data: any, options?: any): Promise<void> { return __appendFile(path, data, options); }
 
 /** Asynchronously retrieves the Stats for the path. */
-export function stat(path: string): Promise<any> { return __stat(path); }
+export function stat(path: string, options?: any): Promise<any> { return __fsp.stat(path, options); }
 
 /** Asynchronously retrieves the Stats for the path without following symbolic links. */
-export function lstat(path: string): Promise<any> { return __lstat(path); }
+export function lstat(path: string, options?: any): Promise<any> { return __fsp.lstat(path, options); }
 
 /** Asynchronously removes a file or symbolic link. */
 export function unlink(path: string): Promise<void> { return __unlink(path); }
@@ -59,7 +57,7 @@ export function rmdir(path: string, options?: any): Promise<void> { return __rmd
 export function rm(path: string, options?: any): Promise<void> { return __rm(path, options); }
 
 /** Asynchronously reads the contents of a directory. */
-export function readdir(path: string, options?: any): Promise<any> { return __readdir(path, options); }
+export function readdir(path: string, options?: any): Promise<any> { return __fsp.readdir(path, options); }
 
 /** Asynchronously renames (moves) a file or directory. */
 export function rename(oldPath: string, newPath: string): Promise<void> { return __rename(oldPath, newPath); }

--- a/stdlib/node/fs/promises.ts
+++ b/stdlib/node/fs/promises.ts
@@ -27,8 +27,9 @@ import {
     symlink as __symlink,
     link as __link,
     mkdtemp as __mkdtemp,
-    constants as __constants,
 } from 'primitive:fs/promises';
+// Node guarantees fs.promises.constants === fs.constants; share the one complete table.
+import { constants } from 'fs';
 
 /** Asynchronously reads the entire contents of a file. */
 export function readFile(path: string, options?: any): Promise<any> { return __readFile(path, options); }
@@ -93,8 +94,8 @@ export function link(existingPath: string, newPath: string): Promise<void> { ret
 /** Asynchronously creates a unique temporary directory. */
 export function mkdtemp(prefix: string): Promise<any> { return __mkdtemp(prefix); }
 
-/** File-system constants (access modes, open flags, copy flags, file-type bits). */
-export const constants: any = __constants;
+/** File-system constants — re-exported from 'fs' so both share one table. */
+export { constants };
 
 export default {
     readFile, writeFile, appendFile, stat, lstat, unlink, mkdir, rmdir, rm,

--- a/stdlib/node/fs/promises.ts
+++ b/stdlib/node/fs/promises.ts
@@ -12,7 +12,6 @@ import {
     unlink as __unlink,
     mkdir as __mkdir,
     rmdir as __rmdir,
-    rm as __rm,
     rename as __rename,
     copyFile as __copyFile,
     access as __access,
@@ -54,7 +53,10 @@ export function mkdir(path: string, options?: any): Promise<any> { return __mkdi
 export function rmdir(path: string, options?: any): Promise<void> { return __rmdir(path, options); }
 
 /** Asynchronously removes files and directories (recursively when requested). */
-export function rm(path: string, options?: any): Promise<void> { return __rm(path, options); }
+export function rm(path: string, options?: any): Promise<void> { return __fsp.rm(path, options); }
+
+/** Asynchronously copies src to dest (recursively when `{ recursive: true }`). */
+export function cp(src: string, dest: string, options?: any): Promise<void> { return __fsp.cp(src, dest, options); }
 
 /** Asynchronously reads the contents of a directory. */
 export function readdir(path: string, options?: any): Promise<any> { return __fsp.readdir(path, options); }
@@ -96,7 +98,7 @@ export function mkdtemp(prefix: string): Promise<any> { return __mkdtemp(prefix)
 export { constants };
 
 export default {
-    readFile, writeFile, appendFile, stat, lstat, unlink, mkdir, rmdir, rm,
+    readFile, writeFile, appendFile, stat, lstat, unlink, mkdir, rmdir, rm, cp,
     readdir, rename, copyFile, access, chmod, truncate, utimes,
     readlink, realpath, symlink, link, mkdtemp, constants,
 };


### PR DESCRIPTION
## Recovery PR — lands the rest of the fs epic onto `main`

The 8 stacked PRs (#987–#994) were each merged into their **parent feature branch** rather than `main`, so only #969 (PR #987) actually reached `main`; the other seven children ended up stranded in the (now-merged) stacked branches.

This branch (`wrk/issue-974-async-chown-fd`) is the top of the original stack and contains all of them linearly. Since `main` already has the #969 commits, this PR's diff is exactly the remaining seven children:

- #978 — binary/encoding I/O correctness + shared Buffer encoder
- #979 — mkdir semantics + accessSync mode + complete `fs.constants`
- #977 — unify Stats/Dirent via one TS Stats class over statRaw
- #984 — compiled `mkdtempSync` absolute-prefix fix
- #973 — rm/rmSync + cp/cpSync/promises.cp
- #975 — promises.watch (async iterator) + opendir/Dir
- #974 — async chown/lchown + callback fd ops

All verified green together at this tip: full xUnit **14458/0**, TypeScript conformance baseline unchanged, Test262 only the pre-existing #882-family failures.

Closes #978, #979, #977, #984, #973, #975, #974.