### PR TITLE
fix(generators): support yield* over typed arrays and Buffers

### DIFF
--- a/Compilation/AsyncGeneratorMoveNextEmitter.Expressions.cs
+++ b/Compilation/AsyncGeneratorMoveNextEmitter.Expressions.cs
@@ -146,6 +146,9 @@ public partial class AsyncGeneratorMoveNextEmitter
 
         // Sync setup
         _il.MarkLabel(syncSetupLabel);
+        // Emitted typed arrays and Buffers are synchronous iterables but do not implement
+        // IEnumerable. Materialize them before the existing sync setup cast (#1289).
+        NormalizeYieldStarTypedArrayOrBuffer(iterableTemp);
         _il.Emit(OpCodes.Ldloc, iterableTemp);
         _il.Emit(OpCodes.Castclass, typeof(System.Collections.IEnumerable));
         var getEnumerator = typeof(System.Collections.IEnumerable).GetMethod("GetEnumerator")!;
@@ -301,8 +304,12 @@ public partial class AsyncGeneratorMoveNextEmitter
         var loopEnd = _il.DefineLabel();
 
         // Emit the iterable expression and get its enumerator
+        var iterableTemp = _il.DeclareLocal(typeof(object));
         EmitExpression(y.Value!);
         EnsureBoxed();
+        _il.Emit(OpCodes.Stloc, iterableTemp);
+        NormalizeYieldStarTypedArrayOrBuffer(iterableTemp);
+        _il.Emit(OpCodes.Ldloc, iterableTemp);
         _il.Emit(OpCodes.Castclass, typeof(System.Collections.IEnumerable));
         _il.Emit(OpCodes.Callvirt, getEnumerator);
 

--- a/Compilation/GeneratorMoveNextEmitter.Expressions.Yield.cs
+++ b/Compilation/GeneratorMoveNextEmitter.Expressions.Yield.cs
@@ -215,6 +215,11 @@ public partial class GeneratorMoveNextEmitter
             _il.MarkLabel(afterMapSetLabel);
         }
 
+        // Emitted typed arrays and Buffers do not implement IEnumerable. Normalize only
+        // those operands through IterateToList before the Symbol.iterator/IEnumerable
+        // dispatch so yield* remains standalone-safe (#1289).
+        NormalizeYieldStarTypedArrayOrBuffer(iterableLocal);
+
         // Check for Symbol.iterator on the object (for custom iterables)
         _il.Emit(OpCodes.Ldloc, iterableLocal);
         _il.Emit(OpCodes.Ldsfld, _ctx!.Runtime!.SymbolIterator);

--- a/Compilation/IteratorMoveNextEmitter.cs
+++ b/Compilation/IteratorMoveNextEmitter.cs
@@ -113,6 +113,50 @@ public abstract partial class IteratorMoveNextEmitter : StateMachineExitRoutingE
     }
 
     /// <summary>
+    /// Materializes an emitted typed array or Buffer into the runtime's standalone-safe
+    /// <c>List&lt;object&gt;</c> representation before a <c>yield*</c> setup casts its operand to
+    /// <see cref="System.Collections.IEnumerable"/>. The emitted <c>$TypedArray</c> and
+    /// <c>$Buffer</c> types deliberately do not implement that interface.
+    /// </summary>
+    protected void NormalizeYieldStarTypedArrayOrBuffer(LocalBuilder iterableLocal)
+    {
+        var runtime = Ctx.Runtime!;
+        var typedArrayType = runtime.TypedArrayBaseType;
+        var bufferType = runtime.TSBufferType;
+        if (typedArrayType is null && bufferType is null)
+            return;
+
+        var materializeLabel = IL.DefineLabel();
+        var doneLabel = IL.DefineLabel();
+
+        if (typedArrayType is not null)
+        {
+            IL.Emit(OpCodes.Ldloc, iterableLocal);
+            IL.Emit(OpCodes.Isinst, typedArrayType);
+            IL.Emit(OpCodes.Brtrue, materializeLabel);
+        }
+
+        if (bufferType is not null)
+        {
+            IL.Emit(OpCodes.Ldloc, iterableLocal);
+            IL.Emit(OpCodes.Isinst, bufferType);
+            IL.Emit(OpCodes.Brtrue, materializeLabel);
+        }
+
+        IL.Emit(OpCodes.Br, doneLabel);
+
+        IL.MarkLabel(materializeLabel);
+        IL.Emit(OpCodes.Ldloc, iterableLocal);
+        IL.Emit(OpCodes.Ldsfld, runtime.SymbolIterator);
+        IL.Emit(OpCodes.Ldtoken, runtime.RuntimeType);
+        IL.Emit(OpCodes.Call, Types.TypeGetTypeFromHandle);
+        IL.Emit(OpCodes.Call, runtime.IterateToList);
+        IL.Emit(OpCodes.Stloc, iterableLocal);
+
+        IL.MarkLabel(doneLabel);
+    }
+
+    /// <summary>
     /// Binds the caught exception value (on the IL stack) to the catch parameter, honouring whether the
     /// parameter was hoisted to a state-machine field (because it is read across a yield/await in the
     /// catch body) or lives in an IL local. Storing to a fresh local unconditionally — the original

--- a/SharpTS.Tests/CompilerTests/StandaloneDllTests.cs
+++ b/SharpTS.Tests/CompilerTests/StandaloneDllTests.cs
@@ -571,6 +571,34 @@ public class StandaloneDllTests
     }
 
     /// <summary>
+    /// #1289: yield* over emitted typed arrays and Buffers must use only emitted runtime
+    /// helpers and continue to execute without a SharpTS.dll dependency.
+    /// </summary>
+    [Fact]
+    public void Isolated_YieldStarTypedArrayAndBuffer_ShouldExecuteWithoutSharpTsDll()
+    {
+        var source = """
+            function* values() {
+                yield* new Uint8Array([1, 2]);
+                yield* Buffer.from([3, 4]);
+            }
+            console.log(JSON.stringify([...values()]));
+            """;
+
+        var (tempDir, dllPath) = CompileStandalone(source);
+        try
+        {
+            Assert.DoesNotContain(GetAssemblyReferences(dllPath), r => r == "SharpTS");
+            var output = ExecuteCompiledDllIsolated(dllPath, timeoutMs: 15000);
+            Assert.Equal("[1,2,3,4]\n", output);
+        }
+        finally
+        {
+            CleanupTempDir(tempDir);
+        }
+    }
+
+    /// <summary>
     /// Phase 23 guardrail: Verifies SharedArrayBuffer works standalone.
     /// </summary>
     [Fact]

--- a/SharpTS.Tests/SharedTests/TypedArrayIterationParityTests.cs
+++ b/SharpTS.Tests/SharedTests/TypedArrayIterationParityTests.cs
@@ -89,28 +89,50 @@ public class TypedArrayIterationParityTests
     // async generator. That is a pre-existing compiled gap far wider than typed arrays, so a
     // dual-mode test here would assert a failure unrelated to this fix rather than pin it.
 
-    /// <summary>
-    /// <c>yield* typedArray</c> stays a compile-time TS2488 in both modes, on purpose: the
-    /// compiled generator emitters' fallback arm casts the operand to <c>IEnumerable</c>, which
-    /// a typed array does not implement, so accepting it would swap a clean diagnostic for an
-    /// <c>InvalidCastException</c> at runtime. Pinned so the rejection stays deliberate and
-    /// symmetric rather than drifting into a crash.
-    /// </summary>
     [Theory]
     [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
-    public void YieldStar_OverTypedArray_RejectedInBothModes(ExecutionMode mode)
+    public void YieldStar_OverTypedArrayAndBuffer(ExecutionMode mode)
     {
-        var files = new Dictionary<string, string>
-        {
-            ["main.ts"] = """
-                const u8 = new Uint8Array([1, 2]);
-                function* g(): Generator<any> { yield 0; yield* u8; }
-                console.log(JSON.stringify([...g()]));
-                """
-        };
+        Expect("""
+            const u8 = new Uint8Array([1, 2]);
+            const i16 = new Int16Array([-1, 300]);
+            const buf = Buffer.from([4, 5]);
 
-        var ex = Assert.ThrowsAny<Exception>(() => TestHarness.RunModules(files, "main.ts", mode));
-        Assert.Contains("not iterable for yield*", ex.Message);
+            function* g() {
+                yield 0;
+                yield* u8;
+                yield* i16;
+                yield* buf;
+            }
+
+            const values: number[] = [...g()];
+            console.log(JSON.stringify(values));
+            """,
+            "[0,1,2,-1,300,4,5]", mode);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void AsyncGeneratorYieldStar_OverTypedArrayAndBuffer(ExecutionMode mode)
+    {
+        Expect("""
+            const u8 = new Uint8Array([1, 2]);
+            const buf = Buffer.from([3, 4]);
+
+            async function* g(): AsyncGenerator<number> {
+                yield 0;
+                yield* u8;
+                yield* buf;
+            }
+
+            async function main() {
+                const values: number[] = [];
+                for await (const value of g()) values.push(value);
+                console.log(JSON.stringify(values));
+            }
+            main();
+            """,
+            "[0,1,2,3,4]", mode);
     }
 
     /// <summary>

--- a/TypeSystem/TypeChecker.Expressions.cs
+++ b/TypeSystem/TypeChecker.Expressions.cs
@@ -324,33 +324,18 @@ public partial class TypeChecker
     /// <summary>
     /// Gets the element type from an iterable type (for yield* delegation).
     /// </summary>
-    /// <remarks>
-    /// Deliberately NOT delegated to <see cref="TryGetSpreadElementType"/>, even though the two
-    /// lists overlap almost entirely. The spreadable set is now wider than what the compiled
-    /// <c>yield*</c> emitters can lower: their fallback arm casts the operand to
-    /// <c>IEnumerable</c> after a Map/Set/Symbol.iterator chain, so a typed array or Buffer
-    /// reaches it and throws <c>InvalidCastException</c> at runtime. Accepting those here would
-    /// trade a clean compile-time TS2488 for a compiled crash. Widen this only together with
-    /// typed-array arms in GeneratorMoveNextEmitter.Expressions.Yield and the two
-    /// AsyncGeneratorMoveNextEmitter sites. (#1282)
-    /// </remarks>
-    private TypeInfo GetIterableElementType(TypeInfo type) => type switch
+    private TypeInfo GetIterableElementType(TypeInfo type)
     {
-        TypeInfo.Array arr => arr.ElementType,
-        TypeInfo.Generator gen => gen.YieldType,
-        TypeInfo.AsyncGenerator asyncGen => asyncGen.YieldType,
-        TypeInfo.Iterator iter => iter.ElementType,
-        TypeInfo.Iterable iterable => iterable.ElementType,
-        TypeInfo.Set set => set.ElementType,
-        TypeInfo.Map map => TypeInfo.Tuple.FromTypes([map.KeyType, map.ValueType], 2),  // [K, V] tuples
-        TypeInfo.String => TypeInfo.String.Shared,  // String yields characters (as strings)
-        TypeInfo.StringLiteral => TypeInfo.String.Shared,  // String literal also yields characters
-        TypeInfo.Any => TypeInfo.Any.Shared,
-        // A hand-written object exposing [Symbol.iterator] is iterable structurally (#485); dedicated
-        // records are handled above, so only genuine structural objects reach here.
-        _ when TryGetStructuralIterableElement(type, out var structuralElem) => structuralElem,
-        _ => throw new TypeCheckException($" Type '{type}' is not iterable for yield*.", tsCode: "TS2488")
-    };
+        // Async generators are valid yield* delegates but are deliberately not spreadable by the
+        // synchronous spread helper.
+        if (type is TypeInfo.AsyncGenerator asyncGen)
+            return asyncGen.YieldType;
+
+        if (TryGetSpreadElementType(type, out var elementType))
+            return elementType;
+
+        throw new TypeCheckException($" Type '{type}' is not iterable for yield*.", tsCode: "TS2488");
+    }
 
     /// <summary>
     /// Tries to get the element type from a spreadable/iterable type.


### PR DESCRIPTION
## Summary
- lower `yield*` over typed arrays and Buffers in synchronous and asynchronous compiled generators through the standalone-safe iterable materializer
- reuse the shared spread/iterable element-type resolution while preserving async-generator handling and TS2488 diagnostics
- replace the rejection guard with dual-mode positive coverage and add an isolated standalone-DLL regression

## Verification
- targeted typed-array iteration and standalone tests: 13 passed
- Debug and Release builds: 0 warnings, 0 errors
- Release CI test suite: passed
- Test262 interpreted and compiled baselines: passed
- TypeScript conformance: 36 passed
- `git diff --check`: passed

Closes #1289