### PR TITLE
ci: remove Intl formatToParts JIT-bug skips — .NET 10 runtime bug fixed (#39)

### DIFF
--- a/Compilation/EmittedRuntime.cs
+++ b/Compilation/EmittedRuntime.cs
@@ -387,13 +387,13 @@ public class EmittedRuntime
     public FieldBuilder CurrentArrayLikeReceiverField { get; set; } = null!;
 
     // Aliases <see cref="CurrentArrayLikeReceiverField"/>. Originally a
-    // dedicated [ThreadStatic] field, but adding a second thread-static slot
-    // to $Runtime triggers a .NET 10 tier-0 QuickJit miscompilation (the
-    // same bug behind the existing IntlDateTimeFormatTests Linux skip /
-    // commit 696bdbc). Reusing the existing field works because the
-    // dispatch site already stores the original receiver there, and
-    // LoadArrayLikeElement disambiguates eager vs lazy by inspecting the
-    // receiver's type at load time (Dict / TSObject → lazy, otherwise eager).
+    // dedicated [ThreadStatic] field; the aliasing was forced by the
+    // layout-sensitive .NET 10 tier-0 JIT bug behind issue #39 (fixed
+    // upstream in 10.0.x servicing, so a dedicated field would be safe
+    // again). Kept because it works cleanly: the dispatch site already
+    // stores the original receiver there, and LoadArrayLikeElement
+    // disambiguates eager vs lazy by inspecting the receiver's type at
+    // load time (Dict / TSObject → lazy, otherwise eager).
     public FieldBuilder LazyArrayLikeReceiverField { get; set; } = null!;
 
     // Lazy-aware materializer used by Array.prototype.* iterator helpers.

--- a/Compilation/RuntimeEmitter.CallArgsPool.cs
+++ b/Compilation/RuntimeEmitter.CallArgsPool.cs
@@ -12,11 +12,11 @@ public partial class RuntimeEmitter
     /// allocating <c>new object[N]</c> on every invocation, we reuse a
     /// thread-static cached array of the right arity.
     ///
-    /// Why a separate class instead of fields on <c>$Runtime</c>: a
-    /// documented .NET 10 tier-0 QuickJit miscompilation triggers when
-    /// <c>$Runtime</c> has more than one <c>[ThreadStatic]</c> field
-    /// (see commit 696bdbc / IntlDateTimeFormatTests). Putting the pool
-    /// on a fresh class sidesteps that.
+    /// Why a separate class instead of fields on <c>$Runtime</c>: at the
+    /// time, a layout-sensitive .NET 10 tier-0 JIT bug (issue #39, since
+    /// fixed upstream in 10.0.x servicing) could re-trigger when
+    /// <c>[ThreadStatic]</c> fields were added to <c>$Runtime</c>, so the
+    /// pool went on a fresh class. Harmless to keep it here.
     ///
     /// Safety / aliasing: the call site fills the array, then dispatches
     /// through <c>$TSFunction.Invoke → MethodInvoker.Invoke(target, Span&lt;object?&gt;)</c>.

--- a/Compilation/RuntimeEmitter.RuntimeClass.cs
+++ b/Compilation/RuntimeEmitter.RuntimeClass.cs
@@ -66,12 +66,12 @@ public partial class RuntimeEmitter
         currentArrayLikeReceiverField.SetCustomAttribute(new CustomAttributeBuilder(threadStaticCtor, []));
         runtime.CurrentArrayLikeReceiverField = currentArrayLikeReceiverField;
         // Reuse `_currentArrayLikeReceiver` for the lazy iteration signal too.
-        // Adding a SECOND [ThreadStatic] field to $Runtime triggers a .NET 10
-        // tier-0 QuickJit miscompilation on `arr.map(...).includes(s)` — same
-        // bug already documented in IntlDateTimeFormatTests / commit 696bdbc.
-        // Reusing the existing field is also semantically clean: the dispatch
-        // site already sets it to the original receiver, and LoadArrayLikeElement
-        // can decide eager vs lazy by inspecting the receiver's type.
+        // (Historically forced by the layout-sensitive .NET 10 tier-0 JIT bug
+        // behind issue #39 — fixed upstream in 10.0.x servicing, so adding
+        // fields here is safe again.) The reuse is kept because it is also
+        // semantically clean: the dispatch site already sets the field to the
+        // original receiver, and LoadArrayLikeElement can decide eager vs lazy
+        // by inspecting the receiver's type.
         runtime.LazyArrayLikeReceiverField = currentArrayLikeReceiverField;
 
         // Thread-static "callback thisArg" for `arr.forEach(cb, thisArg)` and

--- a/Compilation/RuntimeEmitter.cs
+++ b/Compilation/RuntimeEmitter.cs
@@ -114,8 +114,8 @@ public partial class RuntimeEmitter
 
         // Per-thread args[] pool used by method-call dispatch to skip
         // newarr per `obj.method(a, b)` invocation. Lives on a separate
-        // class because $Runtime can't host more than one [ThreadStatic]
-        // field without tripping a .NET 10 tier-0 QuickJit miscompilation.
+        // class — historically to avoid the layout-sensitive .NET 10
+        // tier-0 JIT bug behind issue #39 (since fixed upstream).
         EmitCallArgsPool(moduleBuilder, runtime);
 
         // Emit $Array class for standalone array support

--- a/SharpTS.Tests/Infrastructure/TestHarness.cs
+++ b/SharpTS.Tests/Infrastructure/TestHarness.cs
@@ -253,7 +253,11 @@ public static class TestHarness
         //      which would surface the testhost's argv in-process, not the test's.
         //   2. copySharpTsRuntime == false — RunCompiledStandalone simulates a
         //      shipped DLL with no SharpTS.dll alongside; that only repros via spawn.
-        if (scriptArgs is not null || !copySharpTsRuntime)
+        // SHARPTS_FORCE_SUBPROCESS=1 forces the spawn path for every compiled
+        // test — a diagnostic knob for launch-path-sensitive investigations
+        // (the #39 JIT bug only reproduced through the subprocess path).
+        if (scriptArgs is not null || !copySharpTsRuntime ||
+            Environment.GetEnvironmentVariable("SHARPTS_FORCE_SUBPROCESS") == "1")
             return RunCompiledViaSubprocess(source, decoratorMode, timeout, scriptArgs, includeTestsAssembly, copySharpTsRuntime);
 
         return RunCompiledInProcess(source, decoratorMode, timeout);

--- a/SharpTS.Tests/SharedTests/IntlDateTimeFormatTests.cs
+++ b/SharpTS.Tests/SharedTests/IntlDateTimeFormatTests.cs
@@ -373,73 +373,24 @@ public class IntlDateTimeFormatTests
     }
 
     // ========================================================================
-    // KNOWN .NET 10 JIT BUG — DO NOT REMOVE THESE SKIPS WITHOUT UPSTREAM FIX
+    // HISTORICAL NOTE — .NET 10 tier-0 JIT miscompilation (issue #39, RESOLVED)
     // ========================================================================
-    // Both `_HasTypeAndValue` and `_ContainsLiterals` below trip a .NET 10
-    // tier-0 QuickJit miscompilation that causes `Array.prototype.includes`
-    // (string arg) on a freshly `.map()`-ed `List<object>` of boxed strings
-    // to return the wrong result for the FIRST 1-2 sequential calls
-    // (~90% of runs). Subsequent calls — and the same code re-run after the
-    // method has been re-jitted at tier 1 — produce the correct result.
-    //
-    // Symptom fingerprint (matches both tests):
-    //   const types = parts.map(p => p.type);  // List<object> of boxed strings
-    //   types.includes("year")    // returns false (WRONG) on first call
-    //   types.includes("month")   // returns true  (correct)
-    //   types.includes("day")     // returns true  (correct)
-    //
-    // Original Linux trigger: `DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1`
-    // (auto-enabled on GHA ubuntu-latest where libicu is absent) + xUnit
-    // testhost subprocess spawn. Confirmed via 20-run × 7-config matrix:
-    //   - Disabling QuickJit (DOTNET_TC_QuickJit=0):  10/10 pass
-    //   - Disabling tiered compilation entirely:      10/10 pass
-    //   - Default config + INVARIANT=1:                0/10 pass
-    //   - DLLs are byte-identical across environments
-    //   - Direct `dotnet DLL_PATH` always passes; only xUnit testhost reproduces
-    //
-    // 2026-05-01 update: bug now also reproducing on macos-latest (arm64,
-    // Apple Silicon) WITHOUT the invariant globalization env var, and now
-    // hits BOTH formatToParts tests (previously only `_HasTypeAndValue`).
-    // Consistent with the bug's documented JIT-timing flakiness — the
-    // platform/test boundary is incidental; the underlying tier-0 codegen
-    // bug is what matters. Skip widened to cover Linux + macOS in compiled
-    // mode for both tests.
-    //
-    // Why we don't use the broader workaround:
-    //   Commit 696bdbc set `DOTNET_TC_QuickJit=0` CI-wide. That fixed these
-    //   tests but exposed a separate latent compiled-mode rest-parameter
-    //   dispatch bug, regressing 5 Timers tests + 1 other Intl test.
-    //   Commit cfc667b reverted that workaround and switched to a narrow
-    //   in-test skip — net change: 6 failing → 0 failing, 1 skipped. We're
-    //   continuing the same strategy here; widening the skip is preferable
-    //   to re-introducing the broader workaround.
-    //
-    // To remove these skips:
-    //   - Wait for the .NET 10 runtime fix (tracked in memory file
-    //     `project_intl_ci_invariant_bug.md`; adjacent issues: dotnet/runtime
-    //     #127075, #123790, #119710, #126667)
-    //   - Or: refactor the tests to avoid the JIT-trigger pattern (e.g.
-    //     materialize `.map().includes()` through an interstitial array
-    //     allocation that forces the receiver onto a different IL path)
-    //
-    // See:
-    //   - memory/project_intl_ci_invariant_bug.md (root cause + repro matrix)
-    //   - commit 696bdbc (original Linux discovery + broad workaround)
-    //   - commit cfc667b (revert of broad workaround → narrow skip)
+    // From 2026-04-20 to 2026-07-01 the two formatToParts tests below were
+    // skipped in compiled mode on Linux/macOS: a .NET 10 runtime JIT bug made
+    // `parts.map(p => p.type).includes(...)` return a wrong boolean under
+    // DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1 (~90% of runs, first calls only,
+    // interpreted mode unaffected). Root-caused 2026-07-01 with a local repro:
+    // the trigger was the April-era ArrayMap/ArrayIncludes emission shape
+    // (rewritten in ca9a6641) on early .NET 10 servicing — identical artifacts
+    // fail 9/10 on runtime 10.0.0 and pass 10/10 on 10.0.6/7/8/9, so the
+    // runtime fixed it, not us. Full repro matrix and history in issue #39;
+    // commits 696bdbc and cfc667b document the original workarounds.
     // ========================================================================
 
-    [SkippableTheory]
+    [Theory]
     [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void IntlDateTimeFormat_FormatToParts_HasTypeAndValue(ExecutionMode mode)
     {
-        // See the block comment above. Skips compiled mode on Linux + macOS;
-        // Windows + interpreted mode on all platforms still run this test.
-        Skip.If(
-            mode == ExecutionMode.Compiled && (OperatingSystem.IsLinux() || OperatingSystem.IsMacOS()),
-            ".NET 10 tier-0 QuickJit miscompilation: Array.includes returns wrong result for first call after .map(). " +
-            "Reproduces on Linux (libicu-less GHA runners) and macOS arm64. See 696bdbc, cfc667b, " +
-            "and memory/project_intl_ci_invariant_bug.md.");
-
         var source = @"
             const d = new Date(2024, 0, 15, 14, 30, 45);
             const dtf = new Intl.DateTimeFormat(""en-US"", {year: ""numeric"", month: ""long"", day: ""numeric""});
@@ -453,21 +404,10 @@ public class IntlDateTimeFormatTests
         Assert.Equal("true\ntrue\ntrue\n", output);
     }
 
-    [SkippableTheory]
+    [Theory]
     [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void IntlDateTimeFormat_FormatToParts_ContainsLiterals(ExecutionMode mode)
     {
-        // See the block comment above. Same JIT bug as `_HasTypeAndValue`:
-        // `parts.map(p => p.type).includes("literal")` returns false on the
-        // first call under tier-0 QuickJit. Started reproducing on macOS arm64
-        // in CI run 25200546596 (2026-05-01); add to the skip set alongside
-        // its sibling test.
-        Skip.If(
-            mode == ExecutionMode.Compiled && (OperatingSystem.IsLinux() || OperatingSystem.IsMacOS()),
-            ".NET 10 tier-0 QuickJit miscompilation: Array.includes returns wrong result for first call after .map(). " +
-            "Reproduces on Linux (libicu-less GHA runners) and macOS arm64. See 696bdbc, cfc667b, " +
-            "and memory/project_intl_ci_invariant_bug.md.");
-
         var source = @"
             const d = new Date(2024, 0, 15, 14, 30, 45);
             const dtf = new Intl.DateTimeFormat(""en-US"", {year: ""numeric"", month: ""long"", day: ""numeric""});


### PR DESCRIPTION
Closes #39.

## Summary

Removes the Linux/macOS compiled-mode skips on `IntlDateTimeFormat_FormatToParts_HasTypeAndValue` and `_ContainsLiterals`, in place since `cfc667b` (2026-04-21, widened `aff65dcc` 2026-05-01). The underlying .NET 10 tier-0 JIT miscompilation was root-caused today with a recovered **local reproduction** and is **fixed in .NET 10 servicing**.

## Root cause findings (full detail in #39)

The bug's trigger was the **April-era `ArrayMap`/`ArrayIncludes` emission shape** (rewritten in `ca9a6641`, 2026-05-01) on **early .NET 10 servicing runtimes** — not the GHA environment, as previously believed. Every post-May repro attempt (480 Docker runs, WSL re-tests) ran post-rewrite code, which is why nothing reproduced.

Evidence matrix (WSL x64, `DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1`, 10 iterations/arm unless noted):

| Code | Runtime | Result |
|---|---|---|
| pre-workaround `2f7a3c27` | 10.0.0 | **9/10 FAIL** (`"true\nfalse\ntrue"`, exact April fingerprint; interpreted mode green in same runs) |
| pre-workaround, same artifacts | 10.0.6 / 10.0.7 / 10.0.8 / 10.0.9 | **40/40 pass** |
| pre-workaround, control re-run | 10.0.0 | 2/3 FAIL (same session, minutes later) |
| current main | 10.0.0 → 10.0.9, Win + WSL | **190/190 pass** (incl. contention, tier-0 window stretching, ThreadStatic layout perturbation) |

Identical IL flipping pass/fail purely on runtime version = runtime JIT bug; SharpTS IL exonerated. CI floats on `dotnet-version: 10.0.x` → runtime 10.0.9.

## Changes

- **`IntlDateTimeFormatTests.cs`** — remove both `Skip.If`s, `[SkippableTheory]` → `[Theory]`; the warning block becomes a short historical note.
- **Emitter comments** (`EmittedRuntime.cs`, `RuntimeEmitter.cs`, `RuntimeEmitter.RuntimeClass.cs`, `RuntimeEmitter.CallArgsPool.cs`) — retire the "\$Runtime can't host a second `[ThreadStatic]` field" folk rule: that constraint was a layout-sensitive manifestation of this same fixed bug (and `$Runtime` has had two such fields since 2026-04-27 anyway). No code-shape changes — the field-aliasing and separate `$CallArgsPool` class are kept as-is.
- **`TestHarness.cs`** — keep `SHARPTS_FORCE_SUBPROCESS=1` as a diagnostic knob forcing the pre-`8aa2846f` spawn path (the #39 bug only reproduced through it).

## Validation

- Windows (runtime 10.0.9): full `IntlDateTimeFormatTests` class **72/72, 0 skipped**
- WSL Linux (runtime 10.0.9, CI mirror): **72/72, 0 skipped**; formatToParts + `INVARIANT=1`: 6/6
- WSL Linux (runtime **10.0.0**, the formerly-buggy runtime) + `INVARIANT=1`: 6/6 — current emission shape doesn't trip the bug even there

macOS note: the skip also covered macOS arm64 (May 1 manifestation, runtime 10.0.7, different JIT backend). macOS is currently out of the CI matrix (`dad85a89`); if it returns, these tests run on 10.0.9+ where all evidence says the bug is fixed.