### PR TITLE
Epic #1093: De-duplicate interpreter runtime value-type wrappers

### DIFF
--- a/Runtime/Types/ClusterSingleton.cs
+++ b/Runtime/Types/ClusterSingleton.cs
@@ -162,7 +162,7 @@ public class ClusterSingleton : SharpTSEventEmitter
     /// <summary>
     /// Gets a member for interpreter dispatch.
     /// </summary>
-    public new object? GetMember(string name)
+    public override object? GetMember(string name)
     {
         return name switch
         {

--- a/Runtime/Types/CompiledMessagePortBridge.cs
+++ b/Runtime/Types/CompiledMessagePortBridge.cs
@@ -242,7 +242,7 @@ public sealed class CompiledMessagePortBridge : SharpTSEventEmitter
     /// inherited EventEmitter members; attaching a 'message' listener implicitly
     /// starts the port (Node worker_threads semantics, mirroring SharpTSMessagePort).
     /// </summary>
-    public new object? GetMember(string name)
+    public override object? GetMember(string name)
     {
         return name switch
         {

--- a/Runtime/Types/CryptoAlgorithms.cs
+++ b/Runtime/Types/CryptoAlgorithms.cs
@@ -1,0 +1,49 @@
+using System.Security.Cryptography;
+
+namespace SharpTS.Runtime.Types;
+
+/// <summary>
+/// Shared algorithm-name parsing for the Node <c>crypto</c> value-type wrappers.
+/// </summary>
+/// <remarks>
+/// Hash, Hmac, Sign, and Verify each carried their own identical
+/// <see cref="HashAlgorithmName"/> switch (#1135); this centralizes them.
+/// </remarks>
+internal static class CryptoAlgorithms
+{
+    /// <summary>
+    /// Parses a digest name (<c>md5</c>/<c>sha1</c>/<c>sha256</c>/<c>sha384</c>/
+    /// <c>sha512</c>) into a <see cref="HashAlgorithmName"/>.
+    /// </summary>
+    /// <param name="algorithm">The algorithm name (case-insensitive).</param>
+    /// <param name="stripSignaturePrefix">
+    /// When <c>true</c>, a leading <c>"rsa-"</c>/<c>"ecdsa-"</c> is removed first so
+    /// Sign/Verify accept Node-style names like <c>"RSA-SHA256"</c>.
+    /// </param>
+    /// <param name="context">
+    /// Noun used in the "Unsupported … algorithm" error message (e.g. "hash",
+    /// "HMAC", "signing", "verification").
+    /// </param>
+    public static HashAlgorithmName ParseHashName(
+        string algorithm, bool stripSignaturePrefix = false, string context = "hash")
+    {
+        var normalized = algorithm.ToLowerInvariant();
+        if (stripSignaturePrefix)
+        {
+            if (normalized.StartsWith("rsa-"))
+                normalized = normalized[4..];
+            else if (normalized.StartsWith("ecdsa-"))
+                normalized = normalized[6..];
+        }
+
+        return normalized switch
+        {
+            "md5" => HashAlgorithmName.MD5,
+            "sha1" => HashAlgorithmName.SHA1,
+            "sha256" => HashAlgorithmName.SHA256,
+            "sha384" => HashAlgorithmName.SHA384,
+            "sha512" => HashAlgorithmName.SHA512,
+            _ => throw new ArgumentException($"Unsupported {context} algorithm: {algorithm}")
+        };
+    }
+}

--- a/Runtime/Types/CryptoEncoding.cs
+++ b/Runtime/Types/CryptoEncoding.cs
@@ -1,0 +1,64 @@
+using System.Text;
+
+namespace SharpTS.Runtime.Types;
+
+/// <summary>
+/// Shared byte ⇄ encoded-value conversions for the Node <c>crypto</c> value-type
+/// wrappers (Cipher, Decipher, Hash, Hmac, Sign, Verify, DiffieHellman, ECDH).
+/// </summary>
+/// <remarks>
+/// Before #1135 each wrapper re-rolled its own copy of these conversions (the
+/// byte→hex/base64/Buffer encoder appeared ~7 times, the encoded-input decoder
+/// ~4 times). The copies had already drifted — <c>Decipher.FormatOutput</c> grew
+/// a <c>utf8</c> case that <c>Cipher</c> lacked. Centralizing the logic here makes
+/// that one remaining difference an explicit, documented parameter
+/// (<paramref name="decodeUtf8"/>) instead of a silent copy-paste divergence.
+/// </remarks>
+internal static class CryptoEncoding
+{
+    /// <summary>
+    /// Formats raw bytes according to a Node output encoding: <c>"hex"</c> and
+    /// <c>"base64"</c> always yield a string; <c>null</c> (and any unrecognized
+    /// encoding) yields a <see cref="SharpTSBuffer"/>.
+    /// </summary>
+    /// <param name="decodeUtf8">
+    /// When <c>true</c>, <c>"utf8"</c>/<c>"utf-8"</c> decode the bytes to a string.
+    /// Decryption output (plaintext) sets this; encryption output (ciphertext) does
+    /// not, matching the historical Cipher/Decipher behavior.
+    /// </param>
+    public static object ToBufferOrString(byte[] bytes, string? encoding, bool decodeUtf8 = false)
+    {
+        switch (encoding?.ToLowerInvariant())
+        {
+            case "hex":
+                return Convert.ToHexString(bytes).ToLowerInvariant();
+            case "base64":
+                return Convert.ToBase64String(bytes);
+            case "utf8" or "utf-8" when decodeUtf8:
+                return Encoding.UTF8.GetString(bytes);
+            default:
+                return new SharpTSBuffer(bytes);
+        }
+    }
+
+    /// <summary>
+    /// Decodes input data to raw bytes. A string is interpreted via the given input
+    /// encoding (<c>"hex"</c>/<c>"base64"</c>, otherwise UTF-8); a
+    /// <see cref="SharpTSBuffer"/> or <c>byte[]</c> passes through unchanged.
+    /// </summary>
+    public static byte[] FromEncoded(object? data, string? encoding)
+    {
+        return data switch
+        {
+            string s => encoding?.ToLowerInvariant() switch
+            {
+                "hex" => Convert.FromHexString(s),
+                "base64" => Convert.FromBase64String(s),
+                _ => Encoding.UTF8.GetBytes(s)
+            },
+            SharpTSBuffer buf => buf.Data,
+            byte[] bytes => bytes,
+            _ => throw new ArgumentException("Data must be a string or Buffer")
+        };
+    }
+}

--- a/Runtime/Types/IMemberProvider.cs
+++ b/Runtime/Types/IMemberProvider.cs
@@ -1,0 +1,20 @@
+namespace SharpTS.Runtime.Types;
+
+/// <summary>
+/// The interpreter member-dispatch contract: resolve a named member (method or
+/// property) on a runtime value, returning <c>null</c> when the member is absent.
+/// </summary>
+/// <remarks>
+/// Implemented by <see cref="SharpTSEventEmitter"/> (and therefore its whole family:
+/// Readable/Writable/Duplex/Socket/Http*/etc.). Before #1139 the base
+/// <c>GetMember</c> was neither virtual nor an interface member, so ~30 subclasses
+/// declared <c>public new object? GetMember</c> and lost polymorphism — a base-typed
+/// reference resolved members against the static type, not the runtime type. Making
+/// the base method virtual and the shadows overrides restores normal dispatch and
+/// makes the compiled-reflection fallback unambiguous.
+/// </remarks>
+public interface IMemberProvider
+{
+    /// <summary>Resolves the named member, or returns <c>null</c> if it does not exist.</summary>
+    object? GetMember(string name);
+}

--- a/Runtime/Types/SharpTSAesBase.cs
+++ b/Runtime/Types/SharpTSAesBase.cs
@@ -1,0 +1,270 @@
+using System.Security.Cryptography;
+using SharpTS.Runtime.BuiltIns;
+
+namespace SharpTS.Runtime.Types;
+
+/// <summary>
+/// Shared implementation for the Node-compatible AES <c>Cipher</c>/<c>Decipher</c>
+/// value-type wrappers, which were previously line-for-line parallel (#1135).
+/// </summary>
+/// <remarks>
+/// Both directions support CBC (with PKCS7/no padding) and GCM modes. The
+/// direction-specific pieces are the few abstract members below:
+/// <list type="bullet">
+/// <item><see cref="Noun"/> — "Cipher"/"Decipher", used in error messages.</item>
+/// <item><see cref="ReserveFinalBlock"/> — decryption holds back the last CBC block
+///   for <c>final()</c>; encryption does not.</item>
+/// <item><see cref="DecodeOutputAsUtf8"/> — decryption may render its plaintext output
+///   as a UTF-8 string; encryption output (ciphertext) is never decoded as UTF-8.</item>
+/// <item><see cref="FinalizeGcm"/> — encrypt vs. authenticated-decrypt at <c>final()</c>.</item>
+/// </list>
+/// </remarks>
+public abstract class SharpTSAesBase : IDisposable
+{
+    protected readonly string _algorithm;
+    protected readonly byte[] _key;
+    protected readonly byte[] _iv;
+    protected readonly bool _isGcm;
+    protected readonly int _keySize;
+    private readonly bool _forEncryption;
+
+    // CBC mode
+    protected Aes? _aes;
+    protected ICryptoTransform? _transform;
+    protected readonly List<byte> _cbcBuffer = new();
+
+    // GCM mode
+    protected AesGcm? _aesGcm;
+    protected readonly List<byte> _gcmBuffer = new();
+    protected byte[]? _authTag;
+    protected byte[]? _aad;
+
+    protected bool _finalized;
+    protected bool _autoPadding = true;
+    private bool _disposed;
+
+    /// <param name="forEncryption">True for a Cipher, false for a Decipher.</param>
+    protected SharpTSAesBase(string algorithm, byte[] key, byte[] iv, bool forEncryption)
+    {
+        _forEncryption = forEncryption;
+        _algorithm = algorithm.ToLowerInvariant();
+
+        (_keySize, _isGcm) = ParseAlgorithm(_algorithm);
+
+        // Validate key size
+        if (key.Length != _keySize / 8)
+            throw new ArgumentException($"Invalid key length for {_algorithm}. Expected {_keySize / 8} bytes, got {key.Length} bytes.");
+
+        // Validate IV size
+        var expectedIvSize = _isGcm ? 12 : 16;
+        if (iv.Length != expectedIvSize)
+            throw new ArgumentException($"Invalid IV length for {_algorithm}. Expected {expectedIvSize} bytes, got {iv.Length} bytes.");
+
+        _key = key;
+        _iv = iv;
+        _finalized = false;
+
+        if (_isGcm)
+        {
+            _aesGcm = new AesGcm(_key, AesGcm.TagByteSizes.MaxSize);
+        }
+        else
+        {
+            _aes = Aes.Create();
+            _aes.Key = _key;
+            _aes.IV = _iv;
+            _aes.Mode = CipherMode.CBC;
+            _aes.Padding = PaddingMode.PKCS7;
+            _transform = CreateTransform();
+        }
+    }
+
+    /// <summary>Lowercase "cipher"/"decipher" message stem (e.g. "Cipher").</summary>
+    protected abstract string Noun { get; }
+
+    /// <summary>Decryption holds back the final CBC block for <c>final()</c>.</summary>
+    protected abstract bool ReserveFinalBlock { get; }
+
+    /// <summary>Decryption renders UTF-8 output; encryption (ciphertext) does not.</summary>
+    protected abstract bool DecodeOutputAsUtf8 { get; }
+
+    /// <summary>Performs the GCM transform at <c>final()</c> and returns the result bytes.</summary>
+    protected abstract byte[] FinalizeGcm();
+
+    /// <summary>
+    /// Parses the algorithm string to extract key size and mode.
+    /// </summary>
+    private static (int keySize, bool isGcm) ParseAlgorithm(string algorithm)
+    {
+        return algorithm switch
+        {
+            "aes-128-cbc" => (128, false),
+            "aes-192-cbc" => (192, false),
+            "aes-256-cbc" => (256, false),
+            "aes-128-gcm" => (128, true),
+            "aes-192-gcm" => (192, true),
+            "aes-256-gcm" => (256, true),
+            _ => throw new ArgumentException($"Unsupported cipher algorithm: {algorithm}")
+        };
+    }
+
+    private ICryptoTransform CreateTransform() =>
+        _forEncryption ? _aes!.CreateEncryptor() : _aes!.CreateDecryptor();
+
+    /// <summary>
+    /// Transforms data and returns the result.
+    /// </summary>
+    /// <param name="data">Data to transform (string or Buffer).</param>
+    /// <param name="inputEncoding">Input encoding for string data: utf8 (default), hex, base64.</param>
+    /// <param name="outputEncoding">Output encoding: hex, base64, (utf8 for decipher) or null for Buffer.</param>
+    public object Update(object data, string? inputEncoding = null, string? outputEncoding = null)
+    {
+        if (_finalized)
+            throw new InvalidOperationException($"{Noun} has already been finalized");
+
+        var inputBytes = CryptoEncoding.FromEncoded(data, inputEncoding);
+
+        if (_isGcm)
+        {
+            // Accumulate until final(); the transform happens there.
+            _gcmBuffer.AddRange(inputBytes);
+            return FormatOutput([], outputEncoding);
+        }
+
+        // CBC: buffer data and only process complete 16-byte blocks. Decryption keeps
+        // the last block buffered so final() can strip padding.
+        _cbcBuffer.AddRange(inputBytes);
+
+        const int blockSize = 16;
+        var completeBlocks = (_cbcBuffer.Count / blockSize) - (ReserveFinalBlock ? 1 : 0);
+        if (completeBlocks <= 0)
+            return FormatOutput([], outputEncoding);
+
+        var bytesToProcess = completeBlocks * blockSize;
+        var dataToProcess = _cbcBuffer.Take(bytesToProcess).ToArray();
+        _cbcBuffer.RemoveRange(0, bytesToProcess);
+
+        var outputBytes = new byte[bytesToProcess];
+        var bytesWritten = _transform!.TransformBlock(dataToProcess, 0, dataToProcess.Length, outputBytes, 0);
+
+        if (bytesWritten > 0)
+        {
+            var result = new byte[bytesWritten];
+            Array.Copy(outputBytes, result, bytesWritten);
+            return FormatOutput(result, outputEncoding);
+        }
+
+        return FormatOutput([], outputEncoding);
+    }
+
+    /// <summary>
+    /// Finalizes the transform and returns any remaining output.
+    /// </summary>
+    public object Final(string? outputEncoding = null)
+    {
+        if (_finalized)
+            throw new InvalidOperationException($"{Noun} has already been finalized");
+
+        _finalized = true;
+
+        byte[] result;
+        if (_isGcm)
+        {
+            result = FinalizeGcm();
+        }
+        else
+        {
+            var remainingData = _cbcBuffer.ToArray();
+            result = _transform!.TransformFinalBlock(remainingData, 0, remainingData.Length);
+        }
+
+        return FormatOutput(result, outputEncoding);
+    }
+
+    /// <summary>
+    /// Sets whether to use PKCS7 auto-padding (CBC mode only); a no-op for GCM.
+    /// </summary>
+    protected void SetAutoPaddingCore(bool autoPadding)
+    {
+        if (_finalized)
+            throw new InvalidOperationException($"Cannot set auto padding after {Noun.ToLowerInvariant()} has been finalized");
+
+        if (_isGcm)
+            return; // GCM doesn't use padding
+
+        _autoPadding = autoPadding;
+
+        // Recreate the transform with the new padding mode.
+        _aes!.Padding = autoPadding ? PaddingMode.PKCS7 : PaddingMode.None;
+        _transform?.Dispose();
+        _transform = CreateTransform();
+    }
+
+    /// <summary>
+    /// Sets additional authenticated data (GCM mode only, before final()).
+    /// </summary>
+    protected void SetAADCore(object aad)
+    {
+        if (!_isGcm)
+            throw new InvalidOperationException("setAAD is only available for GCM mode ciphers");
+
+        if (_finalized)
+            throw new InvalidOperationException("setAAD must be called before final()");
+
+        _aad = CryptoEncoding.FromEncoded(aad, null);
+    }
+
+    protected object FormatOutput(byte[] bytes, string? encoding) =>
+        CryptoEncoding.ToBufferOrString(bytes, encoding, DecodeOutputAsUtf8);
+
+    /// <summary>
+    /// Gets a member of this object (for property access). Subclasses override to add
+    /// their direction-specific members (getAuthTag / setAuthTag) and chain to base.
+    /// </summary>
+    public virtual object? GetMember(string name)
+    {
+        return name switch
+        {
+            "update" => BuiltInMethod.CreateV2("update", 1, 3, (_, _, args) =>
+            {
+                if (args.Length == 0)
+                    throw new ArgumentException($"{Noun.ToLowerInvariant()}.update requires data argument");
+
+                var inputEncoding = args.Length > 1 ? args[1].ToObject()?.ToString() : null;
+                var outputEncoding = args.Length > 2 ? args[2].ToObject()?.ToString() : null;
+                return RuntimeValue.FromBoxed(Update(args[0].ToObject()!, inputEncoding, outputEncoding));
+            }),
+            "final" => BuiltInMethod.CreateV2("final", 0, 1, (_, _, args) =>
+            {
+                var outputEncoding = args.Length > 0 ? args[0].ToObject()?.ToString() : null;
+                return RuntimeValue.FromBoxed(Final(outputEncoding));
+            }),
+            "setAutoPadding" => BuiltInMethod.CreateV2("setAutoPadding", 0, 1, (_, _, args) =>
+            {
+                var autoPadding = args.Length == 0
+                    || (args[0].IsBoolean ? args[0].AsBooleanUnsafe()
+                        : !args[0].IsNumber || args[0].AsNumberUnsafe() != 0);
+                SetAutoPaddingCore(autoPadding);
+                return RuntimeValue.FromObject(this);
+            }),
+            "setAAD" => BuiltInMethod.CreateV2("setAAD", 1, (_, _, args) =>
+            {
+                if (args.Length == 0)
+                    throw new ArgumentException($"{Noun.ToLowerInvariant()}.setAAD requires buffer argument");
+                SetAADCore(args[0].ToObject()!);
+                return RuntimeValue.FromObject(this);
+            }),
+            _ => null
+        };
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+
+        _transform?.Dispose();
+        _aes?.Dispose();
+        _aesGcm?.Dispose();
+    }
+}

--- a/Runtime/Types/SharpTSAgent.cs
+++ b/Runtime/Types/SharpTSAgent.cs
@@ -83,7 +83,7 @@ public class SharpTSAgent : SharpTSEventEmitter
     /// <summary>
     /// Gets a member by name for interpreter dispatch.
     /// </summary>
-    public new object? GetMember(string name)
+    public override object? GetMember(string name)
     {
         return name switch
         {

--- a/Runtime/Types/SharpTSBroadcastChannel.cs
+++ b/Runtime/Types/SharpTSBroadcastChannel.cs
@@ -263,7 +263,7 @@ public class SharpTSBroadcastChannel : SharpTSEventEmitter, IDisposable
     /// Gets a member (method or property) by name for interpreter dispatch.
     /// Falls through to <see cref="SharpTSEventEmitter.GetMember"/> for inherited methods.
     /// </summary>
-    public new object? GetMember(string name)
+    public override object? GetMember(string name)
     {
         return name switch
         {

--- a/Runtime/Types/SharpTSChildProcess.cs
+++ b/Runtime/Types/SharpTSChildProcess.cs
@@ -87,7 +87,7 @@ public class SharpTSChildProcess : SharpTSEventEmitter
     /// <summary>
     /// Gets a member (method or property) by name for interpreter dispatch.
     /// </summary>
-    public new object? GetMember(string name)
+    public override object? GetMember(string name)
     {
         return name switch
         {

--- a/Runtime/Types/SharpTSCipher.cs
+++ b/Runtime/Types/SharpTSCipher.cs
@@ -1,5 +1,4 @@
 using System.Security.Cryptography;
-using System.Text;
 using SharpTS.Runtime.BuiltIns;
 
 namespace SharpTS.Runtime.Types;
@@ -14,30 +13,11 @@ namespace SharpTS.Runtime.Types;
 /// - cipher.setAutoPadding(autoPadding) - sets padding mode (CBC only)
 /// - cipher.getAuthTag() - returns auth tag (GCM only)
 /// - cipher.setAAD(buffer) - sets additional authenticated data (GCM only)
+///
+/// The shared encrypt/decrypt machinery lives in <see cref="SharpTSAesBase"/>.
 /// </remarks>
-public class SharpTSCipher : IDisposable
+public class SharpTSCipher : SharpTSAesBase
 {
-    private readonly string _algorithm;
-    private readonly byte[] _key;
-    private readonly byte[] _iv;
-    private readonly bool _isGcm;
-    private readonly int _keySize;
-
-    // CBC mode
-    private Aes? _aes;
-    private ICryptoTransform? _encryptor;
-    private readonly List<byte> _outputBuffer = new();
-
-    // GCM mode
-    private AesGcm? _aesGcm;
-    private readonly List<byte> _plaintextBuffer = new();
-    private byte[]? _authTag;
-    private byte[]? _aad;
-
-    private bool _finalized;
-    private bool _autoPadding = true;
-    private bool _disposed;
-
     /// <summary>
     /// Creates a new Cipher object for the specified algorithm.
     /// </summary>
@@ -45,171 +25,39 @@ public class SharpTSCipher : IDisposable
     /// <param name="key">Encryption key as byte array</param>
     /// <param name="iv">Initialization vector as byte array</param>
     public SharpTSCipher(string algorithm, byte[] key, byte[] iv)
+        : base(algorithm, key, iv, forEncryption: true)
     {
-        _algorithm = algorithm.ToLowerInvariant();
-
-        // Parse algorithm to determine mode and key size
-        var (keySize, isGcm) = ParseAlgorithm(_algorithm);
-        _keySize = keySize;
-        _isGcm = isGcm;
-
-        // Validate key size
-        if (key.Length != keySize / 8)
-            throw new ArgumentException($"Invalid key length for {_algorithm}. Expected {keySize / 8} bytes, got {key.Length} bytes.");
-
-        // Validate IV size
-        var expectedIvSize = isGcm ? 12 : 16;
-        if (iv.Length != expectedIvSize)
-            throw new ArgumentException($"Invalid IV length for {_algorithm}. Expected {expectedIvSize} bytes, got {iv.Length} bytes.");
-
-        _key = key;
-        _iv = iv;
-        _finalized = false;
-
-        if (isGcm)
-        {
-            _aesGcm = new AesGcm(_key, AesGcm.TagByteSizes.MaxSize);
-        }
-        else
-        {
-            _aes = Aes.Create();
-            _aes.Key = _key;
-            _aes.IV = _iv;
-            _aes.Mode = CipherMode.CBC;
-            _aes.Padding = PaddingMode.PKCS7;
-            _encryptor = _aes.CreateEncryptor();
-        }
     }
 
-    /// <summary>
-    /// Parses the algorithm string to extract key size and mode.
-    /// </summary>
-    private static (int keySize, bool isGcm) ParseAlgorithm(string algorithm)
+    protected override string Noun => "Cipher";
+
+    // Encryption processes every complete block immediately.
+    protected override bool ReserveFinalBlock => false;
+
+    // Ciphertext is never meaningfully decoded as UTF-8.
+    protected override bool DecodeOutputAsUtf8 => false;
+
+    protected override byte[] FinalizeGcm()
     {
-        return algorithm switch
-        {
-            "aes-128-cbc" => (128, false),
-            "aes-192-cbc" => (192, false),
-            "aes-256-cbc" => (256, false),
-            "aes-128-gcm" => (128, true),
-            "aes-192-gcm" => (192, true),
-            "aes-256-gcm" => (256, true),
-            _ => throw new ArgumentException($"Unsupported cipher algorithm: {algorithm}")
-        };
-    }
+        var plaintext = _gcmBuffer.ToArray();
+        var ciphertext = new byte[plaintext.Length];
+        _authTag = new byte[AesGcm.TagByteSizes.MaxSize];
 
-    /// <summary>
-    /// Encrypts data and returns the ciphertext.
-    /// </summary>
-    /// <param name="data">Data to encrypt (string or Buffer)</param>
-    /// <param name="inputEncoding">Input encoding for string data: utf8, hex, base64</param>
-    /// <param name="outputEncoding">Output encoding: hex, base64, or null for Buffer</param>
-    /// <returns>Encrypted data as string or Buffer</returns>
-    public object Update(object data, string? inputEncoding = null, string? outputEncoding = null)
-    {
-        if (_finalized)
-            throw new InvalidOperationException("Cipher has already been finalized");
-
-        var inputBytes = ConvertToBytes(data, inputEncoding);
-
-        if (_isGcm)
-        {
-            // For GCM, accumulate plaintext until final()
-            _plaintextBuffer.AddRange(inputBytes);
-            // Return empty result (encryption happens in final)
-            return FormatOutput([], outputEncoding);
-        }
+        if (_aad != null)
+            _aesGcm!.Encrypt(_iv, plaintext, ciphertext, _authTag, _aad);
         else
-        {
-            // For CBC, we need to buffer data and only process complete blocks
-            _outputBuffer.AddRange(inputBytes);
+            _aesGcm!.Encrypt(_iv, plaintext, ciphertext, _authTag);
 
-            // Process complete blocks (each block is 16 bytes for AES)
-            const int blockSize = 16;
-            var completeBlocks = _outputBuffer.Count / blockSize;
-            if (completeBlocks == 0)
-            {
-                // Not enough data for a complete block
-                return FormatOutput([], outputEncoding);
-            }
-
-            var bytesToProcess = completeBlocks * blockSize;
-            var dataToProcess = _outputBuffer.Take(bytesToProcess).ToArray();
-            _outputBuffer.RemoveRange(0, bytesToProcess);
-
-            var outputBytes = new byte[bytesToProcess];
-            var bytesWritten = _encryptor!.TransformBlock(dataToProcess, 0, dataToProcess.Length, outputBytes, 0);
-
-            if (bytesWritten > 0)
-            {
-                var result = new byte[bytesWritten];
-                Array.Copy(outputBytes, result, bytesWritten);
-                return FormatOutput(result, outputEncoding);
-            }
-
-            return FormatOutput([], outputEncoding);
-        }
-    }
-
-    /// <summary>
-    /// Finalizes encryption and returns any remaining ciphertext.
-    /// </summary>
-    /// <param name="outputEncoding">Output encoding: hex, base64, or null for Buffer</param>
-    /// <returns>Final encrypted data as string or Buffer</returns>
-    public object Final(string? outputEncoding = null)
-    {
-        if (_finalized)
-            throw new InvalidOperationException("Cipher has already been finalized");
-
-        _finalized = true;
-
-        if (_isGcm)
-        {
-            // Perform GCM encryption
-            var plaintext = _plaintextBuffer.ToArray();
-            var ciphertext = new byte[plaintext.Length];
-            _authTag = new byte[AesGcm.TagByteSizes.MaxSize];
-
-            if (_aad != null)
-            {
-                _aesGcm!.Encrypt(_iv, plaintext, ciphertext, _authTag, _aad);
-            }
-            else
-            {
-                _aesGcm!.Encrypt(_iv, plaintext, ciphertext, _authTag);
-            }
-
-            return FormatOutput(ciphertext, outputEncoding);
-        }
-        else
-        {
-            // Finalize CBC encryption with any remaining buffered data
-            var remainingData = _outputBuffer.ToArray();
-            var finalBlock = _encryptor!.TransformFinalBlock(remainingData, 0, remainingData.Length);
-            return FormatOutput(finalBlock, outputEncoding);
-        }
+        return ciphertext;
     }
 
     /// <summary>
     /// Sets whether to use auto-padding (CBC mode only).
     /// </summary>
-    /// <param name="autoPadding">True to use PKCS7 padding, false for no padding</param>
     /// <returns>This cipher for chaining</returns>
     public SharpTSCipher SetAutoPadding(bool autoPadding)
     {
-        if (_finalized)
-            throw new InvalidOperationException("Cannot set auto padding after cipher has been finalized");
-
-        if (_isGcm)
-            return this; // GCM doesn't use padding
-
-        _autoPadding = autoPadding;
-
-        // Recreate the encryptor with new padding
-        _aes!.Padding = autoPadding ? PaddingMode.PKCS7 : PaddingMode.None;
-        _encryptor?.Dispose();
-        _encryptor = _aes.CreateEncryptor();
-
+        SetAutoPaddingCore(autoPadding);
         return this;
     }
 
@@ -231,101 +79,25 @@ public class SharpTSCipher : IDisposable
     /// <summary>
     /// Sets additional authenticated data (GCM mode only, before final()).
     /// </summary>
-    /// <param name="aad">Additional authenticated data as Buffer</param>
     /// <returns>This cipher for chaining</returns>
     public SharpTSCipher SetAAD(object aad)
     {
-        if (!_isGcm)
-            throw new InvalidOperationException("setAAD is only available for GCM mode ciphers");
-
-        if (_finalized)
-            throw new InvalidOperationException("setAAD must be called before final()");
-
-        _aad = ConvertToBytes(aad, null);
+        SetAADCore(aad);
         return this;
-    }
-
-    /// <summary>
-    /// Converts input data to byte array.
-    /// </summary>
-    private static byte[] ConvertToBytes(object data, string? encoding)
-    {
-        return data switch
-        {
-            string s => encoding?.ToLowerInvariant() switch
-            {
-                "hex" => Convert.FromHexString(s),
-                "base64" => Convert.FromBase64String(s),
-                _ => Encoding.UTF8.GetBytes(s) // utf8 default
-            },
-            SharpTSBuffer buf => buf.Data,
-            byte[] bytes => bytes,
-            _ => throw new ArgumentException("Data must be a string or Buffer")
-        };
-    }
-
-    /// <summary>
-    /// Formats output bytes according to encoding.
-    /// </summary>
-    private static object FormatOutput(byte[] bytes, string? encoding)
-    {
-        return encoding?.ToLowerInvariant() switch
-        {
-            "hex" => Convert.ToHexString(bytes).ToLowerInvariant(),
-            "base64" => Convert.ToBase64String(bytes),
-            _ => new SharpTSBuffer(bytes)
-        };
     }
 
     /// <summary>
     /// Gets a member of this cipher object (for property access).
     /// </summary>
-    public object? GetMember(string name)
+    public override object? GetMember(string name)
     {
         return name switch
         {
-            "update" => BuiltInMethod.CreateV2("update", 1, 3, (_, _, args) =>
-            {
-                if (args.Length == 0)
-                    throw new ArgumentException("cipher.update requires data argument");
-
-                var inputEncoding = args.Length > 1 ? args[1].ToObject()?.ToString() : null;
-                var outputEncoding = args.Length > 2 ? args[2].ToObject()?.ToString() : null;
-                return RuntimeValue.FromBoxed(Update(args[0].ToObject()!, inputEncoding, outputEncoding));
-            }),
-            "final" => BuiltInMethod.CreateV2("final", 0, 1, (_, _, args) =>
-            {
-                var outputEncoding = args.Length > 0 ? args[0].ToObject()?.ToString() : null;
-                return RuntimeValue.FromBoxed(Final(outputEncoding));
-            }),
-            "setAutoPadding" => BuiltInMethod.CreateV2("setAutoPadding", 0, 1, (_, _, args) =>
-            {
-                var autoPadding = args.Length == 0
-                    || (args[0].IsBoolean ? args[0].AsBooleanUnsafe()
-                        : !args[0].IsNumber || args[0].AsNumberUnsafe() != 0);
-                return RuntimeValue.FromObject(SetAutoPadding(autoPadding));
-            }),
             "getAuthTag" => BuiltInMethod.CreateV2("getAuthTag", 0, (_, _, _) =>
             {
                 return RuntimeValue.FromObject(GetAuthTag());
             }),
-            "setAAD" => BuiltInMethod.CreateV2("setAAD", 1, (_, _, args) =>
-            {
-                if (args.Length == 0)
-                    throw new ArgumentException("cipher.setAAD requires buffer argument");
-                return RuntimeValue.FromObject(SetAAD(args[0].ToObject()!));
-            }),
-            _ => null
+            _ => base.GetMember(name)
         };
-    }
-
-    public void Dispose()
-    {
-        if (_disposed) return;
-        _disposed = true;
-
-        _encryptor?.Dispose();
-        _aes?.Dispose();
-        _aesGcm?.Dispose();
     }
 }

--- a/Runtime/Types/SharpTSClientRequest.cs
+++ b/Runtime/Types/SharpTSClientRequest.cs
@@ -96,11 +96,11 @@ public class SharpTSClientRequest : SharpTSWritable
     /// <summary>Registers the response callback (the cb passed to http.request) as a 'response' listener.</summary>
     public void RegisterResponseCallback(ISharpTSCallable callback)
     {
-        var on = ((SharpTSEventEmitter)this).GetMember("on") as BuiltInMethod;
+        var on = GetEventEmitterMember("on") as BuiltInMethod;
         on?.Bind(this).Call(_interpreter, ["response", callback]);
     }
 
-    public new object? GetMember(string name)
+    public override object? GetMember(string name)
     {
         return name switch
         {
@@ -190,7 +190,7 @@ public class SharpTSClientRequest : SharpTSWritable
 
     private void RegisterFinishCallback(ISharpTSCallable cb)
     {
-        var once = ((SharpTSEventEmitter)this).GetMember("once") as BuiltInMethod;
+        var once = GetEventEmitterMember("once") as BuiltInMethod;
         once?.Bind(this).Call(_interpreter, ["finish", cb]);
     }
 
@@ -276,7 +276,7 @@ public class SharpTSClientRequest : SharpTSWritable
             _timeoutMs = (int)args[0].AsNumberUnsafe();
         if (args.Length > 1 && args[1].ToObject() is ISharpTSCallable cb)
         {
-            var on = ((SharpTSEventEmitter)this).GetMember("on") as BuiltInMethod;
+            var on = GetEventEmitterMember("on") as BuiltInMethod;
             on?.Bind(this).Call(interpreter, ["timeout", cb]);
         }
         return RuntimeValue.FromObject(this);

--- a/Runtime/Types/SharpTSClientResponse.cs
+++ b/Runtime/Types/SharpTSClientResponse.cs
@@ -51,7 +51,7 @@ public class SharpTSClientResponse : SharpTSReadable
     /// <summary>Marks the response as aborted (request torn down before the body finished).</summary>
     internal void MarkAborted() => _aborted = true;
 
-    public new object? GetMember(string name)
+    public override object? GetMember(string name)
     {
         return name switch
         {

--- a/Runtime/Types/SharpTSClusterWorker.cs
+++ b/Runtime/Types/SharpTSClusterWorker.cs
@@ -346,7 +346,7 @@ public class SharpTSClusterWorker : SharpTSEventEmitter, IDisposable
     /// <summary>
     /// Gets a member (method or property) by name.
     /// </summary>
-    public new object? GetMember(string name)
+    public override object? GetMember(string name)
     {
         return name switch
         {

--- a/Runtime/Types/SharpTSDataView.cs
+++ b/Runtime/Types/SharpTSDataView.cs
@@ -1,5 +1,6 @@
 using System.Buffers.Binary;
 using SharpTS.TypeSystem;
+using Interp = SharpTS.Execution.Interpreter;
 
 namespace SharpTS.Runtime.Types;
 
@@ -287,7 +288,7 @@ public class SharpTSDataView : ITypeCategorized
     {
         CheckBounds(byteOffset, 4);
         var span = _buffer.AsSpan(_byteOffset + byteOffset, 4);
-        float val = (float)ToDouble(value);
+        float val = (float)Interp.ToNumber(value);
         if (littleEndian)
             BinaryPrimitives.WriteSingleLittleEndian(span, val);
         else
@@ -301,7 +302,7 @@ public class SharpTSDataView : ITypeCategorized
     {
         CheckBounds(byteOffset, 8);
         var span = _buffer.AsSpan(_byteOffset + byteOffset, 8);
-        double val = ToDouble(value);
+        double val = Interp.ToNumber(value);
         if (littleEndian)
             BinaryPrimitives.WriteDoubleLittleEndian(span, val);
         else
@@ -392,19 +393,6 @@ public class SharpTSDataView : ITypeCategorized
             long l => l,
             float f => (long)f,
             System.Numerics.BigInteger bi => (long)bi,
-            _ => 0
-        };
-    }
-
-    private static double ToDouble(object? value)
-    {
-        return value switch
-        {
-            double d => d,
-            int i => i,
-            long l => l,
-            float f => f,
-            System.Numerics.BigInteger bi => (double)bi,
             _ => 0
         };
     }

--- a/Runtime/Types/SharpTSDatagramSocket.cs
+++ b/Runtime/Types/SharpTSDatagramSocket.cs
@@ -28,7 +28,7 @@ public class SharpTSDatagramSocket : SharpTSEventEmitter
     /// <summary>
     /// Gets a member by name for interpreter dispatch.
     /// </summary>
-    public new object? GetMember(string name)
+    public override object? GetMember(string name)
     {
         return name switch
         {

--- a/Runtime/Types/SharpTSDecipher.cs
+++ b/Runtime/Types/SharpTSDecipher.cs
@@ -1,5 +1,4 @@
 using System.Security.Cryptography;
-using System.Text;
 using SharpTS.Runtime.BuiltIns;
 
 namespace SharpTS.Runtime.Types;
@@ -14,30 +13,11 @@ namespace SharpTS.Runtime.Types;
 /// - decipher.setAutoPadding(autoPadding) - sets padding mode (CBC only)
 /// - decipher.setAuthTag(buffer) - sets auth tag for verification (GCM only)
 /// - decipher.setAAD(buffer) - sets additional authenticated data (GCM only)
+///
+/// The shared encrypt/decrypt machinery lives in <see cref="SharpTSAesBase"/>.
 /// </remarks>
-public class SharpTSDecipher : IDisposable
+public class SharpTSDecipher : SharpTSAesBase
 {
-    private readonly string _algorithm;
-    private readonly byte[] _key;
-    private readonly byte[] _iv;
-    private readonly bool _isGcm;
-    private readonly int _keySize;
-
-    // CBC mode
-    private Aes? _aes;
-    private ICryptoTransform? _decryptor;
-    private readonly List<byte> _inputBuffer = new();
-
-    // GCM mode
-    private AesGcm? _aesGcm;
-    private readonly List<byte> _ciphertextBuffer = new();
-    private byte[]? _authTag;
-    private byte[]? _aad;
-
-    private bool _finalized;
-    private bool _autoPadding = true;
-    private bool _disposed;
-
     /// <summary>
     /// Creates a new Decipher object for the specified algorithm.
     /// </summary>
@@ -45,178 +25,48 @@ public class SharpTSDecipher : IDisposable
     /// <param name="key">Decryption key as byte array</param>
     /// <param name="iv">Initialization vector as byte array</param>
     public SharpTSDecipher(string algorithm, byte[] key, byte[] iv)
+        : base(algorithm, key, iv, forEncryption: false)
     {
-        _algorithm = algorithm.ToLowerInvariant();
-
-        // Parse algorithm to determine mode and key size
-        var (keySize, isGcm) = ParseAlgorithm(_algorithm);
-        _keySize = keySize;
-        _isGcm = isGcm;
-
-        // Validate key size
-        if (key.Length != keySize / 8)
-            throw new ArgumentException($"Invalid key length for {_algorithm}. Expected {keySize / 8} bytes, got {key.Length} bytes.");
-
-        // Validate IV size
-        var expectedIvSize = isGcm ? 12 : 16;
-        if (iv.Length != expectedIvSize)
-            throw new ArgumentException($"Invalid IV length for {_algorithm}. Expected {expectedIvSize} bytes, got {iv.Length} bytes.");
-
-        _key = key;
-        _iv = iv;
-        _finalized = false;
-
-        if (isGcm)
-        {
-            _aesGcm = new AesGcm(_key, AesGcm.TagByteSizes.MaxSize);
-        }
-        else
-        {
-            _aes = Aes.Create();
-            _aes.Key = _key;
-            _aes.IV = _iv;
-            _aes.Mode = CipherMode.CBC;
-            _aes.Padding = PaddingMode.PKCS7;
-            _decryptor = _aes.CreateDecryptor();
-        }
     }
 
-    /// <summary>
-    /// Parses the algorithm string to extract key size and mode.
-    /// </summary>
-    private static (int keySize, bool isGcm) ParseAlgorithm(string algorithm)
+    protected override string Noun => "Decipher";
+
+    // CBC decryption must keep the last block buffered so final() can strip padding.
+    protected override bool ReserveFinalBlock => true;
+
+    // Decrypted plaintext may be rendered as a UTF-8 string.
+    protected override bool DecodeOutputAsUtf8 => true;
+
+    protected override byte[] FinalizeGcm()
     {
-        return algorithm switch
+        if (_authTag == null)
+            throw new InvalidOperationException("Authentication tag must be set using setAuthTag() before calling final() for GCM mode");
+
+        var ciphertext = _gcmBuffer.ToArray();
+        var plaintext = new byte[ciphertext.Length];
+
+        try
         {
-            "aes-128-cbc" => (128, false),
-            "aes-192-cbc" => (192, false),
-            "aes-256-cbc" => (256, false),
-            "aes-128-gcm" => (128, true),
-            "aes-192-gcm" => (192, true),
-            "aes-256-gcm" => (256, true),
-            _ => throw new ArgumentException($"Unsupported cipher algorithm: {algorithm}")
-        };
-    }
-
-    /// <summary>
-    /// Decrypts data and returns the plaintext.
-    /// </summary>
-    /// <param name="data">Data to decrypt (string or Buffer)</param>
-    /// <param name="inputEncoding">Input encoding for string data: hex, base64</param>
-    /// <param name="outputEncoding">Output encoding: utf8, hex, base64, or null for Buffer</param>
-    /// <returns>Decrypted data as string or Buffer</returns>
-    public object Update(object data, string? inputEncoding = null, string? outputEncoding = null)
-    {
-        if (_finalized)
-            throw new InvalidOperationException("Decipher has already been finalized");
-
-        var inputBytes = ConvertToBytes(data, inputEncoding);
-
-        if (_isGcm)
-        {
-            // For GCM, accumulate ciphertext until final()
-            _ciphertextBuffer.AddRange(inputBytes);
-            // Return empty result (decryption happens in final)
-            return FormatOutput([], outputEncoding);
+            if (_aad != null)
+                _aesGcm!.Decrypt(_iv, ciphertext, _authTag, plaintext, _aad);
+            else
+                _aesGcm!.Decrypt(_iv, ciphertext, _authTag, plaintext);
         }
-        else
+        catch (AuthenticationTagMismatchException)
         {
-            // For CBC, we need to buffer data because the last block needs special handling
-            _inputBuffer.AddRange(inputBytes);
-
-            // Process complete blocks, keeping the last block buffered for final()
-            var completeBlocks = (_inputBuffer.Count / 16) - 1;
-            if (completeBlocks <= 0)
-            {
-                return FormatOutput([], outputEncoding);
-            }
-
-            var bytesToProcess = completeBlocks * 16;
-            var dataToProcess = _inputBuffer.Take(bytesToProcess).ToArray();
-            _inputBuffer.RemoveRange(0, bytesToProcess);
-
-            var outputBytes = new byte[bytesToProcess];
-            var bytesWritten = _decryptor!.TransformBlock(dataToProcess, 0, dataToProcess.Length, outputBytes, 0);
-
-            if (bytesWritten > 0)
-            {
-                var result = new byte[bytesWritten];
-                Array.Copy(outputBytes, result, bytesWritten);
-                return FormatOutput(result, outputEncoding);
-            }
-
-            return FormatOutput([], outputEncoding);
+            throw new CryptographicException("Unsupported state or unable to authenticate data");
         }
-    }
 
-    /// <summary>
-    /// Finalizes decryption and returns any remaining plaintext.
-    /// </summary>
-    /// <param name="outputEncoding">Output encoding: utf8, hex, base64, or null for Buffer</param>
-    /// <returns>Final decrypted data as string or Buffer</returns>
-    public object Final(string? outputEncoding = null)
-    {
-        if (_finalized)
-            throw new InvalidOperationException("Decipher has already been finalized");
-
-        _finalized = true;
-
-        if (_isGcm)
-        {
-            // Perform GCM decryption
-            if (_authTag == null)
-                throw new InvalidOperationException("Authentication tag must be set using setAuthTag() before calling final() for GCM mode");
-
-            var ciphertext = _ciphertextBuffer.ToArray();
-            var plaintext = new byte[ciphertext.Length];
-
-            try
-            {
-                if (_aad != null)
-                {
-                    _aesGcm!.Decrypt(_iv, ciphertext, _authTag, plaintext, _aad);
-                }
-                else
-                {
-                    _aesGcm!.Decrypt(_iv, ciphertext, _authTag, plaintext);
-                }
-            }
-            catch (AuthenticationTagMismatchException)
-            {
-                throw new CryptographicException("Unsupported state or unable to authenticate data");
-            }
-
-            return FormatOutput(plaintext, outputEncoding);
-        }
-        else
-        {
-            // Finalize CBC decryption
-            var remainingData = _inputBuffer.ToArray();
-            var finalBlock = _decryptor!.TransformFinalBlock(remainingData, 0, remainingData.Length);
-            return FormatOutput(finalBlock, outputEncoding);
-        }
+        return plaintext;
     }
 
     /// <summary>
     /// Sets whether to use auto-padding (CBC mode only).
     /// </summary>
-    /// <param name="autoPadding">True to use PKCS7 padding, false for no padding</param>
     /// <returns>This decipher for chaining</returns>
     public SharpTSDecipher SetAutoPadding(bool autoPadding)
     {
-        if (_finalized)
-            throw new InvalidOperationException("Cannot set auto padding after decipher has been finalized");
-
-        if (_isGcm)
-            return this; // GCM doesn't use padding
-
-        _autoPadding = autoPadding;
-
-        // Recreate the decryptor with new padding
-        _aes!.Padding = autoPadding ? PaddingMode.PKCS7 : PaddingMode.None;
-        _decryptor?.Dispose();
-        _decryptor = _aes.CreateDecryptor();
-
+        SetAutoPaddingCore(autoPadding);
         return this;
     }
 
@@ -233,111 +83,34 @@ public class SharpTSDecipher : IDisposable
         if (_finalized)
             throw new InvalidOperationException("setAuthTag must be called before final()");
 
-        _authTag = ConvertToBytes(tag, null);
+        _authTag = CryptoEncoding.FromEncoded(tag, null);
         return this;
     }
 
     /// <summary>
     /// Sets additional authenticated data (GCM mode only, before final()).
     /// </summary>
-    /// <param name="aad">Additional authenticated data as Buffer</param>
     /// <returns>This decipher for chaining</returns>
     public SharpTSDecipher SetAAD(object aad)
     {
-        if (!_isGcm)
-            throw new InvalidOperationException("setAAD is only available for GCM mode ciphers");
-
-        if (_finalized)
-            throw new InvalidOperationException("setAAD must be called before final()");
-
-        _aad = ConvertToBytes(aad, null);
+        SetAADCore(aad);
         return this;
-    }
-
-    /// <summary>
-    /// Converts input data to byte array.
-    /// </summary>
-    private static byte[] ConvertToBytes(object data, string? encoding)
-    {
-        return data switch
-        {
-            string s => encoding?.ToLowerInvariant() switch
-            {
-                "hex" => Convert.FromHexString(s),
-                "base64" => Convert.FromBase64String(s),
-                _ => Encoding.UTF8.GetBytes(s) // utf8 default
-            },
-            SharpTSBuffer buf => buf.Data,
-            byte[] bytes => bytes,
-            _ => throw new ArgumentException("Data must be a string or Buffer")
-        };
-    }
-
-    /// <summary>
-    /// Formats output bytes according to encoding.
-    /// </summary>
-    private static object FormatOutput(byte[] bytes, string? encoding)
-    {
-        return encoding?.ToLowerInvariant() switch
-        {
-            "hex" => Convert.ToHexString(bytes).ToLowerInvariant(),
-            "base64" => Convert.ToBase64String(bytes),
-            "utf8" or "utf-8" => Encoding.UTF8.GetString(bytes),
-            _ => new SharpTSBuffer(bytes)
-        };
     }
 
     /// <summary>
     /// Gets a member of this decipher object (for property access).
     /// </summary>
-    public object? GetMember(string name)
+    public override object? GetMember(string name)
     {
         return name switch
         {
-            "update" => BuiltInMethod.CreateV2("update", 1, 3, (_, _, args) =>
-            {
-                if (args.Length == 0)
-                    throw new ArgumentException("decipher.update requires data argument");
-
-                var inputEncoding = args.Length > 1 ? args[1].ToObject()?.ToString() : null;
-                var outputEncoding = args.Length > 2 ? args[2].ToObject()?.ToString() : null;
-                return RuntimeValue.FromBoxed(Update(args[0].ToObject()!, inputEncoding, outputEncoding));
-            }),
-            "final" => BuiltInMethod.CreateV2("final", 0, 1, (_, _, args) =>
-            {
-                var outputEncoding = args.Length > 0 ? args[0].ToObject()?.ToString() : null;
-                return RuntimeValue.FromBoxed(Final(outputEncoding));
-            }),
-            "setAutoPadding" => BuiltInMethod.CreateV2("setAutoPadding", 0, 1, (_, _, args) =>
-            {
-                var autoPadding = args.Length == 0
-                    || (args[0].IsBoolean ? args[0].AsBooleanUnsafe()
-                        : !args[0].IsNumber || args[0].AsNumberUnsafe() != 0);
-                return RuntimeValue.FromObject(SetAutoPadding(autoPadding));
-            }),
             "setAuthTag" => BuiltInMethod.CreateV2("setAuthTag", 1, (_, _, args) =>
             {
                 if (args.Length == 0)
                     throw new ArgumentException("decipher.setAuthTag requires tag argument");
                 return RuntimeValue.FromObject(SetAuthTag(args[0].ToObject()!));
             }),
-            "setAAD" => BuiltInMethod.CreateV2("setAAD", 1, (_, _, args) =>
-            {
-                if (args.Length == 0)
-                    throw new ArgumentException("decipher.setAAD requires buffer argument");
-                return RuntimeValue.FromObject(SetAAD(args[0].ToObject()!));
-            }),
-            _ => null
+            _ => base.GetMember(name)
         };
-    }
-
-    public void Dispose()
-    {
-        if (_disposed) return;
-        _disposed = true;
-
-        _decryptor?.Dispose();
-        _aes?.Dispose();
-        _aesGcm?.Dispose();
     }
 }

--- a/Runtime/Types/SharpTSDiffieHellman.cs
+++ b/Runtime/Types/SharpTSDiffieHellman.cs
@@ -347,33 +347,11 @@ public class SharpTSDiffieHellman
     /// </summary>
     public double VerifyError => 0;
 
-    private static object EncodeResult(byte[] bytes, string? encoding)
-    {
-        return encoding?.ToLowerInvariant() switch
-        {
-            "hex" => Convert.ToHexString(bytes).ToLowerInvariant(),
-            "base64" => Convert.ToBase64String(bytes),
-            _ => new SharpTSBuffer(bytes)
-        };
-    }
+    private static object EncodeResult(byte[] bytes, string? encoding) =>
+        CryptoEncoding.ToBufferOrString(bytes, encoding);
 
-    private static byte[] DecodeInput(object input, string? encoding)
-    {
-        if (input is SharpTSBuffer buffer)
-            return buffer.Data;
-        if (input is byte[] bytes)
-            return bytes;
-        if (input is string str)
-        {
-            return encoding?.ToLowerInvariant() switch
-            {
-                "hex" => Convert.FromHexString(str),
-                "base64" => Convert.FromBase64String(str),
-                _ => System.Text.Encoding.UTF8.GetBytes(str)
-            };
-        }
-        throw new ArgumentException("Input must be a Buffer, byte array, or string");
-    }
+    private static byte[] DecodeInput(object input, string? encoding) =>
+        CryptoEncoding.FromEncoded(input, encoding);
 
     private static BigInteger GenerateRandomPrime(int bitLength)
     {

--- a/Runtime/Types/SharpTSDuplex.cs
+++ b/Runtime/Types/SharpTSDuplex.cs
@@ -8,36 +8,38 @@ namespace SharpTS.Runtime.Types;
 /// Combines both Readable and Writable capabilities.
 /// </summary>
 /// <remarks>
-/// Extends <see cref="SharpTSReadable"/> and adds Writable-side methods.
-/// The read and write sides operate independently.
+/// Extends <see cref="SharpTSReadable"/> and adds the Writable side via a composed
+/// <see cref="WritableCore"/> (C# single inheritance prevents inheriting a writable
+/// base — #1138). The read and write sides operate independently.
 /// </remarks>
 public class SharpTSDuplex : SharpTSReadable
 {
-    // Writable-side state
-    private bool _writable = true;
-    private bool _writableEnded;
-    private bool _writableFinished;
-    private bool _writableDestroyed;
-    private bool _corked;
-    private readonly List<object?> _corkBuffer = [];
-    private ISharpTSCallable? _writeCallback;
-    private ISharpTSCallable? _finalCallback;
+    private readonly WritableCore _writeCore;
     private ISharpTSCallable? _readCallback;
     private int _writableHighWaterMark = 16384;
-    private int _pendingWrites;
-    private int _writableLength;
-    private bool _needDrain;
     private bool _writableObjectMode;
+
+    public SharpTSDuplex()
+    {
+        // The Duplex writable side emits "finish" with no "prefinish" and no auto-destroy
+        // (destroy is handled jointly with the readable side via DestroyDuplex).
+        _writeCore = new WritableCore(
+            this,
+            objectMode: () => _writableObjectMode,
+            highWaterMark: () => _writableHighWaterMark,
+            emitPrefinish: false,
+            onFinished: null);
+    }
 
     /// <summary>
     /// Sets the custom write callback (from constructor options).
     /// </summary>
-    public void SetWriteCallback(ISharpTSCallable callback) => _writeCallback = callback;
+    public void SetWriteCallback(ISharpTSCallable callback) => _writeCore.SetWriteCallback(callback);
 
     /// <summary>
     /// Sets the custom final callback (from constructor options).
     /// </summary>
-    public void SetFinalCallback(ISharpTSCallable callback) => _finalCallback = callback;
+    public void SetFinalCallback(ISharpTSCallable callback) => _writeCore.SetFinalCallback(callback);
 
     /// <summary>
     /// Sets the custom read callback (from constructor options).
@@ -68,11 +70,11 @@ public class SharpTSDuplex : SharpTSReadable
             "uncork" => BuiltInMethod.CreateV2("uncork", 0, Uncork),
 
             // Writable-side properties
-            "writable" => _writable && !_writableEnded && !_writableDestroyed,
-            "writableEnded" => _writableEnded,
-            "writableFinished" => _writableFinished,
-            "writableLength" => (double)_writableLength,
-            "writableCorked" => (double)(_corked ? 1 : 0),
+            "writable" => _writeCore.IsWritable,
+            "writableEnded" => _writeCore.Ended,
+            "writableFinished" => _writeCore.Finished,
+            "writableLength" => (double)_writeCore.WritableLength,
+            "writableCorked" => (double)(_writeCore.Corked ? 1 : 0),
             "writableHighWaterMark" => (double)_writableHighWaterMark,
             "writableObjectMode" => _writableObjectMode,
 
@@ -85,192 +87,26 @@ public class SharpTSDuplex : SharpTSReadable
     }
 
     private RuntimeValue Write(Interp interpreter, RuntimeValue receiver, ReadOnlySpan<RuntimeValue> args)
-    {
-        if (_writableDestroyed || _writableEnded)
-        {
-            EmitEvent(interpreter, "error", ["write after end"]);
-            return RuntimeValue.False;
-        }
-
-        var chunk = args.Length > 0 ? args[0].ToObject() : null;
-        string? encoding = null;
-        ISharpTSCallable? callback = null;
-
-        if (args.Length > 1)
-        {
-            if (args[1].IsString)
-            {
-                encoding = args[1].AsStringUnsafe();
-                if (args.Length > 2 && args[2].ToObject() is ISharpTSCallable cb)
-                {
-                    callback = cb;
-                }
-            }
-            else if (args[1].ToObject() is ISharpTSCallable cb)
-            {
-                callback = cb;
-            }
-        }
-
-        if (_corked)
-        {
-            _corkBuffer.Add(new WriteChunk(chunk, encoding, callback));
-            return RuntimeValue.False;
-        }
-
-        return RuntimeValue.FromBoxed(DoWrite(interpreter, chunk, encoding, callback));
-    }
-
-    private record WriteChunk(object? Chunk, string? Encoding, ISharpTSCallable? Callback);
-
-    private object? DoWrite(Interp interpreter, object? chunk, string? encoding, ISharpTSCallable? callback)
-    {
-        _pendingWrites++;
-        var chunkSize = SharpTSWritable.GetChunkSize(chunk, _writableObjectMode);
-        _writableLength += chunkSize;
-
-        if (_writeCallback != null)
-        {
-            var cbWrapper = new WriteCallbackWrapper(callback, interpreter, this, chunkSize);
-            var writeArgs = new List<object?> { chunk, encoding ?? "utf8", cbWrapper };
-            try
-            {
-                _writeCallback.Call(interpreter, writeArgs);
-            }
-            catch (Exception ex)
-            {
-                EmitEvent(interpreter, "error", [ex.Message]);
-                return false;
-            }
-        }
-        else
-        {
-            // Sync completion
-            _pendingWrites--;
-            _writableLength -= chunkSize;
-            callback?.Call(interpreter, []);
-            CheckDrain(interpreter);
-        }
-
-        // Return false when buffered data exceeds highWaterMark (backpressure)
-        if (_writableLength >= _writableHighWaterMark)
-        {
-            _needDrain = true;
-            return false;
-        }
-
-        return true;
-    }
-
-    private void CheckDrain(Interp interpreter)
-    {
-        if (_needDrain && _writableLength < _writableHighWaterMark)
-        {
-            _needDrain = false;
-            EmitEvent(interpreter, "drain", []);
-        }
-    }
+        => _writeCore.Write(interpreter, args);
 
     private RuntimeValue End(Interp interpreter, RuntimeValue receiver, ReadOnlySpan<RuntimeValue> args)
-    {
-        if (_writableEnded)
-        {
-            return RuntimeValue.FromObject(this);
-        }
-
-        object? chunk = null;
-        string? encoding = null;
-        ISharpTSCallable? callback = null;
-
-        if (args.Length > 0)
-        {
-            if (args[0].ToObject() is ISharpTSCallable cb0)
-            {
-                callback = cb0;
-            }
-            else
-            {
-                chunk = args[0].ToObject();
-                if (args.Length > 1)
-                {
-                    if (args[1].IsString)
-                    {
-                        encoding = args[1].AsStringUnsafe();
-                        if (args.Length > 2 && args[2].ToObject() is ISharpTSCallable cb)
-                        {
-                            callback = cb;
-                        }
-                    }
-                    else if (args[1].ToObject() is ISharpTSCallable cb)
-                    {
-                        callback = cb;
-                    }
-                }
-            }
-        }
-
-        _writableEnded = true;
-        _writable = false;
-
-        if (chunk != null)
-        {
-            DoWrite(interpreter, chunk, encoding, null);
-        }
-
-        if (_corked)
-        {
-            Uncork(interpreter, RuntimeValue.Null, []);
-        }
-
-        if (_finalCallback != null)
-        {
-            var finalCbWrapper = new WriteCallbackWrapper(null, interpreter, this, 0);
-            try
-            {
-                _finalCallback.Call(interpreter, [finalCbWrapper]);
-            }
-            catch (Exception ex)
-            {
-                EmitEvent(interpreter, "error", [ex.Message]);
-            }
-        }
-
-        _writableFinished = true;
-        callback?.Call(interpreter, []);
-        EmitEvent(interpreter, "finish", []);
-
-        return RuntimeValue.FromObject(this);
-    }
+        => _writeCore.End(interpreter, args);
 
     private RuntimeValue Cork(Interp interpreter, RuntimeValue receiver, ReadOnlySpan<RuntimeValue> args)
     {
-        _corked = true;
+        _writeCore.Cork();
         return RuntimeValue.Null;
     }
 
     private RuntimeValue Uncork(Interp interpreter, RuntimeValue receiver, ReadOnlySpan<RuntimeValue> args)
     {
-        if (!_corked)
-        {
-            return RuntimeValue.Null;
-        }
-
-        _corked = false;
-
-        foreach (var item in _corkBuffer.Cast<WriteChunk>())
-        {
-            DoWrite(interpreter, item.Chunk, item.Encoding, item.Callback);
-        }
-        _corkBuffer.Clear();
-
+        _writeCore.Uncork(interpreter);
         return RuntimeValue.Null;
     }
 
     private RuntimeValue DestroyDuplex(Interp interpreter, RuntimeValue receiver, ReadOnlySpan<RuntimeValue> args)
     {
-        _writableDestroyed = true;
-        _writable = false;
-        _corkBuffer.Clear();
+        _writeCore.MarkDestroyed();
 
         // Destroy the readable side too via the base Destroy method
         var baseDestroy = base.GetMember("destroy") as BuiltInMethod;
@@ -280,31 +116,4 @@ public class SharpTSDuplex : SharpTSReadable
     }
 
     public override string ToString() => "Duplex {}";
-
-    private class WriteCallbackWrapper : ISharpTSCallable
-    {
-        private readonly ISharpTSCallable? _callback;
-        private readonly Interp _interpreter;
-        private readonly SharpTSDuplex _stream;
-        private readonly int _chunkSize;
-
-        public WriteCallbackWrapper(ISharpTSCallable? callback, Interp interpreter, SharpTSDuplex stream, int chunkSize)
-        {
-            _callback = callback;
-            _interpreter = interpreter;
-            _stream = stream;
-            _chunkSize = chunkSize;
-        }
-
-        public int Arity() => 1;
-
-        public object? Call(Interp interpreter, List<object?> arguments)
-        {
-            _stream._pendingWrites--;
-            _stream._writableLength -= _chunkSize;
-            _callback?.Call(_interpreter, []);
-            _stream.CheckDrain(_interpreter);
-            return null;
-        }
-    }
 }

--- a/Runtime/Types/SharpTSDuplex.cs
+++ b/Runtime/Types/SharpTSDuplex.cs
@@ -59,7 +59,7 @@ public class SharpTSDuplex : SharpTSReadable
     /// <summary>
     /// Gets a member (method or property) by name for interpreter dispatch.
     /// </summary>
-    public new object? GetMember(string name)
+    public override object? GetMember(string name)
     {
         return name switch
         {

--- a/Runtime/Types/SharpTSECDH.cs
+++ b/Runtime/Types/SharpTSECDH.cs
@@ -103,33 +103,11 @@ public class SharpTSECDH
         _ecdh.ImportPkcs8PrivateKey(keyBytes, out _);
     }
 
-    private static object EncodeResult(byte[] bytes, string? encoding)
-    {
-        return encoding?.ToLowerInvariant() switch
-        {
-            "hex" => Convert.ToHexString(bytes).ToLowerInvariant(),
-            "base64" => Convert.ToBase64String(bytes),
-            _ => new SharpTSBuffer(bytes)
-        };
-    }
+    private static object EncodeResult(byte[] bytes, string? encoding) =>
+        CryptoEncoding.ToBufferOrString(bytes, encoding);
 
-    private static byte[] DecodeInput(object input, string? encoding)
-    {
-        if (input is SharpTSBuffer buffer)
-            return buffer.Data;
-        if (input is byte[] bytes)
-            return bytes;
-        if (input is string str)
-        {
-            return encoding?.ToLowerInvariant() switch
-            {
-                "hex" => Convert.FromHexString(str),
-                "base64" => Convert.FromBase64String(str),
-                _ => System.Text.Encoding.UTF8.GetBytes(str)
-            };
-        }
-        throw new ArgumentException("Input must be a Buffer, byte array, or string");
-    }
+    private static byte[] DecodeInput(object input, string? encoding) =>
+        CryptoEncoding.FromEncoded(input, encoding);
 
     /// <summary>
     /// Gets a member of this ECDH object.

--- a/Runtime/Types/SharpTSEventEmitter.cs
+++ b/Runtime/Types/SharpTSEventEmitter.cs
@@ -12,7 +12,7 @@ namespace SharpTS.Runtime.Types;
 /// Provides event subscription, emission, and management following Node.js EventEmitter semantics.
 /// Supports once listeners, prepend operations, listener inspection, and max listener warnings.
 /// </remarks>
-public class SharpTSEventEmitter : ITypeCategorized
+public class SharpTSEventEmitter : ITypeCategorized, IMemberProvider
 {
     /// <inheritdoc />
     /// <remarks>
@@ -43,8 +43,18 @@ public class SharpTSEventEmitter : ITypeCategorized
 
     /// <summary>
     /// Gets a member (method or property) by name for interpreter dispatch.
+    /// Virtual so the EventEmitter family dispatches polymorphically (#1139); subclasses
+    /// override and chain to <c>base.GetMember</c>.
     /// </summary>
-    public object? GetMember(string name)
+    public virtual object? GetMember(string name) => GetEventEmitterMember(name);
+
+    /// <summary>
+    /// Resolves the core EventEmitter members, independent of any subclass override.
+    /// Call this (instead of casting to <see cref="SharpTSEventEmitter"/>) when you need
+    /// the raw EventEmitter behavior — e.g. a writable-side "drain"/"response" listener
+    /// that must not go through Readable's flowing-mode "on"/"once" wrappers.
+    /// </summary>
+    internal object? GetEventEmitterMember(string name)
     {
         return name switch
         {

--- a/Runtime/Types/SharpTSFSWatcher.cs
+++ b/Runtime/Types/SharpTSFSWatcher.cs
@@ -133,7 +133,7 @@ public class SharpTSFSWatcher : SharpTSEventEmitter, IDisposable
     /// <summary>
     /// Gets a member (method or property) by name for interpreter dispatch.
     /// </summary>
-    public new object? GetMember(string name)
+    public override object? GetMember(string name)
     {
         return name switch
         {

--- a/Runtime/Types/SharpTSHash.cs
+++ b/Runtime/Types/SharpTSHash.cs
@@ -24,15 +24,7 @@ public class SharpTSHash
     /// <param name="algorithm">The hash algorithm name: md5, sha1, sha256, sha512</param>
     public SharpTSHash(string algorithm)
     {
-        var hashName = algorithm.ToLowerInvariant() switch
-        {
-            "md5" => HashAlgorithmName.MD5,
-            "sha1" => HashAlgorithmName.SHA1,
-            "sha256" => HashAlgorithmName.SHA256,
-            "sha384" => HashAlgorithmName.SHA384,
-            "sha512" => HashAlgorithmName.SHA512,
-            _ => throw new ArgumentException($"Unsupported hash algorithm: {algorithm}")
-        };
+        var hashName = CryptoAlgorithms.ParseHashName(algorithm, context: "hash");
 
         _hash = IncrementalHash.CreateHash(hashName);
         _finalized = false;
@@ -66,12 +58,7 @@ public class SharpTSHash
         _finalized = true;
         var hashBytes = _hash.GetHashAndReset();
 
-        return encoding?.ToLowerInvariant() switch
-        {
-            "hex" => Convert.ToHexString(hashBytes).ToLowerInvariant(),
-            "base64" => Convert.ToBase64String(hashBytes),
-            _ => new SharpTSBuffer(hashBytes)
-        };
+        return CryptoEncoding.ToBufferOrString(hashBytes, encoding);
     }
 
     /// <summary>

--- a/Runtime/Types/SharpTSHmac.cs
+++ b/Runtime/Types/SharpTSHmac.cs
@@ -25,15 +25,7 @@ public class SharpTSHmac
     /// <param name="key">The secret key as a string (UTF-8 encoded) or byte array</param>
     public SharpTSHmac(string algorithm, object key)
     {
-        var hashName = algorithm.ToLowerInvariant() switch
-        {
-            "md5" => HashAlgorithmName.MD5,
-            "sha1" => HashAlgorithmName.SHA1,
-            "sha256" => HashAlgorithmName.SHA256,
-            "sha384" => HashAlgorithmName.SHA384,
-            "sha512" => HashAlgorithmName.SHA512,
-            _ => throw new ArgumentException($"Unsupported HMAC algorithm: {algorithm}")
-        };
+        var hashName = CryptoAlgorithms.ParseHashName(algorithm, context: "HMAC");
 
         byte[] keyBytes = ConvertToBytes(key);
         _hmac = IncrementalHash.CreateHMAC(hashName, keyBytes);
@@ -102,12 +94,7 @@ public class SharpTSHmac
         _finalized = true;
         var hmacBytes = _hmac.GetHashAndReset();
 
-        return encoding?.ToLowerInvariant() switch
-        {
-            "hex" => Convert.ToHexString(hmacBytes).ToLowerInvariant(),
-            "base64" => Convert.ToBase64String(hmacBytes),
-            _ => new SharpTSBuffer(hmacBytes)
-        };
+        return CryptoEncoding.ToBufferOrString(hmacBytes, encoding);
     }
 
     /// <summary>

--- a/Runtime/Types/SharpTSHttpRequest.cs
+++ b/Runtime/Types/SharpTSHttpRequest.cs
@@ -56,7 +56,7 @@ public class SharpTSHttpRequest : SharpTSReadable
     /// Gets a member (property or method) by name.
     /// Overrides Readable.GetMember to add HTTP-specific properties.
     /// </summary>
-    public new object? GetMember(string name)
+    public override object? GetMember(string name)
     {
         return name switch
         {

--- a/Runtime/Types/SharpTSHttpResponse.cs
+++ b/Runtime/Types/SharpTSHttpResponse.cs
@@ -69,7 +69,7 @@ public class SharpTSHttpResponse : SharpTSWritable
     /// Gets a member (property or method) by name.
     /// Overrides Writable.GetMember to add HTTP-specific methods.
     /// </summary>
-    public new object? GetMember(string name)
+    public override object? GetMember(string name)
     {
         return name switch
         {

--- a/Runtime/Types/SharpTSHttpServer.cs
+++ b/Runtime/Types/SharpTSHttpServer.cs
@@ -82,7 +82,7 @@ public class SharpTSHttpServer : SharpTSEventEmitter, IDisposable
     /// <summary>
     /// Gets a member (property or method) by name.
     /// </summary>
-    public new object? GetMember(string name)
+    public override object? GetMember(string name)
     {
         return name switch
         {

--- a/Runtime/Types/SharpTSHttpsMessages.cs
+++ b/Runtime/Types/SharpTSHttpsMessages.cs
@@ -20,7 +20,7 @@ public class SharpTSHttpsServerRequest : SharpTSReadable
 
     public SharpTSHttpsServerRequest(HttpProtocol.ParsedRequest parsed) => _parsed = parsed;
 
-    public new object? GetMember(string name)
+    public override object? GetMember(string name)
     {
         return name switch
         {
@@ -85,7 +85,7 @@ public class SharpTSHttpsServerResponse : SharpTSWritable
         _tcpClient = tcpClient;
     }
 
-    public new object? GetMember(string name)
+    public override object? GetMember(string name)
     {
         return name switch
         {

--- a/Runtime/Types/SharpTSHttpsServer.cs
+++ b/Runtime/Types/SharpTSHttpsServer.cs
@@ -82,7 +82,7 @@ public class SharpTSHttpsServer : SharpTSEventEmitter, IDisposable
 
     public bool Listening => _isListening;
 
-    public new object? GetMember(string name)
+    public override object? GetMember(string name)
     {
         return name switch
         {

--- a/Runtime/Types/SharpTSIntlCollator.cs
+++ b/Runtime/Types/SharpTSIntlCollator.cs
@@ -7,9 +7,8 @@ namespace SharpTS.Runtime.Types;
 /// Runtime representation of Intl.Collator.
 /// Provides locale-aware string comparison using .NET's CompareInfo.
 /// </summary>
-public class SharpTSIntlCollator
+public class SharpTSIntlCollator : SharpTSIntlFormatterBase
 {
-    private readonly string _locale;
     private string _usage;
     private string _sensitivity;
     private bool _ignorePunctuation;
@@ -20,24 +19,7 @@ public class SharpTSIntlCollator
 
     public SharpTSIntlCollator(object? locale, object? options)
     {
-        string localeStr = locale?.ToString() ?? "";
-
-        CultureInfo culture;
-        try
-        {
-            culture = string.IsNullOrEmpty(localeStr)
-                ? CultureInfo.CurrentCulture
-                : CultureInfo.GetCultureInfo(localeStr.Replace('_', '-'));
-        }
-        catch
-        {
-            culture = CultureInfo.InvariantCulture;
-        }
-
-        _locale = culture.Name;
-        if (string.IsNullOrEmpty(_locale))
-            _locale = "en-US";
-
+        var culture = ResolveLocale(locale);
         _compareInfo = culture.CompareInfo;
 
         // Defaults
@@ -47,14 +29,9 @@ public class SharpTSIntlCollator
         _numeric = false;
         _caseFirst = "false";
 
-        if (options is SharpTSObject obj)
-        {
-            ParseOptions(obj.Fields);
-        }
-        else if (options is IDictionary<string, object?> dict)
-        {
-            ParseOptions(dict);
-        }
+        var opts = NormalizeOptions(options);
+        if (opts != null)
+            ParseOptions(opts);
 
         _compareOptions = BuildCompareOptions();
     }
@@ -131,7 +108,7 @@ public class SharpTSIntlCollator
         return result < 0 ? -1.0 : result > 0 ? 1.0 : 0.0;
     }
 
-    public Dictionary<string, object?> GetResolvedOptions()
+    public override Dictionary<string, object?> GetResolvedOptions()
     {
         return new Dictionary<string, object?>
         {
@@ -156,17 +133,9 @@ public class SharpTSIntlCollator
     }
 
     /// <summary>
-    /// JS-facing resolvedOptions method for compiled mode reflection dispatch.
-    /// </summary>
-    public object? resolvedOptions()
-    {
-        return GetResolvedOptions();
-    }
-
-    /// <summary>
     /// Gets a member (method) by name for interpreter dispatch.
     /// </summary>
-    public object? GetMember(string name)
+    public override object? GetMember(string name)
     {
         return name switch
         {
@@ -176,11 +145,7 @@ public class SharpTSIntlCollator
                 string y = (args.Length > 1 ? args[1].ToObject() : null)?.ToString() ?? "";
                 return RuntimeValue.FromBoxed(CompareStrings(x, y));
             }),
-            "resolvedOptions" => BuiltInMethod.CreateV2("resolvedOptions", 0, (_, _, _) =>
-            {
-                return RuntimeValue.FromObject(new SharpTSObject(GetResolvedOptions()));
-            }),
-            _ => null
+            _ => base.GetMember(name)
         };
     }
 

--- a/Runtime/Types/SharpTSIntlDateTimeFormat.cs
+++ b/Runtime/Types/SharpTSIntlDateTimeFormat.cs
@@ -11,9 +11,8 @@ namespace SharpTS.Runtime.Types;
 /// Supports BCP 47 Unicode extensions (-u-ca-, -u-nu-, -u-hc-), calendar systems,
 /// numbering systems, formatToParts, formatRange, and formatRangeToParts.
 /// </summary>
-public class SharpTSIntlDateTimeFormat
+public class SharpTSIntlDateTimeFormat : SharpTSIntlFormatterBase
 {
-    private string _locale;
     private string? _dateStyle;
     private string? _timeStyle;
     private string? _year;
@@ -68,22 +67,7 @@ public class SharpTSIntlDateTimeFormat
         // Parse locale with BCP 47 extension support
         string localeStr = locale?.ToString() ?? "";
         var bcp47 = Bcp47Extensions.Parse(localeStr.Replace('_', '-'));
-        string baseLocale = bcp47.BaseLocale;
-
-        try
-        {
-            _culture = string.IsNullOrEmpty(baseLocale)
-                ? CultureInfo.CurrentCulture
-                : CultureInfo.GetCultureInfo(baseLocale);
-        }
-        catch
-        {
-            _culture = CultureInfo.InvariantCulture;
-        }
-
-        _locale = _culture.Name;
-        if (string.IsNullOrEmpty(_locale))
-            _locale = "en-US";
+        _culture = ResolveCulture(bcp47.BaseLocale);
 
         // Defaults from BCP 47 extensions (options override later)
         _calendar = bcp47.Calendar ?? "gregory";
@@ -94,14 +78,9 @@ public class SharpTSIntlDateTimeFormat
         _dtfi = (DateTimeFormatInfo)_culture.DateTimeFormat.Clone();
 
         // Parse options (may override BCP 47 extensions)
-        if (options is SharpTSObject obj)
-        {
-            ParseOptions(obj.Fields);
-        }
-        else if (options is IDictionary<string, object?> dict)
-        {
-            ParseOptions(dict);
-        }
+        var opts = NormalizeOptions(options);
+        if (opts != null)
+            ParseOptions(opts);
 
         // Apply calendar
         var cal = MapCalendar(_calendar);
@@ -553,7 +532,7 @@ public class SharpTSIntlDateTimeFormat
     /// <summary>
     /// Returns an object describing the computed options of the formatter.
     /// </summary>
-    public Dictionary<string, object?> GetResolvedOptions()
+    public override Dictionary<string, object?> GetResolvedOptions()
     {
         var result = new Dictionary<string, object?>
         {
@@ -615,14 +594,6 @@ public class SharpTSIntlDateTimeFormat
     {
         DateTime dt = ToDateTime(date);
         return FormatDate(dt);
-    }
-
-    /// <summary>
-    /// JS-facing resolvedOptions method for compiled mode reflection dispatch.
-    /// </summary>
-    public object? resolvedOptions()
-    {
-        return GetResolvedOptions();
     }
 
     #region formatToParts
@@ -869,7 +840,7 @@ public class SharpTSIntlDateTimeFormat
     /// <summary>
     /// Gets a member (method) by name for interpreter dispatch.
     /// </summary>
-    public object? GetMember(string name)
+    public override object? GetMember(string name)
     {
         return name switch
         {
@@ -877,10 +848,6 @@ public class SharpTSIntlDateTimeFormat
             {
                 DateTime dt = ToDateTime(args.Length > 0 ? args[0].ToObject() : null);
                 return RuntimeValue.FromBoxed(FormatDate(dt));
-            }),
-            "resolvedOptions" => BuiltInMethod.CreateV2("resolvedOptions", 0, (_, _, _) =>
-            {
-                return RuntimeValue.FromObject(new SharpTSObject(GetResolvedOptions()));
             }),
             "formatToParts" => BuiltInMethod.CreateV2("formatToParts", 1, (_, _, args) =>
             {
@@ -907,7 +874,7 @@ public class SharpTSIntlDateTimeFormat
                     items.Add(new SharpTSObject(p));
                 return RuntimeValue.FromObject(new SharpTSArray(items));
             }),
-            _ => null
+            _ => base.GetMember(name)
         };
     }
 

--- a/Runtime/Types/SharpTSIntlDisplayNames.cs
+++ b/Runtime/Types/SharpTSIntlDisplayNames.cs
@@ -7,9 +7,8 @@ namespace SharpTS.Runtime.Types;
 /// Runtime representation of Intl.DisplayNames.
 /// Provides locale-aware display names for languages, regions, scripts, currencies, etc.
 /// </summary>
-public class SharpTSIntlDisplayNames
+public class SharpTSIntlDisplayNames : SharpTSIntlFormatterBase
 {
-    private readonly string _locale;
     private string _type;
     private string _style;
     private string _fallback;
@@ -133,23 +132,7 @@ public class SharpTSIntlDisplayNames
 
     public SharpTSIntlDisplayNames(object? locale, object? options)
     {
-        string localeStr = locale?.ToString() ?? "";
-
-        CultureInfo culture;
-        try
-        {
-            culture = string.IsNullOrEmpty(localeStr)
-                ? CultureInfo.CurrentCulture
-                : CultureInfo.GetCultureInfo(localeStr.Replace('_', '-'));
-        }
-        catch
-        {
-            culture = CultureInfo.InvariantCulture;
-        }
-
-        _locale = culture.Name;
-        if (string.IsNullOrEmpty(_locale))
-            _locale = "en-US";
+        ResolveLocale(locale);
 
         // Defaults
         _type = "language";
@@ -157,14 +140,9 @@ public class SharpTSIntlDisplayNames
         _fallback = "code";
         _languageDisplay = "dialect";
 
-        if (options is SharpTSObject obj)
-        {
-            ParseOptions(obj.Fields);
-        }
-        else if (options is IDictionary<string, object?> dict)
-        {
-            ParseOptions(dict);
-        }
+        var opts = NormalizeOptions(options);
+        if (opts != null)
+            ParseOptions(opts);
     }
 
     private void ParseOptions(IEnumerable<KeyValuePair<string, object?>> opts)
@@ -255,7 +233,7 @@ public class SharpTSIntlDisplayNames
         return DateTimeFieldNames.TryGetValue(code, out var name) ? name : null;
     }
 
-    public Dictionary<string, object?> GetResolvedOptions()
+    public override Dictionary<string, object?> GetResolvedOptions()
     {
         return new Dictionary<string, object?>
         {
@@ -276,17 +254,9 @@ public class SharpTSIntlDisplayNames
     }
 
     /// <summary>
-    /// JS-facing resolvedOptions() method for compiled mode reflection dispatch.
-    /// </summary>
-    public object? resolvedOptions()
-    {
-        return GetResolvedOptions();
-    }
-
-    /// <summary>
     /// Gets a member (method) by name for interpreter dispatch.
     /// </summary>
-    public object? GetMember(string name)
+    public override object? GetMember(string name)
     {
         return name switch
         {
@@ -295,11 +265,7 @@ public class SharpTSIntlDisplayNames
                 string code = (args.Length > 0 ? args[0].ToObject() : null)?.ToString() ?? "";
                 return RuntimeValue.FromBoxed(LookupDisplayName(code));
             }),
-            "resolvedOptions" => BuiltInMethod.CreateV2("resolvedOptions", 0, (_, _, _) =>
-            {
-                return RuntimeValue.FromObject(new SharpTSObject(GetResolvedOptions()));
-            }),
-            _ => null
+            _ => base.GetMember(name)
         };
     }
 

--- a/Runtime/Types/SharpTSIntlFormatterBase.cs
+++ b/Runtime/Types/SharpTSIntlFormatterBase.cs
@@ -1,0 +1,114 @@
+using System.Globalization;
+using SharpTS.Runtime.BuiltIns;
+
+namespace SharpTS.Runtime.Types;
+
+/// <summary>
+/// Shared base for the <c>Intl.*</c> formatter value-type wrappers (NumberFormat,
+/// DateTimeFormat, RelativeTimeFormat, PluralRules, ListFormat, DisplayNames,
+/// Collator, Segmenter).
+/// </summary>
+/// <remarks>
+/// All eight previously repeated, near-verbatim (#1136): the locale-resolution
+/// ctor preamble, the options-dispatch + dictionary normalization, the
+/// primary-language extraction, and the <c>resolvedOptions</c> member. Those are
+/// centralized here; each formatter keeps only its own option fields, its format
+/// method(s), and its <see cref="GetResolvedOptions"/> body.
+///
+/// Interpreter and compiled mode share these very classes (compiled IL calls into
+/// them via <c>RuntimeTypes.Intl</c>), so this refactor is automatically
+/// behaviour-identical across both.
+/// </remarks>
+public abstract class SharpTSIntlFormatterBase
+{
+    /// <summary>The resolved BCP-47 locale name (a canonical CultureInfo name, or "en-US").</summary>
+    protected string _locale = "en-US";
+
+    /// <summary>
+    /// Resolves a JS locale argument (null/string, with <c>'_'</c> normalized to
+    /// <c>'-'</c>) to a <see cref="CultureInfo"/>, setting <see cref="_locale"/> to its
+    /// canonical name (falling back to "en-US"). Returns the culture for subclasses that
+    /// need <c>culture.NumberFormat</c>/<c>CompareInfo</c>/etc.
+    /// </summary>
+    protected CultureInfo ResolveLocale(object? locale)
+        => ResolveCulture((locale?.ToString() ?? "").Replace('_', '-'));
+
+    /// <summary>
+    /// Resolves an already-normalized base-locale string to a <see cref="CultureInfo"/>
+    /// and sets <see cref="_locale"/>. Used directly by DateTimeFormat, which parses
+    /// BCP-47 extensions before resolving the base locale.
+    /// </summary>
+    protected CultureInfo ResolveCulture(string baseLocale)
+    {
+        CultureInfo culture;
+        try
+        {
+            culture = string.IsNullOrEmpty(baseLocale)
+                ? CultureInfo.CurrentCulture
+                : CultureInfo.GetCultureInfo(baseLocale);
+        }
+        catch
+        {
+            culture = CultureInfo.InvariantCulture;
+        }
+
+        _locale = culture.Name;
+        if (string.IsNullOrEmpty(_locale))
+            _locale = "en-US"; // Invariant falls back to en-US for display
+
+        return culture;
+    }
+
+    /// <summary>
+    /// The primary language subtag of <see cref="_locale"/> (e.g. "en-US" → "en").
+    /// </summary>
+    protected string PrimaryLanguage
+    {
+        get
+        {
+            int dashIndex = _locale.IndexOf('-');
+            return dashIndex >= 0
+                ? _locale[..dashIndex].ToLowerInvariant()
+                : _locale.ToLowerInvariant();
+        }
+    }
+
+    /// <summary>
+    /// Normalizes a JS options argument to a key/value sequence: a
+    /// <see cref="SharpTSObject"/>'s fields, an <see cref="IDictionary{TKey,TValue}"/>,
+    /// or <c>null</c> when no options object was provided.
+    /// </summary>
+    protected static IEnumerable<KeyValuePair<string, object?>>? NormalizeOptions(object? options)
+        => options switch
+        {
+            SharpTSObject obj => obj.Fields,
+            IDictionary<string, object?> dict => dict,
+            _ => null
+        };
+
+    /// <summary>
+    /// Builds the <c>resolvedOptions()</c> dictionary for this formatter.
+    /// </summary>
+    public abstract Dictionary<string, object?> GetResolvedOptions();
+
+    /// <summary>
+    /// JS-facing resolvedOptions method for compiled-mode reflection dispatch.
+    /// </summary>
+    public object? resolvedOptions() => GetResolvedOptions();
+
+    /// <summary>
+    /// Member dispatch for interpreter access. Subclasses override to add their
+    /// format-specific members and chain to <c>base.GetMember</c> for resolvedOptions.
+    /// </summary>
+    public virtual object? GetMember(string name)
+    {
+        return name switch
+        {
+            "resolvedOptions" => BuiltInMethod.CreateV2("resolvedOptions", 0, (_, _, _) =>
+            {
+                return RuntimeValue.FromObject(new SharpTSObject(GetResolvedOptions()));
+            }),
+            _ => null
+        };
+    }
+}

--- a/Runtime/Types/SharpTSIntlListFormat.cs
+++ b/Runtime/Types/SharpTSIntlListFormat.cs
@@ -7,48 +7,24 @@ namespace SharpTS.Runtime.Types;
 /// Runtime representation of Intl.ListFormat.
 /// Provides locale-aware list formatting ("A, B, and C").
 /// </summary>
-public class SharpTSIntlListFormat
+public class SharpTSIntlListFormat : SharpTSIntlFormatterBase
 {
-    private readonly string _locale;
     private string _style; // "long", "short", "narrow"
     private string _type;  // "conjunction", "disjunction", "unit"
     private readonly string _lang;
 
     public SharpTSIntlListFormat(object? locale, object? options)
     {
-        string localeStr = locale?.ToString() ?? "";
-
-        CultureInfo culture;
-        try
-        {
-            culture = string.IsNullOrEmpty(localeStr)
-                ? CultureInfo.CurrentCulture
-                : CultureInfo.GetCultureInfo(localeStr.Replace('_', '-'));
-        }
-        catch
-        {
-            culture = CultureInfo.InvariantCulture;
-        }
-
-        _locale = culture.Name;
-        if (string.IsNullOrEmpty(_locale))
-            _locale = "en-US";
-
-        int dashIndex = _locale.IndexOf('-');
-        _lang = dashIndex >= 0 ? _locale[..dashIndex].ToLowerInvariant() : _locale.ToLowerInvariant();
+        ResolveLocale(locale);
+        _lang = PrimaryLanguage;
 
         // Defaults
         _style = "long";
         _type = "conjunction";
 
-        if (options is SharpTSObject obj)
-        {
-            ParseOptions(obj.Fields);
-        }
-        else if (options is IDictionary<string, object?> dict)
-        {
-            ParseOptions(dict);
-        }
+        var opts = NormalizeOptions(options);
+        if (opts != null)
+            ParseOptions(opts);
     }
 
     private void ParseOptions(IEnumerable<KeyValuePair<string, object?>> opts)
@@ -220,7 +196,7 @@ public class SharpTSIntlListFormat
         });
     }
 
-    public Dictionary<string, object?> GetResolvedOptions()
+    public override Dictionary<string, object?> GetResolvedOptions()
     {
         return new Dictionary<string, object?>
         {
@@ -278,17 +254,9 @@ public class SharpTSIntlListFormat
     }
 
     /// <summary>
-    /// JS-facing resolvedOptions method for compiled mode reflection dispatch.
-    /// </summary>
-    public object? resolvedOptions()
-    {
-        return GetResolvedOptions();
-    }
-
-    /// <summary>
     /// Gets a member (method) by name for interpreter dispatch.
     /// </summary>
-    public object? GetMember(string name)
+    public override object? GetMember(string name)
     {
         return name switch
         {
@@ -302,11 +270,7 @@ public class SharpTSIntlListFormat
                 var items = ToStringList(args.Length > 0 ? args[0].ToObject() : null);
                 return RuntimeValue.FromBoxed(GetFormattedParts(items));
             }),
-            "resolvedOptions" => BuiltInMethod.CreateV2("resolvedOptions", 0, (_, _, _) =>
-            {
-                return RuntimeValue.FromObject(new SharpTSObject(GetResolvedOptions()));
-            }),
-            _ => null
+            _ => base.GetMember(name)
         };
     }
 

--- a/Runtime/Types/SharpTSIntlNumberFormat.cs
+++ b/Runtime/Types/SharpTSIntlNumberFormat.cs
@@ -8,9 +8,8 @@ namespace SharpTS.Runtime.Types;
 /// Runtime representation of Intl.NumberFormat.
 /// Provides locale-aware number formatting using .NET's CultureInfo/NumberFormatInfo.
 /// </summary>
-public class SharpTSIntlNumberFormat
+public class SharpTSIntlNumberFormat : SharpTSIntlFormatterBase
 {
-    private string _locale;
     private string _style;
     private string? _currency;
     private int _minimumFractionDigits;
@@ -49,24 +48,7 @@ public class SharpTSIntlNumberFormat
     public SharpTSIntlNumberFormat(object? locale, object? options)
     {
         // Parse locale
-        string localeStr = locale?.ToString() ?? "";
-        _locale = localeStr;
-
-        CultureInfo culture;
-        try
-        {
-            culture = string.IsNullOrEmpty(localeStr)
-                ? CultureInfo.CurrentCulture
-                : CultureInfo.GetCultureInfo(localeStr.Replace('_', '-'));
-        }
-        catch
-        {
-            culture = CultureInfo.InvariantCulture;
-        }
-
-        _locale = culture.Name;
-        if (string.IsNullOrEmpty(_locale))
-            _locale = "en-US"; // Invariant falls back to en-US for display
+        var culture = ResolveLocale(locale);
 
         // Clone number format so we can modify it
         _numberFormat = (NumberFormatInfo)culture.NumberFormat.Clone();
@@ -81,14 +63,9 @@ public class SharpTSIntlNumberFormat
         int defaultMinFrac = 0;
         int defaultMaxFrac = 3;
 
-        if (options is SharpTSObject obj)
-        {
-            ParseOptions(obj.Fields, ref defaultMinFrac, ref defaultMaxFrac);
-        }
-        else if (options is IDictionary<string, object?> dict)
-        {
-            ParseOptions(dict, ref defaultMinFrac, ref defaultMaxFrac);
-        }
+        var opts = NormalizeOptions(options);
+        if (opts != null)
+            ParseOptions(opts, ref defaultMinFrac, ref defaultMaxFrac);
 
         _minimumFractionDigits = defaultMinFrac;
         _maximumFractionDigits = defaultMaxFrac;
@@ -319,7 +296,7 @@ public class SharpTSIntlNumberFormat
     /// <summary>
     /// Returns an object describing the computed options of the formatter.
     /// </summary>
-    public Dictionary<string, object?> GetResolvedOptions()
+    public override Dictionary<string, object?> GetResolvedOptions()
     {
         var result = new Dictionary<string, object?>
         {
@@ -352,17 +329,9 @@ public class SharpTSIntlNumberFormat
     }
 
     /// <summary>
-    /// JS-facing resolvedOptions method for compiled mode reflection dispatch.
-    /// </summary>
-    public object? resolvedOptions()
-    {
-        return GetResolvedOptions();
-    }
-
-    /// <summary>
     /// Gets a member (method) by name for interpreter dispatch.
     /// </summary>
-    public object? GetMember(string name)
+    public override object? GetMember(string name)
     {
         return name switch
         {
@@ -371,11 +340,7 @@ public class SharpTSIntlNumberFormat
                 double num = Interp.ToNumber(args.Length > 0 ? args[0].ToObject() : null);
                 return RuntimeValue.FromBoxed(FormatNumber(num));
             }),
-            "resolvedOptions" => BuiltInMethod.CreateV2("resolvedOptions", 0, (_, _, _) =>
-            {
-                return RuntimeValue.FromObject(new SharpTSObject(GetResolvedOptions()));
-            }),
-            _ => null
+            _ => base.GetMember(name)
         };
     }
 

--- a/Runtime/Types/SharpTSIntlNumberFormat.cs
+++ b/Runtime/Types/SharpTSIntlNumberFormat.cs
@@ -1,5 +1,6 @@
 using System.Globalization;
 using SharpTS.Runtime.BuiltIns;
+using Interp = SharpTS.Execution.Interpreter;
 
 namespace SharpTS.Runtime.Types;
 
@@ -129,17 +130,17 @@ public class SharpTSIntlNumberFormat
 
         if (dict.TryGetValue("minimumFractionDigits", out var minFracVal))
         {
-            defaultMinFrac = ToInt(minFracVal);
+            defaultMinFrac = (int)Interp.ToNumber(minFracVal);
         }
 
         if (dict.TryGetValue("maximumFractionDigits", out var maxFracVal))
         {
-            defaultMaxFrac = ToInt(maxFracVal);
+            defaultMaxFrac = (int)Interp.ToNumber(maxFracVal);
         }
 
         if (dict.TryGetValue("minimumIntegerDigits", out var minIntVal))
         {
-            _minimumIntegerDigits = ToInt(minIntVal);
+            _minimumIntegerDigits = (int)Interp.ToNumber(minIntVal);
         }
 
         if (dict.TryGetValue("useGrouping", out var groupVal))
@@ -346,7 +347,7 @@ public class SharpTSIntlNumberFormat
     /// </summary>
     public object? format(object? number)
     {
-        double num = ToDouble(number);
+        double num = Interp.ToNumber(number);
         return FormatNumber(num);
     }
 
@@ -367,7 +368,7 @@ public class SharpTSIntlNumberFormat
         {
             "format" => BuiltInMethod.CreateV2("format", 1, (_, _, args) =>
             {
-                double num = ToDouble(args.Length > 0 ? args[0].ToObject() : null);
+                double num = Interp.ToNumber(args.Length > 0 ? args[0].ToObject() : null);
                 return RuntimeValue.FromBoxed(FormatNumber(num));
             }),
             "resolvedOptions" => BuiltInMethod.CreateV2("resolvedOptions", 0, (_, _, _) =>
@@ -375,29 +376,6 @@ public class SharpTSIntlNumberFormat
                 return RuntimeValue.FromObject(new SharpTSObject(GetResolvedOptions()));
             }),
             _ => null
-        };
-    }
-
-    private static double ToDouble(object? value)
-    {
-        return value switch
-        {
-            double d => d,
-            int i => i,
-            long l => l,
-            float f => f,
-            string s when double.TryParse(s, NumberStyles.Any, CultureInfo.InvariantCulture, out var d) => d,
-            _ => 0.0
-        };
-    }
-
-    private static int ToInt(object? value)
-    {
-        return value switch
-        {
-            double d => (int)d,
-            int i => i,
-            _ => 0
         };
     }
 

--- a/Runtime/Types/SharpTSIntlPluralRules.cs
+++ b/Runtime/Types/SharpTSIntlPluralRules.cs
@@ -1,5 +1,6 @@
 using System.Globalization;
 using SharpTS.Runtime.BuiltIns;
+using Interp = SharpTS.Execution.Interpreter;
 
 namespace SharpTS.Runtime.Types;
 
@@ -64,13 +65,13 @@ public class SharpTSIntlPluralRules
             _type = t;
 
         if (dict.TryGetValue("minimumIntegerDigits", out var minIntVal))
-            _minimumIntegerDigits = ToInt(minIntVal);
+            _minimumIntegerDigits = (int)Interp.ToNumber(minIntVal);
 
         if (dict.TryGetValue("minimumFractionDigits", out var minFracVal))
-            _minimumFractionDigits = ToInt(minFracVal);
+            _minimumFractionDigits = (int)Interp.ToNumber(minFracVal);
 
         if (dict.TryGetValue("maximumFractionDigits", out var maxFracVal))
-            _maximumFractionDigits = ToInt(maxFracVal);
+            _maximumFractionDigits = (int)Interp.ToNumber(maxFracVal);
     }
 
     /// <summary>
@@ -291,7 +292,7 @@ public class SharpTSIntlPluralRules
     /// </summary>
     public object? select(object? number)
     {
-        double num = ToDouble(number);
+        double num = Interp.ToNumber(number);
         return SelectCategory(num);
     }
 
@@ -312,7 +313,7 @@ public class SharpTSIntlPluralRules
         {
             "select" => BuiltInMethod.CreateV2("select", 1, (_, _, args) =>
             {
-                double num = ToDouble(args.Length > 0 ? args[0].ToObject() : null);
+                double num = Interp.ToNumber(args.Length > 0 ? args[0].ToObject() : null);
                 return RuntimeValue.FromBoxed(SelectCategory(num));
             }),
             "resolvedOptions" => BuiltInMethod.CreateV2("resolvedOptions", 0, (_, _, _) =>
@@ -320,29 +321,6 @@ public class SharpTSIntlPluralRules
                 return RuntimeValue.FromObject(new SharpTSObject(GetResolvedOptions()));
             }),
             _ => null
-        };
-    }
-
-    private static double ToDouble(object? value)
-    {
-        return value switch
-        {
-            double d => d,
-            int i => i,
-            long l => l,
-            float f => f,
-            string s when double.TryParse(s, NumberStyles.Any, CultureInfo.InvariantCulture, out var d) => d,
-            _ => 0.0
-        };
-    }
-
-    private static int ToInt(object? value)
-    {
-        return value switch
-        {
-            double d => (int)d,
-            int i => i,
-            _ => 0
         };
     }
 

--- a/Runtime/Types/SharpTSIntlPluralRules.cs
+++ b/Runtime/Types/SharpTSIntlPluralRules.cs
@@ -8,9 +8,8 @@ namespace SharpTS.Runtime.Types;
 /// Runtime representation of Intl.PluralRules.
 /// Provides plural category selection (zero, one, two, few, many, other) based on CLDR rules.
 /// </summary>
-public class SharpTSIntlPluralRules
+public class SharpTSIntlPluralRules : SharpTSIntlFormatterBase
 {
-    private readonly string _locale;
     private string _type; // "cardinal" or "ordinal"
     private int _minimumIntegerDigits;
     private int _minimumFractionDigits;
@@ -21,23 +20,7 @@ public class SharpTSIntlPluralRules
 
     public SharpTSIntlPluralRules(object? locale, object? options)
     {
-        string localeStr = locale?.ToString() ?? "";
-
-        CultureInfo culture;
-        try
-        {
-            culture = string.IsNullOrEmpty(localeStr)
-                ? CultureInfo.CurrentCulture
-                : CultureInfo.GetCultureInfo(localeStr.Replace('_', '-'));
-        }
-        catch
-        {
-            culture = CultureInfo.InvariantCulture;
-        }
-
-        _locale = culture.Name;
-        if (string.IsNullOrEmpty(_locale))
-            _locale = "en-US";
+        ResolveLocale(locale);
 
         // Defaults
         _type = "cardinal";
@@ -45,14 +28,9 @@ public class SharpTSIntlPluralRules
         _minimumFractionDigits = 0;
         _maximumFractionDigits = 3;
 
-        if (options is SharpTSObject obj)
-        {
-            ParseOptions(obj.Fields);
-        }
-        else if (options is IDictionary<string, object?> dict)
-        {
-            ParseOptions(dict);
-        }
+        var opts = NormalizeOptions(options);
+        if (opts != null)
+            ParseOptions(opts);
     }
 
     private void ParseOptions(IEnumerable<KeyValuePair<string, object?>> opts)
@@ -80,19 +58,12 @@ public class SharpTSIntlPluralRules
     /// </summary>
     public string SelectCategory(double number)
     {
-        string lang = GetLanguageCode();
+        string lang = PrimaryLanguage;
 
         if (_type == "ordinal")
             return SelectOrdinal(number, lang);
 
         return SelectCardinal(number, lang);
-    }
-
-    private string GetLanguageCode()
-    {
-        // Extract primary language from locale (e.g., "en-US" → "en")
-        int dashIndex = _locale.IndexOf('-');
-        return dashIndex >= 0 ? _locale[..dashIndex].ToLowerInvariant() : _locale.ToLowerInvariant();
     }
 
     /// <summary>
@@ -242,7 +213,7 @@ public class SharpTSIntlPluralRules
         return long.TryParse(frac, out var f) ? f : 0;
     }
 
-    public Dictionary<string, object?> GetResolvedOptions()
+    public override Dictionary<string, object?> GetResolvedOptions()
     {
         return new Dictionary<string, object?>
         {
@@ -257,7 +228,7 @@ public class SharpTSIntlPluralRules
 
     private SharpTSArray GetPluralCategories()
     {
-        string lang = GetLanguageCode();
+        string lang = PrimaryLanguage;
         List<object?> categories;
 
         if (_type == "ordinal")
@@ -297,17 +268,9 @@ public class SharpTSIntlPluralRules
     }
 
     /// <summary>
-    /// JS-facing resolvedOptions method for compiled mode reflection dispatch.
-    /// </summary>
-    public object? resolvedOptions()
-    {
-        return GetResolvedOptions();
-    }
-
-    /// <summary>
     /// Gets a member (method) by name for interpreter dispatch.
     /// </summary>
-    public object? GetMember(string name)
+    public override object? GetMember(string name)
     {
         return name switch
         {
@@ -316,11 +279,7 @@ public class SharpTSIntlPluralRules
                 double num = Interp.ToNumber(args.Length > 0 ? args[0].ToObject() : null);
                 return RuntimeValue.FromBoxed(SelectCategory(num));
             }),
-            "resolvedOptions" => BuiltInMethod.CreateV2("resolvedOptions", 0, (_, _, _) =>
-            {
-                return RuntimeValue.FromObject(new SharpTSObject(GetResolvedOptions()));
-            }),
-            _ => null
+            _ => base.GetMember(name)
         };
     }
 

--- a/Runtime/Types/SharpTSIntlRelativeTimeFormat.cs
+++ b/Runtime/Types/SharpTSIntlRelativeTimeFormat.cs
@@ -8,9 +8,8 @@ namespace SharpTS.Runtime.Types;
 /// Runtime representation of Intl.RelativeTimeFormat.
 /// Provides locale-aware relative time formatting ("3 days ago", "in 2 hours").
 /// </summary>
-public class SharpTSIntlRelativeTimeFormat
+public class SharpTSIntlRelativeTimeFormat : SharpTSIntlFormatterBase
 {
-    private readonly string _locale;
     private string _style; // "long", "short", "narrow"
     private string _numeric; // "always", "auto"
     private readonly string _lang;
@@ -77,39 +76,16 @@ public class SharpTSIntlRelativeTimeFormat
 
     public SharpTSIntlRelativeTimeFormat(object? locale, object? options)
     {
-        string localeStr = locale?.ToString() ?? "";
-
-        CultureInfo culture;
-        try
-        {
-            culture = string.IsNullOrEmpty(localeStr)
-                ? CultureInfo.CurrentCulture
-                : CultureInfo.GetCultureInfo(localeStr.Replace('_', '-'));
-        }
-        catch
-        {
-            culture = CultureInfo.InvariantCulture;
-        }
-
-        _locale = culture.Name;
-        if (string.IsNullOrEmpty(_locale))
-            _locale = "en-US";
-
-        int dashIndex = _locale.IndexOf('-');
-        _lang = dashIndex >= 0 ? _locale[..dashIndex].ToLowerInvariant() : _locale.ToLowerInvariant();
+        ResolveLocale(locale);
+        _lang = PrimaryLanguage;
 
         // Defaults
         _style = "long";
         _numeric = "always";
 
-        if (options is SharpTSObject obj)
-        {
-            ParseOptions(obj.Fields);
-        }
-        else if (options is IDictionary<string, object?> dict)
-        {
-            ParseOptions(dict);
-        }
+        var opts = NormalizeOptions(options);
+        if (opts != null)
+            ParseOptions(opts);
     }
 
     private void ParseOptions(IEnumerable<KeyValuePair<string, object?>> opts)
@@ -265,7 +241,7 @@ public class SharpTSIntlRelativeTimeFormat
         return new SharpTSArray(parts);
     }
 
-    public Dictionary<string, object?> GetResolvedOptions()
+    public override Dictionary<string, object?> GetResolvedOptions()
     {
         return new Dictionary<string, object?>
         {
@@ -297,17 +273,9 @@ public class SharpTSIntlRelativeTimeFormat
     }
 
     /// <summary>
-    /// JS-facing resolvedOptions method for compiled mode reflection dispatch.
-    /// </summary>
-    public object? resolvedOptions()
-    {
-        return GetResolvedOptions();
-    }
-
-    /// <summary>
     /// Gets a member (method) by name for interpreter dispatch.
     /// </summary>
-    public object? GetMember(string name)
+    public override object? GetMember(string name)
     {
         return name switch
         {
@@ -323,11 +291,7 @@ public class SharpTSIntlRelativeTimeFormat
                 string unit = (args.Length > 1 ? args[1].ToObject() : null)?.ToString() ?? "second";
                 return RuntimeValue.FromBoxed(GetFormattedParts(num, unit));
             }),
-            "resolvedOptions" => BuiltInMethod.CreateV2("resolvedOptions", 0, (_, _, _) =>
-            {
-                return RuntimeValue.FromObject(new SharpTSObject(GetResolvedOptions()));
-            }),
-            _ => null
+            _ => base.GetMember(name)
         };
     }
 

--- a/Runtime/Types/SharpTSIntlRelativeTimeFormat.cs
+++ b/Runtime/Types/SharpTSIntlRelativeTimeFormat.cs
@@ -1,5 +1,6 @@
 using System.Globalization;
 using SharpTS.Runtime.BuiltIns;
+using Interp = SharpTS.Execution.Interpreter;
 
 namespace SharpTS.Runtime.Types;
 
@@ -280,7 +281,7 @@ public class SharpTSIntlRelativeTimeFormat
     /// </summary>
     public object? format(object? value, object? unit)
     {
-        double num = ToDouble(value);
+        double num = Interp.ToNumber(value);
         string unitStr = unit?.ToString() ?? "second";
         return FormatRelativeTime(num, unitStr);
     }
@@ -290,7 +291,7 @@ public class SharpTSIntlRelativeTimeFormat
     /// </summary>
     public object? formatToParts(object? value, object? unit)
     {
-        double num = ToDouble(value);
+        double num = Interp.ToNumber(value);
         string unitStr = unit?.ToString() ?? "second";
         return GetFormattedParts(num, unitStr);
     }
@@ -312,13 +313,13 @@ public class SharpTSIntlRelativeTimeFormat
         {
             "format" => BuiltInMethod.CreateV2("format", 2, (_, _, args) =>
             {
-                double num = ToDouble(args.Length > 0 ? args[0].ToObject() : null);
+                double num = Interp.ToNumber(args.Length > 0 ? args[0].ToObject() : null);
                 string unit = (args.Length > 1 ? args[1].ToObject() : null)?.ToString() ?? "second";
                 return RuntimeValue.FromBoxed(FormatRelativeTime(num, unit));
             }),
             "formatToParts" => BuiltInMethod.CreateV2("formatToParts", 2, (_, _, args) =>
             {
-                double num = ToDouble(args.Length > 0 ? args[0].ToObject() : null);
+                double num = Interp.ToNumber(args.Length > 0 ? args[0].ToObject() : null);
                 string unit = (args.Length > 1 ? args[1].ToObject() : null)?.ToString() ?? "second";
                 return RuntimeValue.FromBoxed(GetFormattedParts(num, unit));
             }),
@@ -327,19 +328,6 @@ public class SharpTSIntlRelativeTimeFormat
                 return RuntimeValue.FromObject(new SharpTSObject(GetResolvedOptions()));
             }),
             _ => null
-        };
-    }
-
-    private static double ToDouble(object? value)
-    {
-        return value switch
-        {
-            double d => d,
-            int i => i,
-            long l => l,
-            float f => f,
-            string s when double.TryParse(s, NumberStyles.Any, CultureInfo.InvariantCulture, out var d) => d,
-            _ => 0.0
         };
     }
 

--- a/Runtime/Types/SharpTSIntlSegmenter.cs
+++ b/Runtime/Types/SharpTSIntlSegmenter.cs
@@ -7,42 +7,20 @@ namespace SharpTS.Runtime.Types;
 /// Runtime representation of Intl.Segmenter.
 /// Provides locale-aware text segmentation by grapheme, word, or sentence boundaries.
 /// </summary>
-public class SharpTSIntlSegmenter
+public class SharpTSIntlSegmenter : SharpTSIntlFormatterBase
 {
-    private readonly string _locale;
     private string _granularity;
 
     public SharpTSIntlSegmenter(object? locale, object? options)
     {
-        string localeStr = locale?.ToString() ?? "";
-
-        CultureInfo culture;
-        try
-        {
-            culture = string.IsNullOrEmpty(localeStr)
-                ? CultureInfo.CurrentCulture
-                : CultureInfo.GetCultureInfo(localeStr.Replace('_', '-'));
-        }
-        catch
-        {
-            culture = CultureInfo.InvariantCulture;
-        }
-
-        _locale = culture.Name;
-        if (string.IsNullOrEmpty(_locale))
-            _locale = "en-US";
+        ResolveLocale(locale);
 
         // Default granularity
         _granularity = "grapheme";
 
-        if (options is SharpTSObject obj)
-        {
-            ParseOptions(obj.Fields);
-        }
-        else if (options is IDictionary<string, object?> dict)
-        {
-            ParseOptions(dict);
-        }
+        var opts = NormalizeOptions(options);
+        if (opts != null)
+            ParseOptions(opts);
     }
 
     private void ParseOptions(IEnumerable<KeyValuePair<string, object?>> opts)
@@ -64,7 +42,7 @@ public class SharpTSIntlSegmenter
         return new SharpTSIntlSegments(input, _granularity);
     }
 
-    public Dictionary<string, object?> GetResolvedOptions()
+    public override Dictionary<string, object?> GetResolvedOptions()
     {
         return new Dictionary<string, object?>
         {
@@ -82,17 +60,9 @@ public class SharpTSIntlSegmenter
     }
 
     /// <summary>
-    /// JS-facing resolvedOptions() method for compiled mode reflection dispatch.
-    /// </summary>
-    public object? resolvedOptions()
-    {
-        return GetResolvedOptions();
-    }
-
-    /// <summary>
     /// Gets a member (method) by name for interpreter dispatch.
     /// </summary>
-    public object? GetMember(string name)
+    public override object? GetMember(string name)
     {
         return name switch
         {
@@ -101,11 +71,7 @@ public class SharpTSIntlSegmenter
                 string input = (args.Length > 0 ? args[0].ToObject() : null)?.ToString() ?? "";
                 return RuntimeValue.FromBoxed(SegmentText(input));
             }),
-            "resolvedOptions" => BuiltInMethod.CreateV2("resolvedOptions", 0, (_, _, _) =>
-            {
-                return RuntimeValue.FromObject(new SharpTSObject(GetResolvedOptions()));
-            }),
-            _ => null
+            _ => base.GetMember(name)
         };
     }
 

--- a/Runtime/Types/SharpTSMessagePort.cs
+++ b/Runtime/Types/SharpTSMessagePort.cs
@@ -262,7 +262,7 @@ public class SharpTSMessagePort : SharpTSEventEmitter
     /// <summary>
     /// Gets a member (method or property) by name.
     /// </summary>
-    public new object? GetMember(string name)
+    public override object? GetMember(string name)
     {
         return name switch
         {

--- a/Runtime/Types/SharpTSNetServer.cs
+++ b/Runtime/Types/SharpTSNetServer.cs
@@ -58,7 +58,7 @@ public class SharpTSNetServer : SharpTSEventEmitter, IDisposable
     /// <summary>
     /// Gets a member by name for interpreter dispatch.
     /// </summary>
-    public new object? GetMember(string name)
+    public override object? GetMember(string name)
     {
         return name switch
         {

--- a/Runtime/Types/SharpTSPassThrough.cs
+++ b/Runtime/Types/SharpTSPassThrough.cs
@@ -25,7 +25,7 @@ public class SharpTSPassThrough : SharpTSTransform
     /// <summary>
     /// Gets a member (method or property) by name for interpreter dispatch.
     /// </summary>
-    public new object? GetMember(string name)
+    public override object? GetMember(string name)
     {
         // PassThrough inherits everything from Transform
         // with the default pass-through behavior

--- a/Runtime/Types/SharpTSReadStream.cs
+++ b/Runtime/Types/SharpTSReadStream.cs
@@ -188,7 +188,7 @@ public class SharpTSReadStream : SharpTSReadable
         });
     }
 
-    public new object? GetMember(string name)
+    public override object? GetMember(string name)
     {
         return name switch
         {

--- a/Runtime/Types/SharpTSReadable.cs
+++ b/Runtime/Types/SharpTSReadable.cs
@@ -57,7 +57,7 @@ public class SharpTSReadable : SharpTSEventEmitter
     /// <summary>
     /// Gets a member (method or property) by name for interpreter dispatch.
     /// </summary>
-    public new object? GetMember(string name)
+    public override object? GetMember(string name)
     {
         return name switch
         {
@@ -682,12 +682,15 @@ public class SharpTSReadable : SharpTSEventEmitter
         var listener = new DrainResumeListener(this);
         if (dest is SharpTSWritable writable)
         {
-            var onceMethod = ((SharpTSEventEmitter)writable).GetMember("once") as BuiltInMethod;
+            // Use the raw EventEmitter "once" (not Readable's flowing-mode wrapper):
+            // "drain" is a writable-side event and must not flip the readable side
+            // into flowing mode.
+            var onceMethod = writable.GetEventEmitterMember("once") as BuiltInMethod;
             onceMethod?.Bind(writable).Call(interpreter, ["drain", listener]);
         }
         else if (dest is SharpTSDuplex duplex)
         {
-            var onceMethod = ((SharpTSEventEmitter)duplex).GetMember("once") as BuiltInMethod;
+            var onceMethod = duplex.GetEventEmitterMember("once") as BuiltInMethod;
             onceMethod?.Bind(duplex).Call(interpreter, ["drain", listener]);
         }
     }

--- a/Runtime/Types/SharpTSReadableStream.cs
+++ b/Runtime/Types/SharpTSReadableStream.cs
@@ -229,7 +229,7 @@ public class SharpTSReadableStream : ITypeCategorized
         try
         {
             size = SizeAlgorithm != null
-                ? ToDouble(RuntimeCallableDispatcher.Invoke(OwnerInterpreter, SizeAlgorithm, chunk))
+                ? Interp.ToNumber(RuntimeCallableDispatcher.Invoke(OwnerInterpreter, SizeAlgorithm, chunk))
                 : 1.0;
         }
         catch (Exception ex)
@@ -401,14 +401,6 @@ public class SharpTSReadableStream : ITypeCategorized
             ["done"] = (object)done,
         };
     }
-
-    private static double ToDouble(object? v) => v switch
-    {
-        double d => d,
-        int i => i,
-        long l => l,
-        _ => 1.0,
-    };
 
     // ------- public API (member dispatch) ---------------------------------
 

--- a/Runtime/Types/SharpTSReadlineInterface.cs
+++ b/Runtime/Types/SharpTSReadlineInterface.cs
@@ -35,7 +35,7 @@ public class SharpTSReadlineInterface : SharpTSEventEmitter
     /// <summary>
     /// Gets a member of this interface object.
     /// </summary>
-    public new object? GetMember(string name)
+    public override object? GetMember(string name)
     {
         return name switch
         {

--- a/Runtime/Types/SharpTSSign.cs
+++ b/Runtime/Types/SharpTSSign.cs
@@ -33,24 +33,8 @@ public class SharpTSSign
     /// Parses the algorithm string into a HashAlgorithmName.
     /// Supports both simple names (sha256) and prefixed names (RSA-SHA256).
     /// </summary>
-    private static HashAlgorithmName ParseAlgorithm(string algorithm)
-    {
-        // Normalize: remove prefix like "RSA-" or "ECDSA-" and lowercase
-        var normalized = algorithm.ToLowerInvariant();
-        if (normalized.StartsWith("rsa-"))
-            normalized = normalized[4..];
-        else if (normalized.StartsWith("ecdsa-"))
-            normalized = normalized[6..];
-
-        return normalized switch
-        {
-            "sha1" => HashAlgorithmName.SHA1,
-            "sha256" => HashAlgorithmName.SHA256,
-            "sha384" => HashAlgorithmName.SHA384,
-            "sha512" => HashAlgorithmName.SHA512,
-            _ => throw new ArgumentException($"Unsupported signing algorithm: {algorithm}")
-        };
-    }
+    private static HashAlgorithmName ParseAlgorithm(string algorithm) =>
+        CryptoAlgorithms.ParseHashName(algorithm, stripSignaturePrefix: true, context: "signing");
 
     /// <summary>
     /// Updates the signer with the given data.
@@ -121,12 +105,7 @@ public class SharpTSSign
             signature = rsa.SignData(dataBytes, _hashAlgorithm, RSASignaturePadding.Pkcs1);
         }
 
-        return encoding?.ToLowerInvariant() switch
-        {
-            "hex" => Convert.ToHexString(signature).ToLowerInvariant(),
-            "base64" => Convert.ToBase64String(signature),
-            _ => new SharpTSBuffer(signature)
-        };
+        return CryptoEncoding.ToBufferOrString(signature, encoding);
     }
 
     /// <summary>

--- a/Runtime/Types/SharpTSSocket.cs
+++ b/Runtime/Types/SharpTSSocket.cs
@@ -58,7 +58,7 @@ public class SharpTSSocket : SharpTSEventEmitter
     /// <summary>
     /// Gets a member by name for interpreter dispatch.
     /// </summary>
-    public new object? GetMember(string name)
+    public override object? GetMember(string name)
     {
         return name switch
         {

--- a/Runtime/Types/SharpTSStatWatcher.cs
+++ b/Runtime/Types/SharpTSStatWatcher.cs
@@ -122,7 +122,7 @@ public class SharpTSStatWatcher : SharpTSEventEmitter, IDisposable
     /// <summary>
     /// Gets a member (method or property) by name for interpreter dispatch.
     /// </summary>
-    public new object? GetMember(string name)
+    public override object? GetMember(string name)
     {
         return name switch
         {

--- a/Runtime/Types/SharpTSStderr.cs
+++ b/Runtime/Types/SharpTSStderr.cs
@@ -30,7 +30,7 @@ public class SharpTSStderr : SharpTSWritable
     /// Gets a member by name, adding stderr-specific properties on top of Writable.
     /// Overrides end/destroy to be no-ops (process.stderr never ends in Node.js).
     /// </summary>
-    public new object? GetMember(string name)
+    public override object? GetMember(string name)
     {
         return name switch
         {

--- a/Runtime/Types/SharpTSStdin.cs
+++ b/Runtime/Types/SharpTSStdin.cs
@@ -26,7 +26,7 @@ public class SharpTSStdin : SharpTSReadable
     /// <summary>
     /// Gets a member by name, adding stdin-specific properties on top of Readable.
     /// </summary>
-    public new object? GetMember(string name)
+    public override object? GetMember(string name)
     {
         return name switch
         {

--- a/Runtime/Types/SharpTSStdout.cs
+++ b/Runtime/Types/SharpTSStdout.cs
@@ -28,11 +28,14 @@ public class SharpTSStdout : SharpTSWritable
 
     /// <summary>
     /// Gets a member by name, adding stdout-specific properties on top of Writable.
-    /// Must be declared here (with new) so that compiled mode's GetMember reflection
-    /// fallback finds it on this type and avoids AmbiguousMatchException.
     /// Overrides end/destroy to be no-ops (process.stdout never ends in Node.js).
     /// </summary>
-    public new object? GetMember(string name)
+    /// <remarks>
+    /// Now that <see cref="SharpTSEventEmitter.GetMember"/> is virtual (#1139) this is a
+    /// normal override: the compiled-mode reflection fallback resolves the single virtual
+    /// slot unambiguously and dispatches to this most-derived implementation.
+    /// </remarks>
+    public override object? GetMember(string name)
     {
         return name switch
         {

--- a/Runtime/Types/SharpTSTlsServer.cs
+++ b/Runtime/Types/SharpTSTlsServer.cs
@@ -88,7 +88,7 @@ public class SharpTSTlsServer : SharpTSEventEmitter, IDisposable
     /// <summary>
     /// Gets a member by name for interpreter dispatch.
     /// </summary>
-    public new object? GetMember(string name)
+    public override object? GetMember(string name)
     {
         return name switch
         {

--- a/Runtime/Types/SharpTSTlsSocket.cs
+++ b/Runtime/Types/SharpTSTlsSocket.cs
@@ -46,7 +46,7 @@ public class SharpTSTlsSocket : SharpTSSocket
     /// <summary>
     /// Gets a member by name for interpreter dispatch.
     /// </summary>
-    public new object? GetMember(string name)
+    public override object? GetMember(string name)
     {
         return name switch
         {

--- a/Runtime/Types/SharpTSTransform.cs
+++ b/Runtime/Types/SharpTSTransform.cs
@@ -29,7 +29,7 @@ public class SharpTSTransform : SharpTSDuplex
     /// <summary>
     /// Gets a member (method or property) by name for interpreter dispatch.
     /// </summary>
-    public new object? GetMember(string name)
+    public override object? GetMember(string name)
     {
         return name switch
         {

--- a/Runtime/Types/SharpTSTransform.cs
+++ b/Runtime/Types/SharpTSTransform.cs
@@ -52,25 +52,8 @@ public class SharpTSTransform : SharpTSDuplex
 
     private RuntimeValue TransformWrite(Interp interpreter, RuntimeValue receiver, ReadOnlySpan<RuntimeValue> args)
     {
-        var chunk = args.Length > 0 ? args[0].ToObject() : null;
-        string encoding = "utf8";
-        ISharpTSCallable? callback = null;
-
-        if (args.Length > 1)
-        {
-            if (args[1].IsString)
-            {
-                encoding = args[1].AsStringUnsafe();
-                if (args.Length > 2 && args[2].ToObject() is ISharpTSCallable cb)
-                {
-                    callback = cb;
-                }
-            }
-            else if (args[1].ToObject() is ISharpTSCallable cb)
-            {
-                callback = cb;
-            }
-        }
+        var (chunk, parsedEncoding, callback) = StreamArgs.ParseWrite(args);
+        string encoding = parsedEncoding ?? "utf8";
 
         // Create push callback that adds to readable side
         var pushCallback = new TransformPushCallback(this, interpreter);
@@ -100,36 +83,7 @@ public class SharpTSTransform : SharpTSDuplex
 
     private RuntimeValue TransformEnd(Interp interpreter, RuntimeValue receiver, ReadOnlySpan<RuntimeValue> args)
     {
-        object? chunk = null;
-        string? encoding = null;
-        ISharpTSCallable? callback = null;
-
-        if (args.Length > 0)
-        {
-            if (args[0].ToObject() is ISharpTSCallable cb0)
-            {
-                callback = cb0;
-            }
-            else
-            {
-                chunk = args[0].ToObject();
-                if (args.Length > 1)
-                {
-                    if (args[1].IsString)
-                    {
-                        encoding = args[1].AsStringUnsafe();
-                        if (args.Length > 2 && args[2].ToObject() is ISharpTSCallable cb)
-                        {
-                            callback = cb;
-                        }
-                    }
-                    else if (args[1].ToObject() is ISharpTSCallable cb)
-                    {
-                        callback = cb;
-                    }
-                }
-            }
-        }
+        var (chunk, encoding, callback) = StreamArgs.ParseEnd(args);
 
         // Write final chunk if provided
         if (chunk != null)

--- a/Runtime/Types/SharpTSTypedArray.cs
+++ b/Runtime/Types/SharpTSTypedArray.cs
@@ -156,14 +156,63 @@ public abstract class SharpTSTypedArray : ITypeCategorized
     }
 
     /// <summary>
+    /// Allocates a new, zero-initialized typed array of this concrete element type.
+    /// </summary>
+    protected abstract SharpTSTypedArray Allocate(int length);
+
+    /// <summary>
+    /// Creates a view of this concrete element type over the given SharedArrayBuffer.
+    /// </summary>
+    protected abstract SharpTSTypedArray CreateView(SharpTSSharedArrayBuffer buffer, int byteOffset, int length);
+
+    /// <summary>
+    /// Creates a view of this concrete element type over the given ArrayBuffer.
+    /// </summary>
+    protected abstract SharpTSTypedArray CreateView(SharpTSArrayBuffer buffer, int byteOffset, int length);
+
+    /// <summary>
+    /// Creates a view of this concrete element type over the given raw byte buffer.
+    /// </summary>
+    protected abstract SharpTSTypedArray CreateView(byte[] buffer, int byteOffset, int length);
+
+    /// <summary>
+    /// Resolves JS slice/subarray bounds (negative-from-end, clamped to [0, length])
+    /// to a concrete (start, count) pair.
+    /// </summary>
+    private (int start, int count) ClampRange(int begin, int? end)
+    {
+        begin = begin < 0 ? Math.Max(_length + begin, 0) : Math.Min(begin, _length);
+        int actualEnd = end.HasValue
+            ? (end.Value < 0 ? Math.Max(_length + end.Value, 0) : Math.Min(end.Value, _length))
+            : _length;
+        int count = Math.Max(0, actualEnd - begin);
+        return (begin, count);
+    }
+
+    /// <summary>
     /// Creates a new typed array containing a copy of a portion of this array.
     /// </summary>
-    public abstract SharpTSTypedArray Slice(int begin, int? end = null);
+    public SharpTSTypedArray Slice(int begin, int? end = null)
+    {
+        var (start, count) = ClampRange(begin, end);
+        var result = Allocate(count);
+        BlockCopyElementsInto(result, start, count);
+        return result;
+    }
 
     /// <summary>
     /// Creates a new typed array view of the same buffer with specified bounds.
     /// </summary>
-    public abstract SharpTSTypedArray Subarray(int begin, int? end = null);
+    public SharpTSTypedArray Subarray(int begin, int? end = null)
+    {
+        var (start, count) = ClampRange(begin, end);
+        int viewByteOffset = _byteOffset + start * BytesPerElement;
+        if (_sharedBuffer != null)
+            return CreateView(_sharedBuffer, viewByteOffset, count);
+        if (_arrayBuffer != null)
+            return CreateView(_arrayBuffer, viewByteOffset, count);
+        return CreateView(_buffer, viewByteOffset, count);
+    }
 
     /// <summary>
     /// Sets values from an array or typed array, starting at the specified offset.
@@ -513,31 +562,17 @@ public class SharpTSInt8Array : SharpTSTypedArray
     public override void SetVolatile(int index, object? value) =>
         Volatile.Write(ref _buffer[GetByteIndex(index)], (byte)(sbyte)Convert.ToDouble(value));
 
-    public override SharpTSTypedArray Slice(int begin, int? end = null)
-    {
-        begin = begin < 0 ? Math.Max(_length + begin, 0) : Math.Min(begin, _length);
-        int actualEnd = end.HasValue
-            ? (end.Value < 0 ? Math.Max(_length + end.Value, 0) : Math.Min(end.Value, _length))
-            : _length;
-        int count = Math.Max(0, actualEnd - begin);
-        var result = new SharpTSInt8Array(count);
-        BlockCopyElementsInto(result, begin, count);
-        return result;
-    }
+    protected override SharpTSTypedArray Allocate(int length) =>
+        new SharpTSInt8Array(length);
 
-    public override SharpTSTypedArray Subarray(int begin, int? end = null)
-    {
-        begin = begin < 0 ? Math.Max(_length + begin, 0) : Math.Min(begin, _length);
-        int actualEnd = end.HasValue
-            ? (end.Value < 0 ? Math.Max(_length + end.Value, 0) : Math.Min(end.Value, _length))
-            : _length;
-        int count = Math.Max(0, actualEnd - begin);
-        if (_sharedBuffer != null)
-            return new SharpTSInt8Array(_sharedBuffer, _byteOffset + begin, count);
-        if (_arrayBuffer != null)
-            return new SharpTSInt8Array(_arrayBuffer, _byteOffset + begin, count);
-        return new SharpTSInt8Array(_buffer, _byteOffset + begin, count);
-    }
+    protected override SharpTSTypedArray CreateView(SharpTSSharedArrayBuffer buffer, int byteOffset, int length) =>
+        new SharpTSInt8Array(buffer, byteOffset, length);
+
+    protected override SharpTSTypedArray CreateView(SharpTSArrayBuffer buffer, int byteOffset, int length) =>
+        new SharpTSInt8Array(buffer, byteOffset, length);
+
+    protected override SharpTSTypedArray CreateView(byte[] buffer, int byteOffset, int length) =>
+        new SharpTSInt8Array(buffer, byteOffset, length);
 }
 
 /// <summary>
@@ -568,31 +603,17 @@ public class SharpTSUint8Array : SharpTSTypedArray
     public override void SetVolatile(int index, object? value) =>
         Volatile.Write(ref _buffer[GetByteIndex(index)], (byte)Convert.ToDouble(value));
 
-    public override SharpTSTypedArray Slice(int begin, int? end = null)
-    {
-        begin = begin < 0 ? Math.Max(_length + begin, 0) : Math.Min(begin, _length);
-        int actualEnd = end.HasValue
-            ? (end.Value < 0 ? Math.Max(_length + end.Value, 0) : Math.Min(end.Value, _length))
-            : _length;
-        int count = Math.Max(0, actualEnd - begin);
-        var result = new SharpTSUint8Array(count);
-        BlockCopyElementsInto(result, begin, count);
-        return result;
-    }
+    protected override SharpTSTypedArray Allocate(int length) =>
+        new SharpTSUint8Array(length);
 
-    public override SharpTSTypedArray Subarray(int begin, int? end = null)
-    {
-        begin = begin < 0 ? Math.Max(_length + begin, 0) : Math.Min(begin, _length);
-        int actualEnd = end.HasValue
-            ? (end.Value < 0 ? Math.Max(_length + end.Value, 0) : Math.Min(end.Value, _length))
-            : _length;
-        int count = Math.Max(0, actualEnd - begin);
-        if (_sharedBuffer != null)
-            return new SharpTSUint8Array(_sharedBuffer, _byteOffset + begin, count);
-        if (_arrayBuffer != null)
-            return new SharpTSUint8Array(_arrayBuffer, _byteOffset + begin, count);
-        return new SharpTSUint8Array(_buffer, _byteOffset + begin, count);
-    }
+    protected override SharpTSTypedArray CreateView(SharpTSSharedArrayBuffer buffer, int byteOffset, int length) =>
+        new SharpTSUint8Array(buffer, byteOffset, length);
+
+    protected override SharpTSTypedArray CreateView(SharpTSArrayBuffer buffer, int byteOffset, int length) =>
+        new SharpTSUint8Array(buffer, byteOffset, length);
+
+    protected override SharpTSTypedArray CreateView(byte[] buffer, int byteOffset, int length) =>
+        new SharpTSUint8Array(buffer, byteOffset, length);
 }
 
 /// <summary>
@@ -630,31 +651,17 @@ public class SharpTSUint8ClampedArray : SharpTSTypedArray
         Volatile.Write(ref _buffer[GetByteIndex(index)], (byte)Math.Max(0, Math.Min(255, Math.Round(val))));
     }
 
-    public override SharpTSTypedArray Slice(int begin, int? end = null)
-    {
-        begin = begin < 0 ? Math.Max(_length + begin, 0) : Math.Min(begin, _length);
-        int actualEnd = end.HasValue
-            ? (end.Value < 0 ? Math.Max(_length + end.Value, 0) : Math.Min(end.Value, _length))
-            : _length;
-        int count = Math.Max(0, actualEnd - begin);
-        var result = new SharpTSUint8ClampedArray(count);
-        BlockCopyElementsInto(result, begin, count);
-        return result;
-    }
+    protected override SharpTSTypedArray Allocate(int length) =>
+        new SharpTSUint8ClampedArray(length);
 
-    public override SharpTSTypedArray Subarray(int begin, int? end = null)
-    {
-        begin = begin < 0 ? Math.Max(_length + begin, 0) : Math.Min(begin, _length);
-        int actualEnd = end.HasValue
-            ? (end.Value < 0 ? Math.Max(_length + end.Value, 0) : Math.Min(end.Value, _length))
-            : _length;
-        int count = Math.Max(0, actualEnd - begin);
-        if (_sharedBuffer != null)
-            return new SharpTSUint8ClampedArray(_sharedBuffer, _byteOffset + begin, count);
-        if (_arrayBuffer != null)
-            return new SharpTSUint8ClampedArray(_arrayBuffer, _byteOffset + begin, count);
-        return new SharpTSUint8ClampedArray(_buffer, _byteOffset + begin, count);
-    }
+    protected override SharpTSTypedArray CreateView(SharpTSSharedArrayBuffer buffer, int byteOffset, int length) =>
+        new SharpTSUint8ClampedArray(buffer, byteOffset, length);
+
+    protected override SharpTSTypedArray CreateView(SharpTSArrayBuffer buffer, int byteOffset, int length) =>
+        new SharpTSUint8ClampedArray(buffer, byteOffset, length);
+
+    protected override SharpTSTypedArray CreateView(byte[] buffer, int byteOffset, int length) =>
+        new SharpTSUint8ClampedArray(buffer, byteOffset, length);
 }
 
 /// <summary>
@@ -701,31 +708,17 @@ public class SharpTSInt16Array : SharpTSTypedArray
         Volatile.Write(ref slot, (short)Convert.ToDouble(value));
     }
 
-    public override SharpTSTypedArray Slice(int begin, int? end = null)
-    {
-        begin = begin < 0 ? Math.Max(_length + begin, 0) : Math.Min(begin, _length);
-        int actualEnd = end.HasValue
-            ? (end.Value < 0 ? Math.Max(_length + end.Value, 0) : Math.Min(end.Value, _length))
-            : _length;
-        int count = Math.Max(0, actualEnd - begin);
-        var result = new SharpTSInt16Array(count);
-        BlockCopyElementsInto(result, begin, count);
-        return result;
-    }
+    protected override SharpTSTypedArray Allocate(int length) =>
+        new SharpTSInt16Array(length);
 
-    public override SharpTSTypedArray Subarray(int begin, int? end = null)
-    {
-        begin = begin < 0 ? Math.Max(_length + begin, 0) : Math.Min(begin, _length);
-        int actualEnd = end.HasValue
-            ? (end.Value < 0 ? Math.Max(_length + end.Value, 0) : Math.Min(end.Value, _length))
-            : _length;
-        int count = Math.Max(0, actualEnd - begin);
-        if (_sharedBuffer != null)
-            return new SharpTSInt16Array(_sharedBuffer, _byteOffset + begin * 2, count);
-        if (_arrayBuffer != null)
-            return new SharpTSInt16Array(_arrayBuffer, _byteOffset + begin * 2, count);
-        return new SharpTSInt16Array(_buffer, _byteOffset + begin * 2, count);
-    }
+    protected override SharpTSTypedArray CreateView(SharpTSSharedArrayBuffer buffer, int byteOffset, int length) =>
+        new SharpTSInt16Array(buffer, byteOffset, length);
+
+    protected override SharpTSTypedArray CreateView(SharpTSArrayBuffer buffer, int byteOffset, int length) =>
+        new SharpTSInt16Array(buffer, byteOffset, length);
+
+    protected override SharpTSTypedArray CreateView(byte[] buffer, int byteOffset, int length) =>
+        new SharpTSInt16Array(buffer, byteOffset, length);
 }
 
 /// <summary>
@@ -772,31 +765,17 @@ public class SharpTSUint16Array : SharpTSTypedArray
         Volatile.Write(ref slot, (ushort)Convert.ToDouble(value));
     }
 
-    public override SharpTSTypedArray Slice(int begin, int? end = null)
-    {
-        begin = begin < 0 ? Math.Max(_length + begin, 0) : Math.Min(begin, _length);
-        int actualEnd = end.HasValue
-            ? (end.Value < 0 ? Math.Max(_length + end.Value, 0) : Math.Min(end.Value, _length))
-            : _length;
-        int count = Math.Max(0, actualEnd - begin);
-        var result = new SharpTSUint16Array(count);
-        BlockCopyElementsInto(result, begin, count);
-        return result;
-    }
+    protected override SharpTSTypedArray Allocate(int length) =>
+        new SharpTSUint16Array(length);
 
-    public override SharpTSTypedArray Subarray(int begin, int? end = null)
-    {
-        begin = begin < 0 ? Math.Max(_length + begin, 0) : Math.Min(begin, _length);
-        int actualEnd = end.HasValue
-            ? (end.Value < 0 ? Math.Max(_length + end.Value, 0) : Math.Min(end.Value, _length))
-            : _length;
-        int count = Math.Max(0, actualEnd - begin);
-        if (_sharedBuffer != null)
-            return new SharpTSUint16Array(_sharedBuffer, _byteOffset + begin * 2, count);
-        if (_arrayBuffer != null)
-            return new SharpTSUint16Array(_arrayBuffer, _byteOffset + begin * 2, count);
-        return new SharpTSUint16Array(_buffer, _byteOffset + begin * 2, count);
-    }
+    protected override SharpTSTypedArray CreateView(SharpTSSharedArrayBuffer buffer, int byteOffset, int length) =>
+        new SharpTSUint16Array(buffer, byteOffset, length);
+
+    protected override SharpTSTypedArray CreateView(SharpTSArrayBuffer buffer, int byteOffset, int length) =>
+        new SharpTSUint16Array(buffer, byteOffset, length);
+
+    protected override SharpTSTypedArray CreateView(byte[] buffer, int byteOffset, int length) =>
+        new SharpTSUint16Array(buffer, byteOffset, length);
 }
 
 /// <summary>
@@ -852,31 +831,17 @@ public class SharpTSInt32Array : SharpTSTypedArray
         return ref Unsafe.As<byte, int>(ref _buffer[byteIdx]);
     }
 
-    public override SharpTSTypedArray Slice(int begin, int? end = null)
-    {
-        begin = begin < 0 ? Math.Max(_length + begin, 0) : Math.Min(begin, _length);
-        int actualEnd = end.HasValue
-            ? (end.Value < 0 ? Math.Max(_length + end.Value, 0) : Math.Min(end.Value, _length))
-            : _length;
-        int count = Math.Max(0, actualEnd - begin);
-        var result = new SharpTSInt32Array(count);
-        BlockCopyElementsInto(result, begin, count);
-        return result;
-    }
+    protected override SharpTSTypedArray Allocate(int length) =>
+        new SharpTSInt32Array(length);
 
-    public override SharpTSTypedArray Subarray(int begin, int? end = null)
-    {
-        begin = begin < 0 ? Math.Max(_length + begin, 0) : Math.Min(begin, _length);
-        int actualEnd = end.HasValue
-            ? (end.Value < 0 ? Math.Max(_length + end.Value, 0) : Math.Min(end.Value, _length))
-            : _length;
-        int count = Math.Max(0, actualEnd - begin);
-        if (_sharedBuffer != null)
-            return new SharpTSInt32Array(_sharedBuffer, _byteOffset + begin * 4, count);
-        if (_arrayBuffer != null)
-            return new SharpTSInt32Array(_arrayBuffer, _byteOffset + begin * 4, count);
-        return new SharpTSInt32Array(_buffer, _byteOffset + begin * 4, count);
-    }
+    protected override SharpTSTypedArray CreateView(SharpTSSharedArrayBuffer buffer, int byteOffset, int length) =>
+        new SharpTSInt32Array(buffer, byteOffset, length);
+
+    protected override SharpTSTypedArray CreateView(SharpTSArrayBuffer buffer, int byteOffset, int length) =>
+        new SharpTSInt32Array(buffer, byteOffset, length);
+
+    protected override SharpTSTypedArray CreateView(byte[] buffer, int byteOffset, int length) =>
+        new SharpTSInt32Array(buffer, byteOffset, length);
 }
 
 /// <summary>
@@ -923,31 +888,17 @@ public class SharpTSUint32Array : SharpTSTypedArray
         Volatile.Write(ref slot, (uint)Convert.ToDouble(value));
     }
 
-    public override SharpTSTypedArray Slice(int begin, int? end = null)
-    {
-        begin = begin < 0 ? Math.Max(_length + begin, 0) : Math.Min(begin, _length);
-        int actualEnd = end.HasValue
-            ? (end.Value < 0 ? Math.Max(_length + end.Value, 0) : Math.Min(end.Value, _length))
-            : _length;
-        int count = Math.Max(0, actualEnd - begin);
-        var result = new SharpTSUint32Array(count);
-        BlockCopyElementsInto(result, begin, count);
-        return result;
-    }
+    protected override SharpTSTypedArray Allocate(int length) =>
+        new SharpTSUint32Array(length);
 
-    public override SharpTSTypedArray Subarray(int begin, int? end = null)
-    {
-        begin = begin < 0 ? Math.Max(_length + begin, 0) : Math.Min(begin, _length);
-        int actualEnd = end.HasValue
-            ? (end.Value < 0 ? Math.Max(_length + end.Value, 0) : Math.Min(end.Value, _length))
-            : _length;
-        int count = Math.Max(0, actualEnd - begin);
-        if (_sharedBuffer != null)
-            return new SharpTSUint32Array(_sharedBuffer, _byteOffset + begin * 4, count);
-        if (_arrayBuffer != null)
-            return new SharpTSUint32Array(_arrayBuffer, _byteOffset + begin * 4, count);
-        return new SharpTSUint32Array(_buffer, _byteOffset + begin * 4, count);
-    }
+    protected override SharpTSTypedArray CreateView(SharpTSSharedArrayBuffer buffer, int byteOffset, int length) =>
+        new SharpTSUint32Array(buffer, byteOffset, length);
+
+    protected override SharpTSTypedArray CreateView(SharpTSArrayBuffer buffer, int byteOffset, int length) =>
+        new SharpTSUint32Array(buffer, byteOffset, length);
+
+    protected override SharpTSTypedArray CreateView(byte[] buffer, int byteOffset, int length) =>
+        new SharpTSUint32Array(buffer, byteOffset, length);
 }
 
 /// <summary>
@@ -994,31 +945,17 @@ public class SharpTSFloat32Array : SharpTSTypedArray
         Volatile.Write(ref slot, BitConverter.SingleToInt32Bits((float)Convert.ToDouble(value)));
     }
 
-    public override SharpTSTypedArray Slice(int begin, int? end = null)
-    {
-        begin = begin < 0 ? Math.Max(_length + begin, 0) : Math.Min(begin, _length);
-        int actualEnd = end.HasValue
-            ? (end.Value < 0 ? Math.Max(_length + end.Value, 0) : Math.Min(end.Value, _length))
-            : _length;
-        int count = Math.Max(0, actualEnd - begin);
-        var result = new SharpTSFloat32Array(count);
-        BlockCopyElementsInto(result, begin, count);
-        return result;
-    }
+    protected override SharpTSTypedArray Allocate(int length) =>
+        new SharpTSFloat32Array(length);
 
-    public override SharpTSTypedArray Subarray(int begin, int? end = null)
-    {
-        begin = begin < 0 ? Math.Max(_length + begin, 0) : Math.Min(begin, _length);
-        int actualEnd = end.HasValue
-            ? (end.Value < 0 ? Math.Max(_length + end.Value, 0) : Math.Min(end.Value, _length))
-            : _length;
-        int count = Math.Max(0, actualEnd - begin);
-        if (_sharedBuffer != null)
-            return new SharpTSFloat32Array(_sharedBuffer, _byteOffset + begin * 4, count);
-        if (_arrayBuffer != null)
-            return new SharpTSFloat32Array(_arrayBuffer, _byteOffset + begin * 4, count);
-        return new SharpTSFloat32Array(_buffer, _byteOffset + begin * 4, count);
-    }
+    protected override SharpTSTypedArray CreateView(SharpTSSharedArrayBuffer buffer, int byteOffset, int length) =>
+        new SharpTSFloat32Array(buffer, byteOffset, length);
+
+    protected override SharpTSTypedArray CreateView(SharpTSArrayBuffer buffer, int byteOffset, int length) =>
+        new SharpTSFloat32Array(buffer, byteOffset, length);
+
+    protected override SharpTSTypedArray CreateView(byte[] buffer, int byteOffset, int length) =>
+        new SharpTSFloat32Array(buffer, byteOffset, length);
 }
 
 /// <summary>
@@ -1065,31 +1002,17 @@ public class SharpTSFloat64Array : SharpTSTypedArray
         Volatile.Write(ref slot, BitConverter.DoubleToInt64Bits(Convert.ToDouble(value)));
     }
 
-    public override SharpTSTypedArray Slice(int begin, int? end = null)
-    {
-        begin = begin < 0 ? Math.Max(_length + begin, 0) : Math.Min(begin, _length);
-        int actualEnd = end.HasValue
-            ? (end.Value < 0 ? Math.Max(_length + end.Value, 0) : Math.Min(end.Value, _length))
-            : _length;
-        int count = Math.Max(0, actualEnd - begin);
-        var result = new SharpTSFloat64Array(count);
-        BlockCopyElementsInto(result, begin, count);
-        return result;
-    }
+    protected override SharpTSTypedArray Allocate(int length) =>
+        new SharpTSFloat64Array(length);
 
-    public override SharpTSTypedArray Subarray(int begin, int? end = null)
-    {
-        begin = begin < 0 ? Math.Max(_length + begin, 0) : Math.Min(begin, _length);
-        int actualEnd = end.HasValue
-            ? (end.Value < 0 ? Math.Max(_length + end.Value, 0) : Math.Min(end.Value, _length))
-            : _length;
-        int count = Math.Max(0, actualEnd - begin);
-        if (_sharedBuffer != null)
-            return new SharpTSFloat64Array(_sharedBuffer, _byteOffset + begin * 8, count);
-        if (_arrayBuffer != null)
-            return new SharpTSFloat64Array(_arrayBuffer, _byteOffset + begin * 8, count);
-        return new SharpTSFloat64Array(_buffer, _byteOffset + begin * 8, count);
-    }
+    protected override SharpTSTypedArray CreateView(SharpTSSharedArrayBuffer buffer, int byteOffset, int length) =>
+        new SharpTSFloat64Array(buffer, byteOffset, length);
+
+    protected override SharpTSTypedArray CreateView(SharpTSArrayBuffer buffer, int byteOffset, int length) =>
+        new SharpTSFloat64Array(buffer, byteOffset, length);
+
+    protected override SharpTSTypedArray CreateView(byte[] buffer, int byteOffset, int length) =>
+        new SharpTSFloat64Array(buffer, byteOffset, length);
 }
 
 /// <summary>
@@ -1157,31 +1080,17 @@ public class SharpTSBigInt64Array : SharpTSTypedArray
         return ref Unsafe.As<byte, long>(ref _buffer[byteIdx]);
     }
 
-    public override SharpTSTypedArray Slice(int begin, int? end = null)
-    {
-        begin = begin < 0 ? Math.Max(_length + begin, 0) : Math.Min(begin, _length);
-        int actualEnd = end.HasValue
-            ? (end.Value < 0 ? Math.Max(_length + end.Value, 0) : Math.Min(end.Value, _length))
-            : _length;
-        int count = Math.Max(0, actualEnd - begin);
-        var result = new SharpTSBigInt64Array(count);
-        BlockCopyElementsInto(result, begin, count);
-        return result;
-    }
+    protected override SharpTSTypedArray Allocate(int length) =>
+        new SharpTSBigInt64Array(length);
 
-    public override SharpTSTypedArray Subarray(int begin, int? end = null)
-    {
-        begin = begin < 0 ? Math.Max(_length + begin, 0) : Math.Min(begin, _length);
-        int actualEnd = end.HasValue
-            ? (end.Value < 0 ? Math.Max(_length + end.Value, 0) : Math.Min(end.Value, _length))
-            : _length;
-        int count = Math.Max(0, actualEnd - begin);
-        if (_sharedBuffer != null)
-            return new SharpTSBigInt64Array(_sharedBuffer, _byteOffset + begin * 8, count);
-        if (_arrayBuffer != null)
-            return new SharpTSBigInt64Array(_arrayBuffer, _byteOffset + begin * 8, count);
-        return new SharpTSBigInt64Array(_buffer, _byteOffset + begin * 8, count);
-    }
+    protected override SharpTSTypedArray CreateView(SharpTSSharedArrayBuffer buffer, int byteOffset, int length) =>
+        new SharpTSBigInt64Array(buffer, byteOffset, length);
+
+    protected override SharpTSTypedArray CreateView(SharpTSArrayBuffer buffer, int byteOffset, int length) =>
+        new SharpTSBigInt64Array(buffer, byteOffset, length);
+
+    protected override SharpTSTypedArray CreateView(byte[] buffer, int byteOffset, int length) =>
+        new SharpTSBigInt64Array(buffer, byteOffset, length);
 }
 
 /// <summary>
@@ -1240,29 +1149,15 @@ public class SharpTSBigUint64Array : SharpTSTypedArray
         Volatile.Write(ref slot, val);
     }
 
-    public override SharpTSTypedArray Slice(int begin, int? end = null)
-    {
-        begin = begin < 0 ? Math.Max(_length + begin, 0) : Math.Min(begin, _length);
-        int actualEnd = end.HasValue
-            ? (end.Value < 0 ? Math.Max(_length + end.Value, 0) : Math.Min(end.Value, _length))
-            : _length;
-        int count = Math.Max(0, actualEnd - begin);
-        var result = new SharpTSBigUint64Array(count);
-        BlockCopyElementsInto(result, begin, count);
-        return result;
-    }
+    protected override SharpTSTypedArray Allocate(int length) =>
+        new SharpTSBigUint64Array(length);
 
-    public override SharpTSTypedArray Subarray(int begin, int? end = null)
-    {
-        begin = begin < 0 ? Math.Max(_length + begin, 0) : Math.Min(begin, _length);
-        int actualEnd = end.HasValue
-            ? (end.Value < 0 ? Math.Max(_length + end.Value, 0) : Math.Min(end.Value, _length))
-            : _length;
-        int count = Math.Max(0, actualEnd - begin);
-        if (_sharedBuffer != null)
-            return new SharpTSBigUint64Array(_sharedBuffer, _byteOffset + begin * 8, count);
-        if (_arrayBuffer != null)
-            return new SharpTSBigUint64Array(_arrayBuffer, _byteOffset + begin * 8, count);
-        return new SharpTSBigUint64Array(_buffer, _byteOffset + begin * 8, count);
-    }
+    protected override SharpTSTypedArray CreateView(SharpTSSharedArrayBuffer buffer, int byteOffset, int length) =>
+        new SharpTSBigUint64Array(buffer, byteOffset, length);
+
+    protected override SharpTSTypedArray CreateView(SharpTSArrayBuffer buffer, int byteOffset, int length) =>
+        new SharpTSBigUint64Array(buffer, byteOffset, length);
+
+    protected override SharpTSTypedArray CreateView(byte[] buffer, int byteOffset, int length) =>
+        new SharpTSBigUint64Array(buffer, byteOffset, length);
 }

--- a/Runtime/Types/SharpTSVerify.cs
+++ b/Runtime/Types/SharpTSVerify.cs
@@ -33,24 +33,8 @@ public class SharpTSVerify
     /// Parses the algorithm string into a HashAlgorithmName.
     /// Supports both simple names (sha256) and prefixed names (RSA-SHA256).
     /// </summary>
-    private static HashAlgorithmName ParseAlgorithm(string algorithm)
-    {
-        // Normalize: remove prefix like "RSA-" or "ECDSA-" and lowercase
-        var normalized = algorithm.ToLowerInvariant();
-        if (normalized.StartsWith("rsa-"))
-            normalized = normalized[4..];
-        else if (normalized.StartsWith("ecdsa-"))
-            normalized = normalized[6..];
-
-        return normalized switch
-        {
-            "sha1" => HashAlgorithmName.SHA1,
-            "sha256" => HashAlgorithmName.SHA256,
-            "sha384" => HashAlgorithmName.SHA384,
-            "sha512" => HashAlgorithmName.SHA512,
-            _ => throw new ArgumentException($"Unsupported verification algorithm: {algorithm}")
-        };
-    }
+    private static HashAlgorithmName ParseAlgorithm(string algorithm) =>
+        CryptoAlgorithms.ParseHashName(algorithm, stripSignaturePrefix: true, context: "verification");
 
     /// <summary>
     /// Updates the verifier with the given data.
@@ -95,17 +79,7 @@ public class SharpTSVerify
         var dataBytes = _data.ToArray();
 
         // Convert signature to bytes
-        byte[] signatureBytes = signature switch
-        {
-            string sigStr when signatureEncoding?.ToLowerInvariant() == "hex" =>
-                Convert.FromHexString(sigStr),
-            string sigStr when signatureEncoding?.ToLowerInvariant() == "base64" =>
-                Convert.FromBase64String(sigStr),
-            string sigStr => Encoding.UTF8.GetBytes(sigStr),
-            SharpTSBuffer buf => buf.Data,
-            byte[] bytes => bytes,
-            _ => throw new ArgumentException("Signature must be a string or Buffer")
-        };
+        byte[] signatureBytes = CryptoEncoding.FromEncoded(signature, signatureEncoding);
 
         // Detect key type from PEM header
         if (publicKeyPem.Contains("EC PUBLIC KEY") || publicKeyPem.Contains("-----BEGIN PUBLIC KEY-----"))

--- a/Runtime/Types/SharpTSWorker.cs
+++ b/Runtime/Types/SharpTSWorker.cs
@@ -816,7 +816,7 @@ public class SharpTSWorker : SharpTSEventEmitter, IDisposable
     /// <summary>
     /// Gets a member (method or property) by name.
     /// </summary>
-    public new object? GetMember(string name)
+    public override object? GetMember(string name)
     {
         return name switch
         {
@@ -934,7 +934,7 @@ internal class WorkerParentPort : SharpTSEventEmitter
         _worker.PostMessageToParent(message, transfer);
     }
 
-    public new object? GetMember(string name)
+    public override object? GetMember(string name)
     {
         return name switch
         {

--- a/Runtime/Types/SharpTSWritable.cs
+++ b/Runtime/Types/SharpTSWritable.cs
@@ -9,30 +9,32 @@ namespace SharpTS.Runtime.Types;
 /// </summary>
 /// <remarks>
 /// Extends <see cref="SharpTSEventEmitter"/> for event support (drain, finish, error, close).
+/// The write-side machinery (write/end/cork/uncork/backpressure) lives in the shared
+/// <see cref="WritableCore"/>; this class adds the destroy lifecycle and stdout/stderr reuse.
 /// </remarks>
 public class SharpTSWritable : SharpTSEventEmitter
 {
-    private bool _writable = true;
-    private bool _ended;
-    private bool _finished;
-    private bool _destroyed;
-    private bool _corked;
-    private readonly List<object?> _corkBuffer = [];
-    private ISharpTSCallable? _writeCallback;
-    private ISharpTSCallable? _finalCallback;
+    private readonly WritableCore _writeCore;
     private ISharpTSCallable? _destroyCallback;
     private int _highWaterMark = 16384;
-    private int _pendingWrites;
-    private int _writableLength; // total bytes of in-flight writes (backpressure tracking)
-    private bool _needDrain;
     private bool _objectMode;
     private bool _autoDestroy;
-    private bool _errored;
+
+    public SharpTSWritable()
+    {
+        // Writable emits "prefinish" before "finish" and may auto-destroy afterward.
+        _writeCore = new WritableCore(
+            this,
+            objectMode: () => _objectMode,
+            highWaterMark: () => _highWaterMark,
+            emitPrefinish: true,
+            onFinished: interp => { if (_autoDestroy) DoDestroy(interp, null); });
+    }
 
     /// <summary>
     /// Whether this stream has errored — backs stream.isErrored (#1030).
     /// </summary>
-    public bool Errored => _errored;
+    public bool Errored => _writeCore.Errored;
 
     /// <summary>
     /// Gets or sets whether this stream operates in object mode.
@@ -52,12 +54,12 @@ public class SharpTSWritable : SharpTSEventEmitter
     /// <summary>
     /// Sets the custom write callback (from constructor options).
     /// </summary>
-    public void SetWriteCallback(ISharpTSCallable callback) => _writeCallback = callback;
+    public void SetWriteCallback(ISharpTSCallable callback) => _writeCore.SetWriteCallback(callback);
 
     /// <summary>
     /// Sets the custom final callback (from constructor options).
     /// </summary>
-    public void SetFinalCallback(ISharpTSCallable callback) => _finalCallback = callback;
+    public void SetFinalCallback(ISharpTSCallable callback) => _writeCore.SetFinalCallback(callback);
 
     /// <summary>
     /// Sets the custom destroy callback (from constructor options).
@@ -80,317 +82,91 @@ public class SharpTSWritable : SharpTSEventEmitter
             "setDefaultEncoding" => BuiltInMethod.CreateV2("setDefaultEncoding", 1, SetDefaultEncoding),
 
             // Properties
-            "writable" => _writable && !_ended && !_destroyed,
-            "writableEnded" => _ended,
-            "writableFinished" => _finished,
-            "writableLength" => (double)_writableLength,
-            "writableCorked" => (double)(_corked ? 1 : 0),
+            "writable" => _writeCore.IsWritable,
+            "writableEnded" => _writeCore.Ended,
+            "writableFinished" => _writeCore.Finished,
+            "writableLength" => (double)_writeCore.WritableLength,
+            "writableCorked" => (double)(_writeCore.Corked ? 1 : 0),
             "writableHighWaterMark" => (double)_highWaterMark,
             "writableObjectMode" => _objectMode,
-            "destroyed" => _destroyed,
+            "destroyed" => _writeCore.Destroyed,
 
             // Inherit from EventEmitter
             _ => base.GetMember(name)
         };
     }
 
-    /// <summary>
-    /// Writes data to the stream.
-    /// </summary>
     private RuntimeValue Write(Interp interpreter, RuntimeValue receiver, ReadOnlySpan<RuntimeValue> args)
+        => _writeCore.Write(interpreter, args);
+
+    private RuntimeValue End(Interp interpreter, RuntimeValue receiver, ReadOnlySpan<RuntimeValue> args)
+        => _writeCore.End(interpreter, args);
+
+    private RuntimeValue Cork(Interp interpreter, RuntimeValue receiver, ReadOnlySpan<RuntimeValue> args)
     {
-        if (_destroyed || _ended)
-        {
-            EmitError(interpreter, "write after end");
-            return RuntimeValue.False;
-        }
-
-        var chunk = args.Length > 0 ? args[0].ToObject() : null;
-        string? encoding = null;
-        ISharpTSCallable? callback = null;
-
-        // Parse arguments: (chunk, encoding?, callback?)
-        if (args.Length > 1)
-        {
-            if (args[1].IsString)
-            {
-                encoding = args[1].AsStringUnsafe();
-                if (args.Length > 2 && args[2].ToObject() is ISharpTSCallable cb)
-                {
-                    callback = cb;
-                }
-            }
-            else if (args[1].ToObject() is ISharpTSCallable cb)
-            {
-                callback = cb;
-            }
-        }
-
-        if (_corked)
-        {
-            _corkBuffer.Add(new WriteChunk(chunk, encoding, callback));
-            return RuntimeValue.False;
-        }
-
-        return RuntimeValue.FromBoxed(DoWrite(interpreter, chunk, encoding, callback));
+        _writeCore.Cork();
+        return RuntimeValue.Null;
     }
 
-    private record WriteChunk(object? Chunk, string? Encoding, ISharpTSCallable? Callback);
-
-    private object? DoWrite(Interp interpreter, object? chunk, string? encoding, ISharpTSCallable? callback)
+    private RuntimeValue Uncork(Interp interpreter, RuntimeValue receiver, ReadOnlySpan<RuntimeValue> args)
     {
-        _pendingWrites++;
-        var chunkSize = GetChunkSize(chunk, _objectMode);
-        _writableLength += chunkSize;
-
-        if (_writeCallback != null)
-        {
-            // Custom write callback: (chunk, encoding, callback)
-            var cbWrapper = new WriteCallbackWrapper(callback, interpreter, this, chunkSize);
-            var writeArgs = new List<object?> { chunk, encoding ?? "utf8", cbWrapper };
-            try
-            {
-                _writeCallback.Call(interpreter, writeArgs);
-            }
-            catch (Exception ex)
-            {
-                EmitError(interpreter, ex.Message);
-                return false;
-            }
-        }
-        else
-        {
-            // Default behavior: just accept the data (sync completion)
-            _pendingWrites--;
-            _writableLength -= chunkSize;
-            callback?.Call(interpreter, []);
-            CheckDrain(interpreter);
-        }
-
-        // Return false when buffered data exceeds highWaterMark (backpressure)
-        if (_writableLength >= _highWaterMark)
-        {
-            _needDrain = true;
-            return false;
-        }
-
-        return true;
-    }
-
-    private void CheckDrain(Interp interpreter)
-    {
-        if (_needDrain && _writableLength < _highWaterMark)
-        {
-            _needDrain = false;
-            EmitEvent(interpreter, "drain", []);
-        }
-    }
-
-    /// <summary>
-    /// Gets the byte size of a chunk (or 1 for object mode).
-    /// </summary>
-    internal static int GetChunkSize(object? chunk, bool objectMode)
-    {
-        if (objectMode) return 1;
-        return chunk switch
-        {
-            string s => s.Length,
-            SharpTSBuffer buf => buf.Length,
-            _ => 0
-        };
+        _writeCore.Uncork(interpreter);
+        return RuntimeValue.Null;
     }
 
     /// <summary>
     /// Internal write method for piped data. Returns false on backpressure.
     /// </summary>
     internal bool WriteInternal(Interp interpreter, object? chunk, string? encoding)
-    {
-        if (_destroyed || _ended)
-        {
-            return false;
-        }
-
-        return (bool)(DoWrite(interpreter, chunk, encoding, null) ?? false);
-    }
-
-    /// <summary>
-    /// Ends the stream, optionally writing final data.
-    /// </summary>
-    private RuntimeValue End(Interp interpreter, RuntimeValue receiver, ReadOnlySpan<RuntimeValue> args)
-    {
-        if (_ended)
-        {
-            return RuntimeValue.FromObject(this);
-        }
-
-        object? chunk = null;
-        string? encoding = null;
-        ISharpTSCallable? callback = null;
-
-        // Parse arguments: (chunk?, encoding?, callback?)
-        if (args.Length > 0)
-        {
-            if (args[0].ToObject() is ISharpTSCallable cb0)
-            {
-                callback = cb0;
-            }
-            else
-            {
-                chunk = args[0].ToObject();
-                if (args.Length > 1)
-                {
-                    if (args[1].IsString)
-                    {
-                        encoding = args[1].AsStringUnsafe();
-                        if (args.Length > 2 && args[2].ToObject() is ISharpTSCallable cb)
-                        {
-                            callback = cb;
-                        }
-                    }
-                    else if (args[1].ToObject() is ISharpTSCallable cb)
-                    {
-                        callback = cb;
-                    }
-                }
-            }
-        }
-
-        _ended = true;
-        _writable = false;
-
-        // Write final chunk if provided
-        if (chunk != null)
-        {
-            DoWrite(interpreter, chunk, encoding, null);
-        }
-
-        // Flush cork buffer
-        if (_corked)
-        {
-            Uncork(interpreter, RuntimeValue.Null, []);
-        }
-
-        // Call final callback
-        if (_finalCallback != null)
-        {
-            var finalCbWrapper = new WriteCallbackWrapper(null, interpreter, this, 0);
-            try
-            {
-                _finalCallback.Call(interpreter, [finalCbWrapper]);
-            }
-            catch (Exception ex)
-            {
-                EmitError(interpreter, ex.Message);
-            }
-        }
-
-        _finished = true;
-        callback?.Call(interpreter, []);
-        EmitFinish(interpreter);
-
-        return RuntimeValue.FromObject(this);
-    }
+        => _writeCore.WriteDirect(interpreter, chunk, encoding);
 
     /// <summary>
     /// Internal end method for piped streams.
     /// </summary>
     internal void EndInternal(Interp interpreter, object? chunk, string? encoding)
-    {
-        End(interpreter, RuntimeValue.FromObject(this),
-            chunk != null
-                ? [RuntimeValue.FromBoxed(chunk), RuntimeValue.FromBoxed(encoding)]
-                : []);
-    }
-
-    /// <summary>
-    /// Corks the stream, buffering all writes.
-    /// </summary>
-    private RuntimeValue Cork(Interp interpreter, RuntimeValue receiver, ReadOnlySpan<RuntimeValue> args)
-    {
-        _corked = true;
-        return RuntimeValue.Null;
-    }
-
-    /// <summary>
-    /// Uncorks the stream, flushing the buffer.
-    /// </summary>
-    private RuntimeValue Uncork(Interp interpreter, RuntimeValue receiver, ReadOnlySpan<RuntimeValue> args)
-    {
-        if (!_corked)
-        {
-            return RuntimeValue.Null;
-        }
-
-        _corked = false;
-
-        // Flush the cork buffer
-        foreach (var item in _corkBuffer.Cast<WriteChunk>())
-        {
-            DoWrite(interpreter, item.Chunk, item.Encoding, item.Callback);
-        }
-        _corkBuffer.Clear();
-
-        return RuntimeValue.Null;
-    }
+        => _writeCore.EndDirect(interpreter, chunk, encoding);
 
     /// <summary>
     /// Destroys the stream.
     /// </summary>
     private RuntimeValue Destroy(Interp interpreter, RuntimeValue receiver, ReadOnlySpan<RuntimeValue> args)
     {
-        if (_destroyed)
-        {
-            return RuntimeValue.FromObject(this);
-        }
+        DoDestroy(interpreter, args.Length > 0 ? args[0].ToObject() : null);
+        return RuntimeValue.FromObject(this);
+    }
 
-        _destroyed = true;
-        _writable = false;
-        _corkBuffer.Clear();
+    private void DoDestroy(Interp interpreter, object? error)
+    {
+        if (_writeCore.Destroyed)
+            return;
+
+        _writeCore.MarkDestroyed();
 
         if (_destroyCallback != null)
         {
             try
             {
-                var err = args.Length > 0 ? args[0].ToObject() : null;
-                _destroyCallback.Call(interpreter, [err, new DestroyCallbackWrapper(interpreter, this)]);
+                _destroyCallback.Call(interpreter, [error, new DestroyCallbackWrapper(interpreter, this)]);
             }
             catch (Exception ex)
             {
-                EmitError(interpreter, ex.Message);
+                _writeCore.EmitError(interpreter, ex.Message);
             }
         }
         else
         {
-            if (args.Length > 0 && args[0].ToObject() is { } error)
+            if (error is { })
             {
-                EmitError(interpreter, error);
+                _writeCore.EmitError(interpreter, error);
             }
             EmitClose(interpreter);
         }
-
-        return RuntimeValue.FromObject(this);
     }
 
     private RuntimeValue SetDefaultEncoding(Interp interpreter, RuntimeValue receiver, ReadOnlySpan<RuntimeValue> args)
     {
         // Just accept it for compatibility
         return RuntimeValue.FromObject(this);
-    }
-
-    private void EmitError(Interp interpreter, object? error)
-    {
-        _errored = true;
-        EmitEvent(interpreter, "error", [error]);
-    }
-
-    private void EmitFinish(Interp interpreter)
-    {
-        EmitEvent(interpreter, "prefinish", []);
-        EmitEvent(interpreter, "finish", []);
-        if (_autoDestroy)
-        {
-            Destroy(interpreter, RuntimeValue.FromObject(this), []);
-        }
     }
 
     private void EmitClose(Interp interpreter)
@@ -403,59 +179,16 @@ public class SharpTSWritable : SharpTSEventEmitter
     /// </summary>
     internal void ResetWritableState()
     {
-        _writable = true;
-        _ended = false;
-        _finished = false;
-        _destroyed = false;
-        _corked = false;
-        _corkBuffer.Clear();
-        _pendingWrites = 0;
-        _writableLength = 0;
-        _needDrain = false;
+        _writeCore.Reset();
         ClearAllListenersInternal();
     }
 
     public override string ToString() => "Writable {}";
 
     /// <summary>
-    /// Wrapper for write callbacks to match Node.js callback(error?) signature.
-    /// </summary>
-    private class WriteCallbackWrapper : ISharpTSCallable
-    {
-        private readonly ISharpTSCallable? _callback;
-        private readonly Interp _interpreter;
-        private readonly SharpTSWritable _stream;
-        private readonly int _chunkSize;
-
-        public WriteCallbackWrapper(ISharpTSCallable? callback, Interp interpreter, SharpTSWritable stream, int chunkSize)
-        {
-            _callback = callback;
-            _interpreter = interpreter;
-            _stream = stream;
-            _chunkSize = chunkSize;
-        }
-
-        public int Arity() => 0;
-
-        public object? Call(Interp interpreter, List<object?> arguments)
-        {
-            // error argument
-            var error = arguments.Count > 0 ? arguments[0] : null;
-            // Decrement pending writes and buffered length
-            _stream._pendingWrites--;
-            _stream._writableLength -= _chunkSize;
-            // Call the original callback
-            _callback?.Call(_interpreter, []);
-            // Check if we need to emit drain
-            _stream.CheckDrain(_interpreter);
-            return null;
-        }
-    }
-
-    /// <summary>
     /// Wrapper for destroy callback to emit close event.
     /// </summary>
-    private class DestroyCallbackWrapper : ISharpTSCallable
+    private sealed class DestroyCallbackWrapper : ISharpTSCallable
     {
         private readonly Interp _interpreter;
         private readonly SharpTSWritable _stream;
@@ -473,7 +206,7 @@ public class SharpTSWritable : SharpTSEventEmitter
             var error = arguments.Count > 0 ? arguments[0] : null;
             if (error != null)
             {
-                _stream.EmitError(_interpreter, error);
+                _stream._writeCore.EmitError(_interpreter, error);
             }
             _stream.EmitClose(_interpreter);
             return null;

--- a/Runtime/Types/SharpTSWritable.cs
+++ b/Runtime/Types/SharpTSWritable.cs
@@ -69,7 +69,7 @@ public class SharpTSWritable : SharpTSEventEmitter
     /// <summary>
     /// Gets a member (method or property) by name for interpreter dispatch.
     /// </summary>
-    public new object? GetMember(string name)
+    public override object? GetMember(string name)
     {
         return name switch
         {

--- a/Runtime/Types/SharpTSWritableStream.cs
+++ b/Runtime/Types/SharpTSWritableStream.cs
@@ -131,7 +131,7 @@ public class SharpTSWritableStream : ITypeCategorized
         try
         {
             size = SizeAlgorithm != null
-                ? ToDouble(RuntimeCallableDispatcher.Invoke(OwnerInterpreter, SizeAlgorithm, chunk))
+                ? Interp.ToNumber(RuntimeCallableDispatcher.Invoke(OwnerInterpreter, SizeAlgorithm, chunk))
                 : 1.0;
         }
         catch (Exception ex)
@@ -353,14 +353,6 @@ public class SharpTSWritableStream : ITypeCategorized
         PendingCloseTcs?.TrySetException(new SharpTSPromiseRejectedException(error));
         Writer?.NotifyErrored(error);
     }
-
-    private static double ToDouble(object? v) => v switch
-    {
-        double d => d,
-        int i => i,
-        long l => l,
-        _ => 1.0,
-    };
 
     public object? GetMember(string name)
     {

--- a/Runtime/Types/SharpTSWriteStream.cs
+++ b/Runtime/Types/SharpTSWriteStream.cs
@@ -213,7 +213,7 @@ public class SharpTSWriteStream : SharpTSWritable
         });
     }
 
-    public new object? GetMember(string name)
+    public override object? GetMember(string name)
     {
         return name switch
         {

--- a/Runtime/Types/SharpTSZlibTransform.cs
+++ b/Runtime/Types/SharpTSZlibTransform.cs
@@ -92,7 +92,7 @@ public class SharpTSZlibTransform : SharpTSTransform
     /// Adds the Node zlib control methods (params/flush/reset/close) and the
     /// bytesWritten/bytesRead counters on top of the generic stream surface.
     /// </summary>
-    public new object? GetMember(string name)
+    public override object? GetMember(string name)
     {
         return name switch
         {

--- a/Runtime/Types/StreamArgs.cs
+++ b/Runtime/Types/StreamArgs.cs
@@ -1,0 +1,61 @@
+namespace SharpTS.Runtime.Types;
+
+/// <summary>
+/// Shared parsing of the Node stream <c>write</c>/<c>end</c> argument shapes,
+/// which recurred verbatim across Writable, Duplex, and Transform (#1138).
+/// </summary>
+internal static class StreamArgs
+{
+    /// <summary>
+    /// Parses <c>write(chunk, encoding?, callback?)</c>: <c>args[0]</c> is always the
+    /// chunk; the optional encoding is a string and the optional callback is a function.
+    /// </summary>
+    public static (object? chunk, string? encoding, ISharpTSCallable? callback) ParseWrite(
+        ReadOnlySpan<RuntimeValue> args)
+    {
+        object? chunk = args.Length > 0 ? args[0].ToObject() : null;
+        var (encoding, callback) = ParseEncodingAndCallback(args, fromIndex: 1);
+        return (chunk, encoding, callback);
+    }
+
+    /// <summary>
+    /// Parses <c>end(chunk?, encoding?, callback?)</c>: <c>args[0]</c> may be the final
+    /// chunk or, if it is a function, the completion callback.
+    /// </summary>
+    public static (object? chunk, string? encoding, ISharpTSCallable? callback) ParseEnd(
+        ReadOnlySpan<RuntimeValue> args)
+    {
+        if (args.Length == 0)
+            return (null, null, null);
+
+        if (args[0].ToObject() is ISharpTSCallable cb0)
+            return (null, null, cb0);
+
+        object? chunk = args[0].ToObject();
+        var (encoding, callback) = ParseEncodingAndCallback(args, fromIndex: 1);
+        return (chunk, encoding, callback);
+    }
+
+    /// <summary>
+    /// Parses an optional <c>(encoding?, callback?)</c> tail starting at
+    /// <paramref name="fromIndex"/>: a string is the encoding (and a following function
+    /// the callback); a function alone is the callback.
+    /// </summary>
+    private static (string? encoding, ISharpTSCallable? callback) ParseEncodingAndCallback(
+        ReadOnlySpan<RuntimeValue> args, int fromIndex)
+    {
+        if (args.Length <= fromIndex)
+            return (null, null);
+
+        if (args[fromIndex].IsString)
+        {
+            string encoding = args[fromIndex].AsStringUnsafe();
+            ISharpTSCallable? callback = args.Length > fromIndex + 1 && args[fromIndex + 1].ToObject() is ISharpTSCallable cb
+                ? cb
+                : null;
+            return (encoding, callback);
+        }
+
+        return (null, args[fromIndex].ToObject() as ISharpTSCallable);
+    }
+}

--- a/Runtime/Types/WritableCore.cs
+++ b/Runtime/Types/WritableCore.cs
@@ -1,0 +1,300 @@
+using Interp = SharpTS.Execution.Interpreter;
+
+namespace SharpTS.Runtime.Types;
+
+/// <summary>
+/// The shared writable-side machinery for Node stream wrappers. Because
+/// <see cref="SharpTSDuplex"/> must inherit <see cref="SharpTSReadable"/>, it cannot
+/// also inherit a writable base, so the write side was previously re-implemented
+/// verbatim on both <see cref="SharpTSWritable"/> and <see cref="SharpTSDuplex"/>
+/// (#1138). Both now compose a <see cref="WritableCore"/> and delegate to it.
+/// </summary>
+/// <remarks>
+/// Behaviour is identical to the prior per-class implementations. The two points
+/// where the streams historically differed are constructor parameters:
+/// <see cref="_emitPrefinish"/> (Writable emits "prefinish" before "finish") and
+/// <see cref="_onFinished"/> (Writable's auto-destroy hook).
+/// </remarks>
+internal sealed class WritableCore
+{
+    private readonly SharpTSEventEmitter _owner;
+    private readonly Func<bool> _objectMode;
+    private readonly Func<int> _highWaterMark;
+    private readonly bool _emitPrefinish;
+    private readonly Action<Interp>? _onFinished;
+
+    private bool _writable = true;
+    private bool _ended;
+    private bool _finished;
+    private bool _destroyed;
+    private bool _errored;
+    private bool _corked;
+    private readonly List<object?> _corkBuffer = [];
+    private ISharpTSCallable? _writeCallback;
+    private ISharpTSCallable? _finalCallback;
+    private int _pendingWrites;
+    private int _writableLength; // total bytes of in-flight writes (backpressure tracking)
+    private bool _needDrain;
+
+    /// <param name="owner">The stream that owns this core; events are emitted on it.</param>
+    /// <param name="objectMode">Live accessor for the writable-side object mode.</param>
+    /// <param name="highWaterMark">Live accessor for the writable-side high water mark.</param>
+    /// <param name="emitPrefinish">Whether <c>end()</c> emits "prefinish" before "finish".</param>
+    /// <param name="onFinished">Optional hook invoked after "finish" (e.g. auto-destroy).</param>
+    public WritableCore(
+        SharpTSEventEmitter owner,
+        Func<bool> objectMode,
+        Func<int> highWaterMark,
+        bool emitPrefinish,
+        Action<Interp>? onFinished)
+    {
+        _owner = owner;
+        _objectMode = objectMode;
+        _highWaterMark = highWaterMark;
+        _emitPrefinish = emitPrefinish;
+        _onFinished = onFinished;
+    }
+
+    public bool IsWritable => _writable && !_ended && !_destroyed;
+    public bool Ended => _ended;
+    public bool Finished => _finished;
+    public bool Destroyed => _destroyed;
+    public bool Errored => _errored;
+    public bool Corked => _corked;
+    public int WritableLength => _writableLength;
+
+    public void SetWriteCallback(ISharpTSCallable callback) => _writeCallback = callback;
+    public void SetFinalCallback(ISharpTSCallable callback) => _finalCallback = callback;
+
+    /// <summary>
+    /// Implements <c>stream.write(chunk, encoding?, callback?)</c>.
+    /// </summary>
+    public RuntimeValue Write(Interp interpreter, ReadOnlySpan<RuntimeValue> args)
+    {
+        if (_destroyed || _ended)
+        {
+            EmitError(interpreter, "write after end");
+            return RuntimeValue.False;
+        }
+
+        var (chunk, encoding, callback) = StreamArgs.ParseWrite(args);
+
+        if (_corked)
+        {
+            _corkBuffer.Add(new WriteChunk(chunk, encoding, callback));
+            return RuntimeValue.False;
+        }
+
+        return RuntimeValue.FromBoxed(DoWrite(interpreter, chunk, encoding, callback));
+    }
+
+    private record WriteChunk(object? Chunk, string? Encoding, ISharpTSCallable? Callback);
+
+    private object? DoWrite(Interp interpreter, object? chunk, string? encoding, ISharpTSCallable? callback)
+    {
+        _pendingWrites++;
+        var chunkSize = GetChunkSize(chunk, _objectMode());
+        _writableLength += chunkSize;
+
+        if (_writeCallback != null)
+        {
+            // Custom write callback: (chunk, encoding, callback)
+            var cbWrapper = new WriteCallbackWrapper(callback, interpreter, this, chunkSize);
+            var writeArgs = new List<object?> { chunk, encoding ?? "utf8", cbWrapper };
+            try
+            {
+                _writeCallback.Call(interpreter, writeArgs);
+            }
+            catch (Exception ex)
+            {
+                EmitError(interpreter, ex.Message);
+                return false;
+            }
+        }
+        else
+        {
+            // Default behavior: just accept the data (sync completion)
+            _pendingWrites--;
+            _writableLength -= chunkSize;
+            callback?.Call(interpreter, []);
+            CheckDrain(interpreter);
+        }
+
+        // Return false when buffered data exceeds highWaterMark (backpressure)
+        if (_writableLength >= _highWaterMark())
+        {
+            _needDrain = true;
+            return false;
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Writes a chunk directly (used by piping); returns false on backpressure or when not writable.
+    /// </summary>
+    public bool WriteDirect(Interp interpreter, object? chunk, string? encoding)
+    {
+        if (_destroyed || _ended)
+            return false;
+        return (bool)(DoWrite(interpreter, chunk, encoding, null) ?? false);
+    }
+
+    private void CheckDrain(Interp interpreter)
+    {
+        if (_needDrain && _writableLength < _highWaterMark())
+        {
+            _needDrain = false;
+            _owner.EmitEvent(interpreter, "drain", []);
+        }
+    }
+
+    /// <summary>
+    /// Implements <c>stream.end(chunk?, encoding?, callback?)</c>.
+    /// </summary>
+    public RuntimeValue End(Interp interpreter, ReadOnlySpan<RuntimeValue> args)
+    {
+        if (_ended)
+            return RuntimeValue.FromObject(_owner);
+
+        var (chunk, encoding, callback) = StreamArgs.ParseEnd(args);
+
+        _ended = true;
+        _writable = false;
+
+        // Write final chunk if provided
+        if (chunk != null)
+            DoWrite(interpreter, chunk, encoding, null);
+
+        // Flush cork buffer
+        if (_corked)
+            Uncork(interpreter);
+
+        // Call final callback
+        if (_finalCallback != null)
+        {
+            var finalCbWrapper = new WriteCallbackWrapper(null, interpreter, this, 0);
+            try
+            {
+                _finalCallback.Call(interpreter, [finalCbWrapper]);
+            }
+            catch (Exception ex)
+            {
+                EmitError(interpreter, ex.Message);
+            }
+        }
+
+        _finished = true;
+        callback?.Call(interpreter, []);
+
+        if (_emitPrefinish)
+            _owner.EmitEvent(interpreter, "prefinish", []);
+        _owner.EmitEvent(interpreter, "finish", []);
+        _onFinished?.Invoke(interpreter);
+
+        return RuntimeValue.FromObject(_owner);
+    }
+
+    /// <summary>Ends the stream directly (used by piping).</summary>
+    public void EndDirect(Interp interpreter, object? chunk, string? encoding)
+    {
+        End(interpreter,
+            chunk != null
+                ? [RuntimeValue.FromBoxed(chunk), RuntimeValue.FromBoxed(encoding)]
+                : []);
+    }
+
+    /// <summary>Corks the stream, buffering all writes.</summary>
+    public void Cork() => _corked = true;
+
+    /// <summary>Uncorks the stream, flushing the buffered writes.</summary>
+    public void Uncork(Interp interpreter)
+    {
+        if (!_corked)
+            return;
+
+        _corked = false;
+
+        foreach (var item in _corkBuffer.Cast<WriteChunk>())
+            DoWrite(interpreter, item.Chunk, item.Encoding, item.Callback);
+        _corkBuffer.Clear();
+    }
+
+    /// <summary>
+    /// Marks the writable side destroyed and clears the cork buffer. Event emission /
+    /// destroy-callback policy stays with the owning stream, which differs per type.
+    /// </summary>
+    public void MarkDestroyed()
+    {
+        _destroyed = true;
+        _writable = false;
+        _corkBuffer.Clear();
+    }
+
+    /// <summary>Emits an "error" event and records the errored state.</summary>
+    public void EmitError(Interp interpreter, object? error)
+    {
+        _errored = true;
+        _owner.EmitEvent(interpreter, "error", [error]);
+    }
+
+    /// <summary>Resets mutable state for singleton reuse (e.g. process.stdout between runs).</summary>
+    public void Reset()
+    {
+        _writable = true;
+        _ended = false;
+        _finished = false;
+        _destroyed = false;
+        _errored = false;
+        _corked = false;
+        _corkBuffer.Clear();
+        _pendingWrites = 0;
+        _writableLength = 0;
+        _needDrain = false;
+    }
+
+    /// <summary>
+    /// Gets the byte size of a chunk (or 1 for object mode).
+    /// </summary>
+    internal static int GetChunkSize(object? chunk, bool objectMode)
+    {
+        if (objectMode) return 1;
+        return chunk switch
+        {
+            string s => s.Length,
+            SharpTSBuffer buf => buf.Length,
+            _ => 0
+        };
+    }
+
+    /// <summary>
+    /// Wrapper for write callbacks to match Node.js callback(error?) signature.
+    /// </summary>
+    private sealed class WriteCallbackWrapper : ISharpTSCallable
+    {
+        private readonly ISharpTSCallable? _callback;
+        private readonly Interp _interpreter;
+        private readonly WritableCore _core;
+        private readonly int _chunkSize;
+
+        public WriteCallbackWrapper(ISharpTSCallable? callback, Interp interpreter, WritableCore core, int chunkSize)
+        {
+            _callback = callback;
+            _interpreter = interpreter;
+            _core = core;
+            _chunkSize = chunkSize;
+        }
+
+        public int Arity() => 1;
+
+        public object? Call(Interp interpreter, List<object?> arguments)
+        {
+            // Decrement pending writes and buffered length, then run the user's callback.
+            _core._pendingWrites--;
+            _core._writableLength -= _chunkSize;
+            _callback?.Call(_interpreter, []);
+            _core.CheckDrain(_interpreter);
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
Implements all six sub-issues of epic #1093 — the interpreter-side twin of the runtime value-type cleanup. The `SharpTS*` wrappers were authored by copy-paste; this de-duplicates them onto shared bases/helpers, eliminating the latent-divergence hazard the epic flagged (e.g. `Decipher.FormatOutput` had a `utf8` case `Cipher` lacked; forked `ToDouble` defaults).

Each sub-issue is a self-contained commit.

## Commits

- **#1134 — Canonicalize `ToDouble`/`ToInt`** (`b1893371`)
  Delete the 6 private `ToDouble` + 2 `ToInt` copies (DataView, the 3 Intl formatters, the two streams) and route every call site through the canonical `Interpreter.ToNumber`, keeping domain defaults (stream `highWaterMark` 1.0) at the call site.

- **#1135 — `CryptoEncoding`/`CryptoAlgorithms` + `SharpTSAesBase`** (`60695091`)
  Extract the byte⇄hex/base64/utf8/Buffer encoder (×7), the encoded-input decoder (×4+2), and the `HashAlgorithmName` switch (×4) into shared static helpers, and pull Cipher/Decipher onto an abstract `SharpTSAesBase`. The Cipher/Decipher `utf8` divergence becomes one explicit `decodeUtf8` flag rather than silent copy-paste drift. Net −190 lines.

- **#1136 — `SharpTSIntlFormatterBase`** (`dd870fb1`)
  All 8 Intl formatters repeated the locale-resolution preamble, options normalization, primary-language extraction, and `resolvedOptions` member. Hoisted to an abstract base (`ResolveLocale`/`ResolveCulture`/`NormalizeOptions`/`PrimaryLanguage` + abstract `GetResolvedOptions`). Net −170 lines.

- **#1137 — Hoist typed-array `Slice`/`Subarray`** (`26c43bd1`)
  The 11 typed-array subclasses carried byte-identical clamp logic differing only by constructor. Hoisted to the base via four per-subclass factory hooks (`Allocate` + 3 `CreateView` overloads). Net −105 lines.

- **#1138 — `WritableCore` + `StreamArgs`** (`751cb8c0`)
  C# single inheritance forced the writable side to be re-implemented on both `SharpTSWritable` and `SharpTSDuplex`. Extract a composed `WritableCore` (the two differences — `prefinish` emission and the auto-destroy hook — are constructor params) plus a shared `StreamArgs.ParseWrite`/`ParseEnd` (also used by Transform).

- **#1139 — Unify the member-dispatch contract** (`a0fe6536`)
  `GetMember` on `SharpTSEventEmitter` was neither virtual nor an interface member, so ~30 subclasses declared `public new GetMember`, losing polymorphism and forcing a `SharpTSStdout` workaround for a compiled-reflection `AmbiguousMatchException`. Add `interface IMemberProvider`, make the base virtual (with a non-virtual `GetEventEmitterMember` for the few intentional raw-EE bypasses), and convert all 36 shadows to `override`.

## Validation

- `dotnet test` (full xUnit): **14813 passed, 0 failed**.
- `SharpTS.Test262` (interp + compiled): **0 baseline regressions**. (A test-host crash occurs at teardown — confirmed identical on the base commit `6f643ab4`, i.e. the pre-existing orphan-thread teardown flake, not introduced here.)
- `SharpTS.TypeScriptConformance`: **31 passed, 0 failed**.
- Interpreter and compiled output remain behaviourally identical; standalone compiled DLLs gain no `SharpTS.dll` dependency (no compiled IL emitters were changed).

Closes #1134, #1135, #1136, #1137, #1138, #1139.
Part of #1093.