### PR TITLE
refactor: six duplication consolidations from the hygiene backlog

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -489,6 +489,20 @@ static void CompileModuleFile(string absolutePath, string outputPath, bool prese
     DeadCodeInfo deadCodeInfo = deadCodeAnalyzer.Analyze(allStatements);
 
     // Compilation
+    EmitCompiledAssembly(outputPath, preserveConstEnums, useReferenceAssemblies, sdkPath, verifyIL, decoratorMode, outputOptions, metadata, references, target, bundlerMode, externalRefs,
+        compiler => compiler.CompileModules(allModules, resolver, typeMap, deadCodeInfo));
+}
+
+/// <summary>
+/// Shared EXE/DLL emission tail for both compile drivers. Constructs the ILCompiler, runs the
+/// supplied compile step, then saves, verifies (--verify), bundles into a single-file EXE (Exe
+/// target) or writes the runtimeconfig (DLL target), and co-locates SharpTS.dll / external
+/// references when the compilation soft-depends on them. <paramref name="compileBody"/> receives
+/// the configured compiler and performs the one step that differs between the drivers
+/// (whole-module-graph vs single-file compile).
+/// </summary>
+static void EmitCompiledAssembly(string outputPath, bool preserveConstEnums, bool useReferenceAssemblies, string? sdkPath, bool verifyIL, DecoratorMode decoratorMode, OutputOptions outputOptions, AssemblyMetadata? metadata, IReadOnlyList<string> references, OutputTarget target, BundlerMode bundlerMode, ReferenceSet externalRefs, Action<ILCompiler> compileBody)
+{
     string assemblyName = Path.GetFileNameWithoutExtension(outputPath);
 
     if (target == OutputTarget.Exe)
@@ -500,7 +514,7 @@ static void CompileModuleFile(string absolutePath, string outputPath, bool prese
             // Compile to DLL format (will be bundled into EXE)
             ILCompiler compiler = new(assemblyName, preserveConstEnums, useReferenceAssemblies, sdkPath, metadata, references, OutputTarget.Dll);
             compiler.SetDecoratorMode(decoratorMode);
-            compiler.CompileModules(allModules, resolver, typeMap, deadCodeInfo);
+            compileBody(compiler);
             compiler.Save(tempDllPath);
 
             // Run IL verification on the DLL if requested
@@ -544,7 +558,7 @@ static void CompileModuleFile(string absolutePath, string outputPath, bool prese
         // Standard DLL output
         ILCompiler compiler = new(assemblyName, preserveConstEnums, useReferenceAssemblies, sdkPath, metadata, references, target);
         compiler.SetDecoratorMode(decoratorMode);
-        compiler.CompileModules(allModules, resolver, typeMap, deadCodeInfo);
+        compileBody(compiler);
         compiler.Save(outputPath);
 
         GenerateRuntimeConfig(outputPath);
@@ -598,78 +612,8 @@ static void CompileSingleFile(List<Stmt> statements, string outputPath, bool pre
     DeadCodeInfo deadCodeInfo = deadCodeAnalyzer.Analyze(statements);
 
     // Compilation Phase
-    string assemblyName = Path.GetFileNameWithoutExtension(outputPath);
-
-    if (target == OutputTarget.Exe)
-    {
-        // For EXE output, first compile to a temp DLL, then bundle into single-file EXE
-        var tempDllPath = Path.Combine(Path.GetTempPath(), $"{assemblyName}_{Guid.NewGuid():N}.dll");
-        try
-        {
-            // Compile to DLL format (will be bundled into EXE)
-            ILCompiler compiler = new(assemblyName, preserveConstEnums, useReferenceAssemblies, sdkPath, metadata, references, OutputTarget.Dll);
-            compiler.SetDecoratorMode(decoratorMode);
-            compiler.Compile(statements, typeMap, deadCodeInfo);
-            compiler.Save(tempDllPath);
-
-            // Run IL verification on the DLL if requested
-            if (verifyIL)
-            {
-                VerifyCompiledAssembly(tempDllPath, sdkPath, externalRefs);
-            }
-
-            // Bundle into single-file EXE
-            try
-            {
-                var bundleResult = AppHostGenerator.CreateSingleFileExecutable(tempDllPath, outputPath, assemblyName, bundlerMode);
-
-                if (!outputOptions.QuietMode)
-                {
-                    Console.WriteLine($"Compiled to {outputPath} (using {bundleResult.TechniqueDescription})");
-                }
-
-                // Co-locate SharpTS.dll next to the EXE when the program uses a feature that
-                // late-binds into the SharpTS runtime (eval, Proxy, Intl, vm, dns, @DotNetType
-                // dynamic events). Honors --standalone. Pure programs stay a single file.
-                CopySharpTSRuntimeIfNeeded(compiler, outputPath, outputOptions);
-                CopyExternalReferencesIfNeeded(compiler, externalRefs, outputPath, outputOptions);
-            }
-            catch (Exception ex) when (bundlerMode != BundlerMode.Auto)
-            {
-                var bundlerName = bundlerMode == BundlerMode.Sdk ? "SDK" : "built-in";
-                Console.WriteLine($"Error: {bundlerName} bundler failed: {ex.Message}");
-                Console.WriteLine($"The {bundlerName} bundler was explicitly requested. Use '--bundler auto' to allow fallback.");
-                Environment.Exit(1);
-            }
-        }
-        finally
-        {
-            // Clean up temp DLL
-            try { File.Delete(tempDllPath); } catch { }
-        }
-    }
-    else
-    {
-        // Standard DLL output
-        ILCompiler compiler = new(assemblyName, preserveConstEnums, useReferenceAssemblies, sdkPath, metadata, references, target);
-        compiler.SetDecoratorMode(decoratorMode);
-        compiler.Compile(statements, typeMap, deadCodeInfo);
-        compiler.Save(outputPath);
-
-        GenerateRuntimeConfig(outputPath);
-        CopySharpTSRuntimeIfNeeded(compiler, outputPath, outputOptions);
-        CopyExternalReferencesIfNeeded(compiler, externalRefs, outputPath, outputOptions);
-        if (!outputOptions.QuietMode)
-        {
-            Console.WriteLine($"Compiled to {outputPath}");
-        }
-
-        // Run IL verification if requested
-        if (verifyIL)
-        {
-            VerifyCompiledAssembly(outputPath, sdkPath, externalRefs);
-        }
-    }
+    EmitCompiledAssembly(outputPath, preserveConstEnums, useReferenceAssemblies, sdkPath, verifyIL, decoratorMode, outputOptions, metadata, references, target, bundlerMode, externalRefs,
+        compiler => compiler.Compile(statements, typeMap, deadCodeInfo));
 }
 
 /// <summary>

--- a/Runtime/BuiltIns/JSONBuiltIns.cs
+++ b/Runtime/BuiltIns/JSONBuiltIns.cs
@@ -414,93 +414,43 @@ public static class JSONBuiltIns
         }
     }
 
-    /// <summary>
-    /// Serializes a plain <see cref="IReadOnlyDictionary{TKey, TValue}"/> as a
-    /// JSON object. Identical body to <see cref="StringifyObject"/> but for
-    /// the dict shape; kept as a sibling helper rather than a refactor to
-    /// minimize churn on the SharpTSObject path that the rest of the
-    /// interpreter relies on.
-    /// </summary>
     private static void StringifyDictionary(Interpreter interp, IReadOnlyDictionary<string, object?> dict,
-        ISharpTSCallable? replacer, HashSet<string>? allowedKeys, string indentStr, int depth, StringBuilder sb, HashSet<object> seen)
-    {
-        if (!seen.Add(dict))
-            throw new ThrowException("TypeError: Converting circular structure to JSON");
-        try
-        {
-            IEnumerable<KeyValuePair<string, object?>> fields = dict;
-            if (allowedKeys != null)
-            {
-                fields = fields.Where(kv => allowedKeys.Contains(kv.Key));
-            }
-
-            var fieldList = fields.ToList();
-            if (fieldList.Count == 0)
-            {
-                sb.Append("{}");
-                return;
-            }
-
-            sb.Append('{');
-
-            bool pretty = indentStr.Length > 0;
-            string stepIndent = pretty ? "\n" + GetIndent(indentStr, depth + 1) : "";
-
-            if (pretty) sb.Append(stepIndent);
-
-            bool first = true;
-            foreach (var kv in fieldList)
-            {
-                int mark = sb.Length;
-
-                if (!first)
-                {
-                    sb.Append(',');
-                    if (pretty) sb.Append(stepIndent);
-                }
-
-                sb.Append(JsonSerializer.Serialize(kv.Key));
-                sb.Append(':');
-                if (pretty) sb.Append(' ');
-
-                if (StringifyValue(interp, kv.Value, kv.Key, replacer, allowedKeys, indentStr, depth + 1, sb, seen))
-                {
-                    first = false;
-                }
-                else
-                {
-                    sb.Length = mark;
-                }
-            }
-
-            if (pretty)
-            {
-                sb.Append('\n');
-                sb.Append(GetIndent(indentStr, depth));
-            }
-            sb.Append('}');
-        }
-        finally
-        {
-            seen.Remove(dict);
-        }
-    }
+        ISharpTSCallable? replacer, HashSet<string>? allowedKeys, string indentStr, int depth, StringBuilder sb, HashSet<object> seen) =>
+        StringifyJsonObject(interp, dict, dict.Keys, k => dict[k], replacer, allowedKeys, indentStr, depth, sb, seen);
 
     private static void StringifyObject(Interpreter interp, SharpTSObject obj,
-        ISharpTSCallable? replacer, HashSet<string>? allowedKeys, string indentStr, int depth, StringBuilder sb, HashSet<object> seen)
+        ISharpTSCallable? replacer, HashSet<string>? allowedKeys, string indentStr, int depth, StringBuilder sb, HashSet<object> seen) =>
+        StringifyJsonObject(interp, obj, obj.Fields.Keys, k => obj.Fields[k], replacer, allowedKeys, indentStr, depth, sb, seen);
+
+    private static void StringifyInstance(Interpreter interp, SharpTSInstance inst,
+        ISharpTSCallable? replacer, HashSet<string>? allowedKeys, string indentStr, int depth, StringBuilder sb, HashSet<object> seen) =>
+        StringifyJsonObject(interp, inst, inst.GetFieldNames(), inst.GetRawField, replacer, allowedKeys, indentStr, depth, sb, seen);
+
+    /// <summary>
+    /// Shared JSON-object serializer for the three object shapes (plain dictionary,
+    /// SharpTSObject, class instance), which previously carried three copy-pasted bodies:
+    /// circular guard keyed on the node's identity, empty-<c>{}</c> shortcut, pretty-print step
+    /// indent, and the per-entry mark/serialize/rewind-on-undefined dance. Keys are snapshot up
+    /// front and values read lazily per entry via <paramref name="read"/> — matching the spec's
+    /// OwnPropertyKeys-then-Get order — so the allowedKeys filter never allocates a filtered
+    /// dictionary.
+    /// </summary>
+    private static void StringifyJsonObject(Interpreter interp, object node,
+        IEnumerable<string> keys, Func<string, object?> read,
+        ISharpTSCallable? replacer, HashSet<string>? allowedKeys, string indentStr, int depth,
+        StringBuilder sb, HashSet<object> seen)
     {
-        if (!seen.Add(obj))
+        if (!seen.Add(node))
             throw new ThrowException("TypeError: Converting circular structure to JSON");
         try
         {
-            var fields = obj.Fields;
             if (allowedKeys != null)
             {
-                fields = fields.Where(kv => allowedKeys.Contains(kv.Key))
-                    .ToDictionary(kv => kv.Key, kv => kv.Value);
+                keys = keys.Where(allowedKeys.Contains);
             }
 
-            if (fields.Count == 0)
+            var keyList = keys.ToList();
+            if (keyList.Count == 0)
             {
                 sb.Append("{}");
                 return;
@@ -514,7 +464,7 @@ public static class JSONBuiltIns
             if (pretty) sb.Append(stepIndent);
 
             bool first = true;
-            foreach (var kv in fields)
+            foreach (var key in keyList)
             {
                 int mark = sb.Length;
 
@@ -524,11 +474,11 @@ public static class JSONBuiltIns
                     if (pretty) sb.Append(stepIndent);
                 }
 
-                sb.Append(JsonSerializer.Serialize(kv.Key));
+                sb.Append(JsonSerializer.Serialize(key));
                 sb.Append(':');
                 if (pretty) sb.Append(' ');
 
-                if (StringifyValue(interp, kv.Value, kv.Key, replacer, allowedKeys, indentStr, depth + 1, sb, seen))
+                if (StringifyValue(interp, read(key), key, replacer, allowedKeys, indentStr, depth + 1, sb, seen))
                 {
                     first = false;
                 }
@@ -549,73 +499,7 @@ public static class JSONBuiltIns
         }
         finally
         {
-            seen.Remove(obj);
-        }
-    }
-
-    private static void StringifyInstance(Interpreter interp, SharpTSInstance inst,
-        ISharpTSCallable? replacer, HashSet<string>? allowedKeys, string indentStr, int depth, StringBuilder sb, HashSet<object> seen)
-    {
-        if (!seen.Add(inst))
-            throw new ThrowException("TypeError: Converting circular structure to JSON");
-        try
-        {
-            IEnumerable<string> fieldNames = inst.GetFieldNames();
-            if (allowedKeys != null)
-            {
-                fieldNames = fieldNames.Where(k => allowedKeys.Contains(k));
-            }
-
-            var namesList = fieldNames.ToList();
-            if (namesList.Count == 0)
-            {
-                sb.Append("{}");
-                return;
-            }
-
-            sb.Append('{');
-
-            bool pretty = indentStr.Length > 0;
-            string stepIndent = pretty ? "\n" + GetIndent(indentStr, depth + 1) : "";
-
-            if (pretty) sb.Append(stepIndent);
-
-            bool first = true;
-            foreach (var name in namesList)
-            {
-                int mark = sb.Length;
-
-                if (!first)
-                {
-                    sb.Append(',');
-                    if (pretty) sb.Append(stepIndent);
-                }
-
-                sb.Append(JsonSerializer.Serialize(name));
-                sb.Append(':');
-                if (pretty) sb.Append(' ');
-
-                var fieldValue = inst.GetRawField(name);
-                if (StringifyValue(interp, fieldValue, name, replacer, allowedKeys, indentStr, depth + 1, sb, seen))
-                {
-                    first = false;
-                }
-                else
-                {
-                    sb.Length = mark;
-                }
-            }
-
-            if (pretty)
-            {
-                sb.Append('\n');
-                sb.Append(GetIndent(indentStr, depth));
-            }
-            sb.Append('}');
-        }
-        finally
-        {
-            seen.Remove(inst);
+            seen.Remove(node);
         }
     }
 

--- a/Runtime/BuiltIns/Modules/Interpreter/CryptoModuleInterpreter.cs
+++ b/Runtime/BuiltIns/Modules/Interpreter/CryptoModuleInterpreter.cs
@@ -300,18 +300,59 @@ public static class CryptoModuleInterpreter
         if (keylen < 0)
             throw new Exception("crypto.pbkdf2Sync keylen must be non-negative");
 
-        var hashAlgorithm = digest.ToLowerInvariant() switch
+        var hashAlgorithm = ParseKdfDigest(digest, "crypto.pbkdf2Sync");
+
+        var derivedKey = Rfc2898DeriveBytes.Pbkdf2(password, salt, iterations, hashAlgorithm, keylen);
+        return RuntimeValue.FromObject(new SharpTSBuffer(derivedKey));
+    }
+
+    /// <summary>
+    /// Parses the SHA-family digest name accepted by the key-derivation APIs (pbkdf2/hkdf).
+    /// Deliberately narrower than <see cref="CryptoAlgorithms.ParseHashName"/>: the .NET KDF
+    /// primitives used here take only the SHA family (no MD5/SHA-3). <paramref name="apiName"/>
+    /// qualifies the sync APIs' error message; the async paths pass null (their message is
+    /// wrapped by CreateCryptoError with the syscall name).
+    /// </summary>
+    private static HashAlgorithmName ParseKdfDigest(string digest, string? apiName = null) =>
+        digest.ToLowerInvariant() switch
         {
             "sha1" => HashAlgorithmName.SHA1,
             "sha256" => HashAlgorithmName.SHA256,
             "sha384" => HashAlgorithmName.SHA384,
             "sha512" => HashAlgorithmName.SHA512,
-            // Note: MD5 is not supported for PBKDF2 in .NET - use SHA family instead
-            _ => throw new Exception($"crypto.pbkdf2Sync: unsupported digest algorithm '{digest}'. Supported: sha1, sha256, sha384, sha512")
+            _ => throw new Exception(apiName != null
+                ? $"{apiName}: unsupported digest algorithm '{digest}'. Supported: sha1, sha256, sha384, sha512"
+                : $"unsupported digest algorithm '{digest}'")
         };
 
-        var derivedKey = Rfc2898DeriveBytes.Pbkdf2(password, salt, iterations, hashAlgorithm, keylen);
-        return RuntimeValue.FromObject(new SharpTSBuffer(derivedKey));
+    /// <summary>
+    /// Parses the Node scrypt options object (N/cost, r/blockSize, p/parallelization) with
+    /// Node's defaults and validates that N is a power of 2. <paramref name="errorPrefix"/>
+    /// qualifies the sync API's message; the async path passes the default (its message is
+    /// wrapped by CreateCryptoError).
+    /// </summary>
+    private static (int N, int r, int p) ParseScryptOptions(SharpTSObject? options, string errorPrefix = "")
+    {
+        // Default scrypt parameters (Node.js defaults)
+        int N = 16384;  // cost parameter (must be power of 2)
+        int r = 8;      // block size
+        int p = 1;      // parallelization
+
+        if (options != null)
+        {
+            var fields = options.Fields;
+            if (fields.TryGetValue("N", out var costObj) && costObj is double costVal) N = (int)costVal;
+            if (fields.TryGetValue("cost", out var cost2Obj) && cost2Obj is double cost2Val) N = (int)cost2Val;
+            if (fields.TryGetValue("r", out var rObj) && rObj is double rVal) r = (int)rVal;
+            if (fields.TryGetValue("blockSize", out var bsObj) && bsObj is double bsVal) r = (int)bsVal;
+            if (fields.TryGetValue("p", out var pObj) && pObj is double pVal) p = (int)pVal;
+            if (fields.TryGetValue("parallelization", out var parObj) && parObj is double parVal) p = (int)parVal;
+        }
+
+        if (N < 2 || (N & (N - 1)) != 0)
+            throw new Exception($"{errorPrefix}N must be a power of 2 greater than 1");
+
+        return (N, r, p);
     }
 
     private static RuntimeValue ScryptSync(Interp interpreter, RuntimeValue receiver, ReadOnlySpan<RuntimeValue> args)
@@ -327,32 +368,9 @@ public static class CryptoModuleInterpreter
         if (keylen < 0)
             throw new Exception("crypto.scryptSync keylen must be non-negative");
 
-        // Default scrypt parameters (Node.js defaults)
-        int N = 16384;  // cost parameter (must be power of 2)
-        int r = 8;      // block size
-        int p = 1;      // parallelization
-
-        // Parse options if provided
-        if (args.Length > 3 && args[3].ToObject() is SharpTSObject options)
-        {
-            var fields = options.Fields;
-            if (fields.TryGetValue("N", out var costObj) && costObj is double costVal)
-                N = (int)costVal;
-            if (fields.TryGetValue("cost", out var cost2Obj) && cost2Obj is double cost2Val)
-                N = (int)cost2Val;
-            if (fields.TryGetValue("r", out var rObj) && rObj is double rVal)
-                r = (int)rVal;
-            if (fields.TryGetValue("blockSize", out var bsObj) && bsObj is double bsVal)
-                r = (int)bsVal;
-            if (fields.TryGetValue("p", out var pObj) && pObj is double pVal)
-                p = (int)pVal;
-            if (fields.TryGetValue("parallelization", out var parObj) && parObj is double parVal)
-                p = (int)parVal;
-        }
-
-        // Validate N is a power of 2
-        if (N < 2 || (N & (N - 1)) != 0)
-            throw new Exception("crypto.scryptSync: N must be a power of 2 greater than 1");
+        var (N, r, p) = ParseScryptOptions(
+            args.Length > 3 && args[3].ToObject() is SharpTSObject options ? options : null,
+            "crypto.scryptSync: ");
 
         // Use shared scrypt implementation
         var derivedKey = SharpTS.Compilation.ScryptImpl.DeriveBytes(password, salt, N, r, p, keylen);
@@ -602,14 +620,7 @@ public static class CryptoModuleInterpreter
         if (keylen == 0)
             return RuntimeValue.FromObject(new SharpTSBuffer([]));
 
-        var hashAlgorithm = digest.ToLowerInvariant() switch
-        {
-            "sha1" => HashAlgorithmName.SHA1,
-            "sha256" => HashAlgorithmName.SHA256,
-            "sha384" => HashAlgorithmName.SHA384,
-            "sha512" => HashAlgorithmName.SHA512,
-            _ => throw new Exception($"crypto.hkdfSync: unsupported digest algorithm '{digest}'. Supported: sha1, sha256, sha384, sha512")
-        };
+        var hashAlgorithm = ParseKdfDigest(digest, "crypto.hkdfSync");
 
         var derivedKey = HKDF.DeriveKey(hashAlgorithm, ikm, keylen, salt, info);
         return RuntimeValue.FromObject(new SharpTSBuffer(derivedKey));
@@ -796,14 +807,7 @@ public static class CryptoModuleInterpreter
                 if (digest == null) throw new Exception("digest must be a string");
                 if (iterations < 1) throw new Exception("iterations must be at least 1");
 
-                var hashAlgorithm = digest.ToLowerInvariant() switch
-                {
-                    "sha1" => HashAlgorithmName.SHA1,
-                    "sha256" => HashAlgorithmName.SHA256,
-                    "sha384" => HashAlgorithmName.SHA384,
-                    "sha512" => HashAlgorithmName.SHA512,
-                    _ => throw new Exception($"unsupported digest algorithm '{digest}'")
-                };
+                var hashAlgorithm = ParseKdfDigest(digest);
 
                 var derivedKey = Rfc2898DeriveBytes.Pbkdf2(password, salt, iterations, hashAlgorithm, keylen);
                 ScheduleCallbackAndUnref(interpreter, callback, null, new SharpTSBuffer(derivedKey));
@@ -840,20 +844,7 @@ public static class CryptoModuleInterpreter
                 if (password == null) throw new Exception("password is required");
                 if (salt == null) throw new Exception("salt is required");
 
-                int N = 16384, r = 8, p = 1;
-                if (options != null)
-                {
-                    var fields = options.Fields;
-                    if (fields.TryGetValue("N", out var costObj) && costObj is double costVal) N = (int)costVal;
-                    if (fields.TryGetValue("cost", out var cost2Obj) && cost2Obj is double cost2Val) N = (int)cost2Val;
-                    if (fields.TryGetValue("r", out var rObj) && rObj is double rVal) r = (int)rVal;
-                    if (fields.TryGetValue("blockSize", out var bsObj) && bsObj is double bsVal) r = (int)bsVal;
-                    if (fields.TryGetValue("p", out var pObj) && pObj is double pVal) p = (int)pVal;
-                    if (fields.TryGetValue("parallelization", out var parObj) && parObj is double parVal) p = (int)parVal;
-                }
-
-                if (N < 2 || (N & (N - 1)) != 0)
-                    throw new Exception("N must be a power of 2 greater than 1");
+                var (N, r, p) = ParseScryptOptions(options);
 
                 var derivedKey = SharpTS.Compilation.ScryptImpl.DeriveBytes(password, salt, N, r, p, keylen);
                 ScheduleCallbackAndUnref(interpreter, callback, null, new SharpTSBuffer(derivedKey));
@@ -934,14 +925,7 @@ public static class CryptoModuleInterpreter
                     return;
                 }
 
-                var hashAlgorithm = digest.ToLowerInvariant() switch
-                {
-                    "sha1" => HashAlgorithmName.SHA1,
-                    "sha256" => HashAlgorithmName.SHA256,
-                    "sha384" => HashAlgorithmName.SHA384,
-                    "sha512" => HashAlgorithmName.SHA512,
-                    _ => throw new Exception($"unsupported digest algorithm '{digest}'")
-                };
+                var hashAlgorithm = ParseKdfDigest(digest);
 
                 var derivedKey = HKDF.DeriveKey(hashAlgorithm, ikm, keylen, salt, info);
                 ScheduleCallbackAndUnref(interpreter, callback, null, new SharpTSBuffer(derivedKey));

--- a/Runtime/BuiltIns/ObjectBuiltIns.cs
+++ b/Runtime/BuiltIns/ObjectBuiltIns.cs
@@ -40,153 +40,84 @@ public static partial class ObjectBuiltIns
     public static object? GetStaticMethod(string name)
         => _staticLookup.GetMember(name);
 
+    /// <summary>
+    /// Enumerates the own enumerable (key, value) pairs of a receiver, encoding the
+    /// Object.keys/values/entries receiver-type ladder once. Branch order and per-branch
+    /// semantics are load-bearing:
+    /// - SharpTSObject: own enumerable fields.
+    /// - SharpTSArray: ECMA-262 — only present (non-hole) indices are own enumerable
+    ///   properties, so holes are skipped; keys are the stringified indices.
+    /// - SharpTSInstance: declared fields.
+    /// - IDictionary&lt;string, object?&gt;: runtime helpers (e.g. Web Streams iterator results)
+    ///   produce JS-object-shaped data without going through SharpTSObject; compiled mode has
+    ///   the matching dict branch in $Runtime.GetKeys, this keeps the interpreter at parity.
+    /// - SharpTSMath: built-in members are non-enumerable, so the own enumerable keys are
+    ///   exactly the user-assigned extras. Matches compiled mode (#288).
+    /// - Function/arrow function: functions are objects (ToObject is the identity), and their
+    ///   own enumerable keys are the user-assigned expando properties — lodash mixes its
+    ///   utility map onto the `lodash` function and enumerates it via keys() (#314); other
+    ///   callables have none.
+    /// Throws for non-object receivers; <paramref name="apiName"/> qualifies the message.
+    /// </summary>
+    private static IEnumerable<KeyValuePair<string, object?>> EnumerateOwnEnumerable(object? arg, string apiName)
+    {
+        switch (arg)
+        {
+            case SharpTSObject obj:
+                foreach (var k in obj.OwnEnumerableKeys())
+                    yield return new(k, obj.Fields[k]);
+                yield break;
+            case SharpTSArray arr:
+                for (int i = 0; i < arr.Length; i++)
+                    if (arr.HasIndex(i))
+                        yield return new(i.ToString(), arr[i]);
+                yield break;
+            case SharpTSInstance inst:
+                foreach (var n in inst.GetFieldNames())
+                    yield return new(n, inst.GetRawField(n));
+                yield break;
+            case IDictionary<string, object?> dict:
+                foreach (var kv in dict)
+                    yield return kv;
+                yield break;
+            case SharpTSMath math:
+                foreach (var kv in math.OwnEnumerableProperties)
+                    yield return new(kv.Key, kv.Value);
+                yield break;
+            case SharpTSFunction fn:
+                foreach (var k in fn.PropertyKeys)
+                    yield return new(k, fn.TryGetProperty(k, out var v) ? v : null);
+                yield break;
+            case SharpTSArrowFunction arrowFn:
+                foreach (var k in arrowFn.PropertyKeys)
+                    yield return new(k, arrowFn.TryGetProperty(k, out var av) ? av : null);
+                yield break;
+            case ISharpTSCallable:
+                yield break;
+            default:
+                throw new Exception($"{apiName} requires an object argument");
+        }
+    }
+
     private static RuntimeValue KeysV2(Interpreter _, RuntimeValue receiver, ReadOnlySpan<RuntimeValue> args)
     {
-        var arg = args[0].ToObject();
-        if (arg is SharpTSObject obj)
-        {
-            var keys = obj.OwnEnumerableKeys().Select(k => (object?)k).ToList();
-            return RuntimeValue.FromObject(new SharpTSArray(keys));
-        }
-        if (arg is SharpTSArray arr)
-        {
-            // ECMA-262: only present (non-hole) indices are own enumerable
-            // properties, so Object.keys skips holes.
-            var keys = new List<object?>();
-            for (int i = 0; i < arr.Length; i++)
-                if (arr.HasIndex(i)) keys.Add(i.ToString());
-            return RuntimeValue.FromObject(new SharpTSArray(keys));
-        }
-        if (arg is SharpTSInstance inst)
-        {
-            var keys = inst.GetFieldNames().Select(k => (object?)k).ToList();
-            return RuntimeValue.FromObject(new SharpTSArray(keys));
-        }
-        // Plain Dictionary<string, object?> — used by runtime helpers (e.g.,
-        // Web Streams iterator results) that produce JS-object-shaped data
-        // without going through SharpTSObject. Compiled mode already has the
-        // matching dict branch in $Runtime.GetKeys; this branch keeps the
-        // interpreter at parity.
-        if (arg is IDictionary<string, object?> dict)
-        {
-            var keys = dict.Keys.Select(k => (object?)k).ToList();
-            return RuntimeValue.FromObject(new SharpTSArray(keys));
-        }
-        // Math singleton: built-in members are non-enumerable, so the own
-        // enumerable keys are exactly the user-assigned extras (empty unless the
-        // program assigned to Math). Matches compiled mode (#288).
-        if (arg is SharpTSMath math)
-        {
-            var keys = math.OwnEnumerableProperties.Select(kv => (object?)kv.Key).ToList();
-            return RuntimeValue.FromObject(new SharpTSArray(keys));
-        }
-        // Functions are objects (ECMA-262 ToObject is the identity for them):
-        // own enumerable keys are the user-assigned expando properties. lodash
-        // mixes its utility map onto the `lodash` function and enumerates it
-        // via keys() — the correct "[object Function]" tag (#314) routes
-        // functions through baseKeys → Object.keys instead of arrayLikeKeys,
-        // so throwing here broke lodash init.
-        if (arg is SharpTSFunction fn)
-            return RuntimeValue.FromObject(new SharpTSArray(fn.PropertyKeys.Select(k => (object?)k).ToList()));
-        if (arg is SharpTSArrowFunction arrowFn)
-            return RuntimeValue.FromObject(new SharpTSArray(arrowFn.PropertyKeys.Select(k => (object?)k).ToList()));
-        if (arg is ISharpTSCallable)
-            return RuntimeValue.FromObject(new SharpTSArray([]));
-        throw new Exception("Object.keys() requires an object argument");
+        var keys = EnumerateOwnEnumerable(args[0].ToObject(), "Object.keys()")
+            .Select(kv => (object?)kv.Key).ToList();
+        return RuntimeValue.FromObject(new SharpTSArray(keys));
     }
 
     private static RuntimeValue ValuesV2(Interpreter _, RuntimeValue receiver, ReadOnlySpan<RuntimeValue> args)
     {
-        var arg = args[0].ToObject();
-        if (arg is SharpTSObject obj)
-        {
-            var values = obj.OwnEnumerableKeys().Select(k => obj.Fields[k]).ToList();
-            return RuntimeValue.FromObject(new SharpTSArray(values));
-        }
-        if (arg is SharpTSArray arr)
-        {
-            var values = new List<object?>();
-            for (int i = 0; i < arr.Length; i++)
-                if (arr.HasIndex(i)) values.Add(arr[i]);
-            return RuntimeValue.FromObject(new SharpTSArray(values));
-        }
-        if (arg is SharpTSInstance inst)
-        {
-            var values = inst.GetFieldNames().Select(n => inst.GetRawField(n)).ToList();
-            return RuntimeValue.FromObject(new SharpTSArray(values));
-        }
-        if (arg is IDictionary<string, object?> dict)
-        {
-            return RuntimeValue.FromObject(new SharpTSArray(dict.Values.ToList()));
-        }
-        // Math singleton — see Object.keys (#288).
-        if (arg is SharpTSMath math)
-        {
-            var values = math.OwnEnumerableProperties.Select(kv => kv.Value).ToList();
-            return RuntimeValue.FromObject(new SharpTSArray(values));
-        }
-        // Functions are objects — see Object.keys.
-        if (arg is SharpTSFunction fn)
-            return RuntimeValue.FromObject(new SharpTSArray(
-                fn.PropertyKeys.Select(k => fn.TryGetProperty(k, out var v) ? v : null).ToList()));
-        if (arg is SharpTSArrowFunction arrowFn)
-            return RuntimeValue.FromObject(new SharpTSArray(
-                arrowFn.PropertyKeys.Select(k => arrowFn.TryGetProperty(k, out var v) ? v : null).ToList()));
-        if (arg is ISharpTSCallable)
-            return RuntimeValue.FromObject(new SharpTSArray([]));
-        throw new Exception("Object.values() requires an object argument");
+        var values = EnumerateOwnEnumerable(args[0].ToObject(), "Object.values()")
+            .Select(kv => kv.Value).ToList();
+        return RuntimeValue.FromObject(new SharpTSArray(values));
     }
 
     private static RuntimeValue EntriesV2(Interpreter _, RuntimeValue receiver, ReadOnlySpan<RuntimeValue> args)
     {
-        var arg = args[0].ToObject();
-        if (arg is SharpTSObject obj)
-        {
-            var entries = obj.OwnEnumerableKeys().Select(k =>
-                (object?)new SharpTSArray([(object?)k, obj.Fields[k]])).ToList();
-            return RuntimeValue.FromObject(new SharpTSArray(entries));
-        }
-        if (arg is SharpTSArray arr)
-        {
-            var entries = new List<object?>();
-            for (int i = 0; i < arr.Length; i++)
-            {
-                if (!arr.HasIndex(i)) continue;
-                entries.Add(new SharpTSArray([(object?)i.ToString(), arr[i]]));
-            }
-            return RuntimeValue.FromObject(new SharpTSArray(entries));
-        }
-        if (arg is SharpTSInstance inst)
-        {
-            var entries = inst.GetFieldNames().Select(n =>
-                (object?)new SharpTSArray([(object?)n, inst.GetRawField(n)])).ToList();
-            return RuntimeValue.FromObject(new SharpTSArray(entries));
-        }
-        if (arg is IDictionary<string, object?> dict)
-        {
-            var entries = dict.Select(kv =>
-                (object?)new SharpTSArray([(object?)kv.Key, kv.Value])).ToList();
-            return RuntimeValue.FromObject(new SharpTSArray(entries));
-        }
-        // Math singleton — see Object.keys (#288).
-        if (arg is SharpTSMath math)
-        {
-            var entries = math.OwnEnumerableProperties.Select(kv =>
-                (object?)new SharpTSArray([(object?)kv.Key, kv.Value])).ToList();
-            return RuntimeValue.FromObject(new SharpTSArray(entries));
-        }
-        // Functions are objects — see Object.keys.
-        if (arg is SharpTSFunction fn)
-            return RuntimeValue.FromObject(new SharpTSArray(
-                fn.PropertyKeys.Select(k =>
-                    (object?)new SharpTSArray([(object?)k, fn.TryGetProperty(k, out var v) ? v : null])).ToList()));
-        if (arg is SharpTSArrowFunction arrowFn)
-            return RuntimeValue.FromObject(new SharpTSArray(
-                arrowFn.PropertyKeys.Select(k =>
-                    (object?)new SharpTSArray([(object?)k, arrowFn.TryGetProperty(k, out var v) ? v : null])).ToList()));
-        if (arg is ISharpTSCallable)
-            return RuntimeValue.FromObject(new SharpTSArray([]));
-        throw new Exception("Object.entries() requires an object argument");
+        var entries = EnumerateOwnEnumerable(args[0].ToObject(), "Object.entries()")
+            .Select(kv => (object?)new SharpTSArray([(object?)kv.Key, kv.Value])).ToList();
+        return RuntimeValue.FromObject(new SharpTSArray(entries));
     }
 
     private static object? FromEntries(Interpreter interpreter, List<object?> args)

--- a/Runtime/Types/SharpTSPropertyDescriptor.cs
+++ b/Runtime/Types/SharpTSPropertyDescriptor.cs
@@ -105,55 +105,63 @@ public class SharpTSPropertyDescriptor
     /// <summary>
     /// Creates a PropertyDescriptor from a SharpTS object returned by a decorator.
     /// </summary>
-    public static SharpTSPropertyDescriptor FromObject(SharpTSObject obj)
+    /// <remarks>
+    /// Own-only fast path. Presence is detected via HasProperty/HasSetter (the latter only for
+    /// the value/get/set arms) so an explicit <c>value: undefined</c> (or a setter-only
+    /// <c>value</c> accessor) is recorded as specified rather than dropped, distinguishing
+    /// "omitted" from "undefined" (#801). The interpreter-aware pass in ObjectBuiltIns
+    /// re-derives these prototype-aware (walking the chain + ToBoolean) and overrides as needed.
+    /// </remarks>
+    public static SharpTSPropertyDescriptor FromObject(SharpTSObject obj) =>
+        Populate(
+            n => obj.HasProperty(n) || (n is "value" or "get" or "set" && obj.HasSetter(n)),
+            obj.GetProperty);
+
+    /// <summary>
+    /// Runs the six-field descriptor extraction (value/get/set/writable/enumerable/configurable)
+    /// over an abstract (<paramref name="has"/>, <paramref name="read"/>) view of the source —
+    /// each From* variant supplies only its own presence-probe/read pair. Presence flags are
+    /// tracked separately from the values so "omitted" stays distinct from "explicitly
+    /// undefined" (#801).
+    /// </summary>
+    private static SharpTSPropertyDescriptor Populate(Func<string, bool> has, Func<string, object?> read)
     {
         var descriptor = new SharpTSPropertyDescriptor();
 
-        // Own-only fast path. Presence is detected via HasProperty/HasSetter so an
-        // explicit `value: undefined` (or a setter-only `value` accessor) is recorded
-        // as specified rather than dropped, distinguishing "omitted" from "undefined"
-        // (#801). The interpreter-aware pass in ObjectBuiltIns re-derives these
-        // prototype-aware (walking the chain + ToBoolean) and overrides as needed.
-        if (obj.HasProperty("value") || obj.HasSetter("value"))
+        if (has("value"))
         {
-            descriptor.Value = obj.GetProperty("value");
+            descriptor.Value = read("value");
             descriptor.HasValue = true;
         }
 
-        if (obj.HasProperty("get") || obj.HasSetter("get"))
+        if (has("get"))
         {
             descriptor.HasGet = true;
-            if (obj.GetProperty("get") is ISharpTSCallable getterFn)
-            {
-                descriptor.Get = getterFn;
-            }
+            if (read("get") is ISharpTSCallable getterFn) descriptor.Get = getterFn;
         }
 
-        if (obj.HasProperty("set") || obj.HasSetter("set"))
+        if (has("set"))
         {
             descriptor.HasSet = true;
-            if (obj.GetProperty("set") is ISharpTSCallable setterFn)
-            {
-                descriptor.Set = setterFn;
-            }
+            if (read("set") is ISharpTSCallable setterFn) descriptor.Set = setterFn;
         }
 
-        if (obj.HasProperty("writable"))
+        if (has("writable"))
         {
             descriptor.HasWritable = true;
-            if (obj.GetProperty("writable") is bool w) descriptor.Writable = w;
+            if (read("writable") is bool w) descriptor.Writable = w;
         }
 
-        if (obj.HasProperty("enumerable"))
+        if (has("enumerable"))
         {
             descriptor.HasEnumerable = true;
-            if (obj.GetProperty("enumerable") is bool e) descriptor.Enumerable = e;
+            if (read("enumerable") is bool e) descriptor.Enumerable = e;
         }
 
-        if (obj.HasProperty("configurable"))
+        if (has("configurable"))
         {
             descriptor.HasConfigurable = true;
-            if (obj.GetProperty("configurable") is bool c) descriptor.Configurable = c;
+            if (read("configurable") is bool c) descriptor.Configurable = c;
         }
 
         return descriptor;
@@ -183,154 +191,37 @@ public class SharpTSPropertyDescriptor
         }
 
         // For compiled $Object type, use reflection to get properties
-        var descriptor = new SharpTSPropertyDescriptor();
         var type = obj.GetType();
 
         // Try to get the GetProperty method
         var getPropertyMethod = type.GetMethod("GetProperty", System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance, null, [typeof(string)], null);
-
-        if (getPropertyMethod != null)
+        if (getPropertyMethod == null)
         {
-            object? GetProp(string name) => getPropertyMethod.Invoke(obj, [name]);
-
-            // Probe presence via HasProperty(string) when the type exposes it, so an
-            // explicit `value: undefined` is distinguished from an omitted value (#801).
-            var hasPropertyMethod = type.GetMethod("HasProperty",
-                System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance,
-                null, [typeof(string)], null);
-            bool HasProp(string name) => hasPropertyMethod?.Invoke(obj, [name]) is bool b && b;
-
-            if (HasProp("value"))
-            {
-                descriptor.Value = GetProp("value");
-                descriptor.HasValue = true;
-            }
-
-            if (HasProp("get"))
-            {
-                descriptor.HasGet = true;
-                if (GetProp("get") is ISharpTSCallable getterFn) descriptor.Get = getterFn;
-            }
-
-            if (HasProp("set"))
-            {
-                descriptor.HasSet = true;
-                if (GetProp("set") is ISharpTSCallable setterFn) descriptor.Set = setterFn;
-            }
-
-            if (HasProp("writable"))
-            {
-                descriptor.HasWritable = true;
-                if (GetProp("writable") is bool w) descriptor.Writable = w;
-            }
-
-            if (HasProp("enumerable"))
-            {
-                descriptor.HasEnumerable = true;
-                if (GetProp("enumerable") is bool e) descriptor.Enumerable = e;
-            }
-
-            if (HasProp("configurable"))
-            {
-                descriptor.HasConfigurable = true;
-                if (GetProp("configurable") is bool c) descriptor.Configurable = c;
-            }
+            return new SharpTSPropertyDescriptor();
         }
 
-        return descriptor;
+        // Probe presence via HasProperty(string) when the type exposes it, so an
+        // explicit `value: undefined` is distinguished from an omitted value (#801).
+        var hasPropertyMethod = type.GetMethod("HasProperty",
+            System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance,
+            null, [typeof(string)], null);
+
+        return Populate(
+            name => hasPropertyMethod?.Invoke(obj, [name]) is bool b && b,
+            name => getPropertyMethod.Invoke(obj, [name]));
     }
 
     /// <summary>
     /// Creates a PropertyDescriptor from a Dictionary.
     /// </summary>
-    private static SharpTSPropertyDescriptor FromDictionary(Dictionary<string, object?> dict)
-    {
-        var descriptor = new SharpTSPropertyDescriptor();
-
-        if (dict.TryGetValue("value", out var value))
-        {
-            descriptor.Value = value;
-            descriptor.HasValue = true;
-        }
-
-        if (dict.TryGetValue("get", out var getter))
-        {
-            descriptor.HasGet = true;
-            if (getter is ISharpTSCallable getterFn) descriptor.Get = getterFn;
-        }
-
-        if (dict.TryGetValue("set", out var setter))
-        {
-            descriptor.HasSet = true;
-            if (setter is ISharpTSCallable setterFn) descriptor.Set = setterFn;
-        }
-
-        if (dict.TryGetValue("writable", out var writable))
-        {
-            descriptor.HasWritable = true;
-            if (writable is bool w) descriptor.Writable = w;
-        }
-
-        if (dict.TryGetValue("enumerable", out var enumerable))
-        {
-            descriptor.HasEnumerable = true;
-            if (enumerable is bool e) descriptor.Enumerable = e;
-        }
-
-        if (dict.TryGetValue("configurable", out var configurable))
-        {
-            descriptor.HasConfigurable = true;
-            if (configurable is bool c) descriptor.Configurable = c;
-        }
-
-        return descriptor;
-    }
+    private static SharpTSPropertyDescriptor FromDictionary(Dictionary<string, object?> dict) =>
+        Populate(dict.ContainsKey, k => dict[k]);
 
     /// <summary>
     /// Creates a PropertyDescriptor from an IDictionary.
     /// </summary>
-    private static SharpTSPropertyDescriptor FromIDictionary(System.Collections.IDictionary dict)
-    {
-        var descriptor = new SharpTSPropertyDescriptor();
-
-        if (dict.Contains("value"))
-        {
-            descriptor.Value = dict["value"];
-            descriptor.HasValue = true;
-        }
-
-        if (dict.Contains("get"))
-        {
-            descriptor.HasGet = true;
-            if (dict["get"] is ISharpTSCallable getterFn) descriptor.Get = getterFn;
-        }
-
-        if (dict.Contains("set"))
-        {
-            descriptor.HasSet = true;
-            if (dict["set"] is ISharpTSCallable setterFn) descriptor.Set = setterFn;
-        }
-
-        if (dict.Contains("writable"))
-        {
-            descriptor.HasWritable = true;
-            if (dict["writable"] is bool w) descriptor.Writable = w;
-        }
-
-        if (dict.Contains("enumerable"))
-        {
-            descriptor.HasEnumerable = true;
-            if (dict["enumerable"] is bool e) descriptor.Enumerable = e;
-        }
-
-        if (dict.Contains("configurable"))
-        {
-            descriptor.HasConfigurable = true;
-            if (dict["configurable"] is bool c) descriptor.Configurable = c;
-        }
-
-        return descriptor;
-    }
+    private static SharpTSPropertyDescriptor FromIDictionary(System.Collections.IDictionary dict) =>
+        Populate(dict.Contains, k => dict[k]);
 
     /// <summary>
     /// Creates a descriptor for a method.

--- a/Runtime/Types/SharpTSTypedArray.cs
+++ b/Runtime/Types/SharpTSTypedArray.cs
@@ -175,6 +175,15 @@ public abstract class SharpTSTypedArray : ITypeCategorized
     /// </summary>
     protected abstract SharpTSTypedArray CreateView(byte[] buffer, int byteOffset, int length);
 
+    // Internal bridges so same-assembly callers (StructuredClone) can construct a view of the
+    // SAME concrete element type as an existing instance without maintaining a parallel
+    // typeName→constructor switch — the subclass set stays the single source of that mapping.
+    internal SharpTSTypedArray CreateViewFrom(SharpTSSharedArrayBuffer buffer, int byteOffset, int length) =>
+        CreateView(buffer, byteOffset, length);
+
+    internal SharpTSTypedArray CreateViewFrom(byte[] buffer, int byteOffset, int length) =>
+        CreateView(buffer, byteOffset, length);
+
     /// <summary>
     /// Resolves JS slice/subarray bounds (negative-from-end, clamped to [0, length])
     /// to a concrete (start, count) pair.

--- a/Runtime/Types/StructuredClone.cs
+++ b/Runtime/Types/StructuredClone.cs
@@ -251,58 +251,23 @@ public static class StructuredClone
 
         if (source.IsShared)
         {
-            // For SharedArrayBuffer-backed views, create new view over same buffer
+            // For SharedArrayBuffer-backed views, create new view over same buffer.
+            // source's own CreateViewFrom picks the concrete element type — the subclass set is
+            // the single source of the typeName→constructor mapping (a new element type can no
+            // longer silently miss the clone path).
             var sharedBuffer = source.SharedBuffer!;
-            result = CreateTypedArrayView(source.TypeName, sharedBuffer, source.ByteOffset, source.Length);
+            result = source.CreateViewFrom(sharedBuffer, source.ByteOffset, source.Length);
         }
         else
         {
             // For regular buffer, copy the data
             var newBuffer = new byte[source.ByteLength];
             Array.Copy(source.Buffer, source.ByteOffset, newBuffer, 0, source.ByteLength);
-            result = CreateTypedArrayFromBuffer(source.TypeName, newBuffer, source.Length);
+            result = source.CreateViewFrom(newBuffer, 0, source.Length);
         }
 
         cloned[source] = result;
         return result;
-    }
-
-    private static SharpTSTypedArray CreateTypedArrayView(string typeName, SharpTSSharedArrayBuffer buffer, int byteOffset, int length)
-    {
-        return typeName switch
-        {
-            "Int8Array" => new SharpTSInt8Array(buffer, byteOffset, length),
-            "Uint8Array" => new SharpTSUint8Array(buffer, byteOffset, length),
-            "Uint8ClampedArray" => new SharpTSUint8ClampedArray(buffer, byteOffset, length),
-            "Int16Array" => new SharpTSInt16Array(buffer, byteOffset, length),
-            "Uint16Array" => new SharpTSUint16Array(buffer, byteOffset, length),
-            "Int32Array" => new SharpTSInt32Array(buffer, byteOffset, length),
-            "Uint32Array" => new SharpTSUint32Array(buffer, byteOffset, length),
-            "Float32Array" => new SharpTSFloat32Array(buffer, byteOffset, length),
-            "Float64Array" => new SharpTSFloat64Array(buffer, byteOffset, length),
-            "BigInt64Array" => new SharpTSBigInt64Array(buffer, byteOffset, length),
-            "BigUint64Array" => new SharpTSBigUint64Array(buffer, byteOffset, length),
-            _ => throw new DataCloneError($"Unknown TypedArray type: {typeName}")
-        };
-    }
-
-    private static SharpTSTypedArray CreateTypedArrayFromBuffer(string typeName, byte[] buffer, int length)
-    {
-        return typeName switch
-        {
-            "Int8Array" => new SharpTSInt8Array(buffer, 0, length),
-            "Uint8Array" => new SharpTSUint8Array(buffer, 0, length),
-            "Uint8ClampedArray" => new SharpTSUint8ClampedArray(buffer, 0, length),
-            "Int16Array" => new SharpTSInt16Array(buffer, 0, length),
-            "Uint16Array" => new SharpTSUint16Array(buffer, 0, length),
-            "Int32Array" => new SharpTSInt32Array(buffer, 0, length),
-            "Uint32Array" => new SharpTSUint32Array(buffer, 0, length),
-            "Float32Array" => new SharpTSFloat32Array(buffer, 0, length),
-            "Float64Array" => new SharpTSFloat64Array(buffer, 0, length),
-            "BigInt64Array" => new SharpTSBigInt64Array(buffer, 0, length),
-            "BigUint64Array" => new SharpTSBigUint64Array(buffer, 0, length),
-            _ => throw new DataCloneError($"Unknown TypedArray type: {typeName}")
-        };
     }
 
     private static SharpTSMessagePort TransferMessagePort(SharpTSMessagePort port)


### PR DESCRIPTION
Continues the audit backlog after #1266/#1267. Six independent consolidations, one commit each, all behavior-preserving:

## Runtime
- **Object.keys/values/entries**: the three built-ins each hand-rolled the same ordered 8-branch receiver ladder (object, hole-skipping array, instance, plain dict, Math #288, function/arrow expandos #314, other callables, throw). One `EnumerateOwnEnumerable` iterator now encodes it; each built-in is a 3-line projection. The array hole-skip loop exists once.
- **JSON.stringify**: `StringifyDictionary`/`StringifyObject`/`StringifyInstance` were ~65-line copies (the code commented on its own duplication). One `StringifyJsonObject(keys, read)` core keeps the circular guard / `{}` shortcut / pretty indent / rewind-on-undefined dance; keys snapshot + lazy `Get` matches the spec's OwnPropertyKeys-then-Get order and drops the filtered-Dictionary allocation.
- **SharpTSPropertyDescriptor**: the 6-field extraction existed 4× with probe drift; one `Populate(has, read)` core, with FromObject keeping its HasProperty-OR-HasSetter probe (#801 omitted-vs-explicitly-undefined).
- **StructuredClone**: the two 11-arm typeName→constructor switches are gone — cloning delegates to the source instance's own `CreateView` factories via internal bridges, so the typed-array subclass set is the single source of that mapping.
- **crypto**: the SHA-family KDF digest switch (4×) and the scrypt N/r/p options parse (2×) are single-sourced (`ParseKdfDigest` is deliberately narrower than `CryptoAlgorithms.ParseHashName` — the .NET KDF primitives take only the SHA family); per-API error prefixes preserved.

## CLI
- **Program.cs**: `CompileModuleFile`/`CompileSingleFile` duplicated the ~70-line EXE/DLL emission tail verbatim (temp-DLL, Save, --verify, AppHost bundling + explicit-bundler error handler, runtimeconfig, SharpTS.dll co-location). Both now route through `EmitCompiledAssembly` with the one differing compile step as a delegate. Smoke-verified end-to-end: `--compile` to DLL runs under dotnet; `--compile --target exe` bundles (built-in bundler) and the EXE runs.

## Verification
- Full unit suite: **15,452/15,452 pass**
- **Test262 interpreter baseline diff clean** (subset includes `built-ins/JSON` and `built-ins/Object`, directly covering the two riskiest items)
- Per-item targeted slices ran green before each commit: crypto 447, clone/typed-array/worker 268, Object/lodash 191, JSON 193, descriptor/decorator 171