### PR TITLE
fix(compile): #1223 per-iteration closure capture for loop-body block-scoped vars

### DIFF
--- a/Compilation/ClosureAnalyzer.cs
+++ b/Compilation/ClosureAnalyzer.cs
@@ -68,6 +68,40 @@ public class ClosureAnalyzer : AstVisitorBase
     // shared function-DC slot, so it is excluded from the loop-binding set.
     private readonly Dictionary<object, HashSet<string>> _functionNonLoopDecls = [];
 
+    // Names declared by a block-scoped `let`/`const` inside a LOOP BODY of a
+    // function/arrow, plus `for-of`/`for-in` loop variables (#1223). Like the
+    // for-initializer bindings above, each iteration creates a fresh binding
+    // (ECMA-262 13.7.4 / 14.7.5.13), so a closure created in one iteration must
+    // not share a function-DC slot with other iterations. Only names that are
+    // never reassigned after initialization are excluded from the DC (see
+    // GetPerIterationLoopBindings) — for those, the closure's creation-time
+    // snapshot is indistinguishable from a live per-iteration binding.
+    private readonly Dictionary<object, HashSet<string>> _functionLoopBodyDecls = [];
+
+    // Names assigned (=, compound/logical assign, ++/--) anywhere in the program,
+    // including inside nested closures. Program-global and name-keyed on purpose:
+    // an assignment to `x` anywhere conservatively disqualifies every loop-body
+    // declaration named `x` from the per-iteration exclusion, keeping today's
+    // shared-DC mutation visibility for reassigned bindings.
+    private readonly HashSet<string> _assignedNames = [];
+
+    // Defining function → names captured INDIRECTLY from it: the capturing closure
+    // has at least one intermediate callable between itself and the defining scope
+    // (e.g. `() => () => x` where `x` belongs to the enclosing function). Sync-arrow
+    // capture sets stay innermost-only, so such captures are relayed through a
+    // shared scope display class — a name kept out of the DC would populate as null
+    // at the inner closure's creation site (the intermediate body cannot see the
+    // local). Loop-body declarations captured this way therefore decline the
+    // per-iteration exclusion and keep their DC slot (today's fused-iteration
+    // behavior, matching the pre-existing top-level snapshot limitation).
+    private readonly Dictionary<object, HashSet<string>> _functionRelayCaptures = [];
+
+    // Loop-BODY nesting depth within the CURRENT function/arrow. Zero outside
+    // loop bodies; saved/reset/restored across nested function boundaries (a
+    // nested callable's own declarations are not per-iteration relative to an
+    // enclosing loop of its parent).
+    private int _loopBodyDepth;
+
     // ============================================
     // Performance optimization: Inverse index
     // ============================================
@@ -131,21 +165,46 @@ public class ClosureAnalyzer : AstVisitorBase
 
     /// <summary>
     /// Returns the names that <paramref name="functionNode"/> declares EXCLUSIVELY as
-    /// <c>for (let/const …)</c> loop bindings (never also as an ordinary local/param).
+    /// per-iteration loop bindings (never also as an ordinary local/param):
+    /// <c>for (let/const …)</c> initializer bindings (#649), plus loop-BODY block-scoped
+    /// <c>let</c>/<c>const</c> declarations and <c>for-of</c>/<c>for-in</c> loop variables
+    /// that are never reassigned and never captured through an intermediate closure (#1223).
     /// These must be kept out of the shared function display class so closures created
-    /// in different iterations capture distinct per-iteration values (ECMA-262 13.7.4;
-    /// #649). Callers intersect this with the captured-locals set.
+    /// in different iterations capture distinct per-iteration values (ECMA-262 13.7.4).
+    /// Callers intersect this with the captured-locals set.
     /// </summary>
     public HashSet<string> GetPerIterationLoopBindings(object functionNode)
     {
-        if (!_functionLoopBindings.TryGetValue(functionNode, out var bindings) || bindings.Count == 0)
-            return [];
-        var result = new HashSet<string>(bindings);
+        var result = _functionLoopBindings.TryGetValue(functionNode, out var bindings)
+            ? new HashSet<string>(bindings)
+            : [];
         // Shadow-safety: a name that is ALSO an ordinary declaration in this function
         // keeps its shared slot (an ordinary captured-and-mutated local must stay in
         // the function DC). Only purely-loop bindings are eligible for exclusion.
-        if (_functionNonLoopDecls.TryGetValue(functionNode, out var nonLoop))
+        _functionNonLoopDecls.TryGetValue(functionNode, out var nonLoop);
+        if (nonLoop != null)
             result.ExceptWith(nonLoop);
+
+        // Loop-BODY block-scoped declarations (#1223): per-iteration bindings like the
+        // for-initializer names above, but excluded only when never reassigned — a
+        // reassigned binding keeps its shared DC slot so mutations made after a closure
+        // captures it stay visible within the iteration (today's behavior). Never-
+        // reassigned bindings have a constant value per iteration, so the closure's
+        // creation-time snapshot is exactly the per-iteration binding. Names captured
+        // through an intermediate closure also keep their DC slot — the snapshot
+        // populate cannot reach the local from the intermediate body (see
+        // _functionRelayCaptures).
+        if (_functionLoopBodyDecls.TryGetValue(functionNode, out var bodyDecls))
+        {
+            _functionRelayCaptures.TryGetValue(functionNode, out var relayed);
+            foreach (var name in bodyDecls)
+            {
+                if (nonLoop != null && nonLoop.Contains(name)) continue;
+                if (_assignedNames.Contains(name)) continue;
+                if (relayed != null && relayed.Contains(name)) continue;
+                result.Add(name);
+            }
+        }
         return result;
     }
 
@@ -209,9 +268,9 @@ public class ClosureAnalyzer : AstVisitorBase
             // Unlike var, no source-order initialization is implied — capture analysis only needs to
             // know which scope OWNS the name so the inner function shares the binding's slot.
             else if (stmt is Stmt.Var lt && !lt.IsVar)
-                DeclareVariable(lt.Name.Lexeme);
+                DeclareVariable(lt.Name.Lexeme, isPerIterationBinding: true);
             else if (stmt is Stmt.Const ct)
-                DeclareVariable(ct.Name.Lexeme);
+                DeclareVariable(ct.Name.Lexeme, isPerIterationBinding: true);
         }
     }
 
@@ -220,7 +279,12 @@ public class ClosureAnalyzer : AstVisitorBase
     private void EnterScope() => _scopeStack.Push([]);
     private void ExitScope() => _scopeStack.Pop();
 
-    private void DeclareVariable(string name)
+    /// <param name="name">The declared identifier.</param>
+    /// <param name="isPerIterationBinding">True when the declaration creates a fresh
+    /// binding per loop iteration: a block-scoped <c>let</c>/<c>const</c> (callers pass
+    /// this from the statement kind; the loop-body check happens here via
+    /// <see cref="_loopBodyDepth"/>) or a <c>for-of</c>/<c>for-in</c> loop variable.</param>
+    private void DeclareVariable(string name, bool isPerIterationBinding = false)
     {
         if (_scopeStack.Count > 0)
             _scopeStack.Peek().Add(name);
@@ -232,12 +296,23 @@ public class ClosureAnalyzer : AstVisitorBase
         // Record every NON-loop declaration so the per-iteration exclusion stays
         // shadow-safe (see _functionNonLoopDecls). A for-let/const loop binding is
         // declared with its name parked in _pendingLoopBindings, so it is skipped
-        // here and counts only as a loop binding.
+        // here and counts only as a loop binding. A block-scoped let/const inside a
+        // loop body is likewise a per-iteration binding (#1223) and counts in
+        // _functionLoopBodyDecls instead of the non-loop set.
         if (_currentFunction != null && !_pendingLoopBindings.Contains(name))
         {
-            if (!_functionNonLoopDecls.TryGetValue(_currentFunction, out var nonLoop))
-                _functionNonLoopDecls[_currentFunction] = nonLoop = [];
-            nonLoop.Add(name);
+            if (isPerIterationBinding && _loopBodyDepth > 0)
+            {
+                if (!_functionLoopBodyDecls.TryGetValue(_currentFunction, out var bodyDecls))
+                    _functionLoopBodyDecls[_currentFunction] = bodyDecls = [];
+                bodyDecls.Add(name);
+            }
+            else
+            {
+                if (!_functionNonLoopDecls.TryGetValue(_currentFunction, out var nonLoop))
+                    _functionNonLoopDecls[_currentFunction] = nonLoop = [];
+                nonLoop.Add(name);
+            }
         }
     }
 
@@ -296,6 +371,27 @@ public class ClosureAnalyzer : AstVisitorBase
                     _captureSources[_currentFunction] = sources;
                 }
                 sources[name] = definingFunc;
+
+                // Indirect capture (an intermediate callable sits between this closure
+                // and the defining scope): the value can only reach this closure via a
+                // shared DC relay, so the name must not take the per-iteration
+                // snapshot path (#1223 — see _functionRelayCaptures).
+                bool passedCurrent = false;
+                foreach (var frame in _functionStack)
+                {
+                    if (!passedCurrent)
+                    {
+                        if (ReferenceEquals(frame, _currentFunction)) passedCurrent = true;
+                        continue;
+                    }
+                    if (!ReferenceEquals(frame, definingFunc))
+                    {
+                        if (!_functionRelayCaptures.TryGetValue(definingFunc, out var relayed))
+                            _functionRelayCaptures[definingFunc] = relayed = [];
+                        relayed.Add(name);
+                    }
+                    break;
+                }
 
                 PropagateCaptureUpAsyncArrowChain(name, definingFunc);
             }
@@ -369,13 +465,13 @@ public class ClosureAnalyzer : AstVisitorBase
 
     protected override void VisitVar(Stmt.Var stmt)
     {
-        DeclareVariable(stmt.Name.Lexeme);
+        DeclareVariable(stmt.Name.Lexeme, isPerIterationBinding: !stmt.IsVar);
         base.VisitVar(stmt);
     }
 
     protected override void VisitConst(Stmt.Const stmt)
     {
-        DeclareVariable(stmt.Name.Lexeme);
+        DeclareVariable(stmt.Name.Lexeme, isPerIterationBinding: true);
         base.VisitConst(stmt);
     }
 
@@ -446,8 +542,12 @@ public class ClosureAnalyzer : AstVisitorBase
         // Visit iterable BEFORE creating loop scope - matches interpreter/resolver behavior
         Visit(stmt.Iterable);
         EnterScope();
-        DeclareVariable(stmt.Variable.Lexeme);
+        // The loop variable and body declarations are per-iteration bindings (#1223):
+        // depth is bumped before the variable's declare so it lands in the loop-body set.
+        _loopBodyDepth++;
+        DeclareVariable(stmt.Variable.Lexeme, isPerIterationBinding: true);
         Visit(stmt.Body);
+        _loopBodyDepth--;
         ExitScope();
     }
 
@@ -456,9 +556,27 @@ public class ClosureAnalyzer : AstVisitorBase
         // Visit object BEFORE creating loop scope - matches interpreter/resolver behavior
         Visit(stmt.Object);
         EnterScope();
-        DeclareVariable(stmt.Variable.Lexeme);
+        _loopBodyDepth++;
+        DeclareVariable(stmt.Variable.Lexeme, isPerIterationBinding: true);
         Visit(stmt.Body);
+        _loopBodyDepth--;
         ExitScope();
+    }
+
+    protected override void VisitWhile(Stmt.While stmt)
+    {
+        Visit(stmt.Condition);
+        _loopBodyDepth++;
+        Visit(stmt.Body);
+        _loopBodyDepth--;
+    }
+
+    protected override void VisitDoWhile(Stmt.DoWhile stmt)
+    {
+        _loopBodyDepth++;
+        Visit(stmt.Body);
+        _loopBodyDepth--;
+        Visit(stmt.Condition);
     }
 
     protected override void VisitFor(Stmt.For stmt)
@@ -489,7 +607,9 @@ public class ClosureAnalyzer : AstVisitorBase
             Visit(stmt.Condition);
         if (stmt.Increment != null)
             Visit(stmt.Increment);
+        _loopBodyDepth++;
         Visit(stmt.Body);
+        _loopBodyDepth--;
         ExitScope();
     }
 
@@ -552,19 +672,36 @@ public class ClosureAnalyzer : AstVisitorBase
     protected override void VisitAssign(Expr.Assign expr)
     {
         ReferenceVariable(expr.Name.Lexeme);
+        _assignedNames.Add(expr.Name.Lexeme);
         base.VisitAssign(expr);
     }
 
     protected override void VisitCompoundAssign(Expr.CompoundAssign expr)
     {
         ReferenceVariable(expr.Name.Lexeme);
+        _assignedNames.Add(expr.Name.Lexeme);
         base.VisitCompoundAssign(expr);
     }
 
     protected override void VisitLogicalAssign(Expr.LogicalAssign expr)
     {
         ReferenceVariable(expr.Name.Lexeme);
+        _assignedNames.Add(expr.Name.Lexeme);
         base.VisitLogicalAssign(expr);
+    }
+
+    protected override void VisitPrefixIncrement(Expr.PrefixIncrement expr)
+    {
+        if (expr.Operand is Expr.Variable v)
+            _assignedNames.Add(v.Name.Lexeme);
+        base.VisitPrefixIncrement(expr);
+    }
+
+    protected override void VisitPostfixIncrement(Expr.PostfixIncrement expr)
+    {
+        if (expr.Operand is Expr.Variable v)
+            _assignedNames.Add(v.Name.Lexeme);
+        base.VisitPostfixIncrement(expr);
     }
 
     protected override void VisitArrowFunction(Expr.ArrowFunction expr)
@@ -619,6 +756,10 @@ public class ClosureAnalyzer : AstVisitorBase
         // Save current context
         var previousFunction = _currentFunction;
         var previousOuter = new HashSet<string>(_outerVariables);
+        // A nested callable's own declarations are not per-iteration relative to an
+        // enclosing loop of its parent — reset the loop-body depth for its analysis.
+        var previousLoopBodyDepth = _loopBodyDepth;
+        _loopBodyDepth = 0;
 
         // Build set of outer variables for this function
         _outerVariables.Clear();
@@ -670,6 +811,7 @@ public class ClosureAnalyzer : AstVisitorBase
 
         // Restore context
         _currentFunction = previousFunction;
+        _loopBodyDepth = previousLoopBodyDepth;
         _outerVariables.Clear();
         foreach (var name in previousOuter)
             _outerVariables.Add(name);
@@ -681,6 +823,9 @@ public class ClosureAnalyzer : AstVisitorBase
         var previousFunction = _currentFunction;
         var previousOuter = new HashSet<string>(_outerVariables);
         var previousFunctionName = _currentFunctionName;
+        // See AnalyzeFunctionBody: per-iteration classification is per-callable.
+        var previousLoopBodyDepth = _loopBodyDepth;
+        _loopBodyDepth = 0;
 
         // Build set of outer variables for this function
         _outerVariables.Clear();
@@ -734,6 +879,7 @@ public class ClosureAnalyzer : AstVisitorBase
         // Restore context
         _currentFunction = previousFunction;
         _currentFunctionName = previousFunctionName;
+        _loopBodyDepth = previousLoopBodyDepth;
         _outerVariables.Clear();
         foreach (var name in previousOuter)
             _outerVariables.Add(name);

--- a/SharpTS.Tests/SharedTests/LoopBodyBlockScopeCaptureTests.cs
+++ b/SharpTS.Tests/SharedTests/LoopBodyBlockScopeCaptureTests.cs
@@ -1,0 +1,320 @@
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests;
+
+/// <summary>
+/// Regression tests for #1223: a block-scoped <c>let</c>/<c>const</c> declared in a LOOP BODY
+/// inside a function/arrow and captured by a closure must be a fresh binding per iteration
+/// (ECMA-262 13.7.4 / 14.7.5.13), not a single shared slot.
+///
+/// <para>Before the fix, such names were hoisted onto the enclosing callable's shared display
+/// class (one instance per call), so every iteration's closure read the LAST iteration's value.
+/// The #649 per-iteration exclusion only covered <c>for (let/const …)</c> initializer bindings —
+/// loop-BODY declarations (and <c>for-of</c>/<c>for-in</c> loop variables) were missed. The
+/// original symptom was a compiled net program whose two loop clients shared one `client`
+/// capture: client0's 'data' handler destroyed client1, dropping its pending data and hanging
+/// the event loop (issue #1223's "intermittent no-output hang").</para>
+///
+/// <para>The exclusion is deliberately conservative: names that are reassigned after
+/// initialization, or captured through an intermediate closure (<c>() =&gt; () =&gt; x</c>),
+/// keep their shared display-class slot — preserving within-iteration mutation visibility and
+/// the DC relay that a nested closure's populate path needs.</para>
+/// </summary>
+public class LoopBodyBlockScopeCaptureTests
+{
+    // ---- Headline #1223 shape: body const captured inside an arrow ----
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ArrowBody_ForLoopBodyConst_PerIteration(ExecutionMode mode)
+    {
+        var source = """
+            const fns: any[] = [];
+            const go = () => {
+                for (let i = 0; i < 3; i++) {
+                    const x = { id: i };
+                    fns.push(() => x.id);
+                }
+            };
+            go();
+            console.log(fns.map((f: any) => f()).join(","));
+            """;
+        Assert.Equal("0,1,2\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void FunctionBody_ForLoopBodyConst_PerIteration(ExecutionMode mode)
+    {
+        var source = """
+            const fns: any[] = [];
+            function go() {
+                for (let i = 0; i < 3; i++) {
+                    const x = { id: i };
+                    fns.push(() => x.id);
+                }
+            }
+            go();
+            console.log(fns.map((f: any) => f()).join(","));
+            """;
+        Assert.Equal("0,1,2\n", TestHarness.Run(source, mode));
+    }
+
+    // ---- The #1223 net-repro shape: shared mutable state + per-iteration object capture ----
+    // The closure captures BOTH a module-level mutable counter (stays on the entry-point DC)
+    // and the per-iteration body const; each handler must destroy ITS OWN object.
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void MixedCapture_ModuleCounterPlusBodyConst_DestroysOwnObject(ExecutionMode mode)
+    {
+        var source = """
+            let responses = 0;
+            const destroyed: string[] = [];
+            const handlers: any[] = [];
+            const listen = () => {
+                for (let i = 0; i < 2; i++) {
+                    const client = { name: "c" + i, destroy() { destroyed.push(this.name); } };
+                    handlers.push(() => { responses++; client.destroy(); });
+                }
+            };
+            listen();
+            handlers[0]();
+            handlers[1]();
+            console.log(destroyed.join(",") + " resp=" + responses);
+            """;
+        Assert.Equal("c0,c1 resp=2\n", TestHarness.Run(source, mode));
+    }
+
+    // ---- Other loop kinds ----
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void WhileLoopBodyConst_PerIteration(ExecutionMode mode)
+    {
+        var source = """
+            const fns: any[] = [];
+            function go() {
+                let i = 0;
+                while (i < 3) {
+                    const x = { id: i };
+                    fns.push(() => x.id);
+                    i++;
+                }
+            }
+            go();
+            console.log(fns.map((f: any) => f()).join(","));
+            """;
+        Assert.Equal("0,1,2\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void DoWhileLoopBodyConst_PerIteration(ExecutionMode mode)
+    {
+        var source = """
+            const fns: any[] = [];
+            function go() {
+                let i = 0;
+                do {
+                    const x = { id: i };
+                    fns.push(() => x.id);
+                    i++;
+                } while (i < 3);
+            }
+            go();
+            console.log(fns.map((f: any) => f()).join(","));
+            """;
+        Assert.Equal("0,1,2\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ForOfLoopVariable_CapturedInFunction_PerIteration(ExecutionMode mode)
+    {
+        var source = """
+            const fns: any[] = [];
+            const go = () => {
+                for (const v of [10, 20, 30]) {
+                    fns.push(() => v);
+                }
+            };
+            go();
+            console.log(fns.map((f: any) => f()).join(","));
+            """;
+        Assert.Equal("10,20,30\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ForInLoopVariable_CapturedInFunction_PerIteration(ExecutionMode mode)
+    {
+        var source = """
+            const fns: any[] = [];
+            const go = () => {
+                for (const k in { a: 1, b: 2 }) {
+                    fns.push(() => k);
+                }
+            };
+            go();
+            console.log(fns.map((f: any) => f()).join(","));
+            """;
+        Assert.Equal("a,b\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ForOfBodyConst_PerIteration(ExecutionMode mode)
+    {
+        var source = """
+            const fns: any[] = [];
+            function go() {
+                for (const v of [1, 2]) {
+                    const doubled = v * 2;
+                    fns.push(() => doubled);
+                }
+            }
+            go();
+            console.log(fns.map((f: any) => f()).join(","));
+            """;
+        Assert.Equal("2,4\n", TestHarness.Run(source, mode));
+    }
+
+    // ---- State machines: async function and generator bodies ----
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AsyncFunctionLoopBodyConst_PerIteration(ExecutionMode mode)
+    {
+        var source = """
+            const fns: any[] = [];
+            async function go() {
+                for (let i = 0; i < 3; i++) {
+                    const x = { id: i };
+                    fns.push(() => x.id);
+                    await Promise.resolve();
+                }
+            }
+            async function main() {
+                await go();
+                console.log(fns.map((f: any) => f()).join(","));
+            }
+            main();
+            """;
+        Assert.Equal("0,1,2\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void GeneratorLoopBodyConst_PerIteration(ExecutionMode mode)
+    {
+        var source = """
+            const fns: any[] = [];
+            function* gen() {
+                for (let i = 0; i < 3; i++) {
+                    const x = { id: i };
+                    fns.push(() => x.id);
+                    yield i;
+                }
+            }
+            for (const _ of gen()) {}
+            console.log(fns.map((f: any) => f()).join(","));
+            """;
+        Assert.Equal("0,1,2\n", TestHarness.Run(source, mode));
+    }
+
+    // ---- Nested loops: body const of the inner loop sees both indices ----
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void NestedLoopBodyConst_PerIteration(ExecutionMode mode)
+    {
+        var source = """
+            const fns: any[] = [];
+            function go() {
+                for (let i = 0; i < 2; i++) {
+                    for (let j = 0; j < 2; j++) {
+                        const cell = "" + i + j;
+                        fns.push(() => cell);
+                    }
+                }
+            }
+            go();
+            console.log(fns.map((f: any) => f()).join(","));
+            """;
+        Assert.Equal("00,01,10,11\n", TestHarness.Run(source, mode));
+    }
+
+    // ---- Conservative declines: these shapes keep the shared DC slot ----
+
+    // A `let` the closure itself mutates must keep shared mutation visibility
+    // within the iteration (the closure's writes reach the outer read).
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void WriteCapturedBodyLet_MutationVisibleWithinIteration(ExecutionMode mode)
+    {
+        var source = """
+            const outs: string[] = [];
+            function go() {
+                for (let i = 0; i < 2; i++) {
+                    let n = 0;
+                    const inc = () => { n++; };
+                    inc(); inc();
+                    outs.push("n=" + n);
+                }
+            }
+            go();
+            console.log(outs.join(","));
+            """;
+        Assert.Equal("n=2,n=2\n", TestHarness.Run(source, mode));
+    }
+
+    // A body const shadow-adjacent to a function-level binding: the outer binding
+    // keeps its shared slot; the body binding is still per-iteration.
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void BodyConstNextToFunctionLevelCapture_BothCorrect(ExecutionMode mode)
+    {
+        var source = """
+            const fns: any[] = [];
+            const go = () => {
+                let outer = { id: 99 };
+                const touch = () => outer;
+                touch();
+                for (let i = 0; i < 2; i++) {
+                    const y = { id: i };
+                    fns.push(() => y.id + ":" + outer.id);
+                }
+            };
+            go();
+            console.log(fns.map((f: any) => f()).join(","));
+            """;
+        Assert.Equal("0:99,1:99\n", TestHarness.Run(source, mode));
+    }
+
+    // Same name declared BOTH as a function-level local and in a loop body of a
+    // sibling function: per-function tracking keeps them independent.
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void SameNameAcrossSiblingFunctions_Independent(ExecutionMode mode)
+    {
+        var source = """
+            const fns: any[] = [];
+            function a() {
+                for (let i = 0; i < 2; i++) {
+                    const x = { id: i };
+                    fns.push(() => "a" + x.id);
+                }
+            }
+            function b() {
+                const x = { id: 7 };
+                fns.push(() => "b" + x.id);
+            }
+            a();
+            b();
+            console.log(fns.map((f: any) => f()).join(","));
+            """;
+        Assert.Equal("a0,a1,b7\n", TestHarness.Run(source, mode));
+    }
+}


### PR DESCRIPTION
## Summary

#1223's "compiled: intermittent no-output hang" was **not an event-loop race** — it is a deterministic closure-capture codegen bug, with network event ordering supplying the intermittency.

A block-scoped `let`/`const` declared in a **loop body** inside a function/arrow (and `for-of`/`for-in` loop variables) and captured by a closure was hoisted onto the enclosing callable's shared display class (one instance per call), so every iteration's closure read the **last** iteration's value. The #649 per-iteration exclusion only covered `for`-initializer bindings. Minimal repro, compiled (baseline): 

```ts
const go = () => {
    for (let i = 0; i < 2; i++) {
        const client = { id: i };
        fns.push(() => client.id);   // both closures see id=1
    }
};
```

In the net repro, both `'data'` handlers shared one `client` capture: whichever fired first destroyed the **other** client, dropping its pending data → `responses` never reached 2 → `server.close()` never ran → the loop idled forever. The instrumented hang trace shows it directly: `C0:data` → `C1:close` (client1 destroyed by client0's handler, no `C1:data`). Pinning the process to 1 CPU core makes the "intermittent" hang deterministic: **12/12 hangs on baseline, 15/15 clean with this fix**.

## Fix

`ClosureAnalyzer` now records loop-body `let`/`const` declarations and `for-of`/`for-in` loop variables per function and folds them into `GetPerIterationLoopBindings`, so every existing consumer (function DCs, arrow scope DCs, generators, async state machines) keeps them out of shared display classes. They stay plain locals that closures snapshot per creation — the same semantics the top-level path already chose (#1201's "loops are a hard stop" rule). For a never-reassigned binding, the creation-time snapshot is indistinguishable from a live per-iteration binding.

**Conservative declines** (keep the shared DC slot = today's behavior):
- names **reassigned** after initialization anywhere (snapshot would hide within-iteration mutation visibility);
- names captured **through an intermediate closure** (`() => () => x`) — sync-arrow capture sets are innermost-only, so those must relay through a shared scope DC; excluding them would populate `null` (#1231);
- names **also declared** as an ordinary local/param in the same function (existing shadow-safety rule).

## Also fixed by this change

- `for-of`/`for-in` **loop variables** captured in functions/arrows (previously fused across iterations — they were never in the #649 set);
- the same shape in `while`/`do-while` bodies and in **async-function / generator** state machines.

## Found & filed separately (pre-existing, reproduced on baseline)

- #1230 — inner `function` declared in a loop body is unreferenceable in compiled mode (`ReferenceError: Undefined variable`).
- #1231 — chained captures (`() => () => x`) of snapshot-path per-iteration bindings populate as `null` at top level.

## Verification

- xUnit: **15320/15320, 0 failed** (includes 28 new regression tests: for/while/do-while/for-of/for-in bodies, async + generator state machines, write-captured declines, shadowing, sibling-function independence, and the #1223 net-repro shape)
- Test262: **22/0, 4 skipped** (baseline-identical, interp + compiled)
- TypeScriptConformance: **31/0** (baseline-identical)
- #1223 repro: 12/12 hang on baseline pinned to 1 core → **15/15 clean** with fix (plus clean unpinned runs); interpreter unchanged-correct throughout

Closes #1223