### PR TITLE
fix(interp): #1210 execute lazily-reached module deps in BindModuleImports

### DIFF
--- a/Execution/Interpreter.cs
+++ b/Execution/Interpreter.cs
@@ -1915,21 +1915,18 @@ public partial class Interpreter : IDisposable
                 string importedPath = _moduleResolver!.ResolveModulePath(import.ModulePath, module.Path);
                 var importedModuleInstance = _loadedModules.GetValueOrDefault(importedPath);
 
-                // CJS modules are lazy-initialized — ESM imports of CJS need to trigger init now
-                // because BindModuleImports runs BEFORE the body executes (so we can't rely on a
-                // later require() call to set things up).
+                // Lazily-reached dependency: the static InterpretModules order only executes
+                // modules it was handed up front, so anything first reached at runtime — a CJS
+                // require() of a stdlib facade (whose primitive:* imports were loaded but never
+                // executed, #1210), a dynamically imported subtree, or an ESM import of a
+                // lazy-initialized CJS module — must be executed on demand here, BEFORE the
+                // importer's body runs. ExecuteModule routes every module kind (CJS, dotnet:,
+                // builtin:/primitive: placeholders, plain ESM) and registers the instance
+                // before binding its own imports, so circular graphs terminate.
                 if (importedModuleInstance == null)
                 {
                     var importedParsed = _moduleResolver.GetCachedModule(importedPath);
-                    if (importedParsed?.IsCommonJs == true)
-                    {
-                        ExecuteCommonJsModule(importedParsed);
-                        importedModuleInstance = _loadedModules.GetValueOrDefault(importedPath);
-                    }
-                    // dotnet: modules are dependency-free and idempotent — execute on demand.
-                    // Covers modules reached outside the static InterpretModules order
-                    // (e.g. a dynamically imported file that itself imports a dotnet: module).
-                    else if (importedParsed?.IsDotNetModule == true)
+                    if (importedParsed != null)
                     {
                         ExecuteModule(importedParsed);
                         importedModuleInstance = _loadedModules.GetValueOrDefault(importedPath);

--- a/SharpTS.Tests/SharedTests/BuiltInModules/CjsBuiltInModuleRequireTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/CjsBuiltInModuleRequireTests.cs
@@ -126,4 +126,63 @@ public class CjsBuiltInModuleRequireTests
         var output = TestHarness.RunModules(files, "main.cjs", mode);
         Assert.Equal("function\n1\n2\n", output);
     }
+
+    /// <summary>
+    /// Regression (#1210): require() of a stdlib facade with primitive:* imports from an ESM
+    /// entry, without any ESM import of that module anywhere in the program.
+    /// </summary>
+    /// <remarks>
+    /// A CJS entry pre-loads its require() graph via CollectCjsRequireDependencies, so the
+    /// facade's primitive deps get executed by the static InterpretModules walk — which is why
+    /// the main.cjs tests above never hit this. An ESM entry's require() is fully lazy: the
+    /// facade loads, but its `import ... from 'primitive:fs'` used to fail with
+    /// "Module 'primitive:fs' not loaded" because BindModuleImports only lazy-initialized CJS
+    /// and dotnet: deps. Interpreter-only: compiled mode has a separate pre-existing gap
+    /// (facades reached only via require() from ESM files are never bundled into the assembly).
+    /// </remarks>
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void Cjs_Require_PrimitiveSeamFacade_FromEsmEntry(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import * as path from 'path';
+                const fs = require('fs');
+                console.log(typeof fs.existsSync);
+                const zlib = require('zlib');
+                console.log(zlib.gunzipSync(zlib.gzipSync('roundtrip')).toString());
+                const os = require('os');
+                console.log(typeof os.platform);
+                console.log(typeof path.join);
+                """
+        };
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("function\nroundtrip\nfunction\nfunction\n", output);
+    }
+
+    /// <summary>
+    /// Regression (#1210): dynamic import() of a stdlib facade never statically imported hits
+    /// the same lazy path — the facade's primitive:* deps must execute on demand.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void DynamicImport_PrimitiveSeamFacade_WithoutStaticImport(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import * as path from 'path';
+                async function run(): Promise<void> {
+                    const fs = await import('fs');
+                    console.log(typeof fs.existsSync);
+                    const zlib = await import('zlib');
+                    console.log(zlib.gunzipSync(zlib.gzipSync('dyn')).toString());
+                }
+                run();
+                """
+        };
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("function\ndyn\n", output);
+    }
 }


### PR DESCRIPTION
Closes #1210

## Problem

`require('fs')` (or `require('zlib')`, `require('os')`, … — any stdlib facade with `primitive:*` imports) in a program with **no ESM import of that module anywhere** failed in the interpreter:

```
Runtime Error: Module 'primitive:fs' not loaded.
```

The lazy CJS `require()` path (`RequireCommonJsModule`) loads the facade's full parse graph correctly — `LoadStdlibModule` recursively caches the `primitive:*` placeholder modules — but nothing ever *executes* those dependencies. Execution normally happens in the static `InterpretModules` topological walk, which never saw them. When the facade's body binds `import ... from 'primitive:fs'`, `BindModuleImports` found no instance and threw; its lazy-init fallback only covered CJS and `dotnet:` dependencies.

Dynamic `import()` of a facade never statically imported hit the exact same gap.

## Fix

Generalize the `BindModuleImports` fallback: any dependency that is cached in the resolver but not yet executed is executed on demand via `ExecuteModule`, which already routes every module kind (CJS → `ExecuteCommonJsModule`, `dotnet:`, `builtin:`/`primitive:` placeholders, plain ESM) and registers the instance **before** binding its own imports, so circular graphs terminate. For the previously-working kinds this is behavior-identical; for everything else the old behavior was a hard error, so no working program changes.

Verified by hand for the issue's full scope list: `fs`, `fs/promises`, `os`, `process`, `timers`, `timers/promises`, `readline`, `perf_hooks`, `tty`, `async_hooks`, `zlib`, plus `path` (its `primitive:process` usage was flagged "worth checking") — all via bare `require()` and via dynamic `import()`.

## Tests

Two interpreter-mode regression tests in `CjsBuiltInModuleRequireTests` (ESM entry + `require()` of primitive-seamed facades; dynamic `import()` variant). Interpreter-only because compiled mode has a separate pre-existing gap — filed as #1217 (facades reached only via `require()` from ESM files are never bundled into the assembly; the CJS require-literal walk doesn't cover ESM bodies).

Also found while verifying, filed separately: #1218 — any CLI import of `url` fails type-check with `Cannot assign type 'true' to variable 'found' of type 'false'` (pre-existing, harness type-check path doesn't hit it).

## Verification

- xUnit: 15244/15245 — the 1 failure is the pre-existing load-sensitive `ProcessLifecycleTests.Process_UnhandledRejection_And_RejectionHandled` ordering flake; passes in isolation and with its full class (17/17)
- Test262: 22 passed / 0 failed / 4 skipped (baseline-identical)
- TypeScriptConformance: 31/0