### PR TITLE
fix(net): #1227 enqueue end callback before the FIN goes out

### DIFF
--- a/Compilation/RuntimeEmitter.TSNetSocket.cs
+++ b/Compilation/RuntimeEmitter.TSNetSocket.cs
@@ -1407,17 +1407,21 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Br, loopTop);
 
         il.MarkLabel(exitPath);
-        // if (doShutdown) { _ShutdownWritable(); schedule _FireEndCallback }
+        // if (doShutdown) { schedule _FireEndCallback; _ShutdownWritable(); }
+        // Schedule BEFORE the FIN goes out: an in-process peer's 'end' is enqueued
+        // only after its read loop sees the FIN, so the end callback can never be
+        // overtaken by it — Node's ordering, which shutdown-then-schedule left to a
+        // thread-pool race (#1227; mirrors SharpTSSocket.End).
         var noShut = il.DefineLabel();
         il.Emit(OpCodes.Ldloc, doShutdownLocal);
         il.Emit(OpCodes.Brfalse, noShut);
-        il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Call, _netSocketShutdownWritableMethod);
         il.Emit(OpCodes.Call, runtime.EventLoopGetInstance);
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ldftn, _netSocketFireEndCallbackMethod);
         il.Emit(OpCodes.Newobj, typeof(Action).GetConstructor([_types.Object, typeof(IntPtr)])!);
         il.Emit(OpCodes.Call, runtime.EventLoopSchedule);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Call, _netSocketShutdownWritableMethod);
         il.MarkLabel(noShut);
 
         // schedule _FlushTick — drain check + the worker's balancing Unref
@@ -1577,9 +1581,12 @@ public partial class RuntimeEmitter
 
     /// <summary>
     /// Emits body for: private void _FireEndCallback()
-    /// Invokes the end() callback exactly once, after the deferred shutdown completes.
-    /// Then, when the readable side already saw FIN (or the read-end path requested
-    /// an auto-finish), completes the close via Destroy (#1070).
+    /// Invokes the end() callback exactly once. Enqueued on the loop BEFORE the
+    /// shutdown sends the FIN (#1227), so it may run before _ShutdownWritable
+    /// executes; the Destroy branch below closing the transport first is harmless —
+    /// _ShutdownWritable catch-alls, and the branch only fires when the readable
+    /// side already saw FIN (or the read-end path requested an auto-finish), where
+    /// full teardown is the goal. Completes that close via Destroy (#1070).
     /// </summary>
     private void EmitNetSocketFireEndCallbackBody(EmittedRuntime runtime)
     {
@@ -1799,17 +1806,20 @@ public partial class RuntimeEmitter
             il.Emit(OpCodes.Ldfld, _netSocketWriteQueueField);
             il.Emit(OpCodes.Call, typeof(Monitor).GetMethod("Exit", [_types.Object])!);
 
-            // if (shutdownNow) { _ShutdownWritable(); schedule _FireEndCallback }
+            // if (shutdownNow) { schedule _FireEndCallback; _ShutdownWritable(); }
+            // Schedule BEFORE the FIN goes out so an in-process peer's 'end' — enqueued
+            // only after its read loop sees the FIN — can never overtake the end
+            // callback (#1227; mirrors SharpTSSocket.End and the worker-exit path).
             var noShutdownNow = il.DefineLabel();
             il.Emit(OpCodes.Ldloc, shutdownNowLocal);
             il.Emit(OpCodes.Brfalse, noShutdownNow);
-            il.Emit(OpCodes.Ldarg_0);
-            il.Emit(OpCodes.Call, _netSocketShutdownWritableMethod);
             il.Emit(OpCodes.Call, runtime.EventLoopGetInstance);
             il.Emit(OpCodes.Ldarg_0);
             il.Emit(OpCodes.Ldftn, _netSocketFireEndCallbackMethod);
             il.Emit(OpCodes.Newobj, typeof(Action).GetConstructor([_types.Object, typeof(IntPtr)])!);
             il.Emit(OpCodes.Call, runtime.EventLoopSchedule);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Call, _netSocketShutdownWritableMethod);
             il.MarkLabel(noShutdownNow);
         }
 

--- a/Runtime/Types/SharpTSSocket.cs
+++ b/Runtime/Types/SharpTSSocket.cs
@@ -508,7 +508,15 @@ public class SharpTSSocket : SharpTSEventEmitter
         {
             _writeChain = _writeChain.ContinueWith(_ =>
             {
-                ShutdownWritable();
+                // Enqueue BEFORE the FIN goes out: an in-process peer's 'end' is
+                // scheduled only after its read loop sees the FIN, and equal-deadline
+                // timers fire in insertion order, so the end callback can never be
+                // overtaken by the peer's 'end' — Node's deterministic ordering, which
+                // enqueueing after ShutdownWritable() left to a thread-pool race
+                // (#1227). If the loop runs this before ShutdownWritable() executes,
+                // the DestroyCore branch closing the transport first is harmless:
+                // ShutdownWritable catch-alls, and that branch only fires when the
+                // peer already FIN'd, where full teardown is the goal anyway.
                 interpreter.ScheduleTimer(0, 0, () =>
                 {
                     callback?.Call(interpreter, []);
@@ -518,6 +526,7 @@ public class SharpTSSocket : SharpTSEventEmitter
                         DestroyCore(interpreter, null);
                     interpreter.Unref();
                 }, isInterval: false);
+                ShutdownWritable();
             }, TaskContinuationOptions.ExecuteSynchronously);
         }
 


### PR DESCRIPTION
## Summary

Fixes #1227 — the `Socket_EndWithData_FlushesQueuedWritesBeforeFin` load flake that failed the Ubuntu CI lane on PR #1225's run. The test is correct (it pins Node's deterministic ordering); the defect was in the product.

## Root cause

`Socket.end(data, cb)` sent the FIN to the kernel **before** enqueueing the end callback onto the guest event loop:

```csharp
ShutdownWritable();                      // FIN reaches the kernel here
interpreter.ScheduleTimer(0, 0, () => {  // callback enqueued after
```

For an in-process socket pair, the peer's read task sees the FIN on another thread-pool thread and enqueues its `'end'` emission. Equal-deadline timers fire in insertion order (#1067 FIFO tie-break), so whoever calls `ScheduleTimer` first wins. If the ending side's thread is preempted in the instruction gap between shutdown and enqueue — a saturated 2-core CI runner — the peer's `'end'` overtakes the end callback. Node is deterministic here by construction (single-threaded loop processes the client's `'finish'` before polling the server socket); SharpTS delivers kernel completions from multiple pool threads, so the ordering must be enforced by enqueue order, not timing.

Same family as the two load-visible event-loop ordering bugs found in the #1067 epic.

## Fix

Swap to **enqueue-then-shutdown** at all three sites: interpreted `SharpTSSocket.End`, the compiled write-worker exit path, and the compiled `End` inline-shutdown path. The callback is then provably in the loop queue before the FIN can reach the peer, so FIFO delivery guarantees Node's ordering under any load.

The new interleaving (loop runs the callback task before the shutdown executes on the pool thread) is safe: the `DestroyCore`/`Destroy` branch only fires when the peer already FIN'd — where full teardown is the goal — and `ShutdownWritable`/`_ShutdownWritable` catch-all a closed transport.

## Verification

- Full xUnit suite (the load condition that surfaced the race): **15295 / 0**
- Net family (`NetTransportParityTests`, `NetModuleTests`, lifecycle): **74 / 74**
- The formerly-flaky test: 10 consecutive runs, both modes, green
- Compiled net program with `--verify`: IL verification passed, output is Node's exact ordering (`end cb once` → `server saw abc`)
- TypeScriptConformance: **31 / 0**; Test262: **22 / 0** (4 skip, baseline)