### PR TITLE
Epic #1089: finish the in-flight migrations and delete the scaffolding

### DIFF
--- a/Compilation/EmittedRuntime.cs
+++ b/Compilation/EmittedRuntime.cs
@@ -76,7 +76,6 @@ public class EmittedRuntime
     public MethodBuilder TSNamespaceSet { get; set; } = null!;
 
     // The emitted ReferenceEqualityComparer class (for Map/Set key equality)
-    public TypeBuilder ReferenceEqualityComparerType { get; set; } = null!;
     public FieldBuilder ReferenceEqualityComparerInstance { get; set; } = null!;
 
     // Sentinel object for null/undefined Map keys (Dictionary<object,object?> can't use null keys)
@@ -119,7 +118,6 @@ public class EmittedRuntime
     public MethodBuilder ConsoleTime { get; set; } = null!;
     public MethodBuilder ConsoleTimeEnd { get; set; } = null!;
     public MethodBuilder ConsoleTimeLog { get; set; } = null!;
-    public FieldBuilder ConsoleTimersField { get; set; } = null!;
 
     // Phase 2 console methods
     public MethodBuilder ConsoleAssert { get; set; } = null!;
@@ -133,7 +131,6 @@ public class EmittedRuntime
     public MethodBuilder ConsoleGroupEnd { get; set; } = null!;
     public MethodBuilder ConsoleTrace { get; set; } = null!;
     public MethodBuilder ConsoleTraceMultiple { get; set; } = null!;
-    public FieldBuilder ConsoleCountsField { get; set; } = null!;
     public FieldBuilder ConsoleGroupLevelField { get; set; } = null!;
 
     // Union type marker interface (for fast union type detection)
@@ -278,9 +275,7 @@ public class EmittedRuntime
     // $TSFunction static factory + instance cache: stable identity for
     // function-declaration references (see RuntimeEmitter.TSFunction.cs).
     public MethodBuilder TSFunctionGetOrCreate { get; set; } = null!;
-    public FieldBuilder TSFunctionInstanceCacheField { get; set; } = null!;
     public FieldBuilder TSFunctionPrototypeCacheField { get; set; } = null!;
-    public FieldBuilder TSFunctionMethodField { get; set; } = null!;
     public MethodBuilder TSFunctionGetMethodInfo { get; set; } = null!;
     // Exposed for iterator helpers' "skip index box for unary arrows" fast
     // path — read at runtime to detect callback arity without reflection.
@@ -498,7 +493,6 @@ public class EmittedRuntime
     /// <summary>$Runtime.StringReplaceWithFunction(str, pattern, fn) — handles ECMA-262 22.1.3.18 step 3 when replaceValue is callable; calls fn(matched, position, string) per match and stringifies the result.</summary>
     public MethodBuilder StringReplaceWithFunction { get; set; } = null!;
     /// <summary>Strict variant of <see cref="StringPrototypeGenericStub"/> that throws TypeError on null/undefined receivers per ECMA-262 22.1.3.* step 1 (RequireObjectCoercible). Used for borrowed-method calls of <c>String.prototype.match/search/matchAll/etc.</c></summary>
-    public MethodBuilder StringPrototypeStrictStub { get; set; } = null!;
     /// <summary>$Runtime.StringProtoToString(this) — ECMA-262 22.1.3.27 String.prototype.toString. thisStringValue extraction: string→as-is; $Object with __primitiveType="String"→__primitiveValue; String.prototype itself→""; else throws TypeError. Reads the marker dict directly to avoid prototype-chain recursion.</summary>
     public MethodBuilder StringProtoToStringHelper { get; set; } = null!;
     /// <summary>$Runtime.ObjectProtoToString(this) — ECMA-262 19.1.3.6 toString returns "[object X]" branded by receiver type. Wired into Object.prototype.toString slot for borrowed-method dispatch (`obj.toString = Object.prototype.toString; obj.toString()`).</summary>
@@ -587,13 +581,9 @@ public class EmittedRuntime
     /// <summary>$Runtime.PromiseFinallyHelper(__this, args) — wraps PromiseFinally for Promise.prototype.finally.call patterns.</summary>
     public MethodBuilder PromiseFinallyHelperMethod { get; set; } = null!;
     /// <summary>$Runtime.FunctionProtoCall(__this, args) — ECMA-262 §20.2.3.3 Function.prototype.call. Dispatches __this with args[0] as thisArg, args[1..] as call args.</summary>
-    public MethodBuilder FunctionProtoCallHelper { get; set; } = null!;
     /// <summary>$Runtime.FunctionProtoApply(__this, args) — ECMA-262 §20.2.3.1 Function.prototype.apply. Dispatches __this with args[0] as thisArg, args[1] (array-like) as call args.</summary>
-    public MethodBuilder FunctionProtoApplyHelper { get; set; } = null!;
     /// <summary>$Runtime.FunctionProtoBind(__this, args) — ECMA-262 §20.2.3.2 Function.prototype.bind. Returns a $BoundTSFunction (or shim) capturing __this + thisArg + boundArgs.</summary>
-    public MethodBuilder FunctionProtoBindHelper { get; set; } = null!;
     /// <summary>$Runtime.FunctionProtoToString(__this) — ECMA-262 §20.2.3.5. Stringifies the function (or returns native-source-like text).</summary>
-    public MethodBuilder FunctionProtoToStringHelper { get; set; } = null!;
     public MethodBuilder GetIndex { get; set; } = null!;
     public MethodBuilder SetIndex { get; set; } = null!;
     public MethodBuilder SetIndexStrict { get; set; } = null!;
@@ -634,7 +624,6 @@ public class EmittedRuntime
     public MethodBuilder AddEventSubscription { get; set; } = null!;
     public MethodBuilder RemoveEventSubscription { get; set; } = null!;
     public FieldBuilder NonExtensibleObjectsField { get; set; } = null!;
-    public FieldBuilder PrototypeStoreField { get; set; } = null!;
     /// <summary>
     /// Per-object set of deleted built-in property names — `name`/`length`
     /// on functions are configurable per ECMA-262 §17, but their values are
@@ -703,7 +692,6 @@ public class EmittedRuntime
     // "[object Arguments]" and Array.isArray returns false per ECMA-262.
     public TypeBuilder ArgumentsType { get; set; } = null!;
     public ConstructorBuilder ArgumentsDefaultCtor { get; set; } = null!;
-    public ConstructorBuilder ArgumentsCapacityCtor { get; set; } = null!;
     public ConstructorBuilder ArgumentsEnumerableCtor { get; set; } = null!;
     /// <summary>$Arguments._length — JS-visible length (per ECMA-262 sloppy
     /// arguments, "length" doesn't auto-update on out-of-range indexed sets).</summary>
@@ -734,7 +722,6 @@ public class EmittedRuntime
     public TypeBuilder BoundAnyFunctionType { get; set; } = null!;
     public ConstructorBuilder BoundAnyFunctionCtor { get; set; } = null!;
     public MethodBuilder BoundAnyFunctionInvoke { get; set; } = null!;
-    public MethodBuilder BoundAnyFunctionInvokeWithThis { get; set; } = null!;
 
     // Method callable wrapper for GetMember results (BuiltInMethod etc.)
     public TypeBuilder MethodCallableType { get; set; } = null!;
@@ -818,7 +805,6 @@ public class EmittedRuntime
     // Symbol support
     public TypeBuilder TSSymbolType { get; set; } = null!;
     public ConstructorBuilder TSSymbolCtor { get; set; } = null!;
-    public MethodBuilder CreateSymbol { get; set; } = null!;
 
     // Well-known symbols (static fields on $TSSymbol)
     public FieldBuilder SymbolIterator { get; set; } = null!;
@@ -845,7 +831,6 @@ public class EmittedRuntime
     public MethodBuilder SymbolDescriptionGetter { get; set; } = null!;
 
     // Symbol storage for compiled objects (symbol as object key)
-    public FieldBuilder SymbolStorageField { get; set; } = null!;
     public MethodBuilder GetSymbolDictMethod { get; set; } = null!;
     public MethodBuilder IsSymbolMethod { get; set; } = null!;
 
@@ -929,7 +914,6 @@ public class EmittedRuntime
     // Timer support ($TSTimeout type and global functions)
     public TypeBuilder TSTimeoutType { get; set; } = null!;
     public ConstructorBuilder TSTimeoutCtor { get; set; } = null!;
-    public FieldBuilder TSTimeoutVirtualTimerField { get; set; } = null!;
     public MethodBuilder TSTimeoutCancel { get; set; } = null!;
     public MethodBuilder TSTimeoutRef { get; set; } = null!;
     public MethodBuilder TSTimeoutUnref { get; set; } = null!;
@@ -947,21 +931,8 @@ public class EmittedRuntime
     public MethodBuilder ExtractTimerOptionsToken { get; set; } = null!;
 
     // Timer closure for callback execution
-    public TypeBuilder TimeoutClosureType { get; set; } = null!;
-    public ConstructorBuilder TimeoutClosureCtor { get; set; } = null!;
-    public FieldBuilder TimeoutClosureCallback { get; set; } = null!;
-    public FieldBuilder TimeoutClosureArgs { get; set; } = null!;
-    public FieldBuilder TimeoutClosureCts { get; set; } = null!;
-    public MethodBuilder TimeoutClosureExecute { get; set; } = null!;
 
     // Interval closure for callback execution (includes delay for rescheduling)
-    public TypeBuilder IntervalClosureType { get; set; } = null!;
-    public ConstructorBuilder IntervalClosureCtor { get; set; } = null!;
-    public FieldBuilder IntervalClosureCallback { get; set; } = null!;
-    public FieldBuilder IntervalClosureArgs { get; set; } = null!;
-    public FieldBuilder IntervalClosureCts { get; set; } = null!;
-    public FieldBuilder IntervalClosureDelayMs { get; set; } = null!;
-    public MethodBuilder IntervalClosureExecuteIteration { get; set; } = null!;
 
     // Interval methods
     public MethodBuilder SetInterval { get; set; } = null!;
@@ -969,7 +940,6 @@ public class EmittedRuntime
 
     // Microtask support
     public MethodBuilder QueueMicrotask { get; set; } = null!;
-    public FieldBuilder MicrotaskQueue { get; set; } = null!;
     public MethodBuilder ProcessMicrotasks { get; set; } = null!;
 
     // Virtual timer infrastructure (for single-threaded timer semantics)
@@ -982,9 +952,6 @@ public class EmittedRuntime
     public FieldBuilder VirtualTimerIsInterval { get; set; } = null!;
     public FieldBuilder VirtualTimerIntervalMs { get; set; } = null!;
     public FieldBuilder VirtualTimerHasRef { get; set; } = null!;
-    public FieldBuilder TimerQueue { get; set; } = null!;
-    public FieldBuilder TimerStartTicks { get; set; } = null!;
-    public FieldBuilder TimerInitialized { get; set; } = null!;
     public MethodBuilder EnsureTimerInitialized { get; set; } = null!;
     public MethodBuilder GetCurrentTimeMs { get; set; } = null!;
     public MethodBuilder ProcessPendingTimers { get; set; } = null!;
@@ -1090,7 +1057,6 @@ public class EmittedRuntime
     // module-specific static $exports field so require() always sees the latest value.
     public Type CjsModuleType { get; set; } = null!;
     public ConstructorInfo CjsModuleCtor { get; set; } = null!;
-    public MethodInfo CjsModuleExportsGetter { get; set; } = null!;
     public MethodInfo CjsModuleExportsSetter { get; set; } = null!;
 
     // The emitted TSDate class
@@ -1273,7 +1239,6 @@ public class EmittedRuntime
     public MethodBuilder TSErrorCodeSetter { get; set; } = null!;
     public MethodBuilder TSErrorSyscallGetter { get; set; } = null!;
     public MethodBuilder TSErrorSyscallSetter { get; set; } = null!;
-    public MethodBuilder TSErrorToStringMethod { get; set; } = null!;
     public MethodBuilder TSErrorCaptureStackTrace { get; set; } = null!;
 
     // $TypeError
@@ -1355,14 +1320,10 @@ public class EmittedRuntime
     /// <summary>$Array(object?[] ctorArgs) — ECMA-262 Array-constructor semantics for guest classes extending Array (#233): implicit ctors and super(...) chain through this.</summary>
     public ConstructorBuilder TSArrayCtorFromCtorArgs { get; set; } = null!;
     public MethodBuilder TSArrayElementsGetter { get; set; } = null!;
-    public MethodBuilder TSArrayIsFrozenGetter { get; set; } = null!;
-    public MethodBuilder TSArrayIsSealedGetter { get; set; } = null!;
     public MethodBuilder TSArrayFreeze { get; set; } = null!;
-    public MethodBuilder TSArraySeal { get; set; } = null!;
     public MethodBuilder TSArrayGet { get; set; } = null!;
     public MethodBuilder TSArraySet { get; set; } = null!;
     public MethodBuilder TSArraySetStrict { get; set; } = null!;
-    public MethodBuilder TSArrayToString { get; set; } = null!;
 
     // Stage E.2 additions (long-indexed sparse/hole-aware API).
     // Mirrors SharpTSArray public surface. Legacy int-indexed Get/Set above
@@ -1371,7 +1332,6 @@ public class EmittedRuntime
     public MethodBuilder TSArrayLongLengthGetter { get; set; } = null!;
     public MethodBuilder TSArrayLengthGetter { get; set; } = null!;
     public MethodBuilder TSArrayHasIndex { get; set; } = null!;
-    public MethodBuilder TSArrayGetRaw { get; set; } = null!;
     public MethodBuilder TSArrayGetLong { get; set; } = null!;
     public MethodBuilder TSArraySetLong { get; set; } = null!;
     public MethodBuilder TSArraySetStrictLong { get; set; } = null!;
@@ -1381,7 +1341,6 @@ public class EmittedRuntime
     // Unboxed packed-double elements-kind accessors (number[] unboxing project).
     // GetDouble/SetDouble/PushDouble are the fast paths the compiler emits at
     // statically-number[] sites; EnsureBoxed is the deopt (numeric -> boxed).
-    public MethodBuilder TSArrayGetDouble { get; set; } = null!;
     public MethodBuilder TSArraySetDouble { get; set; } = null!;
     public MethodBuilder TSArrayPushDouble { get; set; } = null!;
     public MethodBuilder TSArrayEnsureBoxed { get; set; } = null!;
@@ -1407,8 +1366,6 @@ public class EmittedRuntime
     public Type TSObjectType { get; set; } = null!;
     public ConstructorBuilder TSObjectCtor { get; set; } = null!;
     public MethodBuilder TSObjectFieldsGetter { get; set; } = null!;
-    public MethodBuilder TSObjectIsFrozenGetter { get; set; } = null!;
-    public MethodBuilder TSObjectIsSealedGetter { get; set; } = null!;
     public MethodBuilder TSObjectFreeze { get; set; } = null!;
     public MethodBuilder TSObjectSeal { get; set; } = null!;
     public MethodBuilder TSObjectPreventExtensions { get; set; } = null!;
@@ -1418,15 +1375,11 @@ public class EmittedRuntime
     public MethodBuilder TSObjectHasProperty { get; set; } = null!;
     public MethodBuilder TSObjectDeleteProperty { get; set; } = null!;
     public MethodBuilder TSObjectDeletePropertyStrict { get; set; } = null!;
-    public MethodBuilder TSObjectGetKeys { get; set; } = null!;
-    public MethodBuilder TSObjectToString { get; set; } = null!;
     public MethodBuilder TSObjectDefineGetter { get; set; } = null!;
     public MethodBuilder TSObjectDefineSetter { get; set; } = null!;
     public MethodBuilder TSObjectHasGetter { get; set; } = null!;
     public MethodBuilder TSObjectHasSetter { get; set; } = null!;
-    public MethodBuilder TSObjectGetGetter { get; set; } = null!;
     public MethodBuilder TSObjectGetGettersDict { get; set; } = null!;
-    public MethodBuilder TSObjectGetSetter { get; set; } = null!;
     public MethodBuilder TSObjectGetSettersDict { get; set; } = null!;
 
     // Module registry for dynamic imports
@@ -1534,53 +1487,31 @@ public class EmittedRuntime
     public MethodBuilder FsCloseSync { get; set; } = null!;
     public MethodBuilder FsReadSync { get; set; } = null!;
     public MethodBuilder FsWriteSyncBuffer { get; set; } = null!;
-    public MethodBuilder FsWriteSyncString { get; set; } = null!;
     public MethodBuilder FsFstatSync { get; set; } = null!;
     public MethodBuilder FsFtruncateSync { get; set; } = null!;
     // Long-tail fd primitives (#976): fsync, fd→path, and statfs.
     public MethodBuilder FsFsyncSync { get; set; } = null!;
     public MethodBuilder FsFdPath { get; set; } = null!;
     public MethodBuilder FsStatfsRaw { get; set; } = null!;
-    public FieldBuilder FsFileDescriptorTable { get; set; } = null!;
 
     // File descriptor low-level helpers (reflection-based for standalone DLLs)
     public MethodBuilder FsFlagsParse { get; set; } = null!;
     public MethodBuilder FsFlagsParsePure { get; set; } = null!;
-    public MethodBuilder FdTableGetInstance { get; set; } = null!;
-    public MethodBuilder FdTableOpen { get; set; } = null!;
-    public MethodBuilder FdTableClose { get; set; } = null!;
-    public MethodBuilder FdTableGet { get; set; } = null!;
     public MethodBuilder CreateSharpTSDir { get; set; } = null!;
     public MethodBuilder LibCCreateHardLink { get; set; } = null!;
     public MethodBuilder CreateHardLinkPure { get; set; } = null!;
 
     // $FileDescriptorTable type (pure-IL for standalone DLLs)
-    public TypeBuilder FileDescriptorTableType { get; set; } = null!;
     public FieldBuilder FileDescriptorTableInstance { get; set; } = null!;
-    public ConstructorBuilder FileDescriptorTableCtor { get; set; } = null!;
     public MethodBuilder FileDescriptorTableOpen { get; set; } = null!;
     public MethodBuilder FileDescriptorTableGet { get; set; } = null!;
     public MethodBuilder FileDescriptorTableClose { get; set; } = null!;
-    public MethodBuilder FileDescriptorTableIsValid { get; set; } = null!;
 
     // $Dir type (pure-IL for standalone DLLs)
-    public TypeBuilder DirType { get; set; } = null!;
     public ConstructorBuilder DirCtor { get; set; } = null!;
-    public MethodBuilder DirPathGetter { get; set; } = null!;
-    public MethodBuilder DirReadSync { get; set; } = null!;
-    public MethodBuilder DirCloseSync { get; set; } = null!;
 
     // $Dirent type (pure-IL for standalone DLLs)
-    public TypeBuilder DirentType { get; set; } = null!;
     public ConstructorBuilder DirentCtor { get; set; } = null!;
-    public MethodBuilder DirentNameGetter { get; set; } = null!;
-    public MethodBuilder DirentIsFile { get; set; } = null!;
-    public MethodBuilder DirentIsDirectory { get; set; } = null!;
-    public MethodBuilder DirentIsSymbolicLink { get; set; } = null!;
-    public MethodBuilder DirentIsBlockDevice { get; set; } = null!;
-    public MethodBuilder DirentIsCharacterDevice { get; set; } = null!;
-    public MethodBuilder DirentIsFIFO { get; set; } = null!;
-    public MethodBuilder DirentIsSocket { get; set; } = null!;
 
     // $ArrayBuffer type (pure-IL for standalone DLLs)
     public TypeBuilder ArrayBufferType { get; set; } = null!;
@@ -1635,8 +1566,6 @@ public class EmittedRuntime
     public MethodBuilder TypedArrayElementSet { get; set; } = null!;
     // Unboxed Float64Array element accessors (#878) — direct double get/set on the
     // concrete $Float64Array, bypassing the boxed Get/Set + GetIndex dispatch.
-    public MethodBuilder Float64ArrayGetUnboxed { get; set; } = null!;
-    public MethodBuilder Float64ArraySetUnboxed { get; set; } = null!;
 
     // Unboxed numeric typed-array element accessors (#3) — `double GetUnboxed(int)` /
     // `void SetUnboxed(int, double)` on each concrete numeric $XArray, keyed by element-type
@@ -1788,7 +1717,6 @@ public class EmittedRuntime
     public MethodBuilder ProcessEventEmitterCall { get; set; } = null!;
     public MethodBuilder ProcessEmitExit { get; set; } = null!;
     public MethodBuilder GetProcessEventEmitter { get; set; } = null!;
-    public FieldBuilder ProcessEventEmitterInstance { get; set; } = null!;
 
     // Process stdin/stdout/stderr stream methods
     public MethodBuilder StdinRead { get; set; } = null!;
@@ -1831,10 +1759,6 @@ public class EmittedRuntime
     public MethodBuilder SymbolClosedOwner { get; set; } = null!;
     public MethodBuilder CloseSymbolAccessor { get; set; } = null!;
     public FieldBuilder CachedFetchFunction { get; set; } = null!;
-    public FieldBuilder CachedParseIntFunction { get; set; } = null!;
-    public FieldBuilder CachedParseFloatFunction { get; set; } = null!;
-    public FieldBuilder CachedIsNaNFunction { get; set; } = null!;
-    public FieldBuilder CachedIsFiniteFunction { get; set; } = null!;
     public FieldBuilder GlobalThisProperties { get; set; } = null!;
 
     // Crypto module methods
@@ -1844,40 +1768,22 @@ public class EmittedRuntime
 
     // $Hash type - emitted for standalone crypto support
     // NOTE: Must stay in sync with SharpTS.Runtime.Types.SharpTSHash
-    public Type TSHashType { get; set; } = null!;
     public ConstructorBuilder TSHashCtor { get; set; } = null!;
-    public MethodBuilder TSHashUpdateMethod { get; set; } = null!;
-    public MethodBuilder TSHashDigestMethod { get; set; } = null!;
 
     // $Hmac type - emitted for standalone crypto support
     // NOTE: Must stay in sync with SharpTS.Runtime.Types.SharpTSHmac
     public MethodBuilder CryptoCreateHmac { get; set; } = null!;
-    public Type TSHmacType { get; set; } = null!;
     public ConstructorBuilder TSHmacCtor { get; set; } = null!;
-    public MethodBuilder TSHmacUpdateMethod { get; set; } = null!;
-    public MethodBuilder TSHmacDigestMethod { get; set; } = null!;
 
     // $Cipher type - emitted for standalone crypto support
     // NOTE: Must stay in sync with SharpTS.Runtime.Types.SharpTSCipher
     public MethodBuilder CryptoCreateCipheriv { get; set; } = null!;
-    public Type TSCipherType { get; set; } = null!;
     public ConstructorBuilder TSCipherCtor { get; set; } = null!;
-    public MethodBuilder TSCipherUpdateMethod { get; set; } = null!;
-    public MethodBuilder TSCipherFinalMethod { get; set; } = null!;
-    public MethodBuilder TSCipherSetAutoPaddingMethod { get; set; } = null!;
-    public MethodBuilder TSCipherGetAuthTagMethod { get; set; } = null!;
-    public MethodBuilder TSCipherSetAADMethod { get; set; } = null!;
 
     // $Decipher type - emitted for standalone crypto support
     // NOTE: Must stay in sync with SharpTS.Runtime.Types.SharpTSDecipher
     public MethodBuilder CryptoCreateDecipheriv { get; set; } = null!;
-    public Type TSDecipherType { get; set; } = null!;
     public ConstructorBuilder TSDecipherCtor { get; set; } = null!;
-    public MethodBuilder TSDecipherUpdateMethod { get; set; } = null!;
-    public MethodBuilder TSDecipherFinalMethod { get; set; } = null!;
-    public MethodBuilder TSDecipherSetAutoPaddingMethod { get; set; } = null!;
-    public MethodBuilder TSDecipherSetAuthTagMethod { get; set; } = null!;
-    public MethodBuilder TSDecipherSetAADMethod { get; set; } = null!;
 
     // PBKDF2 and scrypt key derivation
     public MethodBuilder CryptoPbkdf2Sync { get; set; } = null!;
@@ -1895,24 +1801,16 @@ public class EmittedRuntime
     // $Sign type - emitted for standalone crypto signing support
     // NOTE: Must stay in sync with SharpTS.Runtime.Types.SharpTSSign
     public MethodBuilder CryptoCreateSign { get; set; } = null!;
-    public Type TSSignType { get; set; } = null!;
     public ConstructorBuilder TSSignCtor { get; set; } = null!;
-    public MethodBuilder TSSignUpdateMethod { get; set; } = null!;
-    public MethodBuilder TSSignSignMethod { get; set; } = null!;
     public MethodBuilder SignDataBytes { get; set; } = null!;  // Pure IL signing helper
 
     // $Verify type - emitted for standalone crypto verification support
     // NOTE: Must stay in sync with SharpTS.Runtime.Types.SharpTSVerify
     public MethodBuilder CryptoCreateVerify { get; set; } = null!;
-    public Type TSVerifyType { get; set; } = null!;
     public ConstructorBuilder TSVerifyCtor { get; set; } = null!;
-    public MethodBuilder TSVerifyUpdateMethod { get; set; } = null!;
-    public MethodBuilder TSVerifyVerifyMethod { get; set; } = null!;
     public MethodBuilder VerifyDataBytes { get; set; } = null!;  // Pure IL verification helper
 
     // AES-GCM helper methods (needed because AesGcm uses Span<T> parameters)
-    public MethodBuilder AesGcmEncryptHelper { get; set; } = null!;
-    public MethodBuilder AesGcmDecryptHelper { get; set; } = null!;
 
     // Crypto info methods (getHashes, getCiphers)
     public MethodBuilder CryptoGetHashes { get; set; } = null!;
@@ -1942,9 +1840,7 @@ public class EmittedRuntime
     public MethodBuilder TSDHGenerateRandomPrime { get; set; } = null!;
     public MethodBuilder TSDHIsProbablePrime { get; set; } = null!;
     public MethodBuilder TSDHBigIntFromBytes { get; set; } = null!;
-    public Type BoundDHMethodType { get; set; } = null!;
     public ConstructorBuilder BoundDHMethodCtor { get; set; } = null!;
-    public MethodBuilder BoundDHMethodInvoke { get; set; } = null!;
 
     // ECDH support
     public MethodBuilder CryptoCreateECDH { get; set; } = null!;
@@ -1959,9 +1855,7 @@ public class EmittedRuntime
     public MethodBuilder TSECDHEncodeResult { get; set; } = null!;
     public MethodBuilder TSECDHDecodeInput { get; set; } = null!;
     public MethodBuilder TSECDHComputeSecretHelper { get; set; } = null!;
-    public Type BoundECDHMethodType { get; set; } = null!;
     public ConstructorBuilder BoundECDHMethodCtor { get; set; } = null!;
-    public MethodBuilder BoundECDHMethodInvoke { get; set; } = null!;
 
     // RSA encryption/decryption
     public MethodBuilder CryptoPublicEncrypt { get; set; } = null!;
@@ -1987,7 +1881,6 @@ public class EmittedRuntime
     public MethodBuilder CryptoCreateSecretKey { get; set; } = null!;
     public MethodBuilder CryptoCreatePublicKey { get; set; } = null!;
     public MethodBuilder CryptoCreatePrivateKey { get; set; } = null!;
-    public Type TSKeyObjectType { get; set; } = null!;
     public ConstructorBuilder TSKeyObjectCtorSecret { get; set; } = null!;
     public ConstructorBuilder TSKeyObjectCtorAsym { get; set; } = null!;
 
@@ -2021,21 +1914,16 @@ public class EmittedRuntime
     // $HttpServer type - emitted for standalone HTTP server support
     public TypeBuilder TSHttpServerType { get; set; } = null!;
     public ConstructorBuilder TSHttpServerCtor { get; set; } = null!;
-    public MethodBuilder TSHttpServerListen { get; set; } = null!;
     public MethodBuilder TSHttpServerClose { get; set; } = null!;
     public MethodBuilder TSHttpServerAddress { get; set; } = null!;
-    public MethodBuilder TSHttpServerGetMember { get; set; } = null!;
 
     // $HttpRequest type - emitted for standalone HTTP request support
     public TypeBuilder TSHttpRequestType { get; set; } = null!;
     public ConstructorBuilder TSHttpRequestCtor { get; set; } = null!;
-    public MethodBuilder TSHttpRequestGetMember { get; set; } = null!;
 
     // $HttpResponse type - emitted for standalone HTTP response support
     public TypeBuilder TSHttpResponseType { get; set; } = null!;
     public ConstructorBuilder TSHttpResponseCtor { get; set; } = null!;
-    public MethodBuilder TSHttpResponseGetMember { get; set; } = null!;
-    public MethodBuilder TSHttpResponseSetMember { get; set; } = null!;
 
     // Net module methods
     public MethodBuilder NetCreateServer { get; set; } = null!;
@@ -2061,14 +1949,12 @@ public class EmittedRuntime
 
     // $TlsServer emitted type - pure IL standalone TLS server
     // NOTE: Must stay in sync with SharpTS.Runtime.Types.SharpTSTlsServer
-    public Type TlsServerType { get; set; } = null!;
     public ConstructorBuilder TlsServerCtor { get; set; } = null!;
 
     // Dgram module methods
     public MethodBuilder DgramCreateSocket { get; set; } = null!;
 
     // $DatagramSocket emitted type
-    public Type DatagramSocketType { get; set; } = null!;
     public ConstructorBuilder DatagramSocketCtor { get; set; } = null!;
 
     // $Headers type - emitted for standalone Headers support
@@ -2080,11 +1966,9 @@ public class EmittedRuntime
     // the canonical implementation. No compile-time runtime type is emitted.
 
     // $FetchResponse type - emitted for standalone fetch support
-    public TypeBuilder TSFetchResponseType { get; set; } = null!;
     public ConstructorBuilder TSFetchResponseCtor { get; set; } = null!;
 
     // $Request type - emitted for standalone Request constructor support
-    public TypeBuilder TSRequestType { get; set; } = null!;
     public ConstructorBuilder TSRequestCtor { get; set; } = null!;
 
     // $Response type - emitted for standalone Response constructor support
@@ -2131,7 +2015,6 @@ public class EmittedRuntime
     public MethodBuilder TSBufferReadUInt8 { get; set; } = null!;
     public MethodBuilder TSBufferWriteUInt8 { get; set; } = null!;
     public MethodBuilder TSBufferToJSON { get; set; } = null!;
-    public MethodBuilder GetBufferMethod { get; set; } = null!;
 
     // Multi-byte read methods
     public MethodBuilder TSBufferReadInt8 { get; set; } = null!;
@@ -2244,21 +2127,14 @@ public class EmittedRuntime
     // $TextEncoder type - emitted for standalone util support
     public TypeBuilder TSTextEncoderType { get; set; } = null!;
     public ConstructorBuilder TSTextEncoderCtor { get; set; } = null!;
-    public MethodBuilder TSTextEncoderEncodingGetter { get; set; } = null!;
-    public MethodBuilder TSTextEncoderEncode { get; set; } = null!;
-    public MethodBuilder TSTextEncoderEncodeInto { get; set; } = null!;
 
     // $TextDecoder type - emitted for standalone util support
     public TypeBuilder TSTextDecoderType { get; set; } = null!;
     public ConstructorBuilder TSTextDecoderCtor { get; set; } = null!;
-    public MethodBuilder TSTextDecoderEncodingGetter { get; set; } = null!;
-    public MethodBuilder TSTextDecoderFatalGetter { get; set; } = null!;
-    public MethodBuilder TSTextDecoderIgnoreBOMGetter { get; set; } = null!;
     public MethodBuilder TSTextDecoderDecode { get; set; } = null!;
 
     // $TextDecoderDecodeMethod wrapper - callable by compiled code
     public TypeBuilder TSTextDecoderDecodeMethodType { get; set; } = null!;
-    public ConstructorBuilder TSTextDecoderDecodeMethodCtor { get; set; } = null!;
     public MethodBuilder TSTextDecoderDecodeMethodInvoke { get; set; } = null!;
 
     // Util format helper methods (emitted for standalone)
@@ -2282,7 +2158,6 @@ public class EmittedRuntime
 
     // $ReadlineInterface type - emitted for standalone readline support
     // NOTE: Must stay in sync with SharpTS.Runtime.Types.SharpTSReadlineInterface
-    public Type ReadlineInterfaceType { get; set; } = null!;
     public ConstructorBuilder ReadlineInterfaceCtor { get; set; } = null!;
 
     // Child process module methods
@@ -2295,8 +2170,6 @@ public class EmittedRuntime
     public MethodBuilder ChildProcessFork { get; set; } = null!;
 
     // Querystring module methods
-    public MethodBuilder QuerystringParse { get; set; } = null!;
-    public MethodBuilder QuerystringStringify { get; set; } = null!;
 
     // Zlib module methods
     public MethodBuilder ZlibGzipSync { get; set; } = null!;
@@ -2342,7 +2215,6 @@ public class EmittedRuntime
     public MethodBuilder ZlibUnzipAsync { get; set; } = null!;
 
     // $ZlibTransform type - emitted for standalone zlib streaming support
-    public Type TSZlibTransformType { get; set; } = null!;
     public ConstructorBuilder TSZlibTransformCtor { get; set; } = null!;
 
     // $EventEmitter type - emitted for standalone event emitter support
@@ -2367,7 +2239,6 @@ public class EmittedRuntime
     public MethodBuilder TSEventEmitterOnListenerAdded { get; set; } = null!;
 
     // $AsyncLocalStorage support
-    public Type TSAsyncLocalStorageType { get; set; } = null!;
     public ConstructorBuilder TSAsyncLocalStorageCtor { get; set; } = null!;
 
     // Value-position namespace singletons (#224). Null when the matching
@@ -2450,7 +2321,6 @@ public class EmittedRuntime
     public MethodBuilder NodeErrorCodeGetter { get; set; } = null!;
     public MethodBuilder NodeErrorSyscallGetter { get; set; } = null!;
     public MethodBuilder NodeErrorPathGetter { get; set; } = null!;
-    public MethodBuilder NodeErrorErrnoGetter { get; set; } = null!;
 
     // TTY module methods
     public MethodBuilder TtyIsatty { get; set; } = null!;
@@ -2465,23 +2335,14 @@ public class EmittedRuntime
     // perf_hooks (mark/measure/entries/observer) is pure TypeScript in
     // stdlib/node/perf_hooks.ts. Backing fields initialize lazily on first call.
     public MethodBuilder PerfPrimitiveNow { get; set; } = null!;
-    public FieldBuilder PerfPrimitiveStartTicks { get; set; } = null!;
-    public FieldBuilder PerfPrimitiveTicksPerMs { get; set; } = null!;
 
     // $Readable type - emitted for standalone stream support
     // NOTE: Must stay in sync with SharpTS.Runtime.Types.SharpTSReadable
     public Type TSReadableType { get; set; } = null!;
     public ConstructorBuilder TSReadableCtor { get; set; } = null!;
-    public MethodBuilder TSReadableRead { get; set; } = null!;
     public MethodBuilder TSReadablePush { get; set; } = null!;
     public MethodBuilder TSReadablePipe { get; set; } = null!;
-    public MethodBuilder TSReadableUnpipe { get; set; } = null!;
-    public MethodBuilder TSReadableSetEncoding { get; set; } = null!;
     public MethodBuilder TSReadableDestroy { get; set; } = null!;
-    public MethodBuilder TSReadableUnshift { get; set; } = null!;
-    public MethodBuilder TSReadablePause { get; set; } = null!;
-    public MethodBuilder TSReadableResume { get; set; } = null!;
-    public MethodBuilder TSReadableIsPaused { get; set; } = null!;
     // #1024: [Symbol.asyncIterator] support — GetAsyncIterator() is registered via the
     // GetIteratorFunction hook so `for await…of` over a $Readable works in compiled mode.
     public MethodBuilder TSReadableGetAsyncIterator { get; set; } = null!;
@@ -2511,10 +2372,8 @@ public class EmittedRuntime
     public ConstructorBuilder TSWritableCtor { get; set; } = null!;
     public MethodBuilder TSWritableWrite { get; set; } = null!;
     public MethodBuilder TSWritableEnd { get; set; } = null!;
-    public MethodBuilder TSWritableCork { get; set; } = null!;
     public MethodBuilder TSWritableUncork { get; set; } = null!;
     public MethodBuilder TSWritableDestroy { get; set; } = null!;
-    public MethodBuilder TSWritableSetDefaultEncoding { get; set; } = null!;
 
     // $Duplex type - emitted for standalone stream support
     // NOTE: Must stay in sync with SharpTS.Runtime.Types.SharpTSDuplex
@@ -2530,12 +2389,10 @@ public class EmittedRuntime
     public Type TransformDoneCallbackType { get; set; } = null!;
     public MethodBuilder TransformDoneCallbackInvoke { get; set; } = null!;
     public Type WriteCallbackWrapperType { get; set; } = null!;
-    public ConstructorBuilder WriteCallbackWrapperCtor { get; set; } = null!;
     public MethodBuilder WriteCallbackWrapperInvoke { get; set; } = null!;
 
     // $PassThrough type - emitted for standalone stream support
     // NOTE: Must stay in sync with SharpTS.Runtime.Types.SharpTSPassThrough
-    public Type TSPassThroughType { get; set; } = null!;
     public ConstructorBuilder TSPassThroughCtor { get; set; } = null!;
 
     public MethodBuilder TSReadableSetObjectMode { get; set; } = null!;
@@ -2571,12 +2428,6 @@ public class EmittedRuntime
     public MethodBuilder FsCreateWriteStream { get; set; } = null!;
 
     // fs.watch / fs.watchFile / fs.unwatchFile
-    public Type FsWatcherType { get; set; } = null!;
-    public ConstructorBuilder FsWatcherCtor { get; set; } = null!;
-    public MethodBuilder FsWatcherClose { get; set; } = null!;
-    public Type StatWatcherType { get; set; } = null!;
-    public ConstructorBuilder StatWatcherCtor { get; set; } = null!;
-    public MethodBuilder StatWatcherClose { get; set; } = null!;
     public MethodBuilder FsWatch { get; set; } = null!;
     public MethodBuilder FsWatchFile { get; set; } = null!;
     public MethodBuilder FsUnwatchFile { get; set; } = null!;
@@ -2617,14 +2468,12 @@ public class EmittedRuntime
 
     // $SharedArrayBuffer type - emitted for standalone worker support
     // NOTE: Must stay in sync with SharpTS.Runtime.Types.SharpTSSharedArrayBuffer
-    public Type TSSharedArrayBufferType { get; set; } = null!;
     public MethodBuilder TSSharedArrayBufferCtor { get; set; } = null!;
     public MethodBuilder TSSharedArrayBufferByteLengthGetter { get; set; } = null!;
     public MethodBuilder TSSharedArrayBufferSlice { get; set; } = null!;
 
     // $ArrayBuffer type - emitted for standalone support
     // NOTE: Must stay in sync with SharpTS.Runtime.Types.SharpTSArrayBuffer
-    public Type TSArrayBufferType { get; set; } = null!;
     public MethodBuilder TSArrayBufferCtor { get; set; } = null!;
     public MethodBuilder TSArrayBufferByteLengthGetter { get; set; } = null!;
     public MethodBuilder TSArrayBufferSlice { get; set; } = null!;
@@ -2632,7 +2481,6 @@ public class EmittedRuntime
 
     // $DataView type - emitted for standalone support
     // NOTE: Must stay in sync with SharpTS.Runtime.Types.SharpTSDataView
-    public Type TSDataViewType { get; set; } = null!;
     public MethodBuilder TSDataViewCtor { get; set; } = null!;
     public MethodBuilder TSDataViewByteLengthGetter { get; set; } = null!;
     public MethodBuilder TSDataViewByteOffsetGetter { get; set; } = null!;
@@ -2660,71 +2508,12 @@ public class EmittedRuntime
     public MethodBuilder TSDataViewSetBigInt64 { get; set; } = null!;
     public MethodBuilder TSDataViewSetBigUint64 { get; set; } = null!;
 
-    // TypedArray base type and common methods
-    // NOTE: Must stay in sync with SharpTS.Runtime.Types.SharpTSTypedArray
-    public Type TSTypedArrayBaseType { get; set; } = null!;
-    public MethodBuilder TSTypedArrayLengthGetter { get; set; } = null!;
-    public MethodBuilder TSTypedArrayByteLengthGetter { get; set; } = null!;
-    public MethodBuilder TSTypedArrayByteOffsetGetter { get; set; } = null!;
-    public MethodBuilder TSTypedArrayBufferGetter { get; set; } = null!;
-    public MethodBuilder TSTypedArrayGet { get; set; } = null!;
-    public MethodBuilder TSTypedArraySet { get; set; } = null!;
-    public MethodBuilder TSTypedArraySubarray { get; set; } = null!;
-    public MethodBuilder TSTypedArraySlice { get; set; } = null!;
-    public MethodBuilder TSTypedArrayFill { get; set; } = null!;
-    public MethodBuilder TSTypedArrayCopyWithin { get; set; } = null!;
-
     // TypedArray helper methods that avoid hard dependencies on SharpTS.dll
     // These use reflection to work with TypedArrays without requiring SharpTS.dll at runtime
     public MethodBuilder IsTypedArrayMethod { get; set; } = null!;
     public MethodBuilder GetTypedArrayElementMethod { get; set; } = null!;
     public MethodBuilder SetTypedArrayElementMethod { get; set; } = null!;
     public MethodBuilder GetTypedArrayMemberMethod { get; set; } = null!;
-
-    // Concrete TypedArray types
-    public Type TSInt8ArrayType { get; set; } = null!;
-    public ConstructorBuilder TSInt8ArrayCtor { get; set; } = null!;
-    public ConstructorBuilder TSInt8ArrayCtorSAB { get; set; } = null!;
-
-    public Type TSUint8ArrayType { get; set; } = null!;
-    public ConstructorBuilder TSUint8ArrayCtor { get; set; } = null!;
-    public ConstructorBuilder TSUint8ArrayCtorSAB { get; set; } = null!;
-
-    public Type TSUint8ClampedArrayType { get; set; } = null!;
-    public ConstructorBuilder TSUint8ClampedArrayCtor { get; set; } = null!;
-    public ConstructorBuilder TSUint8ClampedArrayCtorSAB { get; set; } = null!;
-
-    public Type TSInt16ArrayType { get; set; } = null!;
-    public ConstructorBuilder TSInt16ArrayCtor { get; set; } = null!;
-    public ConstructorBuilder TSInt16ArrayCtorSAB { get; set; } = null!;
-
-    public Type TSUint16ArrayType { get; set; } = null!;
-    public ConstructorBuilder TSUint16ArrayCtor { get; set; } = null!;
-    public ConstructorBuilder TSUint16ArrayCtorSAB { get; set; } = null!;
-
-    public Type TSInt32ArrayType { get; set; } = null!;
-    public ConstructorBuilder TSInt32ArrayCtor { get; set; } = null!;
-    public ConstructorBuilder TSInt32ArrayCtorSAB { get; set; } = null!;
-
-    public Type TSUint32ArrayType { get; set; } = null!;
-    public ConstructorBuilder TSUint32ArrayCtor { get; set; } = null!;
-    public ConstructorBuilder TSUint32ArrayCtorSAB { get; set; } = null!;
-
-    public Type TSFloat32ArrayType { get; set; } = null!;
-    public ConstructorBuilder TSFloat32ArrayCtor { get; set; } = null!;
-    public ConstructorBuilder TSFloat32ArrayCtorSAB { get; set; } = null!;
-
-    public Type TSFloat64ArrayType { get; set; } = null!;
-    public ConstructorBuilder TSFloat64ArrayCtor { get; set; } = null!;
-    public ConstructorBuilder TSFloat64ArrayCtorSAB { get; set; } = null!;
-
-    public Type TSBigInt64ArrayType { get; set; } = null!;
-    public ConstructorBuilder TSBigInt64ArrayCtor { get; set; } = null!;
-    public ConstructorBuilder TSBigInt64ArrayCtorSAB { get; set; } = null!;
-
-    public Type TSBigUint64ArrayType { get; set; } = null!;
-    public ConstructorBuilder TSBigUint64ArrayCtor { get; set; } = null!;
-    public ConstructorBuilder TSBigUint64ArrayCtorSAB { get; set; } = null!;
 
     // TypedArray FromObject helpers (handles both length and SharedArrayBuffer arguments)
     public Dictionary<string, MethodBuilder> TypedArrayFromObjectHelpers { get; } = [];
@@ -2750,27 +2539,16 @@ public class EmittedRuntime
     // $MessagePort type - emitted for standalone worker support
     // NOTE: Must stay in sync with SharpTS.Runtime.Types.SharpTSMessagePort
     public Type TSMessagePortType { get; set; } = null!;
-    public ConstructorBuilder TSMessagePortCtor { get; set; } = null!;
-    public MethodBuilder TSMessagePortPostMessage { get; set; } = null!;
-    public MethodBuilder TSMessagePortStart { get; set; } = null!;
-    public MethodBuilder TSMessagePortClose { get; set; } = null!;
 
     // $MessageChannel type - emitted for standalone worker support
     // NOTE: Must stay in sync with SharpTS.Runtime.Types.SharpTSMessageChannel
     public Type TSMessageChannelType { get; set; } = null!;
     public MethodBuilder TSMessageChannelCtor { get; set; } = null!;
-    public MethodBuilder TSMessageChannelPort1Getter { get; set; } = null!;
-    public MethodBuilder TSMessageChannelPort2Getter { get; set; } = null!;
 
     // $Worker type - emitted for standalone worker support
     // NOTE: Must stay in sync with SharpTS.Runtime.Types.SharpTSWorker
     public Type TSWorkerType { get; set; } = null!;
     public MethodBuilder TSWorkerCtor { get; set; } = null!;
-    public MethodBuilder TSWorkerThreadIdGetter { get; set; } = null!;
-    public MethodBuilder TSWorkerPostMessage { get; set; } = null!;
-    public MethodBuilder TSWorkerTerminate { get; set; } = null!;
-    public MethodBuilder TSWorkerRef { get; set; } = null!;
-    public MethodBuilder TSWorkerUnref { get; set; } = null!;
 
     // StructuredClone helper methods
     // NOTE: Must stay in sync with SharpTS.Runtime.Types.StructuredClone
@@ -2871,18 +2649,15 @@ public class EmittedRuntime
     public MethodBuilder StatsIsFIFO { get; set; } = null!;
     public MethodBuilder StatsIsSocket { get; set; } = null!;
     public MethodBuilder StatsSizeGetter { get; set; } = null!;
-    public MethodBuilder StatsModeGetter { get; set; } = null!;
 
     // $FrozenSealedState - tracks frozen/sealed/extensible state for objects
     public Type FrozenSealedStateType { get; set; } = null!;
-    public ConstructorInfo FrozenSealedStateCtor { get; set; } = null!;
     public PropertyInfo FrozenSealedStateIsFrozen { get; set; } = null!;
     public PropertyInfo FrozenSealedStateIsSealed { get; set; } = null!;
     public PropertyInfo FrozenSealedStateIsExtensible { get; set; } = null!;
 
     // $PrototypeInfo - holds prototype reference for objects
     public Type PrototypeInfoType { get; set; } = null!;
-    public ConstructorInfo PrototypeInfoCtor { get; set; } = null!;
     public PropertyInfo PrototypeInfoPrototype { get; set; } = null!;
 
     // $CompiledPropertyDescriptor - property descriptor for compiled objects
@@ -2896,11 +2671,6 @@ public class EmittedRuntime
     public PropertyInfo CompiledPropertyDescriptorConfigurable { get; set; } = null!;
 
     // $PropertyDescriptorStore - stores property descriptors for compiled objects
-    public Type PropertyDescriptorStoreType { get; set; } = null!;
-    public FieldBuilder PDSDescriptorsField { get; set; } = null!;
-    public FieldBuilder PDSFrozenSealedField { get; set; } = null!;
-    public FieldBuilder PDSSymbolStorageField { get; set; } = null!;
-    public FieldBuilder PDSPrototypeStoreField { get; set; } = null!;
     public MethodBuilder PDSFreeze { get; set; } = null!;
     public MethodBuilder PDSSeal { get; set; } = null!;
     public MethodBuilder PDSPreventExtensions { get; set; } = null!;
@@ -2921,34 +2691,20 @@ public class EmittedRuntime
 
     // cluster module — emitted types (no reflection to SharpTS.dll)
     // $ClusterContext: static class with [ThreadStatic] fields for worker detection
-    public TypeBuilder ClusterContextType { get; set; } = null!;
     public FieldBuilder ClusterContextIsWorkerField { get; set; } = null!;
-    public FieldBuilder ClusterContextWorkerIdField { get; set; } = null!;
     public FieldBuilder ClusterContextCurrentWorkerField { get; set; } = null!;
-    public FieldBuilder ClusterContextPrimaryToWorkerQueueField { get; set; } = null!;
-    public FieldBuilder ClusterContextWorkerToPrimaryQueueField { get; set; } = null!;
 
     // $ClusterWorker: extends $EventEmitter, manages a worker thread with IPC
     public TypeBuilder ClusterWorkerType { get; set; } = null!;
-    public ConstructorBuilder ClusterWorkerCtor { get; set; } = null!;
-    public MethodBuilder ClusterWorkerSend { get; set; } = null!;
     public MethodBuilder ClusterWorkerDisconnect { get; set; } = null!;
-    public MethodBuilder ClusterWorkerKill { get; set; } = null!;
-    public MethodBuilder ClusterWorkerGetMember { get; set; } = null!;
-    public MethodBuilder ClusterWorkerDeliverMessages { get; set; } = null!;
 
     // $ClusterManager: extends $EventEmitter, singleton managing all workers
-    public TypeBuilder ClusterManagerType { get; set; } = null!;
     public FieldBuilder ClusterManagerInstanceField { get; set; } = null!;
-    public FieldBuilder ClusterManagerEntryPointField { get; set; } = null!;
     public MethodBuilder ClusterManagerFork { get; set; } = null!;
     public MethodBuilder ClusterManagerDisconnectAll { get; set; } = null!;
     public MethodBuilder ClusterManagerSetupPrimary { get; set; } = null!;
     public MethodBuilder ClusterManagerGetWorkersObject { get; set; } = null!;
     public MethodBuilder ClusterManagerGetSettings { get; set; } = null!;
-    public MethodBuilder ClusterManagerGetMember { get; set; } = null!;
-    public MethodBuilder ClusterManagerRemoveWorker { get; set; } = null!;
-    public MethodBuilder ClusterManagerEmitWorkerEvent { get; set; } = null!;
 
     // Convenience statics on $Runtime (delegate to emitted types)
     public MethodBuilder ClusterIsPrimary { get; set; } = null!;
@@ -2960,16 +2716,11 @@ public class EmittedRuntime
     // ============================================================
     public Type BroadcastChannelType { get; set; } = null!;
     public ConstructorBuilder BroadcastChannelCtor { get; set; } = null!;
-    public MethodBuilder BroadcastChannelPostMessage { get; set; } = null!;
-    public MethodBuilder BroadcastChannelClose { get; set; } = null!;
-    public MethodBuilder BroadcastChannelRef { get; set; } = null!;
-    public MethodBuilder BroadcastChannelUnref { get; set; } = null!;
 
     // ============================================================
     // $EventLoop — singleton event loop for compiled mode
     // ============================================================
     public TypeBuilder EventLoopType { get; set; } = null!;
-    public FieldBuilder EventLoopInstanceField { get; set; } = null!;
     public MethodBuilder EventLoopGetInstance { get; set; } = null!;
     public MethodBuilder EventLoopRef { get; set; } = null!;
     public MethodBuilder EventLoopUnref { get; set; } = null!;
@@ -3004,15 +2755,7 @@ public class EmittedRuntime
     // ============================================================
     // $NetServer — emitted TCP server (extends $EventEmitter)
     // ============================================================
-    public TypeBuilder NetServerType { get; set; } = null!;
     public ConstructorBuilder NetServerCtor { get; set; } = null!;
-    public MethodBuilder NetServerListen { get; set; } = null!;
-    public MethodBuilder NetServerClose { get; set; } = null!;
-    public MethodBuilder NetServerAddress { get; set; } = null!;
-    public MethodBuilder NetServerGetConnections { get; set; } = null!;
-    public MethodBuilder NetServerGetMember { get; set; } = null!;
-    public MethodBuilder NetServerSetMember { get; set; } = null!;
-    public FieldBuilder NetServerIsListeningField { get; set; } = null!;
 
     // ============================================================
     // $NetSocket — emitted TCP socket (extends $EventEmitter)
@@ -3023,10 +2766,7 @@ public class EmittedRuntime
     public ConstructorBuilder NetSocketCtorStream { get; set; } = null!;
     public MethodBuilder NetSocketConnect { get; set; } = null!;
     public MethodBuilder NetSocketWrite { get; set; } = null!;
-    public MethodBuilder NetSocketEnd { get; set; } = null!;
-    public MethodBuilder NetSocketDestroy { get; set; } = null!;
     public MethodBuilder NetSocketStartReading { get; set; } = null!;
-    public MethodBuilder NetSocketSetEncoding { get; set; } = null!;
     public MethodBuilder NetSocketGetMember { get; set; } = null!;
 
     // Vm module methods
@@ -3046,34 +2786,22 @@ public class EmittedRuntime
     // Pure-IL Web Streams emitted types. The original late-binding helpers
     // (CreateReadableStream/CreateWritableStream/etc.) were removed when
     // all five stream classes were migrated to pure IL.
-    public Type CountQueuingStrategyType { get; set; } = null!;
     public ConstructorBuilder CountQueuingStrategyCtor { get; set; } = null!;
-    public Type ByteLengthQueuingStrategyType { get; set; } = null!;
     public ConstructorBuilder ByteLengthQueuingStrategyCtor { get; set; } = null!;
 
     public TypeBuilder WritableStreamType { get; set; } = null!;
     public ConstructorBuilder WritableStreamCtor { get; set; } = null!;
-    public MethodBuilder WritableStreamWrite { get; set; } = null!;
-    public MethodBuilder WritableStreamClose { get; set; } = null!;
-    public MethodBuilder WritableStreamAbort { get; set; } = null!;
-    public TypeBuilder WritableStreamDefaultControllerType { get; set; } = null!;
-    public TypeBuilder WritableStreamDefaultWriterType { get; set; } = null!;
-    public ConstructorBuilder WritableStreamDefaultWriterCtor { get; set; } = null!;
 
     public TypeBuilder ReadableStreamType { get; set; } = null!;
     public ConstructorBuilder ReadableStreamCtor { get; set; } = null!;
     public MethodBuilder ReadableStreamEnqueue { get; set; } = null!;
     public MethodBuilder ReadableStreamCloseStream { get; set; } = null!;
     public MethodBuilder ReadableStreamErrorStream { get; set; } = null!;
-    public MethodBuilder ReadableStreamRead { get; set; } = null!;
     /// <summary>
     /// Static $ReadableStream.From(object iterable) → object (#269) — eagerly
     /// drains a guest iterable into a closed readable stream.
     /// </summary>
     public MethodBuilder ReadableStreamFrom { get; set; } = null!;
-    public TypeBuilder ReadableStreamDefaultControllerType { get; set; } = null!;
-    public TypeBuilder ReadableStreamDefaultReaderType { get; set; } = null!;
-    public ConstructorBuilder ReadableStreamDefaultReaderCtor { get; set; } = null!;
 
     public TypeBuilder TransformStreamType { get; set; } = null!;
     public ConstructorBuilder TransformStreamCtor { get; set; } = null!;

--- a/Compilation/RuntimeEmitter.Arguments.cs
+++ b/Compilation/RuntimeEmitter.Arguments.cs
@@ -69,7 +69,7 @@ public partial class RuntimeEmitter
         capIL.Emit(OpCodes.Ldc_I4_0);
         capIL.Emit(OpCodes.Stfld, lengthField);
         capIL.Emit(OpCodes.Ret);
-        runtime.ArgumentsCapacityCtor = capacityCtor;
+        _ = capacityCtor;
 
         // Ctor: public $Arguments(IEnumerable<object> source) : base(source)
         // { _length = base.Count; }  — copies the source and snapshots the

--- a/Compilation/RuntimeEmitter.AsyncLocalStorage.cs
+++ b/Compilation/RuntimeEmitter.AsyncLocalStorage.cs
@@ -23,7 +23,7 @@ public partial class RuntimeEmitter
             TypeAttributes.Public | TypeAttributes.Sealed | TypeAttributes.BeforeFieldInit,
             _types.Object
         );
-        runtime.TSAsyncLocalStorageType = typeBuilder;
+        _ = typeBuilder;
 
         // Field: private AsyncLocal<object> _store
         var storeField = typeBuilder.DefineField("_store", asyncLocalType, FieldAttributes.Private);

--- a/Compilation/RuntimeEmitter.BroadcastChannel.cs
+++ b/Compilation/RuntimeEmitter.BroadcastChannel.cs
@@ -124,10 +124,10 @@ public partial class RuntimeEmitter
         // Publish handles for use by ExpressionEmitterBase.TryEmitBuiltInConstructor.
         runtime.BroadcastChannelType = _broadcastChannelType;
         runtime.BroadcastChannelCtor = _broadcastChannelCtor;
-        runtime.BroadcastChannelPostMessage = _broadcastChannelPostMessage;
-        runtime.BroadcastChannelClose = _broadcastChannelClose;
-        runtime.BroadcastChannelRef = _broadcastChannelRef;
-        runtime.BroadcastChannelUnref = _broadcastChannelUnref;
+        _ = _broadcastChannelPostMessage;
+        _ = _broadcastChannelClose;
+        _ = _broadcastChannelRef;
+        _ = _broadcastChannelUnref;
     }
 
     private void EmitBroadcastChannelConstructor(TypeBuilder typeBuilder, EmittedRuntime runtime)

--- a/Compilation/RuntimeEmitter.CjsModule.cs
+++ b/Compilation/RuntimeEmitter.CjsModule.cs
@@ -67,7 +67,7 @@ public partial class RuntimeEmitter
         runtime.CjsModuleType = builtType;
         runtime.CjsModuleCtor = builtType.GetConstructor(
             [typeof(FieldInfo), _types.String, _types.String, _types.Object, _types.Object])!;
-        runtime.CjsModuleExportsGetter = builtType.GetProperty("exports")!.GetGetMethod()!;
+        _ = builtType.GetProperty("exports")!.GetGetMethod()!;
         runtime.CjsModuleExportsSetter = builtType.GetProperty("exports")!.GetSetMethod()!;
     }
 

--- a/Compilation/RuntimeEmitter.ClusterHelpers.cs
+++ b/Compilation/RuntimeEmitter.ClusterHelpers.cs
@@ -88,7 +88,7 @@ public partial class RuntimeEmitter
     {
         var typeBuilder = moduleBuilder.DefineType("$ClusterContext",
             TypeAttributes.Public | TypeAttributes.Abstract | TypeAttributes.Sealed | TypeAttributes.BeforeFieldInit);
-        runtime.ClusterContextType = typeBuilder;
+        _ = typeBuilder;
 
         var tsAttr = new CustomAttributeBuilder(
             typeof(ThreadStaticAttribute).GetConstructor(Type.EmptyTypes)!, []);
@@ -101,7 +101,7 @@ public partial class RuntimeEmitter
         // [ThreadStatic] public static double WorkerId
         var workerId = typeBuilder.DefineField("WorkerId", _types.Double, FieldAttributes.Public | FieldAttributes.Static);
         workerId.SetCustomAttribute(tsAttr);
-        runtime.ClusterContextWorkerIdField = workerId;
+        _ = workerId;
 
         // [ThreadStatic] public static object CurrentWorker
         var currentWorker = typeBuilder.DefineField("CurrentWorker", _types.Object, FieldAttributes.Public | FieldAttributes.Static);
@@ -111,12 +111,12 @@ public partial class RuntimeEmitter
         // [ThreadStatic] public static BlockingCollection<object> PrimaryToWorkerQueue
         var p2wQueue = typeBuilder.DefineField("PrimaryToWorkerQueue", _blockingCollectionOfObject, FieldAttributes.Public | FieldAttributes.Static);
         p2wQueue.SetCustomAttribute(tsAttr);
-        runtime.ClusterContextPrimaryToWorkerQueueField = p2wQueue;
+        _ = p2wQueue;
 
         // [ThreadStatic] public static BlockingCollection<object> WorkerToPrimaryQueue
         var w2pQueue = typeBuilder.DefineField("WorkerToPrimaryQueue", _blockingCollectionOfObject, FieldAttributes.Public | FieldAttributes.Static);
         w2pQueue.SetCustomAttribute(tsAttr);
-        runtime.ClusterContextWorkerToPrimaryQueueField = w2pQueue;
+        _ = w2pQueue;
 
         typeBuilder.CreateType();
     }
@@ -174,7 +174,7 @@ public partial class RuntimeEmitter
     {
         var ctor = typeBuilder.DefineConstructor(MethodAttributes.Public,
             CallingConventions.Standard, Type.EmptyTypes);
-        runtime.ClusterWorkerCtor = ctor;
+        _ = ctor;
         var il = ctor.GetILGenerator();
 
         // base() — call $EventEmitter ctor
@@ -221,7 +221,7 @@ public partial class RuntimeEmitter
     {
         var method = typeBuilder.DefineMethod("Send",
             MethodAttributes.Public, typeof(void), [_types.Object]);
-        runtime.ClusterWorkerSend = method;
+        _ = method;
         var il = method.GetILGenerator();
 
         var retLabel = il.DefineLabel();
@@ -302,7 +302,7 @@ public partial class RuntimeEmitter
     {
         var method = typeBuilder.DefineMethod("Kill",
             MethodAttributes.Public, typeof(void), Type.EmptyTypes);
-        runtime.ClusterWorkerKill = method;
+        _ = method;
         var il = method.GetILGenerator();
 
         var retLabel = il.DefineLabel();
@@ -337,7 +337,7 @@ public partial class RuntimeEmitter
     {
         var method = typeBuilder.DefineMethod("DeliverMessages",
             MethodAttributes.Public, typeof(void), Type.EmptyTypes);
-        runtime.ClusterWorkerDeliverMessages = method;
+        _ = method;
         var il = method.GetILGenerator();
 
         var loopStart = il.DefineLabel();
@@ -378,7 +378,7 @@ public partial class RuntimeEmitter
     {
         var method = typeBuilder.DefineMethod("GetMember",
             MethodAttributes.Public, _types.Object, [_types.String]);
-        runtime.ClusterWorkerGetMember = method;
+        _ = method;
         var il = method.GetILGenerator();
 
         var strEquals = _types.String.GetMethod("Equals", [_types.String])!;
@@ -460,12 +460,12 @@ public partial class RuntimeEmitter
         var typeBuilder = moduleBuilder.DefineType("$ClusterManager",
             TypeAttributes.Public | TypeAttributes.Class | TypeAttributes.BeforeFieldInit,
             runtime.TSEventEmitterType);
-        runtime.ClusterManagerType = typeBuilder;
+        _ = typeBuilder;
 
         // Static fields
         runtime.ClusterManagerInstanceField = typeBuilder.DefineField("Instance",
             typeBuilder, FieldAttributes.Public | FieldAttributes.Static | FieldAttributes.InitOnly);
-        runtime.ClusterManagerEntryPointField = typeBuilder.DefineField("EntryPoint",
+        _ = typeBuilder.DefineField("EntryPoint",
             typeof(Action), FieldAttributes.Public | FieldAttributes.Static);
 
         // Instance fields
@@ -693,7 +693,7 @@ public partial class RuntimeEmitter
     {
         var method = typeBuilder.DefineMethod("RemoveWorker",
             MethodAttributes.Public, typeof(void), [_types.Double]);
-        runtime.ClusterManagerRemoveWorker = method;
+        _ = method;
         var il = method.GetILGenerator();
 
         var outLocal = il.DeclareLocal(_types.Object);
@@ -714,7 +714,7 @@ public partial class RuntimeEmitter
     {
         var method = typeBuilder.DefineMethod("EmitWorkerEvent",
             MethodAttributes.Public, typeof(void), [_types.String, _types.Object, _types.Double]);
-        runtime.ClusterManagerEmitWorkerEvent = method;
+        _ = method;
         var il = method.GetILGenerator();
 
         // this.Emit(eventName, [worker, exitCode])
@@ -743,7 +743,7 @@ public partial class RuntimeEmitter
     {
         var method = typeBuilder.DefineMethod("GetMember",
             MethodAttributes.Public, _types.Object, [_types.String]);
-        runtime.ClusterManagerGetMember = method;
+        _ = method;
         var il = method.GetILGenerator();
 
         var strEquals = _types.String.GetMethod("Equals", [_types.String])!;

--- a/Compilation/RuntimeEmitter.ConsoleHelpers.cs
+++ b/Compilation/RuntimeEmitter.ConsoleHelpers.cs
@@ -16,7 +16,7 @@ public partial class RuntimeEmitter
             _types.DictionaryStringObject,
             FieldAttributes.Private | FieldAttributes.Static
         );
-        runtime.ConsoleTimersField = timersField;
+        _ = timersField;
 
         // Emit static field for counts dictionary: Dictionary<string, int>
         var countsField = typeBuilder.DefineField(
@@ -24,7 +24,7 @@ public partial class RuntimeEmitter
             _types.DictionaryStringObject,
             FieldAttributes.Private | FieldAttributes.Static
         );
-        runtime.ConsoleCountsField = countsField;
+        _ = countsField;
 
         // NOTE: _consoleGroupLevel field is defined early in EmitRuntimeType to allow ConsoleLog to use it
         var groupLevelField = runtime.ConsoleGroupLevelField;

--- a/Compilation/RuntimeEmitter.FsStatWatcher.cs
+++ b/Compilation/RuntimeEmitter.FsStatWatcher.cs
@@ -53,9 +53,9 @@ public partial class RuntimeEmitter
         EmitStatWatcherConstructor(runtime);
         EmitStatWatcherCloseMethod(runtime);
 
-        runtime.StatWatcherType = _statWatcherType;
-        runtime.StatWatcherCtor = _statWatcherCtor;
-        runtime.StatWatcherClose = _statWatcherCloseMethod;
+        _ = _statWatcherType;
+        _ = _statWatcherCtor;
+        _ = _statWatcherCloseMethod;
 
         _statWatcherType.CreateType();
     }

--- a/Compilation/RuntimeEmitter.FsWatcher.cs
+++ b/Compilation/RuntimeEmitter.FsWatcher.cs
@@ -45,9 +45,9 @@ public partial class RuntimeEmitter
         EmitFsWatcherConstructor(runtime);
         EmitFsWatcherClose(runtime);
 
-        runtime.FsWatcherType = _fsWatcherType;
-        runtime.FsWatcherCtor = _fsWatcherCtor;
-        runtime.FsWatcherClose = _fsWatcherCloseMethod;
+        _ = _fsWatcherType;
+        _ = _fsWatcherCtor;
+        _ = _fsWatcherCloseMethod;
 
         _fsWatcherType.CreateType();
     }

--- a/Compilation/RuntimeEmitter.FunctionPrototypePopulate.cs
+++ b/Compilation/RuntimeEmitter.FunctionPrototypePopulate.cs
@@ -30,10 +30,10 @@ public partial class RuntimeEmitter
         var applyHelper = EmitFunctionProtoApplyHelper(typeBuilder, runtime);
         var bindHelper = EmitFunctionProtoBindHelper(typeBuilder, runtime);
         var toStringHelper = EmitFunctionProtoToStringHelper(typeBuilder, runtime);
-        runtime.FunctionProtoCallHelper = callHelper;
-        runtime.FunctionProtoApplyHelper = applyHelper;
-        runtime.FunctionProtoBindHelper = bindHelper;
-        runtime.FunctionProtoToStringHelper = toStringHelper;
+        _ = callHelper;
+        _ = applyHelper;
+        _ = bindHelper;
+        _ = toStringHelper;
 
         var method = runtime.FunctionPrototypePopulateMethod;
         var il = method.GetILGenerator();

--- a/Compilation/RuntimeEmitter.Functions.cs
+++ b/Compilation/RuntimeEmitter.Functions.cs
@@ -316,7 +316,7 @@ public partial class RuntimeEmitter
             _types.Object,
             [_types.Object, _types.ObjectArray]
         );
-        runtime.BoundAnyFunctionInvokeWithThis = invokeWithThisBuilder;
+        _ = invokeWithThisBuilder;
 
         var iwtIL = invokeWithThisBuilder.GetILGenerator();
         iwtIL.Emit(OpCodes.Ldarg_0);

--- a/Compilation/RuntimeEmitter.GlobalThis.cs
+++ b/Compilation/RuntimeEmitter.GlobalThis.cs
@@ -17,22 +17,22 @@ public partial class RuntimeEmitter
             FieldAttributes.Private | FieldAttributes.Static);
 
         // Static fields for cached global function TSFunction objects
-        runtime.CachedParseIntFunction = typeBuilder.DefineField(
+        _ = typeBuilder.DefineField(
             "_cachedParseIntFunction",
             _types.Object,
             FieldAttributes.Private | FieldAttributes.Static);
 
-        runtime.CachedParseFloatFunction = typeBuilder.DefineField(
+        _ = typeBuilder.DefineField(
             "_cachedParseFloatFunction",
             _types.Object,
             FieldAttributes.Private | FieldAttributes.Static);
 
-        runtime.CachedIsNaNFunction = typeBuilder.DefineField(
+        _ = typeBuilder.DefineField(
             "_cachedIsNaNFunction",
             _types.Object,
             FieldAttributes.Private | FieldAttributes.Static);
 
-        runtime.CachedIsFiniteFunction = typeBuilder.DefineField(
+        _ = typeBuilder.DefineField(
             "_cachedIsFiniteFunction",
             _types.Object,
             FieldAttributes.Private | FieldAttributes.Static);

--- a/Compilation/RuntimeEmitter.Http.cs
+++ b/Compilation/RuntimeEmitter.Http.cs
@@ -1050,7 +1050,7 @@ public partial class RuntimeEmitter
         EmitFetchResponseBodyGetter(typeBuilder, runtime);
 
         // Store the type reference
-        runtime.TSFetchResponseType = typeBuilder;
+        _ = typeBuilder;
         runtime.TSFetchResponseCtor = ctor;
 
         typeBuilder.CreateType();
@@ -3575,7 +3575,7 @@ public partial class RuntimeEmitter
         EmitRequestArrayBufferMethod(typeBuilder, runtime);
         EmitRequestCloneMethod(typeBuilder, runtime, ctor);
 
-        runtime.TSRequestType = typeBuilder;
+        _ = typeBuilder;
         runtime.TSRequestCtor = ctor;
 
         typeBuilder.CreateType();

--- a/Compilation/RuntimeEmitter.NodeError.cs
+++ b/Compilation/RuntimeEmitter.NodeError.cs
@@ -193,7 +193,7 @@ public partial class RuntimeEmitter
             nullableInt32,
             Type.EmptyTypes
         );
-        runtime.NodeErrorErrnoGetter = method;
+        _ = method;
 
         var il = method.GetILGenerator();
         il.Emit(OpCodes.Ldarg_0);

--- a/Compilation/RuntimeEmitter.PerfPrimitive.cs
+++ b/Compilation/RuntimeEmitter.PerfPrimitive.cs
@@ -20,14 +20,14 @@ public partial class RuntimeEmitter
             _types.Int64,
             FieldAttributes.Private | FieldAttributes.Static
         );
-        runtime.PerfPrimitiveStartTicks = startTicksField;
+        _ = startTicksField;
 
         var ticksPerMsField = typeBuilder.DefineField(
             "_perfPrimitiveTicksPerMs",
             _types.Double,
             FieldAttributes.Private | FieldAttributes.Static
         );
-        runtime.PerfPrimitiveTicksPerMs = ticksPerMsField;
+        _ = ticksPerMsField;
 
         var initializedField = typeBuilder.DefineField(
             "_perfPrimitiveInitialized",

--- a/Compilation/RuntimeEmitter.ProcessHelpers.cs
+++ b/Compilation/RuntimeEmitter.ProcessHelpers.cs
@@ -982,7 +982,7 @@ public partial class RuntimeEmitter
             runtime.TSEventEmitterType,
             FieldAttributes.Private | FieldAttributes.Static
         );
-        runtime.ProcessEventEmitterInstance = field;
+        _ = field;
 
         // Getter method that lazily creates the instance
         var getter = typeBuilder.DefineMethod(

--- a/Compilation/RuntimeEmitter.PropertyDescriptorStore.cs
+++ b/Compilation/RuntimeEmitter.PropertyDescriptorStore.cs
@@ -66,7 +66,7 @@ public partial class RuntimeEmitter
 
         var type = typeBuilder.CreateType()!;
         runtime.FrozenSealedStateType = type;
-        runtime.FrozenSealedStateCtor = ctor;
+        _ = ctor;
         runtime.FrozenSealedStateIsFrozen = type.GetProperty("IsFrozen")!;
         runtime.FrozenSealedStateIsSealed = type.GetProperty("IsSealed")!;
         runtime.FrozenSealedStateIsExtensible = type.GetProperty("IsExtensible")!;
@@ -102,7 +102,7 @@ public partial class RuntimeEmitter
 
         var type = typeBuilder.CreateType()!;
         runtime.PrototypeInfoType = type;
-        runtime.PrototypeInfoCtor = ctor;
+        _ = ctor;
         runtime.PrototypeInfoPrototype = type.GetProperty("Prototype")!;
     }
 
@@ -240,10 +240,10 @@ public partial class RuntimeEmitter
         cctorIl.Emit(OpCodes.Ret);
 
         // Store field references for method emission
-        runtime.PDSDescriptorsField = descriptorsField;
-        runtime.PDSFrozenSealedField = frozenSealedField;
-        runtime.PDSSymbolStorageField = symbolStorageField;
-        runtime.PDSPrototypeStoreField = prototypeStoreField;
+        _ = descriptorsField;
+        _ = frozenSealedField;
+        _ = symbolStorageField;
+        _ = prototypeStoreField;
 
         // Get methods from open generic types for use with TypeBuilder.GetMethod
         var cwtOpenType = typeof(ConditionalWeakTable<,>);
@@ -293,7 +293,7 @@ public partial class RuntimeEmitter
         EmitPDSGetAllExtraKeys(typeBuilder, runtime, descriptorsField, descriptorsTryGet, descriptorsDictType, descriptorsDictTryGetValue);
 
         var type = typeBuilder.CreateType()!;
-        runtime.PropertyDescriptorStoreType = type;
+        _ = type;
     }
 
     /// <summary>

--- a/Compilation/RuntimeEmitter.QueuingStrategy.cs
+++ b/Compilation/RuntimeEmitter.QueuingStrategy.cs
@@ -66,7 +66,7 @@ public partial class RuntimeEmitter
         sizeIL.Emit(OpCodes.Ret);
 
         var createdType = typeBuilder.CreateType()!;
-        runtime.CountQueuingStrategyType = createdType;
+        _ = createdType;
         runtime.CountQueuingStrategyCtor = ctor;
     }
 
@@ -141,7 +141,7 @@ public partial class RuntimeEmitter
         sizeIL.Emit(OpCodes.Ret);
 
         var createdType = typeBuilder.CreateType()!;
-        runtime.ByteLengthQueuingStrategyType = createdType;
+        _ = createdType;
         runtime.ByteLengthQueuingStrategyCtor = ctor;
     }
 

--- a/Compilation/RuntimeEmitter.ReadableStream.cs
+++ b/Compilation/RuntimeEmitter.ReadableStream.cs
@@ -69,8 +69,8 @@ public partial class RuntimeEmitter
             _types.Object);
 
         runtime.ReadableStreamType = streamBuilder;
-        runtime.ReadableStreamDefaultControllerType = controllerBuilder;
-        runtime.ReadableStreamDefaultReaderType = readerBuilder;
+        _ = controllerBuilder;
+        _ = readerBuilder;
 
         EmitReadableStreamFields(streamBuilder);
 
@@ -84,7 +84,7 @@ public partial class RuntimeEmitter
         _readableReaderStreamField = readerBuilder.DefineField(
             "_stream", streamBuilder, FieldAttributes.Private);
         var readerCtor = EmitReadableStreamReaderCtor(readerBuilder, streamBuilder);
-        runtime.ReadableStreamDefaultReaderCtor = readerCtor;
+        _ = readerCtor;
 
         // Now the stream constructor (uses controllerCtor).
         var streamCtor = EmitReadableStreamConstructor(streamBuilder, controllerBuilder, controllerCtor, runtime);
@@ -112,7 +112,7 @@ public partial class RuntimeEmitter
         runtime.ReadableStreamEnqueue = enqueueMethod;
         runtime.ReadableStreamCloseStream = closeMethod;
         runtime.ReadableStreamErrorStream = errorMethod;
-        runtime.ReadableStreamRead = readMethod;
+        _ = readMethod;
 
         // Static ReadableStream.from(iterable) (#269) — must be defined before
         // streamBuilder.CreateType() below. Uses the ctor + Enqueue + CloseStream

--- a/Compilation/RuntimeEmitter.ReadlineHelpers.cs
+++ b/Compilation/RuntimeEmitter.ReadlineHelpers.cs
@@ -78,7 +78,7 @@ public partial class RuntimeEmitter
         // Emit Question method (uses runtime.InvokeValue)
         EmitReadlineInterfaceQuestion(_readlineInterfaceTypeBuilder, runtime);
 
-        runtime.ReadlineInterfaceType = _readlineInterfaceTypeBuilder.CreateType()!;
+        _ = _readlineInterfaceTypeBuilder.CreateType()!;
     }
 
     /// <summary>

--- a/Compilation/RuntimeEmitter.ReferenceEqualityComparer.cs
+++ b/Compilation/RuntimeEmitter.ReferenceEqualityComparer.cs
@@ -18,7 +18,7 @@ public partial class RuntimeEmitter
             _types.Object,
             [_types.IEqualityComparerOfObject]
         );
-        runtime.ReferenceEqualityComparerType = typeBuilder;
+        _ = typeBuilder;
 
         // Static Instance field (singleton)
         var instanceField = typeBuilder.DefineField(

--- a/Compilation/RuntimeEmitter.RuntimeClass.cs
+++ b/Compilation/RuntimeEmitter.RuntimeClass.cs
@@ -277,7 +277,7 @@ public partial class RuntimeEmitter
             symbolStorageType,
             FieldAttributes.Private | FieldAttributes.Static | FieldAttributes.InitOnly
         );
-        runtime.SymbolStorageField = symbolStorageField;
+        _ = symbolStorageField;
 
         // Static fields for Object.freeze/seal tracking: ConditionalWeakTable<object, object>
         // Made public so other types (like class constructors) can access for freeze checks
@@ -308,7 +308,7 @@ public partial class RuntimeEmitter
             _types.ConditionalWeakTable,
             FieldAttributes.Public | FieldAttributes.Static | FieldAttributes.InitOnly
         );
-        runtime.PrototypeStoreField = prototypeStoreField;
+        _ = prototypeStoreField;
 
         // ECMA-262 §17 declares `name`/`length` on built-in functions as
         // configurable. test262's verifyProperty exercises that by deleting

--- a/Compilation/RuntimeEmitter.Stats.cs
+++ b/Compilation/RuntimeEmitter.Stats.cs
@@ -312,7 +312,7 @@ public partial class RuntimeEmitter
             _types.Double,
             Type.EmptyTypes
         );
-        runtime.StatsModeGetter = getter;
+        _ = getter;
 
         var il = getter.GetILGenerator();
         il.Emit(OpCodes.Ldarg_0);

--- a/Compilation/RuntimeEmitter.StringPrototypeStubs.cs
+++ b/Compilation/RuntimeEmitter.StringPrototypeStubs.cs
@@ -46,7 +46,7 @@ public partial class RuntimeEmitter
         // receivers per ECMA-262 22.1.3.* step 1. Used for borrowed-method
         // patterns (`String.prototype.match.call(null, /./)`) where the inline
         // dispatch path doesn't fire.
-        runtime.StringPrototypeStrictStub = EmitStringStringStub(typeBuilder, runtime, "_StringPrototypeStrictStub", "ToString", strictReceiver: true);
+        _ = EmitStringStringStub(typeBuilder, runtime, "_StringPrototypeStrictStub", "ToString", strictReceiver: true);
 
         // ECMA-262 22.1.3.27 String.prototype.toString === valueOf === thisStringValue.
         // Returns the underlying string for both primitive strings and Stage-4z19

--- a/Compilation/RuntimeEmitter.TSArray.cs
+++ b/Compilation/RuntimeEmitter.TSArray.cs
@@ -288,7 +288,7 @@ public partial class RuntimeEmitter
         var ensureBoxed = _tsArrayEnsureBoxedMethod;
         var getDouble = typeBuilder.DefineMethod("GetDouble",
             MethodAttributes.Public | MethodAttributes.HideBySig, _types.Double, [_types.Int32]);
-        runtime.TSArrayGetDouble = getDouble;
+        _ = getDouble;
         var setDouble = typeBuilder.DefineMethod("SetDouble",
             MethodAttributes.Public | MethodAttributes.HideBySig, _types.Void, [_types.Int32, _types.Double]);
         runtime.TSArraySetDouble = setDouble;
@@ -778,7 +778,7 @@ public partial class RuntimeEmitter
             "get_IsFrozen",
             MethodAttributes.Public | MethodAttributes.SpecialName | MethodAttributes.HideBySig,
             _types.Boolean, Type.EmptyTypes);
-        runtime.TSArrayIsFrozenGetter = getter;
+        _ = getter;
 
         var il = getter.GetILGenerator();
         il.Emit(OpCodes.Ldarg_0);
@@ -795,7 +795,7 @@ public partial class RuntimeEmitter
             "get_IsSealed",
             MethodAttributes.Public | MethodAttributes.SpecialName | MethodAttributes.HideBySig,
             _types.Boolean, Type.EmptyTypes);
-        runtime.TSArrayIsSealedGetter = getter;
+        _ = getter;
 
         var il = getter.GetILGenerator();
         il.Emit(OpCodes.Ldarg_0);
@@ -826,7 +826,7 @@ public partial class RuntimeEmitter
     private void EmitTSArraySeal(TypeBuilder typeBuilder, EmittedRuntime runtime)
     {
         var method = typeBuilder.DefineMethod("Seal", MethodAttributes.Public, _types.Void, Type.EmptyTypes);
-        runtime.TSArraySeal = method;
+        _ = method;
 
         var il = method.GetILGenerator();
         EmitTSArrayDeoptGuard(il);
@@ -1452,7 +1452,7 @@ public partial class RuntimeEmitter
     private void EmitTSArrayGetRaw(TypeBuilder typeBuilder, EmittedRuntime runtime, MethodBuilder getCore, MethodBuilder syncLength)
     {
         var method = typeBuilder.DefineMethod("GetRaw", MethodAttributes.Public, _types.Object, [_types.Int64]);
-        runtime.TSArrayGetRaw = method;
+        _ = method;
 
         var il = method.GetILGenerator();
         EmitTSArrayDeoptGuard(il);
@@ -2015,7 +2015,7 @@ public partial class RuntimeEmitter
             _types.String,
             Type.EmptyTypes
         );
-        runtime.TSArrayToString = method;
+        _ = method;
 
         var il = method.GetILGenerator();
         EmitTSArrayDeoptGuard(il);

--- a/Compilation/RuntimeEmitter.TSCipher.cs
+++ b/Compilation/RuntimeEmitter.TSCipher.cs
@@ -35,7 +35,7 @@ public partial class RuntimeEmitter
             _types.Object,
             [_types.IDisposable]
         );
-        runtime.TSCipherType = typeBuilder;
+        _ = typeBuilder;
 
         // Fields
         _tsCipherAlgorithmField = typeBuilder.DefineField("_algorithm", _types.String, FieldAttributes.Private);
@@ -378,7 +378,7 @@ public partial class RuntimeEmitter
             _types.Object,
             [_types.Object, _types.Object, _types.Object]
         );
-        runtime.TSCipherUpdateMethod = method;
+        _ = method;
 
         var il = method.GetILGenerator();
 
@@ -425,7 +425,7 @@ public partial class RuntimeEmitter
             _types.Object,
             [_types.String]
         );
-        runtime.TSCipherFinalMethod = method;
+        _ = method;
 
         var il = method.GetILGenerator();
 
@@ -531,7 +531,7 @@ public partial class RuntimeEmitter
             typeBuilder,
             [_types.Boolean]
         );
-        runtime.TSCipherSetAutoPaddingMethod = method;
+        _ = method;
 
         var il = method.GetILGenerator();
 
@@ -551,7 +551,7 @@ public partial class RuntimeEmitter
             _types.Object,
             Type.EmptyTypes
         );
-        runtime.TSCipherGetAuthTagMethod = method;
+        _ = method;
 
         var il = method.GetILGenerator();
 
@@ -596,7 +596,7 @@ public partial class RuntimeEmitter
             typeBuilder,
             [_types.Object]
         );
-        runtime.TSCipherSetAADMethod = method;
+        _ = method;
 
         var il = method.GetILGenerator();
 

--- a/Compilation/RuntimeEmitter.TSDH.cs
+++ b/Compilation/RuntimeEmitter.TSDH.cs
@@ -1482,7 +1482,7 @@ public partial class RuntimeEmitter
             TypeAttributes.Public | TypeAttributes.Sealed | TypeAttributes.BeforeFieldInit,
             _types.Object
         );
-        runtime.BoundDHMethodType = _boundDHMethodTypeBuilder;
+        _ = _boundDHMethodTypeBuilder;
 
         _boundDHMethodDhField = _boundDHMethodTypeBuilder.DefineField("_dh", runtime.TSDiffieHellmanType, FieldAttributes.Private);
         _boundDHMethodMethodNameField = _boundDHMethodTypeBuilder.DefineField("_methodName", _types.String, FieldAttributes.Private);
@@ -1525,7 +1525,7 @@ public partial class RuntimeEmitter
             _types.Object,
             [typeof(object[])]
         );
-        runtime.BoundDHMethodInvoke = invoke;
+        _ = invoke;
 
         var il = invoke.GetILGenerator();
 

--- a/Compilation/RuntimeEmitter.TSDatagramSocket.cs
+++ b/Compilation/RuntimeEmitter.TSDatagramSocket.cs
@@ -168,7 +168,7 @@ public partial class RuntimeEmitter
     /// </summary>
     private void EmitDatagramSocketFinalize(EmittedRuntime runtime)
     {
-        runtime.DatagramSocketType = _dgramSocketTypeBuilder.CreateType()!;
+        _ = _dgramSocketTypeBuilder.CreateType()!;
     }
 
     /// <summary>

--- a/Compilation/RuntimeEmitter.TSDecipher.cs
+++ b/Compilation/RuntimeEmitter.TSDecipher.cs
@@ -36,7 +36,7 @@ public partial class RuntimeEmitter
             _types.Object,
             [_types.IDisposable]
         );
-        runtime.TSDecipherType = typeBuilder;
+        _ = typeBuilder;
 
         // Fields
         _tsDecipherAlgorithmField = typeBuilder.DefineField("_algorithm", _types.String, FieldAttributes.Private);
@@ -385,7 +385,7 @@ public partial class RuntimeEmitter
             _types.Object,
             [_types.Object, _types.Object, _types.Object]
         );
-        runtime.TSDecipherUpdateMethod = method;
+        _ = method;
 
         var il = method.GetILGenerator();
 
@@ -454,7 +454,7 @@ public partial class RuntimeEmitter
             _types.Object,
             [_types.String]
         );
-        runtime.TSDecipherFinalMethod = method;
+        _ = method;
 
         var il = method.GetILGenerator();
 
@@ -559,7 +559,7 @@ public partial class RuntimeEmitter
             typeBuilder,
             [_types.Boolean]
         );
-        runtime.TSDecipherSetAutoPaddingMethod = method;
+        _ = method;
 
         var il = method.GetILGenerator();
 
@@ -580,7 +580,7 @@ public partial class RuntimeEmitter
             typeBuilder,
             [_types.Object]
         );
-        runtime.TSDecipherSetAuthTagMethod = method;
+        _ = method;
 
         var il = method.GetILGenerator();
 
@@ -611,7 +611,7 @@ public partial class RuntimeEmitter
             typeBuilder,
             [_types.Object]
         );
-        runtime.TSDecipherSetAADMethod = method;
+        _ = method;
 
         var il = method.GetILGenerator();
 

--- a/Compilation/RuntimeEmitter.TSDir.cs
+++ b/Compilation/RuntimeEmitter.TSDir.cs
@@ -27,7 +27,7 @@ public partial class RuntimeEmitter
             TypeAttributes.Public | TypeAttributes.Sealed | TypeAttributes.Class,
             _types.Object
         );
-        runtime.DirType = typeBuilder;
+        _ = typeBuilder;
 
         // Fields
         _dirPathField = typeBuilder.DefineField("_path", _types.String, FieldAttributes.Private | FieldAttributes.InitOnly);
@@ -99,7 +99,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ret);
 
         prop.SetGetMethod(getter);
-        runtime.DirPathGetter = getter;
+        _ = getter;
     }
 
     private void EmitDirReadSync(TypeBuilder typeBuilder, EmittedRuntime runtime)
@@ -110,7 +110,7 @@ public partial class RuntimeEmitter
             _types.Object,
             Type.EmptyTypes
         );
-        runtime.DirReadSync = method;
+        _ = method;
 
         var il = method.GetILGenerator();
 
@@ -154,7 +154,7 @@ public partial class RuntimeEmitter
             _types.Object, // Return null for JS compatibility
             Type.EmptyTypes
         );
-        runtime.DirCloseSync = method;
+        _ = method;
 
         var il = method.GetILGenerator();
 
@@ -190,7 +190,7 @@ public partial class RuntimeEmitter
             TypeAttributes.Public | TypeAttributes.Sealed | TypeAttributes.Class,
             _types.Object
         );
-        runtime.DirentType = typeBuilder;
+        _ = typeBuilder;
 
         // Fields
         _direntNameField = typeBuilder.DefineField("_name", _types.String, FieldAttributes.Private | FieldAttributes.InitOnly);
@@ -324,7 +324,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ret);
 
         prop.SetGetMethod(getter);
-        runtime.DirentNameGetter = getter;
+        _ = getter;
     }
 
     private void EmitDirentIsFile(TypeBuilder typeBuilder, EmittedRuntime runtime)
@@ -335,7 +335,7 @@ public partial class RuntimeEmitter
             _types.Object, // Return boxed bool for JS compatibility
             Type.EmptyTypes
         );
-        runtime.DirentIsFile = method;
+        _ = method;
 
         var il = method.GetILGenerator();
         il.Emit(OpCodes.Ldarg_0);
@@ -352,7 +352,7 @@ public partial class RuntimeEmitter
             _types.Object,
             Type.EmptyTypes
         );
-        runtime.DirentIsDirectory = method;
+        _ = method;
 
         var il = method.GetILGenerator();
         il.Emit(OpCodes.Ldarg_0);
@@ -369,7 +369,7 @@ public partial class RuntimeEmitter
             _types.Object,
             Type.EmptyTypes
         );
-        runtime.DirentIsSymbolicLink = method;
+        _ = method;
 
         var il = method.GetILGenerator();
         il.Emit(OpCodes.Ldarg_0);
@@ -386,7 +386,7 @@ public partial class RuntimeEmitter
             _types.Object,
             Type.EmptyTypes
         );
-        runtime.DirentIsBlockDevice = method;
+        _ = method;
 
         var il = method.GetILGenerator();
         // Always return false
@@ -403,7 +403,7 @@ public partial class RuntimeEmitter
             _types.Object,
             Type.EmptyTypes
         );
-        runtime.DirentIsCharacterDevice = method;
+        _ = method;
 
         var il = method.GetILGenerator();
         // Always return false
@@ -420,7 +420,7 @@ public partial class RuntimeEmitter
             _types.Object,
             Type.EmptyTypes
         );
-        runtime.DirentIsFIFO = method;
+        _ = method;
 
         var il = method.GetILGenerator();
         // Always return false
@@ -437,7 +437,7 @@ public partial class RuntimeEmitter
             _types.Object,
             Type.EmptyTypes
         );
-        runtime.DirentIsSocket = method;
+        _ = method;
 
         var il = method.GetILGenerator();
         // Always return false

--- a/Compilation/RuntimeEmitter.TSECDH.cs
+++ b/Compilation/RuntimeEmitter.TSECDH.cs
@@ -700,7 +700,7 @@ public partial class RuntimeEmitter
             TypeAttributes.Public | TypeAttributes.Sealed | TypeAttributes.BeforeFieldInit,
             _types.Object
         );
-        runtime.BoundECDHMethodType = _boundECDHMethodTypeBuilder;
+        _ = _boundECDHMethodTypeBuilder;
 
         // Fields
         _boundECDHMethodEcdhField = _boundECDHMethodTypeBuilder.DefineField("_ecdh", runtime.TSECDHType, FieldAttributes.Private);
@@ -747,7 +747,7 @@ public partial class RuntimeEmitter
             _types.Object,
             [typeof(object[])]
         );
-        runtime.BoundECDHMethodInvoke = invoke;
+        _ = invoke;
 
         var il = invoke.GetILGenerator();
 

--- a/Compilation/RuntimeEmitter.TSError.cs
+++ b/Compilation/RuntimeEmitter.TSError.cs
@@ -393,7 +393,7 @@ public partial class RuntimeEmitter
             _types.String,
             Type.EmptyTypes
         );
-        runtime.TSErrorToStringMethod = method;
+        _ = method;
 
         var il = method.GetILGenerator();
         var hasMessageLabel = il.DefineLabel();

--- a/Compilation/RuntimeEmitter.TSEventLoop.cs
+++ b/Compilation/RuntimeEmitter.TSEventLoop.cs
@@ -37,7 +37,7 @@ public partial class RuntimeEmitter
             typeBuilder,
             FieldAttributes.Private | FieldAttributes.Static
         );
-        runtime.EventLoopInstanceField = instanceField;
+        _ = instanceField;
 
         // Instance fields
         _eventLoopActiveHandlesField = typeBuilder.DefineField(

--- a/Compilation/RuntimeEmitter.TSFileDescriptorTable.cs
+++ b/Compilation/RuntimeEmitter.TSFileDescriptorTable.cs
@@ -25,7 +25,7 @@ public partial class RuntimeEmitter
             TypeAttributes.Public | TypeAttributes.Sealed | TypeAttributes.Class,
             _types.Object
         );
-        runtime.FileDescriptorTableType = typeBuilder;
+        _ = typeBuilder;
 
         // Fields
         var nextFdField = typeBuilder.DefineField(
@@ -55,7 +55,7 @@ public partial class RuntimeEmitter
             CallingConventions.Standard,
             Type.EmptyTypes
         );
-        runtime.FileDescriptorTableCtor = ctor;
+        _ = ctor;
 
         var ctorIl = ctor.GetILGenerator();
 
@@ -277,7 +277,7 @@ public partial class RuntimeEmitter
             _types.Boolean,
             [_types.Int32]
         );
-        runtime.FileDescriptorTableIsValid = method;
+        _ = method;
 
         var il = method.GetILGenerator();
 

--- a/Compilation/RuntimeEmitter.TSFunction.cs
+++ b/Compilation/RuntimeEmitter.TSFunction.cs
@@ -125,7 +125,7 @@ public partial class RuntimeEmitter
         // Fields
         var targetField = typeBuilder.DefineField("_target", _types.Object, FieldAttributes.Private);
         var methodField = typeBuilder.DefineField("_method", _types.MethodInfo, FieldAttributes.Private);
-        runtime.TSFunctionMethodField = methodField;
+        _ = methodField;
         // Cached name and length for functions where reflection doesn't work (e.g., MethodBuilder tokens)
         var cachedNameField = typeBuilder.DefineField("_cachedName", _types.String, FieldAttributes.Private);
         var cachedLengthField = typeBuilder.DefineField("_cachedLength", _types.Int32, FieldAttributes.Private);
@@ -202,7 +202,7 @@ public partial class RuntimeEmitter
         // and must stay fresh.
         var instanceCacheType = _types.MakeGenericType(_types.ConcurrentDictionaryOpen, _types.MethodInfo, typeBuilder);
         var instanceCacheField = typeBuilder.DefineField("_instanceCache", instanceCacheType, FieldAttributes.Public | FieldAttributes.Static | FieldAttributes.InitOnly);
-        runtime.TSFunctionInstanceCacheField = instanceCacheField;
+        _ = instanceCacheField;
 
         // Static MethodInvoker cache keyed by MethodInfo. MethodInvoker.Create()
         // builds an internal dispatch stub that's amortized only when the

--- a/Compilation/RuntimeEmitter.TSHash.cs
+++ b/Compilation/RuntimeEmitter.TSHash.cs
@@ -22,7 +22,7 @@ public partial class RuntimeEmitter
             TypeAttributes.Public | TypeAttributes.Sealed | TypeAttributes.BeforeFieldInit,
             _types.Object
         );
-        runtime.TSHashType = typeBuilder;
+        _ = typeBuilder;
 
         // Fields
         _tsHashField = typeBuilder.DefineField("_hash", _types.IncrementalHash, FieldAttributes.Private);
@@ -173,7 +173,7 @@ public partial class RuntimeEmitter
             typeBuilder,
             [_types.String]
         );
-        runtime.TSHashUpdateMethod = method;
+        _ = method;
 
         var il = method.GetILGenerator();
 
@@ -218,7 +218,7 @@ public partial class RuntimeEmitter
             _types.Object,
             [_types.String]
         );
-        runtime.TSHashDigestMethod = method;
+        _ = method;
 
         var il = method.GetILGenerator();
 

--- a/Compilation/RuntimeEmitter.TSHmac.cs
+++ b/Compilation/RuntimeEmitter.TSHmac.cs
@@ -22,7 +22,7 @@ public partial class RuntimeEmitter
             TypeAttributes.Public | TypeAttributes.Sealed | TypeAttributes.BeforeFieldInit,
             _types.Object
         );
-        runtime.TSHmacType = typeBuilder;
+        _ = typeBuilder;
 
         // Fields
         _tsHmacField = typeBuilder.DefineField("_hmac", _types.IncrementalHash, FieldAttributes.Private);
@@ -174,7 +174,7 @@ public partial class RuntimeEmitter
             typeBuilder,
             [_types.String]
         );
-        runtime.TSHmacUpdateMethod = method;
+        _ = method;
 
         var il = method.GetILGenerator();
 
@@ -219,7 +219,7 @@ public partial class RuntimeEmitter
             _types.Object,
             [_types.String]
         );
-        runtime.TSHmacDigestMethod = method;
+        _ = method;
 
         var il = method.GetILGenerator();
 

--- a/Compilation/RuntimeEmitter.TSHttpServer.cs
+++ b/Compilation/RuntimeEmitter.TSHttpServer.cs
@@ -85,7 +85,7 @@ public partial class RuntimeEmitter
             _types.Object,
             [_types.String]
         );
-        runtime.TSHttpRequestGetMember = method;
+        _ = method;
 
         var il = method.GetILGenerator();
 
@@ -536,7 +536,7 @@ public partial class RuntimeEmitter
             _types.Object,
             [_types.String]
         );
-        runtime.TSHttpResponseGetMember = method;
+        _ = method;
 
         var il = method.GetILGenerator();
 
@@ -625,7 +625,7 @@ public partial class RuntimeEmitter
             typeof(void),
             [_types.String, _types.Object]
         );
-        runtime.TSHttpResponseSetMember = method;
+        _ = method;
 
         var il = method.GetILGenerator();
 
@@ -1386,7 +1386,7 @@ public partial class RuntimeEmitter
             _types.Object,
             [_types.Double, _types.Object]
         );
-        runtime.TSHttpServerListen = method;
+        _ = method;
 
         var il = method.GetILGenerator();
 
@@ -1668,7 +1668,7 @@ public partial class RuntimeEmitter
             _types.Object,
             [_types.String]
         );
-        runtime.TSHttpServerGetMember = method;
+        _ = method;
 
         var il = method.GetILGenerator();
 

--- a/Compilation/RuntimeEmitter.TSKeyObject.cs
+++ b/Compilation/RuntimeEmitter.TSKeyObject.cs
@@ -222,7 +222,7 @@ public partial class RuntimeEmitter
         EmitTSKeyObjectExportMethod(typeBuilder, typeField, symmetricKeyField, rsaKeyField, ecdsaKeyField, runtime);
 
         // Store the type but don't create it yet - will be done after methods are defined
-        runtime.TSKeyObjectType = typeBuilder.CreateType()!;
+        _ = typeBuilder.CreateType()!;
     }
 
     private void EmitTSKeyObjectTypeProperty(TypeBuilder typeBuilder, FieldBuilder typeField)

--- a/Compilation/RuntimeEmitter.TSNetServer.cs
+++ b/Compilation/RuntimeEmitter.TSNetServer.cs
@@ -61,12 +61,12 @@ public partial class RuntimeEmitter
             runtime.TSEventEmitterType
         );
         _netServerTypeBuilder = typeBuilder;
-        runtime.NetServerType = typeBuilder;
+        _ = typeBuilder;
 
         // ── Fields ──
         _netServerListenerField = typeBuilder.DefineField("_listener", typeof(TcpListener), FieldAttributes.Private);
         _netServerIsListeningField = typeBuilder.DefineField("_isListening", _types.Boolean, FieldAttributes.Private);
-        runtime.NetServerIsListeningField = _netServerIsListeningField;
+        _ = _netServerIsListeningField;
         _netServerCtsField = typeBuilder.DefineField("_cts", typeof(CancellationTokenSource), FieldAttributes.Private);
         _netServerConnectionListenerField = typeBuilder.DefineField("_connectionListener", _types.Object, FieldAttributes.Assembly);
         _netServerPortField = typeBuilder.DefineField("_port", _types.Int32, FieldAttributes.Private);
@@ -89,7 +89,7 @@ public partial class RuntimeEmitter
             _types.Object,
             [_types.Object, _types.Object, _types.Object, _types.Object]
         );
-        runtime.NetServerListen = _netServerListenMethod;
+        _ = _netServerListenMethod;
 
         _netServerCloseMethod = typeBuilder.DefineMethod(
             "Close",
@@ -97,7 +97,7 @@ public partial class RuntimeEmitter
             _types.Object,
             [_types.Object]
         );
-        runtime.NetServerClose = _netServerCloseMethod;
+        _ = _netServerCloseMethod;
 
         _netServerAddressMethod = typeBuilder.DefineMethod(
             "Address",
@@ -105,7 +105,7 @@ public partial class RuntimeEmitter
             _types.Object,
             Type.EmptyTypes
         );
-        runtime.NetServerAddress = _netServerAddressMethod;
+        _ = _netServerAddressMethod;
 
         _netServerGetConnectionsMethod = typeBuilder.DefineMethod(
             "GetConnections",
@@ -113,7 +113,7 @@ public partial class RuntimeEmitter
             _types.Object,
             [_types.Object]
         );
-        runtime.NetServerGetConnections = _netServerGetConnectionsMethod;
+        _ = _netServerGetConnectionsMethod;
 
         _netServerGetMemberMethod = typeBuilder.DefineMethod(
             "GetMember",
@@ -121,7 +121,7 @@ public partial class RuntimeEmitter
             _types.Object,
             [_types.String]
         );
-        runtime.NetServerGetMember = _netServerGetMemberMethod;
+        _ = _netServerGetMemberMethod;
 
         _netServerSetMemberMethod = typeBuilder.DefineMethod(
             "SetMember",
@@ -129,7 +129,7 @@ public partial class RuntimeEmitter
             typeof(void),
             [_types.String, _types.Object]
         );
-        runtime.NetServerSetMember = _netServerSetMemberMethod;
+        _ = _netServerSetMemberMethod;
 
         // NOTE: CreateType() is deferred to Phase 2
     }

--- a/Compilation/RuntimeEmitter.TSNetSocket.cs
+++ b/Compilation/RuntimeEmitter.TSNetSocket.cs
@@ -138,7 +138,7 @@ public partial class RuntimeEmitter
             _types.Object,
             [_types.Object, _types.Object, _types.Object]
         );
-        runtime.NetSocketEnd = _netSocketEndMethod;
+        _ = _netSocketEndMethod;
 
         _netSocketDestroyMethod = typeBuilder.DefineMethod(
             "Destroy",
@@ -146,7 +146,7 @@ public partial class RuntimeEmitter
             _types.Object,
             [_types.Object]
         );
-        runtime.NetSocketDestroy = _netSocketDestroyMethod;
+        _ = _netSocketDestroyMethod;
 
         _netSocketSetEncodingMethod = typeBuilder.DefineMethod(
             "SetEncoding",
@@ -154,7 +154,7 @@ public partial class RuntimeEmitter
             _types.Object,
             [_types.Object]
         );
-        runtime.NetSocketSetEncoding = _netSocketSetEncodingMethod;
+        _ = _netSocketSetEncodingMethod;
 
         _netSocketGetMemberMethod = typeBuilder.DefineMethod(
             "GetMember",

--- a/Compilation/RuntimeEmitter.TSObject.cs
+++ b/Compilation/RuntimeEmitter.TSObject.cs
@@ -147,7 +147,7 @@ public partial class RuntimeEmitter
             _types.Boolean,
             Type.EmptyTypes
         );
-        runtime.TSObjectIsFrozenGetter = getter;
+        _ = getter;
 
         var il = getter.GetILGenerator();
         il.Emit(OpCodes.Ldarg_0);
@@ -172,7 +172,7 @@ public partial class RuntimeEmitter
             _types.Boolean,
             Type.EmptyTypes
         );
-        runtime.TSObjectIsSealedGetter = getter;
+        _ = getter;
 
         var il = getter.GetILGenerator();
         il.Emit(OpCodes.Ldarg_0);
@@ -785,7 +785,7 @@ public partial class RuntimeEmitter
             typeof(IEnumerable<string>),
             Type.EmptyTypes
         );
-        runtime.TSObjectGetKeys = getter;
+        _ = getter;
 
         var il = getter.GetILGenerator();
 
@@ -806,7 +806,7 @@ public partial class RuntimeEmitter
             _types.String,
             Type.EmptyTypes
         );
-        runtime.TSObjectToString = method;
+        _ = method;
 
         var il = method.GetILGenerator();
 
@@ -956,7 +956,7 @@ public partial class RuntimeEmitter
             _types.Object,
             [_types.String]
         );
-        runtime.TSObjectGetGetter = method;
+        _ = method;
 
         var il = method.GetILGenerator();
         var valueLocal = il.DeclareLocal(_types.Object);
@@ -997,7 +997,7 @@ public partial class RuntimeEmitter
             _types.Object,
             [_types.String]
         );
-        runtime.TSObjectGetSetter = method;
+        _ = method;
 
         var il = method.GetILGenerator();
         var valueLocal = il.DeclareLocal(_types.Object);

--- a/Compilation/RuntimeEmitter.TSPassThrough.cs
+++ b/Compilation/RuntimeEmitter.TSPassThrough.cs
@@ -17,7 +17,7 @@ public partial class RuntimeEmitter
             TypeAttributes.Public | TypeAttributes.Sealed | TypeAttributes.BeforeFieldInit,
             runtime.TSTransformType  // Extends $Transform
         );
-        runtime.TSPassThroughType = typeBuilder;
+        _ = typeBuilder;
 
         // Constructor
         EmitTSPassThroughCtor(typeBuilder, runtime);

--- a/Compilation/RuntimeEmitter.TSReadable.cs
+++ b/Compilation/RuntimeEmitter.TSReadable.cs
@@ -203,7 +203,7 @@ public partial class RuntimeEmitter
             _types.Object,
             [_types.Object]
         );
-        runtime.TSReadableRead = method;
+        _ = method;
 
         var il = method.GetILGenerator();
         var returnNullLabel = il.DefineLabel();
@@ -817,7 +817,7 @@ public partial class RuntimeEmitter
             typeBuilder,
             [_types.Object]
         );
-        runtime.TSReadableUnpipe = method;
+        _ = method;
 
         var il = method.GetILGenerator();
         // return this (simplified)
@@ -834,7 +834,7 @@ public partial class RuntimeEmitter
             typeBuilder,
             [_types.String]
         );
-        runtime.TSReadableSetEncoding = method;
+        _ = method;
 
         var il = method.GetILGenerator();
         // _encoding = encoding?.ToLowerInvariant() ?? "utf8"
@@ -941,7 +941,7 @@ public partial class RuntimeEmitter
             typeBuilder,
             [_types.Object]
         );
-        runtime.TSReadableUnshift = method;
+        _ = method;
 
         var il = method.GetILGenerator();
         // Simplified: just enqueue (proper implementation would prepend)
@@ -963,7 +963,7 @@ public partial class RuntimeEmitter
             typeBuilder,
             Type.EmptyTypes
         );
-        runtime.TSReadablePause = method;
+        _ = method;
 
         var il = method.GetILGenerator();
         // _flowing = 0 (paused)
@@ -992,7 +992,7 @@ public partial class RuntimeEmitter
             typeBuilder,
             Type.EmptyTypes
         );
-        runtime.TSReadableResume = method;
+        _ = method;
 
         var il = method.GetILGenerator();
         var queueType = typeof(Queue<object?>);
@@ -1066,7 +1066,7 @@ public partial class RuntimeEmitter
             _types.Boolean,
             Type.EmptyTypes
         );
-        runtime.TSReadableIsPaused = method;
+        _ = method;
 
         var il = method.GetILGenerator();
         // return _flowing == 0

--- a/Compilation/RuntimeEmitter.TSSign.cs
+++ b/Compilation/RuntimeEmitter.TSSign.cs
@@ -28,7 +28,7 @@ public partial class RuntimeEmitter
             TypeAttributes.Public | TypeAttributes.Sealed | TypeAttributes.BeforeFieldInit,
             _types.Object
         );
-        runtime.TSSignType = _tsSignTypeBuilder;
+        _ = _tsSignTypeBuilder;
 
         // Fields
         _tsSignHashAlgorithmField = _tsSignTypeBuilder.DefineField("_hashAlgorithm", _types.HashAlgorithmName, FieldAttributes.Private);
@@ -206,7 +206,7 @@ public partial class RuntimeEmitter
             typeBuilder,
             [_types.String]
         );
-        runtime.TSSignUpdateMethod = method;
+        _ = method;
 
         var il = method.GetILGenerator();
 
@@ -251,7 +251,7 @@ public partial class RuntimeEmitter
             _types.Object,
             [_types.String, _types.String]
         );
-        runtime.TSSignSignMethod = method;
+        _ = method;
 
         var il = method.GetILGenerator();
 

--- a/Compilation/RuntimeEmitter.TSTlsSocket.cs
+++ b/Compilation/RuntimeEmitter.TSTlsSocket.cs
@@ -754,7 +754,7 @@ public partial class RuntimeEmitter
             runtime.TSEventEmitterType
         );
         _tlsServerTypeBuilder = typeBuilder;
-        runtime.TlsServerType = typeBuilder;
+        _ = typeBuilder;
 
         // Fields
         _tlsServerIsListeningField = typeBuilder.DefineField("_isListening", _types.Boolean, FieldAttributes.Private);

--- a/Compilation/RuntimeEmitter.TSTypedArray.cs
+++ b/Compilation/RuntimeEmitter.TSTypedArray.cs
@@ -797,8 +797,8 @@ public partial class RuntimeEmitter
         // Keep the Float64-specific handles populated for any direct references.
         if (elementType == "Float64")
         {
-            runtime.Float64ArrayGetUnboxed = getU;
-            runtime.Float64ArraySetUnboxed = setU;
+            _ = getU;
+            _ = setU;
         }
     }
 

--- a/Compilation/RuntimeEmitter.TSVerify.cs
+++ b/Compilation/RuntimeEmitter.TSVerify.cs
@@ -28,7 +28,7 @@ public partial class RuntimeEmitter
             TypeAttributes.Public | TypeAttributes.Sealed | TypeAttributes.BeforeFieldInit,
             _types.Object
         );
-        runtime.TSVerifyType = _tsVerifyTypeBuilder;
+        _ = _tsVerifyTypeBuilder;
 
         // Fields
         _tsVerifyHashAlgorithmField = _tsVerifyTypeBuilder.DefineField("_hashAlgorithm", _types.HashAlgorithmName, FieldAttributes.Private);
@@ -206,7 +206,7 @@ public partial class RuntimeEmitter
             typeBuilder,
             [_types.String]
         );
-        runtime.TSVerifyUpdateMethod = method;
+        _ = method;
 
         var il = method.GetILGenerator();
 
@@ -251,7 +251,7 @@ public partial class RuntimeEmitter
             _types.Object,
             [_types.String, _types.Object, _types.String]
         );
-        runtime.TSVerifyVerifyMethod = method;
+        _ = method;
 
         var il = method.GetILGenerator();
 

--- a/Compilation/RuntimeEmitter.TSWritable.cs
+++ b/Compilation/RuntimeEmitter.TSWritable.cs
@@ -65,7 +65,7 @@ public partial class RuntimeEmitter
             [_types.Object, _types.Object, _types.Int32]
         );
         _tsWriteCallbackWrapperCtor = ctorBuilder;
-        runtime.WriteCallbackWrapperCtor = ctorBuilder;
+        _ = ctorBuilder;
 
         var ctorIL = ctorBuilder.GetILGenerator();
         ctorIL.Emit(OpCodes.Ldarg_0);
@@ -622,7 +622,7 @@ public partial class RuntimeEmitter
             _types.Void,
             Type.EmptyTypes
         );
-        runtime.TSWritableCork = method;
+        _ = method;
 
         var il = method.GetILGenerator();
         il.Emit(OpCodes.Ldarg_0);
@@ -790,7 +790,7 @@ public partial class RuntimeEmitter
             typeBuilder,
             [_types.String]
         );
-        runtime.TSWritableSetDefaultEncoding = method;
+        _ = method;
 
         var il = method.GetILGenerator();
         // Just return this (no-op for compatibility)

--- a/Compilation/RuntimeEmitter.TSZlibTransform.cs
+++ b/Compilation/RuntimeEmitter.TSZlibTransform.cs
@@ -43,7 +43,7 @@ public partial class RuntimeEmitter
             TypeAttributes.Public | TypeAttributes.Sealed | TypeAttributes.BeforeFieldInit,
             runtime.TSTransformType
         );
-        runtime.TSZlibTransformType = typeBuilder;
+        _ = typeBuilder;
 
         // Fields
         _tsZlibKindField = typeBuilder.DefineField("_kind", _types.Int32, FieldAttributes.Private);

--- a/Compilation/RuntimeEmitter.Timer.cs
+++ b/Compilation/RuntimeEmitter.Timer.cs
@@ -29,16 +29,16 @@ public partial class RuntimeEmitter
             TypeAttributes.Public | TypeAttributes.Sealed | TypeAttributes.Class,
             _types.Object
         );
-        runtime.TimeoutClosureType = typeBuilder;
+        _ = typeBuilder;
 
         // Fields: Callback ($TSFunction), Args (object[]), Cts (CancellationTokenSource)
         var callbackField = typeBuilder.DefineField("Callback", runtime.TSFunctionType, FieldAttributes.Public);
         var argsField = typeBuilder.DefineField("Args", _types.ObjectArray, FieldAttributes.Public);
         var ctsField = typeBuilder.DefineField("Cts", _types.CancellationTokenSource, FieldAttributes.Public);
 
-        runtime.TimeoutClosureCallback = callbackField;
-        runtime.TimeoutClosureArgs = argsField;
-        runtime.TimeoutClosureCts = ctsField;
+        _ = callbackField;
+        _ = argsField;
+        _ = ctsField;
 
         // Default constructor
         var ctor = typeBuilder.DefineConstructor(
@@ -46,7 +46,7 @@ public partial class RuntimeEmitter
             CallingConventions.Standard,
             Type.EmptyTypes
         );
-        runtime.TimeoutClosureCtor = ctor;
+        _ = ctor;
 
         var ctorIL = ctor.GetILGenerator();
         ctorIL.Emit(OpCodes.Ldarg_0);
@@ -61,7 +61,7 @@ public partial class RuntimeEmitter
             _types.Void,
             [_types.Task]
         );
-        runtime.TimeoutClosureExecute = executeMethod;
+        _ = executeMethod;
 
         var il = executeMethod.GetILGenerator();
         var skipLabel = il.DefineLabel();
@@ -120,7 +120,7 @@ public partial class RuntimeEmitter
         var virtualTimerField = typeBuilder.DefineField("_virtualTimer", runtime.VirtualTimerType, FieldAttributes.Private);
         var hasRefField = typeBuilder.DefineField("_hasRef", _types.Boolean, FieldAttributes.Private);
 
-        runtime.TSTimeoutVirtualTimerField = virtualTimerField;
+        _ = virtualTimerField;
 
         // Constructor: public $TSTimeout($VirtualTimer virtualTimer)
         EmitTSTimeoutConstructor(typeBuilder, runtime, nextIdField, idField, virtualTimerField, hasRefField);
@@ -461,7 +461,7 @@ public partial class RuntimeEmitter
             TypeAttributes.Public | TypeAttributes.Sealed | TypeAttributes.Class,
             _types.Object
         );
-        runtime.IntervalClosureType = typeBuilder;
+        _ = typeBuilder;
 
         // Fields: Callback ($TSFunction), Args (object[]), Cts (CancellationTokenSource), DelayMs (int)
         var callbackField = typeBuilder.DefineField("Callback", runtime.TSFunctionType, FieldAttributes.Public);
@@ -469,10 +469,10 @@ public partial class RuntimeEmitter
         var ctsField = typeBuilder.DefineField("Cts", _types.CancellationTokenSource, FieldAttributes.Public);
         var delayMsField = typeBuilder.DefineField("DelayMs", _types.Int32, FieldAttributes.Public);
 
-        runtime.IntervalClosureCallback = callbackField;
-        runtime.IntervalClosureArgs = argsField;
-        runtime.IntervalClosureCts = ctsField;
-        runtime.IntervalClosureDelayMs = delayMsField;
+        _ = callbackField;
+        _ = argsField;
+        _ = ctsField;
+        _ = delayMsField;
 
         // Default constructor
         var ctor = typeBuilder.DefineConstructor(
@@ -480,7 +480,7 @@ public partial class RuntimeEmitter
             CallingConventions.Standard,
             Type.EmptyTypes
         );
-        runtime.IntervalClosureCtor = ctor;
+        _ = ctor;
 
         var ctorIL = ctor.GetILGenerator();
         ctorIL.Emit(OpCodes.Ldarg_0);
@@ -495,7 +495,7 @@ public partial class RuntimeEmitter
             _types.Void,
             [_types.Task]
         );
-        runtime.IntervalClosureExecuteIteration = executeMethod;
+        _ = executeMethod;
 
         var il = executeMethod.GetILGenerator();
         var skipLabel = il.DefineLabel();
@@ -687,7 +687,7 @@ public partial class RuntimeEmitter
             queueType,
             FieldAttributes.Private | FieldAttributes.Static
         );
-        runtime.MicrotaskQueue = microtaskQueueField;
+        _ = microtaskQueueField;
 
         // Emit QueueMicrotask method
         var method = runtimeType.DefineMethod(

--- a/Compilation/RuntimeEmitter.UtilModule.cs
+++ b/Compilation/RuntimeEmitter.UtilModule.cs
@@ -43,7 +43,7 @@ public partial class RuntimeEmitter
         var encodingIL = encodingGetter.GetILGenerator();
         encodingIL.Emit(OpCodes.Ldstr, "utf-8");
         encodingIL.Emit(OpCodes.Ret);
-        runtime.TSTextEncoderEncodingGetter = encodingGetter;
+        _ = encodingGetter;
 
         var encodingProp = typeBuilder.DefineProperty(
             "encoding",
@@ -60,7 +60,7 @@ public partial class RuntimeEmitter
             runtime.TSBufferType,
             [_types.String]
         );
-        runtime.TSTextEncoderEncode = encodeMethod;
+        _ = encodeMethod;
 
         var encodeIL = encodeMethod.GetILGenerator();
         var inputLocal = encodeIL.DeclareLocal(_types.String);
@@ -169,7 +169,7 @@ public partial class RuntimeEmitter
         encodingGetterIL.Emit(OpCodes.Ldarg_0);
         encodingGetterIL.Emit(OpCodes.Ldfld, encodingNameField);
         encodingGetterIL.Emit(OpCodes.Ret);
-        runtime.TSTextDecoderEncodingGetter = encodingGetter;
+        _ = encodingGetter;
 
         var encodingProp = typeBuilder.DefineProperty(
             "Encoding",
@@ -190,7 +190,7 @@ public partial class RuntimeEmitter
         fatalGetterIL.Emit(OpCodes.Ldarg_0);
         fatalGetterIL.Emit(OpCodes.Ldfld, fatalField);
         fatalGetterIL.Emit(OpCodes.Ret);
-        runtime.TSTextDecoderFatalGetter = fatalGetter;
+        _ = fatalGetter;
 
         // Property: ignoreBOM
         var ignoreBOMGetter = typeBuilder.DefineMethod(
@@ -203,7 +203,7 @@ public partial class RuntimeEmitter
         ignoreBOMGetterIL.Emit(OpCodes.Ldarg_0);
         ignoreBOMGetterIL.Emit(OpCodes.Ldfld, ignoreBOMField);
         ignoreBOMGetterIL.Emit(OpCodes.Ret);
-        runtime.TSTextDecoderIgnoreBOMGetter = ignoreBOMGetter;
+        _ = ignoreBOMGetter;
 
         // Method: Decode(object input) -> string
         // Accepts $Buffer, byte[], or null
@@ -1022,7 +1022,7 @@ public partial class RuntimeEmitter
             CallingConventions.Standard,
             [runtime.TSTextDecoderType]
         );
-        runtime.TSTextDecoderDecodeMethodCtor = ctor;
+        _ = ctor;
 
         var ctorIL = ctor.GetILGenerator();
         ctorIL.Emit(OpCodes.Ldarg_0);

--- a/Compilation/RuntimeEmitter.VirtualTimers.cs
+++ b/Compilation/RuntimeEmitter.VirtualTimers.cs
@@ -67,7 +67,7 @@ public partial class RuntimeEmitter
             listType,
             FieldAttributes.Private | FieldAttributes.Static
         );
-        runtime.TimerQueue = timerQueueField;
+        _ = timerQueueField;
 
         // Static field: long _timerStartTicks (for high-resolution timing)
         var startTicksField = runtimeType.DefineField(
@@ -75,7 +75,7 @@ public partial class RuntimeEmitter
             _types.Int64,
             FieldAttributes.Private | FieldAttributes.Static
         );
-        runtime.TimerStartTicks = startTicksField;
+        _ = startTicksField;
 
         // Static field: bool _timerInitialized
         var initializedField = runtimeType.DefineField(
@@ -83,7 +83,7 @@ public partial class RuntimeEmitter
             _types.Boolean,
             FieldAttributes.Private | FieldAttributes.Static
         );
-        runtime.TimerInitialized = initializedField;
+        _ = initializedField;
 
         // Emit helper methods
         EmitEnsureTimerInitialized(runtimeType, runtime, timerQueueField, startTicksField, initializedField);

--- a/Compilation/RuntimeEmitter.Worker.cs
+++ b/Compilation/RuntimeEmitter.Worker.cs
@@ -1309,7 +1309,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Callvirt, runtime.TypedArrayElementGet);
         il.Emit(OpCodes.Ret);
 
-        runtime.TSTypedArrayGet = method;
+        _ = method;
     }
 
     private void EmitTypedArraySetHelper(TypeBuilder runtimeType, EmittedRuntime runtime)
@@ -1340,7 +1340,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Callvirt, runtime.TypedArrayElementSet);
         il.Emit(OpCodes.Ret);
 
-        runtime.TSTypedArraySet = method;
+        _ = method;
     }
 
     /// <summary>

--- a/Compilation/RuntimeEmitter.WritableStream.cs
+++ b/Compilation/RuntimeEmitter.WritableStream.cs
@@ -65,8 +65,8 @@ public partial class RuntimeEmitter
             _types.Object);
 
         runtime.WritableStreamType = streamBuilder;
-        runtime.WritableStreamDefaultControllerType = controllerBuilder;
-        runtime.WritableStreamDefaultWriterType = writerBuilder;
+        _ = controllerBuilder;
+        _ = writerBuilder;
 
         EmitWritableStreamFields(streamBuilder);
 
@@ -76,7 +76,7 @@ public partial class RuntimeEmitter
         _writableWriterStreamField = writerBuilder.DefineField(
             "_stream", streamBuilder, FieldAttributes.Private);
         var writerCtor = EmitWritableStreamWriterCtor(writerBuilder, streamBuilder);
-        runtime.WritableStreamDefaultWriterCtor = writerCtor;
+        _ = writerCtor;
 
         // Define controller fields + ctor BEFORE the stream uses it.
         _writableControllerStreamField = controllerBuilder.DefineField(
@@ -93,9 +93,9 @@ public partial class RuntimeEmitter
         var lockedGetter = EmitWritableStreamLockedGetter(streamBuilder);
         EmitWritableStreamGetWriter(streamBuilder, writerCtor);
 
-        runtime.WritableStreamWrite = writeMethod;
-        runtime.WritableStreamClose = closeMethod;
-        runtime.WritableStreamAbort = abortMethod;
+        _ = writeMethod;
+        _ = closeMethod;
+        _ = abortMethod;
 
         EmitWritableStreamWriterDelegatingMethod(writerBuilder, streamBuilder, "Write", writeMethod, [_types.Object]);
         EmitWritableStreamWriterDelegatingMethod(writerBuilder, streamBuilder, "Close", closeMethod, Type.EmptyTypes);

--- a/Execution/IEvaluationContext.cs
+++ b/Execution/IEvaluationContext.cs
@@ -47,6 +47,13 @@ public interface IEvaluationContext
     /// <param name="stmt">The statement to execute.</param>
     /// <returns>A ValueTask containing the execution result.</returns>
     ValueTask<ExecutionResult> ExecuteStmtAsync(Stmt stmt);
+
+    /// <summary>
+    /// Yields to the scheduler between loop iterations so timer callbacks and other work can run.
+    /// The sync context spins the OS thread (<c>Thread.Sleep(0)</c>); the async context yields to
+    /// the event loop (<c>Task.Yield()</c>). Lets one loop body serve both paths.
+    /// </summary>
+    ValueTask YieldToSchedulerAsync();
 }
 
 /// <summary>
@@ -80,6 +87,13 @@ internal sealed class SyncEvaluationContext : IEvaluationContext
         var result = _interpreter.ExecuteStatement(stmt);
         return new ValueTask<ExecutionResult>(result);
     }
+
+    public ValueTask YieldToSchedulerAsync()
+    {
+        // Sync path: spin the OS thread, matching the synchronous for-loop's Thread.Sleep(0).
+        System.Threading.Thread.Sleep(0);
+        return default;
+    }
 }
 
 /// <summary>
@@ -109,6 +123,12 @@ internal sealed class AsyncEvaluationContext : IEvaluationContext
     {
         // Async path: use the async executor
         return new ValueTask<ExecutionResult>(_interpreter.ExecuteStatementAsync(stmt));
+    }
+
+    public async ValueTask YieldToSchedulerAsync()
+    {
+        // Async path: yield to the event loop, matching the async for-loop's await Task.Yield().
+        await Task.Yield();
     }
 }
 

--- a/Execution/Interpreter.Async.cs
+++ b/Execution/Interpreter.Async.cs
@@ -482,74 +482,24 @@ public partial class Interpreter
         return ExecutionResult.Success();
     }
 
-    internal async ValueTask<ExecutionResult> ExecuteWhileAsyncVT(Stmt.While whileStmt)
+    internal ValueTask<ExecutionResult> ExecuteWhileAsyncVT(Stmt.While whileStmt)
     {
         var labels = TakePendingLoopLabels();
-        while (IsTruthy(await EvaluateAsync(whileStmt.Condition)))
-        {
-            var result = await ExecuteStatementAsync(whileStmt.Body);
-            var (shouldBreak, shouldContinue, abruptResult) = HandleLoopResult(result, labels);
-            if (shouldBreak) return ExecutionResult.Success();
-            if (shouldContinue) continue;
-            if (abruptResult.HasValue) return abruptResult.Value;
-            ProcessPendingCallbacks();
-        }
-        return ExecutionResult.Success();
+        return ExecuteWhileCore(_asyncContext, whileStmt, labels);
     }
 
-    internal async ValueTask<ExecutionResult> ExecuteDoWhileAsyncVT(Stmt.DoWhile doWhileStmt)
+    internal ValueTask<ExecutionResult> ExecuteDoWhileAsyncVT(Stmt.DoWhile doWhileStmt)
     {
         var labels = TakePendingLoopLabels();
-        do
-        {
-            var result = await ExecuteStatementAsync(doWhileStmt.Body);
-            var (shouldBreak, shouldContinue, abruptResult) = HandleLoopResult(result, labels);
-            if (shouldBreak) return ExecutionResult.Success();
-            if (shouldContinue) continue;
-            if (abruptResult.HasValue) return abruptResult.Value;
-            ProcessPendingCallbacks();
-        } while (IsTruthy(await EvaluateAsync(doWhileStmt.Condition)));
-        return ExecutionResult.Success();
+        return ExecuteDoWhileCore(_asyncContext, doWhileStmt, labels);
     }
 
-    internal async ValueTask<ExecutionResult> ExecuteForAsyncVT(Stmt.For forStmt)
+    internal ValueTask<ExecutionResult> ExecuteForAsyncVT(Stmt.For forStmt)
     {
         // Drain labels parked for this loop so a `break`/`continue <label>` targeting it (e.g. from an
         // inner `for await`) is matched here instead of escaping. Empty when unlabeled (#728).
         var labels = TakePendingLoopLabels();
-        RuntimeEnvironment loopEnv = new(_environment);
-        using (PushScope(loopEnv))
-        {
-            if (forStmt.Initializer != null)
-                await ExecuteStatementAsync(forStmt.Initializer);
-            // ECMA-262 13.7.4 per-iteration bindings for `for (let/const …)`, so
-            // closures capture distinct values across iterations (#633). Mirrors
-            // the synchronous VisitFor path.
-            var perIterationNames = CollectPerIterationBindings(forStmt.Initializer);
-            if (perIterationNames != null)
-                CreatePerIterationEnvironment(loopEnv, perIterationNames);
-            while (forStmt.Condition == null || IsTruthy(await EvaluateAsync(forStmt.Condition)))
-            {
-                var result = await ExecuteStatementAsync(forStmt.Body);
-                if (result.Type == ExecutionResult.ResultType.Break && TargetsThisLoop(result.TargetLabel, labels)) break;
-                if (result.Type == ExecutionResult.ResultType.Continue && TargetsThisLoop(result.TargetLabel, labels))
-                {
-                    if (perIterationNames != null)
-                        CreatePerIterationEnvironment(loopEnv, perIterationNames);
-                    if (forStmt.Increment != null)
-                        await EvaluateAsync(forStmt.Increment);
-                    await Task.Yield();
-                    continue;
-                }
-                if (result.IsAbrupt) return result;
-                if (perIterationNames != null)
-                    CreatePerIterationEnvironment(loopEnv, perIterationNames);
-                if (forStmt.Increment != null)
-                    await EvaluateAsync(forStmt.Increment);
-                ProcessPendingCallbacks();
-            }
-            return ExecutionResult.Success();
-        }
+        return ExecuteForCore(_asyncContext, forStmt, labels);
     }
 
     internal async ValueTask<ExecutionResult> ExecuteForOfAsyncVT(Stmt.ForOf forOf)
@@ -755,37 +705,6 @@ public partial class Interpreter
         return RuntimeValue.FromBoxed(await EvaluateCallCore(_asyncContext, call));
     }
 
-    private async Task<RuntimeValue> EvaluateGetAsync(Expr.Get get)
-    {
-        // Handle namespace static property access (e.g., Number.MAX_VALUE, Number.NaN)
-        // These namespaces don't have runtime values, but have static properties
-        if (get.Object is Expr.Variable nsVar)
-        {
-            var member = BuiltInRegistry.Instance.GetStaticMethod(nsVar.Name.Lexeme, get.Name.Lexeme);
-            if (member != null)
-            {
-                // If it's a constant (like Number.MAX_VALUE), it's wrapped in a BuiltInMethod
-                // that returns the value when invoked with no args
-                if (member is BuiltInMethod bm && bm.MinArity == 0 && bm.MaxArity == 0)
-                {
-                    // It's a constant property, invoke it to get the value
-                    return RuntimeValue.FromBoxed(bm.Call(this, []));
-                }
-                return RuntimeValue.FromObject(member);
-            }
-        }
-
-        object? obj = (await EvaluateAsync(get.Object)).ToObject();
-        return EvaluateGetOnObject(get, obj);
-    }
-
-    private async Task<RuntimeValue> EvaluateSetAsync(Expr.Set set)
-    {
-        object? obj = (await EvaluateAsync(set.Object)).ToObject();
-        object? value = (await EvaluateAsync(set.Value)).ToObject();
-        return EvaluateSetOnObjectRV(set, obj, value);
-    }
-
     private async Task<RuntimeValue> EvaluateNewAsync(Expr.New newExpr)
     {
         // Use async context with unified core - handles all built-in types
@@ -802,141 +721,6 @@ public partial class Interpreter
     {
         // Use async context with unified core
         return RuntimeValue.FromBoxed(await EvaluateObjectCore(_asyncContext, obj));
-    }
-
-    private async Task<RuntimeValue> EvaluateGetIndexAsync(Expr.GetIndex getIndex)
-    {
-        object? obj = (await EvaluateAsync(getIndex.Object)).ToObject();
-
-        // Optional bracket access: return undefined if object is nullish
-        if (getIndex.Optional && (obj == null || obj is Runtime.Types.SharpTSUndefined))
-        {
-            return RuntimeValue.Undefined;
-        }
-
-        object? index = (await EvaluateAsync(getIndex.Index)).ToObject();
-        return PerformIndexGet(getIndex.Object, obj, index);
-    }
-
-    private async Task<RuntimeValue> EvaluateSetIndexAsync(Expr.SetIndex setIndex)
-    {
-        object? obj = (await EvaluateAsync(setIndex.Object)).ToObject();
-        object? index = (await EvaluateAsync(setIndex.Index)).ToObject();
-        object? value = (await EvaluateAsync(setIndex.Value)).ToObject();
-        return PerformIndexSet(obj, index, value);
-    }
-
-    private async Task<RuntimeValue> EvaluateCompoundAssignAsync(Expr.CompoundAssign compound)
-    {
-        var currentRV = _environment.Get(compound.Name);
-        var operandRV = await EvaluateAsync(compound.Value);
-        var result = ApplyCompoundOperatorRV(compound.Operator.Type, currentRV, operandRV);
-        _environment.Assign(compound.Name, result.ToObject());
-        return result;
-    }
-
-    private async Task<RuntimeValue> EvaluateCompoundSetAsync(Expr.CompoundSet compoundSet)
-    {
-        object? obj = (await EvaluateAsync(compoundSet.Object)).ToObject();
-        RuntimeValue currentRV = EvaluateGetOnObject(new Expr.Get(compoundSet.Object, compoundSet.Name), obj);
-        var operandRV = await EvaluateAsync(compoundSet.Value);
-        RuntimeValue result = ApplyCompoundOperatorRV(compoundSet.Operator.Type, currentRV, operandRV);
-        object? resultObj = result.ToObject();
-        EvaluateSetOnObject(new Expr.Set(compoundSet.Object, compoundSet.Name, new Expr.Literal(resultObj)), obj, resultObj);
-        return result;
-    }
-
-    private async Task<RuntimeValue> EvaluateCompoundSetIndexAsync(Expr.CompoundSetIndex compoundSetIndex)
-    {
-        object? obj = (await EvaluateAsync(compoundSetIndex.Object)).ToObject();
-        object? index = (await EvaluateAsync(compoundSetIndex.Index)).ToObject();
-        object? currentValue = PerformIndexGet(compoundSetIndex.Object, obj, index).ToObject();
-        object? operandValue = (await EvaluateAsync(compoundSetIndex.Value)).ToObject();
-        object? result = ApplyCompoundOperator(compoundSetIndex.Operator.Type, currentValue, operandValue);
-        return PerformIndexSet(obj, index, result);
-    }
-
-    private async Task<RuntimeValue> EvaluateLogicalAssignAsync(Expr.LogicalAssign logical)
-    {
-        var currentRV = _environment.Get(logical.Name);
-
-        switch (logical.Operator.Type)
-        {
-            case TokenType.AND_AND_EQUAL:
-                if (!IsTruthy(currentRV)) return currentRV;
-                break;
-            case TokenType.OR_OR_EQUAL:
-                if (IsTruthy(currentRV)) return currentRV;
-                break;
-            case TokenType.QUESTION_QUESTION_EQUAL:
-                if (!currentRV.IsNullish) return currentRV;
-                break;
-        }
-
-        var newRV = await EvaluateAsync(logical.Value);
-        _environment.Assign(logical.Name, newRV.ToObject());
-        return newRV;
-    }
-
-    private async Task<RuntimeValue> EvaluateLogicalSetAsync(Expr.LogicalSet logical)
-    {
-        object? obj = (await EvaluateAsync(logical.Object)).ToObject();
-
-        // Logical assignment reads first → nullish base throws the *read*-worded
-        // guest TypeError before the short-circuit check (#733).
-        if (obj is null or SharpTSUndefined)
-        {
-            ThrowCannotReadProperty(obj, logical.Name.Lexeme);
-        }
-
-        if (!TryGetPropertyRV(obj, logical.Name, out RuntimeValue currentRV))
-        {
-            throw new InterpreterException($"Only instances and objects have fields. Cannot logical-get '{logical.Name.Lexeme}' on {obj?.GetType().Name ?? "null"}.");
-        }
-
-        switch (logical.Operator.Type)
-        {
-            case TokenType.AND_AND_EQUAL:
-                if (!currentRV.IsTruthy()) return currentRV;
-                break;
-            case TokenType.OR_OR_EQUAL:
-                if (currentRV.IsTruthy()) return currentRV;
-                break;
-            case TokenType.QUESTION_QUESTION_EQUAL:
-                if (!currentRV.IsNullish) return currentRV;
-                break;
-        }
-
-        var newRV = await EvaluateAsync(logical.Value);
-        object? newValue = newRV.ToObject();
-        if (!TrySetProperty(obj, logical.Name, newValue))
-        {
-            throw new InterpreterException($"Only instances and objects have fields. Cannot logical-set '{logical.Name.Lexeme}' on {obj?.GetType().Name ?? "null"}.");
-        }
-        return newRV;
-    }
-
-    private async Task<RuntimeValue> EvaluateLogicalSetIndexAsync(Expr.LogicalSetIndex logical)
-    {
-        object? obj = (await EvaluateAsync(logical.Object)).ToObject();
-        object? index = (await EvaluateAsync(logical.Index)).ToObject();
-        object? currentValue = PerformIndexGet(logical.Object, obj, index).ToObject();
-
-        switch (logical.Operator.Type)
-        {
-            case TokenType.AND_AND_EQUAL:
-                if (!IsTruthy(currentValue)) return RuntimeValue.FromBoxed(currentValue);
-                break;
-            case TokenType.OR_OR_EQUAL:
-                if (IsTruthy(currentValue)) return RuntimeValue.FromBoxed(currentValue);
-                break;
-            case TokenType.QUESTION_QUESTION_EQUAL:
-                if (currentValue != null) return RuntimeValue.FromBoxed(currentValue);
-                break;
-        }
-
-        object? newValue = (await EvaluateAsync(logical.Value)).ToObject();
-        return PerformIndexSet(obj, index, newValue);
     }
 
     private async Task<RuntimeValue> EvaluateTemplateLiteralAsync(Expr.TemplateLiteral template)

--- a/Execution/Interpreter.Expressions.cs
+++ b/Execution/Interpreter.Expressions.cs
@@ -352,21 +352,6 @@ public partial class Interpreter
     }
 
     /// <summary>
-    /// Evaluates a variable reference, looking up its value in the current environment.
-    /// </summary>
-    /// <param name="variable">The variable expression AST node.</param>
-    /// <returns>The current value of the variable.</returns>
-    /// <remarks>
-    /// Uses side-channel resolution information if available, otherwise falls back
-    /// to dynamic lookup via <see cref="RuntimeEnvironment"/>.
-    /// </remarks>
-    /// <seealso href="https://www.typescriptlang.org/docs/handbook/variable-declarations.html">TypeScript Variable Declarations</seealso>
-    private object? EvaluateVariable(Expr.Variable variable)
-    {
-        return LookupVariable(variable.Name, variable);
-    }
-
-    /// <summary>
     /// Evaluates a template literal (backtick string) with embedded expressions.
     /// </summary>
     /// <param name="template">The template literal expression AST node.</param>

--- a/Execution/Interpreter.Expressions.cs
+++ b/Execution/Interpreter.Expressions.cs
@@ -143,12 +143,12 @@ public partial class Interpreter
     internal ValueTask<RuntimeValue> VisitGroupingAsync(Expr.Grouping grouping) => EvaluateAsync(grouping.Expression);
     internal ValueTask<RuntimeValue> VisitLiteralAsync(Expr.Literal literal) => new(EvaluateLiteral(literal));
     internal ValueTask<RuntimeValue> VisitUnaryAsync(Expr.Unary unary) => new(EvaluateUnaryAsync(unary));
-    internal async ValueTask<RuntimeValue> VisitDeleteAsync(Expr.Delete delete) => RuntimeValue.FromBoxed(await EvaluateDeleteAsync(delete));
+    internal async ValueTask<RuntimeValue> VisitDeleteAsync(Expr.Delete delete) => RuntimeValue.FromBoolean(await DeleteCore(_asyncContext, delete));
     internal ValueTask<RuntimeValue> VisitVariableAsync(Expr.Variable variable) => new(LookupVariableRV(variable.Name, variable));
     internal ValueTask<RuntimeValue> VisitAssignAsync(Expr.Assign assign) => EvaluateAssignAsync(assign);
     internal ValueTask<RuntimeValue> VisitCallAsync(Expr.Call call) => new(EvaluateCallAsync(call));
-    internal ValueTask<RuntimeValue> VisitGetAsync(Expr.Get get) => new(EvaluateGetAsync(get));
-    internal ValueTask<RuntimeValue> VisitSetAsync(Expr.Set set) => new(EvaluateSetAsync(set));
+    internal ValueTask<RuntimeValue> VisitGetAsync(Expr.Get get) => EvaluateGetCore(_asyncContext, get);
+    internal ValueTask<RuntimeValue> VisitSetAsync(Expr.Set set) => EvaluateSetCore(_asyncContext, set);
     internal ValueTask<RuntimeValue> VisitGetPrivateAsync(Expr.GetPrivate gp) => new(EvaluateGetPrivateAsync(gp));
     internal ValueTask<RuntimeValue> VisitSetPrivateAsync(Expr.SetPrivate sp) => new(EvaluateSetPrivateAsync(sp));
     internal ValueTask<RuntimeValue> VisitCallPrivateAsync(Expr.CallPrivate cp) => new(EvaluateCallPrivateAsync(cp));
@@ -156,15 +156,15 @@ public partial class Interpreter
     internal ValueTask<RuntimeValue> VisitNewAsync(Expr.New newExpr) => new(EvaluateNewAsync(newExpr));
     internal ValueTask<RuntimeValue> VisitArrayLiteralAsync(Expr.ArrayLiteral array) => new(EvaluateArrayAsync(array));
     internal ValueTask<RuntimeValue> VisitObjectLiteralAsync(Expr.ObjectLiteral obj) => new(EvaluateObjectAsync(obj));
-    internal ValueTask<RuntimeValue> VisitGetIndexAsync(Expr.GetIndex getIndex) => new(EvaluateGetIndexAsync(getIndex));
-    internal ValueTask<RuntimeValue> VisitSetIndexAsync(Expr.SetIndex setIndex) => new(EvaluateSetIndexAsync(setIndex));
+    internal ValueTask<RuntimeValue> VisitGetIndexAsync(Expr.GetIndex getIndex) => EvaluateGetIndexCore(_asyncContext, getIndex);
+    internal ValueTask<RuntimeValue> VisitSetIndexAsync(Expr.SetIndex setIndex) => EvaluateSetIndexCore(_asyncContext, setIndex);
     internal ValueTask<RuntimeValue> VisitSuperAsync(Expr.Super super) => new(EvaluateSuper(super));
-    internal ValueTask<RuntimeValue> VisitCompoundAssignAsync(Expr.CompoundAssign compound) => new(EvaluateCompoundAssignAsync(compound));
-    internal ValueTask<RuntimeValue> VisitCompoundSetAsync(Expr.CompoundSet compoundSet) => new(EvaluateCompoundSetAsync(compoundSet));
-    internal ValueTask<RuntimeValue> VisitCompoundSetIndexAsync(Expr.CompoundSetIndex compoundSetIndex) => new(EvaluateCompoundSetIndexAsync(compoundSetIndex));
-    internal ValueTask<RuntimeValue> VisitLogicalAssignAsync(Expr.LogicalAssign logical) => new(EvaluateLogicalAssignAsync(logical));
-    internal ValueTask<RuntimeValue> VisitLogicalSetAsync(Expr.LogicalSet logicalSet) => new(EvaluateLogicalSetAsync(logicalSet));
-    internal ValueTask<RuntimeValue> VisitLogicalSetIndexAsync(Expr.LogicalSetIndex logicalSetIndex) => new(EvaluateLogicalSetIndexAsync(logicalSetIndex));
+    internal ValueTask<RuntimeValue> VisitCompoundAssignAsync(Expr.CompoundAssign compound) => EvaluateCompoundAssignCore(_asyncContext, compound);
+    internal ValueTask<RuntimeValue> VisitCompoundSetAsync(Expr.CompoundSet compoundSet) => EvaluateCompoundSetCore(_asyncContext, compoundSet);
+    internal ValueTask<RuntimeValue> VisitCompoundSetIndexAsync(Expr.CompoundSetIndex compoundSetIndex) => EvaluateCompoundSetIndexCore(_asyncContext, compoundSetIndex);
+    internal ValueTask<RuntimeValue> VisitLogicalAssignAsync(Expr.LogicalAssign logical) => EvaluateLogicalAssignCore(_asyncContext, logical);
+    internal ValueTask<RuntimeValue> VisitLogicalSetAsync(Expr.LogicalSet logicalSet) => EvaluateLogicalSetCore(_asyncContext, logicalSet);
+    internal ValueTask<RuntimeValue> VisitLogicalSetIndexAsync(Expr.LogicalSetIndex logicalSetIndex) => EvaluateLogicalSetIndexCore(_asyncContext, logicalSetIndex);
     internal ValueTask<RuntimeValue> VisitPrefixIncrementAsync(Expr.PrefixIncrement prefix) => new(EvaluatePrefixIncrementAsync(prefix));
     internal ValueTask<RuntimeValue> VisitPostfixIncrementAsync(Expr.PostfixIncrement postfix) => new(EvaluatePostfixIncrementAsync(postfix));
     internal ValueTask<RuntimeValue> VisitArrowFunctionAsync(Expr.ArrowFunction arrow) => new(EvaluateArrowFunction(arrow));
@@ -876,8 +876,14 @@ public partial class Interpreter
     /// </remarks>
     /// <seealso href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Property_accessors#bracket_notation">MDN Bracket Notation</seealso>
     private RuntimeValue EvaluateGetIndex(Expr.GetIndex getIndex)
+        => EvaluateGetIndexCore(_syncContext, getIndex).GetAwaiter().GetResult();
+
+    /// <summary>
+    /// Core indexed-read logic shared by the sync and async evaluators.
+    /// </summary>
+    private async ValueTask<RuntimeValue> EvaluateGetIndexCore(IEvaluationContext ctx, Expr.GetIndex getIndex)
     {
-        object? obj = Evaluate(getIndex.Object);
+        object? obj = (await ctx.EvaluateExprAsync(getIndex.Object)).ToObject();
 
         // Optional bracket access: return undefined if object is nullish
         if (getIndex.Optional && (obj == null || obj is Runtime.Types.SharpTSUndefined))
@@ -885,7 +891,7 @@ public partial class Interpreter
             return RuntimeValue.Undefined;
         }
 
-        object? index = Evaluate(getIndex.Index);
+        object? index = (await ctx.EvaluateExprAsync(getIndex.Index)).ToObject();
         return PerformIndexGet(getIndex.Object, obj, index);
     }
 
@@ -1103,10 +1109,16 @@ public partial class Interpreter
     /// </remarks>
     /// <seealso href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Property_accessors#bracket_notation">MDN Bracket Notation</seealso>
     private RuntimeValue EvaluateSetIndex(Expr.SetIndex setIndex)
+        => EvaluateSetIndexCore(_syncContext, setIndex).GetAwaiter().GetResult();
+
+    /// <summary>
+    /// Core indexed-assignment logic shared by the sync and async evaluators.
+    /// </summary>
+    private async ValueTask<RuntimeValue> EvaluateSetIndexCore(IEvaluationContext ctx, Expr.SetIndex setIndex)
     {
-        object? obj = Evaluate(setIndex.Object);
-        object? index = Evaluate(setIndex.Index);
-        object? value = Evaluate(setIndex.Value);
+        object? obj = (await ctx.EvaluateExprAsync(setIndex.Object)).ToObject();
+        object? index = (await ctx.EvaluateExprAsync(setIndex.Index)).ToObject();
+        object? value = (await ctx.EvaluateExprAsync(setIndex.Value)).ToObject();
         return PerformIndexSet(obj, index, value);
     }
 

--- a/Execution/Interpreter.Operators.cs
+++ b/Execution/Interpreter.Operators.cs
@@ -22,9 +22,16 @@ public partial class Interpreter
     /// </remarks>
     /// <seealso href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Addition_assignment">MDN Compound Assignment</seealso>
     private RuntimeValue EvaluateCompoundAssign(Expr.CompoundAssign compound)
+        => EvaluateCompoundAssignCore(_syncContext, compound).GetAwaiter().GetResult();
+
+    /// <summary>
+    /// Core compound-assignment logic shared by the sync and async evaluators; the evaluation
+    /// context supplies the operand-evaluation strategy so a single body serves both paths.
+    /// </summary>
+    private async ValueTask<RuntimeValue> EvaluateCompoundAssignCore(IEvaluationContext ctx, Expr.CompoundAssign compound)
     {
         RuntimeValue currentValue = _environment.Get(compound.Name);
-        RuntimeValue addValue = EvaluateRV(compound.Value);
+        RuntimeValue addValue = await ctx.EvaluateExprAsync(compound.Value);
         RuntimeValue newValue = ApplyCompoundOperatorRV(compound.Operator.Type, currentValue, addValue);
         _environment.Assign(compound.Name, newValue);
         return newValue;
@@ -41,8 +48,14 @@ public partial class Interpreter
     /// </remarks>
     /// <seealso href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Addition_assignment">MDN Compound Assignment</seealso>
     private RuntimeValue EvaluateCompoundSet(Expr.CompoundSet compound)
+        => EvaluateCompoundSetCore(_syncContext, compound).GetAwaiter().GetResult();
+
+    /// <summary>
+    /// Core property compound-assignment logic shared by the sync and async evaluators.
+    /// </summary>
+    private async ValueTask<RuntimeValue> EvaluateCompoundSetCore(IEvaluationContext ctx, Expr.CompoundSet compound)
     {
-        object? obj = Evaluate(compound.Object);
+        object? obj = (await ctx.EvaluateExprAsync(compound.Object)).ToObject();
 
         // ECMA-262: a compound assignment reads first (GetValue), so a nullish base
         // throws the *read*-worded guest TypeError before any operation (#733).
@@ -53,7 +66,7 @@ public partial class Interpreter
 
         if (TryGetPropertyRV(obj, compound.Name, out RuntimeValue currentRV))
         {
-            RuntimeValue addValue = EvaluateRV(compound.Value);
+            RuntimeValue addValue = await ctx.EvaluateExprAsync(compound.Value);
             RuntimeValue newValue = ApplyCompoundOperatorRV(compound.Operator.Type, currentRV, addValue);
             if (TrySetProperty(obj, compound.Name, newValue.ToObject()))
             {
@@ -74,9 +87,15 @@ public partial class Interpreter
     /// </remarks>
     /// <seealso href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Addition_assignment">MDN Compound Assignment</seealso>
     private RuntimeValue EvaluateCompoundSetIndex(Expr.CompoundSetIndex compound)
+        => EvaluateCompoundSetIndexCore(_syncContext, compound).GetAwaiter().GetResult();
+
+    /// <summary>
+    /// Core indexed compound-assignment logic shared by the sync and async evaluators.
+    /// </summary>
+    private async ValueTask<RuntimeValue> EvaluateCompoundSetIndexCore(IEvaluationContext ctx, Expr.CompoundSetIndex compound)
     {
-        object? obj = Evaluate(compound.Object);
-        object? index = Evaluate(compound.Index);
+        object? obj = (await ctx.EvaluateExprAsync(compound.Object)).ToObject();
+        object? index = (await ctx.EvaluateExprAsync(compound.Index)).ToObject();
 
         // Nullish base reads first → *read*-worded guest TypeError (#733).
         if (obj is null or SharpTSUndefined)
@@ -86,7 +105,7 @@ public partial class Interpreter
 
         if (obj is SharpTSArray array && index is double idx)
         {
-            RuntimeValue addValue = EvaluateRV(compound.Value);
+            RuntimeValue addValue = await ctx.EvaluateExprAsync(compound.Value);
             RuntimeValue newValue = ApplyCompoundOperatorRV(compound.Operator.Type, array.GetRV((int)idx), addValue);
             array.Set((int)idx, newValue.ToObject());
             return newValue;
@@ -99,7 +118,7 @@ public partial class Interpreter
         if (obj is SharpTSTypedArray typedArray && index is double typedIdx)
         {
             int ti = (int)typedIdx;
-            RuntimeValue addValue = EvaluateRV(compound.Value);
+            RuntimeValue addValue = await ctx.EvaluateExprAsync(compound.Value);
             RuntimeValue newValue = ApplyCompoundOperatorRV(
                 compound.Operator.Type, RuntimeValue.FromBoxed(typedArray[ti]), addValue);
             typedArray[ti] = newValue.ToObject();
@@ -121,6 +140,13 @@ public partial class Interpreter
     /// - <c>x ??= y</c>: Only assigns y to x if x is null/undefined
     /// </remarks>
     private RuntimeValue EvaluateLogicalAssign(Expr.LogicalAssign logical)
+        => EvaluateLogicalAssignCore(_syncContext, logical).GetAwaiter().GetResult();
+
+    /// <summary>
+    /// Core variable logical-assignment logic shared by the sync and async evaluators.
+    /// Short-circuits before evaluating the right-hand side per ECMA-262.
+    /// </summary>
+    private async ValueTask<RuntimeValue> EvaluateLogicalAssignCore(IEvaluationContext ctx, Expr.LogicalAssign logical)
     {
         RuntimeValue currentValue = _environment.Get(logical.Name);
 
@@ -138,7 +164,7 @@ public partial class Interpreter
         }
 
         // Short-circuit condition not met, evaluate and assign
-        RuntimeValue newValue = EvaluateRV(logical.Value);
+        RuntimeValue newValue = await ctx.EvaluateExprAsync(logical.Value);
         _environment.Assign(logical.Name, newValue);
         return newValue;
     }
@@ -147,8 +173,14 @@ public partial class Interpreter
     /// Evaluates a logical assignment expression on an object property (e.g., <c>obj.x &&= y</c>).
     /// </summary>
     private RuntimeValue EvaluateLogicalSet(Expr.LogicalSet logical)
+        => EvaluateLogicalSetCore(_syncContext, logical).GetAwaiter().GetResult();
+
+    /// <summary>
+    /// Core property logical-assignment logic shared by the sync and async evaluators.
+    /// </summary>
+    private async ValueTask<RuntimeValue> EvaluateLogicalSetCore(IEvaluationContext ctx, Expr.LogicalSet logical)
     {
-        object? obj = Evaluate(logical.Object);
+        object? obj = (await ctx.EvaluateExprAsync(logical.Object)).ToObject();
 
         // Logical assignment reads first → nullish base throws the *read*-worded
         // guest TypeError before the short-circuit check (#733).
@@ -176,7 +208,7 @@ public partial class Interpreter
         }
 
         // Short-circuit condition not met, evaluate and assign
-        RuntimeValue newValue = EvaluateRV(logical.Value);
+        RuntimeValue newValue = await ctx.EvaluateExprAsync(logical.Value);
         if (!TrySetProperty(obj, logical.Name, newValue.ToObject()))
         {
             throw new InterpreterException($"Only instances and objects have fields. Cannot logical-set '{logical.Name.Lexeme}' on {obj?.GetType().Name ?? "null"}.");
@@ -188,9 +220,15 @@ public partial class Interpreter
     /// Evaluates a logical assignment expression on an array element (e.g., <c>arr[i] &&= y</c>).
     /// </summary>
     private RuntimeValue EvaluateLogicalSetIndex(Expr.LogicalSetIndex logical)
+        => EvaluateLogicalSetIndexCore(_syncContext, logical).GetAwaiter().GetResult();
+
+    /// <summary>
+    /// Core indexed logical-assignment logic shared by the sync and async evaluators.
+    /// </summary>
+    private async ValueTask<RuntimeValue> EvaluateLogicalSetIndexCore(IEvaluationContext ctx, Expr.LogicalSetIndex logical)
     {
-        object? obj = Evaluate(logical.Object);
-        object? index = Evaluate(logical.Index);
+        object? obj = (await ctx.EvaluateExprAsync(logical.Object)).ToObject();
+        object? index = (await ctx.EvaluateExprAsync(logical.Index)).ToObject();
 
         // Nullish base reads first → *read*-worded guest TypeError (#733).
         if (obj is null or SharpTSUndefined)
@@ -216,7 +254,7 @@ public partial class Interpreter
             }
 
             // Short-circuit condition not met, evaluate and assign
-            RuntimeValue newValue = EvaluateRV(logical.Value);
+            RuntimeValue newValue = await ctx.EvaluateExprAsync(logical.Value);
             array.Set((int)idx, newValue.ToObject());
             return newValue;
         }
@@ -632,38 +670,26 @@ public partial class Interpreter
     /// - delete on non-existent property: returns true
     /// </remarks>
     private RuntimeValue EvaluateDelete(Expr.Delete delete)
-    {
-        bool strictMode = _environment.IsStrictMode;
-
-        bool result = delete.Operand switch
-        {
-            Expr.Get get => DeleteProperty(get, strictMode),
-            Expr.GetIndex getIndex => DeleteIndexedProperty(getIndex, strictMode),
-            Expr.Variable v when strictMode =>
-                throw StrictModeErrors.SyntaxError($"Delete of unqualified identifier '{v.Name.Lexeme}' in strict mode"),
-            Expr.Variable v =>
-                SloppyModeWarnings.WarnAndReturn(false, "delete variable", $"delete {v.Name.Lexeme} returns false in sloppy mode"),
-            _ => true // Deleting other expressions returns true but does nothing
-        };
-        return RuntimeValue.FromBoolean(result);
-    }
+        => RuntimeValue.FromBoolean(DeleteCore(_syncContext, delete).GetAwaiter().GetResult());
 
     /// <summary>
-    /// Async version of EvaluateDelete.
+    /// Core delete logic shared by the sync and async evaluators. The evaluation context
+    /// supplies the operand-evaluation strategy (synchronous or awaiting), so a single body
+    /// serves both paths — there is no separate async twin to keep in lockstep.
     /// </summary>
-    private async Task<object> EvaluateDeleteAsync(Expr.Delete delete)
+    private async ValueTask<bool> DeleteCore(IEvaluationContext ctx, Expr.Delete delete)
     {
         bool strictMode = _environment.IsStrictMode;
 
         return delete.Operand switch
         {
-            Expr.Get get => await DeletePropertyAsync(get, strictMode),
-            Expr.GetIndex getIndex => await DeleteIndexedPropertyAsync(getIndex, strictMode),
+            Expr.Get get => await DeletePropertyCore(ctx, get, strictMode),
+            Expr.GetIndex getIndex => await DeleteIndexedPropertyCore(ctx, getIndex, strictMode),
             Expr.Variable v when strictMode =>
                 throw StrictModeErrors.SyntaxError($"Delete of unqualified identifier '{v.Name.Lexeme}' in strict mode"),
             Expr.Variable v =>
                 SloppyModeWarnings.WarnAndReturn(false, "delete variable", $"delete {v.Name.Lexeme} returns false in sloppy mode"),
-            _ => true
+            _ => true // Deleting other expressions returns true but does nothing
         };
     }
 
@@ -671,9 +697,9 @@ public partial class Interpreter
     /// Deletes a property from an object (delete obj.prop).
     /// In strict mode, throws TypeError for frozen/sealed objects.
     /// </summary>
-    private bool DeleteProperty(Expr.Get get, bool strictMode)
+    private async ValueTask<bool> DeletePropertyCore(IEvaluationContext ctx, Expr.Get get, bool strictMode)
     {
-        object? obj = Evaluate(get.Object);
+        object? obj = (await ctx.EvaluateExprAsync(get.Object)).ToObject();
         string name = get.Name.Lexeme;
 
         if (obj is SharpTSProxy proxy)
@@ -689,72 +715,13 @@ public partial class Interpreter
     }
 
     /// <summary>
-    /// Async version of DeleteProperty.
-    /// In strict mode, throws TypeError for frozen/sealed objects.
-    /// </summary>
-    private async Task<bool> DeletePropertyAsync(Expr.Get get, bool strictMode)
-    {
-        object? obj = (await EvaluateAsync(get.Object)).ToObject();
-        string name = get.Name.Lexeme;
-
-        if (obj is SharpTSProxy proxy)
-            return proxy.TrapDeleteProperty(name, this);
-
-        return obj switch
-        {
-            SharpTSObject tsObj => tsObj.DeletePropertyStrict(name, strictMode),
-            SharpTSInstance tsInst => tsInst.DeleteFieldStrict(name, strictMode),
-            Dictionary<string, object?> dict => dict.Remove(name),
-            _ => true
-        };
-    }
-
-    /// <summary>
     /// Deletes a computed property from an object (delete obj[key]).
     /// In strict mode, throws TypeError for frozen/sealed objects.
     /// </summary>
-    private bool DeleteIndexedProperty(Expr.GetIndex getIndex, bool strictMode)
+    private async ValueTask<bool> DeleteIndexedPropertyCore(IEvaluationContext ctx, Expr.GetIndex getIndex, bool strictMode)
     {
-        object? obj = Evaluate(getIndex.Object);
-        object? key = Evaluate(getIndex.Index);
-
-        // Handle proxy
-        if (obj is SharpTSProxy proxy)
-        {
-            string proxyKey = key is SharpTSSymbol ? key.ToString()! : Stringify(key);
-            return proxy.TrapDeleteProperty(proxyKey, this);
-        }
-
-        // Handle symbol keys
-        if (key is SharpTSSymbol symbol)
-        {
-            return obj switch
-            {
-                SharpTSObject tsObj => tsObj.DeleteBySymbolStrict(symbol, strictMode),
-                SharpTSInstance tsInst => tsInst.DeleteBySymbolStrict(symbol, strictMode),
-                _ => true
-            };
-        }
-
-        string keyStr = Stringify(key);
-
-        return obj switch
-        {
-            SharpTSObject tsObj => tsObj.DeletePropertyStrict(keyStr, strictMode),
-            SharpTSInstance tsInst => tsInst.DeleteFieldStrict(keyStr, strictMode),
-            Dictionary<string, object?> dict => dict.Remove(keyStr),
-            _ => true
-        };
-    }
-
-    /// <summary>
-    /// Async version of DeleteIndexedProperty.
-    /// In strict mode, throws TypeError for frozen/sealed objects.
-    /// </summary>
-    private async Task<bool> DeleteIndexedPropertyAsync(Expr.GetIndex getIndex, bool strictMode)
-    {
-        object? obj = (await EvaluateAsync(getIndex.Object)).ToObject();
-        object? key = (await EvaluateAsync(getIndex.Index)).ToObject();
+        object? obj = (await ctx.EvaluateExprAsync(getIndex.Object)).ToObject();
+        object? key = (await ctx.EvaluateExprAsync(getIndex.Index)).ToObject();
 
         // Handle proxy
         if (obj is SharpTSProxy proxy)

--- a/Execution/Interpreter.Properties.cs
+++ b/Execution/Interpreter.Properties.cs
@@ -1012,15 +1012,6 @@ public partial class Interpreter
     }
 
     /// <summary>
-    /// Evaluates property access on a class instance.
-    /// </summary>
-    private object? EvaluateGetOnInstance(SharpTSInstance instance, Token memberName)
-    {
-        instance.SetInterpreter(this);
-        return instance.Get(memberName);
-    }
-
-    /// <summary>
     /// Evaluates property access on a class instance, returning RuntimeValue directly.
     /// </summary>
     private RuntimeValue EvaluateGetOnInstanceRV(SharpTSInstance instance, Token memberName)

--- a/Execution/Interpreter.Properties.cs
+++ b/Execution/Interpreter.Properties.cs
@@ -471,6 +471,13 @@ public partial class Interpreter
     /// <seealso href="https://www.typescriptlang.org/docs/handbook/2/objects.html">TypeScript Object Types</seealso>
     /// <seealso href="https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#optional-chaining">TypeScript Optional Chaining</seealso>
     private RuntimeValue EvaluateGet(Expr.Get get)
+        => EvaluateGetCore(_syncContext, get).GetAwaiter().GetResult();
+
+    /// <summary>
+    /// Core property-access logic shared by the sync and async evaluators; the evaluation
+    /// context supplies the receiver-evaluation strategy so a single body serves both paths.
+    /// </summary>
+    private async ValueTask<RuntimeValue> EvaluateGetCore(IEvaluationContext ctx, Expr.Get get)
     {
         // Handle namespace static property access (e.g., Number.MAX_VALUE, Number.NaN)
         // These namespaces don't have runtime values, but have static properties.
@@ -498,7 +505,7 @@ public partial class Interpreter
             }
         }
 
-        object? obj = Evaluate(get.Object);
+        object? obj = (await ctx.EvaluateExprAsync(get.Object)).ToObject();
         return EvaluateGetOnObject(get, obj);
     }
 
@@ -1468,9 +1475,15 @@ public partial class Interpreter
     /// </remarks>
     /// <seealso href="https://www.typescriptlang.org/docs/handbook/2/objects.html">TypeScript Object Types</seealso>
     private RuntimeValue EvaluateSet(Expr.Set set)
+        => EvaluateSetCore(_syncContext, set).GetAwaiter().GetResult();
+
+    /// <summary>
+    /// Core property-assignment logic shared by the sync and async evaluators.
+    /// </summary>
+    private async ValueTask<RuntimeValue> EvaluateSetCore(IEvaluationContext ctx, Expr.Set set)
     {
-        object? obj = Evaluate(set.Object);
-        object? value = Evaluate(set.Value);
+        object? obj = (await ctx.EvaluateExprAsync(set.Object)).ToObject();
+        object? value = (await ctx.EvaluateExprAsync(set.Value)).ToObject();
         return EvaluateSetOnObjectRV(set, obj, value);
     }
 

--- a/Execution/Interpreter.Statements.cs
+++ b/Execution/Interpreter.Statements.cs
@@ -1282,26 +1282,24 @@ public partial class Interpreter
     }
 
     /// <summary>
-    /// Core while loop execution logic for synchronous execution.
+    /// Core while-loop execution logic shared by the sync and async evaluators. The evaluation
+    /// context supplies the condition/body evaluation strategy so a single body serves both paths,
+    /// replacing the former lambda-based sync core and the hand-copied async twin.
     /// Uses HandleLoopResult for consistent break/continue handling.
     /// </summary>
-    /// <param name="evaluateCondition">Function to evaluate the loop condition.</param>
-    /// <param name="executeBody">Function to execute the loop body.</param>
-    /// <param name="labels">Labels wrapping this loop, for labeled break/continue support.</param>
-    /// <returns>The execution result (Success or propagated abrupt completion).</returns>
-    private ExecutionResult ExecuteWhileCore(
-        Func<bool> evaluateCondition,
-        Func<ExecutionResult> executeBody,
+    private async ValueTask<ExecutionResult> ExecuteWhileCore(
+        IEvaluationContext ctx,
+        Stmt.While whileStmt,
         IReadOnlyList<string>? labels = null)
     {
-        while (evaluateCondition())
+        while ((await ctx.EvaluateExprAsync(whileStmt.Condition)).IsTruthy())
         {
             // Check vm timeout token on each loop iteration
             if (_vmTimeoutToken.IsCancellationRequested)
                 throw new Runtime.Exceptions.ThrowException(
                     new Runtime.Types.SharpTSError("Script execution timed out."));
 
-            var result = executeBody();
+            var result = await ctx.ExecuteStmtAsync(whileStmt.Body);
             var (shouldBreak, shouldContinue, abruptResult) = HandleLoopResult(result, labels);
             if (shouldBreak) return ExecutionResult.Success();
             if (shouldContinue) continue;
@@ -1311,6 +1309,28 @@ public partial class Interpreter
             // and we execute them here, avoiding thread scheduling issues on macOS.
             ProcessPendingCallbacks();
         }
+        return ExecutionResult.Success();
+    }
+
+    /// <summary>
+    /// Core do-while-loop execution logic shared by the sync and async evaluators; the body runs
+    /// at least once before the condition is tested.
+    /// </summary>
+    private async ValueTask<ExecutionResult> ExecuteDoWhileCore(
+        IEvaluationContext ctx,
+        Stmt.DoWhile doWhileStmt,
+        IReadOnlyList<string>? labels = null)
+    {
+        do
+        {
+            var result = await ctx.ExecuteStmtAsync(doWhileStmt.Body);
+            var (shouldBreak, shouldContinue, abruptResult) = HandleLoopResult(result, labels);
+            if (shouldBreak) return ExecutionResult.Success();
+            if (shouldContinue) continue;
+            if (abruptResult.HasValue) return abruptResult.Value;
+            // Process any pending timer callbacks
+            ProcessPendingCallbacks();
+        } while ((await ctx.EvaluateExprAsync(doWhileStmt.Condition)).IsTruthy());
         return ExecutionResult.Success();
     }
 

--- a/Execution/Interpreter.cs
+++ b/Execution/Interpreter.cs
@@ -2277,26 +2277,13 @@ public partial class Interpreter : IDisposable
     internal ExecutionResult VisitWhile(Stmt.While whileStmt)
     {
         var labels = TakePendingLoopLabels();
-        return ExecuteWhileCore(
-            () => IsTruthy(Evaluate(whileStmt.Condition)),
-            () => Execute(whileStmt.Body),
-            labels);
+        return ExecuteWhileCore(_syncContext, whileStmt, labels).GetAwaiter().GetResult();
     }
 
     internal ExecutionResult VisitDoWhile(Stmt.DoWhile doWhileStmt)
     {
         var labels = TakePendingLoopLabels();
-        do
-        {
-            var result = Execute(doWhileStmt.Body);
-            var (shouldBreak, shouldContinue, abruptResult) = HandleLoopResult(result, labels);
-            if (shouldBreak) return ExecutionResult.Success();
-            if (shouldContinue) continue;
-            if (abruptResult.HasValue) return abruptResult.Value;
-            // Process any pending timer callbacks
-            ProcessPendingCallbacks();
-        } while (IsTruthy(Evaluate(doWhileStmt.Condition)));
-        return ExecutionResult.Success();
+        return ExecuteDoWhileCore(_syncContext, doWhileStmt, labels).GetAwaiter().GetResult();
     }
 
     internal ExecutionResult VisitFor(Stmt.For forStmt)
@@ -2304,6 +2291,16 @@ public partial class Interpreter : IDisposable
         // Drain labels parked by an enclosing labeled statement before running the initializer,
         // so `continue <label>`/`break <label>` resolve to this loop (#558).
         var labels = TakePendingLoopLabels();
+        return ExecuteForCore(_syncContext, forStmt, labels).GetAwaiter().GetResult();
+    }
+
+    /// <summary>
+    /// Core C-style for-loop execution logic shared by the sync and async evaluators. The evaluation
+    /// context supplies the per-clause evaluation strategy and the between-iteration scheduler yield
+    /// (<see cref="IEvaluationContext.YieldToSchedulerAsync"/>), so a single body serves both paths.
+    /// </summary>
+    private async ValueTask<ExecutionResult> ExecuteForCore(IEvaluationContext ctx, Stmt.For forStmt, IReadOnlyList<string>? labels)
+    {
         // Create scope for loop variables (ES6 let/const block scoping)
         // Variables declared with let/const in the initializer are scoped to the loop
         RuntimeEnvironment loopEnv = new(_environment);
@@ -2311,7 +2308,7 @@ public partial class Interpreter : IDisposable
         {
             // Execute initializer once (defines loop variable in loopEnv)
             if (forStmt.Initializer != null)
-                Execute(forStmt.Initializer);
+                await ctx.ExecuteStmtAsync(forStmt.Initializer);
             // ECMA-262 13.7.4: a `for (let/const …)` loop gives each iteration its
             // own bindings for the loop variables, so closures created in different
             // iterations capture distinct values (#633). `var`/expression
@@ -2320,9 +2317,9 @@ public partial class Interpreter : IDisposable
             if (perIterationNames != null)
                 CreatePerIterationEnvironment(loopEnv, perIterationNames);
             // Loop with proper continue handling - increment always runs
-            while (forStmt.Condition == null || IsTruthy(Evaluate(forStmt.Condition)))
+            while (forStmt.Condition == null || (await ctx.EvaluateExprAsync(forStmt.Condition)).IsTruthy())
             {
-                var result = Execute(forStmt.Body);
+                var result = await ctx.ExecuteStmtAsync(forStmt.Body);
                 var (shouldBreak, shouldContinue, abruptResult) = HandleLoopResult(result, labels);
                 if (shouldBreak) break;
                 // On continue (unlabeled or to this loop), execute increment then re-test
@@ -2331,9 +2328,9 @@ public partial class Interpreter : IDisposable
                     if (perIterationNames != null)
                         CreatePerIterationEnvironment(loopEnv, perIterationNames);
                     if (forStmt.Increment != null)
-                        Evaluate(forStmt.Increment);
+                        await ctx.EvaluateExprAsync(forStmt.Increment);
                     // Yield to allow timer callbacks and other threads to execute
-                    Thread.Sleep(0);
+                    await ctx.YieldToSchedulerAsync();
                     continue;
                 }
                 if (abruptResult.HasValue) return abruptResult.Value;
@@ -2341,7 +2338,7 @@ public partial class Interpreter : IDisposable
                 if (perIterationNames != null)
                     CreatePerIterationEnvironment(loopEnv, perIterationNames);
                 if (forStmt.Increment != null)
-                    Evaluate(forStmt.Increment);
+                    await ctx.EvaluateExprAsync(forStmt.Increment);
                 // Process any pending timer callbacks
                 ProcessPendingCallbacks();
             }

--- a/Execution/Interpreter.cs
+++ b/Execution/Interpreter.cs
@@ -1260,8 +1260,6 @@ public partial class Interpreter : IDisposable
         _locals[expr] = depth;
     }
 
-    private object? LookupVariable(Token name, Expr expr) => LookupVariableRV(name, expr).ToObject();
-
     /// <summary>
     /// Looks up a variable and returns its value as RuntimeValue without boxing.
     /// This is the fast path for variable access in expressions.

--- a/Parsing/AST.cs
+++ b/Parsing/AST.cs
@@ -327,7 +327,7 @@ public abstract record Stmt
     /// (defaulting to <c>undefined</c>) so <c>this</c> inside the body resolves (#775).
     /// </summary>
     public record Function(Token Name, List<TypeParam>? TypeParams, string? ThisType, List<Parameter> Parameters, List<Stmt>? Body, string? ReturnType, bool IsStatic = false, AccessModifier Access = AccessModifier.Public, bool IsAbstract = false, bool IsOverride = false, bool IsAsync = false, bool IsGenerator = false, List<Decorator>? Decorators = null, bool IsPrivate = false, bool IsDeclare = false, Expr? ComputedKey = null, bool HasDynamicThis = false) : Stmt;
-    public record Parameter(Token Name, string? Type, Expr? DefaultValue = null, bool IsRest = false, bool IsParameterProperty = false, AccessModifier? Access = null, bool IsReadonly = false, bool IsOptional = false, List<Decorator>? Decorators = null);
+    public record Parameter(Token Name, string? Type, Expr? DefaultValue = null, bool IsRest = false, bool IsParameterProperty = false, AccessModifier? Access = null, bool IsReadonly = false, bool IsOptional = false, List<Decorator>? Decorators = null, TypeNode? TypeAnnotationNode = null);
     /// <summary>
     /// Class field declaration. For computed property names (e.g., [Symbol("key")]: type),
     /// ComputedKey contains the expression and Name is a synthetic token.
@@ -337,7 +337,7 @@ public abstract record Stmt
     /// Getter/setter declaration. For computed accessor names (e.g., static get [Symbol.species]()),
     /// ComputedKey contains the expression and Name is a synthetic token.
     /// </summary>
-    public record Accessor(Token Name, Token Kind, Parameter? SetterParam, List<Stmt> Body, string? ReturnType, AccessModifier Access = AccessModifier.Public, bool IsAbstract = false, bool IsOverride = false, List<Decorator>? Decorators = null, bool IsStatic = false, Expr? ComputedKey = null) : Stmt;
+    public record Accessor(Token Name, Token Kind, Parameter? SetterParam, List<Stmt> Body, string? ReturnType, AccessModifier Access = AccessModifier.Public, bool IsAbstract = false, bool IsOverride = false, List<Decorator>? Decorators = null, bool IsStatic = false, Expr? ComputedKey = null, TypeNode? ReturnTypeNode = null) : Stmt;
     /// <summary>
     /// Auto-accessor field declaration (TypeScript 4.9+): accessor name: Type = initializer
     /// Automatically generates a private backing field with implicit getter/setter.
@@ -385,11 +385,11 @@ public abstract record Stmt
     /// <param name="IsMethod">Declared with method syntax (<c>m(x): T</c>) rather than as a
     /// function-typed property — method members keep bivariant parameter relating under
     /// strictFunctionTypes.</param>
-    public record InterfaceMember(Token Name, string Type, bool IsOptional = false, bool IsReadonly = false, bool IsMethod = false);
+    public record InterfaceMember(Token Name, string Type, bool IsOptional = false, bool IsReadonly = false, bool IsMethod = false, TypeNode? TypeAnnotationNode = null);
     /// <summary>
     /// Index signature in interfaces: [key: string]: valueType, [key: number]: valueType, [key: symbol]: valueType
     /// </summary>
-    public record IndexSignature(Token KeyName, TokenType KeyType, string ValueType);
+    public record IndexSignature(Token KeyName, TokenType KeyType, string ValueType, TypeNode? ValueTypeNode = null);
     /// <summary>
     /// Call signature in interfaces: (params): ReturnType or &lt;T&gt;(params): ReturnType
     /// Indicates the interface represents a callable type (e.g., function).

--- a/Parsing/Parser.Classes.cs
+++ b/Parsing/Parser.Classes.cs
@@ -207,19 +207,23 @@ public partial class Parser
                     // Setter must have exactly one parameter
                     Token paramName = Consume(TokenType.IDENTIFIER, "Expect parameter name in setter.");
                     string? paramType = null;
+                    TypeNode? paramTypeNode = null;
                     if (Match(TokenType.COLON))
                     {
                         paramType = ParseTypeAnnotation();
+                        paramTypeNode = TakeTypeNode();
                     }
-                    setterParam = new Stmt.Parameter(paramName, paramType, null);
+                    setterParam = new Stmt.Parameter(paramName, paramType, null, TypeAnnotationNode: paramTypeNode);
                 }
 
                 Consume(TokenType.RIGHT_PAREN, "Expect ')' after accessor parameters.");
 
                 string? returnType = null;
+                TypeNode? returnTypeNode = null;
                 if (Match(TokenType.COLON))
                 {
                     returnType = ParseTypeAnnotation();
+                    returnTypeNode = TakeTypeNode();
                 }
 
                 List<Stmt> body;
@@ -235,7 +239,7 @@ public partial class Parser
                     body = Block();
                 }
 
-                accessors.Add(new Stmt.Accessor(accessorName, kind, setterParam, body, returnType, access, isMemberAbstract, isOverride, memberDecorators, isStatic, accessorComputedKey));
+                accessors.Add(new Stmt.Accessor(accessorName, kind, setterParam, body, returnType, access, isMemberAbstract, isOverride, memberDecorators, isStatic, accessorComputedKey, returnTypeNode));
             }
             // Check for private field: #name...
             else if (Peek().Type == TokenType.PRIVATE_IDENTIFIER)
@@ -566,8 +570,9 @@ public partial class Parser
         if (!Match(TokenType.COLON)) { _current = saved; return null; }
 
         string valueType = ParseTypeAnnotation();
+        TypeNode? valueTypeNode = TakeTypeNode();
         ConsumeSemicolon("Expect ';' after index signature.");
-        return new Stmt.IndexSignature(keyName, keyType, valueType);
+        return new Stmt.IndexSignature(keyName, keyType, valueType, valueTypeNode);
     }
 
     /// <summary>
@@ -767,25 +772,29 @@ public partial class Parser
                 {
                     Token paramName = Consume(TokenType.IDENTIFIER, "Expect parameter name in setter.");
                     string? paramType = null;
+                    TypeNode? paramTypeNode = null;
                     if (Match(TokenType.COLON))
                     {
                         paramType = ParseTypeAnnotation();
+                        paramTypeNode = TakeTypeNode();
                     }
-                    setterParam = new Stmt.Parameter(paramName, paramType, null);
+                    setterParam = new Stmt.Parameter(paramName, paramType, null, TypeAnnotationNode: paramTypeNode);
                 }
 
                 Consume(TokenType.RIGHT_PAREN, "Expect ')' after accessor parameters.");
 
                 string? returnType = null;
+                TypeNode? returnTypeNode = null;
                 if (Match(TokenType.COLON))
                 {
                     returnType = ParseTypeAnnotation();
+                    returnTypeNode = TakeTypeNode();
                 }
 
                 Consume(TokenType.LEFT_BRACE, "Expect '{' before accessor body.");
                 List<Stmt> body = Block();
 
-                accessors.Add(new Stmt.Accessor(accessorName, kind, setterParam, body, returnType, access, IsStatic: isStatic, ComputedKey: accessorComputedKey));
+                accessors.Add(new Stmt.Accessor(accessorName, kind, setterParam, body, returnType, access, IsStatic: isStatic, ComputedKey: accessorComputedKey, ReturnTypeNode: returnTypeNode));
             }
             // Check for private field/method: #name...
             else if (Peek().Type == TokenType.PRIVATE_IDENTIFIER)

--- a/Parsing/Parser.Declarations.cs
+++ b/Parsing/Parser.Declarations.cs
@@ -346,8 +346,9 @@ public partial class Parser
                     Consume(TokenType.COLON, "Expect ':' after computed member name.");
                     computedType = ParseTypeAnnotation();
                 }
+                TypeNode? computedTypeNode = TakeTypeNode();
                 ConsumeInterfaceMemberSeparator();
-                members.Add(new Stmt.InterfaceMember(computedTok, computedType, computedOptional, computedReadonly, computedIsMethod));
+                members.Add(new Stmt.InterfaceMember(computedTok, computedType, computedOptional, computedReadonly, computedIsMethod, computedTypeNode));
                 continue;
             }
 
@@ -371,9 +372,10 @@ public partial class Parser
                 Consume(TokenType.COLON, "Expect ':' after member name.");
                 type = ParseTypeAnnotation();
             }
+            TypeNode? memberTypeNode = TakeTypeNode();
 
             ConsumeInterfaceMemberSeparator();
-            members.Add(new Stmt.InterfaceMember(memberName, type, isOptional, isReadonly, isMethod));
+            members.Add(new Stmt.InterfaceMember(memberName, type, isOptional, isReadonly, isMethod, memberTypeNode));
         }
 
         Consume(TokenType.RIGHT_BRACE, "Expect '}' after interface body.");
@@ -595,9 +597,10 @@ public partial class Parser
         }
 
         string valueType = ParseTypeAnnotation();
+        TypeNode? valueTypeNode = TakeTypeNode();
         ConsumeInterfaceMemberSeparator();
 
-        return new Stmt.IndexSignature(keyName, keyType, valueType);
+        return new Stmt.IndexSignature(keyName, keyType, valueType, valueTypeNode);
     }
 
     /// <summary>

--- a/Runtime/BuiltIns/ArrayBuiltIns.cs
+++ b/Runtime/BuiltIns/ArrayBuiltIns.cs
@@ -1048,28 +1048,20 @@ public static class ArrayBuiltIns
     // ===================== V2 Wrappers (RuntimeValue boundary) =====================
 
     private static RuntimeValue FlatV2(Interpreter interp, SharpTSArray arr, ReadOnlySpan<RuntimeValue> args)
-        => RuntimeValue.FromBoxed(Flat(interp, arr, SpanToList(args)));
+        => RuntimeValue.FromBoxed(Flat(interp, arr, CallableInterop.ToBoxedList(args)));
 
     private static RuntimeValue FlatMapV2(Interpreter interp, SharpTSArray arr, ReadOnlySpan<RuntimeValue> args)
-        => RuntimeValue.FromBoxed(FlatMap(interp, arr, SpanToList(args)));
+        => RuntimeValue.FromBoxed(FlatMap(interp, arr, CallableInterop.ToBoxedList(args)));
 
     private static RuntimeValue SortV2(Interpreter interp, SharpTSArray arr, ReadOnlySpan<RuntimeValue> args)
-        => RuntimeValue.FromBoxed(Sort(interp, arr, SpanToList(args)));
+        => RuntimeValue.FromBoxed(Sort(interp, arr, CallableInterop.ToBoxedList(args)));
 
     private static RuntimeValue ToSortedV2(Interpreter interp, SharpTSArray arr, ReadOnlySpan<RuntimeValue> args)
-        => RuntimeValue.FromBoxed(ToSorted(interp, arr, SpanToList(args)));
+        => RuntimeValue.FromBoxed(ToSorted(interp, arr, CallableInterop.ToBoxedList(args)));
 
     private static RuntimeValue SpliceV2(Interpreter interp, SharpTSArray arr, ReadOnlySpan<RuntimeValue> args)
-        => RuntimeValue.FromBoxed(Splice(interp, arr, SpanToList(args)));
+        => RuntimeValue.FromBoxed(Splice(interp, arr, CallableInterop.ToBoxedList(args)));
 
     private static RuntimeValue ToSplicedV2(Interpreter interp, SharpTSArray arr, ReadOnlySpan<RuntimeValue> args)
-        => RuntimeValue.FromBoxed(ToSpliced(interp, arr, SpanToList(args)));
-
-    private static List<object?> SpanToList(ReadOnlySpan<RuntimeValue> args)
-    {
-        var list = new List<object?>(args.Length);
-        foreach (var arg in args)
-            list.Add(arg.ToObject());
-        return list;
-    }
+        => RuntimeValue.FromBoxed(ToSpliced(interp, arr, CallableInterop.ToBoxedList(args)));
 }

--- a/Runtime/BuiltIns/BuiltInMethod.cs
+++ b/Runtime/BuiltIns/BuiltInMethod.cs
@@ -21,7 +21,10 @@ public class BuiltInMethod : ISharpTSCallable
     private readonly string _name;
     private readonly int _minArity;
     private readonly int _maxArity;
-    private readonly Func<Interpreter, object?, List<object?>, object?> _implementation;
+    // Legacy boxed implementation. For V2-only built-ins this stays null and is built
+    // lazily on the first boxed Call() (the rare reflective standalone-DLL path) — see
+    // GetLegacyImplementation. At least one of _implementation/_implementationV2 is non-null.
+    private Func<Interpreter, object?, List<object?>, object?>? _implementation;
     private readonly Func<Interpreter, RuntimeValue, ReadOnlySpan<RuntimeValue>, RuntimeValue>? _implementationV2;
     private object? _receiver;
     // Spec-defined Function.prototype.length value visible to user code as
@@ -74,10 +77,13 @@ public class BuiltInMethod : ISharpTSCallable
     /// </summary>
     public bool HasV2Implementation => _implementationV2 != null;
 
-    public BuiltInMethod(string name, int arity, Func<Interpreter, object?, List<object?>, object?> implementation)
+    // Boxed-delegate constructors. The legacy delegate type survives only as plumbing
+    // (CreateConstant + the reflective standalone-DLL Call path), so these are not part of
+    // the public surface — they exist for the dispatcher tests, which have InternalsVisibleTo.
+    internal BuiltInMethod(string name, int arity, Func<Interpreter, object?, List<object?>, object?> implementation)
         : this(name, arity, arity, implementation) { }
 
-    public BuiltInMethod(string name, int minArity, int maxArity, Func<Interpreter, object?, List<object?>, object?> implementation)
+    internal BuiltInMethod(string name, int minArity, int maxArity, Func<Interpreter, object?, List<object?>, object?> implementation)
         : this(name, minArity, maxArity, implementation, isConstant: false) { }
 
     /// <summary>
@@ -114,8 +120,7 @@ public class BuiltInMethod : ISharpTSCallable
         _minArity = arity;
         _maxArity = arity;
         _implementationV2 = implementation;
-        // Create a legacy wrapper
-        _implementation = WrapV2Implementation(implementation);
+        // Legacy wrapper is built lazily on first boxed Call() — see GetLegacyImplementation.
     }
 
     /// <summary>
@@ -157,17 +162,14 @@ public class BuiltInMethod : ISharpTSCallable
         _name = name;
         _minArity = minArity;
         _maxArity = maxArity;
-        // If only V2 is provided, create the legacy wrapper
-        if (implementation == null && implementationV2 != null)
+        if (implementation == null && implementationV2 == null)
         {
-            _implementationV2 = implementationV2;
-            _implementation = WrapV2Implementation(implementationV2);
+            throw new ArgumentNullException(nameof(implementation));
         }
-        else
-        {
-            _implementation = implementation ?? throw new ArgumentNullException(nameof(implementation));
-            _implementationV2 = implementationV2;
-        }
+        // For V2-only methods _implementation stays null and is built lazily on first
+        // boxed Call() (see GetLegacyImplementation).
+        _implementation = implementation;
+        _implementationV2 = implementationV2;
         _receiver = receiver;
         // Bound instances don't have their own cache
     }
@@ -234,7 +236,7 @@ public class BuiltInMethod : ISharpTSCallable
         {
             throw new Exception($"Runtime Error: '{_name}' expects {_minArity}-{_maxArity} arguments but got {arguments.Count}.");
         }
-        return _implementation(interpreter, _receiver, arguments);
+        return GetLegacyImplementation()(interpreter, _receiver, arguments);
     }
 
     /// <summary>
@@ -260,9 +262,19 @@ public class BuiltInMethod : ISharpTSCallable
             boxedArgs.Add(arg.ToObject());
         }
 
-        var result = _implementation(interpreter, _receiver, boxedArgs);
+        var result = GetLegacyImplementation()(interpreter, _receiver, boxedArgs);
         return RuntimeValue.FromBoxed(result);
     }
+
+    /// <summary>
+    /// Returns the legacy boxed implementation, building it lazily from the V2 implementation
+    /// on first use. Only the rare boxed <see cref="Call"/> path (reflectively invoked from
+    /// standalone compiled DLLs) needs it, so V2-only built-ins avoid allocating the wrapper
+    /// closure until then. The wrapper is stateless, so a benign race that builds it twice is
+    /// harmless.
+    /// </summary>
+    private Func<Interpreter, object?, List<object?>, object?> GetLegacyImplementation()
+        => _implementation ??= WrapV2Implementation(_implementationV2!);
 
     /// <summary>
     /// Creates a legacy wrapper for a V2 implementation.

--- a/Runtime/BuiltIns/IteratorBuiltIns.cs
+++ b/Runtime/BuiltIns/IteratorBuiltIns.cs
@@ -295,11 +295,7 @@ public static class IteratorBuiltIns
         => RuntimeValue.FromBoxed(FlatMap(interp, iter, [args[0].ToObject()]));
 
     private static RuntimeValue ReduceV2(Interpreter interp, SharpTSIterator iter, ReadOnlySpan<RuntimeValue> args)
-    {
-        var list = new List<object?>(args.Length);
-        foreach (var arg in args) list.Add(arg.ToObject());
-        return RuntimeValue.FromBoxed(Reduce(interp, iter, list));
-    }
+        => RuntimeValue.FromBoxed(Reduce(interp, iter, CallableInterop.ToBoxedList(args)));
 
     private static RuntimeValue ToArrayV2(Interpreter interp, SharpTSIterator iter, ReadOnlySpan<RuntimeValue> args)
         => RuntimeValue.FromBoxed(ToArray(interp, iter, []));

--- a/Runtime/BuiltIns/ObjectBuiltIns.cs
+++ b/Runtime/BuiltIns/ObjectBuiltIns.cs
@@ -2082,49 +2082,41 @@ public static class ObjectBuiltIns
     // ===================== V2 Wrappers (RuntimeValue boundary — delegates to internal logic) =====================
 
     private static RuntimeValue FromEntriesV2(Interpreter interp, RuntimeValue recv, ReadOnlySpan<RuntimeValue> args)
-        => RuntimeValue.FromBoxed(FromEntries(interp, SpanToList(args)));
+        => RuntimeValue.FromBoxed(FromEntries(interp, CallableInterop.ToBoxedList(args)));
 
     private static RuntimeValue AssignV2(Interpreter interp, RuntimeValue recv, ReadOnlySpan<RuntimeValue> args)
-        => RuntimeValue.FromBoxed(Assign(interp, SpanToList(args)));
+        => RuntimeValue.FromBoxed(Assign(interp, CallableInterop.ToBoxedList(args)));
 
     private static RuntimeValue DefinePropertyV2(Interpreter interp, RuntimeValue recv, ReadOnlySpan<RuntimeValue> args)
-        => RuntimeValue.FromBoxed(DefineProperty(interp, SpanToList(args)));
+        => RuntimeValue.FromBoxed(DefineProperty(interp, CallableInterop.ToBoxedList(args)));
 
     private static RuntimeValue GetOwnPropertyDescriptorV2(Interpreter interp, RuntimeValue recv, ReadOnlySpan<RuntimeValue> args)
-        => RuntimeValue.FromBoxed(GetOwnPropertyDescriptor(interp, SpanToList(args)));
+        => RuntimeValue.FromBoxed(GetOwnPropertyDescriptor(interp, CallableInterop.ToBoxedList(args)));
 
     private static RuntimeValue GetOwnPropertyNamesV2(Interpreter interp, RuntimeValue recv, ReadOnlySpan<RuntimeValue> args)
-        => RuntimeValue.FromBoxed(GetOwnPropertyNames(interp, SpanToList(args)));
+        => RuntimeValue.FromBoxed(GetOwnPropertyNames(interp, CallableInterop.ToBoxedList(args)));
 
     private static RuntimeValue CreateV2(Interpreter interp, RuntimeValue recv, ReadOnlySpan<RuntimeValue> args)
-        => RuntimeValue.FromBoxed(Create(interp, SpanToList(args)));
+        => RuntimeValue.FromBoxed(Create(interp, CallableInterop.ToBoxedList(args)));
 
     private static RuntimeValue PreventExtensionsV2(Interpreter interp, RuntimeValue recv, ReadOnlySpan<RuntimeValue> args)
-        => RuntimeValue.FromBoxed(PreventExtensions(interp, SpanToList(args)));
+        => RuntimeValue.FromBoxed(PreventExtensions(interp, CallableInterop.ToBoxedList(args)));
 
     private static RuntimeValue IsExtensibleMethodV2(Interpreter interp, RuntimeValue recv, ReadOnlySpan<RuntimeValue> args)
-        => RuntimeValue.FromBoxed(IsExtensibleMethod(interp, SpanToList(args)));
+        => RuntimeValue.FromBoxed(IsExtensibleMethod(interp, CallableInterop.ToBoxedList(args)));
 
     private static RuntimeValue GetOwnPropertySymbolsV2(Interpreter interp, RuntimeValue recv, ReadOnlySpan<RuntimeValue> args)
-        => RuntimeValue.FromBoxed(GetOwnPropertySymbols(interp, SpanToList(args)));
+        => RuntimeValue.FromBoxed(GetOwnPropertySymbols(interp, CallableInterop.ToBoxedList(args)));
 
     private static RuntimeValue SetPrototypeOfV2(Interpreter interp, RuntimeValue recv, ReadOnlySpan<RuntimeValue> args)
-        => RuntimeValue.FromBoxed(SetPrototypeOf(interp, SpanToList(args)));
+        => RuntimeValue.FromBoxed(SetPrototypeOf(interp, CallableInterop.ToBoxedList(args)));
 
     private static RuntimeValue GroupByV2(Interpreter interp, RuntimeValue recv, ReadOnlySpan<RuntimeValue> args)
-        => RuntimeValue.FromBoxed(GroupBy(interp, SpanToList(args)));
+        => RuntimeValue.FromBoxed(GroupBy(interp, CallableInterop.ToBoxedList(args)));
 
     private static RuntimeValue DefinePropertiesV2(Interpreter interp, RuntimeValue recv, ReadOnlySpan<RuntimeValue> args)
-        => RuntimeValue.FromBoxed(DefineProperties(interp, SpanToList(args)));
+        => RuntimeValue.FromBoxed(DefineProperties(interp, CallableInterop.ToBoxedList(args)));
 
     private static RuntimeValue GetOwnPropertyDescriptorsV2(Interpreter interp, RuntimeValue recv, ReadOnlySpan<RuntimeValue> args)
-        => RuntimeValue.FromBoxed(GetOwnPropertyDescriptors(interp, SpanToList(args)));
-
-    private static List<object?> SpanToList(ReadOnlySpan<RuntimeValue> args)
-    {
-        var list = new List<object?>(args.Length);
-        foreach (var arg in args)
-            list.Add(arg.ToObject());
-        return list;
-    }
+        => RuntimeValue.FromBoxed(GetOwnPropertyDescriptors(interp, CallableInterop.ToBoxedList(args)));
 }

--- a/Runtime/RuntimeEnvironment.cs
+++ b/Runtime/RuntimeEnvironment.cs
@@ -37,11 +37,6 @@ public class RuntimeEnvironment : ScopeChain<RuntimeValue, RuntimeEnvironment>
     }
 
     /// <summary>
-    /// Gets a variable as object? for legacy callers.
-    /// </summary>
-    public object? GetBoxed(Token name) => Get(name).ToObject();
-
-    /// <summary>
     /// Attempts to get a variable value in a single scope chain traversal.
     /// </summary>
     public bool TryGet(string name, out RuntimeValue value)
@@ -90,11 +85,6 @@ public class RuntimeEnvironment : ScopeChain<RuntimeValue, RuntimeEnvironment>
     {
         return Ancestor(distance)._values.GetValueOrDefault(name);
     }
-
-    /// <summary>
-    /// Gets a variable as object? at a specific scope distance (legacy).
-    /// </summary>
-    public object? GetAtBoxed(int distance, string name) => GetAt(distance, name).ToObject();
 
     /// <summary>
     /// Assigns a variable at a specific scope distance.

--- a/Runtime/Types/CallableInterop.cs
+++ b/Runtime/Types/CallableInterop.cs
@@ -34,7 +34,12 @@ public static class CallableInterop
         return values;
     }
 
-    /// <summary>Converts a RuntimeValue span to a boxed argument list.</summary>
+    /// <summary>
+    /// Converts a RuntimeValue span to a boxed argument list. This is the single shared
+    /// span→boxed-list helper for the built-in V2 shims (Object/Array/Iterator) whose legacy
+    /// bodies still consume <c>List&lt;object?&gt;</c>; it replaces the per-file <c>SpanToList</c>
+    /// copies that previously duplicated it.
+    /// </summary>
     public static List<object?> ToBoxedList(ReadOnlySpan<RuntimeValue> arguments)
     {
         var boxed = new List<object?>(arguments.Length);

--- a/TypeSystem/TypeChecker.Expressions.cs
+++ b/TypeSystem/TypeChecker.Expressions.cs
@@ -2017,14 +2017,14 @@ public partial class TypeChecker
                     if (accessor.Kind.Type == TokenType.GET)
                     {
                         TypeInfo getterRetType = accessor.ReturnType != null
-                            ? ToTypeInfo(accessor.ReturnType)
+                            ? ResolveAnnotation(accessor.ReturnType, accessor.ReturnTypeNode)!
                             : new TypeInfo.Any();
                         mutableClass.Getters[propName] = getterRetType;
                     }
                     else
                     {
                         TypeInfo paramType = accessor.SetterParam?.Type != null
-                            ? ToTypeInfo(accessor.SetterParam.Type)
+                            ? ResolveAnnotation(accessor.SetterParam.Type, accessor.SetterParam.TypeAnnotationNode)!
                             : new TypeInfo.Any();
                         mutableClass.Setters[propName] = paramType;
                     }

--- a/TypeSystem/TypeChecker.Statements.Classes.cs
+++ b/TypeSystem/TypeChecker.Statements.Classes.cs
@@ -79,7 +79,7 @@ public partial class TypeChecker
         {
             foreach (var indexSig in classStmt.IndexSignatures)
             {
-                TypeInfo valueType = ToTypeInfo(indexSig.ValueType);
+                TypeInfo valueType = ResolveAnnotation(indexSig.ValueType, indexSig.ValueTypeNode)!;
                 switch (indexSig.KeyType)
                 {
                     case TokenType.TYPE_STRING: mutableClass.StringIndexType = valueType; break;
@@ -306,7 +306,7 @@ public partial class TypeChecker
                 if (accessor.Kind.Type == TokenType.GET)
                 {
                     TypeInfo getterRetType = accessor.ReturnType != null
-                        ? ToTypeInfo(accessor.ReturnType)
+                        ? ResolveAnnotation(accessor.ReturnType, accessor.ReturnTypeNode)!
                         : new TypeInfo.Any();
                     mutableClass.Getters[propName] = getterRetType;
 
@@ -319,7 +319,7 @@ public partial class TypeChecker
                 else // SET
                 {
                     TypeInfo paramType = accessor.SetterParam?.Type != null
-                        ? ToTypeInfo(accessor.SetterParam.Type)
+                        ? ResolveAnnotation(accessor.SetterParam.Type, accessor.SetterParam.TypeAnnotationNode)!
                         : new TypeInfo.Any();
                     mutableClass.Setters[propName] = paramType;
 
@@ -885,7 +885,7 @@ public partial class TypeChecker
                         // Computed-name accessors aren't registered in Getters/Setters
                         // (no static member name); derive types from the declaration.
                         accessorReturnType = accessor.ComputedKey != null
-                            ? (accessor.ReturnType != null ? ToTypeInfo(accessor.ReturnType) : new TypeInfo.Any())
+                            ? (accessor.ReturnType != null ? ResolveAnnotation(accessor.ReturnType, accessor.ReturnTypeNode)! : new TypeInfo.Any())
                             : classTypeForBody.Getters[accessor.Name.Lexeme];
                     }
                     else
@@ -896,7 +896,7 @@ public partial class TypeChecker
                         if (accessor.SetterParam != null)
                         {
                             TypeInfo setterParamType = accessor.ComputedKey != null
-                                ? (accessor.SetterParam.Type != null ? ToTypeInfo(accessor.SetterParam.Type) : new TypeInfo.Any())
+                                ? (accessor.SetterParam.Type != null ? ResolveAnnotation(accessor.SetterParam.Type, accessor.SetterParam.TypeAnnotationNode)! : new TypeInfo.Any())
                                 : classTypeForBody.Setters[accessor.Name.Lexeme];
                             accessorEnv.Define(accessor.SetterParam.Name.Lexeme, setterParamType);
                         }
@@ -1149,7 +1149,7 @@ public partial class TypeChecker
         {
             foreach (var indexSig in classStmt.IndexSignatures)
             {
-                TypeInfo valueType = ToTypeInfo(indexSig.ValueType);
+                TypeInfo valueType = ResolveAnnotation(indexSig.ValueType, indexSig.ValueTypeNode)!;
                 switch (indexSig.KeyType)
                 {
                     case TokenType.TYPE_STRING: mutableClass.StringIndexType = valueType; break;
@@ -1259,7 +1259,7 @@ public partial class TypeChecker
                 }
 
                 TypeInfo accessorType = accessor.ReturnType != null
-                    ? ToTypeInfo(accessor.ReturnType)
+                    ? ResolveAnnotation(accessor.ReturnType, accessor.ReturnTypeNode)!
                     : new TypeInfo.Any();
 
                 if (accessor.Kind.Type == TokenType.GET)

--- a/TypeSystem/TypeChecker.Statements.Interfaces.cs
+++ b/TypeSystem/TypeChecker.Statements.Interfaces.cs
@@ -74,7 +74,7 @@ public partial class TypeChecker
             {
                 try
                 {
-                    var memberType = ToTypeInfo(member.Type);
+                    var memberType = ResolveAnnotation(member.Type, member.TypeAnnotationNode)!;
 
                     // Check if this is a duplicate member name (overload)
                     if (members.TryGetValue(member.Name.Lexeme, out var existingType))
@@ -232,7 +232,7 @@ public partial class TypeChecker
         {
         foreach (var member in interfaceStmt.Members)
         {
-            var memberType = ToTypeInfo(member.Type);
+            var memberType = ResolveAnnotation(member.Type, member.TypeAnnotationNode)!;
 
             // Check if this is a duplicate member name (overload)
             if (members.TryGetValue(member.Name.Lexeme, out var existingType))
@@ -290,7 +290,7 @@ public partial class TypeChecker
         {
             foreach (var indexSig in interfaceStmt.IndexSignatures)
             {
-                TypeInfo valueType = ToTypeInfo(indexSig.ValueType);
+                TypeInfo valueType = ResolveAnnotation(indexSig.ValueType, indexSig.ValueTypeNode)!;
                 switch (indexSig.KeyType)
                 {
                     case TokenType.TYPE_STRING:


### PR DESCRIPTION
Finishes the half-completed migrations that left two parallel implementations maintained in lockstep, then deletes the scaffolding. Epic #1089.

One commit per sub-issue. Every commit is green on `dotnet test` (14813/0), `SharpTS.Test262` (20/0), and `SharpTS.TypeScriptConformance` (31/0) — no baseline regression — and keeps interpreter and compiled output behaviourally identical.

## #1114 — migration tail cleanups ✅
- Delete the unreferenced boxed env accessors `RuntimeEnvironment.GetBoxed` / `.GetAtBoxed` (zero callers).
- Delete three orphaned boxed methods superseded by their `*RV` twins (`EvaluateVariable`, `LookupVariable(Token, Expr)`, `EvaluateGetOnInstance`) — all zero callers.
- Make the legacy boxed wrapper **lazy**: V2-only `BuiltInMethod`s no longer build the `WrapV2Implementation` closure at registration; it is built on first boxed `Call()` (the rare reflective standalone-DLL path) via `GetLegacyImplementation()`. The boxing-free `CallV2` fast path never allocates it.
- Demote the two test-only boxed `BuiltInMethod` constructors to `internal` (the boxed `Call` itself stays — it is live, reflectively invoked from standalone DLLs).

## #1110 — the `Call`→`CallV2` tail ✅
The ~33 "fake-V2" shims box every argument, call the legacy boxed body, and re-box the result. Their legacy bodies walk prototype/descriptor chains and invoke callbacks through the boxed `ISharpTSCallable.Call` surface, so they must stay boxed for now. The concrete removable tail — the **triplicated `SpanToList`** (`ObjectBuiltIns`, `ArrayBuiltIns`, the otherwise-dead `CallableInterop.ToBoxedList`, plus an inlined copy in `IteratorBuiltIns.ReduceV2`) — is collapsed into the single `CallableInterop.ToBoxedList`, which now has real production callers. (This is the issue's sanctioned fallback for shims that must stay boxed.)

## #1113 — delete the dead `EmittedRuntime` holders ✅
After the move to name-based runtime dispatch, many strongly-typed C# holders became vestigial. A per-property reference scan over the `Compilation/` surface (the only consumer; no reflection on these names) classified all 1972 auto-properties:
- **69 never assigned and never read** → deleted outright (the vestigial "TS"-prefixed typed-array / DataView / ArrayBuffer family that paralleled the live non-TS pure-IL family, plus MessagePort/Worker/MessageChannel/querystring/AES-GCM holders).
- **188 write-only** (assigned once, never read) → `runtime.X = …` becomes `_ = …`, preserving the `DefineMethod`/emit side effect while dropping the unused holder; declaration deleted. Includes the duplicate field pairs `PrototypeStoreField`/`PDSPrototypeStoreField` and `SymbolStorageField`/`PDSSymbolStorageField`.
- **1715 live** → untouched.

The C# build is the safety net: a holder that is actually read fails to compile when deleted, so the green solution build proves all 257 removed properties were truly dead. Every `DefineMethod` call is retained, so emitted IL is byte-identical. (The audit's "Atomics are write-only" claim was wrong — `AtomicsLoad` is read by `AtomicsStaticEmitter`; the data-driven classifier correctly kept it and 1714 others.)

## #1112 — sync→async evaluator unification ✅
The async evaluator was a second evaluator kept in lockstep with the sync one by hand. Adopt the `*Core(IEvaluationContext ctx)` pattern for the remaining nodes so one body serves both paths — the sync context evaluates inline (completed `ValueTask`), the async context awaits:
- **delete** — the issue's headline "6 near-identical methods" collapse to `DeleteCore` + `DeletePropertyCore` + `DeleteIndexedPropertyCore`.
- property get/set, indexed get/set, compound assignment (var/property/index), logical assignment (var/property/index).
- **while / do-while / for** — the lambda-based `ExecuteWhileCore` and the hand-copied async loop bodies become `ExecuteWhileCore`/`ExecuteDoWhileCore`/`ExecuteForCore(ctx)`. A new `IEvaluationContext.YieldToSchedulerAsync()` abstracts the between-iteration yield (sync `Thread.Sleep(0)` vs async `Task.Yield()`).

Unifying also removes latent async-only drift: async property-get now uses the realm-intrinsic-aware namespace check + `IsConstant` gate (Math identity, `Date.now` aliasing), and the async `while` loop now honours the vm-timeout token — both previously only on the sync path. `for-of`/`for-in` stay separate: their async paths are supersets (async iterators, `for await`), not hand-copies. **Net ~190 fewer lines.**

## #1111 — type-AST migration (slice 6) — partial ⚠️
**Not fully complete.** This sub-issue's completion criterion is *deleting the ~2,000-line string scanner*, which is the design doc's multi-PR slice 6 (`docs/plans/type-ast-design.md`, staged 6.1–6.6, each "independently shippable"). This PR ships a safe, verified increment of it:
- Three annotation-consumer groups flipped off `ToTypeInfo(string)` to node-first resolution via `ResolveAnnotation` (node path when the parser produced a `TypeNode`; string scanner only as fallback — behaviour identical): **index signatures**, **interface members** (property + method), and **get/set accessors** (getter return + setter parameter, in class declarations and class expressions).

**Deliberately left for follow-up** (so the type checker is not put at risk by a rushed broad refactor):
- The function/method-signature consumers (params/returns/`this`, parameter properties) — the largest and most intricate group (central `BuildFunctionSignature` + overload + hoisting machinery, many parser sites).
- The `SubstituteTypeParamInString` rendered-string round-trip.
- **The hard blocker to deleting the scanner at all:** the long-tail constructs the scanner still uniquely handles have no `TypeNode` yet — bigint literal types (`1n`), `this`-parameter generic/constructor types, `unique symbol` — and `ToTypeInfo(string)` must be reimplemented as parse-to-node + convert for the REPL/embedding surface before the scanner can go.

## Verification
| Suite | Result |
|---|---|
| `dotnet test` (solution) | 14813 passed, 0 failed |
| `SharpTS.Test262` | 20 passed, 0 failed (interp + compiled) |
| `SharpTS.TypeScriptConformance` | 31 passed, 0 failed |

Standalone compiled DLLs gain no `SharpTS.dll` dependency.

Closes #1110, #1112, #1113, #1114. Advances #1111 (does not close it).
