### PR TITLE
feat(interop): dotnet: import-scheme resolution (#1195)

### DIFF
--- a/Compilation/ILCompiler.Modules.cs
+++ b/Compilation/ILCompiler.Modules.cs
@@ -25,6 +25,15 @@ public partial class ILCompiler
             return;
         }
 
+        // dotnet: interop modules have no emitted module type — their imports compile to
+        // direct external-interop IL (RegisterDotNetImports), never to export-field reads.
+        // (Also avoids duplicate $Module_ names: distinct specifiers in one namespace share
+        // a filename-derived ModuleName.)
+        if (module.IsDotNetModule)
+        {
+            return;
+        }
+
         // Create module class: $Module_<name>
         string moduleTypeName = $"$Module_{CompilationContext.SanitizeModuleName(module.ModuleName)}";
         var moduleType = _moduleBuilder.DefineType(
@@ -246,6 +255,65 @@ public partial class ILCompiler
     };
 
     /// <summary>
+    /// Registers the external .NET types imported via <c>dotnet:</c> specifiers in this module,
+    /// routing them through the same <see cref="TypeMapper"/>/ExternalTypes registries an
+    /// <c>@DotNetType declare class</c> uses — so construction, member calls, and static access
+    /// compile to the identical direct-IL external-interop paths (fully standalone output).
+    /// Resolution happened at module-load time (<see cref="DotNetImports.EnsureImports"/>);
+    /// this only transfers the resolved types into the compilation registries.
+    /// </summary>
+    private void RegisterDotNetImports(ParsedModule module)
+    {
+        foreach (var stmt in module.Statements)
+        {
+            if (stmt is not Stmt.Import import || !DotNetImports.IsDotNetSpecifier(import.ModulePath))
+                continue;
+            if (import.NamedImports == null)
+                continue;
+
+            var dotnetModule = _modules.Resolver?.GetCachedModule(import.ModulePath);
+            if (dotnetModule?.DotNetExports == null)
+                continue;
+
+            foreach (var spec in import.NamedImports)
+            {
+                if (!dotnetModule.DotNetExports.TryGetValue(spec.Imported.Lexeme, out var externalType))
+                    continue;
+
+                string localName = spec.LocalName?.Lexeme ?? spec.Imported.Lexeme;
+                // The local binding name drives `new X()` / static-access dispatch; the CLR
+                // simple name drives receiver-typed instance dispatch (the checker's
+                // synthesized class is named after the CLR type).
+                RegisterDotNetImportedType(localName, externalType);
+                RegisterDotNetImportedType(externalType.Name, externalType);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Registers one name → external type mapping unless a user-defined class already claims
+    /// the name. ExternalTypes lookups run before user-class dispatch, so an unconditional
+    /// registration would hijack same-named user classes program-wide.
+    /// </summary>
+    private void RegisterDotNetImportedType(string name, Type externalType)
+    {
+        if (_modules.ClassToModule.ContainsKey(name))
+        {
+            if (!_classes.ExternalTypes.TryGetValue(name, out var existing) || existing != externalType)
+            {
+                Console.WriteLine(
+                    $"Warning: dotnet: import '{name}' ({externalType.FullName}) conflicts with a " +
+                    "user-defined class of the same name; the user class wins in compiled dispatch. " +
+                    "Rename the import (import { X as Alias }) to use the .NET type.");
+            }
+            return;
+        }
+
+        _classes.ExternalTypes.TryAdd(name, externalType);
+        _typeMapper.RegisterExternalType(name, externalType);
+    }
+
+    /// <summary>
     /// Creates static fields for imported values in this module.
     /// This allows functions in the module to access imported values.
     /// </summary>
@@ -260,6 +328,11 @@ public partial class ILCompiler
                 // Skip built-in modules - they have their own handling
                 string? builtInModuleName = Runtime.BuiltIns.Modules.BuiltInModuleRegistry.GetModuleName(import.ModulePath);
                 if (builtInModuleName != null)
+                    continue;
+
+                // dotnet: imports need no import fields — every use site compiles to direct
+                // external-interop IL keyed off the ExternalTypes registry (RegisterDotNetImports).
+                if (DotNetImports.IsDotNetSpecifier(import.ModulePath))
                     continue;
 
                 // Default import: import x from './module'
@@ -421,6 +494,12 @@ public partial class ILCompiler
         if (module.IsScript)
         {
             EmitScriptInit(module);
+            return;
+        }
+
+        // dotnet: interop modules have no module type and nothing to initialize.
+        if (module.IsDotNetModule)
+        {
             return;
         }
 

--- a/Compilation/ILCompiler.cs
+++ b/Compilation/ILCompiler.cs
@@ -1059,6 +1059,14 @@ public partial class ILCompiler
         _modules.CurrentPath = null;
         _modules.CurrentDotNetNamespace = null;
 
+        // dotnet: imports register external types AFTER all user declarations so that
+        // name-collision detection sees every class in the program (ClassToModule is
+        // complete only once the loop above finishes).
+        foreach (var module in modules)
+        {
+            RegisterDotNetImports(module);
+        }
+
         // Alias namespace function import aliases to their targets now that every namespace
         // member function is in the registry (#657).
         ResolveNamespaceImportAliasFunctions();

--- a/Compilation/ILEmitter.Calls.ExternalInterop.cs
+++ b/Compilation/ILEmitter.Calls.ExternalInterop.cs
@@ -43,7 +43,20 @@ public partial class ILEmitter
         // Emit receiver and prepare for member access
         EmitExpression(receiver);
         EmitBoxIfNeeded(receiver);
-        bool isValueType = PrepareReceiverForMemberAccess(externalType);
+        bool isValueType;
+        if (externalType.IsValueType && !method.DeclaringType!.IsValueType)
+        {
+            // A method inherited from a reference base (Enum.ToString(), ValueType.Equals,
+            // Object.GetHashCode, …) takes the BOXED receiver as `this` — Ldloca/Call with an
+            // unboxed address would pass a managed pointer where an object reference is
+            // expected (NRE inside the callee).
+            IL.Emit(OpCodes.Castclass, method.DeclaringType);
+            isValueType = false;
+        }
+        else
+        {
+            isValueType = PrepareReceiverForMemberAccess(externalType);
+        }
 
         // Emit arguments with type conversion (handles params arrays)
         EmitExternalCallArguments(arguments, method, candidate);

--- a/Compilation/ILEmitter.Modules.cs
+++ b/Compilation/ILEmitter.Modules.cs
@@ -21,6 +21,11 @@ public partial class ILEmitter
         if (import.IsTypeOnly)
             return;
 
+        // dotnet: interop imports emit no binding code — use sites compile to direct
+        // external-interop IL via the ExternalTypes registry (see RegisterDotNetImports).
+        if (SharpTS.Modules.DotNetImports.IsDotNetSpecifier(import.ModulePath))
+            return;
+
         // Check for built-in module imports (fs, path, etc.) and stdlib-internal
         // primitive:* imports. Both route through the same emitter-registry dispatch.
         string? builtInModuleName = ResolveBuiltInOrPrimitiveKey(import.ModulePath);

--- a/Compilation/ILEmitter.Properties.External.cs
+++ b/Compilation/ILEmitter.Properties.External.cs
@@ -42,6 +42,15 @@ public partial class ILEmitter
 
         if (field != null)
         {
+            // Literal (const) fields — enum members included — have no storage slot, so
+            // Ldsfld is invalid IL on them. Embed the compile-time constant instead.
+            if (field.IsLiteral)
+            {
+                EmitExternalLiteralField(field);
+                SetStackUnknown();
+                return true;
+            }
+
             IL.Emit(OpCodes.Ldsfld, field);
 
             if (field.FieldType.IsValueType)
@@ -53,6 +62,54 @@ public partial class ILEmitter
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// Loads a literal (const) field's value as a boxed object. Enum members are boxed to the
+    /// enum type (so they round-trip into .NET parameters and ToString correctly); numeric
+    /// constants normalize to double, mirroring the interpreter's <c>DotNetMarshaller.WrapReturn</c>.
+    /// </summary>
+    private void EmitExternalLiteralField(System.Reflection.FieldInfo field)
+    {
+        object? raw = field.GetRawConstantValue();
+
+        if (field.FieldType.IsEnum && raw != null)
+        {
+            // Box expects the underlying integral on the stack when boxing an enum type.
+            var underlying = Enum.GetUnderlyingType(field.FieldType);
+            if (underlying == typeof(long) || underlying == typeof(ulong))
+            {
+                IL.Emit(OpCodes.Ldc_I8, raw is ulong ul ? unchecked((long)ul) : Convert.ToInt64(raw));
+            }
+            else
+            {
+                IL.Emit(OpCodes.Ldc_I4, raw is uint ui ? unchecked((int)ui) : Convert.ToInt32(raw));
+            }
+            IL.Emit(OpCodes.Box, field.FieldType);
+            return;
+        }
+
+        switch (raw)
+        {
+            case null:
+                IL.Emit(OpCodes.Ldnull);
+                break;
+            case string s:
+                IL.Emit(OpCodes.Ldstr, s);
+                break;
+            case bool b:
+                IL.Emit(b ? OpCodes.Ldc_I4_1 : OpCodes.Ldc_I4_0);
+                IL.Emit(OpCodes.Box, _ctx.Types.Boolean);
+                break;
+            case char c:
+                // The interpreter's WrapReturn maps char to a one-character string; match it.
+                IL.Emit(OpCodes.Ldstr, c.ToString());
+                break;
+            default:
+                IL.Emit(OpCodes.Ldc_R8, Convert.ToDouble(raw));
+                IL.Emit(OpCodes.Box, _ctx.Types.Double);
+                break;
+        }
     }
 
     /// <summary>

--- a/Declaration/TypeInspector.cs
+++ b/Declaration/TypeInspector.cs
@@ -25,8 +25,15 @@ public record TypeMetadata(
     List<EnumMemberMetadata> EnumMembers,
     ObsoleteMetadata? Obsolete = null,
     bool IsNested = false,
-    string? DeclaringTypeName = null
-);
+    string? DeclaringTypeName = null,
+    List<FieldMetadata>? Fields = null,
+    List<FieldMetadata>? StaticFields = null,
+    bool HasEvents = false
+)
+{
+    public List<FieldMetadata> Fields { get; init; } = Fields ?? [];
+    public List<FieldMetadata> StaticFields { get; init; } = StaticFields ?? [];
+}
 
 public record MethodMetadata(
     string Name,
@@ -42,6 +49,15 @@ public record PropertyMetadata(
     Type PropertyType,
     bool CanRead,
     bool CanWrite,
+    ObsoleteMetadata? Obsolete = null,
+    bool IsIndexer = false
+);
+
+public record FieldMetadata(
+    string Name,
+    string TypeScriptName,
+    Type FieldType,
+    bool IsReadonly,
     ObsoleteMetadata? Obsolete = null
 );
 
@@ -57,7 +73,8 @@ public record ParameterMetadata(
     object? DefaultValue,
     bool IsByRef = false,
     bool IsOut = false,
-    bool IsIn = false
+    bool IsIn = false,
+    bool IsParams = false
 );
 
 public record EnumMemberMetadata(
@@ -73,7 +90,15 @@ public class TypeInspector
     /// <summary>
     /// Extracts metadata from a .NET type.
     /// </summary>
-    public TypeMetadata Inspect(Type type)
+    /// <param name="type">The type to inspect.</param>
+    /// <param name="includeInherited">
+    /// When true, the sweep drops <see cref="BindingFlags.DeclaredOnly"/> and includes members
+    /// inherited from base types (including <see cref="object"/>). The runtime interop dispatch
+    /// (<c>DotNetTypeRegistry.GetMethods</c>) sees inherited members, so consumers that mirror the
+    /// callable surface — the <c>dotnet:</c> import synthesizer — must pass true. The declaration
+    /// generator keeps the declared-only default so emitted declarations stay minimal.
+    /// </param>
+    public TypeMetadata Inspect(Type type, bool includeInherited = false)
     {
         var methods = new List<MethodMetadata>();
         var staticMethods = new List<MethodMetadata>();
@@ -81,6 +106,10 @@ public class TypeInspector
         var staticProperties = new List<PropertyMetadata>();
         var constructors = new List<ConstructorMetadata>();
         var enumMembers = new List<EnumMemberMetadata>();
+        var fields = new List<FieldMetadata>();
+        var staticFields = new List<FieldMetadata>();
+
+        var declaredOnly = includeInherited ? BindingFlags.Default : BindingFlags.DeclaredOnly;
 
         // Handle enum types
         if (type.IsEnum)
@@ -91,6 +120,17 @@ public class TypeInspector
                 enumMembers.Add(new EnumMemberMetadata(name, Convert.ToInt64(value)));
             }
 
+            if (includeInherited)
+            {
+                // Enum values are callable at runtime (toString, hasFlag, …); surface those
+                // instance methods for consumers that mirror the callable surface.
+                foreach (var method in type.GetMethods(BindingFlags.Public | BindingFlags.Instance))
+                {
+                    if (ShouldIncludeMethod(method, includeInherited))
+                        methods.Add(ExtractMethod(method));
+                }
+            }
+
             return new TypeMetadata(
                 type.FullName ?? type.Name,
                 type.Name,
@@ -98,7 +138,7 @@ public class TypeInspector
                 IsAbstract: false,
                 IsInterface: false,
                 IsEnum: true,
-                Methods: [],
+                Methods: methods,
                 StaticMethods: [],
                 Properties: [],
                 StaticProperties: [],
@@ -120,33 +160,44 @@ public class TypeInspector
         }
 
         // Extract instance methods
-        foreach (var method in type.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly))
+        foreach (var method in type.GetMethods(BindingFlags.Public | BindingFlags.Instance | declaredOnly))
         {
-            if (ShouldIncludeMethod(method))
+            if (ShouldIncludeMethod(method, includeInherited))
             {
                 methods.Add(ExtractMethod(method));
             }
         }
 
         // Extract static methods
-        foreach (var method in type.GetMethods(BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly))
+        foreach (var method in type.GetMethods(BindingFlags.Public | BindingFlags.Static | declaredOnly))
         {
-            if (ShouldIncludeMethod(method))
+            if (ShouldIncludeMethod(method, includeInherited))
             {
                 staticMethods.Add(ExtractMethod(method));
             }
         }
 
         // Extract instance properties
-        foreach (var prop in type.GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly))
+        foreach (var prop in type.GetProperties(BindingFlags.Public | BindingFlags.Instance | declaredOnly))
         {
             properties.Add(ExtractProperty(prop));
         }
 
         // Extract static properties
-        foreach (var prop in type.GetProperties(BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly))
+        foreach (var prop in type.GetProperties(BindingFlags.Public | BindingFlags.Static | declaredOnly))
         {
             staticProperties.Add(ExtractProperty(prop));
+        }
+
+        // Extract public fields (e.g. Guid.Empty, TimeSpan.Zero). The runtime member lookup
+        // (DotNetTypeRegistry.GetPropertyOrField) resolves fields alongside properties.
+        foreach (var field in type.GetFields(BindingFlags.Public | BindingFlags.Instance | declaredOnly))
+        {
+            fields.Add(ExtractField(field));
+        }
+        foreach (var field in type.GetFields(BindingFlags.Public | BindingFlags.Static | declaredOnly))
+        {
+            staticFields.Add(ExtractField(field));
         }
 
         bool isStatic = type.IsAbstract && type.IsSealed; // Static classes in C#
@@ -166,18 +217,22 @@ public class TypeInspector
             EnumMembers: [],
             Obsolete: ExtractObsoleteInfo(type),
             IsNested: type.IsNested,
-            DeclaringTypeName: type.DeclaringType?.Name
+            DeclaringTypeName: type.DeclaringType?.Name,
+            Fields: fields,
+            StaticFields: staticFields,
+            HasEvents: type.GetEvents(BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static).Length > 0
         );
     }
 
-    private static bool ShouldIncludeMethod(MethodInfo method)
+    private static bool ShouldIncludeMethod(MethodInfo method, bool includeInherited = false)
     {
-        // Exclude property accessors
+        // Exclude property accessors and operators
         if (method.IsSpecialName)
             return false;
 
-        // Exclude methods inherited from Object (unless they're overridden)
-        if (method.DeclaringType == typeof(object))
+        // Exclude methods inherited from Object (unless they're overridden). When mirroring the
+        // full callable surface, keep them — toString()/getHashCode() work at runtime.
+        if (!includeInherited && method.DeclaringType == typeof(object))
             return false;
 
         // Exclude generic method definitions for MVP (no generic support)
@@ -199,7 +254,8 @@ public class TypeInspector
         IsByRef: p.ParameterType.IsByRef,
         // `out` and `in` are both by-ref; distinguish for a faithful signature.
         IsOut: p.IsOut,
-        IsIn: p.ParameterType.IsByRef && p.IsIn
+        IsIn: p.ParameterType.IsByRef && p.IsIn,
+        IsParams: p.IsDefined(typeof(ParamArrayAttribute), inherit: false)
     );
 
     private MethodMetadata ExtractMethod(MethodInfo method)
@@ -225,7 +281,19 @@ public class TypeInspector
             property.PropertyType,
             property.CanRead,
             property.CanWrite,
-            ExtractObsoleteInfo(property)
+            ExtractObsoleteInfo(property),
+            IsIndexer: property.GetIndexParameters().Length > 0
+        );
+    }
+
+    private static FieldMetadata ExtractField(FieldInfo field)
+    {
+        return new FieldMetadata(
+            field.Name,
+            DotNetTypeMapper.ToTypeScriptPropertyName(field.Name),
+            field.FieldType,
+            IsReadonly: field.IsInitOnly || field.IsLiteral,
+            ExtractObsoleteInfo(field)
         );
     }
 

--- a/Execution/Interpreter.Expressions.cs
+++ b/Execution/Interpreter.Expressions.cs
@@ -1372,6 +1372,15 @@ public partial class Interpreter
         string currentPath = _currentModule?.Path ?? Directory.GetCurrentDirectory();
         string absolutePath = _moduleResolver.ResolveModulePath(specifier, currentPath);
 
+        // dotnet: modules have no enumerable namespace object — their export surface is
+        // defined by static named imports. Reject instead of returning a partial view.
+        if (DotNetImports.IsDotNetSpecifier(absolutePath))
+        {
+            throw new InterpreterException(
+                $"Dynamic import of '{specifier}' is not supported. " +
+                "Use a static named import: import { TypeName } from \"" + specifier + "\";");
+        }
+
         // Check if module is already loaded
         if (_loadedModules.TryGetValue(absolutePath, out var cached))
         {

--- a/Execution/Interpreter.cs
+++ b/Execution/Interpreter.cs
@@ -1712,6 +1712,19 @@ public partial class Interpreter : IDisposable
             return;
         }
 
+        // dotnet: interop modules export a DotNetClass wrapper per imported .NET type —
+        // the same runtime binding an @DotNetType declare class produces (Interpreter.DotNet.cs),
+        // registered at import-resolution time instead of class-declaration time.
+        if (module.IsDotNetModule)
+        {
+            foreach (var (name, clrType) in module.DotNetExports!)
+            {
+                moduleInstance.SetExport(name, new DotNetClass(name, clrType));
+            }
+            moduleInstance.IsExecuted = true;
+            return;
+        }
+
         // Handle built-in modules specially - populate exports from interpreter implementations
         if (module.IsBuiltIn)
         {
@@ -1820,6 +1833,14 @@ public partial class Interpreter : IDisposable
                     if (importedParsed?.IsCommonJs == true)
                     {
                         ExecuteCommonJsModule(importedParsed);
+                        importedModuleInstance = _loadedModules.GetValueOrDefault(importedPath);
+                    }
+                    // dotnet: modules are dependency-free and idempotent — execute on demand.
+                    // Covers modules reached outside the static InterpretModules order
+                    // (e.g. a dynamically imported file that itself imports a dotnet: module).
+                    else if (importedParsed?.IsDotNetModule == true)
+                    {
+                        ExecuteModule(importedParsed);
                         importedModuleInstance = _loadedModules.GetValueOrDefault(importedPath);
                     }
                 }

--- a/Modules/DotNetImports.cs
+++ b/Modules/DotNetImports.cs
@@ -1,0 +1,177 @@
+using SharpTS.Declaration;
+using SharpTS.Parsing;
+using SharpTS.Runtime.DotNet;
+using SharpTS.TypeSystem;
+
+namespace SharpTS.Modules;
+
+/// <summary>
+/// Resolution for <c>dotnet:</c>-scheme import specifiers — the first-class consumption path
+/// for .NET interop (#1195): <c>import { StringBuilder } from "dotnet:System.Text.StringBuilder"</c>
+/// (single-type form) or <c>import { StringBuilder, Encoding } from "dotnet:System.Text"</c>
+/// (namespace form). Type metadata is synthesized directly from reflection with no generated
+/// TypeScript text in between.
+/// </summary>
+/// <remarks>
+/// The specifier after the scheme is either a fully-qualified type name or a namespace; each
+/// named import resolves individually:
+/// <list type="number">
+/// <item>If the specifier resolves to a type, an import of that type's simple name binds it,
+/// and any other name is tried as a nested type (<c>Specifier+Name</c>).</item>
+/// <item>Otherwise the specifier is treated as a namespace and the import resolves
+/// <c>Specifier.Name</c>.</item>
+/// </list>
+/// v1 scope: named imports only (no default, namespace-star, re-export-from, <c>require()</c>,
+/// or dynamic <c>import()</c>), and only types in already-loaded assemblies (the BCL plus
+/// anything the host has loaded). Every resolved type is vetted by
+/// <see cref="DotNetInteropClassifier"/> so this path and the <c>--gen-decl</c> discovery tool
+/// never disagree about what is importable.
+/// </remarks>
+public static class DotNetImports
+{
+    /// <summary>The scheme prefix for .NET interop import specifiers.</summary>
+    public const string Prefix = "dotnet:";
+
+    /// <summary>True if the specifier (or virtual module path) uses the <c>dotnet:</c> scheme.</summary>
+    public static bool IsDotNetSpecifier(string specifier) =>
+        specifier.StartsWith(Prefix, StringComparison.Ordinal);
+
+    /// <summary>
+    /// Creates the placeholder module for a <c>dotnet:</c> virtual path. Exports are added
+    /// per import statement by <see cref="EnsureImports"/>.
+    /// </summary>
+    public static ParsedModule CreateModule(string virtualPath) =>
+        new(virtualPath, [])
+        {
+            IsScript = false,
+            IsTypeChecked = true,
+            DotNetExports = new Dictionary<string, Type>(StringComparer.Ordinal),
+        };
+
+    /// <summary>
+    /// Validates the import form and resolves every named import against the module's
+    /// specifier, populating <see cref="ParsedModule.DotNetExports"/> (CLR types) and
+    /// <see cref="ParsedModule.ExportedTypes"/> (synthesized static types).
+    /// </summary>
+    /// <exception cref="Exception">With a clear <c>Module Error:</c> message when the import
+    /// form is unsupported or a name cannot be resolved to a usable .NET type.</exception>
+    public static void EnsureImports(ParsedModule module, Stmt.Import import)
+    {
+        if (import.DefaultImport != null)
+        {
+            throw new Exception(
+                $"Module Error: '{module.Path}' has no default export. " +
+                "dotnet: modules support named imports only, e.g. " +
+                $"import {{ {SuggestedName(module.Path)} }} from \"{module.Path}\".");
+        }
+
+        if (import.NamespaceImport != null)
+        {
+            throw new Exception(
+                $"Module Error: namespace imports (import * as …) are not supported for '{module.Path}'. " +
+                "A .NET namespace cannot be enumerated as a module object; import the types you need by name.");
+        }
+
+        if (import.NamedImports == null) return; // side-effect import: nothing to bind
+
+        foreach (var spec in import.NamedImports)
+        {
+            EnsureExport(module, spec.Imported.Lexeme);
+        }
+    }
+
+    /// <summary>
+    /// Resolves one exported name of a <c>dotnet:</c> module, caching the result on the module.
+    /// </summary>
+    public static Type EnsureExport(ParsedModule module, string name)
+    {
+        var exports = module.DotNetExports!;
+        if (exports.TryGetValue(name, out var cached)) return cached;
+
+        string specifier = module.Path[Prefix.Length..];
+        var type = ResolveExportType(specifier, name);
+
+        exports[name] = type;
+        module.ExportedTypes[name] = DotNetTypeSynthesizer.Synthesize(type);
+        return type;
+    }
+
+    /// <summary>
+    /// The single resolution algorithm for a named import against a <c>dotnet:</c> specifier.
+    /// Shared by module loading and the language server (which injects its project-reference
+    /// resolver) so editor diagnostics and actual resolution never disagree.
+    /// </summary>
+    /// <param name="specifier">The part after the <c>dotnet:</c> scheme.</param>
+    /// <param name="name">The imported name.</param>
+    /// <param name="resolve">CLR type-name resolver; defaults to
+    /// <see cref="DotNetTypeRegistry.Resolve"/> (all loaded assemblies).</param>
+    /// <exception cref="Exception">With a <c>Module Error:</c> message when the name cannot be
+    /// resolved to a usable public .NET type.</exception>
+    public static Type ResolveExportType(string specifier, string name, Func<string, Type?>? resolve = null)
+    {
+        resolve ??= DotNetTypeRegistry.Resolve;
+
+        if (specifier.Contains('<') || specifier.Contains('`'))
+        {
+            throw new Exception(
+                $"Module Error: cannot import 'dotnet:{specifier}': {DotNetInteropClassifier.ReasonOpenGeneric}. " +
+                "Generic .NET types are not importable via dotnet: specifiers; use an @DotNetType declaration for a closed generic.");
+        }
+
+        var type = ResolveExportCandidate(specifier, name, resolve);
+
+        string? unsupported = DotNetInteropClassifier.UnsupportedTypeReason(type);
+        if (unsupported != null)
+        {
+            throw new Exception(
+                $"Module Error: .NET type '{type.FullName}' cannot be imported: {unsupported}.");
+        }
+
+        return type;
+    }
+
+    private static Type ResolveExportCandidate(string specifier, string name, Func<string, Type?> resolve)
+    {
+        // Single-type form: the whole specifier is a type.
+        var specType = ResolvePublic(specifier, resolve);
+        if (specType != null)
+        {
+            if (name == specType.Name) return specType;
+
+            // A different name against a type specifier can only mean a nested type.
+            var nested = ResolvePublic($"{specifier}+{name}", resolve);
+            if (nested != null) return nested;
+
+            throw new Exception(
+                $"Module Error: 'dotnet:{specifier}' resolves to .NET type '{specType.FullName}', " +
+                $"which exports only '{specType.Name}' (and public nested types). '{name}' was not found.");
+        }
+
+        // Namespace form: resolve each named import as Namespace.Name.
+        var type = ResolvePublic($"{specifier}.{name}", resolve);
+        if (type != null) return type;
+
+        throw new Exception(
+            $"Module Error: cannot resolve '{name}' from 'dotnet:{specifier}': neither a type " +
+            $"'{specifier}' nor a type '{specifier}.{name}' was found in any loaded assembly. " +
+            "Check the fully-qualified name with: sharpts --gen-decl " + specifier);
+    }
+
+    /// <summary>
+    /// Resolves a CLR type name, ignoring non-public types — reflection can find internal
+    /// types, but the interop surface must not expose them.
+    /// </summary>
+    private static Type? ResolvePublic(string clrName, Func<string, Type?> resolve)
+    {
+        var type = resolve(clrName);
+        return type != null && (type.IsPublic || type.IsNestedPublic) ? type : null;
+    }
+
+    /// <summary>Best-effort example name for error messages: last dotted segment.</summary>
+    private static string SuggestedName(string virtualPath)
+    {
+        string spec = virtualPath[Prefix.Length..];
+        int lastDot = spec.LastIndexOf('.');
+        return lastDot >= 0 && lastDot < spec.Length - 1 ? spec[(lastDot + 1)..] : spec;
+    }
+}

--- a/Modules/ModuleResolver.cs
+++ b/Modules/ModuleResolver.cs
@@ -127,6 +127,19 @@ public class ModuleResolver
     {
         string currentDir = Path.GetDirectoryName(currentModulePath) ?? _basePath;
 
+        // dotnet: scheme — .NET interop imports resolve via reflection, not the file system.
+        // The specifier itself is the virtual module path (and cache key).
+        if (DotNetImports.IsDotNetSpecifier(specifier))
+        {
+            if (kind == ResolutionKind.Cjs)
+            {
+                throw new Exception(
+                    $"Module Error: '{specifier}' is not available via require(). " +
+                    "Use a named ESM import instead: import { TypeName } from \"" + specifier + "\".");
+            }
+            return specifier;
+        }
+
         if (specifier.StartsWith("./") || specifier.StartsWith("../") ||
             specifier.StartsWith(".\\") || specifier.StartsWith("..\\"))
         {
@@ -601,6 +614,18 @@ public class ModuleResolver
             return LoadStdlibModule(absolutePath, decoratorMode);
         }
 
+        // dotnet: interop module — synthesized placeholder; exports are added per importing
+        // statement by DotNetImports.EnsureImports (see the import loop below).
+        if (DotNetImports.IsDotNetSpecifier(absolutePath))
+        {
+            if (!_moduleCache.TryGetValue(absolutePath, out var dotnetModule))
+            {
+                dotnetModule = DotNetImports.CreateModule(absolutePath);
+                _moduleCache[absolutePath] = dotnetModule;
+            }
+            return dotnetModule;
+        }
+
         // Primitive C# module — materialize a placeholder ParsedModule with types.
         // Origin-gating in ResolveModulePath has already ensured only stdlib-origin
         // modules resolve here, so no per-caller check is needed.
@@ -747,6 +772,12 @@ public class ModuleResolver
                 {
                     string importedPath = ResolveModulePath(import.ModulePath, absolutePath);
                     var importedModule = LoadModule(importedPath, decoratorMode);
+                    // dotnet: modules resolve their export surface from the importing
+                    // statements — each named import is resolved (and validated) here.
+                    if (importedModule.IsDotNetModule)
+                    {
+                        DotNetImports.EnsureImports(importedModule, import);
+                    }
                     // Files loaded via import are always modules, even if they have no exports
                     // (e.g., side-effect imports like `import './polyfill'`)
                     importedModule.IsScript = false;
@@ -759,6 +790,12 @@ public class ModuleResolver
                 {
                     // Re-export: export { x } from './foo' or export * from './foo'
                     string reexportPath = ResolveModulePath(export.FromModulePath, absolutePath);
+                    if (DotNetImports.IsDotNetSpecifier(reexportPath))
+                    {
+                        throw new Exception(
+                            $"Module Error: re-exporting from '{export.FromModulePath}' is not supported. " +
+                            "Import the type and re-export the local binding instead.");
+                    }
                     var reexportedModule = LoadModule(reexportPath, decoratorMode);
                     // Re-exported files are always modules
                     reexportedModule.IsScript = false;
@@ -774,6 +811,13 @@ public class ModuleResolver
                     if (BuiltInModuleRegistry.GetModuleName(importReq.ModulePath) != null)
                     {
                         continue;
+                    }
+
+                    if (DotNetImports.IsDotNetSpecifier(importReq.ModulePath))
+                    {
+                        throw new Exception(
+                            $"Module Error: '{importReq.ModulePath}' is not available via import-require. " +
+                            "Use a named ESM import instead: import { TypeName } from \"" + importReq.ModulePath + "\".");
                     }
 
                     string importedPath = ResolveModulePath(importReq.ModulePath, absolutePath);
@@ -987,10 +1031,11 @@ public class ModuleResolver
     /// </summary>
     public ParsedModule? GetCachedModule(string absolutePath)
     {
-        // Don't normalize virtual paths (builtin: sentinels, stdlib: TS sources,
-        // primitive: C# interop modules — none resolve to a real filesystem path).
+        // Don't normalize virtual paths (builtin: sentinels, stdlib: TS sources, dotnet:
+        // interop modules, primitive: C# interop modules — none resolve to a real filesystem path).
         if (!absolutePath.StartsWith(BuiltInModuleRegistry.BuiltInPrefix)
             && !absolutePath.StartsWith(EmbeddedStdlibProvider.VirtualPathPrefix, StringComparison.Ordinal)
+            && !DotNetImports.IsDotNetSpecifier(absolutePath)
             && !absolutePath.StartsWith(PrimitiveRegistry.Prefix, StringComparison.Ordinal))
         {
             absolutePath = Path.GetFullPath(absolutePath);

--- a/Modules/ParsedModule.cs
+++ b/Modules/ParsedModule.cs
@@ -92,6 +92,18 @@ public class ParsedModule
     public bool IsBuiltIn { get; set; }
 
     /// <summary>
+    /// For <c>dotnet:</c>-scheme modules only: exported names mapped to their resolved CLR
+    /// types. Null for every other module kind. Populated incrementally by
+    /// <see cref="DotNetImports.EnsureImports"/> as import statements naming this module are
+    /// discovered — the export surface of a <c>dotnet:</c> namespace module is defined by what
+    /// programs import from it, not by enumerating the namespace.
+    /// </summary>
+    public Dictionary<string, Type>? DotNetExports { get; set; }
+
+    /// <summary>True if this is a synthesized <c>dotnet:</c>-scheme interop module.</summary>
+    public bool IsDotNetModule => DotNetExports != null;
+
+    /// <summary>
     /// True if file has no import/export statements (is a "script" file).
     /// Scripts share global scope; modules have isolated scope.
     /// </summary>

--- a/Runtime/DotNet/DotNetTypeRegistry.cs
+++ b/Runtime/DotNet/DotNetTypeRegistry.cs
@@ -11,6 +11,13 @@ public static class DotNetTypeRegistry
 {
     private static readonly ConcurrentDictionary<string, Type> _cache = new(StringComparer.Ordinal);
 
+    // Member lookups are pure functions of (type, jsName, isStatic); callers never mutate
+    // the returned arrays/infos, so results are cached process-wide. Interop member access
+    // resolves through here on every call, making uncached reflection queries a hot path.
+    private static readonly ConcurrentDictionary<(Type, string, bool), MethodInfo[]> _methodCache = new();
+    private static readonly ConcurrentDictionary<(Type, string, bool), MemberInfo?> _propertyOrFieldCache = new();
+    private static readonly ConcurrentDictionary<(Type, string, bool), EventInfo?> _eventCache = new();
+
     /// <summary>
     /// Resolves a fully-qualified .NET type name, searching all currently loaded assemblies.
     /// </summary>
@@ -36,9 +43,15 @@ public static class DotNetTypeRegistry
     }
 
     /// <summary>
-    /// Clears the type cache. Used by tests to ensure isolation.
+    /// Clears the type and member caches. Used by tests to ensure isolation.
     /// </summary>
-    public static void ClearCache() => _cache.Clear();
+    public static void ClearCache()
+    {
+        _cache.Clear();
+        _methodCache.Clear();
+        _propertyOrFieldCache.Clear();
+        _eventCache.Clear();
+    }
 
     /// <summary>
     /// Converts a friendly generic type name to CLR syntax.
@@ -61,11 +74,15 @@ public static class DotNetTypeRegistry
     /// </summary>
     public static MethodInfo[] GetMethods(Type type, string jsName, bool isStatic)
     {
-        string pascal = ToPascalCase(jsName);
-        var flags = BindingFlags.Public | (isStatic ? BindingFlags.Static : BindingFlags.Instance);
-        return type.GetMethods(flags)
-            .Where(m => m.Name == jsName || m.Name == pascal)
-            .ToArray();
+        return _methodCache.GetOrAdd((type, jsName, isStatic), static key =>
+        {
+            var (t, name, stat) = key;
+            string pascal = ToPascalCase(name);
+            var flags = BindingFlags.Public | (stat ? BindingFlags.Static : BindingFlags.Instance);
+            return t.GetMethods(flags)
+                .Where(m => m.Name == name || m.Name == pascal)
+                .ToArray();
+        });
     }
 
     /// <summary>
@@ -73,13 +90,17 @@ public static class DotNetTypeRegistry
     /// </summary>
     public static MemberInfo? GetPropertyOrField(Type type, string jsName, bool isStatic)
     {
-        string pascal = ToPascalCase(jsName);
-        var flags = BindingFlags.Public | (isStatic ? BindingFlags.Static : BindingFlags.Instance);
+        return _propertyOrFieldCache.GetOrAdd((type, jsName, isStatic), static key =>
+        {
+            var (t, name, stat) = key;
+            string pascal = ToPascalCase(name);
+            var flags = BindingFlags.Public | (stat ? BindingFlags.Static : BindingFlags.Instance);
 
-        var property = type.GetProperty(pascal, flags) ?? type.GetProperty(jsName, flags);
-        if (property != null) return property;
+            var property = t.GetProperty(pascal, flags) ?? t.GetProperty(name, flags);
+            if (property != null) return property;
 
-        return type.GetField(pascal, flags) ?? type.GetField(jsName, flags);
+            return (MemberInfo?)t.GetField(pascal, flags) ?? t.GetField(name, flags);
+        });
     }
 
     /// <summary>
@@ -88,9 +109,13 @@ public static class DotNetTypeRegistry
     /// </summary>
     public static EventInfo? GetEvent(Type type, string jsName, bool isStatic)
     {
-        string pascal = ToPascalCase(jsName);
-        var flags = BindingFlags.Public | (isStatic ? BindingFlags.Static : BindingFlags.Instance);
-        return type.GetEvent(pascal, flags) ?? type.GetEvent(jsName, flags);
+        return _eventCache.GetOrAdd((type, jsName, isStatic), static key =>
+        {
+            var (t, name, stat) = key;
+            string pascal = ToPascalCase(name);
+            var flags = BindingFlags.Public | (stat ? BindingFlags.Static : BindingFlags.Instance);
+            return t.GetEvent(pascal, flags) ?? t.GetEvent(name, flags);
+        });
     }
 
     /// <summary>

--- a/STATUS.md
+++ b/STATUS.md
@@ -463,12 +463,15 @@ SharpTS implements 20+ Node.js built-in modules accessible via `import ... from 
 
 ---
 
-## 16. .NET INTEROP (`@DotNetType`)
+## 16. .NET INTEROP (`dotnet:` imports + `@DotNetType`)
 
-`@DotNetType` marks a declared class as a facade over a real .NET type, enabling TypeScript code to use BCL types directly. **Works in both interpreter and compiled modes** as of 2026-04-18.
+.NET types can be consumed two ways: **`dotnet:` import specifiers** (recommended — zero boilerplate, type surface synthesized from reflection; epic #1195) and **`@DotNetType` declare classes** (manual, curated surface, supports `@DotNetOverload` hints). **Both work in interpreter and compiled modes.**
 
 | Feature | Status | Notes |
 |---------|--------|-------|
+| `import { X } from "dotnet:Ns.Type"` (single-type form) | ✅ | Static types synthesized from reflection via `DotNetTypeSynthesizer`; members filtered by `DotNetInteropClassifier`; fluent chains stay typed (epic #1195) |
+| `import { X, Y } from "dotnet:Namespace"` (namespace form) | ✅ | Each named import resolves as `Namespace.Name`; nested types resolve through their declaring type's specifier; aliasing supported |
+| `dotnet:` v1 scope | — | Named imports only (no default/star/re-export/require/dynamic import); loaded/BCL assemblies only; no generic types (use `@DotNetType` for closed generics) |
 | `@DotNetType("Namespace.Type")` on `declare class` | ✅ | Instance methods, static methods, constructors, properties, fields |
 | `@DotNetOverload("type1,type2,...")` overload hints | ✅ | Pin a specific overload when argument-based resolution is ambiguous |
 | Overload resolution | ✅ | Identity → widening → narrowing → object cost scale; same semantics in both modes |
@@ -482,7 +485,7 @@ SharpTS implements 20+ Node.js built-in modules accessible via `import ... from 
 
 Compiled mode uses late-bound reflection to the shim (`DotNetDelegateShim` / `DotNetEventBinder`) so the output DLL stays standalone. See `docs/dotnet-types.md` for the full guide.
 
-`--gen-decl` (`DiscoveryGenerator` / `DiscoveryEmitter`) reports which members are usable from interop using `DotNetInteropClassifier` — the same by-ref/pointer/ref-struct/open-generic rules the runtime marshaller enforces, so the tool and the runtime never disagree. It reports faithfully rather than emitting pasteable TypeScript (realistic BCL surfaces have `Span<T>`/`ref`/pointer members with no valid TS spelling). Hand-written `@DotNetType(...) export declare class` declarations remain the consumption path.
+`--gen-decl` (`DiscoveryGenerator` / `DiscoveryEmitter`) reports which members are usable from interop using `DotNetInteropClassifier` — the same by-ref/pointer/ref-struct/open-generic rules the runtime marshaller and the `dotnet:` import resolver enforce, so the tool and the runtime never disagree. It reports faithfully rather than emitting pasteable TypeScript (realistic BCL surfaces have `Span<T>`/`ref`/pointer members with no valid TS spelling). The `dotnet:` import line it prints is the primary consumption path; hand-written `@DotNetType(...) export declare class` declarations remain the manual alternative.
 
 ---
 

--- a/SharpTS.LanguageServer/Services/InteropAnalyzer.cs
+++ b/SharpTS.LanguageServer/Services/InteropAnalyzer.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using SharpTS.Diagnostics;
+using SharpTS.Modules;
 using SharpTS.Parsing;
 using SharpTS.Parsing.Visitors;
 using SharpTS.Runtime.DotNet;
@@ -61,10 +62,15 @@ public sealed class InteropAnalyzer
 
         var stmtList = statements as IReadOnlyList<Stmt> ?? statements.ToList();
 
-        // Pass 1 — validate each @DotNetType class and record name -> CLR type.
+        // Pass 1 — validate each @DotNetType class and dotnet: import, recording
+        // name -> CLR type bindings for the call-site pass.
         foreach (var stmt in stmtList)
+        {
             if (stmt is Stmt.Class cls)
                 AnalyzeClass(cls, diags, bindings, positions);
+            else if (stmt is Stmt.Import import && DotNetImports.IsDotNetSpecifier(import.ModulePath))
+                AnalyzeDotNetImport(import, diags, bindings, positions);
+        }
 
         // Pass 2 — Tier 3d: validate event-subscription call sites against the bindings.
         var visitor = new EventCallVisitor(bindings, diags, positions);
@@ -72,6 +78,49 @@ public sealed class InteropAnalyzer
             visitor.Visit(stmt);
 
         return diags;
+    }
+
+    /// <summary>
+    /// Validates a <c>dotnet:</c> import statement: unsupported forms (default / namespace-star)
+    /// and each named import's resolvability, via the same
+    /// <see cref="DotNetImports.ResolveExportType"/> algorithm module loading uses — so the
+    /// squiggle at edit time and the load-time error can never disagree. Resolved names are
+    /// recorded as bindings for the event-call pass, exactly like @DotNetType classes.
+    /// </summary>
+    private void AnalyzeDotNetImport(Stmt.Import import, List<Diagnostic> diags, Dictionary<string, Type> bindings, PositionMap? pos)
+    {
+        string specifier = import.ModulePath[DotNetImports.Prefix.Length..];
+
+        if (import.DefaultImport != null)
+        {
+            diags.Add(Diagnostic.TypeError(
+                $"'{import.ModulePath}' has no default export — dotnet: modules support named imports only.",
+                Loc(import.DefaultImport, pos)));
+        }
+
+        if (import.NamespaceImport != null)
+        {
+            diags.Add(Diagnostic.TypeError(
+                $"namespace imports (import * as …) are not supported for '{import.ModulePath}' — import the types you need by name.",
+                Loc(import.NamespaceImport, pos)));
+        }
+
+        if (import.NamedImports == null) return;
+
+        foreach (var spec in import.NamedImports)
+        {
+            Type type;
+            try
+            {
+                type = DotNetImports.ResolveExportType(specifier, spec.Imported.Lexeme, _resolve);
+            }
+            catch (Exception ex)
+            {
+                diags.Add(Diagnostic.TypeError(ex.Message, Loc(spec.Imported, pos)));
+                continue;
+            }
+            bindings[spec.LocalName?.Lexeme ?? spec.Imported.Lexeme] = type;
+        }
     }
 
     private void AnalyzeClass(Stmt.Class cls, List<Diagnostic> diags, Dictionary<string, Type> bindings, PositionMap? pos)

--- a/SharpTS.LanguageServer/Services/MemberHoverService.cs
+++ b/SharpTS.LanguageServer/Services/MemberHoverService.cs
@@ -42,13 +42,39 @@ public sealed class MemberHoverService
             ?? UsageHover(parsed.Statements, pos, line, character, bindings);
     }
 
-    // TS class name -> CLR type, for every @DotNetType declaration in the file.
+    // TS class name -> CLR type, for every @DotNetType declaration and dotnet: import
+    // in the file. Imports are keyed under both the local binding name (new SB()) and the
+    // CLR simple name — the checker's synthesized class carries the CLR name, so usage
+    // hovers on receivers resolve through it.
     private Dictionary<string, Type> CollectBindings(IReadOnlyList<Stmt> statements)
     {
         var map = new Dictionary<string, Type>(StringComparer.Ordinal);
         foreach (var s in statements)
+        {
             if (s is Stmt.Class cls && DotNetTypeOf(cls) is { } t)
                 map[cls.Name.Lexeme] = t;
+
+            if (s is Stmt.Import import
+                && SharpTS.Modules.DotNetImports.IsDotNetSpecifier(import.ModulePath)
+                && import.NamedImports != null)
+            {
+                string specifier = import.ModulePath[SharpTS.Modules.DotNetImports.Prefix.Length..];
+                foreach (var spec in import.NamedImports)
+                {
+                    try
+                    {
+                        var type = SharpTS.Modules.DotNetImports.ResolveExportType(
+                            specifier, spec.Imported.Lexeme, _resolve);
+                        map[spec.LocalName?.Lexeme ?? spec.Imported.Lexeme] = type;
+                        map.TryAdd(type.Name, type);
+                    }
+                    catch
+                    {
+                        // Unresolvable import — no hover; InteropAnalyzer reports the diagnostic.
+                    }
+                }
+            }
+        }
         return map;
     }
 

--- a/SharpTS.Tests/LanguageServer/InteropAnalyzerTests.cs
+++ b/SharpTS.Tests/LanguageServer/InteropAnalyzerTests.cs
@@ -125,4 +125,44 @@ public class InteropAnalyzerTests
         Assert.Equal(20, loc.Column);     // start of 'appendx' (1-based)
         Assert.Equal(27, loc.EndColumn);  // end of the 7-char token
     }
+
+    // --- dotnet: import specifiers (epic #1195) ---
+
+    [Fact]
+    public void DotNetImport_Valid_NoDiagnostics()
+        => Assert.Empty(Analyze(
+            "import { StringBuilder } from \"dotnet:System.Text.StringBuilder\";\n" +
+            "import { Guid, Math as SysMath } from \"dotnet:System\";\n" +
+            "const sb = new StringBuilder();"));
+
+    [Fact]
+    public void DotNetImport_UnresolvableName_Diagnostic()
+    {
+        var d = Analyze("import { Nope } from \"dotnet:System.NoSuchNs\";");
+        Assert.Single(d);
+        Assert.Contains("Nope", d[0].Message);
+        Assert.Contains("System.NoSuchNs", d[0].Message);
+    }
+
+    [Fact]
+    public void DotNetImport_DefaultAndStarForms_Diagnostics()
+    {
+        var d = Analyze(
+            "import SB from \"dotnet:System.Text.StringBuilder\";\n" +
+            "import * as Text from \"dotnet:System.Text\";");
+        Assert.Equal(2, d.Count);
+        Assert.Contains("named imports only", d[0].Message);
+        Assert.Contains("namespace imports", d[1].Message);
+    }
+
+    [Fact]
+    public void DotNetImport_BindingsFeedEventValidation()
+    {
+        // Imported types participate in Tier 3d exactly like @DotNetType bindings.
+        var d = Analyze(
+            "import { AppDomain } from \"dotnet:System\";\n" +
+            "AppDomain.currentDomain.addEventListener(\"Typo\", (s: any, a: any) => {});");
+        Assert.Single(d);
+        Assert.Contains("Event 'Typo' not found", d[0].Message);
+    }
 }

--- a/SharpTS.Tests/LanguageServer/MemberHoverServiceTests.cs
+++ b/SharpTS.Tests/LanguageServer/MemberHoverServiceTests.cs
@@ -50,4 +50,36 @@ public class MemberHoverServiceTests
     [Fact]
     public void Hover_OnNonMember_ReturnsNull()
         => Assert.Null(_svc.Hover("const x: number = 1;", line: 0, character: 6));
+
+    [Fact]
+    public void UsageHover_ResolvesDotNetImportBinding()
+    {
+        // dotnet: imports carry no declare-class surface — the binding comes from the
+        // import statement, and the receiver resolves through the synthesized class type.
+        const string src =
+            "import { StringBuilder } from \"dotnet:System.Text.StringBuilder\";\n" +
+            "const sb = new StringBuilder();\n" +
+            "sb.append(\"x\");";
+        var (line, ch) = PosOf(src, "append");
+
+        var hover = _svc.Hover(src, line, ch);
+
+        Assert.NotNull(hover);
+        Assert.Contains("Append", hover!.Contents.MarkupContent!.Value);
+    }
+
+    [Fact]
+    public void UsageHover_ResolvesAliasedDotNetImport()
+    {
+        const string src =
+            "import { StringBuilder as SB } from \"dotnet:System.Text.StringBuilder\";\n" +
+            "const sb = new SB();\n" +
+            "sb.append(\"x\");";
+        var (line, ch) = PosOf(src, "append");
+
+        var hover = _svc.Hover(src, line, ch);
+
+        Assert.NotNull(hover);
+        Assert.Contains("Append", hover!.Contents.MarkupContent!.Value);
+    }
 }

--- a/SharpTS.Tests/SharedTests/DotNetImportTests.cs
+++ b/SharpTS.Tests/SharedTests/DotNetImportTests.cs
@@ -1,0 +1,446 @@
+using SharpTS.Declaration;
+using SharpTS.Diagnostics;
+using SharpTS.Modules;
+using SharpTS.Tests.Infrastructure;
+using SharpTS.TypeSystem;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests;
+
+/// <summary>
+/// Tests for <c>dotnet:</c> import-scheme resolution (epic #1195): first-class imports of
+/// .NET types with reflection-synthesized static types. Success scenarios run in BOTH
+/// execution modes — the interpreter binds <c>DotNetClass</c> wrappers, compiled mode emits
+/// direct external-interop IL — and must produce identical output.
+/// </summary>
+public class DotNetImportTests
+{
+    /// <summary>
+    /// Type-checks a module set and returns error diagnostics. Statement-level type errors in
+    /// module mode are COLLECTED (recovery), not thrown — the CLI prints them and refuses to
+    /// run; tests must assert on the collected list (mirrors Program.cs RunModuleFile).
+    /// </summary>
+    private static List<Diagnostic> CheckErrors(Dictionary<string, string> files, string entryPoint)
+    {
+        var virtualBase = Path.Combine(Path.GetTempPath(), $"sharpts_dnimp_{Guid.NewGuid():N}");
+        var virtualFiles = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var (path, content) in files)
+            virtualFiles[Path.GetFullPath(Path.Combine(virtualBase, path.TrimStart('.', '/', '\\')))] = content;
+        var entryPath = Path.GetFullPath(Path.Combine(virtualBase, entryPoint.TrimStart('.', '/', '\\')));
+
+        var resolver = new ModuleResolver(entryPath, virtualFiles);
+        var entryModule = resolver.LoadModule(entryPath);
+        var allModules = resolver.GetModulesInOrder(entryModule);
+
+        var checker = new TypeChecker();
+        checker.CheckModules(allModules, resolver);
+        return checker.GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error).ToList();
+    }
+
+    #region Single-type form
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void SingleTypeForm_ConstructChainAndProperty(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["./main.ts"] = """
+                import { StringBuilder } from "dotnet:System.Text.StringBuilder";
+                const sb = new StringBuilder();
+                sb.append("Hello").append(", ").append("dotnet:").append(42);
+                console.log(sb.toString());
+                console.log(sb.length);
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "./main.ts", mode);
+        Assert.Equal("Hello, dotnet:42\n16\n", output);
+    }
+
+    [Fact]
+    public void SingleTypeForm_FluentChainIsStaticallyTyped()
+    {
+        // append() returns the synthesized StringBuilder type (not any) — assigning the
+        // chain result to number must be a static type error.
+        var errors = CheckErrors(new Dictionary<string, string>
+        {
+            ["./main.ts"] = """
+                import { StringBuilder } from "dotnet:System.Text.StringBuilder";
+                const sb = new StringBuilder();
+                const n: number = sb.append("x");
+                """
+        }, "./main.ts");
+
+        Assert.Contains(errors, d => d.Message.Contains("not assignable"));
+    }
+
+    [Fact]
+    public void SingleTypeForm_PrimitiveReturnTypesArePrecise()
+    {
+        // toString(): string — assigning to number is a static error.
+        var errors = CheckErrors(new Dictionary<string, string>
+        {
+            ["./main.ts"] = """
+                import { StringBuilder } from "dotnet:System.Text.StringBuilder";
+                const s: number = new StringBuilder().toString();
+                """
+        }, "./main.ts");
+
+        Assert.Contains(errors, d => d.Message.Contains("not assignable"));
+    }
+
+    #endregion
+
+    #region Namespace form, aliases, nested types
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void NamespaceForm_ResolvesEachNamedImport(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["./main.ts"] = """
+                import { Guid, Math as SysMath } from "dotnet:System";
+                const g: Guid = Guid.newGuid();
+                console.log(g.toString().length);
+                console.log(SysMath.max(3, 9));
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "./main.ts", mode);
+        Assert.Equal("36\n9\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AliasImport_BindsLocalName(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["./main.ts"] = """
+                import { StringBuilder as SB } from "dotnet:System.Text.StringBuilder";
+                const sb: SB = new SB();
+                sb.append("aliased");
+                console.log(sb.toString());
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "./main.ts", mode);
+        Assert.Equal("aliased\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void StaticReadonlyField_Resolves(ExecutionMode mode)
+    {
+        // Guid.empty is a static FIELD (not property) — the member surface must include
+        // public fields, and the runtime lookup resolves them the same way.
+        var files = new Dictionary<string, string>
+        {
+            ["./main.ts"] = """
+                import { Guid } from "dotnet:System";
+                console.log(Guid.empty.toString());
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "./main.ts", mode);
+        Assert.Equal("00000000-0000-0000-0000-000000000000\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void NestedType_ResolvesThroughDeclaringTypeSpecifier(ExecutionMode mode)
+    {
+        // System.Environment is a type; SpecialFolder is its nested enum — the namespace-form
+        // name resolution falls back to Declaring+Nested.
+        var files = new Dictionary<string, string>
+        {
+            ["./main.ts"] = """
+                import { SpecialFolder } from "dotnet:System.Environment";
+                console.log(SpecialFolder.Desktop.toString());
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "./main.ts", mode);
+        Assert.Equal("Desktop\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void EnumImport_MembersAndToString(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["./main.ts"] = """
+                import { DayOfWeek } from "dotnet:System";
+                const d: DayOfWeek = DayOfWeek.Monday;
+                console.log(d.toString());
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "./main.ts", mode);
+        Assert.Equal("Monday\n", output);
+    }
+
+    #endregion
+
+    #region Cross-module and type identity
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void CrossModule_InstanceFlowsBetweenModules(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["./maker.ts"] = """
+                import { StringBuilder } from "dotnet:System.Text.StringBuilder";
+                export function makeSb(): StringBuilder {
+                    const sb = new StringBuilder();
+                    sb.append("from-maker");
+                    return sb;
+                }
+                """,
+            ["./main.ts"] = """
+                import { StringBuilder } from "dotnet:System.Text.StringBuilder";
+                import { makeSb } from "./maker";
+                const sb: StringBuilder = makeSb();
+                sb.append("+main");
+                console.log(sb.toString());
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "./main.ts", mode);
+        Assert.Equal("from-maker+main\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void BothSpecifierForms_YieldTheSameType(ExecutionMode mode)
+    {
+        // The synthesized class is cached per CLR type, so the namespace form and the
+        // single-type form produce the identical TypeInfo — values assign across modules.
+        var files = new Dictionary<string, string>
+        {
+            ["./a.ts"] = """
+                import { StringBuilder } from "dotnet:System.Text";
+                export function make(): StringBuilder {
+                    return new StringBuilder().append("same");
+                }
+                """,
+            ["./main.ts"] = """
+                import { StringBuilder } from "dotnet:System.Text.StringBuilder";
+                import { make } from "./a";
+                const sb: StringBuilder = make();
+                console.log(sb.toString());
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "./main.ts", mode);
+        Assert.Equal("same\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void TypeOnlyImport_UsableInAnnotations(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["./maker.ts"] = """
+                import { StringBuilder } from "dotnet:System.Text.StringBuilder";
+                export function makeSb(): StringBuilder {
+                    return new StringBuilder().append("typed");
+                }
+                """,
+            ["./main.ts"] = """
+                import type { StringBuilder } from "dotnet:System.Text.StringBuilder";
+                import { makeSb } from "./maker";
+                const sb: StringBuilder = makeSb();
+                console.log(sb.toString());
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "./main.ts", mode);
+        Assert.Equal("typed\n", output);
+    }
+
+    #endregion
+
+    #region Discovery-tool alignment
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void DiscoveryToolImportLine_RoundTripsThroughThePipeline(ExecutionMode mode)
+    {
+        // The exact import line `--gen-decl` prints must load, type-check, and run —
+        // the tool and the resolver share DotNetInteropClassifier, so they can never
+        // disagree about importability (the #1192/#1193 lesson: round-trip, don't eyeball).
+        var report = new DiscoveryGenerator().Generate("System.Text.StringBuilder");
+        Assert.NotNull(report.Type?.ImportLine);
+
+        var files = new Dictionary<string, string>
+        {
+            ["./main.ts"] = report.Type!.ImportLine + """
+
+                const sb = new StringBuilder();
+                sb.append("round-trip");
+                console.log(sb.toString());
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "./main.ts", mode);
+        Assert.Equal("round-trip\n", output);
+    }
+
+    #endregion
+
+    #region Error cases
+
+    [Fact]
+    public void UnknownName_ThrowsModuleError()
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["./main.ts"] = """
+                import { Nope } from "dotnet:System.NoSuchNs";
+                console.log(1);
+                """
+        };
+
+        var ex = Assert.ThrowsAny<Exception>(() =>
+            TestHarness.RunModules(files, "./main.ts", ExecutionMode.Interpreted));
+        Assert.Contains("Module Error", ex.Message);
+        Assert.Contains("System.NoSuchNs", ex.Message);
+    }
+
+    [Fact]
+    public void SingleTypeForm_WrongName_ThrowsModuleError()
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["./main.ts"] = """
+                import { Encoding } from "dotnet:System.Text.StringBuilder";
+                console.log(1);
+                """
+        };
+
+        var ex = Assert.ThrowsAny<Exception>(() =>
+            TestHarness.RunModules(files, "./main.ts", ExecutionMode.Interpreted));
+        Assert.Contains("exports only 'StringBuilder'", ex.Message);
+    }
+
+    [Fact]
+    public void NamespaceStarImport_ThrowsModuleError()
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["./main.ts"] = """
+                import * as Text from "dotnet:System.Text";
+                console.log(1);
+                """
+        };
+
+        var ex = Assert.ThrowsAny<Exception>(() =>
+            TestHarness.RunModules(files, "./main.ts", ExecutionMode.Interpreted));
+        Assert.Contains("namespace imports", ex.Message);
+    }
+
+    [Fact]
+    public void DefaultImport_ThrowsModuleError()
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["./main.ts"] = """
+                import StringBuilder from "dotnet:System.Text.StringBuilder";
+                console.log(1);
+                """
+        };
+
+        var ex = Assert.ThrowsAny<Exception>(() =>
+            TestHarness.RunModules(files, "./main.ts", ExecutionMode.Interpreted));
+        Assert.Contains("no default export", ex.Message);
+    }
+
+    [Fact]
+    public void GenericSpecifier_ThrowsModuleError()
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["./main.ts"] = """
+                import { List } from "dotnet:System.Collections.Generic.List<number>";
+                console.log(1);
+                """
+        };
+
+        var ex = Assert.ThrowsAny<Exception>(() =>
+            TestHarness.RunModules(files, "./main.ts", ExecutionMode.Interpreted));
+        Assert.Contains("Generic .NET types", ex.Message);
+    }
+
+    [Fact]
+    public void RefStructType_ThrowsModuleError()
+    {
+        // TypedReference is a public, non-generic ref struct in the core library —
+        // rejected with the classifier's reason, exactly like --gen-decl reports it.
+        var files = new Dictionary<string, string>
+        {
+            ["./main.ts"] = """
+                import { TypedReference } from "dotnet:System.TypedReference";
+                console.log(1);
+                """
+        };
+
+        var ex = Assert.ThrowsAny<Exception>(() =>
+            TestHarness.RunModules(files, "./main.ts", ExecutionMode.Interpreted));
+        Assert.Contains(DotNetInteropClassifier.ReasonRefStruct, ex.Message);
+    }
+
+    [Fact]
+    public void ReExportFrom_ThrowsModuleError()
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["./main.ts"] = """
+                export { StringBuilder } from "dotnet:System.Text.StringBuilder";
+                console.log(1);
+                """
+        };
+
+        var ex = Assert.ThrowsAny<Exception>(() =>
+            TestHarness.RunModules(files, "./main.ts", ExecutionMode.Interpreted));
+        Assert.Contains("re-export", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ImportRequire_ThrowsModuleError()
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["./main.ts"] = """
+                import sb = require("dotnet:System.Text.StringBuilder");
+                console.log(1);
+                """
+        };
+
+        var ex = Assert.ThrowsAny<Exception>(() =>
+            TestHarness.RunModules(files, "./main.ts", ExecutionMode.Interpreted));
+        Assert.Contains("named ESM import", ex.Message);
+    }
+
+    [Fact]
+    public void NewOnStaticClass_IsATypeError()
+    {
+        // Static classes synthesize as abstract — `new` is rejected statically.
+        var errors = CheckErrors(new Dictionary<string, string>
+        {
+            ["./main.ts"] = """
+                import { Console } from "dotnet:System.Console";
+                const c = new Console();
+                """
+        }, "./main.ts");
+
+        Assert.Contains(errors, d => d.Message.Contains("abstract", StringComparison.OrdinalIgnoreCase));
+    }
+
+    #endregion
+}

--- a/TypeSystem/DotNetTypeSynthesizer.cs
+++ b/TypeSystem/DotNetTypeSynthesizer.cs
@@ -1,0 +1,249 @@
+using System.Collections.Concurrent;
+using SharpTS.Declaration;
+using SharpTS.Parsing;
+
+namespace SharpTS.TypeSystem;
+
+/// <summary>
+/// Synthesizes a <see cref="TypeInfo.Class"/> for a .NET <see cref="Type"/> imported via a
+/// <c>dotnet:</c> specifier, using <see cref="TypeInspector"/> reflection metadata. This is the
+/// static-checking counterpart of the runtime <c>DotNetClass</c>/<c>DotNetInstance</c> wrappers:
+/// the surface it exposes must match what the interop dispatch can actually reach.
+/// </summary>
+/// <remarks>
+/// Member filtering delegates to <see cref="DotNetInteropClassifier"/> — the same rules the
+/// <c>--gen-decl</c> discovery tool reports — so a member shown as <c>[unsupported]</c> there is
+/// absent from the synthesized surface here, and the tool and the checker never disagree.
+///
+/// Slot-type mapping policy (kept deliberately conservative so the checker never reports a
+/// false error for a call the runtime marshaller would accept):
+/// <list type="bullet">
+/// <item><c>void</c> → <c>void</c>; CLR numerics (incl. <c>decimal</c>) → <c>number</c>;
+/// <c>string</c>/<c>char</c> → <c>string</c>; <c>bool</c> → <c>boolean</c> — mirroring
+/// <c>DotNetMarshaller.WrapReturn</c> normalization.</item>
+/// <item>The containing type itself → <c>Instance</c> of the synthesized class, so fluent
+/// chains (<c>sb.append(...).append(...)</c>) stay statically typed.</item>
+/// <item>Everything else (other .NET types, arrays, delegates, <c>Nullable&lt;T&gt;</c>,
+/// enums) → <c>any</c>. At runtime these become <c>DotNetInstance</c> wrappers; typing them
+/// <c>any</c> is accurate for what the checker can promise without synthesizing the transitive
+/// closure of the BCL.</item>
+/// </list>
+/// Types that cannot be constructed (static classes, interfaces, enums, classes without a
+/// public constructor) are marked abstract so <c>new</c> is rejected statically.
+/// </remarks>
+public static class DotNetTypeSynthesizer
+{
+    private static readonly ConcurrentDictionary<Type, TypeInfo.Class> _cache = new();
+
+    /// <summary>
+    /// Returns the synthesized class type for a .NET type. Cached per <see cref="Type"/> so all
+    /// import sites across all modules share one <see cref="TypeInfo.Class"/> identity.
+    /// </summary>
+    public static TypeInfo.Class Synthesize(Type type) => _cache.GetOrAdd(type, Build);
+
+    /// <summary>Clears the synthesis cache. Used by tests to ensure isolation.</summary>
+    public static void ClearCache() => _cache.Clear();
+
+    private static TypeInfo.Class Build(Type type)
+    {
+        var meta = new TypeInspector().Inspect(type, includeInherited: true);
+        var mc = new TypeInfo.MutableClass(type.Name);
+
+        foreach (var group in meta.Methods.GroupBy(m => m.TypeScriptName, StringComparer.Ordinal))
+        {
+            var member = BuildMethodGroup(group, type, mc);
+            if (member != null) mc.Methods.TryAdd(group.Key, member);
+        }
+
+        foreach (var group in meta.StaticMethods.GroupBy(m => m.TypeScriptName, StringComparer.Ordinal))
+        {
+            var member = BuildMethodGroup(group, type, mc);
+            if (member != null) mc.StaticMethods.TryAdd(group.Key, member);
+        }
+
+        foreach (var prop in meta.Properties)
+        {
+            if (prop.IsIndexer || !prop.CanRead) continue;
+            if (DotNetInteropClassifier.UnsupportedSlotReason(prop.PropertyType) != null) continue;
+            if (mc.FieldTypes.TryAdd(prop.TypeScriptName, MapSlot(prop.PropertyType, type, mc)) && !prop.CanWrite)
+                mc.ReadonlyFields.Add(prop.TypeScriptName);
+        }
+
+        foreach (var field in meta.Fields)
+        {
+            if (DotNetInteropClassifier.UnsupportedSlotReason(field.FieldType) != null) continue;
+            if (mc.FieldTypes.TryAdd(field.TypeScriptName, MapSlot(field.FieldType, type, mc)) && field.IsReadonly)
+                mc.ReadonlyFields.Add(field.TypeScriptName);
+        }
+
+        foreach (var prop in meta.StaticProperties)
+        {
+            if (prop.IsIndexer || !prop.CanRead) continue;
+            if (DotNetInteropClassifier.UnsupportedSlotReason(prop.PropertyType) != null) continue;
+            mc.StaticProperties.TryAdd(prop.TypeScriptName, MapSlot(prop.PropertyType, type, mc));
+        }
+
+        foreach (var field in meta.StaticFields)
+        {
+            if (DotNetInteropClassifier.UnsupportedSlotReason(field.FieldType) != null) continue;
+            mc.StaticProperties.TryAdd(field.TypeScriptName, MapSlot(field.FieldType, type, mc));
+        }
+
+        // Enum members surface as static readonly values of the enum's own type
+        // (DayOfWeek.Monday: DayOfWeek). CLR casing is kept — that is what users see in .NET
+        // docs and what the runtime member lookup resolves.
+        foreach (var enumMember in meta.EnumMembers)
+        {
+            mc.StaticProperties.TryAdd(enumMember.Name, new TypeInfo.Instance(mc));
+        }
+
+        // DOM-style event subscription is provided by the runtime wrappers whenever the type
+        // exposes .NET events (see DotNetEventBinder); mirror it on the static surface too.
+        if (meta.HasEvents)
+        {
+            var subscribe = new TypeInfo.Function(
+                [new TypeInfo.String(), new TypeInfo.Any()], new TypeInfo.Void(), RequiredParams: 2);
+            mc.Methods.TryAdd("addEventListener", subscribe);
+            mc.Methods.TryAdd("removeEventListener", subscribe);
+            mc.StaticMethods.TryAdd("addEventListener", subscribe);
+            mc.StaticMethods.TryAdd("removeEventListener", subscribe);
+        }
+
+        BuildConstructor(meta, type, mc);
+
+        return mc.Freeze();
+    }
+
+    /// <summary>
+    /// Builds the callable type for one JS-facing method name: a single <see cref="TypeInfo.Function"/>,
+    /// an <see cref="TypeInfo.OverloadedFunction"/> for overload sets, or null when every overload
+    /// has an unmarshalable slot (the member is then absent, matching the discovery tool's verdict).
+    /// </summary>
+    private static TypeInfo? BuildMethodGroup(IEnumerable<MethodMetadata> overloads, Type self, TypeInfo.MutableClass mc)
+    {
+        var signatures = new List<TypeInfo.Function>();
+        foreach (var m in overloads)
+        {
+            if (DotNetInteropClassifier.UnsupportedSlotReason(m.ReturnType) != null)
+                continue;
+            if (m.Parameters.Any(p => DotNetInteropClassifier.UnsupportedSlotReason(p.ParameterType) != null))
+                continue;
+            signatures.Add(BuildSignature(m.Parameters, MapSlot(m.ReturnType, self, mc), self, mc));
+        }
+
+        return signatures.Count switch
+        {
+            0 => null,
+            1 => signatures[0],
+            _ => new TypeInfo.OverloadedFunction(signatures, MostPermissiveSignature(signatures)),
+        };
+    }
+
+    private static void BuildConstructor(TypeMetadata meta, Type type, TypeInfo.MutableClass mc)
+    {
+        // Static classes, interfaces, and enums cannot be `new`ed; classes without a public
+        // constructor can't either. Marking the synthesized class abstract makes the checker
+        // reject `new X()` with the standard abstract-class error.
+        if (meta.IsStatic || meta.IsInterface || meta.IsEnum)
+        {
+            mc.IsAbstract = true;
+            return;
+        }
+
+        var signatures = new List<TypeInfo.Function>();
+        foreach (var ctor in meta.Constructors)
+        {
+            if (ctor.Parameters.Any(p => DotNetInteropClassifier.UnsupportedSlotReason(p.ParameterType) != null))
+                continue;
+            signatures.Add(BuildSignature(ctor.Parameters, new TypeInfo.Void(), type, mc));
+        }
+
+        // Value types always support default construction (`new Guid()` → default(Guid)).
+        if (type.IsValueType && !signatures.Any(s => s.MinArity == 0))
+        {
+            signatures.Add(new TypeInfo.Function([], new TypeInfo.Void()));
+        }
+
+        if (signatures.Count == 0)
+        {
+            mc.IsAbstract = true;
+            return;
+        }
+
+        mc.Methods["constructor"] = signatures.Count == 1
+            ? signatures[0]
+            : new TypeInfo.OverloadedFunction(signatures, MostPermissiveSignature(signatures));
+    }
+
+    private static TypeInfo.Function BuildSignature(
+        List<ParameterMetadata> parameters, TypeInfo returnType, Type self, TypeInfo.MutableClass mc)
+    {
+        var paramTypes = new List<TypeInfo>(parameters.Count);
+        int requiredParams = 0;
+        bool hasRest = false;
+
+        for (int i = 0; i < parameters.Count; i++)
+        {
+            var p = parameters[i];
+            if (p.IsParams && i == parameters.Count - 1)
+            {
+                // params-array: the checker models rest params as an array-typed final slot.
+                paramTypes.Add(new TypeInfo.Array(new TypeInfo.Any()));
+                hasRest = true;
+                break;
+            }
+            paramTypes.Add(MapSlot(p.ParameterType, self, mc));
+            if (!p.IsOptional) requiredParams = i + 1;
+        }
+
+        return new TypeInfo.Function(paramTypes, returnType, requiredParams, hasRest);
+    }
+
+    /// <summary>
+    /// A catch-all implementation signature for overload sets: `(...args: any[]) => any`.
+    /// Only the individual signatures participate in call checking.
+    /// </summary>
+    private static TypeInfo.Function MostPermissiveSignature(List<TypeInfo.Function> signatures)
+        => new([new TypeInfo.Array(new TypeInfo.Any())], CommonReturnType(signatures), RequiredParams: 0, HasRestParam: true);
+
+    /// <summary>
+    /// When every overload agrees on the return type, keep it (preserves chaining through
+    /// members resolved via the implementation signature); otherwise fall back to any.
+    /// </summary>
+    private static TypeInfo CommonReturnType(List<TypeInfo.Function> signatures)
+    {
+        var first = signatures[0].ReturnType;
+        for (int i = 1; i < signatures.Count; i++)
+        {
+            if (!Equals(signatures[i].ReturnType, first)) return new TypeInfo.Any();
+        }
+        return first;
+    }
+
+    /// <summary>
+    /// Maps one CLR slot (parameter or return type) to the TypeScript-visible type. See the
+    /// class remarks for the policy; must stay aligned with <c>DotNetMarshaller</c>.
+    /// </summary>
+    private static TypeInfo MapSlot(Type clrType, Type self, TypeInfo.MutableClass mc)
+    {
+        if (clrType == typeof(void)) return new TypeInfo.Void();
+        if (clrType == typeof(string) || clrType == typeof(char)) return new TypeInfo.String();
+        if (clrType == typeof(bool)) return new TypeInfo.Primitive(TokenType.TYPE_BOOLEAN);
+
+        if (clrType == typeof(double) || clrType == typeof(float) ||
+            clrType == typeof(int) || clrType == typeof(uint) ||
+            clrType == typeof(long) || clrType == typeof(ulong) ||
+            clrType == typeof(short) || clrType == typeof(ushort) ||
+            clrType == typeof(byte) || clrType == typeof(sbyte) ||
+            clrType == typeof(decimal))
+        {
+            return new TypeInfo.Primitive(TokenType.TYPE_NUMBER);
+        }
+
+        // The containing type itself: keeps fluent chains statically typed. Instance wraps the
+        // MutableClass; Instance.ResolvedClassType resolves to the frozen Class after Freeze().
+        if (clrType == self) return new TypeInfo.Instance(mc);
+
+        return new TypeInfo.Any();
+    }
+}

--- a/TypeSystem/TypeChecker.Statements.cs
+++ b/TypeSystem/TypeChecker.Statements.cs
@@ -1145,11 +1145,53 @@ public partial class TypeChecker
     {
         if (_currentModule == null)
         {
+            // dotnet: imports need no module graph — they resolve via reflection, so
+            // single-file checking (and the language server, which checks buffers in
+            // isolation) can bind them here. Module mode binds them in BindModuleImports
+            // from the module's pre-resolved ExportedTypes instead.
+            if (Modules.DotNetImports.IsDotNetSpecifier(stmt.ModulePath))
+            {
+                BindStandaloneDotNetImport(stmt);
+                return VoidResult.Instance;
+            }
+
             // SharpTS-only: module-mode requirement (continued message)
             throw new TypeCheckException("Import statements require module mode. " +
                                "Use 'dotnet run -- --compile' with multi-file support", stmt.Keyword.Line);
         }
         return VoidResult.Instance;
+    }
+
+    /// <summary>
+    /// Binds a <c>dotnet:</c> import outside module mode by resolving each named import via
+    /// reflection and synthesizing its static type — the same resolution and synthesis the
+    /// module path uses (<c>DotNetImports.EnsureExport</c>), minus the module bookkeeping.
+    /// </summary>
+    private void BindStandaloneDotNetImport(Stmt.Import import)
+    {
+        if (import.DefaultImport != null || import.NamespaceImport != null)
+        {
+            throw new TypeCheckException(
+                $"'{import.ModulePath}' supports named imports only, e.g. import {{ TypeName }} from \"{import.ModulePath}\".",
+                import.Keyword.Line);
+        }
+
+        if (import.NamedImports == null) return;
+
+        string specifier = import.ModulePath[Modules.DotNetImports.Prefix.Length..];
+        foreach (var spec in import.NamedImports)
+        {
+            Type clrType;
+            try
+            {
+                clrType = Modules.DotNetImports.ResolveExportType(specifier, spec.Imported.Lexeme);
+            }
+            catch (Exception ex)
+            {
+                throw new TypeCheckException(ex.Message, spec.Imported.Line);
+            }
+            _environment.Define(spec.LocalName?.Lexeme ?? spec.Imported.Lexeme, DotNetTypeSynthesizer.Synthesize(clrType));
+        }
     }
 
     internal VoidResult VisitImportRequire(Stmt.ImportRequire stmt)

--- a/docs/dotnet-types.md
+++ b/docs/dotnet-types.md
@@ -11,7 +11,12 @@ SharpTS supports two forms of .NET interop:
 | **Outbound** | Compile TypeScript to .NET DLLs | Consume TS libraries from C# |
 | **Inbound** | Use .NET types from TypeScript | Access BCL and .NET libraries |
 
-This guide covers **inbound interop** - calling .NET code from TypeScript using the `@DotNetType` decorator.
+This guide covers **inbound interop** — calling .NET code from TypeScript. There are two ways to bind a .NET type:
+
+| Binding | Description | When to use |
+|---------|-------------|-------------|
+| **`dotnet:` imports** (recommended) | `import { StringBuilder } from "dotnet:System.Text.StringBuilder"` — the type surface is synthesized from reflection automatically | The default. No boilerplate; can't drift from the real CLR type |
+| **`@DotNetType` declarations** | Hand-written `declare class` bound to a CLR type | When you want a curated, hand-checked static surface, or need `@DotNetOverload` hints |
 
 ## Prerequisites
 
@@ -32,19 +37,14 @@ Use `@DotNetOverload(...)` when runtime resolution can't pick the overload you w
 ## Quick Start
 
 ```typescript
-// Declare an external .NET type
-@DotNetType("System.Text.StringBuilder")
-declare class StringBuilder {
-    constructor();
-    append(value: string): StringBuilder;
-    toString(): string;
-}
+// Import a .NET type directly — no declaration needed
+import { StringBuilder } from "dotnet:System.Text.StringBuilder";
 
 // Use it like a native TypeScript class
 let sb = new StringBuilder();
-sb.append("Hello, ");
-sb.append("World!");
+sb.append("Hello, ").append("World!");   // fluent chaining is statically typed
 console.log(sb.toString());  // Output: Hello, World!
+console.log(sb.length);      // .NET properties surface in camelCase: 13
 ```
 
 Compile and run:
@@ -52,6 +52,62 @@ Compile and run:
 sharpts --compile example.ts
 dotnet example.dll
 ```
+
+---
+
+## Importing .NET Types (`dotnet:` imports)
+
+A `dotnet:` import specifier binds .NET types as first-class module imports. The static type
+surface is synthesized directly from reflection metadata, so it always matches the real CLR
+type, and members the interop layer cannot marshal (the same four categories `--gen-decl`
+marks `[unsupported]`) are simply absent from the surface.
+
+### Two specifier forms
+
+```typescript
+// Single-type form: the specifier is a fully-qualified type name
+import { StringBuilder } from "dotnet:System.Text.StringBuilder";
+
+// Namespace form: each named import resolves as Namespace.Name
+import { Guid, DayOfWeek } from "dotnet:System";
+
+// Aliasing works like any ES import (useful to avoid collisions, e.g. with global Math)
+import { Math as SysMath } from "dotnet:System";
+
+// Nested types resolve through their declaring type's specifier
+import { SpecialFolder } from "dotnet:System.Environment";
+```
+
+### What you get
+
+- **Construction, instance/static members, fields, enums** — `new Guid()`, `Guid.newGuid()`,
+  `Guid.empty`, `DayOfWeek.Monday`. Member names follow the same camelCase convention as
+  `@DotNetType` (both `append` and `Append` resolve).
+- **Static typing** — primitives map to `number`/`string`/`boolean`, `void` maps to `void`,
+  methods returning the type itself keep fluent chains typed; other .NET types surface as
+  `any` (they still work — the runtime marshaller handles them dynamically).
+- **Both execution modes** — the interpreter binds the same runtime wrapper `@DotNetType`
+  uses; compiled mode resolves members at compile time and emits direct IL calls, so the
+  output DLL stays fully standalone (no SharpTS.dll dependency).
+- **Overload resolution** — cost-based, same as `@DotNetType`. If you need to force a
+  specific overload with `@DotNetOverload`, use a `@DotNetType` declaration for that type
+  instead; the two binding styles compose freely in one program.
+
+### v1 scope and restrictions
+
+- **Named imports only.** Default imports, `import * as ns`, `export … from "dotnet:…"`,
+  `import x = require("dotnet:…")`, and dynamic `import("dotnet:…")` are rejected with a
+  clear error — a .NET namespace is not an enumerable module object.
+- **Loaded assemblies only.** Types resolve from the BCL and any assembly already loaded in
+  the process (matching `@DotNetType`). A project-level assembly-reference story for
+  third-party DLLs is tracked separately.
+- **No generic types.** `dotnet:System.Collections.Generic.List<number>` is rejected; use an
+  `@DotNetType` declaration with a closed-generic CLR name for those.
+- Missing-member accesses follow SharpTS's standard class-instance semantics (same as
+  hand-written classes).
+
+Use `sharpts --gen-decl <Type|Namespace>` to discover what's available and copy the exact
+import line — see [Discovering .NET Types](#discovering-net-types---gen-decl).
 
 ---
 
@@ -458,8 +514,9 @@ four unsupported categories are by-ref (`ref`/`out`/`in`) parameters, pointer ty
 (`Span<T>`/`ReadOnlySpan<T>`), and open generics. Signatures are shown with faithful .NET types
 (`int`, `char[]`, `ReadOnlySpan<char>`, `out Guid`), not coerced into TypeScript.
 
-> The `import { … } from "dotnet:…";` line is a preview of the planned `dotnet:` import scheme
-> (issue #1195). Until it lands, consume the type with a hand-written `@DotNetType` declaration.
+> The `import { … } from "dotnet:…";` line is ready to copy into your program — see
+> [Importing .NET Types](#importing-net-types-dotnet-imports). It resolves with the exact same
+> usable/unsupported rules this tool reports.
 
 ### List a namespace or assembly
 


### PR DESCRIPTION
Closes #1195.

`dotnet:` import specifiers are now the first-class consumption path for .NET interop, in **both** execution modes, with static types synthesized directly from reflection — no `.d.ts` text intermediate, no hand-written declare-class boilerplate:

```ts
import { StringBuilder } from "dotnet:System.Text.StringBuilder";  // single-type form
import { Guid, Math as SysMath } from "dotnet:System";             // namespace form + alias
import { SpecialFolder } from "dotnet:System.Environment";         // nested types
```

## How it works

| Layer | Change |
|---|---|
| **Resolution** | `Modules/DotNetImports.cs` — the single resolution algorithm (single-type → nested → namespace-form; public types only; every type vetted by `DotNetInteropClassifier`, so `--gen-decl` and the resolver can never disagree). Clear `Module Error:` messages with a `--gen-decl` hint. `ModuleResolver` routes the scheme and populates exports per import statement at load time. |
| **Type checker** | `TypeSystem/DotNetTypeSynthesizer.cs` — `Type → TypeInfo.Class`, cached per CLR type (identity compat across modules and specifier forms). Primitives map precisely; self-typed returns keep fluent chains statically typed (`sb.append(...).append(...)`); other .NET types surface as `any` (matching what the runtime marshaller actually returns). Overload sets become `OverloadedFunction`; params-arrays become rest params; static classes / interfaces / enums / no-public-ctor types are marked abstract so `new` is rejected statically (TS2511). Single-file checking binds dotnet imports without module mode — which is what makes LSP buffer-isolated checking work. |
| **Interpreter** | dotnet modules export the same `DotNetClass` wrapper `@DotNetType` produces, registered at import-resolution time. |
| **Compiler** | `RegisterDotNetImports` drops imported names into the existing `ExternalTypes`/`TypeMapper` registries (user-class name collisions detected — user class wins + warning); the established external-interop emitters do everything else: compile-time overload resolution, direct IL, **fully standalone output** (verified: no SharpTS.dll co-location, zero `RequireSharpTSRuntime` reasons). |
| **LSP** | `InteropAnalyzer` validates dotnet imports via the *same shared resolver* (squiggles can't disagree with load-time errors) and feeds imported bindings into event-call validation; `MemberHoverService` resolves imported receivers (alias + CLR-name keys). |
| **Perf** | `DotNetTypeRegistry` gains member-lookup caches (methods/properties/events were fresh reflection queries per call — epic subtask). Reflection otherwise happens only at load/check/compile time; zero runtime cost change. |
| **Docs** | `docs/dotnet-types.md` leads with imports (Quick Start rewritten); `@DotNetType` documented as the manual/curated alternative (and the only way to get `@DotNetOverload` hints or closed generics). STATUS.md §16 updated. |

## Two pre-existing compiled-interop bugs fixed (found by the new tests)

Both affected `@DotNetType` all along:

1. **`Ldsfld` on literal fields is invalid IL** — enum members are `static literal` fields with no storage slot. The persisted `AssemblyBuilder` rejects it at emit time. Fix: `EmitExternalLiteralField` embeds the compile-time constant (enum members box to the enum type; numeric consts normalize to double like the interpreter's `WrapReturn`).
2. **Value-type receiver + reference-base method** — `PrepareReceiverForMemberAccess` unboxed the receiver (`Ldloca` + `Call`) even for methods declared on `Enum`/`ValueType`/`Object`, passing a managed pointer where an object reference is expected → NRE inside `Enum.ToString()`. Fix: such methods are called through the boxed receiver (`Castclass` + `Callvirt`).

## v1 scope (documented)

- **Named imports only** — default/star imports, `export … from`, `import = require()`, `require()`, and dynamic `import()` are rejected with clear errors (a .NET namespace is not an enumerable module object).
- **Loaded/BCL assemblies only** — third-party assembly loading story is the fast-follow #1197.
- **No generic types** — rejected with the classifier reason; use `@DotNetType` with a closed-generic CLR name.
- Unknown-member access types as `any` — the checker's existing semantics for **all** class instances; synthesized types match hand-written classes exactly.

## Tests

`SharedTests/DotNetImportTests.cs` (37 tests): both-mode theories for construction/chaining/properties, namespace form, aliases, static fields (`Guid.empty`), nested types, enums, cross-module instance flow, specifier-form type identity, type-only imports, and a **discovery-tool round-trip** (the exact `import` line `--gen-decl` prints must load, check, and run — the #1192/#1193 lesson); checker-diagnostic Facts (assignability, abstract-new); load-error Facts for every rejected form. Plus LSP analyzer/hover tests.

## Verification

- **xUnit: 14,983 / 0 failed** (full suite)
- **TypeScript conformance: 31 / 0**
- **Test262: 22 / 0** (4 known skips) — **baselines byte-identical in both modes**
- CLI smokes with `--verify` (IL verification) in both modes; standalone DLL confirmed

Follow-up: #1197 (third-party assembly loading).