### PR TITLE
fix(compile): initialize namespace fields in the multi-module entry point (#1245)

### DIFF
--- a/Compilation/ILCompiler.Modules.cs
+++ b/Compilation/ILCompiler.Modules.cs
@@ -713,6 +713,14 @@ public partial class ILCompiler
             }
         }
 
+        // Initialize namespace static fields before any module/script $Initialize body runs.
+        // Namespace objects live in flat static fields ($ns_*) on $Program shared across every
+        // module, but a module's $Initialize only POPULATES them (EmitNamespace does
+        // $ns_X.Set(...)); it never creates them. The single-file entry point calls this at the
+        // top of Main; the multi-module entry point must too, or the first Set() dereferences a
+        // null namespace field (#1245).
+        InitializeNamespaceFields(il);
+
         // Call each module/script's $Initialize method in dependency order.
         // CommonJS modules are initialized lazily — only the entry CJS module is run eagerly,
         // and require() triggers the rest. This matches Node semantics for the visible execution

--- a/SharpTS.Tests/SharedTests/NamespaceInModuleTests.cs
+++ b/SharpTS.Tests/SharedTests/NamespaceInModuleTests.cs
@@ -1,0 +1,104 @@
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests;
+
+/// <summary>
+/// Regression tests for #1245: in compiled mode, a <c>namespace</c> declaration combined with a
+/// top-level <c>import</c> (which turns the file into an ES module) crashed at startup with a
+/// <c>NullReferenceException</c> in <c>$TSNamespace.Set</c>. The multi-module entry point never
+/// called <c>InitializeNamespaceFields</c>, so the namespace's backing static field was still null
+/// when the module's <c>$Initialize</c> body tried to populate it. A namespace in a plain script
+/// (no import) was unaffected — becoming an ES module is what broke it. The interpreter always ran
+/// these correctly; each test runs both modes so the compiled path is pinned against that oracle.
+/// </summary>
+public class NamespaceInModuleTests
+{
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Namespace_WithImportAfter_ExportedConst(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                namespace NS {
+                  export const x = 1;
+                }
+                console.log(NS.x);
+                import * as fs from "fs";
+                console.log(typeof fs.statSync);
+                """
+        };
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("1\nfunction\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Namespace_WithImportBefore_ExportedFunction(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import * as path from "path";
+                namespace NS {
+                  export function greet(): string { return "hi"; }
+                }
+                console.log(NS.greet());
+                console.log(typeof path.join);
+                """
+        };
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("hi\nfunction\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void NestedNamespace_WithImport(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import * as path from "path";
+                namespace Outer {
+                  export const a = 10;
+                  export namespace Inner {
+                    export const b = 42;
+                  }
+                }
+                console.log(Outer.a);
+                console.log(Outer.Inner.b);
+                console.log(typeof path.join);
+                """
+        };
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("10\n42\nfunction\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Namespace_WithSiblingModuleImport_ClassAndEnumMembers(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["helper.ts"] = """
+                export function add(a: number, b: number): number { return a + b; }
+                """,
+            ["main.ts"] = """
+                import { add } from "./helper";
+                namespace Calc {
+                  export const base = 10;
+                  export function compute(): number { return add(base, 5); }
+                  export enum Op { Add, Sub }
+                  export class Adder { run(): number { return add(1, 2); } }
+                }
+                console.log(Calc.base);
+                console.log(Calc.compute());
+                console.log(Calc.Op.Sub);
+                console.log(new Calc.Adder().run());
+                """
+        };
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("10\n15\n1\n3\n", output);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #1245. In **compiled** mode, any program containing both a `namespace` declaration **and** a top-level `import` (which makes the file an ES module) crashed at startup with a `NullReferenceException` in `$TSNamespace.Set`, called from the module's `$Initialize`. The interpreter ran the same program correctly.

## Root cause

Namespace objects live in flat static fields (`$ns_*`) on `$Program`, shared across every module. A module's `$Initialize` body only **populates** them — `EmitNamespace` emits `$ns_X.Set(...)` — it never **creates** them.

- The single-file entry point (`EmitSingleFileEntryPoint` / `EmitExeEntryPointWithUserMain`) calls `InitializeNamespaceFields(il)` at the top of `Main`, before any top-level code runs.
- The multi-module entry point (`EmitModulesEntryPoint`, used whenever the program has imports) **omitted** that call.

So when a module's `$Initialize` ran `$ns_NS.Set("x", 1)`, `$ns_NS` was still null → NRE. A `namespace` in a plain script (no import) was fine because that path uses the single-file entry point.

## Fix

Call `InitializeNamespaceFields(il)` in `EmitModulesEntryPoint` before the module `$Initialize` dispatch loop, mirroring the single-file path. Namespace fields are global/flat and defined once, so initializing them all in `Main` before any module init covers ES-module, script, and lazily-required CommonJS modules alike.

## Tests

New `NamespaceInModuleTests` (runs both interpreter and compiled via `ExecutionModes.All`):
- namespace + import in the entry file — exported `const`, import after (the exact issue repro)
- exported `function` member, import before the namespace
- nested namespaces
- namespace alongside a sibling-module import, with `class` and `enum` members

Confirmed the 4 compiled-mode tests fail with `NullReferenceException` without the fix and pass with it (interpreted always passed).

## Verification

- xUnit: **15412 / 0** (baseline 15404 + 8 new)
- Test262: **22 / 0 / 4 skip** (matches baseline, interp + compiled)
- TypeScript conformance: **31 / 0** (matches baseline)
- `--verify` on the fs-free namespace-in-module case is clean; the `$M_fs_*` / `$M_path_*` IL-verify errors that appear when importing those facades are pre-existing and orthogonal (tracked as #1246).