### PR TITLE
fix(compile): #1201 lift captured top-level block-scoped vars onto the entry-point display class

### DIFF
--- a/Compilation/CompilationContext.Closures.cs
+++ b/Compilation/CompilationContext.Closures.cs
@@ -119,6 +119,15 @@ public partial class CompilationContext
     public HashSet<string>? CapturedTopLevelVars { get; set; }
 
     /// <summary>
+    /// #1201: names of top-level BLOCK-scoped let/const bindings lifted onto the entry-point
+    /// display class for this module (subset of <see cref="CapturedTopLevelVars"/>). The
+    /// declaration emitter routes these to their DC field even though they sit in a nested
+    /// scope — every lifted name is declared exactly once in the module, so the name-keyed
+    /// check cannot collide with a shadowing declaration.
+    /// </summary>
+    public HashSet<string>? LiftedBlockScopedTopLevelVars { get; set; }
+
+    /// <summary>
     /// Maps arrow functions to their $entryPointDC field (if they capture top-level vars).
     /// Used when creating capturing arrows to populate the reference to the entry-point display class.
     /// </summary>

--- a/Compilation/ILCompiler.Functions.cs
+++ b/Compilation/ILCompiler.Functions.cs
@@ -1050,6 +1050,7 @@ public partial class ILCompiler
             EntryPointDisplayClassCtor = _closures.EntryPointDisplayClassCtor,
             EntryPointDisplayClassFields = BuildEntryPointDisplayClassFieldsForModule(_modules.CurrentPath),
             CapturedTopLevelVars = BuildCapturedTopLevelVarsForModule(_modules.CurrentPath),
+            LiftedBlockScopedTopLevelVars = BuildLiftedBlockScopedTopLevelVarsForModule(_modules.CurrentPath),
             ArrowEntryPointDCFields = _closures.ArrowEntryPointDCFields.Count > 0 ? _closures.ArrowEntryPointDCFields : null,
             EntryPointDisplayClassStaticField = _closures.EntryPointDisplayClassStaticField,
             // Program type for GetMethodFromHandle resolution
@@ -1228,6 +1229,7 @@ public partial class ILCompiler
             EntryPointDisplayClassCtor = _closures.EntryPointDisplayClassCtor,
             EntryPointDisplayClassFields = BuildEntryPointDisplayClassFieldsForModule(_modules.CurrentPath),
             CapturedTopLevelVars = BuildCapturedTopLevelVarsForModule(_modules.CurrentPath),
+            LiftedBlockScopedTopLevelVars = BuildLiftedBlockScopedTopLevelVarsForModule(_modules.CurrentPath),
             ArrowEntryPointDCFields = _closures.ArrowEntryPointDCFields.Count > 0 ? _closures.ArrowEntryPointDCFields : null,
             EntryPointDisplayClassStaticField = _closures.EntryPointDisplayClassStaticField,
             // Top-level statements run here: var/let/const are module-level bindings (#562).

--- a/Compilation/ILCompiler.Modules.cs
+++ b/Compilation/ILCompiler.Modules.cs
@@ -828,6 +828,7 @@ public partial class ILCompiler
             // Entry-point display class for captured top-level variables
             EntryPointDisplayClassFields = BuildEntryPointDisplayClassFieldsForModule(_modules.CurrentPath),
             CapturedTopLevelVars = BuildCapturedTopLevelVarsForModule(_modules.CurrentPath),
+            LiftedBlockScopedTopLevelVars = BuildLiftedBlockScopedTopLevelVarsForModule(_modules.CurrentPath),
             ArrowEntryPointDCFields = _closures.ArrowEntryPointDCFields.Count > 0 ? _closures.ArrowEntryPointDCFields : null,
             EntryPointDisplayClassStaticField = _closures.EntryPointDisplayClassStaticField,
             // This context emits the module/script top-level statements, so var/let/const

--- a/Compilation/ILCompiler.State.cs
+++ b/Compilation/ILCompiler.State.cs
@@ -169,6 +169,18 @@ public partial class ILCompiler
         // Chosen so it can't clash with any real module path.
         public const string SingleFileKey = "<single-file>";
 
+        // #1201: per-key names of top-level BLOCK-scoped let/const bindings lifted onto the
+        // entry-point display class (subset of ModuleCapturedTopLevelVars[key]). The var/const
+        // declaration emitter consults this so a lifted declaration in a nested block stores to
+        // its DC field instead of a fresh local. Live reference — a later same-key registration
+        // may revoke a lift before emission (RevokeCollidingBlockScopedLifts).
+        public Dictionary<string, HashSet<string>> ModuleLiftedBlockScopedVars { get; } = [];
+
+        // #1201: per-key union of every declared identifier seen by earlier registration calls
+        // sharing the key (scripts merged into the single-file scope). A block-scope lift is
+        // skipped/revoked when its name collides across those trees.
+        public Dictionary<string, HashSet<string>> ModuleRegisteredDeclaredNames { get; } = [];
+
         // Flat union used only for cross-module decisions — e.g., "is this name
         // captured by SOMETHING so non-captured-var emission should skip it?"
         // Not consumed by emitters; those see module-scoped dicts.

--- a/Compilation/ILCompiler.cs
+++ b/Compilation/ILCompiler.cs
@@ -1474,10 +1474,19 @@ public partial class ILCompiler
         HashSet<string>? moduleVars = null;
         Dictionary<string, FieldBuilder>? moduleFields = null;
 
+        // #1201 pre-pass: every name declared anywhere in this statement tree (params, locals,
+        // loop vars, functions, classes, imports, …). Used to (a) revoke block-scoped lifts made
+        // by an earlier same-key registration (script-merged scopes) that this tree re-declares,
+        // and (b) enforce the declared-exactly-once safety rule for this tree's own candidates.
+        var declaredNameCounts = CountDeclaredNames(statements);
+        RevokeCollidingBlockScopedLifts(key, declaredNameCounts.Keys);
+
         foreach (var stmt in statements)
         {
             RegisterCapturedStmt(stmt, key, modulePath, ref moduleVars, ref moduleFields);
         }
+
+        RegisterLiftableBlockScopedVars(statements, key, modulePath, declaredNameCounts, ref moduleVars, ref moduleFields);
 
         static TValue GetOrCreate<TValue>(Dictionary<string, TValue> dict, string k)
             where TValue : new()
@@ -1536,8 +1545,10 @@ public partial class ILCompiler
             mv ??= GetOrCreate(_closures.ModuleCapturedTopLevelVars, captureKey);
             mf ??= GetOrCreate(_closures.ModuleEntryPointDisplayClassFields, captureKey);
 
-            if (mv.Add(varName))
+            if (mv.Add(varName) && !mf.ContainsKey(varName))
             {
+                // A revoked block-scope lift (#1201) may have left this name's field behind;
+                // reuse it rather than defining a same-named duplicate on the display class.
                 string fieldName = path == null
                     ? varName
                     : $"{SanitizeModuleForField(path)}__{varName}";
@@ -1547,6 +1558,216 @@ public partial class ILCompiler
 
             _closures.CapturedTopLevelVars.Add(varName);
         }
+    }
+
+    /// <summary>
+    /// #1201: gives captured top-level BLOCK-scoped <c>let</c>/<c>const</c> bindings the same
+    /// entry-point-display-class home that direct top-level declarations get. Without one, a
+    /// closure capturing such a binding snapshots the entry method's local by value — and a
+    /// closure created inside ANOTHER closure's body (whose creating context can't see that
+    /// local at all) captures <c>null</c> via the populate fallback, so mutations vanish and
+    /// object references are lost. Mirrors what function display classes already do for
+    /// block-scoped locals inside functions.
+    ///
+    /// <para><b>Safety rule:</b> a binding is lifted only when its name is declared exactly once
+    /// in the whole module tree (and never by any other registration sharing this key — the
+    /// script-merged global scope). Names failing the rule keep today's snapshot path, so any
+    /// shadowing/aliasing pattern that works now is untouched. Declarations inside LOOP bodies
+    /// are never lifted: those bindings are per-iteration, and a single shared field would fuse
+    /// iterations that the current snapshot semantics keeps distinct.</para>
+    /// </summary>
+    private void RegisterLiftableBlockScopedVars(
+        List<Stmt> statements,
+        string key,
+        string? modulePath,
+        Dictionary<string, int> declaredNameCounts,
+        ref HashSet<string>? mv,
+        ref Dictionary<string, FieldBuilder>? mf)
+    {
+        var candidates = new List<Stmt>();
+        foreach (var stmt in statements)
+            CollectLiftableBlockScopedDecls(stmt, nested: false, candidates);
+
+        if (!_closures.ModuleRegisteredDeclaredNames.TryGetValue(key, out var namesFromEarlierCalls))
+            _closures.ModuleRegisteredDeclaredNames[key] = namesFromEarlierCalls = [];
+
+        foreach (var decl in candidates)
+        {
+            string name = decl switch
+            {
+                Stmt.Var v => v.Name.Lexeme,
+                Stmt.Const c => c.Name.Lexeme,
+                _ => throw new InvalidOperationException("unreachable: candidates are Var/Const only")
+            };
+            if (!_closures.Analyzer.IsVariableCaptured(name)) continue;
+            if (declaredNameCounts[name] != 1) continue;          // declared-exactly-once rule
+            if (namesFromEarlierCalls.Contains(name)) continue;    // collides across script-merged scopes
+
+            var displayClass = EnsureEntryPointDisplayClass();
+            mv ??= GetOrCreateEntry(_closures.ModuleCapturedTopLevelVars, key);
+            mf ??= GetOrCreateEntry(_closures.ModuleEntryPointDisplayClassFields, key);
+
+            if (!mv.Add(name)) continue; // already stored on the DC by an earlier same-key registration
+
+            if (!mf.ContainsKey(name))
+            {
+                string fieldName = modulePath == null
+                    ? name
+                    : $"{SanitizeModuleForField(modulePath)}__{name}";
+                mf[name] = displayClass.DefineField(fieldName, _types.Object, FieldAttributes.Public);
+            }
+
+            if (!_closures.ModuleLiftedBlockScopedVars.TryGetValue(key, out var lifted))
+                _closures.ModuleLiftedBlockScopedVars[key] = lifted = [];
+            lifted.Add(name);
+            _closures.CapturedTopLevelVars.Add(name);
+        }
+
+        // Record this tree's declared names so later registrations sharing the key (scripts merged
+        // into the single-file scope) can detect collisions with the lifts made here.
+        namesFromEarlierCalls.UnionWith(declaredNameCounts.Keys);
+    }
+
+    /// <summary>
+    /// Revokes block-scope lifts (#1201) made by earlier registrations under the same key when a
+    /// later script re-declares the name: the lifted binding reverts to the plain-local snapshot
+    /// path, restoring pre-lift behavior for both. The orphaned display-class field is harmless
+    /// (direct registration reuses it if the colliding declaration is a captured top-level var).
+    /// </summary>
+    private void RevokeCollidingBlockScopedLifts(string key, IEnumerable<string> declaredNames)
+    {
+        if (!_closures.ModuleLiftedBlockScopedVars.TryGetValue(key, out var lifted) || lifted.Count == 0)
+            return;
+        _closures.ModuleCapturedTopLevelVars.TryGetValue(key, out var mv);
+
+        foreach (var name in declaredNames)
+        {
+            if (!lifted.Remove(name)) continue;
+            mv?.Remove(name);
+            // Drop from the flat union only if no module still stores this name on the DC.
+            if (!_closures.ModuleCapturedTopLevelVars.Values.Any(set => set.Contains(name)))
+                _closures.CapturedTopLevelVars.Remove(name);
+        }
+    }
+
+    private static TValue GetOrCreateEntry<TValue>(Dictionary<string, TValue> dict, string k)
+        where TValue : new()
+    {
+        if (!dict.TryGetValue(k, out var v))
+        {
+            v = new TValue();
+            dict[k] = v;
+        }
+        return v;
+    }
+
+    /// <summary>
+    /// Collects captured-liftable block-scoped declarations (#1201): <c>let</c>/<c>const</c>
+    /// statements nested in non-loop statement containers at module top level. Loops are a hard
+    /// stop (per-iteration bindings); function/class/namespace bodies are separate scopes with
+    /// their own display-class machinery. <c>var</c> declarations are excluded — they are
+    /// function-scoped (hoisted), a different storage story.
+    /// </summary>
+    private static void CollectLiftableBlockScopedDecls(Stmt stmt, bool nested, List<Stmt> result)
+    {
+        switch (stmt)
+        {
+            case Stmt.Var v when nested && !v.IsVar:
+                result.Add(v);
+                break;
+            case Stmt.Const when nested:
+                result.Add(stmt);
+                break;
+            case Stmt.Sequence seq: // no scope of its own — keep the current nesting level
+                foreach (var s in seq.Statements) CollectLiftableBlockScopedDecls(s, nested, result);
+                break;
+            case Stmt.Block block:
+                foreach (var s in block.Statements) CollectLiftableBlockScopedDecls(s, nested: true, result);
+                break;
+            case Stmt.If ifStmt:
+                CollectLiftableBlockScopedDecls(ifStmt.ThenBranch, nested: true, result);
+                if (ifStmt.ElseBranch != null) CollectLiftableBlockScopedDecls(ifStmt.ElseBranch, nested: true, result);
+                break;
+            case Stmt.TryCatch tc:
+                foreach (var s in tc.TryBlock) CollectLiftableBlockScopedDecls(s, nested: true, result);
+                if (tc.CatchBlock != null)
+                    foreach (var s in tc.CatchBlock) CollectLiftableBlockScopedDecls(s, nested: true, result);
+                if (tc.FinallyBlock != null)
+                    foreach (var s in tc.FinallyBlock) CollectLiftableBlockScopedDecls(s, nested: true, result);
+                break;
+            case Stmt.Switch sw:
+                foreach (var c in sw.Cases)
+                    foreach (var s in c.Body) CollectLiftableBlockScopedDecls(s, nested: true, result);
+                if (sw.DefaultBody != null)
+                    foreach (var s in sw.DefaultBody) CollectLiftableBlockScopedDecls(s, nested: true, result);
+                break;
+            case Stmt.LabeledStatement labeled:
+                CollectLiftableBlockScopedDecls(labeled.Statement, nested, result);
+                break;
+        }
+    }
+
+    /// <summary>
+    /// Counts every declared identifier in the statement tree, descending into nested closures,
+    /// class bodies, and loop bodies. Deliberately over-broad (method names, params, catch params,
+    /// enum/namespace/import names all count): the #1201 lift only fires for names this reports as
+    /// declared exactly once, so any potential shadow — however exotic — blocks the lift.
+    /// </summary>
+    private static Dictionary<string, int> CountDeclaredNames(List<Stmt> statements)
+    {
+        var counter = new DeclaredNameCounter();
+        foreach (var stmt in statements)
+            counter.Visit(stmt);
+        return counter.Counts;
+    }
+
+    private sealed class DeclaredNameCounter : Parsing.Visitors.AstVisitorBase
+    {
+        public Dictionary<string, int> Counts { get; } = [];
+
+        private void Add(string name) =>
+            Counts[name] = Counts.TryGetValue(name, out var c) ? c + 1 : 1;
+
+        private void AddParams(List<Stmt.Parameter> parameters)
+        {
+            foreach (var p in parameters) Add(p.Name.Lexeme);
+        }
+
+        protected override void VisitVar(Stmt.Var stmt) { Add(stmt.Name.Lexeme); base.VisitVar(stmt); }
+        protected override void VisitConst(Stmt.Const stmt) { Add(stmt.Name.Lexeme); base.VisitConst(stmt); }
+        protected override void VisitFunction(Stmt.Function stmt)
+        {
+            Add(stmt.Name.Lexeme);
+            AddParams(stmt.Parameters);
+            base.VisitFunction(stmt);
+        }
+        protected override void VisitArrowFunction(Expr.ArrowFunction expr)
+        {
+            if (expr.Name != null) Add(expr.Name.Lexeme);
+            AddParams(expr.Parameters);
+            base.VisitArrowFunction(expr);
+        }
+        protected override void VisitClass(Stmt.Class stmt) { Add(stmt.Name.Lexeme); base.VisitClass(stmt); }
+        protected override void VisitEnum(Stmt.Enum stmt) { Add(stmt.Name.Lexeme); base.VisitEnum(stmt); }
+        protected override void VisitNamespace(Stmt.Namespace stmt) { Add(stmt.Name.Lexeme); base.VisitNamespace(stmt); }
+        protected override void VisitForOf(Stmt.ForOf stmt) { Add(stmt.Variable.Lexeme); base.VisitForOf(stmt); }
+        protected override void VisitForIn(Stmt.ForIn stmt) { Add(stmt.Variable.Lexeme); base.VisitForIn(stmt); }
+        protected override void VisitTryCatch(Stmt.TryCatch stmt)
+        {
+            if (stmt.CatchParam != null) Add(stmt.CatchParam.Lexeme);
+            base.VisitTryCatch(stmt);
+        }
+        protected override void VisitImport(Stmt.Import stmt)
+        {
+            if (stmt.DefaultImport != null) Add(stmt.DefaultImport.Lexeme);
+            if (stmt.NamespaceImport != null) Add(stmt.NamespaceImport.Lexeme);
+            if (stmt.NamedImports != null)
+                foreach (var spec in stmt.NamedImports)
+                    Add((spec.LocalName ?? spec.Imported).Lexeme);
+            base.VisitImport(stmt);
+        }
+        protected override void VisitImportAlias(Stmt.ImportAlias stmt) { Add(stmt.AliasName.Lexeme); base.VisitImportAlias(stmt); }
+        protected override void VisitImportRequire(Stmt.ImportRequire stmt) { Add(stmt.AliasName.Lexeme); base.VisitImportRequire(stmt); }
     }
 
     /// <summary>
@@ -1793,6 +2014,22 @@ public partial class ILCompiler
     {
         string key = modulePath ?? ClosureCompilationState.SingleFileKey;
         if (_closures.ModuleCapturedTopLevelVars.TryGetValue(key, out var vars) && vars.Count > 0)
+        {
+            return vars;
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Returns the lifted block-scoped top-level var names (#1201) visible to code emitted for
+    /// the given module, or <c>null</c> if none. Companion of
+    /// <see cref="BuildCapturedTopLevelVarsForModule"/>; consumed only by the module-top-level
+    /// declaration emitter.
+    /// </summary>
+    private HashSet<string>? BuildLiftedBlockScopedTopLevelVarsForModule(string? modulePath)
+    {
+        string key = modulePath ?? ClosureCompilationState.SingleFileKey;
+        if (_closures.ModuleLiftedBlockScopedVars.TryGetValue(key, out var vars) && vars.Count > 0)
         {
             return vars;
         }

--- a/Compilation/ILEmitter.Statements.cs
+++ b/Compilation/ILEmitter.Statements.cs
@@ -39,8 +39,14 @@ public partial class ILEmitter
         // declaration there is a function-local that must shadow — not overwrite — the module
         // binding; falling into this block wrote a function-local through to the module slot
         // and never created the real local, so captured reads saw null and the module var was
-        // clobbered (#562). A nested block at top level likewise shadows via a fresh local.
-        if (_ctx.IsModuleTopLevel && !_ctx.Locals.IsInNestedScope)
+        // clobbered (#562). A nested block at top level likewise shadows via a fresh local —
+        // EXCEPT a captured block-scoped binding lifted onto the entry-point display class
+        // (#1201): that one's home IS the DC field (a closure created inside another closure's
+        // body can only reach it there), and its name is declared exactly once in the module,
+        // so no shadowing declaration can collide with the name-keyed check.
+        if (_ctx.IsModuleTopLevel &&
+            (!_ctx.Locals.IsInNestedScope ||
+             _ctx.LiftedBlockScopedTopLevelVars?.Contains(v.Name.Lexeme) == true))
         {
             // Check if this is a captured top-level variable - use entry-point display class
             if (_ctx.CapturedTopLevelVars?.Contains(v.Name.Lexeme) == true &&

--- a/SharpTS.Tests/SharedTests/TopLevelBlockScopeCaptureTests.cs
+++ b/SharpTS.Tests/SharedTests/TopLevelBlockScopeCaptureTests.cs
@@ -1,0 +1,253 @@
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests;
+
+/// <summary>
+/// Regressions for #1201: compiled closures capturing a top-level BLOCK-scoped
+/// <c>let</c>/<c>const</c> (e.g. inside <c>if (true) { … }</c>) had no shared storage —
+/// the entry-point display class only registered direct top-level declarations. A closure
+/// created inside another closure's body couldn't reach the entry method's local at all,
+/// so its capture-populate fell through to <c>Ldnull</c>: the inner closure saw
+/// <c>null</c> (silently — <c>typeof null === "object"</c>), mutations vanished, and
+/// object references were lost. The fix lifts such bindings onto the entry-point display
+/// class (mirroring what function display classes do for block-scoped locals inside
+/// functions), guarded by a declared-exactly-once rule so shadowing patterns keep their
+/// existing behavior, and never lifting from loop bodies (per-iteration bindings).
+/// </summary>
+public class TopLevelBlockScopeCaptureTests
+{
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void BlockScopedCapture_ClosureInLoopInClosure_SharesEnvironment(ExecutionMode mode)
+    {
+        // The issue's minimal repro: closures created in a loop inside another closure,
+        // capturing block-scoped outer state. Before the fix, compiled printed
+        // "set=0 n=1" twice (each inner callback saw null-backed fresh state).
+        var source = """
+            if (true) {
+                const served = new Set<string>();
+                let n = 0;
+                setTimeout(() => {
+                    for (let i = 0; i < 2; i++) {
+                        setTimeout(() => {
+                            served.add('x' + i);
+                            n++;
+                            console.log('set=' + served.size + ' n=' + n);
+                        }, 5);
+                    }
+                }, 5);
+            }
+            """;
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("set=1 n=1\nset=2 n=2\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void BlockScopedCapture_RelayedThroughIntermediateClosure_NoLoop(ExecutionMode mode)
+    {
+        // No loop involved: the intermediate closure doesn't reference the captured
+        // names itself, so the inner closure's capture must be relayed. Before the
+        // fix the inner closure captured null for both.
+        var source = """
+            if (true) {
+                const items = new Set<string>();
+                let count = 0;
+                setTimeout(() => {
+                    setTimeout(() => {
+                        items.add('x');
+                        count++;
+                        console.log('set=' + items.size + ' n=' + count);
+                    }, 5);
+                }, 5);
+            }
+            """;
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("set=1 n=1\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void BlockScopedCapture_MutationsSharedBothWays(ExecutionMode mode)
+    {
+        // Two-way sharing between the block body and a closure: block writes after
+        // closure creation must be visible inside the closure, and closure writes
+        // must be visible to later block code.
+        var source = """
+            if (true) {
+                let counter = 0;
+                const bump = () => { counter++; };
+                counter = 10;
+                bump();
+                console.log(counter);
+            }
+            """;
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("11\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void TopLevelLoopBody_Capture_StaysPerIteration(ExecutionMode mode)
+    {
+        // Bindings declared inside a top-level loop body are per-iteration and must
+        // NOT be lifted onto the shared display class — each closure snapshots its
+        // own iteration's value.
+        var source = """
+            const fns: (() => number)[] = [];
+            for (let i = 0; i < 3; i++) {
+                const x = i * 10;
+                fns.push(() => x);
+            }
+            console.log(fns.map(f => f()).join(','));
+            """;
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("0,10,20\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void BlockInsideTopLevelLoop_Capture_StaysPerIteration(ExecutionMode mode)
+    {
+        // A block nested inside a loop is still loop territory: its bindings are
+        // per-iteration, so the lift must not fire for them either.
+        var source = """
+            const fns: (() => string)[] = [];
+            for (let k = 0; k < 2; k++) {
+                if (true) {
+                    const y = 'iter' + k;
+                    fns.push(() => y);
+                }
+            }
+            console.log(fns.map(f => f()).join(','));
+            """;
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("iter0,iter1\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void SiblingBlocks_SameName_EachClosureReadsOwnBinding(ExecutionMode mode)
+    {
+        // Same name declared in two sibling blocks fails the declared-exactly-once
+        // rule, so neither is lifted — each closure keeps its own snapshot and the
+        // bindings stay distinct.
+        var source = """
+            if (true) {
+                const dup = 'first';
+                const g1 = () => dup;
+                console.log(g1());
+            }
+            if (true) {
+                const dup = 'second';
+                const g2 = () => dup;
+                console.log(g2());
+            }
+            """;
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("first\nsecond\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void SwitchCase_BlockScopedCapture_Relayed(ExecutionMode mode)
+    {
+        var source = """
+            switch (1) {
+                case 1: {
+                    const bag = new Set<string>();
+                    setTimeout(() => {
+                        setTimeout(() => {
+                            bag.add('a');
+                            console.log('size=' + bag.size);
+                        }, 5);
+                    }, 5);
+                    break;
+                }
+            }
+            """;
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("size=1\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void TryBlock_BlockScopedCapture_Relayed(ExecutionMode mode)
+    {
+        var source = """
+            try {
+                const bag = new Set<string>();
+                setTimeout(() => {
+                    setTimeout(() => {
+                        bag.add('a');
+                        bag.add('b');
+                        console.log('size=' + bag.size);
+                    }, 5);
+                }, 5);
+            } catch (e) {
+                console.log('err');
+            }
+            """;
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("size=2\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void BlockScopedCapture_InImportedModule(ExecutionMode mode)
+    {
+        // Module-init methods reach the entry-point display class through its static
+        // field rather than a local — the lift must work there too.
+        var files = new Dictionary<string, string>
+        {
+            ["lib.ts"] = """
+                export function start(): void {}
+                if (true) {
+                    const libSet = new Set<string>();
+                    let libN = 0;
+                    setTimeout(() => {
+                        for (let i = 0; i < 2; i++) {
+                            setTimeout(() => {
+                                libSet.add('m' + i);
+                                libN++;
+                                console.log('lib set=' + libSet.size + ' n=' + libN);
+                            }, 5);
+                        }
+                    }, 5);
+                }
+                """,
+            ["main.ts"] = """
+                import { start } from './lib';
+                start();
+                console.log('main ran');
+                """,
+        };
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("main ran\nlib set=1 n=1\nlib set=2 n=2\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void BlockScopedCapture_FunctionExpression_SharesEnvironment(ExecutionMode mode)
+    {
+        // Function EXPRESSIONS route through the arrow display-class machinery and
+        // must share the lifted binding like arrows do. (A function DECLARATION in a
+        // top-level block is different territory: NestedFunctionLifter lambda-lifts
+        // it with by-value capture forwarding — its leading parameter reuses the
+        // binding's name, which fails the declared-exactly-once rule, so the lift
+        // correctly stays out of that pre-existing #605/#622 limitation.)
+        var source = """
+            if (true) {
+                let total = 0;
+                const addOne = function (): void { total += 1; };
+                const addTwo = () => { total += 2; };
+                addOne();
+                addTwo();
+                console.log(total);
+            }
+            """;
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("3\n", output);
+    }
+}


### PR DESCRIPTION
Closes #1201

## Root cause (the loop was incidental)

A `let`/`const` declared in a **top-level block** (`if (true) { … }`, `try`, `switch`, bare block) and captured by closures had no shared storage: `RegisterCapturedTopLevelVarsForModule` only registered **direct** top-level declarations on the entry-point display class.

- A closure directly referencing the binding snapshotted the entry method's local **by value** — object identity survived, mutations didn't.
- A closure created **inside another closure's body** (the issue's repro) had no reachable source at all: `EmitDisplayInstanceFieldPopulation` fell through to its `Ldnull` fallback (`ILEmitter.Calls.Closures.cs`), so the inner closure silently captured `null`. `typeof null === "object"` + silent-null member access produced exactly the reported `set=0 n=1`, and the "leaked event-loop refs" hang was `server.close()` no-op'ing on a null capture.

Plain callback-in-callback fails the same way (no loop needed). The same shape inside any function/arrow always worked because function display classes lift **all** captured locals, block-scoped included — this PR gives the module top level the same treatment.

## Fix

Registration now recurses into non-loop statement containers and lifts captured block-scoped bindings onto the entry-point DC. All downstream machinery (arrow `$entryPointDC` chaining, inner functions, state machines, resolvers) is name-keyed off the existing `CapturedTopLevelVars`/module sets, so lifted names ride existing plumbing; the only emit-side change is a one-condition exception to the #562 nested-scope guard in `EmitVarDeclaration`.

**Safety rules** (nothing that works today changes):
- **Declared-exactly-once**: lift only names declared exactly once in the whole module tree (params, loop vars, imports, class/method names all count — `DeclaredNameCounter`). Name-keyed resolution can never alias a shadow; every existing shadowing/aliasing pattern keeps its current behavior.
- **Loops are hard stops**: bindings in loop bodies keep per-iteration snapshot semantics (`for`-closures at top level still yield `0,10,20`).
- Script-merged single-file scopes revoke lifts on cross-file collisions (`RevokeCollidingBlockScopedLifts`).
- A function **declared** in a top-level block stays on `NestedFunctionLifter`'s lambda-lift path (#605/#622): its forwarding parameter reuses the binding's name, failing the declared-once rule by construction. Function **expressions** ride the arrow machinery and work.

## Verification

- Issue repro compiled now matches interp exactly (`set=1 n=1` / `set=2 n=2`), `--verify` clean; multi-module, async-arrow, switch/try, deep-nesting, loop-header-mutation probes all interp≡compiled.
- New dual-mode suite `TopLevelBlockScopeCaptureTests` — 10 shapes × interp/compiled, 20/20.
- **Gates**: Test262 **22/0/4skip** baseline-identical; TSConf **31/0**; xUnit **15263** across two full runs — each failed only a small *disjoint* set of known load-sensitive families (Process lifecycle, DNS live-smoke, exec-callback, fetch, for-of, Date), every one green in isolation (17/17, 242/242).

## Pre-existing bugs found (A/B-verified on unmodified main; NOT addressed here)

1. **Capture-populate shadow-alias**: a block `let sh` shadowing a *captured module-level* `sh` — a closure in the block captures the **module** binding (`EmitDisplayInstanceFieldPopulation` checks `CapturedTopLevelVars` before `Locals`). Interp `inner`, compiled `outer`. The declared-once rule keeps this PR out of that shape.
2. **Compiled net race**: the issue's net shape (server + 2 loop clients, `destroy()` in own `'data'` callback) intermittently produces **no output** and never exits (~50–75% of runs) even with module-level captures, on main. Same family as the #1211–#1213 event-loop races.

Both deserve their own issues (filing was outside this session's permissions).