### PR TITLE
feat(types): #1207 real bigint literal types (TypeInfo.BigIntLiteral)

### DIFF
--- a/Compilation/DeadCodeAnalyzer.cs
+++ b/Compilation/DeadCodeAnalyzer.cs
@@ -203,9 +203,14 @@ public class DeadCodeAnalyzer
         // Check for exhaustive switch on union types
         if (subjectType is TypeInfo.Union union)
         {
+            // Bigint case values get an "n" suffix so `case 1n:` and `case 1:` stay distinct keys.
             var coveredTypes = sw.Cases
                 .Where(c => c.Value is Expr.Literal)
-                .Select(c => ((Expr.Literal)c.Value).Value?.ToString() ?? "null")
+                .Select(c => ((Expr.Literal)c.Value).Value switch
+                {
+                    System.Numerics.BigInteger bi => bi + "n",
+                    var v => v?.ToString() ?? "null"
+                })
                 .ToHashSet();
 
             bool allCovered = union.FlattenedTypes.All(t => t switch
@@ -213,6 +218,7 @@ public class DeadCodeAnalyzer
                 TypeInfo.StringLiteral sl => coveredTypes.Contains(sl.Value),
                 TypeInfo.NumberLiteral nl => coveredTypes.Contains(nl.Value.ToString()),
                 TypeInfo.BooleanLiteral bl => coveredTypes.Contains(bl.Value.ToString()),
+                TypeInfo.BigIntLiteral bil => coveredTypes.Contains(bil.Value + "n"),
                 TypeInfo.Null => coveredTypes.Contains("null"),
                 _ => false
             });
@@ -411,6 +417,7 @@ public class DeadCodeAnalyzer
         "string" => type is TypeInfo.String or TypeInfo.StringLiteral,
         "number" => type is TypeInfo.Primitive { Type: TokenType.TYPE_NUMBER } or TypeInfo.NumberLiteral,
         "boolean" => type is TypeInfo.Primitive { Type: TokenType.TYPE_BOOLEAN } or TypeInfo.BooleanLiteral,
+        "bigint" => type is TypeInfo.BigInt or TypeInfo.BigIntLiteral,
         "object" => type is TypeInfo.Null or TypeInfo.Record or TypeInfo.Array or TypeInfo.Instance,
         "function" => type is TypeInfo.Function,
         "undefined" => false, // SharpTS doesn't have undefined as a type

--- a/Compilation/ILEmitter.Calls.MethodDispatch.cs
+++ b/Compilation/ILEmitter.Calls.MethodDispatch.cs
@@ -198,7 +198,7 @@ public partial class ILEmitter
         // so route toString/valueOf/toLocaleString to dedicated runtime helpers —
         // critically so `toString(radix)` honors the radix instead of falling through
         // to BigInteger.ToString() (which ignores the argument).
-        if (objType is TypeSystem.TypeInfo.BigInt && methodName is "toString" or "toLocaleString" or "valueOf")
+        if (objType is TypeSystem.TypeInfo.BigInt or TypeSystem.TypeInfo.BigIntLiteral && methodName is "toString" or "toLocaleString" or "valueOf")
         {
             EmitBigIntMethodCall(methodGet.Object, methodName, arguments);
             return;

--- a/Compilation/ILEmitter.Operators.cs
+++ b/Compilation/ILEmitter.Operators.cs
@@ -2001,21 +2001,22 @@ public partial class ILEmitter
         var leftType = _ctx.TypeMap.Get(b.Left);
         var rightType = _ctx.TypeMap.Get(b.Right);
 
-        return leftType is TypeInfo.BigInt || rightType is TypeInfo.BigInt;
+        return leftType is TypeInfo.BigInt or TypeInfo.BigIntLiteral
+            || rightType is TypeInfo.BigInt or TypeInfo.BigIntLiteral;
     }
 
     private bool IsBigIntExpr(Expr expr)
     {
         if (_ctx.TypeMap == null) return false;
         var type = _ctx.TypeMap.Get(expr);
-        return type is TypeInfo.BigInt;
+        return type is TypeInfo.BigInt or TypeInfo.BigIntLiteral;
     }
 
     private bool IsBothBigInt(Expr.Binary b)
     {
         if (_ctx.TypeMap == null) return false;
-        return _ctx.TypeMap.Get(b.Left) is TypeInfo.BigInt
-            && _ctx.TypeMap.Get(b.Right) is TypeInfo.BigInt;
+        return _ctx.TypeMap.Get(b.Left) is TypeInfo.BigInt or TypeInfo.BigIntLiteral
+            && _ctx.TypeMap.Get(b.Right) is TypeInfo.BigInt or TypeInfo.BigIntLiteral;
     }
 
     /// <summary>

--- a/Compilation/TypeMapper.cs
+++ b/Compilation/TypeMapper.cs
@@ -141,7 +141,7 @@ public class TypeMapper
     {
         TypeInfo.Primitive p => MapPrimitive(p),
         TypeInfo.String => _types.String, // String type maps to System.String
-        TypeInfo.BigInt => _types.BigInteger, // BigInt maps to BigInteger
+        TypeInfo.BigInt or TypeInfo.BigIntLiteral => _types.BigInteger, // BigInt maps to BigInteger
         TypeInfo.Array => _types.Object, // Will be TSArray at runtime
         TypeInfo.Function => _types.Object, // Will be delegate at runtime
         TypeInfo.Promise p => MapPromiseType(p), // Promise<T> maps to Task<T>
@@ -222,7 +222,7 @@ public class TypeMapper
         TypeInfo.StringLiteral => _types.String, // "foo" literal widens to string
         TypeInfo.NumberLiteral => _types.Double, // 42 literal widens to number
         TypeInfo.BooleanLiteral => _types.Boolean, // true/false literal widens to boolean
-        TypeInfo.BigInt => _types.BigInteger,
+        TypeInfo.BigInt or TypeInfo.BigIntLiteral => _types.BigInteger, // 1n literal widens to bigint
         TypeInfo.Array arr => MapArrayTypeStrict(arr),
         TypeInfo.Function => _types.Delegate, // Functions map to Delegate for typed interop
         TypeInfo.Promise p => MapPromiseTypeStrict(p),

--- a/SharpTS.Tests/SharedTests/BigIntTests.cs
+++ b/SharpTS.Tests/SharedTests/BigIntTests.cs
@@ -627,4 +627,75 @@ public class BigIntTests
     }
 
     #endregion
+
+    #region Bigint Literal Types (#1207)
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void BigInt_LiteralTypedOperands_UseBigintArithmetic(ExecutionMode mode)
+    {
+        // const-bound operands carry TypeInfo.BigIntLiteral in the type map; the
+        // compiled bigint-arithmetic detection must treat them as bigint, not fall
+        // through to the number path.
+        var source = """
+            const a = 2n;
+            const b = 3n;
+            console.log(a + b);
+            console.log((a * b).toString(2));
+            console.log(a < b);
+            """;
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("5n\n110\ntrue\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void BigInt_TypeofGuard_BranchSurvivesDeadCodeAnalysis(ExecutionMode mode)
+    {
+        // The compiled dead-code analyzer had no "bigint" arm in its typeof matcher,
+        // so `typeof x === "bigint"` on a bigint-typed variable read as never-true and
+        // the guarded branch was folded out of the emitted IL.
+        var source = """
+            let x = 5n;
+            if (typeof x === "bigint") { console.log("big"); } else { console.log("not"); }
+            const c = 7n;
+            if (typeof c === "bigint") { console.log("lit"); } else { console.log("not"); }
+            """;
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("big\nlit\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void BigInt_LiteralTypedReceiver_MethodCallWorks(ExecutionMode mode)
+    {
+        // toString(radix) on a BigIntLiteral-typed receiver must route through the
+        // bigint helper (which honors the radix), same as a bigint-typed one.
+        var source = """
+            const c = 255n;
+            console.log(c.toString(16));
+            console.log(c.toString());
+            """;
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("ff\n255\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void BigInt_LiteralUnionNarrowing_RunsCorrectBranch(ExecutionMode mode)
+    {
+        var source = """
+            function g(x: 1n | 2n | "z"): string {
+                if (x === 1n) {
+                    return "one";
+                }
+                return typeof x === "bigint" ? "two" : x;
+            }
+            console.log(g(1n), g(2n), g("z"));
+            """;
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("one two z\n", output);
+    }
+
+    #endregion
 }

--- a/SharpTS.Tests/TypeCheckerTests/BigIntLiteralTypeTests.cs
+++ b/SharpTS.Tests/TypeCheckerTests/BigIntLiteralTypeTests.cs
@@ -1,0 +1,216 @@
+using SharpTS.Tests.Infrastructure;
+using SharpTS.TypeSystem.Exceptions;
+using Xunit;
+
+namespace SharpTS.Tests.TypeCheckerTests;
+
+/// <summary>
+/// Bigint literal types (#1207): <c>type T = 1n</c> resolves to TypeInfo.BigIntLiteral with
+/// literal identity (1n vs 2n distinct), widening to bigint, tsc const/let widening rules,
+/// and typeof/equality/truthiness narrowing — mirroring number literal types throughout.
+/// Before #1207 these annotations resolved to <c>any</c> (string-scanner parity placeholder).
+/// </summary>
+public class BigIntLiteralTypeTests
+{
+    #region Annotation resolution + assignability
+
+    [Fact]
+    public void Annotation_AcceptsMatchingLiteral()
+    {
+        TestHarness.RunInterpreted("""
+            type One = 1n;
+            let a: One = 1n;
+            let u: 1n | 2n = 2n;
+            """);
+    }
+
+    [Fact]
+    public void Annotation_RejectsDifferentLiteral()
+    {
+        var ex = Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted("""
+            let x: 1n = 2n;
+            """));
+        Assert.Contains("'2n' is not assignable to type '1n'", ex.Message);
+    }
+
+    [Fact]
+    public void Literal_WidensToBigint()
+    {
+        TestHarness.RunInterpreted("""
+            let w: bigint = 1n;
+            function f(x: bigint): bigint { return x; }
+            f(42n);
+            """);
+    }
+
+    [Fact]
+    public void Bigint_NotAssignableToLiteral()
+    {
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted("""
+            let l = 1n; // let widens to bigint
+            let z: 1n = l;
+            """));
+    }
+
+    [Fact]
+    public void Union_RejectsNonMember()
+    {
+        var ex = Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted("""
+            let x: 1n | 2n = 3n;
+            """));
+        Assert.Contains("'3n' is not assignable to type '1n | 2n'", ex.Message);
+    }
+
+    [Fact]
+    public void NumberAndBigintLiterals_AreNotInterchangeable()
+    {
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted("""
+            let x: 1n = 1;
+            """));
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted("""
+            let y: 1 = 1n;
+            """));
+    }
+
+    #endregion
+
+    #region const/let widening
+
+    [Fact]
+    public void ConstKeepsLiteral_LetWidens()
+    {
+        TestHarness.RunInterpreted("""
+            const c = 1n;      // const x = 1n ⇒ 1n
+            const k: 1n = c;
+            let l = 1n;        // let x = 1n ⇒ bigint
+            l = 99n;
+            """);
+    }
+
+    [Fact]
+    public void ObjectLiteralMember_WidensToBigint()
+    {
+        // Freshness widening inside an object literal mirrors the number rule:
+        // const o = { v: 1n } ⇒ { v: bigint }, keeping o.v = 9n legal.
+        TestHarness.RunInterpreted("""
+            const o = { v: 1n };
+            o.v = 9n;
+            """);
+    }
+
+    #endregion
+
+    #region Narrowing
+
+    [Fact]
+    public void TypeofNarrowing_KeepsLiteralConstituents()
+    {
+        TestHarness.RunInterpreted("""
+            function f(x: 1n | 2n | string): string {
+                if (typeof x === "bigint") {
+                    const y: 1n | 2n = x;
+                    return (x * 2n).toString();
+                }
+                return x;
+            }
+            console.log(f(2n), f("s"));
+            """);
+    }
+
+    [Fact]
+    public void EqualityNarrowing_NarrowsLiteralUnion()
+    {
+        TestHarness.RunInterpreted("""
+            function g(x: 1n | 2n): string {
+                if (x === 1n) {
+                    const y: 1n = x;
+                    return "one";
+                }
+                const z: 2n = x;
+                return "two";
+            }
+            console.log(g(1n), g(2n));
+            """);
+    }
+
+    [Fact]
+    public void EqualityNarrowing_GeneralBigintNarrowsToLiteral()
+    {
+        TestHarness.RunInterpreted("""
+            function h(x: bigint | string): string {
+                if (x === 1n) {
+                    const y: 1n = x;
+                    return "one";
+                }
+                return "other";
+            }
+            console.log(h(1n), h("s"));
+            """);
+    }
+
+    [Fact]
+    public void TruthinessNarrowing_ZeroBigintIsFalsy()
+    {
+        TestHarness.RunInterpreted("""
+            function t(x: 0n | 1n): string {
+                if (x) {
+                    const y: 1n = x;
+                    return "one";
+                }
+                const z: 0n = x;
+                return "zero";
+            }
+            console.log(t(0n), t(1n));
+            """);
+    }
+
+    #endregion
+
+    #region Interactions
+
+    [Fact]
+    public void TemplateLiteralType_ExpandsBigintLiteralWithoutSuffix()
+    {
+        // `${1n}` stringifies as "1" (no 'n'), exactly like runtime template interpolation.
+        TestHarness.RunInterpreted("""
+            type V = `v${1n}`;
+            const v: V = "v1";
+            """);
+        Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted("""
+            type V = `v${1n}`;
+            const w: V = "v1n";
+            """));
+    }
+
+    [Fact]
+    public void ConstTypeParameter_PreservesBigintLiteral()
+    {
+        TestHarness.RunInterpreted("""
+            function id<const T>(x: T): T { return x; }
+            const r: 5n = id(5n);
+            """);
+    }
+
+    [Fact]
+    public void LiteralTypedValue_HasBigintMembers()
+    {
+        // Member lookup on a literal-typed receiver resolves through the bigint category.
+        TestHarness.RunInterpreted("""
+            const c = 255n;
+            const s: string = c.toString(16);
+            console.log(s);
+            """);
+    }
+
+    [Fact]
+    public void BigIntConstructor_AcceptsLiteralTypedArgument()
+    {
+        TestHarness.RunInterpreted("""
+            const c = 5n;
+            let b: bigint = BigInt(c);
+            console.log(b);
+            """);
+    }
+
+    #endregion
+}

--- a/SharpTS.Tests/TypeCheckerTests/TypeNodeSliceTests.cs
+++ b/SharpTS.Tests/TypeCheckerTests/TypeNodeSliceTests.cs
@@ -30,9 +30,8 @@ public class TypeNodeSliceTests
     [Fact]
     public void NodePath_EngagesForBigintLiteralType()
     {
-        // Bigint literal types (1n) now carry a node. Resolution keeps parity with the string
-        // path, which had no bigint handling and let "1n" fall through its unknown-name tail to
-        // any — so the annotation resolves (node-first) without constraining the value.
+        // Bigint literal types (1n) carry a node and resolve to TypeInfo.BigIntLiteral (#1207);
+        // BigIntLiteralTypeTests pins the semantics — here we only pin the node path engaging.
         TypeNodeStats.Reset();
         TestHarness.RunInterpreted("""
             let x: 1n;

--- a/TypeSystem/TypeCategoryResolver.cs
+++ b/TypeSystem/TypeCategoryResolver.cs
@@ -20,7 +20,7 @@ public static class TypeCategoryResolver
         TypeInfo.NumberLiteral => TypeCategory.Number,
         TypeInfo.Primitive p when p.Type == TokenType.TYPE_BOOLEAN => TypeCategory.Boolean,
         TypeInfo.BooleanLiteral => TypeCategory.Boolean,
-        TypeInfo.BigInt => TypeCategory.BigInt,
+        TypeInfo.BigInt or TypeInfo.BigIntLiteral => TypeCategory.BigInt,
         TypeInfo.Symbol or TypeInfo.UniqueSymbol => TypeCategory.Symbol,
 
         // Built-in object types

--- a/TypeSystem/TypeChecker.Calls.cs
+++ b/TypeSystem/TypeChecker.Calls.cs
@@ -54,7 +54,7 @@ public partial class TypeChecker
                 throw new TypeCheckException("BigInt() requires exactly one argument.", tsCode: "TS2554");
             }
             var argType = CheckExpr(call.Arguments[0]);
-            if (!IsNumber(argType) && !IsString(argType) && argType is not TypeInfo.BigInt && argType is not TypeInfo.Any)
+            if (!IsNumber(argType) && !IsString(argType) && !IsBigInt(argType) && argType is not TypeInfo.Any)
             {
                 throw new TypeCheckException($"BigInt() argument must be a number, string, or bigint, got '{argType}'.", tsCode: "TS2345");
             }

--- a/TypeSystem/TypeChecker.Compatibility.DiscriminatedUnion.cs
+++ b/TypeSystem/TypeChecker.Compatibility.DiscriminatedUnion.cs
@@ -182,7 +182,7 @@ public partial class TypeChecker
             switch (t)
             {
                 case TypeInfo.StringLiteral or TypeInfo.NumberLiteral or TypeInfo.BooleanLiteral
-                    or TypeInfo.Undefined or TypeInfo.Null:
+                    or TypeInfo.BigIntLiteral or TypeInfo.Undefined or TypeInfo.Null:
                     result.Add(t);
                     break;
                 case TypeInfo.Primitive { Type: Parsing.TokenType.TYPE_BOOLEAN }:

--- a/TypeSystem/TypeChecker.Compatibility.Helpers.cs
+++ b/TypeSystem/TypeChecker.Compatibility.Helpers.cs
@@ -33,12 +33,12 @@ public partial class TypeChecker
             type is TypeInfo.StringLiteral);
 
     private bool IsBigInt(TypeInfo t) =>
-        IsTypeOfKind(t, type => type is TypeInfo.BigInt);
+        IsTypeOfKind(t, type => type is TypeInfo.BigInt or TypeInfo.BigIntLiteral);
 
     /// <summary>
     /// Checks if a type is a primitive (not valid as WeakMap key or WeakSet value).
     /// </summary>
-    private bool IsPrimitiveType(TypeInfo t) => t is TypeInfo.String or TypeInfo.Primitive or TypeInfo.StringLiteral or TypeInfo.NumberLiteral or TypeInfo.BooleanLiteral or TypeInfo.BigInt or TypeInfo.Symbol or TypeInfo.UniqueSymbol;
+    private bool IsPrimitiveType(TypeInfo t) => t is TypeInfo.String or TypeInfo.Primitive or TypeInfo.StringLiteral or TypeInfo.NumberLiteral or TypeInfo.BooleanLiteral or TypeInfo.BigInt or TypeInfo.BigIntLiteral or TypeInfo.Symbol or TypeInfo.UniqueSymbol;
 
     /// <summary>
     /// Checks if a type is an object type (has properties that could be mutated).

--- a/TypeSystem/TypeChecker.Compatibility.TemplateLiterals.cs
+++ b/TypeSystem/TypeChecker.Compatibility.TemplateLiterals.cs
@@ -80,8 +80,11 @@ public partial class TypeChecker
         TypeInfo.StringLiteral sl => sl.Value == value,
         TypeInfo.NumberLiteral nl => double.TryParse(value, out var d) && d == nl.Value,
         TypeInfo.BooleanLiteral bl => (bl.Value ? "true" : "false") == value,
+        // Bigint values stringify without the 'n' suffix: `${1n}` is "1".
+        TypeInfo.BigIntLiteral bil => System.Numerics.BigInteger.TryParse(value, out var bi) && bi == bil.Value,
         TypeInfo.Primitive { Type: TokenType.TYPE_NUMBER } => double.TryParse(value, out _),
         TypeInfo.Primitive { Type: TokenType.TYPE_BOOLEAN } => value is "true" or "false",
+        TypeInfo.BigInt => System.Numerics.BigInteger.TryParse(value, out _),
         TypeInfo.Union u => u.FlattenedTypes.Any(t => MatchesInterpolatedType(value, t)),
         _ => false
     };

--- a/TypeSystem/TypeChecker.Compatibility.TypeGuards.cs
+++ b/TypeSystem/TypeChecker.Compatibility.TypeGuards.cs
@@ -527,7 +527,7 @@ public partial class TypeChecker
     /// <summary>
     /// Maps a literal AST value to its literal type for equality narrowing.
     /// Returns null for values that don't participate (null/undefined have their
-    /// own guard patterns; bigint literals don't form literal types here).
+    /// own guard patterns).
     /// </summary>
     private static TypeInfo? LiteralTypeFor(object? value) => value switch
     {
@@ -535,6 +535,7 @@ public partial class TypeChecker
         int i => new TypeInfo.NumberLiteral(i),
         double d => new TypeInfo.NumberLiteral(d),
         bool b => new TypeInfo.BooleanLiteral(b),
+        System.Numerics.BigInteger bi => new TypeInfo.BigIntLiteral(bi),
         _ => null
     };
 
@@ -556,6 +557,7 @@ public partial class TypeChecker
             TypeInfo.String => literal is TypeInfo.StringLiteral,
             TypeInfo.Primitive { Type: TokenType.TYPE_NUMBER } => literal is TypeInfo.NumberLiteral,
             TypeInfo.Primitive { Type: TokenType.TYPE_BOOLEAN } => literal is TypeInfo.BooleanLiteral,
+            TypeInfo.BigInt => literal is TypeInfo.BigIntLiteral,
             _ => false
         };
 
@@ -601,7 +603,8 @@ public partial class TypeChecker
         // A different literal of the same kind can never equal it.
         if (currentType is TypeInfo.StringLiteral && literalType is TypeInfo.StringLiteral ||
             currentType is TypeInfo.NumberLiteral && literalType is TypeInfo.NumberLiteral ||
-            currentType is TypeInfo.BooleanLiteral && literalType is TypeInfo.BooleanLiteral)
+            currentType is TypeInfo.BooleanLiteral && literalType is TypeInfo.BooleanLiteral ||
+            currentType is TypeInfo.BigIntLiteral && literalType is TypeInfo.BigIntLiteral)
         {
             if (negated)
                 return (varName, currentType, new TypeInfo.Never());
@@ -1319,6 +1322,7 @@ public partial class TypeChecker
         TypeInfo.BooleanLiteral { Value: false } => true,
         TypeInfo.NumberLiteral n => n.Value == 0,            // 0 and -0 (NaN literals don't occur)
         TypeInfo.StringLiteral s => s.Value.Length == 0,
+        TypeInfo.BigIntLiteral b => b.Value.IsZero,
         _ => false
     };
 
@@ -1335,6 +1339,7 @@ public partial class TypeChecker
         TypeInfo.BooleanLiteral { Value: true } => true,
         TypeInfo.NumberLiteral n => n.Value != 0 && !double.IsNaN(n.Value),
         TypeInfo.StringLiteral s => s.Value.Length > 0,
+        TypeInfo.BigIntLiteral b => !b.Value.IsZero,
         // Object-like types are truthy regardless of contents (even empty arrays/objects/`{}`).
         TypeInfo.Object or TypeInfo.Record or TypeInfo.Array or TypeInfo.Tuple or
         TypeInfo.Instance or TypeInfo.Class or TypeInfo.MutableClass or TypeInfo.Interface or
@@ -1357,7 +1362,7 @@ public partial class TypeChecker
         "string" => type is TypeInfo.String or TypeInfo.StringLiteral,
         "number" => type is TypeInfo.Primitive { Type: TokenType.TYPE_NUMBER } or TypeInfo.NumberLiteral,
         "boolean" => type is TypeInfo.Primitive { Type: TokenType.TYPE_BOOLEAN } or TypeInfo.BooleanLiteral,
-        "bigint" => type is TypeInfo.BigInt,
+        "bigint" => type is TypeInfo.BigInt or TypeInfo.BigIntLiteral,
         "object" => type is TypeInfo.Null or TypeInfo.Record or TypeInfo.Array or TypeInfo.Instance or TypeInfo.Object,
         "function" => type is TypeInfo.Function,
         _ => false

--- a/TypeSystem/TypeChecker.Compatibility.cs
+++ b/TypeSystem/TypeChecker.Compatibility.cs
@@ -364,6 +364,7 @@ public partial class TypeChecker
         TypeInfo.StringLiteral sl => $"\"{sl.Value}\"",
         TypeInfo.NumberLiteral nl => nl.Value.ToString(),
         TypeInfo.BooleanLiteral bl => bl.Value ? "true" : "false",
+        TypeInfo.BigIntLiteral bil => $"{bil.Value}n",
         TypeInfo.Array arr => $"{TypeInfoToString(arr.ElementType)}[]",
         TypeInfo.Union u => string.Join(" | ", u.FlattenedTypes.Select(TypeInfoToString)),
         TypeInfo.Intersection i => string.Join(" & ", i.FlattenedTypes.Select(TypeInfoToString)),
@@ -618,6 +619,8 @@ public partial class TypeChecker
             return nl1.Value == nl2.Value;
         if (expected is TypeInfo.BooleanLiteral bl1 && actual is TypeInfo.BooleanLiteral bl2)
             return bl1.Value == bl2.Value;
+        if (expected is TypeInfo.BigIntLiteral bil1 && actual is TypeInfo.BigIntLiteral bil2)
+            return bil1.Value == bil2.Value;
 
         // Literal to primitive widening
         if (expected is TypeInfo.String && actual is TypeInfo.StringLiteral)
@@ -625,6 +628,8 @@ public partial class TypeChecker
         if (expected is TypeInfo.Primitive { Type: TokenType.TYPE_NUMBER } && actual is TypeInfo.NumberLiteral)
             return true;
         if (expected is TypeInfo.Primitive { Type: TokenType.TYPE_BOOLEAN } && actual is TypeInfo.BooleanLiteral)
+            return true;
+        if (expected is TypeInfo.BigInt && actual is TypeInfo.BigIntLiteral)
             return true;
 
         // Template literal type compatibility

--- a/TypeSystem/TypeChecker.Expressions.cs
+++ b/TypeSystem/TypeChecker.Expressions.cs
@@ -877,6 +877,7 @@ public partial class TypeChecker
             TypeInfo.NumberLiteral => new TypeInfo.Primitive(TokenType.TYPE_NUMBER),
             TypeInfo.StringLiteral => new TypeInfo.String(),
             TypeInfo.BooleanLiteral => new TypeInfo.Primitive(TokenType.TYPE_BOOLEAN),
+            TypeInfo.BigIntLiteral => new TypeInfo.BigInt(),
             TypeInfo.Union u => new TypeInfo.Union(u.FlattenedTypes.Select(WidenLiteralType).ToList()),
             // `as const` (and other readonly) arrays/tuples/records keep their literal element/member
             // types — readonly literal types are never widened (#493). Without this, an `as const`
@@ -1822,7 +1823,7 @@ public partial class TypeChecker
         if (value is double d) return new TypeInfo.NumberLiteral(d);
         if (value is string s) return new TypeInfo.StringLiteral(s);
         if (value is bool b) return new TypeInfo.BooleanLiteral(b);
-        if (value is System.Numerics.BigInteger) return new TypeInfo.BigInt();
+        if (value is System.Numerics.BigInteger bi) return new TypeInfo.BigIntLiteral(bi);
         return new TypeInfo.Void();
     }
 

--- a/TypeSystem/TypeChecker.Generics.Inference.cs
+++ b/TypeSystem/TypeChecker.Generics.Inference.cs
@@ -92,7 +92,7 @@ public partial class TypeChecker
     private TypeInfo InferConstLiteralType(TypeInfo argType)
     {
         // Already literal? Keep it
-        if (argType is TypeInfo.StringLiteral or TypeInfo.NumberLiteral or TypeInfo.BooleanLiteral)
+        if (argType is TypeInfo.StringLiteral or TypeInfo.NumberLiteral or TypeInfo.BooleanLiteral or TypeInfo.BigIntLiteral)
             return argType;
 
         // Tuple: preserve element literal types + mark readonly

--- a/TypeSystem/TypeChecker.TypeNodes.cs
+++ b/TypeSystem/TypeChecker.TypeNodes.cs
@@ -52,10 +52,7 @@ public partial class TypeChecker
                     string str => new TypeInfo.StringLiteral(str),
                     double num => new TypeInfo.NumberLiteral(num),
                     bool b => new TypeInfo.BooleanLiteral(b),
-                    // Bigint literal types (1n): parity with the string path, which has no bigint
-                    // handling and lets "1n" fall through its unknown-name tail to Any. Real
-                    // bigint literal types need TypeInfo.BigIntLiteral + compat rules (follow-up).
-                    System.Numerics.BigInteger => new TypeInfo.Any(),
+                    System.Numerics.BigInteger bi => new TypeInfo.BigIntLiteral(bi),
                     _ => null,
                 };
 

--- a/TypeSystem/TypeChecker.TypeParsing.cs
+++ b/TypeSystem/TypeChecker.TypeParsing.cs
@@ -276,7 +276,7 @@ public partial class TypeChecker
         bool hasNull = types.Any(t => t is TypeInfo.Null);
         bool hasUndefined = types.Any(t => t is TypeInfo.Undefined);
         bool hasSymbol = types.Any(t => t is TypeInfo.Symbol);
-        bool hasBigInt = types.Any(t => t is TypeInfo.BigInt);
+        bool hasBigInt = types.Any(t => t is TypeInfo.BigInt or TypeInfo.BigIntLiteral);
 
         // Count how many different primitive categories are present
         int primitiveCount = (hasString ? 1 : 0) + (hasNumber ? 1 : 0) + (hasBoolean ? 1 : 0)
@@ -422,6 +422,7 @@ public partial class TypeChecker
         TypeInfo.StringLiteral => true,
         TypeInfo.NumberLiteral => true,  // Numbers can be stringified
         TypeInfo.BooleanLiteral => true,  // Booleans can be stringified
+        TypeInfo.BigIntLiteral => true,  // Bigints stringify without the 'n' suffix
         TypeInfo.Union u => u.FlattenedTypes.All(IsConcreteStringType),
         _ => false
     };
@@ -460,6 +461,7 @@ public partial class TypeChecker
         TypeInfo.StringLiteral sl => [sl.Value],
         TypeInfo.NumberLiteral nl => [nl.Value.ToString()],
         TypeInfo.BooleanLiteral bl => [bl.Value ? "true" : "false"],
+        TypeInfo.BigIntLiteral bil => [bil.Value.ToString()],  // `${1n}` is "1" — no 'n' suffix
         TypeInfo.Union u => u.FlattenedTypes.SelectMany(GetStringLiteralValues).ToList(),
         _ => throw new InvalidOperationException($"Expected concrete string type, got {type}")
     };

--- a/TypeSystem/TypeInfo.cs
+++ b/TypeSystem/TypeInfo.cs
@@ -1209,6 +1209,15 @@ public abstract record TypeInfo
     }
 
     /// <summary>
+    /// A bigint literal type (<c>1n</c>). Distinct literal values are distinct types
+    /// (<c>1n</c> vs <c>2n</c>); widens to <see cref="BigInt"/>.
+    /// </summary>
+    public record BigIntLiteral(System.Numerics.BigInteger Value) : TypeInfo
+    {
+        public override string ToString() => $"{Value}n";
+    }
+
+    /// <summary>
     /// Represents a template literal type pattern: `prefix${Type}suffix`
     /// </summary>
     /// <param name="Strings">Static string parts (n+1 elements for n interpolations)</param>

--- a/TypeSystem/WorkerDataValidator.cs
+++ b/TypeSystem/WorkerDataValidator.cs
@@ -66,6 +66,7 @@ public static class WorkerDataValidator
             TypeInfo.BooleanLiteral => (true, null),
             TypeInfo.String => (true, null),
             TypeInfo.BigInt => (true, null),
+            TypeInfo.BigIntLiteral => (true, null),
             TypeInfo.Null => (true, null),
             TypeInfo.Undefined => (true, null),
             TypeInfo.Any => (true, null), // any could be anything, allow it (runtime will catch)


### PR DESCRIPTION
Closes #1207

Bigint literal type annotations (`type T = 1n`, `let x: 1n | 2n`) previously resolved to `any` — the string-scanner parity placeholder left by #1111/PR #1206. This PR gives them real semantics via `TypeInfo.BigIntLiteral(BigInteger)`, mirroring number literal types at every consumer.

## Checker
- **Resolution**: the `LiteralTypeNode` BigInteger arm now produces `BigIntLiteral` (the parser already delivered the value); expressions `1n` infer as `BigIntLiteral` via `GetLiteralType`
- **Assignability**: literal-to-literal by value (`1n` vs `2n` distinct), `1n → bigint` widening, union membership; diagnostics render with the `n` suffix (`Type '3n' is not assignable to type '1n | 2n'`)
- **Widening**: `const x = 1n` keeps `1n`; `let x = 1n` and fresh object-literal members widen to `bigint` (`WidenLiteralType`)
- **Narrowing**: `typeof x === "bigint"` keeps literal constituents; literal equality guards narrow unions and general `bigint`; `0n` falsy / non-`0n` truthy; distinct-literal `===` narrows to `never`
- **Interactions**: discriminated-union unit constituents, `const` type parameters, intersection primitive-conflict detection, `IsBigInt`/`IsPrimitiveType`, `BigInt()` argument check, structured-clone validation
- **Template literal types**: `` `v${1n}` `` expands to `"v1"` — no `n` suffix, matching runtime stringification

## Compiled mode
- Bigint arithmetic detection (`IsBigIntOperation`/`IsBigIntExpr`/`IsBothBigInt`), bigint method dispatch (`toString(radix)`), `TypeMapper → BigInteger`, and switch-exhaustiveness coverage (with `n`-suffixed keys so `case 1n:` and `case 1:` stay distinct) all treat `BigIntLiteral` as bigint
- **Fixes a pre-existing compiled bug (verified firsthand)**: `DeadCodeAnalyzer.TypeMatchesTypeof` had no `"bigint"` arm, so it returned "never matches" and `if (typeof x === "bigint")` on a statically-known bigint **folded the guarded branch out of the emitted IL** (the else branch ran). Pinned by `BigInt_TypeofGuard_BranchSurvivesDeadCodeAnalysis`.

## Tests
- New `TypeCheckerTests/BigIntLiteralTypeTests.cs` (16 tests: resolution, assignability, const/let widening, typeof/equality/truthiness narrowing, template expansion, const type params, member lookup)
- 4 new dual-mode theories in `SharedTests/BigIntTests.cs` (literal-typed arithmetic, dead-code guard survival, `toString(radix)` dispatch, union narrowing)

## Verification
- xUnit: **15267/0**
- Test262: **22/0/4skip** — baseline-identical interp+compiled. (An initial battery run under load showed 2 `Fail → Timeout` flips on the pathological `Array/prototype/lastIndexOf` 2^32-length tests — investigated, confirmed load-induced and bigint-unrelated, green on idle rerun.)
- TSConf: **31/0** baseline-identical
- Compiled smoke scripts pass `--verify` IL verification