### PR TITLE
refactor(compile): single-source the MethodInfo-load IL idiom (EmitLoadMethodInfo)

### DIFF
--- a/Compilation/AsyncArrowMoveNextEmitter.ArrowFunctions.cs
+++ b/Compilation/AsyncArrowMoveNextEmitter.ArrowFunctions.cs
@@ -65,9 +65,7 @@ public partial class AsyncArrowMoveNextEmitter
         if (_ctx.DisplayClassFields == null || !_ctx.DisplayClassFields.TryGetValue(af, out var fieldMap))
         {
             // No fields to populate, just create TSFunction
-            _il.Emit(OpCodes.Ldtoken, method);
-            _il.Emit(OpCodes.Call, Types.MethodBaseGetMethodFromHandle);
-            _il.Emit(OpCodes.Castclass, typeof(MethodInfo));
+            Types.EmitLoadMethodInfoViaHandle(_il, method);
             _il.Emit(OpCodes.Newobj, _ctx.Runtime!.TSFunctionCtor);
             SetStackUnknown();
             return;
@@ -91,9 +89,7 @@ public partial class AsyncArrowMoveNextEmitter
 
         // Create TSFunction: new TSFunction(displayInstance, method)
         // Stack has: displayInstance
-        _il.Emit(OpCodes.Ldtoken, method);
-        _il.Emit(OpCodes.Call, Types.MethodBaseGetMethodFromHandle);
-        _il.Emit(OpCodes.Castclass, typeof(MethodInfo));
+        Types.EmitLoadMethodInfoViaHandle(_il, method);
         _il.Emit(OpCodes.Newobj, _ctx.Runtime!.TSFunctionCtor);
         SetStackUnknown();
     }
@@ -102,9 +98,7 @@ public partial class AsyncArrowMoveNextEmitter
     {
         // Create TSFunction for static method: new TSFunction(null, method)
         _il.Emit(OpCodes.Ldnull);
-        _il.Emit(OpCodes.Ldtoken, method);
-        _il.Emit(OpCodes.Call, Types.MethodBaseGetMethodFromHandle);
-        _il.Emit(OpCodes.Castclass, typeof(MethodInfo));
+        Types.EmitLoadMethodInfoViaHandle(_il, method);
         _il.Emit(OpCodes.Newobj, _ctx!.Runtime!.TSFunctionCtor);
         SetStackUnknown();
     }
@@ -173,9 +167,7 @@ public partial class AsyncArrowMoveNextEmitter
                 _il.Emit(OpCodes.Ldnull);
             }
 
-            _il.Emit(OpCodes.Ldtoken, nestedBuilder.StubMethod);
-            _il.Emit(OpCodes.Call, Types.MethodBaseGetMethodFromHandle);
-            _il.Emit(OpCodes.Castclass, typeof(MethodInfo));
+            Types.EmitLoadMethodInfoViaHandle(_il, nestedBuilder.StubMethod);
             _il.Emit(OpCodes.Newobj, _ctx!.Runtime!.TSFunctionCtor);
             SetStackUnknown();
             return;
@@ -196,9 +188,7 @@ public partial class AsyncArrowMoveNextEmitter
         }
 
         // Load the stub method for the nested arrow
-        _il.Emit(OpCodes.Ldtoken, nestedBuilder.StubMethod);
-        _il.Emit(OpCodes.Call, Types.MethodBaseGetMethodFromHandle);
-        _il.Emit(OpCodes.Castclass, typeof(MethodInfo));
+        Types.EmitLoadMethodInfoViaHandle(_il, nestedBuilder.StubMethod);
 
         // Create TSFunction(target: self boxed, method: stub)
         _il.Emit(OpCodes.Newobj, _ctx!.Runtime!.TSFunctionCtor);

--- a/Compilation/AsyncArrowMoveNextEmitter.Variables.cs
+++ b/Compilation/AsyncArrowMoveNextEmitter.Variables.cs
@@ -70,9 +70,7 @@ public partial class AsyncArrowMoveNextEmitter
         if (_ctx?.Functions.TryGetValue(_ctx.ResolveFunctionName(name), out var funcMethod) == true)
         {
             _il.Emit(OpCodes.Ldnull);
-            _il.Emit(OpCodes.Ldtoken, funcMethod);
-            _il.Emit(OpCodes.Call, Types.MethodBaseGetMethodFromHandle);
-            _il.Emit(OpCodes.Castclass, typeof(MethodInfo));
+            Types.EmitLoadMethodInfoViaHandle(_il, funcMethod);
             _il.Emit(OpCodes.Newobj, _ctx.Runtime!.TSFunctionCtor);
             SetStackUnknown();
             return;

--- a/Compilation/AsyncGeneratorMoveNextEmitter.Expressions.cs
+++ b/Compilation/AsyncGeneratorMoveNextEmitter.Expressions.cs
@@ -633,9 +633,7 @@ public partial class AsyncGeneratorMoveNextEmitter
 
         if (_ctx.DisplayClassFields == null || !_ctx.DisplayClassFields.TryGetValue(af, out var fieldMap))
         {
-            _il.Emit(OpCodes.Ldtoken, method);
-            _il.Emit(OpCodes.Call, Types.MethodBaseGetMethodFromHandle);
-            _il.Emit(OpCodes.Castclass, typeof(MethodInfo));
+            Types.EmitLoadMethodInfoViaHandle(_il, method);
             _il.Emit(OpCodes.Newobj, _ctx.Runtime!.TSFunctionCtor);
             SetStackUnknown();
             return;
@@ -680,9 +678,7 @@ public partial class AsyncGeneratorMoveNextEmitter
             _il.Emit(OpCodes.Stfld, field);
         }
 
-        _il.Emit(OpCodes.Ldtoken, method);
-        _il.Emit(OpCodes.Call, Types.MethodBaseGetMethodFromHandle);
-        _il.Emit(OpCodes.Castclass, typeof(MethodInfo));
+        Types.EmitLoadMethodInfoViaHandle(_il, method);
         _il.Emit(OpCodes.Newobj, _ctx.Runtime!.TSFunctionCtor);
         SetStackUnknown();
     }
@@ -690,9 +686,7 @@ public partial class AsyncGeneratorMoveNextEmitter
     private void EmitNonCapturingArrowFunction(MethodBuilder method)
     {
         _il.Emit(OpCodes.Ldnull);
-        _il.Emit(OpCodes.Ldtoken, method);
-        _il.Emit(OpCodes.Call, Types.MethodBaseGetMethodFromHandle);
-        _il.Emit(OpCodes.Castclass, typeof(MethodInfo));
+        Types.EmitLoadMethodInfoViaHandle(_il, method);
         _il.Emit(OpCodes.Newobj, _ctx!.Runtime!.TSFunctionCtor);
         SetStackUnknown();
     }

--- a/Compilation/AsyncMoveNextEmitter.ArrowFunctions.cs
+++ b/Compilation/AsyncMoveNextEmitter.ArrowFunctions.cs
@@ -53,9 +53,7 @@ public partial class AsyncMoveNextEmitter
             _il.Emit(OpCodes.Box, _builder.StateMachineType);
         }
 
-        _il.Emit(OpCodes.Ldtoken, arrowBuilder.StubMethod);
-        _il.Emit(OpCodes.Call, Types.MethodBaseGetMethodFromHandle);
-        _il.Emit(OpCodes.Castclass, typeof(MethodInfo));
+        Types.EmitLoadMethodInfoViaHandle(_il, arrowBuilder.StubMethod);
         _il.Emit(OpCodes.Newobj, _ctx!.Runtime!.TSFunctionCtor);
         SetStackUnknown();
     }
@@ -91,9 +89,7 @@ public partial class AsyncMoveNextEmitter
 
         if (_ctx.DisplayClassFields == null || !_ctx.DisplayClassFields.TryGetValue(af, out var fieldMap))
         {
-            _il.Emit(OpCodes.Ldtoken, method);
-            _il.Emit(OpCodes.Call, Types.MethodBaseGetMethodFromHandle);
-            _il.Emit(OpCodes.Castclass, typeof(MethodInfo));
+            Types.EmitLoadMethodInfoViaHandle(_il, method);
             _il.Emit(OpCodes.Newobj, _ctx.Runtime!.TSFunctionCtor);
             SetStackUnknown();
             return;
@@ -137,9 +133,7 @@ public partial class AsyncMoveNextEmitter
             _il.Emit(OpCodes.Stfld, field);
         }
 
-        _il.Emit(OpCodes.Ldtoken, method);
-        _il.Emit(OpCodes.Call, Types.MethodBaseGetMethodFromHandle);
-        _il.Emit(OpCodes.Castclass, typeof(MethodInfo));
+        Types.EmitLoadMethodInfoViaHandle(_il, method);
         _il.Emit(OpCodes.Newobj, _ctx.Runtime!.TSFunctionCtor);
         SetStackUnknown();
     }
@@ -147,11 +141,7 @@ public partial class AsyncMoveNextEmitter
     private void EmitNonCapturingArrowFunction(Expr.ArrowFunction af, MethodBuilder method)
     {
         _il.Emit(OpCodes.Ldnull);
-        _il.Emit(OpCodes.Ldtoken, method);
-        _il.Emit(OpCodes.Call, typeof(MethodBase).GetMethod(
-            "GetMethodFromHandle",
-            [typeof(RuntimeMethodHandle)])!);
-        _il.Emit(OpCodes.Castclass, typeof(MethodInfo));
+        Types.EmitLoadMethodInfoViaHandle(_il, method);
         _il.Emit(OpCodes.Newobj, _ctx!.Runtime!.TSFunctionCtor);
         SetStackUnknown();
     }

--- a/Compilation/Emitters/ArrayStaticEmitter.cs
+++ b/Compilation/Emitters/ArrayStaticEmitter.cs
@@ -174,11 +174,7 @@ public sealed class ArrayStaticEmitter : IStaticTypeEmitterStrategy
         // Spec doesn't strictly require it but propertyHelper's delete-then-
         // hasOwn round-trip depends on per-instance deletion tracking.
         var il = ctx.IL;
-        il.Emit(OpCodes.Ldtoken, info.method);
-        il.Emit(OpCodes.Ldtoken, info.method.DeclaringType!);
-        il.Emit(OpCodes.Call, ctx.Types.GetMethod(ctx.Types.MethodBase, "GetMethodFromHandle",
-            ctx.Types.RuntimeMethodHandle, ctx.Types.RuntimeTypeHandle));
-        il.Emit(OpCodes.Castclass, ctx.Types.MethodInfo);
+        ctx.Types.EmitLoadMethodInfo(il, info.method);
         il.Emit(OpCodes.Ldstr, info.jsName);
         il.Emit(OpCodes.Ldc_I4, info.jsLength);
         il.Emit(OpCodes.Call, runtime.TSFunctionGetOrCreate);

--- a/Compilation/Emitters/JSONStaticEmitter.cs
+++ b/Compilation/Emitters/JSONStaticEmitter.cs
@@ -136,11 +136,7 @@ public sealed class JSONStaticEmitter : IStaticTypeEmitterStrategy
             _ => 1,
         };
         var il = ctx.IL;
-        il.Emit(OpCodes.Ldtoken, method);
-        il.Emit(OpCodes.Ldtoken, method.DeclaringType!);
-        il.Emit(OpCodes.Call, ctx.Types.GetMethod(ctx.Types.MethodBase, "GetMethodFromHandle",
-            ctx.Types.RuntimeMethodHandle, ctx.Types.RuntimeTypeHandle));
-        il.Emit(OpCodes.Castclass, ctx.Types.MethodInfo);
+        ctx.Types.EmitLoadMethodInfo(il, method);
         il.Emit(OpCodes.Ldstr, propertyName);
         il.Emit(OpCodes.Ldc_I4, specLength);
         il.Emit(OpCodes.Call, runtime.TSFunctionGetOrCreate);

--- a/Compilation/Emitters/MathStaticEmitter.cs
+++ b/Compilation/Emitters/MathStaticEmitter.cs
@@ -480,11 +480,7 @@ public sealed class MathStaticEmitter : IStaticTypeEmitterStrategy
         // $TSFunction.GetOrCreate(MethodInfo, name, length) — cached identity
         // (Math.abs === Math.abs) so delete-and-readd round-trips on the
         // same instance.
-        il.Emit(OpCodes.Ldtoken, info.adapter);
-        il.Emit(OpCodes.Ldtoken, info.adapter.DeclaringType!);
-        il.Emit(OpCodes.Call, ctx.Types.GetMethod(ctx.Types.MethodBase, "GetMethodFromHandle",
-            ctx.Types.RuntimeMethodHandle, ctx.Types.RuntimeTypeHandle));
-        il.Emit(OpCodes.Castclass, ctx.Types.MethodInfo);
+        ctx.Types.EmitLoadMethodInfo(il, info.adapter);
         il.Emit(OpCodes.Ldstr, propertyName);
         il.Emit(OpCodes.Ldc_I4, info.len);
         il.Emit(OpCodes.Call, runtime.TSFunctionGetOrCreate);

--- a/Compilation/Emitters/Modules/StreamModuleEmitter.cs
+++ b/Compilation/Emitters/Modules/StreamModuleEmitter.cs
@@ -111,11 +111,7 @@ public sealed class StreamModuleEmitter : IBuiltInModuleEmitter
         il.Emit(OpCodes.Dup);
         il.Emit(OpCodes.Ldstr, "pipeline");
         il.Emit(OpCodes.Ldnull); // target
-        il.Emit(OpCodes.Ldtoken, ctx.Runtime!.StreamPromisePipeline);
-        var runtimeMethodHandle = ctx.Types.Resolve("System.RuntimeMethodHandle");
-        var methodBase = ctx.Types.Resolve("System.Reflection.MethodBase");
-        il.Emit(OpCodes.Call, ctx.Types.GetMethod(methodBase, "GetMethodFromHandle", runtimeMethodHandle));
-        il.Emit(OpCodes.Castclass, ctx.Types.MethodInfo);
+        ctx.Types.EmitLoadMethodInfoViaHandle(il, ctx.Runtime!.StreamPromisePipeline);
         il.Emit(OpCodes.Newobj, ctx.Runtime!.TSFunctionCtor);
         il.Emit(OpCodes.Call, addMethod);
 
@@ -123,9 +119,7 @@ public sealed class StreamModuleEmitter : IBuiltInModuleEmitter
         il.Emit(OpCodes.Dup);
         il.Emit(OpCodes.Ldstr, "finished");
         il.Emit(OpCodes.Ldnull);
-        il.Emit(OpCodes.Ldtoken, ctx.Runtime!.StreamPromiseFinished);
-        il.Emit(OpCodes.Call, ctx.Types.GetMethod(methodBase, "GetMethodFromHandle", runtimeMethodHandle));
-        il.Emit(OpCodes.Castclass, ctx.Types.MethodInfo);
+        ctx.Types.EmitLoadMethodInfoViaHandle(il, ctx.Runtime!.StreamPromiseFinished);
         il.Emit(OpCodes.Newobj, ctx.Runtime!.TSFunctionCtor);
         il.Emit(OpCodes.Call, addMethod);
 

--- a/Compilation/Emitters/NumberStaticEmitter.cs
+++ b/Compilation/Emitters/NumberStaticEmitter.cs
@@ -139,11 +139,7 @@ public sealed class NumberStaticEmitter : IStaticTypeEmitterStrategy
         // ECMA-262 §17 built-in `name` + spec `length`. `parseInt(string, radix)`
         // is the only Number static with arity 2.
         int specLength = propertyName == "parseInt" ? 2 : 1;
-        il.Emit(OpCodes.Ldtoken, method);
-        il.Emit(OpCodes.Ldtoken, method.DeclaringType!);
-        il.Emit(OpCodes.Call, ctx.Types.GetMethod(ctx.Types.MethodBase, "GetMethodFromHandle",
-            ctx.Types.RuntimeMethodHandle, ctx.Types.RuntimeTypeHandle));
-        il.Emit(OpCodes.Castclass, ctx.Types.MethodInfo);
+        ctx.Types.EmitLoadMethodInfo(il, method);
         il.Emit(OpCodes.Ldstr, propertyName);
         il.Emit(OpCodes.Ldc_I4, specLength);
         il.Emit(OpCodes.Call, runtime.TSFunctionGetOrCreate);

--- a/Compilation/Emitters/ObjectStaticEmitter.cs
+++ b/Compilation/Emitters/ObjectStaticEmitter.cs
@@ -365,11 +365,7 @@ public sealed class ObjectStaticEmitter : IStaticTypeEmitterStrategy
         // `delete fn.length` mark wouldn't survive — propertyHelper's
         // isConfigurable check fails because the second instance is fresh.
         var il = ctx.IL;
-        il.Emit(OpCodes.Ldtoken, method);
-        il.Emit(OpCodes.Ldtoken, method.DeclaringType!);
-        il.Emit(OpCodes.Call, ctx.Types.GetMethod(ctx.Types.MethodBase, "GetMethodFromHandle",
-            ctx.Types.RuntimeMethodHandle, ctx.Types.RuntimeTypeHandle));
-        il.Emit(OpCodes.Castclass, ctx.Types.MethodInfo);
+        ctx.Types.EmitLoadMethodInfo(il, method);
         il.Emit(OpCodes.Ldstr, propertyName);
         il.Emit(OpCodes.Ldc_I4, specLength);
         il.Emit(OpCodes.Call, runtime.TSFunctionGetOrCreate);

--- a/Compilation/Emitters/PromiseStaticEmitter.cs
+++ b/Compilation/Emitters/PromiseStaticEmitter.cs
@@ -145,11 +145,7 @@ public sealed class PromiseStaticEmitter : IStaticTypeEmitterStrategy
         // allSettled/any take one arg; withResolvers takes none.
         int specLength = propertyName == "withResolvers" ? 0 : 1;
         var il = ctx.IL;
-        il.Emit(OpCodes.Ldtoken, method);
-        il.Emit(OpCodes.Ldtoken, method.DeclaringType!);
-        il.Emit(OpCodes.Call, ctx.Types.GetMethod(ctx.Types.MethodBase, "GetMethodFromHandle",
-            ctx.Types.RuntimeMethodHandle, ctx.Types.RuntimeTypeHandle));
-        il.Emit(OpCodes.Castclass, ctx.Types.MethodInfo);
+        ctx.Types.EmitLoadMethodInfo(il, method);
         il.Emit(OpCodes.Ldstr, propertyName);
         il.Emit(OpCodes.Ldc_I4, specLength);
         il.Emit(OpCodes.Call, runtime.TSFunctionGetOrCreate);

--- a/Compilation/Emitters/ReflectStaticEmitter.cs
+++ b/Compilation/Emitters/ReflectStaticEmitter.cs
@@ -497,11 +497,7 @@ public sealed class ReflectStaticEmitter : IStaticTypeEmitterStrategy
                 var closureLocal = il.DeclareLocal(typeof(object));
                 il.Emit(OpCodes.Stloc, closureLocal);
                 il.Emit(OpCodes.Ldloc, closureLocal); // target for TSFunction ctor
-                il.Emit(OpCodes.Ldtoken, ctx.Runtime!.ReflectMetadataDecoratorInvoke);
-                var runtimeMethodHandle = ctx.Types.Resolve("System.RuntimeMethodHandle");
-                var methodBase = ctx.Types.Resolve("System.Reflection.MethodBase");
-                il.Emit(OpCodes.Call, ctx.Types.GetMethod(methodBase, "GetMethodFromHandle", runtimeMethodHandle));
-                il.Emit(OpCodes.Castclass, ctx.Types.MethodInfo);
+                ctx.Types.EmitLoadMethodInfoViaHandle(il, ctx.Runtime!.ReflectMetadataDecoratorInvoke);
                 il.Emit(OpCodes.Newobj, ctx.Runtime!.TSFunctionCtor);
 
                 return true;

--- a/Compilation/Emitters/RegExpStaticEmitter.cs
+++ b/Compilation/Emitters/RegExpStaticEmitter.cs
@@ -56,11 +56,7 @@ public sealed class RegExpStaticEmitter : IStaticTypeEmitterStrategy
         // ObjectStaticEmitter's Object.keys-as-value path; GetOrCreate gives the
         // wrapper stable identity across repeated reads.
         var il = emitter.IL;
-        il.Emit(OpCodes.Ldtoken, escape);
-        il.Emit(OpCodes.Ldtoken, escape.DeclaringType!);
-        il.Emit(OpCodes.Call, ctx.Types.GetMethod(ctx.Types.MethodBase, "GetMethodFromHandle",
-            ctx.Types.RuntimeMethodHandle, ctx.Types.RuntimeTypeHandle));
-        il.Emit(OpCodes.Castclass, ctx.Types.MethodInfo);
+        ctx.Types.EmitLoadMethodInfo(il, escape);
         il.Emit(OpCodes.Ldstr, "escape");
         il.Emit(OpCodes.Ldc_I4_1);
         il.Emit(OpCodes.Call, runtime!.TSFunctionGetOrCreate);

--- a/Compilation/Emitters/StringStaticEmitter.cs
+++ b/Compilation/Emitters/StringStaticEmitter.cs
@@ -141,11 +141,7 @@ public sealed class StringStaticEmitter : IStaticTypeEmitterStrategy
         // String.fromCharCode(...codeUnits) → 1; fromCodePoint(...codePoints) → 1;
         // raw(template, ...substitutions) → 1.
         var il = ctx.IL;
-        il.Emit(OpCodes.Ldtoken, method);
-        il.Emit(OpCodes.Ldtoken, method.DeclaringType!);
-        il.Emit(OpCodes.Call, ctx.Types.GetMethod(ctx.Types.MethodBase, "GetMethodFromHandle",
-            ctx.Types.RuntimeMethodHandle, ctx.Types.RuntimeTypeHandle));
-        il.Emit(OpCodes.Castclass, ctx.Types.MethodInfo);
+        ctx.Types.EmitLoadMethodInfo(il, method);
         il.Emit(OpCodes.Ldstr, propertyName);
         il.Emit(OpCodes.Ldc_I4_1);
         il.Emit(OpCodes.Call, runtime.TSFunctionGetOrCreate);

--- a/Compilation/Emitters/SymbolStaticEmitter.cs
+++ b/Compilation/Emitters/SymbolStaticEmitter.cs
@@ -131,11 +131,7 @@ public sealed class SymbolStaticEmitter : IStaticTypeEmitterStrategy
             {
                 // Symbol.for(key) — spec length 1. Identity via GetOrCreate.
                 var runtime = ctx.Runtime!;
-                il.Emit(OpCodes.Ldtoken, runtime.SymbolFor);
-                il.Emit(OpCodes.Ldtoken, runtime.SymbolFor.DeclaringType!);
-                il.Emit(OpCodes.Call, ctx.Types.GetMethod(ctx.Types.MethodBase, "GetMethodFromHandle",
-                    ctx.Types.RuntimeMethodHandle, ctx.Types.RuntimeTypeHandle));
-                il.Emit(OpCodes.Castclass, ctx.Types.MethodInfo);
+                ctx.Types.EmitLoadMethodInfo(il, runtime.SymbolFor);
                 il.Emit(OpCodes.Ldstr, "for");
                 il.Emit(OpCodes.Ldc_I4_1);
                 il.Emit(OpCodes.Call, runtime.TSFunctionGetOrCreate);
@@ -145,11 +141,7 @@ public sealed class SymbolStaticEmitter : IStaticTypeEmitterStrategy
             {
                 // Symbol.keyFor(sym) — spec length 1.
                 var runtime = ctx.Runtime!;
-                il.Emit(OpCodes.Ldtoken, runtime.SymbolKeyFor);
-                il.Emit(OpCodes.Ldtoken, runtime.SymbolKeyFor.DeclaringType!);
-                il.Emit(OpCodes.Call, ctx.Types.GetMethod(ctx.Types.MethodBase, "GetMethodFromHandle",
-                    ctx.Types.RuntimeMethodHandle, ctx.Types.RuntimeTypeHandle));
-                il.Emit(OpCodes.Castclass, ctx.Types.MethodInfo);
+                ctx.Types.EmitLoadMethodInfo(il, runtime.SymbolKeyFor);
                 il.Emit(OpCodes.Ldstr, "keyFor");
                 il.Emit(OpCodes.Ldc_I4_1);
                 il.Emit(OpCodes.Call, runtime.TSFunctionGetOrCreate);

--- a/Compilation/ExpressionEmitterBase.CommonJs.cs
+++ b/Compilation/ExpressionEmitterBase.CommonJs.cs
@@ -237,11 +237,7 @@ public abstract partial class ExpressionEmitterBase
                 if (helperMethod != null)
                 {
                     IL.Emit(OpCodes.Ldnull);
-                    IL.Emit(OpCodes.Ldtoken, helperMethod);
-                    var runtimeMethodHandle = Ctx.Types.Resolve("System.RuntimeMethodHandle");
-                    var methodBase = Ctx.Types.Resolve("System.Reflection.MethodBase");
-                    IL.Emit(OpCodes.Call, Ctx.Types.GetMethod(methodBase, "GetMethodFromHandle", runtimeMethodHandle));
-                    IL.Emit(OpCodes.Castclass, Ctx.Types.MethodInfo);
+                    Ctx.Types.EmitLoadMethodInfoViaHandle(IL, helperMethod);
                     IL.Emit(OpCodes.Newobj, Ctx.Runtime!.TSFunctionCtor);
                 }
                 else

--- a/Compilation/ExpressionEmitterBase.cs
+++ b/Compilation/ExpressionEmitterBase.cs
@@ -1635,15 +1635,12 @@ public abstract partial class ExpressionEmitterBase : IEmitterContext
         }
 
         // Non-capturing arrow: static method, null target.
+        // The helper's trailing Castclass is load-bearing here: GetMethodFromHandle
+        // returns MethodBase while $TSFunctionCtor expects MethodInfo, and without
+        // it a path leading here from a state-machine label with a different stack
+        // state trips ILVerify PathStackDepth into an InvalidProgramException.
         IL.Emit(OpCodes.Ldnull);
-        IL.Emit(OpCodes.Ldtoken, method);
-        IL.Emit(OpCodes.Call, Types.MethodBaseGetMethodFromHandle);
-        // GetMethodFromHandle returns MethodBase; $TSFunctionCtor expects MethodInfo.
-        // Without this Castclass, ILVerify rejects the stack type — the JIT has been
-        // tolerant so far, but a path leading here from a state-machine label with a
-        // different stack state trips PathStackDepth, which promotes the type error
-        // to an outright InvalidProgramException.
-        IL.Emit(OpCodes.Castclass, typeof(MethodInfo));
+        Types.EmitLoadMethodInfoViaHandle(IL, method);
         IL.Emit(OpCodes.Newobj, Ctx.Runtime!.TSFunctionCtor);
         SetStackUnknown();
     }
@@ -1758,9 +1755,7 @@ public abstract partial class ExpressionEmitterBase : IEmitterContext
             }
         }
 
-        IL.Emit(OpCodes.Ldtoken, method);
-        IL.Emit(OpCodes.Call, Types.MethodBaseGetMethodFromHandle);
-        IL.Emit(OpCodes.Castclass, typeof(MethodInfo));
+        Types.EmitLoadMethodInfoViaHandle(IL, method);
         IL.Emit(OpCodes.Newobj, Ctx.Runtime!.TSFunctionCtor);
         SetStackUnknown();
     }
@@ -1841,11 +1836,11 @@ public abstract partial class ExpressionEmitterBase : IEmitterContext
             if (Ctx.ProgramType != null)
             {
                 IL.Emit(OpCodes.Ldtoken, Ctx.ProgramType);
-                IL.Emit(OpCodes.Call, Types.GetMethod(Types.MethodBase, "GetMethodFromHandle", Types.RuntimeMethodHandle, Types.RuntimeTypeHandle));
+                IL.Emit(OpCodes.Call, Types.MethodBaseGetMethodFromHandleWithType);
             }
             else
             {
-                IL.Emit(OpCodes.Call, Types.GetMethod(Types.MethodBase, "GetMethodFromHandle", Types.RuntimeMethodHandle));
+                IL.Emit(OpCodes.Call, Types.MethodBaseGetMethodFromHandle);
             }
             IL.Emit(OpCodes.Castclass, typeof(MethodInfo));
             int arity = 0;

--- a/Compilation/ILCompiler.Classes.HasFields.cs
+++ b/Compilation/ILCompiler.Classes.HasFields.cs
@@ -354,9 +354,7 @@ public partial class ILCompiler
 
             // Get the TypeBuilder for the two-token ldtoken pattern
             var typeBuilder = _classes.Builders[className];
-            var getMethodFromHandleWithType = _types.GetMethod(
-                _types.MethodBase, "GetMethodFromHandle",
-                _types.RuntimeMethodHandle, _types.RuntimeTypeHandle);
+            var getMethodFromHandleWithType = _types.MethodBaseGetMethodFromHandleWithType;
 
             foreach (var (methodName, methodBuilder) in instanceMethods)
             {
@@ -698,9 +696,7 @@ public partial class ILCompiler
 
             // Get the TypeBuilder for the two-token ldtoken pattern
             var typeBuilder = _classExprs.Builders[classExpr];
-            var getMethodFromHandleWithType = _types.GetMethod(
-                _types.MethodBase, "GetMethodFromHandle",
-                _types.RuntimeMethodHandle, _types.RuntimeTypeHandle);
+            var getMethodFromHandleWithType = _types.MethodBaseGetMethodFromHandleWithType;
 
             foreach (var (methodName, methodBuilder) in instanceMethods)
             {

--- a/Compilation/ILCompiler.Classes.Static.cs
+++ b/Compilation/ILCompiler.Classes.Static.cs
@@ -260,8 +260,6 @@ public partial class ILCompiler
             return;
 
         var getTypeFromHandle = _types.GetMethod(_types.Type, "GetTypeFromHandle", _types.RuntimeTypeHandle);
-        var getMethodFromHandle = _types.MethodBase.GetMethod(
-            "GetMethodFromHandle", [_types.RuntimeMethodHandle, _types.RuntimeTypeHandle])!;
 
         foreach (var (accessor, method) in list)
         {
@@ -277,7 +275,7 @@ public partial class ILCompiler
 
             // getter MethodInfo (or null)
             if (isGetter)
-                EmitMethodInfoLiteral(il, method, typeBuilder, getMethodFromHandle);
+                EmitMethodInfoLiteral(il, method, typeBuilder);
             else
                 il.Emit(OpCodes.Ldnull);
 
@@ -285,7 +283,7 @@ public partial class ILCompiler
             if (isGetter)
                 il.Emit(OpCodes.Ldnull);
             else
-                EmitMethodInfoLiteral(il, method, typeBuilder, getMethodFromHandle);
+                EmitMethodInfoLiteral(il, method, typeBuilder);
 
             // isStatic
             il.Emit(accessor.IsStatic ? OpCodes.Ldc_I4_1 : OpCodes.Ldc_I4_0);
@@ -305,8 +303,6 @@ public partial class ILCompiler
             return;
 
         var getTypeFromHandle = _types.GetMethod(_types.Type, "GetTypeFromHandle", _types.RuntimeTypeHandle);
-        var getMethodFromHandle = _types.MethodBase.GetMethod(
-            "GetMethodFromHandle", [_types.RuntimeMethodHandle, _types.RuntimeTypeHandle])!;
 
         foreach (var (method, key, builder) in list)
         {
@@ -319,7 +315,7 @@ public partial class ILCompiler
             emitter.EmitBoxIfNeeded(key);
 
             // method MethodInfo
-            EmitMethodInfoLiteral(il, builder, typeBuilder, getMethodFromHandle);
+            EmitMethodInfoLiteral(il, builder, typeBuilder);
 
             // isStatic
             il.Emit(method.IsStatic ? OpCodes.Ldc_I4_1 : OpCodes.Ldc_I4_0);
@@ -328,11 +324,11 @@ public partial class ILCompiler
         }
     }
 
-    private void EmitMethodInfoLiteral(ILGenerator il, MethodBuilder method, TypeBuilder declaringType, MethodInfo getMethodFromHandle)
+    private void EmitMethodInfoLiteral(ILGenerator il, MethodBuilder method, TypeBuilder declaringType)
     {
         il.Emit(OpCodes.Ldtoken, method);
         il.Emit(OpCodes.Ldtoken, declaringType);
-        il.Emit(OpCodes.Call, getMethodFromHandle);
+        il.Emit(OpCodes.Call, _types.MethodBaseGetMethodFromHandleWithType);
         il.Emit(OpCodes.Castclass, _types.MethodInfo);
     }
 

--- a/Compilation/ILCompiler.InnerFunctions.cs
+++ b/Compilation/ILCompiler.InnerFunctions.cs
@@ -861,7 +861,7 @@ public partial class ILCompiler
             // Stack has: displayInstance
             il.Emit(OpCodes.Ldtoken, method);
             il.Emit(OpCodes.Ldtoken, displayClass);
-            il.Emit(OpCodes.Call, _types.GetMethod(_types.MethodBase, "GetMethodFromHandle", _types.RuntimeMethodHandle, _types.RuntimeTypeHandle));
+            il.Emit(OpCodes.Call, _types.MethodBaseGetMethodFromHandleWithType);
             il.Emit(OpCodes.Castclass, _types.MethodInfo);
             il.Emit(OpCodes.Newobj, _runtime.TSFunctionCtor);
         }
@@ -870,7 +870,7 @@ public partial class ILCompiler
             // Non-capturing: new TSFunction(null, staticMethod)
             il.Emit(OpCodes.Ldnull);
             il.Emit(OpCodes.Ldtoken, method);
-            il.Emit(OpCodes.Call, _types.GetMethod(_types.MethodBase, "GetMethodFromHandle", _types.RuntimeMethodHandle));
+            il.Emit(OpCodes.Call, _types.MethodBaseGetMethodFromHandle);
             il.Emit(OpCodes.Castclass, _types.MethodInfo);
             il.Emit(OpCodes.Newobj, _runtime.TSFunctionCtor);
         }

--- a/Compilation/ILEmitter.Calls.Closures.cs
+++ b/Compilation/ILEmitter.Calls.Closures.cs
@@ -144,7 +144,7 @@ public partial class ILEmitter
 
         // Load method info for the stub method
         IL.Emit(OpCodes.Ldtoken, stubMethod);
-        IL.Emit(OpCodes.Call, _ctx.Types.GetMethod(_ctx.Types.MethodBase, "GetMethodFromHandle", _ctx.Types.RuntimeMethodHandle));
+        IL.Emit(OpCodes.Call, _ctx.Types.MethodBaseGetMethodFromHandle);
         IL.Emit(OpCodes.Castclass, _ctx.Types.MethodInfo);
 
         // Create TSFunction
@@ -167,7 +167,7 @@ public partial class ILEmitter
         IL.Emit(OpCodes.Ldtoken, method);
 
         // For static methods on a non-generic type:
-        IL.Emit(OpCodes.Call, _ctx.Types.GetMethod(_ctx.Types.MethodBase, "GetMethodFromHandle", _ctx.Types.RuntimeMethodHandle));
+        IL.Emit(OpCodes.Call, _ctx.Types.MethodBaseGetMethodFromHandle);
         IL.Emit(OpCodes.Castclass, _ctx.Types.MethodInfo);
 
         // Call $TSFunction constructor
@@ -477,11 +477,11 @@ public partial class ILEmitter
                 if (_ctx.ProgramType != null)
                 {
                     IL.Emit(OpCodes.Ldtoken, _ctx.ProgramType);
-                    IL.Emit(OpCodes.Call, _ctx.Types.GetMethod(_ctx.Types.MethodBase, "GetMethodFromHandle", _ctx.Types.RuntimeMethodHandle, _ctx.Types.RuntimeTypeHandle));
+                    IL.Emit(OpCodes.Call, _ctx.Types.MethodBaseGetMethodFromHandleWithType);
                 }
                 else
                 {
-                    IL.Emit(OpCodes.Call, _ctx.Types.GetMethod(_ctx.Types.MethodBase, "GetMethodFromHandle", _ctx.Types.RuntimeMethodHandle));
+                    IL.Emit(OpCodes.Call, _ctx.Types.MethodBaseGetMethodFromHandle);
                 }
                 IL.Emit(OpCodes.Castclass, _ctx.Types.MethodInfo);
                 IL.Emit(OpCodes.Newobj, _ctx.Runtime!.TSFunctionCtor);
@@ -569,7 +569,7 @@ public partial class ILEmitter
         // Wrap: new $TSFunction(displayInstance, method)
         IL.Emit(OpCodes.Ldtoken, method);
         IL.Emit(OpCodes.Ldtoken, displayClass);
-        IL.Emit(OpCodes.Call, _ctx.Types.GetMethod(_ctx.Types.MethodBase, "GetMethodFromHandle", _ctx.Types.RuntimeMethodHandle, _ctx.Types.RuntimeTypeHandle));
+        IL.Emit(OpCodes.Call, _ctx.Types.MethodBaseGetMethodFromHandleWithType);
         IL.Emit(OpCodes.Castclass, _ctx.Types.MethodInfo);
         IL.Emit(OpCodes.Newobj, _ctx.Runtime!.TSFunctionCtor);
 

--- a/Compilation/ILEmitter.Calls.Constructors.cs
+++ b/Compilation/ILEmitter.Calls.Constructors.cs
@@ -356,11 +356,11 @@ public partial class ILEmitter
             if (_ctx.ProgramType != null)
             {
                 IL.Emit(OpCodes.Ldtoken, _ctx.ProgramType);
-                IL.Emit(OpCodes.Call, _ctx.Types.GetMethod(_ctx.Types.MethodBase, "GetMethodFromHandle", _ctx.Types.RuntimeMethodHandle, _ctx.Types.RuntimeTypeHandle));
+                IL.Emit(OpCodes.Call, _ctx.Types.MethodBaseGetMethodFromHandleWithType);
             }
             else
             {
-                IL.Emit(OpCodes.Call, _ctx.Types.GetMethod(_ctx.Types.MethodBase, "GetMethodFromHandle", _ctx.Types.RuntimeMethodHandle));
+                IL.Emit(OpCodes.Call, _ctx.Types.MethodBaseGetMethodFromHandle);
             }
             IL.Emit(OpCodes.Castclass, _ctx.Types.MethodInfo);
             int arity = 0;

--- a/Compilation/ILEmitter.Expressions.cs
+++ b/Compilation/ILEmitter.Expressions.cs
@@ -211,11 +211,11 @@ public partial class ILEmitter
             if (_ctx.ProgramType != null)
             {
                 IL.Emit(OpCodes.Ldtoken, _ctx.ProgramType);
-                IL.Emit(OpCodes.Call, _ctx.Types.GetMethod(_ctx.Types.MethodBase, "GetMethodFromHandle", _ctx.Types.RuntimeMethodHandle, _ctx.Types.RuntimeTypeHandle));
+                IL.Emit(OpCodes.Call, _ctx.Types.MethodBaseGetMethodFromHandleWithType);
             }
             else
             {
-                IL.Emit(OpCodes.Call, _ctx.Types.GetMethod(_ctx.Types.MethodBase, "GetMethodFromHandle", _ctx.Types.RuntimeMethodHandle));
+                IL.Emit(OpCodes.Call, _ctx.Types.MethodBaseGetMethodFromHandle);
             }
             IL.Emit(OpCodes.Castclass, _ctx.Types.MethodInfo);
 
@@ -248,14 +248,14 @@ public partial class ILEmitter
                 IL.Emit(OpCodes.Ldarg_0); // Load display class instance
                 IL.Emit(OpCodes.Ldtoken, innerFuncMethod);
                 IL.Emit(OpCodes.Ldtoken, innerDC!);
-                IL.Emit(OpCodes.Call, _ctx.Types.GetMethod(_ctx.Types.MethodBase, "GetMethodFromHandle", _ctx.Types.RuntimeMethodHandle, _ctx.Types.RuntimeTypeHandle));
+                IL.Emit(OpCodes.Call, _ctx.Types.MethodBaseGetMethodFromHandleWithType);
             }
             else
             {
                 // Non-capturing: TSFunction(null, staticMethod)
                 IL.Emit(OpCodes.Ldnull);
                 IL.Emit(OpCodes.Ldtoken, innerFuncMethod);
-                IL.Emit(OpCodes.Call, _ctx.Types.GetMethod(_ctx.Types.MethodBase, "GetMethodFromHandle", _ctx.Types.RuntimeMethodHandle));
+                IL.Emit(OpCodes.Call, _ctx.Types.MethodBaseGetMethodFromHandle);
             }
             IL.Emit(OpCodes.Castclass, _ctx.Types.MethodInfo);
             EmitNewobjUnknown(_ctx.Runtime!.TSFunctionCtor);

--- a/Compilation/ILEmitter.Modules.cs
+++ b/Compilation/ILEmitter.Modules.cs
@@ -659,13 +659,11 @@ public partial class ILEmitter
         if (declaringType != null)
         {
             IL.Emit(OpCodes.Ldtoken, declaringType);
-            IL.Emit(OpCodes.Call, _ctx.Types.GetMethod(_ctx.Types.MethodBase, "GetMethodFromHandle",
-                _ctx.Types.RuntimeMethodHandle, _ctx.Types.RuntimeTypeHandle));
+            IL.Emit(OpCodes.Call, _ctx.Types.MethodBaseGetMethodFromHandleWithType);
         }
         else
         {
-            IL.Emit(OpCodes.Call, _ctx.Types.GetMethod(_ctx.Types.MethodBase, "GetMethodFromHandle",
-                _ctx.Types.RuntimeMethodHandle));
+            IL.Emit(OpCodes.Call, _ctx.Types.MethodBaseGetMethodFromHandle);
         }
 
         IL.Emit(OpCodes.Castclass, _ctx.Types.MethodInfo);
@@ -923,11 +921,7 @@ public partial class ILEmitter
         if (helperMethod != null)
         {
             IL.Emit(OpCodes.Ldnull); // target (null for static methods)
-            IL.Emit(OpCodes.Ldtoken, helperMethod);
-            var runtimeMethodHandle = _ctx.Types.Resolve("System.RuntimeMethodHandle");
-            var methodBase = _ctx.Types.Resolve("System.Reflection.MethodBase");
-            IL.Emit(OpCodes.Call, _ctx.Types.GetMethod(methodBase, "GetMethodFromHandle", runtimeMethodHandle));
-            IL.Emit(OpCodes.Castclass, _ctx.Types.MethodInfo);
+            _ctx.Types.EmitLoadMethodInfoViaHandle(IL, helperMethod);
             IL.Emit(OpCodes.Newobj, _ctx.Runtime!.TSFunctionCtor);
         }
         else

--- a/Compilation/ILEmitter.Namespaces.cs
+++ b/Compilation/ILEmitter.Namespaces.cs
@@ -120,7 +120,7 @@ public partial class ILEmitter
                     // Create TSFunction(null, methodInfo)
                     IL.Emit(OpCodes.Ldnull); // target (static method)
                     IL.Emit(OpCodes.Ldtoken, methodBuilder);
-                    IL.Emit(OpCodes.Call, _ctx.Types.GetMethod(_ctx.Types.MethodBase, "GetMethodFromHandle", _ctx.Types.RuntimeMethodHandle));
+                    IL.Emit(OpCodes.Call, _ctx.Types.MethodBaseGetMethodFromHandle);
                     IL.Emit(OpCodes.Castclass, _ctx.Types.MethodInfo);
                     IL.Emit(OpCodes.Newobj, _ctx.Runtime!.TSFunctionCtor);
                     IL.Emit(OpCodes.Call, _ctx.Runtime!.TSNamespaceSet);

--- a/Compilation/RuntimeEmitter.BuiltInStaticDispatch.cs
+++ b/Compilation/RuntimeEmitter.BuiltInStaticDispatch.cs
@@ -59,10 +59,6 @@ public partial class RuntimeEmitter
         var strEquals = _types.Type.GetMethod("op_Equality", [_types.Type, _types.Type])!;
         var getTypeFromHandle = _types.Type.GetMethod("GetTypeFromHandle", [_types.RuntimeTypeHandle])!;
         var stringOpEq = _types.GetMethod(_types.String, "op_Equality", _types.String, _types.String);
-        // GetMethodFromHandle lives on MethodBase, not Type.
-        var getMethodFromHandle = _types.MethodBase.GetMethod(
-            "GetMethodFromHandle",
-            [_types.RuntimeMethodHandle, _types.RuntimeTypeHandle])!;
 
         // Emit one branch per (Type, name, runtimeMethod, specLength) tuple. Uses
         // TSFunctionGetOrCreate so the returned wrapper has stable identity:
@@ -88,10 +84,7 @@ public partial class RuntimeEmitter
 
             // Match — return TSFunctionGetOrCreate(method, name, length) so the
             // wrapper identity matches the syntactic-dispatch path.
-            il.Emit(OpCodes.Ldtoken, backingMethod);
-            il.Emit(OpCodes.Ldtoken, backingMethod.DeclaringType!);
-            il.Emit(OpCodes.Call, getMethodFromHandle);
-            il.Emit(OpCodes.Castclass, _types.MethodInfo);
+            _types.EmitLoadMethodInfo(il, backingMethod);
             il.Emit(OpCodes.Ldstr, memberName);
             il.Emit(OpCodes.Ldc_I4, specLength);
             il.Emit(OpCodes.Call, runtime.TSFunctionGetOrCreate);
@@ -135,10 +128,7 @@ public partial class RuntimeEmitter
 
             // TSFunctionGetOrCreate(MethodInfo, name, length) — identity-stable
             // wrapper (same MethodInfo key → same wrapper instance).
-            il.Emit(OpCodes.Ldtoken, backingMethod);
-            il.Emit(OpCodes.Ldtoken, backingMethod.DeclaringType!);
-            il.Emit(OpCodes.Call, getMethodFromHandle);
-            il.Emit(OpCodes.Castclass, _types.MethodInfo);
+            _types.EmitLoadMethodInfo(il, backingMethod);
             il.Emit(OpCodes.Ldstr, memberName);
             il.Emit(OpCodes.Ldc_I4, specLength);
             il.Emit(OpCodes.Call, runtime.TSFunctionGetOrCreate);

--- a/Compilation/RuntimeEmitter.BuiltinSingletonPopulate.cs
+++ b/Compilation/RuntimeEmitter.BuiltinSingletonPopulate.cs
@@ -66,8 +66,6 @@ public partial class RuntimeEmitter
         var il = method.GetILGenerator();
         var setItem = _types.GetMethod(_types.DictionaryStringObject, "set_Item",
             _types.String, _types.Object);
-        var getMethodFromHandle = _types.GetMethod(_types.MethodBase, "GetMethodFromHandle",
-            _types.RuntimeMethodHandle, _types.RuntimeTypeHandle);
 
         EmitPrototypePopulateGuard(il, singletonField);
 
@@ -80,10 +78,7 @@ public partial class RuntimeEmitter
             // $TSFunction.GetOrCreate(MethodInfo, name, length) — cached identity
             // so `m.max === Math.max` (same instance the value-form static
             // emitter hands out).
-            il.Emit(OpCodes.Ldtoken, backing);
-            il.Emit(OpCodes.Ldtoken, backing.DeclaringType!);
-            il.Emit(OpCodes.Call, getMethodFromHandle);
-            il.Emit(OpCodes.Castclass, _types.MethodInfo);
+            _types.EmitLoadMethodInfo(il, backing);
             il.Emit(OpCodes.Ldstr, jsName);
             il.Emit(OpCodes.Ldc_I4, jsLength);
             il.Emit(OpCodes.Call, runtime.TSFunctionGetOrCreate);

--- a/Compilation/RuntimeEmitter.Dns.cs
+++ b/Compilation/RuntimeEmitter.Dns.cs
@@ -653,7 +653,7 @@ public partial class RuntimeEmitter
         // return new TSFunction(null, implMethod)
         getterIl.Emit(OpCodes.Ldnull); // target (static method)
         getterIl.Emit(OpCodes.Ldtoken, implMethod);
-        getterIl.Emit(OpCodes.Call, _types.GetMethod(_types.MethodBase, "GetMethodFromHandle", _types.RuntimeMethodHandle));
+        getterIl.Emit(OpCodes.Call, _types.MethodBaseGetMethodFromHandle);
         getterIl.Emit(OpCodes.Castclass, _types.MethodInfo);
         getterIl.Emit(OpCodes.Newobj, runtime.TSFunctionCtor);
         getterIl.Emit(OpCodes.Ret);
@@ -731,7 +731,7 @@ public partial class RuntimeEmitter
         // return new TSFunction(null, implMethod)
         getterIl.Emit(OpCodes.Ldnull); // target (static method)
         getterIl.Emit(OpCodes.Ldtoken, implMethod);
-        getterIl.Emit(OpCodes.Call, _types.GetMethod(_types.MethodBase, "GetMethodFromHandle", _types.RuntimeMethodHandle));
+        getterIl.Emit(OpCodes.Call, _types.MethodBaseGetMethodFromHandle);
         getterIl.Emit(OpCodes.Castclass, _types.MethodInfo);
         getterIl.Emit(OpCodes.Newobj, runtime.TSFunctionCtor);
         getterIl.Emit(OpCodes.Ret);

--- a/Compilation/RuntimeEmitter.ErrorPrototypePopulate.cs
+++ b/Compilation/RuntimeEmitter.ErrorPrototypePopulate.cs
@@ -61,11 +61,7 @@ public partial class RuntimeEmitter
         catch { /* already named — ignore */ }
         var errToStringWrapperLocal = il.DeclareLocal(_types.Object);
         il.Emit(OpCodes.Ldnull);
-        il.Emit(OpCodes.Ldtoken, errorToStringSpec);
-        il.Emit(OpCodes.Ldtoken, errorToStringSpec.DeclaringType!);
-        il.Emit(OpCodes.Call, _types.GetMethod(_types.MethodBase, "GetMethodFromHandle",
-            _types.RuntimeMethodHandle, _types.RuntimeTypeHandle));
-        il.Emit(OpCodes.Castclass, _types.MethodInfo);
+        _types.EmitLoadMethodInfo(il, errorToStringSpec);
         il.Emit(OpCodes.Ldstr, "toString");
         il.Emit(OpCodes.Ldc_I4_0);
         il.Emit(OpCodes.Newobj, runtime.TSFunctionCtorWithCache);

--- a/Compilation/RuntimeEmitter.Functions.cs
+++ b/Compilation/RuntimeEmitter.Functions.cs
@@ -509,11 +509,7 @@ public partial class RuntimeEmitter
             il.Emit(OpCodes.Call, _types.GetMethod(_types.String, "op_Equality", _types.String, _types.String));
             il.Emit(OpCodes.Brfalse, skipLabel);
             il.Emit(OpCodes.Ldarg_0);
-            il.Emit(OpCodes.Ldtoken, helper);
-            il.Emit(OpCodes.Ldtoken, helper.DeclaringType!);
-            il.Emit(OpCodes.Call, _types.GetMethod(_types.MethodBase, "GetMethodFromHandle",
-                _types.RuntimeMethodHandle, _types.RuntimeTypeHandle));
-            il.Emit(OpCodes.Castclass, _types.MethodInfo);
+            _types.EmitLoadMethodInfo(il, helper);
             il.Emit(OpCodes.Newobj, runtime.TSFunctionCtor);
             il.Emit(OpCodes.Ret);
             il.MarkLabel(skipLabel);

--- a/Compilation/RuntimeEmitter.GlobalThis.cs
+++ b/Compilation/RuntimeEmitter.GlobalThis.cs
@@ -333,7 +333,7 @@ public partial class RuntimeEmitter
         void EmitGetOrCreateTSFn(MethodBuilder wrappedMethod, string jsName, int jsLength)
         {
             il.Emit(OpCodes.Ldtoken, wrappedMethod);
-            il.Emit(OpCodes.Call, _types.GetMethod(_types.MethodBase, "GetMethodFromHandle", _types.RuntimeMethodHandle));
+            il.Emit(OpCodes.Call, _types.MethodBaseGetMethodFromHandle);
             il.Emit(OpCodes.Castclass, _types.MethodInfo);
             il.Emit(OpCodes.Ldstr, jsName);
             il.Emit(OpCodes.Ldc_I4, jsLength);
@@ -374,7 +374,7 @@ public partial class RuntimeEmitter
         // Create and cache the TSFunction
         il.Emit(OpCodes.Ldnull); // target (static method)
         il.Emit(OpCodes.Ldtoken, wrappedMethod);
-        il.Emit(OpCodes.Call, _types.GetMethod(_types.MethodBase, "GetMethodFromHandle", _types.RuntimeMethodHandle));
+        il.Emit(OpCodes.Call, _types.MethodBaseGetMethodFromHandle);
         il.Emit(OpCodes.Castclass, _types.MethodInfo);
         il.Emit(OpCodes.Newobj, runtime.TSFunctionCtor);
         il.Emit(OpCodes.Stsfld, cachedField);

--- a/Compilation/RuntimeEmitter.Http.cs
+++ b/Compilation/RuntimeEmitter.Http.cs
@@ -3015,8 +3015,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldstr, "destroy");
         il.Emit(OpCodes.Ldnull); // target (static)
         il.Emit(OpCodes.Ldtoken, _agentDestroyMethod);
-        il.Emit(OpCodes.Call, _types.GetMethod(
-            _types.MethodBase, "GetMethodFromHandle", _types.RuntimeMethodHandle));
+        il.Emit(OpCodes.Call, _types.MethodBaseGetMethodFromHandle);
         il.Emit(OpCodes.Castclass, _types.MethodInfo);
         il.Emit(OpCodes.Newobj, runtime.TSFunctionCtor);
         il.Emit(OpCodes.Call, runtime.SetProperty);
@@ -3026,8 +3025,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldstr, "getName");
         il.Emit(OpCodes.Ldnull); // target (static)
         il.Emit(OpCodes.Ldtoken, _agentGetNameMethod);
-        il.Emit(OpCodes.Call, _types.GetMethod(
-            _types.MethodBase, "GetMethodFromHandle", _types.RuntimeMethodHandle));
+        il.Emit(OpCodes.Call, _types.MethodBaseGetMethodFromHandle);
         il.Emit(OpCodes.Castclass, _types.MethodInfo);
         il.Emit(OpCodes.Newobj, runtime.TSFunctionCtor);
         il.Emit(OpCodes.Call, runtime.SetProperty);
@@ -3218,8 +3216,7 @@ public partial class RuntimeEmitter
             var il = getterMethod.GetILGenerator();
             il.Emit(OpCodes.Ldnull); // target (static)
             il.Emit(OpCodes.Ldtoken, factoryMethod);
-            il.Emit(OpCodes.Call, _types.GetMethod(
-                _types.MethodBase, "GetMethodFromHandle", _types.RuntimeMethodHandle));
+            il.Emit(OpCodes.Call, _types.MethodBaseGetMethodFromHandle);
             il.Emit(OpCodes.Castclass, _types.MethodInfo);
             il.Emit(OpCodes.Newobj, runtime.TSFunctionCtor);
             il.Emit(OpCodes.Ret);

--- a/Compilation/RuntimeEmitter.NamespaceSingletons.cs
+++ b/Compilation/RuntimeEmitter.NamespaceSingletons.cs
@@ -108,7 +108,7 @@ public partial class RuntimeEmitter
             il.Emit(OpCodes.Ldloc, dictLocal);
             il.Emit(OpCodes.Ldstr, jsName);
             il.Emit(OpCodes.Ldtoken, helper);
-            il.Emit(OpCodes.Call, _types.GetMethod(_types.MethodBase, "GetMethodFromHandle", _types.RuntimeMethodHandle));
+            il.Emit(OpCodes.Call, _types.MethodBaseGetMethodFromHandle);
             il.Emit(OpCodes.Castclass, _types.MethodInfo);
             il.Emit(OpCodes.Ldstr, jsName);
             il.Emit(OpCodes.Ldc_I4, jsLength);

--- a/Compilation/RuntimeEmitter.Objects.Descriptors.cs
+++ b/Compilation/RuntimeEmitter.Objects.Descriptors.cs
@@ -1438,11 +1438,7 @@ public partial class RuntimeEmitter
             il.Emit(OpCodes.Stloc, resultDictLocal);
             il.Emit(OpCodes.Ldloc, resultDictLocal);
             il.Emit(OpCodes.Ldstr, "value");
-            il.Emit(OpCodes.Ldtoken, targetMethod);
-            il.Emit(OpCodes.Ldtoken, targetMethod.DeclaringType!);
-            il.Emit(OpCodes.Call, _types.GetMethod(_types.MethodBase, "GetMethodFromHandle",
-                _types.RuntimeMethodHandle, _types.RuntimeTypeHandle));
-            il.Emit(OpCodes.Castclass, _types.MethodInfo);
+            _types.EmitLoadMethodInfo(il, targetMethod);
             il.Emit(OpCodes.Ldstr, n);
             il.Emit(OpCodes.Ldc_I4, specLength);
             il.Emit(OpCodes.Call, runtime.TSFunctionGetOrCreate);
@@ -1576,11 +1572,7 @@ public partial class RuntimeEmitter
             {
                 // Emit TSFunction.GetOrCreate(methodInfo, name, length) so the
                 // descriptor's .value === Number.X (same cached wrapper).
-                il.Emit(OpCodes.Ldtoken, methodTarget);
-                il.Emit(OpCodes.Ldtoken, methodTarget.DeclaringType!);
-                il.Emit(OpCodes.Call, _types.GetMethod(_types.MethodBase, "GetMethodFromHandle",
-                    _types.RuntimeMethodHandle, _types.RuntimeTypeHandle));
-                il.Emit(OpCodes.Castclass, _types.MethodInfo);
+                _types.EmitLoadMethodInfo(il, methodTarget);
                 il.Emit(OpCodes.Ldstr, n);
                 il.Emit(OpCodes.Ldc_I4, methodArity);
                 il.Emit(OpCodes.Call, runtime.TSFunctionGetOrCreate);
@@ -1840,11 +1832,7 @@ public partial class RuntimeEmitter
                 // returns the SAME instance as the static dispatch path
                 // (MathStaticEmitter uses TSFunctionGetOrCreate too), so
                 // `desc.value === Math.X` holds in user code.
-                il.Emit(OpCodes.Ldtoken, methodTarget);
-                il.Emit(OpCodes.Ldtoken, methodTarget.DeclaringType!);
-                il.Emit(OpCodes.Call, _types.GetMethod(_types.MethodBase, "GetMethodFromHandle",
-                    _types.RuntimeMethodHandle, _types.RuntimeTypeHandle));
-                il.Emit(OpCodes.Castclass, _types.MethodInfo);
+                _types.EmitLoadMethodInfo(il, methodTarget);
                 il.Emit(OpCodes.Ldstr, n);
                 il.Emit(OpCodes.Ldc_I4, methodArity);
                 il.Emit(OpCodes.Call, runtime.TSFunctionGetOrCreate);

--- a/Compilation/RuntimeEmitter.Objects.GetPropertyBranches.cs
+++ b/Compilation/RuntimeEmitter.Objects.GetPropertyBranches.cs
@@ -369,7 +369,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldarg_0);  // target (the buffer)
         il.Emit(OpCodes.Ldtoken, runtime.TSBufferToString);
         il.Emit(OpCodes.Ldtoken, runtime.TSBufferType);
-        il.Emit(OpCodes.Call, _types.GetMethod(_types.MethodBase, "GetMethodFromHandle", _types.RuntimeMethodHandle, _types.RuntimeTypeHandle));
+        il.Emit(OpCodes.Call, _types.MethodBaseGetMethodFromHandleWithType);
         il.Emit(OpCodes.Castclass, _types.MethodInfo);
         il.Emit(OpCodes.Newobj, runtime.TSFunctionCtor);
         il.Emit(OpCodes.Ret);
@@ -414,7 +414,7 @@ public partial class RuntimeEmitter
             il.Emit(OpCodes.Ldarg_0);
             il.Emit(OpCodes.Ldtoken, helper);
             il.Emit(OpCodes.Ldtoken, runtime.StatsType);
-            il.Emit(OpCodes.Call, _types.GetMethod(_types.MethodBase, "GetMethodFromHandle", _types.RuntimeMethodHandle, _types.RuntimeTypeHandle));
+            il.Emit(OpCodes.Call, _types.MethodBaseGetMethodFromHandleWithType);
             il.Emit(OpCodes.Castclass, _types.MethodInfo);
             il.Emit(OpCodes.Newobj, runtime.TSFunctionCtor);
             il.Emit(OpCodes.Ret);
@@ -531,11 +531,7 @@ public partial class RuntimeEmitter
             il.Emit(OpCodes.Call, _types.GetMethod(_types.String, "op_Equality", _types.String, _types.String));
             il.Emit(OpCodes.Brfalse, skip);
             il.Emit(OpCodes.Ldarg_0);
-            il.Emit(OpCodes.Ldtoken, helper);
-            il.Emit(OpCodes.Ldtoken, helper.DeclaringType!);
-            il.Emit(OpCodes.Call, _types.GetMethod(_types.MethodBase, "GetMethodFromHandle",
-                _types.RuntimeMethodHandle, _types.RuntimeTypeHandle));
-            il.Emit(OpCodes.Castclass, _types.MethodInfo);
+            _types.EmitLoadMethodInfo(il, helper);
             il.Emit(OpCodes.Newobj, runtime.TSFunctionCtor);
             il.Emit(OpCodes.Ret);
             il.MarkLabel(skip);
@@ -864,11 +860,7 @@ public partial class RuntimeEmitter
             il.Emit(OpCodes.Call, _types.GetMethod(_types.String, "op_Equality", _types.String, _types.String));
             il.Emit(OpCodes.Brfalse, skip);
             il.Emit(OpCodes.Ldnull);
-            il.Emit(OpCodes.Ldtoken, helper);
-            il.Emit(OpCodes.Ldtoken, helper.DeclaringType!);
-            il.Emit(OpCodes.Call, _types.GetMethod(_types.MethodBase, "GetMethodFromHandle",
-                _types.RuntimeMethodHandle, _types.RuntimeTypeHandle));
-            il.Emit(OpCodes.Castclass, _types.MethodInfo);
+            _types.EmitLoadMethodInfo(il, helper);
             il.Emit(OpCodes.Ldstr, jsName);
             il.Emit(OpCodes.Ldc_I4, jsLength);
             il.Emit(OpCodes.Newobj, runtime.TSFunctionCtorWithCache);
@@ -941,11 +933,7 @@ public partial class RuntimeEmitter
             void EmitSignalMethodWrapper(MethodBuilder helper, string jsName, int jsLength)
             {
                 il.Emit(OpCodes.Ldnull);
-                il.Emit(OpCodes.Ldtoken, helper);
-                il.Emit(OpCodes.Ldtoken, helper.DeclaringType!);
-                il.Emit(OpCodes.Call, _types.GetMethod(_types.MethodBase, "GetMethodFromHandle",
-                    _types.RuntimeMethodHandle, _types.RuntimeTypeHandle));
-                il.Emit(OpCodes.Castclass, _types.MethodInfo);
+                _types.EmitLoadMethodInfo(il, helper);
                 il.Emit(OpCodes.Ldstr, jsName);
                 il.Emit(OpCodes.Ldc_I4, jsLength);
                 il.Emit(OpCodes.Newobj, runtime.TSFunctionCtorWithCache);

--- a/Compilation/RuntimeEmitter.Objects.Index.cs
+++ b/Compilation/RuntimeEmitter.Objects.Index.cs
@@ -1649,11 +1649,7 @@ public partial class RuntimeEmitter
 
         // return new $TSFunction(rx, MethodInfo of helper)
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Ldtoken, helperMethod);
-        il.Emit(OpCodes.Ldtoken, helperMethod.DeclaringType!);
-        il.Emit(OpCodes.Call, _types.GetMethod(_types.MethodBase, "GetMethodFromHandle",
-            _types.RuntimeMethodHandle, _types.RuntimeTypeHandle));
-        il.Emit(OpCodes.Castclass, _types.MethodInfo);
+        _types.EmitLoadMethodInfo(il, helperMethod);
         il.Emit(OpCodes.Newobj, runtime.TSFunctionCtor);
         il.Emit(OpCodes.Ret);
 

--- a/Compilation/RuntimeEmitter.Objects.Invocation.cs
+++ b/Compilation/RuntimeEmitter.Objects.Invocation.cs
@@ -89,7 +89,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ldtoken, _types.GetMethod(_types.ListOfObject, "Add", _types.Object));
         il.Emit(OpCodes.Ldtoken, _types.ListOfObject);
-        il.Emit(OpCodes.Call, _types.GetMethod(_types.MethodBase, "GetMethodFromHandle", _types.RuntimeMethodHandle, _types.RuntimeTypeHandle));
+        il.Emit(OpCodes.Call, _types.MethodBaseGetMethodFromHandleWithType);
         il.Emit(OpCodes.Castclass, _types.MethodInfo);
         il.Emit(OpCodes.Newobj, runtime.TSFunctionCtor);
         il.Emit(OpCodes.Ret);

--- a/Compilation/RuntimeEmitter.Objects.Properties.cs
+++ b/Compilation/RuntimeEmitter.Objects.Properties.cs
@@ -1419,11 +1419,7 @@ public partial class RuntimeEmitter
             il.Emit(OpCodes.Call, _types.GetMethod(_types.String, "op_Equality", _types.String, _types.String));
             il.Emit(OpCodes.Brfalse, notHasOwnLabel);
             il.Emit(OpCodes.Ldarg_0);
-            il.Emit(OpCodes.Ldtoken, runtime.HasOwnPropertyHelperMethod);
-            il.Emit(OpCodes.Ldtoken, runtime.HasOwnPropertyHelperMethod.DeclaringType!);
-            il.Emit(OpCodes.Call, _types.GetMethod(_types.MethodBase, "GetMethodFromHandle",
-                _types.RuntimeMethodHandle, _types.RuntimeTypeHandle));
-            il.Emit(OpCodes.Castclass, _types.MethodInfo);
+            _types.EmitLoadMethodInfo(il, runtime.HasOwnPropertyHelperMethod);
             il.Emit(OpCodes.Newobj, runtime.TSFunctionCtor);
             il.Emit(OpCodes.Ret);
             il.MarkLabel(notHasOwnLabel);

--- a/Compilation/RuntimeEmitter.ProcessHelpers.cs
+++ b/Compilation/RuntimeEmitter.ProcessHelpers.cs
@@ -744,8 +744,7 @@ public partial class RuntimeEmitter
             // Create $TSFunction wrapping the write impl method
             il.Emit(OpCodes.Ldnull); // target (static method, no instance)
             il.Emit(OpCodes.Ldtoken, writeImpl);
-            il.Emit(OpCodes.Call, _types.GetMethod(
-                _types.MethodBase, "GetMethodFromHandle", _types.RuntimeMethodHandle));
+            il.Emit(OpCodes.Call, _types.MethodBaseGetMethodFromHandle);
             il.Emit(OpCodes.Castclass, _types.MethodInfo);
             il.Emit(OpCodes.Newobj, runtime.TSFunctionCtor);
 
@@ -886,7 +885,7 @@ public partial class RuntimeEmitter
         // Create new TSFunction(null, implMethod)
         il.Emit(OpCodes.Ldnull); // target (static method)
         il.Emit(OpCodes.Ldtoken, implMethod);
-        il.Emit(OpCodes.Call, _types.GetMethod(_types.MethodBase, "GetMethodFromHandle", _types.RuntimeMethodHandle));
+        il.Emit(OpCodes.Call, _types.MethodBaseGetMethodFromHandle);
         il.Emit(OpCodes.Castclass, _types.MethodInfo);
         il.Emit(OpCodes.Newobj, runtime.TSFunctionCtor);
         il.Emit(OpCodes.Ret);

--- a/Compilation/RuntimeEmitter.PrototypePopulateShared.cs
+++ b/Compilation/RuntimeEmitter.PrototypePopulateShared.cs
@@ -95,11 +95,7 @@ public partial class RuntimeEmitter
         }
         var wrapperLocal = il.DeclareLocal(_types.Object);
         il.Emit(OpCodes.Ldnull); // target — helpers take the receiver as __this
-        il.Emit(OpCodes.Ldtoken, helper);
-        il.Emit(OpCodes.Ldtoken, helper.DeclaringType!);
-        il.Emit(OpCodes.Call, _types.GetMethod(_types.MethodBase, "GetMethodFromHandle",
-            _types.RuntimeMethodHandle, _types.RuntimeTypeHandle));
-        il.Emit(OpCodes.Castclass, _types.MethodInfo);
+        _types.EmitLoadMethodInfo(il, helper);
         il.Emit(OpCodes.Ldstr, jsName);
         il.Emit(OpCodes.Ldc_I4, jsLength);
         il.Emit(OpCodes.Newobj, runtime.TSFunctionCtorWithCache);

--- a/Compilation/RuntimeEmitter.RegExpPrototypePopulate.cs
+++ b/Compilation/RuntimeEmitter.RegExpPrototypePopulate.cs
@@ -73,11 +73,7 @@ public partial class RuntimeEmitter
             il.Emit(OpCodes.Ldloc, symbolDictLocal);
             il.Emit(OpCodes.Ldsfld, symbolField);
             il.Emit(OpCodes.Ldnull);                                // target
-            il.Emit(OpCodes.Ldtoken, helper);
-            il.Emit(OpCodes.Ldtoken, helper.DeclaringType!);
-            il.Emit(OpCodes.Call, _types.GetMethod(_types.MethodBase, "GetMethodFromHandle",
-                _types.RuntimeMethodHandle, _types.RuntimeTypeHandle));
-            il.Emit(OpCodes.Castclass, _types.MethodInfo);
+            _types.EmitLoadMethodInfo(il, helper);
             il.Emit(OpCodes.Ldstr, jsName);
             il.Emit(OpCodes.Ldc_I4, jsLength);
             il.Emit(OpCodes.Newobj, runtime.TSFunctionCtorWithCache);
@@ -105,11 +101,7 @@ public partial class RuntimeEmitter
         {
             // var fn = new $TSFunction(null, helper.MethodInfo, jsName, jsLength);
             il.Emit(OpCodes.Ldnull);
-            il.Emit(OpCodes.Ldtoken, helper);
-            il.Emit(OpCodes.Ldtoken, helper.DeclaringType!);
-            il.Emit(OpCodes.Call, _types.GetMethod(_types.MethodBase, "GetMethodFromHandle",
-                _types.RuntimeMethodHandle, _types.RuntimeTypeHandle));
-            il.Emit(OpCodes.Castclass, _types.MethodInfo);
+            _types.EmitLoadMethodInfo(il, helper);
             il.Emit(OpCodes.Ldstr, "get " + jsName);
             il.Emit(OpCodes.Ldc_I4, jsLength);
             il.Emit(OpCodes.Newobj, runtime.TSFunctionCtorWithCache);
@@ -157,11 +149,7 @@ public partial class RuntimeEmitter
         {
             // Build fn = new $TSFunction(null, helper, jsName, jsLength) → fnLocal.
             il.Emit(OpCodes.Ldnull);
-            il.Emit(OpCodes.Ldtoken, helper);
-            il.Emit(OpCodes.Ldtoken, helper.DeclaringType!);
-            il.Emit(OpCodes.Call, _types.GetMethod(_types.MethodBase, "GetMethodFromHandle",
-                _types.RuntimeMethodHandle, _types.RuntimeTypeHandle));
-            il.Emit(OpCodes.Castclass, _types.MethodInfo);
+            _types.EmitLoadMethodInfo(il, helper);
             il.Emit(OpCodes.Ldstr, jsName);
             il.Emit(OpCodes.Ldc_I4, jsLength);
             il.Emit(OpCodes.Newobj, runtime.TSFunctionCtorWithCache);

--- a/Compilation/RuntimeEmitter.SymbolAccessors.cs
+++ b/Compilation/RuntimeEmitter.SymbolAccessors.cs
@@ -209,8 +209,7 @@ public partial class RuntimeEmitter
         var getMethodHandle = _types.GetProperty(_types.MethodBase, "MethodHandle").GetGetMethod()!;
         var getDeclaringType = _types.GetProperty(typeof(System.Reflection.MemberInfo), "DeclaringType").GetGetMethod()!;
         var containsGenericParams = _types.Type.GetProperty("ContainsGenericParameters")!.GetGetMethod()!;
-        var getMethodFromHandle = _types.GetMethod(_types.MethodBase, "GetMethodFromHandle",
-            _types.RuntimeMethodHandle, _types.RuntimeTypeHandle);
+        var getMethodFromHandle = _types.MethodBaseGetMethodFromHandleWithType;
 
         // ---- SymbolRegistryKey(Type owner) ----
         // return owner.IsConstructedGenericType ? owner.GetGenericTypeDefinition() : owner;

--- a/Compilation/RuntimeEmitter.TSProcess.cs
+++ b/Compilation/RuntimeEmitter.TSProcess.cs
@@ -728,7 +728,7 @@ public partial class RuntimeEmitter
         // fn = new $TSFunction(null, mainImpl)
         il.Emit(OpCodes.Ldnull);
         il.Emit(OpCodes.Ldtoken, mainImpl);
-        il.Emit(OpCodes.Call, _types.GetMethod(_types.MethodBase, "GetMethodFromHandle", _types.RuntimeMethodHandle));
+        il.Emit(OpCodes.Call, _types.MethodBaseGetMethodFromHandle);
         il.Emit(OpCodes.Castclass, _types.MethodInfo);
         il.Emit(OpCodes.Newobj, runtime.TSFunctionCtor);
         il.Emit(OpCodes.Stloc, fnLocal);
@@ -738,7 +738,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldstr, memberName);
         il.Emit(OpCodes.Ldnull);
         il.Emit(OpCodes.Ldtoken, memberImpl);
-        il.Emit(OpCodes.Call, _types.GetMethod(_types.MethodBase, "GetMethodFromHandle", _types.RuntimeMethodHandle));
+        il.Emit(OpCodes.Call, _types.MethodBaseGetMethodFromHandle);
         il.Emit(OpCodes.Castclass, _types.MethodInfo);
         il.Emit(OpCodes.Newobj, runtime.TSFunctionCtor);
         il.Emit(OpCodes.Call, runtime.SetProperty);
@@ -1029,7 +1029,7 @@ public partial class RuntimeEmitter
                 il.Emit(OpCodes.Ldstr, name);
                 il.Emit(OpCodes.Ldnull);
                 il.Emit(OpCodes.Ldtoken, impl);
-                il.Emit(OpCodes.Call, _types.GetMethod(_types.MethodBase, "GetMethodFromHandle", _types.RuntimeMethodHandle));
+                il.Emit(OpCodes.Call, _types.MethodBaseGetMethodFromHandle);
                 il.Emit(OpCodes.Castclass, _types.MethodInfo);
                 il.Emit(OpCodes.Newobj, runtime.TSFunctionCtor);
                 il.Emit(OpCodes.Callvirt, setItem);

--- a/Compilation/RuntimeEmitter.TSReadableAsyncIter.cs
+++ b/Compilation/RuntimeEmitter.TSReadableAsyncIter.cs
@@ -263,8 +263,7 @@ public partial class RuntimeEmitter
     {
         il.Emit(OpCodes.Ldtoken, method);
         il.Emit(OpCodes.Ldtoken, declaringType);
-        il.Emit(OpCodes.Call, _types.MethodBase.GetMethod(
-            "GetMethodFromHandle", [_types.RuntimeMethodHandle, _types.RuntimeTypeHandle])!);
+        il.Emit(OpCodes.Call, _types.MethodBaseGetMethodFromHandleWithType);
         il.Emit(OpCodes.Castclass, _types.MethodInfo);
     }
 

--- a/Compilation/RuntimeEmitter.TSStreamUtils.cs
+++ b/Compilation/RuntimeEmitter.TSStreamUtils.cs
@@ -210,8 +210,7 @@ public partial class RuntimeEmitter
         // Return new $TSFunction(cleanupInstance, cleanupInvokeMethod)
         il.Emit(OpCodes.Ldloc, cleanupInstanceLocal);
         il.Emit(OpCodes.Ldtoken, _cleanupInvokeMethod);
-        il.Emit(OpCodes.Call, _types.GetMethod(
-            _types.MethodBase, "GetMethodFromHandle", _types.RuntimeMethodHandle));
+        il.Emit(OpCodes.Call, _types.MethodBaseGetMethodFromHandle);
         il.Emit(OpCodes.Castclass, _types.MethodInfo);
         il.Emit(OpCodes.Newobj, runtime.TSFunctionCtor);
         il.Emit(OpCodes.Ret);

--- a/Compilation/RuntimeEmitter.TimerPromises.cs
+++ b/Compilation/RuntimeEmitter.TimerPromises.cs
@@ -696,9 +696,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloc, dictLocal);
         il.Emit(OpCodes.Ldstr, "next");
         il.Emit(OpCodes.Ldloc, closureLocal);         // target
-        il.Emit(OpCodes.Ldtoken, _asyncIntervalClosureNext);
-        il.Emit(OpCodes.Call, _types.MethodBaseGetMethodFromHandle);
-        il.Emit(OpCodes.Castclass, typeof(MethodInfo));
+        _types.EmitLoadMethodInfoViaHandle(il, _asyncIntervalClosureNext);
         il.Emit(OpCodes.Ldstr, "next");
         il.Emit(OpCodes.Ldc_I4_0);
         il.Emit(OpCodes.Newobj, runtime.TSFunctionCtorWithCache);
@@ -708,9 +706,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloc, dictLocal);
         il.Emit(OpCodes.Ldstr, "return");
         il.Emit(OpCodes.Ldloc, closureLocal);         // target
-        il.Emit(OpCodes.Ldtoken, _asyncIntervalClosureReturn);
-        il.Emit(OpCodes.Call, _types.MethodBaseGetMethodFromHandle);
-        il.Emit(OpCodes.Castclass, typeof(MethodInfo));
+        _types.EmitLoadMethodInfoViaHandle(il, _asyncIntervalClosureReturn);
         il.Emit(OpCodes.Ldstr, "return");
         il.Emit(OpCodes.Ldc_I4_1);
         il.Emit(OpCodes.Newobj, runtime.TSFunctionCtorWithCache);
@@ -722,9 +718,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Call, runtime.GetSymbolDictMethod);
         il.Emit(OpCodes.Ldsfld, runtime.SymbolAsyncIterator);
         il.Emit(OpCodes.Ldloc, closureLocal);         // target
-        il.Emit(OpCodes.Ldtoken, _asyncIntervalClosureGetSelf);
-        il.Emit(OpCodes.Call, _types.MethodBaseGetMethodFromHandle);
-        il.Emit(OpCodes.Castclass, typeof(MethodInfo));
+        _types.EmitLoadMethodInfoViaHandle(il, _asyncIntervalClosureGetSelf);
         il.Emit(OpCodes.Ldstr, "[Symbol.asyncIterator]");
         il.Emit(OpCodes.Ldc_I4_0);
         il.Emit(OpCodes.Newobj, runtime.TSFunctionCtorWithCache);
@@ -818,9 +812,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloc, dictLocal);
         il.Emit(OpCodes.Ldstr, "next");
         il.Emit(OpCodes.Ldloc, closureLocal);
-        il.Emit(OpCodes.Ldtoken, _asyncIntervalClosureNext);
-        il.Emit(OpCodes.Call, _types.MethodBaseGetMethodFromHandle);
-        il.Emit(OpCodes.Castclass, typeof(MethodInfo));
+        _types.EmitLoadMethodInfoViaHandle(il, _asyncIntervalClosureNext);
         il.Emit(OpCodes.Ldstr, "next");
         il.Emit(OpCodes.Ldc_I4_0);
         il.Emit(OpCodes.Newobj, runtime.TSFunctionCtorWithCache);
@@ -830,9 +822,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloc, dictLocal);
         il.Emit(OpCodes.Ldstr, "return");
         il.Emit(OpCodes.Ldloc, closureLocal);
-        il.Emit(OpCodes.Ldtoken, _asyncIntervalClosureReturn);
-        il.Emit(OpCodes.Call, _types.MethodBaseGetMethodFromHandle);
-        il.Emit(OpCodes.Castclass, typeof(MethodInfo));
+        _types.EmitLoadMethodInfoViaHandle(il, _asyncIntervalClosureReturn);
         il.Emit(OpCodes.Ldstr, "return");
         il.Emit(OpCodes.Ldc_I4_1);
         il.Emit(OpCodes.Newobj, runtime.TSFunctionCtorWithCache);
@@ -843,9 +833,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Call, runtime.GetSymbolDictMethod);
         il.Emit(OpCodes.Ldsfld, runtime.SymbolAsyncIterator);
         il.Emit(OpCodes.Ldloc, closureLocal);
-        il.Emit(OpCodes.Ldtoken, _asyncIntervalClosureGetSelf);
-        il.Emit(OpCodes.Call, _types.MethodBaseGetMethodFromHandle);
-        il.Emit(OpCodes.Castclass, typeof(MethodInfo));
+        _types.EmitLoadMethodInfoViaHandle(il, _asyncIntervalClosureGetSelf);
         il.Emit(OpCodes.Ldstr, "[Symbol.asyncIterator]");
         il.Emit(OpCodes.Ldc_I4_0);
         il.Emit(OpCodes.Newobj, runtime.TSFunctionCtorWithCache);

--- a/Compilation/TypeProvider.cs
+++ b/Compilation/TypeProvider.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using System.Reflection;
+using System.Reflection.Emit;
 using SharpTS.Diagnostics.Exceptions;
 
 namespace SharpTS.Compilation;
@@ -526,6 +527,44 @@ public class TypeProvider
     /// </summary>
     public MethodInfo MethodBaseGetMethodFromHandle =>
         _methodBaseGetMethodFromHandle ??= GetMethod(MethodBase, "GetMethodFromHandle", RuntimeMethodHandle);
+
+    private MethodInfo? _methodBaseGetMethodFromHandleWithType;
+
+    /// <summary>
+    /// Gets the MethodBase.GetMethodFromHandle(RuntimeMethodHandle, RuntimeTypeHandle)
+    /// overload — required when the declaring type is generic or a TypeBuilder whose
+    /// token alone can't resolve the method.
+    /// </summary>
+    public MethodInfo MethodBaseGetMethodFromHandleWithType =>
+        _methodBaseGetMethodFromHandleWithType ??=
+            GetMethod(MethodBase, "GetMethodFromHandle", RuntimeMethodHandle, RuntimeTypeHandle);
+
+    /// <summary>
+    /// Emits the canonical "load a MethodInfo at runtime from a metadata token"
+    /// block in its two-token, declaring-type-qualified form:
+    /// <c>Ldtoken method; Ldtoken method.DeclaringType; Call GetMethodFromHandle(handle, typeHandle); Castclass MethodInfo</c>.
+    /// Use this form when the declaring type may be generic or emitted (TypeBuilder).
+    /// </summary>
+    public void EmitLoadMethodInfo(ILGenerator il, MethodInfo method)
+    {
+        il.Emit(OpCodes.Ldtoken, method);
+        il.Emit(OpCodes.Ldtoken, method.DeclaringType!);
+        il.Emit(OpCodes.Call, MethodBaseGetMethodFromHandleWithType);
+        il.Emit(OpCodes.Castclass, MethodInfo);
+    }
+
+    /// <summary>
+    /// Emits the single-token form of the MethodInfo load:
+    /// <c>Ldtoken method; Call GetMethodFromHandle(handle); Castclass MethodInfo</c>.
+    /// Only valid when the declaring type is non-generic and resolvable from the
+    /// method token alone (the established form at all state-machine emit sites).
+    /// </summary>
+    public void EmitLoadMethodInfoViaHandle(ILGenerator il, MethodInfo method)
+    {
+        il.Emit(OpCodes.Ldtoken, method);
+        il.Emit(OpCodes.Call, MethodBaseGetMethodFromHandle);
+        il.Emit(OpCodes.Castclass, MethodInfo);
+    }
 
     /// <summary>
     /// Gets the StringBuilder.Append(string) method.


### PR DESCRIPTION
Round 8c: the last mechanical item from the July duplication audit.

## Change

The `Ldtoken; [Ldtoken declaringType;] Call GetMethodFromHandle; Castclass MethodInfo` block was open-coded at ~100 sites across ~50 Compilation files in three spellings (cached 1-token property, inline uncached `GetMethod("GetMethodFromHandle", …)` re-reflection at every emit, per-method hoisted locals).

- New `TypeProvider.EmitLoadMethodInfo(il, method)` — 2-token, declaring-type-qualified form (generic/TypeBuilder-safe) — and `EmitLoadMethodInfoViaHandle(il, method)` — 1-token form — over a new cached `MethodBaseGetMethodFromHandleWithType`.
- Every canonical-shape site converted, **preserving each site's original 1- vs 2-token form → emitted IL unchanged**.
- Structurally-different sites (HasFields' generic/non-generic conditional, SymbolAccessors' runtime-handle dispatch, ILEmitter.Modules' token-kind conditional, `EmitMethodInfoLiteral`) keep their shape but now use the cached lookup instead of re-reflecting per emit.
- Net **−153 lines** across 47 files; kills ~10 uncached reflection lookups per compilation.
- `RuntimeEmitter.TSRegExp.cs` (binary-flagged, grep-invisible) checked via perl: zero sites of this idiom.

## Verification

- Full suite: **15452 passed / 0 failed**
- `--verify` IL verification passes on a smoke exercising arrow-function wraps, class statics, and async state machines (all three consumer families of the idiom)
- Build: 0 warnings