### PR TITLE
refactor(ast): unify AstVisitorBase Stmt.Expression handler name (#1250)

### DIFF
--- a/Compilation/StringAccumulatorPromotionAnalyzer.cs
+++ b/Compilation/StringAccumulatorPromotionAnalyzer.cs
@@ -108,7 +108,7 @@ public static class StringAccumulatorPromotionAnalyzer
                 Visit(initializer);
         }
 
-        protected override void VisitExpressionStmt(Stmt.Expression stmt)
+        protected override void VisitExpression(Stmt.Expression stmt)
         {
             // Permitted append in statement position (result discarded): `s = s + E` / `s += E`
             // with E statically string. Consume by visiting ONLY E — not the target, not the inner
@@ -124,7 +124,7 @@ public static class StringAccumulatorPromotionAnalyzer
                     Visit(ca.Value);
                     return;
             }
-            base.VisitExpressionStmt(stmt);
+            base.VisitExpression(stmt);
         }
 
         protected override void VisitGet(Expr.Get expr)

--- a/Parsing/Visitors/AstVisitorBase.cs
+++ b/Parsing/Visitors/AstVisitorBase.cs
@@ -91,7 +91,7 @@ public abstract class AstVisitorBase
 
         switch (stmt)
         {
-            case Stmt.Expression s: VisitExpressionStmt(s); break;
+            case Stmt.Expression s: VisitExpression(s); break;
             case Stmt.Var s: VisitVar(s); break;
             case Stmt.Const s: VisitConst(s); break;
             case Stmt.Function s: VisitFunction(s); break;
@@ -431,7 +431,7 @@ public abstract class AstVisitorBase
 
     #region Statement Visitors - Default implementations traverse children
 
-    protected virtual void VisitExpressionStmt(Stmt.Expression stmt)
+    protected virtual void VisitExpression(Stmt.Expression stmt)
     {
         Visit(stmt.Expr);
     }


### PR DESCRIPTION
## Summary

Renames `VisitExpressionStmt` → `VisitExpression` in the `AstVisitorBase` analyzer-visitor family, so the handler for `Stmt.Expression` follows the same mechanical `Visit` + node-type-name rule used everywhere else (`Stmt.Var` → `VisitVar`, `Expr.Binary` → `VisitBinary`, …).

`Stmt.Expression` was the **only** node whose handler name diverged between the two dispatch families:

| Family | Handler for `Stmt.Expression` (before) |
|---|---|
| Analyzer visitors (`AstVisitorBase` + subclasses) | `VisitExpressionStmt` |
| Registry dispatch (`Interpreter`, `TypeChecker`, via `NodeRegistry.AutoRegister`'s `$"Visit{Name}"`) | `VisitExpression` |

This removes the last exception to the uniform naming and the one wrinkle a future source-generator-based dispatch (the road not taken in #1243) would have to special-case.

## Changes (4 spots, behavior-neutral)

- `Parsing/Visitors/AstVisitorBase.cs` — the `Stmt.Expression` switch case
- `Parsing/Visitors/AstVisitorBase.cs` — the virtual method definition
- `Compilation/StringAccumulatorPromotionAnalyzer.cs` — the override
- `Compilation/StringAccumulatorPromotionAnalyzer.cs` — the `base.VisitExpression(stmt)` call

No collision with the existing `Interpreter.VisitExpression` / `TypeChecker.VisitExpression` methods — those live on the registry-dispatch types, not in the `AstVisitorBase` hierarchy.

## Testing

- `dotnet build` — 0 errors
- Full xUnit suite — **15415 passed / 0 failed** (includes `AstDispatchTests`, which guards the `AstVisitorBase` switch via a `GetUninitializedObject` + `NotSupportedException` probe)

Pure internal C# method rename with no behavioral surface — the Test262/TSConf conformance suites exercise TypeScript semantics this change cannot affect.

Part of #1094.

Closes #1250