### PR TITLE
fix(worker_threads): close the terminate() unref-vs-continuation race

### DIFF
--- a/Runtime/Types/SharpTSWorker.cs
+++ b/Runtime/Types/SharpTSWorker.cs
@@ -761,7 +761,7 @@ public class SharpTSWorker : SharpTSEventEmitter, IDisposable
         // mode, #354); a no-op when neither is present.
         var loopUnref = _loopUnref;
         _loopRef?.Invoke();
-        var task = Task.Run<object?>(() =>
+        var joinTask = Task.Run<object?>(() =>
         {
             _thread.Join(5000); // Wait up to 5 seconds
             // Resolve with the worker's actual exit code (1 once the thread unwinds via
@@ -770,11 +770,43 @@ public class SharpTSWorker : SharpTSEventEmitter, IDisposable
             // documented ceiling.
             return (double)_exitCode;
         });
-        if (_loopRef != null && loopUnref != null)
-        {
-            task.ContinueWith(_ => loopUnref(), TaskScheduler.Default);
-        }
-        return new SharpTSPromise(task);
+
+        // No owning loop to keep alive (no interpreter and no emitted $EventLoop): nothing
+        // can race an Unref, so hand back the raw join promise unchanged.
+        if (_loopRef == null || loopUnref == null)
+            return new SharpTSPromise(joinTask);
+
+        // Settle the terminate() promise AND release the bounded join keep-alive atomically,
+        // inside a single callback delivered ON the event-loop thread, resolve-before-unref.
+        //
+        // Releasing the Ref on a bare thread-pool `ContinueWith(_ => loopUnref(),
+        // TaskScheduler.Default)` (the previous shape) let the Unref drop _activeHandles to 0
+        // — and WakeEventLoop the loop — on a pool thread the instant the join completed,
+        // racing delivery of the awaiting `await worker.terminate()` continuation (which the
+        // interpreter posts onto its callback queue via the loop SynchronizationContext). When
+        // the Unref won, the loop observed "no active handles AND empty callback queue" and
+        // exited before the continuation was enqueued, so a `console.log` after the await was
+        // silently dropped — an intermittent, load-sensitive failure of
+        // Worker_Terminate_WakesAtomicsWaitAndEmitsExitCode1 (the AdoptInnerPromise / #983
+        // race class; the emitted $EventLoop has the structurally identical race, so routing
+        // through ScheduleOnMainThread fixes both runtimes).
+        //
+        // On the loop thread, tcs.TrySetResult synchronously posts the await continuation onto
+        // the loop queue BEFORE loopUnref decrements the handle to 0, so the loop's exit check
+        // always sees pending work and cannot drop it. The join Ref keeps the loop alive until
+        // this callback runs; the join is bounded, so loopUnref always runs exactly once
+        // (balancing the _loopRef?.Invoke() above). Do not switch the TCS to
+        // RunContinuationsAsynchronously — that would decouple the post from the unref and
+        // reopen the race.
+        var tcs = new TaskCompletionSource<object?>();
+        joinTask.ContinueWith(
+            t => ScheduleOnMainThread(() =>
+            {
+                tcs.TrySetResult(t.Result);
+                loopUnref();
+            }),
+            TaskContinuationOptions.ExecuteSynchronously);
+        return new SharpTSPromise(tcs.Task);
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

Fixes the intermittent CI failure of `WorkerThreadsTests.Worker_Terminate_WakesAtomicsWaitAndEmitsExitCode1(mode: Interpreted)` (ubuntu-only). This is a **pre-existing race**, not a regression — it also fails on unrelated `main` commits, and most recently turned PR #1187 red.

Observed failure: output was exactly `"exit:1\n"` — the worker's `'exit'` event fired, but the `console.log("terminated")` after `await w.terminate()` was silently dropped.

## Root cause

`SharpTSWorker.Terminate()` released the bounded join keep-alive on a **thread-pool** `task.ContinueWith(_ => loopUnref(), TaskScheduler.Default)`. When the join completed, that `Unref` dropped `_activeHandles` to 0 (and woke the loop) on a pool thread, racing delivery of the awaiting `await worker.terminate()` continuation — which the interpreter posts onto its callback queue via the loop `SynchronizationContext`. When the `Unref` won, `RunEventLoop` observed `!HasActiveHandles && _callbackQueue.Count == 0`, exited, and `CompleteAdding()` then dropped the late continuation.

`exit:1` always survives because its timer is scheduled during the worker's `finally`, **before** the join completes, while the join Ref still holds the loop alive — which is exactly why `exit` is reliable but `terminated` is flaky.

This is the same class as the already-documented `AdoptInnerPromise` fix and PR #983 (`resolve-thenable-deferred`). The emitted `$EventLoop` has the structurally identical race (passing on CI only by timing luck), so the fix is routed through `ScheduleOnMainThread` to cover both interpreter and compiled modes.

## Fix

Settle the promise and release the join keep-alive **atomically inside a single callback delivered on the event-loop thread, resolve-before-unref**. On the loop thread, `tcs.TrySetResult` synchronously posts the await continuation onto the callback queue **before** `loopUnref()` decrements the handle to 0, so the loop's exit check always sees pending work. The join is bounded (5s), so `loopUnref` still runs exactly once.

## Validation

- **Windows:** 254/254 (worker threads + event-loop / async / timers / cluster / unhandled-rejection subset). No regression.
- The real race is genuinely rare — it did **not** reproduce in black-box stress (200 iters × 12 CPU burners) on Windows or Linux, in either mode. Consistent with it flaking only occasionally on CI.
- **Deterministic white-box A/B on Linux (WSL2, .NET 10):** widening the exact window by 50 ms —
  - buggy order (unref → gap → settle): **20/20** `terminated` dropped, output exactly `"exit:1\n"` (matches the CI signature).
  - fixed order (settle → gap → unref): **0/20** dropped.
  - Same window, opposite outcome → the settle-before-unref ordering is the cure.

## Notes

Not affected: `SharpTSClusterWorker` Kill/Disconnect (synchronous joins, no loop-Ref/ContinueWith bridge).