### PR TITLE
fix(cluster): synchronize shared-listener start-once to stop worker-listen race

### DIFF
--- a/Runtime/Types/SharedListenerRegistry.cs
+++ b/Runtime/Types/SharedListenerRegistry.cs
@@ -126,6 +126,7 @@ internal class SharedTcpListener
 {
     private readonly TcpListener _listener;
     private readonly ConcurrentDictionary<double, WorkerRegistration> _workers = new();
+    private readonly object _startGate = new();
     private int _roundRobinIndex;
     private CancellationTokenSource? _cts;
     private bool _started;
@@ -140,12 +141,22 @@ internal class SharedTcpListener
     public void AddWorker(double workerId, Action<TcpClient> onConnection, Interp workerInterpreter)
     {
         _workers[workerId] = new WorkerRegistration(workerId, onConnection, workerInterpreter);
-        if (!_started)
+
+        // Start the underlying listener exactly once. Two cluster workers calling server.listen() on
+        // the same port register concurrently on their own interpreter threads and are handed the SAME
+        // SharedTcpListener by GetOrAdd, so this start-once transition MUST be synchronized. Without the
+        // lock both workers can pass the `!_started` check, both call _listener.Start(), and the second
+        // Bind on the same socket throws — the throwing worker's ListenAsClusterWorker then never fires
+        // its `listening` callback / 'ready' message, deadlocking a round-robin test until its timeout.
+        // Publish `_started` only after Start succeeds so a genuinely failed first Start can be retried.
+        if (Volatile.Read(ref _started)) return;
+        lock (_startGate)
         {
-            _started = true;
+            if (_started) return;
             _cts = new CancellationTokenSource();
             _listener.Start();
             StartAccepting();
+            Volatile.Write(ref _started, true);
         }
     }
 
@@ -156,9 +167,12 @@ internal class SharedTcpListener
 
     public void Stop()
     {
-        _cts?.Cancel();
-        try { _listener.Stop(); } catch { }
-        _started = false;
+        lock (_startGate)
+        {
+            _cts?.Cancel();
+            try { _listener.Stop(); } catch { }
+            Volatile.Write(ref _started, false);
+        }
     }
 
     private void StartAccepting()
@@ -207,6 +221,7 @@ internal class SharedHttpListener
 {
     private HttpListener? _listener;
     private readonly ConcurrentDictionary<double, HttpWorkerRegistration> _workers = new();
+    private readonly object _startGate = new();
     private int _roundRobinIndex;
     private CancellationTokenSource? _cts;
     private bool _started;
@@ -222,9 +237,15 @@ internal class SharedHttpListener
     public void AddWorker(double workerId, Action<HttpListenerContext> onRequest, Interp workerInterpreter)
     {
         _workers[workerId] = new HttpWorkerRegistration(workerId, onRequest, workerInterpreter);
-        if (!_started)
+
+        // Start the underlying HttpListener exactly once — see SharedTcpListener.AddWorker for the race:
+        // two workers sharing a port register concurrently on the same SharedHttpListener, so the
+        // start-once transition must be synchronized or the second Start() throws and its worker never
+        // reports `listening`/`ready`, hanging the test. Publish `_started` only after Start succeeds.
+        if (Volatile.Read(ref _started)) return;
+        lock (_startGate)
         {
-            _started = true;
+            if (_started) return;
             _cts = new CancellationTokenSource();
             _listener = new HttpListener();
             _listener.Prefixes.Add($"http://+:{_port}/");
@@ -239,6 +260,7 @@ internal class SharedHttpListener
                 _listener.Start();
             }
             StartAccepting();
+            Volatile.Write(ref _started, true);
         }
     }
 
@@ -249,10 +271,13 @@ internal class SharedHttpListener
 
     public void Stop()
     {
-        _cts?.Cancel();
-        try { _listener?.Stop(); } catch { }
-        try { _listener?.Close(); } catch { }
-        _started = false;
+        lock (_startGate)
+        {
+            _cts?.Cancel();
+            try { _listener?.Stop(); } catch { }
+            try { _listener?.Close(); } catch { }
+            Volatile.Write(ref _started, false);
+        }
     }
 
     private void StartAccepting()


### PR DESCRIPTION
## Summary

Fixes the intermittent 60s CI timeout in the cluster port-sharing tests (`RoundRobin_DistributesConnectionsAcrossWorkers`, `Fork_WorkersShareNetPort`, `Fork_WorkersShareHttpPort`, Compiled mode). This is a **real data race**, not test flakiness — pre-existing on `main`.

It surfaced on the CI run for #1239 (inner-function fix), was root-caused there, but the fix landed on the branch *after* #1239 had already merged — so it never reached `main`. This PR lands it.

## Root cause

`SharedTcpListener.AddWorker` / `SharedHttpListener.AddWorker` (`Runtime/Types/SharedListenerRegistry.cs`) started the underlying listener with an **unsynchronized check-then-act**:

```csharp
if (!_started) { _started = true; _listener.Start(); StartAccepting(); }
```

Under `SCHED_RR`, both cluster workers call `server.listen()` on the same port from their own interpreter threads, and `ConcurrentDictionary.GetOrAdd` hands both the **same** `SharedTcpListener`. When the two `AddWorker` calls overlap:

- both read `_started == false`, both set it `true`, and both call `_listener.Start()`;
- the second `Bind` on the same socket throws;
- that exception propagates out of `SharpTSNetServer.ListenAsClusterWorker` **before** it fires the `listening` callback / `process.send('ready')`;
- the primary's `readyCount` never reaches 2, the connections are never made, and the module hangs to the 60s timeout.

Multi-core + CI load widens the race window, so it appeared intermittently, Compiled-mode only, and as a **timeout** (not an assertion failure).

## Fix

Wrap the start-once transition in a lock — double-checked, publishing `_started` only after `Start()` succeeds (so a genuinely failed first `Start` can still be retried) — in both `SharedTcpListener` and `SharedHttpListener`, and guard `Stop()` with the same lock.

## Verification

- **Reproduced** on the pre-fix build: looping the three port-sharing tests, `Fork_WorkersShareNetPort(mode: Compiled)` hung 61s on the first iteration; the next passed in 7s.
- **Post-fix:** 40/40 iterations of the three tests pass with no hang (plus a further reconfirmation loop on this branch's base).
- Full `ClusterModule` / `Net` / `Http` suite: **130 / 0**.
