### PR TITLE
fix(compile): #1222 capture the shadowing block-scoped local, not the shadowed module binding

### DIFF
--- a/Compilation/AsyncArrowMoveNextEmitter.Variables.cs
+++ b/Compilation/AsyncArrowMoveNextEmitter.Variables.cs
@@ -81,6 +81,17 @@ public partial class AsyncArrowMoveNextEmitter
             return;
         }
 
+        // #1222: a top-level BLOCK-scoped shadow is captured BY VALUE into this state
+        // machine — read the snapshot field; the entry-DC static field below holds the
+        // same-named OUTER (module-level) binding.
+        if (TryGetShadowedTopLevelCaptureField(name, out var shadowReadField))
+        {
+            _il.Emit(OpCodes.Ldarg_0);
+            _il.Emit(OpCodes.Ldfld, shadowReadField);
+            SetStackUnknown();
+            return;
+        }
+
         // Fallback: Check if it's a captured top-level variable in entry-point display class
         if (_ctx?.CapturedTopLevelVars?.Contains(name) == true &&
             _ctx.EntryPointDisplayClassFields?.TryGetValue(name, out var entryPointField) == true &&
@@ -157,6 +168,20 @@ public partial class AsyncArrowMoveNextEmitter
             _il.Emit(OpCodes.Ldloc, temp);
             _il.Emit(OpCodes.Stfld, ownAssignField);
             SetStackUnknown();                 // remaining copy is the assignment's value
+            return;
+        }
+
+        // #1222: write the shadow's by-value snapshot field, never the same-named outer
+        // module binding's entry-DC home. (Lost on exit like every standalone-capture
+        // write — matching the by-value semantics of #641/#684.)
+        if (TryGetShadowedTopLevelCaptureField(name, out var shadowAssignField))
+        {
+            var shadowTemp = _il.DeclareLocal(_types.Object);
+            _il.Emit(OpCodes.Stloc, shadowTemp);
+            _il.Emit(OpCodes.Ldarg_0);
+            _il.Emit(OpCodes.Ldloc, shadowTemp);
+            _il.Emit(OpCodes.Stfld, shadowAssignField);
+            SetStackUnknown();
             return;
         }
 
@@ -284,6 +309,18 @@ public partial class AsyncArrowMoveNextEmitter
             return;
         }
 
+        // #1222: write the shadow's by-value snapshot field, never the same-named outer
+        // module binding's entry-DC home (mirror of the EmitAssign branch above).
+        if (TryGetShadowedTopLevelCaptureField(name, out var shadowStoreField))
+        {
+            var shadowTemp = _il.DeclareLocal(_types.Object);
+            _il.Emit(OpCodes.Stloc, shadowTemp);
+            _il.Emit(OpCodes.Ldarg_0);
+            _il.Emit(OpCodes.Ldloc, shadowTemp);
+            _il.Emit(OpCodes.Stfld, shadowStoreField);
+            return;
+        }
+
         // Check if it's a captured top-level variable in entry-point display class
         if (_ctx?.CapturedTopLevelVars?.Contains(name) == true &&
             _ctx.EntryPointDisplayClassFields?.TryGetValue(name, out var entryPointField) == true &&
@@ -397,6 +434,22 @@ public partial class AsyncArrowMoveNextEmitter
         // Fallback: null
         _il.Emit(OpCodes.Ldnull);
         SetStackType(StackType.Null);
+    }
+
+    /// <summary>
+    /// True when <paramref name="name"/> is a top-level BLOCK-scoped shadow of a same-named
+    /// module-level binding, captured by value into this standalone arrow's state machine
+    /// (#1222). Reads/writes must use the snapshot field: the entry-DC static field holds
+    /// the OUTER binding. #1201-lifted bindings are excluded — their home IS the entry-DC
+    /// field and must stay live for mutation visibility.
+    /// </summary>
+    private bool TryGetShadowedTopLevelCaptureField(string name, out FieldBuilder field)
+    {
+        field = null!;
+        return _builder.IsStandalone
+            && _builder.StandaloneCaptureFields.TryGetValue(name, out field!)
+            && _ctx?.ClosureAnalyzer?.IsDirectTopLevelBlockScopedCapture(_builder.Arrow, name) == true
+            && _ctx.LiftedBlockScopedTopLevelVars?.Contains(name) != true;
     }
 
     /// <summary>

--- a/Compilation/ClosureAnalyzer.cs
+++ b/Compilation/ClosureAnalyzer.cs
@@ -51,6 +51,17 @@ public class ClosureAnalyzer : AstVisitorBase
     // name-matching across unrelated scopes (which aliases shadowed names).
     private readonly Dictionary<object, Dictionary<string, object>> _captureSources = [];
 
+    // Maps closure node → captured names whose binding is a top-level BLOCK-scoped
+    // declaration (the nearest declaring scope outside every function is a nested
+    // scope, not the module root), captured by a closure created DIRECTLY in
+    // top-level code (function stack depth 1). Such a capture must snapshot the
+    // block's local like any ordinary local capture: a same-named entry-point
+    // display class field belongs to a DIFFERENT (module-level) binding that the
+    // block one shadows (#1222). Recorded only at depth 1 because a nested
+    // closure's creation site can't see the entry method's locals — those shapes
+    // keep the historical $entryPointDC chain routing.
+    private readonly Dictionary<object, HashSet<string>> _directTopLevelBlockCaptures = [];
+
     // Maps function/arrow node → names it declares as `for (let/const …)` loop
     // bindings. Each iteration of such a loop gets its OWN binding (ECMA-262
     // 13.7.4 CreatePerIterationEnvironment), so a closure created in one iteration
@@ -160,6 +171,21 @@ public class ClosureAnalyzer : AstVisitorBase
                sources.TryGetValue(name, out var src)
             ? src
             : null;
+    }
+
+    /// <summary>
+    /// True when <paramref name="functionNode"/> — a closure created directly in
+    /// top-level code — captures <paramref name="name"/> from a top-level BLOCK
+    /// scope rather than the module root scope (#1222). The capture then denotes
+    /// the block's binding, which may lexically shadow a same-named module-level
+    /// binding; name-keyed routing to the entry-point display class would read
+    /// the outer binding instead. Callers must still exclude #1201-lifted
+    /// bindings (whose home IS the display-class field) before rerouting.
+    /// </summary>
+    public bool IsDirectTopLevelBlockScopedCapture(object functionNode, string name)
+    {
+        return _directTopLevelBlockCaptures.TryGetValue(functionNode, out var names) &&
+               names.Contains(name);
     }
 
 
@@ -299,7 +325,41 @@ public class ClosureAnalyzer : AstVisitorBase
 
                 PropagateCaptureUpAsyncArrowChain(name, definingFunc);
             }
+            else if (_functionStack.Count == 1 && IsNearestDeclaringScopeNested(name))
+            {
+                // Top-level capture (no enclosing function defines the name) whose
+                // nearest declaring scope is a nested top-level block, referenced by
+                // a closure created directly in top-level code (#1222) — see
+                // _directTopLevelBlockCaptures.
+                if (!_directTopLevelBlockCaptures.TryGetValue(_currentFunction, out var blockCaps))
+                {
+                    blockCaps = [];
+                    _directTopLevelBlockCaptures[_currentFunction] = blockCaps;
+                }
+                blockCaps.Add(name);
+            }
         }
+    }
+
+    /// <summary>
+    /// True when the innermost scope on the stack declaring <paramref name="name"/>
+    /// is NOT the root (module) scope. Only meaningful for names with no defining
+    /// function (see <see cref="FindDefiningFunction"/>): for those, every scope
+    /// declaring the name lies in the top-level region, so a non-root hit means a
+    /// top-level block binding. <c>Stack&lt;T&gt;</c> enumerates LIFO, so the last
+    /// scope enumerated is the root pushed by <see cref="Analyze"/>.
+    /// </summary>
+    private bool IsNearestDeclaringScopeNested(string name)
+    {
+        int index = 0;
+        int count = _scopeStack.Count;
+        foreach (var scope in _scopeStack)
+        {
+            index++;
+            if (scope.Contains(name))
+                return index < count;
+        }
+        return false;
     }
 
     /// <summary>

--- a/Compilation/ILCompiler.ArrowFunctions.cs
+++ b/Compilation/ILCompiler.ArrowFunctions.cs
@@ -338,8 +338,15 @@ public partial class ILCompiler
 
                 foreach (var capturedVar in captures)
                 {
-                    // Skip top-level captured vars - they'll be accessed through $entryPointDC
-                    if (_closures.CapturedTopLevelVars.Contains(capturedVar))
+                    // Skip top-level captured vars - they'll be accessed through $entryPointDC.
+                    // #1222 exception: when THIS arrow's capture is an unlifted top-level
+                    // BLOCK-scoped binding, the same-named entry-DC field belongs to a
+                    // DIFFERENT binding (typically the module-level one the block binding
+                    // shadows — the declared-more-than-once name is exactly what the #1201
+                    // lift declined). Give the capture its own copy field so it snapshots
+                    // the creating scope's local like any ordinary local capture.
+                    if (_closures.CapturedTopLevelVars.Contains(capturedVar) &&
+                        !IsShadowedTopLevelBlockCapture(arrow, capturedVar))
                         continue;
 
                     // Skip function-level captured vars - they'll be accessed through $functionDC.
@@ -433,6 +440,27 @@ public partial class ILCompiler
             // args must pad with the `undefined` sentinel (JS semantics), not CLR null. (#640)
             MarkPadsUndefined(_closures.ArrowMethods[arrow]);
         }
+    }
+
+    /// <summary>
+    /// True when <paramref name="arrow"/>'s capture of <paramref name="name"/> resolves to a
+    /// top-level BLOCK-scoped binding that was NOT lifted onto the entry-point display class
+    /// (#1201's declared-exactly-once rule declined it, so the name is also declared elsewhere
+    /// — typically the module-level binding the block one shadows). Such a capture must not
+    /// ride the $entryPointDC chain: the same-named DC field is a DIFFERENT binding (#1222).
+    /// The analyzer records the flag only for closures created directly in top-level code, so
+    /// nested closures keep the historical chain routing. The lifted-set lookup uses the
+    /// arrow's own module key — registration and collection both key scripts under
+    /// <see cref="ClosureCompilationState.SingleFileKey"/> via a null path.
+    /// </summary>
+    private bool IsShadowedTopLevelBlockCapture(Expr.ArrowFunction arrow, string name)
+    {
+        if (!_closures.Analyzer.IsDirectTopLevelBlockScopedCapture(arrow, name))
+            return false;
+        _arrowToModule.TryGetValue(arrow, out var modulePath);
+        string key = modulePath ?? ClosureCompilationState.SingleFileKey;
+        return !(_closures.ModuleLiftedBlockScopedVars.TryGetValue(key, out var lifted) &&
+                 lifted.Contains(name));
     }
 
     private void CollectArrowsFromStmt(Stmt stmt)

--- a/Compilation/ILCompiler.Async.cs
+++ b/Compilation/ILCompiler.Async.cs
@@ -1408,6 +1408,10 @@ public partial class ILCompiler
                 ClassRegistry = GetClassRegistry(),
                 EntryPointDisplayClassFields = BuildEntryPointDisplayClassFieldsForModule(_modules.CurrentPath),
                 CapturedTopLevelVars = BuildCapturedTopLevelVarsForModule(_modules.CurrentPath),
+                // #1222: lets the shadow-capture check distinguish a #1201-lifted binding
+                // (home = entry-DC field, must stay live) from a block-scoped shadow
+                // (by-value standalone capture) — see TryGetShadowedTopLevelCaptureField.
+                LiftedBlockScopedTopLevelVars = BuildLiftedBlockScopedTopLevelVarsForModule(_modules.CurrentPath),
                 ArrowEntryPointDCFields = _closures.ArrowEntryPointDCFields.Count > 0 ? _closures.ArrowEntryPointDCFields : null,
                 EntryPointDisplayClassStaticField = _closures.EntryPointDisplayClassStaticField,
                 // Follow-up to #838: lets this standalone async arrow's MoveNext populate a nested sync

--- a/Compilation/ILEmitter.Calls.Closures.cs
+++ b/Compilation/ILEmitter.Calls.Closures.cs
@@ -427,6 +427,23 @@ public partial class ILEmitter
                 IL.Emit(OpCodes.Ldfld, parentScopeField);
             }
             else if (_ctx.CapturedTopLevelVars?.Contains(capturedVar) == true &&
+                     _ctx.EntryPointDisplayClassFields?.ContainsKey(capturedVar) == true &&
+                     _ctx.ClosureAnalyzer?.IsDirectTopLevelBlockScopedCapture(af, capturedVar) == true &&
+                     _ctx.Locals.GetNestedScopeLocal(capturedVar) is { } shadowLocal)
+            {
+                // #1222: the creating scope's block-scoped local lexically shadows the
+                // same-named module-level binding whose home is the entry-DC field
+                // handled below. Snapshot the shadow like any local capture — the DC
+                // branch would misroute the capture to the OUTER binding. (#1201-lifted
+                // bindings never take this path: their declarations write the DC field
+                // directly and declare no local, so GetNestedScopeLocal returns null.)
+                IL.Emit(OpCodes.Ldloc, shadowLocal);
+                if (shadowLocal.LocalType.IsValueType)
+                {
+                    IL.Emit(OpCodes.Box, shadowLocal.LocalType);
+                }
+            }
+            else if (_ctx.CapturedTopLevelVars?.Contains(capturedVar) == true &&
                      _ctx.EntryPointDisplayClassFields?.TryGetValue(capturedVar, out var entryPointField) == true)
             {
                 // Variable is a captured top-level var in entry-point display class

--- a/Compilation/ILEmitter.Operators.cs
+++ b/Compilation/ILEmitter.Operators.cs
@@ -1142,9 +1142,13 @@ public partial class ILEmitter
             return;
         }
 
-        // Check entry-point display class (captured top-level vars).
+        // Check entry-point display class (captured top-level vars). #1222: an in-scope
+        // local declared in a NESTED scope is a block-scoped shadow of the module-level
+        // binding (module bindings never declare locals) — let it fall through to the
+        // local store below instead of clobbering the outer binding's DC field.
         if (_ctx.CapturedTopLevelVars?.Contains(name) == true &&
-            _ctx.EntryPointDisplayClassFields?.TryGetValue(name, out var entryPointField) == true)
+            _ctx.EntryPointDisplayClassFields?.TryGetValue(name, out var entryPointField) == true &&
+            _ctx.Locals.GetNestedScopeLocal(name) == null)
         {
             if (isTypedDouble) IL.Emit(OpCodes.Box, _ctx.Types.Double);
             var temp = IL.DeclareLocal(_ctx.Types.Object);

--- a/Compilation/LocalsManager.cs
+++ b/Compilation/LocalsManager.cs
@@ -21,12 +21,14 @@ namespace SharpTS.Compilation;
 public class LocalsManager(ILGenerator il)
 {
     // Stack-based storage to support variable shadowing
-    // Each variable name maps to a stack of (LocalBuilder, Type, Tag) entries. Tag is an optional,
-    // emitter-defined marker attached to the binding (e.g. the Expr.ArrowFunction node of a
+    // Each variable name maps to a stack of (LocalBuilder, Type, Tag, ScopeDepth) entries. Tag is an
+    // optional, emitter-defined marker attached to the binding (e.g. the Expr.ArrowFunction node of a
     // non-capturing non-escaping direct-call arrow, #858 follow-up): it lets a call site key off the
     // *actual in-scope binding* rather than the bare name, so a same-named parameter/local in another
     // scope (which carries no tag) can never be mistaken for it. Block-scoped like the local itself.
-    private readonly Dictionary<string, Stack<(LocalBuilder Local, Type Type, object? Tag)>> _localStacks = [];
+    // ScopeDepth records the _scopes depth at declaration (method root = 1), so shadow-sensitive
+    // consumers can tell a block-scoped binding from a method-root one (#1222).
+    private readonly Dictionary<string, Stack<(LocalBuilder Local, Type Type, object? Tag, int ScopeDepth)>> _localStacks = [];
 
     // Track which variables were declared in each scope for cleanup
     private readonly Stack<List<string>> _scopes = new([[]]);
@@ -40,12 +42,12 @@ public class LocalsManager(ILGenerator il)
         // Get or create the stack for this variable name
         if (!_localStacks.TryGetValue(name, out var stack))
         {
-            stack = new Stack<(LocalBuilder, Type, object?)>();
+            stack = new Stack<(LocalBuilder, Type, object?, int)>();
             _localStacks[name] = stack;
         }
 
         // Push the new local onto the stack (shadows any outer variable with same name)
-        stack.Push((local, type, tag));
+        stack.Push((local, type, tag, _scopes.Count));
 
         // Track that this name was declared in the current scope
         _scopes.Peek().Add(name);
@@ -80,11 +82,11 @@ public class LocalsManager(ILGenerator il)
     {
         if (!_localStacks.TryGetValue(name, out var stack))
         {
-            stack = new Stack<(LocalBuilder, Type, object?)>();
+            stack = new Stack<(LocalBuilder, Type, object?, int)>();
             _localStacks[name] = stack;
         }
 
-        stack.Push((local, local.LocalType, null));
+        stack.Push((local, local.LocalType, null, _scopes.Count));
 
         if (_scopes.Count > 0)
             _scopes.Peek().Add(name);
@@ -105,6 +107,25 @@ public class LocalsManager(ILGenerator il)
 
     public bool HasLocal(string name) =>
         _localStacks.TryGetValue(name, out var stack) && stack.Count > 0;
+
+    /// <summary>
+    /// Returns the in-scope local for <paramref name="name"/> ONLY when its current binding
+    /// was declared inside a nested (block) scope; null for method-root locals and unbound
+    /// names. A module-level binding never has such a local — module bindings live on the
+    /// entry-point display class or a static field and their declarations never reach
+    /// <see cref="DeclareLocal(string, Type)"/> — so a nested-scope local whose name also has
+    /// a module-level home is always a lexical shadow of that binding (#1222).
+    /// </summary>
+    public LocalBuilder? GetNestedScopeLocal(string name)
+    {
+        if (_localStacks.TryGetValue(name, out var stack) && stack.Count > 0)
+        {
+            var binding = stack.Peek();
+            if (binding.ScopeDepth > 1)
+                return binding.Local;
+        }
+        return null;
+    }
 
     /// <summary>
     /// Gets the optional emitter-defined tag attached to the in-scope binding for <paramref name="name"/>

--- a/SharpTS.Tests/SharedTests/TopLevelBlockScopeCaptureTests.cs
+++ b/SharpTS.Tests/SharedTests/TopLevelBlockScopeCaptureTests.cs
@@ -227,6 +227,146 @@ public class TopLevelBlockScopeCaptureTests
         Assert.Equal("main ran\nlib set=1 n=1\nlib set=2 n=2\n", output);
     }
 
+    // ── #1222: block-scoped shadow of a captured module-level binding ────────────
+    // When a top-level block declares a let/const that SHADOWS a same-named captured
+    // module-level binding, the name fails #1201's declared-exactly-once rule, so the
+    // block binding stays a plain local. Closures created in the block must capture
+    // that local — before the fix, name-keyed routing sent the capture to the module
+    // binding's entry-point-DC field, so compiled closures read the OUTER value.
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ShadowedModuleBinding_ClosureCapturesBlockLocal(ExecutionMode mode)
+    {
+        // The issue's exact reproducer: compiled printed "outer\nouter".
+        var source = """
+            let sh = 'outer';
+            const getOuter = () => sh;
+            if (true) {
+                let sh = 'inner';
+                const getInner = () => sh;
+                console.log(getInner());
+            }
+            console.log(getOuter());
+            """;
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("inner\nouter\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ShadowedModuleBinding_AsyncArrowReadsShadow(ExecutionMode mode)
+    {
+        // Standalone async arrows deliberately read captured top-level names LIVE from
+        // the entry-DC static field; for a shadow that live read hit the OUTER binding.
+        // The shadow must come from the arrow's by-value snapshot field instead.
+        var source = """
+            let sh = 'outer';
+            const getOuter = () => sh;
+            if (true) {
+                let sh = 'inner';
+                const getInner = async () => sh;
+                getInner().then(v => console.log('async=' + v));
+            }
+            setTimeout(() => console.log('module=' + getOuter()), 10);
+            """;
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("async=inner\nmodule=outer\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ShadowedModuleBinding_AsyncArrowWriteDoesNotClobberModule(ExecutionMode mode)
+    {
+        // A write to the shadow inside the async arrow must land on the arrow's
+        // snapshot field — before the fix it overwrote the module binding's DC field.
+        var source = """
+            let sh = 'outer';
+            const getOuter = () => sh;
+            if (true) {
+                let sh = 'inner';
+                const clobber = async () => { sh = 'clobbered'; return sh; };
+                clobber().then(v => console.log('ret=' + v));
+            }
+            setTimeout(() => console.log('module=' + getOuter()), 10);
+            """;
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("ret=clobbered\nmodule=outer\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ShadowedModuleBinding_IncrementAndCompoundTargetShadow(ExecutionMode mode)
+    {
+        // ++ and += store-backs resolved the entry-DC field before locals, so they
+        // wrote the module binding while plain reads saw the block local.
+        var source = """
+            let n = 100;
+            const getN = () => n;
+            if (true) {
+                let n = 1;
+                n++;
+                n += 2;
+                const g = () => n;
+                console.log('block=' + g() + ',' + n);
+            }
+            console.log('module=' + getN());
+            """;
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("block=4,4\nmodule=100\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ShadowedModuleBinding_FunctionDeclarationInBlock(ExecutionMode mode)
+    {
+        // Function DECLARATIONS in top-level blocks are lambda-lifted with by-value
+        // capture forwarding (#605/#622); the forwarded argument is resolved at the
+        // call site, locals first, so it picks up the shadow.
+        var source = """
+            let f = 'outer';
+            const getOuter = () => f;
+            if (true) {
+                let f = 'inner';
+                function getInner(): string { return f; }
+                console.log(getInner());
+            }
+            console.log(getOuter());
+            """;
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("inner\nouter\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ShadowedModuleBinding_InImportedModule(ExecutionMode mode)
+    {
+        // Module-init methods reach the entry-point DC through its static field;
+        // the shadow decision must hold there too. (The module binding and its
+        // reader are deliberately NOT exported directly — an exported arrow
+        // capturing an exported let is a distinct pre-existing compiled-module
+        // bug, unrelated to shadowing.)
+        var files = new Dictionary<string, string>
+        {
+            ["lib.ts"] = """
+                let tag = 'outer';
+                const getOuter = () => tag;
+                export function readOuter(): string { return getOuter(); }
+                if (true) {
+                    let tag = 'inner';
+                    const getInner = () => tag;
+                    console.log('lib=' + getInner());
+                }
+                """,
+            ["main.ts"] = """
+                import { readOuter } from './lib';
+                console.log('main=' + readOuter());
+                """,
+        };
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("lib=inner\nmain=outer\n", output);
+    }
+
     [Theory]
     [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
     public void BlockScopedCapture_FunctionExpression_SharesEnvironment(ExecutionMode mode)


### PR DESCRIPTION
Closes #1222

## Problem

When a top-level block declares a `let`/`const` that **shadows a captured module-level binding of the same name**, a closure created in that block captured the **module-level** binding:

```ts
let sh = 'outer';
const getOuter = () => sh;
if (true) {
    let sh = 'inner';
    const getInner = () => sh;
    console.log(getInner());  // interp: 'inner' — compiled (before): 'outer'
}
console.log(getOuter());      // 'outer' in both
```

Same silent-wrong-value class as #1105/#1201: IL verifies clean, nothing flags it at compile time.

## Root cause

Name-keyed routing of captured top-level names conflated the two same-named bindings in **three** places, not just the populate the issue pointed at:

1. **Field definition** (`ILCompiler.ArrowFunctions.cs`): any capture whose name is in `CapturedTopLevelVars` was skipped from the arrow's copy-field map and routed through the `$entryPointDC` chain — so the arrow body read the module binding live.
2. **Capture-populate** (`ILEmitter.Calls.Closures.cs`, the issue's root cause): the entry-DC branch preceded the `Locals` fallback.
3. **`++`/`+=` store-back** (`ILEmitter.Operators.cs`): same entry-DC-before-locals order, so compound writes to the shadow clobbered the module binding while plain reads saw the local (split-brain).

Standalone **async** arrows had the same bug via a fourth path: their MoveNext deliberately reads captured top-level names live from the entry-DC static field (correct for module bindings), which for a shadow read — and worse, **wrote** — the outer binding.

## Fix (shadow-aware source decision, per the issue's guidance — no blanket reorder)

- **`ClosureAnalyzer`** records `(closure, name)` pairs where a closure created *directly in top-level code* (function-stack depth 1) captures a binding whose nearest declaring scope is a top-level **block**, not the module root. Only these can shadow a module home; nested closures (whose creation sites can't see the entry method's locals) keep the historical chain routing.
- **Field definition** exempts analyzer-confirmed, **unlifted** block captures from the `$entryPointDC` skip (lifted check keyed per module via `_arrowToModule` — #1201-lifted bindings' home IS the DC field and must keep the chain). The shadow gets an ordinary snapshot copy field.
- **Populate + store-back** prefer an in-scope **nested-scope** local via new `LocalsManager.GetNestedScopeLocal` (declaration scope depth is now tracked). Module bindings never declare locals, so a nested-scope local with a module-homed name is always the lexical shadow; lifted bindings declare no local, so they can't take this path.
- **Standalone async arrows** (`AsyncArrowMoveNextEmitter.Variables.cs`) read/write the shadow's by-value snapshot field (`StandaloneCaptureFields`) instead of the live entry-DC field, in all three resolution sites (read / assign / store). Writes previously **corrupted the module binding**; now they stay in the snapshot, matching the by-value semantics of #641/#684. The standalone async-arrow context now threads `LiftedBlockScopedTopLevelVars` so lifted bindings keep the live path (mutation visibility, #1201).

## Tests

6 new dual-mode theories in `TopLevelBlockScopeCaptureTests`: the exact issue reproducer, async arrow read, async arrow write (module binding intact), `++`/`+=` targeting the shadow, function-declaration-in-block (lifter path), and a module-mode variant (entry-DC-via-static-field context).

## Gates

- xUnit **15,301 / 0 failed**
- Test262 **22 / 0 / 4 skip — baseline-identical** (interp + compiled)
- TypeScriptConformance **31 / 0**
- `--verify` clean on the reproducers

## Found along the way

**#1229** (pre-existing, A/B-verified on main): an `export const` arrow capturing an `export let` is not callable cross-module in compiled mode (`TypeError: object is not a function`). Unrelated to shadowing; the new module-mode test deliberately avoids that shape.