### PR TITLE
types: #99 lib.d.ts loader + checker features — 250→256 Pass

### DIFF
--- a/SharpTS.TypeScriptConformance/baselines/interpreted.txt
+++ b/SharpTS.TypeScriptConformance/baselines/interpreted.txt
@@ -245,7 +245,7 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/undefine
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/unionTypesAssignability.ts Pass
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/enumIsNotASubtypeOfAnythingButNumber.ts Pass
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/nullIsSubtypeOfEverythingButUndefined.ts Pass
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/stringLiteralTypeIsSubtypeOfString.ts Fail
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/stringLiteralTypeIsSubtypeOfString.ts Pass
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfAny.ts Pass
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameter.ts Pass
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts Pass

--- a/SharpTS.TypeScriptConformance/baselines/interpreted.txt
+++ b/SharpTS.TypeScriptConformance/baselines/interpreted.txt
@@ -98,7 +98,7 @@ tests/cases/conformance/es6/Symbols/symbolProperty20.ts Pass
 tests/cases/conformance/es6/Symbols/symbolProperty21.ts Fail
 tests/cases/conformance/es6/Symbols/symbolProperty22.ts Pass
 tests/cases/conformance/es6/Symbols/symbolProperty23.ts Pass
-tests/cases/conformance/es6/Symbols/symbolProperty24.ts Fail
+tests/cases/conformance/es6/Symbols/symbolProperty24.ts Pass
 tests/cases/conformance/es6/Symbols/symbolProperty25.ts Pass
 tests/cases/conformance/es6/Symbols/symbolProperty26.ts Pass
 tests/cases/conformance/es6/Symbols/symbolProperty27.ts Pass

--- a/SharpTS.TypeScriptConformance/baselines/interpreted.txt
+++ b/SharpTS.TypeScriptConformance/baselines/interpreted.txt
@@ -95,7 +95,7 @@ tests/cases/conformance/es6/Symbols/symbolProperty18.ts Pass
 tests/cases/conformance/es6/Symbols/symbolProperty19.ts Pass
 tests/cases/conformance/es6/Symbols/symbolProperty2.ts Pass
 tests/cases/conformance/es6/Symbols/symbolProperty20.ts Pass
-tests/cases/conformance/es6/Symbols/symbolProperty21.ts Fail
+tests/cases/conformance/es6/Symbols/symbolProperty21.ts Pass
 tests/cases/conformance/es6/Symbols/symbolProperty22.ts Pass
 tests/cases/conformance/es6/Symbols/symbolProperty23.ts Pass
 tests/cases/conformance/es6/Symbols/symbolProperty24.ts Pass

--- a/SharpTS.TypeScriptConformance/baselines/interpreted.txt
+++ b/SharpTS.TypeScriptConformance/baselines/interpreted.txt
@@ -132,7 +132,7 @@ tests/cases/conformance/es6/Symbols/symbolProperty51.ts Pass
 tests/cases/conformance/es6/Symbols/symbolProperty52.ts Pass
 tests/cases/conformance/es6/Symbols/symbolProperty53.ts Pass
 tests/cases/conformance/es6/Symbols/symbolProperty54.ts Pass
-tests/cases/conformance/es6/Symbols/symbolProperty55.ts Fail
+tests/cases/conformance/es6/Symbols/symbolProperty55.ts Pass
 tests/cases/conformance/es6/Symbols/symbolProperty56.ts Pass
 tests/cases/conformance/es6/Symbols/symbolProperty57.ts Pass
 tests/cases/conformance/es6/Symbols/symbolProperty58.ts Pass
@@ -149,7 +149,7 @@ tests/cases/conformance/es6/Symbols/symbolType11.ts Pass
 tests/cases/conformance/es6/Symbols/symbolType12.ts Pass
 tests/cases/conformance/es6/Symbols/symbolType13.ts Pass
 tests/cases/conformance/es6/Symbols/symbolType14.ts Pass
-tests/cases/conformance/es6/Symbols/symbolType15.ts Fail
+tests/cases/conformance/es6/Symbols/symbolType15.ts Pass
 tests/cases/conformance/es6/Symbols/symbolType16.ts Pass
 tests/cases/conformance/es6/Symbols/symbolType17.ts Pass
 tests/cases/conformance/es6/Symbols/symbolType18.ts Pass

--- a/SharpTS.TypeScriptConformance/baselines/interpreted.txt
+++ b/SharpTS.TypeScriptConformance/baselines/interpreted.txt
@@ -162,7 +162,7 @@ tests/cases/conformance/es6/Symbols/symbolType5.ts Pass
 tests/cases/conformance/es6/Symbols/symbolType6.ts Pass
 tests/cases/conformance/es6/Symbols/symbolType7.ts Pass
 tests/cases/conformance/es6/Symbols/symbolType8.ts Pass
-tests/cases/conformance/es6/Symbols/symbolType9.ts Fail
+tests/cases/conformance/es6/Symbols/symbolType9.ts Pass
 tests/cases/conformance/esnext/logicalAssignment/logicalAssignment11.ts Pass
 tests/cases/conformance/types/conditional/conditionalTypes1.ts Pass
 tests/cases/conformance/types/conditional/conditionalTypes2.ts Pass

--- a/SharpTS.csproj
+++ b/SharpTS.csproj
@@ -44,6 +44,12 @@
     <None Remove="stdlib\**\*.ts" />
   </ItemGroup>
 
+  <!-- Ambient lib type declarations parsed by LibTypeLoader into the type checker (#99). -->
+  <ItemGroup>
+    <EmbeddedResource Include="libdefs\**\*.d.ts" />
+    <None Remove="libdefs\**\*.d.ts" />
+  </ItemGroup>
+
   <!-- Exclude test, example, benchmark, and SDK projects from this compilation.
        This list is hand-maintained and load-bearing: because this project sits at
        the repo root, the SDK's default **/*.cs glob would otherwise pull in every

--- a/TypeSystem/LibTypeLoader.cs
+++ b/TypeSystem/LibTypeLoader.cs
@@ -1,0 +1,49 @@
+using System.Collections.Frozen;
+using SharpTS.Parsing;
+
+namespace SharpTS.TypeSystem;
+
+/// <summary>
+/// #99 increment 2 — the lib.d.ts loader. Parses the ambient TypeScript lib declarations embedded as
+/// <c>libdefs/*.d.ts</c> resources and resolves them to modeled <see cref="TypeInfo"/>, so the type
+/// checker resolves lib names (e.g. <c>SymbolConstructor</c>) from real declarations instead of
+/// hand-modeled shapes. Built once and cached process-wide (the lib types are the same for every
+/// checker instance). A later increment expands the embedded sources toward the full vendored
+/// <c>external/typescript/src/lib/*.d.ts</c>.
+/// </summary>
+internal static class LibTypeLoader
+{
+    private static FrozenDictionary<string, TypeInfo>? _types;
+
+    /// <summary>Ambient lib type name → its resolved <see cref="TypeInfo"/>.</summary>
+    public static FrozenDictionary<string, TypeInfo> Types => _types ??= Build();
+
+    public static bool TryGet(string name, out TypeInfo type)
+    {
+        if (Types.TryGetValue(name, out var t)) { type = t; return true; }
+        type = null!;
+        return false;
+    }
+
+    private static FrozenDictionary<string, TypeInfo> Build()
+    {
+        var statements = new List<Stmt>();
+        var assembly = typeof(LibTypeLoader).Assembly;
+        foreach (var resourceName in assembly.GetManifestResourceNames())
+        {
+            if (!resourceName.Contains("libdefs") || !resourceName.EndsWith(".d.ts"))
+                continue;
+            using var stream = assembly.GetManifestResourceStream(resourceName);
+            if (stream is null) continue;
+            using var reader = new StreamReader(stream);
+            var parseResult = new Parser(new Lexer(reader.ReadToEnd()).ScanTokens()).Parse();
+            if (parseResult.IsSuccess)
+                statements.AddRange(parseResult.Statements);
+        }
+        // Resolve to TypeInfo via a throwaway checker; its diagnostics are discarded (lib sources are
+        // trusted). Empty-dict on any failure so a broken embed degrades to the prior hand-modeling.
+        return statements.Count > 0
+            ? new TypeChecker().ExtractLibTypes(statements)
+            : FrozenDictionary<string, TypeInfo>.Empty;
+    }
+}

--- a/TypeSystem/TypeChecker.Calls.cs
+++ b/TypeSystem/TypeChecker.Calls.cs
@@ -97,6 +97,13 @@ public partial class TypeChecker
             var instantiatedFunc = InstantiateGenericFunction(genericFunc, typeArgs);
             if (instantiatedFunc is TypeInfo.Function instFunc)
             {
+                // Excess-property check for fresh object-literal args against the instantiated
+                // parameter types (the generic path otherwise skips argument validation).
+                for (int ai = 0; ai < call.Arguments.Count && ai < instFunc.ParamTypes.Count; ai++)
+                {
+                    if (call.Arguments[ai] is Expr.ObjectLiteral && argTypes[ai] is TypeInfo.Record argRec)
+                        CheckExcessProperties(argRec, instFunc.ParamTypes[ai], call.Arguments[ai]);
+                }
                 return instFunc.ReturnType;
             }
             return new TypeInfo.Any();
@@ -210,6 +217,13 @@ public partial class TypeChecker
                         else
                         {
                             argType = CheckExpr(arg);
+                        }
+                        // Excess-property check for a FRESH object-literal argument (tsc's fresh-literal
+                        // rule) against its parameter type — mirrors the assignment path.
+                        if (arg is Expr.ObjectLiteral && argType is TypeInfo.Record argExcessRecord
+                            && paramIndex < regularParamCount)
+                        {
+                            CheckExcessProperties(argExcessRecord, funcType.ParamTypes[paramIndex], arg);
                         }
                         if (paramIndex < regularParamCount)
                         {

--- a/TypeSystem/TypeChecker.Compatibility.Structural.cs
+++ b/TypeSystem/TypeChecker.Compatibility.Structural.cs
@@ -100,6 +100,15 @@ public partial class TypeChecker
             hasStringIndex = cls.StringIndexType != null;
             hasNumberIndex = cls.NumberIndexType != null;
         }
+        else if (expected is TypeInfo.InstantiatedGeneric ig && FlattenInstantiatedInterface(ig) is { } flatIface)
+        {
+            // A generic interface argument (`I<number>`) flattens to its concrete members so a fresh
+            // object literal passed to a generic function is excess-checked too.
+            foreach (var member in flatIface.GetAllMembers())
+                expectedKeys.Add(member.Key);
+            hasStringIndex = flatIface.StringIndexType != null;
+            hasNumberIndex = flatIface.NumberIndexType != null;
+        }
         else
         {
             // For other types (primitives, unions, etc.), skip excess property check
@@ -136,9 +145,30 @@ public partial class TypeChecker
             throw new TypeCheckException(
                 $"Object literal may only specify known properties. " +
                 $"Excess {(excessKeys.Count == 1 ? "property" : "properties")}: {excessList}",
+                line: ExcessPropertyLine(sourceExpr, excessKeys[0]),
                 tsCode: "TS2353"
             );
         }
+    }
+
+    /// <summary>The source line of an excess property (for TS2353 attribution) — the offending
+    /// property's own line rather than the enclosing statement's, which matters when the object
+    /// literal spans multiple lines (e.g. a multi-line call argument). Null if it can't be located.</summary>
+    private static int? ExcessPropertyLine(Expr sourceExpr, string excessKey)
+    {
+        if (sourceExpr is not Expr.ObjectLiteral obj) return null;
+        foreach (var prop in obj.Properties)
+        {
+            if (prop.Key is { } key && GetAccessorMemberName(key) == excessKey)
+                return key switch
+                {
+                    Expr.IdentifierKey id => id.Name.Line,
+                    Expr.LiteralKey lit => lit.Literal.Line,
+                    Expr.ComputedKey ck => TryGetExprLine(ck.Expression),
+                    _ => null
+                };
+        }
+        return null;
     }
 
     private TypeInfo? GetMemberType(TypeInfo type, string name)

--- a/TypeSystem/TypeChecker.Operators.cs
+++ b/TypeSystem/TypeChecker.Operators.cs
@@ -26,7 +26,7 @@ public partial class TypeChecker
             OperatorDescriptor.Plus => CheckPlusOperator(left, right, line),
             OperatorDescriptor.Arithmetic or OperatorDescriptor.Power => CheckArithmeticBinary(left, right, line),
             OperatorDescriptor.Comparison => CheckComparisonBinary(left, right, binary.Operator.Lexeme, line),
-            OperatorDescriptor.Equality => new TypeInfo.Primitive(TokenType.TYPE_BOOLEAN),
+            OperatorDescriptor.Equality => CheckEqualityBinary(left, right, line),
             OperatorDescriptor.Bitwise or OperatorDescriptor.BitwiseShift => CheckBitwiseBinary(left, right, line),
             OperatorDescriptor.UnsignedRightShift => CheckUnsignedShiftBinary(left, right, line),
             OperatorDescriptor.In => CheckInOperator(right, line),
@@ -48,6 +48,31 @@ public partial class TypeChecker
     {
         if (right is TypeInfo.Symbol or TypeInfo.UniqueSymbol)
             throw new TypeCheckException($"Type '{right}' is not assignable to type 'object'.", line > 0 ? line : null, tsCode: "TS2322");
+        return new TypeInfo.Primitive(TokenType.TYPE_BOOLEAN);
+    }
+
+    /// <summary>
+    /// Equality (<c>==</c>/<c>!=</c>/<c>===</c>/<c>!==</c>). tsc's "no overlap" check (TS2367) is broad,
+    /// but only the symbol-vs-non-symbol-primitive slice is implemented here (scoped to keep other
+    /// comparisons untouched): a <c>symbol</c> can never equal a <c>boolean</c>/<c>number</c>/
+    /// <c>string</c>/<c>bigint</c>, so comparing them is flagged unintentional. A symbol vs symbol / vs
+    /// <c>any</c> / vs a union that could hold a symbol is fine.
+    /// </summary>
+    private TypeInfo CheckEqualityBinary(TypeInfo left, TypeInfo right, int line)
+    {
+        bool leftSym = left is TypeInfo.Symbol or TypeInfo.UniqueSymbol;
+        bool rightSym = right is TypeInfo.Symbol or TypeInfo.UniqueSymbol;
+        if (leftSym != rightSym)
+        {
+            TypeInfo other = leftSym ? right : left;
+            if (other is TypeInfo.Primitive or TypeInfo.String or TypeInfo.NumberLiteral
+                or TypeInfo.StringLiteral or TypeInfo.BooleanLiteral or TypeInfo.BigInt or TypeInfo.BigIntLiteral)
+            {
+                throw new TypeCheckException(
+                    $"This comparison appears to be unintentional because the types '{left}' and '{right}' have no overlap.",
+                    line > 0 ? line : null, tsCode: "TS2367");
+            }
+        }
         return new TypeInfo.Primitive(TokenType.TYPE_BOOLEAN);
     }
 

--- a/TypeSystem/TypeChecker.Statements.Classes.cs
+++ b/TypeSystem/TypeChecker.Statements.Classes.cs
@@ -554,6 +554,13 @@ public partial class TypeChecker
                 var interfaceToken = classStmt.Interfaces[i];
                 TypeInfo? itfTypeInfo = _environment.Get(interfaceToken.Lexeme);
 
+                // #99: a lib wrapper type (`implements String`) resolves to the primitive in type
+                // position, not an interface — consult the loaded lib for a real interface so it's a
+                // valid implements target rather than a spurious "not an interface" (TS2304).
+                if (itfTypeInfo is not TypeInfo.Interface and not TypeInfo.GenericInterface
+                    && LibTypeLoader.TryGet(interfaceToken.Lexeme, out var libImplements))
+                    itfTypeInfo = libImplements;
+
                 // Get type arguments for this interface if provided
                 List<string>? typeArgs = classStmt.InterfaceTypeArgs != null && i < classStmt.InterfaceTypeArgs.Count
                     ? classStmt.InterfaceTypeArgs[i]

--- a/TypeSystem/TypeChecker.Statements.Classes.cs
+++ b/TypeSystem/TypeChecker.Statements.Classes.cs
@@ -547,6 +547,9 @@ public partial class TypeChecker
         }
 
         // Validate implemented interfaces (skip for generic classes - validated at instantiation)
+        // Resolved interfaces are captured so an un-annotated method's INFERRED return type can be
+        // re-checked against them after the body pass (this validation runs before inference).
+        List<TypeInfo.Interface> implementsForRecheck = [];
         if (classStmt.Interfaces != null && classTypeParams == null)
         {
             for (int i = 0; i < classStmt.Interfaces.Count; i++)
@@ -620,6 +623,7 @@ public partial class TypeChecker
                 }
 
                 ValidateInterfaceImplementation(classTypeForBody, interfaceType, classStmt.Name.Lexeme, classStmt.Name.Line);
+                implementsForRecheck.Add(interfaceType);
             }
         }
 
@@ -1113,7 +1117,12 @@ public partial class TypeChecker
         // `[Symbol.x]()` method carries its inferred return type rather than the <inferred> placeholder
         // it held at the string-index check earlier (ValidateClassPropertiesAgainstIndex).
         mutableClass.ResetFrozenCache();
-        ValidateClassMembersAgainstSymbolIndex(classStmt, mutableClass.Freeze());
+        var finalizedClass = mutableClass.Freeze();
+        ValidateClassMembersAgainstSymbolIndex(classStmt, finalizedClass);
+        // Re-check implemented-interface method compatibility now that un-annotated method return
+        // types are inferred (the pre-inference pass above saw a <inferred> placeholder — TS2416).
+        if (implementsForRecheck.Count > 0)
+            RecheckImplementsInferredReturns(classStmt, finalizedClass, implementsForRecheck);
     }
 
     /// <summary>

--- a/TypeSystem/TypeChecker.Statements.Interfaces.cs
+++ b/TypeSystem/TypeChecker.Statements.Interfaces.cs
@@ -396,6 +396,10 @@ public partial class TypeChecker
                 var extendType = ResolveAnnotation(
                     extendTypeName,
                     interfaceStmt.ExtendsNodes != null && i < interfaceStmt.ExtendsNodes.Count ? interfaceStmt.ExtendsNodes[i] : null)!;
+                // #99: `interface I extends String` — the wrapper name resolves to the primitive; use
+                // the loaded lib interface so it's a valid extends target (not a spurious TS2312).
+                if (extendType is not TypeInfo.Interface && LibTypeLoader.TryGet(extendTypeName, out var libExtends))
+                    extendType = libExtends;
                 if (extendType is TypeInfo.Interface extendInterface)
                 {
                     extendsList.Add(extendInterface);

--- a/TypeSystem/TypeChecker.Statements.cs
+++ b/TypeSystem/TypeChecker.Statements.cs
@@ -297,6 +297,8 @@ public partial class TypeChecker
         if (_environment.GetTypeAlias(name) is not null) return;
         if (_environment.GetGenericTypeAlias(name) is not null) return;
         if (_openTypeVariablesInScope?.Contains(name) == true) return;
+        // #99 lib-type seam: an ambient lib.d.ts type name (e.g. Symbol/SymbolConstructor) is known.
+        if (TryResolveLibType(name) is not null) return;
 
         throw new TypeCheckException($" Cannot find name '{name}'.", line, tsCode: "TS2304");
     }

--- a/TypeSystem/TypeChecker.TypeParsing.cs
+++ b/TypeSystem/TypeChecker.TypeParsing.cs
@@ -232,8 +232,30 @@ public partial class TypeChecker
             return enumType;
         }
 
+        // #99 lib-type seam: ambient lib.d.ts TYPE-position names SharpTS doesn't load from the
+        // .d.ts files yet (checked AFTER user declarations above, so a user interface of the same
+        // name wins). A later increment backs this with a real lib.d.ts loader.
+        if (TryResolveLibType(typeName) is { } libType)
+        {
+            return libType;
+        }
+
         return new TypeInfo.Any();
     }
+
+    /// <summary>
+    /// The #99 lib-type seam: resolves the ambient TYPE-position names that lib.d.ts declares but
+    /// SharpTS doesn't yet parse from the vendored .d.ts files, to their modeled <see cref="TypeInfo"/>.
+    /// Consulted by both <see cref="ResolveTypeNameCore"/> (for the type) and
+    /// <c>ReportUnknownTypeName</c> (so these names aren't flagged TS2304). Increment 1 covers the
+    /// Symbol family; a later increment replaces this switch with content loaded from lib.d.ts.
+    /// </summary>
+    private static TypeInfo? TryResolveLibType(string name) => name switch
+    {
+        "SymbolConstructor" => WellKnownSymbolTypes.SymbolConstructor,
+        "Symbol" => WellKnownSymbolTypes.SymbolWrapper,
+        _ => null
+    };
 
     /// <summary>
     /// Simplifies an intersection type according to TypeScript semantics:

--- a/TypeSystem/TypeChecker.TypeParsing.cs
+++ b/TypeSystem/TypeChecker.TypeParsing.cs
@@ -250,12 +250,18 @@ public partial class TypeChecker
     /// <c>ReportUnknownTypeName</c> (so these names aren't flagged TS2304). Increment 1 covers the
     /// Symbol family; a later increment replaces this switch with content loaded from lib.d.ts.
     /// </summary>
-    private static TypeInfo? TryResolveLibType(string name) => name switch
+    private static TypeInfo? TryResolveLibType(string name)
     {
-        "SymbolConstructor" => WellKnownSymbolTypes.SymbolConstructor,
-        "Symbol" => WellKnownSymbolTypes.SymbolWrapper,
-        _ => null
-    };
+        // Names loaded from the embedded lib.d.ts (e.g. SymbolConstructor) — the real declarations.
+        if (LibTypeLoader.TryGet(name, out var libType)) return libType;
+        // Names still hand-modeled (the wrapper types need behavior the loaded shape can't yet give —
+        // a symbol must satisfy `Symbol` without SharpTS modeling the primitive's apparent members).
+        return name switch
+        {
+            "Symbol" => WellKnownSymbolTypes.SymbolWrapper,
+            _ => null
+        };
+    }
 
     /// <summary>
     /// Simplifies an intersection type according to TypeScript semantics:

--- a/TypeSystem/TypeChecker.Validation.cs
+++ b/TypeSystem/TypeChecker.Validation.cs
@@ -104,6 +104,38 @@ public partial class TypeChecker
     }
 
     /// <summary>
+    /// Re-checks that an un-annotated method implementing an interface member has a compatible
+    /// INFERRED return type (TS2416), reported at the method's own line. The normal implements
+    /// validation runs before the body pass, when an un-annotated return is still a <c>&lt;inferred&gt;</c>
+    /// placeholder (≈ any) that hides the mismatch; this runs after inference. Only un-annotated
+    /// implementations are considered, so annotated methods (already checked) aren't double-reported.
+    /// </summary>
+    private void RecheckImplementsInferredReturns(Stmt.Class classStmt, TypeInfo.Class classType, List<TypeInfo.Interface> interfaces)
+    {
+        foreach (var method in classStmt.Methods)
+        {
+            if (method.ReturnType != null || method.Body == null) continue;
+            string name = method.ComputedKey != null
+                ? (TryGetWellKnownSymbolMemberName(method.ComputedKey) ?? method.Name.Lexeme)
+                : method.Name.Lexeme;
+            if (FindMemberInClass(classType, name) is not TypeInfo.Function actualFunc) continue;
+            int line = method.ComputedKey != null ? (TryGetExprLine(method.ComputedKey) ?? method.Name.Line) : method.Name.Line;
+            foreach (var itf in interfaces)
+            {
+                if (itf.GetAllMembers().FirstOrDefault(m => m.Key == name).Value is TypeInfo.Function expectedFunc
+                    && !IsCompatible(expectedFunc.ReturnType, actualFunc.ReturnType))
+                {
+                    string display = name.StartsWith("@@") ? $"[Symbol.{name[2..]}]" : name;
+                    RecordTypeError(new TypeCheckException(
+                        $" Property '{display}' in type '{classStmt.Name.Lexeme}' is not assignable to the same property in base type '{itf.Name}'.",
+                        line: line, tsCode: "TS2416"));
+                    break;
+                }
+            }
+        }
+    }
+
+    /// <summary>
     /// The built-in iterable-protocol interfaces a class may legally list in its <c>implements</c>
     /// clause. These are NOT user-declared <c>interface</c>s (so they are absent from the type
     /// environment) but lib types resolved generically — a class satisfies them structurally via a

--- a/TypeSystem/TypeChecker.cs
+++ b/TypeSystem/TypeChecker.cs
@@ -1035,6 +1035,30 @@ public partial class TypeChecker
     /// Full validation happens later during CheckStmt.
     /// Note: Classes are NOT pre-registered to avoid breaking inheritance checking with MutableClass.
     /// </summary>
+    /// <summary>
+    /// #99: register a set of ambient lib declarations into this (throwaway) checker's environment and
+    /// return the resolved interfaces/type-aliases keyed by name. Diagnostics are suppressed — lib
+    /// sources are trusted. Used by <see cref="LibTypeLoader"/> to turn parsed <c>libdefs/*.d.ts</c>
+    /// into modeled <see cref="TypeInfo"/>. Interfaces reference each other through the environment
+    /// (pre-registered above), so no recursion back into the loader.
+    /// </summary>
+    internal System.Collections.Frozen.FrozenDictionary<string, TypeInfo> ExtractLibTypes(List<Stmt> statements)
+    {
+        _suppressDiagnostics++;
+        try
+        {
+            PreRegisterTypeDeclarations(statements);
+            var result = new Dictionary<string, TypeInfo>();
+            foreach (var stmt in statements)
+            {
+                if (stmt is Stmt.Interface itf && _environment.Get(itf.Name.Lexeme) is { } t)
+                    result[itf.Name.Lexeme] = t;
+            }
+            return result.ToFrozenDictionary();
+        }
+        finally { _suppressDiagnostics--; }
+    }
+
     private void PreRegisterTypeDeclarations(IEnumerable<Stmt> statements)
     {
         foreach (var stmt in statements)

--- a/TypeSystem/WellKnownSymbolTypes.cs
+++ b/TypeSystem/WellKnownSymbolTypes.cs
@@ -74,6 +74,19 @@ public static class WellKnownSymbolTypes
     /// CheckGet) before generic member lookup ever consults this type, so adding it here doesn't
     /// change those paths — only genuine "use Symbol as a plain value" sites.
     /// </summary>
+    /// <summary>
+    /// The global `Symbol` WRAPPER object type (lib's `interface Symbol`), as it appears in TYPE
+    /// position (`var s: Symbol`). Distinct from the `symbol` primitive: a `symbol` value IS
+    /// assignable to this wrapper (an object-like target — the wrapper is modeled member-less so a
+    /// symbol satisfies it without SharpTS having to model symbol's apparent toString/valueOf), but
+    /// the wrapper is NOT assignable back to the `symbol` primitive (TS2322 "'symbol' is a primitive,
+    /// but 'Symbol' is a wrapper object").
+    /// </summary>
+    public static readonly TypeInfo.Interface SymbolWrapper = new(
+        "Symbol",
+        FrozenDictionary<string, TypeInfo>.Empty,
+        FrozenSet<string>.Empty);
+
     public static readonly TypeInfo.Interface SymbolConstructor = new(
         "SymbolConstructor",
         new Dictionary<string, TypeInfo>

--- a/libdefs/lib.core.d.ts
+++ b/libdefs/lib.core.d.ts
@@ -3,6 +3,15 @@
 // A faithful (member types simplified to `symbol` for now) subset, expanded toward the real
 // external/typescript/src/lib/*.d.ts in later #99 increments.
 
+// The primitive WRAPPER object types, as they appear in `implements`/`extends` position
+// (`class C implements String`, `interface I extends String`). Modeled member-less for now — enough
+// to be a valid implements/extends target (a class/interface trivially satisfies an empty base);
+// a later increment fills their real methods once the string/number/boolean primitives model their
+// apparent members so the primitive can satisfy the wrapper.
+interface String { }
+interface Number { }
+interface Boolean { }
+
 interface SymbolConstructor {
     readonly iterator: symbol;
     readonly asyncIterator: symbol;

--- a/libdefs/lib.core.d.ts
+++ b/libdefs/lib.core.d.ts
@@ -1,0 +1,22 @@
+// Ambient lib type declarations loaded by LibTypeLoader (#99 increment 2). Embedded as a resource
+// so it is available at runtime — the full vendored TypeScript lib.d.ts is a dev-only submodule.
+// A faithful (member types simplified to `symbol` for now) subset, expanded toward the real
+// external/typescript/src/lib/*.d.ts in later #99 increments.
+
+interface SymbolConstructor {
+    readonly iterator: symbol;
+    readonly asyncIterator: symbol;
+    readonly hasInstance: symbol;
+    readonly isConcatSpreadable: symbol;
+    readonly match: symbol;
+    readonly matchAll: symbol;
+    readonly replace: symbol;
+    readonly search: symbol;
+    readonly species: symbol;
+    readonly split: symbol;
+    readonly toPrimitive: symbol;
+    readonly toStringTag: symbol;
+    readonly unscopables: symbol;
+    for(key: string): symbol;
+    keyFor(sym: symbol): string | undefined;
+}


### PR DESCRIPTION
**Stacked on #1262** (base is `worktree-epic-99`; will retarget to `main` once #1262 merges). Continues the TypeScript conformance work (epic #80 / #99), taking the 296-test subset baseline **250 → 256 Pass / 29 → 23 Fail**. Zero regressions at every step; full xUnit **15452/0** and conformance green on every commit.

### #99 — from deferred epic to a working lib loader
- **Increment 1 — lib-type seam.** A single `TryResolveLibType` consulted by both `ResolveTypeNameCore` (for the type) and `ReportUnknownTypeName` (so the name isn't flagged TS2304). Resolves `Symbol`/`SymbolConstructor` in type position. → flips symbolProperty55, symbolType15.
- **Increment 2a — the loader.** `LibTypeLoader` parses ambient lib declarations **embedded as `libdefs/*.d.ts` resources** (the vendored TypeScript lib is a dev-only submodule, absent at runtime) and resolves them to real `TypeInfo` via a throwaway checker's `ExtractLibTypes`. `SymbolConstructor` now comes from the loaded lib. Built once, cached.
- **Increment 2b — first loader flip.** `implements`/`extends` resolution consults the loaded (member-less) wrapper interfaces for `String`/`Number`/`Boolean`, so `class C implements String` / `interface I extends String` are valid targets. `var s: String` still resolves to the primitive — zero assignability change. → flips stringLiteralTypeIsSubtypeOfString.

### Checker features (found while working the Fail bucket)
- **TS2416** — `implements` now checks against *inferred* method return types (the validation ran before body inference, when un-annotated returns were `<inferred>`≈any). Narrow after-inference re-check of un-annotated methods, reported at the method line. → symbolProperty24.
- **TS2367** — `symbol == boolean/number/string/bigint` flagged as a no-overlap comparison, scoped to symbol-vs-concrete-primitive. → symbolType9.
- **TS2353** — excess-property checking now runs on fresh object-literal **call arguments** (both non-generic and generic paths, which previously skipped argument validation), attributed to the offending property's own line. → symbolProperty21.

Remaining Fail bucket is the hard core: globalThis/Intl ambient types, lib-version awareness (the 6 lib-drift tests), and the accessor getter-return-inference feature.