### PR TITLE
refactor(compile): single-source the guest-error raise idiom (159 sites, −407 lines)

### DIFF
--- a/Compilation/Emitters/JSONStaticEmitter.cs
+++ b/Compilation/Emitters/JSONStaticEmitter.cs
@@ -36,10 +36,7 @@ public sealed class JSONStaticEmitter : IStaticTypeEmitterStrategy
                     il.Emit(OpCodes.Ldloc, argLocal);
                     il.Emit(OpCodes.Isinst, ctx.Runtime!.TSSymbolType);
                     il.Emit(OpCodes.Brfalse, notSymbolLabel);
-                    il.Emit(OpCodes.Ldstr, "Cannot convert a Symbol value to a string");
-                    il.Emit(OpCodes.Newobj, ctx.Runtime!.TSTypeErrorCtor);
-                    il.Emit(OpCodes.Call, ctx.Runtime!.CreateException);
-                    il.Emit(OpCodes.Throw);
+                    GuestErrorEmitter.ThrowTypeError(il, ctx.Runtime!, "Cannot convert a Symbol value to a string");
                     il.MarkLabel(notSymbolLabel);
                     il.Emit(OpCodes.Ldloc, argLocal);
                     // Use ToJsString (ECMA-262 ToString protocol) rather than

--- a/Compilation/Emitters/ObjectStaticEmitter.cs
+++ b/Compilation/Emitters/ObjectStaticEmitter.cs
@@ -393,9 +393,7 @@ public sealed class ObjectStaticEmitter : IStaticTypeEmitterStrategy
         il.MarkLabel(throwLabel);
         il.Emit(OpCodes.Pop);
         il.Emit(OpCodes.Ldstr, callName + " called on null or undefined");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowErrorFromStack(il, runtime, runtime.TSTypeErrorCtor);
         il.MarkLabel(okLabel);
     }
 }

--- a/Compilation/ExpressionEmitterBase.CallHelpers.cs
+++ b/Compilation/ExpressionEmitterBase.CallHelpers.cs
@@ -531,15 +531,11 @@ public abstract partial class ExpressionEmitterBase
 
         IL.MarkLabel(undefinedLabel);
         IL.Emit(OpCodes.Ldstr, $"Cannot {action} properties of undefined ({actionIng} '{methodName}')");
-        IL.Emit(OpCodes.Newobj, Ctx.Runtime!.TSTypeErrorCtor);
-        IL.Emit(OpCodes.Call, Ctx.Runtime!.CreateException);
-        IL.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowErrorFromStack(IL, Ctx.Runtime!, Ctx.Runtime!.TSTypeErrorCtor);
 
         IL.MarkLabel(nullLabel);
         IL.Emit(OpCodes.Ldstr, $"Cannot {action} properties of null ({actionIng} '{methodName}')");
-        IL.Emit(OpCodes.Newobj, Ctx.Runtime!.TSTypeErrorCtor);
-        IL.Emit(OpCodes.Call, Ctx.Runtime!.CreateException);
-        IL.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowErrorFromStack(IL, Ctx.Runtime!, Ctx.Runtime!.TSTypeErrorCtor);
 
         IL.MarkLabel(okLabel);
     }
@@ -575,16 +571,12 @@ public abstract partial class ExpressionEmitterBase
         IL.MarkLabel(undefinedLabel);
         IL.Emit(OpCodes.Pop);                             // discard receiver
         IL.Emit(OpCodes.Ldstr, $"Cannot read properties of undefined (reading '{propertyName}')");
-        IL.Emit(OpCodes.Newobj, Ctx.Runtime!.TSTypeErrorCtor);
-        IL.Emit(OpCodes.Call, Ctx.Runtime!.CreateException);
-        IL.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowErrorFromStack(IL, Ctx.Runtime!, Ctx.Runtime!.TSTypeErrorCtor);
 
         IL.MarkLabel(nullLabel);
         IL.Emit(OpCodes.Pop);                             // discard receiver
         IL.Emit(OpCodes.Ldstr, $"Cannot read properties of null (reading '{propertyName}')");
-        IL.Emit(OpCodes.Newobj, Ctx.Runtime!.TSTypeErrorCtor);
-        IL.Emit(OpCodes.Call, Ctx.Runtime!.CreateException);
-        IL.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowErrorFromStack(IL, Ctx.Runtime!, Ctx.Runtime!.TSTypeErrorCtor);
 
         IL.MarkLabel(okLabel);
     }
@@ -627,9 +619,7 @@ public abstract partial class ExpressionEmitterBase
         IL.Emit(OpCodes.Call, Types.StringConcatObjectObject);
         IL.Emit(OpCodes.Ldstr, "')");
         IL.Emit(OpCodes.Call, Types.StringConcat2);
-        IL.Emit(OpCodes.Newobj, Ctx.Runtime!.TSTypeErrorCtor);
-        IL.Emit(OpCodes.Call, Ctx.Runtime!.CreateException);
-        IL.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowErrorFromStack(IL, Ctx.Runtime!, Ctx.Runtime!.TSTypeErrorCtor);
 
         IL.MarkLabel(nullLabel);
         IL.Emit(OpCodes.Ldstr, prefixNull);
@@ -637,9 +627,7 @@ public abstract partial class ExpressionEmitterBase
         IL.Emit(OpCodes.Call, Types.StringConcatObjectObject);
         IL.Emit(OpCodes.Ldstr, "')");
         IL.Emit(OpCodes.Call, Types.StringConcat2);
-        IL.Emit(OpCodes.Newobj, Ctx.Runtime!.TSTypeErrorCtor);
-        IL.Emit(OpCodes.Call, Ctx.Runtime!.CreateException);
-        IL.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowErrorFromStack(IL, Ctx.Runtime!, Ctx.Runtime!.TSTypeErrorCtor);
 
         IL.MarkLabel(okLabel);
     }

--- a/Compilation/ExpressionEmitterBase.Constructors.cs
+++ b/Compilation/ExpressionEmitterBase.Constructors.cs
@@ -142,9 +142,7 @@ public abstract partial class ExpressionEmitterBase
             case "Blob":
             case "File":
                 IL.Emit(OpCodes.Ldstr, className + " is not yet supported in compiled mode (interpreter only); see SharpTS #1159");
-                IL.Emit(OpCodes.Newobj, Ctx.Runtime!.TSTypeErrorCtor);
-                IL.Emit(OpCodes.Call, Ctx.Runtime!.CreateException);
-                IL.Emit(OpCodes.Throw);
+                GuestErrorEmitter.ThrowErrorFromStack(IL, Ctx.Runtime!, Ctx.Runtime!.TSTypeErrorCtor);
                 IL.Emit(OpCodes.Ldnull); // unreachable; balances the expression's result slot
                 SetStackUnknown();
                 return true;

--- a/Compilation/GeneratorStateMachineBuilder.cs
+++ b/Compilation/GeneratorStateMachineBuilder.cs
@@ -666,10 +666,7 @@ public class GeneratorStateMachineBuilder : StateMachineBuilderBase, IIteratorSt
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ldfld, executingField);
         il.Emit(OpCodes.Brfalse, okLabel);
-        il.Emit(OpCodes.Ldstr, "Generator is already running");
-        il.Emit(OpCodes.Newobj, _runtime!.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, _runtime!.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, _runtime!, "Generator is already running");
         il.MarkLabel(okLabel);
     }
 

--- a/Compilation/GuestErrorEmitter.cs
+++ b/Compilation/GuestErrorEmitter.cs
@@ -1,0 +1,45 @@
+using System.Reflection;
+using System.Reflection.Emit;
+
+namespace SharpTS.Compilation;
+
+/// <summary>
+/// Shared emit helpers for raising a guest error from emitted runtime code:
+/// <c>throw CreateException(new $XxxError(message))</c>. This tail was previously open-coded at
+/// every throw site (~170x across the emitter files); any change to the raise idiom (e.g. the
+/// CreateException wrapping) now lands once. Usable from every emitter class — the RuntimeEmitter
+/// partials pass their local <c>il</c>/<c>runtime</c>, the expression emitters pass
+/// <c>IL</c>/<c>Ctx.Runtime!</c>.
+/// </summary>
+internal static class GuestErrorEmitter
+{
+    /// <summary>Emits <c>throw CreateException(new errorCtor(message))</c>.</summary>
+    public static void ThrowError(ILGenerator il, EmittedRuntime runtime, ConstructorInfo errorCtor, string message)
+    {
+        il.Emit(OpCodes.Ldstr, message);
+        ThrowErrorFromStack(il, runtime, errorCtor);
+    }
+
+    /// <summary>
+    /// Emits <c>throw CreateException(new errorCtor(message))</c> with the message string
+    /// already on the evaluation stack (for computed messages).
+    /// </summary>
+    public static void ThrowErrorFromStack(ILGenerator il, EmittedRuntime runtime, ConstructorInfo errorCtor)
+    {
+        il.Emit(OpCodes.Newobj, errorCtor);
+        il.Emit(OpCodes.Call, runtime.CreateException);
+        il.Emit(OpCodes.Throw);
+    }
+
+    public static void ThrowTypeError(ILGenerator il, EmittedRuntime runtime, string message) =>
+        ThrowError(il, runtime, runtime.TSTypeErrorCtor, message);
+
+    public static void ThrowRangeError(ILGenerator il, EmittedRuntime runtime, string message) =>
+        ThrowError(il, runtime, runtime.TSRangeErrorCtor, message);
+
+    public static void ThrowReferenceError(ILGenerator il, EmittedRuntime runtime, string message) =>
+        ThrowError(il, runtime, runtime.TSReferenceErrorCtor, message);
+
+    public static void ThrowSyntaxError(ILGenerator il, EmittedRuntime runtime, string message) =>
+        ThrowError(il, runtime, runtime.TSSyntaxErrorCtor, message);
+}

--- a/Compilation/ILEmitter.Calls.cs
+++ b/Compilation/ILEmitter.Calls.cs
@@ -129,9 +129,7 @@ public partial class ILEmitter
                 && _ctx.Functions.TryGetValue(_ctx.ResolveFunctionName(name), out _) == false)
             {
                 IL.Emit(OpCodes.Ldstr, name + " is not a function");
-                IL.Emit(OpCodes.Newobj, _ctx.Runtime!.TSTypeErrorCtor);
-                IL.Emit(OpCodes.Call, _ctx.Runtime!.CreateException);
-                IL.Emit(OpCodes.Throw);
+                GuestErrorEmitter.ThrowErrorFromStack(IL, _ctx.Runtime!, _ctx.Runtime!.TSTypeErrorCtor);
                 IL.Emit(OpCodes.Ldnull);  // unreachable, balance stack
                 SetStackUnknown();
                 return;
@@ -410,10 +408,7 @@ public partial class ILEmitter
             // Pop the duplicated receiver since we're going to throw and skip
             // the materialize call that would have consumed it.
             IL.Emit(OpCodes.Pop);
-            IL.Emit(OpCodes.Ldstr, "Invalid array length");
-            IL.Emit(OpCodes.Newobj, runtime.TSRangeErrorCtor);
-            IL.Emit(OpCodes.Call, runtime.CreateException);
-            IL.Emit(OpCodes.Throw);
+            GuestErrorEmitter.ThrowRangeError(IL, runtime, "Invalid array length");
             IL.MarkLabel(lengthOkLabel);
         }
 
@@ -473,10 +468,7 @@ public partial class ILEmitter
             IL.Emit(OpCodes.Pop);
             EmitLengthSideEffect();
             // Throw: TypeError("undefined is not a function")
-            IL.Emit(OpCodes.Ldstr, "undefined is not a function");
-            IL.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-            IL.Emit(OpCodes.Call, runtime.CreateException);
-            IL.Emit(OpCodes.Throw);
+            GuestErrorEmitter.ThrowTypeError(IL, runtime, "undefined is not a function");
             // Unreachable, but keep stack balanced for any dead-code analysis.
             return true;
         }
@@ -512,10 +504,7 @@ public partial class ILEmitter
             IL.MarkLabel(throwPath);
             IL.Emit(OpCodes.Pop); // Pop the duplicated receiver.
             EmitLengthSideEffect();
-            IL.Emit(OpCodes.Ldstr, "undefined is not a function");
-            IL.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-            IL.Emit(OpCodes.Call, runtime.CreateException);
-            IL.Emit(OpCodes.Throw);
+            GuestErrorEmitter.ThrowTypeError(IL, runtime, "undefined is not a function");
 
             IL.MarkLabel(cbValid);
             // The callback expression is re-emitted later when methodArgs

--- a/Compilation/RuntimeEmitter.ArrayFrom.cs
+++ b/Compilation/RuntimeEmitter.ArrayFrom.cs
@@ -43,19 +43,13 @@ public partial class RuntimeEmitter
         var nonNullLabel = il.DefineLabel();
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Brtrue, nonNullLabel);
-        il.Emit(OpCodes.Ldstr, "Array.from requires an array-like object - not null or undefined");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "Array.from requires an array-like object - not null or undefined");
         il.MarkLabel(nonNullLabel);
         var nonUndefLabel = il.DefineLabel();
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Isinst, runtime.UndefinedType);
         il.Emit(OpCodes.Brfalse, nonUndefLabel);
-        il.Emit(OpCodes.Ldstr, "Array.from requires an array-like object - not null or undefined");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "Array.from requires an array-like object - not null or undefined");
         il.MarkLabel(nonUndefLabel);
 
         // ECMA-262 23.1.2.1 step 2-3: if mapfn is undefined, mapping is false.
@@ -72,10 +66,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldarg_1);
         il.Emit(OpCodes.Isinst, runtime.TSFunctionType);
         il.Emit(OpCodes.Brtrue, mapFnOkLabel);
-        il.Emit(OpCodes.Ldstr, "Array.from: mapfn argument must be callable");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "Array.from: mapfn argument must be callable");
         il.MarkLabel(mapFnOkLabel);
 
         // ECMA-262 Array.from: if @@iterator is missing, treat receiver as

--- a/Compilation/RuntimeEmitter.Arrays.Iterators.cs
+++ b/Compilation/RuntimeEmitter.Arrays.Iterators.cs
@@ -126,9 +126,7 @@ public partial class RuntimeEmitter
         // important because test262 harness's `assert.throws(TypeError, fn)` checks
         // `e instanceof TypeError`, and only $TypeError instances satisfy that.
         il.Emit(OpCodes.Ldstr, methodName + " callback is not callable");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowErrorFromStack(il, runtime, runtime.TSTypeErrorCtor);
 
         il.MarkLabel(okLabel);
     }
@@ -2117,10 +2115,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Brtrue, reduceCallableOk);
         il.Emit(OpCodes.Br, reduceCallableThrow);
         il.MarkLabel(reduceCallableThrow);
-        il.Emit(OpCodes.Ldstr, "Array.prototype.reduce callback is not callable");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "Array.prototype.reduce callback is not callable");
         il.MarkLabel(reduceCallableOk);
 
         // Hoist the args[4] allocation once per helper invocation; pre-fill
@@ -2169,10 +2164,7 @@ public partial class RuntimeEmitter
         // No present element — TypeError per spec. Build a real $TypeError
         // instance (not a raw .NET Exception) so test262 patterns like
         // `e instanceof TypeError` and `e.constructor.name === 'TypeError'` hold.
-        il.Emit(OpCodes.Ldstr, "Reduce of empty array with no initial value");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "Reduce of empty array with no initial value");
 
         il.MarkLabel(scanFound);
         // acc = LoadArrayLikeElement(list, scan); i = scan + 1; (lazy-aware)
@@ -2299,10 +2291,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Brtrue, reduceRCallableOk);
         il.Emit(OpCodes.Br, reduceRCallableThrow);
         il.MarkLabel(reduceRCallableThrow);
-        il.Emit(OpCodes.Ldstr, "Array.prototype.reduceRight callback is not callable");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "Array.prototype.reduceRight callback is not callable");
         il.MarkLabel(reduceRCallableOk);
 
         // Hoist the args[4] allocation once per helper invocation; pre-fill
@@ -2350,10 +2339,7 @@ public partial class RuntimeEmitter
         il.MarkLabel(scanEnd);
         // No present element — TypeError per spec. Throw a real $TypeError
         // instance (parity with EmitArrayReduce).
-        il.Emit(OpCodes.Ldstr, "Reduce of empty array with no initial value");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "Reduce of empty array with no initial value");
 
         il.MarkLabel(scanFound);
         // acc = LoadArrayLikeElement(list, scan); i = scan - 1; (lazy-aware)

--- a/Compilation/RuntimeEmitter.Arrays.Mutators.cs
+++ b/Compilation/RuntimeEmitter.Arrays.Mutators.cs
@@ -1601,10 +1601,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Isinst, runtime.TSObjectType);
         il.Emit(OpCodes.Brfalse, afterToPrimCheck);
         il.MarkLabel(stillObjThrowLabel);
-        il.Emit(OpCodes.Ldstr, "Cannot convert object to primitive value");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "Cannot convert object to primitive value");
         il.MarkLabel(afterToPrimCheck);
 
         il.MarkLabel(notObjectLabel);

--- a/Compilation/RuntimeEmitter.Arrays.Search.cs
+++ b/Compilation/RuntimeEmitter.Arrays.Search.cs
@@ -295,10 +295,7 @@ public partial class RuntimeEmitter
         // `.call(null, ...)` must surface this throw rather than silently
         // iterate an empty list.
         il.MarkLabel(throwLabel);
-        il.Emit(OpCodes.Ldstr, "Cannot convert undefined or null to object");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "Cannot convert undefined or null to object");
     }
 
     /// <summary>
@@ -334,10 +331,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldarg_0);
         var notNullLabel = il.DefineLabel();
         il.Emit(OpCodes.Brtrue, notNullLabel);
-        il.Emit(OpCodes.Ldstr, "Cannot convert undefined or null to object");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "Cannot convert undefined or null to object");
         il.MarkLabel(notNullLabel);
 
         // $Undefined → throw TypeError "null/undefined"
@@ -345,10 +339,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Isinst, runtime.UndefinedType);
         var notUndefLabel = il.DefineLabel();
         il.Emit(OpCodes.Brfalse, notUndefLabel);
-        il.Emit(OpCodes.Ldstr, "Cannot convert undefined or null to object");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "Cannot convert undefined or null to object");
         il.MarkLabel(notUndefLabel);
 
         // Symbol → throw TypeError "Cannot convert a Symbol to a string".
@@ -358,10 +349,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Isinst, runtime.TSSymbolType);
         il.Emit(OpCodes.Brfalse, passThroughLabel);
-        il.Emit(OpCodes.Ldstr, "Cannot convert a Symbol value to a string");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "Cannot convert a Symbol value to a string");
 
         // Pass-through (string, $TSObject, etc.).
         il.MarkLabel(passThroughLabel);
@@ -919,10 +907,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Isinst, runtime.TSObjectType);
         il.Emit(OpCodes.Brfalse, afterTypeErrorCheck);
         il.MarkLabel(stillObjForThrow);
-        il.Emit(OpCodes.Ldstr, "Cannot convert object to primitive value");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "Cannot convert object to primitive value");
         il.MarkLabel(afterTypeErrorCheck);
     }
 

--- a/Compilation/RuntimeEmitter.Arrays.cs
+++ b/Compilation/RuntimeEmitter.Arrays.cs
@@ -288,19 +288,13 @@ public partial class RuntimeEmitter
         var notNullForKeysLabel = il.DefineLabel();
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Brtrue, notNullForKeysLabel);
-        il.Emit(OpCodes.Ldstr, "Object.keys called on null or undefined");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "Object.keys called on null or undefined");
         il.MarkLabel(notNullForKeysLabel);
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Isinst, runtime.UndefinedType);
         var notUndefForKeysLabel = il.DefineLabel();
         il.Emit(OpCodes.Brfalse, notUndefForKeysLabel);
-        il.Emit(OpCodes.Ldstr, "Object.keys called on null or undefined");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "Object.keys called on null or undefined");
         il.MarkLabel(notUndefForKeysLabel);
 
         // Proxy short-circuit (#92): if obj is SharpTSProxy, dispatch TrapOwnKeys
@@ -770,10 +764,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Br, gopnTypeOkLabel);
 
         il.MarkLabel(gopnThrowLabel);
-        il.Emit(OpCodes.Ldstr, "Cannot convert undefined or null to object");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "Cannot convert undefined or null to object");
         il.MarkLabel(gopnTypeOkLabel);
 
         // Proxy short-circuit (#92): if obj is SharpTSProxy, dispatch TrapOwnKeys

--- a/Compilation/RuntimeEmitter.BooleanPrototypePopulate.cs
+++ b/Compilation/RuntimeEmitter.BooleanPrototypePopulate.cs
@@ -134,10 +134,7 @@ public partial class RuntimeEmitter
         // plain Object): per ECMA-262 §20.3.3.2 throw TypeError. The borrowed-
         // method tests `s1.toString = Boolean.prototype.toString; s1.toString()`
         // rely on this throw.
-        il.Emit(OpCodes.Ldstr, "Boolean.prototype.toString requires a Boolean this value");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "Boolean.prototype.toString requires a Boolean this value");
 
         il.MarkLabel(falseLabel);
         il.Emit(OpCodes.Ldstr, "false");
@@ -208,10 +205,7 @@ public partial class RuntimeEmitter
         il.MarkLabel(notBoolPrototypeLabel);
 
         // Other receivers: throw TypeError per ECMA-262 §20.3.3.3.
-        il.Emit(OpCodes.Ldstr, "Boolean.prototype.valueOf requires a Boolean this value");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "Boolean.prototype.valueOf requires a Boolean this value");
 
         // Unreachable but balances stack:
         il.Emit(OpCodes.Ldc_I4_0);

--- a/Compilation/RuntimeEmitter.Coercion.cs
+++ b/Compilation/RuntimeEmitter.Coercion.cs
@@ -398,10 +398,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Brtrue, notNullishLabel);
         var throwTypeErrorLabel = il.DefineLabel();
         il.MarkLabel(throwTypeErrorLabel);
-        il.Emit(OpCodes.Ldstr, "Cannot convert undefined or null to object");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "Cannot convert undefined or null to object");
         il.MarkLabel(notNullishLabel);
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Isinst, runtime.UndefinedType);
@@ -616,10 +613,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Isinst, runtime.TSSymbolType);
         il.Emit(OpCodes.Brfalse, notSymbolLabel);
-        il.Emit(OpCodes.Ldstr, "Cannot convert a Symbol value to a string");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "Cannot convert a Symbol value to a string");
         il.MarkLabel(notSymbolLabel);
 
         // A bigint coerces to its bare decimal form ("42"), not Stringify's "42n".
@@ -689,10 +683,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Isinst, runtime.TSSymbolType);
         il.Emit(OpCodes.Brfalse, notSymbolLabel);
-        il.Emit(OpCodes.Ldstr, "Cannot convert a Symbol value to a string");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "Cannot convert a Symbol value to a string");
         il.MarkLabel(notSymbolLabel);
 
         // A bigint coerces to its bare decimal form ("42"), not Stringify's "42n".
@@ -897,10 +888,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloc, primValLocal);
         il.Emit(OpCodes.Isinst, runtime.TSSymbolType);
         il.Emit(OpCodes.Brfalse, unwrapNotSymLabel);
-        il.Emit(OpCodes.Ldstr, "Cannot convert a Symbol value to a string");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "Cannot convert a Symbol value to a string");
         il.MarkLabel(unwrapNotSymLabel);
         // Stringify the primitive — handles bool/double/string identically to
         // the top-level fallback path.
@@ -1004,10 +992,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Isinst, _types.BigInteger);
         il.Emit(OpCodes.Brtrue, resIsPrimitiveLabel);
         // Object result → TypeError per ECMA-262 7.1.1 step 1.b.iii.
-        il.Emit(OpCodes.Ldstr, "Cannot convert object to primitive value");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "Cannot convert object to primitive value");
         il.MarkLabel(resIsPrimitiveLabel);
         il.Emit(OpCodes.Ldloc, toPrimResultLocal);
         il.Emit(OpCodes.Call, runtime.ToJsString);
@@ -1096,10 +1081,7 @@ public partial class RuntimeEmitter
         var noThrowLabel = il.DefineLabel();
         il.Emit(OpCodes.Ldloc, sawNonPrimitiveLocal);
         il.Emit(OpCodes.Brfalse, noThrowLabel);
-        il.Emit(OpCodes.Ldstr, "Cannot convert object to primitive value");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "Cannot convert object to primitive value");
         il.MarkLabel(noThrowLabel);
 
         // No usable toString/valueOf on this object — fall back to "[object Object]"
@@ -1226,10 +1208,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Stloc, argLocal);
         il.Emit(OpCodes.Br, afterToPrimSymN);
         il.MarkLabel(doThrowN);
-        il.Emit(OpCodes.Ldstr, "Cannot convert object to primitive value");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "Cannot convert object to primitive value");
         il.MarkLabel(afterToPrimSymN);
 
         var emptyArgsLocalT = il.DeclareLocal(_types.ObjectArray);
@@ -1293,10 +1272,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Isinst, runtime.TSObjectType);
         il.Emit(OpCodes.Brfalse, afterTeT);
         il.MarkLabel(stillObjTeT);
-        il.Emit(OpCodes.Ldstr, "Cannot convert object to primitive value");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "Cannot convert object to primitive value");
         il.MarkLabel(afterTeT);
 
         il.MarkLabel(skipToPrimLabelTop);
@@ -1309,10 +1285,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloc, argLocal);
         il.Emit(OpCodes.Isinst, runtime.TSSymbolType);
         il.Emit(OpCodes.Brfalse, notSymbolLabel);
-        il.Emit(OpCodes.Ldstr, "Cannot convert a Symbol value to a number");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "Cannot convert a Symbol value to a number");
         il.MarkLabel(notSymbolLabel);
 
         // ECMA-262 7.1.4 step 2: BigInt → TypeError. `(0).toFixed(0n)` must
@@ -1322,10 +1295,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloc, argLocal);
         il.Emit(OpCodes.Isinst, _types.BigInteger);
         il.Emit(OpCodes.Brfalse, notBigIntLabel);
-        il.Emit(OpCodes.Ldstr, "Cannot convert a BigInt to a number");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "Cannot convert a BigInt to a number");
         il.MarkLabel(notBigIntLabel);
 
         // ECMA-262 ToNumber: strings with "0x"/"0X" prefix parse as hex. Convert.ToDouble
@@ -1708,10 +1678,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Isinst, runtime.TSObjectType);
         il.Emit(OpCodes.Brfalse, afterTypeErrorLabel);
         il.MarkLabel(stillObjAfterToString);
-        il.Emit(OpCodes.Ldstr, "Cannot convert object to primitive value");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "Cannot convert object to primitive value");
         il.MarkLabel(afterTypeErrorLabel);
 
         il.MarkLabel(skipToPrimLabel);
@@ -1727,10 +1694,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloc, argLocal);
         il.Emit(OpCodes.Isinst, runtime.TSSymbolType);
         il.Emit(OpCodes.Brfalse, notSymbolConvLabel);
-        il.Emit(OpCodes.Ldstr, "Cannot convert a Symbol value to a number");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "Cannot convert a Symbol value to a number");
         il.MarkLabel(notSymbolConvLabel);
 
         // ECMA-262 21.1.1.1 step 5: Number(BigInt) returns a Number with the

--- a/Compilation/RuntimeEmitter.Dns.cs
+++ b/Compilation/RuntimeEmitter.Dns.cs
@@ -126,10 +126,7 @@ public partial class RuntimeEmitter
             }
 
             il.MarkLabel(invalid);
-            il.Emit(OpCodes.Ldstr, "The argument 'order' must be one of: 'ipv4first', 'ipv6first', 'verbatim'");
-            il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-            il.Emit(OpCodes.Call, runtime.CreateException);
-            il.Emit(OpCodes.Throw);
+            GuestErrorEmitter.ThrowTypeError(il, runtime, "The argument 'order' must be one of: 'ipv4first', 'ipv6first', 'verbatim'");
 
             il.MarkLabel(valid);
             il.Emit(OpCodes.Ldloc, strLocal);

--- a/Compilation/RuntimeEmitter.DynamicConstruct.cs
+++ b/Compilation/RuntimeEmitter.DynamicConstruct.cs
@@ -67,9 +67,6 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ret);
 
         il.MarkLabel(throwLabel);
-        il.Emit(OpCodes.Ldstr, "Value is not a constructor");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "Value is not a constructor");
     }
 }

--- a/Compilation/RuntimeEmitter.ErrorPrototypePopulate.cs
+++ b/Compilation/RuntimeEmitter.ErrorPrototypePopulate.cs
@@ -156,10 +156,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Br, passLabel);
 
         il.MarkLabel(throwLabel);
-        il.Emit(OpCodes.Ldstr, "Error.prototype.toString called on non-object");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "Error.prototype.toString called on non-object");
 
         il.MarkLabel(passLabel);
 

--- a/Compilation/RuntimeEmitter.Functions.NewOp.cs
+++ b/Compilation/RuntimeEmitter.Functions.NewOp.cs
@@ -59,10 +59,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Call, runtime.IsConstructorMethod);
         il.Emit(OpCodes.Brtrue, isConstructorOkLabel);
-        il.Emit(OpCodes.Ldstr, "not a constructor");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "not a constructor");
         il.MarkLabel(skipConstructorCheckLabel);
         il.MarkLabel(isConstructorOkLabel);
 
@@ -74,10 +71,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Isinst, _types.DictionaryStringObject);
         il.Emit(OpCodes.Brfalse, notPlainObjectLabel);
-        il.Emit(OpCodes.Ldstr, "not a constructor");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "not a constructor");
         il.MarkLabel(notPlainObjectLabel);
 
         // newObj = new $Object(new Dictionary<string, object>())
@@ -186,10 +180,7 @@ public partial class RuntimeEmitter
         var notCallableSkip = il.DefineLabel();
         il.Emit(OpCodes.Ldloc, notCallableLocal);
         il.Emit(OpCodes.Brfalse, notCallableSkip);
-        il.Emit(OpCodes.Ldstr, "not a constructor");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "not a constructor");
         il.MarkLabel(notCallableSkip);
 
         // Per JS: return result if it's an object, else newObj.

--- a/Compilation/RuntimeEmitter.GroupBy.cs
+++ b/Compilation/RuntimeEmitter.GroupBy.cs
@@ -28,10 +28,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldarg_1);
         il.Emit(OpCodes.Isinst, runtime.TSFunctionType);
         il.Emit(OpCodes.Brtrue, gbCallableOkLabel);
-        il.Emit(OpCodes.Ldstr, "Object.groupBy: callback is not callable");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "Object.groupBy: callback is not callable");
         il.MarkLabel(gbCallableOkLabel);
 
         // Locals

--- a/Compilation/RuntimeEmitter.HasOwnProperty.cs
+++ b/Compilation/RuntimeEmitter.HasOwnProperty.cs
@@ -451,10 +451,7 @@ public partial class RuntimeEmitter
         var pieAfterNullLabel = il.DefineLabel();
         il.Emit(OpCodes.Br, pieAfterNullLabel);
         il.MarkLabel(pieNullThrowLabel);
-        il.Emit(OpCodes.Ldstr, "Cannot convert undefined or null to object");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "Cannot convert undefined or null to object");
         il.MarkLabel(pieAfterNullLabel);
 
         // Symbol-keyed lookup. PDSGetPropertyDescriptor's name parameter is

--- a/Compilation/RuntimeEmitter.IsPrototypeOf.cs
+++ b/Compilation/RuntimeEmitter.IsPrototypeOf.cs
@@ -71,10 +71,7 @@ public partial class RuntimeEmitter
         var afterReceiverNullLabel = il.DefineLabel();
         il.Emit(OpCodes.Br, afterReceiverNullLabel);
         il.MarkLabel(receiverNullThrowLabel);
-        il.Emit(OpCodes.Ldstr, "Cannot convert undefined or null to object");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "Cannot convert undefined or null to object");
         il.MarkLabel(afterReceiverNullLabel);
 
         // Walk: current = PDSGetPrototype(target);

--- a/Compilation/RuntimeEmitter.IteratorHelpers.cs
+++ b/Compilation/RuntimeEmitter.IteratorHelpers.cs
@@ -93,10 +93,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ret);
 
         il.MarkLabel(throwLabel);
-        il.Emit(OpCodes.Ldstr, "Value is not iterable.");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "Value is not iterable.");
     }
 
     #region Lazy Iterator Types
@@ -851,10 +848,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ret);
 
         il.MarkLabel(throwLabel);
-        il.Emit(OpCodes.Ldstr, "Reduce of empty iterator with no initial value.");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "Reduce of empty iterator with no initial value.");
     }
 
     private void EmitIteratorToArray(TypeBuilder typeBuilder, EmittedRuntime runtime)

--- a/Compilation/RuntimeEmitter.Json.Parse.cs
+++ b/Compilation/RuntimeEmitter.Json.Parse.cs
@@ -42,9 +42,7 @@ public partial class RuntimeEmitter
 
         il.Emit(OpCodes.Ldloc, exLocal);
         il.Emit(OpCodes.Callvirt, _types.GetProperty(_types.Exception, "Message").GetGetMethod()!);
-        il.Emit(OpCodes.Newobj, runtime.TSSyntaxErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowErrorFromStack(il, runtime, runtime.TSSyntaxErrorCtor);
 
         il.MarkLabel(rethrowLabel);
         il.Emit(OpCodes.Rethrow);

--- a/Compilation/RuntimeEmitter.Json.Stringify.cs
+++ b/Compilation/RuntimeEmitter.Json.Stringify.cs
@@ -358,10 +358,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldarg_2);
         il.Emit(OpCodes.Ldc_I4, 512);
         il.Emit(OpCodes.Blt, depthOkLabel);
-        il.Emit(OpCodes.Ldstr, "Converting circular structure to JSON");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "Converting circular structure to JSON");
         il.MarkLabel(depthOkLabel);
 
         // Store value in local (we may modify it via toJSON)
@@ -556,10 +553,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Brfalse, notBigIntLabel);
 
         il.MarkLabel(throwLabel);
-        il.Emit(OpCodes.Ldstr, "BigInt value can't be serialized in JSON");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "BigInt value can't be serialized in JSON");
 
         il.MarkLabel(notBigIntLabel);
     }

--- a/Compilation/RuntimeEmitter.Json.StringifyFull.cs
+++ b/Compilation/RuntimeEmitter.Json.StringifyFull.cs
@@ -410,10 +410,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldarg, 4);
         il.Emit(OpCodes.Ldc_I4, 512);
         il.Emit(OpCodes.Blt, depthOkLabel);
-        il.Emit(OpCodes.Ldstr, "Converting circular structure to JSON");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "Converting circular structure to JSON");
         il.MarkLabel(depthOkLabel);
 
         // Store value in local

--- a/Compilation/RuntimeEmitter.LookupGetterSetter.cs
+++ b/Compilation/RuntimeEmitter.LookupGetterSetter.cs
@@ -68,9 +68,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldstr, isGetter
             ? "Object.prototype.__defineGetter__: callback must be callable"
             : "Object.prototype.__defineSetter__: callback must be callable");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowErrorFromStack(il, runtime, runtime.TSTypeErrorCtor);
         il.MarkLabel(isCallableLabel);
 
         // desc = new Dictionary<string, object>();

--- a/Compilation/RuntimeEmitter.Number.cs
+++ b/Compilation/RuntimeEmitter.Number.cs
@@ -981,10 +981,7 @@ public partial class RuntimeEmitter
         il.MarkLabel(notDoubleLabel);
         // Per ECMA-262 21.1.3.3 step 1, thisNumberValue throws TypeError when
         // receiver is neither a Number primitive nor a Number-marker $TSObject.
-        il.Emit(OpCodes.Ldstr, "Number.prototype.toFixed requires a Number this value");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "Number.prototype.toFixed requires a Number this value");
 
         // ECMA-262 21.1.3.3: digits = ToIntegerOrInfinity(digits, 0). Coerces
         // bool/string via ToNumber.
@@ -1002,20 +999,14 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Bge, notNegativeLabel);
         // ECMA-262 21.1.3.3 step 3: range error for f < 0 or f > 100. Use $RangeError
         // (not bare Exception) so `assert.throws(RangeError, …)` succeeds.
-        il.Emit(OpCodes.Ldstr, "toFixed() digits argument must be between 0 and 100");
-        il.Emit(OpCodes.Newobj, runtime.TSRangeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowRangeError(il, runtime, "toFixed() digits argument must be between 0 and 100");
 
         il.MarkLabel(notNegativeLabel);
         il.Emit(OpCodes.Ldloc, digitsLocal);
         il.Emit(OpCodes.Ldc_I4, 100);
         var notTooLargeLabel = il.DefineLabel();
         il.Emit(OpCodes.Ble, notTooLargeLabel);
-        il.Emit(OpCodes.Ldstr, "toFixed() digits argument must be between 0 and 100");
-        il.Emit(OpCodes.Newobj, runtime.TSRangeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowRangeError(il, runtime, "toFixed() digits argument must be between 0 and 100");
 
         // return value.ToString($"F{digits}", CultureInfo.InvariantCulture).
         // ECMA-262: -0 formatted as "0" (no sign) — strip via abs on zero.
@@ -1102,10 +1093,7 @@ public partial class RuntimeEmitter
         il.MarkLabel(notDoubleLabel);
         // Per ECMA-262 21.1.3.5 step 1, thisNumberValue throws TypeError when
         // receiver is neither a Number primitive nor a Number-marker $TSObject.
-        il.Emit(OpCodes.Ldstr, "Number.prototype.toPrecision requires a Number this value");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "Number.prototype.toPrecision requires a Number this value");
 
         // Check if precision is null OR $Undefined - if so, return value.ToString().
         // ECMA-262 21.1.3.5 step 2: "If precision is undefined, return ! ToString(x)".
@@ -1169,20 +1157,14 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldc_I4_1);
         var notTooSmallLabel = il.DefineLabel();
         il.Emit(OpCodes.Bge, notTooSmallLabel);
-        il.Emit(OpCodes.Ldstr, "toPrecision() argument must be between 1 and 100");
-        il.Emit(OpCodes.Newobj, runtime.TSRangeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowRangeError(il, runtime, "toPrecision() argument must be between 1 and 100");
 
         il.MarkLabel(notTooSmallLabel);
         il.Emit(OpCodes.Ldloc, precisionLocal);
         il.Emit(OpCodes.Ldc_I4, 100);
         var notTooLargeLabel = il.DefineLabel();
         il.Emit(OpCodes.Ble, notTooLargeLabel);
-        il.Emit(OpCodes.Ldstr, "toPrecision() argument must be between 1 and 100");
-        il.Emit(OpCodes.Newobj, runtime.TSRangeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowRangeError(il, runtime, "toPrecision() argument must be between 1 and 100");
 
         il.MarkLabel(notTooLargeLabel);
         il.Emit(OpCodes.Br, formatLabel);
@@ -1388,10 +1370,7 @@ public partial class RuntimeEmitter
         il.MarkLabel(notDoubleLabel);
         // Per ECMA-262 21.1.3.2 step 1, thisNumberValue throws TypeError when
         // receiver is neither a Number primitive nor a Number-marker $TSObject.
-        il.Emit(OpCodes.Ldstr, "Number.prototype.toExponential requires a Number this value");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "Number.prototype.toExponential requires a Number this value");
 
         // Unused but keeps original valueLocal init for this branch (unreachable).
         il.Emit(OpCodes.Ldc_R8, double.NaN);
@@ -1414,10 +1393,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldarg_1);
         il.Emit(OpCodes.Isinst, runtime.TSSymbolType);
         il.Emit(OpCodes.Brfalse, notSymbolDigitsLabel);
-        il.Emit(OpCodes.Ldstr, "Cannot convert a Symbol value to a number");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "Cannot convert a Symbol value to a number");
         il.MarkLabel(notSymbolDigitsLabel);
 
         // Pre-coerce fractionDigits via ToIntegerOrInfinity unless it's
@@ -1558,20 +1534,14 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldc_I4_0);
         var notNegativeLabel = il.DefineLabel();
         il.Emit(OpCodes.Bge, notNegativeLabel);
-        il.Emit(OpCodes.Ldstr, "toExponential() argument must be between 0 and 100");
-        il.Emit(OpCodes.Newobj, runtime.TSRangeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowRangeError(il, runtime, "toExponential() argument must be between 0 and 100");
 
         il.MarkLabel(notNegativeLabel);
         il.Emit(OpCodes.Ldloc, digitsLocal);
         il.Emit(OpCodes.Ldc_I4, 100);
         var notTooLargeLabel = il.DefineLabel();
         il.Emit(OpCodes.Ble, notTooLargeLabel);
-        il.Emit(OpCodes.Ldstr, "toExponential() argument must be between 0 and 100");
-        il.Emit(OpCodes.Newobj, runtime.TSRangeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowRangeError(il, runtime, "toExponential() argument must be between 0 and 100");
 
         // return Regex.Replace(value.ToString($"e{digits}", InvariantCulture),
         //                      @"e([+-])0+(?=\d)", "e$1");
@@ -1825,10 +1795,7 @@ public partial class RuntimeEmitter
         // Receiver is neither a Number primitive nor a Number-marker $TSObject
         // nor the Number.prototype singleton. ECMA-262 21.1.3.6 step 1 calls
         // thisNumberValue which throws TypeError in this case.
-        il.Emit(OpCodes.Ldstr, "Number.prototype.toString requires a Number this value");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "Number.prototype.toString requires a Number this value");
 
         // Check if radix is null
         il.MarkLabel(hasRadixLabel);
@@ -1857,20 +1824,14 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldc_I4_2);
         var radixValidLabel = il.DefineLabel();
         il.Emit(OpCodes.Bge, radixValidLabel);
-        il.Emit(OpCodes.Ldstr, "toString() radix must be between 2 and 36");
-        il.Emit(OpCodes.Newobj, runtime.TSRangeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowRangeError(il, runtime, "toString() radix must be between 2 and 36");
 
         il.MarkLabel(radixValidLabel);
         il.Emit(OpCodes.Ldloc, radixLocal);
         il.Emit(OpCodes.Ldc_I4, 36);
         var radixNotTooLargeLabel = il.DefineLabel();
         il.Emit(OpCodes.Ble, radixNotTooLargeLabel);
-        il.Emit(OpCodes.Ldstr, "toString() radix must be between 2 and 36");
-        il.Emit(OpCodes.Newobj, runtime.TSRangeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowRangeError(il, runtime, "toString() radix must be between 2 and 36");
 
         // Handle special values
         il.MarkLabel(radixNotTooLargeLabel);

--- a/Compilation/RuntimeEmitter.NumberPrototypePopulate.cs
+++ b/Compilation/RuntimeEmitter.NumberPrototypePopulate.cs
@@ -129,10 +129,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ret);
 
         il.MarkLabel(throwTypeErrorLabel);
-        il.Emit(OpCodes.Ldstr, "Number.prototype.valueOf requires that 'this' be a Number");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "Number.prototype.valueOf requires that 'this' be a Number");
 
         return method;
     }

--- a/Compilation/RuntimeEmitter.Objects.Comparison.cs
+++ b/Compilation/RuntimeEmitter.Objects.Comparison.cs
@@ -35,10 +35,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Brtrue, ohoThrowLabel);
         il.Emit(OpCodes.Br, ohoOkLabel);
         il.MarkLabel(ohoThrowLabel);
-        il.Emit(OpCodes.Ldstr, "Cannot convert undefined or null to object");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "Cannot convert undefined or null to object");
         il.MarkLabel(ohoOkLabel);
 
         // Delegate to HasOwnPropertyHelper(receiver, name).
@@ -497,10 +494,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Call, runtime.PDSIsFrozen);
         il.Emit(OpCodes.Brfalse, skipFrozenThrowLabel);
-        il.Emit(OpCodes.Ldstr, "Cannot assign to read only property in frozen object");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "Cannot assign to read only property in frozen object");
         il.MarkLabel(skipFrozenThrowLabel);
 
         // Load target's PDS descriptor for the current key once — used by
@@ -553,10 +547,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Callvirt, runtime.TSObjectHasSetter);
         il.Emit(OpCodes.Brtrue, skipSealedCheckLabel);
         il.MarkLabel(notTSObjectForAccessorCheckLabel);
-        il.Emit(OpCodes.Ldstr, "Cannot add property to non-extensible object");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "Cannot add property to non-extensible object");
         il.MarkLabel(skipSealedCheckLabel);
 
         // Per-key writable=false on target: ECMA-262 OrdinarySetWithOwnDescriptor
@@ -583,10 +574,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloc, targetKeyDescLocal);
         il.Emit(OpCodes.Callvirt, runtime.CompiledPropertyDescriptorWritable.GetGetMethod()!);
         il.Emit(OpCodes.Brtrue, skipNotWritableLabel);
-        il.Emit(OpCodes.Ldstr, "Cannot assign to read only property");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "Cannot assign to read only property");
         il.MarkLabel(skipNotWritableLabel);
 
         // String exotic object: indexed integer keys and "length" are
@@ -632,10 +620,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Callvirt, _types.GetMethod(dictType, "ContainsKey", _types.String));
         il.Emit(OpCodes.Brfalse, skipStringWrapperThrowLabel);
         il.MarkLabel(throwStringWrapperLabel);
-        il.Emit(OpCodes.Ldstr, "Cannot assign to read only property of String exotic object");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "Cannot assign to read only property of String exotic object");
         il.MarkLabel(skipStringWrapperThrowLabel);
 
         // target[kvp.Key] = kvp.Value
@@ -707,10 +692,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Call, runtime.PDSIsFrozen);
         il.Emit(OpCodes.Brfalse, skipSymFrozenThrowLabel);
-        il.Emit(OpCodes.Ldstr, "Cannot assign to read only property in frozen object");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "Cannot assign to read only property in frozen object");
         il.MarkLabel(skipSymFrozenThrowLabel);
 
         // Sealed target + new key → throw.
@@ -723,10 +705,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Call, symKpKey);
         il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.DictionaryObjectObject, "ContainsKey", _types.Object));
         il.Emit(OpCodes.Brtrue, skipSymSealedCheckLabel);
-        il.Emit(OpCodes.Ldstr, "Cannot add property to sealed object");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "Cannot add property to sealed object");
         il.MarkLabel(skipSymSealedCheckLabel);
 
         // targetSymDict[symKey] = symValue
@@ -760,10 +739,7 @@ public partial class RuntimeEmitter
 
         // Target is null/undefined - throw TypeError (ECMA-262 §20.1.2.1 step 1).
         il.MarkLabel(targetNullLabel);
-        il.Emit(OpCodes.Ldstr, "Cannot convert undefined or null to object");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "Cannot convert undefined or null to object");
 
         // Return coerced target (wrapped if a primitive was passed).
         il.MarkLabel(returnLabel);

--- a/Compilation/RuntimeEmitter.Objects.Descriptors.cs
+++ b/Compilation/RuntimeEmitter.Objects.Descriptors.cs
@@ -75,10 +75,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Br, skipTypeThrowLabel);
 
         il.MarkLabel(primitiveThrowLabel);
-        il.Emit(OpCodes.Ldstr, "Object.defineProperty called on non-object");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "Object.defineProperty called on non-object");
         il.MarkLabel(skipTypeThrowLabel);
 
         // Symbol-keyed path: Object.defineProperty(obj, symbol, {value:X}) must store X
@@ -223,10 +220,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Stloc, lenWasCoercedLocal);
         il.Emit(OpCodes.Br, skipArrayLenCheck);
         il.MarkLabel(rangeErrLabel);
-        il.Emit(OpCodes.Ldstr, "Invalid array length");
-        il.Emit(OpCodes.Newobj, runtime.TSRangeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowRangeError(il, runtime, "Invalid array length");
         il.MarkLabel(skipArrayLenCheck);
 
         // Check if object is frozen - if so, throw TypeError
@@ -313,10 +307,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Br, descTypeOkLabel);
 
         il.MarkLabel(descThrowLabel);
-        il.Emit(OpCodes.Ldstr, "Property description must be an object");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "Property description must be an object");
 
         il.MarkLabel(descTypeOkLabel);
 
@@ -565,10 +556,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloc, valueLocal);
         il.Emit(OpCodes.Isinst, runtime.BoundAnyFunctionType);
         il.Emit(OpCodes.Brtrue, getterStoreLabel);
-        il.Emit(OpCodes.Ldstr, "Property descriptor 'get' is not callable");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "Property descriptor 'get' is not callable");
         il.MarkLabel(getterIsUndefLabel);
         // Store $Undefined.Instance so the descriptor remains classified as
         // accessor (slot non-null).
@@ -601,10 +589,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloc, valueLocal);
         il.Emit(OpCodes.Isinst, runtime.BoundAnyFunctionType);
         il.Emit(OpCodes.Brtrue, setterStoreLabel);
-        il.Emit(OpCodes.Ldstr, "Property descriptor 'set' is not callable");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "Property descriptor 'set' is not callable");
         il.MarkLabel(setterIsUndefLabel);
         il.Emit(OpCodes.Ldloc, descriptorLocal);
         il.Emit(OpCodes.Ldsfld, runtime.UndefinedInstance);
@@ -745,10 +730,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Brfalse, noMixLabel);
         il.Emit(OpCodes.Ldloc, newIsDataOuter);
         il.Emit(OpCodes.Brfalse, noMixLabel);
-        il.Emit(OpCodes.Ldstr, "Invalid property descriptor. Cannot both specify accessors and a value or writable attribute");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "Invalid property descriptor. Cannot both specify accessors and a value or writable attribute");
         il.MarkLabel(noMixLabel);
 
         var validationEndLabel = il.DefineLabel();
@@ -993,10 +975,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Br, validationEndLabel);
 
         il.MarkLabel(throwRedefineLabel);
-        il.Emit(OpCodes.Ldstr, "Cannot redefine property");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "Cannot redefine property");
 
         il.MarkLabel(validationEndLabel);
 
@@ -2410,10 +2389,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Br, dpsOkLabel);
 
         il.MarkLabel(dpsThrowLabel);
-        il.Emit(OpCodes.Ldstr, "Object.defineProperties called on non-object");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "Object.defineProperties called on non-object");
         il.MarkLabel(dpsOkLabel);
 
         // ECMA-262 §20.1.2.3 step 2: Let props be ? ToObject(Properties).
@@ -2429,10 +2405,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Br, dpsPropsOkLabel);
 
         il.MarkLabel(dpsPropsThrowLabel);
-        il.Emit(OpCodes.Ldstr, "Cannot convert undefined or null to object");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "Cannot convert undefined or null to object");
         il.MarkLabel(dpsPropsOkLabel);
 
         // Save the ORIGINAL props identity for PDS lookups before the $TSObject

--- a/Compilation/RuntimeEmitter.Objects.Invocation.cs
+++ b/Compilation/RuntimeEmitter.Objects.Invocation.cs
@@ -22,10 +22,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Call, typeof(System.Runtime.CompilerServices.RuntimeHelpers)
             .GetMethod("TryEnsureSufficientExecutionStack", Type.EmptyTypes)!);
         il.Emit(OpCodes.Brtrue, stackOkLabel);
-        il.Emit(OpCodes.Ldstr, "Maximum call stack size exceeded");
-        il.Emit(OpCodes.Newobj, runtime.TSRangeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowRangeError(il, runtime, "Maximum call stack size exceeded");
         il.MarkLabel(stackOkLabel);
     }
 
@@ -40,9 +37,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Call, runtime.TypeOf);
         il.Emit(OpCodes.Ldstr, " is not a function");
         il.Emit(OpCodes.Call, _types.GetMethod(_types.String, "Concat", _types.String, _types.String));
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowErrorFromStack(il, runtime, runtime.TSTypeErrorCtor);
     }
 
     private void EmitGetArrayMethod(TypeBuilder typeBuilder, EmittedRuntime runtime)
@@ -144,10 +139,7 @@ public partial class RuntimeEmitter
             il.Emit(OpCodes.Ldarg_0);
             il.Emit(OpCodes.Isinst, runtime.TSRegExpType);
             il.Emit(OpCodes.Brfalse, notRegExpCallee);
-            il.Emit(OpCodes.Ldstr, "called value is not a function");
-            il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-            il.Emit(OpCodes.Call, runtime.CreateException);
-            il.Emit(OpCodes.Throw);
+            GuestErrorEmitter.ThrowTypeError(il, runtime, "called value is not a function");
             il.MarkLabel(notRegExpCallee);
         }
 
@@ -621,10 +613,7 @@ public partial class RuntimeEmitter
             il.Emit(OpCodes.Ldarg_1);
             il.Emit(OpCodes.Isinst, runtime.TSRegExpType);
             il.Emit(OpCodes.Brfalse, notRegExpCallee);
-            il.Emit(OpCodes.Ldstr, "called value is not a function");
-            il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-            il.Emit(OpCodes.Call, runtime.CreateException);
-            il.Emit(OpCodes.Throw);
+            GuestErrorEmitter.ThrowTypeError(il, runtime, "called value is not a function");
             il.MarkLabel(notRegExpCallee);
         }
 

--- a/Compilation/RuntimeEmitter.Objects.Iteration.cs
+++ b/Compilation/RuntimeEmitter.Objects.Iteration.cs
@@ -264,19 +264,13 @@ public partial class RuntimeEmitter
         var notNullForValsLabel = il.DefineLabel();
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Brtrue, notNullForValsLabel);
-        il.Emit(OpCodes.Ldstr, "Object.values called on null or undefined");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "Object.values called on null or undefined");
         il.MarkLabel(notNullForValsLabel);
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Isinst, runtime.UndefinedType);
         var notUndefForValsLabel = il.DefineLabel();
         il.Emit(OpCodes.Brfalse, notUndefForValsLabel);
-        il.Emit(OpCodes.Ldstr, "Object.values called on null or undefined");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "Object.values called on null or undefined");
         il.MarkLabel(notUndefForValsLabel);
 
         // String primitive: ToObject wraps it as a String exotic object whose
@@ -759,19 +753,13 @@ public partial class RuntimeEmitter
         var notNullForEntsLabel = il.DefineLabel();
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Brtrue, notNullForEntsLabel);
-        il.Emit(OpCodes.Ldstr, "Object.entries called on null or undefined");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "Object.entries called on null or undefined");
         il.MarkLabel(notNullForEntsLabel);
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Isinst, runtime.UndefinedType);
         var notUndefForEntsLabel = il.DefineLabel();
         il.Emit(OpCodes.Brfalse, notUndefForEntsLabel);
-        il.Emit(OpCodes.Ldstr, "Object.entries called on null or undefined");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "Object.entries called on null or undefined");
         il.MarkLabel(notUndefForEntsLabel);
 
         // String primitive: yields [["0","a"], ["1","b"], ...] per ECMA-262
@@ -1397,10 +1385,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Br, notNullLabel);
 
         il.MarkLabel(requireOcThrowLabel);
-        il.Emit(OpCodes.Ldstr, "Object.fromEntries: argument must not be null or undefined");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "Object.fromEntries: argument must not be null or undefined");
 
         il.MarkLabel(notNullLabel);
 

--- a/Compilation/RuntimeEmitter.Objects.Prototype.cs
+++ b/Compilation/RuntimeEmitter.Objects.Prototype.cs
@@ -53,10 +53,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Br, protoOkLabel);
 
         il.MarkLabel(protoThrowLabel);
-        il.Emit(OpCodes.Ldstr, "Object prototype may only be an Object or null");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "Object prototype may only be an Object or null");
 
         il.MarkLabel(protoOkLabel);
 
@@ -102,10 +99,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldarg_1);
         il.Emit(OpCodes.Brtrue, propsIsUndefLabel);
         // Properties is null → throw TypeError per ToObject step.
-        il.Emit(OpCodes.Ldstr, "Cannot convert undefined or null to object");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "Cannot convert undefined or null to object");
         il.MarkLabel(propsIsUndefLabel);
 
         // Cast propertiesObject to Dictionary<string, object?>
@@ -424,10 +418,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Brtrue, gOPSThrowLabel);
         il.Emit(OpCodes.Br, gOPSTypeOkLabel);
         il.MarkLabel(gOPSThrowLabel);
-        il.Emit(OpCodes.Ldstr, "Cannot convert undefined or null to object");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "Cannot convert undefined or null to object");
         il.MarkLabel(gOPSTypeOkLabel);
 
         // Create the result list
@@ -518,19 +509,13 @@ public partial class RuntimeEmitter
         var notNullForGpoLabel = il.DefineLabel();
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Brtrue, notNullForGpoLabel);
-        il.Emit(OpCodes.Ldstr, "Object.getPrototypeOf called on null or undefined");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "Object.getPrototypeOf called on null or undefined");
         il.MarkLabel(notNullForGpoLabel);
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Isinst, runtime.UndefinedType);
         var notUndefForGpoLabel = il.DefineLabel();
         il.Emit(OpCodes.Brfalse, notUndefForGpoLabel);
-        il.Emit(OpCodes.Ldstr, "Object.getPrototypeOf called on null or undefined");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "Object.getPrototypeOf called on null or undefined");
         il.MarkLabel(notUndefForGpoLabel);
 
         var tempLocal = il.DeclareLocal(_types.Object);
@@ -762,10 +747,7 @@ public partial class RuntimeEmitter
         var afterRocLabel = il.DefineLabel();
         il.Emit(OpCodes.Br, afterRocLabel);
         il.MarkLabel(rocThrowLabel);
-        il.Emit(OpCodes.Ldstr, "Object.setPrototypeOf called on null or undefined");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "Object.setPrototypeOf called on null or undefined");
         il.MarkLabel(afterRocLabel);
 
         // ECMA-262 §20.1.2.21 step 3: throw TypeError if Type(proto) is
@@ -800,10 +782,7 @@ public partial class RuntimeEmitter
         }
         il.Emit(OpCodes.Br, protoOkLabel);
         il.MarkLabel(protoThrowLabel);
-        il.Emit(OpCodes.Ldstr, "Object prototype may only be an Object or null");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "Object prototype may only be an Object or null");
         il.MarkLabel(protoOkLabel);
 
         // Check if object is null - if so, skip checks (dead code now that
@@ -822,10 +801,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Isinst, runtime.TSObjectType);
         il.Emit(OpCodes.Brtrue, notClassInstanceLabel);
         // It's a class instance - throw TypeError
-        il.Emit(OpCodes.Ldstr, "Cannot set prototype of class instance");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "Cannot set prototype of class instance");
         il.MarkLabel(notClassInstanceLabel);
 
         // Check if object is extensible - if not, throw TypeError
@@ -834,10 +810,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Brtrue, nullCheckDoneLabel);  // Object is extensible, proceed
 
         // Object is not extensible - throw TypeError
-        il.Emit(OpCodes.Ldstr, "Cannot set prototype of non-extensible object");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "Cannot set prototype of non-extensible object");
 
         il.MarkLabel(nullCheckDoneLabel);
 

--- a/Compilation/RuntimeEmitter.Objects.SetProperty.cs
+++ b/Compilation/RuntimeEmitter.Objects.SetProperty.cs
@@ -861,10 +861,7 @@ public partial class RuntimeEmitter
             il.Emit(OpCodes.Br, validLengthLabel);
 
             il.MarkLabel(rangeErrorLabel);
-            il.Emit(OpCodes.Ldstr, "Invalid array length");
-            il.Emit(OpCodes.Newobj, runtime.TSRangeErrorCtor);
-            il.Emit(OpCodes.Call, runtime.CreateException);
-            il.Emit(OpCodes.Throw);
+            GuestErrorEmitter.ThrowRangeError(il, runtime, "Invalid array length");
 
             il.MarkLabel(validLengthLabel);
             il.Emit(OpCodes.Ldarg_0);

--- a/Compilation/RuntimeEmitter.Objects.StrictShared.cs
+++ b/Compilation/RuntimeEmitter.Objects.StrictShared.cs
@@ -18,9 +18,7 @@ public partial class RuntimeEmitter
     private void EmitThrowTypeError(ILGenerator il, EmittedRuntime runtime, string message)
     {
         il.Emit(OpCodes.Ldstr, message);
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowErrorFromStack(il, runtime, runtime.TSTypeErrorCtor);
     }
 
     /// <summary>
@@ -33,9 +31,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldarg_1);
         il.Emit(OpCodes.Ldstr, suffix);
         il.Emit(OpCodes.Call, _types.GetMethod(_types.String, "Concat", _types.String, _types.String, _types.String));
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowErrorFromStack(il, runtime, runtime.TSTypeErrorCtor);
     }
 
     /// <summary>

--- a/Compilation/RuntimeEmitter.Objects.Templates.cs
+++ b/Compilation/RuntimeEmitter.Objects.Templates.cs
@@ -302,10 +302,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ret);
 
         il.MarkLabel(errorLabel);
-        il.Emit(OpCodes.Ldstr, "Tagged template tag must be a function.");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "Tagged template tag must be a function.");
     }
 
     /// <summary>
@@ -401,9 +398,6 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ret);
 
         il.MarkLabel(errorLabel);
-        il.Emit(OpCodes.Ldstr, "Tagged template tag must be a function.");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "Tagged template tag must be a function.");
     }
 }

--- a/Compilation/RuntimeEmitter.Objects.Utilities.cs
+++ b/Compilation/RuntimeEmitter.Objects.Utilities.cs
@@ -487,10 +487,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Stloc, listLocal);
         il.Emit(OpCodes.Ldloc, listLocal);
         il.Emit(OpCodes.Brtrue, hasListLabel);
-        il.Emit(OpCodes.Ldstr, "Math.sumPrecise requires an iterable");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "Math.sumPrecise requires an iterable");
         il.MarkLabel(hasListLabel);
 
         var sumLocal = il.DeclareLocal(_types.Double);
@@ -530,10 +527,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloc, elemLocal);
         il.Emit(OpCodes.Isinst, _types.Double);
         il.Emit(OpCodes.Brtrue, isDoubleLabel);
-        il.Emit(OpCodes.Ldstr, "Math.sumPrecise: every element must be a Number");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "Math.sumPrecise: every element must be a Number");
         il.MarkLabel(isDoubleLabel);
 
         il.Emit(OpCodes.Ldloc, elemLocal);

--- a/Compilation/RuntimeEmitter.PromisePrototypePopulate.cs
+++ b/Compilation/RuntimeEmitter.PromisePrototypePopulate.cs
@@ -48,10 +48,7 @@ public partial class RuntimeEmitter
             il.Emit(OpCodes.Ldarg_0);
             il.Emit(OpCodes.Isinst, _types.TaskOfObject);
             il.Emit(OpCodes.Brtrue, isPromiseOkLabel);
-            il.Emit(OpCodes.Ldstr, "Promise.prototype.then called on non-Promise");
-            il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-            il.Emit(OpCodes.Call, runtime.CreateException);
-            il.Emit(OpCodes.Throw);
+            GuestErrorEmitter.ThrowTypeError(il, runtime, "Promise.prototype.then called on non-Promise");
             il.MarkLabel(isPromiseOkLabel);
             var taskLocal = il.DeclareLocal(_types.TaskOfObject);
             EmitUnwrapToTask(il, runtime, taskLocal);
@@ -203,9 +200,7 @@ public partial class RuntimeEmitter
         // Not callable — throw TypeError. Message is parameterized so finally
         // callers don't see a "Promise.prototype.catch:" prefix.
         il.Emit(OpCodes.Ldstr, methodNameForError + ": this.then is not callable");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowErrorFromStack(il, runtime, runtime.TSTypeErrorCtor);
         il.MarkLabel(thenCallableLabel);
         // args[0]: undefined (catch) or onFinally (finally — both slots fire
         //         the callback so it runs on fulfillment AND rejection).
@@ -247,9 +242,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Br, okLabel);
         il.MarkLabel(throwLabel);
         il.Emit(OpCodes.Ldstr, message);
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowErrorFromStack(il, runtime, runtime.TSTypeErrorCtor);
         il.MarkLabel(okLabel);
     }
 

--- a/Compilation/RuntimeEmitter.Promises.CombinatorShared.cs
+++ b/Compilation/RuntimeEmitter.Promises.CombinatorShared.cs
@@ -147,9 +147,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Isinst, listType);
         il.Emit(OpCodes.Brtrue, iterableOkLabel);
         il.Emit(OpCodes.Ldstr, $"Promise.{combinatorName} argument is not iterable");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowErrorFromStack(il, runtime, runtime.TSTypeErrorCtor);
         il.MarkLabel(iterableOkLabel);
 
         var listLocal = il.DeclareLocal(listType);

--- a/Compilation/RuntimeEmitter.Promises.cs
+++ b/Compilation/RuntimeEmitter.Promises.cs
@@ -619,9 +619,7 @@ public partial class RuntimeEmitter
 
         il.MarkLabel(throwLabel);
         il.Emit(OpCodes.Ldstr, message);
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowErrorFromStack(il, runtime, runtime.TSTypeErrorCtor);
         il.MarkLabel(okLabel);
     }
 

--- a/Compilation/RuntimeEmitter.Reflect.cs
+++ b/Compilation/RuntimeEmitter.Reflect.cs
@@ -549,10 +549,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Call, runtime.IsConstructorMethod);
         var targetOkLabel = il.DefineLabel();
         il.Emit(OpCodes.Brtrue, targetOkLabel);
-        il.Emit(OpCodes.Ldstr, "Reflect.construct: target is not a constructor");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "Reflect.construct: target is not a constructor");
         il.MarkLabel(targetOkLabel);
 
         // newTarget defaults to target if null/undefined.
@@ -582,10 +579,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Call, runtime.IsConstructorMethod);
         var newTargetOkLabel = il.DefineLabel();
         il.Emit(OpCodes.Brtrue, newTargetOkLabel);
-        il.Emit(OpCodes.Ldstr, "Reflect.construct: newTarget is not a constructor");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "Reflect.construct: newTarget is not a constructor");
         il.MarkLabel(newTargetOkLabel);
 
         // Convert argsList (arg1) to object[]

--- a/Compilation/RuntimeEmitter.RegExp.cs
+++ b/Compilation/RuntimeEmitter.RegExp.cs
@@ -890,10 +890,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloc, regexpLocal);
         il.Emit(OpCodes.Callvirt, runtime.TSRegExpGlobalGetter);
         il.Emit(OpCodes.Brtrue, isGlobalLabel);
-        il.Emit(OpCodes.Ldstr, "String.prototype.matchAll called with a non-global RegExp argument");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "String.prototype.matchAll called with a non-global RegExp argument");
 
         il.MarkLabel(isGlobalLabel);
 

--- a/Compilation/RuntimeEmitter.StringPrototypeStubs.cs
+++ b/Compilation/RuntimeEmitter.StringPrototypeStubs.cs
@@ -127,19 +127,13 @@ public partial class RuntimeEmitter
         var passThroughLabel = il.DefineLabel();
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Brtrue, passThroughLabel);
-        il.Emit(OpCodes.Ldstr, "Cannot convert undefined or null to object");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "Cannot convert undefined or null to object");
         il.MarkLabel(passThroughLabel);
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Isinst, runtime.UndefinedType);
         var notUndefLabel = il.DefineLabel();
         il.Emit(OpCodes.Brfalse, notUndefLabel);
-        il.Emit(OpCodes.Ldstr, "Cannot convert undefined or null to object");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "Cannot convert undefined or null to object");
         il.MarkLabel(notUndefLabel);
         // Delegate to ObjectProtoToString for the actual conversion.
         il.Emit(OpCodes.Ldarg_0);
@@ -167,19 +161,13 @@ public partial class RuntimeEmitter
         var passThroughLabel = il.DefineLabel();
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Brtrue, passThroughLabel);
-        il.Emit(OpCodes.Ldstr, "Cannot convert undefined or null to object");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "Cannot convert undefined or null to object");
         il.MarkLabel(passThroughLabel);
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Isinst, runtime.UndefinedType);
         var notUndefLabel = il.DefineLabel();
         il.Emit(OpCodes.Brfalse, notUndefLabel);
-        il.Emit(OpCodes.Ldstr, "Cannot convert undefined or null to object");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "Cannot convert undefined or null to object");
         il.MarkLabel(notUndefLabel);
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ret);
@@ -532,10 +520,7 @@ public partial class RuntimeEmitter
 
         // Other receivers — TypeError per spec. Borrowed-method calls of the
         // form `String.prototype.toString.call(42)` rely on this throw.
-        il.Emit(OpCodes.Ldstr, "String.prototype.toString requires that 'this' be a String");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "String.prototype.toString requires that 'this' be a String");
 
         return method;
     }
@@ -558,20 +543,14 @@ public partial class RuntimeEmitter
             var notNullLabel = il.DefineLabel();
             il.Emit(OpCodes.Ldarg_0);
             il.Emit(OpCodes.Brtrue, notNullLabel);
-            il.Emit(OpCodes.Ldstr, "Cannot convert undefined or null to object");
-            il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-            il.Emit(OpCodes.Call, runtime.CreateException);
-            il.Emit(OpCodes.Throw);
+            GuestErrorEmitter.ThrowTypeError(il, runtime, "Cannot convert undefined or null to object");
             il.MarkLabel(notNullLabel);
 
             var notUndefLabel = il.DefineLabel();
             il.Emit(OpCodes.Ldarg_0);
             il.Emit(OpCodes.Isinst, runtime.UndefinedType);
             il.Emit(OpCodes.Brfalse, notUndefLabel);
-            il.Emit(OpCodes.Ldstr, "Cannot convert undefined or null to object");
-            il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-            il.Emit(OpCodes.Call, runtime.CreateException);
-            il.Emit(OpCodes.Throw);
+            GuestErrorEmitter.ThrowTypeError(il, runtime, "Cannot convert undefined or null to object");
             il.MarkLabel(notUndefLabel);
 
             // Coerce via $Runtime.ToJsString — JS-spec ToString protocol so
@@ -621,20 +600,14 @@ public partial class RuntimeEmitter
             var notNullLabel = il.DefineLabel();
             il.Emit(OpCodes.Ldarg_0);
             il.Emit(OpCodes.Brtrue, notNullLabel);
-            il.Emit(OpCodes.Ldstr, "Cannot convert undefined or null to object");
-            il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-            il.Emit(OpCodes.Call, runtime.CreateException);
-            il.Emit(OpCodes.Throw);
+            GuestErrorEmitter.ThrowTypeError(il, runtime, "Cannot convert undefined or null to object");
             il.MarkLabel(notNullLabel);
 
             var notUndefLabel = il.DefineLabel();
             il.Emit(OpCodes.Ldarg_0);
             il.Emit(OpCodes.Isinst, runtime.UndefinedType);
             il.Emit(OpCodes.Brfalse, notUndefLabel);
-            il.Emit(OpCodes.Ldstr, "Cannot convert undefined or null to object");
-            il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-            il.Emit(OpCodes.Call, runtime.CreateException);
-            il.Emit(OpCodes.Throw);
+            GuestErrorEmitter.ThrowTypeError(il, runtime, "Cannot convert undefined or null to object");
             il.MarkLabel(notUndefLabel);
 
             il.Emit(OpCodes.Ldarg_0);

--- a/Compilation/RuntimeEmitter.Strings.cs
+++ b/Compilation/RuntimeEmitter.Strings.cs
@@ -584,9 +584,7 @@ public partial class RuntimeEmitter
             il.Emit(OpCodes.Isinst, runtime.TSRegExpType);
             il.Emit(OpCodes.Brfalse, notRegExpLabel);
             il.Emit(OpCodes.Ldstr, "First argument to String.prototype." + jsMethodName + " must not be a regular expression");
-            il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-            il.Emit(OpCodes.Call, runtime.CreateException);
-            il.Emit(OpCodes.Throw);
+            GuestErrorEmitter.ThrowErrorFromStack(il, runtime, runtime.TSTypeErrorCtor);
             il.MarkLabel(notRegExpLabel);
         }
 
@@ -904,10 +902,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Br, nonNegLabel);
 
         il.MarkLabel(throwRangeLabel);
-        il.Emit(OpCodes.Ldstr, "Invalid count value");
-        il.Emit(OpCodes.Newobj, runtime.TSRangeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowRangeError(il, runtime, "Invalid count value");
 
         il.MarkLabel(nonNegLabel);
 
@@ -1722,9 +1717,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Box, _types.Double);
         il.Emit(OpCodes.Call, runtime.ToJsString);
         il.Emit(OpCodes.Call, _types.GetMethod(_types.String, "Concat", _types.String, _types.String));
-        il.Emit(OpCodes.Newobj, runtime.TSRangeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowErrorFromStack(il, runtime, runtime.TSRangeErrorCtor);
 
         il.MarkLabel(validLabel);
 
@@ -1867,10 +1860,7 @@ public partial class RuntimeEmitter
 
         // Throw RangeError
         il.MarkLabel(throwLabel);
-        il.Emit(OpCodes.Ldstr, "The normalization form should be one of NFC, NFD, NFKC, NFKD.");
-        il.Emit(OpCodes.Newobj, runtime.TSRangeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowRangeError(il, runtime, "The normalization form should be one of NFC, NFD, NFKC, NFKD.");
     }
 
     private void EmitStringLocaleCompare(TypeBuilder typeBuilder, EmittedRuntime runtime)

--- a/Compilation/RuntimeEmitter.TSNetBlockList.cs
+++ b/Compilation/RuntimeEmitter.TSNetBlockList.cs
@@ -771,9 +771,7 @@ public partial class RuntimeEmitter
     private void EmitBlockListThrow(ILGenerator il, EmittedRuntime runtime, string message)
     {
         il.Emit(OpCodes.Ldstr, message);
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowErrorFromStack(il, runtime, runtime.TSTypeErrorCtor);
     }
 
     /// <summary>

--- a/Compilation/RuntimeEmitter.TSProcess.cs
+++ b/Compilation/RuntimeEmitter.TSProcess.cs
@@ -1751,10 +1751,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Isinst, _types.Double);
         il.Emit(OpCodes.Brtrue, pidOk);
-        il.Emit(OpCodes.Ldstr, "The \"pid\" argument must be of type number.");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "The \"pid\" argument must be of type number.");
         il.MarkLabel(pidOk);
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Unbox_Any, _types.Double);

--- a/Compilation/RuntimeEmitter.TSRegExp.cs
+++ b/Compilation/RuntimeEmitter.TSRegExp.cs
@@ -759,10 +759,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ret);
 
         il.MarkLabel(throwLabel);
-        il.Emit(OpCodes.Ldstr, "Invalid regular expression: invalid modifier group");
-        il.Emit(OpCodes.Newobj, runtime.TSSyntaxErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowSyntaxError(il, runtime, "Invalid regular expression: invalid modifier group");
     }
 
     /// <summary>
@@ -940,10 +937,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ret);
 
         il.MarkLabel(throwLabel);
-        il.Emit(OpCodes.Ldstr, "Invalid regular expression flags");
-        il.Emit(OpCodes.Newobj, runtime.TSSyntaxErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowSyntaxError(il, runtime, "Invalid regular expression flags");
     }
 
     /// <summary>
@@ -1138,10 +1132,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ret);
 
         il.MarkLabel(throwLabel);
-        il.Emit(OpCodes.Ldstr, "Invalid regular expression: invalid Unicode-mode pattern");
-        il.Emit(OpCodes.Newobj, runtime.TSSyntaxErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowSyntaxError(il, runtime, "Invalid regular expression: invalid Unicode-mode pattern");
     }
 
     private void EmitTSRegExpCtorPattern(TypeBuilder typeBuilder, EmittedRuntime runtime)
@@ -1346,9 +1337,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloc, exLocal);
         il.Emit(OpCodes.Callvirt, typeof(Exception).GetProperty("Message")!.GetGetMethod()!);
         il.Emit(OpCodes.Call, _types.String.GetMethod("Concat", [_types.String, _types.String])!);
-        il.Emit(OpCodes.Newobj, runtime.TSSyntaxErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowErrorFromStack(il, runtime, runtime.TSSyntaxErrorCtor);
 
         il.EndExceptionBlock();
 
@@ -1655,10 +1644,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Brtrue, doWriteLabel);
 
         il.MarkLabel(throwLabel);
-        il.Emit(OpCodes.Ldstr, "Cannot assign to read only property 'lastIndex'");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "Cannot assign to read only property 'lastIndex'");
 
         il.MarkLabel(doWriteLabel);
         il.Emit(OpCodes.Ldarg_0);
@@ -2113,10 +2099,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Stloc, strLocal);
         il.Emit(OpCodes.Ldloc, strLocal);
         il.Emit(OpCodes.Brtrue, argOk);
-        il.Emit(OpCodes.Ldstr, "RegExp.escape called with a non-string argument");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "RegExp.escape called with a non-string argument");
         il.MarkLabel(argOk);
 
         // sb = new StringBuilder(); first = 1; i = 0
@@ -3415,10 +3398,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloc, rxLocal);
         var rxOkLabel = il.DefineLabel();
         il.Emit(OpCodes.Brtrue, rxOkLabel);
-        il.Emit(OpCodes.Ldstr, "RegExp.prototype[Symbol.matchAll] requires a RegExp receiver");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "RegExp.prototype[Symbol.matchAll] requires a RegExp receiver");
         il.MarkLabel(rxOkLabel);
 
         // var list = rx.MatchAll(s);  // List<object?> of full-match substrings
@@ -3496,10 +3476,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloc, rxLocal);
         var rxOkLabel = il.DefineLabel();
         il.Emit(OpCodes.Brtrue, rxOkLabel);
-        il.Emit(OpCodes.Ldstr, "RegExp.prototype[Symbol.replace] requires a RegExp receiver");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "RegExp.prototype[Symbol.replace] requires a RegExp receiver");
         il.MarkLabel(rxOkLabel);
 
         // Spec-aligned global: assembled-flags-string controls looping per
@@ -3839,9 +3816,7 @@ public partial class RuntimeEmitter
         // writable=false (data) OR getter-only (accessor) → throw TypeError.
         il.MarkLabel(throwLabel);
         il.Emit(OpCodes.Ldstr, "Cannot assign to read only property '" + propName + "'");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowErrorFromStack(il, runtime, runtime.TSTypeErrorCtor);
 
         il.MarkLabel(skipLabel);
     }
@@ -3862,10 +3837,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloc, execLocal);
         il.Emit(OpCodes.Isinst, runtime.TSFunctionType);
         il.Emit(OpCodes.Brtrue, execOkLabel);
-        il.Emit(OpCodes.Ldstr, "RegExp.prototype method called on non-RegExp without a callable exec");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "RegExp.prototype method called on non-RegExp without a callable exec");
         il.MarkLabel(execOkLabel);
 
         // result = exec.InvokeWithThis(rx, [S])
@@ -3921,10 +3893,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Br, resultOkLabel);
 
         il.MarkLabel(nonObjectLabel);
-        il.Emit(OpCodes.Ldstr, "RegExp exec returned a non-Object, non-Null value");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "RegExp exec returned a non-Object, non-Null value");
 
         il.MarkLabel(resultOkLabel);
     }
@@ -4024,10 +3993,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloc, rxLocal);
         var rxOkLabel = il.DefineLabel();
         il.Emit(OpCodes.Brtrue, rxOkLabel);
-        il.Emit(OpCodes.Ldstr, "RegExp.prototype[Symbol.split] requires a RegExp receiver");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "RegExp.prototype[Symbol.split] requires a RegExp receiver");
         il.MarkLabel(rxOkLabel);
 
         // var parts = rx.Split(s);
@@ -4234,10 +4200,7 @@ public partial class RuntimeEmitter
 
         // TypeError for primitive `this`.
         il.MarkLabel(throwLabel);
-        il.Emit(OpCodes.Ldstr, "RegExp.prototype.flags called on non-object");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "RegExp.prototype.flags called on non-object");
         return helper;
     }
 
@@ -4361,10 +4324,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Br, throwLabel);
 
         il.MarkLabel(throwLabel);
-        il.Emit(OpCodes.Ldstr, "RegExp.prototype accessor called on non-RegExp");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "RegExp.prototype accessor called on non-RegExp");
 
         il.MarkLabel(checkRegExpLabel);
     }
@@ -4404,10 +4364,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Stloc, rxLocal);
         il.Emit(OpCodes.Ldloc, rxLocal);
         il.Emit(OpCodes.Brtrue, okLabel);
-        il.Emit(OpCodes.Ldstr, "RegExp.prototype.exec called on non-RegExp");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "RegExp.prototype.exec called on non-RegExp");
         il.MarkLabel(okLabel);
 
         // s = ToString(arg1)
@@ -4441,10 +4398,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Stloc, rxLocal);
         il.Emit(OpCodes.Ldloc, rxLocal);
         il.Emit(OpCodes.Brtrue, okLabel);
-        il.Emit(OpCodes.Ldstr, "RegExp.prototype.test called on non-RegExp");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "RegExp.prototype.test called on non-RegExp");
         il.MarkLabel(okLabel);
 
         EmitArgToJsString(il, runtime, argIndex: 1, sLocal);
@@ -4487,10 +4441,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Stloc, rxLocal);
         il.Emit(OpCodes.Ldloc, rxLocal);
         il.Emit(OpCodes.Brtrue, okLabel);
-        il.Emit(OpCodes.Ldstr, "RegExp.prototype.toString called on non-RegExp");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "RegExp.prototype.toString called on non-RegExp");
         il.MarkLabel(okLabel);
 
         // return "/" + rx.Source + "/" + rx.Flags
@@ -4523,10 +4474,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldarg, argIndex);
         il.Emit(OpCodes.Isinst, runtime.TSSymbolType);
         il.Emit(OpCodes.Brfalse, notSymbolLabel);
-        il.Emit(OpCodes.Ldstr, "Cannot convert a Symbol value to a string");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "Cannot convert a Symbol value to a string");
         il.MarkLabel(notSymbolLabel);
 
         // Route through $Runtime.Stringify so user-installed toString
@@ -4616,9 +4564,7 @@ public partial class RuntimeEmitter
         // them from $RegExp's helpers despite emitting before $Runtime's
         // body is filled in.
         il.Emit(OpCodes.Ldstr, siteName + " called on non-object");
-        il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.CreateException);
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowErrorFromStack(il, runtime, runtime.TSTypeErrorCtor);
 
         il.MarkLabel(okLabel);
     }


### PR DESCRIPTION
The largest remaining item from the hygiene backlog: the 4-opcode guest-error raise tail (`Ldstr msg; Newobj TS{Type,Range,Reference,Syntax}ErrorCtor; Call CreateException; Throw`) was open-coded ~170× across the emitter files — any change to the raise idiom had to be edited everywhere, and two files had already grown local re-inventions.

## Change
New `GuestErrorEmitter` static class with `ThrowTypeError`/`ThrowRangeError`/`ThrowReferenceError`/`ThrowSyntaxError` (constant message) and `ThrowErrorFromStack` (computed message already on the stack). **159 sites across 40 files** converted via a same-identifier-anchored multiline rewrite — the pattern required the same ILGenerator identifier and the same runtime expression on all four lines, so only exact matches were touched. The two file-local helpers in `Objects.StrictShared` now delegate through it.

Deliberately **not** converted (genuinely different shapes): sites with error-code setters, non-throwing `CreateException` uses, the `ILCompiler.Classes` error-ctor lookup table, and `TSArray`'s label-dispatch throw variants.

The helper emits the identical opcode stream, so compiled output is byte-for-byte unchanged.

## Verification
- Full unit suite: **15,452/15,452 pass** — including the compiled-mode integration tests, which compile and run whole programs (a mis-converted site would surface as a wrong error type or crash)
- **Test262 interpreter baseline diff clean**
- Net **−407 lines** (204+, 611−)