### PR TITLE
Epic: Node.js vm module → 100% compatibility (ESM Module API, cachedData/options, measureMemory) (#1150)

### DIFF
--- a/Compilation/EmittedRuntime.cs
+++ b/Compilation/EmittedRuntime.cs
@@ -3010,11 +3010,16 @@ public class EmittedRuntime
     // Vm module methods
     public MethodBuilder VmRunInNewContext { get; set; } = null!;
     public MethodBuilder VmRunInThisContext { get; set; } = null!;
+    public MethodBuilder VmRunInContext { get; set; } = null!;
     public MethodBuilder VmCreateContext { get; set; } = null!;
     public MethodBuilder VmIsContext { get; set; } = null!;
     public MethodBuilder VmGetScriptConstructor { get; set; } = null!;
     public MethodBuilder VmNewScript { get; set; } = null!;
     public MethodBuilder VmCompileFunction { get; set; } = null!;
+    public MethodBuilder VmGetConstants { get; set; } = null!;
+    public MethodBuilder VmMeasureMemory { get; set; } = null!;
+    public MethodBuilder VmNewSourceTextModule { get; set; } = null!;
+    public MethodBuilder VmNewSyntheticModule { get; set; } = null!;
 
     // Pure-IL Web Streams emitted types. The original late-binding helpers
     // (CreateReadableStream/CreateWritableStream/etc.) were removed when

--- a/Compilation/Emitters/Modules/VmModuleEmitter.cs
+++ b/Compilation/Emitters/Modules/VmModuleEmitter.cs
@@ -14,7 +14,8 @@ public sealed class VmModuleEmitter : IBuiltInModuleEmitter
 
     private static readonly string[] _exportedMembers =
     [
-        "runInNewContext", "runInThisContext", "createContext", "isContext", "compileFunction", "Script"
+        "runInNewContext", "runInThisContext", "runInContext", "createContext", "isContext",
+        "compileFunction", "constants", "Script"
     ];
 
     public IReadOnlyList<string> GetExportedMembers() => _exportedMembers;
@@ -25,6 +26,7 @@ public sealed class VmModuleEmitter : IBuiltInModuleEmitter
         {
             "runInNewContext" => EmitRunInNewContext(emitter, arguments),
             "runInThisContext" => EmitRunInThisContext(emitter, arguments),
+            "runInContext" => EmitRunInContext(emitter, arguments),
             "createContext" => EmitCreateContext(emitter, arguments),
             "isContext" => EmitIsContext(emitter, arguments),
             "compileFunction" => EmitCompileFunction(emitter, arguments),
@@ -34,26 +36,35 @@ public sealed class VmModuleEmitter : IBuiltInModuleEmitter
 
     public bool TryEmitPropertyGet(IEmitterContext emitter, string propertyName)
     {
+        var ctx = emitter.Context;
+        var il = ctx.IL;
+
         if (propertyName == "Script")
         {
-            var ctx = emitter.Context;
-            var il = ctx.IL;
             il.Emit(OpCodes.Call, ctx.Runtime!.VmGetScriptConstructor);
             emitter.SetStackUnknown();
             return true;
         }
 
-        // Methods emitted as null for namespace dict — actual calls go through TryEmitMethodCall
-        if (propertyName is "runInNewContext" or "runInThisContext" or "createContext" or "isContext" or "compileFunction")
+        if (propertyName == "constants")
         {
-            emitter.Context.IL.Emit(OpCodes.Ldnull);
+            il.Emit(OpCodes.Call, ctx.Runtime!.VmGetConstants);
+            emitter.SetStackUnknown();
+            return true;
+        }
+
+        // Methods emitted as null for namespace dict — actual calls go through TryEmitMethodCall
+        if (propertyName is "runInNewContext" or "runInThisContext" or "runInContext"
+            or "createContext" or "isContext" or "compileFunction")
+        {
+            il.Emit(OpCodes.Ldnull);
             return true;
         }
 
         return false;
     }
 
-    public bool IsExportedProperty(string memberName) => memberName == "Script";
+    public bool IsExportedProperty(string memberName) => memberName is "Script" or "constants";
 
     private static bool EmitRunInNewContext(IEmitterContext emitter, List<Expr> arguments)
     {
@@ -94,6 +105,49 @@ public sealed class VmModuleEmitter : IBuiltInModuleEmitter
         }
 
         il.Emit(OpCodes.Call, ctx.Runtime!.VmRunInNewContext);
+        emitter.SetStackUnknown();
+        return true;
+    }
+
+    private static bool EmitRunInContext(IEmitterContext emitter, List<Expr> arguments)
+    {
+        var ctx = emitter.Context;
+        var il = ctx.IL;
+
+        // code (string)
+        if (arguments.Count > 0)
+        {
+            emitter.EmitExpression(arguments[0]);
+            emitter.EmitBoxIfNeeded(arguments[0]);
+        }
+        else
+        {
+            il.Emit(OpCodes.Ldnull);
+        }
+
+        // contextifiedObject
+        if (arguments.Count > 1)
+        {
+            emitter.EmitExpression(arguments[1]);
+            emitter.EmitBoxIfNeeded(arguments[1]);
+        }
+        else
+        {
+            il.Emit(OpCodes.Ldnull);
+        }
+
+        // options (optional)
+        if (arguments.Count > 2)
+        {
+            emitter.EmitExpression(arguments[2]);
+            emitter.EmitBoxIfNeeded(arguments[2]);
+        }
+        else
+        {
+            il.Emit(OpCodes.Ldnull);
+        }
+
+        il.Emit(OpCodes.Call, ctx.Runtime!.VmRunInContext);
         emitter.SetStackUnknown();
         return true;
     }

--- a/Compilation/Emitters/Modules/VmModuleEmitter.cs
+++ b/Compilation/Emitters/Modules/VmModuleEmitter.cs
@@ -15,7 +15,7 @@ public sealed class VmModuleEmitter : IBuiltInModuleEmitter
     private static readonly string[] _exportedMembers =
     [
         "runInNewContext", "runInThisContext", "runInContext", "createContext", "isContext",
-        "compileFunction", "constants", "Script"
+        "compileFunction", "measureMemory", "constants", "Script"
     ];
 
     public IReadOnlyList<string> GetExportedMembers() => _exportedMembers;
@@ -30,6 +30,7 @@ public sealed class VmModuleEmitter : IBuiltInModuleEmitter
             "createContext" => EmitCreateContext(emitter, arguments),
             "isContext" => EmitIsContext(emitter, arguments),
             "compileFunction" => EmitCompileFunction(emitter, arguments),
+            "measureMemory" => EmitMeasureMemory(emitter, arguments),
             _ => false
         };
     }
@@ -55,7 +56,7 @@ public sealed class VmModuleEmitter : IBuiltInModuleEmitter
 
         // Methods emitted as null for namespace dict — actual calls go through TryEmitMethodCall
         if (propertyName is "runInNewContext" or "runInThisContext" or "runInContext"
-            or "createContext" or "isContext" or "compileFunction")
+            or "createContext" or "isContext" or "compileFunction" or "measureMemory")
         {
             il.Emit(OpCodes.Ldnull);
             return true;
@@ -189,6 +190,7 @@ public sealed class VmModuleEmitter : IBuiltInModuleEmitter
         var ctx = emitter.Context;
         var il = ctx.IL;
 
+        // contextObject (optional)
         if (arguments.Count > 0)
         {
             emitter.EmitExpression(arguments[0]);
@@ -199,7 +201,39 @@ public sealed class VmModuleEmitter : IBuiltInModuleEmitter
             il.Emit(OpCodes.Ldnull);
         }
 
+        // options (optional)
+        if (arguments.Count > 1)
+        {
+            emitter.EmitExpression(arguments[1]);
+            emitter.EmitBoxIfNeeded(arguments[1]);
+        }
+        else
+        {
+            il.Emit(OpCodes.Ldnull);
+        }
+
         il.Emit(OpCodes.Call, ctx.Runtime!.VmCreateContext);
+        emitter.SetStackUnknown();
+        return true;
+    }
+
+    private static bool EmitMeasureMemory(IEmitterContext emitter, List<Expr> arguments)
+    {
+        var ctx = emitter.Context;
+        var il = ctx.IL;
+
+        // options (optional)
+        if (arguments.Count > 0)
+        {
+            emitter.EmitExpression(arguments[0]);
+            emitter.EmitBoxIfNeeded(arguments[0]);
+        }
+        else
+        {
+            il.Emit(OpCodes.Ldnull);
+        }
+
+        il.Emit(OpCodes.Call, ctx.Runtime!.VmMeasureMemory);
         emitter.SetStackUnknown();
         return true;
     }

--- a/Compilation/ExpressionEmitterBase.Constructors.cs
+++ b/Compilation/ExpressionEmitterBase.Constructors.cs
@@ -498,6 +498,15 @@ public abstract partial class ExpressionEmitterBase
                 SetStackUnknown();
                 return true;
 
+            // --- vm.SyntheticModule ---
+            case "SyntheticModule":
+                EmitBoxedArgOrNull(arguments, 0);
+                EmitBoxedArgOrNull(arguments, 1);
+                EmitBoxedArgOrNull(arguments, 2);
+                IL.Emit(OpCodes.Call, Ctx.Runtime!.VmNewSyntheticModule);
+                SetStackUnknown();
+                return true;
+
             // --- Stream constructors ---
             case "Readable":
                 EmitNewReadableConstructor(arguments);

--- a/Compilation/ExpressionEmitterBase.Constructors.cs
+++ b/Compilation/ExpressionEmitterBase.Constructors.cs
@@ -490,6 +490,14 @@ public abstract partial class ExpressionEmitterBase
                 SetStackUnknown();
                 return true;
 
+            // --- vm.SourceTextModule ---
+            case "SourceTextModule":
+                EmitBoxedArgOrNull(arguments, 0);
+                EmitBoxedArgOrNull(arguments, 1);
+                IL.Emit(OpCodes.Call, Ctx.Runtime!.VmNewSourceTextModule);
+                SetStackUnknown();
+                return true;
+
             // --- Stream constructors ---
             case "Readable":
                 EmitNewReadableConstructor(arguments);

--- a/Compilation/RuntimeEmitter.Objects.Invocation.cs
+++ b/Compilation/RuntimeEmitter.Objects.Invocation.cs
@@ -915,6 +915,13 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Brfalse, noCallMethodLabel);
 
         // Call(interpreter=null, args=new List<object?>(object[]))
+        // Wrapped in try/catch so a guest error thrown by the BuiltInMethod (which
+        // reflection re-wraps in TargetInvocationException) is unwrapped to the real
+        // guest exception — without this, a throwing cross-boundary BuiltInMethod (e.g.
+        // vm.Module.link/evaluate failing) escapes guest try/catch as a raw
+        // TargetInvocationException and crashes the program.
+        var reflectResultLocal = il.DeclareLocal(_types.Object);
+        il.BeginExceptionBlock();
         il.Emit(OpCodes.Ldloc, callMiLocal);
         il.Emit(OpCodes.Ldarg_1); // the callable object
         il.Emit(OpCodes.Ldc_I4_2);
@@ -930,6 +937,21 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Newobj, _types.ListObjectNullableCtor_IEnumerable);
         il.Emit(OpCodes.Stelem_Ref);
         il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.MethodInfo, "Invoke", _types.Object, _types.ObjectArray));
+        il.Emit(OpCodes.Stloc, reflectResultLocal);
+        il.BeginCatchBlock(typeof(TargetInvocationException));
+        // ex on stack → rethrow ex.InnerException (the real guest error) if present.
+        il.Emit(OpCodes.Callvirt, typeof(Exception).GetProperty("InnerException")!.GetGetMethod()!);
+        var innerLocal = il.DeclareLocal(typeof(Exception));
+        il.Emit(OpCodes.Stloc, innerLocal);
+        var rethrowOriginal = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, innerLocal);
+        il.Emit(OpCodes.Brfalse, rethrowOriginal);
+        il.Emit(OpCodes.Ldloc, innerLocal);
+        il.Emit(OpCodes.Throw);
+        il.MarkLabel(rethrowOriginal);
+        il.Emit(OpCodes.Rethrow);
+        il.EndExceptionBlock();
+        il.Emit(OpCodes.Ldloc, reflectResultLocal);
         il.Emit(OpCodes.Ret);
 
         // Unrecognized non-callable (plain object, number, $Undefined, …):

--- a/Compilation/RuntimeEmitter.VmHelpers.cs
+++ b/Compilation/RuntimeEmitter.VmHelpers.cs
@@ -18,9 +18,57 @@ public partial class RuntimeEmitter
         EmitVmCreateContext(typeBuilder, runtime);
         EmitVmIsContext(typeBuilder, runtime);
         EmitVmCompileFunction(typeBuilder, runtime);
+        EmitVmMeasureMemory(typeBuilder, runtime);
         EmitVmGetConstants(typeBuilder, runtime);
         EmitVmGetScriptConstructor(typeBuilder, runtime);
         EmitVmNewScript(typeBuilder, runtime);
+    }
+
+    /// <summary>
+    /// Emits: public static object VmMeasureMemory(object options)
+    /// Fetches the raw measureMemory result dictionary from VmModuleInterpreter via
+    /// reflection and wraps it in a native $Promise (a cross-boundary SharpTSPromise is
+    /// not unwrapped by compiled await, so we can't return the interpreter's promise).
+    /// </summary>
+    private void EmitVmMeasureMemory(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    {
+        var method = typeBuilder.DefineMethod(
+            "VmMeasureMemory",
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.Object,
+            [_types.Object]);
+        runtime.VmMeasureMemory = method;
+        runtime.RegisterBuiltInModuleMethod("vm", "measureMemory", method);
+
+        var il = method.GetILGenerator();
+
+        // Type moduleType = Type.GetType("...VmModuleInterpreter, SharpTS");
+        il.Emit(OpCodes.Ldstr, "SharpTS.Runtime.BuiltIns.Modules.Interpreter.VmModuleInterpreter, SharpTS");
+        il.Emit(OpCodes.Call, _types.GetMethod(_types.Type, "GetType", _types.String));
+        var typeLocal = il.DeclareLocal(_types.Type);
+        il.Emit(OpCodes.Stloc, typeLocal);
+
+        // Standalone (SharpTS absent): return a resolved promise of null.
+        var typeOk = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, typeLocal);
+        il.Emit(OpCodes.Brtrue, typeOk);
+        il.Emit(OpCodes.Ldnull);
+        il.Emit(OpCodes.Call, runtime.TSPromiseResolve);
+        il.Emit(OpCodes.Ret);
+        il.MarkLabel(typeOk);
+
+        // object dict = moduleType.GetMethod("MeasureMemoryResultObject").Invoke(null, Array.Empty<object>());
+        il.Emit(OpCodes.Ldloc, typeLocal);
+        il.Emit(OpCodes.Ldstr, "MeasureMemoryResultObject");
+        il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.Type, "GetMethod", _types.String));
+        il.Emit(OpCodes.Ldnull);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Newarr, _types.Object);
+        il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.MethodInfo, "Invoke", _types.Object, _types.ObjectArray));
+
+        // return $Runtime.Resolve(dict)  →  native $Promise
+        il.Emit(OpCodes.Call, runtime.TSPromiseResolve);
+        il.Emit(OpCodes.Ret);
     }
 
     /// <summary>
@@ -104,12 +152,12 @@ public partial class RuntimeEmitter
             "VmCreateContext",
             MethodAttributes.Public | MethodAttributes.Static,
             _types.Object,
-            [_types.Object]);
+            [_types.Object, _types.Object]);
         runtime.VmCreateContext = method;
         runtime.RegisterBuiltInModuleMethod("vm", "createContext", method);
 
         var il = method.GetILGenerator();
-        EmitVmReflectionCall(il, "createContext", 1);
+        EmitVmReflectionCall(il, "createContext", 2);
     }
 
     /// <summary>

--- a/Compilation/RuntimeEmitter.VmHelpers.cs
+++ b/Compilation/RuntimeEmitter.VmHelpers.cs
@@ -14,11 +14,48 @@ public partial class RuntimeEmitter
     {
         EmitVmRunInNewContext(typeBuilder, runtime);
         EmitVmRunInThisContext(typeBuilder, runtime);
+        EmitVmRunInContext(typeBuilder, runtime);
         EmitVmCreateContext(typeBuilder, runtime);
         EmitVmIsContext(typeBuilder, runtime);
         EmitVmCompileFunction(typeBuilder, runtime);
+        EmitVmGetConstants(typeBuilder, runtime);
         EmitVmGetScriptConstructor(typeBuilder, runtime);
         EmitVmNewScript(typeBuilder, runtime);
+    }
+
+    /// <summary>
+    /// Emits: public static object VmRunInContext(object code, object contextifiedObject, object options)
+    /// Delegates to VmModuleInterpreter.GetExports()["runInContext"] via reflection.
+    /// </summary>
+    private void EmitVmRunInContext(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    {
+        var method = typeBuilder.DefineMethod(
+            "VmRunInContext",
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.Object,
+            [_types.Object, _types.Object, _types.Object]);
+        runtime.VmRunInContext = method;
+        runtime.RegisterBuiltInModuleMethod("vm", "runInContext", method);
+
+        var il = method.GetILGenerator();
+        EmitVmReflectionCall(il, "runInContext", 3);
+    }
+
+    /// <summary>
+    /// Emits: public static object VmGetConstants()
+    /// Returns VmModuleInterpreter.GetExports()["constants"] via reflection.
+    /// </summary>
+    private void EmitVmGetConstants(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    {
+        var method = typeBuilder.DefineMethod(
+            "VmGetConstants",
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.Object,
+            Type.EmptyTypes);
+        runtime.VmGetConstants = method;
+
+        var il = method.GetILGenerator();
+        EmitVmGetExportValue(il, "constants");
     }
 
     /// <summary>
@@ -127,7 +164,16 @@ public partial class RuntimeEmitter
         runtime.RegisterBuiltInModuleMethod("vm", "Script", method);
 
         var il = method.GetILGenerator();
+        EmitVmGetExportValue(il, "Script");
+    }
 
+    /// <summary>
+    /// Emits IL that returns VmModuleInterpreter.GetExports()[exportName] (the raw
+    /// exported value — a dict, constructor, or other object — not the result of a Call).
+    /// Returns null when SharpTS isn't present at runtime (standalone graceful degradation).
+    /// </summary>
+    private void EmitVmGetExportValue(ILGenerator il, string exportName)
+    {
         // Type moduleType = Type.GetType("SharpTS.Runtime.BuiltIns.Modules.Interpreter.VmModuleInterpreter, SharpTS");
         il.Emit(OpCodes.Ldstr, "SharpTS.Runtime.BuiltIns.Modules.Interpreter.VmModuleInterpreter, SharpTS");
         il.Emit(OpCodes.Call, _types.GetMethod(_types.Type, "GetType", _types.String));
@@ -152,7 +198,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Newarr, _types.Object);
         il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.MethodInfo, "Invoke", _types.Object, _types.ObjectArray));
 
-        // Get "Script" from exports dict
+        // Get exports[exportName] via the dictionary indexer
         var exportsLocal = il.DeclareLocal(_types.Object);
         il.Emit(OpCodes.Stloc, exportsLocal);
 
@@ -165,7 +211,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Newarr, _types.Object);
         il.Emit(OpCodes.Dup);
         il.Emit(OpCodes.Ldc_I4_0);
-        il.Emit(OpCodes.Ldstr, "Script");
+        il.Emit(OpCodes.Ldstr, exportName);
         il.Emit(OpCodes.Stelem_Ref);
         il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.PropertyInfo, "GetValue", _types.Object, _types.ObjectArray));
         il.Emit(OpCodes.Ret);

--- a/Compilation/RuntimeEmitter.VmHelpers.cs
+++ b/Compilation/RuntimeEmitter.VmHelpers.cs
@@ -22,6 +22,7 @@ public partial class RuntimeEmitter
         EmitVmGetConstants(typeBuilder, runtime);
         EmitVmGetScriptConstructor(typeBuilder, runtime);
         EmitVmNewScript(typeBuilder, runtime);
+        EmitVmNewSourceTextModule(typeBuilder, runtime);
     }
 
     /// <summary>
@@ -278,9 +279,34 @@ public partial class RuntimeEmitter
             [_types.Object, _types.Object]);
         runtime.VmNewScript = method;
 
-        var il = method.GetILGenerator();
+        EmitVmConstructorCall(method.GetILGenerator(), "Script", 2);
+    }
 
-        // Get the Script constructor: VmModuleInterpreter.GetExports()["Script"]
+    /// <summary>
+    /// Emits: public static object VmNewSourceTextModule(object code, object options)
+    /// Creates a vm.SourceTextModule facade via reflection to VmSourceTextModuleConstructor.
+    /// </summary>
+    private void EmitVmNewSourceTextModule(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    {
+        var method = typeBuilder.DefineMethod(
+            "VmNewSourceTextModule",
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.Object,
+            [_types.Object, _types.Object]);
+        runtime.VmNewSourceTextModule = method;
+
+        EmitVmConstructorCall(method.GetILGenerator(), "SourceTextModule", 2);
+    }
+
+    /// <summary>
+    /// Emits IL that constructs a vm export via its ISharpTSCallable constructor:
+    /// <c>VmModuleInterpreter.GetExports()[exportName].Call(null, new List&lt;object?&gt; { arg0..argN-1 })</c>.
+    /// The N constructor arguments are taken from ldarg 0..N-1. Returns null (graceful
+    /// degradation) when SharpTS isn't present at runtime.
+    /// </summary>
+    private void EmitVmConstructorCall(ILGenerator il, string exportName, int argCount)
+    {
+        // Type moduleType = Type.GetType("...VmModuleInterpreter, SharpTS");
         il.Emit(OpCodes.Ldstr, "SharpTS.Runtime.BuiltIns.Modules.Interpreter.VmModuleInterpreter, SharpTS");
         il.Emit(OpCodes.Call, _types.GetMethod(_types.Type, "GetType", _types.String));
         var typeLocal = il.DeclareLocal(_types.Type);
@@ -293,7 +319,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ret);
         il.MarkLabel(typeOk);
 
-        // Get exports
+        // object exports = moduleType.GetMethod("GetExports").Invoke(null, Array.Empty<object>());
         il.Emit(OpCodes.Ldloc, typeLocal);
         il.Emit(OpCodes.Ldstr, "GetExports");
         il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.Type, "GetMethod", _types.String));
@@ -304,7 +330,7 @@ public partial class RuntimeEmitter
         var exportsLocal = il.DeclareLocal(_types.Object);
         il.Emit(OpCodes.Stloc, exportsLocal);
 
-        // Get "Script" from exports
+        // object ctor = exports[exportName]
         il.Emit(OpCodes.Ldloc, exportsLocal);
         il.Emit(OpCodes.Callvirt, _types.GetMethodNoParams(_types.Object, "GetType"));
         il.Emit(OpCodes.Ldstr, "Item");
@@ -314,26 +340,25 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Newarr, _types.Object);
         il.Emit(OpCodes.Dup);
         il.Emit(OpCodes.Ldc_I4_0);
-        il.Emit(OpCodes.Ldstr, "Script");
+        il.Emit(OpCodes.Ldstr, exportName);
         il.Emit(OpCodes.Stelem_Ref);
         il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.PropertyInfo, "GetValue", _types.Object, _types.ObjectArray));
         var ctorLocal = il.DeclareLocal(_types.Object);
         il.Emit(OpCodes.Stloc, ctorLocal);
 
-        // Build args: new List<object?> { code, options }
+        // Build args: new List<object?> { arg0..argN-1 }
         il.Emit(OpCodes.Newobj, _types.ListObjectNullableDefaultCtor);
         var argsLocal = il.DeclareLocal(_types.ListOfObjectNullable);
         il.Emit(OpCodes.Stloc, argsLocal);
 
-        il.Emit(OpCodes.Ldloc, argsLocal);
-        il.Emit(OpCodes.Ldarg_0); // code
-        il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.ListOfObjectNullable, "Add", _types.Object));
+        for (int i = 0; i < argCount; i++)
+        {
+            il.Emit(OpCodes.Ldloc, argsLocal);
+            il.Emit(OpCodes.Ldarg, i);
+            il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.ListOfObjectNullable, "Add", _types.Object));
+        }
 
-        il.Emit(OpCodes.Ldloc, argsLocal);
-        il.Emit(OpCodes.Ldarg_1); // options
-        il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.ListOfObjectNullable, "Add", _types.Object));
-
-        // Call ctor.GetType().GetMethod("Call").Invoke(ctor, new object[] { null, argsList })
+        // ctor.GetType().GetMethod("Call").Invoke(ctor, new object[] { null, argsList })
         il.Emit(OpCodes.Ldloc, ctorLocal);
         il.Emit(OpCodes.Callvirt, _types.GetMethodNoParams(_types.Object, "GetType"));
         il.Emit(OpCodes.Ldstr, "Call");

--- a/Compilation/RuntimeEmitter.VmHelpers.cs
+++ b/Compilation/RuntimeEmitter.VmHelpers.cs
@@ -23,6 +23,7 @@ public partial class RuntimeEmitter
         EmitVmGetScriptConstructor(typeBuilder, runtime);
         EmitVmNewScript(typeBuilder, runtime);
         EmitVmNewSourceTextModule(typeBuilder, runtime);
+        EmitVmNewSyntheticModule(typeBuilder, runtime);
     }
 
     /// <summary>
@@ -296,6 +297,22 @@ public partial class RuntimeEmitter
         runtime.VmNewSourceTextModule = method;
 
         EmitVmConstructorCall(method.GetILGenerator(), "SourceTextModule", 2);
+    }
+
+    /// <summary>
+    /// Emits: public static object VmNewSyntheticModule(object exportNames, object evaluateCallback, object options)
+    /// Creates a vm.SyntheticModule facade via reflection to VmSyntheticModuleConstructor.
+    /// </summary>
+    private void EmitVmNewSyntheticModule(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    {
+        var method = typeBuilder.DefineMethod(
+            "VmNewSyntheticModule",
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.Object,
+            [_types.Object, _types.Object, _types.Object]);
+        runtime.VmNewSyntheticModule = method;
+
+        EmitVmConstructorCall(method.GetILGenerator(), "SyntheticModule", 3);
     }
 
     /// <summary>

--- a/Compilation/RuntimeEmitter.VmHelpers.cs
+++ b/Compilation/RuntimeEmitter.VmHelpers.cs
@@ -50,13 +50,11 @@ public partial class RuntimeEmitter
         var typeLocal = il.DeclareLocal(_types.Type);
         il.Emit(OpCodes.Stloc, typeLocal);
 
-        // Standalone (SharpTS absent): return a resolved promise of null.
+        // Standalone (SharpTS absent): throw a clear "not supported" error.
         var typeOk = il.DefineLabel();
         il.Emit(OpCodes.Ldloc, typeLocal);
         il.Emit(OpCodes.Brtrue, typeOk);
-        il.Emit(OpCodes.Ldnull);
-        il.Emit(OpCodes.Call, runtime.TSPromiseResolve);
-        il.Emit(OpCodes.Ret);
+        EmitThrowVmNotStandalone(il);
         il.MarkLabel(typeOk);
 
         // object dict = moduleType.GetMethod("MeasureMemoryResultObject").Invoke(null, Array.Empty<object>());
@@ -234,8 +232,7 @@ public partial class RuntimeEmitter
         var typeOk = il.DefineLabel();
         il.Emit(OpCodes.Ldloc, typeLocal);
         il.Emit(OpCodes.Brtrue, typeOk);
-        il.Emit(OpCodes.Ldnull);
-        il.Emit(OpCodes.Ret);
+        EmitThrowVmNotStandalone(il);
         il.MarkLabel(typeOk);
 
         // MethodInfo getExports = moduleType.GetMethod("GetExports");
@@ -332,8 +329,7 @@ public partial class RuntimeEmitter
         var typeOk = il.DefineLabel();
         il.Emit(OpCodes.Ldloc, typeLocal);
         il.Emit(OpCodes.Brtrue, typeOk);
-        il.Emit(OpCodes.Ldnull);
-        il.Emit(OpCodes.Ret);
+        EmitThrowVmNotStandalone(il);
         il.MarkLabel(typeOk);
 
         // object exports = moduleType.GetMethod("GetExports").Invoke(null, Array.Empty<object>());
@@ -396,6 +392,19 @@ public partial class RuntimeEmitter
     }
 
     /// <summary>
+    /// Emits a clear "vm requires the SharpTS runtime" throw — reached only when the vm
+    /// program was built with --standalone (SharpTS.dll suppressed), so the soft-dependency
+    /// path degrades to a deterministic error instead of a silent null (cf. the eval/tls
+    /// standalone lesson). A normal --compile co-locates SharpTS.dll, so this never fires.
+    /// </summary>
+    private void EmitThrowVmNotStandalone(ILGenerator il)
+    {
+        il.Emit(OpCodes.Ldstr, "vm module is not supported in standalone compiled output (SharpTS runtime not present).");
+        il.Emit(OpCodes.Newobj, _types.ExceptionCtorString);
+        il.Emit(OpCodes.Throw);
+    }
+
+    /// <summary>
     /// Emits IL that calls VmModuleInterpreter.GetExports()[methodName] via reflection.
     /// Same pattern as EmitChildProcessReflectionCall.
     /// </summary>
@@ -411,8 +420,7 @@ public partial class RuntimeEmitter
         var typeOk = il.DefineLabel();
         il.Emit(OpCodes.Ldloc, typeLocal);
         il.Emit(OpCodes.Brtrue, typeOk);
-        il.Emit(OpCodes.Ldnull);
-        il.Emit(OpCodes.Ret);
+        EmitThrowVmNotStandalone(il);
         il.MarkLabel(typeOk);
 
         // MethodInfo getExports = moduleType.GetMethod("GetExports");

--- a/Execution/Interpreter.Expressions.cs
+++ b/Execution/Interpreter.Expressions.cs
@@ -1363,6 +1363,11 @@ public partial class Interpreter
         string specifier = pathValue?.ToString()
             ?? throw new InterpreterException("Dynamic import path cannot be null.");
 
+        // vm importModuleDynamically hook: resolve through the user-provided loader
+        // instead of the file-system module resolver (vm #1156).
+        if (_vmDynamicImportHook != null)
+            return _vmDynamicImportHook(specifier);
+
         // Create resolver if needed (single-file mode without module context)
         _moduleResolver ??= new ModuleResolver(
             _currentModule?.Path ?? Directory.GetCurrentDirectory());

--- a/Execution/Interpreter.cs
+++ b/Execution/Interpreter.cs
@@ -538,6 +538,20 @@ public partial class Interpreter : IDisposable
     /// </summary>
     public void SetVmTimeoutToken(CancellationToken token) => _vmTimeoutToken = token;
 
+    // vm codeGeneration.strings:false support — when true, eval()/new Function() throw
+    // an EvalError in this (sub-)interpreter, matching a vm context created with
+    // codeGeneration:{ strings:false }.
+    private bool _vmCodeGenerationStringsDisabled;
+
+    /// <summary>
+    /// Disables runtime code generation from strings (eval / new Function) in this
+    /// interpreter. Used by the vm module to honor codeGeneration:{ strings:false }.
+    /// </summary>
+    public void DisableCodeGenerationFromStrings() => _vmCodeGenerationStringsDisabled = true;
+
+    /// <summary>Whether eval/new Function are disabled (codeGeneration.strings:false).</summary>
+    public bool IsCodeGenerationFromStringsDisabled => _vmCodeGenerationStringsDisabled;
+
     // Worker-termination support — a worker sets this to its CancellationToken so a
     // synchronous runtime op that observes it (Atomics.wait) can unwind the worker thread
     // when worker.terminate() cancels it. Distinct from _vmTimeoutToken so the worker abort
@@ -1444,6 +1458,10 @@ public partial class Interpreter : IDisposable
     /// </remarks>
     public object? Eval(string source)
     {
+        if (_vmCodeGenerationStringsDisabled)
+            throw new ThrowException(new SharpTSError(
+                "EvalError: Code generation from strings disallowed for this context"));
+
         var lexer = new Lexer(source);
         List<Token> tokens = lexer.ScanTokens();
         var parser = new Parser(tokens);

--- a/Execution/Interpreter.cs
+++ b/Execution/Interpreter.cs
@@ -552,6 +552,17 @@ public partial class Interpreter : IDisposable
     /// <summary>Whether eval/new Function are disabled (codeGeneration.strings:false).</summary>
     public bool IsCodeGenerationFromStringsDisabled => _vmCodeGenerationStringsDisabled;
 
+    // vm importModuleDynamically support — when set, a dynamic import() inside vm-executed
+    // code is resolved through this hook (specifier → module namespace) instead of the
+    // normal module resolver. See vm #1156.
+    private Func<string, object?>? _vmDynamicImportHook;
+
+    /// <summary>
+    /// Routes dynamic import() in this interpreter through a user hook (the vm
+    /// importModuleDynamically option). The hook maps a specifier to a module namespace.
+    /// </summary>
+    public void SetVmDynamicImportHook(Func<string, object?>? hook) => _vmDynamicImportHook = hook;
+
     // Worker-termination support — a worker sets this to its CancellationToken so a
     // synchronous runtime op that observes it (Atomics.wait) can unwind the worker thread
     // when worker.terminate() cancels it. Distinct from _vmTimeoutToken so the worker abort

--- a/Runtime/BuiltIns/Modules/Interpreter/VmModuleInterpreter.cs
+++ b/Runtime/BuiltIns/Modules/Interpreter/VmModuleInterpreter.cs
@@ -27,7 +27,8 @@ public static class VmModuleInterpreter
             ["compileFunction"] = BuiltInMethod.CreateV2("compileFunction", 1, 3, CompileFunction),
             ["measureMemory"] = BuiltInMethod.CreateV2("measureMemory", 0, 1, MeasureMemory),
             ["constants"] = VmConstants.Create(),
-            ["Script"] = new VmScriptConstructor()
+            ["Script"] = new VmScriptConstructor(),
+            ["SourceTextModule"] = new VmSourceTextModuleConstructor()
         };
     }
 

--- a/Runtime/BuiltIns/Modules/Interpreter/VmModuleInterpreter.cs
+++ b/Runtime/BuiltIns/Modules/Interpreter/VmModuleInterpreter.cs
@@ -21,9 +21,11 @@ public static class VmModuleInterpreter
         {
             ["runInNewContext"] = BuiltInMethod.CreateV2("runInNewContext", 1, 3, RunInNewContext),
             ["runInThisContext"] = BuiltInMethod.CreateV2("runInThisContext", 1, 2, RunInThisContext),
-            ["createContext"] = BuiltInMethod.CreateV2("createContext", 0, 1, CreateContext),
+            ["runInContext"] = BuiltInMethod.CreateV2("runInContext", 2, 3, RunInContext),
+            ["createContext"] = BuiltInMethod.CreateV2("createContext", 0, 2, CreateContext),
             ["isContext"] = BuiltInMethod.CreateV2("isContext", 1, 1, IsContext),
             ["compileFunction"] = BuiltInMethod.CreateV2("compileFunction", 1, 3, CompileFunction),
+            ["constants"] = VmConstants.Create(),
             ["Script"] = new VmScriptConstructor()
         };
     }
@@ -52,6 +54,25 @@ public static class VmModuleInterpreter
 
         var timeout = GetTimeoutOption(args.Length > 1 ? args[1].ToObject() : null);
         return RuntimeValue.FromBoxed(ExecuteInCurrentContext(code, interpreter, timeout));
+    }
+
+    /// <summary>
+    /// vm.runInContext(code, contextifiedObject, options?) — executes code in an
+    /// already-contextified object (created via vm.createContext()). Throws a TypeError
+    /// if the second argument has not been contextified.
+    /// </summary>
+    private static RuntimeValue RunInContext(Interp interpreter, RuntimeValue receiver, ReadOnlySpan<RuntimeValue> args)
+    {
+        if (args.Length == 0 || args[0].ToObject() is not string code)
+            throw new Exception("vm.runInContext requires a code string");
+
+        var contextObject = args.Length > 1 ? args[1].ToObject() : null;
+        if (!VmContext.IsContext(contextObject))
+            throw new Exception("TypeError [ERR_INVALID_ARG_TYPE]: The \"contextifiedObject\" argument must be of type vm.Context.");
+
+        var options = args.Length > 2 ? args[2].ToObject() : null;
+        var timeout = GetTimeoutOption(options);
+        return RuntimeValue.FromBoxed(ExecuteInNewContext(code, contextObject, interpreter, timeout));
     }
 
     /// <summary>

--- a/Runtime/BuiltIns/Modules/Interpreter/VmModuleInterpreter.cs
+++ b/Runtime/BuiltIns/Modules/Interpreter/VmModuleInterpreter.cs
@@ -28,7 +28,8 @@ public static class VmModuleInterpreter
             ["measureMemory"] = BuiltInMethod.CreateV2("measureMemory", 0, 1, MeasureMemory),
             ["constants"] = VmConstants.Create(),
             ["Script"] = new VmScriptConstructor(),
-            ["SourceTextModule"] = new VmSourceTextModuleConstructor()
+            ["SourceTextModule"] = new VmSourceTextModuleConstructor(),
+            ["SyntheticModule"] = new VmSyntheticModuleConstructor()
         };
     }
 

--- a/Runtime/BuiltIns/Modules/Interpreter/VmModuleInterpreter.cs
+++ b/Runtime/BuiltIns/Modules/Interpreter/VmModuleInterpreter.cs
@@ -40,8 +40,11 @@ public static class VmModuleInterpreter
             throw new Exception("vm.runInNewContext requires a code string");
 
         var contextObject = args.Length > 1 ? args[1].ToObject() : null;
-        var timeout = GetTimeoutOption(args.Length > 2 ? args[2].ToObject() : null);
-        return RuntimeValue.FromBoxed(ExecuteInNewContext(code, contextObject, interpreter, timeout));
+        var options = args.Length > 2 ? args[2].ToObject() : null;
+        var timeout = GetTimeoutOption(options);
+        var origin = ScriptOrigin.From(options);
+        return RuntimeValue.FromBoxed(WithScriptOrigin(origin,
+            () => ExecuteInNewContext(code, contextObject, interpreter, timeout, origin.Filename)));
     }
 
     /// <summary>
@@ -52,8 +55,11 @@ public static class VmModuleInterpreter
         if (args.Length == 0 || args[0].ToObject() is not string code)
             throw new Exception("vm.runInThisContext requires a code string");
 
-        var timeout = GetTimeoutOption(args.Length > 1 ? args[1].ToObject() : null);
-        return RuntimeValue.FromBoxed(ExecuteInCurrentContext(code, interpreter, timeout));
+        var options = args.Length > 1 ? args[1].ToObject() : null;
+        var timeout = GetTimeoutOption(options);
+        var origin = ScriptOrigin.From(options);
+        return RuntimeValue.FromBoxed(WithScriptOrigin(origin,
+            () => ExecuteInCurrentContext(code, interpreter, timeout, origin.Filename)));
     }
 
     /// <summary>
@@ -72,7 +78,9 @@ public static class VmModuleInterpreter
 
         var options = args.Length > 2 ? args[2].ToObject() : null;
         var timeout = GetTimeoutOption(options);
-        return RuntimeValue.FromBoxed(ExecuteInNewContext(code, contextObject, interpreter, timeout));
+        var origin = ScriptOrigin.From(options);
+        return RuntimeValue.FromBoxed(WithScriptOrigin(origin,
+            () => ExecuteInNewContext(code, contextObject, interpreter, timeout, origin.Filename)));
     }
 
     /// <summary>
@@ -97,10 +105,10 @@ public static class VmModuleInterpreter
     /// Executes code in a fresh interpreter with context object properties seeded as variables.
     /// Mutations to context variables are written back to the context object.
     /// </summary>
-    internal static object? ExecuteInNewContext(string code, object? contextObject, Interp? parentInterpreter = null, int timeout = -1)
+    internal static object? ExecuteInNewContext(string code, object? contextObject, Interp? parentInterpreter = null, int timeout = -1, string? filename = null)
     {
         // Parse the code
-        var statements = ParseCode(code);
+        var statements = ParseCode(code, filename);
 
         // Extract context properties
         var contextProps = VmContext.ExtractProperties(contextObject);
@@ -145,9 +153,9 @@ public static class VmModuleInterpreter
     /// <summary>
     /// Executes code in the current interpreter's scope.
     /// </summary>
-    internal static object? ExecuteInCurrentContext(string code, Interp interpreter, int timeout = -1)
+    internal static object? ExecuteInCurrentContext(string code, Interp interpreter, int timeout = -1, string? filename = null)
     {
-        var statements = ParseCode(code);
+        var statements = ParseCode(code, filename);
 
         var resolver = new VariableResolver(interpreter);
         resolver.Resolve(statements);
@@ -284,10 +292,12 @@ public static class VmModuleInterpreter
         // Extract options
         object? parsingContext = null;
         List<object?>? contextExtensions = null;
+        var rawOptions = args.Length > 2 && !args[2].IsNull ? args[2].ToObject() : null;
+        var origin = ScriptOrigin.From(rawOptions);
 
-        if (args.Length > 2 && !args[2].IsNull)
+        if (rawOptions != null)
         {
-            var options = VmContext.ExtractProperties(args[2].ToObject());
+            var options = VmContext.ExtractProperties(rawOptions);
             if (options.TryGetValue("parsingContext", out var ctx))
             {
                 if (ctx != null && !VmContext.IsContext(ctx))
@@ -301,6 +311,9 @@ public static class VmModuleInterpreter
                 else if (ext is SharpTSArray extArray)
                     contextExtensions = extArray.ToList();
             }
+            // produceCachedData is accepted but cachedData is a documented .NET ceiling
+            // (#1150); compileFunction returns a bare callable that can't carry a
+            // cachedData property, so the marker is not surfaced here.
         }
 
         // Wrap code as function body and parse
@@ -310,7 +323,7 @@ public static class VmModuleInterpreter
             trimmedCode += ";";
         var paramsStr = string.Join(", ", paramNames);
         var wrappedCode = $"function __vmfn__({paramsStr}) {{ {trimmedCode} }}";
-        var funcDeclStatements = ParseCode(wrappedCode);
+        var funcDeclStatements = ParseCode(wrappedCode, origin.Filename);
 
         // Return a callable that executes the function body in a fresh interpreter
         var compiledFn = BuiltInMethod.CreateV2("compiledFunction", 0, paramNames.Count,
@@ -319,7 +332,8 @@ public static class VmModuleInterpreter
                 var boxedCallArgs = new List<object?>(callArgs.Length);
                 for (int i = 0; i < callArgs.Length; i++)
                     boxedCallArgs.Add(callArgs[i].ToObject());
-                return RuntimeValue.FromBoxed(ExecuteCompiledFunction(funcDeclStatements, paramNames, boxedCallArgs, parsingContext, contextExtensions, interp));
+                return RuntimeValue.FromBoxed(WithScriptOrigin(origin,
+                    () => ExecuteCompiledFunction(funcDeclStatements, paramNames, boxedCallArgs, parsingContext, contextExtensions, interp)));
             });
 
         return RuntimeValue.FromObject(compiledFn);
@@ -391,23 +405,106 @@ public static class VmModuleInterpreter
     }
 
     /// <summary>
+    /// Reads a single option by name from an options object (SharpTSObject, Dictionary,
+    /// or an emitted $Object via reflection). Returns null if absent.
+    /// </summary>
+    internal static object? GetOption(object? options, string key)
+    {
+        switch (options)
+        {
+            case null:
+                return null;
+            case SharpTSObject obj:
+                return obj.GetProperty(key);
+            case Dictionary<string, object?> dict:
+                return dict.TryGetValue(key, out var val) ? val : null;
+            default:
+                // Emitted $Object / other shapes — reflect on a "Fields" dictionary.
+                var fieldsProp = options.GetType().GetProperty("Fields");
+                if (fieldsProp?.GetValue(options) is IEnumerable<KeyValuePair<string, object?>> fields)
+                {
+                    foreach (var kv in fields)
+                        if (kv.Key == key)
+                            return kv.Value;
+                }
+                return null;
+        }
+    }
+
+    /// <summary>Reads a string option, returning <paramref name="fallback"/> if absent/non-string.</summary>
+    internal static string? GetStringOption(object? options, string key, string? fallback = null)
+        => GetOption(options, key) is string s ? s : fallback;
+
+    /// <summary>Reads an integer option (stored as double), returning <paramref name="fallback"/> if absent.</summary>
+    internal static int GetIntOption(object? options, string key, int fallback = 0)
+        => GetOption(options, key) is double d ? (int)d : fallback;
+
+    /// <summary>Reads a boolean option, returning <paramref name="fallback"/> if absent.</summary>
+    internal static bool GetBoolOption(object? options, string key, bool fallback = false)
+        => GetOption(options, key) is bool b ? b : fallback;
+
+    /// <summary>
     /// Extracts the timeout option (in milliseconds) from an options object.
     /// Returns -1 if not specified.
     /// </summary>
     internal static int GetTimeoutOption(object? options)
     {
-        if (options is SharpTSObject obj)
-        {
-            var val = obj.GetProperty("timeout");
-            if (val is double d && d > 0)
-                return (int)d;
-        }
-        else if (options is Dictionary<string, object?> dict)
-        {
-            if (dict.TryGetValue("timeout", out var val) && val is double d && d > 0)
-                return (int)d;
-        }
+        var val = GetOption(options, "timeout");
+        if (val is double d && d > 0)
+            return (int)d;
         return -1;
+    }
+
+    /// <summary>
+    /// Captures the script-origin options (filename / line / column offsets) that flow
+    /// into thrown error stacks. Mirrors Node's defaults.
+    /// </summary>
+    internal readonly record struct ScriptOrigin(string Filename, int LineOffset, int ColumnOffset)
+    {
+        public static ScriptOrigin From(object? options) => new(
+            GetStringOption(options, "filename", "evalmachine.<anonymous>")!,
+            GetIntOption(options, "lineOffset", 0),
+            GetIntOption(options, "columnOffset", 0));
+
+        public static readonly ScriptOrigin Default = new("evalmachine.<anonymous>", 0, 0);
+    }
+
+    /// <summary>
+    /// Runs <paramref name="run"/> and, if a guest error escapes, prepends the script
+    /// origin (filename:line:col) to its stack — matching Node, where vm errors are
+    /// reported against the supplied filename/offsets rather than the host caller.
+    /// </summary>
+    internal static object? WithScriptOrigin(ScriptOrigin origin, Func<object?> run)
+    {
+        try
+        {
+            return run();
+        }
+        catch (Runtime.Exceptions.ThrowException te) when (te.Value is SharpTSError err)
+        {
+            // A guest error object propagated directly (e.g. the timeout error).
+            // Rewrite its stack so the top frame points at the script origin
+            // (filename:line:col), matching how Node reports vm errors. We touch only
+            // .Stack (never .name/.message) and keep the same exception type/flow, so
+            // interpreter and compiled callers stay in agreement.
+            //
+            // LIMITATION: a user `throw` or runtime fault is stringified by the
+            // sub-interpreter's REPL boundary into a host Exception and reconstructed
+            // by the outer interpreter (interp) / $Runtime.WrapException (compiled),
+            // which mint a fresh stack — so the origin frame is not attached for those.
+            // The supplied filename DOES flow into SyntaxError messages at parse time
+            // (see ParseCode), which is the common, cross-mode-faithful case.
+            PrependOriginFrame(err, origin);
+            throw;
+        }
+    }
+
+    private static void PrependOriginFrame(SharpTSError err, ScriptOrigin origin)
+    {
+        if (err.Stack != null && err.Stack.Contains(origin.Filename)) return;
+        var frame = $"    at {origin.Filename}:{origin.LineOffset + 1}:{origin.ColumnOffset + 1}";
+        var header = $"{err.Name}: {err.Message}";
+        err.Stack = header + "\n" + frame;
     }
 
     /// <summary>
@@ -428,7 +525,7 @@ public static class VmModuleInterpreter
     /// Parses a code string into statements. Throws on parse errors.
     /// Follows the REPL pattern: retries with appended ";" on parse failure.
     /// </summary>
-    internal static List<Stmt> ParseCode(string code)
+    internal static List<Stmt> ParseCode(string code, string? filename = null)
     {
         var result = TryParse(code);
 
@@ -441,7 +538,9 @@ public static class VmModuleInterpreter
             if (retryErrors.Count == 0)
                 return retryResult.Statements;
 
-            throw new Exception($"SyntaxError: {errors[0].Message}");
+            // Node reports vm syntax errors against the supplied filename.
+            var prefix = filename != null ? $"{filename}: " : "";
+            throw new Exception($"SyntaxError: {prefix}{errors[0].Message}");
         }
 
         return result.Statements;
@@ -468,8 +567,13 @@ public sealed class VmScriptConstructor : ISharpTSCallable
         if (args.Count == 0 || args[0] is not string code)
             throw new Exception("vm.Script requires a code string");
 
-        // Pre-parse the code (with semicolon retry)
-        var statements = VmModuleInterpreter.ParseCode(code);
+        var options = args.Count > 1 ? args[1] : null;
+        var origin = VmModuleInterpreter.ScriptOrigin.From(options);
+        var produceCachedData = VmModuleInterpreter.GetBoolOption(options, "produceCachedData");
+        var hasCachedDataInput = VmModuleInterpreter.GetOption(options, "cachedData") != null;
+
+        // Pre-parse the code (with semicolon retry); syntax errors carry the filename.
+        var statements = VmModuleInterpreter.ParseCode(code, origin.Filename);
 
         // Create Script as a dictionary — works in both interpreter (via SharpTSObject wrapper)
         // and compiled mode (dictionary is native object representation).
@@ -479,35 +583,64 @@ public sealed class VmScriptConstructor : ISharpTSCallable
             {
                 var contextObject = methodArgs.Length > 0 ? methodArgs[0].ToObject() : null;
                 var timeout = VmModuleInterpreter.GetTimeoutOption(methodArgs.Length > 1 ? methodArgs[1].ToObject() : null);
-                return RuntimeValue.FromBoxed(VmModuleInterpreter.ExecuteParsedInNewContext(statements, contextObject, interp, timeout));
+                return RuntimeValue.FromBoxed(VmModuleInterpreter.WithScriptOrigin(origin,
+                    () => VmModuleInterpreter.ExecuteParsedInNewContext(statements, contextObject, interp, timeout)));
             });
 
         var runInThisCtx = BuiltInMethod.CreateV2("runInThisContext", 0, 1,
             (interp, recv, methodArgs) =>
             {
                 var timeout = VmModuleInterpreter.GetTimeoutOption(methodArgs.Length > 0 ? methodArgs[0].ToObject() : null);
-                if (interp != null)
-                    return RuntimeValue.FromBoxed(VmModuleInterpreter.ExecuteParsedInCurrentContext(statements, interp, timeout));
-                // Compiled mode: no interpreter available, fall back to new context
-                return RuntimeValue.FromBoxed(VmModuleInterpreter.ExecuteParsedInNewContext(statements, null, interp, timeout));
+                return RuntimeValue.FromBoxed(VmModuleInterpreter.WithScriptOrigin(origin, () =>
+                {
+                    if (interp != null)
+                        return VmModuleInterpreter.ExecuteParsedInCurrentContext(statements, interp, timeout);
+                    // Compiled mode: no interpreter available, fall back to new context
+                    return VmModuleInterpreter.ExecuteParsedInNewContext(statements, null, interp, timeout);
+                }));
             });
 
         var runInCtx = BuiltInMethod.CreateV2("runInContext", 1, 2,
             (interp, recv, methodArgs) =>
             {
                 var context = methodArgs.Length > 0 ? methodArgs[0].ToObject() : null;
+                if (!VmContext.IsContext(context))
+                    throw new Exception("TypeError [ERR_INVALID_ARG_TYPE]: The \"contextifiedObject\" argument must be of type vm.Context.");
                 var timeout = VmModuleInterpreter.GetTimeoutOption(methodArgs.Length > 1 ? methodArgs[1].ToObject() : null);
-                return RuntimeValue.FromBoxed(VmModuleInterpreter.ExecuteParsedInNewContext(statements, context, interp, timeout));
+                return RuntimeValue.FromBoxed(VmModuleInterpreter.WithScriptOrigin(origin,
+                    () => VmModuleInterpreter.ExecuteParsedInNewContext(statements, context, interp, timeout)));
             });
+
+        // vm bytecode caching has no .NET equivalent (#1150 ceiling): createCachedData()
+        // returns a deterministic marker Buffer derived from the source. It round-trips
+        // (a passed-in cachedData is never rejected) but yields no real speedup.
+        var createCachedData = BuiltInMethod.CreateV2("createCachedData", 0, 0,
+            (interp, recv, methodArgs) =>
+                RuntimeValue.FromObject(SharpTSBuffer.FromString(code, "utf8")));
 
         // Return as Dictionary<string, object?> — works in both modes:
         // Interpreter: EvaluateGetOnFallback handles IDictionary<string, object?>
         // Compiled: GetFieldsProperty handles Dictionary<string, object?>
-        return new Dictionary<string, object?>
+        var script = new Dictionary<string, object?>
         {
             ["runInNewContext"] = runInNewCtx,
             ["runInThisContext"] = runInThisCtx,
             ["runInContext"] = runInCtx,
+            ["createCachedData"] = createCachedData,
+            ["sourceMapURL"] = null,
         };
+
+        // produceCachedData: emit the marker Buffer up front and flag it produced.
+        if (produceCachedData)
+        {
+            script["cachedData"] = SharpTSBuffer.FromString(code, "utf8");
+            script["cachedDataProduced"] = true;
+        }
+
+        // cachedData input is accepted but never rejected (no real bytecode validation).
+        if (hasCachedDataInput)
+            script["cachedDataRejected"] = false;
+
+        return script;
     }
 }

--- a/Runtime/BuiltIns/Modules/Interpreter/VmModuleInterpreter.cs
+++ b/Runtime/BuiltIns/Modules/Interpreter/VmModuleInterpreter.cs
@@ -46,8 +46,9 @@ public static class VmModuleInterpreter
         var options = args.Length > 2 ? args[2].ToObject() : null;
         var timeout = GetTimeoutOption(options);
         var origin = ScriptOrigin.From(options);
+        var hook = BuildDynamicImportHook(GetOption(options, "importModuleDynamically"), null, interpreter);
         return RuntimeValue.FromBoxed(WithScriptOrigin(origin,
-            () => ExecuteInNewContext(code, contextObject, interpreter, timeout, origin.Filename)));
+            () => ExecuteInNewContext(code, contextObject, interpreter, timeout, origin.Filename, hook)));
     }
 
     /// <summary>
@@ -82,8 +83,9 @@ public static class VmModuleInterpreter
         var options = args.Length > 2 ? args[2].ToObject() : null;
         var timeout = GetTimeoutOption(options);
         var origin = ScriptOrigin.From(options);
+        var hook = BuildDynamicImportHook(GetOption(options, "importModuleDynamically"), null, interpreter);
         return RuntimeValue.FromBoxed(WithScriptOrigin(origin,
-            () => ExecuteInNewContext(code, contextObject, interpreter, timeout, origin.Filename)));
+            () => ExecuteInNewContext(code, contextObject, interpreter, timeout, origin.Filename, hook)));
     }
 
     /// <summary>
@@ -187,7 +189,7 @@ public static class VmModuleInterpreter
     /// Executes code in a fresh interpreter with context object properties seeded as variables.
     /// Mutations to context variables are written back to the context object.
     /// </summary>
-    internal static object? ExecuteInNewContext(string code, object? contextObject, Interp? parentInterpreter = null, int timeout = -1, string? filename = null)
+    internal static object? ExecuteInNewContext(string code, object? contextObject, Interp? parentInterpreter = null, int timeout = -1, string? filename = null, Func<string, object?>? dynamicImportHook = null)
     {
         // Parse the code
         var statements = ParseCode(code, filename);
@@ -207,6 +209,8 @@ public static class VmModuleInterpreter
         // Honor the context's createContext options (codeGeneration / microtaskMode).
         var contextOptions = VmContext.GetOptions(contextObject);
         ApplyContextOptions(subInterpreter, contextOptions);
+        if (dynamicImportHook != null)
+            subInterpreter.SetVmDynamicImportHook(dynamicImportHook);
 
         // Apply timeout if specified
         CancellationTokenSource? cts = null;
@@ -274,7 +278,7 @@ public static class VmModuleInterpreter
     /// Executes pre-parsed statements in a new context.
     /// Used by Script.runInNewContext and Script.runInContext.
     /// </summary>
-    internal static object? ExecuteParsedInNewContext(List<Stmt> statements, object? contextObject, Interp? parentInterpreter = null, int timeout = -1)
+    internal static object? ExecuteParsedInNewContext(List<Stmt> statements, object? contextObject, Interp? parentInterpreter = null, int timeout = -1, Func<string, object?>? dynamicImportHook = null)
     {
         var contextProps = VmContext.ExtractProperties(contextObject);
 
@@ -288,6 +292,8 @@ public static class VmModuleInterpreter
 
         var contextOptions = VmContext.GetOptions(contextObject);
         ApplyContextOptions(subInterpreter, contextOptions);
+        if (dynamicImportHook != null)
+            subInterpreter.SetVmDynamicImportHook(dynamicImportHook);
 
         CancellationTokenSource? cts = null;
         if (timeout > 0)
@@ -419,6 +425,8 @@ public static class VmModuleInterpreter
         var wrappedCode = $"function __vmfn__({paramsStr}) {{ {trimmedCode} }}";
         var funcDeclStatements = ParseCode(wrappedCode, origin.Filename);
 
+        var importModuleDynamically = GetOption(rawOptions, "importModuleDynamically");
+
         // Return a callable that executes the function body in a fresh interpreter
         var compiledFn = BuiltInMethod.CreateV2("compiledFunction", 0, paramNames.Count,
             (interp, recv, callArgs) =>
@@ -426,8 +434,9 @@ public static class VmModuleInterpreter
                 var boxedCallArgs = new List<object?>(callArgs.Length);
                 for (int i = 0; i < callArgs.Length; i++)
                     boxedCallArgs.Add(callArgs[i].ToObject());
+                var hook = BuildDynamicImportHook(importModuleDynamically, null, interp);
                 return RuntimeValue.FromBoxed(WithScriptOrigin(origin,
-                    () => ExecuteCompiledFunction(funcDeclStatements, paramNames, boxedCallArgs, parsingContext, contextExtensions, interp)));
+                    () => ExecuteCompiledFunction(funcDeclStatements, paramNames, boxedCallArgs, parsingContext, contextExtensions, interp, hook)));
             });
 
         return RuntimeValue.FromObject(compiledFn);
@@ -443,12 +452,15 @@ public static class VmModuleInterpreter
         List<object?> callArgs,
         object? parsingContext,
         List<object?>? contextExtensions,
-        Interp? parentInterpreter = null)
+        Interp? parentInterpreter = null,
+        Func<string, object?>? dynamicImportHook = null)
     {
         var subInterpreter = parentInterpreter != null
             ? new Interp(parentInterpreter.Out, parentInterpreter.Error)
             : new Interp();
         var env = subInterpreter.Environment;
+        if (dynamicImportHook != null)
+            subInterpreter.SetVmDynamicImportHook(dynamicImportHook);
 
         // Seed parsingContext variables
         if (parsingContext != null)
@@ -547,6 +559,44 @@ public static class VmModuleInterpreter
         if (val is double d && d > 0)
             return (int)d;
         return -1;
+    }
+
+    /// <summary>
+    /// Builds the dynamic-import resolver for a vm importModuleDynamically option, to be
+    /// installed on the sub-interpreter so an <c>import(x)</c> inside vm code routes through
+    /// the user hook. Returns null when no hook is supplied or the
+    /// USE_MAIN_CONTEXT_DEFAULT_LOADER sentinel is used (fall back to the default loader).
+    /// The hook may return a module namespace object or a vm.Module (which is linked+
+    /// evaluated and exposed via its namespace).
+    /// </summary>
+    internal static Func<string, object?>? BuildDynamicImportHook(object? importModuleDynamically, object? scriptOrModule, Interp? interp)
+    {
+        if (importModuleDynamically == null)
+            return null;
+        if (ReferenceEquals(importModuleDynamically, VmConstants.UseMainContextDefaultLoader))
+            return null;
+
+        return specifier =>
+        {
+            var attributes = new Dictionary<string, object?>();
+            var result = RuntimeCallableDispatcher.Invoke(interp, importModuleDynamically, specifier, scriptOrModule, attributes);
+
+            if (result is SharpTSPromise p && p.Task.IsCompletedSuccessfully)
+                result = p.Task.Result;
+
+            // If the hook returned a vm.Module, link (deps-free) + evaluate it and expose
+            // its namespace; otherwise the hook returned a namespace object directly.
+            var module = VmModuleRegistry.Get(result);
+            if (module != null)
+            {
+                if (module.Status == "unlinked")
+                    module.Link(interp, linker: null);
+                if (module.Status != "evaluated")
+                    module.Evaluate(interp);
+                return new Dictionary<string, object?>(module.Exports);
+            }
+            return result;
+        };
     }
 
     /// <summary>
@@ -665,6 +715,7 @@ public sealed class VmScriptConstructor : ISharpTSCallable
         var origin = VmModuleInterpreter.ScriptOrigin.From(options);
         var produceCachedData = VmModuleInterpreter.GetBoolOption(options, "produceCachedData");
         var hasCachedDataInput = VmModuleInterpreter.GetOption(options, "cachedData") != null;
+        var importModuleDynamically = VmModuleInterpreter.GetOption(options, "importModuleDynamically");
 
         // Pre-parse the code (with semicolon retry); syntax errors carry the filename.
         var statements = VmModuleInterpreter.ParseCode(code, origin.Filename);
@@ -677,20 +728,26 @@ public sealed class VmScriptConstructor : ISharpTSCallable
             {
                 var contextObject = methodArgs.Length > 0 ? methodArgs[0].ToObject() : null;
                 var timeout = VmModuleInterpreter.GetTimeoutOption(methodArgs.Length > 1 ? methodArgs[1].ToObject() : null);
+                var hook = VmModuleInterpreter.BuildDynamicImportHook(importModuleDynamically, null, interp);
                 return RuntimeValue.FromBoxed(VmModuleInterpreter.WithScriptOrigin(origin,
-                    () => VmModuleInterpreter.ExecuteParsedInNewContext(statements, contextObject, interp, timeout)));
+                    () => VmModuleInterpreter.ExecuteParsedInNewContext(statements, contextObject, interp, timeout, hook)));
             });
 
         var runInThisCtx = BuiltInMethod.CreateV2("runInThisContext", 0, 1,
             (interp, recv, methodArgs) =>
             {
                 var timeout = VmModuleInterpreter.GetTimeoutOption(methodArgs.Length > 0 ? methodArgs[0].ToObject() : null);
+                var hook = VmModuleInterpreter.BuildDynamicImportHook(importModuleDynamically, null, interp);
                 return RuntimeValue.FromBoxed(VmModuleInterpreter.WithScriptOrigin(origin, () =>
                 {
                     if (interp != null)
-                        return VmModuleInterpreter.ExecuteParsedInCurrentContext(statements, interp, timeout);
+                    {
+                        if (hook != null) interp.SetVmDynamicImportHook(hook);
+                        try { return VmModuleInterpreter.ExecuteParsedInCurrentContext(statements, interp, timeout); }
+                        finally { if (hook != null) interp.SetVmDynamicImportHook(null); }
+                    }
                     // Compiled mode: no interpreter available, fall back to new context
-                    return VmModuleInterpreter.ExecuteParsedInNewContext(statements, null, interp, timeout);
+                    return VmModuleInterpreter.ExecuteParsedInNewContext(statements, null, interp, timeout, hook);
                 }));
             });
 
@@ -701,8 +758,9 @@ public sealed class VmScriptConstructor : ISharpTSCallable
                 if (!VmContext.IsContext(context))
                     throw new Exception("TypeError [ERR_INVALID_ARG_TYPE]: The \"contextifiedObject\" argument must be of type vm.Context.");
                 var timeout = VmModuleInterpreter.GetTimeoutOption(methodArgs.Length > 1 ? methodArgs[1].ToObject() : null);
+                var hook = VmModuleInterpreter.BuildDynamicImportHook(importModuleDynamically, null, interp);
                 return RuntimeValue.FromBoxed(VmModuleInterpreter.WithScriptOrigin(origin,
-                    () => VmModuleInterpreter.ExecuteParsedInNewContext(statements, context, interp, timeout)));
+                    () => VmModuleInterpreter.ExecuteParsedInNewContext(statements, context, interp, timeout, hook)));
             });
 
         // vm bytecode caching has no .NET equivalent (#1150 ceiling): createCachedData()

--- a/Runtime/BuiltIns/Modules/Interpreter/VmModuleInterpreter.cs
+++ b/Runtime/BuiltIns/Modules/Interpreter/VmModuleInterpreter.cs
@@ -25,6 +25,7 @@ public static class VmModuleInterpreter
             ["createContext"] = BuiltInMethod.CreateV2("createContext", 0, 2, CreateContext),
             ["isContext"] = BuiltInMethod.CreateV2("isContext", 1, 1, IsContext),
             ["compileFunction"] = BuiltInMethod.CreateV2("compileFunction", 1, 3, CompileFunction),
+            ["measureMemory"] = BuiltInMethod.CreateV2("measureMemory", 0, 1, MeasureMemory),
             ["constants"] = VmConstants.Create(),
             ["Script"] = new VmScriptConstructor()
         };
@@ -84,12 +85,91 @@ public static class VmModuleInterpreter
     }
 
     /// <summary>
-    /// vm.createContext(contextObject?) — tags an object as a vm context.
+    /// vm.createContext(contextObject?, options?) — tags an object as a vm context.
+    /// Options (name / origin / codeGeneration / microtaskMode) are stored on the
+    /// context and honored when code runs against it.
     /// </summary>
     private static RuntimeValue CreateContext(Interp interpreter, RuntimeValue receiver, ReadOnlySpan<RuntimeValue> args)
     {
         var contextObject = args.Length > 0 ? args[0].ToObject() : null;
-        return RuntimeValue.FromObject(VmContext.Create(contextObject));
+        var options = args.Length > 1 ? ParseContextOptions(args[1].ToObject()) : null;
+        return RuntimeValue.FromObject(VmContext.Create(contextObject, options));
+    }
+
+    /// <summary>
+    /// Parses a createContext()/runInNewContext() options object into VmContextOptions.
+    /// Reads name, origin, codeGeneration:{ strings, wasm }, and microtaskMode.
+    /// </summary>
+    internal static VmContextOptions? ParseContextOptions(object? options)
+    {
+        if (options == null) return null;
+
+        var name = GetStringOption(options, "name");
+        var originUrl = GetStringOption(options, "origin");
+        var microtaskMode = GetStringOption(options, "microtaskMode");
+
+        var codeGenStrings = true;
+        var codeGenWasm = true;
+        if (GetOption(options, "codeGeneration") is { } codeGen)
+        {
+            codeGenStrings = GetBoolOption(codeGen, "strings", true);
+            codeGenWasm = GetBoolOption(codeGen, "wasm", true);
+        }
+
+        // Only allocate options when something non-default was supplied.
+        if (name == null && originUrl == null && microtaskMode == null && codeGenStrings && codeGenWasm)
+            return null;
+
+        return new VmContextOptions(name, originUrl, codeGenStrings, codeGenWasm, microtaskMode);
+    }
+
+    /// <summary>
+    /// Applies a context's createContext options to a freshly-created sub-interpreter:
+    /// disables eval/new Function when codeGeneration.strings is false.
+    /// (microtaskMode draining happens after evaluation — see <see cref="DrainContextMicrotasks"/>.)
+    /// </summary>
+    private static void ApplyContextOptions(Interp subInterpreter, VmContextOptions? options)
+    {
+        if (options is { CodeGenerationStrings: false })
+            subInterpreter.DisableCodeGenerationFromStrings();
+    }
+
+    /// <summary>Drains the sub-interpreter's microtask queue when microtaskMode is 'afterEvaluate'.</summary>
+    private static void DrainContextMicrotasks(Interp subInterpreter, VmContextOptions? options)
+    {
+        if (options is { DrainMicrotasks: true })
+            subInterpreter.ProcessMicrotasks();
+    }
+
+    /// <summary>
+    /// vm.measureMemory([options]) — returns a Promise resolving to a best-effort,
+    /// GC-derived memory measurement. V8's per-context detailed breakdown has no .NET
+    /// equivalent (#1150 ceiling), so the estimate/range come from GC.GetTotalMemory and
+    /// the per-context split is omitted.
+    /// </summary>
+    private static RuntimeValue MeasureMemory(Interp interpreter, RuntimeValue receiver, ReadOnlySpan<RuntimeValue> args)
+    {
+        return RuntimeValue.FromObject(SharpTSPromise.Resolve(MeasureMemoryResultObject()));
+    }
+
+    /// <summary>
+    /// Builds the (best-effort, GC-derived) measureMemory result payload as plain
+    /// dictionaries so it is readable in both modes (compiled GetFieldsProperty
+    /// dispatches dictionaries; a SharpTSObject's fields are not visible across the
+    /// runtime boundary). The compiled VmMeasureMemory helper calls this directly and
+    /// wraps the result in a native $Promise (a cross-boundary SharpTSPromise is not
+    /// unwrapped by compiled await).
+    /// </summary>
+    public static object MeasureMemoryResultObject()
+    {
+        var bytes = (double)GC.GetTotalMemory(forceFullCollection: false);
+        var range = new SharpTSArray(new List<object?> { bytes, bytes });
+        var total = new Dictionary<string, object?>
+        {
+            ["jsMemoryEstimate"] = bytes,
+            ["jsMemoryRange"] = range,
+        };
+        return new Dictionary<string, object?> { ["total"] = total };
     }
 
     /// <summary>
@@ -122,6 +202,10 @@ public static class VmModuleInterpreter
         foreach (var (key, value) in contextProps)
             env.Define(key, value);
 
+        // Honor the context's createContext options (codeGeneration / microtaskMode).
+        var contextOptions = VmContext.GetOptions(contextObject);
+        ApplyContextOptions(subInterpreter, contextOptions);
+
         // Apply timeout if specified
         CancellationTokenSource? cts = null;
         if (timeout > 0)
@@ -137,6 +221,9 @@ public static class VmModuleInterpreter
             resolver.Resolve(statements);
 
             var result = subInterpreter.InterpretRepl(statements);
+
+            // Drain queued microtasks when microtaskMode:'afterEvaluate'.
+            DrainContextMicrotasks(subInterpreter, contextOptions);
 
             // Write mutations back to context object
             VmContext.WriteBack(contextObject, contextProps, subInterpreter.Environment);
@@ -197,6 +284,9 @@ public static class VmModuleInterpreter
         foreach (var (key, value) in contextProps)
             env.Define(key, value);
 
+        var contextOptions = VmContext.GetOptions(contextObject);
+        ApplyContextOptions(subInterpreter, contextOptions);
+
         CancellationTokenSource? cts = null;
         if (timeout > 0)
         {
@@ -210,6 +300,8 @@ public static class VmModuleInterpreter
             resolver.Resolve(statements);
 
             var result = subInterpreter.InterpretRepl(statements);
+
+            DrainContextMicrotasks(subInterpreter, contextOptions);
 
             VmContext.WriteBack(contextObject, contextProps, subInterpreter.Environment);
 

--- a/Runtime/Types/VmConstants.cs
+++ b/Runtime/Types/VmConstants.cs
@@ -1,0 +1,39 @@
+namespace SharpTS.Runtime.Types;
+
+/// <summary>
+/// Holds the process-wide sentinel values exported as <c>vm.constants</c>.
+/// These are opaque, identity-comparable Symbols (matching Node, where they are
+/// used as marker values):
+/// <list type="bullet">
+/// <item><c>USE_MAIN_CONTEXT_DEFAULT_LOADER</c> — passed as <c>importModuleDynamically</c>
+/// to ask the default ESM loader to resolve dynamic imports (see vm #1156).</item>
+/// <item><c>DONT_CONTEXTIFY</c> — passed as the context object to <c>vm.createContext()</c>
+/// to create a context without contextifying a sandbox (see vm #1153).</item>
+/// </list>
+/// Being static singletons, they round-trip identically through interpreter and
+/// compiled (reflection-delegated) execution.
+/// </summary>
+public static class VmConstants
+{
+    /// <summary>vm.constants.USE_MAIN_CONTEXT_DEFAULT_LOADER</summary>
+    public static readonly SharpTSSymbol UseMainContextDefaultLoader =
+        new("vm.constants.USE_MAIN_CONTEXT_DEFAULT_LOADER");
+
+    /// <summary>vm.constants.DONT_CONTEXTIFY</summary>
+    public static readonly SharpTSSymbol DontContextify =
+        new("vm.constants.DONT_CONTEXTIFY");
+
+    /// <summary>
+    /// Builds a fresh <c>vm.constants</c> object. Returned as a plain dictionary so
+    /// both the interpreter (IDictionary property access) and compiled mode
+    /// (GetFieldsProperty dictionary dispatch) can read its members.
+    /// </summary>
+    public static Dictionary<string, object?> Create()
+    {
+        return new Dictionary<string, object?>
+        {
+            ["USE_MAIN_CONTEXT_DEFAULT_LOADER"] = UseMainContextDefaultLoader,
+            ["DONT_CONTEXTIFY"] = DontContextify,
+        };
+    }
+}

--- a/Runtime/Types/VmContext.cs
+++ b/Runtime/Types/VmContext.cs
@@ -15,12 +15,16 @@ public static class VmContext
 
     /// <summary>
     /// Tags an object as a vm context. If contextObject is null, creates a new SharpTSObject.
-    /// Returns the contextified object.
+    /// Returns the contextified object. The optional createContext options
+    /// (name / origin / codeGeneration / microtaskMode) are stored on the marker and
+    /// honored when code runs against this context.
     /// </summary>
-    public static object Create(object? contextObject)
+    public static object Create(object? contextObject, VmContextOptions? options = null)
     {
         var obj = contextObject ?? new SharpTSObject(new Dictionary<string, object?>());
-        _contexts.GetOrCreateValue(obj);
+        var marker = _contexts.GetOrCreateValue(obj);
+        if (options != null)
+            marker.Options = options;
         return obj;
     }
 
@@ -31,6 +35,17 @@ public static class VmContext
     {
         if (obj == null) return false;
         return _contexts.TryGetValue(obj, out _);
+    }
+
+    /// <summary>
+    /// Returns the createContext options associated with a contextified object, or null
+    /// if the object is not a context or was created without options.
+    /// </summary>
+    public static VmContextOptions? GetOptions(object? obj)
+    {
+        if (obj != null && _contexts.TryGetValue(obj, out var marker))
+            return marker.Options;
+        return null;
     }
 
     /// <summary>
@@ -124,7 +139,32 @@ public static class VmContext
         }
     }
 
-    private sealed class VmContextMarker { }
+    private sealed class VmContextMarker
+    {
+        public VmContextOptions? Options { get; set; }
+    }
+}
+
+/// <summary>
+/// Parsed createContext() options that affect how code runs against the context.
+/// </summary>
+/// <param name="Name">Human-readable context name (createContext <c>name</c>).</param>
+/// <param name="Origin">Context origin URL (createContext <c>origin</c>).</param>
+/// <param name="CodeGenerationStrings">When false, <c>eval</c> / <c>new Function</c> in the
+/// context throw (codeGeneration.strings:false).</param>
+/// <param name="CodeGenerationWasm">When false, WebAssembly compilation in the context is
+/// disallowed (codeGeneration.wasm:false). SharpTS has no Wasm engine, so this is recorded
+/// but not separately enforced.</param>
+/// <param name="MicrotaskMode">When "afterEvaluate", the microtask queue is drained after
+/// each evaluation against the context.</param>
+public sealed record VmContextOptions(
+    string? Name = null,
+    string? Origin = null,
+    bool CodeGenerationStrings = true,
+    bool CodeGenerationWasm = true,
+    string? MicrotaskMode = null)
+{
+    public bool DrainMicrotasks => MicrotaskMode == "afterEvaluate";
 }
 
 /// <summary>

--- a/Runtime/Types/VmModule.cs
+++ b/Runtime/Types/VmModule.cs
@@ -1,0 +1,375 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using SharpTS.Execution;
+using SharpTS.Parsing;
+using SharpTS.Runtime.BuiltIns;
+using SharpTS.Runtime.BuiltIns.Modules.Interpreter;
+using Interp = SharpTS.Execution.Interpreter;
+
+namespace SharpTS.Runtime.Types;
+
+/// <summary>
+/// Maps a guest-visible vm.Module facade (a Dictionary) back to its <see cref="VmModuleBase"/>.
+/// Uses a ConditionalWeakTable so modules can be collected normally and so the linker can
+/// return facades that we resolve back to their backing module.
+/// </summary>
+public static class VmModuleRegistry
+{
+    private static readonly ConditionalWeakTable<object, VmModuleBase> _modules = new();
+
+    public static void Register(object facade, VmModuleBase module) => _modules.AddOrUpdate(facade, module);
+
+    public static bool IsModule(object? facade) => facade != null && _modules.TryGetValue(facade, out _);
+
+    public static VmModuleBase? Get(object? facade)
+        => facade != null && _modules.TryGetValue(facade, out var m) ? m : null;
+}
+
+/// <summary>
+/// Base class for the vm ESM-in-vm Module API (vm.Module). Implements the shared status
+/// state machine (unlinked → linking → linked → evaluating → evaluated/errored), the
+/// guest-visible facade dictionary, the namespace, and link/evaluate scaffolding.
+/// Subclasses (<see cref="VmSourceTextModule"/>, vm.SyntheticModule) supply how
+/// dependencies are discovered and how the module body is evaluated.
+/// </summary>
+public abstract class VmModuleBase
+{
+    private static int _nextId;
+
+    public string Identifier { get; protected init; } = "";
+    public object? ContextObject { get; protected init; }
+    public string Status { get; private set; } = "unlinked";
+    public object? Error { get; private set; }
+
+    /// <summary>Exported name → value. Serves as the (live-after-evaluation) namespace object.</summary>
+    protected readonly Dictionary<string, object?> Namespace = new();
+
+    /// <summary>Resolved dependency modules, keyed by specifier (populated by link()).</summary>
+    protected readonly Dictionary<string, VmModuleBase> Linked = new();
+
+    /// <summary>The guest-visible facade. Its status/error/namespace entries are kept in sync.</summary>
+    protected Dictionary<string, object?> Facade = null!;
+
+    /// <summary>The user-supplied importModuleDynamically hook, if any (wired in #1156).</summary>
+    public object? ImportModuleDynamically { get; protected init; }
+
+    protected static int NextId() => Interlocked.Increment(ref _nextId);
+
+    public abstract IReadOnlyList<string> DependencySpecifiers { get; }
+
+    protected void SetStatus(string status)
+    {
+        Status = status;
+        if (Facade != null) Facade["status"] = status;
+    }
+
+    protected void SetError(object? error)
+    {
+        Error = error;
+        if (Facade != null) Facade["error"] = error;
+    }
+
+    /// <summary>
+    /// Builds the guest-visible facade dictionary (status / namespace / identifier /
+    /// dependencySpecifiers / error / context + the link/evaluate/instantiate/createCachedData
+    /// methods). Works in both modes: the interpreter reads dictionaries via the IDictionary
+    /// fallback, compiled code via GetFieldsProperty.
+    /// </summary>
+    public Dictionary<string, object?> BuildFacade(string sourceForCache)
+    {
+        var depsArray = new SharpTSArray(DependencySpecifiers.Select(s => (object?)s).ToList());
+
+        Facade = new Dictionary<string, object?>
+        {
+            ["status"] = Status,
+            ["identifier"] = Identifier,
+            ["dependencySpecifiers"] = depsArray,
+            ["namespace"] = Namespace,
+            ["error"] = null,
+            ["context"] = ContextObject,
+            ["link"] = BuiltInMethod.CreateV2("link", 1, 1, (interp, recv, a) =>
+            {
+                var linker = a.Length > 0 ? a[0].ToObject() : null;
+                Link(interp, linker);
+                // Synchronous-completing; resolves to undefined (see class remarks).
+                return RuntimeValue.Undefined;
+            }),
+            ["evaluate"] = BuiltInMethod.CreateV2("evaluate", 0, 1, (interp, recv, a) =>
+            {
+                Evaluate(interp);
+                return RuntimeValue.Undefined;
+            }),
+            ["instantiate"] = BuiltInMethod.CreateV2("instantiate", 0, 0, (interp, recv, a) =>
+            {
+                // Legacy no-op: linking already prepared the graph.
+                return RuntimeValue.Undefined;
+            }),
+            ["createCachedData"] = BuiltInMethod.CreateV2("createCachedData", 0, 0, (interp, recv, a) =>
+                RuntimeValue.FromObject(SharpTSBuffer.FromString(sourceForCache, "utf8"))),
+        };
+
+        VmModuleRegistry.Register(Facade, this);
+        return Facade;
+    }
+
+    /// <summary>
+    /// link(linker): resolves every dependency specifier through the user linker and
+    /// recursively links the resulting modules. unlinked → linking → linked.
+    /// NOTE: completes synchronously (the linker is expected to return a Module, or a
+    /// settled promise of one); the facade method returns undefined so `await module.link(..)`
+    /// works identically in interpreter and compiled mode (a cross-boundary SharpTSPromise is
+    /// not unwrapped by compiled await).
+    /// </summary>
+    public void Link(Interp? interp, object? linker)
+    {
+        if (Status != "unlinked")
+            throw new Exception($"TypeError: module.link() called on a module with status '{Status}'");
+
+        SetStatus("linking");
+        try
+        {
+            foreach (var specifier in DependencySpecifiers)
+            {
+                var resolved = CallGuest(interp, linker, specifier, Facade);
+                resolved = UnwrapSettled(resolved);
+                var child = VmModuleRegistry.Get(resolved)
+                    ?? throw new Exception($"TypeError: linker for '{specifier}' did not return a vm.Module");
+                Linked[specifier] = child;
+                if (child.Status == "unlinked")
+                    child.Link(interp, linker);
+            }
+            SetStatus("linked");
+        }
+        catch (Runtime.Exceptions.ThrowException te)
+        {
+            SetError(te.Value);
+            SetStatus("errored");
+            throw;
+        }
+        catch (Exception ex)
+        {
+            // A compiled linker throws a host exception (often wrapped in
+            // TargetInvocationException by reflection). Reconstruct a guest Error and
+            // re-raise it as a ThrowException so guest try/catch sees it in both modes.
+            var err = ErrorBuiltIns.CreateError("Error", [Unwrap(ex).Message]);
+            SetError(err);
+            SetStatus("errored");
+            throw new Runtime.Exceptions.ThrowException(err);
+        }
+    }
+
+    private static Exception Unwrap(Exception ex)
+        => ex is TargetInvocationException { InnerException: { } inner } ? inner : ex;
+
+    /// <summary>
+    /// evaluate(): evaluates dependencies first, then this module's body.
+    /// linked → evaluating → evaluated, or → errored (and records error) on failure.
+    /// </summary>
+    public void Evaluate(Interp? interp)
+    {
+        if (Status == "evaluated") return;
+        if (Status == "errored")
+            throw new Runtime.Exceptions.ThrowException(Error);
+        if (Status != "linked" && Status != "evaluating")
+            throw new Exception($"TypeError: module.evaluate() called on a module with status '{Status}'");
+
+        SetStatus("evaluating");
+        try
+        {
+            foreach (var child in Linked.Values)
+                if (child.Status != "evaluated")
+                    child.Evaluate(interp);
+
+            EvaluateBody(interp);
+            SetStatus("evaluated");
+        }
+        catch (Runtime.Exceptions.ThrowException te)
+        {
+            SetError(te.Value);
+            SetStatus("errored");
+            throw;
+        }
+        catch (Exception ex)
+        {
+            SetError(ErrorBuiltIns.CreateError("Error", [Unwrap(ex).Message]));
+            SetStatus("errored");
+            throw;
+        }
+    }
+
+    /// <summary>Subclass hook: run the module body, populating <see cref="Namespace"/>.</summary>
+    protected abstract void EvaluateBody(Interp? interp);
+
+    /// <summary>The exported bindings (used by dependents that import this module).</summary>
+    public IReadOnlyDictionary<string, object?> Exports => Namespace;
+
+    /// <summary>Invokes a guest callable (ISharpTSCallable or a compiled $TSFunction) with boxed args.</summary>
+    protected static object? CallGuest(Interp? interp, object? callable, params object?[] args)
+    {
+        switch (callable)
+        {
+            case ISharpTSCallable c:
+                return c.Call(interp!, args.ToList());
+            case null:
+                throw new Exception("TypeError: linker is not a function");
+            default:
+                var invoke = callable.GetType().GetMethod("Invoke", [typeof(object[])]);
+                if (invoke != null)
+                    return invoke.Invoke(callable, [args]);
+                throw new Exception("TypeError: linker is not a function");
+        }
+    }
+
+    /// <summary>If a settled SharpTSPromise was returned by the linker, unwrap to its value.</summary>
+    protected static object? UnwrapSettled(object? value)
+    {
+        if (value is SharpTSPromise p && p.Task.IsCompletedSuccessfully)
+            return p.Task.Result;
+        return value;
+    }
+}
+
+/// <summary>
+/// vm.SourceTextModule — an ES module compiled from source text and run inside the vm's
+/// hosted interpreter. Dependencies are discovered by scanning the source's top-level
+/// import statements; link() resolves them via the user linker; evaluate() runs the body
+/// (imports bound from linked namespaces, exports collected into the namespace).
+/// </summary>
+public sealed class VmSourceTextModule : VmModuleBase
+{
+    private readonly string _code;
+    private readonly List<Stmt> _statements;
+    private readonly List<string> _dependencySpecifiers;
+
+    public override IReadOnlyList<string> DependencySpecifiers => _dependencySpecifiers;
+
+    public VmSourceTextModule(string code, object? options)
+    {
+        _code = code;
+        Identifier = VmModuleInterpreter.GetStringOption(options, "identifier") ?? $"vm:module({NextId()})";
+        ContextObject = VmModuleInterpreter.GetOption(options, "context");
+        ImportModuleDynamically = VmModuleInterpreter.GetOption(options, "importModuleDynamically");
+
+        _statements = VmModuleInterpreter.ParseCode(code, Identifier);
+
+        // Dependency specifiers = the module paths of the top-level (non type-only) imports,
+        // in source order, de-duplicated (matching Node).
+        _dependencySpecifiers = new List<string>();
+        var seen = new HashSet<string>();
+        foreach (var stmt in _statements)
+            if (stmt is Stmt.Import imp && !imp.IsTypeOnly && seen.Add(imp.ModulePath))
+                _dependencySpecifiers.Add(imp.ModulePath);
+    }
+
+    protected override void EvaluateBody(Interp? interp)
+    {
+        var sub = interp != null ? new Interp(interp.Out, interp.Error) : new Interp();
+        var env = sub.Environment;
+
+        // Seed the contextified object's properties (if a vm context was supplied).
+        if (ContextObject != null)
+            foreach (var (key, value) in VmContext.ExtractProperties(ContextObject))
+                env.Define(key, value);
+
+        // Bind imported names from the linked dependency namespaces.
+        foreach (var stmt in _statements)
+        {
+            if (stmt is not Stmt.Import imp || imp.IsTypeOnly) continue;
+            if (!Linked.TryGetValue(imp.ModulePath, out var dep)) continue;
+            var depExports = dep.Exports;
+
+            if (imp.NamespaceImport != null)
+                env.Define(imp.NamespaceImport.Lexeme, new Dictionary<string, object?>(depExports));
+            if (imp.DefaultImport != null)
+                env.Define(imp.DefaultImport.Lexeme, depExports.GetValueOrDefault("default"));
+            if (imp.NamedImports != null)
+                foreach (var spec in imp.NamedImports)
+                {
+                    if (spec.IsTypeOnly) continue;
+                    var local = (spec.LocalName ?? spec.Imported).Lexeme;
+                    env.Define(local, depExports.GetValueOrDefault(spec.Imported.Lexeme));
+                }
+        }
+
+        // Build the runnable statement list (imports dropped; exports unwrapped to their
+        // declarations) and record which names are exported.
+        var toRun = new List<Stmt>();
+        var exported = new List<(string local, string exported)>();
+        foreach (var stmt in _statements)
+        {
+            switch (stmt)
+            {
+                case Stmt.Import:
+                    continue;
+                case Stmt.Export exp:
+                    CollectExport(exp, toRun, exported);
+                    break;
+                default:
+                    toRun.Add(stmt);
+                    break;
+            }
+        }
+
+        var resolver = new VariableResolver(sub);
+        resolver.Resolve(toRun);
+        sub.InterpretRepl(toRun);
+
+        // Snapshot the exported bindings into the namespace.
+        foreach (var (local, exportedName) in exported)
+            if (sub.Environment.TryGet(local, out var v))
+                Namespace[exportedName] = v.ToObject();
+
+        sub.Dispose();
+    }
+
+    private static void CollectExport(Stmt.Export exp, List<Stmt> toRun, List<(string, string)> exported)
+    {
+        if (exp.Declaration != null)
+        {
+            toRun.Add(exp.Declaration);
+            foreach (var name in DeclaredNames(exp.Declaration))
+                exported.Add((name, name));
+        }
+        else if (exp.NamedExports != null)
+        {
+            foreach (var spec in exp.NamedExports)
+                exported.Add((spec.LocalName.Lexeme, (spec.ExportedName ?? spec.LocalName).Lexeme));
+        }
+        else if (exp.IsDefaultExport && exp.DefaultExpr != null)
+        {
+            // export default <expr>  →  const <synthetic> = <expr>; namespace["default"] = <synthetic>
+            var name = "__vmDefaultExport__";
+            var token = new Token(TokenType.IDENTIFIER, name, null, exp.Keyword.Line);
+            toRun.Add(new Stmt.Const(token, null, exp.DefaultExpr));
+            exported.Add((name, "default"));
+        }
+    }
+
+    private static IEnumerable<string> DeclaredNames(Stmt declaration) => declaration switch
+    {
+        Stmt.Var v => [v.Name.Lexeme],
+        Stmt.Const c => [c.Name.Lexeme],
+        Stmt.Function f => [f.Name.Lexeme],
+        Stmt.Class cl => [cl.Name.Lexeme],
+        _ => [],
+    };
+}
+
+/// <summary>
+/// Constructor for vm.SourceTextModule — <c>new vm.SourceTextModule(code[, options])</c>.
+/// Returns the module's guest-visible facade dictionary (works in both modes).
+/// </summary>
+public sealed class VmSourceTextModuleConstructor : ISharpTSCallable
+{
+    public int Arity() => 1;
+
+    public object? Call(Interp interpreter, List<object?> args)
+    {
+        if (args.Count == 0 || args[0] is not string code)
+            throw new Exception("vm.SourceTextModule requires a code string");
+
+        var options = args.Count > 1 ? args[1] : null;
+        var module = new VmSourceTextModule(code, options);
+        return module.BuildFacade(code);
+    }
+}

--- a/Runtime/Types/VmModule.cs
+++ b/Runtime/Types/VmModule.cs
@@ -108,8 +108,19 @@ public abstract class VmModuleBase
                 RuntimeValue.FromObject(SharpTSBuffer.FromString(sourceForCache, "utf8"))),
         };
 
+        ConfigureFacade(Facade);
         VmModuleRegistry.Register(Facade, this);
         return Facade;
+    }
+
+    /// <summary>Subclass hook to add type-specific facade members (e.g. SyntheticModule.setExport).</summary>
+    protected virtual void ConfigureFacade(Dictionary<string, object?> facade) { }
+
+    /// <summary>Sets a named export value (vm.SyntheticModule.setExport); updates the namespace.</summary>
+    protected void SetExport(string name, object? value)
+    {
+        Namespace[name] = value;
+        if (Facade != null) Facade["namespace"] = Namespace;
     }
 
     /// <summary>
@@ -130,7 +141,7 @@ public abstract class VmModuleBase
         {
             foreach (var specifier in DependencySpecifiers)
             {
-                var resolved = CallGuest(interp, linker, specifier, Facade);
+                var resolved = CallGuest(interp, linker, thisArg: null, [specifier, Facade]);
                 resolved = UnwrapSettled(resolved);
                 var child = VmModuleRegistry.Get(resolved)
                     ?? throw new Exception($"TypeError: linker for '{specifier}' did not return a vm.Module");
@@ -203,21 +214,30 @@ public abstract class VmModuleBase
     /// <summary>The exported bindings (used by dependents that import this module).</summary>
     public IReadOnlyDictionary<string, object?> Exports => Namespace;
 
-    /// <summary>Invokes a guest callable (ISharpTSCallable or a compiled $TSFunction) with boxed args.</summary>
-    protected static object? CallGuest(Interp? interp, object? callable, params object?[] args)
+    /// <summary>
+    /// Invokes a guest callable (an interpreter ISharpTSCallable or a compiled
+    /// $TSFunction) with the given <c>this</c> value and boxed args. Used for the
+    /// linker (this = null) and the SyntheticModule evaluateCallback (this = the
+    /// module facade, so <c>this.setExport(...)</c> resolves).
+    /// </summary>
+    protected static object? CallGuest(Interp? interp, object? callable, object? thisArg, object?[] args)
     {
-        switch (callable)
+        if (callable is ISharpTSCallable c)
+            return FunctionBuiltIns.CallWithThis(interp!, c, thisArg, args.ToList());
+        if (callable == null)
+            throw new Exception("TypeError: callback is not a function");
+
+        var type = callable.GetType();
+        if (type.Name is "$TSFunction" or "$BoundTSFunction")
         {
-            case ISharpTSCallable c:
-                return c.Call(interp!, args.ToList());
-            case null:
-                throw new Exception("TypeError: linker is not a function");
-            default:
-                var invoke = callable.GetType().GetMethod("Invoke", [typeof(object[])]);
-                if (invoke != null)
-                    return invoke.Invoke(callable, [args]);
-                throw new Exception("TypeError: linker is not a function");
+            var withThis = type.GetMethod("InvokeWithThis", [typeof(object), typeof(object[])]);
+            if (withThis != null)
+                return withThis.Invoke(callable, [thisArg, args]);
         }
+        var invoke = type.GetMethod("Invoke", [typeof(object[])]);
+        if (invoke != null)
+            return invoke.Invoke(callable, [args]);
+        throw new Exception("TypeError: callback is not a function");
     }
 
     /// <summary>If a settled SharpTSPromise was returned by the linker, unwrap to its value.</summary>
@@ -371,5 +391,91 @@ public sealed class VmSourceTextModuleConstructor : ISharpTSCallable
         var options = args.Count > 1 ? args[1] : null;
         var module = new VmSourceTextModule(code, options);
         return module.BuildFacade(code);
+    }
+}
+
+/// <summary>
+/// vm.SyntheticModule — a module whose exports are defined programmatically rather than
+/// from source. <c>exportNames</c> are declared up front; the <c>evaluateCallback</c> runs
+/// at evaluation with <c>this</c> bound to the module and calls <c>this.setExport(name, value)</c>
+/// to populate them. Has no source-level dependencies; participates in link()/evaluate() and
+/// the status state machine like SourceTextModule.
+/// </summary>
+public sealed class VmSyntheticModule : VmModuleBase
+{
+    private static readonly string[] _noDeps = [];
+    private readonly List<string> _exportNames;
+    private readonly object? _evaluateCallback;
+
+    public override IReadOnlyList<string> DependencySpecifiers => _noDeps;
+
+    public VmSyntheticModule(IEnumerable<string> exportNames, object? evaluateCallback, object? options)
+    {
+        _exportNames = exportNames.ToList();
+        _evaluateCallback = evaluateCallback;
+        Identifier = VmModuleInterpreter.GetStringOption(options, "identifier") ?? $"vm:synthetic-module({NextId()})";
+        ContextObject = VmModuleInterpreter.GetOption(options, "context");
+    }
+
+    protected override void ConfigureFacade(Dictionary<string, object?> facade)
+    {
+        facade["setExport"] = BuiltInMethod.CreateV2("setExport", 2, 2, (interp, recv, a) =>
+        {
+            var name = a.Length > 0 ? a[0].ToObject() as string : null;
+            var value = a.Length > 1 ? a[1].ToObject() : null;
+            DoSetExport(name, value);
+            return RuntimeValue.Undefined;
+        });
+    }
+
+    private void DoSetExport(string? name, object? value)
+    {
+        if (Status == "unlinked")
+            throw new Exception("TypeError [ERR_VM_MODULE_STATUS]: Module must be linked before calling setExport()");
+        if (name == null || !_exportNames.Contains(name))
+            throw new Exception($"TypeError [ERR_VM_MODULE_NOT_MODULE]: '{name}' is not a declared export of this SyntheticModule");
+        SetExport(name, value);
+    }
+
+    protected override void EvaluateBody(Interp? interp)
+    {
+        // Run the evaluate callback with `this` bound to the module facade so the
+        // idiomatic `this.setExport(...)` resolves (in both interpreter and compiled mode).
+        if (_evaluateCallback != null)
+            CallGuest(interp, _evaluateCallback, thisArg: Facade, []);
+    }
+}
+
+/// <summary>
+/// Constructor for vm.SyntheticModule —
+/// <c>new vm.SyntheticModule(exportNames, evaluateCallback[, options])</c>.
+/// </summary>
+public sealed class VmSyntheticModuleConstructor : ISharpTSCallable
+{
+    public int Arity() => 2;
+
+    public object? Call(Interp interpreter, List<object?> args)
+    {
+        var exportNames = ExtractStringList(args.Count > 0 ? args[0] : null);
+        var evaluateCallback = args.Count > 1 ? args[1] : null;
+        var options = args.Count > 2 ? args[2] : null;
+        var module = new VmSyntheticModule(exportNames, evaluateCallback, options);
+        return module.BuildFacade(string.Join(",", exportNames));
+    }
+
+    private static List<string> ExtractStringList(object? value)
+    {
+        var result = new List<string>();
+        IEnumerable<object?>? items = value switch
+        {
+            SharpTSArray arr => arr,
+            List<object?> list => list,
+            _ => null,
+        };
+        if (items != null)
+            foreach (var item in items)
+                if (item is string s)
+                    result.Add(s);
+        return result;
     }
 }

--- a/Runtime/Types/VmModule.cs
+++ b/Runtime/Types/VmModule.cs
@@ -330,6 +330,14 @@ public sealed class VmSourceTextModule : VmModuleBase
             }
         }
 
+        // Route dynamic import() inside the module body through importModuleDynamically (#1156).
+        if (ImportModuleDynamically != null)
+        {
+            var hook = VmModuleInterpreter.BuildDynamicImportHook(ImportModuleDynamically, Facade, interp);
+            if (hook != null)
+                sub.SetVmDynamicImportHook(hook);
+        }
+
         var resolver = new VariableResolver(sub);
         resolver.Resolve(toRun);
         sub.InterpretRepl(toRun);

--- a/STATUS.md
+++ b/STATUS.md
@@ -437,7 +437,7 @@ SharpTS implements 20+ Node.js built-in modules accessible via `import ... from 
 | `dgram` | ✅ | createSocket, Socket; bind, send, close, address, setBroadcast, setTTL, addMembership, dropMembership; connect, disconnect, remoteAddress, get/setRecvBufferSize, get/setSendBufferSize; message/listening/close/error/connect events |
 | `cluster` | ✅ | isPrimary/isWorker/isMaster, fork, worker.send/disconnect/kill/isDead/isConnected, process.send/on('message') IPC, cluster events, disconnect, setupPrimary |
 | `child_process` | ✅ | execSync, spawnSync, exec, spawn, execFileSync, execFile, fork (IPC via named pipes); ChildProcess: pid, exitCode, killed, stdout, stderr, stdin, connected, kill, send, disconnect |
-| `vm` | ✅ | runInNewContext, runInThisContext, createContext, isContext, compileFunction, Script (runInNewContext, runInThisContext, runInContext) |
+| `vm` | ✅ | runInNewContext, runInThisContext, runInContext, createContext (name/origin/codeGeneration/microtaskMode), isContext, compileFunction, measureMemory, constants (USE_MAIN_CONTEXT_DEFAULT_LOADER/DONT_CONTEXTIFY); Script (runIn*Context, createCachedData, filename/offsets, cachedData); ESM-in-vm: SourceTextModule + SyntheticModule (link/evaluate/status/namespace/setExport), importModuleDynamically |
 | `url` | ✅ | URL, URLSearchParams, fileURLToPath, pathToFileURL, format, parse |
 | `util` | ✅ | promisify, deprecate, types (isDate, isRegExp, isMap, isSet, etc.), format, inspect, TextEncoder, TextDecoder |
 | `querystring` | ✅ | parse, stringify, escape, unescape |

--- a/SharpTS.Tests/CompilerTests/StandaloneDllTests.cs
+++ b/SharpTS.Tests/CompilerTests/StandaloneDllTests.cs
@@ -261,6 +261,70 @@ public class StandaloneDllTests
         }
     }
 
+    /// <summary>
+    /// vm is a soft dependency: a normal --compile co-locates SharpTS.dll, but a --standalone
+    /// build suppresses the copy and the vm path must throw a clear "not supported" error at
+    /// runtime instead of silently degrading (cf. the eval/tls standalone lesson). The test
+    /// helper never co-locates SharpTS.dll, so running the isolated DLL exercises exactly the
+    /// --standalone path.
+    /// </summary>
+    [Fact]
+    public void Isolated_Vm_ThrowsClearly_WhenSharpTsRuntimeAbsent()
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import * as vm from 'vm';
+                console.log(vm.runInNewContext('1 + 1'));
+                """
+        };
+
+        var (tempDir, dllPath) = CompileStandaloneModule(files, "main.ts");
+        try
+        {
+            var ex = Assert.Throws<Exception>(() => ExecuteCompiledDllIsolated(dllPath, timeoutMs: 15000));
+            Assert.Contains("vm module is not supported in standalone", ex.Message);
+        }
+        finally
+        {
+            CleanupTempDir(tempDir);
+        }
+    }
+
+    /// <summary>
+    /// A vm program records the "vm module" soft-dependency reason so the CLI co-locates
+    /// SharpTS.dll next to non-standalone output.
+    /// </summary>
+    [Fact]
+    public void Vm_RecordsSharpTsRuntimeDependency()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"sharpts_vm_dep_{Guid.NewGuid()}");
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            var entryPath = Path.Combine(tempDir, "main.ts");
+            File.WriteAllText(entryPath, """
+                import * as vm from 'vm';
+                console.log(vm.runInNewContext('1 + 1'));
+                """);
+
+            var resolver = new ModuleResolver(entryPath);
+            var entryModule = resolver.LoadModule(entryPath);
+            var modules = resolver.GetModulesInOrder(entryModule);
+            var typeMap = new TypeChecker().CheckModules(modules, resolver);
+            var deadCodeInfo = new DeadCodeAnalyzer(typeMap).Analyze(modules.SelectMany(m => m.Statements).ToList());
+
+            var compiler = new ILCompiler("vm_dep_test");
+            compiler.CompileModules(modules, resolver, typeMap, deadCodeInfo);
+
+            Assert.Contains("vm module", compiler.RequiredSharpTSRuntimeReasons);
+        }
+        finally
+        {
+            CleanupTempDir(tempDir);
+        }
+    }
+
     [Fact]
     public void Isolated_BroadcastChannel_ShouldExecuteWithoutSharpTsDll()
     {

--- a/SharpTS.Tests/SharedTests/BuiltInModules/VmModuleTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/VmModuleTests.cs
@@ -733,6 +733,144 @@ public class VmModuleTests
 
     #endregion
 
+    #region SourceTextModule (ESM-in-vm) Tests
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Vm_SourceTextModule_LinkEvaluate_ImportsDependency(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import { SourceTextModule } from 'vm';
+                async function main() {
+                    const dep = new SourceTextModule('export const x = 42; export const y = "hi";');
+                    const m = new SourceTextModule('import { x, y } from "dep"; export const sum = x + 1; export const greet = y + x;');
+                    await m.link((spec: string) => dep);
+                    await m.evaluate();
+                    console.log(m.namespace.sum);
+                    console.log(m.namespace.greet);
+                    console.log(dep.namespace.x);
+                }
+                main();
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("43\nhi42\n42\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Vm_SourceTextModule_StatusTransitions(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import { SourceTextModule } from 'vm';
+                async function main() {
+                    const m = new SourceTextModule('export const v = 1;');
+                    console.log(m.status);
+                    await m.link((spec: string) => { throw new Error('no deps'); });
+                    console.log(m.status);
+                    await m.evaluate();
+                    console.log(m.status);
+                }
+                main();
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("unlinked\nlinked\nevaluated\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Vm_SourceTextModule_DependencySpecifiers_Count(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import { SourceTextModule } from 'vm';
+                const m = new SourceTextModule('import { a } from "x"; import { b } from "y"; export const c = 1;');
+                console.log(m.dependencySpecifiers.length);
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("2\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void Vm_SourceTextModule_DependencySpecifiers_Indexing(ExecutionMode mode)
+    {
+        // dependencySpecifiers is an Array; element indexing is observable within the
+        // interpreter (compiled indexing of a cross-boundary SharpTSArray returns undefined
+        // — a known interop detail; the .length is observable cross-mode, covered above).
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import { SourceTextModule } from 'vm';
+                const m = new SourceTextModule('import { a } from "x"; import { b } from "y"; export const c = 1;');
+                console.log(m.dependencySpecifiers[0]);
+                console.log(m.dependencySpecifiers[1]);
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("x\ny\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Vm_SourceTextModule_LinkerError_SetsErrored(ExecutionMode mode)
+    {
+        // The error path is exercised synchronously (link/evaluate complete synchronously in
+        // SharpTS): an awaited synchronously-throwing call is not caught by the compiled async
+        // state machine — a pre-existing limitation unrelated to vm.
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import { SourceTextModule } from 'vm';
+                const m = new SourceTextModule('import { x } from "missing";');
+                try {
+                    m.link((spec: string) => { throw new Error('cannot resolve ' + spec); });
+                } catch (e: any) { }
+                console.log(m.status);
+                console.log(m.error !== undefined && m.error !== null);
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("errored\ntrue\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Vm_SourceTextModule_DefaultExport(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import { SourceTextModule } from 'vm';
+                async function main() {
+                    const dep = new SourceTextModule('export default 99;');
+                    const m = new SourceTextModule('import d from "dep"; export const val = d + 1;');
+                    await m.link((spec: string) => dep);
+                    await m.evaluate();
+                    console.log(m.namespace.val);
+                }
+                main();
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("100\n", output);
+    }
+
+    #endregion
+
     #region Error Handling Tests
 
     [Theory]

--- a/SharpTS.Tests/SharedTests/BuiltInModules/VmModuleTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/VmModuleTests.cs
@@ -871,6 +871,61 @@ public class VmModuleTests
 
     #endregion
 
+    #region SyntheticModule Tests
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Vm_SyntheticModule_ImportedBySourceTextModule_LiveBinding(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import { SourceTextModule, SyntheticModule } from 'vm';
+                async function main() {
+                    const syn = new SyntheticModule(['x', 'y'], function (this: any) {
+                        this.setExport('x', 42);
+                        this.setExport('y', 'hello');
+                    });
+                    const m = new SourceTextModule('import { x, y } from "syn"; export const r = x + 1; export const s = y + "!";');
+                    await m.link((spec: string) => syn);
+                    await m.evaluate();
+                    console.log(m.namespace.r);
+                    console.log(m.namespace.s);
+                    console.log(syn.namespace.x);
+                    console.log(syn.status);
+                }
+                main();
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("43\nhello!\n42\nevaluated\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Vm_SyntheticModule_SetExportBeforeLink_Throws(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import { SyntheticModule } from 'vm';
+                const syn = new SyntheticModule(['a'], function (this: any) { this.setExport('a', 1); });
+                try {
+                    syn.setExport('a', 5);
+                    console.log('no error');
+                } catch (e: any) {
+                    console.log('threw');
+                }
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("threw\n", output);
+    }
+
+    #endregion
+
     #region Error Handling Tests
 
     [Theory]

--- a/SharpTS.Tests/SharedTests/BuiltInModules/VmModuleTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/VmModuleTests.cs
@@ -256,6 +256,107 @@ public class VmModuleTests
 
     #endregion
 
+    #region runInContext (module-level) / constants Tests
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Vm_RunInContext_Basic(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import * as vm from 'vm';
+                const ctx = vm.createContext({ x: 1 });
+                console.log(vm.runInContext('x + 1', ctx));
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("2\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Vm_RunInContext_WritesBack(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import * as vm from 'vm';
+                const ctx = vm.createContext({ count: 10 });
+                vm.runInContext('count = count + 5', ctx);
+                console.log(ctx.count);
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("15\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Vm_RunInContext_NonContext_Throws(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import * as vm from 'vm';
+                try {
+                    vm.runInContext('1 + 1', { x: 1 });
+                    console.log('no error');
+                } catch (e) {
+                    console.log('caught error');
+                }
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("caught error\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Vm_Constants_Exist(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import * as vm from 'vm';
+                console.log(typeof vm.constants === 'object');
+                console.log(vm.constants.DONT_CONTEXTIFY !== undefined);
+                console.log(vm.constants.USE_MAIN_CONTEXT_DEFAULT_LOADER !== undefined);
+                // Sentinels are stable singletons (same value across accesses) and distinct.
+                console.log(vm.constants.DONT_CONTEXTIFY === vm.constants.DONT_CONTEXTIFY);
+                console.log(vm.constants.DONT_CONTEXTIFY !== vm.constants.USE_MAIN_CONTEXT_DEFAULT_LOADER);
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("true\ntrue\ntrue\ntrue\ntrue\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void Vm_Constants_AreSymbols(ExecutionMode mode)
+    {
+        // typeof reports 'symbol' in the interpreter; compiled-mode typeof of a
+        // cross-runtime-boundary SharpTSSymbol reports 'object' (a known interop
+        // detail — the sentinels' identity, exercised above, is what matters).
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import * as vm from 'vm';
+                console.log(typeof vm.constants.DONT_CONTEXTIFY);
+                console.log(typeof vm.constants.USE_MAIN_CONTEXT_DEFAULT_LOADER);
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("symbol\nsymbol\n", output);
+    }
+
+    #endregion
+
     #region Script Tests
 
     [Theory]

--- a/SharpTS.Tests/SharedTests/BuiltInModules/VmModuleTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/VmModuleTests.cs
@@ -438,6 +438,176 @@ public class VmModuleTests
 
     #endregion
 
+    #region Script/compileFunction options + cachedData Tests
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Vm_Script_Filename_InSyntaxError(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import { Script } from 'vm';
+                try {
+                    new Script('let x = ;', { filename: 'my-file.js' });
+                    console.log('no error');
+                } catch (e: any) {
+                    console.log(e.message.indexOf('my-file.js') >= 0);
+                }
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("true\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Vm_Script_OffsetsAndDisplayErrors_Accepted(ExecutionMode mode)
+    {
+        // filename/lineOffset/columnOffset/displayErrors are honored without altering
+        // a successful run's result.
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import { Script } from 'vm';
+                const s = new Script('40 + 2', {
+                    filename: 'calc.js', lineOffset: 5, columnOffset: 2, displayErrors: true
+                });
+                console.log(s.runInNewContext({}));
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("42\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Vm_Script_CreateCachedData_ReturnsValue(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import { Script } from 'vm';
+                const s = new Script('1 + 1');
+                const cd = s.createCachedData();
+                console.log(cd !== undefined && cd !== null);
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("true\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void Vm_Script_CreateCachedData_IsBuffer(ExecutionMode mode)
+    {
+        // The marker is a real Buffer; Buffer.isBuffer/length only recognize it within
+        // the interpreter (compiled Buffer.isBuffer is blind to a cross-boundary
+        // SharpTSBuffer — a known interop detail; cross-mode the value is defined+round-trips).
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import { Script } from 'vm';
+                const s = new Script('1 + 1');
+                const cd = s.createCachedData();
+                console.log(Buffer.isBuffer(cd));
+                console.log(cd.length > 0);
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("true\ntrue\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Vm_Script_ProduceCachedData(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import { Script } from 'vm';
+                const s = new Script('1 + 1', { produceCachedData: true });
+                console.log(s.cachedDataProduced);
+                console.log(s.cachedData !== undefined && s.cachedData !== null);
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("true\ntrue\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Vm_Script_CachedData_RoundTrips_NotRejected(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import { Script } from 'vm';
+                const s1 = new Script('2 * 21', { produceCachedData: true });
+                const s2 = new Script('2 * 21', { cachedData: s1.cachedData });
+                console.log(s2.cachedDataRejected);
+                console.log(s2.runInNewContext({}));
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("false\n42\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void Vm_Script_Filename_InTimeoutErrorStack(ExecutionMode mode)
+    {
+        // The origin frame is attached to errors that propagate as a live guest error
+        // object (the timeout error). User throws/runtime faults are reconstructed at the
+        // execution boundary and don't carry the frame (a documented limitation); the
+        // filename DOES flow into SyntaxErrors cross-mode (covered above).
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import { Script } from 'vm';
+                const s = new Script('while(true){}', { filename: 'loop.js' });
+                try {
+                    s.runInNewContext({}, { timeout: 50 });
+                    console.log('no error');
+                } catch (e: any) {
+                    console.log((e.stack || '').indexOf('loop.js') >= 0);
+                }
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("true\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Vm_CompileFunction_Filename_InSyntaxError(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import { compileFunction } from 'vm';
+                try {
+                    compileFunction('return ;; @@', [], { filename: 'fn-src.js' });
+                    console.log('no error');
+                } catch (e: any) {
+                    console.log(e.message.indexOf('fn-src.js') >= 0);
+                }
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("true\n", output);
+    }
+
+    #endregion
+
     #region Error Handling Tests
 
     [Theory]

--- a/SharpTS.Tests/SharedTests/BuiltInModules/VmModuleTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/VmModuleTests.cs
@@ -926,6 +926,57 @@ public class VmModuleTests
 
     #endregion
 
+    #region importModuleDynamically Tests
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Vm_Script_ImportModuleDynamically_ResolvesViaHook(ExecutionMode mode)
+    {
+        // The result of the in-vm dynamic import is written back to a context scalar to
+        // keep it observable cross-mode (a cross-boundary Promise is not unwrapped by
+        // compiled await; the await happens inside the hosted interpreter).
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import { Script, SourceTextModule, createContext } from 'vm';
+                const dep = new SourceTextModule('export const value = 123;');
+                const importModuleDynamically = (specifier: string) => dep;
+                const ctx: any = createContext({ result: 0 });
+                const script = new Script(
+                    '(async () => { const ns = await import("dep"); result = ns.value; })();',
+                    { importModuleDynamically });
+                script.runInContext(ctx);
+                console.log(ctx.result);
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("123\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Vm_Script_ImportModuleDynamically_UseMainContextDefaultLoader_Accepted(ExecutionMode mode)
+    {
+        // Passing the USE_MAIN_CONTEXT_DEFAULT_LOADER sentinel falls back to the default
+        // loader (no override) and does not disturb a script that performs no import.
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import { Script, constants } from 'vm';
+                const script = new Script('1 + 1', {
+                    importModuleDynamically: constants.USE_MAIN_CONTEXT_DEFAULT_LOADER
+                });
+                console.log(script.runInNewContext({}));
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("2\n", output);
+    }
+
+    #endregion
+
     #region Error Handling Tests
 
     [Theory]

--- a/SharpTS.Tests/SharedTests/BuiltInModules/VmModuleTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/VmModuleTests.cs
@@ -357,6 +357,131 @@ public class VmModuleTests
 
     #endregion
 
+    #region createContext options + measureMemory Tests
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Vm_CreateContext_MicrotaskMode_AfterEvaluate(ExecutionMode mode)
+    {
+        // With microtaskMode:'afterEvaluate', the queued .then microtask runs before
+        // runInContext returns, so the scalar write is visible afterward.
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import * as vm from 'vm';
+                const ctx = vm.createContext({ flag: 0 }, { microtaskMode: 'afterEvaluate' });
+                vm.runInContext('Promise.resolve().then(() => { flag = 1; }); 0;', ctx);
+                console.log(ctx.flag);
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("1\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Vm_CreateContext_CodeGeneration_StringsFalse_BlocksEval(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import * as vm from 'vm';
+                const ctx = vm.createContext({}, { codeGeneration: { strings: false } });
+                try {
+                    vm.runInContext('eval("1 + 1")', ctx);
+                    console.log('no error');
+                } catch (e: any) {
+                    console.log('blocked');
+                }
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("blocked\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Vm_CreateContext_CodeGeneration_Default_AllowsEval(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import * as vm from 'vm';
+                const ctx = vm.createContext({});
+                console.log(vm.runInContext('eval("20 + 22")', ctx));
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("42\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Vm_CreateContext_NameOrigin_Accepted(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import * as vm from 'vm';
+                const ctx = vm.createContext({ x: 5 }, { name: 'my-ctx', origin: 'file:///x' });
+                console.log(vm.runInContext('x * 2', ctx));
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("10\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Vm_MeasureMemory_ResolvesShape(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import * as vm from 'vm';
+                async function main() {
+                    const r: any = await vm.measureMemory();
+                    console.log(typeof r.total.jsMemoryEstimate === 'number');
+                    console.log(r.total.jsMemoryRange !== undefined && r.total.jsMemoryRange !== null);
+                }
+                main();
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("true\ntrue\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void Vm_MeasureMemory_RangeIsArray(ExecutionMode mode)
+    {
+        // jsMemoryRange is a 2-element Array; Array.isArray/.length only fully recognize it
+        // within the interpreter (compiled is blind to a cross-boundary SharpTSArray — a
+        // known interop detail; cross-mode the value is present, covered above).
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import * as vm from 'vm';
+                async function main() {
+                    const r: any = await vm.measureMemory();
+                    console.log(Array.isArray(r.total.jsMemoryRange));
+                    console.log(r.total.jsMemoryRange.length === 2);
+                }
+                main();
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("true\ntrue\n", output);
+    }
+
+    #endregion
+
     #region Script Tests
 
     [Theory]

--- a/TypeSystem/BuiltInModuleTypes.cs
+++ b/TypeSystem/BuiltInModuleTypes.cs
@@ -2166,6 +2166,7 @@ public static class BuiltInModuleTypes
             ["createContext"] = new TypeInfo.Function([anyType, anyType], anyType, RequiredParams: 0),
             ["isContext"] = new TypeInfo.Function([anyType], boolType),
             ["compileFunction"] = new TypeInfo.Function([stringType, stringArrayType, anyType], anyType, RequiredParams: 1),
+            ["measureMemory"] = new TypeInfo.Function([anyType], anyType, RequiredParams: 0),
             ["constants"] = constantsType,
             ["Script"] = new TypeInfo.Function([stringType, anyType], scriptType, RequiredParams: 1),
         };

--- a/TypeSystem/BuiltInModuleTypes.cs
+++ b/TypeSystem/BuiltInModuleTypes.cs
@@ -2186,6 +2186,7 @@ public static class BuiltInModuleTypes
             ["constants"] = constantsType,
             ["Script"] = new TypeInfo.Function([stringType, anyType], scriptType, RequiredParams: 1),
             ["SourceTextModule"] = new TypeInfo.Function([stringType, anyType], moduleType, RequiredParams: 1),
+            ["SyntheticModule"] = new TypeInfo.Function([stringArrayType, anyType, anyType], moduleType, RequiredParams: 2),
         };
     }
 

--- a/TypeSystem/BuiltInModuleTypes.cs
+++ b/TypeSystem/BuiltInModuleTypes.cs
@@ -2151,13 +2151,22 @@ public static class BuiltInModuleTypes
 
         var stringArrayType = new TypeInfo.Array(stringType);
 
+        // vm.constants — opaque sentinel Symbols used as marker option values.
+        var constantsType = new TypeInfo.Record(new Dictionary<string, TypeInfo>
+        {
+            ["USE_MAIN_CONTEXT_DEFAULT_LOADER"] = anyType,
+            ["DONT_CONTEXTIFY"] = anyType,
+        }.ToFrozenDictionary());
+
         return new Dictionary<string, TypeInfo>
         {
             ["runInNewContext"] = new TypeInfo.Function([stringType, anyType, anyType], anyType, RequiredParams: 1),
             ["runInThisContext"] = new TypeInfo.Function([stringType, anyType], anyType, RequiredParams: 1),
-            ["createContext"] = new TypeInfo.Function([anyType], anyType, RequiredParams: 0),
+            ["runInContext"] = new TypeInfo.Function([stringType, anyType, anyType], anyType, RequiredParams: 2),
+            ["createContext"] = new TypeInfo.Function([anyType, anyType], anyType, RequiredParams: 0),
             ["isContext"] = new TypeInfo.Function([anyType], boolType),
             ["compileFunction"] = new TypeInfo.Function([stringType, stringArrayType, anyType], anyType, RequiredParams: 1),
+            ["constants"] = constantsType,
             ["Script"] = new TypeInfo.Function([stringType, anyType], scriptType, RequiredParams: 1),
         };
     }

--- a/TypeSystem/BuiltInModuleTypes.cs
+++ b/TypeSystem/BuiltInModuleTypes.cs
@@ -2151,6 +2151,22 @@ public static class BuiltInModuleTypes
 
         var stringArrayType = new TypeInfo.Array(stringType);
 
+        // vm.Module / SourceTextModule / SyntheticModule instance shape.
+        var moduleType = new TypeInfo.Record(new Dictionary<string, TypeInfo>
+        {
+            ["status"] = stringType,
+            ["identifier"] = stringType,
+            ["namespace"] = anyType,
+            ["dependencySpecifiers"] = stringArrayType,
+            ["error"] = anyType,
+            ["context"] = anyType,
+            ["link"] = new TypeInfo.Function([anyType], anyType, RequiredParams: 1),
+            ["evaluate"] = new TypeInfo.Function([anyType], anyType, RequiredParams: 0),
+            ["instantiate"] = new TypeInfo.Function([], anyType, RequiredParams: 0),
+            ["setExport"] = new TypeInfo.Function([stringType, anyType], anyType, RequiredParams: 2),
+            ["createCachedData"] = new TypeInfo.Function([], anyType, RequiredParams: 0),
+        }.ToFrozenDictionary());
+
         // vm.constants — opaque sentinel Symbols used as marker option values.
         var constantsType = new TypeInfo.Record(new Dictionary<string, TypeInfo>
         {
@@ -2169,6 +2185,7 @@ public static class BuiltInModuleTypes
             ["measureMemory"] = new TypeInfo.Function([anyType], anyType, RequiredParams: 0),
             ["constants"] = constantsType,
             ["Script"] = new TypeInfo.Function([stringType, anyType], scriptType, RequiredParams: 1),
+            ["SourceTextModule"] = new TypeInfo.Function([stringType, anyType], moduleType, RequiredParams: 1),
         };
     }
 

--- a/TypeSystem/BuiltInModuleTypes.cs
+++ b/TypeSystem/BuiltInModuleTypes.cs
@@ -2147,6 +2147,11 @@ public static class BuiltInModuleTypes
             ["runInNewContext"] = new TypeInfo.Function([anyType, anyType], anyType, RequiredParams: 0),
             ["runInThisContext"] = new TypeInfo.Function([anyType], anyType, RequiredParams: 0),
             ["runInContext"] = new TypeInfo.Function([anyType, anyType], anyType, RequiredParams: 1),
+            ["createCachedData"] = new TypeInfo.Function([], anyType, RequiredParams: 0),
+            ["cachedData"] = anyType,
+            ["cachedDataProduced"] = BooleanType,
+            ["cachedDataRejected"] = BooleanType,
+            ["sourceMapURL"] = anyType,
         }.ToFrozenDictionary());
 
         var stringArrayType = new TypeInfo.Array(stringType);


### PR DESCRIPTION
Closes #1150. Implements all 7 children (#1151–#1157), interpreter and compiled paths in agreement, soft-dependency posture preserved.

## What's new

**Module-level surface**
- `vm.runInContext(code, contextifiedObject[, options])` (#1151) — throws a TypeError on a non-context.
- `vm.constants` (#1151) — `USE_MAIN_CONTEXT_DEFAULT_LOADER` / `DONT_CONTEXTIFY` (stable sentinel Symbols).
- Script / compileFunction options (#1152) — `filename`/`lineOffset`/`columnOffset`/`displayErrors` (filename flows into SyntaxError messages); `cachedData`/`produceCachedData` + `script.createCachedData()` (marker Buffer; `cachedDataRejected:false` — the V8 bytecode cache is a documented .NET ceiling).
- `createContext` options (#1153) — `name`/`origin`/`codeGeneration:{strings,wasm}` (`strings:false` blocks `eval`)/`microtaskMode:'afterEvaluate'`.
- `vm.measureMemory()` (#1153) — Promise resolving to the GC-derived `{ total: { jsMemoryEstimate, jsMemoryRange } }` shape (V8 per-context detail is a documented ceiling).

**ESM-in-vm Module API (the core)**
- `vm.SourceTextModule` (#1154) — `dependencySpecifiers` from the source's imports; `link(linker)` (recursive) → `instantiate()`/`evaluate()`; `status` state machine (`unlinked`→`linking`→`linked`→`evaluating`→`evaluated`/`errored`); `namespace`/`identifier`/`error`/`context`/`createCachedData()`.
- `vm.SyntheticModule` (#1155) — `exportNames` + `evaluateCallback` calling `this.setExport(name, value)`; `setExport` before link throws; participates in link/evaluate.
- `importModuleDynamically` hook (#1156) — routes `import()` inside vm code to the user resolver; `USE_MAIN_CONTEXT_DEFAULT_LOADER` falls back to the default loader.

**Types & standalone (#1157)** — full `GetVmModuleTypes` surface; the compiled vm soft-dependency now throws a clear "not supported in standalone" error under `--standalone` instead of a silent null (still records `RequireSharpTSRuntime("vm module")`).

## Design notes / interop

- The Module facades are plain dictionaries and `link()`/`evaluate()` complete synchronously returning `undefined`, so `await m.link(..)`/`await m.evaluate()` behave identically in both modes (a cross-boundary `SharpTSPromise` is not unwrapped by compiled `await`; `measureMemory` is wrapped natively via `TSPromiseResolve`).
- Bonus general fix: compiled `InvokeMethodValue`'s reflection fallback now unwraps `TargetInvocationException`, so a throwing cross-boundary BuiltInMethod (e.g. `module.link` failing) surfaces as a guest-catchable error instead of crashing.
- A handful of cross-runtime-boundary details (compiled `typeof` of a `SharpTSSymbol`, `Buffer.isBuffer`/`Array.isArray`/indexing of a cross-boundary `SharpTSBuffer`/`SharpTSArray`) are interpreter-only and covered by `InterpretedOnly` tests; the cross-mode contract (identity, presence, `.length`) is asserted in `All` mode.

## Tests
- vm dual-mode suite: 111 → now ~125 cases across all features incl. SourceTextModule/SyntheticModule lifecycle, importModuleDynamically, and the new options.
- `StandaloneDllTests`: isolated `--standalone` throws-clearly + records the soft-dependency reason.
- Green: `dotnet test` **14693/0**, `SharpTS.Test262` (exit 0), `SharpTS.TypeScriptConformance` (exit 0) — no baseline regression.