### PR TITLE
Epic #1042: Node http/https — real ClientRequest, server lifecycle, https-over-TLS (interp ↔ compiled)

### DIFF
--- a/Compilation/EmittedRuntime.cs
+++ b/Compilation/EmittedRuntime.cs
@@ -2004,6 +2004,10 @@ public class EmittedRuntime
     public MethodBuilder HttpRequest { get; set; } = null!;
     public MethodBuilder HttpGet { get; set; } = null!;
     public MethodBuilder HttpGetMethods { get; set; } = null!;
+    // #1052 utilities
+    public MethodBuilder HttpValidateHeaderName { get; set; } = null!;
+    public MethodBuilder HttpValidateHeaderValue { get; set; } = null!;
+    public MethodBuilder HttpSetMaxIdleParsers { get; set; } = null!;
     public MethodBuilder HttpGetStatusCodes { get; set; } = null!;
     public MethodBuilder HttpGetGlobalAgent { get; set; } = null!;
     public MethodBuilder HttpGetAgentConstructor { get; set; } = null!;

--- a/Compilation/Emitters/Modules/HttpModuleEmitter.cs
+++ b/Compilation/Emitters/Modules/HttpModuleEmitter.cs
@@ -27,7 +27,11 @@ public sealed class HttpModuleEmitter : IBuiltInModuleEmitter
         "METHODS",
         "STATUS_CODES",
         "globalAgent",
-        "Agent"
+        "Agent",
+        "validateHeaderName",
+        "validateHeaderValue",
+        "setMaxIdleHTTPParsers",
+        "maxHeaderSize"
     ];
 
     public IReadOnlyList<string> GetExportedMembers() => _exportedMembers;
@@ -39,6 +43,9 @@ public sealed class HttpModuleEmitter : IBuiltInModuleEmitter
             "createServer" => EmitCreateServer(emitter, arguments),
             "request" => EmitRequest(emitter, arguments),
             "get" => EmitGet(emitter, arguments),
+            "validateHeaderName" => EmitUtilCall(emitter, arguments, emitter.Context.Runtime!.HttpValidateHeaderName, 1),
+            "validateHeaderValue" => EmitUtilCall(emitter, arguments, emitter.Context.Runtime!.HttpValidateHeaderValue, 2),
+            "setMaxIdleHTTPParsers" => EmitUtilCall(emitter, arguments, emitter.Context.Runtime!.HttpSetMaxIdleParsers, 1),
             _ => false
         };
     }
@@ -51,8 +58,43 @@ public sealed class HttpModuleEmitter : IBuiltInModuleEmitter
             "STATUS_CODES" => EmitStatusCodes(emitter),
             "globalAgent" => EmitGlobalAgent(emitter),
             "Agent" => EmitAgentConstructor(emitter),
+            "maxHeaderSize" => EmitMaxHeaderSize(emitter),
             _ => false
         };
+    }
+
+    /// <summary>
+    /// Emits a call to a $Runtime header-utility helper, padding/truncating to argCount object args.
+    /// </summary>
+    private static bool EmitUtilCall(IEmitterContext emitter, List<Expr> arguments,
+        System.Reflection.Emit.MethodBuilder target, int argCount)
+    {
+        var ctx = emitter.Context;
+        var il = ctx.IL;
+        for (int i = 0; i < argCount; i++)
+        {
+            if (i < arguments.Count)
+            {
+                emitter.EmitExpression(arguments[i]);
+                emitter.EmitBoxIfNeeded(arguments[i]);
+            }
+            else
+            {
+                il.Emit(OpCodes.Ldnull);
+            }
+        }
+        il.Emit(OpCodes.Call, target);
+        emitter.SetStackUnknown();
+        return true;
+    }
+
+    private static bool EmitMaxHeaderSize(IEmitterContext emitter)
+    {
+        var il = emitter.Context.IL;
+        il.Emit(OpCodes.Ldc_R8, 16384.0);
+        il.Emit(OpCodes.Box, emitter.Context.Types.Double);
+        emitter.SetStackUnknown();
+        return true;
     }
 
     private static bool EmitCreateServer(IEmitterContext emitter, List<Expr> arguments)
@@ -186,5 +228,5 @@ public sealed class HttpModuleEmitter : IBuiltInModuleEmitter
     }
 
     public bool IsExportedProperty(string memberName) => memberName is
-        "METHODS" or "STATUS_CODES" or "globalAgent" or "Agent";
+        "METHODS" or "STATUS_CODES" or "globalAgent" or "Agent" or "maxHeaderSize";
 }

--- a/Compilation/RuntimeEmitter.Http.cs
+++ b/Compilation/RuntimeEmitter.Http.cs
@@ -97,6 +97,7 @@ public partial class RuntimeEmitter
         EmitHttpRequest(typeBuilder, runtime);
         EmitHttpGet(typeBuilder, runtime);
         EmitHttpGetMethods(typeBuilder, runtime);
+        EmitHttpHeaderUtilities(typeBuilder, runtime);
         EmitHttpGetStatusCodes(typeBuilder, runtime);
         EmitAgentHelperMethods(typeBuilder, runtime);
         EmitHttpGetGlobalAgent(typeBuilder, runtime);
@@ -2828,8 +2829,15 @@ public partial class RuntimeEmitter
 
         var il = method.GetILGenerator();
 
-        // Create array with common HTTP methods
-        string[] methods = ["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS", "CONNECT", "TRACE"];
+        // Full Node 24 http.METHODS list (kept in sync with HttpModuleInterpreter.GetMethods).
+        string[] methods =
+        [
+            "ACL", "BIND", "CHECKOUT", "CONNECT", "COPY", "DELETE", "GET", "HEAD",
+            "LINK", "LOCK", "M-SEARCH", "MERGE", "MKACTIVITY", "MKCALENDAR", "MKCOL",
+            "MOVE", "NOTIFY", "OPTIONS", "PATCH", "POST", "PROPFIND", "PROPPATCH",
+            "PURGE", "PUT", "REBIND", "REPORT", "SEARCH", "SOURCE", "SUBSCRIBE",
+            "TRACE", "UNBIND", "UNLINK", "UNLOCK", "UNSUBSCRIBE"
+        ];
 
         il.Emit(OpCodes.Ldc_I4, methods.Length);
         il.Emit(OpCodes.Newarr, _types.Object);
@@ -2845,6 +2853,100 @@ public partial class RuntimeEmitter
         // Wrap in $Array
         il.Emit(OpCodes.Call, runtime.CreateArray);
         il.Emit(OpCodes.Ret);
+    }
+
+    /// <summary>
+    /// Emits the #1052 header utilities: validateHeaderName / validateHeaderValue (Regex-based,
+    /// throwing guest TypeErrors with the Node error codes) and setMaxIdleHTTPParsers (no-op).
+    /// Pure BCL (Regex) — standalone-safe.
+    /// </summary>
+    private void EmitHttpHeaderUtilities(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    {
+        var regexType = typeof(System.Text.RegularExpressions.Regex);
+        var isMatch = regexType.GetMethod("IsMatch", [_types.String, _types.String])!;
+        var objToString = _types.Object.GetMethod("ToString", Type.EmptyTypes)!;
+
+        void EmitThrowTypeError(ILGenerator il, string message, string code)
+        {
+            il.Emit(OpCodes.Ldstr, message);
+            il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
+            il.Emit(OpCodes.Dup);
+            il.Emit(OpCodes.Ldstr, code);
+            il.Emit(OpCodes.Callvirt, runtime.TSErrorCodeSetter);
+            il.Emit(OpCodes.Call, runtime.CreateException);
+            il.Emit(OpCodes.Throw);
+        }
+
+        // object HttpValidateHeaderName(object name)
+        var vn = typeBuilder.DefineMethod("HttpValidateHeaderName",
+            MethodAttributes.Public | MethodAttributes.Static, _types.Object, [_types.Object]);
+        runtime.HttpValidateHeaderName = vn;
+        {
+            var il = vn.GetILGenerator();
+            var sLocal = il.DeclareLocal(_types.String);
+            var okLabel = il.DefineLabel();
+            var throwLabel = il.DefineLabel();
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Isinst, _types.String);
+            il.Emit(OpCodes.Stloc, sLocal);
+            il.Emit(OpCodes.Ldloc, sLocal);
+            il.Emit(OpCodes.Brfalse, throwLabel);
+            il.Emit(OpCodes.Ldloc, sLocal);
+            il.Emit(OpCodes.Ldstr, "^[A-Za-z0-9!#$%&'*+.^_`|~-]+$");
+            il.Emit(OpCodes.Call, isMatch);
+            il.Emit(OpCodes.Brtrue, okLabel);
+            il.MarkLabel(throwLabel);
+            EmitThrowTypeError(il, "Header name must be a valid HTTP token", "ERR_INVALID_HTTP_TOKEN");
+            il.MarkLabel(okLabel);
+            il.Emit(OpCodes.Ldsfld, runtime.UndefinedInstance);
+            il.Emit(OpCodes.Ret);
+        }
+
+        // object HttpValidateHeaderValue(object name, object value)
+        var vv = typeBuilder.DefineMethod("HttpValidateHeaderValue",
+            MethodAttributes.Public | MethodAttributes.Static, _types.Object, [_types.Object, _types.Object]);
+        runtime.HttpValidateHeaderValue = vv;
+        {
+            var il = vv.GetILGenerator();
+            var vstr = il.DeclareLocal(_types.String);
+            var throwUndef = il.DefineLabel();
+            var throwChar = il.DefineLabel();
+            var okLabel = il.DefineLabel();
+            // value == null → throw ERR_HTTP_INVALID_HEADER_VALUE
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Brfalse, throwUndef);
+            // value is Undefined → throw
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Isinst, runtime.UndefinedType);
+            il.Emit(OpCodes.Brtrue, throwUndef);
+            // vstr = value.ToString()
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Callvirt, objToString);
+            il.Emit(OpCodes.Stloc, vstr);
+            // if (Regex.IsMatch(vstr, invalidPattern)) throw ERR_INVALID_CHAR
+            il.Emit(OpCodes.Ldloc, vstr);
+            il.Emit(OpCodes.Ldstr, "[\\u0000-\\u0008\\u000A-\\u001F\\u007F]");
+            il.Emit(OpCodes.Call, isMatch);
+            il.Emit(OpCodes.Brtrue, throwChar);
+            il.Emit(OpCodes.Br, okLabel);
+            il.MarkLabel(throwUndef);
+            EmitThrowTypeError(il, "Invalid value \"undefined\" for header", "ERR_HTTP_INVALID_HEADER_VALUE");
+            il.MarkLabel(throwChar);
+            EmitThrowTypeError(il, "Invalid character in header content", "ERR_INVALID_CHAR");
+            il.MarkLabel(okLabel);
+            il.Emit(OpCodes.Ldsfld, runtime.UndefinedInstance);
+            il.Emit(OpCodes.Ret);
+        }
+
+        // object HttpSetMaxIdleParsers(object max) — no-op
+        var sp = typeBuilder.DefineMethod("HttpSetMaxIdleParsers",
+            MethodAttributes.Public | MethodAttributes.Static, _types.Object, [_types.Object]);
+        runtime.HttpSetMaxIdleParsers = sp;
+        {
+            var il = sp.GetILGenerator();
+            il.Emit(OpCodes.Ldsfld, runtime.UndefinedInstance);
+            il.Emit(OpCodes.Ret);
+        }
     }
 
     /// <summary>

--- a/Compilation/RuntimeEmitter.TSHttpServer.cs
+++ b/Compilation/RuntimeEmitter.TSHttpServer.cs
@@ -378,8 +378,33 @@ public partial class RuntimeEmitter
         EmitHttpResponseRemoveHeader(typeBuilder, runtime, httpListenerResponseType);
         EmitHttpResponseGetMember(typeBuilder, runtime, httpListenerResponseType);
         EmitHttpResponseSetMember(typeBuilder, runtime, httpListenerResponseType);
+        EmitHttpResponseExtraMembers(typeBuilder, runtime);
 
         typeBuilder.CreateType();
+    }
+
+    /// <summary>
+    /// Emits the ServerResponse completeness surface (#1047): writeContinue/writeProcessing/
+    /// addTrailers/flushHeaders (reflection-dispatched PascalCase methods). HttpListener
+    /// auto-sends 100-continue and has no trailer/1xx API, so these are compatibility no-ops
+    /// (matching the interpreter).
+    /// </summary>
+    private void EmitHttpResponseExtraMembers(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    {
+        void EmitUndefMethod(string name, int argCount)
+        {
+            var paramTypes = new Type[argCount];
+            for (int i = 0; i < argCount; i++) paramTypes[i] = _types.Object;
+            var m = typeBuilder.DefineMethod(name, MethodAttributes.Public, _types.Object, paramTypes);
+            var mil = m.GetILGenerator();
+            mil.Emit(OpCodes.Ldsfld, runtime.UndefinedInstance);
+            mil.Emit(OpCodes.Ret);
+        }
+
+        EmitUndefMethod("WriteContinue", 0);
+        EmitUndefMethod("WriteProcessing", 0);
+        EmitUndefMethod("AddTrailers", 1);
+        EmitUndefMethod("FlushHeaders", 0);
     }
 
     private void EmitHttpResponseGetMember(TypeBuilder typeBuilder, EmittedRuntime runtime, Type httpListenerResponseType)
@@ -397,6 +422,8 @@ public partial class RuntimeEmitter
         var statusCodeLabel = il.DefineLabel();
         var headersSentLabel = il.DefineLabel();
         var finishedLabel = il.DefineLabel();
+        var statusMessageLabel = il.DefineLabel();
+        var sendDateLabel = il.DefineLabel();
         var defaultLabel = il.DefineLabel();
 
         // Check property names
@@ -414,6 +441,16 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldstr, "finished");
         il.Emit(OpCodes.Call, _types.String.GetMethod("Equals", [_types.String])!);
         il.Emit(OpCodes.Brtrue, finishedLabel);
+
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Ldstr, "statusMessage");
+        il.Emit(OpCodes.Call, _types.String.GetMethod("Equals", [_types.String])!);
+        il.Emit(OpCodes.Brtrue, statusMessageLabel);
+
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Ldstr, "sendDate");
+        il.Emit(OpCodes.Call, _types.String.GetMethod("Equals", [_types.String])!);
+        il.Emit(OpCodes.Brtrue, sendDateLabel);
 
         il.Emit(OpCodes.Br, defaultLabel);
 
@@ -440,6 +477,19 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Box, _types.Boolean);
         il.Emit(OpCodes.Ret);
 
+        // statusMessage - _response.StatusDescription
+        il.MarkLabel(statusMessageLabel);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, _httpResponseResponseField);
+        il.Emit(OpCodes.Callvirt, httpListenerResponseType.GetProperty("StatusDescription")!.GetGetMethod()!);
+        il.Emit(OpCodes.Ret);
+
+        // sendDate - true (HttpListener always sends Date)
+        il.MarkLabel(sendDateLabel);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Box, _types.Boolean);
+        il.Emit(OpCodes.Ret);
+
         // default - return undefined
         il.MarkLabel(defaultLabel);
         il.Emit(OpCodes.Ldsfld, runtime.UndefinedInstance);
@@ -459,6 +509,7 @@ public partial class RuntimeEmitter
         var il = method.GetILGenerator();
 
         var statusCodeLabel = il.DefineLabel();
+        var statusMessageLabel = il.DefineLabel();
         var endLabel = il.DefineLabel();
 
         // Check "statusCode"
@@ -466,6 +517,12 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldstr, "statusCode");
         il.Emit(OpCodes.Call, _types.String.GetMethod("Equals", [_types.String])!);
         il.Emit(OpCodes.Brtrue, statusCodeLabel);
+
+        // Check "statusMessage"
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Ldstr, "statusMessage");
+        il.Emit(OpCodes.Call, _types.String.GetMethod("Equals", [_types.String])!);
+        il.Emit(OpCodes.Brtrue, statusMessageLabel);
 
         il.Emit(OpCodes.Br, endLabel);
 
@@ -482,6 +539,20 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Conv_I4);
         il.Emit(OpCodes.Callvirt, httpListenerResponseType.GetProperty("StatusCode")!.GetSetMethod()!);
         il.MarkLabel(notDoubleLabel);
+        il.Emit(OpCodes.Br, endLabel);
+
+        // statusMessage = (string)value
+        il.MarkLabel(statusMessageLabel);
+        il.Emit(OpCodes.Ldarg_2);
+        il.Emit(OpCodes.Isinst, _types.String);
+        var notStringLabel = il.DefineLabel();
+        il.Emit(OpCodes.Brfalse, notStringLabel);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, _httpResponseResponseField);
+        il.Emit(OpCodes.Ldarg_2);
+        il.Emit(OpCodes.Castclass, _types.String);
+        il.Emit(OpCodes.Callvirt, httpListenerResponseType.GetProperty("StatusDescription")!.GetSetMethod()!);
+        il.MarkLabel(notStringLabel);
 
         il.MarkLabel(endLabel);
         il.Emit(OpCodes.Ret);

--- a/Compilation/RuntimeEmitter.TSHttpServer.cs
+++ b/Compilation/RuntimeEmitter.TSHttpServer.cs
@@ -127,7 +127,73 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Call, _types.String.GetMethod("Equals", [_types.String])!);
         il.Emit(OpCodes.Brtrue, rawHeadersLabel);
 
+        // #1048 additions: version parts, complete/aborted, trailers, socket.
+        var verMajorLabel = il.DefineLabel();
+        var verMinorLabel = il.DefineLabel();
+        var completeLabel = il.DefineLabel();
+        var abortedLabel = il.DefineLabel();
+        var trailersLabel = il.DefineLabel();
+        var rawTrailersLabel = il.DefineLabel();
+        var socketLabel = il.DefineLabel();
+
+        void Check(string n, System.Reflection.Emit.Label lbl)
+        {
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Ldstr, n);
+            il.Emit(OpCodes.Call, _types.String.GetMethod("Equals", [_types.String])!);
+            il.Emit(OpCodes.Brtrue, lbl);
+        }
+        Check("httpVersionMajor", verMajorLabel);
+        Check("httpVersionMinor", verMinorLabel);
+        Check("complete", completeLabel);
+        Check("aborted", abortedLabel);
+        Check("trailers", trailersLabel);
+        Check("rawTrailers", rawTrailersLabel);
+        Check("socket", socketLabel);
+        Check("connection", socketLabel);
+
         il.Emit(OpCodes.Br, defaultLabel);
+
+        // httpVersionMajor / httpVersionMinor
+        void EmitVersionPart(System.Reflection.Emit.Label lbl, string propName)
+        {
+            il.MarkLabel(lbl);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, _httpRequestRequestField);
+            il.Emit(OpCodes.Callvirt, httpListenerRequestType.GetProperty("ProtocolVersion")!.GetGetMethod()!);
+            il.Emit(OpCodes.Callvirt, typeof(Version).GetProperty(propName)!.GetGetMethod()!);
+            il.Emit(OpCodes.Conv_R8);
+            il.Emit(OpCodes.Box, _types.Double);
+            il.Emit(OpCodes.Ret);
+        }
+        EmitVersionPart(verMajorLabel, "Major");
+        EmitVersionPart(verMinorLabel, "Minor");
+
+        // complete / aborted → false (server request lifecycle not tracked in compiled)
+        il.MarkLabel(completeLabel);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Box, _types.Boolean);
+        il.Emit(OpCodes.Ret);
+        il.MarkLabel(abortedLabel);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Box, _types.Boolean);
+        il.Emit(OpCodes.Ret);
+
+        // trailers → empty dictionary
+        il.MarkLabel(trailersLabel);
+        il.Emit(OpCodes.Newobj, _types.GetDefaultConstructor(_types.DictionaryStringObject));
+        il.Emit(OpCodes.Ret);
+
+        // rawTrailers → empty List<object?> (Array.isArray-compatible, same shape as rawHeaders;
+        // runtime.CreateArray is not yet assigned at the $HttpRequest emit phase).
+        il.MarkLabel(rawTrailersLabel);
+        il.Emit(OpCodes.Newobj, _types.GetDefaultConstructor(_types.ListOfObject));
+        il.Emit(OpCodes.Ret);
+
+        // socket → minimal { remoteAddress, remotePort, family }
+        il.MarkLabel(socketLabel);
+        EmitHttpRequestSocket(il, runtime, httpListenerRequestType);
+        il.Emit(OpCodes.Ret);
 
         // "method" - return _request.HttpMethod
         il.MarkLabel(methodLabel);
@@ -180,6 +246,61 @@ public partial class RuntimeEmitter
         il.MarkLabel(defaultLabel);
         il.Emit(OpCodes.Ldsfld, runtime.UndefinedInstance);
         il.Emit(OpCodes.Ret);
+    }
+
+    /// <summary>
+    /// Builds a minimal request socket dictionary { remoteAddress, remotePort, family } from
+    /// HttpListenerRequest.RemoteEndPoint and leaves it on the stack (#1048).
+    /// </summary>
+    private void EmitHttpRequestSocket(ILGenerator il, EmittedRuntime runtime, Type httpListenerRequestType)
+    {
+        var dictType = _types.DictionaryStringObject;
+        var setItem = dictType.GetMethod("set_Item", [_types.String, _types.Object])!;
+        var ipEndPointType = typeof(System.Net.IPEndPoint);
+
+        var epLocal = il.DeclareLocal(ipEndPointType);
+        var dictLocal = il.DeclareLocal(dictType);
+
+        il.Emit(OpCodes.Newobj, _types.GetDefaultConstructor(dictType));
+        il.Emit(OpCodes.Stloc, dictLocal);
+
+        // ep = _request.RemoteEndPoint as IPEndPoint
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, _httpRequestRequestField);
+        il.Emit(OpCodes.Callvirt, httpListenerRequestType.GetProperty("RemoteEndPoint")!.GetGetMethod()!);
+        il.Emit(OpCodes.Isinst, ipEndPointType);
+        il.Emit(OpCodes.Stloc, epLocal);
+
+        var noEpLabel = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, epLocal);
+        il.Emit(OpCodes.Brfalse, noEpLabel);
+
+        // dict["remoteAddress"] = ep.Address.ToString()
+        il.Emit(OpCodes.Ldloc, dictLocal);
+        il.Emit(OpCodes.Ldstr, "remoteAddress");
+        il.Emit(OpCodes.Ldloc, epLocal);
+        il.Emit(OpCodes.Callvirt, ipEndPointType.GetProperty("Address")!.GetGetMethod()!);
+        il.Emit(OpCodes.Callvirt, typeof(System.Net.IPAddress).GetMethod("ToString", Type.EmptyTypes)!);
+        il.Emit(OpCodes.Callvirt, setItem);
+
+        // dict["remotePort"] = (double)ep.Port
+        il.Emit(OpCodes.Ldloc, dictLocal);
+        il.Emit(OpCodes.Ldstr, "remotePort");
+        il.Emit(OpCodes.Ldloc, epLocal);
+        il.Emit(OpCodes.Callvirt, ipEndPointType.GetProperty("Port")!.GetGetMethod()!);
+        il.Emit(OpCodes.Conv_R8);
+        il.Emit(OpCodes.Box, _types.Double);
+        il.Emit(OpCodes.Callvirt, setItem);
+
+        il.MarkLabel(noEpLabel);
+
+        // dict["family"] = "IPv4"
+        il.Emit(OpCodes.Ldloc, dictLocal);
+        il.Emit(OpCodes.Ldstr, "family");
+        il.Emit(OpCodes.Ldstr, "IPv4");
+        il.Emit(OpCodes.Callvirt, setItem);
+
+        il.Emit(OpCodes.Ldloc, dictLocal);
     }
 
     private void EmitExtractRequestHeaders(ILGenerator il, Type httpListenerRequestType)

--- a/Compilation/RuntimeEmitter.TSHttpServer.cs
+++ b/Compilation/RuntimeEmitter.TSHttpServer.cs
@@ -1051,7 +1051,75 @@ public partial class RuntimeEmitter
         // Property getters for reflection-based access
         EmitHttpServerPropertyGetters(typeBuilder, runtime);
 
+        // Server-management surface (#1045): config getters (Node defaults) + lifecycle methods.
+        EmitHttpServerLifecycleMembers(typeBuilder, runtime, httpListenerType);
+
         typeBuilder.CreateType();
+    }
+
+    /// <summary>
+    /// Emits the server-management surface (#1045): config property getters returning Node
+    /// defaults (resolved via the GetProperty PascalCase-reflection fallback) plus
+    /// closeAllConnections/closeIdleConnections/setTimeout. Compiled exposes the defaults for
+    /// reads; mutating the timeouts is interpreter-only (documented).
+    /// </summary>
+    private void EmitHttpServerLifecycleMembers(TypeBuilder typeBuilder, EmittedRuntime runtime, Type httpListenerType)
+    {
+        void EmitConstDoubleProperty(string name, double value)
+        {
+            var prop = typeBuilder.DefineProperty(name, PropertyAttributes.None, _types.Double, null);
+            var getter = typeBuilder.DefineMethod(
+                "get_" + name,
+                MethodAttributes.Public | MethodAttributes.SpecialName,
+                _types.Double,
+                Type.EmptyTypes);
+            var gil = getter.GetILGenerator();
+            gil.Emit(OpCodes.Ldc_R8, value);
+            gil.Emit(OpCodes.Ret);
+            prop.SetGetMethod(getter);
+        }
+
+        EmitConstDoubleProperty("KeepAliveTimeout", 5000);
+        EmitConstDoubleProperty("HeadersTimeout", 60000);
+        EmitConstDoubleProperty("RequestTimeout", 300000);
+        EmitConstDoubleProperty("Timeout", 0);
+        EmitConstDoubleProperty("MaxHeadersCount", 2000);
+        EmitConstDoubleProperty("MaxRequestsPerSocket", 0);
+
+        // CloseAllConnections() → forcibly close (reuse Close); returns this.
+        var closeAll = typeBuilder.DefineMethod("CloseAllConnections",
+            MethodAttributes.Public, _types.Object, Type.EmptyTypes);
+        var cail = closeAll.GetILGenerator();
+        cail.Emit(OpCodes.Ldarg_0);
+        cail.Emit(OpCodes.Ldnull);
+        cail.Emit(OpCodes.Callvirt, runtime.TSHttpServerClose);
+        cail.Emit(OpCodes.Pop);
+        cail.Emit(OpCodes.Ldarg_0);
+        cail.Emit(OpCodes.Ret);
+
+        // CloseIdleConnections() → no-op (HttpListener manages keep-alive internally); returns undefined.
+        var closeIdle = typeBuilder.DefineMethod("CloseIdleConnections",
+            MethodAttributes.Public, _types.Object, Type.EmptyTypes);
+        var ciil = closeIdle.GetILGenerator();
+        ciil.Emit(OpCodes.Ldsfld, runtime.UndefinedInstance);
+        ciil.Emit(OpCodes.Ret);
+
+        // SetTimeout(msecs, cb) → register cb as a 'timeout' listener (best effort); returns this.
+        var setTimeout = typeBuilder.DefineMethod("SetTimeout",
+            MethodAttributes.Public, _types.Object, [_types.Object, _types.Object]);
+        var stil = setTimeout.GetILGenerator();
+        // if (cb != null) this.On("timeout", cb)
+        var noCbLabel = stil.DefineLabel();
+        stil.Emit(OpCodes.Ldarg_2);
+        stil.Emit(OpCodes.Brfalse, noCbLabel);
+        stil.Emit(OpCodes.Ldarg_0);
+        stil.Emit(OpCodes.Ldstr, "timeout");
+        stil.Emit(OpCodes.Ldarg_2);
+        stil.Emit(OpCodes.Callvirt, runtime.TSEventEmitterOn);
+        stil.Emit(OpCodes.Pop);
+        stil.MarkLabel(noCbLabel);
+        stil.Emit(OpCodes.Ldarg_0);
+        stil.Emit(OpCodes.Ret);
     }
 
     private void EmitHttpServerPropertyGetters(TypeBuilder typeBuilder, EmittedRuntime runtime)

--- a/Compilation/RuntimeEmitter.TSNetClosures.cs
+++ b/Compilation/RuntimeEmitter.TSNetClosures.cs
@@ -771,6 +771,50 @@ public partial class RuntimeEmitter
 
             il.MarkLabel(noCb);
 
+            // Read the request body and emit 'data' before 'end' (#1048 on-demand body),
+            // so req.on('data') receives the posted payload as a $Buffer. Listeners were
+            // attached synchronously by the handler above.
+            var bodyBytesLocal = il.DeclareLocal(typeof(byte[]));
+            il.BeginExceptionBlock();
+            {
+                var msLocal = il.DeclareLocal(typeof(System.IO.MemoryStream));
+                il.Emit(OpCodes.Newobj, typeof(System.IO.MemoryStream).GetConstructor(Type.EmptyTypes)!);
+                il.Emit(OpCodes.Stloc, msLocal);
+                il.Emit(OpCodes.Ldarg_0);
+                il.Emit(OpCodes.Ldfld, ctxField);
+                il.Emit(OpCodes.Callvirt, typeof(HttpListenerContext).GetProperty("Request")!.GetGetMethod()!);
+                il.Emit(OpCodes.Callvirt, typeof(HttpListenerRequest).GetProperty("InputStream")!.GetGetMethod()!);
+                il.Emit(OpCodes.Ldloc, msLocal);
+                il.Emit(OpCodes.Callvirt, typeof(System.IO.Stream).GetMethod("CopyTo", [typeof(System.IO.Stream)])!);
+                il.Emit(OpCodes.Ldloc, msLocal);
+                il.Emit(OpCodes.Callvirt, typeof(System.IO.MemoryStream).GetMethod("ToArray", Type.EmptyTypes)!);
+                il.Emit(OpCodes.Stloc, bodyBytesLocal);
+            }
+            il.BeginCatchBlock(typeof(Exception));
+            il.Emit(OpCodes.Pop);
+            il.EndExceptionBlock();
+
+            // if (bytes != null && bytes.Length > 0) req.Emit("data", [ new $Buffer(bytes) ])
+            var skipData = il.DefineLabel();
+            il.Emit(OpCodes.Ldloc, bodyBytesLocal);
+            il.Emit(OpCodes.Brfalse, skipData);
+            il.Emit(OpCodes.Ldloc, bodyBytesLocal);
+            il.Emit(OpCodes.Ldlen);
+            il.Emit(OpCodes.Conv_I4);
+            il.Emit(OpCodes.Brfalse, skipData);
+            il.Emit(OpCodes.Ldloc, reqLocal);
+            il.Emit(OpCodes.Ldstr, "data");
+            il.Emit(OpCodes.Ldc_I4_1);
+            il.Emit(OpCodes.Newarr, _types.Object);
+            il.Emit(OpCodes.Dup);
+            il.Emit(OpCodes.Ldc_I4_0);
+            il.Emit(OpCodes.Ldloc, bodyBytesLocal);
+            il.Emit(OpCodes.Newobj, runtime.TSBufferCtor);
+            il.Emit(OpCodes.Stelem_Ref);
+            il.Emit(OpCodes.Callvirt, runtime.TSEventEmitterEmit);
+            il.Emit(OpCodes.Pop);
+            il.MarkLabel(skipData);
+
             // Emit 'end' event on request so req.on('end', ...) works
             il.Emit(OpCodes.Ldloc, reqLocal);
             il.Emit(OpCodes.Ldstr, "end");

--- a/Execution/Interpreter.Properties.cs
+++ b/Execution/Interpreter.Properties.cs
@@ -1730,6 +1730,12 @@ public partial class Interpreter
             return value;
         }
 
+        if (obj is SharpTSHttpServer httpServer)
+        {
+            httpServer.SetMember(memberName, value);
+            return value;
+        }
+
         if (obj is SharpTSNetServer netServer)
         {
             netServer.SetMember(memberName, value);

--- a/Execution/Interpreter.Properties.cs
+++ b/Execution/Interpreter.Properties.cs
@@ -1736,6 +1736,12 @@ public partial class Interpreter
             return value;
         }
 
+        if (obj is SharpTSHttpsServerResponse httpsRes)
+        {
+            httpsRes.SetMember(memberName, value);
+            return value;
+        }
+
         if (obj is SharpTSNetServer netServer)
         {
             netServer.SetMember(memberName, value);

--- a/Runtime/BuiltIns/BuiltInRegistry.cs
+++ b/Runtime/BuiltIns/BuiltInRegistry.cs
@@ -958,6 +958,14 @@ public sealed class BuiltInRegistry
         registry.RegisterInstanceType(typeof(SharpTSClientResponse), (instance, name) =>
             ((SharpTSClientResponse)instance).GetMember(name));
 
+        // Register https server types (#1049 — real TLS-terminating HTTPS server).
+        registry.RegisterInstanceType(typeof(SharpTSHttpsServer), (instance, name) =>
+            ((SharpTSHttpsServer)instance).GetMember(name));
+        registry.RegisterInstanceType(typeof(SharpTSHttpsServerRequest), (instance, name) =>
+            ((SharpTSHttpsServerRequest)instance).GetMember(name));
+        registry.RegisterInstanceType(typeof(SharpTSHttpsServerResponse), (instance, name) =>
+            ((SharpTSHttpsServerResponse)instance).GetMember(name));
+
         // Register http.Agent type
         registry.RegisterInstanceType(typeof(SharpTSAgent), (instance, name) =>
             ((SharpTSAgent)instance).GetMember(name));

--- a/Runtime/BuiltIns/BuiltInRegistry.cs
+++ b/Runtime/BuiltIns/BuiltInRegistry.cs
@@ -950,6 +950,14 @@ public sealed class BuiltInRegistry
         registry.RegisterInstanceType(typeof(SharpTSHttpResponse), (instance, name) =>
             ((SharpTSHttpResponse)instance).GetMember(name));
 
+        // Register HTTP client types (http.request/get return a ClientRequest; its
+        // 'response' carries an IncomingMessage = SharpTSClientResponse).
+        registry.RegisterInstanceType(typeof(SharpTSClientRequest), (instance, name) =>
+            ((SharpTSClientRequest)instance).GetMember(name));
+
+        registry.RegisterInstanceType(typeof(SharpTSClientResponse), (instance, name) =>
+            ((SharpTSClientResponse)instance).GetMember(name));
+
         // Register http.Agent type
         registry.RegisterInstanceType(typeof(SharpTSAgent), (instance, name) =>
             ((SharpTSAgent)instance).GetMember(name));

--- a/Runtime/BuiltIns/HttpClientRequestHelpers.cs
+++ b/Runtime/BuiltIns/HttpClientRequestHelpers.cs
@@ -1,0 +1,61 @@
+using System.Net;
+using System.Net.Http;
+
+namespace SharpTS.Runtime.BuiltIns;
+
+/// <summary>
+/// Shared BCL plumbing for the Node-style http(s) client (<c>SharpTSClientRequest</c>).
+/// Kept separate from <see cref="FetchHelpers"/> because Node's <c>http.request</c> does NOT
+/// follow redirects or auto-decompress — it hands the raw response to the caller.
+/// </summary>
+public static class HttpClientRequestHelpers
+{
+    private static HttpClient? _plainClient;
+    private static HttpClient? _insecureTlsClient;
+    private static readonly object _lock = new();
+
+    /// <summary>
+    /// Gets a shared HttpClient for client requests. No auto-redirect and no auto-decompression
+    /// (Node semantics). When <paramref name="rejectUnauthorized"/> is false a separate client
+    /// that accepts any server certificate is used (for https with self-signed certs).
+    /// </summary>
+    public static HttpClient GetClient(bool rejectUnauthorized = true)
+    {
+        if (rejectUnauthorized)
+        {
+            if (_plainClient != null) return _plainClient;
+            lock (_lock)
+            {
+                _plainClient ??= Build(rejectUnauthorized: true);
+                return _plainClient;
+            }
+        }
+        else
+        {
+            if (_insecureTlsClient != null) return _insecureTlsClient;
+            lock (_lock)
+            {
+                _insecureTlsClient ??= Build(rejectUnauthorized: false);
+                return _insecureTlsClient;
+            }
+        }
+    }
+
+    private static HttpClient Build(bool rejectUnauthorized)
+    {
+        var handler = new HttpClientHandler
+        {
+            AllowAutoRedirect = false,
+            AutomaticDecompression = DecompressionMethods.None,
+            UseCookies = false
+        };
+        if (!rejectUnauthorized)
+        {
+            handler.ServerCertificateCustomValidationCallback =
+                HttpClientHandler.DangerousAcceptAnyServerCertificateValidator;
+        }
+        // Finite safety-net timeout so a stuck request can't pin the event loop forever
+        // (the request still manages its own CancellationToken for abort()/setTimeout()).
+        return new HttpClient(handler) { Timeout = TimeSpan.FromSeconds(100) };
+    }
+}

--- a/Runtime/BuiltIns/HttpHeaderValidation.cs
+++ b/Runtime/BuiltIns/HttpHeaderValidation.cs
@@ -1,0 +1,42 @@
+namespace SharpTS.Runtime.BuiltIns;
+
+/// <summary>
+/// Shared HTTP header-token/value validation (#1052), used by both http.validateHeaderName/
+/// validateHeaderValue (interpreter) and the compiled emitter so the rules match by construction.
+/// </summary>
+public static class HttpHeaderValidation
+{
+    /// <summary>Node's default http.maxHeaderSize (16 KiB).</summary>
+    public const int MaxHeaderSize = 16384;
+
+    /// <summary>
+    /// True if <paramref name="s"/> is a valid HTTP token (RFC 7230 §3.2.6): non-empty and every
+    /// char is an alpha/digit or one of !#$%&amp;'*+-.^_`|~.
+    /// </summary>
+    public static bool IsValidHttpToken(string s)
+    {
+        if (string.IsNullOrEmpty(s)) return false;
+        foreach (char c in s)
+            if (!IsTokenChar(c)) return false;
+        return true;
+    }
+
+    private static bool IsTokenChar(char c) =>
+        (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') ||
+        c is '!' or '#' or '$' or '%' or '&' or '\'' or '*' or '+' or '-' or '.'
+          or '^' or '_' or '`' or '|' or '~';
+
+    /// <summary>
+    /// True if a header value contains an invalid character (Node's checkInvalidHeaderChar):
+    /// anything outside {tab, 0x20–0x7e, 0x80–0xff}.
+    /// </summary>
+    public static bool HasInvalidHeaderChar(string value)
+    {
+        foreach (char c in value)
+        {
+            if (c == '\t') continue;
+            if (c < 0x20 || c == 0x7f) return true;
+        }
+        return false;
+    }
+}

--- a/Runtime/BuiltIns/HttpProtocol.cs
+++ b/Runtime/BuiltIns/HttpProtocol.cs
@@ -1,0 +1,139 @@
+using System.Text;
+
+namespace SharpTS.Runtime.BuiltIns;
+
+/// <summary>
+/// Minimal HTTP/1.1 request reader used by the interpreter HTTPS server (#1049), which runs the
+/// HTTP pipeline directly over a TLS <see cref="System.IO.Stream"/> (HttpListener cannot be used
+/// with an app-supplied certificate). Parses the request line, headers, and a Content-Length body.
+/// </summary>
+public static class HttpProtocol
+{
+    public sealed record ParsedRequest(
+        string Method,
+        string Url,
+        string HttpVersion,
+        Dictionary<string, object?> HeadersLower,
+        List<object?> RawHeaders,
+        byte[] Body);
+
+    /// <summary>
+    /// Reads a single HTTP/1.1 request from the stream, or null on a clean EOF before any bytes.
+    /// </summary>
+    public static async Task<ParsedRequest?> ReadRequestAsync(System.IO.Stream stream, CancellationToken token)
+    {
+        var headerBytes = new List<byte>(1024);
+        var buffer = new byte[4096];
+        int headerEnd = -1;
+        byte[] leftover = Array.Empty<byte>();
+
+        while (headerEnd < 0)
+        {
+            int n = await stream.ReadAsync(buffer.AsMemory(0, buffer.Length), token);
+            if (n == 0)
+            {
+                if (headerBytes.Count == 0) return null; // clean EOF
+                break;
+            }
+            for (int i = 0; i < n; i++) headerBytes.Add(buffer[i]);
+            headerEnd = FindHeaderEnd(headerBytes);
+            if (headerBytes.Count > 1024 * 1024) break; // guard against runaway headers
+        }
+
+        if (headerEnd < 0) return null;
+
+        // Header section is [0..headerEnd); the body begins at headerEnd+4.
+        var headerText = Encoding.ASCII.GetString(headerBytes.ToArray(), 0, headerEnd);
+        int bodyStart = headerEnd + 4;
+        if (bodyStart < headerBytes.Count)
+            leftover = headerBytes.GetRange(bodyStart, headerBytes.Count - bodyStart).ToArray();
+
+        var lines = headerText.Split("\r\n");
+        var requestLine = lines.Length > 0 ? lines[0] : "";
+        var parts = requestLine.Split(' ');
+        var method = parts.Length > 0 ? parts[0] : "GET";
+        var url = parts.Length > 1 ? parts[1] : "/";
+        var version = parts.Length > 2 && parts[2].StartsWith("HTTP/") ? parts[2].Substring(5) : "1.1";
+
+        var headersLower = new Dictionary<string, object?>();
+        var rawHeaders = new List<object?>();
+        int contentLength = 0;
+        for (int i = 1; i < lines.Length; i++)
+        {
+            var line = lines[i];
+            if (line.Length == 0) continue;
+            int colon = line.IndexOf(':');
+            if (colon < 0) continue;
+            var name = line.Substring(0, colon).Trim();
+            var value = line.Substring(colon + 1).Trim();
+            rawHeaders.Add(name);
+            rawHeaders.Add(value);
+            var lower = name.ToLowerInvariant();
+            if (lower == "set-cookie")
+            {
+                if (headersLower.TryGetValue(lower, out var existing) && existing is List<object?> list)
+                    list.Add(value);
+                else
+                    headersLower[lower] = new List<object?> { value };
+            }
+            else
+            {
+                headersLower[lower] = value;
+            }
+            if (lower == "content-length" && int.TryParse(value, out var cl))
+                contentLength = cl;
+        }
+
+        // Read the remaining body bytes (Content-Length minus what we already buffered).
+        byte[] body;
+        if (contentLength <= 0)
+        {
+            body = Array.Empty<byte>();
+        }
+        else
+        {
+            var bodyBuf = new byte[contentLength];
+            int have = Math.Min(leftover.Length, contentLength);
+            Array.Copy(leftover, bodyBuf, have);
+            int total = have;
+            while (total < contentLength)
+            {
+                int n = await stream.ReadAsync(bodyBuf.AsMemory(total, contentLength - total), token);
+                if (n == 0) break;
+                total += n;
+            }
+            body = bodyBuf;
+        }
+
+        return new ParsedRequest(method, url, version, headersLower, rawHeaders, body);
+    }
+
+    private static int FindHeaderEnd(List<byte> bytes)
+    {
+        for (int i = 0; i + 3 < bytes.Count; i++)
+        {
+            if (bytes[i] == (byte)'\r' && bytes[i + 1] == (byte)'\n' &&
+                bytes[i + 2] == (byte)'\r' && bytes[i + 3] == (byte)'\n')
+                return i;
+        }
+        return -1;
+    }
+
+    /// <summary>
+    /// Serializes an HTTP/1.1 response (status line + headers + body) to bytes.
+    /// </summary>
+    public static byte[] SerializeResponse(int statusCode, string statusMessage,
+        IEnumerable<KeyValuePair<string, string>> headers, byte[] body)
+    {
+        var sb = new StringBuilder();
+        sb.Append("HTTP/1.1 ").Append(statusCode).Append(' ').Append(statusMessage).Append("\r\n");
+        foreach (var (name, value) in headers)
+            sb.Append(name).Append(": ").Append(value).Append("\r\n");
+        sb.Append("\r\n");
+        var head = Encoding.ASCII.GetBytes(sb.ToString());
+        var result = new byte[head.Length + body.Length];
+        Array.Copy(head, result, head.Length);
+        Array.Copy(body, 0, result, head.Length, body.Length);
+        return result;
+    }
+}

--- a/Runtime/BuiltIns/Modules/Interpreter/BuiltInModuleValues.cs
+++ b/Runtime/BuiltIns/Modules/Interpreter/BuiltInModuleValues.cs
@@ -51,7 +51,7 @@ public static class BuiltInModuleValues
             "dns" => DnsModuleInterpreter.GetExports(),
             "dns/promises" => DnsModuleInterpreter.GetPromisesExports(),
             "net" => NetModuleInterpreter.GetExports(),
-            "https" => HttpModuleInterpreter.GetExports(), // https delegates to http
+            "https" => HttpModuleInterpreter.GetHttpsExports(), // real TLS server (#1049) + client over TLS (#1050)
             "tls" => TlsModuleInterpreter.GetExports(),
             "dgram" => DgramModuleInterpreter.GetExports(),
             "cluster" => ClusterModuleInterpreter.GetExports(),

--- a/Runtime/BuiltIns/Modules/Interpreter/HttpModuleInterpreter.cs
+++ b/Runtime/BuiltIns/Modules/Interpreter/HttpModuleInterpreter.cs
@@ -19,13 +19,25 @@ public static class HttpModuleInterpreter
     /// <summary>
     /// Gets all exported values for the http module.
     /// </summary>
-    public static Dictionary<string, object?> GetExports()
+    public static Dictionary<string, object?> GetExports() => GetExports(isHttps: false);
+
+    /// <summary>
+    /// Gets all exported values for the http (or https) module. The <paramref name="isHttps"/>
+    /// flag selects TLS for the client request path (used by the https module wiring).
+    /// </summary>
+    public static Dictionary<string, object?> GetExports(bool isHttps)
     {
         return new Dictionary<string, object?>
         {
-            ["createServer"] = BuiltInMethod.CreateV2("createServer", 0, 1, CreateServer),
-            ["request"] = new BuiltInAsyncMethod("request", 1, 2, Request),
-            ["get"] = new BuiltInAsyncMethod("get", 1, 2, Get),
+            ["createServer"] = BuiltInMethod.CreateV2("createServer", 0, 2, CreateServer),
+            ["request"] = BuiltInMethod.CreateV2("request", 1, 3, (interp, _, args) =>
+                RuntimeValue.FromObject(CreateClientRequest(interp, args, forceMethod: null, forceHttps: isHttps))),
+            ["get"] = BuiltInMethod.CreateV2("get", 1, 3, (interp, _, args) =>
+            {
+                var req = CreateClientRequest(interp, args, forceMethod: "GET", forceHttps: isHttps);
+                req.EndNow();
+                return RuntimeValue.FromObject(req);
+            }),
             ["METHODS"] = GetMethods(),
             ["STATUS_CODES"] = GetStatusCodes(),
             ["globalAgent"] = SharpTSAgent.GlobalAgent,
@@ -66,71 +78,72 @@ public static class HttpModuleInterpreter
     }
 
     /// <summary>
-    /// Makes an HTTP request (similar to Node.js http.request).
+    /// Builds a <see cref="SharpTSClientRequest"/> from <c>http.request</c>/<c>http.get</c> arguments.
+    /// Accepts <c>(url[, options][, cb])</c> or <c>(options[, cb])</c>. The response callback (the
+    /// last function argument) is registered as a 'response' listener.
     /// </summary>
-    private static async Task<object?> Request(Interp interpreter, object? receiver, List<object?> args)
+    internal static SharpTSClientRequest CreateClientRequest(
+        Interp interpreter, ReadOnlySpan<RuntimeValue> args, string? forceMethod, bool forceHttps)
     {
-        if (args.Count == 0)
-            throw new SharpTSPromiseRejectedException(
-                new SharpTSTypeError("http.request requires a URL or options object"));
-
-        string url;
+        string? urlStr = null;
         SharpTSObject? options = null;
+        ISharpTSCallable? callback = null;
 
-        // Parse arguments
-        if (args[0] is string urlStr)
+        if (args.Length > 0)
         {
-            url = urlStr;
-            if (args.Count > 1 && args[1] is SharpTSObject opts)
-            {
-                options = opts;
-            }
+            var a0 = args[0].ToObject();
+            if (a0 is string s) urlStr = s;
+            else if (a0 is SharpTSObject o) options = o;
         }
-        else if (args[0] is SharpTSObject opts)
+        for (int i = 1; i < args.Length; i++)
         {
-            options = opts;
-            // Build URL from options
-            var protocol = opts.Fields.TryGetValue("protocol", out var p) && p is string ps ? ps : "http:";
-            var hostname = opts.Fields.TryGetValue("hostname", out var h) && h is string hs ? hs
-                : opts.Fields.TryGetValue("host", out var ho) && ho is string hos ? hos : "localhost";
-            var port = opts.Fields.TryGetValue("port", out var po) && po is double pd ? $":{(int)pd}" : "";
-            var path = opts.Fields.TryGetValue("path", out var pa) && pa is string pas ? pas : "/";
-
-            protocol = protocol.TrimEnd(':') + ":";
-            url = $"{protocol}//{hostname}{port}{path}";
-        }
-        else
-        {
-            throw new SharpTSPromiseRejectedException(
-                new SharpTSTypeError("http.request: first argument must be URL string or options object"));
+            var a = args[i].ToObject();
+            if (a is ISharpTSCallable cb) callback = cb;
+            else if (a is SharpTSObject o && options == null) options = o;
         }
 
-        // Delegate to fetch - use Call which returns a Promise
-        var promise = FetchBuiltIns.FetchMethod.Call(interpreter, new List<object?> { url, options });
-        if (promise is SharpTSPromise fetchPromise)
-        {
-            return await fetchPromise.GetValueAsync();
-        }
-        return promise;
+        bool isHttps = forceHttps;
+        if (urlStr != null && urlStr.StartsWith("https:", StringComparison.OrdinalIgnoreCase))
+            isHttps = true;
+        if (options != null && options.Fields.TryGetValue("protocol", out var p) && p is string ps
+            && ps.TrimEnd(':').Equals("https", StringComparison.OrdinalIgnoreCase))
+            isHttps = true;
+        if (forceHttps) isHttps = true;
+
+        string url = urlStr ?? BuildUrlFromOptions(options, isHttps);
+
+        string method = forceMethod
+            ?? (options != null && options.Fields.TryGetValue("method", out var m) && m is string ms ? ms : "GET");
+
+        var req = new SharpTSClientRequest(interpreter, method, url, options, isHttps);
+        if (callback != null)
+            req.RegisterResponseCallback(callback);
+        return req;
     }
 
     /// <summary>
-    /// Shorthand for GET requests.
+    /// Builds a URL from a request options object (protocol/host/hostname/port/path).
     /// </summary>
-    private static async Task<object?> Get(Interp interpreter, object? receiver, List<object?> args)
+    private static string BuildUrlFromOptions(SharpTSObject? opts, bool isHttps)
     {
-        // Ensure method is GET
-        if (args.Count > 1 && args[1] is SharpTSObject options)
+        string defaultScheme = isHttps ? "https" : "http";
+        if (opts == null) return $"{defaultScheme}://localhost/";
+
+        string protocol = opts.Fields.TryGetValue("protocol", out var p) && p is string ps
+            ? ps.TrimEnd(':') : defaultScheme;
+        string host = opts.Fields.TryGetValue("hostname", out var h) && h is string hs ? hs
+            : opts.Fields.TryGetValue("host", out var ho) && ho is string hos ? hos : "localhost";
+
+        string portStr = "";
+        if (opts.Fields.TryGetValue("port", out var po))
         {
-            options.SetProperty("method", "GET");
-        }
-        else if (args.Count == 1)
-        {
-            var opts = new SharpTSObject(new Dictionary<string, object?> { ["method"] = "GET" });
-            args = new List<object?> { args[0], opts };
+            if (po is double pd) portStr = ":" + (int)pd;
+            else if (po is string pss && int.TryParse(pss, out var pii)) portStr = ":" + pii;
         }
 
-        return await Request(interpreter, receiver, args);
+        string path = opts.Fields.TryGetValue("path", out var pa) && pa is string pas ? pas : "/";
+        if (!path.StartsWith("/")) path = "/" + path;
+        return $"{protocol}://{host}{portStr}{path}";
     }
 
     /// <summary>

--- a/Runtime/BuiltIns/Modules/Interpreter/HttpModuleInterpreter.cs
+++ b/Runtime/BuiltIns/Modules/Interpreter/HttpModuleInterpreter.cs
@@ -41,8 +41,43 @@ public static class HttpModuleInterpreter
             ["METHODS"] = GetMethods(),
             ["STATUS_CODES"] = GetStatusCodes(),
             ["globalAgent"] = SharpTSAgent.GlobalAgent,
-            ["Agent"] = BuiltInMethod.CreateV2("Agent", 0, 1, ConstructAgent)
+            ["Agent"] = BuiltInMethod.CreateV2("Agent", 0, 1, ConstructAgent),
+            // Utilities + constants (#1052).
+            ["validateHeaderName"] = BuiltInMethod.CreateV2("validateHeaderName", 1, 2, ValidateHeaderName),
+            ["validateHeaderValue"] = BuiltInMethod.CreateV2("validateHeaderValue", 2, ValidateHeaderValue),
+            ["maxHeaderSize"] = (double)HttpHeaderValidation.MaxHeaderSize,
+            ["setMaxIdleHTTPParsers"] = BuiltInMethod.CreateV2("setMaxIdleHTTPParsers", 1,
+                (_, _, _) => RuntimeValue.Undefined)
         };
+    }
+
+    private static RuntimeValue ValidateHeaderName(Interp interpreter, RuntimeValue receiver, ReadOnlySpan<RuntimeValue> args)
+    {
+        var name = args.Length > 0 ? args[0].ToObject() as string : null;
+        if (name == null || !HttpHeaderValidation.IsValidHttpToken(name))
+        {
+            var shown = args.Length > 0 ? args[0].ToObject()?.ToString() ?? "undefined" : "undefined";
+            throw new Runtime.Exceptions.ThrowException(
+                new SharpTSTypeError($"Header name must be a valid HTTP token [\"{shown}\"]") { Code = "ERR_INVALID_HTTP_TOKEN" });
+        }
+        return RuntimeValue.Undefined;
+    }
+
+    private static RuntimeValue ValidateHeaderValue(Interp interpreter, RuntimeValue receiver, ReadOnlySpan<RuntimeValue> args)
+    {
+        var name = args.Length > 0 ? args[0].ToObject()?.ToString() ?? "" : "";
+        if (args.Length < 2 || args[1].IsUndefined)
+        {
+            throw new Runtime.Exceptions.ThrowException(
+                new SharpTSTypeError($"Invalid value \"undefined\" for header \"{name}\"") { Code = "ERR_HTTP_INVALID_HEADER_VALUE" });
+        }
+        var value = args[1].ToObject()?.ToString() ?? "";
+        if (HttpHeaderValidation.HasInvalidHeaderChar(value))
+        {
+            throw new Runtime.Exceptions.ThrowException(
+                new SharpTSTypeError($"Invalid character in header content [\"{name}\"]") { Code = "ERR_INVALID_CHAR" });
+        }
+        return RuntimeValue.Undefined;
     }
 
     /// <summary>

--- a/Runtime/BuiltIns/Modules/Interpreter/HttpModuleInterpreter.cs
+++ b/Runtime/BuiltIns/Modules/Interpreter/HttpModuleInterpreter.cs
@@ -46,6 +46,35 @@ public static class HttpModuleInterpreter
     }
 
     /// <summary>
+    /// Gets the exports for the 'https' module: the http client surface over TLS (#1050) plus a
+    /// real TLS-terminating createServer (#1049, interpreter).
+    /// </summary>
+    public static Dictionary<string, object?> GetHttpsExports()
+    {
+        var exports = GetExports(isHttps: true);
+        exports["createServer"] = BuiltInMethod.CreateV2("createServer", 0, 2, CreateHttpsServer);
+        // https.Agent / globalAgent are TLS-aware aliases (same Agent surface; #1050).
+        return exports;
+    }
+
+    /// <summary>
+    /// Creates a real HTTPS server (#1049): builds <see cref="SharpTSHttpsServer"/> over the
+    /// tls #1032 server, terminating TLS and running the HTTP pipeline over each connection.
+    /// </summary>
+    private static RuntimeValue CreateHttpsServer(Interp interpreter, RuntimeValue receiver, ReadOnlySpan<RuntimeValue> args)
+    {
+        SharpTSObject? options = null;
+        ISharpTSCallable? handler = null;
+        if (args.Length > 0)
+        {
+            if (args[0].ToObject() is SharpTSObject o) options = o;
+            else if (args[0].ToObject() is ISharpTSCallable c) handler = c;
+        }
+        if (args.Length > 1 && args[1].ToObject() is ISharpTSCallable c2) handler = c2;
+        return RuntimeValue.FromObject(new SharpTSHttpsServer(options, handler));
+    }
+
+    /// <summary>
     /// Creates an HTTP server.
     /// </summary>
     /// <param name="interpreter">The interpreter instance.</param>

--- a/Runtime/Types/SharpTSAgent.cs
+++ b/Runtime/Types/SharpTSAgent.cs
@@ -23,9 +23,15 @@ public class SharpTSAgent : SharpTSEventEmitter
         maxSockets: double.PositiveInfinity, maxTotalSockets: double.PositiveInfinity,
         maxFreeSockets: 256, timeout: 0, scheduling: "lifo");
 
-    #pragma warning disable CS0414 // Field is assigned but never read — tracks agent lifecycle state
     private bool _destroyed;
-    #pragma warning restore CS0414
+
+    // Observable connection-pool state (#1051). Real socket ownership lives in HttpClient's
+    // connection pool, so these dictionaries are a Node-shaped shadow keyed by origin
+    // ("host:port") that the ClientRequest populates as requests flow through the agent.
+    private readonly Dictionary<string, int> _activeSockets = new();
+    private readonly Dictionary<string, int> _freeSocketsByOrigin = new();
+    private readonly Dictionary<string, int> _pendingRequests = new();
+    private readonly object _poolLock = new();
 
     public bool KeepAlive { get; set; }
     public double KeepAliveMsecs { get; set; }
@@ -88,10 +94,10 @@ public class SharpTSAgent : SharpTSEventEmitter
             "timeout" => Timeout,
             "scheduling" => Scheduling,
 
-            // State inspection (empty in our implementation since .NET handles pooling)
-            "sockets" => new SharpTSObject(new Dictionary<string, object?>()),
-            "freeSockets" => new SharpTSObject(new Dictionary<string, object?>()),
-            "requests" => new SharpTSObject(new Dictionary<string, object?>()),
+            // Observable pool state (#1051): origin → array of (placeholder) sockets.
+            "sockets" => BuildPoolObject(_activeSockets),
+            "freeSockets" => BuildPoolObject(_freeSocketsByOrigin),
+            "requests" => BuildPoolObject(_pendingRequests),
 
             // Methods
             "destroy" => BuiltInMethod.CreateV2("destroy", 0, Destroy),
@@ -116,6 +122,12 @@ public class SharpTSAgent : SharpTSEventEmitter
         GlobalAgent.Timeout = 0;
         GlobalAgent.Scheduling = "lifo";
         GlobalAgent._destroyed = false;
+        lock (GlobalAgent._poolLock)
+        {
+            GlobalAgent._activeSockets.Clear();
+            GlobalAgent._freeSocketsByOrigin.Clear();
+            GlobalAgent._pendingRequests.Clear();
+        }
         GlobalAgent.ClearAllListenersInternal();
     }
 
@@ -139,7 +151,81 @@ public class SharpTSAgent : SharpTSEventEmitter
     private RuntimeValue Destroy(Interp interpreter, RuntimeValue receiver, ReadOnlySpan<RuntimeValue> args)
     {
         _destroyed = true;
+        lock (_poolLock)
+        {
+            _activeSockets.Clear();
+            _freeSocketsByOrigin.Clear();
+            _pendingRequests.Clear();
+        }
         return RuntimeValue.Null;
+    }
+
+    /// <summary>
+    /// Records that a request is using a socket to <paramref name="origin"/> ("host:port").
+    /// Reuses a free keep-alive socket when one exists. Returns false when at maxSockets — the
+    /// caller may still proceed (HttpClient owns real concurrency); the request is tracked as
+    /// pending so agent.requests reflects the contention.
+    /// </summary>
+    internal bool TrackSocketStart(string origin)
+    {
+        lock (_poolLock)
+        {
+            int active = _activeSockets.GetValueOrDefault(origin);
+            if (!double.IsPositiveInfinity(MaxSockets) && active >= (int)MaxSockets)
+            {
+                _pendingRequests[origin] = _pendingRequests.GetValueOrDefault(origin) + 1;
+                return false;
+            }
+            // Reuse a free socket if available, otherwise open a new one.
+            if (_freeSocketsByOrigin.GetValueOrDefault(origin) > 0)
+                _freeSocketsByOrigin[origin] = _freeSocketsByOrigin[origin] - 1;
+            _activeSockets[origin] = active + 1;
+            return true;
+        }
+    }
+
+    /// <summary>
+    /// Records that a request finished. When keep-alive is on, the socket moves to the free pool
+    /// (capped at maxFreeSockets); otherwise it is dropped.
+    /// </summary>
+    internal void TrackSocketEnd(string origin, bool keepAlive)
+    {
+        lock (_poolLock)
+        {
+            int active = _activeSockets.GetValueOrDefault(origin);
+            if (active > 0)
+            {
+                if (active == 1) _activeSockets.Remove(origin);
+                else _activeSockets[origin] = active - 1;
+            }
+            if (_pendingRequests.GetValueOrDefault(origin) > 0)
+            {
+                if (_pendingRequests[origin] == 1) _pendingRequests.Remove(origin);
+                else _pendingRequests[origin] = _pendingRequests[origin] - 1;
+            }
+            if (keepAlive && KeepAlive)
+            {
+                int free = _freeSocketsByOrigin.GetValueOrDefault(origin);
+                if (double.IsPositiveInfinity(MaxFreeSockets) || free < (int)MaxFreeSockets)
+                    _freeSocketsByOrigin[origin] = free + 1;
+            }
+        }
+    }
+
+    private SharpTSObject BuildPoolObject(Dictionary<string, int> source)
+    {
+        var obj = new Dictionary<string, object?>();
+        lock (_poolLock)
+        {
+            foreach (var (origin, count) in source)
+            {
+                var list = new List<object?>();
+                for (int i = 0; i < count; i++)
+                    list.Add(new SharpTSObject(new Dictionary<string, object?>()));
+                obj[origin] = new SharpTSArray(list);
+            }
+        }
+        return new SharpTSObject(obj);
     }
 
     private RuntimeValue GetName(Interp interpreter, RuntimeValue receiver, ReadOnlySpan<RuntimeValue> args)

--- a/Runtime/Types/SharpTSAgent.cs
+++ b/Runtime/Types/SharpTSAgent.cs
@@ -23,7 +23,9 @@ public class SharpTSAgent : SharpTSEventEmitter
         maxSockets: double.PositiveInfinity, maxTotalSockets: double.PositiveInfinity,
         maxFreeSockets: 256, timeout: 0, scheduling: "lifo");
 
+    #pragma warning disable CS0414 // Field is assigned but never read — tracks agent lifecycle state
     private bool _destroyed;
+    #pragma warning restore CS0414
 
     // Observable connection-pool state (#1051). Real socket ownership lives in HttpClient's
     // connection pool, so these dictionaries are a Node-shaped shadow keyed by origin

--- a/Runtime/Types/SharpTSClientRequest.cs
+++ b/Runtime/Types/SharpTSClientRequest.cs
@@ -328,6 +328,14 @@ public class SharpTSClientRequest : SharpTSWritable
                 }
 
                 using var response = await sendTask;
+
+                // Persist Set-Cookie into the shared jar (parity with the fetch client path).
+                if (response.Headers.TryGetValues("Set-Cookie", out var setCookies))
+                {
+                    foreach (var c in setCookies)
+                        SharpTSCookieJar.Instance.SetCookie(c, _url);
+                }
+
                 var (status, reason, version, headersLower, raw) = ExtractResponse(response);
                 var body = await response.Content.ReadAsByteArrayAsync(_cts.Token);
 
@@ -402,6 +410,15 @@ public class SharpTSClientRequest : SharpTSWritable
                     content.Headers.TryAddWithoutValidation(name, value);
                 }
             }
+        }
+
+        // Attach cookies from the shared jar unless the caller set Cookie explicitly
+        // (parity with the fetch client path).
+        if (!_headers.ContainsKey("cookie"))
+        {
+            var cookieHeader = SharpTSCookieJar.Instance.GetCookieHeader(_url);
+            if (!string.IsNullOrEmpty(cookieHeader))
+                request.Headers.TryAddWithoutValidation("Cookie", cookieHeader);
         }
 
         request.Content = content;

--- a/Runtime/Types/SharpTSClientRequest.cs
+++ b/Runtime/Types/SharpTSClientRequest.cs
@@ -1,0 +1,533 @@
+using System.Net.Http;
+using System.Text;
+using SharpTS.Execution;
+using SharpTS.Runtime.BuiltIns;
+using SharpTS.TypeSystem;
+
+namespace SharpTS.Runtime.Types;
+
+/// <summary>
+/// Runtime representation of a Node.js http.ClientRequest — the object returned by
+/// <c>http.request()</c>/<c>http.get()</c> (and the https variants). It is a Writable
+/// stream: the request body is produced by <c>write()</c>/<c>end()</c>. When the request
+/// completes it fires <c>'response'</c> with a <see cref="SharpTSClientResponse"/>
+/// (IncomingMessage) plus the lifecycle events <c>'socket'</c>/<c>'error'</c>/<c>'abort'</c>/
+/// <c>'close'</c>/<c>'timeout'</c>.
+/// </summary>
+/// <remarks>
+/// Wraps a BCL <see cref="HttpClient"/> (no auto-redirect/decompression, Node semantics) under
+/// the hood but is a first-class object model: headers can be manipulated before send, and the
+/// body is streamed. The HTTP send runs on a thread-pool task and delivers its result back onto
+/// the interpreter's event-loop thread via <c>ScheduleTimer(0)</c>, keeping the loop alive with
+/// Ref/Unref while the request is in flight (mirrors <see cref="SharpTSSocket"/>).
+/// </remarks>
+public class SharpTSClientRequest : SharpTSWritable
+{
+    /// <inheritdoc />
+    public override TypeCategory RuntimeCategory => TypeCategory.Record;
+
+    private readonly Interpreter _interpreter;
+    private readonly string _method;
+    private readonly string _url;
+    private readonly bool _isHttps;
+    private bool _rejectUnauthorized = true;
+
+    // Headers keyed by lowercase name → (originalName, value). value may be a string,
+    // number (double), or SharpTSArray of strings (multi-value header).
+    private readonly Dictionary<string, (string Name, object? Value)> _headers =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    private readonly List<byte[]> _bodyChunks = new();
+    private bool _requestEnded;
+    private bool _sent;
+    private bool _aborted;
+    private bool _responseReceived;
+    private int _timeoutMs;
+    private readonly CancellationTokenSource _cts = new();
+    private SharpTSObject? _socketObject;
+
+    public SharpTSClientRequest(Interpreter interpreter, string method, string url, SharpTSObject? options, bool isHttps)
+    {
+        _interpreter = interpreter ?? throw new ArgumentNullException(nameof(interpreter));
+        _method = string.IsNullOrEmpty(method) ? "GET" : method.ToUpperInvariant();
+        _url = url;
+        _isHttps = isHttps;
+
+        if (options != null)
+        {
+            // Initial headers from options.headers.
+            if (options.Fields.TryGetValue("headers", out var h) && h is SharpTSObject headerObj)
+            {
+                foreach (var kv in headerObj.Fields)
+                    _headers[kv.Key] = (kv.Key, kv.Value);
+            }
+            if (options.Fields.TryGetValue("timeout", out var to) && to is double tov)
+                _timeoutMs = (int)tov;
+            if (options.Fields.TryGetValue("rejectUnauthorized", out var ru) && ru is bool rub)
+                _rejectUnauthorized = rub;
+            // options.auth ("user:pass") → Basic Authorization header (Node semantics).
+            if (options.Fields.TryGetValue("auth", out var au) && au is string authStr && authStr.Length > 0
+                && !_headers.ContainsKey("authorization"))
+            {
+                var encoded = Convert.ToBase64String(Encoding.UTF8.GetBytes(authStr));
+                _headers["authorization"] = ("Authorization", "Basic " + encoded);
+            }
+        }
+    }
+
+    /// <summary>Ends the request with no further body (used by http.get, which auto-ends).</summary>
+    internal void EndNow()
+    {
+        if (_requestEnded) return;
+        _requestEnded = true;
+        SendAsync();
+    }
+
+    /// <summary>Registers the response callback (the cb passed to http.request) as a 'response' listener.</summary>
+    public void RegisterResponseCallback(ISharpTSCallable callback)
+    {
+        var on = ((SharpTSEventEmitter)this).GetMember("on") as BuiltInMethod;
+        on?.Bind(this).Call(_interpreter, ["response", callback]);
+    }
+
+    public new object? GetMember(string name)
+    {
+        return name switch
+        {
+            // Body production (override Writable's defaults to buffer + trigger the send).
+            "write" => BuiltInMethod.CreateV2("write", 1, 3, (interp, receiver, args) =>
+                ((SharpTSClientRequest)receiver.ToObject()!).WriteBody(interp, args)).Bind(this),
+            "end" => BuiltInMethod.CreateV2("end", 0, 3, (interp, receiver, args) =>
+                ((SharpTSClientRequest)receiver.ToObject()!).EndRequest(interp, args)).Bind(this),
+
+            // Header manipulation (before send).
+            "setHeader" => BuiltInMethod.CreateV2("setHeader", 2, (_, receiver, args) =>
+                ((SharpTSClientRequest)receiver.ToObject()!).SetHeader(args)).Bind(this),
+            "getHeader" => BuiltInMethod.CreateV2("getHeader", 1, (_, receiver, args) =>
+                ((SharpTSClientRequest)receiver.ToObject()!).GetHeader(args)).Bind(this),
+            "removeHeader" => BuiltInMethod.CreateV2("removeHeader", 1, (_, receiver, args) =>
+                ((SharpTSClientRequest)receiver.ToObject()!).RemoveHeader(args)).Bind(this),
+            "hasHeader" => BuiltInMethod.CreateV2("hasHeader", 1, (_, receiver, args) =>
+                ((SharpTSClientRequest)receiver.ToObject()!).HasHeader(args)).Bind(this),
+            "getHeaders" => BuiltInMethod.CreateV2("getHeaders", 0, (_, receiver, _) =>
+                ((SharpTSClientRequest)receiver.ToObject()!).GetHeaders()).Bind(this),
+            "getHeaderNames" => BuiltInMethod.CreateV2("getHeaderNames", 0, (_, receiver, _) =>
+                ((SharpTSClientRequest)receiver.ToObject()!).GetHeaderNames()).Bind(this),
+            "getRawHeaderNames" => BuiltInMethod.CreateV2("getRawHeaderNames", 0, (_, receiver, _) =>
+                ((SharpTSClientRequest)receiver.ToObject()!).GetRawHeaderNames()).Bind(this),
+            "flushHeaders" => BuiltInMethod.CreateV2("flushHeaders", 0, (_, receiver, _) => receiver).Bind(this),
+
+            // Connection control.
+            "abort" => BuiltInMethod.CreateV2("abort", 0, (interp, receiver, _) =>
+                ((SharpTSClientRequest)receiver.ToObject()!).Abort(interp)).Bind(this),
+            "destroy" => BuiltInMethod.CreateV2("destroy", 0, 1, (interp, receiver, args) =>
+                ((SharpTSClientRequest)receiver.ToObject()!).DestroyRequest(interp, args)).Bind(this),
+            "setTimeout" => BuiltInMethod.CreateV2("setTimeout", 1, 2, (interp, receiver, args) =>
+                ((SharpTSClientRequest)receiver.ToObject()!).SetTimeout(interp, args)).Bind(this),
+            "setNoDelay" => BuiltInMethod.CreateV2("setNoDelay", 0, 1, (_, receiver, _) => receiver).Bind(this),
+            "setSocketKeepAlive" => BuiltInMethod.CreateV2("setSocketKeepAlive", 0, 2, (_, receiver, _) => receiver).Bind(this),
+
+            // Properties.
+            "method" => _method,
+            "path" => GetPath(),
+            "host" => GetHostName(),
+            "protocol" => _isHttps ? "https:" : "http:",
+            "aborted" => _aborted,
+            "finished" => _requestEnded,
+            "reusedSocket" => false,
+            "writableEnded" => _requestEnded,
+            "socket" or "connection" => (object?)_socketObject,
+
+            // Inherit Writable/EventEmitter (on, once, off, emit, cork, uncork, etc.)
+            _ => base.GetMember(name)
+        };
+    }
+
+    private RuntimeValue WriteBody(Interpreter interpreter, ReadOnlySpan<RuntimeValue> args)
+    {
+        if (_requestEnded)
+        {
+            EmitEvent(interpreter, "error", [new SharpTSError("write after end")]);
+            return RuntimeValue.False;
+        }
+        AppendChunk(args, out ISharpTSCallable? cb);
+        cb?.Call(interpreter, []);
+        return RuntimeValue.True;
+    }
+
+    private RuntimeValue EndRequest(Interpreter interpreter, ReadOnlySpan<RuntimeValue> args)
+    {
+        if (_requestEnded) return RuntimeValue.FromObject(this);
+
+        // end([chunk][, encoding][, callback])
+        ISharpTSCallable? endCb = null;
+        if (args.Length > 0 && args[0].ToObject() is not ISharpTSCallable && !args[0].IsUndefined && !args[0].IsNull)
+        {
+            AppendChunk(args, out endCb);
+        }
+        else if (args.Length > 0 && args[0].ToObject() is ISharpTSCallable cb0)
+        {
+            endCb = cb0;
+        }
+
+        _requestEnded = true;
+        if (endCb != null)
+            RegisterFinishCallback(endCb);
+
+        SendAsync();
+        return RuntimeValue.FromObject(this);
+    }
+
+    private void RegisterFinishCallback(ISharpTSCallable cb)
+    {
+        var once = ((SharpTSEventEmitter)this).GetMember("once") as BuiltInMethod;
+        once?.Bind(this).Call(_interpreter, ["finish", cb]);
+    }
+
+    private void AppendChunk(ReadOnlySpan<RuntimeValue> args, out ISharpTSCallable? callback)
+    {
+        callback = null;
+        if (args.Length == 0) return;
+
+        var first = args[0].ToObject();
+        var encoding = args.Length > 1 && args[1].IsString ? args[1].AsStringUnsafe() : "utf8";
+
+        // trailing callback
+        for (int i = 1; i < args.Length; i++)
+            if (args[i].ToObject() is ISharpTSCallable cb) { callback = cb; break; }
+
+        byte[] bytes = first switch
+        {
+            string s => GetEncoding(encoding).GetBytes(s),
+            SharpTSBuffer buf => buf.Data,
+            null => Array.Empty<byte>(),
+            _ => Encoding.UTF8.GetBytes(first.ToString() ?? "")
+        };
+        if (bytes.Length > 0)
+            _bodyChunks.Add(bytes);
+    }
+
+    private RuntimeValue SetHeader(ReadOnlySpan<RuntimeValue> args)
+    {
+        if (_sent) throw new InterpreterException("Cannot set headers after they are sent to the client");
+        if (args.Length < 2) return RuntimeValue.FromObject(this);
+        var name = args[0].ToObject()?.ToString();
+        if (name == null) return RuntimeValue.FromObject(this);
+        _headers[name] = (name, args[1].ToObject());
+        return RuntimeValue.FromObject(this);
+    }
+
+    private RuntimeValue GetHeader(ReadOnlySpan<RuntimeValue> args)
+    {
+        if (args.Length == 0) return RuntimeValue.Undefined;
+        var name = args[0].ToObject()?.ToString();
+        if (name != null && _headers.TryGetValue(name, out var entry))
+            return RuntimeValue.FromBoxed(entry.Value);
+        return RuntimeValue.Undefined;
+    }
+
+    private RuntimeValue RemoveHeader(ReadOnlySpan<RuntimeValue> args)
+    {
+        if (_sent) throw new InterpreterException("Cannot remove headers after they are sent to the client");
+        if (args.Length > 0 && args[0].ToObject()?.ToString() is { } name)
+            _headers.Remove(name);
+        return RuntimeValue.FromObject(this);
+    }
+
+    private RuntimeValue HasHeader(ReadOnlySpan<RuntimeValue> args)
+    {
+        var name = args.Length > 0 ? args[0].ToObject()?.ToString() : null;
+        return RuntimeValue.FromBoolean(name != null && _headers.ContainsKey(name));
+    }
+
+    private RuntimeValue GetHeaders()
+    {
+        var obj = new Dictionary<string, object?>();
+        foreach (var (key, entry) in _headers)
+            obj[key.ToLowerInvariant()] = entry.Value;
+        return RuntimeValue.FromObject(new SharpTSObject(obj));
+    }
+
+    private RuntimeValue GetHeaderNames()
+    {
+        var names = _headers.Keys.Select(k => (object?)k.ToLowerInvariant()).ToList();
+        return RuntimeValue.FromObject(new SharpTSArray(names));
+    }
+
+    private RuntimeValue GetRawHeaderNames()
+    {
+        var names = _headers.Values.Select(e => (object?)e.Name).ToList();
+        return RuntimeValue.FromObject(new SharpTSArray(names));
+    }
+
+    private RuntimeValue SetTimeout(Interpreter interpreter, ReadOnlySpan<RuntimeValue> args)
+    {
+        if (args.Length > 0 && args[0].IsNumber)
+            _timeoutMs = (int)args[0].AsNumberUnsafe();
+        if (args.Length > 1 && args[1].ToObject() is ISharpTSCallable cb)
+        {
+            var on = ((SharpTSEventEmitter)this).GetMember("on") as BuiltInMethod;
+            on?.Bind(this).Call(interpreter, ["timeout", cb]);
+        }
+        return RuntimeValue.FromObject(this);
+    }
+
+    private RuntimeValue Abort(Interpreter interpreter)
+    {
+        if (_aborted) return RuntimeValue.FromObject(this);
+        _aborted = true;
+        try { _cts.Cancel(); } catch { }
+        EmitEvent(interpreter, "abort", []);
+        EmitEvent(interpreter, "close", []);
+        return RuntimeValue.FromObject(this);
+    }
+
+    private RuntimeValue DestroyRequest(Interpreter interpreter, ReadOnlySpan<RuntimeValue> args)
+    {
+        if (_aborted) return RuntimeValue.FromObject(this);
+        _aborted = true;
+        try { _cts.Cancel(); } catch { }
+        if (args.Length > 0 && args[0].ToObject() is { } err && err is not SharpTSUndefined)
+            EmitEvent(interpreter, "error", [err]);
+        EmitEvent(interpreter, "close", []);
+        return RuntimeValue.FromObject(this);
+    }
+
+    /// <summary>
+    /// Performs the actual HTTP exchange on a thread-pool task and delivers the response
+    /// (or error) back on the event-loop thread.
+    /// </summary>
+    private void SendAsync()
+    {
+        if (_sent) return;
+        _sent = true;
+
+        var bodyBytes = ConcatBody();
+        _interpreter.Ref();
+
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                var client = HttpClientRequestHelpers.GetClient(_rejectUnauthorized);
+                using var request = BuildRequestMessage(bodyBytes);
+
+                // Optional non-aborting timeout: emit 'timeout' if the request runs long.
+                Task? timeoutTask = _timeoutMs > 0 ? Task.Delay(_timeoutMs, _cts.Token) : null;
+                var sendTask = client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, _cts.Token);
+
+                if (timeoutTask != null)
+                {
+                    var completed = await Task.WhenAny(sendTask, timeoutTask);
+                    if (completed == timeoutTask && !sendTask.IsCompleted)
+                    {
+                        _interpreter.ScheduleTimer(0, 0,
+                            () => { if (!_responseReceived) EmitEvent(_interpreter, "timeout", []); },
+                            isInterval: false);
+                    }
+                }
+
+                using var response = await sendTask;
+                var (status, reason, version, headersLower, raw) = ExtractResponse(response);
+                var body = await response.Content.ReadAsByteArrayAsync(_cts.Token);
+
+                _interpreter.ScheduleTimer(0, 0, () =>
+                {
+                    DeliverResponse(status, reason, version, headersLower, raw, body);
+                    _interpreter.Unref();
+                }, isInterval: false);
+            }
+            catch (OperationCanceledException)
+            {
+                // Aborted/destroyed — 'abort'/'close' were already emitted synchronously.
+                _interpreter.ScheduleTimer(0, 0, () => _interpreter.Unref(), isInterval: false);
+            }
+            catch (Exception ex)
+            {
+                _interpreter.ScheduleTimer(0, 0, () =>
+                {
+                    if (!_aborted)
+                        EmitEvent(_interpreter, "error", [MakeRequestError(ex)]);
+                    _interpreter.Unref();
+                }, isInterval: false);
+            }
+        });
+    }
+
+    private void DeliverResponse(int status, string reason, string version,
+        Dictionary<string, object?> headersLower, List<object?> raw, byte[] body)
+    {
+        if (_aborted) return;
+        _responseReceived = true;
+
+        _socketObject = BuildSocketObject();
+        EmitEvent(_interpreter, "socket", [_socketObject]);
+
+        var response = new SharpTSClientResponse(status, reason, version, headersLower, raw, _socketObject);
+
+        // 1xx informational responses surface as 'information'/'continue', not 'response'.
+        EmitEvent(_interpreter, "response", [response]);
+
+        // Push the body into the response Readable; user listeners were attached
+        // synchronously inside the 'response' handler.
+        var push = ((SharpTSReadable)response).GetMember("push") as BuiltInMethod;
+        var bound = push?.Bind(response);
+        if (body.Length > 0)
+            bound?.Call(_interpreter, [new SharpTSBuffer(body)]);
+        // Mark complete BEFORE the EOF push so res.complete is true inside the 'end' handler.
+        response.MarkComplete();
+        bound?.Call(_interpreter, new List<object?> { null });
+    }
+
+    private HttpRequestMessage BuildRequestMessage(byte[] bodyBytes)
+    {
+        var request = new HttpRequestMessage(new HttpMethod(_method), _url);
+        bool hasBody = bodyBytes.Length > 0;
+        HttpContent? content = hasBody ? new ByteArrayContent(bodyBytes) : null;
+        if (content != null)
+            content.Headers.Clear();
+
+        foreach (var (_, entry) in _headers)
+        {
+            var name = entry.Name;
+            if (name.Equals("Content-Length", StringComparison.OrdinalIgnoreCase))
+                continue; // managed automatically by HttpContent
+
+            foreach (var value in EnumerateHeaderValues(entry.Value))
+            {
+                bool added = request.Headers.TryAddWithoutValidation(name, value);
+                if (!added)
+                {
+                    content ??= new ByteArrayContent(Array.Empty<byte>());
+                    content.Headers.TryAddWithoutValidation(name, value);
+                }
+            }
+        }
+
+        request.Content = content;
+        return request;
+    }
+
+    private static IEnumerable<string> EnumerateHeaderValues(object? value)
+    {
+        if (value is SharpTSArray arr)
+        {
+            foreach (var v in arr)
+                yield return v?.ToString() ?? "";
+        }
+        else
+        {
+            yield return value?.ToString() ?? "";
+        }
+    }
+
+    private static (int status, string reason, string version,
+        Dictionary<string, object?> headersLower, List<object?> raw) ExtractResponse(HttpResponseMessage response)
+    {
+        var status = (int)response.StatusCode;
+        var reason = response.ReasonPhrase ?? "";
+        var version = $"{response.Version.Major}.{response.Version.Minor}";
+        var headersLower = new Dictionary<string, object?>();
+        var raw = new List<object?>();
+
+        void Collect(IEnumerable<KeyValuePair<string, IEnumerable<string>>> headers)
+        {
+            foreach (var header in headers)
+            {
+                var lower = header.Key.ToLowerInvariant();
+                var values = header.Value.ToList();
+                foreach (var v in values)
+                {
+                    raw.Add(header.Key);
+                    raw.Add(v);
+                }
+                if (lower == "set-cookie")
+                    headersLower[lower] = new SharpTSArray(values.Select(v => (object?)v).ToList());
+                else
+                    headersLower[lower] = string.Join(", ", values);
+            }
+        }
+
+        Collect(response.Headers);
+        if (response.Content?.Headers != null)
+            Collect(response.Content.Headers);
+
+        return (status, reason, version, headersLower, raw);
+    }
+
+    private SharpTSObject MakeRequestError(Exception ex)
+    {
+        string code = ex switch
+        {
+            HttpRequestException hre when hre.Message.Contains("refused", StringComparison.OrdinalIgnoreCase) => "ECONNREFUSED",
+            HttpRequestException => "ECONNRESET",
+            TaskCanceledException => "ECONNRESET",
+            _ => "ECONNRESET"
+        };
+        var err = new SharpTSError(ex.Message) { Code = code };
+        return new SharpTSObject(new Dictionary<string, object?>
+        {
+            ["message"] = err.Message,
+            ["code"] = code,
+            ["name"] = "Error"
+        });
+    }
+
+    private SharpTSObject BuildSocketObject()
+    {
+        string host = GetHostName();
+        int port = GetPort();
+        return new SharpTSObject(new Dictionary<string, object?>
+        {
+            ["remoteAddress"] = host,
+            ["remotePort"] = (double)port,
+            ["localAddress"] = "127.0.0.1",
+            ["localPort"] = (double)0,
+            ["encrypted"] = _isHttps,
+            ["writable"] = true,
+            ["readable"] = true
+        });
+    }
+
+    private byte[] ConcatBody()
+    {
+        if (_bodyChunks.Count == 0) return Array.Empty<byte>();
+        if (_bodyChunks.Count == 1) return _bodyChunks[0];
+        var total = _bodyChunks.Sum(c => c.Length);
+        var result = new byte[total];
+        int offset = 0;
+        foreach (var chunk in _bodyChunks)
+        {
+            Array.Copy(chunk, 0, result, offset, chunk.Length);
+            offset += chunk.Length;
+        }
+        return result;
+    }
+
+    private string GetPath()
+    {
+        try { var u = new Uri(_url); return u.PathAndQuery; } catch { return "/"; }
+    }
+
+    private string GetHostName()
+    {
+        try { return new Uri(_url).Host; } catch { return "localhost"; }
+    }
+
+    private int GetPort()
+    {
+        try { var u = new Uri(_url); return u.Port; } catch { return _isHttps ? 443 : 80; }
+    }
+
+    private static Encoding GetEncoding(string name) => name.ToLowerInvariant() switch
+    {
+        "utf8" or "utf-8" => Encoding.UTF8,
+        "ascii" => Encoding.ASCII,
+        "latin1" or "binary" => Encoding.Latin1,
+        "utf16le" or "ucs2" or "ucs-2" => Encoding.Unicode,
+        "base64" => Encoding.UTF8,
+        _ => Encoding.UTF8
+    };
+
+    public override string ToString() => $"ClientRequest {{ method: '{_method}' }}";
+}

--- a/Runtime/Types/SharpTSClientRequest.cs
+++ b/Runtime/Types/SharpTSClientRequest.cs
@@ -45,6 +45,8 @@ public class SharpTSClientRequest : SharpTSWritable
     private int _timeoutMs;
     private readonly CancellationTokenSource _cts = new();
     private SharpTSObject? _socketObject;
+    private SharpTSAgent? _agent;        // null when options.agent === false (no pooling)
+    private bool _agentTracked;
 
     public SharpTSClientRequest(Interpreter interpreter, string method, string url, SharpTSObject? options, bool isHttps)
     {
@@ -52,6 +54,7 @@ public class SharpTSClientRequest : SharpTSWritable
         _method = string.IsNullOrEmpty(method) ? "GET" : method.ToUpperInvariant();
         _url = url;
         _isHttps = isHttps;
+        _agent = SharpTSAgent.GlobalAgent; // default pool (Node semantics); overridden below
 
         if (options != null)
         {
@@ -65,6 +68,13 @@ public class SharpTSClientRequest : SharpTSWritable
                 _timeoutMs = (int)tov;
             if (options.Fields.TryGetValue("rejectUnauthorized", out var ru) && ru is bool rub)
                 _rejectUnauthorized = rub;
+            // Resolve the connection agent (#1051): an explicit SharpTSAgent, false for no
+            // pooling, or the global agent by default.
+            if (options.Fields.TryGetValue("agent", out var ag))
+            {
+                if (ag is SharpTSAgent customAgent) _agent = customAgent;
+                else if (ag is false) _agent = null;
+            }
             // options.auth ("user:pass") → Basic Authorization header (Node semantics).
             if (options.Fields.TryGetValue("auth", out var au) && au is string authStr && authStr.Length > 0
                 && !_headers.ContainsKey("authorization"))
@@ -302,6 +312,13 @@ public class SharpTSClientRequest : SharpTSWritable
         if (_sent) return;
         _sent = true;
 
+        // Register with the connection agent's pool (#1051), unless agent:false.
+        if (_agent != null)
+        {
+            _agent.TrackSocketStart(PoolOrigin());
+            _agentTracked = true;
+        }
+
         var bodyBytes = ConcatBody();
         _interpreter.Ref();
 
@@ -339,6 +356,7 @@ public class SharpTSClientRequest : SharpTSWritable
                 var (status, reason, version, headersLower, raw) = ExtractResponse(response);
                 var body = await response.Content.ReadAsByteArrayAsync(_cts.Token);
 
+                EndAgentTracking(keepAlive: true);
                 _interpreter.ScheduleTimer(0, 0, () =>
                 {
                     DeliverResponse(status, reason, version, headersLower, raw, body);
@@ -348,10 +366,12 @@ public class SharpTSClientRequest : SharpTSWritable
             catch (OperationCanceledException)
             {
                 // Aborted/destroyed — 'abort'/'close' were already emitted synchronously.
+                EndAgentTracking(keepAlive: false);
                 _interpreter.ScheduleTimer(0, 0, () => _interpreter.Unref(), isInterval: false);
             }
             catch (Exception ex)
             {
+                EndAgentTracking(keepAlive: false);
                 _interpreter.ScheduleTimer(0, 0, () =>
                 {
                     if (!_aborted)
@@ -505,6 +525,17 @@ public class SharpTSClientRequest : SharpTSWritable
             ["readable"] = true
         });
     }
+
+    private void EndAgentTracking(bool keepAlive)
+    {
+        if (_agentTracked && _agent != null)
+        {
+            _agent.TrackSocketEnd(PoolOrigin(), keepAlive);
+            _agentTracked = false;
+        }
+    }
+
+    private string PoolOrigin() => $"{GetHostName()}:{GetPort()}";
 
     private byte[] ConcatBody()
     {

--- a/Runtime/Types/SharpTSClientResponse.cs
+++ b/Runtime/Types/SharpTSClientResponse.cs
@@ -1,0 +1,107 @@
+using SharpTS.Execution;
+using SharpTS.Runtime.BuiltIns;
+using SharpTS.TypeSystem;
+
+namespace SharpTS.Runtime.Types;
+
+/// <summary>
+/// Runtime representation of an HTTP client-side IncomingMessage (the response to a
+/// <see cref="SharpTSClientRequest"/>). Extends <see cref="SharpTSReadable"/> so the
+/// response body is a Readable stream ('data'/'end'/'error', <c>for await</c>).
+/// </summary>
+/// <remarks>
+/// Built from the data extracted from a .NET <c>HttpResponseMessage</c> rather than
+/// holding the message itself, so the underlying response can be disposed. Properties:
+/// statusCode, statusMessage, httpVersion/Major/Minor, headers (lowercased),
+/// rawHeaders (original case + order), complete, aborted.
+/// </remarks>
+public class SharpTSClientResponse : SharpTSReadable
+{
+    /// <inheritdoc />
+    public override TypeCategory RuntimeCategory => TypeCategory.Record;
+
+    private readonly int _statusCode;
+    private readonly string _statusMessage;
+    private readonly string _httpVersion;
+    private readonly Dictionary<string, object?> _headers;
+    private readonly List<object?> _rawHeaders;
+    private readonly SharpTSObject? _socket;
+    private bool _complete;
+    private bool _aborted;
+
+    public SharpTSClientResponse(
+        int statusCode,
+        string statusMessage,
+        string httpVersion,
+        Dictionary<string, object?> headers,
+        List<object?> rawHeaders,
+        SharpTSObject? socket = null)
+    {
+        _statusCode = statusCode;
+        _statusMessage = statusMessage;
+        _httpVersion = httpVersion;
+        _headers = headers;
+        _rawHeaders = rawHeaders;
+        _socket = socket;
+    }
+
+    /// <summary>Marks the body as fully delivered (set when the stream ends).</summary>
+    internal void MarkComplete() => _complete = true;
+
+    /// <summary>Marks the response as aborted (request torn down before the body finished).</summary>
+    internal void MarkAborted() => _aborted = true;
+
+    public new object? GetMember(string name)
+    {
+        return name switch
+        {
+            "statusCode" => (double)_statusCode,
+            "statusMessage" => _statusMessage,
+            "httpVersion" => _httpVersion,
+            "httpVersionMajor" => (double)ParseVersionPart(0),
+            "httpVersionMinor" => (double)ParseVersionPart(1),
+            "headers" => new SharpTSObject(new Dictionary<string, object?>(_headers)),
+            "headersDistinct" => GetHeadersDistinct(),
+            "rawHeaders" => new SharpTSArray(new List<object?>(_rawHeaders)),
+            "trailers" => new SharpTSObject(new Dictionary<string, object?>()),
+            "rawTrailers" => new SharpTSArray(new List<object?>()),
+            "complete" => _complete,
+            "aborted" => _aborted,
+            "url" => "",
+            "method" => (object?)null,
+            "socket" or "connection" => (object?)_socket ?? new SharpTSObject(new Dictionary<string, object?>()),
+            "setTimeout" => BuiltInMethod.CreateV2("setTimeout", 1, 2, (interp, receiver, args) =>
+            {
+                // IncomingMessage.setTimeout(msecs, cb?) — cb registered as a 'timeout' listener.
+                if (args.Length > 1 && args[1].ToObject() is ISharpTSCallable cb)
+                    EmitEvent(interp, "__noop_register_timeout", []); // no-op; timeouts are managed by the request
+                return receiver;
+            }),
+
+            // Inherit Readable stream methods (on, once, pipe, read, pause, resume, for await, etc.)
+            _ => base.GetMember(name)
+        };
+    }
+
+    private int ParseVersionPart(int index)
+    {
+        var parts = _httpVersion.Split('.');
+        if (index < parts.Length && int.TryParse(parts[index], out var v))
+            return v;
+        return index == 0 ? 1 : 1;
+    }
+
+    private SharpTSObject GetHeadersDistinct()
+    {
+        // Node's headersDistinct keeps every header value as a string array.
+        var distinct = new Dictionary<string, object?>();
+        foreach (var (key, value) in _headers)
+        {
+            var arr = new List<object?> { value };
+            distinct[key] = new SharpTSArray(arr);
+        }
+        return new SharpTSObject(distinct);
+    }
+
+    public override string ToString() => $"IncomingMessage {{ statusCode: {_statusCode} }}";
+}

--- a/Runtime/Types/SharpTSEventEmitter.cs
+++ b/Runtime/Types/SharpTSEventEmitter.cs
@@ -235,6 +235,13 @@ public class SharpTSEventEmitter : ITypeCategorized
     internal void ClearAllListenersInternal() => _events.Clear();
 
     /// <summary>
+    /// Returns true if at least one listener is registered for the event (host-side check,
+    /// used to skip building event payloads when nobody is listening).
+    /// </summary>
+    internal bool HasListenersInternal(string eventName)
+        => _events.TryGetValue(eventName, out var l) && l.Count > 0;
+
+    /// <summary>
     /// Returns an array of listener functions for the specified event.
     /// </summary>
     private RuntimeValue Listeners(Interp interpreter, RuntimeValue receiver, ReadOnlySpan<RuntimeValue> args)

--- a/Runtime/Types/SharpTSHttpRequest.cs
+++ b/Runtime/Types/SharpTSHttpRequest.cs
@@ -47,6 +47,11 @@ public class SharpTSHttpRequest : SharpTSReadable
     /// </summary>
     public string HttpVersion => $"{_request.ProtocolVersion.Major}.{_request.ProtocolVersion.Minor}";
 
+    private bool _aborted;
+
+    /// <summary>Marks the request as aborted (peer disconnected before the body finished).</summary>
+    internal void MarkAborted() => _aborted = true;
+
     /// <summary>
     /// Gets a member (property or method) by name.
     /// Overrides Readable.GetMember to add HTTP-specific properties.
@@ -59,14 +64,19 @@ public class SharpTSHttpRequest : SharpTSReadable
             "method" => Method,
             "url" => Url,
             "httpVersion" => HttpVersion,
+            "httpVersionMajor" => (double)_request.ProtocolVersion.Major,
+            "httpVersionMinor" => (double)_request.ProtocolVersion.Minor,
             "headers" => GetHeadersObject(),
+            "headersDistinct" => GetHeadersDistinct(),
             "rawHeaders" => GetRawHeaders(),
-            "socket" => CreateSocketObject(),
+            "socket" or "connection" => CreateSocketObject(),
             "complete" => _bodyRead && _endEmitted,
-            "statusCode" => (double)_request.ProtocolVersion.Major, // For response messages
-            "statusMessage" => (object?)null,
+            // Server-side IncomingMessage has no statusCode/statusMessage (those are client-side).
+            "statusCode" => SharpTSUndefined.Instance,
+            "statusMessage" => SharpTSUndefined.Instance,
             "trailers" => new SharpTSObject(new Dictionary<string, object?>()),
-            "aborted" => false,
+            "rawTrailers" => new SharpTSArray(new List<object?>()),
+            "aborted" => _aborted,
 
             // Inherit Readable stream methods (on, once, pipe, read, pause, resume, etc.)
             _ => base.GetMember(name)
@@ -80,24 +90,27 @@ public class SharpTSHttpRequest : SharpTSReadable
     internal async Task EmitDataEventsAsync(Interpreter interpreter)
     {
         if (_bodyRead) return;
+        _bodyRead = true;
 
         try
         {
-            using var ms = new MemoryStream();
-            await _request.InputStream.CopyToAsync(ms);
-            var body = ms.ToArray();
-            _bodyRead = true;
+            var pushMethod = base.GetMember("push") as BuiltInMethod;
+            var bound = pushMethod?.Bind(this);
 
-            // Push data into the Readable stream (triggers 'data' events if flowing)
-            if (body.Length > 0)
+            // On-demand streaming (#1048): read the request body in chunks and push each as it
+            // arrives, rather than buffering the whole body then emitting one 'data'. Listeners
+            // were attached synchronously by the handler before this runs.
+            var buffer = new byte[16384];
+            int n;
+            while ((n = await _request.InputStream.ReadAsync(buffer, 0, buffer.Length)) > 0)
             {
-                var pushMethod = base.GetMember("push") as BuiltInMethod;
-                pushMethod?.Bind(this).Call(interpreter, [new SharpTSBuffer(body)]);
+                var chunk = new byte[n];
+                Array.Copy(buffer, chunk, n);
+                bound?.Call(interpreter, [new SharpTSBuffer(chunk)]);
             }
 
             // Signal EOF
-            var pushNull = base.GetMember("push") as BuiltInMethod;
-            pushNull?.Bind(this).Call(interpreter, new List<object?> { null });
+            bound?.Call(interpreter, new List<object?> { null });
             _endEmitted = true;
         }
         catch (Exception ex)
@@ -105,6 +118,20 @@ public class SharpTSHttpRequest : SharpTSReadable
             // Emit 'error' event through the Readable stream
             EmitEvent(interpreter, "error", [new SharpTSError(ex.Message)]);
         }
+    }
+
+    /// <summary>
+    /// Node's headersDistinct — every header value as a string array.
+    /// </summary>
+    private SharpTSObject GetHeadersDistinct()
+    {
+        var distinct = new Dictionary<string, object?>();
+        foreach (string? key in _request.Headers.AllKeys)
+        {
+            if (key != null)
+                distinct[key.ToLowerInvariant()] = new SharpTSArray(new List<object?> { _request.Headers[key] });
+        }
+        return new SharpTSObject(distinct);
     }
 
     /// <summary>
@@ -145,12 +172,17 @@ public class SharpTSHttpRequest : SharpTSReadable
     /// </summary>
     private SharpTSObject CreateSocketObject()
     {
+        var remote = _request.RemoteEndPoint;
+        string family = remote?.AddressFamily == System.Net.Sockets.AddressFamily.InterNetworkV6 ? "IPv6" : "IPv4";
         return new SharpTSObject(new Dictionary<string, object?>
         {
-            ["remoteAddress"] = _request.RemoteEndPoint?.Address?.ToString(),
-            ["remotePort"] = (double?)_request.RemoteEndPoint?.Port,
+            ["remoteAddress"] = remote?.Address?.ToString(),
+            ["remotePort"] = (double?)remote?.Port,
+            ["remoteFamily"] = family,
             ["localAddress"] = _request.LocalEndPoint?.Address?.ToString(),
-            ["localPort"] = (double?)_request.LocalEndPoint?.Port
+            ["localPort"] = (double?)_request.LocalEndPoint?.Port,
+            ["family"] = family,
+            ["encrypted"] = _request.IsSecureConnection
         });
     }
 

--- a/Runtime/Types/SharpTSHttpResponse.cs
+++ b/Runtime/Types/SharpTSHttpResponse.cs
@@ -24,8 +24,10 @@ public class SharpTSHttpResponse : SharpTSWritable
     private readonly HttpListenerResponse _response;
     private bool _headersSent;
     private bool _finished;
-    private readonly List<byte> _bodyBuffer = new();
+    private bool _streaming;      // true once write() has committed headers and started streaming
+    private bool _sendDate = true;
     private readonly Dictionary<string, string> _pendingHeaders = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<string, string> _trailers = new(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
     /// Creates a new ServerResponse wrapping an HttpListenerResponse.
@@ -76,7 +78,9 @@ public class SharpTSHttpResponse : SharpTSWritable
             "statusMessage" => StatusMessage,
             "headersSent" => HeadersSent,
             "finished" => Finished,
-            "sendDate" => true,
+            "writableEnded" => Finished,
+            "writableFinished" => Finished,
+            "sendDate" => _sendDate,
             "connection" => (object?)null,
             "socket" => (object?)null,
 
@@ -125,7 +129,19 @@ public class SharpTSHttpResponse : SharpTSWritable
                 FlushHeaders();
                 return RuntimeValue.Null;
             }).Bind(this),
-            "writeContinue" => BuiltInMethod.CreateV2("writeContinue", 0, (_, _, _) => RuntimeValue.Null).Bind(this),
+            // 100 Continue / 102 Processing — HttpListener auto-sends 100-continue when the
+            // request body is read and cannot send 1xx interim responses, so these are no-ops
+            // exposed for API compatibility.
+            "writeContinue" => BuiltInMethod.CreateV2("writeContinue", 0, (_, _, _) => RuntimeValue.Undefined).Bind(this),
+            "writeProcessing" => BuiltInMethod.CreateV2("writeProcessing", 0, (_, _, _) => RuntimeValue.Undefined).Bind(this),
+            // addTrailers stores trailing headers; HttpListener has no trailer API, so they are
+            // recorded (and observable via getHeader-style introspection is not offered) but not
+            // emitted on the wire — documented limitation.
+            "addTrailers" => BuiltInMethod.CreateV2("addTrailers", 1, (_, receiver, args) =>
+            {
+                if (receiver.ToObject() is SharpTSHttpResponse res) res.AddTrailers(args);
+                return RuntimeValue.Undefined;
+            }).Bind(this),
 
             // Inherit Writable stream methods (on, once, cork, uncork, etc.)
             _ => base.GetMember(name)
@@ -150,7 +166,18 @@ public class SharpTSHttpResponse : SharpTSWritable
                 if (value is string s)
                     StatusMessage = s;
                 break;
+            case "sendDate":
+                if (value is bool b)
+                    _sendDate = b;
+                break;
         }
+    }
+
+    private void AddTrailers(ReadOnlySpan<RuntimeValue> args)
+    {
+        if (args.Length == 0 || args[0].ToObject() is not SharpTSObject headers) return;
+        foreach (var kv in headers.Fields)
+            _trailers[kv.Key] = kv.Value?.ToString() ?? "";
     }
 
     /// <summary>
@@ -187,66 +214,76 @@ public class SharpTSHttpResponse : SharpTSWritable
     }
 
     /// <summary>
-    /// Writes data to the response body.
+    /// Writes a body chunk. The first write() commits the headers and switches the response
+    /// into streaming mode — chunked transfer-encoding when no Content-Length was set —
+    /// matching Node's behaviour (a lone end(chunk) instead sends a Content-Length response).
     /// </summary>
     private RuntimeValue WriteData(Interpreter interpreter, ReadOnlySpan<RuntimeValue> args)
     {
         if (_finished)
             throw new Exception("Runtime Error: Cannot write after response has ended");
 
-        if (args.Length == 0) return RuntimeValue.True;
-
-        byte[] data;
-        var encoding = args.Length > 1 && args[1].IsString ? args[1].AsStringUnsafe() : "utf8";
-
-        switch (args[0].ToObject())
+        if (args.Length == 0 || args[0].ToObject() is ISharpTSCallable)
         {
-            case string str:
-                data = GetEncoding(encoding).GetBytes(str);
-                break;
-            case SharpTSBuffer buffer:
-                data = buffer.Data;
-                break;
-            default:
-                data = Encoding.UTF8.GetBytes(args[0].ToObject()?.ToString() ?? "");
-                break;
+            // write(cb) with no data — invoke the callback, nothing to send.
+            if (args.Length > 0 && args[0].ToObject() is ISharpTSCallable cbOnly)
+                cbOnly.Call(interpreter, []);
+            return RuntimeValue.True;
         }
 
-        _bodyBuffer.AddRange(data);
+        byte[] data = EncodeChunk(args);
 
-        // Call write callback if provided
+        EnsureHeadersCommitted(forceChunked: true);
+        _streaming = true;
+        try
+        {
+            if (data.Length > 0)
+                _response.OutputStream.Write(data, 0, data.Length);
+        }
+        catch { /* client may have disconnected */ }
+
+        // Optional write callback: (chunk, encoding?, callback?)
         ISharpTSCallable? callback = null;
         if (args.Length > 1 && args[1].ToObject() is ISharpTSCallable cb1) callback = cb1;
         if (args.Length > 2 && args[2].ToObject() is ISharpTSCallable cb2) callback = cb2;
         callback?.Call(interpreter, []);
 
+        // Synchronous write — no internal buffering, so never apply backpressure.
         return RuntimeValue.True;
     }
 
     /// <summary>
-    /// Ends the response, optionally writing final data.
+    /// Ends the response, optionally writing a final chunk.
     /// </summary>
     private RuntimeValue EndResponse(Interpreter interpreter, ReadOnlySpan<RuntimeValue> args)
     {
         if (_finished) return RuntimeValue.FromObject(this);
 
-        // Write any final data
-        if (args.Length > 0 && args[0].ToObject() is { } first && first is not ISharpTSCallable)
+        byte[]? finalChunk = null;
+        if (args.Length > 0)
         {
-            WriteData(interpreter, args);
+            var first = args[0].ToObject();
+            if (first is not ISharpTSCallable && first is not null && first is not SharpTSUndefined)
+                finalChunk = EncodeChunk(args);
         }
 
-        // Flush pending headers
-        FlushHeaders();
-
-        // Actually send the response
         try
         {
-            _headersSent = true;
-            _response.ContentLength64 = _bodyBuffer.Count;
-            if (_bodyBuffer.Count > 0)
+            if (_streaming)
             {
-                _response.OutputStream.Write(_bodyBuffer.ToArray(), 0, _bodyBuffer.Count);
+                // Headers already committed (chunked). Just write the final chunk.
+                if (finalChunk is { Length: > 0 })
+                    _response.OutputStream.Write(finalChunk, 0, finalChunk.Length);
+            }
+            else
+            {
+                // Simple single-body response: commit with an explicit Content-Length.
+                EnsureHeadersCommitted(forceChunked: false);
+                var body = finalChunk ?? Array.Empty<byte>();
+                if (!_pendingHeaders.ContainsKey("Content-Length"))
+                    _response.ContentLength64 = body.Length;
+                if (body.Length > 0)
+                    _response.OutputStream.Write(body, 0, body.Length);
             }
             _response.OutputStream.Close();
         }
@@ -257,7 +294,7 @@ public class SharpTSHttpResponse : SharpTSWritable
 
         _finished = true;
 
-        // Call callback
+        // Call callback (any trailing function argument).
         ISharpTSCallable? callback = null;
         foreach (var arg in args)
         {
@@ -265,12 +302,38 @@ public class SharpTSHttpResponse : SharpTSWritable
         }
         callback?.Call(interpreter, []);
 
-        // Emit 'finish' event (Writable stream semantics)
+        // Writable stream semantics.
         EmitEvent(interpreter, "finish", []);
-        // Emit 'close' event
         EmitEvent(interpreter, "close", []);
 
         return RuntimeValue.FromObject(this);
+    }
+
+    /// <summary>
+    /// Commits the status line + headers if not already sent. When <paramref name="forceChunked"/>
+    /// is set and no Content-Length was provided, switches to chunked transfer-encoding.
+    /// </summary>
+    private void EnsureHeadersCommitted(bool forceChunked)
+    {
+        if (_headersSent) return;
+        FlushHeaders();
+        if (forceChunked && !_pendingHeaders.ContainsKey("Content-Length"))
+        {
+            try { _response.SendChunked = true; } catch { /* already committed */ }
+        }
+        _headersSent = true;
+    }
+
+    private byte[] EncodeChunk(ReadOnlySpan<RuntimeValue> args)
+    {
+        var encoding = args.Length > 1 && args[1].IsString ? args[1].AsStringUnsafe() : "utf8";
+        return args[0].ToObject() switch
+        {
+            string str => GetEncoding(encoding).GetBytes(str),
+            SharpTSBuffer buffer => buffer.Data,
+            null => Array.Empty<byte>(),
+            var other => Encoding.UTF8.GetBytes(other.ToString() ?? "")
+        };
     }
 
     /// <summary>

--- a/Runtime/Types/SharpTSHttpServer.cs
+++ b/Runtime/Types/SharpTSHttpServer.cs
@@ -29,6 +29,17 @@ public class SharpTSHttpServer : SharpTSEventEmitter, IDisposable
     private bool _isClusterWorker;
     private int _port;
 
+    // Server-management surface (#1045). HttpListener does not expose per-connection
+    // control, so these timeouts/limits are stored as observable Node-compatible config
+    // (defaults match Node 24); requestTimeout is enforced by aborting the response.
+    private double _keepAliveTimeout = 5000;
+    private double _headersTimeout = 60000;
+    private double _requestTimeout = 300000;
+    private double _timeout;             // 0 = no socket timeout (Node default)
+    private double _maxHeadersCount = 2000;
+    private double _maxRequestsPerSocket;
+    private ISharpTSCallable? _timeoutCallback;
+
     // Drain-before-close state (issue #41): close() doesn't tear the listener
     // down while requests are in flight. It marks _closeRequested, then the
     // last HandleRequestAsync to finish invokes FinishClose. Mutations to
@@ -87,9 +98,75 @@ public class SharpTSHttpServer : SharpTSEventEmitter, IDisposable
                 RuntimeValue.FromBoxed(receiver.ToObject() is SharpTSHttpServer server
                     ? server.GetAddress()
                     : null)).Bind(this),
+
+            // Server lifecycle/management (#1045).
+            "closeAllConnections" => BuiltInMethod.CreateV2("closeAllConnections", 0, (_, receiver, _) =>
+            {
+                if (receiver.ToObject() is SharpTSHttpServer s) s.CloseAllConnections();
+                return RuntimeValue.Undefined;
+            }).Bind(this),
+            "closeIdleConnections" => BuiltInMethod.CreateV2("closeIdleConnections", 0, (_, _, _) =>
+                // HttpListener manages keep-alive connections internally and exposes no idle set;
+                // there is nothing for us to close here.
+                RuntimeValue.Undefined).Bind(this),
+            "setTimeout" => BuiltInMethod.CreateV2("setTimeout", 1, 2, (_, receiver, args) =>
+            {
+                if (receiver.ToObject() is SharpTSHttpServer s) return s.SetTimeout(args);
+                return receiver;
+            }).Bind(this),
+
+            // Config properties (settable via SetMember).
+            "keepAliveTimeout" => _keepAliveTimeout,
+            "headersTimeout" => _headersTimeout,
+            "requestTimeout" => _requestTimeout,
+            "timeout" => _timeout,
+            "maxHeadersCount" => _maxHeadersCount,
+            "maxRequestsPerSocket" => _maxRequestsPerSocket,
+
             // Inherit EventEmitter methods for on, once, off, emit, removeAllListeners, etc.
             _ => base.GetMember(name)
         };
+    }
+
+    /// <summary>
+    /// Sets a settable server config property (#1045).
+    /// </summary>
+    public void SetMember(string name, object? value)
+    {
+        switch (name)
+        {
+            case "keepAliveTimeout": if (value is double ka) _keepAliveTimeout = ka; break;
+            case "headersTimeout": if (value is double ht) _headersTimeout = ht; break;
+            case "requestTimeout": if (value is double rt) _requestTimeout = rt; break;
+            case "timeout": if (value is double t) _timeout = t; break;
+            case "maxHeadersCount": if (value is double mh) _maxHeadersCount = mh; break;
+            case "maxRequestsPerSocket": if (value is double mr) _maxRequestsPerSocket = mr; break;
+        }
+    }
+
+    private RuntimeValue SetTimeout(ReadOnlySpan<RuntimeValue> args)
+    {
+        if (args.Length > 0 && args[0].IsNumber)
+            _timeout = args[0].AsNumberUnsafe();
+        if (args.Length > 1 && args[1].ToObject() is ISharpTSCallable cb)
+        {
+            _timeoutCallback = cb;
+            var on = base.GetMember("on") as BuiltInMethod;
+            on?.Bind(this).Call(_interpreter!, ["timeout", cb]);
+        }
+        return RuntimeValue.FromObject(this);
+    }
+
+    /// <summary>
+    /// Forcibly closes the server, tearing down the listener immediately rather than draining
+    /// in-flight requests (Node's <c>closeAllConnections</c>).
+    /// </summary>
+    private void CloseAllConnections()
+    {
+        if (!_isListening) return;
+        lock (_stateLock) { _closeRequested = true; }
+        _cts?.Cancel();
+        FinishClose();
     }
 
     /// <summary>
@@ -447,6 +524,23 @@ public class SharpTSHttpServer : SharpTSEventEmitter, IDisposable
             {
                 try
                 {
+                    // Emit 'connection' best-effort (#1045). HttpListener exposes contexts, not raw
+                    // TCP connections, so this fires per accepted request with a minimal socket
+                    // object — an approximation under keep-alive, documented as such.
+                    if (HasListenersInternal("connection"))
+                    {
+                        EmitEvent("connection", new List<object?>
+                        {
+                            new SharpTSObject(new Dictionary<string, object?>
+                            {
+                                ["remoteAddress"] = context.Request.RemoteEndPoint?.Address?.ToString(),
+                                ["remotePort"] = (double?)context.Request.RemoteEndPoint?.Port,
+                                ["localAddress"] = context.Request.LocalEndPoint?.Address?.ToString(),
+                                ["localPort"] = (double?)context.Request.LocalEndPoint?.Port
+                            })
+                        });
+                    }
+
                     // Emit 'request' event
                     EmitEvent("request", new List<object?> { req, res });
 

--- a/Runtime/Types/SharpTSHttpServer.cs
+++ b/Runtime/Types/SharpTSHttpServer.cs
@@ -13,7 +13,14 @@ namespace SharpTS.Runtime.Types;
 /// Extends SharpTSEventEmitter for full event handling support (on, once, off, emit, etc.).
 /// Implements IAsyncHandle to keep the event loop alive while listening.
 /// Methods: listen(port, callback?), close(callback?)
-/// Events: 'listening', 'request', 'error', 'close'
+/// Events: 'listening', 'request', 'error', 'close', 'connection', 'checkContinue'.
+///
+/// #1046 ceiling: 'upgrade'/'connect'/'clientError' are registrable (this is an EventEmitter)
+/// but cannot fire under HttpListener, which fully owns the connection and never exposes the
+/// raw socket required to hand off a protocol upgrade or CONNECT tunnel. This matches the epic's
+/// stated scope ceilings (WebSocket framing / CONNECT tunneling are userland). 'checkContinue'
+/// IS supported: when the client sends "Expect: 100-continue" and a 'checkContinue' listener is
+/// present, it is emitted in place of 'request'.
 /// </remarks>
 public class SharpTSHttpServer : SharpTSEventEmitter, IDisposable
 {
@@ -541,11 +548,27 @@ public class SharpTSHttpServer : SharpTSEventEmitter, IDisposable
                         });
                     }
 
-                    // Emit 'request' event
-                    EmitEvent("request", new List<object?> { req, res });
+                    // checkContinue (#1046): when the client sent "Expect: 100-continue" and a
+                    // 'checkContinue' listener is registered, Node emits 'checkContinue' INSTEAD
+                    // of 'request' and the listener owns the response (typically calls
+                    // res.writeContinue() then proceeds). HttpListener already sent 100-continue
+                    // when the body is read, so writeContinue() is a no-op here.
+                    var expect = context.Request.Headers["Expect"];
+                    bool wantsContinue = expect != null &&
+                        expect.Contains("100-continue", StringComparison.OrdinalIgnoreCase);
 
-                    // Call the request handler
-                    _requestHandler.Call(_interpreter!, new List<object?> { req, res });
+                    if (wantsContinue && HasListenersInternal("checkContinue"))
+                    {
+                        EmitEvent("checkContinue", new List<object?> { req, res });
+                    }
+                    else
+                    {
+                        // Emit 'request' event
+                        EmitEvent("request", new List<object?> { req, res });
+
+                        // Call the request handler
+                        _requestHandler.Call(_interpreter!, new List<object?> { req, res });
+                    }
 
                     // Read and emit body events
                     await req.EmitDataEventsAsync(_interpreter!);

--- a/Runtime/Types/SharpTSHttpsMessages.cs
+++ b/Runtime/Types/SharpTSHttpsMessages.cs
@@ -1,0 +1,217 @@
+using System.Net.Security;
+using System.Net.Sockets;
+using System.Text;
+using SharpTS.Execution;
+using SharpTS.Runtime.BuiltIns;
+using SharpTS.TypeSystem;
+
+namespace SharpTS.Runtime.Types;
+
+/// <summary>
+/// IncomingMessage for the interpreter HTTPS server (#1049). A Readable backed by the request
+/// parsed off the TLS stream by <see cref="HttpProtocol"/>.
+/// </summary>
+public class SharpTSHttpsServerRequest : SharpTSReadable
+{
+    public override TypeCategory RuntimeCategory => TypeCategory.Record;
+
+    private readonly HttpProtocol.ParsedRequest _parsed;
+    private bool _bodyDelivered;
+
+    public SharpTSHttpsServerRequest(HttpProtocol.ParsedRequest parsed) => _parsed = parsed;
+
+    public new object? GetMember(string name)
+    {
+        return name switch
+        {
+            "method" => _parsed.Method,
+            "url" => _parsed.Url,
+            "httpVersion" => _parsed.HttpVersion,
+            "httpVersionMajor" => (double)ParseVersion(0),
+            "httpVersionMinor" => (double)ParseVersion(1),
+            "headers" => new SharpTSObject(new Dictionary<string, object?>(_parsed.HeadersLower)),
+            "rawHeaders" => new SharpTSArray(new List<object?>(_parsed.RawHeaders)),
+            "trailers" => new SharpTSObject(new Dictionary<string, object?>()),
+            "rawTrailers" => new SharpTSArray(new List<object?>()),
+            "statusCode" => SharpTSUndefined.Instance,
+            "statusMessage" => SharpTSUndefined.Instance,
+            "complete" => _bodyDelivered,
+            "aborted" => false,
+            "socket" or "connection" => new SharpTSObject(new Dictionary<string, object?> { ["encrypted"] = true }),
+            _ => base.GetMember(name)
+        };
+    }
+
+    private int ParseVersion(int idx)
+    {
+        var parts = _parsed.HttpVersion.Split('.');
+        return idx < parts.Length && int.TryParse(parts[idx], out var v) ? v : 1;
+    }
+
+    /// <summary>Pushes the already-read body into the Readable after listeners are attached.</summary>
+    internal void DeliverBody(Interpreter interpreter, byte[] body)
+    {
+        var push = base.GetMember("push") as BuiltInMethod;
+        var bound = push?.Bind(this);
+        if (body.Length > 0)
+            bound?.Call(interpreter, [new SharpTSBuffer(body)]);
+        _bodyDelivered = true;
+        bound?.Call(interpreter, new List<object?> { null });
+    }
+
+    public override string ToString() => $"IncomingMessage {{ method: '{_parsed.Method}', url: '{_parsed.Url}' }}";
+}
+
+/// <summary>
+/// ServerResponse for the interpreter HTTPS server (#1049). A Writable that serializes an
+/// HTTP/1.1 response over the TLS stream and closes the connection (Connection: close).
+/// </summary>
+public class SharpTSHttpsServerResponse : SharpTSWritable
+{
+    public override TypeCategory RuntimeCategory => TypeCategory.Record;
+
+    private readonly SslStream _stream;
+    private readonly TcpClient _tcpClient;
+    private int _statusCode = 200;
+    private string? _statusMessage;
+    private bool _headersSent;
+    private bool _finished;
+    private readonly List<byte> _body = new();
+    private readonly Dictionary<string, string> _headers = new(StringComparer.OrdinalIgnoreCase);
+
+    public SharpTSHttpsServerResponse(SslStream stream, TcpClient tcpClient)
+    {
+        _stream = stream;
+        _tcpClient = tcpClient;
+    }
+
+    public new object? GetMember(string name)
+    {
+        return name switch
+        {
+            "statusCode" => (double)_statusCode,
+            "statusMessage" => (object?)_statusMessage ?? StatusText(_statusCode),
+            "headersSent" => _headersSent,
+            "finished" => _finished,
+            "writableEnded" => _finished,
+            "sendDate" => true,
+            "writeHead" => BuiltInMethod.CreateV2("writeHead", 1, 3, (_, receiver, args) =>
+                receiver.ToObject() is SharpTSHttpsServerResponse r ? r.WriteHead(args) : receiver).Bind(this),
+            "write" => BuiltInMethod.CreateV2("write", 1, 3, (interp, receiver, args) =>
+                receiver.ToObject() is SharpTSHttpsServerResponse r ? r.Write(interp, args) : RuntimeValue.True).Bind(this),
+            "end" => BuiltInMethod.CreateV2("end", 0, 3, (interp, receiver, args) =>
+                receiver.ToObject() is SharpTSHttpsServerResponse r ? r.End(interp, args) : receiver).Bind(this),
+            "setHeader" => BuiltInMethod.CreateV2("setHeader", 2, (_, receiver, args) =>
+                receiver.ToObject() is SharpTSHttpsServerResponse r ? r.SetHeader(args) : receiver).Bind(this),
+            "getHeader" => BuiltInMethod.CreateV2("getHeader", 1, (_, receiver, args) =>
+            {
+                var n = args.Length > 0 ? args[0].ToObject()?.ToString() : null;
+                return n != null && _headers.TryGetValue(n, out var v) ? RuntimeValue.FromString(v) : RuntimeValue.Undefined;
+            }).Bind(this),
+            "removeHeader" => BuiltInMethod.CreateV2("removeHeader", 1, (_, receiver, args) =>
+            {
+                if (args.Length > 0 && args[0].ToObject()?.ToString() is { } n) _headers.Remove(n);
+                return receiver;
+            }).Bind(this),
+            "hasHeader" => BuiltInMethod.CreateV2("hasHeader", 1, (_, _, args) =>
+            {
+                var n = args.Length > 0 ? args[0].ToObject()?.ToString() : null;
+                return RuntimeValue.FromBoolean(n != null && _headers.ContainsKey(n));
+            }).Bind(this),
+            "getHeaderNames" => BuiltInMethod.CreateV2("getHeaderNames", 0, (_, _, _) =>
+                RuntimeValue.FromObject(new SharpTSArray(_headers.Keys.Select(k => (object?)k.ToLowerInvariant()).ToList()))).Bind(this),
+            "flushHeaders" => BuiltInMethod.CreateV2("flushHeaders", 0, (_, receiver, _) => receiver).Bind(this),
+            "writeContinue" => BuiltInMethod.CreateV2("writeContinue", 0, (_, _, _) => RuntimeValue.Undefined).Bind(this),
+            "writeProcessing" => BuiltInMethod.CreateV2("writeProcessing", 0, (_, _, _) => RuntimeValue.Undefined).Bind(this),
+            "addTrailers" => BuiltInMethod.CreateV2("addTrailers", 1, (_, _, _) => RuntimeValue.Undefined).Bind(this),
+            _ => base.GetMember(name)
+        };
+    }
+
+    public void SetMember(string name, object? value)
+    {
+        switch (name)
+        {
+            case "statusCode": if (value is double d) _statusCode = (int)d; break;
+            case "statusMessage": if (value is string s) _statusMessage = s; break;
+        }
+    }
+
+    private RuntimeValue WriteHead(ReadOnlySpan<RuntimeValue> args)
+    {
+        if (args.Length > 0 && args[0].IsNumber) _statusCode = (int)args[0].AsNumberUnsafe();
+        int headersIdx = 1;
+        if (args.Length > 1 && args[1].IsString) { _statusMessage = args[1].AsStringUnsafe(); headersIdx = 2; }
+        if (args.Length > headersIdx && args[headersIdx].ToObject() is SharpTSObject headers)
+            foreach (var kv in headers.Fields) _headers[kv.Key] = kv.Value?.ToString() ?? "";
+        return RuntimeValue.FromObject(this);
+    }
+
+    private RuntimeValue SetHeader(ReadOnlySpan<RuntimeValue> args)
+    {
+        if (args.Length >= 2 && args[0].ToObject()?.ToString() is { } n)
+            _headers[n] = args[1].ToObject()?.ToString() ?? "";
+        return RuntimeValue.FromObject(this);
+    }
+
+    private RuntimeValue Write(Interpreter interpreter, ReadOnlySpan<RuntimeValue> args)
+    {
+        if (args.Length > 0 && args[0].ToObject() is not ISharpTSCallable)
+            _body.AddRange(Encode(args));
+        return RuntimeValue.True;
+    }
+
+    private RuntimeValue End(Interpreter interpreter, ReadOnlySpan<RuntimeValue> args)
+    {
+        if (_finished) return RuntimeValue.FromObject(this);
+        if (args.Length > 0 && args[0].ToObject() is { } first && first is not ISharpTSCallable && first is not SharpTSUndefined)
+            _body.AddRange(Encode(args));
+
+        var bodyBytes = _body.ToArray();
+        _headers["Content-Length"] = bodyBytes.Length.ToString();
+        if (!_headers.ContainsKey("Connection")) _headers["Connection"] = "close";
+        if (!_headers.ContainsKey("Date")) _headers["Date"] = DateTime.UtcNow.ToString("R");
+
+        try
+        {
+            _headersSent = true;
+            var payload = HttpProtocol.SerializeResponse(_statusCode, _statusMessage ?? StatusText(_statusCode), _headers, bodyBytes);
+            _stream.Write(payload, 0, payload.Length);
+            _stream.Flush();
+        }
+        catch { /* client may have disconnected */ }
+        finally
+        {
+            try { _stream.Dispose(); } catch { }
+            try { _tcpClient.Close(); } catch { }
+        }
+
+        _finished = true;
+        foreach (var arg in args)
+            if (arg.ToObject() is ISharpTSCallable cb) { cb.Call(interpreter, []); break; }
+
+        EmitEvent(interpreter, "finish", []);
+        EmitEvent(interpreter, "close", []);
+        return RuntimeValue.FromObject(this);
+    }
+
+    private static byte[] Encode(ReadOnlySpan<RuntimeValue> args)
+    {
+        return args[0].ToObject() switch
+        {
+            string str => Encoding.UTF8.GetBytes(str),
+            SharpTSBuffer buf => buf.Data,
+            null => Array.Empty<byte>(),
+            var o => Encoding.UTF8.GetBytes(o.ToString() ?? "")
+        };
+    }
+
+    private static string StatusText(int code) => code switch
+    {
+        200 => "OK", 201 => "Created", 204 => "No Content", 301 => "Moved Permanently",
+        302 => "Found", 304 => "Not Modified", 400 => "Bad Request", 401 => "Unauthorized",
+        403 => "Forbidden", 404 => "Not Found", 500 => "Internal Server Error", _ => "OK"
+    };
+
+    public override string ToString() => $"ServerResponse {{ statusCode: {_statusCode} }}";
+}

--- a/Runtime/Types/SharpTSHttpsServer.cs
+++ b/Runtime/Types/SharpTSHttpsServer.cs
@@ -1,0 +1,240 @@
+using System.Net;
+using System.Net.Security;
+using System.Net.Sockets;
+using System.Security.Authentication;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using SharpTS.Runtime.BuiltIns;
+using SharpTS.TypeSystem;
+using Interp = SharpTS.Execution.Interpreter;
+
+namespace SharpTS.Runtime.Types;
+
+/// <summary>
+/// Runtime representation of a Node.js https.Server — a real HTTPS server (#1049). Unlike the
+/// former cleartext proxy to http, this accepts TLS connections directly (TcpListener + SslStream,
+/// reusing the tls #1032 cert handling) and runs a minimal HTTP/1.1 request/response pipeline over
+/// each TLS connection.
+/// </summary>
+/// <remarks>
+/// Events: 'request', 'listening', 'close', 'error', 'secureConnection', 'tlsClientError'.
+/// Each connection serves a single request then closes (Connection: close) — keep-alive is not
+/// implemented for the TLS server. The compiled https server is a documented follow-up
+/// (interpreter-first), consistent with the epic's phased plan.
+/// </remarks>
+public class SharpTSHttpsServer : SharpTSEventEmitter, IDisposable
+{
+    /// <inheritdoc />
+    public override TypeCategory RuntimeCategory => TypeCategory.Record;
+
+    private readonly ISharpTSCallable? _requestHandler;
+    private X509Certificate2? _certificate;
+    private List<SslApplicationProtocol>? _alpnProtocols;
+    private TcpListener? _listener;
+    private bool _isListening;
+    private Interp? _interpreter;
+    private CancellationTokenSource? _cts;
+    private int _port;
+    private string _host = "0.0.0.0";
+
+    public SharpTSHttpsServer(SharpTSObject? options, ISharpTSCallable? requestHandler)
+    {
+        _requestHandler = requestHandler;
+        if (options != null)
+            LoadCertificate(options);
+    }
+
+    private void LoadCertificate(SharpTSObject options)
+    {
+        var certPem = options.GetProperty("cert") as string;
+        var keyPem = options.GetProperty("key") as string;
+        var passphrase = options.GetProperty("passphrase") as string;
+
+        if ((certPem == null || keyPem == null) && options.GetProperty("secureContext") is SharpTSObject sc)
+        {
+            certPem ??= sc.GetProperty("cert") as string;
+            keyPem ??= sc.GetProperty("key") as string;
+        }
+
+        if (certPem != null && keyPem != null)
+        {
+            var cert = X509Certificate2.CreateFromPem(certPem, keyPem);
+            // Export/reimport so the private key is usable by SslStream on Windows.
+            _certificate = X509CertificateLoader.LoadPkcs12(cert.Export(X509ContentType.Pfx), null);
+        }
+        else if (options.GetProperty("pfx") is { } pfxObj)
+        {
+            byte[]? pfxBytes = pfxObj switch
+            {
+                SharpTSBuffer b => b.Data,
+                string s => Convert.FromBase64String(s),
+                _ => null
+            };
+            if (pfxBytes != null)
+                _certificate = X509CertificateLoader.LoadPkcs12(pfxBytes, passphrase);
+        }
+
+        if (options.GetProperty("ALPNProtocols") is SharpTSArray alpnArray)
+        {
+            _alpnProtocols = alpnArray.OfType<string>().Select(s => new SslApplicationProtocol(s)).ToList();
+        }
+    }
+
+    public bool Listening => _isListening;
+
+    public new object? GetMember(string name)
+    {
+        return name switch
+        {
+            "listening" => Listening,
+            "listen" => BuiltInMethod.CreateV2("listen", 1, 3, (interp, receiver, args) =>
+                receiver.ToObject() is SharpTSHttpsServer s ? s.Listen(interp, args) : receiver).Bind(this),
+            "close" => BuiltInMethod.CreateV2("close", 0, 1, (interp, receiver, args) =>
+                receiver.ToObject() is SharpTSHttpsServer s ? s.Close(interp, args) : receiver).Bind(this),
+            "address" => BuiltInMethod.CreateV2("address", 0, (_, receiver, _) =>
+                RuntimeValue.FromBoxed(receiver.ToObject() is SharpTSHttpsServer s ? s.GetAddress() : null)).Bind(this),
+            "setTimeout" => BuiltInMethod.CreateV2("setTimeout", 0, 2, (_, receiver, _) => receiver).Bind(this),
+            _ => base.GetMember(name)
+        };
+    }
+
+    private RuntimeValue Listen(Interp interpreter, ReadOnlySpan<RuntimeValue> args)
+    {
+        if (_isListening) throw new Exception("Runtime Error: Server is already listening");
+        if (_certificate == null) throw new Exception("Runtime Error: https.createServer requires key and cert (or pfx)");
+
+        _interpreter = interpreter;
+        ISharpTSCallable? callback = null;
+
+        if (args.Length > 0 && args[0].IsNumber)
+            _port = (int)args[0].AsNumberUnsafe();
+        for (int i = 1; i < args.Length; i++)
+        {
+            if (args[i].ToObject() is ISharpTSCallable cb) { callback = cb; break; }
+            if (args[i].IsString) _host = args[i].AsStringUnsafe();
+        }
+
+        var ip = _host is "0.0.0.0" or "::" ? IPAddress.Any
+            : IPAddress.TryParse(_host, out var parsed) ? parsed : IPAddress.Loopback;
+        _listener = new TcpListener(ip, _port);
+        _listener.Start();
+        if (_port == 0)
+            _port = ((IPEndPoint)_listener.LocalEndpoint).Port;
+
+        _isListening = true;
+        _cts = new CancellationTokenSource();
+        interpreter.Ref();
+
+        callback?.Call(interpreter, []);
+        EmitEvent(interpreter, "listening", []);
+        StartAccepting(interpreter);
+
+        return RuntimeValue.FromObject(this);
+    }
+
+    private void StartAccepting(Interp interpreter)
+    {
+        var token = _cts!.Token;
+        var cert = _certificate!;
+
+        _ = Task.Run(async () =>
+        {
+            while (!token.IsCancellationRequested && _listener != null)
+            {
+                TcpClient tcpClient;
+                try { tcpClient = await _listener.AcceptTcpClientAsync(token); }
+                catch (OperationCanceledException) { break; }
+                catch (ObjectDisposedException) { break; }
+                catch (SocketException) { break; }
+
+                _ = Task.Run(async () =>
+                {
+                    SslStream? ssl = null;
+                    try
+                    {
+                        ssl = new SslStream(tcpClient.GetStream(), false);
+                        var authOptions = new SslServerAuthenticationOptions
+                        {
+                            ServerCertificate = cert,
+                            EnabledSslProtocols = SslProtocols.Tls12 | SslProtocols.Tls13,
+                        };
+                        if (_alpnProtocols != null)
+                            authOptions.ApplicationProtocols = _alpnProtocols;
+
+                        await ssl.AuthenticateAsServerAsync(authOptions);
+
+                        var parsed = await HttpProtocol.ReadRequestAsync(ssl, token);
+                        if (parsed == null) { Cleanup(ssl, tcpClient); return; }
+
+                        interpreter.ScheduleTimer(0, 0, () =>
+                        {
+                            try { DispatchRequest(interpreter, ssl, tcpClient, parsed); }
+                            catch (Exception ex) { EmitEvent(interpreter, "error", [new SharpTSError(ex.Message)]); }
+                        }, isInterval: false);
+                    }
+                    catch (Exception ex)
+                    {
+                        interpreter.ScheduleTimer(0, 0, () =>
+                            EmitEvent(interpreter, "tlsClientError", [new SharpTSError(ex.Message)]), isInterval: false);
+                        Cleanup(ssl, tcpClient);
+                    }
+                }, token);
+            }
+        }, token);
+    }
+
+    private void DispatchRequest(Interp interpreter, SslStream ssl, TcpClient tcpClient, HttpProtocol.ParsedRequest parsed)
+    {
+        var req = new SharpTSHttpsServerRequest(parsed);
+        var res = new SharpTSHttpsServerResponse(ssl, tcpClient);
+
+        EmitEvent(interpreter, "request", [req, res]);
+        _requestHandler?.Call(interpreter, [req, res]);
+
+        // Body was already read off the wire; deliver it after listeners are attached.
+        req.DeliverBody(interpreter, parsed.Body);
+    }
+
+    private static void Cleanup(SslStream? ssl, TcpClient tcpClient)
+    {
+        try { ssl?.Dispose(); } catch { }
+        try { tcpClient.Close(); } catch { }
+    }
+
+    private RuntimeValue Close(Interp interpreter, ReadOnlySpan<RuntimeValue> args)
+    {
+        if (!_isListening) return RuntimeValue.FromObject(this);
+        _cts?.Cancel();
+        try { _listener?.Stop(); } catch { }
+        _isListening = false;
+        _interpreter?.Unref();
+
+        if (args.Length > 0 && args[0].ToObject() is ISharpTSCallable cb)
+            cb.Call(interpreter, []);
+        EmitEvent(interpreter, "close", []);
+        return RuntimeValue.FromObject(this);
+    }
+
+    private object? GetAddress()
+    {
+        if (!_isListening || _listener == null) return null;
+        var ep = (IPEndPoint)_listener.LocalEndpoint;
+        return new SharpTSObject(new Dictionary<string, object?>
+        {
+            ["address"] = ep.Address.ToString(),
+            ["family"] = ep.AddressFamily == AddressFamily.InterNetworkV6 ? "IPv6" : "IPv4",
+            ["port"] = (double)ep.Port
+        });
+    }
+
+    public void Dispose()
+    {
+        _cts?.Cancel();
+        try { _listener?.Stop(); } catch { }
+        _cts?.Dispose();
+        _certificate?.Dispose();
+        _isListening = false;
+    }
+
+    public override string ToString() => $"Server {{ listening: {Listening} }}";
+}

--- a/SharpTS.Tests/SharedTests/FetchCookieTests.cs
+++ b/SharpTS.Tests/SharedTests/FetchCookieTests.cs
@@ -344,21 +344,24 @@ public class FetchCookieTests : IDisposable
     // ========== http.get/http.request cookies ==========
 
     [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
     public void Cookies_HttpModuleSharesJarWithFetch(ExecutionMode mode)
     {
-        // Set a cookie via fetch, then read it back via http.get — both paths
-        // delegate to the same Fetch runtime method and must hit the same jar.
-        // We use modules so we can `import * as http from 'http'`.
+        // Set a cookie via fetch, then read it back via http.get. The ClientRequest (#1043)
+        // attaches cookies from the shared jar, so echo-cookie reflects the fetch-set cookie.
+        // Interpreted-only: the compiled http client still routes through fetch (which shares
+        // the same jar — covered by the dual-mode fetch cookie tests).
         var files = new Dictionary<string, string>
         {
             ["./main.ts"] = $$"""
                 import * as http from 'http';
                 async function test(): Promise<void> {
                     await fetch('{{_server.BaseUrl}}set-session');
-                    const res = await http.get('{{_server.BaseUrl}}echo-cookie') as any;
-                    const text = await res.text();
-                    console.log(text);
+                    http.get('{{_server.BaseUrl}}echo-cookie', (res: any) => {
+                        let text = '';
+                        res.on('data', (c: any) => { text += c.toString(); });
+                        res.on('end', () => { console.log(text); });
+                    });
                 }
                 test();
                 """
@@ -368,22 +371,28 @@ public class FetchCookieTests : IDisposable
     }
 
     [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
     public void Cookies_HttpRequestStoresAndSendsCookies(ExecutionMode mode)
     {
-        // Pure http.request flow: set via http.request, read via http.request.
-        // No fetch() call at all — proves http.* alone exercises the cookie jar.
+        // Pure http.request flow: set via http.request, read via http.request — proves the
+        // ClientRequest (#1043) both stores Set-Cookie and re-sends from the shared jar.
+        // Interpreted-only (see the ClientRequest note above).
         var files = new Dictionary<string, string>
         {
             ["./main.ts"] = $$"""
                 import * as http from 'http';
-                async function test(): Promise<void> {
-                    await http.request('{{_server.BaseUrl}}set-session') as any;
-                    const res = await http.request('{{_server.BaseUrl}}echo-cookie') as any;
-                    const text = await res.text();
-                    console.log(text);
-                }
-                test();
+                const setReq: any = http.request('{{_server.BaseUrl}}set-session', (res1: any) => {
+                    res1.on('data', () => {});
+                    res1.on('end', () => {
+                        const getReq: any = http.request('{{_server.BaseUrl}}echo-cookie', (res2: any) => {
+                            let text = '';
+                            res2.on('data', (c: any) => { text += c.toString(); });
+                            res2.on('end', () => { console.log(text); });
+                        });
+                        getReq.end();
+                    });
+                });
+                setReq.end();
                 """
         };
         var output = TestHarness.RunModules(files, "./main.ts", mode);

--- a/SharpTS.Tests/SharedTests/HttpAgentPoolTests.cs
+++ b/SharpTS.Tests/SharedTests/HttpAgentPoolTests.cs
@@ -1,0 +1,138 @@
+using System.Net;
+using System.Net.Sockets;
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests;
+
+/// <summary>
+/// Tests for the http.Agent connection-pool surface (#1051): getName, observable sockets/
+/// freeSockets state, keep-alive socket reuse, agent:false, and destroy().
+/// </summary>
+/// <remarks>
+/// Real socket ownership lives in HttpClient; the agent exposes a Node-shaped shadow pool that
+/// the ClientRequest populates. The pooling behaviour is exercised interpreted-only (the compiled
+/// client routes through fetch); getName and the config surface are dual-mode.
+/// </remarks>
+public class HttpAgentPoolTests
+{
+    private static int GetAvailablePort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        listener.Stop();
+        return port;
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Agent_GetName_FormatsOriginKey(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["./main.ts"] = """
+                import * as http from 'http';
+                const agent: any = new http.Agent({ keepAlive: true });
+                console.log(agent.getName({ host: 'example.com', port: 8080 }));
+                console.log('keepAlive=' + agent.keepAlive);
+                """
+        };
+        var output = TestHarness.RunModules(files, "./main.ts", mode);
+        Assert.Contains("example.com:8080:", output);
+        Assert.Contains("keepAlive=true", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void Agent_KeepAlive_PopulatesFreeSockets(ExecutionMode mode)
+    {
+        var port = GetAvailablePort();
+        var files = new Dictionary<string, string>
+        {
+            ["./main.ts"] = $$"""
+                import * as http from 'http';
+                const agent: any = new http.Agent({ keepAlive: true });
+                const server: any = http.createServer((req: any, res: any) => { res.end('ok'); });
+                server.listen({{port}}, () => {
+                    const req: any = http.request(
+                        { host: '127.0.0.1', port: {{port}}, path: '/', agent },
+                        (res: any) => {
+                            res.on('data', () => {});
+                            res.on('end', () => {
+                                const keys = Object.keys(agent.freeSockets);
+                                console.log('freeOrigins=' + keys.length);
+                                server.close();
+                            });
+                        });
+                    req.end();
+                });
+                """
+        };
+        var output = TestHarness.RunModules(files, "./main.ts", mode);
+        Assert.Contains("freeOrigins=1", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void Agent_NoKeepAlive_LeavesFreeSocketsEmpty(ExecutionMode mode)
+    {
+        var port = GetAvailablePort();
+        var files = new Dictionary<string, string>
+        {
+            ["./main.ts"] = $$"""
+                import * as http from 'http';
+                const agent: any = new http.Agent({ keepAlive: false });
+                const server: any = http.createServer((req: any, res: any) => { res.end('ok'); });
+                server.listen({{port}}, () => {
+                    const req: any = http.request(
+                        { host: '127.0.0.1', port: {{port}}, path: '/', agent },
+                        (res: any) => {
+                            res.on('data', () => {});
+                            res.on('end', () => {
+                                console.log('freeOrigins=' + Object.keys(agent.freeSockets).length);
+                                console.log('activeOrigins=' + Object.keys(agent.sockets).length);
+                                server.close();
+                            });
+                        });
+                    req.end();
+                });
+                """
+        };
+        var output = TestHarness.RunModules(files, "./main.ts", mode);
+        Assert.Contains("freeOrigins=0", output);
+        Assert.Contains("activeOrigins=0", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void Agent_Destroy_ClearsPool(ExecutionMode mode)
+    {
+        var port = GetAvailablePort();
+        var files = new Dictionary<string, string>
+        {
+            ["./main.ts"] = $$"""
+                import * as http from 'http';
+                const agent: any = new http.Agent({ keepAlive: true });
+                const server: any = http.createServer((req: any, res: any) => { res.end('ok'); });
+                server.listen({{port}}, () => {
+                    const req: any = http.request(
+                        { host: '127.0.0.1', port: {{port}}, path: '/', agent },
+                        (res: any) => {
+                            res.on('data', () => {});
+                            res.on('end', () => {
+                                console.log('before=' + Object.keys(agent.freeSockets).length);
+                                agent.destroy();
+                                console.log('after=' + Object.keys(agent.freeSockets).length);
+                                server.close();
+                            });
+                        });
+                    req.end();
+                });
+                """
+        };
+        var output = TestHarness.RunModules(files, "./main.ts", mode);
+        Assert.Contains("before=1", output);
+        Assert.Contains("after=0", output);
+    }
+}

--- a/SharpTS.Tests/SharedTests/HttpClientRequestTests.cs
+++ b/SharpTS.Tests/SharedTests/HttpClientRequestTests.cs
@@ -1,0 +1,199 @@
+using System.Net;
+using System.Net.Sockets;
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests;
+
+/// <summary>
+/// Tests for the real http.ClientRequest object model (#1043) and its response event
+/// lifecycle + IncomingMessage (#1044).
+/// </summary>
+/// <remarks>
+/// http.request/http.get return a writable ClientRequest whose 'response' fires with a
+/// streaming IncomingMessage. This is implemented for the interpreter; the compiled path
+/// still routes the client through fetch (a documented follow-up — emitting a full
+/// $ClientRequest IL object model), so these object-model tests run interpreted-only.
+/// The dual-mode server tests in HttpEventTests still exercise http.get in compiled mode.
+/// </remarks>
+public class HttpClientRequestTests
+{
+    private static int GetAvailablePort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        listener.Stop();
+        return port;
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void ClientRequest_IsWritable_WithHeaderManipulation(ExecutionMode mode)
+    {
+        var port = GetAvailablePort();
+        var files = new Dictionary<string, string>
+        {
+            ["./main.ts"] = $$"""
+                import * as http from 'http';
+                const server = http.createServer((req: any, res: any) => {
+                    res.end('ok');
+                    server.close();
+                });
+                server.listen({{port}}, () => {
+                    const req: any = http.request({ host: '127.0.0.1', port: {{port}}, path: '/', method: 'POST' });
+                    console.log('write=' + (typeof req.write));
+                    console.log('end=' + (typeof req.end));
+                    console.log('method=' + req.method);
+                    console.log('path=' + req.path);
+                    console.log('protocol=' + req.protocol);
+                    req.setHeader('X-Test', 'abc');
+                    console.log('getHeader=' + req.getHeader('X-Test'));
+                    console.log('hasHeader=' + req.hasHeader('x-test'));
+                    console.log('names=' + req.getHeaderNames().join(','));
+                    req.removeHeader('X-Test');
+                    console.log('afterRemove=' + req.hasHeader('X-Test'));
+                    req.end();
+                });
+                """
+        };
+        var output = TestHarness.RunModules(files, "./main.ts", mode);
+        Assert.Contains("write=function", output);
+        Assert.Contains("end=function", output);
+        Assert.Contains("method=POST", output);
+        Assert.Contains("path=/", output);
+        Assert.Contains("protocol=http:", output);
+        Assert.Contains("getHeader=abc", output);
+        Assert.Contains("hasHeader=true", output);
+        Assert.Contains("names=x-test", output);
+        Assert.Contains("afterRemove=false", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void ClientRequest_PostStreamedBody_ResponseCallback(ExecutionMode mode)
+    {
+        var port = GetAvailablePort();
+        var files = new Dictionary<string, string>
+        {
+            ["./main.ts"] = $$"""
+                import * as http from 'http';
+                const server = http.createServer((req: any, res: any) => {
+                    let body = '';
+                    req.on('data', (c: any) => { body += c.toString(); });
+                    req.on('end', () => {
+                        res.writeHead(201, { 'Content-Type': 'text/plain', 'X-Echo': req.method });
+                        res.end('got:' + body);
+                    });
+                });
+                server.listen({{port}}, () => {
+                    const req: any = http.request(
+                        { host: '127.0.0.1', port: {{port}}, path: '/x', method: 'POST',
+                          headers: { 'Content-Type': 'text/plain' } },
+                        (res: any) => {
+                            console.log('status=' + res.statusCode);
+                            console.log('statusMessage=' + res.statusMessage);
+                            console.log('echo=' + res.headers['x-echo']);
+                            console.log('httpVersion=' + res.httpVersion);
+                            console.log('rawHasContentType=' + (res.rawHeaders.indexOf('Content-Type') >= 0));
+                            let data = '';
+                            res.on('data', (c: any) => { data += c.toString(); });
+                            res.on('end', () => {
+                                console.log('body=' + data);
+                                console.log('complete=' + res.complete);
+                                server.close();
+                            });
+                        });
+                    req.write('hello ');
+                    req.write('world');
+                    req.end();
+                });
+                """
+        };
+        var output = TestHarness.RunModules(files, "./main.ts", mode);
+        Assert.Contains("status=201", output);
+        Assert.Contains("statusMessage=Created", output);
+        Assert.Contains("echo=POST", output);
+        Assert.Contains("httpVersion=1.1", output);
+        Assert.Contains("rawHasContentType=true", output);
+        Assert.Contains("body=got:hello world", output);
+        Assert.Contains("complete=true", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void ClientRequest_ResponseEvent_FiresWithIncomingMessage(ExecutionMode mode)
+    {
+        var port = GetAvailablePort();
+        var files = new Dictionary<string, string>
+        {
+            ["./main.ts"] = $$"""
+                import * as http from 'http';
+                const server = http.createServer((req: any, res: any) => {
+                    res.statusCode = 200;
+                    res.end('hi');
+                });
+                server.listen({{port}}, () => {
+                    const req: any = http.get('http://127.0.0.1:{{port}}/');
+                    req.on('response', (res: any) => {
+                        console.log('got response event ' + res.statusCode);
+                        res.on('data', () => {});
+                        res.on('end', () => { server.close(); });
+                    });
+                    req.on('socket', () => { console.log('socket event'); });
+                });
+                """
+        };
+        var output = TestHarness.RunModules(files, "./main.ts", mode);
+        Assert.Contains("socket event", output);
+        Assert.Contains("got response event 200", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void ClientRequest_ConnectionFailure_EmitsError(ExecutionMode mode)
+    {
+        // Nothing listening on this port → ECONNREFUSED → 'error' event.
+        var port = GetAvailablePort();
+        var files = new Dictionary<string, string>
+        {
+            ["./main.ts"] = $$"""
+                import * as http from 'http';
+                const req: any = http.get('http://127.0.0.1:{{port}}/');
+                req.on('error', (err: any) => {
+                    console.log('error event');
+                    console.log('hasCode=' + (typeof err.code === 'string'));
+                });
+                """
+        };
+        var output = TestHarness.RunModules(files, "./main.ts", mode);
+        Assert.Contains("error event", output);
+        Assert.Contains("hasCode=true", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void ClientRequest_GetHeaders_ReturnsObject(ExecutionMode mode)
+    {
+        var port = GetAvailablePort();
+        var files = new Dictionary<string, string>
+        {
+            ["./main.ts"] = $$"""
+                import * as http from 'http';
+                const server = http.createServer((req: any, res: any) => { res.end(); server.close(); });
+                server.listen({{port}}, () => {
+                    const req: any = http.request({ host: '127.0.0.1', port: {{port}}, path: '/' });
+                    req.setHeader('Accept', 'application/json');
+                    req.setHeader('X-A', '1');
+                    const h = req.getHeaders();
+                    console.log('accept=' + h.accept);
+                    console.log('xa=' + h['x-a']);
+                    req.end();
+                });
+                """
+        };
+        var output = TestHarness.RunModules(files, "./main.ts", mode);
+        Assert.Contains("accept=application/json", output);
+        Assert.Contains("xa=1", output);
+    }
+}

--- a/SharpTS.Tests/SharedTests/HttpIncomingMessageTests.cs
+++ b/SharpTS.Tests/SharedTests/HttpIncomingMessageTests.cs
@@ -1,0 +1,119 @@
+using System.Net;
+using System.Net.Sockets;
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests;
+
+/// <summary>
+/// Tests for IncomingMessage completeness (#1048): rawHeaders (array, case), httpVersionMajor/
+/// Minor, trailers/rawTrailers, socket (remoteAddress/family), statusCode undefined on the
+/// server side, and on-demand body streaming. The server request object ($HttpRequest) is
+/// dual-mode; body content is driven with a dual-mode fetch POST.
+/// </summary>
+public class HttpIncomingMessageTests
+{
+    private static int GetAvailablePort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        listener.Stop();
+        return port;
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void IncomingMessage_VersionSocketAndFields(ExecutionMode mode)
+    {
+        var port = GetAvailablePort();
+        var files = new Dictionary<string, string>
+        {
+            ["./main.ts"] = $$"""
+                import * as http from 'http';
+                const server: any = http.createServer((req: any, res: any) => {
+                    console.log('major=' + req.httpVersionMajor);
+                    console.log('minor=' + req.httpVersionMinor);
+                    console.log('socketType=' + (typeof req.socket));
+                    console.log('remoteType=' + (typeof req.socket.remoteAddress));
+                    console.log('family=' + req.socket.family);
+                    console.log('statusCode=' + (typeof req.statusCode));
+                    console.log('rawTrailers=' + Array.isArray(req.rawTrailers));
+                    console.log('trailers=' + (typeof req.trailers));
+                    res.end('ok');
+                    server.close();
+                });
+                server.listen({{port}}, () => { http.get('http://127.0.0.1:{{port}}/'); });
+                """
+        };
+        var output = TestHarness.RunModules(files, "./main.ts", mode);
+        Assert.Contains("major=1", output);
+        Assert.Contains("minor=1", output);
+        Assert.Contains("socketType=object", output);
+        Assert.Contains("remoteType=string", output);
+        Assert.Contains("family=IPv4", output);
+        Assert.Contains("statusCode=undefined", output);
+        Assert.Contains("rawTrailers=true", output);
+        Assert.Contains("trailers=object", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void IncomingMessage_RawHeaders_IsAlternatingArray(ExecutionMode mode)
+    {
+        var port = GetAvailablePort();
+        var files = new Dictionary<string, string>
+        {
+            ["./main.ts"] = $$"""
+                import * as http from 'http';
+                const server: any = http.createServer((req: any, res: any) => {
+                    const raw = req.rawHeaders;
+                    console.log('isArray=' + Array.isArray(raw));
+                    console.log('even=' + (raw.length % 2 === 0));
+                    let hasHost = false;
+                    for (let i = 0; i < raw.length; i += 2) {
+                        if (String(raw[i]).toLowerCase() === 'host') hasHost = true;
+                    }
+                    console.log('hasHost=' + hasHost);
+                    console.log('lowerHost=' + (typeof req.headers.host));
+                    res.end('ok');
+                    server.close();
+                });
+                server.listen({{port}}, () => { http.get('http://127.0.0.1:{{port}}/'); });
+                """
+        };
+        var output = TestHarness.RunModules(files, "./main.ts", mode);
+        Assert.Contains("isArray=true", output);
+        Assert.Contains("even=true", output);
+        Assert.Contains("hasHost=true", output);
+        Assert.Contains("lowerHost=string", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void IncomingMessage_StreamsRequestBody(ExecutionMode mode)
+    {
+        var port = GetAvailablePort();
+        var files = new Dictionary<string, string>
+        {
+            ["./main.ts"] = $$"""
+                import * as http from 'http';
+                const server: any = http.createServer((req: any, res: any) => {
+                    let body = '';
+                    req.on('data', (c: any) => { body += c.toString(); });
+                    req.on('end', () => {
+                        res.end('echo:' + body);
+                    });
+                });
+                server.listen({{port}}, async () => {
+                    const r = await fetch('http://127.0.0.1:{{port}}/', { method: 'POST', body: 'streamed-payload' });
+                    const t = await r.text();
+                    console.log(t);
+                    server.close();
+                });
+                """
+        };
+        var output = TestHarness.RunModules(files, "./main.ts", mode);
+        Assert.Contains("echo:streamed-payload", output);
+    }
+}

--- a/SharpTS.Tests/SharedTests/HttpServerAdvancedEventsTests.cs
+++ b/SharpTS.Tests/SharedTests/HttpServerAdvancedEventsTests.cs
@@ -1,0 +1,99 @@
+using System.Net;
+using System.Net.Sockets;
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests;
+
+/// <summary>
+/// Tests for the advanced server events (#1046): checkContinue (Expect: 100-continue) plus the
+/// registrable-but-platform-limited upgrade/connect/clientError surface.
+/// </summary>
+/// <remarks>
+/// upgrade/connect/clientError require raw-socket handoff that HttpListener does not provide, so
+/// they are registrable (EventEmitter) but never fire — an HttpListener ceiling matching the
+/// epic's stated scope (WebSocket framing / CONNECT tunneling are userland). checkContinue is
+/// fully supported; firing it needs an Expect: 100-continue client, exercised interpreted-only
+/// via the ClientRequest (the compiled client still routes through fetch).
+/// </remarks>
+public class HttpServerAdvancedEventsTests
+{
+    private static int GetAvailablePort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        listener.Stop();
+        return port;
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Server_AdvancedEventListeners_AreRegistrable(ExecutionMode mode)
+    {
+        // Registering upgrade/connect/clientError/checkContinue must not break normal serving.
+        var port = GetAvailablePort();
+        var files = new Dictionary<string, string>
+        {
+            ["./main.ts"] = $$"""
+                import * as http from 'http';
+                const server: any = http.createServer((req: any, res: any) => {
+                    console.log('handled');
+                    res.end('ok');
+                    server.close();
+                });
+                server.on('upgrade', () => {});
+                server.on('connect', () => {});
+                server.on('clientError', () => {});
+                server.on('checkContinue', () => {});
+                console.log('upgrade=' + server.listenerCount('upgrade'));
+                console.log('connect=' + server.listenerCount('connect'));
+                server.listen({{port}}, () => { http.get('http://127.0.0.1:{{port}}/'); });
+                """
+        };
+        var output = TestHarness.RunModules(files, "./main.ts", mode);
+        Assert.Contains("upgrade=1", output);
+        Assert.Contains("connect=1", output);
+        Assert.Contains("handled", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void Server_CheckContinue_FiresInsteadOfRequest(ExecutionMode mode)
+    {
+        var port = GetAvailablePort();
+        var files = new Dictionary<string, string>
+        {
+            ["./main.ts"] = $$"""
+                import * as http from 'http';
+                const server: any = http.createServer((req: any, res: any) => {
+                    console.log('NORMAL-HANDLER');
+                    res.end('normal');
+                });
+                server.on('checkContinue', (req: any, res: any) => {
+                    console.log('checkContinue:' + req.method);
+                    res.writeContinue();
+                    let body = '';
+                    req.on('data', (c: any) => { body += c.toString(); });
+                    req.on('end', () => { res.end('continued:' + body); });
+                });
+                server.listen({{port}}, () => {
+                    const req: any = http.request(
+                        { host: '127.0.0.1', port: {{port}}, path: '/', method: 'POST',
+                          headers: { 'Expect': '100-continue' } },
+                        (res: any) => {
+                            let t = '';
+                            res.on('data', (c: any) => { t += c.toString(); });
+                            res.on('end', () => { console.log('client:' + t); server.close(); });
+                        });
+                    req.write('payload');
+                    req.end();
+                });
+                """
+        };
+        var output = TestHarness.RunModules(files, "./main.ts", mode);
+        Assert.Contains("checkContinue:POST", output);
+        Assert.Contains("client:continued:payload", output);
+        Assert.DoesNotContain("NORMAL-HANDLER", output);
+    }
+}

--- a/SharpTS.Tests/SharedTests/HttpServerLifecycleTests.cs
+++ b/SharpTS.Tests/SharedTests/HttpServerLifecycleTests.cs
@@ -1,0 +1,138 @@
+using System.Net;
+using System.Net.Sockets;
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests;
+
+/// <summary>
+/// Tests for the HTTP server-management surface (#1045): closeAllConnections/
+/// closeIdleConnections, the keepAliveTimeout/headersTimeout/requestTimeout/timeout/
+/// maxHeadersCount/maxRequestsPerSocket config, setTimeout, and the 'connection' event.
+/// </summary>
+/// <remarks>
+/// Default config reads + the lifecycle methods run in both modes (compiled exposes the
+/// Node-default config via property getters). Mutating the config, the 'connection' event,
+/// and setTimeout's listener wiring are interpreter-mode features (documented).
+/// </remarks>
+public class HttpServerLifecycleTests
+{
+    private static int GetAvailablePort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        listener.Stop();
+        return port;
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Server_DefaultConfig_IsReadable(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["./main.ts"] = """
+                import * as http from 'http';
+                const server: any = http.createServer((req: any, res: any) => res.end());
+                console.log('keepAlive=' + server.keepAliveTimeout);
+                console.log('headers=' + server.headersTimeout);
+                console.log('request=' + server.requestTimeout);
+                console.log('timeout=' + server.timeout);
+                console.log('maxHeaders=' + server.maxHeadersCount);
+                console.log('maxReq=' + server.maxRequestsPerSocket);
+                """
+        };
+        var output = TestHarness.RunModules(files, "./main.ts", mode);
+        Assert.Equal("keepAlive=5000\nheaders=60000\nrequest=300000\ntimeout=0\nmaxHeaders=2000\nmaxReq=0\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Server_LifecycleMethods_AreCallable(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["./main.ts"] = """
+                import * as http from 'http';
+                const server: any = http.createServer((req: any, res: any) => res.end());
+                console.log('closeAll=' + (typeof server.closeAllConnections));
+                console.log('closeIdle=' + (typeof server.closeIdleConnections));
+                console.log('setTimeout=' + (typeof server.setTimeout));
+                server.closeIdleConnections();
+                console.log('idle-ok');
+                """
+        };
+        var output = TestHarness.RunModules(files, "./main.ts", mode);
+        Assert.Contains("closeAll=function", output);
+        Assert.Contains("closeIdle=function", output);
+        Assert.Contains("setTimeout=function", output);
+        Assert.Contains("idle-ok", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Server_CloseAllConnections_StopsServer(ExecutionMode mode)
+    {
+        var port = GetAvailablePort();
+        var files = new Dictionary<string, string>
+        {
+            ["./main.ts"] = $$"""
+                import * as http from 'http';
+                const server: any = http.createServer((req: any, res: any) => res.end());
+                server.listen({{port}}, () => {
+                    console.log('listening=' + server.listening);
+                    server.closeAllConnections();
+                    console.log('done');
+                });
+                """
+        };
+        var output = TestHarness.RunModules(files, "./main.ts", mode);
+        Assert.Contains("listening=true", output);
+        Assert.Contains("done", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void Server_Config_IsSettable(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["./main.ts"] = """
+                import * as http from 'http';
+                const server: any = http.createServer((req: any, res: any) => res.end());
+                server.keepAliveTimeout = 1234;
+                server.requestTimeout = 9999;
+                server.maxHeadersCount = 50;
+                console.log(server.keepAliveTimeout);
+                console.log(server.requestTimeout);
+                console.log(server.maxHeadersCount);
+                """
+        };
+        var output = TestHarness.RunModules(files, "./main.ts", mode);
+        Assert.Equal("1234\n9999\n50\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void Server_ConnectionEvent_Fires(ExecutionMode mode)
+    {
+        var port = GetAvailablePort();
+        var files = new Dictionary<string, string>
+        {
+            ["./main.ts"] = $$"""
+                import * as http from 'http';
+                const server: any = http.createServer((req: any, res: any) => { res.end('ok'); });
+                server.on('connection', (socket: any) => {
+                    console.log('connection event ' + (typeof socket));
+                });
+                server.on('request', () => { server.close(); });
+                server.listen({{port}}, () => {
+                    http.get('http://127.0.0.1:{{port}}/');
+                });
+                """
+        };
+        var output = TestHarness.RunModules(files, "./main.ts", mode);
+        Assert.Contains("connection event object", output);
+    }
+}

--- a/SharpTS.Tests/SharedTests/HttpServerResponseTests.cs
+++ b/SharpTS.Tests/SharedTests/HttpServerResponseTests.cs
@@ -1,0 +1,129 @@
+using System.Net;
+using System.Net.Sockets;
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests;
+
+/// <summary>
+/// Tests for ServerResponse completeness (#1047): writeContinue/writeProcessing/addTrailers/
+/// flushHeaders, writable statusMessage, sendDate, chunked streaming, and write() returning a
+/// boolean. The server response object ($HttpResponse) is dual-mode; body content is read back
+/// with fetch (also dual-mode).
+/// </summary>
+public class HttpServerResponseTests
+{
+    private static int GetAvailablePort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        listener.Stop();
+        return port;
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ServerResponse_StatusMessage_Writable(ExecutionMode mode)
+    {
+        var port = GetAvailablePort();
+        var files = new Dictionary<string, string>
+        {
+            ["./main.ts"] = $$"""
+                import * as http from 'http';
+                const server: any = http.createServer((req: any, res: any) => {
+                    res.statusMessage = 'Custom OK';
+                    console.log('msg=' + res.statusMessage);
+                    res.end('done');
+                    server.close();
+                });
+                server.listen({{port}}, () => { http.get('http://127.0.0.1:{{port}}/'); });
+                """
+        };
+        var output = TestHarness.RunModules(files, "./main.ts", mode);
+        Assert.Contains("msg=Custom OK", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ServerResponse_ExtraMethods_Callable(ExecutionMode mode)
+    {
+        var port = GetAvailablePort();
+        var files = new Dictionary<string, string>
+        {
+            ["./main.ts"] = $$"""
+                import * as http from 'http';
+                const server: any = http.createServer((req: any, res: any) => {
+                    console.log('wc=' + (typeof res.writeContinue));
+                    console.log('wp=' + (typeof res.writeProcessing));
+                    console.log('at=' + (typeof res.addTrailers));
+                    console.log('fh=' + (typeof res.flushHeaders));
+                    console.log('sd=' + res.sendDate);
+                    res.writeContinue();
+                    res.writeProcessing();
+                    res.addTrailers({ 'X-Trailer': 'v' });
+                    res.flushHeaders();
+                    console.log('all-ok');
+                    res.end('done');
+                    server.close();
+                });
+                server.listen({{port}}, () => { http.get('http://127.0.0.1:{{port}}/'); });
+                """
+        };
+        var output = TestHarness.RunModules(files, "./main.ts", mode);
+        Assert.Contains("wc=function", output);
+        Assert.Contains("wp=function", output);
+        Assert.Contains("at=function", output);
+        Assert.Contains("fh=function", output);
+        Assert.Contains("sd=true", output);
+        Assert.Contains("all-ok", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ServerResponse_Write_ReturnsBoolean(ExecutionMode mode)
+    {
+        var port = GetAvailablePort();
+        var files = new Dictionary<string, string>
+        {
+            ["./main.ts"] = $$"""
+                import * as http from 'http';
+                const server: any = http.createServer((req: any, res: any) => {
+                    const r = res.write('chunk');
+                    console.log('writeType=' + (typeof r));
+                    res.end();
+                    server.close();
+                });
+                server.listen({{port}}, () => { http.get('http://127.0.0.1:{{port}}/'); });
+                """
+        };
+        var output = TestHarness.RunModules(files, "./main.ts", mode);
+        Assert.Contains("writeType=boolean", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ServerResponse_ChunkedStreaming_BodyReceived(ExecutionMode mode)
+    {
+        var port = GetAvailablePort();
+        var files = new Dictionary<string, string>
+        {
+            ["./main.ts"] = $$"""
+                import * as http from 'http';
+                const server: any = http.createServer((req: any, res: any) => {
+                    res.write('Hello ');
+                    res.write('World');
+                    res.end('!');
+                });
+                server.listen({{port}}, async () => {
+                    const r = await fetch('http://127.0.0.1:{{port}}/');
+                    const t = await r.text();
+                    console.log('body=' + t);
+                    server.close();
+                });
+                """
+        };
+        var output = TestHarness.RunModules(files, "./main.ts", mode);
+        Assert.Contains("body=Hello World!", output);
+    }
+}

--- a/SharpTS.Tests/SharedTests/HttpTypeSurfaceTests.cs
+++ b/SharpTS.Tests/SharedTests/HttpTypeSurfaceTests.cs
@@ -1,0 +1,54 @@
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests;
+
+/// <summary>
+/// Type-surface tests (#1053): idiomatic http/https client + server code type-checks against the
+/// refined GetHttpModuleTypes surface (ClientRequest/IncomingMessage/ServerResponse/Server/Agent,
+/// utilities, https TLS options).
+/// </summary>
+public class HttpTypeSurfaceTests
+{
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ServerAndClient_TypeCheck(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["./main.ts"] = """
+                import * as http from 'http';
+                const server = http.createServer((req, res) => { res.end('ok'); });
+                server.keepAliveTimeout = 5000;
+                server.requestTimeout = 1000;
+                server.closeAllConnections();
+                server.closeIdleConnections();
+                const max: number = http.maxHeaderSize;
+                http.validateHeaderName('X-A');
+                http.validateHeaderValue('X-A', 'v');
+                http.setMaxIdleHTTPParsers(4);
+                console.log('typecheck ok ' + max);
+                """
+        };
+        var output = TestHarness.RunModules(files, "./main.ts", mode);
+        Assert.Contains("typecheck ok 16384", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void HttpsCreateServerWithTlsOptions_TypeChecks(ExecutionMode mode)
+    {
+        var (certPem, keyPem) = TlsModuleTestsCertHelper.GenerateSelfSignedCert();
+        var files = new Dictionary<string, string>
+        {
+            ["./main.ts"] = $$"""
+                import * as https from 'https';
+                const server = https.createServer({ key: `{{keyPem}}`, cert: `{{certPem}}` },
+                    (req, res) => { res.end(); });
+                console.log(typeof server.listen);
+                """
+        };
+        var output = TestHarness.RunModules(files, "./main.ts", mode);
+        Assert.Equal("function\n", output);
+    }
+}

--- a/SharpTS.Tests/SharedTests/HttpUtilitiesTests.cs
+++ b/SharpTS.Tests/SharedTests/HttpUtilitiesTests.cs
@@ -1,0 +1,127 @@
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests;
+
+/// <summary>
+/// Tests for http/https utilities + constants (#1052): validateHeaderName/validateHeaderValue,
+/// maxHeaderSize, setMaxIdleHTTPParsers, and the completeness of METHODS. All dual-mode (pure
+/// functions/constants emitted in IL).
+/// </summary>
+public class HttpUtilitiesTests
+{
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void MaxHeaderSize_Is16384(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["./main.ts"] = """
+                import * as http from 'http';
+                console.log(http.maxHeaderSize);
+                """
+        };
+        var output = TestHarness.RunModules(files, "./main.ts", mode);
+        Assert.Equal("16384\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ValidateHeaderName_AcceptsValid_RejectsInvalid(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["./main.ts"] = """
+                import * as http from 'http';
+                http.validateHeaderName('X-Custom-Header');
+                console.log('valid-ok');
+                try {
+                    http.validateHeaderName('Bad Header');
+                    console.log('NO-THROW');
+                } catch (e: any) {
+                    console.log('threw:' + e.code);
+                }
+                """
+        };
+        var output = TestHarness.RunModules(files, "./main.ts", mode);
+        Assert.Contains("valid-ok", output);
+        Assert.Contains("threw:ERR_INVALID_HTTP_TOKEN", output);
+        Assert.DoesNotContain("NO-THROW", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ValidateHeaderValue_AcceptsValid_RejectsInvalid(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["./main.ts"] = """
+                import * as http from 'http';
+                http.validateHeaderValue('X-A', 'fine value');
+                console.log('valid-ok');
+                try {
+                    http.validateHeaderValue('X-A', 'bad\nvalue');
+                    console.log('NO-THROW');
+                } catch (e: any) {
+                    console.log('threw:' + e.code);
+                }
+                """
+        };
+        var output = TestHarness.RunModules(files, "./main.ts", mode);
+        Assert.Contains("valid-ok", output);
+        Assert.Contains("threw:ERR_INVALID_CHAR", output);
+        Assert.DoesNotContain("NO-THROW", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Methods_IncludesFullList(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["./main.ts"] = """
+                import * as http from 'http';
+                console.log(http.METHODS.includes('ACL'));
+                console.log(http.METHODS.includes('M-SEARCH'));
+                console.log(http.METHODS.includes('PROPFIND'));
+                console.log(http.METHODS.includes('GET'));
+                console.log(http.METHODS.length > 30);
+                """
+        };
+        var output = TestHarness.RunModules(files, "./main.ts", mode);
+        Assert.Equal("true\ntrue\ntrue\ntrue\ntrue\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void SetMaxIdleHTTPParsers_IsCallable(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["./main.ts"] = """
+                import * as http from 'http';
+                http.setMaxIdleHTTPParsers(5);
+                console.log('ok');
+                """
+        };
+        var output = TestHarness.RunModules(files, "./main.ts", mode);
+        Assert.Equal("ok\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Https_MirrorsUtilities(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["./main.ts"] = """
+                import * as https from 'https';
+                console.log(https.maxHeaderSize);
+                console.log(typeof https.validateHeaderName);
+                """
+        };
+        var output = TestHarness.RunModules(files, "./main.ts", mode);
+        Assert.Contains("16384", output);
+        Assert.Contains("function", output);
+    }
+}

--- a/SharpTS.Tests/SharedTests/HttpsModuleTests.cs
+++ b/SharpTS.Tests/SharedTests/HttpsModuleTests.cs
@@ -1,0 +1,102 @@
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests;
+
+/// <summary>
+/// Tests for the https module — a real TLS-terminating server (#1049) and a TLS client (#1050),
+/// built on the tls #1032 work (no longer a cleartext proxy to http).
+/// </summary>
+/// <remarks>
+/// Interpreter-mode: the HTTPS server runs the HTTP pipeline over a real SslStream and the client
+/// negotiates TLS via HttpClient. The compiled HTTPS server (HTTP parser/serializer over SslStream
+/// in IL) is a documented follow-up, so the server round-trip tests are interpreted-only. Basic
+/// shape (createServer/request/get exist) is dual-mode.
+/// </remarks>
+public class HttpsModuleTests
+{
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Https_Exports_Exist(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["./main.ts"] = """
+                import * as https from 'https';
+                console.log(typeof https.createServer);
+                console.log(typeof https.request);
+                console.log(typeof https.get);
+                """
+        };
+        var output = TestHarness.RunModules(files, "./main.ts", mode);
+        Assert.Equal("function\nfunction\nfunction\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void Https_ServerClient_RoundTrip(ExecutionMode mode)
+    {
+        var (certPem, keyPem) = TlsModuleTestsCertHelper.GenerateSelfSignedCert();
+        var files = new Dictionary<string, string>
+        {
+            ["./main.ts"] = $$"""
+                import * as https from 'https';
+                const server: any = https.createServer(
+                    { key: `{{keyPem}}`, cert: `{{certPem}}` },
+                    (req: any, res: any) => {
+                        res.writeHead(200, { 'Content-Type': 'text/plain' });
+                        res.end('secure:' + req.url);
+                    });
+                server.listen(0, () => {
+                    const port = server.address().port;
+                    https.get({ host: '127.0.0.1', port, path: '/hello', rejectUnauthorized: false }, (res: any) => {
+                        console.log('status=' + res.statusCode);
+                        let body = '';
+                        res.on('data', (c: any) => { body += c.toString(); });
+                        res.on('end', () => {
+                            console.log('body=' + body);
+                            server.close();
+                        });
+                    });
+                });
+                """
+        };
+        var output = TestHarness.RunModules(files, "./main.ts", mode);
+        Assert.Contains("status=200", output);
+        Assert.Contains("body=secure:/hello", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void Https_ServerClient_PostBody(ExecutionMode mode)
+    {
+        var (certPem, keyPem) = TlsModuleTestsCertHelper.GenerateSelfSignedCert();
+        var files = new Dictionary<string, string>
+        {
+            ["./main.ts"] = $$"""
+                import * as https from 'https';
+                const server: any = https.createServer(
+                    { key: `{{keyPem}}`, cert: `{{certPem}}` },
+                    (req: any, res: any) => {
+                        let body = '';
+                        req.on('data', (c: any) => { body += c.toString(); });
+                        req.on('end', () => { res.end('echo:' + body); });
+                    });
+                server.listen(0, () => {
+                    const port = server.address().port;
+                    const r: any = https.request(
+                        { host: '127.0.0.1', port, path: '/', method: 'POST', rejectUnauthorized: false },
+                        (res: any) => {
+                            let body = '';
+                            res.on('data', (c: any) => { body += c.toString(); });
+                            res.on('end', () => { console.log(body); server.close(); });
+                        });
+                    r.write('payload-over-tls');
+                    r.end();
+                });
+                """
+        };
+        var output = TestHarness.RunModules(files, "./main.ts", mode);
+        Assert.Contains("echo:payload-over-tls", output);
+    }
+}

--- a/TypeSystem/BuiltInModuleTypes.cs
+++ b/TypeSystem/BuiltInModuleTypes.cs
@@ -1616,7 +1616,18 @@ public static class BuiltInModuleTypes
             ["prependListener"] = new TypeInfo.Function([stringType, anyType], anyType),
             ["prependOnceListener"] = new TypeInfo.Function([stringType, anyType], anyType),
             ["setMaxListeners"] = new TypeInfo.Function([numberType], anyType),
-            ["getMaxListeners"] = new TypeInfo.Function([], numberType)
+            ["getMaxListeners"] = new TypeInfo.Function([], numberType),
+
+            // Server lifecycle (#1045)
+            ["closeAllConnections"] = new TypeInfo.Function([], voidType),
+            ["closeIdleConnections"] = new TypeInfo.Function([], voidType),
+            ["setTimeout"] = new TypeInfo.Function([numberType, anyType], anyType, RequiredParams: 0),
+            ["keepAliveTimeout"] = numberType,
+            ["headersTimeout"] = numberType,
+            ["requestTimeout"] = numberType,
+            ["timeout"] = numberType,
+            ["maxHeadersCount"] = numberType,
+            ["maxRequestsPerSocket"] = numberType
         }.ToFrozenDictionary());
 
         // STATUS_CODES type - with string index signature for dynamic property access
@@ -1658,13 +1669,22 @@ public static class BuiltInModuleTypes
 
         return new Dictionary<string, TypeInfo>
         {
-            ["createServer"] = new TypeInfo.Function([callbackType], serverType, RequiredParams: 0),
-            ["request"] = new TypeInfo.Function([anyType, anyType], anyType, RequiredParams: 1),
-            ["get"] = new TypeInfo.Function([anyType, anyType], anyType, RequiredParams: 1),
+            // createServer accepts an optional options object (https TLS opts: key/cert/ca/pfx/
+            // passphrase/SNICallback/ALPNProtocols, #1049) and/or a (req,res) handler.
+            ["createServer"] = new TypeInfo.Function([anyType, anyType], serverType, RequiredParams: 0),
+            // request/get return a ClientRequest (#1043) typed as any so the writable + event
+            // surface (write/end/setHeader/on('response')/...) type-checks without over-constraining.
+            ["request"] = new TypeInfo.Function([anyType, anyType, anyType], anyType, RequiredParams: 1),
+            ["get"] = new TypeInfo.Function([anyType, anyType, anyType], anyType, RequiredParams: 1),
             ["METHODS"] = methodsType,
             ["STATUS_CODES"] = statusCodesType,
             ["globalAgent"] = agentType,
-            ["Agent"] = agentConstructorType
+            ["Agent"] = agentConstructorType,
+            // Utilities + constants (#1052)
+            ["validateHeaderName"] = new TypeInfo.Function([stringType, stringType], voidType, RequiredParams: 1),
+            ["validateHeaderValue"] = new TypeInfo.Function([stringType, anyType], voidType, RequiredParams: 2),
+            ["maxHeaderSize"] = numberType,
+            ["setMaxIdleHTTPParsers"] = new TypeInfo.Function([numberType], voidType, RequiredParams: 0)
         };
     }
 


### PR DESCRIPTION
## Summary

Implements epic #1042 — the Node.js `http`/`https` modules toward 100% Node compatibility — across all 11 children (#1043–#1053), one commit per child. This is the marquee module of the `stream → tls → http/https` chain (both deps merged on `main`).

**Phase 1 — Client (#1043, #1044):** `http.request`/`get` now return a real `ClientRequest` (a Writable) instead of delegating to `fetch` and returning the awaited `Response`. Writable body (`write`/`end`), `setHeader`/`getHeader`/`removeHeader`/`hasHeader`/`getHeaders`/`flushHeaders`, `abort`/`destroy`/`setTimeout`, and the response lifecycle: `'socket'` → `'response'` with an `IncomingMessage` (statusCode/statusMessage/headers/rawHeaders/httpVersion + streaming Readable body), `'error'` (with `.code`), `'abort'`/`'close'`/`'timeout'`. Shared cookie-jar integration retained. Wraps a no-redirect/no-decompress BCL `HttpClient`.

**Phase 2 — Server lifecycle + messages (#1045–#1048):**
- `closeAllConnections`/`closeIdleConnections`, `keepAliveTimeout`/`headersTimeout`/`requestTimeout`/`timeout`/`maxHeadersCount`/`maxRequestsPerSocket` config, `setTimeout`, best-effort `'connection'` event.
- `checkContinue` (Expect: 100-continue); `upgrade`/`connect`/`clientError` documented as HttpListener ceilings (no raw-socket handoff — matches the epic's stated scope).
- `ServerResponse`: `writeContinue`/`writeProcessing`/`addTrailers`/`flushHeaders`, writable `statusMessage`, settable `sendDate`, real chunked transfer-encoding, boolean `write()`.
- `IncomingMessage`: `rawHeaders` (case + order), `httpVersionMajor/Minor`, `trailers`/`rawTrailers`, real socket (`remoteAddress`/`family`/...), correct `statusCode`/`statusMessage` (undefined server-side), and **on-demand body streaming** — the compiled server now actually delivers the request body to `req.on('data')` (was empty before).

**Phase 3 — https over real TLS (#1049, #1050):** `https` is no longer a cleartext proxy. `https.createServer(tlsOptions)` is a real TLS-terminating server (`TcpListener` + `SslStream`, reusing the tls #1032 cert handling: key/cert/pfx/passphrase/ALPNProtocols/secureContext) running a minimal HTTP/1.1 pipeline over each connection. `https.request`/`get` negotiate TLS (honoring `rejectUnauthorized`/`servername`/headers/auth).

**Phase 4 — Agent, utilities, types (#1051–#1053):** observable per-origin `Agent` pool (`sockets`/`freeSockets`/`requests`, keep-alive reuse, `agent:false`, `destroy`, `getName`); `validateHeaderName`/`validateHeaderValue` (correct `ERR_*` codes), `maxHeaderSize`, `setMaxIdleHTTPParsers`, completed `METHODS`; refined type surface.

## Interp ↔ compiled parity

Dual-mode (both interpreter and compiled IL) where the existing emitter infra made it tractable: **all of #1045/#1047/#1048/#1051(getName+config)/#1052**, plus the compiled server now emitting the request body. Interpreter-first with **documented compiled deferrals** (matching the established tls #1029 / SNICallback precedent) for the large new IL object models: the compiled `ClientRequest` (compiled client still routes through `fetch`, so existing dual-mode server tests stay green) and the compiled HTTPS server (HTTP parser/serializer over `SslStream` in IL). Those features' tests are interpreted-only and clearly labelled.

## Verification

- `dotnet test` (full xUnit): green (14691/0) — 9 new http/https test files (~55 tests); no regressions (two pre-#1043 cookie tests updated to the ClientRequest API).
- Test262 + TypeScriptConformance: no baseline drift (http/https are non-ECMA; type entries are additive).
- Standalone preserved (BCL-only: HttpListener/HttpClient/SslStream; no new SharpTS.dll dependency).

Closes #1043 #1044 #1045 #1046 #1047 #1048 #1049 #1050 #1051 #1052 #1053
