### PR TITLE
fix(compiled): BigInt->string coercion in EmitToJsString + Test262 crash guard

### DIFF
--- a/Compilation/RuntimeEmitter.CoreUtilities.cs
+++ b/Compilation/RuntimeEmitter.CoreUtilities.cs
@@ -2158,7 +2158,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Call, runtime.InvokeMethodValue);
         il.Emit(OpCodes.Stloc, toPrimResultLocal);
 
-        // If primitive (null/undefined/string/number/bool) → Stringify and return.
+        // If primitive (null/undefined/string/number/bool/BigInt) → ToJsString and return.
         var resIsPrimitiveLabel = il.DefineLabel();
         il.Emit(OpCodes.Ldloc, toPrimResultLocal);
         il.Emit(OpCodes.Brfalse, resIsPrimitiveLabel);
@@ -2174,6 +2174,9 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloc, toPrimResultLocal);
         il.Emit(OpCodes.Isinst, _types.Boolean);
         il.Emit(OpCodes.Brtrue, resIsPrimitiveLabel);
+        il.Emit(OpCodes.Ldloc, toPrimResultLocal);
+        il.Emit(OpCodes.Isinst, _types.BigInteger);
+        il.Emit(OpCodes.Brtrue, resIsPrimitiveLabel);
         // Object result → TypeError per ECMA-262 7.1.1 step 1.b.iii.
         il.Emit(OpCodes.Ldstr, "Cannot convert object to primitive value");
         il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
@@ -2181,7 +2184,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Throw);
         il.MarkLabel(resIsPrimitiveLabel);
         il.Emit(OpCodes.Ldloc, toPrimResultLocal);
-        il.Emit(OpCodes.Call, runtime.Stringify);
+        il.Emit(OpCodes.Call, runtime.ToJsString);
         il.Emit(OpCodes.Ret);
         il.MarkLabel(afterToPrimSymLabel);
 
@@ -2222,9 +2225,9 @@ public partial class RuntimeEmitter
             il.Emit(OpCodes.Call, runtime.InvokeMethodValue);
             il.Emit(OpCodes.Stloc, resultLocal);
 
-            // If primitive (string / number / bool / null / undefined), Stringify
-            // and return. Per ECMA-262 ToPrimitive, all primitive types — including
-            // undefined and null — are valid OrdinaryToPrimitive results.
+            // If primitive (string / number / bool / null / undefined / BigInt),
+            // ToJsString and return. Per ECMA-262 ToPrimitive, all primitive types
+            // — including undefined and null — are valid OrdinaryToPrimitive results.
             var resultIsString = il.DefineLabel();
             il.Emit(OpCodes.Ldloc, resultLocal);
             il.Emit(OpCodes.Brfalse, resultIsString); // null primitive
@@ -2240,6 +2243,9 @@ public partial class RuntimeEmitter
             il.Emit(OpCodes.Ldloc, resultLocal);
             il.Emit(OpCodes.Isinst, _types.Boolean);
             il.Emit(OpCodes.Brtrue, resultIsString);
+            il.Emit(OpCodes.Ldloc, resultLocal);
+            il.Emit(OpCodes.Isinst, _types.BigInteger);
+            il.Emit(OpCodes.Brtrue, resultIsString);
             // Not primitive — set the flag and continue to next attempt.
             il.Emit(OpCodes.Ldc_I4_1);
             il.Emit(OpCodes.Stloc, sawNonPrimitiveLocal);
@@ -2247,7 +2253,7 @@ public partial class RuntimeEmitter
 
             il.MarkLabel(resultIsString);
             il.Emit(OpCodes.Ldloc, resultLocal);
-            il.Emit(OpCodes.Call, runtime.Stringify);
+            il.Emit(OpCodes.Call, runtime.ToJsString);
             il.Emit(OpCodes.Ret);
         }
 

--- a/SharpTS.Test262/SharpTS.Test262.csproj
+++ b/SharpTS.Test262/SharpTS.Test262.csproj
@@ -37,6 +37,14 @@
 
   <ItemGroup>
     <ProjectReference Include="..\SharpTS.csproj" />
+    <!-- Build the worker subprocess before tests run so TryFindWorkerDll()
+         always succeeds. ReferenceOutputAssembly=false: we spawn it as a
+         child process, not a compile-time assembly reference. Without this,
+         a `dotnet clean` without rebuild silently re-activates the
+         crash-prone in-process collectible-ALC path (issue #964). -->
+    <ProjectReference Include="..\SharpTS.Test262.Worker\SharpTS.Test262.Worker.csproj">
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
   </ItemGroup>
 
 </Project>

--- a/SharpTS.Test262/Test262Tests.cs
+++ b/SharpTS.Test262/Test262Tests.cs
@@ -92,12 +92,21 @@ public abstract class Test262TestsBase
         }
         else
         {
+            // Compiled mode in-process would create ~11k collectible ALCs and call
+            // GC.Collect() every 50 tests, which races with JIT on ALC teardown
+            // under Server+Concurrent GC → fatal CLR error 0x80131506 (issue #964).
+            // The SharpTS.Test262.csproj ProjectReference on the Worker ensures this
+            // branch is only reachable if the Worker project was explicitly cleaned
+            // without rebuilding, or in a partial build.
+            if (mode == Test262ExecutionMode.Compiled)
+                Assert.Fail(
+                    $"[{mode}] worker DLL not found — build SharpTS.Test262.Worker before running " +
+                    $"the compiled baseline (the in-process fallback crashes the host, see issue #964). " +
+                    $"Run: dotnet build SharpTS.Test262.Worker/SharpTS.Test262.Worker.csproj");
+
             _output.WriteLine($"[{mode}] worker DLL not found — falling back to in-process (build SharpTS.Test262.Worker for issue #109 batched mode)");
-            // Deliberately collectible (useNonCollectibleLoad: false, the default):
-            // this fallback can run the whole subset (~11k tests) in-process, so it
-            // relies on per-test ALC Unload to avoid OOM (issue #109). The crash-prone
-            // collectible path (issue #964) is the lesser evil here vs. a 28 GB testhost;
-            // build the worker to avoid both. SmokeTest, which runs only small curated
+            // Interpreted in-process fallback: no collectible ALCs, no GC.Collect()
+            // churn — safe for the full subset. SmokeTest, which runs only small curated
             // lists, opts into the non-collectible path instead.
             var runner = new Test262Runner(test262Root, config.Timeout, skipFeatures);
             foreach (var (relPath, absPath) in files)

--- a/SharpTS.Test262/baselines/compiled.txt
+++ b/SharpTS.Test262/baselines/compiled.txt
@@ -1460,9 +1460,9 @@ test/built-ins/Array/prototype/join/S15.4.4.5_A2_T2.js Pass
 test/built-ins/Array/prototype/join/S15.4.4.5_A2_T3.js Pass
 test/built-ins/Array/prototype/join/S15.4.4.5_A2_T4.js Pass
 test/built-ins/Array/prototype/join/S15.4.4.5_A3.1_T1.js Fail
-test/built-ins/Array/prototype/join/S15.4.4.5_A3.1_T2.js Fail
+test/built-ins/Array/prototype/join/S15.4.4.5_A3.1_T2.js Pass
 test/built-ins/Array/prototype/join/S15.4.4.5_A3.2_T1.js Pass
-test/built-ins/Array/prototype/join/S15.4.4.5_A3.2_T2.js Fail
+test/built-ins/Array/prototype/join/S15.4.4.5_A3.2_T2.js Pass
 test/built-ins/Array/prototype/join/S15.4.4.5_A4_T3.js Pass
 test/built-ins/Array/prototype/join/S15.4.4.5_A5_T1.js Fail
 test/built-ins/Array/prototype/join/S15.4.4.5_A6.6.js Pass
@@ -3017,7 +3017,7 @@ test/built-ins/Array/prototype/toSpliced/unmodified.js Pass
 test/built-ins/Array/prototype/toString/S15.4.4.2_A1_T1.js Pass
 test/built-ins/Array/prototype/toString/S15.4.4.2_A1_T2.js Pass
 test/built-ins/Array/prototype/toString/S15.4.4.2_A1_T3.js Pass
-test/built-ins/Array/prototype/toString/S15.4.4.2_A1_T4.js Fail
+test/built-ins/Array/prototype/toString/S15.4.4.2_A1_T4.js Pass
 test/built-ins/Array/prototype/toString/S15.4.4.2_A3_T1.js Fail
 test/built-ins/Array/prototype/toString/call-with-boolean.js Fail
 test/built-ins/Array/prototype/toString/length.js Pass
@@ -3063,10 +3063,10 @@ test/built-ins/Array/prototype/with/frozen-this-value.js Pass
 test/built-ins/Array/prototype/with/holes-not-preserved.js RuntimeError
 test/built-ins/Array/prototype/with/ignores-species.js Pass
 test/built-ins/Array/prototype/with/immutable.js Pass
-test/built-ins/Array/prototype/with/index-bigger-or-eq-than-length.js Fail
+test/built-ins/Array/prototype/with/index-bigger-or-eq-than-length.js Pass
 test/built-ins/Array/prototype/with/index-casted-to-number.js Pass
 test/built-ins/Array/prototype/with/index-negative.js Pass
-test/built-ins/Array/prototype/with/index-smaller-than-minus-length.js Fail
+test/built-ins/Array/prototype/with/index-smaller-than-minus-length.js Pass
 test/built-ins/Array/prototype/with/index-throw-completion.js Pass
 test/built-ins/Array/prototype/with/length-decreased-while-iterating.js RuntimeError
 test/built-ins/Array/prototype/with/length-exceeding-array-length-limit.js Pass
@@ -3078,7 +3078,7 @@ test/built-ins/Array/prototype/with/negative-fractional-index-truncated-to-zero.
 test/built-ins/Array/prototype/with/no-get-replaced-index.js Pass
 test/built-ins/Array/prototype/with/not-a-constructor.js Pass
 test/built-ins/Array/prototype/with/property-descriptor.js Pass
-test/built-ins/Array/prototype/with/this-value-boolean.js Fail
+test/built-ins/Array/prototype/with/this-value-boolean.js Pass
 test/built-ins/Array/prototype/with/this-value-nullish.js Pass
 test/built-ins/Boolean/S15.6.1.1_A1_T1.js Pass
 test/built-ins/Boolean/S15.6.1.1_A1_T2.js Pass
@@ -3852,7 +3852,7 @@ test/built-ins/Number/prototype/toFixed/S15.7.4.5_A1.3_T01.js Pass
 test/built-ins/Number/prototype/toFixed/S15.7.4.5_A1.3_T02.js Pass
 test/built-ins/Number/prototype/toFixed/S15.7.4.5_A1.4_T01.js Fail
 test/built-ins/Number/prototype/toFixed/S15.7.4.5_A2_T01.js Pass
-test/built-ins/Number/prototype/toFixed/exactness.js Fail
+test/built-ins/Number/prototype/toFixed/exactness.js Pass
 test/built-ins/Number/prototype/toFixed/length.js Pass
 test/built-ins/Number/prototype/toFixed/name.js Pass
 test/built-ins/Number/prototype/toFixed/not-a-constructor.js Pass
@@ -10320,7 +10320,7 @@ test/built-ins/String/prototype/indexOf/position-tointeger-errors.js Fail
 test/built-ins/String/prototype/indexOf/position-tointeger-toprimitive.js RuntimeError
 test/built-ins/String/prototype/indexOf/position-tointeger-wrapped-values.js RuntimeError
 test/built-ins/String/prototype/indexOf/position-tointeger.js RuntimeError
-test/built-ins/String/prototype/indexOf/searchstring-tostring-bigint.js Fail
+test/built-ins/String/prototype/indexOf/searchstring-tostring-bigint.js Pass
 test/built-ins/String/prototype/indexOf/searchstring-tostring-errors.js Pass
 test/built-ins/String/prototype/indexOf/searchstring-tostring-toprimitive.js RuntimeError
 test/built-ins/String/prototype/indexOf/searchstring-tostring-wrapped-values.js Pass
@@ -10689,7 +10689,7 @@ test/built-ins/String/prototype/split/argument-is-new-reg-exp-and-instance-is-st
 test/built-ins/String/prototype/split/argument-is-null-and-instance-is-function-call-that-returned-string.js Pass
 test/built-ins/String/prototype/split/argument-is-reg-exp-a-z-and-instance-is-string-abc.js Pass
 test/built-ins/String/prototype/split/argument-is-regexp-a-z-and-instance-is-string-abc.js Pass
-test/built-ins/String/prototype/split/argument-is-regexp-and-instance-is-number.js Fail
+test/built-ins/String/prototype/split/argument-is-regexp-and-instance-is-number.js Pass
 test/built-ins/String/prototype/split/argument-is-regexp-d-and-instance-is-string-dfe23iu-34-65.js Pass
 test/built-ins/String/prototype/split/argument-is-regexp-l-and-instance-is-string-hello.js Pass
 test/built-ins/String/prototype/split/argument-is-regexp-reg-exp-d-and-instance-is-string-dfe23iu-34-65.js Pass


### PR DESCRIPTION
## Summary

- **Mode B (outcome flip):** `EmitToJsString` (`RuntimeEmitter.CoreUtilities.cs`) was missing `BigInteger` from both the `Symbol.toPrimitive` result check and the `OrdinaryToPrimitive.TryInvoke` result check. When a toPrimitive/toString/valueOf call returned a BigInt, it fell through to `TypeError` instead of string coercion. Both return sites also called `Stringify` (produces `"0n"`) instead of `ToJsString` (produces `"0"` via `EmitBigIntToStringReturn`). This caused non-deterministic `Fail<->RuntimeError` flips in the compiled Test262 baseline. **9 tests now pass:** `String.prototype.indexOf/searchstring-tostring-bigint`, `Array.prototype.join` (x2), `Array.prototype.toString`, `Array.prototype.with` (x3), `Number.prototype.toFixed/exactness`, `String.prototype.split`.

- **Mode A (host crash):** When `TryFindWorkerDll()` returned null (after `dotnet clean` without rebuild), the compiled baseline silently fell back to in-process collectible-ALC execution (~11k ALC cycles + periodic `GC.Collect()`), which races with JIT on ALC teardown under Server+Concurrent GC -> fatal CLR error `0x80131506`. Added `ProjectReference` (`ReferenceOutputAssembly=false`) from `SharpTS.Test262` to `SharpTS.Test262.Worker` so the worker is always built first. Added `Assert.Fail()` guard for compiled mode when the DLL is still absent.

Root-cause investigation done via ultracode multi-agent workflow (9 agents, Scout->Hunt->Synthesize).

## Test plan

- [x] `dotnet build SharpTS.Test262/SharpTS.Test262.csproj -c Release` -- clean, 0 errors
- [x] `dotnet build SharpTS.sln -c Release` -- clean, 0 errors, 1 pre-existing warning
- [x] `dotnet test SharpTS.sln -c Release` -- 14811 passed, 3 pre-existing load-induced flakes unrelated to these changes
- [x] Compiled baseline regenerated with `SHARPTS_TEST262_UPDATE_BASELINE=1` -- 9 Fail->Pass
- [x] Compiled baseline diff check (clean run, no `UPDATE_BASELINE`) -- `Passed: 1` in 16m17s