### PR TITLE
fix(compile): #1231 value-forward per-iteration bindings through sync-arrow chains

### DIFF
--- a/Compilation/ClosureAnalyzer.cs
+++ b/Compilation/ClosureAnalyzer.cs
@@ -96,16 +96,35 @@ public class ClosureAnalyzer : AstVisitorBase
     // shared-DC mutation visibility for reassigned bindings.
     private readonly HashSet<string> _assignedNames = [];
 
-    // Defining function → names captured INDIRECTLY from it: the capturing closure
-    // has at least one intermediate callable between itself and the defining scope
-    // (e.g. `() => () => x` where `x` belongs to the enclosing function). Sync-arrow
-    // capture sets stay innermost-only, so such captures are relayed through a
-    // shared scope display class — a name kept out of the DC would populate as null
-    // at the inner closure's creation site (the intermediate body cannot see the
-    // local). Loop-body declarations captured this way therefore decline the
-    // per-iteration exclusion and keep their DC slot (today's fused-iteration
-    // behavior, matching the pre-existing top-level snapshot limitation).
+    // Defining function → names captured INDIRECTLY from it through a chain that
+    // sync-arrow value-forwarding CANNOT traverse (a nested function-expression or
+    // async-arrow boundary sits between the capturing closure and the defining
+    // scope). Sync-arrow capture sets stay innermost-only, so such captures can only
+    // be relayed through a shared scope display class — a per-iteration name kept out
+    // of the DC would populate as null at the inner closure's creation site. Loop-body
+    // declarations captured this way therefore decline the per-iteration exclusion and
+    // keep their DC slot (fused-iteration behavior). Chains made ENTIRELY of
+    // intermediate sync arrows are handled instead by value-forwarding, so they are
+    // NOT recorded here (see _pendingSyncChainForwards / #1231).
     private readonly Dictionary<object, HashSet<string>> _functionRelayCaptures = [];
+
+    // Top-level (module-scope) names bound per loop iteration: loop-body let/const,
+    // for-of/for-in loop variables, and for-initializer let/const declared outside any
+    // function. #1201 never lifts loop declarations to the entry-point display class,
+    // so these take the value-snapshot path. Used by the sync-arrow chain forwarding
+    // post-pass to decide which top-level captures need value-forwarding (#1231).
+    private readonly HashSet<string> _topLevelPerIterationBindings = [];
+
+    // Candidate sync-arrow chain forwards recorded during traversal and resolved by
+    // ApplySyncArrowChainForwarding after the walk completes (once per-iteration
+    // classification is final). Each entry: an inner closure captures Name from
+    // DefiningFunc (null = top level) through Intermediates — one or more enclosing
+    // plain (non-async) arrows that do not themselves reference Name. When Name turns
+    // out to be a per-iteration snapshot-path binding, it is unioned onto every
+    // intermediate arrow's capture set so each snapshots/relays the per-iteration value
+    // BY VALUE, rather than the inner closure reading null (#1231). Mirrors what
+    // PropagateCaptureUpAsyncArrowChain does eagerly for async arrows (#716).
+    private readonly List<(string Name, object? DefiningFunc, List<object> Intermediates)> _pendingSyncChainForwards = [];
 
     // Loop-BODY nesting depth within the CURRENT function/arrow. Zero outside
     // loop bodies; saved/reset/restored across nested function boundaries (a
@@ -259,6 +278,10 @@ public class ClosureAnalyzer : AstVisitorBase
             Visit(stmt);
         _scopeStack.Pop();
 
+        // Resolve sync-arrow chain forwards now that every capture and per-iteration
+        // classification is final (#1231).
+        ApplySyncArrowChainForwarding();
+
         // Per-iteration cell analysis (#650) is independent of capture-source state,
         // so run it as its own pass over the same statements.
         _cells.Analyze(statements);
@@ -340,6 +363,13 @@ public class ClosureAnalyzer : AstVisitorBase
                 nonLoop.Add(name);
             }
         }
+        else if (_currentFunction == null && isPerIterationBinding && _loopBodyDepth > 0)
+        {
+            // Top-level loop-BODY block-scoped let/const, or a for-of/for-in loop
+            // variable declared at module scope (#1231). For-INITIALIZER bindings at
+            // module scope are recorded by VisitFor (they declare with _loopBodyDepth 0).
+            _topLevelPerIterationBindings.Add(name);
+        }
     }
 
     // Loop-binding names currently being declared by a for-initializer, so
@@ -399,40 +429,33 @@ public class ClosureAnalyzer : AstVisitorBase
                 sources[name] = definingFunc;
 
                 // Indirect capture (an intermediate callable sits between this closure
-                // and the defining scope): the value can only reach this closure via a
-                // shared DC relay, so the name must not take the per-iteration
-                // snapshot path (#1223 — see _functionRelayCaptures).
-                bool passedCurrent = false;
-                foreach (var frame in _functionStack)
-                {
-                    if (!passedCurrent)
-                    {
-                        if (ReferenceEquals(frame, _currentFunction)) passedCurrent = true;
-                        continue;
-                    }
-                    if (!ReferenceEquals(frame, definingFunc))
-                    {
-                        if (!_functionRelayCaptures.TryGetValue(definingFunc, out var relayed))
-                            _functionRelayCaptures[definingFunc] = relayed = [];
-                        relayed.Add(name);
-                    }
-                    break;
-                }
+                // and the defining scope). An all-sync-arrow chain is value-forwarded so
+                // per-iteration bindings reach the inner closure by value (#1231); a chain
+                // crossing a function/async-arrow boundary declines the per-iteration
+                // exclusion and relays through the shared DC instead (#1223).
+                RecordChainCapture(name, definingFunc);
 
                 PropagateCaptureUpAsyncArrowChain(name, definingFunc);
             }
-            else if (_functionStack.Count == 1 && IsNearestDeclaringScopeNested(name))
+            else
             {
-                // Top-level capture (no enclosing function defines the name) whose
-                // nearest declaring scope is a nested top-level block, referenced by
-                // a closure created directly in top-level code (#1222) — see
-                // _directTopLevelBlockCaptures.
-                if (!_directTopLevelBlockCaptures.TryGetValue(_currentFunction, out var blockCaps))
+                // Top-level capture (no enclosing function defines the name).
+                // A chained capture through intermediate sync arrows is value-forwarded
+                // like the function-local case (#1231).
+                RecordChainCapture(name, null);
+
+                if (_functionStack.Count == 1 && IsNearestDeclaringScopeNested(name))
                 {
-                    blockCaps = [];
-                    _directTopLevelBlockCaptures[_currentFunction] = blockCaps;
+                    // The nearest declaring scope is a nested top-level block, referenced
+                    // by a closure created directly in top-level code (#1222) — see
+                    // _directTopLevelBlockCaptures.
+                    if (!_directTopLevelBlockCaptures.TryGetValue(_currentFunction, out var blockCaps))
+                    {
+                        blockCaps = [];
+                        _directTopLevelBlockCaptures[_currentFunction] = blockCaps;
+                    }
+                    blockCaps.Add(name);
                 }
-                blockCaps.Add(name);
             }
         }
     }
@@ -491,6 +514,94 @@ public class ClosureAnalyzer : AstVisitorBase
             if (_captures.TryGetValue(intermediateArrow, out var caps) && caps.Add(name))
                 _allCapturedVariables.Add(name);
         }
+    }
+
+    /// <summary>
+    /// Records the current closure's capture of <paramref name="name"/> from its owner
+    /// (<paramref name="definingFunc"/>, null = top level) when the value must pass
+    /// through one or more INTERMEDIATE enclosing closures. When every intermediate is a
+    /// plain (non-async, non-generator) arrow that does not itself reference the name, the
+    /// capture becomes a value-forwarding candidate (<see cref="_pendingSyncChainForwards"/>):
+    /// a post-pass snapshots the name into each intermediate arrow's own display class so a
+    /// per-iteration binding kept off every shared display class still reaches the innermost
+    /// closure by value (#1231). Non-forwardable shapes (a nested function-expression or
+    /// async-arrow boundary in the chain) fall back to the shared-DC relay — for a function
+    /// owner the name is recorded in <see cref="_functionRelayCaptures"/> so
+    /// <see cref="GetPerIterationLoopBindings"/> keeps it on the function display class.
+    /// Direct (non-chained) captures record nothing here.
+    /// </summary>
+    private void RecordChainCapture(string name, object? definingFunc)
+    {
+        List<object>? intermediates = null;
+        bool forwardable = true;
+        bool passedCurrent = false;
+        foreach (var frame in _functionStack)
+        {
+            if (!passedCurrent)
+            {
+                if (ReferenceEquals(frame, _currentFunction)) passedCurrent = true;
+                continue;
+            }
+            if (definingFunc != null && ReferenceEquals(frame, definingFunc))
+                break; // reached the owning scope
+            // This frame sits between the capturing closure and the owner.
+            if (frame is Expr.ArrowFunction { IsAsync: false, IsGenerator: false } syncArrow)
+            {
+                (intermediates ??= []).Add(syncArrow);
+            }
+            else
+            {
+                // A function-expression or async-arrow boundary: sync-chain value
+                // forwarding cannot traverse it.
+                forwardable = false;
+                break;
+            }
+        }
+
+        if (intermediates == null)
+            return; // direct capture — no intermediate closure to forward through
+
+        if (forwardable)
+        {
+            _pendingSyncChainForwards.Add((name, definingFunc, intermediates));
+        }
+        else if (definingFunc != null)
+        {
+            if (!_functionRelayCaptures.TryGetValue(definingFunc, out var relayed))
+                _functionRelayCaptures[definingFunc] = relayed = [];
+            relayed.Add(name);
+        }
+    }
+
+    /// <summary>
+    /// Post-pass over the recorded sync-arrow chain forward candidates
+    /// (<see cref="_pendingSyncChainForwards"/>). A candidate is applied only when its
+    /// name is a per-iteration snapshot-path binding — a for-initializer / loop-body
+    /// <c>let</c>/<c>const</c> or <c>for-of</c>/<c>for-in</c> variable kept off every
+    /// shared display class. For those, the name is value-forwarded onto each intermediate
+    /// sync arrow's capture set so the per-iteration value reaches the innermost closure by
+    /// value instead of populating null (#1231). Non-per-iteration captures are left
+    /// untouched: they already relay correctly through the entry-point / function display
+    /// class. Runs after the full traversal, when the per-iteration classification (which
+    /// depends on program-wide reassignment and relay information) is final.
+    /// </summary>
+    private void ApplySyncArrowChainForwarding()
+    {
+        foreach (var (name, definingFunc, intermediates) in _pendingSyncChainForwards)
+        {
+            bool perIteration = definingFunc != null
+                ? GetPerIterationLoopBindings(definingFunc).Contains(name)
+                : _topLevelPerIterationBindings.Contains(name);
+            if (!perIteration)
+                continue;
+
+            foreach (var arrow in intermediates)
+            {
+                if (_captures.TryGetValue(arrow, out var caps) && caps.Add(name))
+                    _allCapturedVariables.Add(name);
+            }
+        }
+        _pendingSyncChainForwards.Clear();
     }
 
     /// <summary>
@@ -660,6 +771,13 @@ public class ClosureAnalyzer : AstVisitorBase
             }
             else
             {
+                if (loopNames != null && _currentFunction == null)
+                {
+                    // Module-scope `for (let/const …)` initializer bindings are per-iteration
+                    // snapshot-path names (never lifted to the entry-point DC), so a chained
+                    // capture must value-forward them (#1231 / #649 exclusion).
+                    foreach (var n in loopNames) _topLevelPerIterationBindings.Add(n);
+                }
                 Visit(stmt.Initializer);
             }
         }

--- a/SharpTS.Tests/SharedTests/LoopBodyBlockScopeCaptureTests.cs
+++ b/SharpTS.Tests/SharedTests/LoopBodyBlockScopeCaptureTests.cs
@@ -16,10 +16,18 @@ namespace SharpTS.Tests.SharedTests;
 /// capture: client0's 'data' handler destroyed client1, dropping its pending data and hanging
 /// the event loop (issue #1223's "intermittent no-output hang").</para>
 ///
-/// <para>The exclusion is deliberately conservative: names that are reassigned after
-/// initialization, or captured through an intermediate closure (<c>() =&gt; () =&gt; x</c>),
-/// keep their shared display-class slot — preserving within-iteration mutation visibility and
-/// the DC relay that a nested closure's populate path needs.</para>
+/// <para>The exclusion is deliberately conservative for reassigned names: a binding the closure
+/// itself mutates keeps its shared display-class slot, preserving within-iteration mutation
+/// visibility.</para>
+///
+/// <para>#1231: a per-iteration binding captured through a chain of intermediate <em>sync</em>
+/// arrows (<c>() =&gt; () =&gt; x</c>, where the intermediate arrow does not itself reference
+/// <c>x</c>) is value-forwarded — each intermediate arrow snapshots the binding into its own
+/// display class so the innermost closure reads the true per-iteration value. This holds at
+/// module scope and inside functions/arrows. Before the fix the compiled output was <c>null</c>
+/// (top-level / function-local for-initializer) or the fused last-iteration value (function-local
+/// loop-body). Chains that cross a nested function-expression or async-arrow boundary are not
+/// sync-forwardable and keep the shared-DC relay.</para>
 /// </summary>
 public class LoopBodyBlockScopeCaptureTests
 {
@@ -316,5 +324,154 @@ public class LoopBodyBlockScopeCaptureTests
             console.log(fns.map((f: any) => f()).join(","));
             """;
         Assert.Equal("a0,a1,b7\n", TestHarness.Run(source, mode));
+    }
+
+    // ---- #1231: per-iteration bindings captured through a nested sync-arrow chain ----
+    // The intermediate arrow does not reference the binding, so it can only relay the value
+    // by capturing-and-forwarding it (value-forwarding). Before the fix the compiled inner
+    // closure read null (top-level / for-initializer) or the fused last value (function body).
+
+    // Top-level loop-body const through a two-arrow chain (#1231 shape 1).
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void TopLevel_LoopBodyConst_ChainedCapture_PerIteration(ExecutionMode mode)
+    {
+        var source = """
+            const a: any[] = [];
+            for (let i = 0; i < 3; i++) {
+                const x = { id: i };
+                a.push(() => () => x.id);
+            }
+            console.log(a.map((f: any) => f()()).join(","));
+            """;
+        Assert.Equal("0,1,2\n", TestHarness.Run(source, mode));
+    }
+
+    // Top-level for-initializer binding through a chain (#1231 shape 2 / #649 exclusion).
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void TopLevel_ForInitializer_ChainedCapture_PerIteration(ExecutionMode mode)
+    {
+        var source = """
+            const a: any[] = [];
+            for (let j = 0; j < 3; j++) {
+                a.push(() => () => j);
+            }
+            console.log(a.map((f: any) => f()()).join(","));
+            """;
+        Assert.Equal("0,1,2\n", TestHarness.Run(source, mode));
+    }
+
+    // Function-local loop-body const through a chain (was fused to the last iteration).
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void FunctionBody_LoopBodyConst_ChainedCapture_PerIteration(ExecutionMode mode)
+    {
+        var source = """
+            function go() {
+                const a: any[] = [];
+                for (let i = 0; i < 3; i++) {
+                    const x = { id: i };
+                    a.push(() => () => x.id);
+                }
+                return a;
+            }
+            console.log(go().map((f: any) => f()()).join(","));
+            """;
+        Assert.Equal("0,1,2\n", TestHarness.Run(source, mode));
+    }
+
+    // Function-local for-initializer binding through a chain (was null compiled).
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void FunctionBody_ForInitializer_ChainedCapture_PerIteration(ExecutionMode mode)
+    {
+        var source = """
+            function go() {
+                const a: any[] = [];
+                for (let j = 0; j < 3; j++) {
+                    a.push(() => () => j);
+                }
+                return a;
+            }
+            console.log(go().map((f: any) => f()()).join(","));
+            """;
+        Assert.Equal("0,1,2\n", TestHarness.Run(source, mode));
+    }
+
+    // A binding captured BOTH directly and through a chain in the same loop: both closures
+    // must observe the same per-iteration value (previously the chained capture forced even
+    // the direct one onto the shared fused slot).
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void DirectAndChainedCapture_SameLoop_BothPerIteration(ExecutionMode mode)
+    {
+        var source = """
+            const direct: any[] = [];
+            const chained: any[] = [];
+            for (let i = 0; i < 3; i++) {
+                const x = i;
+                direct.push(() => x);
+                chained.push(() => () => x);
+            }
+            const d = direct.map((f: any) => f()).join(",");
+            const c = chained.map((f: any) => f()()).join(",");
+            console.log(d + " | " + c);
+            """;
+        Assert.Equal("0,1,2 | 0,1,2\n", TestHarness.Run(source, mode));
+    }
+
+    // Deeper chain (four arrows) still forwards the per-iteration value all the way in.
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void TopLevel_LoopBodyConst_DeepChain_PerIteration(ExecutionMode mode)
+    {
+        var source = """
+            const a: any[] = [];
+            for (let i = 0; i < 3; i++) {
+                const x = i;
+                a.push(() => () => () => () => x);
+            }
+            console.log(a.map((f: any) => f()()()()).join(","));
+            """;
+        Assert.Equal("0,1,2\n", TestHarness.Run(source, mode));
+    }
+
+    // Top-level for-of loop variable through a chain.
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void TopLevel_ForOfVariable_ChainedCapture_PerIteration(ExecutionMode mode)
+    {
+        var source = """
+            const a: any[] = [];
+            for (const v of [10, 20, 30]) {
+                a.push(() => () => v);
+            }
+            console.log(a.map((f: any) => f()()).join(","));
+            """;
+        Assert.Equal("10,20,30\n", TestHarness.Run(source, mode));
+    }
+
+    // A chained capture that also references the enclosing class `this`: the per-iteration
+    // binding forwards by value while `this` still relays through the arrow chain.
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ChainedCapture_WithThis_PerIteration(ExecutionMode mode)
+    {
+        var source = """
+            class C {
+                tag = "t";
+                build() {
+                    const a: any[] = [];
+                    for (let i = 0; i < 2; i++) {
+                        const x = i;
+                        a.push(() => () => this.tag + x);
+                    }
+                    return a;
+                }
+            }
+            console.log(new C().build().map((f: any) => f()()).join(","));
+            """;
+        Assert.Equal("t0,t1\n", TestHarness.Run(source, mode));
     }
 }


### PR DESCRIPTION
Closes #1231.

## Symptom

A per-iteration binding — a `for (let …)` initializer binding (#649), or a loop-body `let`/`const` / `for-of`/`for-in` variable (#1223) — captured **only through a chain of intermediate sync arrows** (`() => () => x`, where the intermediate arrow doesn't itself reference `x`) compiled to the wrong value. The interpreter was always correct.

| Shape | Before (compiled) | Now |
|---|---|---|
| Top-level loop-body `const` chained | `null` | correct per-iteration |
| Top-level for-initializer chained (#649) | `null` | correct |
| Function-local for-initializer chained | `null` | correct |
| Function-local loop-body chained | fused (last iteration) | correct |

Pre-existing (reproduced on `main` before the #1223 fix, which deliberately did not change this class).

## Mechanism

These bindings are deliberately kept off every shared display class (the #649/#1201/#1223 value-snapshot path), so a closure snapshots them at creation. But the inner closure is created *inside* the intermediate arrow's body — where the local isn't visible — so `EmitDisplayInstanceFieldPopulation` fell through to its `Ldnull` "variable not found" branch (`ILEmitter.Calls.Closures.cs`).

## Fix

Purely in `Compilation/ClosureAnalyzer.cs` (no emitter change). Value-forward the binding up the sync-arrow chain, mirroring what `PropagateCaptureUpAsyncArrowChain` already does for async arrows (#716):

- **`RecordChainCapture`** runs at each indirect capture. When every intermediate frame is a plain (non-async, non-generator) arrow, it records a forward candidate; a chain crossing a nested function-expression or async-arrow boundary keeps the existing `_functionRelayCaptures` decline (that machinery is **narrowed**, not removed).
- **`ApplySyncArrowChainForwarding`** — a post-pass at the end of `Analyze()` (run there because per-iteration classification isn't final until the whole program is walked). For each candidate that is genuinely a per-iteration binding (`GetPerIterationLoopBindings` for function-local; the new `_topLevelPerIterationBindings` set for module scope), it unions the name onto every intermediate arrow's capture set.

That single structural change is all that's needed: the existing DEFINE phase then gives each intermediate its own field, the outermost snapshots the visible local, and inner levels read the parent's field via the normal `CapturedFields` path. `#650` per-iteration cells forward correctly through the chain too (only the innermost dereferences the `StrongBox`).

Also fixes a mixed direct-plus-chained same-loop capture that previously forced even the direct closure onto the fused slot.

## Tests

- `SharpTS.Tests/SharedTests/LoopBodyBlockScopeCaptureTests.cs`: 8 new theories × both modes (top-level / function-body × loop-body / for-initializer chained, a 4-arrow deep chain, top-level `for-of` chained, direct+chained in one loop, and chained + class `this`). Class doc-comment updated (the old note documented the now-fixed deviation).

## Verification

- **xUnit 15351/0**
- **Test262 22/0/4skip** (interpreter + compiled, baseline-identical)
- **TSConf 31/0** (baseline-identical)
- `--compile … --verify` passes

## Out of scope (still latent)

- Top-level **async**-arrow chains (baseline-confirmed pre-existing; async-chain-with-intermediate-local).
- #1230 (inner `function` declaration in a loop body unreferenceable when compiled) remains open.