### PR TITLE
child_process: complete deferred #1019 (encoding) + #1021 (sync input, verbatim args)

### DIFF
--- a/Compilation/RuntimeEmitter.ChildProcessAsync.cs
+++ b/Compilation/RuntimeEmitter.ChildProcessAsync.cs
@@ -38,7 +38,11 @@ public partial class RuntimeEmitter
     private FieldBuilder _childCtxResCode = null!;     // int
     private FieldBuilder _childCtxResError = null!;    // object (error dict or null)
     private FieldBuilder _childCtxResKind = null!;     // int: 0 normal, 1 timeout, 2 exception
-    private FieldBuilder _childCtxMaxBuffer = null!;   // int: exec maxBuffer cap (chars); <0 unbounded
+    private FieldBuilder _childCtxMaxBuffer = null!;   // int: exec maxBuffer cap (bytes); <0 unbounded
+    private FieldBuilder _childCtxAsBuffer = null!;    // bool: encoding:'buffer' → raw $Buffer output
+    private FieldBuilder _childCtxEncoding = null!;    // string: decode encoding (default "utf8")
+    private MethodBuilder _childReadCappedBytes = null!;
+    private MethodBuilder _childDecodeOutput = null!;
     private FieldBuilder _childCtxStdoutRedir = null!; // bool: stdout redirected (mode != inherit)
     private FieldBuilder _childCtxStderrRedir = null!; // bool: stderr redirected (mode != inherit)
 
@@ -355,6 +359,23 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ldarg_1);
         il.Emit(OpCodes.Callvirt, fnSet);
+
+        // windowsVerbatimArguments: pass the args verbatim as a raw Arguments string (no .NET
+        // quoting), as Node asks. options = arg3; args list = argsListLocal.
+        var notVerbatim = il.DefineLabel();
+        EmitOptionBool(il, 3, "windowsVerbatimArguments");
+        il.Emit(OpCodes.Brfalse, notVerbatim);
+        il.Emit(OpCodes.Ldloc, argsListLocal);
+        il.Emit(OpCodes.Brfalse, notVerbatim);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldstr, " ");
+        il.Emit(OpCodes.Ldloc, argsListLocal);
+        il.Emit(OpCodes.Callvirt, _types.ListOfObject.GetMethod("ToArray")!);
+        il.Emit(OpCodes.Call, typeof(string).GetMethod("Join", [typeof(string), typeof(object[])])!);
+        il.Emit(OpCodes.Callvirt, argSet);
+        il.Emit(OpCodes.Br, endLabel);
+        il.MarkLabel(notVerbatim);
+
         var noArgs = il.DefineLabel();
         il.Emit(OpCodes.Ldloc, argsListLocal);
         il.Emit(OpCodes.Brfalse, noArgs);
@@ -466,6 +487,8 @@ public partial class RuntimeEmitter
         _childCtxResError = t.DefineField("_resError", _types.Object, FieldAttributes.Public);
         _childCtxResKind = t.DefineField("_resKind", _types.Int32, FieldAttributes.Public);
         _childCtxMaxBuffer = t.DefineField("_maxBuffer", _types.Int32, FieldAttributes.Public);
+        _childCtxAsBuffer = t.DefineField("_asBuffer", _types.Boolean, FieldAttributes.Public);
+        _childCtxEncoding = t.DefineField("_encoding", _types.String, FieldAttributes.Public);
         _childCtxStdoutRedir = t.DefineField("_stdoutRedir", _types.Boolean, FieldAttributes.Public);
         _childCtxStderrRedir = t.DefineField("_stderrRedir", _types.Boolean, FieldAttributes.Public);
 
@@ -682,22 +705,25 @@ public partial class RuntimeEmitter
         var overflowLocal = il.DeclareLocal(typeof(bool[]));
         il.Emit(OpCodes.Ldc_I4_1); il.Emit(OpCodes.Newarr, typeof(bool)); il.Emit(OpCodes.Stloc, overflowLocal);
 
-        // _resStdout = ChildReadCapped(_proc.StandardOutput, _maxBuffer, overflow);
-        StoreCtxField(il, _childCtxResStdout, () =>
+        // _resStdout/_resStderr = ChildDecodeOutput(ChildReadCappedBytes(<pipe>.BaseStream,
+        //   _maxBuffer, overflow), _asBuffer, _encoding) — Buffer or decoded string.
+        var baseStreamGet = typeof(System.IO.StreamReader).GetProperty("BaseStream")!.GetGetMethod()!;
+        void ReadDecoded(FieldBuilder resField, MethodInfo pipeGet)
         {
-            il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Ldfld, _childCtxProc); il.Emit(OpCodes.Callvirt, _miProcStdoutGet);
-            il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Ldfld, _childCtxMaxBuffer);
-            il.Emit(OpCodes.Ldloc, overflowLocal);
-            il.Emit(OpCodes.Call, _childReadCapped);
-        });
-        // _resStderr = ChildReadCapped(_proc.StandardError, _maxBuffer, overflow);
-        StoreCtxField(il, _childCtxResStderr, () =>
-        {
-            il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Ldfld, _childCtxProc); il.Emit(OpCodes.Callvirt, _miProcStderrGet);
-            il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Ldfld, _childCtxMaxBuffer);
-            il.Emit(OpCodes.Ldloc, overflowLocal);
-            il.Emit(OpCodes.Call, _childReadCapped);
-        });
+            StoreCtxField(il, resField, () =>
+            {
+                il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Ldfld, _childCtxProc); il.Emit(OpCodes.Callvirt, pipeGet);
+                il.Emit(OpCodes.Callvirt, baseStreamGet);
+                il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Ldfld, _childCtxMaxBuffer);
+                il.Emit(OpCodes.Ldloc, overflowLocal);
+                il.Emit(OpCodes.Call, _childReadCappedBytes);
+                il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Ldfld, _childCtxAsBuffer);
+                il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Ldfld, _childCtxEncoding);
+                il.Emit(OpCodes.Call, _childDecodeOutput);
+            });
+        }
+        ReadDecoded(_childCtxResStdout, _miProcStdoutGet);
+        ReadDecoded(_childCtxResStderr, _miProcStderrGet);
 
         // if (overflow[0]) { try { _proc.Kill(true); } catch {}  _resError = maxBuffer error; }
         var noOverflow = il.DefineLabel();
@@ -1474,6 +1500,7 @@ public partial class RuntimeEmitter
         StoreCtxField(il, ctxLocal, _childCtxTimeout, () => il.Emit(OpCodes.Ldloc, timeoutLocal));
         // maxBuffer (chars), default 1 MB.
         StoreCtxField(il, ctxLocal, _childCtxMaxBuffer, () => EmitParseMaxBuffer(il, optionsLocal));
+        EmitStoreEncodingFields(il, ctxLocal, optionsLocal);
 
         // dict = new Dictionary<string,object?>()
         il.Emit(OpCodes.Newobj, _types.DictionaryStringObject.GetConstructor(Type.EmptyTypes)!);
@@ -1651,6 +1678,74 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Stfld, field);
     }
 
+    /// <summary>
+    /// Sets ctx._asBuffer + ctx._encoding from options["encoding"]: 'buffer' → asBuffer=true;
+    /// any other name → that encoding; absent → 'utf8' (Node's exec default).
+    /// </summary>
+    private void EmitStoreEncodingFields(ILGenerator il, LocalBuilder ctxLocal, LocalBuilder optionsObjLocal)
+    {
+        var encStr = il.DeclareLocal(_types.String);
+        var dictLocal = il.DeclareLocal(_types.DictionaryStringObject);
+        var tmpLocal = il.DeclareLocal(_types.Object);
+        var tryGet = _types.DictionaryStringObject.GetMethod("TryGetValue", [_types.String, _types.Object.MakeByRefType()])!;
+        var strEq = _types.String.GetMethod("op_Equality", [_types.String, _types.String])!;
+        var done = il.DefineLabel();
+
+        il.Emit(OpCodes.Ldnull); il.Emit(OpCodes.Stloc, encStr);
+        il.Emit(OpCodes.Ldloc, optionsObjLocal);
+        il.Emit(OpCodes.Isinst, _types.DictionaryStringObject);
+        il.Emit(OpCodes.Dup); il.Emit(OpCodes.Stloc, dictLocal);
+        il.Emit(OpCodes.Brfalse, done);
+        il.Emit(OpCodes.Ldloc, dictLocal);
+        il.Emit(OpCodes.Ldstr, "encoding");
+        il.Emit(OpCodes.Ldloca, tmpLocal);
+        il.Emit(OpCodes.Callvirt, tryGet);
+        il.Emit(OpCodes.Brfalse, done);
+        il.Emit(OpCodes.Ldloc, tmpLocal);
+        il.Emit(OpCodes.Isinst, _types.String);
+        il.Emit(OpCodes.Stloc, encStr);
+        il.MarkLabel(done);
+
+        // _asBuffer = encStr == "buffer"
+        StoreCtxField(il, ctxLocal, _childCtxAsBuffer, () =>
+        {
+            il.Emit(OpCodes.Ldloc, encStr); il.Emit(OpCodes.Ldstr, "buffer"); il.Emit(OpCodes.Call, strEq);
+        });
+        // _encoding = (encStr == null || encStr == "buffer") ? "utf8" : encStr
+        StoreCtxField(il, ctxLocal, _childCtxEncoding, () =>
+        {
+            var useDefault = il.DefineLabel();
+            var got = il.DefineLabel();
+            il.Emit(OpCodes.Ldloc, encStr); il.Emit(OpCodes.Brfalse, useDefault);
+            il.Emit(OpCodes.Ldloc, encStr); il.Emit(OpCodes.Ldstr, "buffer"); il.Emit(OpCodes.Call, strEq); il.Emit(OpCodes.Brtrue, useDefault);
+            il.Emit(OpCodes.Ldloc, encStr); il.Emit(OpCodes.Br, got);
+            il.MarkLabel(useDefault); il.Emit(OpCodes.Ldstr, "utf8");
+            il.MarkLabel(got);
+        });
+    }
+
+    /// <summary>Leaves a bool on the stack: (arg[argIdx] as dict)?[key] is bool b ? b : false.</summary>
+    private void EmitOptionBool(ILGenerator il, int argIdx, string key)
+    {
+        var dictLocal = il.DeclareLocal(_types.DictionaryStringObject);
+        var tmpLocal = il.DeclareLocal(_types.Object);
+        var resultLocal = il.DeclareLocal(_types.Boolean);
+        var tryGet = _types.DictionaryStringObject.GetMethod("TryGetValue", [_types.String, _types.Object.MakeByRefType()])!;
+        var done = il.DefineLabel();
+        il.Emit(OpCodes.Ldc_I4_0); il.Emit(OpCodes.Stloc, resultLocal);
+        il.Emit(OpCodes.Ldarg, argIdx);
+        il.Emit(OpCodes.Isinst, _types.DictionaryStringObject);
+        il.Emit(OpCodes.Dup); il.Emit(OpCodes.Stloc, dictLocal);
+        il.Emit(OpCodes.Brfalse, done);
+        il.Emit(OpCodes.Ldloc, dictLocal); il.Emit(OpCodes.Ldstr, key); il.Emit(OpCodes.Ldloca, tmpLocal);
+        il.Emit(OpCodes.Callvirt, tryGet);
+        il.Emit(OpCodes.Brfalse, done);
+        il.Emit(OpCodes.Ldloc, tmpLocal); il.Emit(OpCodes.Isinst, _types.Boolean); il.Emit(OpCodes.Brfalse, done);
+        il.Emit(OpCodes.Ldloc, tmpLocal); il.Emit(OpCodes.Unbox_Any, _types.Boolean); il.Emit(OpCodes.Stloc, resultLocal);
+        il.MarkLabel(done);
+        il.Emit(OpCodes.Ldloc, resultLocal);
+    }
+
     /// <summary>Leaves an int on the stack: options["maxBuffer"] as int, default 1 MB.</summary>
     private void EmitParseMaxBuffer(ILGenerator il, LocalBuilder optionsObjLocal)
     {
@@ -1683,37 +1778,29 @@ public partial class RuntimeEmitter
     }
 
     /// <summary>
-    /// static string ChildReadCapped(TextReader reader, int maxBuffer, bool[] flag): reads up to
-    /// maxBuffer chars; on overflow sets flag[0]=true and stops. maxBuffer&lt;0 means unbounded.
+    /// static byte[] ChildReadCappedBytes(Stream stream, int maxBuffer, bool[] flag): reads up
+    /// to maxBuffer bytes; on overflow sets flag[0]=true and stops. maxBuffer&lt;0 = unbounded.
     /// </summary>
     private void EmitChildReadCapped(TypeBuilder runtimeType, EmittedRuntime runtime)
     {
-        var m = runtimeType.DefineMethod("ChildReadCapped",
-            MethodAttributes.Public | MethodAttributes.Static, _types.String,
-            [_types.TextReader, _types.Int32, typeof(bool[])]);
-        _childReadCapped = m;
+        var streamT = typeof(System.IO.Stream);
+        var memT = typeof(System.IO.MemoryStream);
+        var m = runtimeType.DefineMethod("ChildReadCappedBytes",
+            MethodAttributes.Public | MethodAttributes.Static, typeof(byte[]),
+            [streamT, _types.Int32, typeof(bool[])]);
+        _childReadCappedBytes = m;
         var il = m.GetILGenerator();
-        var sbLocal = il.DeclareLocal(_types.StringBuilder);
-        var bufLocal = il.DeclareLocal(typeof(char[]));
+        var msLocal = il.DeclareLocal(memT);
+        var bufLocal = il.DeclareLocal(typeof(byte[]));
         var nLocal = il.DeclareLocal(_types.Int32);
+        var totalLocal = il.DeclareLocal(_types.Int32);
         var remLocal = il.DeclareLocal(_types.Int32);
-        var readM = _types.TextReader.GetMethod("Read", [typeof(char[]), _types.Int32, _types.Int32])!;
-        var appendM = _types.StringBuilder.GetMethod("Append", [typeof(char[]), _types.Int32, _types.Int32])!;
-        var lenGet = _types.StringBuilder.GetProperty("Length")!.GetGetMethod()!;
+        var readM = streamT.GetMethod("Read", [typeof(byte[]), _types.Int32, _types.Int32])!;
+        var writeM = streamT.GetMethod("Write", [typeof(byte[]), _types.Int32, _types.Int32])!;
 
-        // if (maxBuffer < 0) return reader.ReadToEnd();
-        var bounded = il.DefineLabel();
-        il.Emit(OpCodes.Ldarg_1);
-        il.Emit(OpCodes.Ldc_I4_0);
-        il.Emit(OpCodes.Bge, bounded);
-        il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Callvirt, _miReadToEnd);
-        il.Emit(OpCodes.Ret);
-        il.MarkLabel(bounded);
-
-        il.Emit(OpCodes.Newobj, _types.StringBuilder.GetConstructor(Type.EmptyTypes)!);
-        il.Emit(OpCodes.Stloc, sbLocal);
-        il.Emit(OpCodes.Ldc_I4, 4096); il.Emit(OpCodes.Newarr, typeof(char)); il.Emit(OpCodes.Stloc, bufLocal);
+        il.Emit(OpCodes.Newobj, memT.GetConstructor(Type.EmptyTypes)!); il.Emit(OpCodes.Stloc, msLocal);
+        il.Emit(OpCodes.Ldc_I4, 4096); il.Emit(OpCodes.Newarr, typeof(byte)); il.Emit(OpCodes.Stloc, bufLocal);
+        il.Emit(OpCodes.Ldc_I4_0); il.Emit(OpCodes.Stloc, totalLocal);
 
         var loop = il.DefineLabel();
         var end = il.DefineLabel();
@@ -1722,32 +1809,45 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Callvirt, readM);
         il.Emit(OpCodes.Stloc, nLocal);
         il.Emit(OpCodes.Ldloc, nLocal); il.Emit(OpCodes.Ldc_I4_0); il.Emit(OpCodes.Ble, end);
-        // if (sb.Length + n > maxBuffer) { rem = max(0, maxBuffer - sb.Length); sb.Append(buf,0,rem); flag[0]=true; break; }
+        // if (maxBuffer >= 0 && total + n > maxBuffer) { rem = max(0, maxBuffer-total); ms.Write(buf,0,rem); flag[0]=true; break; }
         var noOverflow = il.DefineLabel();
-        il.Emit(OpCodes.Ldloc, sbLocal); il.Emit(OpCodes.Callvirt, lenGet);
-        il.Emit(OpCodes.Ldloc, nLocal); il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Ldarg_1); il.Emit(OpCodes.Ldc_I4_0); il.Emit(OpCodes.Blt, noOverflow); // maxBuffer < 0 → unbounded
+        il.Emit(OpCodes.Ldloc, totalLocal); il.Emit(OpCodes.Ldloc, nLocal); il.Emit(OpCodes.Add);
         il.Emit(OpCodes.Ldarg_1);
         il.Emit(OpCodes.Ble, noOverflow);
-        // rem = maxBuffer - sb.Length; if (rem<0) rem=0;
-        il.Emit(OpCodes.Ldarg_1);
-        il.Emit(OpCodes.Ldloc, sbLocal); il.Emit(OpCodes.Callvirt, lenGet);
-        il.Emit(OpCodes.Sub);
-        il.Emit(OpCodes.Stloc, remLocal);
+        il.Emit(OpCodes.Ldarg_1); il.Emit(OpCodes.Ldloc, totalLocal); il.Emit(OpCodes.Sub); il.Emit(OpCodes.Stloc, remLocal);
         var remOk = il.DefineLabel();
         il.Emit(OpCodes.Ldloc, remLocal); il.Emit(OpCodes.Ldc_I4_0); il.Emit(OpCodes.Bge, remOk);
         il.Emit(OpCodes.Ldc_I4_0); il.Emit(OpCodes.Stloc, remLocal);
         il.MarkLabel(remOk);
-        il.Emit(OpCodes.Ldloc, sbLocal); il.Emit(OpCodes.Ldloc, bufLocal); il.Emit(OpCodes.Ldc_I4_0); il.Emit(OpCodes.Ldloc, remLocal);
-        il.Emit(OpCodes.Callvirt, appendM); il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Ldloc, msLocal); il.Emit(OpCodes.Ldloc, bufLocal); il.Emit(OpCodes.Ldc_I4_0); il.Emit(OpCodes.Ldloc, remLocal);
+        il.Emit(OpCodes.Callvirt, writeM);
         il.Emit(OpCodes.Ldarg_2); il.Emit(OpCodes.Ldc_I4_0); il.Emit(OpCodes.Ldc_I4_1); il.Emit(OpCodes.Stelem_I1);
         il.Emit(OpCodes.Br, end);
         il.MarkLabel(noOverflow);
-        il.Emit(OpCodes.Ldloc, sbLocal); il.Emit(OpCodes.Ldloc, bufLocal); il.Emit(OpCodes.Ldc_I4_0); il.Emit(OpCodes.Ldloc, nLocal);
-        il.Emit(OpCodes.Callvirt, appendM); il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Ldloc, msLocal); il.Emit(OpCodes.Ldloc, bufLocal); il.Emit(OpCodes.Ldc_I4_0); il.Emit(OpCodes.Ldloc, nLocal);
+        il.Emit(OpCodes.Callvirt, writeM);
+        il.Emit(OpCodes.Ldloc, totalLocal); il.Emit(OpCodes.Ldloc, nLocal); il.Emit(OpCodes.Add); il.Emit(OpCodes.Stloc, totalLocal);
         il.Emit(OpCodes.Br, loop);
         il.MarkLabel(end);
-        il.Emit(OpCodes.Ldloc, sbLocal); il.Emit(OpCodes.Callvirt, _types.GetMethodNoParams(_types.StringBuilder, "ToString"));
+        il.Emit(OpCodes.Ldloc, msLocal); il.Emit(OpCodes.Callvirt, memT.GetMethod("ToArray", Type.EmptyTypes)!);
         il.Emit(OpCodes.Ret);
+
+        // static object ChildDecodeOutput(byte[] bytes, bool asBuffer, string encoding):
+        //   var b = new $Buffer(bytes); return asBuffer ? b : b.ToEncodedString(encoding);
+        var d = runtimeType.DefineMethod("ChildDecodeOutput",
+            MethodAttributes.Public | MethodAttributes.Static, _types.Object,
+            [typeof(byte[]), _types.Boolean, _types.String]);
+        _childDecodeOutput = d;
+        var dil = d.GetILGenerator();
+        var bLocal = dil.DeclareLocal(runtime.TSBufferType);
+        dil.Emit(OpCodes.Ldarg_0); dil.Emit(OpCodes.Newobj, runtime.TSBufferCtor); dil.Emit(OpCodes.Stloc, bLocal);
+        var decode = dil.DefineLabel();
+        dil.Emit(OpCodes.Ldarg_1); dil.Emit(OpCodes.Brfalse, decode);
+        dil.Emit(OpCodes.Ldloc, bLocal); dil.Emit(OpCodes.Ret);
+        dil.MarkLabel(decode);
+        dil.Emit(OpCodes.Ldloc, bLocal); dil.Emit(OpCodes.Ldarg_2); dil.Emit(OpCodes.Callvirt, runtime.TSBufferToString);
+        dil.Emit(OpCodes.Ret);
     }
 
     /// <summary>

--- a/Compilation/RuntimeEmitter.ChildProcessHelpers.cs
+++ b/Compilation/RuntimeEmitter.ChildProcessHelpers.cs
@@ -24,6 +24,45 @@ public partial class RuntimeEmitter
     }
 
     /// <summary>
+    /// Declares an inputLocal, parses options[argIdx]["input"] into it, and sets
+    /// RedirectStandardInput = (input != null) on startInfoLocal. Returns inputLocal. (#1021)
+    /// </summary>
+    private LocalBuilder EmitSyncInputRedirect(ILGenerator il, LocalBuilder startInfoLocal, int optionsArgIdx)
+    {
+        var inputLocal = il.DeclareLocal(_types.String);
+        var dictLocal = il.DeclareLocal(_types.DictionaryStringObject);
+        var tmpLocal = il.DeclareLocal(_types.Object);
+        var done = il.DefineLabel();
+        il.Emit(OpCodes.Ldnull); il.Emit(OpCodes.Stloc, inputLocal);
+        il.Emit(OpCodes.Ldarg, optionsArgIdx);
+        il.Emit(OpCodes.Isinst, _types.DictionaryStringObject);
+        il.Emit(OpCodes.Dup); il.Emit(OpCodes.Stloc, dictLocal);
+        il.Emit(OpCodes.Brfalse, done);
+        il.Emit(OpCodes.Ldloc, dictLocal); il.Emit(OpCodes.Ldstr, "input"); il.Emit(OpCodes.Ldloca, tmpLocal);
+        il.Emit(OpCodes.Callvirt, _types.DictionaryStringObject.GetMethod("TryGetValue", [_types.String, _types.Object.MakeByRefType()])!);
+        il.Emit(OpCodes.Brfalse, done);
+        il.Emit(OpCodes.Ldloc, tmpLocal); il.Emit(OpCodes.Isinst, _types.String); il.Emit(OpCodes.Stloc, inputLocal);
+        il.MarkLabel(done);
+        il.Emit(OpCodes.Ldloc, startInfoLocal);
+        il.Emit(OpCodes.Ldloc, inputLocal); il.Emit(OpCodes.Ldnull); il.Emit(OpCodes.Cgt_Un);
+        il.Emit(OpCodes.Callvirt, _types.ProcessStartInfo.GetProperty("RedirectStandardInput")!.GetSetMethod()!);
+        return inputLocal;
+    }
+
+    /// <summary>After Start: if input != null, write it to StandardInput and Close (EOF). (#1021)</summary>
+    private void EmitSyncInputWrite(ILGenerator il, LocalBuilder processLocal, LocalBuilder inputLocal)
+    {
+        var noWrite = il.DefineLabel();
+        var stdinGet = _types.Process.GetProperty("StandardInput")!.GetGetMethod()!;
+        il.Emit(OpCodes.Ldloc, inputLocal); il.Emit(OpCodes.Brfalse, noWrite);
+        il.Emit(OpCodes.Ldloc, processLocal); il.Emit(OpCodes.Callvirt, stdinGet);
+        il.Emit(OpCodes.Ldloc, inputLocal); il.Emit(OpCodes.Callvirt, typeof(System.IO.TextWriter).GetMethod("Write", [_types.String])!);
+        il.Emit(OpCodes.Ldloc, processLocal); il.Emit(OpCodes.Callvirt, stdinGet);
+        il.Emit(OpCodes.Callvirt, typeof(System.IO.TextWriter).GetMethod("Close", Type.EmptyTypes)!);
+        il.MarkLabel(noWrite);
+    }
+
+    /// <summary>
     /// Emits: public static string ChildProcessExecSync(string command, object options)
     /// Executes a command synchronously and returns stdout.
     /// </summary>
@@ -71,6 +110,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloc, startInfoLocal);
         il.Emit(OpCodes.Ldc_I4_1);
         il.Emit(OpCodes.Callvirt, _types.ProcessStartInfo.GetProperty("CreateNoWindow")!.GetSetMethod()!);
+        var __inputES = EmitSyncInputRedirect(il, startInfoLocal, 1);
 
         // Platform check: if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         var notWindowsLabel = il.DefineLabel();
@@ -244,6 +284,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloc, processLocal);
         il.Emit(OpCodes.Callvirt, _types.Process.GetMethod("Start", Type.EmptyTypes)!);
         il.Emit(OpCodes.Pop);
+        EmitSyncInputWrite(il, processLocal, __inputES);
 
         // stdout = process.StandardOutput.ReadToEnd()
         il.Emit(OpCodes.Ldloc, processLocal);
@@ -961,6 +1002,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloc, startInfoLocal);
         il.Emit(OpCodes.Ldc_I4_1);
         il.Emit(OpCodes.Callvirt, _types.ProcessStartInfo.GetProperty("CreateNoWindow")!.GetSetMethod()!);
+        var __inputEFS = EmitSyncInputRedirect(il, startInfoLocal, 2);
 
         // Extract args if provided (args is List<object?>)
         var noArgsLabel = il.DefineLabel();
@@ -1061,6 +1103,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloc, processLocal);
         il.Emit(OpCodes.Callvirt, _types.Process.GetMethod("Start", Type.EmptyTypes)!);
         il.Emit(OpCodes.Pop);
+        EmitSyncInputWrite(il, processLocal, __inputEFS);
 
         il.Emit(OpCodes.Ldloc, processLocal);
         il.Emit(OpCodes.Callvirt, _types.Process.GetProperty("StandardOutput")!.GetGetMethod()!);

--- a/Compilation/RuntimeFeatureDetector.cs
+++ b/Compilation/RuntimeFeatureDetector.cs
@@ -191,9 +191,10 @@ public sealed class RuntimeFeatureDetector
                 _set.UsesOs = true; break;
             case "child_process":
                 // spawn()/fork() expose stdout/stderr as $Readable and stdin as
-                // $Writable, so the Node-stream runtime types must be emitted too.
+                // $Writable; exec/execFile with encoding:'buffer' produce a $Buffer.
                 _set.UsesChildProcess = true;
                 _set.UsesNodeStreams = true;
+                _set.UsesBuffer = true;
                 break;
             case "vm":
                 _set.UsesVm = true; break;

--- a/Runtime/BuiltIns/Modules/Interpreter/ChildProcessModuleInterpreter.cs
+++ b/Runtime/BuiltIns/Modules/Interpreter/ChildProcessModuleInterpreter.cs
@@ -37,12 +37,14 @@ public static class ChildProcessModuleInterpreter
         var options = args.Length > 1 ? args[1].ToObject() as SharpTSObject : null;
         var cwd = GetStringOption(options, "cwd");
         var timeout = GetDoubleOption(options, "timeout", -1);
+        var input = GetStringOption(options, "input");
 
         var startInfo = new ProcessStartInfo
         {
             UseShellExecute = false,
             RedirectStandardOutput = true,
             RedirectStandardError = true,
+            RedirectStandardInput = input != null,
             CreateNoWindow = true
         };
 
@@ -66,6 +68,11 @@ public static class ChildProcessModuleInterpreter
 
         using var process = new Process { StartInfo = startInfo };
         process.Start();
+        if (input != null)
+        {
+            process.StandardInput.Write(input);
+            process.StandardInput.Close();
+        }
 
         var stdout = process.StandardOutput.ReadToEnd();
 
@@ -212,7 +219,7 @@ public static class ChildProcessModuleInterpreter
         interpreter.Ref();
         Task.Run(() =>
         {
-            string stdout = "", stderr = "";
+            object stdout = "", stderr = ""; // string (decoded) or SharpTSBuffer (encoding:'buffer')
             int code = 0, kind = 0; // kind: 0 normal, 1 timeout, 2 exception
             object? error = null;
             try
@@ -247,8 +254,11 @@ public static class ChildProcessModuleInterpreter
                 childProcess.SetProcess(process);
 
                 var maxBuffer = (int)GetDoubleOption(options, "maxBuffer", 1024 * 1024);
-                stdout = ReadCapped(process.StandardOutput, maxBuffer, out var oOver);
-                stderr = ReadCapped(process.StandardError, maxBuffer, out var eOver);
+                var (asBuffer, encoding) = GetOutputEncoding(options);
+                var outBytes = ReadCappedBytes(process.StandardOutput.BaseStream, maxBuffer, out var oOver);
+                var errBytes = ReadCappedBytes(process.StandardError.BaseStream, maxBuffer, out var eOver);
+                stdout = asBuffer ? new SharpTSBuffer(outBytes) : BufferEncoding.Decode(outBytes, encoding);
+                stderr = asBuffer ? new SharpTSBuffer(errBytes) : BufferEncoding.Decode(errBytes, encoding);
                 if (oOver || eOver)
                 {
                     try { process.Kill(); } catch { }
@@ -377,8 +387,12 @@ public static class ChildProcessModuleInterpreter
             else
             {
                 startInfo.FileName = command;
-                foreach (var arg in cmdArgs)
-                    startInfo.ArgumentList.Add(arg);
+                if (GetBoolOption(options, "windowsVerbatimArguments", false))
+                    // Pass args verbatim (no .NET quoting), as Node's windowsVerbatimArguments asks.
+                    startInfo.Arguments = string.Join(" ", cmdArgs);
+                else
+                    foreach (var arg in cmdArgs)
+                        startInfo.ArgumentList.Add(arg);
             }
 
             if (!string.IsNullOrEmpty(cwd))
@@ -539,6 +553,7 @@ public static class ChildProcessModuleInterpreter
 
         var cwd = GetStringOption(options, "cwd");
         var timeout = GetDoubleOption(options, "timeout", -1);
+        var input = GetStringOption(options, "input");
 
         var startInfo = new ProcessStartInfo
         {
@@ -546,6 +561,7 @@ public static class ChildProcessModuleInterpreter
             UseShellExecute = false,
             RedirectStandardOutput = true,
             RedirectStandardError = true,
+            RedirectStandardInput = input != null,
             CreateNoWindow = true
         };
 
@@ -559,6 +575,11 @@ public static class ChildProcessModuleInterpreter
 
         using var process = new Process { StartInfo = startInfo };
         process.Start();
+        if (input != null)
+        {
+            process.StandardInput.Write(input);
+            process.StandardInput.Close();
+        }
 
         var stdout = process.StandardOutput.ReadToEnd();
 
@@ -629,7 +650,7 @@ public static class ChildProcessModuleInterpreter
         interpreter.Ref();
         Task.Run(() =>
         {
-            string stdout = "", stderr = "";
+            object stdout = "", stderr = ""; // string (decoded) or SharpTSBuffer (encoding:'buffer')
             int code = 0, kind = 0; // kind: 0 normal, 1 timeout, 2 exception
             object? error = null;
             try
@@ -657,8 +678,11 @@ public static class ChildProcessModuleInterpreter
                 childProcess.SetProcess(process);
 
                 var maxBuffer = (int)GetDoubleOption(options, "maxBuffer", 1024 * 1024);
-                stdout = ReadCapped(process.StandardOutput, maxBuffer, out var oOver);
-                stderr = ReadCapped(process.StandardError, maxBuffer, out var eOver);
+                var (asBuffer, encoding) = GetOutputEncoding(options);
+                var outBytes = ReadCappedBytes(process.StandardOutput.BaseStream, maxBuffer, out var oOver);
+                var errBytes = ReadCappedBytes(process.StandardError.BaseStream, maxBuffer, out var eOver);
+                stdout = asBuffer ? new SharpTSBuffer(outBytes) : BufferEncoding.Decode(outBytes, encoding);
+                stderr = asBuffer ? new SharpTSBuffer(errBytes) : BufferEncoding.Decode(errBytes, encoding);
                 if (oOver || eOver)
                 {
                     try { process.Kill(); } catch { }
@@ -973,29 +997,40 @@ public static class ChildProcessModuleInterpreter
     /// array form. fd numbers / streams / 'ipc' fall back to "pipe" (documented limitation).
     /// </summary>
     /// <summary>
-    /// Reads a stream up to <paramref name="maxBuffer"/> chars (Node's exec maxBuffer, bytes
-    /// approximated by chars). Sets <paramref name="overflowed"/> and stops at the cap; a
-    /// negative cap means unbounded.
+    /// Reads a stream up to <paramref name="maxBuffer"/> bytes (Node's exec maxBuffer is in
+    /// bytes). Sets <paramref name="overflowed"/> and stops at the cap; a negative cap is unbounded.
     /// </summary>
-    private static string ReadCapped(System.IO.TextReader reader, int maxBuffer, out bool overflowed)
+    private static byte[] ReadCappedBytes(System.IO.Stream stream, int maxBuffer, out bool overflowed)
     {
         overflowed = false;
-        if (maxBuffer < 0)
-            return reader.ReadToEnd();
-        var sb = new System.Text.StringBuilder();
-        var buf = new char[4096];
-        int n;
-        while ((n = reader.Read(buf, 0, buf.Length)) > 0)
+        using var ms = new System.IO.MemoryStream();
+        var buf = new byte[4096];
+        int total = 0, n;
+        while ((n = stream.Read(buf, 0, buf.Length)) > 0)
         {
-            if (sb.Length + n > maxBuffer)
+            if (maxBuffer >= 0 && total + n > maxBuffer)
             {
-                sb.Append(buf, 0, Math.Max(0, maxBuffer - sb.Length));
+                ms.Write(buf, 0, Math.Max(0, maxBuffer - total));
                 overflowed = true;
                 break;
             }
-            sb.Append(buf, 0, n);
+            ms.Write(buf, 0, n);
+            total += n;
         }
-        return sb.ToString();
+        return ms.ToArray();
+    }
+
+    /// <summary>
+    /// Reads the `encoding` option: 'buffer' → raw Buffer output; any other name → decode the
+    /// bytes with that encoding; absent/unrecognised → 'utf8' (Node's exec default). (Explicit
+    /// `encoding: null` → Buffer is not distinguished from absent and decodes as utf8.)
+    /// </summary>
+    private static (bool asBuffer, string encoding) GetOutputEncoding(SharpTSObject? options)
+    {
+        var value = options?.GetProperty("encoding");
+        if (value is string s)
+            return s == "buffer" ? (true, "utf8") : (false, s);
+        return (false, "utf8");
     }
 
     private static SharpTSObject MaxBufferError() => new(new Dictionary<string, object?>

--- a/SharpTS.Tests/SharedTests/BuiltInModules/ChildProcessAsyncTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/ChildProcessAsyncTests.cs
@@ -473,6 +473,85 @@ public class ChildProcessAsyncTests
 
     [Theory]
     [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Exec_Encoding_Buffer_ReturnsBuffer(ExecutionMode mode)
+    {
+        // encoding:'buffer' makes stdout a Buffer instead of a string.
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import { exec } from 'child_process';
+                exec('echo hello', { encoding: 'buffer' }, (err: any, stdout: any) => {
+                  console.log('isBuf:' + Buffer.isBuffer(stdout) + ' val:' + stdout.toString().trim());
+                });
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("isBuf:true val:hello\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ExecSync_Input_FeedsStdin(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import { execSync } from 'child_process';
+                const out = execSync('sort', { input: 'banana\napple\n' });
+                console.log('execSync:' + out.trim());
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("execSync:apple\nbanana\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ExecFileSync_Input_FeedsStdin(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import { execFileSync } from 'child_process';
+                const out = execFileSync('sort', [], { input: 'cherry\nberry\n' });
+                console.log('execFileSync:' + out.trim());
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("execFileSync:berry\ncherry\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Spawn_WindowsVerbatimArguments_Honored(ExecutionMode mode)
+    {
+        // windowsVerbatimArguments passes args as a raw command line; verify a normal spawn
+        // still produces correct output through that path.
+        var command = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "cmd.exe" : "/bin/echo";
+        var args = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+            ? "['/c', 'echo', 'vbworks']"
+            : "['vbworks']";
+
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = $$"""
+                import { spawn } from 'child_process';
+                const c = spawn('{{command}}', {{args}}, { windowsVerbatimArguments: true });
+                let out = '';
+                c.stdout.on('data', (d: any) => { out += d.toString(); });
+                c.stdout.on('end', () => console.log('vb:' + out.trim()));
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("vb:vbworks\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void Exec_MaxBuffer_Overflow_Errors(ExecutionMode mode)
     {
         // Output longer than maxBuffer kills the child and surfaces ERR_CHILD_PROCESS_STDIO_MAXBUFFER.


### PR DESCRIPTION
Follow-up to the epic #1012 (PR #1173), finishing the items that were deferred under budget. Addresses the two issues left open: **#1019** and **#1021**.

## #1019 — `encoding` output + byte-accurate `maxBuffer` (both modes)
- `exec`/`execFile` now read raw **bytes** from the redirected pipe and honor the `encoding` option:
  - `'buffer'` → a real `Buffer`,
  - any named encoding (`hex`, `base64`, `ascii`, `latin1`, `utf16le`, …) → decoded with it,
  - absent → `'utf8'` (Node's exec default — backward compatible).
- `maxBuffer` is now counted in **bytes** (was a char approximation).
- Interpreter uses `BufferEncoding.Decode` (the canonical source of truth) + `SharpTSBuffer`. Compiled adds BCL-only `ChildReadCappedBytes` + `ChildDecodeOutput`; the latter builds a `$Buffer` and decodes via `$Buffer.ToEncodedString`, which is documented to mirror `BufferEncoding.Decode` byte-for-byte — so interp == compiled for every encoding, and **standalone is preserved**. `child_process` now implies `UsesBuffer` so `$Buffer` is emitted.

## #1021 — `input` for `execSync`/`execFileSync` + `windowsVerbatimArguments` (both modes)
- `execSync`/`execFileSync` honor the `input` option (redirect stdin, write, close) — the pattern already shipped for `spawnSync`. Compiled adds reusable `EmitSyncInputRedirect`/`EmitSyncInputWrite`.
- `spawn` honors `windowsVerbatimArguments`: args are passed as a raw `Arguments` string (no .NET quoting) instead of `ArgumentList`. Compiled adds `EmitOptionBool` + a verbatim branch in `ConfigureSpawnStartInfo`.

## Verification
- `dotnet test`: **14573 passed, 0 failed**
- TypeScript conformance: **31/0**
- Test262: **20/0** (baseline-stable)
- New dual-mode tests: `encoding:'buffer'`, `execSync`/`execFileSync` `input` round-trips (`sort`), and a verbatim spawn.

## The one genuine ceiling (documented, not chased)
`argv0` cannot be supported cleanly: .NET `ProcessStartInfo` exposes `FileName`/`Arguments`/`ArgumentList` but **no API to set `argv[0]` independently of the executable** (Node uses `execvp` with a custom argv[0]). This is the only outstanding item on #1021 and matches the epic's "Known .NET ceilings" category.

After merge, #1019 can be closed; #1021 can be closed (with `argv0` noted as a platform ceiling) or kept open to track `argv0` only.