### PR TITLE
feat(repl): type-aware autocomplete, and let Ctrl+C exit the REPL

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -496,6 +496,33 @@ The compilation directory has grown substantially. Key organizational patterns:
 
 ### Tooling & IDE Integration
 
+**Interactive REPL** (`Repl/`):
+
+Built on the PrettyPrompt library, which supplies multi-line editing, persistent history, and the
+completion pane. Session state — the `Interpreter`, the `TypeChecker`, and the accumulated
+statements — lives on `ReplEngine` and is replaced wholesale by `.reset`; `ReplCompletionSession`
+holds it by reference so the callbacks, which are constructed once before the read loop, keep
+working across a reset.
+
+| File | Purpose |
+|------|---------|
+| `ReplEngine.cs` | Read-eval-print loop, session state, Ctrl+C interruption |
+| `ReplCallbacks.cs` | PrettyPrompt callbacks: highlighting, multi-line detection, completion |
+| `ReplCompletionContext.cs` | Classifies what the caret should complete |
+| `ReplCompletionProvider.cs` | Computes autocomplete candidates |
+| `DotCommands.cs` | `.help`, `.type`, `.load`, … |
+| `ValueFormatter.cs` | ANSI-coloured display of evaluation results |
+
+Autocomplete resolves members through the **`TypeChecker`**, generalizing `.type`: the receiver
+expression is parsed and checked against the accumulated session statements, then
+`TypeChecker.GetCompletionMembers` enumerates the resulting `TypeInfo`. That is what lets arbitrary
+receivers (`getUser().`, `arr[0].`) complete and supplies each member's type for the tooltip. Two
+consequences worth knowing: the checker models the built-in singletons (`console`, `Math`, `JSON`,
+…) as `any`, so those fall back to the runtime member tables in `Runtime/BuiltIns/`; and
+runtime-only shapes (a property added after construction, `JSON.parse` results) are invisible to it.
+Identifier completion deliberately skips type checking and reads the live `RuntimeEnvironment`
+instead, because it runs on every keystroke.
+
 **Declaration Generation** (`Declaration/`):
 | File | Purpose |
 |------|---------|

--- a/Execution/Interpreter.Realm.cs
+++ b/Execution/Interpreter.Realm.cs
@@ -42,6 +42,11 @@ public partial class Interpreter
     /// </summary>
     private static readonly FrozenDictionary<string, object> _globalConstants = CreateGlobalsLookup();
 
+    /// <summary>
+    /// The names of every global constant and built-in singleton, for REPL autocomplete.
+    /// </summary>
+    internal static IEnumerable<string> GlobalNames => _globalConstants.Keys;
+
     // The process-wide RegExp constructor singleton (a SharpTSBuiltInConstructor),
     // resolved once from the static globals table. ECMA-262 §22.2.6.1 requires
     // `RegExp.prototype.constructor === RegExp` and, by inheritance,

--- a/Parsing/Lexer.cs
+++ b/Parsing/Lexer.cs
@@ -58,6 +58,15 @@ public class Lexer(string source)
     public TypeScriptPragmas Pragmas =>
         new(_hasTsCheck, _hasTsNoCheck, _tsIgnoreLines, _tsExpectErrorLines);
 
+    /// <summary>
+    /// Every reserved word the lexer recognizes, for REPL autocomplete.
+    /// </summary>
+    internal static IEnumerable<string> KeywordNames => Keywords.Keys;
+
+    /// <summary>Maps a keyword's spelling to its token type, or null if it is not a keyword.</summary>
+    internal static TokenType? KeywordTokenType(string name) =>
+        Keywords.TryGetValue(name, out var type) ? type : null;
+
     private static readonly Dictionary<string, TokenType> Keywords = new()
     {
         { "abstract", TokenType.ABSTRACT },

--- a/Program.cs
+++ b/Program.cs
@@ -239,7 +239,7 @@ static async Task RunPromptAsync(DecoratorMode decoratorMode)
     Console.WriteLine("Type .help for available commands.");
     Console.WriteLine();
 
-    var repl = new SharpTS.Repl.ReplEngine(decoratorMode);
+    using var repl = new SharpTS.Repl.ReplEngine(decoratorMode);
     await repl.RunAsync();
 }
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,12 @@ dotnet tool install -g SharpTS
 sharpts
 ```
 
+The interactive prompt supports multi-line editing, syntax highlighting, persistent history, and
+autocomplete. Suggestions appear as you type — session variables, functions and classes, built-in
+globals, and keywords — and typing `.` offers the members of the receiver's type along with each
+member's signature. Press `Tab` to accept a suggestion, `Ctrl+Space` to request one, and `Esc` to
+dismiss the list. Type `.help` for the dot-commands.
+
 **Run a TypeScript file (interpreted):**
 
 ```bash

--- a/Repl/DotCommands.cs
+++ b/Repl/DotCommands.cs
@@ -40,6 +40,22 @@ internal sealed class DotCommands
     }
 
     /// <summary>
+    /// Every dot-command with its one-line help text. Single source of truth: <see cref="Execute"/>,
+    /// <see cref="PrintHelp"/>, and REPL autocomplete all read this, so a new command shows up in
+    /// all three without further edits.
+    /// </summary>
+    public static readonly (string Name, string Args, string Help)[] Commands =
+    [
+        (".help", "", "Show this help message"),
+        (".clear", "", "Clear the console screen"),
+        (".exit", "", "Exit the REPL (also: Ctrl+C twice)"),
+        (".reset", "", "Reset interpreter state (fresh environment)"),
+        (".type", " <expr>", "Show the TypeScript type of an expression"),
+        (".save", " <file>", "Save session history to a TypeScript file"),
+        (".load", " <file>", "Load and execute a TypeScript file"),
+    ];
+
+    /// <summary>
     /// Returns true if the input is a dot-command.
     /// </summary>
     public static bool IsDotCommand(string input)
@@ -95,22 +111,24 @@ internal sealed class DotCommands
 
     private static void PrintHelp()
     {
+        Console.WriteLine("REPL Commands:");
+        foreach (var (name, args, help) in Commands)
+            Console.WriteLine($"  {name + args,-18} {help}");
+
         Console.WriteLine("""
-            REPL Commands:
-              .help              Show this help message
-              .clear             Clear the console screen
-              .exit              Exit the REPL (also: Ctrl+D)
-              .reset             Reset interpreter state (fresh environment)
-              .type <expr>       Show the TypeScript type of an expression
-              .save <file>       Save session history to a TypeScript file
-              .load <file>       Load and execute a TypeScript file
 
             Keyboard Shortcuts:
               Enter              Submit input (or continue on incomplete input)
               Shift+Enter        Force new line
-              Up/Down            Navigate command history
-              Ctrl+C             Cancel current input / interrupt execution
+              Up/Down            Navigate completions when open, else command history
+              Ctrl+C             Discard current input / interrupt execution; twice to exit
               Ctrl+L             Clear screen
+
+            Completion:
+              (as you type)      Suggestions appear for names and after '.'
+              Tab                Accept the highlighted suggestion
+              Ctrl+Space         Show suggestions
+              Escape             Dismiss suggestions
             """);
     }
 

--- a/Repl/ReplCallbacks.cs
+++ b/Repl/ReplCallbacks.cs
@@ -1,5 +1,7 @@
 using PrettyPrompt;
+using PrettyPrompt.Completion;
 using PrettyPrompt.Consoles;
+using PrettyPrompt.Documents;
 using PrettyPrompt.Highlighting;
 using SharpTS.Parsing;
 
@@ -7,9 +9,9 @@ namespace SharpTS.Repl;
 
 /// <summary>
 /// PrettyPrompt callbacks for the SharpTS REPL.
-/// Handles multi-line detection via TransformKeyPressAsync and syntax highlighting.
+/// Handles multi-line detection via TransformKeyPressAsync, syntax highlighting, and autocomplete.
 /// </summary>
-internal sealed class ReplCallbacks : PromptCallbacks
+internal sealed class ReplCallbacks(ReplCompletionProvider completions) : PromptCallbacks
 {
     // Token type to color mapping for syntax highlighting
     private static readonly Dictionary<TokenType, AnsiColor> TokenColors = new()
@@ -128,6 +130,101 @@ internal sealed class ReplCallbacks : PromptCallbacks
     }
 
     /// <summary>
+    /// Supplies autocomplete candidates for the caret position.
+    /// </summary>
+    protected override Task<IReadOnlyList<CompletionItem>> GetCompletionItemsAsync(
+        string text, int caret, TextSpan spanToBeReplaced, CancellationToken cancellationToken)
+    {
+        IReadOnlyList<CompletionItem> items;
+        try
+        {
+            items = completions
+                .GetCandidates(text, caret)
+                .Select(candidate => (CompletionItem)new ReplCompletionItem(candidate))
+                .ToList();
+        }
+        catch
+        {
+            // A completion failure must never take down the prompt.
+            items = [];
+        }
+
+        return Task.FromResult(items);
+    }
+
+    /// <summary>
+    /// Opens the completion window as the user types, and after a dot.
+    /// </summary>
+    /// <remarks>
+    /// PrettyPrompt's default only opens after <c>.</c> or <c>(</c>, at the first character of the
+    /// prompt, or after a space — and it opens even inside string literals. This override gives
+    /// IntelliSense-style behaviour instead: suggest while a word is being typed, but stay silent
+    /// wherever <see cref="ReplCompletionContext.Classify"/> says completion does not apply (inside
+    /// strings, templates, comments, and after a numeric literal such as <c>1.</c>).
+    /// </remarks>
+    protected override Task<bool> ShouldOpenCompletionWindowAsync(
+        string text, int caret, KeyPress keyPress, CancellationToken cancellationToken)
+        => Task.FromResult(ShouldOpenCompletionWindow(text, caret));
+
+    /// <summary>The trigger policy, separated from the callback so it can be tested directly.</summary>
+    internal static bool ShouldOpenCompletionWindow(string text, int caret)
+    {
+        var context = ReplCompletionContext.Classify(text, caret);
+
+        return context.Kind switch
+        {
+            // Only once a word is actually started, so the menu does not appear on a bare prompt or
+            // after every space.
+            ReplCompletionContextKind.Identifier => context.Partial.Length > 0,
+            ReplCompletionContextKind.None => false,
+            _ => true,
+        };
+    }
+
+    /// <summary>
+    /// Determines the span a committed completion replaces.
+    /// </summary>
+    /// <remarks>
+    /// The default word detection uses <c>IsLetterOrDigit(c) || c == '_'</c>, which excludes <c>$</c>
+    /// even though it is a legal identifier character — committing <c>$foo</c> over a caret in
+    /// <c>$fo</c> would produce <c>$$foo</c>. It also stops at the <c>.</c> of a dot-command and at
+    /// the separators in a path argument. Deriving the span from the same classification that
+    /// produced the candidates keeps the two consistent.
+    /// </remarks>
+    protected override Task<TextSpan> GetSpanToReplaceByCompletionAsync(
+        string text, int caret, CancellationToken cancellationToken)
+    {
+        var context = ReplCompletionContext.Classify(text, caret);
+
+        return context.Kind == ReplCompletionContextKind.None
+            ? base.GetSpanToReplaceByCompletionAsync(text, caret, cancellationToken)
+            : Task.FromResult(TextSpan.FromBounds(context.ReplaceStart, caret));
+    }
+
+    /// <summary>
+    /// Lets Enter submit a finished line instead of committing the highlighted suggestion.
+    /// </summary>
+    /// <remarks>
+    /// Both Enter and Tab commit completions by default, and the menu is open most of the time under
+    /// IntelliSense-style triggering — so Enter would rarely reach the prompt. Returning false here
+    /// leaves the key unhandled, and it falls through to the code pane, which submits.
+    ///
+    /// The <c>IsInputComplete</c> guard is load-bearing, not cosmetic. PrettyPrompt skips
+    /// <see cref="TransformKeyPressAsync"/> whenever a key would commit a completion, so rejecting
+    /// Enter unconditionally would also bypass the Enter-to-newline transform below and break
+    /// multi-line editing. Since that transform only fires for *incomplete* input, restricting the
+    /// rejection to complete input means the bypass can only ever happen where the transform would
+    /// have done nothing anyway.
+    /// </remarks>
+    protected override Task<bool> ConfirmCompletionCommit(
+        string text, int caret, KeyPress keyPress, CancellationToken cancellationToken)
+        => Task.FromResult(ShouldCommitCompletion(keyPress.ConsoleKeyInfo.Key, text));
+
+    /// <summary>The commit policy, separated from the callback so it can be tested directly.</summary>
+    internal static bool ShouldCommitCompletion(ConsoleKey key, string text)
+        => key != ConsoleKey.Enter || !IsInputComplete(text);
+
+    /// <summary>
     /// Provides real-time syntax highlighting by tokenizing the current input.
     /// </summary>
     protected override Task<IReadOnlyCollection<FormatSpan>> HighlightCallbackAsync(
@@ -219,6 +316,74 @@ internal sealed class ReplCallbacks : PromptCallbacks
             // Lexer threw on malformed input — treat as incomplete so user can continue editing
             return false;
         }
+    }
+
+    /// <summary>
+    /// A completion item that ranks by category and colours itself to match the live highlighting.
+    /// </summary>
+    /// <remarks>
+    /// Nested so it can reuse <see cref="TokenColors"/>: a <c>const</c> suggestion is then the exact
+    /// same blue it turns once committed.
+    /// </remarks>
+    private sealed class ReplCompletionItem : CompletionItem
+    {
+        private readonly int _categoryRank;
+
+        public ReplCompletionItem(ReplCompletionCandidate candidate)
+            : base(
+                replacementText: candidate.Name,
+                displayText: Display(candidate),
+                filterText: candidate.Name,
+                getExtendedDescription: candidate.Detail is null
+                    ? null
+                    : _ => Task.FromResult(new FormattedString(candidate.Detail)))
+            => _categoryRank = RankOf(candidate.Kind);
+
+        /// <summary>
+        /// Ranks by how well the item matches what has been typed first, then by category, so that
+        /// a session binding beats a global which beats a keyword among equally good matches.
+        /// </summary>
+        public override int GetCompletionItemPriority(string text, int caret, TextSpan spanToBeReplaced)
+        {
+            var basePriority = base.GetCompletionItemPriority(text, caret, spanToBeReplaced);
+
+            // The base uses `int.MinValue + priority` to mark non-matching items; scaling that would
+            // overflow, so leave negatives alone.
+            return basePriority < 0 ? basePriority : basePriority * 10 + _categoryRank;
+        }
+
+        private static int RankOf(ReplCompletionKind kind) => kind switch
+        {
+            ReplCompletionKind.Member => 5,
+            ReplCompletionKind.Binding => 4,
+            ReplCompletionKind.DotCommand => 3,
+            ReplCompletionKind.FilePath => 3,
+            ReplCompletionKind.Global => 2,
+            _ => 1, // Keyword — real bindings should always win.
+        };
+
+        private static FormattedString Display(ReplCompletionCandidate candidate)
+        {
+            var color = ColorOf(candidate);
+            return color is null
+                ? new FormattedString(candidate.Name)
+                : new FormattedString(
+                    candidate.Name, new FormatSpan(0, candidate.Name.Length, color.Value));
+        }
+
+        private static AnsiColor? ColorOf(ReplCompletionCandidate candidate) => candidate.Kind switch
+        {
+            // Reuse the highlighter's own mapping so keyword colouring cannot drift from it.
+            ReplCompletionKind.Keyword =>
+                Lexer.KeywordTokenType(candidate.Name) is { } tokenType
+                && TokenColors.TryGetValue(tokenType, out var keywordColor)
+                    ? keywordColor
+                    : AnsiColor.Blue,
+            ReplCompletionKind.Global => AnsiColor.Cyan,
+            ReplCompletionKind.DotCommand => AnsiColor.Magenta,
+            ReplCompletionKind.FilePath => AnsiColor.Green,
+            _ => null, // Members and bindings stay default, as identifiers are in the buffer.
+        };
     }
 
     /// <summary>

--- a/Repl/ReplCompletionContext.cs
+++ b/Repl/ReplCompletionContext.cs
@@ -1,0 +1,239 @@
+using SharpTS.Parsing;
+
+namespace SharpTS.Repl;
+
+/// <summary>What the caret is positioned to complete.</summary>
+internal enum ReplCompletionContextKind
+{
+    /// <summary>Completion is suppressed here (inside a literal or comment, or unlexable input).</summary>
+    None,
+
+    /// <summary>A bare identifier prefix — offer bindings, globals, and keywords.</summary>
+    Identifier,
+
+    /// <summary><c>receiver.partial</c> — offer the receiver type's members.</summary>
+    Member,
+
+    /// <summary>A dot-command name at the start of the buffer, e.g. <c>.he</c>.</summary>
+    DotCommand,
+
+    /// <summary>The path argument of <c>.load</c> / <c>.save</c>.</summary>
+    DotCommandArgument,
+}
+
+/// <summary>
+/// Where the caret is and what should be offered there. Pure and console-free so the
+/// tokenizer edge cases can be unit-tested without an interpreter.
+/// </summary>
+/// <param name="Kind">The kind of completion to offer.</param>
+/// <param name="Partial">The word already typed; empty immediately after a dot.</param>
+/// <param name="ReplaceStart">Absolute offset where <paramref name="Partial"/> begins.</param>
+/// <param name="Receiver">
+/// For <see cref="ReplCompletionContextKind.Member"/>, the receiver's source text
+/// (may be an arbitrary expression such as <c>getUser()</c> or <c>arr[0]</c>). Null otherwise.
+/// </param>
+internal sealed record ReplCompletionContext(
+    ReplCompletionContextKind Kind,
+    string Partial,
+    int ReplaceStart,
+    string? Receiver)
+{
+    public static readonly ReplCompletionContext None =
+        new(ReplCompletionContextKind.None, "", 0, null);
+
+    /// <summary>
+    /// Classifies the caret position in <paramref name="text"/>.
+    /// </summary>
+    /// <remarks>
+    /// Everything after the caret is irrelevant, so this works on <c>text[..caret]</c>.
+    ///
+    /// Suppression relies on two lexer behaviours rather than a hand-rolled string/comment scanner:
+    /// an unterminated string, template, or comment produces <em>no token at all</em> (comments are
+    /// skipped as trivia), and <see cref="Token.Lexeme"/> is the raw source slice, so
+    /// <c>Start + Lexeme.Length</c> is an exact end offset. Together they mean a "coverage gap" —
+    /// non-whitespace source after the last token — is a reliable signal that the caret sits inside
+    /// something the lexer refused to tokenize. That single rule covers unterminated <c>"</c>,
+    /// <c>'</c>, <c>`</c>, <c>//</c>, and <c>/* */</c>, while still allowing completion after a
+    /// *closed* comment and inside a template interpolation.
+    /// </remarks>
+    public static ReplCompletionContext Classify(string text, int caret)
+    {
+        // This runs on every keystroke — PrettyPrompt's completion pane calls
+        // GetSpanToReplaceByCompletionAsync for each key press while the menu is open, and
+        // ShouldOpenCompletionWindowAsync on key-up. An exception escaping here would propagate out
+        // of the pane's key handler and wedge the prompt, so classification failure must degrade to
+        // "offer nothing" rather than throw.
+        try
+        {
+            return ClassifyCore(text, caret);
+        }
+        catch
+        {
+            return None;
+        }
+    }
+
+    private static ReplCompletionContext ClassifyCore(string text, int caret)
+    {
+        if (caret < 0 || caret > text.Length) return None;
+        var prefix = text[..caret];
+
+        // Dot-commands are not TypeScript, so handle them before lexing: `.he` would otherwise look
+        // like a member access on an empty receiver. Mirrors DotCommands.IsDotCommand.
+        if (!prefix.Contains('\n') && prefix.TrimStart().StartsWith('.'))
+            return ClassifyDotCommand(prefix);
+
+        List<Token> tokens;
+        try
+        {
+            tokens = new Lexer(prefix).ScanTokens();
+        }
+        catch
+        {
+            // Malformed numerics, stray `#`, etc. Correct failure mode is to offer nothing.
+            return None;
+        }
+
+        // Drop EOF and any synthetic tokens without a real source offset.
+        var real = tokens.Where(t => t.Type != TokenType.EOF && t.Start >= 0).ToList();
+
+        // Coverage-gap guard: anything non-whitespace the lexer did not tokenize means the caret is
+        // inside a literal or comment.
+        var covered = real.Count == 0 ? 0 : real[^1].Start + real[^1].Lexeme.Length;
+        for (int i = covered; i < prefix.Length; i++)
+            if (!char.IsWhiteSpace(prefix[i]))
+                return None;
+
+        if (real.Count == 0)
+            return new ReplCompletionContext(ReplCompletionContextKind.Identifier, "", caret, null);
+
+        var last = real[^1];
+        var lastEndsAtCaret = last.Start + last.Lexeme.Length == caret;
+
+        // Completing directly after a literal is meaningless. Note `1.` arrives here as a single
+        // NUMBER token whose lexeme is "1." (the lexer absorbs the trailing dot), so this is also
+        // what stops `1.` from offering number members — there is no DOT token to react to.
+        if (lastEndsAtCaret && last.Type is TokenType.NUMBER or TokenType.BIGINT_LITERAL
+            or TokenType.STRING or TokenType.REGEX or TokenType.TEMPLATE_HEAD
+            or TokenType.TEMPLATE_MIDDLE or TokenType.TEMPLATE_TAIL or TokenType.TEMPLATE_FULL)
+            return None;
+
+        // `receiver.` — empty partial.
+        if (lastEndsAtCaret && IsDotToken(last.Type))
+            return BuildMember(text, real, dotIndex: real.Count - 1, partial: "", replaceStart: caret);
+
+        // `receiver.par` — partial after a dot.
+        if (lastEndsAtCaret && IsNameLike(last) && real.Count >= 2 && IsDotToken(real[^2].Type))
+            return BuildMember(text, real, dotIndex: real.Count - 2, last.Lexeme, last.Start);
+
+        // A bare identifier prefix.
+        if (lastEndsAtCaret && IsNameLike(last))
+            return new ReplCompletionContext(
+                ReplCompletionContextKind.Identifier, last.Lexeme, last.Start, null);
+
+        // Caret sits after whitespace or punctuation — offer the unfiltered identifier list.
+        return new ReplCompletionContext(ReplCompletionContextKind.Identifier, "", caret, null);
+    }
+
+    private static ReplCompletionContext ClassifyDotCommand(string prefix)
+    {
+        var dotIndex = prefix.Length - prefix.TrimStart().Length;
+        var rest = prefix[dotIndex..];
+
+        var spaceIndex = rest.IndexOf(' ');
+        if (spaceIndex < 0)
+            return new ReplCompletionContext(
+                ReplCompletionContextKind.DotCommand, rest, dotIndex, null);
+
+        // `.load ./src/fo` — the argument is a filesystem path for the file commands only.
+        var command = rest[..spaceIndex].ToLowerInvariant();
+        if (command is not (".load" or ".save"))
+            return None;
+
+        var argStart = dotIndex + spaceIndex + 1;
+        while (argStart < prefix.Length && prefix[argStart] == ' ') argStart++;
+        return new ReplCompletionContext(
+            ReplCompletionContextKind.DotCommandArgument, prefix[argStart..], argStart, null);
+    }
+
+    private static bool IsDotToken(TokenType type)
+        => type is TokenType.DOT or TokenType.QUESTION_DOT;
+
+    /// <summary>
+    /// True for tokens usable as a property name. Keywords count: the lexer claims <c>type</c>,
+    /// <c>get</c>, <c>default</c>, <c>of</c> and ~74 others, but they are all legal after a dot,
+    /// so <c>obj.type</c> must still complete.
+    /// </summary>
+    private static bool IsNameLike(Token token)
+        => token.Type == TokenType.IDENTIFIER || Lexer.KeywordTokenType(token.Lexeme) is not null;
+
+    /// <summary>
+    /// Builds a Member context by walking left from the dot to find the start of the receiver
+    /// expression, balancing bracket pairs so calls and indexers are included.
+    /// </summary>
+    private static ReplCompletionContext BuildMember(
+        string text, List<Token> tokens, int dotIndex, string partial, int replaceStart)
+    {
+        var receiverEnd = tokens[dotIndex].Start;
+        int start = dotIndex;
+        int depth = 0;
+        int i = dotIndex - 1;
+
+        while (i >= 0)
+        {
+            var type = tokens[i].Type;
+
+            if (type is TokenType.RIGHT_PAREN or TokenType.RIGHT_BRACKET or TokenType.RIGHT_BRACE)
+            {
+                depth++;
+                start = i--;
+                continue;
+            }
+
+            if (type is TokenType.LEFT_PAREN or TokenType.LEFT_BRACKET or TokenType.LEFT_BRACE)
+            {
+                // An unmatched opener belongs to an enclosing construct, so the receiver starts here.
+                if (depth == 0) break;
+                depth--;
+                start = i--;
+                continue;
+            }
+
+            // Inside a balanced group everything is part of the receiver.
+            if (depth > 0)
+            {
+                start = i--;
+                continue;
+            }
+
+            if (IsDotToken(type))
+            {
+                start = i--;
+                continue;
+            }
+
+            if (IsNameLike(tokens[i]) || type is TokenType.THIS or TokenType.SUPER)
+            {
+                start = i--;
+
+                // Keep walking only while the chain continues through a dot.
+                if (i >= 0 && IsDotToken(tokens[i].Type)) continue;
+
+                // `new C().foo` — the constructor call is part of the receiver.
+                if (i >= 0 && tokens[i].Type == TokenType.NEW) start = i;
+                break;
+            }
+
+            break;
+        }
+
+        var receiverStart = tokens[start].Start;
+        if (receiverStart >= receiverEnd) return None;
+
+        var receiver = text[receiverStart..receiverEnd].Trim();
+        return receiver.Length == 0
+            ? None
+            : new ReplCompletionContext(
+                ReplCompletionContextKind.Member, partial, replaceStart, receiver);
+    }
+}

--- a/Repl/ReplCompletionProvider.cs
+++ b/Repl/ReplCompletionProvider.cs
@@ -1,0 +1,349 @@
+using SharpTS.Execution;
+using SharpTS.Parsing;
+using SharpTS.Runtime.BuiltIns;
+using SharpTS.TypeSystem;
+
+namespace SharpTS.Repl;
+
+/// <summary>What kind of thing a completion candidate is. Drives ordering and colour.</summary>
+internal enum ReplCompletionKind
+{
+    /// <summary>A member of the receiver's type.</summary>
+    Member,
+
+    /// <summary>A variable/function/class declared in this session.</summary>
+    Binding,
+
+    /// <summary>A built-in global (console, Math, …).</summary>
+    Global,
+
+    /// <summary>A TypeScript reserved word.</summary>
+    Keyword,
+
+    /// <summary>A REPL dot-command.</summary>
+    DotCommand,
+
+    /// <summary>A filesystem entry.</summary>
+    FilePath,
+}
+
+/// <param name="Name">Text inserted when the candidate is committed.</param>
+/// <param name="Kind">Category, used for ranking and colour.</param>
+/// <param name="Detail">Optional tooltip text (a rendered type, or a command's help line).</param>
+internal sealed record ReplCompletionCandidate(
+    string Name,
+    ReplCompletionKind Kind,
+    string? Detail = null);
+
+/// <summary>
+/// The live REPL state that completion reads. Mutable, and handed to the callbacks by reference:
+/// <c>ReplEngine</c> builds its <c>PromptCallbacks</c> once before the read loop but replaces the
+/// interpreter and type checker on <c>.reset</c>, so the callbacks must never capture those
+/// instances directly.
+/// </summary>
+internal sealed class ReplCompletionSession(
+    Interpreter interpreter,
+    TypeChecker typeChecker,
+    DecoratorMode decoratorMode,
+    List<Stmt> accumulatedStatements)
+{
+    public Interpreter Interpreter { get; private set; } = interpreter;
+    public TypeChecker TypeChecker { get; private set; } = typeChecker;
+    public DecoratorMode DecoratorMode { get; } = decoratorMode;
+    public List<Stmt> AccumulatedStatements { get; } = accumulatedStatements;
+
+    /// <summary>
+    /// Bumped whenever the session's declarations change. Used as a cache key, so stale member
+    /// lists are never served after a new line is submitted or the session is reset.
+    /// </summary>
+    public int Generation { get; private set; }
+
+    public void OnStatementsAppended() => Generation++;
+
+    public void Replace(Interpreter interpreter, TypeChecker typeChecker)
+    {
+        Interpreter = interpreter;
+        TypeChecker = typeChecker;
+        Generation++;
+    }
+}
+
+/// <summary>
+/// Computes REPL autocomplete candidates. Deliberately separate from the PrettyPrompt callbacks so
+/// it can be unit-tested without a console: <c>ReplEngine.RunAsync</c> blocks on a real prompt and
+/// <c>PromptCallbacks</c> members are protected.
+/// </summary>
+/// <remarks>
+/// Member completion is resolved statically, through the <see cref="TypeChecker"/>, generalizing
+/// what the <c>.type</c> dot-command already does. That is what lets an arbitrary receiver
+/// expression — <c>getUser().</c>, <c>arr[0].</c> — complete, and it supplies each member's type for
+/// the tooltip. The one place static resolution has no answer is the built-in singletons, which the
+/// checker models as <c>any</c>; see <see cref="SingletonMembers"/>.
+/// </remarks>
+internal sealed class ReplCompletionProvider(ReplCompletionSession session)
+{
+    /// <summary>
+    /// Member names for the global singletons the type checker types as <c>any</c>
+    /// (<c>console</c>, <c>Math</c>, <c>JSON</c>, …). Without this, the most frequently typed
+    /// expressions in a REPL would offer nothing at all. Read straight from the built-in method
+    /// tables so the lists cannot drift from what actually dispatches at runtime.
+    /// </summary>
+    private static readonly Dictionary<string, Func<IEnumerable<string>>> SingletonMembers =
+        new(StringComparer.Ordinal)
+        {
+            ["console"] = () => ConsoleBuiltIns.MemberNames,
+            ["Math"] = () => MathBuiltIns.MemberNames,
+            ["JSON"] = () => JSONBuiltIns.MemberNames,
+            ["Object"] = () => ObjectBuiltIns.StaticMemberNames,
+            ["Number"] = () => NumberBuiltIns.StaticMemberNames,
+            ["String"] = () => StringBuiltIns.StaticMemberNames,
+        };
+
+    // Member lists for the current session generation only. Resolving a member means type-checking
+    // the whole accumulated session, which is far too expensive to redo for every keystroke, but the
+    // result is only valid until the session's declarations change — so the whole cache is dropped
+    // when the generation moves rather than accumulating one entry per generation forever.
+    private readonly Dictionary<string, List<ReplCompletionCandidate>> _memberCache = [];
+    private int _cachedGeneration = -1;
+
+    /// <summary>
+    /// The candidates for the caret position. Never throws; returns an empty list when nothing
+    /// applies, so a completion failure can never take down the prompt.
+    /// </summary>
+    public IReadOnlyList<ReplCompletionCandidate> GetCandidates(string text, int caret)
+    {
+        try
+        {
+            var context = ReplCompletionContext.Classify(text, caret);
+            return context.Kind switch
+            {
+                ReplCompletionContextKind.Member => GetMemberCandidates(context.Receiver!),
+                ReplCompletionContextKind.Identifier => GetIdentifierCandidates(),
+                ReplCompletionContextKind.DotCommand => GetDotCommandCandidates(),
+                ReplCompletionContextKind.DotCommandArgument => GetPathCandidates(context.Partial),
+                _ => [],
+            };
+        }
+        catch
+        {
+            return [];
+        }
+    }
+
+    // ===================== Members =====================
+
+    private List<ReplCompletionCandidate> GetMemberCandidates(string receiver)
+    {
+        if (_cachedGeneration != session.Generation)
+        {
+            _memberCache.Clear();
+            _cachedGeneration = session.Generation;
+        }
+        else if (_memberCache.TryGetValue(receiver, out var cached))
+        {
+            return cached;
+        }
+
+        var candidates = ResolveMembers(receiver);
+        _memberCache[receiver] = candidates;
+        return candidates;
+    }
+
+    private List<ReplCompletionCandidate> ResolveMembers(string receiver)
+    {
+        List<ReplCompletionCandidate> candidates = [];
+
+        var receiverType = ResolveReceiverType(receiver);
+
+        // The checker models the built-in singletons as `any`, so an `any` (or unresolvable)
+        // receiver falls back to the runtime member tables when it names one of them.
+        if (receiverType is null or TypeInfo.Any)
+            return SingletonFallback(receiver);
+
+        foreach (var (name, memberType) in session.TypeChecker.GetCompletionMembers(receiverType))
+        {
+            if (!IsCompletableName(name)) continue;
+            candidates.Add(new ReplCompletionCandidate(
+                name,
+                ReplCompletionKind.Member,
+                memberType is null ? null : Tooltip($"{name}: {memberType}")));
+        }
+
+        // A resolvable type with no members is still worth a singleton check: `Object` resolves to a
+        // real type in some positions but carries its statics only in the runtime table.
+        return candidates.Count == 0 ? SingletonFallback(receiver) : candidates;
+    }
+
+    private static List<ReplCompletionCandidate> SingletonFallback(string receiver)
+    {
+        if (!SingletonMembers.TryGetValue(receiver, out var names)) return [];
+        return names()
+            .Where(IsCompletableName)
+            .Select(n => new ReplCompletionCandidate(n, ReplCompletionKind.Member))
+            .ToList();
+    }
+
+    /// <summary>
+    /// Type-checks the receiver expression in the context of everything already submitted this
+    /// session, and returns its type. Diagnostics are discarded — accumulated statements may
+    /// legitimately contain type errors, and completion must stay silent either way.
+    /// </summary>
+    private TypeInfo? ResolveReceiverType(string receiver)
+    {
+        var parsed = TryParseExpression(receiver);
+        if (parsed is null) return null;
+
+        // The receiver is an expression statement, so it declares nothing and cannot pollute the
+        // checker's persistent environment.
+        var combined = new List<Stmt>(session.AccumulatedStatements);
+        combined.AddRange(parsed);
+
+        var lastExpression = parsed.OfType<Stmt.Expression>().LastOrDefault();
+        if (lastExpression is null) return null;
+
+        try
+        {
+            var result = session.TypeChecker.CheckWithRecovery(combined);
+            return result.TypeMap.TryGet(lastExpression.Expr, out var type) ? type : null;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Parses a receiver expression, retrying with a trailing semicolon — the same convenience the
+    /// REPL applies to submitted input.
+    /// </summary>
+    private List<Stmt>? TryParseExpression(string source)
+    {
+        foreach (var candidate in new[] { source, source + ";" })
+        {
+            try
+            {
+                var tokens = new Lexer(candidate).ScanTokens();
+                var result = new Parser(tokens, session.DecoratorMode).Parse();
+                if (result.IsSuccess) return result.Statements;
+            }
+            catch
+            {
+                // Try the next form.
+            }
+        }
+
+        return null;
+    }
+
+    // ===================== Identifiers, globals, keywords =====================
+
+    /// <summary>
+    /// Bindings, globals, and keywords. Deliberately does no type checking: the completion window
+    /// opens as the user types, so this path has to stay cheap.
+    /// </summary>
+    private List<ReplCompletionCandidate> GetIdentifierCandidates()
+    {
+        List<ReplCompletionCandidate> candidates = [];
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+
+        var interpreter = session.Interpreter;
+        if (!interpreter.IsDisposed)
+        {
+            // Innermost scope first, so an inner binding shadows an outer one of the same name.
+            for (var env = interpreter.Environment; env is not null; env = env.Enclosing)
+            {
+                // Snapshot: a timer callback drained at the next tick could otherwise mutate the
+                // dictionary while PrettyPrompt is still rendering.
+                foreach (var name in env.Names.ToList())
+                    if (IsCompletableName(name) && seen.Add(name))
+                        candidates.Add(new ReplCompletionCandidate(name, ReplCompletionKind.Binding));
+            }
+        }
+
+        // Two sources: the realm's constant table, plus the registered built-in namespaces. The
+        // latter is not redundant — `console` has no singleton instance, so it never lands in the
+        // realm table even though it is very much a global.
+        foreach (var name in Interpreter.GlobalNames.Concat(BuiltInRegistry.Instance.NamespaceNames))
+            if (IsCompletableName(name) && seen.Add(name))
+                candidates.Add(new ReplCompletionCandidate(name, ReplCompletionKind.Global));
+
+        foreach (var name in Lexer.KeywordNames)
+            if (seen.Add(name))
+                candidates.Add(new ReplCompletionCandidate(name, ReplCompletionKind.Keyword));
+
+        return candidates;
+    }
+
+    // ===================== Dot-commands and paths =====================
+
+    private static List<ReplCompletionCandidate> GetDotCommandCandidates() =>
+        DotCommands.Commands
+            .Select(c => new ReplCompletionCandidate(c.Name, ReplCompletionKind.DotCommand, c.Help))
+            .ToList();
+
+    /// <summary>
+    /// Filesystem entries for <c>.load</c> / <c>.save</c>. Enumerated relative to the process
+    /// working directory, which is what those commands resolve against.
+    /// </summary>
+    private static List<ReplCompletionCandidate> GetPathCandidates(string partial)
+    {
+        const int limit = 200;
+
+        var separator = partial.LastIndexOfAny(['/', '\\']);
+        var directoryPart = separator < 0 ? "" : partial[..(separator + 1)];
+        var searchDirectory = directoryPart.Length == 0 ? "." : directoryPart;
+
+        List<ReplCompletionCandidate> candidates = [];
+        try
+        {
+            foreach (var entry in Directory.EnumerateFileSystemEntries(searchDirectory))
+            {
+                var name = Path.GetFileName(entry);
+                if (name.Length == 0) continue;
+
+                var isDirectory = Directory.Exists(entry);
+                candidates.Add(new ReplCompletionCandidate(
+                    directoryPart + name + (isDirectory ? "/" : ""),
+                    ReplCompletionKind.FilePath));
+
+                if (candidates.Count >= limit) break;
+            }
+        }
+        catch
+        {
+            // Missing directory, permission denied, long path — offer nothing.
+        }
+
+        return candidates;
+    }
+
+    // ===================== Helpers =====================
+
+    /// <summary>
+    /// Flattens a rendered type onto one capped line. A recursive or deeply generic type can render
+    /// to something enormous, and it goes straight into the description pane beside the menu.
+    /// </summary>
+    private static string Tooltip(string text)
+    {
+        const int limit = 160;
+
+        var flattened = text.ReplaceLineEndings(" ");
+        return flattened.Length <= limit ? flattened : flattened[..(limit - 1)] + "…";
+    }
+
+    /// <summary>
+    /// True when a name can actually be typed as an identifier or after a dot. Filters synthetic
+    /// runtime slots (mangled or symbol-keyed names) that would be useless or invalid to insert.
+    /// </summary>
+    private static bool IsCompletableName(string name)
+    {
+        if (name.Length == 0) return false;
+        if (!char.IsLetter(name[0]) && name[0] is not ('_' or '$')) return false;
+
+        foreach (var c in name)
+            if (!char.IsLetterOrDigit(c) && c is not ('_' or '$'))
+                return false;
+
+        return true;
+    }
+}

--- a/Repl/ReplEngine.cs
+++ b/Repl/ReplEngine.cs
@@ -13,7 +13,7 @@ namespace SharpTS.Repl;
 /// Enhanced REPL engine using PrettyPrompt for multi-line editing,
 /// syntax highlighting, persistent history, and auto-display of results.
 /// </summary>
-public sealed class ReplEngine
+public sealed class ReplEngine : IDisposable
 {
     private Interpreter _interpreter;
     private VariableResolver _resolver;
@@ -21,6 +21,7 @@ public sealed class ReplEngine
     private readonly DecoratorMode _decoratorMode;
     private readonly List<string> _sessionHistory = [];
     private readonly List<Stmt> _accumulatedStatements = [];
+    private readonly ReplCompletionSession _completionSession;
 
     public ReplEngine(DecoratorMode decoratorMode)
     {
@@ -29,7 +30,19 @@ public sealed class ReplEngine
         _interpreter.SetDecoratorMode(decoratorMode);
         _resolver = new VariableResolver(_interpreter);
         _typeChecker = CreateTypeChecker();
+
+        // Holds the current interpreter/checker by reference so the prompt callbacks, which are
+        // built once before the read loop, keep working after `.reset` replaces them.
+        _completionSession = new ReplCompletionSession(
+            _interpreter, _typeChecker, decoratorMode, _accumulatedStatements);
+        Completions = new ReplCompletionProvider(_completionSession);
     }
+
+    /// <summary>
+    /// Autocomplete over the current session state. Exposed for tests, which cannot drive
+    /// <see cref="RunAsync"/> because it blocks on a real console prompt.
+    /// </summary>
+    internal ReplCompletionProvider Completions { get; }
 
     private TypeChecker CreateTypeChecker()
     {
@@ -47,7 +60,7 @@ public sealed class ReplEngine
         Directory.CreateDirectory(historyDir);
         var historyPath = Path.Combine(historyDir, "repl_history");
 
-        var callbacks = new ReplCallbacks();
+        var callbacks = new ReplCallbacks(Completions);
         var configuration = new PromptConfiguration(
             prompt: new FormattedString("> ", new FormatSpan(0, 2, AnsiColor.Cyan)));
 
@@ -55,6 +68,9 @@ public sealed class ReplEngine
             persistentHistoryFilepath: historyPath,
             callbacks: callbacks,
             configuration: configuration);
+
+        // Tracks a Ctrl+C that discarded the previous line, so a second one exits.
+        var cancelledPreviousLine = false;
 
         while (true)
         {
@@ -65,10 +81,21 @@ public sealed class ReplEngine
 
             if (!response.IsSuccess)
             {
-                // Ctrl+C was pressed — reset current input, continue loop
+                // Ctrl+C. PrettyPrompt reports it as an unsuccessful read whose text is always
+                // empty — so there is no way to tell a cancelled line from a cancelled empty
+                // prompt — and it suppresses process termination, which means this loop is the
+                // only thing that can end the session. A second consecutive press exits, matching
+                // the Node REPL. (Ctrl+D cannot be used for this: PrettyPrompt binds it to
+                // forward-delete, so it never reaches here.)
+                if (cancelledPreviousLine)
+                    break;
+
+                cancelledPreviousLine = true;
+                Console.WriteLine("(To exit, press Ctrl+C again or type .exit)");
                 continue;
             }
 
+            cancelledPreviousLine = false;
             var input = response.Text;
 
             if (string.IsNullOrWhiteSpace(input))
@@ -83,6 +110,10 @@ public sealed class ReplEngine
                     _decoratorMode, _sessionHistory, _accumulatedStatements);
                 commands.Execute(input);
 
+                // `.load` appends to the accumulated statements, so any dot-command may have
+                // changed what completion should offer.
+                _completionSession.OnStatementsAppended();
+
                 if (commands.ExitRequested)
                     break;
 
@@ -94,6 +125,8 @@ public sealed class ReplEngine
                     _resolver = new VariableResolver(_interpreter);
                     _typeChecker = CreateTypeChecker();
                     _accumulatedStatements.Clear();
+                    // Point completion at the new state and drop its cached member lists.
+                    _completionSession.Replace(_interpreter, _typeChecker);
                     Console.WriteLine("REPL state has been reset.");
                 }
 
@@ -142,6 +175,9 @@ public sealed class ReplEngine
         }
     }
 
+    /// <summary>Disposes the interpreter that owns the session's runtime state.</summary>
+    public void Dispose() => _interpreter.Dispose();
+
     private static ParseDiagnosticResult TryParse(string source, DecoratorMode decoratorMode)
     {
         var lexer = new Lexer(source);
@@ -150,7 +186,11 @@ public sealed class ReplEngine
         return parser.Parse();
     }
 
-    private void ExecuteInput(string source)
+    /// <summary>
+    /// Runs one line of REPL input: parse, resolve, interpret, accumulate.
+    /// Internal so tests can build up real session state without driving the console prompt.
+    /// </summary>
+    internal void ExecuteInput(string source)
     {
         try
         {
@@ -192,9 +232,10 @@ public sealed class ReplEngine
             // Execute and capture result
             var result = _interpreter.InterpretRepl(parseResult.Statements);
 
-            // Accumulate statements so .type can resolve types from previous inputs.
-            // Type checking is deferred — only runs when .type is actually invoked.
+            // Accumulate statements so .type and autocomplete can resolve types from previous
+            // inputs. Type checking is deferred — it only runs when one of them is invoked.
             _accumulatedStatements.AddRange(parseResult.Statements);
+            _completionSession.OnStatementsAppended();
 
             // Tick event loop after execution to process async work
             _interpreter.TickEventLoop();

--- a/Runtime/BuiltIns/BuiltInRegistry.cs
+++ b/Runtime/BuiltIns/BuiltInRegistry.cs
@@ -39,6 +39,13 @@ public sealed class BuiltInRegistry
     }
 
     /// <summary>
+    /// The names of every registered built-in namespace, for REPL autocomplete. Some of these
+    /// (notably <c>console</c>) have no singleton instance and so never reach the realm's global
+    /// constant table, making this the only complete source of built-in global names.
+    /// </summary>
+    public IEnumerable<string> NamespaceNames => _namespaces.Keys;
+
+    /// <summary>
     /// Gets the singleton instance for a namespace (e.g., Math returns SharpTSMath.Instance).
     /// </summary>
     /// <param name="name">The namespace name</param>

--- a/Runtime/BuiltIns/BuiltInTypeMemberLookup.cs
+++ b/Runtime/BuiltIns/BuiltInTypeMemberLookup.cs
@@ -24,6 +24,12 @@ public sealed class BuiltInTypeMemberLookup<TReceiver>
     }
 
     /// <summary>
+    /// The names of every property and method in this table, for REPL autocomplete.
+    /// The dispatch switches themselves are not enumerable, so completion reads the tables directly.
+    /// </summary>
+    public IEnumerable<string> MemberNames => _properties.Keys.Concat(_methods.Keys);
+
+    /// <summary>
     /// Gets a member (property or method) for an instance type.
     /// Methods are bound to the receiver before being returned.
     /// </summary>
@@ -69,6 +75,11 @@ public sealed class BuiltInStaticMemberLookup
         _methods = methods;
         _rawConstants = rawConstants;
     }
+
+    /// <summary>
+    /// The names of every constant and method in this table, for REPL autocomplete.
+    /// </summary>
+    public IEnumerable<string> MemberNames => _rawConstants.Keys.Concat(_methods.Keys);
 
     /// <summary>
     /// Gets a static member (constant or method).

--- a/Runtime/BuiltIns/ConsoleBuiltIns.cs
+++ b/Runtime/BuiltIns/ConsoleBuiltIns.cs
@@ -55,6 +55,9 @@ public static class ConsoleBuiltIns
     public static object? GetMember(string name)
         => _lookup.GetMember(name);
 
+    /// <summary>Member names for REPL autocomplete.</summary>
+    public static IEnumerable<string> MemberNames => _lookup.MemberNames;
+
     // ===================== Helper Methods =====================
 
     /// <summary>

--- a/Runtime/BuiltIns/JSONBuiltIns.cs
+++ b/Runtime/BuiltIns/JSONBuiltIns.cs
@@ -24,6 +24,9 @@ public static class JSONBuiltIns
 
     public static object? GetStaticMethod(string name) => _lookup.GetMember(name);
 
+    /// <summary>Member names for REPL autocomplete.</summary>
+    public static IEnumerable<string> MemberNames => _lookup.MemberNames;
+
     private static RuntimeValue ParseJson(Interpreter interp, RuntimeValue _, ReadOnlySpan<RuntimeValue> args)
     {
         var text = args[0].ToObject()?.ToString() ?? "null";

--- a/Runtime/BuiltIns/MathBuiltIns.cs
+++ b/Runtime/BuiltIns/MathBuiltIns.cs
@@ -64,6 +64,9 @@ public static class MathBuiltIns
     public static object? GetMember(string name)
         => _lookup.GetMember(name);
 
+    /// <summary>Member names for REPL autocomplete.</summary>
+    public static IEnumerable<string> MemberNames => _lookup.MemberNames;
+
     private static RuntimeValue Min(Interpreter _, RuntimeValue receiver, ReadOnlySpan<RuntimeValue> args)
     {
         if (args.Length == 0) return RuntimeValue.FromNumber(double.PositiveInfinity);

--- a/Runtime/BuiltIns/NumberBuiltIns.cs
+++ b/Runtime/BuiltIns/NumberBuiltIns.cs
@@ -75,6 +75,9 @@ public static class NumberBuiltIns
     public static object? GetStaticMember(string name)
         => _staticLookup.GetMember(name);
 
+    /// <summary>Static member names for REPL autocomplete.</summary>
+    public static IEnumerable<string> StaticMemberNames => _staticLookup.MemberNames;
+
     /// <summary>
     /// Gets an instance member for a number value (e.g., (123).toFixed(2)).
     /// </summary>

--- a/Runtime/BuiltIns/ObjectBuiltIns.cs
+++ b/Runtime/BuiltIns/ObjectBuiltIns.cs
@@ -40,6 +40,9 @@ public static partial class ObjectBuiltIns
     public static object? GetStaticMethod(string name)
         => _staticLookup.GetMember(name);
 
+    /// <summary>Static member names for REPL autocomplete.</summary>
+    public static IEnumerable<string> StaticMemberNames => _staticLookup.MemberNames;
+
     /// <summary>
     /// Enumerates the own enumerable (key, value) pairs of a receiver, encoding the
     /// Object.keys/values/entries receiver-type ladder once. Branch order and per-branch

--- a/Runtime/BuiltIns/StringBuiltIns.cs
+++ b/Runtime/BuiltIns/StringBuiltIns.cs
@@ -69,6 +69,9 @@ public static class StringBuiltIns
     public static object? GetStaticMember(string name)
         => _staticLookup.GetMember(name);
 
+    /// <summary>Static member names for REPL autocomplete.</summary>
+    public static IEnumerable<string> StaticMemberNames => _staticLookup.MemberNames;
+
     /// <summary>
     /// Returns the unbound <see cref="BuiltInMethod"/> for a
     /// String.prototype.* method, or null if no such method exists. Used by

--- a/Runtime/ScopeChain.cs
+++ b/Runtime/ScopeChain.cs
@@ -37,6 +37,15 @@ public abstract class ScopeChain<TValue, TSelf> where TSelf : ScopeChain<TValue,
     }
 
     /// <summary>
+    /// The names defined directly in this scope, excluding enclosing scopes.
+    /// Walk <see cref="Enclosing"/> to enumerate the whole chain.
+    /// </summary>
+    /// <remarks>
+    /// Used by REPL autocomplete to list the bindings currently in scope.
+    /// </remarks>
+    public IEnumerable<string> Names => _values.Keys;
+
+    /// <summary>
     /// Defines a variable in the current scope.
     /// </summary>
     public void Define(string name, TValue value) => _values[name] = value;

--- a/SharpTS.Tests/ReplTests/ReplCompletionProviderTests.cs
+++ b/SharpTS.Tests/ReplTests/ReplCompletionProviderTests.cs
@@ -1,0 +1,643 @@
+using SharpTS.Parsing;
+using SharpTS.Repl;
+using Xunit;
+
+namespace SharpTS.Tests.ReplTests;
+
+/// <summary>
+/// Tests for REPL autocomplete. Candidate computation lives in <see cref="ReplCompletionProvider"/>
+/// precisely so it can be exercised here without a console — <c>ReplEngine.RunAsync</c> blocks on a
+/// real PrettyPrompt instance, and the callbacks themselves are protected.
+/// </summary>
+public class ReplCompletionProviderTests
+{
+    /// <summary>
+    /// Builds a REPL session by running each line through the real
+    /// parse → resolve → interpret → accumulate pipeline, so tests see genuine session state.
+    /// </summary>
+    private static ReplEngine Session(params string[] lines)
+    {
+        var engine = new ReplEngine(DecoratorMode.Stage3);
+        foreach (var line in lines)
+            engine.ExecuteInput(line);
+        return engine;
+    }
+
+    private static List<string> Names(ReplEngine engine, string text) =>
+        engine.Completions.GetCandidates(text, text.Length).Select(c => c.Name).ToList();
+
+    private static List<string> Names(ReplEngine engine, string text, int caret) =>
+        engine.Completions.GetCandidates(text, caret).Select(c => c.Name).ToList();
+
+    // ===================== Context classification =====================
+
+    [Theory]
+    [InlineData("foo.", "foo", "")]
+    [InlineData("foo.ba", "foo", "ba")]
+    [InlineData("foo?.ba", "foo", "ba")]
+    [InlineData("foo.bar.ba", "foo.bar", "ba")]
+    [InlineData("getUser().", "getUser()", "")]
+    [InlineData("arr[0].", "arr[0]", "")]
+    [InlineData("(a ?? b).", "(a ?? b)", "")]
+    [InlineData("new C().", "new C()", "")]
+    [InlineData("x = foo.", "foo", "")]
+    [InlineData("1 + foo.ba", "foo", "ba")]
+    [InlineData("console.log(d.", "d", "")]
+    public void Classify_MemberContext_ExtractsReceiverAndPartial(
+        string text, string expectedReceiver, string expectedPartial)
+    {
+        var context = ReplCompletionContext.Classify(text, text.Length);
+
+        Assert.Equal(ReplCompletionContextKind.Member, context.Kind);
+        Assert.Equal(expectedReceiver, context.Receiver);
+        Assert.Equal(expectedPartial, context.Partial);
+    }
+
+    [Theory]
+    // Keyword lexemes are legal property names, so these must still complete as members.
+    [InlineData("m.get", "get")]
+    [InlineData("p.type", "type")]
+    [InlineData("s.default", "default")]
+    [InlineData("p.catch", "catch")]
+    public void Classify_KeywordNamedMember_IsStillAMember(string text, string expectedPartial)
+    {
+        var context = ReplCompletionContext.Classify(text, text.Length);
+
+        Assert.Equal(ReplCompletionContextKind.Member, context.Kind);
+        Assert.Equal(expectedPartial, context.Partial);
+    }
+
+    [Theory]
+    [InlineData("\"hello wor")]        // unterminated string
+    [InlineData("'hello wor")]
+    [InlineData("`hello wor")]         // unterminated template
+    [InlineData("\"abc\".x + \"de")]
+    [InlineData("// comm")]            // line comment
+    [InlineData("x + // comm")]
+    [InlineData("/* comm")]            // unterminated block comment
+    [InlineData("obj. // trailing")]
+    [InlineData("1.")]                 // numeric literal, not a member access
+    [InlineData("1.5")]
+    [InlineData("\"abc\"")]            // directly after a closed literal
+    public void Classify_SuppressedPositions_OfferNothing(string text)
+    {
+        var context = ReplCompletionContext.Classify(text, text.Length);
+
+        Assert.Equal(ReplCompletionContextKind.None, context.Kind);
+    }
+
+    [Fact]
+    public void Classify_InsideTemplateInterpolation_CompletesAsMember()
+    {
+        // `${` opens real code, so completion should work inside it.
+        var context = ReplCompletionContext.Classify("`total: ${obj.", 14);
+
+        Assert.Equal(ReplCompletionContextKind.Member, context.Kind);
+        Assert.Equal("obj", context.Receiver);
+    }
+
+    [Fact]
+    public void Classify_AfterClosedComment_StillCompletes()
+    {
+        var context = ReplCompletionContext.Classify("x + /* c */ fo", 14);
+
+        Assert.Equal(ReplCompletionContextKind.Identifier, context.Kind);
+        Assert.Equal("fo", context.Partial);
+    }
+
+    [Fact]
+    public void Classify_DollarPrefixedIdentifier_ReplacesTheWholeWord()
+    {
+        // The default word detection excludes '$', which would commit "$foo" over "fo" as "$$foo".
+        var context = ReplCompletionContext.Classify("$fo", 3);
+
+        Assert.Equal(ReplCompletionContextKind.Identifier, context.Kind);
+        Assert.Equal("$fo", context.Partial);
+        Assert.Equal(0, context.ReplaceStart);
+    }
+
+    [Fact]
+    public void Classify_CaretInsideWord_UsesTextBeforeCaretOnly()
+    {
+        var context = ReplCompletionContext.Classify("foo.bar", 6);
+
+        Assert.Equal(ReplCompletionContextKind.Member, context.Kind);
+        Assert.Equal("foo", context.Receiver);
+        Assert.Equal("ba", context.Partial);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Classify_EmptyInput_IsAnUnfilteredIdentifierContext(string text)
+    {
+        var context = ReplCompletionContext.Classify(text, text.Length);
+
+        Assert.Equal(ReplCompletionContextKind.Identifier, context.Kind);
+        Assert.Equal("", context.Partial);
+    }
+
+    [Theory]
+    [InlineData(".")]
+    [InlineData("..")]
+    [InlineData("a??.")]
+    [InlineData("=>.")]
+    [InlineData("0x")]
+    [InlineData("1_")]
+    [InlineData("/re")]
+    [InlineData("#bad")]
+    [InlineData("}.")]
+    [InlineData("({}).x.")]
+    public void GetCandidates_HostileInput_NeverThrows(string text)
+    {
+        using var engine = Session();
+
+        // The assertion is that this does not throw; an empty list is a fine answer.
+        Assert.NotNull(engine.Completions.GetCandidates(text, text.Length));
+    }
+
+    // ===================== Member completion via the type checker =====================
+
+    [Fact]
+    public void Members_OfString_ComeFromTheStringApparentMembers()
+    {
+        using var engine = Session("const s = \"x\";");
+
+        var names = Names(engine, "s.");
+
+        Assert.Contains("charAt", names);
+        Assert.Contains("toUpperCase", names);
+        Assert.Contains("length", names);
+    }
+
+    [Fact]
+    public void Members_OfArray_ComeFromTheArrayApparentMembers()
+    {
+        using var engine = Session("const a = [1, 2, 3];");
+
+        var names = Names(engine, "a.");
+
+        Assert.Contains("push", names);
+        Assert.Contains("map", names);
+        Assert.Contains("length", names);
+    }
+
+    [Fact]
+    public void Members_OfObjectLiteral_AreItsOwnFields()
+    {
+        using var engine = Session("const p = { name: \"a\", age: 1 };");
+
+        var names = Names(engine, "p.");
+
+        Assert.Contains("name", names);
+        Assert.Contains("age", names);
+    }
+
+    [Fact]
+    public void Members_OfClassInstance_IncludePublicMembersOnly()
+    {
+        using var engine = Session(
+            "class C { x = 1; m() {} get g() { return 1; } private secret = 2; }",
+            "const c = new C();");
+
+        var names = Names(engine, "c.");
+
+        Assert.Contains("x", names);
+        Assert.Contains("m", names);
+        Assert.Contains("g", names);
+        Assert.DoesNotContain("secret", names);
+        Assert.DoesNotContain("constructor", names);
+    }
+
+    [Fact]
+    public void Members_OfSubclassInstance_IncludeInheritedMembers()
+    {
+        // Regression guard: keyof-style enumeration does not walk the superclass chain, so
+        // inherited members must come from the class-specific collector instead.
+        using var engine = Session(
+            "class Base { baseMethod() {} }",
+            "class Derived extends Base { derivedMethod() {} }",
+            "const d = new Derived();");
+
+        var names = Names(engine, "d.");
+
+        Assert.Contains("derivedMethod", names);
+        Assert.Contains("baseMethod", names);
+    }
+
+    [Fact]
+    public void Members_OfClassReference_AreStaticsNotInstanceMembers()
+    {
+        using var engine = Session("class C { static create() {} instanceMethod() {} }");
+
+        var names = Names(engine, "C.");
+
+        Assert.Contains("create", names);
+        Assert.DoesNotContain("instanceMethod", names);
+    }
+
+    [Fact]
+    public void Members_OfInterfaceTypedBinding_IncludeInheritedMembers()
+    {
+        using var engine = Session(
+            "interface A { a: number; }",
+            "interface B extends A { b: number; }",
+            "const value: B = { a: 1, b: 2 };");
+
+        var names = Names(engine, "value.");
+
+        Assert.Contains("b", names);
+        Assert.Contains("a", names);
+    }
+
+    [Fact]
+    public void Members_OfCallResult_ResolveThroughTheExpression()
+    {
+        // The motivating case for resolving receivers through the type checker: a call result has
+        // no live value to inspect until it is evaluated.
+        using var engine = Session("function makeText(): string { return \"x\"; }");
+
+        var names = Names(engine, "makeText().");
+
+        Assert.Contains("charAt", names);
+    }
+
+    [Fact]
+    public void Members_OfIndexedElement_ResolveThroughTheExpression()
+    {
+        using var engine = Session("const words = [\"a\", \"b\"];");
+
+        var names = Names(engine, "words[0].");
+
+        Assert.Contains("charAt", names);
+    }
+
+    [Fact]
+    public void Members_OfNestedProperty_ResolveThroughTheChain()
+    {
+        using var engine = Session("const o = { inner: { deep: \"s\" } };");
+
+        var names = Names(engine, "o.inner.deep.");
+
+        Assert.Contains("charAt", names);
+    }
+
+    [Fact]
+    public void Members_OfMapInstance_ComeFromTheBuiltInModel()
+    {
+        using var engine = Session("const m = new Map<string, number>();");
+
+        var names = Names(engine, "m.");
+
+        Assert.Contains("get", names);
+        Assert.Contains("set", names);
+        Assert.Contains("has", names);
+    }
+
+    [Fact]
+    public void Members_OfUnionTypedBinding_AreTheCommonMembersOnly()
+    {
+        using var engine = Session(
+            "let u: { a: number; b: number } | { a: number; c: number } = { a: 1, b: 2 };");
+
+        var names = Names(engine, "u.");
+
+        Assert.Contains("a", names);
+        Assert.DoesNotContain("b", names);
+        Assert.DoesNotContain("c", names);
+    }
+
+    [Fact]
+    public void Members_CarryTheirTypeAsTooltipDetail()
+    {
+        using var engine = Session("const p = { name: \"a\" };");
+
+        var name = engine.Completions
+            .GetCandidates("p.", 2)
+            .Single(c => c.Name == "name");
+
+        Assert.Equal(ReplCompletionKind.Member, name.Kind);
+        Assert.NotNull(name.Detail);
+        Assert.Contains("string", name.Detail);
+    }
+
+    [Fact]
+    public void Members_TooltipsAreSingleLineAndBounded()
+    {
+        // Tooltip text goes straight into the description pane; a recursive or deeply generic type
+        // can render to something enormous or multi-line.
+        using var engine = Session(
+            "interface Big { a: string; b: number; c: (x: string, y: number) => string; }",
+            "const big: Big = { a: \"\", b: 0, c: (x, y) => x };");
+
+        var details = engine.Completions
+            .GetCandidates("big.", 4)
+            .Select(c => c.Detail)
+            .Where(d => d is not null)
+            .ToList();
+
+        Assert.NotEmpty(details);
+        Assert.All(details, d =>
+        {
+            Assert.DoesNotContain('\n', d!);
+            Assert.DoesNotContain('\r', d!);
+            Assert.True(d!.Length <= 160, $"tooltip too long: {d.Length}");
+        });
+    }
+
+    [Fact]
+    public void Members_OfUnknownReceiver_AreEmpty()
+    {
+        using var engine = Session();
+
+        Assert.Empty(Names(engine, "definitelyNotDefined."));
+    }
+
+    // ===================== Built-in singletons =====================
+
+    [Theory]
+    [InlineData("console.", "log")]
+    [InlineData("console.", "error")]
+    [InlineData("Math.", "floor")]
+    [InlineData("Math.", "max")]
+    [InlineData("JSON.", "parse")]
+    [InlineData("JSON.", "stringify")]
+    [InlineData("Object.", "keys")]
+    public void Members_OfAnyTypedSingletons_FallBackToTheRuntimeTables(string text, string expected)
+    {
+        // The checker types console/Math/JSON/Object as `any`, so these would offer nothing at all
+        // without the runtime member-table fallback.
+        using var engine = Session();
+
+        Assert.Contains(expected, Names(engine, text));
+    }
+
+    // ===================== Identifiers, globals, keywords =====================
+
+    [Fact]
+    public void Identifiers_IncludeSessionBindings()
+    {
+        using var engine = Session("const myThing = 1;", "function myFunc() {}", "class MyClass {}");
+
+        var names = Names(engine, "my");
+
+        Assert.Contains("myThing", names);
+        Assert.Contains("myFunc", names);
+        Assert.Contains("MyClass", names);
+    }
+
+    [Fact]
+    public void Identifiers_IncludeGlobalsAndKeywords()
+    {
+        using var engine = Session();
+
+        var names = Names(engine, "c");
+
+        Assert.Contains("console", names);
+        Assert.Contains("const", names);
+        Assert.Contains("Math", names);
+    }
+
+    [Fact]
+    public void Identifiers_AreCategorisedForRanking()
+    {
+        using var engine = Session("const myThing = 1;");
+
+        var candidates = engine.Completions.GetCandidates("m", 1);
+
+        Assert.Equal(
+            ReplCompletionKind.Binding,
+            candidates.Single(c => c.Name == "myThing").Kind);
+        Assert.Equal(
+            ReplCompletionKind.Global,
+            candidates.Single(c => c.Name == "Math").Kind);
+        Assert.Equal(
+            ReplCompletionKind.Keyword,
+            candidates.Single(c => c.Name == "module").Kind);
+    }
+
+    [Fact]
+    public void Identifiers_ShadowedNameAppearsOnce()
+    {
+        using var engine = Session("const Math = 1;");
+
+        var matches = engine.Completions.GetCandidates("Ma", 2).Where(c => c.Name == "Math").ToList();
+
+        Assert.Single(matches);
+        Assert.Equal(ReplCompletionKind.Binding, matches[0].Kind);
+    }
+
+    [Fact]
+    public void Identifiers_AreNotOfferedInAMemberPosition()
+    {
+        using var engine = Session("const s = \"x\";");
+
+        var names = Names(engine, "s.");
+
+        Assert.DoesNotContain("console", names);
+        Assert.DoesNotContain("const", names);
+    }
+
+    // ===================== Dot-commands and paths =====================
+
+    [Fact]
+    public void DotCommands_AreOfferedAtTheStartOfALine()
+    {
+        using var engine = Session();
+
+        var names = Names(engine, ".");
+
+        Assert.Contains(".help", names);
+        Assert.Contains(".exit", names);
+        Assert.Contains(".type", names);
+        Assert.Equal(DotCommands.Commands.Length, names.Count);
+    }
+
+    [Fact]
+    public void DotCommands_ReplacementSpanCoversTheLeadingDot()
+    {
+        // Otherwise committing ".help" over ".he" would produce "..help".
+        var context = ReplCompletionContext.Classify(".he", 3);
+
+        Assert.Equal(ReplCompletionContextKind.DotCommand, context.Kind);
+        Assert.Equal(0, context.ReplaceStart);
+        Assert.Equal(".he", context.Partial);
+    }
+
+    [Fact]
+    public void DotCommands_CarryTheirHelpTextAsTooltipDetail()
+    {
+        using var engine = Session();
+
+        var help = engine.Completions.GetCandidates(".", 1).Single(c => c.Name == ".help");
+
+        Assert.Equal(ReplCompletionKind.DotCommand, help.Kind);
+        Assert.Equal("Show this help message", help.Detail);
+    }
+
+    [Fact]
+    public void DotCommands_NonFileCommandArgumentsOfferNothing()
+    {
+        var context = ReplCompletionContext.Classify(".exit now", 9);
+
+        Assert.Equal(ReplCompletionContextKind.None, context.Kind);
+    }
+
+    [Theory]
+    [InlineData(".load ")]
+    [InlineData(".save ./")]
+    public void DotCommands_FileArgumentsAreAPathContext(string text)
+    {
+        var context = ReplCompletionContext.Classify(text, text.Length);
+
+        Assert.Equal(ReplCompletionContextKind.DotCommandArgument, context.Kind);
+    }
+
+    [Fact]
+    public void DotCommands_LoadOffersFilesystemEntries()
+    {
+        using var engine = Session();
+
+        var candidates = engine.Completions.GetCandidates(".load ", 6);
+
+        // The working directory always has something in it; the point is that paths are offered.
+        Assert.NotEmpty(candidates);
+        Assert.All(candidates, c => Assert.Equal(ReplCompletionKind.FilePath, c.Kind));
+    }
+
+    // ===================== Trigger and commit policy =====================
+
+    [Theory]
+    [InlineData("co", true)]            // typing a word suggests as you go
+    [InlineData("obj.", true)]          // and immediately after a dot
+    [InlineData("obj.ba", true)]
+    [InlineData(".he", true)]           // and for dot-commands
+    [InlineData("", false)]             // but not on a bare prompt
+    [InlineData("x + ", false)]         // nor after an operator with no word started
+    [InlineData("\"hello wor", false)]  // never inside a string
+    [InlineData("// note", false)]      // nor a comment
+    [InlineData("1.", false)]           // nor after a numeric literal
+    public void TriggerPolicy_OpensOnlyWhereCompletionApplies(string text, bool expected)
+    {
+        Assert.Equal(expected, ReplCallbacks.ShouldOpenCompletionWindow(text, text.Length));
+    }
+
+    [Fact]
+    public void CommitPolicy_TabAlwaysCommits()
+    {
+        Assert.True(ReplCallbacks.ShouldCommitCompletion(ConsoleKey.Tab, "console"));
+        Assert.True(ReplCallbacks.ShouldCommitCompletion(ConsoleKey.Tab, "function f() {"));
+    }
+
+    [Fact]
+    public void CommitPolicy_EnterSubmitsAFinishedLineInsteadOfCommitting()
+    {
+        // Otherwise the menu, which is open most of the time, would swallow every Enter.
+        Assert.False(ReplCallbacks.ShouldCommitCompletion(ConsoleKey.Enter, "console"));
+    }
+
+    [Fact]
+    public void CommitPolicy_EnterStillCommitsWhileInputIsIncomplete()
+    {
+        // Load-bearing: PrettyPrompt skips the Enter-to-newline transform whenever a key would
+        // commit a completion, so rejecting Enter here would break multi-line editing. Restricting
+        // the rejection to complete input keeps the bypass confined to cases where that transform
+        // would have done nothing.
+        Assert.True(ReplCallbacks.ShouldCommitCompletion(ConsoleKey.Enter, "function f() {"));
+        Assert.True(ReplCallbacks.ShouldCommitCompletion(ConsoleKey.Enter, "foo(bar"));
+    }
+
+    // ===================== PrettyPrompt item mapping =====================
+
+    /// <summary>
+    /// Invokes a protected <c>PromptCallbacks</c> override. PrettyPrompt's <c>Prompt</c> cannot be
+    /// constructed without a real terminal (it fails in console-mode setup), so the callbacks are
+    /// driven directly to cover the candidate-to-<c>CompletionItem</c> mapping that the provider
+    /// tests above do not reach.
+    /// </summary>
+    private static object InvokeCallback(ReplCallbacks callbacks, string name, params object?[] args)
+    {
+        var method = typeof(ReplCallbacks).GetMethod(
+            name,
+            System.Reflection.BindingFlags.Instance
+                | System.Reflection.BindingFlags.NonPublic
+                | System.Reflection.BindingFlags.Public)
+            ?? throw new InvalidOperationException($"{name} not found");
+
+        var task = method.Invoke(callbacks, args)
+            ?? throw new InvalidOperationException($"{name} returned null");
+
+        return task.GetType().GetProperty("Result")!.GetValue(task)!;
+    }
+
+    [Fact]
+    public void Callbacks_MapCandidatesToUsableCompletionItems()
+    {
+        using var engine = Session("const greeting = \"hi\";");
+        var callbacks = new ReplCallbacks(engine.Completions);
+
+        var items = (IReadOnlyList<PrettyPrompt.Completion.CompletionItem>)InvokeCallback(
+            callbacks,
+            "GetCompletionItemsAsync",
+            "greeting.", 9, new PrettyPrompt.Documents.TextSpan(9, 0), CancellationToken.None);
+
+        var charAt = items.Single(i => i.ReplacementText == "charAt");
+        Assert.Equal("charAt", charAt.FilterText);
+        Assert.Equal("charAt", charAt.DisplayText);
+    }
+
+    [Fact]
+    public void Callbacks_RankSessionBindingsAboveGlobalsAndKeywords()
+    {
+        using var engine = Session("const cx = 1;");
+        var callbacks = new ReplCallbacks(engine.Completions);
+        var span = new PrettyPrompt.Documents.TextSpan(0, 1);
+
+        var items = (IReadOnlyList<PrettyPrompt.Completion.CompletionItem>)InvokeCallback(
+            callbacks, "GetCompletionItemsAsync", "c", 1, span, CancellationToken.None);
+
+        int Priority(string name) =>
+            items.Single(i => i.ReplacementText == name).GetCompletionItemPriority("c", 1, span);
+
+        Assert.True(Priority("cx") > Priority("crypto"));
+        Assert.True(Priority("crypto") > Priority("class"));
+    }
+
+    [Fact]
+    public void Callbacks_ReplacementSpanCoversADollarPrefixedWord()
+    {
+        using var engine = Session();
+        var callbacks = new ReplCallbacks(engine.Completions);
+
+        var span = (PrettyPrompt.Documents.TextSpan)InvokeCallback(
+            callbacks, "GetSpanToReplaceByCompletionAsync", "$fo", 3, CancellationToken.None);
+
+        Assert.Equal(0, span.Start);
+        Assert.Equal(3, span.Length);
+    }
+
+    // ===================== Session lifecycle =====================
+
+    [Fact]
+    public void Completion_ReflectsBindingsAddedAfterTheProviderWasBuilt()
+    {
+        using var engine = Session();
+        Assert.DoesNotContain("later", Names(engine, "la"));
+
+        engine.ExecuteInput("const later = \"x\";");
+
+        Assert.Contains("later", Names(engine, "la"));
+        Assert.Contains("charAt", Names(engine, "later."));
+    }
+
+    [Fact]
+    public void Completion_MemberListIsNotStaleAfterARedeclaration()
+    {
+        using var engine = Session("const v = \"x\";");
+        Assert.Contains("charAt", Names(engine, "v."));
+
+        engine.ExecuteInput("const v2 = [1];");
+
+        Assert.Contains("push", Names(engine, "v2."));
+    }
+}

--- a/TypeSystem/TypeChecker.Completion.cs
+++ b/TypeSystem/TypeChecker.Completion.cs
@@ -1,0 +1,113 @@
+namespace SharpTS.TypeSystem;
+
+/// <summary>
+/// Member enumeration for REPL autocomplete.
+/// </summary>
+/// <remarks>
+/// Completion needs the *apparent members* of a type — the names you can legally write after a dot.
+/// That is very close to what <c>keyof</c> already computes, so this reuses the existing
+/// <see cref="ExtractKeys"/> machinery rather than duplicating a second member table. The one place
+/// keyof semantics differ from completion semantics is classes: <c>ExtractKeys</c>'s Class case does
+/// not walk the superclass chain, so classes and instances are routed through
+/// <c>CollectPublicInstanceMembers</c> instead, which does (and also yields member types for tooltips).
+/// </remarks>
+public partial class TypeChecker
+{
+    /// <summary>
+    /// The member names of <paramref name="type"/> paired with each member's type where it is known,
+    /// for REPL autocomplete. Returns an empty list for types with no apparent members.
+    /// </summary>
+    internal List<(string Name, TypeInfo? Type)> GetCompletionMembers(TypeInfo type)
+    {
+        List<(string, TypeInfo?)> members = [];
+
+        // A literal type's apparent members are those of its base primitive — `const s = "x"` infers
+        // the literal type `"x"`, and `s.` must still offer the string methods.
+        type = type switch
+        {
+            TypeInfo.StringLiteral => TypeInfo.String.Shared,
+            TypeInfo.NumberLiteral => new TypeInfo.Primitive(Parsing.TokenType.TYPE_NUMBER),
+            TypeInfo.BooleanLiteral => new TypeInfo.Primitive(Parsing.TokenType.TYPE_BOOLEAN),
+            _ => type,
+        };
+
+        // An *instance* of a class: instance members, walking the superclass chain so inherited
+        // members are offered too.
+        if (type is TypeInfo.Instance inst && inst.ResolvedClassType is TypeInfo.Class instCls)
+        {
+            foreach (var (name, memberType) in CollectPublicInstanceMembers(instCls))
+                members.Add((name, memberType));
+            return members;
+        }
+
+        switch (type)
+        {
+            // A *reference* to the class itself (`MyClass.` rather than `new MyClass().`) exposes
+            // statics, not instance members. Keyof-style member enumeration returns the instance
+            // side for a Class, so this case must be handled separately or `MyClass.` would wrongly
+            // offer instance methods.
+            case TypeInfo.Class cls:
+                CollectPublicStatics(cls, members);
+                return members;
+
+            // Interfaces expose inherited members through GetAllMembers; records carry their fields
+            // directly. Both give us member types, which ExtractKeys (name-only) would throw away.
+            case TypeInfo.Interface itf:
+                foreach (var (name, memberType) in itf.GetAllMembers())
+                    members.Add((name, memberType));
+                return members;
+
+            case TypeInfo.Record rec:
+                foreach (var (name, memberType) in rec.Fields)
+                    members.Add((name, memberType));
+                return members;
+
+            case TypeInfo.Enum en:
+                foreach (var name in en.Members.Keys)
+                    members.Add((name, null));
+                return members;
+        }
+
+        // Everything else — string/array/tuple apparent members, generics, unions (common members
+        // only), intersections, and the structurally-modelled built-ins (Date, Map, Set, Promise,
+        // Error, …) — comes from the keyof projection.
+        foreach (var key in ExtractKeys(type))
+        {
+            // Index-signature key types (string/number/symbol) and unresolved `keyof T` are not
+            // member names; only string literals are.
+            if (key is not TypeInfo.StringLiteral literal) continue;
+
+            var name = literal.Value;
+            if (name.Length == 0) continue;
+
+            // Tuples contribute their element indices ("0", "1", …) as keys. `x.0` is not valid
+            // syntax, so they are not completion candidates.
+            if (char.IsAsciiDigit(name[0])) continue;
+
+            members.Add((name, Runtime.BuiltIns.BuiltInTypes.GetInstanceMemberType(type, name)));
+        }
+
+        return members;
+    }
+
+    /// <summary>
+    /// Collects the public static methods and properties of a class and its superclasses.
+    /// Derived statics shadow inherited ones, mirroring <c>CollectPublicInstanceMembers</c>.
+    /// </summary>
+    private static void CollectPublicStatics(TypeInfo.Class cls, List<(string, TypeInfo?)> members)
+    {
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        TypeInfo? current = cls;
+        while (current is TypeInfo.Class c)
+        {
+            var core = c.Core;
+            foreach (var (name, type) in core.StaticMethods)
+                if (IsPublicMember(core.StaticMethodAccessMap, name) && seen.Add(name))
+                    members.Add((name, type));
+            foreach (var (name, type) in core.StaticProperties)
+                if (IsPublicMember(core.StaticFieldAccessMap, name) && seen.Add(name))
+                    members.Add((name, type));
+            current = GetSuperclass(current);
+        }
+    }
+}


### PR DESCRIPTION
## What

The REPL was already built on PrettyPrompt, which ships a completion pane — but the completion callbacks were never implemented, so Tab did nothing. This wires up IntelliSense-style autocomplete:

- **as you type** — session variables/functions/classes, built-in globals, keywords
- **after `.`** — the members of the receiver's *type*, with each member's signature as a tooltip
- **at the start of a line** — dot-commands, and filesystem paths for `.load` / `.save`

Tab accepts, Esc dismisses, Ctrl+Space requests.

## How members resolve

Through the **TypeChecker**, generalizing the existing `.type` command: the receiver expression is parsed and checked against the accumulated session statements, then a new `TypeChecker.GetCompletionMembers` enumerates the resulting `TypeInfo`. That is what lets arbitrary receivers work — `getUser().`, `arr[0].`, `(a ?? b).`, `new C().` — and it is what supplies the type tooltips.

Identifier completion deliberately does **not** type-check; it reads the live `RuntimeEnvironment`, because it runs on every keystroke. Member lists are cached per session generation, since resolving one means checking the whole accumulated session.

`GetCompletionMembers` lives in a new `TypeChecker` partial file, which reaches the existing private `ExtractKeys` and `CollectPublicInstanceMembers` without changing any existing member's visibility.

## Context classification

Rather than hand-rolling a string/comment scanner, this leans on two lexer behaviours:

- `1.` tokenizes as a **single `NUMBER`** (lexeme `"1."`) — the lexer binds the trailing dot to the number — so there is no `DOT` to react to and the `1.` case needs no special handling.
- An unterminated string, template, or comment emits **no token at all** (comments are skipped as trivia). So non-whitespace source past the last token reliably means the caret sits somewhere completion must stay silent. That one rule covers unterminated `"`, `'`, `` ` ``, `//` and `/* */`, while still allowing completion after a *closed* comment and inside a `${…}` interpolation.

Receiver extraction walks left over tokens balancing bracket pairs. Keyword lexemes are accepted as member names, so `obj.type`, `map.get` and `p.catch` still complete.

## Two gaps that had to be closed

- **The checker types `console`, `Math`, `JSON`, `Object` as `any`.** A purely type-driven menu therefore offered *nothing* for the most frequently typed expressions in a REPL. These fall back to the runtime member tables, which needed `MemberNames` accessors on the two built-in lookup classes (`BuiltInTypeMemberLookup` / `BuiltInStaticMemberLookup`) plus one-line passthroughs. Regression tests pin `console.log`, `Math.floor`, `JSON.parse`.
- **`const s = "x"` infers the literal type `"x"`, not `string`.** This initially broke `s.` while `arr[0].` worked. Literal types now map to their base primitive before enumeration.

Also note `ExtractKeys` implements `keyof` semantics, where a `TypeInfo.Class` yields the *instance* side — so a bare class reference `C.` is routed separately to collect statics, or it would have offered instance methods.

## Enter vs. the menu

Both Enter and Tab commit completions by default, and under IntelliSense-style triggering the menu is open most of the time, so Enter would rarely reach the prompt. `ConfirmCompletionCommit` rejects Enter **only when the input is complete**.

That condition is load-bearing, not cosmetic: PrettyPrompt skips `TransformKeyPressAsync` whenever a key *would* commit a completion, so rejecting Enter unconditionally would also bypass the existing Enter-to-newline transform and break multi-line editing. Restricting the rejection to complete input confines the bypass to cases where that transform would have done nothing. Net behaviour: **Tab completes, Enter submits a finished line, Esc dismisses.**

## Ctrl+C now exits

Reported separately, and it turned out to be pre-existing rather than new:

- **Ctrl+C** produces `PromptResult(isSuccess: false, string.Empty, …)`, which the read loop discarded and continued from — and PrettyPrompt suppresses process termination, so the loop was the only thing that could end the session, and it never did.
- **Ctrl+D** was advertised in `.help` as an exit, but PrettyPrompt binds it to forward-delete (emacs); it never produced a result and never reached the loop.

So `.exit` was the only way out. A second consecutive Ctrl+C now exits, matching the Node REPL, with a hint on the first press. A single press cannot be made to exit on an empty line, because the reported text is empty for *every* Ctrl+C — a cancelled line is indistinguishable from a cancelled empty prompt. The help text no longer claims a Ctrl+D exit.

## Robustness

`ReplCompletionContext.Classify` is now failure-tolerant. The completion pane calls `GetSpanToReplaceByCompletionAsync` on **every key press while the menu is open**, so an exception escaping there would leave the key handler dead and wedge the prompt. Item construction is wrapped too, and tooltips are flattened to a single ≤160-char line so a large rendered type cannot disrupt the description pane.

## Testing

93 new tests in `SharpTS.Tests/ReplTests/`, covering member resolution (including inherited members, statics, unions, interfaces, call and index receivers), the `any`-typed singleton fallback, identifier/global/keyword ranking, dot-commands and paths, and the suppression cases (strings, templates, comments, `1.`, hostile input).

Candidate computation lives in its own class because the REPL cannot be driven end-to-end: `PrettyPrompt`'s `Prompt` constructor throws `failed to set output console mode` as soon as stdout is redirected. The trigger and commit policies are extracted into internal statics so they are testable directly, and the `CompletionItem` mapping and priority ordering are covered by reflecting into the callbacks.

**Full suite: 15,549 passed, 5 failed.** The 5 (`UtilFormattingTests.StyleText_*`) are pre-existing — verified by stashing this branch's changes, rerunning them on clean `main`, and getting the identical 5 failures.

## Not verified

The interactive behaviour — menu rendering, Tab commit, arrow navigation, and the double-Ctrl+C exit — has not been seen working, because PrettyPrompt cannot initialise outside a real terminal. Worth a manual pass with `dotnet run`.
