### PR TITLE
fix(fs): compiled AbortSignal (#985) + fd-op/chown error codes (#986) match interpreter

### DIFF
--- a/Compilation/EmittedRuntime.cs
+++ b/Compilation/EmittedRuntime.cs
@@ -2365,6 +2365,12 @@ public class EmittedRuntime
     public MethodBuilder AbortSignalThrowIfAborted { get; set; } = null!;
     public MethodBuilder AbortSignalAddEventListener { get; set; } = null!;
     public MethodBuilder AbortSignalRemoveEventListener { get; set; } = null!;
+    // #985: `__this`-first wrappers so a dynamically-typed (`any`) signal receiver can
+    // resolve addEventListener/removeEventListener/throwIfAborted as callable methods
+    // via the GetProperty $TSFunction-wrapper path (mirrors hasOwnProperty/isPrototypeOf).
+    public MethodBuilder AbortSignalAddEventListenerThis { get; set; } = null!;
+    public MethodBuilder AbortSignalRemoveEventListenerThis { get; set; } = null!;
+    public MethodBuilder AbortSignalThrowIfAbortedThis { get; set; } = null!;
     public MethodBuilder AbortSignalAbort { get; set; } = null!;
     public MethodBuilder AbortSignalTimeout { get; set; } = null!;
     public MethodBuilder AbortSignalAny { get; set; } = null!;

--- a/Compilation/RuntimeEmitter.AbortController.cs
+++ b/Compilation/RuntimeEmitter.AbortController.cs
@@ -33,6 +33,7 @@ public partial class RuntimeEmitter
         EmitAbortSignalThrowIfAborted(typeBuilder, runtime);
         EmitAbortSignalAddEventListener(typeBuilder, runtime);
         EmitAbortSignalRemoveEventListener(typeBuilder, runtime);
+        EmitAbortSignalThisWrappers(typeBuilder, runtime);
         EmitAbortSignalStaticAbort(typeBuilder, runtime);
         EmitAbortSignalStaticTimeout(typeBuilder, runtime);
         EmitAbortSignalStaticAny(typeBuilder, runtime);
@@ -521,6 +522,79 @@ public partial class RuntimeEmitter
         il.MarkLabel(doneLabel);
         il.Emit(OpCodes.Ldnull);
         il.Emit(OpCodes.Ret);
+    }
+
+    /// <summary>
+    /// Emits `__this`-first wrappers around the AbortSignal method helpers so a
+    /// dynamically-typed (`any`) signal receiver can resolve them as callable methods.
+    /// The GetProperty signal branch returns these wrapped in a $TSFunction (target=null,
+    /// _expectsThis=true via the "__this" first-parameter name), so InvokeMethodValue
+    /// injects the receiver. Each returns object (undefined) — addEventListener and
+    /// throwIfAborted have no JS return value. (#985)
+    /// </summary>
+    private void EmitAbortSignalThisWrappers(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    {
+        runtime.AbortSignalAddEventListenerThis =
+            EmitAbortSignalAddRemoveThis(typeBuilder, "AbortSignalAddEventListenerThis", runtime.AbortSignalAddEventListener);
+        runtime.AbortSignalRemoveEventListenerThis =
+            EmitAbortSignalAddRemoveThis(typeBuilder, "AbortSignalRemoveEventListenerThis", runtime.AbortSignalRemoveEventListener);
+
+        // throwIfAborted(): no args beyond the receiver.
+        var throwMethod = typeBuilder.DefineMethod(
+            "AbortSignalThrowIfAbortedThis",
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.Object,
+            [_types.Object]);
+        throwMethod.DefineParameter(1, ParameterAttributes.None, "__this");
+        runtime.AbortSignalThrowIfAbortedThis = throwMethod;
+        var tIl = throwMethod.GetILGenerator();
+        tIl.Emit(OpCodes.Ldarg_0);
+        tIl.Emit(OpCodes.Call, runtime.AbortSignalThrowIfAborted); // void
+        tIl.Emit(OpCodes.Ldnull);
+        tIl.Emit(OpCodes.Ret);
+    }
+
+    /// <summary>
+    /// Emits an `(object __this, object type, object listener) → object` wrapper that
+    /// normalizes `type` to a string (null-safe) and forwards to the given base helper
+    /// `(object signal, string type, object listener) → object`. AdjustArgs pads an
+    /// omitted listener with undefined, so calls like addEventListener('abort') are safe.
+    /// </summary>
+    private MethodBuilder EmitAbortSignalAddRemoveThis(TypeBuilder typeBuilder, string name, MethodBuilder baseHelper)
+    {
+        var method = typeBuilder.DefineMethod(
+            name,
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.Object,
+            [_types.Object, _types.Object, _types.Object]);
+        method.DefineParameter(1, ParameterAttributes.None, "__this");
+        method.DefineParameter(2, ParameterAttributes.None, "type");
+        method.DefineParameter(3, ParameterAttributes.None, "listener");
+
+        var il = method.GetILGenerator();
+
+        // typeStr = type == null ? null : type.ToString()
+        var typeStrLocal = il.DeclareLocal(_types.String);
+        var notNullLabel = il.DefineLabel();
+        var haveTypeLabel = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Dup);
+        il.Emit(OpCodes.Brtrue, notNullLabel);
+        il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Ldnull);
+        il.Emit(OpCodes.Br, haveTypeLabel);
+        il.MarkLabel(notNullLabel);
+        il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.Object, "ToString"));
+        il.MarkLabel(haveTypeLabel);
+        il.Emit(OpCodes.Stloc, typeStrLocal);
+
+        // return baseHelper(__this, typeStr, listener)
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldloc, typeStrLocal);
+        il.Emit(OpCodes.Ldarg_2);
+        il.Emit(OpCodes.Call, baseHelper);
+        il.Emit(OpCodes.Ret);
+        return method;
     }
 
     /// <summary>

--- a/Compilation/RuntimeEmitter.NodeError.cs
+++ b/Compilation/RuntimeEmitter.NodeError.cs
@@ -235,6 +235,66 @@ public partial class RuntimeEmitter
 
         var il = method.GetILGenerator();
 
+        // Preserve an already-formed $NodeError verbatim (e.g. EBADF from the fd table's
+        // Get/Close, or ENOSYS from chown/lchown on Windows). These are thrown by emitted
+        // code *inside* the EmitWithFsErrorHandling try block; without this branch the
+        // type-based mapping below would clobber their deliberate codes to the EINVAL
+        // default. Mirrors the interpreter's WrapFsOperation, which rethrows a NodeError
+        // as-is (keeping its own code/syscall/path and pre-formatted message). (#986)
+        var notNodeError = il.DefineLabel();
+        var nodeErrLocal = il.DeclareLocal(runtime.NodeErrorType);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Isinst, runtime.NodeErrorType);
+        il.Emit(OpCodes.Dup);
+        il.Emit(OpCodes.Stloc, nodeErrLocal);
+        il.Emit(OpCodes.Brfalse, notNodeError);
+
+        // var preserved = new Exception(ne.Message);  // ne.Message is already the fully
+        // formatted "CODE: syscall: message 'path'" string the interpreter produces.
+        var preservedLocal = il.DeclareLocal(_types.Exception);
+        il.Emit(OpCodes.Ldloc, nodeErrLocal);
+        il.Emit(OpCodes.Callvirt, _types.GetProperty(_types.Exception, "Message").GetGetMethod()!);
+        il.Emit(OpCodes.Newobj, _types.GetConstructor(_types.Exception, _types.String));
+        il.Emit(OpCodes.Stloc, preservedLocal);
+
+        // preserved.Data["__nodeError"] = true;
+        il.Emit(OpCodes.Ldloc, preservedLocal);
+        il.Emit(OpCodes.Callvirt, _types.GetProperty(_types.Exception, "Data").GetGetMethod()!);
+        il.Emit(OpCodes.Ldstr, "__nodeError");
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Box, _types.Boolean);
+        il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.IDictionary, "set_Item"));
+
+        // preserved.Data["__code"] = ne.Code;
+        il.Emit(OpCodes.Ldloc, preservedLocal);
+        il.Emit(OpCodes.Callvirt, _types.GetProperty(_types.Exception, "Data").GetGetMethod()!);
+        il.Emit(OpCodes.Ldstr, "__code");
+        il.Emit(OpCodes.Ldloc, nodeErrLocal);
+        il.Emit(OpCodes.Callvirt, runtime.NodeErrorCodeGetter);
+        il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.IDictionary, "set_Item"));
+
+        // preserved.Data["__syscall"] = ne.Syscall;
+        il.Emit(OpCodes.Ldloc, preservedLocal);
+        il.Emit(OpCodes.Callvirt, _types.GetProperty(_types.Exception, "Data").GetGetMethod()!);
+        il.Emit(OpCodes.Ldstr, "__syscall");
+        il.Emit(OpCodes.Ldloc, nodeErrLocal);
+        il.Emit(OpCodes.Callvirt, runtime.NodeErrorSyscallGetter);
+        il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.IDictionary, "set_Item"));
+
+        // preserved.Data["__path"] = ne.Path;
+        il.Emit(OpCodes.Ldloc, preservedLocal);
+        il.Emit(OpCodes.Callvirt, _types.GetProperty(_types.Exception, "Data").GetGetMethod()!);
+        il.Emit(OpCodes.Ldstr, "__path");
+        il.Emit(OpCodes.Ldloc, nodeErrLocal);
+        il.Emit(OpCodes.Callvirt, runtime.NodeErrorPathGetter);
+        il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.IDictionary, "set_Item"));
+
+        // throw preserved;
+        il.Emit(OpCodes.Ldloc, preservedLocal);
+        il.Emit(OpCodes.Throw);
+
+        il.MarkLabel(notNodeError);
+
         // Local for the error code string
         var codeLocal = il.DeclareLocal(_types.String);
 

--- a/Compilation/RuntimeEmitter.Objects.Properties.cs
+++ b/Compilation/RuntimeEmitter.Objects.Properties.cs
@@ -2817,12 +2817,17 @@ public partial class RuntimeEmitter
         var foundLabel = il.DefineLabel();
         il.Emit(OpCodes.Brtrue, foundLabel);
 
-        // $AbortSignal dict surface (#224): "aborted"/"reason"/"onabort" on a
-        // dynamically-typed signal receiver. The typed path intercepts at
-        // compile time (AbortSignalEmitter); an `any` receiver lands here.
-        // Signals are identified by their "_reasonSet" internal slot — the
-        // public keys are computed from the CancellationToken, so they are
-        // never own dict entries and always reach this miss path. Name screen
+        // $AbortSignal dict surface (#224, #985): the properties "aborted"/"reason"/
+        // "onabort" AND the methods "addEventListener"/"removeEventListener"/
+        // "throwIfAborted" on a dynamically-typed (`any`) signal receiver. The typed
+        // path intercepts at compile time (AbortSignalEmitter); an `any` receiver lands
+        // here. The methods are returned as $TSFunction wrappers (target=null,
+        // _expectsThis=true via the "__this" first parameter) so a subsequent
+        // InvokeMethodValue injects the signal as the receiver — i.e.
+        // `signal.addEventListener('abort', cb)` works from inside a helper, not only at
+        // a statically-typed call site. Signals are identified by their "_reasonSet"
+        // internal slot — the public keys are computed from the CancellationToken, so
+        // they are never own dict entries and always reach this miss path. Name screen
         // runs first to keep ordinary dict misses cheap.
         if (_features.UsesAbortController)
         {
@@ -2830,7 +2835,26 @@ public partial class RuntimeEmitter
             var signalNameMatchLabel = il.DefineLabel();
             var strEq = _types.GetMethod(_types.String, "op_Equality", _types.String, _types.String);
 
-            foreach (var signalProp in new[] { "aborted", "reason", "onabort" })
+            // Returns a $TSFunction wrapping `helper`, bound to no target, so the
+            // wrapper's _expectsThis is set (helper's first param is "__this") and
+            // InvokeMethodValue passes the signal receiver through. Same shape as
+            // EmitObjProtoMethodCheck's hasOwnProperty/isPrototypeOf wrappers.
+            void EmitSignalMethodWrapper(MethodBuilder helper, string jsName, int jsLength)
+            {
+                il.Emit(OpCodes.Ldnull);
+                il.Emit(OpCodes.Ldtoken, helper);
+                il.Emit(OpCodes.Ldtoken, helper.DeclaringType!);
+                il.Emit(OpCodes.Call, _types.GetMethod(_types.MethodBase, "GetMethodFromHandle",
+                    _types.RuntimeMethodHandle, _types.RuntimeTypeHandle));
+                il.Emit(OpCodes.Castclass, _types.MethodInfo);
+                il.Emit(OpCodes.Ldstr, jsName);
+                il.Emit(OpCodes.Ldc_I4, jsLength);
+                il.Emit(OpCodes.Newobj, runtime.TSFunctionCtorWithCache);
+                il.Emit(OpCodes.Ret);
+            }
+
+            foreach (var signalProp in new[]
+                { "aborted", "reason", "onabort", "addEventListener", "removeEventListener", "throwIfAborted" })
             {
                 il.Emit(OpCodes.Ldarg_1);
                 il.Emit(OpCodes.Ldstr, signalProp);
@@ -2866,9 +2890,34 @@ public partial class RuntimeEmitter
             il.Emit(OpCodes.Ret);
             il.MarkLabel(notSignalReasonLabel);
 
+            var notSignalOnAbortLabel = il.DefineLabel();
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Ldstr, "onabort");
+            il.Emit(OpCodes.Call, strEq);
+            il.Emit(OpCodes.Brfalse, notSignalOnAbortLabel);
             il.Emit(OpCodes.Ldarg_0);
             il.Emit(OpCodes.Call, runtime.AbortSignalGetOnAbort);
             il.Emit(OpCodes.Ret);
+            il.MarkLabel(notSignalOnAbortLabel);
+
+            var notSignalAelLabel = il.DefineLabel();
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Ldstr, "addEventListener");
+            il.Emit(OpCodes.Call, strEq);
+            il.Emit(OpCodes.Brfalse, notSignalAelLabel);
+            EmitSignalMethodWrapper(runtime.AbortSignalAddEventListenerThis, "addEventListener", 2);
+            il.MarkLabel(notSignalAelLabel);
+
+            var notSignalRelLabel = il.DefineLabel();
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Ldstr, "removeEventListener");
+            il.Emit(OpCodes.Call, strEq);
+            il.Emit(OpCodes.Brfalse, notSignalRelLabel);
+            EmitSignalMethodWrapper(runtime.AbortSignalRemoveEventListenerThis, "removeEventListener", 2);
+            il.MarkLabel(notSignalRelLabel);
+
+            // Only "throwIfAborted" remains among the screened names.
+            EmitSignalMethodWrapper(runtime.AbortSignalThrowIfAbortedThis, "throwIfAborted", 0);
 
             il.MarkLabel(notSignalPropLabel);
         }
@@ -3948,6 +3997,34 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ret);
 
         il.MarkLabel(dictLabel);
+
+        // $AbortSignal dict surface (#985): `signal.onabort = cb` on a dynamically-
+        // typed (`any`) signal receiver. The typed path intercepts at compile time
+        // (AbortSignalEmitter.TryEmitPropertySet); an `any` receiver lands here and
+        // would otherwise store a plain "onabort" dict key that FireAbortEvent (which
+        // reads the internal "_onabort" slot) never sees — so the handler never fired.
+        // Signals are identified by their "_reasonSet" internal slot. Gated on
+        // UsesAbortController so non-signal programs pay nothing; mirrors the GetProperty
+        // signal branch (#224).
+        if (_features.UsesAbortController)
+        {
+            var notSignalOnAbortSet = il.DefineLabel();
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Ldstr, "onabort");
+            il.Emit(OpCodes.Call, _types.GetMethod(_types.String, "op_Equality", _types.String, _types.String));
+            il.Emit(OpCodes.Brfalse, notSignalOnAbortSet);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Castclass, _types.DictionaryStringObject);
+            il.Emit(OpCodes.Ldstr, "_reasonSet");
+            il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.DictionaryStringObject, "ContainsKey", _types.String));
+            il.Emit(OpCodes.Brfalse, notSignalOnAbortSet);
+            il.Emit(OpCodes.Ldarg_0);  // signal
+            il.Emit(OpCodes.Ldarg_2);  // handler
+            il.Emit(OpCodes.Call, runtime.AbortSignalSetOnAbort);
+            il.Emit(OpCodes.Ret);
+            il.MarkLabel(notSignalOnAbortSet);
+        }
+
         // For dictionaries, check frozen/sealed tables and silently ignore if frozen/sealed
         var sealedCheckLabel = il.DefineLabel();
         var doSetLabel = il.DefineLabel();

--- a/SharpTS.Tests/SharedTests/AbortControllerTests.cs
+++ b/SharpTS.Tests/SharedTests/AbortControllerTests.cs
@@ -262,4 +262,93 @@ public class AbortControllerTests
         var output = TestHarness.Run(source, mode);
         Assert.Equal("true\nfalse\ntrue\n", output);
     }
+
+    // #985: the typed strategy (AbortSignalEmitter) only fires when the receiver's
+    // static type is AbortSignal. When a signal flows through an `any` parameter — the
+    // common case for stdlib facades and user helpers — the dynamic dispatch path must
+    // also route the listener API and the onabort setter to the signal helpers. Before
+    // the fix, compiled mode wrote a plain "onabort" dict key (never fired) and threw
+    // "undefined is not a function" for addEventListener.
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AbortSignal_OnAbort_DynamicReceiver_Fires(ExecutionMode mode)
+    {
+        var source = @"
+            function reg(signal: any, cb: any): void { signal.onabort = cb; }
+            const ac = new AbortController();
+            let fired = 'no';
+            reg(ac.signal, () => { fired = 'yes'; });
+            ac.abort();
+            console.log(fired);
+        ";
+        Assert.Equal("yes\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AbortSignal_AddEventListener_DynamicReceiver_Fires(ExecutionMode mode)
+    {
+        var source = @"
+            function reg(signal: any, cb: any): void { signal.addEventListener('abort', cb); }
+            const ac = new AbortController();
+            let fired = 'no';
+            reg(ac.signal, () => { fired = 'yes'; });
+            ac.abort();
+            console.log(fired);
+        ";
+        Assert.Equal("yes\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AbortSignal_RemoveEventListener_DynamicReceiver(ExecutionMode mode)
+    {
+        var source = @"
+            function addL(s: any, cb: any): void { s.addEventListener('abort', cb); }
+            function rmL(s: any, cb: any): void { s.removeEventListener('abort', cb); }
+            const ac = new AbortController();
+            let count = 0;
+            const cb = () => { count++; };
+            addL(ac.signal, cb);
+            rmL(ac.signal, cb);
+            ac.abort();
+            console.log(count);
+        ";
+        Assert.Equal("0\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AbortSignal_ThrowIfAborted_DynamicReceiver(ExecutionMode mode)
+    {
+        var source = @"
+            function tryThrow(s: any): string {
+                try { s.throwIfAborted(); return 'noThrow'; } catch (e: any) { return 'threw'; }
+            }
+            const ac = new AbortController();
+            console.log(tryThrow(ac.signal));
+            ac.abort();
+            console.log(tryThrow(ac.signal));
+        ";
+        Assert.Equal("noThrow\nthrew\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AbortSignal_AbortedAndReason_DynamicReceiver(ExecutionMode mode)
+    {
+        // The property reads on an `any` receiver (#224) must keep working alongside
+        // the new method/onabort routing.
+        var source = @"
+            function isAborted(s: any): boolean { return s.aborted; }
+            function reasonOf(s: any): any { return s.reason; }
+            const ac = new AbortController();
+            console.log(isAborted(ac.signal));
+            ac.abort('boom');
+            console.log(isAborted(ac.signal));
+            console.log(reasonOf(ac.signal));
+        ";
+        Assert.Equal("false\ntrue\nboom\n", TestHarness.Run(source, mode));
+    }
 }

--- a/SharpTS.Tests/SharedTests/BuiltInModules/FsModuleTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/FsModuleTests.cs
@@ -1624,9 +1624,11 @@ public class FsModuleTests
     {
         // Real FSWatcher event timing is non-deterministic (and flaky under load), so
         // this pins the iterator + AbortSignal-termination contract deterministically:
-        // aborting then pulling yields done, and a pre-aborted signal ends a for-await
-        // immediately. (Live change-event observation is covered by manual/e2e checks;
-        // the compiled parked-abort limitation is tracked in #985.)
+        // aborting then pulling yields done, a pre-aborted signal ends a for-await
+        // immediately, and — since #985 — aborting while a pull is PARKED (no events)
+        // wakes it promptly in both modes via the signal's abort listener. The parked
+        // case is deterministic here because next() parks synchronously before abort()
+        // fires finish(); no live change event is involved.
         var uid = Uid();
         var files = new Dictionary<string, string>
         {
@@ -1642,17 +1644,24 @@ public class FsModuleTests
                     ac.abort();
                     const r = await it.next();
                     console.log('done:' + r.done);
+                    // Parked-abort (#985): pull first (parks, no events), then abort.
                     const ac2 = new AbortController();
+                    const it2: any = fs.promises.watch(d, { signal: ac2.signal });
+                    const parked = it2.next();
                     ac2.abort();
+                    const pr = await parked;
+                    console.log('parked:' + pr.done);
+                    const ac3 = new AbortController();
+                    ac3.abort();
                     let count = 0;
-                    for await (const ev of fs.promises.watch(d, { signal: ac2.signal })) { count++; }
+                    for await (const ev of fs.promises.watch(d, { signal: ac3.signal })) { count++; }
                     console.log('count:' + count);
                     fs.rmSync(d, { recursive: true, force: true });
                 }
                 main();
                 """
         };
-        Assert.Equal("done:true\ncount:0\n", TestHarness.RunModules(files, "main.ts", mode));
+        Assert.Equal("done:true\nparked:true\ncount:0\n", TestHarness.RunModules(files, "main.ts", mode));
     }
 
     #endregion

--- a/SharpTS.Tests/SharedTests/BuiltInModules/FsModuleTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/FsModuleTests.cs
@@ -1709,10 +1709,10 @@ public class FsModuleTests
                 async function main() {
                     const f = os.tmpdir() + '/fd974b_{{uid}}.txt';
                     fs.writeFileSync(f, 'x');
-                    // Bad fd surfaces an error with a code to the callback (the exact code
-                    // differs by mode for a stale fd — a pre-existing primitive divergence).
-                    const hasCode: any = await new Promise((res: any) => fs.fstat(999999, (e: any) => res(!!(e && typeof e.code === 'string' && e.code.length > 0))));
-                    console.log('badfd:' + hasCode);
+                    // A stale fd surfaces EBADF to the callback in BOTH modes (#986 — the
+                    // compiled fd table threw EBADF but the catch-all re-mapped it to EINVAL).
+                    const badCode: any = await new Promise((res: any) => fs.fstat(999999, (e: any) => res(e && e.code ? e.code : 'nocode')));
+                    console.log('badfd:' + badCode);
                     // chown's callback is invoked (platform/no-op behavior aside).
                     const called: any = await new Promise((res: any) => fs.chown(f, 0, 0, () => res(true)));
                     console.log('chown:' + called);
@@ -1721,7 +1721,61 @@ public class FsModuleTests
                 main();
                 """
         };
-        Assert.Equal("badfd:true\nchown:true\n", TestHarness.RunModules(files, "main.ts", mode));
+        Assert.Equal("badfd:EBADF\nchown:true\n", TestHarness.RunModules(files, "main.ts", mode));
+    }
+
+    // #986: every sync fd op on a stale descriptor surfaces EBADF (not EINVAL) in both
+    // modes. The compiled fd table already threw EBADF, but EmitWithFsErrorHandling's
+    // catch-all re-mapped any non-BCL exception to the EINVAL default before the fix.
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Fs_SyncFdOps_BadFd_ReturnEBADF(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import * as fs from 'fs';
+                const BAD = 999999;
+                const buf = Buffer.alloc(4);
+                function code(fn: () => void): string { try { fn(); return 'ok'; } catch (e: any) { return e.code; } }
+                console.log('fstat:'  + code(() => fs.fstatSync(BAD)));
+                console.log('ftrunc:' + code(() => fs.ftruncateSync(BAD, 0)));
+                console.log('read:'   + code(() => fs.readSync(BAD, buf, 0, 4, 0)));
+                console.log('write:'  + code(() => fs.writeSync(BAD, buf, 0, 4, 0)));
+                console.log('close:'  + code(() => fs.closeSync(BAD)));
+                """
+        };
+        Assert.Equal(
+            "fstat:EBADF\nftrunc:EBADF\nread:EBADF\nwrite:EBADF\nclose:EBADF\n",
+            TestHarness.RunModules(files, "main.ts", mode));
+    }
+
+    // #986: chown/lchown on Windows report ENOSYS (function not implemented) in both
+    // modes — the compiled side threw ENOSYS but the catch-all clobbered it to EINVAL.
+    // Windows-gated: on Unix the compiled side is a documented no-op (P/Invoke from IL),
+    // so it diverges from the interpreter's real syscall there (out of scope for #986).
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Fs_SyncChownLchown_Windows_ReturnENOSYS(ExecutionMode mode)
+    {
+        if (!OperatingSystem.IsWindows())
+            return; // parity only holds on Windows; see comment above.
+
+        var uid = Uid();
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = $$"""
+                import * as fs from 'fs';
+                import * as os from 'os';
+                const f = os.tmpdir() + '/fd986_{{uid}}.txt';
+                fs.writeFileSync(f, 'x');
+                function code(fn: () => void): string { try { fn(); return 'ok'; } catch (e: any) { return e.code; } }
+                console.log('chown:'  + code(() => fs.chownSync(f, 0, 0)));
+                console.log('lchown:' + code(() => fs.lchownSync(f, 0, 0)));
+                fs.unlinkSync(f);
+                """
+        };
+        Assert.Equal("chown:ENOSYS\nlchown:ENOSYS\n", TestHarness.RunModules(files, "main.ts", mode));
     }
 
     #endregion

--- a/stdlib/node/fs.ts
+++ b/stdlib/node/fs.ts
@@ -680,9 +680,10 @@ function __watchAsync(filename: string, options?: any): any {
             finish();
         } else {
             // Immediate termination when the AbortSignal fires while the iterator is
-            // parked. In compiled mode AbortSignal's listener API is not callable from
-            // stdlib code (the call throws), so this is ignored there — abort is then
-            // observed by the `signal.aborted` check in next() on the following pull.
+            // parked — `finish` wakes any parked resolver so the loop ends without a
+            // further pull. Works in both modes now that a dynamically-typed signal's
+            // addEventListener is callable from stdlib code (#985). The try/catch and
+            // the `signal.aborted` poll in next() remain as defensive fallbacks.
             try { signal.addEventListener('abort', finish); } catch (e) { }
         }
     }


### PR DESCRIPTION
Fixes the two remaining interp↔compiled divergences from the `fs` epic (#968): both are **compiled-only** bugs where the compiled path diverged from the (correct) interpreter. Each is its own commit.

## #986 — compiled fd-op + chown error codes

A stale file descriptor reported `EINVAL` (compiled) instead of `EBADF` (interp/Node), and `chown`/`lchown` on Windows reported `EINVAL` instead of `ENOSYS`.

**Root cause (one bug, two symptoms):** the fd table's `Get`/`Close` already threw `$NodeError("EBADF", …)`, and `FsChownSync`/`FsLchownSync` already threw `$NodeError("ENOSYS", …)` on Windows — but both are thrown *inside* `EmitWithFsErrorHandling`'s try block, whose catch-all routes every exception through `ThrowNodeError`. That helper maps by .NET exception **type** and fell through to the `EINVAL` default for any `$NodeError`, discarding the deliberate code (and doubling the message).

**Fix:** `ThrowNodeError` now detects an incoming `$NodeError` and preserves its own code/syscall/path and pre-formatted message verbatim, mirroring the interpreter's `WrapFsOperation` (which rethrows a `NodeError` as-is). One change fixes both halves; also cleans up the doubled message on the readlink `EINVAL` path.

## #985 — compiled AbortSignal listener API + `onabort` on an `any`-typed receiver

`signal.addEventListener('abort', cb)` threw `TypeError: undefined is not a function`, and `signal.onabort = cb` never fired — but only when the signal flowed through an `any` parameter (the common case: stdlib facades, user helpers). At a statically-typed call site it worked.

**Root cause:** compiled `$AbortSignal` is a plain `Dictionary` whose methods are static `$Runtime` helpers, dispatched by the typed `AbortSignalEmitter` strategy — which only fires when the receiver's static type is `AbortSignal`. Through an `any` param, dispatch fell to generic dynamic member access: `addEventListener` resolved to `undefined`, and `onabort = cb` wrote a dead `"onabort"` dict key that `FireAbortEvent` (which reads the internal `"_onabort"` slot) never saw.

**Fix** (mirrors the existing dynamic GetProperty signal-property fallback, #224):
- `GetProperty`: the signal branch now also returns `$TSFunction` wrappers for `addEventListener`/`removeEventListener`/`throwIfAborted` (target=null, `_expectsThis=true` via a `__this` first param), so `InvokeMethodValue` injects the receiver — the methods become callable from any context.
- `SetProperty`: route `onabort` on a signal dict to `AbortSignalSetOnAbort` (the internal slot) instead of storing a dead key.
- New `AbortSignal{AddEventListener,RemoveEventListener,ThrowIfAborted}This` `__this`-first wrappers adapt to the existing helpers.

All gated on `UsesAbortController` and the `_reasonSet` slot; **standalone preserved** (pure emitted IL, no `SharpTS.dll` dependency).

As a follow-up benefit, `fs.promises.watch` parked-abort now terminates promptly in compiled mode (#975): the facade's `addEventListener('abort', finish)` finally fires. Updated the stale facade comment accordingly.

## Tests
- **#986:** tightened `Fs_CallbackFd_BadFd_And_Chown_Invoke` (badfd now asserts `EBADF`); added `Fs_SyncFdOps_BadFd_ReturnEBADF` (fstat/ftruncate/read/write/close) and `Fs_SyncChownLchown_Windows_ReturnENOSYS` (Windows-gated — Unix has a documented compiled no-op).
- **#985:** added dynamic-receiver tests for onabort/addEventListener/removeEventListener/throwIfAborted/aborted+reason; added a **deterministic** parked-abort case to `Fs_PromisesWatch_AsyncIteratorTerminatesOnAbort`.
- Every case is byte-identical interp==compiled.

## Verification
- `dotnet test` (full suite): **14496 / 0**
- TypeScript conformance: **31 / 0**, unchanged
- Test262 (both modes): **0 regressions** (a flaky "new passes" drift in the compiled baseline varies run-to-run and is unrelated — the 11,384-entry baseline has zero abort/fs entries and my code is gated on `UsesAbortController`/fs paths ECMA never exercises; not baked into the baseline)
- Standalone compiled DLLs run with no `SharpTS.dll` present

Closes #985
Closes #986