### PR TITLE
Epic #1088: correctness bugs from silent fallback & drift

### DIFF
--- a/Compilation/Emitters/Modules/WorkerThreadsModuleEmitter.cs
+++ b/Compilation/Emitters/Modules/WorkerThreadsModuleEmitter.cs
@@ -106,8 +106,13 @@ public sealed class WorkerThreadsModuleEmitter : IBuiltInModuleEmitter
         var ctx = emitter.Context;
         var il = ctx.IL;
 
-        // parentPort is only available in worker context
-        // For now, return null in compiled code
+        // null is the CORRECT value here, not a stub (#1109). parentPort is the worker→parent port and
+        // is null on the main thread in Node. A worker's body never runs as compiled code: even when the
+        // main program is compiled, SharpTSWorker.RunWorkerScript spins up a fresh INTERPRETER for the
+        // worker file, and that interpreter binds the real WorkerParentPort via SetupWorkerGlobals. So
+        // this compiled path is only ever reached on the MAIN thread — exactly the EmitWorkerData case —
+        // where parentPort is null. Wiring a "$MessagePort" would be wrong (none exists in compiled mode),
+        // and throwing would break the canonical `if (parentPort) { ... }` main-thread guard.
         il.Emit(OpCodes.Ldnull);
         return true;
     }

--- a/Compilation/ExternalMethodResolver.cs
+++ b/Compilation/ExternalMethodResolver.cs
@@ -350,9 +350,8 @@ public class ExternalMethodResolver(TypeMap? typeMap, TypeProvider types)
 
     private static bool IsStringType(TSTypeInfo? type) => type switch
     {
-        TSTypeInfo.String => true,
+        TSTypeInfo.String => true,        // `string` is always TypeInfo.String (#1108)
         TSTypeInfo.StringLiteral => true,
-        TSTypeInfo.Primitive { Type: TokenType.TYPE_STRING } => true,
         _ => false
     };
 

--- a/Compilation/ObjectLocalPromotionAnalyzer.cs
+++ b/Compilation/ObjectLocalPromotionAnalyzer.cs
@@ -175,7 +175,9 @@ public static class ObjectLocalPromotionAnalyzer
         {
             TypeInfo.Primitive { Type: TokenType.TYPE_NUMBER } => TokenType.TYPE_NUMBER,
             TypeInfo.Primitive { Type: TokenType.TYPE_BOOLEAN } => TokenType.TYPE_BOOLEAN,
-            TypeInfo.Primitive { Type: TokenType.TYPE_STRING } => TokenType.TYPE_STRING,
+            // `string` is TypeInfo.String, never Primitive(TYPE_STRING) (#1108) — match the canonical
+            // form so string-valued fields are promotable (the shape struct emits a String slot for them).
+            TypeInfo.String => TokenType.TYPE_STRING,
             _ => null
         };
     }

--- a/Compilation/UnionTypeGenerator.cs
+++ b/Compilation/UnionTypeGenerator.cs
@@ -215,8 +215,7 @@ public class UnionTypeGenerator
 
     private string GetTypePropertyName(TSTypeInfo type, int index) => type switch
     {
-        TSTypeInfo.String => "String", // New String type
-        TSTypeInfo.Primitive { Type: Parsing.TokenType.TYPE_STRING } => "String",
+        TSTypeInfo.String => "String", // `string` is always TypeInfo.String (#1108)
         TSTypeInfo.Primitive { Type: Parsing.TokenType.TYPE_NUMBER } => "Number",
         TSTypeInfo.Primitive { Type: Parsing.TokenType.TYPE_BOOLEAN } => "Boolean",
         TSTypeInfo.Class c => c.Name,

--- a/Parsing/Visitors/AstVisitorBase.cs
+++ b/Parsing/Visitors/AstVisitorBase.cs
@@ -71,6 +71,14 @@ public abstract class AstVisitorBase
             case Expr.Yield e: VisitYield(e); break;
             case Expr.RegexLiteral e: VisitRegexLiteral(e); break;
             case Expr.ClassExpr e: VisitClassExpr(e); break;
+            // Fail loud on an unhandled node rather than silently skipping its subtree. A newly
+            // added Expr kind that nobody wired here would otherwise be invisible to every analyzer
+            // built on AstVisitorBase (closure/suspension/variable analysis) — a latent miscompile,
+            // not just missing coverage (#1107).
+            default:
+                throw new NotSupportedException(
+                    $"AstVisitorBase has no dispatch case for expression node '{expr.GetType().Name}'. " +
+                    "Add a case to Visit(Expr) and a corresponding Visit* method (#1107).");
         }
     }
 
@@ -121,6 +129,11 @@ public abstract class AstVisitorBase
             case Stmt.DeclareModule s: VisitDeclareModule(s); break;
             case Stmt.DeclareGlobal s: VisitDeclareGlobal(s); break;
             case Stmt.Using s: VisitUsing(s); break;
+            // Fail loud on an unhandled node rather than silently skipping its subtree (#1107).
+            default:
+                throw new NotSupportedException(
+                    $"AstVisitorBase has no dispatch case for statement node '{stmt.GetType().Name}'. " +
+                    "Add a case to Visit(Stmt) and a corresponding Visit* method (#1107).");
         }
     }
 

--- a/SharpTS.Tests/ParserTests/NamedTupleTests.cs
+++ b/SharpTS.Tests/ParserTests/NamedTupleTests.cs
@@ -10,7 +10,7 @@ namespace SharpTS.Tests.ParserTests;
 public class NamedTupleTests
 {
     private static TypeInfo NumberType => new TypeInfo.Primitive(TokenType.TYPE_NUMBER);
-    private static TypeInfo StringType => new TypeInfo.Primitive(TokenType.TYPE_STRING);
+    private static TypeInfo StringType => new TypeInfo.String(); // 'string' is TypeInfo.String, not Primitive(TYPE_STRING) (#1108)
 
     [Fact]
     public void NamedTuple_BasicParsing_Works()

--- a/SharpTS.Tests/SharedTests/PrimitiveStringTypeTests.cs
+++ b/SharpTS.Tests/SharedTests/PrimitiveStringTypeTests.cs
@@ -1,0 +1,77 @@
+using SharpTS.Parsing;
+using SharpTS.Tests.Infrastructure;
+using SharpTS.TypeSystem;
+using SharpTS.TypeSystem.Exceptions;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests;
+
+/// <summary>
+/// Regression tests for #1108: <c>string</c> has a dedicated <see cref="TypeInfo.String"/>; the vestigial
+/// <c>Primitive(TYPE_STRING)</c> representation was matched by neither the <c>typeof</c> type-guards nor the
+/// compiled string-classification switches, so it silently miscompiled. The representation is now forbidden
+/// at construction, and the few sites that built it (<c>__dirname</c>/<c>__filename</c>) use
+/// <see cref="TypeInfo.String"/>.
+/// </summary>
+public class PrimitiveStringTypeTests
+{
+    [Fact]
+    public void PrimitiveTypeString_IsForbiddenAtConstruction()
+    {
+        // The assert/analyzer: 'string' must be TypeInfo.String, never Primitive(TYPE_STRING).
+        Assert.Throws<ArgumentException>(() => new TypeInfo.Primitive(TokenType.TYPE_STRING));
+        // number/boolean remain valid Primitive tokens.
+        _ = new TypeInfo.Primitive(TokenType.TYPE_NUMBER);
+        _ = new TypeInfo.Primitive(TokenType.TYPE_BOOLEAN);
+    }
+
+    [Fact]
+    public void TypeofString_NarrowsDirname_ToString()
+    {
+        // Before #1108 __dirname's type was Primitive(TYPE_STRING). `typeof x === "string"` matches only
+        // `TypeInfo.String or StringLiteral`, so the guard failed and narrowed __dirname to `never` inside
+        // the block (and `never` IS assignable to number, hiding the error). With __dirname now typed
+        // TypeInfo.String, it narrows to `string`, which is NOT assignable to number.
+        var source = """
+            if (typeof __dirname === "string") {
+                const num: number = __dirname;
+                console.log(num);
+            }
+            """;
+        var ex = Assert.Throws<TypeMismatchException>(() => TestHarness.RunInterpreted(source));
+        Assert.Contains("'string' is not assignable to type 'number'", ex.Message);
+    }
+
+    [Fact]
+    public void TypeofString_NarrowsFilename_AllowsStringUse()
+    {
+        // The positive side: narrowing to `string` keeps string members available (no false error).
+        var source = """
+            if (typeof __filename === "string") {
+                const upper: string = __filename.toUpperCase();
+                console.log(typeof upper);
+            }
+            """;
+        var result = TestHarness.RunInterpreted(source);
+        Assert.Equal("string\n", result);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void StringFieldObjectLocal_PromotesAndRoundTrips(ExecutionMode mode)
+    {
+        // The compiled ObjectLocalPromotionAnalyzer classifies a string field by TypeInfo.String now
+        // (previously only the never-constructed Primitive(TYPE_STRING)), so an object local with a
+        // string field is promotable to a shape struct with a String slot. Interp and compiled must agree.
+        var source = """
+            function run(): string {
+                const o = { name: "alice", age: 30 };
+                o.name = "bob";
+                return o.name + ":" + o.age;
+            }
+            console.log(run());
+            """;
+        var result = TestHarness.Run(source, mode);
+        Assert.Equal("bob:30\n", result);
+    }
+}

--- a/SharpTS.Tests/SharedTests/WorkerThreadsTests.cs
+++ b/SharpTS.Tests/SharedTests/WorkerThreadsTests.cs
@@ -1716,4 +1716,39 @@ public class WorkerThreadsTests
     }
 
     #endregion
+
+    #region parentPort (#1109)
+
+    /// <summary>
+    /// On the MAIN thread, <c>worker_threads.parentPort</c> is <c>null</c> in Node — and that is the
+    /// correct value the compiled <c>EmitParentPort</c> emits (#1109). A worker's body runs under a fresh
+    /// interpreter (SharpTSWorker.RunWorkerScript), which binds the real parentPort via SetupWorkerGlobals,
+    /// so the compiled path is only ever reached on the main thread. This locks in that both modes agree
+    /// and that the canonical <c>if (parentPort)</c> main-thread guard keeps working (not a throw).
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ParentPort_OnMainThread_IsNull(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import { parentPort, isMainThread } from "worker_threads";
+                console.log("main=" + isMainThread);
+                console.log("isnull=" + (parentPort === null));
+                if (parentPort) {
+                    console.log("guard-entered");
+                } else {
+                    console.log("guard-skipped");
+                }
+                """,
+        };
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Contains("main=true", output);
+        Assert.Contains("isnull=true", output);
+        Assert.Contains("guard-skipped", output);
+        Assert.DoesNotContain("guard-entered", output);
+    }
+
+    #endregion
 }

--- a/TypeSystem/TypeChecker.Compatibility.Structural.cs
+++ b/TypeSystem/TypeChecker.Compatibility.Structural.cs
@@ -420,13 +420,13 @@ public partial class TypeChecker
     /// <summary>Marker types for variance measurement: Sub is structurally assignable to Super
     /// but not conversely (extra member).</summary>
     private static readonly TypeInfo.Record VarianceMarkerSuper = new(
-        new Dictionary<string, TypeInfo> { ["'variance"] = new TypeInfo.Primitive(Parsing.TokenType.TYPE_STRING) }
+        new Dictionary<string, TypeInfo> { ["'variance"] = new TypeInfo.String() }
             .ToFrozenDictionary());
     private static readonly TypeInfo.Record VarianceMarkerSub = new(
         new Dictionary<string, TypeInfo>
         {
-            ["'variance"] = new TypeInfo.Primitive(Parsing.TokenType.TYPE_STRING),
-            ["'sub"] = new TypeInfo.Primitive(Parsing.TokenType.TYPE_STRING),
+            ["'variance"] = new TypeInfo.String(),
+            ["'sub"] = new TypeInfo.String(),
         }.ToFrozenDictionary());
 
     private Dictionary<TypeInfo.GenericInterface, TypeParameterVariance[]>? _measuredVariances;

--- a/TypeSystem/TypeChecker.Expressions.cs
+++ b/TypeSystem/TypeChecker.Expressions.cs
@@ -1731,8 +1731,8 @@ public partial class TypeChecker
         if (name.Lexeme == "undefined") return new TypeInfo.Undefined(); // Global undefined
         if (name.Lexeme == "NaN") return new TypeInfo.Primitive(TokenType.TYPE_NUMBER); // Global NaN
         if (name.Lexeme == "Infinity") return new TypeInfo.Primitive(TokenType.TYPE_NUMBER); // Global Infinity
-        if (name.Lexeme == "__dirname") return new TypeInfo.Primitive(TokenType.TYPE_STRING); // Node.js __dirname
-        if (name.Lexeme == "__filename") return new TypeInfo.Primitive(TokenType.TYPE_STRING); // Node.js __filename
+        if (name.Lexeme == "__dirname") return new TypeInfo.String(); // Node.js __dirname
+        if (name.Lexeme == "__filename") return new TypeInfo.String(); // Node.js __filename
         // CommonJS globals — bound by the CJS module wrapper at runtime. Treated as `any` because
         // CJS modules don't carry static type info for module.exports.
         if (name.Lexeme == "require") return new TypeInfo.Any();

--- a/TypeSystem/TypeChecker.Generics.Conditional.cs
+++ b/TypeSystem/TypeChecker.Generics.Conditional.cs
@@ -9,7 +9,7 @@ namespace SharpTS.TypeSystem;
 /// </summary>
 /// <remarks>
 /// Contains methods: EvaluateConditionalType, SubstituteWithoutConditionalEval,
-/// SubstituteTupleWithoutConditionalEval, DistributeConditionalOverUnion,
+/// DistributeConditionalOverUnion,
 /// CheckExtendsWithInfer, CheckExtendsRecursive, IsSameGenericDefinition,
 /// EvaluateIntrinsicStringType, ApplyStringManipulation, MatchTemplateLiteralWithInfer,
 /// MatchStringLiteralToTemplatePattern.
@@ -141,113 +141,12 @@ public partial class TypeChecker
 
     /// <summary>
     /// Substitutes type parameters without triggering conditional type evaluation (to avoid infinite recursion).
+    /// Thin wrapper over the shared <see cref="Substitute(TypeInfo, Dictionary{string, TypeInfo}, bool)"/> switch
+    /// with <c>evalConditionals: false</c> — see that method for the per-variant behaviour and why the two
+    /// substitution paths must share one switch (#1106).
     /// </summary>
     private TypeInfo SubstituteWithoutConditionalEval(TypeInfo type, Dictionary<string, TypeInfo> substitutions)
-    {
-        return type switch
-        {
-            TypeInfo.TypeParameter tp =>
-                substitutions.TryGetValue(tp.Name, out var sub) ? sub : type,
-            TypeInfo.Array arr =>
-                new TypeInfo.Array(SubstituteWithoutConditionalEval(arr.ElementType, substitutions)),
-            TypeInfo.Promise promise =>
-                new TypeInfo.Promise(SubstituteWithoutConditionalEval(promise.ValueType, substitutions)),
-            TypeInfo.Function func =>
-                new TypeInfo.Function(
-                    func.ParamTypes.Select(p => SubstituteWithoutConditionalEval(p, substitutions)).ToList(),
-                    SubstituteWithoutConditionalEval(func.ReturnType, substitutions),
-                    func.RequiredParams,
-                    func.HasRestParam),
-            TypeInfo.Tuple tuple =>
-                SubstituteTupleWithoutConditionalEval(tuple, substitutions),
-            TypeInfo.Union union =>
-                new TypeInfo.Union(union.Types.Select(t => SubstituteWithoutConditionalEval(t, substitutions)).ToList()),
-            TypeInfo.Record rec =>
-                SubstituteRecordMembers(rec, t => SubstituteWithoutConditionalEval(t, substitutions)),
-            TypeInfo.InstantiatedGeneric ig =>
-                new TypeInfo.InstantiatedGeneric(
-                    ig.GenericDefinition,
-                    ig.TypeArguments.Select(a => SubstituteWithoutConditionalEval(a, substitutions)).ToList()),
-            TypeInfo.KeyOf keyOf =>
-                new TypeInfo.KeyOf(SubstituteWithoutConditionalEval(keyOf.SourceType, substitutions)),
-            TypeInfo.TypeOf => type, // typeof doesn't contain type parameters, return as-is
-            TypeInfo.IndexedAccess ia =>
-                new TypeInfo.IndexedAccess(
-                    SubstituteWithoutConditionalEval(ia.ObjectType, substitutions),
-                    SubstituteWithoutConditionalEval(ia.IndexType, substitutions)),
-            TypeInfo.ConditionalType cond =>
-                new TypeInfo.ConditionalType(
-                    SubstituteWithoutConditionalEval(cond.CheckType, substitutions),
-                    SubstituteWithoutConditionalEval(cond.ExtendsType, substitutions),
-                    SubstituteWithoutConditionalEval(cond.TrueType, substitutions),
-                    SubstituteWithoutConditionalEval(cond.FalseType, substitutions))
-                { IsDistributive = cond.IsDistributive },
-            TypeInfo.InferredTypeParameter infer =>
-                substitutions.TryGetValue(infer.Name, out var inferSub)
-                    ? inferSub
-                    : infer.Constraint is { } inferConstraint
-                        ? infer with { Constraint = SubstituteWithoutConditionalEval(inferConstraint, substitutions) }
-                        : type,
-            _ => type
-        };
-    }
-
-    /// <summary>
-    /// Substitutes type parameters in a tuple without triggering conditional type evaluation.
-    /// Handles spread element flattening similar to SubstituteTupleWithFlattening.
-    /// </summary>
-    private TypeInfo SubstituteTupleWithoutConditionalEval(TypeInfo.Tuple tuple, Dictionary<string, TypeInfo> substitutions)
-    {
-        List<TypeInfo.TupleElement> newElements = [];
-        int newRequiredCount = 0;
-
-        foreach (var elem in tuple.Elements)
-        {
-            if (elem.Kind == TupleElementKind.Spread)
-            {
-                var substitutedInner = SubstituteWithoutConditionalEval(elem.Type, substitutions);
-
-                // Flatten if spread resolves to concrete tuple
-                if (substitutedInner is TypeInfo.Tuple innerTuple)
-                {
-                    foreach (var innerElem in innerTuple.Elements)
-                    {
-                        newElements.Add(innerElem);
-                        if (innerElem.Kind == TupleElementKind.Required)
-                            newRequiredCount++;
-                    }
-                    if (innerTuple.RestElementType != null)
-                    {
-                        newElements.Add(new TypeInfo.TupleElement(
-                            new TypeInfo.Array(innerTuple.RestElementType),
-                            TupleElementKind.Spread
-                        ));
-                    }
-                }
-                else if (substitutedInner is TypeInfo.Array arr)
-                {
-                    newElements.Add(new TypeInfo.TupleElement(arr, TupleElementKind.Spread, elem.Name));
-                }
-                else
-                {
-                    newElements.Add(new TypeInfo.TupleElement(substitutedInner, TupleElementKind.Spread, elem.Name));
-                }
-            }
-            else
-            {
-                var substitutedType = SubstituteWithoutConditionalEval(elem.Type, substitutions);
-                newElements.Add(new TypeInfo.TupleElement(substitutedType, elem.Kind, elem.Name));
-                if (elem.Kind == TupleElementKind.Required)
-                    newRequiredCount++;
-            }
-        }
-
-        var newRestType = tuple.RestElementType != null
-            ? SubstituteWithoutConditionalEval(tuple.RestElementType, substitutions)
-            : null;
-
-        return new TypeInfo.Tuple(newElements, newRequiredCount, newRestType);
-    }
+        => Substitute(type, substitutions, evalConditionals: false);
 
     /// <summary>
     /// Distributes a conditional type over a union type.

--- a/TypeSystem/TypeChecker.Generics.Substitution.cs
+++ b/TypeSystem/TypeChecker.Generics.Substitution.cs
@@ -32,78 +32,118 @@ public partial class TypeChecker
     }
 
     /// <summary>
-    /// Substitutes type parameters with concrete types.
+    /// Substitutes type parameters with concrete types, evaluating any conditional types reached.
     /// </summary>
     private TypeInfo Substitute(TypeInfo type, Dictionary<string, TypeInfo> substitutions)
+        => Substitute(type, substitutions, evalConditionals: true);
+
+    /// <summary>
+    /// Single recursive substitution switch shared by <see cref="Substitute(TypeInfo, Dictionary{string, TypeInfo})"/>
+    /// and <see cref="SubstituteWithoutConditionalEval"/>. The <paramref name="evalConditionals"/> flag is the ONLY
+    /// behavioural axis between the two callers:
+    /// <list type="bullet">
+    ///   <item>conditional types: evaluate now (<c>true</c>) vs. recurse into their parts without evaluating
+    ///         (<c>false</c>, the recursion-safe form used while a conditional is mid-evaluation);</item>
+    ///   <item>function parameter positions: marked as instantiated (<c>true</c>, gates the callback comparison
+    ///         rule) vs. left unmarked (<c>false</c>);</item>
+    ///   <item>records: rebuilt fields-only (<c>true</c> — see the NOTE) vs. signature/index preserving
+    ///         (<c>false</c>, which #316 needs so <c>T extends new (...) =&gt; infer U</c> can bind U);</item>
+    ///   <item>indexed access: concrete accesses collapsed to the member type (<c>true</c>) vs. left as a
+    ///         deferred node (<c>false</c>; the conditional machinery resolves these itself).</item>
+    /// </list>
+    /// Keeping ONE switch means a newly added <see cref="TypeInfo"/> variant is substituted on both paths —
+    /// the conditional copy previously fell through <c>SpreadType</c>/<c>MappedType</c>/<c>RecursiveTypeAlias</c>
+    /// to <c>_ =&gt; type</c>, silently returning a type parameter inside any of them un-substituted (#1106).
+    /// </summary>
+    private TypeInfo Substitute(TypeInfo type, Dictionary<string, TypeInfo> substitutions, bool evalConditionals)
     {
+        TypeInfo Sub(TypeInfo t) => Substitute(t, substitutions, evalConditionals);
         return type switch
         {
             TypeInfo.TypeParameter tp =>
                 substitutions.TryGetValue(tp.Name, out var sub) ? sub : type,
             TypeInfo.Array arr =>
-                new TypeInfo.Array(Substitute(arr.ElementType, substitutions)),
+                new TypeInfo.Array(Sub(arr.ElementType)),
             TypeInfo.Promise promise =>
-                new TypeInfo.Promise(Substitute(promise.ValueType, substitutions)),
+                new TypeInfo.Promise(Sub(promise.ValueType)),
             TypeInfo.Function func =>
                 new TypeInfo.Function(
-                    func.ParamTypes.Select(p => Substitute(p, substitutions)).ToList(),
-                    Substitute(func.ReturnType, substitutions),
+                    func.ParamTypes.Select(Sub).ToList(),
+                    Sub(func.ReturnType),
                     func.RequiredParams,
                     func.HasRestParam,
                     ThisType: null,
                     ParamNames: null,
-                    InstantiatedTypeParamPositions: MarkInstantiatedParamPositions(func, substitutions)),
+                    // Marking instantiated parameter positions gates the callback comparison rule; only the
+                    // assignability path (evalConditionals) needs it. The conditional path leaves them unmarked.
+                    InstantiatedTypeParamPositions: evalConditionals
+                        ? MarkInstantiatedParamPositions(func, substitutions)
+                        : null),
             TypeInfo.Tuple tuple =>
-                SubstituteTupleWithFlattening(tuple, substitutions),
+                SubstituteTupleWithFlattening(tuple, substitutions, evalConditionals),
             TypeInfo.SpreadType spread =>
-                new TypeInfo.SpreadType(Substitute(spread.Inner, substitutions)),
+                new TypeInfo.SpreadType(Sub(spread.Inner)),
             TypeInfo.Union union =>
-                new TypeInfo.Union(union.Types.Select(t => Substitute(t, substitutions)).ToList()),
-            // NOTE: fields only. Preserving call/construct signatures here would feed generic
-            // construct-signature *assignment* relating (which erases/instantiates via Substitute)
-            // types it does not yet compare correctly, regressing assignmentCompatWithConstructSignatures.
-            // The conditional-type path that #316 needs preserves them in SubstituteWithoutConditionalEval.
+                new TypeInfo.Union(union.Types.Select(Sub).ToList()),
+            // Assignability path (evalConditionals): fields only. Preserving call/construct signatures here
+            // would feed generic construct-signature *assignment* relating (which erases/instantiates via
+            // Substitute) types it does not yet compare correctly, regressing
+            // assignmentCompatWithConstructSignatures. The conditional-type path that #316 needs preserves
+            // them (SubstituteRecordMembers).
             TypeInfo.Record rec =>
-                new TypeInfo.Record(
-                    rec.Fields.ToDictionary(
-                        kvp => kvp.Key,
-                        kvp => Substitute(kvp.Value, substitutions)).ToFrozenDictionary()),
+                evalConditionals
+                    ? new TypeInfo.Record(
+                        rec.Fields.ToDictionary(
+                            kvp => kvp.Key,
+                            kvp => Sub(kvp.Value)).ToFrozenDictionary())
+                    : SubstituteRecordMembers(rec, Sub),
             TypeInfo.InstantiatedGeneric ig =>
                 new TypeInfo.InstantiatedGeneric(
                     ig.GenericDefinition,
-                    ig.TypeArguments.Select(a => Substitute(a, substitutions)).ToList()),
+                    ig.TypeArguments.Select(Sub).ToList()),
             // Handle new mapped type constructs
             TypeInfo.KeyOf keyOf =>
-                new TypeInfo.KeyOf(Substitute(keyOf.SourceType, substitutions)),
+                new TypeInfo.KeyOf(Sub(keyOf.SourceType)),
             TypeInfo.TypeOf => type, // typeof doesn't contain type parameters, return as-is
             TypeInfo.MappedType mapped =>
                 new TypeInfo.MappedType(
                     mapped.ParameterName,
-                    Substitute(mapped.Constraint, substitutions),
-                    Substitute(mapped.ValueType, substitutions),
+                    Sub(mapped.Constraint),
+                    Sub(mapped.ValueType),
                     mapped.Modifiers,
-                    mapped.AsClause != null ? Substitute(mapped.AsClause, substitutions) : null),
+                    mapped.AsClause != null ? Sub(mapped.AsClause) : null),
             TypeInfo.IndexedAccess ia =>
-                SimplifyConcreteIndexedAccess(
-                    Substitute(ia.ObjectType, substitutions),
-                    Substitute(ia.IndexType, substitutions)),
-            // Conditional types: evaluate with current substitutions
+                evalConditionals
+                    // Collapse a fully concrete access to the member type; a generic one stays deferred.
+                    ? SimplifyConcreteIndexedAccess(Sub(ia.ObjectType), Sub(ia.IndexType))
+                    // The conditional machinery resolves indexed accesses itself (EvaluateConditionalType),
+                    // so leave the node deferred here.
+                    : new TypeInfo.IndexedAccess(Sub(ia.ObjectType), Sub(ia.IndexType)),
+            // Conditional types: evaluate with current substitutions, or (recursion-safe form) substitute
+            // into the parts without evaluating — preserving distributivity.
             TypeInfo.ConditionalType cond =>
-                EvaluateConditionalType(cond, substitutions),
+                evalConditionals
+                    ? EvaluateConditionalType(cond, substitutions)
+                    : new TypeInfo.ConditionalType(
+                        Sub(cond.CheckType),
+                        Sub(cond.ExtendsType),
+                        Sub(cond.TrueType),
+                        Sub(cond.FalseType))
+                      { IsDistributive = cond.IsDistributive },
             // Inferred type parameters: substitute if bound, else keep as-is (substituting any
             // outer type parameters referenced by the constraint)
             TypeInfo.InferredTypeParameter infer =>
                 substitutions.TryGetValue(infer.Name, out var inferSub)
                     ? inferSub
                     : infer.Constraint is { } inferConstraint
-                        ? infer with { Constraint = Substitute(inferConstraint, substitutions) }
+                        ? infer with { Constraint = Sub(inferConstraint) }
                         : type,
             // Recursive type alias: substitute type arguments if present
             TypeInfo.RecursiveTypeAlias rta =>
                 rta.TypeArguments is { Count: > 0 }
                     ? new TypeInfo.RecursiveTypeAlias(
                         rta.AliasName,
-                        rta.TypeArguments.Select(a => Substitute(a, substitutions)).ToList())
+                        rta.TypeArguments.Select(Sub).ToList())
                     : rta,
             // Primitives, Any, Void, Never, Unknown, Null pass through unchanged
             _ => type
@@ -176,8 +216,10 @@ public partial class TypeChecker
     /// <summary>
     /// Substitutes type parameters in a tuple with flattening of spread elements.
     /// When a spread resolves to a concrete tuple, its elements are inlined.
+    /// <paramref name="evalConditionals"/> threads through to the element substitutions (see
+    /// <see cref="Substitute(TypeInfo, Dictionary{string, TypeInfo}, bool)"/>).
     /// </summary>
-    private TypeInfo SubstituteTupleWithFlattening(TypeInfo.Tuple tuple, Dictionary<string, TypeInfo> substitutions)
+    private TypeInfo SubstituteTupleWithFlattening(TypeInfo.Tuple tuple, Dictionary<string, TypeInfo> substitutions, bool evalConditionals)
     {
         List<TypeInfo.TupleElement> newElements = [];
         int newRequiredCount = 0;
@@ -186,7 +228,7 @@ public partial class TypeChecker
         {
             if (elem.Kind == TupleElementKind.Spread)
             {
-                var substitutedInner = Substitute(elem.Type, substitutions);
+                var substitutedInner = Substitute(elem.Type, substitutions, evalConditionals);
 
                 // Flatten if spread resolves to concrete tuple
                 if (substitutedInner is TypeInfo.Tuple innerTuple)
@@ -219,7 +261,7 @@ public partial class TypeChecker
             }
             else
             {
-                var substitutedType = Substitute(elem.Type, substitutions);
+                var substitutedType = Substitute(elem.Type, substitutions, evalConditionals);
                 newElements.Add(new TypeInfo.TupleElement(substitutedType, elem.Kind, elem.Name));
                 if (elem.Kind == TupleElementKind.Required)
                     newRequiredCount++;
@@ -227,7 +269,7 @@ public partial class TypeChecker
         }
 
         var newRestType = tuple.RestElementType != null
-            ? Substitute(tuple.RestElementType, substitutions)
+            ? Substitute(tuple.RestElementType, substitutions, evalConditionals)
             : null;
 
         return new TypeInfo.Tuple(newElements, newRequiredCount, newRestType);

--- a/TypeSystem/TypeInfo.cs
+++ b/TypeSystem/TypeInfo.cs
@@ -132,8 +132,32 @@ public abstract record TypeInfo
         }
     }
 
-    public record Primitive(TokenType Type) : TypeInfo
+    public record Primitive : TypeInfo
     {
+        private readonly TokenType _type;
+
+        public Primitive(TokenType type) => Type = type; // routes through the validating init accessor
+
+        /// <summary>
+        /// The primitive token. <c>string</c> is intentionally NOT representable here — it has a
+        /// dedicated <see cref="TypeInfo.String"/>. A <c>Primitive(TYPE_STRING)</c> value is matched by
+        /// neither the <c>is TypeInfo.String or StringLiteral</c> type-guards (so <c>typeof x === "string"</c>
+        /// narrowing silently fails) nor several compiled-path string switches, so the vestigial
+        /// representation is forbidden at construction (#1108).
+        /// </summary>
+        public TokenType Type
+        {
+            get => _type;
+            init => _type = value != TokenType.TYPE_STRING
+                ? value
+                : throw new ArgumentException(
+                    "Use TypeInfo.String for the 'string' type; Primitive(TYPE_STRING) is forbidden — " +
+                    "it is not matched by typeof type-guards (#1108).",
+                    nameof(value));
+        }
+
+        public void Deconstruct(out TokenType Type) => Type = _type;
+
         public override string ToString() => Type.ToString().Replace("TYPE_", "").ToLower();
     }
     


### PR DESCRIPTION
Fixes the latent **correctness bugs** the maintainability audit surfaced under epic #1088 — each produced a wrong result or silently swallowed a construct, sharing the root cause of "a base default that silently falls back" plus drifted algorithm copies.

#1105 (the fifth child) was already closed. This PR lands the remaining four.

## #1107 — AstVisitorBase fails loud on unhandled nodes
`Visit(Expr)`/`Visit(Stmt)` had no `default` arm, so a newly added AST node nobody wired was silently skipped by the ~20 analyzers built on `AstVisitorBase`. Added `default: throw`. Every concrete `Expr`/`Stmt` record (all in `AST.cs`) is already covered, so the arm only fires for a genuinely new, unwired node.

## #1106 — Unify the two substitution copies
`SubstituteWithoutConditionalEval` omitted `SpreadType`/`MappedType`/`RecursiveTypeAlias` (fell to `_ => type`), returning a type parameter inside any of them **un-substituted** on the conditional path. Folded both copies into one `Substitute(type, subs, bool evalConditionals)` switch — the flag is the only behavioural axis. Adding a `TypeInfo` variant now updates exactly one switch. Behaviour is otherwise identical (the three dropped kinds are now substituted on both paths).

## #1108 — Forbid vestigial `Primitive(TYPE_STRING)`
`string` has a dedicated `TypeInfo.String`; the typeof guards test `is TypeInfo.String or StringLiteral`, which `Primitive(TYPE_STRING)` matches **neither** — so `typeof __dirname === "string"` narrowed `__dirname` to `never` instead of `string`.
- Forbid `Primitive(TYPE_STRING)` at construction (validating accessor) — the requested assert.
- Replace construction sites with `TypeInfo.String` (`__dirname`/`__filename`, variance markers).
- `ObjectLocalPromotionAnalyzer.ClassifyKind` matched only the never-constructed `Primitive(TYPE_STRING)`, so string-field object locals were never promoted (same drift bug) — now matches `TypeInfo.String`; the shape-struct emitter already emits a `String` slot (IL verified, standalone preserved).
- Drop the now-dead `Primitive(TYPE_STRING)` arms in `ExternalMethodResolver`/`UnionTypeGenerator` (both already handle `TypeInfo.String`).

## #1109 — Clarify compiled `parentPort` null is correct (not a stub)
`EmitParentPort` emitted `ldnull` with a "for now" comment that read like an unimplemented gap. It is in fact **correct**: `parentPort` is null on the main thread in Node, and a worker body never runs as compiled code (`SharpTSWorker.RunWorkerScript` runs the worker file under a fresh interpreter that binds the real `parentPort` via `SetupWorkerGlobals`). So this path is only ever reached on the main thread. Wiring a `$MessagePort` would be wrong (none exists in compiled mode); throwing would break the canonical `if (parentPort)` main-thread guard. Replaced the comment with the accurate rationale and added a dual-mode test.

## Verification
- `dotnet test` (full xUnit): **14698 passed, 0 failed**
- TypeScript conformance: no baseline regression (exit 0)
- Test262 (interp + compiled): baseline diff **20/0** (the host-teardown crash on exit is a pre-existing event-loop flake, unrelated — touches neither the event loop nor teardown)
- New string-slot path: IL `--verify` passes; `--standalone` DLL runs with no `SharpTS.dll` dependency
- Added dual-mode tests where applicable (`PrimitiveStringTypeTests`, `WorkerThreadsTests.ParentPort_OnMainThread_IsNull`)

Closes #1106, closes #1107, closes #1108, closes #1109.
Part of #1088.