### PR TITLE
fix(test): #1226 gate TestHarness module runners on type-check diagnostics

### DIFF
--- a/SharpTS.Tests/CompilerTests/EntryPointSyncContextTests.cs
+++ b/SharpTS.Tests/CompilerTests/EntryPointSyncContextTests.cs
@@ -3,6 +3,7 @@ using System.Threading;
 using SharpTS.Compilation;
 using SharpTS.Modules;
 using SharpTS.Parsing;
+using SharpTS.Tests.Infrastructure;
 using SharpTS.TypeSystem;
 using Xunit;
 
@@ -66,7 +67,7 @@ public class EntryPointSyncContextTests
         var modules = resolver.GetModulesInOrder(entryModule);
 
         var checker = new TypeChecker();
-        var typeMap = checker.CheckModules(modules, resolver);
+        var typeMap = TestHarness.CheckModulesOrThrow(checker, modules, resolver);
         var deadCodeInfo = new DeadCodeAnalyzer(typeMap)
             .Analyze(modules.SelectMany(m => m.Statements).ToList());
 

--- a/SharpTS.Tests/CompilerTests/StandaloneDllTests.cs
+++ b/SharpTS.Tests/CompilerTests/StandaloneDllTests.cs
@@ -5,6 +5,7 @@ using System.Text.RegularExpressions;
 using SharpTS.Compilation;
 using SharpTS.Modules;
 using SharpTS.Parsing;
+using SharpTS.Tests.Infrastructure;
 using SharpTS.TypeSystem;
 using Xunit;
 
@@ -316,7 +317,7 @@ public class StandaloneDllTests
             var resolver = new ModuleResolver(entryPath);
             var entryModule = resolver.LoadModule(entryPath);
             var modules = resolver.GetModulesInOrder(entryModule);
-            var typeMap = new TypeChecker().CheckModules(modules, resolver);
+            var typeMap = TestHarness.CheckModulesOrThrow(new TypeChecker(), modules, resolver);
             var deadCodeInfo = new DeadCodeAnalyzer(typeMap).Analyze(modules.SelectMany(m => m.Statements).ToList());
 
             var compiler = new ILCompiler("vm_dep_test");
@@ -383,7 +384,7 @@ public class StandaloneDllTests
             var resolver = new ModuleResolver(entryPath);
             var entryModule = resolver.LoadModule(entryPath);
             var modules = resolver.GetModulesInOrder(entryModule);
-            var typeMap = new TypeChecker().CheckModules(modules, resolver);
+            var typeMap = TestHarness.CheckModulesOrThrow(new TypeChecker(), modules, resolver);
             var deadCodeInfo = new DeadCodeAnalyzer(typeMap).Analyze(modules.SelectMany(m => m.Statements).ToList());
 
             var compiler = new ILCompiler("cluster_dep_test");
@@ -1279,7 +1280,7 @@ public class StandaloneDllTests
         var modules = resolver.GetModulesInOrder(entryModule);
 
         var checker = new TypeChecker();
-        var typeMap = checker.CheckModules(modules, resolver);
+        var typeMap = TestHarness.CheckModulesOrThrow(checker, modules, resolver);
         var deadCodeInfo = new DeadCodeAnalyzer(typeMap).Analyze(modules.SelectMany(m => m.Statements).ToList());
 
         var compiler = new ILCompiler("standalone_test");

--- a/SharpTS.Tests/Infrastructure/TestHarness.cs
+++ b/SharpTS.Tests/Infrastructure/TestHarness.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using System.Reflection;
 using System.Runtime.ExceptionServices;
 using SharpTS.Compilation;
+using SharpTS.Diagnostics;
 using SharpTS.Execution;
 using SharpTS.Modules;
 using SharpTS.Parsing;
@@ -66,19 +67,44 @@ public static class TestHarness
     /// <summary>
     /// Runs TypeScript modules using the specified execution mode.
     /// This is the primary entry point for parameterized module tests.
+    /// Fails with <see cref="TypeCheckDiagnosticException"/> if the program doesn't
+    /// type-check (#1226); tests that intentionally run ill-typed programs pass
+    /// <paramref name="allowTypeErrors"/>.
     /// </summary>
     /// <param name="files">Dictionary of file paths to file contents</param>
     /// <param name="entryPoint">Path to the entry point module</param>
     /// <param name="mode">Execution mode (Interpreted or Compiled)</param>
+    /// <param name="allowTypeErrors">Skip the error-severity diagnostic check after CheckModules</param>
     /// <returns>Captured console output</returns>
-    public static string RunModules(Dictionary<string, string> files, string entryPoint, ExecutionMode mode, TimeSpan? timeout = null)
+    public static string RunModules(Dictionary<string, string> files, string entryPoint, ExecutionMode mode, TimeSpan? timeout = null, bool allowTypeErrors = false)
     {
         return mode switch
         {
-            ExecutionMode.Interpreted => RunModulesInterpreted(files, entryPoint, timeout),
-            ExecutionMode.Compiled => RunModulesCompiled(files, entryPoint, timeout),
+            ExecutionMode.Interpreted => RunModulesInterpreted(files, entryPoint, timeout, allowTypeErrors),
+            ExecutionMode.Compiled => RunModulesCompiled(files, entryPoint, timeout, allowTypeErrors),
             _ => throw new ArgumentOutOfRangeException(nameof(mode))
         };
+    }
+
+    /// <summary>
+    /// Runs <see cref="TypeChecker.CheckModules"/> and throws on error-severity diagnostics,
+    /// mirroring the CLI (<c>Program.RunModuleFile</c>). CheckModules records type errors with
+    /// recovery instead of throwing, so without this check the module runners silently execute
+    /// ill-typed programs and type-check regressions in stdlib facades go unnoticed (#1226).
+    /// Warnings (e.g. from lenient CJS modules) don't block, same as the CLI.
+    /// </summary>
+    internal static TypeMap CheckModulesOrThrow(TypeChecker checker, List<ParsedModule> modules, ModuleResolver resolver, bool allowTypeErrors = false)
+    {
+        var typeMap = checker.CheckModules(modules, resolver);
+        if (!allowTypeErrors)
+        {
+            var errors = checker.GetDiagnostics()
+                .Where(d => d.Severity == DiagnosticSeverity.Error)
+                .ToList();
+            if (errors.Count > 0)
+                throw new TypeCheckDiagnosticException(errors);
+        }
+        return typeMap;
     }
 
     /// <summary>
@@ -680,7 +706,7 @@ public static class TestHarness
     /// <param name="files">Dictionary mapping file paths to source code</param>
     /// <param name="entryPoint">The entry point file path (e.g., "./main.ts")</param>
     /// <returns>Captured console output</returns>
-    public static string RunModulesInterpreted(Dictionary<string, string> files, string entryPoint, TimeSpan? timeout = null)
+    public static string RunModulesInterpreted(Dictionary<string, string> files, string entryPoint, TimeSpan? timeout = null, bool allowTypeErrors = false)
     {
         var effectiveTimeout = timeout ?? DefaultTimeout;
 
@@ -688,7 +714,7 @@ public static class TestHarness
         // disk path that the runtime can stat / spawn workers against; route those through
         // the disk-based path. Everything else uses the in-memory virtual file system.
         if (RequiresRealDisk(files.Values))
-            return RunModulesInterpretedOnDisk(files, entryPoint, effectiveTimeout);
+            return RunModulesInterpretedOnDisk(files, entryPoint, effectiveTimeout, allowTypeErrors);
 
         // Build an in-memory virtual file system instead of writing to %TEMP%. Concurrent
         // disk operations on Windows serialize through the kernel/AV — measured 1.4× speedup
@@ -704,7 +730,7 @@ public static class TestHarness
             var allModules = resolver.GetModulesInOrder(entryModule);
 
             var checker = new TypeChecker();
-            var typeMap = checker.CheckModules(allModules, resolver);
+            var typeMap = CheckModulesOrThrow(checker, allModules, resolver, allowTypeErrors);
 
             using var interpreter = new Interpreter(stdout: sw, stderr: TextWriter.Null);
             // Match the CLI: fire process lifecycle events at loop drain (#1080).
@@ -764,13 +790,13 @@ public static class TestHarness
     ///   - <c>process.cwd()</c> / <c>process.argv</c> read <see cref="Environment"/> directly
     ///     (see <c>RuntimeEmitter.ProcessHelpers</c>) and would return the testhost's view
     /// </summary>
-    public static string RunModulesCompiled(Dictionary<string, string> files, string entryPoint, TimeSpan? timeout = null)
+    public static string RunModulesCompiled(Dictionary<string, string> files, string entryPoint, TimeSpan? timeout = null, bool allowTypeErrors = false)
     {
         if (RequiresSubprocess(files.Values))
-            return RunModulesCompiledViaSubprocess(files, entryPoint);
+            return RunModulesCompiledViaSubprocess(files, entryPoint, allowTypeErrors);
         if (RequiresRealDisk(files.Values))
-            return RunModulesCompiledInProcessOnDisk(files, entryPoint, timeout);
-        return RunModulesCompiledInProcess(files, entryPoint, timeout);
+            return RunModulesCompiledInProcessOnDisk(files, entryPoint, timeout, allowTypeErrors);
+        return RunModulesCompiledInProcess(files, entryPoint, timeout, allowTypeErrors);
     }
 
     private static bool RequiresSubprocess(IEnumerable<string> sources)
@@ -823,7 +849,7 @@ public static class TestHarness
     /// then runs the interpreter in-process. Used for tests that depend on real-disk paths
     /// (<c>__dirname</c>, <c>cluster.fork</c>) — see <see cref="RequiresRealDisk"/>.
     /// </summary>
-    private static string RunModulesInterpretedOnDisk(Dictionary<string, string> files, string entryPoint, TimeSpan? timeout = null)
+    private static string RunModulesInterpretedOnDisk(Dictionary<string, string> files, string entryPoint, TimeSpan? timeout = null, bool allowTypeErrors = false)
     {
         var effectiveTimeout = timeout ?? DefaultTimeout;
 
@@ -851,7 +877,7 @@ public static class TestHarness
                 var allModules = resolver.GetModulesInOrder(entryModule);
 
                 var checker = new TypeChecker();
-                var typeMap = checker.CheckModules(allModules, resolver);
+                var typeMap = CheckModulesOrThrow(checker, allModules, resolver, allowTypeErrors);
 
                 using var interpreter = new Interpreter(stdout: sw, stderr: TextWriter.Null);
                 interpreter.InterpretModules(allModules, resolver, typeMap);
@@ -882,7 +908,7 @@ public static class TestHarness
     /// Disk-backed in-process compiled path for tests that need real-disk paths
     /// (<c>__dirname</c>, <c>cluster.fork</c>) — see <see cref="RequiresRealDisk"/>.
     /// </summary>
-    private static string RunModulesCompiledInProcessOnDisk(Dictionary<string, string> files, string entryPoint, TimeSpan? timeout = null)
+    private static string RunModulesCompiledInProcessOnDisk(Dictionary<string, string> files, string entryPoint, TimeSpan? timeout = null, bool allowTypeErrors = false)
     {
         var effectiveTimeout = timeout ?? DefaultTimeout;
         var tempDir = Path.Combine(Path.GetTempPath(), $"sharpts_module_test_{Guid.NewGuid()}");
@@ -907,7 +933,7 @@ public static class TestHarness
             var allModules = resolver.GetModulesInOrder(entryModule);
 
             var checker = new TypeChecker();
-            var typeMap = checker.CheckModules(allModules, resolver);
+            var typeMap = CheckModulesOrThrow(checker, allModules, resolver, allowTypeErrors);
 
             var allStatements = allModules.SelectMany(m => m.Statements).ToList();
             var deadCodeAnalyzer = new DeadCodeAnalyzer(typeMap);
@@ -955,7 +981,7 @@ public static class TestHarness
         }
     }
 
-    private static string RunModulesCompiledInProcess(Dictionary<string, string> files, string entryPoint, TimeSpan? timeout = null)
+    private static string RunModulesCompiledInProcess(Dictionary<string, string> files, string entryPoint, TimeSpan? timeout = null, bool allowTypeErrors = false)
     {
         var effectiveTimeout = timeout ?? DefaultTimeout;
         // In-memory virtual file system — see BuildVirtualModuleFs and the comment on
@@ -971,7 +997,7 @@ public static class TestHarness
             var allModules = resolver.GetModulesInOrder(entryModule);
 
             var checker = new TypeChecker();
-            var typeMap = checker.CheckModules(allModules, resolver);
+            var typeMap = CheckModulesOrThrow(checker, allModules, resolver, allowTypeErrors);
 
             var allStatements = allModules.SelectMany(m => m.Statements).ToList();
             var deadCodeAnalyzer = new DeadCodeAnalyzer(typeMap);
@@ -1044,7 +1070,7 @@ public static class TestHarness
     /// Subprocess fallback for <see cref="RunModulesCompiled"/>. Used when a module's source
     /// touches <c>process.exit/chdir/cwd/argv</c> — the in-process path can't isolate those.
     /// </summary>
-    private static string RunModulesCompiledViaSubprocess(Dictionary<string, string> files, string entryPoint)
+    private static string RunModulesCompiledViaSubprocess(Dictionary<string, string> files, string entryPoint, bool allowTypeErrors = false)
     {
         var tempDir = Path.Combine(Path.GetTempPath(), $"sharpts_module_test_{Guid.NewGuid()}");
         Directory.CreateDirectory(tempDir);
@@ -1073,7 +1099,7 @@ public static class TestHarness
 
             // Type check
             var checker = new TypeChecker();
-            var typeMap = checker.CheckModules(allModules, resolver);
+            var typeMap = CheckModulesOrThrow(checker, allModules, resolver, allowTypeErrors);
 
             // Dead code analysis across all modules
             var allStatements = allModules.SelectMany(m => m.Statements).ToList();
@@ -1263,7 +1289,7 @@ public static class TestHarness
     /// <param name="files">Map of module path → source.</param>
     /// <param name="entryPoint">Entry module path (key into <paramref name="files"/>).</param>
     /// <returns>List of verification errors (empty when the IL is valid).</returns>
-    public static List<string> CompileModulesAndVerifyOnly(Dictionary<string, string> files, string entryPoint)
+    public static List<string> CompileModulesAndVerifyOnly(Dictionary<string, string> files, string entryPoint, bool allowTypeErrors = false)
     {
         var tempDir = Path.Combine(Path.GetTempPath(), $"sharpts_module_verify_{Guid.NewGuid()}");
         Directory.CreateDirectory(tempDir);
@@ -1287,7 +1313,7 @@ public static class TestHarness
             var allModules = resolver.GetModulesInOrder(entryModule);
 
             var checker = new TypeChecker();
-            var typeMap = checker.CheckModules(allModules, resolver);
+            var typeMap = CheckModulesOrThrow(checker, allModules, resolver, allowTypeErrors);
 
             var allStatements = allModules.SelectMany(m => m.Statements).ToList();
             var deadCodeAnalyzer = new DeadCodeAnalyzer(typeMap);

--- a/SharpTS.Tests/Infrastructure/TypeCheckDiagnosticException.cs
+++ b/SharpTS.Tests/Infrastructure/TypeCheckDiagnosticException.cs
@@ -1,0 +1,24 @@
+using SharpTS.Diagnostics;
+
+namespace SharpTS.Tests.Infrastructure;
+
+/// <summary>
+/// Thrown by the <see cref="TestHarness"/> module runners when the type checker records
+/// error-severity diagnostics after <c>CheckModules</c> (#1226). <c>CheckModules</c> records
+/// errors with recovery instead of throwing, and the interpreter/compiler usually runs the
+/// ill-typed program just fine — so without this check a type-check regression in a stdlib
+/// facade (or in a test program) is invisible to the suite. Mirrors the CLI
+/// (<c>Program.RunModuleFile</c>), which aborts on any error-severity diagnostic. Tests that
+/// intentionally run ill-typed programs opt out via <c>allowTypeErrors: true</c>.
+/// </summary>
+public sealed class TypeCheckDiagnosticException : Exception
+{
+    public IReadOnlyList<Diagnostic> Diagnostics { get; }
+
+    public TypeCheckDiagnosticException(IReadOnlyList<Diagnostic> diagnostics)
+        : base($"Module type checking produced {diagnostics.Count} error(s):\n  " +
+               string.Join("\n  ", diagnostics.Select(d => d.ToString())))
+    {
+        Diagnostics = diagnostics;
+    }
+}

--- a/SharpTS.Tests/SharedTests/BuiltInModules/UrlModuleTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/UrlModuleTests.cs
@@ -255,7 +255,7 @@ public class UrlModuleTests
                 import { parse } from 'url';
                 const parsed = parse('file:///home/user/file.txt');
                 console.log(parsed.protocol);
-                console.log(parsed.pathname.includes('file.txt'));
+                console.log(parsed.pathname !== null && parsed.pathname.includes('file.txt'));
                 """
         };
 

--- a/SharpTS.Tests/SharedTests/BuiltInModules/UtilModuleTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/UtilModuleTests.cs
@@ -1533,7 +1533,7 @@ public class UtilModuleTests
             var entryModule = resolver.LoadModule(mainPath);
             var allModules = resolver.GetModulesInOrder(entryModule);
             var checker = new TypeChecker();
-            var typeMap = checker.CheckModules(allModules, resolver);
+            var typeMap = TestHarness.CheckModulesOrThrow(checker, allModules, resolver);
             var deadCodeAnalyzer = new DeadCodeAnalyzer(typeMap);
             var deadCodeInfo = deadCodeAnalyzer.Analyze(allModules.SelectMany(m => m.Statements).ToList());
 
@@ -1596,7 +1596,7 @@ public class UtilModuleTests
             var entryModule = resolver.LoadModule(mainPath);
             var allModules = resolver.GetModulesInOrder(entryModule);
             var checker = new TypeChecker();
-            var typeMap = checker.CheckModules(allModules, resolver);
+            var typeMap = TestHarness.CheckModulesOrThrow(checker, allModules, resolver);
             var deadCodeAnalyzer = new DeadCodeAnalyzer(typeMap);
             var deadCodeInfo = deadCodeAnalyzer.Analyze(allModules.SelectMany(m => m.Statements).ToList());
 

--- a/SharpTS.Tests/SharedTests/TlsCheckIdentityTests.cs
+++ b/SharpTS.Tests/SharedTests/TlsCheckIdentityTests.cs
@@ -37,7 +37,7 @@ public class TlsCheckIdentityTests
                 const err = tls.checkServerIdentity('evil.com', cert);
                 console.log(err !== undefined);
                 console.log(err instanceof Error);
-                console.log(err.message.indexOf('evil.com') >= 0);
+                console.log(err !== undefined && err.message.indexOf('evil.com') >= 0);
                 """
         };
         var output = TestHarness.RunModules(files, "./main.ts", mode);

--- a/SharpTS.Tests/SharedTests/UnhandledRejectionTests.cs
+++ b/SharpTS.Tests/SharedTests/UnhandledRejectionTests.cs
@@ -1,6 +1,7 @@
 using SharpTS.Execution;
 using SharpTS.Modules;
 using SharpTS.Parsing;
+using SharpTS.Tests.Infrastructure;
 using SharpTS.TypeSystem;
 using Xunit;
 
@@ -69,7 +70,7 @@ public class UnhandledRejectionTests
             var allModules = resolver.GetModulesInOrder(entryModule);
 
             var checker = new TypeChecker();
-            var typeMap = checker.CheckModules(allModules, resolver);
+            var typeMap = TestHarness.CheckModulesOrThrow(checker, allModules, resolver);
 
             using var interpreter = new Interpreter(stdout: stdout, stderr: stderr);
             interpreter.InterpretModules(allModules, resolver, typeMap);

--- a/SharpTS.Tests/TypeCheckerTests/HarnessModuleDiagnosticGateTests.cs
+++ b/SharpTS.Tests/TypeCheckerTests/HarnessModuleDiagnosticGateTests.cs
@@ -1,0 +1,50 @@
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.TypeCheckerTests;
+
+/// <summary>
+/// The module runners (<see cref="TestHarness.RunModules"/> and friends) must fail on
+/// error-severity type-checker diagnostics after <c>CheckModules</c>, mirroring the CLI
+/// (<c>Program.RunModuleFile</c>) — #1226. Before this gate, <c>CheckModules</c> recorded
+/// type errors with recovery, the interpreter/compiler ran the ill-typed program anyway, and
+/// a type-check regression in a stdlib facade (e.g. #1218's <c>url</c> import) stayed invisible
+/// to the whole suite. These tests pin the gate itself so it can't silently regress.
+/// </summary>
+public class HarnessModuleDiagnosticGateTests
+{
+    private static Dictionary<string, string> IllTyped => new()
+    {
+        // `x: number = "str"` is a plain type error the checker records and recovers from;
+        // the program still "runs" (prints 1) under both the interpreter and compiler.
+        ["main.ts"] = "export {};\nconst x: number = \"not a number\";\nconsole.log(1);\n",
+    };
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void RunModules_ThrowsOnTypeError(ExecutionMode mode)
+    {
+        var ex = Assert.Throws<TypeCheckDiagnosticException>(
+            () => TestHarness.RunModules(IllTyped, "main.ts", mode));
+        Assert.NotEmpty(ex.Diagnostics);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void RunModules_AllowTypeErrors_RunsIllTypedProgram(ExecutionMode mode)
+    {
+        // Opt-out escape hatch for tests that intentionally exercise ill-typed programs.
+        var output = TestHarness.RunModules(IllTyped, "main.ts", mode, allowTypeErrors: true);
+        Assert.Equal("1\n", output);
+    }
+
+    [Fact]
+    public void RunModules_WellTypedProgram_DoesNotThrow()
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = "export {};\nconst x: number = 42;\nconsole.log(x);\n",
+        };
+        Assert.Equal("42\n", TestHarness.RunModules(files, "main.ts", ExecutionMode.Interpreted));
+    }
+}

--- a/TypeSystem/BuiltInModuleTypes.cs
+++ b/TypeSystem/BuiltInModuleTypes.cs
@@ -621,7 +621,9 @@ public static class BuiltInModuleTypes
         return new Dictionary<string, TypeInfo>
         {
             // Hash methods
-            ["createHash"] = new TypeInfo.Function([stringType], anyType), // Returns Hash object
+            // createHash(algorithm, options?) — options carries outputLength for XOFs
+            // like shake128/shake256 (#1059).
+            ["createHash"] = new TypeInfo.Function([stringType, anyType], anyType, RequiredParams: 1), // Returns Hash object
             ["createHmac"] = new TypeInfo.Function([stringType, anyType], anyType), // Returns Hmac object
 
             // Cipher methods
@@ -775,6 +777,7 @@ public static class BuiltInModuleTypes
             ["createDiffieHellmanGroup"] = new TypeInfo.Function([stringType], anyType),
             ["getFips"] = new TypeInfo.Function([], numberType),
             ["setFips"] = new TypeInfo.Function([BooleanType], voidType),
+            ["fips"] = BooleanType,
             ["ECDH"] = anyType,
             // Primes (#1062)
             ["generatePrime"] = new TypeInfo.Function([numberType, anyType, anyType], voidType, RequiredParams: 2),


### PR DESCRIPTION
Closes #1226.

## Problem

`TypeChecker.CheckModules` records type errors with *recovery* instead of throwing. The CLI (`Program.RunModuleFile`) checks `GetDiagnostics()` afterward and aborts on any error-severity diagnostic; the test harness's `RunModules*` variants never did. So an ill-typed module program still ran fine at runtime and its type errors were invisible to all ~15k tests — which is exactly how the #1218 `url`-import regression slipped through a green suite. (Same gap the #1195 work hit: "Harness ignores collected checker diagnostics — assert GetDiagnostics().")

## Fix

Added `TestHarness.CheckModulesOrThrow(...)`, which runs `CheckModules` and throws a new `TypeCheckDiagnosticException` if any diagnostic is error-severity (warnings still pass, matching the CLI). Routed **every** module-runner path through it — interpreted/compiled × in-process/on-disk/subprocess — plus `CompileModulesAndVerifyOnly` and the four bespoke test-local `CheckModules` pipelines. A per-call `allowTypeErrors: true` opt-out covers tests that intentionally run ill-typed programs.

The issue suggested a log-only survey first to size the cleanup. In practice, flipping the gate to hard-fail surfaced only **four** latent cases — small enough to just fix rather than stage.

## Latent diagnostics the gate caught (4 cases / 8 dual-mode runs), all fixed

- **`TlsCheckIdentityTests` / `UrlModuleTests`** — the *test sources* dereferenced possibly-`undefined`/`null` values (`err.message`, `pathname.includes`). Node's real return types are nullable there, so the checker was correct; added `!== undefined`/`!== null` guards to the test TypeScript.
- **`crypto.fips` and 2-arg `crypto.createHash(algo, options)`** — genuine gaps in the crypto facade's *type declarations* (`TypeSystem/BuiltInModuleTypes.cs`); the runtime already supported both (`fips` getter, `outputLength` for SHAKE XOFs). Added the `fips` property and an optional options parameter to `createHash`.

Added `HarnessModuleDiagnosticGateTests` pinning the gate: throws on an ill-typed program, `allowTypeErrors: true` opts out, well-typed program runs clean.

## Verification

- xUnit: **15300 / 0**
- TypeScript conformance: **31 / 0**
- Test262: **22 / 0** (4 skipped, baseline-identical)