### PR TITLE
Epic #1023: Node stream module → 100% compatibility (async iteration, helpers, conversions; interp ↔ compiled parity)

### DIFF
--- a/Compilation/EmittedRuntime.cs
+++ b/Compilation/EmittedRuntime.cs
@@ -2466,6 +2466,15 @@ public class EmittedRuntime
     public Type StreamAbortCallbackType { get; set; } = null!;
     public ConstructorBuilder StreamAbortCallbackCtor { get; set; } = null!;
     public MethodBuilder StreamAbortCallbackOnAbort { get; set; } = null!;
+    // #1028: compose(...streams) + Duplex.from(source).
+    public MethodBuilder StreamDuplexFrom { get; set; } = null!;
+    public MethodBuilder StreamCompose { get; set; } = null!;
+    public Type StreamComposeBridgeType { get; set; } = null!;
+    public ConstructorBuilder StreamComposeBridgeCtor { get; set; } = null!;
+    public MethodBuilder StreamComposeBridgeForwardWrite { get; set; } = null!;
+    public MethodBuilder StreamComposeBridgePushData { get; set; } = null!;
+    public MethodBuilder StreamComposeBridgePushEnd { get; set; } = null!;
+    public MethodBuilder StreamComposeBridgeEndFirst { get; set; } = null!;
 
     // $Writable type - emitted for standalone stream support
     // NOTE: Must stay in sync with SharpTS.Runtime.Types.SharpTSWritable

--- a/Compilation/EmittedRuntime.cs
+++ b/Compilation/EmittedRuntime.cs
@@ -2458,6 +2458,9 @@ public class EmittedRuntime
     public MethodBuilder TSReadablePause { get; set; } = null!;
     public MethodBuilder TSReadableResume { get; set; } = null!;
     public MethodBuilder TSReadableIsPaused { get; set; } = null!;
+    // #1024: [Symbol.asyncIterator] support — GetAsyncIterator() is registered via the
+    // GetIteratorFunction hook so `for await…of` over a $Readable works in compiled mode.
+    public MethodBuilder TSReadableGetAsyncIterator { get; set; } = null!;
 
     // $Writable type - emitted for standalone stream support
     // NOTE: Must stay in sync with SharpTS.Runtime.Types.SharpTSWritable

--- a/Compilation/EmittedRuntime.cs
+++ b/Compilation/EmittedRuntime.cs
@@ -2461,6 +2461,11 @@ public class EmittedRuntime
     // #1024: [Symbol.asyncIterator] support — GetAsyncIterator() is registered via the
     // GetIteratorFunction hook so `for await…of` over a $Readable works in compiled mode.
     public MethodBuilder TSReadableGetAsyncIterator { get; set; } = null!;
+    // #1027: addAbortSignal(signal, stream) — destroy-on-abort wiring + its listener closure.
+    public MethodBuilder StreamAddAbortSignal { get; set; } = null!;
+    public Type StreamAbortCallbackType { get; set; } = null!;
+    public ConstructorBuilder StreamAbortCallbackCtor { get; set; } = null!;
+    public MethodBuilder StreamAbortCallbackOnAbort { get; set; } = null!;
 
     // $Writable type - emitted for standalone stream support
     // NOTE: Must stay in sync with SharpTS.Runtime.Types.SharpTSWritable

--- a/Compilation/EmittedRuntime.cs
+++ b/Compilation/EmittedRuntime.cs
@@ -2466,6 +2466,11 @@ public class EmittedRuntime
     public Type StreamAbortCallbackType { get; set; } = null!;
     public ConstructorBuilder StreamAbortCallbackCtor { get; set; } = null!;
     public MethodBuilder StreamAbortCallbackOnAbort { get; set; } = null!;
+    // #1030: isErrored + get/setDefaultHighWaterMark.
+    public MethodBuilder TSReadableErroredGetter { get; set; } = null!;
+    public MethodBuilder TSWritableErroredGetter { get; set; } = null!;
+    public MethodBuilder StreamGetDefaultHighWaterMark { get; set; } = null!;
+    public MethodBuilder StreamSetDefaultHighWaterMark { get; set; } = null!;
     // #1028: compose(...streams) + Duplex.from(source).
     public MethodBuilder StreamDuplexFrom { get; set; } = null!;
     public MethodBuilder StreamCompose { get; set; } = null!;

--- a/Compilation/Emitters/Modules/StreamModuleEmitter.cs
+++ b/Compilation/Emitters/Modules/StreamModuleEmitter.cs
@@ -23,6 +23,9 @@ public sealed class StreamModuleEmitter : IBuiltInModuleEmitter
         "pipeline",
         "addAbortSignal",
         "compose",
+        "isErrored",
+        "getDefaultHighWaterMark",
+        "setDefaultHighWaterMark",
         "promises"
     ];
 
@@ -43,6 +46,15 @@ public sealed class StreamModuleEmitter : IBuiltInModuleEmitter
                 return true;
             case "compose":
                 EmitComposeCall(emitter, arguments);
+                return true;
+            case "isErrored":
+                EmitIsErroredCall(emitter, arguments);
+                return true;
+            case "getDefaultHighWaterMark":
+                EmitDefaultHwmCall(emitter, arguments, emitter.Context.Runtime!.StreamGetDefaultHighWaterMark, getter: true);
+                return true;
+            case "setDefaultHighWaterMark":
+                EmitDefaultHwmCall(emitter, arguments, emitter.Context.Runtime!.StreamSetDefaultHighWaterMark, getter: false);
                 return true;
             case "Readable.from":
                 EmitReadableFromCall(emitter, arguments);
@@ -267,6 +279,91 @@ public sealed class StreamModuleEmitter : IBuiltInModuleEmitter
         }
 
         il.Emit(OpCodes.Call, ctx.Runtime!.StreamReadableFrom);
+    }
+
+    /// <summary>
+    /// Emits: isErrored(stream) → bool. Reads $Readable.Errored / $Writable.Errored, else false.
+    /// </summary>
+    private static void EmitIsErroredCall(IEmitterContext emitter, List<Expr> arguments)
+    {
+        var ctx = emitter.Context;
+        var il = ctx.IL;
+
+        if (arguments.Count > 0)
+        {
+            emitter.EmitExpression(arguments[0]);
+            emitter.EmitBoxIfNeeded(arguments[0]);
+        }
+        else
+        {
+            il.Emit(OpCodes.Ldnull);
+        }
+
+        var objLocal = il.DeclareLocal(typeof(object));
+        il.Emit(OpCodes.Stloc, objLocal);
+
+        var notReadable = il.DefineLabel();
+        var falseLabel = il.DefineLabel();
+        var endLabel = il.DefineLabel();
+
+        il.Emit(OpCodes.Ldloc, objLocal);
+        il.Emit(OpCodes.Isinst, ctx.Runtime!.TSReadableType);
+        il.Emit(OpCodes.Brfalse, notReadable);
+        il.Emit(OpCodes.Ldloc, objLocal);
+        il.Emit(OpCodes.Castclass, ctx.Runtime!.TSReadableType);
+        il.Emit(OpCodes.Callvirt, ctx.Runtime!.TSReadableErroredGetter);
+        il.Emit(OpCodes.Box, typeof(bool));
+        il.Emit(OpCodes.Br, endLabel);
+
+        il.MarkLabel(notReadable);
+        il.Emit(OpCodes.Ldloc, objLocal);
+        il.Emit(OpCodes.Isinst, ctx.Runtime!.TSWritableType);
+        il.Emit(OpCodes.Brfalse, falseLabel);
+        il.Emit(OpCodes.Ldloc, objLocal);
+        il.Emit(OpCodes.Castclass, ctx.Runtime!.TSWritableType);
+        il.Emit(OpCodes.Callvirt, ctx.Runtime!.TSWritableErroredGetter);
+        il.Emit(OpCodes.Box, typeof(bool));
+        il.Emit(OpCodes.Br, endLabel);
+
+        il.MarkLabel(falseLabel);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Box, typeof(bool));
+
+        il.MarkLabel(endLabel);
+    }
+
+    /// <summary>Emits get/setDefaultHighWaterMark by forwarding (boxed) args to the runtime helper.</summary>
+    private static void EmitDefaultHwmCall(IEmitterContext emitter, List<Expr> arguments, System.Reflection.MethodInfo target, bool getter)
+    {
+        var ctx = emitter.Context;
+        var il = ctx.IL;
+
+        // arg0 = objectMode (default false/null)
+        if (arguments.Count > 0)
+        {
+            emitter.EmitExpression(arguments[0]);
+            emitter.EmitBoxIfNeeded(arguments[0]);
+        }
+        else
+        {
+            il.Emit(OpCodes.Ldnull);
+        }
+
+        if (!getter)
+        {
+            // arg1 = value
+            if (arguments.Count > 1)
+            {
+                emitter.EmitExpression(arguments[1]);
+                emitter.EmitBoxIfNeeded(arguments[1]);
+            }
+            else
+            {
+                il.Emit(OpCodes.Ldnull);
+            }
+        }
+
+        il.Emit(OpCodes.Call, target);
     }
 
     private static void EmitDuplexFromCall(IEmitterContext emitter, List<Expr> arguments)

--- a/Compilation/Emitters/Modules/StreamModuleEmitter.cs
+++ b/Compilation/Emitters/Modules/StreamModuleEmitter.cs
@@ -153,8 +153,18 @@ public sealed class StreamModuleEmitter : IBuiltInModuleEmitter
         var ctx = emitter.Context;
         var il = ctx.IL;
 
-        // Simply return the stream (second argument)
-        if (arguments.Count >= 2)
+        // Real wiring (#1027): $Runtime.StreamAddAbortSignal(signal, stream) destroys the stream
+        // with an AbortError when the signal fires, and returns the stream. The helper is only
+        // emitted when AbortController is in use; otherwise fall back to returning the stream.
+        if (arguments.Count >= 2 && ctx.Runtime!.StreamAddAbortSignal != null)
+        {
+            emitter.EmitExpression(arguments[0]);
+            emitter.EmitBoxIfNeeded(arguments[0]);
+            emitter.EmitExpression(arguments[1]);
+            emitter.EmitBoxIfNeeded(arguments[1]);
+            il.Emit(OpCodes.Call, ctx.Runtime!.StreamAddAbortSignal);
+        }
+        else if (arguments.Count >= 2)
         {
             emitter.EmitExpression(arguments[1]);
         }

--- a/Compilation/Emitters/Modules/StreamModuleEmitter.cs
+++ b/Compilation/Emitters/Modules/StreamModuleEmitter.cs
@@ -62,6 +62,13 @@ public sealed class StreamModuleEmitter : IBuiltInModuleEmitter
             case "Duplex.from":
                 EmitDuplexFromCall(emitter, arguments);
                 return true;
+            case "Readable.toWeb":
+            case "Readable.fromWeb":
+                // #1029: Node↔Web stream conversions are an interpreter-only documented subset —
+                // the compiled path is deferred pending stream/web async-iterator + BYOB support
+                // (DEFERRED, see STATUS.md). Throw a clear error rather than fail silently.
+                EmitNotSupportedInCompiled(emitter, methodName);
+                return true;
             case "Readable.isReadable":
                 EmitIsReadableCall(emitter, arguments);
                 return true;
@@ -279,6 +286,18 @@ public sealed class StreamModuleEmitter : IBuiltInModuleEmitter
         }
 
         il.Emit(OpCodes.Call, ctx.Runtime!.StreamReadableFrom);
+    }
+
+    /// <summary>
+    /// Emits a runtime throw for a stream API that is interpreter-only in compiled output (#1029).
+    /// </summary>
+    private static void EmitNotSupportedInCompiled(IEmitterContext emitter, string methodName)
+    {
+        var ctx = emitter.Context;
+        var il = ctx.IL;
+        il.Emit(OpCodes.Ldstr, $"stream.{methodName} is not yet supported in compiled output (#1029); run in the interpreter.");
+        il.Emit(OpCodes.Newobj, ctx.Types.InvalidOperationExceptionCtorString);
+        il.Emit(OpCodes.Throw);
     }
 
     /// <summary>

--- a/Compilation/Emitters/Modules/StreamModuleEmitter.cs
+++ b/Compilation/Emitters/Modules/StreamModuleEmitter.cs
@@ -22,6 +22,7 @@ public sealed class StreamModuleEmitter : IBuiltInModuleEmitter
         "finished",
         "pipeline",
         "addAbortSignal",
+        "compose",
         "promises"
     ];
 
@@ -40,8 +41,14 @@ public sealed class StreamModuleEmitter : IBuiltInModuleEmitter
             case "addAbortSignal":
                 EmitAddAbortSignalCall(emitter, arguments);
                 return true;
+            case "compose":
+                EmitComposeCall(emitter, arguments);
+                return true;
             case "Readable.from":
                 EmitReadableFromCall(emitter, arguments);
+                return true;
+            case "Duplex.from":
+                EmitDuplexFromCall(emitter, arguments);
                 return true;
             case "Readable.isReadable":
                 EmitIsReadableCall(emitter, arguments);
@@ -260,5 +267,34 @@ public sealed class StreamModuleEmitter : IBuiltInModuleEmitter
         }
 
         il.Emit(OpCodes.Call, ctx.Runtime!.StreamReadableFrom);
+    }
+
+    private static void EmitDuplexFromCall(IEmitterContext emitter, List<Expr> arguments)
+    {
+        EmitPackedArgsCall(emitter, arguments, emitter.Context.Runtime!.StreamDuplexFrom);
+    }
+
+    private static void EmitComposeCall(IEmitterContext emitter, List<Expr> arguments)
+    {
+        EmitPackedArgsCall(emitter, arguments, emitter.Context.Runtime!.StreamCompose);
+    }
+
+    /// <summary>Packs the arguments into an object[] and calls the given runtime helper.</summary>
+    private static void EmitPackedArgsCall(IEmitterContext emitter, List<Expr> arguments, System.Reflection.MethodInfo target)
+    {
+        var ctx = emitter.Context;
+        var il = ctx.IL;
+
+        il.Emit(OpCodes.Ldc_I4, arguments.Count);
+        il.Emit(OpCodes.Newarr, typeof(object));
+        for (int i = 0; i < arguments.Count; i++)
+        {
+            il.Emit(OpCodes.Dup);
+            il.Emit(OpCodes.Ldc_I4, i);
+            emitter.EmitExpression(arguments[i]);
+            emitter.EmitBoxIfNeeded(arguments[i]);
+            il.Emit(OpCodes.Stelem_Ref);
+        }
+        il.Emit(OpCodes.Call, target);
     }
 }

--- a/Compilation/RuntimeEmitter.Iterator.cs
+++ b/Compilation/RuntimeEmitter.Iterator.cs
@@ -385,6 +385,25 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Brfalse, returnNullLabel);
 
+        // #1024: node:stream $Readable exposes [Symbol.asyncIterator] via GetAsyncIterator().
+        // It carries no per-object symbol dict and isn't a user class, so hook it here:
+        //   if (symbol == SymbolAsyncIterator && obj is $Readable) return new $TSFunction(obj, GetAsyncIterator);
+        if (runtime.TSReadableType != null && runtime.TSReadableGetAsyncIterator != null)
+        {
+            var notReadableAsyncIter = il.DefineLabel();
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Ldsfld, runtime.SymbolAsyncIterator);
+            il.Emit(OpCodes.Bne_Un, notReadableAsyncIter);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Isinst, runtime.TSReadableType);
+            il.Emit(OpCodes.Brfalse, notReadableAsyncIter);
+            il.Emit(OpCodes.Ldarg_0); // target
+            EmitInstanceMethodInfoLiteral(il, runtime.TSReadableGetAsyncIterator, runtime.TSReadableType);
+            il.Emit(OpCodes.Newobj, runtime.TSFunctionCtor);
+            il.Emit(OpCodes.Ret);
+            il.MarkLabel(notReadableAsyncIter);
+        }
+
         // Get symbol dict: var dict = GetSymbolDict(obj);
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Call, runtime.GetSymbolDictMethod);

--- a/Compilation/RuntimeEmitter.RuntimeClass.cs
+++ b/Compilation/RuntimeEmitter.RuntimeClass.cs
@@ -688,6 +688,10 @@ public partial class RuntimeEmitter
         {
             EmitFireAbortEvent(typeBuilder, runtime);
             EmitAbortControllerMethods(typeBuilder, runtime);
+            // stream.addAbortSignal destroy-on-abort wiring (#1027) — needs the AbortSignal
+            // helpers above + the $StreamAbortCallback closure emitted in the stream block.
+            if (_features.UsesNodeStreams)
+                EmitStreamAddAbortSignalMethod(typeBuilder, runtime);
         }
         // String/Number/Boolean populate shells already defined above
         // (before cctor) so the cctor can call them eagerly.

--- a/Compilation/RuntimeEmitter.StreamAddAbortSignal.cs
+++ b/Compilation/RuntimeEmitter.StreamAddAbortSignal.cs
@@ -1,0 +1,156 @@
+using System.Reflection;
+using System.Reflection.Emit;
+
+namespace SharpTS.Compilation;
+
+/// <summary>
+/// Emits the real <c>stream.addAbortSignal(signal, stream)</c> for standalone output (#1027):
+/// destroys the stream with an <c>AbortError</c> when the signal fires (or immediately if the
+/// signal is already aborted). Uses the #985 compiled-AbortSignal path (the signal's
+/// <c>_listeners</c> slot via <c>AbortSignalAddEventListener</c>), so output stays standalone.
+/// </summary>
+public partial class RuntimeEmitter
+{
+    /// <summary>
+    /// Emits the <c>$StreamAbortCallback</c> closure class (field: the stream; method
+    /// <c>OnAbort()</c> destroys it with an AbortError). Wrapped in a $TSFunction and added as
+    /// the signal's abort listener. Emitted in the stream block (needs $Readable/$Writable
+    /// Destroy + $Error, all available by then).
+    /// </summary>
+    private void EmitStreamAbortCallbackClass(ModuleBuilder moduleBuilder, EmittedRuntime runtime)
+    {
+        var typeBuilder = moduleBuilder.DefineType(
+            "$StreamAbortCallback",
+            TypeAttributes.Public | TypeAttributes.BeforeFieldInit,
+            _types.Object);
+        runtime.StreamAbortCallbackType = typeBuilder;
+
+        var streamField = typeBuilder.DefineField("_stream", _types.Object, FieldAttributes.Private);
+
+        // ctor(object stream)
+        var ctor = typeBuilder.DefineConstructor(MethodAttributes.Public, CallingConventions.Standard, [_types.Object]);
+        runtime.StreamAbortCallbackCtor = ctor;
+        var cil = ctor.GetILGenerator();
+        cil.Emit(OpCodes.Ldarg_0);
+        cil.Emit(OpCodes.Call, _types.Object.GetConstructor(Type.EmptyTypes)!);
+        cil.Emit(OpCodes.Ldarg_0);
+        cil.Emit(OpCodes.Ldarg_1);
+        cil.Emit(OpCodes.Stfld, streamField);
+        cil.Emit(OpCodes.Ret);
+
+        // object OnAbort() — destroys _stream with an AbortError, returns null.
+        var onAbort = typeBuilder.DefineMethod("OnAbort", MethodAttributes.Public, _types.Object, Type.EmptyTypes);
+        runtime.StreamAbortCallbackOnAbort = onAbort;
+        var il = onAbort.GetILGenerator();
+        EmitDestroyStreamWithAbortError(il, runtime, gen =>
+        {
+            gen.Emit(OpCodes.Ldarg_0);
+            gen.Emit(OpCodes.Ldfld, streamField);
+        });
+        il.Emit(OpCodes.Ldnull);
+        il.Emit(OpCodes.Ret);
+
+        typeBuilder.CreateType();
+    }
+
+    /// <summary>
+    /// Emits <c>$Runtime.StreamAddAbortSignal(object signal, object stream)</c>. Must run after
+    /// EmitAbortControllerMethods (AbortSignalGetAborted / AbortSignalAddEventListener) and after
+    /// the $StreamAbortCallback class. Gated on UsesNodeStreams &amp;&amp; UsesAbortController.
+    /// </summary>
+    private void EmitStreamAddAbortSignalMethod(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    {
+        var method = typeBuilder.DefineMethod(
+            "StreamAddAbortSignal",
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.Object,
+            [_types.Object, _types.Object]);
+        runtime.StreamAddAbortSignal = method;
+
+        var il = method.GetILGenerator();
+        var retStream = il.DefineLabel();
+
+        // if (signal == null || stream == null) return stream;
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Brfalse, retStream);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Brfalse, retStream);
+
+        // Only handle a real signal (Dictionary-backed). Otherwise no-op.
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Isinst, _types.DictionaryStringObject);
+        il.Emit(OpCodes.Brfalse, retStream);
+
+        // if (AbortSignalGetAborted(signal)) { destroy now; } else { register listener; }
+        var registerLabel = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Call, runtime.AbortSignalGetAborted);
+        il.Emit(OpCodes.Brfalse, registerLabel);
+
+        // already aborted → destroy the stream now
+        EmitDestroyStreamWithAbortError(il, runtime, gen => gen.Emit(OpCodes.Ldarg_1));
+        il.Emit(OpCodes.Br, retStream);
+
+        // register: AbortSignalAddEventListener(signal, "abort", new $TSFunction(new $StreamAbortCallback(stream), OnAbort));
+        il.MarkLabel(registerLabel);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldstr, "abort");
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Newobj, runtime.StreamAbortCallbackCtor);
+        EmitInstanceMethodInfoLiteral(il, runtime.StreamAbortCallbackOnAbort, runtime.StreamAbortCallbackType);
+        il.Emit(OpCodes.Newobj, runtime.TSFunctionCtor);
+        il.Emit(OpCodes.Call, runtime.AbortSignalAddEventListener);
+        il.Emit(OpCodes.Pop);
+
+        il.MarkLabel(retStream);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Ret);
+    }
+
+    /// <summary>
+    /// Emits: var err = new $Error("The operation was aborted"); err.Name = "AbortError";
+    /// var s = &lt;loadStream&gt;; if (s is $Readable) ((Readable)s).Destroy(err); else if (s is $Writable) ((Writable)s).Destroy(err);
+    /// Leaves the stack unchanged.
+    /// </summary>
+    private void EmitDestroyStreamWithAbortError(ILGenerator il, EmittedRuntime runtime, Action<ILGenerator> loadStream)
+    {
+        var errLocal = il.DeclareLocal(_types.Object);
+        var sLocal = il.DeclareLocal(_types.Object);
+
+        // err = new $Error("The operation was aborted"); err.Name = "AbortError";
+        il.Emit(OpCodes.Ldstr, "The operation was aborted");
+        il.Emit(OpCodes.Newobj, runtime.TSErrorCtorMessage);
+        il.Emit(OpCodes.Dup);
+        il.Emit(OpCodes.Ldstr, "AbortError");
+        il.Emit(OpCodes.Callvirt, runtime.TSErrorNameSetter);
+        il.Emit(OpCodes.Stloc, errLocal);
+
+        loadStream(il);
+        il.Emit(OpCodes.Stloc, sLocal);
+
+        var notReadable = il.DefineLabel();
+        var done = il.DefineLabel();
+
+        il.Emit(OpCodes.Ldloc, sLocal);
+        il.Emit(OpCodes.Isinst, runtime.TSReadableType);
+        il.Emit(OpCodes.Brfalse, notReadable);
+        il.Emit(OpCodes.Ldloc, sLocal);
+        il.Emit(OpCodes.Castclass, runtime.TSReadableType);
+        il.Emit(OpCodes.Ldloc, errLocal);
+        il.Emit(OpCodes.Callvirt, runtime.TSReadableDestroy);
+        il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Br, done);
+
+        il.MarkLabel(notReadable);
+        il.Emit(OpCodes.Ldloc, sLocal);
+        il.Emit(OpCodes.Isinst, runtime.TSWritableType);
+        il.Emit(OpCodes.Brfalse, done);
+        il.Emit(OpCodes.Ldloc, sLocal);
+        il.Emit(OpCodes.Castclass, runtime.TSWritableType);
+        il.Emit(OpCodes.Ldloc, errLocal);
+        il.Emit(OpCodes.Callvirt, runtime.TSWritableDestroy);
+        il.Emit(OpCodes.Pop);
+
+        il.MarkLabel(done);
+    }
+}

--- a/Compilation/RuntimeEmitter.StreamCompose.cs
+++ b/Compilation/RuntimeEmitter.StreamCompose.cs
@@ -359,6 +359,71 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Newobj, runtime.TSFunctionCtor);
     }
 
+    /// <summary>
+    /// Emits the module-level default-highWaterMark state + accessors (#1030):
+    /// static int fields (init 16384 byte / 16 object via .cctor) and
+    /// GetDefaultHwm(objectMode)→double / SetDefaultHwm(objectMode, value)→null.
+    /// </summary>
+    private void EmitStreamDefaultHwm(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    {
+        var byteField = typeBuilder.DefineField("_defaultHwmByte", _types.Int32, FieldAttributes.Private | FieldAttributes.Static);
+        var objField = typeBuilder.DefineField("_defaultHwmObject", _types.Int32, FieldAttributes.Private | FieldAttributes.Static);
+
+        // .cctor: _defaultHwmByte = 16384; _defaultHwmObject = 16;
+        var cctor = typeBuilder.DefineTypeInitializer();
+        var cil = cctor.GetILGenerator();
+        cil.Emit(OpCodes.Ldc_I4, 16384);
+        cil.Emit(OpCodes.Stsfld, byteField);
+        cil.Emit(OpCodes.Ldc_I4, 16);
+        cil.Emit(OpCodes.Stsfld, objField);
+        cil.Emit(OpCodes.Ret);
+
+        // public static object GetDefaultHwm(object objectMode)
+        var get = typeBuilder.DefineMethod("GetDefaultHwm", MethodAttributes.Public | MethodAttributes.Static, _types.Object, [_types.Object]);
+        runtime.StreamGetDefaultHighWaterMark = get;
+        {
+            var il = get.GetILGenerator();
+            var byteLabel = il.DefineLabel();
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Call, runtime.IsTruthy);
+            il.Emit(OpCodes.Brfalse, byteLabel);
+            il.Emit(OpCodes.Ldsfld, objField);
+            il.Emit(OpCodes.Conv_R8);
+            il.Emit(OpCodes.Box, _types.Double);
+            il.Emit(OpCodes.Ret);
+            il.MarkLabel(byteLabel);
+            il.Emit(OpCodes.Ldsfld, byteField);
+            il.Emit(OpCodes.Conv_R8);
+            il.Emit(OpCodes.Box, _types.Double);
+            il.Emit(OpCodes.Ret);
+        }
+
+        // public static object SetDefaultHwm(object objectMode, object value)
+        var set = typeBuilder.DefineMethod("SetDefaultHwm", MethodAttributes.Public | MethodAttributes.Static, _types.Object, [_types.Object, _types.Object]);
+        runtime.StreamSetDefaultHighWaterMark = set;
+        {
+            var il = set.GetILGenerator();
+            var byteLabel = il.DefineLabel();
+            var done = il.DefineLabel();
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Call, runtime.IsTruthy);
+            il.Emit(OpCodes.Brfalse, byteLabel);
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Call, runtime.ToNumber);
+            il.Emit(OpCodes.Conv_I4);
+            il.Emit(OpCodes.Stsfld, objField);
+            il.Emit(OpCodes.Br, done);
+            il.MarkLabel(byteLabel);
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Call, runtime.ToNumber);
+            il.Emit(OpCodes.Conv_I4);
+            il.Emit(OpCodes.Stsfld, byteField);
+            il.MarkLabel(done);
+            il.Emit(OpCodes.Ldnull);
+            il.Emit(OpCodes.Ret);
+        }
+    }
+
     private void EmitOnListener(ILGenerator il, EmittedRuntime runtime, Action loadEmitter, string eventName, LocalBuilder bridgeLocal, MethodBuilder bridgeMethod)
     {
         loadEmitter();

--- a/Compilation/RuntimeEmitter.StreamCompose.cs
+++ b/Compilation/RuntimeEmitter.StreamCompose.cs
@@ -1,0 +1,371 @@
+using System.Reflection;
+using System.Reflection.Emit;
+
+namespace SharpTS.Compilation;
+
+/// <summary>
+/// Emits compiled <c>stream.compose(...streams)</c> and <c>Duplex.from(source)</c> (#1028),
+/// mirroring the interpreter (<see cref="SharpTS.Runtime.Types.SharpTSDuplexConstructor"/> /
+/// <c>StreamModuleInterpreter.Compose</c>). All BCL-only / emitted-runtime — standalone preserved.
+/// </summary>
+public partial class RuntimeEmitter
+{
+    /// <summary>
+    /// public static object DuplexFrom(object[] args) — like ReadableFrom but yields a $Duplex
+    /// whose readable side carries the iterable's items.
+    /// </summary>
+    private void EmitStreamDuplexFrom(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    {
+        var method = typeBuilder.DefineMethod(
+            "DuplexFrom",
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.Object,
+            [_types.MakeArrayType(_types.Object)]);
+        runtime.StreamDuplexFrom = method;
+
+        var il = method.GetILGenerator();
+        var streamLocal = il.DeclareLocal(runtime.TSDuplexType);
+        il.Emit(OpCodes.Newobj, runtime.TSDuplexCtor);
+        il.Emit(OpCodes.Stloc, streamLocal);
+
+        // SetObjectMode(true) — Duplex inherits TSReadableSetObjectMode.
+        il.Emit(OpCodes.Ldloc, streamLocal);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Call, runtime.TSReadableSetObjectMode);
+
+        var iterableLocal = il.DeclareLocal(_types.Object);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Ldelem_Ref);
+        il.Emit(OpCodes.Stloc, iterableLocal);
+
+        var notListLabel = il.DefineLabel();
+        var doneLabel = il.DefineLabel();
+
+        il.Emit(OpCodes.Ldloc, iterableLocal);
+        il.Emit(OpCodes.Isinst, _types.ListOfObject);
+        il.Emit(OpCodes.Brfalse, notListLabel);
+
+        var listLocal = il.DeclareLocal(_types.ListOfObject);
+        il.Emit(OpCodes.Ldloc, iterableLocal);
+        il.Emit(OpCodes.Castclass, _types.ListOfObject);
+        il.Emit(OpCodes.Stloc, listLocal);
+
+        var countLocal = il.DeclareLocal(_types.Int32);
+        var idxLocal = il.DeclareLocal(_types.Int32);
+        il.Emit(OpCodes.Ldloc, listLocal);
+        il.Emit(OpCodes.Callvirt, _types.ListOfObject.GetProperty("Count")!.GetGetMethod()!);
+        il.Emit(OpCodes.Stloc, countLocal);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Stloc, idxLocal);
+
+        var pushLoop = il.DefineLabel();
+        var pushEnd = il.DefineLabel();
+        il.MarkLabel(pushLoop);
+        il.Emit(OpCodes.Ldloc, idxLocal);
+        il.Emit(OpCodes.Ldloc, countLocal);
+        il.Emit(OpCodes.Bge, pushEnd);
+        il.Emit(OpCodes.Ldloc, streamLocal);
+        il.Emit(OpCodes.Ldloc, listLocal);
+        il.Emit(OpCodes.Ldloc, idxLocal);
+        il.Emit(OpCodes.Callvirt, _types.ListOfObject.GetMethod("get_Item")!);
+        il.Emit(OpCodes.Callvirt, runtime.TSReadablePush);
+        il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Ldloc, idxLocal);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Stloc, idxLocal);
+        il.Emit(OpCodes.Br, pushLoop);
+        il.MarkLabel(pushEnd);
+        il.Emit(OpCodes.Br, doneLabel);
+
+        il.MarkLabel(notListLabel);
+        il.MarkLabel(doneLabel);
+
+        // Push null for EOF.
+        il.Emit(OpCodes.Ldloc, streamLocal);
+        il.Emit(OpCodes.Ldnull);
+        il.Emit(OpCodes.Callvirt, runtime.TSReadablePush);
+        il.Emit(OpCodes.Pop);
+
+        il.Emit(OpCodes.Ldloc, streamLocal);
+        il.Emit(OpCodes.Ret);
+    }
+
+    /// <summary>
+    /// Emits the <c>$StreamComposeBridge</c> closure class (fields: first stream, composed Duplex;
+    /// methods ForwardWrite / PushData / PushEnd / EndFirst). Each method is wrapped in a $TSFunction
+    /// by <see cref="EmitStreamComposeMethod"/>.
+    /// </summary>
+    private void EmitStreamComposeBridgeClass(ModuleBuilder moduleBuilder, EmittedRuntime runtime)
+    {
+        var typeBuilder = moduleBuilder.DefineType(
+            "$StreamComposeBridge",
+            TypeAttributes.Public | TypeAttributes.Sealed | TypeAttributes.BeforeFieldInit,
+            _types.Object);
+        runtime.StreamComposeBridgeType = typeBuilder;
+
+        var firstField = typeBuilder.DefineField("_first", _types.Object, FieldAttributes.Private);
+        var duplexField = typeBuilder.DefineField("_duplex", _types.Object, FieldAttributes.Private);
+
+        // ctor(object first, object duplex)
+        var ctor = typeBuilder.DefineConstructor(MethodAttributes.Public, CallingConventions.Standard, [_types.Object, _types.Object]);
+        runtime.StreamComposeBridgeCtor = ctor;
+        var cil = ctor.GetILGenerator();
+        cil.Emit(OpCodes.Ldarg_0);
+        cil.Emit(OpCodes.Call, _types.Object.GetConstructor(Type.EmptyTypes)!);
+        cil.Emit(OpCodes.Ldarg_0); cil.Emit(OpCodes.Ldarg_1); cil.Emit(OpCodes.Stfld, firstField);
+        cil.Emit(OpCodes.Ldarg_0); cil.Emit(OpCodes.Ldarg_2); cil.Emit(OpCodes.Stfld, duplexField);
+        cil.Emit(OpCodes.Ret);
+
+        // object ForwardWrite(object[] args): chunk = args[0]; first.Write(chunk, null, null);
+        runtime.StreamComposeBridgeForwardWrite = typeBuilder.DefineMethod("ForwardWrite", MethodAttributes.Public, _types.Object, [_types.ObjectArray]);
+        {
+            var il = runtime.StreamComposeBridgeForwardWrite.GetILGenerator();
+            EmitWriteToStream(il, runtime,
+                loadStream: g => { g.Emit(OpCodes.Ldarg_0); g.Emit(OpCodes.Ldfld, firstField); },
+                loadChunk: g => { g.Emit(OpCodes.Ldarg_1); g.Emit(OpCodes.Ldc_I4_0); g.Emit(OpCodes.Ldelem_Ref); });
+            il.Emit(OpCodes.Ldnull);
+            il.Emit(OpCodes.Ret);
+        }
+
+        // object PushData(object[] args): duplex.Push(args[0]);
+        runtime.StreamComposeBridgePushData = typeBuilder.DefineMethod("PushData", MethodAttributes.Public, _types.Object, [_types.ObjectArray]);
+        {
+            var il = runtime.StreamComposeBridgePushData.GetILGenerator();
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, duplexField);
+            il.Emit(OpCodes.Castclass, runtime.TSReadableType);
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Ldc_I4_0);
+            il.Emit(OpCodes.Ldelem_Ref);
+            il.Emit(OpCodes.Callvirt, runtime.TSReadablePush);
+            il.Emit(OpCodes.Pop);
+            il.Emit(OpCodes.Ldnull);
+            il.Emit(OpCodes.Ret);
+        }
+
+        // object PushEnd(object[] args): duplex.Push(null);
+        runtime.StreamComposeBridgePushEnd = typeBuilder.DefineMethod("PushEnd", MethodAttributes.Public, _types.Object, [_types.ObjectArray]);
+        {
+            var il = runtime.StreamComposeBridgePushEnd.GetILGenerator();
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, duplexField);
+            il.Emit(OpCodes.Castclass, runtime.TSReadableType);
+            il.Emit(OpCodes.Ldnull);
+            il.Emit(OpCodes.Callvirt, runtime.TSReadablePush);
+            il.Emit(OpCodes.Pop);
+            il.Emit(OpCodes.Ldnull);
+            il.Emit(OpCodes.Ret);
+        }
+
+        // object EndFirst(object[] args): first.End(null, null, null);
+        runtime.StreamComposeBridgeEndFirst = typeBuilder.DefineMethod("EndFirst", MethodAttributes.Public, _types.Object, [_types.ObjectArray]);
+        {
+            var il = runtime.StreamComposeBridgeEndFirst.GetILGenerator();
+            EmitEndStream(il, runtime, g => { g.Emit(OpCodes.Ldarg_0); g.Emit(OpCodes.Ldfld, firstField); });
+            il.Emit(OpCodes.Ldnull);
+            il.Emit(OpCodes.Ret);
+        }
+
+        typeBuilder.CreateType();
+    }
+
+    /// <summary>Emits: if (s is $Duplex) ((Duplex)s).Write(chunk,null,null); else if (s is $Writable) ((Writable)s).Write(chunk,null,null);</summary>
+    private void EmitWriteToStream(ILGenerator il, EmittedRuntime runtime, Action<ILGenerator> loadStream, Action<ILGenerator> loadChunk)
+    {
+        var sLocal = il.DeclareLocal(_types.Object);
+        loadStream(il);
+        il.Emit(OpCodes.Stloc, sLocal);
+
+        var notDuplex = il.DefineLabel();
+        var done = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, sLocal);
+        il.Emit(OpCodes.Isinst, runtime.TSDuplexType);
+        il.Emit(OpCodes.Brfalse, notDuplex);
+        il.Emit(OpCodes.Ldloc, sLocal);
+        il.Emit(OpCodes.Castclass, runtime.TSDuplexType);
+        loadChunk(il);
+        il.Emit(OpCodes.Ldnull);
+        il.Emit(OpCodes.Ldnull);
+        il.Emit(OpCodes.Callvirt, runtime.TSDuplexWrite);
+        il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Br, done);
+
+        il.MarkLabel(notDuplex);
+        il.Emit(OpCodes.Ldloc, sLocal);
+        il.Emit(OpCodes.Isinst, runtime.TSWritableType);
+        il.Emit(OpCodes.Brfalse, done);
+        il.Emit(OpCodes.Ldloc, sLocal);
+        il.Emit(OpCodes.Castclass, runtime.TSWritableType);
+        loadChunk(il);
+        il.Emit(OpCodes.Ldnull);
+        il.Emit(OpCodes.Ldnull);
+        il.Emit(OpCodes.Callvirt, runtime.TSWritableWrite);
+        il.Emit(OpCodes.Pop);
+
+        il.MarkLabel(done);
+    }
+
+    /// <summary>Emits: if (s is $Duplex) ((Duplex)s).End(null,null,null); else if (s is $Writable) ((Writable)s).End(null,null,null);</summary>
+    private void EmitEndStream(ILGenerator il, EmittedRuntime runtime, Action<ILGenerator> loadStream)
+    {
+        var sLocal = il.DeclareLocal(_types.Object);
+        loadStream(il);
+        il.Emit(OpCodes.Stloc, sLocal);
+
+        var notDuplex = il.DefineLabel();
+        var done = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, sLocal);
+        il.Emit(OpCodes.Isinst, runtime.TSDuplexType);
+        il.Emit(OpCodes.Brfalse, notDuplex);
+        il.Emit(OpCodes.Ldloc, sLocal);
+        il.Emit(OpCodes.Castclass, runtime.TSDuplexType);
+        il.Emit(OpCodes.Ldnull); il.Emit(OpCodes.Ldnull); il.Emit(OpCodes.Ldnull);
+        il.Emit(OpCodes.Callvirt, runtime.TSDuplexEnd);
+        il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Br, done);
+
+        il.MarkLabel(notDuplex);
+        il.Emit(OpCodes.Ldloc, sLocal);
+        il.Emit(OpCodes.Isinst, runtime.TSWritableType);
+        il.Emit(OpCodes.Brfalse, done);
+        il.Emit(OpCodes.Ldloc, sLocal);
+        il.Emit(OpCodes.Castclass, runtime.TSWritableType);
+        il.Emit(OpCodes.Ldnull); il.Emit(OpCodes.Ldnull); il.Emit(OpCodes.Ldnull);
+        il.Emit(OpCodes.Callvirt, runtime.TSWritableEnd);
+        il.Emit(OpCodes.Pop);
+
+        il.MarkLabel(done);
+    }
+
+    /// <summary>
+    /// public static object Compose(object[] streams) — pipes the streams together and returns a
+    /// $Duplex whose writable side feeds the first and readable side is fed by the last.
+    /// </summary>
+    private void EmitStreamComposeMethod(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    {
+        var method = typeBuilder.DefineMethod(
+            "Compose",
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.Object,
+            [_types.MakeArrayType(_types.Object)]);
+        runtime.StreamCompose = method;
+
+        var il = method.GetILGenerator();
+        var nLocal = il.DeclareLocal(_types.Int32);
+        var iLocal = il.DeclareLocal(_types.Int32);
+        var dLocal = il.DeclareLocal(runtime.TSDuplexType);
+        var bridgeLocal = il.DeclareLocal(runtime.StreamComposeBridgeType);
+        var lastLocal = il.DeclareLocal(_types.Object);
+
+        var retNull = il.DefineLabel();
+
+        // n = streams.Length; if (n == 0) return null;
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldlen);
+        il.Emit(OpCodes.Conv_I4);
+        il.Emit(OpCodes.Stloc, nLocal);
+        il.Emit(OpCodes.Ldloc, nLocal);
+        il.Emit(OpCodes.Brfalse, retNull);
+
+        // pipe consecutive: for (i=0; i<n-1; i++) if (streams[i] is $Readable) ((Readable)streams[i]).Pipe(streams[i+1], null);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Stloc, iLocal);
+        var pipeLoop = il.DefineLabel();
+        var pipeEnd = il.DefineLabel();
+        il.MarkLabel(pipeLoop);
+        il.Emit(OpCodes.Ldloc, iLocal);
+        il.Emit(OpCodes.Ldloc, nLocal);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Sub);
+        il.Emit(OpCodes.Bge, pipeEnd);
+
+        var notReadable = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldloc, iLocal);
+        il.Emit(OpCodes.Ldelem_Ref);
+        il.Emit(OpCodes.Isinst, runtime.TSReadableType);
+        il.Emit(OpCodes.Brfalse, notReadable);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldloc, iLocal);
+        il.Emit(OpCodes.Ldelem_Ref);
+        il.Emit(OpCodes.Castclass, runtime.TSReadableType);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldloc, iLocal);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Ldelem_Ref);
+        il.Emit(OpCodes.Ldnull);
+        il.Emit(OpCodes.Callvirt, runtime.TSReadablePipe);
+        il.Emit(OpCodes.Pop);
+        il.MarkLabel(notReadable);
+
+        il.Emit(OpCodes.Ldloc, iLocal);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Stloc, iLocal);
+        il.Emit(OpCodes.Br, pipeLoop);
+        il.MarkLabel(pipeEnd);
+
+        // last = streams[n-1];
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldloc, nLocal);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Sub);
+        il.Emit(OpCodes.Ldelem_Ref);
+        il.Emit(OpCodes.Stloc, lastLocal);
+
+        // d = new $Duplex(); d.SetObjectMode(true);
+        il.Emit(OpCodes.Newobj, runtime.TSDuplexCtor);
+        il.Emit(OpCodes.Stloc, dLocal);
+        il.Emit(OpCodes.Ldloc, dLocal);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Call, runtime.TSReadableSetObjectMode);
+
+        // bridge = new $StreamComposeBridge(streams[0], d);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Ldelem_Ref);
+        il.Emit(OpCodes.Ldloc, dLocal);
+        il.Emit(OpCodes.Newobj, runtime.StreamComposeBridgeCtor);
+        il.Emit(OpCodes.Stloc, bridgeLocal);
+
+        // d.SetWriteCallback(new $TSFunction(bridge, ForwardWrite));
+        il.Emit(OpCodes.Ldloc, dLocal);
+        EmitBridgeTSFunction(il, runtime, bridgeLocal, runtime.StreamComposeBridgeForwardWrite);
+        il.Emit(OpCodes.Callvirt, runtime.TSDuplexSetWriteCallback!);
+
+        // ((EventEmitter)last).On("data", new $TSFunction(bridge, PushData));
+        EmitOnListener(il, runtime, () => { il.Emit(OpCodes.Ldloc, lastLocal); }, "data", bridgeLocal, runtime.StreamComposeBridgePushData);
+        // ((EventEmitter)last).On("end", new $TSFunction(bridge, PushEnd));
+        EmitOnListener(il, runtime, () => { il.Emit(OpCodes.Ldloc, lastLocal); }, "end", bridgeLocal, runtime.StreamComposeBridgePushEnd);
+        // ((EventEmitter)d).On("finish", new $TSFunction(bridge, EndFirst));
+        EmitOnListener(il, runtime, () => { il.Emit(OpCodes.Ldloc, dLocal); }, "finish", bridgeLocal, runtime.StreamComposeBridgeEndFirst);
+
+        // return d;
+        il.Emit(OpCodes.Ldloc, dLocal);
+        il.Emit(OpCodes.Ret);
+
+        il.MarkLabel(retNull);
+        il.Emit(OpCodes.Ldnull);
+        il.Emit(OpCodes.Ret);
+    }
+
+    private void EmitBridgeTSFunction(ILGenerator il, EmittedRuntime runtime, LocalBuilder bridgeLocal, MethodBuilder bridgeMethod)
+    {
+        il.Emit(OpCodes.Ldloc, bridgeLocal);
+        EmitInstanceMethodInfoLiteral(il, bridgeMethod, runtime.StreamComposeBridgeType);
+        il.Emit(OpCodes.Newobj, runtime.TSFunctionCtor);
+    }
+
+    private void EmitOnListener(ILGenerator il, EmittedRuntime runtime, Action loadEmitter, string eventName, LocalBuilder bridgeLocal, MethodBuilder bridgeMethod)
+    {
+        loadEmitter();
+        il.Emit(OpCodes.Castclass, runtime.TSEventEmitterType);
+        il.Emit(OpCodes.Ldstr, eventName);
+        EmitBridgeTSFunction(il, runtime, bridgeLocal, bridgeMethod);
+        il.Emit(OpCodes.Callvirt, runtime.TSEventEmitterOn);
+        il.Emit(OpCodes.Pop);
+    }
+}

--- a/Compilation/RuntimeEmitter.TSReadable.cs
+++ b/Compilation/RuntimeEmitter.TSReadable.cs
@@ -117,6 +117,9 @@ public partial class RuntimeEmitter
         EmitTSReadableMap(typeBuilder, runtime);
         EmitTSReadableFilter(typeBuilder, runtime);
 
+        // Async iterator helpers (#1025) — need Push/SetObjectMode (Phase 2a) + $Array/$Promise.
+        EmitTSReadableIterHelpers(typeBuilder, runtime, typeof(Queue<object?>));
+
         // Finalize the type
         typeBuilder.CreateType();
     }

--- a/Compilation/RuntimeEmitter.TSReadable.cs
+++ b/Compilation/RuntimeEmitter.TSReadable.cs
@@ -21,6 +21,10 @@ public partial class RuntimeEmitter
     private FieldBuilder _tsReadableObjectModeField = null!;
     private FieldBuilder _tsReadableHighWaterMarkField = null!;
     private FieldBuilder _tsReadableBufferSizeField = null!;
+    // Async iteration support (#1024)
+    private FieldBuilder _tsReadableErroredField = null!;
+    private FieldBuilder _tsReadableErrorField = null!;
+    private FieldBuilder _tsReadableIterWaiterField = null!;
 
     /// <summary>
     /// Phase 1: Define the $Readable type, fields, and constructor.
@@ -51,6 +55,10 @@ public partial class RuntimeEmitter
         _tsReadableObjectModeField = typeBuilder.DefineField("_objectMode", _types.Boolean, FieldAttributes.Family);
         _tsReadableHighWaterMarkField = typeBuilder.DefineField("_highWaterMark", _types.Int32, FieldAttributes.Family);
         _tsReadableBufferSizeField = typeBuilder.DefineField("_bufferSize", _types.Int32, FieldAttributes.Family);
+        // Async iteration support (#1024): error state + parked async-iterator pull.
+        _tsReadableErroredField = typeBuilder.DefineField("_errored", _types.Boolean, FieldAttributes.Family);
+        _tsReadableErrorField = typeBuilder.DefineField("_error", _types.Object, FieldAttributes.Family);
+        _tsReadableIterWaiterField = typeBuilder.DefineField("_iterWaiter", _types.TaskCompletionSourceOfObject, FieldAttributes.Family);
 
         // Constructor
         EmitTSReadableCtor(typeBuilder, runtime, queueOfObject);
@@ -69,6 +77,11 @@ public partial class RuntimeEmitter
         EmitTSReadableForEach(typeBuilder, runtime, queueOfObject);
         EmitTSReadableSetObjectMode(typeBuilder, runtime);
         EmitTSReadableSetHighWaterMark(typeBuilder, runtime);
+
+        // [Symbol.asyncIterator] surface (#1024). Emitted in Phase 1 so MakeIterResult is
+        // available to Push (Phase 2a), which settles a parked pull. None of these depend
+        // on Duplex/Transform.
+        EmitTSReadableAsyncIteratorMethods(typeBuilder, runtime, queueOfObject);
 
         // Property getters
         EmitTSReadablePropertyGetters(typeBuilder, runtime, queueOfObject);
@@ -444,6 +457,9 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldc_I4_0);
         il.Emit(OpCodes.Stfld, _tsReadableReadableField);
 
+        // Settle a parked `for await` pull as done (#1024).
+        EmitSettleIterWaiterDone(il, runtime);
+
         // Emit 'end' event: this.Emit("end", [])
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ldstr, "end");
@@ -520,6 +536,10 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Br, returnFalseLabel);
 
         il.MarkLabel(notNullLabel);
+
+        // Hand the chunk directly to a parked `for await` pull, if any (#1024).
+        // On delivery this returns true from Push so the chunk is not also buffered/emitted.
+        EmitDeliverChunkToIterWaiterAndReturn(il, runtime);
 
         // Check if flowing mode: if (_flowing == 1) emit 'data' directly
         var notFlowingLabel = il.DefineLabel();
@@ -869,9 +889,21 @@ public partial class RuntimeEmitter
         var clearMethod = queueType.GetMethod("Clear")!;
         il.Emit(OpCodes.Callvirt, clearMethod);
 
-        // if (error != null) emit 'error'
+        // if (error != null) { _errored = true; _error = error; fault any parked pull; emit 'error'; }
         il.Emit(OpCodes.Ldarg_1);
         il.Emit(OpCodes.Brfalse, noErrorLabel);
+
+        // _errored = true; _error = error;  (#1024)
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Stfld, _tsReadableErroredField);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Stfld, _tsReadableErrorField);
+
+        // A pending `for await` pull rejects with the destroy error.
+        EmitFaultIterWaiter(il, runtime);
+
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ldstr, "error");
         il.Emit(OpCodes.Ldc_I4_1);

--- a/Compilation/RuntimeEmitter.TSReadable.cs
+++ b/Compilation/RuntimeEmitter.TSReadable.cs
@@ -1231,6 +1231,21 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ret);
         readableLengthProp.SetGetMethod(getReadableLength);
 
+        // errored property (#1030): backs stream.isErrored
+        var erroredProp = typeBuilder.DefineProperty("Errored", PropertyAttributes.None, _types.Boolean, null);
+        var getErrored = typeBuilder.DefineMethod(
+            "get_Errored",
+            MethodAttributes.Public | MethodAttributes.SpecialName,
+            _types.Boolean,
+            Type.EmptyTypes
+        );
+        runtime.TSReadableErroredGetter = getErrored;
+        il = getErrored.GetILGenerator();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, _tsReadableErroredField);
+        il.Emit(OpCodes.Ret);
+        erroredProp.SetGetMethod(getErrored);
+
         // destroyed property
         var destroyedProp = typeBuilder.DefineProperty("Destroyed", PropertyAttributes.None, _types.Boolean, null);
         var getDestroyed = typeBuilder.DefineMethod(

--- a/Compilation/RuntimeEmitter.TSReadableAsyncIter.cs
+++ b/Compilation/RuntimeEmitter.TSReadableAsyncIter.cs
@@ -1,0 +1,366 @@
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Threading.Tasks;
+
+namespace SharpTS.Compilation;
+
+/// <summary>
+/// Emits the <c>[Symbol.asyncIterator]</c> surface for the standalone <c>$Readable</c> class
+/// (#1024), so <c>for await (const chunk of readable)</c> works in compiled output.
+/// Mirrors <see cref="SharpTS.Runtime.Types.SharpTSReadable"/>'s interpreter iterator:
+/// <list type="bullet">
+///   <item><c>GetAsyncIterator()</c> returns a <c>{ next, return }</c> iterator object.</item>
+///   <item><c>IterNext()</c> yields one buffered chunk, settles done on end, rejects on error,
+///     or parks a <see cref="TaskCompletionSource{TResult}"/> for a slow producer.</item>
+///   <item><c>IterReturn()</c> destroys the stream for an early <c>break</c>/return/throw.</item>
+/// </list>
+/// All BCL-only — no SharpTS.dll dependency, so standalone output is preserved.
+/// </summary>
+public partial class RuntimeEmitter
+{
+    private MethodBuilder _tsReadableMakeIterResult = null!;
+    private MethodBuilder _tsReadableIterNext = null!;
+    private MethodBuilder _tsReadableIterReturn = null!;
+
+    /// <summary>
+    /// Phase 2b: emit the async-iterator methods on <c>$Readable</c>. Must run before
+    /// <c>CreateType()</c>. Depends only on BCL types plus the already-emitted
+    /// <c>$TSFunction</c> / <c>$PromiseRejectedException</c> ctors — never on a
+    /// $Runtime method (those are emitted later, after the stream classes).
+    /// </summary>
+    private void EmitTSReadableAsyncIteratorMethods(TypeBuilder typeBuilder, EmittedRuntime runtime, Type queueType)
+    {
+        EmitTSReadableMakeIterResult(typeBuilder, runtime);
+        EmitTSReadableIterNext(typeBuilder, runtime, queueType);
+        EmitTSReadableIterReturn(typeBuilder, runtime, queueType);
+        EmitTSReadableGetAsyncIterator(typeBuilder, runtime);
+    }
+
+    private static MethodInfo TaskFromResultObject(TypeProvider types)
+        => types.Task.GetMethod("FromResult")!.MakeGenericMethod(types.Object);
+
+    /// <summary>
+    /// private Dictionary&lt;string,object?&gt; MakeIterResult(object? value, bool done)
+    /// — builds the <c>{ value, done }</c> iterator-result record.
+    /// </summary>
+    private void EmitTSReadableMakeIterResult(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    {
+        var method = typeBuilder.DefineMethod(
+            "MakeIterResult",
+            MethodAttributes.Private,
+            _types.Object,
+            [_types.Object, _types.Boolean]);
+        _tsReadableMakeIterResult = method;
+
+        var il = method.GetILGenerator();
+        var dictSetItem = _types.GetMethod(_types.DictionaryStringObject, "set_Item", _types.String, _types.Object);
+        var dictLocal = il.DeclareLocal(_types.DictionaryStringObject);
+
+        il.Emit(OpCodes.Newobj, _types.GetDefaultConstructor(_types.DictionaryStringObject));
+        il.Emit(OpCodes.Stloc, dictLocal);
+
+        // dict["value"] = value;
+        il.Emit(OpCodes.Ldloc, dictLocal);
+        il.Emit(OpCodes.Ldstr, "value");
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Callvirt, dictSetItem);
+
+        // dict["done"] = (object)done;
+        il.Emit(OpCodes.Ldloc, dictLocal);
+        il.Emit(OpCodes.Ldstr, "done");
+        il.Emit(OpCodes.Ldarg_2);
+        il.Emit(OpCodes.Box, _types.Boolean);
+        il.Emit(OpCodes.Callvirt, dictSetItem);
+
+        il.Emit(OpCodes.Ldloc, dictLocal);
+        il.Emit(OpCodes.Ret);
+    }
+
+    /// <summary>
+    /// public object IterNext() — returns a Task&lt;object?&gt; resolving to { value, done }.
+    /// </summary>
+    private void EmitTSReadableIterNext(TypeBuilder typeBuilder, EmittedRuntime runtime, Type queueType)
+    {
+        var method = typeBuilder.DefineMethod(
+            "IterNext",
+            MethodAttributes.Public,
+            _types.Object,
+            Type.EmptyTypes);
+        _tsReadableIterNext = method;
+
+        var il = method.GetILGenerator();
+        var countGetter = queueType.GetProperty("Count")!.GetGetMethod()!;
+        var dequeue = queueType.GetMethod("Dequeue")!;
+        var fromResult = TaskFromResultObject(_types);
+        var tcsCtor = _types.TaskCompletionSourceOfObject.GetConstructor([typeof(TaskCreationOptions)])!;
+        var tcsTaskGetter = _types.TaskCompletionSourceOfObject.GetProperty("Task")!.GetGetMethod()!;
+        var trySetException = _types.TaskCompletionSourceOfObject.GetMethod("TrySetException", [_types.Exception])!;
+
+        var notBuffered = il.DefineLabel();
+        var notErrored = il.DefineLabel();
+        var notEnded = il.DefineLabel();
+        var endedReturnLabel = il.DefineLabel();
+
+        // if (_readBuffer.Count > 0) return Task.FromResult(MakeIterResult(_readBuffer.Dequeue(), false));
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, _tsReadableBufferField);
+        il.Emit(OpCodes.Callvirt, countGetter);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Ble, notBuffered);
+
+        il.Emit(OpCodes.Ldarg_0); // this (for MakeIterResult)
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, _tsReadableBufferField);
+        il.Emit(OpCodes.Callvirt, dequeue);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Call, _tsReadableMakeIterResult);
+        il.Emit(OpCodes.Call, fromResult);
+        il.Emit(OpCodes.Ret);
+
+        il.MarkLabel(notBuffered);
+        // if (_errored) { var tcs = new TCS(); tcs.TrySetException(new $PromiseRejectedException(_error)); return tcs.Task; }
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, _tsReadableErroredField);
+        il.Emit(OpCodes.Brfalse, notErrored);
+
+        var tcsErrLocal = il.DeclareLocal(_types.TaskCompletionSourceOfObject);
+        il.Emit(OpCodes.Ldc_I4_0); // TaskCreationOptions.None
+        il.Emit(OpCodes.Newobj, tcsCtor);
+        il.Emit(OpCodes.Stloc, tcsErrLocal);
+        il.Emit(OpCodes.Ldloc, tcsErrLocal);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, _tsReadableErrorField);
+        il.Emit(OpCodes.Newobj, runtime.TSPromiseRejectedExceptionCtor);
+        il.Emit(OpCodes.Callvirt, trySetException);
+        il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Ldloc, tcsErrLocal);
+        il.Emit(OpCodes.Callvirt, tcsTaskGetter);
+        il.Emit(OpCodes.Ret);
+
+        il.MarkLabel(notErrored);
+        // if (_ended || _destroyed) return Task.FromResult(MakeIterResult(null, true));
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, _tsReadableEndedField);
+        il.Emit(OpCodes.Brtrue, endedReturnLabel);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, _tsReadableDestroyedField);
+        il.Emit(OpCodes.Brfalse, notEnded);
+
+        il.MarkLabel(endedReturnLabel);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldnull);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Call, _tsReadableMakeIterResult);
+        il.Emit(OpCodes.Call, fromResult);
+        il.Emit(OpCodes.Ret);
+
+        il.MarkLabel(notEnded);
+        // _iterWaiter = new TCS(RunContinuationsAsynchronously); return _iterWaiter.Task;
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldc_I4, (int)TaskCreationOptions.RunContinuationsAsynchronously);
+        il.Emit(OpCodes.Newobj, tcsCtor);
+        il.Emit(OpCodes.Stfld, _tsReadableIterWaiterField);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, _tsReadableIterWaiterField);
+        il.Emit(OpCodes.Callvirt, tcsTaskGetter);
+        il.Emit(OpCodes.Ret);
+    }
+
+    /// <summary>
+    /// public object IterReturn() — destroys the stream, settles any parked pull, returns a
+    /// resolved Task with { value: undefined, done: true }.
+    /// </summary>
+    private void EmitTSReadableIterReturn(TypeBuilder typeBuilder, EmittedRuntime runtime, Type queueType)
+    {
+        var method = typeBuilder.DefineMethod(
+            "IterReturn",
+            MethodAttributes.Public,
+            _types.Object,
+            Type.EmptyTypes);
+        _tsReadableIterReturn = method;
+
+        var il = method.GetILGenerator();
+        var clear = queueType.GetMethod("Clear")!;
+        var listClear = _types.GetMethod(_types.ListOfObject, "Clear");
+        var fromResult = TaskFromResultObject(_types);
+
+        // if (!_destroyed) { _destroyed = true; _readable = false; _readBuffer.Clear(); _pipeDestinations.Clear(); }
+        var alreadyDestroyed = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, _tsReadableDestroyedField);
+        il.Emit(OpCodes.Brtrue, alreadyDestroyed);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Stfld, _tsReadableDestroyedField);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Stfld, _tsReadableReadableField);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, _tsReadableBufferField);
+        il.Emit(OpCodes.Callvirt, clear);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, _tsReadablePipeDestinationsField);
+        il.Emit(OpCodes.Callvirt, listClear);
+        il.MarkLabel(alreadyDestroyed);
+
+        // Settle a parked pull as done (best-effort).
+        EmitSettleIterWaiterDone(il, runtime);
+
+        // return Task.FromResult(MakeIterResult(null, true));
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldnull);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Call, _tsReadableMakeIterResult);
+        il.Emit(OpCodes.Call, fromResult);
+        il.Emit(OpCodes.Ret);
+    }
+
+    /// <summary>
+    /// public object GetAsyncIterator() — returns a { next, return } iterator object whose
+    /// methods bind back to this $Readable's IterNext / IterReturn.
+    /// </summary>
+    private void EmitTSReadableGetAsyncIterator(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    {
+        var method = typeBuilder.DefineMethod(
+            "GetAsyncIterator",
+            MethodAttributes.Public,
+            _types.Object,
+            Type.EmptyTypes);
+        runtime.TSReadableGetAsyncIterator = method;
+
+        var il = method.GetILGenerator();
+        var dictSetItem = _types.GetMethod(_types.DictionaryStringObject, "set_Item", _types.String, _types.Object);
+        var dictLocal = il.DeclareLocal(_types.DictionaryStringObject);
+
+        il.Emit(OpCodes.Newobj, _types.GetDefaultConstructor(_types.DictionaryStringObject));
+        il.Emit(OpCodes.Stloc, dictLocal);
+
+        // dict["next"] = new $TSFunction(this, IterNext);
+        il.Emit(OpCodes.Ldloc, dictLocal);
+        il.Emit(OpCodes.Ldstr, "next");
+        il.Emit(OpCodes.Ldarg_0);
+        EmitInstanceMethodInfoLiteral(il, _tsReadableIterNext, typeBuilder);
+        il.Emit(OpCodes.Newobj, runtime.TSFunctionCtor);
+        il.Emit(OpCodes.Callvirt, dictSetItem);
+
+        // dict["return"] = new $TSFunction(this, IterReturn);
+        il.Emit(OpCodes.Ldloc, dictLocal);
+        il.Emit(OpCodes.Ldstr, "return");
+        il.Emit(OpCodes.Ldarg_0);
+        EmitInstanceMethodInfoLiteral(il, _tsReadableIterReturn, typeBuilder);
+        il.Emit(OpCodes.Newobj, runtime.TSFunctionCtor);
+        il.Emit(OpCodes.Callvirt, dictSetItem);
+
+        il.Emit(OpCodes.Ldloc, dictLocal);
+        il.Emit(OpCodes.Ret);
+    }
+
+    /// <summary>
+    /// Emits the load of a MethodInfo literal for an intra-assembly MethodBuilder
+    /// (resolves at runtime via the 2-arg GetMethodFromHandle).
+    /// </summary>
+    private void EmitInstanceMethodInfoLiteral(ILGenerator il, MethodBuilder method, Type declaringType)
+    {
+        il.Emit(OpCodes.Ldtoken, method);
+        il.Emit(OpCodes.Ldtoken, declaringType);
+        il.Emit(OpCodes.Call, _types.MethodBase.GetMethod(
+            "GetMethodFromHandle", [_types.RuntimeMethodHandle, _types.RuntimeTypeHandle])!);
+        il.Emit(OpCodes.Castclass, _types.MethodInfo);
+    }
+
+    /// <summary>
+    /// Emits: if (_iterWaiter != null) { var w = _iterWaiter; _iterWaiter = null; w.TrySetResult(MakeIterResult(null, true)); }
+    /// Leaves the evaluation stack unchanged. Used by Push (EOF) / Destroy / IterReturn.
+    /// </summary>
+    private void EmitSettleIterWaiterDone(ILGenerator il, EmittedRuntime runtime)
+    {
+        var trySetResult = _types.TaskCompletionSourceOfObject.GetMethod("TrySetResult", [_types.Object])!;
+        var noWaiter = il.DefineLabel();
+        var wLocal = il.DeclareLocal(_types.TaskCompletionSourceOfObject);
+
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, _tsReadableIterWaiterField);
+        il.Emit(OpCodes.Stloc, wLocal);
+        il.Emit(OpCodes.Ldloc, wLocal);
+        il.Emit(OpCodes.Brfalse, noWaiter);
+
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldnull);
+        il.Emit(OpCodes.Stfld, _tsReadableIterWaiterField);
+
+        il.Emit(OpCodes.Ldloc, wLocal);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldnull);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Call, _tsReadableMakeIterResult);
+        il.Emit(OpCodes.Callvirt, trySetResult);
+        il.Emit(OpCodes.Pop);
+
+        il.MarkLabel(noWaiter);
+    }
+
+    /// <summary>
+    /// Emits: if (_iterWaiter != null) { var w = _iterWaiter; _iterWaiter = null; w.TrySetException(new $PromiseRejectedException(arg1)); }
+    /// Leaves the stack unchanged. Loads the error from arg1 (Destroy's error parameter).
+    /// </summary>
+    private void EmitFaultIterWaiter(ILGenerator il, EmittedRuntime runtime)
+    {
+        var trySetException = _types.TaskCompletionSourceOfObject.GetMethod("TrySetException", [_types.Exception])!;
+        var noWaiter = il.DefineLabel();
+        var wLocal = il.DeclareLocal(_types.TaskCompletionSourceOfObject);
+
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, _tsReadableIterWaiterField);
+        il.Emit(OpCodes.Stloc, wLocal);
+        il.Emit(OpCodes.Ldloc, wLocal);
+        il.Emit(OpCodes.Brfalse, noWaiter);
+
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldnull);
+        il.Emit(OpCodes.Stfld, _tsReadableIterWaiterField);
+
+        il.Emit(OpCodes.Ldloc, wLocal);
+        il.Emit(OpCodes.Ldarg_1); // error
+        il.Emit(OpCodes.Newobj, runtime.TSPromiseRejectedExceptionCtor);
+        il.Emit(OpCodes.Callvirt, trySetException);
+        il.Emit(OpCodes.Pop);
+
+        il.MarkLabel(noWaiter);
+    }
+
+    /// <summary>
+    /// Emits: if (_iterWaiter != null) { var w = _iterWaiter; _iterWaiter = null; w.TrySetResult(MakeIterResult(chunk, false)); return true; }
+    /// The chunk is loaded from arg1 (Push's chunk parameter). Used by Push's data path; on
+    /// delivery it returns <c>true</c> from Push so the chunk is not also buffered.
+    /// </summary>
+    private void EmitDeliverChunkToIterWaiterAndReturn(ILGenerator il, EmittedRuntime runtime)
+    {
+        var trySetResult = _types.TaskCompletionSourceOfObject.GetMethod("TrySetResult", [_types.Object])!;
+        var noWaiter = il.DefineLabel();
+        var wLocal = il.DeclareLocal(_types.TaskCompletionSourceOfObject);
+
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, _tsReadableIterWaiterField);
+        il.Emit(OpCodes.Stloc, wLocal);
+        il.Emit(OpCodes.Ldloc, wLocal);
+        il.Emit(OpCodes.Brfalse, noWaiter);
+
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldnull);
+        il.Emit(OpCodes.Stfld, _tsReadableIterWaiterField);
+
+        il.Emit(OpCodes.Ldloc, wLocal);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldarg_1); // chunk
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Call, _tsReadableMakeIterResult);
+        il.Emit(OpCodes.Callvirt, trySetResult);
+        il.Emit(OpCodes.Pop);
+
+        // return true; (chunk consumed by the iterator)
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Ret);
+
+        il.MarkLabel(noWaiter);
+    }
+}

--- a/Compilation/RuntimeEmitter.TSReadableHelpers.cs
+++ b/Compilation/RuntimeEmitter.TSReadableHelpers.cs
@@ -1,0 +1,541 @@
+using System.Reflection;
+using System.Reflection.Emit;
+
+namespace SharpTS.Compilation;
+
+/// <summary>
+/// Emits the async-iterator helpers on the standalone <c>$Readable</c> class (#1025):
+/// <c>reduce</c>/<c>some</c>/<c>every</c>/<c>find</c> (consuming → resolved $Promise) and
+/// <c>drop</c>/<c>take</c>/<c>flatMap</c>/<c>asIndexedPairs</c> (lazy → a new $Readable carrying
+/// the transformed chunks). Mirrors <see cref="SharpTS.Runtime.Types.SharpTSReadable"/>'s
+/// buffer-based interpreter helpers. All BCL-only / emitted-runtime — standalone preserved.
+///
+/// Emitted in Phase 2b (after Push/Pipe + SetObjectMode), so it can use TSReadablePush /
+/// TSReadableSetObjectMode / TSReadableCtor; the consuming helpers use TSPromiseResolve and
+/// IsTruthy; asIndexedPairs/flatMap use TSArrayCtor / TSArrayElementsGetter.
+/// </summary>
+public partial class RuntimeEmitter
+{
+    private MethodBuilder _tsReadableDrainToList = null!;
+
+    private void EmitTSReadableIterHelpers(TypeBuilder typeBuilder, EmittedRuntime runtime, Type queueType)
+    {
+        EmitTSReadableDrainToList(typeBuilder, runtime, queueType);
+        EmitTSReadableReduce(typeBuilder, runtime);
+        EmitTSReadablePredicate(typeBuilder, runtime, "Some");
+        EmitTSReadablePredicate(typeBuilder, runtime, "Every");
+        EmitTSReadablePredicate(typeBuilder, runtime, "Find");
+        EmitTSReadableDropTake(typeBuilder, runtime, "Drop");
+        EmitTSReadableDropTake(typeBuilder, runtime, "Take");
+        EmitTSReadableFlatMap(typeBuilder, runtime);
+        EmitTSReadableAsIndexedPairs(typeBuilder, runtime);
+    }
+
+    /// <summary>private List&lt;object&gt; DrainToList() — drains _readBuffer into a fresh list.</summary>
+    private void EmitTSReadableDrainToList(TypeBuilder typeBuilder, EmittedRuntime runtime, Type queueType)
+    {
+        var method = typeBuilder.DefineMethod("DrainToList", MethodAttributes.Private, _types.ListOfObject, Type.EmptyTypes);
+        _tsReadableDrainToList = method;
+
+        var il = method.GetILGenerator();
+        var countGetter = queueType.GetProperty("Count")!.GetGetMethod()!;
+        var dequeue = queueType.GetMethod("Dequeue")!;
+        var listAdd = _types.GetMethod(_types.ListOfObject, "Add", _types.Object);
+        var listLocal = il.DeclareLocal(_types.ListOfObject);
+        var loop = il.DefineLabel();
+        var done = il.DefineLabel();
+
+        il.Emit(OpCodes.Newobj, _types.GetDefaultConstructor(_types.ListOfObject));
+        il.Emit(OpCodes.Stloc, listLocal);
+
+        il.MarkLabel(loop);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, _tsReadableBufferField);
+        il.Emit(OpCodes.Callvirt, countGetter);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Ble, done);
+        il.Emit(OpCodes.Ldloc, listLocal);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, _tsReadableBufferField);
+        il.Emit(OpCodes.Callvirt, dequeue);
+        il.Emit(OpCodes.Callvirt, listAdd);
+        il.Emit(OpCodes.Br, loop);
+        il.MarkLabel(done);
+        il.Emit(OpCodes.Ldloc, listLocal);
+        il.Emit(OpCodes.Ret);
+    }
+
+    // Helpers shared across the methods below.
+    private MethodInfo ListCountGetter => _types.GetProperty(_types.ListOfObject, "Count").GetGetMethod()!;
+    private MethodInfo ListItemGetter => _types.GetMethod(_types.ListOfObject, "get_Item", _types.Int32);
+    private MethodInfo TSFunctionInvoke1Arg(EmittedRuntime runtime) => runtime.TSFunctionInvoke;
+
+    /// <summary>Emits a $TSFunction.Invoke(new object[]{ ...args }) call; the function ref and args
+    /// are produced by the supplied delegates. Leaves the (object) result on the stack.</summary>
+    private void EmitInvokeUserFn(ILGenerator il, EmittedRuntime runtime, LocalBuilder fnLocal, Action<ILGenerator> loadArgsArray)
+    {
+        il.Emit(OpCodes.Ldloc, fnLocal);
+        loadArgsArray(il);
+        il.Emit(OpCodes.Callvirt, runtime.TSFunctionInvoke);
+    }
+
+    /// <summary>public object Reduce(object fn, object initial)</summary>
+    private void EmitTSReadableReduce(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    {
+        var method = typeBuilder.DefineMethod("Reduce", MethodAttributes.Public, _types.Object, [_types.Object, _types.Object]);
+        var il = method.GetILGenerator();
+
+        var fnLocal = il.DeclareLocal(runtime.TSFunctionType);
+        var itemsLocal = il.DeclareLocal(_types.ListOfObject);
+        var accLocal = il.DeclareLocal(_types.Object);
+        var iLocal = il.DeclareLocal(_types.Int32);
+        var countLocal = il.DeclareLocal(_types.Int32);
+
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Castclass, runtime.TSFunctionType);
+        il.Emit(OpCodes.Stloc, fnLocal);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Call, _tsReadableDrainToList);
+        il.Emit(OpCodes.Stloc, itemsLocal);
+        il.Emit(OpCodes.Ldloc, itemsLocal);
+        il.Emit(OpCodes.Callvirt, ListCountGetter);
+        il.Emit(OpCodes.Stloc, countLocal);
+
+        // bool hasInitial = !(initial is UndefinedType);
+        var noInitial = il.DefineLabel();
+        var afterSeed = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_2);
+        il.Emit(OpCodes.Isinst, runtime.UndefinedType);
+        il.Emit(OpCodes.Brtrue, noInitial);
+
+        // acc = initial; i = 0;
+        il.Emit(OpCodes.Ldarg_2);
+        il.Emit(OpCodes.Stloc, accLocal);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Stloc, iLocal);
+        il.Emit(OpCodes.Br, afterSeed);
+
+        il.MarkLabel(noInitial);
+        // if (count == 0) return TSPromiseResolve(undefined);
+        var haveItems = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, countLocal);
+        il.Emit(OpCodes.Brtrue, haveItems);
+        il.Emit(OpCodes.Ldsfld, runtime.UndefinedInstance);
+        il.Emit(OpCodes.Call, runtime.TSPromiseResolve);
+        il.Emit(OpCodes.Ret);
+        il.MarkLabel(haveItems);
+        // acc = items[0]; i = 1;
+        il.Emit(OpCodes.Ldloc, itemsLocal);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Callvirt, ListItemGetter);
+        il.Emit(OpCodes.Stloc, accLocal);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Stloc, iLocal);
+
+        il.MarkLabel(afterSeed);
+        // for (; i < count; i++) acc = fn.Invoke([acc, items[i]]);
+        var loop = il.DefineLabel();
+        var endLoop = il.DefineLabel();
+        il.MarkLabel(loop);
+        il.Emit(OpCodes.Ldloc, iLocal);
+        il.Emit(OpCodes.Ldloc, countLocal);
+        il.Emit(OpCodes.Bge, endLoop);
+
+        EmitInvokeUserFn(il, runtime, fnLocal, gen =>
+        {
+            gen.Emit(OpCodes.Ldc_I4_2);
+            gen.Emit(OpCodes.Newarr, _types.Object);
+            gen.Emit(OpCodes.Dup);
+            gen.Emit(OpCodes.Ldc_I4_0);
+            gen.Emit(OpCodes.Ldloc, accLocal);
+            gen.Emit(OpCodes.Stelem_Ref);
+            gen.Emit(OpCodes.Dup);
+            gen.Emit(OpCodes.Ldc_I4_1);
+            gen.Emit(OpCodes.Ldloc, itemsLocal);
+            gen.Emit(OpCodes.Ldloc, iLocal);
+            gen.Emit(OpCodes.Callvirt, ListItemGetter);
+            gen.Emit(OpCodes.Stelem_Ref);
+        });
+        il.Emit(OpCodes.Stloc, accLocal);
+
+        il.Emit(OpCodes.Ldloc, iLocal);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Stloc, iLocal);
+        il.Emit(OpCodes.Br, loop);
+
+        il.MarkLabel(endLoop);
+        il.Emit(OpCodes.Ldloc, accLocal);
+        il.Emit(OpCodes.Call, runtime.TSPromiseResolve);
+        il.Emit(OpCodes.Ret);
+    }
+
+    /// <summary>public object Some/Every/Find(object fn) — drains, predicates, returns resolved $Promise.</summary>
+    private void EmitTSReadablePredicate(TypeBuilder typeBuilder, EmittedRuntime runtime, string kind)
+    {
+        var method = typeBuilder.DefineMethod(kind, MethodAttributes.Public, _types.Object, [_types.Object]);
+        var il = method.GetILGenerator();
+
+        var fnLocal = il.DeclareLocal(runtime.TSFunctionType);
+        var itemsLocal = il.DeclareLocal(_types.ListOfObject);
+        var iLocal = il.DeclareLocal(_types.Int32);
+        var countLocal = il.DeclareLocal(_types.Int32);
+
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Castclass, runtime.TSFunctionType);
+        il.Emit(OpCodes.Stloc, fnLocal);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Call, _tsReadableDrainToList);
+        il.Emit(OpCodes.Stloc, itemsLocal);
+        il.Emit(OpCodes.Ldloc, itemsLocal);
+        il.Emit(OpCodes.Callvirt, ListCountGetter);
+        il.Emit(OpCodes.Stloc, countLocal);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Stloc, iLocal);
+
+        var loop = il.DefineLabel();
+        var endLoop = il.DefineLabel();
+        var hitLabel = il.DefineLabel();   // the per-item "decisive" branch (early return)
+        var continueLabel = il.DefineLabel();
+
+        il.MarkLabel(loop);
+        il.Emit(OpCodes.Ldloc, iLocal);
+        il.Emit(OpCodes.Ldloc, countLocal);
+        il.Emit(OpCodes.Bge, endLoop);
+
+        // bool t = IsTruthy(fn.Invoke([items[i]]));
+        EmitInvokeUserFn(il, runtime, fnLocal, gen =>
+        {
+            gen.Emit(OpCodes.Ldc_I4_1);
+            gen.Emit(OpCodes.Newarr, _types.Object);
+            gen.Emit(OpCodes.Dup);
+            gen.Emit(OpCodes.Ldc_I4_0);
+            gen.Emit(OpCodes.Ldloc, itemsLocal);
+            gen.Emit(OpCodes.Ldloc, iLocal);
+            gen.Emit(OpCodes.Callvirt, ListItemGetter);
+            gen.Emit(OpCodes.Stelem_Ref);
+        });
+        il.Emit(OpCodes.Call, runtime.IsTruthy);
+
+        // Every short-circuits on a FALSE result; Some/Find short-circuit on a TRUE result.
+        if (kind == "Every")
+            il.Emit(OpCodes.Brfalse, hitLabel);
+        else
+            il.Emit(OpCodes.Brtrue, hitLabel);
+
+        // not decisive → i++; continue
+        il.MarkLabel(continueLabel);
+        il.Emit(OpCodes.Ldloc, iLocal);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Stloc, iLocal);
+        il.Emit(OpCodes.Br, loop);
+
+        // decisive hit → early return
+        il.MarkLabel(hitLabel);
+        if (kind == "Some")
+        {
+            il.Emit(OpCodes.Ldc_I4_1);
+            il.Emit(OpCodes.Box, _types.Boolean);
+        }
+        else if (kind == "Every")
+        {
+            il.Emit(OpCodes.Ldc_I4_0);
+            il.Emit(OpCodes.Box, _types.Boolean);
+        }
+        else // Find — return the matching item
+        {
+            il.Emit(OpCodes.Ldloc, itemsLocal);
+            il.Emit(OpCodes.Ldloc, iLocal);
+            il.Emit(OpCodes.Callvirt, ListItemGetter);
+        }
+        il.Emit(OpCodes.Call, runtime.TSPromiseResolve);
+        il.Emit(OpCodes.Ret);
+
+        il.MarkLabel(endLoop);
+        // Default result: Some->false, Every->true, Find->undefined
+        if (kind == "Some")
+        {
+            il.Emit(OpCodes.Ldc_I4_0);
+            il.Emit(OpCodes.Box, _types.Boolean);
+        }
+        else if (kind == "Every")
+        {
+            il.Emit(OpCodes.Ldc_I4_1);
+            il.Emit(OpCodes.Box, _types.Boolean);
+        }
+        else
+        {
+            il.Emit(OpCodes.Ldsfld, runtime.UndefinedInstance);
+        }
+        il.Emit(OpCodes.Call, runtime.TSPromiseResolve);
+        il.Emit(OpCodes.Ret);
+    }
+
+    /// <summary>public object Drop/Take(object n) — returns a new $Readable with the subset.</summary>
+    private void EmitTSReadableDropTake(TypeBuilder typeBuilder, EmittedRuntime runtime, string kind)
+    {
+        var method = typeBuilder.DefineMethod(kind, MethodAttributes.Public, _types.Object, [_types.Object]);
+        var il = method.GetILGenerator();
+
+        var nLocal = il.DeclareLocal(_types.Int32);
+        var itemsLocal = il.DeclareLocal(_types.ListOfObject);
+        var rLocal = il.DeclareLocal(runtime.TSReadableType);
+        var iLocal = il.DeclareLocal(_types.Int32);
+        var countLocal = il.DeclareLocal(_types.Int32);
+
+        // n = (int)ToNumber(arg1)
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Call, runtime.ToNumber);
+        il.Emit(OpCodes.Conv_I4);
+        il.Emit(OpCodes.Stloc, nLocal);
+
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Call, _tsReadableDrainToList);
+        il.Emit(OpCodes.Stloc, itemsLocal);
+        il.Emit(OpCodes.Ldloc, itemsLocal);
+        il.Emit(OpCodes.Callvirt, ListCountGetter);
+        il.Emit(OpCodes.Stloc, countLocal);
+
+        EmitNewHelperReadable(il, runtime, rLocal, objectModeFromThis: true);
+
+        // start index: Drop -> n, Take -> 0;  end: Drop -> count, Take -> min(n,count)
+        if (kind == "Drop")
+        {
+            il.Emit(OpCodes.Ldloc, nLocal);
+            il.Emit(OpCodes.Stloc, iLocal);
+        }
+        else
+        {
+            il.Emit(OpCodes.Ldc_I4_0);
+            il.Emit(OpCodes.Stloc, iLocal);
+            // count = min(n, count)
+            var keepCount = il.DefineLabel();
+            il.Emit(OpCodes.Ldloc, nLocal);
+            il.Emit(OpCodes.Ldloc, countLocal);
+            il.Emit(OpCodes.Bge, keepCount);
+            il.Emit(OpCodes.Ldloc, nLocal);
+            il.Emit(OpCodes.Stloc, countLocal);
+            il.MarkLabel(keepCount);
+        }
+
+        var loop = il.DefineLabel();
+        var endLoop = il.DefineLabel();
+        il.MarkLabel(loop);
+        il.Emit(OpCodes.Ldloc, iLocal);
+        il.Emit(OpCodes.Ldloc, countLocal);
+        il.Emit(OpCodes.Bge, endLoop);
+        // r.Push(items[i]);
+        il.Emit(OpCodes.Ldloc, rLocal);
+        il.Emit(OpCodes.Ldloc, itemsLocal);
+        il.Emit(OpCodes.Ldloc, iLocal);
+        il.Emit(OpCodes.Callvirt, ListItemGetter);
+        il.Emit(OpCodes.Callvirt, runtime.TSReadablePush);
+        il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Ldloc, iLocal);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Stloc, iLocal);
+        il.Emit(OpCodes.Br, loop);
+        il.MarkLabel(endLoop);
+
+        EmitPushNullAndReturn(il, runtime, rLocal);
+    }
+
+    /// <summary>public object FlatMap(object fn) — maps each chunk; flattens $Array results.</summary>
+    private void EmitTSReadableFlatMap(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    {
+        var method = typeBuilder.DefineMethod("FlatMap", MethodAttributes.Public, _types.Object, [_types.Object]);
+        var il = method.GetILGenerator();
+
+        var fnLocal = il.DeclareLocal(runtime.TSFunctionType);
+        var itemsLocal = il.DeclareLocal(_types.ListOfObject);
+        var rLocal = il.DeclareLocal(runtime.TSReadableType);
+        var iLocal = il.DeclareLocal(_types.Int32);
+        var countLocal = il.DeclareLocal(_types.Int32);
+        var mappedLocal = il.DeclareLocal(_types.Object);
+
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Castclass, runtime.TSFunctionType);
+        il.Emit(OpCodes.Stloc, fnLocal);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Call, _tsReadableDrainToList);
+        il.Emit(OpCodes.Stloc, itemsLocal);
+        il.Emit(OpCodes.Ldloc, itemsLocal);
+        il.Emit(OpCodes.Callvirt, ListCountGetter);
+        il.Emit(OpCodes.Stloc, countLocal);
+
+        EmitNewHelperReadable(il, runtime, rLocal, objectModeFromThis: false, forceObjectMode: true);
+
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Stloc, iLocal);
+
+        var loop = il.DefineLabel();
+        var endLoop = il.DefineLabel();
+        il.MarkLabel(loop);
+        il.Emit(OpCodes.Ldloc, iLocal);
+        il.Emit(OpCodes.Ldloc, countLocal);
+        il.Emit(OpCodes.Bge, endLoop);
+
+        // mapped = fn.Invoke([items[i]]);
+        EmitInvokeUserFn(il, runtime, fnLocal, gen =>
+        {
+            gen.Emit(OpCodes.Ldc_I4_1);
+            gen.Emit(OpCodes.Newarr, _types.Object);
+            gen.Emit(OpCodes.Dup);
+            gen.Emit(OpCodes.Ldc_I4_0);
+            gen.Emit(OpCodes.Ldloc, itemsLocal);
+            gen.Emit(OpCodes.Ldloc, iLocal);
+            gen.Emit(OpCodes.Callvirt, ListItemGetter);
+            gen.Emit(OpCodes.Stelem_Ref);
+        });
+        il.Emit(OpCodes.Stloc, mappedLocal);
+
+        // if (mapped is $Array) push each element; else push mapped.
+        var notArray = il.DefineLabel();
+        var afterPush = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, mappedLocal);
+        il.Emit(OpCodes.Isinst, runtime.TSArrayType);
+        il.Emit(OpCodes.Brfalse, notArray);
+
+        // var elems = ((TSArray)mapped).Elements; for j: r.Push(elems[j]);
+        var elemsLocal = il.DeclareLocal(_types.ListOfObject);
+        var jLocal = il.DeclareLocal(_types.Int32);
+        var elemCountLocal = il.DeclareLocal(_types.Int32);
+        il.Emit(OpCodes.Ldloc, mappedLocal);
+        il.Emit(OpCodes.Castclass, runtime.TSArrayType);
+        il.Emit(OpCodes.Callvirt, runtime.TSArrayElementsGetter);
+        il.Emit(OpCodes.Stloc, elemsLocal);
+        il.Emit(OpCodes.Ldloc, elemsLocal);
+        il.Emit(OpCodes.Callvirt, ListCountGetter);
+        il.Emit(OpCodes.Stloc, elemCountLocal);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Stloc, jLocal);
+        var innerLoop = il.DefineLabel();
+        var innerEnd = il.DefineLabel();
+        il.MarkLabel(innerLoop);
+        il.Emit(OpCodes.Ldloc, jLocal);
+        il.Emit(OpCodes.Ldloc, elemCountLocal);
+        il.Emit(OpCodes.Bge, innerEnd);
+        il.Emit(OpCodes.Ldloc, rLocal);
+        il.Emit(OpCodes.Ldloc, elemsLocal);
+        il.Emit(OpCodes.Ldloc, jLocal);
+        il.Emit(OpCodes.Callvirt, ListItemGetter);
+        il.Emit(OpCodes.Callvirt, runtime.TSReadablePush);
+        il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Ldloc, jLocal);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Stloc, jLocal);
+        il.Emit(OpCodes.Br, innerLoop);
+        il.MarkLabel(innerEnd);
+        il.Emit(OpCodes.Br, afterPush);
+
+        il.MarkLabel(notArray);
+        il.Emit(OpCodes.Ldloc, rLocal);
+        il.Emit(OpCodes.Ldloc, mappedLocal);
+        il.Emit(OpCodes.Callvirt, runtime.TSReadablePush);
+        il.Emit(OpCodes.Pop);
+
+        il.MarkLabel(afterPush);
+        il.Emit(OpCodes.Ldloc, iLocal);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Stloc, iLocal);
+        il.Emit(OpCodes.Br, loop);
+        il.MarkLabel(endLoop);
+
+        EmitPushNullAndReturn(il, runtime, rLocal);
+    }
+
+    /// <summary>public object AsIndexedPairs() — emits [index, value] pairs into a new $Readable.</summary>
+    private void EmitTSReadableAsIndexedPairs(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    {
+        var method = typeBuilder.DefineMethod("AsIndexedPairs", MethodAttributes.Public, _types.Object, Type.EmptyTypes);
+        var il = method.GetILGenerator();
+
+        var itemsLocal = il.DeclareLocal(_types.ListOfObject);
+        var rLocal = il.DeclareLocal(runtime.TSReadableType);
+        var iLocal = il.DeclareLocal(_types.Int32);
+        var countLocal = il.DeclareLocal(_types.Int32);
+        var listAdd = _types.GetMethod(_types.ListOfObject, "Add", _types.Object);
+
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Call, _tsReadableDrainToList);
+        il.Emit(OpCodes.Stloc, itemsLocal);
+        il.Emit(OpCodes.Ldloc, itemsLocal);
+        il.Emit(OpCodes.Callvirt, ListCountGetter);
+        il.Emit(OpCodes.Stloc, countLocal);
+
+        EmitNewHelperReadable(il, runtime, rLocal, objectModeFromThis: false, forceObjectMode: true);
+
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Stloc, iLocal);
+        var loop = il.DefineLabel();
+        var endLoop = il.DefineLabel();
+        il.MarkLabel(loop);
+        il.Emit(OpCodes.Ldloc, iLocal);
+        il.Emit(OpCodes.Ldloc, countLocal);
+        il.Emit(OpCodes.Bge, endLoop);
+
+        // var pair = new List<object>(); pair.Add((double)i boxed); pair.Add(items[i]);
+        var pairLocal = il.DeclareLocal(_types.ListOfObject);
+        il.Emit(OpCodes.Newobj, _types.GetDefaultConstructor(_types.ListOfObject));
+        il.Emit(OpCodes.Stloc, pairLocal);
+        il.Emit(OpCodes.Ldloc, pairLocal);
+        il.Emit(OpCodes.Ldloc, iLocal);
+        il.Emit(OpCodes.Conv_R8);
+        il.Emit(OpCodes.Box, _types.Double);
+        il.Emit(OpCodes.Callvirt, listAdd);
+        il.Emit(OpCodes.Ldloc, pairLocal);
+        il.Emit(OpCodes.Ldloc, itemsLocal);
+        il.Emit(OpCodes.Ldloc, iLocal);
+        il.Emit(OpCodes.Callvirt, ListItemGetter);
+        il.Emit(OpCodes.Callvirt, listAdd);
+
+        // r.Push(new $Array(pair));
+        il.Emit(OpCodes.Ldloc, rLocal);
+        il.Emit(OpCodes.Ldloc, pairLocal);
+        il.Emit(OpCodes.Newobj, runtime.TSArrayCtor);
+        il.Emit(OpCodes.Callvirt, runtime.TSReadablePush);
+        il.Emit(OpCodes.Pop);
+
+        il.Emit(OpCodes.Ldloc, iLocal);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Stloc, iLocal);
+        il.Emit(OpCodes.Br, loop);
+        il.MarkLabel(endLoop);
+
+        EmitPushNullAndReturn(il, runtime, rLocal);
+    }
+
+    /// <summary>Emits: rLocal = new $Readable(); rLocal.SetObjectMode(forceObjectMode ? true : this._objectMode);</summary>
+    private void EmitNewHelperReadable(ILGenerator il, EmittedRuntime runtime, LocalBuilder rLocal, bool objectModeFromThis, bool forceObjectMode = false)
+    {
+        il.Emit(OpCodes.Newobj, runtime.TSReadableCtor);
+        il.Emit(OpCodes.Stloc, rLocal);
+        il.Emit(OpCodes.Ldloc, rLocal);
+        if (forceObjectMode)
+        {
+            il.Emit(OpCodes.Ldc_I4_1);
+        }
+        else
+        {
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, _tsReadableObjectModeField);
+        }
+        il.Emit(OpCodes.Callvirt, runtime.TSReadableSetObjectMode);
+    }
+
+    /// <summary>Emits: rLocal.Push(null); return rLocal;</summary>
+    private void EmitPushNullAndReturn(ILGenerator il, EmittedRuntime runtime, LocalBuilder rLocal)
+    {
+        il.Emit(OpCodes.Ldloc, rLocal);
+        il.Emit(OpCodes.Ldnull);
+        il.Emit(OpCodes.Callvirt, runtime.TSReadablePush);
+        il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Ldloc, rLocal);
+        il.Emit(OpCodes.Ret);
+    }
+}

--- a/Compilation/RuntimeEmitter.TSStreamUtils.cs
+++ b/Compilation/RuntimeEmitter.TSStreamUtils.cs
@@ -26,9 +26,14 @@ public partial class RuntimeEmitter
             TypeAttributes.Public | TypeAttributes.Abstract | TypeAttributes.Sealed | TypeAttributes.BeforeFieldInit
         );
 
+        // compose bridge closure (#1028) — needs $Duplex/$Writable Write/End + $Readable Push.
+        EmitStreamComposeBridgeClass(moduleBuilder, runtime);
+
         EmitStreamFinished(typeBuilder, runtime);
         EmitStreamPipeline(typeBuilder, runtime);
         EmitStreamReadableFrom(typeBuilder, runtime);
+        EmitStreamDuplexFrom(typeBuilder, runtime);     // #1028
+        EmitStreamComposeMethod(typeBuilder, runtime);  // #1028
         EmitStreamPromisePipeline(typeBuilder, runtime);
         EmitStreamPromiseFinished(typeBuilder, runtime);
         EmitStreamConstructorFactories(typeBuilder, runtime);

--- a/Compilation/RuntimeEmitter.TSStreamUtils.cs
+++ b/Compilation/RuntimeEmitter.TSStreamUtils.cs
@@ -34,6 +34,7 @@ public partial class RuntimeEmitter
         EmitStreamReadableFrom(typeBuilder, runtime);
         EmitStreamDuplexFrom(typeBuilder, runtime);     // #1028
         EmitStreamComposeMethod(typeBuilder, runtime);  // #1028
+        EmitStreamDefaultHwm(typeBuilder, runtime);     // #1030
         EmitStreamPromisePipeline(typeBuilder, runtime);
         EmitStreamPromiseFinished(typeBuilder, runtime);
         EmitStreamConstructorFactories(typeBuilder, runtime);

--- a/Compilation/RuntimeEmitter.TSWritable.cs
+++ b/Compilation/RuntimeEmitter.TSWritable.cs
@@ -30,6 +30,7 @@ public partial class RuntimeEmitter
     private FieldBuilder _tsWritableAutoDestroyField = null!;
     private FieldBuilder _tsWritableLengthField = null!;
     private FieldBuilder _tsWritableNeedDrainField = null!;
+    private FieldBuilder _tsWritableErroredField = null!;
 
     /// <summary>
     /// Emits the $WriteCallbackWrapper helper class.
@@ -212,6 +213,7 @@ public partial class RuntimeEmitter
         _tsWritableAutoDestroyField = typeBuilder.DefineField("_autoDestroy", _types.Boolean, FieldAttributes.Private);
         _tsWritableLengthField = typeBuilder.DefineField("_writableLength", _types.Int32, FieldAttributes.Public);
         _tsWritableNeedDrainField = typeBuilder.DefineField("_needDrain", _types.Boolean, FieldAttributes.Public);
+        _tsWritableErroredField = typeBuilder.DefineField("_errored", _types.Boolean, FieldAttributes.Private); // #1030
 
         // Emit the helper callback wrapper class (after fields so it can reference them)
         EmitTSWriteCallbackWrapperClass(moduleBuilder, runtime);
@@ -748,9 +750,12 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldfld, _tsWritableCorkBufferField);
         il.Emit(OpCodes.Callvirt, _types.ListOfObject.GetMethod("Clear")!);
 
-        // if (error != null) emit 'error'
+        // if (error != null) { _errored = true; emit 'error'; }  (#1030)
         il.Emit(OpCodes.Ldarg_1);
         il.Emit(OpCodes.Brfalse, noErrorLabel);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Stfld, _tsWritableErroredField);
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ldstr, "error");
         il.Emit(OpCodes.Ldc_I4_1);
@@ -883,6 +888,21 @@ public partial class RuntimeEmitter
 
     private void EmitTSWritablePropertyGetters(TypeBuilder typeBuilder, EmittedRuntime runtime)
     {
+        // errored property (#1030): backs stream.isErrored
+        var erroredProp = typeBuilder.DefineProperty("Errored", PropertyAttributes.None, _types.Boolean, null);
+        var getErrored = typeBuilder.DefineMethod(
+            "get_Errored",
+            MethodAttributes.Public | MethodAttributes.SpecialName,
+            _types.Boolean,
+            Type.EmptyTypes
+        );
+        runtime.TSWritableErroredGetter = getErrored;
+        var eil = getErrored.GetILGenerator();
+        eil.Emit(OpCodes.Ldarg_0);
+        eil.Emit(OpCodes.Ldfld, _tsWritableErroredField);
+        eil.Emit(OpCodes.Ret);
+        erroredProp.SetGetMethod(getErrored);
+
         // writable property: _writable && !_ended && !_destroyed
         // Note: Use PascalCase getter names (get_Writable) for GetFieldsProperty lookup
         var writableProp = typeBuilder.DefineProperty("Writable", PropertyAttributes.None, _types.Boolean, null);

--- a/Compilation/RuntimeEmitter.cs
+++ b/Compilation/RuntimeEmitter.cs
@@ -273,6 +273,8 @@ public partial class RuntimeEmitter
             EmitTSReadableMapFilterMethods(runtime);               // Phase 2b: Map, Filter (need Transform) + CreateType
             EmitTSPassThroughClass(moduleBuilder, runtime);
             EmitTSStreamUtilsClass(moduleBuilder, runtime);
+            // addAbortSignal listener closure (#1027) — needs $Readable/$Writable Destroy + $Error.
+            EmitStreamAbortCallbackClass(moduleBuilder, runtime);
         }
         if (features.UsesZlib)
             EmitTSZlibTransformClass(moduleBuilder, runtime);

--- a/Execution/Interpreter.Async.cs
+++ b/Execution/Interpreter.Async.cs
@@ -193,6 +193,13 @@ public partial class Interpreter
             return new SharpTSReadableStreamAsyncIterator(rs, reader);
         }
 
+        // node:stream Readable (incl. Duplex/Transform/PassThrough) — wrap in an async
+        // iterator that pulls buffered chunks and parks on a slow producer (#1024).
+        if (iterable is SharpTSReadable readable)
+        {
+            return new SharpTSReadableAsyncIterator(readable);
+        }
+
         if (iterable is SharpTSObject obj)
         {
             var asyncIteratorFn = obj.GetBySymbol(SharpTSSymbol.AsyncIterator);

--- a/Runtime/BuiltIns/Modules/Interpreter/ChildProcessModuleInterpreter.cs
+++ b/Runtime/BuiltIns/Modules/Interpreter/ChildProcessModuleInterpreter.cs
@@ -894,23 +894,26 @@ public static class ChildProcessModuleInterpreter
                 var writer = new StreamWriter(pipeServer) { AutoFlush = true };
                 childProcess.SetupIpc(pipeServer, writer, cts);
 
-                // IPC message reader — marshal each message onto the owning loop.
+                // IPC message reader — marshal each message onto the owning loop. The loop reads
+                // until EOF (the child closing its write-end / exiting) rather than polling the
+                // cancellation token, so a final message buffered in the pipe (e.g. a reply sent
+                // right before the child exits) is always drained — see the WaitForExit handshake
+                // below, which awaits this task before emitting 'close'/'exit' + unref'ing.
                 var ipcReader = Task.Run(() =>
                 {
                     try
                     {
                         using var reader = new StreamReader(pipeServer, leaveOpen: true);
-                        while (!cts.Token.IsCancellationRequested)
+                        string? line;
+                        while ((line = reader.ReadLine()) != null)
                         {
-                            var line = reader.ReadLine();
-                            if (line == null) break;
                             var message = IpcSerializer.Deserialize(line);
                             post(() => emit(childProcess, "message", message));
                         }
                     }
                     catch (OperationCanceledException) { }
                     catch { }
-                }, cts.Token);
+                });
 
                 var stdoutTask = Task.Run(() =>
                 {
@@ -937,6 +940,14 @@ public static class ChildProcessModuleInterpreter
                 });
 
                 process.WaitForExit();
+
+                // The child has exited, so its IPC write-end is closed: the reader is guaranteed
+                // to drain any remaining buffered message and then see EOF (null), completing
+                // promptly. Awaiting it here ensures a reply written just before the child exited
+                // is posted as 'message' BEFORE we post 'close'/'exit' and drop the keep-alive ref
+                // — otherwise the loop could unref and drain out before the 'message' callback runs
+                // (the Fork_IpcRoundTrip empty-output race under CPU contention).
+                ipcReader.Wait();
                 cts.Cancel();
                 stdoutTask.Wait();
                 stderrTask.Wait();

--- a/Runtime/BuiltIns/Modules/Interpreter/StreamModuleInterpreter.cs
+++ b/Runtime/BuiltIns/Modules/Interpreter/StreamModuleInterpreter.cs
@@ -218,16 +218,56 @@ public static class StreamModuleInterpreter
     }
 
     /// <summary>
-    /// stream.addAbortSignal(signal, stream) — destroys stream when signal is aborted.
+    /// stream.addAbortSignal(signal, stream) — destroys the stream with an AbortError when the
+    /// signal fires (#1027). If the signal is already aborted, the stream is destroyed at once.
     /// </summary>
     private static RuntimeValue AddAbortSignal(Interp interpreter, RuntimeValue receiver, ReadOnlySpan<RuntimeValue> args)
     {
-        // Basic implementation: just return the stream
-        // AbortSignal integration requires async runtime support
         if (args.Length < 2)
             throw new Exception("addAbortSignal() requires signal and stream arguments");
 
+        var signal = args[0].ToObject() as SharpTSAbortSignal;
+        var stream = args[1].ToObject();
+
+        if (signal != null && stream != null)
+        {
+            if (signal.Aborted)
+                DestroyStreamWithAbort(interpreter, stream, signal);
+            else
+                signal.AddEventListener("abort", new AbortDestroyListener(stream, signal));
+        }
+
         return args[1]; // Return the stream
+    }
+
+    /// <summary>Destroys a stream with the signal's reason (or a fresh AbortError).</summary>
+    private static void DestroyStreamWithAbort(Interp interpreter, object stream, SharpTSAbortSignal signal)
+    {
+        var destroy = GetStreamMethod(stream, "destroy");
+        destroy?.Call(interpreter, [MakeAbortError(signal)]);
+    }
+
+    /// <summary>Returns the signal's reason when it is an Error/object, else a Node-style AbortError.</summary>
+    private static object MakeAbortError(SharpTSAbortSignal signal)
+    {
+        var reason = signal.Reason;
+        if (reason is SharpTSError || reason is SharpTSObject)
+            return reason;
+        return new SharpTSError("The operation was aborted") { Name = "AbortError", Code = "ABORT_ERR" };
+    }
+
+    /// <summary>Listener that destroys the stream when its AbortSignal fires.</summary>
+    private sealed class AbortDestroyListener : ISharpTSCallable
+    {
+        private readonly object _stream;
+        private readonly SharpTSAbortSignal _signal;
+        public AbortDestroyListener(object stream, SharpTSAbortSignal signal) { _stream = stream; _signal = signal; }
+        public int Arity() => 0;
+        public object? Call(Interp interpreter, List<object?> arguments)
+        {
+            DestroyStreamWithAbort(interpreter, _stream, _signal);
+            return null;
+        }
     }
 
     private static BuiltInMethod? GetStreamMethod(object? stream, string methodName)

--- a/Runtime/BuiltIns/Modules/Interpreter/StreamModuleInterpreter.cs
+++ b/Runtime/BuiltIns/Modules/Interpreter/StreamModuleInterpreter.cs
@@ -34,6 +34,9 @@ public static class StreamModuleInterpreter
             ["pipeline"] = BuiltInMethod.CreateV2("pipeline", 2, int.MaxValue, Pipeline),
             ["addAbortSignal"] = BuiltInMethod.CreateV2("addAbortSignal", 2, AddAbortSignal),
             ["compose"] = BuiltInMethod.CreateV2("compose", 1, int.MaxValue, Compose),
+            ["isErrored"] = BuiltInMethod.CreateV2("isErrored", 1, IsErrored),
+            ["getDefaultHighWaterMark"] = BuiltInMethod.CreateV2("getDefaultHighWaterMark", 0, 1, GetDefaultHighWaterMark),
+            ["setDefaultHighWaterMark"] = BuiltInMethod.CreateV2("setDefaultHighWaterMark", 2, SetDefaultHighWaterMark),
             ["promises"] = StreamPromisesModuleInterpreter.CreatePromisesNamespace()
         };
     }
@@ -376,6 +379,42 @@ public static class StreamModuleInterpreter
             GetStreamMethod(_composed, "destroy")?.Call(interpreter, [error]);
             return null;
         }
+    }
+
+    // Module-level default highWaterMarks (#1030). Shared with the compiled $StreamUtils defaults.
+    private static int _defaultHwmByte = 16384;
+    private static int _defaultHwmObject = 16;
+
+    /// <summary>stream.isErrored(stream) — true if the stream has errored.</summary>
+    private static RuntimeValue IsErrored(Interp interpreter, RuntimeValue receiver, ReadOnlySpan<RuntimeValue> args)
+    {
+        var obj = args.Length > 0 ? args[0].ToObject() : null;
+        bool errored = obj switch
+        {
+            SharpTSReadable r => r.Errored,
+            SharpTSWritable w => w.Errored,
+            _ => false
+        };
+        return RuntimeValue.FromBoolean(errored);
+    }
+
+    /// <summary>stream.getDefaultHighWaterMark(objectMode?) — the current default highWaterMark.</summary>
+    private static RuntimeValue GetDefaultHighWaterMark(Interp interpreter, RuntimeValue receiver, ReadOnlySpan<RuntimeValue> args)
+    {
+        bool objectMode = args.Length > 0 && args[0].IsTruthy();
+        return RuntimeValue.FromNumber(objectMode ? _defaultHwmObject : _defaultHwmByte);
+    }
+
+    /// <summary>stream.setDefaultHighWaterMark(objectMode, value) — sets the default highWaterMark.</summary>
+    private static RuntimeValue SetDefaultHighWaterMark(Interp interpreter, RuntimeValue receiver, ReadOnlySpan<RuntimeValue> args)
+    {
+        bool objectMode = args.Length > 0 && args[0].IsTruthy();
+        int value = args.Length > 1 && args[1].IsNumber ? (int)args[1].AsNumberUnsafe() : 0;
+        if (objectMode)
+            _defaultHwmObject = value;
+        else
+            _defaultHwmByte = value;
+        return RuntimeValue.Undefined;
     }
 
     private static BuiltInMethod? GetStreamMethod(object? stream, string methodName)

--- a/Runtime/BuiltIns/Modules/Interpreter/StreamModuleInterpreter.cs
+++ b/Runtime/BuiltIns/Modules/Interpreter/StreamModuleInterpreter.cs
@@ -33,6 +33,7 @@ public static class StreamModuleInterpreter
             ["finished"] = BuiltInMethod.CreateV2("finished", 1, 3, Finished),
             ["pipeline"] = BuiltInMethod.CreateV2("pipeline", 2, int.MaxValue, Pipeline),
             ["addAbortSignal"] = BuiltInMethod.CreateV2("addAbortSignal", 2, AddAbortSignal),
+            ["compose"] = BuiltInMethod.CreateV2("compose", 1, int.MaxValue, Compose),
             ["promises"] = StreamPromisesModuleInterpreter.CreatePromisesNamespace()
         };
     }
@@ -266,6 +267,113 @@ public static class StreamModuleInterpreter
         public object? Call(Interp interpreter, List<object?> arguments)
         {
             DestroyStreamWithAbort(interpreter, _stream, _signal);
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// stream.compose(...streams) — composes streams into a single Duplex (#1028). Writing to the
+    /// returned Duplex feeds the first stream; the chain is piped together; the last stream's output
+    /// is pushed onto the Duplex's readable side.
+    /// </summary>
+    private static RuntimeValue Compose(Interp interpreter, RuntimeValue receiver, ReadOnlySpan<RuntimeValue> args)
+    {
+        if (args.Length < 1)
+            throw new Exception("compose() requires at least one stream");
+
+        var streams = new List<object?>(args.Length);
+        for (int i = 0; i < args.Length; i++)
+            streams.Add(args[i].ToObject());
+
+        // Pipe consecutive streams together.
+        for (int i = 0; i < streams.Count - 1; i++)
+            GetStreamMethod(streams[i], "pipe")?.Call(interpreter, [streams[i + 1]]);
+
+        var first = streams[0];
+        var last = streams[^1];
+
+        var composed = new SharpTSDuplex { ObjectMode = true, WritableObjectMode = true };
+        composed.SetWriteCallback(new ComposeForwardListener(first));
+        composed.SetFinalCallback(new ComposeFinalListener(first));
+
+        if (last is SharpTSEventEmitter lastEmitter)
+        {
+            lastEmitter.AddListenerDirect("data", new ComposeDataListener(composed));
+            lastEmitter.AddListenerDirect("end", new ComposeEndListener(composed));
+            lastEmitter.AddListenerDirect("error", new ComposeErrorListener(composed));
+        }
+
+        return RuntimeValue.FromObject(composed);
+    }
+
+    /// <summary>Write callback for a composed Duplex: forwards each chunk to the first stream.</summary>
+    private sealed class ComposeForwardListener : ISharpTSCallable
+    {
+        private readonly object? _first;
+        public ComposeForwardListener(object? first) => _first = first;
+        public int Arity() => 3;
+        public object? Call(Interp interpreter, List<object?> arguments)
+        {
+            var chunk = arguments.Count > 0 ? arguments[0] : null;
+            var done = arguments.Count > 2 ? arguments[2] as ISharpTSCallable : null;
+            GetStreamMethod(_first, "write")?.Call(interpreter, [chunk]);
+            done?.Call(interpreter, []);
+            return null;
+        }
+    }
+
+    /// <summary>Final callback for a composed Duplex: ends the first stream when the Duplex ends.</summary>
+    private sealed class ComposeFinalListener : ISharpTSCallable
+    {
+        private readonly object? _first;
+        public ComposeFinalListener(object? first) => _first = first;
+        public int Arity() => 1;
+        public object? Call(Interp interpreter, List<object?> arguments)
+        {
+            var done = arguments.Count > 0 ? arguments[0] as ISharpTSCallable : null;
+            GetStreamMethod(_first, "end")?.Call(interpreter, []);
+            done?.Call(interpreter, []);
+            return null;
+        }
+    }
+
+    /// <summary>Pushes the last stream's data onto the composed Duplex's readable side.</summary>
+    private sealed class ComposeDataListener : ISharpTSCallable
+    {
+        private readonly SharpTSDuplex _composed;
+        public ComposeDataListener(SharpTSDuplex composed) => _composed = composed;
+        public int Arity() => 1;
+        public object? Call(Interp interpreter, List<object?> arguments)
+        {
+            var chunk = arguments.Count > 0 ? arguments[0] : null;
+            GetStreamMethod(_composed, "push")?.Call(interpreter, [chunk]);
+            return null;
+        }
+    }
+
+    /// <summary>Ends the composed Duplex's readable side when the last stream ends.</summary>
+    private sealed class ComposeEndListener : ISharpTSCallable
+    {
+        private readonly SharpTSDuplex _composed;
+        public ComposeEndListener(SharpTSDuplex composed) => _composed = composed;
+        public int Arity() => 0;
+        public object? Call(Interp interpreter, List<object?> arguments)
+        {
+            GetStreamMethod(_composed, "push")?.Call(interpreter, [(object?)null]);
+            return null;
+        }
+    }
+
+    /// <summary>Propagates the last stream's error to the composed Duplex.</summary>
+    private sealed class ComposeErrorListener : ISharpTSCallable
+    {
+        private readonly SharpTSDuplex _composed;
+        public ComposeErrorListener(SharpTSDuplex composed) => _composed = composed;
+        public int Arity() => 1;
+        public object? Call(Interp interpreter, List<object?> arguments)
+        {
+            var error = arguments.Count > 0 ? arguments[0] : null;
+            GetStreamMethod(_composed, "destroy")?.Call(interpreter, [error]);
             return null;
         }
     }

--- a/Runtime/Types/SharpTSDuplexConstructor.cs
+++ b/Runtime/Types/SharpTSDuplexConstructor.cs
@@ -1,3 +1,4 @@
+using SharpTS.Runtime.BuiltIns;
 using Interp = SharpTS.Execution.Interpreter;
 
 namespace SharpTS.Runtime.Types;
@@ -81,8 +82,33 @@ public sealed class SharpTSDuplexConstructor : ISharpTSCallable
     {
         return name switch
         {
+            "from" => BuiltInMethod.CreateV2("from", 1, DuplexFrom),
             _ => null
         };
+    }
+
+    /// <summary>
+    /// Duplex.from(source) — builds a Duplex whose readable side yields the items of an
+    /// iterable/array source (mirrors Readable.from); other source kinds push nothing (#1028).
+    /// </summary>
+    private static RuntimeValue DuplexFrom(Interp interpreter, RuntimeValue receiver, ReadOnlySpan<RuntimeValue> args)
+    {
+        var source = args.Length > 0 ? args[0].ToObject() : null;
+        var stream = new SharpTSDuplex { ObjectMode = true, WritableObjectMode = true };
+
+        if (source is SharpTSArray arr)
+        {
+            foreach (var item in arr)
+                stream.PushFromHost(interpreter, item);
+        }
+        else if (source is List<object?> list)
+        {
+            foreach (var item in list)
+                stream.PushFromHost(interpreter, item);
+        }
+
+        stream.PushFromHost(interpreter, null); // EOF
+        return RuntimeValue.FromObject(stream);
     }
 
     /// <summary>

--- a/Runtime/Types/SharpTSReadable.cs
+++ b/Runtime/Types/SharpTSReadable.cs
@@ -50,6 +50,11 @@ public class SharpTSReadable : SharpTSEventEmitter
     public int HighWaterMark { get => _highWaterMark; set => _highWaterMark = value; }
 
     /// <summary>
+    /// Whether this stream has errored (destroyed with an error) — backs stream.isErrored (#1030).
+    /// </summary>
+    public bool Errored => _errored;
+
+    /// <summary>
     /// Gets a member (method or property) by name for interpreter dispatch.
     /// </summary>
     public new object? GetMember(string name)

--- a/Runtime/Types/SharpTSReadable.cs
+++ b/Runtime/Types/SharpTSReadable.cs
@@ -899,7 +899,7 @@ public class SharpTSReadable : SharpTSEventEmitter
     // toArray/forEach). Consuming helpers return a resolved Promise; lazy helpers return a
     // new objectMode Readable carrying the transformed chunks. Interp == compiled by construction.
 
-    private List<object?> DrainBufferToList()
+    internal List<object?> DrainBufferToList()
     {
         var items = new List<object?>(_readBuffer.Count);
         while (_readBuffer.Count > 0)

--- a/Runtime/Types/SharpTSReadable.cs
+++ b/Runtime/Types/SharpTSReadable.cs
@@ -72,6 +72,17 @@ public class SharpTSReadable : SharpTSEventEmitter
             "map" => BuiltInMethod.CreateV2("map", 1, Map),
             "filter" => BuiltInMethod.CreateV2("filter", 1, Filter),
 
+            // Async iterator helpers (#1025). Consuming helpers return a Promise;
+            // lazy helpers return a new Readable carrying the transformed chunks.
+            "reduce" => BuiltInMethod.CreateV2("reduce", 1, 2, Reduce),
+            "some" => BuiltInMethod.CreateV2("some", 1, Some),
+            "every" => BuiltInMethod.CreateV2("every", 1, Every),
+            "find" => BuiltInMethod.CreateV2("find", 1, Find),
+            "drop" => BuiltInMethod.CreateV2("drop", 1, Drop),
+            "take" => BuiltInMethod.CreateV2("take", 1, Take),
+            "flatMap" => BuiltInMethod.CreateV2("flatMap", 1, FlatMap),
+            "asIndexedPairs" => BuiltInMethod.CreateV2("asIndexedPairs", 0, AsIndexedPairs),
+
             // Wrap event methods to drain buffer after 'data' listener is added
             "on" or "addListener" => BuiltInMethod.CreateV2(name, 2, WrapOnForFlowing),
             "once" => BuiltInMethod.CreateV2("once", 2, WrapOnceForFlowing),
@@ -876,6 +887,156 @@ public class SharpTSReadable : SharpTSEventEmitter
             size += GetChunkLength(chunk);
         }
         return size;
+    }
+
+    // ---- Async iterator helpers (#1025) ----
+    // These consume / transform the currently-buffered chunks (the same buffer model as
+    // toArray/forEach). Consuming helpers return a resolved Promise; lazy helpers return a
+    // new objectMode Readable carrying the transformed chunks. Interp == compiled by construction.
+
+    private List<object?> DrainBufferToList()
+    {
+        var items = new List<object?>(_readBuffer.Count);
+        while (_readBuffer.Count > 0)
+            items.Add(_readBuffer.Dequeue());
+        return items;
+    }
+
+    private static SharpTSReadable MakeHelperReadable(bool objectMode)
+    {
+        var r = new SharpTSReadable { ObjectMode = objectMode };
+        return r;
+    }
+
+    private RuntimeValue Reduce(Interp interpreter, RuntimeValue receiver, ReadOnlySpan<RuntimeValue> args)
+    {
+        var fn = args.Length > 0 ? args[0].ToObject() as ISharpTSCallable : null;
+        if (fn == null)
+            throw new Exception("reduce() requires a function argument");
+        var items = DrainBufferToList();
+
+        object? acc;
+        int start;
+        if (args.Length > 1)
+        {
+            acc = args[1].ToObject();
+            start = 0;
+        }
+        else if (items.Count > 0)
+        {
+            acc = items[0];
+            start = 1;
+        }
+        else
+        {
+            // Empty stream with no initial value — yields undefined (matches compiled parity).
+            return RuntimeValue.FromObject(SharpTSPromise.Resolve(SharpTSUndefined.Instance));
+        }
+
+        for (int i = start; i < items.Count; i++)
+            acc = fn.Call(interpreter, [acc, items[i]]);
+
+        return RuntimeValue.FromObject(SharpTSPromise.Resolve(acc));
+    }
+
+    private RuntimeValue Some(Interp interpreter, RuntimeValue receiver, ReadOnlySpan<RuntimeValue> args)
+    {
+        var fn = args.Length > 0 ? args[0].ToObject() as ISharpTSCallable : null;
+        if (fn == null)
+            throw new Exception("some() requires a function argument");
+        foreach (var item in DrainBufferToList())
+        {
+            if (RuntimeValue.FromBoxed(fn.Call(interpreter, [item])).IsTruthy())
+                return RuntimeValue.FromObject(SharpTSPromise.Resolve(true));
+        }
+        return RuntimeValue.FromObject(SharpTSPromise.Resolve(false));
+    }
+
+    private RuntimeValue Every(Interp interpreter, RuntimeValue receiver, ReadOnlySpan<RuntimeValue> args)
+    {
+        var fn = args.Length > 0 ? args[0].ToObject() as ISharpTSCallable : null;
+        if (fn == null)
+            throw new Exception("every() requires a function argument");
+        foreach (var item in DrainBufferToList())
+        {
+            if (!RuntimeValue.FromBoxed(fn.Call(interpreter, [item])).IsTruthy())
+                return RuntimeValue.FromObject(SharpTSPromise.Resolve(false));
+        }
+        return RuntimeValue.FromObject(SharpTSPromise.Resolve(true));
+    }
+
+    private RuntimeValue Find(Interp interpreter, RuntimeValue receiver, ReadOnlySpan<RuntimeValue> args)
+    {
+        var fn = args.Length > 0 ? args[0].ToObject() as ISharpTSCallable : null;
+        if (fn == null)
+            throw new Exception("find() requires a function argument");
+        foreach (var item in DrainBufferToList())
+        {
+            if (RuntimeValue.FromBoxed(fn.Call(interpreter, [item])).IsTruthy())
+                return RuntimeValue.FromObject(SharpTSPromise.Resolve(item));
+        }
+        return RuntimeValue.FromObject(SharpTSPromise.Resolve(SharpTSUndefined.Instance));
+    }
+
+    private RuntimeValue Drop(Interp interpreter, RuntimeValue receiver, ReadOnlySpan<RuntimeValue> args)
+    {
+        int n = args.Length > 0 && args[0].IsNumber ? (int)args[0].AsNumberUnsafe() : 0;
+        var items = DrainBufferToList();
+        var result = MakeHelperReadable(_objectMode);
+        for (int i = n; i < items.Count; i++)
+            result.PushFromHost(interpreter, items[i]);
+        result.PushFromHost(interpreter, null);
+        return RuntimeValue.FromObject(result);
+    }
+
+    private RuntimeValue Take(Interp interpreter, RuntimeValue receiver, ReadOnlySpan<RuntimeValue> args)
+    {
+        int n = args.Length > 0 && args[0].IsNumber ? (int)args[0].AsNumberUnsafe() : 0;
+        var items = DrainBufferToList();
+        var result = MakeHelperReadable(_objectMode);
+        for (int i = 0; i < items.Count && i < n; i++)
+            result.PushFromHost(interpreter, items[i]);
+        result.PushFromHost(interpreter, null);
+        return RuntimeValue.FromObject(result);
+    }
+
+    private RuntimeValue FlatMap(Interp interpreter, RuntimeValue receiver, ReadOnlySpan<RuntimeValue> args)
+    {
+        var fn = args.Length > 0 ? args[0].ToObject() as ISharpTSCallable : null;
+        if (fn == null)
+            throw new Exception("flatMap() requires a function argument");
+        var result = MakeHelperReadable(true);
+        foreach (var item in DrainBufferToList())
+        {
+            var mapped = fn.Call(interpreter, [item]);
+            if (mapped is SharpTSArray arr)
+            {
+                foreach (var e in arr)
+                    result.PushFromHost(interpreter, e);
+            }
+            else
+            {
+                result.PushFromHost(interpreter, mapped);
+            }
+        }
+        result.PushFromHost(interpreter, null);
+        return RuntimeValue.FromObject(result);
+    }
+
+    private RuntimeValue AsIndexedPairs(Interp interpreter, RuntimeValue receiver, ReadOnlySpan<RuntimeValue> args)
+    {
+        var result = MakeHelperReadable(true);
+        int index = 0;
+        foreach (var item in DrainBufferToList())
+        {
+            var pairElements = new SharpTS.Runtime.Deque<object?>();
+            pairElements.AddLast((double)index);
+            pairElements.AddLast(item);
+            result.PushFromHost(interpreter, new SharpTSArray(pairElements));
+            index++;
+        }
+        result.PushFromHost(interpreter, null);
+        return RuntimeValue.FromObject(result);
     }
 
     // ---- Async iteration support (#1024) ----

--- a/Runtime/Types/SharpTSReadable.cs
+++ b/Runtime/Types/SharpTSReadable.cs
@@ -23,6 +23,12 @@ public class SharpTSReadable : SharpTSEventEmitter
     private bool _objectMode;
     private int _highWaterMark = 16384; // bytes for binary mode, 16 for object mode
 
+    // Async iteration support (#1024): tracks error state for `for await` rejection,
+    // and parks a pending next() pull when the buffer is empty and the stream is live.
+    private bool _errored;
+    private object? _error;
+    private System.Threading.Tasks.TaskCompletionSource<object?>? _iterWaiter;
+
     /// <summary>
     /// Gets or sets whether this stream operates in object mode.
     /// In object mode, chunks can be any JavaScript value (not just strings/Buffers).
@@ -316,10 +322,14 @@ public class SharpTSReadable : SharpTSEventEmitter
         {
             _ended = true;
             _readable = false;
+            TryDeliverToIterWaiter(null, end: true);
             if (_flowing == true)
                 EmitData(interpreter, "end", null);
             return;
         }
+
+        if (TryDeliverToIterWaiter(chunk, end: false))
+            return;
 
         if (_flowing == true)
             EmitData(interpreter, "data", chunk);
@@ -353,6 +363,7 @@ public class SharpTSReadable : SharpTSEventEmitter
             // EOF signal
             _ended = true;
             _readable = false;
+            TryDeliverToIterWaiter(null, end: true);
             if (_flowing == true)
             {
                 EmitEvent(interpreter, "end", []);
@@ -363,6 +374,12 @@ public class SharpTSReadable : SharpTSEventEmitter
             }
             FlushPipes(interpreter);
             return RuntimeValue.False;
+        }
+
+        // Hand the chunk directly to a parked `for await` pull, if any (#1024).
+        if (TryDeliverToIterWaiter(chunk, end: false))
+        {
+            return RuntimeValue.FromBoolean(GetBufferSize() < _highWaterMark);
         }
 
         if (_flowing == true)
@@ -570,10 +587,21 @@ public class SharpTSReadable : SharpTSEventEmitter
         _readBuffer.Clear();
         _pipeDestinations.Clear();
 
-        if (args.Length > 0 && args[0].ToObject() is { } error)
+        var destroyError = args.Length > 0 ? args[0].ToObject() : null;
+        if (destroyError is not null)
         {
+            _errored = true;
+            _error = destroyError;
+            // A pending `for await` pull rejects with the destroy error (#1024).
+            var faulted = _iterWaiter;
+            _iterWaiter = null;
+            faulted?.TrySetException(new SharpTSPromiseRejectedException(destroyError));
             // Emit error event
-            EmitEvent(interpreter, "error", [error]);
+            EmitEvent(interpreter, "error", [destroyError]);
+        }
+        else
+        {
+            TryDeliverToIterWaiter(null, end: true);
         }
 
         EmitEvent(interpreter, "close", []);
@@ -848,6 +876,68 @@ public class SharpTSReadable : SharpTSEventEmitter
             size += GetChunkLength(chunk);
         }
         return size;
+    }
+
+    // ---- Async iteration support (#1024) ----
+
+    private static Dictionary<string, object?> MakeIterResult(object? value, bool done)
+        => new() { ["value"] = done ? SharpTSUndefined.Instance : value, ["done"] = done };
+
+    /// <summary>
+    /// Pulls the next chunk for <c>[Symbol.asyncIterator]().next()</c>. Returns a Task that
+    /// resolves to an <c>{ value, done }</c> record. When the buffer is empty and the stream
+    /// is still live, the returned task is parked until the next push / end / error so a slow
+    /// (asynchronous) producer is awaited rather than ending the loop prematurely.
+    /// </summary>
+    internal System.Threading.Tasks.Task<object?> IterNextAsync()
+    {
+        if (_readBuffer.Count > 0)
+            return System.Threading.Tasks.Task.FromResult<object?>(MakeIterResult(_readBuffer.Dequeue(), false));
+        if (_errored)
+        {
+            var tcs = new System.Threading.Tasks.TaskCompletionSource<object?>();
+            tcs.SetException(new SharpTSPromiseRejectedException(_error));
+            return tcs.Task;
+        }
+        if (_ended || _destroyed)
+            return System.Threading.Tasks.Task.FromResult<object?>(MakeIterResult(null, true));
+
+        // Park until a producer pushes more, ends, or errors.
+        _iterWaiter = new System.Threading.Tasks.TaskCompletionSource<object?>(
+            System.Threading.Tasks.TaskCreationOptions.RunContinuationsAsynchronously);
+        return _iterWaiter.Task;
+    }
+
+    /// <summary>
+    /// Cleanup for an early <c>for await</c> exit (break/return/throw) — destroys the stream
+    /// and settles any parked pull as done.
+    /// </summary>
+    internal void IterReturn()
+    {
+        if (!_destroyed)
+        {
+            _destroyed = true;
+            _readable = false;
+            _readBuffer.Clear();
+            _pipeDestinations.Clear();
+        }
+        var waiter = _iterWaiter;
+        _iterWaiter = null;
+        waiter?.TrySetResult(MakeIterResult(null, true));
+    }
+
+    /// <summary>
+    /// Hands a value to a parked async-iterator pull, if one is waiting. Returns true when the
+    /// value was consumed by the iterator (so the caller must not also buffer / emit it).
+    /// </summary>
+    private bool TryDeliverToIterWaiter(object? chunk, bool end)
+    {
+        var waiter = _iterWaiter;
+        if (waiter == null)
+            return false;
+        _iterWaiter = null;
+        waiter.TrySetResult(end ? MakeIterResult(null, true) : MakeIterResult(chunk, false));
+        return true;
     }
 
     public override string ToString() => "Readable {}";

--- a/Runtime/Types/SharpTSReadableAsyncIterator.cs
+++ b/Runtime/Types/SharpTSReadableAsyncIterator.cs
@@ -1,0 +1,83 @@
+using System.Threading.Tasks;
+using SharpTS.Runtime.BuiltIns;
+using SharpTS.TypeSystem;
+
+namespace SharpTS.Runtime.Types;
+
+/// <summary>
+/// Async iterator wrapper that makes a <see cref="SharpTSReadable"/> (and its
+/// <see cref="SharpTSDuplex"/> / <see cref="SharpTSTransform"/> subclasses) usable with
+/// <c>for await (const chunk of readable)</c>. Mirrors Node's
+/// <c>Readable.prototype[Symbol.asyncIterator]</c> (#1024).
+/// </summary>
+/// <remarks>
+/// Registered as the return value of <see cref="SharpTSReadable"/>'s
+/// <c>Symbol.asyncIterator</c> lookup path; the interpreter's <c>TryGetAsyncIterator</c>
+/// special-cases <see cref="SharpTSReadable"/> alongside its <see cref="SharpTSReadableStream"/>
+/// branch.
+///
+/// Lifecycle:
+/// <list type="bullet">
+///   <item><c>[Symbol.asyncIterator]()</c> returns <c>this</c> (self-iterable).</item>
+///   <item><c>next()</c> delegates to <see cref="SharpTSReadable.IterNextAsync"/>, yielding one
+///     buffered chunk at a time and settling <c>done:true</c> on <c>end</c>, or rejecting on
+///     <c>error</c>. A pull against an empty-but-live stream parks until the next push.</item>
+///   <item><c>return()</c> destroys the stream — matches the spec "AsyncIteratorClose" step when
+///     the loop exits via <c>break</c>/<c>return</c>/throw.</item>
+/// </list>
+/// </remarks>
+public class SharpTSReadableAsyncIterator : SharpTSObject
+{
+    public override TypeCategory RuntimeCategory => TypeCategory.AsyncGenerator;
+
+    private readonly SharpTSReadable _stream;
+    private bool _done;
+
+    public SharpTSReadableAsyncIterator(SharpTSReadable stream)
+        : base(new Dictionary<string, object?>())
+    {
+        _stream = stream;
+
+        // Self-iterable.
+        SetBySymbol(SharpTSSymbol.AsyncIterator,
+            BuiltInMethod.CreateV2("[Symbol.asyncIterator]", 0, (_, _, _) => RuntimeValue.FromObject(this)));
+
+        SetProperty("next", BuiltInMethod.CreateV2("next", 0, (_, _, _) =>
+        {
+            if (_done)
+            {
+                return RuntimeValue.FromObject(Task.FromResult<object?>(new Dictionary<string, object?>
+                {
+                    ["value"] = SharpTSUndefined.Instance,
+                    ["done"] = (object)true,
+                }));
+            }
+
+            var pull = _stream.IterNextAsync();
+            // Observe a done:true result so subsequent next() calls short-circuit.
+            async Task<object?> AwaitAndObserve()
+            {
+                var result = await pull.ConfigureAwait(false);
+                if (result is IDictionary<string, object?> dict &&
+                    dict.TryGetValue("done", out var d) && d is bool db && db)
+                {
+                    _done = true;
+                }
+                return result;
+            }
+            return RuntimeValue.FromObject(AwaitAndObserve());
+        }));
+
+        SetProperty("return", BuiltInMethod.CreateV2("return", 0, 1, (_, _, args) =>
+        {
+            _done = true;
+            _stream.IterReturn();
+            var returnValue = args.Length > 0 ? args[0].ToObject() : SharpTSUndefined.Instance;
+            return RuntimeValue.FromObject(Task.FromResult<object?>(new Dictionary<string, object?>
+            {
+                ["value"] = returnValue,
+                ["done"] = (object)true,
+            }));
+        }));
+    }
+}

--- a/Runtime/Types/SharpTSReadableConstructor.cs
+++ b/Runtime/Types/SharpTSReadableConstructor.cs
@@ -71,8 +71,43 @@ public sealed class SharpTSReadableConstructor : ISharpTSCallable
         {
             "from" => BuiltInMethod.CreateV2("from", 1, 2, ReadableFrom),
             "isReadable" => BuiltInMethod.CreateV2("isReadable", 1, IsReadable),
+            "toWeb" => BuiltInMethod.CreateV2("toWeb", 1, ToWeb),
+            "fromWeb" => BuiltInMethod.CreateV2("fromWeb", 1, FromWeb),
             _ => null
         };
+    }
+
+    /// <summary>
+    /// Readable.toWeb(readable) — converts a Node Readable to a WHATWG ReadableStream by draining
+    /// its currently-buffered chunks (documented subset, #1029). Mirrors
+    /// <c>ReadableStream.from(readable.toArray())</c>.
+    /// </summary>
+    private static RuntimeValue ToWeb(Interp interpreter, RuntimeValue receiver, ReadOnlySpan<RuntimeValue> args)
+    {
+        var ws = new SharpTSReadableStream(interpreter, underlyingSource: null, strategy: null);
+        if (args.Length > 0 && args[0].ToObject() is SharpTSReadable r)
+        {
+            foreach (var chunk in r.DrainBufferToList())
+                ws.EnqueueInternal(chunk);
+        }
+        ws.CloseInternal();
+        return RuntimeValue.FromObject(ws);
+    }
+
+    /// <summary>
+    /// Readable.fromWeb(readableStream) — converts a WHATWG ReadableStream to a Node Readable by
+    /// draining its currently-queued chunks (documented subset, #1029).
+    /// </summary>
+    private static RuntimeValue FromWeb(Interp interpreter, RuntimeValue receiver, ReadOnlySpan<RuntimeValue> args)
+    {
+        var stream = new SharpTSReadable { ObjectMode = true };
+        if (args.Length > 0 && args[0].ToObject() is SharpTSReadableStream ws)
+        {
+            while (ws.Queue.Count > 0)
+                stream.PushFromHost(interpreter, ws.Queue.Dequeue().Value);
+        }
+        stream.PushFromHost(interpreter, null); // EOF
+        return RuntimeValue.FromObject(stream);
     }
 
     /// <summary>

--- a/Runtime/Types/SharpTSWritable.cs
+++ b/Runtime/Types/SharpTSWritable.cs
@@ -27,6 +27,12 @@ public class SharpTSWritable : SharpTSEventEmitter
     private bool _needDrain;
     private bool _objectMode;
     private bool _autoDestroy;
+    private bool _errored;
+
+    /// <summary>
+    /// Whether this stream has errored — backs stream.isErrored (#1030).
+    /// </summary>
+    public bool Errored => _errored;
 
     /// <summary>
     /// Gets or sets whether this stream operates in object mode.
@@ -373,6 +379,7 @@ public class SharpTSWritable : SharpTSEventEmitter
 
     private void EmitError(Interp interpreter, object? error)
     {
+        _errored = true;
         EmitEvent(interpreter, "error", [error]);
     }
 

--- a/SharpTS.Tests/SharedTests/BuiltInModules/StreamModuleTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/StreamModuleTests.cs
@@ -1600,6 +1600,51 @@ public class StreamModuleTests
         Assert.Equal("true\n", output);
     }
 
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Stream_AddAbortSignal_DestroysOnAbort(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import { Readable, addAbortSignal } from 'stream';
+                const r = new Readable();
+                const ac = new AbortController();
+                addAbortSignal(ac.signal, r);
+                const events: string[] = [];
+                r.on('error', (e: any) => events.push('error:' + (e.name ?? e)));
+                r.on('close', () => events.push('close'));
+                ac.abort();
+                console.log(events.join(','), r.destroyed);
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("error:AbortError,close true\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Stream_AddAbortSignal_AlreadyAborted_DestroysImmediately(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import { Readable, addAbortSignal } from 'stream';
+                const r = new Readable();
+                const ac = new AbortController();
+                ac.abort();
+                const events: string[] = [];
+                r.on('error', (e: any) => events.push('error:' + (e.name ?? e)));
+                addAbortSignal(ac.signal, r);
+                console.log(events.join(','), r.destroyed);
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("error:AbortError true\n", output);
+    }
+
     #endregion
 
     #region Async iteration (Symbol.asyncIterator) — #1024

--- a/SharpTS.Tests/SharedTests/BuiltInModules/StreamModuleTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/StreamModuleTests.cs
@@ -1581,4 +1581,135 @@ public class StreamModuleTests
     }
 
     #endregion
+
+    #region Async iteration (Symbol.asyncIterator) — #1024
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Readable_AsyncIterator_SyncProducer(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import { Readable } from 'stream';
+                async function main(): Promise<void> {
+                    const r = new Readable({ objectMode: true });
+                    r.push(1); r.push(2); r.push(3); r.push(null);
+                    const out: number[] = [];
+                    for await (const x of r) { out.push(x); }
+                    console.log(out.join(','));
+                }
+                main();
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("1,2,3\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Readable_AsyncIterator_SlowProducer(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import { Readable } from 'stream';
+                async function main(): Promise<void> {
+                    const r = new Readable({ objectMode: true });
+                    let i = 0;
+                    const t = setInterval(() => {
+                        i++;
+                        if (i <= 3) { r.push(i * 10); }
+                        else { r.push(null); clearInterval(t); }
+                    }, 5);
+                    const out: number[] = [];
+                    for await (const x of r) { out.push(x); }
+                    console.log(out.join(','));
+                }
+                main();
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("10,20,30\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Readable_AsyncIterator_EarlyBreak_Destroys(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import { Readable } from 'stream';
+                async function main(): Promise<void> {
+                    const r = new Readable({ objectMode: true });
+                    r.push('a'); r.push('b'); r.push('c'); r.push(null);
+                    const out: string[] = [];
+                    for await (const x of r) { out.push(x); if (out.length === 2) break; }
+                    console.log(out.join(','), r.destroyed);
+                }
+                main();
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("a,b true\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Readable_AsyncIterator_ErrorRejects(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import { Readable } from 'stream';
+                async function main(): Promise<void> {
+                    const r = new Readable({ objectMode: true });
+                    let i = 0;
+                    const t = setInterval(() => {
+                        i++;
+                        if (i === 1) { r.push('x'); }
+                        else { r.destroy(new Error('boom')); clearInterval(t); }
+                    }, 5);
+                    try {
+                        for await (const x of r) { console.log('got', x); }
+                        console.log('no error');
+                    } catch (e: any) {
+                        console.log('caught:', e.message ?? e);
+                    }
+                }
+                main();
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("got x\ncaught: boom\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Readable_AsyncIterator_FromArray(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import { Readable } from 'stream';
+                async function main(): Promise<void> {
+                    const r = Readable.from([10, 20, 30]);
+                    let sum = 0;
+                    for await (const x of r) { sum += x; }
+                    console.log(sum);
+                }
+                main();
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("60\n", output);
+    }
+
+    #endregion
 }

--- a/SharpTS.Tests/SharedTests/BuiltInModules/StreamModuleTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/StreamModuleTests.cs
@@ -1922,4 +1922,68 @@ public class StreamModuleTests
     }
 
     #endregion
+
+    #region isErrored + get/setDefaultHighWaterMark + prefinish ordering — #1030
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Stream_IsErrored(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import { Readable, isErrored } from 'stream';
+                const r = new Readable();
+                r.on('error', () => {});
+                console.log(isErrored(r));
+                r.destroy(new Error('boom'));
+                console.log(isErrored(r));
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("false\ntrue\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Stream_DefaultHighWaterMark_GetSet(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import { getDefaultHighWaterMark, setDefaultHighWaterMark } from 'stream';
+                console.log(getDefaultHighWaterMark(false));
+                console.log(getDefaultHighWaterMark(true));
+                setDefaultHighWaterMark(true, 99);
+                console.log(getDefaultHighWaterMark(true));
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("16384\n16\n99\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Stream_PrefinishFinishOrdering(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import { Writable } from 'stream';
+                const w = new Writable({ write(c: any, e: any, cb: any) { cb(); } });
+                const order: string[] = [];
+                w.on('prefinish', () => order.push('prefinish'));
+                w.on('finish', () => order.push('finish'));
+                w.end();
+                console.log(order.join(','));
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("prefinish,finish\n", output);
+    }
+
+    #endregion
 }

--- a/SharpTS.Tests/SharedTests/BuiltInModules/StreamModuleTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/StreamModuleTests.cs
@@ -1873,4 +1873,53 @@ public class StreamModuleTests
     }
 
     #endregion
+
+    #region compose + Duplex.from — #1028
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Stream_Compose_TransformChain(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import { compose, Transform } from 'stream';
+                const up = new Transform({ objectMode: true, transform(c: any, e: any, cb: any) { cb(null, String(c).toUpperCase()); } });
+                const bang = new Transform({ objectMode: true, transform(c: any, e: any, cb: any) { cb(null, c + '!'); } });
+                const composed = compose(up, bang);
+                const out: string[] = [];
+                composed.on('data', (d: any) => out.push(d));
+                composed.write('a');
+                composed.write('b');
+                console.log(out.join(','));
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("A!,B!\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Stream_DuplexFrom_Iterable(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import { Duplex } from 'stream';
+                async function main(): Promise<void> {
+                    const d = Duplex.from([1, 2, 3]);
+                    const got: number[] = [];
+                    for await (const x of d) got.push(x);
+                    console.log(got.join(','));
+                }
+                main();
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("1,2,3\n", output);
+    }
+
+    #endregion
 }

--- a/SharpTS.Tests/SharedTests/BuiltInModules/StreamModuleTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/StreamModuleTests.cs
@@ -1986,4 +1986,55 @@ public class StreamModuleTests
     }
 
     #endregion
+
+    #region Node↔Web conversions (toWeb/fromWeb) — #1029 (interpreter-only documented subset)
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void Stream_Readable_ToWeb(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import { Readable } from 'stream';
+                async function main(): Promise<void> {
+                    const r = new Readable({ objectMode: true });
+                    r.push('a'); r.push('b'); r.push(null);
+                    const web = Readable.toWeb(r);
+                    const got: string[] = [];
+                    for await (const c of web) got.push(c);
+                    console.log(got.join(','));
+                }
+                main();
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("a,b\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void Stream_Readable_FromWeb(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import { Readable } from 'stream';
+                async function main(): Promise<void> {
+                    const ws = new ReadableStream({ start(c: any) { c.enqueue(1); c.enqueue(2); c.enqueue(3); c.close(); } });
+                    const node = Readable.fromWeb(ws);
+                    const got: number[] = [];
+                    for await (const x of node) got.push(x);
+                    console.log(got.join(','));
+                }
+                main();
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("1,2,3\n", output);
+    }
+
+    #endregion
 }

--- a/SharpTS.Tests/SharedTests/BuiltInModules/StreamModuleTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/StreamModuleTests.cs
@@ -1712,4 +1712,100 @@ public class StreamModuleTests
     }
 
     #endregion
+
+    #region Async iterator helpers (reduce/some/every/find/flatMap/drop/take/asIndexedPairs) — #1025
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Readable_Helper_ReduceSomeEveryFind(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import { Readable } from 'stream';
+                async function main(): Promise<void> {
+                    const mk = () => { const r = new Readable({ objectMode: true }); [1, 2, 3, 4].forEach(x => r.push(x)); r.push(null); return r; };
+                    console.log(await mk().reduce((a: number, x: number) => a + x, 0));
+                    console.log(await mk().reduce((a: number, x: number) => a + x));
+                    console.log(await mk().some((x: number) => x > 3));
+                    console.log(await mk().some((x: number) => x > 9));
+                    console.log(await mk().every((x: number) => x > 0));
+                    console.log(await mk().every((x: number) => x > 2));
+                    console.log(await mk().find((x: number) => x > 2));
+                    console.log(await mk().find((x: number) => x > 9));
+                }
+                main();
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("10\n10\ntrue\nfalse\ntrue\nfalse\n3\nundefined\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Readable_Helper_DropTake(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import { Readable } from 'stream';
+                async function main(): Promise<void> {
+                    const mk = () => { const r = new Readable({ objectMode: true }); [1, 2, 3, 4, 5].forEach(x => r.push(x)); r.push(null); return r; };
+                    console.log((await mk().drop(2).toArray()).join(','));
+                    console.log((await mk().take(2).toArray()).join(','));
+                }
+                main();
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("3,4,5\n1,2\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Readable_Helper_FlatMap(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import { Readable } from 'stream';
+                async function main(): Promise<void> {
+                    const r = new Readable({ objectMode: true });
+                    [1, 2, 3].forEach(x => r.push(x)); r.push(null);
+                    const out = await r.flatMap((x: number) => [x, x * 10]).toArray();
+                    console.log(out.join(','));
+                }
+                main();
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("1,10,2,20,3,30\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Readable_Helper_AsIndexedPairs(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import { Readable } from 'stream';
+                async function main(): Promise<void> {
+                    const r = new Readable({ objectMode: true });
+                    ['a', 'b', 'c'].forEach(x => r.push(x)); r.push(null);
+                    const out = await r.asIndexedPairs().toArray();
+                    console.log(out.map((p: any) => '[' + p[0] + ',' + p[1] + ']').join(''));
+                }
+                main();
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("[0,a][1,b][2,c]\n", output);
+    }
+
+    #endregion
 }

--- a/SharpTS.Tests/SharedTests/BuiltInModules/StreamModuleTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/StreamModuleTests.cs
@@ -1557,6 +1557,26 @@ public class StreamModuleTests
         Assert.Contains("6,8", output);
     }
 
+    // #1026: `Readable.prototype.map` must return a Transform stream, NOT an array — i.e. the
+    // call must dispatch to $Readable.Map, not the Array/Iterator map emitter. Verifies parity.
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Stream_Readable_Map_ReturnsStream_NotArray(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import { Readable } from 'stream';
+                const r = new Readable({ objectMode: true });
+                const m = r.map((x: any) => x * 2);
+                console.log(typeof m, typeof m.pipe, Array.isArray(m));
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("object function false\n", output);
+    }
+
     #endregion
 
     #region addAbortSignal

--- a/TypeSystem/BuiltInModuleTypes.cs
+++ b/TypeSystem/BuiltInModuleTypes.cs
@@ -1806,7 +1806,21 @@ public static class BuiltInModuleTypes
             ["toArray"] = new TypeInfo.Function([], new TypeInfo.Array(anyType)),
             ["forEach"] = new TypeInfo.Function([anyType], voidType),
             ["map"] = new TypeInfo.Function([anyType], anyType),
-            ["filter"] = new TypeInfo.Function([anyType], anyType)
+            ["filter"] = new TypeInfo.Function([anyType], anyType),
+
+            // Async-iterator helpers (#1025): consuming helpers return Promises,
+            // transform-returning helpers (drop/take/flatMap/asIndexedPairs) return a stream.
+            ["reduce"] = new TypeInfo.Function([anyType, anyType], new TypeInfo.Promise(anyType), RequiredParams: 1),
+            ["some"] = new TypeInfo.Function([anyType], new TypeInfo.Promise(boolType)),
+            ["every"] = new TypeInfo.Function([anyType], new TypeInfo.Promise(boolType)),
+            ["find"] = new TypeInfo.Function([anyType], new TypeInfo.Promise(anyType)),
+            ["flatMap"] = new TypeInfo.Function([anyType], anyType),
+            ["drop"] = new TypeInfo.Function([numberType], anyType),
+            ["take"] = new TypeInfo.Function([numberType], anyType),
+            ["asIndexedPairs"] = new TypeInfo.Function([], anyType),
+
+            // Async-iterable surface (#1024): `for await (const x of readable)`.
+            ["@@asyncIterator"] = new TypeInfo.Function([], anyType)
         }.ToFrozenDictionary());
 
         // Readable constructor with static methods

--- a/TypeSystem/BuiltInModuleTypes.cs
+++ b/TypeSystem/BuiltInModuleTypes.cs
@@ -1869,7 +1869,10 @@ public static class BuiltInModuleTypes
         // Duplex constructor
         var duplexConstructorType = new TypeInfo.Interface(
             Name: "Duplex",
-            Members: new Dictionary<string, TypeInfo>().ToFrozenDictionary(),
+            Members: new Dictionary<string, TypeInfo>
+            {
+                ["from"] = new TypeInfo.Function([anyType, anyType], streamInstanceType, RequiredParams: 1)
+            }.ToFrozenDictionary(),
             OptionalMembers: FrozenSet<string>.Empty,
             ConstructorSignatures:
             [
@@ -1929,6 +1932,9 @@ public static class BuiltInModuleTypes
         // addAbortSignal function type
         var addAbortSignalType = new TypeInfo.Function([anyType, anyType], anyType);
 
+        // compose function type (#1028): compose(...streams) → Duplex
+        var composeType = new TypeInfo.Function([anyType], streamInstanceType, RequiredParams: 1, HasRestParam: true);
+
         // promises sub-module
         var promisesType = new TypeInfo.Record(new Dictionary<string, TypeInfo>
         {
@@ -1946,6 +1952,7 @@ public static class BuiltInModuleTypes
             ["finished"] = finishedType,
             ["pipeline"] = pipelineType,
             ["addAbortSignal"] = addAbortSignalType,
+            ["compose"] = composeType,
             ["promises"] = promisesType
         };
     }

--- a/TypeSystem/BuiltInModuleTypes.cs
+++ b/TypeSystem/BuiltInModuleTypes.cs
@@ -1829,7 +1829,9 @@ public static class BuiltInModuleTypes
             Members: new Dictionary<string, TypeInfo>
             {
                 ["from"] = new TypeInfo.Function([anyType, anyType], streamInstanceType, RequiredParams: 1),
-                ["isReadable"] = new TypeInfo.Function([anyType], boolType)
+                ["isReadable"] = new TypeInfo.Function([anyType], boolType),
+                ["toWeb"] = new TypeInfo.Function([anyType], anyType),     // #1029
+                ["fromWeb"] = new TypeInfo.Function([anyType], streamInstanceType) // #1029
             }.ToFrozenDictionary(),
             OptionalMembers: FrozenSet<string>.Empty,
             ConstructorSignatures:

--- a/TypeSystem/BuiltInModuleTypes.cs
+++ b/TypeSystem/BuiltInModuleTypes.cs
@@ -1935,6 +1935,11 @@ public static class BuiltInModuleTypes
         // compose function type (#1028): compose(...streams) → Duplex
         var composeType = new TypeInfo.Function([anyType], streamInstanceType, RequiredParams: 1, HasRestParam: true);
 
+        // #1030 statics
+        var isErroredType = new TypeInfo.Function([anyType], boolType);
+        var getDefaultHwmType = new TypeInfo.Function([boolType], numberType, RequiredParams: 0);
+        var setDefaultHwmType = new TypeInfo.Function([boolType, numberType], voidType);
+
         // promises sub-module
         var promisesType = new TypeInfo.Record(new Dictionary<string, TypeInfo>
         {
@@ -1953,6 +1958,9 @@ public static class BuiltInModuleTypes
             ["pipeline"] = pipelineType,
             ["addAbortSignal"] = addAbortSignalType,
             ["compose"] = composeType,
+            ["isErrored"] = isErroredType,
+            ["getDefaultHighWaterMark"] = getDefaultHwmType,
+            ["setDefaultHighWaterMark"] = setDefaultHwmType,
             ["promises"] = promisesType
         };
     }


### PR DESCRIPTION
Completes epic #1023 — brings `node:stream`'s generic classes to (near) 100% Node compatibility with **interpreter ↔ compiled parity**. Every new API is implemented in both modes (compiled = BCL-only emitted IL, **standalone preserved**, `--verify` clean) with dual-mode tests, except the explicitly-blocked Web conversions which ship a documented interpreter subset.

Node target: 24.15.0. **xUnit 14601/0**, **Test262** and **TypeScriptConformance** green (no baseline drift).

## Children

- **#1024 — `Symbol.asyncIterator` on Readable** (`for await…of stream`). Both modes. Yields buffered chunks one at a time, settles `done` on `end`, rejects on `destroy(err)`, parks a pending pull for a slow/async producer; early `break` destroys the stream (AsyncIteratorClose). Compiled surfaces `GetAsyncIterator` via a `GetIteratorFunction` hook so the existing `EmitForAwaitOf` protocol drives it.
- **#1025 — async iterator helpers** `reduce`/`some`/`every`/`find` (consuming → resolved Promise, early-exit) + `flatMap`/`drop`/`take`/`asIndexedPairs` (lazy → a new Readable). Both modes, buffer-based (consistent with the existing `toArray`/`forEach`).
- **#1026 — compiled `$Readable` map/filter/forEach/toArray parity.** Already defined on `$Readable`; added a guard test proving `r.map(fn)` returns a Transform stream (not routed to the Array/Iterator emitters) in both modes.
- **#1027 — real `addAbortSignal(signal, stream)`.** Replaces the no-op stubs: destroys the stream with an `AbortError` on abort (or immediately if already aborted), in both modes. Compiled wires through the #985 AbortSignal listener path.
- **#1028 — `compose(...streams)` + `Duplex.from(source)`.** Both modes. `compose` pipes the streams and returns a Duplex (write→first, last→readable) via a `$StreamComposeBridge` closure; `Duplex.from` mirrors `Readable.from`.
- **#1029 — `Readable.toWeb`/`fromWeb`** (the genuinely-blocked child). Ships the achievable **interpreter documented subset** (buffer transfer); compiled throws a clear deferral error rather than failing silently. Writable/Duplex conversions + full streaming remain deferred pending the DEFERRED `stream/web` async-iterator/BYOB work.
- **#1030 — `isErrored` + `get/setDefaultHighWaterMark` + prefinish ordering.** New statics in both modes; verified `prefinish→finish→close` ordering. `construct`/`decodeStrings` ctor options are gracefully accepted; the `signal` ctor option is deferred in favor of the equivalent dual-mode `addAbortSignal`.
- **#1031 — type-surface additions + polish.** Each new method/static has a type-checker entry in `GetStreamModuleTypes` (`@@asyncIterator`, the 8 helpers, `compose`, `Duplex.from`, `isErrored`, default-hwm, `Readable.toWeb/fromWeb`); idiomatic usage type-checks; no conformance drift.

## Constraints

- ✅ Green on `dotnet test` (14601/0), `SharpTS.Test262`, `SharpTS.TypeScriptConformance`.
- ✅ Standalone preserved — all new compiled code is BCL-only emitted IL (reflection-IL helpers; `--verify` clean; DLLs run without SharpTS.dll).
- ✅ Interpreter and compiled agree — dual-mode tests for every new API (except #1029's interpreter-only subset, which is documented and fails loudly in compiled).

Closes #1024, #1025, #1026, #1027, #1028, #1029, #1030, #1031. Part of #1023.