### PR TITLE
fix(interp): collapse drifted boxed EvaluateGetOnRecord onto the RV implementation

### DIFF
--- a/Execution/Interpreter.Properties.cs
+++ b/Execution/Interpreter.Properties.cs
@@ -1049,84 +1049,21 @@ public partial class Interpreter
     };
 
     /// <summary>
-    /// Evaluates property access on a record/object literal, walking the __proto__
-    /// chain when the property is not an own property. JS spec: property access
-    /// traverses the prototype chain until a match or null is reached.
+    /// Boxed adapter over <see cref="EvaluateGetOnRecordRV"/> — the single implementation of
+    /// record property reads. (A previous hand-maintained boxed copy had drifted: it stopped the
+    /// __proto__ walk at a <see cref="SharpTSInstance"/> prototype, so field reads through
+    /// `Object.create(new Point())`-style chains resolved to undefined for boxed callers.)
     /// </summary>
-    private object? EvaluateGetOnRecord(SharpTSObject simpleObj, string memberName)
-    {
-        // Check for getter first on the own object
-        var getter = simpleObj.GetGetter(memberName);
-        if (getter != null)
-        {
-            // Invoke the getter with 'this' bound to the object
-            var boundGetter = BindAccessorToObject(getter, simpleObj);
-            return boundGetter.Call(this, []);
-        }
-
-        // Own property
-        if (simpleObj.HasProperty(memberName))
-        {
-            var value = simpleObj.GetProperty(memberName);
-            // Bind 'this' for function expressions and object method shorthand (HasOwnThis=true),
-            // including generator / async-generator methods (#775).
-            if (TryBindReceiverForMethodAccess(value, simpleObj) is { } boundMethod)
-                return boundMethod;
-            return value;
-        }
-
-        // Walk __proto__ chain — JS constructor-function pattern relies on this so methods
-        // assigned via `Foo.prototype.x = ...` are reachable on `new Foo()` instances.
-        // Lodash's MapCache (lodash.js ~2177) does `this.clear()` in its ctor where `clear`
-        // lives on `MapCache.prototype`; without this walk it resolves to undefined.
-        object? current = simpleObj.HasProperty("__proto__") ? simpleObj.GetProperty("__proto__") : null;
-        for (int i = 0; i < 64 && current is SharpTSObject proto; i++)
-        {
-            var protoGetter = proto.GetGetter(memberName);
-            if (protoGetter != null)
-            {
-                var boundProtoGetter = BindAccessorToObject(protoGetter, simpleObj);
-                return boundProtoGetter.Call(this, []);
-            }
-            if (proto.HasProperty(memberName))
-            {
-                var value = proto.GetProperty(memberName);
-                if (TryBindReceiverForMethodAccess(value, simpleObj) is { } boundMethod)
-                    return boundMethod;
-                return value;
-            }
-            object? next = proto.HasProperty("__proto__") ? proto.GetProperty("__proto__") : null;
-            if (ReferenceEquals(next, proto)) break; // cycle guard
-            current = next;
-        }
-
-        // Boxed primitive method dispatch: `(new Number(5)).toFixed(2)` etc.
-        // Delegate through to the underlying primitive value's built-in methods.
-        if (simpleObj.HasProperty("__primitiveType")
-            && simpleObj.GetProperty("__primitiveType") is string _
-            && simpleObj.HasProperty("__primitiveValue"))
-        {
-            var pv = simpleObj.GetProperty("__primitiveValue");
-            if (pv != null)
-            {
-                var dispatched = BuiltInRegistry.Instance.GetInstanceMember(pv, memberName);
-                if (dispatched != null) return dispatched;
-            }
-        }
-
-        // Final fallback: inherited Object.prototype methods (see the RV
-        // overload for rationale). Excluded for null-prototype objects.
-        if (!simpleObj.IsNullPrototype
-            && SharpTSObjectPrototype.Instance.GetMember(memberName) is SharpTSObjectUnboundMethod protoMethod)
-            return protoMethod.BindTo(simpleObj);
-
-        return SharpTSUndefined.Instance;
-    }
+    private object? EvaluateGetOnRecord(SharpTSObject simpleObj, string memberName) =>
+        EvaluateGetOnRecordRV(simpleObj, memberName).ToObject();
 
     /// <summary>
-    /// Evaluates property access on a record/object literal, returning RuntimeValue directly.
-    /// Walks __proto__ on miss so constructor-function prototype methods are reachable
-    /// (see <see cref="EvaluateGetOnRecord"/> for full rationale).
+    /// Evaluates property access on a record/object literal, walking the __proto__ chain when the
+    /// property is not an own property (JS spec: property access traverses the prototype chain
+    /// until a match or null). The constructor-function pattern relies on this so methods assigned
+    /// via `Foo.prototype.x = ...` are reachable on `new Foo()` instances — Lodash's MapCache
+    /// (lodash.js ~2177) does `this.clear()` in its ctor where `clear` lives on
+    /// `MapCache.prototype`; without the walk it resolves to undefined.
     /// </summary>
     private RuntimeValue EvaluateGetOnRecordRV(SharpTSObject simpleObj, string memberName)
     {


### PR DESCRIPTION
One of the fix-first duplication findings from the 2026-07-01 audit (re-verified today): `EvaluateGetOnRecord` (boxed) and `EvaluateGetOnRecordRV` were a ~68-line near-duplicate that had **already drifted** — the boxed `__proto__` walk stopped at a `SharpTSInstance` prototype and dispatched getters via legacy `.Call`, while the RV loop handles the instance arm and uses `CallV2`.

## Observable bug fixed
Boxed callers are the named-CJS-import interop reads (`Interpreter.cs` import/re-export paths) and the for-of iterator-protocol `done`/`value` reads. With a CJS module whose exports object is `Object.create(new Point())`:

```ts
// point.cjs: class Point { constructor() { this.x = 42; } }
//            module.exports = Object.create(new Point());
import { x } from "./point.cjs";
console.log(x); // main: undefined  →  this PR: 42
```

## Change
The boxed method is now a one-line `.ToObject()` adapter over `EvaluateGetOnRecordRV` (−65 lines; `RuntimeValue.ToObject` maps `Undefined` back to the `SharpTSUndefined.Instance` sentinel, so miss behavior is identical). Rationale docs moved onto the RV method, which is now the single implementation.

## Verification
- Live before/after repro above (pre-fix binaries print `undefined`, post-fix `42`), plus a for-of protocol sanity check
- Full unit suite: **15,452/15,452 pass**
- **Test262 interpreter baseline diff clean** (subset incl. `built-ins/Object`, property-accessors — no regressions, no unexpected new-passes)
- TS-conformance unaffected (type-checker only; this is a runtime change)