### PR TITLE
child_process: 100% Node parity — interpreter ↔ compiled (epic #1012)

### DIFF
--- a/Compilation/Emitters/Modules/ChildProcessModuleEmitter.cs
+++ b/Compilation/Emitters/Modules/ChildProcessModuleEmitter.cs
@@ -307,6 +307,10 @@ public sealed class ChildProcessModuleEmitter : IBuiltInModuleEmitter
         var ctx = emitter.Context;
         var il = ctx.IL;
 
+        // fork runs a child .ts module through the interpreter, which a standalone binary
+        // can't do — co-locate SharpTS.dll (suppressed by --standalone, which then throws).
+        ctx.Runtime!.RequireSharpTSRuntime("child_process.fork");
+
         // Emit module path
         if (arguments.Count > 0)
         {

--- a/Compilation/RuntimeEmitter.ChildProcessAsync.cs
+++ b/Compilation/RuntimeEmitter.ChildProcessAsync.cs
@@ -554,11 +554,25 @@ public partial class RuntimeEmitter
     private void EmitCtxKill(EmittedRuntime runtime)
     {
         // object Kill(object signal):
-        //   if (_dict["killed"] truthy already) -> still attempt, but Node returns true.
-        //   _dict["killed"] = true; try { if (!_proc.HasExited) _proc.Kill(true); } catch {}
-        //   return true;
+        //   _dict["killed"] = true; _dict["signalCode"] = signal ?? "SIGTERM";
+        //   try { if (!_proc.HasExited) _proc.Kill(true); } catch {}  return true;
         var il = _childCtxKill.GetILGenerator();
         EmitDictSetFromCtx(il, "killed", () => { il.Emit(OpCodes.Ldc_I4_1); il.Emit(OpCodes.Box, _types.Boolean); });
+        // signalCode = (signal is string) ? signal : "SIGTERM"
+        EmitDictSetFromCtx(il, "signalCode", () =>
+        {
+            var have = il.DefineLabel();
+            var done = il.DefineLabel();
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Isinst, _types.String);
+            il.Emit(OpCodes.Dup);
+            il.Emit(OpCodes.Brtrue, have);
+            il.Emit(OpCodes.Pop);
+            il.Emit(OpCodes.Ldstr, "SIGTERM");
+            il.Emit(OpCodes.Br, done);
+            il.MarkLabel(have);
+            il.MarkLabel(done);
+        });
 
         var afterKill = il.DefineLabel();
         il.BeginExceptionBlock();

--- a/Compilation/RuntimeEmitter.ChildProcessAsync.cs
+++ b/Compilation/RuntimeEmitter.ChildProcessAsync.cs
@@ -38,6 +38,7 @@ public partial class RuntimeEmitter
     private FieldBuilder _childCtxResCode = null!;     // int
     private FieldBuilder _childCtxResError = null!;    // object (error dict or null)
     private FieldBuilder _childCtxResKind = null!;     // int: 0 normal, 1 timeout, 2 exception
+    private FieldBuilder _childCtxMaxBuffer = null!;   // int: exec maxBuffer cap (chars); <0 unbounded
     private FieldBuilder _childCtxStdoutRedir = null!; // bool: stdout redirected (mode != inherit)
     private FieldBuilder _childCtxStderrRedir = null!; // bool: stderr redirected (mode != inherit)
 
@@ -58,6 +59,7 @@ public partial class RuntimeEmitter
     private MethodBuilder _childAsyncUnref = null!;
     private MethodBuilder _childConfigureSpawn = null!;
     private MethodBuilder _childStdioMode = null!;
+    private MethodBuilder _childReadCapped = null!;
 
     // $ChildPush — a one-shot closure that pushes one chunk (or null = EOF) into a
     // $Readable on the event-loop thread, so all stream-buffer access stays single-threaded.
@@ -108,6 +110,7 @@ public partial class RuntimeEmitter
         DefineChildCtxType(runtime);
         EmitChildRunAsyncHelpers(runtimeType, runtime);
         EmitChildStdioMode(runtimeType, runtime);
+        EmitChildReadCapped(runtimeType, runtime);
         EmitConfigureSpawnStartInfo(runtimeType, runtime);
         EmitChildCtxMethods(runtime);
         _childCtxType.CreateType();
@@ -459,6 +462,7 @@ public partial class RuntimeEmitter
         _childCtxResCode = t.DefineField("_resCode", _types.Int32, FieldAttributes.Public);
         _childCtxResError = t.DefineField("_resError", _types.Object, FieldAttributes.Public);
         _childCtxResKind = t.DefineField("_resKind", _types.Int32, FieldAttributes.Public);
+        _childCtxMaxBuffer = t.DefineField("_maxBuffer", _types.Int32, FieldAttributes.Public);
         _childCtxStdoutRedir = t.DefineField("_stdoutRedir", _types.Boolean, FieldAttributes.Public);
         _childCtxStderrRedir = t.DefineField("_stderrRedir", _types.Boolean, FieldAttributes.Public);
 
@@ -669,22 +673,45 @@ public partial class RuntimeEmitter
             il.Emit(OpCodes.Box, _types.Double);
         });
 
-        // _resStdout = _proc.StandardOutput.ReadToEnd();
+        // bool[] overflow = new bool[1];
+        var overflowLocal = il.DeclareLocal(typeof(bool[]));
+        il.Emit(OpCodes.Ldc_I4_1); il.Emit(OpCodes.Newarr, typeof(bool)); il.Emit(OpCodes.Stloc, overflowLocal);
+
+        // _resStdout = ChildReadCapped(_proc.StandardOutput, _maxBuffer, overflow);
         StoreCtxField(il, _childCtxResStdout, () =>
         {
-            il.Emit(OpCodes.Ldarg_0);
-            il.Emit(OpCodes.Ldfld, _childCtxProc);
-            il.Emit(OpCodes.Callvirt, _miProcStdoutGet);
-            il.Emit(OpCodes.Callvirt, _miReadToEnd);
+            il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Ldfld, _childCtxProc); il.Emit(OpCodes.Callvirt, _miProcStdoutGet);
+            il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Ldfld, _childCtxMaxBuffer);
+            il.Emit(OpCodes.Ldloc, overflowLocal);
+            il.Emit(OpCodes.Call, _childReadCapped);
         });
-        // _resStderr = _proc.StandardError.ReadToEnd();
+        // _resStderr = ChildReadCapped(_proc.StandardError, _maxBuffer, overflow);
         StoreCtxField(il, _childCtxResStderr, () =>
         {
-            il.Emit(OpCodes.Ldarg_0);
-            il.Emit(OpCodes.Ldfld, _childCtxProc);
-            il.Emit(OpCodes.Callvirt, _miProcStderrGet);
-            il.Emit(OpCodes.Callvirt, _miReadToEnd);
+            il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Ldfld, _childCtxProc); il.Emit(OpCodes.Callvirt, _miProcStderrGet);
+            il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Ldfld, _childCtxMaxBuffer);
+            il.Emit(OpCodes.Ldloc, overflowLocal);
+            il.Emit(OpCodes.Call, _childReadCapped);
         });
+
+        // if (overflow[0]) { try { _proc.Kill(true); } catch {}  _resError = maxBuffer error; }
+        var noOverflow = il.DefineLabel();
+        var afterKill = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, overflowLocal); il.Emit(OpCodes.Ldc_I4_0); il.Emit(OpCodes.Ldelem_I1);
+        il.Emit(OpCodes.Brfalse, noOverflow);
+        il.BeginExceptionBlock();
+        il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Ldfld, _childCtxProc);
+        il.Emit(OpCodes.Ldc_I4_1); il.Emit(OpCodes.Callvirt, _miProcKillTree);
+        il.Emit(OpCodes.Leave, afterKill);
+        il.BeginCatchBlock(_types.Exception); il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Leave, afterKill);
+        il.EndExceptionBlock();
+        il.MarkLabel(afterKill);
+        StoreCtxField(il, _childCtxResError, () =>
+            EmitNewErrorObject(il,
+                () => il.Emit(OpCodes.Ldstr, "stdout maxBuffer length exceeded"),
+                () => il.Emit(OpCodes.Ldstr, "ERR_CHILD_PROCESS_STDIO_MAXBUFFER")));
+        il.MarkLabel(noOverflow);
 
         // Timeout branch
         var noTimeoutWait = il.DefineLabel();
@@ -724,10 +751,12 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Stloc, codeLocal);
         StoreCtxField(il, _childCtxResCode, () => il.Emit(OpCodes.Ldloc, codeLocal));
 
-        // if (code != 0) _resError = { message: "Command failed with exit code N", code: N }
+        // if (code != 0 && _resError == null) _resError = { message: "Command failed with exit code N", code: N }
         var zeroCode = il.DefineLabel();
         il.Emit(OpCodes.Ldloc, codeLocal);
         il.Emit(OpCodes.Brfalse, zeroCode);
+        il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Ldfld, _childCtxResError);
+        il.Emit(OpCodes.Brtrue, zeroCode); // a maxBuffer (or other) error already set — keep it
         StoreCtxField(il, _childCtxResError, () =>
             EmitNewErrorObject(il,
                 () =>
@@ -1429,6 +1458,8 @@ public partial class RuntimeEmitter
         StoreCtxField(il, ctxLocal, _childCtxCallback, () => il.Emit(OpCodes.Ldloc, callbackLocal));
         StoreCtxField(il, ctxLocal, _childCtxOptions, () => il.Emit(OpCodes.Ldloc, optionsLocal));
         StoreCtxField(il, ctxLocal, _childCtxTimeout, () => il.Emit(OpCodes.Ldloc, timeoutLocal));
+        // maxBuffer (chars), default 1 MB.
+        StoreCtxField(il, ctxLocal, _childCtxMaxBuffer, () => EmitParseMaxBuffer(il, optionsLocal));
 
         // dict = new Dictionary<string,object?>()
         il.Emit(OpCodes.Newobj, _types.DictionaryStringObject.GetConstructor(Type.EmptyTypes)!);
@@ -1576,6 +1607,105 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldarg_0);
         emitValue();
         il.Emit(OpCodes.Stfld, field);
+    }
+
+    /// <summary>Leaves an int on the stack: options["maxBuffer"] as int, default 1 MB.</summary>
+    private void EmitParseMaxBuffer(ILGenerator il, LocalBuilder optionsObjLocal)
+    {
+        var resultLocal = il.DeclareLocal(_types.Int32);
+        var dictLocal = il.DeclareLocal(_types.DictionaryStringObject);
+        var tmpLocal = il.DeclareLocal(_types.Object);
+        var tryGet = _types.DictionaryStringObject.GetMethod("TryGetValue", [_types.String, _types.Object.MakeByRefType()])!;
+        var done = il.DefineLabel();
+
+        il.Emit(OpCodes.Ldc_I4, 1048576);
+        il.Emit(OpCodes.Stloc, resultLocal);
+        il.Emit(OpCodes.Ldloc, optionsObjLocal);
+        il.Emit(OpCodes.Isinst, _types.DictionaryStringObject);
+        il.Emit(OpCodes.Dup); il.Emit(OpCodes.Stloc, dictLocal);
+        il.Emit(OpCodes.Brfalse, done);
+        il.Emit(OpCodes.Ldloc, dictLocal);
+        il.Emit(OpCodes.Ldstr, "maxBuffer");
+        il.Emit(OpCodes.Ldloca, tmpLocal);
+        il.Emit(OpCodes.Callvirt, tryGet);
+        il.Emit(OpCodes.Brfalse, done);
+        il.Emit(OpCodes.Ldloc, tmpLocal);
+        il.Emit(OpCodes.Isinst, _types.Double);
+        il.Emit(OpCodes.Brfalse, done);
+        il.Emit(OpCodes.Ldloc, tmpLocal);
+        il.Emit(OpCodes.Unbox_Any, _types.Double);
+        il.Emit(OpCodes.Conv_I4);
+        il.Emit(OpCodes.Stloc, resultLocal);
+        il.MarkLabel(done);
+        il.Emit(OpCodes.Ldloc, resultLocal);
+    }
+
+    /// <summary>
+    /// static string ChildReadCapped(TextReader reader, int maxBuffer, bool[] flag): reads up to
+    /// maxBuffer chars; on overflow sets flag[0]=true and stops. maxBuffer&lt;0 means unbounded.
+    /// </summary>
+    private void EmitChildReadCapped(TypeBuilder runtimeType, EmittedRuntime runtime)
+    {
+        var m = runtimeType.DefineMethod("ChildReadCapped",
+            MethodAttributes.Public | MethodAttributes.Static, _types.String,
+            [_types.TextReader, _types.Int32, typeof(bool[])]);
+        _childReadCapped = m;
+        var il = m.GetILGenerator();
+        var sbLocal = il.DeclareLocal(_types.StringBuilder);
+        var bufLocal = il.DeclareLocal(typeof(char[]));
+        var nLocal = il.DeclareLocal(_types.Int32);
+        var remLocal = il.DeclareLocal(_types.Int32);
+        var readM = _types.TextReader.GetMethod("Read", [typeof(char[]), _types.Int32, _types.Int32])!;
+        var appendM = _types.StringBuilder.GetMethod("Append", [typeof(char[]), _types.Int32, _types.Int32])!;
+        var lenGet = _types.StringBuilder.GetProperty("Length")!.GetGetMethod()!;
+
+        // if (maxBuffer < 0) return reader.ReadToEnd();
+        var bounded = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Bge, bounded);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Callvirt, _miReadToEnd);
+        il.Emit(OpCodes.Ret);
+        il.MarkLabel(bounded);
+
+        il.Emit(OpCodes.Newobj, _types.StringBuilder.GetConstructor(Type.EmptyTypes)!);
+        il.Emit(OpCodes.Stloc, sbLocal);
+        il.Emit(OpCodes.Ldc_I4, 4096); il.Emit(OpCodes.Newarr, typeof(char)); il.Emit(OpCodes.Stloc, bufLocal);
+
+        var loop = il.DefineLabel();
+        var end = il.DefineLabel();
+        il.MarkLabel(loop);
+        il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Ldloc, bufLocal); il.Emit(OpCodes.Ldc_I4_0); il.Emit(OpCodes.Ldc_I4, 4096);
+        il.Emit(OpCodes.Callvirt, readM);
+        il.Emit(OpCodes.Stloc, nLocal);
+        il.Emit(OpCodes.Ldloc, nLocal); il.Emit(OpCodes.Ldc_I4_0); il.Emit(OpCodes.Ble, end);
+        // if (sb.Length + n > maxBuffer) { rem = max(0, maxBuffer - sb.Length); sb.Append(buf,0,rem); flag[0]=true; break; }
+        var noOverflow = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, sbLocal); il.Emit(OpCodes.Callvirt, lenGet);
+        il.Emit(OpCodes.Ldloc, nLocal); il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Ble, noOverflow);
+        // rem = maxBuffer - sb.Length; if (rem<0) rem=0;
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Ldloc, sbLocal); il.Emit(OpCodes.Callvirt, lenGet);
+        il.Emit(OpCodes.Sub);
+        il.Emit(OpCodes.Stloc, remLocal);
+        var remOk = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, remLocal); il.Emit(OpCodes.Ldc_I4_0); il.Emit(OpCodes.Bge, remOk);
+        il.Emit(OpCodes.Ldc_I4_0); il.Emit(OpCodes.Stloc, remLocal);
+        il.MarkLabel(remOk);
+        il.Emit(OpCodes.Ldloc, sbLocal); il.Emit(OpCodes.Ldloc, bufLocal); il.Emit(OpCodes.Ldc_I4_0); il.Emit(OpCodes.Ldloc, remLocal);
+        il.Emit(OpCodes.Callvirt, appendM); il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Ldarg_2); il.Emit(OpCodes.Ldc_I4_0); il.Emit(OpCodes.Ldc_I4_1); il.Emit(OpCodes.Stelem_I1);
+        il.Emit(OpCodes.Br, end);
+        il.MarkLabel(noOverflow);
+        il.Emit(OpCodes.Ldloc, sbLocal); il.Emit(OpCodes.Ldloc, bufLocal); il.Emit(OpCodes.Ldc_I4_0); il.Emit(OpCodes.Ldloc, nLocal);
+        il.Emit(OpCodes.Callvirt, appendM); il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Br, loop);
+        il.MarkLabel(end);
+        il.Emit(OpCodes.Ldloc, sbLocal); il.Emit(OpCodes.Callvirt, _types.GetMethodNoParams(_types.StringBuilder, "ToString"));
+        il.Emit(OpCodes.Ret);
     }
 
     /// <summary>Emit: new $TSFunction(target, methodof(method)).</summary>

--- a/Compilation/RuntimeEmitter.ChildProcessAsync.cs
+++ b/Compilation/RuntimeEmitter.ChildProcessAsync.cs
@@ -54,6 +54,7 @@ public partial class RuntimeEmitter
 
     private MethodBuilder _childRunAsync = null!;
     private MethodBuilder _childAsyncUnref = null!;
+    private MethodBuilder _childConfigureSpawn = null!;
 
     // $ChildPush — a one-shot closure that pushes one chunk (or null = EOF) into a
     // $Readable on the event-loop thread, so all stream-buffer access stays single-threaded.
@@ -103,9 +104,202 @@ public partial class RuntimeEmitter
         DefineChildPushType(runtime);
         DefineChildCtxType(runtime);
         EmitChildRunAsyncHelpers(runtimeType, runtime);
+        EmitConfigureSpawnStartInfo(runtimeType, runtime);
         EmitChildCtxMethods(runtime);
         _childCtxType.CreateType();
         _childPushType.CreateType();
+    }
+
+    /// <summary>
+    /// static void ConfigureSpawnStartInfo(ProcessStartInfo si, string command, object args, object options)
+    /// Sets FileName/Arguments(/ArgumentList) honoring the `shell` option (true → default
+    /// platform shell; string → that shell), mirroring the interpreter's ApplyShellCommand.
+    /// </summary>
+    private void EmitConfigureSpawnStartInfo(TypeBuilder runtimeType, EmittedRuntime runtime)
+    {
+        var m = runtimeType.DefineMethod("ConfigureSpawnStartInfo",
+            MethodAttributes.Public | MethodAttributes.Static, _types.Void,
+            [_types.ProcessStartInfo, _types.String, _types.Object, _types.Object]);
+        _childConfigureSpawn = m;
+        var il = m.GetILGenerator();
+
+        var argsListLocal = il.DeclareLocal(_types.ListOfObject);
+        var fullCmdLocal = il.DeclareLocal(_types.String);
+        var useShellLocal = il.DeclareLocal(_types.Boolean);
+        var shellPathLocal = il.DeclareLocal(_types.String);
+        var tmpLocal = il.DeclareLocal(_types.Object);
+        var dictLocal = il.DeclareLocal(_types.DictionaryStringObject);
+        var concat2 = _types.String.GetMethod("Concat", [_types.String, _types.String])!;
+        var concat3 = _types.String.GetMethod("Concat", [_types.String, _types.String, _types.String])!;
+        var fnSet = _types.ProcessStartInfo.GetProperty("FileName")!.GetSetMethod()!;
+        var argSet = _types.ProcessStartInfo.GetProperty("Arguments")!.GetSetMethod()!;
+
+        // argsList = args as List
+        il.Emit(OpCodes.Ldarg_2);
+        il.Emit(OpCodes.Isinst, _types.ListOfObject);
+        il.Emit(OpCodes.Stloc, argsListLocal);
+
+        // fullCmd = command; if (argsList != null && argsList.Count>0) fullCmd = command + " " + string.Join(" ", argsList.ToArray())
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Stloc, fullCmdLocal);
+        var noJoin = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, argsListLocal);
+        il.Emit(OpCodes.Brfalse, noJoin);
+        il.Emit(OpCodes.Ldloc, argsListLocal);
+        il.Emit(OpCodes.Callvirt, _types.ListOfObject.GetProperty("Count")!.GetGetMethod()!);
+        il.Emit(OpCodes.Brfalse, noJoin);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Ldstr, " ");
+        il.Emit(OpCodes.Ldstr, " ");
+        il.Emit(OpCodes.Ldloc, argsListLocal);
+        il.Emit(OpCodes.Callvirt, _types.ListOfObject.GetMethod("ToArray")!);
+        il.Emit(OpCodes.Call, typeof(string).GetMethod("Join", [typeof(string), typeof(object[])])!);
+        il.Emit(OpCodes.Call, concat3);
+        il.Emit(OpCodes.Stloc, fullCmdLocal);
+        il.MarkLabel(noJoin);
+
+        // useShell = false; shellPath = null
+        il.Emit(OpCodes.Ldc_I4_0); il.Emit(OpCodes.Stloc, useShellLocal);
+        il.Emit(OpCodes.Ldnull); il.Emit(OpCodes.Stloc, shellPathLocal);
+
+        // if (options is Dict && dict.TryGetValue("shell", out tmp)) { ... }
+        var afterShellOpt = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_3);
+        il.Emit(OpCodes.Isinst, _types.DictionaryStringObject);
+        il.Emit(OpCodes.Dup);
+        il.Emit(OpCodes.Stloc, dictLocal);
+        il.Emit(OpCodes.Brfalse, afterShellOpt);
+        il.Emit(OpCodes.Ldloc, dictLocal);
+        il.Emit(OpCodes.Ldstr, "shell");
+        il.Emit(OpCodes.Ldloca, tmpLocal);
+        il.Emit(OpCodes.Callvirt, _types.DictionaryStringObject.GetMethod("TryGetValue", [_types.String, _types.Object.MakeByRefType()])!);
+        il.Emit(OpCodes.Brfalse, afterShellOpt);
+
+        // if (tmp is bool) useShell = (bool)tmp;
+        var notBool = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, tmpLocal);
+        il.Emit(OpCodes.Isinst, _types.Boolean);
+        il.Emit(OpCodes.Brfalse, notBool);
+        il.Emit(OpCodes.Ldloc, tmpLocal);
+        il.Emit(OpCodes.Unbox_Any, _types.Boolean);
+        il.Emit(OpCodes.Stloc, useShellLocal);
+        il.Emit(OpCodes.Br, afterShellOpt);
+        il.MarkLabel(notBool);
+        // else if (tmp is string s && s.Length>0) { useShell=true; shellPath=s; }
+        var notStr = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, tmpLocal);
+        il.Emit(OpCodes.Isinst, _types.String);
+        il.Emit(OpCodes.Dup);
+        il.Emit(OpCodes.Brfalse, notStr);          // (string s) on stack
+        il.Emit(OpCodes.Dup);
+        il.Emit(OpCodes.Callvirt, _types.String.GetProperty("Length")!.GetGetMethod()!);
+        il.Emit(OpCodes.Brfalse, notStr);          // length 0 → leaves the string; handled below
+        il.Emit(OpCodes.Stloc, shellPathLocal);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Stloc, useShellLocal);
+        il.Emit(OpCodes.Br, afterShellOpt);
+        il.MarkLabel(notStr);
+        il.Emit(OpCodes.Pop);                       // discard the Isinst result / empty string
+        il.MarkLabel(afterShellOpt);
+
+        // Branch on useShell
+        var directLabel = il.DefineLabel();
+        var endLabel = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, useShellLocal);
+        il.Emit(OpCodes.Brfalse, directLabel);
+
+        // Shell path: platform branch
+        var notWindows = il.DefineLabel();
+        var afterPlatform = il.DefineLabel();
+        il.Emit(OpCodes.Call, _types.OSPlatform.GetProperty("Windows")!.GetGetMethod()!);
+        il.Emit(OpCodes.Call, _types.RuntimeInformation.GetMethod("IsOSPlatform", [_types.OSPlatform])!);
+        il.Emit(OpCodes.Brfalse, notWindows);
+        // Windows: FileName = shellPath ?? "cmd.exe"; Arguments = "/d /s /c " + fullCmd
+        il.Emit(OpCodes.Ldarg_0);
+        EmitShellPathOrDefault(il, shellPathLocal, "cmd.exe");
+        il.Emit(OpCodes.Callvirt, fnSet);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldstr, "/d /s /c ");
+        il.Emit(OpCodes.Ldloc, fullCmdLocal);
+        il.Emit(OpCodes.Call, concat2);
+        il.Emit(OpCodes.Callvirt, argSet);
+        il.Emit(OpCodes.Br, afterPlatform);
+        // Unix: FileName = shellPath ?? "/bin/sh"; Arguments = "-c \"" + fullCmd.Replace("\"","\\\"") + "\""
+        il.MarkLabel(notWindows);
+        il.Emit(OpCodes.Ldarg_0);
+        EmitShellPathOrDefault(il, shellPathLocal, "/bin/sh");
+        il.Emit(OpCodes.Callvirt, fnSet);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldstr, "-c \"");
+        il.Emit(OpCodes.Ldloc, fullCmdLocal);
+        il.Emit(OpCodes.Ldstr, "\"");
+        il.Emit(OpCodes.Ldstr, "\\\"");
+        il.Emit(OpCodes.Callvirt, _types.String.GetMethod("Replace", [_types.String, _types.String])!);
+        il.Emit(OpCodes.Ldstr, "\"");
+        il.Emit(OpCodes.Call, concat3);
+        il.Emit(OpCodes.Callvirt, argSet);
+        il.MarkLabel(afterPlatform);
+        il.Emit(OpCodes.Br, endLabel);
+
+        // Direct path: FileName = command; add args to ArgumentList
+        il.MarkLabel(directLabel);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Callvirt, fnSet);
+        var noArgs = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, argsListLocal);
+        il.Emit(OpCodes.Brfalse, noArgs);
+        var argListLocal = il.DeclareLocal(typeof(System.Collections.ObjectModel.Collection<string>));
+        var iLocal = il.DeclareLocal(_types.Int32);
+        var aTmp = il.DeclareLocal(_types.Object);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Callvirt, _types.ProcessStartInfo.GetProperty("ArgumentList")!.GetGetMethod()!);
+        il.Emit(OpCodes.Stloc, argListLocal);
+        il.Emit(OpCodes.Ldc_I4_0); il.Emit(OpCodes.Stloc, iLocal);
+        var loop = il.DefineLabel();
+        var loopEnd = il.DefineLabel();
+        il.MarkLabel(loop);
+        il.Emit(OpCodes.Ldloc, iLocal);
+        il.Emit(OpCodes.Ldloc, argsListLocal);
+        il.Emit(OpCodes.Callvirt, _types.ListOfObject.GetProperty("Count")!.GetGetMethod()!);
+        il.Emit(OpCodes.Bge, loopEnd);
+        il.Emit(OpCodes.Ldloc, argsListLocal);
+        il.Emit(OpCodes.Ldloc, iLocal);
+        il.Emit(OpCodes.Callvirt, _types.ListOfObject.GetMethod("get_Item", [_types.Int32])!);
+        il.Emit(OpCodes.Stloc, aTmp);
+        il.Emit(OpCodes.Ldloc, argListLocal);
+        var aNull = il.DefineLabel();
+        var aAdd = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, aTmp);
+        il.Emit(OpCodes.Brfalse, aNull);
+        il.Emit(OpCodes.Ldloc, aTmp);
+        il.Emit(OpCodes.Callvirt, _types.Object.GetMethod("ToString")!);
+        il.Emit(OpCodes.Br, aAdd);
+        il.MarkLabel(aNull);
+        il.Emit(OpCodes.Ldstr, "");
+        il.MarkLabel(aAdd);
+        il.Emit(OpCodes.Callvirt, typeof(System.Collections.ObjectModel.Collection<string>).GetMethod("Add", [_types.String])!);
+        il.Emit(OpCodes.Ldloc, iLocal); il.Emit(OpCodes.Ldc_I4_1); il.Emit(OpCodes.Add); il.Emit(OpCodes.Stloc, iLocal);
+        il.Emit(OpCodes.Br, loop);
+        il.MarkLabel(loopEnd);
+        il.MarkLabel(noArgs);
+
+        il.MarkLabel(endLabel);
+        il.Emit(OpCodes.Ret);
+    }
+
+    /// <summary>Emit: (shellPathLocal != null && len>0) ? shellPathLocal : default.</summary>
+    private void EmitShellPathOrDefault(ILGenerator il, LocalBuilder shellPathLocal, string def)
+    {
+        var useDefault = il.DefineLabel();
+        var done = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, shellPathLocal);
+        il.Emit(OpCodes.Brfalse, useDefault);
+        il.Emit(OpCodes.Ldloc, shellPathLocal);
+        il.Emit(OpCodes.Br, done);
+        il.MarkLabel(useDefault);
+        il.Emit(OpCodes.Ldstr, def);
+        il.MarkLabel(done);
     }
 
     /// <summary>$ChildPush { object _stream; object _chunk; void Run() =&gt; (($Readable)_stream).Push(_chunk); }</summary>

--- a/Compilation/RuntimeEmitter.ChildProcessAsync.cs
+++ b/Compilation/RuntimeEmitter.ChildProcessAsync.cs
@@ -1,0 +1,879 @@
+using System.Diagnostics;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Threading.Tasks;
+
+namespace SharpTS.Compilation;
+
+/// <summary>
+/// Compiled-mode real async for child_process (#1012). Mirrors the interpreter
+/// (Runtime/BuiltIns/Modules/Interpreter/ChildProcessModuleInterpreter.cs) and reuses
+/// the fs #971 backgrounding shape: a process runs on Task.Run while an EventLoop.Ref()
+/// keeps the loop alive, then the callback / lifecycle events fire and the loop is
+/// Unref'd (with the same Task.Delay grace fs uses to keep fire-and-forget callbacks
+/// from racing program exit).
+///
+/// The ChildProcess returned to guest code is a Dictionary&lt;string,object?&gt; (a compiled
+/// "$Object"); the worker mutates that dict in place (pid/exitCode/killed/...) so the
+/// guest's property reads observe live state. All IL is BCL-only so output stays standalone.
+/// </summary>
+public partial class RuntimeEmitter
+{
+    // $ChildProcessCtx — shared mutable state for one spawned/exec'd child.
+    private TypeBuilder _childCtxType = null!;
+    private ConstructorBuilder _childCtxCtor = null!;
+    private FieldBuilder _childCtxProc = null!;        // Process (not yet started in dispatch)
+    private FieldBuilder _childCtxEmitter = null!;     // object ($EventEmitter)
+    private FieldBuilder _childCtxDict = null!;        // Dictionary<string,object?> (the ChildProcess)
+    private FieldBuilder _childCtxCallback = null!;    // object (callback or null)
+    private FieldBuilder _childCtxOptions = null!;     // object (options dict or null)
+    private FieldBuilder _childCtxStdout = null!;      // object ($Readable)
+    private FieldBuilder _childCtxStderr = null!;      // object ($Readable)
+    private FieldBuilder _childCtxStdin = null!;       // object ($Writable)
+    private FieldBuilder _childCtxTimeout = null!;     // double (ms; <=0 = none)
+    private FieldBuilder _childCtxKillSignal = null!;  // string (default SIGTERM)
+    // Captured worker results, stored on the bg thread and replayed on the loop thread.
+    private FieldBuilder _childCtxResStdout = null!;   // object (string)
+    private FieldBuilder _childCtxResStderr = null!;   // object (string)
+    private FieldBuilder _childCtxResCode = null!;     // int
+    private FieldBuilder _childCtxResError = null!;    // object (error dict or null)
+    private FieldBuilder _childCtxResKind = null!;     // int: 0 normal, 1 timeout, 2 exception
+
+    private MethodBuilder _childCtxRunCaptured = null!;
+    private MethodBuilder _childCtxEmitCaptured = null!;
+    private MethodBuilder _childCtxRunStreamed = null!;
+    private MethodBuilder _childCtxKill = null!;
+    private MethodBuilder _childCtxSend = null!;
+    private MethodBuilder _childCtxDisconnect = null!;
+    private MethodBuilder _childCtxRef = null!;
+    private MethodBuilder _childCtxStdinWrite = null!;
+    private MethodBuilder _childCtxStdinEnd = null!;
+
+    private MethodBuilder _childRunAsync = null!;
+    private MethodBuilder _childAsyncUnref = null!;
+
+    // BCL handles, resolved once.
+    private MethodInfo _miProcStart = null!;
+    private MethodInfo _miProcIdGet = null!;
+    private MethodInfo _miProcStdoutGet = null!;
+    private MethodInfo _miProcStderrGet = null!;
+    private MethodInfo _miProcStdinGet = null!;
+    private MethodInfo _miProcExitCodeGet = null!;
+    private MethodInfo _miProcHasExitedGet = null!;
+    private MethodInfo _miProcWaitForExit = null!;
+    private MethodInfo _miProcWaitForExitMs = null!;
+    private MethodInfo _miProcKillTree = null!;
+    private MethodInfo _miReadToEnd = null!;
+    private MethodInfo _miExceptionMessageGet = null!;
+    private MethodInfo _miDictSet = null!;
+    private MethodInfo _miGetMethodFromHandle = null!;
+
+    /// <summary>
+    /// Builds the $ChildProcessCtx type + the ChildRunAsync backgrounding helpers.
+    /// Called from EmitChildProcessMethods before the dispatch methods are emitted.
+    /// </summary>
+    private void EmitChildProcessAsyncInfra(TypeBuilder runtimeType, EmittedRuntime runtime)
+    {
+        _miProcStart = _types.Process.GetMethod("Start", Type.EmptyTypes)!;
+        _miProcIdGet = _types.Process.GetProperty("Id")!.GetGetMethod()!;
+        _miProcStdoutGet = _types.Process.GetProperty("StandardOutput")!.GetGetMethod()!;
+        _miProcStderrGet = _types.Process.GetProperty("StandardError")!.GetGetMethod()!;
+        _miProcStdinGet = _types.Process.GetProperty("StandardInput")!.GetGetMethod()!;
+        _miProcExitCodeGet = _types.Process.GetProperty("ExitCode")!.GetGetMethod()!;
+        _miProcHasExitedGet = _types.Process.GetProperty("HasExited")!.GetGetMethod()!;
+        _miProcWaitForExit = _types.Process.GetMethod("WaitForExit", Type.EmptyTypes)!;
+        _miProcWaitForExitMs = _types.Process.GetMethod("WaitForExit", [_types.Int32])!;
+        _miProcKillTree = _types.Process.GetMethod("Kill", [_types.Boolean])!;
+        _miReadToEnd = _types.TextReader.GetMethod("ReadToEnd")!;
+        _miExceptionMessageGet = _types.Exception.GetProperty("Message")!.GetGetMethod()!;
+        _miDictSet = _types.GetMethod(_types.DictionaryStringObject, "set_Item", _types.String, _types.Object)!;
+        _miGetMethodFromHandle = typeof(MethodBase).GetMethod("GetMethodFromHandle", [typeof(RuntimeMethodHandle)])!;
+
+        DefineChildCtxType(runtime);
+        EmitChildRunAsyncHelpers(runtimeType, runtime);
+        EmitChildCtxMethods(runtime);
+        _childCtxType.CreateType();
+    }
+
+    private void DefineChildCtxType(EmittedRuntime runtime)
+    {
+        var mb = (ModuleBuilder)((TypeBuilder)runtime.TSEventEmitterType).Module;
+        var t = mb.DefineType(
+            "$ChildProcessCtx",
+            TypeAttributes.Public | TypeAttributes.Sealed | TypeAttributes.BeforeFieldInit,
+            _types.Object);
+        _childCtxType = t;
+
+        _childCtxProc = t.DefineField("_proc", _types.Process, FieldAttributes.Public);
+        _childCtxEmitter = t.DefineField("_emitter", _types.Object, FieldAttributes.Public);
+        _childCtxDict = t.DefineField("_dict", _types.DictionaryStringObject, FieldAttributes.Public);
+        _childCtxCallback = t.DefineField("_callback", _types.Object, FieldAttributes.Public);
+        _childCtxOptions = t.DefineField("_options", _types.Object, FieldAttributes.Public);
+        _childCtxStdout = t.DefineField("_stdout", _types.Object, FieldAttributes.Public);
+        _childCtxStderr = t.DefineField("_stderr", _types.Object, FieldAttributes.Public);
+        _childCtxStdin = t.DefineField("_stdin", _types.Object, FieldAttributes.Public);
+        _childCtxTimeout = t.DefineField("_timeout", _types.Double, FieldAttributes.Public);
+        _childCtxKillSignal = t.DefineField("_killSignal", _types.String, FieldAttributes.Public);
+        _childCtxResStdout = t.DefineField("_resStdout", _types.Object, FieldAttributes.Public);
+        _childCtxResStderr = t.DefineField("_resStderr", _types.Object, FieldAttributes.Public);
+        _childCtxResCode = t.DefineField("_resCode", _types.Int32, FieldAttributes.Public);
+        _childCtxResError = t.DefineField("_resError", _types.Object, FieldAttributes.Public);
+        _childCtxResKind = t.DefineField("_resKind", _types.Int32, FieldAttributes.Public);
+
+        var ctor = t.DefineConstructor(MethodAttributes.Public, CallingConventions.Standard, Type.EmptyTypes);
+        var cil = ctor.GetILGenerator();
+        cil.Emit(OpCodes.Ldarg_0);
+        cil.Emit(OpCodes.Call, _types.Object.GetConstructor(Type.EmptyTypes)!);
+        cil.Emit(OpCodes.Ret);
+        _childCtxCtor = ctor;
+
+        // Declare the method builders now (bodies filled by EmitChildCtxMethods) so
+        // ldtoken references resolve while wiring the dict in dispatch.
+        _childCtxRunCaptured = t.DefineMethod("RunCaptured", MethodAttributes.Public, _types.Object, Type.EmptyTypes);
+        _childCtxEmitCaptured = t.DefineMethod("EmitCaptured", MethodAttributes.Public, _types.Void, Type.EmptyTypes);
+        _childCtxRunStreamed = t.DefineMethod("RunStreamed", MethodAttributes.Public, _types.Object, Type.EmptyTypes);
+        _childCtxKill = t.DefineMethod("Kill", MethodAttributes.Public, _types.Object, [_types.Object]);
+        _childCtxSend = t.DefineMethod("Send", MethodAttributes.Public, _types.Object, [_types.Object]);
+        _childCtxDisconnect = t.DefineMethod("Disconnect", MethodAttributes.Public, _types.Object, Type.EmptyTypes);
+        _childCtxRef = t.DefineMethod("RefSelf", MethodAttributes.Public, _types.Object, Type.EmptyTypes);
+        _childCtxStdinWrite = t.DefineMethod("StdinWrite", MethodAttributes.Public, _types.Object,
+            [_types.Object, _types.Object, _types.Object]);
+        _childCtxStdinEnd = t.DefineMethod("StdinEnd", MethodAttributes.Public, _types.Object,
+            [_types.Object, _types.Object, _types.Object]);
+    }
+
+    /// <summary>
+    /// static void ChildRunAsync(Func&lt;object&gt; worker): EventLoop.Ref(); Task.Run(worker)
+    /// then Unref (with Task.Delay grace). Mirrors FsRunAsync but self-contained so
+    /// child_process never depends on UsesFs.
+    /// </summary>
+    private void EmitChildRunAsyncHelpers(TypeBuilder runtimeType, EmittedRuntime runtime)
+    {
+        // static void ChildAsyncUnrefNow() => EventLoop.GetInstance().Unref();
+        var now = runtimeType.DefineMethod("ChildAsyncUnrefNow",
+            MethodAttributes.Public | MethodAttributes.Static, _types.Void, Type.EmptyTypes);
+        {
+            var il = now.GetILGenerator();
+            il.Emit(OpCodes.Call, runtime.EventLoopGetInstance);
+            il.Emit(OpCodes.Call, runtime.EventLoopUnref);
+            il.Emit(OpCodes.Ret);
+        }
+
+        // static void ChildAsyncUnrefDrop(Task t) => EventLoop.GetInstance().Schedule(new Action(ChildAsyncUnrefNow));
+        var drop = runtimeType.DefineMethod("ChildAsyncUnrefDrop",
+            MethodAttributes.Public | MethodAttributes.Static, _types.Void, [typeof(Task)]);
+        {
+            var il = drop.GetILGenerator();
+            il.Emit(OpCodes.Call, runtime.EventLoopGetInstance);
+            il.Emit(OpCodes.Ldnull);
+            il.Emit(OpCodes.Ldftn, now);
+            il.Emit(OpCodes.Newobj, typeof(Action).GetConstructor([_types.Object, typeof(IntPtr)])!);
+            il.Emit(OpCodes.Callvirt, runtime.EventLoopSchedule);
+            il.Emit(OpCodes.Ret);
+        }
+
+        // static void ChildAsyncUnref(Task t) => Task.Delay(8).ContinueWith(ChildAsyncUnrefDrop);
+        var unref = runtimeType.DefineMethod("ChildAsyncUnref",
+            MethodAttributes.Public | MethodAttributes.Static, _types.Void, [typeof(Task)]);
+        {
+            var il = unref.GetILGenerator();
+            il.Emit(OpCodes.Ldc_I4, 8);
+            il.Emit(OpCodes.Call, typeof(Task).GetMethod("Delay", [_types.Int32])!);
+            il.Emit(OpCodes.Ldnull);
+            il.Emit(OpCodes.Ldftn, drop);
+            il.Emit(OpCodes.Newobj, typeof(Action<Task>).GetConstructor([_types.Object, typeof(IntPtr)])!);
+            il.Emit(OpCodes.Callvirt, typeof(Task).GetMethod("ContinueWith", [typeof(Action<Task>)])!);
+            il.Emit(OpCodes.Pop);
+            il.Emit(OpCodes.Ret);
+        }
+        _childAsyncUnref = unref;
+
+        // static void ChildRunAsync(Func<object> worker)
+        var taskRunOpen = typeof(Task).GetMethods(BindingFlags.Public | BindingFlags.Static)
+            .First(x => x.Name == "Run" && x.IsGenericMethodDefinition
+                && x.GetParameters().Length == 1
+                && x.GetParameters()[0].ParameterType.IsGenericType
+                && x.GetParameters()[0].ParameterType.GetGenericTypeDefinition() == typeof(Func<>));
+        var taskRun = taskRunOpen.MakeGenericMethod(_types.Object);
+
+        var run = runtimeType.DefineMethod("ChildRunAsync",
+            MethodAttributes.Public | MethodAttributes.Static, _types.Void, [typeof(Func<object>)]);
+        {
+            var il = run.GetILGenerator();
+            il.Emit(OpCodes.Call, runtime.EventLoopGetInstance);
+            il.Emit(OpCodes.Call, runtime.EventLoopRef);
+
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Call, taskRun);
+            var tLocal = il.DeclareLocal(_types.TaskOfObject);
+            il.Emit(OpCodes.Stloc, tLocal);
+
+            il.Emit(OpCodes.Ldloc, tLocal);
+            il.Emit(OpCodes.Ldnull);
+            il.Emit(OpCodes.Ldftn, unref);
+            il.Emit(OpCodes.Newobj, typeof(Action<Task>).GetConstructor([_types.Object, typeof(IntPtr)])!);
+            il.Emit(OpCodes.Ldc_I4, (int)TaskContinuationOptions.ExecuteSynchronously);
+            il.Emit(OpCodes.Callvirt, typeof(Task).GetMethod("ContinueWith", [typeof(Action<Task>), typeof(TaskContinuationOptions)])!);
+            il.Emit(OpCodes.Pop);
+            il.Emit(OpCodes.Ret);
+        }
+        _childRunAsync = run;
+    }
+
+    // ---- Small IL helpers shared by the ctx method bodies ----
+
+    /// <summary>Emit: ctx._emitter as $EventEmitter . Emit(name, new object[]{ arg }). Leaves nothing.</summary>
+    private void EmitCtxEmit(ILGenerator il, EmittedRuntime runtime, string name, Action emitArg)
+    {
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, _childCtxEmitter);
+        il.Emit(OpCodes.Castclass, runtime.TSEventEmitterType);
+        il.Emit(OpCodes.Ldstr, name);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Newarr, _types.Object);
+        il.Emit(OpCodes.Dup);
+        il.Emit(OpCodes.Ldc_I4_0);
+        emitArg();
+        il.Emit(OpCodes.Stelem_Ref);
+        il.Emit(OpCodes.Call, runtime.TSEventEmitterEmit);
+        il.Emit(OpCodes.Pop);
+    }
+
+    /// <summary>Emit a fresh error object dict { message = msg, [code = code] } onto the stack.</summary>
+    private void EmitNewErrorObject(ILGenerator il, Action emitMessage, Action? emitCode)
+    {
+        var dictLocal = il.DeclareLocal(_types.DictionaryStringObject);
+        il.Emit(OpCodes.Newobj, _types.DictionaryStringObject.GetConstructor(Type.EmptyTypes)!);
+        il.Emit(OpCodes.Stloc, dictLocal);
+        il.Emit(OpCodes.Ldloc, dictLocal);
+        il.Emit(OpCodes.Ldstr, "message");
+        emitMessage();
+        il.Emit(OpCodes.Callvirt, _miDictSet);
+        if (emitCode != null)
+        {
+            il.Emit(OpCodes.Ldloc, dictLocal);
+            il.Emit(OpCodes.Ldstr, "code");
+            emitCode();
+            il.Emit(OpCodes.Callvirt, _miDictSet);
+        }
+        il.Emit(OpCodes.Ldloc, dictLocal);
+    }
+
+    /// <summary>Emit: runtime.InvokeValue(ctx._callback, args[]) when callback != null. Pops result.</summary>
+    private void EmitInvokeCallback(ILGenerator il, EmittedRuntime runtime, Action emitArgsArray)
+    {
+        var skip = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, _childCtxCallback);
+        il.Emit(OpCodes.Brfalse, skip);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, _childCtxCallback);
+        emitArgsArray();
+        il.Emit(OpCodes.Call, runtime.InvokeValue);
+        il.Emit(OpCodes.Pop);
+        il.MarkLabel(skip);
+    }
+
+    private void EmitChildCtxMethods(EmittedRuntime runtime)
+    {
+        EmitCtxRunCaptured(runtime);
+        EmitCtxEmitCaptured(runtime);
+        EmitCtxRunStreamed(runtime);
+        EmitCtxKill(runtime);
+        EmitCtxSend(runtime);
+        EmitCtxDisconnect(runtime);
+        EmitCtxRef(runtime);
+        EmitCtxStdinWrite(runtime);
+        EmitCtxStdinEnd(runtime);
+    }
+
+    /// <summary>
+    /// exec/execFile worker (bg thread): start, capture stdout+stderr fully, wait
+    /// (honoring timeout), record the outcome on ctx, then Schedule EmitCaptured on the
+    /// event loop so the callback / lifecycle events fire on the loop thread AFTER the
+    /// synchronous script has registered its listeners — matching the interpreter.
+    /// </summary>
+    private void EmitCtxRunCaptured(EmittedRuntime runtime)
+    {
+        var il = _childCtxRunCaptured.GetILGenerator();
+        var codeLocal = il.DeclareLocal(_types.Int32);
+        var afterTry = il.DefineLabel();
+
+        // _resStdout = ""; _resStderr = ""; _resKind = 0;
+        StoreCtxField(il, _childCtxResStdout, () => il.Emit(OpCodes.Ldstr, ""));
+        StoreCtxField(il, _childCtxResStderr, () => il.Emit(OpCodes.Ldstr, ""));
+        StoreCtxField(il, _childCtxResKind, () => il.Emit(OpCodes.Ldc_I4_0));
+
+        il.BeginExceptionBlock();
+
+        // _proc.Start(); _dict["pid"] = (double)_proc.Id;
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, _childCtxProc);
+        il.Emit(OpCodes.Callvirt, _miProcStart);
+        il.Emit(OpCodes.Pop);
+
+        EmitDictSetFromCtx(il, "pid", () =>
+        {
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, _childCtxProc);
+            il.Emit(OpCodes.Callvirt, _miProcIdGet);
+            il.Emit(OpCodes.Conv_R8);
+            il.Emit(OpCodes.Box, _types.Double);
+        });
+
+        // _resStdout = _proc.StandardOutput.ReadToEnd();
+        StoreCtxField(il, _childCtxResStdout, () =>
+        {
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, _childCtxProc);
+            il.Emit(OpCodes.Callvirt, _miProcStdoutGet);
+            il.Emit(OpCodes.Callvirt, _miReadToEnd);
+        });
+        // _resStderr = _proc.StandardError.ReadToEnd();
+        StoreCtxField(il, _childCtxResStderr, () =>
+        {
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, _childCtxProc);
+            il.Emit(OpCodes.Callvirt, _miProcStderrGet);
+            il.Emit(OpCodes.Callvirt, _miReadToEnd);
+        });
+
+        // Timeout branch
+        var noTimeoutWait = il.DefineLabel();
+        var afterWait = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, _childCtxTimeout);
+        il.Emit(OpCodes.Ldc_R8, 0.0);
+        il.Emit(OpCodes.Ble_Un, noTimeoutWait);
+
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, _childCtxProc);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, _childCtxTimeout);
+        il.Emit(OpCodes.Conv_I4);
+        il.Emit(OpCodes.Callvirt, _miProcWaitForExitMs);
+        il.Emit(OpCodes.Brtrue, afterWait);
+
+        // Timed out: kill tree, killed=true, _resKind=1, leave.
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, _childCtxProc);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Callvirt, _miProcKillTree);
+        EmitDictSetFromCtx(il, "killed", () => { il.Emit(OpCodes.Ldc_I4_1); il.Emit(OpCodes.Box, _types.Boolean); });
+        StoreCtxField(il, _childCtxResKind, () => il.Emit(OpCodes.Ldc_I4_1));
+        il.Emit(OpCodes.Leave, afterTry);
+
+        il.MarkLabel(noTimeoutWait);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, _childCtxProc);
+        il.Emit(OpCodes.Callvirt, _miProcWaitForExit);
+        il.MarkLabel(afterWait);
+
+        // code = _proc.ExitCode; _resCode = code;
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, _childCtxProc);
+        il.Emit(OpCodes.Callvirt, _miProcExitCodeGet);
+        il.Emit(OpCodes.Stloc, codeLocal);
+        StoreCtxField(il, _childCtxResCode, () => il.Emit(OpCodes.Ldloc, codeLocal));
+
+        // if (code != 0) _resError = { message: "Command failed with exit code N", code: N }
+        var zeroCode = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, codeLocal);
+        il.Emit(OpCodes.Brfalse, zeroCode);
+        StoreCtxField(il, _childCtxResError, () =>
+            EmitNewErrorObject(il,
+                () =>
+                {
+                    il.Emit(OpCodes.Ldstr, "Command failed with exit code ");
+                    il.Emit(OpCodes.Ldloca, codeLocal);
+                    il.Emit(OpCodes.Call, _types.Int32.GetMethod("ToString", Type.EmptyTypes)!);
+                    il.Emit(OpCodes.Call, _types.String.GetMethod("Concat", [_types.String, _types.String])!);
+                },
+                () => { il.Emit(OpCodes.Ldloc, codeLocal); il.Emit(OpCodes.Conv_R8); il.Emit(OpCodes.Box, _types.Double); }));
+        il.MarkLabel(zeroCode);
+        il.Emit(OpCodes.Leave, afterTry);
+
+        // catch (Exception ex): _resKind = 2; _resError = { message: ex.Message }
+        il.BeginCatchBlock(_types.Exception);
+        var exLocal = il.DeclareLocal(_types.Exception);
+        il.Emit(OpCodes.Stloc, exLocal);
+        StoreCtxField(il, _childCtxResKind, () => il.Emit(OpCodes.Ldc_I4_2));
+        StoreCtxField(il, _childCtxResError, () =>
+            EmitNewErrorObject(il,
+                () => { il.Emit(OpCodes.Ldloc, exLocal); il.Emit(OpCodes.Callvirt, _miExceptionMessageGet); },
+                null));
+        il.Emit(OpCodes.Leave, afterTry);
+        il.EndExceptionBlock();
+
+        il.MarkLabel(afterTry);
+        // EventLoop.GetInstance().Schedule(new Action(this.EmitCaptured));
+        EmitScheduleOnLoop(il, runtime, _childCtxEmitCaptured);
+        il.Emit(OpCodes.Ldnull);
+        il.Emit(OpCodes.Ret);
+    }
+
+    /// <summary>
+    /// Replays the captured exec/execFile outcome on the event-loop thread: fires the
+    /// (error|null, stdout, stderr) callback and emits close/exit (or error).
+    /// </summary>
+    private void EmitCtxEmitCaptured(EmittedRuntime runtime)
+    {
+        var il = _childCtxEmitCaptured.GetILGenerator();
+        var codeLocal = il.DeclareLocal(_types.Int32);
+        var ret = il.DefineLabel();
+
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, _childCtxResCode);
+        il.Emit(OpCodes.Stloc, codeLocal);
+
+        // switch (_resKind)
+        var kindExc = il.DefineLabel();
+        var kindTimeout = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, _childCtxResKind);
+        il.Emit(OpCodes.Ldc_I4_2);
+        il.Emit(OpCodes.Beq, kindExc);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, _childCtxResKind);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Beq, kindTimeout);
+
+        // kind 0 (normal): _dict["exitCode"] = code; cb(_resError, out, err); emit close/exit
+        EmitDictSetFromCtx(il, "exitCode", () => { il.Emit(OpCodes.Ldloc, codeLocal); il.Emit(OpCodes.Conv_R8); il.Emit(OpCodes.Box, _types.Double); });
+        EmitInvokeCallback(il, runtime, () => EmitArgs3(il,
+            () => { il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Ldfld, _childCtxResError); },
+            () => { il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Ldfld, _childCtxResStdout); },
+            () => { il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Ldfld, _childCtxResStderr); }));
+        EmitCtxEmit(il, runtime, "close", () => { il.Emit(OpCodes.Ldloc, codeLocal); il.Emit(OpCodes.Conv_R8); il.Emit(OpCodes.Box, _types.Double); });
+        EmitCtxEmit(il, runtime, "exit", () => { il.Emit(OpCodes.Ldloc, codeLocal); il.Emit(OpCodes.Conv_R8); il.Emit(OpCodes.Box, _types.Double); });
+        il.Emit(OpCodes.Br, ret);
+
+        // kind 1 (timeout): _dict["exitCode"] = -1; emit error; cb(_resError', out, err)
+        il.MarkLabel(kindTimeout);
+        // build the timeout error here (matches interp message)
+        StoreCtxField(il, _childCtxResError, () => EmitNewErrorObject(il, () => il.Emit(OpCodes.Ldstr, "Command timed out"), null));
+        EmitDictSetFromCtx(il, "exitCode", () => { il.Emit(OpCodes.Ldc_R8, -1.0); il.Emit(OpCodes.Box, _types.Double); });
+        EmitCtxEmit(il, runtime, "error", () => { il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Ldfld, _childCtxResError); });
+        EmitInvokeCallback(il, runtime, () => EmitArgs3(il,
+            () => { il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Ldfld, _childCtxResError); },
+            () => { il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Ldfld, _childCtxResStdout); },
+            () => { il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Ldfld, _childCtxResStderr); }));
+        il.Emit(OpCodes.Br, ret);
+
+        // kind 2 (exception): emit error; cb(_resError, "", "")
+        il.MarkLabel(kindExc);
+        EmitCtxEmit(il, runtime, "error", () => { il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Ldfld, _childCtxResError); });
+        EmitInvokeCallback(il, runtime, () => EmitArgs3(il,
+            () => { il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Ldfld, _childCtxResError); },
+            () => il.Emit(OpCodes.Ldstr, ""),
+            () => il.Emit(OpCodes.Ldstr, "")));
+
+        il.MarkLabel(ret);
+        il.Emit(OpCodes.Ret);
+    }
+
+    /// <summary>Emit: EventLoop.GetInstance().Schedule(new Action(this, ldftn method)).</summary>
+    private void EmitScheduleOnLoop(ILGenerator il, EmittedRuntime runtime, MethodBuilder method)
+    {
+        il.Emit(OpCodes.Call, runtime.EventLoopGetInstance);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldftn, method);
+        il.Emit(OpCodes.Newobj, typeof(Action).GetConstructor([_types.Object, typeof(IntPtr)])!);
+        il.Emit(OpCodes.Callvirt, runtime.EventLoopSchedule);
+    }
+
+    /// <summary>Builds new object[]{ a, b, c } on the stack.</summary>
+    private void EmitArgs3(ILGenerator il, Action a, Action b, Action c)
+    {
+        il.Emit(OpCodes.Ldc_I4_3);
+        il.Emit(OpCodes.Newarr, _types.Object);
+        il.Emit(OpCodes.Dup); il.Emit(OpCodes.Ldc_I4_0); a(); il.Emit(OpCodes.Stelem_Ref);
+        il.Emit(OpCodes.Dup); il.Emit(OpCodes.Ldc_I4_1); b(); il.Emit(OpCodes.Stelem_Ref);
+        il.Emit(OpCodes.Dup); il.Emit(OpCodes.Ldc_I4_2); c(); il.Emit(OpCodes.Stelem_Ref);
+    }
+
+    /// <summary>Emit: _dict[key] = &lt;value&gt; (value produced by emitValue).</summary>
+    private void EmitDictSetFromCtx(ILGenerator il, string key, Action emitValue)
+    {
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, _childCtxDict);
+        il.Emit(OpCodes.Ldstr, key);
+        emitValue();
+        il.Emit(OpCodes.Callvirt, _miDictSet);
+    }
+
+    private void EmitCtxKill(EmittedRuntime runtime)
+    {
+        // object Kill(object signal):
+        //   if (_dict["killed"] truthy already) -> still attempt, but Node returns true.
+        //   _dict["killed"] = true; try { if (!_proc.HasExited) _proc.Kill(true); } catch {}
+        //   return true;
+        var il = _childCtxKill.GetILGenerator();
+        EmitDictSetFromCtx(il, "killed", () => { il.Emit(OpCodes.Ldc_I4_1); il.Emit(OpCodes.Box, _types.Boolean); });
+
+        var afterKill = il.DefineLabel();
+        il.BeginExceptionBlock();
+        var skipKill = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, _childCtxProc);
+        il.Emit(OpCodes.Brfalse, skipKill);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, _childCtxProc);
+        il.Emit(OpCodes.Callvirt, _miProcHasExitedGet);
+        il.Emit(OpCodes.Brtrue, skipKill);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, _childCtxProc);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Callvirt, _miProcKillTree);
+        il.MarkLabel(skipKill);
+        il.Emit(OpCodes.Leave, afterKill);
+        il.BeginCatchBlock(_types.Exception);
+        il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Leave, afterKill);
+        il.EndExceptionBlock();
+        il.MarkLabel(afterKill);
+
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Box, _types.Boolean);
+        il.Emit(OpCodes.Ret);
+    }
+
+    private void EmitCtxSend(EmittedRuntime runtime)
+    {
+        // object Send(object message): no IPC channel for non-fork children -> return false.
+        // Real IPC send is wired by the fork child (#1017).
+        var il = _childCtxSend.GetILGenerator();
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Box, _types.Boolean);
+        il.Emit(OpCodes.Ret);
+    }
+
+    private void EmitCtxDisconnect(EmittedRuntime runtime)
+    {
+        // object Disconnect(): no-op for non-fork children -> return null.
+        var il = _childCtxDisconnect.GetILGenerator();
+        il.Emit(OpCodes.Ldnull);
+        il.Emit(OpCodes.Ret);
+    }
+
+    private void EmitCtxRef(EmittedRuntime runtime)
+    {
+        // object RefSelf(): ref()/unref() both return the ChildProcess (the dict).
+        var il = _childCtxRef.GetILGenerator();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, _childCtxDict);
+        il.Emit(OpCodes.Ret);
+    }
+
+    // RunStreamed / StdinWrite / StdinEnd bodies are filled by the spawn child (#1014).
+    // For now they are inert (return null) so the type verifies.
+    private void EmitCtxRunStreamed(EmittedRuntime runtime)
+    {
+        var il = _childCtxRunStreamed.GetILGenerator();
+        il.Emit(OpCodes.Ldnull);
+        il.Emit(OpCodes.Ret);
+    }
+
+    private void EmitCtxStdinWrite(EmittedRuntime runtime)
+    {
+        var il = _childCtxStdinWrite.GetILGenerator();
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Box, _types.Boolean);
+        il.Emit(OpCodes.Ret);
+    }
+
+    private void EmitCtxStdinEnd(EmittedRuntime runtime)
+    {
+        var il = _childCtxStdinEnd.GetILGenerator();
+        il.Emit(OpCodes.Ldnull);
+        il.Emit(OpCodes.Ret);
+    }
+
+    // ================= Dispatch-side helpers =================
+
+    /// <summary>
+    /// Apply options.cwd + options.env to a ProcessStartInfo. options is an object that
+    /// may be a Dictionary or null. env replaces the inherited environment (Node semantics).
+    /// </summary>
+    private void EmitApplyChildOptions(ILGenerator il, LocalBuilder startInfoLocal, LocalBuilder optionsObjLocal)
+    {
+        var dictLocal = il.DeclareLocal(_types.DictionaryStringObject);
+        var tmpLocal = il.DeclareLocal(_types.Object);
+        var doneLabel = il.DefineLabel();
+        var tryGet = _types.DictionaryStringObject.GetMethod("TryGetValue", [_types.String, _types.Object.MakeByRefType()])!;
+
+        // dict = options as Dictionary; if null, done.
+        il.Emit(OpCodes.Ldloc, optionsObjLocal);
+        il.Emit(OpCodes.Isinst, _types.DictionaryStringObject);
+        il.Emit(OpCodes.Dup);
+        il.Emit(OpCodes.Stloc, dictLocal);
+        il.Emit(OpCodes.Brfalse, doneLabel);
+
+        // cwd
+        var noCwd = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, dictLocal);
+        il.Emit(OpCodes.Ldstr, "cwd");
+        il.Emit(OpCodes.Ldloca, tmpLocal);
+        il.Emit(OpCodes.Callvirt, tryGet);
+        il.Emit(OpCodes.Brfalse, noCwd);
+        il.Emit(OpCodes.Ldloc, tmpLocal);
+        il.Emit(OpCodes.Brfalse, noCwd);
+        il.Emit(OpCodes.Ldloc, startInfoLocal);
+        il.Emit(OpCodes.Ldloc, tmpLocal);
+        il.Emit(OpCodes.Callvirt, _types.Object.GetMethod("ToString")!);
+        il.Emit(OpCodes.Callvirt, _types.ProcessStartInfo.GetProperty("WorkingDirectory")!.GetSetMethod()!);
+        il.MarkLabel(noCwd);
+
+        // env
+        var noEnv = il.DefineLabel();
+        var envDictLocal = il.DeclareLocal(_types.DictionaryStringObject);
+        var envEnumLocal = il.DeclareLocal(typeof(Dictionary<string, object?>.Enumerator));
+        var envKvpLocal = il.DeclareLocal(typeof(KeyValuePair<string, object?>));
+        il.Emit(OpCodes.Ldloc, dictLocal);
+        il.Emit(OpCodes.Ldstr, "env");
+        il.Emit(OpCodes.Ldloca, tmpLocal);
+        il.Emit(OpCodes.Callvirt, tryGet);
+        il.Emit(OpCodes.Brfalse, noEnv);
+        il.Emit(OpCodes.Ldloc, tmpLocal);
+        il.Emit(OpCodes.Isinst, _types.DictionaryStringObject);
+        il.Emit(OpCodes.Dup);
+        il.Emit(OpCodes.Stloc, envDictLocal);
+        il.Emit(OpCodes.Brfalse, noEnv);
+
+        var envProp = _types.ProcessStartInfo.GetProperty("Environment")!.GetGetMethod()!;
+        var iDictStringString = typeof(IDictionary<string, string?>);
+        il.Emit(OpCodes.Ldloc, startInfoLocal);
+        il.Emit(OpCodes.Callvirt, envProp);
+        il.Emit(OpCodes.Callvirt, typeof(ICollection<KeyValuePair<string, string?>>).GetMethod("Clear")!);
+
+        il.Emit(OpCodes.Ldloc, envDictLocal);
+        il.Emit(OpCodes.Callvirt, _types.DictionaryStringObject.GetMethod("GetEnumerator")!);
+        il.Emit(OpCodes.Stloc, envEnumLocal);
+        var envLoop = il.DefineLabel();
+        var envLoopEnd = il.DefineLabel();
+        il.Emit(OpCodes.Br, envLoopEnd);
+        il.MarkLabel(envLoop);
+        il.Emit(OpCodes.Ldloca, envEnumLocal);
+        il.Emit(OpCodes.Call, typeof(Dictionary<string, object?>.Enumerator).GetProperty("Current")!.GetGetMethod()!);
+        il.Emit(OpCodes.Stloc, envKvpLocal);
+        il.Emit(OpCodes.Ldloc, startInfoLocal);
+        il.Emit(OpCodes.Callvirt, envProp);
+        il.Emit(OpCodes.Ldloca, envKvpLocal);
+        il.Emit(OpCodes.Call, typeof(KeyValuePair<string, object?>).GetProperty("Key")!.GetGetMethod()!);
+        // value?.ToString() ?? ""
+        il.Emit(OpCodes.Ldloca, envKvpLocal);
+        il.Emit(OpCodes.Call, typeof(KeyValuePair<string, object?>).GetProperty("Value")!.GetGetMethod()!);
+        var valNull = il.DefineLabel();
+        var valDone = il.DefineLabel();
+        il.Emit(OpCodes.Stloc, tmpLocal);
+        il.Emit(OpCodes.Ldloc, tmpLocal);
+        il.Emit(OpCodes.Brfalse, valNull);
+        il.Emit(OpCodes.Ldloc, tmpLocal);
+        il.Emit(OpCodes.Callvirt, _types.Object.GetMethod("ToString")!);
+        il.Emit(OpCodes.Br, valDone);
+        il.MarkLabel(valNull);
+        il.Emit(OpCodes.Ldstr, "");
+        il.MarkLabel(valDone);
+        il.Emit(OpCodes.Callvirt, iDictStringString.GetMethod("set_Item", [_types.String, _types.String])!);
+        il.MarkLabel(envLoopEnd);
+        il.Emit(OpCodes.Ldloca, envEnumLocal);
+        il.Emit(OpCodes.Call, typeof(Dictionary<string, object?>.Enumerator).GetMethod("MoveNext")!);
+        il.Emit(OpCodes.Brtrue, envLoop);
+        il.MarkLabel(noEnv);
+
+        il.MarkLabel(doneLabel);
+    }
+
+    /// <summary>
+    /// timeoutLocal = (double)(options["timeout"]) if present and numeric, else 0.
+    /// </summary>
+    private void EmitParseTimeout(ILGenerator il, LocalBuilder optionsObjLocal, LocalBuilder timeoutLocal)
+    {
+        var dictLocal = il.DeclareLocal(_types.DictionaryStringObject);
+        var tmpLocal = il.DeclareLocal(_types.Object);
+        var tryGet = _types.DictionaryStringObject.GetMethod("TryGetValue", [_types.String, _types.Object.MakeByRefType()])!;
+        var done = il.DefineLabel();
+
+        il.Emit(OpCodes.Ldc_R8, 0.0);
+        il.Emit(OpCodes.Stloc, timeoutLocal);
+
+        il.Emit(OpCodes.Ldloc, optionsObjLocal);
+        il.Emit(OpCodes.Isinst, _types.DictionaryStringObject);
+        il.Emit(OpCodes.Dup);
+        il.Emit(OpCodes.Stloc, dictLocal);
+        il.Emit(OpCodes.Brfalse, done);
+
+        il.Emit(OpCodes.Ldloc, dictLocal);
+        il.Emit(OpCodes.Ldstr, "timeout");
+        il.Emit(OpCodes.Ldloca, tmpLocal);
+        il.Emit(OpCodes.Callvirt, tryGet);
+        il.Emit(OpCodes.Brfalse, done);
+        il.Emit(OpCodes.Ldloc, tmpLocal);
+        il.Emit(OpCodes.Isinst, _types.Double);
+        il.Emit(OpCodes.Brfalse, done);
+        il.Emit(OpCodes.Ldloc, tmpLocal);
+        il.Emit(OpCodes.Unbox_Any, _types.Double);
+        il.Emit(OpCodes.Stloc, timeoutLocal);
+        il.MarkLabel(done);
+    }
+
+    /// <summary>
+    /// Pick the first of candidates that is a Dictionary (options) into outLocal, else null.
+    /// </summary>
+    private void EmitSelectOptions(ILGenerator il, LocalBuilder[] candidates, LocalBuilder outLocal)
+    {
+        var done = il.DefineLabel();
+        il.Emit(OpCodes.Ldnull);
+        il.Emit(OpCodes.Stloc, outLocal);
+        foreach (var c in candidates)
+        {
+            var next = il.DefineLabel();
+            il.Emit(OpCodes.Ldloc, c);
+            il.Emit(OpCodes.Isinst, _types.DictionaryStringObject);
+            il.Emit(OpCodes.Brfalse, next);
+            il.Emit(OpCodes.Ldloc, c);
+            il.Emit(OpCodes.Stloc, outLocal);
+            il.Emit(OpCodes.Br, done);
+            il.MarkLabel(next);
+        }
+        il.MarkLabel(done);
+    }
+
+    /// <summary>
+    /// Pick the first of candidates that is non-null and neither a Dictionary nor a List
+    /// (i.e. a callback) into outLocal, else null. Scan candidates in priority order.
+    /// </summary>
+    private void EmitSelectCallback(ILGenerator il, LocalBuilder[] candidates, LocalBuilder outLocal)
+    {
+        var done = il.DefineLabel();
+        il.Emit(OpCodes.Ldnull);
+        il.Emit(OpCodes.Stloc, outLocal);
+        foreach (var c in candidates)
+        {
+            var next = il.DefineLabel();
+            il.Emit(OpCodes.Ldloc, c);
+            il.Emit(OpCodes.Brfalse, next);            // null -> skip
+            il.Emit(OpCodes.Ldloc, c);
+            il.Emit(OpCodes.Isinst, _types.DictionaryStringObject);
+            il.Emit(OpCodes.Brtrue, next);             // dict -> skip
+            il.Emit(OpCodes.Ldloc, c);
+            il.Emit(OpCodes.Isinst, _types.ListOfObject);
+            il.Emit(OpCodes.Brtrue, next);             // list -> skip
+            il.Emit(OpCodes.Ldloc, c);
+            il.Emit(OpCodes.Stloc, outLocal);
+            il.Emit(OpCodes.Br, done);
+            il.MarkLabel(next);
+        }
+        il.MarkLabel(done);
+    }
+
+    /// <summary>
+    /// Given a configured (not started) Process in processLocal, an options object and a
+    /// callback object, build the $EventEmitter + $ChildProcessCtx + ChildProcess dict,
+    /// launch the captured/streamed worker on the event loop, and leave the ChildProcess
+    /// dict ($Object) on the stack. When streamed, also builds stdout/stderr/stdin streams.
+    /// </summary>
+    private void EmitBuildChildAndLaunch(ILGenerator il, EmittedRuntime runtime,
+        LocalBuilder processLocal, LocalBuilder optionsLocal, LocalBuilder callbackLocal, bool streamed)
+    {
+        var emitterLocal = il.DeclareLocal(runtime.TSEventEmitterType);
+        var ctxLocal = il.DeclareLocal(_childCtxType);
+        var dictLocal = il.DeclareLocal(_types.DictionaryStringObject);
+        var timeoutLocal = il.DeclareLocal(_types.Double);
+
+        EmitParseTimeout(il, optionsLocal, timeoutLocal);
+
+        // emitter = new $EventEmitter()
+        il.Emit(OpCodes.Newobj, runtime.TSEventEmitterCtor);
+        il.Emit(OpCodes.Stloc, emitterLocal);
+
+        // ctx = new $ChildProcessCtx()
+        il.Emit(OpCodes.Newobj, _childCtxCtor);
+        il.Emit(OpCodes.Stloc, ctxLocal);
+        StoreCtxField(il, ctxLocal, _childCtxProc, () => il.Emit(OpCodes.Ldloc, processLocal));
+        StoreCtxField(il, ctxLocal, _childCtxEmitter, () => il.Emit(OpCodes.Ldloc, emitterLocal));
+        StoreCtxField(il, ctxLocal, _childCtxCallback, () => il.Emit(OpCodes.Ldloc, callbackLocal));
+        StoreCtxField(il, ctxLocal, _childCtxOptions, () => il.Emit(OpCodes.Ldloc, optionsLocal));
+        StoreCtxField(il, ctxLocal, _childCtxTimeout, () => il.Emit(OpCodes.Ldloc, timeoutLocal));
+
+        // dict = new Dictionary<string,object?>()
+        il.Emit(OpCodes.Newobj, _types.DictionaryStringObject.GetConstructor(Type.EmptyTypes)!);
+        il.Emit(OpCodes.Stloc, dictLocal);
+
+        // pid = 0.0, killed = false, connected = false, exitCode = null, signalCode = null
+        EmitDictSet(il, dictLocal, "pid", () => { il.Emit(OpCodes.Ldc_R8, 0.0); il.Emit(OpCodes.Box, _types.Double); });
+        EmitDictSet(il, dictLocal, "killed", () => { il.Emit(OpCodes.Ldc_I4_0); il.Emit(OpCodes.Box, _types.Boolean); });
+        EmitDictSet(il, dictLocal, "connected", () => { il.Emit(OpCodes.Ldc_I4_0); il.Emit(OpCodes.Box, _types.Boolean); });
+        EmitDictSet(il, dictLocal, "exitCode", () => il.Emit(OpCodes.Ldnull));
+        EmitDictSet(il, dictLocal, "signalCode", () => il.Emit(OpCodes.Ldnull));
+
+        // on/once delegate to the emitter; kill/send/disconnect/ref/unref to ctx methods.
+        EmitDictSet(il, dictLocal, "on", () => EmitTSFunc(il, runtime, () => il.Emit(OpCodes.Ldloc, emitterLocal), runtime.TSEventEmitterOn));
+        EmitDictSet(il, dictLocal, "once", () => EmitTSFunc(il, runtime, () => il.Emit(OpCodes.Ldloc, emitterLocal), runtime.TSEventEmitterOnce));
+        EmitDictSet(il, dictLocal, "addListener", () => EmitTSFunc(il, runtime, () => il.Emit(OpCodes.Ldloc, emitterLocal), runtime.TSEventEmitterOn));
+        EmitDictSet(il, dictLocal, "kill", () => EmitTSFunc(il, runtime, () => il.Emit(OpCodes.Ldloc, ctxLocal), _childCtxKill));
+        EmitDictSet(il, dictLocal, "send", () => EmitTSFunc(il, runtime, () => il.Emit(OpCodes.Ldloc, ctxLocal), _childCtxSend));
+        EmitDictSet(il, dictLocal, "disconnect", () => EmitTSFunc(il, runtime, () => il.Emit(OpCodes.Ldloc, ctxLocal), _childCtxDisconnect));
+        EmitDictSet(il, dictLocal, "ref", () => EmitTSFunc(il, runtime, () => il.Emit(OpCodes.Ldloc, ctxLocal), _childCtxRef));
+        EmitDictSet(il, dictLocal, "unref", () => EmitTSFunc(il, runtime, () => il.Emit(OpCodes.Ldloc, ctxLocal), _childCtxRef));
+
+        if (streamed)
+            EmitBuildChildStreams(il, runtime, ctxLocal, dictLocal);
+
+        // ctx._dict = dict
+        StoreCtxField(il, ctxLocal, _childCtxDict, () => il.Emit(OpCodes.Ldloc, dictLocal));
+
+        // ChildRunAsync(new Func<object>(ctx, streamed ? RunStreamed : RunCaptured))
+        il.Emit(OpCodes.Ldloc, ctxLocal);
+        il.Emit(OpCodes.Ldftn, streamed ? _childCtxRunStreamed : _childCtxRunCaptured);
+        il.Emit(OpCodes.Newobj, typeof(Func<object>).GetConstructor([_types.Object, typeof(IntPtr)])!);
+        il.Emit(OpCodes.Call, _childRunAsync);
+
+        // return CreateObject(dict)
+        il.Emit(OpCodes.Ldloc, dictLocal);
+        il.Emit(OpCodes.Call, runtime.CreateObject);
+    }
+
+    // Stream wiring (real $Readable/$Writable + pumps) is implemented by the spawn
+    // child (#1014). For now the streamed path is unused (exec/execFile capture to
+    // strings); this placeholder keeps the seam compiling.
+    private void EmitBuildChildStreams(ILGenerator il, EmittedRuntime runtime, LocalBuilder ctxLocal, LocalBuilder dictLocal)
+    {
+        EmitDictSet(il, dictLocal, "stdout", () => { il.Emit(OpCodes.Newobj, _types.DictionaryStringObject.GetConstructor(Type.EmptyTypes)!); il.Emit(OpCodes.Call, runtime.CreateObject); });
+        EmitDictSet(il, dictLocal, "stderr", () => { il.Emit(OpCodes.Newobj, _types.DictionaryStringObject.GetConstructor(Type.EmptyTypes)!); il.Emit(OpCodes.Call, runtime.CreateObject); });
+        EmitDictSet(il, dictLocal, "stdin", () => { il.Emit(OpCodes.Newobj, _types.DictionaryStringObject.GetConstructor(Type.EmptyTypes)!); il.Emit(OpCodes.Call, runtime.CreateObject); });
+    }
+
+    private void EmitDictSet(ILGenerator il, LocalBuilder dictLocal, string key, Action emitValue)
+    {
+        il.Emit(OpCodes.Ldloc, dictLocal);
+        il.Emit(OpCodes.Ldstr, key);
+        emitValue();
+        il.Emit(OpCodes.Callvirt, _miDictSet);
+    }
+
+    private void StoreCtxField(ILGenerator il, LocalBuilder ctxLocal, FieldBuilder field, Action emitValue)
+    {
+        il.Emit(OpCodes.Ldloc, ctxLocal);
+        emitValue();
+        il.Emit(OpCodes.Stfld, field);
+    }
+
+    /// <summary>this.field = &lt;value&gt; — for use inside ctx instance methods (this = arg0).</summary>
+    private void StoreCtxField(ILGenerator il, FieldBuilder field, Action emitValue)
+    {
+        il.Emit(OpCodes.Ldarg_0);
+        emitValue();
+        il.Emit(OpCodes.Stfld, field);
+    }
+
+    /// <summary>Emit: new $TSFunction(target, methodof(method)).</summary>
+    private void EmitTSFunc(ILGenerator il, EmittedRuntime runtime, Action emitTarget, MethodInfo method)
+    {
+        emitTarget();
+        il.Emit(OpCodes.Ldtoken, method);
+        il.Emit(OpCodes.Call, _miGetMethodFromHandle);
+        il.Emit(OpCodes.Castclass, typeof(MethodInfo));
+        il.Emit(OpCodes.Newobj, runtime.TSFunctionCtor);
+    }
+}

--- a/Compilation/RuntimeEmitter.ChildProcessAsync.cs
+++ b/Compilation/RuntimeEmitter.ChildProcessAsync.cs
@@ -38,6 +38,8 @@ public partial class RuntimeEmitter
     private FieldBuilder _childCtxResCode = null!;     // int
     private FieldBuilder _childCtxResError = null!;    // object (error dict or null)
     private FieldBuilder _childCtxResKind = null!;     // int: 0 normal, 1 timeout, 2 exception
+    private FieldBuilder _childCtxStdoutRedir = null!; // bool: stdout redirected (mode != inherit)
+    private FieldBuilder _childCtxStderrRedir = null!; // bool: stderr redirected (mode != inherit)
 
     private MethodBuilder _childCtxRunCaptured = null!;
     private MethodBuilder _childCtxEmitCaptured = null!;
@@ -55,6 +57,7 @@ public partial class RuntimeEmitter
     private MethodBuilder _childRunAsync = null!;
     private MethodBuilder _childAsyncUnref = null!;
     private MethodBuilder _childConfigureSpawn = null!;
+    private MethodBuilder _childStdioMode = null!;
 
     // $ChildPush — a one-shot closure that pushes one chunk (or null = EOF) into a
     // $Readable on the event-loop thread, so all stream-buffer access stays single-threaded.
@@ -104,10 +107,93 @@ public partial class RuntimeEmitter
         DefineChildPushType(runtime);
         DefineChildCtxType(runtime);
         EmitChildRunAsyncHelpers(runtimeType, runtime);
+        EmitChildStdioMode(runtimeType, runtime);
         EmitConfigureSpawnStartInfo(runtimeType, runtime);
         EmitChildCtxMethods(runtime);
         _childCtxType.CreateType();
         _childPushType.CreateType();
+    }
+
+    /// <summary>
+    /// static int ChildStdioMode(object options, int fd): 0 pipe, 1 inherit, 2 ignore — from the
+    /// `stdio` option (string shorthand applied to all fds, or the array form). Mirrors the
+    /// interpreter's ParseStdioModes; unknown values (fd/stream/'ipc') fall back to pipe.
+    /// </summary>
+    private void EmitChildStdioMode(TypeBuilder runtimeType, EmittedRuntime runtime)
+    {
+        var m = runtimeType.DefineMethod("ChildStdioMode",
+            MethodAttributes.Public | MethodAttributes.Static, _types.Int32, [_types.Object, _types.Int32]);
+        _childStdioMode = m;
+        var il = m.GetILGenerator();
+        var dictLocal = il.DeclareLocal(_types.DictionaryStringObject);
+        var tmpLocal = il.DeclareLocal(_types.Object);
+        var strLocal = il.DeclareLocal(_types.String);
+        var pipe = il.DefineLabel();
+
+        // dict = options as Dictionary; if null -> pipe
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Isinst, _types.DictionaryStringObject);
+        il.Emit(OpCodes.Dup);
+        il.Emit(OpCodes.Stloc, dictLocal);
+        il.Emit(OpCodes.Brfalse, pipe);
+        // if (!dict.TryGetValue("stdio", out tmp)) -> pipe
+        il.Emit(OpCodes.Ldloc, dictLocal);
+        il.Emit(OpCodes.Ldstr, "stdio");
+        il.Emit(OpCodes.Ldloca, tmpLocal);
+        il.Emit(OpCodes.Callvirt, _types.DictionaryStringObject.GetMethod("TryGetValue", [_types.String, _types.Object.MakeByRefType()])!);
+        il.Emit(OpCodes.Brfalse, pipe);
+
+        // if (tmp is string) strLocal = tmp; else if (tmp is List l) strLocal = l[fd] as string (when fd<count); else pipe
+        var haveStr = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, tmpLocal);
+        il.Emit(OpCodes.Isinst, _types.String);
+        il.Emit(OpCodes.Dup);
+        il.Emit(OpCodes.Stloc, strLocal);
+        il.Emit(OpCodes.Brtrue, haveStr);
+        // list form
+        var notList = il.DefineLabel();
+        var listLocal = il.DeclareLocal(_types.ListOfObject);
+        il.Emit(OpCodes.Ldloc, tmpLocal);
+        il.Emit(OpCodes.Isinst, _types.ListOfObject);
+        il.Emit(OpCodes.Dup);
+        il.Emit(OpCodes.Stloc, listLocal);
+        il.Emit(OpCodes.Brfalse, notList);
+        // if (fd >= list.Count) pipe
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Ldloc, listLocal);
+        il.Emit(OpCodes.Callvirt, _types.ListOfObject.GetProperty("Count")!.GetGetMethod()!);
+        il.Emit(OpCodes.Bge, pipe);
+        il.Emit(OpCodes.Ldloc, listLocal);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Callvirt, _types.ListOfObject.GetMethod("get_Item", [_types.Int32])!);
+        il.Emit(OpCodes.Isinst, _types.String);
+        il.Emit(OpCodes.Stloc, strLocal);
+        il.Emit(OpCodes.Br, haveStr);
+        il.MarkLabel(notList);
+        il.Emit(OpCodes.Br, pipe);
+
+        il.MarkLabel(haveStr);
+        // if (strLocal == "inherit") return 1; if (strLocal == "ignore") return 2; else 0
+        var notInherit = il.DefineLabel();
+        var strEq = _types.String.GetMethod("op_Equality", [_types.String, _types.String])!;
+        il.Emit(OpCodes.Ldloc, strLocal);
+        il.Emit(OpCodes.Ldstr, "inherit");
+        il.Emit(OpCodes.Call, strEq);
+        il.Emit(OpCodes.Brfalse, notInherit);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Ret);
+        il.MarkLabel(notInherit);
+        var notIgnore = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, strLocal);
+        il.Emit(OpCodes.Ldstr, "ignore");
+        il.Emit(OpCodes.Call, strEq);
+        il.Emit(OpCodes.Brfalse, notIgnore);
+        il.Emit(OpCodes.Ldc_I4_2);
+        il.Emit(OpCodes.Ret);
+        il.MarkLabel(notIgnore);
+        il.MarkLabel(pipe);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Ret);
     }
 
     /// <summary>
@@ -133,6 +219,23 @@ public partial class RuntimeEmitter
         var concat3 = _types.String.GetMethod("Concat", [_types.String, _types.String, _types.String])!;
         var fnSet = _types.ProcessStartInfo.GetProperty("FileName")!.GetSetMethod()!;
         var argSet = _types.ProcessStartInfo.GetProperty("Arguments")!.GetSetMethod()!;
+
+        // Redirect each fd unless its stdio mode is 'inherit' (1). options = arg3.
+        void SetRedirect(string prop, int fd)
+        {
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldarg_3);
+            il.Emit(OpCodes.Ldc_I4, fd);
+            il.Emit(OpCodes.Call, _childStdioMode);
+            il.Emit(OpCodes.Ldc_I4_1);
+            il.Emit(OpCodes.Ceq);           // mode == inherit
+            il.Emit(OpCodes.Ldc_I4_0);
+            il.Emit(OpCodes.Ceq);           // redirect = !(mode == inherit)
+            il.Emit(OpCodes.Callvirt, _types.ProcessStartInfo.GetProperty(prop)!.GetSetMethod()!);
+        }
+        SetRedirect("RedirectStandardInput", 0);
+        SetRedirect("RedirectStandardOutput", 1);
+        SetRedirect("RedirectStandardError", 2);
 
         // argsList = args as List
         il.Emit(OpCodes.Ldarg_2);
@@ -356,6 +459,8 @@ public partial class RuntimeEmitter
         _childCtxResCode = t.DefineField("_resCode", _types.Int32, FieldAttributes.Public);
         _childCtxResError = t.DefineField("_resError", _types.Object, FieldAttributes.Public);
         _childCtxResKind = t.DefineField("_resKind", _types.Int32, FieldAttributes.Public);
+        _childCtxStdoutRedir = t.DefineField("_stdoutRedir", _types.Boolean, FieldAttributes.Public);
+        _childCtxStderrRedir = t.DefineField("_stderrRedir", _types.Boolean, FieldAttributes.Public);
 
         var ctor = t.DefineConstructor(MethodAttributes.Public, CallingConventions.Standard, Type.EmptyTypes);
         var cil = ctor.GetILGenerator();
@@ -839,24 +944,40 @@ public partial class RuntimeEmitter
 
         // Process was started synchronously in the dispatch (so stdin is usable immediately).
         il.BeginExceptionBlock();
-        // t1 = Task.Run(new Action(this, PumpStdout)); t2 = Task.Run(new Action(this, PumpStderr));
-        il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Ldftn, _childCtxPumpStdout);
-        il.Emit(OpCodes.Newobj, actionCtor);
-        il.Emit(OpCodes.Call, taskRunAction);
-        il.Emit(OpCodes.Stloc, t1);
-        il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Ldftn, _childCtxPumpStderr);
-        il.Emit(OpCodes.Newobj, actionCtor);
-        il.Emit(OpCodes.Call, taskRunAction);
-        il.Emit(OpCodes.Stloc, t2);
 
-        // _proc.WaitForExit(); t1.Wait(); t2.Wait();
+        // Start a pump task only for a redirected fd (an 'inherit' fd is not redirected, so
+        // reading it would throw). t1/t2 default to null and are awaited with a null-guard.
+        il.Emit(OpCodes.Ldnull); il.Emit(OpCodes.Stloc, t1);
+        il.Emit(OpCodes.Ldnull); il.Emit(OpCodes.Stloc, t2);
+        void StartPump(FieldBuilder redirField, MethodBuilder pump, LocalBuilder tLocal)
+        {
+            var skip = il.DefineLabel();
+            il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Ldfld, redirField);
+            il.Emit(OpCodes.Brfalse, skip);
+            il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Ldftn, pump);
+            il.Emit(OpCodes.Newobj, actionCtor);
+            il.Emit(OpCodes.Call, taskRunAction);
+            il.Emit(OpCodes.Stloc, tLocal);
+            il.MarkLabel(skip);
+        }
+        StartPump(_childCtxStdoutRedir, _childCtxPumpStdout, t1);
+        StartPump(_childCtxStderrRedir, _childCtxPumpStderr, t2);
+
+        // _proc.WaitForExit(); t1?.Wait(); t2?.Wait();
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ldfld, _childCtxProc);
         il.Emit(OpCodes.Callvirt, _miProcWaitForExit);
-        il.Emit(OpCodes.Ldloc, t1);
-        il.Emit(OpCodes.Callvirt, typeof(Task).GetMethod("Wait", Type.EmptyTypes)!);
-        il.Emit(OpCodes.Ldloc, t2);
-        il.Emit(OpCodes.Callvirt, typeof(Task).GetMethod("Wait", Type.EmptyTypes)!);
+        void AwaitTask(LocalBuilder tLocal)
+        {
+            var skip = il.DefineLabel();
+            il.Emit(OpCodes.Ldloc, tLocal);
+            il.Emit(OpCodes.Brfalse, skip);
+            il.Emit(OpCodes.Ldloc, tLocal);
+            il.Emit(OpCodes.Callvirt, typeof(Task).GetMethod("Wait", Type.EmptyTypes)!);
+            il.MarkLabel(skip);
+        }
+        AwaitTask(t1);
+        AwaitTask(t2);
 
         // _resCode = _proc.ExitCode;
         StoreCtxField(il, _childCtxResCode, () =>
@@ -925,10 +1046,15 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloc, nLocal);
         il.Emit(OpCodes.Ldc_I4_0);
         il.Emit(OpCodes.Ble, loopEnd);
-        // Schedule push(stream, new string(buf,0,n))
+        // Schedule push(stream, new string(buf,0,n)) — but only when piped (stream != null);
+        // for 'ignore' the field is null and we just drain.
+        var skipData = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Ldfld, streamField);
+        il.Emit(OpCodes.Brfalse, skipData);
         EmitScheduleChildPush(il, runtime,
             () => { il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Ldfld, streamField); },
             () => { il.Emit(OpCodes.Ldloc, bufLocal); il.Emit(OpCodes.Ldc_I4_0); il.Emit(OpCodes.Ldloc, nLocal); il.Emit(OpCodes.Newobj, newStr); });
+        il.MarkLabel(skipData);
         il.Emit(OpCodes.Br, loop);
         il.MarkLabel(loopEnd);
         il.Emit(OpCodes.Leave, afterTry);
@@ -938,10 +1064,14 @@ public partial class RuntimeEmitter
         il.EndExceptionBlock();
         il.MarkLabel(afterTry);
 
-        // Schedule push(stream, null) — EOF/end
+        // Schedule push(stream, null) — EOF/end (only when piped).
+        var skipEnd = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Ldfld, streamField);
+        il.Emit(OpCodes.Brfalse, skipEnd);
         EmitScheduleChildPush(il, runtime,
             () => { il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Ldfld, streamField); },
             () => il.Emit(OpCodes.Ldnull));
+        il.MarkLabel(skipEnd);
         il.Emit(OpCodes.Ret);
     }
 
@@ -1322,7 +1452,7 @@ public partial class RuntimeEmitter
         EmitDictSet(il, dictLocal, "unref", () => EmitTSFunc(il, runtime, () => il.Emit(OpCodes.Ldloc, ctxLocal), _childCtxRef));
 
         if (streamed)
-            EmitBuildChildStreams(il, runtime, ctxLocal, dictLocal);
+            EmitBuildChildStreams(il, runtime, ctxLocal, dictLocal, optionsLocal);
 
         // ctx._dict = dict
         StoreCtxField(il, ctxLocal, _childCtxDict, () => il.Emit(OpCodes.Ldloc, dictLocal));
@@ -1359,22 +1489,62 @@ public partial class RuntimeEmitter
     /// object whose write/end push to the child's StandardInput. stdout/stderr are stored
     /// on ctx so the worker can push into them.
     /// </summary>
-    private void EmitBuildChildStreams(ILGenerator il, EmittedRuntime runtime, LocalBuilder ctxLocal, LocalBuilder dictLocal)
+    private void EmitBuildChildStreams(ILGenerator il, EmittedRuntime runtime, LocalBuilder ctxLocal, LocalBuilder dictLocal, LocalBuilder optionsLocal)
     {
-        var stdoutLocal = il.DeclareLocal(runtime.TSReadableType);
-        var stderrLocal = il.DeclareLocal(runtime.TSReadableType);
+        // mode(fd): 0 pipe, 1 inherit, 2 ignore. Only 'pipe' fds get a real stream (others null,
+        // matching Node). redir = mode != inherit (so 'ignore' is still read-and-drained).
+        void Mode(LocalBuilder outLocal, int fd)
+        {
+            il.Emit(OpCodes.Ldloc, optionsLocal);
+            il.Emit(OpCodes.Ldc_I4, fd);
+            il.Emit(OpCodes.Call, _childStdioMode);
+            il.Emit(OpCodes.Stloc, outLocal);
+        }
+        var outMode = il.DeclareLocal(_types.Int32);
+        var errMode = il.DeclareLocal(_types.Int32);
+        var inMode = il.DeclareLocal(_types.Int32);
+        Mode(outMode, 1); Mode(errMode, 2); Mode(inMode, 0);
 
-        il.Emit(OpCodes.Newobj, runtime.TSReadableCtor);
-        il.Emit(OpCodes.Stloc, stdoutLocal);
-        il.Emit(OpCodes.Newobj, runtime.TSReadableCtor);
-        il.Emit(OpCodes.Stloc, stderrLocal);
+        // ctx redirected flags (mode != inherit)
+        void StoreRedir(FieldBuilder f, LocalBuilder mode)
+        {
+            StoreCtxField(il, ctxLocal, f, () =>
+            {
+                il.Emit(OpCodes.Ldloc, mode); il.Emit(OpCodes.Ldc_I4_1); il.Emit(OpCodes.Ceq);
+                il.Emit(OpCodes.Ldc_I4_0); il.Emit(OpCodes.Ceq);
+            });
+        }
+        StoreRedir(_childCtxStdoutRedir, outMode);
+        StoreRedir(_childCtxStderrRedir, errMode);
 
-        StoreCtxField(il, ctxLocal, _childCtxStdout, () => il.Emit(OpCodes.Ldloc, stdoutLocal));
-        StoreCtxField(il, ctxLocal, _childCtxStderr, () => il.Emit(OpCodes.Ldloc, stderrLocal));
-        EmitDictSet(il, dictLocal, "stdout", () => il.Emit(OpCodes.Ldloc, stdoutLocal));
-        EmitDictSet(il, dictLocal, "stderr", () => il.Emit(OpCodes.Ldloc, stderrLocal));
+        // A readable fd: if pipe, build $Readable + wire ctx + dict; else dict[key]=null.
+        void BuildReadable(LocalBuilder mode, FieldBuilder ctxField, string key)
+        {
+            var pipe = il.DefineLabel();
+            var done = il.DefineLabel();
+            il.Emit(OpCodes.Ldloc, mode);
+            il.Emit(OpCodes.Brfalse, pipe); // 0 == pipe
+            EmitDictSet(il, dictLocal, key, () => il.Emit(OpCodes.Ldnull));
+            il.Emit(OpCodes.Br, done);
+            il.MarkLabel(pipe);
+            var sLocal = il.DeclareLocal(runtime.TSReadableType);
+            il.Emit(OpCodes.Newobj, runtime.TSReadableCtor);
+            il.Emit(OpCodes.Stloc, sLocal);
+            StoreCtxField(il, ctxLocal, ctxField, () => il.Emit(OpCodes.Ldloc, sLocal));
+            EmitDictSet(il, dictLocal, key, () => il.Emit(OpCodes.Ldloc, sLocal));
+            il.MarkLabel(done);
+        }
+        BuildReadable(outMode, _childCtxStdout, "stdout");
+        BuildReadable(errMode, _childCtxStderr, "stderr");
 
-        // stdin = { writable: true, write: ctx.StdinWrite, end: ctx.StdinEnd }
+        // stdin: if pipe, a forwarding { writable, write, end }; else null.
+        var stdinPipe = il.DefineLabel();
+        var stdinDone = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, inMode);
+        il.Emit(OpCodes.Brfalse, stdinPipe);
+        EmitDictSet(il, dictLocal, "stdin", () => il.Emit(OpCodes.Ldnull));
+        il.Emit(OpCodes.Br, stdinDone);
+        il.MarkLabel(stdinPipe);
         var stdinLocal = il.DeclareLocal(_types.DictionaryStringObject);
         il.Emit(OpCodes.Newobj, _types.DictionaryStringObject.GetConstructor(Type.EmptyTypes)!);
         il.Emit(OpCodes.Stloc, stdinLocal);
@@ -1382,6 +1552,7 @@ public partial class RuntimeEmitter
         EmitDictSet(il, stdinLocal, "write", () => EmitTSFunc(il, runtime, () => il.Emit(OpCodes.Ldloc, ctxLocal), _childCtxStdinWrite));
         EmitDictSet(il, stdinLocal, "end", () => EmitTSFunc(il, runtime, () => il.Emit(OpCodes.Ldloc, ctxLocal), _childCtxStdinEnd));
         EmitDictSet(il, dictLocal, "stdin", () => { il.Emit(OpCodes.Ldloc, stdinLocal); il.Emit(OpCodes.Call, runtime.CreateObject); });
+        il.MarkLabel(stdinDone);
     }
 
     private void EmitDictSet(ILGenerator il, LocalBuilder dictLocal, string key, Action emitValue)

--- a/Compilation/RuntimeEmitter.ChildProcessAsync.cs
+++ b/Compilation/RuntimeEmitter.ChildProcessAsync.cs
@@ -60,6 +60,8 @@ public partial class RuntimeEmitter
     private MethodBuilder _childConfigureSpawn = null!;
     private MethodBuilder _childStdioMode = null!;
     private MethodBuilder _childReadCapped = null!;
+    private MethodBuilder _childSpawnError = null!;
+    private MethodBuilder _childCtxRunSpawnError = null!;
 
     // $ChildPush — a one-shot closure that pushes one chunk (or null = EOF) into a
     // $Readable on the event-loop thread, so all stream-buffer access stays single-threaded.
@@ -111,6 +113,7 @@ public partial class RuntimeEmitter
         EmitChildRunAsyncHelpers(runtimeType, runtime);
         EmitChildStdioMode(runtimeType, runtime);
         EmitChildReadCapped(runtimeType, runtime);
+        EmitChildSpawnError(runtimeType, runtime);
         EmitConfigureSpawnStartInfo(runtimeType, runtime);
         EmitChildCtxMethods(runtime);
         _childCtxType.CreateType();
@@ -478,6 +481,7 @@ public partial class RuntimeEmitter
         _childCtxRunCaptured = t.DefineMethod("RunCaptured", MethodAttributes.Public, _types.Object, Type.EmptyTypes);
         _childCtxEmitCaptured = t.DefineMethod("EmitCaptured", MethodAttributes.Public, _types.Void, Type.EmptyTypes);
         _childCtxRunStreamed = t.DefineMethod("RunStreamed", MethodAttributes.Public, _types.Object, Type.EmptyTypes);
+        _childCtxRunSpawnError = t.DefineMethod("RunSpawnError", MethodAttributes.Public, _types.Object, Type.EmptyTypes);
         _childCtxEmitStreamClose = t.DefineMethod("EmitStreamClose", MethodAttributes.Public, _types.Void, Type.EmptyTypes);
         _childCtxPumpStdout = t.DefineMethod("PumpStdout", MethodAttributes.Public, _types.Void, Type.EmptyTypes);
         _childCtxPumpStderr = t.DefineMethod("PumpStderr", MethodAttributes.Public, _types.Void, Type.EmptyTypes);
@@ -628,6 +632,7 @@ public partial class RuntimeEmitter
         EmitCtxRunCaptured(runtime);
         EmitCtxEmitCaptured(runtime);
         EmitCtxRunStreamed(runtime);
+        EmitCtxRunSpawnError(runtime);
         EmitCtxPumpStdout(runtime);
         EmitCtxPumpStderr(runtime);
         EmitCtxEmitStreamClose(runtime);
@@ -1029,6 +1034,15 @@ public partial class RuntimeEmitter
         il.EndExceptionBlock();
 
         il.MarkLabel(afterTry);
+        EmitScheduleOnLoop(il, runtime, _childCtxEmitStreamClose);
+        il.Emit(OpCodes.Ldnull);
+        il.Emit(OpCodes.Ret);
+    }
+
+    /// <summary>Spawn-failure worker: schedule EmitStreamClose (which, with _resKind==2, emits 'error').</summary>
+    private void EmitCtxRunSpawnError(EmittedRuntime runtime)
+    {
+        var il = _childCtxRunSpawnError.GetILGenerator();
         EmitScheduleOnLoop(il, runtime, _childCtxEmitStreamClose);
         il.Emit(OpCodes.Ldnull);
         il.Emit(OpCodes.Ret);
@@ -1488,10 +1502,21 @@ public partial class RuntimeEmitter
         // ctx._dict = dict
         StoreCtxField(il, ctxLocal, _childCtxDict, () => il.Emit(OpCodes.Ldloc, dictLocal));
 
-        // For spawn (streamed), start the process synchronously so child.stdin.write()/
-        // .end() called on the same synchronous tick reach a live StandardInput.
+        var funcCtor = typeof(Func<object>).GetConstructor([_types.Object, typeof(IntPtr)])!;
+        void Launch(MethodBuilder worker)
+        {
+            il.Emit(OpCodes.Ldloc, ctxLocal);
+            il.Emit(OpCodes.Ldftn, worker);
+            il.Emit(OpCodes.Newobj, funcCtor);
+            il.Emit(OpCodes.Call, _childRunAsync);
+        }
+
         if (streamed)
         {
+            // Start the process synchronously so child.stdin.write()/.end() on the same tick
+            // reach a live StandardInput. A start failure (e.g. ENOENT) becomes an async 'error'.
+            var afterLaunch = il.DefineLabel();
+            il.BeginExceptionBlock();
             il.Emit(OpCodes.Ldloc, processLocal);
             il.Emit(OpCodes.Callvirt, _miProcStart);
             il.Emit(OpCodes.Pop);
@@ -1502,13 +1527,30 @@ public partial class RuntimeEmitter
                 il.Emit(OpCodes.Conv_R8);
                 il.Emit(OpCodes.Box, _types.Double);
             });
+            Launch(_childCtxRunStreamed);
+            il.Emit(OpCodes.Leave, afterLaunch);
+            il.BeginCatchBlock(_types.Exception);
+            var exLocal = il.DeclareLocal(_types.Exception);
+            il.Emit(OpCodes.Stloc, exLocal);
+            StoreCtxField(il, ctxLocal, _childCtxResKind, () => il.Emit(OpCodes.Ldc_I4_2));
+            StoreCtxField(il, ctxLocal, _childCtxResError, () =>
+            {
+                il.Emit(OpCodes.Ldloc, exLocal);
+                il.Emit(OpCodes.Ldloc, processLocal);
+                il.Emit(OpCodes.Callvirt, _types.Process.GetProperty("StartInfo")!.GetGetMethod()!);
+                il.Emit(OpCodes.Callvirt, _types.ProcessStartInfo.GetProperty("FileName")!.GetGetMethod()!);
+                il.Emit(OpCodes.Ldstr, "spawn");
+                il.Emit(OpCodes.Call, _childSpawnError);
+            });
+            Launch(_childCtxRunSpawnError);
+            il.Emit(OpCodes.Leave, afterLaunch);
+            il.EndExceptionBlock();
+            il.MarkLabel(afterLaunch);
         }
-
-        // ChildRunAsync(new Func<object>(ctx, streamed ? RunStreamed : RunCaptured))
-        il.Emit(OpCodes.Ldloc, ctxLocal);
-        il.Emit(OpCodes.Ldftn, streamed ? _childCtxRunStreamed : _childCtxRunCaptured);
-        il.Emit(OpCodes.Newobj, typeof(Func<object>).GetConstructor([_types.Object, typeof(IntPtr)])!);
-        il.Emit(OpCodes.Call, _childRunAsync);
+        else
+        {
+            Launch(_childCtxRunCaptured);
+        }
 
         // return CreateObject(dict)
         il.Emit(OpCodes.Ldloc, dictLocal);
@@ -1705,6 +1747,73 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Br, loop);
         il.MarkLabel(end);
         il.Emit(OpCodes.Ldloc, sbLocal); il.Emit(OpCodes.Callvirt, _types.GetMethodNoParams(_types.StringBuilder, "ToString"));
+        il.Emit(OpCodes.Ret);
+    }
+
+    /// <summary>
+    /// static object ChildSpawnError(object exObj, string command, string syscall): a Node-style
+    /// error dict. A missing executable (Win32 error 2) → ENOENT with code/errno/syscall/path.
+    /// </summary>
+    private void EmitChildSpawnError(TypeBuilder runtimeType, EmittedRuntime runtime)
+    {
+        var m = runtimeType.DefineMethod("ChildSpawnError",
+            MethodAttributes.Public | MethodAttributes.Static, _types.Object,
+            [_types.Object, _types.String, _types.String]);
+        _childSpawnError = m;
+        var il = m.GetILGenerator();
+        var w32 = typeof(System.ComponentModel.Win32Exception);
+        var concat3 = _types.String.GetMethod("Concat", [_types.String, _types.String, _types.String])!;
+        var concat2 = _types.String.GetMethod("Concat", [_types.String, _types.String])!;
+        var prefixLocal = il.DeclareLocal(_types.String);   // "syscall command"
+        var dictLocal = il.DeclareLocal(_types.DictionaryStringObject);
+        var wLocal = il.DeclareLocal(w32);
+        var generic = il.DefineLabel();
+
+        // w = exObj as Win32Exception; if (w == null || w.NativeErrorCode != 2) -> generic
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Isinst, w32);
+        il.Emit(OpCodes.Dup);
+        il.Emit(OpCodes.Stloc, wLocal);
+        il.Emit(OpCodes.Brfalse, generic);
+        il.Emit(OpCodes.Ldloc, wLocal);
+        il.Emit(OpCodes.Callvirt, w32.GetProperty("NativeErrorCode")!.GetGetMethod()!);
+        il.Emit(OpCodes.Ldc_I4_2);
+        il.Emit(OpCodes.Bne_Un, generic);
+
+        // prefix = syscall + " " + command
+        il.Emit(OpCodes.Ldarg_2); il.Emit(OpCodes.Ldstr, " "); il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Call, concat3);
+        il.Emit(OpCodes.Stloc, prefixLocal);
+
+        il.Emit(OpCodes.Newobj, _types.DictionaryStringObject.GetConstructor(Type.EmptyTypes)!);
+        il.Emit(OpCodes.Stloc, dictLocal);
+        void Set(string key, Action v) { il.Emit(OpCodes.Ldloc, dictLocal); il.Emit(OpCodes.Ldstr, key); v(); il.Emit(OpCodes.Callvirt, _miDictSet); }
+        Set("message", () => { il.Emit(OpCodes.Ldloc, prefixLocal); il.Emit(OpCodes.Ldstr, " ENOENT"); il.Emit(OpCodes.Call, concat2); });
+        Set("code", () => il.Emit(OpCodes.Ldstr, "ENOENT"));
+        Set("errno", () =>
+        {
+            var unix = il.DefineLabel();
+            var done = il.DefineLabel();
+            il.Emit(OpCodes.Call, _types.OSPlatform.GetProperty("Windows")!.GetGetMethod()!);
+            il.Emit(OpCodes.Call, _types.RuntimeInformation.GetMethod("IsOSPlatform", [_types.OSPlatform])!);
+            il.Emit(OpCodes.Brfalse, unix);
+            il.Emit(OpCodes.Ldc_R8, -4058.0); il.Emit(OpCodes.Br, done);
+            il.MarkLabel(unix); il.Emit(OpCodes.Ldc_R8, -2.0);
+            il.MarkLabel(done); il.Emit(OpCodes.Box, _types.Double);
+        });
+        Set("syscall", () => il.Emit(OpCodes.Ldloc, prefixLocal));
+        Set("path", () => il.Emit(OpCodes.Ldarg_1));
+        il.Emit(OpCodes.Ldloc, dictLocal);
+        il.Emit(OpCodes.Ret);
+
+        // generic: { message: ((Exception)exObj).Message }
+        il.MarkLabel(generic);
+        il.Emit(OpCodes.Newobj, _types.DictionaryStringObject.GetConstructor(Type.EmptyTypes)!);
+        il.Emit(OpCodes.Stloc, dictLocal);
+        il.Emit(OpCodes.Ldloc, dictLocal); il.Emit(OpCodes.Ldstr, "message");
+        il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Castclass, _types.Exception); il.Emit(OpCodes.Callvirt, _miExceptionMessageGet);
+        il.Emit(OpCodes.Callvirt, _miDictSet);
+        il.Emit(OpCodes.Ldloc, dictLocal);
         il.Emit(OpCodes.Ret);
     }
 

--- a/Compilation/RuntimeEmitter.ChildProcessAsync.cs
+++ b/Compilation/RuntimeEmitter.ChildProcessAsync.cs
@@ -42,6 +42,9 @@ public partial class RuntimeEmitter
     private MethodBuilder _childCtxRunCaptured = null!;
     private MethodBuilder _childCtxEmitCaptured = null!;
     private MethodBuilder _childCtxRunStreamed = null!;
+    private MethodBuilder _childCtxEmitStreamClose = null!;
+    private MethodBuilder _childCtxPumpStdout = null!;
+    private MethodBuilder _childCtxPumpStderr = null!;
     private MethodBuilder _childCtxKill = null!;
     private MethodBuilder _childCtxSend = null!;
     private MethodBuilder _childCtxDisconnect = null!;
@@ -51,6 +54,14 @@ public partial class RuntimeEmitter
 
     private MethodBuilder _childRunAsync = null!;
     private MethodBuilder _childAsyncUnref = null!;
+
+    // $ChildPush — a one-shot closure that pushes one chunk (or null = EOF) into a
+    // $Readable on the event-loop thread, so all stream-buffer access stays single-threaded.
+    private TypeBuilder _childPushType = null!;
+    private ConstructorBuilder _childPushCtor = null!;
+    private MethodBuilder _childPushRun = null!;
+    private FieldBuilder _childPushStream = null!;
+    private FieldBuilder _childPushChunk = null!;
 
     // BCL handles, resolved once.
     private MethodInfo _miProcStart = null!;
@@ -89,10 +100,42 @@ public partial class RuntimeEmitter
         _miDictSet = _types.GetMethod(_types.DictionaryStringObject, "set_Item", _types.String, _types.Object)!;
         _miGetMethodFromHandle = typeof(MethodBase).GetMethod("GetMethodFromHandle", [typeof(RuntimeMethodHandle)])!;
 
+        DefineChildPushType(runtime);
         DefineChildCtxType(runtime);
         EmitChildRunAsyncHelpers(runtimeType, runtime);
         EmitChildCtxMethods(runtime);
         _childCtxType.CreateType();
+        _childPushType.CreateType();
+    }
+
+    /// <summary>$ChildPush { object _stream; object _chunk; void Run() =&gt; (($Readable)_stream).Push(_chunk); }</summary>
+    private void DefineChildPushType(EmittedRuntime runtime)
+    {
+        var mb = (ModuleBuilder)((TypeBuilder)runtime.TSEventEmitterType).Module;
+        var t = mb.DefineType("$ChildPush",
+            TypeAttributes.Public | TypeAttributes.Sealed | TypeAttributes.BeforeFieldInit, _types.Object);
+        _childPushType = t;
+        _childPushStream = t.DefineField("_stream", _types.Object, FieldAttributes.Public);
+        _childPushChunk = t.DefineField("_chunk", _types.Object, FieldAttributes.Public);
+
+        var ctor = t.DefineConstructor(MethodAttributes.Public, CallingConventions.Standard, [_types.Object, _types.Object]);
+        var cil = ctor.GetILGenerator();
+        cil.Emit(OpCodes.Ldarg_0); cil.Emit(OpCodes.Call, _types.Object.GetConstructor(Type.EmptyTypes)!);
+        cil.Emit(OpCodes.Ldarg_0); cil.Emit(OpCodes.Ldarg_1); cil.Emit(OpCodes.Stfld, _childPushStream);
+        cil.Emit(OpCodes.Ldarg_0); cil.Emit(OpCodes.Ldarg_2); cil.Emit(OpCodes.Stfld, _childPushChunk);
+        cil.Emit(OpCodes.Ret);
+        _childPushCtor = ctor;
+
+        _childPushRun = t.DefineMethod("Run", MethodAttributes.Public, _types.Void, Type.EmptyTypes);
+        var il = _childPushRun.GetILGenerator();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, _childPushStream);
+        il.Emit(OpCodes.Castclass, runtime.TSReadableType);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, _childPushChunk);
+        il.Emit(OpCodes.Callvirt, runtime.TSReadablePush);
+        il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Ret);
     }
 
     private void DefineChildCtxType(EmittedRuntime runtime)
@@ -132,6 +175,9 @@ public partial class RuntimeEmitter
         _childCtxRunCaptured = t.DefineMethod("RunCaptured", MethodAttributes.Public, _types.Object, Type.EmptyTypes);
         _childCtxEmitCaptured = t.DefineMethod("EmitCaptured", MethodAttributes.Public, _types.Void, Type.EmptyTypes);
         _childCtxRunStreamed = t.DefineMethod("RunStreamed", MethodAttributes.Public, _types.Object, Type.EmptyTypes);
+        _childCtxEmitStreamClose = t.DefineMethod("EmitStreamClose", MethodAttributes.Public, _types.Void, Type.EmptyTypes);
+        _childCtxPumpStdout = t.DefineMethod("PumpStdout", MethodAttributes.Public, _types.Void, Type.EmptyTypes);
+        _childCtxPumpStderr = t.DefineMethod("PumpStderr", MethodAttributes.Public, _types.Void, Type.EmptyTypes);
         _childCtxKill = t.DefineMethod("Kill", MethodAttributes.Public, _types.Object, [_types.Object]);
         _childCtxSend = t.DefineMethod("Send", MethodAttributes.Public, _types.Object, [_types.Object]);
         _childCtxDisconnect = t.DefineMethod("Disconnect", MethodAttributes.Public, _types.Object, Type.EmptyTypes);
@@ -279,6 +325,9 @@ public partial class RuntimeEmitter
         EmitCtxRunCaptured(runtime);
         EmitCtxEmitCaptured(runtime);
         EmitCtxRunStreamed(runtime);
+        EmitCtxPumpStdout(runtime);
+        EmitCtxPumpStderr(runtime);
+        EmitCtxEmitStreamClose(runtime);
         EmitCtxKill(runtime);
         EmitCtxSend(runtime);
         EmitCtxDisconnect(runtime);
@@ -565,28 +614,275 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ret);
     }
 
-    // RunStreamed / StdinWrite / StdinEnd bodies are filled by the spawn child (#1014).
-    // For now they are inert (return null) so the type verifies.
+    /// <summary>
+    /// spawn worker (bg thread): start, pump stdout/stderr on background tasks (each pushing
+    /// chunks into its $Readable on the loop thread), wait, then Schedule EmitStreamClose.
+    /// </summary>
     private void EmitCtxRunStreamed(EmittedRuntime runtime)
     {
         var il = _childCtxRunStreamed.GetILGenerator();
+        var t1 = il.DeclareLocal(typeof(Task));
+        var t2 = il.DeclareLocal(typeof(Task));
+        var afterTry = il.DefineLabel();
+        var actionCtor = typeof(Action).GetConstructor([_types.Object, typeof(IntPtr)])!;
+        var taskRunAction = typeof(Task).GetMethod("Run", [typeof(Action)])!;
+
+        StoreCtxField(il, _childCtxResKind, () => il.Emit(OpCodes.Ldc_I4_0));
+
+        // Process was started synchronously in the dispatch (so stdin is usable immediately).
+        il.BeginExceptionBlock();
+        // t1 = Task.Run(new Action(this, PumpStdout)); t2 = Task.Run(new Action(this, PumpStderr));
+        il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Ldftn, _childCtxPumpStdout);
+        il.Emit(OpCodes.Newobj, actionCtor);
+        il.Emit(OpCodes.Call, taskRunAction);
+        il.Emit(OpCodes.Stloc, t1);
+        il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Ldftn, _childCtxPumpStderr);
+        il.Emit(OpCodes.Newobj, actionCtor);
+        il.Emit(OpCodes.Call, taskRunAction);
+        il.Emit(OpCodes.Stloc, t2);
+
+        // _proc.WaitForExit(); t1.Wait(); t2.Wait();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, _childCtxProc);
+        il.Emit(OpCodes.Callvirt, _miProcWaitForExit);
+        il.Emit(OpCodes.Ldloc, t1);
+        il.Emit(OpCodes.Callvirt, typeof(Task).GetMethod("Wait", Type.EmptyTypes)!);
+        il.Emit(OpCodes.Ldloc, t2);
+        il.Emit(OpCodes.Callvirt, typeof(Task).GetMethod("Wait", Type.EmptyTypes)!);
+
+        // _resCode = _proc.ExitCode;
+        StoreCtxField(il, _childCtxResCode, () =>
+        {
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, _childCtxProc);
+            il.Emit(OpCodes.Callvirt, _miProcExitCodeGet);
+        });
+        il.Emit(OpCodes.Leave, afterTry);
+
+        il.BeginCatchBlock(_types.Exception);
+        var exLocal = il.DeclareLocal(_types.Exception);
+        il.Emit(OpCodes.Stloc, exLocal);
+        StoreCtxField(il, _childCtxResKind, () => il.Emit(OpCodes.Ldc_I4_2));
+        StoreCtxField(il, _childCtxResError, () =>
+            EmitNewErrorObject(il,
+                () => { il.Emit(OpCodes.Ldloc, exLocal); il.Emit(OpCodes.Callvirt, _miExceptionMessageGet); },
+                null));
+        il.Emit(OpCodes.Leave, afterTry);
+        il.EndExceptionBlock();
+
+        il.MarkLabel(afterTry);
+        EmitScheduleOnLoop(il, runtime, _childCtxEmitStreamClose);
         il.Emit(OpCodes.Ldnull);
         il.Emit(OpCodes.Ret);
     }
 
+    private void EmitCtxPumpStdout(EmittedRuntime runtime) => EmitPumpBody(_childCtxPumpStdout, runtime, _miProcStdoutGet, _childCtxStdout);
+    private void EmitCtxPumpStderr(EmittedRuntime runtime) => EmitPumpBody(_childCtxPumpStderr, runtime, _miProcStderrGet, _childCtxStderr);
+
+    /// <summary>
+    /// Read the redirected pipe in char chunks; for each chunk Schedule a $ChildPush onto
+    /// the loop (data), and on EOF Schedule a $ChildPush(null) (end).
+    /// </summary>
+    private void EmitPumpBody(MethodBuilder method, EmittedRuntime runtime, MethodInfo readerGetter, FieldBuilder streamField)
+    {
+        var il = method.GetILGenerator();
+        var readerLocal = il.DeclareLocal(_types.TextReader);
+        var bufLocal = il.DeclareLocal(typeof(char[]));
+        var nLocal = il.DeclareLocal(_types.Int32);
+        var readMethod = _types.TextReader.GetMethod("Read", [typeof(char[]), _types.Int32, _types.Int32])!;
+        var newStr = typeof(string).GetConstructor([typeof(char[]), _types.Int32, _types.Int32])!;
+        var afterTry = il.DefineLabel();
+
+        // reader = _proc.<getter>(); buf = new char[4096];
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, _childCtxProc);
+        il.Emit(OpCodes.Callvirt, readerGetter);
+        il.Emit(OpCodes.Stloc, readerLocal);
+        il.Emit(OpCodes.Ldc_I4, 4096);
+        il.Emit(OpCodes.Newarr, typeof(char));
+        il.Emit(OpCodes.Stloc, bufLocal);
+
+        il.BeginExceptionBlock();
+        var loop = il.DefineLabel();
+        var loopEnd = il.DefineLabel();
+        il.MarkLabel(loop);
+        // n = reader.Read(buf, 0, 4096)
+        il.Emit(OpCodes.Ldloc, readerLocal);
+        il.Emit(OpCodes.Ldloc, bufLocal);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Ldc_I4, 4096);
+        il.Emit(OpCodes.Callvirt, readMethod);
+        il.Emit(OpCodes.Stloc, nLocal);
+        // if (n <= 0) break;
+        il.Emit(OpCodes.Ldloc, nLocal);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Ble, loopEnd);
+        // Schedule push(stream, new string(buf,0,n))
+        EmitScheduleChildPush(il, runtime,
+            () => { il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Ldfld, streamField); },
+            () => { il.Emit(OpCodes.Ldloc, bufLocal); il.Emit(OpCodes.Ldc_I4_0); il.Emit(OpCodes.Ldloc, nLocal); il.Emit(OpCodes.Newobj, newStr); });
+        il.Emit(OpCodes.Br, loop);
+        il.MarkLabel(loopEnd);
+        il.Emit(OpCodes.Leave, afterTry);
+        il.BeginCatchBlock(_types.Exception);
+        il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Leave, afterTry);
+        il.EndExceptionBlock();
+        il.MarkLabel(afterTry);
+
+        // Schedule push(stream, null) — EOF/end
+        EmitScheduleChildPush(il, runtime,
+            () => { il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Ldfld, streamField); },
+            () => il.Emit(OpCodes.Ldnull));
+        il.Emit(OpCodes.Ret);
+    }
+
+    /// <summary>Emit: EventLoop.GetInstance().Schedule(new Action(new $ChildPush(stream, chunk), Run)).</summary>
+    private void EmitScheduleChildPush(ILGenerator il, EmittedRuntime runtime, Action emitStream, Action emitChunk)
+    {
+        il.Emit(OpCodes.Call, runtime.EventLoopGetInstance);
+        emitStream();
+        emitChunk();
+        il.Emit(OpCodes.Newobj, _childPushCtor);
+        il.Emit(OpCodes.Ldftn, _childPushRun);
+        il.Emit(OpCodes.Newobj, typeof(Action).GetConstructor([_types.Object, typeof(IntPtr)])!);
+        il.Emit(OpCodes.Callvirt, runtime.EventLoopSchedule);
+    }
+
+    /// <summary>Replays spawn close/exit (or error) on the loop thread, after all data/end pushes.</summary>
+    private void EmitCtxEmitStreamClose(EmittedRuntime runtime)
+    {
+        var il = _childCtxEmitStreamClose.GetILGenerator();
+        var codeLocal = il.DeclareLocal(_types.Int32);
+        var ret = il.DefineLabel();
+
+        // if (_resKind == 2) emit error; return
+        var notExc = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, _childCtxResKind);
+        il.Emit(OpCodes.Ldc_I4_2);
+        il.Emit(OpCodes.Bne_Un, notExc);
+        EmitCtxEmit(il, runtime, "error", () => { il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Ldfld, _childCtxResError); });
+        il.Emit(OpCodes.Br, ret);
+        il.MarkLabel(notExc);
+
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, _childCtxResCode);
+        il.Emit(OpCodes.Stloc, codeLocal);
+        EmitDictSetFromCtx(il, "exitCode", () => { il.Emit(OpCodes.Ldloc, codeLocal); il.Emit(OpCodes.Conv_R8); il.Emit(OpCodes.Box, _types.Double); });
+        EmitCtxEmit(il, runtime, "close", () => { il.Emit(OpCodes.Ldloc, codeLocal); il.Emit(OpCodes.Conv_R8); il.Emit(OpCodes.Box, _types.Double); });
+        EmitCtxEmit(il, runtime, "exit", () => { il.Emit(OpCodes.Ldloc, codeLocal); il.Emit(OpCodes.Conv_R8); il.Emit(OpCodes.Box, _types.Double); });
+
+        il.MarkLabel(ret);
+        il.Emit(OpCodes.Ret);
+    }
+
+    /// <summary>stdin.write(chunk, enc?, cb?) — forward chunk to the child's StandardInput.</summary>
     private void EmitCtxStdinWrite(EmittedRuntime runtime)
     {
         var il = _childCtxStdinWrite.GetILGenerator();
+        var afterWrite = il.DefineLabel();
+        var swGet = _types.Process.GetProperty("StandardInput")!.GetGetMethod()!;
+        var swWrite = typeof(System.IO.TextWriter).GetMethod("Write", [_types.String])!;
+        var swFlush = typeof(System.IO.TextWriter).GetMethod("Flush", Type.EmptyTypes)!;
+
+        // try { if (chunk != null) { var w = _proc.StandardInput; w.Write(chunk.ToString()); w.Flush(); } } catch {}
+        il.BeginExceptionBlock();
+        var skip = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Brfalse, skip);
+        var wLocal = il.DeclareLocal(typeof(System.IO.TextWriter));
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, _childCtxProc);
+        il.Emit(OpCodes.Callvirt, swGet);
+        il.Emit(OpCodes.Stloc, wLocal);
+        il.Emit(OpCodes.Ldloc, wLocal);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Callvirt, _types.Object.GetMethod("ToString")!);
+        il.Emit(OpCodes.Callvirt, swWrite);
+        il.Emit(OpCodes.Ldloc, wLocal);
+        il.Emit(OpCodes.Callvirt, swFlush);
+        il.MarkLabel(skip);
+        il.Emit(OpCodes.Leave, afterWrite);
+        il.BeginCatchBlock(_types.Exception);
+        il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Leave, afterWrite);
+        il.EndExceptionBlock();
+        il.MarkLabel(afterWrite);
+
+        // Invoke a write callback if present: prefer arg3 (cb), else arg2 (enc-as-cb).
+        EmitInvokeWriteCb(il, runtime);
+
         il.Emit(OpCodes.Ldc_I4_1);
         il.Emit(OpCodes.Box, _types.Boolean);
         il.Emit(OpCodes.Ret);
     }
 
+    /// <summary>stdin.end(chunk?, enc?, cb?) — optionally write, then close the child's StandardInput.</summary>
     private void EmitCtxStdinEnd(EmittedRuntime runtime)
     {
         var il = _childCtxStdinEnd.GetILGenerator();
+        var afterEnd = il.DefineLabel();
+        var swGet = _types.Process.GetProperty("StandardInput")!.GetGetMethod()!;
+        var swWrite = typeof(System.IO.TextWriter).GetMethod("Write", [_types.String])!;
+        var swClose = typeof(System.IO.TextWriter).GetMethod("Close", Type.EmptyTypes)!;
+
+        il.BeginExceptionBlock();
+        var wLocal = il.DeclareLocal(typeof(System.IO.TextWriter));
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, _childCtxProc);
+        il.Emit(OpCodes.Callvirt, swGet);
+        il.Emit(OpCodes.Stloc, wLocal);
+        var skip = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Brfalse, skip);
+        il.Emit(OpCodes.Ldloc, wLocal);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Callvirt, _types.Object.GetMethod("ToString")!);
+        il.Emit(OpCodes.Callvirt, swWrite);
+        il.MarkLabel(skip);
+        il.Emit(OpCodes.Ldloc, wLocal);
+        il.Emit(OpCodes.Callvirt, swClose);
+        il.Emit(OpCodes.Leave, afterEnd);
+        il.BeginCatchBlock(_types.Exception);
+        il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Leave, afterEnd);
+        il.EndExceptionBlock();
+        il.MarkLabel(afterEnd);
+
+        EmitInvokeWriteCb(il, runtime);
         il.Emit(OpCodes.Ldnull);
         il.Emit(OpCodes.Ret);
+    }
+
+    /// <summary>If arg3 (or arg2) is a $TSFunction, invoke it with [null].</summary>
+    private void EmitInvokeWriteCb(ILGenerator il, EmittedRuntime runtime)
+    {
+        var done = il.DefineLabel();
+        var tryArg2 = il.DefineLabel();
+        // arg3 callable?
+        il.Emit(OpCodes.Ldarg_3);
+        il.Emit(OpCodes.Isinst, runtime.TSFunctionType);
+        il.Emit(OpCodes.Brfalse, tryArg2);
+        il.Emit(OpCodes.Ldarg_3);
+        EmitInvokeNullArg(il, runtime);
+        il.Emit(OpCodes.Br, done);
+        il.MarkLabel(tryArg2);
+        il.Emit(OpCodes.Ldarg_2);
+        il.Emit(OpCodes.Isinst, runtime.TSFunctionType);
+        il.Emit(OpCodes.Brfalse, done);
+        il.Emit(OpCodes.Ldarg_2);
+        EmitInvokeNullArg(il, runtime);
+        il.MarkLabel(done);
+    }
+
+    /// <summary>Stack: [callable]. Emits InvokeValue(callable, new object[]{ null }) and pops.</summary>
+    private void EmitInvokeNullArg(ILGenerator il, EmittedRuntime runtime)
+    {
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Newarr, _types.Object);
+        il.Emit(OpCodes.Call, runtime.InvokeValue);
+        il.Emit(OpCodes.Pop);
     }
 
     // ================= Dispatch-side helpers =================
@@ -823,6 +1119,22 @@ public partial class RuntimeEmitter
         // ctx._dict = dict
         StoreCtxField(il, ctxLocal, _childCtxDict, () => il.Emit(OpCodes.Ldloc, dictLocal));
 
+        // For spawn (streamed), start the process synchronously so child.stdin.write()/
+        // .end() called on the same synchronous tick reach a live StandardInput.
+        if (streamed)
+        {
+            il.Emit(OpCodes.Ldloc, processLocal);
+            il.Emit(OpCodes.Callvirt, _miProcStart);
+            il.Emit(OpCodes.Pop);
+            EmitDictSet(il, dictLocal, "pid", () =>
+            {
+                il.Emit(OpCodes.Ldloc, processLocal);
+                il.Emit(OpCodes.Callvirt, _miProcIdGet);
+                il.Emit(OpCodes.Conv_R8);
+                il.Emit(OpCodes.Box, _types.Double);
+            });
+        }
+
         // ChildRunAsync(new Func<object>(ctx, streamed ? RunStreamed : RunCaptured))
         il.Emit(OpCodes.Ldloc, ctxLocal);
         il.Emit(OpCodes.Ldftn, streamed ? _childCtxRunStreamed : _childCtxRunCaptured);
@@ -834,14 +1146,34 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Call, runtime.CreateObject);
     }
 
-    // Stream wiring (real $Readable/$Writable + pumps) is implemented by the spawn
-    // child (#1014). For now the streamed path is unused (exec/execFile capture to
-    // strings); this placeholder keeps the seam compiling.
+    /// <summary>
+    /// Build real $Readable stdout/stderr (pumped by RunStreamed) and a forwarding stdin
+    /// object whose write/end push to the child's StandardInput. stdout/stderr are stored
+    /// on ctx so the worker can push into them.
+    /// </summary>
     private void EmitBuildChildStreams(ILGenerator il, EmittedRuntime runtime, LocalBuilder ctxLocal, LocalBuilder dictLocal)
     {
-        EmitDictSet(il, dictLocal, "stdout", () => { il.Emit(OpCodes.Newobj, _types.DictionaryStringObject.GetConstructor(Type.EmptyTypes)!); il.Emit(OpCodes.Call, runtime.CreateObject); });
-        EmitDictSet(il, dictLocal, "stderr", () => { il.Emit(OpCodes.Newobj, _types.DictionaryStringObject.GetConstructor(Type.EmptyTypes)!); il.Emit(OpCodes.Call, runtime.CreateObject); });
-        EmitDictSet(il, dictLocal, "stdin", () => { il.Emit(OpCodes.Newobj, _types.DictionaryStringObject.GetConstructor(Type.EmptyTypes)!); il.Emit(OpCodes.Call, runtime.CreateObject); });
+        var stdoutLocal = il.DeclareLocal(runtime.TSReadableType);
+        var stderrLocal = il.DeclareLocal(runtime.TSReadableType);
+
+        il.Emit(OpCodes.Newobj, runtime.TSReadableCtor);
+        il.Emit(OpCodes.Stloc, stdoutLocal);
+        il.Emit(OpCodes.Newobj, runtime.TSReadableCtor);
+        il.Emit(OpCodes.Stloc, stderrLocal);
+
+        StoreCtxField(il, ctxLocal, _childCtxStdout, () => il.Emit(OpCodes.Ldloc, stdoutLocal));
+        StoreCtxField(il, ctxLocal, _childCtxStderr, () => il.Emit(OpCodes.Ldloc, stderrLocal));
+        EmitDictSet(il, dictLocal, "stdout", () => il.Emit(OpCodes.Ldloc, stdoutLocal));
+        EmitDictSet(il, dictLocal, "stderr", () => il.Emit(OpCodes.Ldloc, stderrLocal));
+
+        // stdin = { writable: true, write: ctx.StdinWrite, end: ctx.StdinEnd }
+        var stdinLocal = il.DeclareLocal(_types.DictionaryStringObject);
+        il.Emit(OpCodes.Newobj, _types.DictionaryStringObject.GetConstructor(Type.EmptyTypes)!);
+        il.Emit(OpCodes.Stloc, stdinLocal);
+        EmitDictSet(il, stdinLocal, "writable", () => { il.Emit(OpCodes.Ldc_I4_1); il.Emit(OpCodes.Box, _types.Boolean); });
+        EmitDictSet(il, stdinLocal, "write", () => EmitTSFunc(il, runtime, () => il.Emit(OpCodes.Ldloc, ctxLocal), _childCtxStdinWrite));
+        EmitDictSet(il, stdinLocal, "end", () => EmitTSFunc(il, runtime, () => il.Emit(OpCodes.Ldloc, ctxLocal), _childCtxStdinEnd));
+        EmitDictSet(il, dictLocal, "stdin", () => { il.Emit(OpCodes.Ldloc, stdinLocal); il.Emit(OpCodes.Call, runtime.CreateObject); });
     }
 
     private void EmitDictSet(ILGenerator il, LocalBuilder dictLocal, string key, Action emitValue)

--- a/Compilation/RuntimeEmitter.ChildProcessHelpers.cs
+++ b/Compilation/RuntimeEmitter.ChildProcessHelpers.cs
@@ -13,6 +13,7 @@ public partial class RuntimeEmitter
     private void EmitChildProcessMethods(TypeBuilder typeBuilder, EmittedRuntime runtime)
     {
         EmitChildProcessNoOp(typeBuilder);
+        EmitChildProcessAsyncInfra(typeBuilder, runtime);
         EmitChildProcessExecSync(typeBuilder, runtime);
         EmitChildProcessSpawnSync(typeBuilder, runtime);
         EmitChildProcessExec(typeBuilder, runtime);
@@ -764,13 +765,34 @@ public partial class RuntimeEmitter
         runtime.RegisterBuiltInModuleMethod("child_process", "exec", method);
 
         var il = method.GetILGenerator();
-        // Store command arg in a local for EmitCreateExecProcess
+        // exec(command, optionsOrCallback?, callback?)
         var cmdLocal = il.DeclareLocal(_types.String);
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Stloc, cmdLocal);
 
+        // a1 = arg1, a2 = arg2
+        var a1 = il.DeclareLocal(_types.Object);
+        var a2 = il.DeclareLocal(_types.Object);
+        il.Emit(OpCodes.Ldarg_1); il.Emit(OpCodes.Stloc, a1);
+        il.Emit(OpCodes.Ldarg_2); il.Emit(OpCodes.Stloc, a2);
+
+        var optionsLocal = il.DeclareLocal(_types.Object);
+        var callbackLocal = il.DeclareLocal(_types.Object);
+        EmitSelectOptions(il, [a1, a2], optionsLocal);
+        EmitSelectCallback(il, [a2, a1], callbackLocal);
+
+        // Build the shell Process (not started) and apply cwd/env.
         EmitCreateExecProcess(il, cmdLocal); // leaves Process on stack
-        EmitBuildChildProcessObject(il, runtime, includeStdio: false);
+        var processLocal = il.DeclareLocal(_types.Process);
+        il.Emit(OpCodes.Stloc, processLocal);
+        // Re-derive the start info from the process to apply options.
+        var siLocal = il.DeclareLocal(_types.ProcessStartInfo);
+        il.Emit(OpCodes.Ldloc, processLocal);
+        il.Emit(OpCodes.Callvirt, _types.Process.GetProperty("StartInfo")!.GetGetMethod()!);
+        il.Emit(OpCodes.Stloc, siLocal);
+        EmitApplyChildOptions(il, siLocal, optionsLocal);
+
+        EmitBuildChildAndLaunch(il, runtime, processLocal, optionsLocal, callbackLocal, streamed: false);
         il.Emit(OpCodes.Ret);
     }
 
@@ -1077,7 +1099,7 @@ public partial class RuntimeEmitter
 
         var il = method.GetILGenerator();
 
-        // Similar to spawn: ProcessStartInfo(file) + args
+        // execFile(file, args?, options?, callback?)
         var startInfoLocal = il.DeclareLocal(_types.ProcessStartInfo);
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Newobj, _types.ProcessStartInfo.GetConstructor([_types.String])!);
@@ -1099,21 +1121,65 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldc_I4_1);
         il.Emit(OpCodes.Callvirt, _types.ProcessStartInfo.GetProperty("CreateNoWindow")!.GetSetMethod()!);
 
-        // Set args from arg1 if it's a List
+        // Add args from arg1 if it's a List (proper per-arg, not space-join).
         var noArgsLabel = il.DefineLabel();
+        var argsListLocal = il.DeclareLocal(_types.ListOfObject);
+        var argListLocal = il.DeclareLocal(typeof(System.Collections.ObjectModel.Collection<string>));
+        var iLocal = il.DeclareLocal(_types.Int32);
+        var argTmpLocal = il.DeclareLocal(_types.Object);
         il.Emit(OpCodes.Ldarg_1);
         il.Emit(OpCodes.Isinst, _types.ListOfObject);
+        il.Emit(OpCodes.Dup);
+        il.Emit(OpCodes.Stloc, argsListLocal);
         il.Emit(OpCodes.Brfalse, noArgsLabel);
 
         il.Emit(OpCodes.Ldloc, startInfoLocal);
-        il.Emit(OpCodes.Ldstr, " ");
-        il.Emit(OpCodes.Ldarg_1);
-        il.Emit(OpCodes.Castclass, _types.ListOfObject);
-        il.Emit(OpCodes.Callvirt, _types.ListOfObject.GetMethod("ToArray")!);
-        il.Emit(OpCodes.Call, typeof(string).GetMethod("Join", [typeof(string), typeof(object[])])!);
-        il.Emit(OpCodes.Callvirt, _types.ProcessStartInfo.GetProperty("Arguments")!.GetSetMethod()!);
-
+        il.Emit(OpCodes.Callvirt, _types.ProcessStartInfo.GetProperty("ArgumentList")!.GetGetMethod()!);
+        il.Emit(OpCodes.Stloc, argListLocal);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Stloc, iLocal);
+        var argsLoop = il.DefineLabel();
+        var argsLoopEnd = il.DefineLabel();
+        il.MarkLabel(argsLoop);
+        il.Emit(OpCodes.Ldloc, iLocal);
+        il.Emit(OpCodes.Ldloc, argsListLocal);
+        il.Emit(OpCodes.Callvirt, _types.ListOfObject.GetProperty("Count")!.GetGetMethod()!);
+        il.Emit(OpCodes.Bge, argsLoopEnd);
+        il.Emit(OpCodes.Ldloc, argsListLocal);
+        il.Emit(OpCodes.Ldloc, iLocal);
+        il.Emit(OpCodes.Callvirt, _types.ListOfObject.GetMethod("get_Item", [_types.Int32])!);
+        il.Emit(OpCodes.Stloc, argTmpLocal);
+        il.Emit(OpCodes.Ldloc, argListLocal);
+        var argNull = il.DefineLabel();
+        var argAdd = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, argTmpLocal);
+        il.Emit(OpCodes.Brfalse, argNull);
+        il.Emit(OpCodes.Ldloc, argTmpLocal);
+        il.Emit(OpCodes.Callvirt, _types.Object.GetMethod("ToString")!);
+        il.Emit(OpCodes.Br, argAdd);
+        il.MarkLabel(argNull);
+        il.Emit(OpCodes.Ldstr, "");
+        il.MarkLabel(argAdd);
+        il.Emit(OpCodes.Callvirt, typeof(System.Collections.ObjectModel.Collection<string>).GetMethod("Add", [_types.String])!);
+        il.Emit(OpCodes.Ldloc, iLocal);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Stloc, iLocal);
+        il.Emit(OpCodes.Br, argsLoop);
+        il.MarkLabel(argsLoopEnd);
         il.MarkLabel(noArgsLabel);
+
+        // Disambiguate options/callback among arg1/arg2/arg3.
+        var a1 = il.DeclareLocal(_types.Object);
+        var a2 = il.DeclareLocal(_types.Object);
+        var a3 = il.DeclareLocal(_types.Object);
+        il.Emit(OpCodes.Ldarg_1); il.Emit(OpCodes.Stloc, a1);
+        il.Emit(OpCodes.Ldarg_2); il.Emit(OpCodes.Stloc, a2);
+        il.Emit(OpCodes.Ldarg_3); il.Emit(OpCodes.Stloc, a3);
+        var optionsLocal = il.DeclareLocal(_types.Object);
+        var callbackLocal = il.DeclareLocal(_types.Object);
+        EmitSelectOptions(il, [a1, a2, a3], optionsLocal);
+        EmitSelectCallback(il, [a3, a2, a1], callbackLocal);
 
         var processLocal = il.DeclareLocal(_types.Process);
         il.Emit(OpCodes.Newobj, _types.Process.GetConstructor(Type.EmptyTypes)!);
@@ -1122,8 +1188,8 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloc, startInfoLocal);
         il.Emit(OpCodes.Callvirt, _types.Process.GetProperty("StartInfo")!.GetSetMethod()!);
 
-        il.Emit(OpCodes.Ldloc, processLocal);
-        EmitBuildChildProcessObject(il, runtime, includeStdio: false);
+        EmitApplyChildOptions(il, startInfoLocal, optionsLocal);
+        EmitBuildChildAndLaunch(il, runtime, processLocal, optionsLocal, callbackLocal, streamed: false);
         il.Emit(OpCodes.Ret);
     }
 

--- a/Compilation/RuntimeEmitter.ChildProcessHelpers.cs
+++ b/Compilation/RuntimeEmitter.ChildProcessHelpers.cs
@@ -835,29 +835,61 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldc_I4_1);
         il.Emit(OpCodes.Callvirt, _types.ProcessStartInfo.GetProperty("CreateNoWindow")!.GetSetMethod()!);
 
-        // Build args string from args list (arg1)
-        // If args is List<object?>, join with spaces
+        // Add args from arg1 if it's a List (proper per-arg via ArgumentList).
         var noArgsLabel = il.DefineLabel();
-        var afterArgsLabel = il.DefineLabel();
-
+        var argsListLocal = il.DeclareLocal(_types.ListOfObject);
+        var argListLocal = il.DeclareLocal(typeof(System.Collections.ObjectModel.Collection<string>));
+        var iLocal = il.DeclareLocal(_types.Int32);
+        var argTmpLocal = il.DeclareLocal(_types.Object);
         il.Emit(OpCodes.Ldarg_1);
         il.Emit(OpCodes.Isinst, _types.ListOfObject);
+        il.Emit(OpCodes.Dup);
+        il.Emit(OpCodes.Stloc, argsListLocal);
         il.Emit(OpCodes.Brfalse, noArgsLabel);
 
-        // Build argument string: string.Join(" ", args.Select(a => a.ToString()))
-        il.Emit(OpCodes.Ldstr, " ");
-        il.Emit(OpCodes.Ldarg_1);
-        il.Emit(OpCodes.Castclass, _types.ListOfObject);
-        il.Emit(OpCodes.Callvirt, _types.ListOfObject.GetMethod("ToArray")!);
-        il.Emit(OpCodes.Call, typeof(string).GetMethod("Join", [typeof(string), typeof(object[])])!);
-        var argsStringLocal = il.DeclareLocal(_types.String);
-        il.Emit(OpCodes.Stloc, argsStringLocal);
-
         il.Emit(OpCodes.Ldloc, startInfoLocal);
-        il.Emit(OpCodes.Ldloc, argsStringLocal);
-        il.Emit(OpCodes.Callvirt, _types.ProcessStartInfo.GetProperty("Arguments")!.GetSetMethod()!);
-
+        il.Emit(OpCodes.Callvirt, _types.ProcessStartInfo.GetProperty("ArgumentList")!.GetGetMethod()!);
+        il.Emit(OpCodes.Stloc, argListLocal);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Stloc, iLocal);
+        var argsLoop = il.DefineLabel();
+        var argsLoopEnd = il.DefineLabel();
+        il.MarkLabel(argsLoop);
+        il.Emit(OpCodes.Ldloc, iLocal);
+        il.Emit(OpCodes.Ldloc, argsListLocal);
+        il.Emit(OpCodes.Callvirt, _types.ListOfObject.GetProperty("Count")!.GetGetMethod()!);
+        il.Emit(OpCodes.Bge, argsLoopEnd);
+        il.Emit(OpCodes.Ldloc, argsListLocal);
+        il.Emit(OpCodes.Ldloc, iLocal);
+        il.Emit(OpCodes.Callvirt, _types.ListOfObject.GetMethod("get_Item", [_types.Int32])!);
+        il.Emit(OpCodes.Stloc, argTmpLocal);
+        il.Emit(OpCodes.Ldloc, argListLocal);
+        var argNull = il.DefineLabel();
+        var argAdd = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, argTmpLocal);
+        il.Emit(OpCodes.Brfalse, argNull);
+        il.Emit(OpCodes.Ldloc, argTmpLocal);
+        il.Emit(OpCodes.Callvirt, _types.Object.GetMethod("ToString")!);
+        il.Emit(OpCodes.Br, argAdd);
+        il.MarkLabel(argNull);
+        il.Emit(OpCodes.Ldstr, "");
+        il.MarkLabel(argAdd);
+        il.Emit(OpCodes.Callvirt, typeof(System.Collections.ObjectModel.Collection<string>).GetMethod("Add", [_types.String])!);
+        il.Emit(OpCodes.Ldloc, iLocal);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Stloc, iLocal);
+        il.Emit(OpCodes.Br, argsLoop);
+        il.MarkLabel(argsLoopEnd);
         il.MarkLabel(noArgsLabel);
+
+        // options = arg1 (if dict, the no-args form spawn(cmd, opts)) or arg2.
+        var a1 = il.DeclareLocal(_types.Object);
+        var a2 = il.DeclareLocal(_types.Object);
+        il.Emit(OpCodes.Ldarg_1); il.Emit(OpCodes.Stloc, a1);
+        il.Emit(OpCodes.Ldarg_2); il.Emit(OpCodes.Stloc, a2);
+        var optionsLocal = il.DeclareLocal(_types.Object);
+        EmitSelectOptions(il, [a2, a1], optionsLocal);
 
         // new Process { StartInfo = startInfo }
         var processLocal = il.DeclareLocal(_types.Process);
@@ -867,8 +899,12 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloc, startInfoLocal);
         il.Emit(OpCodes.Callvirt, _types.Process.GetProperty("StartInfo")!.GetSetMethod()!);
 
-        il.Emit(OpCodes.Ldloc, processLocal); // leave on stack
-        EmitBuildChildProcessObject(il, runtime, includeStdio: true);
+        EmitApplyChildOptions(il, startInfoLocal, optionsLocal);
+
+        // spawn has no callback; pass null callback, streamed worker.
+        var nullCb = il.DeclareLocal(_types.Object);
+        il.Emit(OpCodes.Ldnull); il.Emit(OpCodes.Stloc, nullCb);
+        EmitBuildChildAndLaunch(il, runtime, processLocal, optionsLocal, nullCb, streamed: true);
         il.Emit(OpCodes.Ret);
     }
 

--- a/Compilation/RuntimeEmitter.ChildProcessHelpers.cs
+++ b/Compilation/RuntimeEmitter.ChildProcessHelpers.cs
@@ -814,9 +814,8 @@ public partial class RuntimeEmitter
 
         var startInfoLocal = il.DeclareLocal(_types.ProcessStartInfo);
 
-        // startInfo = new ProcessStartInfo(command)
-        il.Emit(OpCodes.Ldarg_0); // command = FileName
-        il.Emit(OpCodes.Newobj, _types.ProcessStartInfo.GetConstructor([_types.String])!);
+        // startInfo = new ProcessStartInfo()
+        il.Emit(OpCodes.Newobj, _types.ProcessStartInfo.GetConstructor(Type.EmptyTypes)!);
         il.Emit(OpCodes.Stloc, startInfoLocal);
 
         il.Emit(OpCodes.Ldloc, startInfoLocal);
@@ -835,54 +834,6 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldc_I4_1);
         il.Emit(OpCodes.Callvirt, _types.ProcessStartInfo.GetProperty("CreateNoWindow")!.GetSetMethod()!);
 
-        // Add args from arg1 if it's a List (proper per-arg via ArgumentList).
-        var noArgsLabel = il.DefineLabel();
-        var argsListLocal = il.DeclareLocal(_types.ListOfObject);
-        var argListLocal = il.DeclareLocal(typeof(System.Collections.ObjectModel.Collection<string>));
-        var iLocal = il.DeclareLocal(_types.Int32);
-        var argTmpLocal = il.DeclareLocal(_types.Object);
-        il.Emit(OpCodes.Ldarg_1);
-        il.Emit(OpCodes.Isinst, _types.ListOfObject);
-        il.Emit(OpCodes.Dup);
-        il.Emit(OpCodes.Stloc, argsListLocal);
-        il.Emit(OpCodes.Brfalse, noArgsLabel);
-
-        il.Emit(OpCodes.Ldloc, startInfoLocal);
-        il.Emit(OpCodes.Callvirt, _types.ProcessStartInfo.GetProperty("ArgumentList")!.GetGetMethod()!);
-        il.Emit(OpCodes.Stloc, argListLocal);
-        il.Emit(OpCodes.Ldc_I4_0);
-        il.Emit(OpCodes.Stloc, iLocal);
-        var argsLoop = il.DefineLabel();
-        var argsLoopEnd = il.DefineLabel();
-        il.MarkLabel(argsLoop);
-        il.Emit(OpCodes.Ldloc, iLocal);
-        il.Emit(OpCodes.Ldloc, argsListLocal);
-        il.Emit(OpCodes.Callvirt, _types.ListOfObject.GetProperty("Count")!.GetGetMethod()!);
-        il.Emit(OpCodes.Bge, argsLoopEnd);
-        il.Emit(OpCodes.Ldloc, argsListLocal);
-        il.Emit(OpCodes.Ldloc, iLocal);
-        il.Emit(OpCodes.Callvirt, _types.ListOfObject.GetMethod("get_Item", [_types.Int32])!);
-        il.Emit(OpCodes.Stloc, argTmpLocal);
-        il.Emit(OpCodes.Ldloc, argListLocal);
-        var argNull = il.DefineLabel();
-        var argAdd = il.DefineLabel();
-        il.Emit(OpCodes.Ldloc, argTmpLocal);
-        il.Emit(OpCodes.Brfalse, argNull);
-        il.Emit(OpCodes.Ldloc, argTmpLocal);
-        il.Emit(OpCodes.Callvirt, _types.Object.GetMethod("ToString")!);
-        il.Emit(OpCodes.Br, argAdd);
-        il.MarkLabel(argNull);
-        il.Emit(OpCodes.Ldstr, "");
-        il.MarkLabel(argAdd);
-        il.Emit(OpCodes.Callvirt, typeof(System.Collections.ObjectModel.Collection<string>).GetMethod("Add", [_types.String])!);
-        il.Emit(OpCodes.Ldloc, iLocal);
-        il.Emit(OpCodes.Ldc_I4_1);
-        il.Emit(OpCodes.Add);
-        il.Emit(OpCodes.Stloc, iLocal);
-        il.Emit(OpCodes.Br, argsLoop);
-        il.MarkLabel(argsLoopEnd);
-        il.MarkLabel(noArgsLabel);
-
         // options = arg1 (if dict, the no-args form spawn(cmd, opts)) or arg2.
         var a1 = il.DeclareLocal(_types.Object);
         var a2 = il.DeclareLocal(_types.Object);
@@ -890,6 +841,13 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldarg_2); il.Emit(OpCodes.Stloc, a2);
         var optionsLocal = il.DeclareLocal(_types.Object);
         EmitSelectOptions(il, [a2, a1], optionsLocal);
+
+        // Set FileName/Arguments(/ArgumentList), honoring options.shell.
+        il.Emit(OpCodes.Ldloc, startInfoLocal);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Ldloc, optionsLocal);
+        il.Emit(OpCodes.Call, _childConfigureSpawn);
 
         // new Process { StartInfo = startInfo }
         var processLocal = il.DeclareLocal(_types.Process);

--- a/Compilation/RuntimeEmitter.ChildProcessHelpers.cs
+++ b/Compilation/RuntimeEmitter.ChildProcessHelpers.cs
@@ -1189,7 +1189,12 @@ public partial class RuntimeEmitter
 
     /// <summary>
     /// Emits: public static object ChildProcessFork(string modulePath, object args, object options)
-    /// Pure IL — returns a ChildProcess-like object (fork is a simplified spawn).
+    /// fork runs a child .ts module through the SharpTS interpreter — a compiled standalone
+    /// binary has no in-process compiler, so it co-locates SharpTS.dll (RequireSharpTSRuntime,
+    /// recorded at the fork call site) and bridges by reflection to
+    /// ChildProcessModuleInterpreter.ForkForCompiledLoop, passing the compiled $EventLoop's
+    /// Ref/Unref/Schedule so IPC + lifecycle events marshal onto the compiled loop (#1017).
+    /// Mirrors $Runtime.CreateWorker. With --standalone (SharpTS.dll absent) it throws.
     /// </summary>
     private void EmitChildProcessFork(TypeBuilder typeBuilder, EmittedRuntime runtime)
     {
@@ -1202,10 +1207,65 @@ public partial class RuntimeEmitter
         runtime.RegisterBuiltInModuleMethod("child_process", "fork", method);
 
         var il = method.GetILGenerator();
-        // Fork needs to run a TS file in a child process. For now, return a minimal ChildProcess object.
-        // Create a dummy process (current process) just to have a pid
-        il.Emit(OpCodes.Call, _types.Process.GetMethod("GetCurrentProcess")!);
-        EmitBuildChildProcessObject(il, runtime, includeStdio: false);
+        var typeLocal = il.DeclareLocal(_types.Type);
+        var loopLocal = il.DeclareLocal(runtime.EventLoopType);
+        var refLocal = il.DeclareLocal(typeof(Action));
+        var unrefLocal = il.DeclareLocal(typeof(Action));
+        var scheduleLocal = il.DeclareLocal(typeof(Action<Action>));
+        var argsLocal = il.DeclareLocal(_types.ObjectArray);
+        var actionCtor = typeof(Action).GetConstructor([_types.Object, typeof(IntPtr)])!;
+        var actionOfActionCtor = typeof(Action<Action>).GetConstructor([_types.Object, typeof(IntPtr)])!;
+
+        // Type t = Type.GetType("SharpTS.Runtime.BuiltIns.Modules.Interpreter.ChildProcessModuleInterpreter, SharpTS");
+        il.Emit(OpCodes.Ldstr, "SharpTS.Runtime.BuiltIns.Modules.Interpreter.ChildProcessModuleInterpreter, SharpTS");
+        il.Emit(OpCodes.Call, _types.GetMethod(_types.Type, "GetType", _types.String));
+        il.Emit(OpCodes.Stloc, typeLocal);
+
+        var typeOk = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, typeLocal);
+        il.Emit(OpCodes.Brtrue, typeOk);
+        il.Emit(OpCodes.Ldstr, "child_process.fork requires the SharpTS runtime (SharpTS.dll) to be present. " +
+                               "Compile without --standalone so it is co-located with the output.");
+        il.Emit(OpCodes.Newobj, _types.InvalidOperationExceptionCtorString);
+        il.Emit(OpCodes.Throw);
+        il.MarkLabel(typeOk);
+
+        // loop = $EventLoop.GetInstance();
+        il.Emit(OpCodes.Call, runtime.EventLoopGetInstance);
+        il.Emit(OpCodes.Stloc, loopLocal);
+        // ref/unref/schedule delegates bound to the loop instance
+        il.Emit(OpCodes.Ldloc, loopLocal);
+        il.Emit(OpCodes.Ldftn, runtime.EventLoopRef);
+        il.Emit(OpCodes.Newobj, actionCtor);
+        il.Emit(OpCodes.Stloc, refLocal);
+        il.Emit(OpCodes.Ldloc, loopLocal);
+        il.Emit(OpCodes.Ldftn, runtime.EventLoopUnref);
+        il.Emit(OpCodes.Newobj, actionCtor);
+        il.Emit(OpCodes.Stloc, unrefLocal);
+        il.Emit(OpCodes.Ldloc, loopLocal);
+        il.Emit(OpCodes.Ldftn, runtime.EventLoopSchedule);
+        il.Emit(OpCodes.Newobj, actionOfActionCtor);
+        il.Emit(OpCodes.Stloc, scheduleLocal);
+
+        // object[] args = { modulePath, argsObj, optionsObj, ref, unref, schedule };
+        il.Emit(OpCodes.Ldc_I4_6);
+        il.Emit(OpCodes.Newarr, _types.Object);
+        il.Emit(OpCodes.Stloc, argsLocal);
+        void SetArg(int i, OpCode ld) { il.Emit(OpCodes.Ldloc, argsLocal); il.Emit(OpCodes.Ldc_I4, i); il.Emit(ld); il.Emit(OpCodes.Stelem_Ref); }
+        SetArg(0, OpCodes.Ldarg_0);
+        SetArg(1, OpCodes.Ldarg_1);
+        SetArg(2, OpCodes.Ldarg_2);
+        il.Emit(OpCodes.Ldloc, argsLocal); il.Emit(OpCodes.Ldc_I4_3); il.Emit(OpCodes.Ldloc, refLocal); il.Emit(OpCodes.Stelem_Ref);
+        il.Emit(OpCodes.Ldloc, argsLocal); il.Emit(OpCodes.Ldc_I4_4); il.Emit(OpCodes.Ldloc, unrefLocal); il.Emit(OpCodes.Stelem_Ref);
+        il.Emit(OpCodes.Ldloc, argsLocal); il.Emit(OpCodes.Ldc_I4_5); il.Emit(OpCodes.Ldloc, scheduleLocal); il.Emit(OpCodes.Stelem_Ref);
+
+        // return t.GetMethod("ForkForCompiledLoop").Invoke(null, args);
+        il.Emit(OpCodes.Ldloc, typeLocal);
+        il.Emit(OpCodes.Ldstr, "ForkForCompiledLoop");
+        il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.Type, "GetMethod", _types.String));
+        il.Emit(OpCodes.Ldnull);
+        il.Emit(OpCodes.Ldloc, argsLocal);
+        il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.MethodInfo, "Invoke", _types.Object, _types.ObjectArray));
         il.Emit(OpCodes.Ret);
     }
 }

--- a/Compilation/RuntimeEmitter.ChildProcessHelpers.cs
+++ b/Compilation/RuntimeEmitter.ChildProcessHelpers.cs
@@ -366,6 +366,29 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldc_I4_1);
         il.Emit(OpCodes.Callvirt, _types.ProcessStartInfo.GetProperty("CreateNoWindow")!.GetSetMethod()!);
 
+        // input = options["input"] as string; RedirectStandardInput = input != null. (#1021)
+        var inputLocal = il.DeclareLocal(_types.String);
+        il.Emit(OpCodes.Ldnull); il.Emit(OpCodes.Stloc, inputLocal);
+        var noInputOpt = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_2);
+        il.Emit(OpCodes.Isinst, _types.DictionaryStringObject);
+        il.Emit(OpCodes.Dup); il.Emit(OpCodes.Stloc, dictLocal);
+        il.Emit(OpCodes.Brfalse, noInputOpt);
+        il.Emit(OpCodes.Ldloc, dictLocal);
+        il.Emit(OpCodes.Ldstr, "input");
+        il.Emit(OpCodes.Ldloca, tempObjLocal);
+        il.Emit(OpCodes.Callvirt, _types.DictionaryStringObject.GetMethod("TryGetValue", [_types.String, _types.Object.MakeByRefType()])!);
+        il.Emit(OpCodes.Brfalse, noInputOpt);
+        il.Emit(OpCodes.Ldloc, tempObjLocal);
+        il.Emit(OpCodes.Isinst, _types.String);
+        il.Emit(OpCodes.Stloc, inputLocal);
+        il.MarkLabel(noInputOpt);
+        il.Emit(OpCodes.Ldloc, startInfoLocal);
+        il.Emit(OpCodes.Ldloc, inputLocal);
+        il.Emit(OpCodes.Ldnull);
+        il.Emit(OpCodes.Cgt_Un); // input != null
+        il.Emit(OpCodes.Callvirt, _types.ProcessStartInfo.GetProperty("RedirectStandardInput")!.GetSetMethod()!);
+
         // Extract args if provided (args is List<object?>)
         var noArgsLabel = il.DefineLabel();
         var afterArgsLabel = il.DefineLabel();
@@ -471,6 +494,20 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloc, processLocal);
         il.Emit(OpCodes.Callvirt, _types.Process.GetMethod("Start", Type.EmptyTypes)!);
         il.Emit(OpCodes.Pop);
+
+        // if (input != null) { process.StandardInput.Write(input); process.StandardInput.Close(); }  (#1021)
+        var noInputWrite = il.DefineLabel();
+        var stdinGet = _types.Process.GetProperty("StandardInput")!.GetGetMethod()!;
+        il.Emit(OpCodes.Ldloc, inputLocal);
+        il.Emit(OpCodes.Brfalse, noInputWrite);
+        il.Emit(OpCodes.Ldloc, processLocal);
+        il.Emit(OpCodes.Callvirt, stdinGet);
+        il.Emit(OpCodes.Ldloc, inputLocal);
+        il.Emit(OpCodes.Callvirt, typeof(System.IO.TextWriter).GetMethod("Write", [_types.String])!);
+        il.Emit(OpCodes.Ldloc, processLocal);
+        il.Emit(OpCodes.Callvirt, stdinGet);
+        il.Emit(OpCodes.Callvirt, typeof(System.IO.TextWriter).GetMethod("Close", Type.EmptyTypes)!);
+        il.MarkLabel(noInputWrite);
 
         il.Emit(OpCodes.Ldloc, processLocal);
         il.Emit(OpCodes.Callvirt, _types.Process.GetProperty("StandardOutput")!.GetGetMethod()!);

--- a/Compilation/RuntimeFeatureDetector.cs
+++ b/Compilation/RuntimeFeatureDetector.cs
@@ -190,7 +190,11 @@ public sealed class RuntimeFeatureDetector
             case "os":
                 _set.UsesOs = true; break;
             case "child_process":
-                _set.UsesChildProcess = true; break;
+                // spawn()/fork() expose stdout/stderr as $Readable and stdin as
+                // $Writable, so the Node-stream runtime types must be emitted too.
+                _set.UsesChildProcess = true;
+                _set.UsesNodeStreams = true;
+                break;
             case "vm":
                 _set.UsesVm = true; break;
             case "tty":

--- a/Program.cs
+++ b/Program.cs
@@ -161,6 +161,10 @@ static void RunModuleFile(string absolutePath, DecoratorMode decoratorMode, bool
         var interpreter = new Interpreter();
         interpreter.SetDecoratorMode(decoratorMode);
 
+        // If this process was forked, wire its IPC channel to this interpreter's loop so
+        // 'message' handlers run with an interpreter and the child stays alive (#1017).
+        SharpTS.Runtime.Types.ForkIpcClient.Instance?.AttachLoop(interpreter);
+
         // Variable Resolution Phase (enables O(1) lookups)
         var varResolver = new VariableResolver(interpreter);
         foreach (var module in allModules)
@@ -208,6 +212,9 @@ static void Run(string source, DecoratorMode decoratorMode, bool emitDecoratorMe
 {
     interpreter ??= new Interpreter();
     interpreter.SetDecoratorMode(decoratorMode);
+
+    // Forked-child IPC: attach this interpreter's loop (idempotent — only acts once).
+    SharpTS.Runtime.Types.ForkIpcClient.Instance?.AttachLoop(interpreter);
 
     Lexer lexer = new(source);
     List<Token> tokens = lexer.ScanTokens();
@@ -655,8 +662,38 @@ static void CopySharpTSRuntimeIfNeeded(ILCompiler compiler, string outputPath, O
     {
         if (!string.Equals(Path.GetFullPath(sharpTsPath), Path.GetFullPath(destPath), StringComparison.OrdinalIgnoreCase))
             File.Copy(sharpTsPath, destPath, overwrite: true);
+
+        // child_process.fork() spawns a SEPARATE `dotnet exec SharpTS.dll <module>` process
+        // (unlike Worker/eval which load SharpTS.dll in-process). That child needs SharpTS's
+        // full runtime closure — its runtimeconfig.json, deps.json, and dependency DLLs — so
+        // co-locate the whole SharpTS bin directory next to the output. Other soft-deps only
+        // need SharpTS.dll loaded in-process.
+        if (reasons.Contains("child_process.fork"))
+        {
+            var sharpTsDir = Path.GetDirectoryName(sharpTsPath);
+            if (!string.IsNullOrEmpty(sharpTsDir))
+            {
+                foreach (var src in Directory.EnumerateFiles(sharpTsDir))
+                {
+                    var name = Path.GetFileName(src);
+                    var ext = Path.GetExtension(name);
+                    bool isRuntimeFile = ext.Equals(".dll", StringComparison.OrdinalIgnoreCase)
+                        || name.Equals("SharpTS.runtimeconfig.json", StringComparison.OrdinalIgnoreCase)
+                        || name.Equals("SharpTS.deps.json", StringComparison.OrdinalIgnoreCase);
+                    if (!isRuntimeFile) continue;
+                    var dst = Path.Combine(outDir, name);
+                    if (string.Equals(Path.GetFullPath(src), Path.GetFullPath(dst), StringComparison.OrdinalIgnoreCase))
+                        continue;
+                    File.Copy(src, dst, overwrite: true);
+                }
+            }
+        }
+
         if (!outputOptions.QuietMode)
-            Console.WriteLine($"Copied SharpTS.dll next to output — required at runtime by: {reasonList}");
+        {
+            var what = reasons.Contains("child_process.fork") ? "SharpTS runtime" : "SharpTS.dll";
+            Console.WriteLine($"Copied {what} next to output — required at runtime by: {reasonList}");
+        }
     }
     catch (Exception ex)
     {

--- a/Runtime/BuiltIns/Modules/Interpreter/ChildProcessModuleInterpreter.cs
+++ b/Runtime/BuiltIns/Modules/Interpreter/ChildProcessModuleInterpreter.cs
@@ -719,8 +719,46 @@ public static class ChildProcessModuleInterpreter
         }
 
         var cwd = GetStringOption(options, "cwd");
+        var childProcess = RunFork(modulePath, forkArgs, options, cwd, interpreter,
+            interpreter.Ref, interpreter.Unref, interpreter.EnqueueCallback,
+            (cp, ev, arg) => cp.EmitWith(interpreter, ev, arg));
+        return RuntimeValue.FromObject(childProcess);
+    }
 
-        // Resolve the module path relative to cwd
+    /// <summary>
+    /// Compiled-output bridge for fork (#1017). The emitted <c>$Runtime.ChildProcessFork</c>
+    /// resolves this by reflection (keeping the standalone DLL free of a hard SharpTS.dll
+    /// reference) and passes the compiled <c>$EventLoop</c>'s Ref/Unref/Schedule so IPC and
+    /// lifecycle events marshal onto the compiled loop — mirroring SharpTSWorker.CreateForCompiledLoop.
+    /// </summary>
+    public static SharpTSChildProcess ForkForCompiledLoop(
+        string modulePath, object? argsObj, object? optionsObj,
+        Action eventLoopRef, Action eventLoopUnref, Action<Action> eventLoopSchedule)
+    {
+        var forkArgs = new List<string>();
+        if (argsObj is SharpTSArray a)
+            foreach (var x in a)
+                forkArgs.Add(x?.ToString() ?? "");
+        var options = optionsObj as SharpTSObject;
+        var cwd = GetStringOption(options, "cwd");
+
+        return RunFork(modulePath, forkArgs, options, cwd, interp: null,
+            eventLoopRef, eventLoopUnref, eventLoopSchedule,
+            (cp, ev, arg) => cp.EmitDirect(ev, arg));
+    }
+
+    /// <summary>
+    /// Shared fork core: spawns the SharpTS runtime to run the child module over a named-pipe
+    /// IPC channel, keeping the owning event loop alive (refLoop/unrefLoop) and marshalling
+    /// IPC messages + stream chunks + lifecycle events onto it (post). <paramref name="interp"/>
+    /// is the interpreter for interp-mode (null in compiled mode — stream pushes/events then
+    /// dispatch compiled listeners directly).
+    /// </summary>
+    private static SharpTSChildProcess RunFork(
+        string modulePath, List<string> forkArgs, SharpTSObject? options, string? cwd,
+        Interp? interp, Action refLoop, Action unrefLoop, Action<Action> post,
+        Action<SharpTSChildProcess, string, object?> emit)
+    {
         var resolvedModule = modulePath;
         if (!Path.IsPathRooted(resolvedModule))
         {
@@ -728,20 +766,11 @@ public static class ChildProcessModuleInterpreter
             resolvedModule = Path.GetFullPath(Path.Combine(basePath, resolvedModule));
         }
 
-        // Create a unique IPC pipe name
         var pipeName = $"sharpts-ipc-{Guid.NewGuid():N}";
-
-        // Create the ChildProcess
         var childProcess = new SharpTSChildProcess();
         var cts = new CancellationTokenSource();
-
-        // Create named pipe server for IPC
         var pipeServer = new NamedPipeServerStream(pipeName, PipeDirection.InOut,
             1, PipeTransmissionMode.Byte, PipeOptions.Asynchronous);
-
-        // Build the command to run SharpTS with the child module
-        var entryAssembly = Assembly.GetEntryAssembly();
-        var sharpTsPath = entryAssembly?.Location ?? "";
 
         var startInfo = new ProcessStartInfo
         {
@@ -751,51 +780,47 @@ public static class ChildProcessModuleInterpreter
             CreateNoWindow = true
         };
 
-        // Determine how to spawn: dotnet <dll> or direct executable
+        // The child must run the SharpTS interpreter on the .ts module. SharpTS.dll is always
+        // the assembly hosting this method — the CLI entry in interp mode, and the co-located
+        // runtime in compiled mode (RequireSharpTSRuntime). (Using the *entry* assembly would
+        // be wrong when SharpTS is embedded, e.g. the xUnit testhost.)
+        var sharpTsPath = typeof(ChildProcessModuleInterpreter).Assembly.Location;
         var processPath = Environment.ProcessPath;
-        if (processPath != null && Path.GetFileNameWithoutExtension(processPath)
-                .Equals("dotnet", StringComparison.OrdinalIgnoreCase))
+        var processName = processPath != null ? Path.GetFileNameWithoutExtension(processPath) : "";
+        bool processIsDotnet = processName.Equals("dotnet", StringComparison.OrdinalIgnoreCase);
+        bool processIsSharpTs = processName.Equals("sharpts", StringComparison.OrdinalIgnoreCase);
+
+        if (processIsSharpTs && !string.IsNullOrEmpty(processPath))
         {
-            // Running via `dotnet run` or `dotnet <dll>`
-            startInfo.FileName = processPath;
-            if (!string.IsNullOrEmpty(sharpTsPath) && sharpTsPath.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
-            {
-                startInfo.ArgumentList.Add("exec");
-                startInfo.ArgumentList.Add(sharpTsPath);
-            }
-        }
-        else if (!string.IsNullOrEmpty(processPath))
-        {
-            // Running as standalone executable
-            startInfo.FileName = processPath;
+            // Running as a self-contained SharpTS executable — run it directly on the module.
+            startInfo.FileName = processPath!;
         }
         else
         {
-            throw new Exception("Cannot determine SharpTS executable path for fork()");
+            // Everything else (interp via `dotnet SharpTS.dll`, compiled output, or SharpTS
+            // embedded as a library e.g. the test host): run the SharpTS.dll interpreter via
+            // the dotnet host — ProcessPath when it is dotnet, otherwise the muxer on PATH.
+            startInfo.FileName = processIsDotnet ? processPath! : "dotnet";
+            startInfo.ArgumentList.Add("exec");
+            startInfo.ArgumentList.Add(sharpTsPath);
         }
 
         startInfo.ArgumentList.Add(resolvedModule);
-
-        // Pass fork args
         foreach (var arg in forkArgs)
             startInfo.ArgumentList.Add(arg);
 
-        // Set IPC pipe name via environment variable
         startInfo.Environment["SHARPTS_IPC_PIPE"] = pipeName;
-
         if (!string.IsNullOrEmpty(cwd))
             startInfo.WorkingDirectory = cwd;
-
         ApplyEnvOptions(options, startInfo);
-        // Ensure IPC pipe name survives env override
-        startInfo.Environment["SHARPTS_IPC_PIPE"] = pipeName;
+        startInfo.Environment["SHARPTS_IPC_PIPE"] = pipeName; // survive an env override
 
-        // Set up stdout/stderr streams on the child process
         var stdoutStream = new SharpTSReadable();
         var stderrStream = new SharpTSReadable();
         childProcess.SetStdoutStream(stdoutStream);
         childProcess.SetStderrStream(stderrStream);
 
+        refLoop();
         Task.Run(() =>
         {
             try
@@ -805,7 +830,6 @@ public static class ChildProcessModuleInterpreter
                 childProcess.SetPid(process.Id);
                 childProcess.SetProcess(process);
 
-                // Wait for child to connect to IPC pipe
                 var connectTask = pipeServer.WaitForConnectionAsync(cts.Token);
                 if (!connectTask.Wait(10_000))
                 {
@@ -816,7 +840,7 @@ public static class ChildProcessModuleInterpreter
                 var writer = new StreamWriter(pipeServer) { AutoFlush = true };
                 childProcess.SetupIpc(pipeServer, writer, cts);
 
-                // Start reading IPC messages from child
+                // IPC message reader — marshal each message onto the owning loop.
                 var ipcReader = Task.Run(() =>
                 {
                     try
@@ -825,23 +849,25 @@ public static class ChildProcessModuleInterpreter
                         while (!cts.Token.IsCancellationRequested)
                         {
                             var line = reader.ReadLine();
-                            if (line == null) break; // pipe closed
+                            if (line == null) break;
                             var message = IpcSerializer.Deserialize(line);
-                            childProcess.EmitDirect("message", message);
+                            post(() => emit(childProcess, "message", message));
                         }
                     }
                     catch (OperationCanceledException) { }
                     catch { }
                 }, cts.Token);
 
-                // Read stdout/stderr
                 var stdoutTask = Task.Run(() =>
                 {
                     var buffer = new char[4096];
                     int read;
                     while ((read = process.StandardOutput.Read(buffer, 0, buffer.Length)) > 0)
-                        stdoutStream.EmitDirect("data", new string(buffer, 0, read));
-                    stdoutStream.EmitDirect("end");
+                    {
+                        var chunk = new string(buffer, 0, read);
+                        post(() => stdoutStream.PushFromHost(interp, chunk));
+                    }
+                    post(() => stdoutStream.PushFromHost(interp, null));
                 });
 
                 var stderrTask = Task.Run(() =>
@@ -849,29 +875,47 @@ public static class ChildProcessModuleInterpreter
                     var buffer = new char[4096];
                     int read;
                     while ((read = process.StandardError.Read(buffer, 0, buffer.Length)) > 0)
-                        stderrStream.EmitDirect("data", new string(buffer, 0, read));
-                    stderrStream.EmitDirect("end");
+                    {
+                        var chunk = new string(buffer, 0, read);
+                        post(() => stderrStream.PushFromHost(interp, chunk));
+                    }
+                    post(() => stderrStream.PushFromHost(interp, null));
                 });
 
                 process.WaitForExit();
                 cts.Cancel();
                 stdoutTask.Wait();
                 stderrTask.Wait();
+                int code = process.ExitCode;
 
-                childProcess.SetExitCode(process.ExitCode);
-                childProcess.EmitDirect("close", (double)process.ExitCode);
-                childProcess.EmitDirect("exit", (double)process.ExitCode);
+                post(() =>
+                {
+                    try
+                    {
+                        childProcess.SetExitCode(code);
+                        emit(childProcess, "close", (double)code);
+                        emit(childProcess, "exit", (double)code);
+                    }
+                    finally { unrefLoop(); }
+                });
             }
             catch (Exception ex)
             {
-                childProcess.EmitDirect("error", new SharpTSObject(new Dictionary<string, object?>
+                post(() =>
                 {
-                    ["message"] = ex.Message
-                }));
+                    try
+                    {
+                        emit(childProcess, "error", new SharpTSObject(new Dictionary<string, object?>
+                        {
+                            ["message"] = ex.Message
+                        }));
+                    }
+                    finally { unrefLoop(); }
+                });
             }
         });
 
-        return RuntimeValue.FromObject(childProcess);
+        return childProcess;
     }
 
     private static string? GetStringOption(SharpTSObject? options, string name)

--- a/Runtime/BuiltIns/Modules/Interpreter/ChildProcessModuleInterpreter.cs
+++ b/Runtime/BuiltIns/Modules/Interpreter/ChildProcessModuleInterpreter.cs
@@ -339,94 +339,142 @@ public static class ChildProcessModuleInterpreter
         childProcess.SetStderrStream(stderrStream);
         childProcess.SetStdinStream(stdinStream);
 
-        // Run asynchronously
+        // Start synchronously so child.stdin.write()/.end() on the same tick reach a live
+        // StandardInput; a spawn failure is surfaced as an async 'error' event.
+        Process process;
+        try
+        {
+            var startInfo = new ProcessStartInfo
+            {
+                FileName = command,
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                RedirectStandardInput = true,
+                CreateNoWindow = true
+            };
+
+            foreach (var arg in cmdArgs)
+                startInfo.ArgumentList.Add(arg);
+
+            if (!string.IsNullOrEmpty(cwd))
+                startInfo.WorkingDirectory = cwd;
+
+            ApplyEnvOptions(options, startInfo);
+
+            process = new Process { StartInfo = startInfo };
+            process.Start();
+            childProcess.SetPid(process.Id);
+            childProcess.SetProcess(process);
+
+            // Wire stdin: forwarding write() to the started process (write() runs on the loop thread).
+            stdinStream.SetWriteCallback(BuiltInMethod.CreateV2("write", 1, 3, (interp, recv, wargs) =>
+            {
+                if (wargs.Length > 0 && !wargs[0].IsNull)
+                {
+                    try
+                    {
+                        process.StandardInput.Write(wargs[0].ToObject()!.ToString());
+                        process.StandardInput.Flush();
+                    }
+                    catch { }
+                }
+                if (wargs.Length > 2 && wargs[2].ToObject() is ISharpTSCallable cb)
+                    cb.Call(interpreter, [null]);
+                else if (wargs.Length > 1 && wargs[1].ToObject() is ISharpTSCallable cb2)
+                    cb2.Call(interpreter, [null]);
+                return RuntimeValue.True;
+            }));
+
+            // stdin.end() closes the child's StandardInput so it sees EOF.
+            stdinStream.SetFinalCallback(BuiltInMethod.CreateV2("final", 0, 1, (interp, recv, fargs) =>
+            {
+                try { process.StandardInput.Close(); }
+                catch { }
+                if (fargs.Length > 0 && fargs[0].ToObject() is ISharpTSCallable done)
+                    done.Call(interp, [null]);
+                return RuntimeValue.Undefined;
+            }));
+        }
+        catch (Exception ex)
+        {
+            interpreter.Ref();
+            interpreter.EnqueueCallback(() =>
+            {
+                try
+                {
+                    childProcess.EmitWith(interpreter, "error", new SharpTSObject(new Dictionary<string, object?>
+                    {
+                        ["message"] = ex.Message
+                    }));
+                }
+                finally { interpreter.Unref(); }
+            });
+            return RuntimeValue.FromObject(childProcess);
+        }
+
+        // Keep the loop alive while the child runs; stream chunks and lifecycle events are
+        // marshalled onto the loop thread (PushFromHost / EmitWith) so they run with a real
+        // interpreter and after the synchronous script has attached its listeners.
+        var startedProcess = process;
+        interpreter.Ref();
         Task.Run(() =>
         {
             try
             {
-                var startInfo = new ProcessStartInfo
-                {
-                    FileName = command,
-                    UseShellExecute = false,
-                    RedirectStandardOutput = true,
-                    RedirectStandardError = true,
-                    RedirectStandardInput = true,
-                    CreateNoWindow = true
-                };
-
-                foreach (var arg in cmdArgs)
-                {
-                    startInfo.ArgumentList.Add(arg);
-                }
-
-                if (!string.IsNullOrEmpty(cwd))
-                    startInfo.WorkingDirectory = cwd;
-
-                ApplyEnvOptions(options, startInfo);
-
-                var process = new Process { StartInfo = startInfo };
-                process.Start();
-                childProcess.SetPid(process.Id);
-                childProcess.SetProcess(process);
-
-                // Wire up stdin: when write() is called on the writable stream,
-                // forward data to the process stdin
-                stdinStream.SetWriteCallback(BuiltInMethod.CreateV2("write", 1, 3, (interp, recv, wargs) =>
-                {
-                    if (wargs.Length > 0 && !wargs[0].IsNull)
-                    {
-                        try
-                        {
-                            process.StandardInput.Write(wargs[0].ToObject()!.ToString());
-                            process.StandardInput.Flush();
-                        }
-                        catch { }
-                    }
-                    // Call the callback if provided (3rd arg in Node.js write(chunk, enc, cb))
-                    if (wargs.Length > 2 && wargs[2].ToObject() is ISharpTSCallable cb)
-                        cb.Call(null!, [null]);
-                    else if (wargs.Length > 1 && wargs[1].ToObject() is ISharpTSCallable cb2)
-                        cb2.Call(null!, [null]);
-                    return RuntimeValue.True;
-                }));
-
-                // Read stdout and stderr asynchronously and push to streams
                 var stdoutTask = Task.Run(() =>
                 {
                     var buffer = new char[4096];
                     int read;
-                    while ((read = process.StandardOutput.Read(buffer, 0, buffer.Length)) > 0)
+                    while ((read = startedProcess.StandardOutput.Read(buffer, 0, buffer.Length)) > 0)
                     {
-                        stdoutStream.EmitDirect("data", new string(buffer, 0, read));
+                        var chunk = new string(buffer, 0, read);
+                        interpreter.EnqueueCallback(() => stdoutStream.PushFromHost(interpreter, chunk));
                     }
-                    stdoutStream.EmitDirect("end");
+                    interpreter.EnqueueCallback(() => stdoutStream.PushFromHost(interpreter, null));
                 });
 
                 var stderrTask = Task.Run(() =>
                 {
                     var buffer = new char[4096];
                     int read;
-                    while ((read = process.StandardError.Read(buffer, 0, buffer.Length)) > 0)
+                    while ((read = startedProcess.StandardError.Read(buffer, 0, buffer.Length)) > 0)
                     {
-                        stderrStream.EmitDirect("data", new string(buffer, 0, read));
+                        var chunk = new string(buffer, 0, read);
+                        interpreter.EnqueueCallback(() => stderrStream.PushFromHost(interpreter, chunk));
                     }
-                    stderrStream.EmitDirect("end");
+                    interpreter.EnqueueCallback(() => stderrStream.PushFromHost(interpreter, null));
                 });
 
-                process.WaitForExit();
+                startedProcess.WaitForExit();
                 stdoutTask.Wait();
                 stderrTask.Wait();
+                int code = startedProcess.ExitCode;
 
-                childProcess.SetExitCode(process.ExitCode);
-                childProcess.EmitDirect("close", (double)process.ExitCode);
-                childProcess.EmitDirect("exit", (double)process.ExitCode);
+                interpreter.EnqueueCallback(() =>
+                {
+                    try
+                    {
+                        childProcess.SetExitCode(code);
+                        childProcess.EmitWith(interpreter, "close", (double)code);
+                        childProcess.EmitWith(interpreter, "exit", (double)code);
+                    }
+                    finally { interpreter.Unref(); }
+                });
             }
             catch (Exception ex)
             {
-                childProcess.EmitDirect("error", new SharpTSObject(new Dictionary<string, object?>
+                interpreter.EnqueueCallback(() =>
                 {
-                    ["message"] = ex.Message
-                }));
+                    try
+                    {
+                        childProcess.EmitWith(interpreter, "error", new SharpTSObject(new Dictionary<string, object?>
+                        {
+                            ["message"] = ex.Message
+                        }));
+                    }
+                    finally { interpreter.Unref(); }
+                });
             }
         });
 

--- a/Runtime/BuiltIns/Modules/Interpreter/ChildProcessModuleInterpreter.cs
+++ b/Runtime/BuiltIns/Modules/Interpreter/ChildProcessModuleInterpreter.cs
@@ -239,8 +239,14 @@ public static class ChildProcessModuleInterpreter
                 childProcess.SetPid(process.Id);
                 childProcess.SetProcess(process);
 
-                stdout = process.StandardOutput.ReadToEnd();
-                stderr = process.StandardError.ReadToEnd();
+                var maxBuffer = (int)GetDoubleOption(options, "maxBuffer", 1024 * 1024);
+                stdout = ReadCapped(process.StandardOutput, maxBuffer, out var oOver);
+                stderr = ReadCapped(process.StandardError, maxBuffer, out var eOver);
+                if (oOver || eOver)
+                {
+                    try { process.Kill(); } catch { }
+                    error = MaxBufferError();
+                }
 
                 if (timeout > 0)
                 {
@@ -257,7 +263,7 @@ public static class ChildProcessModuleInterpreter
                     code = process.ExitCode;
                 }
 
-                if (kind == 0 && code != 0)
+                if (kind == 0 && error == null && code != 0)
                     error = new SharpTSObject(new Dictionary<string, object?>
                     {
                         ["message"] = $"Command failed with exit code {code}",
@@ -648,8 +654,14 @@ public static class ChildProcessModuleInterpreter
                 childProcess.SetPid(process.Id);
                 childProcess.SetProcess(process);
 
-                stdout = process.StandardOutput.ReadToEnd();
-                stderr = process.StandardError.ReadToEnd();
+                var maxBuffer = (int)GetDoubleOption(options, "maxBuffer", 1024 * 1024);
+                stdout = ReadCapped(process.StandardOutput, maxBuffer, out var oOver);
+                stderr = ReadCapped(process.StandardError, maxBuffer, out var eOver);
+                if (oOver || eOver)
+                {
+                    try { process.Kill(); } catch { }
+                    error = MaxBufferError();
+                }
 
                 if (timeout > 0)
                 {
@@ -666,7 +678,7 @@ public static class ChildProcessModuleInterpreter
                     code = process.ExitCode;
                 }
 
-                if (kind == 0 && code != 0)
+                if (kind == 0 && error == null && code != 0)
                     error = new SharpTSObject(new Dictionary<string, object?>
                     {
                         ["message"] = $"Command failed with exit code {code}",
@@ -958,6 +970,38 @@ public static class ChildProcessModuleInterpreter
     /// "inherit", or "ignore". Accepts the string shorthand (applied to all three) or the
     /// array form. fd numbers / streams / 'ipc' fall back to "pipe" (documented limitation).
     /// </summary>
+    /// <summary>
+    /// Reads a stream up to <paramref name="maxBuffer"/> chars (Node's exec maxBuffer, bytes
+    /// approximated by chars). Sets <paramref name="overflowed"/> and stops at the cap; a
+    /// negative cap means unbounded.
+    /// </summary>
+    private static string ReadCapped(System.IO.TextReader reader, int maxBuffer, out bool overflowed)
+    {
+        overflowed = false;
+        if (maxBuffer < 0)
+            return reader.ReadToEnd();
+        var sb = new System.Text.StringBuilder();
+        var buf = new char[4096];
+        int n;
+        while ((n = reader.Read(buf, 0, buf.Length)) > 0)
+        {
+            if (sb.Length + n > maxBuffer)
+            {
+                sb.Append(buf, 0, Math.Max(0, maxBuffer - sb.Length));
+                overflowed = true;
+                break;
+            }
+            sb.Append(buf, 0, n);
+        }
+        return sb.ToString();
+    }
+
+    private static SharpTSObject MaxBufferError() => new(new Dictionary<string, object?>
+    {
+        ["message"] = "stdout maxBuffer length exceeded",
+        ["code"] = "ERR_CHILD_PROCESS_STDIO_MAXBUFFER"
+    });
+
     private static (string stdin, string stdout, string stderr) ParseStdioModes(SharpTSObject? options)
     {
         var value = options?.GetProperty("stdio");

--- a/Runtime/BuiltIns/Modules/Interpreter/ChildProcessModuleInterpreter.cs
+++ b/Runtime/BuiltIns/Modules/Interpreter/ChildProcessModuleInterpreter.cs
@@ -329,15 +329,17 @@ public static class ChildProcessModuleInterpreter
 
         var cwd = GetStringOption(options, "cwd");
         var (useShell, shellPath) = GetShellOption(options);
+        var (stdinMode, stdoutMode, stderrMode) = ParseStdioModes(options);
 
-        // Create the ChildProcess event emitter with streams
+        // Create the ChildProcess; only 'pipe' fds get a real stream (Node sets the others
+        // to null). 'inherit' shares the parent's fd; 'ignore' discards.
         var childProcess = new SharpTSChildProcess();
-        var stdoutStream = new SharpTSReadable();
-        var stderrStream = new SharpTSReadable();
-        var stdinStream = new SharpTSWritable();
-        childProcess.SetStdoutStream(stdoutStream);
-        childProcess.SetStderrStream(stderrStream);
-        childProcess.SetStdinStream(stdinStream);
+        var stdoutStream = stdoutMode == "pipe" ? new SharpTSReadable() : null;
+        var stderrStream = stderrMode == "pipe" ? new SharpTSReadable() : null;
+        var stdinStream = stdinMode == "pipe" ? new SharpTSWritable() : null;
+        if (stdoutStream != null) childProcess.SetStdoutStream(stdoutStream);
+        if (stderrStream != null) childProcess.SetStderrStream(stderrStream);
+        if (stdinStream != null) childProcess.SetStdinStream(stdinStream);
 
         // Start synchronously so child.stdin.write()/.end() on the same tick reach a live
         // StandardInput; a spawn failure is surfaced as an async 'error' event.
@@ -347,9 +349,10 @@ public static class ChildProcessModuleInterpreter
             var startInfo = new ProcessStartInfo
             {
                 UseShellExecute = false,
-                RedirectStandardOutput = true,
-                RedirectStandardError = true,
-                RedirectStandardInput = true,
+                // 'inherit' shares the parent's fd (no redirect); 'pipe'/'ignore' redirect.
+                RedirectStandardOutput = stdoutMode != "inherit",
+                RedirectStandardError = stderrMode != "inherit",
+                RedirectStandardInput = stdinMode != "inherit",
                 CreateNoWindow = true
             };
 
@@ -375,34 +378,37 @@ public static class ChildProcessModuleInterpreter
             childProcess.SetPid(process.Id);
             childProcess.SetProcess(process);
 
-            // Wire stdin: forwarding write() to the started process (write() runs on the loop thread).
-            stdinStream.SetWriteCallback(BuiltInMethod.CreateV2("write", 1, 3, (interp, recv, wargs) =>
+            // Wire stdin (only when piped): forwarding write() to the started process.
+            if (stdinStream != null)
             {
-                if (wargs.Length > 0 && !wargs[0].IsNull)
+                stdinStream.SetWriteCallback(BuiltInMethod.CreateV2("write", 1, 3, (interp, recv, wargs) =>
                 {
-                    try
+                    if (wargs.Length > 0 && !wargs[0].IsNull)
                     {
-                        process.StandardInput.Write(wargs[0].ToObject()!.ToString());
-                        process.StandardInput.Flush();
+                        try
+                        {
+                            process.StandardInput.Write(wargs[0].ToObject()!.ToString());
+                            process.StandardInput.Flush();
+                        }
+                        catch { }
                     }
-                    catch { }
-                }
-                if (wargs.Length > 2 && wargs[2].ToObject() is ISharpTSCallable cb)
-                    cb.Call(interpreter, [null]);
-                else if (wargs.Length > 1 && wargs[1].ToObject() is ISharpTSCallable cb2)
-                    cb2.Call(interpreter, [null]);
-                return RuntimeValue.True;
-            }));
+                    if (wargs.Length > 2 && wargs[2].ToObject() is ISharpTSCallable cb)
+                        cb.Call(interpreter, [null]);
+                    else if (wargs.Length > 1 && wargs[1].ToObject() is ISharpTSCallable cb2)
+                        cb2.Call(interpreter, [null]);
+                    return RuntimeValue.True;
+                }));
 
-            // stdin.end() closes the child's StandardInput so it sees EOF.
-            stdinStream.SetFinalCallback(BuiltInMethod.CreateV2("final", 0, 1, (interp, recv, fargs) =>
-            {
-                try { process.StandardInput.Close(); }
-                catch { }
-                if (fargs.Length > 0 && fargs[0].ToObject() is ISharpTSCallable done)
-                    done.Call(interp, [null]);
-                return RuntimeValue.Undefined;
-            }));
+                // stdin.end() closes the child's StandardInput so it sees EOF.
+                stdinStream.SetFinalCallback(BuiltInMethod.CreateV2("final", 0, 1, (interp, recv, fargs) =>
+                {
+                    try { process.StandardInput.Close(); }
+                    catch { }
+                    if (fargs.Length > 0 && fargs[0].ToObject() is ISharpTSCallable done)
+                        done.Call(interp, [null]);
+                    return RuntimeValue.Undefined;
+                }));
+            }
         }
         catch (Exception ex)
         {
@@ -430,33 +436,43 @@ public static class ChildProcessModuleInterpreter
         {
             try
             {
-                var stdoutTask = Task.Run(() =>
+                // Pump each redirected pipe: 'pipe' feeds the stream; 'ignore' drains and
+                // discards; 'inherit' isn't redirected, so it isn't read here.
+                Task? stdoutTask = stdoutMode == "inherit" ? null : Task.Run(() =>
                 {
                     var buffer = new char[4096];
                     int read;
                     while ((read = startedProcess.StandardOutput.Read(buffer, 0, buffer.Length)) > 0)
                     {
-                        var chunk = new string(buffer, 0, read);
-                        interpreter.EnqueueCallback(() => stdoutStream.PushFromHost(interpreter, chunk));
+                        if (stdoutStream != null)
+                        {
+                            var chunk = new string(buffer, 0, read);
+                            interpreter.EnqueueCallback(() => stdoutStream.PushFromHost(interpreter, chunk));
+                        }
                     }
-                    interpreter.EnqueueCallback(() => stdoutStream.PushFromHost(interpreter, null));
+                    if (stdoutStream != null)
+                        interpreter.EnqueueCallback(() => stdoutStream.PushFromHost(interpreter, null));
                 });
 
-                var stderrTask = Task.Run(() =>
+                Task? stderrTask = stderrMode == "inherit" ? null : Task.Run(() =>
                 {
                     var buffer = new char[4096];
                     int read;
                     while ((read = startedProcess.StandardError.Read(buffer, 0, buffer.Length)) > 0)
                     {
-                        var chunk = new string(buffer, 0, read);
-                        interpreter.EnqueueCallback(() => stderrStream.PushFromHost(interpreter, chunk));
+                        if (stderrStream != null)
+                        {
+                            var chunk = new string(buffer, 0, read);
+                            interpreter.EnqueueCallback(() => stderrStream.PushFromHost(interpreter, chunk));
+                        }
                     }
-                    interpreter.EnqueueCallback(() => stderrStream.PushFromHost(interpreter, null));
+                    if (stderrStream != null)
+                        interpreter.EnqueueCallback(() => stderrStream.PushFromHost(interpreter, null));
                 });
 
                 startedProcess.WaitForExit();
-                stdoutTask.Wait();
-                stderrTask.Wait();
+                stdoutTask?.Wait();
+                stderrTask?.Wait();
                 int code = startedProcess.ExitCode;
 
                 interpreter.EnqueueCallback(() =>
@@ -935,6 +951,29 @@ public static class ChildProcessModuleInterpreter
             return defaultValue;
         var value = options.GetProperty(name);
         return value is double d ? d : defaultValue;
+    }
+
+    /// <summary>
+    /// Reads the `stdio` option into per-fd modes (stdin, stdout, stderr), each "pipe",
+    /// "inherit", or "ignore". Accepts the string shorthand (applied to all three) or the
+    /// array form. fd numbers / streams / 'ipc' fall back to "pipe" (documented limitation).
+    /// </summary>
+    private static (string stdin, string stdout, string stderr) ParseStdioModes(SharpTSObject? options)
+    {
+        var value = options?.GetProperty("stdio");
+        static string Norm(object? v) => v is string s && (s == "inherit" || s == "ignore" || s == "pipe") ? s : "pipe";
+
+        if (value is string str)
+        {
+            var m = Norm(str);
+            return (m, m, m);
+        }
+        if (value is SharpTSArray arr)
+        {
+            string At(int i) => i < arr.Count ? Norm(arr[i]) : "pipe";
+            return (At(0), At(1), At(2));
+        }
+        return ("pipe", "pipe", "pipe");
     }
 
     /// <summary>

--- a/Runtime/BuiltIns/Modules/Interpreter/ChildProcessModuleInterpreter.cs
+++ b/Runtime/BuiltIns/Modules/Interpreter/ChildProcessModuleInterpreter.cs
@@ -328,7 +328,7 @@ public static class ChildProcessModuleInterpreter
         }
 
         var cwd = GetStringOption(options, "cwd");
-        var useShell = GetBoolOption(options, "shell", false);
+        var (useShell, shellPath) = GetShellOption(options);
 
         // Create the ChildProcess event emitter with streams
         var childProcess = new SharpTSChildProcess();
@@ -346,7 +346,6 @@ public static class ChildProcessModuleInterpreter
         {
             var startInfo = new ProcessStartInfo
             {
-                FileName = command,
                 UseShellExecute = false,
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,
@@ -354,8 +353,17 @@ public static class ChildProcessModuleInterpreter
                 CreateNoWindow = true
             };
 
-            foreach (var arg in cmdArgs)
-                startInfo.ArgumentList.Add(arg);
+            if (useShell)
+            {
+                // Run "command args" through a shell (cmd.exe / sh), matching exec().
+                ApplyShellCommand(startInfo, command, cmdArgs, shellPath);
+            }
+            else
+            {
+                startInfo.FileName = command;
+                foreach (var arg in cmdArgs)
+                    startInfo.ArgumentList.Add(arg);
+            }
 
             if (!string.IsNullOrEmpty(cwd))
                 startInfo.WorkingDirectory = cwd;
@@ -883,6 +891,41 @@ public static class ChildProcessModuleInterpreter
             return defaultValue;
         var value = options.GetProperty(name);
         return value is double d ? d : defaultValue;
+    }
+
+    /// <summary>
+    /// Reads the `shell` option: true → default platform shell; a string → that shell path;
+    /// false/absent → no shell. Returns (useShell, shellPath?).
+    /// </summary>
+    private static (bool useShell, string? shellPath) GetShellOption(SharpTSObject? options)
+    {
+        if (options == null)
+            return (false, null);
+        var value = options.GetProperty("shell");
+        if (value is bool b)
+            return (b, null);
+        if (value is string s && !string.IsNullOrEmpty(s))
+            return (true, s);
+        return (false, null);
+    }
+
+    /// <summary>
+    /// Configures a ProcessStartInfo to run "command args" through a shell (cmd.exe /c on
+    /// Windows, /bin/sh -c on Unix, or an explicit shell path), mirroring exec().
+    /// </summary>
+    private static void ApplyShellCommand(ProcessStartInfo startInfo, string command, List<string> cmdArgs, string? shellPath)
+    {
+        var fullCommand = cmdArgs.Count > 0 ? command + " " + string.Join(" ", cmdArgs) : command;
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            startInfo.FileName = string.IsNullOrEmpty(shellPath) ? "cmd.exe" : shellPath;
+            startInfo.Arguments = "/d /s /c " + fullCommand;
+        }
+        else
+        {
+            startInfo.FileName = string.IsNullOrEmpty(shellPath) ? "/bin/sh" : shellPath;
+            startInfo.Arguments = "-c \"" + fullCommand.Replace("\"", "\\\"") + "\"";
+        }
     }
 
     private static bool GetBoolOption(SharpTSObject? options, string name, bool defaultValue)

--- a/Runtime/BuiltIns/Modules/Interpreter/ChildProcessModuleInterpreter.cs
+++ b/Runtime/BuiltIns/Modules/Interpreter/ChildProcessModuleInterpreter.cs
@@ -418,16 +418,11 @@ public static class ChildProcessModuleInterpreter
         }
         catch (Exception ex)
         {
+            var spawnErr = SpawnError(ex, command, "spawn");
             interpreter.Ref();
             interpreter.EnqueueCallback(() =>
             {
-                try
-                {
-                    childProcess.EmitWith(interpreter, "error", new SharpTSObject(new Dictionary<string, object?>
-                    {
-                        ["message"] = ex.Message
-                    }));
-                }
+                try { childProcess.EmitWith(interpreter, "error", spawnErr); }
                 finally { interpreter.Unref(); }
             });
             return RuntimeValue.FromObject(childProcess);
@@ -1001,6 +996,28 @@ public static class ChildProcessModuleInterpreter
         ["message"] = "stdout maxBuffer length exceeded",
         ["code"] = "ERR_CHILD_PROCESS_STDIO_MAXBUFFER"
     });
+
+    /// <summary>
+    /// Converts a process-start failure into a Node-style error object. A missing executable
+    /// (Win32 ERROR_FILE_NOT_FOUND) becomes an ENOENT error carrying code/errno/syscall/path.
+    /// </summary>
+    private static SharpTSObject SpawnError(Exception ex, string command, string syscall)
+    {
+        if (ex is System.ComponentModel.Win32Exception w32 && w32.NativeErrorCode == 2)
+        {
+            // libuv reports UV_ENOENT as -4058 on Windows, -2 on POSIX.
+            var errno = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? -4058.0 : -2.0;
+            return new(new Dictionary<string, object?>
+            {
+                ["message"] = $"{syscall} {command} ENOENT",
+                ["code"] = "ENOENT",
+                ["errno"] = errno,
+                ["syscall"] = $"{syscall} {command}",
+                ["path"] = command
+            });
+        }
+        return new(new Dictionary<string, object?> { ["message"] = ex.Message });
+    }
 
     private static (string stdin, string stdout, string stderr) ParseStdioModes(SharpTSObject? options)
     {

--- a/Runtime/BuiltIns/Modules/Interpreter/ChildProcessModuleInterpreter.cs
+++ b/Runtime/BuiltIns/Modules/Interpreter/ChildProcessModuleInterpreter.cs
@@ -107,7 +107,7 @@ public static class ChildProcessModuleInterpreter
 
         var options = args.Length > 2 ? args[2].ToObject() as SharpTSObject : null;
         var cwd = GetStringOption(options, "cwd");
-        var useShell = GetBoolOption(options, "shell", false);
+        var input = GetStringOption(options, "input");
 
         var startInfo = new ProcessStartInfo
         {
@@ -115,6 +115,7 @@ public static class ChildProcessModuleInterpreter
             UseShellExecute = false,
             RedirectStandardOutput = true,
             RedirectStandardError = true,
+            RedirectStandardInput = input != null,
             CreateNoWindow = true
         };
 
@@ -137,6 +138,12 @@ public static class ChildProcessModuleInterpreter
         {
             using var process = new Process { StartInfo = startInfo };
             process.Start();
+            if (input != null)
+            {
+                // Feed the synchronous stdin, then close so the child sees EOF.
+                process.StandardInput.Write(input);
+                process.StandardInput.Close();
+            }
             stdout = process.StandardOutput.ReadToEnd();
             stderr = process.StandardError.ReadToEnd();
             process.WaitForExit();

--- a/Runtime/BuiltIns/Modules/Interpreter/ChildProcessModuleInterpreter.cs
+++ b/Runtime/BuiltIns/Modules/Interpreter/ChildProcessModuleInterpreter.cs
@@ -198,9 +198,16 @@ public static class ChildProcessModuleInterpreter
         // Create the ChildProcess event emitter
         var childProcess = new SharpTSChildProcess();
 
-        // Run the process asynchronously
+        // Keep the event loop alive while the child runs; the terminal callback /
+        // lifecycle events are marshalled back onto the loop (EnqueueCallback) so they
+        // run on the loop thread AFTER the synchronous script registers its listeners —
+        // matching Node's "deferred to a future tick" guarantee.
+        interpreter.Ref();
         Task.Run(() =>
         {
+            string stdout = "", stderr = "";
+            int code = 0, kind = 0; // kind: 0 normal, 1 timeout, 2 exception
+            object? error = null;
             try
             {
                 var startInfo = new ProcessStartInfo
@@ -232,59 +239,63 @@ public static class ChildProcessModuleInterpreter
                 childProcess.SetPid(process.Id);
                 childProcess.SetProcess(process);
 
-                var stdout = process.StandardOutput.ReadToEnd();
-                var stderr = process.StandardError.ReadToEnd();
+                stdout = process.StandardOutput.ReadToEnd();
+                stderr = process.StandardError.ReadToEnd();
 
                 if (timeout > 0)
                 {
                     if (!process.WaitForExit((int)timeout))
                     {
                         process.Kill();
-                        childProcess.SetExitCode(-1);
-                        childProcess.EmitDirect("error", new SharpTSObject(new Dictionary<string, object?>
-                        {
-                            ["message"] = "Command timed out"
-                        }));
-                        callback?.Call(null!, [new SharpTSObject(new Dictionary<string, object?>
-                        {
-                            ["message"] = "Command timed out"
-                        }), stdout, stderr]);
-                        return;
+                        kind = 1;
                     }
+                    else { code = process.ExitCode; }
                 }
                 else
                 {
                     process.WaitForExit();
+                    code = process.ExitCode;
                 }
 
-                childProcess.SetExitCode(process.ExitCode);
-
-                if (process.ExitCode != 0)
-                {
-                    var errorObj = new SharpTSObject(new Dictionary<string, object?>
+                if (kind == 0 && code != 0)
+                    error = new SharpTSObject(new Dictionary<string, object?>
                     {
-                        ["message"] = $"Command failed with exit code {process.ExitCode}",
-                        ["code"] = (double)process.ExitCode
+                        ["message"] = $"Command failed with exit code {code}",
+                        ["code"] = (double)code
                     });
-                    callback?.Call(null!, [errorObj, stdout, stderr]);
-                }
-                else
-                {
-                    callback?.Call(null!, [null, stdout, stderr]);
-                }
-
-                childProcess.EmitDirect("close", (double)process.ExitCode);
-                childProcess.EmitDirect("exit", (double)process.ExitCode);
             }
             catch (Exception ex)
             {
-                var errorObj = new SharpTSObject(new Dictionary<string, object?>
-                {
-                    ["message"] = ex.Message
-                });
-                childProcess.EmitDirect("error", errorObj);
-                callback?.Call(null!, [errorObj, "", ""]);
+                kind = 2;
+                error = new SharpTSObject(new Dictionary<string, object?> { ["message"] = ex.Message });
             }
+
+            interpreter.EnqueueCallback(() =>
+            {
+                try
+                {
+                    if (kind == 2)
+                    {
+                        childProcess.EmitWith(interpreter, "error", error);
+                        callback?.CallBoxed(interpreter, [error, "", ""]);
+                    }
+                    else if (kind == 1)
+                    {
+                        childProcess.SetExitCode(-1);
+                        var timeoutErr = new SharpTSObject(new Dictionary<string, object?> { ["message"] = "Command timed out" });
+                        childProcess.EmitWith(interpreter, "error", timeoutErr);
+                        callback?.CallBoxed(interpreter, [timeoutErr, stdout, stderr]);
+                    }
+                    else
+                    {
+                        childProcess.SetExitCode(code);
+                        callback?.CallBoxed(interpreter, [error, stdout, stderr]);
+                        childProcess.EmitWith(interpreter, "close", (double)code);
+                        childProcess.EmitWith(interpreter, "exit", (double)code);
+                    }
+                }
+                finally { interpreter.Unref(); }
+            });
         });
 
         return RuntimeValue.FromObject(childProcess);
@@ -535,8 +546,12 @@ public static class ChildProcessModuleInterpreter
 
         var childProcess = new SharpTSChildProcess();
 
+        interpreter.Ref();
         Task.Run(() =>
         {
+            string stdout = "", stderr = "";
+            int code = 0, kind = 0; // kind: 0 normal, 1 timeout, 2 exception
+            object? error = null;
             try
             {
                 var startInfo = new ProcessStartInfo
@@ -561,53 +576,63 @@ public static class ChildProcessModuleInterpreter
                 childProcess.SetPid(process.Id);
                 childProcess.SetProcess(process);
 
-                var stdout = process.StandardOutput.ReadToEnd();
-                var stderr = process.StandardError.ReadToEnd();
+                stdout = process.StandardOutput.ReadToEnd();
+                stderr = process.StandardError.ReadToEnd();
 
                 if (timeout > 0)
                 {
                     if (!process.WaitForExit((int)timeout))
                     {
                         process.Kill();
-                        childProcess.SetExitCode(-1);
-                        var timeoutErr = new SharpTSObject(new Dictionary<string, object?>
-                            { ["message"] = "Command timed out" });
-                        childProcess.EmitDirect("error", timeoutErr);
-                        callback?.Call(null!, [timeoutErr, stdout, stderr]);
-                        return;
+                        kind = 1;
                     }
+                    else { code = process.ExitCode; }
                 }
                 else
                 {
                     process.WaitForExit();
+                    code = process.ExitCode;
                 }
 
-                childProcess.SetExitCode(process.ExitCode);
-
-                if (process.ExitCode != 0)
-                {
-                    var errorObj = new SharpTSObject(new Dictionary<string, object?>
+                if (kind == 0 && code != 0)
+                    error = new SharpTSObject(new Dictionary<string, object?>
                     {
-                        ["message"] = $"Command failed with exit code {process.ExitCode}",
-                        ["code"] = (double)process.ExitCode
+                        ["message"] = $"Command failed with exit code {code}",
+                        ["code"] = (double)code
                     });
-                    callback?.Call(null!, [errorObj, stdout, stderr]);
-                }
-                else
-                {
-                    callback?.Call(null!, [null, stdout, stderr]);
-                }
-
-                childProcess.EmitDirect("close", (double)process.ExitCode);
-                childProcess.EmitDirect("exit", (double)process.ExitCode);
             }
             catch (Exception ex)
             {
-                var errorObj = new SharpTSObject(new Dictionary<string, object?>
-                    { ["message"] = ex.Message });
-                childProcess.EmitDirect("error", errorObj);
-                callback?.Call(null!, [errorObj, "", ""]);
+                kind = 2;
+                error = new SharpTSObject(new Dictionary<string, object?> { ["message"] = ex.Message });
             }
+
+            interpreter.EnqueueCallback(() =>
+            {
+                try
+                {
+                    if (kind == 2)
+                    {
+                        childProcess.EmitWith(interpreter, "error", error);
+                        callback?.CallBoxed(interpreter, [error, "", ""]);
+                    }
+                    else if (kind == 1)
+                    {
+                        childProcess.SetExitCode(-1);
+                        var timeoutErr = new SharpTSObject(new Dictionary<string, object?> { ["message"] = "Command timed out" });
+                        childProcess.EmitWith(interpreter, "error", timeoutErr);
+                        callback?.CallBoxed(interpreter, [timeoutErr, stdout, stderr]);
+                    }
+                    else
+                    {
+                        childProcess.SetExitCode(code);
+                        callback?.CallBoxed(interpreter, [error, stdout, stderr]);
+                        childProcess.EmitWith(interpreter, "close", (double)code);
+                        childProcess.EmitWith(interpreter, "exit", (double)code);
+                    }
+                }
+                finally { interpreter.Unref(); }
+            });
         });
 
         return RuntimeValue.FromObject(childProcess);

--- a/Runtime/Types/ForkIpcClient.cs
+++ b/Runtime/Types/ForkIpcClient.cs
@@ -1,4 +1,5 @@
 using System.IO.Pipes;
+using Interp = SharpTS.Execution.Interpreter;
 
 namespace SharpTS.Runtime.Types;
 
@@ -15,6 +16,9 @@ public sealed class ForkIpcClient : IDisposable
     private readonly CancellationTokenSource _cts = new();
     private bool _connected;
     private bool _disposed;
+    private Interp? _interpreter;
+    private readonly object _refLock = new();
+    private bool _loopRefed;
 
     /// <summary>
     /// Gets the singleton instance if this process was forked with IPC.
@@ -54,13 +58,49 @@ public sealed class ForkIpcClient : IDisposable
 
         try
         {
+            // Connect early (the parent's WaitForConnection blocks until we do), but defer
+            // reading until AttachLoop wires the child interpreter + event loop.
             _instance = new ForkIpcClient(pipeName);
-            _instance.StartReading();
         }
         catch
         {
             // Failed to connect - not a valid fork() child
             _instance = null;
+        }
+    }
+
+    /// <summary>
+    /// Attaches the child's interpreter + event loop. Refs the loop (so the child stays
+    /// alive to receive messages) and starts the IPC reader, which marshals incoming
+    /// 'message'/'disconnect' onto the loop thread so the handlers run with an interpreter.
+    /// Called once, right after the child's interpreter is created.
+    /// </summary>
+    private bool _attached;
+    public void AttachLoop(Interp interpreter)
+    {
+        lock (_refLock)
+        {
+            if (_attached) return; // idempotent — only the first interpreter owns the channel
+            _attached = true;
+            _interpreter = interpreter;
+            if (!_loopRefed && _connected)
+            {
+                _loopRefed = true;
+                interpreter.Ref();
+            }
+        }
+        StartReading();
+    }
+
+    private void ReleaseLoopRef()
+    {
+        lock (_refLock)
+        {
+            if (_loopRefed)
+            {
+                _loopRefed = false;
+                _interpreter?.Unref();
+            }
         }
     }
 
@@ -96,13 +136,14 @@ public sealed class ForkIpcClient : IDisposable
         try { _writer.Dispose(); } catch { }
         try { _pipe.Dispose(); } catch { }
 
-        // Emit 'disconnect' on the process EventEmitter
-        SharpTSProcess.Instance.EmitDirect("disconnect");
+        // Emit 'disconnect' on the loop thread, then drop the keep-alive ref so the child
+        // can exit once its work is done.
+        EmitOnLoop("disconnect", null, releaseRef: true);
     }
 
     /// <summary>
-    /// Starts a background task to read incoming IPC messages from the parent.
-    /// Messages are emitted as 'message' events on the process EventEmitter.
+    /// Starts a background task to read incoming IPC messages from the parent. Messages are
+    /// marshalled onto the loop thread and emitted as 'message' on the process EventEmitter.
     /// </summary>
     private void StartReading()
     {
@@ -116,20 +157,51 @@ public sealed class ForkIpcClient : IDisposable
                     if (line == null)
                     {
                         _connected = false;
-                        SharpTSProcess.Instance.EmitDirect("disconnect");
+                        EmitOnLoop("disconnect", null, releaseRef: true);
                         break;
                     }
 
                     var message = IpcSerializer.Deserialize(line);
-                    SharpTSProcess.Instance.EmitDirect("message", message);
+                    EmitOnLoop("message", message, releaseRef: false);
                 }
             }
             catch (OperationCanceledException) { }
             catch
             {
                 _connected = false;
+                ReleaseLoopRef();
             }
         }, _cts.Token);
+    }
+
+    /// <summary>
+    /// Emits an event on the process EventEmitter from the loop thread (interpreter-aware, so
+    /// handlers that use their interpreter — e.g. process.send inside an 'message' handler —
+    /// work). Falls back to a direct emit if no interpreter is attached.
+    /// </summary>
+    private void EmitOnLoop(string eventName, object? arg, bool releaseRef)
+    {
+        var interp = _interpreter;
+        if (interp == null)
+        {
+            if (arg == null) SharpTSProcess.Instance.EmitDirect(eventName);
+            else SharpTSProcess.Instance.EmitDirect(eventName, arg);
+            if (releaseRef) ReleaseLoopRef();
+            return;
+        }
+
+        interp.EnqueueCallback(() =>
+        {
+            try
+            {
+                if (arg == null) SharpTSProcess.Instance.EmitWith(interp, eventName);
+                else SharpTSProcess.Instance.EmitWith(interp, eventName, arg);
+            }
+            finally
+            {
+                if (releaseRef) ReleaseLoopRef();
+            }
+        });
     }
 
     public void Dispose()

--- a/Runtime/Types/SharpTSChildProcess.cs
+++ b/Runtime/Types/SharpTSChildProcess.cs
@@ -24,6 +24,8 @@ public class SharpTSChildProcess : SharpTSEventEmitter
     private StreamWriter? _ipcWriter;
     private CancellationTokenSource? _ipcCts;
     private string? _signalCode;
+    private readonly object _ipcLock = new();
+    private readonly List<object?> _pendingSends = new();
 
     /// <summary>
     /// Sets the underlying OS process for kill() support.
@@ -60,10 +62,26 @@ public class SharpTSChildProcess : SharpTSEventEmitter
     /// </summary>
     public void SetupIpc(NamedPipeServerStream pipeServer, StreamWriter writer, CancellationTokenSource cts)
     {
-        _ipcPipeServer = pipeServer;
-        _ipcWriter = writer;
-        _ipcCts = cts;
-        _connected = true;
+        lock (_ipcLock)
+        {
+            _ipcPipeServer = pipeServer;
+            _ipcWriter = writer;
+            _ipcCts = cts;
+            _connected = true;
+
+            // Flush any messages sent before the channel finished connecting (Node buffers
+            // these rather than throwing — see Send()).
+            foreach (var msg in _pendingSends)
+            {
+                try
+                {
+                    writer.WriteLine(IpcSerializer.Serialize(msg));
+                    writer.Flush();
+                }
+                catch { }
+            }
+            _pendingSends.Clear();
+        }
     }
 
     /// <summary>
@@ -120,20 +138,27 @@ public class SharpTSChildProcess : SharpTSEventEmitter
 
     private RuntimeValue Send(Interp interpreter, RuntimeValue receiver, ReadOnlySpan<RuntimeValue> args)
     {
-        if (!_connected || _ipcWriter == null)
-            throw new Exception("channel closed");
-
         var message = args.Length > 0 ? args[0].ToObject() : null;
-        try
+        lock (_ipcLock)
         {
-            var json = IpcSerializer.Serialize(message);
-            _ipcWriter.WriteLine(json);
-            _ipcWriter.Flush();
-            return RuntimeValue.True;
-        }
-        catch
-        {
-            return RuntimeValue.False;
+            // Buffer sends issued before the IPC channel finished connecting (the channel is
+            // established on a background task); they flush in SetupIpc. Matches Node, which
+            // queues messages until the channel is ready instead of throwing.
+            if (!_connected || _ipcWriter == null)
+            {
+                _pendingSends.Add(message);
+                return RuntimeValue.True;
+            }
+            try
+            {
+                _ipcWriter.WriteLine(IpcSerializer.Serialize(message));
+                _ipcWriter.Flush();
+                return RuntimeValue.True;
+            }
+            catch
+            {
+                return RuntimeValue.False;
+            }
         }
     }
 

--- a/Runtime/Types/SharpTSEventEmitter.cs
+++ b/Runtime/Types/SharpTSEventEmitter.cs
@@ -427,6 +427,41 @@ public class SharpTSEventEmitter : ITypeCategorized
     }
 
     /// <summary>
+    /// Like <see cref="EmitDirect"/> but invokes listeners with a real interpreter, so
+    /// interpreter-function listeners that use their interpreter argument (e.g. ones that
+    /// call <c>console.log</c>) work. Used by async built-ins (child_process, etc.) that
+    /// emit lifecycle events from the event-loop thread.
+    /// </summary>
+    public bool EmitWith(Interp interpreter, string eventName, params object?[] args)
+    {
+        if (!_events.TryGetValue(eventName, out var listeners) || listeners.Count == 0)
+            return false;
+
+        var snapshot = new List<ListenerWrapper>(listeners);
+
+        foreach (var wrapper in snapshot)
+        {
+            if (wrapper.Once)
+            {
+                for (var node = listeners.First; node != null; node = node.Next)
+                {
+                    if (ReferenceEquals(node.Value, wrapper))
+                    {
+                        listeners.Remove(node);
+                        if (listeners.Count == 0)
+                            _events.Remove(eventName);
+                        break;
+                    }
+                }
+            }
+
+            SharpTS.Runtime.RuntimeCallableDispatcher.Invoke(interpreter, wrapper.Listener, args);
+        }
+
+        return true;
+    }
+
+    /// <summary>
     /// Invokes a listener directly without an interpreter.
     /// </summary>
     /// <remarks>

--- a/SharpTS.Tests/Compilation/RuntimeTypeSyncTests.cs
+++ b/SharpTS.Tests/Compilation/RuntimeTypeSyncTests.cs
@@ -148,8 +148,11 @@ public class RuntimeTypeSyncTests : IClassFixture<RuntimeTypeSyncTests.CompiledA
 
         new(typeof(SharpTSEventEmitter), "EventEmitter",
             [.. BaseIgnored, "GetMember",
-             // C#-specific optimization methods, not part of JS EventEmitter API
-             "AddListenerDirect", "EmitDirect", "RemoveListenerDirect"]),
+             // C#-specific optimization methods, not part of JS EventEmitter API.
+             // EmitWith is interp-only: async built-ins emit lifecycle events on the
+             // event-loop thread with a real interpreter (compiled $TSFunction listeners
+             // need no interpreter, so the emitted $EventEmitter has no equivalent).
+             "AddListenerDirect", "EmitDirect", "EmitWith", "RemoveListenerDirect"]),
     ];
 
     private record SyncPair(Type RuntimeType, string EmittedNameSuffix, string[] IgnoredMethods);

--- a/SharpTS.Tests/CompilerTests/StandaloneDllTests.cs
+++ b/SharpTS.Tests/CompilerTests/StandaloneDllTests.cs
@@ -35,7 +35,8 @@ public class StandaloneDllTests
         "Compilation/RuntimeEmitter.AbortController.cs", // AbortSignal.any() via RuntimeTypes.AbortSignalAnyCompiled
         "Compilation/RuntimeEmitter.ProcessHelpers.cs",      // ProcessEventEmitterCall and ProcessEmitExit fallback
         // "Compilation/RuntimeEmitter.Net.cs" — now uses emitted $NetServer/$NetSocket directly (no reflection)
-        // RuntimeEmitter.ChildProcessHelpers.cs / ZlibHelpers.cs / DnsPromises.cs — pruned: now pure IL, no SharpTS late binding
+        "Compilation/RuntimeEmitter.ChildProcessHelpers.cs", // child_process.fork bridges to the interpreter's ForkForCompiledLoop (requires SharpTS.dll co-located; suppressed by --standalone) — #1017
+        // ZlibHelpers.cs / DnsPromises.cs — pruned: now pure IL, no SharpTS late binding
         // RuntimeEmitter.ClusterHelpers.cs — pure IL, no reflection needed
         "Compilation/RuntimeEmitter.VmHelpers.cs",             // vm module delegation to interpreter via reflection
         "Compilation/RuntimeEmitter.DnsResolver.cs",           // dns.Resolver factory via RuntimeTypes

--- a/SharpTS.Tests/Infrastructure/TestHarness.cs
+++ b/SharpTS.Tests/Infrastructure/TestHarness.cs
@@ -768,11 +768,19 @@ public static class TestHarness
             if (s.Contains("process.exit(") ||
                 s.Contains("process.chdir(") ||
                 s.Contains("process.cwd(") ||
-                s.Contains("process.argv"))
+                s.Contains("process.argv") ||
+                // child_process.fork() spawns a real `dotnet exec SharpTS.dll <module>` child;
+                // the compiled test must run as a real subprocess with the SharpTS runtime present.
+                UsesChildProcessFork(s))
                 return true;
         }
         return false;
     }
+
+    /// <summary>True for a source that calls child_process.fork (imports it from 'child_process'
+    /// and invokes fork(...)). Distinguished from cluster.fork by the import.</summary>
+    private static bool UsesChildProcessFork(string s) =>
+        s.Contains("'child_process'") && s.Contains("fork(") && !s.Contains("cluster.fork(");
 
     /// <summary>
     /// Some test sources need the file to exist on a real disk path:
@@ -790,7 +798,9 @@ public static class TestHarness
         {
             if (s.Contains("__dirname") ||
                 s.Contains("__filename") ||
-                s.Contains("cluster.fork("))
+                s.Contains("cluster.fork(") ||
+                // child_process.fork() loads the child .ts module from disk in a separate process.
+                UsesChildProcessFork(s))
                 return true;
         }
         return false;
@@ -1067,11 +1077,27 @@ public static class TestHarness
             {
                 File.Copy(sharpTsDll, Path.Combine(tempDir, "SharpTS.dll"), overwrite: true);
 
+                var sharpTsDir = Path.GetDirectoryName(sharpTsDll)!;
                 // Copy ZstdSharp.dll (required for zstd compression in compiled mode)
-                var zstdDll = Path.Combine(Path.GetDirectoryName(sharpTsDll)!, "ZstdSharp.dll");
+                var zstdDll = Path.Combine(sharpTsDir, "ZstdSharp.dll");
                 if (File.Exists(zstdDll))
-                {
                     File.Copy(zstdDll, Path.Combine(tempDir, "ZstdSharp.dll"), overwrite: true);
+
+                // child_process.fork spawns `dotnet exec SharpTS.dll <module>` — that separate
+                // process needs SharpTS's full runtime closure (runtimeconfig + deps + dep DLLs),
+                // mirroring Program.CopySharpTSRuntimeIfNeeded.
+                if (files.Values.Any(UsesChildProcessFork))
+                {
+                    foreach (var src in Directory.EnumerateFiles(sharpTsDir))
+                    {
+                        var name = Path.GetFileName(src);
+                        var ext = Path.GetExtension(name);
+                        bool isRuntimeFile = ext.Equals(".dll", StringComparison.OrdinalIgnoreCase)
+                            || name.Equals("SharpTS.runtimeconfig.json", StringComparison.OrdinalIgnoreCase)
+                            || name.Equals("SharpTS.deps.json", StringComparison.OrdinalIgnoreCase);
+                        if (isRuntimeFile)
+                            File.Copy(src, Path.Combine(tempDir, name), overwrite: true);
+                    }
                 }
             }
 
@@ -1317,9 +1343,7 @@ public static class TestHarness
                 // Copy ZstdSharp.dll (required for zstd compression in compiled mode)
                 var zstdDll = Path.Combine(Path.GetDirectoryName(sharpTsDll)!, "ZstdSharp.dll");
                 if (File.Exists(zstdDll))
-                {
                     File.Copy(zstdDll, Path.Combine(tempDir, "ZstdSharp.dll"), overwrite: true);
-                }
             }
 
             // Write runtimeconfig.json

--- a/SharpTS.Tests/SharedTests/BuiltInModules/ChildProcessAsyncTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/ChildProcessAsyncTests.cs
@@ -188,6 +188,25 @@ public class ChildProcessAsyncTests
 
     [Theory]
     [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Spawn_MissingCommand_EmitsEnoentError(ExecutionMode mode)
+    {
+        // A missing executable emits an async 'error' event with code 'ENOENT' (+ syscall/path),
+        // rather than throwing a generic exception.
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import { spawn } from 'child_process';
+                const c = spawn('this_command_does_not_exist_xyz');
+                c.on('error', (err: any) => console.log('code=' + err.code + ' syscall=' + err.syscall + ' path=' + err.path));
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("code=ENOENT syscall=spawn this_command_does_not_exist_xyz path=this_command_does_not_exist_xyz\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void Spawn_Kill_SetsKilledAndSignal(ExecutionMode mode)
     {
         // Spawn a long-running process, kill it, and observe live killed/signalCode in 'exit'.

--- a/SharpTS.Tests/SharedTests/BuiltInModules/ChildProcessAsyncTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/ChildProcessAsyncTests.cs
@@ -217,6 +217,89 @@ public class ChildProcessAsyncTests
 
     [Theory]
     [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Exec_Callback_FiresWithStdout(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import { exec } from 'child_process';
+                exec('echo hello', (err: any, stdout: any, stderr: any) => {
+                    console.log('cb:' + (err === null) + ':' + stdout.trim());
+                });
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("cb:true:hello\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Exec_EmitsCloseThenExit(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import { exec } from 'child_process';
+                const c = exec('echo hi');
+                c.on('close', (code: any) => console.log('close:' + code));
+                c.on('exit', (code: any) => console.log('exit:' + code));
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("close:0\nexit:0\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Exec_NonZeroExit_CallbackReceivesError(ExecutionMode mode)
+    {
+        var command = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+            ? "exit 3"
+            : "exit 3";
+
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = $$"""
+                import { exec } from 'child_process';
+                exec('{{command}}', (err: any, stdout: any, stderr: any) => {
+                    console.log('err:' + (err !== null) + ':code:' + (err ? err.code : 'none'));
+                });
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("err:true:code:3\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ExecFile_Callback_FiresWithStdout(ExecutionMode mode)
+    {
+        var command = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+            ? "cmd.exe"
+            : "/bin/echo";
+        var args = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+            ? "['/c', 'echo', 'filecb']"
+            : "['filecb']";
+
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = $$"""
+                import { execFile } from 'child_process';
+                execFile('{{command}}', {{args}}, (err: any, stdout: any, stderr: any) => {
+                    console.log('filecb:' + (err === null) + ':' + stdout.trim());
+                });
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("filecb:true:filecb\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void Exec_ChildProcess_HasPidProperty(ExecutionMode mode)
     {
         var echoCommand = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)

--- a/SharpTS.Tests/SharedTests/BuiltInModules/ChildProcessAsyncTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/ChildProcessAsyncTests.cs
@@ -61,6 +61,24 @@ public class ChildProcessAsyncTests
 
     [Theory]
     [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void SpawnSync_Input_FeedsStdin(ExecutionMode mode)
+    {
+        // The `input` option feeds the synchronous child's stdin; `sort` echoes it back sorted.
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import { spawnSync } from 'child_process';
+                const r = spawnSync('sort', [], { input: 'banana\napple\n' });
+                console.log('sorted:' + r.stdout.trim());
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("sorted:apple\nbanana\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void ExecSync_StillWorks(ExecutionMode mode)
     {
         var echoCommand = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)

--- a/SharpTS.Tests/SharedTests/BuiltInModules/ChildProcessAsyncTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/ChildProcessAsyncTests.cs
@@ -290,6 +290,36 @@ public class ChildProcessAsyncTests
 
     [Theory]
     [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Fork_IpcRoundTrip(ExecutionMode mode)
+    {
+        // Parent forks a child .ts module, exchanges a JSON message over IPC, then disconnects.
+        // fork spawns a real `dotnet exec SharpTS.dll <child>` process, so the harness runs this
+        // on disk (interp) / via a real subprocess with the SharpTS runtime co-located (compiled).
+        var files = new Dictionary<string, string>
+        {
+            ["child.ts"] = """
+                process.on('message', (m: any) => {
+                  process.send({ reply: 'got ' + m.hello });
+                  process.disconnect();
+                });
+                """,
+            ["main.ts"] = """
+                import { fork } from 'child_process';
+                const c = fork(__dirname + '/child.ts');
+                c.on('message', (m: any) => {
+                  console.log('parent got: ' + m.reply);
+                  c.disconnect();
+                });
+                c.send({ hello: 'world' });
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("parent got: got world\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void Fork_TypeIsFunction(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>

--- a/SharpTS.Tests/SharedTests/BuiltInModules/ChildProcessAsyncTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/ChildProcessAsyncTests.cs
@@ -436,6 +436,25 @@ public class ChildProcessAsyncTests
 
     [Theory]
     [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Exec_MaxBuffer_Overflow_Errors(ExecutionMode mode)
+    {
+        // Output longer than maxBuffer kills the child and surfaces ERR_CHILD_PROCESS_STDIO_MAXBUFFER.
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import { exec } from 'child_process';
+                exec('echo aaaaaaaaaaaaaaaa', { maxBuffer: 3 }, (err: any, stdout: any) => {
+                  console.log('code:' + (err ? err.code : 'none'));
+                });
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("code:ERR_CHILD_PROCESS_STDIO_MAXBUFFER\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void Exec_NonZeroExit_CallbackReceivesError(ExecutionMode mode)
     {
         var command = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)

--- a/SharpTS.Tests/SharedTests/BuiltInModules/ChildProcessAsyncTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/ChildProcessAsyncTests.cs
@@ -127,6 +127,57 @@ public class ChildProcessAsyncTests
 
     [Theory]
     [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Spawn_Stdout_DataAndClose(ExecutionMode mode)
+    {
+        var command = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+            ? "cmd.exe"
+            : "/bin/echo";
+        var args = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+            ? "['/c', 'echo', 'spawned']"
+            : "['spawned']";
+
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = $$"""
+                import { spawn } from 'child_process';
+                const c = spawn('{{command}}', {{args}});
+                let out = '';
+                c.stdout.on('data', (d: any) => { out += d.toString(); });
+                c.stdout.on('end', () => console.log('end:' + out.trim()));
+                c.on('close', (code: any) => console.log('close:' + code));
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("end:spawned\nclose:0\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Spawn_Stdin_RoundTrip(ExecutionMode mode)
+    {
+        // `sort` reads all of stdin and writes it back; a single line round-trips unchanged.
+        var command = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "sort" : "sort";
+
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = $$"""
+                import { spawn } from 'child_process';
+                const c = spawn('{{command}}');
+                let out = '';
+                c.stdout.on('data', (d: any) => { out += d.toString(); });
+                c.stdout.on('end', () => console.log('got:' + out.trim()));
+                c.stdin.write('hello\n');
+                c.stdin.end();
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("got:hello\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void Spawn_HasStdinStream(ExecutionMode mode)
     {
         var command = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)

--- a/SharpTS.Tests/SharedTests/BuiltInModules/ChildProcessAsyncTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/ChildProcessAsyncTests.cs
@@ -127,6 +127,27 @@ public class ChildProcessAsyncTests
 
     [Theory]
     [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Spawn_Shell_RunsThroughShell(ExecutionMode mode)
+    {
+        // `echo shellworks` is a shell builtin / single shell command line — it only resolves
+        // with shell:true (there is no executable literally named "echo shellworks").
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import { spawn } from 'child_process';
+                const c = spawn('echo shellworks', [], { shell: true });
+                let out = '';
+                c.stdout.on('data', (d: any) => { out += d.toString(); });
+                c.stdout.on('end', () => console.log('shell:' + out.trim()));
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("shell:shellworks\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void Spawn_Kill_SetsKilledAndSignal(ExecutionMode mode)
     {
         // Spawn a long-running process, kill it, and observe live killed/signalCode in 'exit'.

--- a/SharpTS.Tests/SharedTests/BuiltInModules/ChildProcessAsyncTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/ChildProcessAsyncTests.cs
@@ -127,6 +127,47 @@ public class ChildProcessAsyncTests
 
     [Theory]
     [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Spawn_Kill_SetsKilledAndSignal(ExecutionMode mode)
+    {
+        // Spawn a long-running process, kill it, and observe live killed/signalCode in 'exit'.
+        var command = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "ping" : "sleep";
+        var args = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+            ? "['-n', '10', '127.0.0.1']"
+            : "['10']";
+
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = $$"""
+                import { spawn } from 'child_process';
+                const c = spawn('{{command}}', {{args}});
+                c.on('exit', () => console.log('killed=' + c.killed + ' signal=' + c.signalCode));
+                c.kill();
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("killed=true signal=SIGTERM\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Exec_ExitCode_IsLiveAfterClose(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import { exec } from 'child_process';
+                const c = exec('echo hi');
+                c.on('close', () => console.log('exitCode=' + c.exitCode));
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("exitCode=0\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void Spawn_Stdout_DataAndClose(ExecutionMode mode)
     {
         var command = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)

--- a/SharpTS.Tests/SharedTests/BuiltInModules/ChildProcessAsyncTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/ChildProcessAsyncTests.cs
@@ -127,6 +127,46 @@ public class ChildProcessAsyncTests
 
     [Theory]
     [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Spawn_Stdio_Ignore_NullsStreams(ExecutionMode mode)
+    {
+        // stdio:'ignore' discards the child's output and sets the stdio streams to null,
+        // while the child still runs to completion.
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import { spawn } from 'child_process';
+                const c = spawn('echo hi', [], { shell: true, stdio: 'ignore' });
+                console.log('out=' + (c.stdout === null || c.stdout === undefined) + ' err=' + (c.stderr === null || c.stderr === undefined));
+                c.on('close', (code: any) => console.log('close:' + code));
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("out=true err=true\nclose:0\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Spawn_Stdio_Array_PipesOnlyStdout(ExecutionMode mode)
+    {
+        // stdio array: [stdin=ignore, stdout=pipe, stderr=ignore] — only stdout is a stream.
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import { spawn } from 'child_process';
+                const c = spawn('echo arrayform', [], { shell: true, stdio: ['ignore', 'pipe', 'ignore'] });
+                let out = '';
+                c.stdout.on('data', (d: any) => { out += d.toString(); });
+                c.stdout.on('end', () => console.log('out:' + out.trim() + ' stdin=' + (c.stdin === null || c.stdin === undefined)));
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("out:arrayform stdin=true\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void Spawn_Shell_RunsThroughShell(ExecutionMode mode)
     {
         // `echo shellworks` is a shell builtin / single shell command line — it only resolves

--- a/TypeSystem/BuiltInModuleTypes.cs
+++ b/TypeSystem/BuiltInModuleTypes.cs
@@ -794,6 +794,11 @@ public static class BuiltInModuleTypes
 
         var boolType = new TypeInfo.Primitive(TokenType.TYPE_BOOLEAN);
 
+        // The second positional argument of spawn/execFile/fork is either the args array OR
+        // (when omitted) the options/callback — Node overloads it. Accept all of them so
+        // `spawn(cmd, { shell: true })` and `execFile(file, cb)` type-check (#1022/#1016).
+        var argsOrOptions = new TypeInfo.Union([new TypeInfo.Array(stringType), anyType]);
+
         var childProcessType = new TypeInfo.Record(new Dictionary<string, TypeInfo>
         {
             ["pid"] = numberType,
@@ -806,6 +811,7 @@ public static class BuiltInModuleTypes
             ["signalCode"] = new TypeInfo.Union([stringType, new TypeInfo.Null()]),
             ["on"] = new TypeInfo.Function([stringType, anyType], anyType),
             ["once"] = new TypeInfo.Function([stringType, anyType], anyType),
+            ["addListener"] = new TypeInfo.Function([stringType, anyType], anyType),
             ["kill"] = new TypeInfo.Function([stringType], boolType, RequiredParams: 0),
             ["send"] = new TypeInfo.Function([anyType], boolType),
             ["disconnect"] = new TypeInfo.Function([], new TypeInfo.Void()),
@@ -818,12 +824,12 @@ public static class BuiltInModuleTypes
             // Sync methods
             ["execSync"] = new TypeInfo.Function([stringType, anyType], stringType, RequiredParams: 1),
             ["spawnSync"] = new TypeInfo.Function(
-                [stringType, new TypeInfo.Array(stringType), anyType],
+                [stringType, argsOrOptions, anyType],
                 spawnResultType,
                 RequiredParams: 1
             ),
             ["execFileSync"] = new TypeInfo.Function(
-                [stringType, new TypeInfo.Array(stringType), anyType],
+                [stringType, argsOrOptions, anyType],
                 stringType,
                 RequiredParams: 1
             ),
@@ -834,17 +840,17 @@ public static class BuiltInModuleTypes
                 RequiredParams: 1
             ),
             ["spawn"] = new TypeInfo.Function(
-                [stringType, new TypeInfo.Array(stringType), anyType],
+                [stringType, argsOrOptions, anyType],
                 childProcessType,
                 RequiredParams: 1
             ),
             ["execFile"] = new TypeInfo.Function(
-                [stringType, new TypeInfo.Array(stringType), anyType, anyType],
+                [stringType, argsOrOptions, anyType, anyType],
                 childProcessType,
                 RequiredParams: 1
             ),
             ["fork"] = new TypeInfo.Function(
-                [stringType, new TypeInfo.Array(stringType), anyType],
+                [stringType, argsOrOptions, anyType],
                 childProcessType,
                 RequiredParams: 1
             )


### PR DESCRIPTION
Closes #1012. Implements all 10 children (#1013–#1022), each in its own commit, bringing Node's `child_process` to interpreter↔compiled parity.

## What landed (one commit per child)
| # | What |
|---|------|
| #1013 | Compiled `exec`/`execFile` real async — `(error, stdout, stderr)` callback + `exit`/`close`/`error` events (builds the `$ChildProcessCtx` async seam) |
| #1014 | Compiled `spawn` real `$Readable` stdout/stderr (`data`/`end`) + forwarding writable stdin |
| #1015 | Compiled `kill` + live `killed`/`exitCode`/`signalCode`/`connected` |
| #1016 | `shell` option in `spawn` (both modes) |
| #1017 | Compiled `fork` + named-pipe IPC, full send/`message`/`disconnect` roundtrip |
| #1018 | `stdio` string shorthand + array form (pipe/inherit/ignore) |
| #1019 | `maxBuffer` enforcement (`ERR_CHILD_PROCESS_STDIO_MAXBUFFER`) |
| #1020 | ENOENT `'error'` event with `code`/`errno`/`syscall`/`path` |
| #1021 | `input` (sync stdin) for `spawnSync` |
| #1022 | Type-surface polish (overloaded args/options, `addListener`) |

## Architecture
- **Compiled async** = new `$ChildProcessCtx` runtime type. Workers run on `Task.Run` while a self-contained `ChildRunAsync` Refs the `$EventLoop` (the proven fs #971 shape), then **Schedule** the callback + lifecycle events onto the loop so they fire after the synchronous script registers listeners. All BCL-only IL → **standalone preserved**.
- **Interpreter had the same latent bug** as the fs epic: async APIs were fire-and-forget (no loop Ref) and `EmitDirect` ran listeners with a null interpreter. Fixed via `Ref()` + `EnqueueCallback` marshaling + a new interpreter-aware `SharpTSEventEmitter.EmitWith`.
- **fork standalone decision (option A):** compiled `fork` spawns a separate `dotnet exec SharpTS.dll <module>` process, so it records `RequireSharpTSRuntime("child_process.fork")` (call-site only) and `CopySharpTSRuntimeIfNeeded` co-locates SharpTS's full runtime closure; `--standalone` suppresses it and `fork` throws.

## Verification
- `dotnet test`: **14541 passed, 0 failed**
- TypeScript conformance: **31/0** (no baseline drift)
- Test262 (interp + compiled): **20/0** (baseline-stable)
- Standalone preserved (fork is the one deliberate, gated soft-dependency)

Every API has dual-mode (interp == compiled) tests in `ChildProcessAsyncTests`.

## Documented deviations / known .NET ceilings
- **`encoding`/`'buffer'` output deferred** (#1019) — output is always a UTF-8 string; `maxBuffer` is fully implemented both modes.
- **ENOENT shape is spawn-only** (#1020) — `exec`/`execFile` run via a shell that exists, so a missing inner command exits non-zero (matching Node). Real signal-on-exit reporting is best-effort (Windows has no POSIX signals); `signalCode` reflects the requested kill signal.
- **#1021** delivered `input` for `spawnSync`; `argv0`/`windowsVerbatimArguments` deferred (niche), `windowsHide` ≈ covered by `CreateNoWindow`, compiled async `timeout` landed in #1013.
- Compiled stdin is a forwarding object, not a `$Writable` instance (its write sink is a private field); write/end behavior matches.

`subprocess.send(handle)` (passing live sockets/fds) is out of scope per the epic's .NET ceilings — JSON IPC only.