### PR TITLE
feat(interop): sharpts.json reference manifest + NuGet packages for dotnet: imports (#1197)

### DIFF
--- a/Cli/CommandLineParser.cs
+++ b/Cli/CommandLineParser.cs
@@ -25,11 +25,18 @@ namespace SharpTS.Cli;
 /// <param name="DecoratorMode">Decorator parsing mode (None, Legacy, Stage3). Defaults to Stage3.</param>
 /// <param name="EmitDecoratorMetadata">Whether to emit design-time type metadata</param>
 /// <param name="CheckJs">When true, type-check `.js`/`.cjs`/`.mjs`/`.jsx` files like `.ts`. Mirrors tsc's `checkJs` tsconfig option. Defaults to false (matches tsc).</param>
+/// <param name="References">Assembly references from -r/--reference, applied in every mode
+/// (run, compile, --gen-decl, REPL) on top of any sharpts.json manifest. Paths resolve
+/// against the current working directory.</param>
 public record GlobalOptions(
     DecoratorMode DecoratorMode = DecoratorMode.Stage3,
     bool EmitDecoratorMetadata = false,
-    bool CheckJs = false
-);
+    bool CheckJs = false,
+    IReadOnlyList<string>? References = null
+)
+{
+    public IReadOnlyList<string> References { get; init; } = References ?? [];
+}
 
 /// <summary>
 /// Options specific to compilation mode.
@@ -115,7 +122,16 @@ public abstract record ParsedCommand
     /// <param name="TypeOrAssembly">Type name, namespace, or assembly path to inspect</param>
     /// <param name="OutputPath">Optional output file path</param>
     /// <param name="Json">Emit machine-readable JSON instead of human-readable text</param>
-    public sealed record GenDecl(string TypeOrAssembly, string? OutputPath, bool Json = false) : ParsedCommand;
+    /// <param name="References">Assembly references (-r) to load before discovery</param>
+    public sealed record GenDecl(
+        string TypeOrAssembly,
+        string? OutputPath,
+        bool Json = false,
+        IReadOnlyList<string>? References = null
+    ) : ParsedCommand
+    {
+        public IReadOnlyList<string> References { get; init; } = References ?? [];
+    }
 
     /// <summary>Parsing error with message and exit code.</summary>
     /// <param name="Message">Error message to display</param>
@@ -162,7 +178,7 @@ public class CommandLineParser
         // Handle --gen-decl
         if (remainingArgs[0] == "--gen-decl")
         {
-            return ParseGenDeclCommand(remainingArgs);
+            return ParseGenDeclCommand(remainingArgs, globalOptions);
         }
 
 
@@ -209,6 +225,7 @@ public class CommandLineParser
         var decoratorMode = DecoratorMode.Stage3;  // Stage3 decorators enabled by default
         var emitDecoratorMetadata = false;
         var checkJs = false;  // Match tsc default: don't type-check .js files unless asked
+        List<string> references = [];
         List<string> remaining = [];
         List<string> scriptArgs = [];
 
@@ -226,9 +243,9 @@ public class CommandLineParser
             args = args[..doubleDashIndex];
         }
 
-        foreach (var arg in args)
+        for (int i = 0; i < args.Length; i++)
         {
-            switch (arg)
+            switch (args[i])
             {
                 case "--experimentalDecorators":
                     decoratorMode = DecoratorMode.Legacy;
@@ -243,13 +260,16 @@ public class CommandLineParser
                 case "--checkJs":
                     checkJs = true;
                     break;
+                case "-r" or "--reference" when i + 1 < args.Length:
+                    references.Add(args[++i]);
+                    break;
                 default:
-                    remaining.Add(arg);
+                    remaining.Add(args[i]);
                     break;
             }
         }
 
-        return (new GlobalOptions(decoratorMode, emitDecoratorMetadata, checkJs), remaining.ToArray(), scriptArgs.ToArray());
+        return (new GlobalOptions(decoratorMode, emitDecoratorMetadata, checkJs, references), remaining.ToArray(), scriptArgs.ToArray());
     }
 
     private ParsedCommand ParseCompileCommand(string[] args, GlobalOptions globalOptions)
@@ -277,9 +297,6 @@ public class CommandLineParser
         string? apiKey = null;
         string? packageIdOverride = null;
         string? versionOverride = null;
-
-        // Assembly references
-        List<string> references = [];
 
         // Parse remaining arguments
         for (int i = 2; i < args.Length; i++)
@@ -392,10 +409,6 @@ public class CommandLineParser
             {
                 versionOverride = args[++i];
             }
-            else if ((args[i] is "-r" or "--reference") && i + 1 < args.Length)
-            {
-                references.Add(args[++i]);
-            }
         }
 
         // Determine output file: use explicit output if provided, otherwise derive from input + target
@@ -409,7 +422,7 @@ public class CommandLineParser
             VerifyIL: verifyIL,
             MsBuildErrors: msbuildErrors,
             QuietMode: quietMode,
-            References: references,
+            References: globalOptions.References,
             Bundler: bundlerMode,
             Standalone: standalone
         );
@@ -425,7 +438,7 @@ public class CommandLineParser
         return new ParsedCommand.Compile(inputFile, outputFile, compileOptions, packOptions, globalOptions);
     }
 
-    private ParsedCommand ParseGenDeclCommand(string[] args)
+    private ParsedCommand ParseGenDeclCommand(string[] args, GlobalOptions globalOptions)
     {
         if (args.Length < 2)
         {
@@ -460,7 +473,7 @@ public class CommandLineParser
             }
         }
 
-        return new ParsedCommand.GenDecl(typeOrAssembly, outputPath, json);
+        return new ParsedCommand.GenDecl(typeOrAssembly, outputPath, json, globalOptions.References);
     }
 
 }

--- a/Compilation/ILCompiler.cs
+++ b/Compilation/ILCompiler.cs
@@ -91,6 +91,15 @@ public partial class ILCompiler
     public IReadOnlyCollection<string> RequiredSharpTSRuntimeReasons =>
         _runtime?.RequiredSharpTSRuntimeReasons ?? (IReadOnlyCollection<string>)Array.Empty<string>();
 
+    /// <summary>
+    /// The assemblies of every external .NET type the compilation bound (@DotNetType
+    /// classes and dotnet: imports). These are HARD metadata references in the emitted
+    /// IL; the CLI intersects them with the sharpts.json / -r reference set to decide
+    /// which third-party DLLs to co-locate with the output.
+    /// </summary>
+    public IReadOnlyCollection<System.Reflection.Assembly> ExternalInteropAssemblies =>
+        _typeMapper.ExternalTypes.Values.Select(t => t.Assembly).Distinct().ToArray();
+
     // Type information from static analysis
     private TypeMap _typeMap = null!;
 

--- a/Compilation/ILVerifier.cs
+++ b/Compilation/ILVerifier.cs
@@ -10,14 +10,19 @@ namespace SharpTS.Compilation;
 public class ILVerifier : IResolver, IDisposable
 {
     private readonly string? _sdkPath;
+    private readonly IReadOnlyList<string> _extraProbeDirectories;
     private readonly Dictionary<string, PEReader> _assemblyCache = new();
     private bool _disposed;
 
     /// <param name="sdkPath">Optional extra probe directory (e.g. an explicit --sdk-path).
     /// Probed after the shared-framework runtime directory.</param>
-    public ILVerifier(string? sdkPath = null)
+    /// <param name="extraProbeDirectories">Additional probe directories, e.g. the locations
+    /// of third-party reference assemblies (sharpts.json / -r) the emitted IL calls into.
+    /// Probed last.</param>
+    public ILVerifier(string? sdkPath = null, IEnumerable<string>? extraProbeDirectories = null)
     {
         _sdkPath = sdkPath;
+        _extraProbeDirectories = extraProbeDirectories?.Distinct().ToArray() ?? [];
     }
 
     /// <summary>
@@ -158,6 +163,14 @@ public class ILVerifier : IResolver, IDisposable
         if (_sdkPath != null)
         {
             var reader = TryLoad(name, _sdkPath);
+            if (reader != null)
+                return reader;
+        }
+
+        // Finally, third-party reference directories (sharpts.json / -r assemblies).
+        foreach (var dir in _extraProbeDirectories)
+        {
+            var reader = TryLoad(name, dir);
             if (reader != null)
                 return reader;
         }

--- a/Modules/DotNetImports.cs
+++ b/Modules/DotNetImports.cs
@@ -111,6 +111,17 @@ public static class DotNetImports
     {
         resolve ??= DotNetTypeRegistry.Resolve;
 
+        if (specifier.Contains('/') || specifier.Contains('\\') || specifier.Contains('#') ||
+            specifier.EndsWith(".dll", StringComparison.OrdinalIgnoreCase) ||
+            specifier.EndsWith(".exe", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new Exception(
+                $"Module Error: cannot import 'dotnet:{specifier}': dotnet: specifiers name types or " +
+                "namespaces, not assembly paths. Add the assembly to a sharpts.json manifest " +
+                "(\"references\": [\"./libs/MyLib.dll\"]) or pass -r ./libs/MyLib.dll, then import the " +
+                "type by name: import { Widget } from \"dotnet:MyLib.Widget\".");
+        }
+
         if (specifier.Contains('<') || specifier.Contains('`'))
         {
             throw new Exception(

--- a/Program.cs
+++ b/Program.cs
@@ -10,12 +10,16 @@
 //   dotnet run -- --compile <file.ts>    - Compile to .NET IL assembly
 //   dotnet run -- -c <file.ts> -o out.dll - Compile with custom output path
 //
+// Global flags:
+//   -r, --reference <assembly.dll>       - Add .NET assembly reference (repeatable; all modes).
+//                                          sharpts.json next to/above the entry script supplies
+//                                          project-level references and NuGet packages.
+//
 // Compilation flags:
 //   --ref-asm                            - Emit reference-assembly-compatible output
 //   --sdk-path <path>                    - Explicit path to .NET SDK reference assemblies
 //   --preserveConstEnums                 - Preserve const enum declarations
 //   --verify                             - Verify emitted IL using Microsoft.ILVerification
-//   -r, --reference <assembly.dll>       - Add assembly reference (can be repeated)
 //
 // Decorator flags:
 //   --experimentalDecorators             - Enable Legacy (Stage 2) decorators
@@ -45,6 +49,7 @@ using SharpTS.Execution;
 using SharpTS.Modules;
 using SharpTS.Packaging;
 using SharpTS.Parsing;
+using SharpTS.References;
 using SharpTS.TypeSystem;
 
 // Initialize fork IPC if this process was spawned via child_process.fork()
@@ -72,11 +77,14 @@ switch (command)
         break;
 
     case ParsedCommand.Repl repl:
+        var replRefs = LoadDotNetReferences(Environment.CurrentDirectory, repl.Options.References);
+        if (replRefs.ManifestPath != null)
+            Console.WriteLine($"Loaded {replRefs.ManifestPath}: {replRefs.References.Count} assembly reference(s)");
         RunPromptAsync(repl.Options.DecoratorMode).GetAwaiter().GetResult();
         break;
 
     case ParsedCommand.Script script:
-        RunFile(script.ScriptPath, script.Options.DecoratorMode, script.Options.EmitDecoratorMetadata, script.ScriptArgs, script.Options.CheckJs);
+        RunFile(script.ScriptPath, script.Options.DecoratorMode, script.Options.EmitDecoratorMetadata, script.ScriptArgs, script.Options.CheckJs, script.Options.References);
         break;
 
     case ParsedCommand.Compile compile:
@@ -99,14 +107,38 @@ switch (command)
         break;
 
     case ParsedCommand.GenDecl genDecl:
-        GenerateDeclarations(genDecl.TypeOrAssembly, genDecl.OutputPath, genDecl.Json);
+        GenerateDeclarations(genDecl.TypeOrAssembly, genDecl.OutputPath, genDecl.Json, genDecl.References);
         break;
 }
 
-static void RunFile(string path, DecoratorMode decoratorMode, bool emitDecoratorMetadata, string[]? scriptArgs = null, bool checkJs = false)
+/// <summary>
+/// Resolves and loads third-party reference assemblies (sharpts.json manifest + -r flags)
+/// before any module loading or type checking, so every resolution seam sees the types.
+/// Reference errors are user-facing configuration problems: print and exit.
+/// </summary>
+static ReferenceSet LoadDotNetReferences(string startDirectory, IReadOnlyList<string> cliReferences)
+{
+    try
+    {
+        return DotNetReferences.Load(startDirectory, cliReferences);
+    }
+    catch (Exception ex)
+    {
+        Console.WriteLine(ex.Message);
+        Environment.Exit(1);
+        throw; // unreachable
+    }
+}
+
+static void RunFile(string path, DecoratorMode decoratorMode, bool emitDecoratorMetadata, string[]? scriptArgs = null, bool checkJs = false, IReadOnlyList<string>? references = null)
 {
     string absolutePath = Path.GetFullPath(path);
     string source = File.ReadAllText(absolutePath);
+
+    // Third-party assembly references (sharpts.json walked up from the entry script,
+    // plus -r flags) load before any module resolution so dotnet: imports and
+    // @DotNetType declarations can see the types.
+    LoadDotNetReferences(Path.GetDirectoryName(absolutePath) ?? ".", references ?? []);
 
     // Set script arguments for process.argv
     SharpTS.Runtime.BuiltIns.ProcessBuiltIns.SetScriptArguments(absolutePath, scriptArgs ?? []);
@@ -291,6 +323,11 @@ static void CompileFile(string inputPath, string outputPath, bool preserveConstE
         string absolutePath = Path.GetFullPath(inputPath);
         string source = File.ReadAllText(absolutePath);
 
+        // Third-party assembly references (sharpts.json + -r) load into this process
+        // before module resolution: dotnet: imports resolve at module-load time, and
+        // the returned set drives the post-Save co-location of referenced DLLs.
+        var externalRefs = LoadDotNetReferences(Path.GetDirectoryName(absolutePath) ?? ".", references);
+
         // Load package.json if packaging is enabled
         PackageJson? packageJson = null;
         AssemblyMetadata? metadata = null;
@@ -376,11 +413,11 @@ static void CompileFile(string inputPath, string outputPath, bool preserveConstE
 
         if (hasModules)
         {
-            CompileModuleFile(absolutePath, outputPath, preserveConstEnums, useReferenceAssemblies, sdkPath, verifyIL, decoratorMode, outputOptions, metadata, references, target, bundlerMode);
+            CompileModuleFile(absolutePath, outputPath, preserveConstEnums, useReferenceAssemblies, sdkPath, verifyIL, decoratorMode, outputOptions, metadata, references, target, bundlerMode, externalRefs);
         }
         else
         {
-            CompileSingleFile(statements, outputPath, preserveConstEnums, useReferenceAssemblies, sdkPath, verifyIL, decoratorMode, outputOptions, metadata, references, target, bundlerMode, absolutePath, lexer.Pragmas);
+            CompileSingleFile(statements, outputPath, preserveConstEnums, useReferenceAssemblies, sdkPath, verifyIL, decoratorMode, outputOptions, metadata, references, target, bundlerMode, absolutePath, lexer.Pragmas, externalRefs);
         }
 
         // Package if requested
@@ -410,7 +447,7 @@ static void CompileFile(string inputPath, string outputPath, bool preserveConstE
     }
 }
 
-static void CompileModuleFile(string absolutePath, string outputPath, bool preserveConstEnums, bool useReferenceAssemblies, string? sdkPath, bool verifyIL, DecoratorMode decoratorMode, OutputOptions outputOptions, AssemblyMetadata? metadata, IReadOnlyList<string> references, OutputTarget target, BundlerMode bundlerMode)
+static void CompileModuleFile(string absolutePath, string outputPath, bool preserveConstEnums, bool useReferenceAssemblies, string? sdkPath, bool verifyIL, DecoratorMode decoratorMode, OutputOptions outputOptions, AssemblyMetadata? metadata, IReadOnlyList<string> references, OutputTarget target, BundlerMode bundlerMode, ReferenceSet externalRefs)
 {
     // Phase 1: Load all static dependencies via ModuleResolver
     var resolver = new ModuleResolver(absolutePath);
@@ -463,7 +500,7 @@ static void CompileModuleFile(string absolutePath, string outputPath, bool prese
             // Run IL verification on the DLL if requested
             if (verifyIL)
             {
-                VerifyCompiledAssembly(tempDllPath, sdkPath);
+                VerifyCompiledAssembly(tempDllPath, sdkPath, externalRefs);
             }
 
             // Bundle into single-file EXE
@@ -480,6 +517,7 @@ static void CompileModuleFile(string absolutePath, string outputPath, bool prese
                 // late-binds into the SharpTS runtime (eval, Proxy, Intl, vm, dns, @DotNetType
                 // dynamic events). Honors --standalone. Pure programs stay a single file.
                 CopySharpTSRuntimeIfNeeded(compiler, outputPath, outputOptions);
+                CopyExternalReferencesIfNeeded(compiler, externalRefs, outputPath, outputOptions);
             }
             catch (Exception ex) when (bundlerMode != BundlerMode.Auto)
             {
@@ -505,6 +543,7 @@ static void CompileModuleFile(string absolutePath, string outputPath, bool prese
 
         GenerateRuntimeConfig(outputPath);
         CopySharpTSRuntimeIfNeeded(compiler, outputPath, outputOptions);
+        CopyExternalReferencesIfNeeded(compiler, externalRefs, outputPath, outputOptions);
         if (!outputOptions.QuietMode)
         {
             Console.WriteLine($"Compiled to {outputPath}");
@@ -513,13 +552,14 @@ static void CompileModuleFile(string absolutePath, string outputPath, bool prese
         // Run IL verification if requested
         if (verifyIL)
         {
-            VerifyCompiledAssembly(outputPath, sdkPath);
+            VerifyCompiledAssembly(outputPath, sdkPath, externalRefs);
         }
     }
 }
 
-static void CompileSingleFile(List<Stmt> statements, string outputPath, bool preserveConstEnums, bool useReferenceAssemblies, string? sdkPath, bool verifyIL, DecoratorMode decoratorMode, OutputOptions outputOptions, AssemblyMetadata? metadata, IReadOnlyList<string> references, OutputTarget target, BundlerMode bundlerMode, string? sourcePath = null, TypeScriptPragmas? pragmas = null)
+static void CompileSingleFile(List<Stmt> statements, string outputPath, bool preserveConstEnums, bool useReferenceAssemblies, string? sdkPath, bool verifyIL, DecoratorMode decoratorMode, OutputOptions outputOptions, AssemblyMetadata? metadata, IReadOnlyList<string> references, OutputTarget target, BundlerMode bundlerMode, string? sourcePath = null, TypeScriptPragmas? pragmas = null, ReferenceSet? externalRefs = null)
 {
+    externalRefs ??= ReferenceSet.Empty;
     // Set up diagnostic reporter
     var reporter = new DiagnosticReporter { MsBuildFormat = outputOptions.MsBuildErrors, QuietMode = outputOptions.QuietMode };
 
@@ -569,7 +609,7 @@ static void CompileSingleFile(List<Stmt> statements, string outputPath, bool pre
             // Run IL verification on the DLL if requested
             if (verifyIL)
             {
-                VerifyCompiledAssembly(tempDllPath, sdkPath);
+                VerifyCompiledAssembly(tempDllPath, sdkPath, externalRefs);
             }
 
             // Bundle into single-file EXE
@@ -586,6 +626,7 @@ static void CompileSingleFile(List<Stmt> statements, string outputPath, bool pre
                 // late-binds into the SharpTS runtime (eval, Proxy, Intl, vm, dns, @DotNetType
                 // dynamic events). Honors --standalone. Pure programs stay a single file.
                 CopySharpTSRuntimeIfNeeded(compiler, outputPath, outputOptions);
+                CopyExternalReferencesIfNeeded(compiler, externalRefs, outputPath, outputOptions);
             }
             catch (Exception ex) when (bundlerMode != BundlerMode.Auto)
             {
@@ -611,6 +652,7 @@ static void CompileSingleFile(List<Stmt> statements, string outputPath, bool pre
 
         GenerateRuntimeConfig(outputPath);
         CopySharpTSRuntimeIfNeeded(compiler, outputPath, outputOptions);
+        CopyExternalReferencesIfNeeded(compiler, externalRefs, outputPath, outputOptions);
         if (!outputOptions.QuietMode)
         {
             Console.WriteLine($"Compiled to {outputPath}");
@@ -619,7 +661,7 @@ static void CompileSingleFile(List<Stmt> statements, string outputPath, bool pre
         // Run IL verification if requested
         if (verifyIL)
         {
-            VerifyCompiledAssembly(outputPath, sdkPath);
+            VerifyCompiledAssembly(outputPath, sdkPath, externalRefs);
         }
     }
 }
@@ -702,6 +744,129 @@ static void CopySharpTSRuntimeIfNeeded(ILCompiler compiler, string outputPath, O
     }
 }
 
+/// <summary>
+/// Co-locates third-party reference assemblies (sharpts.json / -r) with the compiled output.
+/// Unlike the SharpTS runtime soft-dependency, these are HARD metadata references — the
+/// emitted IL calls into them by token, and default host probing only searches the app
+/// directory. Copies only the assemblies whose types the program actually used, plus their
+/// transitive dependency closure (assets-graph subtree for NuGet packages, AssemblyName walk
+/// for local DLLs). <c>--standalone</c> suppresses the copy but lists what deployment needs.
+/// </summary>
+static void CopyExternalReferencesIfNeeded(ILCompiler compiler, ReferenceSet externalRefs, string outputPath, OutputOptions outputOptions)
+{
+    if (externalRefs.IsEmpty)
+        return;
+
+    // Which reference DLLs did the compilation actually bind types from?
+    var used = new List<ResolvedReference>();
+    foreach (var assembly in compiler.ExternalInteropAssemblies)
+    {
+        string location;
+        try { location = assembly.Location; } catch { continue; }
+        if (string.IsNullOrEmpty(location)) continue;
+        var match = externalRefs.FindByPath(Path.GetFullPath(location));
+        if (match != null && !used.Contains(match)) used.Add(match);
+    }
+    if (used.Count == 0)
+        return; // external types came only from the BCL / already-deployed assemblies
+
+    // Loaded assemblies by full path, for the local-DLL dependency walk.
+    var loadedByPath = new Dictionary<string, Assembly>(
+        OperatingSystem.IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal);
+    foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+    {
+        try
+        {
+            if (!assembly.IsDynamic && !string.IsNullOrEmpty(assembly.Location))
+                loadedByPath[Path.GetFullPath(assembly.Location)] = assembly;
+        }
+        catch { }
+    }
+
+    var copySet = new List<string>();
+    var seen = new HashSet<string>(loadedByPath.Comparer);
+
+    void AddLocalClosure(string dllPath)
+    {
+        if (!seen.Add(dllPath)) return;
+        copySet.Add(dllPath);
+
+        // Dependencies resolve from the reference set (recurse) or as siblings of the
+        // DLL that references them (copy). Shared-framework names match neither and
+        // fall out naturally.
+        if (!loadedByPath.TryGetValue(dllPath, out var assembly)) return;
+        foreach (var dependency in assembly.GetReferencedAssemblies())
+        {
+            string fileName = dependency.Name + ".dll";
+            var inSet = externalRefs.References.FirstOrDefault(r =>
+                string.Equals(Path.GetFileName(r.Path), fileName, StringComparison.OrdinalIgnoreCase));
+            if (inSet != null)
+            {
+                AddLocalClosure(inSet.Path);
+                continue;
+            }
+            string sibling = Path.Combine(Path.GetDirectoryName(dllPath)!, fileName);
+            if (File.Exists(sibling) && seen.Add(sibling))
+                copySet.Add(sibling);
+        }
+    }
+
+    foreach (var reference in used)
+    {
+        if (reference.Origin == ReferenceOrigin.Package)
+        {
+            foreach (var asset in externalRefs.RuntimeClosureFor(reference))
+            {
+                if (seen.Add(asset)) copySet.Add(asset);
+            }
+            // The closure always contains the package's own assets, but keep the used
+            // DLL itself even if the closure lookup came up empty.
+            if (seen.Add(reference.Path)) copySet.Add(reference.Path);
+        }
+        else
+        {
+            AddLocalClosure(reference.Path);
+        }
+    }
+
+    string usedNames = string.Join(", ", used.Select(r => Path.GetFileNameWithoutExtension(r.Path)));
+
+    if (outputOptions.Standalone)
+    {
+        if (!outputOptions.QuietMode)
+            Console.WriteLine(
+                $"Note: output references external .NET assemblies ({usedNames}); --standalone set, so they were " +
+                "not copied. The output will not run unless these assemblies are deployed next to it: " +
+                string.Join(", ", copySet.Select(Path.GetFileName)));
+        return;
+    }
+
+    var outDir = Path.GetDirectoryName(Path.GetFullPath(outputPath))!;
+    int copied = 0;
+    foreach (var source in copySet)
+    {
+        var destPath = Path.Combine(outDir, Path.GetFileName(source));
+        try
+        {
+            if (!string.Equals(Path.GetFullPath(source), Path.GetFullPath(destPath), StringComparison.OrdinalIgnoreCase))
+            {
+                File.Copy(source, destPath, overwrite: true);
+                copied++;
+            }
+        }
+        catch (Exception ex)
+        {
+            if (!outputOptions.QuietMode)
+                Console.WriteLine($"Warning: failed to copy referenced assembly '{source}' next to output: {ex.Message}");
+        }
+    }
+
+    if (copied > 0 && !outputOptions.QuietMode)
+    {
+        Console.WriteLine($"Copied {copied} referenced assembl{(copied == 1 ? "y" : "ies")} next to output — required by external .NET types: {usedNames}");
+    }
+}
+
 static void GenerateRuntimeConfig(string outputPath)
 {
     string runtimeConfigPath = Path.ChangeExtension(outputPath, ".runtimeconfig.json");
@@ -719,11 +884,16 @@ static void GenerateRuntimeConfig(string outputPath)
     File.WriteAllText(runtimeConfigPath, runtimeConfig);
 }
 
-static void VerifyCompiledAssembly(string outputPath, string? sdkPath)
+static void VerifyCompiledAssembly(string outputPath, string? sdkPath, ReferenceSet? externalRefs = null)
 {
-    // The verifier resolves against the shared-framework runtime directory;
-    // an explicit --sdk-path is only an additional probe location.
-    using var verifier = new ILVerifier(sdkPath);
+    // The verifier resolves against the shared-framework runtime directory; an explicit
+    // --sdk-path and the directories of third-party reference assemblies (whose types the
+    // emitted IL references by token) are additional probe locations.
+    var probeDirs = externalRefs?.References
+        .Select(r => Path.GetDirectoryName(r.Path))
+        .Where(d => !string.IsNullOrEmpty(d))
+        .Cast<string>();
+    using var verifier = new ILVerifier(sdkPath, probeDirs);
     using var stream = File.OpenRead(outputPath);
     verifier.VerifyAndReport(stream);
 }
@@ -809,8 +979,12 @@ static void CreateNuGetPackage(string assemblyPath, PackageJson? packageJson, Pa
     }
 }
 
-static void GenerateDeclarations(string typeOrAssembly, string? outputPath, bool json)
+static void GenerateDeclarations(string typeOrAssembly, string? outputPath, bool json, IReadOnlyList<string> references)
 {
+    // Manifest (from CWD) + -r assemblies load first so type/namespace discovery
+    // sees third-party types, not just already-loaded ones.
+    LoadDotNetReferences(Environment.CurrentDirectory, references);
+
     try
     {
         // --gen-decl is a .NET interop *discovery* tool (issue #1194): it inspects a type,
@@ -881,6 +1055,14 @@ static void PrintHelp()
     Console.WriteLine("  --experimentalDecorators      Enable Legacy (Stage 2) decorators");
     Console.WriteLine("  --decorators                  Enable TC39 Stage 3 decorators");
     Console.WriteLine("  --emitDecoratorMetadata       Emit design-time type metadata");
+    Console.WriteLine("  -r, --reference <asm.dll>     Add a .NET assembly reference (repeatable; all modes)");
+    Console.WriteLine();
+    Console.WriteLine(".NET References:");
+    Console.WriteLine("  A sharpts.json next to (or above) the entry script supplies project-level");
+    Console.WriteLine("  references for dotnet: imports and @DotNetType:");
+    Console.WriteLine("    { \"references\": [\"./libs/MyLib.dll\"], \"packages\": { \"Some.Package\": \"1.2.3\" } }");
+    Console.WriteLine("  Packages restore via 'dotnet restore' into the global NuGet cache (.sharpts/");
+    Console.WriteLine("  holds the restore cache; add it to .gitignore).");
     Console.WriteLine();
     Console.WriteLine("Script Arguments:");
     Console.WriteLine("  Arguments after script.ts are passed to process.argv");
@@ -892,7 +1074,6 @@ static void PrintHelp()
     Console.WriteLine("  -o <path>                     Output file path (default: <input>.dll or .exe)");
     Console.WriteLine("  -t, --target <type>           Output type: dll (default) or exe");
     Console.WriteLine("  --bundler <mode>              Bundler selection: auto (default), sdk, or builtin");
-    Console.WriteLine("  -r, --reference <asm.dll>     Add assembly reference (repeatable)");
     Console.WriteLine("  --preserveConstEnums          Preserve const enum declarations");
     Console.WriteLine("  --ref-asm                     Emit reference-assembly-compatible output");
     Console.WriteLine("  --sdk-path <path>             Path to .NET SDK reference assemblies");

--- a/README.md
+++ b/README.md
@@ -54,8 +54,9 @@ SharpTS supports two execution modes:
 
 ### .NET Interop
 
-- **Use .NET types from TypeScript** via `@DotNetType` decorator
+- **Use .NET types from TypeScript** via `dotnet:` imports (or the `@DotNetType` decorator)
 - Access BCL classes like `StringBuilder`, `Guid`, `DateTime`, `TimeSpan`
+- **Third-party DLLs and NuGet packages** via a `sharpts.json` manifest (`references` + `packages`)
 - Automatic type conversion and overload resolution
 - **Compile TypeScript for C# consumption** with reflection or direct reference
 
@@ -217,13 +218,8 @@ $ dotnet functional.dll
 ### Use .NET Types from TypeScript
 
 ```typescript
-// Use BCL types directly in TypeScript
-@DotNetType("System.Text.StringBuilder")
-declare class StringBuilder {
-    constructor();
-    append(value: string): StringBuilder;
-    toString(): string;
-}
+// Import BCL types directly — the static type surface comes from reflection
+import { StringBuilder } from "dotnet:System.Text.StringBuilder";
 
 let sb = new StringBuilder();
 sb.append("Hello from .NET!");
@@ -235,6 +231,24 @@ $ sharpts --compile dotnet-example.ts
 $ dotnet dotnet-example.dll
 Hello from .NET!
 ```
+
+Third-party assemblies and NuGet packages plug in via a `sharpts.json` manifest next to
+your script (or a per-invocation `-r ./libs/MyLib.dll` flag):
+
+```jsonc
+{
+  "references": ["./libs/MyLib.dll"],
+  "packages": { "Newtonsoft.Json": "13.0.3" }
+}
+```
+
+```typescript
+import { Widget } from "dotnet:MyLib.Widget";
+import { JsonConvert } from "dotnet:Newtonsoft.Json.JsonConvert";
+```
+
+See [Using .NET Types](docs/dotnet-types.md) for the full guide (including the manual
+`@DotNetType` declaration style and the `--gen-decl` discovery tool).
 
 ### Access TypeScript classes from .NET (C#)
 

--- a/References/DotNetReferences.cs
+++ b/References/DotNetReferences.cs
@@ -1,0 +1,130 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+
+namespace SharpTS.References;
+
+/// <summary>
+/// The single entry point for third-party assembly references (issue #1197):
+/// discovers the sharpts.json manifest, restores its NuGet packages, and resolves
+/// the full set of reference DLL paths from CLI -r flags + manifest references +
+/// package runtime assets.
+///
+/// Two call shapes:
+/// <list type="bullet">
+/// <item><see cref="Resolve"/> — paths only, no loading. Used by the language server,
+/// which inspects types through a MetadataLoadContext and must never execute
+/// workspace code.</item>
+/// <item><see cref="Load"/> — <see cref="Resolve"/> + <c>Assembly.LoadFrom</c> into the
+/// default load context, so every existing resolution seam (interpreter, compiler,
+/// --gen-decl, @DotNetType) finds the types via its AppDomain scan. Used by run,
+/// compile, --gen-decl, and REPL modes before any module loading begins.</item>
+/// </list>
+/// </summary>
+public static class DotNetReferences
+{
+    /// <summary>
+    /// Discovers the manifest (upward walk from <paramref name="startDirectory"/>),
+    /// restores packages when present, and resolves all reference paths.
+    /// Load order: CLI -r (resolved against the current directory) → manifest
+    /// references (resolved against the manifest directory) → package runtime
+    /// closures; first occurrence wins de-duplication.
+    /// </summary>
+    /// <exception cref="Exception">Missing reference DLL, malformed manifest, or
+    /// failed restore — all with messages naming the offending file/entry.</exception>
+    public static ReferenceSet Resolve(string startDirectory, IReadOnlyList<string> cliReferences)
+    {
+        var manifest = SharpTsManifestLoader.FindAndLoad(startDirectory);
+        if (manifest == null && cliReferences.Count == 0)
+            return ReferenceSet.Empty;
+
+        var seen = new HashSet<string>(PathComparer);
+        var references = new List<ResolvedReference>();
+
+        foreach (var cliRef in cliReferences)
+        {
+            string fullPath = Path.GetFullPath(cliRef);
+            if (!File.Exists(fullPath))
+            {
+                throw new Exception(
+                    $"Error: reference '{cliRef}' (from -r/--reference) not found" +
+                    (fullPath != cliRef ? $" (resolved to '{fullPath}')." : "."));
+            }
+            if (seen.Add(fullPath))
+                references.Add(new ResolvedReference(fullPath, ReferenceOrigin.Cli));
+        }
+
+        Dictionary<string, IReadOnlyList<string>>? packageClosures = null;
+        if (manifest != null)
+        {
+            foreach (var entry in manifest.References ?? [])
+            {
+                string fullPath = Path.GetFullPath(Path.Combine(manifest.ManifestDirectory, entry));
+                if (!File.Exists(fullPath))
+                {
+                    throw new Exception(
+                        $"Error: sharpts.json ('{manifest.ManifestPath}'): reference '{entry}' not found " +
+                        $"(resolved to '{fullPath}'). Check the path or remove the entry.");
+                }
+                if (seen.Add(fullPath))
+                    references.Add(new ResolvedReference(fullPath, ReferenceOrigin.Manifest));
+            }
+
+            if (manifest.Packages is { Count: > 0 })
+            {
+                var restore = NuGetRestorer.Restore(manifest);
+                packageClosures = restore.PackageClosures;
+                foreach (var asset in restore.RuntimeAssets)
+                {
+                    if (seen.Add(asset.Path))
+                        references.Add(new ResolvedReference(asset.Path, ReferenceOrigin.Package, asset.PackageId));
+                }
+            }
+        }
+
+        return new ReferenceSet(manifest?.ManifestPath, references, packageClosures);
+    }
+
+    /// <summary>
+    /// <see cref="Resolve"/> + loads every resolved assembly into the default load
+    /// context. Must run before module loading / type checking so the AppDomain
+    /// scans in DotNetTypeRegistry, ILCompiler, and DiscoveryGenerator see the types.
+    /// Idempotent: re-loading the same path returns the already-loaded assembly.
+    /// </summary>
+    public static ReferenceSet Load(string startDirectory, IReadOnlyList<string> cliReferences)
+    {
+        var set = Resolve(startDirectory, cliReferences);
+        if (set.IsEmpty) return set;
+
+        List<string>? failures = null;
+        foreach (var reference in set.References)
+        {
+            try
+            {
+                var assembly = Assembly.LoadFrom(reference.Path);
+                if (assembly.GetCustomAttribute<ReferenceAssemblyAttribute>() != null)
+                {
+                    (failures ??= []).Add(
+                        $"'{reference.Path}' is a reference assembly (metadata only, no executable code). " +
+                        "Point at the implementation assembly (e.g. bin/, not obj/ref/).");
+                }
+            }
+            catch (Exception ex) when (ex is BadImageFormatException or FileLoadException or FileNotFoundException)
+            {
+                (failures ??= []).Add($"'{reference.Path}' could not be loaded: {ex.Message}");
+            }
+        }
+
+        if (failures != null)
+        {
+            string origin = set.ManifestPath != null ? $" (manifest: '{set.ManifestPath}')" : "";
+            throw new Exception(
+                $"Error: failed to load reference assembl{(failures.Count == 1 ? "y" : "ies")}{origin}:\n  " +
+                string.Join("\n  ", failures));
+        }
+
+        return set;
+    }
+
+    private static StringComparer PathComparer =>
+        OperatingSystem.IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
+}

--- a/References/NuGetRestorer.cs
+++ b/References/NuGetRestorer.cs
@@ -1,0 +1,158 @@
+using System.Diagnostics;
+using System.Security;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace SharpTS.References;
+
+/// <summary>One runtime-asset DLL from a restored package.</summary>
+internal sealed record PackageAsset(string Path, string PackageId);
+
+/// <summary>
+/// Result of a package restore: every runtime DLL in the resolved graph, plus the
+/// per-package transitive closure used by the compiled-output copy step.
+/// </summary>
+internal sealed record RestoreResult(
+    IReadOnlyList<PackageAsset> RuntimeAssets,
+    Dictionary<string, IReadOnlyList<string>> PackageClosures);
+
+/// <summary>
+/// Restores sharpts.json "packages" by shelling out to <c>dotnet restore</c> on a
+/// generated minimal project under <c>.sharpts/</c> next to the manifest, then
+/// reading the resulting <c>project.assets.json</c>. Deliberately NOT the NuGet
+/// client libraries: programmatic restore would add NuGet.Commands/ProjectModel/
+/// DependencyResolver to SharpTS.dll's dependency closure (which gets co-located
+/// next to compiled output), and the CLI honors nuget.config discovery, credential
+/// providers, and offline cache behavior for free.
+/// </summary>
+internal static class NuGetRestorer
+{
+    /// <summary>Target framework for the restore graph; matches the SharpTS runtime.</summary>
+    private const string TargetFramework = "net10.0";
+
+    public static RestoreResult Restore(SharpTsManifest manifest)
+    {
+        string restoreDir = Path.Combine(manifest.ManifestDirectory, ".sharpts");
+        string projectPath = Path.Combine(restoreDir, "restore.csproj");
+        string assetsPath = Path.Combine(restoreDir, "obj", "project.assets.json");
+        string hashPath = Path.Combine(restoreDir, "restore.hash");
+
+        string hash = ComputeHash(manifest.Packages!);
+
+        // Hash gate: when the package set hasn't changed since the last successful
+        // restore, skip the dotnet invocation entirely (fast startup, works offline).
+        bool upToDate = File.Exists(assetsPath) && File.Exists(hashPath) &&
+                        File.ReadAllText(hashPath).Trim() == hash;
+
+        if (!upToDate)
+        {
+            RunRestore(manifest, restoreDir, projectPath);
+            if (!File.Exists(assetsPath))
+            {
+                throw new Exception(
+                    $"Error: NuGet restore for sharpts.json ('{manifest.ManifestPath}') completed but " +
+                    $"produced no assets file at '{assetsPath}'.");
+            }
+            File.WriteAllText(hashPath, hash);
+        }
+
+        return ProjectAssetsReader.Read(assetsPath, manifest.ManifestPath, TargetFramework);
+    }
+
+    private static string ComputeHash(Dictionary<string, string> packages)
+    {
+        var lines = packages
+            .Select(kv => $"{kv.Key}@{kv.Value}")
+            .OrderBy(l => l, StringComparer.OrdinalIgnoreCase);
+        byte[] digest = SHA256.HashData(Encoding.UTF8.GetBytes(TargetFramework + "\n" + string.Join("\n", lines)));
+        return Convert.ToHexString(digest);
+    }
+
+    private static void RunRestore(SharpTsManifest manifest, string restoreDir, string projectPath)
+    {
+        Directory.CreateDirectory(restoreDir);
+        WriteRestoreProject(manifest, projectPath);
+
+        // Isolation stubs: without these, MSBuild walks up from .sharpts/ and imports
+        // the host repo's Directory.Build.props / Directory.Packages.props — Central
+        // Package Management there would fail our versioned PackageReferences (NU1008).
+        // nuget.config is intentionally NOT stubbed: discovery from the manifest
+        // directory is a feature (custom sources, hermetic tests).
+        const string emptyProject = "<Project></Project>";
+        File.WriteAllText(Path.Combine(restoreDir, "Directory.Build.props"), emptyProject);
+        File.WriteAllText(Path.Combine(restoreDir, "Directory.Build.targets"), emptyProject);
+        File.WriteAllText(Path.Combine(restoreDir, "Directory.Packages.props"), emptyProject);
+
+        var psi = new ProcessStartInfo("dotnet")
+        {
+            WorkingDirectory = manifest.ManifestDirectory,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false
+        };
+        psi.ArgumentList.Add("restore");
+        psi.ArgumentList.Add(projectPath);
+        psi.ArgumentList.Add("--nologo");
+
+        Process process;
+        try
+        {
+            process = Process.Start(psi)
+                ?? throw new Exception("Error: failed to start 'dotnet restore'.");
+        }
+        catch (System.ComponentModel.Win32Exception)
+        {
+            throw new Exception(
+                "Error: the 'dotnet' CLI was not found on PATH; it is required to restore " +
+                $"sharpts.json packages ('{manifest.ManifestPath}').");
+        }
+
+        string stdout = process.StandardOutput.ReadToEnd();
+        string stderr = process.StandardError.ReadToEnd();
+        if (!process.WaitForExit(TimeSpan.FromMinutes(10)))
+        {
+            try { process.Kill(entireProcessTree: true); } catch { }
+            throw new Exception(
+                $"Error: NuGet restore for sharpts.json ('{manifest.ManifestPath}') timed out after 10 minutes.");
+        }
+
+        if (process.ExitCode != 0)
+        {
+            string output = Tail(string.IsNullOrWhiteSpace(stderr) ? stdout : stdout + "\n" + stderr, 25);
+            throw new Exception(
+                $"Error: NuGet restore failed for sharpts.json packages ('{manifest.ManifestPath}'):\n{output}");
+        }
+    }
+
+    private static void WriteRestoreProject(SharpTsManifest manifest, string projectPath)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("<Project Sdk=\"Microsoft.NET.Sdk\">");
+        sb.AppendLine("  <PropertyGroup>");
+        sb.AppendLine($"    <TargetFramework>{TargetFramework}</TargetFramework>");
+        sb.AppendLine("    <EnableDefaultItems>false</EnableDefaultItems>");
+        sb.AppendLine("    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>");
+        // Only the package graph matters — no compilation happens against this project.
+        // Without this, restore may try to download Microsoft.*.App.Ref targeting packs
+        // (when not installed with the SDK), breaking offline and custom-source setups.
+        sb.AppendLine("    <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>");
+        sb.AppendLine("  </PropertyGroup>");
+        sb.AppendLine("  <ItemGroup>");
+        foreach (var (id, version) in manifest.Packages!.OrderBy(kv => kv.Key, StringComparer.OrdinalIgnoreCase))
+        {
+            sb.AppendLine($"    <PackageReference Include=\"{SecurityElement.Escape(id)}\" Version=\"{SecurityElement.Escape(version)}\" />");
+        }
+        sb.AppendLine("  </ItemGroup>");
+        sb.AppendLine("</Project>");
+        File.WriteAllText(projectPath, sb.ToString());
+    }
+
+    private static string Tail(string text, int maxLines)
+    {
+        var lines = text.Split('\n', StringSplitOptions.RemoveEmptyEntries)
+            .Select(l => l.TrimEnd('\r'))
+            .Where(l => !string.IsNullOrWhiteSpace(l))
+            .ToArray();
+        return string.Join("\n", lines.TakeLast(maxLines));
+    }
+}

--- a/References/ProjectAssetsReader.cs
+++ b/References/ProjectAssetsReader.cs
@@ -1,0 +1,137 @@
+using System.Text.Json;
+
+namespace SharpTS.References;
+
+/// <summary>
+/// Reads the parts of a NuGet <c>project.assets.json</c> the reference story needs:
+/// each package's runtime DLL assets (absolute paths into the package folders) and
+/// the package dependency edges, from which per-package transitive closures are
+/// computed for the compiled-output copy step.
+/// </summary>
+internal static class ProjectAssetsReader
+{
+    public static RestoreResult Read(string assetsPath, string manifestPath, string targetFramework)
+    {
+        using var doc = JsonDocument.Parse(File.ReadAllText(assetsPath));
+        var root = doc.RootElement;
+
+        // Package install roots (usually just ~/.nuget/packages/, but nuget.config
+        // can redirect globalPackagesFolder — hermetic tests rely on that).
+        var packageFolders = new List<string>();
+        if (root.TryGetProperty("packageFolders", out var folders))
+        {
+            foreach (var folder in folders.EnumerateObject())
+                packageFolders.Add(folder.Name);
+        }
+
+        // libraries: "Id/Version" -> { "path": "id/version", ... }
+        var libraryPaths = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        if (root.TryGetProperty("libraries", out var libraries))
+        {
+            foreach (var lib in libraries.EnumerateObject())
+            {
+                if (lib.Value.TryGetProperty("path", out var path))
+                    libraryPaths[lib.Name] = path.GetString() ?? "";
+            }
+        }
+
+        if (!root.TryGetProperty("targets", out var targets))
+            throw new Exception($"Error: '{assetsPath}' has no targets section (corrupt restore for '{manifestPath}'?).");
+
+        // Exact-TFM target preferred; fall back to the first target defensively
+        // (single-TFM restore project, so there is only ever one in practice).
+        JsonElement target = default;
+        bool found = false;
+        foreach (var t in targets.EnumerateObject())
+        {
+            if (!found || t.Name == targetFramework)
+            {
+                target = t.Value;
+                found = true;
+                if (t.Name == targetFramework) break;
+            }
+        }
+        if (!found)
+            throw new Exception($"Error: '{assetsPath}' has no restore targets (corrupt restore for '{manifestPath}'?).");
+
+        var assetsByPackage = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
+        var dependencyEdges = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var entry in target.EnumerateObject())
+        {
+            if (!entry.Value.TryGetProperty("type", out var type) || type.GetString() != "package")
+                continue;
+
+            string packageId = entry.Name.Split('/')[0];
+            var assets = assetsByPackage[packageId] = [];
+            var deps = dependencyEdges[packageId] = [];
+
+            if (entry.Value.TryGetProperty("runtime", out var runtime))
+            {
+                foreach (var asset in runtime.EnumerateObject())
+                {
+                    // "_._" placeholders mark intentionally-empty asset groups.
+                    if (asset.Name.EndsWith("_._", StringComparison.Ordinal)) continue;
+                    string? absolute = ResolveAssetPath(entry.Name, asset.Name, libraryPaths, packageFolders);
+                    if (absolute != null) assets.Add(absolute);
+                }
+            }
+
+            if (entry.Value.TryGetProperty("dependencies", out var dependencies))
+            {
+                foreach (var dep in dependencies.EnumerateObject())
+                    deps.Add(dep.Name);
+            }
+        }
+
+        // Flat runtime-asset list in deterministic order.
+        var runtimeAssets = new List<PackageAsset>();
+        foreach (var packageId in assetsByPackage.Keys.OrderBy(k => k, StringComparer.OrdinalIgnoreCase))
+        {
+            foreach (var asset in assetsByPackage[packageId].OrderBy(a => a, StringComparer.Ordinal))
+                runtimeAssets.Add(new PackageAsset(asset, packageId));
+        }
+
+        // Per-package transitive closure of runtime assets.
+        var closures = new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase);
+        foreach (var packageId in assetsByPackage.Keys)
+        {
+            var closure = new List<string>();
+            var visited = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var queue = new Queue<string>();
+            queue.Enqueue(packageId);
+            while (queue.Count > 0)
+            {
+                string current = queue.Dequeue();
+                if (!visited.Add(current)) continue;
+                if (assetsByPackage.TryGetValue(current, out var assets))
+                    closure.AddRange(assets);
+                if (dependencyEdges.TryGetValue(current, out var deps))
+                {
+                    foreach (var dep in deps) queue.Enqueue(dep);
+                }
+            }
+            closures[packageId] = closure;
+        }
+
+        return new RestoreResult(runtimeAssets, closures);
+    }
+
+    private static string? ResolveAssetPath(
+        string libraryKey, string assetRelativePath,
+        Dictionary<string, string> libraryPaths, List<string> packageFolders)
+    {
+        if (!libraryPaths.TryGetValue(libraryKey, out var libraryPath)) return null;
+
+        string relative = Path.Combine(
+            libraryPath.Replace('/', Path.DirectorySeparatorChar),
+            assetRelativePath.Replace('/', Path.DirectorySeparatorChar));
+
+        foreach (var folder in packageFolders)
+        {
+            string candidate = Path.GetFullPath(Path.Combine(folder, relative));
+            if (File.Exists(candidate)) return candidate;
+        }
+        return null;
+    }
+}

--- a/References/ReferenceSet.cs
+++ b/References/ReferenceSet.cs
@@ -1,0 +1,78 @@
+namespace SharpTS.References;
+
+/// <summary>Where a resolved reference DLL came from.</summary>
+public enum ReferenceOrigin
+{
+    /// <summary>CLI -r/--reference flag.</summary>
+    Cli,
+    /// <summary>The sharpts.json "references" list.</summary>
+    Manifest,
+    /// <summary>A restored NuGet package's runtime assets.</summary>
+    Package
+}
+
+/// <summary>One resolved reference assembly path.</summary>
+/// <param name="Path">Absolute path to the DLL.</param>
+/// <param name="Origin">Which surface supplied it.</param>
+/// <param name="PackageId">NuGet package id for <see cref="ReferenceOrigin.Package"/> origins.</param>
+public sealed record ResolvedReference(string Path, ReferenceOrigin Origin, string? PackageId = null);
+
+/// <summary>
+/// The full set of third-party reference assemblies for one invocation:
+/// CLI -r flags + sharpts.json references + restored NuGet package assets,
+/// de-duplicated, in deterministic load order (CLI first, so a per-invocation
+/// override wins the AppDomain first-match scan).
+/// </summary>
+public sealed class ReferenceSet
+{
+    public static readonly ReferenceSet Empty = new(null, []);
+
+    /// <summary>Absolute path of the discovered manifest, or null when none.</summary>
+    public string? ManifestPath { get; }
+
+    /// <summary>Resolved references in load order.</summary>
+    public IReadOnlyList<ResolvedReference> References { get; }
+
+    private readonly Dictionary<string, IReadOnlyList<string>> _packageClosures;
+
+    public ReferenceSet(
+        string? manifestPath,
+        IReadOnlyList<ResolvedReference> references,
+        Dictionary<string, IReadOnlyList<string>>? packageClosures = null)
+    {
+        ManifestPath = manifestPath;
+        References = references;
+        _packageClosures = packageClosures ?? [];
+    }
+
+    public bool IsEmpty => References.Count == 0;
+
+    /// <summary>
+    /// The runtime-asset closure (this package plus its transitive package
+    /// dependencies) for a <see cref="ReferenceOrigin.Package"/> reference,
+    /// from the restore assets graph. Empty for non-package origins.
+    /// </summary>
+    public IReadOnlyList<string> RuntimeClosureFor(ResolvedReference reference)
+    {
+        if (reference.PackageId != null &&
+            _packageClosures.TryGetValue(reference.PackageId, out var closure))
+        {
+            return closure;
+        }
+        return [];
+    }
+
+    /// <summary>Finds the reference entry for an assembly file path, if any.</summary>
+    public ResolvedReference? FindByPath(string assemblyPath)
+    {
+        foreach (var reference in References)
+        {
+            if (string.Equals(reference.Path, assemblyPath, PathComparison))
+                return reference;
+        }
+        return null;
+    }
+
+    internal static StringComparison PathComparison =>
+        OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+}

--- a/References/SharpTsManifest.cs
+++ b/References/SharpTsManifest.cs
@@ -1,0 +1,33 @@
+using System.Text.Json.Serialization;
+
+namespace SharpTS.References;
+
+/// <summary>
+/// Model for the sharpts.json project manifest: assembly references and NuGet
+/// packages that <c>dotnet:</c> imports and <c>@DotNetType</c> declarations may
+/// resolve types from. See docs/dotnet-types.md.
+/// </summary>
+public class SharpTsManifest
+{
+    /// <summary>
+    /// Local assembly references. Relative paths resolve against the manifest's
+    /// directory (<see cref="ManifestDirectory"/>), not the current working directory.
+    /// </summary>
+    [JsonPropertyName("references")]
+    public List<string>? References { get; set; }
+
+    /// <summary>
+    /// NuGet package references (id → version), restored on demand via
+    /// <c>dotnet restore</c> into the global package cache.
+    /// </summary>
+    [JsonPropertyName("packages")]
+    public Dictionary<string, string>? Packages { get; set; }
+
+    /// <summary>Absolute path of the loaded manifest file (set by the loader).</summary>
+    [JsonIgnore]
+    public string ManifestPath { get; set; } = "";
+
+    /// <summary>Directory containing the manifest; base for relative reference paths.</summary>
+    [JsonIgnore]
+    public string ManifestDirectory => Path.GetDirectoryName(ManifestPath) ?? "";
+}

--- a/References/SharpTsManifestLoader.cs
+++ b/References/SharpTsManifestLoader.cs
@@ -1,0 +1,98 @@
+using System.Text.Json;
+
+namespace SharpTS.References;
+
+/// <summary>
+/// Discovers and parses sharpts.json manifests.
+/// </summary>
+public static class SharpTsManifestLoader
+{
+    public const string FileName = "sharpts.json";
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        ReadCommentHandling = JsonCommentHandling.Skip,
+        AllowTrailingCommas = true
+    };
+
+    /// <summary>
+    /// Finds and loads the nearest sharpts.json in <paramref name="startDirectory"/>
+    /// or its parents.
+    /// </summary>
+    /// <remarks>
+    /// The upward walk stops (exclusive) at the system temp root and the user profile
+    /// root — a sharpts.json sitting in those directories is ambient noise from
+    /// unrelated tooling, not the manifest of the project being run. Each ceiling is
+    /// still searched when it IS the start directory. (Same policy as
+    /// <see cref="Packaging.PackageJsonLoader.FindAndLoad"/>.)
+    /// </remarks>
+    /// <returns>The loaded manifest, or null when none exists.</returns>
+    /// <exception cref="Exception">When a found manifest fails to parse — unlike
+    /// discovery misses, a malformed manifest is a hard error naming the file.</exception>
+    public static SharpTsManifest? FindAndLoad(string startDirectory)
+    {
+        var dir = new DirectoryInfo(startDirectory);
+
+        var ceilings = new[]
+            {
+                Path.GetTempPath(),
+                Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)
+            }
+            .Where(p => !string.IsNullOrEmpty(p))
+            .Select(p => Path.GetFullPath(p).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar))
+            .ToArray();
+
+        bool isStartDirectory = true;
+        while (dir != null)
+        {
+            var currentPath = dir.FullName.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+
+            // Stop when the walk ASCENDS into a ceiling directory; only search
+            // a ceiling when the caller started there.
+            if (!isStartDirectory &&
+                ceilings.Any(c => string.Equals(currentPath, c, StringComparison.OrdinalIgnoreCase)))
+            {
+                return null;
+            }
+
+            var manifestPath = Path.Combine(dir.FullName, FileName);
+            if (File.Exists(manifestPath))
+            {
+                return Load(manifestPath);
+            }
+            isStartDirectory = false;
+            dir = dir.Parent;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Loads a sharpts.json from an explicit path. Malformed JSON is a hard error
+    /// (the user asked for this manifest to apply; silently ignoring it would make
+    /// every dotnet: import fail with a misleading "type not found").
+    /// </summary>
+    public static SharpTsManifest Load(string path)
+    {
+        if (!File.Exists(path))
+            throw new FileNotFoundException($"sharpts.json not found at: {path}", path);
+
+        SharpTsManifest? manifest;
+        try
+        {
+            using var stream = File.OpenRead(path);
+            manifest = JsonSerializer.Deserialize<SharpTsManifest>(stream, JsonOptions);
+        }
+        catch (JsonException ex)
+        {
+            throw new Exception($"Error: sharpts.json ('{path}') is not valid JSON: {ex.Message}");
+        }
+
+        if (manifest == null)
+            throw new Exception($"Error: sharpts.json ('{path}') is empty or null.");
+
+        manifest.ManifestPath = Path.GetFullPath(path);
+        return manifest;
+    }
+}

--- a/Runtime/DotNet/DotNetTypeRegistry.cs
+++ b/Runtime/DotNet/DotNetTypeRegistry.cs
@@ -30,7 +30,16 @@ public static class DotNetTypeRegistry
         {
             foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
             {
-                type = assembly.GetType(clrTypeName, throwOnError: false);
+                // A single broken assembly (e.g. a sharpts.json reference targeting a
+                // missing dependency) must not poison resolution of unrelated types.
+                try
+                {
+                    type = assembly.GetType(clrTypeName, throwOnError: false);
+                }
+                catch (Exception ex) when (ex is FileNotFoundException or FileLoadException or TypeLoadException or BadImageFormatException)
+                {
+                    continue;
+                }
                 if (type != null) break;
             }
         }

--- a/STATUS.md
+++ b/STATUS.md
@@ -471,7 +471,9 @@ SharpTS implements 20+ Node.js built-in modules accessible via `import ... from 
 |---------|--------|-------|
 | `import { X } from "dotnet:Ns.Type"` (single-type form) | ✅ | Static types synthesized from reflection via `DotNetTypeSynthesizer`; members filtered by `DotNetInteropClassifier`; fluent chains stay typed (epic #1195) |
 | `import { X, Y } from "dotnet:Namespace"` (namespace form) | ✅ | Each named import resolves as `Namespace.Name`; nested types resolve through their declaring type's specifier; aliasing supported |
-| `dotnet:` v1 scope | — | Named imports only (no default/star/re-export/require/dynamic import); loaded/BCL assemblies only; no generic types (use `@DotNetType` for closed generics) |
+| `dotnet:` scope | — | Named imports only (no default/star/re-export/require/dynamic import); no generic types (use `@DotNetType` for closed generics); no paths in specifiers (use `sharpts.json`) |
+| `sharpts.json` reference manifest | ✅ | `{ "references": [dll paths], "packages": { id: version } }` discovered by upward walk from the entry script; applies uniformly to interpreter, compiler, LSP, and `--gen-decl`; global `-r/--reference` flag augments per-invocation (issue #1197) |
+| NuGet packages in manifest | ✅ | Restored via `dotnet restore` on a generated project under `.sharpts/` (hash-gated — skipped when the package set is unchanged; offline after first restore); transitive dependencies resolved, loaded, and co-located with compiled output |
 | `@DotNetType("Namespace.Type")` on `declare class` | ✅ | Instance methods, static methods, constructors, properties, fields |
 | `@DotNetOverload("type1,type2,...")` overload hints | ✅ | Pin a specific overload when argument-based resolution is ambiguous |
 | Overload resolution | ✅ | Identity → widening → narrowing → object cost scale; same semantics in both modes |
@@ -480,7 +482,7 @@ SharpTS implements 20+ Node.js built-in modules accessible via `import ... from 
 | Event subscription (`+=` / `-=`) | ✅ | `obj.on(e)` / `obj.off(e)` style plus direct `+=` compound assignment in compiled mode; main-thread-only |
 | Exception mapping | ✅ | .NET exceptions surface as JS-catchable errors with message preservation (`DotNetExceptionMapper`) |
 | Value / reference type marshaling | ✅ | Primitives, strings, arrays, dictionaries; `DotNetMarshaller` centralizes conversion |
-| External assembly discovery | ✅ | `TryResolveExternalType` scans loaded AppDomain assemblies; no additional reference wiring needed |
+| External assembly discovery | ✅ | `TryResolveExternalType` scans loaded AppDomain assemblies; `sharpts.json`/`-r` assemblies load at startup so every seam sees them; compiled output co-locates used reference DLLs (+ closure) next to the output |
 | `--gen-decl` discovery tool | ✅ | Inspect a type/namespace/assembly: faithful CLR signatures + per-member usable/unsupported marker + `dotnet:` import line + `--json` (issue #1194) |
 
 Compiled mode uses late-bound reflection to the shim (`DotNetDelegateShim` / `DotNetEventBinder`) so the output DLL stays standalone. See `docs/dotnet-types.md` for the full guide.

--- a/SharpTS.LanguageServer/Program.cs
+++ b/SharpTS.LanguageServer/Program.cs
@@ -26,6 +26,21 @@ try
     if (projectFile != null && File.Exists(projectFile))
         paths.AddRange(CsprojParser.Parse(projectFile));
 
+    // sharpts.json (walked up from the workspace root = CWD, matching the CLI's
+    // discovery from the entry script) supplies more paths for the SAME loader:
+    // Resolve, not Load — the editor process inspects workspace assemblies through
+    // the MetadataLoadContext and never executes their code. Read once at startup,
+    // like --project. A broken manifest must not kill the server: log and continue.
+    try
+    {
+        var refSet = SharpTS.References.DotNetReferences.Resolve(Environment.CurrentDirectory, []);
+        paths.AddRange(refSet.References.Select(r => r.Path));
+    }
+    catch (Exception ex)
+    {
+        await Console.Error.WriteLineAsync($"[LSP] sharpts.json ignored: {ex.Message}");
+    }
+
     using var loader = new AssemblyReferenceLoader(paths, sdkPath);
     Func<IEnumerable<string>> typeNames = () => loader.GetAllPublicTypes()
         .Select(t => t.FullName)

--- a/SharpTS.Tests/Infrastructure/ExternalAssemblyFixture.cs
+++ b/SharpTS.Tests/Infrastructure/ExternalAssemblyFixture.cs
@@ -1,0 +1,177 @@
+using System.Diagnostics;
+using Xunit;
+
+namespace SharpTS.Tests.Infrastructure;
+
+/// <summary>
+/// Collection fixture for third-party assembly-reference tests (issue #1197): builds,
+/// ONCE per test run, a small classlib DLL and two local NuGet packages (Main → Base
+/// dependency) that tests reference from sharpts.json manifests / -r flags. Uses
+/// `dotnet build`/`dotnet pack` — the suite already requires the SDK for its
+/// subprocess runs.
+/// </summary>
+public sealed class ExternalAssemblyFixture : IDisposable
+{
+    public const string GreeterTypeName = "SharpTsFixtures.External.Greeter";
+    public const string GreeterAssemblyName = "SharpTsExternalFixture";
+    public const string MainPackageId = "TestPkg.Main";
+    public const string BasePackageId = "TestPkg.Base";
+    public const string PackageVersion = "1.0.0";
+    public const string MainTypeName = "TestPkg.Main.MainInfo";
+
+    private readonly string _root;
+
+    /// <summary>Path to the built classlib DLL (SharpTsExternalFixture.dll).</summary>
+    public string GreeterDllPath { get; }
+
+    /// <summary>Folder containing TestPkg.Main/TestPkg.Base .nupkg files (a NuGet folder source).</summary>
+    public string PackageSourceDir { get; }
+
+    public ExternalAssemblyFixture()
+    {
+        _root = Path.Combine(Path.GetTempPath(), $"sharpts_extasm_fixture_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_root);
+        PackageSourceDir = Path.Combine(_root, "pkgsource");
+        Directory.CreateDirectory(PackageSourceDir);
+
+        // Classlib referenced via "references" / -r.
+        string libDir = WriteProject("greeter", $"""
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+                <AssemblyName>{GreeterAssemblyName}</AssemblyName>
+                <Nullable>enable</Nullable>
+              </PropertyGroup>
+            </Project>
+            """,
+            ("Greeter.cs", """
+            namespace SharpTsFixtures.External;
+
+            public class Greeter
+            {
+                public static string Hello(string name) => $"Hello, {name}!";
+                public double Add(double a, double b) => a + b;
+            }
+            """));
+        RunDotnet(libDir, "build -c Release --nologo -v q");
+        GreeterDllPath = Path.Combine(libDir, "bin", "Release", "net10.0", $"{GreeterAssemblyName}.dll");
+        if (!File.Exists(GreeterDllPath))
+            throw new InvalidOperationException($"Fixture build produced no DLL at {GreeterDllPath}");
+
+        // Two packages, Main depending on Base — exercises transitive restore + closure copy.
+        string baseDir = WriteProject("pkgbase", $"""
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+                <AssemblyName>{BasePackageId}</AssemblyName>
+                <PackageId>{BasePackageId}</PackageId>
+                <Version>{PackageVersion}</Version>
+              </PropertyGroup>
+            </Project>
+            """,
+            ("BaseInfo.cs", """
+            namespace TestPkg.Base;
+            public class BaseInfo
+            {
+                public static string Version() => "base-1.0";
+            }
+            """));
+        string mainDir = WriteProject("pkgmain", $"""
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+                <AssemblyName>{MainPackageId}</AssemblyName>
+                <PackageId>{MainPackageId}</PackageId>
+                <Version>{PackageVersion}</Version>
+              </PropertyGroup>
+              <ItemGroup>
+                <ProjectReference Include="../pkgbase/pkgbase.csproj" />
+              </ItemGroup>
+            </Project>
+            """,
+            ("MainInfo.cs", """
+            namespace TestPkg.Main;
+            public class MainInfo
+            {
+                public static string Describe() => $"main-1.0 on {TestPkg.Base.BaseInfo.Version()}";
+            }
+            """));
+        RunDotnet(baseDir, $"pack -c Release --nologo -v q -o \"{PackageSourceDir}\"");
+        RunDotnet(mainDir, $"pack -c Release --nologo -v q -o \"{PackageSourceDir}\"");
+    }
+
+    /// <summary>
+    /// Writes a nuget.config into <paramref name="dir"/> that sees ONLY the fixture's
+    /// folder source and redirects the global packages folder into the test directory —
+    /// restore tests touch neither the network nor the user's package cache.
+    /// </summary>
+    public void WriteHermeticNuGetConfig(string dir)
+    {
+        File.WriteAllText(Path.Combine(dir, "nuget.config"), $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <configuration>
+              <packageSources>
+                <clear />
+                <add key="fixture" value="{PackageSourceDir}" />
+              </packageSources>
+              <config>
+                <add key="globalPackagesFolder" value="./pkgcache" />
+              </config>
+            </configuration>
+            """);
+    }
+
+    private string WriteProject(string name, string csproj, params (string Name, string Content)[] sources)
+    {
+        string dir = Path.Combine(_root, name);
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, $"{name}.csproj"), csproj);
+        // Isolate from any ambient MSBuild configuration above the temp root.
+        File.WriteAllText(Path.Combine(dir, "Directory.Build.props"), "<Project></Project>");
+        File.WriteAllText(Path.Combine(dir, "Directory.Build.targets"), "<Project></Project>");
+        File.WriteAllText(Path.Combine(dir, "Directory.Packages.props"), "<Project></Project>");
+        foreach (var (sourceName, content) in sources)
+            File.WriteAllText(Path.Combine(dir, sourceName), content);
+        return dir;
+    }
+
+    private static void RunDotnet(string workingDirectory, string arguments)
+    {
+        var psi = new ProcessStartInfo("dotnet", arguments)
+        {
+            WorkingDirectory = workingDirectory,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false
+        };
+        using var process = Process.Start(psi)!;
+        string stdout = process.StandardOutput.ReadToEnd();
+        string stderr = process.StandardError.ReadToEnd();
+        if (!process.WaitForExit(TimeSpan.FromMinutes(5)))
+        {
+            try { process.Kill(entireProcessTree: true); } catch { }
+            throw new TimeoutException($"'dotnet {arguments}' timed out in {workingDirectory}");
+        }
+        if (process.ExitCode != 0)
+        {
+            throw new InvalidOperationException(
+                $"'dotnet {arguments}' failed ({process.ExitCode}) in {workingDirectory}:\n{stdout}\n{stderr}");
+        }
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            if (Directory.Exists(_root))
+                Directory.Delete(_root, recursive: true);
+        }
+        catch
+        {
+            // Ignore cleanup errors
+        }
+    }
+}
+
+[CollectionDefinition("ExternalAssembly")]
+public class ExternalAssemblyCollection : ICollectionFixture<ExternalAssemblyFixture>;

--- a/SharpTS.Tests/IntegrationTests/CliManifestTests.cs
+++ b/SharpTS.Tests/IntegrationTests/CliManifestTests.cs
@@ -1,0 +1,227 @@
+using System.Diagnostics;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using SharpTS.Modules;
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.IntegrationTests;
+
+/// <summary>
+/// End-to-end CLI tests for the sharpts.json reference manifest and the global -r flag
+/// (issue #1197): interpreter + compiled resolution of dotnet: imports from a
+/// third-party DLL, co-location of referenced DLLs next to compiled output, standalone
+/// execution, --gen-decl discovery, and the error surfaces.
+/// </summary>
+[Collection("ExternalAssembly")]
+public class CliManifestTests(ExternalAssemblyFixture fixture)
+{
+    private const string MainTs = $$"""
+        import { Greeter } from "dotnet:{{ExternalAssemblyFixture.GreeterTypeName}}";
+        console.log(Greeter.hello("World"));
+        const g = new Greeter();
+        console.log(g.add(2, 40));
+        """;
+
+    private TempTestDirectory CreateWorkspace(bool withManifest = true)
+    {
+        var dir = CliTestHelper.CreateTempDirectory();
+        Directory.CreateDirectory(dir.GetPath("libs"));
+        File.Copy(fixture.GreeterDllPath, dir.GetPath($"libs/{ExternalAssemblyFixture.GreeterAssemblyName}.dll"));
+        if (withManifest)
+            dir.CreateFile("sharpts.json",
+                $$"""{ "references": ["./libs/{{ExternalAssemblyFixture.GreeterAssemblyName}}.dll"] }""");
+        dir.CreateFile("main.ts", MainTs);
+        return dir;
+    }
+
+    [Fact]
+    public void Interp_ResolvesDotnetImportFromManifestDll()
+    {
+        using var dir = CreateWorkspace();
+
+        var result = CliTestHelper.RunCli("main.ts", dir.Path);
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Equal("Hello, World!\n42\n", result.StandardOutput);
+    }
+
+    [Fact]
+    public void Interp_ManifestDiscoveredByUpwardWalkFromEntryScript()
+    {
+        using var dir = CreateWorkspace();
+        Directory.CreateDirectory(dir.GetPath("src/app"));
+        dir.CreateFile("src/app/entry.ts", MainTs);
+
+        var result = CliTestHelper.RunCli("src/app/entry.ts", dir.Path);
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Equal("Hello, World!\n42\n", result.StandardOutput);
+    }
+
+    [Fact]
+    public void Interp_ReferenceFlagWorksWithoutManifest()
+    {
+        using var dir = CreateWorkspace(withManifest: false);
+
+        var result = CliTestHelper.RunCli(
+            $"main.ts -r libs/{ExternalAssemblyFixture.GreeterAssemblyName}.dll", dir.Path);
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Equal("Hello, World!\n42\n", result.StandardOutput);
+    }
+
+    [Fact]
+    public void Compiled_CopiesReferencedDllAndRunsStandalone()
+    {
+        using var dir = CreateWorkspace();
+        Directory.CreateDirectory(dir.GetPath("out"));
+
+        var compile = CliTestHelper.RunCli("--compile main.ts -o out/app.dll --verify", dir.Path,
+            TimeSpan.FromSeconds(120));
+
+        Assert.Equal(0, compile.ExitCode);
+        Assert.Contains("IL verification passed", compile.StandardOutput);
+        // The referenced DLL was co-located next to the output (hard metadata reference).
+        Assert.True(File.Exists(dir.GetPath($"out/{ExternalAssemblyFixture.GreeterAssemblyName}.dll")));
+        // No SharpTS.dll: dotnet: imports compile to direct IL, fully standalone.
+        Assert.False(File.Exists(dir.GetPath("out/SharpTS.dll")));
+
+        var run = RunProgram(dir.GetPath("out/app.dll"));
+        Assert.Equal(0, run.ExitCode);
+        Assert.Equal("Hello, World!\n42\n", run.StandardOutput);
+    }
+
+    [Fact]
+    public void Compiled_AssemblyRefTableHasFixtureButNotSharpTS()
+    {
+        using var dir = CreateWorkspace();
+        Directory.CreateDirectory(dir.GetPath("out"));
+        var compile = CliTestHelper.RunCli("--compile main.ts -o out/app.dll", dir.Path,
+            TimeSpan.FromSeconds(120));
+        Assert.Equal(0, compile.ExitCode);
+
+        using var stream = File.OpenRead(dir.GetPath("out/app.dll"));
+        using var peReader = new PEReader(stream);
+        var metadata = peReader.GetMetadataReader();
+        var refNames = metadata.AssemblyReferences
+            .Select(h => metadata.GetString(metadata.GetAssemblyReference(h).Name))
+            .ToList();
+
+        Assert.Contains(ExternalAssemblyFixture.GreeterAssemblyName, refNames);
+        Assert.DoesNotContain("SharpTS", refNames);
+    }
+
+    [Fact]
+    public void GenDecl_ReferenceFlagEnablesTypeDiscovery()
+    {
+        using var dir = CreateWorkspace(withManifest: false);
+
+        var result = CliTestHelper.RunCli(
+            $"--gen-decl {ExternalAssemblyFixture.GreeterTypeName} -r libs/{ExternalAssemblyFixture.GreeterAssemblyName}.dll",
+            dir.Path);
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains(
+            $"import {{ Greeter }} from \"dotnet:{ExternalAssemblyFixture.GreeterTypeName}\";",
+            result.StandardOutput);
+    }
+
+    [Fact]
+    public void GenDecl_ManifestDiscoveredFromWorkingDirectory()
+    {
+        using var dir = CreateWorkspace();
+
+        var result = CliTestHelper.RunCli(
+            $"--gen-decl {ExternalAssemblyFixture.GreeterTypeName}", dir.Path);
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains("static hello(name: string): string", result.StandardOutput);
+    }
+
+    [Fact]
+    public void MissingManifestReference_ExitsNonzeroNamingEntry()
+    {
+        using var dir = CliTestHelper.CreateTempDirectory();
+        dir.CreateFile("sharpts.json", """{ "references": ["./nope/missing.dll"] }""");
+        dir.CreateFile("main.ts", "console.log(1);");
+
+        var result = CliTestHelper.RunCli("main.ts", dir.Path);
+
+        Assert.Equal(1, result.ExitCode);
+        Assert.Contains("sharpts.json", result.StandardOutput);
+        Assert.Contains("./nope/missing.dll", result.StandardOutput);
+    }
+
+    [Fact]
+    public void MalformedManifest_ExitsNonzeroNamingFile()
+    {
+        using var dir = CliTestHelper.CreateTempDirectory();
+        dir.CreateFile("sharpts.json", "{ not json ");
+        dir.CreateFile("main.ts", "console.log(1);");
+
+        var result = CliTestHelper.RunCli("main.ts", dir.Path);
+
+        Assert.Equal(1, result.ExitCode);
+        Assert.Contains("sharpts.json", result.StandardOutput);
+        Assert.Contains("not valid JSON", result.StandardOutput);
+    }
+
+    [Fact]
+    public void PathEmbeddedSpecifier_RejectedWithManifestHint()
+    {
+        // The shared resolution algorithm rejects it for every consumer (interp, compiler, LSP).
+        var ex = Assert.ThrowsAny<Exception>(() =>
+            DotNetImports.ResolveExportType("./libs/MyLib.dll#Greeter", "Greeter"));
+
+        Assert.StartsWith("Module Error:", ex.Message);
+        Assert.Contains("sharpts.json", ex.Message);
+        Assert.Contains("-r", ex.Message);
+    }
+
+    [Theory]
+    [InlineData("libs/MyLib.dll")]
+    [InlineData(@"libs\MyLib.dll")]
+    [InlineData("MyLib.exe")]
+    [InlineData("MyLib.dll#Widget")]
+    public void PathLikeSpecifiers_AllRejected(string specifier)
+    {
+        var ex = Assert.ThrowsAny<Exception>(() => DotNetImports.ResolveExportType(specifier, "Widget"));
+        Assert.Contains("not assembly paths", ex.Message);
+    }
+
+    [Fact]
+    public void PathEmbeddedSpecifier_RejectedEndToEnd()
+    {
+        using var dir = CliTestHelper.CreateTempDirectory();
+        dir.CreateFile("main.ts", """import { Greeter } from "dotnet:./libs/MyLib.dll#Greeter";""");
+
+        var result = CliTestHelper.RunCli("main.ts", dir.Path);
+
+        Assert.Contains("Module Error", result.StandardOutput);
+        Assert.Contains("sharpts.json", result.StandardOutput);
+    }
+
+    internal static CliTestHelper.CliResult RunProgram(string dllPath, string? workingDirectory = null)
+    {
+        var psi = new ProcessStartInfo("dotnet", $"\"{dllPath}\"")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            WorkingDirectory = workingDirectory ?? Path.GetDirectoryName(dllPath)!
+        };
+        using var process = Process.Start(psi)!;
+        var stdout = process.StandardOutput.ReadToEnd();
+        var stderr = process.StandardError.ReadToEnd();
+        if (!process.WaitForExit(TimeSpan.FromSeconds(60)))
+        {
+            try { process.Kill(entireProcessTree: true); } catch { }
+            throw new TimeoutException($"Compiled program timed out: {dllPath}");
+        }
+        return new CliTestHelper.CliResult(
+            process.ExitCode,
+            CliTestHelper.NormalizeOutput(stdout),
+            CliTestHelper.NormalizeOutput(stderr));
+    }
+}

--- a/SharpTS.Tests/IntegrationTests/CliNuGetRestoreTests.cs
+++ b/SharpTS.Tests/IntegrationTests/CliNuGetRestoreTests.cs
@@ -1,0 +1,124 @@
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.IntegrationTests;
+
+/// <summary>
+/// Hermetic end-to-end tests for sharpts.json "packages" (issue #1197, NuGet restore):
+/// every test's nuget.config clears all sources, points at the fixture's local folder
+/// source, and redirects the global packages folder into the test directory — no
+/// network, no user-cache pollution. TestPkg.Main depends on TestPkg.Base, exercising
+/// transitive restore, loading, and copy closure.
+/// </summary>
+[Collection("ExternalAssembly")]
+public class CliNuGetRestoreTests(ExternalAssemblyFixture fixture)
+{
+    private static readonly TimeSpan RestoreTimeout = TimeSpan.FromSeconds(180);
+
+    private const string MainTs = $$"""
+        import { MainInfo } from "dotnet:{{ExternalAssemblyFixture.MainTypeName}}";
+        console.log(MainInfo.describe());
+        """;
+
+    private TempTestDirectory CreateWorkspace()
+    {
+        var dir = CliTestHelper.CreateTempDirectory();
+        fixture.WriteHermeticNuGetConfig(dir.Path);
+        dir.CreateFile("sharpts.json", $$"""
+            { "packages": { "{{ExternalAssemblyFixture.MainPackageId}}": "{{ExternalAssemblyFixture.PackageVersion}}" } }
+            """);
+        dir.CreateFile("main.ts", MainTs);
+        return dir;
+    }
+
+    [Fact]
+    public void Interp_RestoresAndRunsWithTransitiveDependency()
+    {
+        using var dir = CreateWorkspace();
+
+        var result = CliTestHelper.RunCli("main.ts", dir.Path, RestoreTimeout);
+
+        Assert.Equal(0, result.ExitCode);
+        // "on base-1.0" comes from TestPkg.Base — the transitive dependency loaded.
+        Assert.Equal("main-1.0 on base-1.0\n", result.StandardOutput);
+        Assert.True(File.Exists(dir.GetPath(".sharpts/restore.hash")));
+        Assert.True(File.Exists(dir.GetPath(".sharpts/obj/project.assets.json")));
+    }
+
+    [Fact]
+    public void SecondRun_SkipsRestoreViaHashGate()
+    {
+        using var dir = CreateWorkspace();
+        var first = CliTestHelper.RunCli("main.ts", dir.Path, RestoreTimeout);
+        Assert.Equal(0, first.ExitCode);
+
+        // A gated (skipped) restore never touches .sharpts/ — only a re-invoked restore
+        // regenerates restore.csproj. Delete it: if the second run recreates it, the
+        // hash gate failed.
+        File.Delete(dir.GetPath(".sharpts/restore.csproj"));
+
+        var second = CliTestHelper.RunCli("main.ts", dir.Path, RestoreTimeout);
+
+        Assert.Equal(0, second.ExitCode);
+        Assert.Equal("main-1.0 on base-1.0\n", second.StandardOutput);
+        Assert.False(File.Exists(dir.GetPath(".sharpts/restore.csproj")),
+            "restore ran again despite an unchanged package set");
+    }
+
+    [Fact]
+    public void ChangedPackageSet_InvalidatesHashGate()
+    {
+        using var dir = CreateWorkspace();
+        var first = CliTestHelper.RunCli("main.ts", dir.Path, RestoreTimeout);
+        Assert.Equal(0, first.ExitCode);
+
+        // Adding a package changes the hash — restore must re-run and now include Base
+        // as a direct reference too.
+        dir.CreateFile("sharpts.json", $$"""
+            {
+              "packages": {
+                "{{ExternalAssemblyFixture.MainPackageId}}": "{{ExternalAssemblyFixture.PackageVersion}}",
+                "{{ExternalAssemblyFixture.BasePackageId}}": "{{ExternalAssemblyFixture.PackageVersion}}"
+              }
+            }
+            """);
+
+        var second = CliTestHelper.RunCli("main.ts", dir.Path, RestoreTimeout);
+
+        Assert.Equal(0, second.ExitCode);
+        Assert.Equal("main-1.0 on base-1.0\n", second.StandardOutput);
+    }
+
+    [Fact]
+    public void Compiled_CopiesPackageClosureAndRunsStandalone()
+    {
+        using var dir = CreateWorkspace();
+        Directory.CreateDirectory(dir.GetPath("out"));
+
+        var compile = CliTestHelper.RunCli("--compile main.ts -o out/app.dll --verify", dir.Path, RestoreTimeout);
+
+        Assert.Equal(0, compile.ExitCode);
+        Assert.Contains("IL verification passed", compile.StandardOutput);
+        // The used package AND its transitive dependency were co-located.
+        Assert.True(File.Exists(dir.GetPath($"out/{ExternalAssemblyFixture.MainPackageId}.dll")));
+        Assert.True(File.Exists(dir.GetPath($"out/{ExternalAssemblyFixture.BasePackageId}.dll")));
+        Assert.False(File.Exists(dir.GetPath("out/SharpTS.dll")));
+
+        var run = CliManifestTests.RunProgram(dir.GetPath("out/app.dll"));
+        Assert.Equal(0, run.ExitCode);
+        Assert.Equal("main-1.0 on base-1.0\n", run.StandardOutput);
+    }
+
+    [Fact]
+    public void RestoreFailure_ExitsNonzeroNamingManifest()
+    {
+        using var dir = CreateWorkspace();
+        dir.CreateFile("sharpts.json", """{ "packages": { "No.Such.Package": "9.9.9" } }""");
+
+        var result = CliTestHelper.RunCli("main.ts", dir.Path, RestoreTimeout);
+
+        Assert.Equal(1, result.ExitCode);
+        Assert.Contains("NuGet restore failed", result.StandardOutput);
+        Assert.Contains("sharpts.json", result.StandardOutput);
+    }
+}

--- a/SharpTS.Tests/LanguageServer/ManifestReferenceTests.cs
+++ b/SharpTS.Tests/LanguageServer/ManifestReferenceTests.cs
@@ -1,0 +1,56 @@
+using SharpTS.Compilation;
+using SharpTS.LanguageServer.Services;
+using SharpTS.Parsing;
+using SharpTS.References;
+using SharpTS.Tests.Infrastructure;
+using SharpTS.Tests.IntegrationTests;
+using Xunit;
+
+namespace SharpTS.Tests.LanguageServer;
+
+/// <summary>
+/// The language-server side of sharpts.json (issue #1197): manifest-resolved paths feed
+/// the existing MetadataLoadContext <see cref="AssemblyReferenceLoader"/> (Resolve, never
+/// Load — the editor process must not execute workspace code), and the shared resolver
+/// then validates dotnet: imports against manifest types exactly like the runtime does.
+/// Mirrors the wiring in SharpTS.LanguageServer/Program.cs.
+/// </summary>
+[Collection("ExternalAssembly")]
+public class ManifestReferenceTests(ExternalAssemblyFixture fixture)
+{
+    [Fact]
+    public void ManifestPaths_FeedLoader_ResolveTypeAndValidateImport()
+    {
+        using var dir = CliTestHelper.CreateTempDirectory();
+        var dllName = $"{ExternalAssemblyFixture.GreeterAssemblyName}.dll";
+        File.Copy(fixture.GreeterDllPath, dir.GetPath(dllName));
+        dir.CreateFile("sharpts.json", $$"""{ "references": ["./{{dllName}}"] }""");
+
+        var refSet = DotNetReferences.Resolve(dir.Path, []);
+        using var loader = new AssemblyReferenceLoader(refSet.References.Select(r => r.Path));
+
+        // The MLC loader resolves the manifest type without loading it for execution.
+        Assert.NotNull(loader.TryResolve(ExternalAssemblyFixture.GreeterTypeName));
+
+        // And the shared import analyzer produces zero diagnostics for a valid import
+        // against it — squiggles can't disagree with the actual loader.
+        var source = $"import {{ Greeter }} from \"dotnet:{ExternalAssemblyFixture.GreeterTypeName}\";";
+        var tokens = new Lexer(source).ScanTokens();
+        var parsed = new Parser(tokens, DecoratorMode.Stage3).Parse();
+        Assert.True(parsed.IsSuccess);
+        var diagnostics = new InteropAnalyzer(loader.TryResolve).Analyze(parsed.Statements);
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void BrokenManifest_ResolveThrows_ServerWiringTreatsItAsNonFatal()
+    {
+        using var dir = CliTestHelper.CreateTempDirectory();
+        dir.CreateFile("sharpts.json", "{ broken ");
+
+        // The LSP Program.cs wraps Resolve in try/catch and continues BCL-only; here we
+        // pin that Resolve throws (rather than silently returning empty) so the server
+        // logs the reason.
+        Assert.ThrowsAny<Exception>(() => DotNetReferences.Resolve(dir.Path, []));
+    }
+}

--- a/SharpTS.Tests/ReferencesTests/DotNetReferencesTests.cs
+++ b/SharpTS.Tests/ReferencesTests/DotNetReferencesTests.cs
@@ -1,0 +1,110 @@
+using SharpTS.References;
+using SharpTS.Tests.Infrastructure;
+using SharpTS.Tests.IntegrationTests;
+using Xunit;
+
+namespace SharpTS.Tests.ReferencesTests;
+
+/// <summary>
+/// Unit tests for the shared reference resolve/load entry point (issue #1197).
+/// Resolve is pure path work (dummy files suffice); Load tests use the built
+/// fixture DLL because they load into the test AppDomain.
+/// </summary>
+[Collection("ExternalAssembly")]
+public class DotNetReferencesTests(ExternalAssemblyFixture fixture)
+{
+    [Fact]
+    public void Resolve_NoManifestNoFlags_IsEmpty()
+    {
+        using var dir = CliTestHelper.CreateTempDirectory();
+
+        var set = DotNetReferences.Resolve(dir.Path, []);
+
+        Assert.True(set.IsEmpty);
+        Assert.Null(set.ManifestPath);
+    }
+
+    [Fact]
+    public void Resolve_CliBeforeManifest_DedupedByFullPath()
+    {
+        using var dir = CliTestHelper.CreateTempDirectory();
+        var libA = dir.CreateFile("libs/a.dll", "not really a dll");
+        var libB = dir.CreateFile("libs/b.dll", "not really a dll");
+        dir.CreateFile("sharpts.json", """{ "references": ["./libs/a.dll", "./libs/b.dll"] }""");
+
+        var set = DotNetReferences.Resolve(dir.Path, [libA]);
+
+        // CLI ref first; the manifest's duplicate of a.dll folds into it.
+        Assert.Equal(2, set.References.Count);
+        Assert.Equal(Path.GetFullPath(libA), set.References[0].Path);
+        Assert.Equal(ReferenceOrigin.Cli, set.References[0].Origin);
+        Assert.Equal(Path.GetFullPath(libB), set.References[1].Path);
+        Assert.Equal(ReferenceOrigin.Manifest, set.References[1].Origin);
+    }
+
+    [Fact]
+    public void Resolve_ManifestRelativePathsResolveAgainstManifestDirectory()
+    {
+        using var dir = CliTestHelper.CreateTempDirectory();
+        dir.CreateFile("libs/a.dll", "x");
+        dir.CreateFile("sharpts.json", """{ "references": ["./libs/a.dll"] }""");
+        Directory.CreateDirectory(dir.GetPath("src"));
+
+        // Start the walk from a nested dir: the entry resolves against the manifest's
+        // directory, not the start directory.
+        var set = DotNetReferences.Resolve(dir.GetPath("src"), []);
+
+        Assert.Equal(Path.GetFullPath(dir.GetPath("libs/a.dll")), Assert.Single(set.References).Path);
+    }
+
+    [Fact]
+    public void Resolve_MissingManifestReference_ErrorNamesManifestEntryAndResolvedPath()
+    {
+        using var dir = CliTestHelper.CreateTempDirectory();
+        dir.CreateFile("sharpts.json", """{ "references": ["./nope/missing.dll"] }""");
+
+        var ex = Assert.ThrowsAny<Exception>(() => DotNetReferences.Resolve(dir.Path, []));
+        Assert.Contains("sharpts.json", ex.Message);
+        Assert.Contains("./nope/missing.dll", ex.Message);
+        Assert.Contains(Path.GetFullPath(dir.GetPath("nope/missing.dll")), ex.Message);
+    }
+
+    [Fact]
+    public void Resolve_MissingCliReference_ErrorMentionsFlag()
+    {
+        using var dir = CliTestHelper.CreateTempDirectory();
+
+        var ex = Assert.ThrowsAny<Exception>(() =>
+            DotNetReferences.Resolve(dir.Path, [dir.GetPath("missing.dll")]));
+        Assert.Contains("-r/--reference", ex.Message);
+    }
+
+    [Fact]
+    public void Load_LoadsAssemblyAndIsIdempotent()
+    {
+        using var dir = CliTestHelper.CreateTempDirectory();
+        var dll = dir.GetPath("SharpTsExternalFixture.dll");
+        File.Copy(fixture.GreeterDllPath, dll);
+        dir.CreateFile("sharpts.json", """{ "references": ["./SharpTsExternalFixture.dll"] }""");
+
+        var first = DotNetReferences.Load(dir.Path, []);
+        var second = DotNetReferences.Load(dir.Path, []);
+
+        Assert.Single(first.References);
+        Assert.Single(second.References);
+        // The type is now resolvable through the registry's AppDomain scan.
+        Assert.NotNull(SharpTS.Runtime.DotNet.DotNetTypeRegistry.Resolve(ExternalAssemblyFixture.GreeterTypeName));
+    }
+
+    [Fact]
+    public void Load_CorruptDll_AggregatedErrorNamesFile()
+    {
+        using var dir = CliTestHelper.CreateTempDirectory();
+        var bad = dir.CreateFile("bad.dll", "this is not a PE file");
+        dir.CreateFile("sharpts.json", """{ "references": ["./bad.dll"] }""");
+
+        var ex = Assert.ThrowsAny<Exception>(() => DotNetReferences.Load(dir.Path, []));
+        Assert.Contains("could not be loaded", ex.Message);
+        Assert.Contains(Path.GetFullPath(bad), ex.Message);
+    }
+}

--- a/SharpTS.Tests/ReferencesTests/SharpTsManifestLoaderTests.cs
+++ b/SharpTS.Tests/ReferencesTests/SharpTsManifestLoaderTests.cs
@@ -1,0 +1,86 @@
+using SharpTS.References;
+using SharpTS.Tests.IntegrationTests;
+using Xunit;
+
+namespace SharpTS.Tests.ReferencesTests;
+
+/// <summary>
+/// Unit tests for sharpts.json discovery and parsing (issue #1197).
+/// </summary>
+public class SharpTsManifestLoaderTests
+{
+    [Fact]
+    public void FindAndLoad_FindsManifestInStartDirectory()
+    {
+        using var dir = CliTestHelper.CreateTempDirectory();
+        dir.CreateFile("sharpts.json", """{ "references": ["./libs/a.dll"] }""");
+
+        var manifest = SharpTsManifestLoader.FindAndLoad(dir.Path);
+
+        Assert.NotNull(manifest);
+        Assert.Equal(Path.GetFullPath(dir.GetPath("sharpts.json")), manifest.ManifestPath);
+        Assert.Equal(Path.GetFullPath(dir.Path), Path.GetFullPath(manifest.ManifestDirectory));
+        Assert.Equal(["./libs/a.dll"], manifest.References!);
+    }
+
+    [Fact]
+    public void FindAndLoad_WalksUpFromNestedDirectory()
+    {
+        using var dir = CliTestHelper.CreateTempDirectory();
+        dir.CreateFile("sharpts.json", """{ "packages": { "Some.Pkg": "1.2.3" } }""");
+        Directory.CreateDirectory(dir.GetPath("src/nested"));
+
+        var manifest = SharpTsManifestLoader.FindAndLoad(dir.GetPath("src/nested"));
+
+        Assert.NotNull(manifest);
+        Assert.Equal("1.2.3", manifest.Packages!["Some.Pkg"]);
+    }
+
+    [Fact]
+    public void FindAndLoad_ReturnsNullWhenNoManifest()
+    {
+        // The walk from a fresh temp dir ascends only as far as the temp-root ceiling,
+        // so an ambient manifest elsewhere on the machine can't leak in.
+        using var dir = CliTestHelper.CreateTempDirectory();
+
+        Assert.Null(SharpTsManifestLoader.FindAndLoad(dir.Path));
+    }
+
+    [Fact]
+    public void Load_AcceptsCommentsTrailingCommasAndAnyKeyCase()
+    {
+        using var dir = CliTestHelper.CreateTempDirectory();
+        var path = dir.CreateFile("sharpts.json", """
+            {
+              // assemblies for dotnet: imports
+              "References": [
+                "./libs/a.dll",
+              ],
+              "PACKAGES": { "Newtonsoft.Json": "13.0.3", },
+            }
+            """);
+
+        var manifest = SharpTsManifestLoader.Load(path);
+
+        Assert.Equal(["./libs/a.dll"], manifest.References!);
+        Assert.Equal("13.0.3", manifest.Packages!["Newtonsoft.Json"]);
+    }
+
+    [Fact]
+    public void Load_MalformedJsonIsHardErrorNamingTheFile()
+    {
+        using var dir = CliTestHelper.CreateTempDirectory();
+        var path = dir.CreateFile("sharpts.json", "{ not json ");
+
+        var ex = Assert.ThrowsAny<Exception>(() => SharpTsManifestLoader.Load(path));
+        Assert.Contains("sharpts.json", ex.Message);
+        Assert.Contains(path, ex.Message);
+    }
+
+    [Fact]
+    public void Load_MissingFileThrows()
+    {
+        using var dir = CliTestHelper.CreateTempDirectory();
+        Assert.Throws<FileNotFoundException>(() => SharpTsManifestLoader.Load(dir.GetPath("sharpts.json")));
+    }
+}

--- a/docs/dotnet-types.md
+++ b/docs/dotnet-types.md
@@ -93,21 +93,73 @@ import { SpecialFolder } from "dotnet:System.Environment";
   specific overload with `@DotNetOverload`, use a `@DotNetType` declaration for that type
   instead; the two binding styles compose freely in one program.
 
-### v1 scope and restrictions
+### Scope and restrictions
 
 - **Named imports only.** Default imports, `import * as ns`, `export … from "dotnet:…"`,
   `import x = require("dotnet:…")`, and dynamic `import("dotnet:…")` are rejected with a
   clear error — a .NET namespace is not an enumerable module object.
-- **Loaded assemblies only.** Types resolve from the BCL and any assembly already loaded in
-  the process (matching `@DotNetType`). A project-level assembly-reference story for
-  third-party DLLs is tracked separately.
 - **No generic types.** `dotnet:System.Collections.Generic.List<number>` is rejected; use an
   `@DotNetType` declaration with a closed-generic CLR name for those.
+- **No paths in specifiers.** `dotnet:./libs/MyLib.dll#MyLib.Widget` is rejected — specifiers
+  name types or namespaces. Point SharpTS at the assembly via `sharpts.json` or `-r`
+  (below), then import the type by name.
 - Missing-member accesses follow SharpTS's standard class-instance semantics (same as
   hand-written classes).
 
 Use `sharpts --gen-decl <Type|Namespace>` to discover what's available and copy the exact
 import line — see [Discovering .NET Types](#discovering-net-types---gen-decl).
+
+---
+
+## Third-Party Assemblies (`sharpts.json`)
+
+Out of the box, types resolve from the BCL and anything already loaded in the process. To
+use your own or third-party assemblies, add a `sharpts.json` manifest next to (or in any
+directory above) your entry script:
+
+```jsonc
+// sharpts.json — comments and trailing commas are allowed
+{
+  // Local assembly references. Relative paths resolve against THIS file's directory.
+  "references": ["./libs/MyLib.dll"],
+
+  // NuGet packages, restored on demand with `dotnet restore` (nuget.org by default;
+  // a nuget.config next to the manifest configures sources as usual).
+  "packages": { "Newtonsoft.Json": "13.0.3" }
+}
+```
+
+```typescript
+import { Widget } from "dotnet:MyLib.Widget";       // from ./libs/MyLib.dll
+import { JsonConvert } from "dotnet:Newtonsoft.Json.JsonConvert";  // from the package
+```
+
+The manifest applies uniformly to **every tool**: the interpreter, the compiler, the
+language server, and `--gen-decl`. A per-invocation `-r/--reference <asm.dll>` flag
+(available in all modes) augments the manifest and wins when both list the same assembly.
+
+How it behaves:
+
+- **Discovery** walks up from the entry script (the working directory for the REPL,
+  `--gen-decl`, and the language server), stopping at the temp and user-profile roots.
+- **Packages** restore into the global NuGet cache via `dotnet restore` on a generated
+  project under `.sharpts/` next to the manifest (add `.sharpts/` to `.gitignore`). The
+  restore is skipped entirely when the package set hasn't changed, so startup stays fast
+  and works offline once restored. Transitive dependencies are resolved and loaded.
+- **Compiled output** references these assemblies by metadata token (hard references).
+  The compiler co-locates the used assemblies — plus their dependency closure — next to
+  the output, so `dotnet out.dll` just works. `--standalone` suppresses the copy and
+  prints what your deployment must provide instead.
+- **The language server** reads the manifest once at startup (like `--project`) and
+  inspects the assemblies through a `MetadataLoadContext` — it never executes workspace
+  code. Restart the server after editing the manifest.
+
+Limitations: no RuntimeIdentifier-specific or native package assets (managed `lib/`
+assets only); package versions are exact or standard NuGet ranges.
+
+> **Security note:** referenced assemblies run with **full trust** the first time a member
+> is used. Listing a DLL or package in sharpts.json is an explicit opt-in, the same trust
+> decision as installing an npm dependency.
 
 ---
 


### PR DESCRIPTION
Third-party assembly story for the `dotnet:` import scheme — the fast-follow deferred from #1195. Closes #1197.

## Design (settled with the issue's candidate list)

**`sharpts.json` manifest** (candidate 1), discovered by upward walk from the entry script, with **full NuGet restore** for a `packages` section. Path-embedded specifiers (candidate 2) are rejected with a clear error; no probing convention (candidate 3). A global `-r/--reference` flag augments per invocation in every mode.

```jsonc
// sharpts.json — comments and trailing commas allowed
{
  "references": ["./libs/MyLib.dll"],          // relative to this file
  "packages": { "Newtonsoft.Json": "13.0.3" }  // dotnet restore, hash-gated
}
```

## How it works

- **One mechanism, four seams.** `References/DotNetReferences.Resolve/Load` discovers the manifest, restores packages, and `Assembly.LoadFrom`s the DLLs at startup — before any module loading. Every existing resolution seam (interpreter `DotNetTypeRegistry.Resolve`, compile-time `EnsureImports`/`TryResolveExternalType`, `--gen-decl` discovery) already scans the AppDomain, so they all see the types with no resolution changes. The LSP uses `Resolve` (paths only) feeding its existing MetadataLoadContext loader — it never executes workspace code.
- **NuGet restore = shell out to `dotnet restore`** on a generated project under `.sharpts/` (dotnet-script model): no NuGet.Commands/ProjectModel dependencies added to SharpTS.dll, nuget.config discovery + credential providers for free. MSBuild-isolation stubs prevent host-repo `Directory.Build.props`/CPM leakage; `DisableImplicitFrameworkReferences` keeps restore independent of targeting packs. A SHA-256 hash gate skips the process entirely when the package set is unchanged — second run costs ~0.3s and works offline.
- **Compiled output** hard-references these assemblies by metadata token, so the compiler co-locates the *used* assemblies plus their dependency closure (assets-graph subtree for packages, AssemblyName walk for local DLLs) next to the output; `--standalone` suppresses the copy and prints what deployment must provide. `--verify` now probes reference directories so ILVerify resolves third-party tokens.

## Verification

| Suite | Result |
|---|---|
| Full xUnit | **15018 / 0** (35 new tests) |
| TypeScriptConformance | 31 / 0 |
| Test262 (interp + compiled) | 22 / 0 + 4 known skips, baseline-identical |
| CLI smokes | interp, compiled `--verify`, standalone run with only third-party DLLs (no SharpTS.dll), `-r` on run/gen-decl, hermetic restore incl. transitive deps |

New tests build a fixture classlib + two local nupkgs (Main→Base) once per run via `dotnet build`/`pack`; restore tests are fully hermetic (folder source + redirected `globalPackagesFolder`, `<clear/>` sources — no network, no user-cache pollution). The AssemblyRef-table test pins that compiled output references the fixture assembly and **not** SharpTS.

Docs: `docs/dotnet-types.md` (new "Third-Party Assemblies" section replacing the "Loaded assemblies only" limitation, incl. the full-trust security note), README, STATUS.md §16, CLI help.