### PR TITLE
test(conformance): honor @noImplicitAny in the TS conformance runner

### DIFF
--- a/SharpTS.TypeScriptConformance/TypeScriptConformanceRunner.cs
+++ b/SharpTS.TypeScriptConformance/TypeScriptConformanceRunner.cs
@@ -133,15 +133,20 @@ public sealed class TypeScriptConformanceRunner
         TypeCheckDiagnosticResult checkResult;
         try
         {
-            // strictNullChecks follows the test's directives (strictNullChecks overrides strict),
-            // defaulting off — matching how tsc generated the legacy *.errors.txt baselines.
+            // Each strictness knob follows the test's directives, with the specific directive
+            // overriding @strict and everything defaulting off — matching how tsc generated the
+            // legacy *.errors.txt baselines.
             bool strictNullChecks = metadata.StrictNullChecks ?? metadata.Strict;
+            bool noImplicitAny = metadata.NoImplicitAny ?? metadata.Strict;
             // Raise the error cap well above the product default (10) so we collect every diagnostic
             // a test expects — *.errors.txt baselines can list many errors in one file.
-            var checker = new TypeChecker(
-                strictNullChecks: strictNullChecks,
-                maxErrors: 1000,
-                strictFunctionTypes: metadata.Strict);
+            var checker = new TypeChecker(new TypeCheckerOptions
+            {
+                StrictNullChecks = strictNullChecks,
+                StrictFunctionTypes = metadata.Strict,
+                NoImplicitAny = noImplicitAny,
+                MaxErrors = 1000,
+            });
             checkResult = checker.CheckWithRecovery(parseResult.Statements);
         }
         catch (Exception ex)
@@ -228,6 +233,11 @@ public sealed class TypeScriptConformanceRunner
     /// </summary>
     private static string? ResolveNewestTargetBaseline(string baselinesDir, string basename)
     {
+        // A missing baselines directory means "no baseline", not a crash. Without this an
+        // uninitialized external/typescript submodule takes down the resolver with a
+        // DirectoryNotFoundException instead of bucketing cleanly.
+        if (!Directory.Exists(baselinesDir)) return null;
+
         string? best = null;
         var bestRank = int.MinValue;
         foreach (var path in Directory.EnumerateFiles(baselinesDir, $"{basename}(target=*).errors.txt"))

--- a/SharpTS.TypeScriptConformance/TypeScriptConformanceRunnerTests.cs
+++ b/SharpTS.TypeScriptConformance/TypeScriptConformanceRunnerTests.cs
@@ -94,6 +94,66 @@ public class TypeScriptConformanceRunnerTests
         }
         finally { File.Delete(tmp); }
     }
+
+    #region Strictness directives reach the checker
+
+    /// <summary>
+    /// Runs a synthetic test through the real runner and returns the TS codes it produced.
+    /// A <c>/fake-root</c> means no <c>*.errors.txt</c> baseline is found, so the outcome is
+    /// uninteresting — what is pinned here is the directive → TypeChecker option wiring.
+    /// </summary>
+    private static IReadOnlyList<string> ActualCodes(string source)
+    {
+        var tmp = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllText(tmp, source);
+            var result = new TypeScriptConformanceRunner("/fake-root").RunOne(tmp);
+            Assert.NotEqual(TypeScriptConformanceOutcome.HarnessError, result.Outcome);
+            Assert.NotEqual(TypeScriptConformanceOutcome.TypeCheckError, result.Outcome);
+            return result.ActualDiagnostics?.Select(d => d.TsCode).ToList() ?? [];
+        }
+        finally { File.Delete(tmp); }
+    }
+
+    // An unannotated parameter on a DECLARED function — the one shape SharpTS reports
+    // noImplicitAny for. Arrows are deliberately exempt, so they cannot be used here.
+    private const string ImplicitAnyParam = "function f(x) { return x; }\n";
+
+    [Fact]
+    public void NoDirectives_DoNotEnableNoImplicitAny()
+    {
+        // The legacy corpus was generated with noImplicitAny off; that must stay the default.
+        Assert.DoesNotContain("TS7006", ActualCodes(ImplicitAnyParam));
+    }
+
+    [Fact]
+    public void StrictDirective_EnablesNoImplicitAny()
+    {
+        Assert.Contains("TS7006", ActualCodes("// @strict: true\n" + ImplicitAnyParam));
+    }
+
+    [Fact]
+    public void NoImplicitAnyDirective_EnablesItWithoutStrict()
+    {
+        Assert.Contains("TS7006", ActualCodes("// @noImplicitAny: true\n" + ImplicitAnyParam));
+    }
+
+    [Fact]
+    public void NoImplicitAnyDirective_OverridesStrict()
+    {
+        // The specific directive beats the umbrella, matching how @strictNullChecks behaves.
+        Assert.DoesNotContain("TS7006",
+            ActualCodes("// @strict: true\n// @noImplicitAny: false\n" + ImplicitAnyParam));
+    }
+
+    [Fact]
+    public void StrictDirectiveFalse_LeavesNoImplicitAnyOff()
+    {
+        Assert.DoesNotContain("TS7006", ActualCodes("// @strict: false\n" + ImplicitAnyParam));
+    }
+
+    #endregion
 }
 
 /// <summary>


### PR DESCRIPTION
Stacked on #1284 — review/merge that first. Closes the follow-up that PR named.

## What

`metadata.NoImplicitAny` was parsed and stored but **never read**. This wires it up the same way `@strictNullChecks` already works: the specific directive overrides `@strict`, everything defaults off, matching how tsc generated the legacy `*.errors.txt` baselines.

```csharp
bool strictNullChecks = metadata.StrictNullChecks ?? metadata.Strict;
bool noImplicitAny    = metadata.NoImplicitAny    ?? metadata.Strict;   // new
```

## The baseline does not move

**250 Pass / 29 Fail / 16 Skipped / 1 TypeCheckError — unchanged.** `baselines/interpreted.txt` is untouched.

I predicted in #1284 that this would shift ~26 tests. That was wrong, and worth correcting: the estimate assumed a broad `noImplicitAny` covering arrows. SharpTS''s is deliberately narrow — declared functions, methods and constructors only.

Verified rather than assumed:

- 28 subset tests carry `@strict: true` or `@noImplicitAny: true`
- 27 of them actually run — 21 Pass, 6 Fail, only 1 skipped — so this is not neutral because the tests are inert
- **none of them declares a function, method or constructor with an unannotated parameter**, which is the only shape SharpTS reports

So the corpus has nothing for this flag to catch today.

## Why land it anyway

- `metadata.NoImplicitAny` stops being dead config.
- The corpus will now catch the **next** widening automatically — TS7031 for binding elements, or arrows once contextual parameter typing covers generic/overloaded/union-typed callees.
- It matches tsc''s option model, so the runner does not quietly diverge from the semantics the baselines were generated under.

## Tests

A zero-drift baseline is otherwise indistinguishable from a silently broken flag, so five tests pin the directive → option wiring in both directions, driving the real `RunOne` over a synthetic test file:

| Directives | TS7006 |
|---|---|
| *(none)* | not reported |
| `@strict: true` | reported |
| `@noImplicitAny: true` | reported |
| `@strict: true` + `@noImplicitAny: false` | not reported |
| `@strict: false` | not reported |

## Drive-by fix

Those tests surfaced a latent crash: `ResolveNewestTargetBaseline` enumerated the baselines directory without checking it exists, so an uninitialized `external/typescript` submodule took down the resolver with a `DirectoryNotFoundException` instead of bucketing cleanly as `HarnessError`. One-line guard.

## Verification

`dotnet test SharpTS.TypeScriptConformance` — 36/36 (31 existing + 5 new), zero baseline drift, `baselines/interpreted.txt` unmodified in the diff.