### PR TITLE
fix(build): resolve all compiler and analyzer warnings

### DIFF
--- a/Compilation/RuntimeEmitter.ChildProcessAsync.cs
+++ b/Compilation/RuntimeEmitter.ChildProcessAsync.cs
@@ -63,7 +63,6 @@ public partial class RuntimeEmitter
     private MethodBuilder _childAsyncUnref = null!;
     private MethodBuilder _childConfigureSpawn = null!;
     private MethodBuilder _childStdioMode = null!;
-    private MethodBuilder _childReadCapped = null!;
     private MethodBuilder _childSpawnError = null!;
     private MethodBuilder _childCtxRunSpawnError = null!;
 

--- a/Compilation/RuntimeEmitter.TSProcess.cs
+++ b/Compilation/RuntimeEmitter.TSProcess.cs
@@ -2154,14 +2154,18 @@ public partial class RuntimeEmitter
             il.Emit(OpCodes.Stloc, signalLocal);
 
             bool isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
-            (PosixSignal Signal, string Name)[] map =
-            [
+            var map = new List<(PosixSignal Signal, string Name)>
+            {
                 (PosixSignal.SIGINT, "SIGINT"),
                 (PosixSignal.SIGTERM, "SIGTERM"),
                 (PosixSignal.SIGHUP, "SIGHUP"),
                 (PosixSignal.SIGQUIT, isWindows ? "SIGBREAK" : "SIGQUIT"),
-                (PosixSignal.SIGWINCH, "SIGWINCH"),
-            ];
+            };
+            // SIGWINCH is [UnsupportedOSPlatform("windows")] and can never fire there,
+            // so it is baked out of the emitted dispatch map on Windows (same
+            // compile-time platform bake as SIGBREAK above).
+            if (!OperatingSystem.IsWindows())
+                map.Add((PosixSignal.SIGWINCH, "SIGWINCH"));
             var end = il.DefineLabel();
             foreach (var (signal, name) in map)
             {
@@ -2215,18 +2219,21 @@ public partial class RuntimeEmitter
             il.Emit(OpCodes.Ret);
             il.MarkLabel(notRegistered);
 
-            // map name → PosixSignal (compile-time platform bake for SIGBREAK)
-            bool isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+            // map name → PosixSignal (SIGBREAK rides the CTRL_BREAK-backed SIGQUIT)
             var signalLocal = il.DeclareLocal(_types.Int32);
-            (string Name, PosixSignal Signal)[] map =
-            [
+            var map = new List<(string Name, PosixSignal Signal)>
+            {
                 ("SIGINT", PosixSignal.SIGINT),
                 ("SIGTERM", PosixSignal.SIGTERM),
                 ("SIGHUP", PosixSignal.SIGHUP),
                 ("SIGQUIT", PosixSignal.SIGQUIT),
-                ("SIGBREAK", isWindows ? PosixSignal.SIGQUIT : PosixSignal.SIGQUIT),
-                ("SIGWINCH", PosixSignal.SIGWINCH),
-            ];
+                ("SIGBREAK", PosixSignal.SIGQUIT),
+            };
+            // SIGWINCH is [UnsupportedOSPlatform("windows")]: registering it there
+            // would just throw (swallowed below), so bake it out of the emitted map
+            // on Windows — process.on('SIGWINCH') stays the same silent no-op.
+            if (!OperatingSystem.IsWindows())
+                map.Add(("SIGWINCH", PosixSignal.SIGWINCH));
             var haveSignal = il.DefineLabel();
             foreach (var (name, signal) in map)
             {

--- a/Compilation/RuntimeEmitter.WebCrypto.Types.cs
+++ b/Compilation/RuntimeEmitter.WebCrypto.Types.cs
@@ -41,7 +41,7 @@ public partial class RuntimeEmitter
         EmitWebCryptoType(moduleBuilder, runtime);
 
         // crypto.getRandomValues(x) / named import — uniform module wrapper on $Runtime.
-        var wrapper = _runtimeTypeBuilder.DefineMethod(
+        var wrapper = _runtimeTypeBuilder!.DefineMethod(
             "CryptoWrapper_getRandomValues",
             MethodAttributes.Public | MethodAttributes.Static,
             _types.Object,

--- a/Execution/Interpreter.cs
+++ b/Execution/Interpreter.cs
@@ -185,9 +185,10 @@ public partial class Interpreter : IDisposable
 
     // Active handles counter - keeps the event loop alive while there are active operations.
     // Uses Interlocked operations for thread-safe lock-free access, consistent with _hasScheduledTimers.
-    // Synchronization strategy: all counters/flags use lock-free atomic operations for reads/writes,
+    // Synchronization strategy: all counters/flags use lock-free atomic operations for reads/writes
+    // (Interlocked/Volatile, so the field itself is deliberately not `volatile`),
     // while the timer queue itself uses _virtualTimersLock for compound operations.
-    private volatile int _activeHandles;
+    private int _activeHandles;
 
     // Event loop infrastructure - BlockingCollection for efficient waiting (no polling)
     // SynchronizationContext routes async/await continuations back to the main thread
@@ -571,9 +572,9 @@ public partial class Interpreter : IDisposable
 
     /// <summary>
     /// Gets whether there are active handles keeping the event loop alive.
-    /// Thread-safe - reads volatile int which is atomic on all .NET platforms.
+    /// Thread-safe - volatile read of an int, which is atomic on all .NET platforms.
     /// </summary>
-    internal bool HasActiveHandles => _activeHandles > 0;
+    internal bool HasActiveHandles => Volatile.Read(ref _activeHandles) > 0;
 
     /// <summary>
     /// Non-blocking event loop tick: drains pending microtasks, due timers, and queued callbacks.

--- a/Runtime/BuiltIns/Modules/Interpreter/DnsModuleInterpreter.cs
+++ b/Runtime/BuiltIns/Modules/Interpreter/DnsModuleInterpreter.cs
@@ -568,7 +568,7 @@ public static class DnsModuleInterpreter
     /// List&lt;object?&gt; of strings → SharpTSArray,
     /// Dictionary → SharpTSObject.
     /// </summary>
-    private static object WrapDnsResult(object raw)
+    private static object? WrapDnsResult(object? raw)
     {
         if (raw is Dictionary<string, object?> dict)
             return new SharpTSObject(dict);

--- a/SharpTS.Tests/Infrastructure/FakeDnsServer.cs
+++ b/SharpTS.Tests/Infrastructure/FakeDnsServer.cs
@@ -51,9 +51,11 @@ public sealed class FakeDnsServer : IDisposable
 
         Port = ((IPEndPoint)_udp.Client.LocalEndPoint!).Port;
         Address = $"127.0.0.1:{Port}";
-        Task.Run(ServeUdp);
+        // Fire-and-forget serve loops: they run until Dispose closes the sockets,
+        // and terminal exceptions are handled inside the loops themselves.
+        _ = Task.Run(ServeUdpAsync);
         if (_tcp is not null)
-            Task.Run(ServeTcp);
+            _ = Task.Run(ServeTcpAsync);
     }
 
     /// <summary>Server address in "127.0.0.1:port" form.</summary>
@@ -90,7 +92,7 @@ public sealed class FakeDnsServer : IDisposable
         }
     }
 
-    private async Task ServeUdp()
+    private async Task ServeUdpAsync()
     {
         try
         {
@@ -109,7 +111,7 @@ public sealed class FakeDnsServer : IDisposable
         catch (SocketException) { }
     }
 
-    private async Task ServeTcp()
+    private async Task ServeTcpAsync()
     {
         try
         {

--- a/SharpTS.Tests/SharedTests/TlsModuleTests.cs
+++ b/SharpTS.Tests/SharedTests/TlsModuleTests.cs
@@ -269,7 +269,11 @@ public class TlsModuleTests
         var files = new Dictionary<string, string> { ["./main.ts"] = source };
         string? output = null;
         var task = Task.Run(() => output = TestHarness.RunModules(files, "./main.ts", ExecutionMode.Interpreted));
-        if (!await task.WaitAsync(TimeSpan.FromSeconds(15)).ContinueWith(t => t.IsCompletedSuccessfully))
+        try
+        {
+            await task.WaitAsync(TimeSpan.FromSeconds(15));
+        }
+        catch (TimeoutException)
         {
             Assert.Fail("TLS handshake test timed out");
         }
@@ -320,8 +324,14 @@ public class TlsModuleTests
         var files = new Dictionary<string, string> { ["./main.ts"] = source };
         string? output = null;
         var task = Task.Run(() => output = TestHarness.RunModules(files, "./main.ts", ExecutionMode.Interpreted));
-        var completed = await task.WaitAsync(TimeSpan.FromSeconds(15)).ContinueWith(t => t.IsCompletedSuccessfully);
-        Assert.True(completed, $"TLS reject test timed out. Partial output: [{output ?? "null"}]");
+        try
+        {
+            await task.WaitAsync(TimeSpan.FromSeconds(15));
+        }
+        catch (TimeoutException)
+        {
+            Assert.Fail($"TLS reject test timed out. Partial output: [{output ?? "null"}]");
+        }
         Assert.Contains("error caught", output!);
     }
 

--- a/SharpTS.Tests/SharpTS.Tests.csproj
+++ b/SharpTS.Tests/SharpTS.Tests.csproj
@@ -10,6 +10,13 @@
          scales much better. -->
     <ServerGarbageCollection>true</ServerGarbageCollection>
     <ConcurrentGarbageCollection>true</ConcurrentGarbageCollection>
+    <!-- VSTHRD002 (don't sync-block on tasks) flows in transitively from the
+         LanguageServer's OmniSharp dependency (vs-threading analyzers). The test
+         harness deliberately runs interpreter/compiler work on a threadpool task
+         and blocks with a hard timeout so hung guest code fails the test instead
+         of hanging the run; xUnit workers have no blocking SynchronizationContext,
+         so the deadlock this rule guards against cannot occur here. -->
+    <NoWarn>$(NoWarn);VSTHRD002</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/TypeSystem/TypeChecker.Statements.cs
+++ b/TypeSystem/TypeChecker.Statements.cs
@@ -1272,7 +1272,7 @@ public partial class TypeChecker
             if (binding.TypeAnnotation != null)
             {
                 declaredType = ResolveAnnotation(binding.TypeAnnotation, binding.TypeAnnotationNode);
-                if (!IsCompatible(declaredType, initType))
+                if (declaredType != null && !IsCompatible(declaredType, initType))
                 {
                     throw new TypeMismatchException(declaredType, initType, binding.Name!.Line, tsCode: "TS2322");
                 }


### PR DESCRIPTION
## Summary

Clears all 47 build-warning sites so the solution builds with **0 warnings, 0 errors**: 8 compiler-warning sites in the main project and ~39 vs-threading analyzer sites in the test project (the VSTHRD analyzers reach `SharpTS.Tests` transitively through the LanguageServer''s OmniSharp dependency).

## Main project

- **CS0420** (`Execution/Interpreter.cs`): `_activeHandles` was `volatile` but accessed via `Interlocked`/`Volatile.Read(ref ...)`, which bypasses volatile semantics. Dropped the modifier and made the one remaining direct read (`HasActiveHandles`) an explicit `Volatile.Read`, so every access is uniformly atomic.
- **CS8622** (`DnsModuleInterpreter.cs`): widened `WrapDnsResult` to `object? -> object?` to match the `Func<object?, object?>` delegate it is passed as; the body already passes unrecognized values through unchanged.
- **CS8604** (`TypeChecker.Statements.cs`): `ResolveAnnotation` returns `TypeInfo?`; the `using`-declaration check now only runs the compatibility test when a declared type actually resolved (null already fell back to the initializer type).
- **CS8602** (`RuntimeEmitter.WebCrypto.Types.cs`): use the established `_runtimeTypeBuilder!` idiom of the other post-phase-1 emit sites.
- **CS0414** (`RuntimeEmitter.ChildProcessAsync.cs`): deleted the dead `_childReadCapped` field — its only reference was its own initializer (the live helper is `_childReadCappedBytes`).
- **CA1416 ×2** (`RuntimeEmitter.TSProcess.cs`): `PosixSignal.SIGWINCH` is `[UnsupportedOSPlatform("windows")]`. Both emitted signal maps now add the SIGWINCH entry behind an `OperatingSystem.IsWindows()` guard, consistent with the emitter''s existing compile-time platform bake for SIGBREAK. Windows behavior is unchanged: SIGWINCH could never fire or register there (registration threw and was swallowed by the emitted try/catch; `process.on(''SIGWINCH'')` stays a silent no-op). Also removed a dead ternary that mapped SIGBREAK to `SIGQUIT` in both arms.

## Test project

- **VSTHRD110/VSTHRD200** (`FakeDnsServer.cs`): intentional fire-and-forget serve loops are now explicit `_ = Task.Run(...)` discards with a comment; methods renamed `ServeUdpAsync`/`ServeTcpAsync`.
- **VSTHRD105** (`TlsModuleTests.cs`): replaced the two `WaitAsync(...).ContinueWith(t => t.IsCompletedSuccessfully)` timeout checks with `try { await task.WaitAsync(...) } catch (TimeoutException) { Assert.Fail(...) }` — besides the scheduler warning, the old pattern reported any task fault as a "timeout"; real failures now propagate with their original exception.
- **VSTHRD002 (36 sites)**: disabled for `SharpTS.Tests` with a documented justification in the csproj. Every site is the harness''s deliberate design — run interpreter/compiler work on a threadpool task and sync-block with a hard timeout so hung guest code fails the test instead of hanging the run. xUnit workers carry no blocking `SynchronizationContext`, so the deadlock this rule targets cannot occur, and converting the sync harness used by hundreds of sync tests to async would be a large refactor with no safety gain.

## Caveat

Like the existing SIGBREAK handling, the SIGWINCH map is baked at compile time: a DLL compiled on Windows will not dispatch SIGWINCH if run on Linux. That tradeoff already existed for SIGBREAK; no tests rely on SIGWINCH.

## Verification

- `dotnet build`: **0 warnings, 0 errors** across all projects.
- `dotnet test` filtered to the touched areas (DNS, TLS, signals, `using` declarations, web streams, unhandled rejections): **381 passed, 0 failed**.