### PR TITLE
perf(interp): lazy `arguments` materialization (−29% alloc on call-heavy code)

### DIFF
--- a/Compilation/ClosureAnalyzer.cs
+++ b/Compilation/ClosureAnalyzer.cs
@@ -1069,7 +1069,9 @@ public class ClosureAnalyzer : AstVisitorBase
     /// Returns true if any statement (directly or inside a nested arrow) references
     /// the identifier <c>arguments</c>, stopping at nested non-arrow function boundaries
     /// (those have their own <c>arguments</c> binding per JS spec, so a reference inside
-    /// them belongs to the nested function, not this one).
+    /// them belongs to the nested function, not this one). Scanning lives in the shared
+    /// <see cref="ArgumentsRefScanner"/> (also used by the interpreter's lazy
+    /// <c>arguments</c> materialization).
     /// </summary>
     private static bool ReferencesArgumentsIdentifierNonArrow(List<Stmt> stmts)
     {
@@ -1080,33 +1082,5 @@ public class ClosureAnalyzer : AstVisitorBase
             if (scanner.Found) return true;
         }
         return false;
-    }
-
-    private sealed class ArgumentsRefScanner : AstVisitorBase
-    {
-        public bool Found { get; private set; }
-
-        protected override void VisitVariable(Expr.Variable expr)
-        {
-            if (expr.Name.Lexeme == "arguments")
-            {
-                Found = true;
-                ShouldContinue = false;
-            }
-        }
-
-        // Nested non-arrow function declarations/expressions introduce their own
-        // `arguments` binding — references inside belong to that inner function,
-        // so stop descending.
-        protected override void VisitFunction(Stmt.Function stmt) { /* skip */ }
-
-        protected override void VisitArrowFunction(Expr.ArrowFunction expr)
-        {
-            // Function expressions (HasOwnThis=true) behave like declarations: their
-            // own `arguments` shadows ours. True arrow functions (HasOwnThis=false)
-            // inherit lexically, so we must recurse.
-            if (expr.HasOwnThis) return;
-            base.VisitArrowFunction(expr);
-        }
     }
 }

--- a/Parsing/Visitors/ArgumentsRefScanner.cs
+++ b/Parsing/Visitors/ArgumentsRefScanner.cs
@@ -1,0 +1,52 @@
+namespace SharpTS.Parsing.Visitors;
+
+/// <summary>
+/// Detects whether a function body references the JS <c>arguments</c> binding,
+/// stopping at nested non-arrow function boundaries (those bind their own
+/// <c>arguments</c> per spec, so a reference inside them belongs to the nested
+/// function) and descending into true arrows (which inherit it lexically).
+/// Single source shared by the closure analyzer (compiled mode) and the
+/// interpreter's lazy <c>arguments</c> materialization — keep the scoping rules
+/// here so the two modes can't drift.
+/// </summary>
+public sealed class ArgumentsRefScanner : AstVisitorBase
+{
+    private readonly bool _treatEvalReferenceAsUse;
+
+    /// <param name="treatEvalReferenceAsUse">
+    /// When true, a reference to the identifier <c>eval</c> also counts as a use.
+    /// The interpreter implements direct eval against the live scope chain, so
+    /// <c>eval("arguments[0]")</c> can observe the binding without the scanner
+    /// ever seeing the <c>arguments</c> identifier — callers that gate binding
+    /// creation on this scan must stay conservative in that case. The compiled
+    /// closure analyzer passes false (its existing behavior).
+    /// </param>
+    public ArgumentsRefScanner(bool treatEvalReferenceAsUse = false)
+        => _treatEvalReferenceAsUse = treatEvalReferenceAsUse;
+
+    public bool Found { get; private set; }
+
+    protected override void VisitVariable(Expr.Variable expr)
+    {
+        if (expr.Name.Lexeme == "arguments" ||
+            (_treatEvalReferenceAsUse && expr.Name.Lexeme == "eval"))
+        {
+            Found = true;
+            ShouldContinue = false;
+        }
+    }
+
+    // Nested non-arrow function declarations/expressions introduce their own
+    // `arguments` binding — references inside belong to that inner function,
+    // so stop descending.
+    protected override void VisitFunction(Stmt.Function stmt) { /* skip */ }
+
+    protected override void VisitArrowFunction(Expr.ArrowFunction expr)
+    {
+        // Function expressions (HasOwnThis=true) behave like declarations: their
+        // own `arguments` shadows ours. True arrow functions (HasOwnThis=false)
+        // inherit lexically, so we must recurse.
+        if (expr.HasOwnThis) return;
+        base.VisitArrowFunction(expr);
+    }
+}

--- a/Runtime/Types/ArgumentsUsage.cs
+++ b/Runtime/Types/ArgumentsUsage.cs
@@ -1,0 +1,59 @@
+using System.Runtime.CompilerServices;
+using SharpTS.Parsing;
+using SharpTS.Parsing.Visitors;
+
+namespace SharpTS.Runtime.Types;
+
+/// <summary>
+/// Per-declaration cache answering "does this function's body observe the JS
+/// <c>arguments</c> binding?" so call paths can skip materializing the
+/// <c>arguments</c> array (a List + SharpTSArray + per-arg boxing on EVERY
+/// call) for the overwhelming majority of functions that never touch it.
+/// Conservative on direct eval: a body referencing <c>eval</c> keeps the
+/// binding, since interpreter eval runs against the live scope chain and can
+/// observe <c>arguments</c> without the identifier appearing in the AST.
+/// Keyed by declaration node reference, so closures re-created from the same
+/// declaration (function factories) scan once.
+/// </summary>
+internal static class ArgumentsUsage
+{
+    private static readonly ConditionalWeakTable<object, object> _cache = new();
+    private static readonly object BoxedTrue = true;
+    private static readonly object BoxedFalse = false;
+
+    public static bool UsesArguments(Stmt.Function declaration)
+    {
+        if (_cache.TryGetValue(declaration, out var cached))
+            return (bool)cached;
+        bool result = declaration.Body != null && Scan(declaration.Body, null);
+        _cache.AddOrUpdate(declaration, result ? BoxedTrue : BoxedFalse);
+        return result;
+    }
+
+    public static bool UsesArguments(Expr.ArrowFunction declaration)
+    {
+        if (_cache.TryGetValue(declaration, out var cached))
+            return (bool)cached;
+        bool result = Scan(declaration.BlockBody, declaration.ExpressionBody);
+        _cache.AddOrUpdate(declaration, result ? BoxedTrue : BoxedFalse);
+        return result;
+    }
+
+    private static bool Scan(List<Stmt>? blockBody, Expr? expressionBody)
+    {
+        var scanner = new ArgumentsRefScanner(treatEvalReferenceAsUse: true);
+        if (expressionBody != null)
+        {
+            scanner.Visit(expressionBody);
+            return scanner.Found;
+        }
+        if (blockBody == null)
+            return false;
+        foreach (var stmt in blockBody)
+        {
+            scanner.Visit(stmt);
+            if (scanner.Found) return true;
+        }
+        return false;
+    }
+}

--- a/Runtime/Types/SharpTSFunction.cs
+++ b/Runtime/Types/SharpTSFunction.cs
@@ -217,7 +217,11 @@ public class SharpTSFunction : ISharpTSCallable, ITypeCategorized
         // Bind the JS-spec `arguments` array-like to the current call's args.
         // Arrow functions do NOT bind `arguments` — they inherit from the
         // enclosing non-arrow function (handled by SharpTSArrowFunction).
-        environment.Define("arguments", new SharpTSArray(arguments));
+        // Materialized only when the body can observe it (ArgumentsUsage scan).
+        if (ArgumentsUsage.UsesArguments(_declaration))
+        {
+            environment.Define("arguments", new SharpTSArray(arguments));
+        }
 
         var result = interpreter.ExecuteBlock(_declaration.Body, environment);
         if (result.Type == ExecutionResult.ResultType.Return)
@@ -330,10 +334,14 @@ public class SharpTSFunction : ISharpTSCallable, ITypeCategorized
 
         ParameterBinder.BindRV(_declaration.Parameters, arguments, environment, interpreter);
         // See Call for the JS-spec rationale; materialize the args span into a
-        // SharpTSArray so `arguments[i]` and `arguments.length` work.
-        var argsList = new List<object?>(arguments.Length);
-        for (int i = 0; i < arguments.Length; i++) argsList.Add(arguments[i].ToObject());
-        environment.Define("arguments", new SharpTSArray(argsList));
+        // SharpTSArray so `arguments[i]` and `arguments.length` work — but only
+        // when the body can observe it (ArgumentsUsage scan).
+        if (ArgumentsUsage.UsesArguments(_declaration))
+        {
+            var argsList = new List<object?>(arguments.Length);
+            for (int i = 0; i < arguments.Length; i++) argsList.Add(arguments[i].ToObject());
+            environment.Define("arguments", new SharpTSArray(argsList));
+        }
 
         var result = interpreter.ExecuteBlock(_declaration.Body, environment);
         if (result.Type == ExecutionResult.ResultType.Return)
@@ -548,7 +556,8 @@ public class SharpTSArrowFunction : ISharpTSCallable, ITypeCategorized
         // for lodash-style wrappers: `function outer() { return function() {
         // return func.apply(this, arguments); }; }` — the returned function is a
         // function expression, not an arrow, and must see its own `arguments`.
-        if (HasOwnThis)
+        // Materialized only when the body can observe it (ArgumentsUsage scan).
+        if (HasOwnThis && ArgumentsUsage.UsesArguments(_declaration))
         {
             environment.Define("arguments", new SharpTSArray(new List<object?>(arguments)));
         }
@@ -618,7 +627,8 @@ public class SharpTSArrowFunction : ISharpTSCallable, ITypeCategorized
         }
 
         // Function expressions (HasOwnThis) bind their own `arguments`; true arrows do not.
-        if (HasOwnThis)
+        // Materialized only when the body can observe it (ArgumentsUsage scan).
+        if (HasOwnThis && ArgumentsUsage.UsesArguments(_declaration))
         {
             var argsList = new List<object?>(arguments.Length);
             for (int i = 0; i < arguments.Length; i++) argsList.Add(arguments[i].ToObject());

--- a/SharpTS.Tests/SharedTests/ArgumentsMagicVariableTests.cs
+++ b/SharpTS.Tests/SharedTests/ArgumentsMagicVariableTests.cs
@@ -179,4 +179,46 @@ public class ArgumentsMagicVariableTests
         var output = TestHarness.Run(source, mode);
         Assert.Equal("\na\nabc\n", output);
     }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void Arguments_FunctionExpression_ApplyForwarding(ExecutionMode mode)
+    {
+        // Lodash-style wrapper: the returned function EXPRESSION binds its own
+        // `arguments` and forwards them via apply. Guards the lazy-materialization
+        // scan (interpreter only materializes `arguments` for bodies that observe
+        // it): the inner expression's usage must not be attributed to `outer`,
+        // and must still be materialized for the inner function itself.
+        var source = @"
+            function sum(a: number, b: number): number { return a + b; }
+            function outer(func: any): any {
+                return function (): any {
+                    return func.apply(this, arguments);
+                };
+            }
+            const wrapped = outer(sum);
+            console.log(wrapped(3, 4));
+        ";
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("7\n", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    public void Arguments_VisibleToDirectEval(ExecutionMode mode)
+    {
+        // Direct eval runs against the live scope chain, so `arguments` must be
+        // materialized even though the identifier never appears in the AST —
+        // the lazy-materialization scan treats any `eval` reference in the body
+        // as a conservative use. Interpreter-only: compiled eval is a separate
+        // soft-dependency feature.
+        var source = @"
+            function probe(a: number, b: number): any {
+                return eval('arguments.length');
+            }
+            console.log(probe(1, 2));
+        ";
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("2\n", output);
+    }
 }


### PR DESCRIPTION
Round 9b: the top remaining interpreter perf item from the July audits.

## Problem

Every interpreter call of a user function unconditionally materialized the JS `arguments` binding — a `List<object?>` + `SharpTSArray`, plus per-arg `ToObject()` boxing on the CallV2 span path — even though the overwhelming majority of functions never reference it.

## Change

- Hoisted `ClosureAnalyzer`'s private `ArgumentsRefScanner` to `Parsing/Visitors/ArgumentsRefScanner.cs` as the single shared source. It already encodes the spec scoping rules: stop at nested non-arrow function boundaries (they bind their own `arguments`), descend into true arrows (they inherit lexically). The compiled-mode analyzer keeps identical behavior.
- New `ArgumentsUsage` cache (`ConditionalWeakTable` keyed by declaration AST node — function factories scan once per declaration, not per closure) gates all four `Define("arguments", …)` sites: `SharpTSFunction.Call`/`CallV2` and the function-expression paths.
- **Direct-eval conservatism:** interpreter `eval` runs against the live scope chain, so `eval("arguments[0]")` can observe the binding without the identifier appearing in the AST. The scanner takes a `treatEvalReferenceAsUse` option (true for the interpreter gate, false for the compiled analyzer's existing behavior) — any `eval` reference in a body keeps the materialization.

## Measurement

In-process lex+parse+check+interpret loop over a call-heavy script (180k mixed declaration/expression/arrow calls + fib recursion), Release, A/B via detached origin/main checkout, medians of 5:

| | origin/main | this PR | delta |
|---|---|---|---|
| allocated / run | 175,437 KB | 123,882 KB | **−29.4%** |
| gen0 GCs / 30 runs | 573 | 404 | **−29.5%** |
| time / run (median) | 106.1 ms | 94.4 ms | **−11.0%** |

## Verification

- Full unit suite: **15452 passed / 0 failed**
- New regression tests: lodash-style `function(){ return func.apply(this, arguments); }` forwarding (both execution modes) and `eval('arguments.length')` visibility (interpreter-only)
- **Test262 interpreted baseline: diff clean** — the decisive gate, since `arguments` semantics (sloppy/strict, extras past arity, apply/call interplay) are heavily covered there