### PR TITLE
fix(interp): #1215 eliminate every known flaky/env-sensitive test — event-loop parked-resume visibility + dot-dir project discovery

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,13 @@ jobs:
       # DNS/HTTP calls (tagged [Trait("Category","LiveNetwork")]); those depend on
       # the runner's network and false-red CI (#495). Run them on demand locally:
       # dotnet test --filter "Category=LiveNetwork"
+      #
+      # Category!=LoadSensitive is the same quarantine for tests that inherently
+      # depend on load/wall-clock timing (#1215 policy): the default suite must
+      # contain no test we know can fail without a code defect. Currently no test
+      # carries the tag — every known load-flake was fixed at the product level
+      # (#1211/#1212/#1213) — but any future inherently-timing-dependent test gets
+      # [Trait("Category","LoadSensitive")] and is excluded here automatically.
       - name: Test
-        run: dotnet test --no-build --configuration Release --verbosity normal --filter "Category!=LiveNetwork"
+        run: dotnet test --no-build --configuration Release --verbosity normal --filter "Category!=LiveNetwork&Category!=LoadSensitive"
         timeout-minutes: 10

--- a/Runtime/Types/EventLoopTestHooks.cs
+++ b/Runtime/Types/EventLoopTestHooks.cs
@@ -1,0 +1,28 @@
+namespace SharpTS.Runtime.Types;
+
+/// <summary>
+/// Test-only latency injection for event-loop liveness regression tests.
+/// </summary>
+/// <remarks>
+/// When <c>SHARPTS_TEST_STREAM_PARKED_RESUME_DELAY_MS</c> is set, the resume of a
+/// parked stream read (async-iterator <c>next()</c>, pipeTo pump read) stalls that
+/// long immediately after the parked task settles. Deterministically reproduces the
+/// loaded-CI thread-pool scheduling delay that exposed the settled-but-not-yet-
+/// enqueued continuation window (#1211/#1212): with the resume hopping through the
+/// thread pool the injected stall sits inside the window invisible to
+/// <c>RunEventLoopCore</c>'s exit check and the program exits silently; with the
+/// resume riding the interpreter's SynchronizationContext the stall runs on the
+/// event-loop thread inside a queued callback, merely delaying output. The sleep is
+/// deliberately synchronous — an awaited <c>Task.Delay</c> would itself be invisible
+/// in-flight work and re-create the very window under test. Read per call so a test
+/// can scope it with try/finally. Same env-var seam pattern as
+/// SHARPTS_TEST_FS_ASYNC_DELAY_MS (#319).
+/// </remarks>
+internal static class EventLoopTestHooks
+{
+    internal static void ParkedResumeDelay()
+    {
+        if (int.TryParse(Environment.GetEnvironmentVariable("SHARPTS_TEST_STREAM_PARKED_RESUME_DELAY_MS"), out var ms) && ms > 0)
+            Thread.Sleep(ms);
+    }
+}

--- a/Runtime/Types/SharpTSReadableAsyncIterator.cs
+++ b/Runtime/Types/SharpTSReadableAsyncIterator.cs
@@ -55,9 +55,18 @@ public class SharpTSReadableAsyncIterator : SharpTSObject
 
             var pull = _stream.IterNextAsync();
             // Observe a done:true result so subsequent next() calls short-circuit.
+            // No ConfigureAwait(false) on the parked pull: the resume must ride the
+            // interpreter's SynchronizationContext so the producer's TrySetResult
+            // posts it into the event loop's callback queue synchronously. A
+            // thread-pool resume is invisible to the loop's exit check, so a
+            // producer that settles the pull and drops its last timer handle in
+            // the same tick (setInterval's final push(null)+clearInterval) let the
+            // program exit before the loop body ran (#1211).
             async Task<object?> AwaitAndObserve()
             {
-                var result = await pull.ConfigureAwait(false);
+                bool parked = !pull.IsCompleted;
+                var result = await pull;
+                if (parked) EventLoopTestHooks.ParkedResumeDelay();
                 if (result is IDictionary<string, object?> dict &&
                     dict.TryGetValue("done", out var d) && d is bool db && db)
                 {

--- a/Runtime/Types/SharpTSReadableStream.cs
+++ b/Runtime/Types/SharpTSReadableStream.cs
@@ -332,14 +332,15 @@ public class SharpTSReadableStream : ITypeCategorized
         }
 
         // Queue empty, stream still readable — park the read.
-        // NOTE: default TaskCreationOptions (NOT RunContinuationsAsynchronously).
-        // With the InterpreterSynchronizationContext set up at the top of
-        // InterpretModules, the await captured inside an async script
-        // function correctly posts its continuation back through the
-        // interpreter's callback queue. Using default options means
-        // TrySetResult below can hand off via the continuation mechanism
-        // rather than inlining on the timer-callback thread.
-        var pending = new TaskCompletionSource<object?>();
+        // RunContinuationsAsynchronously: awaiters of a parked read (the pipeTo
+        // pump, the async iterator, guest `await reader.read()`) capture the
+        // InterpreterSynchronizationContext, so TrySetResult posts each resume
+        // into the event loop's callback queue synchronously — visible to the
+        // loop's exit check from the instant of settling (#1212, the #320
+        // liveness family). Without this flag a same-context settle (producer
+        // enqueue() on the loop thread) would inline the consumer's resume
+        // inside the enqueue call — reentrancy the streams spec doesn't allow.
+        var pending = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
         Reader!.PendingReads.Enqueue(pending);
         CallPullIfNeeded();
         return pending.Task;

--- a/Runtime/Types/SharpTSReadableStreamAsyncIterator.cs
+++ b/Runtime/Types/SharpTSReadableStreamAsyncIterator.cs
@@ -56,9 +56,16 @@ public class SharpTSReadableStreamAsyncIterator : SharpTSObject
             }
             var readTask = _stream.ReadInternal();
             // Wrap in a continuation that flips _done when the result is done:true.
+            // No ConfigureAwait(false) on the parked read: the resume must ride the
+            // interpreter's SynchronizationContext so the producer's TrySetResult
+            // posts it into the event loop's callback queue synchronously —
+            // a thread-pool resume is invisible to the loop's exit check and the
+            // program can exit before the loop body runs (#1211's web-stream twin).
             async Task<object?> AwaitAndObserve()
             {
-                var result = await readTask.ConfigureAwait(false);
+                bool parked = !readTask.IsCompleted;
+                var result = await readTask;
+                if (parked) EventLoopTestHooks.ParkedResumeDelay();
                 if (result is IDictionary<string, object?> dict &&
                     dict.TryGetValue("done", out var d) && d is bool db && db)
                 {

--- a/Runtime/Types/WebStreamsHelpers.cs
+++ b/Runtime/Types/WebStreamsHelpers.cs
@@ -148,22 +148,26 @@ internal static class WebStreamsHelpers
         async Task<object?> CallWrite(object chunk)
         {
             var task = (Task<object?>?)writeMethod.Invoke(dest, [chunk]);
-            if (task != null) await task.ConfigureAwait(false);
+            if (task != null) await task;
             return SharpTSUndefined.Instance;
         }
         async Task CallClose()
         {
             var task = (Task<object?>?)closeMethod.Invoke(dest, null);
-            if (task != null) await task.ConfigureAwait(false);
+            if (task != null) await task;
         }
         async Task CallAbort(object? reason)
         {
             var task = (Task<object?>?)abortMethod.Invoke(dest, [reason]);
-            if (task != null) await task.ConfigureAwait(false);
+            if (task != null) await task;
         }
 
         async Task<object?> PumpAsync()
         {
+            // No ConfigureAwait(false) in the pump — resumes must ride the
+            // interpreter's SynchronizationContext so they stay visible to the
+            // event loop's exit check (see PipeTo's pump, #1212).
+            //
             // Scope a Ref to the abort/cancel/reject teardown so the source
             // cancel() callback cannot be dropped by event-loop quiescence —
             // same liveness fix as PipeTo (#325/#320 doctrine). The steady-state
@@ -185,23 +189,26 @@ internal static class WebStreamsHelpers
                     if (signal != null && signal.Aborted)
                     {
                         RefTeardown();
-                        if (!preventAbort) await CallAbort(signal.Reason).ConfigureAwait(false);
-                        if (!preventCancel) await source.CancelInternal(signal.Reason).Task.ConfigureAwait(false);
+                        if (!preventAbort) await CallAbort(signal.Reason);
+                        if (!preventCancel) await source.CancelInternal(signal.Reason).Task;
                         throw new SharpTSPromiseRejectedException(signal.Reason);
                     }
 
-                    var readResult = await source.ReadInternal().ConfigureAwait(false);
+                    var readTask = source.ReadInternal();
+                    bool parked = !readTask.IsCompleted;
+                    var readResult = await readTask;
+                    if (parked) EventLoopTestHooks.ParkedResumeDelay();
                     if (readResult is not IDictionary<string, object?> resultObj) throw new InvalidOperationException("read() returned non-object");
                     var done = resultObj.TryGetValue("done", out var d) && d is bool db && db;
                     if (done)
                     {
-                        if (!preventClose) await CallClose().ConfigureAwait(false);
+                        if (!preventClose) await CallClose();
                         if (source.Reader == reader) source.Reader = null;
                         return SharpTSUndefined.Instance;
                     }
 
                     var chunk = resultObj.TryGetValue("value", out var v) ? v : SharpTSUndefined.Instance;
-                    await CallWrite(chunk!).ConfigureAwait(false);
+                    await CallWrite(chunk!);
                 }
             }
             catch (Exception ex)
@@ -210,11 +217,11 @@ internal static class WebStreamsHelpers
                 var reason = ex is SharpTSPromiseRejectedException pre ? pre.Reason : ex;
                 if (!preventAbort)
                 {
-                    try { await CallAbort(reason).ConfigureAwait(false); } catch { }
+                    try { await CallAbort(reason); } catch { }
                 }
                 if (!preventCancel && source.State == SharpTSReadableStream.StreamState.Readable)
                 {
-                    try { await source.CancelInternal(reason).Task.ConfigureAwait(false); } catch { }
+                    try { await source.CancelInternal(reason).Task; } catch { }
                 }
                 if (source.Reader == reader) source.Reader = null;
                 throw;
@@ -257,6 +264,16 @@ internal static class WebStreamsHelpers
 
         async Task<object?> PumpAsync()
         {
+            // No ConfigureAwait(false) anywhere in the pump: every resume of a
+            // parked await (read, write, teardown) must ride the interpreter's
+            // SynchronizationContext so the settling TrySetResult posts it into
+            // the event loop's callback queue synchronously — visible to the
+            // loop's exit check, and running guest callbacks (write/abort/
+            // cancel) on the loop thread rather than a pool thread. A pool-hop
+            // resume was invisible to the exit check, so a one-shot timer
+            // producer whose callback settled the parked read let the program
+            // exit before "wrote x" was ever printed (#1212).
+            //
             // The pipe promise itself is deliberately NOT Ref'd — an infinite
             // source must be allowed to never settle, so a blanket Ref would
             // hang the process (#319/#320 doctrine). But the abort/cancel/reject
@@ -292,19 +309,22 @@ internal static class WebStreamsHelpers
                     if (signal != null && signal.Aborted)
                     {
                         RefTeardown();
-                        if (!preventAbort) await dest.AbortInternal(signal.Reason).ConfigureAwait(false);
-                        if (!preventCancel) await source.CancelInternal(signal.Reason).Task.ConfigureAwait(false);
+                        if (!preventAbort) await dest.AbortInternal(signal.Reason);
+                        if (!preventCancel) await source.CancelInternal(signal.Reason).Task;
                         throw new SharpTSPromiseRejectedException(signal.Reason);
                     }
 
-                    var readResult = await source.ReadInternal().ConfigureAwait(false);
+                    var readTask = source.ReadInternal();
+                    bool parked = !readTask.IsCompleted;
+                    var readResult = await readTask;
+                    if (parked) EventLoopTestHooks.ParkedResumeDelay();
                     if (readResult is not IDictionary<string, object?> resultObj) throw new InvalidOperationException("read() returned non-object");
                     var done = resultObj.TryGetValue("done", out var d) && d is bool db && db;
                     if (done)
                     {
                         if (!preventClose && dest.State == SharpTSWritableStream.WritableState.Writable)
                         {
-                            await dest.CloseAsyncInternal().ConfigureAwait(false);
+                            await dest.CloseAsyncInternal();
                         }
                         if (source.Reader == reader) source.Reader = null;
                         if (dest.Writer == writer) dest.Writer = null;
@@ -312,7 +332,7 @@ internal static class WebStreamsHelpers
                     }
 
                     var chunk = resultObj.TryGetValue("value", out var v) ? v : SharpTSUndefined.Instance;
-                    await dest.EnqueueWrite(chunk).ConfigureAwait(false);
+                    await dest.EnqueueWrite(chunk);
                 }
             }
             catch (Exception ex)
@@ -324,11 +344,11 @@ internal static class WebStreamsHelpers
                 var reason = ex is SharpTSPromiseRejectedException pre ? pre.Reason : ex;
                 if (!preventAbort && dest.State == SharpTSWritableStream.WritableState.Writable)
                 {
-                    try { await dest.AbortInternal(reason).ConfigureAwait(false); } catch { }
+                    try { await dest.AbortInternal(reason); } catch { }
                 }
                 if (!preventCancel && source.State == SharpTSReadableStream.StreamState.Readable)
                 {
-                    try { await source.CancelInternal(reason).Task.ConfigureAwait(false); } catch { }
+                    try { await source.CancelInternal(reason).Task; } catch { }
                 }
                 if (source.Reader == reader) source.Reader = null;
                 if (dest.Writer == writer) dest.Writer = null;

--- a/SharpTS.Tests/BuildTests/ProjectStructureTests.cs
+++ b/SharpTS.Tests/BuildTests/ProjectStructureTests.cs
@@ -30,10 +30,15 @@ public class ProjectStructureTests
 
         // Every sibling project directory under the repo root (the core project, build
         // output, and the external submodules excluded — the submodules carry no .cs).
+        // Dot-directories (.claude worktrees, .perf-probe scratch dirs, .git) are skipped
+        // to mirror the SDK's DefaultItemExcludes (**/.*/**): the compiler never globs
+        // sources under them, so a csproj there needs no <Compile Remove> entry — and
+        // untracked working dirs must not turn this test red on dev machines (#1214).
         var siblingProjects = Directory
             .EnumerateFiles(repoRoot, "*.csproj", SearchOption.AllDirectories)
             .Where(p => !string.Equals(p, coreCsproj, StringComparison.OrdinalIgnoreCase))
-            .Where(p => !IsUnder(repoRoot, p, "external", "bin", "obj"))
+            .Where(p => !IsUnder(repoRoot, p, "external"))
+            .Where(p => !HasSkippedSegment(repoRoot, p))
             .ToList();
 
         Assert.NotEmpty(siblingProjects); // sanity: discovery actually found the sibling projects
@@ -61,6 +66,20 @@ public class ProjectStructureTests
         var rel = Path.GetRelativePath(repoRoot, path).Replace('\\', '/');
         return topLevelDirs.Any(d =>
             rel.StartsWith(d + "/", StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <summary>
+    /// True when any directory segment of the path is a dot-directory or a
+    /// bin/obj output directory (at any depth — publish output can nest csproj
+    /// copies under a project's own bin/).
+    /// </summary>
+    private static bool HasSkippedSegment(string repoRoot, string path)
+    {
+        var rel = Path.GetRelativePath(repoRoot, Path.GetDirectoryName(path)!);
+        return rel.Split('/', '\\').Any(seg =>
+            seg.StartsWith('.') ||
+            seg.Equals("bin", StringComparison.OrdinalIgnoreCase) ||
+            seg.Equals("obj", StringComparison.OrdinalIgnoreCase));
     }
 
     private static string FindRepoRoot()

--- a/SharpTS.Tests/SharedTests/BuiltInModules/EventLoopParkedResumeTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/EventLoopParkedResumeTests.cs
@@ -1,0 +1,150 @@
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests.BuiltInModules;
+
+/// <summary>
+/// Event-loop liveness contract for parked-consumer resumes (#1211/#1212, the #320 family):
+/// when a producer settles a parked stream read (async-iterator <c>next()</c>, pipeTo pump
+/// read), the consumer's resume must be visible to the event loop's exit check from the moment
+/// of settling. The resume rides the interpreter's SynchronizationContext, whose Post lands in
+/// the callback queue synchronously inside TrySetResult — so a producer that settles the read
+/// and tears down its own timer in the same tick (setInterval's last tick, a one-shot
+/// setTimeout) cannot leave the loop looking quiescent while the continuation is in flight.
+///
+/// Before the fix these resumes hopped through the thread pool (<c>ConfigureAwait(false)</c>
+/// in the stream runtime types): invisible to <c>RunEventLoopCore</c>'s
+/// no-handles-and-empty-queue exit, so under CI thread-pool pressure the program exited
+/// silently before the loop body ever ran — the "Expected 10,20,30 / Actual ''" signature.
+///
+/// SHARPTS_TEST_STREAM_PARKED_RESUME_DELAY_MS stalls the resume immediately after the parked
+/// task settles, deterministically reproducing that scheduling delay: with a thread-pool hop
+/// the stall sits inside the invisible window and each test fails 100% with empty output; with
+/// the SynchronizationContext resume it runs inside a queued loop callback and merely delays
+/// output. Assertions are output-correctness only (never a wall-clock window — #295 flake-class
+/// rules) so the tests cannot themselves flake.
+///
+/// Interpreted mode only: compiled mode keeps continuations on the loop via the emitted
+/// $EventLoopSyncContext instead.
+/// </summary>
+public class EventLoopParkedResumeTests
+{
+    private const string DelayVar = "SHARPTS_TEST_STREAM_PARKED_RESUME_DELAY_MS";
+
+    // 600ms: decisively past the 250ms WaitForPromise quiescence window, and far past the
+    // RunEventLoopCore exit check (which has no grace window at all). Env var is process-wide,
+    // so concurrently running stream tests also absorb the stall during this test's window —
+    // they still pass, just slower (same accepted tradeoff as SHARPTS_TEST_FS_ASYNC_DELAY_MS).
+    private const string DelayMs = "600";
+
+    /// <summary>
+    /// The #1211 shape (StreamModuleTests.Readable_AsyncIterator_SlowProducer): a `for await`
+    /// over a stream-module Readable races a setInterval producer whose final tick pushes EOF
+    /// and clears the interval — dropping the handle count to zero in the same tick that
+    /// settles the parked pull. Covers SharpTSReadableAsyncIterator.
+    /// </summary>
+    [Fact]
+    public void ParkedReadableIteratorResume_SurvivesProducerTeardown()
+    {
+        Environment.SetEnvironmentVariable(DelayVar, DelayMs);
+        try
+        {
+            var files = new Dictionary<string, string>
+            {
+                ["main.ts"] = """
+                    import { Readable } from 'stream';
+                    async function main(): Promise<void> {
+                        const r = new Readable({ objectMode: true });
+                        let i = 0;
+                        const t = setInterval(() => {
+                            i++;
+                            if (i <= 3) { r.push(i * 10); }
+                            else { r.push(null); clearInterval(t); }
+                        }, 5);
+                        const out: number[] = [];
+                        for await (const x of r) { out.push(x); }
+                        console.log(out.join(','));
+                    }
+                    main();
+                    """
+            };
+
+            var output = TestHarness.RunModules(files, "main.ts", ExecutionMode.Interpreted);
+            Assert.Equal("10,20,30\n", output);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(DelayVar, null);
+        }
+    }
+
+    /// <summary>
+    /// The #1212 shape (StreamsWebSemanticTests.ReadableStream_PipeTo_PushSourceViaTimer): the
+    /// pipeTo pump's parked read is settled by a one-shot setTimeout producer; the timer's ref
+    /// is released when its callback returns, so the settled pump resume is briefly the only
+    /// remaining work. Covers the WebStreamsHelpers.PipeTo pump.
+    /// </summary>
+    [Fact]
+    public void ParkedPipeToPumpResume_SurvivesProducerTeardown()
+    {
+        Environment.SetEnvironmentVariable(DelayVar, DelayMs);
+        try
+        {
+            var files = new Dictionary<string, string>
+            {
+                ["main.ts"] = """
+                    let ctrl: any;
+                    const source = new ReadableStream({ start(c) { ctrl = c; } });
+                    const dest = new WritableStream({ write(chunk) { console.log("wrote " + chunk); } });
+                    setTimeout(() => { ctrl.enqueue("x"); ctrl.close(); }, 10);
+                    async function run() {
+                        await source.pipeTo(dest);
+                        console.log("done");
+                    }
+                    run();
+                    """
+            };
+
+            var output = TestHarness.RunModules(files, "main.ts", ExecutionMode.Interpreted);
+            Assert.Equal("wrote x\ndone\n", output);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(DelayVar, null);
+        }
+    }
+
+    /// <summary>
+    /// Same race through the web-stream async iterator (`for await` over a ReadableStream
+    /// rather than a stream-module Readable). Covers SharpTSReadableStreamAsyncIterator.
+    /// </summary>
+    [Fact]
+    public void ParkedWebStreamIteratorResume_SurvivesProducerTeardown()
+    {
+        Environment.SetEnvironmentVariable(DelayVar, DelayMs);
+        try
+        {
+            var files = new Dictionary<string, string>
+            {
+                ["main.ts"] = """
+                    let ctrl: any;
+                    const rs = new ReadableStream({ start(c) { ctrl = c; } });
+                    setTimeout(() => { ctrl.enqueue("a"); ctrl.close(); }, 10);
+                    async function main(): Promise<void> {
+                        const out: string[] = [];
+                        for await (const x of rs) { out.push(x); }
+                        console.log(out.join(','));
+                    }
+                    main();
+                    """
+            };
+
+            var output = TestHarness.RunModules(files, "main.ts", ExecutionMode.Interpreted);
+            Assert.Equal("a\n", output);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(DelayVar, null);
+        }
+    }
+}

--- a/SharpTS.Tests/SharedTests/BuiltInModules/StreamsWebSemanticTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/StreamsWebSemanticTests.cs
@@ -359,13 +359,18 @@ public class StreamsWebSemanticTests
     /// than being starved by the synchronous pump. The deterministic
     /// compiled-mode coverage for that fix is
     /// <see cref="ReadableStream_PipeTo_MidPipeAbortSignal_Compiled"/>; this
-    /// guest test stays InterpretedOnly only because its end-to-end assertion
-    /// flakes under CI load in interpreter mode (real thread-pool continuation
-    /// timing) — the compiled variant runs synchronously and is deterministic.
+    /// guest test stays InterpretedOnly because compiled mode has that separate
+    /// synchronous-pump variant.
     ///
-    /// This guest-level test asserts the end-to-end behavior but only flakes
-    /// under load; the deterministic regression guard for the interpreter fix
-    /// itself is <see cref="PipeTo_MidPipeAbort_RefsEventLoopAcrossTeardown"/>.
+    /// The residual "real thread-pool continuation timing" flake this remark
+    /// used to document (#1213) is gone: since #1215 the pump's awaits ride the
+    /// interpreter's SynchronizationContext instead of ConfigureAwait(false)
+    /// thread-pool hops, so the whole abort/cancel/reject teardown runs on the
+    /// event-loop thread and its output ordering is deterministic. The
+    /// white-box guards for the two product fixes are
+    /// <see cref="PipeTo_MidPipeAbort_RefsEventLoopAcrossTeardown"/> (teardown
+    /// Ref, #325) and <c>EventLoopParkedResumeTests</c> (visible parked-resume
+    /// handoff, #1211/#1212).
     /// </remarks>
     [Theory]
     [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]


### PR DESCRIPTION
## Epic #1215 — reliable tests

All four known offenders fixed at the product level. No timeout bumps, no quarantines — every formerly-flaky test is now deterministic and stays in the default suite.

Closes #1211
Closes #1212
Closes #1213
Closes #1214
Closes #1215

## Root cause of the flake class (#1211/#1212/#1213)

The interpreter's loop thread runs `InterpreterSynchronizationContext`, and .NET refuses to inline `ConfigureAwait(false)` continuations on a thread with a non-default sync context (`AwaitTaskContinuation.IsValidLocationForInlining`) — it dispatches them to the **thread pool**. Every parked stream read (stream-module async-iterator `next()`, web-stream async iterator, pipeTo pump read) resumed through such a hop, **invisible** to `RunEventLoopCore`'s exit check (no active handles + empty callback queue — no grace window at all).

So a producer that settled the parked read and dropped the last timer handle in the same tick — `setInterval`'s final `push(null); clearInterval(t)` (#1211), a one-shot `setTimeout` whose ref releases when its callback returns (#1212) — raced the pool dispatch against the exit check. Under CI thread-pool pressure the loop exited first: the silent `Expected "10,20,30" / Actual ""` signature. #1213's abort-teardown output ordering flaked by the same mechanism (its teardown Ref from #325 was necessary but not sufficient).

## The fix

- **Remove every `ConfigureAwait(false)` from the stream runtime types** (`WebStreamsHelpers`, `SharpTSReadableAsyncIterator`, `SharpTSReadableStreamAsyncIterator` — the only occurrences in all of `Runtime/`). Resumes now ride the sync context: `TrySetResult` posts them into the callback queue **synchronously inside the settle**, so there is no observable window — a structural fix, not a race-shrink. Works from any settling thread.
- **`ReadInternal`'s parked TCS → `RunContinuationsAsynchronously`**: with sync-context awaiters, a same-context settle would otherwise inline the consumer inside the producer's `enqueue()` — reentrancy the streams spec forbids.
- Side benefit: pump bodies and guest `write()`/`abort()`/`cancel()` callbacks now always execute on the loop thread; previously they ran on pool threads (a latent environment race).
- The `#325` scoped teardown Ref is kept (still correct for the teardown's guest-promise awaits).

## Deterministic verification (per the #319/#320 technique — both directions)

New seam `SHARPTS_TEST_STREAM_PARKED_RESUME_DELAY_MS` (`EventLoopTestHooks`) stalls each parked resume *synchronously* inside the formerly-invisible window (an awaited `Task.Delay` would itself be invisible in-flight work and re-create the bug under test). New guards in `EventLoopParkedResumeTests` cover all three park points:

| Guard (shape) | Pre-fix | Post-fix |
|---|---|---|
| Readable async iterator + setInterval producer (#1211) | fails 100%, output `""` | passes |
| pipeTo pump + setTimeout push source (#1212) | fails 100%, output `""` | passes |
| Web-stream async iterator + timer producer | fails 100%, output `""` | passes |

`ReadableStream_PipeTo_AbortSignalCancelsSourceAndAbortsDest` (#1213) is now deterministic end-to-end — its self-documented load-flaky remark is rewritten; the formerly-flaky trio passed 15/15 consecutive stress runs.

## #1214 — env-sensitive `ProjectStructureTests`

Discovery now skips any path containing a dot-directory segment — mirroring the SDK's `DefaultItemExcludes` (`**/.*/**`), i.e. exactly what the compiler's default glob would never include — plus `bin`/`obj` at any depth. Verified against a synthetic `.perf-probe-test/` csproj (red before, green after), and the test now passes from inside an agent worktree.

## Policy (small, durable)

- CI filter extended to `Category!=LiveNetwork&Category!=LoadSensitive` — the opt-in quarantine lane for future inherently-timing-dependent tests. No test currently carries the tag; everything known was fixed for real.
- `fail-fast: false` was already present in the matrix (#495 suggestion 4) — verified, not redone.
- Still unpinned: the one "fs callback under load" flake from epic #1078 validation (exact test name never recorded). It may well have been this same pool-hop class; to be filed if ever re-observed.

## Validation

- xUnit full suite: **15,243 / 15,243** (first fully-clean run from inside a worktree — no env flakes)
- Test262: **22 passed / 0 failed / 4 skipped** (baseline-identical, interp + compiled)
- TS-conformance: **31 / 31** (baseline-identical)