### PR TITLE
feat(fs): ReadStream/WriteStream Node option+event parity — interp + compiled (#980)

### DIFF
--- a/Runtime/BuiltIns/Modules/Interpreter/FsModuleInterpreter.cs
+++ b/Runtime/BuiltIns/Modules/Interpreter/FsModuleInterpreter.cs
@@ -1090,7 +1090,7 @@ public static class FsModuleInterpreter
         if (args.Length > 1 && args[1].ToObject() is SharpTSObject opts)
         {
             options = new Dictionary<string, object?>();
-            foreach (var key in new[] { "encoding", "start", "end", "highWaterMark", "flags", "autoClose" })
+            foreach (var key in new[] { "encoding", "start", "end", "highWaterMark", "flags", "autoClose", "fd", "mode", "emitClose", "signal" })
             {
                 var val = opts.GetProperty(key);
                 if (val != null)
@@ -1099,7 +1099,15 @@ public static class FsModuleInterpreter
         }
 
         var stream = new SharpTSReadStream(path, options);
-        stream.StartReading(interpreter);
+        // Defer reading to the next event-loop tick so listeners attached
+        // synchronously after createReadStream() see open/ready/data/end/close
+        // in Node order (#980). Ref/Unref keeps the loop alive across the tick (#205).
+        interpreter.Ref();
+        interpreter.ScheduleTimer(0, 0, () =>
+        {
+            try { stream.StartReading(interpreter); }
+            finally { interpreter.Unref(); }
+        }, isInterval: false);
         return RuntimeValue.FromObject(stream);
     }
 
@@ -1111,7 +1119,7 @@ public static class FsModuleInterpreter
         if (args.Length > 1 && args[1].ToObject() is SharpTSObject opts)
         {
             options = new Dictionary<string, object?>();
-            foreach (var key in new[] { "flags", "autoClose" })
+            foreach (var key in new[] { "flags", "autoClose", "encoding", "start", "mode", "emitClose", "fd", "signal" })
             {
                 var val = opts.GetProperty(key);
                 if (val != null)

--- a/Runtime/Types/SharpTSReadStream.cs
+++ b/Runtime/Types/SharpTSReadStream.cs
@@ -1,4 +1,5 @@
 using SharpTS.Runtime.BuiltIns;
+using SharpTS.Runtime.BuiltIns.Modules.Interop;
 using Interp = SharpTS.Execution.Interpreter;
 
 namespace SharpTS.Runtime.Types;
@@ -6,6 +7,13 @@ namespace SharpTS.Runtime.Types;
 /// <summary>
 /// Runtime representation of fs.createReadStream() — a Readable that reads a file in chunks.
 /// </summary>
+/// <remarks>
+/// #980 parity pass: honors flags/fd/mode/encoding/start/end/highWaterMark/autoClose/
+/// emitClose/signal, emits open→ready→(data*)→end→close in Node order, and exposes
+/// path/bytesRead/pending/destroyed. The interpreter reads synchronously inside
+/// StartReading (our single-threaded event model), so an already-aborted signal is
+/// reported before any data; the abort is also re-checked between chunks.
+/// </remarks>
 public class SharpTSReadStream : SharpTSReadable
 {
     private readonly string _filePath;
@@ -15,8 +23,15 @@ public class SharpTSReadStream : SharpTSReadable
     private readonly long _end;
     private readonly int _chunkSize;
     private readonly string? _encodingOption;
+    private readonly int? _fd;
+    private readonly string _flags;
+    private readonly int? _mode;
+    private readonly bool _emitClose;
+    private readonly SharpTSAbortSignal? _signal;
     private long _bytesRead;
     private bool _started;
+    private bool _pending = true;
+    private bool _closed;
 
     public SharpTSReadStream(string filePath, Dictionary<string, object?>? options = null)
     {
@@ -26,6 +41,8 @@ public class SharpTSReadStream : SharpTSReadable
         _end = long.MaxValue;
         _chunkSize = 65536;
         _encodingOption = null;
+        _flags = "r";
+        _emitClose = true;
 
         if (options != null)
         {
@@ -39,6 +56,16 @@ public class SharpTSReadStream : SharpTSReadable
                 _chunkSize = (int)hwmD;
             if (options.TryGetValue("autoClose", out var ac) && ac is bool acBool)
                 _autoClose = acBool;
+            if (options.TryGetValue("flags", out var fl) && fl is string flStr)
+                _flags = flStr;
+            if (options.TryGetValue("fd", out var fdv) && fdv is double fdD)
+                _fd = (int)fdD;
+            if (options.TryGetValue("mode", out var md) && md is double mdD)
+                _mode = (int)mdD;
+            if (options.TryGetValue("emitClose", out var ec) && ec is bool ecBool)
+                _emitClose = ecBool;
+            if (options.TryGetValue("signal", out var sig) && sig is SharpTSAbortSignal absig)
+                _signal = absig;
         }
     }
 
@@ -50,10 +77,37 @@ public class SharpTSReadStream : SharpTSReadable
         if (_started) return;
         _started = true;
 
+        // An already-aborted signal fails before any open/data (Node semantics).
+        if (_signal is { Aborted: true })
+        {
+            EmitEvent(interpreter, "error", [MakeAbortError()]);
+            EmitCloseEvent(interpreter);
+            return;
+        }
+
         try
         {
-            _fileStream = new FileStream(_filePath, FileMode.Open, FileAccess.Read, FileShare.Read);
-            EmitEvent(interpreter, "open", [(double)_fileStream.SafeFileHandle.DangerousGetHandle().ToInt64()]);
+            bool ownsStream = !_fd.HasValue;
+            if (_fd.HasValue)
+            {
+                _fileStream = FileDescriptorTable.Instance.Get(_fd.Value);
+            }
+            else
+            {
+                var mode = _flags switch
+                {
+                    "r+" => FileMode.Open,
+                    "w" or "w+" => FileMode.Create,
+                    "a" or "a+" => FileMode.OpenOrCreate,
+                    _ => FileMode.Open
+                };
+                _fileStream = new FileStream(_filePath, mode, FileAccess.Read, FileShare.ReadWrite);
+            }
+
+            var fdNumber = _fd ?? (double)_fileStream.SafeFileHandle.DangerousGetHandle().ToInt64();
+            EmitEvent(interpreter, "open", [(double)fdNumber]);
+            _pending = false;
+            EmitEvent(interpreter, "ready", []);
 
             if (_start > 0)
                 _fileStream.Seek(_start, SeekOrigin.Begin);
@@ -61,8 +115,17 @@ public class SharpTSReadStream : SharpTSReadable
             var buffer = new byte[_chunkSize];
             long remaining = _end == long.MaxValue ? long.MaxValue : _end - _start + 1;
 
+            var pushMethod = GetMember("push") as BuiltInMethod;
+
             while (remaining > 0)
             {
+                if (_signal is { Aborted: true })
+                {
+                    EmitEvent(interpreter, "error", [MakeAbortError()]);
+                    CloseFileStream(interpreter, ownsStream);
+                    return;
+                }
+
                 int toRead = (int)Math.Min(buffer.Length, remaining);
                 int bytesRead = _fileStream.Read(buffer, 0, toRead);
                 if (bytesRead == 0) break;
@@ -73,42 +136,56 @@ public class SharpTSReadStream : SharpTSReadable
                 var data = new byte[bytesRead];
                 Array.Copy(buffer, data, bytesRead);
 
-                object chunk;
-                if (_encodingOption != null)
-                {
-                    chunk = System.Text.Encoding.UTF8.GetString(data);
-                }
-                else
-                {
-                    chunk = new SharpTSBuffer(data);
-                }
+                object chunk = _encodingOption != null
+                    ? System.Text.Encoding.UTF8.GetString(data)
+                    : new SharpTSBuffer(data);
 
-                // Use base Push via the BuiltInMethod mechanism
-                var pushMethod = GetMember("push") as BuiltInMethod;
                 pushMethod?.Bind(this).Call(interpreter, [chunk]);
             }
 
-            // Signal EOF
-            var pushEof = GetMember("push") as BuiltInMethod;
-            pushEof?.Bind(this).Call(interpreter, new List<object?> { null });
+            // Signal EOF (push null → 'end').
+            pushMethod?.Bind(this).Call(interpreter, new List<object?> { null });
 
-            CloseFileStream(interpreter);
+            CloseFileStream(interpreter, ownsStream);
         }
         catch (Exception ex)
         {
             EmitEvent(interpreter, "error", [ex.Message]);
-            CloseFileStream(interpreter);
+            CloseFileStream(interpreter, !_fd.HasValue);
         }
     }
 
-    private void CloseFileStream(Interp interpreter)
+    private void CloseFileStream(Interp interpreter, bool ownsStream)
     {
+        if (_closed) return;
         if (_fileStream != null && _autoClose)
         {
-            _fileStream.Dispose();
+            if (ownsStream)
+                _fileStream.Dispose();
+            else
+                FileDescriptorTable.Instance.Close(_fd!.Value);
             _fileStream = null;
-            EmitEvent(interpreter, "close", []);
         }
+        _closed = true;
+        EmitCloseEvent(interpreter);
+    }
+
+    /// <summary>Emits 'close' unless emitClose:false suppressed it.</summary>
+    private void EmitCloseEvent(Interp interpreter)
+    {
+        if (_emitClose)
+            EmitEvent(interpreter, "close", []);
+    }
+
+    /// <summary>Builds a Node-shaped AbortError ({ name, code, message }).</summary>
+    private static SharpTSObject MakeAbortError()
+    {
+        return new SharpTSObject(new Dictionary<string, object?>
+        {
+            ["name"] = "AbortError",
+            ["code"] = "ABORT_ERR",
+            ["message"] = "The operation was aborted",
+        });
     }
 
     public new object? GetMember(string name)
@@ -117,6 +194,7 @@ public class SharpTSReadStream : SharpTSReadable
         {
             "path" => _filePath,
             "bytesRead" => (double)_bytesRead,
+            "pending" => _pending,
             _ => base.GetMember(name)
         };
     }

--- a/Runtime/Types/SharpTSWriteStream.cs
+++ b/Runtime/Types/SharpTSWriteStream.cs
@@ -1,4 +1,5 @@
 using SharpTS.Runtime.BuiltIns;
+using SharpTS.Runtime.BuiltIns.Modules.Interop;
 using Interp = SharpTS.Execution.Interpreter;
 
 namespace SharpTS.Runtime.Types;
@@ -6,19 +7,40 @@ namespace SharpTS.Runtime.Types;
 /// <summary>
 /// Runtime representation of fs.createWriteStream() — a Writable that writes to a file.
 /// </summary>
+/// <remarks>
+/// #980 parity pass: honors flags/fd/mode/encoding/start/autoClose/emitClose/signal,
+/// emits open→ready, finish, close (suppressed by emitClose:false), and error; exposes
+/// path/bytesWritten/pending/destroyed. fd writes share the descriptor via the fd table.
+/// </remarks>
 public class SharpTSWriteStream : SharpTSWritable
 {
     private readonly string _filePath;
     private FileStream? _fileStream;
     private readonly bool _autoClose;
+    private readonly bool _ownsStream;
     private readonly string _flags;
+    private readonly string _encoding;
+    private readonly bool _emitClose;
+    private readonly int? _fd;
+    private readonly SharpTSAbortSignal? _signal;
     private long _bytesWritten;
+    private bool _pending = true;
+    private bool _closed;
+    // Replay state for late-attached open/ready/close listeners (#980): these
+    // events fire during synchronous creation/end before user listeners can
+    // attach, so a listener added afterward is invoked immediately (mirrors the
+    // base Readable's 'end' replay).
+    private bool _openFired, _readyFired, _closeFired;
+    private double _openFd;
 
     public SharpTSWriteStream(string filePath, Dictionary<string, object?>? options = null)
     {
         _filePath = filePath;
         _autoClose = true;
         _flags = "w";
+        _encoding = "utf8";
+        _emitClose = true;
+        long start = 0;
 
         if (options != null)
         {
@@ -26,35 +48,70 @@ public class SharpTSWriteStream : SharpTSWritable
                 _flags = flagsStr;
             if (options.TryGetValue("autoClose", out var ac) && ac is bool acBool)
                 _autoClose = acBool;
+            if (options.TryGetValue("encoding", out var enc) && enc is string encStr)
+                _encoding = encStr;
+            if (options.TryGetValue("emitClose", out var ec) && ec is bool ecBool)
+                _emitClose = ecBool;
+            if (options.TryGetValue("start", out var s) && s is double startD)
+                start = (long)startD;
+            if (options.TryGetValue("fd", out var fdv) && fdv is double fdD)
+                _fd = (int)fdD;
+            if (options.TryGetValue("signal", out var sig) && sig is SharpTSAbortSignal absig)
+                _signal = absig;
         }
 
-        // Open the file based on flags
-        var mode = _flags switch
+        if (_fd.HasValue)
         {
-            "a" => FileMode.Append,
-            "ax" => FileMode.Append,
-            "w" => FileMode.Create,
-            "wx" => FileMode.CreateNew,
-            _ => FileMode.Create
-        };
+            _fileStream = FileDescriptorTable.Instance.Get(_fd.Value);
+            _ownsStream = false;
+        }
+        else
+        {
+            var mode = _flags switch
+            {
+                "a" => FileMode.Append,
+                "ax" => FileMode.Append,
+                "a+" => FileMode.Append,
+                "w" => FileMode.Create,
+                "w+" => FileMode.Create,
+                "wx" => FileMode.CreateNew,
+                "r+" => FileMode.Open,
+                _ => FileMode.Create
+            };
+            var access = mode == FileMode.Append ? FileAccess.Write : FileAccess.ReadWrite;
+            _fileStream = new FileStream(_filePath, mode, access, FileShare.ReadWrite);
+            _ownsStream = true;
+        }
 
-        _fileStream = new FileStream(_filePath, mode, FileAccess.Write, FileShare.None);
+        if (start > 0 && _fileStream.CanSeek)
+            _fileStream.Seek(start, SeekOrigin.Begin);
 
-        // Set internal write callback to write to file
+        // Internal write callback writes each chunk to the file.
         SetWriteCallback(new WriteStreamCallback(this));
 
-        // Listen for 'finish' to close the file (works with both direct end() and piped end)
+        // Close the file once the writable side finishes (direct end() or piped end).
         AddListenerDirect("finish", new FinishListener(this));
     }
 
     /// <summary>
-    /// Emits the 'open' event. Call after construction.
+    /// Emits 'open' then 'ready' (Node order). Call after construction.
     /// </summary>
     public void EmitOpen(Interp interpreter)
     {
+        if (_signal is { Aborted: true })
+        {
+            EmitEvent(interpreter, "error", [MakeAbortError()]);
+            CloseFileStream(interpreter);
+            return;
+        }
         if (_fileStream != null)
         {
-            EmitEvent(interpreter, "open", [(double)_fileStream.SafeFileHandle.DangerousGetHandle().ToInt64()]);
+            _openFd = _fd ?? (double)_fileStream.SafeFileHandle.DangerousGetHandle().ToInt64();
+            _openFired = true;
+            EmitEvent(interpreter, "open", [_openFd]);
+            _pending = false;
+            _readyFired = true;
+            EmitEvent(interpreter, "ready", []);
         }
     }
 
@@ -69,33 +126,39 @@ public class SharpTSWriteStream : SharpTSWritable
         public object? Call(Interp interpreter, List<object?> arguments)
         {
             var chunk = arguments.Count > 0 ? arguments[0] : null;
+            var encoding = arguments.Count > 1 && arguments[1] is string e ? e : _stream._encoding;
             var callback = arguments.Count > 2 ? arguments[2] as ISharpTSCallable : null;
+
+            if (_stream._signal is { Aborted: true })
+            {
+                _stream.EmitEvent(interpreter, "error", [MakeAbortError()]);
+                callback?.Call(interpreter, []);
+                return null;
+            }
 
             if (chunk != null && _stream._fileStream != null)
             {
-                byte[] data;
-                if (chunk is SharpTSBuffer buf)
+                try
                 {
-                    data = buf.Data;
+                    byte[] data = chunk is SharpTSBuffer buf
+                        ? buf.Data
+                        : BufferEncoding.Encode(chunk.ToString() ?? "", encoding);
+                    _stream._fileStream.Write(data, 0, data.Length);
+                    _stream._bytesWritten += data.Length;
                 }
-                else
+                catch (Exception ex)
                 {
-                    data = System.Text.Encoding.UTF8.GetBytes(chunk.ToString() ?? "");
+                    _stream.EmitEvent(interpreter, "error", [ex.Message]);
                 }
-
-                _stream._fileStream.Write(data, 0, data.Length);
-                _stream._bytesWritten += data.Length;
             }
 
-            // Call the done callback
             callback?.Call(interpreter, []);
-
             return null;
         }
     }
 
     /// <summary>
-    /// Listener for 'finish' event to close the file stream.
+    /// Listener for 'finish' to close the file stream.
     /// </summary>
     private class FinishListener : ISharpTSCallable
     {
@@ -107,20 +170,47 @@ public class SharpTSWriteStream : SharpTSWritable
 
         public object? Call(Interp interpreter, List<object?> arguments)
         {
-            _stream.CloseFileStream(interpreter);
+            // Close on the next tick so every 'finish' listener runs first — Node
+            // emits 'close' after 'finish', not interleaved within it (#980).
+            interpreter.Ref();
+            interpreter.ScheduleTimer(0, 0, () =>
+            {
+                try { _stream.CloseFileStream(interpreter); }
+                finally { interpreter.Unref(); }
+            }, isInterval: false);
             return null;
         }
     }
 
     private void CloseFileStream(Interp interpreter)
     {
+        if (_closed) return;
         if (_fileStream != null && _autoClose)
         {
             _fileStream.Flush();
-            _fileStream.Dispose();
+            if (_ownsStream)
+                _fileStream.Dispose();
+            else
+                FileDescriptorTable.Instance.Close(_fd!.Value);
             _fileStream = null;
+        }
+        _closed = true;
+        if (_emitClose)
+        {
+            _closeFired = true;
             EmitEvent(interpreter, "close", []);
         }
+    }
+
+    /// <summary>Builds a Node-shaped AbortError ({ name, code, message }).</summary>
+    private static SharpTSObject MakeAbortError()
+    {
+        return new SharpTSObject(new Dictionary<string, object?>
+        {
+            ["name"] = "AbortError",
+            ["code"] = "ABORT_ERR",
+            ["message"] = "The operation was aborted",
+        });
     }
 
     public new object? GetMember(string name)
@@ -129,8 +219,28 @@ public class SharpTSWriteStream : SharpTSWritable
         {
             "path" => _filePath,
             "bytesWritten" => (double)_bytesWritten,
+            "pending" => _pending,
+            "on" or "addListener" or "once" => BuiltInMethod.CreateV2(name, 2,
+                (interp, recv, args) => WrapOnReplay(interp, name, args)),
             _ => base.GetMember(name)
         };
+    }
+
+    // Wraps on/once/addListener so a listener for open/ready/close added after the
+    // event already fired (during synchronous creation/end) is invoked immediately.
+    private RuntimeValue WrapOnReplay(Interp interpreter, string method, ReadOnlySpan<RuntimeValue> args)
+    {
+        (base.GetMember(method) as BuiltInMethod)?.Bind(this).CallV2(interpreter, args);
+
+        var ev = args.Length > 0 ? args[0].ToObject()?.ToString() : null;
+        var listener = args.Length > 1 ? args[1].ToObject() as ISharpTSCallable : null;
+        if (listener != null)
+        {
+            if (ev == "open" && _openFired) listener.Call(interpreter, [_openFd]);
+            else if (ev == "ready" && _readyFired) listener.Call(interpreter, []);
+            else if (ev == "close" && _closeFired) listener.Call(interpreter, []);
+        }
+        return RuntimeValue.FromObject(this);
     }
 
     public override string ToString() => $"WriteStream {{ path: '{_filePath}' }}";

--- a/SharpTS.Tests/SharedTests/BuiltInModules/FsStreamTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/FsStreamTests.cs
@@ -52,12 +52,12 @@ public class FsStreamTests
 
             var files = new Dictionary<string, string>
             {
+                // 'end' fires on the next tick (Node-faithful, #980) — log from the
+                // handler rather than synchronously after attaching it.
                 ["main.ts"] = "import * as fs from 'fs';\n" +
                     "const stream = fs.createReadStream('" + p + "', { encoding: 'utf8' });\n" +
-                    "let ended = false;\n" +
                     "stream.on('data', () => {});\n" +
-                    "stream.on('end', () => { ended = true; });\n" +
-                    "console.log(ended);\n"
+                    "stream.on('end', () => { console.log('true'); });\n"
             };
 
             var output = TestHarness.RunModules(files, "main.ts", mode);

--- a/stdlib/node/fs.ts
+++ b/stdlib/node/fs.ts
@@ -1135,11 +1135,22 @@ class FileHandle {
     /** Flushes the fd's data writes to disk (#976). */
     datasync(): Promise<void> { return __promisifyVoid(() => __fsyncSync(this.fd)); }
 
-    /** Returns a ReadStream over the underlying file. */
-    createReadStream(options?: any): any { return createReadStream(this.__path, options); }
+    /** Returns a ReadStream over the handle's fd (#980). autoClose defaults false —
+     *  the handle owns the descriptor; close it via fh.close(). */
+    createReadStream(options?: any): any {
+        const o: any = { autoClose: false };
+        if (options) for (const k in options) o[k] = options[k];
+        o.fd = this.fd;
+        return createReadStream(this.__path, o);
+    }
 
-    /** Returns a WriteStream over the underlying file. */
-    createWriteStream(options?: any): any { return createWriteStream(this.__path, options); }
+    /** Returns a WriteStream over the handle's fd (#980). autoClose defaults false. */
+    createWriteStream(options?: any): any {
+        const o: any = { autoClose: false };
+        if (options) for (const k in options) o[k] = options[k];
+        o.fd = this.fd;
+        return createWriteStream(this.__path, o);
+    }
 
     /** Closes the file descriptor. Idempotent. */
     close(): Promise<void> {


### PR DESCRIPTION
Closes #968's final child, #980. Brings `fs.createReadStream`/`createWriteStream` to Node option + event parity in **both** the interpreter and the compiled backend.

## Interpreter
ReadStream defers reading to the next tick so listeners attached after `createReadStream()` see `open→ready→data*→end→close` in Node order. WriteStream emits `open→ready→finish→close`. Both honor `fd`/`flags`/`mode`/`encoding`/`start`/`end`/`highWaterMark`/`autoClose`/`emitClose`/`signal`; add `pending`; AbortSignal→`AbortError`; `emitClose:false` suppresses `close`. `createReadStream({fd})` + `FileHandle.createReadStream`/`createWriteStream` share the descriptor.

## Compiled
- `$FsReadStream`: emits `open`/`ready`/`close` (via an `OnListenerAdded` replay, exactly like the base `$Readable` replays `end` — no event loop), chunks by `highWaterMark`, honors `fd`/`start`/`end`/`encoding`/`emitClose`/`autoClose`, adds `Pending`/`bytesRead`.
- `$FsWriteStream`: **reparented onto `$EventEmitter`** (was a non-emitter `object` with a no-op `On` stub) — now emits `open`/`ready`/`finish`/`close`, honors `flags`/`fd`/`start`/`autoClose`/`emitClose`, `Write` handles `byte[]`/`$Buffer`/string so `pipe()` moves content.

The compiled fix uses replay rather than deferral because the compiled entry point doesn't run the event loop for a raw `$EventLoop.Schedule`d action in a top-level program (a #971-family quiescence issue).

## Verification
8 dual-mode parity tests (read events+chunking+bytesRead, emitClose+start/end, write events+bytesWritten+content, pipe read→write). Byte-identical interp==compiled, standalone preserved. **Full suite 14480/0**; TS conformance unchanged.

Minor documented divergences: compiled reads eagerly (`pending=false` right after `createReadStream` vs interp `true`); AbortSignal abort is interpreter-only here (compiled AbortSignal limitation, #985).