### PR TITLE
worker_threads parity (epic #996): terminate teardown, events, transfer/detach, env-data, stdio, introspection

### DIFF
--- a/Compilation/EmittedRuntime.cs
+++ b/Compilation/EmittedRuntime.cs
@@ -2732,6 +2732,8 @@ public class EmittedRuntime
     public MethodBuilder WorkerThreadsIsMainThread { get; set; } = null!;
     public MethodBuilder WorkerThreadsThreadId { get; set; } = null!;
     public MethodBuilder WorkerThreadsReceiveMessageOnPort { get; set; } = null!;
+    public MethodBuilder WorkerThreadsGetEnvironmentData { get; set; } = null!;
+    public MethodBuilder WorkerThreadsSetEnvironmentData { get; set; } = null!;
 
     // DNS module methods
     public MethodBuilder DnsLookup { get; set; } = null!;

--- a/Compilation/EmittedRuntime.cs
+++ b/Compilation/EmittedRuntime.cs
@@ -2734,6 +2734,7 @@ public class EmittedRuntime
     public MethodBuilder WorkerThreadsReceiveMessageOnPort { get; set; } = null!;
     public MethodBuilder WorkerThreadsGetEnvironmentData { get; set; } = null!;
     public MethodBuilder WorkerThreadsSetEnvironmentData { get; set; } = null!;
+    public MethodBuilder WorkerThreadsMarkAsUntransferable { get; set; } = null!;
 
     // DNS module methods
     public MethodBuilder DnsLookup { get; set; } = null!;

--- a/Compilation/Emitters/Modules/WorkerThreadsModuleEmitter.cs
+++ b/Compilation/Emitters/Modules/WorkerThreadsModuleEmitter.cs
@@ -15,7 +15,8 @@ public sealed class WorkerThreadsModuleEmitter : IBuiltInModuleEmitter
     [
         "Worker", "MessageChannel", "MessagePort", "BroadcastChannel",
         "isMainThread", "threadId", "workerData", "parentPort",
-        "receiveMessageOnPort", "getEnvironmentData", "setEnvironmentData"
+        "receiveMessageOnPort", "getEnvironmentData", "setEnvironmentData",
+        "markAsUntransferable"
     ];
 
     public IReadOnlyList<string> GetExportedMembers() => _exportedMembers;
@@ -30,6 +31,7 @@ public sealed class WorkerThreadsModuleEmitter : IBuiltInModuleEmitter
             "receiveMessageOnPort" => EmitReceiveMessageOnPort(emitter, arguments),
             "getEnvironmentData" => EmitGetEnvironmentData(emitter, arguments),
             "setEnvironmentData" => EmitSetEnvironmentData(emitter, arguments),
+            "markAsUntransferable" => EmitMarkAsUntransferable(emitter, arguments),
             _ => false
         };
     }
@@ -223,6 +225,30 @@ public sealed class WorkerThreadsModuleEmitter : IBuiltInModuleEmitter
         il.Emit(OpCodes.Call, ctx.Runtime!.WorkerThreadsSetEnvironmentData);
 
         // setEnvironmentData returns undefined.
+        il.Emit(OpCodes.Ldsfld, ctx.Runtime!.UndefinedInstance);
+        return true;
+    }
+
+    private static bool EmitMarkAsUntransferable(IEmitterContext emitter, List<Expr> arguments)
+    {
+        var ctx = emitter.Context;
+        var il = ctx.IL;
+
+        // Reaching the C# StructuredClone registry needs SharpTS.dll co-located (#1002).
+        ctx.Runtime!.RequireSharpTSRuntime("worker_threads.markAsUntransferable");
+
+        if (arguments.Count > 0)
+        {
+            emitter.EmitExpression(arguments[0]);
+            emitter.EmitBoxIfNeeded(arguments[0]);
+        }
+        else
+        {
+            il.Emit(OpCodes.Ldnull);
+        }
+        il.Emit(OpCodes.Call, ctx.Runtime!.WorkerThreadsMarkAsUntransferable);
+
+        // markAsUntransferable returns undefined.
         il.Emit(OpCodes.Ldsfld, ctx.Runtime!.UndefinedInstance);
         return true;
     }

--- a/Compilation/Emitters/Modules/WorkerThreadsModuleEmitter.cs
+++ b/Compilation/Emitters/Modules/WorkerThreadsModuleEmitter.cs
@@ -15,7 +15,7 @@ public sealed class WorkerThreadsModuleEmitter : IBuiltInModuleEmitter
     [
         "Worker", "MessageChannel", "MessagePort", "BroadcastChannel",
         "isMainThread", "threadId", "workerData", "parentPort",
-        "receiveMessageOnPort"
+        "receiveMessageOnPort", "getEnvironmentData", "setEnvironmentData"
     ];
 
     public IReadOnlyList<string> GetExportedMembers() => _exportedMembers;
@@ -28,6 +28,8 @@ public sealed class WorkerThreadsModuleEmitter : IBuiltInModuleEmitter
         return methodName switch
         {
             "receiveMessageOnPort" => EmitReceiveMessageOnPort(emitter, arguments),
+            "getEnvironmentData" => EmitGetEnvironmentData(emitter, arguments),
+            "setEnvironmentData" => EmitSetEnvironmentData(emitter, arguments),
             _ => false
         };
     }
@@ -153,6 +155,75 @@ public sealed class WorkerThreadsModuleEmitter : IBuiltInModuleEmitter
         emitter.EmitExpression(arguments[0]);
         emitter.EmitBoxIfNeeded(arguments[0]);
         il.Emit(OpCodes.Call, ctx.Runtime!.WorkerThreadsReceiveMessageOnPort);
+        return true;
+    }
+
+    private static bool EmitGetEnvironmentData(IEmitterContext emitter, List<Expr> arguments)
+    {
+        var ctx = emitter.Context;
+        var il = ctx.IL;
+
+        // Reaching the C# WorkerEnvironmentData store needs SharpTS.dll co-located (#1000).
+        ctx.Runtime!.RequireSharpTSRuntime("worker_threads.getEnvironmentData");
+
+        if (arguments.Count > 0)
+        {
+            emitter.EmitExpression(arguments[0]);
+            emitter.EmitBoxIfNeeded(arguments[0]);
+        }
+        else
+        {
+            il.Emit(OpCodes.Ldnull);
+        }
+        il.Emit(OpCodes.Call, ctx.Runtime!.WorkerThreadsGetEnvironmentData);
+
+        // Map absent (CLR null) to JS undefined — stored values are never null (a null/undefined
+        // set deletes the key), so null here means "not present".
+        var result = il.DeclareLocal(ctx.Types.Object);
+        var notNull = il.DefineLabel();
+        var done = il.DefineLabel();
+        il.Emit(OpCodes.Stloc, result);
+        il.Emit(OpCodes.Ldloc, result);
+        il.Emit(OpCodes.Brtrue, notNull);
+        il.Emit(OpCodes.Ldsfld, ctx.Runtime!.UndefinedInstance);
+        il.Emit(OpCodes.Br, done);
+        il.MarkLabel(notNull);
+        il.Emit(OpCodes.Ldloc, result);
+        il.MarkLabel(done);
+        return true;
+    }
+
+    private static bool EmitSetEnvironmentData(IEmitterContext emitter, List<Expr> arguments)
+    {
+        var ctx = emitter.Context;
+        var il = ctx.IL;
+
+        ctx.Runtime!.RequireSharpTSRuntime("worker_threads.setEnvironmentData");
+
+        // key
+        if (arguments.Count > 0)
+        {
+            emitter.EmitExpression(arguments[0]);
+            emitter.EmitBoxIfNeeded(arguments[0]);
+        }
+        else
+        {
+            il.Emit(OpCodes.Ldnull);
+        }
+        // value (absent → null, which deletes the key)
+        if (arguments.Count > 1)
+        {
+            emitter.EmitExpression(arguments[1]);
+            emitter.EmitBoxIfNeeded(arguments[1]);
+        }
+        else
+        {
+            il.Emit(OpCodes.Ldnull);
+        }
+        il.Emit(OpCodes.Call, ctx.Runtime!.WorkerThreadsSetEnvironmentData);
+
+        // setEnvironmentData returns undefined.
+        il.Emit(OpCodes.Ldsfld, ctx.Runtime!.UndefinedInstance);
         return true;
     }
 }

--- a/Compilation/RuntimeEmitter.TSArrayBuffer.cs
+++ b/Compilation/RuntimeEmitter.TSArrayBuffer.cs
@@ -25,6 +25,14 @@ public partial class RuntimeEmitter
             FieldAttributes.Private | FieldAttributes.InitOnly
         );
 
+        // Field: bool _detached — set when this buffer is transferred away via postMessage's
+        // transfer list (#999). Not InitOnly: Detach() mutates it.
+        var detachedField = typeBuilder.DefineField(
+            "_detached",
+            typeof(bool),
+            FieldAttributes.Private
+        );
+
         // Constructor: public $ArrayBuffer(int byteLength)
         var ctor = typeBuilder.DefineConstructor(
             MethodAttributes.Public,
@@ -47,11 +55,14 @@ public partial class RuntimeEmitter
 
         ctorIl.Emit(OpCodes.Ret);
 
-        // Property: public int ByteLength => _buffer.Length
-        EmitArrayBufferByteLength(typeBuilder, runtime, bufferField);
+        // Property: public int ByteLength => _detached ? 0 : _buffer.Length
+        EmitArrayBufferByteLength(typeBuilder, runtime, bufferField, detachedField);
 
         // Method: public byte[] GetBuffer() => _buffer (internal access)
         EmitArrayBufferGetBuffer(typeBuilder, runtime, bufferField);
+
+        // Method: public void Detach() => _detached = true (called by StructuredClone on transfer)
+        EmitArrayBufferDetach(typeBuilder, detachedField);
 
         // Method: public $ArrayBuffer Slice(int begin, int end)
         EmitArrayBufferSlice(typeBuilder, runtime, bufferField, ctor);
@@ -61,9 +72,10 @@ public partial class RuntimeEmitter
     }
 
     /// <summary>
-    /// Emits: public int ByteLength { get; }
+    /// Emits: public int ByteLength { get; } — returns 0 once detached (Node neuters a
+    /// transferred ArrayBuffer; its byteLength becomes 0).
     /// </summary>
-    private void EmitArrayBufferByteLength(TypeBuilder typeBuilder, EmittedRuntime runtime, FieldBuilder bufferField)
+    private void EmitArrayBufferByteLength(TypeBuilder typeBuilder, EmittedRuntime runtime, FieldBuilder bufferField, FieldBuilder detachedField)
     {
         var property = typeBuilder.DefineProperty(
             "ByteLength",
@@ -81,6 +93,15 @@ public partial class RuntimeEmitter
         runtime.ArrayBufferByteLengthGetter = getter;
 
         var il = getter.GetILGenerator();
+        var notDetached = il.DefineLabel();
+        // if (!_detached) goto notDetached
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, detachedField);
+        il.Emit(OpCodes.Brfalse, notDetached);
+        // return 0
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Ret);
+        il.MarkLabel(notDetached);
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ldfld, bufferField);
         il.Emit(OpCodes.Ldlen);
@@ -88,6 +109,25 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ret);
 
         property.SetGetMethod(getter);
+    }
+
+    /// <summary>
+    /// Emits: public void Detach() => _detached = true.
+    /// </summary>
+    private void EmitArrayBufferDetach(TypeBuilder typeBuilder, FieldBuilder detachedField)
+    {
+        var method = typeBuilder.DefineMethod(
+            "Detach",
+            MethodAttributes.Public,
+            _types.Void,
+            Type.EmptyTypes
+        );
+
+        var il = method.GetILGenerator();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Stfld, detachedField);
+        il.Emit(OpCodes.Ret);
     }
 
     /// <summary>

--- a/Compilation/RuntimeEmitter.Worker.cs
+++ b/Compilation/RuntimeEmitter.Worker.cs
@@ -1736,7 +1736,12 @@ public partial class RuntimeEmitter
         il2.Emit(OpCodes.Ret);
         runtime.WorkerThreadsThreadId = threadIdMethod;
 
-        // receiveMessageOnPort
+        // receiveMessageOnPort — main-thread compiled stub. The $MessagePort type is emitted
+        // AFTER this method (EmitMessageChannelTypes runs after EmitRuntimeClass), so this
+        // helper cannot read the port's queue. It returns `undefined` (Node's empty-port
+        // result) rather than null (#1000). Synchronously draining a $MessagePort on the main
+        // thread in compiled mode remains unimplemented (a worker drives receiveMessageOnPort
+        // through the interpreter, which is fully functional).
         var receiveMethod = runtimeType.DefineMethod(
             "WorkerThreadsReceiveMessageOnPort",
             MethodAttributes.Public | MethodAttributes.Static,
@@ -1745,8 +1750,76 @@ public partial class RuntimeEmitter
         );
 
         var il3 = receiveMethod.GetILGenerator();
-        il3.Emit(OpCodes.Ldnull);
+        il3.Emit(OpCodes.Ldsfld, runtime.UndefinedInstance);
         il3.Emit(OpCodes.Ret);
         runtime.WorkerThreadsReceiveMessageOnPort = receiveMethod;
+
+        // getEnvironmentData / setEnvironmentData — route to the C# per-process
+        // WorkerEnvironmentData store via reflection (worker programs co-locate SharpTS.dll;
+        // RequireSharpTSRuntime is recorded at the call sites in WorkerThreadsModuleEmitter so
+        // a program that never calls these stays standalone). #1000.
+        EmitWorkerThreadsEnvironmentData(runtimeType, runtime);
+    }
+
+    /// <summary>
+    /// Emits the getEnvironmentData/setEnvironmentData runtime helpers that reflectively call
+    /// <c>SharpTS.Runtime.Types.WorkerEnvironmentData</c>.
+    /// </summary>
+    private void EmitWorkerThreadsEnvironmentData(TypeBuilder runtimeType, EmittedRuntime runtime)
+    {
+        const string storeType = "SharpTS.Runtime.Types.WorkerEnvironmentData, SharpTS";
+
+        // public static object WorkerThreadsGetEnvironmentData(object key)
+        //   => WorkerEnvironmentData.Get(key)   (null when absent — caller maps to undefined)
+        var getMethod = runtimeType.DefineMethod(
+            "WorkerThreadsGetEnvironmentData",
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.Object,
+            [_types.Object]
+        );
+        var gil = getMethod.GetILGenerator();
+        gil.Emit(OpCodes.Ldstr, storeType);
+        gil.Emit(OpCodes.Call, _types.GetMethod(_types.Type, "GetType", _types.String));
+        gil.Emit(OpCodes.Ldstr, "Get");
+        gil.Emit(OpCodes.Callvirt, _types.GetMethod(_types.Type, "GetMethod", _types.String));
+        gil.Emit(OpCodes.Ldnull); // static method — no instance
+        gil.Emit(OpCodes.Ldc_I4_1);
+        gil.Emit(OpCodes.Newarr, _types.Object);
+        gil.Emit(OpCodes.Dup);
+        gil.Emit(OpCodes.Ldc_I4_0);
+        gil.Emit(OpCodes.Ldarg_0); // key
+        gil.Emit(OpCodes.Stelem_Ref);
+        gil.Emit(OpCodes.Callvirt, _types.GetMethod(_types.MethodBase, "Invoke", _types.Object, _types.ObjectArray));
+        gil.Emit(OpCodes.Ret);
+        runtime.WorkerThreadsGetEnvironmentData = getMethod;
+
+        // public static void WorkerThreadsSetEnvironmentData(object key, object value)
+        //   => WorkerEnvironmentData.Set(key, value)
+        var setMethod = runtimeType.DefineMethod(
+            "WorkerThreadsSetEnvironmentData",
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.Void,
+            [_types.Object, _types.Object]
+        );
+        var sil = setMethod.GetILGenerator();
+        sil.Emit(OpCodes.Ldstr, storeType);
+        sil.Emit(OpCodes.Call, _types.GetMethod(_types.Type, "GetType", _types.String));
+        sil.Emit(OpCodes.Ldstr, "Set");
+        sil.Emit(OpCodes.Callvirt, _types.GetMethod(_types.Type, "GetMethod", _types.String));
+        sil.Emit(OpCodes.Ldnull); // static method — no instance
+        sil.Emit(OpCodes.Ldc_I4_2);
+        sil.Emit(OpCodes.Newarr, _types.Object);
+        sil.Emit(OpCodes.Dup);
+        sil.Emit(OpCodes.Ldc_I4_0);
+        sil.Emit(OpCodes.Ldarg_0); // key
+        sil.Emit(OpCodes.Stelem_Ref);
+        sil.Emit(OpCodes.Dup);
+        sil.Emit(OpCodes.Ldc_I4_1);
+        sil.Emit(OpCodes.Ldarg_1); // value
+        sil.Emit(OpCodes.Stelem_Ref);
+        sil.Emit(OpCodes.Callvirt, _types.GetMethod(_types.MethodBase, "Invoke", _types.Object, _types.ObjectArray));
+        sil.Emit(OpCodes.Pop); // discard Invoke result (Set returns void → null)
+        sil.Emit(OpCodes.Ret);
+        runtime.WorkerThreadsSetEnvironmentData = setMethod;
     }
 }

--- a/Compilation/RuntimeEmitter.Worker.cs
+++ b/Compilation/RuntimeEmitter.Worker.cs
@@ -1821,5 +1821,30 @@ public partial class RuntimeEmitter
         sil.Emit(OpCodes.Pop); // discard Invoke result (Set returns void → null)
         sil.Emit(OpCodes.Ret);
         runtime.WorkerThreadsSetEnvironmentData = setMethod;
+
+        // public static void WorkerThreadsMarkAsUntransferable(object value)
+        //   => StructuredClone.MarkUntransferable(value)   (#1002)
+        var markMethod = runtimeType.DefineMethod(
+            "WorkerThreadsMarkAsUntransferable",
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.Void,
+            [_types.Object]
+        );
+        var mil = markMethod.GetILGenerator();
+        mil.Emit(OpCodes.Ldstr, "SharpTS.Runtime.Types.StructuredClone, SharpTS");
+        mil.Emit(OpCodes.Call, _types.GetMethod(_types.Type, "GetType", _types.String));
+        mil.Emit(OpCodes.Ldstr, "MarkUntransferable");
+        mil.Emit(OpCodes.Callvirt, _types.GetMethod(_types.Type, "GetMethod", _types.String));
+        mil.Emit(OpCodes.Ldnull); // static method — no instance
+        mil.Emit(OpCodes.Ldc_I4_1);
+        mil.Emit(OpCodes.Newarr, _types.Object);
+        mil.Emit(OpCodes.Dup);
+        mil.Emit(OpCodes.Ldc_I4_0);
+        mil.Emit(OpCodes.Ldarg_0); // value
+        mil.Emit(OpCodes.Stelem_Ref);
+        mil.Emit(OpCodes.Callvirt, _types.GetMethod(_types.MethodBase, "Invoke", _types.Object, _types.ObjectArray));
+        mil.Emit(OpCodes.Pop); // discard Invoke result (MarkUntransferable returns void → null)
+        mil.Emit(OpCodes.Ret);
+        runtime.WorkerThreadsMarkAsUntransferable = markMethod;
     }
 }

--- a/Execution/Interpreter.Statements.cs
+++ b/Execution/Interpreter.Statements.cs
@@ -266,6 +266,12 @@ public partial class Interpreter
             // It is not a guest throw, so leave pendingError null.
             blockResult = ExecutionResult.Return(RuntimeValue.FromBoxed(grex.Value));
         }
+        catch (Runtime.Exceptions.WorkerTerminatedException)
+        {
+            // worker.terminate() abort — not a guest throw and not catchable; re-throw ahead of
+            // the generic handler so it unwinds the worker thread to its host loop.
+            throw;
+        }
         catch (Exception ex)
         {
             // Capture host exceptions as pending errors. A re-caught ThrowException is a guest
@@ -480,6 +486,12 @@ public partial class Interpreter
                 }
             }
         }
+        catch (Runtime.Exceptions.WorkerTerminatedException)
+        {
+            // worker.terminate() abort — not catchable by guest code; re-throw ahead of the
+            // generic handler so it unwinds the worker thread.
+            throw;
+        }
         catch (Exception ex)
         {
             // A re-caught ThrowException is a genuine guest throw crossing back through a host
@@ -546,6 +558,12 @@ public partial class Interpreter
                     }
                     return (true, ExecutionResult.Success());
                 }
+                catch (Runtime.Exceptions.WorkerTerminatedException)
+                {
+                    // worker.terminate() abort raised while running a guest catch block —
+                    // re-throw so it unwinds the worker thread instead of being re-caught.
+                    throw;
+                }
                 catch (Exception ex)
                 {
                     object? catchError = ex is ThrowException tex ? tex.Value : ex.Message;
@@ -609,6 +627,12 @@ public partial class Interpreter
             // try. A return is not catchable, so bypass the catch clause and record a Return;
             // the finally block below still runs (ECMA-262 §27.5.3.4).
             pendingResult = ExecutionResult.Return(RuntimeValue.FromBoxed(grex.Value));
+        }
+        catch (Runtime.Exceptions.WorkerTerminatedException)
+        {
+            // worker.terminate() abort — a worker cannot catch its own termination; re-throw
+            // ahead of the guest catch so it unwinds the worker thread (skips this catch/finally).
+            throw;
         }
         catch (Exception ex)
         {
@@ -681,6 +705,12 @@ public partial class Interpreter
                     // propagate as a Return (which runs the enclosing finally) rather than
                     // re-throwing it as a guest error (ECMA-262 §27.5.3.4).
                     return (true, ExecutionResult.Return(RuntimeValue.FromBoxed(grex.Value)));
+                }
+                catch (Runtime.Exceptions.WorkerTerminatedException)
+                {
+                    // worker.terminate() abort raised while running a guest catch block —
+                    // re-throw so it unwinds the worker thread instead of being re-caught.
+                    throw;
                 }
                 catch (Exception ex)
                 {

--- a/Execution/Interpreter.cs
+++ b/Execution/Interpreter.cs
@@ -538,6 +538,23 @@ public partial class Interpreter : IDisposable
     /// </summary>
     public void SetVmTimeoutToken(CancellationToken token) => _vmTimeoutToken = token;
 
+    // Worker-termination support — a worker sets this to its CancellationToken so a
+    // synchronous runtime op that observes it (Atomics.wait) can unwind the worker thread
+    // when worker.terminate() cancels it. Distinct from _vmTimeoutToken so the worker abort
+    // raises a non-catchable WorkerTerminatedException rather than a guest "timed out" throw.
+    private CancellationToken _workerTerminationToken;
+
+    /// <summary>
+    /// Associates this interpreter with the owning worker's cancellation token so blocking
+    /// runtime operations (notably <c>Atomics.wait</c>) can be woken by <c>worker.terminate()</c>.
+    /// </summary>
+    public void SetWorkerTerminationToken(CancellationToken token) => _workerTerminationToken = token;
+
+    /// <summary>
+    /// The owning worker's termination token, or a non-cancelable default on the main thread.
+    /// </summary>
+    public CancellationToken WorkerTerminationToken => _workerTerminationToken;
+
     /// <summary>
     /// Represents a scheduled timer callback that will be executed by the main thread.
     /// </summary>
@@ -1344,6 +1361,12 @@ public partial class Interpreter : IDisposable
             // Always run the event loop - servers/timers may have been registered
             RunEventLoop();
         }
+        catch (Runtime.Exceptions.WorkerTerminatedException)
+        {
+            // worker.terminate() unwound this worker thread — propagate silently (not a
+            // guest error) so SharpTSWorker.WorkerThreadMain emits exit, not error.
+            throw;
+        }
         catch (Exception error)
         {
             Out.WriteLine($"Runtime Error: {error.Message}");
@@ -1500,6 +1523,11 @@ public partial class Interpreter : IDisposable
             // Always run the event loop at the end - servers/timers may have been
             // registered during module execution (even without a main function)
             RunEventLoop();
+        }
+        catch (Runtime.Exceptions.WorkerTerminatedException)
+        {
+            // worker.terminate() unwound this worker thread — propagate silently (see Interpret).
+            throw;
         }
         catch (ThrowException tex)
         {

--- a/Runtime/BuiltIns/Modules/Interpreter/WorkerThreadsModuleInterpreter.cs
+++ b/Runtime/BuiltIns/Modules/Interpreter/WorkerThreadsModuleInterpreter.cs
@@ -72,10 +72,13 @@ public static class WorkerThreadsModuleInterpreter
                 return RuntimeValue.Undefined;
             }),
 
-            // moveMessagePortToContext (not fully implemented - requires VM)
+            // moveMessagePortToContext: not supported. It re-homes a MessagePort into a vm
+            // context's V8 isolate — SharpTS has no per-context isolate model (one process,
+            // shared interpreters), so there is nothing to move a port into (#1004).
             ["moveMessagePortToContext"] = BuiltInMethod.CreateV2("moveMessagePortToContext", 2, (interp, recv, args) =>
             {
-                throw new Exception("moveMessagePortToContext is not supported in SharpTS");
+                throw new Exception(
+                    "moveMessagePortToContext() is not supported in SharpTS: it requires V8 vm contexts/isolates, which SharpTS's single-process threading model does not provide.");
             }),
 
             // getEnvironmentData / setEnvironmentData — a real per-process data store keyed by

--- a/Runtime/BuiltIns/Modules/Interpreter/WorkerThreadsModuleInterpreter.cs
+++ b/Runtime/BuiltIns/Modules/Interpreter/WorkerThreadsModuleInterpreter.cs
@@ -63,11 +63,13 @@ public static class WorkerThreadsModuleInterpreter
             // resourceLimits (not fully implemented)
             ["resourceLimits"] = new SharpTSObject(new Dictionary<string, object?>()),
 
-            // markAsUntransferable (no-op in our implementation)
+            // markAsUntransferable: mark the object so it is cloned (never transferred) if it
+            // appears in a postMessage transfer list (#1002).
             ["markAsUntransferable"] = BuiltInMethod.CreateV2("markAsUntransferable", 1, (interp, recv, args) =>
             {
-                // No-op - we don't track transferability at runtime
-                return RuntimeValue.Null;
+                if (args.Length > 0)
+                    StructuredClone.MarkUntransferable(args[0].ToObject());
+                return RuntimeValue.Undefined;
             }),
 
             // moveMessagePortToContext (not fully implemented - requires VM)

--- a/Runtime/BuiltIns/Modules/Interpreter/WorkerThreadsModuleInterpreter.cs
+++ b/Runtime/BuiltIns/Modules/Interpreter/WorkerThreadsModuleInterpreter.cs
@@ -52,7 +52,9 @@ public static class WorkerThreadsModuleInterpreter
                     CompiledMessagePortBridge bridge => bridge.ReceiveMessageSync(),
                     _ => throw new Exception("receiveMessageOnPort requires a MessagePort argument"),
                 };
-                return RuntimeValue.FromBoxed(result);
+                // Node returns `undefined` (not null) when the port has no queued message;
+                // a present message is wrapped as `{ message }` by ReceiveMessageSync.
+                return result is null ? RuntimeValue.Undefined : RuntimeValue.FromBoxed(result);
             }),
 
             // SHARE_ENV constant (placeholder - we don't support env sharing)
@@ -74,33 +76,26 @@ public static class WorkerThreadsModuleInterpreter
                 throw new Exception("moveMessagePortToContext is not supported in SharpTS");
             }),
 
-            // getEnvironmentData / setEnvironmentData (environment data sharing)
+            // getEnvironmentData / setEnvironmentData — a real per-process data store keyed by
+            // arbitrary values, independent of process.env (#1000).
             ["getEnvironmentData"] = BuiltInMethod.CreateV2("getEnvironmentData", 1, (interp, recv, args) =>
             {
-                // Simple implementation - return from process.env
-                if (args.Length > 0 && args[0].IsString)
-                {
-                    return RuntimeValue.FromBoxed(Environment.GetEnvironmentVariable(args[0].AsStringUnsafe()));
-                }
-                return RuntimeValue.Null;
+                var key = args.Length > 0 ? args[0].ToObject() : null;
+                return WorkerEnvironmentData.TryGet(key, out var value)
+                    ? RuntimeValue.FromBoxed(value)
+                    : RuntimeValue.Undefined;
             }),
 
-            ["setEnvironmentData"] = BuiltInMethod.CreateV2("setEnvironmentData", 2, (interp, recv, args) =>
+            ["setEnvironmentData"] = BuiltInMethod.CreateV2("setEnvironmentData", 1, 2, (interp, recv, args) =>
             {
-                if (args.Length >= 2 && args[0].IsString)
+                if (args.Length >= 1)
                 {
-                    var key = args[0].AsStringUnsafe();
-                    string? value = args[1].ToObject()?.ToString();
-                    if (value != null)
-                    {
-                        Environment.SetEnvironmentVariable(key, value);
-                    }
-                    else
-                    {
-                        Environment.SetEnvironmentVariable(key, null);
-                    }
+                    var key = args[0].ToObject();
+                    // setEnvironmentData(key) with no value (or undefined/null) deletes the key.
+                    var value = args.Length >= 2 ? args[1].ToObject() : null;
+                    WorkerEnvironmentData.Set(key, value);
                 }
-                return RuntimeValue.Null;
+                return RuntimeValue.Undefined;
             }),
         };
     }

--- a/Runtime/Exceptions/WorkerTerminatedException.cs
+++ b/Runtime/Exceptions/WorkerTerminatedException.cs
@@ -1,0 +1,24 @@
+namespace SharpTS.Runtime.Exceptions;
+
+/// <summary>
+/// Control-flow exception representing a <c>worker.terminate()</c> abort injected into a
+/// running worker thread (Node <c>worker_threads</c> semantics).
+/// </summary>
+/// <remarks>
+/// Raised when a worker's <see cref="System.Threading.CancellationToken"/> is cancelled by
+/// <c>Worker.Terminate()</c> while the worker is blocked in a synchronous runtime operation
+/// that observes cancellation (notably <c>Atomics.wait</c>, which otherwise parks the worker
+/// thread in <c>Monitor.Wait(..., Timeout.Infinite)</c> with no way to wake it). The exception
+/// unwinds the worker thread so its host loop reaches its <c>finally</c> — emitting the
+/// <c>exit</c> event and releasing the OS thread — instead of leaking until process exit.
+///
+/// Unlike <see cref="ThrowException"/>, this is NOT a guest <c>throw</c>: it must bypass guest
+/// <c>catch</c> clauses (a worker cannot catch its own termination, matching V8). The
+/// interpreter's block and <c>try</c>/<c>catch</c> executors recognize it and re-throw it ahead
+/// of their generic <c>catch (Exception)</c> handlers — mirroring how
+/// <see cref="GeneratorReturnException"/> bypasses the same frames — so it propagates silently
+/// and uncatchably up to <c>SharpTSWorker.WorkerThreadMain</c>.
+/// </remarks>
+public sealed class WorkerTerminatedException : Exception
+{
+}

--- a/Runtime/Types/SharpTSArrayBuffer.cs
+++ b/Runtime/Types/SharpTSArrayBuffer.cs
@@ -13,14 +13,28 @@ namespace SharpTS.Runtime.Types;
 public class SharpTSArrayBuffer : ITypeCategorized
 {
     private readonly byte[] _data;
+    private bool _detached;
 
     /// <inheritdoc />
     public TypeCategory RuntimeCategory => TypeCategory.Buffer;
 
     /// <summary>
-    /// Gets the size of the buffer in bytes.
+    /// Gets the size of the buffer in bytes. A detached buffer (transferred via
+    /// <c>postMessage</c>'s transfer list) reports 0, matching Node neutering.
     /// </summary>
-    public int ByteLength { get; }
+    public int ByteLength => _detached ? 0 : _data.Length;
+
+    /// <summary>
+    /// Whether this buffer has been detached (its memory transferred away).
+    /// </summary>
+    public bool IsDetached => _detached;
+
+    /// <summary>
+    /// Marks this buffer as detached after its contents were transferred to another
+    /// agent. Subsequent access throws and <see cref="ByteLength"/> reports 0 (Node
+    /// neuters the source ArrayBuffer on transfer).
+    /// </summary>
+    public void Detach() => _detached = true;
 
     /// <summary>
     /// Creates a new ArrayBuffer with the specified byte length.
@@ -33,27 +47,44 @@ public class SharpTSArrayBuffer : ITypeCategorized
             throw new Exception("RangeError: Invalid ArrayBuffer length");
         }
 
-        ByteLength = byteLength;
         _data = new byte[byteLength];
     }
 
     /// <summary>
     /// Gets a span over the entire buffer for direct memory access.
     /// </summary>
-    public Span<byte> AsSpan() => _data.AsSpan();
+    public Span<byte> AsSpan()
+    {
+        ThrowIfDetached();
+        return _data.AsSpan();
+    }
 
     /// <summary>
     /// Gets a span over a portion of the buffer.
     /// </summary>
     /// <param name="start">The starting byte offset.</param>
     /// <param name="length">The number of bytes.</param>
-    public Span<byte> AsSpan(int start, int length) => _data.AsSpan(start, length);
+    public Span<byte> AsSpan(int start, int length)
+    {
+        ThrowIfDetached();
+        return _data.AsSpan(start, length);
+    }
 
     /// <summary>
     /// Gets the underlying byte array for direct access.
     /// Use with caution - prefer AsSpan() for bounds-checked access.
     /// </summary>
-    internal byte[] GetBackingArray() => _data;
+    internal byte[] GetBackingArray()
+    {
+        ThrowIfDetached();
+        return _data;
+    }
+
+    private void ThrowIfDetached()
+    {
+        if (_detached)
+            throw new Exception("TypeError: Cannot perform operation on a detached ArrayBuffer");
+    }
 
     /// <summary>
     /// Creates a new ArrayBuffer containing a copy of a portion of this buffer.
@@ -63,6 +94,7 @@ public class SharpTSArrayBuffer : ITypeCategorized
     /// <returns>A new ArrayBuffer containing the copied bytes.</returns>
     public SharpTSArrayBuffer Slice(int begin, int? end = null)
     {
+        ThrowIfDetached();
         // Handle negative indices
         int actualBegin = begin < 0 ? Math.Max(ByteLength + begin, 0) : Math.Min(begin, ByteLength);
         int actualEnd = end.HasValue

--- a/Runtime/Types/SharpTSAtomics.cs
+++ b/Runtime/Types/SharpTSAtomics.cs
@@ -2,6 +2,7 @@ using System.Collections.Concurrent;
 using System.Numerics;
 using System.Runtime.CompilerServices;
 using SharpTS.Runtime.BuiltIns;
+using SharpTS.Runtime.Exceptions;
 
 namespace SharpTS.Runtime.Types;
 
@@ -62,6 +63,12 @@ public static class SharpTSAtomics
     {
         public readonly object Lock = new();
         public bool Notified;
+
+        /// <summary>
+        /// Set by a worker's CancellationToken when <c>worker.terminate()</c> fires, so a
+        /// parked <c>Monitor.Wait</c> wakes and unwinds the worker thread instead of leaking.
+        /// </summary>
+        public bool Cancelled;
     }
 
     #region Validation
@@ -498,23 +505,47 @@ public static class SharpTSAtomics
     /// Waits until the value at the given position changes from the expected value.
     /// Returns "ok" if notified, "timed-out" if timeout expired, "not-equal" if value doesn't match.
     /// </summary>
-    public static string Wait(SharpTSTypedArray typedArray, int index, object? expectedValue, double? timeout = null)
+    public static string Wait(SharpTSTypedArray typedArray, int index, object? expectedValue, double? timeout = null, CancellationToken cancellationToken = default)
     {
         if (typedArray is SharpTSInt32Array int32Array)
         {
             ValidateSharedInt32Array(typedArray, "wait");
-            return WaitInt32(int32Array, index, (int)Convert.ToDouble(expectedValue), timeout);
+            return WaitInt32(int32Array, index, (int)Convert.ToDouble(expectedValue), timeout, cancellationToken);
         }
         else if (typedArray is SharpTSBigInt64Array bigInt64Array)
         {
             ValidateSharedBigInt64Array(typedArray, "wait");
-            return WaitBigInt64(bigInt64Array, index, ConvertToBigInt64(expectedValue), timeout);
+            return WaitBigInt64(bigInt64Array, index, ConvertToBigInt64(expectedValue), timeout, cancellationToken);
         }
 
         throw new Exception("TypeError: Atomics.wait requires an Int32Array or BigInt64Array");
     }
 
-    private static string WaitInt32(SharpTSInt32Array array, int index, int expectedValue, double? timeout)
+    /// <summary>
+    /// Registers a cancellation hook that wakes <paramref name="entry"/> when the worker's
+    /// token fires (<c>worker.terminate()</c>). Returns a registration the caller disposes.
+    /// Safe against the already-cancelled case: the callback runs synchronously here, before
+    /// the caller takes <c>entry.Lock</c> / parks, and the caller re-checks <c>Cancelled</c>.
+    /// </summary>
+    private static CancellationTokenRegistration RegisterWaitCancellation(WaiterEntry entry, CancellationToken cancellationToken)
+    {
+        if (!cancellationToken.CanBeCanceled)
+            return default;
+
+        return cancellationToken.Register(static state =>
+        {
+            var e = (WaiterEntry)state!;
+            // Monitor.Wait releases e.Lock while parked, so this acquires it, flags the
+            // cancellation, and pulses the parked worker awake.
+            lock (e.Lock)
+            {
+                e.Cancelled = true;
+                Monitor.Pulse(e.Lock);
+            }
+        }, entry);
+    }
+
+    private static string WaitInt32(SharpTSInt32Array array, int index, int expectedValue, double? timeout, CancellationToken cancellationToken)
     {
         ValidateIndex(array, index);
 
@@ -531,6 +562,7 @@ public static class SharpTSAtomics
         var entry = new WaiterEntry();
         waiterList.Add(entry);
 
+        var registration = RegisterWaitCancellation(entry, cancellationToken);
         try
         {
             lock (entry.Lock)
@@ -539,6 +571,10 @@ public static class SharpTSAtomics
                 if (Volatile.Read(ref slot) != expectedValue)
                     return "not-equal";
 
+                // terminate() may have already fired before we registered / parked.
+                if (entry.Cancelled || cancellationToken.IsCancellationRequested)
+                    throw new WorkerTerminatedException();
+
                 int timeoutMs = timeout.HasValue && timeout.Value >= 0
                     ? (int)Math.Min(timeout.Value, int.MaxValue)
                     : Timeout.Infinite;
@@ -546,17 +582,22 @@ public static class SharpTSAtomics
                 if (timeoutMs == 0)
                     return "timed-out";
 
-                bool signaled = Monitor.Wait(entry.Lock, timeoutMs);
+                Monitor.Wait(entry.Lock, timeoutMs);
+
+                if (entry.Cancelled)
+                    throw new WorkerTerminatedException();
+
                 return entry.Notified ? "ok" : "timed-out";
             }
         }
         finally
         {
+            registration.Dispose();
             waiterList.Remove(entry);
         }
     }
 
-    private static string WaitBigInt64(SharpTSBigInt64Array array, int index, long expectedValue, double? timeout)
+    private static string WaitBigInt64(SharpTSBigInt64Array array, int index, long expectedValue, double? timeout, CancellationToken cancellationToken)
     {
         ValidateIndex(array, index);
 
@@ -572,12 +613,16 @@ public static class SharpTSAtomics
         var entry = new WaiterEntry();
         waiterList.Add(entry);
 
+        var registration = RegisterWaitCancellation(entry, cancellationToken);
         try
         {
             lock (entry.Lock)
             {
                 if (Volatile.Read(ref slot) != expectedValue)
                     return "not-equal";
+
+                if (entry.Cancelled || cancellationToken.IsCancellationRequested)
+                    throw new WorkerTerminatedException();
 
                 int timeoutMs = timeout.HasValue && timeout.Value >= 0
                     ? (int)Math.Min(timeout.Value, int.MaxValue)
@@ -586,12 +631,17 @@ public static class SharpTSAtomics
                 if (timeoutMs == 0)
                     return "timed-out";
 
-                bool signaled = Monitor.Wait(entry.Lock, timeoutMs);
+                Monitor.Wait(entry.Lock, timeoutMs);
+
+                if (entry.Cancelled)
+                    throw new WorkerTerminatedException();
+
                 return entry.Notified ? "ok" : "timed-out";
             }
         }
         finally
         {
+            registration.Dispose();
             waiterList.Remove(entry);
         }
     }
@@ -717,12 +767,15 @@ public static class SharpTSAtomics
                 return RuntimeValue.FromBoxed(CompareExchange(arr, (int)args[1].AsNumberUnsafe(), args[2].ToObject(), args[3].ToObject()));
             }),
 
-            "wait" => BuiltInMethod.CreateV2("wait", 3, 4, static (_, _, args) =>
+            "wait" => BuiltInMethod.CreateV2("wait", 3, 4, static (interp, _, args) =>
             {
                 if (args.Length < 3 || args[0].ToObject() is not SharpTSTypedArray arr || !args[1].IsNumber)
                     throw new Exception("Atomics.wait requires a typed array, index, and expected value");
                 double? timeout = args.Length > 3 && args[3].IsNumber ? args[3].AsNumberUnsafe() : null;
-                return RuntimeValue.FromString(Wait(arr, (int)args[1].AsNumberUnsafe(), args[2].ToObject(), timeout));
+                // A worker sets its termination token on the interpreter so terminate() can wake
+                // a parked wait; on the main thread the token is non-cancelable (a no-op).
+                var terminationToken = interp?.WorkerTerminationToken ?? default;
+                return RuntimeValue.FromString(Wait(arr, (int)args[1].AsNumberUnsafe(), args[2].ToObject(), timeout, terminationToken));
             }),
 
             "notify" => BuiltInMethod.CreateV2("notify", 2, 3, static (_, _, args) =>

--- a/Runtime/Types/SharpTSMessagePort.cs
+++ b/Runtime/Types/SharpTSMessagePort.cs
@@ -71,9 +71,12 @@ public class SharpTSMessagePort : SharpTSEventEmitter
     // (postMessage/start/close) resolved as undefined (#209).
 
     /// <summary>
-    /// Represents a cloned message ready for delivery.
+    /// Represents a cloned message ready for delivery. When <paramref name="IsError"/> is
+    /// true the message failed to clone on the sender, and the receiver dispatches a
+    /// <c>'messageerror'</c> event instead of <c>'message'</c> (#1001) — mirroring how the
+    /// receiver, not the sender, surfaces a clone failure in Node.
     /// </summary>
-    internal record ClonedMessage(object? Data, SharpTSArray? Transfer);
+    internal record ClonedMessage(object? Data, SharpTSArray? Transfer, bool IsError = false);
 
     /// <summary>
     /// Sets the partner port for bidirectional communication.
@@ -128,15 +131,21 @@ public class SharpTSMessagePort : SharpTSEventEmitter
         if (_closed)
             return; // Silently ignore messages to closed ports
 
-        // Clone the message
-        var clonedMessage = StructuredClone.Clone(message, transfer);
+        if (_partner == null || _partner._closed)
+            return; // No partner (or a worker port) — subclasses can override
 
-        if (_partner != null && !_partner._closed)
+        // Clone the message. A clone failure surfaces on the RECEIVER as 'messageerror'
+        // (Node delivery model), not as a synchronous throw on the sender (#1001).
+        ClonedMessage delivery;
+        try
         {
-            // Direct delivery to partner port
-            _partner.EnqueueMessage(new ClonedMessage(clonedMessage, transfer));
+            delivery = new ClonedMessage(StructuredClone.Clone(message, transfer), transfer);
         }
-        // If no partner, this might be a worker port - subclasses can override
+        catch (StructuredClone.DataCloneError)
+        {
+            delivery = new ClonedMessage(null, null, IsError: true);
+        }
+        _partner.EnqueueMessage(delivery);
     }
 
     /// <summary>
@@ -227,6 +236,12 @@ public class SharpTSMessagePort : SharpTSEventEmitter
 
         while (_queue.TryTake(out var message))
         {
+            if (message.IsError)
+            {
+                // The sender's clone failed — Node fires 'messageerror' on the receiver.
+                EmitEvent("messageerror", []);
+                continue;
+            }
             // Node worker_threads semantics: 'message' listeners receive the
             // cloned input value of postMessage() directly (not a browser-style
             // MessageEvent wrapper).
@@ -284,7 +299,9 @@ public class SharpTSMessagePort : SharpTSEventEmitter
                 var listener = args[1].ToObject()
                     ?? throw new Exception("Listener must be a function");
                 AddListenerDirect(eventName, listener, once: name == "once");
-                if (eventName == "message")
+                // Attaching a 'message' (or 'messageerror', #1001) listener implicitly
+                // starts the port so queued deliveries flow.
+                if (eventName == "message" || eventName == "messageerror")
                 {
                     OwnerInterpreter ??= interp;
                     Start();

--- a/Runtime/Types/SharpTSReadable.cs
+++ b/Runtime/Types/SharpTSReadable.cs
@@ -301,6 +301,42 @@ public class SharpTSReadable : SharpTSEventEmitter
     }
 
     /// <summary>
+    /// Pushes a chunk into the stream from host (C#) code — used to feed a programmatically
+    /// driven Readable such as a worker's <c>stdout</c>/<c>stderr</c> (#1003). Must be called
+    /// on the stream's owner-loop thread. Emits 'data' when flowing (via the parent interpreter
+    /// when present, or directly for a compiled parent that has no interpreter), otherwise
+    /// buffers until a 'data' listener resumes the stream. Passing null signals EOF ('end').
+    /// </summary>
+    public void PushFromHost(Interp? interpreter, object? chunk)
+    {
+        if (_destroyed)
+            return;
+
+        if (chunk == null)
+        {
+            _ended = true;
+            _readable = false;
+            if (_flowing == true)
+                EmitData(interpreter, "end", null);
+            return;
+        }
+
+        if (_flowing == true)
+            EmitData(interpreter, "data", chunk);
+        else
+            _readBuffer.Enqueue(chunk);
+    }
+
+    private void EmitData(Interp? interpreter, string eventName, object? chunk)
+    {
+        var args = chunk == null ? new List<object?>() : new List<object?> { chunk };
+        if (interpreter != null)
+            EmitEvent(interpreter, eventName, args);
+        else
+            EmitDirect(eventName, args.ToArray());
+    }
+
+    /// <summary>
     /// Pushes data into the stream buffer.
     /// </summary>
     private RuntimeValue Push(Interp interpreter, RuntimeValue receiver, ReadOnlySpan<RuntimeValue> args)

--- a/Runtime/Types/SharpTSWorker.cs
+++ b/Runtime/Types/SharpTSWorker.cs
@@ -4,6 +4,7 @@ using SharpTS.Execution;
 using SharpTS.Modules;
 using SharpTS.Parsing;
 using SharpTS.Runtime.BuiltIns;
+using SharpTS.Runtime.Exceptions;
 using SharpTS.TypeSystem;
 
 namespace SharpTS.Runtime.Types;
@@ -38,6 +39,15 @@ public class SharpTSWorker : SharpTSEventEmitter, IDisposable
     private volatile bool _isTerminated;
     private Exception? _workerError;
     private Interpreter? _parentInterpreter;
+
+    // The worker's own (isolated) interpreter, captured once it starts so terminate()
+    // can Shutdown() its event loop promptly (mirrors SharpTSClusterWorker._workerInterpreter).
+    private volatile Interpreter? _workerInterpreter;
+
+    // Exit code reported via the 'exit' event and the terminate() promise. 0 on clean exit;
+    // 1 on terminate() or an uncaught worker error (Node semantics). Written by the worker
+    // thread's finally; read by Terminate()'s join task — volatile for cross-thread visibility.
+    private volatile int _exitCode;
 
     // Event-loop keep-alive accounting against the parent interpreter. Node keeps
     // the parent process alive for a running Worker's lifetime by default;
@@ -252,18 +262,39 @@ public class SharpTSWorker : SharpTSEventEmitter, IDisposable
     /// </summary>
     private void WorkerThreadMain()
     {
+        int exitCode = 0;
         try
         {
             RunWorkerScript();
+
+            // A guest-level uncaught error is printed by the interpreter and surfaced via
+            // LastUncaughtError rather than thrown back here; Node exits such a worker with 1.
+            if (_workerInterpreter?.LastUncaughtError != null)
+                exitCode = 1;
+        }
+        catch (WorkerTerminatedException)
+        {
+            // terminate() unwound the worker (e.g. out of a parked Atomics.wait). This is an
+            // abort, not an error — Node emits 'exit' with code 1 and no 'error' event.
+            exitCode = 1;
         }
         catch (Exception ex)
         {
             _workerError = ex;
-            // Emit error on parent thread
-            EnqueueErrorToParent(ex);
+            // A terminated worker must not surface an 'error' event; a genuine uncaught
+            // host error must.
+            if (!_isTerminated)
+                EnqueueErrorToParent(ex);
+            exitCode = 1;
         }
         finally
         {
+            // terminate() always yields exit code 1 even if the worker happened to unwind
+            // through a clean path (e.g. event loop stopped by Shutdown()).
+            if (_isTerminated)
+                exitCode = 1;
+            _exitCode = exitCode;
+
             _isRunning = false;
             _parentToWorkerQueue.CompleteAdding();
             _workerToParentQueue.CompleteAdding();
@@ -275,7 +306,7 @@ public class SharpTSWorker : SharpTSEventEmitter, IDisposable
             ReleaseRunningRef();
 
             // Notify parent that worker has exited
-            EnqueueExitToParent(0);
+            EnqueueExitToParent(exitCode);
         }
     }
 
@@ -295,6 +326,11 @@ public class SharpTSWorker : SharpTSEventEmitter, IDisposable
 
         // Create isolated interpreter for this worker
         using var interpreter = new Interpreter();
+
+        // Expose this worker to terminate(): Shutdown() stops an idle event loop, and the
+        // termination token lets a parked Atomics.wait unwind the thread (#997).
+        _workerInterpreter = interpreter;
+        interpreter.SetWorkerTerminationToken(_cts.Token);
 
         // Set up worker globals
         SetupWorkerGlobals(interpreter);
@@ -630,6 +666,12 @@ public class SharpTSWorker : SharpTSEventEmitter, IDisposable
         _cts.Cancel();
         _parentToWorkerQueue.CompleteAdding();
 
+        // Stop an idle/event-loop worker cooperatively at its next blocking point instead of
+        // waiting out the 5s join (mirrors SharpTSClusterWorker Kill/Disconnect). A worker
+        // parked in Atomics.wait is woken by the _cts cancellation hook installed in
+        // SharpTSAtomics; a worker in a tight native call is the documented .NET ceiling.
+        _workerInterpreter?.Shutdown();
+
         // The worker is being torn down — drop its running keep-alive Ref now
         // rather than waiting for the worker thread's finally, so the only loop
         // keep-alive from here is the bounded join Ref below. Idempotent with the
@@ -648,7 +690,11 @@ public class SharpTSWorker : SharpTSEventEmitter, IDisposable
         var task = Task.Run<object?>(() =>
         {
             _thread.Join(5000); // Wait up to 5 seconds
-            return (double)0;
+            // Resolve with the worker's actual exit code (1 once the thread unwinds via
+            // terminate; the worker's finally sets _exitCode before the thread ends, so it is
+            // visible here). If a tight native loop outlasts the join, this stays 0 — the
+            // documented ceiling.
+            return (double)_exitCode;
         });
         if (_loopRef != null && loopUnref != null)
         {

--- a/Runtime/Types/SharpTSWorker.cs
+++ b/Runtime/Types/SharpTSWorker.cs
@@ -57,6 +57,10 @@ public class SharpTSWorker : SharpTSEventEmitter, IDisposable
     private readonly SharpTSReadable? _stderr;
     private readonly object? _resourceLimits;
 
+    // Wall-clock start, used for the best-effort worker.performance.eventLoopUtilization()
+    // (#1004) — SharpTS has no precise idle/active loop accounting.
+    private readonly long _startTick = Environment.TickCount64;
+
     // Event-loop keep-alive accounting against the parent interpreter. Node keeps
     // the parent process alive for a running Worker's lifetime by default;
     // worker.unref() opts out and worker.ref() opts back in. Without this, a
@@ -865,6 +869,29 @@ public class SharpTSWorker : SharpTSEventEmitter, IDisposable
             "stderr" => _stderr is not null ? (object?)_stderr : null,
             "stdin" => null,
             "resourceLimits" => _resourceLimits ?? new SharpTSObject(new Dictionary<string, object?>()),
+
+            // #1004 introspection. getHeapSnapshot has no .NET equivalent (V8 snapshot format) —
+            // a clear error beats "undefined is not a function". performance offers a best-effort
+            // eventLoopUtilization (SharpTS lacks precise idle/active loop accounting).
+            "getHeapSnapshot" => BuiltInMethod.CreateV2("getHeapSnapshot", 0, 1, (_, _, _) =>
+                throw new Exception(
+                    "worker.getHeapSnapshot() is not supported in SharpTS: a V8-format heap snapshot has no .NET equivalent.")),
+
+            "performance" => new SharpTSObject(new Dictionary<string, object?>
+            {
+                ["eventLoopUtilization"] = BuiltInMethod.CreateV2("eventLoopUtilization", 0, 2, (_, _, _) =>
+                {
+                    // Best-effort: treat the worker as active for its whole lifetime (no idle
+                    // accounting). `active` is wall-clock ms since the worker was created.
+                    double active = Math.Max(0, Environment.TickCount64 - _startTick);
+                    return RuntimeValue.FromObject(new SharpTSObject(new Dictionary<string, object?>
+                    {
+                        ["idle"] = 0.0,
+                        ["active"] = active,
+                        ["utilization"] = 1.0,
+                    }));
+                }),
+            }),
 
             "postMessage" => BuiltInMethod.CreateV2("postMessage", 1, 2, (_, _, args) =>
             {

--- a/Runtime/Types/SharpTSWorker.cs
+++ b/Runtime/Types/SharpTSWorker.cs
@@ -495,8 +495,18 @@ public class SharpTSWorker : SharpTSEventEmitter, IDisposable
 
         try
         {
-            var cloned = StructuredClone.Clone(message, transfer);
-            _workerToParentQueue.Add(new SharpTSMessagePort.ClonedMessage(cloned, transfer));
+            // A clone failure is delivered to the parent Worker as 'messageerror' (Node's
+            // receiver-side model), not thrown back into the worker's postMessage (#1001).
+            SharpTSMessagePort.ClonedMessage delivery;
+            try
+            {
+                delivery = new SharpTSMessagePort.ClonedMessage(StructuredClone.Clone(message, transfer), transfer);
+            }
+            catch (StructuredClone.DataCloneError)
+            {
+                delivery = new SharpTSMessagePort.ClonedMessage(null, null, IsError: true);
+            }
+            _workerToParentQueue.Add(delivery);
 
             // Schedule delivery on the parent thread. Routed through
             // ScheduleOnMainThread so compiled mode (no parent interpreter) marshals
@@ -504,10 +514,6 @@ public class SharpTSWorker : SharpTSEventEmitter, IDisposable
             // _parentInterpreter?.ScheduleTimer here would silently drop every worker
             // message in compiled programs (#354).
             ScheduleOnMainThread(DeliverMessagesToParent);
-        }
-        catch (StructuredClone.DataCloneError e)
-        {
-            throw new Exception($"Failed to clone message: {e.Message}");
         }
         catch (InvalidOperationException)
         {
@@ -523,6 +529,14 @@ public class SharpTSWorker : SharpTSEventEmitter, IDisposable
     {
         while (_workerToParentQueue.TryTake(out var message))
         {
+            if (message.IsError)
+            {
+                // The worker's postMessage value failed to clone — fire 'messageerror' on
+                // the parent Worker instead of 'message' (#1001).
+                EmitEventOnMainThread("messageerror");
+                continue;
+            }
+
             var eventData = new SharpTSObject(new Dictionary<string, object?>
             {
                 ["data"] = message.Data
@@ -672,12 +686,18 @@ public class SharpTSWorker : SharpTSEventEmitter, IDisposable
 
         try
         {
-            var cloned = StructuredClone.Clone(message, transfer);
-            _parentToWorkerQueue.Add(new SharpTSMessagePort.ClonedMessage(cloned, transfer));
-        }
-        catch (StructuredClone.DataCloneError e)
-        {
-            throw new Exception($"Failed to clone message: {e.Message}");
+            // A clone failure is delivered to the worker's parentPort as 'messageerror'
+            // (Node's receiver-side model), not thrown back to the parent's postMessage (#1001).
+            SharpTSMessagePort.ClonedMessage delivery;
+            try
+            {
+                delivery = new SharpTSMessagePort.ClonedMessage(StructuredClone.Clone(message, transfer), transfer);
+            }
+            catch (StructuredClone.DataCloneError)
+            {
+                delivery = new SharpTSMessagePort.ClonedMessage(null, null, IsError: true);
+            }
+            _parentToWorkerQueue.Add(delivery);
         }
         catch (InvalidOperationException)
         {
@@ -921,18 +941,25 @@ internal class WorkerMessageHandler
 
             try
             {
-                // Get the parentPort and emit message event
+                // Get the parentPort and emit the message (or messageerror) event
                 if (_interpreter.Environment.TryGet("parentPort", out var portRV) &&
                     portRV.ToObject() is WorkerParentPort parentPort)
                 {
-                    var eventData = new SharpTSObject(new Dictionary<string, object?>
-                    {
-                        ["data"] = message.Data
-                    });
-
-                    // Emit on parentPort
                     var emitMethod = parentPort.GetMember("emit") as BuiltInMethod;
-                    emitMethod?.Call(_interpreter, ["message", eventData]);
+                    if (message.IsError)
+                    {
+                        // The parent's postMessage value failed to clone — fire 'messageerror'
+                        // on the worker's parentPort instead of 'message' (#1001).
+                        emitMethod?.Call(_interpreter, ["messageerror"]);
+                    }
+                    else
+                    {
+                        var eventData = new SharpTSObject(new Dictionary<string, object?>
+                        {
+                            ["data"] = message.Data
+                        });
+                        emitMethod?.Call(_interpreter, ["message", eventData]);
+                    }
                 }
             }
             catch (Exception ex)

--- a/Runtime/Types/SharpTSWorker.cs
+++ b/Runtime/Types/SharpTSWorker.cs
@@ -49,6 +49,14 @@ public class SharpTSWorker : SharpTSEventEmitter, IDisposable
     // thread's finally; read by Terminate()'s join task — volatile for cross-thread visibility.
     private volatile int _exitCode;
 
+    // Per-worker stdio + resourceLimits (#1003). When `stdout`/`stderr: true`, the worker's
+    // console output is diverted off the shared Console into these Readable streams (exposed as
+    // worker.stdout/worker.stderr) instead of the parent's stdout. resourceLimits is stored and
+    // echoed on worker.resourceLimits — .NET cannot enforce V8 heap/stack sizing (epic ceiling).
+    private readonly SharpTSReadable? _stdout;
+    private readonly SharpTSReadable? _stderr;
+    private readonly object? _resourceLimits;
+
     // Event-loop keep-alive accounting against the parent interpreter. Node keeps
     // the parent process alive for a running Worker's lifetime by default;
     // worker.unref() opts out and worker.ref() opts back in. Without this, a
@@ -135,30 +143,32 @@ public class SharpTSWorker : SharpTSEventEmitter, IDisposable
         // Capture sync context for compiled code to marshal callbacks to main thread
         _syncContext = SynchronizationContext.Current;
 
-        // Extract options. Only workerData and transferList are honored: the worker
-        // runs an isolated interpreter on a dedicated thread in this same process, so
-        // the worker's console output already shares the parent's stdout/stderr by
-        // default. The Node stdio options (stdin/stdout/stderr) and resourceLimits are
-        // intentionally NOT supported:
-        //   - stdin/stdout/stderr=true would have to expose per-worker Readable/Writable
-        //     streams and divert the worker off the shared (process-global) Console,
-        //     which is not thread-safe in a single-process model.
-        //   - resourceLimits maps to V8 heap/stack sizing (maxOldGenerationSizeMb, …)
-        //     for which the .NET runtime exposes no per-thread equivalent.
-        // They are not read here (rather than read-and-ignored) so the dead fields can't
-        // masquerade as support. See issue #407.
+        // Extract options. The worker runs an isolated interpreter on a dedicated thread in
+        // this same process, so by default its console output shares the parent's Console.
+        //
+        // stdout/stderr: true (#1003) diverts the worker's console output off the shared
+        // Console into per-worker Readable streams (worker.stdout/worker.stderr); each chunk
+        // is marshalled onto the parent loop before delivery (the streams are only touched on
+        // the parent's thread). resourceLimits is stored and echoed on worker.resourceLimits —
+        // .NET exposes no per-thread V8 heap/stack sizing, so it cannot be enforced (#407 ceiling).
+        // stdin remains unsupported (no parent→worker process.stdin bridge yet).
         //
         // The bag is a SharpTSObject in interpreter mode and a Dictionary<string, object?>
         // (a compiled object literal) in compiled mode; ReadOption reads through both so
-        // workerData/transferList are honored either way (#380). transferList is read as
-        // IEnumerable<object?> so both the interpreter SharpTSArray and a compiled
-        // List<object?> survive — a transferred MessagePort is then adopted by the worker
-        // (cross-thread for interpreter ports, via CompiledMessagePortBridge for compiled
-        // $MessagePort) inside StructuredClone.Clone (#406).
+        // options are honored either way (#380). transferList is read as IEnumerable<object?>
+        // so both the interpreter SharpTSArray and a compiled List<object?> survive — a
+        // transferred MessagePort is then adopted by the worker (cross-thread for interpreter
+        // ports, via CompiledMessagePortBridge for compiled $MessagePort) inside
+        // StructuredClone.Clone (#406).
         if (options != null)
         {
             _workerData = ReadOption(options, "workerData");
             _transferList = ReadOption(options, "transferList") as IEnumerable<object?>;
+            _resourceLimits = ReadOption(options, "resourceLimits");
+            if (ReadOption(options, "stdout") is true)
+                _stdout = new SharpTSReadable();
+            if (ReadOption(options, "stderr") is true)
+                _stderr = new SharpTSReadable();
         }
 
         // Clone workerData for transfer to worker
@@ -205,12 +215,19 @@ public class SharpTSWorker : SharpTSEventEmitter, IDisposable
     /// mode (#380). Returns null when the property is absent or the bag is an
     /// unsupported shape (e.g. a compiled options literal that uses accessors).
     /// </summary>
-    private static object? ReadOption(object? options, string name) => options switch
+    private static object? ReadOption(object? options, string name)
     {
-        SharpTSObject obj => obj.GetProperty(name),
-        IDictionary<string, object?> dict => dict.TryGetValue(name, out var v) ? v : null,
-        _ => null,
-    };
+        object? value = options switch
+        {
+            SharpTSObject obj => obj.GetProperty(name),
+            IDictionary<string, object?> dict => dict.TryGetValue(name, out var v) ? v : null,
+            _ => null,
+        };
+        // A missing SharpTSObject property reads as `undefined`, not null — normalize it so an
+        // absent option is treated as truly absent (e.g. omitting workerData while passing
+        // stdout/resourceLimits must not try to clone `undefined`).
+        return value is SharpTSUndefined ? null : value;
+    }
 
     /// <summary>
     /// Factory used by compiled output to construct a worker whose running-lifetime
@@ -299,6 +316,13 @@ public class SharpTSWorker : SharpTSEventEmitter, IDisposable
             _parentToWorkerQueue.CompleteAdding();
             _workerToParentQueue.CompleteAdding();
 
+            // Signal end-of-stream on the diverted stdio Readables (#1003). Scheduled after the
+            // data pushes (FIFO on the parent loop) so 'end' follows the last 'data'.
+            if (_stdout != null)
+                ScheduleOnMainThread(() => _stdout.PushFromHost(_parentInterpreter, null));
+            if (_stderr != null)
+                ScheduleOnMainThread(() => _stderr.PushFromHost(_parentInterpreter, null));
+
             // Worker is done — stop keeping the parent loop alive (Node unrefs an
             // exited worker). Released before the exit event is enqueued so the
             // parent's only remaining work is that event's delivery timer, which
@@ -324,8 +348,12 @@ public class SharpTSWorker : SharpTSEventEmitter, IDisposable
 
         string source = File.ReadAllText(absolutePath);
 
-        // Create isolated interpreter for this worker
-        using var interpreter = new Interpreter();
+        // Create isolated interpreter for this worker. With stdout/stderr: true, divert the
+        // worker's console output into the per-worker Readable streams instead of the shared
+        // Console (#1003); otherwise keep the default Console writers.
+        TextWriter outWriter = _stdout != null ? new WorkerStreamWriter(this, _stdout) : Console.Out;
+        TextWriter errWriter = _stderr != null ? new WorkerStreamWriter(this, _stderr) : Console.Error;
+        using var interpreter = new Interpreter(outWriter, errWriter);
 
         // Expose this worker to terminate(): Shutdown() stops an idle event loop, and the
         // termination token lets a parked Atomics.wait unwind the thread (#997).
@@ -643,6 +671,34 @@ public class SharpTSWorker : SharpTSEventEmitter, IDisposable
     }
 
     /// <summary>
+    /// Feeds a chunk of the worker's diverted console output into a worker.stdout/worker.stderr
+    /// Readable (#1003). Called on the worker thread by <see cref="WorkerStreamWriter"/>; the
+    /// push is marshalled onto the parent loop so the stream is only ever touched — and 'data'
+    /// delivered — on the parent's thread (no cross-thread access to the stream's state).
+    /// </summary>
+    private void PushToWorkerStream(SharpTSReadable target, string text)
+    {
+        ScheduleOnMainThread(() => target.PushFromHost(_parentInterpreter, text));
+    }
+
+    /// <summary>
+    /// A <see cref="TextWriter"/> that redirects the worker interpreter's console output into a
+    /// per-worker Readable stream instead of the shared Console (worker stdout/stderr, #1003).
+    /// </summary>
+    private sealed class WorkerStreamWriter(SharpTSWorker worker, SharpTSReadable target) : TextWriter
+    {
+        public override System.Text.Encoding Encoding => System.Text.Encoding.UTF8;
+        public override void Write(string? value) => Push(value);
+        public override void WriteLine(string? value) => Push((value ?? string.Empty) + Environment.NewLine);
+        public override void Write(char value) => Push(value.ToString());
+        private void Push(string? text)
+        {
+            if (!string.IsNullOrEmpty(text))
+                worker.PushToWorkerStream(target, text);
+        }
+    }
+
+    /// <summary>
     /// Processes any pending callbacks queued for the main thread.
     /// Call this periodically from the main thread in console applications
     /// to receive Worker messages and events.
@@ -800,6 +856,15 @@ public class SharpTSWorker : SharpTSEventEmitter, IDisposable
         return name switch
         {
             "threadId" => ThreadId,
+
+            // #1003: per-worker stdio + resourceLimits. stdout/stderr are Readable streams when
+            // `stdout`/`stderr: true` was passed (else null, matching the no-pipe default).
+            // resourceLimits echoes the passed object (stored, not enforced). stdin is not
+            // supported (no parent→worker process.stdin bridge) — null.
+            "stdout" => _stdout is not null ? (object?)_stdout : null,
+            "stderr" => _stderr is not null ? (object?)_stderr : null,
+            "stdin" => null,
+            "resourceLimits" => _resourceLimits ?? new SharpTSObject(new Dictionary<string, object?>()),
 
             "postMessage" => BuiltInMethod.CreateV2("postMessage", 1, 2, (_, _, args) =>
             {

--- a/Runtime/Types/SharpTSWorker.cs
+++ b/Runtime/Types/SharpTSWorker.cs
@@ -339,6 +339,12 @@ public class SharpTSWorker : SharpTSEventEmitter, IDisposable
         var messageHandler = new WorkerMessageHandler(this, interpreter);
         messageHandler.Start();
 
+        // The worker environment is ready and user JS is about to run — Node emits 'online'
+        // here. Scheduled before any user code so it always precedes the worker's first
+        // 'message'. Not emitted on an earlier failure (e.g. missing script) — the worker
+        // never came online (#998).
+        EnqueueOnlineToParent();
+
         try
         {
             // A worker whose script uses import/export must run through the same
@@ -527,6 +533,16 @@ public class SharpTSWorker : SharpTSEventEmitter, IDisposable
     }
 
     /// <summary>
+    /// Enqueues the 'online' event (Node emits it once the worker's JS starts executing).
+    /// Carries no payload, matching Node. Scheduled before the worker runs any user code so
+    /// it is always delivered ahead of the worker's first 'message'.
+    /// </summary>
+    private void EnqueueOnlineToParent()
+    {
+        ScheduleOnMainThread(() => EmitEventOnMainThread("online"));
+    }
+
+    /// <summary>
     /// Enqueues an error event to be delivered to the parent.
     /// </summary>
     private void EnqueueErrorToParent(Exception ex)
@@ -592,6 +608,23 @@ public class SharpTSWorker : SharpTSEventEmitter, IDisposable
         {
             // Compiled path - use direct emit
             EmitDirect(eventName, data);
+        }
+    }
+
+    /// <summary>
+    /// Emits an event with no payload (e.g. 'online') so listeners receive zero arguments,
+    /// matching Node — rather than a spurious trailing null/undefined.
+    /// </summary>
+    private void EmitEventOnMainThread(string eventName)
+    {
+        if (_parentInterpreter != null)
+        {
+            var emitMethod = GetMember("emit") as BuiltInMethod;
+            emitMethod?.Call(_parentInterpreter, [eventName]);
+        }
+        else
+        {
+            EmitDirect(eventName);
         }
     }
 

--- a/Runtime/Types/StructuredClone.cs
+++ b/Runtime/Types/StructuredClone.cs
@@ -1,4 +1,5 @@
 using System.Numerics;
+using System.Runtime.CompilerServices;
 
 namespace SharpTS.Runtime.Types;
 
@@ -22,6 +23,21 @@ public static class StructuredClone
     {
         public DataCloneError(string message) : base($"DataCloneError: {message}") { }
     }
+
+    // Objects marked via worker_threads.markAsUntransferable. When such an object appears in a
+    // postMessage transfer list it is IGNORED (cloned in the payload instead of transferred),
+    // matching Node (#1002). Reference-keyed and weak so marking does not pin the object.
+    private static readonly ConditionalWeakTable<object, object> _untransferable = new();
+
+    /// <summary>Marks <paramref name="value"/> so it is never transferred (only cloned).</summary>
+    public static void MarkUntransferable(object? value)
+    {
+        if (value != null)
+            _untransferable.AddOrUpdate(value, value);
+    }
+
+    /// <summary>Whether <paramref name="value"/> was marked via <see cref="MarkUntransferable"/>.</summary>
+    public static bool IsUntransferable(object value) => _untransferable.TryGetValue(value, out _);
 
     /// <summary>
     /// Clones a value using the structured clone algorithm.
@@ -50,6 +66,13 @@ public static class StructuredClone
         {
             foreach (var item in transfer)
             {
+                // markAsUntransferable: a marked object in the transfer list is ignored — it is
+                // cloned in the payload instead of transferred (Node semantics, #1002).
+                if (item != null && IsUntransferable(item))
+                {
+                    continue;
+                }
+
                 if (item is SharpTSMessagePort || CompiledMessagePortBridge.IsEmittedMessagePort(item))
                 {
                     transferred.Add(item!);
@@ -291,6 +314,13 @@ public static class StructuredClone
         // one object. Instead mark it and its partner cross-thread: each port then
         // marshals delivery onto its own owner-loop thread and a started port keeps
         // that loop alive (#406).
+        //
+        // #1002 DECISION: SharpTS does NOT neuter the source MessagePort on transfer.
+        // This is an intentional, documented deviation from Node — SharpTS's single-process
+        // two-thread model shares one port object across both threads (unlike V8's separate
+        // serialize/deserialize), so neutering the sender would neuter the receiver too. The
+        // markAsUntransferable + ArrayBuffer-detach paths (#999/#1002) are spec-faithful;
+        // only this port-neuter case is the model-dictated exception.
         port.MarkTransferredAcrossThreads();
         return port;
     }

--- a/Runtime/Types/StructuredClone.cs
+++ b/Runtime/Types/StructuredClone.cs
@@ -38,9 +38,14 @@ public static class StructuredClone
     {
         var cloned = new Dictionary<object, object>();
         var transferred = new HashSet<object>();
+        // ArrayBuffers in the transfer list are detached on this (sender) side after the
+        // clone — Node neuters a transferred ArrayBuffer (byteLength becomes 0). Collected
+        // separately because detach must happen AFTER the payload is copied.
+        List<object>? transferredBuffers = null;
 
-        // Process transfer list. A transferable is either the interpreter
-        // SharpTSMessagePort or the emitted compiled $MessagePort (#406).
+        // Process transfer list. Transferables are MessagePort (interpreter
+        // SharpTSMessagePort or the emitted compiled $MessagePort, #406) and ArrayBuffer
+        // (interpreter SharpTSArrayBuffer or the emitted compiled $ArrayBuffer, #999).
         if (transfer != null)
         {
             foreach (var item in transfer)
@@ -49,15 +54,47 @@ public static class StructuredClone
                 {
                     transferred.Add(item!);
                 }
+                else if (item is SharpTSArrayBuffer || item?.GetType().Name == "$ArrayBuffer")
+                {
+                    transferred.Add(item!);
+                    (transferredBuffers ??= new List<object>()).Add(item!);
+                }
                 else if (item != null)
                 {
-                    // Only MessagePort is transferable in our implementation
-                    throw new DataCloneError("Only MessagePort objects can be transferred");
+                    throw new DataCloneError("Only ArrayBuffer and MessagePort objects can be transferred");
                 }
             }
         }
 
-        return CloneInternal(value, cloned, transferred);
+        var result = CloneInternal(value, cloned, transferred);
+
+        // Neuter the source ArrayBuffers now that their contents have been copied to the
+        // clone. A buffer in the transfer list is detached whether or not it appeared in
+        // the payload (Node semantics).
+        if (transferredBuffers != null)
+        {
+            foreach (var buffer in transferredBuffers)
+                DetachArrayBuffer(buffer);
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Detaches a transferred ArrayBuffer on the sender side: the interpreter
+    /// <see cref="SharpTSArrayBuffer"/> directly, or the emitted compiled <c>$ArrayBuffer</c>
+    /// via its <c>Detach()</c> method (reflection keeps this assembly standalone-agnostic).
+    /// </summary>
+    private static void DetachArrayBuffer(object buffer)
+    {
+        if (buffer is SharpTSArrayBuffer interpBuffer)
+        {
+            interpBuffer.Detach();
+        }
+        else if (buffer.GetType().Name == "$ArrayBuffer")
+        {
+            buffer.GetType().GetMethod("Detach")?.Invoke(buffer, null);
+        }
     }
 
     private static object? CloneInternal(object? value, Dictionary<object, object> cloned, HashSet<object> transferred)
@@ -78,6 +115,11 @@ public static class StructuredClone
         {
             // SharedArrayBuffer - pass by reference (this is the key sharing mechanism!)
             SharpTSSharedArrayBuffer sab => sab,
+
+            // ArrayBuffer (non-shared) - copy the bytes into an independent buffer. When the
+            // source is in the transfer list it is detached afterwards by Clone() (#999); the
+            // receiver always gets its own copy (no cross-thread aliasing of a mutable buffer).
+            SharpTSArrayBuffer arrayBuffer => CloneArrayBuffer(arrayBuffer, cloned),
 
             // TypedArray - recreate view, share backing if SharedArrayBuffer
             SharpTSTypedArray typedArray => CloneTypedArray(typedArray, cloned, transferred),
@@ -433,6 +475,14 @@ public static class StructuredClone
         return new SharpTSBuffer(newData);
     }
 
+    private static SharpTSArrayBuffer CloneArrayBuffer(SharpTSArrayBuffer source, Dictionary<object, object> cloned)
+    {
+        var result = new SharpTSArrayBuffer(source.ByteLength);
+        source.AsSpan().CopyTo(result.AsSpan());
+        cloned[source] = result;
+        return result;
+    }
+
     /// <summary>
     /// Clones an emitted $ArrayBuffer type from compiled code.
     /// Uses reflection to access the buffer and create a new instance.
@@ -504,6 +554,7 @@ public static class StructuredClone
         switch (value)
         {
             case SharpTSSharedArrayBuffer:
+            case SharpTSArrayBuffer:
             case SharpTSDate:
             case SharpTSRegExp:
             case SharpTSError:

--- a/Runtime/Types/WorkerEnvironmentData.cs
+++ b/Runtime/Types/WorkerEnvironmentData.cs
@@ -1,0 +1,66 @@
+namespace SharpTS.Runtime.Types;
+
+/// <summary>
+/// Process-global store backing <c>worker_threads.getEnvironmentData</c> /
+/// <c>setEnvironmentData</c>.
+/// </summary>
+/// <remarks>
+/// Node keeps an internal environment-data Map keyed by arbitrary values, independent of
+/// <c>process.env</c>. SharpTS previously routed these to <c>process.env</c>
+/// (<c>Environment.Get/SetEnvironmentVariable</c>), which only supports string keys/values
+/// and leaks into the OS environment. This store is a real per-process Map keyed by arbitrary
+/// values; because a worker child runs in the same process under its own interpreter, a value
+/// set on the parent is visible to the worker through this shared store (Node snapshots a copy
+/// into each worker at spawn — SharpTS shares the store live, an observable equivalence for
+/// data set before the worker reads it).
+///
+/// Values are deep-copied on set (structured clone) so a stored object is independent of the
+/// caller's reference, matching Node. Setting a value of <c>null</c>/<c>undefined</c> removes
+/// the key (Node deletes it), so an absent key reads back as <c>undefined</c>.
+/// </remarks>
+public static class WorkerEnvironmentData
+{
+    private static readonly object _gate = new();
+    private static readonly Dictionary<object, object?> _data = new();
+
+    // Stand-in for a null/undefined key, which a Dictionary cannot store directly.
+    private static readonly object _nullKey = new();
+
+    /// <summary>
+    /// Stores <paramref name="value"/> under <paramref name="key"/>. A null value removes the
+    /// key (Node treats <c>setEnvironmentData(key, undefined)</c> as a delete).
+    /// </summary>
+    public static void Set(object? key, object? value)
+    {
+        var k = key ?? _nullKey;
+        lock (_gate)
+        {
+            if (value is null)
+                _data.Remove(k);
+            else
+                _data[k] = StructuredClone.Clone(value);
+        }
+    }
+
+    /// <summary>
+    /// Reads the value stored under <paramref name="key"/>. Returns true and the value when
+    /// present; false (and null) when absent, so callers can surface <c>undefined</c>.
+    /// </summary>
+    public static bool TryGet(object? key, out object? value)
+    {
+        var k = key ?? _nullKey;
+        lock (_gate)
+            return _data.TryGetValue(k, out value);
+    }
+
+    /// <summary>
+    /// Reads the value stored under <paramref name="key"/>, or null when absent. Convenience
+    /// for the compiled emit path, which has no out-parameter calling convention.
+    /// </summary>
+    public static object? Get(object? key)
+    {
+        var k = key ?? _nullKey;
+        lock (_gate)
+            return _data.TryGetValue(k, out var value) ? value : null;
+    }
+}

--- a/SharpTS.Tests/SharedTests/WorkerThreadsTests.cs
+++ b/SharpTS.Tests/SharedTests/WorkerThreadsTests.cs
@@ -771,6 +771,96 @@ public class WorkerThreadsTests
 
     #endregion
 
+    #region introspection (#1004)
+
+    /// <summary>
+    /// #1004: <c>worker.performance.eventLoopUtilization()</c> returns a best-effort
+    /// <c>{ idle, active, utilization }</c> object (SharpTS has no precise idle/active loop
+    /// accounting). Dual-mode.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Worker_Performance_EventLoopUtilization_ReturnsShape(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["worker_ok.ts"] = """
+                postMessage("ok");
+                """,
+            ["main.ts"] = """
+                import { Worker } from "worker_threads";
+                const w: any = new Worker(__dirname + "/worker_ok.ts", { workerData: "go" });
+                const elu: any = w.performance.eventLoopUtilization();
+                console.log("elu:" + typeof elu.idle + "," + typeof elu.active + "," + typeof elu.utilization);
+                w.on("message", (e: any) => { console.log("worker:" + e.data); });
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Contains("elu:number,number,number", output);
+        Assert.Contains("worker:ok", output);
+    }
+
+    /// <summary>
+    /// #1004: <c>worker.getHeapSnapshot()</c> throws a clear "not supported" error — a
+    /// V8-format heap snapshot has no .NET equivalent (epic ceiling). Dual-mode.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Worker_GetHeapSnapshot_ThrowsClearError(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["worker_ok.ts"] = """
+                postMessage("ok");
+                """,
+            ["main.ts"] = """
+                import { Worker } from "worker_threads";
+                const w: any = new Worker(__dirname + "/worker_ok.ts", { workerData: "go" });
+                try {
+                    w.getHeapSnapshot();
+                    console.log("no-throw");
+                } catch (e: any) {
+                    console.log("heap-err:" + (("" + (e && e.message ? e.message : e)).indexOf("not supported") >= 0));
+                }
+                w.on("message", (e: any) => { console.log("worker:" + e.data); });
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Contains("heap-err:true", output);
+        Assert.DoesNotContain("no-throw", output);
+    }
+
+    /// <summary>
+    /// #1004: <c>moveMessagePortToContext()</c> throws a clear "not supported" error — it needs
+    /// V8 vm contexts/isolates, which SharpTS's single-process model does not provide.
+    /// Interpreter only (the compiled worker_threads emitter does not expose it).
+    /// </summary>
+    [Fact]
+    public void MoveMessagePortToContext_ThrowsClearError_Interpreted()
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import { moveMessagePortToContext, MessageChannel } from "worker_threads";
+                const ch: any = new MessageChannel();
+                try {
+                    moveMessagePortToContext(ch.port1, {});
+                    console.log("no-throw");
+                } catch (e: any) {
+                    console.log("mvp-err:" + (("" + (e && e.message ? e.message : e)).indexOf("not supported") >= 0));
+                }
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", ExecutionMode.Interpreted);
+        Assert.Contains("mvp-err:true", output);
+        Assert.DoesNotContain("no-throw", output);
+    }
+
+    #endregion
+
     #region worker stdio + resourceLimits (#1003)
 
     /// <summary>

--- a/SharpTS.Tests/SharedTests/WorkerThreadsTests.cs
+++ b/SharpTS.Tests/SharedTests/WorkerThreadsTests.cs
@@ -771,6 +771,43 @@ public class WorkerThreadsTests
 
     #endregion
 
+    #region markAsUntransferable (#1002)
+
+    /// <summary>
+    /// #1002: an ArrayBuffer passed to <c>markAsUntransferable</c> is ignored in a transfer
+    /// list — it is cloned (copied) instead of transferred, so the source is NOT detached
+    /// (<c>byteLength</c> preserved). Contrast with #999 where an unmarked transferred buffer
+    /// is detached to 0. Dual-mode: <c>markAsUntransferable</c> records the object in the C#
+    /// <c>StructuredClone</c> registry (compiled via a reflection helper), and the Worker
+    /// transferList clone honors it in both modes.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Worker_MarkAsUntransferable_BufferIsClonedNotDetached(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["worker_ok.ts"] = """
+                postMessage("ok");
+                """,
+            ["main.ts"] = """
+                import { Worker, markAsUntransferable } from "worker_threads";
+                const buf = new ArrayBuffer(8);
+                markAsUntransferable(buf);
+                // buf is in the transfer list but marked untransferable → ignored, not detached.
+                const w = new Worker(__dirname + "/worker_ok.ts", { workerData: "go", transferList: [buf] });
+                console.log("len:" + buf.byteLength);
+                w.on("message", (e: any) => { console.log("worker:" + e.data); });
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Contains("len:8", output);
+        Assert.Contains("worker:ok", output);
+    }
+
+    #endregion
+
     #region 'messageerror' event (#1001)
 
     /// <summary>

--- a/SharpTS.Tests/SharedTests/WorkerThreadsTests.cs
+++ b/SharpTS.Tests/SharedTests/WorkerThreadsTests.cs
@@ -488,6 +488,96 @@ public class WorkerThreadsTests
         Assert.Contains("terminated", output);
     }
 
+    /// <summary>
+    /// #997: terminating a worker parked in <c>Atomics.wait</c> must actually unwind the
+    /// worker thread (not just settle the promise), and the <c>'exit'</c> event must report
+    /// code 1. The worker parks on a never-notified index, so before the fix the
+    /// <c>Monitor.Wait(Infinite)</c> had no cancellation hook: the 5s join timed out, the
+    /// thread leaked, and its <c>finally</c> — the only emitter of <c>'exit'</c> — never ran.
+    /// </summary>
+    /// <remarks>
+    /// The arriving <c>'exit'</c> event is the correctness signal: it is enqueued solely from
+    /// the worker thread's <c>finally</c>, which executes only once the thread unwinds out of
+    /// the parked wait. A still-leaked thread would never produce it. <c>"survived"</c> after
+    /// the wait must never be delivered — termination is not catchable by guest code.
+    /// </remarks>
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Worker_Terminate_WakesAtomicsWaitAndEmitsExitCode1(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["worker_wait.ts"] = """
+                // Park on a worker-local SAB index that nothing ever notifies, so the wait
+                // blocks forever unless terminate() unwinds the thread.
+                const view = new Int32Array(new SharedArrayBuffer(16));
+                postMessage("parked");
+                Atomics.wait(view, 0, 0);
+                postMessage("survived"); // unreachable once terminate() aborts the worker
+                """,
+            ["main.ts"] = """
+                import { Worker } from "worker_threads";
+                const w = new Worker(__dirname + "/worker_wait.ts");
+                w.on("exit", (code: any) => { console.log("exit:" + code); });
+                w.on("message", (e: any) => {
+                    if (e.data === "parked") {
+                        // Give the worker a beat to actually enter the wait, then terminate.
+                        setTimeout(async () => {
+                            await w.terminate();
+                            console.log("terminated");
+                        }, 50);
+                    } else {
+                        console.log("got:" + e.data);
+                    }
+                });
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Contains("exit:1", output);
+        Assert.Contains("terminated", output);
+        Assert.DoesNotContain("got:survived", output);
+    }
+
+    /// <summary>
+    /// #997: terminating a cooperatively-idle worker (its event loop held open by a pending
+    /// timer) stops it promptly via <c>Interpreter.Shutdown()</c> and reports <c>'exit'</c>
+    /// code 1 — Node uses 1 for a terminated worker. Before the fix the exit code was
+    /// hardcoded 0 and nothing stopped the loop early, so a terminated worker either reported
+    /// 0 or waited out the 5s join.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Worker_Terminate_StopsCooperativeEventLoopWorkerWithExitCode1(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["worker_idle.ts"] = """
+                // Hold the worker's loop open well past terminate() so the only way it exits
+                // is the terminate() Shutdown(), not the timer firing.
+                setTimeout(() => {}, 3000);
+                postMessage("ready");
+                """,
+            ["main.ts"] = """
+                import { Worker } from "worker_threads";
+                const w = new Worker(__dirname + "/worker_idle.ts");
+                w.on("exit", (code: any) => { console.log("exit:" + code); });
+                w.on("message", (e: any) => {
+                    if (e.data === "ready") {
+                        setTimeout(async () => {
+                            await w.terminate();
+                            console.log("terminated");
+                        }, 50);
+                    }
+                });
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Contains("exit:1", output);
+        Assert.Contains("terminated", output);
+    }
+
     #endregion
 
     #region Running-Worker event-loop liveness (#329)

--- a/SharpTS.Tests/SharedTests/WorkerThreadsTests.cs
+++ b/SharpTS.Tests/SharedTests/WorkerThreadsTests.cs
@@ -771,6 +771,66 @@ public class WorkerThreadsTests
 
     #endregion
 
+    #region worker stdio + resourceLimits (#1003)
+
+    /// <summary>
+    /// #1003: the <c>resourceLimits</c> option is stored and echoed back on
+    /// <c>worker.resourceLimits</c> (cosmetic — .NET cannot enforce V8 heap/stack sizing).
+    /// Dual-mode.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Worker_ResourceLimits_EchoedBack(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["worker_ok.ts"] = """
+                postMessage("ok");
+                """,
+            ["main.ts"] = """
+                import { Worker } from "worker_threads";
+                const w: any = new Worker(__dirname + "/worker_ok.ts", {
+                    workerData: "go",
+                    resourceLimits: { maxOldGenerationSizeMb: 24, stackSizeMb: 4 },
+                });
+                console.log("rl:" + w.resourceLimits.maxOldGenerationSizeMb + "," + w.resourceLimits.stackSizeMb);
+                w.on("message", (e: any) => { console.log("worker:" + e.data); });
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Contains("rl:24,4", output);
+        Assert.Contains("worker:ok", output);
+    }
+
+    /// <summary>
+    /// #1003: with <c>stdout: true</c>, the worker's console output is diverted off the shared
+    /// Console into a per-worker Readable <c>worker.stdout</c>; the parent reads it via
+    /// 'data'/'end'. Each chunk is marshalled onto the parent loop before delivery. Dual-mode.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Worker_StdoutTrue_CapturesWorkerConsoleOutput(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["worker_out.ts"] = """
+                console.log("hello-from-worker");
+                """,
+            ["main.ts"] = """
+                import { Worker } from "worker_threads";
+                const w: any = new Worker(__dirname + "/worker_out.ts", { stdout: true });
+                // Print each chunk directly — don't depend on 'data' vs 'end' ordering.
+                w.stdout.on("data", (chunk: any) => { console.log("OUT[" + ("" + chunk).trim() + "]"); });
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Contains("OUT[hello-from-worker]", output);
+    }
+
+    #endregion
+
     #region markAsUntransferable (#1002)
 
     /// <summary>
@@ -993,7 +1053,7 @@ public class WorkerThreadsTests
     /// </summary>
     [Theory]
     [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
-    public void Worker_UnsupportedStdioAndResourceLimitsOptions_AreIgnored(ExecutionMode mode)
+    public void Worker_StdioAndResourceLimitsOptions_AreHonored(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
         {
@@ -1002,13 +1062,16 @@ public class WorkerThreadsTests
                 """,
             ["main.ts"] = """
                 import { Worker } from "worker_threads";
-                const w = new Worker(__dirname + "/worker_echo.ts", {
+                const w: any = new Worker(__dirname + "/worker_echo.ts", {
                     workerData: 42,
                     stdout: true,
                     stderr: true,
                     stdin: true,
                     resourceLimits: { maxOldGenerationSizeMb: 16 },
                 });
+                // #1003: passing all stdio + resourceLimits options no longer breaks
+                // construction; resourceLimits echoes and the worker still runs.
+                console.log("rl:" + w.resourceLimits.maxOldGenerationSizeMb);
                 w.on("message", (e: any) => {
                     console.log("received:" + e.data);
                 });
@@ -1017,6 +1080,7 @@ public class WorkerThreadsTests
 
         var output = TestHarness.RunModules(files, "main.ts", mode);
         Assert.Contains("received:ran", output);
+        Assert.Contains("rl:16", output);
     }
 
     #endregion

--- a/SharpTS.Tests/SharedTests/WorkerThreadsTests.cs
+++ b/SharpTS.Tests/SharedTests/WorkerThreadsTests.cs
@@ -614,6 +614,104 @@ public class WorkerThreadsTests
 
     #endregion
 
+    #region ArrayBuffer transfer + detach (#999)
+
+    /// <summary>
+    /// #999: an ArrayBuffer placed in a Worker's <c>transferList</c> is detached on the
+    /// sender side (Node neuters it — <c>byteLength</c> becomes 0). The Worker constructor
+    /// clones <c>workerData</c> with the transfer list synchronously, so the source buffer
+    /// is detached by the time <c>new Worker</c> returns. Dual-mode: the Worker uses the C#
+    /// <c>StructuredClone</c> in both interpreter and compiled parents.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Worker_ArrayBufferInTransferList_DetachesSource(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["worker_ok.ts"] = """
+                postMessage("ok");
+                """,
+            ["main.ts"] = """
+                import { Worker } from "worker_threads";
+                const buf = new ArrayBuffer(8);
+                new Uint8Array(buf)[0] = 1;
+                const w = new Worker(__dirname + "/worker_ok.ts", { workerData: "go", transferList: [buf] });
+                // Transfer happened synchronously during construction — source is detached.
+                console.log("len:" + buf.byteLength);
+                w.on("message", (e: any) => { console.log("worker:" + e.data); });
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Contains("len:0", output);
+        Assert.Contains("worker:ok", output);
+    }
+
+    /// <summary>
+    /// #999 (gap follow-up): a non-transferred ArrayBuffer passed as <c>workerData</c> is
+    /// deep-copied, not detached — its <c>byteLength</c> is preserved on the sender. Before
+    /// the fix the interpreter had no ArrayBuffer clone arm and threw "Cannot clone value of
+    /// type SharpTSArrayBuffer", so the worker failed to spawn. Dual-mode.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Worker_NonTransferredArrayBufferWorkerData_IsCopiedNotDetached(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["worker_ok.ts"] = """
+                postMessage("ok");
+                """,
+            ["main.ts"] = """
+                import { Worker } from "worker_threads";
+                const buf = new ArrayBuffer(8);
+                const w = new Worker(__dirname + "/worker_ok.ts", { workerData: buf });
+                console.log("len:" + buf.byteLength);
+                w.on("message", (e: any) => { console.log("worker:" + e.data); });
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Contains("len:8", output);
+        Assert.Contains("worker:ok", output);
+    }
+
+    /// <summary>
+    /// #999: full transfer round-trip — the bytes of a transferred ArrayBuffer arrive in the
+    /// worker (it reads them back), and the parent's source buffer is detached. Interpreter
+    /// only: a compiled parent hands the interpreting worker an emitted <c>$ArrayBuffer</c>
+    /// that the interpreter's TypedArray constructor doesn't bridge yet (a separate cross-mode
+    /// gap), so the byte read-back is verified in interpreter mode; detach is covered in both
+    /// modes by <see cref="Worker_ArrayBufferInTransferList_DetachesSource"/>.
+    /// </summary>
+    [Fact]
+    public void Worker_TransferredArrayBuffer_MovesBytesToWorker_Interpreted()
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["worker_read.ts"] = """
+                const u = new Uint8Array(workerData);
+                postMessage(u[0] + "," + u[1] + ",len=" + u.length);
+                """,
+            ["main.ts"] = """
+                import { Worker } from "worker_threads";
+                const buf = new ArrayBuffer(4);
+                const u = new Uint8Array(buf);
+                u[0] = 9; u[1] = 8;
+                const w = new Worker(__dirname + "/worker_read.ts", { workerData: buf, transferList: [buf] });
+                console.log("src:" + buf.byteLength);
+                w.on("message", (e: any) => { console.log("got:" + e.data); });
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", ExecutionMode.Interpreted);
+        Assert.Contains("src:0", output);
+        Assert.Contains("got:9,8,len=4", output);
+    }
+
+    #endregion
+
     #region Running-Worker event-loop liveness (#329)
 
     /// <summary>

--- a/SharpTS.Tests/SharedTests/WorkerThreadsTests.cs
+++ b/SharpTS.Tests/SharedTests/WorkerThreadsTests.cs
@@ -771,6 +771,98 @@ public class WorkerThreadsTests
 
     #endregion
 
+    #region 'messageerror' event (#1001)
+
+    /// <summary>
+    /// #1001: when a worker posts a value that fails to clone, the parent <c>Worker</c> fires
+    /// <c>'messageerror'</c> (Node's receiver-side model) rather than throwing in the worker's
+    /// postMessage. Dual-mode: the worker always interprets and posts through the C#
+    /// <c>SharpTSWorker</c>, whose clone throws DataCloneError for a function in both modes.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Worker_PostUncloneableToParent_FiresMessageError(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["worker_msgerr.ts"] = """
+                // A function cannot be structured-cloned → parent gets 'messageerror'.
+                postMessage(() => {});
+                """,
+            ["main.ts"] = """
+                import { Worker } from "worker_threads";
+                const w = new Worker(__dirname + "/worker_msgerr.ts");
+                w.on("messageerror", () => { console.log("parent-messageerror"); });
+                w.on("message", (e: any) => { console.log("message:" + e.data); });
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Contains("parent-messageerror", output);
+        Assert.DoesNotContain("message:", output);
+    }
+
+    /// <summary>
+    /// #1001: when the parent posts a value that fails to clone, the worker's
+    /// <c>parentPort</c> fires <c>'messageerror'</c>. The worker echoes which event it saw.
+    /// Dual-mode (parent posts through the C# <c>SharpTSWorker</c>).
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Worker_ParentPostsUncloneable_WorkerParentPortFiresMessageError(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["worker_pw.ts"] = """
+                import { parentPort } from "worker_threads";
+                parentPort.on("messageerror", () => { postMessage("saw-err"); });
+                parentPort.on("message", () => { postMessage("saw-msg"); });
+                postMessage("ready");
+                setTimeout(() => {}, 500); // stay alive to receive the parent's post
+                """,
+            ["main.ts"] = """
+                import { Worker } from "worker_threads";
+                const w = new Worker(__dirname + "/worker_pw.ts");
+                w.on("message", (e: any) => {
+                    if (e.data === "ready") { w.postMessage(() => {}); }
+                    else { console.log(e.data); }
+                });
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Contains("saw-err", output);
+        Assert.DoesNotContain("saw-msg", output);
+    }
+
+    /// <summary>
+    /// #1001: a <c>MessageChannel</c> port whose peer posts an uncloneable value fires
+    /// <c>'messageerror'</c> on the receiver. Interpreter only — the compiled emitted
+    /// structured clone returns uncloneable values by reference (it does not throw), so a
+    /// compiled <c>$MessagePort</c> has no clone-failure point. The Worker paths above cover
+    /// the dual-mode behavior.
+    /// </summary>
+    [Fact]
+    public void MessageChannelPort_PostUncloneable_FiresMessageError_Interpreted()
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import { MessageChannel } from "worker_threads";
+                const { port1, port2 } = new MessageChannel();
+                port2.on("messageerror", () => { console.log("port-err"); });
+                port2.on("message", () => { console.log("port-msg"); });
+                port1.postMessage(() => {});
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", ExecutionMode.Interpreted);
+        Assert.Contains("port-err", output);
+        Assert.DoesNotContain("port-msg", output);
+    }
+
+    #endregion
+
     #region Running-Worker event-loop liveness (#329)
 
     /// <summary>

--- a/SharpTS.Tests/SharedTests/WorkerThreadsTests.cs
+++ b/SharpTS.Tests/SharedTests/WorkerThreadsTests.cs
@@ -712,6 +712,65 @@ public class WorkerThreadsTests
 
     #endregion
 
+    #region environment data + receiveMessageOnPort (#1000)
+
+    /// <summary>
+    /// #1000: <c>setEnvironmentData</c>/<c>getEnvironmentData</c> use a real per-process data
+    /// store (not <c>process.env</c>). Data set on the parent is visible in the worker via
+    /// <c>getEnvironmentData</c>, and must NOT leak into <c>process.env</c>. Dual-mode: the
+    /// parent's set routes to the shared C# store in both modes (compiled via a reflection
+    /// helper); the worker reads it through the interpreter.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Worker_EnvironmentData_VisibleInWorker_NotInProcessEnv(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["worker_env.ts"] = """
+                import { getEnvironmentData } from "worker_threads";
+                // process.env must NOT carry the value — setEnvironmentData uses a separate store.
+                const leaked: any = (process as any).env["ed_k1000"];
+                postMessage("env:" + getEnvironmentData("ed_k1000") + ":leak=" + (leaked === undefined ? "no" : "yes"));
+                """,
+            ["main.ts"] = """
+                import { Worker, setEnvironmentData } from "worker_threads";
+                setEnvironmentData("ed_k1000", "ed_val");
+                const w = new Worker(__dirname + "/worker_env.ts");
+                w.on("message", (e: any) => { console.log(e.data); });
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Contains("env:ed_val:leak=no", output);
+    }
+
+    /// <summary>
+    /// #1000: <c>receiveMessageOnPort</c> on an empty port returns <c>undefined</c> (was CLR
+    /// null). Dual-mode on the main thread. The non-empty <c>{ message }</c> result is covered
+    /// dual-mode by <see cref="Worker_ReceiveMessageOnPort_OnTransferredPort"/> (driven through
+    /// the interpreter inside the worker).
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ReceiveMessageOnPort_EmptyPort_IsUndefined(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import { MessageChannel, receiveMessageOnPort } from "worker_threads";
+                const { port1, port2 } = new MessageChannel();
+                const r: any = receiveMessageOnPort(port2);
+                console.log("empty:" + (r === undefined));
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Contains("empty:true", output);
+    }
+
+    #endregion
+
     #region Running-Worker event-loop liveness (#329)
 
     /// <summary>

--- a/SharpTS.Tests/SharedTests/WorkerThreadsTests.cs
+++ b/SharpTS.Tests/SharedTests/WorkerThreadsTests.cs
@@ -580,6 +580,40 @@ public class WorkerThreadsTests
 
     #endregion
 
+    #region 'online' event (#998)
+
+    /// <summary>
+    /// #998: Node emits <c>'online'</c> on a Worker once the worker's JS starts executing,
+    /// before any <c>'message'</c> it posts. SharpTS emitted no such event. The worker posts
+    /// a message at the top of its script; the parent must see <c>'online'</c> first.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Worker_Online_FiresBeforeFirstMessage(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["worker_post.ts"] = """
+                postMessage("hello");
+                """,
+            ["main.ts"] = """
+                import { Worker } from "worker_threads";
+                const w = new Worker(__dirname + "/worker_post.ts");
+                w.on("online", () => { console.log("online"); });
+                w.on("message", (e: any) => { console.log("message:" + e.data); });
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Contains("online", output);
+        Assert.Contains("message:hello", output);
+        // 'online' must be delivered before the first 'message'.
+        Assert.True(output.IndexOf("online") < output.IndexOf("message:hello"),
+            $"'online' should precede the first 'message'. Output:\n{output}");
+    }
+
+    #endregion
+
     #region Running-Worker event-loop liveness (#329)
 
     /// <summary>


### PR DESCRIPTION
Completes epic #996 — brings `worker_threads` to near-100% Node parity. Eight stacked commits, one per child issue.

Full xUnit suite: **14513 / 0**. `worker_threads` tests grew 88 → **115**. Every behavior is verified **dual-mode** (interpreter + compiled) unless noted; the compiled parent reaches the C# `SharpTSWorker`/stream objects via the runtime dispatch path.

## Children

| Issue | Commit | Summary |
|------|--------|---------|
| #997 | `a71d7cc` | **terminate() teardown + exit code** (the one real bug). `terminate()` now wakes a worker parked in `Atomics.wait` (a cancellation hook pulses the `Monitor.Wait`; the worker unwinds via a non-catchable `WorkerTerminatedException`) and stops an idle event-loop worker promptly via `Interpreter.Shutdown()`. `exit` reports code `1` on terminate/uncaught error; the terminate promise resolves the real exit code. |
| #998 | `51ecb93` | **`'online'` event** — emitted once the worker's JS starts, before its first `'message'`. |
| #999 | `3ee31c6` | **ArrayBuffer transfer + detach** — `transferList` now accepts `ArrayBuffer` (interp + emitted `$ArrayBuffer`); the source is detached (`byteLength → 0`). Added the missing interpreter ArrayBuffer payload-clone arm. |
| #1000 | `22b68a2` | **Real environment-data store** (not `process.env`) for `get`/`setEnvironmentData`; `receiveMessageOnPort` returns `undefined` (not null) on an empty port. |
| #1001 | `d8fede5` | **`'messageerror'` event** — a clone failure on `postMessage` is delivered to the receiver as `'messageerror'` (BroadcastChannel's receiver-side model) instead of throwing on the sender. |
| #1002 | `7d79c5d` | **`markAsUntransferable`** — marked objects are cloned (not transferred), so they survive on the sender. |
| #1003 | `abcb0fb` | **`stdout`/`stderr` streams + `resourceLimits` echo** — `stdout`/`stderr: true` diverts worker console output into per-worker `Readable` streams (`worker.stdout`/`worker.stderr`); `worker.resourceLimits` echoes the passed object. |
| #1004 | `b897b7f` | **Introspection** — `getHeapSnapshot()` (clear not-supported error), `worker.performance.eventLoopUtilization()` (best-effort), `moveMessagePortToContext()` (clear not-supported error). |

## Documented `.NET`-model ceilings / deviations

- **CPU-bound `while(true){}` worker** can't be force-killed (no `Thread.Abort`); cooperative termination only.
- **MessagePort source-neuter on transfer** is intentionally *not* done — SharpTS's single-process two-thread model hands the same port object to both threads (unlike V8's separate serialize/deserialize), so neutering the sender would neuter the receiver. Documented in `TransferMessagePort`.
- **`getHeapSnapshot()`** has no .NET equivalent (V8 snapshot format) → clear error. **`resourceLimits`** is echoed but not enforced (no per-thread V8 heap/stack sizing). **`moveMessagePortToContext()`** needs V8 vm isolates → clear error.
- **`worker.stdin`** (parent→worker `process.stdin` bridge) and the compiled main-thread `MessageChannel` `messageerror`/synchronous `receiveMessageOnPort` (the emitted clone doesn't throw / the `$MessagePort` type is emitted after the worker-threads helpers) remain follow-ups; documented in the relevant commits.

Closes #997, #998, #999, #1000, #1001, #1002, #1003, #1004.