### PR TITLE
refactor: three more backlog consolidations (streams, ++/-- arms, CallV2 routing)

### DIFF
--- a/Compilation/ILEmitter.Operators.cs
+++ b/Compilation/ILEmitter.Operators.cs
@@ -1288,74 +1288,124 @@ public partial class ILEmitter
                 return;
 
             // Prefix increment on property: ++obj.prop
-            // Get current value
-            EmitExpression(get.Object);
-            EmitBoxIfNeeded(get.Object);
-            IL.Emit(OpCodes.Ldstr, get.Name.Lexeme);
-            IL.Emit(OpCodes.Call, _ctx.Runtime!.GetProperty);
-            EmitUnboxToDouble();
-
-            // Increment or decrement
-            IL.Emit(OpCodes.Ldc_R8, 1.0);
-            if (pi.Operator.Type == TokenType.PLUS_PLUS)
-                IL.Emit(OpCodes.Add);
-            else
-                IL.Emit(OpCodes.Sub);
-
-            // Box new value and store in temp
-            IL.Emit(OpCodes.Box, _ctx.Types.Double);
-            var newValue = IL.DeclareLocal(_ctx.Types.Object);
-            IL.Emit(OpCodes.Stloc, newValue);
-
-            // SetProperty(obj, name, newValue)
-            EmitExpression(get.Object);
-            EmitBoxIfNeeded(get.Object);
-            IL.Emit(OpCodes.Ldstr, get.Name.Lexeme);
-            IL.Emit(OpCodes.Ldloc, newValue);
-            IL.Emit(OpCodes.Call, _ctx.Runtime!.SetProperty);
-
-            // Return new value (prefix behavior)
-            IL.Emit(OpCodes.Ldloc, newValue);
-            SetStackUnknown();
+            EmitIncrementProperty(get, pi.Operator.Type == TokenType.PLUS_PLUS, isPrefix: true);
             return;
         }
 
         if (pi.Operand is Expr.GetIndex gi)
         {
             // Prefix increment on array index: ++arr[i]
-            // Get current value
-            EmitExpression(gi.Object);
-            EmitBoxIfNeeded(gi.Object);
-            EmitExpression(gi.Index);
-            EmitBoxIfNeeded(gi.Index);
-            IL.Emit(OpCodes.Call, _ctx.Runtime!.GetIndex);
-            EmitUnboxToDouble();
-
-            // Increment or decrement
-            IL.Emit(OpCodes.Ldc_R8, 1.0);
-            if (pi.Operator.Type == TokenType.PLUS_PLUS)
-                IL.Emit(OpCodes.Add);
-            else
-                IL.Emit(OpCodes.Sub);
-
-            // Box new value and store in temp
-            IL.Emit(OpCodes.Box, _ctx.Types.Double);
-            var newValue = IL.DeclareLocal(_ctx.Types.Object);
-            IL.Emit(OpCodes.Stloc, newValue);
-
-            // SetIndex(obj, index, newValue)
-            EmitExpression(gi.Object);
-            EmitBoxIfNeeded(gi.Object);
-            EmitExpression(gi.Index);
-            EmitBoxIfNeeded(gi.Index);
-            IL.Emit(OpCodes.Ldloc, newValue);
-            IL.Emit(OpCodes.Call, _ctx.Runtime!.SetIndex);
-
-            // Return new value (prefix behavior)
-            IL.Emit(OpCodes.Ldloc, newValue);
-            SetStackUnknown();
+            EmitIncrementIndex(gi, pi.Operator.Type == TokenType.PLUS_PLUS, isPrefix: true);
             return;
         }
+    }
+
+    /// <summary>
+    /// Shared read→±1→write lowering for <c>++</c>/<c>--</c> on a property (<c>obj.prop</c>).
+    /// <paramref name="isPrefix"/> selects the expression result — the new value (prefix) or a
+    /// saved copy of the old value (postfix). Local declaration order (postfix: old before new)
+    /// and box points match the previous per-arm copies exactly.
+    /// </summary>
+    private void EmitIncrementProperty(Expr.Get get, bool isIncrement, bool isPrefix)
+    {
+        // Get current value
+        EmitExpression(get.Object);
+        EmitBoxIfNeeded(get.Object);
+        IL.Emit(OpCodes.Ldstr, get.Name.Lexeme);
+        IL.Emit(OpCodes.Call, _ctx.Runtime!.GetProperty);
+        EmitUnboxToDouble();
+
+        LocalBuilder? oldValue = null;
+        if (!isPrefix)
+        {
+            // Save old value for postfix return
+            oldValue = IL.DeclareLocal(_ctx.Types.Double);
+            IL.Emit(OpCodes.Dup);
+            IL.Emit(OpCodes.Stloc, oldValue);
+        }
+
+        // Increment or decrement
+        IL.Emit(OpCodes.Ldc_R8, 1.0);
+        IL.Emit(isIncrement ? OpCodes.Add : OpCodes.Sub);
+
+        // Box new value and store in temp
+        IL.Emit(OpCodes.Box, _ctx.Types.Double);
+        var newValue = IL.DeclareLocal(_ctx.Types.Object);
+        IL.Emit(OpCodes.Stloc, newValue);
+
+        // SetProperty(obj, name, newValue)
+        EmitExpression(get.Object);
+        EmitBoxIfNeeded(get.Object);
+        IL.Emit(OpCodes.Ldstr, get.Name.Lexeme);
+        IL.Emit(OpCodes.Ldloc, newValue);
+        IL.Emit(OpCodes.Call, _ctx.Runtime!.SetProperty);
+
+        if (isPrefix)
+        {
+            // Return new value (prefix behavior)
+            IL.Emit(OpCodes.Ldloc, newValue);
+        }
+        else
+        {
+            // Return old value (postfix behavior)
+            IL.Emit(OpCodes.Ldloc, oldValue!);
+            IL.Emit(OpCodes.Box, _ctx.Types.Double);
+        }
+        SetStackUnknown();
+    }
+
+    /// <summary>
+    /// Shared read→±1→write lowering for <c>++</c>/<c>--</c> on an index (<c>arr[i]</c>).
+    /// Same result seam as <see cref="EmitIncrementProperty"/>.
+    /// </summary>
+    private void EmitIncrementIndex(Expr.GetIndex gi, bool isIncrement, bool isPrefix)
+    {
+        // Get current value
+        EmitExpression(gi.Object);
+        EmitBoxIfNeeded(gi.Object);
+        EmitExpression(gi.Index);
+        EmitBoxIfNeeded(gi.Index);
+        IL.Emit(OpCodes.Call, _ctx.Runtime!.GetIndex);
+        EmitUnboxToDouble();
+
+        LocalBuilder? oldValue = null;
+        if (!isPrefix)
+        {
+            // Save old value for postfix return
+            oldValue = IL.DeclareLocal(_ctx.Types.Double);
+            IL.Emit(OpCodes.Dup);
+            IL.Emit(OpCodes.Stloc, oldValue);
+        }
+
+        // Increment or decrement
+        IL.Emit(OpCodes.Ldc_R8, 1.0);
+        IL.Emit(isIncrement ? OpCodes.Add : OpCodes.Sub);
+
+        // Box new value and store in temp
+        IL.Emit(OpCodes.Box, _ctx.Types.Double);
+        var newValue = IL.DeclareLocal(_ctx.Types.Object);
+        IL.Emit(OpCodes.Stloc, newValue);
+
+        // SetIndex(obj, index, newValue)
+        EmitExpression(gi.Object);
+        EmitBoxIfNeeded(gi.Object);
+        EmitExpression(gi.Index);
+        EmitBoxIfNeeded(gi.Index);
+        IL.Emit(OpCodes.Ldloc, newValue);
+        IL.Emit(OpCodes.Call, _ctx.Runtime!.SetIndex);
+
+        if (isPrefix)
+        {
+            // Return new value (prefix behavior)
+            IL.Emit(OpCodes.Ldloc, newValue);
+        }
+        else
+        {
+            // Return old value (postfix behavior)
+            IL.Emit(OpCodes.Ldloc, oldValue!);
+            IL.Emit(OpCodes.Box, _ctx.Types.Double);
+        }
+        SetStackUnknown();
     }
 
     protected override void EmitPostfixIncrement(Expr.PostfixIncrement pi)
@@ -1433,84 +1483,14 @@ public partial class ILEmitter
                 return;
 
             // Postfix increment on property: obj.prop++
-            // Get current value
-            EmitExpression(get.Object);
-            EmitBoxIfNeeded(get.Object);
-            IL.Emit(OpCodes.Ldstr, get.Name.Lexeme);
-            IL.Emit(OpCodes.Call, _ctx.Runtime!.GetProperty);
-            EmitUnboxToDouble();
-
-            // Save old value for postfix return
-            var oldValue = IL.DeclareLocal(_ctx.Types.Double);
-            IL.Emit(OpCodes.Dup);
-            IL.Emit(OpCodes.Stloc, oldValue);
-
-            // Increment or decrement
-            IL.Emit(OpCodes.Ldc_R8, 1.0);
-            if (pi.Operator.Type == TokenType.PLUS_PLUS)
-                IL.Emit(OpCodes.Add);
-            else
-                IL.Emit(OpCodes.Sub);
-
-            // Box new value and store in temp
-            IL.Emit(OpCodes.Box, _ctx.Types.Double);
-            var newValue = IL.DeclareLocal(_ctx.Types.Object);
-            IL.Emit(OpCodes.Stloc, newValue);
-
-            // SetProperty(obj, name, newValue)
-            EmitExpression(get.Object);
-            EmitBoxIfNeeded(get.Object);
-            IL.Emit(OpCodes.Ldstr, get.Name.Lexeme);
-            IL.Emit(OpCodes.Ldloc, newValue);
-            IL.Emit(OpCodes.Call, _ctx.Runtime!.SetProperty);
-
-            // Return old value (postfix behavior)
-            IL.Emit(OpCodes.Ldloc, oldValue);
-            IL.Emit(OpCodes.Box, _ctx.Types.Double);
-            SetStackUnknown();
+            EmitIncrementProperty(get, pi.Operator.Type == TokenType.PLUS_PLUS, isPrefix: false);
             return;
         }
 
         if (pi.Operand is Expr.GetIndex gi)
         {
             // Postfix increment on array index: arr[i]++
-            // Get current value
-            EmitExpression(gi.Object);
-            EmitBoxIfNeeded(gi.Object);
-            EmitExpression(gi.Index);
-            EmitBoxIfNeeded(gi.Index);
-            IL.Emit(OpCodes.Call, _ctx.Runtime!.GetIndex);
-            EmitUnboxToDouble();
-
-            // Save old value
-            var oldValue = IL.DeclareLocal(_ctx.Types.Double);
-            IL.Emit(OpCodes.Dup);
-            IL.Emit(OpCodes.Stloc, oldValue);
-
-            // Increment or decrement
-            IL.Emit(OpCodes.Ldc_R8, 1.0);
-            if (pi.Operator.Type == TokenType.PLUS_PLUS)
-                IL.Emit(OpCodes.Add);
-            else
-                IL.Emit(OpCodes.Sub);
-
-            // Box new value and store in temp
-            IL.Emit(OpCodes.Box, _ctx.Types.Double);
-            var newValue = IL.DeclareLocal(_ctx.Types.Object);
-            IL.Emit(OpCodes.Stloc, newValue);
-
-            // SetIndex(obj, index, newValue)
-            EmitExpression(gi.Object);
-            EmitBoxIfNeeded(gi.Object);
-            EmitExpression(gi.Index);
-            EmitBoxIfNeeded(gi.Index);
-            IL.Emit(OpCodes.Ldloc, newValue);
-            IL.Emit(OpCodes.Call, _ctx.Runtime!.SetIndex);
-
-            // Return old value
-            IL.Emit(OpCodes.Ldloc, oldValue);
-            IL.Emit(OpCodes.Box, _ctx.Types.Double);
-            SetStackUnknown();
+            EmitIncrementIndex(gi, pi.Operator.Type == TokenType.PLUS_PLUS, isPrefix: false);
             return;
         }
     }

--- a/Execution/Interpreter.Properties.cs
+++ b/Execution/Interpreter.Properties.cs
@@ -90,7 +90,7 @@ public partial class Interpreter
                 ["constructor"] = userFn,
             });
             var bound = userFn.BindThis(newThis);
-            var result = bound.Call(this, fnArgs);
+            var result = bound.CallBoxed(this, fnArgs);
             // JS spec: if the constructor returns an object (incl. a function), use
             // it; otherwise use the new `this` (#446).
             return IsConstructorReturnObject(result) ? result : newThis;
@@ -122,7 +122,7 @@ public partial class Interpreter
                 ["constructor"] = userArrowFn,
             });
             var bound = userArrowFn.Bind(newThis);
-            var result = bound.Call(this, arrowArgs);
+            var result = bound.CallBoxed(this, arrowArgs);
             return IsConstructorReturnObject(result) ? result : newThis;
         }
 
@@ -145,7 +145,7 @@ public partial class Interpreter
             List<object?> ctorArgs = await ctx.EvaluateAllAsync(newExpr.Arguments);
             try
             {
-                return callable.Call(this, ctorArgs);
+                return callable.CallBoxed(this, ctorArgs);
             }
             catch (Exception ex) when (IsNativeConstructorFailure(ex))
             {
@@ -174,7 +174,7 @@ public partial class Interpreter
         }
 
         List<object?> arguments = await ctx.EvaluateAllAsync(newExpr.Arguments);
-        return sharpClass.Call(this, arguments);
+        return sharpClass.CallBoxed(this, arguments);
     }
 
     /// <summary>
@@ -213,7 +213,7 @@ public partial class Interpreter
                 ["constructor"] = userFn,
             });
             var bound = userFn.BindThis(newThis);
-            var result = bound.Call(this, [.. args]);
+            var result = bound.CallBoxed(this, [.. args]);
             return IsConstructorReturnObject(result) ? result : newThis;
         }
         if (callable is SharpTSArrowFunction arrowFn && arrowFn.HasOwnThis)
@@ -229,7 +229,7 @@ public partial class Interpreter
                 ["constructor"] = arrowFn,
             });
             var bound = arrowFn.Bind(newThis);
-            var result = bound.Call(this, [.. args]);
+            var result = bound.CallBoxed(this, [.. args]);
             return IsConstructorReturnObject(result) ? result : newThis;
         }
         // Built-in constructor (e.g. RegExp via SharpTSBuiltInConstructor).
@@ -241,7 +241,7 @@ public partial class Interpreter
         // Fallback: treat as a callable; Reflect.construct shape.
         if (callable is ISharpTSCallable c)
         {
-            return c.Call(this, [.. args]);
+            return c.CallBoxed(this, [.. args]);
         }
         throw new InterpreterException("TypeError: Construct called on non-callable.");
     }
@@ -336,7 +336,7 @@ public partial class Interpreter
                 ["constructor"] = userFn,
             });
             var bound = userFn.BindThis(newThis);
-            var result = bound.Call(this, fnArgs);
+            var result = bound.CallBoxed(this, fnArgs);
             return RuntimeValue.FromBoxed(IsConstructorReturnObject(result) ? result : newThis);
         }
 
@@ -362,7 +362,7 @@ public partial class Interpreter
                 ["constructor"] = userArrowFn,
             });
             var bound = userArrowFn.Bind(newThis);
-            var result = bound.Call(this, arrowArgs);
+            var result = bound.CallBoxed(this, arrowArgs);
             return RuntimeValue.FromBoxed(IsConstructorReturnObject(result) ? result : newThis);
         }
 
@@ -384,7 +384,7 @@ public partial class Interpreter
             }
             try
             {
-                return RuntimeValue.FromBoxed(callable.Call(this, ctorArgs));
+                return RuntimeValue.FromBoxed(callable.CallBoxed(this, ctorArgs));
             }
             catch (Exception ex) when (IsNativeConstructorFailure(ex))
             {
@@ -499,7 +499,7 @@ public partial class Interpreter
                 // by BuiltInMethod.CreateConstant / BuiltInStaticBuilder.CallableConstant.
                 if (member is BuiltInMethod bm && bm.IsConstant)
                 {
-                    return RuntimeValue.FromBoxed(bm.Call(this, []));
+                    return RuntimeValue.FromBoxed(bm.CallBoxed(this, []));
                 }
                 return RuntimeValue.FromObject(member);
             }
@@ -578,7 +578,7 @@ public partial class Interpreter
                 var getter = so.GetGetter(name);
                 if (getter != null)
                 {
-                    value = BindAccessorToObject(getter, so).Call(this, []);
+                    value = BindAccessorToObject(getter, so).CallBoxed(this, []);
                     return true;
                 }
                 if (so.HasSetter(name))
@@ -737,7 +737,7 @@ public partial class Interpreter
             // Accessor defined via Object.defineProperty(fn, name, {get, set}).
             if (fn.TryGetAccessor(memberName, out var getter, out _) && getter != null)
             {
-                return RuntimeValue.FromBoxed(getter.Call(this, []));
+                return RuntimeValue.FromBoxed(getter.CallBoxed(this, []));
             }
             if (fn.TryGetProperty(memberName, out var userProp))
                 return RuntimeValue.FromBoxed(userProp);
@@ -752,7 +752,7 @@ public partial class Interpreter
         if (obj is SharpTSArrowFunction arrowFn)
         {
             if (arrowFn.TryGetAccessor(memberName, out var getter, out _) && getter != null)
-                return RuntimeValue.FromBoxed(getter.Call(this, []));
+                return RuntimeValue.FromBoxed(getter.CallBoxed(this, []));
             if (arrowFn.TryGetProperty(memberName, out var arrowProp))
                 return RuntimeValue.FromBoxed(arrowProp);
             // Lazy-init `fn.prototype` for function expressions (HasOwnThis).
@@ -786,7 +786,7 @@ public partial class Interpreter
         if (obj is SharpTSRegExp regex)
         {
             if (regex.TryGetAccessor(memberName, out var rxGetter, out _) && rxGetter != null)
-                return RuntimeValue.FromBoxed(rxGetter.Call(this, []));
+                return RuntimeValue.FromBoxed(rxGetter.CallBoxed(this, []));
             if (memberName == "flags")
                 return RuntimeValue.FromBoxed(Runtime.BuiltIns.RegExpBuiltIns.GetMember(regex, memberName, this));
             // ECMA-262 §22.2.6.1: `constructor` is inherited from
@@ -814,7 +814,7 @@ public partial class Interpreter
         if (obj is SharpTSPromise promise)
         {
             if (promise.TryGetAccessor(memberName, out var ownGetter, out _) && ownGetter != null)
-                return RuntimeValue.FromBoxed(ownGetter.Call(this, []));
+                return RuntimeValue.FromBoxed(ownGetter.CallBoxed(this, []));
             if (promise.TryGetOwnProperty(memberName, out var ownProp))
                 return RuntimeValue.FromBoxed(ownProp);
             if (promise is SharpTSPromiseSubclassInstance promiseSub)
@@ -823,7 +823,7 @@ public partial class Interpreter
                     return RuntimeValue.FromObject(promiseSub.Klass);
                 var promiseGetter = promiseSub.Klass.FindGetter(memberName);
                 if (promiseGetter != null)
-                    return RuntimeValue.FromBoxed(promiseGetter.BindThis(promiseSub).Call(this, []));
+                    return RuntimeValue.FromBoxed(promiseGetter.BindThis(promiseSub).CallBoxed(this, []));
                 var promiseMethod = promiseSub.Klass.FindMethod(memberName);
                 if (promiseMethod != null)
                     return RuntimeValue.FromObject(SharpTSClass.BindMethodToReceiver(promiseMethod, promiseSub));
@@ -849,7 +849,7 @@ public partial class Interpreter
             if (rxProtoGetter != null)
             {
                 var bound = rxProtoGetter is SharpTSFunction rxFn ? rxFn.BindThis(obj) : rxProtoGetter;
-                return RuntimeValue.FromBoxed(bound.Call(this, []));
+                return RuntimeValue.FromBoxed(bound.CallBoxed(this, []));
             }
             if (rxProto.Fields.ContainsKey(memberName))
                 return RuntimeValue.FromBoxed(rxProto.GetProperty(memberName));
@@ -881,7 +881,7 @@ public partial class Interpreter
                 return RuntimeValue.FromObject(subclassArray.Klass);
             var classGetter = subclassArray.Klass.FindGetter(memberName);
             if (classGetter != null)
-                return RuntimeValue.FromBoxed(classGetter.BindThis(subclassArray).Call(this, []));
+                return RuntimeValue.FromBoxed(classGetter.BindThis(subclassArray).CallBoxed(this, []));
             var classMethod = subclassArray.Klass.FindMethod(memberName);
             if (classMethod != null)
                 return RuntimeValue.FromObject(SharpTSClass.BindMethodToReceiver(classMethod, subclassArray));
@@ -963,7 +963,7 @@ public partial class Interpreter
         var staticGetter = klass.FindStaticGetter(memberName);
         if (staticGetter != null)
         {
-            return staticGetter.BindStatic(klass).Call(this, []);
+            return staticGetter.BindStatic(klass).CallBoxed(this, []);
         }
 
         // Try static method
@@ -1183,7 +1183,7 @@ public partial class Interpreter
         if (obj is SharpTSFunction fn)
         {
             if (fn.TryGetAccessor(memberName, out var getter, out _) && getter != null)
-                return getter.Call(this, []);
+                return getter.CallBoxed(this, []);
             if (fn.TryGetProperty(memberName, out var v)) return v;
             if (memberName == "name") return fn.TryGetProperty("name", out var n) ? n : "";
             if (memberName == "length") return (double)fn.Arity();
@@ -1201,7 +1201,7 @@ public partial class Interpreter
         if (obj is SharpTSArrowFunction arrowFn2)
         {
             if (arrowFn2.TryGetAccessor(memberName, out var arrowGetter, out _) && arrowGetter != null)
-                return arrowGetter.Call(this, []);
+                return arrowGetter.CallBoxed(this, []);
             if (arrowFn2.TryGetProperty(memberName, out var arrowProp2)) return arrowProp2;
             if (memberName == "length") return (double)arrowFn2.Arity();
             return SharpTSUndefined.Instance;
@@ -1270,7 +1270,7 @@ public partial class Interpreter
             // path in EvaluateGet does — otherwise the alias path returns the
             // BuiltInMethod wrapper and identity with the direct form breaks.
             if (ctorMember is BuiltInMethod { IsConstant: true } ctorConstant)
-                return ctorConstant.Call(this, []);
+                return ctorConstant.CallBoxed(this, []);
             return ctorMember ?? SharpTSUndefined.Instance;
         }
 
@@ -1313,7 +1313,7 @@ public partial class Interpreter
                 return subclassArray.Klass;
             var classGetter = subclassArray.Klass.FindGetter(memberName);
             if (classGetter != null)
-                return classGetter.BindThis(subclassArray).Call(this, []);
+                return classGetter.BindThis(subclassArray).CallBoxed(this, []);
             var classMethod = subclassArray.Klass.FindMethod(memberName);
             if (classMethod != null)
                 return SharpTSClass.BindMethodToReceiver(classMethod, subclassArray);
@@ -1325,7 +1325,7 @@ public partial class Interpreter
         if (obj is SharpTSPromise promise)
         {
             if (promise.TryGetAccessor(memberName, out var ownGetter, out _) && ownGetter != null)
-                return ownGetter.Call(this, []);
+                return ownGetter.CallBoxed(this, []);
             if (promise.TryGetOwnProperty(memberName, out var promiseOwnProp))
                 return promiseOwnProp;
             if (promise is SharpTSPromiseSubclassInstance promiseSub)
@@ -1334,7 +1334,7 @@ public partial class Interpreter
                     return promiseSub.Klass;
                 var promiseGetter = promiseSub.Klass.FindGetter(memberName);
                 if (promiseGetter != null)
-                    return promiseGetter.BindThis(promiseSub).Call(this, []);
+                    return promiseGetter.BindThis(promiseSub).CallBoxed(this, []);
                 var promiseMethod = promiseSub.Klass.FindMethod(memberName);
                 if (promiseMethod != null)
                     return SharpTSClass.BindMethodToReceiver(promiseMethod, promiseSub);
@@ -1457,7 +1457,7 @@ public partial class Interpreter
             // Accessor set path (Object.defineProperty setter).
             if (userFn.TryGetAccessor(set.Name.Lexeme, out _, out var setter) && setter != null)
             {
-                setter.Call(this, [value]);
+                setter.CallBoxed(this, [value]);
                 return value;
             }
             userFn.SetProperty(set.Name.Lexeme, value);
@@ -1467,7 +1467,7 @@ public partial class Interpreter
         {
             if (arrowFn.TryGetAccessor(set.Name.Lexeme, out _, out var arrowSetter) && arrowSetter != null)
             {
-                arrowSetter.Call(this, [value]);
+                arrowSetter.CallBoxed(this, [value]);
                 return value;
             }
             arrowFn.SetProperty(set.Name.Lexeme, value);
@@ -1537,7 +1537,7 @@ public partial class Interpreter
                 var staticSetterClass = klass.FindStaticSetter(memberName);
                 if (staticSetterClass != null)
                 {
-                    staticSetterClass.BindStatic(klass).Call(this, [value]);
+                    staticSetterClass.BindStatic(klass).CallBoxed(this, [value]);
                     return value;
                 }
                 klass.SetStaticProperty(memberName, value);
@@ -1561,7 +1561,7 @@ public partial class Interpreter
                 if (regex.TryGetAccessor(memberName, out _, out var userSetter)
                     && userSetter != null)
                 {
-                    userSetter.Call(this, [value]);
+                    userSetter.CallBoxed(this, [value]);
                     return value;
                 }
                 if (memberName == "lastIndex")
@@ -1588,7 +1588,7 @@ public partial class Interpreter
                 var promiseSetter = promiseSub.Klass.FindSetter(memberName);
                 if (promiseSetter != null)
                 {
-                    promiseSetter.BindThis(promiseSub).Call(this, [value]);
+                    promiseSetter.BindThis(promiseSub).CallBoxed(this, [value]);
                     return value;
                 }
                 promiseSub.SetOwnProperty(memberName, value);
@@ -1629,7 +1629,7 @@ public partial class Interpreter
             if (setter != null)
             {
                 var boundSetter = BindAccessorToObject(setter, simpleObj);
-                boundSetter.Call(this, [value]);
+                boundSetter.CallBoxed(this, [value]);
                 return value;
             }
 
@@ -1885,7 +1885,7 @@ public partial class Interpreter
                 throw new InterpreterException($"Static private method '{methodName}' does not exist on class '{klass.Name}'.");
             }
 
-            return RuntimeValue.FromBoxed(method.Call(this, arguments));
+            return RuntimeValue.FromBoxed(method.CallBoxed(this, arguments));
         }
 
         // Instance private method call
@@ -1901,7 +1901,7 @@ public partial class Interpreter
             }
 
             // Bind method to instance
-            return RuntimeValue.FromBoxed(SharpTSClass.BindMethod(method, instance).Call(this, arguments));
+            return RuntimeValue.FromBoxed(SharpTSClass.BindMethod(method, instance).CallBoxed(this, arguments));
         }
 
         throw new InterpreterException($"Cannot call private method '{methodName}' on non-class value.");

--- a/Runtime/Types/SharpTSDuplex.cs
+++ b/Runtime/Types/SharpTSDuplex.cs
@@ -57,51 +57,23 @@ public class SharpTSDuplex : SharpTSReadable
     public bool WritableObjectMode { get => _writableObjectMode; set => _writableObjectMode = value; }
 
     /// <summary>
-    /// Gets a member (method or property) by name for interpreter dispatch.
+    /// Gets a member (method or property) by name for interpreter dispatch. The writable-side
+    /// methods and properties come from the shared <see cref="WritableCore"/> dispatch;
+    /// <c>destroyed</c> intentionally falls through to the Readable base.
     /// </summary>
     public override object? GetMember(string name)
     {
+        if (_writeCore.GetWritableMember(name) is { } writableMember)
+            return writableMember;
+
         return name switch
         {
-            // Writable-side methods
-            "write" => BuiltInMethod.CreateV2("write", 1, 3, Write),
-            "end" => BuiltInMethod.CreateV2("end", 0, 3, End),
-            "cork" => BuiltInMethod.CreateV2("cork", 0, Cork),
-            "uncork" => BuiltInMethod.CreateV2("uncork", 0, Uncork),
-
-            // Writable-side properties
-            "writable" => _writeCore.IsWritable,
-            "writableEnded" => _writeCore.Ended,
-            "writableFinished" => _writeCore.Finished,
-            "writableLength" => (double)_writeCore.WritableLength,
-            "writableCorked" => (double)(_writeCore.Corked ? 1 : 0),
-            "writableHighWaterMark" => (double)_writableHighWaterMark,
-            "writableObjectMode" => _writableObjectMode,
-
             // Override destroy to handle both sides
             "destroy" => BuiltInMethod.CreateV2("destroy", 0, 1, DestroyDuplex),
 
             // Inherit Readable methods and properties
             _ => base.GetMember(name)
         };
-    }
-
-    private RuntimeValue Write(Interp interpreter, RuntimeValue receiver, ReadOnlySpan<RuntimeValue> args)
-        => _writeCore.Write(interpreter, args);
-
-    private RuntimeValue End(Interp interpreter, RuntimeValue receiver, ReadOnlySpan<RuntimeValue> args)
-        => _writeCore.End(interpreter, args);
-
-    private RuntimeValue Cork(Interp interpreter, RuntimeValue receiver, ReadOnlySpan<RuntimeValue> args)
-    {
-        _writeCore.Cork();
-        return RuntimeValue.Null;
-    }
-
-    private RuntimeValue Uncork(Interp interpreter, RuntimeValue receiver, ReadOnlySpan<RuntimeValue> args)
-    {
-        _writeCore.Uncork(interpreter);
-        return RuntimeValue.Null;
     }
 
     private RuntimeValue DestroyDuplex(Interp interpreter, RuntimeValue receiver, ReadOnlySpan<RuntimeValue> args)

--- a/Runtime/Types/SharpTSWritable.cs
+++ b/Runtime/Types/SharpTSWritable.cs
@@ -67,51 +67,23 @@ public class SharpTSWritable : SharpTSEventEmitter
     public void SetDestroyCallback(ISharpTSCallable callback) => _destroyCallback = callback;
 
     /// <summary>
-    /// Gets a member (method or property) by name for interpreter dispatch.
+    /// Gets a member (method or property) by name for interpreter dispatch. The writable-side
+    /// methods and properties come from the shared <see cref="WritableCore"/> dispatch.
     /// </summary>
     public override object? GetMember(string name)
     {
+        if (_writeCore.GetWritableMember(name) is { } writableMember)
+            return writableMember;
+
         return name switch
         {
-            // Writable-specific methods
-            "write" => BuiltInMethod.CreateV2("write", 1, 3, Write),
-            "end" => BuiltInMethod.CreateV2("end", 0, 3, End),
-            "cork" => BuiltInMethod.CreateV2("cork", 0, Cork),
-            "uncork" => BuiltInMethod.CreateV2("uncork", 0, Uncork),
             "destroy" => BuiltInMethod.CreateV2("destroy", 0, 1, Destroy),
             "setDefaultEncoding" => BuiltInMethod.CreateV2("setDefaultEncoding", 1, SetDefaultEncoding),
-
-            // Properties
-            "writable" => _writeCore.IsWritable,
-            "writableEnded" => _writeCore.Ended,
-            "writableFinished" => _writeCore.Finished,
-            "writableLength" => (double)_writeCore.WritableLength,
-            "writableCorked" => (double)(_writeCore.Corked ? 1 : 0),
-            "writableHighWaterMark" => (double)_highWaterMark,
-            "writableObjectMode" => _objectMode,
             "destroyed" => _writeCore.Destroyed,
 
             // Inherit from EventEmitter
             _ => base.GetMember(name)
         };
-    }
-
-    private RuntimeValue Write(Interp interpreter, RuntimeValue receiver, ReadOnlySpan<RuntimeValue> args)
-        => _writeCore.Write(interpreter, args);
-
-    private RuntimeValue End(Interp interpreter, RuntimeValue receiver, ReadOnlySpan<RuntimeValue> args)
-        => _writeCore.End(interpreter, args);
-
-    private RuntimeValue Cork(Interp interpreter, RuntimeValue receiver, ReadOnlySpan<RuntimeValue> args)
-    {
-        _writeCore.Cork();
-        return RuntimeValue.Null;
-    }
-
-    private RuntimeValue Uncork(Interp interpreter, RuntimeValue receiver, ReadOnlySpan<RuntimeValue> args)
-    {
-        _writeCore.Uncork(interpreter);
-        return RuntimeValue.Null;
     }
 
     /// <summary>

--- a/Runtime/Types/WritableCore.cs
+++ b/Runtime/Types/WritableCore.cs
@@ -1,3 +1,4 @@
+using SharpTS.Runtime.BuiltIns;
 using Interp = SharpTS.Execution.Interpreter;
 
 namespace SharpTS.Runtime.Types;
@@ -65,6 +66,54 @@ internal sealed class WritableCore
 
     public void SetWriteCallback(ISharpTSCallable callback) => _writeCallback = callback;
     public void SetFinalCallback(ISharpTSCallable callback) => _finalCallback = callback;
+
+    /// <summary>
+    /// Shared writable-side member dispatch for the two composing streams: the
+    /// write/end/cork/uncork methods and the writable* property values (high-water-mark and
+    /// object-mode via the live accessors the owner supplied at construction). Returns null when
+    /// the name is not a writable-side member so the owner falls through to its own arms and its
+    /// EventEmitter/Readable base. destroy/destroyed stay per-class: Writable's destroy runs its
+    /// destroy callback, while Duplex's must tear down both sides and resolves <c>destroyed</c>
+    /// to the readable-side flag.
+    /// </summary>
+    public object? GetWritableMember(string name)
+    {
+        return name switch
+        {
+            "write" => BuiltInMethod.CreateV2("write", 1, 3, WriteMember),
+            "end" => BuiltInMethod.CreateV2("end", 0, 3, EndMember),
+            "cork" => BuiltInMethod.CreateV2("cork", 0, CorkMember),
+            "uncork" => BuiltInMethod.CreateV2("uncork", 0, UncorkMember),
+
+            "writable" => IsWritable,
+            "writableEnded" => Ended,
+            "writableFinished" => Finished,
+            "writableLength" => (double)WritableLength,
+            "writableCorked" => (double)(Corked ? 1 : 0),
+            "writableHighWaterMark" => (double)_highWaterMark(),
+            "writableObjectMode" => _objectMode(),
+
+            _ => null
+        };
+    }
+
+    private RuntimeValue WriteMember(Interp interpreter, RuntimeValue receiver, ReadOnlySpan<RuntimeValue> args)
+        => Write(interpreter, args);
+
+    private RuntimeValue EndMember(Interp interpreter, RuntimeValue receiver, ReadOnlySpan<RuntimeValue> args)
+        => End(interpreter, args);
+
+    private RuntimeValue CorkMember(Interp interpreter, RuntimeValue receiver, ReadOnlySpan<RuntimeValue> args)
+    {
+        Cork();
+        return RuntimeValue.Null;
+    }
+
+    private RuntimeValue UncorkMember(Interp interpreter, RuntimeValue receiver, ReadOnlySpan<RuntimeValue> args)
+    {
+        Uncork(interpreter);
+        return RuntimeValue.Null;
+    }
 
     /// <summary>
     /// Implements <c>stream.write(chunk, encoding?, callback?)</c>.


### PR DESCRIPTION
Continues the audit backlog after #1268. Three consolidations, one commit each:

- **Writable/Duplex member dispatch** — #1093/#1138 centralized the writable behavior into `WritableCore` but left the `GetMember` layer duplicated. `WritableCore.GetWritableMember` now serves the write/end/cork/uncork methods and all seven `writable*` property arms (high-water-mark/object-mode via the live accessors each owner already supplies); the classes keep only their genuinely-different arms (Writable's `destroy`/`destroyed`/`setDefaultEncoding`; Duplex's both-sides destroy, with `destroyed` still falling through to the Readable base).
- **`++`/`--` property/index arms** — the four near-identical read→unbox→±1→box→store copies in `ILEmitter.Operators.cs` collapsed into `EmitIncrementProperty`/`EmitIncrementIndex` with an `isPrefix` seam. Local declaration order and box points preserved → IL unchanged. (The variable-target case was already unified in #1127; the static-field fast paths stay.)
- **Legacy `.Call` sweep** — the 34 remaining `\.Call(this, …)` sites in `Interpreter.Properties.cs` (accessor getters/setters, class calls, method dispatch) now route through `CallableInterop.CallBoxed`, the sanctioned CallV2 bridge — migrated implementors run boxing-free on these paths; unmigrated ones hit the default bridge, unchanged.

## Verification
- Full unit suite: **15,452/15,452 pass**
- **Test262 interpreter baseline diff clean** (relevant to the `.Call` sweep, which touches property reads broadly)
- Per-item slices ran green before each commit: streams 320, operators 397, property/accessor/class 1,506