### PR TITLE
fix(compile): #1217 bundle stdlib facades reached only via require() from ESM modules

### DIFF
--- a/Modules/ModuleResolver.cs
+++ b/Modules/ModuleResolver.cs
@@ -831,6 +831,16 @@ public class ModuleResolver
                 }
             }
 
+            // ESM modules (and scripts) can also reach modules via bare require() — it's a
+            // global in SharpTS, mirroring Node's createRequire interop. Walk the body for
+            // literal require() specifiers that resolve to embedded stdlib facades so they
+            // get bundled into compiled output (#1217); without this the emitter's require()
+            // lowering finds the facade in neither CommonJsGetExportsMethods nor
+            // ModuleExportFields and lowers the call to a runtime MODULE_NOT_FOUND throw.
+            // Scoped to stdlib on purpose: user modules reached only via require() stay
+            // runtime-lazy in the interpreter and out of the static type-check graph.
+            CollectCjsRequireDependencies(module, statements, absolutePath, decoratorMode, stdlibOnly: true);
+
             return module;
         }
         finally
@@ -912,17 +922,21 @@ public class ModuleResolver
     }
 
     /// <summary>
-    /// Walks a CommonJS module's body for literal `require('./literal')` calls and recursively
+    /// Walks a module's body for literal `require('./literal')` calls and recursively
     /// loads each target. Adds resolved targets to <see cref="ParsedModule.Dependencies"/>.
     /// Non-literal specifiers are ignored here — the IL compiler will reject them later.
     /// Unresolvable specifiers are also ignored — they'll either resolve via the optional-dep
     /// runtime throw path or surface as a compile error from the IL emitter.
     /// </summary>
+    /// <param name="stdlibOnly">When true (ESM/script callers, #1217), only specifiers that
+    /// resolve to embedded stdlib modules are loaded; user modules reached via require()
+    /// from non-CJS files stay runtime-lazy.</param>
     private void CollectCjsRequireDependencies(
         ParsedModule module,
         List<Stmt> statements,
         string absolutePath,
-        DecoratorMode decoratorMode)
+        DecoratorMode decoratorMode,
+        bool stdlibOnly = false)
     {
         var walker = new CjsRequireWalker();
         foreach (var stmt in statements)
@@ -939,13 +953,19 @@ public class ModuleResolver
             string requiredPath;
             try
             {
-                // Literal require() in a CJS body — pass Cjs so dual-export packages
-                // route to the "require" entry, not "import" (matches Node semantics).
+                // Literal require() — pass Cjs so dual-export packages route to the
+                // "require" entry, not "import" (matches Node semantics).
                 requiredPath = ResolveModulePath(specifier, absolutePath, ResolutionKind.Cjs);
             }
             catch
             {
                 // Optional dep / will be handled at runtime by the optional-dep throw path.
+                continue;
+            }
+
+            if (stdlibOnly &&
+                !requiredPath.StartsWith(EmbeddedStdlibProvider.VirtualPathPrefix, StringComparison.Ordinal))
+            {
                 continue;
             }
 

--- a/SharpTS.Tests/SharedTests/BuiltInModules/CjsBuiltInModuleRequireTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/CjsBuiltInModuleRequireTests.cs
@@ -128,20 +128,22 @@ public class CjsBuiltInModuleRequireTests
     }
 
     /// <summary>
-    /// Regression (#1210): require() of a stdlib facade with primitive:* imports from an ESM
-    /// entry, without any ESM import of that module anywhere in the program.
+    /// Regression (#1210 interpreter, #1217 compiled): require() of a stdlib facade with
+    /// primitive:* imports from an ESM entry, without any ESM import of that module anywhere
+    /// in the program.
     /// </summary>
     /// <remarks>
     /// A CJS entry pre-loads its require() graph via CollectCjsRequireDependencies, so the
     /// facade's primitive deps get executed by the static InterpretModules walk — which is why
-    /// the main.cjs tests above never hit this. An ESM entry's require() is fully lazy: the
-    /// facade loads, but its `import ... from 'primitive:fs'` used to fail with
-    /// "Module 'primitive:fs' not loaded" because BindModuleImports only lazy-initialized CJS
-    /// and dotnet: deps. Interpreter-only: compiled mode has a separate pre-existing gap
-    /// (facades reached only via require() from ESM files are never bundled into the assembly).
+    /// the main.cjs tests above never hit this. An ESM entry's require() used to be fully
+    /// lazy: interpreted, the facade loaded but its `import ... from 'primitive:fs'` failed
+    /// with "Module 'primitive:fs' not loaded" (#1210, fixed in BindModuleImports); compiled,
+    /// the facade was never bundled into the assembly at all, so the require() lowering threw
+    /// MODULE_NOT_FOUND at startup (#1217, fixed by running the require-literal walk over
+    /// ESM bodies scoped to stdlib specifiers).
     /// </remarks>
     [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void Cjs_Require_PrimitiveSeamFacade_FromEsmEntry(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -159,6 +161,29 @@ public class CjsBuiltInModuleRequireTests
         };
         var output = TestHarness.RunModules(files, "main.ts", mode);
         Assert.Equal("function\nroundtrip\nfunction\nfunction\n", output);
+    }
+
+    /// <summary>
+    /// Regression (#1217): the require() call sits inside a function body in an ESM module —
+    /// the discovery walk must find nested require literals, not just top-level statements.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Cjs_Require_StdlibFacade_InsideFunction_FromEsmEntry(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import * as path from 'path';
+                function lazyOs(): any {
+                    return require('os');
+                }
+                console.log(typeof lazyOs().platform);
+                console.log(typeof path.join);
+                """
+        };
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("function\nfunction\n", output);
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

Fixes #1217 — the compiled-mode counterpart of #1210. An ESM module that reaches a stdlib facade **only** via `require()` compiled fine but threw at startup:

```
Cannot find module 'fs': resolved to 'stdlib:node/fs.ts' which is not a CJS module in this assembly
```

## Cause

`ModuleResolver.CollectCjsRequireDependencies` walked `require('<literal>')` calls only for CJS modules, so a facade reached only from an ESM file's `require()` was never loaded into the module graph and never bundled into the output assembly. The emit-side lowering (`TryEmitCjsRequireCall`) already handles bundled stdlib ESM modules via the `ModuleExportFields` namespace-materialization path — only discovery was missing.

## Fix

Run the require-literal walk over ESM/script bodies too, **scoped to specifiers that resolve to embedded stdlib virtual paths** (`stdlib:*`), via a new `stdlibOnly` flag on `CollectCjsRequireDependencies`. User modules reached only via `require()` from ESM intentionally stay runtime-lazy — pulling them into the static graph would newly type-check and eagerly bundle code that loads lazily today (the scoped variant the issue suggested).

Interpreter side effect: facades discovered this way now join the static `InterpretModules` order (eager init) — harmless for side-effect-free facades; the #1210 lazy paths in `BindModuleImports` remain (still exercised by dynamic `import()`) and are idempotent against eager init.

## Tests

- Flipped the #1210 regression test `Cjs_Require_PrimitiveSeamFacade_FromEsmEntry` from `InterpretedOnly` to all modes.
- Added `Cjs_Require_StdlibFacade_InsideFunction_FromEsmEntry` (both modes) — require nested in a function body, pinning that discovery walks nested calls.
- CLI end-to-end: the exact issue repro compiles and runs (`--compile` then `dotnet main.dll`).

## Verification

- xUnit: **15292 / 0 failed**
- Test262: **22 passed / 0 failed / 4 skipped** (baseline-identical)
- TypeScript conformance: **31 / 0** (baseline-identical)