### PR TITLE
perf(interp): four small allocation cuts on interpreter hot paths

### DIFF
--- a/Execution/Interpreter.Expressions.cs
+++ b/Execution/Interpreter.Expressions.cs
@@ -366,8 +366,9 @@ public partial class Interpreter
         // ToString coercion of an interpolated value goes through ToPrimitive
         // (string hint), so a boxed wrapper / object with own toString renders
         // its primitive (`${new String("ab")}` → "ab") rather than "[object Object]" (#708).
-        var evaluatedExprs = template.Expressions
-            .Select(e => ToPrimitive(Evaluate(e), PrimitiveHint.String)).ToList();
+        var evaluatedExprs = new List<object?>(template.Expressions.Count);
+        foreach (var e in template.Expressions)
+            evaluatedExprs.Add(ToPrimitive(Evaluate(e), PrimitiveHint.String));
         return RuntimeValue.FromString(BuildTemplateLiteralString(template.Strings, evaluatedExprs));
     }
 

--- a/Execution/Interpreter.Properties.cs
+++ b/Execution/Interpreter.Properties.cs
@@ -519,10 +519,17 @@ public partial class Interpreter
     /// methods read flags / lastIndex / exec / unicode / global via Get
     /// so user-installed getters fire and throw upstream).
     /// </summary>
+    // Synthetic Get nodes depend only on the property name and are immutable records the
+    // evaluator never keys by identity, so they are shared process-wide instead of allocating
+    // a Token + Expr.Get per internal Get() (the RegExp protocol methods call this per
+    // flags/lastIndex/exec read). Bounded by the set of names spec algorithms read.
+    private static readonly System.Collections.Concurrent.ConcurrentDictionary<string, Expr.Get> _syntheticGets =
+        new(StringComparer.Ordinal);
+
     internal object? GetProperty(object? obj, string name)
     {
-        var syntheticName = new Token(TokenType.IDENTIFIER, name, null, 0);
-        var syntheticGet = new Expr.Get(null!, syntheticName, Optional: false);
+        var syntheticGet = _syntheticGets.GetOrAdd(name, static n =>
+            new Expr.Get(null!, new Token(TokenType.IDENTIFIER, n, null, 0), Optional: false));
         return EvaluateGetOnObject(syntheticGet, obj).ToObject();
     }
 

--- a/Runtime/BuiltIns/JSONBuiltIns.cs
+++ b/Runtime/BuiltIns/JSONBuiltIns.cs
@@ -503,10 +503,25 @@ public static class JSONBuiltIns
         }
     }
 
+    // Per-thread memo of "indentStr repeated depth times". One pretty-print walk calls
+    // GetIndent at every nested node with the same step string and small depths, so the
+    // previous fresh Concat per node dominated pretty-print allocations. Reset when the
+    // step string changes; bounded by the deepest nesting seen on the thread.
+    [ThreadStatic] private static List<string>? _indentCache;
+    [ThreadStatic] private static string? _indentCacheStep;
+
     private static string GetIndent(string indentStr, int depth)
     {
-        // Optimization: Cache small indent strings? 
-        // For now, this is acceptable as it's only for pretty printing.
-        return string.Concat(Enumerable.Repeat(indentStr, depth));
+        if (depth == 0 || indentStr.Length == 0) return string.Empty;
+
+        if (_indentCache == null || _indentCacheStep != indentStr)
+        {
+            _indentCacheStep = indentStr;
+            _indentCache = [string.Empty];
+        }
+
+        while (_indentCache.Count <= depth)
+            _indentCache.Add(_indentCache[^1] + indentStr);
+        return _indentCache[depth];
     }
 }

--- a/Runtime/ScopeChain.cs
+++ b/Runtime/ScopeChain.cs
@@ -14,7 +14,10 @@ namespace SharpTS.Runtime;
 public abstract class ScopeChain<TValue, TSelf> where TSelf : ScopeChain<TValue, TSelf>
 {
     protected readonly Dictionary<string, TValue> _values = new(StringComparer.Ordinal);
-    private readonly HashSet<string> _readOnlyNames = new(StringComparer.Ordinal);
+
+    // Lazily allocated: only named function expressions mark a read-only name, so the
+    // overwhelming majority of scopes never need the set.
+    private HashSet<string>? _readOnlyNames;
 
     /// <summary>
     /// The enclosing scope, or null if this is the global scope.
@@ -67,14 +70,15 @@ public abstract class ScopeChain<TValue, TSelf> where TSelf : ScopeChain<TValue,
     /// Marks a variable as read-only. Used for named function expressions
     /// where the function name cannot be reassigned inside the function body.
     /// </summary>
-    public void MarkAsReadOnly(string name) => _readOnlyNames.Add(name);
+    public void MarkAsReadOnly(string name) =>
+        (_readOnlyNames ??= new(StringComparer.Ordinal)).Add(name);
 
     /// <summary>
     /// Checks if a variable is read-only in the current or enclosing scopes.
     /// </summary>
     public bool IsReadOnly(string name)
     {
-        if (_readOnlyNames.Contains(name)) return true;
+        if (_readOnlyNames?.Contains(name) == true) return true;
         return Enclosing?.IsReadOnly(name) ?? false;
     }
 }


### PR DESCRIPTION
The still-open remainder of the 2026-07-01 perf audit's quick-win tier. (The three headline items — `_locals` reference-equality comparer, `SemanticOperatorResolver` descriptor interning, and the `@DotNetType` member caches — turned out to be already landed on main; verified in place rather than re-applied.)

- **ScopeChain**: every scope eagerly allocated a `_readOnlyNames` HashSet that only named function expressions ever populate; now lazy.
- **EvaluateTemplateLiteral (sync)**: presized `foreach` loop instead of LINQ `Select().ToList()` per template evaluation, matching the async variant.
- **JSON pretty-print**: `GetIndent` memoizes "indentStr × depth" per thread instead of a fresh `string.Concat(Enumerable.Repeat(...))` at every nested node (the code's own comment asked for this).
- **`Interpreter.GetProperty`** (§7.3.3 Get used by RegExp-protocol and other spec algorithms): the per-call synthetic `Token` + `Expr.Get` is now a shared per-name cached node — immutable records the evaluator never keys by identity.

All behavior-preserving; no API changes.

## Verification
- Full unit suite: **15,452/15,452 pass**
- **Test262 interpreter baseline diff clean**
- Targeted slices (template/JSON/RegExp/function): 1,557 pass