### PR TITLE
Fix typed-array destructuring and sync for-await iteration

### DIFF
--- a/Compilation/AsyncGeneratorMoveNextEmitter.Statements.cs
+++ b/Compilation/AsyncGeneratorMoveNextEmitter.Statements.cs
@@ -182,10 +182,9 @@ public partial class AsyncGeneratorMoveNextEmitter
     /// <c>AsyncGeneratorStateAnalyzer.VisitForOf</c>, consumed here in the same order.
     /// </summary>
     /// <remarks>
-    /// Scope matches the prior override: the iterator is driven through the <c>$IAsyncGenerator</c>
-    /// interface — the only async-iterator shape reachable as a CLR <c>IAsyncEnumerator&lt;object&gt;</c>
-    /// in compiled mode (custom <c>Symbol.asyncIterator</c> sources are guest objects, which this position
-    /// did not accept before either — a separate, pre-existing gap). <c>next()</c> returns a
+    /// The iterator is driven through the <c>$IAsyncGenerator</c> interface. Synchronous iterables are
+    /// first wrapped by the emitted async-from-sync adapter; custom <c>Symbol.asyncIterator</c> sources
+    /// remain a separate, pre-existing gap in this emitter. <c>next()</c> returns a
     /// <c>Task&lt;object&gt;</c> ({ value, done }) that maps directly onto the async-gen await mechanism
     /// (<see cref="EmitAwaitFromValueOnStack"/>), so rejected steps propagate / reach an enclosing try
     /// exactly as a normal <c>await</c> does.
@@ -204,10 +203,11 @@ public partial class AsyncGeneratorMoveNextEmitter
         var iteratorField = _builder.StateMachineType.DefineField(
             $"<>7__aiter{loopId}", _types.Object, FieldAttributes.Private);
 
-        // Evaluate the async iterable and store it as the iterator (the async generator IS its own
-        // iterator). Casting to $IAsyncGenerator validates the shape, matching the prior override.
+        // Evaluate the iterable, adapt synchronous sources, and store the
+        // resulting async iterator. Casting validates non-iterable inputs.
         EmitExpression(f.Iterable);
         EnsureBoxed();
+        _il.Emit(OpCodes.Call, _ctx.Runtime.AdaptSyncIterableToAsyncGenerator);
         _il.Emit(OpCodes.Castclass, asyncGenInterface);
         var iterTemp = _il.DeclareLocal(asyncGenInterface);
         _il.Emit(OpCodes.Stloc, iterTemp);

--- a/Compilation/AsyncMoveNextEmitter.Statements.Loops.cs
+++ b/Compilation/AsyncMoveNextEmitter.Statements.Loops.cs
@@ -68,7 +68,7 @@ public partial class AsyncMoveNextEmitter
 
         // Synchronous prelude: evaluate the iterable and resolve the iterator + protocol kind:
         //   isCustom == true  → iterable[Symbol.asyncIterator]() ; step via InvokeIteratorNext / "return".
-        //   isCustom == false → the value is itself the iterator   ; step via the $IAsyncGenerator interface.
+        //   isCustom == false → an $IAsyncGenerator, including the emitted async-from-sync adapter.
         // Evaluating the iterable, or calling its [Symbol.asyncIterator], can throw synchronously (e.g. a
         // pre-aborted signal) — guarded below so that throw reaches an enclosing try's catch.
         void EmitPrelude()
@@ -87,9 +87,11 @@ public partial class AsyncMoveNextEmitter
             _il.Emit(OpCodes.Ldloc, asyncIterFnLocal);
             _il.Emit(OpCodes.Brtrue, customSetup);
 
-            // iterator = iterable; isCustom = false
+            // No async iterator: adapt any synchronous iterable per
+            // CreateAsyncFromSyncIterator semantics (#1287).
             _il.Emit(OpCodes.Ldarg_0);
             _il.Emit(OpCodes.Ldloc, iterableLocal);
+            _il.Emit(OpCodes.Call, _ctx.Runtime.AdaptSyncIterableToAsyncGenerator);
             _il.Emit(OpCodes.Stfld, iteratorField);
             _il.Emit(OpCodes.Ldarg_0);
             _il.Emit(OpCodes.Ldc_I4_0);

--- a/Compilation/EmittedRuntime.cs
+++ b/Compilation/EmittedRuntime.cs
@@ -1412,6 +1412,11 @@ public class EmittedRuntime
     public MethodBuilder AsyncGeneratorReturnMethod { get; set; } = null!;
     public MethodBuilder AsyncGeneratorThrowMethod { get; set; } = null!;
 
+    // Async-from-sync iterator adapter (for await...of over synchronous iterables)
+    public TypeBuilder AsyncFromSyncIteratorType { get; set; } = null!;
+    public ConstructorBuilder AsyncFromSyncIteratorCtor { get; set; } = null!;
+    public MethodBuilder AdaptSyncIterableToAsyncGenerator { get; set; } = null!;
+
     // Async Generator await continuation helper
     public MethodBuilder AsyncGeneratorAwaitContinue { get; set; } = null!;
 

--- a/Compilation/RuntimeEmitter.AsyncFromSyncIterator.cs
+++ b/Compilation/RuntimeEmitter.AsyncFromSyncIterator.cs
@@ -1,0 +1,620 @@
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Threading.Tasks;
+
+namespace SharpTS.Compilation;
+
+/// <summary>
+/// Emits the async-from-sync adapter used by compiled <c>for await...of</c>
+/// loops when a value has no <c>Symbol.asyncIterator</c>.
+/// </summary>
+public partial class RuntimeEmitter
+{
+    private MethodBuilder _asyncFromSyncCreateResult = null!;
+    private MethodBuilder _asyncFromSyncAwaitResult = null!;
+    private MethodBuilder _asyncFromSyncAwaitContinuation = null!;
+
+    /// <summary>
+    /// Emits a BCL-only adapter into the generated assembly, preserving
+    /// standalone output with no dependency on SharpTS.dll.
+    /// </summary>
+    private void EmitAsyncFromSyncIteratorSupport(ModuleBuilder moduleBuilder, EmittedRuntime runtime)
+    {
+        var runtimeType = _runtimeTypeBuilder!;
+
+        EmitAsyncFromSyncCreateResult(runtimeType);
+        EmitAsyncFromSyncAwaitContinuation(runtimeType, runtime);
+        EmitAsyncFromSyncAwaitResult(runtimeType, runtime);
+        EmitAsyncFromSyncIteratorType(moduleBuilder, runtime);
+        EmitAdaptSyncIterableToAsyncGenerator(runtimeType, runtime);
+    }
+
+    /// <summary>
+    /// static object AsyncFromSyncCreateResult(object value, bool done)
+    /// </summary>
+    private void EmitAsyncFromSyncCreateResult(TypeBuilder runtimeType)
+    {
+        var method = runtimeType.DefineMethod(
+            "AsyncFromSyncCreateResult",
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.Object,
+            [_types.Object, _types.Boolean]);
+        _asyncFromSyncCreateResult = method;
+
+        var il = method.GetILGenerator();
+        var dictLocal = il.DeclareLocal(_types.DictionaryStringObject);
+
+        il.Emit(OpCodes.Newobj, _types.DictionaryStringObjectCtor);
+        il.Emit(OpCodes.Stloc, dictLocal);
+
+        il.Emit(OpCodes.Ldloc, dictLocal);
+        il.Emit(OpCodes.Ldstr, "value");
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Callvirt, _types.DictionaryStringObjectSetItem);
+
+        il.Emit(OpCodes.Ldloc, dictLocal);
+        il.Emit(OpCodes.Ldstr, "done");
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Box, _types.Boolean);
+        il.Emit(OpCodes.Callvirt, _types.DictionaryStringObjectSetItem);
+
+        il.Emit(OpCodes.Ldloc, dictLocal);
+        il.Emit(OpCodes.Ret);
+    }
+
+    /// <summary>
+    /// static object AsyncFromSyncAwaitContinuation(Task&lt;object&gt; task, object step)
+    /// — replaces the sync result's value with the awaited value while preserving done.
+    /// </summary>
+    private void EmitAsyncFromSyncAwaitContinuation(TypeBuilder runtimeType, EmittedRuntime runtime)
+    {
+        var method = runtimeType.DefineMethod(
+            "AsyncFromSyncAwaitContinuation",
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.Object,
+            [_types.TaskOfObject, _types.Object]);
+        _asyncFromSyncAwaitContinuation = method;
+
+        var il = method.GetILGenerator();
+        var awaiterLocal = il.DeclareLocal(_types.TaskAwaiterOfObject);
+        var valueLocal = il.DeclareLocal(_types.Object);
+
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Callvirt, _types.TaskOfObjectGetAwaiter);
+        il.Emit(OpCodes.Stloc, awaiterLocal);
+        il.Emit(OpCodes.Ldloca, awaiterLocal);
+        il.Emit(OpCodes.Call, _types.GetMethodNoParams(_types.TaskAwaiterOfObject, "GetResult"));
+        il.Emit(OpCodes.Stloc, valueLocal);
+
+        il.Emit(OpCodes.Ldloc, valueLocal);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Call, runtime.GetIteratorDone);
+        il.Emit(OpCodes.Call, _asyncFromSyncCreateResult);
+        il.Emit(OpCodes.Ret);
+    }
+
+    /// <summary>
+    /// static Task&lt;object&gt; AsyncFromSyncAwaitResult(object step)
+    /// — awaits Promise/Task/thenable iterator values and rebuilds the result.
+    /// </summary>
+    private void EmitAsyncFromSyncAwaitResult(TypeBuilder runtimeType, EmittedRuntime runtime)
+    {
+        var method = runtimeType.DefineMethod(
+            "AsyncFromSyncAwaitResult",
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.TaskOfObject,
+            [_types.Object]);
+        _asyncFromSyncAwaitResult = method;
+
+        var il = method.GetILGenerator();
+        var valueLocal = il.DeclareLocal(_types.Object);
+        var taskLocal = il.DeclareLocal(_types.TaskOfObject);
+        var notPromise = il.DefineLabel();
+        var notTask = il.DefineLabel();
+        var haveTask = il.DefineLabel();
+
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Call, runtime.GetIteratorValue);
+        il.Emit(OpCodes.Stloc, valueLocal);
+
+        il.Emit(OpCodes.Ldloc, valueLocal);
+        il.Emit(OpCodes.Isinst, runtime.TSPromiseType);
+        il.Emit(OpCodes.Brfalse, notPromise);
+        il.Emit(OpCodes.Ldloc, valueLocal);
+        il.Emit(OpCodes.Castclass, runtime.TSPromiseType);
+        il.Emit(OpCodes.Callvirt, runtime.TSPromiseTaskGetter);
+        il.Emit(OpCodes.Stloc, taskLocal);
+        il.Emit(OpCodes.Br, haveTask);
+
+        il.MarkLabel(notPromise);
+        il.Emit(OpCodes.Ldloc, valueLocal);
+        il.Emit(OpCodes.Isinst, _types.TaskOfObject);
+        il.Emit(OpCodes.Brfalse, notTask);
+        il.Emit(OpCodes.Ldloc, valueLocal);
+        il.Emit(OpCodes.Castclass, _types.TaskOfObject);
+        il.Emit(OpCodes.Stloc, taskLocal);
+        il.Emit(OpCodes.Br, haveTask);
+
+        // Ordinary values and thenables follow the same PromiseResolve-style
+        // adoption path used by compiled await expressions.
+        il.MarkLabel(notTask);
+        il.Emit(OpCodes.Ldloc, valueLocal);
+        il.Emit(OpCodes.Call, runtime.CoerceAwaitableToTaskMethod);
+        il.Emit(OpCodes.Stloc, taskLocal);
+
+        il.MarkLabel(haveTask);
+        il.Emit(OpCodes.Ldloc, taskLocal);
+        il.Emit(OpCodes.Ldnull);
+        il.Emit(OpCodes.Ldftn, _asyncFromSyncAwaitContinuation);
+        var continuationType = _types.MakeGenericType(
+            typeof(Func<,,>), _types.TaskOfObject, _types.Object, _types.Object);
+        il.Emit(OpCodes.Newobj, continuationType.GetConstructor([_types.Object, typeof(IntPtr)])!);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldc_I4, (int)TaskContinuationOptions.ExecuteSynchronously);
+        il.Emit(OpCodes.Callvirt, ResolveAsyncFromSyncContinueWith());
+        il.Emit(OpCodes.Ret);
+    }
+
+    private MethodInfo ResolveAsyncFromSyncContinueWith() =>
+        _types.TaskOfObject.GetMethods(BindingFlags.Public | BindingFlags.Instance)
+            .First(m => m.Name == "ContinueWith" && m.IsGenericMethodDefinition
+                && m.GetParameters() is { Length: 3 } p
+                && p[0].ParameterType.IsGenericType
+                && p[0].ParameterType.GetGenericTypeDefinition() == typeof(Func<,,>)
+                && p[1].ParameterType == typeof(object)
+                && p[2].ParameterType == typeof(TaskContinuationOptions))
+            .MakeGenericMethod(_types.Object);
+
+    private void EmitAsyncFromSyncIteratorType(ModuleBuilder moduleBuilder, EmittedRuntime runtime)
+    {
+        var typeBuilder = moduleBuilder.DefineType(
+            "$AsyncFromSyncIterator",
+            TypeAttributes.Public | TypeAttributes.Sealed | TypeAttributes.BeforeFieldInit,
+            _types.Object,
+            [runtime.AsyncGeneratorInterfaceType]);
+        runtime.AsyncFromSyncIteratorType = typeBuilder;
+
+        var iteratorField = typeBuilder.DefineField("_iterator", _types.Object, FieldAttributes.Private);
+        var isProtocolField = typeBuilder.DefineField("_isProtocol", _types.Boolean, FieldAttributes.Private);
+
+        var ctor = typeBuilder.DefineConstructor(
+            MethodAttributes.Public,
+            CallingConventions.Standard,
+            [_types.Object, _types.Boolean]);
+        runtime.AsyncFromSyncIteratorCtor = ctor;
+        var ctorIl = ctor.GetILGenerator();
+        ctorIl.Emit(OpCodes.Ldarg_0);
+        ctorIl.Emit(OpCodes.Call, _types.Object.GetConstructor(Type.EmptyTypes)!);
+        ctorIl.Emit(OpCodes.Ldarg_0);
+        ctorIl.Emit(OpCodes.Ldarg_1);
+        ctorIl.Emit(OpCodes.Stfld, iteratorField);
+        ctorIl.Emit(OpCodes.Ldarg_0);
+        ctorIl.Emit(OpCodes.Ldarg_2);
+        ctorIl.Emit(OpCodes.Stfld, isProtocolField);
+        ctorIl.Emit(OpCodes.Ret);
+
+        EmitAsyncFromSyncNext(typeBuilder, runtime, iteratorField, isProtocolField);
+        EmitAsyncFromSyncReturn(typeBuilder, runtime, iteratorField, isProtocolField);
+        EmitAsyncFromSyncThrow(typeBuilder, runtime, iteratorField, isProtocolField);
+        EmitAsyncFromSyncInheritedMembers(typeBuilder, runtime, iteratorField);
+
+        typeBuilder.CreateType();
+    }
+
+    private void EmitAsyncFromSyncNext(
+        TypeBuilder typeBuilder,
+        EmittedRuntime runtime,
+        FieldBuilder iteratorField,
+        FieldBuilder isProtocolField)
+    {
+        var method = typeBuilder.DefineMethod(
+            "next",
+            MethodAttributes.Public | MethodAttributes.Virtual | MethodAttributes.Final |
+            MethodAttributes.HideBySig | MethodAttributes.NewSlot,
+            _types.TaskOfObject,
+            [_types.Object]);
+        typeBuilder.DefineMethodOverride(method, runtime.AsyncGeneratorNextMethod);
+
+        var il = method.GetILGenerator();
+        var resultTask = il.DeclareLocal(_types.TaskOfObject);
+        var stepLocal = il.DeclareLocal(_types.Object);
+        var enumLocal = il.DeclareLocal(_types.IEnumeratorOfObject);
+        var exLocal = il.DeclareLocal(_types.Exception);
+        var clrIterator = il.DefineLabel();
+        var exhausted = il.DefineLabel();
+        var haveStep = il.DefineLabel();
+        var done = il.DefineLabel();
+
+        il.BeginExceptionBlock();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, isProtocolField);
+        il.Emit(OpCodes.Brfalse, clrIterator);
+
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, iteratorField);
+        il.Emit(OpCodes.Call, runtime.InvokeIteratorNext);
+        il.Emit(OpCodes.Stloc, stepLocal);
+        il.Emit(OpCodes.Br, haveStep);
+
+        il.MarkLabel(clrIterator);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, iteratorField);
+        il.Emit(OpCodes.Castclass, _types.IEnumeratorOfObject);
+        il.Emit(OpCodes.Stloc, enumLocal);
+        il.Emit(OpCodes.Ldloc, enumLocal);
+        il.Emit(OpCodes.Callvirt, _types.GetMethodNoParams(_types.IEnumerator, "MoveNext"));
+        il.Emit(OpCodes.Brfalse, exhausted);
+        il.Emit(OpCodes.Ldloc, enumLocal);
+        il.Emit(OpCodes.Callvirt, _types.GetPropertyGetter(_types.IEnumeratorOfObject, "Current"));
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Call, _asyncFromSyncCreateResult);
+        il.Emit(OpCodes.Stloc, stepLocal);
+        il.Emit(OpCodes.Br, haveStep);
+
+        il.MarkLabel(exhausted);
+        il.Emit(OpCodes.Ldsfld, runtime.UndefinedInstance);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Call, _asyncFromSyncCreateResult);
+        il.Emit(OpCodes.Stloc, stepLocal);
+
+        il.MarkLabel(haveStep);
+        il.Emit(OpCodes.Ldloc, stepLocal);
+        il.Emit(OpCodes.Call, _asyncFromSyncAwaitResult);
+        il.Emit(OpCodes.Stloc, resultTask);
+        il.Emit(OpCodes.Leave, done);
+
+        il.BeginCatchBlock(_types.Exception);
+        il.Emit(OpCodes.Stloc, exLocal);
+        il.Emit(OpCodes.Ldloc, exLocal);
+        il.Emit(OpCodes.Call, TaskFromExceptionObject());
+        il.Emit(OpCodes.Stloc, resultTask);
+        il.Emit(OpCodes.Leave, done);
+        il.EndExceptionBlock();
+
+        il.MarkLabel(done);
+        il.Emit(OpCodes.Ldloc, resultTask);
+        il.Emit(OpCodes.Ret);
+    }
+
+    private void EmitAsyncFromSyncReturn(
+        TypeBuilder typeBuilder,
+        EmittedRuntime runtime,
+        FieldBuilder iteratorField,
+        FieldBuilder isProtocolField)
+    {
+        var method = typeBuilder.DefineMethod(
+            "return",
+            MethodAttributes.Public | MethodAttributes.Virtual | MethodAttributes.Final |
+            MethodAttributes.HideBySig | MethodAttributes.NewSlot,
+            _types.TaskOfObject,
+            [_types.Object]);
+        typeBuilder.DefineMethodOverride(method, runtime.AsyncGeneratorReturnMethod);
+
+        var il = method.GetILGenerator();
+        var resultTask = il.DeclareLocal(_types.TaskOfObject);
+        var stepLocal = il.DeclareLocal(_types.Object);
+        var fnLocal = il.DeclareLocal(_types.Object);
+        var exLocal = il.DeclareLocal(_types.Exception);
+        var clrIterator = il.DefineLabel();
+        var noProtocolReturn = il.DefineLabel();
+        var notGenerator = il.DefineLabel();
+        var noDispose = il.DefineLabel();
+        var afterDispose = il.DefineLabel();
+        var haveStep = il.DefineLabel();
+        var done = il.DefineLabel();
+
+        il.BeginExceptionBlock();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, isProtocolField);
+        il.Emit(OpCodes.Brfalse, clrIterator);
+
+        // Custom sync iterator: call its optional return(value).
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, iteratorField);
+        il.Emit(OpCodes.Ldstr, "return");
+        il.Emit(OpCodes.Call, runtime.GetProperty);
+        il.Emit(OpCodes.Stloc, fnLocal);
+        il.Emit(OpCodes.Ldloc, fnLocal);
+        il.Emit(OpCodes.Brfalse, noProtocolReturn);
+        il.Emit(OpCodes.Ldloc, fnLocal);
+        il.Emit(OpCodes.Isinst, runtime.UndefinedType);
+        il.Emit(OpCodes.Brtrue, noProtocolReturn);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, iteratorField);
+        il.Emit(OpCodes.Ldloc, fnLocal);
+        EmitSingleObjectArgumentArray(il, argumentIndex: 1);
+        il.Emit(OpCodes.Call, runtime.InvokeMethodValue);
+        il.Emit(OpCodes.Stloc, stepLocal);
+        il.Emit(OpCodes.Br, haveStep);
+
+        il.MarkLabel(noProtocolReturn);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Call, _asyncFromSyncCreateResult);
+        il.Emit(OpCodes.Stloc, stepLocal);
+        il.Emit(OpCodes.Br, haveStep);
+
+        // Emitted sync generators expose return(value); use it so finally blocks run.
+        il.MarkLabel(clrIterator);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, iteratorField);
+        il.Emit(OpCodes.Isinst, runtime.GeneratorInterfaceType);
+        il.Emit(OpCodes.Brfalse, notGenerator);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, iteratorField);
+        il.Emit(OpCodes.Castclass, runtime.GeneratorInterfaceType);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Callvirt, runtime.GeneratorReturnMethod);
+        il.Emit(OpCodes.Stloc, stepLocal);
+        il.Emit(OpCodes.Br, haveStep);
+
+        // Other CLR enumerators are closed through IDisposable.
+        il.MarkLabel(notGenerator);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, iteratorField);
+        il.Emit(OpCodes.Isinst, _types.IDisposable);
+        il.Emit(OpCodes.Dup);
+        il.Emit(OpCodes.Brfalse, noDispose);
+        il.Emit(OpCodes.Callvirt, _types.GetMethodNoParams(_types.IDisposable, "Dispose"));
+        il.Emit(OpCodes.Br, afterDispose);
+        il.MarkLabel(noDispose);
+        il.Emit(OpCodes.Pop);
+        il.MarkLabel(afterDispose);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Call, _asyncFromSyncCreateResult);
+        il.Emit(OpCodes.Stloc, stepLocal);
+
+        il.MarkLabel(haveStep);
+        il.Emit(OpCodes.Ldloc, stepLocal);
+        il.Emit(OpCodes.Call, _asyncFromSyncAwaitResult);
+        il.Emit(OpCodes.Stloc, resultTask);
+        il.Emit(OpCodes.Leave, done);
+
+        il.BeginCatchBlock(_types.Exception);
+        il.Emit(OpCodes.Stloc, exLocal);
+        il.Emit(OpCodes.Ldloc, exLocal);
+        il.Emit(OpCodes.Call, TaskFromExceptionObject());
+        il.Emit(OpCodes.Stloc, resultTask);
+        il.Emit(OpCodes.Leave, done);
+        il.EndExceptionBlock();
+
+        il.MarkLabel(done);
+        il.Emit(OpCodes.Ldloc, resultTask);
+        il.Emit(OpCodes.Ret);
+    }
+
+    private void EmitAsyncFromSyncThrow(
+        TypeBuilder typeBuilder,
+        EmittedRuntime runtime,
+        FieldBuilder iteratorField,
+        FieldBuilder isProtocolField)
+    {
+        var method = typeBuilder.DefineMethod(
+            "throw",
+            MethodAttributes.Public | MethodAttributes.Virtual | MethodAttributes.Final |
+            MethodAttributes.HideBySig | MethodAttributes.NewSlot,
+            _types.TaskOfObject,
+            [_types.Object]);
+        typeBuilder.DefineMethodOverride(method, runtime.AsyncGeneratorThrowMethod);
+
+        var il = method.GetILGenerator();
+        var fnLocal = il.DeclareLocal(_types.Object);
+        var stepLocal = il.DeclareLocal(_types.Object);
+        var noThrow = il.DefineLabel();
+        var clrIterator = il.DefineLabel();
+
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, isProtocolField);
+        il.Emit(OpCodes.Brfalse, clrIterator);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, iteratorField);
+        il.Emit(OpCodes.Ldstr, "throw");
+        il.Emit(OpCodes.Call, runtime.GetProperty);
+        il.Emit(OpCodes.Stloc, fnLocal);
+        il.Emit(OpCodes.Ldloc, fnLocal);
+        il.Emit(OpCodes.Brfalse, noThrow);
+        il.Emit(OpCodes.Ldloc, fnLocal);
+        il.Emit(OpCodes.Isinst, runtime.UndefinedType);
+        il.Emit(OpCodes.Brtrue, noThrow);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, iteratorField);
+        il.Emit(OpCodes.Ldloc, fnLocal);
+        EmitSingleObjectArgumentArray(il, argumentIndex: 1);
+        il.Emit(OpCodes.Call, runtime.InvokeMethodValue);
+        il.Emit(OpCodes.Stloc, stepLocal);
+        il.Emit(OpCodes.Ldloc, stepLocal);
+        il.Emit(OpCodes.Call, _asyncFromSyncAwaitResult);
+        il.Emit(OpCodes.Ret);
+
+        il.MarkLabel(clrIterator);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, iteratorField);
+        il.Emit(OpCodes.Isinst, runtime.GeneratorInterfaceType);
+        il.Emit(OpCodes.Brfalse, noThrow);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, iteratorField);
+        il.Emit(OpCodes.Castclass, runtime.GeneratorInterfaceType);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Callvirt, runtime.GeneratorThrowMethod);
+        il.Emit(OpCodes.Call, _asyncFromSyncAwaitResult);
+        il.Emit(OpCodes.Ret);
+
+        il.MarkLabel(noThrow);
+        il.Emit(OpCodes.Ldstr, "Synchronous iterator does not provide a throw() method.");
+        il.Emit(OpCodes.Newobj, _types.ExceptionCtorString);
+        il.Emit(OpCodes.Call, TaskFromExceptionObject());
+        il.Emit(OpCodes.Ret);
+    }
+
+    private void EmitAsyncFromSyncInheritedMembers(
+        TypeBuilder typeBuilder,
+        EmittedRuntime runtime,
+        FieldBuilder iteratorField)
+    {
+        var current = typeBuilder.DefineMethod(
+            "get_Current",
+            MethodAttributes.Public | MethodAttributes.Virtual | MethodAttributes.Final |
+            MethodAttributes.SpecialName | MethodAttributes.HideBySig | MethodAttributes.NewSlot,
+            _types.Object,
+            Type.EmptyTypes);
+        var currentIl = current.GetILGenerator();
+        currentIl.Emit(OpCodes.Ldsfld, runtime.UndefinedInstance);
+        currentIl.Emit(OpCodes.Ret);
+        typeBuilder.DefineMethodOverride(
+            current, _types.GetPropertyGetter(_types.IAsyncEnumeratorOfObject, "Current"));
+
+        var moveNext = typeBuilder.DefineMethod(
+            "MoveNextAsync",
+            MethodAttributes.Public | MethodAttributes.Virtual | MethodAttributes.Final |
+            MethodAttributes.HideBySig | MethodAttributes.NewSlot,
+            _types.ValueTaskOfBool,
+            Type.EmptyTypes);
+        var moveNextIl = moveNext.GetILGenerator();
+        var valueTaskBool = moveNextIl.DeclareLocal(_types.ValueTaskOfBool);
+        moveNextIl.Emit(OpCodes.Ldloca, valueTaskBool);
+        moveNextIl.Emit(OpCodes.Initobj, _types.ValueTaskOfBool);
+        moveNextIl.Emit(OpCodes.Ldloc, valueTaskBool);
+        moveNextIl.Emit(OpCodes.Ret);
+        typeBuilder.DefineMethodOverride(
+            moveNext, _types.GetMethodNoParams(_types.IAsyncEnumeratorOfObject, "MoveNextAsync"));
+
+        var dispose = typeBuilder.DefineMethod(
+            "DisposeAsync",
+            MethodAttributes.Public | MethodAttributes.Virtual | MethodAttributes.Final |
+            MethodAttributes.HideBySig | MethodAttributes.NewSlot,
+            _types.ValueTask,
+            Type.EmptyTypes);
+        var disposeIl = dispose.GetILGenerator();
+        var noDispose = disposeIl.DefineLabel();
+        var afterDispose = disposeIl.DefineLabel();
+        var valueTask = disposeIl.DeclareLocal(_types.ValueTask);
+        disposeIl.Emit(OpCodes.Ldarg_0);
+        disposeIl.Emit(OpCodes.Ldfld, iteratorField);
+        disposeIl.Emit(OpCodes.Isinst, _types.IDisposable);
+        disposeIl.Emit(OpCodes.Dup);
+        disposeIl.Emit(OpCodes.Brfalse, noDispose);
+        disposeIl.Emit(OpCodes.Callvirt, _types.GetMethodNoParams(_types.IDisposable, "Dispose"));
+        disposeIl.Emit(OpCodes.Br, afterDispose);
+        disposeIl.MarkLabel(noDispose);
+        disposeIl.Emit(OpCodes.Pop);
+        disposeIl.MarkLabel(afterDispose);
+        disposeIl.Emit(OpCodes.Ldloca, valueTask);
+        disposeIl.Emit(OpCodes.Initobj, _types.ValueTask);
+        disposeIl.Emit(OpCodes.Ldloc, valueTask);
+        disposeIl.Emit(OpCodes.Ret);
+        typeBuilder.DefineMethodOverride(
+            dispose, _types.GetMethodNoParams(_types.IAsyncDisposable, "DisposeAsync"));
+
+        var getAsyncEnumerator = typeBuilder.DefineMethod(
+            "GetAsyncEnumerator",
+            MethodAttributes.Public | MethodAttributes.Virtual | MethodAttributes.Final |
+            MethodAttributes.HideBySig | MethodAttributes.NewSlot,
+            _types.IAsyncEnumeratorOfObject,
+            [_types.CancellationToken]);
+        var getAsyncEnumeratorIl = getAsyncEnumerator.GetILGenerator();
+        getAsyncEnumeratorIl.Emit(OpCodes.Ldarg_0);
+        getAsyncEnumeratorIl.Emit(OpCodes.Ret);
+        typeBuilder.DefineMethodOverride(
+            getAsyncEnumerator,
+            _types.GetMethod(_types.IAsyncEnumerableOfObject, "GetAsyncEnumerator", _types.CancellationToken));
+    }
+
+    /// <summary>
+    /// static object AdaptSyncIterableToAsyncGenerator(object source)
+    /// </summary>
+    private void EmitAdaptSyncIterableToAsyncGenerator(TypeBuilder runtimeType, EmittedRuntime runtime)
+    {
+        var method = runtimeType.DefineMethod(
+            "AdaptSyncIterableToAsyncGenerator",
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.Object,
+            [_types.Object]);
+        runtime.AdaptSyncIterableToAsyncGenerator = method;
+
+        var il = method.GetILGenerator();
+        var iteratorFnLocal = il.DeclareLocal(_types.Object);
+        var iteratorLocal = il.DeclareLocal(_types.Object);
+        var trySyncProtocol = il.DefineLabel();
+        var tryClrIterator = il.DefineLabel();
+        var tryEnumerable = il.DefineLabel();
+        var materialize = il.DefineLabel();
+        var constructClr = il.DefineLabel();
+
+        // A genuine async generator already implements the common interface.
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Isinst, runtime.AsyncGeneratorInterfaceType);
+        il.Emit(OpCodes.Brfalse, trySyncProtocol);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ret);
+
+        // A custom Symbol.iterator must be called exactly once and retains its
+        // return/throw protocol for early-close behavior.
+        il.MarkLabel(trySyncProtocol);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldsfld, runtime.SymbolIterator);
+        il.Emit(OpCodes.Call, runtime.GetIteratorFunction);
+        il.Emit(OpCodes.Stloc, iteratorFnLocal);
+        il.Emit(OpCodes.Ldloc, iteratorFnLocal);
+        il.Emit(OpCodes.Brfalse, tryClrIterator);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldloc, iteratorFnLocal);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Newarr, _types.Object);
+        il.Emit(OpCodes.Call, runtime.InvokeMethodValue);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Newobj, runtime.AsyncFromSyncIteratorCtor);
+        il.Emit(OpCodes.Ret);
+
+        // Preserve an existing object enumerator or obtain one once from an
+        // IEnumerable<object>. This covers arrays, Sets, and sync generators.
+        il.MarkLabel(tryClrIterator);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Isinst, _types.IEnumeratorOfObject);
+        il.Emit(OpCodes.Dup);
+        il.Emit(OpCodes.Brfalse, tryEnumerable);
+        il.Emit(OpCodes.Stloc, iteratorLocal);
+        il.Emit(OpCodes.Br, constructClr);
+        il.MarkLabel(tryEnumerable);
+        il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Isinst, _types.IEnumerableOfObject);
+        il.Emit(OpCodes.Brfalse, materialize);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Call, runtime.NormalizeToEnumerator);
+        il.Emit(OpCodes.Stloc, iteratorLocal);
+        il.Emit(OpCodes.Br, constructClr);
+
+        // Strings, Maps, typed arrays, Buffers, and non-generic CLR iterables
+        // use IterateToList's existing JS-aware normalization, then iterate the
+        // resulting dense object list.
+        il.MarkLabel(materialize);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldsfld, runtime.SymbolIterator);
+        il.Emit(OpCodes.Ldtoken, runtime.RuntimeType);
+        il.Emit(OpCodes.Call, _types.GetMethod(_types.Type, "GetTypeFromHandle"));
+        il.Emit(OpCodes.Call, runtime.IterateToList);
+        il.Emit(OpCodes.Callvirt, _types.GetMethodNoParams(_types.IEnumerableOfObject, "GetEnumerator"));
+        il.Emit(OpCodes.Stloc, iteratorLocal);
+
+        il.MarkLabel(constructClr);
+        il.Emit(OpCodes.Ldloc, iteratorLocal);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Newobj, runtime.AsyncFromSyncIteratorCtor);
+        il.Emit(OpCodes.Ret);
+    }
+
+    private MethodInfo TaskFromExceptionObject() =>
+        typeof(Task).GetMethod("FromException", 1, [typeof(Exception)])!
+            .MakeGenericMethod(_types.Object);
+
+    private void EmitSingleObjectArgumentArray(ILGenerator il, int argumentIndex)
+    {
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Newarr, _types.Object);
+        il.Emit(OpCodes.Dup);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Ldarg, argumentIndex);
+        il.Emit(OpCodes.Stelem_Ref);
+    }
+}

--- a/Compilation/RuntimeEmitter.cs
+++ b/Compilation/RuntimeEmitter.cs
@@ -423,6 +423,12 @@ public partial class RuntimeEmitter
         // EmitRuntimeClass (depends on InvokeValue / WrapException).
         EmitPromiseCapabilitySupport(moduleBuilder, runtime);
 
+        // The async-from-sync adapter depends on iterator helpers plus
+        // CoerceAwaitableToTask, all of which are now defined. It is gated on
+        // for-await syntax because most programs never reference this type.
+        if (features.UsesForAwaitOf)
+            EmitAsyncFromSyncIteratorSupport(moduleBuilder, runtime);
+
         // AbortSignal / Intl value-position singletons (#224). Must follow
         // EmitRuntimeClass — they wrap the AbortSignal*/CreateIntl* helpers
         // emitted there.

--- a/Compilation/RuntimeFeatureDetector.cs
+++ b/Compilation/RuntimeFeatureDetector.cs
@@ -73,6 +73,7 @@ public sealed class RuntimeFeatureDetector
             UsesProxy = false,
             UsesDynamicImport = false,
             UsesAsyncGenerator = false,
+            UsesForAwaitOf = false,
             UsesWeakRef = false,
             UsesWeakMap = false,
             UsesWeakSet = false,
@@ -670,6 +671,8 @@ public sealed class RuntimeFeatureDetector
                 VisitStmt(f.Body);
                 break;
             case Stmt.ForOf fo:
+                if (fo.IsAsync)
+                    _set.UsesForAwaitOf = true;
                 VisitExpr(fo.Iterable);
                 VisitStmt(fo.Body);
                 break;

--- a/Compilation/RuntimeFeatureSet.cs
+++ b/Compilation/RuntimeFeatureSet.cs
@@ -64,6 +64,7 @@ public sealed class RuntimeFeatureSet
     public bool UsesProxy { get; set; } = true;             // `new Proxy(...)` / bare `Proxy` identifier
     public bool UsesDynamicImport { get; set; } = true;     // `import(specifier)` syntax (Expr.DynamicImport)
     public bool UsesAsyncGenerator { get; set; } = true;    // `async function*` / async generators
+    public bool UsesForAwaitOf { get; set; } = true;        // `for await (... of ...)`
     public bool UsesWeakRef { get; set; } = true;           // `new WeakRef(target)` — bare or `new`
     public bool UsesWeakMap { get; set; } = true;           // `new WeakMap(...)` — bare or `new`
     public bool UsesWeakSet { get; set; } = true;           // `new WeakSet(...)` — bare or `new`

--- a/Compilation/StatementEmitterBase.cs
+++ b/Compilation/StatementEmitterBase.cs
@@ -852,12 +852,14 @@ public abstract class StatementEmitterBase : ExpressionEmitterBase
             il.Emit(OpCodes.Br, afterLoopLabel); // Skip the fallback path
         }
 
-        // ===== $IAsyncGenerator fallback path =====
+        // ===== $IAsyncGenerator / async-from-sync fallback path =====
         il.MarkLabel(asyncGenLabel);
         {
-            // Cast to $IAsyncGenerator interface
+            // Adapt synchronous iterables, then cast to the common interface.
+            // Non-iterables still fail here.
             var asyncGenInterface = runtime.AsyncGeneratorInterfaceType;
             il.Emit(OpCodes.Ldloc, iterableLocal);
+            il.Emit(OpCodes.Call, runtime.AdaptSyncIterableToAsyncGenerator);
             il.Emit(OpCodes.Castclass, asyncGenInterface);
 
             // Store the async generator in a local

--- a/Execution/Interpreter.Async.cs
+++ b/Execution/Interpreter.Async.cs
@@ -105,8 +105,9 @@ public partial class Interpreter
         {
             foreach (var item in syncIterator)
             {
-                // For 'for await...of', unwrap promises from sync iterators
-                object? value = forOf.IsAsync && item is Task<object?> t ? await AwaitPreservingEnvironment(t) : item;
+                // CreateAsyncFromSyncIterator awaits each yielded value (including
+                // guest Promises and ordinary thenables), not just raw CLR Tasks.
+                object? value = forOf.IsAsync ? await AwaitAsyncIterationValue(item) : item;
 
                 var result = await ExecuteLoopBodyAsync(forOf.Variable.Lexeme, value, forOf.Body);
                 var (shouldBreak, shouldContinue, abruptResult) = HandleLoopResult(result, labels);
@@ -138,20 +139,53 @@ public partial class Interpreter
 
         foreach (var item in items)
         {
-            // For 'for await...of' with sync iterables, unwrap promises
-            object? value = forOf.IsAsync && item is Task<object?> t ? await t : item;
+            object? value = forOf.IsAsync ? await AwaitAsyncIterationValue(item) : item;
 
             var result = await ExecuteLoopBodyAsync(forOf.Variable.Lexeme, value, forOf.Body);
             var (shouldBreak, shouldContinue, abruptResult) = HandleLoopResult(result, labels);
-            if (shouldBreak) return ExecutionResult.Success();
+            if (shouldBreak)
+            {
+                CloseSyncGeneratorOnEarlyExit(iterable);
+                return ExecutionResult.Success();
+            }
             if (shouldContinue) continue;
-            if (abruptResult.HasValue) return abruptResult.Value;
+            if (abruptResult.HasValue)
+            {
+                CloseSyncGeneratorOnEarlyExit(iterable);
+                return abruptResult.Value;
+            }
 
             // Process any pending timer callbacks
             ProcessPendingCallbacks();
         }
 
         return ExecutionResult.Success();
+    }
+
+    /// <summary>
+    /// Applies the PromiseResolve-style value adoption required by
+    /// CreateAsyncFromSyncIterator.
+    /// </summary>
+    private async Task<object?> AwaitAsyncIterationValue(object? value)
+    {
+        if (value is SharpTSPromise promise)
+            return await AwaitPreservingEnvironment(promise.GetValueAsync());
+        if (value is Task<object?> task)
+            return await AwaitPreservingEnvironment(task);
+        if (TryGetThenable(value, out var thenFn))
+            return await AwaitPreservingEnvironment(AdoptThenable(value!, thenFn));
+        return value;
+    }
+
+    /// <summary>
+    /// A SharpTSGenerator's IEnumerable facade does not own the generator and
+    /// therefore cannot close it from IEnumerator.Dispose. Inject return() on an
+    /// abrupt for-await exit so active finally blocks run.
+    /// </summary>
+    private static void CloseSyncGeneratorOnEarlyExit(object? iterable)
+    {
+        if (iterable is SharpTSGenerator generator)
+            generator.Return(SharpTSUndefined.Instance);
     }
 
     private async Task<ExecutionResult> ExecuteLoopBodyAsync(string varName, object? value, Stmt body)

--- a/Parsing/Parser.Destructuring.cs
+++ b/Parsing/Parser.Destructuring.cs
@@ -151,9 +151,9 @@ public partial class Parser
         // const _dest0 = __arrayDestructure(initializer);
         // JS array destructuring follows the iterator protocol, not positional
         // indexing. The wrapper normalizes non-indexable iterables (generators,
-        // Set, Map, objects with [Symbol.iterator]) into an array so the index
-        // access below is spec-correct (#685); arrays/tuples/strings pass through
-        // unchanged to keep the fast index path.
+        // Set, Map, typed arrays, Buffers, strings, objects with [Symbol.iterator])
+        // into an array so the index access below is spec-correct (#685/#1288);
+        // arrays/tuples pass through unchanged to keep the fast index path.
         Token temp = GenerateTempVar(pattern.Line);
         Expr normalizedInit = new Expr.Call(
             new Expr.Variable(new Token(TokenType.IDENTIFIER, "__arrayDestructure", null, pattern.Line)),

--- a/SharpTS.Tests/CompilerTests/RuntimeFeatureDetectorTests.cs
+++ b/SharpTS.Tests/CompilerTests/RuntimeFeatureDetectorTests.cs
@@ -1,0 +1,19 @@
+using SharpTS.Compilation;
+using SharpTS.Parsing;
+using Xunit;
+
+namespace SharpTS.Tests.CompilerTests;
+
+public class RuntimeFeatureDetectorTests
+{
+    [Theory]
+    [InlineData("async function f() { for await (const x of [1]) {} }", true)]
+    [InlineData("function f() { for (const x of [1]) {} }", false)]
+    public void DetectsForAwaitOfAdapterRequirement(string source, bool expected)
+    {
+        var statements = new Parser(new Lexer(source).ScanTokens()).ParseOrThrow();
+        var features = new RuntimeFeatureDetector().Detect(statements);
+
+        Assert.Equal(expected, features.UsesForAwaitOf);
+    }
+}

--- a/SharpTS.Tests/CompilerTests/StandaloneDllTests.cs
+++ b/SharpTS.Tests/CompilerTests/StandaloneDllTests.cs
@@ -570,6 +570,31 @@ public class StandaloneDllTests
         }
     }
 
+    [Fact]
+    public void Isolated_ForAwaitOfSyncIterable_ShouldExecuteWithoutSharpTsDll()
+    {
+        var source = """
+            async function main() {
+                const values: any[] = [];
+                for await (const x of [1, Promise.resolve(2)]) values.push(x);
+                for await (const x of "ok") values.push(x);
+                console.log(JSON.stringify(values));
+            }
+            main();
+            """;
+
+        var (tempDir, dllPath) = CompileStandalone(source);
+        try
+        {
+            Assert.DoesNotContain(GetAssemblyReferences(dllPath), r => r == "SharpTS");
+            Assert.Equal("[1,2,\"o\",\"k\"]\n", ExecuteCompiledDllIsolated(dllPath, timeoutMs: 15000));
+        }
+        finally
+        {
+            CleanupTempDir(tempDir);
+        }
+    }
+
     /// <summary>
     /// #1289: yield* over emitted typed arrays and Buffers must use only emitted runtime
     /// helpers and continue to execute without a SharpTS.dll dependency.

--- a/SharpTS.Tests/SharedTests/AsyncIteratorEdgeCaseTests.cs
+++ b/SharpTS.Tests/SharedTests/AsyncIteratorEdgeCaseTests.cs
@@ -11,6 +11,95 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class AsyncIteratorEdgeCaseTests
 {
+    #region Async From Sync (#1287)
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ForAwaitOf_SyncBuiltins_AwaitsValues(ExecutionMode mode)
+    {
+        var source = """
+            async function main() {
+                const values: any[] = [];
+                const mixed: any[] = [1, Promise.resolve(2), 3];
+
+                for await (const x of mixed) values.push(x);
+                for await (const x of new Set([4, 5])) values.push(x);
+                for await (const x of "ok") values.push(x);
+                for await (const x of new Map([["a", 6]])) values.push(x);
+
+                console.log(JSON.stringify(values));
+            }
+            main();
+            """;
+
+        Assert.Equal("[1,2,3,4,5,\"o\",\"k\",[\"a\",6]]\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ForAwaitOf_SyncIterators_CloseOnBreak(ExecutionMode mode)
+    {
+        var source = """
+            let customClosed = false;
+            const iterable: any = {
+                [Symbol.iterator]() {
+                    let i = 0;
+                    return {
+                        next() { i++; return { value: i, done: i > 3 }; },
+                        return() {
+                            customClosed = true;
+                            return { value: undefined, done: true };
+                        }
+                    };
+                }
+            };
+
+            let generatorClosed = false;
+            function* values() {
+                try { yield 10; yield 20; }
+                finally { generatorClosed = true; }
+            }
+
+            async function main() {
+                for await (const x of iterable) break;
+                for await (const x of values()) break;
+                console.log(customClosed + " " + generatorClosed);
+            }
+            main();
+            """;
+
+        Assert.Equal("true true\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ForAwaitOf_SyncIterable_WorksInAsyncArrowAndAsyncGenerator(ExecutionMode mode)
+    {
+        var source = """
+            const collect = async () => {
+                const out: number[] = [];
+                for await (const x of new Set([7, 8])) out.push(x);
+                return out;
+            };
+
+            async function* transform() {
+                for await (const x of [1, 2]) yield x * 10;
+            }
+
+            async function main() {
+                console.log(JSON.stringify(await collect()));
+                const out: number[] = [];
+                for await (const x of transform()) out.push(x);
+                console.log(JSON.stringify(out));
+            }
+            main();
+            """;
+
+        Assert.Equal("[7,8]\n[10,20]\n", TestHarness.Run(source, mode));
+    }
+
+    #endregion
+
     #region Error Handling
 
     [Theory]

--- a/SharpTS.Tests/SharedTests/DestructuringTests.cs
+++ b/SharpTS.Tests/SharedTests/DestructuringTests.cs
@@ -651,24 +651,28 @@ public class DestructuringTests
 
     #endregion
 
-    #region Typed-array Rest (#781)
+    #region Typed-array and Buffer Sources (#781, #1288)
 
-    // #781: a rest element over a typed-array source must collect a fresh Array (Array.isArray === true),
-    // not a typed-array slice. Interpreter-only: compiled `new Uint8Array([...])` is blocked by #782.
+    // #781/#1288: typed arrays and Buffers are normalized to a fresh Array before destructuring.
+    // This keeps ordinary element bindings working and makes a rest binding a real Array rather
+    // than a typed-array/Buffer slice.
     [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
-    public void ArrayDestructuring_TypedArrayRest_BindsFreshArray(ExecutionMode mode)
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ArrayDestructuring_TypedArrayAndBufferSources(ExecutionMode mode)
     {
         var source = """
-            const [a, ...rest] = new Uint8Array([1, 2, 3]);
-            console.log(a);
-            console.log(Array.isArray(rest));
-            console.log(rest.length);
-            console.log(rest[0], rest[1]);
+            const u8 = new Uint8Array([1, 2, 3]);
+            const [a, b] = u8;
+            const [, ...typedRest] = u8;
+            console.log(a, b, Array.isArray(typedRest), JSON.stringify(typedRest));
+
+            const buffer = Buffer.from([4, 5, 6]);
+            const [c, ...bufferRest] = buffer;
+            console.log(c, Array.isArray(bufferRest), JSON.stringify(bufferRest));
             """;
 
         var output = TestHarness.Run(source, mode);
-        Assert.Equal("1\ntrue\n2\n2 3\n", output);
+        Assert.Equal("1 2 true [2,3]\n4 true [5,6]\n", output);
     }
 
     #endregion

--- a/SharpTS.Tests/SharedTests/TypedArrayIterationParityTests.cs
+++ b/SharpTS.Tests/SharedTests/TypedArrayIterationParityTests.cs
@@ -81,13 +81,21 @@ public class TypedArrayIterationParityTests
             """, mode);
     }
 
-    // NOTE: for-await-of over a sync iterable is deliberately not covered here. The
-    // interpreter handles it (and now covers typed arrays/Buffers alongside arrays and
-    // Sets), but compiled output cannot iterate ANY sync iterable in a for-await-of —
-    // `for await (const x of ['a','b'])` throws
-    // `InvalidCastException: '$Array' to '$IAsyncGenerator'` because the emitter assumes an
-    // async generator. That is a pre-existing compiled gap far wider than typed arrays, so a
-    // dual-mode test here would assert a failure unrelated to this fix rather than pin it.
+    [Theory]
+    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    public void ForAwaitOf_OverTypedArrayAndBuffer(ExecutionMode mode)
+    {
+        Expect("""
+            async function main() {
+                const values: number[] = [];
+                for await (const x of new Uint8Array([1, 2])) values.push(x);
+                for await (const x of new Int16Array([-1, 300])) values.push(x);
+                for await (const x of Buffer.from([4, 5])) values.push(x);
+                console.log(JSON.stringify(values));
+            }
+            main();
+            """, "[1,2,-1,300,4,5]", mode);
+    }
 
     [Theory]
     [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]

--- a/TypeSystem/TypeChecker.Iterables.cs
+++ b/TypeSystem/TypeChecker.Iterables.cs
@@ -7,9 +7,10 @@ namespace SharpTS.TypeSystem;
 /// <summary>
 /// Structural typing of the sync iterable/iterator protocols (#485). SharpTS models
 /// iterables/iterators nominally (dedicated <see cref="TypeInfo"/> records: Array, Set, Map, Iterator,
-/// Generator, …); these helpers bridge to TypeScript's structural view so a hand-written object exposing
-/// <c>[Symbol.iterator]()</c> / <c>next()</c> is recognized as an iterable/iterator and its element type
-/// is derived from <c>next().value</c> rather than collapsing to <c>any</c>.
+/// Generator, TypedArray, Buffer, …); these helpers bridge to TypeScript's structural view so a
+/// hand-written object exposing <c>[Symbol.iterator]()</c> / <c>next()</c> is recognized as an
+/// iterable/iterator and its element type is derived from <c>next().value</c> rather than collapsing
+/// to <c>any</c>.
 /// </summary>
 public partial class TypeChecker
 {
@@ -218,6 +219,12 @@ public partial class TypeChecker
             case TypeInfo.Generator gen: elementType = gen.YieldType; return true;
             case TypeInfo.Iterable iterable: elementType = iterable.ElementType; return true;
             case TypeInfo.String or TypeInfo.StringLiteral: elementType = TypeInfo.String.Shared; return true;
+            case TypeInfo.TypedArray typed:
+                elementType = typed.ElementType.StartsWith("Big")
+                    ? TypeInfo.BigInt.Shared
+                    : TypeInfo.Primitive.Number;
+                return true;
+            case TypeInfo.Buffer: elementType = TypeInfo.Primitive.Number; return true;
             case TypeInfo.Any: elementType = TypeInfo.Any.Shared; return true;
             case TypeInfo.Record or TypeInfo.Interface or TypeInfo.Instance:
                 return TryGetStructuralIterableElement(type, out elementType);
@@ -232,13 +239,14 @@ public partial class TypeChecker
     /// normalizes an array binding-pattern source through the iterator protocol. Index-addressable
     /// sources (arrays, tuples, <c>any</c>) pass through with their precise type so the desugared
     /// positional index access stays accurate — notably tuples keep their per-position element types.
-    /// Any other iterable (Set, Map, generators, <c>[Symbol.iterator]</c> objects) becomes
-    /// <c>Array&lt;element&gt;</c>, so the subsequent <c>_dest0[i]</c> reads the element type instead of
-    /// erroring. A <b>string</b> is deliberately NOT passed through: it iterates to <c>string[]</c> so a
-    /// rest element binds a fresh array (<c>const [a, ...rest] = "hi"</c> → <c>rest: string[]</c>),
-    /// matching ECMA-262 instead of binding the trailing substring (#753); non-rest element types are
-    /// unchanged (<c>string</c> either way). A non-iterable, non-indexable source is returned unchanged
-    /// so the existing index-access diagnostic still fires.
+    /// Any other iterable (Set, Map, generators, typed arrays, Buffers, <c>[Symbol.iterator]</c> objects)
+    /// becomes <c>Array&lt;element&gt;</c>, so the subsequent <c>_dest0[i]</c> reads the element type
+    /// instead of dispatching through the source's original runtime representation. A <b>string</b> is
+    /// deliberately NOT passed through: it iterates to <c>string[]</c> so a rest element binds a fresh
+    /// array (<c>const [a, ...rest] = "hi"</c> → <c>rest: string[]</c>), matching ECMA-262 instead of
+    /// binding the trailing substring (#753); non-rest element types are unchanged (<c>string</c> either
+    /// way). A non-iterable, non-indexable source is returned unchanged so the existing index-access
+    /// diagnostic still fires.
     /// </summary>
     private TypeInfo NormalizeArrayDestructureSourceType(TypeInfo sourceType)
     {


### PR DESCRIPTION
## Summary

- normalize typed arrays and Buffers before compiled array destructuring, preserving ordinary element bindings and Array-valued rest bindings
- emit a standalone, feature-gated async-from-sync iterator adapter for `for await...of` in async functions, async arrows, and async generators
- await Promise/Task/thenable values from sync iterators and preserve early-close behavior for custom iterators and generators
- align the interpreter's Promise adoption and sync-generator cleanup with the compiled path

Closes #1288.
Closes #1287.

## Validation

- `dotnet build SharpTS.sln --no-restore`
- focused dual-mode/standalone regressions: 13/13 passed
- async iterator/generator regression sweep: 56/56 passed
- full `SharpTS.Tests`: 15,726 passed; one live DNS smoke test failed transiently, then passed 2/2 in isolation
- TypeScript conformance: 36/36 passed
- standalone CLI repros for both issues passed IL verification

Test262 was attempted with 15- and 30-minute limits. The harness emitted no mismatch before either limit, but did not return a final summary, so that validation is recorded as incomplete.
