### PR TITLE
Epic #1095: Build & project-structure hygiene (#1144, #1145, #1146, #1149)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -504,12 +504,20 @@ The compilation directory has grown substantially. Key organizational patterns:
 | `TypeInspector.cs` | Type introspection |
 | `TypeScriptEmitter.cs` | TypeScript syntax emission |
 
-**Language Server Protocol** (`LspBridge/`):
+**Language Server Protocol** (`SharpTS.LanguageServer/`):
+
+A standalone OmniSharp-based LSP server, distributed as its own `sharpts-lsp` dotnet
+tool (separate from the core `sharpts` compiler — OmniSharp never ships in `SharpTS.dll`).
+It drives live diagnostics, hover, completion, and signature help over SharpTS's own
+`TypeChecker`. Replaced the former bespoke `LspBridge/` JSON protocol (see
+`docs/plans/lsp-server.md`).
+
 | File | Purpose |
 |------|---------|
-| `LspBridge.cs` | Main LSP bridge |
-| `Handlers/*.cs` | Command handlers for IDE features |
-| `Protocol/*.cs` | Request/response models |
+| `SharpTSLanguageServer.cs` | Server bootstrap / capability registration |
+| `Handlers/*.cs` | LSP handlers (completion, hover, signature help, text-document sync) |
+| `Services/*.cs` | Diagnostics, decorator, interop, and member-hover services |
+| `Conversions/`, `PositionMap.cs`, `DocumentStore.cs` | LSP ↔ SharpTS model conversions and document state |
 
 **MSBuild Integration** (`SharpTS.Sdk.Tasks/`):
 | File | Purpose |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ Source → Lexer → Parser → TypeChecker → Interpreter (tree-walk)
 | `Packaging/` | NuGet package generation |
 | `Cli/` | Command-line argument parsing |
 | `Declaration/` | TypeScript declaration generation from .NET types |
-| `LspBridge/` | Language Server Protocol bridge for IDE integration |
+| `SharpTS.LanguageServer/` | Standalone OmniSharp-based LSP server (`sharpts-lsp` tool) for IDE integration |
 | `SharpTS.Tests/` | xUnit test project |
 
 ### Critical Architecture Patterns
@@ -125,13 +125,20 @@ var method = typeof(RuntimeTypes).GetMethod("SomeMethod");
 il.Emit(OpCodes.Call, method);
 ```
 
-**Instead, use reflection-based IL that resolves at runtime:**
+**Instead, emit reflection-based IL that resolves the type at runtime via
+`Type.GetType("…, SharpTS")`.** The `RuntimeEmitter.*` partials provide per-feature
+helpers that already follow this pattern — reuse the closest one rather than calling
+`typeof(...)` directly. For example:
 ```csharp
-// GOOD - uses RuntimeEmitter helper methods
-EmitReflectionCall(il, "SharpTS.Compilation.RuntimeTypes, SharpTS", "SomeMethod", argCount);
-// or for void methods:
-EmitReflectionCallVoid(il, "SharpTS.Compilation.RuntimeTypes, SharpTS", "SomeMethod", argCount);
+// GOOD - defines a static helper on the emitted runtime type whose body does
+// Type.GetType("SharpTS.Compilation.RuntimeTypes, SharpTS").GetMethod(name).Invoke(...)
+runtime.SomeMethod = EmitReflectionHelper(typeBuilder, "SomeMethod", argCount);
 ```
+Other variants emit the same late-bound `Type.GetType("…, SharpTS")` dispatch inline
+(e.g. `EmitVmReflectionCall` in `RuntimeEmitter.VmHelpers.cs`,
+`EmitReflectionConstructFromType` in `ILEmitter.Calls.Constructors.cs`). When no
+existing helper fits, add one alongside them — never reference a SharpTS type via a
+metadata token.
 
 The same applies to `PropertyDescriptorStore`, `ObjectBuiltIns`, and any other SharpTS types.
 

--- a/Compilation/Emitters/Modules/ProcessModuleEmitter.cs
+++ b/Compilation/Emitters/Modules/ProcessModuleEmitter.cs
@@ -195,36 +195,19 @@ public sealed class ProcessModuleEmitter : IBuiltInModuleEmitter
     }
 
     /// <summary>
-    /// Emits an object[] array with remaining arguments starting from startIndex.
+    /// Emits an object[] array with the remaining arguments starting from startIndex,
+    /// expanding any <see cref="Expr.Spread"/> (<c>...args</c>) at runtime via the shared
+    /// spread-aware builder. Leaves an <c>object[]</c> on the stack. Forwarding spreads
+    /// here is what lets <c>process.nextTick</c>'s TS facade pass <c>...args</c> straight
+    /// through instead of hand-unrolling an arity ladder (#1149).
     /// </summary>
     private static void EmitArgsArray(IEmitterContext emitter, List<Expr> arguments, int startIndex)
     {
-        var ctx = emitter.Context;
-        var il = ctx.IL;
-
         int extraArgCount = Math.Max(0, arguments.Count - startIndex);
-
-        if (extraArgCount > 0)
-        {
-            // Create array with remaining arguments
-            il.Emit(OpCodes.Ldc_I4, extraArgCount);
-            il.Emit(OpCodes.Newarr, ctx.Types.Object);
-
-            for (int i = startIndex; i < arguments.Count; i++)
-            {
-                il.Emit(OpCodes.Dup);
-                il.Emit(OpCodes.Ldc_I4, i - startIndex);
-                emitter.EmitExpression(arguments[i]);
-                emitter.EmitBoxIfNeeded(arguments[i]);
-                il.Emit(OpCodes.Stelem_Ref);
-            }
-        }
-        else
-        {
-            // Empty args array
-            il.Emit(OpCodes.Ldc_I4_0);
-            il.Emit(OpCodes.Newarr, ctx.Types.Object);
-        }
+        var extra = extraArgCount > 0
+            ? arguments.GetRange(startIndex, extraArgCount)
+            : new List<Expr>();
+        emitter.EmitArgsArrayWithSpread(extra);
     }
 
     #endregion

--- a/Compilation/Emitters/Modules/TimersPrimitiveEmitter.cs
+++ b/Compilation/Emitters/Modules/TimersPrimitiveEmitter.cs
@@ -198,35 +198,18 @@ public sealed class TimersPrimitiveEmitter : IBuiltInModuleEmitter
     }
 
     /// <summary>
-    /// Emits an object[] array with remaining arguments starting from startIndex.
+    /// Emits an object[] array with the remaining arguments starting from startIndex,
+    /// expanding any <see cref="Expr.Spread"/> (<c>...args</c>) at runtime via the shared
+    /// spread-aware builder. Leaves an <c>object[]</c> on the stack. Forwarding spreads
+    /// here is what lets <c>stdlib/node/timers.ts</c> pass <c>...args</c> straight through
+    /// instead of hand-unrolling an arity ladder (#1149).
     /// </summary>
     private static void EmitArgsArray(IEmitterContext emitter, List<Expr> arguments, int startIndex)
     {
-        var ctx = emitter.Context;
-        var il = ctx.IL;
-
         int extraArgCount = Math.Max(0, arguments.Count - startIndex);
-
-        if (extraArgCount > 0)
-        {
-            // Create array with remaining arguments
-            il.Emit(OpCodes.Ldc_I4, extraArgCount);
-            il.Emit(OpCodes.Newarr, ctx.Types.Object);
-
-            for (int i = startIndex; i < arguments.Count; i++)
-            {
-                il.Emit(OpCodes.Dup);
-                il.Emit(OpCodes.Ldc_I4, i - startIndex);
-                emitter.EmitExpression(arguments[i]);
-                emitter.EmitBoxIfNeeded(arguments[i]);
-                il.Emit(OpCodes.Stelem_Ref);
-            }
-        }
-        else
-        {
-            // Empty args array
-            il.Emit(OpCodes.Ldc_I4_0);
-            il.Emit(OpCodes.Newarr, ctx.Types.Object);
-        }
+        var extra = extraArgCount > 0
+            ? arguments.GetRange(startIndex, extraArgCount)
+            : new List<Expr>();
+        emitter.EmitArgsArrayWithSpread(extra);
     }
 }

--- a/Compilation/Emitters/ProcessStaticEmitter.cs
+++ b/Compilation/Emitters/ProcessStaticEmitter.cs
@@ -301,36 +301,17 @@ public sealed class ProcessStaticEmitter : IStaticTypeEmitterStrategy
     }
 
     /// <summary>
-    /// Emits an object[] array with remaining arguments starting from startIndex.
+    /// Emits an object[] array with the remaining arguments starting from startIndex,
+    /// expanding any <see cref="Expr.Spread"/> (<c>...args</c>) at runtime via the shared
+    /// spread-aware builder. Leaves an <c>object[]</c> on the stack (#1149).
     /// </summary>
     private static void EmitArgsArray(IEmitterContext emitter, List<Expr> arguments, int startIndex)
     {
-        var ctx = emitter.Context;
-        var il = ctx.IL;
-
         int extraArgCount = Math.Max(0, arguments.Count - startIndex);
-
-        if (extraArgCount > 0)
-        {
-            // Create array with remaining arguments
-            il.Emit(OpCodes.Ldc_I4, extraArgCount);
-            il.Emit(OpCodes.Newarr, ctx.Types.Object);
-
-            for (int i = startIndex; i < arguments.Count; i++)
-            {
-                il.Emit(OpCodes.Dup);
-                il.Emit(OpCodes.Ldc_I4, i - startIndex);
-                emitter.EmitExpression(arguments[i]);
-                emitter.EmitBoxIfNeeded(arguments[i]);
-                il.Emit(OpCodes.Stelem_Ref);
-            }
-        }
-        else
-        {
-            // Empty args array
-            il.Emit(OpCodes.Ldc_I4_0);
-            il.Emit(OpCodes.Newarr, ctx.Types.Object);
-        }
+        var extra = extraArgCount > 0
+            ? arguments.GetRange(startIndex, extraArgCount)
+            : new List<Expr>();
+        emitter.EmitArgsArrayWithSpread(extra);
     }
 
     /// <summary>

--- a/Diagnostics/IDiagnosticResult.cs
+++ b/Diagnostics/IDiagnosticResult.cs
@@ -1,0 +1,50 @@
+// =============================================================================
+// IDiagnosticResult.cs - Shared diagnostics contract + projection logic
+// =============================================================================
+
+namespace SharpTS.Diagnostics;
+
+/// <summary>
+/// A phase result (e.g. <see cref="ParseDiagnosticResult"/>,
+/// <see cref="TypeCheckDiagnosticResult"/>) that carries the diagnostics collected
+/// during that phase, plus the common success/error projections over them.
+/// </summary>
+/// <remarks>
+/// The projection bodies live once in <see cref="DiagnosticResults"/>; each result type
+/// exposes them as instance properties that forward to it, so the logic is no longer
+/// copied per result type while concrete-type access (<c>result.IsSuccess</c>) keeps
+/// working without an extra <c>using</c> at every call site.
+/// </remarks>
+public interface IDiagnosticResult
+{
+    /// <summary>All diagnostics collected during the phase.</summary>
+    IReadOnlyList<Diagnostic> Diagnostics { get; }
+
+    /// <summary>Gets whether the phase succeeded without errors.</summary>
+    bool IsSuccess { get; }
+
+    /// <summary>Gets only the error diagnostics.</summary>
+    IEnumerable<Diagnostic> Errors { get; }
+
+    /// <summary>Gets the count of errors.</summary>
+    int ErrorCount { get; }
+}
+
+/// <summary>
+/// Single source of truth for the success/error projections shared by every
+/// <see cref="IDiagnosticResult"/>.
+/// </summary>
+public static class DiagnosticResults
+{
+    /// <summary>Whether the supplied diagnostics contain no errors.</summary>
+    public static bool IsSuccess(IReadOnlyList<Diagnostic> diagnostics) =>
+        !diagnostics.Any(d => d.Severity == DiagnosticSeverity.Error);
+
+    /// <summary>Only the error diagnostics.</summary>
+    public static IEnumerable<Diagnostic> Errors(IReadOnlyList<Diagnostic> diagnostics) =>
+        diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error);
+
+    /// <summary>The count of error diagnostics.</summary>
+    public static int ErrorCount(IReadOnlyList<Diagnostic> diagnostics) =>
+        diagnostics.Count(d => d.Severity == DiagnosticSeverity.Error);
+}

--- a/Diagnostics/ParseDiagnosticResult.cs
+++ b/Diagnostics/ParseDiagnosticResult.cs
@@ -16,20 +16,14 @@ public record ParseDiagnosticResult(
     List<Stmt> Statements,
     IReadOnlyList<Diagnostic> Diagnostics,
     bool HitErrorLimit = false
-)
+) : IDiagnosticResult
 {
-    /// <summary>
-    /// Gets whether parsing succeeded without errors.
-    /// </summary>
-    public bool IsSuccess => !Diagnostics.Any(d => d.Severity == DiagnosticSeverity.Error);
+    /// <summary>Gets whether parsing succeeded without errors.</summary>
+    public bool IsSuccess => DiagnosticResults.IsSuccess(Diagnostics);
 
-    /// <summary>
-    /// Gets only the error diagnostics.
-    /// </summary>
-    public IEnumerable<Diagnostic> Errors => Diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error);
+    /// <summary>Gets only the error diagnostics.</summary>
+    public IEnumerable<Diagnostic> Errors => DiagnosticResults.Errors(Diagnostics);
 
-    /// <summary>
-    /// Gets the count of errors.
-    /// </summary>
-    public int ErrorCount => Diagnostics.Count(d => d.Severity == DiagnosticSeverity.Error);
+    /// <summary>Gets the count of errors.</summary>
+    public int ErrorCount => DiagnosticResults.ErrorCount(Diagnostics);
 }

--- a/Diagnostics/TypeCheckDiagnosticResult.cs
+++ b/Diagnostics/TypeCheckDiagnosticResult.cs
@@ -16,20 +16,14 @@ public record TypeCheckDiagnosticResult(
     TypeMap TypeMap,
     IReadOnlyList<Diagnostic> Diagnostics,
     bool HitErrorLimit = false
-)
+) : IDiagnosticResult
 {
-    /// <summary>
-    /// Gets whether type checking succeeded without errors.
-    /// </summary>
-    public bool IsSuccess => !Diagnostics.Any(d => d.Severity == DiagnosticSeverity.Error);
+    /// <summary>Gets whether type checking succeeded without errors.</summary>
+    public bool IsSuccess => DiagnosticResults.IsSuccess(Diagnostics);
 
-    /// <summary>
-    /// Gets only the error diagnostics.
-    /// </summary>
-    public IEnumerable<Diagnostic> Errors => Diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error);
+    /// <summary>Gets only the error diagnostics.</summary>
+    public IEnumerable<Diagnostic> Errors => DiagnosticResults.Errors(Diagnostics);
 
-    /// <summary>
-    /// Gets the count of errors.
-    /// </summary>
-    public int ErrorCount => Diagnostics.Count(d => d.Severity == DiagnosticSeverity.Error);
+    /// <summary>Gets the count of errors.</summary>
+    public int ErrorCount => DiagnosticResults.ErrorCount(Diagnostics);
 }

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,17 +1,29 @@
 <Project>
   <PropertyGroup>
-    <!-- Shared version across all packages -->
-    <Version>1.0.0</Version>
+    <!-- Target framework + C# language settings shared by every project in the repo.
+         Individual projects only override these when they have a concrete reason to. -->
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
 
-    <!-- Shared metadata -->
+    <!-- Single version source of truth: MinVer derives the version from Git tags
+         (prefix `v`) for every packable project, replacing the former hard-coded
+         <Version>. At release time CI passes -p:Version explicitly to `dotnet pack`
+         to pin the published artifacts to the exact tag (.github/workflows/publish.yml);
+         that override and MinVer agree because the tagged commit is HEAD. -->
+    <MinVerTagPrefix>v</MinVerTagPrefix>
+
+    <!-- Shared package metadata -->
     <Authors>Nick B. Nassiri</Authors>
     <PackageProjectUrl>https://github.com/nickna/SharpTS</PackageProjectUrl>
     <RepositoryUrl>https://github.com/nickna/SharpTS.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
-
-    <!-- Build settings -->
-    <LangVersion>latest</LangVersion>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Repo-wide automatic versioning from Git tags. Build-time only (PrivateAssets=All). -->
+    <PackageReference Include="MinVer" Version="6.0.0" PrivateAssets="All" />
+  </ItemGroup>
 </Project>

--- a/Examples/Interop/SharpTS.Example.Interop.csproj
+++ b/Examples/Interop/SharpTS.Example.Interop.csproj
@@ -2,9 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net10.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
+    <!-- TargetFramework / ImplicitUsings / Nullable inherited from Directory.Build.props. -->
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/SharpTS.LanguageServer/SharpTS.LanguageServer.csproj
+++ b/SharpTS.LanguageServer/SharpTS.LanguageServer.csproj
@@ -2,9 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net10.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
+    <!-- TargetFramework / ImplicitUsings / Nullable inherited from Directory.Build.props. -->
 
     <!-- Distributed as its own dotnet tool (separate from the `sharpts` compiler tool),
          so OmniSharp lives only here and never in the core SharpTS package/tool. -->

--- a/SharpTS.Microbenchmarks/SharpTS.Microbenchmarks.csproj
+++ b/SharpTS.Microbenchmarks/SharpTS.Microbenchmarks.csproj
@@ -2,9 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net10.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
+    <!-- TargetFramework / ImplicitUsings / Nullable inherited from Directory.Build.props. -->
     <IsPackable>false</IsPackable>
 
     <!-- Pinned explicitly so embedded-resource names (referenced by string in

--- a/SharpTS.Sdk.Tasks/SharpTS.Sdk.Tasks.csproj
+++ b/SharpTS.Sdk.Tasks/SharpTS.Sdk.Tasks.csproj
@@ -1,12 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <!-- TargetFramework / Nullable / LangVersion inherited from Directory.Build.props. -->
 
     <!-- This is an MSBuild tasks assembly, not a standalone app -->
     <OutputType>Library</OutputType>
 
-    <!-- C# language version -->
-    <LangVersion>14</LangVersion>
+    <!-- Opt out of the repo-wide ImplicitUsings: the implicit `global using
+         System.Threading.Tasks;` would make the unqualified `Task` base class
+         (Microsoft.Build.Utilities.Task) ambiguous in ReadTsConfigTask. -->
+    <ImplicitUsings>disable</ImplicitUsings>
 
     <!-- Sign the assembly for use in MSBuild -->
     <SignAssembly>false</SignAssembly>

--- a/SharpTS.Sdk/SharpTS.Sdk.csproj
+++ b/SharpTS.Sdk/SharpTS.Sdk.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
-    <LangVersion>14</LangVersion>
+    <!-- TargetFramework / LangVersion inherited from Directory.Build.props.
+         This project has no compiled sources (IncludeBuildOutput=false); it only
+         packages the SDK files + bundled tool output. -->
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/SharpTS.Test262.Worker/SharpTS.Test262.Worker.csproj
+++ b/SharpTS.Test262.Worker/SharpTS.Test262.Worker.csproj
@@ -12,9 +12,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net10.0</TargetFramework>
-    <Nullable>enable</Nullable>
-    <ImplicitUsings>enable</ImplicitUsings>
+    <!-- TargetFramework / ImplicitUsings / Nullable inherited from Directory.Build.props. -->
     <RootNamespace>SharpTS.Test262.Worker</RootNamespace>
     <AssemblyName>SharpTS.Test262.Worker</AssemblyName>
     <!-- Server GC: workers do back-to-back compile + ALC unload — workstation GC's

--- a/SharpTS.Test262/SharpTS.Test262.csproj
+++ b/SharpTS.Test262/SharpTS.Test262.csproj
@@ -10,9 +10,7 @@
   -->
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
+    <!-- TargetFramework / ImplicitUsings / Nullable inherited from Directory.Build.props. -->
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <!-- Server GC: per-test compile + ALC unload churn benefits from per-core heaps and

--- a/SharpTS.Tests/BuildTests/ProjectStructureTests.cs
+++ b/SharpTS.Tests/BuildTests/ProjectStructureTests.cs
@@ -1,0 +1,80 @@
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace SharpTS.Tests.BuildTests;
+
+/// <summary>
+/// Guards the hand-maintained source-exclusion list in the root <c>SharpTS.csproj</c>.
+///
+/// The core library's project file sits at the repository root, so the SDK's default
+/// <c>**/*.cs</c> glob would otherwise compile every sibling project's sources into
+/// <c>SharpTS.dll</c>. A &lt;Compile Remove&gt; block keeps them out, but it must be
+/// edited whenever a new top-level project is added. The build itself fails fast via the
+/// <c>GuardAgainstForeignProjectSources</c> MSBuild target (see <c>SharpTS.csproj</c>);
+/// this test is the cheap, CI-visible mirror of that invariant so a missing exclusion is
+/// also surfaced as a plain test failure (issue #1144).
+/// </summary>
+public class ProjectStructureTests
+{
+    [Fact]
+    public void EverySiblingProject_IsExcludedFromCoreCompilation()
+    {
+        var repoRoot = FindRepoRoot();
+        var coreCsproj = Path.Combine(repoRoot, "SharpTS.csproj");
+        var csprojText = File.ReadAllText(coreCsproj);
+
+        // Directory prefixes the core explicitly removes, e.g. <Compile Remove="SharpTS.Tests/**" />.
+        var excludedPrefixes = Regex.Matches(csprojText, """<Compile Remove="([^"]+?)/\*\*"\s*/>""")
+            .Select(m => m.Groups[1].Value.Replace('\\', '/').TrimEnd('/'))
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        // Every sibling project directory under the repo root (the core project, build
+        // output, and the external submodules excluded — the submodules carry no .cs).
+        var siblingProjects = Directory
+            .EnumerateFiles(repoRoot, "*.csproj", SearchOption.AllDirectories)
+            .Where(p => !string.Equals(p, coreCsproj, StringComparison.OrdinalIgnoreCase))
+            .Where(p => !IsUnder(repoRoot, p, "external", "bin", "obj"))
+            .ToList();
+
+        Assert.NotEmpty(siblingProjects); // sanity: discovery actually found the sibling projects
+
+        var uncovered = new List<string>();
+        foreach (var proj in siblingProjects)
+        {
+            var relDir = Path.GetRelativePath(repoRoot, Path.GetDirectoryName(proj)!)
+                .Replace('\\', '/');
+            bool covered = excludedPrefixes.Any(prefix =>
+                relDir.Equals(prefix, StringComparison.OrdinalIgnoreCase) ||
+                relDir.StartsWith(prefix + "/", StringComparison.OrdinalIgnoreCase));
+            if (!covered)
+                uncovered.Add(relDir);
+        }
+
+        Assert.True(uncovered.Count == 0,
+            "These sibling project directories are not covered by a <Compile Remove> entry in " +
+            "SharpTS.csproj, so their sources would compile into SharpTS.dll:\n  " +
+            string.Join("\n  ", uncovered));
+    }
+
+    private static bool IsUnder(string repoRoot, string path, params string[] topLevelDirs)
+    {
+        var rel = Path.GetRelativePath(repoRoot, path).Replace('\\', '/');
+        return topLevelDirs.Any(d =>
+            rel.StartsWith(d + "/", StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static string FindRepoRoot()
+    {
+        var dir = AppContext.BaseDirectory;
+        while (dir != null)
+        {
+            if (Directory.Exists(Path.Combine(dir, "Compilation")) &&
+                File.Exists(Path.Combine(dir, "SharpTS.csproj")))
+            {
+                return dir;
+            }
+            dir = Path.GetDirectoryName(dir);
+        }
+        throw new InvalidOperationException("Could not find repository root");
+    }
+}

--- a/SharpTS.Tests/CompilerTests/StandaloneDllTests.cs
+++ b/SharpTS.Tests/CompilerTests/StandaloneDllTests.cs
@@ -49,7 +49,8 @@ public class StandaloneDllTests
     /// SharpTS types that would embed assembly references in emitted IL.
     ///
     /// WRONG: typeof(RuntimeTypes).GetMethod(...) - embeds SharpTS.dll reference
-    /// RIGHT: EmitReflectionCall(il, "SharpTS.Compilation.RuntimeTypes, SharpTS", ...) - runtime lookup
+    /// RIGHT: EmitReflectionHelper(typeBuilder, "SomeMethod", argCount) - emits a
+    ///        Type.GetType("SharpTS.Compilation.RuntimeTypes, SharpTS") runtime lookup
     /// </summary>
     [Fact]
     public void CompilationFiles_ShouldNotUseTypeofForEmittedIL()
@@ -103,7 +104,7 @@ public class StandaloneDllTests
 
         Assert.True(violations.Count == 0,
             $"Found {violations.Count} typeof() references that create SharpTS.dll dependencies in emitted IL.\n" +
-            $"Use EmitReflectionCall/EmitReflectionCallVoid instead.\n\n" +
+            $"Use a Type.GetType(\"…, SharpTS\") reflection helper (e.g. EmitReflectionHelper) instead.\n\n" +
             string.Join("\n", violations.Take(20)));
     }
 

--- a/SharpTS.Tests/SharedTests/BuiltInModules/ProcessNextTickTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/ProcessNextTickTests.cs
@@ -151,6 +151,55 @@ public class ProcessNextTickTests
         Assert.Equal("42\nhello\n", output);
     }
 
+    // Regression for #1149: the facade forwards `...args` to the primitive instead
+    // of hand-unrolling an arity ladder, so more than 8 trailing args now survive in
+    // both interpreter and compiled modes (the old ladder capped at 8).
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void NextTick_PassesArguments_BeyondEightArgs(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import { nextTick } from 'process';
+                let received: any[] = [];
+                nextTick((...rest: any[]) => { received = rest; },
+                    1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+                let start = Date.now();
+                while (Date.now() - start < 50) { }
+                console.log(received.length);
+                console.log(received.join(','));
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("10\n1,2,3,4,5,6,7,8,9,10\n", output);
+    }
+
+    // Regression for #1149: a caller-side spread (`...payload`) is expanded by the
+    // built-in module emitter rather than packed as a single nested-array element.
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void NextTick_ForwardsCallerSpread(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import { nextTick } from 'process';
+                let received: any[] = [];
+                const payload = ['a', 'b', 'c'];
+                nextTick((...rest: any[]) => { received = rest; }, ...payload);
+                let start = Date.now();
+                while (Date.now() - start < 50) { }
+                console.log(received.length);
+                console.log(received.join(','));
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("3\na,b,c\n", output);
+    }
+
     #endregion
 
     #region Multiple Callbacks Tests

--- a/SharpTS.Tests/SharedTests/BuiltInModules/TimersModuleTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/TimersModuleTests.cs
@@ -246,4 +246,56 @@ public class TimersModuleTests
     }
 
     #endregion
+
+    #region Trailing-Args Forwarding Tests
+
+    // Regression for #1149: the timers facade forwards `...args` to the primitive
+    // instead of hand-unrolling an arity ladder, so more than 8 trailing args now
+    // survive in both interpreter and compiled modes (the old ladder capped at 8).
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Timers_SetTimeout_ForwardsBeyondEightArgs(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import { setTimeout } from 'timers';
+                let received: any[] = [];
+                setTimeout((...rest: any[]) => { received = rest; }, 0,
+                    1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+                let start = Date.now();
+                while (Date.now() - start < 50) { }
+                console.log(received.length);
+                console.log(received.join(','));
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("10\n1,2,3,4,5,6,7,8,9,10\n", output);
+    }
+
+    // Regression for #1149: setImmediate forwards a caller-side spread (`...payload`).
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Timers_SetImmediate_ForwardsCallerSpread(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import { setImmediate } from 'timers';
+                let received: any[] = [];
+                const payload = ['a', 'b', 'c'];
+                setImmediate((...rest: any[]) => { received = rest; }, ...payload);
+                let start = Date.now();
+                while (Date.now() - start < 50) { }
+                console.log(received.length);
+                console.log(received.join(','));
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("3\na,b,c\n", output);
+    }
+
+    #endregion
 }

--- a/SharpTS.Tests/SharpTS.Tests.csproj
+++ b/SharpTS.Tests/SharpTS.Tests.csproj
@@ -1,9 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
+    <!-- TargetFramework / ImplicitUsings / Nullable inherited from Directory.Build.props. -->
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <!-- Server + Concurrent GC: the test workload is heavily multi-threaded (xUnit parallel

--- a/SharpTS.TypeScriptConformance/SharpTS.TypeScriptConformance.csproj
+++ b/SharpTS.TypeScriptConformance/SharpTS.TypeScriptConformance.csproj
@@ -11,9 +11,7 @@
   -->
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
+    <!-- TargetFramework / ImplicitUsings / Nullable inherited from Directory.Build.props. -->
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>

--- a/SharpTS.csproj
+++ b/SharpTS.csproj
@@ -2,12 +2,9 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net10.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-
-    <!-- Version (auto-detected from Git tags by MinVer) -->
-    <MinVerTagPrefix>v</MinVerTagPrefix>
+    <!-- TargetFramework / ImplicitUsings / Nullable / LangVersion and the MinVer
+         versioning config are inherited from Directory.Build.props. -->
 
     <!-- Tool packaging -->
     <PackAsTool>true</PackAsTool>
@@ -76,7 +73,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MinVer" Version="6.0.0" PrivateAssets="All" />
+    <!-- MinVer is inherited from Directory.Build.props (repo-wide versioning). -->
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     <PackageReference Include="NickNa.PEPacker" Version="1.0.2" />
     <PackageReference Include="System.Reflection.MetadataLoadContext" Version="9.0.0" />

--- a/SharpTS.csproj
+++ b/SharpTS.csproj
@@ -44,7 +44,11 @@
     <None Remove="stdlib\**\*.ts" />
   </ItemGroup>
 
-  <!-- Exclude test, example, benchmark, and SDK projects from this compilation -->
+  <!-- Exclude test, example, benchmark, and SDK projects from this compilation.
+       This list is hand-maintained and load-bearing: because this project sits at
+       the repo root, the SDK's default **/*.cs glob would otherwise pull in every
+       sibling project's sources. The GuardAgainstForeignProjectSources target below
+       fails the build if a sibling project is ever added without a matching entry. -->
   <ItemGroup>
     <Compile Remove="SharpTS.Tests/**" />
     <None Remove="SharpTS.Tests/**" />
@@ -71,6 +75,36 @@
     <Compile Remove="external/**" />
     <None Remove="external/**" />
   </ItemGroup>
+
+  <!--
+    Build-time guard for the exclusion list above. A new top-level project added
+    without a matching <Compile Remove> entry would silently compile foreign sources
+    into SharpTS.dll. This target fails the build if any .cs file belonging to a
+    sibling project's directory (one that has its own .csproj) leaks into @(Compile),
+    so a missing exclusion is caught immediately rather than shipped. The external/
+    submodules carry no .cs/.csproj and are skipped for speed. Bypass with
+    -p:DisableForeignSourceGuard=true.
+  -->
+  <Target Name="GuardAgainstForeignProjectSources"
+          BeforeTargets="CoreCompile"
+          Condition="'$(DisableForeignSourceGuard)' != 'true'">
+    <ItemGroup>
+      <!-- Sibling project files anywhere beneath the repo root (this project, the
+           build output, and the external submodules excluded). -->
+      <_GuardSiblingProject Include="$(MSBuildProjectDirectory)\**\*.csproj"
+                            Exclude="$(MSBuildProjectFullPath);$(MSBuildProjectDirectory)\external\**;$(MSBuildProjectDirectory)\bin\**;$(MSBuildProjectDirectory)\obj\**" />
+      <!-- Every .cs that lives under one of those sibling projects' directories. -->
+      <_GuardForeignSource Include="%(_GuardSiblingProject.RootDir)%(_GuardSiblingProject.Directory)**\*.cs" />
+      <!-- Set intersection Compile ∩ ForeignSource = foreign sources leaking in.
+           (A ∩ B == A minus (A minus B); Exclude matches on normalized full path.) -->
+      <_GuardCompileFull Include="@(Compile->'%(FullPath)')" />
+      <_GuardForeignFull Include="@(_GuardForeignSource->'%(FullPath)')" />
+      <_GuardCompileNotForeign Include="@(_GuardCompileFull)" Exclude="@(_GuardForeignFull)" />
+      <_GuardLeaked Include="@(_GuardCompileFull)" Exclude="@(_GuardCompileNotForeign)" />
+    </ItemGroup>
+    <Error Condition="'@(_GuardLeaked)' != ''"
+           Text="SharpTS.csproj is compiling source(s) that belong to a sibling project (its directory has its own .csproj). Add the directory to the &lt;Compile Remove&gt;/&lt;None Remove&gt; exclusion block in SharpTS.csproj. Leaked file(s): @(_GuardLeaked)" />
+  </Target>
 
   <ItemGroup>
     <!-- MinVer is inherited from Directory.Build.props (repo-wide versioning). -->

--- a/stdlib/node/process.ts
+++ b/stdlib/node/process.ts
@@ -82,23 +82,11 @@ export function memoryUsage(): { rss: number; heapTotal: number; heapUsed: numbe
     return __memoryUsage();
 }
 
-// `nextTick` cannot be wrapped with `...args` + spread-forwarded to the
-// primitive: the compiled `primitive:process` emitter's EmitNextTick packs
-// a single Expr.Spread as a nested-array element rather than expanding it,
-// so `__nextTick(callback, ...args)` drops the trailing args. Workaround:
-// manually dispatch by arity up to a reasonable limit (matches Node's
-// common usage pattern; a callback with more than 8 payload args is rare).
+// `nextTick` forwards its trailing `...args` straight to the primitive; the
+// built-in module emitters now expand a trailing `Expr.Spread` at runtime (see
+// ProcessModuleEmitter.EmitArgsArray), so there is no arity ceiling.
 export function nextTick(callback: any, ...args: any[]): void {
-    const n = args.length;
-    if (n === 0) __nextTick(callback);
-    else if (n === 1) __nextTick(callback, args[0]);
-    else if (n === 2) __nextTick(callback, args[0], args[1]);
-    else if (n === 3) __nextTick(callback, args[0], args[1], args[2]);
-    else if (n === 4) __nextTick(callback, args[0], args[1], args[2], args[3]);
-    else if (n === 5) __nextTick(callback, args[0], args[1], args[2], args[3], args[4]);
-    else if (n === 6) __nextTick(callback, args[0], args[1], args[2], args[3], args[4], args[5]);
-    else if (n === 7) __nextTick(callback, args[0], args[1], args[2], args[3], args[4], args[5], args[6]);
-    else __nextTick(callback, args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7]);
+    __nextTick(callback, ...args);
 }
 
 // Node's `process` module exposes its surface as both named exports and a

--- a/stdlib/node/timers.ts
+++ b/stdlib/node/timers.ts
@@ -7,12 +7,10 @@
 // infrastructure; importing here adds no semantic difference.
 //
 // Rest-arg note: the setTimeout / setInterval / setImmediate primitives pack
-// trailing callback args into an object[]. The TS facade below arity-dispatches
-// rather than spread-forwarding — a `__setTimeout(cb, delay, ...args)` call
-// into a primitive emitter hits the same compiler gap process.nextTick
-// documented (Expr.Spread not expanded by built-in module emitters). Flat
-// positional dispatch sidesteps it. The 8-arg ceiling matches Node's
-// practical usage; >8 callback payload args are vanishingly rare.
+// trailing callback args into an object[]. The facade forwards `...args`
+// straight through; the built-in module emitters expand a trailing
+// `Expr.Spread` at runtime (see TimersPrimitiveEmitter.EmitArgsArray), so there
+// is no arity ceiling.
 
 import {
     setTimeout as __setTimeout,
@@ -25,17 +23,7 @@ import {
 
 /** Schedules `callback` to run after `delay` ms with optional trailing args. */
 export function setTimeout(callback: any, delay?: number, ...args: any[]): any {
-    const d = delay ?? 0;
-    const n = args.length;
-    if (n === 0) return __setTimeout(callback, d);
-    if (n === 1) return __setTimeout(callback, d, args[0]);
-    if (n === 2) return __setTimeout(callback, d, args[0], args[1]);
-    if (n === 3) return __setTimeout(callback, d, args[0], args[1], args[2]);
-    if (n === 4) return __setTimeout(callback, d, args[0], args[1], args[2], args[3]);
-    if (n === 5) return __setTimeout(callback, d, args[0], args[1], args[2], args[3], args[4]);
-    if (n === 6) return __setTimeout(callback, d, args[0], args[1], args[2], args[3], args[4], args[5]);
-    if (n === 7) return __setTimeout(callback, d, args[0], args[1], args[2], args[3], args[4], args[5], args[6]);
-    return __setTimeout(callback, d, args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7]);
+    return __setTimeout(callback, delay ?? 0, ...args);
 }
 
 /** Cancels a pending timeout created by setTimeout. */
@@ -45,17 +33,7 @@ export function clearTimeout(handle?: any): void {
 
 /** Schedules `callback` to repeat every `delay` ms with optional trailing args. */
 export function setInterval(callback: any, delay?: number, ...args: any[]): any {
-    const d = delay ?? 0;
-    const n = args.length;
-    if (n === 0) return __setInterval(callback, d);
-    if (n === 1) return __setInterval(callback, d, args[0]);
-    if (n === 2) return __setInterval(callback, d, args[0], args[1]);
-    if (n === 3) return __setInterval(callback, d, args[0], args[1], args[2]);
-    if (n === 4) return __setInterval(callback, d, args[0], args[1], args[2], args[3]);
-    if (n === 5) return __setInterval(callback, d, args[0], args[1], args[2], args[3], args[4]);
-    if (n === 6) return __setInterval(callback, d, args[0], args[1], args[2], args[3], args[4], args[5]);
-    if (n === 7) return __setInterval(callback, d, args[0], args[1], args[2], args[3], args[4], args[5], args[6]);
-    return __setInterval(callback, d, args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7]);
+    return __setInterval(callback, delay ?? 0, ...args);
 }
 
 /** Cancels a pending interval created by setInterval. */
@@ -65,16 +43,7 @@ export function clearInterval(handle?: any): void {
 
 /** Schedules `callback` to run on the next event-loop iteration. */
 export function setImmediate(callback: any, ...args: any[]): any {
-    const n = args.length;
-    if (n === 0) return __setImmediate(callback);
-    if (n === 1) return __setImmediate(callback, args[0]);
-    if (n === 2) return __setImmediate(callback, args[0], args[1]);
-    if (n === 3) return __setImmediate(callback, args[0], args[1], args[2]);
-    if (n === 4) return __setImmediate(callback, args[0], args[1], args[2], args[3]);
-    if (n === 5) return __setImmediate(callback, args[0], args[1], args[2], args[3], args[4]);
-    if (n === 6) return __setImmediate(callback, args[0], args[1], args[2], args[3], args[4], args[5]);
-    if (n === 7) return __setImmediate(callback, args[0], args[1], args[2], args[3], args[4], args[5], args[6]);
-    return __setImmediate(callback, args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7]);
+    return __setImmediate(callback, ...args);
 }
 
 /** Cancels a pending immediate created by setImmediate. */


### PR DESCRIPTION
## Epic #1095 — Build & project-structure hygiene

Pays down the build/project-structure debt called out in the 2026-06-29 maintainability audit. Each sub-issue is a self-contained commit; isolated from the C# refactor tracks.

### #1146 — Fix project-doc drift _(commit 1)_
`CLAUDE.md` and `ARCHITECTURE.md` described a `LspBridge/` directory that no longer exists (migrated to the standalone OmniSharp-based `SharpTS.LanguageServer/` + `sharpts-lsp` tool), and `CLAUDE.md`'s Standalone DLL Constraint pointed contributors at a non-existent `EmitReflectionCall`/`EmitReflectionCallVoid` helper.
- Directory table + LSP section now describe `SharpTS.LanguageServer/`.
- The Standalone-DLL example references the **real** reflection helpers (`EmitReflectionHelper`, `EmitVmReflectionCall`, `EmitReflectionConstructFromType`).
- Reconciled the matching guidance string in `StandaloneDllTests` (message text only).

### #1149 — `IDiagnosticResult` dedup + timer/process arity ladders _(commit 2)_
1. **Dedup:** `ParseDiagnosticResult` and `TypeCheckDiagnosticResult` carried byte-identical `IsSuccess`/`Errors`/`ErrorCount` bodies. Extracted an `IDiagnosticResult` interface + single-source-of-truth `DiagnosticResults` helper; both records forward to it. (Instance forwarders rather than default-interface-members/extension-members, so `result.IsSuccess` on a `var` keeps compiling at every call site with no extra `using`.)
2. **Spread-forwarding gap:** the `timers.ts` (`setTimeout`/`setInterval`/`setImmediate`) and `process.ts` (`nextTick`) facades hand-unrolled an arity ladder capped at 8 args, because the built-in module emitters packed a trailing `Expr.Spread` as one nested-array element instead of expanding it. Routed those `EmitArgsArray` helpers through the shared, spread-aware `EmitArgsArrayWithSpread` (`ExpandCallArgs` is emitted unconditionally → standalone DLLs gain no `SharpTS.dll` dependency). The facades now forward `...args` directly, no ceiling.
- Dual-mode regression tests for >8 trailing args and caller-side spreads on `setTimeout`/`setImmediate`/`nextTick`. Interpreter ≡ compiled; IL verification passes.

### #1145 — Centralize MSBuild config + single-source versioning _(commit 3)_
`Directory.Build.props` was only half-adopted.
- Hoisted `TargetFramework` + `ImplicitUsings` into `Directory.Build.props`; dropped them (and the 7 redundant `Nullable` lines) from every project.
- Standardized `LangVersion`: removed the SDK projects' `14` pins → all inherit `latest` (== C# 14 on .NET 10, no behaviour change today).
- **Single version source of truth:** moved MinVer into `Directory.Build.props` and deleted the hard-coded `<Version>1.0.0</Version>`. Every packable project now derives its version from Git tags identically — verified core + `SharpTS.LanguageServer` both resolve `1.0.8-alpha.0.N` from `v1.0.7` (LanguageServer was previously stuck at `1.0.0`). CI's `-p:Version` still overrides at pack time.
- `SharpTS.Sdk.Tasks` opts out of `ImplicitUsings` (the implicit `System.Threading.Tasks` would make the MSBuild `Task` base class ambiguous).

### #1144 — Guard the root-csproj exclusion list _(commit 4)_
The issue prefers relocating the core into `src/SharpTS/`, but that has a large, hard-to-validate blast radius from this worktree (8 `ProjectReference` paths, the CI publish workflow, the `SharpTS.Sdk` relative packaging paths to `..\bin\Release\…\publish`, the benchmarks harness, embedded-stdlib resource naming, documented `dotnet run` ergonomics). Took the issue's **sanctioned alternative** ("if relocation is too disruptive, add a build-time check"):
- New `GuardAgainstForeignProjectSources` MSBuild target (`BeforeTargets=CoreCompile`) fails the build if any `.cs` under a sibling project's directory (one with its own `.csproj`) leaks into `@(Compile)`, naming the offending file. Verified both ways — passes on the current tree; fails with an actionable message when an un-excluded sibling project is added.
- `ProjectStructureTests`: fast, CI-visible xUnit mirror asserting every sibling `.csproj` directory is covered by a `<Compile Remove>` entry.

---

### Validation
- **`dotnet test` (full xUnit):** 14754 passed / 1 pre-existing load flake (`ClusterModuleTests.Fork_WorkersShareHttpPort` — real port binding under heavy parallel load; passes cleanly in isolation; untouched by this PR).
- **TypeScriptConformance:** 31/0, no baseline regression.
- **Test262:** interpreted baseline clean; compiled baseline reports **`0 regressions, 8 new passes`** — the new passes are the known run-to-run timeout-flip flake (these tests' baseline entries vary under machine load and are intentionally not baselined). This PR's changes emit byte-identical IL for every Test262 program (the timers/process spread fix only fires for programs importing those Node modules), so the new passes are not attributable to it. **No regressions.**
- Full solution + the three standalone conformance/Test262 projects all build clean. Standalone compiled DLLs verified to gain no `SharpTS.dll` dependency (`StandaloneDllTests` green; manual spread programs run standalone).

Closes #1144, #1145, #1146, #1149. Part of #1095.
