### PR TITLE
fix(types): #1218 push declared-type frames in CheckModules

### DIFF
--- a/SharpTS.Tests/TypeCheckerTests/ModuleDeclaredTypeTrackingTests.cs
+++ b/SharpTS.Tests/TypeCheckerTests/ModuleDeclaredTypeTrackingTests.cs
@@ -1,0 +1,88 @@
+using SharpTS.Diagnostics;
+using SharpTS.Modules;
+using SharpTS.TypeSystem;
+using Xunit;
+
+namespace SharpTS.Tests.TypeCheckerTests;
+
+/// <summary>
+/// <see cref="TypeChecker.CheckModules"/> must keep at least one declared-type frame on the stack
+/// while checking module bodies, like <c>Check</c>/<c>CheckWithRecovery</c> do (#743). Without one,
+/// <c>RecordDeclaredType</c> silently drops every binding and <c>GetDeclaredType</c> falls back to
+/// the environment binding — which control-flow narrowing mutates — so a reassignment inside a
+/// narrowed branch was checked against the narrowed literal type instead of the declared one
+/// (#1218: every CLI import of 'url' failed with "Cannot assign type 'true' to variable 'found' of
+/// type 'false'", from <c>URLSearchParams._setKey</c>). Plain functions were immune because their
+/// body check pushes its own frame; class methods and module top-level code were not. These assert
+/// on <c>GetDiagnostics()</c> directly because CheckModules records errors with recovery — the run
+/// itself succeeds, which is exactly how the test suite missed the regression.
+/// </summary>
+public class ModuleDeclaredTypeTrackingTests
+{
+    private static IReadOnlyList<Diagnostic> CheckModule(string source)
+    {
+        var baseDir = Path.Combine(Path.GetTempPath(), $"sharpts_decltrack_{Guid.NewGuid():N}");
+        var entryPath = Path.GetFullPath(Path.Combine(baseDir, "main.ts"));
+        var virtualFiles = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            [entryPath] = source,
+        };
+
+        var resolver = new ModuleResolver(entryPath, virtualFiles);
+        var entryModule = resolver.LoadModule(entryPath);
+        var allModules = resolver.GetModulesInOrder(entryModule);
+
+        var checker = new TypeChecker();
+        checker.CheckModules(allModules, resolver);
+        return checker.GetDiagnostics();
+    }
+
+    private static void AssertNoErrors(IReadOnlyList<Diagnostic> diags)
+    {
+        var errors = diags.Where(d => d.Severity == DiagnosticSeverity.Error).ToList();
+        Assert.True(errors.Count == 0, string.Join("\n", errors.Select(e => e.ToString())));
+    }
+
+    [Fact]
+    public void UrlImport_TypeChecksClean()
+    {
+        // The verbatim #1218 symptom: any import of 'url' pulled in URLSearchParams._setKey,
+        // whose `let found = false; … found = true;` was rejected.
+        AssertNoErrors(CheckModule(
+            "import { parse } from 'url';\nconst p = parse('http://example.com/a?b=1');\nconsole.log(p.host);\n"));
+    }
+
+    [Fact]
+    public void ModuleTopLevel_NarrowedLetReassignment_TypeChecksClean()
+    {
+        // Module-mode top-level facet of the same root cause: `!x` narrows x to `false`, and the
+        // reassignment must still check against the declared (widened) boolean.
+        AssertNoErrors(CheckModule("export {};\nlet x = false;\nif (!x) { x = true; }\n"));
+    }
+
+    [Fact]
+    public void ClassMethodLocal_NarrowedLetReassignment_TypeChecksClean()
+    {
+        // Class-method facet, independent of the stdlib facade: method bodies don't push their own
+        // declared-type frame, so the local's widened type must be recorded in the module frame.
+        AssertNoErrors(CheckModule(
+            """
+            export class Pairs {
+                private _pairs: string[][] = [];
+                setKey(key: string, val: string): void {
+                    let found = false;
+                    const next: string[][] = [];
+                    for (let i = 0; i < this._pairs.length; i++) {
+                        if (this._pairs[i][0] === key) {
+                            if (!found) { next.push([key, val]); found = true; }
+                        } else {
+                            next.push(this._pairs[i]);
+                        }
+                    }
+                    if (!found) next.push([key, val]);
+                    this._pairs = next;
+                }
+            }
+            """));
+    }
+}

--- a/TypeSystem/TypeChecker.cs
+++ b/TypeSystem/TypeChecker.cs
@@ -1142,6 +1142,16 @@ public partial class TypeChecker
 
         _moduleResolver = resolver;
 
+        // Base declared-type frame for the whole run, mirroring Check()/CheckWithRecovery (#743) —
+        // shared by all script files, which share global scope. With no frame on the stack,
+        // RecordDeclaredType silently drops every binding and GetDeclaredType falls back to the
+        // environment binding — which control-flow narrowing mutates — so an assignment inside a
+        // narrowed branch is checked against the narrowed literal type instead of the declared one
+        // (#1218: `let found = false; if (!found) { found = true; }` rejected in module mode).
+        // Clear first: the checker may retain frames from a prior check's early exit.
+        _declaredVariableTypesStack.Clear();
+        PushDeclaredVariableScope();
+
         // Pre-define built-ins in the global environment
         _environment.Define("console", new TypeInfo.Any());
         _environment.Define("Reflect", new TypeInfo.Any());
@@ -1150,24 +1160,35 @@ public partial class TypeChecker
         // Create a shared script environment for script files (they share global scope)
         var scriptEnv = new TypeEnvironment(_environment);
 
-        // First pass: collect all exports from each module
-        foreach (var module in modules)
+        // First pass: collect all exports from each module. This preparatory pass type-checks
+        // bodies too (suppressed), so it runs in its own declared-type frame: its records are
+        // discarded rather than leaking into the base frame the authoritative second pass — which
+        // re-checks and re-records everything — reads through (#1218).
+        PushDeclaredVariableScope();
+        try
         {
-            _currentModule = module;
-            // Attribute diagnostics to the module being checked — without
-            // this, errors raised inside module sources (including built-in
-            // module declarations like events.ts) render as bare
-            // "at line N" with no file context (#216).
-            _filePath = module.Path;
-            if (module.IsScript)
+            foreach (var module in modules)
             {
-                // Scripts use shared environment and don't export
-                CollectScriptDeclarations(module, scriptEnv);
+                _currentModule = module;
+                // Attribute diagnostics to the module being checked — without
+                // this, errors raised inside module sources (including built-in
+                // module declarations like events.ts) render as bare
+                // "at line N" with no file context (#216).
+                _filePath = module.Path;
+                if (module.IsScript)
+                {
+                    // Scripts use shared environment and don't export
+                    CollectScriptDeclarations(module, scriptEnv);
+                }
+                else
+                {
+                    CollectModuleExports(module);
+                }
             }
-            else
-            {
-                CollectModuleExports(module);
-            }
+        }
+        finally
+        {
+            PopDeclaredVariableScope();
         }
 
         // Second pass: type-check each module with imports resolved
@@ -1236,40 +1257,51 @@ public partial class TypeChecker
                 // Bind imports from dependencies
                 BindModuleImports(module, moduleEnv);
 
-                // Type-check module body with error recovery
-                using (new EnvironmentScope(this, moduleEnv))
+                // Per-module declared-type frame: the module's top-level bindings (and class-method
+                // locals, which record into the innermost frame) are tracked like function locals
+                // and don't leak into sibling modules (#1218).
+                PushDeclaredVariableScope();
+                try
                 {
-                    // First pass: pre-register type declarations
-                    PreRegisterTypeDeclarations(module.Statements);
-
-                    // Hoist class declarations (as Any for forward references)
-                    HoistClassDeclarations(module.Statements);
-
-                    // Second pass: hoist function declarations (now types are available)
-                    HoistFunctionDeclarations(module.Statements);
-
-                    // Hoist var declarations (pre-define as any for forward reference support)
-                    HoistVarDeclarations(module.Statements);
-
-                    // Hoist let/const declarations (pre-define as any for forward reference support — #533)
-                    HoistLexicalDeclarations(module.Statements);
-
-                    // Third pass: check all statements with error recovery
-                    foreach (var stmt in module.Statements)
+                    // Type-check module body with error recovery
+                    using (new EnvironmentScope(this, moduleEnv))
                     {
-                        // Fallback line for diagnostics whose throw-site doesn't carry one, mirroring
-                        // the script path (CheckWithRecovery). Without it, module-mode errors render
-                        // with no location (#468).
-                        _currentStatementLine = TryGetStmtLine(stmt);
-                        try
+                        // First pass: pre-register type declarations
+                        PreRegisterTypeDeclarations(module.Statements);
+
+                        // Hoist class declarations (as Any for forward references)
+                        HoistClassDeclarations(module.Statements);
+
+                        // Second pass: hoist function declarations (now types are available)
+                        HoistFunctionDeclarations(module.Statements);
+
+                        // Hoist var declarations (pre-define as any for forward reference support)
+                        HoistVarDeclarations(module.Statements);
+
+                        // Hoist let/const declarations (pre-define as any for forward reference support — #533)
+                        HoistLexicalDeclarations(module.Statements);
+
+                        // Third pass: check all statements with error recovery
+                        foreach (var stmt in module.Statements)
                         {
-                            CheckStmt(stmt);
-                        }
-                        catch (TypeCheckException ex)
-                        {
-                            RecordTypeError(ex);
+                            // Fallback line for diagnostics whose throw-site doesn't carry one, mirroring
+                            // the script path (CheckWithRecovery). Without it, module-mode errors render
+                            // with no location (#468).
+                            _currentStatementLine = TryGetStmtLine(stmt);
+                            try
+                            {
+                                CheckStmt(stmt);
+                            }
+                            catch (TypeCheckException ex)
+                            {
+                                RecordTypeError(ex);
+                            }
                         }
                     }
+                }
+                finally
+                {
+                    PopDeclaredVariableScope();
                 }
             }
 


### PR DESCRIPTION
## Summary

Fixes #1218 — every CLI import of `url` failed at type-check with `Cannot assign type 'true' to variable 'found' of type 'false'`.

## Root cause

`CheckModules` ran with an **empty declared-variable-types stack**: the #743 fix (push a base frame so top-level bindings are tracked like function locals) went only into `Check()`/`CheckWithRecovery`. With no frame on the stack:

- `RecordDeclaredType` silently no-ops (it writes to `Peek()` only when the stack is non-empty), and
- `GetDeclaredType` falls back to the environment binding — which **control-flow narrowing mutates**.

So in `let found = false; if (!found) { found = true; }`, the `!found` guard narrows the environment binding to literal `false`, and the assignment of `true` is then checked against `false` instead of the declared (widened) `boolean`.

This explains every observation in the issue:

- **Why url but not util/assert**: the pattern in util/assert sits inside plain functions, and `CheckFunctionBodyAndInferReturn` pushes its own frame. `URLSearchParams._setKey` is a **class method** — method bodies don't push a frame, so they depend entirely on the ambient one `CheckModules` never provided. Module **top-level** code was equally affected: `export {}; let x = false; if (!x) { x = true; }` failed in any module-mode file.
- **Why minimal extractions didn't repro**: an import-less file is a script → `CheckWithRecovery` → frame exists.
- **Why the xUnit harness stayed green**: `CheckModules` records errors with recovery instead of throwing, and `TestHarness` never asserts `GetDiagnostics()` — the interpreter then runs the program fine. The CLI does check diagnostics. (The new tests assert on `GetDiagnostics()` directly; a broader harness-level diagnostics assertion is worth considering separately, since it may surface other latent facade diagnostics.)

## Fix

Mirror `Check()`'s frame discipline in `CheckModules`:

1. **Base frame at entry** (clear + push, the established idiom) — covers script files, which share global scope.
2. **Throwaway frame** around the suppressed export-collection pass, so its records don't leak into the frame the authoritative pass reads through.
3. **Per-module frame** in the second pass, so module top-level bindings and class-method locals are tracked like function locals and don't leak across sibling modules.

## Tests

`ModuleDeclaredTypeTrackingTests` (3 new): the verbatim url-import repro, the module-top-level facet, and the class-method facet in a plain user module — all asserting `GetDiagnostics()` is error-free through the in-memory `CheckModules` path.

## Verification

- xUnit: **15292 / 0 failed**
- TypeScriptConformance: **31 / 0** (baseline-identical)
- Test262: **22 / 0, 4 skipped** (baseline-identical)
- Manual: `dotnet run -- repro.ts` and `--compile` + run of the emitted DLL both work for `import { parse } from 'url'`