### PR TITLE
fix(parser+interop): decorated exported classes (#1192) + --gen-decl discovery tool (#1194)

### DIFF
--- a/Cli/CommandLineParser.cs
+++ b/Cli/CommandLineParser.cs
@@ -111,10 +111,11 @@ public abstract record ParsedCommand
         GlobalOptions GlobalOptions
     ) : ParsedCommand;
 
-    /// <summary>Generate TypeScript declarations for a .NET type or assembly.</summary>
-    /// <param name="TypeOrAssembly">Type name or assembly path</param>
+    /// <summary>Inspect a .NET type, namespace, or assembly for interop discovery (issue #1194).</summary>
+    /// <param name="TypeOrAssembly">Type name, namespace, or assembly path to inspect</param>
     /// <param name="OutputPath">Optional output file path</param>
-    public sealed record GenDecl(string TypeOrAssembly, string? OutputPath) : ParsedCommand;
+    /// <param name="Json">Emit machine-readable JSON instead of human-readable text</param>
+    public sealed record GenDecl(string TypeOrAssembly, string? OutputPath, bool Json = false) : ParsedCommand;
 
     /// <summary>Parsing error with message and exit code.</summary>
     /// <param name="Message">Error message to display</param>
@@ -198,7 +199,7 @@ public class CommandLineParser
         return new ParsedCommand.Error(
             "Usage: sharpts [script] [args...]\n" +
             "       sharpts --compile <script.ts> [-o output.dll]\n" +
-            "       sharpts --gen-decl <TypeName|AssemblyPath> [-o output.d.ts]",
+            "       sharpts --gen-decl <TypeName|Namespace|AssemblyPath> [--json] [-o output.txt]",
             64
         );
     }
@@ -429,17 +430,22 @@ public class CommandLineParser
         if (args.Length < 2)
         {
             return new ParsedCommand.Error(
-                "Usage: sharpts --gen-decl <TypeName|AssemblyPath> [-o output.d.ts]\n" +
+                "Usage: sharpts --gen-decl <TypeName|Namespace|AssemblyPath> [--json] [-o output.txt]\n" +
+                "Inspects a .NET type/namespace/assembly and reports which members are usable from\n" +
+                "TypeScript interop, with the dotnet: import line for usable types.\n" +
                 "Examples:\n" +
-                "  sharpts --gen-decl System.Console              # Generate declaration for a type\n" +
-                "  sharpts --gen-decl ./MyAssembly.dll            # Generate declarations for all types in assembly\n" +
-                "  sharpts --gen-decl System.Console -o console.d.ts  # Write to file",
+                "  sharpts --gen-decl System.Text.StringBuilder       # Member breakdown for a type\n" +
+                "  sharpts --gen-decl System.Text                     # List the types in a namespace\n" +
+                "  sharpts --gen-decl ./MyAssembly.dll                # List the types in an assembly\n" +
+                "  sharpts --gen-decl System.Guid --json              # Machine-readable JSON\n" +
+                "  sharpts --gen-decl System.Guid -o guid.txt         # Write to file",
                 64
             );
         }
 
         string typeOrAssembly = args[1];
         string? outputPath = null;
+        bool json = false;
 
         // Parse options
         for (int i = 2; i < args.Length; i++)
@@ -448,9 +454,13 @@ public class CommandLineParser
             {
                 outputPath = args[++i];
             }
+            else if (args[i] == "--json")
+            {
+                json = true;
+            }
         }
 
-        return new ParsedCommand.GenDecl(typeOrAssembly, outputPath);
+        return new ParsedCommand.GenDecl(typeOrAssembly, outputPath, json);
     }
 
 }

--- a/Compilation/ILCompiler.Functions.cs
+++ b/Compilation/ILCompiler.Functions.cs
@@ -1121,6 +1121,22 @@ public partial class ILCompiler
                 continue;
             }
 
+            // An exported class (`@dec export class`) is wrapped in Stmt.Export, so the
+            // bare-Stmt.Class branch above never sees it and its runtime decorators would
+            // be dropped in compiled mode (issue #1192). Emit the export's own logic
+            // (EmitStatement — module-export storage in module mode, a no-op in script
+            // mode, exactly as before) and then the wrapped class's runtime decorators,
+            // mirroring the bare-class branch.
+            if (stmt is Stmt.Export { Declaration: Stmt.Class exportedClass })
+            {
+                emitter.EmitStatement(stmt);
+                if (_decoratorMode != DecoratorMode.None && HasAnyRuntimeDecorators(exportedClass))
+                {
+                    EmitRuntimeDecorators(exportedClass, emitter, il);
+                }
+                continue;
+            }
+
             // Special handling for expression statements to wait for top-level async
             // calls — "top-level await" behavior. Shared with the module/script init
             // bodies so every entry point pumps the loop the same way (see the remarks

--- a/Declaration/DiscoveryEmitter.cs
+++ b/Declaration/DiscoveryEmitter.cs
@@ -1,0 +1,142 @@
+using System.Text;
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace SharpTS.Declaration;
+
+/// <summary>
+/// Renders a <see cref="DiscoveryReport"/> for human reading (text) or tooling (<c>--json</c>).
+/// This is the discovery-oriented replacement for <c>TypeScriptEmitter</c>'s role in
+/// <c>--gen-decl</c>: it has no obligation to produce syntactically valid TypeScript, so it can
+/// show unsupported members transparently instead of mangling them into invalid syntax.
+/// </summary>
+public static class DiscoveryEmitter
+{
+    private const string UsableMarker = "[usable]     ";
+    private const string UnsupportedMarker = "[unsupported]";
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) },
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        // Keep generic-argument angle brackets and quotes readable in signatures rather than
+        // <-escaping them — this output is a dev tool, not HTML.
+        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
+    };
+
+    /// <summary>Serializes the report as indented JSON for editor/tooling consumption.</summary>
+    public static string EmitJson(DiscoveryReport report) => JsonSerializer.Serialize(report, JsonOptions);
+
+    /// <summary>Renders the report as human-readable text.</summary>
+    public static string EmitText(DiscoveryReport report) => report.Kind switch
+    {
+        DiscoveryKind.TypeDetail => EmitTypeDetail(report.Type!),
+        DiscoveryKind.TableOfContents => EmitTableOfContents(report),
+        _ => throw new ArgumentOutOfRangeException(nameof(report))
+    };
+
+    private static string EmitTypeDetail(TypeReport type)
+    {
+        var sb = new StringBuilder();
+        sb.Append(type.FullName).Append(" — ").Append(type.Kind).AppendLine();
+
+        if (type.ImportLine != null)
+        {
+            sb.AppendLine();
+            sb.Append("  ").AppendLine(type.ImportLine);
+        }
+        else if (type.UnsupportedTypeReason != null)
+        {
+            sb.AppendLine();
+            sb.Append("  This type cannot be imported: ").AppendLine(type.UnsupportedTypeReason);
+        }
+
+        // Group members by category, preserving first-seen order.
+        var categories = new List<string>();
+        var byCategory = new Dictionary<string, List<MemberReport>>();
+        foreach (var member in type.Members)
+        {
+            if (!byCategory.TryGetValue(member.Category, out var list))
+            {
+                list = [];
+                byCategory[member.Category] = list;
+                categories.Add(member.Category);
+            }
+            list.Add(member);
+        }
+
+        foreach (var category in categories)
+        {
+            sb.AppendLine();
+            sb.Append("  ").Append(category).AppendLine(":");
+            foreach (var member in byCategory[category])
+            {
+                EmitMemberLine(sb, member);
+            }
+        }
+
+        if (type.Members.Count == 0)
+        {
+            sb.AppendLine();
+            sb.AppendLine("  (no public members)");
+        }
+
+        return sb.ToString();
+    }
+
+    private static void EmitMemberLine(StringBuilder sb, MemberReport member)
+    {
+        // Enum values carry no usability marker — they are always plain numbers.
+        if (member.Category == "Values")
+        {
+            sb.Append("    ").AppendLine(member.Signature);
+            return;
+        }
+
+        string marker = member.Usable ? UsableMarker : UnsupportedMarker;
+        sb.Append("    ").Append(marker).Append(' ').Append(member.Signature);
+        if (!member.Usable && member.UnsupportedReason != null)
+        {
+            sb.Append("   — ").Append(member.UnsupportedReason);
+        }
+        sb.AppendLine();
+    }
+
+    private static string EmitTableOfContents(DiscoveryReport report)
+    {
+        var types = report.Types!;
+        var sb = new StringBuilder();
+
+        int usable = types.Count(t => t.Usable);
+        int unsupported = types.Count - usable;
+
+        sb.Append(report.Scope).Append(" — ")
+          .Append(types.Count).Append(" public type(s), ")
+          .Append(usable).Append(" usable")
+          .Append(unsupported > 0 ? $", {unsupported} unsupported" : "")
+          .AppendLine();
+        sb.AppendLine();
+
+        foreach (var entry in types)
+        {
+            string marker = entry.Usable ? UsableMarker : UnsupportedMarker;
+            sb.Append("  ").Append(marker).Append(' ')
+              .Append(entry.Kind.PadRight(14)).Append(' ')
+              .Append(entry.FullName);
+            if (!entry.Usable && entry.UnsupportedReason != null)
+            {
+                sb.Append("   — ").Append(entry.UnsupportedReason);
+            }
+            sb.AppendLine();
+        }
+
+        sb.AppendLine();
+        sb.AppendLine("For a full member breakdown and the dotnet: import line, run:");
+        sb.Append("    sharpts --gen-decl <TypeName>").AppendLine();
+
+        return sb.ToString();
+    }
+}

--- a/Declaration/DiscoveryGenerator.cs
+++ b/Declaration/DiscoveryGenerator.cs
@@ -1,0 +1,248 @@
+using System.Reflection;
+
+namespace SharpTS.Declaration;
+
+/// <summary>
+/// Builds a <see cref="DiscoveryReport"/> for a .NET type, namespace, or assembly — the engine
+/// behind <c>--gen-decl</c>'s discovery/inspection mode (issue #1194). Unlike the older
+/// TypeScript-source generator, it never has to produce valid TypeScript: it reports real CLR
+/// signatures faithfully (<c>ReadOnlySpan&lt;char&gt;</c>, <c>out Guid</c>, …) and marks each
+/// member usable or unsupported using <see cref="DotNetInteropClassifier"/> — the same rules the
+/// runtime interop marshaller enforces, so the tool and the runtime can never disagree.
+/// </summary>
+public class DiscoveryGenerator
+{
+    private readonly TypeInspector _inspector = new();
+
+    /// <summary>
+    /// Resolves <paramref name="input"/> as a type, then a namespace, then an assembly path, and
+    /// builds the matching report. Throws <see cref="ArgumentException"/> if nothing resolves.
+    /// </summary>
+    public DiscoveryReport Generate(string input)
+    {
+        // Assembly file path → table of contents for the whole assembly.
+        if (input.EndsWith(".dll", StringComparison.OrdinalIgnoreCase) ||
+            input.EndsWith(".exe", StringComparison.OrdinalIgnoreCase))
+        {
+            return GenerateForAssembly(input);
+        }
+
+        // A specific type → full member detail.
+        Type? type = ResolveType(input);
+        if (type != null)
+        {
+            return GenerateForType(type);
+        }
+
+        // Otherwise treat it as a namespace → table of contents.
+        var toc = GenerateForNamespace(input);
+        if (toc != null)
+        {
+            return toc;
+        }
+
+        throw new ArgumentException(
+            $"'{input}' did not resolve to a .NET type, namespace, or assembly. " +
+            "Check the name is fully qualified (e.g. System.Text.StringBuilder) and its assembly is loadable.");
+    }
+
+    /// <summary>Builds a full detail report for a single resolved type.</summary>
+    public DiscoveryReport GenerateForType(Type type)
+    {
+        var metadata = _inspector.Inspect(type);
+        var typeReport = BuildTypeReport(metadata, type);
+        return new DiscoveryReport(DiscoveryKind.TypeDetail, type.FullName ?? type.Name, Type: typeReport);
+    }
+
+    /// <summary>Builds a table-of-contents report for every public type in an assembly file.</summary>
+    public DiscoveryReport GenerateForAssembly(string assemblyPath)
+    {
+        if (!File.Exists(assemblyPath))
+        {
+            throw new FileNotFoundException($"Assembly not found: {assemblyPath}");
+        }
+
+        Assembly assembly;
+        try
+        {
+            assembly = Assembly.LoadFrom(assemblyPath);
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException($"Failed to load assembly: {ex.Message}", ex);
+        }
+
+        var entries = assembly.GetExportedTypes()
+            .Where(t => !t.Name.StartsWith('<') && !t.IsNested)
+            .OrderBy(t => t.FullName, StringComparer.Ordinal)
+            .Select(ToTocEntry)
+            .ToList();
+
+        return new DiscoveryReport(
+            DiscoveryKind.TableOfContents,
+            assemblyPath,
+            Scope: assembly.GetName().Name ?? assemblyPath,
+            Types: entries);
+    }
+
+    /// <summary>
+    /// Builds a table-of-contents report for a namespace by scanning all loaded assemblies, or
+    /// null if no loaded type lives in that namespace.
+    /// </summary>
+    public DiscoveryReport? GenerateForNamespace(string ns)
+    {
+        var entries = new List<TocEntry>();
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+        {
+            Type[] types;
+            try
+            {
+                types = assembly.GetExportedTypes();
+            }
+            catch
+            {
+                continue; // Skip assemblies that can't be reflected over.
+            }
+
+            foreach (var type in types)
+            {
+                if (type.Namespace != ns || type.IsNested || type.Name.StartsWith('<'))
+                    continue;
+                if (!seen.Add(type.FullName ?? type.Name))
+                    continue;
+                entries.Add(ToTocEntry(type));
+            }
+        }
+
+        if (entries.Count == 0)
+            return null;
+
+        entries.Sort((a, b) => string.CompareOrdinal(a.FullName, b.FullName));
+        return new DiscoveryReport(DiscoveryKind.TableOfContents, ns, Scope: ns, Types: entries);
+    }
+
+    // ── Report building ──────────────────────────────────────────────
+
+    private static TocEntry ToTocEntry(Type type)
+    {
+        string? reason = DotNetInteropClassifier.UnsupportedTypeReason(type);
+        return new TocEntry(type.FullName ?? type.Name, KindOf(type), reason == null, reason);
+    }
+
+    private static TypeReport BuildTypeReport(TypeMetadata metadata, Type type)
+    {
+        // KindOf reads the reflected type so structs read as "struct", static classes as
+        // "static class", etc. — the same label the table-of-contents uses.
+        string kind = KindOf(type);
+
+        string? typeReason = DotNetInteropClassifier.UnsupportedTypeReason(type);
+        string? importLine = typeReason == null
+            ? $"import {{ {metadata.SimpleName} }} from \"dotnet:{metadata.FullName}\";"
+            : null;
+
+        var members = new List<MemberReport>();
+
+        if (metadata.IsEnum)
+        {
+            foreach (var m in metadata.EnumMembers)
+                members.Add(new MemberReport("Values", $"{m.Name} = {m.Value}", true, null));
+        }
+        else
+        {
+            foreach (var ctor in metadata.Constructors)
+                members.Add(BuildCallableReport("Constructors", "constructor", ctor.Parameters, returnType: null));
+
+            foreach (var prop in metadata.StaticProperties)
+                members.Add(BuildPropertyReport("Static properties", prop, isStatic: true));
+
+            foreach (var prop in metadata.Properties)
+                members.Add(BuildPropertyReport("Instance properties", prop, isStatic: false));
+
+            foreach (var method in metadata.StaticMethods)
+                members.Add(BuildCallableReport("Static methods", method.TypeScriptName, method.Parameters, method.ReturnType, isStatic: true));
+
+            foreach (var method in metadata.Methods)
+                members.Add(BuildCallableReport("Instance methods", method.TypeScriptName, method.Parameters, method.ReturnType));
+        }
+
+        return new TypeReport(metadata.FullName, metadata.SimpleName, kind, importLine, typeReason, members);
+    }
+
+    /// <summary>Builds a report line for a constructor or method (a callable with parameters).</summary>
+    private static MemberReport BuildCallableReport(
+        string category, string name, List<ParameterMetadata> parameters, Type? returnType, bool isStatic = false)
+    {
+        string prefix = isStatic ? "static " : "";
+        string paramText = string.Join(", ", parameters.Select(DotNetTypeMapper.DescribeParameter));
+        string returnText = returnType == null ? "" : $": {DotNetTypeMapper.Describe(returnType)}";
+        string signature = $"{prefix}{name}({paramText}){returnText}";
+
+        // A member is usable only if every parameter slot and the return slot are marshalable.
+        string? reason = null;
+        foreach (var p in parameters)
+        {
+            reason = DotNetInteropClassifier.UnsupportedSlotReason(p.ParameterType);
+            if (reason != null) break;
+        }
+        if (reason == null && returnType != null)
+            reason = DotNetInteropClassifier.UnsupportedSlotReason(returnType);
+
+        return new MemberReport(category, signature, reason == null, reason);
+    }
+
+    private static MemberReport BuildPropertyReport(string category, PropertyMetadata prop, bool isStatic)
+    {
+        string prefix = isStatic ? "static " : "";
+        string accessors = prop.CanWrite ? "{ get; set; }" : "{ get; }";
+        string signature = $"{prefix}{prop.TypeScriptName}: {DotNetTypeMapper.Describe(prop.PropertyType)}   {accessors}";
+        string? reason = DotNetInteropClassifier.UnsupportedSlotReason(prop.PropertyType);
+        return new MemberReport(category, signature, reason == null, reason);
+    }
+
+    private static string KindOf(Type type)
+    {
+        if (type.IsEnum) return "enum";
+        if (type.IsInterface) return "interface";
+        if (type.IsAbstract && type.IsSealed) return "static class";
+        if (type.IsValueType) return "struct";
+        if (type.IsAbstract) return "abstract class";
+        return "class";
+    }
+
+    // ── Type resolution ──────────────────────────────────────────────
+
+    /// <summary>
+    /// Resolves a type name the same way the runtime interop does (<see cref="Runtime.DotNet.DotNetTypeRegistry"/>),
+    /// falling back to a handful of common BCL assembly qualifiers for convenience.
+    /// </summary>
+    private static Type? ResolveType(string typeName)
+    {
+        Type? type = Runtime.DotNet.DotNetTypeRegistry.Resolve(typeName);
+        if (type != null)
+            return type;
+
+        string[] commonAssemblies =
+        [
+            "System.Runtime", "System.Console", "System.Collections",
+            "System.Linq", "System.Private.CoreLib", "mscorlib", "System.Net.Http"
+        ];
+
+        foreach (var asmName in commonAssemblies)
+        {
+            try
+            {
+                type = Type.GetType($"{typeName}, {asmName}", throwOnError: false);
+                if (type != null)
+                    return type;
+            }
+            catch
+            {
+                // Continue trying other assemblies.
+            }
+        }
+
+        return null;
+    }
+}

--- a/Declaration/DiscoveryReport.cs
+++ b/Declaration/DiscoveryReport.cs
@@ -1,0 +1,62 @@
+namespace SharpTS.Declaration;
+
+/// <summary>Whether a <see cref="DiscoveryReport"/> describes one type in detail or lists many.</summary>
+public enum DiscoveryKind
+{
+    /// <summary>Full member breakdown for a single resolved type.</summary>
+    TypeDetail,
+
+    /// <summary>Flat "table of contents" list of the types in a namespace or assembly.</summary>
+    TableOfContents
+}
+
+/// <summary>
+/// One member (constructor, method, property, or enum value) in a <see cref="TypeReport"/>,
+/// already rendered to a faithful signature and classified as usable or unsupported.
+/// </summary>
+/// <param name="Category">Display group, e.g. "Constructors", "Instance methods".</param>
+/// <param name="Signature">Faithful signature, e.g. <c>append(value: ReadOnlySpan&lt;char&gt;): StringBuilder</c>.</param>
+/// <param name="Usable">True if SharpTS interop can call this member today.</param>
+/// <param name="UnsupportedReason">Why it can't be used (null when <paramref name="Usable"/>).</param>
+public record MemberReport(
+    string Category,
+    string Signature,
+    bool Usable,
+    string? UnsupportedReason
+);
+
+/// <summary>Full discovery detail for a single .NET type.</summary>
+/// <param name="FullName">Fully-qualified CLR name (e.g. <c>System.Text.StringBuilder</c>).</param>
+/// <param name="SimpleName">Short name used in the import binding.</param>
+/// <param name="Kind">"class", "abstract class", "static class", "interface", or "enum".</param>
+/// <param name="ImportLine">The <c>import … from "dotnet:…";</c> line, or null if the type is unusable.</param>
+/// <param name="UnsupportedTypeReason">Why the type as a whole is unusable (null when importable).</param>
+/// <param name="Members">All discovered members in display order.</param>
+public record TypeReport(
+    string FullName,
+    string SimpleName,
+    string Kind,
+    string? ImportLine,
+    string? UnsupportedTypeReason,
+    List<MemberReport> Members
+);
+
+/// <summary>One row in a table-of-contents listing.</summary>
+public record TocEntry(
+    string FullName,
+    string Kind,
+    bool Usable,
+    string? UnsupportedReason
+);
+
+/// <summary>
+/// The result of a <c>--gen-decl</c> discovery run: either a single type's detail or a
+/// table-of-contents listing for a namespace/assembly.
+/// </summary>
+public record DiscoveryReport(
+    DiscoveryKind Kind,
+    string Query,
+    TypeReport? Type = null,
+    string? Scope = null,
+    List<TocEntry>? Types = null
+);

--- a/Declaration/DotNetInteropClassifier.cs
+++ b/Declaration/DotNetInteropClassifier.cs
@@ -1,0 +1,72 @@
+namespace SharpTS.Declaration;
+
+/// <summary>
+/// Single source of truth for "can SharpTS's <c>@DotNetType</c> interop actually use this
+/// today?" Classifies a .NET type slot (a parameter or return type) or a whole type as
+/// <em>usable</em> or <em>unsupported (with a reason)</em>.
+/// </summary>
+/// <remarks>
+/// The <c>--gen-decl</c> discovery tool (<see cref="DiscoveryEmitter"/>) and the runtime
+/// interop marshaller (<c>Runtime/DotNet/DotNetMarshaller.cs</c>) must never disagree about
+/// what is callable, so both classify against these rules. The marshaller has no code path
+/// for by-ref (<c>ref</c>/<c>out</c>/<c>in</c>) slots, pointers, or ref structs
+/// (<c>Span&lt;T&gt;</c>/<c>ReadOnlySpan&lt;T&gt;</c>), and open generic parameters have no
+/// concrete runtime type — those are the four unsupported categories. When the <c>dotnet:</c>
+/// import resolver lands (#1195) it should call these same helpers.
+/// </remarks>
+public static class DotNetInteropClassifier
+{
+    /// <summary>Human-readable reason a slot is unsupported: a by-ref parameter/return.</summary>
+    public const string ReasonByRef = "by-ref (ref/out/in) is not marshalable";
+
+    /// <summary>Human-readable reason a slot is unsupported: a pointer type.</summary>
+    public const string ReasonPointer = "pointer types are not marshalable";
+
+    /// <summary>Human-readable reason a slot is unsupported: a ref struct (Span&lt;T&gt; etc.).</summary>
+    public const string ReasonRefStruct = "ref struct (Span/ReadOnlySpan) cannot cross the interop boundary";
+
+    /// <summary>Human-readable reason a slot is unsupported: an unbound generic parameter.</summary>
+    public const string ReasonOpenGeneric = "open generic has no concrete runtime type";
+
+    /// <summary>
+    /// Returns null if a single type slot (a parameter or a method/property return type) can
+    /// be marshaled across the interop boundary today, or a human-readable reason if it can't.
+    /// </summary>
+    public static string? UnsupportedSlotReason(Type type)
+    {
+        // by-ref (ref/out/in) — the marshaller has no path to write back to the caller's slot.
+        if (type.IsByRef)
+            return ReasonByRef;
+
+        // Raw pointers can't be represented as a TS runtime value.
+        if (type.IsPointer)
+            return ReasonPointer;
+
+        // Ref structs (Span<T>, ReadOnlySpan<T>, …) cannot be boxed, so they can never be
+        // passed as an object across the interop boundary.
+        if (type.IsByRefLike)
+            return ReasonRefStruct;
+
+        // An unbound generic parameter (T) or any type that still contains one has no
+        // concrete runtime type to marshal to/from.
+        if (type.IsGenericParameter || type.ContainsGenericParameters)
+            return ReasonOpenGeneric;
+
+        return null;
+    }
+
+    /// <summary>
+    /// Returns null if the type itself can be imported/used as a whole, or a reason if it
+    /// can't (an open generic type definition, a pointer, or a ref struct).
+    /// </summary>
+    public static string? UnsupportedTypeReason(Type type)
+    {
+        if (type.IsGenericTypeDefinition || type.ContainsGenericParameters)
+            return ReasonOpenGeneric;
+        if (type.IsPointer)
+            return ReasonPointer;
+        if (type.IsByRefLike)
+            return ReasonRefStruct;
+        return null;
+    }
+}

--- a/Declaration/DotNetTypeMapper.cs
+++ b/Declaration/DotNetTypeMapper.cs
@@ -184,6 +184,92 @@ public static class DotNetTypeMapper
     }
 
     /// <summary>
+    /// Renders a .NET type <em>faithfully</em> — the real CLR shape, including forms that have
+    /// no valid TypeScript spelling (<c>ReadOnlySpan&lt;char&gt;</c>, <c>int*</c>, <c>Guid&amp;</c>,
+    /// open generics). Used by the <c>--gen-decl</c> discovery tool, whose job is to describe a
+    /// type accurately rather than emit pasteable TypeScript — so it never mangles these into
+    /// invalid syntax the way <see cref="MapToTypeScript"/> (a lossy TS coercion) would.
+    /// </summary>
+    public static string Describe(Type type)
+    {
+        // by-ref (ref/out/in) — the caller prefixes the ref/out/in keyword; show the pointee.
+        if (type.IsByRef)
+            return Describe(type.GetElementType()!);
+
+        if (type.IsPointer)
+            return Describe(type.GetElementType()!) + "*";
+
+        if (type.IsArray)
+        {
+            int rank = type.GetArrayRank();
+            string commas = rank > 1 ? new string(',', rank - 1) : "";
+            return Describe(type.GetElementType()!) + "[" + commas + "]";
+        }
+
+        if (type == typeof(void))
+            return "void";
+
+        // An unbound generic parameter renders as its own name (T, TKey, …).
+        if (type.IsGenericParameter)
+            return type.Name;
+
+        // Nullable<T> → "T?".
+        var underlyingNullable = Nullable.GetUnderlyingType(type);
+        if (underlyingNullable != null)
+            return Describe(underlyingNullable) + "?";
+
+        if (type.IsGenericType)
+        {
+            string baseName = StripArity(type.Name);
+            var args = type.GetGenericArguments().Select(Describe);
+            return $"{baseName}<{string.Join(", ", args)}>";
+        }
+
+        // C# keyword aliases keep primitives readable (int, string, bool, …).
+        return CSharpAlias(type) ?? type.Name;
+    }
+
+    /// <summary>
+    /// Renders a parameter faithfully, including the <c>ref</c>/<c>out</c>/<c>in</c> modifier
+    /// (which lives on the parameter, not the type) and a trailing <c>?</c> for optional params.
+    /// </summary>
+    public static string DescribeParameter(ParameterMetadata param)
+    {
+        string modifier = param.IsByRef
+            ? (param.IsOut ? "out " : param.IsIn ? "in " : "ref ")
+            : "";
+        string name = ToTypeScriptPropertyName(param.Name);
+        string optional = param.IsOptional ? "?" : "";
+        return $"{name}{optional}: {modifier}{Describe(param.ParameterType)}";
+    }
+
+    private static string StripArity(string name)
+    {
+        int tick = name.IndexOf('`');
+        return tick >= 0 ? name[..tick] : name;
+    }
+
+    private static string? CSharpAlias(Type type)
+    {
+        if (type == typeof(bool)) return "bool";
+        if (type == typeof(byte)) return "byte";
+        if (type == typeof(sbyte)) return "sbyte";
+        if (type == typeof(char)) return "char";
+        if (type == typeof(short)) return "short";
+        if (type == typeof(ushort)) return "ushort";
+        if (type == typeof(int)) return "int";
+        if (type == typeof(uint)) return "uint";
+        if (type == typeof(long)) return "long";
+        if (type == typeof(ulong)) return "ulong";
+        if (type == typeof(float)) return "float";
+        if (type == typeof(double)) return "double";
+        if (type == typeof(decimal)) return "decimal";
+        if (type == typeof(string)) return "string";
+        if (type == typeof(object)) return "object";
+        return null;
+    }
+
+    /// <summary>
     /// Converts a .NET method name to TypeScript naming convention (camelCase).
     /// </summary>
     public static string ToTypeScriptMethodName(string dotNetName)

--- a/Declaration/TypeInspector.cs
+++ b/Declaration/TypeInspector.cs
@@ -54,7 +54,10 @@ public record ParameterMetadata(
     string Name,
     Type ParameterType,
     bool IsOptional,
-    object? DefaultValue
+    object? DefaultValue,
+    bool IsByRef = false,
+    bool IsOut = false,
+    bool IsIn = false
 );
 
 public record EnumMemberMetadata(
@@ -184,15 +187,25 @@ public class TypeInspector
         return true;
     }
 
+    /// <summary>
+    /// Maps a reflected <see cref="ParameterInfo"/> to <see cref="ParameterMetadata"/>, capturing
+    /// the by-ref (ref/out/in) shape faithfully so the discovery tool can render and classify it.
+    /// </summary>
+    private static ParameterMetadata ToParameterMetadata(ParameterInfo p) => new(
+        p.Name ?? $"arg{p.Position}",
+        p.ParameterType,
+        p.IsOptional,
+        p.HasDefaultValue ? p.DefaultValue : null,
+        IsByRef: p.ParameterType.IsByRef,
+        // `out` and `in` are both by-ref; distinguish for a faithful signature.
+        IsOut: p.IsOut,
+        IsIn: p.ParameterType.IsByRef && p.IsIn
+    );
+
     private MethodMetadata ExtractMethod(MethodInfo method)
     {
         var parameters = method.GetParameters()
-            .Select(p => new ParameterMetadata(
-                p.Name ?? $"arg{p.Position}",
-                p.ParameterType,
-                p.IsOptional,
-                p.HasDefaultValue ? p.DefaultValue : null
-            ))
+            .Select(ToParameterMetadata)
             .ToList();
 
         return new MethodMetadata(
@@ -219,12 +232,7 @@ public class TypeInspector
     private ConstructorMetadata ExtractConstructor(ConstructorInfo ctor)
     {
         var parameters = ctor.GetParameters()
-            .Select(p => new ParameterMetadata(
-                p.Name ?? $"arg{p.Position}",
-                p.ParameterType,
-                p.IsOptional,
-                p.HasDefaultValue ? p.DefaultValue : null
-            ))
+            .Select(ToParameterMetadata)
             .ToList();
 
         return new ConstructorMetadata(parameters, ExtractObsoleteInfo(ctor));

--- a/Parsing/Parser.Declarations.cs
+++ b/Parsing/Parser.Declarations.cs
@@ -28,6 +28,13 @@ public partial class Parser
             return new Stmt.FileDirective(decorators);
         }
 
+        // `@decorator export class ...` — decorators legally appear *before* `export`.
+        // The EXPORT branch at the top of Declaration() only fires when EXPORT is the
+        // first token, so a decorated exported class reaches here with EXPORT unconsumed.
+        // Thread the decorators into ExportDeclaration() so they reach the class body
+        // the same way the bare (non-export) class paths below already do.
+        if (Match(TokenType.EXPORT)) return ExportDeclaration(decorators);
+
         if (Match(TokenType.DECLARE))
         {
             Token declareKeyword = Previous();

--- a/Parsing/Parser.Modules.cs
+++ b/Parsing/Parser.Modules.cs
@@ -205,13 +205,31 @@ public partial class Parser
     /// - export default class {}                    (default class export)
     /// - export = expression;                       (CommonJS export assignment)
     /// </summary>
-    private Stmt ExportDeclaration()
+    /// <param name="classDecorators">
+    /// Decorators parsed before the `export` keyword (`@decorator export class …`). Only the
+    /// class-producing forms — `export [default|abstract] class` and `export declare [abstract]
+    /// class` — accept them; every other export form rejects them via <see cref="RejectDecorators"/>,
+    /// matching TypeScript's "decorators can only be applied to classes and class members" rule.
+    /// </param>
+    private Stmt ExportDeclaration(List<Decorator>? classDecorators = null)
     {
         Token keyword = Previous();
+
+        // Decorators are only valid on the class-producing export forms below. Every other
+        // branch calls this first so `@dec export function/const/{…}/…` reports the same
+        // "not valid here" error TypeScript does, instead of silently dropping the decorators.
+        void RejectDecorators()
+        {
+            if (classDecorators is { Count: > 0 })
+            {
+                throw new Exception($"Parse Error at line {classDecorators[0].AtToken.Line}: Decorators are not valid here. Decorators can only be applied to classes and class members.");
+            }
+        }
 
         // export = <expression> (CommonJS export assignment)
         if (Match(TokenType.EQUAL))
         {
+            RejectDecorators();
             Expr exportValue = Expression();
             ConsumeSemicolon("Expect ';' after export assignment.");
             return new Stmt.Export(keyword, null, null, null, null, false, exportValue);
@@ -228,13 +246,14 @@ public partial class Parser
             // export default async function name() { } / async function* name() { }
             if (Match(TokenType.CLASS))
             {
-                declaration = ClassDeclaration(isAbstract: false);
+                declaration = ClassDeclaration(isAbstract: false, classDecorators: classDecorators);
             }
             else if (Check(TokenType.ASYNC) && PeekNext().Type == TokenType.FUNCTION)
             {
                 // `export default async function ...` — only claim ASYNC here when a
                 // `function` follows, so `export default async () => {}` still parses
                 // as a default async-arrow expression below.
+                RejectDecorators();
                 Advance(); // consume 'async'
                 Advance(); // consume 'function'
                 bool isGenerator = Match(TokenType.STAR);
@@ -242,12 +261,14 @@ public partial class Parser
             }
             else if (Match(TokenType.FUNCTION))
             {
+                RejectDecorators();
                 bool isGenerator = Match(TokenType.STAR);
                 declaration = FunctionDeclaration("function", isAsync: false, isGenerator: isGenerator);
             }
             else
             {
                 // export default <expression>;
+                RejectDecorators();
                 defaultExpr = Expression();
                 ConsumeSemicolon("Expect ';' after export default expression.");
             }
@@ -258,6 +279,7 @@ public partial class Parser
         // export { x, y } or export { x } from './module'
         if (Match(TokenType.LEFT_BRACE))
         {
+            RejectDecorators();
             var namedExports = ParseExportSpecifiers();
 
             // Re-export: export { x } from './module'
@@ -274,6 +296,7 @@ public partial class Parser
         // export * from './module' (re-export all)
         if (Match(TokenType.STAR))
         {
+            RejectDecorators();
             Consume(TokenType.FROM, "Expect 'from' after '*'.");
             string fromPath = (string)Consume(TokenType.STRING, "Expect module path.").Literal!;
             ConsumeSemicolon("Expect ';' after export.");
@@ -286,6 +309,7 @@ public partial class Parser
         // export import X = require('path') (re-export require)
         if (Match(TokenType.IMPORT))
         {
+            RejectDecorators();
             if (Check(TokenType.IDENTIFIER) && PeekNext().Type == TokenType.EQUAL)
             {
                 return ParseImportWithEquals(isExported: true);
@@ -298,6 +322,7 @@ public partial class Parser
         if (Match(TokenType.ASYNC))
         {
             // export async function foo() {}  /  export async function* foo() {}
+            RejectDecorators();
             Consume(TokenType.FUNCTION, "Expect 'function' after 'async'.");
             bool isGenerator = Match(TokenType.STAR);
             decl = FunctionDeclaration("function", isAsync: true, isGenerator: isGenerator);
@@ -305,20 +330,22 @@ public partial class Parser
         else if (Match(TokenType.FUNCTION))
         {
             // export function foo() {}  /  export function* foo() {}
+            RejectDecorators();
             bool isGenerator = Match(TokenType.STAR);
             decl = FunctionDeclaration("function", isAsync: false, isGenerator: isGenerator);
         }
         else if (Match(TokenType.CLASS))
         {
-            decl = ClassDeclaration(isAbstract: false);
+            decl = ClassDeclaration(isAbstract: false, classDecorators: classDecorators);
         }
         else if (Match(TokenType.ABSTRACT))
         {
             Consume(TokenType.CLASS, "Expect 'class' after 'abstract'.");
-            decl = ClassDeclaration(isAbstract: true);
+            decl = ClassDeclaration(isAbstract: true, classDecorators: classDecorators);
         }
         else if (Match(TokenType.CONST))
         {
+            RejectDecorators();
             if (Match(TokenType.ENUM))
             {
                 decl = EnumDeclaration(isConst: true);
@@ -334,33 +361,58 @@ public partial class Parser
         }
         else if (Match(TokenType.LET))
         {
+            RejectDecorators();
             decl = VarDeclaration();
         }
         else if (Match(TokenType.VAR))
         {
+            RejectDecorators();
             // IsVar so the declaration participates in var hoisting (VarHoister).
             decl = VarDeclaration(isConst: false, isVar: true);
         }
         else if (Match(TokenType.INTERFACE))
         {
+            RejectDecorators();
             decl = InterfaceDeclaration();
         }
         else if (Match(TokenType.TYPE))
         {
+            RejectDecorators();
             decl = TypeAliasDeclaration();
         }
         else if (Match(TokenType.ENUM))
         {
+            RejectDecorators();
             decl = EnumDeclaration(isConst: false);
         }
         else if (Match(TokenType.NAMESPACE))
         {
+            RejectDecorators();
             decl = NamespaceDeclaration(isExported: true);
         }
         else if (Match(TokenType.DECLARE))
         {
-            // `export declare function/const/…` — an exported ambient declaration.
-            decl = AmbientDeclaration();
+            // `export declare [abstract] class …` — an exported ambient class declaration
+            // (the form `--gen-decl` and docs/dotnet-types.md emit, e.g.
+            // `@DotNetType(...) export declare class X {}`). Handle the class forms here,
+            // mirroring the bare `declare class` path in Declaration(), so decorators reach
+            // the class body; other ambient forms go through AmbientDeclaration() and reject
+            // decorators.
+            if (Match(TokenType.ABSTRACT))
+            {
+                Consume(TokenType.CLASS, "Expect 'class' after 'declare abstract'.");
+                decl = ClassDeclaration(isAbstract: true, classDecorators: classDecorators, isDeclare: true);
+            }
+            else if (Match(TokenType.CLASS))
+            {
+                decl = ClassDeclaration(isAbstract: false, classDecorators: classDecorators, isDeclare: true);
+            }
+            else
+            {
+                // `export declare function/const/…` — a non-class exported ambient declaration.
+                RejectDecorators();
+                decl = AmbientDeclaration();
+            }
         }
         else
         {

--- a/Program.cs
+++ b/Program.cs
@@ -99,7 +99,7 @@ switch (command)
         break;
 
     case ParsedCommand.GenDecl genDecl:
-        GenerateDeclarations(genDecl.TypeOrAssembly, genDecl.OutputPath);
+        GenerateDeclarations(genDecl.TypeOrAssembly, genDecl.OutputPath, genDecl.Json);
         break;
 }
 
@@ -809,35 +809,23 @@ static void CreateNuGetPackage(string assemblyPath, PackageJson? packageJson, Pa
     }
 }
 
-static void GenerateDeclarations(string typeOrAssembly, string? outputPath)
+static void GenerateDeclarations(string typeOrAssembly, string? outputPath, bool json)
 {
     try
     {
-        var generator = new DeclarationGenerator();
-        string result;
-
-        // Check if this is an assembly file path
-        if (typeOrAssembly.EndsWith(".dll", StringComparison.OrdinalIgnoreCase) ||
-            typeOrAssembly.EndsWith(".exe", StringComparison.OrdinalIgnoreCase))
-        {
-            if (!File.Exists(typeOrAssembly))
-            {
-                Console.WriteLine($"Error: Assembly not found: {typeOrAssembly}");
-                Environment.Exit(1);
-            }
-            result = generator.GenerateForAssembly(typeOrAssembly);
-        }
-        else
-        {
-            // Treat as a type name
-            result = generator.GenerateForType(typeOrAssembly);
-        }
+        // --gen-decl is a .NET interop *discovery* tool (issue #1194): it inspects a type,
+        // namespace, or assembly and reports which members are usable from TypeScript interop,
+        // with the `dotnet:` import line for usable types. It no longer emits pasteable TS
+        // source (which was lossy for Span<T>/ref/pointer surfaces — see #1193).
+        var generator = new DiscoveryGenerator();
+        var report = generator.Generate(typeOrAssembly);
+        string result = json ? DiscoveryEmitter.EmitJson(report) : DiscoveryEmitter.EmitText(report);
 
         // Output to file or console
         if (outputPath != null)
         {
             File.WriteAllText(outputPath, result);
-            Console.WriteLine($"Generated declarations: {outputPath}");
+            Console.WriteLine($"Wrote discovery report: {outputPath}");
         }
         else
         {
@@ -885,7 +873,7 @@ static void PrintHelp()
     Console.WriteLine("  sharpts [options] [script.ts] [args...]");
     Console.WriteLine("  sharpts [options] script.ts -- [script-args...]");
     Console.WriteLine("  sharpts --compile <script.ts> [compile-options]");
-    Console.WriteLine("  sharpts --gen-decl <TypeName|AssemblyPath> [-o output.d.ts]");
+    Console.WriteLine("  sharpts --gen-decl <TypeName|Namespace|AssemblyPath> [--json] [-o output.txt]");
     Console.WriteLine();
     Console.WriteLine("Options:");
     Console.WriteLine("  -h, --help                    Show this help message");
@@ -927,6 +915,8 @@ static void PrintHelp()
     Console.WriteLine("  sharpts --compile app.ts          Compile to app.dll");
     Console.WriteLine("  sharpts --compile app.ts -t exe   Compile to executable");
     Console.WriteLine("  sharpts --compile app.ts --pack   Compile and create NuGet package");
+    Console.WriteLine("  sharpts --gen-decl System.Text.StringBuilder   Inspect a .NET type for interop");
+    Console.WriteLine("  sharpts --gen-decl System.Text     List the interop-usable types in a namespace");
 }
 
 static void PrintCompileUsage()

--- a/STATUS.md
+++ b/STATUS.md
@@ -478,8 +478,11 @@ SharpTS implements 20+ Node.js built-in modules accessible via `import ... from 
 | Exception mapping | ✅ | .NET exceptions surface as JS-catchable errors with message preservation (`DotNetExceptionMapper`) |
 | Value / reference type marshaling | ✅ | Primitives, strings, arrays, dictionaries; `DotNetMarshaller` centralizes conversion |
 | External assembly discovery | ✅ | `TryResolveExternalType` scans loaded AppDomain assemblies; no additional reference wiring needed |
+| `--gen-decl` discovery tool | ✅ | Inspect a type/namespace/assembly: faithful CLR signatures + per-member usable/unsupported marker + `dotnet:` import line + `--json` (issue #1194) |
 
 Compiled mode uses late-bound reflection to the shim (`DotNetDelegateShim` / `DotNetEventBinder`) so the output DLL stays standalone. See `docs/dotnet-types.md` for the full guide.
+
+`--gen-decl` (`DiscoveryGenerator` / `DiscoveryEmitter`) reports which members are usable from interop using `DotNetInteropClassifier` — the same by-ref/pointer/ref-struct/open-generic rules the runtime marshaller enforces, so the tool and the runtime never disagree. It reports faithfully rather than emitting pasteable TypeScript (realistic BCL surfaces have `Span<T>`/`ref`/pointer members with no valid TS spelling). Hand-written `@DotNetType(...) export declare class` declarations remain the consumption path.
 
 ---
 

--- a/SharpTS.Tests/CliTests/CommandLineParserTests.cs
+++ b/SharpTS.Tests/CliTests/CommandLineParserTests.cs
@@ -323,6 +323,25 @@ public class CommandLineParserTests
     }
 
     [Fact]
+    public void Parse_GenDecl_JsonFlag_SetsJson()
+    {
+        var result = _parser.Parse(["--gen-decl", "System.Guid", "--json"]);
+
+        var genDecl = Assert.IsType<ParsedCommand.GenDecl>(result);
+        Assert.Equal("System.Guid", genDecl.TypeOrAssembly);
+        Assert.True(genDecl.Json);
+    }
+
+    [Fact]
+    public void Parse_GenDecl_DefaultsJsonFalse()
+    {
+        var result = _parser.Parse(["--gen-decl", "System.Guid"]);
+
+        var genDecl = Assert.IsType<ParsedCommand.GenDecl>(result);
+        Assert.False(genDecl.Json);
+    }
+
+    [Fact]
     public void Parse_GenDecl_MissingArg_ReturnsError()
     {
         var result = _parser.Parse(["--gen-decl"]);

--- a/SharpTS.Tests/CompilerTests/DotNetTypeTests.cs
+++ b/SharpTS.Tests/CompilerTests/DotNetTypeTests.cs
@@ -188,6 +188,30 @@ public class DotNetTypeTests
     }
 
     [Fact]
+    public void StringBuilder_Append_Works_OnExportDeclareClass()
+    {
+        // `@DotNetType(...) export declare class X` is the form docs/dotnet-types.md shows.
+        // Before issue #1192 this failed to even parse; verify compiled mode handles the
+        // exported ambient class identically to the bare `declare class` form above.
+        var source = """
+            @DotNetType("System.Text.StringBuilder")
+            export declare class StringBuilder {
+                constructor();
+                append(value: string): StringBuilder;
+                toString(): string;
+            }
+            let sb: StringBuilder = new StringBuilder();
+            sb.append("Hello");
+            sb.append(" ");
+            sb.append("World");
+            console.log(sb.toString());
+            """;
+
+        var output = TestHarness.RunCompiled(source, DecoratorMode.Legacy);
+        Assert.Equal("Hello World\n", output);
+    }
+
+    [Fact]
     public void StringBuilder_MethodChaining_Works()
     {
         var source = """

--- a/SharpTS.Tests/DeclarationTests/DiscoveryGeneratorTests.cs
+++ b/SharpTS.Tests/DeclarationTests/DiscoveryGeneratorTests.cs
@@ -1,0 +1,182 @@
+using System.Text.Json;
+using SharpTS.Declaration;
+using Xunit;
+
+namespace SharpTS.Tests.DeclarationTests;
+
+/// <summary>
+/// Tests for the <c>--gen-decl</c> discovery/inspection tool (issue #1194): faithful .NET
+/// signatures, per-member usability classification, the <c>dotnet:</c> import line, namespace vs
+/// type granularity, and <c>--json</c> output.
+/// </summary>
+public class DiscoveryGeneratorTests
+{
+    private readonly DiscoveryGenerator _generator = new();
+
+    // ── Faithful type rendering (DotNetTypeMapper.Describe) ──────────
+
+    [Theory]
+    [InlineData(typeof(int), "int")]
+    [InlineData(typeof(string), "string")]
+    [InlineData(typeof(void), "void")]
+    [InlineData(typeof(int[]), "int[]")]
+    [InlineData(typeof(int?), "int?")]
+    [InlineData(typeof(List<int>), "List<int>")]
+    [InlineData(typeof(Dictionary<string, int>), "Dictionary<string, int>")]
+    [InlineData(typeof(ReadOnlySpan<char>), "ReadOnlySpan<char>")]
+    public void Describe_RendersFaithfulDotNetShape(Type type, string expected)
+    {
+        Assert.Equal(expected, DotNetTypeMapper.Describe(type));
+    }
+
+    // ── Interop classification ───────────────────────────────────────
+
+    [Fact]
+    public void Classifier_MarksPlainTypesUsable()
+    {
+        Assert.Null(DotNetInteropClassifier.UnsupportedSlotReason(typeof(int)));
+        Assert.Null(DotNetInteropClassifier.UnsupportedSlotReason(typeof(string)));
+        Assert.Null(DotNetInteropClassifier.UnsupportedSlotReason(typeof(List<int>)));
+    }
+
+    [Fact]
+    public void Classifier_MarksRefStructUnsupported()
+    {
+        Assert.Equal(
+            DotNetInteropClassifier.ReasonRefStruct,
+            DotNetInteropClassifier.UnsupportedSlotReason(typeof(ReadOnlySpan<char>)));
+    }
+
+    [Fact]
+    public void Classifier_MarksByRefUnsupported()
+    {
+        Assert.Equal(
+            DotNetInteropClassifier.ReasonByRef,
+            DotNetInteropClassifier.UnsupportedSlotReason(typeof(int).MakeByRefType()));
+    }
+
+    [Fact]
+    public void Classifier_MarksPointerUnsupported()
+    {
+        Assert.Equal(
+            DotNetInteropClassifier.ReasonPointer,
+            DotNetInteropClassifier.UnsupportedSlotReason(typeof(int).MakePointerType()));
+    }
+
+    [Fact]
+    public void Classifier_MarksOpenGenericUnsupported()
+    {
+        Type openArg = typeof(List<>).GetGenericArguments()[0]; // the unbound T
+        Assert.Equal(
+            DotNetInteropClassifier.ReasonOpenGeneric,
+            DotNetInteropClassifier.UnsupportedSlotReason(openArg));
+    }
+
+    // ── Type-detail report ───────────────────────────────────────────
+
+    [Fact]
+    public void GenerateForType_StringBuilder_HasImportLineAndUsableAppend()
+    {
+        var report = _generator.Generate("System.Text.StringBuilder");
+
+        Assert.Equal(DiscoveryKind.TypeDetail, report.Kind);
+        Assert.NotNull(report.Type);
+        Assert.Equal(
+            "import { StringBuilder } from \"dotnet:System.Text.StringBuilder\";",
+            report.Type!.ImportLine);
+
+        // append(value: string): StringBuilder is marshalable → usable.
+        var stringAppend = report.Type.Members.FirstOrDefault(m =>
+            m.Signature == "append(value: string): StringBuilder");
+        Assert.NotNull(stringAppend);
+        Assert.True(stringAppend!.Usable);
+        Assert.Null(stringAppend.UnsupportedReason);
+    }
+
+    [Fact]
+    public void GenerateForType_StringBuilder_FlagsSpanOverloadUnsupported()
+    {
+        var report = _generator.Generate("System.Text.StringBuilder");
+
+        // Every ReadOnlySpan<char> Append overload is unsupported with the ref-struct reason.
+        var spanAppends = report.Type!.Members
+            .Where(m => m.Signature.Contains("ReadOnlySpan<char>") && m.Signature.StartsWith("append("))
+            .ToList();
+
+        Assert.NotEmpty(spanAppends);
+        Assert.All(spanAppends, m =>
+        {
+            Assert.False(m.Usable);
+            Assert.Equal(DotNetInteropClassifier.ReasonRefStruct, m.UnsupportedReason);
+        });
+    }
+
+    [Fact]
+    public void GenerateForType_Guid_RendersOutParamFaithfullyAndFlagsIt()
+    {
+        var report = _generator.Generate("System.Guid");
+
+        // tryParse(input: string, result: out Guid): bool — faithful `out`, by-ref unsupported.
+        var tryParse = report.Type!.Members.FirstOrDefault(m =>
+            m.Signature == "static tryParse(input: string, result: out Guid): bool");
+        Assert.NotNull(tryParse);
+        Assert.False(tryParse!.Usable);
+        Assert.Equal(DotNetInteropClassifier.ReasonByRef, tryParse.UnsupportedReason);
+    }
+
+    [Fact]
+    public void GenerateForType_Guid_ReportsStructKind()
+    {
+        var report = _generator.Generate("System.Guid");
+        Assert.Equal("struct", report.Type!.Kind);
+    }
+
+    // ── Namespace table of contents ──────────────────────────────────
+
+    [Fact]
+    public void Generate_Namespace_ReturnsTableOfContents()
+    {
+        var report = _generator.Generate("System.Text");
+
+        Assert.Equal(DiscoveryKind.TableOfContents, report.Kind);
+        Assert.NotNull(report.Types);
+        Assert.Contains(report.Types!, t => t.FullName == "System.Text.StringBuilder" && t.Usable);
+        // Ref-struct enumerators in the namespace are listed but marked unsupported.
+        Assert.Contains(report.Types!, t => !t.Usable);
+    }
+
+    [Fact]
+    public void Generate_UnresolvableInput_Throws()
+    {
+        Assert.Throws<ArgumentException>(() => _generator.Generate("Nope.Not.A.Real.Type"));
+    }
+
+    // ── Emitter output ───────────────────────────────────────────────
+
+    [Fact]
+    public void EmitText_TypeDetail_IncludesMarkersAndImport()
+    {
+        var report = _generator.Generate("System.Text.StringBuilder");
+        string text = DiscoveryEmitter.EmitText(report);
+
+        Assert.Contains("import { StringBuilder } from \"dotnet:System.Text.StringBuilder\";", text);
+        Assert.Contains("[usable]", text);
+        Assert.Contains("[unsupported]", text);
+        Assert.Contains("ReadOnlySpan<char>", text);
+    }
+
+    [Fact]
+    public void EmitJson_ProducesValidParseableJson()
+    {
+        var report = _generator.Generate("System.Guid");
+        string json = DiscoveryEmitter.EmitJson(report);
+
+        using var doc = JsonDocument.Parse(json); // throws if invalid
+        var root = doc.RootElement;
+        Assert.Equal("typeDetail", root.GetProperty("kind").GetString());
+        Assert.Equal("System.Guid", root.GetProperty("query").GetString());
+        Assert.True(root.GetProperty("type").GetProperty("members").GetArrayLength() > 0);
+        // Angle brackets stay readable (relaxed escaping), not <-escaped.
+        Assert.DoesNotContain("\\u003C", json);
+    }
+}

--- a/SharpTS.Tests/InterpreterTests/DotNetTypeInterpreterTests.cs
+++ b/SharpTS.Tests/InterpreterTests/DotNetTypeInterpreterTests.cs
@@ -14,6 +14,30 @@ public class DotNetTypeInterpreterTests
     #region Instance methods / constructor
 
     [Fact]
+    public void StringBuilder_Append_Works_OnExportDeclareClass()
+    {
+        // `@DotNetType(...) export declare class X` is the exact form docs/dotnet-types.md
+        // and `--gen-decl` emit. It must round-trip identically to the bare `declare class`
+        // form above (regression guard for issue #1192).
+        var source = """
+            @DotNetType("System.Text.StringBuilder")
+            export declare class StringBuilder {
+                constructor();
+                append(value: string): StringBuilder;
+                toString(): string;
+            }
+            let sb: StringBuilder = new StringBuilder();
+            sb.append("Hello");
+            sb.append(" ");
+            sb.append("World");
+            console.log(sb.toString());
+            """;
+
+        var output = TestHarness.RunInterpreted(source, DecoratorMode.Legacy);
+        Assert.Equal("Hello World\n", output);
+    }
+
+    [Fact]
     public void StringBuilder_Append_Works()
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/DecoratorTests.cs
+++ b/SharpTS.Tests/SharedTests/DecoratorTests.cs
@@ -386,4 +386,116 @@ public class DecoratorTests
     }
 
     #endregion
+
+    #region Decorators on exported classes (issue #1192)
+
+    // `@decorator` legally appears *before* `export` (the only valid decorator
+    // placement TypeScript allows on an exported class). Before the fix, Declaration()
+    // only checked EXPORT before parsing decorators, so `@dec export class` fell through
+    // to "Decorators are not valid here." These cover every export-class form.
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void LegacyClassDecorator_OnExportClass(ExecutionMode mode)
+    {
+        const string source = """
+            function logged(target: any): void {
+                console.log("Class decorated");
+            }
+
+            @logged
+            export class MyClass {
+                constructor() {}
+            }
+            """;
+
+        var output = TestHarness.Run(source, mode, DecoratorMode.Legacy);
+        Assert.Equal("Class decorated\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void LegacyClassDecorator_OnExportDefaultClass(ExecutionMode mode)
+    {
+        const string source = """
+            function logged(target: any): void {
+                console.log("Class decorated");
+            }
+
+            @logged
+            export default class MyClass {
+                constructor() {}
+            }
+            """;
+
+        var output = TestHarness.Run(source, mode, DecoratorMode.Legacy);
+        Assert.Equal("Class decorated\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void LegacyClassDecorator_OnExportAbstractClass(ExecutionMode mode)
+    {
+        const string source = """
+            function logged(target: any): void {
+                console.log("Class decorated");
+            }
+
+            @logged
+            export abstract class Shape {
+                abstract area(): number;
+            }
+
+            class Square extends Shape {
+                constructor(private side: number) { super(); }
+                area(): number { return this.side * this.side; }
+            }
+
+            console.log(new Square(3).area());
+            """;
+
+        var output = TestHarness.Run(source, mode, DecoratorMode.Legacy);
+        Assert.Equal("Class decorated\n9\n", output);
+    }
+
+    [Fact]
+    public void ClassDecorator_OnExportClass_PassesDecoratorArgument()
+    {
+        // Factory decorator on an exported class — the decorator arguments must still be
+        // threaded through, not dropped, when the class is exported.
+        const string source = """
+            function tag(name: string): any {
+                return function (target: any): void {
+                    console.log("Tagged: " + name);
+                };
+            }
+
+            @tag("widget")
+            export class Widget {
+                constructor() {}
+            }
+            """;
+
+        var output = TestHarness.RunInterpreted(source, DecoratorMode.Legacy);
+        Assert.Equal("Tagged: widget\n", output);
+    }
+
+    [Fact]
+    public void Decorator_OnExportFunction_IsRejected()
+    {
+        // Decorators are only valid on classes/class members — an exported *function*
+        // with a preceding decorator must still be a parse error.
+        const string source = """
+            function logged(target: any): void {}
+
+            @logged
+            export function foo(): void {}
+            """;
+
+        var exception = Assert.Throws<Exception>(() =>
+            TestHarness.RunInterpreted(source, DecoratorMode.Legacy));
+        Assert.Contains("Decorators are not valid here", exception.Message);
+    }
+
+    #endregion
 }

--- a/docs/dotnet-types.md
+++ b/docs/dotnet-types.md
@@ -421,43 +421,67 @@ console.log(sb.toString());  // Method call (parentheses required)
 
 ---
 
-## Generating Declarations
+## Discovering .NET Types (`--gen-decl`)
 
-SharpTS can auto-generate TypeScript declarations from .NET types using the `DeclarationGenerator`:
+`--gen-decl` is an **interop discovery/inspection tool**: point it at a .NET type, namespace, or
+assembly and it reports the real CLR signatures and which members SharpTS can actually use today.
+It does *not* emit pasteable TypeScript source — realistic BCL types have `Span<T>`, `ref`/`out`,
+and pointer members with no valid TypeScript spelling, so faithful description beats lossy codegen.
+To bind a type in your program, hand-write a `@DotNetType` declaration (below) using the usable
+members it reports.
 
-### From Individual Types
+### Inspect a type
 
-```csharp
-var generator = new DeclarationGenerator();
-string declaration = generator.GenerateForType("System.Text.StringBuilder");
-Console.WriteLine(declaration);
+```
+sharpts --gen-decl System.Text.StringBuilder
 ```
 
-Output:
-```typescript
-@DotNetType("System.Text.StringBuilder")
-export declare class StringBuilder {
-    constructor();
-    constructor(capacity: number);
-    constructor(value: string);
-    append(value: string): StringBuilder;
-    append(value: number): StringBuilder;
-    append(value: boolean): StringBuilder;
-    appendLine(): StringBuilder;
-    appendLine(value: string): StringBuilder;
-    insert(index: number, value: string): StringBuilder;
-    remove(startIndex: number, length: number): StringBuilder;
-    replace(oldValue: string, newValue: string): StringBuilder;
-    clear(): StringBuilder;
-    toString(): string;
-    readonly length: number;
-    readonly capacity: number;
-}
+```
+System.Text.StringBuilder — class
+
+  import { StringBuilder } from "dotnet:System.Text.StringBuilder";
+
+  Constructors:
+    [usable]      constructor()
+    [usable]      constructor(capacity: int)
+    [usable]      constructor(value: string)
+  ...
+  Instance methods:
+    [usable]      append(value: string): StringBuilder
+    [usable]      append(value: char[], startIndex: int, charCount: int): StringBuilder
+    [unsupported] copyTo(sourceIndex: int, destination: Span<char>, count: int): void   — ref struct (Span/ReadOnlySpan) cannot cross the interop boundary
 ```
 
-### Type Mapping in Generated Declarations
+Each member is marked `[usable]` or `[unsupported]` using the **same rules the runtime interop
+marshaller enforces**, so the tool and your program can never disagree about what's callable. The
+four unsupported categories are by-ref (`ref`/`out`/`in`) parameters, pointer types, ref structs
+(`Span<T>`/`ReadOnlySpan<T>`), and open generics. Signatures are shown with faithful .NET types
+(`int`, `char[]`, `ReadOnlySpan<char>`, `out Guid`), not coerced into TypeScript.
 
-The generator automatically maps .NET types to TypeScript:
+> The `import { … } from "dotnet:…";` line is a preview of the planned `dotnet:` import scheme
+> (issue #1195). Until it lands, consume the type with a hand-written `@DotNetType` declaration.
+
+### List a namespace or assembly
+
+Passing a namespace or an assembly path prints a table of contents instead of member detail:
+
+```
+sharpts --gen-decl System.Text            # every loaded type in the namespace
+sharpts --gen-decl ./MyLibrary.dll        # every public type in the assembly
+```
+
+### JSON output
+
+Add `--json` for machine-readable output (e.g. to feed editor tooling):
+
+```
+sharpts --gen-decl System.Guid --json
+sharpts --gen-decl System.Guid -o guid.txt   # or write to a file
+```
+
+### Type mapping for hand-written declarations
+
+When you hand-write a `@DotNetType` declaration, map .NET types to TypeScript as follows:
 
 | .NET Type | TypeScript Type |
 |-----------|-----------------|


### PR DESCRIPTION
Fixes #1192 and implements #1194 (part of the #1195 .NET-interop redesign thread).

## #1192 — decorated exported classes
Running the repro (not just reading tests) surfaced **two** bugs:

1. **Parser** — `Declaration()` checked `EXPORT` *before* parsing decorators, so `@decorator export class` fell through to *"Decorators are not valid here."* Now it re-checks `EXPORT` after `ParseDecorators()` and threads the decorators into `ExportDeclaration(List<Decorator>?)`. That method's `export declare` branch now handles `[abstract] class` inline — which also fixed a **second latent bug**: bare `export declare class` never parsed before (it routed to `AmbientDeclaration()`, which has no `class` case). A `RejectDecorators()` guard keeps `@dec export function/const/{…}` correctly erroring.
2. **IL compiler** — `EmitDefaultEntryPoint` only matched bare `Stmt.Class` for runtime-decorator emission, so `@dec export class` **silently dropped its decorator in compiled mode only** (interpreter was fine). Added an `Stmt.Export { Declaration: Stmt.Class }` branch.

`@DotNetType(...) export declare class` (the form `docs/dotnet-types.md` shows) now round-trips end-to-end in both interpreter and compiled modes.

## #1194 — `--gen-decl` repurposed as a discovery/inspection tool
`--gen-decl` no longer emits (lossy) TypeScript source — realistic BCL types have `Span<T>`/`ref`/pointer members with no valid TS spelling. It now **describes** a type/namespace/assembly:

- **Faithful CLR signatures** (`ReadOnlySpan<char>`, `out Guid`, `int[]`, `List<int>`) via `DotNetTypeMapper.Describe` — never coerced into invalid TS.
- **Per-member usable/unsupported markers** via new `DotNetInteropClassifier` (by-ref / pointer / ref-struct / open-generic), mirroring the runtime marshaller's limits so the tool and runtime can never disagree. The #1195 `dotnet:` import resolver is meant to reuse this same classifier.
- Prints the **`dotnet:` import line** for usable types.
- **Type / namespace / assembly** granularity, plus **`--json`** output.

New files: `Declaration/{DotNetInteropClassifier,DiscoveryReport,DiscoveryGenerator,DiscoveryEmitter}.cs`. `TypeInspector` kept (extended `ParameterMetadata` with `IsByRef/IsOut/IsIn`). The old `DeclarationGenerator`/`TypeScriptEmitter` remain a tested library — hand-written `@DotNetType export declare class` is still a supported consumption path — just no longer CLI-wired. #1193 stays closed-superseded (untouched).

### Example
```
$ sharpts --gen-decl System.Text.StringBuilder
System.Text.StringBuilder — class

  import { StringBuilder } from "dotnet:System.Text.StringBuilder";
  ...
  Instance methods:
    [usable]      append(value: string): StringBuilder
    [unsupported] copyTo(sourceIndex: int, destination: Span<char>, count: int): void   — ref struct (Span/ReadOnlySpan) cannot cross the interop boundary
```

## Verification
- **xUnit full suite: 14945 / 0**
- **TypeScript conformance: 31 / 0**
- **Test262 (interp + compiled): 22 / 0 / 4 skip** — matches committed baseline

New tests: `DiscoveryGeneratorTests`, plus additions to `DecoratorTests`, `DotNetTypeInterpreterTests`, `DotNetTypeTests`, `CommandLineParserTests`. Docs updated (`docs/dotnet-types.md`, `STATUS.md`).
