### PR TITLE
fix(compile): #1229 exported arrow capturing an exported let is not callable cross-module

### DIFF
--- a/Compilation/NonEscapingArrowLocalAnalyzer.cs
+++ b/Compilation/NonEscapingArrowLocalAnalyzer.cs
@@ -33,6 +33,9 @@ namespace SharpTS.Compilation;
 ///         ambiguity / shadowing without full scope resolution);</item>
 ///   <item>the name is not captured by any closure (a captured binding is routed to an <c>object</c>
 ///         display-class field, never a typed local slot the call site can key on).</item>
+///   <item>the name is not exported (an exported binding escapes through its module's export field and
+///         is invoked cross-module via the generic reflective dispatch, not the local-slot fast path — so
+///         the bare display-class instance would surface as a non-callable object, #1229).</item>
 /// </list>
 ///
 /// <para>The catch-all is <see cref="Visitor.VisitVariable"/>: any bare variable occurrence not consumed
@@ -117,6 +120,37 @@ public static class NonEscapingArrowLocalAnalyzer
 
         protected override void VisitVariable(Expr.Variable expr) =>
             Disqualified.Add(expr.Name.Lexeme);
+
+        protected override void VisitExport(Stmt.Export stmt)
+        {
+            // An exported binding escapes this module: its value is copied into the module's
+            // export field (read by `$GetNamespace` and by importing modules, which call it
+            // through the generic reflective `InvokeMethodValue` dispatch — never the local-slot
+            // direct-call fast path this optimization relies on). Storing the bare display-class
+            // instance without a `$TSFunction` wrapper would then surface a plain object where a
+            // callable is expected ("object is not a function", #1229). Disqualify the exported
+            // name(s), then fall through to the base walk so uses INSIDE the declaration's
+            // initializer still count toward other candidates.
+            DisqualifyExportedNames(stmt.Declaration);
+            if (stmt.NamedExports != null)
+                foreach (var spec in stmt.NamedExports)
+                    Disqualified.Add(spec.LocalName.Lexeme);
+
+            base.VisitExport(stmt);
+        }
+
+        private void DisqualifyExportedNames(Stmt? decl)
+        {
+            switch (decl)
+            {
+                case Stmt.Const c: Disqualified.Add(c.Name.Lexeme); break;
+                case Stmt.Var v: Disqualified.Add(v.Name.Lexeme); break;
+                case Stmt.Sequence seq:
+                    foreach (var inner in seq.Statements)
+                        DisqualifyExportedNames(inner);
+                    break;
+            }
+        }
 
         protected override void VisitAssign(Expr.Assign expr)
         {

--- a/SharpTS.Tests/SharedTests/TopLevelBlockScopeCaptureTests.cs
+++ b/SharpTS.Tests/SharedTests/TopLevelBlockScopeCaptureTests.cs
@@ -343,9 +343,9 @@ public class TopLevelBlockScopeCaptureTests
     {
         // Module-init methods reach the entry-point DC through its static field;
         // the shadow decision must hold there too. (The module binding and its
-        // reader are deliberately NOT exported directly — an exported arrow
-        // capturing an exported let is a distinct pre-existing compiled-module
-        // bug, unrelated to shadowing.)
+        // reader are deliberately NOT exported directly to keep this test focused
+        // on shadowing — the distinct exported-arrow-capturing-exported-let case is
+        // #1229, covered by ExportedArrow_CapturingExportedLet_IsCallableCrossModule.)
         var files = new Dictionary<string, string>
         {
             ["lib.ts"] = """
@@ -365,6 +365,53 @@ public class TopLevelBlockScopeCaptureTests
         };
         var output = TestHarness.RunModules(files, "main.ts", mode);
         Assert.Equal("lib=inner\nmain=outer\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ExportedArrow_CapturingExportedLet_IsCallableCrossModule(ExecutionMode mode)
+    {
+        // #1229: an `export const` arrow capturing an `export let` from the same module.
+        // The non-escaping-arrow optimization (#858) flagged `getOuter` as a direct-call-only
+        // local and stored the bare display-class instance instead of a $TSFunction wrapper —
+        // but the exported binding escapes through the module's export field and is invoked
+        // cross-module via generic reflective dispatch, which then saw a plain object
+        // ("TypeError: object is not a function"). Exported names must be disqualified.
+        var files = new Dictionary<string, string>
+        {
+            ["lib.ts"] = """
+                export let tag = 'outer';
+                export const getOuter = () => tag;
+                """,
+            ["main.ts"] = """
+                import { getOuter } from './lib';
+                console.log('main=' + getOuter());
+                """,
+        };
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("main=outer\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ExportedArrow_WithParam_CapturingExportedLet_IsCallableCrossModule(ExecutionMode mode)
+    {
+        // #1229 variant: a capturing exported arrow that also takes a parameter, exported via a
+        // separate `export { … }` statement (the specifier-list escape route, not the inline form).
+        var files = new Dictionary<string, string>
+        {
+            ["lib.ts"] = """
+                export let base = 10;
+                const add = (x: number) => x + base;
+                export { add };
+                """,
+            ["main.ts"] = """
+                import { add } from './lib';
+                console.log('add=' + add(5));
+                """,
+        };
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("add=15\n", output);
     }
 
     [Theory]


### PR DESCRIPTION
Fixes #1229.

## Problem

In compiled module mode, an `export const` arrow that captures an `export let` from the same module was not callable from an importing module:

```ts
// lib.ts
export let tag = 'outer';
export const getOuter = () => tag;
// main.ts
import { getOuter } from './lib';
console.log('main=' + getOuter());   // Compiled: TypeError: object is not a function
```

Interpreter printed `main=outer`; compiled threw `TypeError: object is not a function` at `$Runtime.InvokeMethodValue`.

## Root cause

The non-escaping-arrow optimization (#858, `NonEscapingArrowLocalAnalyzer`) flags `const NAME = arrow` bindings whose only uses are direct `NAME(args)` calls. For a capturing arrow it has the emitter store the **bare display-class instance** instead of a `$TSFunction` wrapper, keying every call on the local slot's CLR type for an unboxed `callvirt Invoke`.

An **exported** binding, though, escapes through its module's export field: the value is copied into the export field, read by `$GetNamespace`, and invoked from other modules via the generic reflective dispatch (`InvokeMethodValue`) — which then finds a plain display-class object where a callable is expected. The whole-program analyzer never saw the export as a disqualifying use, so it wrongly optimized `getOuter`.

Decompiled buggy output:
```csharp
getOuter = new <>c__DisplayClass0 { tag = obj };     // raw display class — not callable
```
After the fix:
```csharp
getOuter = new $TSFunction(new <>c__DisplayClass0 { tag = obj }, <method>);
```

## Fix

Disqualify exported names in `NonEscapingArrowLocalAnalyzer` — both the inline `export const NAME = …` form and the `export { NAME }` specifier form. Such arrows keep their `$TSFunction` wrapper. The optimization still fires for genuinely module-local direct-call arrows (verified: local capturing arrows still emit the bare display class + direct `.Invoke()`).

## Tests

Added `ExportedArrow_CapturingExportedLet_IsCallableCrossModule` and `ExportedArrow_WithParam_CapturingExportedLet_IsCallableCrossModule` to `TopLevelBlockScopeCaptureTests` (both execution modes, inline + specifier export shapes). Updated the stale note in `ShadowedModuleBinding_InImportedModule` that had called this out as an unfixed pre-existing bug.

- xUnit: **15311 passed / 0 failed**
- Test262 (interp + compiled): **22 / 0 / 4 skip** (baseline-green)
- TypeScript conformance: **31 / 0** (baseline-green)