### PR TITLE
refactor(compile): single-source ILEmitter/state-machine Expr.Get static dispatch (drift fix)

### DIFF
--- a/Compilation/ExpressionEmitterBase.CallHelpers.cs
+++ b/Compilation/ExpressionEmitterBase.CallHelpers.cs
@@ -1073,6 +1073,110 @@ public abstract partial class ExpressionEmitterBase
     }
 
     /// <summary>
+    /// Emits <c>module.promises.methodName()</c> (fs.promises, dns.promises,
+    /// stream.promises) via the registered "/promises" module emitter.
+    /// Shared by <see cref="TryEmitGetCalleeViaBaseClass"/> and ILEmitter's
+    /// EmitCall so the dispatch rules can't drift apart.
+    /// </summary>
+    protected bool TryEmitModulePromisesMethodCall(Expr.Get methodGet, List<Expr> arguments)
+    {
+        if (methodGet.Object is Expr.Get promisesGet &&
+            promisesGet.Name.Lexeme == "promises" &&
+            promisesGet.Object is Expr.Variable promisesModuleVar &&
+            Ctx.BuiltInModuleNamespaces != null &&
+            Ctx.BuiltInModuleNamespaces.TryGetValue(promisesModuleVar.Name.Lexeme, out var promisesModuleName) &&
+            Ctx.BuiltInModuleEmitterRegistry?.GetEmitter(promisesModuleName + "/promises") is { } promisesEmitter &&
+            promisesEmitter.TryEmitMethodCall(this, methodGet.Name.Lexeme, arguments))
+        {
+            SetStackUnknown();
+            return true;
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Emits <c>Class.staticMethod()</c> (with generic class support) and the
+    /// inherited Promise statics on Promise subclasses (#242/#309:
+    /// MyP.resolve / reject / all / … are not user-declared statics, so the
+    /// static-method lookup misses them — emit the base Promise static and
+    /// wrap the result in the subclass). Shared by
+    /// <see cref="TryEmitGetCalleeViaBaseClass"/> and ILEmitter's EmitCall;
+    /// the ILEmitter copy of this block had previously drifted and omitted
+    /// the Promise-subclass arm, so MyP.resolve(1) threw. Extra-arg boxing
+    /// goes through the <see cref="EnsureBoxedArg"/> seam (ILEmitter overrides
+    /// it with its richer EmitBoxIfNeeded).
+    /// </summary>
+    protected bool TryEmitClassStaticDispatch(Expr.Call c, Expr.Get methodGet)
+    {
+        if (methodGet.Object is not Expr.Variable classVar ||
+            !Ctx.Classes.TryGetValue(Ctx.ResolveClassName(classVar.Name.Lexeme), out var classBuilder))
+        {
+            return false;
+        }
+
+        string resolvedClassName = Ctx.ResolveClassName(classVar.Name.Lexeme);
+        if (Ctx.ClassRegistry!.TryGetCallableStaticMethod(resolvedClassName, methodGet.Name.Lexeme, classBuilder, out var callableMethod))
+        {
+            var staticMethodParams = callableMethod!.GetParameters();
+            var paramCount = staticMethodParams.Length;
+
+            // When a later argument can suspend, spill each argument to a registered, boxed
+            // object local first — emitting them directly onto the IL stack would leave the
+            // earlier args (and partial evaluation) stacked across the await/yield, which is
+            // invalid IL and loses values across the MoveNext re-entry (#439). Await-free calls
+            // (all of synchronous mode) keep the direct on-stack emission.
+            if (AnyContainsSuspension(c.Arguments))
+            {
+                var argLocals = new LocalBuilder[c.Arguments.Count];
+                for (int i = 0; i < c.Arguments.Count; i++)
+                {
+                    Type pType = i < staticMethodParams.Length ? staticMethodParams[i].ParameterType : Types.Object;
+                    argLocals[i] = i < staticMethodParams.Length
+                        ? SpillConvertedArg(c.Arguments[i], pType)
+                        : SpillBoxed(c.Arguments[i]);
+                }
+                for (int i = 0; i < c.Arguments.Count; i++)
+                {
+                    IL.Emit(OpCodes.Ldloc, argLocals[i]);
+                    EmitCoerceBoxedToType(i < staticMethodParams.Length ? staticMethodParams[i].ParameterType : Types.Object);
+                }
+            }
+            else
+            {
+                for (int i = 0; i < c.Arguments.Count; i++)
+                {
+                    EmitExpression(c.Arguments[i]);
+                    if (i < staticMethodParams.Length)
+                        EmitConversionForParameter(c.Arguments[i], staticMethodParams[i].ParameterType);
+                    else
+                        EnsureBoxedArg(c.Arguments[i]);
+                }
+            }
+
+            for (int i = c.Arguments.Count; i < paramCount; i++)
+                EmitOmittedArgument(staticMethodParams[i].ParameterType);
+
+            IL.Emit(OpCodes.Call, callableMethod);
+            SetStackUnknown();
+            return true;
+        }
+
+        // Promise subclasses (#242) inherit the Promise static side:
+        // emit the base Promise static (leaves Task<object?> on the
+        // stack), then construct the subclass around it via its executor
+        // constructor — PromiseFromExecutor adopts a raw task, so the
+        // result is a subclass-typed promise (NewPromiseCapability-lite).
+        if (methodGet.Name.Lexeme is "resolve" or "reject" or "all" or "race" or "allSettled" or "any" or "withResolvers"
+            && Ctx.ClassRegistry.IsPromiseSubclass(resolvedClassName)
+            && TryEmitDerivedPromiseStatic(resolvedClassName, classBuilder, methodGet.Name.Lexeme, c.Arguments))
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
     /// Tries to handle an Expr.Get callee via shared dispatch patterns:
     /// module.promises, class statics, Promise.then/catch/finally, type-first dispatch,
     /// fallback string/array methods, ambiguous methods.
@@ -1087,84 +1191,11 @@ public abstract partial class ExpressionEmitterBase
         if (_callHandlers.TryHandle(this, c))
             return true;
 
-        // module.promises.methodName() (fs.promises, dns.promises, stream.promises)
-        if (methodGet.Object is Expr.Get promisesGet &&
-            promisesGet.Name.Lexeme == "promises" &&
-            promisesGet.Object is Expr.Variable promisesModuleVar &&
-            Ctx.BuiltInModuleNamespaces != null &&
-            Ctx.BuiltInModuleNamespaces.TryGetValue(promisesModuleVar.Name.Lexeme, out var promisesModuleName) &&
-            Ctx.BuiltInModuleEmitterRegistry?.GetEmitter(promisesModuleName + "/promises") is { } promisesEmitter)
-        {
-            if (promisesEmitter.TryEmitMethodCall(this, methodGet.Name.Lexeme, c.Arguments))
-            {
-                SetStackUnknown();
-                return true;
-            }
-        }
+        if (TryEmitModulePromisesMethodCall(methodGet, c.Arguments))
+            return true;
 
-        // Class.staticMethod() with generic class support
-        if (methodGet.Object is Expr.Variable classVar &&
-            Ctx.Classes.TryGetValue(Ctx.ResolveClassName(classVar.Name.Lexeme), out var classBuilder))
-        {
-            string resolvedClassName = Ctx.ResolveClassName(classVar.Name.Lexeme);
-            if (Ctx.ClassRegistry!.TryGetCallableStaticMethod(resolvedClassName, methodGet.Name.Lexeme, classBuilder, out var callableMethod))
-            {
-                var staticMethodParams = callableMethod!.GetParameters();
-                var paramCount = staticMethodParams.Length;
-
-                // When a later argument can suspend, spill each argument to a registered, boxed
-                // object local first — emitting them directly onto the IL stack would leave the
-                // earlier args (and partial evaluation) stacked across the await/yield, which is
-                // invalid IL and loses values across the MoveNext re-entry (#439). Await-free calls
-                // (all of synchronous mode) keep the direct on-stack emission.
-                if (AnyContainsSuspension(c.Arguments))
-                {
-                    var argLocals = new LocalBuilder[c.Arguments.Count];
-                    for (int i = 0; i < c.Arguments.Count; i++)
-                    {
-                        Type pType = i < staticMethodParams.Length ? staticMethodParams[i].ParameterType : Types.Object;
-                        argLocals[i] = i < staticMethodParams.Length
-                            ? SpillConvertedArg(c.Arguments[i], pType)
-                            : SpillBoxed(c.Arguments[i]);
-                    }
-                    for (int i = 0; i < c.Arguments.Count; i++)
-                    {
-                        IL.Emit(OpCodes.Ldloc, argLocals[i]);
-                        EmitCoerceBoxedToType(i < staticMethodParams.Length ? staticMethodParams[i].ParameterType : Types.Object);
-                    }
-                }
-                else
-                {
-                    for (int i = 0; i < c.Arguments.Count; i++)
-                    {
-                        EmitExpression(c.Arguments[i]);
-                        if (i < staticMethodParams.Length)
-                            EmitConversionForParameter(c.Arguments[i], staticMethodParams[i].ParameterType);
-                        else
-                            EnsureBoxed();
-                    }
-                }
-
-                for (int i = c.Arguments.Count; i < paramCount; i++)
-                    EmitOmittedArgument(staticMethodParams[i].ParameterType);
-
-                IL.Emit(OpCodes.Call, callableMethod);
-                SetStackUnknown();
-                return true;
-            }
-
-            // Promise subclasses (#242) inherit the Promise static side:
-            // emit the base Promise static (leaves Task<object?> on the
-            // stack), then construct the subclass around it via its executor
-            // constructor — PromiseFromExecutor adopts a raw task, so the
-            // result is a subclass-typed promise (NewPromiseCapability-lite).
-            if (methodGet.Name.Lexeme is "resolve" or "reject" or "all" or "race" or "allSettled" or "any" or "withResolvers"
-                && Ctx.ClassRegistry.IsPromiseSubclass(resolvedClassName)
-                && TryEmitDerivedPromiseStatic(resolvedClassName, classBuilder, methodGet.Name.Lexeme, c.Arguments))
-            {
-                return true;
-            }
-        }
+        if (TryEmitClassStaticDispatch(c, methodGet))
+            return true;
 
         // Promise instance methods: promise.then/catch/finally
         string methodName = methodGet.Name.Lexeme;

--- a/Compilation/ExpressionEmitterBase.cs
+++ b/Compilation/ExpressionEmitterBase.cs
@@ -109,6 +109,17 @@ public abstract partial class ExpressionEmitterBase : IEmitterContext
 
     #region Boxing and Type Conversion Delegations
     protected void EnsureBoxed() => _helpers.EnsureBoxed();
+
+    /// <summary>
+    /// Boxes an already-evaluated call argument left on the stack. The base
+    /// boxes from tracked stack state alone (state-machine emitters alias
+    /// EmitBoxIfNeeded to EnsureBoxed); ILEmitter overrides with its richer
+    /// EmitBoxIfNeeded, which adds a TypeMap reference-type skip and a
+    /// literal fallback for when stack-type tracking misses. This seam is the
+    /// single deliberate divergence inside the shared static-dispatch helpers
+    /// — keep it explicit rather than folding either behavior into the other.
+    /// </summary>
+    protected virtual void EnsureBoxedArg(Expr arg) => EnsureBoxed();
     protected void EnsureDouble() => _helpers.EnsureDouble();
     protected void EnsureBoolean() => _helpers.EnsureBoolean();
     protected void EnsureString() => _helpers.EnsureString();

--- a/Compilation/ILEmitter.Calls.cs
+++ b/Compilation/ILEmitter.Calls.cs
@@ -162,57 +162,17 @@ public partial class ILEmitter
             if (TryEmitOptionalChainMethodCall(c))
                 return;
 
-            // module.promises.methodName() (fs.promises, dns.promises, stream.promises)
-            if (methodGet.Object is Expr.Get promisesGet &&
-                promisesGet.Name.Lexeme == "promises" &&
-                promisesGet.Object is Expr.Variable promisesModuleVar &&
-                _ctx.BuiltInModuleNamespaces != null &&
-                _ctx.BuiltInModuleNamespaces.TryGetValue(promisesModuleVar.Name.Lexeme, out var promisesModuleName) &&
-                _ctx.BuiltInModuleEmitterRegistry?.GetEmitter(promisesModuleName + "/promises") is { } promisesEmitter)
-            {
-                if (promisesEmitter.TryEmitMethodCall(this, methodGet.Name.Lexeme, c.Arguments))
-                {
-                    SetStackUnknown();
-                    return;
-                }
-            }
+            // module.promises + Class.staticMethod + inherited Promise statics:
+            // shared with TryEmitGetCalleeViaBaseClass so the dispatch rules
+            // can't drift (an earlier inline copy here omitted the
+            // Promise-subclass arm and shipped a MyP.resolve(1) crash).
+            // Extra-arg boxing stays on ILEmitter's EmitBoxIfNeeded via the
+            // EnsureBoxedArg override.
+            if (TryEmitModulePromisesMethodCall(methodGet, c.Arguments))
+                return;
 
-            // Class.staticMethod() with generic class support
-            if (methodGet.Object is Expr.Variable classVar &&
-                _ctx.Classes.TryGetValue(_ctx.ResolveClassName(classVar.Name.Lexeme), out var classBuilder))
-            {
-                string resolvedClassName = _ctx.ResolveClassName(classVar.Name.Lexeme);
-                if (_ctx.ClassRegistry!.TryGetCallableStaticMethod(resolvedClassName, methodGet.Name.Lexeme, classBuilder, out var callableMethod))
-                {
-                    var staticMethodParams = callableMethod!.GetParameters();
-                    for (int i = 0; i < c.Arguments.Count; i++)
-                    {
-                        EmitExpression(c.Arguments[i]);
-                        if (i < staticMethodParams.Length)
-                            EmitConversionForParameter(c.Arguments[i], staticMethodParams[i].ParameterType);
-                        else
-                            EmitBoxIfNeeded(c.Arguments[i]);
-                    }
-                    for (int i = c.Arguments.Count; i < staticMethodParams.Length; i++)
-                        EmitOmittedArgument(staticMethodParams[i].ParameterType);
-                    IL.Emit(OpCodes.Call, callableMethod);
-                    SetStackUnknown();
-                    return;
-                }
-
-                // Promise subclasses (#242/#309) inherit the Promise static side:
-                // MyP.resolve / MyP.reject / MyP.all etc. are not user-declared
-                // statics (so TryGetCallableStaticMethod above misses them) — emit
-                // the base Promise static and wrap the result in the subclass.
-                // Mirrors TryEmitGetCalleeViaBaseClass; the inline ILEmitter path
-                // had drifted and omitted this block, so MyP.resolve(1) threw.
-                if (methodGet.Name.Lexeme is "resolve" or "reject" or "all" or "race" or "allSettled" or "any" or "withResolvers"
-                    && _ctx.ClassRegistry.IsPromiseSubclass(resolvedClassName)
-                    && TryEmitDerivedPromiseStatic(resolvedClassName, classBuilder, methodGet.Name.Lexeme, c.Arguments))
-                {
-                    return;
-                }
-            }
+            if (TryEmitClassStaticDispatch(c, methodGet))
+                return;
 
             // Instance method dispatch (Array/String/Map/Promise/etc.)
             EmitMethodCall(methodGet, c.Arguments);

--- a/Compilation/ILEmitter.Helpers.cs
+++ b/Compilation/ILEmitter.Helpers.cs
@@ -134,6 +134,13 @@ public partial class ILEmitter
         }
     }
 
+    /// <summary>
+    /// Routes the shared static-dispatch helpers' extra-arg boxing through
+    /// EmitBoxIfNeeded so ILEmitter keeps its TypeMap/literal-aware boxing
+    /// (the base seam defaults to stack-state-only EnsureBoxed).
+    /// </summary>
+    protected override void EnsureBoxedArg(Expr arg) => EmitBoxIfNeeded(arg);
+
     public void EmitBoxIfNeeded(Expr expr)
     {
         // First, check if we already have an unboxed value type on the stack

--- a/SharpTS.Tests/SharedTests/StaticDispatchBoxingTests.cs
+++ b/SharpTS.Tests/SharedTests/StaticDispatchBoxingTests.cs
@@ -1,0 +1,73 @@
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests;
+
+/// <summary>
+/// Pins the Class.staticMethod dispatch shared between ILEmitter.EmitCall and
+/// TryEmitGetCalleeViaBaseClass (TryEmitClassStaticDispatch). The two paths
+/// had drifted before — the inline ILEmitter copy once omitted the
+/// Promise-subclass arm (MyP.resolve(1) threw), and its argument boxing used
+/// EmitBoxIfNeeded while the base used EnsureBoxed (now the EnsureBoxedArg
+/// seam). These tests exercise the dispatch with boxing-sensitive arguments
+/// from both a top-level (sync ILEmitter) and an async (state-machine base
+/// helper) call site.
+/// </summary>
+public class StaticDispatchBoxingTests
+{
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void StaticMethod_BoxedPrimitiveArgs_SyncTopLevel(ExecutionMode mode)
+    {
+        var source = """
+            class Probe {
+                static kind(v: any): string { return typeof v; }
+            }
+            console.log(Probe.kind(42));
+            console.log(Probe.kind(1 + 2));
+            console.log(Probe.kind(true));
+            console.log(Probe.kind(3 > 2));
+            console.log(Probe.kind("s"));
+            """;
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("number\nnumber\nboolean\nboolean\nstring\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void StaticMethod_BoxedPrimitiveArgs_InsideAsync(ExecutionMode mode)
+    {
+        var source = """
+            class Probe {
+                static kind(v: any): string { return typeof v; }
+            }
+            async function go(): Promise<void> {
+                console.log(Probe.kind(42));
+                console.log(Probe.kind(1 + 2));
+                console.log(Probe.kind(true));
+                const x: number = await Promise.resolve(5);
+                console.log(Probe.kind(x * 2));
+            }
+            go();
+            """;
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("number\nnumber\nboolean\nnumber\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void PromiseSubclassStatic_InsideAsync(ExecutionMode mode)
+    {
+        var source = """
+            class MyP<T> extends Promise<T> {}
+            async function go(): Promise<void> {
+                const v = await MyP.resolve(11);
+                console.log("got", v);
+                console.log(MyP.resolve(1) instanceof MyP);
+            }
+            go();
+            """;
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("got 11\ntrue\n", output);
+    }
+}


### PR DESCRIPTION
Round 8a: closes the highest-risk item left from the July audits — the actively-diverging duplicate of the Expr.Get static-dispatch blocks.

## Problem

`ILEmitter.EmitCall` re-inlined the `module.promises.method()` and `Class.staticMethod()` / inherited-Promise-static dispatch that `TryEmitGetCalleeViaBaseClass` also implements. The copies had already drifted twice:
- an earlier drift omitted the Promise-subclass arm and shipped a `MyP.resolve(1)` crash (the code carries a comment admitting this);
- since then, the base copy gained the #439 await-safe argument spill the inline copy lacks, and the two boxed extra args differently (`EmitBoxIfNeeded` vs `EnsureBoxed`).

## Change

- Extracted `TryEmitModulePromisesMethodCall` + `TryEmitClassStaticDispatch` into `ExpressionEmitterBase.CallHelpers`; both `TryEmitGetCalleeViaBaseClass` and `ILEmitter.EmitCall` now route through them.
- The boxing divergence is now an explicit, documented seam: `protected virtual EnsureBoxedArg(Expr)` defaults to stack-state `EnsureBoxed()` (state-machine behavior unchanged); ILEmitter overrides it with its richer TypeMap/literal-aware `EmitBoxIfNeeded` (its behavior unchanged). **Both paths emit their exact prior IL** — this is a dedup, not a behavior change.
- The suspension-spill branch is unreachable from ILEmitter (sync bodies contain no await/yield), so sharing it is inert there.

## Tests

- New `StaticDispatchBoxingTests` (3 theories × interpreter/compiled): boxing-sensitive static args from a sync top-level call site (ILEmitter path), from inside an async function (state-machine path), and Promise-subclass statics from async code.
- Existing `PromiseSubclassTests.ExtendsPromise_TopLevelStaticThen` already pins the historical `MyP.resolve(1)` regression.
- Full suite: **15458 passed / 0 failed**. EmitterSyncTests pass (no allowlist changes needed — the new virtual lives on the base, and only ILEmitter overrides it).