### PR TITLE
fix(compiler): regex/super/dynamic-import in async & generator bodies (#1105)

### DIFF
--- a/Compilation/AsyncGeneratorMoveNextEmitter.Expressions.cs
+++ b/Compilation/AsyncGeneratorMoveNextEmitter.Expressions.cs
@@ -767,14 +767,8 @@ public partial class AsyncGeneratorMoveNextEmitter
 
     #endregion
 
-    #region Missing Abstract Implementations
-
-    protected override void EmitSuper(Expr.Super s)
-    {
-        // Super not supported in async generators - push null
-        _il.Emit(OpCodes.Ldnull);
-        SetStackUnknown();
-    }
-
-    #endregion
+    // EmitSuper is inherited from ExpressionEmitterBase (#1105): the base loads the
+    // hoisted `this` and resolves through GetSuperMethod, which works in the async
+    // generator state machine. The old override here pushed `null`, silently
+    // miscompiling `super.x` inside an async generator body.
 }

--- a/Compilation/ExpressionEmitterBase.cs
+++ b/Compilation/ExpressionEmitterBase.cs
@@ -2125,12 +2125,44 @@ public abstract partial class ExpressionEmitterBase : IEmitterContext
     protected virtual void EmitSpread(Expr.Spread sp) => EmitExpression(sp.Expression);
 
     /// <summary>
-    /// Emits a regex literal. Default implementation pushes null - override in ILEmitter for actual regex creation.
+    /// Emits a regex literal as a <c>$RegExp</c> instance. Lives in the shared base (not just
+    /// <see cref="ILEmitter"/>) so regex literals work identically in every emission context —
+    /// plain functions, arrows, and the four state-machine bodies (async / async-arrow /
+    /// generator / async-generator). It needs no sync-only state: the per-site hoist fields
+    /// hang off the shared <see cref="EmittedRuntime.RegexHoistFields"/>, reachable everywhere
+    /// (#1105 — previously the base pushed <c>null</c>, silently miscompiling every regex inside
+    /// an async or generator body).
     /// </summary>
     protected virtual void EmitRegexLiteral(Expr.RegexLiteral re)
     {
-        IL.Emit(OpCodes.Ldnull);
-        SetStackUnknown();
+        // Hoisted literal (RegexLiteralHoistAnalyzer flagged this exact node as
+        // used in a safe consuming position): load the per-site static $RegExp,
+        // constructing it once on first evaluation. This removes the
+        // per-evaluation allocation + $RegExp ctor for literals in hot loops.
+        // Lazy init (vs. a .cctor) preserves SyntaxError throw-on-evaluation for
+        // an invalid pattern, and a rare concurrent double-construct just yields
+        // an equivalent instance (we only hoist where lastIndex is irrelevant).
+        if (Ctx.Runtime?.RegexHoistFields is { } hoistFields
+            && hoistFields.TryGetValue(re, out var field))
+        {
+            var done = IL.DefineLabel();
+            IL.Emit(OpCodes.Ldsfld, field);          // [field]
+            IL.Emit(OpCodes.Dup);                    // [field, field]
+            IL.Emit(OpCodes.Brtrue, done);           // non-null → done with [field]
+            IL.Emit(OpCodes.Pop);                    // []
+            IL.Emit(OpCodes.Ldstr, re.Pattern);
+            IL.Emit(OpCodes.Ldstr, re.Flags);
+            IL.Emit(OpCodes.Call, Ctx.Runtime!.CreateRegExpWithFlags); // [new]
+            IL.Emit(OpCodes.Dup);                    // [new, new]
+            IL.Emit(OpCodes.Stsfld, field);          // [new]
+            IL.MarkLabel(done);                      // [regex] on both paths
+            SetStackUnknown();
+            return;
+        }
+
+        IL.Emit(OpCodes.Ldstr, re.Pattern);
+        IL.Emit(OpCodes.Ldstr, re.Flags);
+        EmitCallUnknown(Ctx.Runtime!.CreateRegExpWithFlags);
     }
     #endregion
 

--- a/Compilation/GeneratorMoveNextEmitter.Expressions.cs
+++ b/Compilation/GeneratorMoveNextEmitter.Expressions.cs
@@ -1,27 +1,15 @@
-using System.Reflection.Emit;
-using SharpTS.Parsing;
-
 namespace SharpTS.Compilation;
 
 public partial class GeneratorMoveNextEmitter
 {
-    // EmitExpression dispatch is inherited from ExpressionEmitterBase
-
-    #region Abstract Implementations
-
-    protected override void EmitSuper(Expr.Super s)
-    {
-        // Not implemented in generator context - push null
-        _il.Emit(OpCodes.Ldnull);
-        SetStackUnknown();
-    }
-
-    protected override void EmitDynamicImport(Expr.DynamicImport di)
-    {
-        // Not implemented in generator context - push null
-        _il.Emit(OpCodes.Ldnull);
-        SetStackUnknown();
-    }
-
-    #endregion
+    // Expression emission is fully inherited from ExpressionEmitterBase.
+    //
+    // EmitRegexLiteral, EmitSuper, and EmitDynamicImport used to be overridden
+    // here (or inherited as a null-pushing base stub) so that a regex literal,
+    // `super.x`, or `import()` inside a generator body silently evaluated to
+    // `null` at runtime (#1105). The shared base now carries working
+    // implementations for all three — regex builds a $RegExp, super loads the
+    // hoisted `this` and resolves through GetSuperMethod, and dynamic import goes
+    // through the module registry — so the generator emitter inherits them
+    // unchanged. EmitterSyncTests enforces that no silent override creeps back.
 }

--- a/Compilation/ILEmitter.Expressions.cs
+++ b/Compilation/ILEmitter.Expressions.cs
@@ -849,37 +849,9 @@ public partial class ILEmitter
         SetStackType(StackType.String);
     }
 
-    protected override void EmitRegexLiteral(Expr.RegexLiteral re)
-    {
-        // Hoisted literal (RegexLiteralHoistAnalyzer flagged this exact node as
-        // used in a safe consuming position): load the per-site static $RegExp,
-        // constructing it once on first evaluation. This removes the
-        // per-evaluation allocation + $RegExp ctor for literals in hot loops.
-        // Lazy init (vs. a .cctor) preserves SyntaxError throw-on-evaluation for
-        // an invalid pattern, and a rare concurrent double-construct just yields
-        // an equivalent instance (we only hoist where lastIndex is irrelevant).
-        if (_ctx.Runtime?.RegexHoistFields is { } hoistFields
-            && hoistFields.TryGetValue(re, out var field))
-        {
-            var done = IL.DefineLabel();
-            IL.Emit(OpCodes.Ldsfld, field);          // [field]
-            IL.Emit(OpCodes.Dup);                    // [field, field]
-            IL.Emit(OpCodes.Brtrue, done);           // non-null → done with [field]
-            IL.Emit(OpCodes.Pop);                    // []
-            IL.Emit(OpCodes.Ldstr, re.Pattern);
-            IL.Emit(OpCodes.Ldstr, re.Flags);
-            IL.Emit(OpCodes.Call, _ctx.Runtime!.CreateRegExpWithFlags); // [new]
-            IL.Emit(OpCodes.Dup);                    // [new, new]
-            IL.Emit(OpCodes.Stsfld, field);          // [new]
-            IL.MarkLabel(done);                      // [regex] on both paths
-            SetStackUnknown();
-            return;
-        }
-
-        IL.Emit(OpCodes.Ldstr, re.Pattern);
-        IL.Emit(OpCodes.Ldstr, re.Flags);
-        EmitCallUnknown(_ctx.Runtime!.CreateRegExpWithFlags);
-    }
+    // EmitRegexLiteral is inherited from ExpressionEmitterBase (#1105): the full
+    // hoist-aware $RegExp emission now lives in the shared base so regex literals
+    // compile identically in plain functions, arrows, and all state-machine bodies.
 
     protected override void EmitClassExpression(Expr.ClassExpr ce)
     {

--- a/SharpTS.Tests/Compilation/EmitterSyncTests.cs
+++ b/SharpTS.Tests/Compilation/EmitterSyncTests.cs
@@ -150,8 +150,9 @@ public class EmitterSyncTests
             "EmitForOf",            // Hoisted enumerator for yield across loop boundaries
             "EmitForIn",            // #547: hoisted key-list/index for yield across for-in iterations
             "EmitYield",            // Core: yield value + suspend
-            "EmitSuper",            // This field indirection
-            "EmitDynamicImport",    // Dynamic import fallback
+            // #1105: EmitSuper/EmitDynamicImport are NO LONGER overridden — the old overrides
+            // pushed `null`, silently miscompiling `super.x`/`import()` in a generator body. The
+            // base implementations (hoisted-this + GetSuperMethod / module registry) work here.
             // #674: a captured-AND-mutated generator local is lifted into a shared function display
             // class; EmitArrowFunction still rejects the residual not-yet-DC-backed write case (e.g.
             // instance generator methods) so it fails fast instead of dropping the write.
@@ -191,7 +192,9 @@ public class EmitterSyncTests
             "EmitYield",            // Core: yield value + suspend
             "EmitAwait",            // Core: suspend/resume state machine
             "EmitArrowFunction",    // Display class in async generator context
-            "EmitSuper",            // This field indirection
+            // #1105: EmitSuper is NO LONGER overridden — the old override pushed `null`, silently
+            // miscompiling `super.x` in an async generator body. The base (hoisted-this +
+            // GetSuperMethod) works here.
             // --- #725: route a captured-and-mutated local through the function display class ---
             "GetFunctionDCField",   // Exposes <>__functionDC so a capturing arrow threads it in
             "EmitVariable",         // Read a captured-and-mutated local through the function DC (+ #766 rename)

--- a/SharpTS.Tests/SharedTests/DifferentialParityTests.cs
+++ b/SharpTS.Tests/SharedTests/DifferentialParityTests.cs
@@ -207,6 +207,17 @@ internal static class ParityCorpus
         // Regex (verbatim C# strings so the TS keeps its backslashes)
         ["regex-basic"] = @"console.log(/\d+/.test('abc123'), 'a1b2c3'.match(/\d/g)?.join(','), 'hello world'.replace(/o/g, '0'), 'a-b-c'.split(/-/).join('|'));",
         ["regex-groups"] = @"console.log('2020-01-15'.replace(/(\d+)-(\d+)-(\d+)/, '$3/$2/$1'), [...'a1b2'.matchAll(/(\w)(\d)/g)].map(m => m[1] + m[2]).join(','));",
+        // #1105: regex / super inside the four state-machine bodies used to compile to `null`
+        // (silent miscompile) because the state-machine emitters inherited a null-pushing base
+        // stub instead of the real $RegExp / GetSuperMethod emission. These pin the parity.
+        ["regex-in-async-fn"] = @"async function f() { const re = /ab+c/; return re.test('abbbc'); } f().then(r => console.log('async-regex:', r));",
+        ["regex-in-generator"] = @"function* g() { const re = /xy+z/; yield re.test('xyyyz'); } console.log('gen-regex:', g().next().value);",
+        ["regex-in-async-arrow"] = @"const f = async () => /a.c/.test('axc'); f().then(r => console.log('async-arrow-regex:', r));",
+        ["regex-in-async-gen"] = @"async function* g() { yield /\d+/.test('123'); } (async () => { for await (const v of g()) console.log('async-gen-regex:', v); })();",
+        ["regex-hoist-in-async-loop"] = @"async function f() { let c = 0; for (let i = 0; i < 3; i++) if (/foo/.test('foobar')) c++; return c; } f().then(c => console.log('async-hoist:', c));",
+        ["super-in-generator"] = @"class B { greet(n: string) { return 'hi ' + n; } } class D extends B { *g() { yield super.greet('gen'); } } console.log('gen-super:', new D().g().next().value);",
+        ["super-in-async-gen"] = @"class B { greet(n: string) { return 'hi ' + n; } } class D extends B { async *g() { yield super.greet('agen'); } } (async () => { for await (const v of new D().g()) console.log('async-gen-super:', v); })();",
+        ["super-in-async-fn"] = @"class B { greet(n: string) { return 'hi ' + n; } } class D extends B { async f() { return super.greet('afn'); } } new D().f().then(v => console.log('async-fn-super:', v));",
         // JSON parse/round-trip + specials (NaN/Infinity -> null, undefined elided)
         ["json-parse"] = "console.log(JSON.parse('{\"a\":1,\"b\":[true,null,1.5]}').b.length, JSON.stringify(JSON.parse('[1,2,3]')));",
         ["json-special"] = "console.log(JSON.stringify({ a: undefined, b: null, c: NaN, d: Infinity }), JSON.stringify([undefined, null, NaN]));",


### PR DESCRIPTION
Closes #1105.

## Problem (reproduced firsthand)

A regex literal, `super.x`, or `import()` inside an `async function` / `function*` body **silently compiled to `null`** in compiled mode — wrong result at runtime, no error:

```ts
async function asyncRegex() { const re = /ab+c/; return re.test("abbbc"); }
function*    genRegex()   { const re = /xy+z/; yield re.test("xyyyz"); }
```

Interpreted: `true / true`. Compiled (before): `false / false`.

## Root cause

The four state-machine emitters (async / async-arrow / generator / async-generator) derive from `StatementEmitterBase`, **not** `ILEmitter`, so they inherited a base `EmitRegexLiteral` that pushed `Ldnull`. The generator emitters additionally *overrode* `EmitSuper`/`EmitDynamicImport` to push `null`. The real implementations existed only in `ILEmitter`. The "base default pushes null, override only in ILEmitter" pattern guaranteed every such expression kind silently miscompiled in a state-machine body.

## Fix

- **Regex** — ported the full hoist-aware `$RegExp` emission from `ILEmitter` into the shared `ExpressionEmitterBase.EmitRegexLiteral`. The per-site hoist fields already hang off the shared `EmittedRuntime`, so it needs no sync-only state. Removed the now-redundant `ILEmitter` override. Regex now compiles identically in functions, arrows, and all four state machines.
- **super** — removed the silent-`null` `EmitSuper` overrides in `GeneratorMoveNextEmitter` and `AsyncGeneratorMoveNextEmitter`. The base default (load hoisted `this` → `GetSuperMethod`, which resolves via the instance's runtime base type) works in the state machine. Verified `super.x` in generators and async generators now matches interpreted output and the existing async-function behavior.
- **dynamic import** — removed the silent-`null` `EmitDynamicImport` override in `GeneratorMoveNextEmitter`. The base default routes through the module registry, behaving identically to async functions. (The remaining "module not pre-compiled" error is an orthogonal compiled-mode bundling limitation that affects async functions the same way — not state-machine-specific, so no super/import follow-up is needed.)
- **Tests** — updated the `EmitterSyncTests` allowlist (removed the three stale override entries) and added 8 `DifferentialParityTests` snippets pinning regex/super across the four bodies (each snippet runs through **both** interpreter and compiler and asserts identical output).

Note: contrary to the issue's "make the base virtuals throw a `CompileException` + file follow-ups" suggestion, `super` actually **works** through the base default in state machines — so making them work beat failing loud, and no feature-gap follow-up is required.

## Verification

- Full xUnit suite: **14519 passed / 0 failed / 16 skipped** (skips are pre-existing network/package smoke tests).
- `EmitterSyncTests` (2) + `DifferentialParityTests` (91, incl. 8 new) green.
- All manual repros show `interp == compiled` for regex/super in every state-machine body.
- The Test262 `CompiledBaseline` test host-crashes here (Internal CLR error `0x80131506`) under both parallel and `SHARPTS_TEST262_WORKERS=1` — confirmed **pre-existing** by stashing to clean `main` (same crash), so unrelated to this change. The committed subset's `RegExp` folder is top-level regex = byte-identical IL.